### PR TITLE
[flang] Improve error message output

### DIFF
--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -493,7 +493,7 @@ std::optional<Expr<SomeType>> NonPointerInitializationExpr(const Symbol &symbol,
       } else {
         context.messages().Say(
             "Initialization expression for '%s' (%s) cannot be computed as a constant value"_err_en_US,
-            symbol.name(), folded.AsFortran());
+            symbol.name(), x.AsFortran());
       }
     } else if (xType) {
       context.messages().Say(

--- a/flang/test/Semantics/structconst02.f90
+++ b/flang/test/Semantics/structconst02.f90
@@ -14,7 +14,7 @@ module module1
     integer(kind=ik) :: ix = int(0,kind=ik)
     real(kind=rk) :: rx = real(0.,kind=rk)
     complex(kind=zk) :: zx = cmplx(0.,0.,kind=zk)
-    !ERROR: Initialization expression for 'cx' (%SET_LENGTH(" ",len)) cannot be computed as a constant value
+    !ERROR: Initialization expression for 'cx' (" ") cannot be computed as a constant value
     character(kind=ck,len=len) :: cx = ' '
     logical(kind=lk) :: lx = .false.
     real(kind=rk), pointer :: rp => NULL()


### PR DESCRIPTION
When a local character variable with non-constant length has an initializer, it's an error in a couple of ways (SAVE variable with unknown size, static initializer that isn't constant due to conversion to an unknown length).  The error that f18 reports is the latter, but the message contains a formatted representation of the initialization expression that exposes a non-Fortran %SET_LENGTH() operation. Print the original expression in the message instead.