### PR TITLE
[x86][Windows] Fix chromium build break

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -2475,8 +2475,12 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
       (Subtarget.isTargetWindowsMSVC() || Subtarget.isTargetWindowsItanium()))
     // clang-format off
    for (ISD::NodeType Op :
-         {ISD::FCEIL,  ISD::STRICT_FCEIL,
+         {ISD::FACOS,  ISD::STRICT_FACOS,
+          ISD::FASIN,  ISD::STRICT_FASIN,
+          ISD::FATAN,  ISD::STRICT_FATAN,
+          ISD::FCEIL,  ISD::STRICT_FCEIL,
           ISD::FCOS,   ISD::STRICT_FCOS,
+          ISD::FCOSH,  ISD::STRICT_FCOSH,
           ISD::FEXP,   ISD::STRICT_FEXP,
           ISD::FFLOOR, ISD::STRICT_FFLOOR,
           ISD::FREM,   ISD::STRICT_FREM,
@@ -2484,7 +2488,9 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
           ISD::FLOG10, ISD::STRICT_FLOG10,
           ISD::FPOW,   ISD::STRICT_FPOW,
           ISD::FSIN,   ISD::STRICT_FSIN,
-          ISD::FTAN,   ISD::STRICT_FTAN})
+          ISD::FSINH,  ISD::STRICT_FSINH,
+          ISD::FTAN,   ISD::STRICT_FTAN,
+          ISD::FTANH,  ISD::STRICT_FTANH})
       if (isOperationExpand(Op, MVT::f32))
         setOperationAction(Op, MVT::f32, Promote);
   // clang-format on

--- a/llvm/test/CodeGen/X86/fp-strict-libcalls-msvc32.ll
+++ b/llvm/test/CodeGen/X86/fp-strict-libcalls-msvc32.ll
@@ -180,12 +180,15 @@ define float @tan(float %x) #0 {
 define float @acos(float %x) #0 {
 ; CHECK-LABEL: acos:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushl   %eax
+; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
-; CHECK-NEXT:    fstps (%esp)
+; CHECK-NEXT:    fstpl (%esp)
 ; CHECK-NEXT:    wait
-; CHECK-NEXT:    calll _acosf
-; CHECK-NEXT:    popl    %eax
+; CHECK-NEXT:    calll _acos
+; CHECK-NEXT:    fstps {{[0-9]+}}(%esp)
+; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
+; CHECK-NEXT:    wait
+; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
   %result = call float @llvm.experimental.constrained.acos.f32(float %x, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
   ret float %result
@@ -194,12 +197,15 @@ define float @acos(float %x) #0 {
 define float @asin(float %x) #0 {
 ; CHECK-LABEL: asin:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushl   %eax
+; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
-; CHECK-NEXT:    fstps (%esp)
+; CHECK-NEXT:    fstpl (%esp)
 ; CHECK-NEXT:    wait
-; CHECK-NEXT:    calll _asinf
-; CHECK-NEXT:    popl    %eax
+; CHECK-NEXT:    calll _asin
+; CHECK-NEXT:    fstps {{[0-9]+}}(%esp)
+; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
+; CHECK-NEXT:    wait
+; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
   %result = call float @llvm.experimental.constrained.asin.f32(float %x, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
   ret float %result
@@ -208,12 +214,15 @@ define float @asin(float %x) #0 {
 define float @atan(float %x) #0 {
 ; CHECK-LABEL: atan:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushl   %eax
+; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
-; CHECK-NEXT:    fstps (%esp)
+; CHECK-NEXT:    fstpl (%esp)
 ; CHECK-NEXT:    wait
-; CHECK-NEXT:    calll _atanf
-; CHECK-NEXT:    popl    %eax
+; CHECK-NEXT:    calll _atan
+; CHECK-NEXT:    fstps {{[0-9]+}}(%esp)
+; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
+; CHECK-NEXT:    wait
+; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
   %result = call float @llvm.experimental.constrained.atan.f32(float %x, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
   ret float %result
@@ -222,12 +231,15 @@ define float @atan(float %x) #0 {
 define float @cosh(float %x) #0 {
 ; CHECK-LABEL: cosh:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushl   %eax
+; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
-; CHECK-NEXT:    fstps (%esp)
+; CHECK-NEXT:    fstpl (%esp)
 ; CHECK-NEXT:    wait
-; CHECK-NEXT:    calll _coshf
-; CHECK-NEXT:    popl    %eax
+; CHECK-NEXT:    calll _cosh
+; CHECK-NEXT:    fstps {{[0-9]+}}(%esp)
+; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
+; CHECK-NEXT:    wait
+; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
   %result = call float @llvm.experimental.constrained.cosh.f32(float %x, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
   ret float %result
@@ -236,26 +248,31 @@ define float @cosh(float %x) #0 {
 define float @sinh(float %x) #0 {
 ; CHECK-LABEL: sinh:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushl   %eax
+; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
-; CHECK-NEXT:    fstps (%esp)
+; CHECK-NEXT:    fstpl (%esp)
 ; CHECK-NEXT:    wait
-; CHECK-NEXT:    calll _sinhf
-; CHECK-NEXT:    popl    %eax
+; CHECK-NEXT:    calll _sinh
+; CHECK-NEXT:    fstps {{[0-9]+}}(%esp)
+; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
+; CHECK-NEXT:    wait
+; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
   %result = call float @llvm.experimental.constrained.sinh.f32(float %x, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
   ret float %result
 }
 
 define float @tanh(float %x) #0 {
-; CHECK-LABEL: tanh:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushl   %eax
+; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
-; CHECK-NEXT:    fstps (%esp)
+; CHECK-NEXT:    fstpl (%esp)
 ; CHECK-NEXT:    wait
-; CHECK-NEXT:    calll _tanhf
-; CHECK-NEXT:    popl    %eax
+; CHECK-NEXT:    calll _tanh
+; CHECK-NEXT:    fstps {{[0-9]+}}(%esp)
+; CHECK-NEXT:    flds {{[0-9]+}}(%esp)
+; CHECK-NEXT:    wait
+; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
   %result = call float @llvm.experimental.constrained.tanh.f32(float %x, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
   ret float %result


### PR DESCRIPTION
Windows does not support float C89 math functions like:
- acosf
- asinf
- atanf
- coshf
- sinhf
- tanhf 
 All 6 are disabled in [TargetLibraryInfo.cpp:293](https://github.com/llvm/llvm-project/blob/39e192b379362e9e645427631c35450d55ed517d/llvm/lib/Analysis/TargetLibraryInfo.cpp#L293C4-L296C41)
These 6 libfuncs need to be type promoted.

This PR fixes the bug introduced by https://github.com/llvm/llvm-project/pull/98949