### PR TITLE
[Clang][CodeGen] Fix bad codegen when building Clang with latest MSVC

### DIFF
--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -2092,10 +2092,10 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
         auto *classStart =
             llvm::StructType::get(PtrTy, PtrTy, PtrTy, LongTy, LongTy);
         auto &astContext = CGM.getContext();
-        auto flags = Builder.CreateLoad(
-            Address{Builder.CreateStructGEP(classStart, selfValue, 4), LongTy,
-                    CharUnits::fromQuantity(
-                        astContext.getTypeAlign(astContext.UnsignedLongTy))});
+        llvm::Value *Val = Builder.CreateStructGEP(classStart, selfValue, 4);
+        auto Align = CharUnits::fromQuantity(
+            astContext.getTypeAlign(astContext.UnsignedLongTy));
+        auto flags = Builder.CreateLoad(Address{Val, LongTy, Align});
         auto isInitialized =
             Builder.CreateAnd(flags, ClassFlags::ClassFlagInitialized);
         llvm::BasicBlock *notInitializedBlock =

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -2092,6 +2092,11 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
         auto *classStart =
             llvm::StructType::get(PtrTy, PtrTy, PtrTy, LongTy, LongTy);
         auto &astContext = CGM.getContext();
+        // FIXME: The following few lines up to and including the call to
+        // `CreateLoad` were known to miscompile when MSVC 19.40.33813 is used
+        // to build Clang. When the bug is fixed in future MSVC releases, we
+        // should revert these lines to their previous state. See discussion in
+        // https://github.com/llvm/llvm-project/pull/102681
         llvm::Value *Val = Builder.CreateStructGEP(classStart, selfValue, 4);
         auto Align = CharUnits::fromQuantity(
             astContext.getTypeAlign(astContext.UnsignedLongTy));


### PR DESCRIPTION
Before this PR, when using the latest MSVC `Microsoft (R) C/C++ Optimizing Compiler Version 19.40.33813 for x64` one of the Clang unit test used to fail: `CodeGenObjC/gnustep2-direct-method.m`, see full failure log [here](https://github.com/llvm/llvm-project/pull/100517#issuecomment-2266269490).

This seems to have been introduced by https://github.com/llvm/llvm-project/commit/c9e5af3944e85c5f1272c48522b4e9eda398b462 however further inspection shows that commit only triggers a bug in the MSVC compiler.

It seems that the symptom is bad alignement generated in one of the load instructions:
```
huge alignment values are unsupported
  %2 = load i64, ptr %1, align 9223372036854775808
```
When `Builder.CreateLoad` is called [here](https://github.com/llvm/llvm-project/blob/main/clang/lib/CodeGen/CGObjCGNU.cpp#L2096), somehow [this call](https://github.com/llvm/llvm-project/blob/main/clang/lib/CodeGen/CGBuilder.h#L110) to `Addr.getAlignment().getAsAlign()` returns a bad alignement. The problem occurs at the highlighted line in the screenshot (`sub bh,cl`):

![Screenshot 2024-08-09 154835](https://github.com/user-attachments/assets/48a9a0a9-39f0-4d8e-bc14-77fe1de13e59)

The code line on the right is translated to the assembly on the left. `llvm::count_zero` returns a proper value (as seen in `rcx`), however `sub bh, cl` uses a bad constant in `bh` (it is not 63 as expected). I think the optimizer meant to use `dil` not `bh`. A few lines below it does `mov byte ptr [rsp + 40h], dil`. If after `sub` is executed I manually set 6 in `rdi`, as it should have been, the test passes.

This happens only in optimized builds. I used `llvm\utils\release\build_llvm_release.bat --version 19.0.0 --x64 --skip-checkout --local-python` to build a LLVM installer.

Bug reported here: https://developercommunity.visualstudio.com/t/Bad-code-generation-when-building-LLVM-w/10719589?port=1025&fsid=e572244a-cde7-4d75-a73d-9b8cd94204dd