### PR TITLE
[Tooling] -fsyntax-only adjuster: remove -c and -S

### DIFF
--- a/clang/lib/Tooling/ArgumentsAdjusters.cpp
+++ b/clang/lib/Tooling/ArgumentsAdjusters.cpp
@@ -49,10 +49,11 @@ ArgumentsAdjuster getClangSyntaxOnlyAdjuster() {
           }))
         continue;
 
-      if (!Arg.starts_with("-fcolor-diagnostics") &&
+      if (Arg != "-c" && Arg != "-S" &&
+          !Arg.starts_with("-fcolor-diagnostics") &&
           !Arg.starts_with("-fdiagnostics-color"))
         AdjustedArgs.push_back(Args[i]);
-      // If we strip a color option, make sure we strip any preceeding `-Xclang`
+      // If we strip an option, make sure we strip any preceeding `-Xclang`
       // option as well.
       // FIXME: This should be added to most argument adjusters!
       else if (!AdjustedArgs.empty() && AdjustedArgs.back() == "-Xclang")

--- a/clang/test/Tooling/clang-check-extra-arg.cpp
+++ b/clang/test/Tooling/clang-check-extra-arg.cpp
@@ -1,4 +1,6 @@
-// RUN: clang-check "%s" -extra-arg=-Wunimplemented-warning -extra-arg-before=-Wunimplemented-warning-before -- -c 2>&1 | FileCheck %s
+/// Check we do not report "argument unused during compilation: '-c'"
+// RUN: clang-check "%s" -extra-arg=-Wunimplemented-warning -extra-arg-before=-Wunimplemented-warning-before -- -c 2>&1 | FileCheck %s --implicit-check-not='argument unused'
+// RUN: clang-check "%s" -extra-arg=-Wunimplemented-warning -extra-arg-before=-Wunimplemented-warning-before -- -S -Xclang -S 2>&1 | FileCheck %s --implicit-check-not='argument unused'
 
 // CHECK: unknown warning option '-Wunimplemented-warning-before'
 // CHECK: unknown warning option '-Wunimplemented-warning'


### PR DESCRIPTION
compile_commands.json entries often have -c. When adding -fsyntax-only,
we should remove -c to prevent the following warning:

```
% clang -c -fsyntax-only a.c
clang: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
```

Previously, -c and -S were inappropriately claimed in
`addPGOAndCoverageFlags` (see the workaround added by commit
a07b135ce0c0111bd83450b5dc29ef0381cdbc39). Now the workaround have been
removed (#98607). (clangDriver reports a -Wunused-command-line-argument
diagnostic for each unclaimed option.)

Fix #100909
