### PR TITLE
[OpenMP] Rename worker threads for improved debuggability

### DIFF
--- a/openmp/runtime/cmake/LibompDefinitions.cmake
+++ b/openmp/runtime/cmake/LibompDefinitions.cmake
@@ -23,6 +23,8 @@ function(libomp_get_definitions_flags cppflags)
   else()
     libomp_append(cppflags_local "-D _GNU_SOURCE")
     libomp_append(cppflags_local "-D _REENTRANT")
+    # or use HAVE_PTHREAD_SETNAME_NP from top-level cmake/config-ix.cmake
+    libomp_append(cppflags_local "-D LIBOMP_HAVE_LINUX_PTHREAD_SETNAME" LIBOMP_HAVE_LINUX_PTHREAD_SETNAME)
   endif()
 
   # CMake doesn't include CPPFLAGS from environment, but we will.

--- a/openmp/runtime/cmake/config-ix.cmake
+++ b/openmp/runtime/cmake/config-ix.cmake
@@ -101,6 +101,11 @@ if(${LIBOMP_FORTRAN_MODULES})
   libomp_check_fortran_flag(-m32 LIBOMP_HAVE_M32_FORTRAN_FLAG)
 endif()
 
+# Check non-posix pthread API here before CMAKE_REQUIRED_DEFINITIONS gets messed up
+if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+  check_symbol_exists(pthread_setname_np "pthread.h" LIBOMP_HAVE_LINUX_PTHREAD_SETNAME)
+endif()
+
 # Check for Unix shared memory
 check_symbol_exists(shm_open "sys/mman.h" LIBOMP_HAVE_SHM_OPEN_NO_LRT)
 if (NOT LIBOMP_HAVE_SHM_OPEN_NO_LRT)

--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -879,12 +879,12 @@ void __kmp_create_worker(int gtid, kmp_info_t *th, size_t stack_size) {
   }
 
 #ifdef KMP_OS_LINUX
- #if ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
+#if ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
   // Rename worker threads for improved debuggability
   if (!KMP_UBER_GTID(gtid)) {
     pthread_setname_np(handle, "openmp_worker");
   }
- #endif
+#endif
 #endif
 
   th->th.th_info.ds.ds_thread = handle;

--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -878,7 +878,7 @@ void __kmp_create_worker(int gtid, kmp_info_t *th, size_t stack_size) {
     KMP_SYSFAIL("pthread_create", status);
   }
 
-#if defined(KMP_OS_LINUX) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
+#ifdef LIBOMP_HAVE_LINUX_PTHREAD_SETNAME
   // Rename worker threads for improved debuggability
   if (!KMP_UBER_GTID(gtid)) {
     pthread_setname_np(handle, "openmp_worker");

--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -878,7 +878,7 @@ void __kmp_create_worker(int gtid, kmp_info_t *th, size_t stack_size) {
     KMP_SYSFAIL("pthread_create", status);
   }
 
-#ifdef _GNU_SOURCE
+#ifdef KMP_OS_LINUX
  #if ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
   // Rename worker threads for improved debuggability
   if (!KMP_UBER_GTID(gtid)) {

--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -878,6 +878,15 @@ void __kmp_create_worker(int gtid, kmp_info_t *th, size_t stack_size) {
     KMP_SYSFAIL("pthread_create", status);
   }
 
+#ifdef _GNU_SOURCE
+ #if ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
+  // Rename worker threads for improved debuggability
+  if (!KMP_UBER_GTID(gtid)) {
+    pthread_setname_np(handle, "openmp_worker");
+  }
+ #endif
+#endif
+
   th->th.th_info.ds.ds_thread = handle;
 
 #ifdef KMP_THREAD_ATTR

--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -878,13 +878,11 @@ void __kmp_create_worker(int gtid, kmp_info_t *th, size_t stack_size) {
     KMP_SYSFAIL("pthread_create", status);
   }
 
-#ifdef KMP_OS_LINUX
-#if ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
+#if defined(KMP_OS_LINUX) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
   // Rename worker threads for improved debuggability
   if (!KMP_UBER_GTID(gtid)) {
     pthread_setname_np(handle, "openmp_worker");
   }
-#endif
 #endif
 
   th->th.th_info.ds.ds_thread = handle;


### PR DESCRIPTION
Rename the worker threads "openmp_worker"