### PR TITLE
[SandboxIR] Implement AddrSpaceCastInst

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -28,9 +28,11 @@
 //                                      |
 //                                      +- BranchInst
 //                                      |
-//                                      +- CastInst -----------+- BitCastInst
-//                                      |                      |
-//                                      |                      +- PtrToIntInst
+//                                      +- CastInst --------+- AddrSpaceCastInst
+//                                      |                   |
+//                                      |                   +- BitCastInst
+//                                      |                   |
+//                                      |                   +- PtrToIntInst
 //                                      |
 //                                      +- CallBase -----------+- CallBrInst
 //                                      |                      |
@@ -1404,6 +1406,43 @@ public:
     if (auto *I = dyn_cast<Instruction>(From))
       return I->getOpcode() == Instruction::Opcode::BitCast;
     return false;
+  }
+#ifndef NDEBUG
+  void dump(raw_ostream &OS) const override;
+  LLVM_DUMP_METHOD void dump() const override;
+#endif
+};
+
+class AddrSpaceCastInst : public CastInst {
+public:
+  static Value *create(Value *Src, Type *DestTy, BBIterator WhereIt,
+                       BasicBlock *WhereBB, Context &Ctx,
+                       const Twine &Name = "");
+  static Value *create(Value *Src, Type *DestTy, Instruction *InsertBefore,
+                       Context &Ctx, const Twine &Name = "");
+  static Value *create(Value *Src, Type *DestTy, BasicBlock *InsertAtEnd,
+                       Context &Ctx, const Twine &Name = "");
+
+  static bool classof(const Value *From) {
+    if (auto *I = dyn_cast<Instruction>(From))
+      return I->getOpcode() == Opcode::AddrSpaceCast;
+    return false;
+  }
+  /// \Returns the pointer operand.
+  Value *getPointerOperand() { return getOperand(0); }
+  /// \Returns the pointer operand.
+  const Value *getPointerOperand() const {
+    return const_cast<AddrSpaceCastInst *>(this)->getPointerOperand();
+  }
+  /// \Returns the operand index of the pointer operand.
+  static unsigned getPointerOperandIndex() { return 0u; }
+  /// \Returns the address space of the pointer operand.
+  unsigned getSrcAddressSpace() const {
+    return getPointerOperand()->getType()->getPointerAddressSpace();
+  }
+  /// \Returns the address space of the result.
+  unsigned getDestAddressSpace() const {
+    return getType()->getPointerAddressSpace();
   }
 #ifndef NDEBUG
   void dump(raw_ostream &OS) const override;

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -1200,6 +1200,39 @@ void BitCastInst::dump() const {
   dump(dbgs());
   dbgs() << "\n";
 }
+#endif // NDEBUG
+
+Value *AddrSpaceCastInst::create(Value *Src, Type *DestTy, BBIterator WhereIt,
+                                 BasicBlock *WhereBB, Context &Ctx,
+                                 const Twine &Name) {
+  return CastInst::create(DestTy, Instruction::Opcode::AddrSpaceCast, Src,
+                          WhereIt, WhereBB, Ctx, Name);
+}
+
+Value *AddrSpaceCastInst::create(Value *Src, Type *DestTy,
+                                 Instruction *InsertBefore, Context &Ctx,
+                                 const Twine &Name) {
+  return CastInst::create(DestTy, Instruction::Opcode::AddrSpaceCast, Src,
+                          InsertBefore, Ctx, Name);
+}
+
+Value *AddrSpaceCastInst::create(Value *Src, Type *DestTy,
+                                 BasicBlock *InsertAtEnd, Context &Ctx,
+                                 const Twine &Name) {
+  return CastInst::create(DestTy, Instruction::Opcode::AddrSpaceCast, Src,
+                          InsertAtEnd, Ctx, Name);
+}
+
+#ifndef NDEBUG
+void AddrSpaceCastInst::dump(raw_ostream &OS) const {
+  dumpCommonPrefix(OS);
+  dumpCommonSuffix(OS);
+}
+
+void AddrSpaceCastInst::dump() const {
+  dump(dbgs());
+  dbgs() << "\n";
+}
 
 void OpaqueInst::dump(raw_ostream &OS) const {
   dumpCommonPrefix(OS);


### PR DESCRIPTION
This patch implements sandboxir::AddrSpaceCastInst which mirrors llvm::AddrSpaceCastInst.