### PR TITLE
[mlir] [python] Update PyYAML minimum version to 5.4 and limit ml_dtypes to 0.4.0

### DIFF
--- a/mlir/python/requirements.txt
+++ b/mlir/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.19.5, <=1.26
 pybind11>=2.9.0, <=2.10.3
 PyYAML>=5.4.0, <=6.0.1
-ml_dtypes<=0.4.0   # provides several NumPy dtype extensions, including the bf16
+ml_dtypes>=0.1.0, <=0.4.0   # provides several NumPy dtype extensions, including the bf16

--- a/mlir/python/requirements.txt
+++ b/mlir/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.19.5, <=1.26
 pybind11>=2.9.0, <=2.10.3
 PyYAML>=5.4.0, <=6.0.1
-ml_dtypes>=0.4.0   # provides several NumPy dtype extensions, including the bf16
+ml_dtypes<=0.4.0   # provides several NumPy dtype extensions, including the bf16

--- a/mlir/python/requirements.txt
+++ b/mlir/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.19.5, <=1.26
 pybind11>=2.9.0, <=2.10.3
-PyYAML>=5.3.1, <=6.0.1
+PyYAML>=5.4, <=6.0.1
 ml_dtypes   # provides several NumPy dtype extensions, including the bf16

--- a/mlir/python/requirements.txt
+++ b/mlir/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.19.5, <=1.26
 pybind11>=2.9.0, <=2.10.3
-PyYAML>=5.4, <=6.0.1
-ml_dtypes   # provides several NumPy dtype extensions, including the bf16
+PyYAML>=5.4.0, <=6.0.1
+ml_dtypes>=0.4.0   # provides several NumPy dtype extensions, including the bf16


### PR DESCRIPTION
PyYAML 5.3.1 has a security vulnerability as described here: https://nvd.nist.gov/vuln/detail/CVE-2020-14343. Update the minimum PyYAML version to 5.4. Also limit ml_dtypes version to 0.4.0.