### PR TITLE
workflows/release-binaries: Give attestation artifacts a unique name

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -442,7 +442,7 @@ jobs:
     - name: Upload Build Provenance
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
       with:
-        name: ${{ runner.os }}-${{ runner.arch }}-release-binary-attestation
+        name: ${{ needs.prepare.outputs.release-binary-filename }}-attestation
         path: ${{ needs.prepare.outputs.release-binary-filename }}.jsonl
 
     - name: Upload Release


### PR DESCRIPTION
We need a different attestation for each supported architecture, so there artifacts all need to have a different name.

The upload step is run on a Linux runner, so no matter which architecture's binary is being uploaded the runner.os and runner.arch variables would always be 'Linux' and 'X64' and so we can't use them for naming the artifact.