### PR TITLE
[Object] Refine isData/isBSS criteria

### DIFF
--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -949,15 +949,15 @@ bool ELFObjectFile<ELFT>::isSectionText(DataRefImpl Sec) const {
 template <class ELFT>
 bool ELFObjectFile<ELFT>::isSectionData(DataRefImpl Sec) const {
   const Elf_Shdr *EShdr = getSection(Sec);
-  return EShdr->sh_type == ELF::SHT_PROGBITS &&
-         EShdr->sh_flags & ELF::SHF_ALLOC &&
-         !(EShdr->sh_flags & ELF::SHF_EXECINSTR);
+  return (EShdr->sh_flags & ELF::SHF_ALLOC) &&
+         !(EShdr->sh_flags & ELF::SHF_EXECINSTR) &&
+         EShdr->sh_type != ELF::SHT_NOBITS;
 }
 
 template <class ELFT>
 bool ELFObjectFile<ELFT>::isSectionBSS(DataRefImpl Sec) const {
   const Elf_Shdr *EShdr = getSection(Sec);
-  return EShdr->sh_flags & (ELF::SHF_ALLOC | ELF::SHF_WRITE) &&
+  return EShdr->sh_flags & ELF::SHF_ALLOC &&
          EShdr->sh_type == ELF::SHT_NOBITS;
 }
 

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -957,8 +957,7 @@ bool ELFObjectFile<ELFT>::isSectionData(DataRefImpl Sec) const {
 template <class ELFT>
 bool ELFObjectFile<ELFT>::isSectionBSS(DataRefImpl Sec) const {
   const Elf_Shdr *EShdr = getSection(Sec);
-  return EShdr->sh_flags & ELF::SHF_ALLOC &&
-         EShdr->sh_type == ELF::SHT_NOBITS;
+  return EShdr->sh_flags & ELF::SHF_ALLOC && EShdr->sh_type == ELF::SHT_NOBITS;
 }
 
 template <class ELFT>

--- a/llvm/test/tools/llvm-nm/data.test
+++ b/llvm/test/tools/llvm-nm/data.test
@@ -2,7 +2,9 @@
 # RUN: llvm-nm --no-sort %t | FileCheck %s
 
 # CHECK:      b mybss_local
+# CHECK-NEXT: b mybss2_local
 # CHECK-NEXT: d mydata_local
+# CHECK-NEXT: d mydata2_local
 # CHECK-NEXT: d mytdata_local
 # CHECK-NEXT: B mybss_global
 # CHECK-NEXT: D mydata_global
@@ -18,8 +20,14 @@ Sections:
   - Name: mybss
     Type: SHT_NOBITS
     Flags: [ SHF_ALLOC, SHF_WRITE ]
+  - Name: mybss2
+    Type: SHT_NOBITS
+    Flags: [ SHF_ALLOC ]
   - Name: mydata
     Type: SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_WRITE ]
+  - Name: mydata2
+    Type: 0x1000
     Flags: [ SHF_ALLOC, SHF_WRITE ]
   - Name: mytdata
     Type: SHT_PROGBITS
@@ -27,8 +35,12 @@ Sections:
 Symbols:
   - Name:    mybss_local
     Section: mybss
+  - Name:    mybss2_local
+    Section: mybss2
   - Name:    mydata_local
     Section: mydata
+  - Name:    mydata2_local
+    Section: mydata2
   - Name:    mytdata_local
     Section: mytdata
 

--- a/llvm/test/tools/llvm-nm/readonly.test
+++ b/llvm/test/tools/llvm-nm/readonly.test
@@ -4,9 +4,11 @@
 # CHECK:      r myrodata0_local
 # CHECK-NEXT: r myrodata1_local
 # CHECK-NEXT: r myrodata2_local
+# CHECK-NEXT: r myrodata3_local
 # CHECK-NEXT: R myrodata0_global
 # CHECK-NEXT: R myrodata1_global
 # CHECK-NEXT: R myrodata2_global
+# CHECK-NEXT: R myrodata3_global
 
 !ELF
 FileHeader:
@@ -24,6 +26,9 @@ Sections:
   - Name: myrodata2
     Type: SHT_PROGBITS
     Flags: [ SHF_ALLOC, SHF_MERGE, SHF_STRINGS ]
+  - Name: myrodata3
+    Type: 0x1000
+    Flags: [ SHF_ALLOC ]
 Symbols:
   - Name:    myrodata0_local
     Section: myrodata0
@@ -31,6 +36,8 @@ Symbols:
     Section: myrodata1
   - Name:    myrodata2_local
     Section: myrodata2
+  - Name:    myrodata3_local
+    Section: myrodata3
 
   - Name:    myrodata0_global
     Binding: STB_GLOBAL
@@ -41,3 +48,6 @@ Symbols:
   - Name:    myrodata2_global
     Binding: STB_GLOBAL
     Section: myrodata2
+  - Name:    myrodata3_global
+    Binding: STB_GLOBAL
+    Section: myrodata3

--- a/llvm/test/tools/llvm-objdump/section-headers.test
+++ b/llvm/test/tools/llvm-objdump/section-headers.test
@@ -17,6 +17,9 @@
 # WHITESPACE-NEXT: {{^}}  4 .other        00000000 0000000000000000 0000000000000000 {{$}}
 # WHITESPACE-NEXT: {{^}}  5 .debug_abbrev 00000000 0000000000000000 0000000000000000 DEBUG{{$}}
 # WHITESPACE-NEXT: {{^}}  6 .debug_info   00000000 0000000000000000 0000000000000000 DATA, DEBUG{{$}}
+# WHITESPACE-NEXT: {{^}}  7 .mydata       00000000 0000000000000000 0000000000000000 DATA{{$}}
+# WHITESPACE-NEXT: {{^}}  8 .bss1         00000000 0000000000000000 0000000000000000 BSS{{$}}
+# WHITESPACE-NEXT: {{^}}  9 .nonalloc.bss 00000000 0000000000000000 0000000000000000 {{$}}
 
 # WHITESPACE-NO-LMA:      {{^}}Sections:{{$}}
 # WHITESPACE-NO-LMA-NEXT: {{^}}Idx Name          Size     VMA              Type{{$}}
@@ -27,6 +30,9 @@
 # WHITESPACE-NO-LMA-NEXT: {{^}}  4 .other        00000000 0000000000000000 {{$}}
 # WHITESPACE-NO-LMA-NEXT: {{^}}  5 .debug_abbrev 00000000 0000000000000000 DEBUG{{$}}
 # WHITESPACE-NO-LMA-NEXT: {{^}}  6 .debug_info   00000000 0000000000000000 DATA, DEBUG{{$}}
+# WHITESPACE-NO-LMA-NEXT: {{^}}  7 .mydata       00000000 0000000000000000 DATA{{$}}
+# WHITESPACE-NO-LMA-NEXT: {{^}}  8 .bss1         00000000 0000000000000000 BSS{{$}}
+# WHITESPACE-NO-LMA-NEXT: {{^}}  9 .nonalloc.bss 00000000 0000000000000000 {{$}}
 
 --- !ELF
 FileHeader:
@@ -51,6 +57,14 @@ Sections:
   - Name:  .debug_info
     Type:  SHT_PROGBITS
     Flags: [ SHF_WRITE, SHF_ALLOC ]
+  - Name:  .mydata
+    Type:  0x70000000
+    Flags: [ SHF_ALLOC ]
+  - Name:  .bss1
+    Type:  SHT_NOBITS
+    Flags: [SHF_ALLOC]
+  - Name:  .nonalloc.bss
+    Type:  SHT_NOBITS
  
 ## Check that --section-headers and --headers are aliases for -h.
 # RUN: llvm-objdump --section-headers --show-lma %t-whitespace.o \


### PR DESCRIPTION
In GNU, DATA applies to not only SHT_PROGBITS, but also other non-NOBITS
types. BSS doesn't require the SHF_WRITE flag.
