### PR TITLE
[NFC][scf] Fix error in example for 'IndexSwitchOp'

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -1121,7 +1121,7 @@ def IndexSwitchOp : SCF_Op<"index_switch", [RecursiveMemoryEffects,
     Example:
 
     ```mlir
-    %0 = scf.index_switch %arg0 : index -> i32
+    %0 = scf.index_switch %arg0 -> i32
     case 2 {
       %1 = arith.constant 10 : i32
       scf.yield %1 : i32


### PR DESCRIPTION
Fixed error in the example: `error: custom op 'scf.index_switch' expected 'default'
    %0 = scf.index_switch %arg0 : index -> i32
`