### PR TITLE
`InOrderIssueStage` for llvm-mca should be generic over LSUnitBase

### DIFF
--- a/llvm/include/llvm/MCA/Stages/InOrderIssueStage.h
+++ b/llvm/include/llvm/MCA/Stages/InOrderIssueStage.h
@@ -21,7 +21,7 @@
 
 namespace llvm {
 namespace mca {
-class LSUnit;
+class LSUnitBase;
 class RegisterFile;
 
 struct StallInfo {
@@ -56,7 +56,7 @@ class InOrderIssueStage final : public Stage {
   RegisterFile &PRF;
   ResourceManager RM;
   CustomBehaviour &CB;
-  LSUnit &LSU;
+  LSUnitBase &LSU;
 
   /// Instructions that were issued, but not executed yet.
   SmallVector<InstRef, 4> IssuedInst;
@@ -113,7 +113,7 @@ class InOrderIssueStage final : public Stage {
 
 public:
   InOrderIssueStage(const MCSubtargetInfo &STI, RegisterFile &PRF,
-                    CustomBehaviour &CB, LSUnit &LSU);
+                    CustomBehaviour &CB, LSUnitBase &LSU);
 
   unsigned getIssueWidth() const;
   bool isAvailable(const InstRef &) const override;

--- a/llvm/lib/MCA/Stages/InOrderIssueStage.cpp
+++ b/llvm/lib/MCA/Stages/InOrderIssueStage.cpp
@@ -45,7 +45,7 @@ void StallInfo::cycleEnd() {
 
 InOrderIssueStage::InOrderIssueStage(const MCSubtargetInfo &STI,
                                      RegisterFile &PRF, CustomBehaviour &CB,
-                                     LSUnit &LSU)
+                                     LSUnitBase &LSU)
     : STI(STI), PRF(PRF), RM(STI.getSchedModel()), CB(CB), LSU(LSU),
       NumIssued(), CarryOver(), Bandwidth(), LastWriteBackCycle() {}
 


### PR DESCRIPTION
Other HardwareUnits (such as the [Scheduler](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/MCA/HardwareUnits/Scheduler.h#L71)) and Stages (such as [RetireStage](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/MCA/Stages/RetireStage.h#L32)) are generic over `LSUnitBase` rather than the specialized `LSUnit`.