### PR TITLE
[flang][OpenMP] Fix 2 more regressions after #101009

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1645,7 +1645,8 @@ static void CheckPresent(evaluate::ActualArguments &arguments,
       } else {
         symbol = arg->GetAssumedTypeDummy();
       }
-      if (!symbol || !symbol->attrs().test(semantics::Attr::OPTIONAL)) {
+      if (!symbol ||
+          !symbol->GetUltimate().attrs().test(semantics::Attr::OPTIONAL)) {
         messages.Say(arg ? arg->sourceLocation() : messages.at(),
             "Argument of PRESENT() must be the name of a whole OPTIONAL dummy argument"_err_en_US);
       }

--- a/flang/test/Semantics/OpenMP/complex.f90
+++ b/flang/test/Semantics/OpenMP/complex.f90
@@ -1,0 +1,13 @@
+! RUN: %flang_fc1 -fopenmp -fsyntax-only %s
+
+! Check that using %re/%im inside 'parallel' doesn't cause syntax errors.
+subroutine test_complex_re_im
+  complex :: cc(4) = (1,2)
+  integer :: i
+
+  !$omp parallel do private(cc)
+    do i = 1, 4
+      print *, cc(i)%re, cc(i)%im
+    end do
+  !$omp end parallel do
+end subroutine

--- a/flang/test/Semantics/OpenMP/present.f90
+++ b/flang/test/Semantics/OpenMP/present.f90
@@ -1,0 +1,9 @@
+! RUN: %flang_fc1 -fopenmp -fsyntax-only %s
+
+! Check that using 'present' inside 'parallel' doesn't cause syntax errors.
+subroutine test_present(opt)
+  integer, optional :: opt
+  !$omp parallel
+    if (present(opt)) print *, "present"
+  !$omp end parallel
+end subroutine


### PR DESCRIPTION
PR #101009 exposed a semantic check issue with OPTIONAL dummy
arguments.
Another issue occurred when using %{re,im,len,kind}, as these also
need to be skipped when handling variables with implicitly defined
DSAs.

These issues were found by Fujitsu testsuite.
