### PR TITLE
Simplify hot-path size computations in BumpPtrAllocator.

### DIFF
--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -171,8 +171,8 @@ public:
       // will point to the allocation of the entire slab.
       __msan_allocated_memory(reinterpret_cast<char *>(AlignedPtr), Size);
       // Similarly, tell ASan about this space.
-      __asan_unpoison_memory_region(AlignedPtr, Size);
-      return reinterpret_cast<char *>(reinterpret_cast<char *>(AlignedPtr));
+      __asan_unpoison_memory_region(reinterpret_cast<char *>(AlignedPtr), Size);
+      return reinterpret_cast<char *>(AlignedPtr);
     }
 
     return AllocateSlow(Size, SizeToAllocate, Alignment);

--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -149,8 +149,7 @@ public:
     // Keep track of how many bytes we've allocated.
     BytesAllocated += Size;
 
-    size_t Adjustment = offsetToAlignedAddr(CurPtr, Alignment);
-    assert(Adjustment + Size >= Size && "Adjustment + Size must not overflow");
+    uintptr_t AlignedPtr = alignAddr(CurPtr, Alignment);
 
     size_t SizeToAllocate = Size;
 #if LLVM_ADDRESS_SANITIZER_BUILD
@@ -158,19 +157,22 @@ public:
     SizeToAllocate += RedZoneSize;
 #endif
 
+    uintptr_t AllocEndPtr = AlignedPtr + SizeToAllocate;
+    assert(AllocEndPtr >= uintptr_t(CurPtr) &&
+           "Alignment + Size must not overflow");
+
     // Check if we have enough space.
-    if (LLVM_LIKELY(Adjustment + SizeToAllocate <= size_t(End - CurPtr)
+    if (LLVM_LIKELY(AllocEndPtr <= uintptr_t(End)
                     // We can't return nullptr even for a zero-sized allocation!
                     && CurPtr != nullptr)) {
-      char *AlignedPtr = CurPtr + Adjustment;
-      CurPtr = AlignedPtr + SizeToAllocate;
+      CurPtr = reinterpret_cast<char *>(AllocEndPtr);
       // Update the allocation point of this memory block in MemorySanitizer.
       // Without this, MemorySanitizer messages for values originated from here
       // will point to the allocation of the entire slab.
-      __msan_allocated_memory(AlignedPtr, Size);
+      __msan_allocated_memory(reinterpret_cast<char *>(AlignedPtr), Size);
       // Similarly, tell ASan about this space.
       __asan_unpoison_memory_region(AlignedPtr, Size);
-      return AlignedPtr;
+      return reinterpret_cast<char *>(reinterpret_cast<char *>(AlignedPtr));
     }
 
     return AllocateSlow(Size, SizeToAllocate, Alignment);


### PR DESCRIPTION
~0.1% instruction count improvements

https://llvm-compile-time-tracker.com/compare.php?from=07d2709a17860a202d91781769a88837e4fb5f2a&to=d5cc47831ecd9f0a2b164b16da67f74b94e9aafc&stat=instructions:u
