### PR TITLE
[libclang/python] Improve error reporting of `TranslationUnit` creating functions

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -642,7 +642,6 @@ class BaseEnumeration(Enum):
     Common base class for named enumerations held in sync with Index.h values.
     """
 
-
     def from_param(self):
         return self.value
 
@@ -717,7 +716,6 @@ class CursorKind(BaseEnumeration):
     def is_unexposed(self):
         """Test if this is an unexposed kind."""
         return conf.lib.clang_isUnexposed(self)  # type: ignore [no-any-return]
-
 
     ###
     # Declaration Kinds
@@ -844,7 +842,6 @@ class CursorKind(BaseEnumeration):
 
     # A C++ access specifier decl.
     CXX_ACCESS_SPEC_DECL = 39
-
 
     ###
     # Reference Kinds
@@ -3145,9 +3142,7 @@ class TranslationUnit(ClangObject):
 
         ptr = c_object_p()
         errc = conf.lib.clang_createTranslationUnit2(
-            index,
-            os.fspath(filename),
-            byref(ptr)
+            index, os.fspath(filename), byref(ptr)
         )
 
         if errc != 0:
@@ -3300,7 +3295,7 @@ class TranslationUnit(ClangObject):
             self, len(unsaved_files), unsaved_files_array, options
         )
         if errc != 0:
-            raise TranslationUnitLoadError(errc, 'Error reparsing TranslationUnit.')
+            raise TranslationUnitLoadError(errc, "Error reparsing TranslationUnit.")
 
     def save(self, filename):
         """Saves the TranslationUnit to a file.
@@ -3754,7 +3749,11 @@ functionList: list[LibFunc] = [
     ("clang_codeCompleteGetNumDiagnostics", [CodeCompletionResults], c_int),
     ("clang_createIndex", [c_int, c_int], c_object_p),
     ("clang_createTranslationUnit", [Index, c_interop_string], c_object_p),
-    ("clang_createTranslationUnit2", [Index, c_interop_string, POINTER(c_object_p)], c_int),
+    (
+        "clang_createTranslationUnit2",
+        [Index, c_interop_string, POINTER(c_object_p)],
+        c_int,
+    ),
     ("clang_CXRewriter_create", [TranslationUnit], c_object_p),
     ("clang_CXRewriter_dispose", [Rewriter]),
     ("clang_CXRewriter_insertTextBefore", [Rewriter, SourceLocation, c_interop_string]),
@@ -3951,7 +3950,16 @@ functionList: list[LibFunc] = [
     ),
     (
         "clang_parseTranslationUnit2",
-        [Index, c_interop_string, c_void_p, c_int, c_void_p, c_int, c_int, POINTER(c_object_p)],
+        [
+            Index,
+            c_interop_string,
+            c_void_p,
+            c_int,
+            c_void_p,
+            c_int,
+            c_int,
+            POINTER(c_object_p),
+        ],
         c_int,
     ),
     ("clang_reparseTranslationUnit", [TranslationUnit, c_int, c_void_p, c_int], c_int),

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -59,6 +59,9 @@ Clang Python Bindings Potentially Breaking Changes
 - Calling a property on the `CompletionChunk` or `CompletionString` class
   statically now leads to an error, instead of returning a `CachedProperty` object
   that is used internally. Properties are only available on instances.
+- `TranslationUnitLoadError` now contains an optional error code in `error_code`
+  attribute. Also, `TranslationUnit.reparse` will throw `TranslationUnitLoadError`
+  when operation fails.
 
 What's New in Clang |release|?
 ==============================

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -55,12 +55,12 @@ Clang Frontend Potentially Breaking Changes
 Clang Python Bindings Potentially Breaking Changes
 --------------------------------------------------
 - Parts of the interface returning string results will now return
-  the empty string `""` when no result is available, instead of `None`.
-- Calling a property on the `CompletionChunk` or `CompletionString` class
-  statically now leads to an error, instead of returning a `CachedProperty` object
+  the empty string ``""`` when no result is available, instead of ``None``.
+- Calling a property on the ``CompletionChunk`` or ``CompletionString`` class
+  statically now leads to an error, instead of returning a ``CachedProperty`` object
   that is used internally. Properties are only available on instances.
-- `TranslationUnitLoadError` now contains an error code in `error_code`
-  attribute. Also, `TranslationUnit.reparse` will throw `TranslationUnitLoadError`
+- ``TranslationUnitLoadError`` now contains an error code in ``error_code``
+  attribute. Also, ``TranslationUnit.reparse`` will throw ``TranslationUnitLoadError``
   when operation fails.
 
 What's New in Clang |release|?

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -59,7 +59,7 @@ Clang Python Bindings Potentially Breaking Changes
 - Calling a property on the `CompletionChunk` or `CompletionString` class
   statically now leads to an error, instead of returning a `CachedProperty` object
   that is used internally. Properties are only available on instances.
-- `TranslationUnitLoadError` now contains an optional error code in `error_code`
+- `TranslationUnitLoadError` now contains an error code in `error_code`
   attribute. Also, `TranslationUnit.reparse` will throw `TranslationUnitLoadError`
   when operation fails.
 


### PR DESCRIPTION
Provide more detailed errors when parsing a translation unit fails.
This is part 2 of #101784 