### PR TITLE
[SystemZ][z/OS] Fix incorrect codegen for ADA_ENTRY pseudo instruction

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -346,9 +346,10 @@ void SystemZAsmPrinter::emitInstruction(const MachineInstr *MI) {
             *OutStreamer,
             MCInstBuilder(SystemZ::LLILF).addReg(TargetReg).addImm(Disp));
       } else
-        EmitToStreamer(
-            *OutStreamer,
-            MCInstBuilder(SystemZ::ALGFI).addReg(TargetReg).addReg(TargetReg).addImm(Disp));
+        EmitToStreamer(*OutStreamer, MCInstBuilder(SystemZ::ALGFI)
+                                         .addReg(TargetReg)
+                                         .addReg(TargetReg)
+                                         .addImm(Disp));
       Disp = 0;
       Op = Op0;
     }

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -348,7 +348,7 @@ void SystemZAsmPrinter::emitInstruction(const MachineInstr *MI) {
       } else
         EmitToStreamer(
             *OutStreamer,
-            MCInstBuilder(SystemZ::ALGFI).addReg(TargetReg).addImm(Disp));
+            MCInstBuilder(SystemZ::ALGFI).addReg(TargetReg).addReg(TargetReg).addImm(Disp));
       Disp = 0;
       Op = Op0;
     }

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
@@ -298,13 +298,13 @@ let Predicates = [IsTargetXPLINK64] in {
   }
 
   let hasNoSchedulingInfo = 1, Defs = [CC] in {
-    def ADA_ENTRY : Alias<12, (outs GR64:$Reg), (ins adasym:$addr,
+    def ADA_ENTRY : Alias<12, (outs ADDR64:$Reg), (ins adasym:$addr,
                               ADDR64:$ADA, imm64:$Offset),
                             [(set i64:$Reg, (z_ada_entry i64:$addr,
                               i64:$ADA, i64:$Offset))]>;
   }
   let mayLoad = 1, AddedComplexity = 20, hasNoSchedulingInfo = 1, Defs = [CC] in {
-    def ADA_ENTRY_VALUE : Alias<12, (outs GR64:$Reg), (ins adasym:$addr,
+    def ADA_ENTRY_VALUE : Alias<12, (outs ADDR64:$Reg), (ins adasym:$addr,
                               ADDR64:$ADA, imm64:$Offset),
                             [(set i64:$Reg, (z_load (z_ada_entry
                               iPTR:$addr, iPTR:$ADA, i64:$Offset)))]>;

--- a/llvm/test/CodeGen/SystemZ/Large/large-ada-01.py
+++ b/llvm/test/CodeGen/SystemZ/Large/large-ada-01.py
@@ -3,7 +3,7 @@
 # generation of a different instruction sequence
 # RUN: %python %s | llc -mtriple=s390x-ibm-zos -O2 | FileCheck %s
 
-# CHECK: llilf	1, {{[0-9]+}} 
+# CHECK: llilf	1, {{[0-9]+}}
 # CHECK-NEXT: la	1, 0(1,8)
 
 from __future__ import print_function
@@ -14,14 +14,14 @@ print("define hidden signext i32 @main() {")
 print("entry:")
 
 for i in range(num_calls):
-  print("  call void @foo%d()" % i)
+    print("  call void @foo%d()" % i)
 
 print("  call void @bar(ptr noundef @foo)")
 print("ret i32 0")
 print("}")
 
 for i in range(num_calls):
-  print("declare void @foo%d(...)" % i)
+    print("declare void @foo%d(...)" % i)
 
 print("declare void @bar(ptr noundef)")
 print("define internal void @foo() {")

--- a/llvm/test/CodeGen/SystemZ/Large/large-ada-01.py
+++ b/llvm/test/CodeGen/SystemZ/Large/large-ada-01.py
@@ -1,0 +1,30 @@
+# Test code generation for retrieving function descriptors
+# from the ADA when the ADA is extremely large and forces the
+# generation of a different instruction sequence
+# RUN: %python %s | llc -mtriple=s390x-ibm-zos -O2 | FileCheck %s
+
+# CHECK: llilf	1, {{[0-9]+}} 
+# CHECK-NEXT: la	1, 0(1,8)
+
+from __future__ import print_function
+
+num_calls = 35000
+
+print("define hidden signext i32 @main() {")
+print("entry:")
+
+for i in range(num_calls):
+  print("  call void @foo%d()" % i)
+
+print("  call void @bar(ptr noundef @foo)")
+print("ret i32 0")
+print("}")
+
+for i in range(num_calls):
+  print("declare void @foo%d(...)" % i)
+
+print("declare void @bar(ptr noundef)")
+print("define internal void @foo() {")
+print("entry:")
+print("  ret void")
+print("  }")

--- a/llvm/test/CodeGen/SystemZ/Large/large-ada-02.py
+++ b/llvm/test/CodeGen/SystemZ/Large/large-ada-02.py
@@ -1,0 +1,33 @@
+# Test code generation for retrieving function descriptors
+# from the ADA when the ADA is extremely large and forces the
+# generation of a different instruction sequence
+# RUN: %python %s | llc -mtriple=s390x-ibm-zos -O2 | FileCheck %s
+	
+# CHECK: algfi	8, {{[0-9]+}}
+# CHECK: la	8, 0(8)
+
+from __future__ import print_function
+
+num_calls = 35000
+
+print("define hidden signext i32 @main() {")
+print("entry:")
+
+for i in range(num_calls):
+  print("  call void @foo%d()" % i)
+
+# This is added to force the use of register r8 to generate
+# la 8, 0(8) which generates the algfi instruction
+print("%0 = call ptr asm \" LGR $0,$1\0A\", \"=r,{r8}\"(ptr nonnull @foo)")
+print("  call void @bar(ptr noundef %0)")
+print("ret i32 0")
+print("}")
+
+for i in range(num_calls):
+  print("declare void @foo%d(...)" % i)
+
+print("declare void @bar(ptr noundef)")
+print("define internal void @foo() {")
+print("entry:")
+print("  ret void")
+print("  }")

--- a/llvm/test/CodeGen/SystemZ/Large/large-ada-02.py
+++ b/llvm/test/CodeGen/SystemZ/Large/large-ada-02.py
@@ -18,7 +18,7 @@ for i in range(num_calls):
 
 # This is added to force the use of register r8 to generate
 # la 8, 0(8) which generates the algfi instruction
-print("%0 = call ptr asm \" LGR $0,$1\0A\", \"=r,{r8}\"(ptr nonnull @foo)")
+print('%0 = call ptr asm " LGR $0,$1\0A", "=r,{r8}"(ptr nonnull @foo)')
 print("  call void @bar(ptr noundef %0)")
 print("ret i32 0")
 print("}")

--- a/llvm/test/CodeGen/SystemZ/Large/large-ada-02.py
+++ b/llvm/test/CodeGen/SystemZ/Large/large-ada-02.py
@@ -2,7 +2,7 @@
 # from the ADA when the ADA is extremely large and forces the
 # generation of a different instruction sequence
 # RUN: %python %s | llc -mtriple=s390x-ibm-zos -O2 | FileCheck %s
-	
+
 # CHECK: algfi	8, {{[0-9]+}}
 # CHECK: la	8, 0(8)
 
@@ -14,7 +14,7 @@ print("define hidden signext i32 @main() {")
 print("entry:")
 
 for i in range(num_calls):
-  print("  call void @foo%d()" % i)
+    print("  call void @foo%d()" % i)
 
 # This is added to force the use of register r8 to generate
 # la 8, 0(8) which generates the algfi instruction
@@ -24,7 +24,7 @@ print("ret i32 0")
 print("}")
 
 for i in range(num_calls):
-  print("declare void @foo%d(...)" % i)
+    print("declare void @foo%d(...)" % i)
 
 print("declare void @bar(ptr noundef)")
 print("define internal void @foo() {")


### PR DESCRIPTION
The current MCInstBuilder for generating an ALGFI when loading something from the ADA is incorrect and will crash the compiler.

r0 must also be excluded from the registers returned as the result, since it is treated as the value "0" on z/OS.

Also add some tests to properly test the paths where LLILF and ALGFI are generated.