### PR TITLE
[lldb] Remove Phabricator usernames from Code Owners file

### DIFF
--- a/lldb/CodeOwners.rst
+++ b/lldb/CodeOwners.rst
@@ -17,7 +17,7 @@ assistance.
 All parts of LLDB not covered by someone else
 ----------------------------------------------
 | Jonas Devlieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 Components
 ----------
@@ -27,100 +27,100 @@ LLDB.
 ABI
 ~~~
 | Jason Molenda
-| jmolenda\@apple.com (email), jasonmolenda (Phabricator), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
+| jmolenda\@apple.com (email), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
 
 | David Spickett
-| david.spickett\@linaro.org (email), DavidSpickett (Phabricator), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
+| david.spickett\@linaro.org (email), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
 
 
 Breakpoint
 ~~~~~~~~~~
 | Jim Ingham
-| jingham\@apple.com (email), jingham (Phabricator), jimingham (GitHub), jingham (Discourse)
+| jingham\@apple.com (email), jimingham (GitHub), jingham (Discourse)
 
 CMake & Build System
 ~~~~~~~~~~~~~~~~~~~~
 | Jonas Devlieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 | Alex Langford
-| alangford\@apple.com (email), bulbazord (Phabricator), bulbazord (GitHub), bulbazord (Discourse), bulba_zord (Discord)
+| alangford\@apple.com (email), bulbazord (GitHub), bulbazord (Discourse), bulba_zord (Discord)
 
 Commands
 ~~~~~~~~
 | Jim Ingham
-| jingham\@apple.com (email), jingham (Phabricator), jimingham (GitHub), jingham (Discourse)
+| jingham\@apple.com (email), jimingham (GitHub), jingham (Discourse)
 
 Expression Parser
 ~~~~~~~~~~~~~~~~~
 | Michael Buch
-| michaelbuch12\@gmail.com (email), Michael137 (Phabricator), Michael137 (GitHub), Michael137 (Discourse)
+| michaelbuch12\@gmail.com (email), Michael137 (GitHub), Michael137 (Discourse)
 
 | Jim Ingham
-| jingham\@apple.com (email), jingham (Phabricator), jimingham (GitHub), jingham (Discourse)
+| jingham\@apple.com (email), jimingham (GitHub), jingham (Discourse)
 
 Interpreter
 ~~~~~~~~~~~
 | Jim Ingham
-| jingham\@apple.com (email), jingham (Phabricator), jimingham (GitHub), jingham (Discourse)
+| jingham\@apple.com (email), jimingham (GitHub), jingham (Discourse)
 
 | Greg Clayton
-| gclayton\@fb.com (email), clayborg (Phabricator), clayborg (GitHub), clayborg (Discourse)
+| gclayton\@fb.com (email), clayborg (GitHub), clayborg (Discourse)
 
 
 Lua
 ~~~
 | Jonas Delvieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 Python
 ~~~~~~
 | Med Ismail Bennani
-| ismail\@bennani.ma (email), mib (Phabricator), medismailben (GitHub), mib (Discourse), mib#8727 (Discord)
+| ismail\@bennani.ma (email), medismailben (GitHub), mib (Discourse), mib#8727 (Discord)
 
 Target/Process Control
 ~~~~~~~~~~~~~~~~~~~~~~
 | Med Ismail Bennani
-| ismail\@bennani.ma (email), mib (Phabricator), medismailben (GitHub), mib (Discourse), mib#8727 (Discord)
+| ismail\@bennani.ma (email), medismailben (GitHub), mib (Discourse), mib#8727 (Discord)
 
 | Jim Ingham
-| jingham\@apple.com (email), jingham (Phabricator), jimingham (GitHub), jingham (Discourse)
+| jingham\@apple.com (email), jimingham (GitHub), jingham (Discourse)
 
 Test Suite
 ~~~~~~~~~~
 | Jonas Devlieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 | Pavel Labath
-| pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
+| pavel\@labath.sk (email), labath (GitHub), labath (Discourse)
 
 Trace
 ~~~~~
 | Walter Erquinigo
-| a20012251\@gmail.com (email), wallace (Phabricator), walter-erquinigo (GitHub), wallace (Discourse), werquinigo (Discord)
+| a20012251\@gmail.com (email), walter-erquinigo (GitHub), wallace (Discourse), werquinigo (Discord)
 
 Unwinding
 ~~~~~~~~~
 | Jason Molenda
-| jmolenda\@apple.com (email), jasonmolenda (Phabricator), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
+| jmolenda\@apple.com (email), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
 
 Utility
 ~~~~~~~
 | Jonas Devlieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 | Pavel Labath
-| pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
+| pavel\@labath.sk (email), labath (GitHub), labath (Discourse)
 
 ValueObject
 ~~~~~~~~~~~
 | Jim Ingham
-| jingham\@apple.com (email), jingham (Phabricator), jimingham (GitHub), jingham (Discourse)
+| jingham\@apple.com (email), jimingham (GitHub), jingham (Discourse)
 
 Watchpoints
 ~~~~~~~~~~~
 | Jason Molenda
-| jmolenda\@apple.com (email), jasonmolenda (Phabricator), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
+| jmolenda\@apple.com (email), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
 
 File Formats
 ------------
@@ -130,54 +130,54 @@ info formats.
 (PE)COFF
 ~~~~~~~~
 | Saleem Abdulrasool
-| compnerd\@compnerd.org (email), compnerd (Phabricator), compnerd (GitHub), compnerd (Discourse), compnerd (Discord)
+| compnerd\@compnerd.org (email), compnerd (GitHub), compnerd (Discourse), compnerd (Discord)
 
 Breakpad
 ~~~~~~~~
 | Zequan Wu
-| zequanwu\@google.com (email), zequanwu (Phabricator), ZequanWu (GitHub), ZequanWu (Discourse)
+| zequanwu\@google.com (email), ZequanWu (GitHub), ZequanWu (Discourse)
 
 | Pavel Labath
-| pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
+| pavel\@labath.sk (email), labath (GitHub), labath (Discourse)
 
 CTF
 ~~~
 | Jonas Devlieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 DWARF
 ~~~~~
 | Adrian Prantl
-| aprantl\@apple.com (email), aprantl (Phabricator), adrian-prantl (GitHub), adrian.prantl (Discourse), adrian.prantl (Discord), Adrian Prantl#4366 (Discourse)
+| aprantl\@apple.com (email), adrian-prantl (GitHub), adrian.prantl (Discourse), adrian.prantl (Discord), Adrian Prantl#4366 (Discourse)
 
 | Greg Clayton
-| gclayton\@fb.com (email), clayborg (Phabricator), clayborg (GitHub), clayborg (Discourse)
+| gclayton\@fb.com (email), clayborg (GitHub), clayborg (Discourse)
 
 ELF
 ~~~
 | David Spickett
-| david.spickett\@linaro.org (email), DavidSpickett (Phabricator), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
+| david.spickett\@linaro.org (email), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
 
 | Pavel Labath
-| pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
+| pavel\@labath.sk (email), labath (GitHub), labath (Discourse)
 
 JSON
 ~~~~
 | Jonas Devlieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 MachO
 ~~~~~
 | Greg Clayton
-| gclayton\@fb.com (email), clayborg (Phabricator), clayborg (GitHub), clayborg (Discourse)
+| gclayton\@fb.com (email), clayborg (GitHub), clayborg (Discourse)
 
 | Jason Molenda
-| jmolenda\@apple.com (email), jasonmolenda (Phabricator), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
+| jmolenda\@apple.com (email), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
 
 PDB
 ~~~
 | Zequan Wu
-| zequanwu\@google.com (email), zequanwu (Phabricator), ZequanWu (GitHub), ZequanWu (Discourse)
+| zequanwu\@google.com (email), ZequanWu (GitHub), ZequanWu (Discourse)
 
 Platforms
 ---------
@@ -186,36 +186,36 @@ The following people are responsible for decisions involving platforms.
 Android
 ~~~~~~~
 | Pavel Labath
-| pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
+| pavel\@labath.sk (email), labath (GitHub), labath (Discourse)
 
 Darwin
 ~~~~~~
 | Jim Ingham
-| jingham\@apple.com (email), jingham (Phabricator), jimingham (GitHub), jingham (Discourse)
+| jingham\@apple.com (email), jimingham (GitHub), jingham (Discourse)
 
 | Jason Molenda
-| jmolenda\@apple.com (email), jasonmolenda (Phabricator), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
+| jmolenda\@apple.com (email), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
 
 | Jonas Devlieghere
-| jonas\@devlieghere.com (email), jdevlieghere (Phabricator), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
+| jonas\@devlieghere.com (email), jdevlieghere (GitHub), jdevlieghere (Discourse), jdevlieghere (Discord)
 
 FreeBSD
 ~~~~~~~
 | Ed Maste
-| emaste\@freebsd.org (email), emaste (Phabricator), emaste (GitHub), emaste (Discourse), emaste (Discord)
+| emaste\@freebsd.org (email), emaste (GitHub), emaste (Discourse), emaste (Discord)
 
 Linux
 ~~~~~
 | Pavel Labath
-| pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
+| pavel\@labath.sk (email), labath (GitHub), labath (Discourse)
 
 | David Spickett
-| david.spickett\@linaro.org (email), DavidSpickett (Phabricator), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
+| david.spickett\@linaro.org (email), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
 
 Windows
 ~~~~~~~
 | Omair Javaid
-| omair.javaid\@linaro.org (email), omjavaid (Phabricator), omjavaid (GitHub), omjavaid (Discourse), omjavaid#9902 (Discord)
+| omair.javaid\@linaro.org (email), omjavaid (GitHub), omjavaid (Discourse), omjavaid#9902 (Discord)
 
 Tools
 -----
@@ -224,23 +224,23 @@ The following people are responsible for decisions involving specific tools.
 debugserver
 ~~~~~~~~~~~
 | Jason Molenda
-| jmolenda\@apple.com (email), jasonmolenda (Phabricator), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
+| jmolenda\@apple.com (email), jasonmolenda (GitHub), jasonmolenda (Discourse), jasonmolenda (Discord)
 
 lldb-server
 ~~~~~~~~~~~
 | David Spickett
-| david.spickett\@linaro.org (email), DavidSpickett (Phabricator), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
+| david.spickett\@linaro.org (email), DavidSpickett (GitHub), DavidSpickett (Discourse), davidspickett (Discord)
 
 | Pavel Labath
-| pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
+| pavel\@labath.sk (email), labath (GitHub), labath (Discourse)
 
 lldb-dap
 ~~~~~~~~
 | Greg Clayton
-| gclayton\@fb.com (email), clayborg (Phabricator), clayborg (GitHub), clayborg (Discourse)
+| gclayton\@fb.com (email), clayborg (GitHub), clayborg (Discourse)
 
 | Walter Erquinigo
-| a20012251\@gmail.com (email), wallace (Phabricator), walter-erquinigo (GitHub), wallace (Discourse), werquinigo (Discord)
+| a20012251\@gmail.com (email), walter-erquinigo (GitHub), wallace (Discourse), werquinigo (Discord)
 
 Former Code Owners
 ==================


### PR DESCRIPTION
Removing them simplifies the content and means we don't confuse anyone who joined after the Phabricator shutdown.

You could use them for review archaeology but this is only a subset of the names you'd encounter there anyway. So I don't think this is a good reason to keep them here. With a couple of exceptions the Phabricator/GitHub names are the same and/or related to their full name anyway.