### PR TITLE
[libc] Enable quick_exit routines on the GPU

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -165,6 +165,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.strtoll
     libc.src.stdlib.strtoul
     libc.src.stdlib.strtoull
+    libc.src.stdlib.at_quick_exit
+    libc.src.stdlib.quick_exit
 
     # TODO: Implement these correctly
     libc.src.stdlib.aligned_alloc


### PR DESCRIPTION
Summary:
We should be able to use these on the GPU just like exit.
