### PR TITLE
[mlir][vector] Fix return of `DropUnitDimsFromTransposeOp` pattern

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1782,7 +1782,7 @@ struct DropUnitDimsFromTransposeOp final
     rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(
         op, op.getResultVectorType(), tranposeWithoutUnitDims);
 
-    return failure();
+    return success();
   }
 };
 


### PR DESCRIPTION
This accidentally returned `failure()` (rather than `success()`) when it applied.