### PR TITLE
[clang-format] Adjust requires clause wrapping (#101550)

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5379,22 +5379,47 @@ the configuration (without a prefix: ``Auto``).
   Possible values:
 
   * ``RCPS_OwnLine`` (in configuration: ``OwnLine``)
-    Always put the ``requires`` clause on its own line.
+    Always put the ``requires`` clause on its own line (possibly followed by
+    a semicolon).
 
     .. code-block:: c++
 
       template <typename T>
-      requires C<T>
+        requires C<T>
       struct Foo {...
 
       template <typename T>
-      requires C<T>
+      void bar(T t)
+        requires C<T>;
+
+      template <typename T>
+        requires C<T>
       void bar(T t) {...
 
       template <typename T>
       void baz(T t)
-      requires C<T>
+        requires C<T>
       {...
+
+  * ``RCPS_OwnLineWithBrace`` (in configuration: ``OwnLineWithBrace``)
+    As with ``OwnLine``, except, unless otherwise prohibited, place a
+    following open brace (of a function definition) to follow on the same
+    line.
+
+    .. code-block:: c++
+
+      void bar(T t)
+        requires C<T> {
+        return;
+      }
+
+      void bar(T t)
+        requires C<T> {}
+
+      template <typename T>
+        requires C<T>
+      void baz(T t) {
+        ...
 
   * ``RCPS_WithPreceding`` (in configuration: ``WithPreceding``)
     Try to put the clause together with the preceding part of a declaration.

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4147,7 +4147,8 @@ the configuration (without a prefix: ``Auto``).
 
 **IndentRequiresClause** (``Boolean``) :versionbadge:`clang-format 15` :ref:`¶ <IndentRequiresClause>`
   Indent the requires clause in a template. This only applies when
-  ``RequiresClausePosition`` is ``OwnLine``, or ``WithFollowing``.
+  ``RequiresClausePosition`` is ``OwnLine``, ``OwnLineWithBrace``,
+  or ``WithFollowing``.
 
   In clang-format 12, 13 and 14 it was named ``IndentRequires``.
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2823,7 +2823,8 @@ struct FormatStyle {
   PPDirectiveIndentStyle IndentPPDirectives;
 
   /// Indent the requires clause in a template. This only applies when
-  /// ``RequiresClausePosition`` is ``OwnLine``, or ``WithFollowing``.
+  /// ``RequiresClausePosition`` is ``OwnLine``, ``OwnLineWithBrace``,
+  /// or ``WithFollowing``.
   ///
   /// In clang-format 12, 13 and 14 it was named ``IndentRequires``.
   /// \code

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3909,22 +3909,45 @@ struct FormatStyle {
   /// ``IndentRequires`` option is only used if the ``requires`` is put on the
   /// start of a line.
   enum RequiresClausePositionStyle : int8_t {
-    /// Always put the ``requires`` clause on its own line.
+    /// Always put the ``requires`` clause on its own line (possibly followed by
+    /// a semicolon).
     /// \code
     ///   template <typename T>
-    ///   requires C<T>
+    ///     requires C<T>
     ///   struct Foo {...
     ///
     ///   template <typename T>
-    ///   requires C<T>
+    ///   void bar(T t)
+    ///     requires C<T>;
+    ///
+    ///   template <typename T>
+    ///     requires C<T>
     ///   void bar(T t) {...
     ///
     ///   template <typename T>
     ///   void baz(T t)
-    ///   requires C<T>
+    ///     requires C<T>
     ///   {...
     /// \endcode
     RCPS_OwnLine,
+    /// As with ``OwnLine``, except, unless otherwise prohibited, place a
+    /// following open brace (of a function definition) to follow on the same
+    /// line.
+    /// \code
+    ///   void bar(T t)
+    ///     requires C<T> {
+    ///     return;
+    ///   }
+    ///
+    ///   void bar(T t)
+    ///     requires C<T> {}
+    ///
+    ///   template <typename T>
+    ///     requires C<T>
+    ///   void baz(T t) {
+    ///     ...
+    /// \endcode
+    RCPS_OwnLineWithBrace,
     /// Try to put the clause together with the preceding part of a declaration.
     /// For class templates: stick to the template declaration.
     /// For function templates: stick to the template declaration.

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1395,6 +1395,7 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
     switch (Style.RequiresClausePosition) {
     case FormatStyle::RCPS_OwnLine:
     case FormatStyle::RCPS_WithFollowing:
+    case FormatStyle::RCPS_OwnLineWithBrace:
       return CurrentState.Indent;
     default:
       break;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -530,6 +530,7 @@ struct ScalarEnumerationTraits<FormatStyle::RequiresClausePositionStyle> {
   static void enumeration(IO &IO,
                           FormatStyle::RequiresClausePositionStyle &Value) {
     IO.enumCase(Value, "OwnLine", FormatStyle::RCPS_OwnLine);
+    IO.enumCase(Value, "OwnLineWithBrace", FormatStyle::RCPS_OwnLineWithBrace);
     IO.enumCase(Value, "WithPreceding", FormatStyle::RCPS_WithPreceding);
     IO.enumCase(Value, "WithFollowing", FormatStyle::RCPS_WithFollowing);
     IO.enumCase(Value, "SingleLine", FormatStyle::RCPS_SingleLine);

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5683,15 +5683,13 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
            (Style.BreakTemplateDeclarations == FormatStyle::BTDS_Leave &&
             Right.NewlinesBefore > 0);
   }
-  if (Left.ClosesRequiresClause && Right.isNot(tok::semi)) {
+  if (Left.ClosesRequiresClause) {
     switch (Style.RequiresClausePosition) {
     case FormatStyle::RCPS_OwnLine:
     case FormatStyle::RCPS_WithPreceding:
-      return true;
+      return Right.isNot(tok::semi);
     case FormatStyle::RCPS_OwnLineWithBrace:
-      if (Right.isNot(tok::l_brace))
-        return true;
-      break;
+      return !Right.isOneOf(tok::semi, tok::l_brace);
     default:
       break;
     }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5664,6 +5664,7 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
   if (Right.is(TT_RequiresClause)) {
     switch (Style.RequiresClausePosition) {
     case FormatStyle::RCPS_OwnLine:
+    case FormatStyle::RCPS_OwnLineWithBrace:
     case FormatStyle::RCPS_WithFollowing:
       return true;
     default:
@@ -5682,12 +5683,15 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
            (Style.BreakTemplateDeclarations == FormatStyle::BTDS_Leave &&
             Right.NewlinesBefore > 0);
   }
-  if (Left.ClosesRequiresClause && Right.isNot(tok::semi) &&
-      Right.isNot(tok::l_brace)) {
+  if (Left.ClosesRequiresClause && Right.isNot(tok::semi)) {
     switch (Style.RequiresClausePosition) {
     case FormatStyle::RCPS_OwnLine:
     case FormatStyle::RCPS_WithPreceding:
       return true;
+    case FormatStyle::RCPS_OwnLineWithBrace:
+      if (Right.isNot(tok::l_brace))
+        return true;
+      break;
     default:
       break;
     }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5682,7 +5682,8 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
            (Style.BreakTemplateDeclarations == FormatStyle::BTDS_Leave &&
             Right.NewlinesBefore > 0);
   }
-  if (Left.ClosesRequiresClause && Right.isNot(tok::semi)) {
+  if (Left.ClosesRequiresClause && Right.isNot(tok::semi) &&
+      Right.isNot(tok::l_brace)) {
     switch (Style.RequiresClausePosition) {
     case FormatStyle::RCPS_OwnLine:
     case FormatStyle::RCPS_WithPreceding:

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -25860,10 +25860,6 @@ TEST_F(FormatTest, RequiresClausesPositions) {
   Style.RequiresClausePosition = FormatStyle::RCPS_OwnLineWithBrace;
   Style.IndentRequiresClause = true;
 
-  // The default in LLVM style is REI_OuterScope, but these tests were written
-  // when the default was REI_Keyword.
-  Style.RequiresExpressionIndentation = FormatStyle::REI_Keyword;
-
   verifyFormat("template <typename T>\n"
                "  requires(Foo<T> && std::trait<T>)\n"
                "struct Bar;",

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4325,8 +4325,7 @@ TEST_F(FormatTest, FormatsNamespaces) {
                Style);
   verifyFormat("template <int I>\n"
                "constexpr void foo()\n"
-               "  requires(I == 42)\n"
-               "{}\n"
+               "  requires(I == 42) {}\n"
                "namespace ns {\n"
                "void foo() {}\n"
                "} // namespace ns",
@@ -17041,12 +17040,10 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
   EXPECT_FALSE(
       SpaceAfterRequires.SpaceBeforeParensOptions.AfterRequiresInExpression);
   verifyFormat("void f(auto x)\n"
-               "  requires requires(int i) { x + i; }\n"
-               "{}",
+               "  requires requires(int i) { x + i; } {}",
                SpaceAfterRequires);
   verifyFormat("void f(auto x)\n"
-               "  requires(requires(int i) { x + i; })\n"
-               "{}",
+               "  requires(requires(int i) { x + i; }) {}",
                SpaceAfterRequires);
   verifyFormat("if (requires(int i) { x + i; })\n"
                "  return;",
@@ -17059,12 +17056,10 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
 
   SpaceAfterRequires.SpaceBeforeParensOptions.AfterRequiresInClause = true;
   verifyFormat("void f(auto x)\n"
-               "  requires requires(int i) { x + i; }\n"
-               "{}",
+               "  requires requires(int i) { x + i; } {}",
                SpaceAfterRequires);
   verifyFormat("void f(auto x)\n"
-               "  requires (requires(int i) { x + i; })\n"
-               "{}",
+               "  requires (requires(int i) { x + i; }) {}",
                SpaceAfterRequires);
   verifyFormat("if (requires(int i) { x + i; })\n"
                "  return;",
@@ -17078,12 +17073,10 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
   SpaceAfterRequires.SpaceBeforeParensOptions.AfterRequiresInClause = false;
   SpaceAfterRequires.SpaceBeforeParensOptions.AfterRequiresInExpression = true;
   verifyFormat("void f(auto x)\n"
-               "  requires requires (int i) { x + i; }\n"
-               "{}",
+               "  requires requires (int i) { x + i; } {}",
                SpaceAfterRequires);
   verifyFormat("void f(auto x)\n"
-               "  requires(requires (int i) { x + i; })\n"
-               "{}",
+               "  requires(requires (int i) { x + i; }) {}",
                SpaceAfterRequires);
   verifyFormat("if (requires (int i) { x + i; })\n"
                "  return;",
@@ -17096,12 +17089,10 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
 
   SpaceAfterRequires.SpaceBeforeParensOptions.AfterRequiresInClause = true;
   verifyFormat("void f(auto x)\n"
-               "  requires requires (int i) { x + i; }\n"
-               "{}",
+               "  requires requires (int i) { x + i; } {}",
                SpaceAfterRequires);
   verifyFormat("void f(auto x)\n"
-               "  requires (requires (int i) { x + i; })\n"
-               "{}",
+               "  requires (requires (int i) { x + i; }) {}",
                SpaceAfterRequires);
   verifyFormat("if (requires (int i) { x + i; })\n"
                "  return;",
@@ -25799,8 +25790,7 @@ TEST_F(FormatTest, RequiresClausesPositions) {
                "  requires Foo<T> && requires(T t) {\n"
                "                       { t.baz() } -> std::same_as<bool>;\n"
                "                       requires std::same_as<T::Factor, int>;\n"
-               "                     }\n"
-               "{\n"
+               "                     } {\n"
                "  return t.baz() ? T::Factor : 5;\n"
                "}",
                Style);
@@ -25814,16 +25804,14 @@ TEST_F(FormatTest, RequiresClausesPositions) {
 
   verifyFormat("template <typename T>\n"
                "int bar(T t)\n"
-               "  requires F<T>\n"
-               "{\n"
+               "  requires F<T> {\n"
                "  return 5;\n"
                "}",
                Style);
 
   verifyFormat("template <typename T>\n"
                "int S::bar(T t) &&\n"
-               "  requires F<T>\n"
-               "{\n"
+               "  requires F<T> {\n"
                "  return 5;\n"
                "}",
                Style);
@@ -25843,16 +25831,14 @@ TEST_F(FormatTest, RequiresClausesPositions) {
 
   verifyFormat("template <typename T>\n"
                "int S::bar(T t) &&\n"
-               "requires F<T>\n"
-               "{\n"
+               "requires F<T> {\n"
                "  return 5;\n"
                "}",
                Style);
 
   verifyFormat("template <typename T>\n"
                "int bar(T t)\n"
-               "requires F<T>\n"
-               "{\n"
+               "requires F<T> {\n"
                "  return 5;\n"
                "}",
                Style);
@@ -25982,13 +25968,9 @@ TEST_F(FormatTest, RequiresClausesPositions) {
                "struct Bar {};\n"
                "template <typename T> requires Foo<T>\n"
                "void bar() {}\n"
-               "template <typename T>\n"
-               "void bar() requires Foo<T>\n"
-               "{}\n"
+               "template <typename T> void bar() requires Foo<T> {}\n"
                "template <typename T> void bar() requires Foo<T>;\n"
-               "template <typename T>\n"
-               "void S::bar() && requires Foo<T>\n"
-               "{}\n"
+               "template <typename T> void S::bar() && requires Foo<T> {}\n"
                "template <typename T> requires Foo<T>\n"
                "Bar(T) -> Bar<T>;",
                Style);
@@ -26001,8 +25983,7 @@ TEST_F(FormatTest, RequiresClausesPositions) {
                "void bar() {}\n"
                "template <typename AAAAAAA>\n"
                "void bar()\n"
-               "    requires Foo<AAAAAAAAAAAAAAAA>\n"
-               "{}\n"
+               "    requires Foo<AAAAAAAAAAAAAAAA> {}\n"
                "template <typename AAAAAAA>\n"
                "requires Foo<AAAAAAAA>\n"
                "Bar(T) -> Bar<T>;\n"


### PR DESCRIPTION
Address #101550 by adjusting line wrapping after a requires clause to permit a following '{' on the same line with OwnLine and WithPreceeding RequiresClausePositioning.

Thus, instead of:
```
bool Foo ()
  requires(true)
{
  return true;
}
```

we have:
```
bool Foo ()
  requires(true) {
  return true;
}
```

If the function body is empty, we'll get:
```
bool Foo ()
  requires(true) {}
```

I attempted to get a line break between the open and close braces, but failed. Perhaps that's fine -- it's rare and only happens in the empty body case.