### PR TITLE
[RISCV][GISel] Remove support for s32 G_VAARG on RV64.

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
@@ -495,9 +495,9 @@ RISCVLegalizerInfo::RISCVLegalizerInfo(const RISCVSubtarget &ST)
   // as the destination.
   getActionDefinitionsBuilder(G_VAARG)
       // TODO: Implement narrowScalar and widenScalar for G_VAARG for types
-      // outside the [s32, sXLen] range.
-      .clampScalar(0, s32, sXLen)
-      .lowerForCartesianProduct({s32, sXLen, p0}, {p0});
+      // other than sXLen.
+      .clampScalar(0, sXLen, sXLen)
+      .lowerForCartesianProduct({sXLen, p0}, {p0});
 
   getActionDefinitionsBuilder(G_VSCALE)
       .clampScalar(0, sXLen, sXLen)

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-vaarg-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-vaarg-rv64.mir
@@ -5,35 +5,6 @@
 # greater than 1, so we will always generate code to adjust for this alignment.
 
 ---
-name:            va_arg_i32
-legalized:       false
-tracksRegLiveness: true
-fixedStack:
-  - { id: 0, type: default, offset: 0, size: 8, alignment: 16,
-      isImmutable: true, isAliased: false }
-stack:
-  - { id: 0, type: default, offset: 0, size: 8, alignment: 8 }
-machineFunctionInfo:
-  varArgsFrameIndex: -1
-  varArgsSaveSize: 0
-body:             |
-  bb.1:
-    ; CHECK-LABEL: name: va_arg_i32
-    ; CHECK: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0
-    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(p0) = G_LOAD [[FRAME_INDEX]](p0) :: (load (p0))
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 3
-    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[LOAD]], [[C]](s64)
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 -4
-    ; CHECK-NEXT: [[PTRMASK:%[0-9]+]]:_(p0) = G_PTRMASK [[PTR_ADD]], [[C1]](s64)
-    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = G_PTR_ADD [[PTRMASK]], [[C2]](s64)
-    ; CHECK-NEXT: G_STORE [[PTR_ADD1]](p0), [[FRAME_INDEX]](p0) :: (store (p0))
-    ; CHECK-NEXT: PseudoRET
-    %0:_(p0) = G_FRAME_INDEX %stack.0
-    %1:_(s32) = G_VAARG %0(p0), 4
-    PseudoRET
-...
----
 name:            va_arg_i64
 legalized:       false
 tracksRegLiveness: true


### PR DESCRIPTION
Part of making s32 not legal for RV64. Unfortunately, generic widening/narrowing is not implement for this operation so I had to remove all tests.

I don't think clang use G_VAARG on RISC-V so this shouldn't be a big deal in practice.