### PR TITLE
[SandboxIR] Added setVolatile member function to LoadInst and StoreInst

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -777,7 +777,7 @@ public:
   /// Return true if this is a load from a volatile memory location.
   bool isVolatile() const { return cast<llvm::LoadInst>(Val)->isVolatile(); }
   /// Specify whether this is a volatile load or not.
-  void setVolatile(bool V) { return cast<llvm::LoadInst>(Val)->setVolatile(V); }
+  void setVolatile(bool V);
 
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);
@@ -828,9 +828,7 @@ public:
   /// Return true if this is a store from a volatile memory location.
   bool isVolatile() const { return cast<llvm::StoreInst>(Val)->isVolatile(); }
   /// Specify whether this is a volatile store or not.
-  void setVolatile(bool V) {
-    return cast<llvm::StoreInst>(Val)->setVolatile(V);
-  }
+  void setVolatile(bool V);
 
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -776,6 +776,8 @@ class LoadInst final : public Instruction {
 public:
   /// Return true if this is a load from a volatile memory location.
   bool isVolatile() const { return cast<llvm::LoadInst>(Val)->isVolatile(); }
+  /// Specify whether this is a volatile load or not.
+  void setVolatile(bool V) { return cast<llvm::LoadInst>(Val)->setVolatile(V); }
 
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);
@@ -825,6 +827,11 @@ class StoreInst final : public Instruction {
 public:
   /// Return true if this is a store from a volatile memory location.
   bool isVolatile() const { return cast<llvm::StoreInst>(Val)->isVolatile(); }
+  /// Specify whether this is a volatile store or not.
+  void setVolatile(bool V) {
+    return cast<llvm::StoreInst>(Val)->setVolatile(V);
+  }
+
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);
   }
@@ -1334,7 +1341,7 @@ class CastInst : public Instruction {
   /// constructor directly.
   CastInst(llvm::CastInst *CI, Context &Ctx)
       : Instruction(ClassID::Cast, getCastOpcode(CI->getOpcode()), CI, Ctx) {}
-  friend Context; // for SBCastInstruction()
+  friend Context;        // for SBCastInstruction()
   friend class PtrToInt; // For constructor.
   Use getOperandUseInternal(unsigned OpIdx, bool Verify) const final {
     return getOperandUseDefault(OpIdx, Verify);

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -828,7 +828,9 @@ public:
   /// Return true if this is a store from a volatile memory location.
   bool isVolatile() const { return cast<llvm::StoreInst>(Val)->isVolatile(); }
   /// Specify whether this is a volatile store or not.
-  void setVolatile(bool V) { return cast<llvm::StoreInst>(Val)->setVolatile(V); }
+  void setVolatile(bool V) {
+    return cast<llvm::StoreInst>(Val)->setVolatile(V);
+  }
 
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -828,9 +828,7 @@ public:
   /// Return true if this is a store from a volatile memory location.
   bool isVolatile() const { return cast<llvm::StoreInst>(Val)->isVolatile(); }
   /// Specify whether this is a volatile store or not.
-  void setVolatile(bool V) {
-    return cast<llvm::StoreInst>(Val)->setVolatile(V);
-  }
+  void setVolatile(bool V) { return cast<llvm::StoreInst>(Val)->setVolatile(V); }
 
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);

--- a/llvm/include/llvm/SandboxIR/Tracker.h
+++ b/llvm/include/llvm/SandboxIR/Tracker.h
@@ -213,6 +213,25 @@ public:
 #endif
 };
 
+class SetVolatile : public IRChangeBase {
+  Instruction *Inst;
+  bool WasVolatile;
+  /// This could either be StoreInst or LoadInst
+  PointerUnion<StoreInst *, LoadInst *> InstUnion;
+
+public:
+  SetVolatile(Instruction *I, bool WasVolatile, Tracker &Tracker);
+  void revert() final;
+  void accept() final {}
+#ifndef NDEBUG
+  void dump(raw_ostream &OS) const final {
+    dumpCommon(OS);
+    OS << "SetVolatile";
+  }
+  LLVM_DUMP_METHOD void dump() const final;
+#endif
+};
+
 class MoveInstr : public IRChangeBase {
   /// The instruction that moved.
   Instruction *MovedI;

--- a/llvm/include/llvm/SandboxIR/Tracker.h
+++ b/llvm/include/llvm/SandboxIR/Tracker.h
@@ -54,6 +54,8 @@ namespace llvm::sandboxir {
 
 class BasicBlock;
 class CallBrInst;
+class LoadInst;
+class StoreInst;
 class Instruction;
 class Tracker;
 
@@ -214,11 +216,10 @@ public:
 };
 
 class SetVolatile : public IRChangeBase {
-  /// This holds the properties of whether
-  /// LoadInst or StoreInst was volatile
+  /// This holds the properties of whether LoadInst or StoreInst was volatile
   bool WasVolatile;
   /// This could either be StoreInst or LoadInst
-  PointerUnion<StoreInst *, LoadInst *> InstUnion;
+  PointerUnion<StoreInst *, LoadInst *> StoreOrLoad;
 
 public:
   SetVolatile(Instruction *I, Tracker &Tracker);

--- a/llvm/include/llvm/SandboxIR/Tracker.h
+++ b/llvm/include/llvm/SandboxIR/Tracker.h
@@ -214,13 +214,14 @@ public:
 };
 
 class SetVolatile : public IRChangeBase {
-  Instruction *Inst;
+  /// This holds the properties of whether
+  /// LoadInst or StoreInst was volatile
   bool WasVolatile;
   /// This could either be StoreInst or LoadInst
   PointerUnion<StoreInst *, LoadInst *> InstUnion;
 
 public:
-  SetVolatile(Instruction *I, bool WasVolatile, Tracker &Tracker);
+  SetVolatile(Instruction *I, Tracker &Tracker);
   void revert() final;
   void accept() final {}
 #ifndef NDEBUG

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -613,8 +613,7 @@ void BranchInst::dump() const {
 void LoadInst::setVolatile(bool V) {
   auto &Tracker = Ctx.getTracker();
   if (Tracker.isTracking())
-    Tracker.track(
-        std::make_unique<SetVolatile>(cast<Instruction>(this), Tracker));
+    Tracker.track(std::make_unique<SetVolatile>(this, Tracker));
   cast<llvm::LoadInst>(Val)->setVolatile(V);
 }
 
@@ -676,8 +675,7 @@ void LoadInst::dump() const {
 void StoreInst::setVolatile(bool V) {
   auto &Tracker = Ctx.getTracker();
   if (Tracker.isTracking())
-    Tracker.track(
-        std::make_unique<SetVolatile>(cast<Instruction>(this), Tracker));
+    Tracker.track(std::make_unique<SetVolatile>(this, Tracker));
   cast<llvm::StoreInst>(Val)->setVolatile(V);
 }
 

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -610,6 +610,14 @@ void BranchInst::dump() const {
 }
 #endif // NDEBUG
 
+void LoadInst::setVolatile(bool V) {
+  auto &Tracker = Ctx.getTracker();
+  if (Tracker.isTracking())
+    Tracker.track(
+        std::make_unique<SetVolatile>(cast<Instruction>(this), Tracker));
+  cast<llvm::LoadInst>(Val)->setVolatile(V);
+}
+
 LoadInst *LoadInst::create(Type *Ty, Value *Ptr, MaybeAlign Align,
                            Instruction *InsertBefore, Context &Ctx,
                            const Twine &Name) {
@@ -664,6 +672,15 @@ void LoadInst::dump() const {
   dbgs() << "\n";
 }
 #endif // NDEBUG
+
+void StoreInst::setVolatile(bool V) {
+  auto &Tracker = Ctx.getTracker();
+  if (Tracker.isTracking())
+    Tracker.track(
+        std::make_unique<SetVolatile>(cast<Instruction>(this), Tracker));
+  cast<llvm::StoreInst>(Val)->setVolatile(V);
+}
+
 StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
                              Instruction *InsertBefore, Context &Ctx) {
   return create(V, Ptr, Align, InsertBefore, /*IsVolatile=*/false, Ctx);

--- a/llvm/lib/SandboxIR/Tracker.cpp
+++ b/llvm/lib/SandboxIR/Tracker.cpp
@@ -178,6 +178,8 @@ void SetVolatile::revert() {
     Load->setVolatile(WasVolatile);
   } else if (auto *Store = StoreOrLoad.dyn_cast<StoreInst *>()) {
     Store->setVolatile(WasVolatile);
+  } else {
+    llvm_unreachable("Expected LoadInst or StoreInst");
   }
 }
 #ifndef NDEBUG

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -753,6 +753,7 @@ define void @foo(ptr %arg0, ptr %arg1) {
   auto *Ld = cast<sandboxir::LoadInst>(&*It++);
   auto *VLd = cast<sandboxir::LoadInst>(&*It++);
   auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
+  bool OrigVolatileValue;
 
   // Check isVolatile()
   EXPECT_FALSE(Ld->isVolatile());
@@ -767,7 +768,10 @@ define void @foo(ptr %arg0, ptr %arg1) {
       sandboxir::LoadInst::create(Ld->getType(), Arg1, Align(8),
                                   /*InsertBefore=*/Ret, Ctx, "NewLd");
   EXPECT_FALSE(NewLd->isVolatile());
+  OrigVolatileValue = NewLd->isVolatile();
+  NewLd->setVolatile(true);
   EXPECT_EQ(NewLd->getType(), Ld->getType());
+  NewLd->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewLd->getPointerOperand(), Arg1);
   EXPECT_EQ(NewLd->getAlign(), 8);
   EXPECT_EQ(NewLd->getName(), "NewLd");
@@ -778,12 +782,20 @@ define void @foo(ptr %arg0, ptr %arg1) {
                                   /*IsVolatile=*/true, Ctx, "NewVLd");
 
   EXPECT_TRUE(NewVLd->isVolatile());
+  OrigVolatileValue = NewVLd->isVolatile();
+  NewVLd->setVolatile(false);
+  EXPECT_FALSE(NewVLd->isVolatile());
+  NewVLd->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewVLd->getName(), "NewVLd");
   // Check create(InsertAtEnd)
   sandboxir::LoadInst *NewLdEnd =
       sandboxir::LoadInst::create(Ld->getType(), Arg1, Align(8),
                                   /*InsertAtEnd=*/BB, Ctx, "NewLdEnd");
   EXPECT_FALSE(NewLdEnd->isVolatile());
+  OrigVolatileValue = NewLdEnd->isVolatile();
+  NewLdEnd->setVolatile(true);
+  EXPECT_TRUE(NewLdEnd->isVolatile());
+  NewLdEnd->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewLdEnd->getName(), "NewLdEnd");
   EXPECT_EQ(NewLdEnd->getType(), Ld->getType());
   EXPECT_EQ(NewLdEnd->getPointerOperand(), Arg1);
@@ -796,6 +808,10 @@ define void @foo(ptr %arg0, ptr %arg1) {
                                   /*InsertAtEnd=*/BB,
                                   /*IsVolatile=*/true, Ctx, "NewVLdEnd");
   EXPECT_TRUE(NewVLdEnd->isVolatile());
+  OrigVolatileValue = NewVLdEnd->isVolatile();
+  NewVLdEnd->setVolatile(false);
+  EXPECT_FALSE(NewVLdEnd->isVolatile());
+  NewVLdEnd->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewVLdEnd->getName(), "NewVLdEnd");
   EXPECT_EQ(NewVLdEnd->getType(), VLd->getType());
   EXPECT_EQ(NewVLdEnd->getPointerOperand(), Arg1);
@@ -822,6 +838,7 @@ define void @foo(i8 %val, ptr %ptr) {
   auto *St = cast<sandboxir::StoreInst>(&*It++);
   auto *VSt = cast<sandboxir::StoreInst>(&*It++);
   auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
+  bool OrigVolatileValue;
 
   // Check that the StoreInst has been created correctly.
   EXPECT_FALSE(St->isVolatile());
@@ -836,6 +853,10 @@ define void @foo(i8 %val, ptr %ptr) {
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertBefore=*/Ret, Ctx);
   EXPECT_FALSE(NewSt->isVolatile());
+  OrigVolatileValue = NewSt->isVolatile();
+  NewSt->setVolatile(true);
+  EXPECT_TRUE(NewSt->isVolatile());
+  NewSt->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewSt->getType(), St->getType());
   EXPECT_EQ(NewSt->getValueOperand(), Val);
   EXPECT_EQ(NewSt->getPointerOperand(), Ptr);
@@ -847,6 +868,10 @@ define void @foo(i8 %val, ptr %ptr) {
                                    /*InsertBefore=*/Ret,
                                    /*IsVolatile=*/true, Ctx);
   EXPECT_TRUE(NewVSt->isVolatile());
+  OrigVolatileValue = NewVSt->isVolatile();
+  NewVSt->setVolatile(false);
+  EXPECT_FALSE(NewVSt->isVolatile());
+  NewVSt->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewVSt->getType(), VSt->getType());
   EXPECT_EQ(NewVSt->getValueOperand(), Val);
   EXPECT_EQ(NewVSt->getPointerOperand(), Ptr);
@@ -857,6 +882,10 @@ define void @foo(i8 %val, ptr %ptr) {
       sandboxir::StoreInst::create(Val, Ptr, Align(8),
                                    /*InsertAtEnd=*/BB, Ctx);
   EXPECT_FALSE(NewStEnd->isVolatile());
+  OrigVolatileValue = NewStEnd->isVolatile();
+  NewStEnd->setVolatile(true);
+  EXPECT_TRUE(NewStEnd->isVolatile());
+  NewStEnd->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewStEnd->getType(), St->getType());
   EXPECT_EQ(NewStEnd->getValueOperand(), Val);
   EXPECT_EQ(NewStEnd->getPointerOperand(), Ptr);
@@ -869,6 +898,10 @@ define void @foo(i8 %val, ptr %ptr) {
                                    /*InsertAtEnd=*/BB,
                                    /*IsVolatile=*/true, Ctx);
   EXPECT_TRUE(NewVStEnd->isVolatile());
+  OrigVolatileValue = NewVStEnd->isVolatile();
+  NewVStEnd->setVolatile(false);
+  EXPECT_FALSE(NewVStEnd->isVolatile());
+  NewVStEnd->setVolatile(OrigVolatileValue);
   EXPECT_EQ(NewVStEnd->getType(), VSt->getType());
   EXPECT_EQ(NewVStEnd->getValueOperand(), Val);
   EXPECT_EQ(NewVStEnd->getPointerOperand(), Ptr);

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -597,25 +597,22 @@ define void @foo(ptr %arg0, i8 %val) {
   sandboxir::Context Ctx(C);
 
   auto *F = Ctx.createFunction(&LLVMF);
-  unsigned ArgIdx = 0;
-  [[maybe_unused]] auto *Arg0 = F->getArg(ArgIdx++);
-  [[maybe_unused]] auto *Val = F->getArg(ArgIdx++);
   auto *BB = &*F->begin();
   auto It = BB->begin();
   auto *Load = cast<sandboxir::LoadInst>(&*It++);
   auto *Store = cast<sandboxir::StoreInst>(&*It++);
-  [[maybe_unused]] auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
 
   EXPECT_FALSE(Load->isVolatile());
   EXPECT_FALSE(Store->isVolatile());
-  // Check setVolatile()
   Ctx.save();
   Load->setVolatile(true);
   EXPECT_TRUE(Load->isVolatile());
   Ctx.revert();
+  EXPECT_FALSE(Load->isVolatile());
 
   Ctx.save();
   Store->setVolatile(true);
   EXPECT_TRUE(Store->isVolatile());
   Ctx.revert();
+  EXPECT_FALSE(Store->isVolatile());
 }

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -606,16 +606,16 @@ define void @foo(ptr %arg0, i8 %val) {
   auto *Store = cast<sandboxir::StoreInst>(&*It++);
   [[maybe_unused]] auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
 
+  EXPECT_FALSE(Load->isVolatile());
+  EXPECT_FALSE(Store->isVolatile());
   // Check setVolatile()
   Ctx.save();
   Load->setVolatile(true);
   EXPECT_TRUE(Load->isVolatile());
-  Load->setVolatile(false);
-  EXPECT_FALSE(Load->isVolatile());
+  Ctx.revert();
 
   Ctx.save();
   Store->setVolatile(true);
   EXPECT_TRUE(Store->isVolatile());
-  Store->setVolatile(false);
-  EXPECT_FALSE(Store->isVolatile());
+  Ctx.revert();
 }


### PR DESCRIPTION
This patch include the implementation of setVolatile() for the LoadInst and StoreInst. Along with test cases.

cc: @vporpo  