### PR TITLE
[C++20] [Modules] Always emit the inline builtins

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4022,6 +4022,11 @@ bool CodeGenModule::shouldEmitFunction(GlobalDecl GD) {
     return true;
 
   const auto *F = cast<FunctionDecl>(GD.getDecl());
+  // Inline builtins declaration must be emitted. They often are fortified
+  // functions.
+  if (F->isInlineBuiltinDeclaration())
+    return true;
+
   if (CodeGenOpts.OptimizationLevel == 0 && !F->hasAttr<AlwaysInlineAttr>())
     return false;
 
@@ -4066,11 +4071,6 @@ bool CodeGenModule::shouldEmitFunction(GlobalDecl GD) {
           return false;
     }
   }
-
-  // Inline builtins declaration must be emitted. They often are fortified
-  // functions.
-  if (F->isInlineBuiltinDeclaration())
-    return true;
 
   // PR9614. Avoid cases where the source code is lying to us. An available
   // externally function should have an equivalent function somewhere else,

--- a/clang/test/Modules/inline-builtins.cppm
+++ b/clang/test/Modules/inline-builtins.cppm
@@ -1,0 +1,36 @@
+// REQUIRES: !system-windows
+//
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: cd %t
+//
+// RUN: %clang_cc1 -std=c++20 -O3 %t/a.cppm -emit-module-interface -o %t/a.pcm
+// RUN: %clang_cc1 -std=c++20 -O3 %t/test.cc -fmodule-file=a=%t/a.pcm \
+// RUN:   -emit-llvm -o - | FileCheck %t/test.cc
+
+//--- memmove.h
+typedef long unsigned int size_t;
+extern "C" void *memmove (void *__dest, const void *__src, size_t __n)
+     throw () __attribute__ ((__nonnull__ (1, 2)));
+extern "C" __inline __attribute__ ((__always_inline__)) __attribute__ ((__gnu_inline__)) void *
+ memmove (void *__dest, const void *__src, size_t __len) throw ()
+{
+  return __builtin_memmove(__dest, __src, __len);
+}
+
+//--- a.cppm
+module;
+#include "memmove.h"
+export module a;
+export using ::memmove;
+
+//--- test.cc
+import a;
+
+void test() {
+  int a, b;
+  unsigned c = 0;
+  memmove(&a, &b, c);
+}
+
+// CHECK-NOT: memmove


### PR DESCRIPTION
See the attached test for the motivation example. If we're too greedy to not emit the definition for inline builtins, we may meet a middle end crash. And it should be good to emit inline builtins always.