### PR TITLE
[Clang][Sema] fix noexecpt mismatch of friend declaration

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -192,6 +192,8 @@ Bug Fixes to C++ Support
 - Clang now preserves the unexpanded flag in a lambda transform used for pack expansion. (#GH56852), (#GH85667),
   (#GH99877).
 - Fixed a bug when diagnosing ambiguous explicit specializations of constrained member functions.
+- Fix mismatch of noexecpt in friend function declaration by copying template instantiated parameters to
+  current local scope.(#GH101330).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/SemaCXX/pr101330.cpp
+++ b/clang/test/SemaCXX/pr101330.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
+// expected-no-diagnostics
+
+template <typename T>
+struct C {
+    template <int N, typename U>
+    friend void func(const C<U> &m) noexcept(N == 0);
+};
+
+template <int N, typename U>
+void func(const C<U> &m) noexcept(N == 0) {}
+
+int main() {
+    C<int> t;
+    return 0;
+}


### PR DESCRIPTION
Creating a new local scope without combining outer one will makes some instantiated template parameters can't be found in instantiate a friend function. This will lead to the mismatch with its definition as they have template parameter with different depths. This patch fix this issue by adding instantiated template parameters to current scope. This will make clang find the correct instantiated template parameters and make the depth of template parameter correct.
Fix issue https://github.com/llvm/llvm-project/issues/101330