### PR TITLE
[BOLT] Fix C2360 compiler error with MSVC in Relocation.cpp

### DIFF
--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -1070,7 +1070,7 @@ void Relocation::print(raw_ostream &OS) const {
     OS << "RType:" << Twine::utohexstr(Type);
     break;
 
-  case Triple::aarch64:
+  case Triple::aarch64: {
     static const char *const AArch64RelocNames[] = {
 #define ELF_RELOC(name, value) #name,
 #include "llvm/BinaryFormat/ELFRelocs/AArch64.def"
@@ -1079,6 +1079,7 @@ void Relocation::print(raw_ostream &OS) const {
     assert(Type < ArrayRef(AArch64RelocNames).size());
     OS << AArch64RelocNames[Type];
     break;
+  }
 
   case Triple::riscv64:
     // RISC-V relocations are not sequentially numbered so we cannot use an
@@ -1095,7 +1096,7 @@ void Relocation::print(raw_ostream &OS) const {
     }
     break;
 
-  case Triple::x86_64:
+  case Triple::x86_64: {
     static const char *const X86RelocNames[] = {
 #define ELF_RELOC(name, value) #name,
 #include "llvm/BinaryFormat/ELFRelocs/x86_64.def"
@@ -1104,6 +1105,7 @@ void Relocation::print(raw_ostream &OS) const {
     assert(Type < ArrayRef(X86RelocNames).size());
     OS << X86RelocNames[Type];
     break;
+  }
   }
   OS << ", 0x" << Twine::utohexstr(Offset);
   if (Symbol) {


### PR DESCRIPTION
Since 67e733d36ef0c5ec9fab899ecf9f191d83c7d418, `Relocation::print` has defined arrays for relocation names on X86 and AArch64 inside the switch cases. Since these arrays are static, this should be legal according to the spec. However, MSVC still emits an error when compiling these

The fix is to add brackets around the relevant case statements, the same as for if the declared variables were not static

---

There is a recently-opened issue on the Visual Studio feedback forums about this: https://developercommunity.visualstudio.com/t/C2360-and-C2361-should-not-apply-to-stat/10712105  But even if it does get fixed in an update to MSVC, existing versions would still run into this issue when compiling BOLT. The workaround seems small and unobtrusive enough