### PR TITLE
[PS4/PS5][Driver] Allow unified-lto.c test to find .*ld.exe

### DIFF
--- a/clang/test/Driver/unified-lto.c
+++ b/clang/test/Driver/unified-lto.c
@@ -27,7 +27,7 @@
 // RUN: %clang --target=x86_64-sie-ps5 -### %s -fno-unified-lto -flto=full 2>&1 | FileCheck --check-prefixes=LD,NOLTO %s
 // RUN: %clang --target=x86_64-sie-ps5 -### %s -fno-unified-lto -flto=thin 2>&1 | FileCheck --check-prefixes=LD,NOLTO %s
 
-// LD: {{.*ld}}"
+// LD: {{.*ld(\.exe)?}}"
 // LTOFULL-SAME: "--lto=full"
 // LTOTHIN-SAME: "--lto=thin"
 // NOLTO-NOT: "--lto


### PR DESCRIPTION
It's common in SIE development environments to have the PlayStation linkers on the %PATH%. In such cases, the driver will resolve the linker name to an existing executable, replete with ".exe" extension. Update recent modifications to clang/test/Driver/unified-lto.c to allow for this.