### PR TITLE
[clang][Interp] Fix getField() for integral pointers

### DIFF
--- a/clang/lib/AST/Interp/Compiler.cpp
+++ b/clang/lib/AST/Interp/Compiler.cpp
@@ -335,6 +335,10 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
     if (!PointeeType.isNull()) {
       if (std::optional<PrimType> T = classify(PointeeType))
         Desc = P.createDescriptor(SubExpr, *T);
+      else
+        Desc = P.createDescriptor(SubExpr, PointeeType.getTypePtr(),
+                                  std::nullopt, true, false,
+                                  /*IsMutable=*/false, nullptr);
     }
     return this->emitNull(classifyPrim(CE->getType()), Desc, CE);
   }

--- a/clang/lib/AST/Interp/Interp.h
+++ b/clang/lib/AST/Interp/Interp.h
@@ -1504,6 +1504,12 @@ inline bool GetPtrField(InterpState &S, CodePtr OpPC, uint32_t Off) {
 
   if (Ptr.isBlockPointer() && Off > Ptr.block()->getSize())
     return false;
+
+  if (Ptr.isIntegralPointer()) {
+    S.Stk.push<Pointer>(Ptr.asIntPointer().atOffset(S.getCtx(), Off));
+    return true;
+  }
+
   S.Stk.push<Pointer>(Ptr.atField(Off));
   return true;
 }
@@ -1526,6 +1532,11 @@ inline bool GetPtrFieldPop(InterpState &S, CodePtr OpPC, uint32_t Off) {
 
   if (Ptr.isBlockPointer() && Off > Ptr.block()->getSize())
     return false;
+
+  if (Ptr.isIntegralPointer()) {
+    S.Stk.push<Pointer>(Ptr.asIntPointer().atOffset(S.getCtx(), Off));
+    return true;
+  }
 
   S.Stk.push<Pointer>(Ptr.atField(Off));
   return true;

--- a/clang/lib/AST/Interp/Pointer.h
+++ b/clang/lib/AST/Interp/Pointer.h
@@ -44,6 +44,8 @@ struct BlockPointer {
 struct IntPointer {
   const Descriptor *Desc;
   uint64_t Value;
+
+  IntPointer atOffset(const ASTContext &ASTCtx, unsigned Offset) const;
 };
 
 enum class Storage { Block, Int, Fn };
@@ -87,6 +89,9 @@ public:
     StorageKind = Storage::Int;
     PointeeStorage.Int.Value = 0;
     PointeeStorage.Int.Desc = nullptr;
+  }
+  Pointer(IntPointer &&IntPtr) : StorageKind(Storage::Int) {
+    PointeeStorage.Int = std::move(IntPtr);
   }
   Pointer(Block *B);
   Pointer(Block *B, uint64_t BaseAndOffset);
@@ -161,9 +166,8 @@ public:
 
   /// Creates a pointer to a field.
   [[nodiscard]] Pointer atField(unsigned Off) const {
+    assert(isBlockPointer());
     unsigned Field = Offset + Off;
-    if (isIntegralPointer())
-      return Pointer(asIntPointer().Value + Field, asIntPointer().Desc);
     return Pointer(asBlockPointer().Pointee, Field, Field);
   }
 

--- a/clang/test/AST/Interp/c.c
+++ b/clang/test/AST/Interp/c.c
@@ -101,8 +101,6 @@ int somefunc(int i) {
                              // all-warning {{overflow in expression; result is 131'073 with type 'int'}}
 }
 
-/// FIXME: The following test is incorrect in the new interpreter.
-/// The null pointer returns 16 from its getIntegerRepresentation().
 #pragma clang diagnostic ignored "-Wpointer-to-int-cast"
 struct ArrayStruct {
   char n[1];
@@ -111,10 +109,7 @@ char name2[(int)&((struct ArrayStruct*)0)->n]; // expected-warning {{folded to c
                                                // pedantic-expected-warning {{folded to constant array}} \
                                                // ref-warning {{folded to constant array}} \
                                                // pedantic-ref-warning {{folded to constant array}}
-_Static_assert(sizeof(name2) == 0, ""); // expected-error {{failed}} \
-                                        // expected-note {{evaluates to}} \
-                                        // pedantic-expected-error {{failed}} \
-                                        // pedantic-expected-note {{evaluates to}}
+_Static_assert(sizeof(name2) == 0, "");
 
 #ifdef __SIZEOF_INT128__
 void *PR28739d = &(&PR28739d)[(__int128)(unsigned long)-1]; // all-warning {{refers past the last possible element}}


### PR DESCRIPTION
Instead of just adding the Record::Field offset, instead get the FieldDecl offset in the RecordLayout.

Unfortunately, the offset we pass to the ops here is not made to easily go back to a FieldDecl, so we have to iterate over the parent Record.