### PR TITLE
[lldb] Move definition of SBSaveCoreOptions dtor out of header (#102539)

### DIFF
--- a/libc/src/stdio/printf_core/parser.h
+++ b/libc/src/stdio/printf_core/parser.h
@@ -211,11 +211,11 @@ public:
         case (LengthModifier::wf):
           if (bw == 0) {
             section.has_conv = false;
-          } else if (bw <= cpp::numeric_limits<int>::digits) {
+          } else if (bw <= cpp::numeric_limits<unsigned int>::digits) {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, int, conv_index);
-          } else if (bw <= cpp::numeric_limits<long>::digits) {
+          } else if (bw <= cpp::numeric_limits<unsigned long>::digits) {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, long, conv_index);
-          } else if (bw <= cpp::numeric_limits<long long>::digits) {
+          } else if (bw <= cpp::numeric_limits<unsigned long long>::digits) {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, long long, conv_index);
           } else {
             WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, intmax_t, conv_index);

--- a/libc/test/src/stdbit/stdc_leading_zeros_ui_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_ui_test.cpp
@@ -12,14 +12,15 @@
 #include <stddef.h>
 
 TEST(LlvmLibcStdcLeadingZerosUiTest, Zero) {
-  EXPECT_EQ(
-      LIBC_NAMESPACE::stdc_leading_zeros_ui(0U),
-      static_cast<unsigned>(LIBC_NAMESPACE::cpp::numeric_limits<int>::digits));
+  EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ui(0U),
+            static_cast<unsigned>(
+                LIBC_NAMESPACE::cpp::numeric_limits<unsigned int>::digits));
 }
 
 TEST(LlvmLibcStdcLeadingZerosUiTest, OneHot) {
-  for (unsigned i = 0U; i != LIBC_NAMESPACE::cpp::numeric_limits<int>::digits;
-       ++i)
+  for (unsigned i = 0U;
+       i != LIBC_NAMESPACE::cpp::numeric_limits<unsigned int>::digits; ++i)
     EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_ui(1U << i),
-              LIBC_NAMESPACE::cpp::numeric_limits<int>::digits - i - 1);
+              LIBC_NAMESPACE::cpp::numeric_limits<unsigned int>::digits - i -
+                  1);
 }


### PR DESCRIPTION
This class is technically not usable in its current state. When you use
it in a simple C++ project, your compiler will complain about an
incomplete definition of SaveCoreOptions. Normally this isn't a problem,
other classes in the SBAPI do this. The difference is that
SBSaveCoreOptions has a default destructor in the header, so the
compiler will attempt to generate the code for the destructor with an
incomplete definition of the impl type.

All methods for every class, including constructors and destructors,
must have a separate implementation not in a header.