### PR TITLE
uintptr_t to pointer cast: fix compilation error.

### DIFF
--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -171,7 +171,8 @@ public:
       // will point to the allocation of the entire slab.
       __msan_allocated_memory(AlignedPtr, Size);
       // Similarly, tell ASan about this space.
-      __asan_unpoison_memory_region(AlignedPtr, Size);
+      __asan_unpoison_memory_region(reinterpret_cast<const void *>(AlignedPtr),
+                                    Size);
       return reinterpret_cast<char *>(AlignedPtr);
     }
 


### PR DESCRIPTION
Compilation error introduced in #101312:

"no matching function for call to '__asan_unpoison_memory_region'"
