### PR TITLE
[nsan] Remove mallopt from nsan_interceptors

### DIFF
--- a/compiler-rt/lib/nsan/nsan_interceptors.cpp
+++ b/compiler-rt/lib/nsan/nsan_interceptors.cpp
@@ -21,10 +21,6 @@
 
 #include <wchar.h>
 
-#if SANITIZER_LINUX
-extern "C" int mallopt(int param, int value);
-#endif
-
 using namespace __sanitizer;
 using __nsan::nsan_init_is_running;
 using __nsan::nsan_initialized;
@@ -208,12 +204,6 @@ INTERCEPTOR(uptr, strxfrm, char *dst, const char *src, uptr size) {
 void __nsan::InitializeInterceptors() {
   static bool initialized = false;
   CHECK(!initialized);
-
-  // Instruct libc malloc to consume less memory.
-#if SANITIZER_LINUX
-  mallopt(1, 0);          // M_MXFAST
-  mallopt(-3, 32 * 1024); // M_MMAP_THRESHOLD
-#endif
 
   InitializeMallocInterceptors();
 


### PR DESCRIPTION
Fixes a build failure on 19.1.0-rc1 when building on linux with musl as the libc

musl does not provide mallopt, whereas glibc does. mallopt has portability issues with other libc implementations. Just remove the use.