### PR TITLE
[clang-doc] add support for comments for members in HTML output

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -352,6 +352,8 @@ genHTML(const EnumInfo &I, const ClangDocContext &CDCtx);
 static std::vector<std::unique_ptr<TagNode>>
 genHTML(const FunctionInfo &I, const ClangDocContext &CDCtx,
         StringRef ParentInfoDir);
+static std::unique_ptr<TagNode>
+genHTML(const std::vector<CommentInfo> &C);
 
 static std::vector<std::unique_ptr<TagNode>>
 genEnumsBlock(const std::vector<EnumInfo> &Enums,
@@ -418,9 +420,13 @@ genRecordMembersBlock(const llvm::SmallVector<MemberTypeInfo, 4> &Members,
     if (Access != "")
       Access = Access + " ";
     auto LIBody = std::make_unique<TagNode>(HTMLTag::TAG_LI);
-    LIBody->Children.emplace_back(std::make_unique<TextNode>(Access));
-    LIBody->Children.emplace_back(genReference(M.Type, ParentInfoDir));
-    LIBody->Children.emplace_back(std::make_unique<TextNode>(" " + M.Name));
+    auto MemberDecl = std::make_unique<TagNode>(HTMLTag::TAG_DIV);
+    MemberDecl->Children.emplace_back(std::make_unique<TextNode>(Access));
+    MemberDecl->Children.emplace_back(genReference(M.Type, ParentInfoDir));
+    MemberDecl->Children.emplace_back(std::make_unique<TextNode>(" " + M.Name));
+    if (!M.Description.empty())
+      LIBody->Children.emplace_back(genHTML(M.Description));
+    LIBody->Children.emplace_back(std::move(MemberDecl));
     ULBody->Children.emplace_back(std::move(LIBody));
   }
   return Out;

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -352,8 +352,7 @@ genHTML(const EnumInfo &I, const ClangDocContext &CDCtx);
 static std::vector<std::unique_ptr<TagNode>>
 genHTML(const FunctionInfo &I, const ClangDocContext &CDCtx,
         StringRef ParentInfoDir);
-static std::unique_ptr<TagNode>
-genHTML(const std::vector<CommentInfo> &C);
+static std::unique_ptr<TagNode> genHTML(const std::vector<CommentInfo> &C);
 
 static std::vector<std::unique_ptr<TagNode>>
 genEnumsBlock(const std::vector<EnumInfo> &Enums,

--- a/clang-tools-extra/test/clang-doc/basic-project.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.test
@@ -94,8 +94,10 @@
 // HTML-RECTANGLE:   <a href="Shape.html">Shape</a>
 // HTML-RECTANGLE: </p>
 // HTML-RECTANGLE: <h2 id="Members">Members</h2>
-// HTML-RECTANGLE: <li>private double width_</li>
-// HTML-RECTANGLE: <li>private double height_</li>
+// HTML-RECTANGLE: <p> Width of the rectangle.</p>
+// HTML-RECTANGLE: <div>private double width_</div>
+// HTML-RECTANGLE: <p> Height of the rectangle.</p>
+// HTML-RECTANGLE: <div>private double height_</div>
 // HTML-RECTANGLE: <h2 id="Functions">Functions</h2>
 // HTML-RECTANGLE: <h3 id="{{([0-9A-F]{40})}}">Rectangle</h3>
 // HTML-RECTANGLE: <p>public void Rectangle(double width, double height)</p>
@@ -115,7 +117,8 @@
 // HTML-CIRCLE:   <a href="Shape.html">Shape</a>
 // HTML-CIRCLE: </p>
 // HTML-CIRCLE: <h2 id="Members">Members</h2>
-// HTML-CIRCLE: <li>private double radius_</li>
+// HTML-CIRCLE: <p> Radius of the circle.</p>
+// HTML-CIRCLE: <div>private double radius_</div>
 // HTML-CIRCLE: <h2 id="Functions">Functions</h2>
 // HTML-CIRCLE: <h3 id="{{([0-9A-F]{40})}}">Circle</h3>
 // HTML-CIRCLE: <p>public void Circle(double radius)</p>

--- a/clang-tools-extra/unittests/clang-doc/HTMLGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/HTMLGeneratorTest.cpp
@@ -197,7 +197,9 @@ TEST(HTMLGeneratorTest, emitRecordHTML) {
     </p>
     <h2 id="Members">Members</h2>
     <ul>
-      <li>private int X</li>
+      <li>
+        <div>private int X</div>
+      </li>
     </ul>
     <h2 id="Records">Records</h2>
     <ul>


### PR DESCRIPTION
currently the HTML output does not support comments attached to class members, this patch modifies the HTMLGenerator to add comments for the output.

