### PR TITLE
[NFC] Fix typo in `REAL(pthread_join(th, ret))`

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
@@ -86,7 +86,7 @@ int internal_pthread_join(void *th, void **ret);
       return REAL(pthread_create)(th, attr, callback, param);             \
     }                                                                     \
     int internal_pthread_join(void *th, void **ret) {                     \
-      return REAL(pthread_join(th, ret));                                 \
+      return REAL(pthread_join)(th, ret);                                 \
     }                                                                     \
     }  // namespace __sanitizer
 

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -1097,7 +1097,7 @@ int internal_pthread_create(void *th, void *attr, void *(*callback)(void *),
 }
 int internal_pthread_join(void *th, void **ret) {
   ScopedIgnoreInterceptors ignore;
-  return REAL(pthread_join(th, ret));
+  return REAL(pthread_join)(th, ret);
 }
 }  // namespace __sanitizer
 


### PR DESCRIPTION
Looks like the macro expands to the same,
but usually we do `REAL(pthread_join)(th, ret)`.
