### PR TITLE
[libc] [gpu] Change Time To Be Per Iteration

### DIFF
--- a/libc/benchmarks/gpu/LibcGpuBenchmark.cpp
+++ b/libc/benchmarks/gpu/LibcGpuBenchmark.cpp
@@ -115,7 +115,7 @@ void print_results(Benchmark *b) {
   cpp::atomic_thread_fence(cpp::MemoryOrder::RELEASE);
 
   LIBC_NAMESPACE::printf(
-      "%-20s |%8ld |%8ld |%8ld |%11d |%9ld %2s |%9ld |%9d |\n",
+      "%-20s |%8ld |%8ld |%8ld |%11d |%14ld %2s |%9ld |%9d |\n",
       b->get_test_name().data(), result.cycles, result.min, result.max,
       result.total_iterations, result.total_time, time_unit,
       static_cast<uint64_t>(result.standard_deviation), num_threads);
@@ -126,9 +126,9 @@ void print_header() {
   LIBC_NAMESPACE::printf("Running Suite: %-10s\n",
                          benchmarks[0]->get_suite_name().data());
   LIBC_NAMESPACE::printf("%s", RESET);
-  LIBC_NAMESPACE::printf("Benchmark            |  Cycles |     Min |     Max | "
-                         "Iterations |        "
-                         "Time |   Stddev |  Threads |\n");
+  LIBC_NAMESPACE::printf(
+      "Benchmark            |  Cycles |     Min |     Max | "
+      "Iterations | Time / Iteration |   Stddev |  Threads |\n");
   LIBC_NAMESPACE::printf(
       "---------------------------------------------------------------------"
       "--------------------------------\n");
@@ -222,7 +222,7 @@ BenchmarkResult benchmark(const BenchmarkOptions &options,
   result.max = max;
   result.samples = samples;
   result.total_iterations = total_iterations;
-  result.total_time = total_time;
+  result.total_time = total_time / total_iterations;
   return result;
 };
 


### PR DESCRIPTION
Previously, the time field was the total time take to run all iterations of the benchmark. This PR changes the value displayed to be the average time take by each iteration. 