### PR TITLE
[Clang][Sema] Fix mismatch of out-of-line definition of template class

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -212,6 +212,7 @@ Bug Fixes to C++ Support
 - Clang now preserves the unexpanded flag in a lambda transform used for pack expansion. (#GH56852), (#GH85667),
   (#GH99877).
 - Fixed a bug when diagnosing ambiguous explicit specializations of constrained member functions.
+- Fix a bug in out-of-line definition of constrained class template nested in a class template. (GH102320).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -951,7 +951,8 @@ static const Expr *SubstituteConstraintExpressionWithoutSatisfaction(
       DeclInfo.getDecl(), DeclInfo.getLexicalDeclContext(), /*Final=*/false,
       /*Innermost=*/std::nullopt,
       /*RelativeToPrimary=*/true,
-      /*Pattern=*/nullptr, /*ForConstraintInstantiation=*/true,
+      /*Pattern=*/nullptr,
+      !isa_and_present<ClassTemplateDecl>(DeclInfo.getDecl()),
       /*SkipForSpecialization*/ false);
 
   if (MLTAL.getNumSubstitutedLevels() == 0)

--- a/clang/test/SemaCXX/PR102320.cpp
+++ b/clang/test/SemaCXX/PR102320.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
+// expected-no-diagnostics
+
+template<typename>
+concept Constrained = true;
+
+template <typename T>
+class C
+{
+    template<Constrained>
+    class D;
+};
+
+template <typename T>
+template <Constrained>
+class C<T>::D
+{
+};


### PR DESCRIPTION
Skip adding template instantiation arguments when the declaration is a nested class template when instantiating constraint expression.
attempt to fix https://github.com/llvm/llvm-project/issues/102320