### PR TITLE
[lldb][Docs] Add edit link to docs pages

### DIFF
--- a/lldb/docs/_templates/components/edit-this-page.html
+++ b/lldb/docs/_templates/components/edit-this-page.html
@@ -1,0 +1,9 @@
+{% extends "furo/components/edit-this-page.html" %}
+
+{% block link_available -%}
+{%- if pagename.startswith("python_api") -%}
+  <!-- Python API docs are generated. -->
+{%- else -%}
+  {{ furo_edit_button(determine_page_edit_link()) }}
+{%- endif -%}
+{%- endblock %}

--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -167,9 +167,9 @@ html_theme = "furo"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  "source_repository": "https://github.com/llvm/llvm-project",
-  "source_branch": "main",
-  "source_directory": "lldb/docs/",
+    "source_repository": "https://github.com/llvm/llvm-project",
+    "source_branch": "main",
+    "source_directory": "lldb/docs/",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -166,7 +166,11 @@ html_theme = "furo"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {}
+html_theme_options = {
+  "source_repository": "https://github.com/llvm/llvm-project",
+  "source_branch": "main",
+  "source_directory": "lldb/docs/",
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
That aren't the generated `python_api/` pages.

This button is a pencil icon at the top right of the page and takes you to a GitHub page where you can edit the content, assuming you have a fork already. If not it tells you how to make one.

This is hardcoded to the llvm-project URL and main branch. So folks will need a downstream patch if they want to change that.

For the upstream repo, main is right because even if a release branch was open for PRs, it would only be for cherry picks from main.

The icon isn't as obvious as the "edit on GitHub" icons seen elsewhere but it's built in, and we could change it later if we wanted to.