### PR TITLE
[scudo][Fuchsia] Avoid variable access after unmap

### DIFF
--- a/compiler-rt/lib/scudo/standalone/mem_map_fuchsia.cpp
+++ b/compiler-rt/lib/scudo/standalone/mem_map_fuchsia.cpp
@@ -156,11 +156,13 @@ void MemMapFuchsia::unmapImpl(uptr Addr, uptr Size) {
     // the same operations in the opposite order.
     Status = _zx_handle_close(Vmo);
     CHECK_EQ(Status, ZX_OK);
-    Status = _zx_vmar_unmap(_zx_vmar_root_self(), Addr, Size);
-    CHECK_EQ(Status, ZX_OK);
+    Vmo = ZX_HANDLE_INVALID;
 
     MapAddr = WindowBase = WindowSize = 0;
-    Vmo = ZX_HANDLE_INVALID;
+
+    // NB: This instance is stored on the pages that will become unmapped.
+    Status = _zx_vmar_unmap(_zx_vmar_root_self(), Addr, Size);
+    CHECK_EQ(Status, ZX_OK);
   } else {
     // Unmap the subrange.
     Status = _zx_vmar_unmap(_zx_vmar_root_self(), Addr, Size);


### PR DESCRIPTION
Following #102024, unmap() no longer transfers ownership of the MemMapT instance before it performs the unmapping. Since the instance itself is stored in the mapped pages, instance variable accesses in MemMapFuchsia::unmapImpl() cannot be safely made after the zx_vmar_unmap() call.

This PR re-arranges variable accesses in MemMapFuchsia::unmapImpl to before the zx_vmar_unmap() call. This should resolve the crash that surfaced in Fuchsia's Scudo integration roller: https://ci.chromium.org/ui/p/turquoise/builders/global.try/core.arm64-release/b8740290070678159665/overview