### PR TITLE
[clang][Interp] Fall back to dummy pointers if createGlobal() fails

### DIFF
--- a/clang/lib/AST/Interp/Compiler.h
+++ b/clang/lib/AST/Interp/Compiler.h
@@ -89,13 +89,14 @@ public:
 /// State encapsulating if a the variable creation has been successful,
 /// unsuccessful, or no variable has been created at all.
 struct VarCreationState {
-  std::optional<bool> S = std::nullopt;
+  enum SS { Failure = 0, Success = 1, NotCreated, DummyCreated } S;
   VarCreationState() = default;
-  VarCreationState(bool b) : S(b) {}
-  static VarCreationState NotCreated() { return VarCreationState(); }
+  VarCreationState(SS b) : S(b) {}
+  VarCreationState(bool b) : S(b ? Success : Failure) {}
 
-  operator bool() const { return S && *S; }
-  bool notCreated() const { return !S; }
+  operator bool() const { return S == Success; }
+  bool notCreated() const { return S == NotCreated; }
+  bool dummyCreated() const { return S == DummyCreated; }
 };
 
 /// Compilation context for expressions.

--- a/clang/test/AST/Interp/records.cpp
+++ b/clang/test/AST/Interp/records.cpp
@@ -1576,3 +1576,13 @@ namespace ctorOverrider {
   constexpr Covariant1 cb;
 }
 #endif
+
+namespace IncompleteStaticStructMember {
+  struct Foo;
+  struct Bar {
+    static const Foo x;
+    static const Foo y;
+  };
+  static_assert(&Bar::x != nullptr, ""); // both-warning {{always true}}
+  static_assert(&Bar::x != &Bar::y, "");
+}


### PR DESCRIPTION
createGlobal fails e.g. if the type isn't complete.