### PR TITLE
[mlir] Fix build after ec50f5828f25

### DIFF
--- a/mlir/unittests/Support/CyclicReplacerCacheTest.cpp
+++ b/mlir/unittests/Support/CyclicReplacerCacheTest.cpp
@@ -26,14 +26,15 @@ TEST(CachedCyclicReplacerTest, testNoRecursion) {
 
 TEST(CachedCyclicReplacerTest, testInPlaceRecursionPruneAnywhere) {
   // Replacer cycles through ints 0 -> 1 -> 2 -> 0 -> ...
-  CachedCyclicReplacer<int, int> replacer(
-      /*replacer=*/[&](int n) { return replacer((n + 1) % 3); },
+  std::optional<CachedCyclicReplacer<int, int>> replacer;
+  replacer.emplace(
+      /*replacer=*/[&](int n) { return (*replacer)((n + 1) % 3); },
       /*cycleBreaker=*/[&](int n) { return -1; });
 
   // Starting at 0.
-  EXPECT_EQ(replacer(0), -1);
+  EXPECT_EQ((*replacer)(0), -1);
   // Starting at 2.
-  EXPECT_EQ(replacer(2), -1);
+  EXPECT_EQ((*replacer)(2), -1);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This commit fixes what appears to be invalid C++ -- a lambda capturing a variable before it is declared. The code compiles with GCC and Clang but not MSVC.