### PR TITLE
[AIX] Compile with `-pthread` if LLVM_ENABLE_THREADS

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1152,7 +1152,7 @@ if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
 
   # Make functions, like errno, thread safe.
   if (LLVM_ENABLE_THREADS)
-    add_compile_definitions(_THREAD_SAFE)
+    append("-pthread" CMAKE_CXX_FLAGS CMAKE_C_FLAGS)
   endif()
 
   # Modules should be built with -shared -Wl,-G, so we can use runtime linking

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1150,6 +1150,11 @@ if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
           add_compile_definitions(_XOPEN_SOURCE=700)
           add_compile_definitions(_LARGE_FILE_API)
 
+  # Make functions, like errno, thread safe.
+  if (LLVM_ENABLE_THREADS)
+    add_compile_definitions(_THREAD_SAFE)
+  endif()
+
   # Modules should be built with -shared -Wl,-G, so we can use runtime linking
   # with plugins.
   string(APPEND CMAKE_MODULE_LINKER_FLAGS " -shared -Wl,-G")


### PR DESCRIPTION
LTO may be multithreaded. Specify this flag to ensure thread safety on AIX.