### PR TITLE
[CMake] Followup to #102396 and restore old DynamicLibrary symbols behavior

### DIFF
--- a/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
+++ b/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
@@ -17,10 +17,9 @@ set_output_directory(DynamicLibraryLib
 
 add_llvm_unittest(DynamicLibraryTests
   DynamicLibraryTest.cpp
-
-  EXPORT_SYMBOLS
   )
 target_link_libraries(DynamicLibraryTests PRIVATE DynamicLibraryLib)
+export_executable_symbols(DynamicLibraryTests)
 
 function(dynlib_add_module NAME)
   add_library(${NAME} MODULE


### PR DESCRIPTION
Followup to #102138 and #102396, restore more old behavior to fix
ppc64-aix bot.
