### PR TITLE
[libc] Add support for 'features.h' when targeting the GPU

### DIFF
--- a/libc/config/gpu/headers.txt
+++ b/libc/config/gpu/headers.txt
@@ -14,6 +14,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.stdio
     libc.include.wchar
     libc.include.uchar
+    libc.include.features
 
     # Header for RPC extensions
     libc.include.gpu_rpc


### PR DESCRIPTION
Summary:
`features.h` provides some information about the C library, provide this
on the GPU so external users can tell if it's the LLVM C library.
