### PR TITLE
[C++20] [Modules] Don't set modules owner ship information for builtin declarations

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2376,6 +2376,12 @@ NamedDecl *Sema::LazilyCreateBuiltin(IdentifierInfo *II, unsigned ID,
   FunctionDecl *New = CreateBuiltin(II, R, ID, Loc);
   RegisterLocallyScopedExternCDecl(New, S);
 
+  // Builtin functions shouldn't be owned by any module.
+  if (New->hasOwningModule()) {
+    New->setLocalOwningModule(nullptr);
+    New->setModuleOwnershipKind(Decl::ModuleOwnershipKind::Unowned);
+  }
+
   // TUScope is the translation-unit scope to insert this function into.
   // FIXME: This is hideous. We need to teach PushOnScopeChains to
   // relate Scopes to DeclContexts, and probably eliminate CurContext

--- a/clang/test/Modules/pr101939.cppm
+++ b/clang/test/Modules/pr101939.cppm
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -std=c++20 %s -ast-dump | FileCheck %s
+
+export module mod;
+export auto a = __builtin_expect(true, true);
+
+// CHECK-NOT: FunctionDecl{{.*}} in mod {{.*}} __builtin_expect


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/101939

As the issue said, the builtin declarations shouldn't be in any modules.