### PR TITLE
[clang][Interp] Properly abort on reads from non-const variables

### DIFF
--- a/clang/lib/AST/Interp/Interp.cpp
+++ b/clang/lib/AST/Interp/Interp.cpp
@@ -301,10 +301,11 @@ bool CheckConstant(InterpState &S, CodePtr OpPC, const Descriptor *Desc) {
   assert(Desc);
 
   auto IsConstType = [&S](const VarDecl *VD) -> bool {
-    if (VD->isConstexpr())
+    QualType T = VD->getType();
+
+    if (T.isConstant(S.getCtx()))
       return true;
 
-    QualType T = VD->getType();
     if (S.getLangOpts().CPlusPlus && !S.getLangOpts().CPlusPlus11)
       return (T->isSignedIntegerOrEnumerationType() ||
               T->isUnsignedIntegerOrEnumerationType()) &&
@@ -325,7 +326,7 @@ bool CheckConstant(InterpState &S, CodePtr OpPC, const Descriptor *Desc) {
   if (const auto *D = Desc->asVarDecl();
       D && D->hasGlobalStorage() && D != S.EvaluatingDecl && !IsConstType(D)) {
     diagnoseNonConstVariable(S, OpPC, D);
-    return S.inConstantContext();
+    return false;
   }
 
   return true;

--- a/clang/test/AST/Interp/bitfields.cpp
+++ b/clang/test/AST/Interp/bitfields.cpp
@@ -1,10 +1,7 @@
-// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -Wno-bitfield-constant-conversion -verify %s
-// RUN: %clang_cc1 -verify=ref -Wno-bitfield-constant-conversion %s
-// RUN: %clang_cc1 -std=c++20 -fexperimental-new-constant-interpreter -Wno-bitfield-constant-conversion -verify %s
-// RUN: %clang_cc1 -std=c++20 -verify=ref -Wno-bitfield-constant-conversion %s
-
-// expected-no-diagnostics
-// ref-no-diagnostics
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -Wno-bitfield-constant-conversion -verify=expected,both %s
+// RUN: %clang_cc1 -verify=ref,both -Wno-bitfield-constant-conversion %s
+// RUN: %clang_cc1 -std=c++20 -fexperimental-new-constant-interpreter -Wno-bitfield-constant-conversion -verify=expected,both %s
+// RUN: %clang_cc1 -std=c++20 -verify=ref,both -Wno-bitfield-constant-conversion %s
 
 namespace Basic {
   struct A {
@@ -122,4 +119,12 @@ namespace test0 {
   void b(C &c) {
     c.onebit = int_source();
   }
+}
+
+namespace NonConstBitWidth {
+  int n3 = 37; // both-note {{declared here}}
+  struct S {
+    int l : n3; // both-error {{constant expression}} \
+                // both-note {{read of non-const variable}}
+  };
 }


### PR DESCRIPTION
We need to return false here in any case. Use isConstant() to capure the weird OpenCL cases.