### PR TITLE
[NFC][bolt][test] Change '|&' to '2>&1 |' for lit internal shell support

### DIFF
--- a/bolt/test/X86/encoding-validation.s
+++ b/bolt/test/X86/encoding-validation.s
@@ -2,7 +2,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
 # RUN: ld.lld %t.o -o %t.exe -q
-# RUN: llvm-bolt %t.exe --relocs -o %t.out --check-encoding |& FileCheck %s
+# RUN: llvm-bolt %t.exe --relocs -o %t.out --check-encoding 2>&1 | FileCheck %s
 
   .text
   .globl _start

--- a/bolt/test/X86/gotpcrelx.s
+++ b/bolt/test/X86/gotpcrelx.s
@@ -10,11 +10,11 @@
 # RUN: ld.lld %t.o -o %t.pie.exe -q -pie
 # RUN: ld.lld %t.o -o %t.no-relax.exe -q --no-relax
 # RUN: llvm-bolt %t.exe --relocs -o %t.out --print-cfg --print-only=_start \
-# RUN:   |& FileCheck --check-prefix=BOLT %s
+# RUN:   2>&1 | FileCheck --check-prefix=BOLT %s
 # RUN: llvm-bolt %t.pie.exe -o %t.null --print-cfg --print-only=_start \
-# RUN:   |& FileCheck --check-prefix=PIE-BOLT %s
+# RUN:   2>&1 | FileCheck --check-prefix=PIE-BOLT %s
 # RUN: llvm-bolt %t.no-relax.exe -o %t.null --print-cfg --print-only=_start \
-# RUN:   |& FileCheck --check-prefix=NO-RELAX-BOLT %s
+# RUN:   2>&1 | FileCheck --check-prefix=NO-RELAX-BOLT %s
 # RUN: llvm-objdump -d --no-show-raw-insn --print-imm-hex \
 # RUN:   %t.out | FileCheck --check-prefix=DISASM %s
 

--- a/bolt/test/X86/icf-jump-tables.test
+++ b/bolt/test/X86/icf-jump-tables.test
@@ -4,7 +4,7 @@
 # REQUIRES: system-linux
 
 # RUN: %clang %cflags -O1 -g %p/../Inputs/icf-jump-tables.c -o %t.exe -Wl,-q
-# RUN: llvm-bolt %t.exe --icf -o %t.bolt |& FileCheck %s
+# RUN: llvm-bolt %t.exe --icf -o %t.bolt 2>&1 | FileCheck %s
 
 ## Check that BOLT successfully folded a function with jump table:
 # CHECK: ICF folded {{.*}}. {{[^0]}} functions had jump tables.

--- a/bolt/test/X86/indirect-goto-pie.test
+++ b/bolt/test/X86/indirect-goto-pie.test
@@ -6,7 +6,7 @@ REQUIRES: x86_64-linux
 
 RUN: %clang %S/Inputs/indirect_goto.c -o %t -fpic -pie -Wl,-q
 RUN: not llvm-bolt %t -o %t.bolt --relocs=1 --print-cfg --print-only=main \
-RUN:   |& FileCheck %s
+RUN:   2>&1 | FileCheck %s
 
 ## Check that processing works if main() is skipped.
 RUN: llvm-bolt %t -o %t.bolt --relocs=1 --skip-funcs=main

--- a/bolt/test/X86/jump-table-func-entry.s
+++ b/bolt/test/X86/jump-table-func-entry.s
@@ -7,7 +7,7 @@
 # RUN: %clang %cflags %t.o -o %t.exe -no-pie -Wl,-q
 
 # RUN: llvm-bolt %t.exe --print-normalized --print-only=foo -o %t.out \
-# RUN:   |& FileCheck %s
+# RUN:   2>&1 | FileCheck %s
 
 
 

--- a/bolt/test/X86/keep-nops.s
+++ b/bolt/test/X86/keep-nops.s
@@ -5,7 +5,7 @@
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
 # RUN: ld.lld %t.o -o %t.exe -q
 # RUN: llvm-bolt %t.exe -o %t.bolt.exe --keep-nops --relocs --print-finalized \
-# RUN:   |& FileCheck --check-prefix=CHECK-BOLT %s
+# RUN:   2>&1 | FileCheck --check-prefix=CHECK-BOLT %s
 # RUN: llvm-objdump -d %t.bolt.exe | FileCheck %s
 
   .text

--- a/bolt/test/X86/linux-bug-table.s
+++ b/bolt/test/X86/linux-bug-table.s
@@ -15,7 +15,7 @@
 ## Verify bug entry bindings again after unreachable code elimination.
 
 # RUN: llvm-bolt %t.out -o %t.out.1 --print-only=_start --print-normalized \
-# RUN:   |& FileCheck --check-prefix=CHECK-REOPT %s
+# RUN:   2>&1 | FileCheck --check-prefix=CHECK-REOPT %s
 
 # CHECK:      BOLT-INFO: Linux kernel binary detected
 # CHECK:      BOLT-INFO: parsed 2 bug table entries

--- a/bolt/test/X86/linux-orc.s
+++ b/bolt/test/X86/linux-orc.s
@@ -9,7 +9,7 @@
 
 ## Verify reading contents of ORC sections.
 
-# RUN: llvm-bolt %t.exe --dump-orc -o /dev/null |& FileCheck %s \
+# RUN: llvm-bolt %t.exe --dump-orc -o /dev/null 2>&1 | FileCheck %s \
 # RUN:   --check-prefix=CHECK-ORC
 
 # CHECK-ORC: 	    BOLT-INFO: ORC unwind information:
@@ -27,19 +27,19 @@
 ## Verify ORC bindings to instructions.
 
 # RUN: llvm-bolt %t.exe --print-normalized --dump-orc --print-orc -o %t.out \
-# RUN:   --keep-nops=0 --bolt-info=0 |& FileCheck %s
+# RUN:   --keep-nops=0 --bolt-info=0 2>&1 | FileCheck %s
 
 
 ## Verify ORC bindings after rewrite.
 
 # RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized --print-orc \
-# RUN:   |& FileCheck %s
+# RUN:   2>&1 | FileCheck %s
 
 ## Verify ORC binding after rewrite when some of the functions are skipped.
 
 # RUN: llvm-bolt %t.exe -o %t.out --skip-funcs=bar --bolt-info=0 --keep-nops=0
 # RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized --print-orc \
-# RUN:   |& FileCheck %s
+# RUN:   2>&1 | FileCheck %s
 
 # CHECK:      BOLT-INFO: Linux kernel binary detected
 # CHECK:      BOLT-INFO: parsed 9 ORC entries

--- a/bolt/test/X86/linux-pci-fixup.s
+++ b/bolt/test/X86/linux-pci-fixup.s
@@ -3,7 +3,7 @@
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags -nostdlib %t.o -o %t.exe \
 # RUN:   -Wl,--image-base=0xffffffff80000000,--no-dynamic-linker,--no-eh-frame-hdr,--no-pie
-# RUN: llvm-bolt %t.exe --print-normalized -o %t.out |& FileCheck %s
+# RUN: llvm-bolt %t.exe --print-normalized -o %t.out 2>&1 | FileCheck %s
 
 ## Check that BOLT correctly parses the Linux kernel .pci_fixup section and
 ## verify that PCI fixup hook in the middle of a function is detected.

--- a/bolt/test/X86/linux-smp-locks.s
+++ b/bolt/test/X86/linux-smp-locks.s
@@ -7,11 +7,11 @@
 # RUN: %clang %cflags -nostdlib %t.o -o %t.exe \
 # RUN:   -Wl,--image-base=0xffffffff80000000,--no-dynamic-linker,--no-eh-frame-hdr,--no-pie
 # RUN: llvm-bolt %t.exe --print-normalized --keep-nops=0 --bolt-info=0 -o %t.out \
-# RUN:   |& FileCheck %s
+# RUN:   2>&1 | FileCheck %s
 
 ## Check the output of BOLT with NOPs removed.
 
-# RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized |& FileCheck %s
+# RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized 2>&1 | FileCheck %s
 
 # CHECK:      BOLT-INFO: Linux kernel binary detected
 # CHECK:      BOLT-INFO: parsed 2 SMP lock entries

--- a/bolt/test/X86/linux-static-calls.s
+++ b/bolt/test/X86/linux-static-calls.s
@@ -9,11 +9,11 @@
 ## Verify static calls bindings to instructions.
 
 # RUN: llvm-bolt %t.exe --print-normalized -o %t.out --keep-nops=0 \
-# RUN:   --bolt-info=0 |& FileCheck %s
+# RUN:   --bolt-info=0 2>&1 | FileCheck %s
 
 ## Verify the bindings again on the rewritten binary with nops removed.
 
-# RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized |& FileCheck %s
+# RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized 2>&1 | FileCheck %s
 
 # CHECK:      BOLT-INFO: Linux kernel binary detected
 # CHECK:      BOLT-INFO: parsed 2 static call entries

--- a/bolt/test/X86/linux-static-keys.s
+++ b/bolt/test/X86/linux-static-keys.s
@@ -11,17 +11,17 @@
 ## Verify static keys jump bindings to instructions.
 
 # RUN: llvm-bolt %t.exe --print-normalized -o %t.out --keep-nops=0 \
-# RUN:   --bolt-info=0 |& FileCheck %s
+# RUN:   --bolt-info=0 2>&1 | FileCheck %s
 
 ## Verify that profile is matched correctly.
 
 # RUN: llvm-bolt %t.exe --print-normalized -o %t.out --keep-nops=0 \
-# RUN:   --bolt-info=0 --data %t.fdata |& \
-# RUN:   FileCheck --check-prefix=CHECK-FDATA %s
+# RUN:   --bolt-info=0 --data %t.fdata 2>&1 \
+# RUN:   | FileCheck --check-prefix=CHECK-FDATA %s
 
 ## Verify the bindings again on the rewritten binary with nops removed.
 
-# RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized |& FileCheck %s
+# RUN: llvm-bolt %t.out -o %t.out.1 --print-normalized 2>&1 | FileCheck %s
 
 # CHECK:      BOLT-INFO: Linux kernel binary detected
 # CHECK:      BOLT-INFO: parsed 2 static keys jump entries

--- a/bolt/test/X86/pt_gnu_relro.s
+++ b/bolt/test/X86/pt_gnu_relro.s
@@ -22,7 +22,7 @@
 # READELF: 04 .got
 
 # RUN: llvm-bolt %t.exe --relocs -o %t.null -v=1 \
-# RUN:   |& FileCheck --check-prefix=BOLT %s
+# RUN:   2>&1 | FileCheck --check-prefix=BOLT %s
 # BOLT: BOLT-INFO: marking .got as GNU_RELRO
 
   .globl _start

--- a/bolt/test/X86/unclaimed-jt-entries.s
+++ b/bolt/test/X86/unclaimed-jt-entries.s
@@ -18,7 +18,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags -no-pie %t.o -o %t.exe -Wl,-q
-# RUN: llvm-bolt %t.exe -v=1 -o %t.out |& FileCheck %s
+# RUN: llvm-bolt %t.exe -v=1 -o %t.out 2>&1 | FileCheck %s
 
 # CHECK: BOLT-WARNING: unclaimed data to code reference (possibly an unrecognized jump table entry) to .Ltmp[[#]] in main
 # CHECK: BOLT-WARNING: unclaimed data to code reference (possibly an unrecognized jump table entry) to .Ltmp[[#]] in main

--- a/bolt/test/X86/vararg.test
+++ b/bolt/test/X86/vararg.test
@@ -5,7 +5,7 @@
 REQUIRES: x86_64-linux
 
 RUN: %clangxx %cxxflags -no-pie %p/../Inputs/vararg.s -o %t -Wl,-q
-RUN: llvm-bolt %t -o %t.null --print-cfg --print-only=.*printf.* |& FileCheck %s
+RUN: llvm-bolt %t -o %t.null --print-cfg --print-only=.*printf.* 2>&1 | FileCheck %s
 
 CHECK: IsSimple    : 0
 CHECK: Entry Point

--- a/bolt/test/runtime/X86/unclaimed-jt-entries.s
+++ b/bolt/test/runtime/X86/unclaimed-jt-entries.s
@@ -18,7 +18,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags %S/Inputs/unclaimed-jt-entries.c -no-pie %t.o -o %t.exe -Wl,-q
-# RUN: llvm-bolt %t.exe -v=1 -o %t.out --sequential-disassembly |& FileCheck %s
+# RUN: llvm-bolt %t.exe -v=1 -o %t.out --sequential-disassembly 2>&1 | FileCheck %s
 
 # CHECK: BOLT-WARNING: unclaimed data to code reference (possibly an unrecognized jump table entry) to .Ltmp[[#]] in func
 # CHECK: BOLT-WARNING: unclaimed data to code reference (possibly an unrecognized jump table entry) to .Ltmp[[#]] in func


### PR DESCRIPTION
This patches changes all references to '|&' in bolt tests to instead use the '2>&1 |' syntax for better consistency across testing and so that lit's internal shell can be used to run these tests. This addresses a suggestion made in the comments of this RFC: https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179. 

Fixes https://github.com/llvm/llvm-project/issues/102388