### PR TITLE
[SandboxIR] Implement missing PHINode functions

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1585,12 +1585,12 @@ public:
     return cast<llvm::PHINode>(Val)->hasConstantOrUndefValue();
   }
   bool isComplete() const { return cast<llvm::PHINode>(Val)->isComplete(); }
-  // TODO: Implement the below functions:
-  // void replaceIncomingBlockWith (const BasicBlock *Old, BasicBlock *New);
+  void replaceIncomingBlockWith (const BasicBlock *Old, BasicBlock *New);
+  void removeIncomingValueIf(function_ref< bool(unsigned)> Predicate,
+                             bool DeletePHIIfEmpty=true);
+  // TODO: Implement 
   // void copyIncomingBlocks(iterator_range<const_block_iterator> BBRange,
   //                         uint32_t ToIdx = 0)
-  // void removeIncomingValueIf(function_ref< bool(unsigned)> Predicate,
-  //                            bool DeletePHIIfEmpty=true)
 #ifndef NDEBUG
   void verify() const final {
     assert(isa<llvm::PHINode>(Val) && "Expected PHINode!");

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1586,8 +1586,7 @@ public:
   }
   bool isComplete() const { return cast<llvm::PHINode>(Val)->isComplete(); }
   void replaceIncomingBlockWith (const BasicBlock *Old, BasicBlock *New);
-  void removeIncomingValueIf(function_ref< bool(unsigned)> Predicate,
-                             bool DeletePHIIfEmpty=true);
+  void removeIncomingValueIf(function_ref< bool(unsigned)> Predicate);
   // TODO: Implement 
   // void copyIncomingBlocks(iterator_range<const_block_iterator> BBRange,
   //                         uint32_t ToIdx = 0)

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1585,7 +1585,7 @@ public:
     return cast<llvm::PHINode>(Val)->hasConstantOrUndefValue();
   }
   bool isComplete() const { return cast<llvm::PHINode>(Val)->isComplete(); }
-  void replaceIncomingBlockWith (const BasicBlock *Old, BasicBlock *New);
+  void replaceIncomingBlockWith(const BasicBlock *Old, BasicBlock *New);
   void removeIncomingValueIf(function_ref< bool(unsigned)> Predicate);
   // TODO: Implement 
   // void copyIncomingBlocks(iterator_range<const_block_iterator> BBRange,

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1586,8 +1586,8 @@ public:
   }
   bool isComplete() const { return cast<llvm::PHINode>(Val)->isComplete(); }
   void replaceIncomingBlockWith(const BasicBlock *Old, BasicBlock *New);
-  void removeIncomingValueIf(function_ref< bool(unsigned)> Predicate);
-  // TODO: Implement 
+  void removeIncomingValueIf(function_ref<bool(unsigned)> Predicate);
+  // TODO: Implement
   // void copyIncomingBlocks(iterator_range<const_block_iterator> BBRange,
   //                         uint32_t ToIdx = 0)
 #ifndef NDEBUG

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -1152,10 +1152,10 @@ Value *PHINode::hasConstantValue() const {
 }
 void PHINode::replaceIncomingBlockWith (const BasicBlock *Old, BasicBlock *New) {
   assert(New && Old && "Sandbox IR PHI node got a null basic block!");
-  for (unsigned Op = 0,
-            NumOps = cast<llvm::PHINode>(Val)->getNumOperands(); Op != NumOps; ++Op)
-    if (getIncomingBlock(Op) == Old)
-      setIncomingBlock(Op, New);
+  for (unsigned Idx = 0,
+            NumOps = cast<llvm::PHINode>(Val)->getNumOperands(); Idx != NumOps; ++Idx)
+    if (getIncomingBlock(Idx) == Old)
+      setIncomingBlock(Idx, New);
 }
 void PHINode::removeIncomingValueIf(function_ref< bool(unsigned)> Predicate,
                                     bool DeletePHIIfEmpty) {
@@ -1164,7 +1164,7 @@ void PHINode::removeIncomingValueIf(function_ref< bool(unsigned)> Predicate,
   // directly if performance becomes an issue.
   for (unsigned Idx = 0; Idx < getNumIncomingValues(); ++Idx)
     if (Predicate(Idx))
-      removeIncomingValue(Idx);
+      removeIncomingValue(Idx, DeletePHIIfEmpty);
 }
 
 static llvm::Instruction::CastOps getLLVMCastOp(Instruction::Opcode Opc) {

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -1157,14 +1157,19 @@ void PHINode::replaceIncomingBlockWith (const BasicBlock *Old, BasicBlock *New) 
     if (getIncomingBlock(Idx) == Old)
       setIncomingBlock(Idx, New);
 }
-void PHINode::removeIncomingValueIf(function_ref< bool(unsigned)> Predicate,
-                                    bool DeletePHIIfEmpty) {
+void PHINode::removeIncomingValueIf(function_ref< bool(unsigned)> Predicate) {
   // Avoid duplicate tracking by going through this->removeIncomingValue here at
   // the expense of some performance. Copy PHI::removeIncomingValueIf more
   // directly if performance becomes an issue.
-  for (unsigned Idx = 0; Idx < getNumIncomingValues(); ++Idx)
-    if (Predicate(Idx))
-      removeIncomingValue(Idx, DeletePHIIfEmpty);
+  unsigned Idx = 0;
+  unsigned LastIdx = getNumIncomingValues();
+  while (Idx < LastIdx) {
+    if (Predicate(Idx)) {
+      removeIncomingValue(Idx);
+      --LastIdx;
+    } else
+      ++Idx;
+  }
 }
 
 static llvm::Instruction::CastOps getLLVMCastOp(Instruction::Opcode Opc) {

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -1150,10 +1150,10 @@ Value *PHINode::hasConstantValue() const {
   llvm::Value *LLVMV = cast<llvm::PHINode>(Val)->hasConstantValue();
   return LLVMV != nullptr ? Ctx.getValue(LLVMV) : nullptr;
 }
-void PHINode::replaceIncomingBlockWith (const BasicBlock *Old, BasicBlock *New) {
+void PHINode::replaceIncomingBlockWith(const BasicBlock *Old, BasicBlock *New) {
   assert(New && Old && "Sandbox IR PHI node got a null basic block!");
-  for (unsigned Idx = 0,
-            NumOps = cast<llvm::PHINode>(Val)->getNumOperands(); Idx != NumOps; ++Idx)
+  for (unsigned Idx = 0, NumOps = cast<llvm::PHINode>(Val)->getNumOperands();
+       Idx != NumOps; ++Idx)
     if (getIncomingBlock(Idx) == Old)
       setIncomingBlock(Idx, New);
 }

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1976,16 +1976,17 @@ bb3:
   EXPECT_EQ(PHI->isComplete(), LLVMPHI->isComplete());
   // Check replaceIncomingBlockWith
   OrigBB = PHI->getIncomingBlock(0);
-  EXPECT_EQ(OrigBB, BB1);
-  EXPECT_NE(OrigBB, BB2);
-  PHI->replaceIncomingBlockWith(BB1, BB2);
-  EXPECT_EQ(PHI->getIncomingBlock(0), BB2);
+  auto *NewBB = BB2;
+  EXPECT_NE(NewBB, OrigBB);
+  PHI->replaceIncomingBlockWith(OrigBB, NewBB);
+  EXPECT_EQ(PHI->getIncomingBlock(0), NewBB);
   // Check replaceIncomingValueIf
   EXPECT_EQ(PHI->getNumIncomingValues(), 2u);
   PHI->removeIncomingValueIf([&](unsigned Idx) {
     return PHI->getIncomingBlock(Idx) == BB2;
   });
   EXPECT_EQ(PHI->getNumIncomingValues(), 1u);
+  EXPECT_EQ(PHI->getIncomingBlock(0), BB1);
   // Check create().
   auto *NewPHI = cast<sandboxir::PHINode>(
       sandboxir::PHINode::create(PHI->getType(), 0, Br, Ctx, "NewPHI"));

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1974,7 +1974,18 @@ bb3:
   EXPECT_EQ(PHI->hasConstantOrUndefValue(), LLVMPHI->hasConstantOrUndefValue());
   // Check isComplete().
   EXPECT_EQ(PHI->isComplete(), LLVMPHI->isComplete());
-
+  // Check replaceIncomingBlockWith
+  OrigBB = PHI->getIncomingBlock(0);
+  EXPECT_EQ(OrigBB, BB1);
+  EXPECT_NE(OrigBB, BB2);
+  PHI->replaceIncomingBlockWith(BB1, BB2);
+  EXPECT_EQ(PHI->getIncomingBlock(0), BB2);
+  // Check replaceIncomingValueIf
+  EXPECT_EQ(PHI->getNumIncomingValues(), 2u);
+  PHI->removeIncomingValueIf([&](unsigned Idx) {
+    return PHI->getIncomingBlock(Idx) == BB2;
+  });
+  EXPECT_EQ(PHI->getNumIncomingValues(), 1u);
   // Check create().
   auto *NewPHI = cast<sandboxir::PHINode>(
       sandboxir::PHINode::create(PHI->getType(), 0, Br, Ctx, "NewPHI"));

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1876,10 +1876,16 @@ bb1:
   br label %bb2
 
 bb2:
-  %phi = phi i32 [ %arg, %bb1 ], [ 0, %bb2 ], [ 1, %bb3]
+  %phi = phi i32 [ %arg, %bb1 ], [ 0, %bb2 ], [ 1, %bb3 ], [ 2, %bb4 ], [ 3, %bb5 ]
   br label %bb2
 
 bb3:
+  br label %bb2
+
+bb4:
+  br label %bb2
+
+bb5:
   br label %bb2
   ret void
 }
@@ -1975,19 +1981,29 @@ bb3:
   EXPECT_EQ(PHI->hasConstantOrUndefValue(), LLVMPHI->hasConstantOrUndefValue());
   // Check isComplete().
   EXPECT_EQ(PHI->isComplete(), LLVMPHI->isComplete());
+  // Check replaceIncomingValueIf
+  EXPECT_EQ(PHI->getNumIncomingValues(), 5u);
+  auto *RemainBB0 = PHI->getIncomingBlock(0);
+  auto *RemoveBB0 = PHI->getIncomingBlock(1);
+  auto *RemainBB1 = PHI->getIncomingBlock(2);
+  auto *RemoveBB1 = PHI->getIncomingBlock(3);
+  auto *RemainBB2 = PHI->getIncomingBlock(4);
+  PHI->removeIncomingValueIf([&](unsigned Idx) {
+    return PHI->getIncomingBlock(Idx) == RemoveBB0 ||
+           PHI->getIncomingBlock(Idx) == RemoveBB1;
+  });
+  EXPECT_EQ(PHI->getNumIncomingValues(), 3u);
+  EXPECT_EQ(PHI->getIncomingBlock(0), RemainBB0);
+  EXPECT_EQ(PHI->getIncomingBlock(1), RemainBB1);
+  EXPECT_EQ(PHI->getIncomingBlock(2), RemainBB2);
   // Check replaceIncomingBlockWith
-  OrigBB = PHI->getIncomingBlock(0);
-  auto *NewBB = BB2;
+  OrigBB = RemainBB0;
+  auto *NewBB = RemainBB1;
   EXPECT_NE(NewBB, OrigBB);
   PHI->replaceIncomingBlockWith(OrigBB, NewBB);
   EXPECT_EQ(PHI->getIncomingBlock(0), NewBB);
-  // Check replaceIncomingValueIf
-  EXPECT_EQ(PHI->getNumIncomingValues(), 3u);
-  PHI->removeIncomingValueIf([&](unsigned Idx) {
-    return PHI->getIncomingBlock(Idx) == NewBB;
-  });
-  EXPECT_EQ(PHI->getNumIncomingValues(), 1u);
-  EXPECT_EQ(PHI->getIncomingBlock(0), BB3);
+  EXPECT_EQ(PHI->getIncomingBlock(1), RemainBB1);
+  EXPECT_EQ(PHI->getIncomingBlock(2), RemainBB2);
   // Check create().
   auto *NewPHI = cast<sandboxir::PHINode>(
       sandboxir::PHINode::create(PHI->getType(), 0, Br, Ctx, "NewPHI"));

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1876,10 +1876,11 @@ bb1:
   br label %bb2
 
 bb2:
-  %phi = phi i32 [ %arg, %bb1 ], [ 0, %bb2 ]
+  %phi = phi i32 [ %arg, %bb1 ], [ 0, %bb2 ], [ 1, %bb3]
   br label %bb2
 
 bb3:
+  br label %bb2
   ret void
 }
 )IR");
@@ -1981,12 +1982,12 @@ bb3:
   PHI->replaceIncomingBlockWith(OrigBB, NewBB);
   EXPECT_EQ(PHI->getIncomingBlock(0), NewBB);
   // Check replaceIncomingValueIf
-  EXPECT_EQ(PHI->getNumIncomingValues(), 2u);
+  EXPECT_EQ(PHI->getNumIncomingValues(), 3u);
   PHI->removeIncomingValueIf([&](unsigned Idx) {
-    return PHI->getIncomingBlock(Idx) == BB2;
+    return PHI->getIncomingBlock(Idx) == NewBB;
   });
   EXPECT_EQ(PHI->getNumIncomingValues(), 1u);
-  EXPECT_EQ(PHI->getIncomingBlock(0), BB1);
+  EXPECT_EQ(PHI->getIncomingBlock(0), BB3);
   // Check create().
   auto *NewPHI = cast<sandboxir::PHINode>(
       sandboxir::PHINode::create(PHI->getType(), 0, Br, Ctx, "NewPHI"));

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -682,9 +682,8 @@ bb2:
 
   // Check removeIncomingValueIf(FromBB1).
   Ctx.save();
-  PHI->removeIncomingValueIf([&](unsigned Idx) {
-    return PHI->getIncomingBlock(Idx) == BB1;
-  });
+  PHI->removeIncomingValueIf(
+      [&](unsigned Idx) { return PHI->getIncomingBlock(Idx) == BB1; });
   EXPECT_EQ(PHI->getNumIncomingValues(), 1u);
   Ctx.revert();
   EXPECT_EQ(PHI->getNumIncomingValues(), 2u);

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -688,7 +688,8 @@ bb2:
   EXPECT_EQ(PHI->getNumIncomingValues(), 1u);
   Ctx.revert();
   EXPECT_EQ(PHI->getNumIncomingValues(), 2u);
-
+  EXPECT_EQ(PHI->getIncomingBlock(0), BB0);
+  EXPECT_EQ(PHI->getIncomingBlock(1), BB1);
   // Check removeIncomingValue() remove all.
   Ctx.save();
   PHI->removeIncomingValue(0u);

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -680,6 +680,15 @@ bb2:
   EXPECT_EQ(PHI->getIncomingBlock(1), BB1);
   EXPECT_EQ(PHI->getIncomingValue(1), Arg1);
 
+  // Check removeIncomingValueIf(FromBB1).
+  Ctx.save();
+  PHI->removeIncomingValueIf([&](unsigned Idx) {
+    return PHI->getIncomingBlock(Idx) == BB1;
+  });
+  EXPECT_EQ(PHI->getNumIncomingValues(), 1u);
+  Ctx.revert();
+  EXPECT_EQ(PHI->getNumIncomingValues(), 2u);
+
   // Check removeIncomingValue() remove all.
   Ctx.save();
   PHI->removeIncomingValue(0u);


### PR DESCRIPTION
replaceIncomingBlockWith and removeIncomingValueIf are both straightforward and done.

I'll defer copyIncomingBlocks until a couple of other changes that also handle blocks go in.