### PR TITLE
[libc][bazel] Remove tid tests from bazel

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1078,22 +1078,6 @@ libc_support_library(
 )
 
 libc_support_library(
-    name = "__support_osutil_pid",
-    srcs = ["src/__support/OSUtil/linux/pid.cpp"],
-    hdrs = ["src/__support/OSUtil/pid.h"],
-    target_compatible_with = select({
-        "@platforms//os:linux": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
-    deps = [
-        ":__support_macros_attributes",
-        ":__support_macros_optimization",
-        ":__support_osutil_syscall",
-        ":types_pid_t",
-    ],
-)
-
-libc_support_library(
     name = "__support_stringutil",
     srcs = glob(["src/__support/StringUtil/tables/**/*.h"]) + [
         "src/__support/StringUtil/error_to_string.cpp",
@@ -3040,20 +3024,6 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
-    ],
-)
-
-libc_function(
-    name = "getpid",
-    srcs = ["src/unistd/linux/getpid.cpp"],
-    hdrs = ["src/unistd/getpid.h"],
-    deps = [
-        ":__support_common",
-        ":__support_macros_config",
-        ":__support_osutil_pid",
-        ":__support_osutil_syscall",
-        ":errno",
-        ":types_pid_t",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
@@ -261,13 +261,6 @@ libc_test(
 #     ],
 # )
 
-libc_test(
-    name = "getpid_test",
-    srcs = ["getpid_test.cpp"],
-    libc_function_deps = [
-        "//libc:getpid",
-    ],
-)
 
 libc_test(
     name = "getppid_test",


### PR DESCRIPTION
In patch https://github.com/llvm/llvm-project/pull/100915 the tid code
was reverted. The bazel build wasn't updated, leaving some broken
targets. This patch fixes those.
