### PR TITLE
[libc] Enable floating point support for baremetal printf

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -5,9 +5,6 @@
     }
   },
   "printf": {
-    "LIBC_CONF_PRINTF_DISABLE_FLOAT": {
-      "value": true
-    },
     "LIBC_CONF_PRINTF_DISABLE_INDEX_MODE": {
       "value": true
     },


### PR DESCRIPTION
It's somewhat common for baremetal projects to use floating point so printf support is actually desirable.

fixes #100816