### PR TITLE
[libc] Fix CFP long double and add tests

### DIFF
--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -526,8 +526,8 @@ clinger_fast_path(ExpandedFloat<T> init_num,
   T float_mantissa;
   if constexpr (cpp::is_same_v<StorageType, UInt<128>>) {
     float_mantissa =
-        (static_cast<T>(uint64_t(mantissa)) * static_cast<T>(0x1.0p64)) +
-        static_cast<T>(uint64_t(mantissa >> 64));
+        (static_cast<T>(uint64_t(mantissa >> 64)) * static_cast<T>(0x1.0p64)) +
+        static_cast<T>(uint64_t(mantissa));
   } else {
     float_mantissa = static_cast<T>(mantissa);
   }
@@ -591,7 +591,7 @@ clinger_fast_path(ExpandedFloat<T> init_num,
   }
 
   ExpandedFloat<T> output;
-  output.mantissa = result.get_mantissa();
+  output.mantissa = result.get_explicit_mantissa();
   output.exponent = result.get_biased_exponent();
   return output;
 }

--- a/libc/test/src/__support/str_to_double_test.cpp
+++ b/libc/test/src/__support/str_to_double_test.cpp
@@ -5,21 +5,21 @@ namespace LIBC_NAMESPACE_DECL {
 using LlvmLibcStrToDblTest = LlvmLibcStrToFloatTest<double>;
 
 TEST_F(LlvmLibcStrToDblTest, ClingerFastPathFloat64Simple) {
-  clinger_fast_path_test(123, 0, 0xEC00000000000, 1029);
-  clinger_fast_path_test(1234567890123456, 1, 0x5ee2a2eb5a5c0, 1076);
-  clinger_fast_path_test(1234567890, -10, 0xf9add3739635f, 1019);
+  clinger_fast_path_test(123, 0, 0x1EC00000000000, 1029);
+  clinger_fast_path_test(1234567890123456, 1, 0x15ee2a2eb5a5c0, 1076);
+  clinger_fast_path_test(1234567890, -10, 0x1f9add3739635f, 1019);
 }
 
 TEST_F(LlvmLibcStrToDblTest, ClingerFastPathFloat64ExtendedExp) {
-  clinger_fast_path_test(1, 30, 0x93e5939a08cea, 1122);
-  clinger_fast_path_test(1, 37, 0xe17b84357691b, 1145);
+  clinger_fast_path_test(1, 30, 0x193e5939a08cea, 1122);
+  clinger_fast_path_test(1, 37, 0x1e17b84357691b, 1145);
   clinger_fast_path_fails_test(10, 37);
   clinger_fast_path_fails_test(1, 100);
 }
 
 TEST_F(LlvmLibcStrToDblTest, ClingerFastPathFloat64NegativeExp) {
-  clinger_fast_path_test(1, -10, 0xb7cdfd9d7bdbb, 989);
-  clinger_fast_path_test(1, -20, 0x79ca10c924223, 956);
+  clinger_fast_path_test(1, -10, 0x1b7cdfd9d7bdbb, 989);
+  clinger_fast_path_test(1, -20, 0x179ca10c924223, 956);
   clinger_fast_path_fails_test(1, -25);
 }
 

--- a/libc/test/src/__support/str_to_float_test.cpp
+++ b/libc/test/src/__support/str_to_float_test.cpp
@@ -6,21 +6,21 @@ namespace LIBC_NAMESPACE_DECL {
 using LlvmLibcStrToFltTest = LlvmLibcStrToFloatTest<float>;
 
 TEST_F(LlvmLibcStrToFltTest, ClingerFastPathFloat32Simple) {
-  clinger_fast_path_test(123, 0, 0x760000, 133);
-  clinger_fast_path_test(1234567, 1, 0x3c6146, 150);
-  clinger_fast_path_test(12345, -5, 0x7cd35b, 123);
+  clinger_fast_path_test(123, 0, 0xf60000, 133);
+  clinger_fast_path_test(1234567, 1, 0xbc6146, 150);
+  clinger_fast_path_test(12345, -5, 0xfcd35b, 123);
 }
 
 TEST_F(LlvmLibcStrToFltTest, ClingerFastPathFloat32ExtendedExp) {
-  clinger_fast_path_test(1, 15, 0x635fa9, 176);
-  clinger_fast_path_test(1, 17, 0x31a2bc, 183);
+  clinger_fast_path_test(1, 15, 0xe35fa9, 176);
+  clinger_fast_path_test(1, 17, 0xb1a2bc, 183);
   clinger_fast_path_fails_test(10, 17);
   clinger_fast_path_fails_test(1, 50);
 }
 
 TEST_F(LlvmLibcStrToFltTest, ClingerFastPathFloat32NegativeExp) {
-  clinger_fast_path_test(1, -5, 0x27c5ac, 110);
-  clinger_fast_path_test(1, -10, 0x5be6ff, 93);
+  clinger_fast_path_test(1, -5, 0xa7c5ac, 110);
+  clinger_fast_path_test(1, -10, 0xdbe6ff, 93);
   clinger_fast_path_fails_test(1, -15);
 }
 

--- a/libc/test/src/__support/str_to_long_double_test.cpp
+++ b/libc/test/src/__support/str_to_long_double_test.cpp
@@ -55,6 +55,12 @@ TEST_F(LlvmLibcStrToLongDblTest, EiselLemireFloat80Fallback) {
   ASSERT_FALSE(internal::eisel_lemire<long double>({1, -1000}).has_value());
 }
 
+TEST_F(LlvmLibcStrToLongDblTest, ClingerFastPathFloat80Simple) {
+  clinger_fast_path_test(123, 0, 0xf600000000000000, 16389);
+  clinger_fast_path_test(1234567, 1, 0xbc61460000000000, 16406);
+  clinger_fast_path_test(12345, -5, 0xfcd35a858793dd98, 16379);
+}
+
 #elif defined(LIBC_TYPES_LONG_DOUBLE_IS_FLOAT128)
 
 TEST_F(LlvmLibcStrToLongDblTest, EiselLemireFloat128Simple) {
@@ -76,6 +82,15 @@ TEST_F(LlvmLibcStrToLongDblTest, EiselLemireFloat128Fallback) {
   ASSERT_FALSE(internal::eisel_lemire<long double>(
                    {0x5ce0e9a5'6015fec5'aadfa328'ae39b333_u128, 1})
                    .has_value());
+}
+
+TEST_F(LlvmLibcStrToLongDblTest, ClingerFastPathFloat128Simple) {
+  clinger_fast_path_test(123, 0, 0x1ec00'00000000'00000000'00000000_u128,
+                         16389);
+  clinger_fast_path_test(1234567, 1, 0x178c2'8c000000'00000000'00000000_u128,
+                         16406);
+  clinger_fast_path_test(12345, -5, 0x1f9a6'b50b0f27'bb2fec56'd5cfaace_u128,
+                         16379);
 }
 
 #else


### PR DESCRIPTION
The previous patch removing the fenv requirement for str to float had an
error that got missed due to a lack of tests. This patch fixes the issue
and adds tests, as well as updating the existing tests.
