### PR TITLE
[ASTDump] TextNodeDumper learned to dump builtin name for AtomicExpr

### DIFF
--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -410,6 +410,7 @@ public:
   void VisitOpenACCConstructStmt(const OpenACCConstructStmt *S);
   void VisitOpenACCLoopConstruct(const OpenACCLoopConstruct *S);
   void VisitEmbedExpr(const EmbedExpr *S);
+  void VisitAtomicExpr(const AtomicExpr *AE);
 };
 
 } // namespace clang

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -2892,3 +2892,7 @@ void TextNodeDumper::VisitEmbedExpr(const EmbedExpr *S) {
   AddChild("begin", [=] { OS << S->getStartingElementPos(); });
   AddChild("number of elements", [=] { OS << S->getDataElementCount(); });
 }
+
+void TextNodeDumper::VisitAtomicExpr(const AtomicExpr *AE) {
+  OS << ' ' << AE->getOpAsString();
+}

--- a/clang/test/AST/atomic-expr.cpp
+++ b/clang/test/AST/atomic-expr.cpp
@@ -25,14 +25,14 @@ void useage(){
 }
 
 // CHECK:FunctionTemplateDecl 0x{{[0-9a-f]+}} <{{[^,]+}}, line:{{.*}}:1> line:{{.*}}:6 pr43370
-// CHECK: AtomicExpr
+// CHECK: AtomicExpr 0x{{[0-9a-f]+}} <{{.*}}> 'void' __atomic_store_n
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-SAME: <ArrayToPointerDecay>
 // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-f]+}} <{{[^:]+}}:20> 'int[2]' lvalue Var 0x{{[0-9a-f]+}} 'arr' 'int[2]'
 // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-f]+}} <{{[^:]+}}:28> 'int' 5
 // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-f]+}} <{{[^:]+}}:25> 'int' 0
 // CHECK:FunctionDecl 0x{{[0-9a-f]+}} <line:{{.*}}:1, line:{{.*}}:1> line:{{.*}}:6 used pr43370
-// CHECK: AtomicExpr
+// CHECK: AtomicExpr 0x{{[0-9a-f]+}} <{{.*}}> 'void' __atomic_store_n
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-SAME: <ArrayToPointerDecay>
 // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-f]+}} <{{[^:]+}}:20> 'int[2]' lvalue Var 0x{{[0-9a-f]+}} 'arr' 'int[2]'
@@ -40,7 +40,7 @@ void useage(){
 // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-f]+}} <{{[^:]+}}:25> 'int' 0
 
 // CHECK:FunctionTemplateDecl 0x{{[0-9a-f]+}} <line:{{.*}}:1, line:{{.*}}:1> line:{{.*}}:6 foo
-// CHECK: AtomicExpr
+// CHECK: AtomicExpr 0x{{[0-9a-f]+}} <{{.*}}> 'bool' __atomic_compare_exchange_n
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-SAME: <ArrayToPointerDecay>
 // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-f]+}} <{{[^:]+}}:37> 'int[2]' lvalue Var 0x{{[0-9a-f]+}} 'arr' 'int[2]'
@@ -53,7 +53,7 @@ void useage(){
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-NEXT: IntegerLiteral 0x{{[0-9a-f]+}} <{{[^:]+}}:50> 'int' 0
 // CHECK:FunctionDecl 0x{{[0-9a-f]+}} <line:{{.*}}:1, line:{{.*}}:1> line:{{.*}}:6 used foo
-// CHECK: AtomicExpr
+// CHECK: AtomicExpr 0x{{[0-9a-f]+}} <{{.*}}> 'bool' __atomic_compare_exchange_n
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-SAME: <ArrayToPointerDecay>
 // CHECK-NEXT: DeclRefExpr 0x{{[0-9a-f]+}} <{{[^:]+}}:37> 'int[2]' lvalue Var 0x{{[0-9a-f]+}} 'arr' 'int[2]'


### PR DESCRIPTION
In 4198576157bfd0d08c08b784220d6132b709ae2c, we add support for dumping builtin name for AtomicExpr in JSON dump. This change syncs `TextNodeDumper` with `JSONNodeDumper`, makes `TextNodeDumper` learned to dump builtin name for AtomicExpr.