### PR TITLE
[clang] Fixing Clang HIP inconsistent order for template functions

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -34,6 +34,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -1193,7 +1194,7 @@ public:
 
   /// Keep track of CUDA/HIP external kernels or device variables ODR-used by
   /// host code.
-  llvm::DenseSet<const ValueDecl *> CUDAExternalDeviceDeclODRUsedByHost;
+  llvm::SetVector<const ValueDecl *> CUDAExternalDeviceDeclODRUsedByHost;
 
   /// Keep track of CUDA/HIP implicit host device functions used on device side
   /// in device compilation.

--- a/clang/test/CodeGenHIP/hip-checksum.cpp
+++ b/clang/test/CodeGenHIP/hip-checksum.cpp
@@ -1,0 +1,27 @@
+// RUN: x=$(%clang_cc1 -x hip -triple amdgcn -target-cpu gfx908 -emit-llvm -fcuda-is-device %s -o - | md5sum | awk '{ print $1 }') && echo $x
+// RUN: y1=$(%clang_cc1 -x hip -triple amdgcn -target-cpu gfx908 -emit-llvm -fcuda-is-device %s -o - | md5sum | awk '{ print $1 }') && echo $y1 >> %t.md5
+// RUN: y2=$(%clang_cc1 -x hip -triple amdgcn -target-cpu gfx908 -emit-llvm -fcuda-is-device %s -o - | md5sum | awk '{ print $1 }') && echo $y2 >> %t.md5
+// RUN: y3=$(%clang_cc1 -x hip -triple amdgcn -target-cpu gfx908 -emit-llvm -fcuda-is-device %s -o - | md5sum | awk '{ print $1 }') && echo $y3 >> %t.md5
+// RUN: y4=$(%clang_cc1 -x hip -triple amdgcn -target-cpu gfx908 -emit-llvm -fcuda-is-device %s -o - | md5sum | awk '{ print $1 }') && echo $y4 >> %t.md5
+// RUN: y5=$(%clang_cc1 -x hip -triple amdgcn -target-cpu gfx908 -emit-llvm -fcuda-is-device %s -o - | md5sum | awk '{ print $1 }') && echo $y5 >> %t.md5
+// RUN: if grep -qv "$x" %t.md5; then echo "Test failed"; else echo "Test passed"; fi
+// CHECK: Test passed
+// CHECK-NOT: Test failed
+
+#include "../CodeGenCUDA/Inputs/cuda.h"
+
+template<int i>
+__attribute__((global)) void kernel() {
+  printf("Hello from kernel %d\n", i);
+}
+
+template __attribute__((global)) void kernel<1>();
+template __attribute__((global)) void kernel<2>();
+template __attribute__((global)) void kernel<3>();
+
+int main(int argc, char* argv[]) {
+    hipLaunchKernel(reinterpret_cast<void*>(kernel<1>), dim3(1), dim3(1),nullptr, 0, 0);
+    hipLaunchKernel(reinterpret_cast<void*>(kernel<2>), dim3(1), dim3(1),nullptr, 0, 0);
+    hipLaunchKernel(reinterpret_cast<void*>(kernel<3>), dim3(1), dim3(1),nullptr, 0, 0);
+}
+


### PR DESCRIPTION
Fixing the issue - [#101458 ](https://github.com/llvm/llvm-project/issues/101458)
As mentioned in the issue, the order of the functions in the asm output from clang is non-deterministic. Here is the reproducer:

```
#include "hip/hip_runtime.h"
 
#define CHECK(cmd)                                                                                \
   {                                                                                             \
       hipError_t error = cmd;                                                                   \
       if (error != hipSuccess) {                                                                \
           fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error,        \
                   __FILE__, __LINE__);                                                          \
           exit(EXIT_FAILURE);                                                                   \
       }                                                                                         \
   }
 
template<int i>
__global__ void kernel() {
 printf("Hello from kernel %d\n", i);
}
 
template __global__ void kernel<1>();
template __global__ void kernel<2>();
template __global__ void kernel<3>();
 
int main(int argc, char* argv[]) {
   hipLaunchKernelGGL(kernel<1>, dim3(1), dim3(1), 0, 0);
   CHECK(hipDeviceSynchronize());
   hipLaunchKernelGGL(kernel<2>, dim3(1), dim3(1), 0, 0);
   CHECK(hipDeviceSynchronize());
   hipLaunchKernelGGL(kernel<3>, dim3(1), dim3(1), 0, 0);
   CHECK(hipDeviceSynchronize());
}
```
```
for i in $(seq 5); do
 clang -x hip --offload-arch=gfx908 -save-temps -fgpu-rdc -Ofast test_hip.cpp
 md5sum test_hip-hip-amdgcn-amd-amdhsa-gfx908.bc
 llvm-dis test_hip-hip-amdgcn-amd-amdhsa-gfx908.bc
 cp test_hip-hip-amdgcn-amd-amdhsa-gfx908.ll test_hip-hip-amdgcn-amd-amdhsa-gfx908.$i.ll
done
75be8654e3a6c39e1e83f5c8b7dda364 test_hip-hip-amdgcn-amd-amdhsa-gfx908.bc
bde823a75c56e9af933be309d8e433f3 test_hip-hip-amdgcn-amd-amdhsa-gfx908.bc
e18bbc2e4768556c52864c716cba9c02 test_hip-hip-amdgcn-amd-amdhsa-gfx908.bc
e18bbc2e4768556c52864c716cba9c02 test_hip-hip-amdgcn-amd-amdhsa-gfx908.bc
75be8654e3a6c39e1e83f5c8b7dda364 test_hip-hip-amdgcn-amd-amdhsa-gfx908.bc
```

The order of functions referenced in `__clang_gpu_used_external` changes each time:
 
```
diff --git a/test_hip-hip-amdgcn-amd-amdhsa-gfx908.1.ll b/test_hip-hip-amdgcn-amd-amdhsa-gfx908.2.ll
index 91c0453..abd2b01 100644
--- a/test_hip-hip-amdgcn-amd-amdhsa-gfx908.1.ll
+++ b/test_hip-hip-amdgcn-amd-amdhsa-gfx908.2.ll
@@ -17,7 +17,7 @@ $_Z6kernelILi2EEvv = comdat any
 $_Z6kernelILi3EEvv = comdat any
 
 @.str = private unnamed_addr addrspace(4) constant [22 x i8] c"Hello from kernel %d\0A\00", align 1
-@__clang_gpu_used_external = internal addrspace(1) global [3 x ptr] [ptr @_Z6kernelILi1EEvv, ptr @_Z6kernelILi2EEvv, ptr @_Z6kernelILi3EEvv]
+@__clang_gpu_used_external = internal addrspace(1) global [3 x ptr] [ptr @_Z6kernelILi2EEvv, ptr @_Z6kernelILi3EEvv, ptr @_Z6kernelILi1EEvv]
 @__oclc_ABI_version = weak_odr hidden local_unnamed_addr addrspace(4) constant i32 500
 @llvm.compiler.used = appending addrspace(1) global [1 x ptr] [ptr addrspacecast (ptr addrspace(1) @__clang_gpu_used_external to ptr)], section "llvm.metadata"
```
 
The order is determined by the order the functions are stored in the `DenseSet` `CUDAExternalDeviceDeclODRUsedByHost `(which is non-deterministic). Hence changing `CUDAExternalDeviceDeclODRUsedByHost` from `llvm::DenseSet` to `llvm::SetVector` for a deterministic behaviour.