### PR TITLE
[RISCV] Use listconcat to shorten some of the profile feature lists.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProfiles.td
+++ b/llvm/lib/Target/RISCV/RISCVProfiles.td
@@ -6,169 +6,113 @@
 //
 //===----------------------------------------------------------------------===//
 
-class RISCVProfile<string name, list<SubtargetFeature> features>
-    : SubtargetFeature<name, "Is" # NAME, "true",
-                       "RISC-V " # name # " profile", features> {
-  // Indicates if the profile is not yet ratified, so should be treated as
-  // experimental.
-  bit Experimental = false;
-}
-class RISCVExperimentalProfile<string name, list<SubtargetFeature> features>
-    : RISCVProfile<"experimental-"#name, features> {
-  let Experimental = true;
-}
+//===----------------------------------------------------------------------===//
+// Profile Featuyre Lists
+//===----------------------------------------------------------------------===//
+
+// RVI Profile Family
 
 defvar RVI20U32Features = [Feature32Bit, FeatureStdExtI];
 defvar RVI20U64Features = [Feature64Bit, FeatureStdExtI];
 
-defvar RVA20U64Features = [Feature64Bit,
-                           FeatureStdExtI,
-                           FeatureStdExtM,
-                           FeatureStdExtA,
-                           FeatureStdExtF,
-                           FeatureStdExtD,
-                           FeatureStdExtC,
-                           FeatureStdExtZicntr,
-                           FeatureStdExtZiccif,
-                           FeatureStdExtZiccrse,
-                           FeatureStdExtZiccamoa,
-                           FeatureStdExtZa128rs,
-                           FeatureStdExtZicclsm];
+// RVA Profile Family
 
+defvar RVA20U64BaseFeatures = [Feature64Bit,
+                               FeatureStdExtI,
+                               FeatureStdExtM,
+                               FeatureStdExtA,
+                               FeatureStdExtF,
+                               FeatureStdExtD,
+                               FeatureStdExtC,
+                               FeatureStdExtZicntr,
+                               FeatureStdExtZiccif,
+                               FeatureStdExtZiccrse,
+                               FeatureStdExtZiccamoa,
+                               FeatureStdExtZicclsm];
+defvar RVA20U64Features = !listconcat(RVA20U64BaseFeatures,
+                                      [FeatureStdExtZa128rs]);
+
+defvar RVA20S64BaseFeatures = [FeatureStdExtZifencei,
+                               FeatureStdExtSvbare,
+                               FeatureStdExtSvade,
+                               FeatureStdExtSsccptr,
+                               FeatureStdExtSstvecd,
+                               FeatureStdExtSstvala];
 defvar RVA20S64Features = !listconcat(RVA20U64Features,
-                                      [FeatureStdExtZifencei,
-                                       FeatureStdExtSvbare,
-                                       FeatureStdExtSvade,
-                                       FeatureStdExtSsccptr,
-                                       FeatureStdExtSstvecd,
-                                       FeatureStdExtSstvala]);
+                                      RVA20S64BaseFeatures);
 
-defvar RVA22U64Features = [Feature64Bit,
-                           FeatureStdExtI,
-                           FeatureStdExtM,
-                           FeatureStdExtA,
-                           FeatureStdExtF,
-                           FeatureStdExtD,
-                           FeatureStdExtC,
-                           FeatureStdExtZicntr,
-                           FeatureStdExtZiccif,
-                           FeatureStdExtZiccrse,
-                           FeatureStdExtZiccamoa,
-                           FeatureStdExtZicclsm,
-                           FeatureStdExtZa64rs,
-                           FeatureStdExtZihpm,
-                           FeatureStdExtZihintpause,
-                           FeatureStdExtZba,
-                           FeatureStdExtZbb,
-                           FeatureStdExtZbs,
-                           FeatureStdExtZic64b,
-                           FeatureStdExtZicbom,
-                           FeatureStdExtZicbop,
-                           FeatureStdExtZicboz,
-                           FeatureStdExtZfhmin,
-                           FeatureStdExtZkt];
+defvar RVA22U64Features = !listconcat(RVA20U64BaseFeatures,
+                                      [FeatureStdExtZa64rs,
+                                       FeatureStdExtZihpm,
+                                       FeatureStdExtZihintpause,
+                                       FeatureStdExtZba,
+                                       FeatureStdExtZbb,
+                                       FeatureStdExtZbs,
+                                       FeatureStdExtZic64b,
+                                       FeatureStdExtZicbom,
+                                       FeatureStdExtZicbop,
+                                       FeatureStdExtZicboz,
+                                       FeatureStdExtZfhmin,
+                                       FeatureStdExtZkt]);
 
+defvar RVA22S64BaseFeatures = !listconcat(RVA20S64BaseFeatures,
+                                          [FeatureStdExtSscounterenw,
+                                           FeatureStdExtSvpbmt,
+                                           FeatureStdExtSvinval]);
 defvar RVA22S64Features = !listconcat(RVA22U64Features,
-                                      [FeatureStdExtZifencei,
-                                       FeatureStdExtSvbare,
-                                       FeatureStdExtSvade,
-                                       FeatureStdExtSsccptr,
-                                       FeatureStdExtSstvecd,
-                                       FeatureStdExtSstvala,
-                                       FeatureStdExtSscounterenw,
-                                       FeatureStdExtSvpbmt,
-                                       FeatureStdExtSvinval]);
+                                      RVA22S64BaseFeatures);
 
-defvar RVA23U64Features = [Feature64Bit,
-                           FeatureStdExtI,
-                           FeatureStdExtM,
-                           FeatureStdExtA,
-                           FeatureStdExtF,
-                           FeatureStdExtD,
-                           FeatureStdExtC,
-                           FeatureStdExtZicntr,
-                           FeatureStdExtZihpm,
-                           FeatureStdExtZiccif,
-                           FeatureStdExtZiccrse,
-                           FeatureStdExtZiccamoa,
-                           FeatureStdExtZicclsm,
-                           FeatureStdExtZa64rs,
-                           FeatureStdExtZihintpause,
-                           FeatureStdExtZba,
-                           FeatureStdExtZbb,
-                           FeatureStdExtZbs,
-                           FeatureStdExtZic64b,
-                           FeatureStdExtZicbom,
-                           FeatureStdExtZicbop,
-                           FeatureStdExtZicboz,
-                           FeatureStdExtZfhmin,
-                           FeatureStdExtZkt,
-                           FeatureStdExtV,
-                           FeatureStdExtZvfhmin,
-                           FeatureStdExtZvbb,
-                           FeatureStdExtZvkt,
-                           FeatureStdExtZihintntl,
-                           FeatureStdExtZicond,
-                           FeatureStdExtZimop,
-                           FeatureStdExtZcmop,
-                           FeatureStdExtZcb,
-                           FeatureStdExtZfa,
-                           FeatureStdExtZawrs];
+defvar RVA23U64Features = !listconcat(RVA22U64Features,
+                                      [FeatureStdExtV,
+                                       FeatureStdExtZvfhmin,
+                                       FeatureStdExtZvbb,
+                                       FeatureStdExtZvkt,
+                                       FeatureStdExtZihintntl,
+                                       FeatureStdExtZicond,
+                                       FeatureStdExtZimop,
+                                       FeatureStdExtZcmop,
+                                       FeatureStdExtZcb,
+                                       FeatureStdExtZfa,
+                                       FeatureStdExtZawrs]);
 
+defvar RVA23S64BaseFeatures = !listconcat(RVA22S64BaseFeatures,
+                                          [FeatureStdExtSvnapot,
+                                           FeatureStdExtSstc,
+                                           FeatureStdExtSscofpmf,
+                                           FeatureStdExtSsnpm,
+                                           FeatureStdExtSsu64xl,
+                                           FeatureStdExtH,
+                                           FeatureStdExtSsstateen,
+                                           FeatureStdExtShcounterenw,
+                                           FeatureStdExtShvstvala,
+                                           FeatureStdExtShtvala,
+                                           FeatureStdExtShvstvecd,
+                                           FeatureStdExtShvsatpa,
+                                           FeatureStdExtShgatpa]);
 defvar RVA23S64Features = !listconcat(RVA23U64Features,
-                                      [FeatureStdExtZifencei,
-                                       FeatureStdExtSvbare,
-                                       FeatureStdExtSvade,
-                                       FeatureStdExtSsccptr,
-                                       FeatureStdExtSstvecd,
-                                       FeatureStdExtSstvala,
-                                       FeatureStdExtSscounterenw,
-                                       FeatureStdExtSvpbmt,
-                                       FeatureStdExtSvinval,
-                                       FeatureStdExtSvnapot,
-                                       FeatureStdExtSstc,
-                                       FeatureStdExtSscofpmf,
-                                       FeatureStdExtSsnpm,
-                                       FeatureStdExtSsu64xl,
-                                       FeatureStdExtH,
-                                       FeatureStdExtSsstateen,
-                                       FeatureStdExtShcounterenw,
-                                       FeatureStdExtShvstvala,
-                                       FeatureStdExtShtvala,
-                                       FeatureStdExtShvstvecd,
-                                       FeatureStdExtShvsatpa,
-                                       FeatureStdExtShgatpa]);
+                                      RVA23S64BaseFeatures);
 
-defvar RVB23U64Features = [Feature64Bit,
-                           FeatureStdExtI,
-                           FeatureStdExtM,
-                           FeatureStdExtA,
-                           FeatureStdExtF,
-                           FeatureStdExtD,
-                           FeatureStdExtC,
-                           FeatureStdExtZicntr,
-                           FeatureStdExtZihpm,
-                           FeatureStdExtZiccif,
-                           FeatureStdExtZiccrse,
-                           FeatureStdExtZiccamoa,
-                           FeatureStdExtZicclsm,
-                           FeatureStdExtZa64rs,
-                           FeatureStdExtZihintpause,
-                           FeatureStdExtZba,
-                           FeatureStdExtZbb,
-                           FeatureStdExtZbs,
-                           FeatureStdExtZic64b,
-                           FeatureStdExtZicbom,
-                           FeatureStdExtZicbop,
-                           FeatureStdExtZicboz,
-                           FeatureStdExtZkt,
-                           FeatureStdExtZihintntl,
-                           FeatureStdExtZicond,
-                           FeatureStdExtZimop,
-                           FeatureStdExtZcmop,
-                           FeatureStdExtZcb,
-                           FeatureStdExtZfa,
-                           FeatureStdExtZawrs];
+// RVB Profile Family
+
+defvar RVB23U64Features = !listconcat(RVA20U64BaseFeatures,
+                                      [FeatureStdExtZihpm,
+                                       FeatureStdExtZa64rs,
+                                       FeatureStdExtZihintpause,
+                                       FeatureStdExtZba,
+                                       FeatureStdExtZbb,
+                                       FeatureStdExtZbs,
+                                       FeatureStdExtZic64b,
+                                       FeatureStdExtZicbom,
+                                       FeatureStdExtZicbop,
+                                       FeatureStdExtZicboz,
+                                       FeatureStdExtZkt,
+                                       FeatureStdExtZihintntl,
+                                       FeatureStdExtZicond,
+                                       FeatureStdExtZimop,
+                                       FeatureStdExtZcmop,
+                                       FeatureStdExtZcb,
+                                       FeatureStdExtZfa,
+                                       FeatureStdExtZawrs]);
 
 defvar RVB23S64Features = !listconcat(RVB23U64Features,
                                       [FeatureStdExtZifencei,
@@ -185,6 +129,8 @@ defvar RVB23S64Features = !listconcat(RVB23U64Features,
                                        FeatureStdExtSscofpmf,
                                        FeatureStdExtSsu64xl]);
 
+// RVM Profile Family
+
 defvar RVM23U32Features = [Feature32Bit,
                            FeatureStdExtI,
                            FeatureStdExtM,
@@ -198,6 +144,22 @@ defvar RVM23U32Features = [Feature32Bit,
                            FeatureStdExtZicbop,
                            FeatureStdExtZimop,
                            FeatureStdExtZcmop];
+
+//===----------------------------------------------------------------------===//
+// Profile Definitions for ISA String
+//===----------------------------------------------------------------------===//
+
+class RISCVProfile<string name, list<SubtargetFeature> features>
+    : SubtargetFeature<name, "Is" # NAME, "true",
+                       "RISC-V " # name # " profile", features> {
+  // Indicates if the profile is not yet ratified, so should be treated as
+  // experimental.
+  bit Experimental = false;
+}
+class RISCVExperimentalProfile<string name, list<SubtargetFeature> features>
+    : RISCVProfile<"experimental-"#name, features> {
+  let Experimental = true;
+}
 
 def RVI20U32 : RISCVProfile<"rvi20u32", RVI20U32Features>;
 def RVI20U64 : RISCVProfile<"rvi20u64", RVI20U64Features>;


### PR DESCRIPTION
The profiles in a family gain more features overtime so each year can mostly inherit from the previous year.

I did make an exception for Za128rs becoming Za64rs in RVA22. Technically Za64rs is a stricter requirement than Za128rs so it would be ok to have both, but I didn't want to change existing ISA strings.

I used RVA20U64BaseFeatures as the base for RVB23U64 to shorten its list a bit. RVB23 is the first year for that family and was created as a reaction to too many features being added to RVA so inheriting from an earlier RVA seemed somewhat reasonable to me.