### PR TITLE
[MLIR][DLTI][Transform] Introduce transform.dlti.query - 2nd attempt

### DIFF
--- a/mlir/include/mlir/Dialect/DLTI/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/DLTI/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(TransformOps)
+
 add_mlir_dialect(DLTI dlti)
 add_mlir_doc(DLTIAttrs DLTIDialect Dialects/ -gen-dialect-doc)
 

--- a/mlir/include/mlir/Dialect/DLTI/DLTI.h
+++ b/mlir/include/mlir/Dialect/DLTI/DLTI.h
@@ -22,6 +22,19 @@ namespace detail {
 class DataLayoutEntryAttrStorage;
 } // namespace detail
 } // namespace mlir
+namespace mlir {
+namespace dlti {
+/// Find the first DataLayoutSpec associated to `op`, via either the
+/// DataLayoutOpInterface, a method on ModuleOp, or an attribute implementing
+/// the interface, on `op` and else on `op`'s ancestors in turn.
+DataLayoutSpecInterface getDataLayoutSpec(Operation *op);
+
+/// Find the first TargetSystemSpec associated to `op`, via either the
+/// DataLayoutOpInterface, a method on ModuleOp, or an attribute implementing
+/// the interface, on `op` and else on `op`'s ancestors in turn.
+TargetSystemSpecInterface getTargetSystemSpec(Operation *op);
+} // namespace dlti
+} // namespace mlir
 
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/DLTI/DLTIAttrs.h.inc"

--- a/mlir/include/mlir/Dialect/DLTI/TransformOps/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/DLTI/TransformOps/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(LLVM_TARGET_DEFINITIONS DLTITransformOps.td)
+mlir_tablegen(DLTITransformOps.h.inc -gen-op-decls)
+mlir_tablegen(DLTITransformOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRDLTITransformOpsIncGen)
+
+add_mlir_doc(DLTITransformOps DLTITransformOps Dialects/ -gen-op-doc)

--- a/mlir/include/mlir/Dialect/DLTI/TransformOps/DLTITransformOps.h
+++ b/mlir/include/mlir/Dialect/DLTI/TransformOps/DLTITransformOps.h
@@ -1,0 +1,38 @@
+//===- DLTITransformOps.h - DLTI transform ops ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_DLTI_TRANSFORMOPS_DLTITRANSFORMOPS_H
+#define MLIR_DIALECT_DLTI_TRANSFORMOPS_DLTITRANSFORMOPS_H
+
+#include "mlir/Dialect/Transform/IR/TransformAttrs.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformTypes.h"
+#include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
+
+namespace mlir {
+namespace transform {
+class QueryOp;
+} // namespace transform
+} // namespace mlir
+
+namespace mlir {
+class DialectRegistry;
+
+namespace dlti {
+void registerTransformDialectExtension(DialectRegistry &registry);
+} // namespace dlti
+} // namespace mlir
+
+////===----------------------------------------------------------------------===//
+//// DLTI Transform Operations
+////===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "mlir/Dialect/DLTI/TransformOps/DLTITransformOps.h.inc"
+
+#endif // MLIR_DIALECT_DLTI_TRANSFORMOPS_DLTITRANSFORMOPS_H

--- a/mlir/include/mlir/Dialect/DLTI/TransformOps/DLTITransformOps.td
+++ b/mlir/include/mlir/Dialect/DLTI/TransformOps/DLTITransformOps.td
@@ -1,0 +1,61 @@
+//===- DLTITransformOps.td - DLTI transform ops ------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DLTI_TRANSFORM_OPS
+#define DLTI_TRANSFORM_OPS
+
+include "mlir/Dialect/Transform/IR/TransformDialect.td"
+include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
+include "mlir/Dialect/Transform/IR/TransformTypes.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/OpBase.td"
+
+def QueryOp : Op<Transform_Dialect, "dlti.query", [
+  TransformOpInterface, TransformEachOpTrait,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Return attribute (as param) associated to key via DTLI";
+  let description = [{
+    This op queries data layout and target information associated to payload
+    IR by way of the DLTI dialect. A lookup is performed for the given `key`
+    at the `target` op, with the DLTI dialect determining which interfaces and
+    attributes are consulted - first checking `target` and then its ancestors.
+
+    When only `key` is provided, the lookup occurs with respect to the data
+    layout specification of DLTI. When `device` is provided, the lookup occurs
+    with respect to DLTI's target device specifications associated to a DLTI
+    system device specification.
+
+    #### Return modes
+
+    When succesful, the result, `associated_attr`, associates one attribute as a
+    param for each op in `target`'s payload.
+
+    If the lookup fails - as DLTI specifications or entries with the right
+    names are missing (i.e. the values of `device` and `key`) - a definite
+    failure is returned.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target,
+                       OptionalAttr<StrAttr>:$device,
+                       StrAttr:$key);
+  let results = (outs TransformParamTypeInterface:$associated_attr);
+  let assemblyFormat =
+      "(`:``:` $device^ `:``:`)? $key `at` $target attr-dict `:`"
+      "functional-type(operands, results)";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        TransformState &state);
+  }];
+}
+
+#endif // DLTI_TRANSFORM_OPS

--- a/mlir/include/mlir/InitAllExtensions.h
+++ b/mlir/include/mlir/InitAllExtensions.h
@@ -25,6 +25,7 @@
 #include "mlir/Conversion/UBToLLVM/UBToLLVM.h"
 #include "mlir/Dialect/Affine/TransformOps/AffineTransformOps.h"
 #include "mlir/Dialect/Bufferization/TransformOps/BufferizationTransformOps.h"
+#include "mlir/Dialect/DLTI/TransformOps/DLTITransformOps.h"
 #include "mlir/Dialect/Func/Extensions/AllExtensions.h"
 #include "mlir/Dialect/Func/TransformOps/FuncTransformOps.h"
 #include "mlir/Dialect/GPU/TransformOps/GPUTransformOps.h"
@@ -69,6 +70,7 @@ inline void registerAllExtensions(DialectRegistry &registry) {
   // Register all transform dialect extensions.
   affine::registerTransformDialectExtension(registry);
   bufferization::registerTransformDialectExtension(registry);
+  dlti::registerTransformDialectExtension(registry);
   func::registerTransformDialectExtension(registry);
   gpu::registerTransformDialectExtension(registry);
   linalg::registerTransformDialectExtension(registry);

--- a/mlir/lib/Dialect/DLTI/CMakeLists.txt
+++ b/mlir/lib/Dialect/DLTI/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(TransformOps)
 add_mlir_dialect_library(MLIRDLTIDialect
   DLTI.cpp
   Traits.cpp

--- a/mlir/lib/Dialect/DLTI/DLTI.cpp
+++ b/mlir/lib/Dialect/DLTI/DLTI.cpp
@@ -393,6 +393,41 @@ TargetSystemSpecAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 // DLTIDialect
 //===----------------------------------------------------------------------===//
 
+DataLayoutSpecInterface dlti::getDataLayoutSpec(Operation *op) {
+  DataLayoutSpecInterface dlSpec = nullptr;
+
+  for (Operation *cur = op; cur && !dlSpec; cur = cur->getParentOp()) {
+    if (auto dataLayoutOp = dyn_cast<DataLayoutOpInterface>(cur))
+      dlSpec = dataLayoutOp.getDataLayoutSpec();
+    else if (auto moduleOp = dyn_cast<ModuleOp>(cur))
+      dlSpec = moduleOp.getDataLayoutSpec();
+    else
+      for (NamedAttribute attr : cur->getAttrs())
+        if ((dlSpec = llvm::dyn_cast<DataLayoutSpecInterface>(attr.getValue())))
+          break;
+  }
+
+  return dlSpec;
+}
+
+TargetSystemSpecInterface dlti::getTargetSystemSpec(Operation *op) {
+  TargetSystemSpecInterface sysSpec = nullptr;
+
+  for (Operation *cur = op; cur && !sysSpec; cur = cur->getParentOp()) {
+    if (auto dataLayoutOp = dyn_cast<DataLayoutOpInterface>(cur))
+      sysSpec = dataLayoutOp.getTargetSystemSpec();
+    else if (auto moduleOp = dyn_cast<ModuleOp>(cur))
+      sysSpec = moduleOp.getTargetSystemSpec();
+    else
+      for (NamedAttribute attr : cur->getAttrs())
+        if ((sysSpec =
+                 llvm::dyn_cast<TargetSystemSpecInterface>(attr.getValue())))
+          break;
+  }
+
+  return sysSpec;
+}
+
 constexpr const StringLiteral mlir::DLTIDialect::kDataLayoutAttrName;
 constexpr const StringLiteral mlir::DLTIDialect::kDataLayoutEndiannessKey;
 constexpr const StringLiteral mlir::DLTIDialect::kDataLayoutEndiannessBig;

--- a/mlir/lib/Dialect/DLTI/TransformOps/CMakeLists.txt
+++ b/mlir/lib/Dialect/DLTI/TransformOps/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_mlir_dialect_library(MLIRDLTITransformOps
+  DLTITransformOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/DLTI/TransformOps
+
+  DEPENDS
+  MLIRDLTITransformOpsIncGen
+  MLIRDLTIDialect
+
+  LINK_LIBS PUBLIC
+  MLIRDLTIDialect
+  MLIRSideEffectInterfaces
+  MLIRTransformDialect
+  )

--- a/mlir/lib/Dialect/DLTI/TransformOps/DLTITransformOps.cpp
+++ b/mlir/lib/Dialect/DLTI/TransformOps/DLTITransformOps.cpp
@@ -1,0 +1,96 @@
+
+//===- DLTITransformOps.cpp - Implementation of DLTI transform ops --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/DLTI/TransformOps/DLTITransformOps.h"
+
+#include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
+#include "mlir/Dialect/Transform/Utils/Utils.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+
+using namespace mlir;
+using namespace mlir::transform;
+
+#define DEBUG_TYPE "dlti-transforms"
+
+//===----------------------------------------------------------------------===//
+// QueryOp
+//===----------------------------------------------------------------------===//
+
+void transform::QueryOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  onlyReadsHandle(getTargetMutable(), effects);
+  producesHandle(getOperation()->getOpResults(), effects);
+  onlyReadsPayload(effects);
+}
+
+DiagnosedSilenceableFailure transform::QueryOp::applyToOne(
+    transform::TransformRewriter &rewriter, Operation *target,
+    transform::ApplyToEachResultList &results, TransformState &state) {
+  StringAttr deviceId = getDeviceAttr();
+  StringAttr key = getKeyAttr();
+
+  DataLayoutEntryInterface entry;
+  if (deviceId) {
+    TargetSystemSpecInterface sysSpec = dlti::getTargetSystemSpec(target);
+    if (!sysSpec)
+      return mlir::emitDefiniteFailure(target->getLoc())
+             << "no target system spec associated to: " << target;
+
+    if (auto targetSpec = sysSpec.getDeviceSpecForDeviceID(deviceId))
+      entry = targetSpec->getSpecForIdentifier(key);
+    else
+      return mlir::emitDefiniteFailure(target->getLoc())
+             << "no " << deviceId << " target device spec found";
+  } else {
+    DataLayoutSpecInterface dlSpec = dlti::getDataLayoutSpec(target);
+    if (!dlSpec)
+      return mlir::emitDefiniteFailure(target->getLoc())
+             << "no data layout spec associated to: " << target;
+
+    entry = dlSpec.getSpecForIdentifier(key);
+  }
+
+  if (!entry)
+    return mlir::emitDefiniteFailure(target->getLoc())
+           << "no DLTI entry for key: " << key;
+
+  results.push_back(entry.getValue());
+
+  return DiagnosedSilenceableFailure::success();
+}
+
+//===----------------------------------------------------------------------===//
+// Transform op registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+class DLTITransformDialectExtension
+    : public transform::TransformDialectExtension<
+          DLTITransformDialectExtension> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DLTITransformDialectExtension)
+
+  using Base::Base;
+
+  void init() {
+    registerTransformOps<
+#define GET_OP_LIST
+#include "mlir/Dialect/DLTI/TransformOps/DLTITransformOps.cpp.inc"
+        >();
+  }
+};
+} // namespace
+
+#define GET_OP_CLASSES
+#include "mlir/Dialect/DLTI/TransformOps/DLTITransformOps.cpp.inc"
+
+void mlir::dlti::registerTransformDialectExtension(DialectRegistry &registry) {
+  registry.addExtensions<DLTITransformDialectExtension>();
+}

--- a/mlir/test/Dialect/DLTI/query.mlir
+++ b/mlir/test/Dialect/DLTI/query.mlir
@@ -1,0 +1,296 @@
+// RUN: mlir-opt -transform-interpreter -canonicalize -split-input-file -verify-diagnostics %s | FileCheck %s
+
+// expected-remark @below {{associated attr 42 : i32}}
+module attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 42 : i32>>} {
+  func.func private @f() 
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %funcs = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %module = transform.get_parent_op %funcs : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query "test.id" at %module : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %module : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 42 : i32>>} {
+  // expected-remark @below {{associated attr 24 : i32}}
+  func.func private @f() attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 24 : i32>>}
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %funcs = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query "test.id" at %funcs : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %funcs : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// expected-remark @below {{associated attr 42 : i32}}
+module attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 42 : i32>>} {
+  func.func private @f() attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 24 : i32>>}
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %funcs = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %module = transform.get_parent_op %funcs : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query "test.id" at %module : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %module : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 42 : i32>>} {
+  func.func @matmul_tensors(
+    %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<?x?xf32>)
+      -> tensor<?x?xf32> {
+    // expected-remark @below {{associated attr 42 : i32}}
+    %0 = linalg.matmul  ins(%arg0, %arg1: tensor<?x?xf32>, tensor<?x?xf32>)
+                       outs(%arg2: tensor<?x?xf32>)
+      -> tensor<?x?xf32>
+    return %0 : tensor<?x?xf32>
+  }
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query "test.id" at %matmul : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %matmul : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 42 : i32>>} {
+  func.func @matmul_tensors(
+    %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<?x?xf32>)
+      -> tensor<?x?xf32> attributes {test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 24 : i32>>} {
+    // expected-remark @below {{associated attr 24 : i32}}
+    %0 = linalg.matmul  ins(%arg0, %arg1: tensor<?x?xf32>, tensor<?x?xf32>)
+                       outs(%arg2: tensor<?x?xf32>)
+      -> tensor<?x?xf32>
+    return %0 : tensor<?x?xf32>
+  }
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query "test.id" at %matmul : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %matmul : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// expected-remark @below {{associated attr 42 : i32}}
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 42 : i32>>>} {
+  func.func private @f()
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %module = transform.get_parent_op %func : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query ::"CPU"::"test.id" at %module : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %module : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 42 : i32>>,
+                                                         "GPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 43 : i32>>>} {
+  // expected-remark @below {{associated attr 43 : i32}}
+  func.func private @f() 
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query ::"GPU"::"test.id" at %func : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %func : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 42 : i32>>,
+                                                         "GPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 43 : i32>>>} {
+  // expected-remark @below {{associated attr 24 : i32}}
+  func.func private @f() attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 24 : i32>>> }
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query ::"CPU"::"test.id" at %func : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %func : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"cache::L1::size_in_bytes", 65536 : i32>,
+                                                                                         #dlti.dl_entry<"cache::L1d::size_in_bytes", 32768 : i32>>> } {
+  // expected-remark @below {{L1::size_in_bytes 65536 : i32}}
+  // expected-remark @below {{L1d::size_in_bytes 32768 : i32}}
+  func.func private @f()
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %l1_size = transform.dlti.query ::"CPU"::"cache::L1::size_in_bytes" at %func : (!transform.any_op) -> !transform.param<i32>
+    %l1d_size = transform.dlti.query ::"CPU"::"cache::L1d::size_in_bytes" at %func : (!transform.any_op) -> !transform.param<i32>
+    transform.debug.emit_param_as_remark %l1_size, "L1::size_in_bytes" at %func : !transform.param<i32>, !transform.any_op
+    transform.debug.emit_param_as_remark %l1d_size, "L1d::size_in_bytes" at %func : !transform.param<i32>, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": 
+    #dlti.target_device_spec<#dlti.dl_entry<"inner_most_tile_size", 42 : i32>>>} {
+  // CHECK-LABEL: func @matmul_tensors
+  func.func @matmul_tensors(
+    %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<?x?xf32>)
+      -> tensor<?x?xf32> {
+    // CHECK: scf.for {{.*}} to {{.*}} step {{.*}}42
+    // CHECK:   tensor.extract_slice
+    // CHECK:   linalg.matmul 
+    // CHECK:   tensor.insert_slice
+    // CHECK:   scf.yield
+    %0 = linalg.matmul ins(%arg0, %arg1: tensor<?x?xf32>, tensor<?x?xf32>)
+                       outs(%arg2: tensor<?x?xf32>)
+      -> tensor<?x?xf32>
+    // CHECK: return
+    return %0 : tensor<?x?xf32>
+  }
+}
+
+// Demonstrates obtaining transform op parameters from DLTI attributes and directly putting them to use.
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %tile_size = transform.dlti.query ::"CPU"::"inner_most_tile_size" at %matmul : (!transform.any_op) -> !transform.param<i32>
+    transform.structured.tile_using_for %matmul tile_sizes [%tile_size] : (!transform.any_op, !transform.param<i32>) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 42 : i32>>,
+                                                         "GPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 43 : i32>>>} {
+  // expected-error @below {{no "NPU" target device spec found}}
+  func.func private @f() 
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query ::"NPU"::"test.id" at %func : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %func : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 42 : i32>>,
+                                                         "GPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 43 : i32>>>} {
+  // expected-error @below {{no DLTI entry for key: "unspecified"}}
+  func.func private @f() 
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query ::"CPU"::"unspecified" at %func : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %func : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.target_system_spec<"CPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 42 : i32>>,
+                                                         "GPU": #dlti.target_device_spec<#dlti.dl_entry<"test.id", 43 : i32>>>} {
+  // expected-error @below {{no data layout spec associated to: }}
+  func.func private @f() 
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query "test.id" at %func : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %func : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 42 : i32>>} {
+  // expected-error @below {{no target system spec associated to: }}
+  func.func private @f() 
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query ::"CPU"::"test.id" at %func : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %func : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module {
+  // expected-error @below {{no target system spec associated to: }}
+  func.func private @f() 
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %func = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    %param = transform.dlti.query ::"CPU"::"test.id" at %func : (!transform.any_op) -> !transform.any_param
+    transform.debug.emit_param_as_remark %param, "associated attr" at %func : !transform.any_param, !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+module attributes { test.dlti = #dlti.dl_spec<#dlti.dl_entry<"test.id", 42 : i32>>} {
+  func.func private @f()
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg: !transform.any_op) {
+    %funcs = transform.structured.match ops{["func.func"]} in %arg : (!transform.any_op) -> !transform.any_op
+    // expected-error @below {{expected the type of the parameter attribute ('i32') to match the parameter type ('i64')}}
+    %param = transform.dlti.query "test.id" at %funcs : (!transform.any_op) -> !transform.param<i64>
+    transform.debug.emit_param_as_remark %param, "associated attr" at %funcs : !transform.param<i64>, !transform.any_op
+    transform.yield
+  }
+}


### PR DESCRIPTION
This transform op makes it possible to query attributes associated to IR
by means of the DLTI dialect.

The op takes both a `key` and a target `op` to perform the query at.
Facility functions automatically find the closest ancestor op which
defines the appropriate DLTI interface or has an attribute implementing
a DLTI interface. By default the lookup uses the data layout interfaces
of DLTI. If the optional `device` parameter is provided, the lookup
happens with respect to the interfaces for TargetSystemSpec and
TargetDeviceSpec.

This op uses new free-standing functions in the `dlti` namespace to not
only look up specifications via the `DataLayoutSpecOpInterface` and on
`ModuleOp`s but also on any ancestor op that has an appropriate DLTI
attribute.