### PR TITLE
[lld][InstrProf] Add "Separate" irpgo-profile-sort option

### DIFF
--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -48,9 +48,9 @@ getRelocHash(const Reloc &reloc,
     sectionIdx = sectionIdxIt->getSecond();
   std::string kind;
   if (isec)
-    kind = ("Section " + Twine((uint8_t)isec->kind())).str();
+    kind = ("Section " + Twine(static_cast<uint8_t>(isec->kind()))).str();
   if (auto *sym = reloc.referent.dyn_cast<Symbol *>()) {
-    kind += (" Symbol " + Twine((uint8_t)sym->kind())).str();
+    kind += (" Symbol " + Twine(static_cast<uint8_t>(sym->kind()))).str();
     if (auto *d = dyn_cast<Defined>(sym)) {
       if (isa_and_nonnull<CStringInputSection>(isec))
         return getRelocHash(kind, 0, isec->getOffset(d->value), reloc.addend);

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -126,8 +126,9 @@ def no_call_graph_profile_sort : Flag<["--"], "no-call-graph-profile-sort">,
 def print_symbol_order_eq: Joined<["--"], "print-symbol-order=">,
     HelpText<"Print a symbol order specified by --call-graph-profile-sort into the specified file">,
     Group<grp_lld>;
-def irpgo_profile_sort: Joined<["--"], "irpgo-profile-sort=">,
-    MetaVarName<"<profile>">,
+def irpgo_profile_sort: Separate<["--"], "irpgo-profile-sort">, Group<grp_lld>;
+def irpgo_profile_sort_eq: Joined<["--"], "irpgo-profile-sort=">,
+    Alias<!cast<Separate>(irpgo_profile_sort)>, MetaVarName<"<profile>">,
     HelpText<"Read the IRPGO profile at <profile> to order sections to improve startup time">,
     Group<grp_lld>;
 def compression_sort: Joined<["--"], "compression-sort=">,

--- a/lld/test/MachO/bp-section-orderer-errs.s
+++ b/lld/test/MachO/bp-section-orderer-errs.s
@@ -1,5 +1,6 @@
+# RUN: not %lld -o /dev/null --irpgo-profile-sort %s --call-graph-profile-sort 2>&1 | FileCheck %s --check-prefix=IRPGO-ERR
 # RUN: not %lld -o /dev/null --irpgo-profile-sort=%s --call-graph-profile-sort 2>&1 | FileCheck %s --check-prefix=IRPGO-ERR
-# IRPGO-ERR: --irpgo-profile-sort= is incompatible with --call-graph-profile-sort
+# IRPGO-ERR: --irpgo-profile-sort is incompatible with --call-graph-profile-sort
 
 # RUN: not %lld -o /dev/null --compression-sort=function --call-graph-profile-sort %s 2>&1 | FileCheck %s --check-prefix=COMPRESSION-ERR
 # COMPRESSION-ERR: --compression-sort= is incompatible with --call-graph-profile-sort


### PR DESCRIPTION
Add the "Separate" option `--irpgo-profile-sort <profile` instead of just the "Joined" option `--irpgo-profile-sort=<profile>`. This is useful if the path has a `,` for some reason which would break when trying to use `-Wl,--irpgo-profile-sort=<profile-with-comma>`.

While I'm here, use `static_cast<>` instead of the C style cast introduced in https://github.com/llvm/llvm-project/pull/100627