### PR TITLE
[clang] fix classification of a string literal expression used as initializer

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -130,7 +130,7 @@ Improvements to Clang's diagnostics
 - Some template related diagnostics have been improved.
 
   .. code-block:: c++
-    
+
      void foo() { template <typename> int i; } // error: templates can only be declared in namespace or class scope
 
      struct S {
@@ -170,6 +170,8 @@ Bug Fixes to C++ Support
 - Fixed a failed assertion when checking invalid delete operator declaration. (#GH96191)
 - Fix a crash when checking destructor reference with an invalid initializer. (#GH97230)
 - Clang now correctly parses potentially declarative nested-name-specifiers in pointer-to-member declarators.
+- Fix a crash when checking the initialzier of an object that was initialized
+  with a string literal. (#GH82167)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/SemaCXX/GH82167.cpp
+++ b/clang/test/SemaCXX/GH82167.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++23 -fsyntax-only -verify -xobjective-c++ %s
+// expected-no-diagnostics
+
+namespace t1 {
+  struct array {
+    char elems[2];
+  };
+
+  template <unsigned> struct Literal {
+    array arr;
+    constexpr Literal() : arr("") {}
+  };
+
+  template struct Literal<0>;
+} // namespace t1
+
+namespace t2 {
+  struct array {
+    char elems[2];
+  };
+
+  template <unsigned> struct Literal {
+    array arr;
+    constexpr Literal() : arr(@encode(int)) {}
+  };
+
+  template struct Literal<0>;
+} // namespace t2


### PR DESCRIPTION
Since 3bf72d7d64b8465acd4f4af1a469d68d9dc86058 we have made a simplification where we transform a string literal into a prvalue, where normally they would always be lvalues.

This patch fixes expression classification to account for this case.

Fixes #82167