### PR TITLE
[llvm-lit] Lit Internal Shell -Fix Command Not Found Error

### DIFF
--- a/compiler-rt/test/profile/Linux/instrprof-comdat.test
+++ b/compiler-rt/test/profile/Linux/instrprof-comdat.test
@@ -1,6 +1,6 @@
 RUN: mkdir -p %t.d
 RUN: %clangxx_profgen -o %t.d/comdat -fcoverage-mapping -fuse-ld=gold %S/../Inputs/instrprof-comdat-1.cpp %S/../Inputs/instrprof-comdat-2.cpp
-RUN: LLVM_PROFILE_FILE=%t-comdat.profraw %run %t.d/comdat
+RUN: env LLVM_PROFILE_FILE=%t-comdat.profraw %run %t.d/comdat
 RUN: llvm-profdata merge -o %t.d/comdat.prof %t-comdat.profraw 
 RUN: llvm-cov show --instr-profile=%t.d/comdat.prof %t.d/comdat | FileCheck --check-prefix=HEADER %S/../Inputs/instrprof-comdat.h
 


### PR DESCRIPTION
Added `env` in front of `LLVM_PROFILE_FILE` to properly set the environment
variable correctly.