### PR TITLE
[CodeGen] Fix off-by-one in RegAllocHints grow

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -801,7 +801,7 @@ public:
   /// of an earlier hint it will be overwritten.
   void setRegAllocationHint(Register VReg, unsigned Type, Register PrefReg) {
     assert(VReg.isVirtual());
-    RegAllocHints.grow(Register::index2VirtReg(getNumVirtRegs()));
+    RegAllocHints.grow(Register::index2VirtReg(getNumVirtRegs() - 1));
     RegAllocHints[VReg].first  = Type;
     RegAllocHints[VReg].second.clear();
     RegAllocHints[VReg].second.push_back(PrefReg);
@@ -811,7 +811,7 @@ public:
   /// vector for VReg.
   void addRegAllocationHint(Register VReg, Register PrefReg) {
     assert(VReg.isVirtual());
-    RegAllocHints.grow(Register::index2VirtReg(getNumVirtRegs()));
+    RegAllocHints.grow(Register::index2VirtReg(getNumVirtRegs() - 1));
     RegAllocHints[VReg].second.push_back(PrefReg);
   }
 


### PR DESCRIPTION
grow() expects a value in the range, not the size. Fix this off-by-one. Fixup of #102186.