### PR TITLE
[mlir] Unbreak msvc build. NFC.

### DIFF
--- a/mlir/unittests/Support/CyclicReplacerCacheTest.cpp
+++ b/mlir/unittests/Support/CyclicReplacerCacheTest.cpp
@@ -27,8 +27,8 @@ TEST(CachedCyclicReplacerTest, testNoRecursion) {
 TEST(CachedCyclicReplacerTest, testInPlaceRecursionPruneAnywhere) {
   // Replacer cycles through ints 0 -> 1 -> 2 -> 0 -> ...
   CachedCyclicReplacer<int, int> replacer(
-      /*replacer=*/[&](int n) { return replacer((n + 1) % 3); },
-      /*cycleBreaker=*/[&](int n) { return -1; });
+      /*replacer=*/[&replacer](int n) { return replacer((n + 1) % 3); },
+      /*cycleBreaker=*/[](int n) { return -1; });
 
   // Starting at 0.
   EXPECT_EQ(replacer(0), -1);


### PR DESCRIPTION
Since ec50f5828f25, compiling the unittests fail with 
```
mlir\unittests\Support\CyclicReplacerCacheTest.cpp(30,40): error C2326: 'auto CachedCyclicReplacerTest_testInPlaceRecursionPruneAnywhere_Test::TestBody::<lambda_1>::operator ()(int) const': function cannot access 'replacer'
```
I think this is legal, as calling a lambda recursively is legal as well, as long as the declarator's type does not depend on the lambda's type. Explicitly listing the captures unbreaks the build for msvc. While it compiles, IntelliSense still shows it as error (red squiggly line).

Alternative to #101021