### PR TITLE
[flang] Fix folding of RANK(assumed-type assumed-rank)

### DIFF
--- a/flang/lib/Evaluate/variable.cpp
+++ b/flang/lib/Evaluate/variable.cpp
@@ -250,7 +250,8 @@ DescriptorInquiry::DescriptorInquiry(NamedEntity &&base, Field field, int dim)
   const Symbol &last{base_.GetLastSymbol()};
   CHECK(IsDescriptor(last));
   CHECK((field == Field::Len && dim == 0) ||
-      (field != Field::Len && dim >= 0 && dim < last.Rank()));
+      (field != Field::Len && dim >= 0 &&
+          (dim < last.Rank() || IsAssumedRank(last))));
 }
 
 // LEN()

--- a/flang/test/Evaluate/fold-assumed-type-rank.f90
+++ b/flang/test/Evaluate/fold-assumed-type-rank.f90
@@ -1,0 +1,6 @@
+! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+subroutine sub3(ar_at)
+  type(*) :: ar_at(..)
+!CHECK:  PRINT *, int(int(rank(ar_at),kind=8),kind=4)
+  print *, rank(ar_at)
+end


### PR DESCRIPTION
The code that deals with the special case of RANK(assumed-rank) in intrinsic function folding wasn't handling the even more special case of assumed-type assumed-rank dummy arguments.