### PR TITLE
[MLIR][LLVM] Allow importing of nameless globals

### DIFF
--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -368,7 +368,7 @@ private:
   ModuleOp mlirModule;
   /// The LLVM module being imported.
   std::unique_ptr<llvm::Module> llvmModule;
-  /// Nameless globals
+  /// Nameless globals.
   DenseMap<llvm::GlobalVariable *, FlatSymbolRefAttr> namelessGlobals;
 
   /// A dialect interface collection used for dispatching the import to specific

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -19,7 +19,6 @@
 #include "mlir/Target/LLVMIR/Import.h"
 #include "mlir/Target/LLVMIR/LLVMImportInterface.h"
 #include "mlir/Target/LLVMIR/TypeFromLLVM.h"
-#include "llvm/IR/GlobalVariable.h"
 
 namespace llvm {
 class BasicBlock;

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -369,6 +369,8 @@ private:
   std::unique_ptr<llvm::Module> llvmModule;
   /// Nameless globals.
   DenseMap<llvm::GlobalVariable *, FlatSymbolRefAttr> namelessGlobals;
+  /// Counter used to assign a unique ID to each nameless global.
+  unsigned namelessGlobalId = 0;
 
   /// A dialect interface collection used for dispatching the import to specific
   /// dialects.

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -19,6 +19,7 @@
 #include "mlir/Target/LLVMIR/Import.h"
 #include "mlir/Target/LLVMIR/LLVMImportInterface.h"
 #include "mlir/Target/LLVMIR/TypeFromLLVM.h"
+#include "llvm/IR/GlobalVariable.h"
 
 namespace llvm {
 class BasicBlock;
@@ -367,6 +368,8 @@ private:
   ModuleOp mlirModule;
   /// The LLVM module being imported.
   std::unique_ptr<llvm::Module> llvmModule;
+  /// Nameless globals
+  DenseMap<llvm::GlobalVariable *, FlatSymbolRefAttr> namelessGlobals;
 
   /// A dialect interface collection used for dispatching the import to specific
   /// dialects.

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -891,7 +891,7 @@ LogicalResult ModuleImport::convertGlobal(llvm::GlobalVariable *globalVar) {
         debugImporter->translateGlobalVariableExpression(globalExpressions[0]);
 
   std::string globalName = globalVar->getName().str();
-  if (globalName == "") {
+  if (globalName.empty()) {
     globalName = getNamelessGlobalPrefix().str() +
                  std::to_string(namelessGlobals.size());
     namelessGlobals[globalVar] = FlatSymbolRefAttr::get(context, globalName);

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1075,7 +1075,7 @@ FailureOr<Value> ModuleImport::convertConstant(llvm::Constant *constant) {
     Type type = convertType(globalVar->getType());
     StringRef globalName = globalVar->getName();
     FlatSymbolRefAttr symbolRef;
-    if (globalName == "")
+    if (globalName.empty())
       symbolRef = namelessGlobals[globalVar];
     else
       symbolRef = FlatSymbolRefAttr::get(context, globalName);

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -894,8 +894,11 @@ LogicalResult ModuleImport::convertGlobal(llvm::GlobalVariable *globalVar) {
   // always requires a symbol name.
   std::string globalName = globalVar->getName().str();
   if (globalName.empty()) {
-    globalName = getNamelessGlobalPrefix().str() +
-                 std::to_string(namelessGlobals.size());
+    // Make sure the symbol name does not clash with an existing symbol.
+    do {
+      globalName =
+          getNamelessGlobalPrefix().str() + std::to_string(namelessGlobalId++);
+    } while (llvmModule->getNamedValue(globalName));
     namelessGlobals[globalVar] = FlatSymbolRefAttr::get(context, globalName);
   }
   GlobalOp globalOp = builder.create<GlobalOp>(

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -890,6 +890,8 @@ LogicalResult ModuleImport::convertGlobal(llvm::GlobalVariable *globalVar) {
     globalExpressionAttr =
         debugImporter->translateGlobalVariableExpression(globalExpressions[0]);
 
+  // Workaround to support LLVM's nameless globals. MLIR, in contrast to LLVM,
+  // always requires a symbol name.
   std::string globalName = globalVar->getName().str();
   if (globalName.empty()) {
     globalName = getNamelessGlobalPrefix().str() +
@@ -898,7 +900,7 @@ LogicalResult ModuleImport::convertGlobal(llvm::GlobalVariable *globalVar) {
   }
   GlobalOp globalOp = builder.create<GlobalOp>(
       mlirModule.getLoc(), type, globalVar->isConstant(),
-      convertLinkageFromLLVM(globalVar->getLinkage()), globalName.c_str(),
+      convertLinkageFromLLVM(globalVar->getLinkage()), StringRef(globalName),
       valueAttr, alignment, /*addr_space=*/globalVar->getAddressSpace(),
       /*dso_local=*/globalVar->isDSOLocal(),
       /*thread_local=*/globalVar->isThreadLocal(), /*comdat=*/SymbolRefAttr(),

--- a/mlir/test/Target/LLVMIR/Import/global-variables.ll
+++ b/mlir/test/Target/LLVMIR/Import/global-variables.ll
@@ -280,7 +280,20 @@ define void @bar() {
 ; CHECK-DAG: #[[GLOBAL_VAR:.*]] = #llvm.di_global_variable<file = #[[FILE]], line = 268, type = #[[COMPOSITE_TYPE]], isLocalToUnit = true, isDefined = true>
 ; CHECK-DAG: #[[GLOBAL_VAR_EXPR:.*]] = #llvm.di_global_variable_expression<var = #[[GLOBAL_VAR]], expr = <>>
 
-; CHECK-DAG: llvm.mlir.global external constant @".str.1"() {addr_space = 0 : i32, dbg_expr = #[[GLOBAL_VAR_EXPR]]}
+; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.0("0\00") {addr_space = 0 : i32, dso_local}
+; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.1("1\00") {addr_space = 0 : i32, dso_local}
+;
+; CHECK:  llvm.mlir.global internal constant @zero() {addr_space = 0 : i32, dso_local} : !llvm.ptr {
+; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global.0 : !llvm.ptr
+; CHECK:  llvm.mlir.global internal constant @one() {addr_space = 0 : i32, dso_local} : !llvm.ptr {
+; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global.1 : !llvm.ptr
+
+; CHECK: llvm.mlir.global external constant @".str.1"() {addr_space = 0 : i32, dbg_expr = #[[GLOBAL_VAR_EXPR]]}
+
+@0 = private unnamed_addr constant [2 x i8] c"0\00"
+@1 = private unnamed_addr constant [2 x i8] c"1\00"
+@zero = internal constant ptr @0
+@one = internal constant ptr @1
 
 @.str.1 = external constant [10 x i8], !dbg !0
 

--- a/mlir/test/Target/LLVMIR/Import/global-variables.ll
+++ b/mlir/test/Target/LLVMIR/Import/global-variables.ll
@@ -280,14 +280,14 @@ define void @bar() {
 ; CHECK-DAG: #[[GLOBAL_VAR:.*]] = #llvm.di_global_variable<file = #[[FILE]], line = 268, type = #[[COMPOSITE_TYPE]], isLocalToUnit = true, isDefined = true>
 ; CHECK-DAG: #[[GLOBAL_VAR_EXPR:.*]] = #llvm.di_global_variable_expression<var = #[[GLOBAL_VAR]], expr = <>>
 
-; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.0("0\00")
+; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0("0\00")
 ; We skip over @mlir.llvm.nameless_global.1 and 2 because they exist
-; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.3("1\00")
+; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_3("1\00")
 ;
 ; CHECK:  llvm.mlir.global internal constant @zero() {addr_space = 0 : i32, dso_local} : !llvm.ptr {
-; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global.0 : !llvm.ptr
+; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
 ; CHECK:  llvm.mlir.global internal constant @one() {addr_space = 0 : i32, dso_local} : !llvm.ptr {
-; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global.3 : !llvm.ptr
+; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global_3 : !llvm.ptr
 
 ; CHECK: llvm.mlir.global external constant @".str.1"() {addr_space = 0 : i32, dbg_expr = #[[GLOBAL_VAR_EXPR]]}
 
@@ -296,8 +296,8 @@ define void @bar() {
 @zero = internal constant ptr @0
 @one = internal constant ptr @1
 
-@"mlir.llvm.nameless_global.1" = external constant [10 x i8], !dbg !0
-declare void @"mlir.llvm.nameless_global.2"()
+@"mlir.llvm.nameless_global_1" = external constant [10 x i8], !dbg !0
+declare void @"mlir.llvm.nameless_global_2"()
 
 @.str.1 = external constant [10 x i8], !dbg !0
 

--- a/mlir/test/Target/LLVMIR/Import/global-variables.ll
+++ b/mlir/test/Target/LLVMIR/Import/global-variables.ll
@@ -280,7 +280,7 @@ define void @bar() {
 ; CHECK-DAG: #[[GLOBAL_VAR:.*]] = #llvm.di_global_variable<file = #[[FILE]], line = 268, type = #[[COMPOSITE_TYPE]], isLocalToUnit = true, isDefined = true>
 ; CHECK-DAG: #[[GLOBAL_VAR_EXPR:.*]] = #llvm.di_global_variable_expression<var = #[[GLOBAL_VAR]], expr = <>>
 
-; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.0("0\00") {addr_space = 0 : i32, dso_local}
+; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.0("0\00")
 ; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.1("1\00") {addr_space = 0 : i32, dso_local}
 ;
 ; CHECK:  llvm.mlir.global internal constant @zero() {addr_space = 0 : i32, dso_local} : !llvm.ptr {

--- a/mlir/test/Target/LLVMIR/Import/global-variables.ll
+++ b/mlir/test/Target/LLVMIR/Import/global-variables.ll
@@ -281,12 +281,13 @@ define void @bar() {
 ; CHECK-DAG: #[[GLOBAL_VAR_EXPR:.*]] = #llvm.di_global_variable_expression<var = #[[GLOBAL_VAR]], expr = <>>
 
 ; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.0("0\00")
-; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.1("1\00") {addr_space = 0 : i32, dso_local}
+; We skip over @mlir.llvm.nameless_global.1 and 2 because they exist
+; CHECK:  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global.3("1\00")
 ;
 ; CHECK:  llvm.mlir.global internal constant @zero() {addr_space = 0 : i32, dso_local} : !llvm.ptr {
 ; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global.0 : !llvm.ptr
 ; CHECK:  llvm.mlir.global internal constant @one() {addr_space = 0 : i32, dso_local} : !llvm.ptr {
-; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global.1 : !llvm.ptr
+; CHECK:    llvm.mlir.addressof @mlir.llvm.nameless_global.3 : !llvm.ptr
 
 ; CHECK: llvm.mlir.global external constant @".str.1"() {addr_space = 0 : i32, dbg_expr = #[[GLOBAL_VAR_EXPR]]}
 
@@ -294,6 +295,9 @@ define void @bar() {
 @1 = private unnamed_addr constant [2 x i8] c"1\00"
 @zero = internal constant ptr @0
 @one = internal constant ptr @1
+
+@"mlir.llvm.nameless_global.1" = external constant [10 x i8], !dbg !0
+declare void @"mlir.llvm.nameless_global.2"()
 
 @.str.1 = external constant [10 x i8], !dbg !0
 


### PR DESCRIPTION
LLVM allows nameless globals for private global variables whereas in MLIR globals must be addressed using symbols. We attach symbols to nameless globals in order to enable their import.