### PR TITLE
[NVPTX] Fix DwarfFrameBase construction

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXFrameLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXFrameLowering.cpp
@@ -93,5 +93,8 @@ MachineBasicBlock::iterator NVPTXFrameLowering::eliminateCallFramePseudoInstr(
 
 TargetFrameLowering::DwarfFrameBase
 NVPTXFrameLowering::getDwarfFrameBase(const MachineFunction &MF) const {
-  return {DwarfFrameBase::CFA, {0}};
+  DwarfFrameBase FrameBase;
+  FrameBase.Kind = DwarfFrameBase::CFA;
+  FrameBase.Location.Offset = 0;
+  return FrameBase;
 }


### PR DESCRIPTION
The `{0}` here was initializing the first union member `Register`, rather than the union member used by CFA, which is `Offset`. Prior to https://github.com/llvm/llvm-project/pull/99263 this was harmless, but now they have different layout, leading to test failures on some platforms (at least i686 and s390x).