### PR TITLE
[SandboxIR] Added new StoreInst::create() functions with isVolatile arg

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -804,7 +804,7 @@ class StoreInst final : public Instruction {
   }
 
 public:
-  /// Return true if this is a load from a volatile memory location.
+  /// Return true if this is a store from a volatile memory location.
   bool isVolatile() const { return cast<llvm::StoreInst>(Val)->isVolatile(); }
 
   unsigned getUseOperandNo(const Use &Use) const final {

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -805,7 +805,7 @@ class StoreInst final : public Instruction {
 
 public:
   /// Return true if this is a load from a volatile memory location.
-  bool isVolatile() const { return cast<llvm::LoadInst>(Val)->isVolatile(); }
+  bool isVolatile() const { return cast<llvm::StoreInst>(Val)->isVolatile(); }
 
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -804,6 +804,9 @@ class StoreInst final : public Instruction {
   }
 
 public:
+   /// Return true if this is a load from a volatile memory location.
+  bool isVolatile() const { return cast<llvm::LoadInst>(Val)->isVolatile(); }
+
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);
   }
@@ -811,7 +814,13 @@ public:
   static StoreInst *create(Value *V, Value *Ptr, MaybeAlign Align,
                            Instruction *InsertBefore, Context &Ctx);
   static StoreInst *create(Value *V, Value *Ptr, MaybeAlign Align,
+                           Instruction *InsertBefore, bool IsVolatile,
+                           Context &Ctx);
+  static StoreInst *create(Value *V, Value *Ptr, MaybeAlign Align,
                            BasicBlock *InsertAtEnd, Context &Ctx);
+  static StoreInst *create(Value *V, Value *Ptr, MaybeAlign Align,
+                           BasicBlock *InsertAtEnd, bool IsVolatile,
+                           Context &Ctx);
   /// For isa/dyn_cast.
   static bool classof(const Value *From);
   Value *getValueOperand() const;

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -806,7 +806,6 @@ class StoreInst final : public Instruction {
 public:
   /// Return true if this is a store from a volatile memory location.
   bool isVolatile() const { return cast<llvm::StoreInst>(Val)->isVolatile(); }
-
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);
   }

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -804,7 +804,7 @@ class StoreInst final : public Instruction {
   }
 
 public:
-   /// Return true if this is a load from a volatile memory location.
+  /// Return true if this is a load from a volatile memory location.
   bool isVolatile() const { return cast<llvm::LoadInst>(Val)->isVolatile(); }
 
   unsigned getUseOperandNo(const Use &Use) const final {

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -654,13 +654,7 @@ void LoadInst::dump() const {
 #endif // NDEBUG
 StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
                              Instruction *InsertBefore, Context &Ctx) {
-  llvm::Instruction *BeforeIR = InsertBefore->getTopmostLLVMInstruction();
-  auto &Builder = Ctx.getLLVMIRBuilder();
-  Builder.SetInsertPoint(BeforeIR);
-  auto *NewSI =
-      Builder.CreateAlignedStore(V->Val, Ptr->Val, Align, /*isVolatile=*/false);
-  auto *NewSBI = Ctx.createStoreInst(NewSI);
-  return NewSBI;
+  return create(V, Ptr, Align, InsertBefore, /*IsVolatile=*/false, Ctx);
 }
 
 StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
@@ -676,13 +670,7 @@ StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
 
 StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
                              BasicBlock *InsertAtEnd, Context &Ctx) {
-  auto *InsertAtEndIR = cast<llvm::BasicBlock>(InsertAtEnd->Val);
-  auto &Builder = Ctx.getLLVMIRBuilder();
-  Builder.SetInsertPoint(InsertAtEndIR);
-  auto *NewSI =
-      Builder.CreateAlignedStore(V->Val, Ptr->Val, Align, /*isVolatile=*/false);
-  auto *NewSBI = Ctx.createStoreInst(NewSI);
-  return NewSBI;
+  return create(V, Ptr, Align, InsertAtEnd, /*IsVolatile=*/false, Ctx);
 }
 
 StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -662,6 +662,18 @@ StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
   auto *NewSBI = Ctx.createStoreInst(NewSI);
   return NewSBI;
 }
+
+StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
+                             Instruction *InsertBefore, bool IsVolatile,
+                             Context &Ctx) {
+  llvm::Instruction *BeforeIR = InsertBefore->getTopmostLLVMInstruction();
+  auto &Builder = Ctx.getLLVMIRBuilder();
+  Builder.SetInsertPoint(BeforeIR);
+  auto *NewSI = Builder.CreateAlignedStore(V->Val, Ptr->Val, Align, IsVolatile);
+  auto *NewSBI = Ctx.createStoreInst(NewSI);
+  return NewSBI;
+}
+
 StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
                              BasicBlock *InsertAtEnd, Context &Ctx) {
   auto *InsertAtEndIR = cast<llvm::BasicBlock>(InsertAtEnd->Val);
@@ -669,6 +681,17 @@ StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
   Builder.SetInsertPoint(InsertAtEndIR);
   auto *NewSI =
       Builder.CreateAlignedStore(V->Val, Ptr->Val, Align, /*isVolatile=*/false);
+  auto *NewSBI = Ctx.createStoreInst(NewSI);
+  return NewSBI;
+}
+
+StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
+                             BasicBlock *InsertAtEnd, bool IsVolatile,
+                             Context &Ctx) {
+  auto *InsertAtEndIR = cast<llvm::BasicBlock>(InsertAtEnd->Val);
+  auto &Builder = Ctx.getLLVMIRBuilder();
+  Builder.SetInsertPoint(InsertAtEndIR);
+  auto *NewSI = Builder.CreateAlignedStore(V->Val, Ptr->Val, Align, IsVolatile);
   auto *NewSBI = Ctx.createStoreInst(NewSI);
   return NewSBI;
 }

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -826,6 +826,7 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertBefore=*/Ret,
                                    /*IsVolatile=*/true, Ctx);
+  // Check if create was volatile
   EXPECT_TRUE(NewVSt->isVolatile());
 }
 

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -815,7 +815,6 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
   sandboxir::StoreInst *NewSt =
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertBefore=*/Ret, Ctx);
-  // Check if create was volatile
   EXPECT_FALSE(NewSt->isVolatile());
   EXPECT_EQ(NewSt->getType(), St->getType());
   EXPECT_EQ(NewSt->getValueOperand(), Val);
@@ -826,14 +825,15 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertBefore=*/Ret,
                                    /*IsVolatile=*/true, Ctx);
-  // Check if create was volatile
   EXPECT_TRUE(NewVSt->isVolatile());
-
+  EXPECT_EQ(NewVSt->getType(), VSt->getType());
+  EXPECT_EQ(NewVSt->getValueOperand(), Val);
+  EXPECT_EQ(NewVSt->getPointerOperand(), Ptr);
+  EXPECT_EQ(NewVSt->getAlign(), 8);
   // Check create(InsertAtEnd)
   sandboxir::StoreInst *NewStEnd =
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertAtEnd=*/BB, Ctx);
-  // Check if create was volatile
   EXPECT_FALSE(NewStEnd->isVolatile());
   EXPECT_EQ(NewStEnd->getType(), St->getType());
   EXPECT_EQ(NewStEnd->getValueOperand(), Val);
@@ -846,7 +846,6 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertAtEnd=*/BB,
                                    /*IsVolatile=*/true, Ctx);
-  // Check if create was volatile
   EXPECT_TRUE(NewVStEnd->isVolatile());
   EXPECT_EQ(NewVStEnd->getType(), VSt->getType());
   EXPECT_EQ(NewVStEnd->getValueOperand(), Val);

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -785,9 +785,9 @@ define void @foo(ptr %arg0, ptr %arg1) {
 
 TEST_F(SandboxIRTest, StoreInst) {
   parseIR(C, R"IR(
-define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
+define void @foo(i8 %val, ptr %ptr) {
   store i8 %val, ptr %ptr, align 64
-  store volatile i8 %val, ptr %vptr, align 64
+  store volatile i8 %val, ptr %ptr, align 64
   ret void
 }
 )IR");
@@ -803,7 +803,6 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
   auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
 
   // Check that the StoreInst has been created correctly.
-  // Check isVolatile()
   EXPECT_FALSE(St->isVolatile());
   EXPECT_TRUE(VSt->isVolatile());
   // Check getPointerOperand()
@@ -820,6 +819,7 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
   EXPECT_EQ(NewSt->getValueOperand(), Val);
   EXPECT_EQ(NewSt->getPointerOperand(), Ptr);
   EXPECT_EQ(NewSt->getAlign(), 8);
+  EXPECT_EQ(NewSt->getNextNode(), Ret);
   // Check create(InsertBefore, IsVolatile=true)
   sandboxir::StoreInst *NewVSt =
       sandboxir::StoreInst::create(Val, Ptr, Align(8),

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -821,13 +821,39 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
   EXPECT_EQ(NewSt->getValueOperand(), Val);
   EXPECT_EQ(NewSt->getPointerOperand(), Ptr);
   EXPECT_EQ(NewSt->getAlign(), 8);
-  // Check create(InsertBefore)
+  // Check create(InsertBefore, IsVolatile=true)
   sandboxir::StoreInst *NewVSt =
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertBefore=*/Ret,
                                    /*IsVolatile=*/true, Ctx);
   // Check if create was volatile
   EXPECT_TRUE(NewVSt->isVolatile());
+
+  // Check create(InsertAtEnd)
+  sandboxir::StoreInst *NewStEnd =
+      sandboxir::StoreInst::create(Val, Ptr, Align(8),
+                                   /*InsertAtEnd=*/BB, Ctx);
+  // Check if create was volatile
+  EXPECT_FALSE(NewStEnd->isVolatile());
+  EXPECT_EQ(NewStEnd->getType(), St->getType());
+  EXPECT_EQ(NewStEnd->getValueOperand(), Val);
+  EXPECT_EQ(NewStEnd->getPointerOperand(), Ptr);
+  EXPECT_EQ(NewStEnd->getAlign(), 8);
+  EXPECT_EQ(NewStEnd->getParent(), BB);
+  EXPECT_EQ(NewStEnd->getNextNode(), nullptr);
+  // Check create(InsertAtEnd, IsVolatile=true)
+  sandboxir::StoreInst *NewVStEnd =
+      sandboxir::StoreInst::create(Val, Ptr, Align(8),
+                                   /*InsertAtEnd=*/BB,
+                                   /*IsVolatile=*/true, Ctx);
+  // Check if create was volatile
+  EXPECT_TRUE(NewVStEnd->isVolatile());
+  EXPECT_EQ(NewVStEnd->getType(), VSt->getType());
+  EXPECT_EQ(NewVStEnd->getValueOperand(), Val);
+  EXPECT_EQ(NewVStEnd->getPointerOperand(), Ptr);
+  EXPECT_EQ(NewVStEnd->getAlign(), 8);
+  EXPECT_EQ(NewVStEnd->getParent(), BB);
+  EXPECT_EQ(NewVStEnd->getNextNode(), nullptr);
 }
 
 TEST_F(SandboxIRTest, ReturnInst) {

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -785,8 +785,9 @@ define void @foo(ptr %arg0, ptr %arg1) {
 
 TEST_F(SandboxIRTest, StoreInst) {
   parseIR(C, R"IR(
-define void @foo(i8 %val, ptr %ptr) {
+define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
   store i8 %val, ptr %ptr, align 64
+  store volatile i8 %val, ptr %vptr, align 64
   ret void
 }
 )IR");
@@ -798,9 +799,13 @@ define void @foo(i8 %val, ptr %ptr) {
   auto *BB = &*F->begin();
   auto It = BB->begin();
   auto *St = cast<sandboxir::StoreInst>(&*It++);
+  auto *VSt = cast<sandboxir::StoreInst>(&*It++);
   auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
 
   // Check that the StoreInst has been created correctly.
+  // Check isVolatile()
+  EXPECT_FALSE(St->isVolatile());
+  EXPECT_TRUE(VSt->isVolatile());
   // Check getPointerOperand()
   EXPECT_EQ(St->getValueOperand(), Val);
   EXPECT_EQ(St->getPointerOperand(), Ptr);
@@ -810,10 +815,18 @@ define void @foo(i8 %val, ptr %ptr) {
   sandboxir::StoreInst *NewSt =
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertBefore=*/Ret, Ctx);
+  // Check if create was volatile
+  EXPECT_FALSE(NewSt->isVolatile());
   EXPECT_EQ(NewSt->getType(), St->getType());
   EXPECT_EQ(NewSt->getValueOperand(), Val);
   EXPECT_EQ(NewSt->getPointerOperand(), Ptr);
   EXPECT_EQ(NewSt->getAlign(), 8);
+  // Check create(InsertBefore)
+  sandboxir::StoreInst *NewVSt =
+      sandboxir::StoreInst::create(Val, Ptr, Align(8),
+                                   /*InsertBefore=*/Ret,
+                                   /*IsVolatile=*/true, Ctx);
+  EXPECT_TRUE(NewVSt->isVolatile());
 }
 
 TEST_F(SandboxIRTest, ReturnInst) {

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -830,6 +830,7 @@ define void @foo(i8 %val, ptr %ptr, ptr %vptr) {
   EXPECT_EQ(NewVSt->getValueOperand(), Val);
   EXPECT_EQ(NewVSt->getPointerOperand(), Ptr);
   EXPECT_EQ(NewVSt->getAlign(), 8);
+  EXPECT_EQ(NewVSt->getNextNode(), Ret);
   // Check create(InsertAtEnd)
   sandboxir::StoreInst *NewStEnd =
       sandboxir::StoreInst::create(Val, Ptr, Align(8),


### PR DESCRIPTION
Closed PR: https://github.com/llvm/llvm-project/pull/100957

As stated this patch just implements the volatile-memory data for StoreInst