### PR TITLE
[llvm-lit] Fix error in compiler-rt tests when using lit internal shell with env

### DIFF
--- a/compiler-rt/test/dfsan/custom.cpp
+++ b/compiler-rt/test/dfsan/custom.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_dfsan %s -o %t && DFSAN_OPTIONS="strict_data_dependencies=0" %run %t
+// RUN: %clang_dfsan %s -o %t && env DFSAN_OPTIONS="strict_data_dependencies=0" %run %t
 // RUN: %clang_dfsan -DSTRICT_DATA_DEPENDENCIES %s -o %t && %run %t
 // RUN: %clang_dfsan -DORIGIN_TRACKING -mllvm -dfsan-track-origins=1 -mllvm -dfsan-combine-pointer-labels-on-load=false -DSTRICT_DATA_DEPENDENCIES %s -o %t && %run %t
-// RUN: %clang_dfsan -DORIGIN_TRACKING -mllvm -dfsan-track-origins=1 -mllvm -dfsan-combine-pointer-labels-on-load=false -no-pie %s -o %t && DFSAN_OPTIONS="strict_data_dependencies=0" %run %t
+// RUN: %clang_dfsan -DORIGIN_TRACKING -mllvm -dfsan-track-origins=1 -mllvm -dfsan-combine-pointer-labels-on-load=false -no-pie %s -o %t && env DFSAN_OPTIONS="strict_data_dependencies=0" %run %t
 //
 // Tests custom implementations of various glibc functions.
 

--- a/compiler-rt/test/dfsan/flags.c
+++ b/compiler-rt/test/dfsan/flags.c
@@ -1,6 +1,6 @@
-// RUN: %clang_dfsan %s -fsanitize-ignorelist=%S/Inputs/flags_abilist.txt -mllvm -dfsan-debug-nonzero-labels -o %t && DFSAN_OPTIONS=warn_unimplemented=1 %run %t 2>&1 | FileCheck %s
-// RUN: %clang_dfsan %s -fsanitize-ignorelist=%S/Inputs/flags_abilist.txt -mllvm -dfsan-debug-nonzero-labels -o %t && DFSAN_OPTIONS=warn_unimplemented=0 %run %t 2>&1 | count 0
-// RUN: %clang_dfsan %s -fsanitize-ignorelist=%S/Inputs/flags_abilist.txt -mllvm -dfsan-debug-nonzero-labels -o %t && DFSAN_OPTIONS=warn_nonzero_labels=1 %run %t 2>&1 | FileCheck --check-prefix=CHECK-NONZERO %s
+// RUN: %clang_dfsan %s -fsanitize-ignorelist=%S/Inputs/flags_abilist.txt -mllvm -dfsan-debug-nonzero-labels -o %t && env DFSAN_OPTIONS=warn_unimplemented=1 %run %t 2>&1 | FileCheck %s
+// RUN: %clang_dfsan %s -fsanitize-ignorelist=%S/Inputs/flags_abilist.txt -mllvm -dfsan-debug-nonzero-labels -o %t && env DFSAN_OPTIONS=warn_unimplemented=0 %run %t 2>&1 | count 0
+// RUN: %clang_dfsan %s -fsanitize-ignorelist=%S/Inputs/flags_abilist.txt -mllvm -dfsan-debug-nonzero-labels -o %t && env DFSAN_OPTIONS=warn_nonzero_labels=1 %run %t 2>&1 | FileCheck --check-prefix=CHECK-NONZERO %s
 
 // Tests that flags work correctly.
 

--- a/compiler-rt/test/dfsan/fork.cpp
+++ b/compiler-rt/test/dfsan/fork.cpp
@@ -6,7 +6,7 @@
 // RUN: %run %t 2>&1 | FileCheck %s
 //
 // RUN: %clangxx_dfsan -mllvm -dfsan-track-origins=1 %s -o %t
-// RUN: DFSAN_OPTIONS=store_context_size=1000,origin_history_size=0,origin_history_per_stack_limit=0 %run %t 2>&1 | FileCheck %s
+// RUN: env DFSAN_OPTIONS=store_context_size=1000,origin_history_size=0,origin_history_per_stack_limit=0 %run %t 2>&1 | FileCheck %s
 
 #include <assert.h>
 #include <errno.h>

--- a/compiler-rt/test/dfsan/origin_limit.c
+++ b/compiler-rt/test/dfsan/origin_limit.c
@@ -3,10 +3,10 @@
 // RUN: %run %t >%t.out 2>&1
 // RUN: FileCheck %s < %t.out
 //
-// RUN: DFSAN_OPTIONS=origin_history_size=2 %run %t >%t.out 2>&1
+// RUN: env DFSAN_OPTIONS=origin_history_size=2 %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK2 < %t.out
 //
-// RUN: DFSAN_OPTIONS=origin_history_size=0 %run %t >%t.out 2>&1
+// RUN: env DFSAN_OPTIONS=origin_history_size=0 %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK0 < %t.out
 
 #include <sanitizer/dfsan_interface.h>

--- a/compiler-rt/test/msan/Linux/sendmsg.cpp
+++ b/compiler-rt/test/msan/Linux/sendmsg.cpp
@@ -9,13 +9,13 @@
 // RUN: %clangxx_msan %s -DSENDMMSG -o %t && %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
 
 // RUN: %clangxx_msan %s -DSEND -DPOISON -o %t && \
-// RUN:   MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
+// RUN:   env MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
 // RUN: %clangxx_msan %s -DSENDTO -DPOISON -o %t && \
-// RUN:   MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
+// RUN:   env MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
 // RUN: %clangxx_msan %s -DSENDMSG -DPOISON -o %t && \
-// RUN:   MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
+// RUN:   env MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
 // RUN: %clangxx_msan %s -DSENDMMSG -DPOISON -o %t && \
-// RUN:   MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
+// RUN:   env MSAN_OPTIONS=intercept_send=0 %run %t 2>&1 | FileCheck %s --check-prefix=NEGATIVE
 
 // UNSUPPORTED: android
 

--- a/compiler-rt/test/msan/chained_origin_empty_stack.cpp
+++ b/compiler-rt/test/msan/chained_origin_empty_stack.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx_msan -fno-sanitize-memory-param-retval -fsanitize-memory-track-origins=2 -O3 %s -o %t && \
-// RUN:     MSAN_OPTIONS=store_context_size=1 not %run %t 2>&1 | FileCheck %s
+// RUN:     env MSAN_OPTIONS=store_context_size=1 not %run %t 2>&1 | FileCheck %s
 
 // Test that stack trace for the intermediate store is not empty.
 

--- a/compiler-rt/test/msan/chained_origin_limits.cpp
+++ b/compiler-rt/test/msan/chained_origin_limits.cpp
@@ -3,63 +3,61 @@
 // Heap origin.
 // RUN: %clangxx_msan -fsanitize-memory-track-origins=2 -O3 %s -o %t
 
-// RUN: MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK2 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK-PER-STACK --check-prefix=CHECK-%short-stack < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
 
 // Stack origin.
 // RUN: %clangxx_msan -DSTACK -fsanitize-memory-track-origins=2 -O3 %s -o %t
 
-// RUN: MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK2 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK-PER-STACK --check-prefix=CHECK-%short-stack < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
-
 
 // Heap origin, with calls.
 // RUN: %clangxx_msan -mllvm -msan-instrumentation-with-call-threshold=0 -fsanitize-memory-track-origins=2 -O3 %s -o %t
 
-// RUN: MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK2 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK-PER-STACK --check-prefix=CHECK-%short-stack < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
-
 
 // Stack origin, with calls.
 // RUN: %clangxx_msan -DSTACK -mllvm -msan-instrumentation-with-call-threshold=0 -fsanitize-memory-track-origins=2 -O3 %s -o %t
 
-// RUN: MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=2 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK2 < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_per_stack_limit=1 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK-PER-STACK --check-prefix=CHECK-%short-stack < %t.out
 
-// RUN: MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
+// RUN: env MSAN_OPTIONS=origin_history_size=7,origin_history_per_stack_limit=0 not %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK7 < %t.out
 
 #include <stdio.h>

--- a/compiler-rt/test/msan/coverage-levels.cpp
+++ b/compiler-rt/test/msan/coverage-levels.cpp
@@ -2,13 +2,13 @@
 //
 // RUN: %clangxx_msan -DINIT_VAR=1 -O1 -fsanitize-coverage=func,trace-pc-guard  %s -o %t
 // RUN: mkdir -p %t-dir
-// RUN: MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir %run %t 2>&1 | FileCheck %s --check-prefix=CHECK1 --check-prefix=CHECK_NOWARN
+// RUN: env MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir %run %t 2>&1 | FileCheck %s --check-prefix=CHECK1 --check-prefix=CHECK_NOWARN
 // RUN: %clangxx_msan -O1 -fsanitize-coverage=func,trace-pc-guard  %s -o %t
-// RUN: MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK1 --check-prefix=CHECK_WARN
+// RUN: env MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK1 --check-prefix=CHECK_WARN
 // RUN: %clangxx_msan -O1 -fsanitize-coverage=bb,trace-pc-guard  %s -o %t
-// RUN: MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK2 --check-prefix=CHECK_WARN
+// RUN: env MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK2 --check-prefix=CHECK_WARN
 // RUN: %clangxx_msan -O1 -fsanitize-coverage=edge,trace-pc-guard  %s -o %t
-// RUN: MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK3 --check-prefix=CHECK_WARN
+// RUN: env MSAN_OPTIONS=coverage=1:verbosity=1:coverage_dir=%t-dir not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK3 --check-prefix=CHECK_WARN
 
 volatile int sink;
 int main(int argc, char **argv) {

--- a/compiler-rt/test/msan/dtor-member.cpp
+++ b/compiler-rt/test/msan/dtor-member.cpp
@@ -10,7 +10,7 @@
 // RUN: %clangxx_msan %s -fsanitize=memory -fno-sanitize-memory-use-after-dtor -o %t &&  %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK-NO-FLAG < %t.out
 
-// RUN: %clangxx_msan -fsanitize=memory -fsanitize-memory-use-after-dtor %s -o %t && MSAN_OPTIONS=poison_in_dtor=0 %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize=memory -fsanitize-memory-use-after-dtor %s -o %t && env MSAN_OPTIONS=poison_in_dtor=0 %run %t >%t.out 2>&1
 // RUN: FileCheck %s --check-prefix=CHECK-NO-FLAG < %t.out
 
 #include <sanitizer/msan_interface.h>

--- a/compiler-rt/test/msan/fork.cpp
+++ b/compiler-rt/test/msan/fork.cpp
@@ -3,7 +3,7 @@
 // and verify that origin reads do not deadlock in the child process.
 
 // RUN: %clangxx_msan -std=c++11 -fsanitize-memory-track-origins=2 -g -O3 %s -o %t
-// RUN: MSAN_OPTIONS=store_context_size=1000,origin_history_size=0,origin_history_per_stack_limit=0 %run %t 2>&1 | FileCheck %s
+// RUN: env MSAN_OPTIONS=store_context_size=1000,origin_history_size=0,origin_history_per_stack_limit=0 %run %t 2>&1 | FileCheck %s
 
 // Fun fact: if test output is redirected to a file (as opposed to
 // being piped directly to FileCheck), we may lose some "done"s due to

--- a/compiler-rt/test/msan/interception_sigaction_test.cpp
+++ b/compiler-rt/test/msan/interception_sigaction_test.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx_msan -O0 -g %s -o %t
-// RUN: MSAN_OPTIONS=handle_segv=2 %t 2>&1 | FileCheck %s
+// RUN: env MSAN_OPTIONS=handle_segv=2 %t 2>&1 | FileCheck %s
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/compiler-rt/test/msan/memcmp_test.cpp
+++ b/compiler-rt/test/msan/memcmp_test.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx_msan -O0 -g %s -o %t
 // RUN: not %run %t 2>&1 | FileCheck %s
-// RUN: MSAN_OPTIONS=intercept_memcmp=0 %run %t
+// RUN: env MSAN_OPTIONS=intercept_memcmp=0 %run %t
 
 #include <string.h>
 #include <stdio.h>

--- a/compiler-rt/test/msan/msan_check_mem_is_initialized.cpp
+++ b/compiler-rt/test/msan/msan_check_mem_is_initialized.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx_msan -O0 -g -DPOSITIVE %s -o %t
 // RUN: not %run %t 2>&1 | FileCheck %s
-// RUN: MSAN_OPTIONS=verbosity=1 not %run %t 2>&1 | \
+// RUN: env MSAN_OPTIONS=verbosity=1 not %run %t 2>&1 | \
 // RUN:     FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-VERBOSE
 
 // RUN: %clangxx_msan -O0 -g %s -o %t && %run %t

--- a/compiler-rt/test/msan/poison_in_free.cpp
+++ b/compiler-rt/test/msan/poison_in_free.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx_msan -O0 %s -o %t && not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
-// RUN: %clangxx_msan -O0 %s -o %t && MSAN_OPTIONS=poison_in_free=0 %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -O0 %s -o %t && env MSAN_OPTIONS=poison_in_free=0 %run %t >%t.out 2>&1
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/msan/print_stats.cpp
+++ b/compiler-rt/test/msan/print_stats.cpp
@@ -1,21 +1,21 @@
-// RUN: %clangxx_msan -fsanitize-memory-track-origins=2 -g %s -o %t 
+// RUN: %clangxx_msan -fsanitize-memory-track-origins=2 -g %s -o %t
 // RUN: %run %t 2>&1 | \
 // RUN:   FileCheck --check-prefixes=CHECK,CHECK-NOSTATS %s
-// RUN: MSAN_OPTIONS=print_stats=1 %run %t 2>&1 | \
+// RUN: env MSAN_OPTIONS=print_stats=1 %run %t 2>&1 | \
 // RUN:   FileCheck --check-prefixes=CHECK,CHECK-NOSTATS %s
-// RUN: MSAN_OPTIONS=print_stats=1,atexit=1 %run %t 2>&1 | \
+// RUN: env MSAN_OPTIONS=print_stats=1,atexit=1 %run %t 2>&1 | \
 // RUN:   FileCheck --check-prefixes=CHECK,CHECK-STATS %s
 
-// RUN: %clangxx_msan -fsanitize-memory-track-origins=2 -g -DPOSITIVE=1 %s -o %t 
+// RUN: %clangxx_msan -fsanitize-memory-track-origins=2 -g -DPOSITIVE=1 %s -o %t
 // RUN: not %run %t 2>&1 | \
 // RUN:   FileCheck --check-prefixes=CHECK,CHECK-NOSTATS %s
-// RUN: MSAN_OPTIONS=print_stats=1 not %run %t 2>&1 | \
+// RUN: env MSAN_OPTIONS=print_stats=1 not %run %t 2>&1 | \
 // RUN:   FileCheck --check-prefixes=CHECK,CHECK-STATS %s
 
 // RUN: %clangxx_msan -fsanitize-memory-track-origins=2 -fsanitize-recover=memory -g -DPOSITIVE=1 %s -o %t
 // RUN: not %run %t 2>&1 | \
 // RUN:  FileCheck --check-prefixes=CHECK,CHECK-NOSTATS,CHECK-RECOVER %s
-// RUN: MSAN_OPTIONS=print_stats=1 not %run %t 2>&1 | \
+// RUN: env MSAN_OPTIONS=print_stats=1 not %run %t 2>&1 | \
 // RUN:   FileCheck --check-prefixes=CHECK,CHECK-STATS,CHECK-RECOVER %s
 
 #include <stdio.h>

--- a/compiler-rt/test/msan/recover-dso.cpp
+++ b/compiler-rt/test/msan/recover-dso.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx_msan -O0 %s -o %t && not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
-// RUN: %clangxx_msan -O0 %s -o %t && MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -O0 %s -o %t && env MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
-// RUN: %clangxx_msan -O0 %s -o %t && MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -O0 %s -o %t && env MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
 
 // Test how -fsanitize-recover=memory and MSAN_OPTIONS=keep_going affect reports
@@ -12,9 +12,9 @@
 
 // RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
-// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && env MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
-// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && env MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
 
 // Test how legacy -mllvm -msan-keep-going and MSAN_OPTIONS=keep_going affect

--- a/compiler-rt/test/msan/recover.cpp
+++ b/compiler-rt/test/msan/recover.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx_msan -O0 %s -o %t && not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
-// RUN: %clangxx_msan -O0 %s -o %t && MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -O0 %s -o %t && env MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
-// RUN: %clangxx_msan -O0 %s -o %t && MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -O0 %s -o %t && env MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
 
 // Test behavior of -fsanitize-recover=memory and MSAN_OPTIONS=keep_going.
@@ -11,20 +11,20 @@
 
 // RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
-// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && env MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
-// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && env MSAN_OPTIONS=keep_going=1 not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
-// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && MSAN_OPTIONS=halt_on_error=1 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && env MSAN_OPTIONS=halt_on_error=1 not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
-// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && MSAN_OPTIONS=halt_on_error=0 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -fsanitize-recover=memory -O0 %s -o %t && env MSAN_OPTIONS=halt_on_error=0 not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
 
 // Basic test of legacy -mllvm -msan-keep-going and MSAN_OPTIONS=keep_going.
 
 // RUN: %clangxx_msan -mllvm -msan-keep-going=1 -O0 %s -o %t && not %run %t >%t.out 2>&1
 // FileCheck --check-prefix=CHECK-RECOVER %s <%t.out
-// RUN: %clangxx_msan -mllvm -msan-keep-going=1 -O0 %s -o %t && MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
+// RUN: %clangxx_msan -mllvm -msan-keep-going=1 -O0 %s -o %t && env MSAN_OPTIONS=keep_going=0 not %run %t >%t.out 2>&1
 // FileCheck %s <%t.out
 
 #include <stdio.h>

--- a/compiler-rt/test/msan/release_origin.c
+++ b/compiler-rt/test/msan/release_origin.c
@@ -1,5 +1,5 @@
-// RUN: %clang_msan -fsanitize-memory-track-origins=0 -O0 %s -o %t && MSAN_OPTIONS=soft_rss_limit_mb=18:verbosity=1:allocator_may_return_null=1 %run %t 2>&1 | FileCheck %s -implicit-check-not="soft rss limit" -check-prefixes=CHECK,NOORIG
-// RUN: %clang_msan -fsanitize-memory-track-origins=2 -O0 %s -o %t && MSAN_OPTIONS=soft_rss_limit_mb=36:verbosity=1:allocator_may_return_null=1 %run %t 2>&1 | FileCheck %s -implicit-check-not="soft rss limit" -check-prefixes=CHECK,ORIGIN
+// RUN: %clang_msan -fsanitize-memory-track-origins=0 -O0 %s -o %t && env MSAN_OPTIONS=soft_rss_limit_mb=18:verbosity=1:allocator_may_return_null=1 %run %t 2>&1 | FileCheck %s -implicit-check-not="soft rss limit" -check-prefixes=CHECK,NOORIG
+// RUN: %clang_msan -fsanitize-memory-track-origins=2 -O0 %s -o %t && env MSAN_OPTIONS=soft_rss_limit_mb=36:verbosity=1:allocator_may_return_null=1 %run %t 2>&1 | FileCheck %s -implicit-check-not="soft rss limit" -check-prefixes=CHECK,ORIGIN
 
 #include <assert.h>
 #include <sanitizer/allocator_interface.h>

--- a/compiler-rt/test/msan/strcmp.c
+++ b/compiler-rt/test/msan/strcmp.c
@@ -1,6 +1,6 @@
 // RUN: %clang_msan %s -o %t
-// RUN: MSAN_OPTIONS=intercept_strcmp=false %run %t 2>&1
-// RUN: MSAN_OPTIONS=intercept_strcmp=true not %run %t 2>&1 | FileCheck %s
+// RUN: env MSAN_OPTIONS=intercept_strcmp=false %run %t 2>&1
+// RUN: env MSAN_OPTIONS=intercept_strcmp=true not %run %t 2>&1 | FileCheck %s
 // RUN:                                    not %run %t 2>&1 | FileCheck %s
 
 #include <assert.h>

--- a/compiler-rt/test/msan/strndup.cpp
+++ b/compiler-rt/test/msan/strndup.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx_msan %s -o %t && not %run %t 2>&1 | FileCheck --check-prefix=ON %s
-// RUN: %clangxx_msan %s -o %t && MSAN_OPTIONS=intercept_strndup=0 %run %t 2>&1 | FileCheck --check-prefix=OFF --allow-empty %s
+// RUN: %clangxx_msan %s -o %t && env MSAN_OPTIONS=intercept_strndup=0 %run %t 2>&1 | FileCheck --check-prefix=OFF --allow-empty %s
 
 // When built as C on Linux, strndup is transformed to __strndup.
 // RUN: %clangxx_msan -O3 -xc %s -o %t && not %run %t 2>&1 | FileCheck --check-prefix=ON %s

--- a/compiler-rt/test/profile/Linux/instrprof-comdat.test
+++ b/compiler-rt/test/profile/Linux/instrprof-comdat.test
@@ -1,6 +1,6 @@
 RUN: mkdir -p %t.d
 RUN: %clangxx_profgen -o %t.d/comdat -fcoverage-mapping -fuse-ld=gold %S/../Inputs/instrprof-comdat-1.cpp %S/../Inputs/instrprof-comdat-2.cpp
-RUN: LLVM_PROFILE_FILE=%t-comdat.profraw %run %t.d/comdat
+RUN: env LLVM_PROFILE_FILE=%t-comdat.profraw %run %t.d/comdat
 RUN: llvm-profdata merge -o %t.d/comdat.prof %t-comdat.profraw 
 RUN: llvm-cov show --instr-profile=%t.d/comdat.prof %t.d/comdat | FileCheck --check-prefix=HEADER %S/../Inputs/instrprof-comdat.h
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_segv_handler.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_segv_handler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -O1 %s -o %t && TSAN_OPTIONS="flush_memory_ms=1 memory_limit_mb=1" %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx -O1 %s -o %t && env TSAN_OPTIONS="flush_memory_ms=1 memory_limit_mb=1" %run %t 2>&1 | FileCheck %s
 
 // JVM uses SEGV to preempt threads. All threads do a load from a known address
 // periodically. When runtime needs to preempt threads, it unmaps the page.

--- a/compiler-rt/test/ubsan/TestCases/Misc/Linux/static-link.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/Linux/static-link.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: ubsan-standalone
 // REQUIRES: target={{x86_64.*}}
 // UNSUPPORTED: i386-target-arch, internal_symbolizer
-// RUN: %clangxx -fsanitize=bool -static  %s -o %t && UBSAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigfpe=0 %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx -fsanitize=bool -static  %s -o %t && env UBSAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigfpe=0 %run %t 2>&1 | FileCheck %s
 // RUN: %run %t 2>&1 | FileCheck %s
 #include <signal.h>
 #include <stdio.h>

--- a/compiler-rt/test/xray/TestCases/Posix/arg1-arg0-logging.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/arg1-arg0-logging.cpp
@@ -3,7 +3,7 @@
 //
 // RUN: rm -f arg0-arg1-logging-*
 // RUN: %clangxx_xray -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=true verbosity=1 xray_logfile_base=arg0-arg1-logging-" %run %t
+// RUN: env XRAY_OPTIONS="patch_premain=true verbosity=1 xray_logfile_base=arg0-arg1-logging-" %run %t
 
 // REQUIRES: target={{(aarch64|x86_64)-.*}}
 

--- a/compiler-rt/test/xray/TestCases/Posix/arg1-logger.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/arg1-logger.cpp
@@ -3,7 +3,7 @@
 //
 // RUN: %clangxx_xray -std=c++11 %s -o %t
 // RUN: rm -f arg1-logger-*
-// RUN: XRAY_OPTIONS="patch_premain=true verbosity=1 xray_mode=xray-basic \
+// RUN: env XRAY_OPTIONS="patch_premain=true verbosity=1 xray_mode=xray-basic \
 // RUN:    xray_logfile_base=arg1-logger-" %run %t 2>&1 | FileCheck %s
 //
 // After all that, clean up the XRay log file.

--- a/compiler-rt/test/xray/TestCases/Posix/arg1-logging-implicit-this.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/arg1-logging-implicit-this.cpp
@@ -2,7 +2,7 @@
 //
 // RUN: %clangxx_xray -g -std=c++11 %s -o %t
 // RUN: rm -f log-args-this-*
-// RUN: XRAY_OPTIONS="patch_premain=true verbosity=1 xray_logfile_base=log-args-this-" %run %t
+// RUN: env XRAY_OPTIONS="patch_premain=true verbosity=1 xray_logfile_base=log-args-this-" %run %t
 
 // REQUIRES: target={{(aarch64|x86_64)-.*}}
 

--- a/compiler-rt/test/xray/TestCases/Posix/argv0-log-file-name.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/argv0-log-file-name.cpp
@@ -2,7 +2,7 @@
 // name.
 
 // RUN: %clangxx_xray -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic" %run %t > xray.log.file.name 2>&1
+// RUN: env XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic" %run %t > xray.log.file.name 2>&1
 // RUN: ls | FileCheck xray.log.file.name
 // RUN: rm xray-log.argv0-log-file-name.* xray.log.file.name
 

--- a/compiler-rt/test/xray/TestCases/Posix/coverage-sample.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/coverage-sample.cpp
@@ -1,9 +1,9 @@
 // Check that we can patch and unpatch specific function ids.
 //
 // RUN: %clangxx_xray -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=false" %run %t | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=false" %run %t | FileCheck %s
 // RUN: %clangxx_xray -fno-xray-function-index -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=false" %run %t | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=false" %run %t | FileCheck %s
 
 // UNSUPPORTED: target-is-mips64,target-is-mips64el
 

--- a/compiler-rt/test/xray/TestCases/Posix/fdr-reinit.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/fdr-reinit.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: target={{(aarch64|arm).*}}
 // RUN: %clangxx_xray -g -std=c++11 %s -o %t
 // RUN: rm xray-log.fdr-reinit* || true
-// RUN: XRAY_OPTIONS="verbosity=1" %run %t
+// RUN: env XRAY_OPTIONS="verbosity=1" %run %t
 // RUN: rm xray-log.fdr-reinit* || true
 #include "xray/xray_log_interface.h"
 #include <atomic>

--- a/compiler-rt/test/xray/TestCases/Posix/fixedsize-logging.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/fixedsize-logging.cpp
@@ -1,7 +1,7 @@
 // Check to make sure that we have a log file with a fixed-size.
 
 // RUN: %clangxx_xray -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic verbosity=1 xray_logfile_base=fixedsize-logging-" %run %t 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic verbosity=1 xray_logfile_base=fixedsize-logging-" %run %t 2>&1 | FileCheck %s
 //
 // After all that, clean up the output xray log.
 //

--- a/compiler-rt/test/xray/TestCases/Posix/func-id-utils.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/func-id-utils.cpp
@@ -2,9 +2,9 @@
 // maximum function id for the current binary.
 //
 // RUN: %clangxx_xray -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=false" %run %t
+// RUN: env XRAY_OPTIONS="patch_premain=false" %run %t
 // RUN: %clangxx_xray -fno-xray-function-index -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=false" %run %t
+// RUN: env XRAY_OPTIONS="patch_premain=false" %run %t
 
 // UNSUPPORTED: target-is-mips64,target-is-mips64el
 

--- a/compiler-rt/test/xray/TestCases/Posix/optional-inmemory-log.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/optional-inmemory-log.cpp
@@ -2,7 +2,7 @@
 // we turn it off via options.
 
 // RUN: %clangxx_xray -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=true verbosity=1 xray_logfile_base=optional-inmemory-log.xray-" %run %t 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=true verbosity=1 xray_logfile_base=optional-inmemory-log.xray-" %run %t 2>&1 | FileCheck %s
 //
 // Make sure we clean out the logs in case there was a bug.
 //

--- a/compiler-rt/test/xray/TestCases/Posix/patching-unpatching.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/patching-unpatching.cpp
@@ -2,9 +2,9 @@
 // appropriately.
 //
 // RUN: %clangxx_xray -fxray-instrument -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=false" %run %t 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=false" %run %t 2>&1 | FileCheck %s
 // RUN: %clangxx_xray -fxray-instrument -fno-xray-function-index -std=c++11 %s -o %t
-// RUN: XRAY_OPTIONS="patch_premain=false" %run %t 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=false" %run %t 2>&1 | FileCheck %s
 
 // UNSUPPORTED: target-is-mips64,target-is-mips64el
 

--- a/compiler-rt/test/xray/TestCases/Posix/pic_test.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/pic_test.cpp
@@ -3,7 +3,7 @@
 // RUN: %clangxx_xray -fxray-instrument -std=c++11 -ffunction-sections \
 // RUN:     -fdata-sections -fpic -fpie -Wl,--gc-sections %s -o %t
 // RUN: rm -f pic-test-logging-*
-// RUN: XRAY_OPTIONS="patch_premain=true verbosity=1 xray_mode=xray-basic \
+// RUN: env XRAY_OPTIONS="patch_premain=true verbosity=1 xray_mode=xray-basic \
 // RUN:     xray_logfile_base=pic-test-logging-" %run %t 2>&1 | FileCheck %s
 // After all that, clean up the output xray log.
 //

--- a/compiler-rt/test/xray/TestCases/Posix/typed-event-logging.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/typed-event-logging.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx_xray %s -o %t
-// RUN: XRAY_OPTIONS=patch_premain=false:verbosity=1 %run %t 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS=patch_premain=false:verbosity=1 %run %t 2>&1 | FileCheck %s
 
 // REQUIRES: target={{(aarch64|x86_64)-.*linux.*}}
 


### PR DESCRIPTION
When running tests in compiler-rt using the lit internal shell with the following command:
```
LIT_USE_INTERNAL_SHELL=1 ninja check-compiler-rt
```
one common error that occurs is:
```
'XRAY_OPTIONS=patch_premain=false:verbosity=1': command not found
```
This error, along with over 50 similar "environment variable not found" errors, appears across 35 files in complier-rt. These errors happen because the environment variables are not being set correctly when the internal shell is used, leading to commands failing due to unrecognized environment variables.

This patch addresses the issue by using the `env` command to properly set the environment variables before running the tests. By explicitly setting the environment variables through `env`, the internal shell can correctly interpret and apply them, allowing the tests to pass.
fixes: #106598
[link to RFC](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179) 