### PR TITLE
[libc][math][c23] Temporarily disable expf16 on AArch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -540,7 +540,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.canonicalizef16
     libc.src.math.ceilf16
     libc.src.math.copysignf16
-    libc.src.math.expf16
     libc.src.math.f16add
     libc.src.math.f16addf
     libc.src.math.f16div


### PR DESCRIPTION
See Buildbot failure:
https://lab.llvm.org/buildbot/#/builders/104/builds/3378.
