### PR TITLE
workflows/release-tasks: Add missing permissions for release binaries

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -78,6 +78,8 @@ jobs:
     name: Build Release Binaries
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     needs:
       - validate-tag
       - release-create


### PR DESCRIPTION
Now that the release binaries create artifact attestations, we need to ensure that we call the workflow with the correct permissions.