### PR TITLE
[lldb] Updated lldb-server to spawn the child process and share socket

### DIFF
--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -565,16 +565,6 @@ int main_platform(int argc, char *argv[]) {
     printf("Connection established.\n");
 
     if (g_server) {
-      // Collect child zombie processes.
-#if !defined(_WIN32)
-      ::pid_t waitResult;
-      while ((waitResult = waitpid(-1, nullptr, WNOHANG)) > 0) {
-        // waitResult is the child pid
-        std::lock_guard<std::mutex> guard(gdbserver_portmap_mutex);
-        gdbserver_portmap.FreePortForProcess(waitResult);
-      }
-#endif
-      // After collecting zombie ports, get the next available
       std::optional<uint16_t> available_port;
       {
         std::lock_guard<std::mutex> guard(gdbserver_portmap_mutex);

--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -48,11 +48,11 @@ using namespace llvm;
 // option descriptors for getopt_long_only()
 
 #ifdef _WIN32
-typedef pipe_t fd_t;
-const fd_t kInvalidSharedFD = LLDB_INVALID_PIPE;
+typedef pipe_t shared_fd_t;
+const shared_fd_t kInvalidSharedFD = LLDB_INVALID_PIPE;
 #else
-typedef NativeSocket fd_t;
-const fd_t kInvalidSharedFD = Socket::kInvalidSocketValue;
+typedef NativeSocket shared_fd_t;
+const shared_fd_t kInvalidSharedFD = Socket::kInvalidSocketValue;
 #endif
 
 class SharedSocket {
@@ -82,7 +82,7 @@ public:
 #endif
   }
 
-  fd_t GetSendableFD() { return m_fd; }
+  shared_fd_t GetSendableFD() { return m_fd; }
 
   Status CompleteSending(lldb::pid_t child_pid) {
 #ifdef _WIN32
@@ -109,7 +109,7 @@ public:
     return Status();
   }
 
-  static Status GetNativeSocket(fd_t fd, NativeSocket &socket) {
+  static Status GetNativeSocket(shared_fd_t fd, NativeSocket &socket) {
 #ifdef _WIN32
     socket = Socket::kInvalidSocketValue;
     // Read WSAPROTOCOL_INFO from the parent process and create NativeSocket.
@@ -146,7 +146,7 @@ private:
   Pipe m_socket_pipe;
   NativeSocket m_socket;
 #endif
-  fd_t m_fd;
+  shared_fd_t m_fd;
 };
 
 static int g_debug = 0;
@@ -363,7 +363,7 @@ int main_platform(int argc, char *argv[]) {
   StringRef
       log_channels; // e.g. "lldb process threads:gdb-remote default:linux all"
 
-  fd_t fd = kInvalidSharedFD;
+  shared_fd_t fd = kInvalidSharedFD;
 
   int min_gdbserver_port = 0;
   int max_gdbserver_port = 0;
@@ -454,7 +454,7 @@ int main_platform(int argc, char *argv[]) {
         WithColor::error() << "invalid fd " << optarg << "\n";
         option_error = 6;
       } else
-        fd = (fd_t)_fd;
+        fd = (shared_fd_t)_fd;
     } break;
 
     case 'h': /* fall-through is intentional */


### PR DESCRIPTION
`lldb-server platform --server` works on Windows now w/o multithreading. The rest functionality remains unchanged.

Fixes #90923, fixes #56346.

This is the part 1 of the replacement of #100670.

In the part 2 I plan to switch `lldb-server gdbserver` to use `--fd` and listen a common gdb port for all gdbserver connections. Then we can remove gdb port mapping to fiх #97537.