### PR TITLE
[AIX] Turn on `#pragma mc_func` check by default

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8098,7 +8098,7 @@ def source_date_epoch : Separate<["-"], "source-date-epoch">,
 
 defm err_pragma_mc_func_aix : BoolFOption<"err-pragma-mc-func-aix",
   PreprocessorOpts<"ErrorOnPragmaMcfuncOnAIX">, DefaultTrue,
-  PosFlag<SetTrue, [], [ClangOption, CC1Option],
+  PosFlag<SetTrue, [], [ClangOption],
           "Treat uses of #pragma mc_func as errors">,
   NegFlag<SetFalse,[], [ClangOption, CC1Option],
           "Ignore uses of #pragma mc_func">>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8097,7 +8097,7 @@ def source_date_epoch : Separate<["-"], "source-date-epoch">,
 } // let Visibility = [CC1Option]
 
 defm err_pragma_mc_func_aix : BoolFOption<"err-pragma-mc-func-aix",
-  PreprocessorOpts<"ErrorOnPragmaMcfuncOnAIX">, DefaultFalse,
+  PreprocessorOpts<"ErrorOnPragmaMcfuncOnAIX">, DefaultTrue,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],
           "Treat uses of #pragma mc_func as errors">,
   NegFlag<SetFalse,[], [ClangOption, CC1Option],

--- a/clang/include/clang/Lex/PreprocessorOptions.h
+++ b/clang/include/clang/Lex/PreprocessorOptions.h
@@ -213,7 +213,7 @@ public:
 
   /// If set, the preprocessor reports an error when processing #pragma mc_func
   /// on AIX.
-  bool ErrorOnPragmaMcfuncOnAIX = false;
+  bool ErrorOnPragmaMcfuncOnAIX = true;
 
 public:
   PreprocessorOptions() : PrecompiledPreambleBytes(0, false) {}
@@ -252,7 +252,7 @@ public:
     PrecompiledPreambleBytes.first = 0;
     PrecompiledPreambleBytes.second = false;
     RetainExcludedConditionalBlocks = false;
-    ErrorOnPragmaMcfuncOnAIX = false;
+    ErrorOnPragmaMcfuncOnAIX = true;
   }
 };
 

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -562,7 +562,7 @@ void AIX::addClangTargetOptions(
     CC1Args.push_back("-fno-sized-deallocation");
 
   if (Args.hasFlag(options::OPT_ferr_pragma_mc_func_aix,
-                   options::OPT_fno_err_pragma_mc_func_aix, false))
+                   options::OPT_fno_err_pragma_mc_func_aix, true))
     CC1Args.push_back("-ferr-pragma-mc-func-aix");
   else
     CC1Args.push_back("-fno-err-pragma-mc-func-aix");

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -561,10 +561,8 @@ void AIX::addClangTargetOptions(
                               options::OPT_fno_sized_deallocation))
     CC1Args.push_back("-fno-sized-deallocation");
 
-  if (Args.hasFlag(options::OPT_ferr_pragma_mc_func_aix,
-                   options::OPT_fno_err_pragma_mc_func_aix, true))
-    CC1Args.push_back("-ferr-pragma-mc-func-aix");
-  else
+  if (!Args.hasFlag(options::OPT_ferr_pragma_mc_func_aix,
+                    options::OPT_fno_err_pragma_mc_func_aix, true))
     CC1Args.push_back("-fno-err-pragma-mc-func-aix");
 }
 

--- a/clang/test/Preprocessor/pragma_mc_func.c
+++ b/clang/test/Preprocessor/pragma_mc_func.c
@@ -1,3 +1,4 @@
+// RUN: not %clang --target=powerpc64-ibm-aix -fsyntax-only %s 2>&1 | FileCheck %s
 // RUN: not %clang --target=powerpc64-ibm-aix -ferr-pragma-mc-func-aix -fsyntax-only \
 // RUN:   %s 2>&1 | FileCheck %s
 #pragma mc_func asm_barrier {"60000000"}
@@ -8,11 +9,10 @@
 // RUN: %clang --target=powerpc64-ibm-aix -fno-err-pragma-mc-func-aix -fsyntax-only %s
 // RUN: %clang --target=powerpc64-ibm-aix -ferr-pragma-mc-func-aix -fsyntax-only \
 // RUN:    -fno-err-pragma-mc-func-aix %s
-// RUN: %clang --target=powerpc64-ibm-aix -fsyntax-only %s
 // RUN: %clang --target=powerpc64-ibm-aix -Werror=unknown-pragmas \
 // RUN:   -fno-err-pragma-mc-func-aix -fsyntax-only %s
 
-// Cases where we have errors or warnings.
+// Cases on a non-AIX target.
 // RUN: not %clang --target=powerpc64le-unknown-linux-gnu \
 // RUN:   -Werror=unknown-pragmas -fno-err-pragma-mc-func-aix -fsyntax-only %s 2>&1 | \
 // RUN:   FileCheck --check-prefix=UNUSED %s

--- a/clang/test/Preprocessor/pragma_mc_func.c
+++ b/clang/test/Preprocessor/pragma_mc_func.c
@@ -1,6 +1,8 @@
 // RUN: not %clang --target=powerpc64-ibm-aix -fsyntax-only %s 2>&1 | FileCheck %s
 // RUN: not %clang --target=powerpc64-ibm-aix -ferr-pragma-mc-func-aix -fsyntax-only \
 // RUN:   %s 2>&1 | FileCheck %s
+// RUN: not %clang --target=powerpc64-ibm-aix -fno-err-pragma-mc-func-aix \
+// RUN:   -ferr-pragma-mc-func-aix -fsyntax-only %s 2>&1 | FileCheck %s
 #pragma mc_func asm_barrier {"60000000"}
 
 // CHECK:  error: #pragma mc_func is not supported


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/99888 added a check (and corresponding options) to flag uses of `#pragma mc_func` on AIX. 

This PR turns on the check by default. 