### PR TITLE
[flang] More support for anonymous parent components in struct constr…

### DIFF
--- a/flang/test/Semantics/structconst10.f90
+++ b/flang/test/Semantics/structconst10.f90
@@ -1,0 +1,25 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+module m1
+  type a1
+     integer ::x1=1
+  end type a1
+  type,extends(a1)::a2
+     integer ::x2=3
+  end type a2
+  type,extends(a2)::a3
+     integer   ::x3=3
+  end type a3
+end module m1
+
+program test
+  use m1
+  type(a3) v
+  !PORTABILITY: Whole parent component 'a2' in structure constructor should not be anonymous
+  v=a3(a2(x1=18,x2=6),x3=6)
+  !PORTABILITY: Whole parent component 'a1' in structure constructor should not be anonymous
+  v=a3(a1(x1=18),x2=6,x3=6)
+  !PORTABILITY: Whole parent component 'a2' in structure constructor should not be anonymous
+  !PORTABILITY: Whole parent component 'a1' in structure constructor should not be anonymous
+  v=a3(a2(a1(x1=18),x2=6),x3=6)
+  v=a3(a2=a2(a1=a1(x1=18),x2=6),x3=6) ! ok
+end


### PR DESCRIPTION
…uctors

A non-conforming extension to Fortran present in a couple other compilers is allowing a anonymous component in a structure constructor to initialize a parent (or greater ancestor) component.  This was working in this compiler only for direct parents, and only when the type was not use-associated.

Fixes https://github.com/llvm/llvm-project/issues/102557.