### PR TITLE
[test] Avoid writing to a potentially write-protected dir

### DIFF
--- a/clang/test/SemaHLSL/BuiltIns/length-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/length-errors.hlsl
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -verify -verify-ignore-unexpected
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -disable-llvm-passes -verify -verify-ignore-unexpected
+
 
 void test_too_few_arg()
 {


### PR DESCRIPTION
The test length-errors.hlsl don't check the output written to the current directory. The current directory may be write protected e.g. in a sandboxed environment.

This patch simply remove the -emit-llvm option as this testcase don't care about the outputed llvm IR.