### PR TITLE
[NFC][llvm][support] rename INFINITY in regcomp

### DIFF
--- a/llvm/lib/Support/regcomp.c
+++ b/llvm/lib/Support/regcomp.c
@@ -278,7 +278,7 @@ static char nuls[10];		/* place to point scanner in event of error */
 #else
 #define	DUPMAX	255
 #endif
-#define	INFINITY	(DUPMAX + 1)
+#define REGINFINITY (DUPMAX + 1)
 
 #ifndef NDEBUG
 static int never = 0;		/* for use in asserts; shuts lint up */
@@ -582,7 +582,7 @@ p_ere_exp(struct parse *p)
 				count2 = p_count(p);
 				REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-				count2 = INFINITY;
+				count2 = REGINFINITY;
 		} else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
@@ -753,7 +753,7 @@ p_simp_re(struct parse *p,
 				count2 = p_count(p);
 				REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-				count2 = INFINITY;
+				count2 = REGINFINITY;
 		} else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
@@ -1115,7 +1115,7 @@ repeat(struct parse *p,
 #	define	N	2
 #	define	INF	3
 #	define	REP(f, t)	((f)*8 + (t))
-#	define	MAP(n)	(((n) <= 1) ? (n) : ((n) == INFINITY) ? INF : N)
+#	define	MAP(n)	(((n) <= 1) ? (n) : ((n) == REGINFINITY) ? INF : N)
 	sopno copy;
 
 	if (p->error != 0)	/* head off possible runaway recursion */

--- a/llvm/lib/Support/regcomp.c
+++ b/llvm/lib/Support/regcomp.c
@@ -582,8 +582,8 @@ p_ere_exp(struct parse *p)
 				count2 = p_count(p);
 				REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-				count2 = REGINFINITY;
-		} else		/* just a single number */
+                          count2 = REGINFINITY;
+                } else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
 		if (!EAT('}')) {	/* error heuristics */
@@ -753,8 +753,8 @@ p_simp_re(struct parse *p,
 				count2 = p_count(p);
 				REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-				count2 = REGINFINITY;
-		} else		/* just a single number */
+                          count2 = REGINFINITY;
+                } else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
 		if (!EATTWO('\\', '}')) {	/* error heuristics */
@@ -1115,8 +1115,8 @@ repeat(struct parse *p,
 #	define	N	2
 #	define	INF	3
 #	define	REP(f, t)	((f)*8 + (t))
-#	define	MAP(n)	(((n) <= 1) ? (n) : ((n) == REGINFINITY) ? INF : N)
-	sopno copy;
+#define MAP(n) (((n) <= 1) ? (n) : ((n) == REGINFINITY) ? INF : N)
+        sopno copy;
 
 	if (p->error != 0)	/* head off possible runaway recursion */
 		return;

--- a/llvm/lib/Support/regcomp.c
+++ b/llvm/lib/Support/regcomp.c
@@ -582,8 +582,8 @@ p_ere_exp(struct parse *p)
 				count2 = p_count(p);
 				REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-                          count2 = REGINFINITY;
-                } else		/* just a single number */
+				count2 = REGINFINITY;
+		} else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
 		if (!EAT('}')) {	/* error heuristics */
@@ -753,8 +753,8 @@ p_simp_re(struct parse *p,
 				count2 = p_count(p);
 				REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-                          count2 = REGINFINITY;
-                } else		/* just a single number */
+				count2 = REGINFINITY;
+		} else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
 		if (!EATTWO('\\', '}')) {	/* error heuristics */
@@ -1115,8 +1115,8 @@ repeat(struct parse *p,
 #	define	N	2
 #	define	INF	3
 #	define	REP(f, t)	((f)*8 + (t))
-#define MAP(n) (((n) <= 1) ? (n) : ((n) == REGINFINITY) ? INF : N)
-        sopno copy;
+#	define	MAP(n)	(((n) <= 1) ? (n) : ((n) == REGINFINITY) ? INF : N)
+	sopno copy;
 
 	if (p->error != 0)	/* head off possible runaway recursion */
 		return;


### PR DESCRIPTION
since C23 this macro is defined by float.h, which clang implements in it's float.h since #96659 landed.

However, regcomp.c in LLVMSupport happened to define it's own macro with that name, leading to problems when bootstrapping. This change renames the offending macro.