### PR TITLE
[RFC][libc++] Use IWYU pragma's.

### DIFF
--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -7,6 +7,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+// This header contains several configuration defines.
+// Removing the header would #ifndef TEST_FOO to unconditionally pass when
+// it's optionally defined in this header.
+//
+// IWYU pragma: always_keep
+
 #ifndef SUPPORT_TEST_MACROS_HPP
 #define SUPPORT_TEST_MACROS_HPP
 


### PR DESCRIPTION
The tools IWYU/clangd can suggest to remove unused headers. This suggests to remove test_macros.h. Removing this header can break tests.

For example tests use
   #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<wchar_t>();
   #endif

Since developers typically have wide characters support, the header is not used. However, removing the header would break configurations that have wide characters disabled.