### PR TITLE
[DirectX] Simplify DXIL_OP_INTRINSIC_MAP tablegen'ed code

### DIFF
--- a/llvm/lib/Target/DirectX/DXILConstants.h
+++ b/llvm/lib/Target/DirectX/DXILConstants.h
@@ -17,7 +17,6 @@ namespace dxil {
 
 #define DXIL_OP_ENUM
 #include "DXILOperation.inc"
-#undef DXIL_OP_ENUM
 
 } // namespace dxil
 } // namespace llvm

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -104,20 +104,19 @@ static void lowerIntrinsic(dxil::OpCode DXILOp, Function &F, Module &M) {
 static bool lowerIntrinsics(Module &M) {
   bool Updated = false;
 
-#define DXIL_OP_INTRINSIC_MAP
-#include "DXILOperation.inc"
-#undef DXIL_OP_INTRINSIC_MAP
-
   for (Function &F : make_early_inc_range(M.functions())) {
     if (!F.isDeclaration())
       continue;
     Intrinsic::ID ID = F.getIntrinsicID();
-    if (ID == Intrinsic::not_intrinsic)
+    switch (ID) {
+    default:
       continue;
-    auto LowerIt = LowerMap.find(ID);
-    if (LowerIt == LowerMap.end())
-      continue;
-    lowerIntrinsic(LowerIt->second, F, M);
+#define DXIL_OP_INTRINSIC(OpCode, Intrin)                                      \
+  case Intrin:                                                                 \
+    lowerIntrinsic(OpCode, F, M);                                              \
+    break;
+#include "DXILOperation.inc"
+    }
     Updated = true;
   }
   return Updated;

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -434,12 +434,7 @@ static std::string getAttributeMaskString(const SmallVector<Record *> Recs) {
 /// \param Output stream
 static void emitDXILEnums(std::vector<DXILOperationDesc> &Ops,
                           raw_ostream &OS) {
-  // Sort by OpCode
-  llvm::sort(Ops, [](DXILOperationDesc &A, DXILOperationDesc &B) {
-    return A.OpCode < B.OpCode;
-  });
-
-  OS << "#ifdef DXIL_OP_ENUM\n";
+  OS << "#ifdef DXIL_OP_ENUM\n\n";
   OS << "// Enumeration for operations specified by DXIL\n";
   OS << "enum class OpCode : unsigned {\n";
 
@@ -461,7 +456,8 @@ static void emitDXILEnums(std::vector<DXILOperationDesc> &Ops,
     OS << C << ",\n";
   }
   OS << "\n};\n\n";
-  OS << "#endif // DXIL_OP_ENUM\n";
+  OS << "#undef DXIL_OP_ENUM\n";
+  OS << "#endif\n\n";
 }
 
 /// Emit map of DXIL operation to LLVM or DirectX intrinsic
@@ -469,20 +465,17 @@ static void emitDXILEnums(std::vector<DXILOperationDesc> &Ops,
 /// \param Output stream
 static void emitDXILIntrinsicMap(std::vector<DXILOperationDesc> &Ops,
                                  raw_ostream &OS) {
-  OS << "\n#ifdef DXIL_OP_INTRINSIC_MAP\n";
-
-  // FIXME: use array instead of SmallDenseMap.
-  OS << "static const SmallDenseMap<Intrinsic::ID, dxil::OpCode> LowerMap = "
-        "{\n";
-  for (auto &Op : Ops) {
+  OS << "#ifdef DXIL_OP_INTRINSIC\n";
+  OS << "\n";
+  for (const auto &Op : Ops) {
     if (Op.Intrinsic.empty())
       continue;
-    // {Intrinsic::sin, dxil::OpCode::Sin},
-    OS << "  { Intrinsic::" << Op.Intrinsic << ", dxil::OpCode::" << Op.OpName
-       << "},\n";
+    OS << "DXIL_OP_INTRINSIC(dxil::OpCode::" << Op.OpName
+       << ", Intrinsic::" << Op.Intrinsic << ")\n";
   }
-  OS << "};\n\n";
-  OS << "#endif // DXIL_OP_INTRINSIC_MAP\n";
+  OS << "\n";
+  OS << "#undef DXIL_OP_INTRINSIC\n";
+  OS << "#endif\n\n";
 }
 
 /// Emit DXIL operation table
@@ -490,11 +483,6 @@ static void emitDXILIntrinsicMap(std::vector<DXILOperationDesc> &Ops,
 /// \param Output stream
 static void emitDXILOperationTable(std::vector<DXILOperationDesc> &Ops,
                                    raw_ostream &OS) {
-  // Sort by OpCode.
-  llvm::sort(Ops, [](DXILOperationDesc &A, DXILOperationDesc &B) {
-    return A.OpCode < B.OpCode;
-  });
-
   // Collect Names.
   SequenceToOffsetTable<std::string> OpClassStrings;
   SequenceToOffsetTable<std::string> OpStrings;
@@ -601,7 +589,7 @@ static void emitDXILOperationTable(std::vector<DXILOperationDesc> &Ops,
   OS << "  };\n\n";
   OS << "  unsigned Index = Prop.ParameterTableOffset;\n";
   OS << "  return DXILOpParameterKindTable + Index;\n";
-  OS << "}\n ";
+  OS << "}\n\n";
 }
 
 static void emitDXILOperationTableDataStructs(RecordKeeper &Records,
@@ -653,12 +641,18 @@ static void EmitDXILOperation(RecordKeeper &Records, raw_ostream &OS) {
   for (auto *Record : OpIntrProps) {
     DXILOps.emplace_back(DXILOperationDesc(Record));
   }
+  // Sort by opcode.
+  llvm::sort(DXILOps, [](DXILOperationDesc &A, DXILOperationDesc &B) {
+    return A.OpCode < B.OpCode;
+  });
+
   emitDXILEnums(DXILOps, OS);
   emitDXILIntrinsicMap(DXILOps, OS);
-  OS << "#ifdef DXIL_OP_OPERATION_TABLE\n";
+  OS << "#ifdef DXIL_OP_OPERATION_TABLE\n\n";
   emitDXILOperationTableDataStructs(Records, OS);
   emitDXILOperationTable(DXILOps, OS);
-  OS << "#endif // DXIL_OP_OPERATION_TABLE\n";
+  OS << "#undef DXIL_OP_OPERATION_TABLE\n";
+  OS << "#endif\n\n";
 }
 
 static TableGen::Emitter::Opt X("gen-dxil-operation", EmitDXILOperation,

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -645,6 +645,12 @@ static void EmitDXILOperation(RecordKeeper &Records, raw_ostream &OS) {
   llvm::sort(DXILOps, [](DXILOperationDesc &A, DXILOperationDesc &B) {
     return A.OpCode < B.OpCode;
   });
+  int PrevOp = -1;
+  for (DXILOperationDesc &Desc : DXILOps) {
+    if (Desc.OpCode == PrevOp)
+      PrintFatalError(Twine("Duplicate opcode: ") + Twine(Desc.OpCode));
+    PrevOp = Desc.OpCode;
+  }
 
   emitDXILEnums(DXILOps, OS);
   emitDXILIntrinsicMap(DXILOps, OS);


### PR DESCRIPTION
Rather than generate a map with a known name, just define the mapping
so the code that uses it can do what it needs.
