### PR TITLE
[clang][Interp] Convert blocks to DeadBlocks when destroying frames

### DIFF
--- a/clang/lib/AST/Interp/InterpFrame.cpp
+++ b/clang/lib/AST/Interp/InterpFrame.cpp
@@ -75,9 +75,7 @@ InterpFrame::~InterpFrame() {
   if (Func) {
     for (auto &Scope : Func->scopes()) {
       for (auto &Local : Scope.locals()) {
-        Block *B = localBlock(Local.Offset);
-        if (B->isInitialized())
-          B->invokeDtor();
+        S.deallocate(localBlock(Local.Offset));
       }
     }
   }

--- a/clang/test/AST/Interp/new-delete.cpp
+++ b/clang/test/AST/Interp/new-delete.cpp
@@ -564,6 +564,27 @@ namespace DeleteThis {
                                                // both-note {{in call to 'super_secret_double_delete()'}}
 }
 
+/// FIXME: This is currently diagnosed, but should work.
+/// If the destructor for S is _not_ virtual however, it should fail.
+namespace CastedDelete {
+  struct S {
+    constexpr S(int *p) : p(p) {}
+    constexpr virtual ~S() { *p = 1; }
+    int *p;
+  };
+  struct T: S {
+    // implicit destructor defined eagerly because it is constexpr and virtual
+    using S::S;
+  };
+
+  constexpr int vdtor_1() {
+    int a;
+    delete (S*)new T(&a); // expected-note {{delete of pointer to subobject}}
+    return a;
+  }
+  static_assert(vdtor_1() == 1); // expected-error {{not an integral constant expression}} \
+                                 // expected-note {{in call to}}
+}
 
 #else
 /// Make sure we reject this prior to C++20


### PR DESCRIPTION
This doesn't fix the attached test case, but at least we're not crashing anymore. 