### PR TITLE
[SandboxIR] Implement UnreachableInst

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -975,7 +975,7 @@ public:
   static bool classof(const Value *From);
   unsigned getNumSuccessors() const { return 0; }
   unsigned getUseOperandNo(const Use &Use) const final {
-    return getUseOperandNoDefault(Use);
+    llvm_unreachable("UnreachableInst has no operands!");
   }
   unsigned getNumOfIRInstrs() const final { return 1u; }
 #ifndef NDEBUG

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -959,10 +959,8 @@ public:
 
 class UnreachableInst final : public Instruction {
   /// Use UnreachableInst::create() instead of calling the constructor.
-  UnreachableInst(llvm::Instruction *I, Context &Ctx)
+  UnreachableInst(llvm::UnreachableInst *I, Context &Ctx)
       : Instruction(ClassID::Unreachable, Opcode::Unreachable, I, Ctx) {}
-  UnreachableInst(ClassID SubclassID, llvm::Instruction *I, Context &Ctx)
-      : Instruction(SubclassID, Opcode::Unreachable, I, Ctx) {}
   friend Context;
   Use getOperandUseInternal(unsigned OpIdx, bool Verify) const final {
     return getOperandUseDefault(OpIdx, Verify);
@@ -976,12 +974,6 @@ public:
   static UnreachableInst *create(BasicBlock *InsertAtEnd, Context &Ctx);
   static bool classof(const Value *From);
   unsigned getNumSuccessors() const { return 0; }
-  BasicBlock *getSuccessor(unsigned idx) const {
-    llvm_unreachable("UnreachableInst has no successors!");
-  }
-  void setSuccessor(unsigned idx, BasicBlock *B) {
-    llvm_unreachable("UnreachableInst has no successors!");
-  }
   unsigned getUseOperandNo(const Use &Use) const final {
     return getUseOperandNoDefault(Use);
   }

--- a/llvm/include/llvm/SandboxIR/SandboxIRValues.def
+++ b/llvm/include/llvm/SandboxIR/SandboxIRValues.def
@@ -61,7 +61,6 @@ DEF_INSTR(Cast,  OPCODES(\
 DEF_INSTR(PHI,           OP(PHI),           PHINode)
 DEF_INSTR(Unreachable,   OP(Unreachable),   UnreachableInst)
 
-
 // clang-format on
 #ifdef DEF_VALUE
 #undef DEF_VALUE

--- a/llvm/include/llvm/SandboxIR/SandboxIRValues.def
+++ b/llvm/include/llvm/SandboxIR/SandboxIRValues.def
@@ -59,7 +59,9 @@ DEF_INSTR(Cast,  OPCODES(\
                          OP(AddrSpaceCast) \
                          ),                 CastInst)
 DEF_INSTR(PHI,           OP(PHI),           PHINode)
-  
+DEF_INSTR(Unreachable,   OP(Unreachable),   UnreachableInst)
+
+
 // clang-format on
 #ifdef DEF_VALUE
 #undef DEF_VALUE

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -1498,7 +1498,8 @@ Value *Context::getOrCreateValueInternal(llvm::Value *LLVMV, llvm::User *U) {
   }
   case llvm::Instruction::Unreachable: {
     auto *LLVMUnreachable = cast<llvm::UnreachableInst>(LLVMV);
-    It->second = std::unique_ptr<UnreachableInst>(new UnreachableInst(LLVMUnreachable, *this));
+    It->second = std::unique_ptr<UnreachableInst>(
+        new UnreachableInst(LLVMUnreachable, *this));
     return It->second.get();
   }
   default:

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -747,6 +747,38 @@ void StoreInst::dump() const {
 }
 #endif // NDEBUG
 
+UnreachableInst *UnreachableInst::create(Instruction *InsertBefore,
+                                         Context &Ctx) {
+  auto &Builder = Ctx.getLLVMIRBuilder();
+  Builder.SetInsertPoint(cast<llvm::Instruction>(InsertBefore->Val));
+  llvm::UnreachableInst *NewUI = Builder.CreateUnreachable();
+  return Ctx.createUnreachableInst(NewUI);
+}
+
+UnreachableInst *UnreachableInst::create(BasicBlock *InsertAtEnd,
+                                         Context &Ctx) {
+  auto &Builder = Ctx.getLLVMIRBuilder();
+  Builder.SetInsertPoint(cast<llvm::BasicBlock>(InsertAtEnd->Val));
+  llvm::UnreachableInst *NewUI = Builder.CreateUnreachable();
+  return Ctx.createUnreachableInst(NewUI);
+}
+
+bool UnreachableInst::classof(const Value *From) {
+  return From->getSubclassID() == ClassID::Unreachable;
+}
+
+#ifndef NDEBUG
+void UnreachableInst::dump(raw_ostream &OS) const {
+  dumpCommonPrefix(OS);
+  dumpCommonSuffix(OS);
+}
+
+void UnreachableInst::dump() const {
+  dump(dbgs());
+  dbgs() << "\n";
+}
+#endif // NDEBUG
+
 ReturnInst *ReturnInst::createCommon(Value *RetVal, IRBuilder<> &Builder,
                                      Context &Ctx) {
   llvm::ReturnInst *NewRI;
@@ -1520,6 +1552,12 @@ InvokeInst *Context::createInvokeInst(llvm::InvokeInst *I) {
 CallBrInst *Context::createCallBrInst(llvm::CallBrInst *I) {
   auto NewPtr = std::unique_ptr<CallBrInst>(new CallBrInst(I, *this));
   return cast<CallBrInst>(registerValue(std::move(NewPtr)));
+}
+
+UnreachableInst *Context::createUnreachableInst(llvm::UnreachableInst *UI) {
+  auto NewPtr =
+      std::unique_ptr<UnreachableInst>(new UnreachableInst(UI, *this));
+  return cast<UnreachableInst>(registerValue(std::move(NewPtr)));
 }
 
 GetElementPtrInst *

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -1496,6 +1496,11 @@ Value *Context::getOrCreateValueInternal(llvm::Value *LLVMV, llvm::User *U) {
     It->second = std::unique_ptr<PHINode>(new PHINode(LLVMPhi, *this));
     return It->second.get();
   }
+  case llvm::Instruction::Unreachable: {
+    auto *LLVMUnreachable = cast<llvm::UnreachableInst>(LLVMV);
+    It->second = std::unique_ptr<UnreachableInst>(new UnreachableInst(LLVMUnreachable, *this));
+    return It->second.get();
+  }
   default:
     break;
   }

--- a/llvm/lib/SandboxIR/SandboxIR.cpp
+++ b/llvm/lib/SandboxIR/SandboxIR.cpp
@@ -750,7 +750,8 @@ void StoreInst::dump() const {
 UnreachableInst *UnreachableInst::create(Instruction *InsertBefore,
                                          Context &Ctx) {
   auto &Builder = Ctx.getLLVMIRBuilder();
-  Builder.SetInsertPoint(cast<llvm::Instruction>(InsertBefore->Val));
+  llvm::Instruction *LLVMBefore = InsertBefore->getTopmostLLVMInstruction();
+  Builder.SetInsertPoint(LLVMBefore);
   llvm::UnreachableInst *NewUI = Builder.CreateUnreachable();
   return Ctx.createUnreachableInst(NewUI);
 }

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -2054,7 +2054,6 @@ define void @foo() {
   auto *UI = cast<sandboxir::UnreachableInst>(&*It++);
 
   EXPECT_TRUE(llvm::isa<sandboxir::UnreachableInst>(UI));
-
   // Check create(InsertBefore)
   sandboxir::UnreachableInst *NewUI =
       sandboxir::UnreachableInst::create(/*InsertBefore=*/Ret, Ctx);

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -2053,7 +2053,8 @@ define void @foo() {
   auto *Ret = &*It++;
   auto *UI = cast<sandboxir::UnreachableInst>(&*It++);
 
-  EXPECT_TRUE(llvm::isa<sandboxir::UnreachableInst>(UI));
+  EXPECT_EQ(UI->getNumSuccessors(), 0u);
+  EXPECT_EQ(UI->getNumOfIRInstrs(), 1u);
   // Check create(InsertBefore)
   sandboxir::UnreachableInst *NewUI =
       sandboxir::UnreachableInst::create(/*InsertBefore=*/Ret, Ctx);

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -2041,9 +2041,7 @@ bb3:
 TEST_F(SandboxIRTest, UnreachableInst) {
   parseIR(C, R"IR(
 define void @foo() {
-  call void @llvm.donothing()
   unreachable
-  ret void
 }
 )IR");
   llvm::Function *LLVMF = &*M->getFunction("foo");
@@ -2051,19 +2049,17 @@ define void @foo() {
   sandboxir::Function *F = Ctx.createFunction(LLVMF);
   auto *BB = &*F->begin();
   auto It = BB->begin();
-  auto *CallInst = dyn_cast<sandboxir::CallInst>(&*It++);
   auto *UI = cast<sandboxir::UnreachableInst>(&*It++);
 
   EXPECT_EQ(UI->getNumSuccessors(), 0u);
   EXPECT_EQ(UI->getNumOfIRInstrs(), 1u);
   // Check create(InsertBefore)
   sandboxir::UnreachableInst *NewUI =
-      sandboxir::UnreachableInst::create(/*InsertBefore=*/CallInst, Ctx);
-  EXPECT_NE(NewUI, nullptr);
-  EXPECT_EQ(NewUI->getParent(), BB);
+      sandboxir::UnreachableInst::create(/*InsertBefore=*/UI, Ctx);
+  EXPECT_EQ(NewUI->getNextNode(), UI);
   // Check create(InsertAtEnd)
   sandboxir::UnreachableInst *NewUIEnd =
       sandboxir::UnreachableInst::create(/*InsertAtEnd=*/BB, Ctx);
-  EXPECT_NE(NewUIEnd, nullptr);
   EXPECT_EQ(NewUIEnd->getParent(), BB);
+  EXPECT_EQ(NewUIEnd->getNextNode(), nullptr);
 }


### PR DESCRIPTION
This patch implements the `UnreachableInst` instruction in SandboxIR. Mirroring `llvm::UnreachableInst`.

cc: @vporpo 