### PR TITLE
workflows/release-binaries: Fix problem with python installation on macos-14

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -57,6 +57,12 @@ jobs:
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
 
     steps:
+    # It's good practice to use setup-python, but this is also required on macos-14
+    # due to https://github.com/actions/runner-images/issues/10385
+    - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f
+      with:
+        python-version: '3.12'
+
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 


### PR DESCRIPTION
python3 wasn't able to see modules installed by pip, so we need to use the setup-python action to ensure that the default pip and python3 both use the same prefix.

See https://github.com/actions/runner-images/issues/10385