### PR TITLE
[BOLT] Move ADRRelaxationPass

### DIFF
--- a/bolt/lib/Rewrite/BinaryPassManager.cpp
+++ b/bolt/lib/Rewrite/BinaryPassManager.cpp
@@ -357,6 +357,8 @@ Error BinaryFunctionPassManager::runAllPasses(BinaryContext &BC) {
 
     Manager.registerPass(
         std::make_unique<VeneerElimination>(PrintVeneerElimination));
+
+    Manager.registerPass(std::make_unique<ADRRelaxationPass>());
   }
 
   if (BC.isRISCV()) {
@@ -490,8 +492,6 @@ Error BinaryFunctionPassManager::runAllPasses(BinaryContext &BC) {
   Manager.registerPass(std::make_unique<ReorderData>());
 
   if (BC.isAArch64()) {
-    Manager.registerPass(std::make_unique<ADRRelaxationPass>());
-
     // Tighten branches according to offset differences between branch and
     // targets. No extra instructions after this pass, otherwise we may have
     // relocations out of range and crash during linking.


### PR DESCRIPTION
For non-simple functions we need nop instruction to be presented to
transform ADR to ADRP+ADD sequence, so run this pass before remove nops
pass.
