### PR TITLE
[LLD][COFF] Validate import library machine type.

### DIFF
--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -987,6 +987,13 @@ void ObjFile::enqueuePdbFile(StringRef path, ObjFile *fromFile) {
 ImportFile::ImportFile(COFFLinkerContext &ctx, MemoryBufferRef m)
     : InputFile(ctx, ImportKind, m), live(!ctx.config.doGC), thunkLive(live) {}
 
+MachineTypes ImportFile::getMachineType() const {
+  uint16_t machine =
+      reinterpret_cast<const coff_import_header *>(mb.getBufferStart())
+          ->Machine;
+  return MachineTypes(machine);
+}
+
 void ImportFile::parse() {
   const auto *hdr =
       reinterpret_cast<const coff_import_header *>(mb.getBufferStart());

--- a/lld/COFF/InputFiles.h
+++ b/lld/COFF/InputFiles.h
@@ -344,6 +344,7 @@ public:
   explicit ImportFile(COFFLinkerContext &ctx, MemoryBufferRef m);
 
   static bool classof(const InputFile *f) { return f->kind() == ImportKind; }
+  MachineTypes getMachineType() const override;
 
   Symbol *impSym = nullptr;
   Symbol *thunkSym = nullptr;

--- a/lld/test/COFF/implib-machine.s
+++ b/lld/test/COFF/implib-machine.s
@@ -1,0 +1,32 @@
+# REQUIRES: x86
+# RUN: split-file %s %t.dir
+# RUN: llvm-lib -machine:i386 -out:%t.dir/test32.lib -def:%t.dir/test32.def
+# RUN: llvm-lib -machine:amd64 -out:%t.dir/test64.lib -def:%t.dir/test64.def
+# RUN: llvm-mc -triple i686-windows-msvc %t.dir/test.s -filetype=obj -o %t.dir/test32.obj
+# RUN: llvm-mc -triple x86_64-windows-msvc %t.dir/test.s -filetype=obj -o %t.dir/test64.obj
+
+# RUN: not lld-link -dll -noentry -out:%t32.dll %t.dir/test32.obj %t.dir/test64.lib 2>&1 | FileCheck --check-prefix=ERR32 %s
+# ERR32: error: test.dll: machine type x64 conflicts with x86
+
+# RUN: not lld-link -dll -noentry -out:%t64.dll %t.dir/test64.obj %t.dir/test32.lib 2>&1 | FileCheck --check-prefix=ERR64 %s
+# ERR64: error: test.dll: machine type x86 conflicts with x64
+
+#--- test.s
+        .def     @feat.00;
+        .scl    3;
+        .type   0;
+        .endef
+        .globl  @feat.00
+@feat.00 = 1
+        .data
+        .rva __imp__test
+
+#--- test32.def
+NAME test.dll
+EXPORTS
+         test DATA
+
+#--- test64.def
+NAME test.dll
+EXPORTS
+         _test DATA


### PR DESCRIPTION
This depends on  #102737 and #102736.

Check import library machine type instead of ignoring it. This matches MSVC link.exe's behavior. It will be also useful for ARM64EC, which needs to handle multiple machine types (ARM64EC and x86_64 for pure EC, additionally aarch64 for ARM64X) differently, depending on the type