### PR TITLE
[llvm][SandboxIR] Fix some clang-cl warnings on Windows

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1429,7 +1429,7 @@ class CastInst : public UnaryInstruction {
   CastInst(llvm::CastInst *CI, Context &Ctx)
       : UnaryInstruction(ClassID::Cast, getCastOpcode(CI->getOpcode()), CI,
                          Ctx) {}
-  friend Context;        // for SBCastInstruction()
+  friend Context; // for SBCastInstruction()
   Use getOperandUseInternal(unsigned OpIdx, bool Verify) const final {
     return getOperandUseDefault(OpIdx, Verify);
   }

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1430,7 +1430,6 @@ class CastInst : public UnaryInstruction {
       : UnaryInstruction(ClassID::Cast, getCastOpcode(CI->getOpcode()), CI,
                          Ctx) {}
   friend Context;        // for SBCastInstruction()
-  friend class PtrToInt; // For constructor.
   Use getOperandUseInternal(unsigned OpIdx, bool Verify) const final {
     return getOperandUseDefault(OpIdx, Verify);
   }

--- a/llvm/include/llvm/SandboxIR/Use.h
+++ b/llvm/include/llvm/SandboxIR/Use.h
@@ -22,6 +22,7 @@ class Context;
 class Value;
 class User;
 class CallBase;
+class CallBrInst;
 class PHINode;
 
 /// Represents a Def-use/Use-def edge in SandboxIR.


### PR DESCRIPTION
```
[4958/6355] Building CXX object lib\SandboxIR\CMakeFiles\LLVMSandboxIR.dir\Tracker.cpp.obj In file included from C:\Work\david.spickett\llvm-project\llvm\lib\SandboxIR\Tracker.cpp:9: In file included from C:\Work\david.spickett\llvm-project\llvm\include\llvm/SandboxIR/Tracker.h:48: C:\Work\david.spickett\llvm-project\llvm\include\llvm/SandboxIR/Use.h(46,16): warning: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier [-Wmicrosoft-unqualified-friend]
   46 |   friend class CallBrInst;         // For constructor
      |                ^
      |                ::llvm::
In file included from C:\Work\david.spickett\llvm-project\llvm\lib\SandboxIR\Tracker.cpp:13:
C:\Work\david.spickett\llvm-project\llvm\include\llvm/SandboxIR/SandboxIR.h(1433,16): warning:
unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier [-Wmicrosoft-unqualified-friend]
 1433 |   friend class PtrToInt; // For constructor.
      |                ^
      |                ::llvm::
```

First one I think is a missing forward declaration and I couldn't find the right class for the second one but it appears to be unused anyway.