### PR TITLE
[Clang][NFC] Restore "Non-comprehensive list of changes in this release" in ReleaseNotes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -105,6 +105,9 @@ C2y Feature Support
 C23 Feature Support
 ^^^^^^^^^^^^^^^^^^^
 
+Non-comprehensive list of changes in this release
+-------------------------------------------------
+
 New Compiler Flags
 ------------------
 


### PR DESCRIPTION
This was removed in 10c6d6349e51bb245b9deec4aafca9885971135b