### PR TITLE
[InstCombine] (NFC) Remove improper TODO for a - UMIN

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -899,7 +899,6 @@ static Instruction *foldSelectZeroOrMul(SelectInst &SI, InstCombinerImpl &IC) {
 
 /// Transform patterns such as (a > b) ? a - b : 0 into usub.sat(a, b).
 /// There are 8 commuted/swapped variants of this pattern.
-/// TODO: Also support a - UMIN(a,b) patterns.
 static Value *canonicalizeSaturatedSubtract(const ICmpInst *ICI,
                                             const Value *TrueVal,
                                             const Value *FalseVal,


### PR DESCRIPTION
It is already handled in a different method, especially as a - UMIN(a, b) cannot be handled by a select statement, unless it means something like: "(c < b) ? b - ((b > c) ? c : b) : 0;" but LLVM handles that case as well.