### PR TITLE
[CodeGen] Allocate RegAllocHints map lazily

### DIFF
--- a/llvm/lib/CodeGen/MachineRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegisterInfo.cpp
@@ -47,7 +47,6 @@ MachineRegisterInfo::MachineRegisterInfo(MachineFunction *MF)
                                : MF->getSubtarget().enableSubRegLiveness()) {
   unsigned NumRegs = getTargetRegisterInfo()->getNumRegs();
   VRegInfo.reserve(256);
-  RegAllocHints.reserve(256);
   UsedPhysRegMask.resize(NumRegs);
   PhysRegUseDefLists.reset(new MachineOperand*[NumRegs]());
   TheDelegates.clear();
@@ -147,7 +146,6 @@ MachineRegisterInfo::recomputeRegClass(Register Reg) {
 Register MachineRegisterInfo::createIncompleteVirtualRegister(StringRef Name) {
   Register Reg = Register::index2VirtReg(getNumVirtRegs());
   VRegInfo.grow(Reg);
-  RegAllocHints.grow(Reg);
   insertVRegByName(Name, Reg);
   return Reg;
 }

--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -421,13 +421,16 @@ bool TargetRegisterInfo::getRegAllocationHints(
     SmallVectorImpl<MCPhysReg> &Hints, const MachineFunction &MF,
     const VirtRegMap *VRM, const LiveRegMatrix *Matrix) const {
   const MachineRegisterInfo &MRI = MF.getRegInfo();
-  const std::pair<unsigned, SmallVector<Register, 4>> &Hints_MRI =
+  const std::pair<unsigned, SmallVector<Register, 4>> *Hints_MRI =
       MRI.getRegAllocationHints(VirtReg);
+
+  if (!Hints_MRI)
+    return false;
 
   SmallSet<Register, 32> HintedRegs;
   // First hint may be a target hint.
-  bool Skip = (Hints_MRI.first != 0);
-  for (auto Reg : Hints_MRI.second) {
+  bool Skip = (Hints_MRI->first != 0);
+  for (auto Reg : Hints_MRI->second) {
     if (Skip) {
       Skip = false;
       continue;

--- a/llvm/tools/llvm-reduce/deltas/ReduceVirtualRegisters.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceVirtualRegisters.cpp
@@ -23,9 +23,9 @@ static void dropRegisterHintsFromFunction(Oracle &O, MachineFunction &MF) {
   for (unsigned I = 0, E = MRI.getNumVirtRegs(); I != E; ++I) {
     Register Reg = Register::index2VirtReg(I);
 
-    const std::pair<unsigned, SmallVector<Register, 4>> &Hints =
+    const std::pair<unsigned, SmallVector<Register, 4>> *Hints =
         MRI.getRegAllocationHints(Reg);
-    if (Hints.second.empty())
+    if (!Hints || Hints->second.empty())
       continue;
 
     if (!O.shouldKeep())


### PR DESCRIPTION
This hint map is not required whenever a new register is added, in fact, at -O0, it is not used at all. Growing this map is quite expensive, as SmallVectors are not trivially copyable.

Grow this map only when hints are actually added to avoid multiple grows and grows when no hints are added at all.

[c-t-t](http://llvm-compile-time-tracker.com/compare.php?from=d337f5aa59fecd2413b076ed9573e378c57c1307&to=48d30d0cc360dee267986c6e07171ba92c198c5f&stat=instructions:u)