### PR TITLE
[analyzer][NFC] Trivial refactoring of region invalidation

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -484,17 +484,6 @@ private:
   friend void ProgramStateRetain(const ProgramState *state);
   friend void ProgramStateRelease(const ProgramState *state);
 
-  /// \sa invalidateValues()
-  /// \sa invalidateRegions()
-  ProgramStateRef
-  invalidateRegionsImpl(ArrayRef<SVal> Values,
-                        const Expr *E, unsigned BlockCount,
-                        const LocationContext *LCtx,
-                        bool ResultsInSymbolEscape,
-                        InvalidatedSymbols *IS,
-                        RegionAndSymbolInvalidationTraits *HTraits,
-                        const CallEvent *Call) const;
-
   SVal wrapSymbolicRegion(SVal Base) const;
 };
 


### PR DESCRIPTION
This commit removes `invalidateRegionsImpl()`, moving its body to `invalidateRegions(ValueList Values, ...)`, because it was a completely useless layer of indirection.

Moreover I'm fixing some strange indentation within this function body and renaming two variables to the proper `UpperCamelCase` format.