### PR TITLE
[lldb][Platform] Move the GetSDKPathFromDebugInfo helpers from PlatformDarwin into Platform

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -31,6 +31,7 @@
 #include "lldb/lldb-private-forward.h"
 #include "lldb/lldb-public.h"
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
 
@@ -451,8 +452,9 @@ public:
   ///          (e.g., a public and internal SDK).
   virtual llvm::Expected<std::pair<XcodeSDK, bool>>
   GetSDKPathFromDebugInfo(Module &module) {
-    return llvm::createStringError(llvm::formatv(
-        "{0} not implemented for '{1}' platform.", __func__, GetName()));
+    return llvm::createStringError(
+        llvm::formatv("{0} not implemented for '{1}' platform.",
+                      LLVM_PRETTY_FUNCTION, GetName()));
   }
 
   /// Returns the full path of the most appropriate SDK for the
@@ -466,8 +468,9 @@ public:
   ///          Xcode SDK.
   virtual llvm::Expected<std::string>
   ResolveSDKPathFromDebugInfo(Module &module) {
-    return llvm::createStringError(llvm::formatv(
-        "{0} not implemented for '{1}' platform.", __func__, GetName()));
+    return llvm::createStringError(
+        llvm::formatv("{0} not implemented for '{1}' platform.",
+                      LLVM_PRETTY_FUNCTION, GetName()));
   }
 
   const std::string &GetRemoteURL() const { return m_remote_url; }

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -27,6 +27,7 @@
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/Timeout.h"
 #include "lldb/Utility/UserIDResolver.h"
+#include "lldb/Utility/XcodeSDK.h"
 #include "lldb/lldb-private-forward.h"
 #include "lldb/lldb-public.h"
 
@@ -434,6 +435,39 @@ public:
   virtual lldb_private::ConstString
   GetSDKDirectory(lldb_private::Target &target) {
     return lldb_private::ConstString();
+  }
+
+  /// Search each CU associated with the specified 'module' for
+  /// the SDK paths the CUs were compiled against. In the presence
+  /// of different SDKs, we try to pick the most appropriate one
+  /// using \ref XcodeSDK::Merge.
+  ///
+  /// \param[in] module Module whose debug-info CUs to parse for
+  ///                   which SDK they were compiled against.
+  ///
+  /// \returns If successful, returns a pair of a parsed XcodeSDK
+  ///          object and a boolean that is 'true' if we encountered
+  ///          a conflicting combination of SDKs when parsing the CUs
+  ///          (e.g., a public and internal SDK).
+  virtual llvm::Expected<std::pair<XcodeSDK, bool>>
+  GetSDKPathFromDebugInfo(Module &module) {
+    return llvm::createStringError(llvm::formatv(
+        "{0} not implemented for '{1}' platform.", __func__, GetName()));
+  }
+
+  /// Returns the full path of the most appropriate SDK for the
+  /// specified 'module'. This function gets this path by parsing
+  /// debug-info (see \ref `GetSDKPathFromDebugInfo`).
+  ///
+  /// \param[in] module Module whose debug-info to parse for
+  ///                   which SDK it was compiled against.
+  ///
+  /// \returns If successful, returns the full path to an
+  ///          Xcode SDK.
+  virtual llvm::Expected<std::string>
+  ResolveSDKPathFromDebugInfo(Module &module) {
+    return llvm::createStringError(llvm::formatv(
+        "{0} not implemented for '{1}' platform.", __func__, GetName()));
   }
 
   const std::string &GetRemoteURL() const { return m_remote_url; }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -124,32 +124,11 @@ public:
   /// located in.
   static FileSpec GetCurrentCommandLineToolsDirectory();
 
-  /// Search each CU associated with the specified 'module' for
-  /// the SDK paths the CUs were compiled against. In the presence
-  /// of different SDKs, we try to pick the most appropriate one
-  /// using \ref XcodeSDK::Merge.
-  ///
-  /// \param[in] module Module whose debug-info CUs to parse for
-  ///                   which SDK they were compiled against.
-  ///
-  /// \returns If successful, returns a pair of a parsed XcodeSDK
-  ///          object and a boolean that is 'true' if we encountered
-  ///          a conflicting combination of SDKs when parsing the CUs
-  ///          (e.g., a public and internal SDK).
-  static llvm::Expected<std::pair<XcodeSDK, bool>>
-  GetSDKPathFromDebugInfo(Module &module);
+  llvm::Expected<std::pair<XcodeSDK, bool>>
+  GetSDKPathFromDebugInfo(Module &module) override;
 
-  /// Returns the full path of the most appropriate SDK for the
-  /// specified 'module'. This function gets this path by parsing
-  /// debug-info (see \ref `GetSDKPathFromDebugInfo`).
-  ///
-  /// \param[in] module Module whose debug-info to parse for
-  ///                   which SDK it was compiled against.
-  ///
-  /// \returns If successful, returns the full path to an
-  ///          Xcode SDK.
-  static llvm::Expected<std::string>
-  ResolveSDKPathFromDebugInfo(Module &module);
+  llvm::Expected<std::string>
+  ResolveSDKPathFromDebugInfo(Module &module) override;
 
 protected:
   static const char *GetCompatibleArch(ArchSpec::Core core, size_t idx);

--- a/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
@@ -162,7 +162,9 @@ DWARF:
   ModuleSP module = t.GetModule();
   ASSERT_NE(module, nullptr);
 
-  auto path_or_err = PlatformDarwin::ResolveSDKPathFromDebugInfo(*module);
+  auto platform_sp = Platform::GetHostPlatform();
+  ASSERT_TRUE(platform_sp);
+  auto path_or_err = platform_sp->ResolveSDKPathFromDebugInfo(*module);
   EXPECT_FALSE(static_cast<bool>(path_or_err));
   llvm::consumeError(path_or_err.takeError());
 }
@@ -206,7 +208,9 @@ DWARF:
   ModuleSP module = t.GetModule();
   ASSERT_NE(module, nullptr);
 
-  auto path_or_err = PlatformDarwin::ResolveSDKPathFromDebugInfo(*module);
+  auto platform_sp = Platform::GetHostPlatform();
+  ASSERT_TRUE(platform_sp);
+  auto path_or_err = platform_sp->ResolveSDKPathFromDebugInfo(*module);
   EXPECT_FALSE(static_cast<bool>(path_or_err));
   llvm::consumeError(path_or_err.takeError());
 }
@@ -254,7 +258,9 @@ DWARF:
   ModuleSP module = t.GetModule();
   ASSERT_NE(module, nullptr);
 
-  auto sdk_or_err = PlatformDarwin::GetSDKPathFromDebugInfo(*module);
+  auto platform_sp = Platform::GetHostPlatform();
+  ASSERT_TRUE(platform_sp);
+  auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*module);
   ASSERT_TRUE(static_cast<bool>(sdk_or_err));
 
   auto [sdk, found_mismatch] = *sdk_or_err;


### PR DESCRIPTION
This is needed for relanding https://github.com/llvm/llvm-project/pull/102497, where we plan on calling these APIs from generic ExpressionParser code.