### PR TITLE
[analyzer] Assert Callee is FunctionDecl in doesFnIntendToHandleOwnership()

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
@@ -756,7 +756,7 @@ protected:
   bool doesFnIntendToHandleOwnership(const Decl *Callee,
                                      ASTContext &ACtx) final {
     using namespace clang::ast_matchers;
-    const FunctionDecl *FD = dyn_cast<FunctionDecl>(Callee);
+    const FunctionDecl *FD = cast<FunctionDecl>(Callee);
 
     auto Matches =
         match(findAll(callExpr().bind("call")), *FD->getBody(), ACtx);


### PR DESCRIPTION
This patch replaces dyn_cast<> with cast<> for converting Callee to FunctionDecl, asserting non-null assumption to prevent undefined behavior due to null dereferences, reported by static analyzer tool and enforces the invariant that Callee must be a valid FunctionDecl.