### PR TITLE
ADT: Add non-const overload of PackedVector::raw_bits()

### DIFF
--- a/llvm/include/llvm/ADT/PackedVector.h
+++ b/llvm/include/llvm/ADT/PackedVector.h
@@ -143,6 +143,7 @@ public:
   }
 
   const BitVectorTy &raw_bits() const { return Bits; }
+  BitVectorTy &raw_bits() { return Bits; }
 };
 
 // Leave BitNum=0 undefined.


### PR DESCRIPTION
This is convenient when operating on vectors in a bulk, bit-manipulating fashion. I plan to use this in a future change.