### PR TITLE
[BOLT][NFC] Keep input icount for disassembled functions

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -242,6 +242,9 @@ private:
   /// Original size of the function.
   uint64_t Size;
 
+  /// Original instruction count of the function, if disassembly succeeded.
+  uint64_t InputInstructionCount{0};
+
   /// Address of the function in output.
   uint64_t OutputAddress{0};
 
@@ -2172,6 +2175,9 @@ public:
 
   /// Get the number of instructions within this function.
   uint64_t getInstructionCount() const;
+
+  /// Get the original number of instructions.
+  uint64_t getInputInstructionCount() const { return InputInstructionCount; }
 
   const CFIInstrMapType &getFDEProgram() const { return FrameInstructions; }
 

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1499,6 +1499,8 @@ add_instruction:
 
   clearList(Relocations);
 
+  InputInstructionCount = Instructions.size();
+
   if (!IsSimple) {
     clearList(Instructions);
     return createNonFatalBOLTError("");


### PR DESCRIPTION
Preserve input instruction count for profile density computation (#101094). 
Set it right after disassembly, if it has succeeded.

This way, we address two issues:
- overhead: otherwise, we'd need to iterate over basic blocks to get
  instruction count.
- availability: non-simple functions in non-relocation mode (=BOLT split
  functions in BOLTed binaries) don't have CFG, so it's impossible to
  get the number of instructions.

