### PR TITLE
[RISCV][NFC] Remove unneeded defining name of `vundefined`

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -2407,10 +2407,10 @@ let HasMasked = false, HasVL = false, IRName = "" in {
       ManualCodegen = [{
         return llvm::PoisonValue::get(ResultType);
       }] in {
-    def vundefined : RVVBuiltin<"v", "v", "csilxfd">;
+    def : RVVBuiltin<"v", "v", "csilxfd">;
     let RequiredFeatures = ["Zvfbfmin"] in
-      def vundefined_bf16 : RVVBuiltin<"v", "v", "y">;
-    def vundefined_u : RVVBuiltin<"Uv", "Uv", "csil">;
+      def : RVVBuiltin<"v", "v", "y">;
+    def : RVVBuiltin<"Uv", "Uv", "csil">;
 
     foreach nf = NFList in {
       let NF = nf in {


### PR DESCRIPTION
`vundefined` doesn't have corresponding named IR, instead it generates
`poison` value, we already define the `Name` for C intrinsics, so we
don't need the defining name at all.
