### PR TITLE
[update_llc_test_checks][AMDGPU] Update AMDGPU regexp in update_llc_test_checks.py

### DIFF
--- a/llvm/utils/UpdateTestChecks/asm.py
+++ b/llvm/utils/UpdateTestChecks/asm.py
@@ -52,6 +52,7 @@ ASM_FUNCTION_AARCH64_RE = re.compile(
 
 ASM_FUNCTION_AMDGPU_RE = re.compile(
     r"\.type\s+_?(?P<func>[^,\n]+),@function\n"
+    r"(^\s*\.amdgpu_hsa_kernel (?P=func)\n)?"
     r'^_?(?P=func):(?:[ \t]*;+[ \t]*@"?(?P=func)"?)?\n'
     r"(?P<body>.*?)\n"  # (body of the function)
     # This list is incomplete


### PR DESCRIPTION
Updating `llvm/test/CodeGen/AMDGPU/GlobalISel/extractelement.ll` with `update_llc_test_checks.py` ended with several kernels with no checks.

Llc's output contained the line ".amdgpu_hsa_kernel <funcname>" after the ".type <funcname>,@function" entry which was not considered by the regexp.