### PR TITLE
[DirectX] Add triples to two tests after #97593

### DIFF
--- a/llvm/test/CodeGen/DirectX/any.ll
+++ b/llvm/test/CodeGen/DirectX/any.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -dxil-op-lower < %s | FileCheck %s
+; RUN: opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.0-library < %s | FileCheck %s
 
 ; Make sure dxil operation function calls for any are generated for float and half.
 

--- a/llvm/test/CodeGen/DirectX/lerp.ll
+++ b/llvm/test/CodeGen/DirectX/lerp.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -dxil-op-lower < %s | FileCheck %s
+; RUN: opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.0-library < %s | FileCheck %s
 
 ; Make sure dxil operation function calls for lerp are generated for float and half.
 


### PR DESCRIPTION
As of cdfd884b0ec6 "[DXIL] Add DXIL version-specific TableGen specification and implementation of DXIL Ops (#97593)", all of these tests need to specify triples.