### PR TITLE
[flang][mlir] Add llvm.ident metadata when compiling with flang

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/Support/FIRContext.h
+++ b/flang/include/flang/Optimizer/Dialect/Support/FIRContext.h
@@ -71,6 +71,12 @@ void setTargetFeatures(mlir::ModuleOp mod, llvm::StringRef features);
 /// Get the target features from the Module.
 mlir::LLVM::TargetFeaturesAttr getTargetFeatures(mlir::ModuleOp mod);
 
+/// Set the compiler identifier for the module.
+void setIdent(mlir::ModuleOp mod, llvm::StringRef ident);
+
+/// Get the compiler identifier from the Module.
+llvm::StringRef getIdent(mlir::ModuleOp mod);
+
 /// Helper for determining the target from the host, etc. Tools may use this
 /// function to provide a consistent interpretation of the `--target=<string>`
 /// command-line option.

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/Bridge.h"
+#include "flang/Common/Version.h"
 #include "flang/Lower/Allocatable.h"
 #include "flang/Lower/CallInterface.h"
 #include "flang/Lower/Coarray.h"
@@ -6125,6 +6126,7 @@ Fortran::lower::LoweringBridge::LoweringBridge(
   fir::setTargetFeatures(*module.get(), targetMachine.getTargetFeatureString());
   fir::support::setMLIRDataLayout(*module.get(),
                                   targetMachine.createDataLayout());
+  fir::setIdent(*module.get(), Fortran::common::getFlangFullVersion());
 }
 
 void Fortran::lower::genCleanUpInRegionIfAny(

--- a/flang/lib/Optimizer/Dialect/Support/FIRContext.cpp
+++ b/flang/lib/Optimizer/Dialect/Support/FIRContext.cpp
@@ -118,7 +118,7 @@ void fir::setIdent(mlir::ModuleOp mod, llvm::StringRef ident) {
   if (ident.empty())
     return;
 
-  auto *ctx = mod.getContext();
+  mlir::MLIRContext *ctx = mod.getContext();
   mod->setAttr(mlir::LLVM::LLVMDialect::getIdentAttrName(),
                mlir::StringAttr::get(ctx, ident));
 }

--- a/flang/lib/Optimizer/Dialect/Support/FIRContext.cpp
+++ b/flang/lib/Optimizer/Dialect/Support/FIRContext.cpp
@@ -114,6 +114,22 @@ mlir::LLVM::TargetFeaturesAttr fir::getTargetFeatures(mlir::ModuleOp mod) {
   return {};
 }
 
+static constexpr const char *identName = "llvm.ident";
+
+void fir::setIdent(mlir::ModuleOp mod, llvm::StringRef ident) {
+  if (ident.empty())
+    return;
+
+  auto *ctx = mod.getContext();
+  mod->setAttr(identName, mlir::StringAttr::get(ctx, ident));
+}
+
+llvm::StringRef fir::getIdent(mlir::ModuleOp mod) {
+  if (auto attr = mod->getAttrOfType<mlir::StringAttr>(identName))
+    return attr;
+  return {};
+}
+
 std::string fir::determineTargetTriple(llvm::StringRef triple) {
   // Treat "" or "default" as stand-ins for the default machine.
   if (triple.empty() || triple == "default")

--- a/flang/lib/Optimizer/Dialect/Support/FIRContext.cpp
+++ b/flang/lib/Optimizer/Dialect/Support/FIRContext.cpp
@@ -114,18 +114,18 @@ mlir::LLVM::TargetFeaturesAttr fir::getTargetFeatures(mlir::ModuleOp mod) {
   return {};
 }
 
-static constexpr const char *identName = "llvm.ident";
-
 void fir::setIdent(mlir::ModuleOp mod, llvm::StringRef ident) {
   if (ident.empty())
     return;
 
   auto *ctx = mod.getContext();
-  mod->setAttr(identName, mlir::StringAttr::get(ctx, ident));
+  mod->setAttr(mlir::LLVM::LLVMDialect::getIdentAttrName(),
+               mlir::StringAttr::get(ctx, ident));
 }
 
 llvm::StringRef fir::getIdent(mlir::ModuleOp mod) {
-  if (auto attr = mod->getAttrOfType<mlir::StringAttr>(identName))
+  if (auto attr = mod->getAttrOfType<mlir::StringAttr>(
+          mlir::LLVM::LLVMDialect::getIdentAttrName()))
     return attr;
   return {};
 }

--- a/flang/test/Lower/ident.f90
+++ b/flang/test/Lower/ident.f90
@@ -1,0 +1,5 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s
+
+! CHECK: module attributes {
+! CHECK-SAME: llvm.ident = "flang version {{.+}}"

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
@@ -27,6 +27,7 @@ def LLVM_Dialect : Dialect {
     static StringRef getNoAliasScopesAttrName() { return "noalias_scopes"; }
     static StringRef getAliasScopesAttrName() { return "alias_scopes"; }
     static StringRef getAccessGroupsAttrName() { return "access_groups"; }
+    static StringRef getIdentAttrName() { return "llvm.ident"; }
 
     /// Names of llvm parameter attributes.
     static StringRef getAlignAttrName() { return "llvm.align"; }

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -196,6 +196,9 @@ public:
   /// LLVM dialect operation.
   LogicalResult convertLinkerOptionsMetadata();
 
+  /// Converts !llvm.ident metadata to the llvm.ident LLVM ModuleOp attribute.
+  LogicalResult convertIdentMetadata();
+
   /// Converts all LLVM metadata nodes that translate to attributes such as
   /// alias analysis or access group metadata, and builds a map from the
   /// metadata nodes to the converted attributes.

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -329,6 +329,9 @@ private:
   /// metadata nodes for them.
   LogicalResult createTBAAMetadata();
 
+  /// Process the ident LLVM Metadata, if it exists.
+  LogicalResult createIdentMetadata();
+
   /// Translates dialect attributes attached to the given operation.
   LogicalResult
   convertDialectAttributes(Operation *op,

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -518,6 +518,20 @@ LogicalResult ModuleImport::convertLinkerOptionsMetadata() {
   return success();
 }
 
+LogicalResult ModuleImport::convertIdentMetadata() {
+  for (const llvm::NamedMDNode &named : llvmModule->named_metadata()) {
+    // llvm.ident should have a single operand. That operand is itself an
+    // MDNode with a single string operand.
+    if (named.getName() == "llvm.ident")
+      if (named.getNumOperands() == 1)
+        if (auto *md = dyn_cast<llvm::MDNode>(named.getOperand(0)))
+          if (auto *mdStr = dyn_cast<llvm::MDString>(md->getOperand(0)))
+            mlirModule->setAttr("llvm.ident",
+                                builder.getStringAttr(mdStr->getString()));
+  }
+  return success();
+}
+
 LogicalResult ModuleImport::convertMetadata() {
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToEnd(mlirModule.getBody());
@@ -545,6 +559,8 @@ LogicalResult ModuleImport::convertMetadata() {
     }
   }
   if (failed(convertLinkerOptionsMetadata()))
+    return failure();
+  if (failed(convertIdentMetadata()))
     return failure();
   return success();
 }

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -522,11 +522,14 @@ LogicalResult ModuleImport::convertIdentMetadata() {
   for (const llvm::NamedMDNode &named : llvmModule->named_metadata()) {
     // llvm.ident should have a single operand. That operand is itself an
     // MDNode with a single string operand.
-    if (named.getName() == "llvm.ident")
-      if (named.getNumOperands() == 1)
-        if (auto *md = dyn_cast<llvm::MDNode>(named.getOperand(0)))
+    if (named.getName() != LLVMDialect::getIdentAttrName())
+      continue;
+
+    if (named.getNumOperands() == 1)
+      if (auto *md = dyn_cast<llvm::MDNode>(named.getOperand(0)))
+        if (md->getNumOperands() == 1)
           if (auto *mdStr = dyn_cast<llvm::MDString>(md->getOperand(0)))
-            mlirModule->setAttr("llvm.ident",
+            mlirModule->setAttr(LLVMDialect::getIdentAttrName(),
                                 builder.getStringAttr(mdStr->getString()));
   }
   return success();

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1815,11 +1815,12 @@ LogicalResult ModuleTranslation::createTBAAMetadata() {
 }
 
 LogicalResult ModuleTranslation::createIdentMetadata() {
-  if (auto attr = mlirModule->getAttrOfType<mlir::StringAttr>("llvm.ident")) {
-    llvm::StringRef ident = attr;
+  if (auto attr = mlirModule->getAttrOfType<StringAttr>(
+          LLVMDialect::getIdentAttrName())) {
+    StringRef ident = attr;
     llvm::LLVMContext &ctx = llvmModule->getContext();
     llvm::NamedMDNode *namedMd =
-        llvmModule->getOrInsertNamedMetadata("llvm.ident");
+        llvmModule->getOrInsertNamedMetadata(LLVMDialect::getIdentAttrName());
     llvm::MDNode *md = llvm::MDNode::get(ctx, llvm::MDString::get(ctx, ident));
     namedMd->addOperand(md);
   }

--- a/mlir/test/Target/LLVMIR/Import/ident.ll
+++ b/mlir/test/Target/LLVMIR/Import/ident.ll
@@ -1,0 +1,6 @@
+; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
+
+; CHECK: module attributes {
+; CHECK-SAME: "flang version 61.7.4"
+!llvm.ident = !{!0}
+!0 = !{!"flang version 61.7.4"}

--- a/mlir/test/Target/LLVMIR/Import/ident.ll
+++ b/mlir/test/Target/LLVMIR/Import/ident.ll
@@ -1,6 +1,6 @@
 ; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
 
 ; CHECK: module attributes {
-; CHECK-SAME: "flang version 61.7.4"
+; CHECK-SAME: llvm.ident = "flang version 61.7.4"
 !llvm.ident = !{!0}
 !0 = !{!"flang version 61.7.4"}

--- a/mlir/test/Target/LLVMIR/ident.mlir
+++ b/mlir/test/Target/LLVMIR/ident.mlir
@@ -1,0 +1,6 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// CHECK: !llvm.ident = !{![[ID:[0-9]+]]}
+// CHECK: ![[ID]] = !{!"flang version 61.7.4"}
+module attributes {llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.ident = "flang version 61.7.4", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+}

--- a/mlir/test/Target/LLVMIR/ident.mlir
+++ b/mlir/test/Target/LLVMIR/ident.mlir
@@ -2,5 +2,5 @@
 
 // CHECK: !llvm.ident = !{![[ID:[0-9]+]]}
 // CHECK: ![[ID]] = !{!"flang version 61.7.4"}
-module attributes {llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.ident = "flang version 61.7.4", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+module attributes {llvm.ident = "flang version 61.7.4"} {
 }


### PR DESCRIPTION
This brings the behavior of flang in line with clang which also adds this metadata unconditionally.

Some time ago, there was a question on flang's slack channel asking if there was a way to determine if some binary was compiled with flang. With this patch, the compiler version string will be present in an object file and can be retrieved using, for instance, the `string` command on *nix. 