### PR TITLE
[SCEV] Return nullopt from CompareValueComplexity() if depth limit reached

### DIFF
--- a/polly/test/ScopInfo/invariant_load_zext_parameter-2.ll
+++ b/polly/test/ScopInfo/invariant_load_zext_parameter-2.ll
@@ -25,8 +25,8 @@
 ; CHECK: p0: ((sext i32 %tmp6 to i64) * %p1)
 ; CHECK: p1: ((sext i32 %tmp3 to i64) * (sext i32 %tmp8 to i64) * (%p0 + %p1) * %p3)
 ; CHECK: p2: ((sext i32 %tmp3 to i64) * (%p0 + %p1))
-; CHECK: p3: ((sext i32 %tmp5 to i64) * %p0)
-; CHECK: p4: ((sext i32 %tmp7 to i64) * %p2)
+; CHECK: p3: ((sext i32 %tmp7 to i64) * %p2)
+; CHECK: p4: ((sext i32 %tmp5 to i64) * %p0)
 ;
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 


### PR DESCRIPTION
Similarly to CompareSCEVComplexity() itself, we should return nullopt instead of 0 from CompareValueComplexity(), because we do not know how the values relate to each other. This means that the values will not be added to the equality cache, and it can not become inconsistent due to different results at different depths.

The test case is adopted from https://github.com/llvm/llvm-project/pull/100721.

This also has a pretty large positive compile-time impact in some cases (see http://llvm-compile-time-tracker.com/compare.php?from=73c72f2c6505d5bc8b47bb0420f6cba5b24270fe&to=02cb332824f53cf650558de2f88b5ba81aa799d8&stat=instructions:u). This is because we early exit complexity comparison and skip the EquivalenceClasses cache. The LTO improvement on lencod is legitimate -- that benchmark currently spends 10% of total time in SCEV complexity grouping. (And the thing all these SCEVs are computed for is quite silly ... I'll address that separately.)