### PR TITLE
[clang][dataflow] Fix casting in `ChromiumCheckModel`.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Models/ChromiumCheckModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/ChromiumCheckModel.cpp
@@ -56,7 +56,7 @@ bool ChromiumCheckModel::transfer(const CFGElement &Element, Environment &Env) {
     return false;
   auto Stmt = CS->getStmt();
   if (const auto *Call = dyn_cast<CallExpr>(Stmt)) {
-    if (const auto *M = dyn_cast<CXXMethodDecl>(Call->getDirectCallee())) {
+    if (const auto *M = dyn_cast_or_null<CXXMethodDecl>(Call->getDirectCallee())) {
       if (isCheckLikeMethod(CheckDecls, *M)) {
         // Mark this branch as unreachable.
         Env.assume(Env.arena().makeLiteral(false));

--- a/clang/lib/Analysis/FlowSensitive/Models/ChromiumCheckModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/ChromiumCheckModel.cpp
@@ -56,7 +56,8 @@ bool ChromiumCheckModel::transfer(const CFGElement &Element, Environment &Env) {
     return false;
   auto Stmt = CS->getStmt();
   if (const auto *Call = dyn_cast<CallExpr>(Stmt)) {
-    if (const auto *M = dyn_cast_or_null<CXXMethodDecl>(Call->getDirectCallee())) {
+    if (const auto *M =
+            dyn_cast_or_null<CXXMethodDecl>(Call->getDirectCallee())) {
       if (isCheckLikeMethod(CheckDecls, *M)) {
         // Mark this branch as unreachable.
         Env.assume(Env.arena().makeLiteral(false));


### PR DESCRIPTION
`getDirectCallee()` may return a null pointer if the callee is not a `FunctionDecl` (for example when using function pointers), this requires to use `dyn_cast_or_null` instead of `dyn_cast`.