### PR TITLE
[libc] inline thread self

### DIFF
--- a/libc/src/__support/threads/thread.cpp
+++ b/libc/src/__support/threads/thread.cpp
@@ -17,9 +17,6 @@
 #include "src/__support/macros/attributes.h"
 
 namespace LIBC_NAMESPACE_DECL {
-
-LIBC_THREAD_LOCAL Thread self;
-
 namespace {
 
 using AtExitCallback = void(void *);

--- a/libc/src/__support/threads/thread.h
+++ b/libc/src/__support/threads/thread.h
@@ -231,7 +231,7 @@ struct Thread {
   int get_name(cpp::StringStream &name) const;
 };
 
-extern LIBC_THREAD_LOCAL Thread self;
+LIBC_INLINE_VAR LIBC_THREAD_LOCAL Thread self;
 
 // Platforms should implement this function.
 [[noreturn]] void thread_exit(ThreadReturnValue retval, ThreadStyle style);


### PR DESCRIPTION
The codegen for non-inlined version is "quite ugly" as it emits some checks to make sure the initialization routine is properly executed because the compiler does not see how the TLS object is initialized. This leads to some `callq 0x0` junk in the final outputs.

For codegen details, see https://godbolt.org/z/rb5qYj3vY.