### PR TITLE
[lldb][test] Fix TestMultipleDebuggers test on non-x86, other small issues

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1514,19 +1514,23 @@ class Base(unittest.TestCase):
             stdflag = "-std=c++11"
         return stdflag
 
-    def buildDriver(self, sources, exe_name):
+    def buildDriver(self, sources, exe_name, defines=None):
         """Platform-specific way to build a program that links with LLDB (via the liblldb.so
         or LLDB.framework).
         """
+        if defines is None:
+            defines = []
+
         stdflag = self.getstdFlag()
         stdlibflag = self.getstdlibFlag()
+        defines = " ".join(["-D{}={}".format(name, value) for name, value in defines])
 
         lib_dir = configuration.lldb_libs_dir
         if self.hasDarwinFramework():
             d = {
                 "CXX_SOURCES": sources,
                 "EXE": exe_name,
-                "CFLAGS_EXTRAS": "%s %s" % (stdflag, stdlibflag),
+                "CFLAGS_EXTRAS": "%s %s %s" % (stdflag, stdlibflag, defines),
                 "FRAMEWORK_INCLUDES": "-F%s" % self.framework_dir,
                 "LD_EXTRAS": "%s -Wl,-rpath,%s" % (self.lib_lldb, self.framework_dir),
             }
@@ -1534,12 +1538,13 @@ class Base(unittest.TestCase):
             d = {
                 "CXX_SOURCES": sources,
                 "EXE": exe_name,
-                "CFLAGS_EXTRAS": "%s %s -I%s -I%s"
+                "CFLAGS_EXTRAS": "%s %s -I%s -I%s %s"
                 % (
                     stdflag,
                     stdlibflag,
                     os.path.join(os.environ["LLDB_SRC"], "include"),
                     os.path.join(configuration.lldb_obj_root, "include"),
+                    defines,
                 ),
                 "LD_EXTRAS": "-L%s -lliblldb" % lib_dir,
             }
@@ -1547,12 +1552,13 @@ class Base(unittest.TestCase):
             d = {
                 "CXX_SOURCES": sources,
                 "EXE": exe_name,
-                "CFLAGS_EXTRAS": "%s %s -I%s -I%s"
+                "CFLAGS_EXTRAS": "%s %s -I%s -I%s %s"
                 % (
                     stdflag,
                     stdlibflag,
                     os.path.join(os.environ["LLDB_SRC"], "include"),
                     os.path.join(configuration.lldb_obj_root, "include"),
+                    defines,
                 ),
                 "LD_EXTRAS": "-L%s -llldb -Wl,-rpath,%s" % (lib_dir, lib_dir),
             }

--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -12,15 +12,17 @@ from lldbsuite.test import lldbutil
 class TestMultipleSimultaneousDebuggers(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    # This test has been flaky lately on Linux buildbots and Github/Buildkite CI
-    # runs.
-    @skipIfLinux
+    # Sometimes times out on Linux, see https://github.com/llvm/llvm-project/issues/101162.
     @skipIfNoSBHeaders
     @skipIfWindows
     @skipIfHostIncompatibleWithTarget
     def test_multiple_debuggers(self):
         self.driver_exe = self.getBuildArtifact("multi-process-driver")
-        self.buildDriver("multi-process-driver.cpp", self.driver_exe)
+        self.buildDriver(
+            "multi-process-driver.cpp",
+            self.driver_exe,
+            defines=[("LLDB_HOST_ARCH", lldbplatformutil.getArchitecture())],
+        )
         self.addTearDownHook(lambda: os.remove(self.driver_exe))
 
         self.inferior_exe = self.getBuildArtifact("testprog")

--- a/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
+++ b/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "lldb/API/LLDB.h"
 #include "lldb/API/SBCommandInterpreter.h"
@@ -29,6 +30,9 @@
 #define NUMBER_OF_SIMULTANEOUS_DEBUG_SESSIONS 10
 
 #define DEBUG 0
+
+#define STR1(x) #x
+#define STR(x) STR1(x)
 
 using namespace lldb;
 
@@ -102,20 +106,21 @@ void *do_one_debugger (void *in)
     if (debugger.IsValid ())
     {
         debugger.SetAsync (true);
-        SBTarget target = debugger.CreateTargetWithFileAndArch(inferior_process_name, "x86_64");
+        SBTarget target = debugger.CreateTargetWithFileAndArch(inferior_process_name,
+                                                               STR(LLDB_HOST_ARCH));
         SBCommandInterpreter command_interp = debugger.GetCommandInterpreter();
         if (target.IsValid())
         {
             SBBreakpoint bar_br = target.BreakpointCreateByName ("bar", "testprog");
             if (!bar_br.IsValid())
             {
-                printf ("#%lld: failed to set breakpoint on bar, exiting.\n", threadnum);
+                printf ("#%" PRIu64 ": failed to set breakpoint on bar, exiting.\n", threadnum);
                 exit (1);
             }
             SBBreakpoint foo_br = target.BreakpointCreateByName ("foo", "testprog");
             if (!foo_br.IsValid())
             {
-                printf ("#%lld: Failed to set breakpoint on foo()\n", threadnum);
+                printf ("#%" PRIu64 ": Failed to set breakpoint on foo()\n", threadnum);
             }
 
             SBLaunchInfo launch_info (NULL);
@@ -136,15 +141,17 @@ void *do_one_debugger (void *in)
 
                 if (!walk_stack_to_main (process.GetThreadAtIndex(0)))
                 {
-                    printf ("#%lld: backtrace while @ foo() failed\n", threadnum);
+                    printf ("#%" PRIu64 ": backtrace while @ foo() failed\n", threadnum);
                     completed_threads_array[threadnum] = true;
                     return (void *) 1;
                 }
 
-                if (strcmp (process.GetThreadAtIndex(0).GetFrameAtIndex(0).GetFunctionName(), "foo") != 0)
+                // On Linux the () are included.
+                const char* hit_fn = process.GetThreadAtIndex(0).GetFrameAtIndex(0).GetFunctionName();
+                if (strcmp (hit_fn, "foo") != 0 && strcmp (hit_fn, "foo()") != 0)
                 {
 #if DEBUG == 1
-                    printf ("#%lld: First breakpoint did not stop at foo(), instead stopped at '%s'\n", threadnum, process.GetThreadAtIndex(0).GetFrameAtIndex(0).GetFunctionName());
+                    printf ("#%" PRIu64 ": First breakpoint did not stop at foo(), instead stopped at '%s'\n", threadnum, process.GetThreadAtIndex(0).GetFrameAtIndex(0).GetFunctionName());
 #endif
                     completed_threads_array[threadnum] = true;
                     return (void*) 1;
@@ -156,7 +163,7 @@ void *do_one_debugger (void *in)
 
                 if (process.GetState() == StateType::eStateExited)
                 {
-                    printf ("#%lld: Process exited\n", threadnum);
+                    printf ("#%" PRIu64 ": Process exited\n", threadnum);
                     completed_threads_array[threadnum] = true;
                     return (void *) 1;
                 }
@@ -164,14 +171,15 @@ void *do_one_debugger (void *in)
 
                 if (!walk_stack_to_main (process.GetThreadAtIndex(0)))
                 {
-                    printf ("#%lld: backtrace while @ bar() failed\n", threadnum);
+                    printf ("#%" PRIu64 ": backtrace while @ bar() failed\n", threadnum);
                     completed_threads_array[threadnum] = true;
                     return (void *) 1;
                 }
 
-                if (strcmp (process.GetThreadAtIndex(0).GetFrameAtIndex(0).GetFunctionName(), "bar") != 0)
+                hit_fn = process.GetThreadAtIndex(0).GetFrameAtIndex(0).GetFunctionName();
+                if (strcmp (hit_fn, "bar") != 0 && strcmp (hit_fn, "bar()") != 0)
                 {
-                    printf ("#%lld: First breakpoint did not stop at bar()\n", threadnum);
+                    printf ("#%" PRIu64 ": First breakpoint did not stop at bar()\n", threadnum);
                     completed_threads_array[threadnum] = true;
                     return (void*) 1;
                 }
@@ -183,7 +191,7 @@ void *do_one_debugger (void *in)
                 SBDebugger::Destroy(debugger);
 
 #if DEBUG == 1
-                printf ("#%lld: All good!\n", threadnum);
+                printf ("#%" PRIu64 ": All good!\n", threadnum);
 #endif
                 successful_threads_array[threadnum] = true;
                 completed_threads_array[threadnum] = true;
@@ -191,7 +199,7 @@ void *do_one_debugger (void *in)
             }
             else
             {
-                printf("#%lld: process failed to launch\n", threadnum);
+                printf("#%" PRIu64 ": process failed to launch\n", threadnum);
                 successful_threads_array[threadnum] = false;
                 completed_threads_array[threadnum] = true;
                 return (void*) 0;
@@ -199,7 +207,7 @@ void *do_one_debugger (void *in)
         }
         else
         {
-            printf ("#%lld: did not get valid target\n", threadnum);
+            printf ("#%" PRIu64 ": did not get valid target\n", threadnum);
             successful_threads_array[threadnum] = false;
             completed_threads_array[threadnum] = true;
             return (void*) 0;
@@ -207,7 +215,7 @@ void *do_one_debugger (void *in)
     }
     else
     {
-        printf ("#%lld: did not get debugger\n", threadnum);
+        printf ("#%" PRIu64 ": did not get debugger\n", threadnum);
         successful_threads_array[threadnum] = false;
         completed_threads_array[threadnum] = true;
         return (void*) 0;


### PR DESCRIPTION
This test has been flaky lately (https://github.com/llvm/llvm-project/issues/101162) and I disabled it everywhere initially.

I found that it always uses "x86_64" for the program architecture so the test was "passing" elsewhere but I don't think it was meant to. So I have added a define to pass on the host's architecture when compiling. This makes it work on AArch64 as well.

While I'm here I've fixed the uint64_t formatting warnings by using the defined formats that'll work everywhere.

In addition, I found that the function names include "()" on Linux, so now we check for "foo" or "foo()".

The test cpp file has never been, or was only partially formatted so I've not formatted the changes, just kept to the local style.

I've removed the Linux skip to see if any of this helps the timeouts, and to verify the build command changes. If the timeouts come back I'll disable it again.