### PR TITLE
[mlir][Transforms] Preserve all analysis in print passes

### DIFF
--- a/mlir/lib/Transforms/OpStats.cpp
+++ b/mlir/lib/Transforms/OpStats.cpp
@@ -55,6 +55,7 @@ void PrintOpStatsPass::runOnOperation() {
     printSummaryInJSON();
   } else
     printSummary();
+  markAllAnalysesPreserved();
 }
 
 void PrintOpStatsPass::printSummary() {

--- a/mlir/lib/Transforms/PrintIR.cpp
+++ b/mlir/lib/Transforms/PrintIR.cpp
@@ -25,6 +25,7 @@ struct PrintIRPass : public impl::PrintIRPassBase<PrintIRPass> {
       llvm::dbgs() << " " << this->label;
     llvm::dbgs() << " //----- //\n";
     getOperation()->dump();
+    markAllAnalysesPreserved();
   }
 };
 

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -93,6 +93,7 @@ public:
       processOperation(getOperation());
       emitAllEdgeStmts();
     });
+    markAllAnalysesPreserved();
   }
 
   /// Create a CFG graph for a region. Used in `Region::viewGraph`.


### PR DESCRIPTION
PrintIRPass, PrintOpStatsPass and PrintOpGraphPass don't mutate IR so preserve all analysis to save computation resource a bit.