### PR TITLE
[AMDGPU][AsmParser][NFCI] All NamedIntOperands to be of the i32 type.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1017,9 +1017,8 @@ def SDWAVopcDst : BoolRC {
   let PrintMethod = "printVOPDst";
 }
 
-class NamedIntOperand<ValueType Type, string prefix, bit Optional = 1,
-                      string name = NAME>
-    : CustomOperand<Type, Optional, name> {
+class NamedIntOperand<string prefix, bit Optional = 1, string name = NAME>
+    : CustomOperand<i32, Optional, name> {
   string Prefix = prefix;
 
   let PredicateMethod =
@@ -1079,10 +1078,10 @@ class ArrayOperand0<string Id, string Name = NAME>
 let ImmTy = "ImmTyOffset" in
 def flat_offset : CustomOperand<i32, 1, "FlatOffset">;
 let PrintMethod = "printOffset" in
-def Offset : NamedIntOperand<i32, "offset">;
+def Offset : NamedIntOperand<"offset">;
 let Validator = "isUInt<8>" in {
-def Offset0 : NamedIntOperand<i32, "offset0">;
-def Offset1 : NamedIntOperand<i32, "offset1">;
+def Offset0 : NamedIntOperand<"offset0">;
+def Offset1 : NamedIntOperand<"offset1">;
 }
 
 def gds : NamedBitOperand<"gds", "GDS">;
@@ -1118,7 +1117,7 @@ def exp_vm : NamedBitOperand<"vm", "ExpVM">;
 def FORMAT : CustomOperand<i8>;
 
 let PrintInHex = 1 in
-def DMask : NamedIntOperand<i16, "dmask">;
+def DMask : NamedIntOperand<"dmask">;
 
 def Dim : CustomOperand<i8, /*optional=*/1>;
 
@@ -1139,24 +1138,24 @@ def dpp8 : CustomOperand<i32, 0, "DPP8">;
 def dpp_ctrl : CustomOperand<i32, 0, "DPPCtrl">;
 
 let DefaultValue = "0xf", PrintInHex = 1, AlwaysPrint = 1 in {
-def DppRowMask : NamedIntOperand<i32, "row_mask">;
-def DppBankMask : NamedIntOperand<i32, "bank_mask">;
+def DppRowMask : NamedIntOperand<"row_mask">;
+def DppBankMask : NamedIntOperand<"bank_mask">;
 }
-def DppBoundCtrl : NamedIntOperand<i1, "bound_ctrl"> {
+def DppBoundCtrl : NamedIntOperand<"bound_ctrl"> {
   let ConvertMethod = "[this] (int64_t &BC) -> bool { return convertDppBoundCtrl(BC); }";
   let PrintMethod = "printDppBoundCtrl";
 }
 
 let DecoderMethod = "decodeDpp8FI", PrintMethod = "printDppFI" in
-def Dpp8FI : NamedIntOperand<i32, "fi", 1, "DppFI">;
+def Dpp8FI : NamedIntOperand<"fi", 1, "DppFI">;
 let PrintMethod = "printDppFI" in
-def Dpp16FI : NamedIntOperand<i32, "fi", 1, "DppFI">;
+def Dpp16FI : NamedIntOperand<"fi", 1, "DppFI">;
 
 def blgp : CustomOperand<i32, 1, "BLGP">;
-def CBSZ : NamedIntOperand<i32, "cbsz"> {
+def CBSZ : NamedIntOperand<"cbsz"> {
   let Validator = "isUInt<3>";
 }
-def ABID : NamedIntOperand<i32, "abid"> {
+def ABID : NamedIntOperand<"abid"> {
   let Validator = "isUInt<4>";
 }
 def hwreg : CustomOperand<i32, 0, "Hwreg">;
@@ -1164,21 +1163,21 @@ def hwreg : CustomOperand<i32, 0, "Hwreg">;
 def exp_tgt : CustomOperand<i32, 0, "ExpTgt">;
 
 let AlwaysPrint = 1 in {
-def WaitVDST : NamedIntOperand<i8, "wait_vdst"> {
+def WaitVDST : NamedIntOperand<"wait_vdst"> {
   let Validator = "isUInt<4>";
 }
-def WaitEXP : NamedIntOperand<i8, "wait_exp"> {
+def WaitEXP : NamedIntOperand<"wait_exp"> {
   let Validator = "isUInt<3>";
 }
-def WaitVAVDst : NamedIntOperand<i8, "wait_va_vdst"> {
+def WaitVAVDst : NamedIntOperand<"wait_va_vdst"> {
   let Validator = "isUInt<4>";
 }
-def WaitVMVSrc : NamedIntOperand<i8, "wait_vm_vsrc"> {
+def WaitVMVSrc : NamedIntOperand<"wait_vm_vsrc"> {
   let Validator = "isUInt<1>";
 }
 } // End AlwaysPrint = 1
 
-def ByteSel : NamedIntOperand<i8, "byte_sel"> {
+def ByteSel : NamedIntOperand<"byte_sel"> {
   let Validator = "isUInt<2>";
 }
 

--- a/llvm/lib/Target/AMDGPU/SMInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SMInstructions.td
@@ -11,11 +11,11 @@ def smrd_offset_8 : ImmOperand<i32, "SMRDOffset8", 1>;
 let EncoderMethod = "getSMEMOffsetEncoding",
     DecoderMethod = "decodeSMEMOffset" in {
 def SMEMOffset : ImmOperand<i32, "SMEMOffset", 1>;
-def SMEMOffsetMod : NamedIntOperand<i32, "offset", 0> {
+def SMEMOffsetMod : NamedIntOperand<"offset", 0> {
   let AlwaysPrint = 1;
   let PrintInHex = 1;
 }
-def OptSMEMOffsetMod : NamedIntOperand<i32, "offset"> {
+def OptSMEMOffsetMod : NamedIntOperand<"offset"> {
   let ImmTy = SMEMOffsetMod.ImmTy;
   let PredicateMethod = SMEMOffsetMod.PredicateMethod;
   let PrintMethod = SMEMOffsetMod.PrintMethod;


### PR DESCRIPTION
There's no need for them to have different types.

Part of <https://github.com/llvm/llvm-project/issues/62629>.