### PR TITLE
[clang] Add frontend flag to enable support for broken external resugarers

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -162,6 +162,7 @@ LANGOPT(CoroAlignedAllocation, 1, 0, "prefer Aligned Allocation according to P20
 LANGOPT(DllExportInlines  , 1, 1, "dllexported classes dllexport inline methods")
 LANGOPT(RelaxedTemplateTemplateArgs, 1, 1, "C++17 relaxed matching of template template arguments")
 LANGOPT(ExperimentalLibrary, 1, 0, "enable unstable and experimental library features")
+LANGOPT(SupportBrokenExternalResugarers, 1, 0, "Suppress transforms which would impede broken external resugarers")
 
 LANGOPT(PointerAuthIntrinsics, 1, 0, "pointer authentication intrinsics")
 LANGOPT(PointerAuthCalls  , 1, 0, "function pointer authentication")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3449,6 +3449,11 @@ defm relaxed_template_template_args : BoolFOption<"relaxed-template-template-arg
   PosFlag<SetTrue, [], [], "Enable">,
   NegFlag<SetFalse, [], [CC1Option], "Disable">,
   BothFlags<[], [ClangOption], " C++17 relaxed template template argument matching">>;
+defm support_broken_external_resugarers : BoolFOption<"support-broken-external-resugarers",
+  LangOpts<"SupportBrokenExternalResugarers">, DefaultFalse,
+  PosFlag<SetTrue, [], [CC1Option], "Enable">,
+  NegFlag<SetFalse, [], [], "Disable">,
+  BothFlags<[], [], " support for broken external resugarers">>;
 defm sized_deallocation : BoolFOption<"sized-deallocation",
   LangOpts<"SizedDeallocation">, Default<cpp14.KeyPath>,
   PosFlag<SetTrue, [], [], "Enable C++14 sized global deallocation functions">,

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -3333,9 +3333,16 @@ QualType Sema::CheckTemplateIdType(TemplateName Name,
       return QualType();
 
     // Only substitute for the innermost template argument list.
+    // NOTE: Some external resugarers rely on leaving a Subst* node here.
+    // Make the substituion non-final in that case.
+    // Note that these external resugarers are essentially broken
+    // for depending on this, because we don't provide
+    // enough context in the Subst* nodes in order
+    // to tell different template type alias specializations apart.
     MultiLevelTemplateArgumentList TemplateArgLists;
-    TemplateArgLists.addOuterTemplateArguments(Template, SugaredConverted,
-                                               /*Final=*/true);
+    TemplateArgLists.addOuterTemplateArguments(
+        Template, SugaredConverted,
+        /*Final=*/!getLangOpts().SupportBrokenExternalResugarers);
     TemplateArgLists.addOuterRetainedLevels(
         AliasTemplate->getTemplateParameters()->getDepth());
 

--- a/clang/test/AST/ast-dump-support-broken-external-resugarers.cpp
+++ b/clang/test/AST/ast-dump-support-broken-external-resugarers.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fsyntax-only -fsupport-broken-external-resugarers -ast-dump -ast-dump-filter=dump %s | FileCheck -strict-whitespace %s
+
+namespace t1 {
+template<class T> using X = T;
+using dump = X<int>;
+
+// CHECK-LABEL: Dumping t1::dump:
+// CHECK-NEXT:  TypeAliasDecl
+// CHECK-NEXT:  `-ElaboratedType
+// CHECK-NEXT:    `-TemplateSpecializationType
+// CHECK-NEXT:      |-name: 'X':'t1::X' qualified
+// CHECK-NEXT:      | `-TypeAliasTemplateDecl
+// CHECK-NEXT:      |-TemplateArgument
+// CHECK-NEXT:      | `-BuiltinType {{.+}} 'int'
+// CHECK-NEXT:      `-SubstTemplateTypeParmType 0x{{[0-9]+}} 'int' sugar class depth 0 index 0 T
+// CHECK-NEXT:        |-TypeAliasTemplate {{.+}} 'X'
+// CHECK-NEXT:        `-BuiltinType {{.+}} 'int'
+} // namespace t1


### PR DESCRIPTION
There are some external projects that can't rely on our own sugar propagation for templated entities, because they need to resugar types which only exist within their framework, and so are entirely invisible to our internal tooling.

This new flag is meant to prevent our transforms from removing any Subst* nodes.

For this patch, it's wired only to template type alias substitutions.

Note that our AST does *not* represent enough information to correctly resugar template type alias, so any users of this are either defective or working under limited scenarios.

See discussion at https://github.com/llvm/llvm-project/pull/101858 for motivation.