### PR TITLE
[libc] Define `MB_LEN_MAX` in `limits.h`

### DIFF
--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -20,6 +20,7 @@
 #endif // CHAR_BIT
 
 #ifndef MB_LEN_MAX
+// Represents a single UTF-32 wide character in the default locale.
 #define MB_LEN_MAX 4
 #endif // MB_LEN_MAX
 

--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -19,12 +19,9 @@
 #endif // __CHAR_BIT__
 #endif // CHAR_BIT
 
-// TODO: https://github.com/llvm/llvm-project/issues/79358
-//   Define MB_LEN_MAX if missing.
-//     clang: MB_LEN_MAX = 1 -
-// https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/limits.h#L64
-//     glibc: MB_LEN_MAX = 16 -
-// https://github.com/bminor/glibc/blob/master/include/limits.h#L32
+#ifndef MB_LEN_MAX
+#define MB_LEN_MAX 4
+#endif // MB_LEN_MAX
 
 // *_WIDTH macros
 


### PR DESCRIPTION
Summary:
This is supposed to define the maximum bytes required to store a char in
any locale. There's some question about what this should be set to. I
believe because the proposed solution for `locale.h` is to only support
the default locale, we should do what `musl` does and set it to `4`
which covers up to UTF-32.

Fixes https://github.com/llvm/llvm-project/issues/79358
