### PR TITLE
[SandboxIR] Implement AtomicCmpXchgInst

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIRValues.def
+++ b/llvm/include/llvm/SandboxIR/SandboxIRValues.def
@@ -45,6 +45,7 @@ DEF_INSTR(Call,           OP(Call),           CallInst)
 DEF_INSTR(Invoke,         OP(Invoke),         InvokeInst)
 DEF_INSTR(CallBr,         OP(CallBr),         CallBrInst)
 DEF_INSTR(GetElementPtr,  OP(GetElementPtr),  GetElementPtrInst)
+DEF_INSTR(AtomicCmpXchg, OP(AtomicCmpXchg), AtomicCmpXchgInst)
 DEF_INSTR(Alloca,         OP(Alloca),         AllocaInst)
 DEF_INSTR(Cast,   OPCODES(\
                           OP(ZExt)          \

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -644,6 +644,81 @@ define void @foo(i8 %arg) {
   EXPECT_EQ(Invoke->getSuccessor(1), ExceptionBB);
 }
 
+TEST_F(TrackerTest, AtomicCmpXchgSetters) {
+  parseIR(C, R"IR(
+define void @foo(ptr %ptr, i8 %cmp, i8 %new) {
+  %cmpxchg = cmpxchg ptr %ptr, i8 %cmp, i8 %new monotonic monotonic, align 128
+  ret void
+}
+)IR");
+  Function &LLVMF = *M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto &F = *Ctx.createFunction(&LLVMF);
+  auto *BB = &*F.begin();
+  auto It = BB->begin();
+  auto *CmpXchg = cast<sandboxir::AtomicCmpXchgInst>(&*It++);
+
+  // Check setAlignment().
+  Ctx.save();
+  auto OrigAlign = CmpXchg->getAlign();
+  Align NewAlign(1024);
+  EXPECT_NE(NewAlign, OrigAlign);
+  CmpXchg->setAlignment(NewAlign);
+  EXPECT_EQ(CmpXchg->getAlign(), NewAlign);
+  Ctx.revert();
+  EXPECT_EQ(CmpXchg->getAlign(), OrigAlign);
+
+  // Check setVolatile().
+  Ctx.save();
+  auto OrigIsVolatile = CmpXchg->isVolatile();
+  bool NewIsVolatile = true;
+  EXPECT_NE(NewIsVolatile, OrigIsVolatile);
+  CmpXchg->setVolatile(NewIsVolatile);
+  EXPECT_EQ(CmpXchg->isVolatile(), NewIsVolatile);
+  Ctx.revert();
+  EXPECT_EQ(CmpXchg->isVolatile(), OrigIsVolatile);
+
+  // Check setWeak().
+  Ctx.save();
+  auto OrigIsWeak = CmpXchg->isWeak();
+  bool NewIsWeak = true;
+  EXPECT_NE(NewIsWeak, OrigIsWeak);
+  CmpXchg->setWeak(NewIsWeak);
+  EXPECT_EQ(CmpXchg->isWeak(), NewIsWeak);
+  Ctx.revert();
+  EXPECT_EQ(CmpXchg->isWeak(), OrigIsWeak);
+
+  // Check setSuccessOrdering().
+  Ctx.save();
+  auto OrigSuccessOrdering = CmpXchg->getSuccessOrdering();
+  auto NewSuccessOrdering = AtomicOrdering::SequentiallyConsistent;
+  EXPECT_NE(NewSuccessOrdering, OrigSuccessOrdering);
+  CmpXchg->setSuccessOrdering(NewSuccessOrdering);
+  EXPECT_EQ(CmpXchg->getSuccessOrdering(), NewSuccessOrdering);
+  Ctx.revert();
+  EXPECT_EQ(CmpXchg->getSuccessOrdering(), OrigSuccessOrdering);
+
+  // Check setFailureOrdering().
+  Ctx.save();
+  auto OrigFailureOrdering = CmpXchg->getFailureOrdering();
+  auto NewFailureOrdering = AtomicOrdering::SequentiallyConsistent;
+  EXPECT_NE(NewFailureOrdering, OrigFailureOrdering);
+  CmpXchg->setFailureOrdering(NewFailureOrdering);
+  EXPECT_EQ(CmpXchg->getFailureOrdering(), NewFailureOrdering);
+  Ctx.revert();
+  EXPECT_EQ(CmpXchg->getFailureOrdering(), OrigFailureOrdering);
+
+  // Check setSyncScopeID().
+  Ctx.save();
+  auto OrigSSID = CmpXchg->getSyncScopeID();
+  auto NewSSID = SyncScope::SingleThread;
+  EXPECT_NE(NewSSID, OrigSSID);
+  CmpXchg->setSyncScopeID(NewSSID);
+  EXPECT_EQ(CmpXchg->getSyncScopeID(), NewSSID);
+  Ctx.revert();
+  EXPECT_EQ(CmpXchg->getSyncScopeID(), OrigSSID);
+}
+
 TEST_F(TrackerTest, AllocaInstSetters) {
   parseIR(C, R"IR(
 define void @foo(i8 %arg) {


### PR DESCRIPTION
This patch implements sandboxir::AtomicCmpXchgInst which mirrors llvm::AtomiCmpXchgInst.