### PR TITLE
[NFC][Clang] Clean up VisitUnaryPlus by removing unused FP feature check

### DIFF
--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -649,7 +649,6 @@ ComplexPairTy ComplexExprEmitter::EmitCast(CastKind CK, Expr *Op,
 
 ComplexPairTy ComplexExprEmitter::VisitUnaryPlus(const UnaryOperator *E,
                                                  QualType PromotionType) {
-  E->hasStoredFPFeatures();
   QualType promotionTy =
       PromotionType.isNull()
           ? getPromotionType(E->getStoredFPFeaturesOrDefault(),


### PR DESCRIPTION
This commit removes an unnecessary call to `E->hasStoredFPFeatures()` within the `VisitUnaryPlus` function. The method's return value was not being used, leading to a redundant operation. The removal of this line streamlines the function and eliminates an unneeded check for stored floating-point features.