### PR TITLE
[Github] Allow CI to run different Python version tests at once

### DIFF
--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -22,12 +22,6 @@ on:
       - '.github/workflows/libclang-python-tests.yml'
       - '.github/workflows/llvm-project-tests.yml'
 
-concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-
 jobs:
   check-clang-python:
     # Build libclang and then run the libclang Python binding's unit tests.

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -51,7 +51,7 @@ concurrency:
   # Cancel intermediate builds: only if it is a pull request build.
   # If the group name here is the same as the group name in the workflow that includes
   # this one, then the action will try to wait on itself and get stuck.
-  group: llvm-project-${{ github.workflow }}-${{ inputs.projects }}${{ github.ref }}
+  group: llvm-project-${{ github.workflow }}-${{ inputs.projects }}-${{ inputs.python_version }}${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:


### PR DESCRIPTION
Previously, #77219 added a `python_version` parameter for the Github Actions CI Ninja-based build tests. This is necessary to run component tests on different Python versions, as is currently done by the only user of this parameter, the [Libclang Python bindings test](https://github.com/llvm/llvm-project/blob/main/.github/workflows/libclang-python-tests.yml).
The parameter was however not added to the concurrency group of the workflow, meaning that starting the workflow with two different Python versions immediately cancels one of them, as pointed out by https://github.com/llvm/llvm-project/pull/77219#issuecomment-1937105822. This change fixes that problem by making the Python version part of the concurrency group key, and removes the superfluous concurrency group from the calling workflow.