### PR TITLE
[nfc][ctx_prof] Rename `PGOContextualProfile` to `PGOCtxProfContext`

### DIFF
--- a/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
@@ -24,16 +24,16 @@
 #include <vector>
 
 namespace llvm {
-/// The loaded contextual profile, suitable for mutation during IPO passes. We
-/// generally expect a fraction of counters and of callsites to be populated.
-/// We continue to model counters as vectors, but callsites are modeled as a map
-/// of a map. The expectation is that, typically, there is a small number of
-/// indirect targets (usually, 1 for direct calls); but potentially a large
-/// number of callsites, and, as inlining progresses, the callsite count of a
-/// caller will grow.
-class PGOContextualProfile final {
+/// A node (context) in the loaded contextual profile, suitable for mutation
+/// during IPO passes. We generally expect a fraction of counters and of
+/// callsites to be populated. We continue to model counters as vectors, but
+/// callsites are modeled as a map of a map. The expectation is that, typically,
+/// there is a small number of indirect targets (usually, 1 for direct calls);
+/// but potentially a large number of callsites, and, as inlining progresses,
+/// the callsite count of a caller will grow.
+class PGOCtxProfContext final {
 public:
-  using CallTargetMapTy = std::map<GlobalValue::GUID, PGOContextualProfile>;
+  using CallTargetMapTy = std::map<GlobalValue::GUID, PGOCtxProfContext>;
   using CallsiteMapTy = DenseMap<uint32_t, CallTargetMapTy>;
 
 private:
@@ -42,19 +42,18 @@ private:
   SmallVector<uint64_t, 16> Counters;
   CallsiteMapTy Callsites;
 
-  PGOContextualProfile(GlobalValue::GUID G,
-                       SmallVectorImpl<uint64_t> &&Counters)
+  PGOCtxProfContext(GlobalValue::GUID G, SmallVectorImpl<uint64_t> &&Counters)
       : GUID(G), Counters(std::move(Counters)) {}
 
-  Expected<PGOContextualProfile &>
+  Expected<PGOCtxProfContext &>
   getOrEmplace(uint32_t Index, GlobalValue::GUID G,
                SmallVectorImpl<uint64_t> &&Counters);
 
 public:
-  PGOContextualProfile(const PGOContextualProfile &) = delete;
-  PGOContextualProfile &operator=(const PGOContextualProfile &) = delete;
-  PGOContextualProfile(PGOContextualProfile &&) = default;
-  PGOContextualProfile &operator=(PGOContextualProfile &&) = default;
+  PGOCtxProfContext(const PGOCtxProfContext &) = delete;
+  PGOCtxProfContext &operator=(const PGOCtxProfContext &) = delete;
+  PGOCtxProfContext(PGOCtxProfContext &&) = default;
+  PGOCtxProfContext &operator=(PGOCtxProfContext &&) = default;
 
   GlobalValue::GUID guid() const { return GUID; }
   const SmallVectorImpl<uint64_t> &counters() const { return Counters; }
@@ -80,7 +79,7 @@ class PGOCtxProfileReader final {
   Error wrongValue(const Twine &);
   Error unsupported(const Twine &);
 
-  Expected<std::pair<std::optional<uint32_t>, PGOContextualProfile>>
+  Expected<std::pair<std::optional<uint32_t>, PGOCtxProfContext>>
   readContext(bool ExpectIndex);
   bool canReadContext();
 
@@ -89,7 +88,7 @@ public:
       : Magic(Buffer.substr(0, PGOCtxProfileWriter::ContainerMagic.size())),
         Cursor(Buffer.substr(PGOCtxProfileWriter::ContainerMagic.size())) {}
 
-  Expected<std::map<GlobalValue::GUID, PGOContextualProfile>> loadContexts();
+  Expected<std::map<GlobalValue::GUID, PGOCtxProfContext>> loadContexts();
 };
 } // namespace llvm
 #endif

--- a/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
@@ -25,7 +25,7 @@
 
 namespace llvm {
 /// A node (context) in the loaded contextual profile, suitable for mutation
-/// during IPO passes. We generally expect a fraction of counters and of
+/// during IPO passes. We generally expect a fraction of counters and
 /// callsites to be populated. We continue to model counters as vectors, but
 /// callsites are modeled as a map of a map. The expectation is that, typically,
 /// there is a small number of indirect targets (usually, 1 for direct calls);

--- a/llvm/lib/ProfileData/PGOCtxProfReader.cpp
+++ b/llvm/lib/ProfileData/PGOCtxProfReader.cpp
@@ -33,18 +33,18 @@ using namespace llvm;
   if (auto Err = (EXPR))                                                       \
     return Err;
 
-Expected<PGOContextualProfile &>
-PGOContextualProfile::getOrEmplace(uint32_t Index, GlobalValue::GUID G,
-                                   SmallVectorImpl<uint64_t> &&Counters) {
-  auto [Iter, Inserted] = Callsites[Index].insert(
-      {G, PGOContextualProfile(G, std::move(Counters))});
+Expected<PGOCtxProfContext &>
+PGOCtxProfContext::getOrEmplace(uint32_t Index, GlobalValue::GUID G,
+                                SmallVectorImpl<uint64_t> &&Counters) {
+  auto [Iter, Inserted] =
+      Callsites[Index].insert({G, PGOCtxProfContext(G, std::move(Counters))});
   if (!Inserted)
     return make_error<InstrProfError>(instrprof_error::invalid_prof,
                                       "Duplicate GUID for same callsite.");
   return Iter->second;
 }
 
-void PGOContextualProfile::getContainedGuids(
+void PGOCtxProfContext::getContainedGuids(
     DenseSet<GlobalValue::GUID> &Guids) const {
   Guids.insert(GUID);
   for (const auto &[_, Callsite] : Callsites)
@@ -74,7 +74,7 @@ bool PGOCtxProfileReader::canReadContext() {
          Blk->ID == PGOCtxProfileBlockIDs::ContextNodeBlockID;
 }
 
-Expected<std::pair<std::optional<uint32_t>, PGOContextualProfile>>
+Expected<std::pair<std::optional<uint32_t>, PGOCtxProfContext>>
 PGOCtxProfileReader::readContext(bool ExpectIndex) {
   RET_ON_ERR(Cursor.EnterSubBlock(PGOCtxProfileBlockIDs::ContextNodeBlockID));
 
@@ -125,7 +125,7 @@ PGOCtxProfileReader::readContext(bool ExpectIndex) {
     }
   }
 
-  PGOContextualProfile Ret(*Guid, std::move(*Counters));
+  PGOCtxProfContext Ret(*Guid, std::move(*Counters));
 
   while (canReadContext()) {
     EXPECT_OR_RET(SC, readContext(true));
@@ -174,9 +174,9 @@ Error PGOCtxProfileReader::readMetadata() {
   return Error::success();
 }
 
-Expected<std::map<GlobalValue::GUID, PGOContextualProfile>>
+Expected<std::map<GlobalValue::GUID, PGOCtxProfContext>>
 PGOCtxProfileReader::loadContexts() {
-  std::map<GlobalValue::GUID, PGOContextualProfile> Ret;
+  std::map<GlobalValue::GUID, PGOCtxProfContext> Ret;
   RET_ON_ERR(readMetadata());
   while (canReadContext()) {
     EXPECT_OR_RET(E, readContext(false));

--- a/llvm/unittests/ProfileData/PGOCtxProfReaderWriterTest.cpp
+++ b/llvm/unittests/ProfileData/PGOCtxProfReaderWriterTest.cpp
@@ -64,7 +64,7 @@ public:
   const std::map<GUID, const ContextNode *> &roots() const { return Roots; }
 };
 
-void checkSame(const ContextNode &Raw, const PGOContextualProfile &Profile) {
+void checkSame(const ContextNode &Raw, const PGOCtxProfContext &Profile) {
   EXPECT_EQ(Raw.guid(), Profile.guid());
   ASSERT_EQ(Raw.counters_size(), Profile.counters().size());
   for (auto I = 0U; I < Raw.counters_size(); ++I)


### PR DESCRIPTION
This better captures what the class is - just a node. The profile has a bit more info - for example, we can glean how many counters and callsites each captured function have. This is good information to have when maintaining the profile during ICP, and while it can be recomputed, it fits better (and avoids extra compute) under a to-be-introduced `PGOContextualProfile` - which is what `loadContexts()` will return (effectivelly today's map + the extra info)