### PR TITLE
[SimplifyCFG] Avoid introducing of too many phi nodes during sinking

### DIFF
--- a/llvm/test/Transforms/PGOProfile/cspgo_profile_summary.ll
+++ b/llvm/test/Transforms/PGOProfile/cspgo_profile_summary.ll
@@ -66,10 +66,10 @@ for.end:
   ret void
 }
 ; PGOSUMMARY-LABEL: @bar
-; PGOSUMMARY: %even.odd = select i1 %tobool{{[0-9]*}}, ptr @even, ptr @odd
+; PGOSUMMARY: br i1 %tobool, label %if.else, label %if.then
 ; PGOSUMMARY-SAME: !prof ![[BW_PGO_BAR:[0-9]+]]
 ; CSPGOSUMMARY-LABEL: @bar
-; CSPGOSUMMARY: %even.odd = select i1 %tobool{{[0-9]*}}, ptr @even, ptr @odd
+; CSPGOSUMMARY: br i1 %tobool, label %if.else, label %if.then
 ; CSPGOSUMMARY-SAME: !prof ![[BW_CSPGO_BAR:[0-9]+]]
 
 define internal fastcc i32 @cond(i32 %i) {
@@ -102,9 +102,9 @@ for.end:
   ret void
 }
 ; CSPGOSUMMARY-LABEL: @foo
-; CSPGOSUMMARY: %even.odd.i = select i1 %tobool.i{{[0-9]*}}, ptr @even, ptr @odd
+; CSPGOSUMMARY: br i1 %tobool.i, label %if.else.i, label %if.then.i
 ; CSPGOSUMMARY-SAME: !prof ![[BW_CSPGO_BAR]]
-; CSPGOSUMMARY: %even.odd.i2 = select i1 %tobool.i{{[0-9]*}}, ptr @odd, ptr @even
+; CSPGOSUMMARY: br i1 %tobool.i, label %if.then.i2, label %if.else.i21
 ; CSPGOSUMMARY-SAME: !prof ![[BW_CSPGO_BAR]]
 
 declare dso_local i32 @bar_m(i32)


### PR DESCRIPTION
Currently, the sinking heuristic considers sinking profitable if we're introducing at most one phi per sunk instruction.

In practice, this usually works out fairly nicely, because we usually end up trading one original phi for one new phi, with the exception of void instructions where we do have to introduce a phi to allow non-trivial sinking at all.

However, there are pathological cases like the one in `@many_indirect_phis`, where we really do end up adding an extra phi for each sunk instruction, which is non-profitable.

This patch changes the heuristic to keep track of the number of phis that will be needed depending on how many instructions are sunk, and do not allow sinking if the number of phis increases.

Unfortunately, this is not entirely accurate either, because a phi count reduction in one place can effectively cancel out a phi count increase in another. E.g. if we sink some instruction sequence rooted at a void instruction in a way that ultimately requires no phis at all, the bonus this case gets may be consumed by something else (this is the `@store_and_unrelated_many_phi_add2` case).

Fixes https://github.com/llvm/llvm-project/issues/96838.