### PR TITLE
[clang][Interp] Remove GlobalDecl flag

### DIFF
--- a/clang/lib/AST/Interp/Compiler.cpp
+++ b/clang/lib/AST/Interp/Compiler.cpp
@@ -29,9 +29,7 @@ template <class Emitter> class DeclScope final : public LocalScope<Emitter> {
 public:
   DeclScope(Compiler<Emitter> *Ctx, const ValueDecl *VD)
       : LocalScope<Emitter>(Ctx, VD), Scope(Ctx->P, VD),
-        OldGlobalDecl(Ctx->GlobalDecl),
         OldInitializingDecl(Ctx->InitializingDecl) {
-    Ctx->GlobalDecl = Context::shouldBeGloballyIndexed(VD);
     Ctx->InitializingDecl = VD;
     Ctx->InitStack.push_back(InitLink::Decl(VD));
   }
@@ -41,14 +39,12 @@ public:
   }
 
   ~DeclScope() {
-    this->Ctx->GlobalDecl = OldGlobalDecl;
     this->Ctx->InitializingDecl = OldInitializingDecl;
     this->Ctx->InitStack.pop_back();
   }
 
 private:
   Program::DeclScope Scope;
-  bool OldGlobalDecl;
   const ValueDecl *OldInitializingDecl;
 };
 
@@ -2265,7 +2261,7 @@ bool Compiler<Emitter>::VisitMaterializeTemporaryExpr(
   // the temporary is explicitly static, create a global variable.
   std::optional<PrimType> SubExprT = classify(SubExpr);
   bool IsStatic = E->getStorageDuration() == SD_Static;
-  if (GlobalDecl || IsStatic) {
+  if (IsStatic) {
     std::optional<unsigned> GlobalIndex = P.createGlobal(E);
     if (!GlobalIndex)
       return false;

--- a/clang/lib/AST/Interp/Compiler.h
+++ b/clang/lib/AST/Interp/Compiler.h
@@ -389,9 +389,6 @@ protected:
   llvm::SmallVector<InitLink> InitStack;
   bool InitStackActive = false;
 
-  /// Flag indicating if we're initializing a global variable.
-  bool GlobalDecl = false;
-
   /// Type of the expression returned by the function.
   std::optional<PrimType> ReturnType;
 

--- a/clang/lib/AST/Interp/Context.cpp
+++ b/clang/lib/AST/Interp/Context.cpp
@@ -56,6 +56,7 @@ bool Context::evaluateAsRValue(State &Parent, const Expr *E, APValue &Result) {
 
   if (!Recursing) {
     assert(Stk.empty());
+    C.cleanup();
 #ifndef NDEBUG
     // Make sure we don't rely on some value being still alive in
     // InterpStack memory.
@@ -82,6 +83,7 @@ bool Context::evaluate(State &Parent, const Expr *E, APValue &Result) {
 
   if (!Recursing) {
     assert(Stk.empty());
+    C.cleanup();
 #ifndef NDEBUG
     // Make sure we don't rely on some value being still alive in
     // InterpStack memory.
@@ -111,6 +113,7 @@ bool Context::evaluateAsInitializer(State &Parent, const VarDecl *VD,
 
   if (!Recursing) {
     assert(Stk.empty());
+    C.cleanup();
 #ifndef NDEBUG
     // Make sure we don't rely on some value being still alive in
     // InterpStack memory.

--- a/clang/test/AST/Interp/codegen.cpp
+++ b/clang/test/AST/Interp/codegen.cpp
@@ -54,3 +54,13 @@ namespace reinterpretcast {
   // CHECK: define {{.*}} ptr @_ZN15reinterpretcast2f1Em
   // CHECK: inttoptr
 }
+
+namespace Bitfield {
+  struct S { int a : 5; ~S(); };
+  // CHECK: alloca
+  // CHECK: call {{.*}}memset
+  // CHECK: store i32 {{.*}}, ptr @_ZGRN8Bitfield1rE_
+  // CHECK: call void @_ZN8Bitfield1SD1
+  // CHECK: store ptr @_ZGRN8Bitfield1rE_, ptr @_ZN8Bitfield1rE, align 8
+  int &&r = S().a;
+}


### PR DESCRIPTION
When initializing global variables, we still need to create local variables for temporaries created in the process. Otherwise, we will never call their destructors.