### PR TITLE
[libc][math][c23] Temporarily disable totalorderf128 on RISC-V

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -605,7 +605,6 @@ if(LIBC_TYPES_HAS_FLOAT128)
     libc.src.math.roundf128
     libc.src.math.scalbnf128
     libc.src.math.sqrtf128
-    libc.src.math.totalorderf128
     libc.src.math.totalordermagf128
     libc.src.math.truncf128
     libc.src.math.ufromfpf128


### PR DESCRIPTION
See Buildbot failure:
https://lab.llvm.org/staging/#/builders/132/builds/698.
