### PR TITLE
[Docs] Fix sidebar link to renamed anchor #(forum-and-)mailing-list

### DIFF
--- a/flang/docs/_templates/indexsidebar.html
+++ b/flang/docs/_templates/indexsidebar.html
@@ -10,7 +10,7 @@
 <h3>Getting Involved</h3>
 <! TODO: Point links to website(flang.llvm.org) and not github once webpage comes up.>
 <ul class="want-points">
-    <li><a href="https://github.com/llvm/llvm-project/blob/main/flang/docs/GettingInvolved.md#mailing-lists">Mailing Lists</a></li>
+    <li><a href="https://github.com/llvm/llvm-project/blob/main/flang/docs/GettingInvolved.md#forum-and-mailing-lists">Forum and Mailing Lists</a></li>
     <li><a href="https://github.com/llvm/llvm-project/blob/main/flang/docs/GettingInvolved.md#chat">Slack</a></li>
     <li><a href="https://github.com/llvm/llvm-project/blob/main/flang/docs/GettingInvolved.md#calls">Calls</a></li>
 </ul>

--- a/llvm/docs/_templates/indexsidebar.html
+++ b/llvm/docs/_templates/indexsidebar.html
@@ -14,7 +14,7 @@
 <ul class="want-points">
     <li><a href="https://llvm.org/docs/Contributing.html">Contributing to LLVM</a></li>
     <li><a href="https://llvm.org/docs/HowToSubmitABug.html">Submitting Bug Reports</a></li>
-    <li><a href="https://llvm.org/docs/GettingInvolved.html#mailing-lists">Mailing Lists</a></li>
+    <li><a href="https://llvm.org/docs/GettingInvolved.html#forums-mailing-lists">Forums &amp; Mailing Lists</a></li>
     <li><a href="https://llvm.org/docs/GettingInvolved.html#irc">IRC</a></li>
     <li><a href="https://llvm.org/docs/GettingInvolved.html#meetups-and-social-events">Meetups and Social Events</a></li>
 </ul>


### PR DESCRIPTION
These was renamed in b4990ac33015200b74d830beaea2883d313ac16c and a749e3295df4aee18a0ad723875a6501f30ac744 without updating the link in the sidebar, which just link to the top of the page currently.