### PR TITLE
[compiler-rt] [HWASan] leave BufferedStackTrace uninit

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan.h
+++ b/compiler-rt/lib/hwasan/hwasan.h
@@ -139,15 +139,15 @@ void hwasan_free(void *ptr, StackTrace *stack);
 void InstallAtExitHandler();
 
 #define GET_MALLOC_STACK_TRACE                                            \
-  BufferedStackTrace stack;                                               \
+  __attribute__((uninitialized)) BufferedStackTrace stack;                \
   if (hwasan_inited)                                                      \
     stack.Unwind(StackTrace::GetCurrentPc(), GET_CURRENT_FRAME(),         \
                  nullptr, common_flags()->fast_unwind_on_malloc,          \
                  common_flags()->malloc_context_size)
 
-#define GET_FATAL_STACK_TRACE_PC_BP(pc, bp)              \
-  BufferedStackTrace stack;                              \
-  if (hwasan_inited)                                     \
+#define GET_FATAL_STACK_TRACE_PC_BP(pc, bp)                \
+  __attribute__((uninitialized)) BufferedStackTrace stack; \
+  if (hwasan_inited)                                       \
     stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal)
 
 void HwasanTSDInit();

--- a/compiler-rt/lib/hwasan/hwasan.h
+++ b/compiler-rt/lib/hwasan/hwasan.h
@@ -139,14 +139,14 @@ void hwasan_free(void *ptr, StackTrace *stack);
 void InstallAtExitHandler();
 
 #define GET_MALLOC_STACK_TRACE                                            \
-  __attribute__((uninitialized)) BufferedStackTrace stack;                \
+  UNINITIALIZED BufferedStackTrace stack;                \
   if (hwasan_inited)                                                      \
     stack.Unwind(StackTrace::GetCurrentPc(), GET_CURRENT_FRAME(),         \
                  nullptr, common_flags()->fast_unwind_on_malloc,          \
                  common_flags()->malloc_context_size)
 
 #define GET_FATAL_STACK_TRACE_PC_BP(pc, bp)                \
-  __attribute__((uninitialized)) BufferedStackTrace stack; \
+  UNINITIALIZED BufferedStackTrace stack; \
   if (hwasan_inited)                                       \
     stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal)
 

--- a/compiler-rt/lib/hwasan/hwasan.h
+++ b/compiler-rt/lib/hwasan/hwasan.h
@@ -139,15 +139,15 @@ void hwasan_free(void *ptr, StackTrace *stack);
 void InstallAtExitHandler();
 
 #define GET_MALLOC_STACK_TRACE                                            \
-  UNINITIALIZED BufferedStackTrace stack;                \
+  UNINITIALIZED BufferedStackTrace stack;                                 \
   if (hwasan_inited)                                                      \
     stack.Unwind(StackTrace::GetCurrentPc(), GET_CURRENT_FRAME(),         \
                  nullptr, common_flags()->fast_unwind_on_malloc,          \
                  common_flags()->malloc_context_size)
 
-#define GET_FATAL_STACK_TRACE_PC_BP(pc, bp)                \
-  UNINITIALIZED BufferedStackTrace stack; \
-  if (hwasan_inited)                                       \
+#define GET_FATAL_STACK_TRACE_PC_BP(pc, bp)              \
+  UNINITIALIZED BufferedStackTrace stack;                \
+  if (hwasan_inited)                                     \
     stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal)
 
 void HwasanTSDInit();


### PR DESCRIPTION
Otherwise we have to memset 2040 bytes (255 * 8) for each call to a
malloc-like function.

This caused noticable slowdown on AOSP.
