### PR TITLE
[AMDGPU][AsmParser] Eliminate validateExeczVcczOperands().

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1777,7 +1777,6 @@ private:
                              const SMLoc &IDLoc);
   bool validateTHAndScopeBits(const MCInst &Inst, const OperandVector &Operands,
                               const unsigned CPol);
-  bool validateExeczVcczOperands(const OperandVector &Operands);
   bool validateTFE(const MCInst &Inst, const OperandVector &Operands);
   std::optional<StringRef> validateLdsDirect(const MCInst &Inst);
   unsigned getConstantBusLimit(unsigned Opcode) const;
@@ -3039,7 +3038,8 @@ bool AMDGPUAsmParser::ParseAMDGPURegister(RegisterKind &RegKind, unsigned &Reg,
     if (Reg == AMDGPU::SGPR_NULL) {
       Error(Loc, "'null' operand is not supported on this GPU");
     } else {
-      Error(Loc, "register not available on this GPU");
+      Error(Loc, Twine(AMDGPUInstPrinter::getRegisterName(Reg)) +
+                     " register not available on this GPU");
     }
     return false;
   }
@@ -5052,22 +5052,6 @@ bool AMDGPUAsmParser::validateTHAndScopeBits(const MCInst &Inst,
   return true;
 }
 
-bool AMDGPUAsmParser::validateExeczVcczOperands(const OperandVector &Operands) {
-  if (!isGFX11Plus())
-    return true;
-  for (auto &Operand : Operands) {
-    if (!Operand->isReg())
-      continue;
-    unsigned Reg = Operand->getReg();
-    if (Reg == SRC_EXECZ || Reg == SRC_VCCZ) {
-      Error(getRegLoc(Reg, Operands),
-            "execz and vccz are not supported on this GPU");
-      return false;
-    }
-  }
-  return true;
-}
-
 bool AMDGPUAsmParser::validateTFE(const MCInst &Inst,
                                   const OperandVector &Operands) {
   const MCInstrDesc &Desc = MII.get(Inst.getOpcode());
@@ -5201,9 +5185,6 @@ bool AMDGPUAsmParser::validateInstruction(const MCInst &Inst,
     return false;
   }
   if (!validateWaitCnt(Inst, Operands)) {
-    return false;
-  }
-  if (!validateExeczVcczOperands(Operands)) {
     return false;
   }
   if (!validateTFE(Inst, Operands)) {
@@ -6247,39 +6228,41 @@ bool AMDGPUAsmParser::ParseDirective(AsmToken DirectiveID) {
 
 bool AMDGPUAsmParser::subtargetHasRegister(const MCRegisterInfo &MRI,
                                            unsigned RegNo) {
-
-  if (MRI.regsOverlap(AMDGPU::TTMP12_TTMP13_TTMP14_TTMP15, RegNo))
+  if (MRI.regsOverlap(TTMP12_TTMP13_TTMP14_TTMP15, RegNo))
     return isGFX9Plus();
 
   // GFX10+ has 2 more SGPRs 104 and 105.
-  if (MRI.regsOverlap(AMDGPU::SGPR104_SGPR105, RegNo))
+  if (MRI.regsOverlap(SGPR104_SGPR105, RegNo))
     return hasSGPR104_SGPR105();
 
   switch (RegNo) {
-  case AMDGPU::SRC_SHARED_BASE_LO:
-  case AMDGPU::SRC_SHARED_BASE:
-  case AMDGPU::SRC_SHARED_LIMIT_LO:
-  case AMDGPU::SRC_SHARED_LIMIT:
-  case AMDGPU::SRC_PRIVATE_BASE_LO:
-  case AMDGPU::SRC_PRIVATE_BASE:
-  case AMDGPU::SRC_PRIVATE_LIMIT_LO:
-  case AMDGPU::SRC_PRIVATE_LIMIT:
+  case SRC_SHARED_BASE_LO:
+  case SRC_SHARED_BASE:
+  case SRC_SHARED_LIMIT_LO:
+  case SRC_SHARED_LIMIT:
+  case SRC_PRIVATE_BASE_LO:
+  case SRC_PRIVATE_BASE:
+  case SRC_PRIVATE_LIMIT_LO:
+  case SRC_PRIVATE_LIMIT:
     return isGFX9Plus();
-  case AMDGPU::SRC_POPS_EXITING_WAVE_ID:
+  case SRC_POPS_EXITING_WAVE_ID:
     return isGFX9Plus() && !isGFX11Plus();
-  case AMDGPU::TBA:
-  case AMDGPU::TBA_LO:
-  case AMDGPU::TBA_HI:
-  case AMDGPU::TMA:
-  case AMDGPU::TMA_LO:
-  case AMDGPU::TMA_HI:
+  case TBA:
+  case TBA_LO:
+  case TBA_HI:
+  case TMA:
+  case TMA_LO:
+  case TMA_HI:
     return !isGFX9Plus();
-  case AMDGPU::XNACK_MASK:
-  case AMDGPU::XNACK_MASK_LO:
-  case AMDGPU::XNACK_MASK_HI:
+  case XNACK_MASK:
+  case XNACK_MASK_LO:
+  case XNACK_MASK_HI:
     return (isVI() || isGFX9()) && getTargetStreamer().getTargetID()->isXnackSupported();
-  case AMDGPU::SGPR_NULL:
+  case SGPR_NULL:
     return isGFX10Plus();
+  case SRC_EXECZ:
+  case SRC_VCCZ:
+    return !isGFX11Plus();
   default:
     break;
   }
@@ -6292,9 +6275,9 @@ bool AMDGPUAsmParser::subtargetHasRegister(const MCRegisterInfo &MRI,
     // On GFX10Plus flat scratch is not a valid register operand and can only be
     // accessed with s_setreg/s_getreg.
     switch (RegNo) {
-    case AMDGPU::FLAT_SCR:
-    case AMDGPU::FLAT_SCR_LO:
-    case AMDGPU::FLAT_SCR_HI:
+    case FLAT_SCR:
+    case FLAT_SCR_LO:
+    case FLAT_SCR_HI:
       return false;
     default:
       return true;
@@ -6303,7 +6286,7 @@ bool AMDGPUAsmParser::subtargetHasRegister(const MCRegisterInfo &MRI,
 
   // VI only has 102 SGPRs, so make sure we aren't trying to use the 2 more that
   // SI/CI have.
-  if (MRI.regsOverlap(AMDGPU::SGPR102_SGPR103, RegNo))
+  if (MRI.regsOverlap(SGPR102_SGPR103, RegNo))
     return hasSGPR102_SGPR103();
 
   return true;

--- a/llvm/test/MC/AMDGPU/expressions.s
+++ b/llvm/test/MC/AMDGPU/expressions.s
@@ -337,4 +337,4 @@ v_sin_f32 v0, -s1000
 
 xnack_mask_lo=1
 v_sin_f32 v0, xnack_mask_lo
-// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask_lo register not available on this GPU

--- a/llvm/test/MC/AMDGPU/flat-scratch.s
+++ b/llvm/test/MC/AMDGPU/flat-scratch.s
@@ -5,32 +5,32 @@
 // RUN: not llvm-mc -triple=amdgcn -mcpu=tonga -show-encoding %s  | FileCheck -check-prefix=VI %s
 
 s_mov_b64 flat_scratch, -1
-// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch register not available on this GPU
 // CI: s_mov_b64 flat_scratch, -1 ; encoding: [0xc1,0x04,0xe8,0xbe]
 // VI: s_mov_b64 flat_scratch, -1 ; encoding: [0xc1,0x01,0xe6,0xbe]
 
 s_mov_b32 flat_scratch_lo, -1
-// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch_lo register not available on this GPU
 // CI: s_mov_b32 flat_scratch_lo, -1 ; encoding: [0xc1,0x03,0xe8,0xbe]
 // VI: s_mov_b32 flat_scratch_lo, -1 ; encoding: [0xc1,0x00,0xe6,0xbe]
 
 s_mov_b32 flat_scratch_hi, -1
-// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch_hi register not available on this GPU
 // CI: s_mov_b32 flat_scratch_hi, -1 ; encoding: [0xc1,0x03,0xe9,0xbe]
 // VI: s_mov_b32 flat_scratch_hi, -1 ; encoding: [0xc1,0x00,0xe7,0xbe]
 
 
 s_mov_b64 flat_scratch_lo, -1
-// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch_lo register not available on this GPU
 // NOCI: :[[@LINE-2]]:{{[0-9]+}}: error: invalid operand for instruction
 // NOVI: :[[@LINE-3]]:{{[0-9]+}}: error: invalid operand for instruction
 
 s_mov_b64 flat_scratch_hi, -1
-// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch_hi register not available on this GPU
 // NOCI: :[[@LINE-2]]:{{[0-9]+}}: error: invalid operand for instruction
 // NOVI: :[[@LINE-3]]:{{[0-9]+}}: error: invalid operand for instruction
 
 s_mov_b32 flat_scratch, -1
-// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSI: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch register not available on this GPU
 // NOCI: :[[@LINE-2]]:{{[0-9]+}}: error: invalid operand for instruction
 // NOVI: :[[@LINE-3]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/AMDGPU/gfx10_err_pos.s
+++ b/llvm/test/MC/AMDGPU/gfx10_err_pos.s
@@ -1124,12 +1124,12 @@ v_add_nc_i32 v256, v0, v1
 // register not available on this GPU
 
 s_and_b32     ttmp9, tma_hi, 0x0000ffff
-// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: tma_hi register not available on this GPU
 // CHECK-NEXT:{{^}}s_and_b32     ttmp9, tma_hi, 0x0000ffff
 // CHECK-NEXT:{{^}}                     ^
 
 s_mov_b32 flat_scratch, -1
-// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch register not available on this GPU
 // CHECK-NEXT:{{^}}s_mov_b32 flat_scratch, -1
 // CHECK-NEXT:{{^}}          ^
 

--- a/llvm/test/MC/AMDGPU/gfx11_asm_operands.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_operands.s
@@ -16,35 +16,35 @@ s_cbranch_execz 0x100
 
 s_add_i32 s0, execz, s2
 // GFX10: encoding: [0xfc,0x02,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 s_add_i32 s0, src_execz, s2
 // GFX10: encoding: [0xfc,0x02,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 s_add_i32 s0, s1, execz
 // GFX10: encoding: [0x01,0xfc,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 s_add_i32 s0, s1, src_execz
 // GFX10: encoding: [0x01,0xfc,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 v_add_f64 v[0:1], execz, v[2:3]
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0xfc,0x04,0x02,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 v_add_f64 v[0:1], src_execz, v[2:3]
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0xfc,0x04,0x02,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 v_add_f64 v[0:1], v[1:2], execz
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0x01,0xf9,0x01,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 v_add_f64 v[0:1], v[1:2], src_execz
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0x01,0xf9,0x01,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_execz register not available on this GPU
 
 //---------------------------------------------------------------------------//
 // VCCZ
@@ -56,35 +56,35 @@ s_cbranch_vccz 0x100
 
 s_add_i32 s0, vccz, s2
 // GFX10: encoding: [0xfb,0x02,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 s_add_i32 s0, src_vccz, s2
 // GFX10: encoding: [0xfb,0x02,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 s_add_i32 s0, s1, vccz
 // GFX10: encoding: [0x01,0xfb,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 s_add_i32 s0, s1, src_vccz
 // GFX10: encoding: [0x01,0xfb,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 v_add_f64 v[0:1], vccz, v[2:3]
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0xfb,0x04,0x02,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 v_add_f64 v[0:1], src_vccz, v[2:3]
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0xfb,0x04,0x02,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 v_add_f64 v[0:1], v[1:2], vccz
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0x01,0xf7,0x01,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 v_add_f64 v[0:1], v[1:2], src_vccz
 // GFX10: encoding: [0x00,0x00,0x64,0xd5,0x01,0xf7,0x01,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: execz and vccz are not supported on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_vccz register not available on this GPU
 
 //---------------------------------------------------------------------------//
 // LDS_DIRECT
@@ -112,32 +112,32 @@ v_mov_b32 v0, src_lds_direct
 
 s_add_i32 s0, src_pops_exiting_wave_id, s1
 // GFX10: encoding: [0xef,0x01,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 
 s_add_i32 s0, s1, src_pops_exiting_wave_id
 // GFX10: encoding: [0x01,0xef,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 
 s_add_i32 s0, pops_exiting_wave_id, s1
 // GFX10: encoding: [0xef,0x01,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 
 s_add_i32 s0, s1, pops_exiting_wave_id
 // GFX10: encoding: [0x01,0xef,0x00,0x81]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 
 v_add_co_u32 v0, s0, pops_exiting_wave_id, v1
 // GFX10: encoding: [0x00,0x00,0x0f,0xd7,0xef,0x02,0x02,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 
 v_add_co_u32 v0, s0, src_pops_exiting_wave_id, v1
 // GFX10: encoding: [0x00,0x00,0x0f,0xd7,0xef,0x02,0x02,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 
 v_add_co_u32 v0, s0, v1, pops_exiting_wave_id
 // GFX10: encoding: [0x00,0x00,0x0f,0xd7,0x01,0xdf,0x01,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 
 v_add_co_u32 v0, s0, v1, src_pops_exiting_wave_id
 // GFX10: encoding: [0x00,0x00,0x0f,0xd7,0x01,0xdf,0x01,0x00]
-// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX11-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU

--- a/llvm/test/MC/AMDGPU/literals.s
+++ b/llvm/test/MC/AMDGPU/literals.s
@@ -650,89 +650,89 @@ v_ceil_f32_sdwa v5, |execz| dst_sel:DWORD src0_sel:DWORD
 // named inline values: shared_base, shared_limit, private_base, etc
 //---------------------------------------------------------------------------//
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: buffer_atomic_add v0, off, s[0:3], src_shared_base offset:4095 ; encoding: [0xff,0x0f,0x08,0xe1,0x00,0x00,0x00,0xeb]
 buffer_atomic_add v0, off, s[0:3], src_shared_base offset:4095
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: s_add_i32 s0, src_shared_base, s0 ; encoding: [0xeb,0x00,0x00,0x81]
 s_add_i32 s0, src_shared_base, s0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_limit register not available on this GPU
 // GFX9: s_add_i32 s0, src_shared_limit, s0 ; encoding: [0xec,0x00,0x00,0x81]
 s_add_i32 s0, src_shared_limit, s0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_private_base register not available on this GPU
 // GFX9: s_add_i32 s0, src_private_base, s0 ; encoding: [0xed,0x00,0x00,0x81]
 s_add_i32 s0, src_private_base, s0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_private_limit register not available on this GPU
 // GFX9: s_add_i32 s0, src_private_limit, s0 ; encoding: [0xee,0x00,0x00,0x81]
 s_add_i32 s0, src_private_limit, s0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 // GFX9: s_add_i32 s0, src_pops_exiting_wave_id, s0 ; encoding: [0xef,0x00,0x00,0x81]
 s_add_i32 s0, src_pops_exiting_wave_id, s0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: s_and_b64 s[0:1], s[0:1], src_shared_base ; encoding: [0x00,0xeb,0x80,0x86]
 s_and_b64 s[0:1], s[0:1], src_shared_base
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_limit register not available on this GPU
 // GFX9: s_and_b64 s[0:1], s[0:1], src_shared_limit ; encoding: [0x00,0xec,0x80,0x86]
 s_and_b64 s[0:1], s[0:1], src_shared_limit
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_private_base register not available on this GPU
 // GFX9: s_and_b64 s[0:1], s[0:1], src_private_base ; encoding: [0x00,0xed,0x80,0x86]
 s_and_b64 s[0:1], s[0:1], src_private_base
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_private_limit register not available on this GPU
 // GFX9: s_and_b64 s[0:1], s[0:1], src_private_limit ; encoding: [0x00,0xee,0x80,0x86]
 s_and_b64 s[0:1], s[0:1], src_private_limit
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_pops_exiting_wave_id register not available on this GPU
 // GFX9: s_and_b64 s[0:1], s[0:1], src_pops_exiting_wave_id ; encoding: [0x00,0xef,0x80,0x86]
 s_and_b64 s[0:1], s[0:1], src_pops_exiting_wave_id
 
 // GFX9: v_add_u16_e32 v0, src_shared_base, v0 ; encoding: [0xeb,0x00,0x00,0x4c]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_add_u16 v0, src_shared_base, v0
 
 // GFX9: v_add_u16_sdwa v0, src_shared_base, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD ; encoding: [0xf9,0x00,0x00,0x4c,0xeb,0x06,0x86,0x06]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_add_u16_sdwa v0, src_shared_base, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 
 // GFX9: v_add_u16_sdwa v0, v0, src_shared_base dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD ; encoding: [0xf9,0xd6,0x01,0x4c,0x00,0x06,0x06,0x86]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_add_u16_sdwa v0, v0, src_shared_base dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 
 // GFX9: v_add_u32_e32 v0, src_shared_base, v0 ; encoding: [0xeb,0x00,0x00,0x68]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_add_u32 v0, src_shared_base, v0
 
 // GFX9: v_add_u32_e64 v0, src_shared_base, v0 ; encoding: [0x00,0x00,0x34,0xd1,0xeb,0x00,0x02,0x00]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_add_u32_e64 v0, src_shared_base, v0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: v_cmp_eq_i64_e32 vcc, src_shared_base, v[0:1] ; encoding: [0xeb,0x00,0xc4,0x7d]
 v_cmp_eq_i64 vcc, src_shared_base, v[0:1]
 
 // GFX9: v_max_f16_e32 v0, src_shared_base, v0 ; encoding: [0xeb,0x00,0x00,0x5a]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_max_f16 v0, src_shared_base, v0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: v_max_f32_e32 v0, src_shared_base, v0 ; encoding: [0xeb,0x00,0x00,0x16]
 v_max_f32 v0, src_shared_base, v0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: v_max_f64 v[0:1], src_shared_base, v[0:1] ; encoding: [0x00,0x00,0x83,0xd2,0xeb,0x00,0x02,0x00]
 v_max_f64 v[0:1], src_shared_base, v[0:1]
 
@@ -742,52 +742,52 @@ v_pk_add_f16 v0, src_shared_base, v0
 
 // GFX9: v_ceil_f16_e64 v0, -src_shared_base ; encoding: [0x00,0x00,0x85,0xd1,0xeb,0x00,0x00,0x20]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f16 v0, neg(src_shared_base)
 
 // GFX9: v_ceil_f16_e64 v0, |src_shared_base| ; encoding: [0x00,0x01,0x85,0xd1,0xeb,0x00,0x00,0x00]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f16 v0, abs(src_shared_base)
 
 // GFX9: v_ceil_f64_e64 v[5:6], |src_shared_base| ; encoding: [0x05,0x01,0x58,0xd1,0xeb,0x00,0x00,0x00]
 // NOSI: :[[@LINE+3]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOCIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOCIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f64 v[5:6], |src_shared_base|
 
 // GFX9: v_ceil_f64_e64 v[5:6], -src_shared_base ; encoding: [0x05,0x00,0x58,0xd1,0xeb,0x00,0x00,0x20]
 // NOSI: :[[@LINE+3]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOCIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOCIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f64 v[5:6], -src_shared_base
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: v_ceil_f32_e64 v0, -src_shared_base ; encoding: [0x00,0x00,0x5d,0xd1,0xeb,0x00,0x00,0x20]
 v_ceil_f32 v0, -src_shared_base
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // GFX9: v_ceil_f32_e64 v0, |src_shared_base| ; encoding: [0x00,0x01,0x5d,0xd1,0xeb,0x00,0x00,0x00]
 v_ceil_f32 v0, |src_shared_base|
 
 // GFX9: v_ceil_f16_sdwa v5, |src_shared_base| dst_sel:DWORD dst_unused:UNUSED_PRESERVE src0_sel:DWORD ; encoding: [0xf9,0x8a,0x0a,0x7e,0xeb,0x16,0xa6,0x00]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f16_sdwa v5, |src_shared_base| dst_sel:DWORD dst_unused:UNUSED_PRESERVE
 
 // GFX9: v_ceil_f16_sdwa v5, -src_shared_base dst_sel:DWORD dst_unused:UNUSED_PRESERVE src0_sel:DWORD ; encoding: [0xf9,0x8a,0x0a,0x7e,0xeb,0x16,0x96,0x00]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f16_sdwa v5, -src_shared_base dst_sel:DWORD dst_unused:UNUSED_PRESERVE
 
 // GFX9: v_ceil_f32_sdwa v5, src_shared_base dst_sel:DWORD dst_unused:UNUSED_PRESERVE src0_sel:DWORD ; encoding: [0xf9,0x3a,0x0a,0x7e,0xeb,0x16,0x86,0x00]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f32_sdwa v5, src_shared_base dst_sel:DWORD src0_sel:DWORD
 
 // GFX9: v_ceil_f32_sdwa v5, |src_shared_base| dst_sel:DWORD dst_unused:UNUSED_PRESERVE src0_sel:DWORD ; encoding: [0xf9,0x3a,0x0a,0x7e,0xeb,0x16,0xa6,0x00]
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 v_ceil_f32_sdwa v5, |src_shared_base| dst_sel:DWORD src0_sel:DWORD
 
 //---------------------------------------------------------------------------//
@@ -796,7 +796,7 @@ v_ceil_f32_sdwa v5, |src_shared_base| dst_sel:DWORD src0_sel:DWORD
 
 // NOGFX9: :[[@LINE+3]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 // NOSICI: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+1]]:{{[0-9]+}}: error: src_private_base register not available on this GPU
 v_add_u32 v0, private_base, s0
 
 // NOGFX9: :[[@LINE+3]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
@@ -805,17 +805,17 @@ v_add_u32 v0, private_base, s0
 v_add_u32 v0, scc, s0
 
 // v_div_fmas implicitly reads VCC
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 v_div_fmas_f32 v0, shared_base, v0, v1
 
 // v_div_fmas implicitly reads VCC
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_limit register not available on this GPU
 // NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 v_div_fmas_f32 v0, v0, shared_limit, v1
 
 // v_div_fmas implicitly reads VCC
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_private_limit register not available on this GPU
 // NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 v_div_fmas_f32 v0, v0, v1, private_limit
 
@@ -836,7 +836,7 @@ v_div_fmas_f32 v0, v0, v1, vccz
 // NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 v_addc_co_u32 v0, vcc, shared_base, v0, vcc
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_shared_base register not available on this GPU
 // NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 v_madak_f32 v0, shared_base, v0, 0x11213141
 
@@ -871,11 +871,11 @@ v_madmk_f16 v0, 0xff32, 0x1122, v0
 // NOGFX89: :[[@LINE+1]]:{{[0-9]+}}: error: only one unique literal operand is allowed
 v_madmk_f16 v0, 0xff32, 1, v0
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_private_base register not available on this GPU
 // NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 v_cmp_eq_f32 s[0:1], private_base, private_limit
 
-// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE+2]]:{{[0-9]+}}: error: src_private_base register not available on this GPU
 // NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand (violates constant bus restrictions)
 v_cmp_eq_f32 s[0:1], private_base, s0
 

--- a/llvm/test/MC/AMDGPU/out-of-range-registers.s
+++ b/llvm/test/MC/AMDGPU/out-of-range-registers.s
@@ -12,11 +12,11 @@ s_add_i32 s106, s0, s1
 // GCN-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: register index is out of range
 
 s_add_i32 s104, s0, s1
-// SICIVI9-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// SICIVI9-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: s104 register not available on this GPU
 // GFX10: s_add_i32 s104, s0, s1 ; encoding:
 
 s_add_i32 s105, s0, s1
-// SICIVI9-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// SICIVI9-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: s105 register not available on this GPU
 // GFX10: s_add_i32 s105, s0, s1 ; encoding:
 
 v_add_i32 v256, v0, v1
@@ -41,7 +41,7 @@ s_mov_b64 s[105:106], -1
 // GCN-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid register alignment
 
 s_mov_b64 s[104:105], -1
-// SICIVI9-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// SICIVI9-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: s[104:105] register not available on this GPU
 // GFX10: s_mov_b64 s[104:105], -1 ; encoding:
 
 s_load_dwordx4 s[102:105], s[2:3], s4
@@ -89,29 +89,29 @@ s_mov_b32 ttmp16, 0
 s_mov_b32 ttmp12, 0
 // GFX9: s_mov_b32 ttmp12, 0 ; encoding:
 // GFX10: s_mov_b32 ttmp12, 0 ; encoding:
-// SIVICI-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// SIVICI-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: ttmp12 register not available on this GPU
 
 s_mov_b32 ttmp15, 0
 // GFX9: s_mov_b32 ttmp15, 0 ; encoding:
 // GFX10: s_mov_b32 ttmp15, 0 ; encoding:
-// SIVICI-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// SIVICI-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: ttmp15 register not available on this GPU
 
 s_mov_b32 flat_scratch_lo, 0
-// SI-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
-// GFX10-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// SI-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch_lo register not available on this GPU
+// GFX10-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: flat_scratch_lo register not available on this GPU
 // CIVI9: s_mov_b32 flat_scratch_lo, 0 ; encoding: [0x80,0x00,0xe6,0xbe]
 
 s_mov_b32 flat_scratch_hi, 0
-// SI-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
-// GFX10-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// SI-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch_hi register not available on this GPU
+// GFX10-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: flat_scratch_hi register not available on this GPU
 // CIVI9: s_mov_b32 flat_scratch_hi, 0 ; encoding: [0x80,0x00,0xe7,0xbe]
 
 s_mov_b32 tma_lo, 0
 // SIVICI: s_mov_b32 tma_lo, 0 ; encoding:
-// GFX9-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
-// GFX10-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX9-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
+// GFX10-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
 
 s_mov_b32 tba_lo, 0
 // SIVICI: s_mov_b32 tba_lo, 0 ; encoding:
-// GFX9-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
-// GFX10-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// GFX9-ERR: :[[@LINE-2]]:{{[0-9]+}}: error: tba_lo register not available on this GPU
+// GFX10-ERR: :[[@LINE-3]]:{{[0-9]+}}: error: tba_lo register not available on this GPU

--- a/llvm/test/MC/AMDGPU/reg-syntax-err.s
+++ b/llvm/test/MC/AMDGPU/reg-syntax-err.s
@@ -28,7 +28,7 @@ s_mov_b32 s1, s[0:2] 1
 // NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 
 s_mov_b32 s1, xnack_mask_lo 1
-// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask_lo register not available on this GPU
 
 s_mov_b32 s1, s s0
 // NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
@@ -58,7 +58,7 @@ s_mov_b32 s1, s[0:2] vcc_lo
 // NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 
 s_mov_b32 s1, xnack_mask_lo s1
-// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask_lo register not available on this GPU
 
 exp mrt0 v1, v2, v3, v4000 off
 // NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: register index is out of range

--- a/llvm/test/MC/AMDGPU/reg-syntax-extra.s
+++ b/llvm/test/MC/AMDGPU/reg-syntax-extra.s
@@ -38,9 +38,9 @@ s_mov_b64 [exec_lo,exec_hi], s[2:3]
 // GFX10: s_mov_b64 exec, s[2:3]         ; encoding: [0x02,0x04,0xfe,0xbe]
 
 s_mov_b64 [flat_scratch_lo,flat_scratch_hi], s[2:3]
-// NOSICI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICI: :[[@LINE-1]]:{{[0-9]+}}: error: flat_scratch_lo register not available on this GPU
 // VI:   s_mov_b64 flat_scratch, s[2:3]  ; encoding: [0x02,0x01,0xe6,0xbe]
-// NOGFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX10: :[[@LINE-3]]:{{[0-9]+}}: error: flat_scratch_lo register not available on this GPU
 
 s_mov_b64 [vcc_lo,vcc_hi], s[2:3]
 // SICI: s_mov_b64 vcc, s[2:3]           ; encoding: [0x02,0x04,0xea,0xbe]
@@ -50,12 +50,12 @@ s_mov_b64 [vcc_lo,vcc_hi], s[2:3]
 s_mov_b64 [tba_lo,tba_hi], s[2:3]
 // SICI:  s_mov_b64 tba, s[2:3]           ; encoding: [0x02,0x04,0xec,0xbe]
 // VI:    s_mov_b64 tba, s[2:3]           ; encoding: [0x02,0x01,0xec,0xbe]
-// NOGFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tba_lo register not available on this GPU
 
 s_mov_b64 [tma_lo,tma_hi], s[2:3]
 // SICI:  s_mov_b64 tma, s[2:3]           ; encoding: [0x02,0x04,0xee,0xbe]
 // VI:    s_mov_b64 tma, s[2:3]           ; encoding: [0x02,0x01,0xee,0xbe]
-// NOGFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
 
 v_mov_b32_e32 [v1], [v2]
 // GCN:  v_mov_b32_e32 v1, v2 ; encoding: [0x02,0x03,0x02,0x7e]

--- a/llvm/test/MC/AMDGPU/smem.s
+++ b/llvm/test/MC/AMDGPU/smem.s
@@ -50,12 +50,12 @@ s_memrealtime s[4:5]
 s_memrealtime tba
 // VI: s_memrealtime tba ; encoding: [0x00,0x1b,0x94,0xc0,0x00,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tba register not available on this GPU
 
 s_memrealtime tma
 // VI: s_memrealtime tma ; encoding: [0x80,0x1b,0x94,0xc0,0x00,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tma register not available on this GPU
 
 s_memrealtime ttmp[0:1]
 // VI:    s_memrealtime ttmp[0:1] ; encoding: [0x00,0x1c,0x94,0xc0,0x00,0x00,0x00,0x00]
@@ -86,25 +86,25 @@ s_store_dword s1, s[2:3], s4 glc
 s_store_dword tba_lo, s[2:3], s4
 // VI: s_store_dword tba_lo, s[2:3], s4 ; encoding: [0x01,0x1b,0x40,0xc0,0x04,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tba_lo register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_store_dword tba_hi, s[2:3], s4
 // VI: s_store_dword tba_hi, s[2:3], s4 ; encoding: [0x41,0x1b,0x40,0xc0,0x04,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tba_hi register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_store_dword tma_lo, s[2:3], s4
 // VI: s_store_dword tma_lo, s[2:3], s4 ; encoding: [0x81,0x1b,0x40,0xc0,0x04,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_store_dword tma_hi, s[2:3], s4
 // VI: s_store_dword tma_hi, s[2:3], s4 ; encoding: [0xc1,0x1b,0x40,0xc0,0x04,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tma_hi register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_load_dword s1, s[2:3], 0xfc glc
@@ -125,25 +125,25 @@ s_buffer_store_dword s10, s[92:95], m0
 s_buffer_store_dword tba_lo, s[92:95], m0
 // VI: s_buffer_store_dword tba_lo, s[92:95], m0 ; encoding: [0x2e,0x1b,0x60,0xc0,0x7c,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tba_lo register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_buffer_store_dword tba_hi, s[92:95], m0
 // VI: s_buffer_store_dword tba_hi, s[92:95], m0 ; encoding: [0x6e,0x1b,0x60,0xc0,0x7c,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tba_hi register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_buffer_store_dword tma_lo, s[92:95], m0
 // VI: s_buffer_store_dword tma_lo, s[92:95], m0 ; encoding: [0xae,0x1b,0x60,0xc0,0x7c,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_buffer_store_dword tma_hi, s[92:95], m0
 // VI: s_buffer_store_dword tma_hi, s[92:95], m0 ; encoding: [0xee,0x1b,0x60,0xc0,0x7c,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tma_hi register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_buffer_store_dword ttmp0, s[92:95], m0
@@ -165,7 +165,7 @@ s_buffer_store_dwordx4 s[8:11], s[92:95], m0 glc
 s_buffer_store_dwordx2 tba, s[92:95], m0 glc
 // VI: s_buffer_store_dwordx2 tba, s[92:95], m0 glc ; encoding: [0x2e,0x1b,0x65,0xc0,0x7c,0x00,0x00,0x00]
 // NOSICI: :[[@LINE-2]]:{{[0-9]+}}: error: instruction not supported on this GPU
-// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX1012: :[[@LINE-3]]:{{[0-9]+}}: error: tba register not available on this GPU
 // NOGFX1030: :[[@LINE-4]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
 s_buffer_load_dword s10, s[92:95], m0
@@ -176,22 +176,22 @@ s_buffer_load_dword s10, s[92:95], m0
 s_buffer_load_dword tba_lo, s[92:95], m0
 // VI: s_buffer_load_dword tba_lo, s[92:95], m0 ; encoding: [0x2e,0x1b,0x20,0xc0,0x7c,0x00,0x00,0x00]
 // SICI: s_buffer_load_dword tba_lo, s[92:95], m0 ; encoding: [0x7c,0x5c,0x36,0xc2]
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tba_lo register not available on this GPU
 
 s_buffer_load_dword tba_hi, s[92:95], m0
 // VI: s_buffer_load_dword tba_hi, s[92:95], m0 ; encoding: [0x6e,0x1b,0x20,0xc0,0x7c,0x00,0x00,0x00]
 // SICI: s_buffer_load_dword tba_hi, s[92:95], m0 ; encoding: [0x7c,0xdc,0x36,0xc2]
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tba_hi register not available on this GPU
 
 s_buffer_load_dword tma_lo, s[92:95], m0
 // VI: s_buffer_load_dword tma_lo, s[92:95], m0 ; encoding: [0xae,0x1b,0x20,0xc0,0x7c,0x00,0x00,0x00]
 // SICI: s_buffer_load_dword tma_lo, s[92:95], m0 ; encoding: [0x7c,0x5c,0x37,0xc2]
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
 
 s_buffer_load_dword tma_hi, s[92:95], m0
 // VI: s_buffer_load_dword tma_hi, s[92:95], m0 ; encoding: [0xee,0x1b,0x20,0xc0,0x7c,0x00,0x00,0x00]
 // SICI: s_buffer_load_dword tma_hi, s[92:95], m0 ; encoding: [0x7c,0xdc,0x37,0xc2]
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tma_hi register not available on this GPU
 
 s_buffer_load_dword ttmp0, s[92:95], m0
 // VI:    s_buffer_load_dword ttmp0, s[92:95], m0 ; encoding: [0x2e,0x1c,0x20,0xc0,0x7c,0x00,0x00,0x00]
@@ -207,12 +207,12 @@ s_buffer_load_dwordx2 s[10:11], s[92:95], m0
 s_buffer_load_dwordx2 tba, s[92:95], m0
 // VI:   s_buffer_load_dwordx2 tba, s[92:95], m0 ; encoding: [0x2e,0x1b,0x24,0xc0,0x7c,0x00,0x00,0x00]
 // SICI: s_buffer_load_dwordx2 tba, s[92:95], m0 ; encoding: [0x7c,0x5c,0x76,0xc2]
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tba register not available on this GPU
 
 s_buffer_load_dwordx2 tma, s[92:95], m0
 // VI: s_buffer_load_dwordx2 tma, s[92:95], m0 ; encoding: [0xae,0x1b,0x24,0xc0,0x7c,0x00,0x00,0x00]
 // SICI: s_buffer_load_dwordx2 tma, s[92:95], m0 ; encoding: [0x7c,0x5c,0x77,0xc2]
-// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9GFX10: :[[@LINE-3]]:{{[0-9]+}}: error: tma register not available on this GPU
 
 s_buffer_load_dwordx2 ttmp[0:1], s[92:95], m0
 // VI:    s_buffer_load_dwordx2 ttmp[0:1], s[92:95], m0 ; encoding: [0x2e,0x1c,0x24,0xc0,0x7c,0x00,0x00,0x00]

--- a/llvm/test/MC/AMDGPU/smrd-err.s
+++ b/llvm/test/MC/AMDGPU/smrd-err.s
@@ -2,13 +2,13 @@
 // RUN: not llvm-mc -triple=amdgcn -mcpu=tonga %s 2>&1 | FileCheck -check-prefix=NOVI --implicit-check-not=error: %s
 
 s_load_dwordx4 s[100:103], s[2:3], s4
-// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: s[100:103] register not available on this GPU
 // SI: s_load_dwordx4 s[100:103], s[2:3], s4
 
 s_load_dwordx8 s[96:103], s[2:3], s4
-// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: s[96:103] register not available on this GPU
 // SI: 	s_load_dwordx8 s[96:103], s[2:3], s4
 
 s_load_dwordx16 s[88:103], s[2:3], s4
-// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-1]]:{{[0-9]+}}: error: s[88:103] register not available on this GPU
 // SI: s_load_dwordx16 s[88:103], s[2:3], s4

--- a/llvm/test/MC/AMDGPU/smrd.s
+++ b/llvm/test/MC/AMDGPU/smrd.s
@@ -111,7 +111,7 @@ s_load_dwordx4 ttmp[4:7], ttmp[2:3], ttmp4
 
 s_load_dwordx4 s[100:103], s[2:3], s4
 // GCN: s_load_dwordx4 s[100:103], s[2:3], s4 ; encoding: [0x04,0x02,0xb2,0xc0]
-// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: s[100:103] register not available on this GPU
 
 s_load_dwordx8 s[8:15], s[2:3], 1
 // GCN: s_load_dwordx8 s[8:15], s[2:3], 0x1 ; encoding: [0x01,0x03,0xc4,0xc0]
@@ -123,7 +123,7 @@ s_load_dwordx8 s[8:15], s[2:3], s4
 
 s_load_dwordx8 s[96:103], s[2:3], s4
 // GCN: s_load_dwordx8 s[96:103], s[2:3], s4 ; encoding: [0x04,0x02,0xf0,0xc0]
-// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: s[96:103] register not available on this GPU
 
 s_load_dwordx16 s[16:31], s[2:3], 1
 // GCN: s_load_dwordx16 s[16:31], s[2:3], 0x1 ; encoding: [0x01,0x03,0x08,0xc1]
@@ -135,7 +135,7 @@ s_load_dwordx16 s[16:31], s[2:3], s4
 
 s_load_dwordx16 s[88:103], s[2:3], s4
 // GCN: s_load_dwordx16 s[88:103], s[2:3], s4 ; encoding: [0x04,0x02,0x2c,0xc1]
-// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: s[88:103] register not available on this GPU
 
 s_buffer_load_dword s1, s[4:7], 1
 // GCN: s_buffer_load_dword s1, s[4:7], 0x1 ; encoding: [0x01,0x85,0x00,0xc2]
@@ -195,7 +195,7 @@ s_buffer_load_dwordx4 ttmp[8:11], ttmp[4:7], ttmp4
 
 s_buffer_load_dwordx4 s[100:103], s[4:7], s4
 // GCN: s_buffer_load_dwordx4 s[100:103], s[4:7], s4 ; encoding: [0x04,0x04,0xb2,0xc2]
-// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: s[100:103] register not available on this GPU
 
 s_buffer_load_dwordx8 s[8:15], s[4:7], 1
 // GCN: s_buffer_load_dwordx8 s[8:15], s[4:7], 0x1 ; encoding: [0x01,0x05,0xc4,0xc2]
@@ -207,7 +207,7 @@ s_buffer_load_dwordx8 s[8:15], s[4:7], s4
 
 s_buffer_load_dwordx8 s[96:103], s[4:7], s4
 // GCN: s_buffer_load_dwordx8 s[96:103], s[4:7], s4 ; encoding: [0x04,0x04,0xf0,0xc2]
-// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: s[96:103] register not available on this GPU
 
 s_buffer_load_dwordx16 s[16:31], s[4:7], 1
 // GCN: s_buffer_load_dwordx16 s[16:31], s[4:7], 0x1 ; encoding: [0x01,0x05,0x08,0xc3]
@@ -219,7 +219,7 @@ s_buffer_load_dwordx16 s[16:31], s[4:7], s4
 
 s_buffer_load_dwordx16 s[88:103], s[4:7], s4
 // GCN: s_buffer_load_dwordx16 s[88:103], s[4:7], s4 ; encoding: [0x04,0x04,0x2c,0xc3]
-// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE-2]]:{{[0-9]+}}: error: s[88:103] register not available on this GPU
 
 s_dcache_inv
 // GCN: s_dcache_inv ; encoding: [0x00,0x00,0xc0,0xc7]

--- a/llvm/test/MC/AMDGPU/sop1-err.s
+++ b/llvm/test/MC/AMDGPU/sop1-err.s
@@ -32,13 +32,13 @@ s_mov_b32 s
 // Out of range register
 
 s_mov_b32 s102, 1
-// VI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// VI: :[[@LINE-1]]:{{[0-9]+}}: error: s102 register not available on this GPU
 
 s_mov_b32 s103, 1
-// VI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// VI: :[[@LINE-1]]:{{[0-9]+}}: error: s103 register not available on this GPU
 
 s_mov_b64 s[102:103], -1
-// VI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// VI: :[[@LINE-1]]:{{[0-9]+}}: error: s[102:103] register not available on this GPU
 
 s_setpc_b64 0
 // GCN: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/AMDGPU/sop1.s
+++ b/llvm/test/MC/AMDGPU/sop1.s
@@ -62,7 +62,7 @@ s_mov_b64 s[0:1], 0x80000000
 
 s_mov_b64 s[102:103], -1
 // SICI: s_mov_b64 s[102:103], -1 ; encoding: [0xc1,0x04,0xe6,0xbe]
-// NOGFX89: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX89: :[[@LINE-2]]:{{[0-9]+}}: error: s[102:103] register not available on this GPU
 // GFX10: s_mov_b64 s[102:103], -1 ; encoding: [0xc1,0x04,0xe6,0xbe]
 
 s_cmov_b32 s1, 200

--- a/llvm/test/MC/AMDGPU/sop2.s
+++ b/llvm/test/MC/AMDGPU/sop2.s
@@ -235,7 +235,7 @@ s_absdiff_i32 s2, s4, s6
 
 s_add_u32 s101, s102, s103
 // SICI: s_add_u32 s101, s102, s103 ; encoding: [0x66,0x67,0x65,0x80]
-// NOGFX89: :[[@LINE-2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX89: :[[@LINE-2]]:{{[0-9]+}}: error: s102 register not available on this GPU
 // GFX10: s_add_u32 s101, s102, s103 ; encoding: [0x66,0x67,0x65,0x80]
 
 s_lshl1_add_u32 s5, s1, s2

--- a/llvm/test/MC/AMDGPU/trap.s
+++ b/llvm/test/MC/AMDGPU/trap.s
@@ -45,7 +45,7 @@ s_and_b32     ttmp10, ttmp8, 0x00000080
 s_and_b32     ttmp9, tma_hi, 0x0000ffff
 // SICI: s_and_b32 ttmp9, tma_hi, 0xffff ; encoding: [0x6f,0xff,0x79,0x87,0xff,0xff,0x00,0x00]
 // VI:   s_and_b32 ttmp9, tma_hi, 0xffff ; encoding: [0x6f,0xff,0x79,0x86,0xff,0xff,0x00,0x00]
-// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: tma_hi register not available on this GPU
 
 s_and_b32     ttmp9, ttmp9, 0x000001ff
 // SICI: s_and_b32 ttmp9, ttmp9, 0x1ff   ; encoding: [0x79,0xff,0x79,0x87,0xff,0x01,0x00,0x00]
@@ -55,7 +55,7 @@ s_and_b32     ttmp9, ttmp9, 0x000001ff
 s_and_b32     ttmp9, tma_lo, 0xffff0000
 // SICI: s_and_b32 ttmp9, tma_lo, 0xffff0000 ; encoding: [0x6e,0xff,0x79,0x87,0x00,0x00,0xff,0xff]
 // VI:   s_and_b32 ttmp9, tma_lo, 0xffff0000 ; encoding: [0x6e,0xff,0x79,0x86,0x00,0x00,0xff,0xff]
-// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
 
 s_and_b32     ttmp9, ttmp9, ttmp8
 // SICI: s_and_b32 ttmp9, ttmp9, ttmp8   ; encoding: [0x79,0x78,0x79,0x87]
@@ -110,7 +110,7 @@ s_mov_b32     ttmp8, m0
 s_mov_b32     ttmp8, tma_lo
 // SICI: s_mov_b32 ttmp8, tma_lo         ; encoding: [0x6e,0x03,0xf8,0xbe]
 // VI:   s_mov_b32 ttmp8, tma_lo         ; encoding: [0x6e,0x00,0xf8,0xbe]
-// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: tma_lo register not available on this GPU
 
 s_mul_i32     ttmp8, 0x00000324, ttmp8
 // SICI: s_mul_i32 ttmp8, 0x324, ttmp8   ; encoding: [0xff,0x78,0x78,0x93,0x24,0x03,0x00,0x00]
@@ -125,19 +125,19 @@ s_or_b32      ttmp9, ttmp9, 0x00280000
 // ttmp12..ttmp15 (GFX9 only)
 
 s_add_u32     ttmp0, ttmp12, 4
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp12 register not available on this GPU
 // GFX9: s_add_u32 ttmp0, ttmp12, 4       ; encoding: [0x78,0x84,0x6c,0x80]
 
 s_add_u32     ttmp0, ttmp13, 4
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp13 register not available on this GPU
 // GFX9: s_add_u32 ttmp0, ttmp13, 4       ; encoding: [0x79,0x84,0x6c,0x80]
 
 s_add_u32     ttmp0, ttmp14, 4
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp14 register not available on this GPU
 // GFX9: s_add_u32 ttmp0, ttmp14, 4       ; encoding: [0x7a,0x84,0x6c,0x80]
 
 s_add_u32     ttmp0, ttmp15, 4
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp15 register not available on this GPU
 // GFX9: s_add_u32 ttmp0, ttmp15, 4       ; encoding: [0x7b,0x84,0x6c,0x80]
 
 //===----------------------------------------------------------------------===//
@@ -162,31 +162,31 @@ s_mov_b64     exec, [ttmp4,ttmp5]
 s_mov_b64     tba, ttmp[4:5]
 // SICI: s_mov_b64 tba, ttmp[4:5]        ; encoding: [0x74,0x04,0xec,0xbe]
 // VI:   s_mov_b64 tba, ttmp[4:5]        ; encoding: [0x74,0x01,0xec,0xbe]
-// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: tba register not available on this GPU
 
 s_mov_b64     ttmp[4:5], tba
 // SICI: s_mov_b64 ttmp[4:5], tba        ; encoding: [0x6c,0x04,0xf4,0xbe]
 // VI:   s_mov_b64 ttmp[4:5], tba        ; encoding: [0x6c,0x01,0xf4,0xbe]
-// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: tba register not available on this GPU
 
 s_mov_b64     tma, ttmp[4:5]
 // SICI: s_mov_b64 tma, ttmp[4:5]        ; encoding: [0x74,0x04,0xee,0xbe]
 // VI:   s_mov_b64 tma, ttmp[4:5]        ; encoding: [0x74,0x01,0xee,0xbe]
-// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: tma register not available on this GPU
 
 s_mov_b64     ttmp[4:5], tma
 // SICI: s_mov_b64 ttmp[4:5], tma        ; encoding: [0x6e,0x04,0xf4,0xbe]
 // VI:   s_mov_b64 ttmp[4:5], tma        ; encoding: [0x6e,0x01,0xf4,0xbe]
-// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE-3]]:{{[0-9]+}}: error: tma register not available on this GPU
 
 // ttmp12..ttmp15 (GFX9 only)
 
 s_mov_b64     ttmp[12:13], exec
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp[12:13] register not available on this GPU
 // GFX9: s_mov_b64 ttmp[12:13], exec       ; encoding: [0x7e,0x01,0xf8,0xbe]
 
 s_mov_b64     ttmp[14:15], exec
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp[14:15] register not available on this GPU
 // GFX9: s_mov_b64 ttmp[14:15], exec       ; encoding: [0x7e,0x01,0xfa,0xbe]
 
 //===----------------------------------------------------------------------===//
@@ -205,7 +205,7 @@ s_buffer_load_dwordx8 ttmp[4:11], s[0:3], s0
 // SICI: s_buffer_load_dwordx8 ttmp[4:11], s[0:3], s0 ; encoding: [0x00,0x00,0xfa,0xc2]
 
 s_buffer_load_dwordx8 ttmp[8:15], s[0:3], s0
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp[8:15] register not available on this GPU
 // GFX9: [0x00,0x1d,0x2c,0xc0,0x00,0x00,0x00,0x00]
 
 s_load_dwordx8 ttmp[0:7], s[0:1], s0
@@ -219,7 +219,7 @@ s_load_dwordx8 ttmp[4:11], s[0:1], s0
 // SICI: s_load_dwordx8 ttmp[4:11], s[0:1], s0 ; encoding: [0x00,0x00,0xfa,0xc0]
 
 s_load_dwordx8 ttmp[8:15], s[0:1], s0
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp[8:15] register not available on this GPU
 // GFX9: [0x00,0x1d,0x0c,0xc0,0x00,0x00,0x00,0x00]
 
 //===----------------------------------------------------------------------===//
@@ -228,11 +228,11 @@ s_load_dwordx8 ttmp[8:15], s[0:1], s0
 //===----------------------------------------------------------------------===//
 
 s_buffer_load_dwordx16 ttmp[0:15], s[0:3], s0
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp[0:15] register not available on this GPU
 // GFX9: [0x00,0x1b,0x30,0xc0,0x00,0x00,0x00,0x00]
 
 s_load_dwordx16 ttmp[0:15], s[0:1], s0
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp[0:15] register not available on this GPU
 // GFX9: [0x00,0x1b,0x10,0xc0,0x00,0x00,0x00,0x00]
 
 //===----------------------------------------------------------------------===//
@@ -257,5 +257,5 @@ buffer_atomic_inc v1, off, ttmp[8:11], 56 glc
 // ttmp12..ttmp15 (GFX9 only)
 
 buffer_atomic_inc v1, off, ttmp[12:15], 56 glc
-// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI: :[[@LINE-1]]:{{[0-9]+}}: error: ttmp[12:15] register not available on this GPU
 // GFX9: buffer_atomic_inc v1, off, ttmp[12:15], 56 glc ; encoding: [0x00,0x40,0x2c,0xe1,0x00,0x01,0x1e,0xb8]

--- a/llvm/test/MC/AMDGPU/vop_sdwa.s
+++ b/llvm/test/MC/AMDGPU/vop_sdwa.s
@@ -722,7 +722,7 @@ v_mov_b32 v1, s2 dst_sel:BYTE_0 dst_unused:UNUSED_PRESERVE src0_sel:DWORD
 v_mov_b32 v1, exec_lo dst_sel:BYTE_0 dst_unused:UNUSED_PRESERVE src0_sel:DWORD
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
-// NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: ttmp12 register not available on this GPU
 // GFX9: v_mov_b32_sdwa v1, ttmp12 dst_sel:BYTE_0 dst_unused:UNUSED_PRESERVE src0_sel:DWORD ; encoding: [0xf9,0x02,0x02,0x7e,0x78,0x10,0x86,0x00]
 v_mov_b32_sdwa v1, ttmp12 dst_sel:BYTE_0 dst_unused:UNUSED_PRESERVE src0_sel:DWORD
 
@@ -743,12 +743,12 @@ v_add_f32 v0, exec_lo, vcc dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 s
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: not a valid operand.
 // NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: invalid operand for instruction
-// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: tba_lo register not available on this GPU
 v_add_f32 v0, v1, tba_lo dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:BYTE_2
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: not a valid operand.
 // NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: invalid operand for instruction
-// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: tma_hi register not available on this GPU
 v_add_f32 v0, v1, tma_hi dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:BYTE_2
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
@@ -762,22 +762,22 @@ v_cmp_eq_f32_sdwa vcc, s1, v2 src0_sel:WORD_1 src1_sel:BYTE_2
 v_cmp_eq_f32_sdwa vcc, v1, s22 src0_sel:WORD_1 src1_sel:BYTE_2
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
-// NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: ttmp[12:13] register not available on this GPU
 // GFX9: v_cmp_eq_f32_sdwa ttmp[12:13], v1, v2 src0_sel:WORD_1 src1_sel:BYTE_2 ; encoding: [0xf9,0x04,0x84,0x7c,0x01,0xf8,0x05,0x02]
 v_cmp_eq_f32_sdwa ttmp[12:13], v1, v2 src0_sel:WORD_1 src1_sel:BYTE_2
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
 // NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: operands are not valid for this GPU or mode
-// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: tba register not available on this GPU
 v_cmp_eq_f32_sdwa tba, v1, v2 src0_sel:WORD_1 src1_sel:BYTE_2
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
 // NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: operands are not valid for this GPU or mode
-// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOGFX9: :[[@LINE+1]]:{{[0-9]+}}: error: tma register not available on this GPU
 v_cmp_eq_f32_sdwa tma, v1, v2 src0_sel:WORD_1 src1_sel:BYTE_2
 
 // NOSICI: :[[@LINE+3]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported
-// NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: register not available on this GPU
+// NOVI: :[[@LINE+2]]:{{[0-9]+}}: error: ttmp15 register not available on this GPU
 // GFX9: v_cmp_eq_f32_sdwa vcc, v1, ttmp15 src0_sel:WORD_1 src1_sel:BYTE_2 ; encoding: [0xf9,0xf6,0x84,0x7c,0x01,0x00,0x05,0x82]
 v_cmp_eq_f32_sdwa vcc, v1, ttmp15 src0_sel:WORD_1 src1_sel:BYTE_2
 

--- a/llvm/test/MC/AMDGPU/xnack-mask.s
+++ b/llvm/test/MC/AMDGPU/xnack-mask.s
@@ -7,25 +7,25 @@
 // RUN: not llvm-mc -triple=amdgcn -mcpu=stoney -mattr=+xnack -show-encoding %s | FileCheck -check-prefix=XNACK %s
 
 s_mov_b64 xnack_mask, -1
-// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask register not available on this GPU
 // XNACK:    s_mov_b64 xnack_mask, -1 ; encoding: [0xc1,0x01,0xe8,0xbe]
 
 s_mov_b32 xnack_mask_lo, -1
-// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask_lo register not available on this GPU
 // XNACK:    s_mov_b32 xnack_mask_lo, -1 ; encoding: [0xc1,0x00,0xe8,0xbe]
 
 s_mov_b32 xnack_mask_hi, -1
-// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask_hi register not available on this GPU
 // XNACK:    s_mov_b32 xnack_mask_hi, -1 ; encoding: [0xc1,0x00,0xe9,0xbe]
 
 s_mov_b32 xnack_mask, -1
-// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask register not available on this GPU
 // XNACKERR: :[[@LINE-2]]:{{[0-9]+}}: error: invalid operand for instruction
 
 s_mov_b64 xnack_mask_lo, -1
-// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask_lo register not available on this GPU
 // XNACKERR: :[[@LINE-2]]:{{[0-9]+}}: error: invalid operand for instruction
 
 s_mov_b64 xnack_mask_hi, -1
-// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: register not available on this GPU
+// NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask_hi register not available on this GPU
 // XNACKERR: :[[@LINE-2]]:{{[0-9]+}}: error: invalid operand for instruction


### PR DESCRIPTION
Mention the names of unavailable registers in error messages to not make the diagnostics for execz/vccz less rich than it was.

Clean up unnecessary name qualifications while there.

Part of <https://github.com/llvm/llvm-project/issues/62629>.