### PR TITLE
AMDGPU: Add some leaf intrinsics to isAlwaysUniform

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSearchableTables.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSearchableTables.td
@@ -381,3 +381,7 @@ def : AlwaysUniform<int_amdgcn_if_break>;
 def : AlwaysUniform<int_amdgcn_workgroup_id_x>;
 def : AlwaysUniform<int_amdgcn_workgroup_id_y>;
 def : AlwaysUniform<int_amdgcn_workgroup_id_z>;
+def : AlwaysUniform<int_amdgcn_s_getpc>;
+def : AlwaysUniform<int_amdgcn_s_getreg>;
+def : AlwaysUniform<int_amdgcn_s_memrealtime>;
+def : AlwaysUniform<int_amdgcn_s_memtime>;

--- a/llvm/test/Analysis/UniformityAnalysis/AMDGPU/always_uniform.ll
+++ b/llvm/test/Analysis/UniformityAnalysis/AMDGPU/always_uniform.ll
@@ -103,6 +103,39 @@ define void @workgroup_id_z(ptr addrspace(1) inreg %out) {
   ret void
 }
 
+; CHECK-LABEL: for function 's_getpc':
+; CHECK: ALL VALUES UNIFORM
+define void @s_getpc(ptr addrspace(1) inreg %out) {
+  %result = call i64 @llvm.amdgcn.s.getpc()
+  store i64 %result, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; CHECK-LABEL: for function 's_getreg':
+; CHECK: ALL VALUES UNIFORM
+define void @s_getreg(ptr addrspace(1) inreg %out) {
+  %result = call i32 @llvm.amdgcn.s.getreg(i32 123)
+  store i32 %result, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+; CHECK-LABEL: for function 's_memtime':
+; CHECK: ALL VALUES UNIFORM
+define void @s_memtime(ptr addrspace(1) inreg %out) {
+  %result = call i64 @llvm.amdgcn.s.memtime()
+  store i64 %result, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; CHECK-LABEL: for function 's_memrealtime':
+; CHECK: ALL VALUES UNIFORM
+define void @s_memrealtime(ptr addrspace(1) inreg %out) {
+  %result = call i64 @llvm.amdgcn.s.memrealtime()
+  store i64 %result, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+
 declare i32 @llvm.amdgcn.workitem.id.x() #0
 declare i32 @llvm.amdgcn.readfirstlane(i32) #0
 declare i64 @llvm.amdgcn.icmp.i32(i32, i32, i32) #1


### PR DESCRIPTION
These would always be uniform anyway, but it shouldn't hurt to
mark them as always uniform. This will help use TTI::isAlwaysUniform
in place of proper uniformity analysis in trivial situations.