### PR TITLE
[libc][startup] fix main thread TLS unmapped with wrong value

### DIFF
--- a/libc/startup/linux/do_start.cpp
+++ b/libc/startup/linux/do_start.cpp
@@ -133,7 +133,7 @@ static ThreadAttributes main_thread_attrib;
   // We register the cleanup_tls function to be the last atexit callback to be
   // invoked. It will tear down the TLS. Other callbacks may depend on TLS (such
   // as the stack protector canary).
-  atexit([]() { cleanup_tls(tls.tp, tls.size); });
+  atexit([]() { cleanup_tls(tls.addr, tls.size); });
   // We want the fini array callbacks to be run after other atexit
   // callbacks are run. So, we register them before running the init
   // array callbacks as they can potentially register their own atexit


### PR DESCRIPTION
We have been unmapping a wrong address all the time.
```c
munmap(0x704cffebb000, 41048)           = 0
munmap(0x704cffec6000, 69632)           = 0
munmap(0x704cffe9f000, 41048)           = 0
munmap(0x704cffeaa000, 69632)           = 0
munmap(0x704cffe83000, 41048)           = 0
munmap(0x704cffe8e000, 69632)           = 0
munmap(0x704cffe67000, 41048)           = 0
munmap(0x704cffe72000, 69632)           = 0
munmap(0x704cffe4b000, 41048)           = 0
munmap(0x704cffe56000, 69632)           = 0
munmap(0x704cffe2f000, 41048)           = 0
munmap(0x704cffe3a000, 69632)           = 0
munmap(0x704cfff51028, 41048)           = -1 EINVAL (Invalid argument)
```