### PR TITLE
Workflows: Add composite actions for managing sccache caches for a PR

### DIFF
--- a/.github/workflows/pr-sccache-restore/action.yml
+++ b/.github/workflows/pr-sccache-restore/action.yml
@@ -1,0 +1,26 @@
+name: PR sccache restore
+
+inputs:
+  artifact-name-suffix:
+    desciption: The suffix to append to the artifict name (sccache-pr#)
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/workflows/unprivileged-download-artifact
+      id: download-artifact
+      with:
+        artifact-name: sccache-pr${{ github.event.pull_request.number }}-${{ inputs.artifact-name-suffix }}
+
+    - shell: bash
+      if: steps.download-artifact.outputs.filename != ''
+      run: |
+        # Is this the best way to clear the cache?
+        rm -Rf .sccache/
+        unzip ${{ steps.download-artifact.outputs.filename }}
+        rm ${{ steps.download-artifact.outputs.filename }}
+        tar --zstd -xf sccache.tar.zst
+        rm sccache.tar.zst
+        ls -altr
+

--- a/.github/workflows/pr-sccache-save/action.yml
+++ b/.github/workflows/pr-sccache-save/action.yml
@@ -1,0 +1,27 @@
+name: PR sccache save
+inputs:
+  artifact-name-suffix:
+    desciption: The suffix to append to the artifict name (sccache-pr#)
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Package sccache Directory
+      shell: bash
+      run: |
+        # Dereference symlinks so that this works on Windows.
+        tar -h -c .sccache | zstd -T0 -c > sccache.tar.zst
+
+    - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: 'sccache-pr${{ github.event.number }}-${{ inputs.artifact-name-suffix }}'
+        path: sccache.tar.zst
+        retention-days: 7
+        overwrite: true
+
+    - shell: bash
+      run: |
+        rm sccache.tar.zst
+        sccache --show-stats
+


### PR DESCRIPTION
These actions allow you to create and reusue an sccache cache that is unique to a PR.  This way each time you update a PR you will be able to resuse the sccache cache from the previous PR build.  This will help increase the cache hit rate vs trying to use a global cache that is share amongst several PRs.