### PR TITLE
[clang][Interp] Handle Pointer::toAPValue() for expr bases

### DIFF
--- a/clang/test/AST/Interp/codegen.cpp
+++ b/clang/test/AST/Interp/codegen.cpp
@@ -32,6 +32,16 @@ namespace BaseClassOffsets {
   B* b = &c;
 }
 
+namespace ExprBase {
+  struct A { int n; };
+  struct B { int n; };
+  struct C : A, B {};
+
+  extern const int &&t = ((B&&)C{}).n;
+  // CHECK: @_ZGRN8ExprBase1tE_ = internal global {{.*}} zeroinitializer,
+  // CHECK: @_ZN8ExprBase1tE = constant ptr {{.*}} @_ZGRN8ExprBase1tE_, {{.*}} 8
+}
+
 namespace reinterpretcast {
   const unsigned int n = 1234;
   extern const int &s = reinterpret_cast<const int&>(n);

--- a/clang/test/AST/Interp/new-delete.cpp
+++ b/clang/test/AST/Interp/new-delete.cpp
@@ -358,7 +358,7 @@ namespace delete_random_things {
                                              // both-note {{delete of pointer to subobject }}
   static_assert((delete (new int + 1), true)); // both-error {{}} \
                                                // ref-note {{delete of pointer '&{*new int#0} + 1' that does not point to complete object}} \
-                                               // expected-note {{delete of pointer '&new int + 1' that does not point to complete object}}
+                                               // expected-note {{delete of pointer '&{*new int#1} + 1' that does not point to complete object}}
   static_assert((delete[] (new int[3] + 1), true)); // both-error {{}} \
                                                     // both-note {{delete of pointer to subobject}}
   static_assert((delete &(int&)(int&&)0, true)); // both-error {{}} \


### PR DESCRIPTION
No reason to return early for them anymore.