### PR TITLE
Simplify hot-path size computations in BumpPtrAllocator.

### DIFF
--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -158,7 +158,8 @@ public:
 #endif
 
     uintptr_t AllocEndPtr = AlignedPtr + SizeToAllocate;
-    assert(AllocEndPtr >= uintptr_t(CurPtr) && "Alignment + Size must not overflow");
+    assert(AllocEndPtr >= uintptr_t(CurPtr) &&
+           "Alignment + Size must not overflow");
 
     // Check if we have enough space.
     if (LLVM_LIKELY(AllocEndPtr <= uintptr_t(End)


### PR DESCRIPTION
~0.1% instruction count improvements

https://llvm-compile-time-tracker.com/compare.php?from=07d2709a17860a202d91781769a88837e4fb5f2a&to=d5cc47831ecd9f0a2b164b16da67f74b94e9aafc&stat=instructions:u