### PR TITLE
[libc] created fuzz test for sin function

### DIFF
--- a/libc/fuzzing/CMakeLists.txt
+++ b/libc/fuzzing/CMakeLists.txt
@@ -3,7 +3,7 @@ add_custom_target(libc-fuzzer)
 
 add_subdirectory(__support)
 # TODO(#85680): Re-enable math fuzzing after headers are sorted out
-# add_subdirectory(math)
+add_subdirectory(math)
 add_subdirectory(stdlib)
 add_subdirectory(stdio)
 add_subdirectory(string)

--- a/libc/fuzzing/math/CMakeLists.txt
+++ b/libc/fuzzing/math/CMakeLists.txt
@@ -61,3 +61,12 @@ add_libc_fuzzer(
     libc.src.math.nextafterf
     libc.src.math.nextafterl
 )
+
+add_libc_fuzzer(
+  sin_fuzz
+  NEED_MPFR
+  SRCS
+    sin_fuzz.cpp
+  DEPENDS
+    libc.src.math.sin
+)

--- a/libc/fuzzing/math/sin_fuzz.cpp
+++ b/libc/fuzzing/math/sin_fuzz.cpp
@@ -1,0 +1,40 @@
+//===-- sin_fuzz.cpp ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Fuzzing test for llvm-libc sin implementation.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/math/sin.h"
+#include <cmath>
+#include <mpfr.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const double x) {
+  // remove NaN and inf as preconditions
+  if (std::isnan(x))
+    return 0;
+  if (std::isinf(x))
+    return 0;
+  // signed zeros already tested in unit tests
+  if (std::signbit(x) && x == 0.0)
+    return 0;
+  mpfr_t input;
+  mpfr_init2(input, 64);
+  mpfr_set_d(input, x, MPFR_RNDN);
+  int output = mpfr_sin(input, input, MPFR_RNDN);
+  mpfr_subnormalize(input, output, MPFR_RNDN);
+  double to_compare = mpfr_get_d(input, MPFR_RNDN);
+
+  double result = LIBC_NAMESPACE::sin(x);
+
+  if (result != to_compare)
+    __builtin_trap();
+
+  mpfr_clear(input);
+  return 0;
+}

--- a/libc/fuzzing/math/sin_fuzz.cpp
+++ b/libc/fuzzing/math/sin_fuzz.cpp
@@ -24,7 +24,7 @@ extern "C" int LLVMFuzzerTestOneInput(const double x) {
   if (std::signbit(x) && x == 0.0)
     return 0;
   mpfr_t input;
-  mpfr_init2(input, 64);
+  mpfr_init2(input, 53);
   mpfr_set_d(input, x, MPFR_RNDN);
   int output = mpfr_sin(input, input, MPFR_RNDN);
   mpfr_subnormalize(input, output, MPFR_RNDN);


### PR DESCRIPTION
Verifies that sin function output is correct by comparing with MPFR
output. NaN and inf are not tested (as our output will vary compared to
MPFR), and signed zeroes are already tested in unit tests.
