### PR TITLE
[lldb/Target] Rename ThreadPlanPython into ScriptedThreadPlan

### DIFF
--- a/lldb/include/lldb/Target/ScriptedThreadPlan.h
+++ b/lldb/include/lldb/Target/ScriptedThreadPlan.h
@@ -1,5 +1,4 @@
-//===-- ThreadPlanPython.h --------------------------------------------*- C++
-//-*-===//
+//===-- ScriptedThreadPlan.h ------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_TARGET_THREADPLANPYTHON_H
-#define LLDB_TARGET_THREADPLANPYTHON_H
+#ifndef LLDB_TARGET_SCRIPTEDTHREADPLAN_H
+#define LLDB_TARGET_SCRIPTEDTHREADPLAN_H
 
 #include <string>
 
@@ -27,13 +26,10 @@
 
 namespace lldb_private {
 
-//  ThreadPlanPython:
-//
-
-class ThreadPlanPython : public ThreadPlan {
+class ScriptedThreadPlan : public ThreadPlan {
 public:
-  ThreadPlanPython(Thread &thread, const char *class_name,
-                   const StructuredDataImpl &args_data);
+  ScriptedThreadPlan(Thread &thread, const char *class_name,
+                     const StructuredDataImpl &args_data);
 
   void GetDescription(Stream *s, lldb::DescriptionLevel level) override;
 
@@ -52,15 +48,14 @@ public:
   void DidPush() override;
 
   bool IsPlanStale() override;
-  
-  bool DoWillResume(lldb::StateType resume_state, bool current_plan) override;
 
+  bool DoWillResume(lldb::StateType resume_state, bool current_plan) override;
 
 protected:
   bool DoPlanExplainsStop(Event *event_ptr) override;
 
   lldb::StateType GetPlanRunState() override;
-  
+
   ScriptInterpreter *GetScriptInterpreter();
 
 private:
@@ -73,10 +68,10 @@ private:
   bool m_stop_others;
   lldb::ScriptedThreadPlanInterfaceSP m_interface;
 
-  ThreadPlanPython(const ThreadPlanPython &) = delete;
-  const ThreadPlanPython &operator=(const ThreadPlanPython &) = delete;
+  ScriptedThreadPlan(const ScriptedThreadPlan &) = delete;
+  const ScriptedThreadPlan &operator=(const ScriptedThreadPlan &) = delete;
 };
 
 } // namespace lldb_private
 
-#endif // LLDB_TARGET_THREADPLANPYTHON_H
+#endif // LLDB_TARGET_SCRIPTEDTHREADPLAN_H

--- a/lldb/source/API/SBThreadPlan.cpp
+++ b/lldb/source/API/SBThreadPlan.cpp
@@ -21,12 +21,12 @@
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Queue.h"
+#include "lldb/Target/ScriptedThreadPlan.h"
 #include "lldb/Target/StopInfo.h"
 #include "lldb/Target/SystemRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Target/ThreadPlan.h"
-#include "lldb/Target/ThreadPlanPython.h"
 #include "lldb/Target/ThreadPlanStepInRange.h"
 #include "lldb/Target/ThreadPlanStepInstruction.h"
 #include "lldb/Target/ThreadPlanStepOut.h"
@@ -66,8 +66,8 @@ SBThreadPlan::SBThreadPlan(lldb::SBThread &sb_thread, const char *class_name) {
 
   Thread *thread = sb_thread.get();
   if (thread)
-    m_opaque_wp = std::make_shared<ThreadPlanPython>(*thread, class_name,
-                                                     StructuredDataImpl());
+    m_opaque_wp = std::make_shared<ScriptedThreadPlan>(*thread, class_name,
+                                                       StructuredDataImpl());
 }
 
 SBThreadPlan::SBThreadPlan(lldb::SBThread &sb_thread, const char *class_name,
@@ -76,8 +76,8 @@ SBThreadPlan::SBThreadPlan(lldb::SBThread &sb_thread, const char *class_name,
 
   Thread *thread = sb_thread.get();
   if (thread)
-    m_opaque_wp = std::make_shared<ThreadPlanPython>(*thread, class_name,
-                                                     *args_data.m_impl_up);
+    m_opaque_wp = std::make_shared<ScriptedThreadPlan>(*thread, class_name,
+                                                       *args_data.m_impl_up);
 }
 
 // Assignment operator

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -36,6 +36,7 @@ add_lldb_library(lldbTarget
   RegisterFlags.cpp
   RegisterNumber.cpp
   RemoteAwarePlatform.cpp
+  ScriptedThreadPlan.cpp
   SectionLoadHistory.cpp
   SectionLoadList.cpp
   StackFrame.cpp
@@ -57,7 +58,6 @@ add_lldb_library(lldbTarget
   ThreadPlanCallFunctionUsingABI.cpp
   ThreadPlanCallOnFunctionExit.cpp
   ThreadPlanCallUserExpression.cpp
-  ThreadPlanPython.cpp
   ThreadPlanRunToAddress.cpp
   ThreadPlanShouldStopHere.cpp
   ThreadPlanStepInRange.cpp

--- a/lldb/source/Target/ScriptedThreadPlan.cpp
+++ b/lldb/source/Target/ScriptedThreadPlan.cpp
@@ -1,4 +1,4 @@
-//===-- ThreadPlanPython.cpp ----------------------------------------------===//
+//===-- ScriptedThreadPlan.cpp --------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,10 +14,10 @@
 #include "lldb/Interpreter/ScriptInterpreter.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/ScriptedThreadPlan.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Target/ThreadPlan.h"
-#include "lldb/Target/ThreadPlanPython.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/State.h"
@@ -25,11 +25,9 @@
 using namespace lldb;
 using namespace lldb_private;
 
-// ThreadPlanPython
-
-ThreadPlanPython::ThreadPlanPython(Thread &thread, const char *class_name,
-                                   const StructuredDataImpl &args_data)
-    : ThreadPlan(ThreadPlan::eKindPython, "Python based Thread Plan", thread,
+ScriptedThreadPlan::ScriptedThreadPlan(Thread &thread, const char *class_name,
+                                       const StructuredDataImpl &args_data)
+    : ThreadPlan(ThreadPlan::eKindPython, "Script based Thread Plan", thread,
                  eVoteNoOpinion, eVoteNoOpinion),
       m_class_name(class_name), m_args_data(args_data), m_did_push(false),
       m_stop_others(false) {
@@ -38,7 +36,7 @@ ThreadPlanPython::ThreadPlanPython(Thread &thread, const char *class_name,
     SetPlanComplete(false);
     // FIXME: error handling
     // error.SetErrorStringWithFormat(
-    //     "ThreadPlanPython::%s () - ERROR: %s", __FUNCTION__,
+    //     "ScriptedThreadPlan::%s () - ERROR: %s", __FUNCTION__,
     //     "Couldn't get script interpreter");
     return;
   }
@@ -48,7 +46,7 @@ ThreadPlanPython::ThreadPlanPython(Thread &thread, const char *class_name,
     SetPlanComplete(false);
     // FIXME: error handling
     // error.SetErrorStringWithFormat(
-    //     "ThreadPlanPython::%s () - ERROR: %s", __FUNCTION__,
+    //     "ScriptedThreadPlan::%s () - ERROR: %s", __FUNCTION__,
     //     "Script interpreter couldn't create Scripted Thread Plan Interface");
     return;
   }
@@ -58,26 +56,26 @@ ThreadPlanPython::ThreadPlanPython(Thread &thread, const char *class_name,
   SetPrivate(false);
 }
 
-bool ThreadPlanPython::ValidatePlan(Stream *error) {
+bool ScriptedThreadPlan::ValidatePlan(Stream *error) {
   if (!m_did_push)
     return true;
 
   if (!m_implementation_sp) {
     if (error)
       error->Printf("Error constructing Python ThreadPlan: %s",
-          m_error_str.empty() ? "<unknown error>"
-                                : m_error_str.c_str());
+                    m_error_str.empty() ? "<unknown error>"
+                                        : m_error_str.c_str());
     return false;
   }
 
   return true;
 }
 
-ScriptInterpreter *ThreadPlanPython::GetScriptInterpreter() {
+ScriptInterpreter *ScriptedThreadPlan::GetScriptInterpreter() {
   return m_process.GetTarget().GetDebugger().GetScriptInterpreter();
 }
 
-void ThreadPlanPython::DidPush() {
+void ScriptedThreadPlan::DidPush() {
   // We set up the script side in DidPush, so that it can push other plans in
   // the constructor, and doesn't have to care about the details of DidPush.
   m_did_push = true;
@@ -92,10 +90,10 @@ void ThreadPlanPython::DidPush() {
   }
 }
 
-bool ThreadPlanPython::ShouldStop(Event *event_ptr) {
+bool ScriptedThreadPlan::ShouldStop(Event *event_ptr) {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Python Thread Plan: %s )", LLVM_PRETTY_FUNCTION,
-            m_class_name.c_str());
+  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
+            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
 
   bool should_stop = true;
   if (m_implementation_sp) {
@@ -110,10 +108,10 @@ bool ThreadPlanPython::ShouldStop(Event *event_ptr) {
   return should_stop;
 }
 
-bool ThreadPlanPython::IsPlanStale() {
+bool ScriptedThreadPlan::IsPlanStale() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Python Thread Plan: %s )", LLVM_PRETTY_FUNCTION,
-            m_class_name.c_str());
+  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
+            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
 
   bool is_stale = true;
   if (m_implementation_sp) {
@@ -128,10 +126,10 @@ bool ThreadPlanPython::IsPlanStale() {
   return is_stale;
 }
 
-bool ThreadPlanPython::DoPlanExplainsStop(Event *event_ptr) {
+bool ScriptedThreadPlan::DoPlanExplainsStop(Event *event_ptr) {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Python Thread Plan: %s )", LLVM_PRETTY_FUNCTION,
-            m_class_name.c_str());
+  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
+            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
 
   bool explains_stop = true;
   if (m_implementation_sp) {
@@ -147,10 +145,10 @@ bool ThreadPlanPython::DoPlanExplainsStop(Event *event_ptr) {
   return explains_stop;
 }
 
-bool ThreadPlanPython::MischiefManaged() {
+bool ScriptedThreadPlan::MischiefManaged() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Python Thread Plan: %s )", LLVM_PRETTY_FUNCTION,
-            m_class_name.c_str());
+  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
+            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
   bool mischief_managed = true;
   if (m_implementation_sp) {
     // I don't really need mischief_managed, since it's simpler to just call
@@ -165,20 +163,21 @@ bool ThreadPlanPython::MischiefManaged() {
   return mischief_managed;
 }
 
-lldb::StateType ThreadPlanPython::GetPlanRunState() {
+lldb::StateType ScriptedThreadPlan::GetPlanRunState() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Python Thread Plan: %s )", LLVM_PRETTY_FUNCTION,
-            m_class_name.c_str());
+  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
+            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
   lldb::StateType run_state = eStateRunning;
   if (m_implementation_sp)
     run_state = m_interface->GetRunState();
   return run_state;
 }
 
-void ThreadPlanPython::GetDescription(Stream *s, lldb::DescriptionLevel level) {
+void ScriptedThreadPlan::GetDescription(Stream *s,
+                                        lldb::DescriptionLevel level) {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Python Thread Plan: %s )", LLVM_PRETTY_FUNCTION,
-            m_class_name.c_str());
+  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
+            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
   if (m_implementation_sp) {
     ScriptInterpreter *script_interp = GetScriptInterpreter();
     if (script_interp) {
@@ -187,8 +186,8 @@ void ThreadPlanPython::GetDescription(Stream *s, lldb::DescriptionLevel level) {
       if (err) {
         LLDB_LOG_ERROR(GetLog(LLDBLog::Thread), std::move(err),
                        "Can't call ScriptedThreadPlan::GetStopDescription.");
-        s->Printf("Python thread plan implemented by class %s.",
-            m_class_name.c_str());
+        s->Printf("Scripted thread plan implemented by class %s.",
+                  m_class_name.c_str());
       } else
         s->PutCString(
             reinterpret_cast<StreamString *>(stream.get())->GetData());
@@ -198,21 +197,21 @@ void ThreadPlanPython::GetDescription(Stream *s, lldb::DescriptionLevel level) {
   // It's an error not to have a description, so if we get here, we should
   // add something.
   if (m_stop_description.Empty())
-    s->Printf("Python thread plan implemented by class %s.",
+    s->Printf("Scripted thread plan implemented by class %s.",
               m_class_name.c_str());
   s->PutCString(m_stop_description.GetData());
 }
 
 // The ones below are not currently exported to Python.
-bool ThreadPlanPython::WillStop() {
+bool ScriptedThreadPlan::WillStop() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Python Thread Plan: %s )", LLVM_PRETTY_FUNCTION,
-            m_class_name.c_str());
+  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
+            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
   return true;
 }
 
-bool ThreadPlanPython::DoWillResume(lldb::StateType resume_state, 
-                                  bool current_plan) {
+bool ScriptedThreadPlan::DoWillResume(lldb::StateType resume_state,
+                                      bool current_plan) {
   m_stop_description.Clear();
-  return true;                                  
+  return true;
 }

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -25,6 +25,7 @@
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/ScriptedThreadPlan.h"
 #include "lldb/Target/StackFrameRecognizer.h"
 #include "lldb/Target/StopInfo.h"
 #include "lldb/Target/SystemRuntime.h"
@@ -32,7 +33,6 @@
 #include "lldb/Target/ThreadPlan.h"
 #include "lldb/Target/ThreadPlanBase.h"
 #include "lldb/Target/ThreadPlanCallFunction.h"
-#include "lldb/Target/ThreadPlanPython.h"
 #include "lldb/Target/ThreadPlanRunToAddress.h"
 #include "lldb/Target/ThreadPlanStack.h"
 #include "lldb/Target/ThreadPlanStepInRange.h"
@@ -1378,7 +1378,7 @@ lldb::ThreadPlanSP Thread::QueueThreadPlanForStepScripted(
     StructuredData::ObjectSP extra_args_sp, bool stop_other_threads,
     Status &status) {
 
-  ThreadPlanSP thread_plan_sp(new ThreadPlanPython(
+  ThreadPlanSP thread_plan_sp(new ScriptedThreadPlan(
       *this, class_name, StructuredDataImpl(extra_args_sp)));
   thread_plan_sp->SetStopOthers(stop_other_threads);
   status = QueueThreadPlan(thread_plan_sp, abort_other_plans);


### PR DESCRIPTION
Following 9a9ec228cdcf, since the ThreadPlanPython class started making use of the Scripted Interface instead of calling directly into the python methods, this class can work with other scripting languages (as long as someone add the interfact for that language ;p).

So it doesn't make sense anymore for it to keep this name and also we should avoid having language specific related classes outside the plugin directory.

This patch renames the internal class from `ThreadPlanPython` to `ScriptedThreadPlan` as its advertised externally, and also updates the various log messages.

This should hopefully make the codebase more coherent.