### PR TITLE
Fix all mypy --strict errors in clang python binding

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -62,35 +62,47 @@ from __future__ import annotations
 #
 # o implement additional SourceLocation, SourceRange, and File methods.
 
-from ctypes import *
+from ctypes import (c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint, c_long,  # pyright: ignore[reportUnusedImport]
+                    c_ulong, c_longlong,c_ulonglong, c_size_t, c_ssize_t,  # pyright: ignore[reportUnusedImport]
+                    c_bool, c_char, c_wchar, c_float, c_double, c_longdouble,  # pyright: ignore[reportUnusedImport]
+                    c_char_p, c_wchar_p, c_void_p)  # pyright: ignore[reportUnusedImport]
+from ctypes import py_object, Structure, POINTER, byref, cast, cdll
+from .ctyped import *
+from .ctyped import ANNO_CONVERTIBLE, generate_metadata
 
 import os
 import sys
 from enum import Enum
 
 from typing import (
+    cast as tcast,
     Any,
     Callable,
+    Generator,
     Generic,
+    List,
     Optional,
+    Tuple,
     Type as TType,
     TypeVar,
     TYPE_CHECKING,
     Union as TUnion,
 )
 
+from typing_extensions import Annotated
+
 if TYPE_CHECKING:
-    from ctypes import _Pointer
     from typing_extensions import Protocol, TypeAlias
+    from ctypes import CDLL
 
     StrPath: TypeAlias = TUnion[str, os.PathLike[str]]
-    LibFunc: TypeAlias = TUnion[
-        "tuple[str, Optional[list[Any]]]",
-        "tuple[str, Optional[list[Any]], Any]",
-        "tuple[str, Optional[list[Any]], Any, Callable[..., Any]]",
-    ]
-
+    StrOrBytes: TypeAlias = TUnion[str, bytes]
+    FsPath: TypeAlias = TUnion[StrOrBytes, os.PathLike[str]]
     TSeq = TypeVar("TSeq", covariant=True)
+
+    class SupportsReadStringData(Protocol):
+        def read(self) -> str | bytes:
+            ...
 
     class NoSliceSequence(Protocol[TSeq]):
         def __len__(self) -> int:
@@ -102,7 +114,7 @@ if TYPE_CHECKING:
 
 # Python 3 strings are unicode, translate them to/from utf8 for C-interop.
 class c_interop_string(c_char_p):
-    def __init__(self, p: str | bytes | None = None):
+    def __init__(self, p: 'CInteropString' = None):
         if p is None:
             p = ""
         if isinstance(p, str):
@@ -120,7 +132,7 @@ class c_interop_string(c_char_p):
         return val.decode("utf8")
 
     @classmethod
-    def from_param(cls, param: str | bytes | None) -> c_interop_string:
+    def from_param(cls, param: 'CInteropString') -> c_interop_string:
         if isinstance(param, str):
             return cls(param)
         if isinstance(param, bytes):
@@ -136,6 +148,8 @@ class c_interop_string(c_char_p):
     def to_python_string(x: c_interop_string, *args: Any) -> str | None:
         return x.value
 
+CInteropString = Annotated[TUnion[str, bytes, None], ANNO_CONVERTIBLE, c_interop_string]
+
 
 def b(x: str | bytes) -> bytes:
     if isinstance(x, bytes):
@@ -147,7 +161,8 @@ def b(x: str | bytes) -> bytes:
 # object. This is a problem, because it means that from_parameter will see an
 # integer and pass the wrong value on platforms where int != void*. Work around
 # this by marshalling object arguments as void**.
-c_object_p: TType[_Pointer[Any]] = POINTER(c_void_p)
+CObjectP = CPointer[c_void_p]
+c_object_p: TType[CObjectP] = convert_annotation(CObjectP)
 
 ### Exception Classes ###
 
@@ -183,7 +198,7 @@ class TranslationUnitSaveError(Exception):
     # Indicates that the translation unit was somehow invalid.
     ERROR_INVALID_TU = 3
 
-    def __init__(self, enumeration, message):
+    def __init__(self, enumeration: int, message: str):
         assert isinstance(enumeration, int)
 
         if enumeration < 1 or enumeration > 3:
@@ -241,7 +256,7 @@ class _CXString(Structure):
         conf.lib.clang_disposeString(self)
 
     @staticmethod
-    def from_result(res: _CXString, fn: Any = None, args: Any = None) -> str:
+    def from_result(res: _CXString, fn: Optional[Callable[..., _CXString]] = None, args: Optional[Tuple[Any, ...]] = None) -> str:
         assert isinstance(res, _CXString)
         pystr: str | None = conf.lib.clang_getCString(res)
         if pystr is None:
@@ -271,22 +286,22 @@ class SourceLocation(Structure):
         return self._data
 
     @staticmethod
-    def from_position(tu, file, line, column):
+    def from_position(tu: TranslationUnit, file: File, line: int, column: int):
         """
         Retrieve the source location associated with a given file/line/column in
         a particular translation unit.
         """
-        return conf.lib.clang_getLocation(tu, file, line, column)  # type: ignore [no-any-return]
+        return conf.lib.clang_getLocation(tu, file, line, column)
 
     @staticmethod
-    def from_offset(tu, file, offset):
+    def from_offset(tu: TranslationUnit, file: File, offset: int):
         """Retrieve a SourceLocation from a given character offset.
 
         tu -- TranslationUnit file belongs to
         file -- File instance to obtain offset from
         offset -- Integer character offset within file
         """
-        return conf.lib.clang_getLocationForOffset(tu, file, offset)  # type: ignore [no-any-return]
+        return conf.lib.clang_getLocationForOffset(tu, file, offset)
 
     @property
     def file(self):
@@ -311,12 +326,14 @@ class SourceLocation(Structure):
     @property
     def is_in_system_header(self):
         """Returns true if the given source location is in a system header."""
-        return conf.lib.clang_Location_isInSystemHeader(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Location_isInSystemHeader(self)
 
-    def __eq__(self, other):
-        return conf.lib.clang_equalLocations(self, other)  # type: ignore [no-any-return]
+    def __eq__(self, other: object):
+        if not isinstance(other, SourceLocation):
+            return NotImplemented
+        return conf.lib.clang_equalLocations(self, other)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         return not self.__eq__(other)
 
     def __repr__(self):
@@ -346,8 +363,8 @@ class SourceRange(Structure):
     # FIXME: Eliminate this and make normal constructor? Requires hiding ctypes
     # object.
     @staticmethod
-    def from_locations(start, end):
-        return conf.lib.clang_getRange(start, end)  # type: ignore [no-any-return]
+    def from_locations(start: SourceLocation, end: SourceLocation):
+        return conf.lib.clang_getRange(start, end)
 
     @property
     def start(self):
@@ -355,7 +372,7 @@ class SourceRange(Structure):
         Return a SourceLocation representing the first character within a
         source range.
         """
-        return conf.lib.clang_getRangeStart(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getRangeStart(self)
 
     @property
     def end(self):
@@ -363,23 +380,26 @@ class SourceRange(Structure):
         Return a SourceLocation representing the last character within a
         source range.
         """
-        return conf.lib.clang_getRangeEnd(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getRangeEnd(self)
 
-    def __eq__(self, other):
-        return conf.lib.clang_equalRanges(self, other)  # type: ignore [no-any-return]
+    def __eq__(self, other: object):
+        if not isinstance(other, SourceRange):
+            return NotImplemented
+        return conf.lib.clang_equalRanges(self, other)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         return not self.__eq__(other)
 
-    def __contains__(self, other):
+    def __contains__(self, other: object):
         """Useful to detect the Token/Lexer bug"""
         if not isinstance(other, SourceLocation):
             return False
-        if other.file is None and self.start.file is None:
-            pass
-        elif (
-            self.start.file.name != other.file.name
-            or other.file.name != self.end.file.name
+        if (
+            other.file is not None
+            and self.start.file is not None
+            and self.end.file is not None
+            and (other.file.name != self.start.file.name
+                 or other.file.name != self.end.file.name)
         ):
             # same file name
             return False
@@ -421,7 +441,9 @@ class Diagnostic:
     DisplayCategoryName = 0x20
     _FormatOptionsMask = 0x3F
 
-    def __init__(self, ptr):
+    ptr: CObjectP
+
+    def __init__(self, ptr: CObjectP):
         self.ptr = ptr
 
     def __del__(self):
@@ -429,15 +451,15 @@ class Diagnostic:
 
     @property
     def severity(self):
-        return conf.lib.clang_getDiagnosticSeverity(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getDiagnosticSeverity(self)
 
     @property
     def location(self):
-        return conf.lib.clang_getDiagnosticLocation(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getDiagnosticLocation(self)
 
     @property
     def spelling(self):
-        return conf.lib.clang_getDiagnosticSpelling(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getDiagnosticSpelling(self)
 
     @property
     def ranges(self) -> NoSliceSequence[SourceRange]:
@@ -451,7 +473,7 @@ class Diagnostic:
             def __getitem__(self, key: int) -> SourceRange:
                 if key >= len(self):
                     raise IndexError
-                return conf.lib.clang_getDiagnosticRange(self.diag, key)  # type: ignore [no-any-return]
+                return conf.lib.clang_getDiagnosticRange(self.diag, key)
 
         return RangeIterator(self)
 
@@ -494,17 +516,17 @@ class Diagnostic:
     @property
     def category_number(self):
         """The category number for this diagnostic or 0 if unavailable."""
-        return conf.lib.clang_getDiagnosticCategory(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getDiagnosticCategory(self)
 
     @property
     def category_name(self):
         """The string name of the category for this diagnostic."""
-        return conf.lib.clang_getDiagnosticCategoryText(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getDiagnosticCategoryText(self)
 
     @property
     def option(self):
         """The command-line option that enables this diagnostic."""
-        return conf.lib.clang_getDiagnosticOption(self, None)  # type: ignore [no-any-return]
+        return conf.lib.clang_getDiagnosticOption(self, None)
 
     @property
     def disable_option(self):
@@ -513,7 +535,7 @@ class Diagnostic:
         conf.lib.clang_getDiagnosticOption(self, byref(disable))
         return _CXString.from_result(disable)
 
-    def format(self, options=None):
+    def format(self, options: Optional[int] = None):
         """
         Format this diagnostic for display. The options argument takes
         Diagnostic.Display* flags, which can be combined using bitwise OR. If
@@ -524,7 +546,7 @@ class Diagnostic:
             options = conf.lib.clang_defaultDiagnosticDisplayOptions()
         if options & ~Diagnostic._FormatOptionsMask:
             raise ValueError("Invalid format options")
-        return conf.lib.clang_formatDiagnostic(self, options)  # type: ignore [no-any-return]
+        return conf.lib.clang_formatDiagnostic(self, options)
 
     def __repr__(self):
         return "<Diagnostic severity %r, location %r, spelling %r>" % (
@@ -547,7 +569,10 @@ class FixIt:
     with the given value.
     """
 
-    def __init__(self, range, value):
+    range: SourceRange
+    value: str
+
+    def __init__(self, range: SourceRange, value: str):
         self.range = range
         self.value = value
 
@@ -570,7 +595,11 @@ class TokenGroup:
     You should not instantiate this class outside of this module.
     """
 
-    def __init__(self, tu, memory, count):
+    _tu: TranslationUnit
+    _memory: CPointer[Token]
+    _count: c_uint
+
+    def __init__(self, tu: TranslationUnit, memory: CPointer[Token], count: c_uint):
         self._tu = tu
         self._memory = memory
         self._count = count
@@ -579,7 +608,7 @@ class TokenGroup:
         conf.lib.clang_disposeTokens(self._tu, self._memory, self._count)
 
     @staticmethod
-    def get_tokens(tu, extent):
+    def get_tokens(tu: TranslationUnit, extent: SourceRange):
         """Helper method to return all tokens in an extent.
 
         This functionality is needed multiple places in this module. We define
@@ -622,7 +651,7 @@ class BaseEnumeration(Enum):
         return self.value
 
     @classmethod
-    def from_id(cls, id):
+    def from_id(cls, id: int):
         return cls(id)
 
     def __repr__(self):
@@ -636,7 +665,7 @@ class TokenKind(BaseEnumeration):
     """Describes a specific type of a Token."""
 
     @classmethod
-    def from_value(cls, value):
+    def from_value(cls, value: int):
         """Obtain a registered TokenKind instance from its value."""
         return cls.from_id(value)
 
@@ -659,39 +688,38 @@ class CursorKind(BaseEnumeration):
 
     def is_declaration(self):
         """Test if this is a declaration kind."""
-        return conf.lib.clang_isDeclaration(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isDeclaration(self)
 
     def is_reference(self):
         """Test if this is a reference kind."""
-        return conf.lib.clang_isReference(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isReference(self)
 
     def is_expression(self):
         """Test if this is an expression kind."""
-        return conf.lib.clang_isExpression(self)  # type: ignore [no-any-return]
-
+        return conf.lib.clang_isExpression(self)
     def is_statement(self):
         """Test if this is a statement kind."""
-        return conf.lib.clang_isStatement(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isStatement(self)
 
     def is_attribute(self):
         """Test if this is an attribute kind."""
-        return conf.lib.clang_isAttribute(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isAttribute(self)
 
     def is_invalid(self):
         """Test if this is an invalid kind."""
-        return conf.lib.clang_isInvalid(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isInvalid(self)
 
     def is_translation_unit(self):
         """Test if this is a translation unit kind."""
-        return conf.lib.clang_isTranslationUnit(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isTranslationUnit(self)
 
     def is_preprocessing(self):
         """Test if this is a preprocessing kind."""
-        return conf.lib.clang_isPreprocessing(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isPreprocessing(self)
 
     def is_unexposed(self):
         """Test if this is an unexposed kind."""
-        return conf.lib.clang_isUnexposed(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isUnexposed(self)
 
 
     ###
@@ -1555,7 +1583,7 @@ class Cursor(Structure):
     _fields_ = [("_kind_id", c_int), ("xdata", c_int), ("data", c_void_p * 3)]
 
     @staticmethod
-    def from_location(tu, location):
+    def from_location(tu: TranslationUnit, location: SourceLocation):
         # We store a reference to the TU in the instance so the TU won't get
         # collected before the cursor.
         cursor = conf.lib.clang_getCursor(tu, location)
@@ -1563,10 +1591,12 @@ class Cursor(Structure):
 
         return cursor
 
-    def __eq__(self, other):
-        return conf.lib.clang_equalCursors(self, other)  # type: ignore [no-any-return]
+    def __eq__(self, other: object):
+        if not isinstance(other, Cursor):
+            return NotImplemented
+        return conf.lib.clang_equalCursors(self, other)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         return not self.__eq__(other)
 
     def is_definition(self):
@@ -1574,41 +1604,41 @@ class Cursor(Structure):
         Returns true if the declaration pointed at by the cursor is also a
         definition of that entity.
         """
-        return conf.lib.clang_isCursorDefinition(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isCursorDefinition(self)
 
     def is_const_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared 'const'.
         """
-        return conf.lib.clang_CXXMethod_isConst(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isConst(self)
 
     def is_converting_constructor(self):
         """Returns True if the cursor refers to a C++ converting constructor."""
-        return conf.lib.clang_CXXConstructor_isConvertingConstructor(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXConstructor_isConvertingConstructor(self)
 
     def is_copy_constructor(self):
         """Returns True if the cursor refers to a C++ copy constructor."""
-        return conf.lib.clang_CXXConstructor_isCopyConstructor(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXConstructor_isCopyConstructor(self)
 
     def is_default_constructor(self):
         """Returns True if the cursor refers to a C++ default constructor."""
-        return conf.lib.clang_CXXConstructor_isDefaultConstructor(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXConstructor_isDefaultConstructor(self)
 
     def is_move_constructor(self):
         """Returns True if the cursor refers to a C++ move constructor."""
-        return conf.lib.clang_CXXConstructor_isMoveConstructor(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXConstructor_isMoveConstructor(self)
 
     def is_default_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared '= default'.
         """
-        return conf.lib.clang_CXXMethod_isDefaulted(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isDefaulted(self)
 
     def is_deleted_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared '= delete'.
         """
-        return conf.lib.clang_CXXMethod_isDeleted(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isDeleted(self)
 
     def is_copy_assignment_operator_method(self):
         """Returnrs True if the cursor refers to a copy-assignment operator.
@@ -1633,7 +1663,7 @@ class Cursor(Structure):
 
         Is not.
         """
-        return conf.lib.clang_CXXMethod_isCopyAssignmentOperator(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isCopyAssignmentOperator(self)
 
     def is_move_assignment_operator_method(self):
         """Returnrs True if the cursor refers to a move-assignment operator.
@@ -1658,7 +1688,7 @@ class Cursor(Structure):
 
         Is not.
         """
-        return conf.lib.clang_CXXMethod_isMoveAssignmentOperator(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isMoveAssignmentOperator(self)
 
     def is_explicit_method(self):
         """Determines if a C++ constructor or conversion function is
@@ -1703,41 +1733,41 @@ class Cursor(Structure):
         This method will return 0 for the constructor and 1 for
         the conversion function.
         """
-        return conf.lib.clang_CXXMethod_isExplicit(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isExplicit(self)
 
     def is_mutable_field(self):
         """Returns True if the cursor refers to a C++ field that is declared
         'mutable'.
         """
-        return conf.lib.clang_CXXField_isMutable(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXField_isMutable(self)
 
     def is_pure_virtual_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared pure virtual.
         """
-        return conf.lib.clang_CXXMethod_isPureVirtual(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isPureVirtual(self)
 
     def is_static_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared 'static'.
         """
-        return conf.lib.clang_CXXMethod_isStatic(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isStatic(self)
 
     def is_virtual_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared 'virtual'.
         """
-        return conf.lib.clang_CXXMethod_isVirtual(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXMethod_isVirtual(self)
 
     def is_abstract_record(self):
         """Returns True if the cursor refers to a C++ record declaration
         that has pure virtual member functions.
         """
-        return conf.lib.clang_CXXRecord_isAbstract(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXXRecord_isAbstract(self)
 
     def is_scoped_enum(self):
         """Returns True if the cursor refers to a scoped enum declaration."""
-        return conf.lib.clang_EnumDecl_isScoped(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_EnumDecl_isScoped(self)
 
     def get_definition(self):
         """
@@ -1747,7 +1777,7 @@ class Cursor(Structure):
         """
         # TODO: Should probably check that this is either a reference or
         # declaration prior to issuing the lookup.
-        return conf.lib.clang_getCursorDefinition(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getCursorDefinition(self)
 
     def get_usr(self):
         """Return the Unified Symbol Resolution (USR) for the entity referenced
@@ -1758,13 +1788,13 @@ class Cursor(Structure):
         program. USRs can be compared across translation units to determine,
         e.g., when references in one translation refer to an entity defined in
         another translation unit."""
-        return conf.lib.clang_getCursorUSR(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getCursorUSR(self)
 
     def get_included_file(self):
         """Returns the File that is included by the current inclusion cursor."""
         assert self.kind == CursorKind.INCLUSION_DIRECTIVE
 
-        return conf.lib.clang_getIncludedFile(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getIncludedFile(self)
 
     @property
     def kind(self):
@@ -1964,7 +1994,9 @@ class Cursor(Structure):
             # is a signed or unsigned quantity.
             underlying_type = self.type
             if underlying_type.kind == TypeKind.ENUM:
-                underlying_type = underlying_type.get_declaration().enum_type
+                decl = underlying_type.get_declaration()
+                assert decl is not None
+                underlying_type = decl.enum_type
             if underlying_type.kind in (
                 TypeKind.CHAR_U,
                 TypeKind.UCHAR,
@@ -2034,12 +2066,12 @@ class Cursor(Structure):
     @property
     def brief_comment(self):
         """Returns the brief comment text associated with that Cursor"""
-        return conf.lib.clang_Cursor_getBriefCommentText(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getBriefCommentText(self)
 
     @property
     def raw_comment(self):
         """Returns the raw comment text associated with that Cursor"""
-        return conf.lib.clang_Cursor_getRawCommentText(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getRawCommentText(self)
 
     def get_arguments(self):
         """Return an iterator for accessing the arguments of this cursor."""
@@ -2049,30 +2081,30 @@ class Cursor(Structure):
 
     def get_num_template_arguments(self):
         """Returns the number of template args associated with this cursor."""
-        return conf.lib.clang_Cursor_getNumTemplateArguments(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getNumTemplateArguments(self)
 
-    def get_template_argument_kind(self, num):
+    def get_template_argument_kind(self, num: int):
         """Returns the TemplateArgumentKind for the indicated template
         argument."""
-        return conf.lib.clang_Cursor_getTemplateArgumentKind(self, num)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getTemplateArgumentKind(self, num)
 
-    def get_template_argument_type(self, num):
+    def get_template_argument_type(self, num: int):
         """Returns the CXType for the indicated template argument."""
-        return conf.lib.clang_Cursor_getTemplateArgumentType(self, num)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getTemplateArgumentType(self, num)
 
-    def get_template_argument_value(self, num):
+    def get_template_argument_value(self, num: int):
         """Returns the value of the indicated arg as a signed 64b integer."""
-        return conf.lib.clang_Cursor_getTemplateArgumentValue(self, num)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getTemplateArgumentValue(self, num)
 
-    def get_template_argument_unsigned_value(self, num):
+    def get_template_argument_unsigned_value(self, num: int):
         """Returns the value of the indicated arg as an unsigned 64b integer."""
-        return conf.lib.clang_Cursor_getTemplateArgumentUnsignedValue(self, num)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getTemplateArgumentUnsignedValue(self, num)
 
     def get_children(self):
         """Return an iterator for accessing the children of this cursor."""
 
         # FIXME: Expose iteration from CIndex, PR6125.
-        def visitor(child, parent, children):
+        def visitor(child: Cursor, parent: Cursor, children: list[Cursor]) -> int:
             # FIXME: Document this assertion in API.
             # FIXME: There should just be an isNull method.
             assert child != conf.lib.clang_getNullCursor()
@@ -2086,7 +2118,7 @@ class Cursor(Structure):
         conf.lib.clang_visitChildren(self, cursor_visit_callback(visitor), children)
         return iter(children)
 
-    def walk_preorder(self):
+    def walk_preorder(self) -> Generator[Cursor, None, None]:
         """Depth-first preorder walk over the cursor and its descendants.
 
         Yields cursors.
@@ -2106,30 +2138,32 @@ class Cursor(Structure):
 
     def get_field_offsetof(self):
         """Returns the offsetof the FIELD_DECL pointed by this Cursor."""
-        return conf.lib.clang_Cursor_getOffsetOfField(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_getOffsetOfField(self)
 
-    def is_anonymous(self):
+    def is_anonymous(self) -> bool:
         """
         Check if the record is anonymous.
         """
         if self.kind == CursorKind.FIELD_DECL:
-            return self.type.get_declaration().is_anonymous()
-        return conf.lib.clang_Cursor_isAnonymous(self)  # type: ignore [no-any-return]
+            decl = self.type.get_declaration()
+            assert decl is not None
+            return decl.is_anonymous()
+        return conf.lib.clang_Cursor_isAnonymous(self)
 
     def is_bitfield(self):
         """
         Check if the field is a bitfield.
         """
-        return conf.lib.clang_Cursor_isBitField(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Cursor_isBitField(self)
 
     def get_bitfield_width(self):
         """
         Retrieve the width of a bitfield.
         """
-        return conf.lib.clang_getFieldDeclBitWidth(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getFieldDeclBitWidth(self)
 
     @staticmethod
-    def from_result(res, fn, args):
+    def from_result(res: Cursor, fn: Callable[..., Cursor], args: Tuple[Any, ...]) -> Optional[Cursor]:
         assert isinstance(res, Cursor)
         # FIXME: There should just be an isNull method.
         if res == conf.lib.clang_getNullCursor():
@@ -2153,7 +2187,7 @@ class Cursor(Structure):
         return res
 
     @staticmethod
-    def from_cursor_result(res, fn, args):
+    def from_cursor_result(res: Cursor, fn: Callable[..., Cursor], args: Tuple[Any, ...]) -> Optional[Cursor]:
         assert isinstance(res, Cursor)
         if res == conf.lib.clang_getNullCursor():
             return None
@@ -2263,7 +2297,7 @@ class TypeKind(BaseEnumeration):
     @property
     def spelling(self):
         """Retrieve the spelling of this TypeKind."""
-        return conf.lib.clang_getTypeKindSpelling(self.value)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTypeKindSpelling(self.value)
 
     INVALID = 0
     UNEXPOSED = 1
@@ -2439,7 +2473,7 @@ class Type(Structure):
 
             def __getitem__(self, key: int) -> Type:
                 # FIXME Support slice objects.
-                if not isinstance(key, int):
+                if not isinstance(key, int): # pyright: ignore[reportUnnecessaryIsInstance]
                     raise TypeError("Must supply a non-negative int.")
 
                 if key < 0:
@@ -2495,7 +2529,7 @@ class Type(Structure):
         return self._tu
 
     @staticmethod
-    def from_result(res, fn, args):
+    def from_result(res: Type, fn: Callable[..., Type], args: Tuple[Any, ...]) -> Type:
         assert isinstance(res, Type)
 
         tu = None
@@ -2510,10 +2544,10 @@ class Type(Structure):
         return res
 
     def get_num_template_arguments(self):
-        return conf.lib.clang_Type_getNumTemplateArguments(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
 
-    def get_template_argument_type(self, num):
-        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)  # type: ignore [no-any-return]
+    def get_template_argument_type(self, num: int):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
 
     def get_canonical(self):
         """
@@ -2525,7 +2559,7 @@ class Type(Structure):
         example, if 'T' is a typedef for 'int', the canonical type for
         'T' would be 'int'.
         """
-        return conf.lib.clang_getCanonicalType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getCanonicalType(self)
 
     def is_const_qualified(self):
         """Determine whether a Type has the "const" qualifier set.
@@ -2533,7 +2567,7 @@ class Type(Structure):
         This does not look through typedefs that may have added "const"
         at a different level.
         """
-        return conf.lib.clang_isConstQualifiedType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isConstQualifiedType(self)
 
     def is_volatile_qualified(self):
         """Determine whether a Type has the "volatile" qualifier set.
@@ -2541,7 +2575,7 @@ class Type(Structure):
         This does not look through typedefs that may have added "volatile"
         at a different level.
         """
-        return conf.lib.clang_isVolatileQualifiedType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isVolatileQualifiedType(self)
 
     def is_restrict_qualified(self):
         """Determine whether a Type has the "restrict" qualifier set.
@@ -2549,83 +2583,83 @@ class Type(Structure):
         This does not look through typedefs that may have added "restrict" at
         a different level.
         """
-        return conf.lib.clang_isRestrictQualifiedType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isRestrictQualifiedType(self)
 
     def is_function_variadic(self):
         """Determine whether this function Type is a variadic function type."""
         assert self.kind == TypeKind.FUNCTIONPROTO
 
-        return conf.lib.clang_isFunctionTypeVariadic(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isFunctionTypeVariadic(self)
 
     def get_address_space(self):
-        return conf.lib.clang_getAddressSpace(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getAddressSpace(self)
 
     def get_typedef_name(self):
-        return conf.lib.clang_getTypedefName(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTypedefName(self)
 
     def is_pod(self):
         """Determine whether this Type represents plain old data (POD)."""
-        return conf.lib.clang_isPODType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_isPODType(self)
 
     def get_pointee(self):
         """
         For pointer types, returns the type of the pointee.
         """
-        return conf.lib.clang_getPointeeType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getPointeeType(self)
 
     def get_declaration(self):
         """
         Return the cursor for the declaration of the given type.
         """
-        return conf.lib.clang_getTypeDeclaration(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTypeDeclaration(self)
 
     def get_result(self):
         """
         Retrieve the result type associated with a function type.
         """
-        return conf.lib.clang_getResultType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getResultType(self)
 
     def get_array_element_type(self):
         """
         Retrieve the type of the elements of the array type.
         """
-        return conf.lib.clang_getArrayElementType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getArrayElementType(self)
 
     def get_array_size(self):
         """
         Retrieve the size of the constant array.
         """
-        return conf.lib.clang_getArraySize(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getArraySize(self)
 
     def get_class_type(self):
         """
         Retrieve the class type of the member pointer type.
         """
-        return conf.lib.clang_Type_getClassType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Type_getClassType(self)
 
     def get_named_type(self):
         """
         Retrieve the type named by the qualified-id.
         """
-        return conf.lib.clang_Type_getNamedType(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Type_getNamedType(self)
 
     def get_align(self):
         """
         Retrieve the alignment of the record.
         """
-        return conf.lib.clang_Type_getAlignOf(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Type_getAlignOf(self)
 
     def get_size(self):
         """
         Retrieve the size of the record.
         """
-        return conf.lib.clang_Type_getSizeOf(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_Type_getSizeOf(self)
 
-    def get_offset(self, fieldname):
+    def get_offset(self, fieldname: str):
         """
         Retrieve the offset of a field in the record.
         """
-        return conf.lib.clang_Type_getOffsetOf(self, fieldname)  # type: ignore [no-any-return]
+        return conf.lib.clang_Type_getOffsetOf(self, fieldname)
 
     def get_ref_qualifier(self):
         """
@@ -2636,7 +2670,7 @@ class Type(Structure):
     def get_fields(self):
         """Return an iterator for accessing the fields of this type."""
 
-        def visitor(field, children):
+        def visitor(field: Cursor, children: List[Cursor]):
             assert field != conf.lib.clang_getNullCursor()
 
             # Create reference to TU so it isn't GC'd before Cursor.
@@ -2644,7 +2678,7 @@ class Type(Structure):
             fields.append(field)
             return 1  # continue
 
-        fields: list[Cursor] = []
+        fields: List[Cursor] = []
         conf.lib.clang_Type_visitFields(self, fields_visit_callback(visitor), fields)
         return iter(fields)
 
@@ -2654,21 +2688,23 @@ class Type(Structure):
         the ExceptionSpecificationKind enumeration.
         """
         return ExceptionSpecificationKind.from_id(
-            conf.lib.clang.getExceptionSpecificationType(self)
+            conf.lib.clang_getExceptionSpecificationType(self)
         )
 
     @property
     def spelling(self):
         """Retrieve the spelling of this Type."""
-        return conf.lib.clang_getTypeSpelling(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTypeSpelling(self)
 
-    def __eq__(self, other):
-        if type(other) != type(self):
+    def __eq__(self, other: object):
+        if other is None: # in case user write `x.type == None`
             return False
+        elif not isinstance(other, Type):
+            return NotImplemented
+        else:
+            return conf.lib.clang_equalTypes(self, other)
 
-        return conf.lib.clang_equalTypes(self, other)  # type: ignore [no-any-return]
-
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         return not self.__eq__(other)
 
 
@@ -2684,13 +2720,17 @@ class ClangObject:
     A helper for Clang objects. This class helps act as an intermediary for
     the ctypes library and the Clang CIndex library.
     """
+    obj: CObjectP
+    _as_parameter_: CObjectP
 
-    def __init__(self, obj):
+    def __init__(self, obj: CObjectP):
         assert isinstance(obj, c_object_p) and obj
         self.obj = self._as_parameter_ = obj
 
     def from_param(self):
         return self._as_parameter_
+
+ClangObjectParam = Annotated[TUnion[CObjectP, ClangObject], ANNO_CONVERTIBLE, c_object_p]
 
 
 class _CXUnsavedFile(Structure):
@@ -2698,6 +2738,7 @@ class _CXUnsavedFile(Structure):
 
     _fields_ = [("name", c_char_p), ("contents", c_char_p), ("length", c_ulong)]
 
+UnsavedFileInfo: TypeAlias = Tuple['FsPath', TUnion['StrOrBytes', 'SupportsReadStringData']]
 
 # Functions calls through the python interface are rather slow. Fortunately,
 # for most symboles, we do not need to perform a function call. Their spelling
@@ -2729,7 +2770,9 @@ SpellingCache = {
 
 class CompletionChunk:
     class Kind:
-        def __init__(self, name):
+        name: str
+
+        def __init__(self, name: str):
             self.name = name
 
         def __str__(self):
@@ -2738,7 +2781,10 @@ class CompletionChunk:
         def __repr__(self):
             return "<ChunkKind: %s>" % self
 
-    def __init__(self, completionString, key):
+    cs: CObjectP
+    key: int
+
+    def __init__(self, completionString: CObjectP, key: int):
         self.cs = completionString
         self.key = key
         self.__kindNumberCache = -1
@@ -2750,7 +2796,7 @@ class CompletionChunk:
     def spelling(self):
         if self.__kindNumber in SpellingCache:
             return SpellingCache[self.__kindNumber]
-        return conf.lib.clang_getCompletionChunkText(self.cs, self.key)  # type: ignore [no-any-return]
+        return conf.lib.clang_getCompletionChunkText(self.cs, self.key)
 
     # We do not use @CachedProperty here, as the manual implementation is
     # apparently still significantly faster. Please profile carefully if you
@@ -2770,11 +2816,7 @@ class CompletionChunk:
     @CachedProperty
     def string(self):
         res = conf.lib.clang_getCompletionChunkCompletionString(self.cs, self.key)
-
-        if res:
-            return CompletionString(res)
-        else:
-            None
+        return CompletionString(res) if res else None
 
     def isKindOptional(self):
         return self.__kindNumber == 0
@@ -2819,7 +2861,9 @@ completionChunkKindMap = {
 
 class CompletionString(ClangObject):
     class Availability:
-        def __init__(self, name):
+        name: str
+
+        def __init__(self, name: str):
             self.name = name
 
         def __str__(self):
@@ -2833,16 +2877,16 @@ class CompletionString(ClangObject):
 
     @CachedProperty
     def num_chunks(self):
-        return conf.lib.clang_getNumCompletionChunks(self.obj)  # type: ignore [no-any-return]
+        return conf.lib.clang_getNumCompletionChunks(self.obj)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int):
         if self.num_chunks <= key:
             raise IndexError
         return CompletionChunk(self.obj, key)
 
     @property
     def priority(self):
-        return conf.lib.clang_getCompletionPriority(self.obj)  # type: ignore [no-any-return]
+        return conf.lib.clang_getCompletionPriority(self.obj)
 
     @property
     def availability(self):
@@ -2852,7 +2896,7 @@ class CompletionString(ClangObject):
     @property
     def briefComment(self):
         if conf.function_exists("clang_getCompletionBriefComment"):
-            return conf.lib.clang_getCompletionBriefComment(self.obj)  # type: ignore [no-any-return]
+            return conf.lib.clang_getCompletionBriefComment(self.obj)
         return _CXString()
 
     def __repr__(self):
@@ -2893,10 +2937,10 @@ class CodeCompletionResult(Structure):
 class CCRStructure(Structure):
     _fields_ = [("results", POINTER(CodeCompletionResult)), ("numResults", c_int)]
 
-    def __len__(self):
+    def __len__(self) -> r_int:
         return self.numResults
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int) -> CodeCompletionResult:
         if len(self) <= key:
             raise IndexError
 
@@ -2904,23 +2948,25 @@ class CCRStructure(Structure):
 
 
 class CodeCompletionResults(ClangObject):
-    def __init__(self, ptr):
-        assert isinstance(ptr, POINTER(CCRStructure)) and ptr
-        self.ptr = self._as_parameter_ = ptr
+    obj: CPointer[CCRStructure] # type: ignore[assignment]
+    _as_parameter_: CPointer[CCRStructure] # type: ignore[assignment]
 
-    def from_param(self):
-        return self._as_parameter_
+    def __init__(self, ptr: CPointer[CCRStructure]):
+        assert isinstance(ptr, POINTER(CCRStructure)) and ptr
+        self.obj = self._as_parameter_ = ptr # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __del__(self):
         conf.lib.clang_disposeCodeCompleteResults(self)
 
     @property
     def results(self):
-        return self.ptr.contents
+        return self.obj.contents
 
     @property
     def diagnostics(self) -> NoSliceSequence[Diagnostic]:
         class DiagnosticsItr:
+            ccr: CodeCompletionResults
+
             def __init__(self, ccr: CodeCompletionResults):
                 self.ccr = ccr
 
@@ -2928,7 +2974,7 @@ class CodeCompletionResults(ClangObject):
                 return int(conf.lib.clang_codeCompleteGetNumDiagnostics(self.ccr))
 
             def __getitem__(self, key: int) -> Diagnostic:
-                return conf.lib.clang_codeCompleteGetDiagnostic(self.ccr, key)  # type: ignore [no-any-return]
+                return conf.lib.clang_codeCompleteGetDiagnostic(self.ccr, key)
 
         return DiagnosticsItr(self)
 
@@ -2941,7 +2987,7 @@ class Index(ClangObject):
     """
 
     @staticmethod
-    def create(excludeDecls=False):
+    def create(excludeDecls: bool = False):
         """
         Create a new Index.
         Parameters:
@@ -2952,11 +2998,16 @@ class Index(ClangObject):
     def __del__(self):
         conf.lib.clang_disposeIndex(self)
 
-    def read(self, path):
+    def read(self, path: FsPath):
         """Load a TranslationUnit from the given AST file."""
         return TranslationUnit.from_ast_file(path, self)
 
-    def parse(self, path, args=None, unsaved_files=None, options=0):
+    def parse(
+        self, path: Optional[FsPath],
+        args: Optional[List[str]] = None,
+        unsaved_files: Optional[List[UnsavedFileInfo]] = None,
+        options: int = 0,
+    ):
         """Load the translation unit from the given source code file by running
         clang and generating the AST before loading. Additional command line
         parameters can be passed to clang via the args parameter.
@@ -3012,14 +3063,14 @@ class TranslationUnit(ClangObject):
     PARSE_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION = 128
 
     @staticmethod
-    def process_unsaved_files(unsaved_files) -> Array[_CXUnsavedFile] | None:
+    def process_unsaved_files(unsaved_files: List[UnsavedFileInfo]) -> Optional[CArray[_CXUnsavedFile]]:
         unsaved_array = None
         if len(unsaved_files):
             unsaved_array = (_CXUnsavedFile * len(unsaved_files))()
             for i, (name, contents) in enumerate(unsaved_files):
                 if hasattr(contents, "read"):
-                    contents = contents.read()
-                binary_contents = b(contents)
+                    contents = tcast('SupportsReadStringData', contents).read()
+                binary_contents = b(tcast('StrOrBytes', contents))
                 unsaved_array[i].name = b(os.fspath(name))
                 unsaved_array[i].contents = binary_contents
                 unsaved_array[i].length = len(binary_contents)
@@ -3027,7 +3078,11 @@ class TranslationUnit(ClangObject):
 
     @classmethod
     def from_source(
-        cls, filename, args=None, unsaved_files=None, options=0, index=None
+        cls, filename: Optional[FsPath],
+        args: Optional[List[str]] = None,
+        unsaved_files: Optional[List[UnsavedFileInfo]] = None,
+        options: int = 0,
+        index: Optional[Index] = None
     ):
         """Create a TranslationUnit by parsing source.
 
@@ -3099,7 +3154,7 @@ class TranslationUnit(ClangObject):
         return cls(ptr, index=index)
 
     @classmethod
-    def from_ast_file(cls, filename, index=None):
+    def from_ast_file(cls, filename: FsPath, index: Optional[Index] = None):
         """Create a TranslationUnit instance from a saved AST file.
 
         A previously-saved AST file (provided with -emit-ast or
@@ -3122,7 +3177,7 @@ class TranslationUnit(ClangObject):
 
         return cls(ptr=ptr, index=index)
 
-    def __init__(self, ptr, index):
+    def __init__(self, ptr: CObjectP, index: Index):
         """Create a TranslationUnit instance.
 
         TranslationUnits should be created using one of the from_* @classmethod
@@ -3138,12 +3193,12 @@ class TranslationUnit(ClangObject):
     @property
     def cursor(self):
         """Retrieve the cursor that represents the given translation unit."""
-        return conf.lib.clang_getTranslationUnitCursor(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTranslationUnitCursor(self)
 
     @property
     def spelling(self):
         """Get the original translation unit source file name."""
-        return conf.lib.clang_getTranslationUnitSpelling(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTranslationUnitSpelling(self)
 
     def get_includes(self):
         """
@@ -3154,25 +3209,25 @@ class TranslationUnit(ClangObject):
         headers.
         """
 
-        def visitor(fobj, lptr, depth, includes):
+        def visitor(fobj: CObjectP, lptr: CPointer[SourceLocation], depth: int, includes: List[FileInclusion]) -> None:
             if depth > 0:
                 loc = lptr.contents
                 includes.append(FileInclusion(loc.file, File(fobj), loc, depth))
 
         # Automatically adapt CIndex/ctype pointers to python objects
-        includes = []
+        includes: List[FileInclusion] = []
         conf.lib.clang_getInclusions(
             self, translation_unit_includes_callback(visitor), includes
         )
 
         return iter(includes)
 
-    def get_file(self, filename):
+    def get_file(self, filename: FsPath):
         """Obtain a File from this translation unit."""
 
         return File.from_name(self, filename)
 
-    def get_location(self, filename, position):
+    def get_location(self, filename: FsPath, position: Tuple[int, int]):
         """Obtain a SourceLocation for a file in this translation unit.
 
         The position can be specified by passing:
@@ -3188,7 +3243,8 @@ class TranslationUnit(ClangObject):
 
         return SourceLocation.from_position(self, f, position[0], position[1])
 
-    def get_extent(self, filename, locations):
+    _Location = TUnion[int, Tuple[int, int], SourceLocation]
+    def get_extent(self, filename: FsPath, locations: Tuple[_Location, _Location]):
         """Obtain a SourceRange from this translation unit.
 
         The bounds of the SourceRange must ultimately be defined by a start and
@@ -3211,6 +3267,7 @@ class TranslationUnit(ClangObject):
         start_location, end_location = locations
 
         if hasattr(start_location, "__len__"):
+            start_location = tcast(Tuple[int, int], start_location)
             start_location = SourceLocation.from_position(
                 self, f, start_location[0], start_location[1]
             )
@@ -3218,6 +3275,7 @@ class TranslationUnit(ClangObject):
             start_location = SourceLocation.from_offset(self, f, start_location)
 
         if hasattr(end_location, "__len__"):
+            end_location = tcast(Tuple[int, int], end_location)
             end_location = SourceLocation.from_position(
                 self, f, end_location[0], end_location[1]
             )
@@ -3236,6 +3294,8 @@ class TranslationUnit(ClangObject):
         """
 
         class DiagIterator:
+            tu: TranslationUnit
+
             def __init__(self, tu: TranslationUnit):
                 self.tu = tu
 
@@ -3250,7 +3310,7 @@ class TranslationUnit(ClangObject):
 
         return DiagIterator(self)
 
-    def reparse(self, unsaved_files=None, options=0):
+    def reparse(self, unsaved_files: Optional[List[UnsavedFileInfo]] = None, options: int = 0):
         """
         Reparse an already parsed translation unit.
 
@@ -3263,11 +3323,11 @@ class TranslationUnit(ClangObject):
             unsaved_files = []
 
         unsaved_files_array = self.process_unsaved_files(unsaved_files)
-        ptr = conf.lib.clang_reparseTranslationUnit(
+        ptr = conf.lib.clang_reparseTranslationUnit( # pyright: ignore[reportUnusedVariable]
             self, len(unsaved_files), unsaved_files_array, options
         )
 
-    def save(self, filename):
+    def save(self, filename: FsPath):
         """Saves the TranslationUnit to a file.
 
         This is equivalent to passing -emit-ast to the clang frontend. The
@@ -3295,13 +3355,13 @@ class TranslationUnit(ClangObject):
 
     def codeComplete(
         self,
-        path,
-        line,
-        column,
-        unsaved_files=None,
-        include_macros=False,
-        include_code_patterns=False,
-        include_brief_comments=False,
+        path: FsPath,
+        line: int,
+        column: int,
+        unsaved_files: Optional[List[UnsavedFileInfo]] = None,
+        include_macros: bool = False,
+        include_code_patterns: bool = False,
+        include_brief_comments: bool = False,
     ):
         """
         Code complete in this translation unit.
@@ -3339,7 +3399,7 @@ class TranslationUnit(ClangObject):
             return CodeCompletionResults(ptr)
         return None
 
-    def get_tokens(self, locations=None, extent=None):
+    def get_tokens(self, locations: Optional[Tuple[SourceLocation, SourceLocation]] = None, extent: Optional[SourceRange] = None):
         """Obtain tokens in this translation unit.
 
         This is a generator for Token instances. The caller specifies a range
@@ -3347,10 +3407,15 @@ class TranslationUnit(ClangObject):
         2-tuple of SourceLocation or as a SourceRange. If both are defined,
         behavior is undefined.
         """
+        
         if locations is not None:
-            extent = SourceRange(start=locations[0], end=locations[1])
+            final_extent = SourceRange.from_locations(start=locations[0], end=locations[1])
+        elif extent is not None:
+            final_extent = extent
+        else:
+            raise ValueError('no extent given')
 
-        return TokenGroup.get_tokens(self, extent)
+        return TokenGroup.get_tokens(self, final_extent)
 
 
 class File(ClangObject):
@@ -3359,8 +3424,10 @@ class File(ClangObject):
     translation unit.
     """
 
+    _tu: TranslationUnit
+
     @staticmethod
-    def from_name(translation_unit, file_name):
+    def from_name(translation_unit: TranslationUnit, file_name: FsPath):
         """Retrieve a file handle within the given translation unit."""
         return File(
             conf.lib.clang_getFile(translation_unit, os.fspath(file_name)),
@@ -3369,12 +3436,12 @@ class File(ClangObject):
     @property
     def name(self):
         """Return the complete file and path name of the file."""
-        return conf.lib.clang_getFileName(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getFileName(self)
 
     @property
     def time(self):
         """Return the last modification time of the file."""
-        return conf.lib.clang_getFileTime(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getFileTime(self)
 
     def __str__(self):
         return self.name
@@ -3383,13 +3450,13 @@ class File(ClangObject):
         return "<File: %s>" % (self.name)
 
     @staticmethod
-    def from_result(res, fn, args):
+    def from_result(res: CObjectP, fn: Callable[..., CObjectP], args: Tuple[Any, ...]):
         assert isinstance(res, c_object_p)
-        res = File(res)
+        resobj = File(res) # type: ignore
 
         # Copy a reference to the TranslationUnit to prevent premature GC.
-        res._tu = args[0]._tu
-        return res
+        resobj._tu = args[0]._tu
+        return resobj
 
 
 class FileInclusion:
@@ -3401,7 +3468,12 @@ class FileInclusion:
     file in the stack. Note that the input file has depth 0.
     """
 
-    def __init__(self, src, tgt, loc, depth):
+    source: Optional[File]
+    include: File
+    location: SourceLocation
+    depth: int
+
+    def __init__(self, src: Optional[File], tgt: File, loc: SourceLocation, depth: int):
         self.source = src
         self.include = tgt
         self.location = loc
@@ -3427,7 +3499,9 @@ class CompilationDatabaseError(Exception):
     # The database could not be loaded
     ERROR_CANNOTLOADDATABASE = 1
 
-    def __init__(self, enumeration, message):
+    cdb_error: int
+
+    def __init__(self, enumeration: int, message: str):
         assert isinstance(enumeration, int)
 
         if enumeration > 1:
@@ -3444,7 +3518,10 @@ class CompilationDatabaseError(Exception):
 class CompileCommand:
     """Represents the compile command used to build a file"""
 
-    def __init__(self, cmd, ccmds):
+    cmd: CObjectP
+    ccmd: CompileCommands
+
+    def __init__(self, cmd: CObjectP, ccmds: CompileCommands):
         self.cmd = cmd
         # Keep a reference to the originating CompileCommands
         # to prevent garbage collection
@@ -3453,12 +3530,12 @@ class CompileCommand:
     @property
     def directory(self):
         """Get the working directory for this CompileCommand"""
-        return conf.lib.clang_CompileCommand_getDirectory(self.cmd)  # type: ignore [no-any-return]
+        return conf.lib.clang_CompileCommand_getDirectory(self.cmd)
 
     @property
     def filename(self):
         """Get the working filename for this CompileCommand"""
-        return conf.lib.clang_CompileCommand_getFilename(self.cmd)  # type: ignore [no-any-return]
+        return conf.lib.clang_CompileCommand_getFilename(self.cmd)
 
     @property
     def arguments(self):
@@ -3479,7 +3556,9 @@ class CompileCommands:
     that can be used for building a specific file.
     """
 
-    def __init__(self, ccmds):
+    ccmds: CObjectP
+
+    def __init__(self, ccmds: CObjectP):
         self.ccmds = ccmds
 
     def __del__(self):
@@ -3488,14 +3567,14 @@ class CompileCommands:
     def __len__(self):
         return int(conf.lib.clang_CompileCommands_getSize(self.ccmds))
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int):
         cc = conf.lib.clang_CompileCommands_getCommand(self.ccmds, i)
         if not cc:
             raise IndexError
         return CompileCommand(cc, self)
 
     @staticmethod
-    def from_result(res, fn, args):
+    def from_result(res: CObjectP, fn: Callable[..., CObjectP], args: Tuple[Any, ...]):
         if not res:
             return None
         return CompileCommands(res)
@@ -3513,13 +3592,13 @@ class CompilationDatabase(ClangObject):
         conf.lib.clang_CompilationDatabase_dispose(self)
 
     @staticmethod
-    def from_result(res, fn, args):
+    def from_result(res: CObjectP, fn: Callable[..., CObjectP], args: Tuple[Any, ...]) -> CompilationDatabase:
         if not res:
             raise CompilationDatabaseError(0, "CompilationDatabase loading failed")
         return CompilationDatabase(res)
 
     @staticmethod
-    def fromDirectory(buildDir):
+    def fromDirectory(buildDir: FsPath):
         """Builds a CompilationDatabase from the database found in buildDir"""
         errorCode = c_uint()
         try:
@@ -3529,15 +3608,15 @@ class CompilationDatabase(ClangObject):
         except CompilationDatabaseError as e:
             raise CompilationDatabaseError(
                 int(errorCode.value), "CompilationDatabase loading failed"
-            )
+            ) from e
         return cdb
 
-    def getCompileCommands(self, filename):
+    def getCompileCommands(self, filename: FsPath):
         """
         Get an iterable object providing all the CompileCommands available to
         build filename. Returns None if filename is not found in the database.
         """
-        return conf.lib.clang_CompilationDatabase_getCompileCommands(  # type: ignore [no-any-return]
+        return conf.lib.clang_CompilationDatabase_getCompileCommands(
             self, os.fspath(filename)
         )
 
@@ -3546,7 +3625,7 @@ class CompilationDatabase(ClangObject):
         Get an iterable object providing all the CompileCommands available from
         the database.
         """
-        return conf.lib.clang_CompilationDatabase_getAllCompileCommands(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CompilationDatabase_getAllCompileCommands(self)
 
 
 class Token(Structure):
@@ -3567,7 +3646,7 @@ class Token(Structure):
 
         This is the textual representation of the token in source.
         """
-        return conf.lib.clang_getTokenSpelling(self._tu, self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTokenSpelling(self._tu, self)
 
     @property
     def kind(self):
@@ -3577,12 +3656,12 @@ class Token(Structure):
     @property
     def location(self):
         """The SourceLocation this Token occurs at."""
-        return conf.lib.clang_getTokenLocation(self._tu, self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTokenLocation(self._tu, self)
 
     @property
     def extent(self):
         """The SourceRange this Token occupies."""
-        return conf.lib.clang_getTokenExtent(self._tu, self)  # type: ignore [no-any-return]
+        return conf.lib.clang_getTokenExtent(self._tu, self)
 
     @property
     def cursor(self):
@@ -3603,7 +3682,7 @@ class Rewriter(ClangObject):
     """
 
     @staticmethod
-    def create(tu):
+    def create(tu: TranslationUnit):
         """
         Creates a new Rewriter
         Parameters:
@@ -3611,27 +3690,27 @@ class Rewriter(ClangObject):
         """
         return Rewriter(conf.lib.clang_CXRewriter_create(tu))
 
-    def __init__(self, ptr):
+    def __init__(self, ptr: CObjectP):
         ClangObject.__init__(self, ptr)
 
     def __del__(self):
         conf.lib.clang_CXRewriter_dispose(self)
 
-    def insert_text_before(self, loc, insert):
+    def insert_text_before(self, loc: SourceLocation, insert: str):
         """
         Insert the specified string at the specified location in
         the original buffer.
         """
         conf.lib.clang_CXRewriter_insertTextBefore(self, loc, insert)
 
-    def replace_text(self, extent, replacement):
+    def replace_text(self, extent: SourceRange, replacement: str):
         """
         This method replaces a range of characters in the input buffer with
         a new string.
         """
         conf.lib.clang_CXRewriter_replaceText(self, extent, replacement)
 
-    def remove_text(self, extent):
+    def remove_text(self, extent: SourceRange):
         """
         Remove the specified text region.
         """
@@ -3644,7 +3723,7 @@ class Rewriter(ClangObject):
         Returns 1 if any files were not saved successfully,
         returns 0 otherwise.
         """
-        return conf.lib.clang_CXRewriter_overwriteChangedFiles(self)  # type: ignore [no-any-return]
+        return conf.lib.clang_CXRewriter_overwriteChangedFiles(self)
 
     def write_main_file_to_stdout(self):
         """
@@ -3657,297 +3736,641 @@ class Rewriter(ClangObject):
 # Now comes the plumbing to hook up the C library.
 
 # Register callback types
-translation_unit_includes_callback = CFUNCTYPE(
-    None, c_object_p, POINTER(SourceLocation), c_uint, py_object
-)
-cursor_visit_callback = CFUNCTYPE(c_int, Cursor, Cursor, py_object)
-fields_visit_callback = CFUNCTYPE(c_int, Cursor, py_object)
+TranslationUnitIncludesCallback = Annotated[CFuncPointer, None, c_object_p, CPointer[SourceLocation], c_uint, py_object]
+CursorVisitCallback = Annotated[CFuncPointer, c_int, Cursor, Cursor, py_object]
+FieldsVisitCallback = Annotated[CFuncPointer, c_int, Cursor, py_object]
+
+translation_unit_includes_callback: TType[CFuncPointer] = convert_annotation(TranslationUnitIncludesCallback)
+cursor_visit_callback: TType[CFuncPointer] = convert_annotation(CursorVisitCallback)
+fields_visit_callback: TType[CFuncPointer] = convert_annotation(FieldsVisitCallback)
+
 
 # Functions strictly alphabetical order.
-functionList: list[LibFunc] = [
-    (
-        "clang_annotateTokens",
-        [TranslationUnit, POINTER(Token), c_uint, POINTER(Cursor)],
-    ),
-    ("clang_CompilationDatabase_dispose", [c_object_p]),
-    (
-        "clang_CompilationDatabase_fromDirectory",
-        [c_interop_string, POINTER(c_uint)],
-        c_object_p,
-        CompilationDatabase.from_result,
-    ),
-    (
-        "clang_CompilationDatabase_getAllCompileCommands",
-        [c_object_p],
-        c_object_p,
-        CompileCommands.from_result,
-    ),
-    (
-        "clang_CompilationDatabase_getCompileCommands",
-        [c_object_p, c_interop_string],
-        c_object_p,
-        CompileCommands.from_result,
-    ),
-    ("clang_CompileCommands_dispose", [c_object_p]),
-    ("clang_CompileCommands_getCommand", [c_object_p, c_uint], c_object_p),
-    ("clang_CompileCommands_getSize", [c_object_p], c_uint),
-    (
-        "clang_CompileCommand_getArg",
-        [c_object_p, c_uint],
-        _CXString,
-        _CXString.from_result,
-    ),
-    (
-        "clang_CompileCommand_getDirectory",
-        [c_object_p],
-        _CXString,
-        _CXString.from_result,
-    ),
-    (
-        "clang_CompileCommand_getFilename",
-        [c_object_p],
-        _CXString,
-        _CXString.from_result,
-    ),
-    ("clang_CompileCommand_getNumArgs", [c_object_p], c_uint),
-    (
-        "clang_codeCompleteAt",
-        [TranslationUnit, c_interop_string, c_int, c_int, c_void_p, c_int, c_int],
-        POINTER(CCRStructure),
-    ),
-    ("clang_codeCompleteGetDiagnostic", [CodeCompletionResults, c_int], Diagnostic),
-    ("clang_codeCompleteGetNumDiagnostics", [CodeCompletionResults], c_int),
-    ("clang_createIndex", [c_int, c_int], c_object_p),
-    ("clang_createTranslationUnit", [Index, c_interop_string], c_object_p),
-    ("clang_CXRewriter_create", [TranslationUnit], c_object_p),
-    ("clang_CXRewriter_dispose", [Rewriter]),
-    ("clang_CXRewriter_insertTextBefore", [Rewriter, SourceLocation, c_interop_string]),
-    ("clang_CXRewriter_overwriteChangedFiles", [Rewriter], c_int),
-    ("clang_CXRewriter_removeText", [Rewriter, SourceRange]),
-    ("clang_CXRewriter_replaceText", [Rewriter, SourceRange, c_interop_string]),
-    ("clang_CXRewriter_writeMainFileToStdOut", [Rewriter]),
-    ("clang_CXXConstructor_isConvertingConstructor", [Cursor], bool),
-    ("clang_CXXConstructor_isCopyConstructor", [Cursor], bool),
-    ("clang_CXXConstructor_isDefaultConstructor", [Cursor], bool),
-    ("clang_CXXConstructor_isMoveConstructor", [Cursor], bool),
-    ("clang_CXXField_isMutable", [Cursor], bool),
-    ("clang_CXXMethod_isConst", [Cursor], bool),
-    ("clang_CXXMethod_isDefaulted", [Cursor], bool),
-    ("clang_CXXMethod_isDeleted", [Cursor], bool),
-    ("clang_CXXMethod_isCopyAssignmentOperator", [Cursor], bool),
-    ("clang_CXXMethod_isMoveAssignmentOperator", [Cursor], bool),
-    ("clang_CXXMethod_isExplicit", [Cursor], bool),
-    ("clang_CXXMethod_isPureVirtual", [Cursor], bool),
-    ("clang_CXXMethod_isStatic", [Cursor], bool),
-    ("clang_CXXMethod_isVirtual", [Cursor], bool),
-    ("clang_CXXRecord_isAbstract", [Cursor], bool),
-    ("clang_EnumDecl_isScoped", [Cursor], bool),
-    ("clang_defaultDiagnosticDisplayOptions", [], c_uint),
-    ("clang_defaultSaveOptions", [TranslationUnit], c_uint),
-    ("clang_disposeCodeCompleteResults", [CodeCompletionResults]),
-    # ("clang_disposeCXTUResourceUsage",
-    #  [CXTUResourceUsage]),
-    ("clang_disposeDiagnostic", [Diagnostic]),
-    ("clang_disposeIndex", [Index]),
-    ("clang_disposeString", [_CXString]),
-    ("clang_disposeTokens", [TranslationUnit, POINTER(Token), c_uint]),
-    ("clang_disposeTranslationUnit", [TranslationUnit]),
-    ("clang_equalCursors", [Cursor, Cursor], bool),
-    ("clang_equalLocations", [SourceLocation, SourceLocation], bool),
-    ("clang_equalRanges", [SourceRange, SourceRange], bool),
-    ("clang_equalTypes", [Type, Type], bool),
-    ("clang_formatDiagnostic", [Diagnostic, c_uint], _CXString, _CXString.from_result),
-    ("clang_getArgType", [Type, c_uint], Type, Type.from_result),
-    ("clang_getArrayElementType", [Type], Type, Type.from_result),
-    ("clang_getArraySize", [Type], c_longlong),
-    ("clang_getFieldDeclBitWidth", [Cursor], c_int),
-    ("clang_getCanonicalCursor", [Cursor], Cursor, Cursor.from_cursor_result),
-    ("clang_getCanonicalType", [Type], Type, Type.from_result),
-    ("clang_getChildDiagnostics", [Diagnostic], c_object_p),
-    ("clang_getCompletionAvailability", [c_void_p], c_int),
-    ("clang_getCompletionBriefComment", [c_void_p], _CXString, _CXString.from_result),
-    ("clang_getCompletionChunkCompletionString", [c_void_p, c_int], c_object_p),
-    ("clang_getCompletionChunkKind", [c_void_p, c_int], c_int),
-    (
-        "clang_getCompletionChunkText",
-        [c_void_p, c_int],
-        _CXString,
-        _CXString.from_result,
-    ),
-    ("clang_getCompletionPriority", [c_void_p], c_int),
-    (
-        "clang_getCString",
-        [_CXString],
-        c_interop_string,
-        c_interop_string.to_python_string,
-    ),
-    ("clang_getCursor", [TranslationUnit, SourceLocation], Cursor),
-    ("clang_getCursorAvailability", [Cursor], c_int),
-    ("clang_getCursorDefinition", [Cursor], Cursor, Cursor.from_result),
-    ("clang_getCursorDisplayName", [Cursor], _CXString, _CXString.from_result),
-    ("clang_getCursorExtent", [Cursor], SourceRange),
-    ("clang_getCursorLexicalParent", [Cursor], Cursor, Cursor.from_cursor_result),
-    ("clang_getCursorLocation", [Cursor], SourceLocation),
-    ("clang_getCursorReferenced", [Cursor], Cursor, Cursor.from_result),
-    ("clang_getCursorReferenceNameRange", [Cursor, c_uint, c_uint], SourceRange),
-    ("clang_getCursorResultType", [Cursor], Type, Type.from_result),
-    ("clang_getCursorSemanticParent", [Cursor], Cursor, Cursor.from_cursor_result),
-    ("clang_getCursorSpelling", [Cursor], _CXString, _CXString.from_result),
-    ("clang_getCursorType", [Cursor], Type, Type.from_result),
-    ("clang_getCursorUSR", [Cursor], _CXString, _CXString.from_result),
-    ("clang_Cursor_getMangling", [Cursor], _CXString, _CXString.from_result),
-    # ("clang_getCXTUResourceUsage",
-    #  [TranslationUnit],
-    #  CXTUResourceUsage),
-    ("clang_getCXXAccessSpecifier", [Cursor], c_uint),
-    ("clang_getDeclObjCTypeEncoding", [Cursor], _CXString, _CXString.from_result),
-    ("clang_getDiagnostic", [c_object_p, c_uint], c_object_p),
-    ("clang_getDiagnosticCategory", [Diagnostic], c_uint),
-    ("clang_getDiagnosticCategoryText", [Diagnostic], _CXString, _CXString.from_result),
-    (
-        "clang_getDiagnosticFixIt",
-        [Diagnostic, c_uint, POINTER(SourceRange)],
-        _CXString,
-        _CXString.from_result,
-    ),
-    ("clang_getDiagnosticInSet", [c_object_p, c_uint], c_object_p),
-    ("clang_getDiagnosticLocation", [Diagnostic], SourceLocation),
-    ("clang_getDiagnosticNumFixIts", [Diagnostic], c_uint),
-    ("clang_getDiagnosticNumRanges", [Diagnostic], c_uint),
-    (
-        "clang_getDiagnosticOption",
-        [Diagnostic, POINTER(_CXString)],
-        _CXString,
-        _CXString.from_result,
-    ),
-    ("clang_getDiagnosticRange", [Diagnostic, c_uint], SourceRange),
-    ("clang_getDiagnosticSeverity", [Diagnostic], c_int),
-    ("clang_getDiagnosticSpelling", [Diagnostic], _CXString, _CXString.from_result),
-    ("clang_getElementType", [Type], Type, Type.from_result),
-    ("clang_getEnumConstantDeclUnsignedValue", [Cursor], c_ulonglong),
-    ("clang_getEnumConstantDeclValue", [Cursor], c_longlong),
-    ("clang_getEnumDeclIntegerType", [Cursor], Type, Type.from_result),
-    ("clang_getFile", [TranslationUnit, c_interop_string], c_object_p),
-    ("clang_getFileName", [File], _CXString, _CXString.from_result),
-    ("clang_getFileTime", [File], c_uint),
-    ("clang_getIBOutletCollectionType", [Cursor], Type, Type.from_result),
-    ("clang_getIncludedFile", [Cursor], c_object_p, File.from_result),
-    (
-        "clang_getInclusions",
-        [TranslationUnit, translation_unit_includes_callback, py_object],
-    ),
-    (
-        "clang_getInstantiationLocation",
-        [
-            SourceLocation,
-            POINTER(c_object_p),
-            POINTER(c_uint),
-            POINTER(c_uint),
-            POINTER(c_uint),
-        ],
-    ),
-    ("clang_getLocation", [TranslationUnit, File, c_uint, c_uint], SourceLocation),
-    ("clang_getLocationForOffset", [TranslationUnit, File, c_uint], SourceLocation),
-    ("clang_getNullCursor", None, Cursor),
-    ("clang_getNumArgTypes", [Type], c_uint),
-    ("clang_getNumCompletionChunks", [c_void_p], c_int),
-    ("clang_getNumDiagnostics", [c_object_p], c_uint),
-    ("clang_getNumDiagnosticsInSet", [c_object_p], c_uint),
-    ("clang_getNumElements", [Type], c_longlong),
-    ("clang_getNumOverloadedDecls", [Cursor], c_uint),
-    ("clang_getOverloadedDecl", [Cursor, c_uint], Cursor, Cursor.from_cursor_result),
-    ("clang_getPointeeType", [Type], Type, Type.from_result),
-    ("clang_getRange", [SourceLocation, SourceLocation], SourceRange),
-    ("clang_getRangeEnd", [SourceRange], SourceLocation),
-    ("clang_getRangeStart", [SourceRange], SourceLocation),
-    ("clang_getResultType", [Type], Type, Type.from_result),
-    ("clang_getSpecializedCursorTemplate", [Cursor], Cursor, Cursor.from_cursor_result),
-    ("clang_getTemplateCursorKind", [Cursor], c_uint),
-    ("clang_getTokenExtent", [TranslationUnit, Token], SourceRange),
-    ("clang_getTokenKind", [Token], c_uint),
-    ("clang_getTokenLocation", [TranslationUnit, Token], SourceLocation),
-    (
-        "clang_getTokenSpelling",
-        [TranslationUnit, Token],
-        _CXString,
-        _CXString.from_result,
-    ),
-    ("clang_getTranslationUnitCursor", [TranslationUnit], Cursor, Cursor.from_result),
-    (
-        "clang_getTranslationUnitSpelling",
-        [TranslationUnit],
-        _CXString,
-        _CXString.from_result,
-    ),
-    (
-        "clang_getTUResourceUsageName",
-        [c_uint],
-        c_interop_string,
-        c_interop_string.to_python_string,
-    ),
-    ("clang_getTypeDeclaration", [Type], Cursor, Cursor.from_result),
-    ("clang_getTypedefDeclUnderlyingType", [Cursor], Type, Type.from_result),
-    ("clang_getTypedefName", [Type], _CXString, _CXString.from_result),
-    ("clang_getTypeKindSpelling", [c_uint], _CXString, _CXString.from_result),
-    ("clang_getTypeSpelling", [Type], _CXString, _CXString.from_result),
-    ("clang_hashCursor", [Cursor], c_uint),
-    ("clang_isAttribute", [CursorKind], bool),
-    ("clang_isConstQualifiedType", [Type], bool),
-    ("clang_isCursorDefinition", [Cursor], bool),
-    ("clang_isDeclaration", [CursorKind], bool),
-    ("clang_isExpression", [CursorKind], bool),
-    ("clang_isFileMultipleIncludeGuarded", [TranslationUnit, File], bool),
-    ("clang_isFunctionTypeVariadic", [Type], bool),
-    ("clang_isInvalid", [CursorKind], bool),
-    ("clang_isPODType", [Type], bool),
-    ("clang_isPreprocessing", [CursorKind], bool),
-    ("clang_isReference", [CursorKind], bool),
-    ("clang_isRestrictQualifiedType", [Type], bool),
-    ("clang_isStatement", [CursorKind], bool),
-    ("clang_isTranslationUnit", [CursorKind], bool),
-    ("clang_isUnexposed", [CursorKind], bool),
-    ("clang_isVirtualBase", [Cursor], bool),
-    ("clang_isVolatileQualifiedType", [Type], bool),
-    (
-        "clang_parseTranslationUnit",
-        [Index, c_interop_string, c_void_p, c_int, c_void_p, c_int, c_int],
-        c_object_p,
-    ),
-    ("clang_reparseTranslationUnit", [TranslationUnit, c_int, c_void_p, c_int], c_int),
-    ("clang_saveTranslationUnit", [TranslationUnit, c_interop_string, c_uint], c_int),
-    (
-        "clang_tokenize",
-        [TranslationUnit, SourceRange, POINTER(POINTER(Token)), POINTER(c_uint)],
-    ),
-    ("clang_visitChildren", [Cursor, cursor_visit_callback, py_object], c_uint),
-    ("clang_Cursor_getNumArguments", [Cursor], c_int),
-    ("clang_Cursor_getArgument", [Cursor, c_uint], Cursor, Cursor.from_result),
-    ("clang_Cursor_getNumTemplateArguments", [Cursor], c_int),
-    (
-        "clang_Cursor_getTemplateArgumentKind",
-        [Cursor, c_uint],
-        TemplateArgumentKind.from_id,
-    ),
-    ("clang_Cursor_getTemplateArgumentType", [Cursor, c_uint], Type, Type.from_result),
-    ("clang_Cursor_getTemplateArgumentValue", [Cursor, c_uint], c_longlong),
-    ("clang_Cursor_getTemplateArgumentUnsignedValue", [Cursor, c_uint], c_ulonglong),
-    ("clang_Cursor_isAnonymous", [Cursor], bool),
-    ("clang_Cursor_isBitField", [Cursor], bool),
-    ("clang_Cursor_getBinaryOpcode", [Cursor], c_int),
-    ("clang_Cursor_getBriefCommentText", [Cursor], _CXString, _CXString.from_result),
-    ("clang_Cursor_getRawCommentText", [Cursor], _CXString, _CXString.from_result),
-    ("clang_Cursor_getOffsetOfField", [Cursor], c_longlong),
-    ("clang_Location_isInSystemHeader", [SourceLocation], bool),
-    ("clang_Type_getAlignOf", [Type], c_longlong),
-    ("clang_Type_getClassType", [Type], Type, Type.from_result),
-    ("clang_Type_getNumTemplateArguments", [Type], c_int),
-    ("clang_Type_getTemplateArgumentAsType", [Type, c_uint], Type, Type.from_result),
-    ("clang_Type_getOffsetOf", [Type, c_interop_string], c_longlong),
-    ("clang_Type_getSizeOf", [Type], c_longlong),
-    ("clang_Type_getCXXRefQualifier", [Type], c_uint),
-    ("clang_Type_getNamedType", [Type], Type, Type.from_result),
-    ("clang_Type_visitFields", [Type, fields_visit_callback, py_object], c_uint),
-]
+# NOTE:
+#   - These functions are stubs, they are not implemented, and is replaced by C functions at runtime.
+#   - If Config.compatibility_check is set to `False`, then a function is allowed to be missing.
+#   - If a function is missing in C library, it will not be replaced, thus causing NotImplementedError when called.
+#   - Missing functions are given a `_missing_` attribute, you can check it with `hasattr(conf.lib.xxx, '_missing_')`.
+#   - These stub functions are generated with a script from old data and manually corrected, so parameter names are missing.
+class LibclangExports:
+    def clang_annotateTokens(self, p1: TranslationUnit, p2: CPointerParam[Token], p3: p_ulong, p4: CPointerParam[Cursor]) -> r_long:
+        raise NotImplementedError
+
+    def clang_CompilationDatabase_dispose(self, p1: ClangObjectParam) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(CompilationDatabase.from_result)
+    def clang_CompilationDatabase_fromDirectory(self, p1: CInteropString, p2: CPointerParam[c_ulong]) -> CObjectP:
+        raise NotImplementedError
+
+    @with_errcheck(CompileCommands.from_result)
+    def clang_CompilationDatabase_getAllCompileCommands(self, p1: ClangObjectParam) -> CObjectP:
+        raise NotImplementedError
+
+    @with_errcheck(CompileCommands.from_result)
+    def clang_CompilationDatabase_getCompileCommands(self, p1: ClangObjectParam, p2: CInteropString) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_CompileCommands_dispose(self, p1: CObjectP) -> r_long:
+        raise NotImplementedError
+
+    def clang_CompileCommands_getCommand(self, p1: CObjectP, p2: p_ulong) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_CompileCommands_getSize(self, p1: CObjectP) -> r_ulong:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_CompileCommand_getArg(self, p1: CObjectP, p2: p_ulong) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_CompileCommand_getDirectory(self, p1: CObjectP) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_CompileCommand_getFilename(self, p1: CObjectP) -> _CXString:
+        raise NotImplementedError
+
+    def clang_CompileCommand_getNumArgs(self, p1: CObjectP) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_codeCompleteAt(self, p1: TranslationUnit, p2: CInteropString, p3: p_long, p4: p_long, p5: CPointerParam[_CXUnsavedFile], p6: p_long, p7: p_long) -> CPointer[CCRStructure]:
+        raise NotImplementedError
+
+    def clang_codeCompleteGetDiagnostic(self, p1: CodeCompletionResults, p2: p_long) -> Diagnostic:
+        raise NotImplementedError
+
+    def clang_codeCompleteGetNumDiagnostics(self, p1: CodeCompletionResults) -> r_long:
+        raise NotImplementedError
+
+    def clang_createIndex(self, p1: p_long, p2: p_long) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_createTranslationUnit(self, p1: Index, p2: CInteropString) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_CXRewriter_create(self, p1: TranslationUnit) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_CXRewriter_dispose(self, p1: Rewriter) -> r_long:
+        raise NotImplementedError
+
+    def clang_CXRewriter_insertTextBefore(self, p1: Rewriter, p2: SourceLocation, p3: CInteropString) -> r_long:
+        raise NotImplementedError
+
+    def clang_CXRewriter_overwriteChangedFiles(self, p1: Rewriter) -> r_long:
+        raise NotImplementedError
+
+    def clang_CXRewriter_removeText(self, p1: Rewriter, p2: SourceRange) -> r_long:
+        raise NotImplementedError
+
+    def clang_CXRewriter_replaceText(self, p1: Rewriter, p2: SourceRange, p3: CInteropString) -> r_long:
+        raise NotImplementedError
+
+    def clang_CXRewriter_writeMainFileToStdOut(self, p1: Rewriter) -> r_long:
+        raise NotImplementedError
+
+    def clang_CXXConstructor_isConvertingConstructor(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXConstructor_isCopyConstructor(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXConstructor_isDefaultConstructor(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXConstructor_isMoveConstructor(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXField_isMutable(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isConst(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isDefaulted(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isDeleted(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isCopyAssignmentOperator(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isMoveAssignmentOperator(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isExplicit(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isPureVirtual(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isStatic(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXMethod_isVirtual(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_CXXRecord_isAbstract(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_Cursor_getStorageClass(self, p1: Cursor) -> r_int:
+        raise NotImplementedError
+
+    def clang_EnumDecl_isScoped(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_defaultDiagnosticDisplayOptions(self) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_defaultSaveOptions(self, p1: TranslationUnit) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_disposeCodeCompleteResults(self, p1: CodeCompletionResults) -> r_long:
+        raise NotImplementedError
+
+    def clang_disposeDiagnostic(self, p1: Diagnostic) -> r_long:
+        raise NotImplementedError
+
+    def clang_disposeIndex(self, p1: Index) -> r_long:
+        raise NotImplementedError
+
+    def clang_disposeString(self, p1: _CXString) -> r_long:
+        raise NotImplementedError
+
+    def clang_disposeTokens(self, p1: TranslationUnit, p2: CPointer[Token], p3: p_uint) -> r_long:
+        raise NotImplementedError
+
+    def clang_disposeTranslationUnit(self, p1: TranslationUnit) -> r_long:
+        raise NotImplementedError
+
+    def clang_equalCursors(self, p1: Cursor, p2: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_equalLocations(self, p1: SourceLocation, p2: SourceLocation) -> bool:
+        raise NotImplementedError
+
+    def clang_equalRanges(self, p1: SourceRange, p2: SourceRange) -> bool:
+        raise NotImplementedError
+
+    def clang_equalTypes(self, p1: Type, p2: Type) -> bool:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_formatDiagnostic(self, p1: Diagnostic, p2: p_ulong) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getAddressSpace(self, p1: Type) -> r_int:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getArgType(self, p1: Type, p2: p_ulong) -> Type:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getArrayElementType(self, p1: Type) -> Type:
+        raise NotImplementedError
+
+    def clang_getArraySize(self, p1: Type) -> r_longlong:
+        raise NotImplementedError
+
+    def clang_getFieldDeclBitWidth(self, p1: Cursor) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_cursor_result)
+    def clang_getCanonicalCursor(self, p1: Cursor) -> Cursor:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getCanonicalType(self, p1: Type) -> Type:
+        raise NotImplementedError
+
+    def clang_getChildDiagnostics(self, p1: Diagnostic) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_getCompletionAvailability(self, p1: CObjectP) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getCompletionBriefComment(self, p1: CObjectP) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getCompletionChunkCompletionString(self, p1: CObjectP, p2: p_long) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_getCompletionChunkKind(self, p1: CObjectP, p2: p_long) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getCompletionChunkText(self, p1: CObjectP, p2: p_long) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getCompletionPriority(self, p1: CObjectP) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(c_interop_string.to_python_string)
+    def clang_getCString(self, p1: _CXString) -> c_interop_string:
+        raise NotImplementedError
+
+    def clang_getCursor(self, p1: TranslationUnit, p2: SourceLocation) -> Cursor:
+        raise NotImplementedError
+
+    def clang_getCursorAvailability(self, p1: Cursor) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_result)
+    def clang_getCursorDefinition(self, p1: Cursor) -> Cursor:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getCursorDisplayName(self, p1: Cursor) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getCursorExceptionSpecificationType(self, p1: Cursor) -> r_int:
+        raise NotImplementedError
+
+    def clang_getCursorExtent(self, p1: Cursor) -> SourceRange:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_cursor_result)
+    def clang_getCursorLexicalParent(self, p1: Cursor) -> Cursor:
+        raise NotImplementedError
+
+    def clang_getCursorLinkage(self, p1: Cursor) -> r_int:
+        raise NotImplementedError
+
+    def clang_getCursorLocation(self, p1: Cursor) -> SourceLocation:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_result)
+    def clang_getCursorReferenced(self, p1: Cursor) -> Cursor:
+        raise NotImplementedError
+
+    def clang_getCursorReferenceNameRange(self, p1: Cursor, p2: p_ulong, p3: p_ulong) -> SourceRange:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getCursorResultType(self, p1: Cursor) -> Type:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_cursor_result)
+    def clang_getCursorSemanticParent(self, p1: Cursor) -> Cursor:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getCursorSpelling(self, p1: Cursor) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getCursorTLSKind(self, p1: Cursor) -> r_int:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getCursorType(self, p1: Cursor) -> Type:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getCursorUSR(self, p1: Cursor) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_Cursor_getMangling(self, p1: Cursor) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getCXXAccessSpecifier(self, p1: Cursor) -> r_ulong:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getDeclObjCTypeEncoding(self, p1: Cursor) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getDiagnostic(self, p1: ClangObjectParam, p2: p_ulong) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_getDiagnosticCategory(self, p1: Diagnostic) -> r_ulong:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getDiagnosticCategoryText(self, p1: Diagnostic) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getDiagnosticFixIt(self, p1: Diagnostic, p2: p_ulong, p3: CPointerParam[SourceRange]) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getDiagnosticInSet(self, p1: CObjectP, p2: p_ulong) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_getDiagnosticLocation(self, p1: Diagnostic) -> SourceLocation:
+        raise NotImplementedError
+
+    def clang_getDiagnosticNumFixIts(self, p1: Diagnostic) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_getDiagnosticNumRanges(self, p1: Diagnostic) -> r_ulong:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getDiagnosticOption(self, p1: Diagnostic, p2: CPointerParam[_CXString]) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getDiagnosticRange(self, p1: Diagnostic, p2: p_ulong) -> SourceRange:
+        raise NotImplementedError
+
+    def clang_getDiagnosticSeverity(self, p1: Diagnostic) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getDiagnosticSpelling(self, p1: Diagnostic) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getElementType(self, p1: Type) -> Type:
+        raise NotImplementedError
+
+    def clang_getEnumConstantDeclUnsignedValue(self, p1: Cursor) -> r_ulonglong:
+        raise NotImplementedError
+
+    def clang_getEnumConstantDeclValue(self, p1: Cursor) -> r_longlong:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getEnumDeclIntegerType(self, p1: Cursor) -> Type:
+        raise NotImplementedError
+
+    def clang_getExceptionSpecificationType(self, p1: Type) -> r_int:
+        raise NotImplementedError
+
+    def clang_getFile(self, p1: TranslationUnit, p2: CInteropString) -> CObjectP:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getFileName(self, p1: File) -> _CXString:
+        raise NotImplementedError
+
+    def clang_getFileTime(self, p1: File) -> r_ulong:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getIBOutletCollectionType(self, p1: Cursor) -> Type:
+        raise NotImplementedError
+
+    @with_errcheck(File.from_result)
+    def clang_getIncludedFile(self, p1: Cursor) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_getInclusions(self, p1: TranslationUnit, p2: TranslationUnitIncludesCallback, p3: CPyObject[List[FileInclusion]]) -> r_long:
+        raise NotImplementedError
+
+    def clang_getInstantiationLocation(self, p1: SourceLocation, p2: CPointerParam[CObjectP], p3: CPointerParam[c_ulong], p4: CPointerParam[c_ulong], p5: CPointerParam[c_ulong]) -> r_long:
+        raise NotImplementedError
+
+    def clang_getLocation(self, p1: TranslationUnit, p2: File, p3: p_ulong, p4: p_ulong) -> SourceLocation:
+        raise NotImplementedError
+
+    def clang_getLocationForOffset(self, p1: TranslationUnit, p2: File, p3: p_ulong) -> SourceLocation:
+        raise NotImplementedError
+
+    def clang_getNullCursor(self) -> Cursor:
+        raise NotImplementedError
+
+    def clang_getNumArgTypes(self, p1: Type) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_getNumCompletionChunks(self, p1: CObjectP) -> r_long:
+        raise NotImplementedError
+
+    def clang_getNumDiagnostics(self, p1: ClangObjectParam) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_getNumDiagnosticsInSet(self, p1: CObjectP) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_getNumElements(self, p1: Type) -> r_longlong:
+        raise NotImplementedError
+
+    def clang_getNumOverloadedDecls(self, p1: Cursor) -> r_ulong:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_cursor_result)
+    def clang_getOverloadedDecl(self, p1: Cursor, p2: p_ulong) -> Cursor:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getPointeeType(self, p1: Type) -> Type:
+        raise NotImplementedError
+
+    def clang_getRange(self, p1: SourceLocation, p2: SourceLocation) -> SourceRange:
+        raise NotImplementedError
+
+    def clang_getRangeEnd(self, p1: SourceRange) -> SourceLocation:
+        raise NotImplementedError
+
+    def clang_getRangeStart(self, p1: SourceRange) -> SourceLocation:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getResultType(self, p1: Type) -> Type:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_cursor_result)
+    def clang_getSpecializedCursorTemplate(self, p1: Cursor) -> Cursor:
+        raise NotImplementedError
+
+    def clang_getTemplateCursorKind(self, p1: Cursor) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_getTokenExtent(self, p1: TranslationUnit, p2: Token) -> SourceRange:
+        raise NotImplementedError
+
+    def clang_getTokenKind(self, p1: Token) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_getTokenLocation(self, p1: TranslationUnit, p2: Token) -> SourceLocation:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getTokenSpelling(self, p1: TranslationUnit, p2: Token) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_result)
+    def clang_getTranslationUnitCursor(self, p1: TranslationUnit) -> Cursor:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getTranslationUnitSpelling(self, p1: TranslationUnit) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(c_interop_string.to_python_string)
+    def clang_getTUResourceUsageName(self, p1: p_ulong) -> c_interop_string:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_result)
+    def clang_getTypeDeclaration(self, p1: Type) -> Cursor:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_getTypedefDeclUnderlyingType(self, p1: Cursor) -> Type:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getTypedefName(self, p1: Type) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getTypeKindSpelling(self, p1: p_ulong) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_getTypeSpelling(self, p1: Type) -> _CXString:
+        raise NotImplementedError
+
+    def clang_hashCursor(self, p1: Cursor) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_isAttribute(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isConstQualifiedType(self, p1: Type) -> bool:
+        raise NotImplementedError
+
+    def clang_isCursorDefinition(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_isDeclaration(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isExpression(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isFileMultipleIncludeGuarded(self, p1: TranslationUnit, p2: File) -> bool:
+        raise NotImplementedError
+
+    def clang_isFunctionTypeVariadic(self, p1: Type) -> bool:
+        raise NotImplementedError
+
+    def clang_isInvalid(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isPODType(self, p1: Type) -> bool:
+        raise NotImplementedError
+
+    def clang_isPreprocessing(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isReference(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isRestrictQualifiedType(self, p1: Type) -> bool:
+        raise NotImplementedError
+
+    def clang_isStatement(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isTranslationUnit(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isUnexposed(self, p1: CursorKind) -> bool:
+        raise NotImplementedError
+
+    def clang_isVirtualBase(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_isVolatileQualifiedType(self, p1: Type) -> bool:
+        raise NotImplementedError
+
+    def clang_parseTranslationUnit(self, p1: Index, p2: CInteropString, p3: CPointerParam[c_char_p], p4: p_long, p5: CPointerParam[_CXUnsavedFile], p6: p_long, p7: p_long) -> CObjectP:
+        raise NotImplementedError
+
+    def clang_reparseTranslationUnit(self, p1: TranslationUnit, p2: p_long, p3: CPointerParam[_CXUnsavedFile], p4: p_long) -> r_long:
+        raise NotImplementedError
+
+    def clang_saveTranslationUnit(self, p1: TranslationUnit, p2: CInteropString, p3: p_ulong) -> r_long:
+        raise NotImplementedError
+
+    def clang_tokenize(self, p1: TranslationUnit, p2: SourceRange, p3: CPointerParam[CPointer[Token]], p4: CPointerParam[c_ulong]) -> r_long:
+        raise NotImplementedError
+
+    def clang_visitChildren(self, p1: Cursor, p2: CursorVisitCallback, p3: CPyObject[List[Cursor]]) -> r_ulong:
+        raise NotImplementedError
+
+    def clang_Cursor_getNumArguments(self, p1: Cursor) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(Cursor.from_result)
+    def clang_Cursor_getArgument(self, p1: Cursor, p2: p_ulong) -> Cursor:
+        raise NotImplementedError
+
+    def clang_Cursor_getNumTemplateArguments(self, p1: Cursor) -> r_long:
+        raise NotImplementedError
+
+    @with_converter(TemplateArgumentKind.from_id)
+    def clang_Cursor_getTemplateArgumentKind(self, p1: Cursor, p2: p_ulong) -> r_int:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_Cursor_getTemplateArgumentType(self, p1: Cursor, p2: p_ulong) -> Type:
+        raise NotImplementedError
+
+    def clang_Cursor_getTemplateArgumentValue(self, p1: Cursor, p2: p_ulong) -> r_longlong:
+        raise NotImplementedError
+
+    def clang_Cursor_getTemplateArgumentUnsignedValue(self, p1: Cursor, p2: p_ulong) -> r_ulonglong:
+        raise NotImplementedError
+
+    def clang_Cursor_isAnonymous(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_Cursor_isBitField(self, p1: Cursor) -> bool:
+        raise NotImplementedError
+
+    def clang_Cursor_getBinaryOpcode(self, p1: Cursor) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_Cursor_getBriefCommentText(self, p1: Cursor) -> _CXString:
+        raise NotImplementedError
+
+    @with_errcheck(_CXString.from_result)
+    def clang_Cursor_getRawCommentText(self, p1: Cursor) -> _CXString:
+        raise NotImplementedError
+
+    def clang_Cursor_getOffsetOfField(self, p1: Cursor) -> r_longlong:
+        raise NotImplementedError
+
+    def clang_Location_isInSystemHeader(self, p1: SourceLocation) -> bool:
+        raise NotImplementedError
+
+    def clang_Type_getAlignOf(self, p1: Type) -> r_longlong:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_Type_getClassType(self, p1: Type) -> Type:
+        raise NotImplementedError
+
+    def clang_Type_getNumTemplateArguments(self, p1: Type) -> r_long:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_Type_getTemplateArgumentAsType(self, p1: Type, p2: p_ulong) -> Type:
+        raise NotImplementedError
+
+    def clang_Type_getOffsetOf(self, p1: Type, p2: CInteropString) -> r_longlong:
+        raise NotImplementedError
+
+    def clang_Type_getSizeOf(self, p1: Type) -> r_longlong:
+        raise NotImplementedError
+
+    def clang_Type_getCXXRefQualifier(self, p1: Type) -> r_ulong:
+        raise NotImplementedError
+
+    @with_errcheck(Type.from_result)
+    def clang_Type_getNamedType(self, p1: Type) -> Type:
+        raise NotImplementedError
+
+    def clang_Type_visitFields(self, p1: Type, p2: FieldsVisitCallback, p3: CPyObject[List[Cursor]]) -> r_ulong:
+        raise NotImplementedError
 
 
 class LibclangError(Exception):
@@ -3956,44 +4379,6 @@ class LibclangError(Exception):
 
     def __str__(self) -> str:
         return self.m
-
-
-def register_function(lib: CDLL, item: LibFunc, ignore_errors: bool) -> None:
-    # A function may not exist, if these bindings are used with an older or
-    # incompatible version of libclang.so.
-    try:
-        func = getattr(lib, item[0])
-    except AttributeError as e:
-        msg = (
-            str(e) + ". Please ensure that your python bindings are "
-            "compatible with your libclang.so version."
-        )
-        if ignore_errors:
-            return
-        raise LibclangError(msg)
-
-    if len(item) >= 2:
-        func.argtypes = item[1]
-
-    if len(item) >= 3:
-        func.restype = item[2]
-
-    if len(item) == 4:
-        func.errcheck = item[3]
-
-
-def register_functions(lib: CDLL, ignore_errors: bool) -> None:
-    """Register function prototypes with a libclang library instance.
-
-    This must be called as part of library instantiation so Python knows how
-    to call out to the shared library.
-    """
-
-    def register(item: LibFunc) -> None:
-        register_function(lib, item, ignore_errors)
-
-    for f in functionList:
-        register(f)
 
 
 class Config:
@@ -4051,11 +4436,16 @@ class Config:
         Config.compatibility_check = check_status
 
     @CachedProperty
-    def lib(self) -> CDLL:
+    def lib(self) -> LibclangExports:
         lib = self.get_cindex_library()
-        register_functions(lib, not Config.compatibility_check)
+        exports, missing = load_annotated_library(lib, LibclangExports, globals())
+        if Config.compatibility_check and missing:
+            raise LibclangError(
+                f"Missing functions: {missing}. Please ensure that your python"
+                "bindings are compatible with your libclang.so version."
+            )
         Config.loaded = True
-        return lib
+        return exports
 
     def get_filename(self) -> str:
         if Config.library_file:
@@ -4097,6 +4487,11 @@ class Config:
             return False
 
         return True
+
+
+def generate_metadata_debug():
+    ''' Generate ctypes metadata for debugging purpose. '''
+    return {name: info for name, info in generate_metadata(LibclangExports, globals())}
 
 
 conf = Config()

--- a/clang/bindings/python/clang/ctyped.py
+++ b/clang/bindings/python/clang/ctyped.py
@@ -1,0 +1,334 @@
+from ctypes import (CFUNCTYPE, POINTER, WINFUNCTYPE, c_bool, c_byte, c_char,
+                    c_char_p, c_double, c_float, c_int, c_long, c_longdouble,
+                    c_longlong, c_short, c_size_t, c_ssize_t, c_ubyte, c_uint,
+                    c_ulong, c_ulonglong, c_ushort, c_void_p, c_wchar,
+                    c_wchar_p, py_object)
+from inspect import Parameter, signature
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Generator, Generic,
+                    List, Optional, Tuple, Type, TypeVar, Union, cast)
+
+from typing_extensions import Annotated, ParamSpec, TypeAlias
+
+_T = TypeVar('_T')
+
+if TYPE_CHECKING:
+    from ctypes import _CArgObject  # pyright: ignore[reportPrivateUsage]
+    from ctypes import _CData  # pyright: ignore[reportPrivateUsage]
+
+AnyCData = TypeVar('AnyCData', bound='_CData')
+
+if TYPE_CHECKING:
+    from ctypes import Array as _Array  # pyright: ignore[reportPrivateUsage]
+    from ctypes import \
+        _FuncPointer as _FuncPointer  # pyright: ignore[reportPrivateUsage]
+    from ctypes import \
+        _Pointer as _Pointer  # pyright: ignore[reportPrivateUsage]
+
+    # ctypes documentation noted implicit conversion for pointers:
+    # "For example, you can pass compatible array instances instead of pointer
+    #  types. So, for POINTER(c_int), ctypes accepts an array of c_int:"
+    # "In addition, if a function argument is explicitly declared to be a
+    #  pointer type (such as POINTER(c_int)) in argtypes, an object of the
+    #  pointed type (c_int in this case) can be passed to the function. ctypes
+    #  will apply the required byref() conversion in this case automatically."
+    # also, current ctype typeshed thinks byref returns _CArgObject
+    _PointerCompatible: TypeAlias = Union['_CArgObject', _Pointer[AnyCData], None, _Array[AnyCData], AnyCData]
+    _PyObject: TypeAlias = Union['py_object[_T]', _T]
+else:
+    # at runtime we don't really import those symbols
+    class _Array(Generic[AnyCData]): ...
+    class _Pointer(Generic[AnyCData]): ...
+    class _PointerCompatible(Generic[AnyCData]): ...
+    class _FuncPointer: ...
+    class _PyObject(Generic[AnyCData]): ...
+
+
+# ANNO_CONVETIBLE can be used to declare that a class have a `from_param`
+# method which can convert other types when used as `argtypes`.
+# For example: `CClass = Annotated[bytes, ANNO_CONVERTIBLE, c_class]` means
+# `c_class`(name of your class) can convert `bytes` parameters. Then use
+# `CClass` as parameter type in stub function declaration and you will get what
+# you want.
+
+ANNO_CONVERTIBLE = object()
+ANNO_BASIC = ANNO_CONVERTIBLE
+ANNO_ARRAY = object()
+ANNO_POINTER = object()
+ANNO_CFUNC = object()
+ANNO_WINFUNC = object()
+ANNO_PYOBJ = object()
+
+
+# corresponding annotated python types for ctypes
+# use p_* for parameters, r_* for returns
+
+r_bool = Annotated[bool, ANNO_BASIC, c_bool]
+r_char = Annotated[bytes, ANNO_BASIC, c_char]
+r_wchar = Annotated[str, ANNO_BASIC, c_wchar]
+r_byte = Annotated[int, ANNO_BASIC, c_byte]
+r_ubyte = Annotated[int, ANNO_BASIC, c_ubyte]
+r_short = Annotated[int, ANNO_BASIC, c_short]
+r_ushort = Annotated[int, ANNO_BASIC, c_ushort]
+r_int = Annotated[int, ANNO_BASIC, c_int]
+r_uint = Annotated[int, ANNO_BASIC, c_uint]
+r_long = Annotated[int, ANNO_BASIC, c_long]
+r_ulong = Annotated[int, ANNO_BASIC, c_ulong]
+r_longlong = Annotated[int, ANNO_BASIC, c_longlong]
+r_ulonglong = Annotated[int, ANNO_BASIC, c_ulonglong]
+r_size_t = Annotated[int, ANNO_BASIC, c_size_t]
+r_ssize_t = Annotated[int, ANNO_BASIC, c_ssize_t]
+r_float = Annotated[float, ANNO_BASIC, c_float]
+r_double = Annotated[float, ANNO_BASIC, c_double]
+r_longdouble = Annotated[float, ANNO_BASIC, c_longdouble]
+r_char_p = Annotated[Optional[bytes], ANNO_BASIC, c_char_p]
+r_wchar_p = Annotated[Optional[str], ANNO_BASIC, c_wchar_p]
+r_void_p = Annotated[Optional[int], ANNO_BASIC, c_void_p]
+
+p_bool = Annotated[Union[c_bool, bool], ANNO_BASIC, c_bool]
+p_char = Annotated[Union[c_char, bytes], ANNO_BASIC, c_char]
+p_wchar = Annotated[Union[c_wchar, str], ANNO_BASIC, c_wchar]
+p_byte = Annotated[Union[c_byte, int], ANNO_BASIC, c_byte]
+p_ubyte = Annotated[Union[c_ubyte, int], ANNO_BASIC, c_ubyte]
+p_short = Annotated[Union[c_short, int], ANNO_BASIC, c_short]
+p_ushort = Annotated[Union[c_ushort, int], ANNO_BASIC, c_ushort]
+p_int = Annotated[Union[c_int, int], ANNO_BASIC, c_int]
+p_uint = Annotated[Union[c_uint, int], ANNO_BASIC, c_uint]
+p_long = Annotated[Union[c_long, int], ANNO_BASIC, c_long]
+p_ulong = Annotated[Union[c_ulong, int], ANNO_BASIC, c_ulong]
+p_longlong = Annotated[Union[c_longlong, int], ANNO_BASIC, c_longlong]
+p_ulonglong = Annotated[Union[c_ulonglong, int], ANNO_BASIC, c_ulonglong]
+p_size_t = Annotated[Union[c_size_t, int], ANNO_BASIC, c_size_t]
+p_ssize_t = Annotated[Union[c_ssize_t, int], ANNO_BASIC, c_ssize_t]
+p_float = Annotated[Union[c_float, float], ANNO_BASIC, c_float]
+p_double = Annotated[Union[c_double, float], ANNO_BASIC, c_double]
+p_longdouble = Annotated[Union[c_longdouble, float], ANNO_BASIC, c_longdouble]
+p_char_p = Annotated[Union[c_char_p, _Array[c_wchar], bytes, None], ANNO_BASIC, c_char_p]
+p_wchar_p = Annotated[Union[c_wchar_p, _Array[c_wchar], str, None], ANNO_BASIC, c_wchar_p]
+p_void_p = Annotated[Union['_CArgObject', c_void_p, int, None], ANNO_BASIC, c_void_p]
+
+# export Pointer, PointerCompatible, Array and FuncPointer annotation
+
+CArray = Annotated[_Array[AnyCData], ANNO_ARRAY]
+CPointer = Annotated[_Pointer[AnyCData], ANNO_POINTER]
+CPointerParam = Annotated[_PointerCompatible[AnyCData], ANNO_POINTER]
+CFuncPointer = Annotated[_FuncPointer, ANNO_CFUNC]
+WinFuncPointer = Annotated[_FuncPointer, ANNO_WINFUNC]
+CPyObject = Annotated[_PyObject[_T], ANNO_PYOBJ]
+
+
+_Params = ParamSpec('_Params')
+_OrigRet = TypeVar('_OrigRet')
+_NewRet = TypeVar('_NewRet')
+
+def with_errcheck(checker: Callable[[_OrigRet, Callable[..., _OrigRet], Tuple[Any, ...]], _NewRet]):
+    ''' Decorates a stub function with an error checker. '''
+    def decorator(wrapped: Callable[_Params, _OrigRet]) -> Callable[_Params, _NewRet]:
+        def wrapper(*args: _Params.args, **kwargs: _Params.kwargs) -> _NewRet:
+            return cast(_NewRet, None)  # make type checker happy
+
+        # attach original declaration and error checker to wrapper
+        setattr(wrapper, '_decl_errcheck_', (wrapped, checker))
+        return wrapper
+
+    return decorator
+
+# NOTE: Actually, converter is a deprecated form of `restype`.
+# According to ctypes documentation:
+# "It is possible to assign a callable Python object that is not a ctypes
+#  type, in this case the function is assumed to return a C int, and the
+#  callable will be called with this integer, allowing further processing
+#  or error checking. Using this is deprecated, for more flexible post
+#  processing or error checking use a ctypes data type as restype and
+#  assign a callable to the errcheck attribute."
+
+def with_converter(converter: Callable[[int], _NewRet]):
+    ''' Decorates a stub function with a converter, its return type MUST be `r_int`. '''
+    def decorator(wrapped: Callable[_Params, r_int]) -> Callable[_Params, _NewRet]:
+        def wrapper(*args: _Params.args, **kwargs: _Params.kwargs) -> _NewRet:
+            return cast(_NewRet, None)  # make type checker happy
+
+        # attach original declaration and converter to wrapper
+        setattr(wrapper, '_decl_converter_', (wrapped, converter))
+        return wrapper
+
+    return decorator
+
+
+def convert_annotation(typ: Any, global_ns: Optional[Dict[str, Any]] = None) -> Type[Any]:
+    ''' Convert an annotation to effective runtime type. '''
+    if global_ns is None:
+        global_ns = globals()
+
+    if isinstance(typ, str):
+        try: typ = eval(typ, global_ns)
+        except Exception as exc:
+            raise ValueError('Evaluation of delayed annotation failed!') from exc
+
+    if not hasattr(typ, '__metadata__'):
+        return typ
+
+    # type is Annotated
+    ident, *detail = typ.__metadata__
+    if ident is ANNO_CONVERTIBLE:
+        ctyp, = detail
+        return ctyp
+    elif ident is ANNO_ARRAY:
+        try: count, = detail
+        except ValueError:
+            raise ValueError('CArray needs to be annotated with its size')
+        ctyp, = typ.__args__[0].__args__
+        return convert_annotation(ctyp, global_ns) * count
+    elif ident is ANNO_POINTER:
+        assert not detail
+        ctyp, = typ.__args__[0].__args__
+        return POINTER(convert_annotation(ctyp, global_ns)) # type: ignore
+    elif ident is ANNO_CFUNC:
+        if not detail:
+            raise ValueError('CFuncPointer needs to be annotated with its signature')
+        return CFUNCTYPE(*(convert_annotation(t, global_ns) for t in detail))
+    elif ident is ANNO_WINFUNC:
+        if not detail:
+            raise ValueError('WinFuncPointer needs to be annotated with its signature')
+        return WINFUNCTYPE(*(convert_annotation(t, global_ns) for t in detail))
+    elif ident is ANNO_PYOBJ:
+        assert not detail
+        return py_object
+    else:
+        raise ValueError(f'Unexpected annotated type {typ}')
+
+
+def convert_func_decl(decl: Callable[..., Any], errcheck: Any = None, converter: Any = None, global_ns: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    ''' Converts a stub function to ctypes metadata. '''
+    if global_ns is None:
+        global_ns = globals()
+
+    result: Dict[str, Any] = {}
+
+    if hasattr(decl, '_decl_errcheck_'):
+        rdecl, errcheck = getattr(decl, '_decl_errcheck_')
+        return convert_func_decl(rdecl, errcheck, converter, global_ns)
+    
+    if hasattr(decl, '_decl_converter_'):
+        rdecl, converter = getattr(decl, '_decl_converter_')
+        return convert_func_decl(rdecl, errcheck, converter, global_ns)
+    
+    sig = signature(decl)
+
+    param_annos = [p.annotation for p in sig.parameters.values() if p.name != 'self']
+    if all(anno is not Parameter.empty for anno in param_annos):
+        result['argtypes'] = [convert_annotation(anno, global_ns) for anno in param_annos] or None
+
+    if sig.return_annotation is not Parameter.empty:
+        result['restype'] = convert_annotation(sig.return_annotation, global_ns)
+
+    if errcheck is not None: result['errcheck'] = errcheck
+    if converter is not None: result['restype'] = converter
+
+    return result
+
+
+if TYPE_CHECKING:
+    from ctypes import CDLL, WinDLL
+    _DLLT = TypeVar('_DLLT', bound=CDLL)
+_LibDecl = TypeVar('_LibDecl')
+
+
+def generate_metadata(decl_cls: Type[_LibDecl], global_ns: Optional[Dict[str, Any]] = None) -> Generator[Tuple[str, Dict[str, Any]], None, None]:
+    ''' Generate ctypes metadata for a stub class. '''
+    if global_ns is None:
+        global_ns = globals()
+
+    for name in dir(decl_cls):
+        if name.startswith('_'): continue
+        value = getattr(decl_cls, name)
+        if not callable(value): continue
+
+        yield name, convert_func_decl(value, global_ns=global_ns)
+
+
+def load_annotated_library(loader: 'Union[CDLL, WinDLL]', decl_cls: Type[_LibDecl], global_ns: Optional[Dict[str, Any]] = None) -> Tuple[_LibDecl, List[str]]:
+    ''' Load a library and set signature metadata according to python type hints.
+        `decl_cls` is a class which should only contain method declarations.
+        Note: you should only name `self` as `self`, the converter depends on this.
+    '''
+    if global_ns is None:
+        global_ns = globals()
+
+    result = decl_cls()
+    missing: List[str] = []
+
+    for name, info in generate_metadata(decl_cls, global_ns):
+        try: func = getattr(loader, name)
+        except AttributeError:
+            stub = getattr(result, name)
+            stub._missing_ = True
+            missing.append(name); continue
+
+        for attr, infoval in info.items():
+            setattr(func, attr, infoval)
+
+        setattr(result, name, func)
+
+    return result, missing
+
+
+__all__ = [
+    'ANNO_CONVERTIBLE',
+    'AnyCData',
+
+    'p_bool',
+    'p_char',
+    'p_wchar',
+    'p_byte',
+    'p_ubyte',
+    'p_short',
+    'p_ushort',
+    'p_int',
+    'p_uint',
+    'p_long',
+    'p_ulong',
+    'p_longlong',
+    'p_ulonglong',
+    'p_size_t',
+    'p_ssize_t',
+    'p_float',
+    'p_double',
+    'p_longdouble',
+    'p_char_p',
+    'p_wchar_p',
+    'p_void_p',
+
+    'r_bool',
+    'r_char',
+    'r_wchar',
+    'r_byte',
+    'r_ubyte',
+    'r_short',
+    'r_ushort',
+    'r_int',
+    'r_uint',
+    'r_long',
+    'r_ulong',
+    'r_longlong',
+    'r_ulonglong',
+    'r_size_t',
+    'r_ssize_t',
+    'r_float',
+    'r_double',
+    'r_longdouble',
+    'r_char_p',
+    'r_wchar_p',
+    'r_void_p',
+
+    'CArray',
+    'CPointer',
+    'CPointerParam',
+    'CFuncPointer',
+    'WinFuncPointer',
+    'CPyObject',
+
+    'convert_annotation',
+    'with_errcheck',
+    'with_converter',
+    'load_annotated_library',
+]

--- a/clang/bindings/python/tests/cindex/test_translation_unit.py
+++ b/clang/bindings/python/tests/cindex/test_translation_unit.py
@@ -93,7 +93,7 @@ int SOME_DEFINE;
 """,
                 ),
                 (
-                    "./fake.h",
+                    f".{os.sep}fake.h",
                     """
 #define SOME_DEFINE y
 """,

--- a/clang/bindings/python/tests/cindex/test_type.py
+++ b/clang/bindings/python/tests/cindex/test_type.py
@@ -167,7 +167,7 @@ class TestType(unittest.TestCase):
         self.assertNotEqual(a.type, v.type)
 
         self.assertNotEqual(a.type, None)
-        self.assertNotEqual(a.type, "foo")
+        self.assertNotEqual(a.type.spelling, "foo")
 
     def test_type_spelling(self):
         """Ensure Type.spelling works."""

--- a/clang/bindings/python/tests/ctyped/test_stub_conversion.py
+++ b/clang/bindings/python/tests/ctyped/test_stub_conversion.py
@@ -1,0 +1,359 @@
+# mypy: ignore-errors
+
+import re
+import unittest
+from ctypes import *  # pyright: ignore[reportWildcardImportFromLibrary]
+from typing import Any, Dict, List, Set, Tuple
+
+from dictdiffer import diff as dictdiff  # type: ignore
+
+from clang.cindex import *
+from clang.cindex import _CXString  # pyright: ignore[reportPrivateUsage]
+from clang.cindex import (CCRStructure, Rewriter, c_interop_string, c_object_p,
+                          cursor_visit_callback, fields_visit_callback,
+                          generate_metadata_debug,
+                          translation_unit_includes_callback)
+
+
+# Functions strictly alphabetical order.
+# This is previous version of ctypes metadata, we check equality to this so
+# that we can ensure `ctyped` doesn't break anything in its conversion.
+FUNCTION_LIST: list[Tuple[Any, ...]] = [
+    (
+        "clang_annotateTokens",
+        [TranslationUnit, POINTER(Token), c_uint, POINTER(Cursor)],
+    ),
+    ("clang_CompilationDatabase_dispose", [c_object_p]),
+    (
+        "clang_CompilationDatabase_fromDirectory",
+        [c_interop_string, POINTER(c_uint)],
+        c_object_p,
+        CompilationDatabase.from_result,
+    ),
+    (
+        "clang_CompilationDatabase_getAllCompileCommands",
+        [c_object_p],
+        c_object_p,
+        CompileCommands.from_result,
+    ),
+    (
+        "clang_CompilationDatabase_getCompileCommands",
+        [c_object_p, c_interop_string],
+        c_object_p,
+        CompileCommands.from_result,
+    ),
+    ("clang_CompileCommands_dispose", [c_object_p]),
+    ("clang_CompileCommands_getCommand", [c_object_p, c_uint], c_object_p),
+    ("clang_CompileCommands_getSize", [c_object_p], c_uint),
+    (
+        "clang_CompileCommand_getArg",
+        [c_object_p, c_uint],
+        _CXString,
+        _CXString.from_result,
+    ),
+    (
+        "clang_CompileCommand_getDirectory",
+        [c_object_p],
+        _CXString,
+        _CXString.from_result,
+    ),
+    (
+        "clang_CompileCommand_getFilename",
+        [c_object_p],
+        _CXString,
+        _CXString.from_result,
+    ),
+    ("clang_CompileCommand_getNumArgs", [c_object_p], c_uint),
+    (
+        "clang_codeCompleteAt",
+        [TranslationUnit, c_interop_string, c_int, c_int, c_void_p, c_int, c_int],
+        POINTER(CCRStructure),
+    ),
+    ("clang_codeCompleteGetDiagnostic", [CodeCompletionResults, c_int], Diagnostic),
+    ("clang_codeCompleteGetNumDiagnostics", [CodeCompletionResults], c_int),
+    ("clang_createIndex", [c_int, c_int], c_object_p),
+    ("clang_createTranslationUnit", [Index, c_interop_string], c_object_p),
+    ("clang_CXRewriter_create", [TranslationUnit], c_object_p),
+    ("clang_CXRewriter_dispose", [Rewriter]),
+    ("clang_CXRewriter_insertTextBefore", [Rewriter, SourceLocation, c_interop_string]),
+    ("clang_CXRewriter_overwriteChangedFiles", [Rewriter], c_int),
+    ("clang_CXRewriter_removeText", [Rewriter, SourceRange]),
+    ("clang_CXRewriter_replaceText", [Rewriter, SourceRange, c_interop_string]),
+    ("clang_CXRewriter_writeMainFileToStdOut", [Rewriter]),
+    ("clang_CXXConstructor_isConvertingConstructor", [Cursor], bool),
+    ("clang_CXXConstructor_isCopyConstructor", [Cursor], bool),
+    ("clang_CXXConstructor_isDefaultConstructor", [Cursor], bool),
+    ("clang_CXXConstructor_isMoveConstructor", [Cursor], bool),
+    ("clang_CXXField_isMutable", [Cursor], bool),
+    ("clang_CXXMethod_isConst", [Cursor], bool),
+    ("clang_CXXMethod_isDefaulted", [Cursor], bool),
+    ("clang_CXXMethod_isDeleted", [Cursor], bool),
+    ("clang_CXXMethod_isCopyAssignmentOperator", [Cursor], bool),
+    ("clang_CXXMethod_isMoveAssignmentOperator", [Cursor], bool),
+    ("clang_CXXMethod_isExplicit", [Cursor], bool),
+    ("clang_CXXMethod_isPureVirtual", [Cursor], bool),
+    ("clang_CXXMethod_isStatic", [Cursor], bool),
+    ("clang_CXXMethod_isVirtual", [Cursor], bool),
+    ("clang_CXXRecord_isAbstract", [Cursor], bool),
+    ("clang_EnumDecl_isScoped", [Cursor], bool),
+    ("clang_defaultDiagnosticDisplayOptions", [], c_uint),
+    ("clang_defaultSaveOptions", [TranslationUnit], c_uint),
+    ("clang_disposeCodeCompleteResults", [CodeCompletionResults]),
+    # ("clang_disposeCXTUResourceUsage",
+    #  [CXTUResourceUsage]),
+    ("clang_disposeDiagnostic", [Diagnostic]),
+    ("clang_disposeIndex", [Index]),
+    ("clang_disposeString", [_CXString]),
+    ("clang_disposeTokens", [TranslationUnit, POINTER(Token), c_uint]),
+    ("clang_disposeTranslationUnit", [TranslationUnit]),
+    ("clang_equalCursors", [Cursor, Cursor], bool),
+    ("clang_equalLocations", [SourceLocation, SourceLocation], bool),
+    ("clang_equalRanges", [SourceRange, SourceRange], bool),
+    ("clang_equalTypes", [Type, Type], bool),
+    ("clang_formatDiagnostic", [Diagnostic, c_uint], _CXString, _CXString.from_result),
+    ("clang_getArgType", [Type, c_uint], Type, Type.from_result),
+    ("clang_getArrayElementType", [Type], Type, Type.from_result),
+    ("clang_getArraySize", [Type], c_longlong),
+    ("clang_getFieldDeclBitWidth", [Cursor], c_int),
+    ("clang_getCanonicalCursor", [Cursor], Cursor, Cursor.from_cursor_result),
+    ("clang_getCanonicalType", [Type], Type, Type.from_result),
+    ("clang_getChildDiagnostics", [Diagnostic], c_object_p),
+    ("clang_getCompletionAvailability", [c_void_p], c_int),
+    ("clang_getCompletionBriefComment", [c_void_p], _CXString, _CXString.from_result),
+    ("clang_getCompletionChunkCompletionString", [c_void_p, c_int], c_object_p),
+    ("clang_getCompletionChunkKind", [c_void_p, c_int], c_int),
+    (
+        "clang_getCompletionChunkText",
+        [c_void_p, c_int],
+        _CXString,
+        _CXString.from_result,
+    ),
+    ("clang_getCompletionPriority", [c_void_p], c_int),
+    (
+        "clang_getCString",
+        [_CXString],
+        c_interop_string,
+        c_interop_string.to_python_string,
+    ),
+    ("clang_getCursor", [TranslationUnit, SourceLocation], Cursor),
+    ("clang_getCursorAvailability", [Cursor], c_int),
+    ("clang_getCursorDefinition", [Cursor], Cursor, Cursor.from_result),
+    ("clang_getCursorDisplayName", [Cursor], _CXString, _CXString.from_result),
+    ("clang_getCursorExtent", [Cursor], SourceRange),
+    ("clang_getCursorLexicalParent", [Cursor], Cursor, Cursor.from_cursor_result),
+    ("clang_getCursorLocation", [Cursor], SourceLocation),
+    ("clang_getCursorReferenced", [Cursor], Cursor, Cursor.from_result),
+    ("clang_getCursorReferenceNameRange", [Cursor, c_uint, c_uint], SourceRange),
+    ("clang_getCursorResultType", [Cursor], Type, Type.from_result),
+    ("clang_getCursorSemanticParent", [Cursor], Cursor, Cursor.from_cursor_result),
+    ("clang_getCursorSpelling", [Cursor], _CXString, _CXString.from_result),
+    ("clang_getCursorType", [Cursor], Type, Type.from_result),
+    ("clang_getCursorUSR", [Cursor], _CXString, _CXString.from_result),
+    ("clang_Cursor_getMangling", [Cursor], _CXString, _CXString.from_result),
+    # ("clang_getCXTUResourceUsage",
+    #  [TranslationUnit],
+    #  CXTUResourceUsage),
+    ("clang_getCXXAccessSpecifier", [Cursor], c_uint),
+    ("clang_getDeclObjCTypeEncoding", [Cursor], _CXString, _CXString.from_result),
+    ("clang_getDiagnostic", [c_object_p, c_uint], c_object_p),
+    ("clang_getDiagnosticCategory", [Diagnostic], c_uint),
+    ("clang_getDiagnosticCategoryText", [Diagnostic], _CXString, _CXString.from_result),
+    (
+        "clang_getDiagnosticFixIt",
+        [Diagnostic, c_uint, POINTER(SourceRange)],
+        _CXString,
+        _CXString.from_result,
+    ),
+    ("clang_getDiagnosticInSet", [c_object_p, c_uint], c_object_p),
+    ("clang_getDiagnosticLocation", [Diagnostic], SourceLocation),
+    ("clang_getDiagnosticNumFixIts", [Diagnostic], c_uint),
+    ("clang_getDiagnosticNumRanges", [Diagnostic], c_uint),
+    (
+        "clang_getDiagnosticOption",
+        [Diagnostic, POINTER(_CXString)],
+        _CXString,
+        _CXString.from_result,
+    ),
+    ("clang_getDiagnosticRange", [Diagnostic, c_uint], SourceRange),
+    ("clang_getDiagnosticSeverity", [Diagnostic], c_int),
+    ("clang_getDiagnosticSpelling", [Diagnostic], _CXString, _CXString.from_result),
+    ("clang_getElementType", [Type], Type, Type.from_result),
+    ("clang_getEnumConstantDeclUnsignedValue", [Cursor], c_ulonglong),
+    ("clang_getEnumConstantDeclValue", [Cursor], c_longlong),
+    ("clang_getEnumDeclIntegerType", [Cursor], Type, Type.from_result),
+    ("clang_getFile", [TranslationUnit, c_interop_string], c_object_p),
+    ("clang_getFileName", [File], _CXString, _CXString.from_result),
+    ("clang_getFileTime", [File], c_uint),
+    ("clang_getIBOutletCollectionType", [Cursor], Type, Type.from_result),
+    ("clang_getIncludedFile", [Cursor], c_object_p, File.from_result),
+    (
+        "clang_getInclusions",
+        [TranslationUnit, translation_unit_includes_callback, py_object],
+    ),
+    (
+        "clang_getInstantiationLocation",
+        [
+            SourceLocation,
+            POINTER(c_object_p),
+            POINTER(c_uint),
+            POINTER(c_uint),
+            POINTER(c_uint),
+        ],
+    ),
+    ("clang_getLocation", [TranslationUnit, File, c_uint, c_uint], SourceLocation),
+    ("clang_getLocationForOffset", [TranslationUnit, File, c_uint], SourceLocation),
+    ("clang_getNullCursor", None, Cursor),
+    ("clang_getNumArgTypes", [Type], c_uint),
+    ("clang_getNumCompletionChunks", [c_void_p], c_int),
+    ("clang_getNumDiagnostics", [c_object_p], c_uint),
+    ("clang_getNumDiagnosticsInSet", [c_object_p], c_uint),
+    ("clang_getNumElements", [Type], c_longlong),
+    ("clang_getNumOverloadedDecls", [Cursor], c_uint),
+    ("clang_getOverloadedDecl", [Cursor, c_uint], Cursor, Cursor.from_cursor_result),
+    ("clang_getPointeeType", [Type], Type, Type.from_result),
+    ("clang_getRange", [SourceLocation, SourceLocation], SourceRange),
+    ("clang_getRangeEnd", [SourceRange], SourceLocation),
+    ("clang_getRangeStart", [SourceRange], SourceLocation),
+    ("clang_getResultType", [Type], Type, Type.from_result),
+    ("clang_getSpecializedCursorTemplate", [Cursor], Cursor, Cursor.from_cursor_result),
+    ("clang_getTemplateCursorKind", [Cursor], c_uint),
+    ("clang_getTokenExtent", [TranslationUnit, Token], SourceRange),
+    ("clang_getTokenKind", [Token], c_uint),
+    ("clang_getTokenLocation", [TranslationUnit, Token], SourceLocation),
+    (
+        "clang_getTokenSpelling",
+        [TranslationUnit, Token],
+        _CXString,
+        _CXString.from_result,
+    ),
+    ("clang_getTranslationUnitCursor", [TranslationUnit], Cursor, Cursor.from_result),
+    (
+        "clang_getTranslationUnitSpelling",
+        [TranslationUnit],
+        _CXString,
+        _CXString.from_result,
+    ),
+    (
+        "clang_getTUResourceUsageName",
+        [c_uint],
+        c_interop_string,
+        c_interop_string.to_python_string,
+    ),
+    ("clang_getTypeDeclaration", [Type], Cursor, Cursor.from_result),
+    ("clang_getTypedefDeclUnderlyingType", [Cursor], Type, Type.from_result),
+    ("clang_getTypedefName", [Type], _CXString, _CXString.from_result),
+    ("clang_getTypeKindSpelling", [c_uint], _CXString, _CXString.from_result),
+    ("clang_getTypeSpelling", [Type], _CXString, _CXString.from_result),
+    ("clang_hashCursor", [Cursor], c_uint),
+    ("clang_isAttribute", [CursorKind], bool),
+    ("clang_isConstQualifiedType", [Type], bool),
+    ("clang_isCursorDefinition", [Cursor], bool),
+    ("clang_isDeclaration", [CursorKind], bool),
+    ("clang_isExpression", [CursorKind], bool),
+    ("clang_isFileMultipleIncludeGuarded", [TranslationUnit, File], bool),
+    ("clang_isFunctionTypeVariadic", [Type], bool),
+    ("clang_isInvalid", [CursorKind], bool),
+    ("clang_isPODType", [Type], bool),
+    ("clang_isPreprocessing", [CursorKind], bool),
+    ("clang_isReference", [CursorKind], bool),
+    ("clang_isRestrictQualifiedType", [Type], bool),
+    ("clang_isStatement", [CursorKind], bool),
+    ("clang_isTranslationUnit", [CursorKind], bool),
+    ("clang_isUnexposed", [CursorKind], bool),
+    ("clang_isVirtualBase", [Cursor], bool),
+    ("clang_isVolatileQualifiedType", [Type], bool),
+    (
+        "clang_parseTranslationUnit",
+        [Index, c_interop_string, c_void_p, c_int, c_void_p, c_int, c_int],
+        c_object_p,
+    ),
+    ("clang_reparseTranslationUnit", [TranslationUnit, c_int, c_void_p, c_int], c_int),
+    ("clang_saveTranslationUnit", [TranslationUnit, c_interop_string, c_uint], c_int),
+    (
+        "clang_tokenize",
+        [TranslationUnit, SourceRange, POINTER(POINTER(Token)), POINTER(c_uint)],
+    ),
+    ("clang_visitChildren", [Cursor, cursor_visit_callback, py_object], c_uint),
+    ("clang_Cursor_getNumArguments", [Cursor], c_int),
+    ("clang_Cursor_getArgument", [Cursor, c_uint], Cursor, Cursor.from_result),
+    ("clang_Cursor_getNumTemplateArguments", [Cursor], c_int),
+    (
+        "clang_Cursor_getTemplateArgumentKind",
+        [Cursor, c_uint],
+        TemplateArgumentKind.from_id,
+    ),
+    ("clang_Cursor_getTemplateArgumentType", [Cursor, c_uint], Type, Type.from_result),
+    ("clang_Cursor_getTemplateArgumentValue", [Cursor, c_uint], c_longlong),
+    ("clang_Cursor_getTemplateArgumentUnsignedValue", [Cursor, c_uint], c_ulonglong),
+    ("clang_Cursor_isAnonymous", [Cursor], bool),
+    ("clang_Cursor_isBitField", [Cursor], bool),
+    ("clang_Cursor_getBinaryOpcode", [Cursor], c_int),
+    ("clang_Cursor_getBriefCommentText", [Cursor], _CXString, _CXString.from_result),
+    ("clang_Cursor_getRawCommentText", [Cursor], _CXString, _CXString.from_result),
+    ("clang_Cursor_getOffsetOfField", [Cursor], c_longlong),
+    ("clang_Location_isInSystemHeader", [SourceLocation], bool),
+    ("clang_Type_getAlignOf", [Type], c_longlong),
+    ("clang_Type_getClassType", [Type], Type, Type.from_result),
+    ("clang_Type_getNumTemplateArguments", [Type], c_int),
+    ("clang_Type_getTemplateArgumentAsType", [Type, c_uint], Type, Type.from_result),
+    ("clang_Type_getOffsetOf", [Type, c_interop_string], c_longlong),
+    ("clang_Type_getSizeOf", [Type], c_longlong),
+    ("clang_Type_getCXXRefQualifier", [Type], c_uint),
+    ("clang_Type_getNamedType", [Type], Type, Type.from_result),
+    ("clang_Type_visitFields", [Type, fields_visit_callback, py_object], c_uint),
+]
+
+
+# Sadly, ctypes provides no API to check if type is pointer or array.
+# Here we use regex to check type name.
+arr_regex = re.compile(r'(?P<typ>[A-Za-z0-9_]+)_Array_(?P<count>[0-9]+)')
+ptr_regex = re.compile(r'LP_(?P<typ>[A-Za-z0-9_]+)')
+
+def is_ptr_type(typ: Any):
+    return typ in (c_void_p, c_char_p, c_wchar_p) or ptr_regex.fullmatch(typ.__name__) is not None
+
+def is_arr_type(typ: Any):
+    return arr_regex.fullmatch(typ.__name__) is not None
+
+# If we change a c_void_p parameter to a more exact pointer types, it
+# should still be working.
+def is_void_specialization(old_type: Any, new_type: Any):
+    return old_type == c_void_p and is_ptr_type(new_type)
+
+
+def old_data_to_dict(data: List[Any]):
+    result: Dict[str, Any] = {}
+    result['argtypes'], *data = data
+    if not result['argtypes']: result['argtypes'] = None
+    if data: result['restype'], *data = data
+    else: result['restype'] = c_int
+    if data: result['errcheck'], *data = data
+    return result
+
+
+def is_incompatible_diff(diff: Any):
+    kind, path, detail = diff # pyright: ignore[reportUnusedVariable]
+    if kind == 'add': return True
+    old_type, new_type = detail
+    if is_void_specialization(old_type, new_type): return False
+    return True
+
+
+class TestStubConversion(unittest.TestCase):
+    def test_equality(self):
+        """Ensure that items registered appear as class attributes."""
+        old_function_dict: Dict[str, Dict[str, Any]] = {name: old_data_to_dict(val) for name, *val in FUNCTION_LIST}
+        new_function_dict = generate_metadata_debug()
+
+        missing_functions = set(old_function_dict.keys())
+        stable_functions: Set[str] = set()
+        for new_func in new_function_dict:
+            if new_func in missing_functions:
+                missing_functions.remove(new_func)
+                stable_functions.add(new_func)
+
+        type_diff = [list(dictdiff(old_function_dict[name], new_function_dict[name])) for name in stable_functions] # type: ignore
+        type_break = [diffset for diffset in type_diff if diffset and any(is_incompatible_diff(diff) for diff in diffset)] # type: ignore
+
+        self.assertTrue(not missing_functions, f'Functions {missing_functions} are missing after stub conversion!')
+        self.assertTrue(not type_break, f'Type break happens after stub conversion!')

--- a/clang/bindings/python/tests/ctyped/test_stub_conversion.py
+++ b/clang/bindings/python/tests/ctyped/test_stub_conversion.py
@@ -18,7 +18,7 @@ from clang.cindex import (CCRStructure, Rewriter, c_interop_string, c_object_p,
 # Functions strictly alphabetical order.
 # This is previous version of ctypes metadata, we check equality to this so
 # that we can ensure `ctyped` doesn't break anything in its conversion.
-FUNCTION_LIST: list[Tuple[Any, ...]] = [
+FUNCTION_LIST: List[Tuple[Any, ...]] = [
     (
         "clang_annotateTokens",
         [TranslationUnit, POINTER(Token), c_uint, POINTER(Cursor)],
@@ -341,7 +341,7 @@ def is_incompatible_diff(diff: Any):
 
 class TestStubConversion(unittest.TestCase):
     def test_equality(self):
-        """Ensure that items registered appear as class attributes."""
+        """Ensure that ctyped does not break anything."""
         old_function_dict: Dict[str, Dict[str, Any]] = {name: old_data_to_dict(val) for name, *val in FUNCTION_LIST}
         new_function_dict = generate_metadata_debug()
 


### PR DESCRIPTION
Related: https://github.com/llvm/llvm-project/issues/76664

I used metadata reflection so that we can import C library functions just by declaring annotated python functions. This makes C function types visible to type checker, then it's easy to fix most typing errors.