### PR TITLE
[BranchFolding] Add a hook to tail merge only bbs without successors

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2236,6 +2236,14 @@ public:
     return 3;
   }
 
+  /// Return true if the target prefers to tail merge only basic blocks that
+  /// do not have successors. This is beneficial for targets where jumps
+  /// are costly.
+  virtual bool
+  shouldTailMergeOnlyBBsWithoutSucc(const MachineFunction &MF) const {
+    return false;
+  }
+
   /// Returns the callee operand from the given \p MI.
   virtual const MachineOperand &getCalleeOperand(const MachineInstr &MI) const {
     return MI.getOperand(0);

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -1035,6 +1035,9 @@ bool BranchFolder::TailMergeBlocks(MachineFunction &MF) {
   if (MergePotentials.size() >= 2)
     MadeChange |= TryTailMergeBlocks(nullptr, nullptr, MinCommonTailLength);
 
+  if (TII->shouldTailMergeOnlyBBsWithoutSucc(MF))
+    return MadeChange;
+
   // Look at blocks (IBB) with multiple predecessors (PBB).
   // We change each predecessor to a canonical form, by
   // (1) temporarily removing any unconditional branch from the predecessor


### PR DESCRIPTION
This patch adds a new hook `TargetInstrInfo::shouldTailMergeOnlyBBsWithoutSucc` so targets can override it. This is beneficial for targets where jumps are costly.