### PR TITLE
[libcxxabi][libunwind] Support for using LLVM libc

### DIFF
--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -168,6 +168,12 @@ message(STATUS "Using libc++abi testing configuration: ${LIBCXXABI_TEST_CONFIG}"
 set(LIBCXXABI_TEST_PARAMS "" CACHE STRING
     "A list of parameters to run the Lit test suite with.")
 
+set(LIBCXXABI_SUPPORTED_C_LIBRARIES system llvm-libc)
+set(LIBCXXABI_LIBC "system" CACHE STRING "Specify C library to use. Supported values are ${LIBCXXABI_SUPPORTED_C_LIBRARIES}.")
+if (NOT "${LIBCXXABI_LIBC}" IN_LIST LIBCXXABI_SUPPORTED_C_LIBRARIES)
+  message(FATAL_ERROR "Unsupported C library: '${LIBCXXABI_CXX_ABI}'. Supported values are ${LIBCXXABI_SUPPORTED_C_LIBRARIES}.")
+endif()
+
 #===============================================================================
 # Configure System
 #===============================================================================
@@ -248,6 +254,8 @@ add_library_flags("${LIBCXXABI_ADDITIONAL_LIBRARIES}")
 
 # Configure compiler. Must happen after setting the target flags.
 include(config-ix)
+
+include(HandleLibC) # Setup the C library flags
 
 if (CXX_SUPPORTS_NOSTDINCXX_FLAG)
   list(APPEND LIBCXXABI_COMPILE_FLAGS -nostdinc++)

--- a/libcxxabi/cmake/Modules/HandleLibC.cmake
+++ b/libcxxabi/cmake/Modules/HandleLibC.cmake
@@ -1,0 +1,39 @@
+#===============================================================================
+# Define targets for linking against the selected C library
+#
+# After including this file, the following targets are defined:
+# - libcxxabi-libc-headers: An interface target that allows getting access to the
+#                        headers of the selected C library.
+# - libcxxabi-libc-shared: A target representing the selected shared C library.
+# - libcxxabi-libc-static: A target representing the selected static C library.
+#===============================================================================
+
+# Link against a system-provided libc
+if (LIBCXXABI_LIBC STREQUAL "system")
+  add_library(libcxxabi-libc-headers INTERFACE)
+
+  add_library(libcxxabi-libc-static INTERFACE)
+  add_library(libcxxabi-libc-shared INTERFACE)
+
+# Link against the in-tree LLVM libc
+elseif (LIBCXXABI_LIBC STREQUAL "llvm-libc")
+  add_library(libcxxabi-libc-headers INTERFACE)
+  target_link_libraries(libcxxabi-libc-headers INTERFACE libc-headers)
+  if(CXX_SUPPORTS_NOSTDLIBINC_FLAG)
+    target_compile_options(libcxxabi-libc-headers INTERFACE "-nostdlibinc")
+  endif()
+
+  add_library(libcxxabi-libc-static INTERFACE)
+  if (TARGET libc)
+    target_link_libraries(libcxxabi-libc-static INTERFACE libc)
+  endif()
+  if (TARGET libm)
+    target_link_libraries(libcxxabi-libc-static INTERFACE libm)
+  endif()
+  if (CXX_SUPPORTS_NOLIBC_FLAG)
+    target_link_options(libcxxabi-libc-static INTERFACE "-nolibc")
+  endif()
+
+  # TODO: There's no support for building LLVM libc as a shared library yet.
+  add_library(libcxxabi-libc-shared INTERFACE)
+endif()

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -166,11 +166,12 @@ if (LIBCXXABI_USE_LLVM_UNWINDER)
     target_link_libraries(cxxabi_shared_objects PUBLIC unwind_shared)
   endif()
 endif()
-target_link_libraries(cxxabi_shared_objects PRIVATE cxx-headers ${LIBCXXABI_LIBRARIES})
+target_link_libraries(cxxabi_shared_objects
+  PUBLIC cxxabi-headers
+  PRIVATE cxx-headers libcxxabi-libc-headers ${LIBCXXABI_LIBRARIES})
 if (NOT CXX_SUPPORTS_NOSTDLIBXX_FLAG)
   target_link_libraries(cxxabi_shared_objects PRIVATE ${LIBCXXABI_BUILTINS_LIBRARY})
 endif()
-target_link_libraries(cxxabi_shared_objects PUBLIC cxxabi-headers)
 set_target_properties(cxxabi_shared_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
@@ -205,7 +206,7 @@ if (LIBCXXABI_ENABLE_SHARED)
   endif ()
 
   target_link_libraries(cxxabi_shared
-    PUBLIC cxxabi_shared_objects
+    PUBLIC cxxabi_shared_objects libcxxabi-libc-shared
     PRIVATE ${LIBCXXABI_LIBRARIES})
 
   list(APPEND LIBCXXABI_BUILD_TARGETS "cxxabi_shared")
@@ -253,8 +254,9 @@ if (LIBCXXABI_USE_LLVM_UNWINDER AND LIBCXXABI_STATICALLY_LINK_UNWINDER_IN_STATIC
   target_link_libraries(cxxabi_static_objects PUBLIC unwind_static_objects) # propagate usage requirements
   target_sources(cxxabi_static_objects PUBLIC $<TARGET_OBJECTS:unwind_static_objects>)
 endif()
-target_link_libraries(cxxabi_static_objects PRIVATE cxx-headers ${LIBCXXABI_STATIC_LIBRARIES} ${LIBCXXABI_LIBRARIES})
-target_link_libraries(cxxabi_static_objects PUBLIC cxxabi-headers)
+target_link_libraries(cxxabi_static_objects
+  PUBLIC cxxabi-headers
+  PRIVATE cxx-headers libcxxabi-libc-headers ${LIBCXXABI_STATIC_LIBRARIES} ${LIBCXXABI_LIBRARIES})
 set_target_properties(cxxabi_static_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
@@ -287,7 +289,7 @@ endif()
 if (LIBCXXABI_ENABLE_STATIC)
   add_library(cxxabi_static STATIC)
   if (LIBCXXABI_USE_LLVM_UNWINDER AND NOT LIBCXXABI_STATICALLY_LINK_UNWINDER_IN_STATIC_LIBRARY)
-    target_link_libraries(cxxabi_static PUBLIC unwind_static)
+    target_link_libraries(cxxabi_static PUBLIC unwind_static libcxxabi-libc-static)
   endif()
   set_target_properties(cxxabi_static
     PROPERTIES

--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -82,6 +82,12 @@ message(STATUS "Using libunwind testing configuration: ${LIBUNWIND_TEST_CONFIG}"
 set(LIBUNWIND_TEST_PARAMS "" CACHE STRING
     "A list of parameters to run the Lit test suite with.")
 
+set(LIBUNWIND_SUPPORTED_C_LIBRARIES system llvm-libc)
+set(LIBUNWIND_LIBC "system" CACHE STRING "Specify C library to use. Supported values are ${LIBUNWIND_SUPPORTED_C_LIBRARIES}.")
+if (NOT "${LIBUNWIND_LIBC}" IN_LIST LIBUNWIND_SUPPORTED_C_LIBRARIES)
+  message(FATAL_ERROR "Unsupported C library: '${LIBUNWIND_CXX_ABI}'. Supported values are ${LIBUNWIND_SUPPORTED_C_LIBRARIES}.")
+endif()
+
 if (NOT LIBUNWIND_ENABLE_SHARED AND NOT LIBUNWIND_ENABLE_STATIC)
   message(FATAL_ERROR "libunwind must be built as either a shared or static library.")
 endif()

--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -171,6 +171,8 @@ include(HandleLibunwindFlags)
 # Configure compiler.
 include(config-ix)
 
+include(HandleLibC) # Setup the C library flags
+
 if (LIBUNWIND_USE_COMPILER_RT AND NOT LIBUNWIND_HAS_NODEFAULTLIBS_FLAG)
   list(APPEND LIBUNWIND_LINK_FLAGS "-rtlib=compiler-rt")
 endif()

--- a/libunwind/cmake/Modules/HandleLibC.cmake
+++ b/libunwind/cmake/Modules/HandleLibC.cmake
@@ -1,0 +1,39 @@
+#===============================================================================
+# Define targets for linking against the selected C library
+#
+# After including this file, the following targets are defined:
+# - libunwind-libc-headers: An interface target that allows getting access to the
+#                        headers of the selected C library.
+# - libunwind-libc-shared: A target representing the selected shared C library.
+# - libunwind-libc-static: A target representing the selected static C library.
+#===============================================================================
+
+# Link against a system-provided libc
+if (LIBUNWIND_LIBC STREQUAL "system")
+  add_library(libunwind-libc-headers INTERFACE)
+
+  add_library(libunwind-libc-static INTERFACE)
+  add_library(libunwind-libc-shared INTERFACE)
+
+# Link against the in-tree LLVM libc
+elseif (LIBUNWIND_LIBC STREQUAL "llvm-libc")
+  add_library(libunwind-libc-headers INTERFACE)
+  target_link_libraries(libunwind-libc-headers INTERFACE libc-headers)
+  if(CXX_SUPPORTS_NOSTDLIBINC_FLAG)
+    target_compile_options(libunwind-libc-headers INTERFACE "-nostdlibinc")
+  endif()
+
+  add_library(libunwind-libc-static INTERFACE)
+  if (TARGET libc)
+    target_link_libraries(libunwind-libc-static INTERFACE libc)
+  endif()
+  if (TARGET libm)
+    target_link_libraries(libunwind-libc-static INTERFACE libm)
+  endif()
+  if (CXX_SUPPORTS_NOLIBC_FLAG)
+    target_link_options(libunwind-libc-static INTERFACE "-nolibc")
+  endif()
+
+  # TODO: There's no support for building LLVM libc as a shared library yet.
+  add_library(libunwind-libc-shared INTERFACE)
+endif()

--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -148,9 +148,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL MSVC)
 else()
   target_compile_options(unwind_shared_objects PRIVATE -fno-rtti)
 endif()
-target_link_libraries(unwind_shared_objects PRIVATE unwind-headers ${LIBUNWIND_LIBRARIES})
 target_compile_options(unwind_shared_objects PUBLIC "${LIBUNWIND_ADDITIONAL_COMPILE_FLAGS}")
-target_link_libraries(unwind_shared_objects PUBLIC "${LIBUNWIND_ADDITIONAL_LIBRARIES}")
+target_link_libraries(unwind_shared_objects
+  PUBLIC "${LIBUNWIND_ADDITIONAL_LIBRARIES}"
+  PRIVATE unwind-headers libunwind-libc-headers ${LIBUNWIND_LIBRARIES})
 set_target_properties(unwind_shared_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
@@ -164,7 +165,7 @@ endif()
 
 if (LIBUNWIND_ENABLE_SHARED)
   add_library(unwind_shared SHARED)
-  target_link_libraries(unwind_shared PUBLIC unwind_shared_objects)
+  target_link_libraries(unwind_shared PUBLIC unwind_shared_objects libunwind-libc-shared)
   set_target_properties(unwind_shared
     PROPERTIES
       LINK_FLAGS "${LIBUNWIND_LINK_FLAGS}"
@@ -188,9 +189,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL MSVC)
 else()
   target_compile_options(unwind_static_objects PRIVATE -fno-rtti)
 endif()
-target_link_libraries(unwind_static_objects PRIVATE unwind-headers ${LIBUNWIND_LIBRARIES})
 target_compile_options(unwind_static_objects PUBLIC "${LIBUNWIND_ADDITIONAL_COMPILE_FLAGS}")
-target_link_libraries(unwind_static_objects PUBLIC "${LIBUNWIND_ADDITIONAL_LIBRARIES}")
+target_link_libraries(unwind_static_objects
+  PUBLIC "${LIBUNWIND_ADDITIONAL_LIBRARIES}"
+  PRIVATE unwind-headers libunwind-libc-headers ${LIBUNWIND_LIBRARIES})
 set_target_properties(unwind_static_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
@@ -210,7 +212,7 @@ endif()
 
 if (LIBUNWIND_ENABLE_STATIC)
   add_library(unwind_static STATIC)
-  target_link_libraries(unwind_static PUBLIC unwind_static_objects)
+  target_link_libraries(unwind_static PUBLIC unwind_static_objects libunwind-libc-static)
   set_target_properties(unwind_static
     PROPERTIES
       LINK_FLAGS "${LIBUNWIND_LINK_FLAGS}"


### PR DESCRIPTION
This is analogous to #99287 and provides an option to build libc++abi and libunwind against LLVM libc when selected.