### PR TITLE
[libc][newhdrgen] Remove shebangs in files other than yaml_to_classes.py

### DIFF
--- a/libc/newhdrgen/class_implementation/classes/enumeration.py
+++ b/libc/newhdrgen/class_implementation/classes/enumeration.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ====-- Enumeration class for libc function headers ----------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/class_implementation/classes/function.py
+++ b/libc/newhdrgen/class_implementation/classes/function.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ====-- Function class for libc function headers -------------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/class_implementation/classes/macro.py
+++ b/libc/newhdrgen/class_implementation/classes/macro.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ====-- Macro class for libc function headers ----------------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/class_implementation/classes/object.py
+++ b/libc/newhdrgen/class_implementation/classes/object.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ====-- Object class for libc function headers ---------------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/class_implementation/classes/type.py
+++ b/libc/newhdrgen/class_implementation/classes/type.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ====-- Type class for libc function headers -----------------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/gpu_headers.py
+++ b/libc/newhdrgen/gpu_headers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ===- GPU HeaderFile Class for --export-decls version --------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/header.py
+++ b/libc/newhdrgen/header.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ====- HeaderFile Class for libc function headers  -----------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/yaml_to_classes.py
+++ b/libc/newhdrgen/yaml_to_classes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ===- Generate headers for libc functions  -------------------*- python -*--==#
 #

--- a/libc/newhdrgen/yaml_to_classes.py
+++ b/libc/newhdrgen/yaml_to_classes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # ===- Generate headers for libc functions  -------------------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/libc/newhdrgen/yaml_to_classes.py
+++ b/libc/newhdrgen/yaml_to_classes.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # ===- Generate headers for libc functions  -------------------*- python -*--==#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
None of the Python files were committed with the executable bit set, and
only yaml_to_classes.py was intended to be executed.

Also sets the executable bit on yaml_to_classes.py and changes the
shebang to run python3 instead of python.
