### PR TITLE
[libcxx] Add fallback to standard C when `unistd` is unavailable

### DIFF
--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -83,7 +83,7 @@ inline std::string get_temp_file_name() {
     abort();
   if (fclose(file) == EOF)
     abort();
-  return std::string(filename);
+  return std::string(Name);
 #else
   std::string Name = "libcxx.XXXXXX";
   int FD           = mkstemp(&Name[0]);

--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -40,8 +40,8 @@
 #   include <io.h> // _mktemp_s
 #   include <fcntl.h> // _O_EXCL, ...
 #   include <sys/stat.h> // _S_IREAD, ...
-#else
-#   include <unistd.h> // close
+#elif __has_include(<unistd.h>)
+#  include <unistd.h> // close
 #endif
 
 #if defined(_CS_GNU_LIBC_VERSION)
@@ -55,31 +55,41 @@ extern "C" {
 }
 #endif
 
-inline
-std::string get_temp_file_name()
-{
+inline std::string get_temp_file_name() {
 #if defined(_WIN32)
-    while (true) {
-        char Name[] = "libcxx.XXXXXX";
-        if (_mktemp_s(Name, sizeof(Name)) != 0) abort();
-        int fd = _open(Name, _O_RDWR | _O_CREAT | _O_EXCL, _S_IREAD | _S_IWRITE);
-        if (fd != -1) {
-            _close(fd);
-            return Name;
-        }
-        if (errno == EEXIST)
-            continue;
-        abort();
+  while (true) {
+    char Name[] = "libcxx.XXXXXX";
+    if (_mktemp_s(Name, sizeof(Name)) != 0)
+      abort();
+    int fd = _open(Name, _O_RDWR | _O_CREAT | _O_EXCL, _S_IREAD | _S_IWRITE);
+    if (fd != -1) {
+      _close(fd);
+      return Name;
     }
+    if (errno == EEXIST)
+      continue;
+    abort();
+  }
+#elif !__has_include(<unistd.h>)
+  char buffer[L_tmpnam];
+  char* filename = tmpnam(buffer);
+  if (!filename)
+    abort();
+  FILE* file = fopen(filename, "w");
+  if (!file)
+    abort();
+  if (fclose(file) == EOF)
+    abort();
+  return std::string(filename);
 #else
-    std::string Name = "libcxx.XXXXXX";
-    int FD = mkstemp(&Name[0]);
-    if (FD == -1) {
-        perror("mkstemp");
-        abort();
-    }
-    close(FD);
-    return Name;
+  std::string Name = "libcxx.XXXXXX";
+  int FD           = mkstemp(&Name[0]);
+  if (FD == -1) {
+    perror("mkstemp");
+    abort();
+  }
+  close(FD);
+  return Name;
 #endif
 }
 

--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -71,7 +71,7 @@ inline std::string get_temp_file_name() {
     abort();
   }
 #elif !__has_include(<unistd.h>)
-  // Without `unistd.h` we cannot guarnatee that the file is unused, however we
+  // Without `unistd.h` we cannot guarantee that the file is unused, however we
   // can simply generate a good guess in the temporary folder and create it.
   constexpr char chars[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   char Name[]            = "/tmp/libcxx.XXXXXX";

--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -75,7 +75,7 @@ inline std::string get_temp_file_name() {
   // can simply generate a good guess in the temporary folder and create it.
   constexpr char chars[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   char Name[]            = "/tmp/libcxx.XXXXXX";
-  for (int i = 0; i < sizeof(Name); ++i)
+  for (std::size_t i = 0; i < sizeof(Name); ++i)
     if (Name[i] == 'X')
       Name[i] = chars[rand() % strlen(chars)];
   FILE* file = fopen(filename, "w");

--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -71,10 +71,13 @@ inline std::string get_temp_file_name() {
     abort();
   }
 #elif !__has_include(<unistd.h>)
-  char buffer[L_tmpnam];
-  char* filename = tmpnam(buffer);
-  if (!filename)
-    abort();
+  // Without `unistd.h` we cannot guarnatee that the file is unused, however we
+  // can simply generate a good guess in the temporary folder and create it.
+  constexpr char chars[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  char Name[]            = "/tmp/libcxx.XXXXXX";
+  for (int i = 0; i < sizeof(Name); ++i)
+    if (Name[i] == 'X')
+      Name[i] = chars[rand() % strlen(chars)];
   FILE* file = fopen(filename, "w");
   if (!file)
     abort();


### PR DESCRIPTION
Summary:
This utility function gets a temp file to use for tests. It either uses
WIN32 or POSIX to create it. Some targets only follow the C standard,
and this test case will fail. This patch simply adds a fallback that
uses the `tmpnam` function from standard C. This function isn't ideal,
but it is good enough for our use-case.
