### PR TITLE
[llvm-ar] --help: fix unquoted angle bracket

### DIFF
--- a/llvm/tools/llvm-ar/llvm-ar.cpp
+++ b/llvm/tools/llvm-ar/llvm-ar.cpp
@@ -130,7 +130,7 @@ MODIFIERS:
          << "USAGE: " + ToolName +
                 " [options] [-]<operation>[modifiers] [relpos] "
                 "[count] <archive> [files]\n"
-         << "       " + ToolName + " -M [<mri-script]\n\n";
+         << "       " + ToolName + " [-M mri-script]\n\n";
 
   outs() << ArOptions;
 }

--- a/llvm/tools/llvm-ar/llvm-ar.cpp
+++ b/llvm/tools/llvm-ar/llvm-ar.cpp
@@ -130,7 +130,7 @@ MODIFIERS:
          << "USAGE: " + ToolName +
                 " [options] [-]<operation>[modifiers] [relpos] "
                 "[count] <archive> [files]\n"
-         << "       " + ToolName + " [-M < mri-script]\n\n";
+         << "       " + ToolName + " -M [< mri-script]\n\n";
 
   outs() << ArOptions;
 }

--- a/llvm/tools/llvm-ar/llvm-ar.cpp
+++ b/llvm/tools/llvm-ar/llvm-ar.cpp
@@ -130,7 +130,7 @@ MODIFIERS:
          << "USAGE: " + ToolName +
                 " [options] [-]<operation>[modifiers] [relpos] "
                 "[count] <archive> [files]\n"
-         << "       " + ToolName + " [-M mri-script]\n\n";
+         << "       " + ToolName + " [-M < mri-script]\n\n";
 
   outs() << ArOptions;
 }


### PR DESCRIPTION
Changes the argument in llvm-ar help message from `-M [<mri-script]` to `-M [< mri-script]`