### PR TITLE
Verifier: Reword range metadata error message

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -4142,8 +4142,10 @@ void Verifier::verifyRangeMetadata(const Value &I, const MDNode *Range,
     ConstantInt *High =
         mdconst::dyn_extract<ConstantInt>(Range->getOperand(2 * i + 1));
     Check(High, "The upper limit must be an integer!", High);
-    Check(High->getType() == Low->getType() &&
-          High->getType() == Ty->getScalarType(),
+
+    Check(High->getType() == Low->getType(), "Range pair types must match!",
+          &I);
+    Check(High->getType() == Ty->getScalarType(),
           "Range types must match instruction type!", &I);
 
     APInt HighV = High->getValue();

--- a/llvm/test/Verifier/absolute_symbol.ll
+++ b/llvm/test/Verifier/absolute_symbol.ll
@@ -58,11 +58,11 @@ define void @absolute_func_empty_arguments() !absolute_symbol !0 {
 ; CHECK-NEXT: ptr @absolute_two_arguments_wrong_width
 !4 = !{i32 256, i32 512}
 
-; CHECK-NEXT: Range types must match instruction type!
+; CHECK-NEXT: Range pair types must match!
 ; CHECK-NEXT: ptr @absolute_two_arguments_one_wrong_width0
 !5 = !{i32 256, i64 512}
 
-; CHECK-NEXT: Range types must match instruction type!
+; CHECK-NEXT: Range pair types must match!
 ; CHECK-NEXT: ptr @absolute_two_arguments_one_wrong_width1
 !6 = !{i64 256, i32 512}
 

--- a/llvm/test/Verifier/range-1.ll
+++ b/llvm/test/Verifier/range-1.ll
@@ -47,7 +47,7 @@ entry:
   ret i8 %y
 }
 !5 = !{i32 0, i8 0}
-; CHECK: Range types must match instruction type!
+; CHECK: Range pair types must match!
 ; CHECK:  %y = load
 
 define i8 @f7(ptr %x) {
@@ -56,7 +56,7 @@ entry:
   ret i8 %y
 }
 !6 = !{i8 0, i32 0}
-; CHECK: Range types must match instruction type!
+; CHECK: Range pair types must match!
 ; CHECK:  %y = load
 
 define i8 @f8(ptr %x) {


### PR DESCRIPTION
This was using the same message for the case where the type
doesn't match the instruction, and the types didn't match each other.
Make it clear which one the issue is.