### PR TITLE
[libunwind] Be more careful about enabling GCS

### DIFF
--- a/libunwind/src/cet_unwind.h
+++ b/libunwind/src/cet_unwind.h
@@ -39,8 +39,12 @@
 // need to guard any use of GCS instructions with __chkfeat though, as GCS may
 // not be enabled.
 #if defined(_LIBUNWIND_TARGET_AARCH64) && defined(__ARM_FEATURE_GCS_DEFAULT)
-#define _LIBUNWIND_USE_GCS 1
 #include <arm_acle.h>
+
+// We can only use GCS if arm_acle.h defines the GCS intrinsics.
+#ifdef _CHKFEAT_GCS
+#define _LIBUNWIND_USE_GCS 1
+#endif
 
 #define _LIBUNWIND_POP_CET_SSP(x)                                              \
   do {                                                                         \


### PR DESCRIPTION
We need both GCS to be enabled by the compiler (which we do by checking if __ARM_FEATURE_GCS_DEFAULT is defined) and for arm_acle.h to define the GCS intrinsics. Check the latter by checking if _CHKFEAT_GCS is defined.