### PR TITLE
Allow flang-new binary to be specified for omp fortran modules

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -505,7 +505,7 @@ if(build_runtimes)
   if("openmp" IN_LIST LLVM_ENABLE_RUNTIMES)
     if (${LLVM_TOOL_FLANG_BUILD})
       message(STATUS "Configuring build of omp_lib.mod and omp_lib_kinds.mod via flang")
-      set(LIBOMP_FORTRAN_MODULES_COMPILER "${CMAKE_BINARY_DIR}/bin/flang")
+      set(LIBOMP_FORTRAN_MODULES_COMPILER "${CMAKE_BINARY_DIR}/bin/flang" CACHE INTERNAL "")
       set(LIBOMP_MODULES_INSTALL_PATH "${CMAKE_INSTALL_INCLUDEDIR}/flang")
       # TODO: This is a workaround until flang becomes a first-class project
       # in llvm/CMakeList.txt.  Until then, this line ensures that flang is


### PR DESCRIPTION
This allows the path of the flang-new binary to be specified as a cmake configuration.

This is useful when cross compiling, as flang-new may exist on the build machine, which should be used instead of the host.

For example, by passing "-DFLANG_NEW_EXE=/usr/bin/flang-new", that binary will be used instead of just built host compiler.