### PR TITLE
[LLDB] Add `<cstdint>` to AddressableBits

### DIFF
--- a/lldb/include/lldb/Utility/AddressableBits.h
+++ b/lldb/include/lldb/Utility/AddressableBits.h
@@ -12,6 +12,8 @@
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-public.h"
 
+#include <cstdint>
+
 namespace lldb_private {
 
 /// \class AddressableBits AddressableBits.h "lldb/Core/AddressableBits.h"


### PR DESCRIPTION
AddressableBits uses `uint32_t` without including `<cstdint>` which fails to build w/ GCC 15 after a change in libstdc++ [0]

[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2