### PR TITLE
 [llvm-lit] Adding -e option to lit's built-in cat command

### DIFF
--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -18,6 +18,8 @@ class Options:
 
 
 def convertTextNotation(data, options):
+    assert options.show_ends or options.show_nonprinting
+
     newdata = StringIO()
     if isinstance(data, str):
         data = bytearray(data.encode())
@@ -37,12 +39,11 @@ def convertTextNotation(data, options):
             if intval < 32:
                 newdata.write("^")
                 newdata.write(chr(intval + 64))
+                continue
             elif intval == 127:
                 newdata.write("^?")
-            else:
-                newdata.write(chr(intval))
-        else:
-            newdata.write(chr(intval))
+                continue
+        newdata.write(chr(intval))
 
     return newdata.getvalue().encode()
 

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -7,16 +7,19 @@ try:
 except ImportError:
     from io import StringIO
 
+
 @dataclass
 class Options:
     show_ends: bool
     show_nonprinting: bool
 
+
 def convertTextNotation(data, options):
     newdata = StringIO()
     if isinstance(data, str):
         data = bytearray(data.encode())
-    
+
+
     for intval in data:
         if options.show_ends:
             if intval == 10:

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -50,8 +50,8 @@ def convertTextNotation(data, options):
 
 def main(argv):
     arguments = argv[1:]
-    short_options = "ve"
-    long_options = ["show-nonprinting"]
+    short_options = "eEv"
+    long_options = ["show-ends", "show-nonprinting"]
     enabled_options = Options(show_ends=False, show_nonprinting=False)
     convert_text = False
 
@@ -65,7 +65,7 @@ def main(argv):
         if option == "-v" or option == "--show-nonprinting" or option == "-e":
             enabled_options.show_nonprinting = True
             convert_text = True
-        if option == "-e":
+        if option == "-E" or option == "--show-ends" or option == "-e":
             enabled_options.show_ends = True
             convert_text = True
 

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -7,34 +7,43 @@ except ImportError:
     from io import StringIO
 
 
-def convertToCaretAndMNotation(data):
+def convertTextNotation(data, options):
     newdata = StringIO()
     if isinstance(data, str):
         data = bytearray(data.encode())
 
     for intval in data:
-        if intval == 9 or intval == 10:
-            newdata.write(chr(intval))
-            continue
-        if intval > 127:
-            intval = intval - 128
-            newdata.write("M-")
-        if intval < 32:
-            newdata.write("^")
-            newdata.write(chr(intval + 64))
-        elif intval == 127:
-            newdata.write("^?")
-        else:
-            newdata.write(chr(intval))
+        if "show_ends" in options:
+            if intval == 10:
+                newdata.write("$")
+                newdata.write(chr(intval))
+                continue
+        if "show_nonprinting" in options:
+            if intval == 9 or intval == 10:
+                newdata.write(chr(intval))
+                continue
+            if intval > 127:
+                intval = intval - 128
+                newdata.write("M-")
+            if intval < 32:
+                newdata.write("^")
+                newdata.write(chr(intval + 64))
+            elif intval == 127:
+                newdata.write("^?")
+            else:
+                newdata.write(chr(intval))
+
+    if "show_ends" in options:
+        newdata.write("$")
 
     return newdata.getvalue().encode()
 
 
 def main(argv):
     arguments = argv[1:]
-    short_options = "v"
+    short_options = "ve"
     long_options = ["show-nonprinting"]
-    show_nonprinting = False
+    enabled_options = []
 
     try:
         options, filenames = getopt.gnu_getopt(arguments, short_options, long_options)
@@ -43,8 +52,10 @@ def main(argv):
         sys.exit(1)
 
     for option, value in options:
-        if option == "-v" or option == "--show-nonprinting":
-            show_nonprinting = True
+        if option == "-v" or option == "--show-nonprinting" or option == "-e":
+            enabled_options.append("show_nonprinting")
+        if option == "-e":
+            enabled_options.append("show_ends")
 
     writer = getattr(sys.stdout, "buffer", None)
     if writer is None:
@@ -69,8 +80,8 @@ def main(argv):
                 fileToCat = open(filename, "rb")
                 contents = fileToCat.read()
 
-            if show_nonprinting:
-                contents = convertToCaretAndMNotation(contents)
+            if enabled_options:
+                contents = convertTextNotation(contents, enabled_options)
             elif is_text:
                 contents = contents.encode()
             writer.write(contents)

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -8,9 +8,12 @@ except ImportError:
     from io import StringIO
 
 
+# This dataclass defines all currently supported options for cat
 @dataclass
 class Options:
+    # Options: -e. True if newlines should be displayed with a '$'
     show_ends: bool
+    # Options: -v, -e. True if text should be converted to ^ and M- notation
     show_nonprinting: bool
 
 
@@ -21,11 +24,10 @@ def convertTextNotation(data, options):
 
 
     for intval in data:
-        if options.show_ends:
-            if intval == 10:
-                newdata.write("$")
-                newdata.write(chr(intval))
-                continue
+        if options.show_ends and intval == 10:
+            newdata.write("$")
+            newdata.write(chr(intval))
+            continue
         if options.show_nonprinting:
             if intval == 9 or intval == 10:
                 newdata.write(chr(intval))

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -1,6 +1,6 @@
 import getopt
 import sys
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 
 try:
     from StringIO import StringIO
@@ -22,9 +22,8 @@ def convertTextNotation(data, options):
     if isinstance(data, str):
         data = bytearray(data.encode())
 
-
     for intval in data:
-        if options.show_ends and intval == 10:
+        if intval == 10 and options.show_ends:
             newdata.write("$")
             newdata.write(chr(intval))
             continue
@@ -53,6 +52,7 @@ def main(argv):
     short_options = "ve"
     long_options = ["show-nonprinting"]
     enabled_options = Options(show_ends=False, show_nonprinting=False)
+    convert_text = False
 
     try:
         options, filenames = getopt.gnu_getopt(arguments, short_options, long_options)
@@ -63,8 +63,10 @@ def main(argv):
     for option, value in options:
         if option == "-v" or option == "--show-nonprinting" or option == "-e":
             enabled_options.show_nonprinting = True
+            convert_text = True
         if option == "-e":
             enabled_options.show_ends = True
+            convert_text = True
 
     writer = getattr(sys.stdout, "buffer", None)
     if writer is None:
@@ -89,7 +91,7 @@ def main(argv):
                 fileToCat = open(filename, "rb")
                 contents = fileToCat.read()
 
-            if True in fields(enabled_options):
+            if convert_text:
                 contents = convertTextNotation(contents, enabled_options)
             elif is_text:
                 contents = contents.encode()


### PR DESCRIPTION
This patch extends support for using cat -e in lit tests that use the internal
shell. The logic for enabling options is changed to accommodate for the
possibility of having several options. This patch is dependent on https://github.com/llvm/llvm-project/pull/101530. 

Fixes https://github.com/llvm/llvm-project/issues/102377