### PR TITLE
[libc][math][c23] Fix getpayloadf128 smoke test on RV32

### DIFF
--- a/libc/test/src/math/smoke/GetPayloadTest.h
+++ b/libc/test/src/math/smoke/GetPayloadTest.h
@@ -38,7 +38,14 @@ public:
     EXPECT_FP_EQ(T(0.0), funcWrapper(func, aNaN));
     EXPECT_FP_EQ(T(0.0), funcWrapper(func, neg_aNaN));
 
-    T default_snan_payload = StorageType(1) << (FPBits::SIG_LEN - 2);
+    // Essentially this:
+    //   T default_snan_payload = StorageType(1) << (FPBits::SIG_LEN - 2);
+    // but supports StorageType being a BigInt.
+    FPBits default_snan_payload_bits = FPBits::one();
+    default_snan_payload_bits.set_biased_exponent(FPBits::SIG_LEN - 2 +
+                                                  FPBits::EXP_BIAS);
+    T default_snan_payload = default_snan_payload_bits.get_val();
+
     EXPECT_FP_EQ(default_snan_payload, funcWrapper(func, sNaN));
     EXPECT_FP_EQ(default_snan_payload, funcWrapper(func, neg_sNaN));
 


### PR DESCRIPTION
Fixes
https://github.com/llvm/llvm-project/pull/101285#issuecomment-2265765022.
