### PR TITLE
[NFC][libc++][test][AIX] UnXFAIL LIT test transform.pass.cpp

### DIFF
--- a/libcxx/test/std/re/re.traits/transform.pass.cpp
+++ b/libcxx/test/std/re/re.traits/transform.pass.cpp
@@ -8,7 +8,6 @@
 //
 // NetBSD does not support LC_COLLATE at the moment
 // XFAIL: netbsd
-// XFAIL: LIBCXX-AIX-FIXME
 
 // REQUIRES: locale.cs_CZ.ISO8859-2
 


### PR DESCRIPTION
Remove `XFAIL: LIBCXX-AIX-FIXME` from lit test `transform.pass.cpp` now that AIX system call `wcsxfrm`/`wcsxfrm_l` is fixed in AIX 7.2.5.8 and 7.3.2.2 and buildbot machines have been upgraded.