### PR TITLE
[libc] disable strfroml entrypoint on aarch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -189,7 +189,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.srand
     libc.src.stdlib.strfromd
     libc.src.stdlib.strfromf
-    libc.src.stdlib.strfroml
+    # TODO: long double support is buggy with clang-11. Re-enable when buildbots are upgraded.
+    # libc.src.stdlib.strfroml
     libc.src.stdlib.strtod
     libc.src.stdlib.strtof
     libc.src.stdlib.strtol


### PR DESCRIPTION
Disable `strfroml` entrypoint on aarch64 to please clang-11 buildbots. Detailed in https://github.com/llvm/llvm-project/issues/101846. This is not a fix for #101846 so I will keep the issue open until our buildbot is updated or other mitigation is applied.

