### PR TITLE
[NFC][SPIRV] Fix SPIRV backend build

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutor.h
@@ -43,6 +43,7 @@ class MachineInstr;
 class MachineIRBuilder;
 class MachineInstrBuilder;
 class MachineFunction;
+class MachineModuleInfo;
 class MachineOperand;
 class MachineRegisterInfo;
 class RegisterBankInfo;
@@ -582,7 +583,8 @@ public:
   virtual void setupMF(MachineFunction &mf, GISelKnownBits *kb,
                        CodeGenCoverage *covinfo = nullptr,
                        ProfileSummaryInfo *psi = nullptr,
-                       BlockFrequencyInfo *bfi = nullptr) {
+                       BlockFrequencyInfo *bfi = nullptr,
+                       MachineModuleInfo *MMI = nullptr) {
     CoverageInfo = covinfo;
     KB = kb;
     MF = &mf;

--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -19,6 +19,7 @@
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
 #include "llvm/CodeGen/GlobalISel/Utils.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/TargetLowering.h"
@@ -102,9 +103,10 @@ bool InstructionSelect::runOnMachineFunction(MachineFunction &MF) {
       BFI = &getAnalysis<LazyBlockFrequencyInfoPass>().getBFI();
   }
 
+  auto *MMI = &getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
   CodeGenCoverage CoverageInfo;
   assert(ISel && "Cannot work without InstructionSelector");
-  ISel->setupMF(MF, KB, &CoverageInfo, PSI, BFI);
+  ISel->setupMF(MF, KB, &CoverageInfo, PSI, BFI, MMI);
 
   // An optimization remark emitter. Used to report failures.
   MachineOptimizationRemarkEmitter MORE(MF, /*MBFI=*/nullptr);

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -78,8 +78,8 @@ public:
 
   void setupMF(MachineFunction &MF, GISelKnownBits *KB,
                CodeGenCoverage *CoverageInfo, ProfileSummaryInfo *PSI,
-               BlockFrequencyInfo *BFI) override {
-    InstructionSelector::setupMF(MF, KB, CoverageInfo, PSI, BFI);
+               BlockFrequencyInfo *BFI, MachineModuleInfo *MMI) override {
+    InstructionSelector::setupMF(MF, KB, CoverageInfo, PSI, BFI, MMI);
     MIB.setMF(MF);
 
     // hasFnAttribute() is expensive to call on every BRCOND selection, so

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -60,11 +60,12 @@ const char *AMDGPUInstructionSelector::getName() { return DEBUG_TYPE; }
 void AMDGPUInstructionSelector::setupMF(MachineFunction &MF, GISelKnownBits *KB,
                                         CodeGenCoverage *CoverageInfo,
                                         ProfileSummaryInfo *PSI,
-                                        BlockFrequencyInfo *BFI) {
+                                        BlockFrequencyInfo *BFI,
+                                        MachineModuleInfo *MMI) {
   MRI = &MF.getRegInfo();
   Subtarget = &MF.getSubtarget<GCNSubtarget>();
   Subtarget->checkSubtargetFeatures(MF.getFunction());
-  InstructionSelector::setupMF(MF, KB, CoverageInfo, PSI, BFI);
+  InstructionSelector::setupMF(MF, KB, CoverageInfo, PSI, BFI, MMI);
 }
 
 // Return the wave level SGPR base address if this is a wave address.

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
@@ -60,7 +60,7 @@ public:
 
   void setupMF(MachineFunction &MF, GISelKnownBits *KB,
                CodeGenCoverage *CoverageInfo, ProfileSummaryInfo *PSI,
-               BlockFrequencyInfo *BFI) override;
+               BlockFrequencyInfo *BFI, MachineModuleInfo *MMI) override;
 
 private:
   struct GEPInfo {

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -88,7 +88,7 @@ public:
                            const RegisterBankInfo &RBI);
   void setupMF(MachineFunction &MF, GISelKnownBits *KB,
                CodeGenCoverage *CoverageInfo, ProfileSummaryInfo *PSI,
-               BlockFrequencyInfo *BFI) override;
+               BlockFrequencyInfo *BFI, MachineModuleInfo *MMI) override;
   // Common selection code. Instruction-specific selection occurs in spvSelect.
   bool select(MachineInstr &I) override;
   static const char *getName() { return DEBUG_TYPE; }
@@ -279,11 +279,12 @@ SPIRVInstructionSelector::SPIRVInstructionSelector(const SPIRVTargetMachine &TM,
 void SPIRVInstructionSelector::setupMF(MachineFunction &MF, GISelKnownBits *KB,
                                        CodeGenCoverage *CoverageInfo,
                                        ProfileSummaryInfo *PSI,
-                                       BlockFrequencyInfo *BFI) {
-  MMI = &MF.getMMI().getObjFileInfo<SPIRVMachineModuleInfo>();
+                                       BlockFrequencyInfo *BFI,
+                                       MachineModuleInfo *MI) {
+  MMI = &MI->getObjFileInfo<SPIRVMachineModuleInfo>();
   MRI = &MF.getRegInfo();
   GR.setCurrentFunc(MF);
-  InstructionSelector::setupMF(MF, KB, CoverageInfo, PSI, BFI);
+  InstructionSelector::setupMF(MF, KB, CoverageInfo, PSI, BFI, MI);
 }
 
 static bool isImm(const MachineOperand &MO, MachineRegisterInfo *MRI);


### PR DESCRIPTION
Pass MachineModuleInfo through to the InstructionSelector in setupMF.

This resolves a build breakage in the SPIRV backend caused by removing the MachineModuleInfo from the MachineFunction.