### PR TITLE
[libc] Enable more entrypoints for riscv

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -576,8 +576,12 @@ if(LIBC_TYPES_HAS_FLOAT128)
     libc.src.math.canonicalizef128
     libc.src.math.ceilf128
     libc.src.math.copysignf128
+    libc.src.math.daddf128
+    libc.src.math.ddivf128
+    libc.src.math.dfmaf128
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
+    libc.src.math.dsubf128
     libc.src.math.fabsf128
     libc.src.math.fdimf128
     libc.src.math.floorf128
@@ -617,6 +621,7 @@ if(LIBC_TYPES_HAS_FLOAT128)
     libc.src.math.roundevenf128
     libc.src.math.roundf128
     libc.src.math.scalbnf128
+    libc.src.math.setpayloadf128
     libc.src.math.sqrtf128
     libc.src.math.totalorderf128
     libc.src.math.totalordermagf128

--- a/libc/test/src/math/smoke/SetPayloadTest.h
+++ b/libc/test/src/math/smoke/SetPayloadTest.h
@@ -33,7 +33,12 @@ public:
     EXPECT_EQ(1, func(&res, T(-1.0)));
     EXPECT_EQ(1, func(&res, T(0x42.1p+0)));
     EXPECT_EQ(1, func(&res, T(-0x42.1p+0)));
-    EXPECT_EQ(1, func(&res, T(StorageType(1) << (FPBits::FRACTION_LEN - 1))));
+
+    FPBits default_snan_payload_bits = FPBits::one();
+    default_snan_payload_bits.set_biased_exponent(FPBits::FRACTION_LEN - 1 +
+                                                  FPBits::EXP_BIAS);
+    T default_snan_payload = default_snan_payload_bits.get_val();
+    EXPECT_EQ(1, func(&res, default_snan_payload));
   }
 
   void testValidPayloads(SetPayloadFunc func) {
@@ -57,7 +62,15 @@ public:
     EXPECT_EQ(FPBits::quiet_nan(Sign::POS, 0x123).uintval(),
               FPBits(res).uintval());
 
-    EXPECT_EQ(0, func(&res, T(FPBits::FRACTION_MASK >> 1)));
+    // The following code is creating a NaN manually to prevent a conversion
+    // from BigInt to long double.
+    FPBits default_snan_payload_bits = FPBits::one();
+    default_snan_payload_bits.set_biased_exponent(FPBits::SIG_LEN - 2 +
+                                                  FPBits::EXP_BIAS);
+    default_snan_payload_bits.set_mantissa(FPBits::SIG_MASK - 3);
+    T default_snan_payload = default_snan_payload_bits.get_val();
+
+    EXPECT_EQ(0, func(&res, default_snan_payload));
     EXPECT_TRUE(FPBits(res).is_quiet_nan());
     EXPECT_EQ(
         FPBits::quiet_nan(Sign::POS, FPBits::FRACTION_MASK >> 1).uintval(),

--- a/libc/test/src/math/smoke/SetPayloadTest.h
+++ b/libc/test/src/math/smoke/SetPayloadTest.h
@@ -63,7 +63,7 @@ public:
               FPBits(res).uintval());
 
     // The following code is creating a NaN manually to prevent a conversion
-    // from BigInt to long double.
+    // from BigInt to float128.
     FPBits nan_payload_bits = FPBits::one();
     nan_payload_bits.set_biased_exponent(FPBits::SIG_LEN - 2 +
                                          FPBits::EXP_BIAS);

--- a/libc/test/src/math/smoke/SetPayloadTest.h
+++ b/libc/test/src/math/smoke/SetPayloadTest.h
@@ -34,11 +34,11 @@ public:
     EXPECT_EQ(1, func(&res, T(0x42.1p+0)));
     EXPECT_EQ(1, func(&res, T(-0x42.1p+0)));
 
-    FPBits default_snan_payload_bits = FPBits::one();
-    default_snan_payload_bits.set_biased_exponent(FPBits::FRACTION_LEN - 1 +
-                                                  FPBits::EXP_BIAS);
-    T default_snan_payload = default_snan_payload_bits.get_val();
-    EXPECT_EQ(1, func(&res, default_snan_payload));
+    FPBits nan_payload_bits = FPBits::one();
+    nan_payload_bits.set_biased_exponent(FPBits::FRACTION_LEN - 1 +
+                                         FPBits::EXP_BIAS);
+    T nan_payload = nan_payload_bits.get_val();
+    EXPECT_EQ(1, func(&res, nan_payload));
   }
 
   void testValidPayloads(SetPayloadFunc func) {
@@ -64,13 +64,13 @@ public:
 
     // The following code is creating a NaN manually to prevent a conversion
     // from BigInt to long double.
-    FPBits default_snan_payload_bits = FPBits::one();
-    default_snan_payload_bits.set_biased_exponent(FPBits::SIG_LEN - 2 +
-                                                  FPBits::EXP_BIAS);
-    default_snan_payload_bits.set_mantissa(FPBits::SIG_MASK - 3);
-    T default_snan_payload = default_snan_payload_bits.get_val();
+    FPBits nan_payload_bits = FPBits::one();
+    nan_payload_bits.set_biased_exponent(FPBits::SIG_LEN - 2 +
+                                         FPBits::EXP_BIAS);
+    nan_payload_bits.set_mantissa(FPBits::SIG_MASK - 3);
+    T nan_payload = nan_payload_bits.get_val();
 
-    EXPECT_EQ(0, func(&res, default_snan_payload));
+    EXPECT_EQ(0, func(&res, nan_payload));
     EXPECT_TRUE(FPBits(res).is_quiet_nan());
     EXPECT_EQ(
         FPBits::quiet_nan(Sign::POS, FPBits::FRACTION_MASK >> 1).uintval(),

--- a/libc/test/src/math/smoke/SetPayloadTest.h
+++ b/libc/test/src/math/smoke/SetPayloadTest.h
@@ -62,8 +62,8 @@ public:
     EXPECT_EQ(FPBits::quiet_nan(Sign::POS, 0x123).uintval(),
               FPBits(res).uintval());
 
-    // The following code is creating a NaN manually to prevent a conversion
-    // from BigInt to float128.
+    // The following code is creating a NaN payload manually to prevent a
+    // conversion from BigInt to float128.
     FPBits nan_payload_bits = FPBits::one();
     nan_payload_bits.set_biased_exponent(FPBits::SIG_LEN - 2 +
                                          FPBits::EXP_BIAS);


### PR DESCRIPTION
This patch enables more entrypoints for riscv. The changes to the test cases are introduced to support rv32 which has long double but doesn't have int128