### PR TITLE
[libcxx] Use `aligned_alloc` for testing instead of `posix_memalign`

### DIFF
--- a/libcxx/test/libcxx/language.support/support.dynamic/new_faligned_allocation.pass.cpp
+++ b/libcxx/test/libcxx/language.support/support.dynamic/new_faligned_allocation.pass.cpp
@@ -76,7 +76,7 @@ int main(int, char**) {
   test_allocations(64, 64);
   // Size being a multiple of alignment also needs to be supported.
   test_allocations(64, 32);
-  // When aligned allocation is implemented using posix_memalign,
+  // When aligned allocation is implemented using aligned_alloc,
   // that function requires a minimum alignment of sizeof(void*).
   // Check that we can also create overaligned allocations with
   // an alignment argument less than sizeof(void*).

--- a/libcxx/test/support/count_new.h
+++ b/libcxx/test/support/count_new.h
@@ -460,6 +460,9 @@ inline void* allocate_aligned_impl(std::size_t size, std::align_val_t align) {
   void* ret                   = nullptr;
 #    ifdef USE_ALIGNED_ALLOC
   ret = _aligned_malloc(size, alignment);
+#    elif TEST_STD_VER >= 17
+  size_t rounded_size = (size + alignment - 1) & ~(alignment - 1);
+  ret                 = aligned_alloc(alignment, size > rounded_size ? size : rounded_size);
 #    else
   assert(posix_memalign(&ret, std::max(alignment, sizeof(void*)), size) != EINVAL);
 #    endif

--- a/libcxx/test/support/count_new.h
+++ b/libcxx/test/support/count_new.h
@@ -455,12 +455,21 @@ void operator delete[](void* p, std::nothrow_t const&) TEST_NOEXCEPT {
 #      define USE_ALIGNED_ALLOC
 #    endif
 
+#    if defined(__APPLE__)
+#      if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&                                                   \
+           __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500)
+#        define TEST_HAS_NO_C11_ALIGNED_ALLOC
+#      endif
+#    elif defined(__ANDROID__) && __ANDROID_API__ < 28
+#      define TEST_HAS_NO_C11_ALIGNED_ALLOC
+#    endif
+
 inline void* allocate_aligned_impl(std::size_t size, std::align_val_t align) {
   const std::size_t alignment = static_cast<std::size_t>(align);
   void* ret                   = nullptr;
 #    ifdef USE_ALIGNED_ALLOC
   ret = _aligned_malloc(size, alignment);
-#    elif TEST_STD_VER >= 17
+#    elif TEST_STD_VER >= 17 && !defined(TEST_HAS_NO_C11_ALIGNED_ALLOC)
   size_t rounded_size = (size + alignment - 1) & ~(alignment - 1);
   ret                 = aligned_alloc(alignment, size > rounded_size ? size : rounded_size);
 #    else


### PR DESCRIPTION
Summary:
The `aligned_alloc` function is the C11 replacement for
`posix_memalign`. We should favor the C standard over the POSIX standard
so more C library implementations can run the tests.
