### PR TITLE
[libc++] Re-enable transitive include tests when TZDB isn't provided

### DIFF
--- a/libcxx/test/libcxx/transitive_includes.gen.py
+++ b/libcxx/test/libcxx/transitive_includes.gen.py
@@ -73,7 +73,7 @@ else:
 {lit_header_restrictions.get(header, '')}
 
 // TODO: Fix this test to make it work with localization or wide characters disabled
-// UNSUPPORTED: no-localization, no-wide-characters, no-threads, no-filesystem, libcpp-has-no-experimental-tzdb, no-tzdb
+// UNSUPPORTED: no-localization, no-wide-characters, no-threads, no-filesystem
 
 // When built with modules, this test doesn't work because --trace-includes doesn't
 // report the stack of includes correctly.


### PR DESCRIPTION
That doesn't seem to cause any issues with these tests.