### PR TITLE
[flang] Add parsing-support for IVDEP directive

### DIFF
--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -39,6 +39,8 @@ A list of non-standard directives supported by Flang
 * `!dir$ vector always` forces vectorization on the following loop regardless
   of cost model decisions. The loop must still be vectorizable.
   [This directive currently only works on plain do loops without labels].
+* `!dir$ ivdev` tells vecorisation to ignore the dependency analysis of the
+  following loop.
 
 # Directive Details
 

--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -39,7 +39,7 @@ A list of non-standard directives supported by Flang
 * `!dir$ vector always` forces vectorization on the following loop regardless
   of cost model decisions. The loop must still be vectorizable.
   [This directive currently only works on plain do loops without labels].
-* `!dir$ ivdev` tells vecorization to ignore the dependency analysis of the
+* `!dir$ ivdep` tells vecorization to ignore the dependency analysis of the
   following loop.
 
 # Directive Details

--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -39,7 +39,7 @@ A list of non-standard directives supported by Flang
 * `!dir$ vector always` forces vectorization on the following loop regardless
   of cost model decisions. The loop must still be vectorizable.
   [This directive currently only works on plain do loops without labels].
-* `!dir$ ivdep` tells vecorization to ignore the dependency analysis of the
+* `!dir$ ivdep` tells vectorization to ignore the dependency analysis of the
   following loop.
 
 # Directive Details

--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -39,7 +39,7 @@ A list of non-standard directives supported by Flang
 * `!dir$ vector always` forces vectorization on the following loop regardless
   of cost model decisions. The loop must still be vectorizable.
   [This directive currently only works on plain do loops without labels].
-* `!dir$ ivdev` tells vecorisation to ignore the dependency analysis of the
+* `!dir$ ivdev` tells vecorization to ignore the dependency analysis of the
   following loop.
 
 # Directive Details

--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -203,6 +203,7 @@ public:
   NODE(parser, CompilerDirective)
   NODE(CompilerDirective, AssumeAligned)
   NODE(CompilerDirective, IgnoreTKR)
+  NODE(CompilerDirective, IgnoreVectorDep)
   NODE(CompilerDirective, LoopCount)
   NODE(CompilerDirective, NameValue)
   NODE(CompilerDirective, Unrecognized)

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3342,10 +3342,12 @@ struct CompilerDirective {
     TUPLE_CLASS_BOILERPLATE(NameValue);
     std::tuple<Name, std::optional<std::uint64_t>> t;
   };
+  EMPTY_CLASS(IgnoreVectorDep);
   EMPTY_CLASS(Unrecognized);
   CharBlock source;
-  std::variant<std::list<IgnoreTKR>, LoopCount, std::list<AssumeAligned>,
-      VectorAlways, std::list<NameValue>, Unrecognized>
+  std::variant<std::list<IgnoreTKR>, IgnoreVectorDep, LoopCount,
+      std::list<AssumeAligned>, VectorAlways, std::list<NameValue>,
+      Unrecognized>
       u;
 };
 

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1272,7 +1272,7 @@ TYPE_PARSER(construct<StatOrErrmsg>("STAT =" >> statVariable) ||
 constexpr auto ignore_tkr{
     "IGNORE_TKR" >> optionalList(construct<CompilerDirective::IgnoreTKR>(
                         maybe(parenthesized(many(letter))), name))};
-constexpr auto ignore_vector_dep{
+constexpr auto ignoreVectorDep{
     "IVDEP" >> construct<CompilerDirective::IgnoreVectorDep>()};
 const constexpr auto loopCount{
     "LOOP COUNT" >> construct<CompilerDirective::LoopCount>(
@@ -1286,7 +1286,7 @@ TYPE_PARSER(beginDirective >> "DIR$ "_tok >>
     sourced((construct<CompilerDirective>(ignore_tkr) ||
                 construct<CompilerDirective>(loopCount) ||
                 construct<CompilerDirective>(assumeAligned) ||
-                construct<CompilerDirective>(ignore_vector_dep) ||
+                construct<CompilerDirective>(ignoreVectorDep) ||
                 construct<CompilerDirective>(vectorAlways) ||
                 construct<CompilerDirective>(
                     many(construct<CompilerDirective::NameValue>(

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1266,12 +1266,15 @@ TYPE_PARSER(construct<StatOrErrmsg>("STAT =" >> statVariable) ||
 // Directives, extensions, and deprecated statements
 // !DIR$ IGNORE_TKR [ [(tkrdmac...)] name ]...
 // !DIR$ LOOP COUNT (n1[, n2]...)
+// !DIR$ IVDEP
 // !DIR$ name[=value] [, name[=value]]...
 // !DIR$ <anything else>
 constexpr auto ignore_tkr{
     "IGNORE_TKR" >> optionalList(construct<CompilerDirective::IgnoreTKR>(
                         maybe(parenthesized(many(letter))), name))};
-constexpr auto loopCount{
+constexpr auto ignore_vector_dep{
+    "IVDEP" >> construct<CompilerDirective::IgnoreVectorDep>()};
+const constexpr auto loopCount{
     "LOOP COUNT" >> construct<CompilerDirective::LoopCount>(
                         parenthesized(nonemptyList(digitString64)))};
 constexpr auto assumeAligned{"ASSUME_ALIGNED" >>
@@ -1283,6 +1286,7 @@ TYPE_PARSER(beginDirective >> "DIR$ "_tok >>
     sourced((construct<CompilerDirective>(ignore_tkr) ||
                 construct<CompilerDirective>(loopCount) ||
                 construct<CompilerDirective>(assumeAligned) ||
+                construct<CompilerDirective>(ignore_vector_dep) ||
                 construct<CompilerDirective>(vectorAlways) ||
                 construct<CompilerDirective>(
                     many(construct<CompilerDirective::NameValue>(

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1826,7 +1826,7 @@ public:
               Word("!DIR$ IGNORE_TKR"); // emitted even if tkr list is empty
               Walk(" ", tkr, ", ");
             },
-            [&](const CompilerDirective::IgnoreVectorDep &ivdep) {
+            [&](const CompilerDirective::IgnoreVectorDep &) {
               Word("!DIR$ IVDEP");
             },
             [&](const CompilerDirective::LoopCount &lcount) {

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1826,6 +1826,9 @@ public:
               Word("!DIR$ IGNORE_TKR"); // emitted even if tkr list is empty
               Walk(" ", tkr, ", ");
             },
+            [&](const CompilerDirective::IgnoreVectorDep &ivdep) {
+              Word("!DIR$ IVDEP");
+            },
             [&](const CompilerDirective::LoopCount &lcount) {
               Walk("!DIR$ LOOP COUNT (", lcount.v, ", ", ")");
             },

--- a/flang/test/Parser/compiler-directives.f90
+++ b/flang/test/Parser/compiler-directives.f90
@@ -35,3 +35,10 @@ subroutine vector_always
   do i=1,10
   enddo
 end subroutine
+
+subroutine ignore_vector_dep
+  !dir$ ivdep
+  ! CHECK: !DIR$ IVDEP
+  do i=1,10
+  enddo
+end subroutine


### PR DESCRIPTION
This adds the parser-side of the IVDEP (Ignore Vector memory DEPendencies) directive. This still produces a warning when used at this point.

There will be a follow-up patch to implement the lowering for this, so that it passes attributes to LLVM to indicate that it should ignore memory dependencies for the vectorisation of the loop following the IVDEP directive.