### PR TITLE
Fix some X86 tests

### DIFF
--- a/llvm/test/CodeGen/Generic/extractelement-shuffle.ll
+++ b/llvm/test/CodeGen/Generic/extractelement-shuffle.ll
@@ -1,5 +1,4 @@
 ; RUN: llc < %s
-; REQUIRES: default_triple
 
 ; Examples that exhibits a bug in DAGCombine.  The case is triggered by the
 ; following program.  The bug is DAGCombine assumes that the bit convert

--- a/llvm/test/CodeGen/X86/2006-10-02-BoolRetCrash.ll
+++ b/llvm/test/CodeGen/X86/2006-10-02-BoolRetCrash.ll
@@ -1,6 +1,5 @@
-; RUN: llc < %s 
+; RUN: llc -march=x86 < %s
 ; PR933
-; REQUIRES: default_triple
 
 define fastcc i1 @test() {
         ret i1 true

--- a/llvm/test/CodeGen/X86/2010-07-06-DbgCrash.ll
+++ b/llvm/test/CodeGen/X86/2010-07-06-DbgCrash.ll
@@ -1,5 +1,4 @@
-; RUN: llc -O0 -relocation-model pic < %s -o /dev/null
-; REQUIRES: default_triple
+; RUN: llc -mtriple=x86_64-- -O0 -relocation-model pic < %s -o /dev/null
 ; PR7545
 
 @.str = private constant [4 x i8] c"one\00", align 1 ; <ptr> [#uses=1]


### PR DESCRIPTION
extractelement-shuffle.ll: Test for bugfix in DAGCombiner, moved to Generic.

2010-07-06-DbgCrash.ll and 2006-10-02-BoolRetCrash.ll: Bugfixes in X86, run tests with X86 backend.
