### PR TITLE
LSV/test/AArch64: add missing lit.local.cfg; fix build

### DIFF
--- a/llvm/test/Transforms/LoadStoreVectorizer/AArch64/lit.local.cfg
+++ b/llvm/test/Transforms/LoadStoreVectorizer/AArch64/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "AArch64" in config.root.targets:
+    config.unsupported = True


### PR DESCRIPTION
Follow up on 199d6f2 (LSV: document hang reported in #37865) to fix the build when omitting the AArch64 target. Add the missing lit.local.cfg.