### PR TITLE
[SLP] The order of store chains needs to consider the size of the values.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -19123,6 +19123,12 @@ bool SLPVectorizerPass::vectorizeStoreChains(BoUpSLP &R) {
     if (V->getPointerOperandType()->getTypeID() >
         V2->getPointerOperandType()->getTypeID())
       return false;
+    if (V->getValueOperand()->getType()->getScalarSizeInBits() <
+        V2->getValueOperand()->getType()->getScalarSizeInBits())
+      return true;
+    if (V->getValueOperand()->getType()->getScalarSizeInBits() >
+        V2->getValueOperand()->getType()->getScalarSizeInBits())
+      return false;
     // UndefValues are compatible with all other values.
     if (isa<UndefValue>(V->getValueOperand()) ||
         isa<UndefValue>(V2->getValueOperand()))

--- a/llvm/test/Transforms/SLPVectorizer/X86/stores_mix_sizes.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/stores_mix_sizes.ll
@@ -5,17 +5,9 @@ define void @test(ptr %p) {
 ; CHECK-SAME: ptr [[P:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[IDX1:%.*]] = getelementptr i8, ptr [[P]], i64 1
-; CHECK-NEXT:    store i8 0, ptr [[IDX1]], align 4
 ; CHECK-NEXT:    [[IDX_64_9:%.*]] = getelementptr i64, ptr [[P]], i64 9
 ; CHECK-NEXT:    store i64 1, ptr [[IDX_64_9]], align 8
-; CHECK-NEXT:    [[IDX2:%.*]] = getelementptr i8, ptr [[P]], i64 2
-; CHECK-NEXT:    store <4 x i8> zeroinitializer, ptr [[IDX2]], align 4
-; CHECK-NEXT:    [[IDX6:%.*]] = getelementptr i8, ptr [[P]], i64 6
-; CHECK-NEXT:    store i8 0, ptr [[IDX6]], align 4
-; CHECK-NEXT:    [[IDX7:%.*]] = getelementptr i8, ptr [[P]], i64 7
-; CHECK-NEXT:    store i8 0, ptr [[IDX7]], align 4
-; CHECK-NEXT:    [[IDX8:%.*]] = getelementptr i8, ptr [[P]], i64 8
-; CHECK-NEXT:    store i8 0, ptr [[IDX8]], align 4
+; CHECK-NEXT:    store <8 x i8> zeroinitializer, ptr [[IDX1]], align 4
 ; CHECK-NEXT:    ret void
 ;
   entry:


### PR DESCRIPTION
When store chains have the same value type ID and pointer type ID, they may mix different sizes of values, such as i8 and i64. This can lead to missed vectorization opportunities.