### PR TITLE
[mlir][vector] Update representation of insert/extract_strided_slice

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorAttributes.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorAttributes.td
@@ -16,6 +16,11 @@
 include "mlir/Dialect/Vector/IR/Vector.td"
 include "mlir/IR/EnumAttr.td"
 
+class Vector_Attr<string attrName, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<Vector_Dialect, attrName, traits> {
+  let mnemonic = attrMnemonic;
+}
+
 // The "kind" of combining function for contractions and reductions.
 def COMBINING_KIND_ADD : I32BitEnumAttrCaseBit<"ADD", 0, "add">;
 def COMBINING_KIND_MUL : I32BitEnumAttrCaseBit<"MUL", 1, "mul">;
@@ -80,6 +85,44 @@ def PrintPunctuation : I32EnumAttr<"PrintPunctuation",
 
 def Vector_PrintPunctuation : EnumAttr<Vector_Dialect, PrintPunctuation, "punctuation"> {
   let assemblyFormat = "`<` $value `>`";
+}
+
+def Vector_StridedSliceAttr : Vector_Attr<"StridedSlice", "strided_slice">
+{
+  let summary = "strided vector slice";
+
+  let description = [{
+    An attribute that represents a strided slice of a vector.
+
+    *Examples:*
+
+    Without sizes:
+
+    `{offsets = [0, 0, 2], strides = [1, 1]}`
+
+    With sizes (used for extract_strided_slice):
+
+    `{offsets = [0, 2], sizes = [2, 4], strides = [1, 1]}`
+
+    TODO? Come up with a range syntax (similar to Python slices).
+  }];
+
+  let parameters = (ins
+    ArrayRefParameter<"int64_t">:$offsets,
+    OptionalArrayRefParameter<"int64_t">:$sizes,
+    ArrayRefParameter<"int64_t">:$strides
+  );
+
+  let builders = [AttrBuilder<(ins "ArrayRef<int64_t>":$offsets, "ArrayRef<int64_t>":$strides), [{
+      return $_get($_ctxt, offsets, ArrayRef<int64_t>{}, strides);
+    }]>
+  ];
+
+  let assemblyFormat = [{
+    `{` `offsets` `=` `[` $offsets `]` `,`
+    (`sizes` `=` `[` $sizes^ `]` `,`)?
+    `strides` `=` `[` $strides `]` `}`
+  }];
 }
 
 #endif // MLIR_DIALECT_VECTOR_IR_VECTOR_ATTRIBUTES

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1040,8 +1040,8 @@ def Vector_InsertStridedSliceOp :
     PredOpTrait<"operand #0 and result have same element type",
                  TCresVTEtIsSameAsOpBase<0, 0>>,
     AllTypesMatch<["dest", "res"]>]>,
-    Arguments<(ins AnyVector:$source, AnyVector:$dest, I64ArrayAttr:$offsets,
-               I64ArrayAttr:$strides)>,
+    Arguments<(ins AnyVector:$source, AnyVector:$dest,
+               Vector_StridedSliceAttr:$strided_slice)>,
     Results<(outs AnyVector:$res)> {
   let summary = "strided_slice operation";
   let description = [{
@@ -1060,13 +1060,13 @@ def Vector_InsertStridedSliceOp :
 
     ```mlir
     %2 = vector.insert_strided_slice %0, %1
-        {offsets = [0, 0, 2], strides = [1, 1]}:
-      vector<2x4xf32> into vector<16x4x8xf32>
+        {offsets = [0, 0, 2], strides = [1, 1]}
+        : vector<2x4xf32> into vector<16x4x8xf32>
     ```
   }];
 
   let assemblyFormat = [{
-    $source `,` $dest attr-dict `:` type($source) `into` type($dest)
+    $source `,` $dest $strided_slice attr-dict `:` type($source) `into` type($dest)
   }];
 
   let builders = [
@@ -1081,10 +1081,13 @@ def Vector_InsertStridedSliceOp :
       return ::llvm::cast<VectorType>(getDest().getType());
     }
     bool hasNonUnitStrides() {
-      return llvm::any_of(getStrides(), [](Attribute attr) {
-        return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
+      return llvm::any_of(getStrides(), [](int64_t stride) {
+        return stride != 1;
       });
     }
+
+    ArrayRef<int64_t> getOffsets() { return getStridedSlice().getOffsets(); }
+    ArrayRef<int64_t> getStrides() { return getStridedSlice().getStrides(); }
   }];
 
   let hasFolder = 1;
@@ -1182,8 +1185,7 @@ def Vector_ExtractStridedSliceOp :
   Vector_Op<"extract_strided_slice", [Pure,
     PredOpTrait<"operand and result have same element type",
                  TCresVTEtIsSameAsOpBase<0, 0>>]>,
-    Arguments<(ins AnyVector:$vector, I64ArrayAttr:$offsets,
-               I64ArrayAttr:$sizes, I64ArrayAttr:$strides)>,
+    Arguments<(ins AnyVector:$vector, Vector_StridedSliceAttr:$strided_slice)>,
     Results<(outs AnyVector)> {
   let summary = "extract_strided_slice operation";
   let description = [{
@@ -1201,12 +1203,8 @@ def Vector_ExtractStridedSliceOp :
 
     ```mlir
     %1 = vector.extract_strided_slice %0
-        {offsets = [0, 2], sizes = [2, 4], strides = [1, 1]}:
-      vector<4x8x16xf32> to vector<2x4x16xf32>
-
-    // TODO: Evolve to a range form syntax similar to:
-    %1 = vector.extract_strided_slice %0[0:2:1][2:4:1]
-      vector<4x8x16xf32> to vector<2x4x16xf32>
+        {offsets = [0, 2], sizes = [2, 4], strides = [1, 1]}
+        : vector<4x8x16xf32> to vector<2x4x16xf32>
     ```
   }];
   let builders = [
@@ -1217,17 +1215,20 @@ def Vector_ExtractStridedSliceOp :
     VectorType getSourceVectorType() {
       return ::llvm::cast<VectorType>(getVector().getType());
     }
-    void getOffsets(SmallVectorImpl<int64_t> &results);
     bool hasNonUnitStrides() {
-      return llvm::any_of(getStrides(), [](Attribute attr) {
-        return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
+      return llvm::any_of(getStrides(), [](int64_t stride) {
+        return stride != 1;
       });
     }
+
+    ArrayRef<int64_t> getOffsets() { return getStridedSlice().getOffsets(); }
+    ArrayRef<int64_t> getSizes() { return getStridedSlice().getSizes(); }
+    ArrayRef<int64_t> getStrides() { return getStridedSlice().getStrides(); }
   }];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
   let hasVerifier = 1;
-  let assemblyFormat = "$vector attr-dict `:` type($vector) `to` type(results)";
+  let assemblyFormat = "$vector $strided_slice attr-dict `:` type($vector) `to` type(results)";
 }
 
 // TODO: Tighten semantics so that masks and inbounds can't be used

--- a/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
+++ b/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
@@ -940,12 +940,6 @@ convertTransferWriteToStores(RewriterBase &rewriter, vector::TransferWriteOp op,
   return success();
 }
 
-static void populateFromInt64AttrArray(ArrayAttr arrayAttr,
-                                       SmallVectorImpl<int64_t> &results) {
-  for (auto attr : arrayAttr)
-    results.push_back(cast<IntegerAttr>(attr).getInt());
-}
-
 static LogicalResult
 convertExtractStridedSlice(RewriterBase &rewriter,
                            vector::ExtractStridedSliceOp op,
@@ -996,11 +990,8 @@ convertExtractStridedSlice(RewriterBase &rewriter,
   auto sourceVector = it->second;
 
   // offset and sizes at warp-level of onwership.
-  SmallVector<int64_t> offsets;
-  populateFromInt64AttrArray(op.getOffsets(), offsets);
+  ArrayRef<int64_t> offsets = op.getOffsets();
 
-  SmallVector<int64_t> sizes;
-  populateFromInt64AttrArray(op.getSizes(), sizes);
   ArrayRef<int64_t> warpVectorShape = op.getSourceVectorType().getShape();
 
   // Compute offset in vector registers. Note that the mma.sync vector registers

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -46,9 +46,6 @@ static uint64_t getFirstIntValue(ValueRange values) {
 static uint64_t getFirstIntValue(ArrayRef<Attribute> attr) {
   return cast<IntegerAttr>(attr[0]).getInt();
 }
-static uint64_t getFirstIntValue(ArrayAttr attr) {
-  return (*attr.getAsValueRange<IntegerAttr>().begin()).getZExtValue();
-}
 static uint64_t getFirstIntValue(ArrayRef<OpFoldResult> foldResults) {
   auto attr = foldResults[0].dyn_cast<Attribute>();
   if (attr)
@@ -187,9 +184,9 @@ struct VectorExtractStridedSliceOpConvert final
     if (!dstType)
       return failure();
 
-    uint64_t offset = getFirstIntValue(extractOp.getOffsets());
-    uint64_t size = getFirstIntValue(extractOp.getSizes());
-    uint64_t stride = getFirstIntValue(extractOp.getStrides());
+    int64_t offset = extractOp.getOffsets().front();
+    int64_t size = extractOp.getSizes().front();
+    int64_t stride = extractOp.getStrides().front();
     if (stride != 1)
       return failure();
 
@@ -323,10 +320,10 @@ struct VectorInsertStridedSliceOpConvert final
     Value srcVector = adaptor.getOperands().front();
     Value dstVector = adaptor.getOperands().back();
 
-    uint64_t stride = getFirstIntValue(insertOp.getStrides());
+    uint64_t stride = insertOp.getStrides().front();
     if (stride != 1)
       return failure();
-    uint64_t offset = getFirstIntValue(insertOp.getOffsets());
+    uint64_t offset = insertOp.getOffsets().front();
 
     if (isa<spirv::ScalarType>(srcVector.getType())) {
       assert(!isa<spirv::ScalarType>(dstVector.getType()));

--- a/mlir/lib/Dialect/Arith/Transforms/IntNarrowing.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/IntNarrowing.cpp
@@ -549,11 +549,8 @@ struct ExtensionOverExtractStridedSlice final
     if (failed(ext))
       return failure();
 
-    VectorType origTy = op.getType();
-    VectorType extractTy =
-        origTy.cloneWith(origTy.getShape(), ext->getInElementType());
     Value newExtract = rewriter.create<vector::ExtractStridedSliceOp>(
-        op.getLoc(), extractTy, ext->getIn(), op.getOffsets(), op.getSizes(),
+        op.getLoc(), ext->getIn(), op.getOffsets(), op.getSizes(),
         op.getStrides());
     ext->recreateAndReplace(rewriter, op, newExtract);
     return success();

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -1340,13 +1340,6 @@ LogicalResult vector::ExtractOp::verify() {
   return success();
 }
 
-template <typename IntType>
-static SmallVector<IntType> extractVector(ArrayAttr arrayAttr) {
-  return llvm::to_vector<4>(llvm::map_range(
-      arrayAttr.getAsRange<IntegerAttr>(),
-      [](IntegerAttr attr) { return static_cast<IntType>(attr.getInt()); }));
-}
-
 /// Fold the result of chains of ExtractOp in place by simply concatenating the
 /// positions.
 static LogicalResult foldExtractOpFromExtractChain(ExtractOp extractOp) {
@@ -1770,8 +1763,7 @@ static Value foldExtractFromExtractStrided(ExtractOp extractOp) {
     return Value();
 
   // Trim offsets for dimensions fully extracted.
-  auto sliceOffsets =
-      extractVector<int64_t>(extractStridedSliceOp.getOffsets());
+  SmallVector<int64_t> sliceOffsets(extractStridedSliceOp.getOffsets());
   while (!sliceOffsets.empty()) {
     size_t lastOffset = sliceOffsets.size() - 1;
     if (sliceOffsets.back() != 0 ||
@@ -1825,12 +1817,10 @@ static Value foldExtractStridedOpFromInsertChain(ExtractOp extractOp) {
                              insertOp.getSourceVectorType().getRank();
     if (destinationRank > insertOp.getSourceVectorType().getRank())
       return Value();
-    auto insertOffsets = extractVector<int64_t>(insertOp.getOffsets());
+    ArrayRef<int64_t> insertOffsets = insertOp.getOffsets();
     ArrayRef<int64_t> extractOffsets = extractOp.getStaticPosition();
 
-    if (llvm::any_of(insertOp.getStrides(), [](Attribute attr) {
-          return llvm::cast<IntegerAttr>(attr).getInt() != 1;
-        }))
+    if (insertOp.hasNonUnitStrides())
       return Value();
     bool disjoint = false;
     SmallVector<int64_t, 4> offsetDiffs;
@@ -2193,12 +2183,6 @@ void ExtractOp::getCanonicalizationPatterns(RewritePatternSet &results,
               ExtractOpFromBroadcast, ExtractOpFromCreateMask>(context);
   results.add(foldExtractFromShapeCastToShapeCast);
   results.add(foldExtractFromFromElements);
-}
-
-static void populateFromInt64AttrArray(ArrayAttr arrayAttr,
-                                       SmallVectorImpl<int64_t> &results) {
-  for (auto attr : arrayAttr)
-    results.push_back(llvm::cast<IntegerAttr>(attr).getInt());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2907,26 +2891,8 @@ void InsertStridedSliceOp::build(OpBuilder &builder, OperationState &result,
                                  Value source, Value dest,
                                  ArrayRef<int64_t> offsets,
                                  ArrayRef<int64_t> strides) {
-  result.addOperands({source, dest});
-  auto offsetsAttr = getVectorSubscriptAttr(builder, offsets);
-  auto stridesAttr = getVectorSubscriptAttr(builder, strides);
-  result.addTypes(dest.getType());
-  result.addAttribute(InsertStridedSliceOp::getOffsetsAttrName(result.name),
-                      offsetsAttr);
-  result.addAttribute(InsertStridedSliceOp::getStridesAttrName(result.name),
-                      stridesAttr);
-}
-
-// TODO: Should be moved to Tablegen ConfinedAttr attributes.
-template <typename OpType>
-static LogicalResult isIntegerArrayAttrSmallerThanShape(OpType op,
-                                                        ArrayAttr arrayAttr,
-                                                        ArrayRef<int64_t> shape,
-                                                        StringRef attrName) {
-  if (arrayAttr.size() > shape.size())
-    return op.emitOpError("expected ")
-           << attrName << " attribute of rank no greater than vector rank";
-  return success();
+  build(builder, result, source, dest,
+        StridedSliceAttr::get(builder.getContext(), offsets, strides));
 }
 
 // Returns true if all integers in `arrayAttr` are in the half-open [min, max}
@@ -2934,16 +2900,15 @@ static LogicalResult isIntegerArrayAttrSmallerThanShape(OpType op,
 // Otherwise, the admissible interval is [min, max].
 template <typename OpType>
 static LogicalResult
-isIntegerArrayAttrConfinedToRange(OpType op, ArrayAttr arrayAttr, int64_t min,
-                                  int64_t max, StringRef attrName,
-                                  bool halfOpen = true) {
-  for (auto attr : arrayAttr) {
-    auto val = llvm::cast<IntegerAttr>(attr).getInt();
+isIntArrayConfinedToRange(OpType op, ArrayRef<int64_t> array, int64_t min,
+                          int64_t max, StringRef arrayName,
+                          bool halfOpen = true) {
+  for (int64_t val : array) {
     auto upper = max;
     if (!halfOpen)
       upper += 1;
     if (val < min || val >= upper)
-      return op.emitOpError("expected ") << attrName << " to be confined to ["
+      return op.emitOpError("expected ") << arrayName << " to be confined to ["
                                          << min << ", " << upper << ")";
   }
   return success();
@@ -2954,13 +2919,12 @@ isIntegerArrayAttrConfinedToRange(OpType op, ArrayAttr arrayAttr, int64_t min,
 // Otherwise, the admissible interval is [min, max].
 template <typename OpType>
 static LogicalResult
-isIntegerArrayAttrConfinedToShape(OpType op, ArrayAttr arrayAttr,
-                                  ArrayRef<int64_t> shape, StringRef attrName,
-                                  bool halfOpen = true, int64_t min = 0) {
-  for (auto [index, attrDimPair] :
-       llvm::enumerate(llvm::zip_first(arrayAttr, shape))) {
-    int64_t val = llvm::cast<IntegerAttr>(std::get<0>(attrDimPair)).getInt();
-    int64_t max = std::get<1>(attrDimPair);
+isIntArrayConfinedToShape(OpType op, ArrayRef<int64_t> array,
+                          ArrayRef<int64_t> shape, StringRef attrName,
+                          bool halfOpen = true, int64_t min = 0) {
+  for (auto [index, dimPair] : llvm::enumerate(llvm::zip_first(array, shape))) {
+    int64_t val, max;
+    std::tie(val, max) = dimPair;
     if (!halfOpen)
       max += 1;
     if (val < min || val >= max)
@@ -2977,40 +2941,32 @@ isIntegerArrayAttrConfinedToShape(OpType op, ArrayAttr arrayAttr,
 // If `halfOpen` is true then the admissible interval is [min, max). Otherwise,
 // the admissible interval is [min, max].
 template <typename OpType>
-static LogicalResult isSumOfIntegerArrayAttrConfinedToShape(
-    OpType op, ArrayAttr arrayAttr1, ArrayAttr arrayAttr2,
-    ArrayRef<int64_t> shape, StringRef attrName1, StringRef attrName2,
+static LogicalResult isSumOfIntArrayConfinedToShape(
+    OpType op, ArrayRef<int64_t> array1, ArrayRef<int64_t> array2,
+    ArrayRef<int64_t> shape, StringRef arrayName1, StringRef arrayName2,
     bool halfOpen = true, int64_t min = 1) {
-  assert(arrayAttr1.size() <= shape.size());
-  assert(arrayAttr2.size() <= shape.size());
-  for (auto [index, it] :
-       llvm::enumerate(llvm::zip(arrayAttr1, arrayAttr2, shape))) {
-    auto val1 = llvm::cast<IntegerAttr>(std::get<0>(it)).getInt();
-    auto val2 = llvm::cast<IntegerAttr>(std::get<1>(it)).getInt();
-    int64_t max = std::get<2>(it);
+  assert(array1.size() <= shape.size());
+  assert(array2.size() <= shape.size());
+  for (auto [index, it] : llvm::enumerate(llvm::zip(array1, array2, shape))) {
+    int64_t val1, val2, max;
+    std::tie(val1, val2, max) = it;
     if (!halfOpen)
       max += 1;
     if (val1 + val2 < 0 || val1 + val2 >= max)
       return op.emitOpError("expected sum(")
-             << attrName1 << ", " << attrName2 << ") dimension " << index
+             << arrayName1 << ", " << arrayName2 << ") dimension " << index
              << " to be confined to [" << min << ", " << max << ")";
   }
   return success();
 }
 
-static ArrayAttr makeI64ArrayAttr(ArrayRef<int64_t> values,
-                                  MLIRContext *context) {
-  auto attrs = llvm::map_range(values, [context](int64_t v) -> Attribute {
-    return IntegerAttr::get(IntegerType::get(context, 64), APInt(64, v));
-  });
-  return ArrayAttr::get(context, llvm::to_vector<8>(attrs));
-}
-
 LogicalResult InsertStridedSliceOp::verify() {
   auto sourceVectorType = getSourceVectorType();
   auto destVectorType = getDestVectorType();
-  auto offsets = getOffsetsAttr();
-  auto strides = getStridesAttr();
+  auto offsets = getOffsets();
+  auto strides = getStrides();
+  if (!getStridedSlice().getSizes().empty())
+    return emitOpError("slice sizes not supported");
   if (offsets.size() != static_cast<unsigned>(destVectorType.getRank()))
     return emitOpError(
         "expected offsets of same size as destination vector rank");
@@ -3025,18 +2981,14 @@ LogicalResult InsertStridedSliceOp::verify() {
   SmallVector<int64_t, 4> sourceShapeAsDestShape(
       destShape.size() - sourceShape.size(), 0);
   sourceShapeAsDestShape.append(sourceShape.begin(), sourceShape.end());
-  auto offName = InsertStridedSliceOp::getOffsetsAttrName();
-  auto stridesName = InsertStridedSliceOp::getStridesAttrName();
-  if (failed(isIntegerArrayAttrConfinedToShape(*this, offsets, destShape,
-                                               offName)) ||
-      failed(isIntegerArrayAttrConfinedToRange(*this, strides, /*min=*/1,
-                                               /*max=*/1, stridesName,
-                                               /*halfOpen=*/false)) ||
-      failed(isSumOfIntegerArrayAttrConfinedToShape(
-          *this, offsets,
-          makeI64ArrayAttr(sourceShapeAsDestShape, getContext()), destShape,
-          offName, "source vector shape",
-          /*halfOpen=*/false, /*min=*/1)))
+  if (failed(isIntArrayConfinedToShape(*this, offsets, destShape, "offsets")) ||
+      failed(isIntArrayConfinedToRange(*this, strides, /*min=*/1,
+                                       /*max=*/1, "strides",
+                                       /*halfOpen=*/false)) ||
+      failed(isSumOfIntArrayConfinedToShape(*this, offsets,
+                                            sourceShapeAsDestShape, destShape,
+                                            "offsets", "source vector shape",
+                                            /*halfOpen=*/false, /*min=*/1)))
     return failure();
 
   unsigned rankDiff = destShape.size() - sourceShape.size();
@@ -3161,7 +3113,7 @@ public:
     VectorType sliceVecTy = sourceValue.getType();
     ArrayRef<int64_t> sliceShape = sliceVecTy.getShape();
     int64_t rankDifference = destTy.getRank() - sliceVecTy.getRank();
-    SmallVector<int64_t, 4> offsets = getI64SubArray(op.getOffsets());
+    ArrayRef<int64_t> offsets = op.getOffsets();
     SmallVector<int64_t, 4> destStrides = computeStrides(destTy.getShape());
 
     // Calcualte the destination element indices by enumerating all slice
@@ -3336,14 +3288,15 @@ Type OuterProductOp::getExpectedMaskType() {
 //   2. Add sizes from 'vectorType' for remaining dims.
 // Scalable flags are inherited from 'vectorType'.
 static Type inferStridedSliceOpResultType(VectorType vectorType,
-                                          ArrayAttr offsets, ArrayAttr sizes,
-                                          ArrayAttr strides) {
+                                          ArrayRef<int64_t> offsets,
+                                          ArrayRef<int64_t> sizes,
+                                          ArrayRef<int64_t> strides) {
   assert(offsets.size() == sizes.size() && offsets.size() == strides.size());
   SmallVector<int64_t, 4> shape;
   shape.reserve(vectorType.getRank());
   unsigned idx = 0;
   for (unsigned e = offsets.size(); idx < e; ++idx)
-    shape.push_back(llvm::cast<IntegerAttr>(sizes[idx]).getInt());
+    shape.push_back(sizes[idx]);
   for (unsigned e = vectorType.getShape().size(); idx < e; ++idx)
     shape.push_back(vectorType.getShape()[idx]);
 
@@ -3356,51 +3309,48 @@ void ExtractStridedSliceOp::build(OpBuilder &builder, OperationState &result,
                                   ArrayRef<int64_t> sizes,
                                   ArrayRef<int64_t> strides) {
   result.addOperands(source);
-  auto offsetsAttr = getVectorSubscriptAttr(builder, offsets);
-  auto sizesAttr = getVectorSubscriptAttr(builder, sizes);
-  auto stridesAttr = getVectorSubscriptAttr(builder, strides);
-  result.addTypes(
-      inferStridedSliceOpResultType(llvm::cast<VectorType>(source.getType()),
-                                    offsetsAttr, sizesAttr, stridesAttr));
-  result.addAttribute(ExtractStridedSliceOp::getOffsetsAttrName(result.name),
-                      offsetsAttr);
-  result.addAttribute(ExtractStridedSliceOp::getSizesAttrName(result.name),
-                      sizesAttr);
-  result.addAttribute(ExtractStridedSliceOp::getStridesAttrName(result.name),
-                      stridesAttr);
+  auto stridedSliceAttr =
+      StridedSliceAttr::get(builder.getContext(), offsets, sizes, strides);
+  result.addTypes(inferStridedSliceOpResultType(
+      llvm::cast<VectorType>(source.getType()), offsets, sizes, strides));
+  result.addAttribute(
+      ExtractStridedSliceOp::getStridedSliceAttrName(result.name),
+      stridedSliceAttr);
 }
 
 LogicalResult ExtractStridedSliceOp::verify() {
   auto type = getSourceVectorType();
-  auto offsets = getOffsetsAttr();
-  auto sizes = getSizesAttr();
-  auto strides = getStridesAttr();
+  auto offsets = getOffsets();
+  auto sizes = getSizes();
+  auto strides = getStrides();
   if (offsets.size() != sizes.size() || offsets.size() != strides.size())
     return emitOpError(
         "expected offsets, sizes and strides attributes of same size");
 
   auto shape = type.getShape();
-  auto offName = getOffsetsAttrName();
-  auto sizesName = getSizesAttrName();
-  auto stridesName = getStridesAttrName();
-  if (failed(
-          isIntegerArrayAttrSmallerThanShape(*this, offsets, shape, offName)) ||
-      failed(
-          isIntegerArrayAttrSmallerThanShape(*this, sizes, shape, sizesName)) ||
-      failed(isIntegerArrayAttrSmallerThanShape(*this, strides, shape,
-                                                stridesName)) ||
-      failed(
-          isIntegerArrayAttrConfinedToShape(*this, offsets, shape, offName)) ||
-      failed(isIntegerArrayAttrConfinedToShape(*this, sizes, shape, sizesName,
-                                               /*halfOpen=*/false,
-                                               /*min=*/1)) ||
-      failed(isIntegerArrayAttrConfinedToRange(*this, strides, /*min=*/1,
-                                               /*max=*/1, stridesName,
-                                               /*halfOpen=*/false)) ||
-      failed(isSumOfIntegerArrayAttrConfinedToShape(*this, offsets, sizes,
-                                                    shape, offName, sizesName,
-                                                    /*halfOpen=*/false)))
+  auto isIntArraySmallerThanShape = [&](ArrayRef<int64_t> array,
+                                        StringRef arrayName) -> LogicalResult {
+    if (array.size() > shape.size())
+      return emitOpError("expected ")
+             << arrayName << " to have rank no greater than vector rank";
+    return success();
+  };
+
+  if (failed(isIntArraySmallerThanShape(offsets, "offsets")) ||
+      failed(isIntArraySmallerThanShape(sizes, "sizes")) ||
+      failed(isIntArraySmallerThanShape(strides, "strides")) ||
+      failed(isIntArrayConfinedToShape(*this, offsets, shape, "offsets")) ||
+      failed(isIntArrayConfinedToShape(*this, sizes, shape, "sizes",
+                                       /*halfOpen=*/false,
+                                       /*min=*/1)) ||
+      failed(isIntArrayConfinedToRange(*this, strides, /*min=*/1,
+                                       /*max=*/1, "strides",
+                                       /*halfOpen=*/false)) ||
+      failed(isSumOfIntArrayConfinedToShape(*this, offsets, sizes, shape,
+                                            "offsets", "sizes",
+                                            /*halfOpen=*/false))) {
     return failure();
+  }
 
   auto resultType = inferStridedSliceOpResultType(getSourceVectorType(),
                                                   offsets, sizes, strides);
@@ -3410,7 +3360,7 @@ LogicalResult ExtractStridedSliceOp::verify() {
   for (unsigned idx = 0; idx < sizes.size(); ++idx) {
     if (type.getScalableDims()[idx]) {
       auto inputDim = type.getShape()[idx];
-      auto inputSize = llvm::cast<IntegerAttr>(sizes[idx]).getInt();
+      auto inputSize = sizes[idx];
       if (inputDim != inputSize)
         return emitOpError("expected size at idx=")
                << idx
@@ -3428,20 +3378,16 @@ LogicalResult ExtractStridedSliceOp::verify() {
 // extracted vector is a subset of one of the vector inserted.
 static LogicalResult
 foldExtractStridedOpFromInsertChain(ExtractStridedSliceOp op) {
-  // Helper to extract integer out of ArrayAttr.
-  auto getElement = [](ArrayAttr array, int idx) {
-    return llvm::cast<IntegerAttr>(array[idx]).getInt();
-  };
-  ArrayAttr extractOffsets = op.getOffsets();
-  ArrayAttr extractStrides = op.getStrides();
-  ArrayAttr extractSizes = op.getSizes();
+  ArrayRef<int64_t> extractOffsets = op.getOffsets();
+  ArrayRef<int64_t> extractStrides = op.getStrides();
+  ArrayRef<int64_t> extractSizes = op.getSizes();
   auto insertOp = op.getVector().getDefiningOp<InsertStridedSliceOp>();
   while (insertOp) {
     if (op.getSourceVectorType().getRank() !=
         insertOp.getSourceVectorType().getRank())
       return failure();
-    ArrayAttr insertOffsets = insertOp.getOffsets();
-    ArrayAttr insertStrides = insertOp.getStrides();
+    ArrayRef<int64_t> insertOffsets = insertOp.getOffsets();
+    ArrayRef<int64_t> insertStrides = insertOp.getStrides();
     // If the rank of extract is greater than the rank of insert, we are likely
     // extracting a partial chunk of the vector inserted.
     if (extractOffsets.size() > insertOffsets.size())
@@ -3450,12 +3396,12 @@ foldExtractStridedOpFromInsertChain(ExtractStridedSliceOp op) {
     bool disjoint = false;
     SmallVector<int64_t, 4> offsetDiffs;
     for (unsigned dim = 0, e = extractOffsets.size(); dim < e; ++dim) {
-      if (getElement(extractStrides, dim) != getElement(insertStrides, dim))
+      if (extractStrides[dim] != insertStrides[dim])
         return failure();
-      int64_t start = getElement(insertOffsets, dim);
+      int64_t start = insertOffsets[dim];
       int64_t end = start + insertOp.getSourceVectorType().getDimSize(dim);
-      int64_t offset = getElement(extractOffsets, dim);
-      int64_t size = getElement(extractSizes, dim);
+      int64_t offset = extractOffsets[dim];
+      int64_t size = extractSizes[dim];
       // Check if the start of the extract offset is in the interval inserted.
       if (start <= offset && offset < end) {
         // If the extract interval overlaps but is not fully included we may
@@ -3473,7 +3419,9 @@ foldExtractStridedOpFromInsertChain(ExtractStridedSliceOp op) {
       op.setOperand(insertOp.getSource());
       // OpBuilder is only used as a helper to build an I64ArrayAttr.
       OpBuilder b(op.getContext());
-      op.setOffsetsAttr(b.getI64ArrayAttr(offsetDiffs));
+      auto stridedSliceAttr = StridedSliceAttr::get(
+          op.getContext(), offsetDiffs, op.getSizes(), op.getStrides());
+      op.setStridedSliceAttr(stridedSliceAttr);
       return success();
     }
     // If the chunk extracted is disjoint from the chunk inserted, keep looking
@@ -3496,11 +3444,6 @@ OpFoldResult ExtractStridedSliceOp::fold(FoldAdaptor adaptor) {
     return getResult();
   return {};
 }
-
-void ExtractStridedSliceOp::getOffsets(SmallVectorImpl<int64_t> &results) {
-  populateFromInt64AttrArray(getOffsets(), results);
-}
-
 namespace {
 
 // Pattern to rewrite an ExtractStridedSliceOp(ConstantMaskOp) to
@@ -3524,11 +3467,8 @@ public:
     // Gather constant mask dimension sizes.
     ArrayRef<int64_t> maskDimSizes = constantMaskOp.getMaskDimSizes();
     // Gather strided slice offsets and sizes.
-    SmallVector<int64_t, 4> sliceOffsets;
-    populateFromInt64AttrArray(extractStridedSliceOp.getOffsets(),
-                               sliceOffsets);
-    SmallVector<int64_t, 4> sliceSizes;
-    populateFromInt64AttrArray(extractStridedSliceOp.getSizes(), sliceSizes);
+    ArrayRef<int64_t> sliceOffsets = extractStridedSliceOp.getOffsets();
+    ArrayRef<int64_t> sliceSizes = extractStridedSliceOp.getSizes();
 
     // Compute slice of vector mask region.
     SmallVector<int64_t, 4> sliceMaskDimSizes;
@@ -3620,10 +3560,10 @@ public:
 
     // Expand offsets and sizes to match the vector rank.
     SmallVector<int64_t, 4> offsets(sliceRank, 0);
-    copy(getI64SubArray(extractStridedSliceOp.getOffsets()), offsets.begin());
+    copy(extractStridedSliceOp.getOffsets(), offsets.begin());
 
     SmallVector<int64_t, 4> sizes(sourceShape);
-    copy(getI64SubArray(extractStridedSliceOp.getSizes()), sizes.begin());
+    copy(extractStridedSliceOp.getSizes(), sizes.begin());
 
     // Calculate the slice elements by enumerating all slice positions and
     // linearizing them. The enumeration order is lexicographic which yields a
@@ -3686,10 +3626,9 @@ public:
     bool isScalarSrc = (srcRank == 0 || srcVecType.getNumElements() == 1);
     if (!lowerDimMatch && !isScalarSrc) {
       source = rewriter.create<ExtractStridedSliceOp>(
-          op->getLoc(), source,
-          getI64SubArray(op.getOffsets(), /* dropFront=*/rankDiff),
-          getI64SubArray(op.getSizes(), /* dropFront=*/rankDiff),
-          getI64SubArray(op.getStrides(), /* dropFront=*/rankDiff));
+          op->getLoc(), source, op.getOffsets().drop_front(rankDiff),
+          op.getSizes().drop_front(rankDiff),
+          op.getStrides().drop_front(rankDiff));
     }
     rewriter.replaceOpWithNewOp<BroadcastOp>(op, op.getType(), source);
     return success();

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorScan.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorScan.cpp
@@ -130,23 +130,16 @@ struct ScanToArithOps : public OpRewritePattern<vector::ScanOp> {
     VectorType initialValueType = scanOp.getInitialValueType();
     int64_t initialValueRank = initialValueType.getRank();
 
-    SmallVector<int64_t> reductionShape(destShape);
-    reductionShape[reductionDim] = 1;
-    VectorType reductionType = VectorType::get(reductionShape, elType);
     SmallVector<int64_t> offsets(destRank, 0);
     SmallVector<int64_t> strides(destRank, 1);
     SmallVector<int64_t> sizes(destShape);
     sizes[reductionDim] = 1;
-    ArrayAttr scanSizes = rewriter.getI64ArrayAttr(sizes);
-    ArrayAttr scanStrides = rewriter.getI64ArrayAttr(strides);
 
     Value lastOutput, lastInput;
     for (int i = 0; i < destShape[reductionDim]; i++) {
       offsets[reductionDim] = i;
-      ArrayAttr scanOffsets = rewriter.getI64ArrayAttr(offsets);
       Value input = rewriter.create<vector::ExtractStridedSliceOp>(
-          loc, reductionType, scanOp.getSource(), scanOffsets, scanSizes,
-          scanStrides);
+          loc, scanOp.getSource(), offsets, sizes, strides);
       Value output;
       if (i == 0) {
         if (inclusive) {

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -683,7 +683,7 @@ func.func @extract_strided_slice(%arg0: vector<4x8x16xf32>) {
 // -----
 
 func.func @extract_strided_slice(%arg0: vector<4x8x16xf32>) {
-  // expected-error@+1 {{expected offsets attribute of rank no greater than vector rank}}
+  // expected-error@+1 {{op expected offsets to have rank no greater than vector rank}}
   %1 = vector.extract_strided_slice %arg0 {offsets = [2, 2, 2, 2], sizes = [2, 2, 2, 2], strides = [1, 1, 1, 1]} : vector<4x8x16xf32> to vector<2x2x16xf32>
 }
 

--- a/mlir/test/Dialect/Vector/linearize.mlir
+++ b/mlir/test/Dialect/Vector/linearize.mlir
@@ -172,18 +172,18 @@ func.func @test_extract_strided_slice_1(%arg0 : vector<4x8xf32>) -> vector<2x2xf
 
   // BW-0: %[[RES:.*]] = vector.extract_strided_slice %[[ARG:.*]] {offsets = [0, 4], sizes = [2, 2], strides = [1, 1]} : vector<4x8xf32> to vector<2x2xf32>
   // BW-0: return %[[RES]] : vector<2x2xf32>
-  %0 = vector.extract_strided_slice %arg0 { sizes = [2, 2], strides = [1, 1], offsets = [0, 4]}
+  %0 = vector.extract_strided_slice %arg0 { offsets = [0, 4], sizes = [2, 2], strides = [1, 1] }
      : vector<4x8xf32> to vector<2x2xf32>
   return %0 : vector<2x2xf32>
 }
 
 // ALL-LABEL:   func.func @test_extract_strided_slice_1_scalable(
 // ALL-SAME:    %[[VAL_0:.*]]: vector<4x[8]xf32>) -> vector<2x[8]xf32> {
-func.func @test_extract_strided_slice_1_scalable(%arg0: vector<4x[8]xf32>) -> vector<2x[8]xf32> {  
+func.func @test_extract_strided_slice_1_scalable(%arg0: vector<4x[8]xf32>) -> vector<2x[8]xf32> {
   // ALL-NOT: vector.shuffle
   // ALL-NOT: vector.shape_cast
   // ALL: %[[RES:.*]] = vector.extract_strided_slice %[[VAL_0]] {offsets = [1, 0], sizes = [2, 8], strides = [1, 1]} : vector<4x[8]xf32> to vector<2x[8]xf32>
-  %0 = vector.extract_strided_slice %arg0 { sizes = [2, 8], strides = [1, 1], offsets = [1, 0] } : vector<4x[8]xf32> to vector<2x[8]xf32>
+  %0 = vector.extract_strided_slice %arg0 { offsets = [1, 0], sizes = [2, 8], strides = [1, 1] } : vector<4x[8]xf32> to vector<2x[8]xf32>
   // ALL: return %[[RES]] : vector<2x[8]xf32>
   return %0 : vector<2x[8]xf32>
 }
@@ -206,7 +206,7 @@ func.func @test_extract_strided_slice_2(%arg0 : vector<2x8x2xf32>) -> vector<1x4
 
   // BW-0: %[[RES:.*]] = vector.extract_strided_slice %[[ORIG_ARG]] {offsets = [1, 2], sizes = [1, 4], strides = [1, 1]} : vector<2x8x2xf32> to vector<1x4x2xf32>
   // BW-0: return %[[RES]] : vector<1x4x2xf32>
-  %0 = vector.extract_strided_slice %arg0 { offsets = [1, 2], strides = [1, 1], sizes = [1, 4] }
+  %0 = vector.extract_strided_slice %arg0 { offsets = [1, 2], sizes = [1, 4], strides = [1, 1] }
     : vector<2x8x2xf32> to vector<1x4x2xf32>
   return %0 : vector<1x4x2xf32>
 }


### PR DESCRIPTION
This commit updates the representation of both extract_strided_slice and insert_strided_slice to primitive arrays of int64_ts, rather than ArrayAttrs of IntegerAttrs. This prevents a lot of boilerplate conversions between IntegerAttr and int64_t.

This is done by adding a new `StridedSliceAttr` which matches the previous syntax and can be used for both operations.

It may also be possible to explore alternate slice syntax for the `StridedSliceAttr` in future.