### PR TITLE
[TargetLowering] Remove weird use of MVT::isVoid in an assert.

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -1640,7 +1640,8 @@ public:
     MVT NVT = VT;
     do {
       NVT = (MVT::SimpleValueType)(NVT.SimpleTy+1);
-      assert(NVT.isInteger() == VT.isInteger() && NVT != MVT::isVoid &&
+      assert(NVT.isInteger() == VT.isInteger() &&
+             NVT.isFloatingPoint() == VT.isFloatingPoint() &&
              "Didn't find type to promote to!");
     } while (VTBits >= NVT.getScalarSizeInBits() || !isTypeLegal(NVT) ||
              getOperationAction(Op, NVT) == Promote);


### PR DESCRIPTION
At the time this was written there were no vector types in MVT. The order was:
  scalar integer types
  scalar FP types
  isVoid

I believe this isVoid check was to catch walking off the end of the scalar FP types. While the isInteger()==isInteger caught walking off the end of scalar integer types.

These days we have:
  scalar integer types
  scalar FP types
  fixed vector integer types
  fixed vector FP types
  scalable vector integer types
  scalable vector FP types.
  Glue
  isVoid

So checking isVoid doesn't detect what it used to. I've changed it to check isFloatingPoint() == isFloatingPoint() instead.