### PR TITLE
Delete assignment operator from `MachineBlockFrequencyInfo`

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
@@ -41,6 +41,8 @@ public:
                                      MachineBranchProbabilityInfo &MBPI,
                                      MachineLoopInfo &MLI);
   MachineBlockFrequencyInfo(MachineBlockFrequencyInfo &&);
+  MachineBlockFrequencyInfo &
+  operator=(const MachineBlockFrequencyInfo &) = delete;
   ~MachineBlockFrequencyInfo();
 
   /// Handle invalidation explicitly.


### PR DESCRIPTION
Since the `MachineBlockFrequencyInfo` class has an overloaded copy constructor, the assignment operator should be deleted to prevent undefined behaviour