### PR TITLE
[Clang][CodeGen] Add `[[clang::asm_dialect]]` attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4730,3 +4730,10 @@ def ClspvLibclcBuiltin: InheritableAttr {
   let Documentation = [ClspvLibclcBuiltinDoc];
   let SimpleHandler = 1;
 }
+
+def AsmDialect: DeclOrStmtAttr {
+  let Spellings = [Clang<"asm_dialect">];
+  let Subjects = SubjectList<[GCCAsmStmt, Function], ErrorDiag, "'asm' inline assembly statements or functions">;
+  let Args = [EnumArgument<"Dialect", "Kind", /*is_string=*/true, ["intel", "att", "reset", ""], ["Intel", "ATT", "Global", "Local"]>];
+  let Documentation = [Undocumented];
+}

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -724,6 +724,8 @@ void CodeGenFunction::EmitAttributedStmt(const AttributedStmt &S) {
   bool noinline = false;
   bool alwaysinline = false;
   bool noconvergent = false;
+  AsmDialectAttr::Kind asmdialect = AsmDialectAttr::Kind::Local;
+
   const CallExpr *musttail = nullptr;
 
   for (const auto *A : S.getAttrs()) {
@@ -755,6 +757,9 @@ void CodeGenFunction::EmitAttributedStmt(const AttributedStmt &S) {
         Builder.CreateAssumption(AssumptionVal);
       }
     } break;
+    case attr::AsmDialect: {
+      asmdialect = cast<AsmDialectAttr>(A)->getDialect();
+    } break;
     }
   }
   SaveAndRestore save_nomerge(InNoMergeAttributedStmt, nomerge);
@@ -762,6 +767,7 @@ void CodeGenFunction::EmitAttributedStmt(const AttributedStmt &S) {
   SaveAndRestore save_alwaysinline(InAlwaysInlineAttributedStmt, alwaysinline);
   SaveAndRestore save_noconvergent(InNoConvergentAttributedStmt, noconvergent);
   SaveAndRestore save_musttail(MustTailCall, musttail);
+  SaveAndRestore save_asmdialect(AsmDialect, asmdialect);
   EmitStmt(S.getSubStmt(), S.getAttrs());
 }
 
@@ -3029,12 +3035,47 @@ void CodeGenFunction::EmitAsmStmt(const AsmStmt &S) {
 
   bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;
 
-  llvm::InlineAsm::AsmDialect GnuAsmDialect =
-      CGM.getCodeGenOpts().getInlineAsmDialect() == CodeGenOptions::IAD_ATT
-          ? llvm::InlineAsm::AD_ATT
-          : llvm::InlineAsm::AD_Intel;
-  llvm::InlineAsm::AsmDialect AsmDialect = isa<MSAsmStmt>(&S) ?
-    llvm::InlineAsm::AD_Intel : GnuAsmDialect;
+  llvm::InlineAsm::AsmDialect AsmDialect;
+  auto GlobalAsmDialect = [&] {
+    return CGM.getCodeGenOpts().getInlineAsmDialect() == CodeGenOptions::IAD_ATT
+               ? llvm::InlineAsm::AD_ATT
+               : llvm::InlineAsm::AD_Intel;
+  };
+  if (auto *GS = dyn_cast<GCCAsmStmt>(&S)) {
+    switch (this->AsmDialect) { // Fixme: rename member
+    case AsmDialectAttr::Intel:
+      AsmDialect = llvm::InlineAsm::AsmDialect::AD_Intel;
+      break;
+    case AsmDialectAttr::ATT:
+      AsmDialect = llvm::InlineAsm::AsmDialect::AD_ATT;
+      break;
+    case AsmDialectAttr::Local:
+      if (CurFuncDecl) {
+        if (auto *DialectAttr = CurFuncDecl->getAttr<AsmDialectAttr>()) {
+          switch (DialectAttr->getDialect()) {
+          case AsmDialectAttr::Intel:
+            AsmDialect = llvm::InlineAsm::AsmDialect::AD_Intel;
+            break;
+          case AsmDialectAttr::ATT:
+            AsmDialect = llvm::InlineAsm::AsmDialect::AD_ATT;
+            break;
+          case AsmDialectAttr::Global:
+          case AsmDialectAttr::Local:
+            AsmDialect = GlobalAsmDialect();
+            break;
+          }
+          break;
+        }
+      }
+      [[fallthrough]];
+    case AsmDialectAttr::Global:
+      AsmDialect = GlobalAsmDialect();
+      break;
+    }
+  } else {
+    assert(isa<MSAsmStmt>(&S));
+    AsmDialect = llvm::InlineAsm::AD_Intel;
+  }
 
   llvm::InlineAsm *IA = llvm::InlineAsm::get(
       FTy, AsmString, Constraints, HasSideEffect,

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -615,6 +615,10 @@ public:
   /// True if the current statement has noconvergent attribute.
   bool InNoConvergentAttributedStmt = false;
 
+  /// Override for the assembly dialect to use when substituting
+  /// parameters (from the [[clang::asm_dialect("kind")]] attribute)
+  AsmDialectAttr::Kind AsmDialect = AsmDialectAttr::Kind::Local;
+
   // The CallExpr within the current statement that the musttail attribute
   // applies to.  nullptr if there is no 'musttail' on the current statement.
   const CallExpr *MustTailCall = nullptr;

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -356,16 +356,14 @@ Retry:
     break;
 
   case tok::kw_asm: {
-    for (const ParsedAttr &AL : CXX11Attrs)
+    for (const ParsedAttr &AL : CXX11Attrs) {
       // Could be relaxed if asm-related regular keyword attributes are
       // added later.
-      (AL.isRegularKeywordAttribute()
-           ? Diag(AL.getRange().getBegin(), diag::err_keyword_not_allowed)
-           : Diag(AL.getRange().getBegin(), diag::warn_attribute_ignored))
-          << AL;
-    // Prevent these from being interpreted as statement attributes later on.
-    CXX11Attrs.clear();
-    ProhibitAttributes(GNUAttrs);
+      if (AL.isRegularKeywordAttribute()) {
+        Diag(AL.getRange().getBegin(), diag::err_keyword_not_allowed) << AL;
+        AL.setInvalid();
+      }
+    }
     bool msAsm = false;
     Res = ParseAsmStatement(msAsm);
     if (msAsm) return Res;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5599,6 +5599,21 @@ DLLExportAttr *Sema::mergeDLLExportAttr(Decl *D,
   return ::new (Context) DLLExportAttr(Context, CI);
 }
 
+static void handleAsmDialectAttr(Sema &S, Decl *D, const ParsedAttr &A) {
+  StringRef Name;
+  SourceLocation LiteralLoc;
+  if (!S.checkStringLiteralArgumentAttr(A, 0, Name, &LiteralLoc))
+    return;
+
+  AsmDialectAttr::Kind Kind;
+  if (Name.empty() || !AsmDialectAttr::ConvertStrToKind(Name, Kind)) {
+    S.Diag(LiteralLoc, diag::warn_attribute_type_not_supported) << A << Name;
+    return;
+  }
+
+  D->addAttr(::new (S.Context) AsmDialectAttr(S.Context, A, Kind));
+}
+
 static void handleDLLAttr(Sema &S, Decl *D, const ParsedAttr &A) {
   if (isa<ClassTemplatePartialSpecializationDecl>(D) &&
       (S.Context.getTargetInfo().shouldDLLImportComdatSymbols())) {
@@ -6416,6 +6431,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     break;
   case ParsedAttr::AT_AMDGPUMaxNumWorkGroups:
     S.AMDGPU().handleAMDGPUMaxNumWorkGroupsAttr(D, AL);
+    break;
+  case ParsedAttr::AT_AsmDialect:
+    handleAsmDialectAttr(S, D, AL);
     break;
   case ParsedAttr::AT_AVRSignal:
     S.AVR().handleSignalAttr(D, AL);

--- a/clang/test/CodeGen/inline-asm-mixed-dialect.c
+++ b/clang/test/CodeGen/inline-asm-mixed-dialect.c
@@ -1,0 +1,66 @@
+// RUN: %clang_cc1 -ffreestanding -triple i386 -fasm-blocks -O0 -S %s -o - | FileCheck %s
+// RUN: %clang_cc1 -ffreestanding -triple x86_64 -fasm-blocks -O0 -S %s -o - | FileCheck %s
+// REQUIRES: x86-registered-target
+
+void f(void) {
+  int src = 0;
+  int dst;
+  [[clang::asm_dialect("intel")]] __asm__ (
+    ".intel_syntax noprefix\n\t"
+    "# f1\n\t"
+    "mov %1, %0\n\t"
+    "add %0, 1\n\t"
+    : "=r" (dst)
+    : "r" (src)
+  );
+  // CHECK:      # f1
+  // CHECK-NEXT: movl %eax, %eax
+  // CHECK-NEXT: addl $1, %eax
+  [[clang::asm_dialect("att")]] __asm__ (
+    ".att_syntax prefix\n\t"
+    "# f2\n\t"
+    "movl %1, %0\n\t"
+    "addl $1, %0\n\t"
+    : "=r" (dst)
+    : "r" (src)
+  );
+  // CHECK:      # f2
+  // CHECK-NEXT: movl %eax, %eax
+  // CHECK-NEXT: addl $1, %eax
+}
+
+
+#pragma clang attribute push ([[clang::asm_dialect("intel")]], apply_to = function)
+void intel_fn(void) {
+  int src = 0;
+  int dst;
+  __asm__ (
+    ".intel_syntax noprefix\n\t"
+    "# intel_fn\n\t"
+    "mov %1, %0\n\t"
+    "add %0, 1\n\t"
+    : "=r" (dst)
+    : "r" (src)
+  );
+  // CHECK:      # intel_fn
+  // CHECK-NEXT: movl %eax, %eax
+  // CHECK-NEXT: addl $1, %eax
+}
+#pragma clang attribute pop
+#pragma clang attribute push ([[clang::asm_dialect("att")]], apply_to = function)
+void att_fn(void) {
+  int src = 0;
+  int dst;
+  __asm__ (
+    ".att_syntax prefix\n\t"
+    "# att_fn\n\t"
+    "movl %1, %0\n\t"
+    "addl $1, %0\n\t"
+    : "=r" (dst)
+    : "r" (src)
+  );
+  // CHECK:      # att_fn
+  // CHECK-NEXT: movl %eax, %eax
+  // CHECK-NEXT: addl $1, %eax
+}
+#pragma clang attribute pop

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -19,6 +19,7 @@
 // CHECK-NEXT: AnyX86NoCfCheck (SubjectMatchRule_hasType_functionType)
 // CHECK-NEXT: ArcWeakrefUnavailable (SubjectMatchRule_objc_interface)
 // CHECK-NEXT: ArmBuiltinAlias (SubjectMatchRule_function)
+// CHECK-NEXT: AsmDialect (SubjectMatchRule_function)
 // CHECK-NEXT: AssumeAligned (SubjectMatchRule_objc_method, SubjectMatchRule_function)
 // CHECK-NEXT: Availability ((SubjectMatchRule_record, SubjectMatchRule_enum, SubjectMatchRule_enum_constant, SubjectMatchRule_field, SubjectMatchRule_function, SubjectMatchRule_namespace, SubjectMatchRule_objc_category, SubjectMatchRule_objc_implementation, SubjectMatchRule_objc_interface, SubjectMatchRule_objc_method, SubjectMatchRule_objc_property, SubjectMatchRule_objc_protocol, SubjectMatchRule_record, SubjectMatchRule_type_alias, SubjectMatchRule_variable))
 // CHECK-NEXT: AvailableOnlyInDefaultEvalMethod (SubjectMatchRule_type_alias)

--- a/clang/test/Parser/asm.c
+++ b/clang/test/Parser/asm.c
@@ -14,7 +14,7 @@ void f2(void) {
   asm("foo" : : "r" (b)); // expected-error {{use of undeclared identifier 'b'}} 
 
   [[]] asm("");
-  [[gnu::deprecated]] asm(""); // expected-warning {{'deprecated' attribute ignored}}
+  [[gnu::deprecated]] asm(""); // expected-error {{'deprecated' attribute cannot be applied to a statement}}
 }
 
 void a(void) __asm__(""); // expected-error {{cannot use an empty string literal in 'asm'}}

--- a/clang/test/Parser/asm.cpp
+++ b/clang/test/Parser/asm.cpp
@@ -10,5 +10,5 @@ int foo6 asm ("" L"bar7"); // expected-error {{cannot use wide string literal in
 
 void f() {
   [[]] asm("");
-  [[gnu::deprecated]] asm(""); // expected-warning {{'deprecated' attribute ignored}}
+  [[gnu::deprecated]] asm(""); // expected-error {{'deprecated' attribute cannot be applied to a statement}}
 }


### PR DESCRIPTION
This attribute applies to `GCCAsmStmt` statements or functions. If a function is declared with this, it is effectively the default for all `GCCAsmStmt`s contained in the function.

Takes one string argument: `"intel"`, `"att"` or `"reset"`. If `"reset"`, the dialect used will be the one specified on the command line.

Resolves #101328