### PR TITLE
[OpenMP][AArch64] Fix branch protection in microtasks

### DIFF
--- a/openmp/runtime/src/z_Linux_asm.S
+++ b/openmp/runtime/src/z_Linux_asm.S
@@ -17,27 +17,6 @@
 
 #include "kmp_config.h"
 
-#if KMP_OS_LINUX
-// BTI and PAC gnu property note
-#define NT_GNU_PROPERTY_TYPE_0 5
-#define GNU_PROPERTY_AARCH64_FEATURE_1_AND 0xc0000000
-#define GNU_PROPERTY_AARCH64_FEATURE_1_BTI 1
-#define GNU_PROPERTY_AARCH64_FEATURE_1_PAC 2
-
-# define GNU_PROPERTY(type, value)                                             \
-  .pushsection .note.gnu.property, "a";                                        \
-  .p2align 3;                                                                  \
-  .word 4;                                                                     \
-  .word 16;                                                                    \
-  .word NT_GNU_PROPERTY_TYPE_0;                                                \
-  .asciz "GNU";                                                                \
-  .word type;                                                                  \
-  .word 4;                                                                     \
-  .word value;                                                                 \
-  .word 0;                                                                     \
-  .popsection
-#endif
-
 #if KMP_ARCH_X86 || KMP_ARCH_X86_64
 
 # if KMP_MIC
@@ -196,6 +175,27 @@ KMP_PREFIX_UNDERSCORE(\proc):
 	.cfi_startproc
 .endm
 # endif // KMP_OS_DARWIN
+
+# if KMP_OS_LINUX
+// BTI and PAC gnu property note
+#  define NT_GNU_PROPERTY_TYPE_0 5
+#  define GNU_PROPERTY_AARCH64_FEATURE_1_AND 0xc0000000
+#  define GNU_PROPERTY_AARCH64_FEATURE_1_BTI 1
+#  define GNU_PROPERTY_AARCH64_FEATURE_1_PAC 2
+
+#  define GNU_PROPERTY(type, value)                                            \
+  .pushsection .note.gnu.property, "a";                                        \
+  .p2align 3;                                                                  \
+  .word 4;                                                                     \
+  .word 16;                                                                    \
+  .word NT_GNU_PROPERTY_TYPE_0;                                                \
+  .asciz "GNU";                                                                \
+  .word type;                                                                  \
+  .word 4;                                                                     \
+  .word value;                                                                 \
+  .word 0;                                                                     \
+  .popsection
+# endif
 
 # if defined(__ARM_FEATURE_BTI_DEFAULT)
 #  define BTI_FLAG GNU_PROPERTY_AARCH64_FEATURE_1_BTI

--- a/openmp/runtime/src/z_Linux_asm.S
+++ b/openmp/runtime/src/z_Linux_asm.S
@@ -209,11 +209,18 @@ KMP_PREFIX_UNDERSCORE(\proc):
 # endif
 
 # if (BTI_FLAG | PAC_FLAG) != 0
-#  define BTI_C hint #34
+#  if PAC_FLAG != 0
+#   define PACBTI_C hint #25
+#   define PACBTI_RET hint #29
+#  else
+#   define PACBTI_C hint #34
+#   define PACBTI_RET
+#  endif
 #  define GNU_PROPERTY_BTI_PAC \
     GNU_PROPERTY(GNU_PROPERTY_AARCH64_FEATURE_1_AND, BTI_FLAG | PAC_FLAG)
 # else
-#  define BTI_C
+#  define PACBTI_C
+#  define PACBTI_RET
 #  define GNU_PROPERTY_BTI_PAC
 # endif
 #endif // (KMP_OS_LINUX || KMP_OS_DARWIN || KMP_OS_WINDOWS) && (KMP_ARCH_AARCH64 || KMP_ARCH_AARCH64_32 || KMP_ARCH_ARM)
@@ -1336,7 +1343,7 @@ __tid = 8
 // mark_begin;
 	.text
 	PROC __kmp_invoke_microtask
-	BTI_C
+	PACBTI_C
 
 	stp	x29, x30, [sp, #-16]!
 # if OMPT_SUPPORT
@@ -1400,6 +1407,7 @@ KMP_LABEL(kmp_1):
 	ldp	x19, x20, [sp], #16
 # endif
 	ldp	x29, x30, [sp], #16
+	PACBTI_RET
 	ret
 
 	DEBUG_INFO __kmp_invoke_microtask

--- a/openmp/runtime/src/z_Linux_asm.S
+++ b/openmp/runtime/src/z_Linux_asm.S
@@ -17,6 +17,27 @@
 
 #include "kmp_config.h"
 
+#if KMP_OS_LINUX
+// BTI and PAC gnu property note
+#define NT_GNU_PROPERTY_TYPE_0 5
+#define GNU_PROPERTY_AARCH64_FEATURE_1_AND 0xc0000000
+#define GNU_PROPERTY_AARCH64_FEATURE_1_BTI 1
+#define GNU_PROPERTY_AARCH64_FEATURE_1_PAC 2
+
+# define GNU_PROPERTY(type, value)                                             \
+  .pushsection .note.gnu.property, "a";                                        \
+  .p2align 3;                                                                  \
+  .word 4;                                                                     \
+  .word 16;                                                                    \
+  .word NT_GNU_PROPERTY_TYPE_0;                                                \
+  .asciz "GNU";                                                                \
+  .word type;                                                                  \
+  .word 4;                                                                     \
+  .word value;                                                                 \
+  .word 0;                                                                     \
+  .popsection
+#endif
+
 #if KMP_ARCH_X86 || KMP_ARCH_X86_64
 
 # if KMP_MIC
@@ -176,6 +197,25 @@ KMP_PREFIX_UNDERSCORE(\proc):
 .endm
 # endif // KMP_OS_DARWIN
 
+# if defined(__ARM_FEATURE_BTI_DEFAULT)
+#  define BTI_FLAG GNU_PROPERTY_AARCH64_FEATURE_1_BTI
+# else
+#  define BTI_FLAG 0
+# endif
+# if __ARM_FEATURE_PAC_DEFAULT & 3
+#  define PAC_FLAG GNU_PROPERTY_AARCH64_FEATURE_1_PAC
+# else
+#  define PAC_FLAG 0
+# endif
+
+# if (BTI_FLAG | PAC_FLAG) != 0
+#  define BTI_C hint #34
+#  define GNU_PROPERTY_BTI_PAC \
+    GNU_PROPERTY(GNU_PROPERTY_AARCH64_FEATURE_1_AND, BTI_FLAG | PAC_FLAG)
+# else
+#  define BTI_C
+#  define GNU_PROPERTY_BTI_PAC
+# endif
 #endif // (KMP_OS_LINUX || KMP_OS_DARWIN || KMP_OS_WINDOWS) && (KMP_ARCH_AARCH64 || KMP_ARCH_AARCH64_32 || KMP_ARCH_ARM)
 
 .macro COMMON name, size, align_power
@@ -1296,6 +1336,7 @@ __tid = 8
 // mark_begin;
 	.text
 	PROC __kmp_invoke_microtask
+	BTI_C
 
 	stp	x29, x30, [sp, #-16]!
 # if OMPT_SUPPORT
@@ -2451,4 +2492,8 @@ KMP_PREFIX_UNDERSCORE(__kmp_unnamed_critical_addr):
 # elif !KMP_ARCH_WASM
 .section .note.GNU-stack,"",@progbits
 # endif
+#endif
+
+#if KMP_OS_LINUX && (KMP_ARCH_AARCH64 || KMP_ARCH_AARCH64_32)
+GNU_PROPERTY_BTI_PAC
 #endif


### PR DESCRIPTION
Start __kmp_invoke_microtask with PACBTI in order to identify the function as a valid branch target. Before returning, SP is authenticated.
Also add the BTI and PAC markers to z_Linux_asm.S.

With this patch, libomp.so can now be generated with DT_AARCH64_BTI_PLT when built with -mbranch-protection=standard.

The implementation is based on the code available in compiler-rt.