### PR TITLE
[lldb] Rename `scripting template` to `scripting extension` (NFC)

### DIFF
--- a/lldb/source/Commands/CommandObjectScripting.cpp
+++ b/lldb/source/Commands/CommandObjectScripting.cpp
@@ -129,18 +129,18 @@ private:
   CommandOptions m_options;
 };
 
-#define LLDB_OPTIONS_scripting_template_list
+#define LLDB_OPTIONS_scripting_extension_list
 #include "CommandOptions.inc"
 
-class CommandObjectScriptingTemplateList : public CommandObjectParsed {
+class CommandObjectScriptingExtensionList : public CommandObjectParsed {
 public:
-  CommandObjectScriptingTemplateList(CommandInterpreter &interpreter)
+  CommandObjectScriptingExtensionList(CommandInterpreter &interpreter)
       : CommandObjectParsed(
-            interpreter, "scripting template list",
+            interpreter, "scripting extension list",
             "List all the available scripting extension templates. ",
             "scripting template list [--language <scripting-language> --]") {}
 
-  ~CommandObjectScriptingTemplateList() override = default;
+  ~CommandObjectScriptingExtensionList() override = default;
 
   Options *GetOptions() override { return &m_options; }
 
@@ -174,7 +174,7 @@ public:
     }
 
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
-      return llvm::ArrayRef(g_scripting_template_list_options);
+      return llvm::ArrayRef(g_scripting_extension_list_options);
     }
 
     lldb::ScriptLanguage m_language = lldb::eScriptLanguageDefault;
@@ -195,8 +195,8 @@ protected:
     };
 
     size_t num_listed_interface = 0;
-    size_t num_templates = PluginManager::GetNumScriptedInterfaces();
-    for (size_t i = 0; i < num_templates; i++) {
+    size_t num_extensions = PluginManager::GetNumScriptedInterfaces();
+    for (size_t i = 0; i < num_extensions; i++) {
       llvm::StringRef plugin_name =
           PluginManager::GetScriptedInterfaceNameAtIndex(i);
       if (plugin_name.empty())
@@ -223,7 +223,7 @@ protected:
       usages.Dump(s, ScriptedInterfaceUsages::UsageKind::API);
       usages.Dump(s, ScriptedInterfaceUsages::UsageKind::CommandInterpreter);
 
-      if (i != num_templates - 1)
+      if (i != num_extensions - 1)
         s.EOL();
     }
 
@@ -235,19 +235,19 @@ private:
   CommandOptions m_options;
 };
 
-class CommandObjectMultiwordScriptingTemplate : public CommandObjectMultiword {
+class CommandObjectMultiwordScriptingExtension : public CommandObjectMultiword {
 public:
-  CommandObjectMultiwordScriptingTemplate(CommandInterpreter &interpreter)
+  CommandObjectMultiwordScriptingExtension(CommandInterpreter &interpreter)
       : CommandObjectMultiword(
-            interpreter, "scripting template",
-            "Commands for operating on the scripting templates.",
-            "scripting template [<subcommand-options>]") {
+            interpreter, "scripting extension",
+            "Commands for operating on the scripting extensions.",
+            "scripting extension [<subcommand-options>]") {
     LoadSubCommand(
         "list",
-        CommandObjectSP(new CommandObjectScriptingTemplateList(interpreter)));
+        CommandObjectSP(new CommandObjectScriptingExtensionList(interpreter)));
   }
 
-  ~CommandObjectMultiwordScriptingTemplate() override = default;
+  ~CommandObjectMultiwordScriptingExtension() override = default;
 };
 
 CommandObjectMultiwordScripting::CommandObjectMultiwordScripting(
@@ -258,9 +258,9 @@ CommandObjectMultiwordScripting::CommandObjectMultiwordScripting(
           "scripting <subcommand> [<subcommand-options>]") {
   LoadSubCommand("run",
                  CommandObjectSP(new CommandObjectScriptingRun(interpreter)));
-  LoadSubCommand("template",
-                 CommandObjectSP(
-                     new CommandObjectMultiwordScriptingTemplate(interpreter)));
+  LoadSubCommand("extension",
+                 CommandObjectSP(new CommandObjectMultiwordScriptingExtension(
+                     interpreter)));
 }
 
 CommandObjectMultiwordScripting::~CommandObjectMultiwordScripting() = default;

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -841,8 +841,8 @@ let Command = "scripting run" in {
     " language. If none is specific the default scripting language is used.">;
 }
 
-let Command = "scripting template list" in {
-  def scripting_template_list_language : Option<"language", "l">,
+let Command = "scripting extension list" in {
+  def scripting_extension_list_language : Option<"language", "l">,
     EnumArg<"ScriptLang">, Desc<"Specify the scripting "
     " language. If none is specified the default scripting language is used.">;
 }

--- a/lldb/test/Shell/Commands/command-scripting-extension-list.test
+++ b/lldb/test/Shell/Commands/command-scripting-extension-list.test
@@ -1,7 +1,7 @@
 # REQUIRES: python
 # RUN: %lldb -s %s -o exit | FileCheck %s
 
-scripting template list
+scripting extension list
 # CHECK:Available scripted extension templates:
 
 # CHECK:  Name: OperatingSystemPythonInterface
@@ -38,5 +38,5 @@ scripting template list
 # CHECK-NEXT:  API Usages: SBThread.StepUsingScriptedThreadPlan
 # CHECK-NEXT:  Command Interpreter Usages: thread step-scripted -C <script-name> [-k key -v value ...]
 
-scripting template list -l lua
+scripting extension list -l lua
 # CHECK: Available scripted extension templates: None


### PR DESCRIPTION
This patch renames the `scripting template` subcommand to be `scripting extension` instead since that would make more sense for upcoming commands.