### PR TITLE
[NFC] Remove unnecessary copy of Triples

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -2727,8 +2727,6 @@ void CXXNameMangler::mangleQualifiers(Qualifiers Quals, const DependentAddressSp
     //   <type> ::= U <OpenCL-addrspace>
     //   <type> ::= U <CUDA-addrspace>
 
-    llvm::Triple Triple = getASTContext().getTargetInfo().getTriple();
-
     SmallString<64> ASString;
     LangAS AS = Quals.getAddressSpace();
 
@@ -2800,7 +2798,7 @@ void CXXNameMangler::mangleQualifiers(Qualifiers Quals, const DependentAddressSp
         // For z/OS, there are no special mangling rules applied to the ptr32
         // qualifier. Ex: void foo(int * __ptr32 p) -> _Z3f2Pi. The mangling for
         // "p" is treated the same as a regular integer pointer.
-        if (!Triple.isOSzOS())
+        if (!getASTContext().getTargetInfo().getTriple().isOSzOS())
           ASString = "ptr32_uptr";
         break;
       case LangAS::ptr64:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -7057,7 +7057,6 @@ static bool handleMSPointerTypeQualifierAttr(TypeProcessingState &State,
 
   // Add address space to type based on its attributes.
   LangAS ASIdx = LangAS::Default;
-  llvm::Triple Triple = S.Context.getTargetInfo().getTriple();
   uint64_t PtrWidth =
       S.Context.getTargetInfo().getPointerWidth(LangAS::Default);
   if (PtrWidth == 32) {
@@ -7066,7 +7065,7 @@ static bool handleMSPointerTypeQualifierAttr(TypeProcessingState &State,
     else if (Attrs[attr::UPtr])
       ASIdx = LangAS::ptr32_uptr;
   } else if (PtrWidth == 64 && Attrs[attr::Ptr32]) {
-    if (Triple.isOSzOS() || Attrs[attr::UPtr])
+    if (S.Context.getTargetInfo().getTriple().isOSzOS() || Attrs[attr::UPtr])
       ASIdx = LangAS::ptr32_uptr;
     else
       ASIdx = LangAS::ptr32_sptr;


### PR DESCRIPTION
Remove unnecessary copy of Triple in ItaniumMangle.cpp, SemaType.cpp