### PR TITLE
[CodeGen][NFCI] Don't re-implement parts of ASTContext::getIntWidth

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -756,9 +756,7 @@ static WidthAndSignedness
 getIntegerWidthAndSignedness(const clang::ASTContext &context,
                              const clang::QualType Type) {
   assert(Type->isIntegerType() && "Given type is not an integer.");
-  unsigned Width = Type->isBooleanType()  ? 1
-                   : Type->isBitIntType() ? context.getIntWidth(Type)
-                                          : context.getTypeInfo(Type).Width;
+  unsigned Width = context.getIntWidth(Type);
   bool Signed = Type->isSignedIntegerType();
   return {Width, Signed};
 }


### PR DESCRIPTION
ASTContext::getIntWidth returns 1 if isBooleanType(), and falls back on
getTypeSize in the default case, which itself just returns the Width
from getTypeInfo's returned struct, so can be used in all cases here,
not just for _BitInt types.
