### PR TITLE
Fix a crash with empty escape sequences when lexing

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -170,6 +170,8 @@ Bug Fixes in This Version
   be used in C++.
 - Fixed a failed assertion when checking required literal types in C context. (#GH101304).
 - Fixed a crash when trying to transform a dependent address space type. Fixes #GH101685.
+- Fixed a crash when diagnosing format strings and encountering an empty
+  delimited escape sequence (e.g., ``"\o{}"``). #GH102218
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Lex/LiteralSupport.cpp
+++ b/clang/lib/Lex/LiteralSupport.cpp
@@ -190,9 +190,10 @@ static unsigned ProcessCharEscape(const char *ThisTokBegin,
       Delimited = true;
       ThisTokBuf++;
       if (*ThisTokBuf == '}') {
-        Diag(Diags, Features, Loc, ThisTokBegin, EscapeBegin, ThisTokBuf,
-             diag::err_delimited_escape_empty);
-        return ResultChar;
+        HadError = true;
+        if (Diags)
+          Diag(Diags, Features, Loc, ThisTokBegin, EscapeBegin, ThisTokBuf,
+               diag::err_delimited_escape_empty);
       }
     } else if (ThisTokBuf == ThisTokEnd || !isHexDigit(*ThisTokBuf)) {
       if (Diags)
@@ -283,9 +284,10 @@ static unsigned ProcessCharEscape(const char *ThisTokBegin,
     Delimited = true;
     ++ThisTokBuf;
     if (*ThisTokBuf == '}') {
-      Diag(Diags, Features, Loc, ThisTokBegin, EscapeBegin, ThisTokBuf,
-           diag::err_delimited_escape_empty);
-      return ResultChar;
+      HadError = true;
+      if (Diags)
+        Diag(Diags, Features, Loc, ThisTokBegin, EscapeBegin, ThisTokBuf,
+             diag::err_delimited_escape_empty);
     }
 
     while (ThisTokBuf != ThisTokEnd) {

--- a/clang/test/Lexer/char-escapes-delimited.c
+++ b/clang/test/Lexer/char-escapes-delimited.c
@@ -123,3 +123,16 @@ void separators(void) {
 static_assert('\N??<DOLLAR SIGN??>' == '$'); // expected-warning 2{{trigraph converted}} \
                                              // ext-warning {{extension}} cxx23-warning {{C++23}}
 #endif
+
+void GH102218(void) {
+  // The format specifier checking code runs the lexer with diagnostics
+  // disabled. This used to crash Clang for malformed \o and \x because the
+  // lexer missed a null pointer check for the diagnostics engine in that case.
+  extern int printf(const char *, ...);
+  printf("\o{}"); // expected-error {{delimited escape sequence cannot be empty}}
+  printf("\x{}"); // expected-error {{delimited escape sequence cannot be empty}}
+
+  // These cases always worked but are here for completeness.
+  printf("\u{}"); // expected-error {{delimited escape sequence cannot be empty}}
+  printf("\N{}"); // expected-error {{delimited escape sequence cannot be empty}}
+}


### PR DESCRIPTION
The utilities we use for lexing string and character literals can be run in a mode where we pass a null pointer for the diagnostics engine. This mode is used by the format string checkers, for example. However, there were two places that failed to account for a null diagnostic engine pointer: `\o{}` and `\x{}`.

This patch adds a check for a null pointer and correctly handles fallback behavior.

Fixes #102218