### PR TITLE
[Support] Store dominator tree nodes in a vector

### DIFF
--- a/llvm/include/llvm/ADT/GraphTraits.h
+++ b/llvm/include/llvm/ADT/GraphTraits.h
@@ -71,6 +71,20 @@ struct GraphTraits {
   // static unsigned       size       (GraphType *G)
   //    Return total number of nodes in the graph
 
+  // Optionally implement the following:
+  // static unsigned getNumber(NodeRef)
+  //    Return a unique number of a node. Numbers are ideally dense, these are
+  //    used to store nodes in a vector.
+  // static unsigned getMaxNumber(GraphType *G)
+  //    Return the maximum number that getNumber() will return, or 0 if this is
+  //    unknown. Intended for reserving large enough buffers.
+  // static unsigned getNumberEpoch(GraphType *G)
+  //    Return the "epoch" of the node numbers. Should return a different
+  //    number after renumbering, so users can assert that the epoch didn't
+  //    change => numbers are still valid. If renumberings are not tracked, it
+  //    is always valid to return a constant value. This is solely for to ease
+  //    debugging by having a way to detect use of outdated numbers.
+
   // If anyone tries to use this class without having an appropriate
   // specialization, make an error.  If you get this error, it's because you
   // need to include the appropriate specialization of GraphTraits<> for your

--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -337,7 +337,7 @@ protected:
       return true;
 
     size_t NumNodes = 0;
-    // All node we have must exist and be equal in the other tree
+    // All nodes we have must exist and be equal in the other tree.
     for (const auto &Node : DomTreeNodes) {
       if (!Node)
         continue;
@@ -346,7 +346,7 @@ protected:
       NumNodes++;
     }
 
-    // If we the other tree has more nodes than we have, they're not equal
+    // If the other tree has more nodes than we have, they're not equal.
     size_t NumOtherNodes = 0;
     for (const auto &OtherNode : Other.DomTreeNodes)
       if (OtherNode)
@@ -359,9 +359,8 @@ private:
   using has_number_t =
       decltype(GraphTraits<T *>::getNumber(std::declval<T *>()));
 
-  template <class T_ = NodeT>
   std::optional<unsigned> getNodeIndex(const NodeT *BB) const {
-    if constexpr (is_detected<has_number_t, T_>::value) {
+    if constexpr (is_detected<has_number_t, NodeT>::value) {
       // BB can be nullptr, map nullptr to index 0.
       assert(BlockNumberEpoch ==
                  GraphTraits<ParentPtr>::getNumberEpoch(Parent) &&
@@ -374,8 +373,8 @@ private:
     }
   }
 
-  template <class T_ = NodeT> unsigned getNodeIndexForInsert(const NodeT *BB) {
-    if constexpr (is_detected<has_number_t, T_>::value) {
+  unsigned getNodeIndexForInsert(const NodeT *BB) {
+    if constexpr (is_detected<has_number_t, NodeT>::value) {
       // getNodeIndex will never fail if nodes have getNumber().
       unsigned Idx = *getNodeIndex(BB);
       if (Idx >= DomTreeNodes.size()) {
@@ -829,9 +828,9 @@ public:
   }
 
 private:
-  template <class T_ = NodeT> void updateBlockNumberEpoch() {
+  void updateBlockNumberEpoch() {
     // Nothing to do for graphs that don't number their blocks.
-    if constexpr (is_detected<has_number_t, T_>::value)
+    if constexpr (is_detected<has_number_t, NodeT>::value)
       BlockNumberEpoch = GraphTraits<ParentPtr>::getNumberEpoch(Parent);
   }
 
@@ -849,7 +848,7 @@ public:
     DomTreeBuilder::CalculateWithUpdates(*this, Updates);
   }
 
-  /// Update dominator tree after renumbering blocks
+  /// Update dominator tree after renumbering blocks.
   template <class T_ = NodeT>
   std::enable_if_t<is_detected<has_number_t, T_>::value, void>
   updateBlockNumbers() {

--- a/llvm/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/llvm/include/llvm/Support/GenericDomTreeConstruction.h
@@ -1231,7 +1231,9 @@ struct SemiNCAInfo {
     doFullDFSWalk(DT, AlwaysDescend);
 
     for (auto &NodeToTN : DT.DomTreeNodes) {
-      const TreeNodePtr TN = NodeToTN.second.get();
+      const TreeNodePtr TN = NodeToTN.get();
+      if (!TN)
+        continue;
       const NodePtr BB = TN->getBlock();
 
       // Virtual root has a corresponding virtual CFG node.
@@ -1264,7 +1266,9 @@ struct SemiNCAInfo {
   // Running time: O(N).
   static bool VerifyLevels(const DomTreeT &DT) {
     for (auto &NodeToTN : DT.DomTreeNodes) {
-      const TreeNodePtr TN = NodeToTN.second.get();
+      const TreeNodePtr TN = NodeToTN.get();
+      if (!TN)
+        continue;
       const NodePtr BB = TN->getBlock();
       if (!BB) continue;
 
@@ -1319,7 +1323,9 @@ struct SemiNCAInfo {
     // For each tree node verify if children's DFS numbers cover their parent's
     // DFS numbers with no gaps.
     for (const auto &NodeToTN : DT.DomTreeNodes) {
-      const TreeNodePtr Node = NodeToTN.second.get();
+      const TreeNodePtr Node = NodeToTN.get();
+      if (!Node)
+        continue;
 
       // Handle tree leaves.
       if (Node->isLeaf()) {
@@ -1432,7 +1438,9 @@ struct SemiNCAInfo {
   // the nodes it dominated previously will now become unreachable.
   bool verifyParentProperty(const DomTreeT &DT) {
     for (auto &NodeToTN : DT.DomTreeNodes) {
-      const TreeNodePtr TN = NodeToTN.second.get();
+      const TreeNodePtr TN = NodeToTN.get();
+      if (!TN)
+        continue;
       const NodePtr BB = TN->getBlock();
       if (!BB || TN->isLeaf())
         continue;
@@ -1466,7 +1474,9 @@ struct SemiNCAInfo {
   // siblings will now still be reachable.
   bool verifySiblingProperty(const DomTreeT &DT) {
     for (auto &NodeToTN : DT.DomTreeNodes) {
-      const TreeNodePtr TN = NodeToTN.second.get();
+      const TreeNodePtr TN = NodeToTN.get();
+      if (!TN)
+        continue;
       const NodePtr BB = TN->getBlock();
       if (!BB || TN->isLeaf())
         continue;

--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -44,6 +44,7 @@ add_llvm_unittest(SupportTests
   FileOutputBufferTest.cpp
   FormatVariadicTest.cpp
   FSUniqueIDTest.cpp
+  GenericDomTreeTest.cpp
   GlobPatternTest.cpp
   HashBuilderTest.cpp
   IndexedAccessorTest.cpp

--- a/llvm/unittests/Support/GenericDomTreeTest.cpp
+++ b/llvm/unittests/Support/GenericDomTreeTest.cpp
@@ -1,0 +1,109 @@
+//===- unittests/Support/GenericDomTreeTest.cpp - GenericDomTree.h tests --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/GenericDomTree.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/Support/DataTypes.h"
+#include "gtest/gtest.h"
+using namespace llvm;
+
+namespace {
+
+// Very simple (fake) graph structure to test dominator tree on.
+struct NumberedGraph;
+
+struct NumberedNode {
+  NumberedGraph *Parent;
+  unsigned Number;
+
+  NumberedNode(NumberedGraph *Parent, unsigned Number)
+      : Parent(Parent), Number(Number) {}
+
+  NumberedGraph *getParent() const { return Parent; }
+};
+
+struct NumberedGraph {
+  SmallVector<std::unique_ptr<NumberedNode>> Nodes;
+  unsigned NumberEpoch = 0;
+
+  NumberedNode *addNode() {
+    unsigned Num = Nodes.size();
+    return Nodes.emplace_back(std::make_unique<NumberedNode>(this, Num)).get();
+  }
+};
+} // namespace
+
+namespace llvm {
+template <> struct GraphTraits<NumberedNode *> {
+  using NodeRef = NumberedNode *;
+  static unsigned getNumber(NumberedNode *Node) { return Node->Number; }
+};
+
+template <> struct GraphTraits<const NumberedNode *> {
+  using NodeRef = NumberedNode *;
+  static unsigned getNumber(const NumberedNode *Node) { return Node->Number; }
+};
+
+template <> struct GraphTraits<NumberedGraph *> {
+  using NodeRef = NumberedNode *;
+  static unsigned getMaxNumber(NumberedGraph *G) { return G->Nodes.size(); }
+  static unsigned getNumberEpoch(NumberedGraph *G) { return G->NumberEpoch; }
+};
+
+namespace DomTreeBuilder {
+// Dummy specialization. Only needed so that we can call recalculate(), which
+// sets DT.Parent -- but we can't access DT.Parent here.
+template <> void Calculate(DomTreeBase<NumberedNode> &DT) {}
+} // end namespace DomTreeBuilder
+} // end namespace llvm
+
+namespace {
+
+TEST(GenericDomTree, BlockNumbers) {
+  NumberedGraph G;
+  NumberedNode *N1 = G.addNode();
+  NumberedNode *N2 = G.addNode();
+
+  DomTreeBase<NumberedNode> DT;
+  DT.recalculate(G); // only sets parent
+  // Construct fake domtree: node 0 dominates all other nodes
+  DT.setNewRoot(N1);
+  DT.addNewBlock(N2, N1);
+
+  // Roundtrip is correct
+  for (auto &N : G.Nodes)
+    EXPECT_EQ(DT.getNode(N.get())->getBlock(), N.get());
+  // If we manually change a number, we should get a different node.
+  ASSERT_EQ(N1->Number, 0u);
+  ASSERT_EQ(N2->Number, 1u);
+  N1->Number = 1;
+  EXPECT_EQ(DT.getNode(N1)->getBlock(), N2);
+  EXPECT_EQ(DT.getNode(N2)->getBlock(), N2);
+  N2->Number = 0;
+  EXPECT_EQ(DT.getNode(N2)->getBlock(), N1);
+
+  // Renumer blocks, should fix node domtree-internal node map
+  DT.updateBlockNumbers();
+  for (auto &N : G.Nodes)
+    EXPECT_EQ(DT.getNode(N.get())->getBlock(), N.get());
+
+  // Adding a new node with a higher number is no problem
+  NumberedNode *N3 = G.addNode();
+  EXPECT_EQ(DT.getNode(N3), nullptr);
+  // ... even if it exceeds getMaxNumber()
+  NumberedNode *N4 = G.addNode();
+  N4->Number = 1000;
+  EXPECT_EQ(DT.getNode(N4), nullptr);
+
+  DT.addNewBlock(N3, N1);
+  DT.addNewBlock(N4, N1);
+  for (auto &N : G.Nodes)
+    EXPECT_EQ(DT.getNode(N.get())->getBlock(), N.get());
+}
+
+} // namespace


### PR DESCRIPTION
Use basic block numbers to store dominator tree nodes in a vector. This avoids frequent map lookups. Use block number epochs to validate that no renumbering occured since the tree was created; after a renumbering, the dominator tree can be updated with updateBlockNumbers().

Block numbers, block number epoch, and max block number are fetched via newly added GraphTraits methods. Graphs which do not implement getNumber() for blocks will use a DenseMap for an ad-hoc numbering.

---

~~NB: there's currently no code path that exercises the getNumber() case. I'll write unit tests later to at least cover updateBlockNumbers().~~ Added a unit test to cover the getNumber() paths.

[c-t-t](http://llvm-compile-time-tracker.com/compare.php?from=e7f9d8e5c3e49e729c69aaa9be3322f7902370b8&to=5b907f0f5c34fcaf20ad1caa8e53b7d616e75c8d&stat=instructions:u). The extra indirection map->vector costs 0.2% (interestingly, there's no effect in stage1-O3). I'd like to keep nodes in a single place, though, because it makes code a lot more simple.