### PR TITLE
[libc] Provide 'signal.h' header for the GPU

### DIFF
--- a/libc/config/gpu/headers.txt
+++ b/libc/config/gpu/headers.txt
@@ -2,6 +2,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.assert
     libc.include.ctype
     libc.include.string
+    libc.include.signal
     libc.include.float
     libc.include.stdint
     libc.include.inttypes

--- a/libc/include/llvm-libc-macros/gpu/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/gpu/CMakeLists.txt
@@ -3,3 +3,9 @@ add_header(
   HDR
     time-macros.h
 )
+
+add_header(
+  signal_macros
+  HDR
+    signal-macros.h
+)

--- a/libc/include/llvm-libc-macros/gpu/signal-macros.h
+++ b/libc/include/llvm-libc-macros/gpu/signal-macros.h
@@ -1,0 +1,28 @@
+//===-- Definition of GPU signal number macros ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_GPU_SIGNAL_MACROS_H
+#define LLVM_LIBC_MACROS_GPU_SIGNAL_MACROS_H
+
+#define SIGINT 2
+#define SIGILL 4
+#define SIGABRT 6
+#define SIGFPE 8
+#define SIGSEGV 11
+#define SIGTERM 15
+
+#define SIG_DFL ((__sighandler_t)(0))
+#define SIG_IGN ((__sighandler_t)(1))
+#define SIG_ERR ((__sighandler_t)(-1))
+
+// Max signal number
+#define NSIG 64
+
+#define __NSIGSET_WORDS NSIG
+
+#endif // LLVM_LIBC_MACROS_GPU_SIGNAL_MACROS_H

--- a/libc/include/llvm-libc-macros/signal-macros.h
+++ b/libc/include/llvm-libc-macros/signal-macros.h
@@ -9,8 +9,10 @@
 #ifndef LLVM_LIBC_MACROS_SIGNAL_MACROS_H
 #define LLVM_LIBC_MACROS_SIGNAL_MACROS_H
 
-#ifdef __linux__
+#if defined(__linux__)
 #include "linux/signal-macros.h"
+#elif defined(__NVPTX__) || defined(__AMDGPU__)
+#include "gpu/signal-macros.h"
 #endif
 
 #endif // LLVM_LIBC_MACROS_SIGNAL_MACROS_H

--- a/libc/include/llvm-libc-types/struct_sigaction.h
+++ b/libc/include/llvm-libc-types/struct_sigaction.h
@@ -17,7 +17,7 @@ struct sigaction {
     void (*sa_handler)(int);
     void (*sa_sigaction)(int, siginfo_t *, void *);
   };
-  sigset_t sa_mask;
+  struct sigset_t sa_mask;
   int sa_flags;
 #ifdef __linux__
   // This field is present on linux for most targets.


### PR DESCRIPTION
Summary:
This header is practically useless, but we provide it mostly for the
macros so that applications can compile. I'm only doing this for the
`libc++` unittests that want it, and it is part of the C standard
technically. I just made an RPC call to do `raise`. Anything more isn't
going to work since it'd be way too annoying to make the CPU call into
some signal handler the GPU registered.
