### PR TITLE
[llvm][ELF] Add statistics on various section sizes

### DIFF
--- a/llvm/test/CodeGen/X86/section-stats.ll
+++ b/llvm/test/CodeGen/X86/section-stats.ll
@@ -1,0 +1,7 @@
+; RUN: llc -o /dev/null -filetype=obj -stats %s 2>&1 | FileCheck %s
+
+; CHECK: {{[0-9+]}} elf-object-writer - Total size of SHF_ALLOC text sections
+
+define void @f() {
+    ret void
+}

--- a/llvm/test/CodeGen/X86/section-stats.ll
+++ b/llvm/test/CodeGen/X86/section-stats.ll
@@ -1,6 +1,9 @@
+; REQUIRES: asserts
 ; RUN: llc -o /dev/null -filetype=obj -stats %s 2>&1 | FileCheck %s
 
 ; CHECK: {{[0-9+]}} elf-object-writer - Total size of SHF_ALLOC text sections
+
+target triple = "x86_64-unknown-linux-gnu"
 
 define void @f() {
     ret void

--- a/llvm/test/CodeGen/X86/section-stats.ll
+++ b/llvm/test/CodeGen/X86/section-stats.ll
@@ -1,9 +1,12 @@
 ; REQUIRES: asserts
 ; RUN: llc -o /dev/null -filetype=obj -stats %s 2>&1 | FileCheck %s
 
-; CHECK: {{[0-9+]}} elf-object-writer - Total size of SHF_ALLOC text sections
+; CHECK-DAG: 1 elf-object-writer - Total size of SHF_ALLOC text sections
+; CHECK-DAG: 1 elf-object-writer - Total size of SHF_ALLOC read-write sections
 
 target triple = "x86_64-unknown-linux-gnu"
+
+@g = global i8 1
 
 define void @f() {
     ret void


### PR DESCRIPTION
Useful with other infrastructure that consume LLVM statistics to get an idea of distribution of section sizes.

The breakdown of various section types is subject to change, this is just an initial go at gather some sort of stats.

Example stats compiling X86ISelLowering.cpp (-g1):

```
        "elf-object-writer.AllocROBytes": 308268,
        "elf-object-writer.AllocRWBytes": 6240,
        "elf-object-writer.AllocTextBytes": 1659203,
        "elf-object-writer.DebugBytes": 3180386,
        "elf-object-writer.OtherBytes": 5862,
        "elf-object-writer.RelocationBytes": 2623440,
        "elf-object-writer.StrtabBytes": 228599,
        "elf-object-writer.SymtabBytes": 120336,
        "elf-object-writer.UnwindBytes": 85216,
```