### PR TITLE
[mlir][doc] Fix docs for `PtrDialect` using the `-gen-dialect-doc`(NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Ptr/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Ptr/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(PtrOps ptr)
-add_mlir_doc(PtrOps PtrOps Dialects/ -gen-dialect-doc)
+add_mlir_doc(PtrOps PtrOps Dialects/ -gen-dialect-doc -dialect=ptr)
 
 set(LLVM_TARGET_DEFINITIONS PtrOps.td)
 mlir_tablegen(PtrOpsAttrs.h.inc -gen-attrdef-decls -attrdefs-dialect=ptr)

--- a/mlir/include/mlir/Dialect/Ptr/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Ptr/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(PtrOps ptr)
-add_mlir_doc(PtrOps PtrOps Dialects/ -gen-op-doc)
+add_mlir_doc(PtrOps PtrOps Dialects/ -gen-dialect-doc)
 
 set(LLVM_TARGET_DEFINITIONS PtrOps.td)
 mlir_tablegen(PtrOpsAttrs.h.inc -gen-attrdef-decls -attrdefs-dialect=ptr)


### PR DESCRIPTION
The `-gen-op-doc` option was previously used, which did not generate a page for `PtrDialect` and resulted in an empty page. Switched to using the `-gen-dialect-doc` option to correctly generate a page for `PtrDialect` that includes information on its Attributes and Types.