### PR TITLE
Add __size_returning_new variant detection to TLI.

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.def
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.def
@@ -356,6 +356,32 @@ TLI_DEFINE_ENUM_INTERNAL(ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t)
 TLI_DEFINE_STRING_INTERNAL("_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t")
 TLI_DEFINE_SIG_INTERNAL(Ptr, Long, Long, Ptr, Bool)
 
+/// The following are variants of operator new which return the actual size
+/// reserved by the allocator proposed in P0901R5 (Size feedback in operator new).
+/// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0901r5.html
+/// They are implemented by tcmalloc, see source at
+/// https://github.com/google/tcmalloc/blob/master/tcmalloc/malloc_extension.h
+
+/// __sized_ptr_t __size_returning_new(size_t size)
+TLI_DEFINE_ENUM_INTERNAL(size_returning_new)
+TLI_DEFINE_STRING_INTERNAL("__size_returning_new")
+TLI_DEFINE_SIG_INTERNAL(Struct, Long)
+
+/// __sized_ptr_t __size_returning_new_hot_cold(size_t, __hot_cold_t)
+TLI_DEFINE_ENUM_INTERNAL(size_returning_new_hot_cold)
+TLI_DEFINE_STRING_INTERNAL("__size_returning_new_hot_cold")
+TLI_DEFINE_SIG_INTERNAL(Struct, Long, Bool)
+
+/// __sized_ptr_t __size_returning_new_aligned(size_t, std::align_val_t)
+TLI_DEFINE_ENUM_INTERNAL(size_returning_new_aligned)
+TLI_DEFINE_STRING_INTERNAL("__size_returning_new_aligned")
+TLI_DEFINE_SIG_INTERNAL(Struct, Long, Long)
+
+/// __sized_ptr_t __size_returning_new_aligned(size_t, std::align_val_t, __hot_cold_t)
+TLI_DEFINE_ENUM_INTERNAL(size_returning_new_aligned_hot_cold)
+TLI_DEFINE_STRING_INTERNAL("__size_returning_new_aligned_hot_cold")
+TLI_DEFINE_SIG_INTERNAL(Struct, Long, Long, Bool)
+
 /// double __acos_finite(double x);
 TLI_DEFINE_ENUM_INTERNAL(acos_finite)
 TLI_DEFINE_STRING_INTERNAL("__acos_finite")

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -512,6 +512,10 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setUnavailable(LibFunc_Znam12__hot_cold_t);
     TLI.setUnavailable(LibFunc_ZnamSt11align_val_t12__hot_cold_t);
     TLI.setUnavailable(LibFunc_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t);
+    TLI.setUnavailable(LibFunc_size_returning_new);
+    TLI.setUnavailable(LibFunc_size_returning_new_hot_cold);
+    TLI.setUnavailable(LibFunc_size_returning_new_aligned);
+    TLI.setUnavailable(LibFunc_size_returning_new_aligned_hot_cold);
   } else {
     // Not MSVC, assume it's Itanium.
     TLI.setUnavailable(LibFunc_msvc_new_int);

--- a/llvm/test/tools/llvm-tli-checker/ps4-tli-check.yaml
+++ b/llvm/test/tools/llvm-tli-checker/ps4-tli-check.yaml
@@ -32,14 +32,15 @@
 # RUN: FileCheck %s --check-prefix=AVAIL --input-file %t3.txt
 # RUN: FileCheck %s --check-prefix=UNAVAIL --input-file %t3.txt
 #
-# CHECK: << Total TLI yes SDK no:  8
+# CHECK: << Total TLI yes SDK no:  12
 # CHECK: >> Total TLI no  SDK yes: 0
 # CHECK: == Total TLI yes SDK yes: 248
 #
 # WRONG_DETAIL: << TLI yes SDK no : '_ZdaPv' aka operator delete[](void*)
 # WRONG_DETAIL: >> TLI no  SDK yes: '_ZdaPvj' aka operator delete[](void*, unsigned int)
-# WRONG_DETAIL-COUNT-8: << TLI yes SDK no : {{.*}}__hot_cold_t
-# WRONG_SUMMARY: << Total TLI yes SDK no:  9{{$}}
+# WRONG_DETAIL-COUNT-8: << TLI yes SDK no : '_Zn{{.*}}__hot_cold_t
+# WRONG_DETAIL-COUNT-4: << TLI yes SDK no : '__size_returning_new{{.*}}
+# WRONG_SUMMARY: << Total TLI yes SDK no:  13{{$}}
 # WRONG_SUMMARY: >> Total TLI no  SDK yes: 1{{$}}
 # WRONG_SUMMARY: == Total TLI yes SDK yes: 247
 #
@@ -47,8 +48,8 @@
 ## the exact count first; the two directives should add up to that.
 ## Yes, this means additions to TLI will fail this test, but the argument
 ## to -COUNT can't be an expression.
-# AVAIL: TLI knows 489 symbols, 256 available
-# AVAIL-COUNT-256: {{^}} available
+# AVAIL: TLI knows 493 symbols, 260 available
+# AVAIL-COUNT-260: {{^}} available
 # AVAIL-NOT:       {{^}} available
 # UNAVAIL-COUNT-233: not available
 # UNAVAIL-NOT:       not available

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -472,6 +472,10 @@ TEST_F(TargetLibraryInfoTest, ValidProto) {
       "declare i8* @_ZnwmSt11align_val_tRKSt9nothrow_t(i64, i64, %struct*)\n"
       "declare i8* @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64, i64, "
       "%struct*, i8)\n"
+      "declare %struct @__size_returning_new(i64)\n"
+      "declare %struct @__size_returning_new_hot_cold(i64, i8)\n"
+      "declare %struct @__size_returning_new_aligned(i64, i64)\n"
+      "declare %struct @__size_returning_new_aligned_hot_cold(i64, i64, i8)\n"
 
       "declare void @\"??3@YAXPEAX@Z\"(i8*)\n"
       "declare void @\"??3@YAXPEAXAEBUnothrow_t@std@@@Z\"(i8*, %struct*)\n"


### PR DESCRIPTION
Add support to detect __size_returning_new variants defined inproposal P0901R5 to extend to operator new, see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0901r5.html for details.

This PR matches the declarations exported by tcmalloc in https://github.com/google/tcmalloc/blob/f2516691d01051defc558679f37720bba88d9862/tcmalloc/malloc_extension.h#L707-L711