### PR TITLE
[libc] Remove verbose printing from hdrgen tool

### DIFF
--- a/libc/newhdrgen/yaml_to_classes.py
+++ b/libc/newhdrgen/yaml_to_classes.py
@@ -252,8 +252,6 @@ def main(
         with open(output_file_path, "w") as f:
             f.write(header_str)
 
-    print(f"Generated header file: {output_file_path}")
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate header files from YAML")


### PR DESCRIPTION
Summary:
This fills the terminal with information already present from the
`add_custom_command(COMMENT ...)` field, so it breaks everything into
new lines. Remove this print to clean that up.
