### PR TITLE
Return available function types for BindingDecls.

### DIFF
--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -1161,14 +1161,19 @@ int64_t Decl::getID() const {
 
 const FunctionType *Decl::getFunctionType(bool BlocksToo) const {
   QualType Ty;
-  if (isa<BindingDecl>(this))
-    return nullptr;
-  else if (const auto *D = dyn_cast<ValueDecl>(this))
+  if (const auto *D = dyn_cast<ValueDecl>(this))
     Ty = D->getType();
   else if (const auto *D = dyn_cast<TypedefNameDecl>(this))
     Ty = D->getUnderlyingType();
   else
     return nullptr;
+
+  if (Ty.isNull()) {
+    // BindingDecls do not have types during parsing, so return nullptr. This is
+    // the only known case where `Ty` is null.
+    assert(isa<BindingDecl>(this));
+    return nullptr;
+  }
 
   if (Ty->isFunctionPointerType())
     Ty = Ty->castAs<PointerType>()->getPointeeType();

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -26,6 +26,7 @@ add_clang_unittest(ASTTests
   CommentTextTest.cpp
   ConceptPrinterTest.cpp
   DataCollectionTest.cpp
+  DeclBaseTest.cpp
   DeclPrinterTest.cpp
   DeclTest.cpp
   EvaluateAsRValueTest.cpp

--- a/clang/unittests/AST/DeclBaseTest.cpp
+++ b/clang/unittests/AST/DeclBaseTest.cpp
@@ -1,0 +1,59 @@
+//===- unittests/AST/DeclBaseTest.cpp --- Declaration tests----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for Decl class in the AST.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/DeclBase.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Type.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/LLVM.h"
+#include "clang/Tooling/Tooling.h"
+#include "gtest/gtest.h"
+
+using ::clang::BindingDecl;
+using ::clang::ast_matchers::bindingDecl;
+using ::clang::ast_matchers::hasName;
+using ::clang::ast_matchers::match;
+using ::clang::ast_matchers::selectFirst;
+
+TEST(DeclGetFunctionType, BindingDecl) {
+  llvm::StringRef Code = R"cpp(
+    template <typename A, typename B>
+    struct Pair {
+      A AnA;
+      B AB;
+    };
+
+    void target(int *i) {
+      Pair<void (*)(int *), bool> P;
+      auto [FunctionPointer, B] = P;
+      FunctionPointer(i);
+    }
+  )cpp";
+
+  auto AST =
+      clang::tooling::buildASTFromCodeWithArgs(Code, /*Args=*/{"-std=c++20"});
+  clang::ASTContext &Ctx = AST->getASTContext();
+
+  auto *BD = selectFirst<clang::BindingDecl>(
+      "FunctionPointer",
+      match(bindingDecl(hasName("FunctionPointer")).bind("FunctionPointer"),
+            Ctx));
+  ASSERT_NE(BD, nullptr);
+
+  EXPECT_NE(BD->getFunctionType(), nullptr);
+
+  // Emulate a call before the BindingDecl has a bound type.
+  const_cast<clang::BindingDecl *>(BD)->setBinding(clang::QualType(), nullptr);
+  EXPECT_EQ(BD->getFunctionType(), nullptr);
+}

--- a/llvm/utils/gn/secondary/clang/unittests/AST/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/unittests/AST/BUILD.gn
@@ -34,6 +34,7 @@ unittest("ASTTests") {
     "CommentTextTest.cpp",
     "ConceptPrinterTest.cpp",
     "DataCollectionTest.cpp",
+    "DeclBaseTest.cpp",
     "DeclPrinterTest.cpp",
     "DeclTest.cpp",
     "EvaluateAsRValueTest.cpp",


### PR DESCRIPTION
Only return nullptr when we don't have an available QualType.