### PR TITLE
[PS4/PS5][Driver] Allow -static in PlayStation drivers

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -141,6 +141,9 @@ void tools::PS4cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_pie))
     CmdArgs.push_back("-pie");
 
+
+  if (Args.hasArg(options::OPT_static))
+    CmdArgs.push_back("--static");
   if (Args.hasArg(options::OPT_rdynamic))
     CmdArgs.push_back("-export-dynamic");
   if (Args.hasArg(options::OPT_shared))
@@ -238,6 +241,8 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_pie))
     CmdArgs.push_back("-pie");
 
+  if (Args.hasArg(options::OPT_static))
+    CmdArgs.push_back("--static");
   if (Args.hasArg(options::OPT_rdynamic))
     CmdArgs.push_back("-export-dynamic");
   if (Args.hasArg(options::OPT_shared))
@@ -316,10 +321,6 @@ toolchains::PS4PS5Base::PS4PS5Base(const Driver &D, const llvm::Triple &Triple,
                                    const ArgList &Args, StringRef Platform,
                                    const char *EnvVar)
     : Generic_ELF(D, Triple, Args) {
-  if (Args.hasArg(clang::driver::options::OPT_static))
-    D.Diag(clang::diag::err_drv_unsupported_opt_for_target)
-        << "-static" << Platform;
-
   // Determine where to find the PS4/PS5 libraries.
   // If -isysroot was passed, use that as the SDK base path.
   // If not, we use the EnvVar if it exists; otherwise use the driver's

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -141,7 +141,6 @@ void tools::PS4cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_pie))
     CmdArgs.push_back("-pie");
 
-
   if (Args.hasArg(options::OPT_static))
     CmdArgs.push_back("--static");
   if (Args.hasArg(options::OPT_rdynamic))

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -142,7 +142,7 @@ void tools::PS4cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-pie");
 
   if (Args.hasArg(options::OPT_static))
-    CmdArgs.push_back("--static");
+    CmdArgs.push_back("-static");
   if (Args.hasArg(options::OPT_rdynamic))
     CmdArgs.push_back("-export-dynamic");
   if (Args.hasArg(options::OPT_shared))
@@ -241,7 +241,7 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-pie");
 
   if (Args.hasArg(options::OPT_static))
-    CmdArgs.push_back("--static");
+    CmdArgs.push_back("-static");
   if (Args.hasArg(options::OPT_rdynamic))
     CmdArgs.push_back("-export-dynamic");
   if (Args.hasArg(options::OPT_shared))

--- a/clang/test/Driver/ps4-linker.c
+++ b/clang/test/Driver/ps4-linker.c
@@ -3,7 +3,7 @@
 // RUN: %clang --target=x86_64-scei-ps4 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s
 
 // CHECK-STATIC: {{ld(\.exe)?}}"
-// CHECK-STATIC-SAME: "--static"
+// CHECK-STATIC-SAME: "-static"
 
 // Test the driver's control over the JustMyCode behavior with linker flags.
 

--- a/clang/test/Driver/ps4-linker.c
+++ b/clang/test/Driver/ps4-linker.c
@@ -1,3 +1,10 @@
+// Test that -static is forwarded to the linker
+
+// RUN: %clang --target=x86_64-scei-ps4 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s
+
+// CHECK-STATIC: {{ld(\.exe)?}}"
+// CHECK-STATIC-SAME: "--static"
+
 // Test the driver's control over the JustMyCode behavior with linker flags.
 
 // RUN: %clang --target=x86_64-scei-ps4 -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK-LTO,CHECK-LIB %s

--- a/clang/test/Driver/ps4-pic.c
+++ b/clang/test/Driver/ps4-pic.c
@@ -23,8 +23,6 @@
 // CHECK-DIAG-PIE: option '-fno-PIE' was ignored by the PS4 toolchain, using '-fPIC'
 // CHECK-DIAG-pic: option '-fno-pic' was ignored by the PS4 toolchain, using '-fPIC'
 // CHECK-DIAG-pie: option '-fno-pie' was ignored by the PS4 toolchain, using '-fPIC'
-//
-// CHECK-STATIC-ERR: unsupported option '-static' for target 'PS4'
 
 // RUN: %clang -c %s -target x86_64-scei-ps4 -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CHECK-PIC2
@@ -79,9 +77,10 @@
 // RUN: not %clang -c %s --target=x86_64-scei-ps4 -mdynamic-no-pic -fPIC -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CHECK-DYNAMIC-NO-PIC2
 //
-// -static not supported at all.
-// RUN: not %clang -c %s --target=x86_64-scei-ps4 -static -### 2>&1 \
-// RUN:   | FileCheck %s --check-prefix=CHECK-STATIC-ERR
+// The -static argument *doesn't* override PIC: -static only affects
+// linking, and -fPIC only affects code generation.
+// RUN: %clang -c %s -target x86_64-scei-ps4 -static -fPIC -### 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-PIC2
 //
 // -fno-PIC etc. is obeyed if -mcmodel=kernel is also present.
 // RUN: %clang -c %s -target x86_64-scei-ps4 -mcmodel=kernel -fno-PIC -### 2>&1 \

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -3,7 +3,7 @@
 // RUN: %clang --target=x86_64-scei-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s
 
 // CHECK-STATIC: {{ld(\.exe)?}}"
-// CHECK-STATIC-SAME: "--static"
+// CHECK-STATIC-SAME: "-static"
 
 // Test the driver's control over the JustMyCode behavior with linker flags.
 

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -1,3 +1,10 @@
+// Test that -static is forwarded to the linker
+
+// RUN: %clang --target=x86_64-scei-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s
+
+// CHECK-STATIC: {{ld(\.exe)?}}"
+// CHECK-STATIC-SAME: "--static"
+
 // Test the driver's control over the JustMyCode behavior with linker flags.
 
 // RUN: %clang --target=x86_64-scei-ps5 -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-LIB %s

--- a/clang/test/Driver/ps5-pic.c
+++ b/clang/test/Driver/ps5-pic.c
@@ -23,8 +23,6 @@
 // CHECK-DIAG-PIE: option '-fno-PIE' was ignored by the PS5 toolchain, using '-fPIC'
 // CHECK-DIAG-pic: option '-fno-pic' was ignored by the PS5 toolchain, using '-fPIC'
 // CHECK-DIAG-pie: option '-fno-pie' was ignored by the PS5 toolchain, using '-fPIC'
-//
-// CHECK-STATIC-ERR: unsupported option '-static' for target 'PS5'
 
 // RUN: %clang -c %s -target x86_64-sie-ps5 -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CHECK-PIC2
@@ -79,9 +77,10 @@
 // RUN: not %clang -c %s --target=x86_64-sie-ps5 -mdynamic-no-pic -fPIC -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CHECK-DYNAMIC-NO-PIC2
 //
-// -static not supported at all.
-// RUN: not %clang -c %s --target=x86_64-sie-ps5 -static -### 2>&1 \
-// RUN:   | FileCheck %s --check-prefix=CHECK-STATIC-ERR
+// The -static argument *doesn't* override PIC: -static only affects
+// linking, and -fPIC only affects code generation.
+// RUN: %clang -c %s -target x86_64-sie-ps5 -static -fPIC -### 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-PIC2
 //
 // -fno-PIC etc. is obeyed if -mcmodel=kernel is also present.
 // RUN: %clang -c %s -target x86_64-sie-ps5 -mcmodel=kernel -fno-PIC -### 2>&1 \


### PR DESCRIPTION
On PlayStation, allow users to supply -static to the linker, via the driver.

An initial step. Later changes will have the PS5 driver supply additional options to the linker, if and when -static is passed.

SIE tracker: TOOLCHAIN-16704