### PR TITLE
[flang][runtime] Don't emit excess digits for ES0.0E0 or EN0.0E0

### DIFF
--- a/flang/runtime/edit-output.cpp
+++ b/flang/runtime/edit-output.cpp
@@ -300,10 +300,12 @@ RT_API_ATTRS bool RealOutputEditing<KIND>::EditEorDOutput(
     flags |= decimal::AlwaysSign;
   }
   int scale{edit.modes.scale}; // 'kP' value
+  bool isEN{edit.variation == 'N'};
+  bool isES{edit.variation == 'S'};
   if (editWidth == 0) { // "the processor selects the field width"
     if (edit.digits.has_value()) { // E0.d
       if (editDigits == 0 && scale <= 0) { // E0.0
-        significantDigits = 1;
+        significantDigits = isEN || isES ? 0 : 1;
       }
     } else { // E0
       flags |= decimal::Minimize;
@@ -311,8 +313,6 @@ RT_API_ATTRS bool RealOutputEditing<KIND>::EditEorDOutput(
           sizeof buffer_ - 5; // sign, NUL, + 3 extra for EN scaling
     }
   }
-  bool isEN{edit.variation == 'N'};
-  bool isES{edit.variation == 'S'};
   int zeroesAfterPoint{0};
   if (isEN) {
     scale = IsZero() ? 1 : 3;

--- a/flang/unittests/Runtime/NumericalFormatTest.cpp
+++ b/flang/unittests/Runtime/NumericalFormatTest.cpp
@@ -753,6 +753,8 @@ TEST(IOApiTests, FormatDoubleValues) {
       {"(F5.0,';')", 0.49999999999999994, "   0.;"},
       {"(F5.0,';')", 0.5, "   0.;"},
       {"(F5.0,';')", 0.5000000000000001, "   1.;"},
+      {"(ES0.0E0,';')", 0.666, "7.E-1;"},
+      {"(EN0.0E0,';')", 0.666, "666.E-3;"},
   };
 
   for (auto const &[format, value, expect] : individualTestCases) {


### PR DESCRIPTION
Don't emit any digits after the decimal point.