### PR TITLE
[libc++] Simplify the implementation of std::get for pairs

### DIFF
--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -635,42 +635,42 @@ get(const pair<_T1, _T2>&& __p) _NOEXCEPT {
 #if _LIBCPP_STD_VER >= 14
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1& get(pair<_T1, _T2>& __p) _NOEXCEPT {
-  return __get_pair<0>::get(__p);
+  return __p.first;
 }
 
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1 const& get(pair<_T1, _T2> const& __p) _NOEXCEPT {
-  return __get_pair<0>::get(__p);
+  return __p.first;
 }
 
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
-  return __get_pair<0>::get(std::move(__p));
+  return std::forward<_T1>(std::move(__p).first);
 }
 
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1 const&& get(pair<_T1, _T2> const&& __p) _NOEXCEPT {
-  return __get_pair<0>::get(std::move(__p));
+  return std::forward<_T1>(std::move(__p).first);
 }
 
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1& get(pair<_T2, _T1>& __p) _NOEXCEPT {
-  return __get_pair<1>::get(__p);
+  return __p.second;
 }
 
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1 const& get(pair<_T2, _T1> const& __p) _NOEXCEPT {
-  return __get_pair<1>::get(__p);
+  return __p.second;
 }
 
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1&& get(pair<_T2, _T1>&& __p) _NOEXCEPT {
-  return __get_pair<1>::get(std::move(__p));
+  return std::forward<_T1>(std::move(__p).second);
 }
 
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1 const&& get(pair<_T2, _T1> const&& __p) _NOEXCEPT {
-  return __get_pair<1>::get(std::move(__p));
+  return std::forward<_T1>(std::move(__p).second);
 }
 
 #endif // _LIBCPP_STD_VER >= 14

--- a/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_ref.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pair.astuple/get_ref.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03
+
+// <utility>
+
+// template <class T1, class T2> struct pair
+
+// template<size_t I, class T1, class T2>
+//     typename tuple_element<I, std::pair<T1, T2> >::type&&
+//     get(pair<T1, T2>&&);
+
+#include <cassert>
+#include <utility>
+
+#include "test_macros.h"
+
+TEST_CONSTEXPR_CXX14 bool test() {
+  int i = 1;
+  int j = 2;
+
+  {
+    std::pair<int&, int&&> p(i, std::move(j));
+    assert(&std::get<int&>(p) == &i);
+    assert(&std::get<int&&>(p) == &j);
+
+    assert(&std::get<int&>(std::move(p)) == &i);
+    assert(std::get<int&&>(std::move(p)) == 2);
+
+    const std::pair<int&, int&&> cp(i, std::move(j));
+    assert(&std::get<int&>(cp) == &i);
+    assert(&std::get<int&&>(cp) == &j);
+
+    assert(&std::get<int&>(std::move(cp)) == &i);
+    assert(std::get<int&&>(std::move(cp)) == 2);
+  }
+
+  {
+    std::pair<int&&, int&> p(std::move(i), j);
+    assert(&std::get<int&>(p) == &j);
+    assert(&std::get<int&&>(p) == &i);
+
+    assert(&std::get<int&>(std::move(p)) == &j);
+    assert(std::get<int&&>(std::move(p)) == 1);
+
+    const std::pair<int&&, int&> cp(std::move(i), j);
+    assert(&std::get<int&>(cp) == &j);
+    assert(&std::get<int&&>(cp) == &i);
+
+    assert(&std::get<int&>(std::move(cp)) == &j);
+    assert(std::get<int&&>(std::move(cp)) == 1);
+  }
+
+  return true;
+}
+
+int main() {
+  test();
+#if TEST_STD_VER >= 14
+  static_assert(test());
+#endif
+}


### PR DESCRIPTION
There doesn't seem to be any benefit by calling `__get_pair`, so we can just remove the additional indirection.
