### PR TITLE
[sanitizer_common][test] Fix InternalMmapWithOffset on 32-bit Linux/s…

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -220,7 +220,7 @@ uptr internal_mmap(void *addr, uptr length, int prot, int flags, int fd,
   // mmap2 specifies file offset in 4096-byte units.
   CHECK(IsAligned(offset, 4096));
   return internal_syscall(SYSCALL(mmap2), addr, length, prot, flags, fd,
-                          offset / 4096);
+                          (OFF_T)(offset / 4096));
 #      endif
 }
 #    endif  // !SANITIZER_S390


### PR DESCRIPTION
…parc64

```
  SanitizerCommon-Unit :: ./Sanitizer-sparc-Test/SanitizerCommon/InternalMmapWithOffset

```
`FAIL`s on 32-bit Linux/sparc64:
```
projects/compiler-rt/lib/sanitizer_common/tests/./Sanitizer-sparc-Test --gtest_filter=SanitizerCommon.InternalMmapWithOffset
--
compiler-rt/lib/sanitizer_common/tests/sanitizer_libc_test.cpp:335: Failure
Expected equality of these values:
  'A'
    Which is: 'A' (65, 0x41)
  p[0]
    Which is: '\0'
```
It turns out the `pgoffset` arg to `mmap2` is passed incorrectly in this case, unlike the 64-bit test.  The caller, `MapWritableFileToMemory`, passes an `u64` arg, while `mmap2` expects an `off_t`.  This patch casts the arg accordingly.

Tested on `sparc64-unknown-linux-gnu` and `x86_64-pc-linux-gnu`.