### PR TITLE
[Inliner] Fix bugs for partial inlining with vector

### DIFF
--- a/llvm/lib/Transforms/IPO/PartialInlining.cpp
+++ b/llvm/lib/Transforms/IPO/PartialInlining.cpp
@@ -1308,8 +1308,8 @@ bool PartialInlinerImpl::tryPartialInline(FunctionCloner &Cloner) {
   InstructionCost SizeCost = std::get<0>(OutliningCosts);
   InstructionCost NonWeightedRcost = std::get<1>(OutliningCosts);
 
-  assert(SizeCost.isValid() && NonWeightedRcost.isValid() &&
-         "Expected valid costs");
+  if (!SizeCost.isValid() || !NonWeightedRcost.isValid())
+    return false;
 
   // Only calculate RelativeToEntryFreq when we are doing single region
   // outlining.


### PR DESCRIPTION
In the cost model of partial inlining, cost for intrinsics will be applied. However, some intrinsics for vector have invalid cost, which is not allowed for partial inlining. Instead of assertion, we directly do not do partial inlining in this circumstance to avoid compiling errors.