### PR TITLE
[IR] Add CallBr to Instruction::isFenceLike.

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -791,6 +791,7 @@ public:
     case Instruction::CatchRet:
     case Instruction::Call:
     case Instruction::Invoke:
+    case Instruction::CallBr:
       return true;
     }
   }


### PR DESCRIPTION
I happened to notice it was missing relative to Call and Invoke. I don't have a test case.