### PR TITLE
workflows/release-binaries: Enable flang builds on Windows

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -124,15 +124,7 @@ jobs:
           target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_DARWIN_osx_ARCHS=$arches -DBOOTSTRAP_DARWIN_osx_BUILTIN_ARCHS=$arches"
         fi
 
-        # x86 macOS and x86 Windows have trouble building flang, so disable it.
-        # Windows: https://github.com/llvm/llvm-project/issues/100202
-        # macOS: 'rebase opcodes terminated early at offset 1 of 80016' when building __fortran_builtins.mod
         build_flang="true"
-
-        if [ "$target" = "Windows-X64" ]; then
-          target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_PROJECTS=\"clang;lld;lldb;clang-tools-extra;bolt;polly;mlir\""
-          build_flang="false"
-        fi
 
         if [ "${{ runner.os }}" = "Windows" ]; then
           # The build times out on Windows, so we need to disable LTO.

--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -47,11 +47,10 @@ set(LLVM_TARGETS_TO_BUILD Native CACHE STRING "")
 set(CLANG_ENABLE_BOOTSTRAP ON CACHE BOOL "")
 
 set(STAGE1_PROJECTS "clang")
-set(STAGE1_RUNTIMES "")
+set(STAGE1_RUNTIMES "compiler-rt")
 
 if (LLVM_RELEASE_ENABLE_PGO)
   list(APPEND STAGE1_PROJECTS "lld")
-  list(APPEND STAGE1_RUNTIMES "compiler-rt")
   set(CLANG_BOOTSTRAP_TARGETS
     generate-profdata
     stage2-package

--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -49,7 +49,8 @@ set(CLANG_ENABLE_BOOTSTRAP ON CACHE BOOL "")
 set(STAGE1_PROJECTS "clang")
 
 # Building Flang on Windows requires compiler-rt, so we need to build it in
-# stage1.
+# stage1.  compiler-rt is also required for building the Flang tests on
+# macOS.
 set(STAGE1_RUNTIMES "compiler-rt")
 
 if (LLVM_RELEASE_ENABLE_PGO)

--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -47,10 +47,16 @@ set(LLVM_TARGETS_TO_BUILD Native CACHE STRING "")
 set(CLANG_ENABLE_BOOTSTRAP ON CACHE BOOL "")
 
 set(STAGE1_PROJECTS "clang")
+
+# Building Flang on Windows requires compiler-rt, so we need to build it in
+# stage1.
 set(STAGE1_RUNTIMES "compiler-rt")
 
 if (LLVM_RELEASE_ENABLE_PGO)
   list(APPEND STAGE1_PROJECTS "lld")
+  if (NOT "compiler-rt" IN_LIST STAGE1_RUNTIMES)
+    list(APPEND STAGE1_PROJECTS "compiler-rt")
+  endif()
   set(CLANG_BOOTSTRAP_TARGETS
     generate-profdata
     stage2-package

--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -55,9 +55,6 @@ set(STAGE1_RUNTIMES "compiler-rt")
 
 if (LLVM_RELEASE_ENABLE_PGO)
   list(APPEND STAGE1_PROJECTS "lld")
-  if (NOT "compiler-rt" IN_LIST STAGE1_RUNTIMES)
-    list(APPEND STAGE1_PROJECTS "compiler-rt")
-  endif()
   set(CLANG_BOOTSTRAP_TARGETS
     generate-profdata
     stage2-package


### PR DESCRIPTION
Flang for Windows depends on compiler-rt, so we need to enable it for the stage1 builds.  This also fixes failures building the flang tests on macOS.

Fixes #100202.
