### PR TITLE
[libc] Make str_to_float independent of fenv

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -190,8 +190,6 @@ add_header_library(
     libc.src.__support.CPP.bit
     libc.src.__support.CPP.limits
     libc.src.__support.CPP.optional
-    libc.src.__support.FPUtil.dyadic_float
-    libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.errno.errno

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -525,13 +525,9 @@ clinger_fast_path(ExpandedFloat<T> init_num,
   FPBits result;
   T float_mantissa;
   if constexpr (cpp::is_same_v<StorageType, UInt<128>>) {
-    // float_mantissa = static_cast<T>(fputil::DyadicFloat<128>(
-    //     Sign::POS, 0,
-    //     fputil::DyadicFloat<128>::MantissaType(
-    //         {uint64_t(mantissa), uint64_t(mantissa >> 64)})));
-    float_mantissa = (static_cast<T>(uint64_t(mantissa)) *
-                      static_cast<T>(1ull << 32) * static_cast<T>(1ull << 32)) +
-                     static_cast<T>(uint64_t(mantissa >> 64));
+    float_mantissa =
+        (static_cast<T>(uint64_t(mantissa)) * static_cast<T>(0x1.0p64)) +
+        static_cast<T>(uint64_t(mantissa >> 64));
   } else {
     float_mantissa = static_cast<T>(mantissa);
   }

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -13,9 +13,7 @@
 #include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/CPP/string_view.h"
-#include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
-#include "src/__support/FPUtil/dyadic_float.h"
 #include "src/__support/FPUtil/rounding_mode.h"
 #include "src/__support/common.h"
 #include "src/__support/ctype_utils.h"
@@ -26,6 +24,8 @@
 #include "src/__support/str_to_num_result.h"
 #include "src/__support/uint128.h"
 #include "src/errno/libc_errno.h" // For ERANGE
+
+#include <stdint.h>
 
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
@@ -525,10 +525,13 @@ clinger_fast_path(ExpandedFloat<T> init_num,
   FPBits result;
   T float_mantissa;
   if constexpr (cpp::is_same_v<StorageType, UInt<128>>) {
-    float_mantissa = static_cast<T>(fputil::DyadicFloat<128>(
-        Sign::POS, 0,
-        fputil::DyadicFloat<128>::MantissaType(
-            {uint64_t(mantissa), uint64_t(mantissa >> 64)})));
+    // float_mantissa = static_cast<T>(fputil::DyadicFloat<128>(
+    //     Sign::POS, 0,
+    //     fputil::DyadicFloat<128>::MantissaType(
+    //         {uint64_t(mantissa), uint64_t(mantissa >> 64)})));
+    float_mantissa = (static_cast<T>(uint64_t(mantissa)) *
+                      static_cast<T>(1ull << 32) * static_cast<T>(1ull << 32)) +
+                     static_cast<T>(uint64_t(mantissa >> 64));
   } else {
     float_mantissa = static_cast<T>(mantissa);
   }

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -658,8 +658,6 @@ libc_support_library(
         ":__support_cpp_optional",
         ":__support_cpp_string_view",
         ":__support_ctype_utils",
-        ":__support_fputil_dyadic_float",
-        ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
         ":__support_str_to_integer",


### PR DESCRIPTION
The str_to_float conversion code doesn't need the features provided by
fenv and the dependency is creating a blocker for hand-in-hand. This
patch uses a workaround to remove this dependency.
