### PR TITLE
[libc++] re-enable clang-tidy in the CI and fix any issues

### DIFF
--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -219,7 +219,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void notify_all() const noexcept { std::__atomic_notify_all(*this); }
 
 protected:
-  typedef _Tp _Aligned_Tp __attribute__((aligned(required_alignment)));
+  using _Aligned_Tp [[__gnu__::__aligned__(required_alignment)]] = _Tp;
   _Aligned_Tp* __ptr_;
 
   _LIBCPP_HIDE_FROM_ABI __atomic_ref_base(_Tp& __obj) : __ptr_(std::addressof(__obj)) {}

--- a/libcxx/include/__bit/rotate.h
+++ b/libcxx/include/__bit/rotate.h
@@ -26,31 +26,31 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp __rotl(_Tp __x, int __s) _NOEXCEPT {
   static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotl requires an unsigned integer type");
-  const int __N = numeric_limits<_Tp>::digits;
-  int __r       = __s % __N;
+  const int __n = numeric_limits<_Tp>::digits;
+  int __r       = __s % __n;
 
   if (__r == 0)
     return __x;
 
   if (__r > 0)
-    return (__x << __r) | (__x >> (__N - __r));
+    return (__x << __r) | (__x >> (__n - __r));
 
-  return (__x >> -__r) | (__x << (__N + __r));
+  return (__x >> -__r) | (__x << (__n + __r));
 }
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp __rotr(_Tp __x, int __s) _NOEXCEPT {
   static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotr requires an unsigned integer type");
-  const int __N = numeric_limits<_Tp>::digits;
-  int __r       = __s % __N;
+  const int __n = numeric_limits<_Tp>::digits;
+  int __r       = __s % __n;
 
   if (__r == 0)
     return __x;
 
   if (__r > 0)
-    return (__x >> __r) | (__x << (__N - __r));
+    return (__x >> __r) | (__x << (__n - __r));
 
-  return (__x << -__r) | (__x >> (__N + __r));
+  return (__x << -__r) | (__x >> (__n + __r));
 }
 
 #if _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__chrono/zoned_time.h
+++ b/libcxx/include/__chrono/zoned_time.h
@@ -201,8 +201,8 @@ template <class _TimeZonePtrOrName, class _Duration>
 zoned_time(_TimeZonePtrOrName&&, local_time<_Duration>, choose = choose::earliest)
     -> zoned_time<common_type_t<_Duration, seconds>, __time_zone_representation<_TimeZonePtrOrName>>;
 
-template <class _Duration, class _TimeZonePtrOrName, class TimeZonePtr2>
-zoned_time(_TimeZonePtrOrName&&, zoned_time<_Duration, TimeZonePtr2>, choose = choose::earliest)
+template <class _Duration, class _TimeZonePtrOrName, class _TimeZonePtr2>
+zoned_time(_TimeZonePtrOrName&&, zoned_time<_Duration, _TimeZonePtr2>, choose = choose::earliest)
     -> zoned_time<common_type_t<_Duration, seconds>, __time_zone_representation<_TimeZonePtrOrName>>;
 
 using zoned_seconds = zoned_time<seconds>;

--- a/libcxx/include/__format/format_context.h
+++ b/libcxx/include/__format/format_context.h
@@ -132,6 +132,7 @@ private:
       : __out_it_(std::move(__out_it)), __args_(__args) {}
 #  endif
 
+public:
   basic_format_context(const basic_format_context&)            = delete;
   basic_format_context& operator=(const basic_format_context&) = delete;
 };

--- a/libcxx/include/__memory_resource/polymorphic_allocator.h
+++ b/libcxx/include/__memory_resource/polymorphic_allocator.h
@@ -174,13 +174,15 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI memory_resource* resource() const noexcept { return __res_; }
 
-  friend bool operator==(const polymorphic_allocator& __lhs, const polymorphic_allocator& __rhs) noexcept {
+  _LIBCPP_HIDE_FROM_ABI friend bool
+  operator==(const polymorphic_allocator& __lhs, const polymorphic_allocator& __rhs) noexcept {
     return *__lhs.resource() == *__rhs.resource();
   }
 
 #  if _LIBCPP_STD_VER <= 17
   // This overload is not specified, it was added due to LWG3683.
-  friend bool operator!=(const polymorphic_allocator& __lhs, const polymorphic_allocator& __rhs) noexcept {
+  _LIBCPP_HIDE_FROM_ABI friend bool
+  operator!=(const polymorphic_allocator& __lhs, const polymorphic_allocator& __rhs) noexcept {
     return *__lhs.resource() != *__rhs.resource();
   }
 #  endif

--- a/libcxx/include/__mutex/unique_lock.h
+++ b/libcxx/include/__mutex/unique_lock.h
@@ -84,16 +84,16 @@ public:
     return *this;
   }
 
-  void lock();
-  bool try_lock();
+  _LIBCPP_HIDE_FROM_ABI void lock();
+  _LIBCPP_HIDE_FROM_ABI bool try_lock();
 
   template <class _Rep, class _Period>
-  bool try_lock_for(const chrono::duration<_Rep, _Period>& __d);
+  _LIBCPP_HIDE_FROM_ABI bool try_lock_for(const chrono::duration<_Rep, _Period>& __d);
 
   template <class _Clock, class _Duration>
-  bool try_lock_until(const chrono::time_point<_Clock, _Duration>& __t);
+  _LIBCPP_HIDE_FROM_ABI bool try_lock_until(const chrono::time_point<_Clock, _Duration>& __t);
 
-  void unlock();
+  _LIBCPP_HIDE_FROM_ABI void unlock();
 
   _LIBCPP_HIDE_FROM_ABI void swap(unique_lock& __u) _NOEXCEPT {
     std::swap(__m_, __u.__m_);
@@ -114,7 +114,7 @@ public:
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(unique_lock);
 
 template <class _Mutex>
-void unique_lock<_Mutex>::lock() {
+_LIBCPP_HIDE_FROM_ABI void unique_lock<_Mutex>::lock() {
   if (__m_ == nullptr)
     __throw_system_error(EPERM, "unique_lock::lock: references null mutex");
   if (__owns_)
@@ -124,7 +124,7 @@ void unique_lock<_Mutex>::lock() {
 }
 
 template <class _Mutex>
-bool unique_lock<_Mutex>::try_lock() {
+_LIBCPP_HIDE_FROM_ABI bool unique_lock<_Mutex>::try_lock() {
   if (__m_ == nullptr)
     __throw_system_error(EPERM, "unique_lock::try_lock: references null mutex");
   if (__owns_)
@@ -135,7 +135,7 @@ bool unique_lock<_Mutex>::try_lock() {
 
 template <class _Mutex>
 template <class _Rep, class _Period>
-bool unique_lock<_Mutex>::try_lock_for(const chrono::duration<_Rep, _Period>& __d) {
+_LIBCPP_HIDE_FROM_ABI bool unique_lock<_Mutex>::try_lock_for(const chrono::duration<_Rep, _Period>& __d) {
   if (__m_ == nullptr)
     __throw_system_error(EPERM, "unique_lock::try_lock_for: references null mutex");
   if (__owns_)
@@ -146,7 +146,7 @@ bool unique_lock<_Mutex>::try_lock_for(const chrono::duration<_Rep, _Period>& __
 
 template <class _Mutex>
 template <class _Clock, class _Duration>
-bool unique_lock<_Mutex>::try_lock_until(const chrono::time_point<_Clock, _Duration>& __t) {
+_LIBCPP_HIDE_FROM_ABI bool unique_lock<_Mutex>::try_lock_until(const chrono::time_point<_Clock, _Duration>& __t) {
   if (__m_ == nullptr)
     __throw_system_error(EPERM, "unique_lock::try_lock_until: references null mutex");
   if (__owns_)
@@ -156,7 +156,7 @@ bool unique_lock<_Mutex>::try_lock_until(const chrono::time_point<_Clock, _Durat
 }
 
 template <class _Mutex>
-void unique_lock<_Mutex>::unlock() {
+_LIBCPP_HIDE_FROM_ABI void unique_lock<_Mutex>::unlock() {
   if (!__owns_)
     __throw_system_error(EPERM, "unique_lock::unlock: not locked");
   __m_->unlock();

--- a/libcxx/include/memory_resource
+++ b/libcxx/include/memory_resource
@@ -72,7 +72,6 @@ namespace std::pmr {
 #  include <limits>
 #  include <mutex>
 #  include <new>
-#  include <stdexcept>
 #  include <tuple>
 #endif
 

--- a/libcxx/modules/std/mdspan.inc
+++ b/libcxx/modules/std/mdspan.inc
@@ -15,6 +15,11 @@ export namespace std {
   // [mdspan.extents.dextents], alias template dextents
   using std::dextents;
 
+#  if _LIBCPP_STD_VER >= 26
+  // [mdspan.extents.dims]
+  using std::dims;
+#  endif // _LIBCPP_STD_VER >= 26
+
   // [mdspan.layout], layout mapping
   using std::layout_left;
   using std::layout_right;

--- a/libcxx/modules/std/new.inc
+++ b/libcxx/modules/std/new.inc
@@ -27,11 +27,13 @@ export namespace std {
 
   // [ptr.launder], pointer optimization barrier
   using std::launder;
-#if 0
+#if _LIBCPP_STD_VER >= 17
+#  if defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
   // [hardware.interference], hardware interference size
   using std::hardware_constructive_interference_size;
   using std::hardware_destructive_interference_size;
-#endif
+#  endif
+#endif // _LIBCPP_STD_VER >= 17
 } // namespace std
 
 export {

--- a/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
+++ b/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 # Note it has not been tested whether version 11 works.
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/test.cpp" "
 #include <version>
-#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12
+#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 11
   # error The libstdc++ version is too old.
 #endif
 int main(){}
@@ -83,7 +83,7 @@ try_compile(HAS_NEWER_STANDARD_LIBRARY
 
 if(NOT HAS_NEWER_STANDARD_LIBRARY)
   message(STATUS "Clang-tidy tests are disabled due to using "
-                 "stdlibc++ older than version 12")
+                 "stdlibc++ older than version 11")
   return()
 endif()
 message(STATUS "Clang-tidy tests are enabled.")

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -77,8 +77,10 @@ header_exportable_declarations::header_exportable_declarations(
 
   list = Options.get("ExtraDeclarations");
   if (list)
-    for (auto decl : std::views::split(*list, ' '))
-      std::cout << "using ::" << std::string_view{decl.data(), decl.size()} << ";\n";
+    for (auto decl : std::views::split(*list, ' ')) {
+      auto common = decl | std::views::common;
+      std::cout << "using ::" << std::string{common.begin(), common.end()} << ";\n";
+    }
 }
 
 header_exportable_declarations::~header_exportable_declarations() {


### PR DESCRIPTION
It looks like we've accidentally disabled clang-tidy in the CI. This re-enables it and fixes the issues accumulated while it was disabled.
