### PR TITLE
[libc] Use proxy headers for `limits.h` values

### DIFF
--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -47,6 +47,7 @@ add_header_library(
     limits.h
   DEPENDS
     .type_traits
+    libc.hdr.limits_macros
     libc.include.llvm-libc-macros.limits_macros
     libc.src.__support.macros.properties.types
 )

--- a/libc/src/__support/CPP/limits.h
+++ b/libc/src/__support/CPP/limits.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_CPP_LIMITS_H
 #define LLVM_LIBC_SRC___SUPPORT_CPP_LIMITS_H
 
-#include "include/llvm-libc-macros/limits-macros.h" // CHAR_BIT
+#include "hdr/limits_macros.h" // CHAR_BIT
 #include "src/__support/CPP/type_traits/is_integral.h"
 #include "src/__support/CPP/type_traits/is_signed.h"
-#include "src/__support/macros/attributes.h"       // LIBC_INLINE
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h" // LIBC_TYPES_HAS_INT128
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -150,6 +150,12 @@ libc_support_library(
     hdrs = ["hdr/stdio_macros.h"],
 )
 
+
+libc_support_library(
+    name = "hdr_limits_macros",
+    hdrs = ["hdr/limits_macros.h"],
+)
+
 ############################ Type Proxy Header Files ###########################
 
 libc_support_library(
@@ -362,7 +368,7 @@ libc_support_library(
         "__support_cpp_type_traits",
         "__support_macros_attributes",
         ":__support_macros_properties_types",
-        ":llvm_libc_macros_limits_macros",
+        ":hdr_limits_macros",
     ],
 )
 


### PR DESCRIPTION
Summary:
This defines some constants that may conflict with the system when in
overlay mode. Use the proxy header instead.

Fixes: https://github.com/llvm/llvm-project/issues/102368
