### PR TITLE
[Support] [Windows] Stop redefining _WIN32_IE

### DIFF
--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -23,11 +23,9 @@
 
 // mingw-w64 tends to define it as 0x0502 in its headers.
 #undef _WIN32_WINNT
-#undef _WIN32_IE
 
 // Require at least Windows 7 API.
 #define _WIN32_WINNT 0x0601
-#define _WIN32_IE    0x0800 // MinGW at it again. FIXME: verify if still needed.
 #define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX
 #define NOMINMAX


### PR DESCRIPTION
This was added in 181fd8cd89ff97fe654fabbb2032e0ad6607b4d0, where the shlobj.h header was taken into use. The shlobj.h header does have some APIs conditionally visible based on the _WIN32_IE define, but none of the calls added in that commit seem to need any specific version.

fd6cb64c4891301648e5ab814afdafa118977c3d and
6b129bd464831194da957b3462d7ddd27a0b2a08 further bumped the version it is set to, while the latter also added a FIXME to check whether it still is needed.

It doesn't seem to be needed currently; the code currently builds fine without this define, both with mingw-w64 and MSVC.

Additionally, to show that the value of _WIN32_IE doesn't seem to be relevant to our builds these days - if the current define is changed to hardcode _WIN32_IE to an ancient value like 0x0400, our code still builds fine, both with mingw-w64 and MSVC. Therefore, overriding this define no longer seem to be relevant.