### PR TITLE
[MLGO] Error if default eviction advisor is requested with model

### DIFF
--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
@@ -72,7 +72,7 @@ static cl::opt<std::string> TrainingLog(
     "regalloc-training-log", cl::Hidden,
     cl::desc("Training log for the register allocator eviction model"));
 
-static cl::opt<std::string> ModelUnderTraining(
+cl::opt<std::string> ModelUnderTraining(
     "regalloc-model", cl::Hidden,
     cl::desc("The model being trained for register allocation eviction"));
 

--- a/llvm/lib/CodeGen/RegAllocEvictionAdvisor.cpp
+++ b/llvm/lib/CodeGen/RegAllocEvictionAdvisor.cpp
@@ -44,6 +44,10 @@ static cl::opt<bool> EnableLocalReassignment(
              "may be compile time intensive"),
     cl::init(false));
 
+#ifdef LLVM_HAVE_TFLITE
+extern cl::opt<std::string> ModelUnderTraining;
+#endif // #ifdef LLVM_HAVE_TFLITE
+
 namespace llvm {
 cl::opt<unsigned> EvictInterferenceCutoff(
     "regalloc-eviction-max-interference-cutoff", cl::Hidden,
@@ -85,6 +89,14 @@ private:
     if (NotAsRequested)
       M.getContext().emitError("Requested regalloc eviction advisor analysis "
                                "could not be created. Using default");
+
+#ifdef LLVM_HAVE_TFLITE
+    if (!ModelUnderTraining.empty())
+      M.getContext().emitError(
+          "A model has been passed in, but the default eviction advisor "
+          "analysis was requested. The model will not be used.");
+#endif // #ifdef LLVM_HAVE_TFLITE
+
     return RegAllocEvictionAdvisorAnalysis::doInitialization(M);
   }
   const bool NotAsRequested;

--- a/llvm/test/CodeGen/MLRegAlloc/dev-mode-default-advisor-model-error.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/dev-mode-default-advisor-model-error.ll
@@ -1,0 +1,14 @@
+; REQUIRES: have_tflite
+; REQUIRES: x86_64-linux
+;
+; Checking that if we specify a model, but do not specify the development
+; advisor, we get an error.
+;
+; RUN: not llc -mtriple=x86_64-linux-unknown -regalloc=greedy -regalloc-enable-advisor=default \
+; RUN:   -regalloc-model=/model_foo %s -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: A model has been passed in, but the default eviction advisor analysis was requested. The model will not be used.
+
+define i32 @foo() {
+  ret i32 0
+}


### PR DESCRIPTION
This patch causes the default Regalloc eviction advisor to emit an error if a model is specified. This ensures that someone passing -regalloc-model will get an error if they forget to pass -regalloc-enable-advisor=development instead of having the compiler silently ignore the flag. This does not emit a warning in the -regalloc-enable-advisor=release case, but that should be much less common as it is an explicit flag instead of the default.