### PR TITLE
[SandboxIR] Implement FPToSIInst

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -32,6 +32,8 @@
 //                                      |                   |
 //                                      |                   +- BitCastInst
 //                                      |                   |
+//                                      |                   +- FPToSIInst
+//                                      |                   |
 //                                      |                   +- IntToPtrInst
 //                                      |                   |
 //                                      |                   +- PtrToIntInst
@@ -1372,6 +1374,27 @@ public:
   void dump(raw_ostream &OS) const override;
   LLVM_DUMP_METHOD void dump() const override;
 #endif
+};
+
+class FPToSIInst final : public CastInst {
+public:
+  static Value *create(Value *Src, Type *DestTy, BBIterator WhereIt,
+                       BasicBlock *WhereBB, Context &Ctx,
+                       const Twine &Name = "");
+  static Value *create(Value *Src, Type *DestTy, Instruction *InsertBefore,
+                       Context &Ctx, const Twine &Name = "");
+  static Value *create(Value *Src, Type *DestTy, BasicBlock *InsertAtEnd,
+                       Context &Ctx, const Twine &Name = "");
+
+  static bool classof(const Value *From) {
+    if (auto *I = dyn_cast<Instruction>(From))
+      return I->getOpcode() == Opcode::FPToSI;
+    return false;
+  }
+#ifndef NDEBUG
+  void dump(raw_ostream &OS) const final;
+  LLVM_DUMP_METHOD void dump() const final;
+#endif // NDEBUG
 };
 
 class IntToPtrInst final : public CastInst {

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -1143,6 +1143,34 @@ void CastInst::dump() const {
 }
 #endif // NDEBUG
 
+Value *FPToSIInst::create(Value *Src, Type *DestTy, BBIterator WhereIt,
+                          BasicBlock *WhereBB, Context &Ctx,
+                          const Twine &Name) {
+  return CastInst::create(DestTy, Instruction::Opcode::FPToSI, Src, WhereIt,
+                          WhereBB, Ctx, Name);
+}
+Value *FPToSIInst::create(Value *Src, Type *DestTy, Instruction *InsertBefore,
+                          Context &Ctx, const Twine &Name) {
+  return create(Src, DestTy, InsertBefore->getIterator(),
+                InsertBefore->getParent(), Ctx, Name);
+}
+Value *FPToSIInst::create(Value *Src, Type *DestTy, BasicBlock *InsertAtEnd,
+                          Context &Ctx, const Twine &Name) {
+  return create(Src, DestTy, InsertAtEnd->end(), InsertAtEnd, Ctx, Name);
+}
+
+#ifndef NDEBUG
+void FPToSIInst::dump(raw_ostream &OS) const {
+  dumpCommonPrefix(OS);
+  dumpCommonSuffix(OS);
+}
+
+void FPToSIInst::dump() const {
+  dump(dbgs());
+  dbgs() << "\n";
+}
+#endif // NDEBUG
+
 Value *IntToPtrInst::create(Value *Src, Type *DestTy, BBIterator WhereIt,
                             BasicBlock *WhereBB, Context &Ctx,
                             const Twine &Name) {


### PR DESCRIPTION
This patch implements sandboxir::FPToSIInst which mirrors llvm::FPToSIInst.