### PR TITLE
[clang][Interp] Ignore ObjCBoxedExpr subexpr...

### DIFF
--- a/clang/lib/AST/Interp/Compiler.cpp
+++ b/clang/lib/AST/Interp/Compiler.cpp
@@ -3161,10 +3161,11 @@ bool Compiler<Emitter>::VisitExtVectorElementExpr(
 
 template <class Emitter>
 bool Compiler<Emitter>::VisitObjCBoxedExpr(const ObjCBoxedExpr *E) {
+  const Expr *SubExpr = E->getSubExpr();
   if (!E->isExpressibleAsConstantInitializer())
-    return this->emitInvalid(E);
+    return this->discard(SubExpr) && this->emitInvalid(E);
 
-  return this->delegate(E->getSubExpr());
+  return this->delegate(SubExpr);
 }
 
 template <class Emitter>

--- a/clang/test/AST/Interp/objc.mm
+++ b/clang/test/AST/Interp/objc.mm
@@ -11,3 +11,28 @@
 @end
 constexpr NSString *t0 = @"abc";
 constexpr NSString *t1 = @("abc");
+
+
+#if __LP64__
+typedef unsigned long NSUInteger;
+typedef long NSInteger;
+#else
+typedef unsigned int NSUInteger;
+typedef int NSInteger;
+#endif
+
+
+@class NSNumber;
+
+
+@interface NSObject
++ (NSObject*)nsobject;
+@end
+
+@interface NSNumber : NSObject
++ (NSNumber *)numberWithInt:(int)value;
+@end
+
+int main(void) {
+  NSNumber *bv = @(1391126400 * 1000); // both-warning {{overflow in expression; result is -443'003'904 with type 'int'}}
+}


### PR DESCRIPTION
... if it can't be expressed as a constant initializer.