### PR TITLE
[ValueTracking] Skip ephemeral check as instruction is not Assume

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -2486,7 +2486,7 @@ static bool isKnownNonNullFromDominatingCondition(const Value *V,
 
     if ((match(U, m_IDiv(m_Value(), m_Specific(V))) ||
          match(U, m_IRem(m_Value(), m_Specific(V)))) &&
-        isValidAssumeForContext(cast<Instruction>(U), CtxI, DT))
+        isValidAssumeForContext(cast<Instruction>(U), CtxI, DT, true))
       return true;
 
     // Consider only compare instructions uniquely controlling a branch


### PR DESCRIPTION
The call to isValidAssumeForContext is used to check if the rem/div instruction is guaranteed to be executed before or after the CxtI and checking if CxtI only is used by the rem/div instruction (ephemeral check) do not help with this question.