### PR TITLE
[lldb] Fully namespace SBType callback function parameters

### DIFF
--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -135,16 +135,16 @@ class LLDB_API SBWatchpoint;
 class LLDB_API SBWatchpointOptions;
 class LLDB_API SBUnixSignals;
 
-typedef bool (*SBBreakpointHitCallback)(void *baton, SBProcess &process,
-                                        SBThread &thread,
+typedef bool (*SBBreakpointHitCallback)(void *baton, lldb::SBProcess &process,
+                                        lldb::SBThread &thread,
                                         lldb::SBBreakpointLocation &location);
 
 typedef void (*SBDebuggerDestroyCallback)(lldb::user_id_t debugger_id,
                                           void *baton);
 
-typedef SBError (*SBPlatformLocateModuleCallback)(
-    void *baton, const SBModuleSpec &module_spec, SBFileSpec &module_file_spec,
-    SBFileSpec &symbol_file_spec);
+typedef lldb::SBError (*SBPlatformLocateModuleCallback)(
+    void *baton, const lldb::SBModuleSpec &module_spec,
+    lldb::SBFileSpec &module_file_spec, lldb::SBFileSpec &symbol_file_spec);
 }
 
 #endif // LLDB_API_SBDEFINES_H

--- a/lldb/include/lldb/lldb-types.h
+++ b/lldb/include/lldb/lldb-types.h
@@ -72,7 +72,7 @@ typedef int pipe_t;                     // Host pipe type
 
 typedef void (*LogOutputCallback)(const char *, void *baton);
 typedef bool (*CommandOverrideCallback)(void *baton, const char **argv);
-typedef bool (*ExpressionCancelCallback)(ExpressionEvaluationPhase phase,
+typedef bool (*ExpressionCancelCallback)(lldb::ExpressionEvaluationPhase phase,
                                          void *baton);
 
 typedef void *ScriptObjectPtr;


### PR DESCRIPTION
This commit fully namespaces callback function pointer parameters that are SB types in `SBDefines` and `lldb-types`. We have a clang-based tool that reads these headers and it would benefit from having the parameters being fully namespaced here.