### PR TITLE
[CodeGen] Use SmallVector for MBB preds/succs

### DIFF
--- a/llvm/include/llvm/Analysis/RegionInfoImpl.h
+++ b/llvm/include/llvm/Analysis/RegionInfoImpl.h
@@ -814,7 +814,8 @@ RegionInfoBase<Tr>::getMaxRegionExit(BlockT *BB) const {
     // Get the single exit of BB.
     if (R && R->getEntry() == BB)
       Exit = R->getExit();
-    else if (BlockTraits::child_begin(BB) + 1 == BlockTraits::child_end(BB))
+    else if (std::next(BlockTraits::child_begin(BB)) ==
+             BlockTraits::child_end(BB))
       Exit = *BlockTraits::child_begin(BB);
     else // No single exit exists.
       return Exit;

--- a/llvm/include/llvm/Analysis/RegionInfoImpl.h
+++ b/llvm/include/llvm/Analysis/RegionInfoImpl.h
@@ -814,7 +814,7 @@ RegionInfoBase<Tr>::getMaxRegionExit(BlockT *BB) const {
     // Get the single exit of BB.
     if (R && R->getEntry() == BB)
       Exit = R->getExit();
-    else if (++BlockTraits::child_begin(BB) == BlockTraits::child_end(BB))
+    else if (BlockTraits::child_begin(BB) + 1 == BlockTraits::child_end(BB))
       Exit = *BlockTraits::child_begin(BB);
     else // No single exit exists.
       return Exit;

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -157,8 +157,8 @@ private:
   Instructions Insts;
 
   /// Keep track of the predecessor / successor basic blocks.
-  std::vector<MachineBasicBlock *> Predecessors;
-  std::vector<MachineBasicBlock *> Successors;
+  SmallVector<MachineBasicBlock *, 4> Predecessors;
+  SmallVector<MachineBasicBlock *, 2> Successors;
 
   /// Keep track of the probabilities to the successors. This vector has the
   /// same order as Successors, or it is empty if we don't use it (disable
@@ -387,18 +387,20 @@ public:
   }
 
   // Machine-CFG iterators
-  using pred_iterator = std::vector<MachineBasicBlock *>::iterator;
-  using const_pred_iterator = std::vector<MachineBasicBlock *>::const_iterator;
-  using succ_iterator = std::vector<MachineBasicBlock *>::iterator;
-  using const_succ_iterator = std::vector<MachineBasicBlock *>::const_iterator;
+  using pred_iterator = SmallVectorImpl<MachineBasicBlock *>::iterator;
+  using const_pred_iterator =
+      SmallVectorImpl<MachineBasicBlock *>::const_iterator;
+  using succ_iterator = SmallVectorImpl<MachineBasicBlock *>::iterator;
+  using const_succ_iterator =
+      SmallVectorImpl<MachineBasicBlock *>::const_iterator;
   using pred_reverse_iterator =
-      std::vector<MachineBasicBlock *>::reverse_iterator;
+      SmallVectorImpl<MachineBasicBlock *>::reverse_iterator;
   using const_pred_reverse_iterator =
-      std::vector<MachineBasicBlock *>::const_reverse_iterator;
+      SmallVectorImpl<MachineBasicBlock *>::const_reverse_iterator;
   using succ_reverse_iterator =
-      std::vector<MachineBasicBlock *>::reverse_iterator;
+      SmallVectorImpl<MachineBasicBlock *>::reverse_iterator;
   using const_succ_reverse_iterator =
-      std::vector<MachineBasicBlock *>::const_reverse_iterator;
+      SmallVectorImpl<MachineBasicBlock *>::const_reverse_iterator;
   pred_iterator        pred_begin()       { return Predecessors.begin(); }
   const_pred_iterator  pred_begin() const { return Predecessors.begin(); }
   pred_iterator        pred_end()         { return Predecessors.end();   }

--- a/llvm/lib/CodeGen/MIRSampleProfile.cpp
+++ b/llvm/lib/CodeGen/MIRSampleProfile.cpp
@@ -126,8 +126,10 @@ template <> struct IRTraits<MachineBasicBlock> {
   using PostDominatorTreeT = MachinePostDominatorTree;
   using OptRemarkEmitterT = MachineOptimizationRemarkEmitter;
   using OptRemarkAnalysisT = MachineOptimizationRemarkAnalysis;
-  using PredRangeT = iterator_range<std::vector<MachineBasicBlock *>::iterator>;
-  using SuccRangeT = iterator_range<std::vector<MachineBasicBlock *>::iterator>;
+  using PredRangeT =
+      iterator_range<SmallVectorImpl<MachineBasicBlock *>::iterator>;
+  using SuccRangeT =
+      iterator_range<SmallVectorImpl<MachineBasicBlock *>::iterator>;
   static Function &getFunction(MachineFunction &F) { return F.getFunction(); }
   static const MachineBasicBlock *getEntryBB(const MachineFunction *F) {
     return GraphTraits<const MachineFunction *>::getEntryNode(F);

--- a/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
@@ -249,7 +249,8 @@ void HexagonCopyHoisting::moveCopyInstr(MachineBasicBlock *DestBB,
   DestBB->splice(FirstTI, MI->getParent(), MI);
 
   addMItoCopyList(MI);
-  for (auto I = DestBB->succ_begin() + 1, E = DestBB->succ_end(); I != E; ++I) {
+  for (auto I = std::next(DestBB->succ_begin()), E = DestBB->succ_end(); I != E;
+       ++I) {
     MachineBasicBlock *SuccBB = *I;
     auto &BBCopyInst = CopyMIList[SuccBB->getNumber()];
     MachineInstr *SuccMI = BBCopyInst[Key];

--- a/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
@@ -249,7 +249,7 @@ void HexagonCopyHoisting::moveCopyInstr(MachineBasicBlock *DestBB,
   DestBB->splice(FirstTI, MI->getParent(), MI);
 
   addMItoCopyList(MI);
-  for (auto I = ++(DestBB->succ_begin()), E = DestBB->succ_end(); I != E; ++I) {
+  for (auto I = DestBB->succ_begin() + 1, E = DestBB->succ_end(); I != E; ++I) {
     MachineBasicBlock *SuccBB = *I;
     auto &BBCopyInst = CopyMIList[SuccBB->getNumber()];
     MachineInstr *SuccMI = BBCopyInst[Key];


### PR DESCRIPTION
Avoid extra heap allocations for typical predecessor/successor counts.

[c-t-t](http://llvm-compile-time-tracker.com/compare.php?from=e7f9d8e5c3e49e729c69aaa9be3322f7902370b8&to=61a0ed0ea4eab2a9d4b0f1d1ce7b62b57b7cf50e&stat=instructions:u) -0.14% stage2-O0-g