### PR TITLE
[libc] fix rwlock test

### DIFF
--- a/libc/test/integration/src/pthread/pthread_rwlock_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_rwlock_test.cpp
@@ -217,11 +217,12 @@ static void timedlock_with_deadlock_test() {
             ETIMEDOUT);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_rwlock_timedrdlock(&rwlock, &ts), 0);
   ASSERT_EQ(
-      LIBC_NAMESPACE::pthread_rwlock_clockwrlock(&rwlock, CLOCK_MONOTONIC, &ts),
+      LIBC_NAMESPACE::pthread_rwlock_clockwrlock(&rwlock, CLOCK_REALTIME, &ts),
       ETIMEDOUT);
   ASSERT_EQ(
-      LIBC_NAMESPACE::pthread_rwlock_clockrdlock(&rwlock, CLOCK_MONOTONIC, &ts),
+      LIBC_NAMESPACE::pthread_rwlock_clockrdlock(&rwlock, CLOCK_REALTIME, &ts),
       0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_rwlock_unlock(&rwlock), 0);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_rwlock_unlock(&rwlock), 0);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_rwlock_unlock(&rwlock), 0);
   // notice that ts is already expired, but the following should still succeed.


### PR DESCRIPTION
Previous commit uses wrong clock id and forget to release an additional rdlock. cc @Eric977 
Sorry for missing this in my initial review.

Fixes https://github.com/llvm/llvm-project/issues/100960.

Notice that the timestamp is created via
```c++
  LIBC_NAMESPACE::clock_gettime(CLOCK_REALTIME, &ts);
  ts.tv_nsec += 50'000;
  if (ts.tv_nsec >= 1'000'000'000) {
    ts.tv_nsec -= 1'000'000'000;
    ts.tv_sec += 1;
  }
```