### PR TITLE
[Bounds Safety][NFC] Add some missing coverage for `-fexperimental-late-parse-attributes`

### DIFF
--- a/clang/test/AST/attr-counted-by-or-null-struct-ptrs.c
+++ b/clang/test/AST/attr-counted-by-or-null-struct-ptrs.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes %s -ast-dump | FileCheck %s
 
 #define __counted_by_or_null(f)  __attribute__((counted_by_or_null(f)))
 

--- a/clang/test/AST/attr-counted-by-struct-ptrs.c
+++ b/clang/test/AST/attr-counted-by-struct-ptrs.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes %s -ast-dump | FileCheck %s
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 

--- a/clang/test/AST/attr-sized-by-or-null-struct-ptrs.c
+++ b/clang/test/AST/attr-sized-by-or-null-struct-ptrs.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes %s -ast-dump | FileCheck %s
 
 #define __sized_by_or_null(f)  __attribute__((sized_by_or_null(f)))
 

--- a/clang/test/AST/attr-sized-by-struct-ptrs.c
+++ b/clang/test/AST/attr-sized-by-struct-ptrs.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes %s -ast-dump | FileCheck %s
 
 #define __sized_by(f)  __attribute__((sized_by(f)))
 

--- a/clang/test/Sema/attr-counted-by-bounds-safety-vlas.c
+++ b/clang/test/Sema/attr-counted-by-bounds-safety-vlas.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety -fexperimental-late-parse-attributes -verify %s
 //
 // This is a portion of the `attr-counted-by-vla.c` test but is checked
 // under the semantics of `-fexperimental-bounds-safety` which has different

--- a/clang/test/Sema/attr-counted-by-or-null-last-field.c
+++ b/clang/test/Sema/attr-counted-by-or-null-last-field.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fsyntax-only -fexperimental-late-parse-attributes -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,immediate %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes -verify=expected,late %s
 
 #define __counted_by_or_null(f)  __attribute__((counted_by_or_null(f)))
 
@@ -81,17 +81,12 @@ struct found_outside_of_struct {
   struct bar ** ptr __counted_by_or_null(global); // expected-error {{field 'global' in 'counted_by_or_null' not inside structure}}
 };
 
-#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
-  struct bar *self[] __counted_by_or_null(self); // expected-error {{use of undeclared identifier 'self'}}
+  // immediate-error@+2{{use of undeclared identifier 'self'}}
+  // late-error@+1{{'counted_by_or_null' only applies to pointers; did you mean to use 'counted_by'?}}
+  struct bar *self[] __counted_by_or_null(self);
 };
-#else
-struct self_referrential {
-  int bork;
-  struct bar *self[] __counted_by_or_null(self); // expected-error {{'counted_by_or_null' only applies to pointers; did you mean to use 'counted_by'?}}
-};
-#endif
 
 struct non_int_count {
   double dbl_count;

--- a/clang/test/Sema/attr-counted-by-or-null-last-field.c
+++ b/clang/test/Sema/attr-counted-by-or-null-last-field.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fsyntax-only -fexperimental-late-parse-attributes -verify %s
 
 #define __counted_by_or_null(f)  __attribute__((counted_by_or_null(f)))
 
@@ -80,10 +81,17 @@ struct found_outside_of_struct {
   struct bar ** ptr __counted_by_or_null(global); // expected-error {{field 'global' in 'counted_by_or_null' not inside structure}}
 };
 
+#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
   struct bar *self[] __counted_by_or_null(self); // expected-error {{use of undeclared identifier 'self'}}
 };
+#else
+struct self_referrential {
+  int bork;
+  struct bar *self[] __counted_by_or_null(self); // expected-error {{'counted_by_or_null' only applies to pointers; did you mean to use 'counted_by'?}}
+};
+#endif
 
 struct non_int_count {
   double dbl_count;

--- a/clang/test/Sema/attr-counted-by-or-null-struct-ptrs-sizeless-types.c
+++ b/clang/test/Sema/attr-counted-by-or-null-struct-ptrs-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -triple arm64-apple-darwin -fsyntax-only -verify %s
 
 #define __counted_by_or_null(f)  __attribute__((counted_by_or_null(f)))
 

--- a/clang/test/Sema/attr-counted-by-or-null-struct-ptrs.c
+++ b/clang/test/Sema/attr-counted-by-or-null-struct-ptrs.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -fsyntax-only -verify %s
 
 #define __counted_by_or_null(f)  __attribute__((counted_by_or_null(f)))
 #define __counted_by(f)  __attribute__((counted_by(f)))

--- a/clang/test/Sema/attr-counted-by-or-null-vla-sizeless-types.c
+++ b/clang/test/Sema/attr-counted-by-or-null-vla-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -triple arm64-apple-darwin -fsyntax-only -verify %s
 
 #define __counted_by_or_null(f)  __attribute__((counted_by_or_null(f)))
 

--- a/clang/test/Sema/attr-counted-by-struct-ptrs-sizeless-types.c
+++ b/clang/test/Sema/attr-counted-by-struct-ptrs-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -triple arm64-apple-darwin -fsyntax-only -verify %s
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 

--- a/clang/test/Sema/attr-counted-by-struct-ptrs.c
+++ b/clang/test/Sema/attr-counted-by-struct-ptrs.c
@@ -1,6 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
-// Test that in late parsing mode attributes that don't require late parsing
-// are handled correctly
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes %s -verify
 
 #define __counted_by(f)  __attribute__((counted_by(f)))

--- a/clang/test/Sema/attr-counted-by-struct-ptrs.c
+++ b/clang/test/Sema/attr-counted-by-struct-ptrs.c
@@ -1,4 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// Test that in late parsing mode attributes that don't require late parsing
+// are handled correctly
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes %s -verify
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 

--- a/clang/test/Sema/attr-counted-by-vla-sizeless-types.c
+++ b/clang/test/Sema/attr-counted-by-vla-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple arm64-apple-darwin -fexperimental-late-parse-attributes -fsyntax-only -verify %s
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 

--- a/clang/test/Sema/attr-counted-by-vla.c
+++ b/clang/test/Sema/attr-counted-by-vla.c
@@ -1,7 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
-// Test that in late parsing mode attributes that don't require late parsing
-// still parse correctly.
-// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fsyntax-only -fexperimental-late-parse-attributes %s -verify
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,immediate %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes %s -verify=expected,late
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 
@@ -81,17 +79,12 @@ struct found_outside_of_struct {
   struct bar *fam[] __counted_by(global); // expected-error {{field 'global' in 'counted_by' not inside structure}}
 };
 
-#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
-  struct bar *self[] __counted_by(self); // expected-error {{use of undeclared identifier 'self'}}
+  // immediate-error@+2{{use of undeclared identifier 'self'}}
+  // late-error@+1{{'counted_by' requires a non-boolean integer type argument}}
+  struct bar *self[] __counted_by(self);
 };
-#else
-struct self_referrential {
-  int bork;
-  struct bar *self[] __counted_by(self); // expected-error {{'counted_by' requires a non-boolean integer type argument}}
-};
-#endif
 
 struct non_int_count {
   double dbl_count;

--- a/clang/test/Sema/attr-counted-by-vla.c
+++ b/clang/test/Sema/attr-counted-by-vla.c
@@ -1,4 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// Test that in late parsing mode attributes that don't require late parsing
+// still parse correctly.
+// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fsyntax-only -fexperimental-late-parse-attributes %s -verify
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 
@@ -78,10 +81,17 @@ struct found_outside_of_struct {
   struct bar *fam[] __counted_by(global); // expected-error {{field 'global' in 'counted_by' not inside structure}}
 };
 
+#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
   struct bar *self[] __counted_by(self); // expected-error {{use of undeclared identifier 'self'}}
 };
+#else
+struct self_referrential {
+  int bork;
+  struct bar *self[] __counted_by(self); // expected-error {{'counted_by' requires a non-boolean integer type argument}}
+};
+#endif
 
 struct non_int_count {
   double dbl_count;

--- a/clang/test/Sema/attr-sized-by-last-field.c
+++ b/clang/test/Sema/attr-sized-by-last-field.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fexperimental-late-parse-attributes -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,immediate %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -fsyntax-only -verify=expected,late %s
 
 #define __sized_by(f)  __attribute__((sized_by(f)))
 
@@ -81,17 +81,12 @@ struct found_outside_of_struct {
   struct bar ** ptr __sized_by(global); // expected-error {{field 'global' in 'sized_by' not inside structure}}
 };
 
-#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
-  struct bar *self[] __sized_by(self); // expected-error {{use of undeclared identifier 'self'}}
+  // immediate-error@+2{{use of undeclared identifier 'self'}}
+  // late-error@+1{{'sized_by' only applies to pointers; did you mean to use 'counted_by'?}}
+  struct bar *self[] __sized_by(self);
 };
-#else
-struct self_referrential {
-  int bork;
-  struct bar *self[] __sized_by(self); // expected-error {{'sized_by' only applies to pointers; did you mean to use 'counted_by'?}}
-};
-#endif
 
 struct non_int_size {
   double dbl_size;

--- a/clang/test/Sema/attr-sized-by-last-field.c
+++ b/clang/test/Sema/attr-sized-by-last-field.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fexperimental-late-parse-attributes -fsyntax-only -verify %s
 
 #define __sized_by(f)  __attribute__((sized_by(f)))
 
@@ -80,10 +81,17 @@ struct found_outside_of_struct {
   struct bar ** ptr __sized_by(global); // expected-error {{field 'global' in 'sized_by' not inside structure}}
 };
 
+#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
   struct bar *self[] __sized_by(self); // expected-error {{use of undeclared identifier 'self'}}
 };
+#else
+struct self_referrential {
+  int bork;
+  struct bar *self[] __sized_by(self); // expected-error {{'sized_by' only applies to pointers; did you mean to use 'counted_by'?}}
+};
+#endif
 
 struct non_int_size {
   double dbl_size;

--- a/clang/test/Sema/attr-sized-by-or-null-last-field.c
+++ b/clang/test/Sema/attr-sized-by-or-null-last-field.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fsyntax-only -fexperimental-late-parse-attributes -verify %s
 
 #define __sized_by_or_null(f)  __attribute__((sized_by_or_null(f)))
 
@@ -80,10 +81,17 @@ struct found_outside_of_struct {
   struct bar ** ptr __sized_by_or_null(global); // expected-error {{field 'global' in 'sized_by_or_null' not inside structure}}
 };
 
+#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
   struct bar *self[] __sized_by_or_null(self); // expected-error {{use of undeclared identifier 'self'}}
 };
+#else
+struct self_referrential {
+  int bork;
+  struct bar *self[] __sized_by_or_null(self); // expected-error {{'sized_by_or_null' only applies to pointers; did you mean to use 'counted_by'?}}
+};
+#endif
 
 struct non_int_size {
   double dbl_size;

--- a/clang/test/Sema/attr-sized-by-or-null-last-field.c
+++ b/clang/test/Sema/attr-sized-by-or-null-last-field.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -DLATE_PARSING_ENABLED -fsyntax-only -fexperimental-late-parse-attributes -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,immediate %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes -verify=expected,late %s
 
 #define __sized_by_or_null(f)  __attribute__((sized_by_or_null(f)))
 
@@ -81,17 +81,12 @@ struct found_outside_of_struct {
   struct bar ** ptr __sized_by_or_null(global); // expected-error {{field 'global' in 'sized_by_or_null' not inside structure}}
 };
 
-#ifndef LATE_PARSING_ENABLED
 struct self_referrential {
   int bork;
-  struct bar *self[] __sized_by_or_null(self); // expected-error {{use of undeclared identifier 'self'}}
+  // immediate-error@+2{{use of undeclared identifier 'self'}}
+  // late-error@+1{{'sized_by_or_null' only applies to pointers; did you mean to use 'counted_by'?}}
+  struct bar *self[] __sized_by_or_null(self);
 };
-#else
-struct self_referrential {
-  int bork;
-  struct bar *self[] __sized_by_or_null(self); // expected-error {{'sized_by_or_null' only applies to pointers; did you mean to use 'counted_by'?}}
-};
-#endif
 
 struct non_int_size {
   double dbl_size;

--- a/clang/test/Sema/attr-sized-by-or-null-struct-ptrs-sizeless-types.c
+++ b/clang/test/Sema/attr-sized-by-or-null-struct-ptrs-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -triple arm64-apple-darwin -fsyntax-only -verify %s
 
 #define __sized_by_or_null(f)  __attribute__((sized_by_or_null(f)))
 

--- a/clang/test/Sema/attr-sized-by-or-null-struct-ptrs.c
+++ b/clang/test/Sema/attr-sized-by-or-null-struct-ptrs.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -fsyntax-only -verify %s
 
 #define __sized_by_or_null(f)  __attribute__((sized_by_or_null(f)))
 #define __counted_by(f)  __attribute__((counted_by(f)))

--- a/clang/test/Sema/attr-sized-by-or-null-vla-sizeless-types.c
+++ b/clang/test/Sema/attr-sized-by-or-null-vla-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -triple arm64-apple-darwin -fsyntax-only -verify %s
 
 #define __sized_by_or_null(f)  __attribute__((sized_by_or_null(f)))
 

--- a/clang/test/Sema/attr-sized-by-struct-ptrs-sizeless-types.c
+++ b/clang/test/Sema/attr-sized-by-struct-ptrs-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -triple arm64-apple-darwin -fsyntax-only -verify %s
 
 #define __sized_by(f)  __attribute__((sized_by(f)))
 

--- a/clang/test/Sema/attr-sized-by-struct-ptrs.c
+++ b/clang/test/Sema/attr-sized-by-struct-ptrs.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -fsyntax-only -verify %s
 
 #define __sized_by(f)  __attribute__((sized_by(f)))
 #define __counted_by(f)  __attribute__((counted_by(f)))

--- a/clang/test/Sema/attr-sized-by-vla-sizeless-types.c
+++ b/clang/test/Sema/attr-sized-by-vla-sizeless-types.c
@@ -1,5 +1,6 @@
 // __SVInt8_t is specific to ARM64 so specify that in the target triple
 // RUN: %clang_cc1 -triple arm64-apple-darwin -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fexperimental-late-parse-attributes -triple arm64-apple-darwin -fsyntax-only -verify %s
 
 #define __sized_by(f)  __attribute__((sized_by(f)))
 


### PR DESCRIPTION
Previously we weren't properly checking that using `-fexperimental-late-parse-attributes` worked on source code that didn't need late parsing.

For example we weren't testing that the attribute appearing in the type position generated the right AST with
`-fexperimental-late-parse-attributes` on or off.

This patch adds additional `RUN` lines to re-run the relevant test cases with `-fexperimental-late-parse-attributes` enabled.

rdar://133325597