### PR TITLE
[DebugInfo][RemoveDIs] Use iterator-insertion in unittests and fuzzer

### DIFF
--- a/llvm/include/llvm/FuzzMutate/OpDescriptor.h
+++ b/llvm/include/llvm/FuzzMutate/OpDescriptor.h
@@ -89,7 +89,7 @@ public:
 struct OpDescriptor {
   unsigned Weight;
   SmallVector<SourcePred, 2> SourcePreds;
-  std::function<Value *(ArrayRef<Value *>, Instruction *)> BuilderFunc;
+  std::function<Value *(ArrayRef<Value *>, BasicBlock::iterator)> BuilderFunc;
 };
 
 static inline SourcePred onlyType(Type *Only) {

--- a/llvm/lib/FuzzMutate/Operations.cpp
+++ b/llvm/lib/FuzzMutate/Operations.cpp
@@ -98,8 +98,8 @@ void llvm::describeFuzzerVectorOps(std::vector<fuzzerop::OpDescriptor> &Ops) {
 }
 
 OpDescriptor llvm::fuzzerop::selectDescriptor(unsigned Weight) {
-  auto buildOp = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    return SelectInst::Create(Srcs[0], Srcs[1], Srcs[2], "S", Inst);
+  auto buildOp = [](ArrayRef<Value *> Srcs, BasicBlock::iterator InsertPt) {
+    return SelectInst::Create(Srcs[0], Srcs[1], Srcs[2], "S", InsertPt);
   };
   return {Weight,
           {boolOrVecBoolType(), matchFirstLengthWAnyType(), matchSecondType()},
@@ -107,16 +107,16 @@ OpDescriptor llvm::fuzzerop::selectDescriptor(unsigned Weight) {
 }
 
 OpDescriptor llvm::fuzzerop::fnegDescriptor(unsigned Weight) {
-  auto buildOp = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    return UnaryOperator::Create(Instruction::FNeg, Srcs[0], "F", Inst);
+  auto buildOp = [](ArrayRef<Value *> Srcs, BasicBlock::iterator InsertPt) {
+    return UnaryOperator::Create(Instruction::FNeg, Srcs[0], "F", InsertPt);
   };
   return {Weight, {anyFloatOrVecFloatType()}, buildOp};
 }
 
 OpDescriptor llvm::fuzzerop::binOpDescriptor(unsigned Weight,
                                              Instruction::BinaryOps Op) {
-  auto buildOp = [Op](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    return BinaryOperator::Create(Op, Srcs[0], Srcs[1], "B", Inst);
+  auto buildOp = [Op](ArrayRef<Value *> Srcs, BasicBlock::iterator InsertPt) {
+    return BinaryOperator::Create(Op, Srcs[0], Srcs[1], "B", InsertPt);
   };
   switch (Op) {
   case Instruction::Add:
@@ -148,8 +148,9 @@ OpDescriptor llvm::fuzzerop::binOpDescriptor(unsigned Weight,
 OpDescriptor llvm::fuzzerop::cmpOpDescriptor(unsigned Weight,
                                              Instruction::OtherOps CmpOp,
                                              CmpInst::Predicate Pred) {
-  auto buildOp = [CmpOp, Pred](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    return CmpInst::Create(CmpOp, Pred, Srcs[0], Srcs[1], "C", Inst);
+  auto buildOp = [CmpOp, Pred](ArrayRef<Value *> Srcs,
+                               BasicBlock::iterator InsertPt) {
+    return CmpInst::Create(CmpOp, Pred, Srcs[0], Srcs[1], "C", InsertPt);
   };
 
   switch (CmpOp) {
@@ -163,9 +164,10 @@ OpDescriptor llvm::fuzzerop::cmpOpDescriptor(unsigned Weight,
 }
 
 OpDescriptor llvm::fuzzerop::splitBlockDescriptor(unsigned Weight) {
-  auto buildSplitBlock = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    BasicBlock *Block = Inst->getParent();
-    BasicBlock *Next = Block->splitBasicBlock(Inst, "BB");
+  auto buildSplitBlock = [](ArrayRef<Value *> Srcs,
+                            BasicBlock::iterator InsertPt) {
+    BasicBlock *Block = InsertPt->getParent();
+    BasicBlock *Next = Block->splitBasicBlock(InsertPt, "BB");
 
     // If it was an exception handling block, we are done.
     if (Block->isEHPad())
@@ -174,7 +176,8 @@ OpDescriptor llvm::fuzzerop::splitBlockDescriptor(unsigned Weight) {
     // Loop back on this block by replacing the unconditional forward branch
     // with a conditional with a backedge.
     if (Block != &Block->getParent()->getEntryBlock()) {
-      BranchInst::Create(Block, Next, Srcs[0], Block->getTerminator());
+      BranchInst::Create(Block, Next, Srcs[0],
+                         Block->getTerminator()->getIterator());
       Block->getTerminator()->eraseFromParent();
 
       // We need values for each phi in the block. Since there isn't a good way
@@ -193,12 +196,12 @@ OpDescriptor llvm::fuzzerop::splitBlockDescriptor(unsigned Weight) {
 }
 
 OpDescriptor llvm::fuzzerop::gepDescriptor(unsigned Weight) {
-  auto buildGEP = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
+  auto buildGEP = [](ArrayRef<Value *> Srcs, BasicBlock::iterator InsertPt) {
     // TODO: It would be better to generate a random type here, rather than
     // generating a random value and picking its type.
     Type *Ty = Srcs[1]->getType();
     auto Indices = ArrayRef(Srcs).drop_front(2);
-    return GetElementPtrInst::Create(Ty, Srcs[0], Indices, "G", Inst);
+    return GetElementPtrInst::Create(Ty, Srcs[0], Indices, "G", InsertPt);
   };
   // TODO: Handle aggregates and vectors
   // TODO: Support multiple indices.
@@ -239,10 +242,11 @@ static SourcePred validExtractValueIndex() {
 }
 
 OpDescriptor llvm::fuzzerop::extractValueDescriptor(unsigned Weight) {
-  auto buildExtract = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
+  auto buildExtract = [](ArrayRef<Value *> Srcs,
+                         BasicBlock::iterator InsertPt) {
     // TODO: It's pretty inefficient to shuffle this all through constants.
     unsigned Idx = cast<ConstantInt>(Srcs[1])->getZExtValue();
-    return ExtractValueInst::Create(Srcs[0], {Idx}, "E", Inst);
+    return ExtractValueInst::Create(Srcs[0], {Idx}, "E", InsertPt);
   };
   // TODO: Should we handle multiple indices?
   return {Weight, {anyAggregateType(), validExtractValueIndex()}, buildExtract};
@@ -298,10 +302,10 @@ static SourcePred validInsertValueIndex() {
 }
 
 OpDescriptor llvm::fuzzerop::insertValueDescriptor(unsigned Weight) {
-  auto buildInsert = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
+  auto buildInsert = [](ArrayRef<Value *> Srcs, BasicBlock::iterator InsertPt) {
     // TODO: It's pretty inefficient to shuffle this all through constants.
     unsigned Idx = cast<ConstantInt>(Srcs[2])->getZExtValue();
-    return InsertValueInst::Create(Srcs[0], Srcs[1], {Idx}, "I", Inst);
+    return InsertValueInst::Create(Srcs[0], Srcs[1], {Idx}, "I", InsertPt);
   };
   return {
       Weight,
@@ -310,16 +314,17 @@ OpDescriptor llvm::fuzzerop::insertValueDescriptor(unsigned Weight) {
 }
 
 OpDescriptor llvm::fuzzerop::extractElementDescriptor(unsigned Weight) {
-  auto buildExtract = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    return ExtractElementInst::Create(Srcs[0], Srcs[1], "E", Inst);
+  auto buildExtract = [](ArrayRef<Value *> Srcs,
+                         BasicBlock::iterator InsertPt) {
+    return ExtractElementInst::Create(Srcs[0], Srcs[1], "E", InsertPt);
   };
   // TODO: Try to avoid undefined accesses.
   return {Weight, {anyVectorType(), anyIntType()}, buildExtract};
 }
 
 OpDescriptor llvm::fuzzerop::insertElementDescriptor(unsigned Weight) {
-  auto buildInsert = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    return InsertElementInst::Create(Srcs[0], Srcs[1], Srcs[2], "I", Inst);
+  auto buildInsert = [](ArrayRef<Value *> Srcs, BasicBlock::iterator InsertPt) {
+    return InsertElementInst::Create(Srcs[0], Srcs[1], Srcs[2], "I", InsertPt);
   };
   // TODO: Try to avoid undefined accesses.
   return {Weight,
@@ -343,8 +348,9 @@ static SourcePred validShuffleVectorIndex() {
 }
 
 OpDescriptor llvm::fuzzerop::shuffleVectorDescriptor(unsigned Weight) {
-  auto buildShuffle = [](ArrayRef<Value *> Srcs, Instruction *Inst) {
-    return new ShuffleVectorInst(Srcs[0], Srcs[1], Srcs[2], "S", Inst);
+  auto buildShuffle = [](ArrayRef<Value *> Srcs,
+                         BasicBlock::iterator InsertPt) {
+    return new ShuffleVectorInst(Srcs[0], Srcs[1], Srcs[2], "S", InsertPt);
   };
   return {Weight,
           {anyVectorType(), matchFirstType(), validShuffleVectorIndex()},

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
@@ -88,7 +88,8 @@ static void maybeRewriteCallWithDifferentBundles(
             });
 
   // Finally actually replace the bundles on the call.
-  CallBase *NewCall = CallBase::Create(OrigCall, NewBundles, OrigCall);
+  CallBase *NewCall =
+      CallBase::Create(OrigCall, NewBundles, OrigCall->getIterator());
   OrigCall->replaceAllUsesWith(NewCall);
   OrigCall->eraseFromParent();
 }

--- a/llvm/unittests/Analysis/CGSCCPassManagerTest.cpp
+++ b/llvm/unittests/Analysis/CGSCCPassManagerTest.cpp
@@ -1205,7 +1205,7 @@ TEST_F(CGSCCPassManagerTest, TestAnalysisInvalidationCGSCCUpdate) {
         // Insert a bitcast of `h3` so that we retain a ref edge to it.
         (void)CastInst::CreatePointerCast(
             &H3F, PointerType::getUnqual(H2F.getContext()), "dummy",
-            &*H2F.begin()->begin());
+            H2F.begin()->begin());
 
         // Now update the call graph.
         auto &NewC =
@@ -1251,7 +1251,7 @@ TEST_F(CGSCCPassManagerTest, TestAnalysisInvalidationCGSCCUpdate) {
         assert(H3F.getName() == "h3" && "Wrong called function!");
         H2F.begin()->begin()->eraseFromParent();
         // And insert a call to `h3`.
-        (void)CallInst::Create(&H3F, {}, "", &*H2F.begin()->begin());
+        (void)CallInst::Create(&H3F, {}, "", H2F.begin()->begin());
 
         // Now update the call graph.
         auto &NewC =
@@ -1359,7 +1359,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses0) {
         ASSERT_NE(FnH3, nullptr);
 
         // And insert a call to `h1`, `h2`, and `h3`.
-        Instruction *IP = &FnH2->getEntryBlock().front();
+        BasicBlock::iterator IP = FnH2->getEntryBlock().begin();
         (void)CallInst::Create(FnH1, {}, "", IP);
         (void)CallInst::Create(FnH2, {}, "", IP);
         (void)CallInst::Create(FnH3, {}, "", IP);
@@ -1396,7 +1396,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses1) {
     ASSERT_NE(FnH3, nullptr);
 
     // And insert a call to `h1`, `h2`, and `h3`.
-    Instruction *IP = &FnH2->getEntryBlock().front();
+    BasicBlock::iterator IP = FnH2->getEntryBlock().begin();
     (void)CallInst::Create(FnH1, {}, "", IP);
     (void)CallInst::Create(FnH2, {}, "", IP);
     (void)CallInst::Create(FnH3, {}, "", IP);
@@ -1429,7 +1429,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses2) {
         ASSERT_NE(FnH2, nullptr);
 
         // And insert a call to `h2`
-        Instruction *IP = &FnF->getEntryBlock().front();
+        BasicBlock::iterator IP = FnF->getEntryBlock().begin();
         (void)CallInst::Create(FnH2, {}, "", IP);
 
         auto &FN = *llvm::find_if(
@@ -1460,7 +1460,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses3) {
     ASSERT_NE(FnH2, nullptr);
 
     // And insert a call to `h2`
-    Instruction *IP = &FnF->getEntryBlock().front();
+    BasicBlock::iterator IP = FnF->getEntryBlock().begin();
     (void)CallInst::Create(FnH2, {}, "", IP);
 
     auto &FN = *llvm::find_if(
@@ -1492,7 +1492,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses4) {
         ReturnInst::Create(FnewF->getContext(), BB);
 
         // And insert a call to `newF`
-        Instruction *IP = &FnF->getEntryBlock().front();
+        BasicBlock::iterator IP = FnF->getEntryBlock().begin();
         (void)CallInst::Create(FnewF, {}, "", IP);
 
         // Use the CallGraphUpdater to update the call graph for the new
@@ -1536,7 +1536,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses5) {
     CGU.initialize(CG, C, AM, UR);
 
     // And insert a call to `newF`
-    Instruction *IP = &FnF->getEntryBlock().front();
+    BasicBlock::iterator IP = FnF->getEntryBlock().begin();
     (void)CallInst::Create(FnewF, {}, "", IP);
 
     auto &FN = *llvm::find_if(
@@ -1569,7 +1569,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses6) {
         ASSERT_NE(FnH3, nullptr);
 
         // And insert a call to `h1`, `h2`, and `h3`.
-        Instruction *IP = &FnH2->getEntryBlock().front();
+        BasicBlock::iterator IP = FnH2->getEntryBlock().begin();
         (void)CallInst::Create(FnH1, {}, "", IP);
         (void)CallInst::Create(FnH2, {}, "", IP);
         (void)CallInst::Create(FnH3, {}, "", IP);
@@ -1600,7 +1600,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses7) {
         ASSERT_NE(FnH2, nullptr);
 
         // And insert a call to `h2`
-        Instruction *IP = &FnF->getEntryBlock().front();
+        BasicBlock::iterator IP = FnF->getEntryBlock().begin();
         (void)CallInst::Create(FnH2, {}, "", IP);
 
         // Use the CallGraphUpdater to update the call graph for the new
@@ -1690,7 +1690,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses10) {
         ASSERT_NE(FnH3, nullptr);
 
         // And insert a call to `h1`, and `h3`.
-        Instruction *IP = &FnH1->getEntryBlock().front();
+        BasicBlock::iterator IP = FnH1->getEntryBlock().begin();
         (void)CallInst::Create(FnH1, {}, "", IP);
         (void)CallInst::Create(FnH3, {}, "", IP);
 
@@ -1763,11 +1763,11 @@ TEST_F(CGSCCPassManagerTest, TestInsertionOfNewFunctions1) {
           // 2. Insert a ref edge from 'f' to 'f'.
           (void)CastInst::CreatePointerCast(
               &F, PointerType::getUnqual(F.getContext()), "f.ref",
-              &F.getEntryBlock().front());
+              F.getEntryBlock().begin());
           // 3. Insert a ref edge from 'f' to 'g'.
           (void)CastInst::CreatePointerCast(
               G, PointerType::getUnqual(F.getContext()), "g.ref",
-              &F.getEntryBlock().front());
+              F.getEntryBlock().begin());
 
           CG.addSplitFunction(F, *G);
 
@@ -1827,9 +1827,9 @@ TEST_F(CGSCCPassManagerTest, TestInsertionOfNewFunctions2) {
       (void)ReturnInst::Create(G2->getContext(), G2BB);
 
       // Add 'f -> g1' call edge.
-      (void)CallInst::Create(G1, {}, "", &F.getEntryBlock().front());
+      (void)CallInst::Create(G1, {}, "", F.getEntryBlock().begin());
       // Add 'f -> g2' call edge.
-      (void)CallInst::Create(G2, {}, "", &F.getEntryBlock().front());
+      (void)CallInst::Create(G2, {}, "", F.getEntryBlock().begin());
 
       CG.addSplitFunction(F, *G1);
       CG.addSplitFunction(F, *G2);
@@ -1853,11 +1853,11 @@ TEST_F(CGSCCPassManagerTest, TestInsertionOfNewFunctions2) {
       // Add 'f -> h1' ref edge.
       (void)CastInst::CreatePointerCast(H1,
                                         PointerType::getUnqual(F.getContext()),
-                                        "h1.ref", &F.getEntryBlock().front());
+                                        "h1.ref", F.getEntryBlock().begin());
       // Add 'f -> h2' ref edge.
       (void)CastInst::CreatePointerCast(H2,
                                         PointerType::getUnqual(F.getContext()),
-                                        "h2.ref", &F.getEntryBlock().front());
+                                        "h2.ref", F.getEntryBlock().begin());
 
       CG.addSplitRefRecursiveFunctions(F, SmallVector<Function *, 2>({H1, H2}));
 
@@ -1980,7 +1980,8 @@ TEST_F(CGSCCPassManagerTest, TestInsertionOfNewNonTrivialCallEdge) {
       ASSERT_TRUE(F3 != nullptr);
 
       // Create call from f1 to f3.
-      (void)CallInst::Create(F3, {}, "", F.getEntryBlock().getTerminator());
+      (void)CallInst::Create(F3, {}, "",
+                             F.getEntryBlock().getTerminator()->getIterator());
 
       ASSERT_NO_FATAL_FAILURE(
           updateCGAndAnalysisManagerForCGSCCPass(CG, C, *N, AM, UR, FAM))

--- a/llvm/unittests/Analysis/LazyCallGraphTest.cpp
+++ b/llvm/unittests/Analysis/LazyCallGraphTest.cpp
@@ -2357,7 +2357,7 @@ TEST(LazyCallGraphTest, AddSplitFunction1) {
   (void)ReturnInst::Create(Context, GBB);
 
   // Create f -call-> g.
-  (void)CallInst::Create(G, {}, "", &*F.getEntryBlock().begin());
+  (void)CallInst::Create(G, {}, "", F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2398,7 +2398,7 @@ TEST(LazyCallGraphTest, AddSplitFunction2) {
 
   // Create f -ref-> g.
   (void)CastInst::CreatePointerCast(G, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2441,7 +2441,7 @@ TEST(LazyCallGraphTest, AddSplitFunction3) {
   (void)ReturnInst::Create(Context, GBB);
 
   // Create f -call-> g.
-  (void)CallInst::Create(G, {}, "", &*F.getEntryBlock().begin());
+  (void)CallInst::Create(G, {}, "", F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2487,7 +2487,7 @@ TEST(LazyCallGraphTest, AddSplitFunction4) {
 
   // Create f -ref-> g.
   (void)CastInst::CreatePointerCast(G, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2533,7 +2533,7 @@ TEST(LazyCallGraphTest, AddSplitFunction5) {
 
   // Create f -ref-> g.
   (void)CastInst::CreatePointerCast(G, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2577,7 +2577,7 @@ TEST(LazyCallGraphTest, AddSplitFunction6) {
   (void)ReturnInst::Create(Context, GBB);
 
   // Create f -call-> g.
-  (void)CallInst::Create(G, {}, "", &*F.getEntryBlock().begin());
+  (void)CallInst::Create(G, {}, "", F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2628,7 +2628,7 @@ TEST(LazyCallGraphTest, AddSplitFunction7) {
   (void)ReturnInst::Create(Context, GBB);
 
   // Create f -call-> g.
-  (void)CallInst::Create(G, {}, "", &*F.getEntryBlock().begin());
+  (void)CallInst::Create(G, {}, "", F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2681,7 +2681,7 @@ TEST(LazyCallGraphTest, AddSplitFunction8) {
 
   // Create f -ref-> g.
   (void)CastInst::CreatePointerCast(G, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2734,7 +2734,7 @@ TEST(LazyCallGraphTest, AddSplitFunction9) {
   (void)ReturnInst::Create(Context, GBB);
 
   // Create f -call-> g.
-  (void)CallInst::Create(G, {}, "", &*F.getEntryBlock().begin());
+  (void)CallInst::Create(G, {}, "", F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2778,7 +2778,7 @@ TEST(LazyCallGraphTest, AddSplitFunctions1) {
 
   // Create f -ref-> g.
   (void)CastInst::CreatePointerCast(G, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2822,7 +2822,7 @@ TEST(LazyCallGraphTest, AddSplitFunctions2) {
 
   // Create f -ref-> g.
   (void)CastInst::CreatePointerCast(G, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2875,9 +2875,9 @@ TEST(LazyCallGraphTest, AddSplitFunctions3) {
 
   // Create f -ref-> g1 and f -ref-> g2.
   (void)CastInst::CreatePointerCast(G1, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
   (void)CastInst::CreatePointerCast(G2, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -2934,9 +2934,9 @@ TEST(LazyCallGraphTest, AddSplitFunctions4) {
 
   // Create f -ref-> g1 and f -ref-> g2.
   (void)CastInst::CreatePointerCast(G1, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
   (void)CastInst::CreatePointerCast(G2, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 
@@ -3004,9 +3004,9 @@ TEST(LazyCallGraphTest, AddSplitFunctions5) {
 
   // Create f -ref-> g1 and f -ref-> g2.
   (void)CastInst::CreatePointerCast(G1, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
   (void)CastInst::CreatePointerCast(G2, PointerType::getUnqual(Context), "",
-                                    &*F.getEntryBlock().begin());
+                                    F.getEntryBlock().begin());
 
   EXPECT_FALSE(verifyModule(*M, &errs()));
 

--- a/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
+++ b/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
@@ -137,7 +137,7 @@ TEST_F(ScalarEvolutionsTest, SimplifiedPHI) {
                      LoopBB);
   ReturnInst::Create(Context, nullptr, ExitBB);
   auto *Ty = Type::getInt32Ty(Context);
-  auto *PN = PHINode::Create(Ty, 2, "", &*LoopBB->begin());
+  auto *PN = PHINode::Create(Ty, 2, "", LoopBB->begin());
   PN->addIncoming(Constant::getNullValue(Ty), EntryBB);
   PN->addIncoming(UndefValue::get(Ty), LoopBB);
   ScalarEvolution SE = buildSE(*F);
@@ -930,10 +930,12 @@ TEST_F(ScalarEvolutionsTest, SCEVAddRecFromPHIwithLargeConstants) {
   auto *Int64_32 = ConstantInt::get(Context, APInt(64, 32));
   auto *Br = BranchInst::Create(
       LoopBB, ExitBB, UndefValue::get(Type::getInt1Ty(Context)), LoopBB);
-  auto *Phi = PHINode::Create(Type::getInt64Ty(Context), 2, "", Br);
-  auto *Shl = BinaryOperator::CreateShl(Phi, Int64_32, "", Br);
-  auto *AShr = BinaryOperator::CreateExactAShr(Shl, Int64_32, "", Br);
-  auto *Add = BinaryOperator::CreateAdd(AShr, MinInt64, "", Br);
+  auto *Phi =
+      PHINode::Create(Type::getInt64Ty(Context), 2, "", Br->getIterator());
+  auto *Shl = BinaryOperator::CreateShl(Phi, Int64_32, "", Br->getIterator());
+  auto *AShr =
+      BinaryOperator::CreateExactAShr(Shl, Int64_32, "", Br->getIterator());
+  auto *Add = BinaryOperator::CreateAdd(AShr, MinInt64, "", Br->getIterator());
   Phi->addIncoming(MinInt64, EntryBB);
   Phi->addIncoming(Add, LoopBB);
   // exit:
@@ -986,10 +988,11 @@ TEST_F(ScalarEvolutionsTest, SCEVAddRecFromPHIwithLargeConstantAccum) {
   auto *Int32_16 = ConstantInt::get(Context, APInt(32, 16));
   auto *Br = BranchInst::Create(
       LoopBB, ExitBB, UndefValue::get(Type::getInt1Ty(Context)), LoopBB);
-  auto *Phi = PHINode::Create(Int32Ty, 2, "", Br);
-  auto *Shl = BinaryOperator::CreateShl(Phi, Int32_16, "", Br);
-  auto *AShr = BinaryOperator::CreateExactAShr(Shl, Int32_16, "", Br);
-  auto *Add = BinaryOperator::CreateAdd(AShr, MinInt32, "", Br);
+  auto *Phi = PHINode::Create(Int32Ty, 2, "", Br->getIterator());
+  auto *Shl = BinaryOperator::CreateShl(Phi, Int32_16, "", Br->getIterator());
+  auto *AShr =
+      BinaryOperator::CreateExactAShr(Shl, Int32_16, "", Br->getIterator());
+  auto *Add = BinaryOperator::CreateAdd(AShr, MinInt32, "", Br->getIterator());
   auto *Arg = &*(F->arg_begin());
   Phi->addIncoming(Arg, EntryBB);
   Phi->addIncoming(Add, LoopBB);

--- a/llvm/unittests/FuzzMutate/OperationsTest.cpp
+++ b/llvm/unittests/FuzzMutate/OperationsTest.cpp
@@ -261,7 +261,7 @@ TEST(OperationsTest, SplitBlock) {
   // Create a block with only a return and split it on the return.
   auto *BB = BasicBlock::Create(Ctx, "BB", F);
   auto *RI = ReturnInst::Create(Ctx, BB);
-  SBOp.BuilderFunc({UndefValue::get(Type::getInt1Ty(Ctx))}, RI);
+  SBOp.BuilderFunc({UndefValue::get(Type::getInt1Ty(Ctx))}, RI->getIterator());
 
   // We should end up with an unconditional branch from BB to BB1, and the
   // return ends up in BB1.
@@ -271,9 +271,9 @@ TEST(OperationsTest, SplitBlock) {
   ASSERT_THAT(RI->getParent(), Eq(BB1));
 
   // Now add an instruction to BB1 and split on that.
-  auto *AI = new AllocaInst(Type::getInt8Ty(Ctx), 0, "a", RI);
+  auto *AI = new AllocaInst(Type::getInt8Ty(Ctx), 0, "a", RI->getIterator());
   Value *Cond = ConstantInt::getFalse(Ctx);
-  SBOp.BuilderFunc({Cond}, AI);
+  SBOp.BuilderFunc({Cond}, AI->getIterator());
 
   // We should end up with a loop back on BB1 and the instruction we split on
   // moves to BB2.
@@ -313,7 +313,7 @@ TEST(OperationsTest, SplitEHBlock) {
 
   fuzzerop::OpDescriptor Descr = fuzzerop::splitBlockDescriptor(1);
 
-  Descr.BuilderFunc({ConstantInt::getTrue(Ctx)}, &*BB.getFirstInsertionPt());
+  Descr.BuilderFunc({ConstantInt::getTrue(Ctx)}, BB.getFirstInsertionPt());
   ASSERT_TRUE(!verifyModule(*M, &errs()));
 }
 
@@ -346,7 +346,7 @@ TEST(OperationsTest, SplitBlockWithPhis) {
 
   // Now we split the block with PHI nodes, making sure they're all updated.
   Value *Cond = ConstantInt::getFalse(Ctx);
-  SBOp.BuilderFunc({Cond}, RI);
+  SBOp.BuilderFunc({Cond}, RI->getIterator());
 
   // Make sure the PHIs are updated with a value for the third incoming edge.
   EXPECT_THAT(PHI1->getNumIncomingValues(), Eq(3u));
@@ -373,7 +373,7 @@ TEST(OperationsTest, GEP) {
                                            ConstantInt::get(Int32Ty, 0)));
 
   GEPOp.BuilderFunc({UndefValue::get(Int8PtrTy), ConstantInt::get(Int32Ty, 0)},
-                    RI);
+                    RI->getIterator());
   EXPECT_FALSE(verifyModule(M, &errs()));
 }
 

--- a/llvm/unittests/IR/BasicBlockTest.cpp
+++ b/llvm/unittests/IR/BasicBlockTest.cpp
@@ -49,12 +49,15 @@ TEST(BasicBlockTest, PhiRange) {
 
   // Now insert some PHI nodes.
   auto *Int32Ty = Type::getInt32Ty(Context);
-  auto *P1 = PHINode::Create(Int32Ty, /*NumReservedValues*/ 3, "phi.1", BI);
-  auto *P2 = PHINode::Create(Int32Ty, /*NumReservedValues*/ 3, "phi.2", BI);
-  auto *P3 = PHINode::Create(Int32Ty, /*NumReservedValues*/ 3, "phi.3", BI);
+  auto *P1 = PHINode::Create(Int32Ty, /*NumReservedValues*/ 3, "phi.1",
+                             BI->getIterator());
+  auto *P2 = PHINode::Create(Int32Ty, /*NumReservedValues*/ 3, "phi.2",
+                             BI->getIterator());
+  auto *P3 = PHINode::Create(Int32Ty, /*NumReservedValues*/ 3, "phi.3",
+                             BI->getIterator());
 
   // Some non-PHI nodes.
-  auto *Sum = BinaryOperator::CreateAdd(P1, P2, "sum", BI);
+  auto *Sum = BinaryOperator::CreateAdd(P1, P2, "sum", BI->getIterator());
 
   // Now wire up the incoming values that are interesting.
   P1->addIncoming(P2, BB.get());

--- a/llvm/unittests/Transforms/Utils/ScalarEvolutionExpanderTest.cpp
+++ b/llvm/unittests/Transforms/Utils/ScalarEvolutionExpanderTest.cpp
@@ -99,22 +99,24 @@ TEST_F(ScalarEvolutionExpanderTest, ExpandPtrTypeSCEV) {
   const DataLayout &DL = F->getDataLayout();
   BranchInst *Br = BranchInst::Create(
       LoopBB, ExitBB, UndefValue::get(Type::getInt1Ty(Context)), LoopBB);
-  AllocaInst *Alloca =
-      new AllocaInst(I32Ty, DL.getAllocaAddrSpace(), "alloca", Br);
+  AllocaInst *Alloca = new AllocaInst(I32Ty, DL.getAllocaAddrSpace(), "alloca",
+                                      Br->getIterator());
   ConstantInt *Ci32 = ConstantInt::get(Context, APInt(32, 1));
   GetElementPtrInst *Gep0 =
-      GetElementPtrInst::Create(I32Ty, Alloca, Ci32, "gep0", Br);
-  CastInst *CastA =
-      CastInst::CreateBitOrPointerCast(Gep0, I8PtrTy, "bitcast1", Br);
+      GetElementPtrInst::Create(I32Ty, Alloca, Ci32, "gep0", Br->getIterator());
+  CastInst *CastA = CastInst::CreateBitOrPointerCast(Gep0, I8PtrTy, "bitcast1",
+                                                     Br->getIterator());
   GetElementPtrInst *Gep1 =
-      GetElementPtrInst::Create(I8Ty, CastA, Ci32, "gep1", Br);
+      GetElementPtrInst::Create(I8Ty, CastA, Ci32, "gep1", Br->getIterator());
   GetElementPtrInst *Gep2 = GetElementPtrInst::Create(
-      I8Ty, UndefValue::get(I8PtrTy), Ci32, "gep2", Br);
+      I8Ty, UndefValue::get(I8PtrTy), Ci32, "gep2", Br->getIterator());
   CmpInst *Cmp = CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_ULT,
-                                 UndefValue::get(I8PtrTy), CastA, "cmp", Br);
-  SelectInst *Sel = SelectInst::Create(Cmp, Gep1, Gep2, "select", Br);
-  CastInst *CastB =
-      CastInst::CreateBitOrPointerCast(Sel, I32PtrTy, "bitcast2", Br);
+                                 UndefValue::get(I8PtrTy), CastA, "cmp",
+                                 Br->getIterator());
+  SelectInst *Sel =
+      SelectInst::Create(Cmp, Gep1, Gep2, "select", Br->getIterator());
+  CastInst *CastB = CastInst::CreateBitOrPointerCast(Sel, I32PtrTy, "bitcast2",
+                                                     Br->getIterator());
 
   ScalarEvolution SE = buildSE(*F);
   auto *S = SE.getSCEV(CastB);


### PR DESCRIPTION
These are the final few places in LLVM that use instruction pointers to insert instructions -- use iterators instead, which is needed for debug-info correctness in the future. Most of this is a gentle scattering of getIterator calls or not deref-then-addrofing iterators. libfuzzer does require a storage change to keep built instruction positions in a container though. The unit-test changes are very straightforwards.

This leaves us in a position where libfuzzer can't fuzz on either of debug-info records, however I don't believe that fuzzing of debug-info is in scope for the library.