### PR TITLE
[BOLT] Fix -print-relocations option

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1485,8 +1485,6 @@ add_instruction:
   if (uint64_t Offset = getFirstInstructionOffset())
     Labels[Offset] = BC.Ctx->createNamedTempSymbol();
 
-  clearList(Relocations);
-
   if (!IsSimple) {
     clearList(Instructions);
     return createNonFatalBOLTError("");
@@ -2277,6 +2275,7 @@ Error BinaryFunction::buildCFG(MCPlusBuilder::AllocatorIdTy AllocatorId) {
   clearList(Instructions);
   clearList(OffsetToCFI);
   clearList(TakenBranches);
+  clearList(Relocations);
 
   // Update the state.
   CurrentState = State::CFG;

--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -1065,24 +1065,26 @@ MCBinaryExpr::Opcode Relocation::getComposeOpcodeFor(uint64_t Type) {
 }
 
 void Relocation::print(raw_ostream &OS) const {
+  // Relocations are not sequentially numbered so we cannot use an array
   switch (Arch) {
   default:
     OS << "RType:" << Twine::utohexstr(Type);
     break;
 
   case Triple::aarch64:
-    static const char *const AArch64RelocNames[] = {
-#define ELF_RELOC(name, value) #name,
+    switch (Type) {
+    default:
+      llvm_unreachable("illegal AArch64 relocation");
+#define ELF_RELOC(name, value)                                                 \
+  case value:                                                                  \
+    OS << #name;                                                               \
+    break;
 #include "llvm/BinaryFormat/ELFRelocs/AArch64.def"
 #undef ELF_RELOC
-    };
-    assert(Type < ArrayRef(AArch64RelocNames).size());
-    OS << AArch64RelocNames[Type];
+    }
     break;
 
   case Triple::riscv64:
-    // RISC-V relocations are not sequentially numbered so we cannot use an
-    // array
     switch (Type) {
     default:
       llvm_unreachable("illegal RISC-V relocation");
@@ -1096,13 +1098,16 @@ void Relocation::print(raw_ostream &OS) const {
     break;
 
   case Triple::x86_64:
-    static const char *const X86RelocNames[] = {
-#define ELF_RELOC(name, value) #name,
+    switch (Type) {
+    default:
+      llvm_unreachable("illegal X86-64 relocation");
+#define ELF_RELOC(name, value)                                                 \
+  case value:                                                                  \
+    OS << #name;                                                               \
+    break;
 #include "llvm/BinaryFormat/ELFRelocs/x86_64.def"
 #undef ELF_RELOC
-    };
-    assert(Type < ArrayRef(X86RelocNames).size());
-    OS << X86RelocNames[Type];
+    }
     break;
   }
   OS << ", 0x" << Twine::utohexstr(Offset);

--- a/bolt/test/X86/print-relocations.s
+++ b/bolt/test/X86/print-relocations.s
@@ -1,0 +1,23 @@
+
+# This test is to check if -print-relocations option works correctly.
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown \
+# RUN:   %s -o %t.o
+# RUN: ld.lld -q %t.o -o %t.exe -q
+# RUN: llvm-bolt %t.exe -o %t.bolt.exe -print-only=_start \
+# RUN:   -print-disasm -print-relocations | FileCheck %s
+
+# CHECK: leaq    foo(%rip), %rax # Relocs: (R: R_X86_64_REX_GOTPCRELX
+  .globl _start
+  .type _start, %function
+_start:
+  movq 0(%rip), %rax
+  .reloc .-4, R_X86_64_REX_GOTPCRELX, foo-4
+  ret
+
+  .globl foo
+  .type foo, %function
+foo:
+  nop


### PR DESCRIPTION
1. AArch64/X86 relocations are not sequentially numbered (more details on
    llvm/include/llvm/BinaryFormat/ELFRelocs/AArch64.def), so directly
    mapping the relocation type to its name can trigger a debug
    assertion `assert(Type < ArrayRef(AArch64RelocNames).size())`.
    
2. Do not clear relocation lists in BF during disassembling, so we could
    print out relocation infos with -print-disasm for debugging.