### PR TITLE
[LV] Fix emission of debug message in legality check

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -1521,12 +1521,21 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
       return false;
   }
 
-
   unsigned SCEVThreshold = VectorizeSCEVCheckThreshold;
   if (Hints->getForce() == LoopVectorizeHints::FK_Enabled)
     SCEVThreshold = PragmaVectorizeSCEVCheckThreshold;
 
+  if (Result) {
+    LLVM_DEBUG(dbgs() << "LV: We can vectorize this loop"
+                      << (LAI->getRuntimePointerChecking()->Need
+                              ? " (with a runtime bound check)"
+                              : "")
+                      << "!\n");
+  }
+
   if (PSE.getPredicate().getComplexity() > SCEVThreshold) {
+    LLVM_DEBUG(dbgs() << "LV: Vectorization not profitable "
+                         "due to SCEVThreshold");
     reportVectorizationFailure("Too many SCEV checks needed",
         "Too many SCEV assumptions need to be made and checked at runtime",
         "TooManySCEVRunTimeChecks", ORE, TheLoop);
@@ -1534,13 +1543,6 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
       Result = false;
     else
       return false;
-  }
-  if (Result) {
-    LLVM_DEBUG(dbgs() << "LV: We can vectorize this loop"
-                      << (LAI->getRuntimePointerChecking()->Need
-                              ? " (with a runtime bound check)"
-                              : "")
-                      << "!\n");
   }
 
   // Okay! We've done all the tests. If any have failed, return false. Otherwise

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -1452,7 +1452,7 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
   // vectorizer.
   if (!canVectorizeLoopNestCFG(TheLoop, UseVPlanNativePath)) {
     if (DoExtraAnalysis) {
-      LLVM_DEBUG(dbgs() << "LV legality check failed: loop nest");
+      LLVM_DEBUG(dbgs() << "LV: legality check failed: loop nest");
       Result = false;
     } else {
       return false;

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -1521,10 +1521,6 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
       return false;
   }
 
-  unsigned SCEVThreshold = VectorizeSCEVCheckThreshold;
-  if (Hints->getForce() == LoopVectorizeHints::FK_Enabled)
-    SCEVThreshold = PragmaVectorizeSCEVCheckThreshold;
-
   if (Result) {
     LLVM_DEBUG(dbgs() << "LV: We can vectorize this loop"
                       << (LAI->getRuntimePointerChecking()->Need
@@ -1532,6 +1528,10 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
                               : "")
                       << "!\n");
   }
+
+  unsigned SCEVThreshold = VectorizeSCEVCheckThreshold;
+  if (Hints->getForce() == LoopVectorizeHints::FK_Enabled)
+    SCEVThreshold = PragmaVectorizeSCEVCheckThreshold;
 
   if (PSE.getPredicate().getComplexity() > SCEVThreshold) {
     LLVM_DEBUG(dbgs() << "LV: Vectorization not profitable "

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -1451,10 +1451,12 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
   // Check whether the loop-related control flow in the loop nest is expected by
   // vectorizer.
   if (!canVectorizeLoopNestCFG(TheLoop, UseVPlanNativePath)) {
-    if (DoExtraAnalysis)
+    if (DoExtraAnalysis) {
+      LLVM_DEBUG(dbgs() << "LV legality check failed: loop nest");
       Result = false;
-    else
+    } else {
       return false;
+    }
   }
 
   // We need to have a loop header.
@@ -1519,11 +1521,6 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
       return false;
   }
 
-  LLVM_DEBUG(dbgs() << "LV: We can vectorize this loop"
-                    << (LAI->getRuntimePointerChecking()->Need
-                            ? " (with a runtime bound check)"
-                            : "")
-                    << "!\n");
 
   unsigned SCEVThreshold = VectorizeSCEVCheckThreshold;
   if (Hints->getForce() == LoopVectorizeHints::FK_Enabled)
@@ -1537,6 +1534,13 @@ bool LoopVectorizationLegality::canVectorize(bool UseVPlanNativePath) {
       Result = false;
     else
       return false;
+  }
+  if (Result) {
+    LLVM_DEBUG(dbgs() << "LV: We can vectorize this loop"
+                      << (LAI->getRuntimePointerChecking()->Need
+                              ? " (with a runtime bound check)"
+                              : "")
+                      << "!\n");
   }
 
   // Okay! We've done all the tests. If any have failed, return false. Otherwise

--- a/llvm/test/Transforms/LoopVectorize/check-no-vectorize.ll
+++ b/llvm/test/Transforms/LoopVectorize/check-no-vectorize.ll
@@ -1,0 +1,36 @@
+; This test asserts that we don't emit both
+; successful and unsuccessful message about vectorization.
+
+; RUN: opt -passes=loop-vectorize -debug -disable-output -pass-remarks-missed=loop-vectorize %s 2>&1 | FileCheck %s
+; CHECK-NOT: LV: We can vectorize this loop
+; CHECK: LV: Not vectorizing: Cannot prove legality
+
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+@a = dso_local global [32000 x i32] zeroinitializer, align 4
+@b = dso_local global [32000 x i32] zeroinitializer, align 4
+
+define dso_local void @foo() local_unnamed_addr {
+entry:
+  %.pre = load i32, ptr getelementptr inbounds (i8, ptr @a, i64 4), align 4
+  %.pre17 = load i32, ptr @a, align 4
+  br label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret void
+
+for.body:                                         ; preds = %entry, %for.body
+  %0 = phi i32 [ %.pre17, %entry ], [ %add6, %for.body ]
+  %1 = phi i32 [ %.pre, %entry ], [ %2, %for.body ]
+  %indvars.iv = phi i64 [ 1, %entry ], [ %indvars.iv.next, %for.body ]
+  %arrayidx = getelementptr inbounds [32000 x i32], ptr @a, i64 0, i64 %indvars.iv
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %arrayidx2 = getelementptr inbounds [32000 x i32], ptr @a, i64 0, i64 %indvars.iv.next
+  %2 = load i32, ptr %arrayidx2, align 4
+  %add3 = add nsw i32 %2, %1
+  %add6 = add nsw i32 %add3, %0
+  store i32 %add6, ptr %arrayidx, align 4
+  %exitcond.not = icmp eq i64 %indvars.iv.next, 31999
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+}

--- a/llvm/test/Transforms/LoopVectorize/check-no-vectorize.ll
+++ b/llvm/test/Transforms/LoopVectorize/check-no-vectorize.ll
@@ -4,14 +4,14 @@
 ; RUN: opt -passes=loop-vectorize -debug -disable-output -pass-remarks-missed=loop-vectorize %s 2>&1 | FileCheck %s
 ; CHECK-NOT: LV: We can vectorize this loop
 ; CHECK: LV: Not vectorizing: Cannot prove legality
+; CHECK-NOT: LV: We can vectorize this loop
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
-target triple = "aarch64-unknown-linux-gnu"
 
-@a = dso_local global [32000 x i32] zeroinitializer, align 4
-@b = dso_local global [32000 x i32] zeroinitializer, align 4
+@a = global [32000 x i32] zeroinitializer, align 4
+@b = global [32000 x i32] zeroinitializer, align 4
 
-define dso_local void @foo() local_unnamed_addr {
+define void @foo() {
 entry:
   %.pre = load i32, ptr getelementptr inbounds (i8, ptr @a, i64 4), align 4
   %.pre17 = load i32, ptr @a, align 4

--- a/llvm/test/Transforms/LoopVectorize/check-no-vectorize.ll
+++ b/llvm/test/Transforms/LoopVectorize/check-no-vectorize.ll
@@ -1,36 +1,32 @@
-; This test asserts that we don't emit both
+; This test checks that we don't emit both
 ; successful and unsuccessful message about vectorization.
 
-; RUN: opt -passes=loop-vectorize -debug -disable-output -pass-remarks-missed=loop-vectorize %s 2>&1 | FileCheck %s
+; REQUIRES: asserts
+; RUN: opt -passes=loop-vectorize -debug -disable-output < %s 2>&1 | FileCheck %s
 ; CHECK-NOT: LV: We can vectorize this loop
 ; CHECK: LV: Not vectorizing: Cannot prove legality
 ; CHECK-NOT: LV: We can vectorize this loop
 
-target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
-
 @a = global [32000 x i32] zeroinitializer, align 4
-@b = global [32000 x i32] zeroinitializer, align 4
 
-define void @foo() {
+define void @foo(i32 %val1, i32 %val2) {
 entry:
-  %.pre = load i32, ptr getelementptr inbounds (i8, ptr @a, i64 4), align 4
-  %.pre17 = load i32, ptr @a, align 4
   br label %for.body
 
-for.cond.cleanup:                                 ; preds = %for.body
-  ret void
-
 for.body:                                         ; preds = %entry, %for.body
-  %0 = phi i32 [ %.pre17, %entry ], [ %add6, %for.body ]
-  %1 = phi i32 [ %.pre, %entry ], [ %2, %for.body ]
-  %indvars.iv = phi i64 [ 1, %entry ], [ %indvars.iv.next, %for.body ]
-  %arrayidx = getelementptr inbounds [32000 x i32], ptr @a, i64 0, i64 %indvars.iv
-  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
-  %arrayidx2 = getelementptr inbounds [32000 x i32], ptr @a, i64 0, i64 %indvars.iv.next
+  %0 = phi i32 [ %val1, %entry ], [ %add1, %for.body ]
+  %1 = phi i32 [ %val2, %entry ], [ %2, %for.body ]
+  %iv = phi i64 [ 1, %entry ], [ %iv.next, %for.body ]
+  %arrayidx = getelementptr inbounds [32000 x i32], ptr @a, i64 0, i64 %iv
+  %iv.next = add nuw nsw i64 %iv, 1
+  %arrayidx2 = getelementptr inbounds [32000 x i32], ptr @a, i64 0, i64 %iv.next
   %2 = load i32, ptr %arrayidx2, align 4
-  %add3 = add nsw i32 %2, %1
-  %add6 = add nsw i32 %add3, %0
-  store i32 %add6, ptr %arrayidx, align 4
-  %exitcond.not = icmp eq i64 %indvars.iv.next, 31999
-  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+  %add0 = add nsw i32 %2, %1
+  %add1 = add nsw i32 %add0, %0
+  store i32 %add1, ptr %arrayidx, align 4
+  %exitcond = icmp eq i64 %iv.next, 31999
+  br i1 %exitcond, label %exit, label %for.body
+
+exit:                                 ; preds = %for.body
+  ret void
 }


### PR DESCRIPTION
Successful vectorization message is emitted even
after "Result" is false.  "Result" = false indicates failure of one of the legality check and thus
successful message should not be printed.