### PR TITLE
[libc] Fix old unittests for wchar tests

### DIFF
--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_wchar_unittests)
 
-add_libc_unittest(
+add_libc_test(
   btowc_test
   SUITE
     libc_wchar_unittests
@@ -11,7 +11,7 @@ add_libc_unittest(
     libc.src.wchar.btowc
 )
 
-add_libc_unittest(
+add_libc_test(
   wctob_test
   SUITE
     libc_wchar_unittests


### PR DESCRIPTION
Summary:
These need to use `add_libc_test`.
