### PR TITLE
[clang] Remove dead incremental Parser code

### DIFF
--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -629,11 +629,6 @@ bool Parser::ParseTopLevelDecl(DeclGroupPtrTy &Result,
                                Sema::ModuleImportState &ImportState) {
   DestroyTemplateIdAnnotationsRAIIObj CleanupRAII(*this);
 
-  // Skip over the EOF token, flagging end of previous input for incremental
-  // processing
-  if (PP.isIncrementalProcessingEnabled() && Tok.is(tok::eof))
-    ConsumeToken();
-
   Result = nullptr;
   switch (Tok.getKind()) {
   case tok::annot_pragma_unused:


### PR DESCRIPTION
When incremental processing is enabled, the Parser will never report `tok::eof` but `tok::annot_repl_input_end`. However, that case is already taken care of in `IncrementalParser::ParseOrWrapTopLevelDecl()` so this check was never executing.