### PR TITLE
[GlobalISel] Combiner: Install Observer into MachineFunction

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/Combiner.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Combiner.cpp
@@ -153,7 +153,7 @@ bool Combiner::combineMachineInstrs() {
     // down RPOT.
     Changed = false;
 
-    RAIIDelegateInstaller DelInstall(MF, ObserverWrapper.get());
+    RAIIMFObsDelInstaller DelInstall(MF, *ObserverWrapper);
     for (MachineBasicBlock *MBB : post_order(&MF)) {
       for (MachineInstr &CurMI :
            llvm::make_early_inc_range(llvm::reverse(*MBB))) {


### PR DESCRIPTION
The Combiner doesn't install the Observer into the MachineFunction.
This probably went unnoticed, because MachineFunction::getObserver() is
currently only used in constrainOperandRegClass(), but this might cause
issues down the line.
