### PR TITLE
[libc++] mark P0645 as complete

### DIFF
--- a/libcxx/docs/Status/Cxx20.rst
+++ b/libcxx/docs/Status/Cxx20.rst
@@ -41,8 +41,8 @@ Paper Status
 .. note::
 
    .. [#note-P0591] P0591: The changes in [mem.poly.allocator.mem] are missing.
-   .. [#note-P0645] P0645: The paper is implemented but still marked as an incomplete feature
-      (the feature-test macro is not set).
+   .. [#note-P0645] P0645: The implementation was complete since Clang 14,
+      except the feature-test macro was not set until Clang 19.
    .. [#note-P0966] P0966: It was previously erroneously marked as complete in version 8.0. See `bug 45368 <https://llvm.org/PR45368>`__.
    .. [#note-P0619] P0619: Only sections D.8, D.9, D.10 and D.13 are implemented. Sections D.4, D.7, D.11, and D.12 remain undone.
    .. [#note-P0883.1] P0883: shared_ptr and floating-point changes weren't applied as they themselves aren't implemented yet.


### PR DESCRIPTION
Now that #98275 has been merged, the footnote for P0645 has become obsolete. I don't know if people prefer to just remove the footnote, or whether to keep it (to note the history), and whether to increment the "First version". I've made a suggestion, but I don't have a strong opinion - it should just be cleaned up one way or another.

CC @mordante @ldionne 