### PR TITLE
[Modules] Fix cyclic module dependencies in clang

### DIFF
--- a/clang/include/clang/Serialization/ObjectFilePCHContainerReader.h
+++ b/clang/include/clang/Serialization/ObjectFilePCHContainerReader.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_CLANG_SERIALIZATION_OBJECTFILEPCHCONTAINERREADER_H
 #define LLVM_CLANG_SERIALIZATION_OBJECTFILEPCHCONTAINERREADER_H
 
-#include "clang/Frontend/PCHContainerOperations.h"
+#include "clang/Serialization/PCHContainerOperations.h"
 
 namespace clang {
 /// A PCHContainerReader implementation that uses LLVM to


### PR DESCRIPTION
Breakup the cyclic dependency in module 'Clang_Frontend':
Clang_Frontend -> Clang_Serialization -> Clang_Frontend
