### PR TITLE
[libc] Allow time conversions to compile on bare metal

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -201,7 +201,12 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.strtoull
 
     # time.h entrypoints
+    libc.src.time.asctime
+    libc.src.time.asctime_r
     libc.src.time.difftime
+    libc.src.time.gmtime
+    libc.src.time.gmtime_r
+    libc.src.time.mktime
 
     # internal entrypoints
     libc.startup.baremetal.init

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -197,7 +197,12 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.strtoull
 
     # time.h entrypoints
+    libc.src.time.asctime
+    libc.src.time.asctime_r
     libc.src.time.difftime
+    libc.src.time.gmtime
+    libc.src.time.gmtime_r
+    libc.src.time.mktime
 
     # internal entrypoints
     libc.startup.baremetal.init

--- a/libc/src/time/time_utils.h
+++ b/libc/src/time/time_utils.h
@@ -92,7 +92,12 @@ extern int64_t update_from_seconds(int64_t total_seconds, struct tm *tm);
 
 // POSIX.1-2017 requires this.
 LIBC_INLINE time_t out_of_range() {
+#ifdef EOVERFLOW
+  // For non-POSIX uses of the standard C time functions, where EOVERFLOW is
+  // not defined, it's OK not to set errno at all. The plain C standard doesn't
+  // require it.
   libc_errno = EOVERFLOW;
+#endif
   return TimeConstants::OUT_OF_RANGE_RETURN_VALUE;
 }
 


### PR DESCRIPTION
The `<time.h>` functions `asctime`, `gmtime`, `mktime` and their `_r` variants are purely computational functions which convert between well defined time representations and/or strings. There's no reason these shouldn't be available in bare-metal builds of the library as well as hosted ones: even if the library has no way to find out the time in POSIX format, it might still see POSIX-style `time_t` values in input data (e.g. network protocols) and need to interpret them.

The only obstacle to this was that the `out_of_range()` helper function set `errno` to `EOVERFLOW`, which fails in a bare-metal build because the extra POSIX error values aren't defined, including `EOVERFLOW`. So I've made that assignment conditional on `EOVERFLOW` being defined.

-------------------------

Fixes https://github.com/llvm/llvm-project/issues/85556