### PR TITLE
[NFC] Temporarily disable failing TableGen unit test.

### DIFF
--- a/llvm/test/TableGen/SubtargetFeatureUniqueNames.td
+++ b/llvm/test/TableGen/SubtargetFeatureUniqueNames.td
@@ -1,3 +1,6 @@
+// Temporarily disable test due to non-deterministic order of error messages.
+// UNSUPPORTED: target={{.*}}
+
 // RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s
 // Verify that subtarget features with same names result in an error.
 


### PR DESCRIPTION
- This test was reported as failing in ASAN builds, with non-deterministic order of the error message and note expected.
- This is due to llvm::sort() being unstable.
- Temporarily disable the test while its been fixed.