### PR TITLE
[lldb/API] Fix SBStructuredData support any JSON type

### DIFF
--- a/lldb/source/API/SBStructuredData.cpp
+++ b/lldb/source/API/SBStructuredData.cpp
@@ -86,7 +86,12 @@ lldb::SBError SBStructuredData::SetFromJSON(lldb::SBStream &stream) {
       StructuredData::ParseJSON(stream.GetData());
   m_impl_up->SetObjectSP(json_obj);
 
-  if (!json_obj || json_obj->GetType() != eStructuredDataTypeDictionary)
+  static constexpr StructuredDataType unsupported_type[] = {
+      eStructuredDataTypeInvalid,
+      eStructuredDataTypeGeneric,
+  };
+
+  if (!json_obj || llvm::is_contained(unsupported_type, json_obj->GetType()))
     error.SetErrorString("Invalid Syntax");
   return error;
 }

--- a/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
+++ b/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
@@ -110,6 +110,37 @@ class TestStructuredDataAPI(TestBase):
         self.assertTrue(my_random_class)
         self.assertEqual(my_random_class.payload, MyRandomClass.payload)
 
+        example = lldb.SBStructuredData()
+        self.assertSuccess(example.SetFromJSON("1"))
+        self.assertEqual(example.GetType(), lldb.eStructuredDataTypeInteger)
+        self.assertEqual(example.GetIntegerValue(), 1)
+
+        self.assertSuccess(example.SetFromJSON("4.19"))
+        self.assertEqual(example.GetType(), lldb.eStructuredDataTypeFloat)
+        self.assertEqual(example.GetFloatValue(), 4.19)
+
+        self.assertSuccess(example.SetFromJSON('"Bonjour, 123!"'))
+        self.assertEqual(example.GetType(), lldb.eStructuredDataTypeString)
+        self.assertEqual(example.GetStringValue(42), "Bonjour, 123!")
+
+        self.assertSuccess(example.SetFromJSON("true"))
+        self.assertEqual(example.GetType(), lldb.eStructuredDataTypeBoolean)
+        self.assertTrue(example.GetBooleanValue())
+
+        self.assertSuccess(example.SetFromJSON("null"))
+        self.assertEqual(example.GetType(), lldb.eStructuredDataTypeNull)
+
+        example_arr = [1, 2.3, "4", {"5": False}]
+        arr_str = json.dumps(example_arr)
+        s.Clear()
+        s.Print(arr_str)
+        self.assertSuccess(example.SetFromJSON(s))
+
+        s.Clear()
+        self.assertSuccess(example.GetAsJSON(s))
+        sb_data = json.loads(s.GetData())
+        self.assertEqual(sb_data, example_arr)
+
     def invalid_struct_test(self, example):
         invalid_struct = lldb.SBStructuredData()
         invalid_struct = example.GetValueForKey("invalid_key")


### PR DESCRIPTION
This patch loosen the parsing requirement to allow parsing not only
JSON dictionaries but also valid JSON type (integer, float, string,
bool, array, null).

Signed-off-by: Med Ismail Bennani <ismail@bennani.ma>
