### PR TITLE
[analyzer] Fix crash on using `bitcast(<type>, <array>)` as array subscript

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/Store.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Store.cpp
@@ -476,10 +476,8 @@ SVal StoreManager::getLValueElement(QualType elementType, NonLoc Offset,
   if (!Off) {
     // Handle cases when LazyCompoundVal is used for an array index.
     // Such case is possible if code does:
-    //
     //   char b[4];
     //   a[__builtin_bitcast(int, b)];
-    //
     // Return UnknownVal, since we cannot model it.
     return UnknownVal();
   }

--- a/clang/lib/StaticAnalyzer/Core/Store.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Store.cpp
@@ -472,7 +472,19 @@ SVal StoreManager::getLValueElement(QualType elementType, NonLoc Offset,
   const auto *ElemR = dyn_cast<ElementRegion>(BaseRegion);
 
   // Convert the offset to the appropriate size and signedness.
-  Offset = svalBuilder.convertToArrayIndex(Offset).castAs<NonLoc>();
+  auto Off = svalBuilder.convertToArrayIndex(Offset).getAs<NonLoc>();
+  if (!Off) {
+    // Handle cases when LazyCompoundVal is used for an array index.
+    // Such case is possible if code does:
+    //
+    //   char b[4];
+    //   a[__builtin_bitcast(int, b)];
+    //
+    // Return UnknownVal, since we cannot model it.
+    return UnknownVal();
+  }
+
+  Offset = Off.value();
 
   if (!ElemR) {
     // If the base region is not an ElementRegion, create one.

--- a/clang/test/Analysis/exercise-ps.c
+++ b/clang/test/Analysis/exercise-ps.c
@@ -6,6 +6,8 @@
 // Just exercise the analyzer on code that has at one point caused issues
 // (i.e., no assertions or crashes).
 
+void clang_analyzer_dump_int(int);
+
 static void f1(const char *x, char *y) {
   while (*x != 0) {
     *y++ = *x++;
@@ -38,6 +40,9 @@ void f4(char *array) {
   char b[4] = {0};
 
   _Static_assert(sizeof(int) == 4, "Wrong triple for the test");
+
+  clang_analyzer_dump_int(__builtin_bit_cast(int, b)); // expected-warning {{lazyCompoundVal}}
+  clang_analyzer_dump_int(array[__builtin_bit_cast(int, b)]); // expected-warning {{Unknown}}
 
   array[__builtin_bit_cast(int, b)] = 0x10; // no crash
 }

--- a/clang/test/Analysis/exercise-ps.c
+++ b/clang/test/Analysis/exercise-ps.c
@@ -1,5 +1,6 @@
-// RUN: %clang_analyze_cc1 %s -verify -Wno-error=implicit-function-declaration \
-// RUN:   -analyzer-checker=core,unix.Malloc \
+// RUN: %clang_analyze_cc1 %s -triple=x86_64-unknown-linux \
+// RUN:   -verify -Wno-error=implicit-function-declaration \
+// RUN:   -analyzer-checker=core,unix.Malloc,debug.ExprInspection \
 // RUN:   -analyzer-config core.CallAndMessage:ArgPointeeInitializedness=true
 //
 // Just exercise the analyzer on code that has at one point caused issues
@@ -35,5 +36,8 @@ void f3(void *dest) {
 // and should just assume it's unknown and do not crash.
 void f4(char *array) {
   char b[4] = {0};
+
+  _Static_assert(sizeof(int) == 4, "Wrong triple for the test");
+
   array[__builtin_bit_cast(int, b)] = 0x10; // no crash
 }

--- a/clang/test/Analysis/exercise-ps.c
+++ b/clang/test/Analysis/exercise-ps.c
@@ -30,3 +30,10 @@ void f3(void *dest) {
   void *src = __builtin_alloca(5);
   memcpy(dest, src, 1); // expected-warning{{2nd function call argument is a pointer to uninitialized value}}
 }
+
+// Reproduce crash from GH#94496. When array is used as subcript to another array, CSA cannot model it
+// and should just assume it's unknown and do not crash.
+void f4(char *array) {
+  char b[4] = {0};
+  array[__builtin_bit_cast(int, b)] = 0x10; // no crash
+}


### PR DESCRIPTION
Current CSA logic does not expect `LazyCompoundValKind`  as array index. This may happen if array is used as subscript to another, in case of bitcast to integer type.

Catch such cases and return `UnknownVal`, since CSA cannot model array ->
int casts.

Closes #94496 
