### PR TITLE
[AIX]export function descriptor symbols related to template functions.

### DIFF
--- a/llvm/utils/extract_symbols.py
+++ b/llvm/utils/extract_symbols.py
@@ -485,7 +485,7 @@ if __name__ == "__main__":
     for k, v in list(symbol_defs.items()):
         # On AIX, export function descriptors instead of function entries.
         if platform.system() == "AIX" and k.startswith("."):
-          continue
+            continue
         template = get_template_name(k, args.mangling)
         if v == 1 and (not template or template in template_instantiation_refs):
             print(k, file=outfile)

--- a/llvm/utils/extract_symbols.py
+++ b/llvm/utils/extract_symbols.py
@@ -484,5 +484,9 @@ if __name__ == "__main__":
         outfile = sys.stdout
     for k, v in list(symbol_defs.items()):
         template = get_template_name(k, args.mangling)
+        # On AIX, "template" functions starting with "_" are actually function
+        # descriptors which are data symbols. Export these data symbols.
+        if template and platform.system() == "AIX" and k.startswith("_"):
+            template = None
         if v == 1 and (not template or template in template_instantiation_refs):
             print(k, file=outfile)

--- a/llvm/utils/extract_symbols.py
+++ b/llvm/utils/extract_symbols.py
@@ -140,7 +140,7 @@ def should_keep_itanium_symbol(symbol, calling_convention_decoration):
     if not symbol.startswith("_") and not symbol.startswith("."):
         return symbol
     # Discard manglings that aren't nested names
-    match = re.match("_Z(T[VTIS])?(N.+)", symbol)
+    match = re.match("\.?_Z(T[VTIS])?(N.+)", symbol)
     if not match:
         return None
     # Demangle the name. If the name is too complex then we don't need to keep
@@ -323,7 +323,7 @@ def get_template_name(sym, mangling):
         if mangling == "microsoft":
             names = parse_microsoft_mangling(sym)
         else:
-            match = re.match("_Z(T[VTIS])?(N.+)", sym)
+            match = re.match("\.?_Z(T[VTIS])?(N.+)", sym)
             if match:
                 names, _ = parse_itanium_nested_name(match.group(2))
             else:
@@ -483,10 +483,9 @@ if __name__ == "__main__":
     else:
         outfile = sys.stdout
     for k, v in list(symbol_defs.items()):
+        # On AIX, export function descriptors instead of function entries.
+        if platform.system() == "AIX" and k.startswith("."):
+          continue
         template = get_template_name(k, args.mangling)
-        # On AIX, "template" functions starting with "_" are actually function
-        # descriptors which are data symbols. Export these data symbols.
-        if template and platform.system() == "AIX" and k.startswith("_"):
-            template = None
         if v == 1 and (not template or template in template_instantiation_refs):
             print(k, file=outfile)


### PR DESCRIPTION
This fixes regressions caused by https://github.com/llvm/llvm-project/pull/97526

After that patch, all undefined references to DS symbol are removed. This makes DS symbols(for template functions) have no reference in some cases. So extract_symbols.py does not export these DS symbols for these cases.

On AIX, exporting the function descriptor depends on references to the function descriptor itself and the function entry symbol.

Without this fix, on AIX, we get:
```
rtld: 0712-001 Symbol _ZN4llvm15SmallVectorBaseIjE13mallocForGrowEPvmmRm was referenced
      from module llvm-project/build/unittests/Passes/Plugins/TestPlugin.so(), but a runtime definition
            of the symbol was not found. 
```