### PR TITLE
docs: Clarify commit access requirements in the Developer Policy

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -475,8 +475,8 @@ What are the expectations around a revert?
 Obtaining Commit Access
 -----------------------
 
-We grant commit access to contributors with a track record of submitting high
-quality patches.  If you would like commit access, please send an email to
+We grant commit access to contributors that can provide a valid justification
+If you would like commit access, please send an email to
 `Chris <mailto:clattner@llvm.org>`_ with your GitHub username.  This is true
 for former contributors with SVN access as well as new contributors. If
 approved, a GitHub invitation will be sent to your GitHub account. In case you

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -475,7 +475,7 @@ What are the expectations around a revert?
 Obtaining Commit Access
 -----------------------
 
-We grant commit access to contributors that can provide a valid justification
+We grant commit access to contributors that can provide a valid justification.
 If you would like commit access, please send an email to
 `Chris <mailto:clattner@llvm.org>`_ with your GitHub username.  This is true
 for former contributors with SVN access as well as new contributors. If


### PR DESCRIPTION
We have been discussing changes to our commit access polices recently and based on some feedback from clattner here:

https://discourse.llvm.org/t/rfc-new-criteria-for-commit-access/76290/81

We need to update our Developer Policy so that it matches what we are actually doing in this project.  We currently grant commit access to anyone with a valid justification, not just contributors who have submitted high-quality patches in the past.