### PR TITLE
workflows/release-binaries-all: Pass secrets on to release-binaries workflow

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -91,4 +91,8 @@ jobs:
       release-version: "${{ needs.setup-variables.outputs.release-version }}"
       upload: ${{ needs.setup-variables.outputs.upload == 'true'}}
       runs-on: "${{ matrix.runs-on }}"
-
+    secrets:
+      # This will be empty for pull_request events, but that's fine, because
+      # the release-binaries workflow does not use this secret for the
+      # pull_request event.
+      RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -37,6 +37,11 @@ on:
         description: "Runner to use for the build"
         required: true
         type: string
+    secrets:
+      RELEASE_TASKS_USER_TOKEN:
+        description: "Secret used to check user permissions."
+        required: false
+
 
 permissions:
   contents: read # Default everything to read-only


### PR DESCRIPTION
A called workflow does not have access to secrets by default, so we need to explicitly pass any secret that we want to use.