### PR TITLE
[libclang/python] Fix `get_exception_specification_kind`

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2654,7 +2654,7 @@ class Type(Structure):
         the ExceptionSpecificationKind enumeration.
         """
         return ExceptionSpecificationKind.from_id(
-            conf.lib.clang.getExceptionSpecificationType(self)
+            conf.lib.clang_getExceptionSpecificationType(self)
         )
 
     @property

--- a/clang/bindings/python/tests/cindex/test_exception_specification_kind.py
+++ b/clang/bindings/python/tests/cindex/test_exception_specification_kind.py
@@ -13,7 +13,7 @@ import unittest
 
 def find_function_declarations(node, declarations=[]):
     if node.kind == clang.cindex.CursorKind.FUNCTION_DECL:
-        declarations.append((node.spelling, node.exception_specification_kind))
+        declarations.append(node)
     for child in node.get_children():
         declarations = find_function_declarations(child, declarations)
     return declarations
@@ -33,4 +33,12 @@ class TestExceptionSpecificationKind(unittest.TestCase):
             ("square2", ExceptionSpecificationKind.BASIC_NOEXCEPT),
             ("square3", ExceptionSpecificationKind.COMPUTED_NOEXCEPT),
         ]
-        self.assertListEqual(declarations, expected)
+        from_cursor = [
+            (node.spelling, node.exception_specification_kind) for node in declarations
+        ]
+        from_type = [
+            (node.spelling, node.type.get_exception_specification_kind())
+            for node in declarations
+        ]
+        self.assertListEqual(from_cursor, expected)
+        self.assertListEqual(from_type, expected)

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -299,6 +299,7 @@ Sanitizers
 
 Python Binding Changes
 ----------------------
+- Fixed an issue that led to crashes when calling ``Type.get_exception_specification_kind``.
 
 OpenMP Support
 --------------


### PR DESCRIPTION
Fix a bug with `get_exception_specification_kind`. The function did not work before. Also add a test that confirms that it works now.