### PR TITLE
[VP] Provide createAlignedLoad to emit VP load instruction.

### DIFF
--- a/llvm/include/llvm/IR/VectorBuilder.h
+++ b/llvm/include/llvm/IR/VectorBuilder.h
@@ -106,6 +106,13 @@ public:
   Value *createSimpleTargetReduction(Intrinsic::ID RdxID, Type *ValTy,
                                      ArrayRef<Value *> VecOpArray,
                                      const Twine &Name = Twine());
+
+  /// Emit a VP load intrinsic call.
+  /// \param Ty         The return type of the load.
+  /// \param Ptr        The load address.
+  /// \param Alignment  The alignment information of the load.
+  CallInst *createAlignedLoad(Type *Ty, Value *Ptr, Align Alignment,
+                              const Twine &Name = Twine());
 };
 
 } // namespace llvm

--- a/llvm/lib/IR/VectorBuilder.cpp
+++ b/llvm/lib/IR/VectorBuilder.cpp
@@ -70,6 +70,15 @@ Value *VectorBuilder::createSimpleTargetReduction(Intrinsic::ID RdxID,
   return createVectorInstructionImpl(VPID, ValTy, InstOpArray, Name);
 }
 
+CallInst *VectorBuilder::createAlignedLoad(Type *Ty, Value *Ptr,
+                                           Align Alignment, const Twine &Name) {
+  auto VPLI =
+      cast<CallInst>(createVectorInstruction(Instruction::Load, Ty, Ptr, Name));
+  VPLI->addParamAttr(
+      0, Attribute::getWithAlignment(VPLI->getContext(), Alignment));
+  return VPLI;
+}
+
 Value *VectorBuilder::createVectorInstructionImpl(Intrinsic::ID VPID,
                                                   Type *ReturnTy,
                                                   ArrayRef<Value *> InstOpArray,

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -9364,11 +9364,8 @@ void VPWidenLoadEVLRecipe::execute(VPTransformState &State) {
   } else {
     VectorBuilder VBuilder(Builder);
     VBuilder.setEVL(EVL).setMask(Mask);
-    NewLI = cast<CallInst>(VBuilder.createVectorInstruction(
-        Instruction::Load, DataTy, Addr, "vp.op.load"));
+    NewLI = VBuilder.createAlignedLoad(DataTy, Addr, Alignment, "vp.op.load");
   }
-  NewLI->addParamAttr(
-      0, Attribute::getWithAlignment(NewLI->getContext(), Alignment));
   State.addMetadata(NewLI, LI);
   Instruction *Res = NewLI;
   if (isReverse())


### PR DESCRIPTION
This patch Introduces a new method `createAlignedLoad` in VectorBuilder to pack the creation of an aligned load instruction. Additionally, changed `VPWidenLoadEVLRecipe::execute` to use `createAlignedLoad` for simplifying the implementation and improving readability and maintainability.  