### PR TITLE
Ofast deprecation clarifications

### DIFF
--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -429,8 +429,12 @@ Code Generation Options
 
     :option:`-Ofast` Enables all the optimizations from :option:`-O3` along
     with other aggressive optimizations that may violate strict compliance with
-    language standards. This is deprecated in favor of :option:`-O3`
-    in combination with :option:`-ffast-math`.
+    language standards. This is deprecated in Clang-19 and a warning is emitted
+    that :option:`-O3` in combination with :option:`-ffast-math` should be used
+    instead if the request for non-standard math behavior is intended.  There
+    is no timeline yet for removal; the aim is to discourage use of
+    :option:`-Ofast` due to the surprising behavior of an optimization flag
+    changing the observable behavior of correct code.
 
     :option:`-Os` Like :option:`-O2` with extra optimizations to reduce code
     size.

--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -431,7 +431,7 @@ Code Generation Options
     with other aggressive optimizations that may violate strict compliance with
     language standards. This is deprecated in Clang 19 and a warning is emitted
     that :option:`-O3` in combination with :option:`-ffast-math` should be used
-    instead if the request for non-standard math behavior is intended.  There
+    instead if the request for non-standard math behavior is intended. There
     is no timeline yet for removal; the aim is to discourage use of
     :option:`-Ofast` due to the surprising behavior of an optimization flag
     changing the observable behavior of correct code.

--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -429,7 +429,7 @@ Code Generation Options
 
     :option:`-Ofast` Enables all the optimizations from :option:`-O3` along
     with other aggressive optimizations that may violate strict compliance with
-    language standards. This is deprecated in Clang-19 and a warning is emitted
+    language standards. This is deprecated in Clang 19 and a warning is emitted
     that :option:`-O3` in combination with :option:`-ffast-math` should be used
     instead if the request for non-standard math behavior is intended.  There
     is no timeline yet for removal; the aim is to discourage use of


### PR DESCRIPTION
Following up on the RFC discussion, this is clarifying that the main purpose and effect of the -Ofast deprecation is to discourage its usage and that everything else is more or less open for discussion, e.g. there is no timeline yet for removal.