### PR TITLE
Add flag to suppress overflow errors in C++ constant expressions.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -74,6 +74,14 @@ def err_expr_not_ice : Error<
 def ext_expr_not_ice : Extension<
   "expression is not an %select{integer|integral}0 constant expression; "
   "folding it to a constant is a GNU extension">, InGroup<GNUFoldingConstant>;
+def ext_expr_ice_overflow : Extension<
+  "expression is not an integer constant expression "
+  "because of arithmetic overflow; folding it to a constant is a GNU "
+  "extension">, InGroup<GNUFoldingConstant>;
+def ext_expr_ice_overflow_cxx : Extension<
+  "expression is not an integral constant expression "
+  "because of arithmetic overflow">,
+  InGroup<DiagGroup<"constant-overflow">>, DefaultError, SFINAEFailure;
 def err_typecheck_converted_constant_expression : Error<
   "value of type %0 is not implicitly convertible to %1">;
 def err_typecheck_converted_constant_expression_disallowed : Error<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -7242,6 +7242,7 @@ public:
     virtual SemaDiagnosticBuilder diagnoseNotICE(Sema &S,
                                                  SourceLocation Loc) = 0;
     virtual SemaDiagnosticBuilder diagnoseFold(Sema &S, SourceLocation Loc);
+    virtual SemaDiagnosticBuilder diagnoseOverflow(Sema &S, SourceLocation Loc);
     virtual ~VerifyICEDiagnoser() {}
   };
 

--- a/clang/test/C/drs/dr2xx.c
+++ b/clang/test/C/drs/dr2xx.c
@@ -287,7 +287,7 @@ void dr261(void) {
    * but we fold it as a constant expression anyway as a GNU extension.
    */
   enum e2 {
-    ex2 = __INT_MAX__ + (0, 1) /* expected-warning {{expression is not an integer constant expression; folding it to a constant is a GNU extension}}
+    ex2 = __INT_MAX__ + (0, 1) /* expected-warning {{expression is not an integer constant expression because of arithmetic overflow; folding it to a constant is a GNU extension}}
                                   expected-note {{value 2147483648 is outside the range of representable values of type 'int'}}
                                   expected-warning {{left operand of comma operator has no effect}}
                                 */

--- a/clang/test/Sema/shift-count-overflow.c
+++ b/clang/test/Sema/shift-count-overflow.c
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -verify=expected,c -pedantic %s
 // RUN: %clang_cc1 -x c++ -std=c++98 -fsyntax-only -verify=expected,cpp %s
 // RUN: %clang_cc1 -x c++ -std=c++11 -fsyntax-only -verify=expected,cpp %s
+// RUN: %clang_cc1 -x c++ -std=c++11 -fsyntax-only -Wno-constant-overflow -verify=suppress %s
+
+// suppress-no-diagnostics
 
 enum shiftof {
     X = (1<<32) // c-warning {{expression is not an integer constant expression; folding it to a constant is a GNU extension}}


### PR DESCRIPTION
Recent Android NDK headers are broken on 32-bit because they contain an invalid shift, and older versions of clang didn't catch this. Demote the error to a default-error with a flag so it can be suppressed.  See discussion on #70307.

Not sure if this is really worth doing if it only affects the Android NDK; Android trunk has been fixed.  And presumably most people will use the compiler from the NDK itself, so they'll update their headers before they ever run into this.  But posting so we can discuss...

CC @glandium