### PR TITLE
[libc] heap_sort_fuzz deleted unnecessary includes

### DIFF
--- a/libc/fuzzing/stdlib/heap_sort_fuzz.cpp
+++ b/libc/fuzzing/stdlib/heap_sort_fuzz.cpp
@@ -10,7 +10,6 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/macros/config.h"
 #include "src/stdlib/heap_sort.h"
 #include <stdint.h>
 


### PR DESCRIPTION
Including src/__suppot/macros/config.h is unnecessary
