### PR TITLE
[flang][cuda][NFC] Disambiguate namespace with cuf dialect

### DIFF
--- a/flang/include/flang/Runtime/CUDA/allocator.h
+++ b/flang/include/flang/Runtime/CUDA/allocator.h
@@ -23,7 +23,7 @@
     terminator.Crash("'%s' failed with '%s'", #expr, name); \
   }(expr)
 
-namespace Fortran::runtime::cuf {
+namespace Fortran::runtime::cuda {
 
 void CUFRegisterAllocator();
 
@@ -36,5 +36,5 @@ void CUFFreeDevice(void *);
 void *CUFAllocManaged(std::size_t);
 void CUFFreeManaged(void *);
 
-} // namespace Fortran::runtime::cuf
+} // namespace Fortran::runtime::cuda
 #endif // FORTRAN_RUNTIME_CUDA_ALLOCATOR_H_

--- a/flang/include/flang/Runtime/CUDA/descriptor.h
+++ b/flang/include/flang/Runtime/CUDA/descriptor.h
@@ -13,7 +13,7 @@
 #include "flang/Runtime/entry-names.h"
 #include <cstddef>
 
-namespace Fortran::runtime::cuf {
+namespace Fortran::runtime::cuda {
 
 extern "C" {
 
@@ -26,5 +26,5 @@ void RTDECL(CUFFreeDesciptor)(
     Descriptor *, const char *sourceFile = nullptr, int sourceLine = 0);
 
 } // extern "C"
-} // namespace Fortran::runtime::cuf
+} // namespace Fortran::runtime::cuda
 #endif // FORTRAN_RUNTIME_CUDA_DESCRIPTOR_H_

--- a/flang/runtime/CUDA/allocator.cpp
+++ b/flang/runtime/CUDA/allocator.cpp
@@ -17,7 +17,7 @@
 
 #include "cuda.h"
 
-namespace Fortran::runtime::cuf {
+namespace Fortran::runtime::cuda {
 
 void CUFRegisterAllocator() {
   allocatorRegistry.Register(
@@ -57,4 +57,4 @@ void CUFFreeManaged(void *p) {
   CUDA_REPORT_IF_ERROR(cuMemFree(reinterpret_cast<CUdeviceptr>(p)));
 }
 
-} // namespace Fortran::runtime::cuf
+} // namespace Fortran::runtime::cuda

--- a/flang/runtime/CUDA/descriptor.cpp
+++ b/flang/runtime/CUDA/descriptor.cpp
@@ -9,7 +9,7 @@
 #include "flang/Runtime/CUDA/descriptor.h"
 #include "flang/Runtime/CUDA/allocator.h"
 
-namespace Fortran::runtime::cuf {
+namespace Fortran::runtime::cuda {
 extern "C" {
 RT_EXT_API_GROUP_BEGIN
 
@@ -25,4 +25,4 @@ void RTDEF(CUFFreeDesciptor)(
 
 RT_EXT_API_GROUP_END
 }
-} // namespace Fortran::runtime::cuf
+} // namespace Fortran::runtime::cuda

--- a/flang/unittests/Runtime/CUDA/AllocatorCUF.cpp
+++ b/flang/unittests/Runtime/CUDA/AllocatorCUF.cpp
@@ -17,7 +17,7 @@
 #include "cuda.h"
 
 using namespace Fortran::runtime;
-using namespace Fortran::runtime::cuf;
+using namespace Fortran::runtime::cuda;
 
 static OwningPtr<Descriptor> createAllocatable(
     Fortran::common::TypeCategory tc, int kind, int rank = 1) {
@@ -55,7 +55,7 @@ public:
 
 TEST(AllocatableCUFTest, SimpleDeviceAllocate) {
   using Fortran::common::TypeCategory;
-  Fortran::runtime::cuf::CUFRegisterAllocator();
+  Fortran::runtime::cuda::CUFRegisterAllocator();
   ScopedContext ctx;
   // REAL(4), DEVICE, ALLOCATABLE :: a(:)
   auto a{createAllocatable(TypeCategory::Real, 4)};
@@ -73,7 +73,7 @@ TEST(AllocatableCUFTest, SimpleDeviceAllocate) {
 
 TEST(AllocatableCUFTest, SimplePinnedAllocate) {
   using Fortran::common::TypeCategory;
-  Fortran::runtime::cuf::CUFRegisterAllocator();
+  Fortran::runtime::cuda::CUFRegisterAllocator();
   ScopedContext ctx;
   // INTEGER(4), PINNED, ALLOCATABLE :: a(:)
   auto a{createAllocatable(TypeCategory::Integer, 4)};
@@ -92,7 +92,7 @@ TEST(AllocatableCUFTest, SimplePinnedAllocate) {
 
 TEST(AllocatableCUFTest, DescriptorAllocationTest) {
   using Fortran::common::TypeCategory;
-  Fortran::runtime::cuf::CUFRegisterAllocator();
+  Fortran::runtime::cuda::CUFRegisterAllocator();
   ScopedContext ctx;
   // REAL(4), DEVICE, ALLOCATABLE :: a(:)
   auto a{createAllocatable(TypeCategory::Real, 4)};


### PR DESCRIPTION
Rename namespace `Fortran::runtime::cuf` to `Fortran::runtime::cuda` to avoid embiguity with the namespace `::cuf` that is defined in the CUF dialect.