### PR TITLE
[TargetLowering] Fix the problem of emulated-TLS implementation without checking alias of current global value at first.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -10225,8 +10225,10 @@ SDValue TargetLowering::LowerToTLSEmulatedModel(const GlobalAddressSDNode *GA,
 
   ArgListTy Args;
   ArgListEntry Entry;
-  std::string NameString = ("__emutls_v." + GA->getGlobal()->getName()).str();
-  Module *VariableModule = const_cast<Module*>(GA->getGlobal()->getParent());
+  const GlobalValue *GV = GA->getGlobal();
+  GV = GV->getAliaseeObject() ? GV->getAliaseeObject() : GV;
+  std::string NameString = ("__emutls_v." + GV->getName()).str();
+  Module *VariableModule = const_cast<Module*>(GV->getParent());
   StringRef EmuTlsVarName(NameString);
   GlobalVariable *EmuTlsVar = VariableModule->getNamedGlobal(EmuTlsVarName);
   assert(EmuTlsVar && "Cannot find EmuTlsVar ");

--- a/llvm/test/CodeGen/AArch64/emutls_alias.ll
+++ b/llvm/test/CodeGen/AArch64/emutls_alias.ll
@@ -1,0 +1,20 @@
+; RUN: llc < %s -emulated-tls -mtriple=aarch64-linux-ohos -O0 \
+; RUN:     | FileCheck -check-prefix=EMUTLS_CHECK %s
+ 
+%struct.__res_state = type { [5 x i8] }
+ 
+@foo = dso_local thread_local global %struct.__res_state { [5 x i8] c"\01\02\03\04\05" }, align 1
+ 
+@bar = hidden thread_local(initialexec) alias %struct.__res_state, ptr @foo
+ 
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  store i32 0, ptr %1, align 4
+  store i8 0, ptr @bar, align 1
+  ; EMUTLS_CHECK: adrp    x0, __emutls_v.foo
+  ; EMUTLS_CHECK-NEXT: add     x0, x0, :lo12:__emutls_v.foo
+  ret i32 0
+}
+ 
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+neon,+v8a" }


### PR DESCRIPTION
For a __thread variable x, when emulated TLS is enabled and there is an access to x, the compiler first looks up the symbol __emutls_v.x within the module. However, the issue arises with an alias y of x, the compiler still tries to look up __emutls_v.y instead of __emutls_v.x. As a result, the lookup returns a nullptr, causing the compiler to crash. The purpose of this MR (Merge Request) is to ensure that in emulated TLS, before checking __emutls_v.y, the compiler first identifies which global value y is an alias of.