### PR TITLE
[clang] Improve diagnostics with incompatible VLA types

### DIFF
--- a/clang/lib/AST/ASTDiagnostic.cpp
+++ b/clang/lib/AST/ASTDiagnostic.cpp
@@ -424,6 +424,27 @@ void clang::FormatASTNodeDiagnosticArgument(
       Val = TDT.PrintFromType ? TDT.FromType : TDT.ToType;
       Modifier = StringRef();
       Argument = StringRef();
+
+      if (FromType->isVariablyModifiedType() &&
+          ToType->isVariablyModifiedType() &&
+          ConvertTypeToDiagnosticString(Context, FromType, PrevArgs,
+                                        QualTypeVals) ==
+              ConvertTypeToDiagnosticString(Context, ToType, PrevArgs,
+                                            QualTypeVals)) {
+        assert(Modifier.empty() && Argument.empty() &&
+               "Invalid modifier for QualType argument");
+
+        QualType Ty(QualType::getFromOpaquePtr(reinterpret_cast<void *>(Val)));
+        OS << ConvertTypeToDiagnosticString(Context, Ty, PrevArgs,
+                                            QualTypeVals);
+        NeedQuotes = false;
+
+        if (!TDT.PrintFromType)
+          OS << "; VLA types differ despite using the same array size "
+                "expression";
+
+        break;
+      }
       // Fall through
       [[fallthrough]];
     }

--- a/clang/test/Sema/incompatible-vla-assignment.cpp
+++ b/clang/test/Sema/incompatible-vla-assignment.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+void func(int n) {
+    int grp[n][n];
+    int (*ptr)[n];
+
+    for (int i = 0; i < n; i++)
+        ptr = &grp[i]; // expected-error {{incompatible pointer types assigning to 'int (*)[n]' from 'int (*)[n]'; VLA types differ despite using the same array size expression}}
+}
+
+void func(int n, int (&array)[n]) {
+  int (&other)[n] = array; // expected-error {{non-const lvalue reference to type 'int[n]' cannot bind to a value of unrelated type 'int[n]'; VLA types differ despite using the same array size expression}}
+}


### PR DESCRIPTION
This PR addresses #99914, by emitting a separate diagnostic for VLA's with the same bounds.

@AaronBallman Let me know what you think.

Thanks