### PR TITLE
[libc] Add `lgamma` and `lgamma_r` stubs for the GPU

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -349,6 +349,8 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.tanhf
     libc.src.math.tgamma
     libc.src.math.tgammaf
+    libc.src.math.lgamma
+    libc.src.math.lgamma_r
     libc.src.math.trunc
     libc.src.math.truncf
 )

--- a/libc/newhdrgen/yaml/math.yaml
+++ b/libc/newhdrgen/yaml/math.yaml
@@ -2153,3 +2153,42 @@ functions:
       - type: int
       - type: unsigned int
     guard: LIBC_TYPES_HAS_FLOAT128
+  - name: lgamma
+    standards: 
+      - stdc
+    return_type: double
+    arguments:
+      - type: double
+  - name: lgammaf
+    standards: 
+      - stdc
+    return_type: float
+    arguments:
+      - type: float
+  - name: lgammal
+    standards: 
+      - stdc
+    return_type: long double
+    arguments:
+      - type: long double
+  - name: lgamma_r
+    standards: 
+      - gnu
+    return_type: double
+    arguments:
+      - type: double
+      - type: int *
+  - name: lgammaf_r
+    standards: 
+      - gnu
+    return_type: float
+    arguments:
+      - type: float
+      - type: int *
+  - name: lgammal_r
+    standards: 
+      - gnu
+    return_type: long double
+    arguments:
+      - type: long double
+      - type: int *

--- a/libc/spec/gnu_ext.td
+++ b/libc/spec/gnu_ext.td
@@ -33,6 +33,21 @@ def GnuExtensions : StandardSpec<"GNUExtensions"> {
             RetValSpec<VoidType>,
             [ArgSpec<FloatType>, ArgSpec<FloatPtr>, ArgSpec<FloatPtr>]
         >,
+        FunctionSpec<
+            "lgamma_r",
+            RetValSpec<DoubleType>,
+            [ArgSpec<DoubleType, IntPtr>]
+        >,
+        FunctionSpec<
+            "lgammaf_r",
+            RetValSpec<FloatType>,
+            [ArgSpec<FloatType, IntPtr>]
+        >,
+        FunctionSpec<
+            "lgammal_r",
+            RetValSpec<LongDoubleType>,
+            [ArgSpec<LongDoubleType, IntPtr>]
+        >,
       ]
   >;
 

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -767,6 +767,10 @@ def StdC : StandardSpec<"stdc"> {
           GuardedFunctionSpec<"f16divf128", RetValSpec<Float16Type>, [ArgSpec<Float128Type>, ArgSpec<Float128Type>], "LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128">,
 
           GuardedFunctionSpec<"f16sqrtf128", RetValSpec<Float16Type>, [ArgSpec<Float128Type>], "LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128">,
+
+          FunctionSpec<"lgamma", RetValSpec<DoubleType>, [ArgSpec<DoubleType>]>,
+          FunctionSpec<"lgammaf", RetValSpec<FloatType>, [ArgSpec<FloatType>]>,
+          FunctionSpec<"lgammal", RetValSpec<LongDoubleType>, [ArgSpec<LongDoubleType>]>,
       ]
   >;
 

--- a/libc/src/math/CMakeLists.txt
+++ b/libc/src/math/CMakeLists.txt
@@ -448,6 +448,8 @@ add_math_entrypoint_object(tanhf)
 
 add_math_entrypoint_object(tgamma)
 add_math_entrypoint_object(tgammaf)
+add_math_entrypoint_object(lgamma)
+add_math_entrypoint_object(lgamma_r)
 
 add_math_entrypoint_object(totalorder)
 add_math_entrypoint_object(totalorderf)

--- a/libc/src/math/amdgpu/CMakeLists.txt
+++ b/libc/src/math/amdgpu/CMakeLists.txt
@@ -527,3 +527,27 @@ add_entrypoint_object(
     -O2
   VENDOR
 )
+
+add_entrypoint_object(
+  lgamma
+  SRCS
+    lgamma.cpp
+  HDRS
+    ../lgamma.h
+  COMPILE_OPTIONS
+    ${bitcode_link_flags}
+    -O2
+  VENDOR
+)
+
+add_entrypoint_object(
+  lgamma_r
+  SRCS
+    lgamma_r.cpp
+  HDRS
+    ../lgamma_r.h
+  COMPILE_OPTIONS
+    ${bitcode_link_flags}
+    -O2
+  VENDOR
+)

--- a/libc/src/math/amdgpu/declarations.h
+++ b/libc/src/math/amdgpu/declarations.h
@@ -82,6 +82,8 @@ float __ocml_remquo_f32(float, float, gpu::Private<int> *);
 double __ocml_remquo_f64(double, double, gpu::Private<int> *);
 double __ocml_tgamma_f64(double);
 float __ocml_tgamma_f32(float);
+double __ocml_lgamma_f64(double);
+double __ocml_lgamma_r_f64(double, gpu::Private<int> *);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/amdgpu/lgamma.cpp
+++ b/libc/src/math/amdgpu/lgamma.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of the lgamma function for GPU ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/lgamma.h"
+#include "src/__support/common.h"
+
+#include "declarations.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, lgamma, (double x)) { return __ocml_lgamma_f64(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/amdgpu/lgamma_r.cpp
+++ b/libc/src/math/amdgpu/lgamma_r.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of the lgamma_r function for GPU -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/lgamma_r.h"
+#include "src/__support/common.h"
+
+#include "declarations.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, lgamma_r, (double x, int *signp)) {
+  int tmp = *signp;
+  double r = __ocml_lgamma_r_f64(x, (gpu::Private<int> *)&tmp);
+  *signp = tmp;
+  return r;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/lgamma.h
+++ b/libc/src/math/lgamma.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for lgamma ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_MATH_LGAMMA_H
+#define LLVM_LIBC_SRC_MATH_LGAMMA_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+double lgamma(double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_MATH_LGAMMA_H

--- a/libc/src/math/lgamma_r.h
+++ b/libc/src/math/lgamma_r.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for lgamma_r-----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_MATH_LGAMMA_R_H
+#define LLVM_LIBC_SRC_MATH_LGAMMA_R_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+double lgamma_r(double x, int *signp);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_MATH_LGAMMA_R_H

--- a/libc/src/math/nvptx/CMakeLists.txt
+++ b/libc/src/math/nvptx/CMakeLists.txt
@@ -480,3 +480,27 @@ add_entrypoint_object(
     -O2
   VENDOR
 )
+
+add_entrypoint_object(
+  lgamma
+  SRCS
+    lgamma.cpp
+  HDRS
+    ../lgamma.h
+  COMPILE_OPTIONS
+    ${bitcode_link_flags}
+    -O2
+  VENDOR
+)
+
+add_entrypoint_object(
+  lgamma_r
+  SRCS
+    lgamma_r.cpp
+  HDRS
+    ../lgamma_r.h
+  COMPILE_OPTIONS
+    ${bitcode_link_flags}
+    -O2
+  VENDOR
+)

--- a/libc/src/math/nvptx/declarations.h
+++ b/libc/src/math/nvptx/declarations.h
@@ -86,6 +86,7 @@ double __nv_remquo(double, double, int *);
 float __nv_remquof(float, float, int *);
 double __nv_tgamma(double);
 float __nv_tgammaf(float);
+float __nv_lgamma(double);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/nvptx/lgamma.cpp
+++ b/libc/src/math/nvptx/lgamma.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of the lgamma function for GPU ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/lgamma.h"
+#include "src/__support/common.h"
+
+#include "declarations.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, lgamma, (double x)) { return __nv_lgamma(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/nvptx/lgamma_r.cpp
+++ b/libc/src/math/nvptx/lgamma_r.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of the lgamma_r function for GPU -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/lgamma_r.h"
+#include "src/__support/common.h"
+
+#include "declarations.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, lgamma_r, (double x, int *signp)) {
+  double result = __nv_lgamma(x);
+  *signp = (result < 0.0) ? -1 : 1;
+  return result;
+}
+
+} // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Summary:
These functions are used by the <random> implementation in libc++ and
cause a lot of tests to fail. For now we provide these through the
vendor abstraction until we have a real version. The NVPTX version
doesn't even update the output correctly so these are just temporary.
