### PR TITLE
[sanitizer_common] Fix internal_*stat on Linux/sparc64

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -35,7 +35,7 @@
 // access stat from asm/stat.h, without conflicting with definition in
 // sys/stat.h, we use this trick.  sparc64 is similar, using
 // syscall(__NR_stat64) and struct kernel_stat64.
-#  if SANITIZER_MIPS64 || SANITIZER_SPARC64
+#  if SANITIZER_LINUX && (SANITIZER_MIPS64 || SANITIZER_SPARC64)
 #    include <asm/unistd.h>
 #    include <sys/types.h>
 #    define stat kernel_stat


### PR DESCRIPTION
Backport of fcd6bd5587cc376cd8f43b60d1c7d61fdfe0f535 and 16e9bb9cd7f50ae2ec7f29a80bc3b95f528bfdbf to `release/19.x` branch.