### PR TITLE
[IR] Use single map in PredIteratorCache (NFC)

### DIFF
--- a/llvm/include/llvm/IR/PredIteratorCache.h
+++ b/llvm/include/llvm/IR/PredIteratorCache.h
@@ -25,52 +25,29 @@ namespace llvm {
 /// predecessor iterator queries.  This is useful for code that repeatedly
 /// wants the predecessor list for the same blocks.
 class PredIteratorCache {
-  /// BlockToPredsMap - Pointer to null-terminated list.
-  mutable DenseMap<BasicBlock *, BasicBlock **> BlockToPredsMap;
-  mutable DenseMap<BasicBlock *, unsigned> BlockToPredCountMap;
+  /// Cached list of predecessors, allocated in Memory.
+  mutable DenseMap<BasicBlock *, ArrayRef<BasicBlock *>> BlockToPredsMap;
 
   /// Memory - This is the space that holds cached preds.
   BumpPtrAllocator Memory;
 
-private:
-  /// GetPreds - Get a cached list for the null-terminated predecessor list of
-  /// the specified block.  This can be used in a loop like this:
-  ///   for (BasicBlock **PI = PredCache->GetPreds(BB); *PI; ++PI)
-  ///      use(*PI);
-  /// instead of:
-  /// for (pred_iterator PI = pred_begin(BB), E = pred_end(BB); PI != E; ++PI)
-  BasicBlock **GetPreds(BasicBlock *BB) {
-    BasicBlock **&Entry = BlockToPredsMap[BB];
-    if (Entry)
+public:
+  size_t size(BasicBlock *BB) { return get(BB).size(); }
+  ArrayRef<BasicBlock *> get(BasicBlock *BB) {
+    ArrayRef<BasicBlock *> &Entry = BlockToPredsMap[BB];
+    if (Entry.data())
       return Entry;
 
     SmallVector<BasicBlock *, 32> PredCache(predecessors(BB));
-    PredCache.push_back(nullptr); // null terminator.
-
-    BlockToPredCountMap[BB] = PredCache.size() - 1;
-
-    Entry = Memory.Allocate<BasicBlock *>(PredCache.size());
-    std::copy(PredCache.begin(), PredCache.end(), Entry);
+    BasicBlock **Data = Memory.Allocate<BasicBlock *>(PredCache.size());
+    std::copy(PredCache.begin(), PredCache.end(), Data);
+    Entry = ArrayRef(Data, PredCache.size());
     return Entry;
-  }
-
-  unsigned GetNumPreds(BasicBlock *BB) const {
-    auto Result = BlockToPredCountMap.find(BB);
-    if (Result != BlockToPredCountMap.end())
-      return Result->second;
-    return BlockToPredCountMap[BB] = pred_size(BB);
-  }
-
-public:
-  size_t size(BasicBlock *BB) const { return GetNumPreds(BB); }
-  ArrayRef<BasicBlock *> get(BasicBlock *BB) {
-    return ArrayRef(GetPreds(BB), GetNumPreds(BB));
   }
 
   /// clear - Remove all information.
   void clear() {
     BlockToPredsMap.clear();
-    BlockToPredCountMap.clear();
     Memory.Reset();
   }
 };

--- a/llvm/include/llvm/IR/PredIteratorCache.h
+++ b/llvm/include/llvm/IR/PredIteratorCache.h
@@ -26,7 +26,7 @@ namespace llvm {
 /// wants the predecessor list for the same blocks.
 class PredIteratorCache {
   /// Cached list of predecessors, allocated in Memory.
-  mutable DenseMap<BasicBlock *, ArrayRef<BasicBlock *>> BlockToPredsMap;
+  DenseMap<BasicBlock *, ArrayRef<BasicBlock *>> BlockToPredsMap;
 
   /// Memory - This is the space that holds cached preds.
   BumpPtrAllocator Memory;


### PR DESCRIPTION
Use a single map storing ArrayRef instead of two separate maps for the base pointer and size. This saves one map lookup per cache accesses.

This is an alternative to https://github.com/llvm/llvm-project/pull/101885 with a similar compile-time improvement: http://llvm-compile-time-tracker.com/compare.php?from=1fa7f05b709748e8a36936cbb5508070c8214354&to=1af82f2ca51aa324c772941770dd3ee4043b2b4d&stat=instructions:u