### PR TITLE
[MC] Move some bool members to MCFragment. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCFragment.h
+++ b/llvm/include/llvm/MC/MCFragment.h
@@ -69,8 +69,15 @@ private:
   FragmentType Kind;
 
 protected:
+  /// Used by subclasses for better packing.
+  ///
+  /// MCEncodedFragment
   bool HasInstructions : 1;
+  bool AlignToBundleEnd : 1;
+  /// MCDataFragment
   bool LinkerRelaxable : 1;
+  /// MCRelaxableFragment: x86-specific
+  bool AllowAutoPadding : 1;
 
   MCFragment(FragmentType Kind, bool HasInstructions);
 
@@ -115,9 +122,6 @@ public:
 /// data.
 ///
 class MCEncodedFragment : public MCFragment {
-  /// Should this fragment be aligned to the end of a bundle?
-  bool AlignToBundleEnd = false;
-
   uint8_t BundlePadding = 0;
 
 protected:
@@ -228,11 +232,8 @@ public:
 /// relaxed during the assembler layout and relaxation stage.
 ///
 class MCRelaxableFragment : public MCEncodedFragmentWithFixups<8, 1> {
-
   /// The instruction this is a fragment for.
   MCInst Inst;
-  /// Can we auto pad the instruction?
-  bool AllowAutoPadding = false;
 
 public:
   MCRelaxableFragment(const MCInst &Inst, const MCSubtargetInfo &STI)

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -27,7 +27,8 @@
 using namespace llvm;
 
 MCFragment::MCFragment(FragmentType Kind, bool HasInstructions)
-    : Kind(Kind), HasInstructions(HasInstructions), LinkerRelaxable(false) {}
+    : Kind(Kind), HasInstructions(HasInstructions), AlignToBundleEnd(false),
+      LinkerRelaxable(false), AllowAutoPadding(false) {}
 
 void MCFragment::destroy() {
   switch (Kind) {


### PR DESCRIPTION
Move `AllowAutoPadding` to MCFragment, which reduce the
MCRelaxableFragment size by 8 bytes. While here, also move
`AlignToBundleEnd` next to `HasInstructions`. Functions that create
fragments are slightly shorter due to fewer byte zeroing instructions.

Although fewer in number than MCDataFragments, MCRelaxableFragment
objects still constitute a significant proportion warranting
optimization.
```
% clang -c sqlite3.i -w -g -Xclang -print-stats
...
   2206 assembler             - Number of emitted assembler fragments - align
  83980 assembler             - Number of emitted assembler fragments - data
     84 assembler             - Number of emitted assembler fragments - fill
 169462 assembler             - Number of emitted assembler fragments - total
  11396 assembler             - Number of emitted assembler fragments - relaxable
```
