### PR TITLE
[flang][cuda] Force default allocator in device code

### DIFF
--- a/flang/include/flang/Runtime/descriptor.h
+++ b/flang/include/flang/Runtime/descriptor.h
@@ -436,14 +436,6 @@ public:
   RT_API_ATTRS inline int GetAllocIdx() const {
     return (raw_.extra & _CFI_ALLOCATOR_IDX_MASK) >> _CFI_ALLOCATOR_IDX_SHIFT;
   }
-  RT_API_ATTRS inline int GetNormalizedAllocIdx() const {
-#ifdef RT_DEVICE_COMPILATION
-    // Force default allocator in device code.
-    return kDefaultAllocator;
-#else
-    return GetAllocIdx();
-#endif
-  }
   RT_API_ATTRS inline void SetAllocIdx(int pos) {
     raw_.extra &= ~_CFI_ALLOCATOR_IDX_MASK; // Clear the allocator index bits.
     raw_.extra |= (pos << _CFI_ALLOCATOR_IDX_SHIFT);

--- a/flang/include/flang/Runtime/descriptor.h
+++ b/flang/include/flang/Runtime/descriptor.h
@@ -436,6 +436,14 @@ public:
   RT_API_ATTRS inline int GetAllocIdx() const {
     return (raw_.extra & _CFI_ALLOCATOR_IDX_MASK) >> _CFI_ALLOCATOR_IDX_SHIFT;
   }
+  RT_API_ATTRS inline int GetNormalizedAllocIdx() const {
+#ifdef RT_DEVICE_COMPILATION
+    // Force default allocator in device code.
+    return kDefaultAllocator;
+#else
+    return GetAllocIdx();
+#endif
+  }
   RT_API_ATTRS inline void SetAllocIdx(int pos) {
     raw_.extra &= ~_CFI_ALLOCATOR_IDX_MASK; // Clear the allocator index bits.
     raw_.extra |= (pos << _CFI_ALLOCATOR_IDX_SHIFT);

--- a/flang/runtime/descriptor.cpp
+++ b/flang/runtime/descriptor.cpp
@@ -162,11 +162,17 @@ RT_API_ATTRS int Descriptor::Allocate() {
     elementBytes = raw_.elem_len = 0;
   }
   std::size_t byteSize{Elements() * elementBytes};
+
+  // Force default allocator in device code.
+#ifdef RT_DEVICE_COMPILATION
+  AllocFct alloc{allocatorRegistry.GetAllocator(kDefaultAllocator)};
+#else
+  AllocFct alloc{allocatorRegistry.GetAllocator(GetAllocIdx())};
+#endif
+
   // Zero size allocation is possible in Fortran and the resulting
   // descriptor must be allocated/associated. Since std::malloc(0)
   // result is implementation defined, always allocate at least one byte.
-
-  AllocFct alloc{allocatorRegistry.GetAllocator(GetAllocIdx())};
   void *p{alloc(byteSize ? byteSize : 1)};
   if (!p) {
     return CFI_ERROR_MEM_ALLOCATION;
@@ -209,7 +215,12 @@ RT_API_ATTRS int Descriptor::Deallocate() {
   if (!descriptor.base_addr) {
     return CFI_ERROR_BASE_ADDR_NULL;
   } else {
+    // Force default deallocator in device code.
+#ifdef RT_DEVICE_COMPILATION
+    FreeFct free{allocatorRegistry.GetDeallocator(kDefaultAllocator)};
+#else
     FreeFct free{allocatorRegistry.GetDeallocator(GetAllocIdx())};
+#endif
     free(descriptor.base_addr);
     descriptor.base_addr = nullptr;
     return CFI_SUCCESS;

--- a/flang/runtime/descriptor.cpp
+++ b/flang/runtime/descriptor.cpp
@@ -154,7 +154,7 @@ RT_API_ATTRS std::size_t Descriptor::Elements() const {
   return elements;
 }
 
-RT_API_ATTRS static int MapAllocIdx(const Descriptor &desc) {
+RT_API_ATTRS static inline int MapAllocIdx(const Descriptor &desc) {
 #ifdef RT_DEVICE_COMPILATION
   // Force default allocator in device code.
   return kDefaultAllocator;

--- a/flang/runtime/descriptor.cpp
+++ b/flang/runtime/descriptor.cpp
@@ -162,14 +162,7 @@ RT_API_ATTRS int Descriptor::Allocate() {
     elementBytes = raw_.elem_len = 0;
   }
   std::size_t byteSize{Elements() * elementBytes};
-
-  // Force default allocator in device code.
-#ifdef RT_DEVICE_COMPILATION
-  AllocFct alloc{allocatorRegistry.GetAllocator(kDefaultAllocator)};
-#else
-  AllocFct alloc{allocatorRegistry.GetAllocator(GetAllocIdx())};
-#endif
-
+  AllocFct alloc{allocatorRegistry.GetAllocator(GetNormalizedAllocIdx())};
   // Zero size allocation is possible in Fortran and the resulting
   // descriptor must be allocated/associated. Since std::malloc(0)
   // result is implementation defined, always allocate at least one byte.
@@ -215,12 +208,7 @@ RT_API_ATTRS int Descriptor::Deallocate() {
   if (!descriptor.base_addr) {
     return CFI_ERROR_BASE_ADDR_NULL;
   } else {
-    // Force default deallocator in device code.
-#ifdef RT_DEVICE_COMPILATION
-    FreeFct free{allocatorRegistry.GetDeallocator(kDefaultAllocator)};
-#else
-    FreeFct free{allocatorRegistry.GetDeallocator(GetAllocIdx())};
-#endif
+    FreeFct free{allocatorRegistry.GetDeallocator(GetNormalizedAllocIdx())};
     free(descriptor.base_addr);
     descriptor.base_addr = nullptr;
     return CFI_SUCCESS;


### PR DESCRIPTION
Allocation/deallocation from device code can use standard malloc/free since the cuda functions cannot be called. Force the default allocator/deallocator in the device runtime build so we don't need to register extra allocators. 