### PR TITLE
[compiler-rt][AArch64][NFCI] Use CONSTRUCTOR_ATTRIBUTE in sme-abi-vg.c

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/sme-abi-vg.c
+++ b/compiler-rt/lib/builtins/aarch64/sme-abi-vg.c
@@ -10,10 +10,7 @@ struct FEATURES {
 
 extern struct FEATURES __aarch64_cpu_features;
 
-#if __GNUC__ >= 9
-#pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
-#endif
-__attribute__((constructor(90))) static void get_aarch64_cpu_features(void) {
+CONSTRUCTOR_ATTRIBUTE static void get_aarch64_cpu_features(void) {
   if (__atomic_load_n(&__aarch64_cpu_features.features, __ATOMIC_RELAXED))
     return;
 


### PR DESCRIPTION
sme-abi-vg.c includes cpu_model/aarch64.h which includes cpu_model.h which has an equivalent define for `CONSTRUCTOR_ATTRIBUTE` that has the same checks for the GCC version that we repeat here. Just use that, rather than repeating the same logic.

---

Feel free to take or leave as you prefer - I just spotted this could be tweaked when looking at some equivalent RISC-V code.