### PR TITLE
workflows: Re-implement the get-llvm-version action as a composite

### DIFF
--- a/.github/workflows/get-llvm-version/action.yml
+++ b/.github/workflows/get-llvm-version/action.yml
@@ -22,5 +22,5 @@ runs:
       id: version
       run: |
         for v in major minor patch; do
-          echo echo "$v=`llvm/utils/release/get-llvm-version.sh -$v`" >> $GITHUB_OUTPUT
+          echo "$v=`llvm/utils/release/get-llvm-version.sh --$v`" >> $GITHUB_OUTPUT
         done

--- a/.github/workflows/get-llvm-version/action.yml
+++ b/.github/workflows/get-llvm-version/action.yml
@@ -1,0 +1,26 @@
+name: Get LLVM Version
+description: >-
+  Get the LLVM version from the llvm-project source tree.  This action assumes
+  the llvm-project sources have already been checked out into GITHUB_WORKSPACE.
+
+outputs:
+  major:
+    description: LLVM major version
+    value: ${{ steps.version.outputs.major }}
+  minor:
+    description: LLVM minor version
+    value: ${{ steps.version.outputs.minor }}
+  patch:
+    description: LLVM patch version
+    value: ${{ steps.version.outputs.patch }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Version
+      shell: bash
+      id: version
+      run: |
+        for v in major minor patch; do
+          echo echo "$v=`llvm/utils/release/get-llvm-version.sh -$v`" >> $GITHUB_OUTPUT
+        done

--- a/.github/workflows/libclang-abi-tests.yml
+++ b/.github/workflows/libclang-abi-tests.yml
@@ -33,9 +33,9 @@ jobs:
       ABI_HEADERS: ${{ steps.vars.outputs.ABI_HEADERS }}
       ABI_LIBS: ${{ steps.vars.outputs.ABI_LIBS }}
       BASELINE_VERSION_MAJOR: ${{ steps.vars.outputs.BASELINE_VERSION_MAJOR }}
-      LLVM_VERSION_MAJOR: ${{ steps.version.outputs.LLVM_VERSION_MAJOR }}
-      LLVM_VERSION_MINOR: ${{ steps.version.outputs.LLVM_VERSION_MINOR }}
-      LLVM_VERSION_PATCH: ${{ steps.version.outputs.LLVM_VERSION_PATCH }}
+      LLVM_VERSION_MAJOR: ${{ steps.version.outputs.major }}
+      LLVM_VERSION_MINOR: ${{ steps.version.outputs.minor }}
+      LLVM_VERSION_PATCH: ${{ steps.version.outputs.patch }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -44,14 +44,14 @@ jobs:
 
       - name: Get LLVM version
         id: version
-        uses: llvm/actions/get-llvm-version@main
+        uses: ./.github/workflows/get-llvm-version
 
       - name: Setup Variables
         id: vars
         run: |
           remote_repo='https://github.com/llvm/llvm-project'
-          if [ ${{ steps.version.outputs.LLVM_VERSION_PATCH }} -eq 0 ]; then
-            major_version=$(( ${{ steps.version.outputs.LLVM_VERSION_MAJOR }} - 1))
+          if [ ${{ steps.version.outputs.patch }} -eq 0 ]; then
+            major_version=$(( ${{ steps.version.outputs.major }} - 1))
             baseline_ref="llvmorg-$major_version.1.0"
 
             # If there is a minor release, we want to use that as the base line.
@@ -73,8 +73,8 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           else
             {
-              echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.LLVM_VERSION_MAJOR }}"
-              echo "BASELINE_REF=llvmorg-${{ steps.version.outputs.LLVM_VERSION_MAJOR }}.1.0"
+              echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.major }}"
+              echo "BASELINE_REF=llvmorg-${{ steps.version.outputs.major }}.1.0"
               echo "ABI_HEADERS=."
               echo "ABI_LIBS=libclang.so libclang-cpp.so"
             } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -43,9 +43,9 @@ jobs:
       ABI_HEADERS: ${{ steps.vars.outputs.ABI_HEADERS }}
       BASELINE_VERSION_MAJOR: ${{ steps.vars.outputs.BASELINE_VERSION_MAJOR }}
       BASELINE_VERSION_MINOR: ${{ steps.vars.outputs.BASELINE_VERSION_MINOR }}
-      LLVM_VERSION_MAJOR: ${{ steps.version.outputs.LLVM_VERSION_MAJOR }}
-      LLVM_VERSION_MINOR: ${{ steps.version.outputs.LLVM_VERSION_MINOR }}
-      LLVM_VERSION_PATCH: ${{ steps.version.outputs.LLVM_VERSION_PATCH }}
+      LLVM_VERSION_MAJOR: ${{ steps.version.outputs.major }}
+      LLVM_VERSION_MINOR: ${{ steps.version.outputs.minor }}
+      LLVM_VERSION_PATCH: ${{ steps.version.outputs.patch }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get LLVM version
         id: version
-        uses: llvm/actions/get-llvm-version@main
+        uses: ./.github/workflows/get-llvm-version
 
       - name: Setup Variables
         id: vars
@@ -66,14 +66,14 @@ jobs:
           # 18.1.0 We want to check 17.0.x
           # 18.1.1 We want to check 18.1.0
           echo "BASELINE_VERSION_MINOR=1" >> "$GITHUB_OUTPUT"
-          if [ ${{ steps.version.outputs.LLVM_VERSION_PATCH }} -eq 0 ]; then
+          if [ ${{ steps.version.outputs.patch }} -eq 0 ]; then
             {
-              echo "BASELINE_VERSION_MAJOR=$(( ${{ steps.version.outputs.LLVM_VERSION_MAJOR }} - 1))"
+              echo "BASELINE_VERSION_MAJOR=$(( ${{ steps.version.outputs.major }} - 1))"
               echo "ABI_HEADERS=llvm-c"
             } >> "$GITHUB_OUTPUT"
           else
             {
-              echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.LLVM_VERSION_MAJOR }}"
+              echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.major }}"
               echo "ABI_HEADERS=."
             } >> "$GITHUB_OUTPUT"
           fi

--- a/llvm/utils/release/get-llvm-version.sh
+++ b/llvm/utils/release/get-llvm-version.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#===-- get-llvm-version.sh - Test the LLVM release candidates --------------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+#
+# Extract the current LLVM version from the CMake files. 
+#
+#===------------------------------------------------------------------------===#
+
+cmake_file=$(dirname $0)/../../../cmake/Modules/LLVMVersion.cmake
+function usage() {
+    echo "usage: `basename $0`"
+    echo ""
+    echo "Calling this script with now options will output the full version: e.g. 19.1.0"
+    echo " --cmake-file      Path to cmake file with the version (default: $cmake_file)
+    echo " You can use at most one of the following options:
+    echo " --major           Print the major version."
+    echo " --minor           Print the minor version."
+    echo " --patch           Print the patch version."
+}
+
+print=""
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        --cmake-file )
+            shift
+    	    cmake_file="$1"
+    	    ;;
+        --major)
+            if [ -n "$print" ]; then
+                echo "Only one of --major, --minor, --patch is allowed"
+                exit 1
+            fi
+            print="major"
+            ;;
+        --minor)
+            if [ -n "$print" ]; then
+                echo "Only one of --major, --minor, --patch is allowed"
+                exit 1
+            fi
+            print="minor"
+            ;;
+        --patch)
+            if [ -n "$print" ]; then
+                echo "Only one of --major, --minor, --patch is allowed"
+                exit 1
+            fi
+            print="patch"
+            ;;
+        --help | -h | -\? )
+            usage
+            exit 0
+            ;;
+        * )
+            echo "unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+major=`grep -o 'LLVM_VERSION_MAJOR[[:space:]]\+\([0-9]\+\)' $cmake_file  | grep -o '[0-9]\+'`
+minor=`grep -o 'LLVM_VERSION_MINOR[[:space:]]\+\([0-9]\+\)' $cmake_file  | grep -o '[0-9]\+'`
+patch=`grep -o 'LLVM_VERSION_PATCH[[:space:]]\+\([0-9]\+\)' $cmake_file  | grep -o '[0-9]\+'`
+
+case $print in
+    major)
+        echo "$major"
+        ;;
+    minor)
+        echo "$minor"
+        ;;
+    patch)
+        echo "$patch"
+        ;;
+    *)
+        echo "$major.$minor.$patch"
+        ;;
+esac
+


### PR DESCRIPTION
The old version in the llvm/actions repo stopped working after the version variables were moved out of llvm/CMakeLists.txt.  Composite actions are more simple and don't require javascript, which is why I reimplemented it as a composite action.