### PR TITLE
[RISCV] Add Syntacore SCR4 RV32/64 processors definition

### DIFF
--- a/clang/test/Driver/riscv-cpus.c
+++ b/clang/test/Driver/riscv-cpus.c
@@ -381,3 +381,30 @@
 
 // RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=syntacore-scr3-rv64 | FileCheck -check-prefix=MTUNE-SYNTACORE-SCR3-RV64 %s
 // MTUNE-SYNTACORE-SCR3-RV64: "-tune-cpu" "syntacore-scr3-rv64"
+
+// RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=syntacore-scr4-rv32 | FileCheck -check-prefix=MCPU-SYNTACORE-SCR4-RV32 %s
+// MCPU-SYNTACORE-SCR4-RV32: "-target-cpu" "syntacore-scr4-rv32"
+// MCPU-SYNTACORE-SCR4-RV32-SAME: "-target-feature" "+m"
+// MCPU-SYNTACORE-SCR4-RV32-SAME: "-target-feature" "+f"
+// MCPU-SYNTACORE-SCR4-RV32-SAME: "-target-feature" "+d"
+// MCPU-SYNTACORE-SCR4-RV32-SAME: "-target-feature" "+c"
+// MCPU-SYNTACORE-SCR4-RV32-SAME: "-target-feature" "+zicsr"
+// MCPU-SYNTACORE-SCR4-RV32-SAME: "-target-feature" "+zifencei"
+// MCPU-SYNTACORE-SCR4-RV32-SAME: "-target-abi" "ilp32d"
+
+// RUN: %clang --target=riscv32 -### -c %s 2>&1 -mtune=syntacore-scr4-rv32 | FileCheck -check-prefix=MTUNE-SYNTACORE-SCR4-RV32 %s
+// MTUNE-SYNTACORE-SCR4-RV32: "-tune-cpu" "syntacore-scr4-rv32"
+
+// RUN: %clang --target=riscv64 -### -c %s 2>&1 -mcpu=syntacore-scr4-rv64 | FileCheck -check-prefix=MCPU-SYNTACORE-SCR4-RV64 %s
+// MCPU-SYNTACORE-SCR4-RV64: "-target-cpu" "syntacore-scr4-rv64"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-feature" "+m"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-feature" "+a"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-feature" "+f"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-feature" "+d"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-feature" "+c"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-feature" "+zicsr"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-feature" "+zifencei"
+// MCPU-SYNTACORE-SCR4-RV64-SAME: "-target-abi" "lp64d"
+
+// RUN: %clang --target=riscv64 -### -c %s 2>&1 -mtune=syntacore-scr4-rv64 | FileCheck -check-prefix=MTUNE-SYNTACORE-SCR4-RV64 %s
+// MTUNE-SYNTACORE-SCR4-RV64: "-tune-cpu" "syntacore-scr4-rv64"

--- a/clang/test/Misc/target-invalid-cpu-note.c
+++ b/clang/test/Misc/target-invalid-cpu-note.c
@@ -81,16 +81,16 @@
 
 // RUN: not %clang_cc1 -triple riscv32 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV32
 // RISCV32: error: unknown target CPU 'not-a-cpu'
-// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32{{$}}
+// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32, syntacore-scr4-rv32{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV64
 // RISCV64: error: unknown target CPU 'not-a-cpu'
-// RISCV64-NEXT: note: valid target CPU values are: generic-rv64, rocket-rv64, sifive-p450, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, veyron-v1, xiangshan-nanhu{{$}}
+// RISCV64-NEXT: note: valid target CPU values are: generic-rv64, rocket-rv64, sifive-p450, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, syntacore-scr4-rv64, veyron-v1, xiangshan-nanhu{{$}}
 
 // RUN: not %clang_cc1 -triple riscv32 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV32
 // TUNE-RISCV32: error: unknown target CPU 'not-a-cpu'
-// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32, generic, rocket, sifive-7-series{{$}}
+// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32, syntacore-scr4-rv32, generic, rocket, sifive-7-series{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV64
 // TUNE-RISCV64: error: unknown target CPU 'not-a-cpu'
-// TUNE-RISCV64-NEXT: note: valid target CPU values are: generic-rv64, rocket-rv64, sifive-p450, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, veyron-v1, xiangshan-nanhu, generic, rocket, sifive-7-series{{$}}
+// TUNE-RISCV64-NEXT: note: valid target CPU values are: generic-rv64, rocket-rv64, sifive-p450, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, syntacore-scr4-rv64, veyron-v1, xiangshan-nanhu, generic, rocket, sifive-7-series{{$}}

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -106,6 +106,7 @@ Changes to the RISC-V Backend
 * `.balign N, 0`, `.p2align N, 0`, `.align N, 0` in code sections will now fill
   the required alignment space with a sequence of `0x0` bytes (the requested
   fill value) rather than NOPs.
+* Added Syntacore SCR4 CPUs: ``-mcpu=syntacore-scr4-rv32/64``
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -350,6 +350,31 @@ def SYNTACORE_SCR3_RV64 : RISCVProcessorModel<"syntacore-scr3-rv64",
                                                FeatureStdExtC],
                                               [TuneNoDefaultUnroll, FeaturePostRAScheduler]>;
 
+def SYNTACORE_SCR4_RV32 : RISCVProcessorModel<"syntacore-scr4-rv32",
+                                              NoSchedModel,
+                                              [Feature32Bit,
+                                               FeatureStdExtI,
+                                               FeatureStdExtZicsr,
+                                               FeatureStdExtZifencei,
+                                               FeatureStdExtM,
+                                               FeatureStdExtF,
+                                               FeatureStdExtD,
+                                               FeatureStdExtC],
+                                              [TuneNoDefaultUnroll, FeaturePostRAScheduler]>;
+
+def SYNTACORE_SCR4_RV64 : RISCVProcessorModel<"syntacore-scr4-rv64",
+                                              NoSchedModel,
+                                              [Feature64Bit,
+                                               FeatureStdExtI,
+                                               FeatureStdExtZicsr,
+                                               FeatureStdExtZifencei,
+                                               FeatureStdExtM,
+                                               FeatureStdExtA,
+                                               FeatureStdExtF,
+                                               FeatureStdExtD,
+                                               FeatureStdExtC],
+                                              [TuneNoDefaultUnroll, FeaturePostRAScheduler]>;
+
 def VENTANA_VEYRON_V1 : RISCVProcessorModel<"veyron-v1",
                                             NoSchedModel,
                                             [Feature64Bit,


### PR DESCRIPTION
Syntacore SCR4 is a microcontroller-class processor core that has much in common with SCR3. The most significant difference for compilers is F and D extensions support. Overview: https://syntacore.com/products/scr4

Two CPUs are added:
  * 'syntacore-scr4-rv32' -- rv32imfdc
  * 'syntacore-scr4-rv64' -- rv64imafdc

Scheduling model will be added in a separate PR.
