### PR TITLE
ObjectFileJSON and Section changes to support section.address field i…

### DIFF
--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -685,7 +685,7 @@ bool fromJSON(const llvm::json::Value &value,
               lldb_private::JSONSection &section, llvm::json::Path path) {
   llvm::json::ObjectMapper o(value, path);
   return o && o.map("name", section.name) && o.map("type", section.type) &&
-         o.map("size", section.address) && o.map("size", section.size);
+         o.map("address", section.address) && o.map("size", section.size);
 }
 
 bool fromJSON(const llvm::json::Value &value, lldb::SectionType &type,

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
@@ -183,7 +183,7 @@ void ObjectFileJSON::CreateSections(SectionList &unified_section_list) {
   for (const auto &section : m_sections) {
     auto section_sp = std::make_shared<Section>(
         GetModule(), this, id++, ConstString(section.name),
-        section.type.value_or(eSectionTypeCode), 0, section.size.value_or(0), 0,
+        section.type.value_or(eSectionTypeCode), section.address.value_or(0), section.size.value_or(0), 0,
         section.size.value_or(0), /*log2align*/ 0, /*flags*/ 0);
     m_sections_up->AddSection(section_sp);
     unified_section_list.AddSection(section_sp);


### PR DESCRIPTION
This is a pull request to demonstrate the changes I made to get symbolication working using JSON Object/Symbol files.

https://discourse.llvm.org/t/lldb-support-renaming-symbols-by-address-using-a-symbol-file-provided-by-json-or-other-formatted-data-to-assist-reverse-engineering-e-g-protobuf-plist-xml-etc/80355/8
