### PR TITLE
[flang] Fix -fdefault-integer-8 result kind of relations

### DIFF
--- a/flang/include/flang/Evaluate/expression.h
+++ b/flang/include/flang/Evaluate/expression.h
@@ -660,7 +660,7 @@ extern template class Relational<SomeType>;
 // Logical expressions of a kind bigger than LogicalResult
 // do not include Relational<> operations as possibilities,
 // since the results of Relationals are always LogicalResult
-// (kind=1).
+// (kind=4).
 template <int KIND>
 class Expr<Type<TypeCategory::Logical, KIND>>
     : public ExpressionBase<Type<TypeCategory::Logical, KIND>> {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3587,8 +3587,12 @@ MaybeExpr RelationHelper(ExpressionAnalyzer &context, RelationalOperator opr,
         analyzer.IsIntrinsicRelational(opr, *leftType, *rightType)) {
       analyzer.CheckForNullPointer("as a relational operand");
       analyzer.CheckForAssumedRank("as a relational operand");
-      return AsMaybeExpr(Relate(context.GetContextualMessages(), opr,
-          analyzer.MoveExpr(0), analyzer.MoveExpr(1)));
+      if (auto cmp{Relate(context.GetContextualMessages(), opr,
+              analyzer.MoveExpr(0), analyzer.MoveExpr(1))}) {
+        return AsMaybeExpr(ConvertToKind<TypeCategory::Logical>(
+            context.GetDefaultKind(TypeCategory::Logical),
+            AsExpr(std::move(*cmp))));
+      }
     } else {
       return analyzer.TryDefinedOp(opr,
           leftType && leftType->category() == TypeCategory::Logical &&

--- a/flang/test/Evaluate/logical-args.f90
+++ b/flang/test/Evaluate/logical-args.f90
@@ -7,7 +7,6 @@ module m
      subroutine foo4(l)
        logical(kind=4), intent(in) :: l
      end subroutine foo4
-
      subroutine foo8(l)
        logical(kind=8), intent(in) :: l
      end subroutine foo8
@@ -17,9 +16,16 @@ end module m
 program main
   use m
   integer :: x(10), y
+
   ! CHECK: CALL foo(.true._4)
-  ! CHECK-8: CALL foo(logical(.true._4,kind=8))
+  ! CHECK-8: CALL foo(.true._8)
+  call foo(.true.)
+  ! CHECK: CALL foo(.true._4)
+  ! CHECK-8: CALL foo(.true._8)
   call foo(1 < 2)
+  ! CHECK: CALL foo(x(1_8)>y)
+  ! CHECK-8: CALL foo(logical(x(1_8)>y,kind=8))
+  call foo(x(1) > y)
   ! CHECK: CALL fooa(x>y)
   ! CHECK-8: CALL fooa(logical(x>y,kind=8))
   call fooa(x > y)
@@ -28,14 +34,18 @@ program main
   ! CHECK: CALL foo4(.true._4)
   ! CHECK-8: CALL foo8(.true._8)
   call foog(.true.)
+  ! CHECK: CALL foo4(.true._4)
+  ! CHECK-8: CALL foo8(.true._8)
+  call foog(1 < 2)
+  ! CHECK: CALL foo4(x(1_8)>y)
+  ! CHECK-8: CALL foo8(logical(x(1_8)>y,kind=8))
+  call foog(x(1) > y)
 
-  contains
-    subroutine foo(l)
-      logical :: l
-    end subroutine foo
-
-    subroutine fooa(l)
-      logical :: l(10)
-    end subroutine fooa
-
+ contains
+  subroutine foo(l)
+    logical :: l
+  end subroutine foo
+  subroutine fooa(l)
+    logical :: l(10)
+  end subroutine fooa
 end program main


### PR DESCRIPTION
The result of a relational operator is a default logical, which is LOGICAL(8) under the -fdefault-integer-8 option.

Fixes https://github.com/llvm/llvm-project/issues/101161.