### PR TITLE
[APINotes] Do not crash for C++ operators

### DIFF
--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -1044,11 +1044,16 @@ void Sema::ProcessAPINotes(Decl *D) {
 
   if (auto TagContext = dyn_cast<TagDecl>(D->getDeclContext())) {
     if (auto CXXMethod = dyn_cast<CXXMethodDecl>(D)) {
-      for (auto Reader : APINotes.findAPINotes(D->getLocation())) {
-        if (auto Context = UnwindTagContext(TagContext, APINotes)) {
-          auto Info =
-              Reader->lookupCXXMethod(Context->id, CXXMethod->getName());
-          ProcessVersionedAPINotes(*this, CXXMethod, Info);
+      if (!isa<CXXConstructorDecl>(CXXMethod) &&
+          !isa<CXXDestructorDecl>(CXXMethod) &&
+          !isa<CXXConversionDecl>(CXXMethod) &&
+          !CXXMethod->isOverloadedOperator()) {
+        for (auto Reader : APINotes.findAPINotes(D->getLocation())) {
+          if (auto Context = UnwindTagContext(TagContext, APINotes)) {
+            auto Info =
+                Reader->lookupCXXMethod(Context->id, CXXMethod->getName());
+            ProcessVersionedAPINotes(*this, CXXMethod, Info);
+          }
         }
       }
     }

--- a/clang/test/APINotes/Inputs/Headers/Methods.h
+++ b/clang/test/APINotes/Inputs/Headers/Methods.h
@@ -2,6 +2,8 @@ struct IntWrapper {
   int value;
 
   IntWrapper getIncremented() const { return {value + 1}; }
+
+  IntWrapper operator+(const IntWrapper& RHS) const { return {value + RHS.value}; }
 };
 
 struct Outer {
@@ -9,5 +11,9 @@ struct Outer {
     int value;
 
     Inner getDecremented() const { return {value - 1}; }
+
+    bool operator==(const Inner& RHS) const {
+      return value == RHS.value;
+    }
   };
 };


### PR DESCRIPTION
This fixes a crash during `CXXMethod->getName()` in `Sema::ProcessAPINotes`: we were trying to get the name of a C++ method as a string, which fails with an assertion if the name is not a simple identifier.