### PR TITLE
[CodeGen] Fix PreISelLowering not reporting changes

### DIFF
--- a/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
@@ -357,12 +357,14 @@ bool PreISelIntrinsicLowering::lowerIntrinsics(Module &M) const {
 #define BEGIN_REGISTER_VP_INTRINSIC(VPID, MASKPOS, VLENPOS)                    \
   case Intrinsic::VPID:
 #include "llvm/IR/VPIntrinsics.def"
-      Changed |= forEachCall(F, [&](CallInst *CI) {
+      forEachCall(F, [&](CallInst *CI) {
         Function *Parent = CI->getParent()->getParent();
         const TargetTransformInfo &TTI = LookupTTI(*Parent);
         auto *VPI = cast<VPIntrinsic>(CI);
         return expandVectorPredicationIntrinsic(*VPI, TTI);
       });
+      // Not all intrinsics are removed, but the code is changed in any case.
+      Changed = true;
       break;
     case Intrinsic::objc_autorelease:
       Changed |= lowerObjCCall(F, "objc_autorelease");


### PR DESCRIPTION
expandVectorPredication may change code, even if the intrinsic itself remains in the code. Report changes whenever such an intrinsic is encountered, because code could have been changed.

Another follow-up fix for #101652 to fix expensive-checks-only failure.