### PR TITLE
[clang][Interp] Fix array subscript eval order

### DIFF
--- a/clang/lib/AST/Interp/Interp.h
+++ b/clang/lib/AST/Interp/Interp.h
@@ -1158,6 +1158,21 @@ bool Pop(InterpState &S, CodePtr OpPC) {
   return true;
 }
 
+/// [Value1, Value2] -> [Value2, Value1]
+template <PrimType TopName, PrimType BottomName>
+bool Flip(InterpState &S, CodePtr OpPC) {
+  using TopT = typename PrimConv<TopName>::T;
+  using BottomT = typename PrimConv<BottomName>::T;
+
+  const auto &Top = S.Stk.pop<TopT>();
+  const auto &Bottom = S.Stk.pop<BottomT>();
+
+  S.Stk.push<TopT>(Top);
+  S.Stk.push<BottomT>(Bottom);
+
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 // Const
 //===----------------------------------------------------------------------===//

--- a/clang/lib/AST/Interp/Opcodes.td
+++ b/clang/lib/AST/Interp/Opcodes.td
@@ -729,6 +729,11 @@ def Dup : Opcode {
   let HasGroup = 1;
 }
 
+def Flip : Opcode {
+  let Types = [AllTypeClass, AllTypeClass];
+  let HasGroup = 1;
+}
+
 // [] -> []
 def Invalid : Opcode {}
 def Unsupported : Opcode {}

--- a/clang/test/AST/Interp/eval-order.cpp
+++ b/clang/test/AST/Interp/eval-order.cpp
@@ -45,7 +45,7 @@ namespace EvalOrder {
     }
     template <typename T> constexpr T &&b(T &&v) {
       if (!done_a)
-        throw "wrong"; // expected-note 7{{not valid}}
+        throw "wrong"; // expected-note 5{{not valid}}
       done_b = true;
       return (T &&)v;
     }
@@ -95,10 +95,9 @@ namespace EvalOrder {
   constexpr int arr[3] = {};
   SEQ(A(arr)[B(0)]);
   SEQ(A(+arr)[B(0)]);
-  SEQ(A(0)[B(arr)]); // expected-error {{not an integral constant expression}} FIXME \
-                     // expected-note 2{{in call to}}
-  SEQ(A(0)[B(+arr)]); // expected-error {{not an integral constant expression}} FIXME \
-                      // expected-note 2{{in call to}}
+  SEQ(A(0)[B(arr)]);
+  SEQ(A(0)[B(+arr)]);
+
   SEQ(A(ud)[B(0)]);
 
   // Rule 7: a << b


### PR DESCRIPTION
Always evaluate LHS first, then RHS.