### PR TITLE
[clang-format] Use double hyphen for multiple-letter flags

### DIFF
--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -134,7 +134,7 @@ def main():
             if line_count != 0:
                 end_line += line_count - 1
             lines_by_file.setdefault(filename, []).extend(
-                ["-lines", str(start_line) + ":" + str(end_line)]
+                ["--lines", str(start_line) + ":" + str(end_line)]
             )
 
     # Reformat files containing changes in place.
@@ -146,12 +146,12 @@ def main():
         if args.i:
             command.append("-i")
         if args.sort_includes:
-            command.append("-sort-includes")
+            command.append("--sort-includes")
         command.extend(lines)
         if args.style:
-            command.extend(["-style", args.style])
+            command.extend(["--style", args.style])
         if args.fallback_style:
-            command.extend(["-fallback-style", args.fallback_style])
+            command.extend(["--fallback-style", args.fallback_style])
 
         try:
             p = subprocess.Popen(

--- a/clang/tools/clang-format/clang-format-sublime.py
+++ b/clang/tools/clang-format/clang-format-sublime.py
@@ -35,18 +35,18 @@ class ClangFormatCommand(sublime_plugin.TextCommand):
         regions = []
         command = [binary]
         if style:
-            command.extend(["-style", style])
+            command.extend(["--style", style])
         for region in self.view.sel():
             regions.append(region)
             region_offset = min(region.a, region.b)
             region_length = abs(region.b - region.a)
             command.extend(
                 [
-                    "-offset",
+                    "--offset",
                     str(region_offset),
-                    "-length",
+                    "--length",
                     str(region_length),
-                    "-assume-filename",
+                    "--assume-filename",
                     str(self.view.file_name()),
                 ]
             )

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -166,19 +166,19 @@ uses the function `buffer-file-name'."
         (let ((status (apply #'call-process-region
                              nil nil clang-format-executable
                              nil `(,temp-buffer ,temp-file) nil
-                             `("-output-replacements-xml"
+                             `("--output-replacements-xml"
                                ;; Guard against a nil assume-file-name.
                                ;; If the clang-format option -assume-filename
                                ;; is given a blank string it will crash as per
                                ;; the following bug report
                                ;; https://bugs.llvm.org/show_bug.cgi?id=34667
                                ,@(and assume-file-name
-                                      (list "-assume-filename" assume-file-name))
-                               ,@(and style (list "-style" style))
-                               "-fallback-style" ,clang-format-fallback-style
-                               "-offset" ,(number-to-string file-start)
-                               "-length" ,(number-to-string (- file-end file-start))
-                               "-cursor" ,(number-to-string cursor))))
+                                      (list "--assume-filename" assume-file-name))
+                               ,@(and style (list "--style" style))
+                               "--fallback-style" ,clang-format-fallback-style
+                               "--offset" ,(number-to-string file-start)
+                               "--length" ,(number-to-string (- file-end file-start))
+                               "--cursor" ,(number-to-string cursor))))
               (stderr (with-temp-buffer
                         (unless (zerop (cadr (insert-file-contents temp-file)))
                           (insert ": "))

--- a/clang/tools/clang-format/clang-format.py
+++ b/clang/tools/clang-format/clang-format.py
@@ -78,7 +78,7 @@ def main():
 
     # Determine range to format.
     if vim.eval('exists("l:lines")') == "1":
-        lines = ["-lines", vim.eval("l:lines")]
+        lines = ["--lines", vim.eval("l:lines")]
     elif vim.eval('exists("l:formatdiff")') == "1" and os.path.exists(
         vim.current.buffer.name
     ):
@@ -88,12 +88,12 @@ def main():
         lines = []
         for op in reversed(sequence.get_opcodes()):
             if op[0] not in ["equal", "delete"]:
-                lines += ["-lines", "%s:%s" % (op[3] + 1, op[4])]
+                lines += ["--lines", "%s:%s" % (op[3] + 1, op[4])]
         if lines == []:
             return
     else:
         lines = [
-            "-lines",
+            "--lines",
             "%s:%s" % (vim.current.range.start + 1, vim.current.range.end + 1),
         ]
 
@@ -116,15 +116,15 @@ def main():
         startupinfo.wShowWindow = subprocess.SW_HIDE
 
     # Call formatter.
-    command = [binary, "-cursor", str(cursor_byte)]
-    if lines != ["-lines", "all"]:
+    command = [binary, "--cursor", str(cursor_byte)]
+    if lines != ["--lines", "all"]:
         command += lines
     if style:
-        command.extend(["-style", style])
+        command.extend(["--style", style])
     if fallback_style:
-        command.extend(["-fallback-style", fallback_style])
+        command.extend(["--fallback-style", fallback_style])
     if vim.current.buffer.name:
-        command.extend(["-assume-filename", vim.current.buffer.name])
+        command.extend(["--assume-filename", vim.current.buffer.name])
     p = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -499,12 +499,12 @@ def clang_format_to_blob(filename, line_ranges, revision=None,
   Returns the object ID (SHA-1) of the created blob."""
   clang_format_cmd = [binary]
   if style:
-    clang_format_cmd.extend(['-style='+style])
+    clang_format_cmd.extend(['--style='+style])
   clang_format_cmd.extend([
-      '-lines=%s:%s' % (start_line, start_line+line_count-1)
+      '--lines=%s:%s' % (start_line, start_line+line_count-1)
       for start_line, line_count in line_ranges])
   if revision is not None:
-    clang_format_cmd.extend(['-assume-filename='+filename])
+    clang_format_cmd.extend(['--assume-filename='+filename])
     git_show_cmd = ['git', 'cat-file', 'blob', '%s:%s' % (revision, filename)]
     git_show = subprocess.Popen(git_show_cmd, env=env, stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE)


### PR DESCRIPTION
- Closes: #100974 