### PR TITLE
[clang][Interp] Don't diagnose indexing arrays with index 0

### DIFF
--- a/clang/lib/AST/Interp/Interp.h
+++ b/clang/lib/AST/Interp/Interp.h
@@ -2421,7 +2421,7 @@ inline bool ArrayElemPtr(InterpState &S, CodePtr OpPC) {
   const T &Offset = S.Stk.pop<T>();
   const Pointer &Ptr = S.Stk.peek<Pointer>();
 
-  if (!Ptr.isZero()) {
+  if (!Ptr.isZero() && !Offset.isZero()) {
     if (!CheckArray(S, OpPC, Ptr))
       return false;
   }
@@ -2437,7 +2437,7 @@ inline bool ArrayElemPtrPop(InterpState &S, CodePtr OpPC) {
   const T &Offset = S.Stk.pop<T>();
   const Pointer &Ptr = S.Stk.pop<Pointer>();
 
-  if (!Ptr.isZero()) {
+  if (!Ptr.isZero() && !Offset.isZero()) {
     if (!CheckArray(S, OpPC, Ptr))
       return false;
   }

--- a/clang/test/AST/Interp/literals.cpp
+++ b/clang/test/AST/Interp/literals.cpp
@@ -1196,13 +1196,15 @@ namespace incdecbool {
 }
 
 #if __cplusplus >= 201402L
-/// NOTE: The diagnostics of the two interpreters are a little
-/// different here, but they both make sense.
 constexpr int externvar1() { // both-error {{never produces a constant expression}}
-  extern char arr[]; // ref-note {{declared here}}
-   return arr[0]; // ref-note {{read of non-constexpr variable 'arr'}} \
-                  // expected-note {{indexing of array without known bound}}
+  extern char arr[]; // both-note {{declared here}}
+   return arr[0]; // both-note {{read of non-constexpr variable 'arr'}}
 }
+namespace externarr {
+  extern int arr[];
+  constexpr int *externarrindex = &arr[0]; /// No diagnostic.
+}
+
 
 namespace StmtExprs {
   constexpr int foo() {


### PR DESCRIPTION
Even if the array is of unknown bounds, index 0 is fine.