### PR TITLE
[libc] Use cpp::numeric_limits in preference to C23 <limits.h> macros

### DIFF
--- a/libc/src/stdio/printf_core/parser.h
+++ b/libc/src/stdio/printf_core/parser.h
@@ -11,6 +11,7 @@
 
 #include "include/llvm-libc-macros/stdfix-macros.h"
 #include "src/__support/CPP/algorithm.h" // max
+#include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/macros/config.h"
@@ -210,11 +211,11 @@ public:
         case (LengthModifier::wf):
           if (bw == 0) {
             section.has_conv = false;
-          } else if (bw <= INT_WIDTH) {
+          } else if (bw <= cpp::numeric_limits<int>::digits) {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, int, conv_index);
-          } else if (bw <= LONG_WIDTH) {
+          } else if (bw <= cpp::numeric_limits<long>::digits) {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, long, conv_index);
-          } else if (bw <= LLONG_WIDTH) {
+          } else if (bw <= cpp::numeric_limits<long long>::digits) {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, long long, conv_index);
           } else {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, intmax_t, conv_index);

--- a/libc/test/src/stdbit/stdc_bit_floor_ui_test.cpp
+++ b/libc/test/src/stdbit/stdc_bit_floor_ui_test.cpp
@@ -15,7 +15,11 @@ TEST(LlvmLibcStdcBitfloorUiTest, Zero) {
 }
 
 TEST(LlvmLibcStdcBitfloorUiTest, Ones) {
-  for (unsigned i = 0U; i != INT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_floor_ui(UINT_MAX >> i),
-              1U << (UINT_WIDTH - i - 1));
+  for (unsigned i = 0U; i != LIBC_NAMESPACE::cpp::numeric_limits<int>::digits;
+       ++i)
+    EXPECT_EQ(
+        LIBC_NAMESPACE::stdc_bit_floor_ui(
+            LIBC_NAMESPACE::cpp::numeric_limits<unsigned int>::max() >> i),
+        1U << (LIBC_NAMESPACE::cpp::numeric_limits<unsigned int>::digits - i -
+               1));
 }

--- a/libc/test/src/stdbit/stdc_leading_zeros_ui_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_ui_test.cpp
@@ -12,12 +12,14 @@
 #include <stddef.h>
 
 TEST(LlvmLibcStdcLeadingZerosUiTest, Zero) {
-  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ui(0U),
-            static_cast<unsigned>(INT_WIDTH));
+  EXPECT_EQ(
+      LIBC_NAMESPACE::stdc_leading_zeros_ui(0U),
+      static_cast<unsigned>(LIBC_NAMESPACE::cpp::numeric_limits<int>::digits));
 }
 
 TEST(LlvmLibcStdcLeadingZerosUiTest, OneHot) {
-  for (unsigned i = 0U; i != INT_WIDTH; ++i)
+  for (unsigned i = 0U; i != LIBC_NAMESPACE::cpp::numeric_limits<int>::digits;
+       ++i)
     EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ui(1U << i),
-              INT_WIDTH - i - 1);
+              LIBC_NAMESPACE::cpp::numeric_limits<int>::digits - i - 1);
 }


### PR DESCRIPTION
This updates some code to consistently use cpp::numeric_limits,
the src/__support polyfill for std::numeric_limits, rather than
the C <limits.h> macros.  This is in keeping with the general
C++-oriented style in libc code, and also sidesteps issues about
the new C23 *_WIDTH macros that the compiler-provided header does
not define outside C23 mode.

Bug: https://issues.fuchsia.dev/358196552
