### PR TITLE
[Clang] Adjust `exit()` builtin impl

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -2660,9 +2660,10 @@ def Calloc : LibBuiltin<"stdlib.h"> {
 }
 
 def Exit : LibBuiltin<"stdlib.h"> {
-  let Spellings = ["exit", "_Exit"];
+  let Spellings = ["exit"];
   let Attributes = [NoReturn];
   let Prototype = "void(int)";
+  let AddBuiltinPrefixedAlias = 1;
 }
 
 def Malloc : LibBuiltin<"stdlib.h"> {
@@ -3266,9 +3267,10 @@ def StrnCaseCmp : GNULibBuiltin<"strings.h"> {
 }
 
 def GNU_Exit : GNULibBuiltin<"unistd.h"> {
-  let Spellings = ["_exit"];
+  let Spellings = ["_exit", "_Exit"];
   let Attributes = [NoReturn];
   let Prototype = "void(int)";
+  let AddBuiltinPrefixedAlias = 1;
 }
 
 def VFork : LibBuiltin<"unistd.h"> {

--- a/clang/test/CodeGen/attributes.c
+++ b/clang/test/CodeGen/attributes.c
@@ -113,6 +113,27 @@ void t24(f_t f1) {
   (*p)();
 }
 
+// CHECK:define{{.*}} void @t25() [[NUW]] {
+// CHECK: call void @exit(i32 noundef 1)
+// CHECK-NEXT: unreachable
+void t25(void) {
+  __builtin_exit(1);
+}
+
+// CHECK:define{{.*}} void @t26() [[NUW]] {
+// CHECK: call void @_exit(i32 noundef 2)
+// CHECK-NEXT: unreachable
+void t26(void) {
+  __builtin__exit(2);
+}
+
+// CHECK:define{{.*}} void @t27() [[NUW]] {
+// CHECK: call void @_Exit(i32 noundef 3)
+// CHECK-NEXT: unreachable
+void t27(void) {
+  __builtin__Exit(3);
+}
+
 // CHECK: attributes [[NUW]] = { noinline nounwind{{.*}} }
 // CHECK: attributes [[NR]] = { noinline noreturn nounwind{{.*}} }
 // CHECK: attributes [[COLDDEF]] = { cold {{.*}}}


### PR DESCRIPTION
- `_Exit` is an alias to `_exit` and `_exit` is declared in unistd.h header, so don't mix
`_Exit` and `exit`. Only `exit` decl placed in stdlib.h.
- Add `__builtin_` variants for exit functions like GCC does