### PR TITLE
[libc] Fix overflow check for 32-bit mktime.

### DIFF
--- a/libc/src/time/mktime.cpp
+++ b/libc/src/time/mktime.cpp
@@ -42,12 +42,18 @@ LLVM_LIBC_FUNCTION(time_t, mktime, (struct tm * tm_out)) {
       return time_utils::out_of_range();
     if (tm_out->tm_mday > 19)
       return time_utils::out_of_range();
-    if (tm_out->tm_hour > 3)
-      return time_utils::out_of_range();
-    if (tm_out->tm_min > 14)
-      return time_utils::out_of_range();
-    if (tm_out->tm_sec > 7)
-      return time_utils::out_of_range();
+    else if (tm_out->tm_mday == 19) {
+      if (tm_out->tm_hour > 3)
+        return time_utils::out_of_range();
+      else if (tm_out->tm_hour == 3) {
+        if (tm_out->tm_min > 14)
+          return time_utils::out_of_range();
+        else if (tm_out->tm_min == 14) {
+          if (tm_out->tm_sec > 7)
+            return time_utils::out_of_range();
+        }
+      }
+    }
   }
 
   // Years are ints.  A 32-bit year will fit into a 64-bit time_t.


### PR DESCRIPTION
The 32-bit time_t rolls over to a value with its high bit set at 2038-01-19 03:14:07. The overflow check for this in mktime() was checking each individual component of the time: reject if year>2038, or if month>1, or if day>19, etc. As a result it would reject valid times before the overflow point, because a low-order component was out of range even though a higher-order one makes the time as a whole safe. The earliest failing value is 2145916808 == 2038-01-01 00:00:08, in which only the seconds field 'overflows'.

Fixed so that if any component is _less_ than its threshold value, we don't check the lower-order components.