### PR TITLE
[RISCV][GISel] Don't custom legalize load/store of vector of pointers if ELEN < XLEN.

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
@@ -330,9 +330,11 @@ RISCVLegalizerInfo::RISCVLegalizerInfo(const RISCVSubtarget &ST)
 
     // we will take the custom lowering logic if we have scalable vector types
     // with non-standard alignments
-    LoadStoreActions.customIf(
-          LegalityPredicates::any(typeIsLegalIntOrFPVec(0, IntOrFPVecTys, ST),
-                                  typeIsLegalPtrVec(0, PtrVecTys, ST)));
+    LoadStoreActions.customIf(typeIsLegalIntOrFPVec(0, IntOrFPVecTys, ST));
+
+    // Pointers require that XLen sized elements are legal.
+    if (XLen <= ST.getELen())
+      LoadStoreActions.customIf(typeIsLegalPtrVec(0, PtrVecTys, ST));
   }
 
   LoadStoreActions.widenScalarToNextPow2(0, /* MinSize = */ 8)


### PR DESCRIPTION
We need to have elements than can hold a pointer sized element.
    
No test because it crashes in LowerLoad or LowerStore now which
needs to be addressed separately.

I also reordered things so all the vector load/store stuff is together.