### PR TITLE
[flang][runtime] Handle multi-byte characters while tabbing

### DIFF
--- a/flang/runtime/internal-unit.h
+++ b/flang/runtime/internal-unit.h
@@ -31,6 +31,7 @@ public:
 
   RT_API_ATTRS bool Emit(const char *, std::size_t, IoErrorHandler &);
   RT_API_ATTRS std::size_t GetNextInputBytes(const char *&, IoErrorHandler &);
+  RT_API_ATTRS std::size_t ViewBytesInRecord(const char *&, bool forward) const;
   RT_API_ATTRS bool AdvanceRecord(IoErrorHandler &);
   RT_API_ATTRS void BackspaceRecord(IoErrorHandler &);
   RT_API_ATTRS std::int64_t InquirePos();

--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -32,6 +32,12 @@ std::size_t IoStatementBase::GetNextInputBytes(const char *&p) {
   return 0;
 }
 
+std::size_t IoStatementBase::ViewBytesInRecord(
+    const char *&p, bool forward) const {
+  p = nullptr;
+  return 0;
+}
+
 bool IoStatementBase::AdvanceRecord(int) { return false; }
 
 void IoStatementBase::BackspaceRecord() {}
@@ -104,6 +110,8 @@ template <Direction DIR>
 std::size_t InternalIoStatementState<DIR>::GetNextInputBytes(const char *&p) {
   return unit_.GetNextInputBytes(p, *this);
 }
+
+// InternalIoStatementState<DIR>::ViewBytesInRecord() not needed or defined
 
 template <Direction DIR>
 bool InternalIoStatementState<DIR>::AdvanceRecord(int n) {
@@ -411,6 +419,12 @@ bool ExternalIoStatementState<DIR>::Emit(
 template <Direction DIR>
 std::size_t ExternalIoStatementState<DIR>::GetNextInputBytes(const char *&p) {
   return unit().GetNextInputBytes(p, *this);
+}
+
+template <Direction DIR>
+std::size_t ExternalIoStatementState<DIR>::ViewBytesInRecord(
+    const char *&p, bool forward) const {
+  return unit().ViewBytesInRecord(p, forward);
 }
 
 template <Direction DIR>

--- a/flang/runtime/io-stmt.h
+++ b/flang/runtime/io-stmt.h
@@ -93,6 +93,7 @@ public:
       const char *, std::size_t bytes, std::size_t elementBytes = 0);
   RT_API_ATTRS bool Receive(char *, std::size_t, std::size_t elementBytes = 0);
   RT_API_ATTRS std::size_t GetNextInputBytes(const char *&);
+  RT_API_ATTRS std::size_t ViewBytesInRecord(const char *&, bool forward) const;
   RT_API_ATTRS bool AdvanceRecord(int = 1);
   RT_API_ATTRS void BackspaceRecord();
   RT_API_ATTRS void HandleRelativePosition(std::int64_t byteOffset);
@@ -132,9 +133,9 @@ public:
   RT_API_ATTRS Fortran::common::optional<char32_t> GetCurrentChar(
       std::size_t &byteCount);
 
-  // The "remaining" arguments to CueUpInput(), SkipSpaces(), & NextInField()
-  // are always in units of bytes, not characters; the distinction matters
-  // for internal input from CHARACTER(KIND=2 and 4).
+  // The result of CueUpInput() and the "remaining" arguments to SkipSpaces()
+  // and NextInField() are always in units of bytes, not characters; the
+  // distinction matters for internal input from CHARACTER(KIND=2 and 4).
 
   // For fixed-width fields, return the number of remaining bytes.
   // Skip over leading blanks.
@@ -279,6 +280,7 @@ public:
   RT_API_ATTRS bool Receive(
       char *, std::size_t bytes, std::size_t elementBytes = 0);
   RT_API_ATTRS std::size_t GetNextInputBytes(const char *&);
+  RT_API_ATTRS std::size_t ViewBytesInRecord(const char *&, bool forward) const;
   RT_API_ATTRS bool AdvanceRecord(int);
   RT_API_ATTRS void BackspaceRecord();
   RT_API_ATTRS void HandleRelativePosition(std::int64_t);
@@ -448,6 +450,7 @@ public:
   RT_API_ATTRS ExternalIoStatementBase(
       ExternalFileUnit &, const char *sourceFile = nullptr, int sourceLine = 0);
   RT_API_ATTRS ExternalFileUnit &unit() { return unit_; }
+  RT_API_ATTRS const ExternalFileUnit &unit() const { return unit_; }
   RT_API_ATTRS MutableModes &mutableModes();
   RT_API_ATTRS ConnectionState &GetConnectionState();
   RT_API_ATTRS int asynchronousID() const { return asynchronousID_; }
@@ -473,6 +476,7 @@ public:
   RT_API_ATTRS bool Emit(
       const char *, std::size_t bytes, std::size_t elementBytes = 0);
   RT_API_ATTRS std::size_t GetNextInputBytes(const char *&);
+  RT_API_ATTRS std::size_t ViewBytesInRecord(const char *&, bool forward) const;
   RT_API_ATTRS bool AdvanceRecord(int = 1);
   RT_API_ATTRS void BackspaceRecord();
   RT_API_ATTRS void HandleRelativePosition(std::int64_t);
@@ -539,6 +543,7 @@ public:
   RT_API_ATTRS bool Emit(
       const char *, std::size_t bytes, std::size_t elementBytes = 0);
   RT_API_ATTRS std::size_t GetNextInputBytes(const char *&);
+  RT_API_ATTRS std::size_t ViewBytesInRecord(const char *&, bool forward) const;
   RT_API_ATTRS void HandleRelativePosition(std::int64_t);
   RT_API_ATTRS void HandleAbsolutePosition(std::int64_t);
 

--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -148,6 +148,24 @@ std::size_t ExternalFileUnit::GetNextInputBytes(
   return p ? length : 0;
 }
 
+std::size_t ExternalFileUnit::ViewBytesInRecord(
+    const char *&p, bool forward) const {
+  p = nullptr;
+  auto recl{recordLength.value_or(positionInRecord)};
+  if (forward) {
+    if (positionInRecord < recl) {
+      p = Frame() + recordOffsetInFrame_ + positionInRecord;
+      return recl - positionInRecord;
+    }
+  } else {
+    if (positionInRecord <= recl) {
+      p = Frame() + recordOffsetInFrame_ + positionInRecord;
+    }
+    return positionInRecord - leftTabLimit.value_or(0);
+  }
+  return 0;
+}
+
 const char *ExternalFileUnit::FrameNextInput(
     IoErrorHandler &handler, std::size_t bytes) {
   RUNTIME_CHECK(handler, isUnformatted.has_value() && !*isUnformatted);

--- a/flang/runtime/unit.h
+++ b/flang/runtime/unit.h
@@ -166,6 +166,7 @@ public:
   RT_API_ATTRS bool Receive(
       char *, std::size_t, std::size_t elementBytes, IoErrorHandler &);
   RT_API_ATTRS std::size_t GetNextInputBytes(const char *&, IoErrorHandler &);
+  RT_API_ATTRS std::size_t ViewBytesInRecord(const char *&, bool forward) const;
   RT_API_ATTRS bool BeginReadingRecord(IoErrorHandler &);
   RT_API_ATTRS void FinishReadingRecord(IoErrorHandler &);
   RT_API_ATTRS bool AdvanceRecord(IoErrorHandler &);

--- a/flang/runtime/utf.cpp
+++ b/flang/runtime/utf.cpp
@@ -44,6 +44,17 @@ RT_OFFLOAD_VAR_GROUP_END
 #endif // FLANG_RUNTIME_NO_GLOBAL_VAR_DEFS
 
 RT_OFFLOAD_API_GROUP_BEGIN
+
+std::size_t MeasurePreviousUTF8Bytes(const char *end, std::size_t limit) {
+  // Scan back over UTF-8 continuation bytes, if any
+  for (std::size_t n{1}; n <= limit; ++n) {
+    if ((end[-n] & 0xc0) != 0x80) {
+      return n;
+    }
+  }
+  return limit;
+}
+
 // Non-minimal encodings are accepted.
 Fortran::common::optional<char32_t> DecodeUTF8(const char *p0) {
   const std::uint8_t *p{reinterpret_cast<const std::uint8_t *>(p0)};

--- a/flang/runtime/utf.h
+++ b/flang/runtime/utf.h
@@ -58,6 +58,9 @@ static inline RT_API_ATTRS std::size_t MeasureUTF8Bytes(char first) {
   return UTF8FirstByteTable[static_cast<std::uint8_t>(first)];
 }
 
+RT_API_ATTRS std::size_t MeasurePreviousUTF8Bytes(
+    const char *end, std::size_t limit);
+
 // Ensure that all bytes are present in sequence in the input buffer
 // before calling; use MeasureUTF8Bytes(first byte) to count them.
 RT_API_ATTRS Fortran::common::optional<char32_t> DecodeUTF8(const char *);


### PR DESCRIPTION
When repositioning within the current record with control edit descriptors (Xn, Tn, TLn, TRn), deal with multiple-byte character encodings.  This affects only external I/O to units with UTF-8 encoding.