### PR TITLE
[AMDGPU][NFCI] Mark AGPRs and VGPRs with different flags in HWEncoding.

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
@@ -533,27 +533,13 @@ void AMDGPUMCCodeEmitter::getAVOperandEncoding(
   unsigned Reg = MI.getOperand(OpNo).getReg();
   unsigned Enc = MRI.getEncodingValue(Reg);
   unsigned Idx = Enc & AMDGPU::HWEncoding::REG_IDX_MASK;
-  bool IsVGPROrAGPR = Enc & AMDGPU::HWEncoding::IS_VGPR_OR_AGPR;
+  bool IsVGPROrAGPR =
+      Enc & (AMDGPU::HWEncoding::IS_VGPR | AMDGPU::HWEncoding::IS_AGPR);
 
   // VGPR and AGPR have the same encoding, but SrcA and SrcB operands of mfma
   // instructions use acc[0:1] modifier bits to distinguish. These bits are
   // encoded as a virtual 9th bit of the register for these operands.
-  bool IsAGPR = false;
-  if (MRI.getRegClass(AMDGPU::AGPR_32RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_64RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_96RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_128RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_160RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_192RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_224RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_256RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_288RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_320RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_352RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_384RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AReg_512RegClassID).contains(Reg) ||
-      MRI.getRegClass(AMDGPU::AGPR_LO16RegClassID).contains(Reg))
-    IsAGPR = true;
+  bool IsAGPR = Enc & AMDGPU::HWEncoding::IS_AGPR;
 
   Op = Idx | (IsVGPROrAGPR << 8) | (IsAGPR << 9);
 }
@@ -588,8 +574,9 @@ void AMDGPUMCCodeEmitter::getMachineOpValue(const MCInst &MI,
   if (MO.isReg()){
     unsigned Enc = MRI.getEncodingValue(MO.getReg());
     unsigned Idx = Enc & AMDGPU::HWEncoding::REG_IDX_MASK;
-    bool IsVGPR = Enc & AMDGPU::HWEncoding::IS_VGPR_OR_AGPR;
-    Op = Idx | (IsVGPR << 8);
+    bool IsVGPROrAGPR =
+        Enc & (AMDGPU::HWEncoding::IS_VGPR | AMDGPU::HWEncoding::IS_AGPR);
+    Op = Idx | (IsVGPROrAGPR << 8);
     return;
   }
   unsigned OpNo = &MO - MI.begin();
@@ -603,7 +590,7 @@ void AMDGPUMCCodeEmitter::getMachineOpValueT16(
   if (MO.isReg()) {
     unsigned Enc = MRI.getEncodingValue(MO.getReg());
     unsigned Idx = Enc & AMDGPU::HWEncoding::REG_IDX_MASK;
-    bool IsVGPR = Enc & AMDGPU::HWEncoding::IS_VGPR_OR_AGPR;
+    bool IsVGPR = Enc & AMDGPU::HWEncoding::IS_VGPR;
     Op = Idx | (IsVGPR << 8);
     return;
   }
@@ -651,7 +638,7 @@ void AMDGPUMCCodeEmitter::getMachineOpValueT16Lo128(
     uint16_t Encoding = MRI.getEncodingValue(MO.getReg());
     unsigned RegIdx = Encoding & AMDGPU::HWEncoding::REG_IDX_MASK;
     bool IsHi = Encoding & AMDGPU::HWEncoding::IS_HI;
-    bool IsVGPR = Encoding & AMDGPU::HWEncoding::IS_VGPR_OR_AGPR;
+    bool IsVGPR = Encoding & AMDGPU::HWEncoding::IS_VGPR;
     assert((!IsVGPR || isUInt<7>(RegIdx)) && "VGPR0-VGPR127 expected!");
     Op = (IsVGPR ? 0x100 : 0) | (IsHi ? 0x80 : 0) | RegIdx;
     return;

--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -369,8 +369,9 @@ enum : unsigned {
 namespace HWEncoding {
 enum : unsigned {
   REG_IDX_MASK = 0xff,
-  IS_VGPR_OR_AGPR = 1 << 8,
-  IS_HI = 1 << 9, // High 16-bit register.
+  IS_VGPR = 1 << 8,
+  IS_AGPR = 1 << 9,
+  IS_HI = 1 << 10, // High 16-bit register.
 };
 } // namespace HWEncoding
 

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
@@ -122,16 +122,17 @@ class SIRegisterTuples<list<SubRegIndex> Indices, RegisterClass RC,
 //===----------------------------------------------------------------------===//
 //  Declarations that describe the SI registers
 //===----------------------------------------------------------------------===//
-class SIReg <string n, bits<8> regIdx = 0, bit isAGPROrVGPR = 0,
-             bit isHi = 0> : Register<n> {
+class SIReg <string n, bits<8> regIdx = 0, bit isVGPR = 0,
+             bit isAGPR = 0, bit isHi = 0> : Register<n> {
   let Namespace = "AMDGPU";
 
   // These are generic helper values we use to form actual register
   // codes. They should not be assumed to match any particular register
   // encodings on any particular subtargets.
   let HWEncoding{7-0} = regIdx;
-  let HWEncoding{8} = isAGPROrVGPR;
-  let HWEncoding{9} = isHi;
+  let HWEncoding{8} = isVGPR;
+  let HWEncoding{9} = isAGPR;
+  let HWEncoding{10} = isHi;
 
   int Index = !cast<int>(regIdx);
 }
@@ -157,9 +158,9 @@ class SIRegisterClass <string n, list<ValueType> rTypes, int Align, dag rList>
 }
 
 multiclass SIRegLoHi16 <string n, bits<8> regIdx, bit ArtificialHigh = 1,
-                        bit isAGPROrVGPR = 0> {
-  def _LO16 : SIReg<n#".l", regIdx, isAGPROrVGPR>;
-  def _HI16 : SIReg<!if(ArtificialHigh, "", n#".h"), regIdx, isAGPROrVGPR,
+                        bit isVGPR = 0, bit isAGPR = 0> {
+  def _LO16 : SIReg<n#".l", regIdx, isVGPR, isAGPR>;
+  def _HI16 : SIReg<!if(ArtificialHigh, "", n#".h"), regIdx, isVGPR, isAGPR,
                     /* isHi */ 1> {
     let isArtificial = ArtificialHigh;
   }
@@ -169,7 +170,8 @@ multiclass SIRegLoHi16 <string n, bits<8> regIdx, bit ArtificialHigh = 1,
     let SubRegIndices = [lo16, hi16];
     let CoveredBySubRegs = !not(ArtificialHigh);
     let HWEncoding{7-0} = regIdx;
-    let HWEncoding{8} = isAGPROrVGPR;
+    let HWEncoding{8} = isVGPR;
+    let HWEncoding{9} = isAGPR;
 
     int Index = !cast<int>(regIdx);
   }
@@ -348,14 +350,16 @@ foreach Index = 0...105 in {
 // VGPR registers
 foreach Index = 0...255 in {
   defm VGPR#Index :
-    SIRegLoHi16 <"v"#Index, Index, 0, 1>,
+    SIRegLoHi16 <"v"#Index, Index, /* ArtificialHigh= */ 0,
+                 /* isVGPR= */ 1, /* isAGPR= */ 0>,
     DwarfRegNum<[!add(Index, 2560), !add(Index, 1536)]>;
 }
 
 // AccVGPR registers
 foreach Index = 0...255 in {
   defm AGPR#Index :
-      SIRegLoHi16 <"a"#Index, Index, 1, 1>,
+      SIRegLoHi16 <"a"#Index, Index, /* ArtificialHigh= */ 1,
+                   /* isVGPR= */ 0, /* isAGPR= */ 1>,
       DwarfRegNum<[!add(Index, 3072), !add(Index, 2048)]>;
 }
 


### PR DESCRIPTION
Simplifies checks for AGPRs and VGPRs and makes them more explicit and less fragile.