### PR TITLE
[StructuralHashPrinter] Always print 16-digit hash

### DIFF
--- a/llvm/lib/Analysis/StructuralHash.cpp
+++ b/llvm/lib/Analysis/StructuralHash.cpp
@@ -14,20 +14,20 @@
 #include "llvm/Analysis/StructuralHash.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/StructuralHash.h"
-#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Format.h"
 
 using namespace llvm;
 
 PreservedAnalyses StructuralHashPrinterPass::run(Module &M,
                                                  ModuleAnalysisManager &MAM) {
   OS << "Module Hash: "
-     << Twine::utohexstr(StructuralHash(M, EnableDetailedStructuralHash))
+     << format("%016" PRIx64, StructuralHash(M, EnableDetailedStructuralHash))
      << "\n";
   for (Function &F : M) {
     if (F.isDeclaration())
       continue;
     OS << "Function " << F.getName() << " Hash: "
-       << Twine::utohexstr(StructuralHash(F, EnableDetailedStructuralHash))
+       << format("%016" PRIx64, StructuralHash(F, EnableDetailedStructuralHash))
        << "\n";
   }
   return PreservedAnalyses::all();

--- a/llvm/test/Analysis/StructuralHash/structural-hash-printer.ll
+++ b/llvm/test/Analysis/StructuralHash/structural-hash-printer.ll
@@ -14,12 +14,11 @@ define i32 @f2(i32 %a) {
 	ret i32 %b
 }
 
-; CHECK: Module Hash: {{([a-z0-9]{14,})}}
-; CHECK-NEXT: Function f1 Hash: [[F1H:([a-z0-9]{14,})]]
+; CHECK: Module Hash: {{([a-f0-9]{16,})}}
+; CHECK-NEXT: Function f1 Hash: [[F1H:([a-f0-9]{16,})]]
 ; CHECK-NEXT: Function f2 Hash: [[F1H]]
 
-; DETAILED-HASH: Module Hash: {{([a-z0-9]{14,})}}
-; DETAILED-HASH-NEXT: Function f1 Hash: [[DF1H:([a-z0-9]{14,})]]
+; DETAILED-HASH: Module Hash: {{([a-f0-9]{16,})}}
+; DETAILED-HASH-NEXT: Function f1 Hash: [[DF1H:([a-f0-9]{16,})]]
 ; DETAILED-HASH-NOT: [[DF1H]]
-; DETAILED-HASH-NEXT: Function f2 Hash: {{([a-z0-9]{14,})}}
-
+; DETAILED-HASH-NEXT: Function f2 Hash: {{([a-f0-9]{16,})}}


### PR DESCRIPTION
The hash may contain less than 14 significant digits, which caused the test to fail.