### PR TITLE
[clang][Interp] Improve "in call to" call argument printing

### DIFF
--- a/clang/lib/AST/Interp/InterpFrame.cpp
+++ b/clang/lib/AST/Interp/InterpFrame.cpp
@@ -102,8 +102,9 @@ void InterpFrame::popArgs() {
 }
 
 template <typename T>
-static void print(llvm::raw_ostream &OS, const T &V, ASTContext &, QualType) {
-  OS << V;
+static void print(llvm::raw_ostream &OS, const T &V, ASTContext &ASTCtx,
+                  QualType Ty) {
+  V.toAPValue(ASTCtx).printPretty(OS, ASTCtx, Ty);
 }
 
 template <>

--- a/clang/test/AST/Interp/constexpr-frame-describe.cpp
+++ b/clang/test/AST/Interp/constexpr-frame-describe.cpp
@@ -81,3 +81,18 @@ static_assert(bar.fail2<int*, 42>()); // both-error {{constant expression}} \
 static_assert(bar.fail3(3, 4UL, bar, &bar)); // both-error {{constant expression}} \
                                              // expected-note {{in call to 'bar.fail3<int, unsigned long, Bar<int>, const Bar<int> *>(3, 4, &bar, &bar)'}} \
                                              // ref-note {{in call to 'bar.fail3<int, unsigned long, Bar<int>, const Bar<int> *>(3, 4, {}, &bar)'}}
+
+
+
+/// FIXME: Bound member pointer printing doesn't work right, see the last parameter to MemPtr().
+struct MemPtrTest {
+  int n;
+  void f();
+};
+MemPtrTest mpt; // both-note {{here}}
+constexpr int MemPtr(int (MemPtrTest::*a), void (MemPtrTest::*b)(), int &c) {
+  return c; // both-note {{read of non-constexpr variable 'mpt'}}
+}
+static_assert(MemPtr(&MemPtrTest::n, &MemPtrTest::f, mpt.*&MemPtrTest::n), ""); // both-error {{constant expression}} \
+                                                                                // expected-note {{in call to 'MemPtr(&MemPtrTest::n, &MemPtrTest::f, mpt)'}} \
+                                                                                // ref-note {{in call to 'MemPtr(&MemPtrTest::n, &MemPtrTest::f, mpt.n)'}}


### PR DESCRIPTION
Always go through toAPValue() first and pretty-print that. In the future, I think we could get rid of the individual toDiagnosticString() implementations. This way we also get the correct printing for floats.