### PR TITLE
[llvm] Use llvm::set_is_subset (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -20,6 +20,13 @@
 namespace llvm {
 
 namespace detail {
+template <typename Set>
+using check_has_member_size_t = decltype(std::declval<Set>().size());
+
+template <typename Set>
+static constexpr bool HasMemberSize =
+    is_detected<check_has_member_size_t, Set>::value;
+
 template <typename Set, typename Fn>
 using check_has_member_remove_if_t =
     decltype(std::declval<Set>().remove_if(std::declval<Fn>()));
@@ -149,8 +156,10 @@ void set_subtract(S1Ty &S1, const S2Ty &S2, S1Ty &Removed, S1Ty &Remaining) {
 ///
 template <class S1Ty, class S2Ty>
 bool set_is_subset(const S1Ty &S1, const S2Ty &S2) {
-  if (S1.size() > S2.size())
-    return false;
+  if constexpr (detail::HasMemberSize<S1Ty> && detail::HasMemberSize<S2Ty>) {
+    if (S1.size() > S2.size())
+      return false;
+  }
   for (const auto It : S1)
     if (!S2.count(It))
       return false;

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -56,7 +56,7 @@ static void completeEphemeralValues(SmallPtrSetImpl<const Value *> &Visited,
            "Failed to add a worklist entry to our visited set!");
 
     // If all uses of this value are ephemeral, then so is this value.
-    if (!all_of(V->users(), [&](const User *U) { return EphValues.count(U); }))
+    if (!llvm::set_is_subset(V->users(), EphValues))
       continue;
 
     EphValues.insert(V);

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -4146,9 +4146,7 @@ static bool impliesPoison(const SCEV *AssumedPoison, const SCEV *S) {
 
   // Make sure that no matter which SCEV in PC1.MaybePoison is actually poison,
   // it will also make S poison by being part of PC2.MaybePoison.
-  return all_of(PC1.MaybePoison, [&](const SCEVUnknown *S) {
-    return PC2.MaybePoison.contains(S);
-  });
+  return llvm::set_is_subset(PC1.MaybePoison, PC2.MaybePoison);
 }
 
 void ScalarEvolution::getPoisonGeneratingValues(

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -462,9 +462,7 @@ static bool isEphemeralValueOf(const Instruction *I, const Value *E) {
       continue;
 
     // If all uses of this value are ephemeral, then so is this value.
-    if (llvm::all_of(V->users(), [&](const User *U) {
-                                   return EphValues.count(U);
-                                 })) {
+    if (llvm::set_is_subset(V->users(), EphValues)) {
       if (V == E)
         return true;
 

--- a/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
+++ b/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
@@ -1747,10 +1747,7 @@ static void deleteDeadBlocksFromLoop(Loop &L,
     if (!DeadBlockSet.count(ChildL->getHeader()))
       return false;
 
-    assert(llvm::all_of(ChildL->blocks(),
-                        [&](BasicBlock *ChildBB) {
-                          return DeadBlockSet.count(ChildBB);
-                        }) &&
+    assert(llvm::set_is_subset(ChildL->blocks(), DeadBlockSet) &&
            "If the child loop header is dead all blocks in the child loop must "
            "be dead as well!");
     LoopUpdater.markLoopAsDeleted(*ChildL, ChildL->getName());

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -2331,9 +2331,8 @@ static bool sinkCommonCodeFromPredecessors(BasicBlock *BB,
       unsigned NumPHIInsts = 0;
       for (Use &U : (*LRI)[0]->operands()) {
         auto It = PHIOperands.find(&U);
-        if (It != PHIOperands.end() && !all_of(It->second, [&](Value *V) {
-              return InstructionsToSink.contains(V);
-            })) {
+        if (It != PHIOperands.end() &&
+            !llvm::set_is_subset(It->second, InstructionsToSink)) {
           ++NumPHIInsts;
           // FIXME: this check is overly optimistic. We may end up not sinking
           // said instruction, due to the very same profitability check.


### PR DESCRIPTION
Some iterator ranges do not have a size method, so this patch makes
the size check optional in llvm::set_is_subset with a constexpr if.
