### PR TITLE
[clang][analyzer] Remove array bounds check from PointerSubChecker

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -2501,7 +2501,14 @@ alpha.core.PointerSub (C)
 Check for pointer subtractions on two pointers pointing to different memory
 chunks. According to the C standard §6.5.6 only subtraction of pointers that
 point into (or one past the end) the same array object is valid (for this
-purpose non-array variables are like arrays of size 1).
+purpose non-array variables are like arrays of size 1). This checker only
+searches for different memory objects at subtraction, but does not check if the
+array index is correct (
+:ref:`alpha.security.ArrayBoundsV2 <alpha-security-ArrayBoundsV2>` checks the
+index to some extent).
+
+Furthermore, only cases are reported where stack-allocated objects are involved
+(no warnings on pointers to memory allocated by `malloc`).
 
 .. code-block:: c
 
@@ -2511,11 +2518,6 @@ purpose non-array variables are like arrays of size 1).
    x = &d[4] - &c[1]; // warn: 'c' and 'd' are different arrays
    x = (&a + 1) - &a;
    x = &b - &a; // warn: 'a' and 'b' are different variables
-   x = (&a + 2) - &a; // warn: for a variable it is only valid to have a pointer
-                      // to one past the address of it
-   x = &c[10] - &c[0];
-   x = &c[11] - &c[0]; // warn: index larger than one past the end
-   x = &c[-1] - &c[0]; // warn: negative index
  }
 
  struct S {
@@ -2537,9 +2539,6 @@ There may be existing applications that use code like above for calculating
 offsets of members in a structure, using pointer subtractions. This is still
 undefined behavior according to the standard and code like this can be replaced
 with the `offsetof` macro.
-
-The checker only reports cases where stack-allocated objects are involved (no
-warnings on pointers to memory allocated by `malloc`).
 
 .. _alpha-core-StackAddressAsyncEscape:
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -2503,12 +2503,9 @@ chunks. According to the C standard §6.5.6 only subtraction of pointers that
 point into (or one past the end) the same array object is valid (for this
 purpose non-array variables are like arrays of size 1). This checker only
 searches for different memory objects at subtraction, but does not check if the
-array index is correct (
-:ref:`alpha.security.ArrayBoundsV2 <alpha-security-ArrayBoundsV2>` checks the
-index to some extent).
-
-Furthermore, only cases are reported where stack-allocated objects are involved
-(no warnings on pointers to memory allocated by `malloc`).
+array index is correct. Furthermore, only cases are reported where
+stack-allocated objects are involved (no warnings on pointers to memory
+allocated by `malloc`).
 
 .. code-block:: c
 

--- a/clang/test/Analysis/pointer-sub-notes.c
+++ b/clang/test/Analysis/pointer-sub-notes.c
@@ -1,22 +1,5 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.core.PointerSub -analyzer-output=text -verify %s
 
-void negative_1() {
-  int a[3];
-  int x = -1;
-  // FIXME: should indicate that 'x' is -1
-  int d = &a[x] - &a[0]; // expected-warning{{Using a negative array index at pointer subtraction is undefined behavior}} \
-                         // expected-note{{Using a negative array index at pointer subtraction is undefined behavior}}
-}
-
-void negative_2() {
-  int a[3];
-  int *p1 = a, *p2 = a;
-  --p2;
-  // FIXME: should indicate that 'p2' is negative
-  int d = p1 - p2; // expected-warning{{Using a negative array index at pointer subtraction is undefined behavior}} \
-                   // expected-note{{Using a negative array index at pointer subtraction is undefined behavior}}
-}
-
 void different_1() {
   int a[3]; // expected-note{{Array at the left-hand side of subtraction}}
   int b[3]; // expected-note{{Array at the right-hand side of subtraction}}

--- a/clang/test/Analysis/pointer-sub.c
+++ b/clang/test/Analysis/pointer-sub.c
@@ -9,9 +9,7 @@ void f1(void) {
   d = (&x + 1) - &x; // no-warning ('&x' is like a single-element array)
   d = &x - (&x + 1); // no-warning
   d = (&x + 0) - &x; // no-warning
-
-  d = (z + 9) - z; // no-warning (pointers to same array)
-  d = (z + 10) - z; // no-warning (pointer to "one after the end")
+  d = (z + 10) - z; // no-warning
 }
 
 void f2(void) {

--- a/clang/test/Analysis/pointer-sub.c
+++ b/clang/test/Analysis/pointer-sub.c
@@ -9,13 +9,9 @@ void f1(void) {
   d = (&x + 1) - &x; // no-warning ('&x' is like a single-element array)
   d = &x - (&x + 1); // no-warning
   d = (&x + 0) - &x; // no-warning
-  d = (&x - 1) - &x; // expected-warning{{Indexing the address of a variable with other than 1 at this place is undefined behavior}}
-  d = (&x + 2) - &x; // expected-warning{{Indexing the address of a variable with other than 1 at this place is undefined behavior}}
 
   d = (z + 9) - z; // no-warning (pointers to same array)
   d = (z + 10) - z; // no-warning (pointer to "one after the end")
-  d = (z + 11) - z; // expected-warning{{Using an array index greater than the array size at pointer subtraction is undefined behavior}}
-  d = (z - 1) - z; // expected-warning{{Using a negative array index at pointer subtraction is undefined behavior}}
 }
 
 void f2(void) {
@@ -27,11 +23,6 @@ void f2(void) {
 
   q = &b[3];
   d = q - p; // expected-warning{{Subtraction of two pointers that}}
-
-  q = a + 10;
-  d = q - p; // no warning (use of pointer to one after the end is allowed)
-  q = a + 11;
-  d = q - a; // expected-warning{{Using an array index greater than the array size at pointer subtraction is undefined behavior}}
 
   d = &a[4] - a; // no-warning
   d = &a[2] - p; // no-warning


### PR DESCRIPTION
At pointer subtraction only pointers are allowed that point into an array (or one after the end), this fact was checker by the checker. This check is now removed because it is a special case of array indexing error that is handled by a different checker (ArrayBoundsV2). At least theoretically the array bounds checker (when finalized) should find the same cases that were detected by the PointerSubChecker.