### PR TITLE
[llvm][llvm-readobj] Add NT_ARM_FPMR corefile note type

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1713,6 +1713,7 @@ enum : unsigned {
   NT_ARM_SSVE = 0x40b,
   NT_ARM_ZA = 0x40c,
   NT_ARM_ZT = 0x40d,
+  NT_ARM_FPMR = 0x40e,
 
   NT_FILE = 0x46494c45,
   NT_PRXFPREG = 0x46e62b7f,

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -135,6 +135,7 @@ void ScalarEnumerationTraits<ELFYAML::ELF_NT>::enumeration(
   ECase(NT_ARM_SSVE);
   ECase(NT_ARM_ZA);
   ECase(NT_ARM_ZT);
+  ECase(NT_ARM_FPMR);
   ECase(NT_FILE);
   ECase(NT_PRXFPREG);
   ECase(NT_SIGINFO);

--- a/llvm/test/tools/llvm-readobj/ELF/note-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core.test
@@ -260,6 +260,11 @@
 # RUN: llvm-readelf --notes %t_nt_arm_zt.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_ZT (AArch64 SME ZT registers)"
 # RUN: llvm-readobj --notes %t_nt_arm_zt.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_ZT (AArch64 SME ZT registers)"
 
+## Check ELF::NT_ARM_FPMR
+# RUN: yaml2obj %s -DTYPE=0x40e -o %t_nt_arm_fpmr.o
+# RUN: llvm-readelf --notes %t_nt_arm_fpmr.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_FPMR (AArch64 Floating Point Mode Register)"
+# RUN: llvm-readobj --notes %t_nt_arm_fpmr.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_FPMR (AArch64 Floating Point Mode Register)"
+
 ## Check ELF::NT_FILE.
 # RUN: yaml2obj %s -DTYPE=0x46494c45 -o %t_nt_file.o
 # RUN: llvm-readelf --notes %t_nt_file.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_FILE (mapped files)"

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -6035,6 +6035,7 @@ const NoteType CoreNoteTypes[] = {
     {ELF::NT_ARM_SSVE, "NT_ARM_SSVE (AArch64 Streaming SVE registers)"},
     {ELF::NT_ARM_ZA, "NT_ARM_ZA (AArch64 SME ZA registers)"},
     {ELF::NT_ARM_ZT, "NT_ARM_ZT (AArch64 SME ZT registers)"},
+    {ELF::NT_ARM_FPMR, "NT_ARM_FPMR (AArch64 Floating Point Mode Register)"},
 
     {ELF::NT_FILE, "NT_FILE (mapped files)"},
     {ELF::NT_PRXFPREG, "NT_PRXFPREG (user_xfpregs structure)"},


### PR DESCRIPTION
This contains the fpmr register which was added in Armv9.5-a. This register mainly contains controls for fp8 formats.

It was added to the Linux Kernel in
https://github.com/torvalds/linux/commit/4035c22ef7d43a6c00d6a6584c60e902b95b46af.