### PR TITLE
[NFC][lld][ELF] move "initSymbolAnchors" to "lld/ELF/Writer.cpp" 

### DIFF
--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -239,7 +239,6 @@ void addArmSyntheticSectionMappingSymbol(Defined *);
 void sortArmMappingSymbols();
 void convertArmInstructionstoBE8(InputSection *sec, uint8_t *buf);
 void createTaggedSymbols(const SmallVector<ELFFileBase *, 0> &files);
-void initSymbolAnchors();
 
 LLVM_LIBRARY_VISIBILITY extern const TargetInfo *target;
 TargetInfo *getTarget();

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1415,6 +1415,59 @@ static void finalizeSynthetic(SyntheticSection *sec) {
   }
 }
 
+void elf::initSymbolAnchors() {
+  SmallVector<InputSection *, 0> storage;
+  for (OutputSection *osec : ctx.outputSections) {
+    if (!(osec->flags & SHF_EXECINSTR))
+      continue;
+    for (InputSection *sec : getInputSections(*osec, storage)) {
+      sec->relaxAux = make<RelaxAux>();
+      if (sec->relocs().size()) {
+        sec->relaxAux->relocDeltas =
+            std::make_unique<uint32_t[]>(sec->relocs().size());
+        sec->relaxAux->relocTypes =
+            std::make_unique<RelType[]>(sec->relocs().size());
+      }
+    }
+  }
+  // Store anchors (st_value and st_value+st_size) for symbols relative to text
+  // sections.
+  //
+  // For a defined symbol foo, we may have `d->file != file` with --wrap=foo.
+  // We should process foo, as the defining object file's symbol table may not
+  // contain foo after redirectSymbols changed the foo entry to __wrap_foo. To
+  // avoid adding a Defined that is undefined in one object file, use
+  // `!d->scriptDefined` to exclude symbols that are definitely not wrapped.
+  //
+  // `relaxAux->anchors` may contain duplicate symbols, but that is fine.
+  for (InputFile *file : ctx.objectFiles)
+    for (Symbol *sym : file->getSymbols()) {
+      auto *d = dyn_cast<Defined>(sym);
+      if (!d || (d->file != file && !d->scriptDefined))
+        continue;
+      if (auto *sec = dyn_cast_or_null<InputSection>(d->section))
+        if (sec->flags & SHF_EXECINSTR && sec->relaxAux) {
+          // If sec is discarded, relaxAux will be nullptr.
+          sec->relaxAux->anchors.push_back({d->value, d, false});
+          sec->relaxAux->anchors.push_back({d->value + d->size, d, true});
+        }
+    }
+  // Sort anchors by offset so that we can find the closest relocation
+  // efficiently. For a zero size symbol, ensure that its start anchor precedes
+  // its end anchor. For two symbols with anchors at the same offset, their
+  // order does not matter.
+  for (OutputSection *osec : ctx.outputSections) {
+    if (!(osec->flags & SHF_EXECINSTR))
+      continue;
+    for (InputSection *sec : getInputSections(*osec, storage)) {
+      llvm::sort(sec->relaxAux->anchors, [](auto &a, auto &b) {
+        return std::make_pair(a.offset, a.end) <
+               std::make_pair(b.offset, b.end);
+      });
+    }
+  }
+}
+
 // We need to generate and finalize the content that depends on the address of
 // InputSections. As the generation of the content may also alter InputSection
 // addresses we must converge to a fixed point. We do that here. See the comment

--- a/lld/ELF/Writer.h
+++ b/lld/ELF/Writer.h
@@ -47,6 +47,7 @@ struct PhdrEntry {
 void addReservedSymbols();
 bool includeInSymtab(const Symbol &b);
 unsigned getSectionRank(OutputSection &osec);
+void initSymbolAnchors();
 
 template <class ELFT> uint32_t calcMipsEFlags();
 


### PR DESCRIPTION
This function is a general interface, it was used in RISCV and Loong architectures for relaxation implementation. Thus, moving this function to "lld/ELF/Writer.cpp" should be more reasonable.
(#101867)