### PR TITLE
[InstCombine][WIP] Fold `(binop VarTwoPossibleVals, C)` to `select`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -2836,6 +2836,9 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
                                       /*SimplifyOnly*/ false, *this))
     return BinaryOperator::CreateAnd(Op0, V);
 
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
+
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -674,6 +674,8 @@ public:
   Instruction *foldSignBitTest(ICmpInst &I);
   Instruction *foldICmpWithZero(ICmpInst &Cmp);
 
+  Instruction *foldOpWithTwoPossibleValuesToSelect(BinaryOperator &I);
+
   Value *foldMultiplicationOverflowCheck(ICmpInst &Cmp);
 
   Instruction *foldICmpBinOpWithConstant(ICmpInst &Cmp, BinaryOperator *BO,

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -598,6 +598,9 @@ Instruction *InstCombinerImpl::foldFPSignBitOps(BinaryOperator &I) {
     return replaceInstUsesWith(I, Fabs);
   }
 
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
+
   return nullptr;
 }
 
@@ -1577,6 +1580,9 @@ Instruction *InstCombinerImpl::visitUDiv(BinaryOperator &I) {
         I, Builder.CreateLShr(Op0, Res, I.getName(), I.isExact()));
   }
 
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
+
   return nullptr;
 }
 
@@ -1716,6 +1722,10 @@ Instruction *InstCombinerImpl::visitSDiv(BinaryOperator &I) {
     return SelectInst::Create(Cond, ConstantInt::get(Ty, 1),
                               ConstantInt::getAllOnesValue(Ty));
   }
+
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
+
   return nullptr;
 }
 
@@ -2230,6 +2240,9 @@ Instruction *InstCombinerImpl::visitURem(BinaryOperator &I) {
     }
   }
 
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
+
   return nullptr;
 }
 
@@ -2301,6 +2314,9 @@ Instruction *InstCombinerImpl::visitSRem(BinaryOperator &I) {
         return replaceOperand(I, 1, NewRHSV);
     }
   }
+
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
 
   return nullptr;
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1250,6 +1250,9 @@ Instruction *InstCombinerImpl::visitShl(BinaryOperator &I) {
     }
   }
 
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
+
   return nullptr;
 }
 
@@ -1592,6 +1595,9 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
   if (Instruction *Overflow = foldLShrOverflowBit(I))
     return Overflow;
 
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
+
   return nullptr;
 }
 
@@ -1794,6 +1800,9 @@ Instruction *InstCombinerImpl::visitAShr(BinaryOperator &I) {
     auto *NewAShr = Builder.CreateAShr(X, Op1, Op0->getName() + ".not");
     return BinaryOperator::CreateNot(NewAShr);
   }
+
+  if (Instruction *R = foldOpWithTwoPossibleValuesToSelect(I))
+    return R;
 
   return nullptr;
 }

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -395,7 +395,7 @@ define i32 @ashr_sel_op1_use(i1 %b) {
 ; CHECK-LABEL: @ashr_sel_op1_use(
 ; CHECK-NEXT:    [[S:%.*]] = select i1 [[B:%.*]], i32 2, i32 0
 ; CHECK-NEXT:    call void @use(i32 [[S]])
-; CHECK-NEXT:    [[R:%.*]] = ashr i32 -2, [[S]]
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[B]], i32 -1, i32 -2
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %s = select i1 %b, i32 2, i32 0

--- a/llvm/test/Transforms/InstCombine/pr72433.ll
+++ b/llvm/test/Transforms/InstCombine/pr72433.ll
@@ -6,8 +6,7 @@ define i32 @widget(i32 %arg, i32 %arg1) {
 ; CHECK-SAME: i32 [[ARG:%.*]], i32 [[ARG1:%.*]]) {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne i32 [[ARG]], 0
-; CHECK-NEXT:    [[TMP0:%.*]] = zext i1 [[ICMP]] to i32
-; CHECK-NEXT:    [[MUL:%.*]] = shl nuw nsw i32 20, [[TMP0]]
+; CHECK-NEXT:    [[MUL:%.*]] = select i1 [[ICMP]], i32 40, i32 20
 ; CHECK-NEXT:    [[XOR:%.*]] = zext i1 [[ICMP]] to i32
 ; CHECK-NEXT:    [[ADD9:%.*]] = or disjoint i32 [[MUL]], [[XOR]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i1 [[ICMP]] to i32

--- a/llvm/test/Transforms/InstCombine/redundant-left-shift-input-masking-pr49778.ll
+++ b/llvm/test/Transforms/InstCombine/redundant-left-shift-input-masking-pr49778.ll
@@ -5,9 +5,7 @@
 define i32 @src(i1 %x2) {
 ; CHECK-LABEL: @src(
 ; CHECK-NEXT:    [[X13:%.*]] = zext i1 [[X2:%.*]] to i32
-; CHECK-NEXT:    [[_7:%.*]] = shl nsw i32 -1, [[X13]]
-; CHECK-NEXT:    [[MASK:%.*]] = xor i32 [[_7]], -1
-; CHECK-NEXT:    [[_8:%.*]] = and i32 [[MASK]], [[X13]]
+; CHECK-NEXT:    [[_8:%.*]] = zext i1 [[X2]] to i32
 ; CHECK-NEXT:    [[_9:%.*]] = shl nuw nsw i32 [[_8]], [[X13]]
 ; CHECK-NEXT:    ret i32 [[_9]]
 ;

--- a/llvm/test/Transforms/InstCombine/sext-of-trunc-nsw.ll
+++ b/llvm/test/Transforms/InstCombine/sext-of-trunc-nsw.ll
@@ -117,9 +117,10 @@ define i64 @narrow_source_matching_signbits(i32 %x) {
 
 define i64 @narrow_source_not_matching_signbits(i32 %x) {
 ; CHECK-LABEL: @narrow_source_not_matching_signbits(
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[X:%.*]], 8
-; CHECK-NEXT:    [[A:%.*]] = shl nsw i32 -1, [[M]]
-; CHECK-NEXT:    [[B:%.*]] = trunc i32 [[A]] to i8
+; CHECK-NEXT:    [[TMP1:%.*]] = trunc i32 [[X:%.*]] to i8
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i8 [[TMP1]], 3
+; CHECK-NEXT:    [[TMP3:%.*]] = and i8 [[TMP2]], 1
+; CHECK-NEXT:    [[B:%.*]] = add nsw i8 [[TMP3]], -1
 ; CHECK-NEXT:    [[C:%.*]] = sext i8 [[B]] to i64
 ; CHECK-NEXT:    ret i64 [[C]]
 ;
@@ -148,9 +149,10 @@ define i24 @wide_source_matching_signbits(i32 %x) {
 
 define i24 @wide_source_not_matching_signbits(i32 %x) {
 ; CHECK-LABEL: @wide_source_not_matching_signbits(
-; CHECK-NEXT:    [[M2:%.*]] = and i32 [[X:%.*]], 8
-; CHECK-NEXT:    [[A:%.*]] = shl nsw i32 -1, [[M2]]
-; CHECK-NEXT:    [[B:%.*]] = trunc i32 [[A]] to i8
+; CHECK-NEXT:    [[TMP1:%.*]] = trunc i32 [[X:%.*]] to i8
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i8 [[TMP1]], 3
+; CHECK-NEXT:    [[TMP3:%.*]] = and i8 [[TMP2]], 1
+; CHECK-NEXT:    [[B:%.*]] = add nsw i8 [[TMP3]], -1
 ; CHECK-NEXT:    [[C:%.*]] = sext i8 [[B]] to i24
 ; CHECK-NEXT:    ret i24 [[C]]
 ;
@@ -178,9 +180,11 @@ define i32 @same_source_matching_signbits(i32 %x) {
 
 define i32 @same_source_not_matching_signbits(i32 %x) {
 ; CHECK-LABEL: @same_source_not_matching_signbits(
-; CHECK-NEXT:    [[M2:%.*]] = and i32 [[X:%.*]], 8
-; CHECK-NEXT:    [[TMP1:%.*]] = shl i32 -16777216, [[M2]]
-; CHECK-NEXT:    [[C:%.*]] = ashr exact i32 [[TMP1]], 24
+; CHECK-NEXT:    [[TMP1:%.*]] = trunc i32 [[X:%.*]] to i8
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i8 [[TMP1]], 3
+; CHECK-NEXT:    [[TMP3:%.*]] = and i8 [[TMP2]], 1
+; CHECK-NEXT:    [[B:%.*]] = add nsw i8 [[TMP3]], -1
+; CHECK-NEXT:    [[C:%.*]] = sext i8 [[B]] to i32
 ; CHECK-NEXT:    ret i32 [[C]]
 ;
   %m2 = and i32 %x, 8
@@ -208,9 +212,10 @@ define i32 @same_source_matching_signbits_extra_use(i32 %x) {
 
 define i32 @same_source_not_matching_signbits_extra_use(i32 %x) {
 ; CHECK-LABEL: @same_source_not_matching_signbits_extra_use(
-; CHECK-NEXT:    [[M2:%.*]] = and i32 [[X:%.*]], 8
-; CHECK-NEXT:    [[A:%.*]] = shl nsw i32 -1, [[M2]]
-; CHECK-NEXT:    [[B:%.*]] = trunc i32 [[A]] to i8
+; CHECK-NEXT:    [[TMP1:%.*]] = trunc i32 [[X:%.*]] to i8
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i8 [[TMP1]], 3
+; CHECK-NEXT:    [[TMP3:%.*]] = and i8 [[TMP2]], 1
+; CHECK-NEXT:    [[B:%.*]] = add nsw i8 [[TMP3]], -1
 ; CHECK-NEXT:    call void @use8(i8 [[B]])
 ; CHECK-NEXT:    [[C:%.*]] = sext i8 [[B]] to i32
 ; CHECK-NEXT:    ret i32 [[C]]

--- a/llvm/test/Transforms/InstCombine/shift-amount-reassociation-in-bittest.ll
+++ b/llvm/test/Transforms/InstCombine/shift-amount-reassociation-in-bittest.ll
@@ -675,9 +675,8 @@ define i1 @constantexpr() {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr @f.a, align 2
 ; CHECK-NEXT:    [[SHR:%.*]] = lshr i16 [[TMP0]], 1
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 ptrtoint (ptr @f.a to i16), 1
-; CHECK-NEXT:    [[ZEXT:%.*]] = zext i1 [[CMP]] to i16
-; CHECK-NEXT:    [[TMP1:%.*]] = shl nuw nsw i16 1, [[ZEXT]]
+; CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp eq i16 ptrtoint (ptr @f.a to i16), 1
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[CMP_NOT]], i16 1, i16 2
 ; CHECK-NEXT:    [[TMP2:%.*]] = and i16 [[SHR]], [[TMP1]]
 ; CHECK-NEXT:    [[TOBOOL:%.*]] = icmp ne i16 [[TMP2]], 0
 ; CHECK-NEXT:    ret i1 [[TOBOOL]]


### PR DESCRIPTION
I.e:
    `(binop X, C)` where `X` equals `C0` or `C1` to:
    `(select (icmp eq X, C0), (binop C0, C), (binop C1, C))`

We currently handle the opposite case for `add`, `or`, `xor`, and
`sub` in `foldSelectICmpAnd`. For the ops we don't handle there, this
patch makes the decision intentional.
