### PR TITLE
LSV: document hang reported in #37865

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
@@ -216,6 +216,8 @@ void reorder(Instruction *I) {
       if (IM->getParent() != I->getParent())
         continue;
 
+      assert(IM != I && "Unexpected cycle while re-ordering instructions");
+
       if (!IM->comesBefore(I)) {
         InstructionsToMove.insert(IM);
         Worklist.push_back(IM);

--- a/llvm/test/Transforms/LoadStoreVectorizer/AArch64/pr37865.ll
+++ b/llvm/test/Transforms/LoadStoreVectorizer/AArch64/pr37865.ll
@@ -2,6 +2,7 @@
 ; RUN: not --crash opt -mtriple=aarch64 -passes=load-store-vectorizer -disable-output %s
 
 define i32 @load_cycle(ptr %x) {
+; CHECK: Unexpected cycle while re-ordering instructions
 entry:
   %gep.x.1 = getelementptr inbounds [2 x i32], ptr %x, i32 0, i32 1
   %load.x.1 = load i32, ptr %gep.x.1

--- a/llvm/test/Transforms/LoadStoreVectorizer/AArch64/pr37865.ll
+++ b/llvm/test/Transforms/LoadStoreVectorizer/AArch64/pr37865.ll
@@ -1,5 +1,6 @@
 ; REQUIRES: asserts
-; RUN: not --crash opt -mtriple=aarch64 -passes=load-store-vectorizer -disable-output %s
+; RUN: not --crash opt -mtriple=aarch64 -passes=load-store-vectorizer \
+; RUN:   -disable-output %s 2>&1 | FileCheck %s
 
 define i32 @load_cycle(ptr %x) {
 ; CHECK: Unexpected cycle while re-ordering instructions

--- a/llvm/test/Transforms/LoadStoreVectorizer/AArch64/pr37865.ll
+++ b/llvm/test/Transforms/LoadStoreVectorizer/AArch64/pr37865.ll
@@ -1,0 +1,13 @@
+; REQUIRES: asserts
+; RUN: not --crash opt -mtriple=aarch64 -passes=load-store-vectorizer -disable-output %s
+
+define i32 @load_cycle(ptr %x) {
+entry:
+  %gep.x.1 = getelementptr inbounds [2 x i32], ptr %x, i32 0, i32 1
+  %load.x.1 = load i32, ptr %gep.x.1
+  %rem = urem i32 %load.x.1, 1
+  %gep.x.2 = getelementptr inbounds [2 x i32], ptr %x, i32 %rem, i32 0
+  %load.x.2 = load i32, ptr %gep.x.2
+  %ret = add i32 %load.x.2, %load.x.1
+  ret i32 %ret
+}


### PR DESCRIPTION
LoadStoreVectorizer hangs on certain examples, when its reorder function goes into a cycle. Detect this cycle and explicitly forbid it, using an assert, and document the resulting crash in a test-case under AArch64.