### PR TITLE
[llvm-locstats] Switch shebang from python to python3

### DIFF
--- a/llvm/utils/llvm-locstats/llvm-locstats.py
+++ b/llvm/utils/llvm-locstats/llvm-locstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This is a tool that works like debug location coverage calculator.
 # It parses the llvm-dwarfdump --statistics output by reporting it


### PR DESCRIPTION
Some system only provide python3 and do not alias python to python3 by default. This means that directly executing llvm-locstats.py does not work as the system cannot find the interpreter. This should be safe to bump now that the project-wide minimum Python version for LLVM is v3.8.