### PR TITLE
[NFC] Eliminate top-level "using namespace" from some headers.

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -29,8 +29,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Target/TargetMachine.h"
 
-using namespace llvm;
-
 namespace llvm {
 
 // This struct represents the cluster information for a machine basic block,

--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
@@ -943,7 +943,7 @@ void MLEvictAdvisor::extractFeatures(
 #undef SET
 }
 
-void extractInstructionFeatures(
+void llvm::extractInstructionFeatures(
     SmallVectorImpl<LRStartEndInfo> &LRPosInfo, MLModelRunner *RegallocRunner,
     function_ref<int(SlotIndex)> GetOpcode,
     function_ref<float(SlotIndex)> GetMBBFreq,
@@ -1060,13 +1060,12 @@ void extractInstructionFeatures(
   }
 }
 
-void extractMBBFrequency(const SlotIndex CurrentIndex,
-                         const size_t CurrentInstructionIndex,
-                         std::map<MachineBasicBlock *, size_t> &VisitedMBBs,
-                         function_ref<float(SlotIndex)> GetMBBFreq,
-                         MachineBasicBlock *CurrentMBBReference,
-                         MLModelRunner *RegallocRunner, const int MBBFreqIndex,
-                         const int MBBMappingIndex) {
+void llvm::extractMBBFrequency(
+    const SlotIndex CurrentIndex, const size_t CurrentInstructionIndex,
+    std::map<MachineBasicBlock *, size_t> &VisitedMBBs,
+    function_ref<float(SlotIndex)> GetMBBFreq,
+    MachineBasicBlock *CurrentMBBReference, MLModelRunner *RegallocRunner,
+    const int MBBFreqIndex, const int MBBMappingIndex) {
   size_t CurrentMBBIndex = VisitedMBBs[CurrentMBBReference];
   float CurrentMBBFreq = GetMBBFreq(CurrentIndex);
   if (CurrentMBBIndex < ModelMaxSupportedMBBCount) {

--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.h
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.h
@@ -19,7 +19,7 @@
 #include "llvm/CodeGen/SlotIndexes.h"
 #include <map>
 
-using namespace llvm;
+namespace llvm {
 
 // LRStartEndInfo contains the start and end of a specific live range as
 // slot indices as well as storing the index of the physical register it
@@ -90,5 +90,7 @@ static const std::vector<int64_t> InstructionsMappingShape{
 static const int64_t ModelMaxSupportedMBBCount = 100;
 static const std::vector<int64_t> MBBFrequencyShape{1,
                                                     ModelMaxSupportedMBBCount};
+
+} // namespace llvm
 
 #endif // LLVM_CODEGEN_MLREGALLOCEVICTIONADVISOR_H

--- a/llvm/lib/CodeGen/SelectionDAG/MatchContext.h
+++ b/llvm/lib/CodeGen/SelectionDAG/MatchContext.h
@@ -16,9 +16,8 @@
 #include "llvm/CodeGen/SelectionDAG.h"
 #include "llvm/CodeGen/TargetLowering.h"
 
-using namespace llvm;
+namespace llvm {
 
-namespace {
 class EmptyMatchContext {
   SelectionDAG &DAG;
   const TargetLowering &TLI;
@@ -171,5 +170,7 @@ public:
     return TLI.isOperationLegalOrCustom(VPOp, VT, LegalOnly);
   }
 };
-} // end anonymous namespace
-#endif
+
+} // namespace llvm
+
+#endif // LLVM_LIB_CODEGEN_SELECTIONDAG_MATCHCONTEXT_H

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
@@ -15,10 +15,6 @@
 
 #include "RuntimeDyldImpl.h"
 
-#define DEBUG_TYPE "dyld"
-
-using namespace llvm;
-
 namespace llvm {
 
 // Common base class for COFF dynamic linker support.
@@ -56,6 +52,4 @@ private:
 
 } // end namespace llvm
 
-#undef DEBUG_TYPE
-
-#endif
+#endif // LLVM_RUNTIME_DYLD_COFF_H

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
@@ -16,8 +16,6 @@
 #include "RuntimeDyldImpl.h"
 #include "llvm/ADT/DenseMap.h"
 
-using namespace llvm;
-
 namespace llvm {
 namespace object {
 class ELFObjectFileBase;
@@ -233,4 +231,4 @@ public:
 
 } // end namespace llvm
 
-#endif
+#endif // LLVM_LIB_EXECUTIONENGINE_RUNTIMEDYLD_RUNTIMEDYLDELF_H

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldMachO.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldMachO.h
@@ -17,11 +17,6 @@
 #include "llvm/Object/MachO.h"
 #include "llvm/Support/Format.h"
 
-#define DEBUG_TYPE "dyld"
-
-using namespace llvm;
-using namespace llvm::object;
-
 namespace llvm {
 class RuntimeDyldMachO : public RuntimeDyldImpl {
 protected:
@@ -162,6 +157,4 @@ public:
 
 } // end namespace llvm
 
-#undef DEBUG_TYPE
-
-#endif
+#endif // LLVM_LIB_EXECUTIONENGINE_RUNTIMEDYLD_RUNTIMEDYLDMACHO_H

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
@@ -18,8 +18,7 @@
 #include "llvm/CodeGen/GlobalISel/Combiner.h"
 #include "llvm/CodeGen/GlobalISel/CombinerHelper.h"
 
-using namespace llvm;
-
+namespace llvm {
 class AMDGPUCombinerHelper : public CombinerHelper {
 public:
   using CombinerHelper::CombinerHelper;
@@ -32,5 +31,7 @@ public:
   void applyExpandPromotedF16FMed3(MachineInstr &MI, Register Src0,
                                    Register Src1, Register Src2);
 };
+
+} // namespace llvm
 
 #endif // LLVM_LIB_TARGET_AMDGPU_AMDGPUCOMBINERHELPER_H

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
@@ -20,9 +20,7 @@
 #include "llvm/CodeGen/SelectionDAGISel.h"
 #include "llvm/Target/TargetMachine.h"
 
-using namespace llvm;
-
-namespace {
+namespace llvm {
 
 static inline bool getConstantValue(SDValue N, uint32_t &Out) {
   // This is only used for packed vectors, where using 0 for undef should
@@ -59,8 +57,6 @@ static inline SDNode *packConstantV2I16(const SDNode *N, SelectionDAG &DAG) {
 
   return nullptr;
 }
-
-} // namespace
 
 /// AMDGPU specific code to select AMDGPU machine instructions for
 /// SelectionDAG operations.
@@ -300,5 +296,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override;
   StringRef getPassName() const override;
 };
+
+} // namespace llvm
 
 #endif // LLVM_LIB_TARGET_AMDGPU_AMDGPUISELDAGTODAG_H

--- a/llvm/lib/Target/AMDGPU/R600ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/R600ISelDAGToDAG.cpp
@@ -18,6 +18,8 @@
 #include "R600Subtarget.h"
 #include "llvm/Analysis/ValueTracking.h"
 
+using namespace llvm;
+
 namespace {
 class R600DAGToDAGISel : public AMDGPUDAGToDAGISel {
   const R600Subtarget *Subtarget = nullptr;

--- a/llvm/lib/Target/AMDGPU/R600MachineScheduler.h
+++ b/llvm/lib/Target/AMDGPU/R600MachineScheduler.h
@@ -17,8 +17,6 @@
 #include "llvm/CodeGen/MachineScheduler.h"
 #include <vector>
 
-using namespace llvm;
-
 namespace llvm {
 
 class R600InstrInfo;

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendELF.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendELF.h
@@ -6,16 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TARGET_ARM_ELFARMASMBACKEND_H
-#define LLVM_LIB_TARGET_ARM_ELFARMASMBACKEND_H
+#ifndef LLVM_LIB_TARGET_ARM_MCTARGETDESC_ELFARMASMBACKEND_H
+#define LLVM_LIB_TARGET_ARM_MCTARGETDESC_ELFARMASMBACKEND_H
 
 #include "ARMAsmBackend.h"
 #include "MCTargetDesc/ARMMCTargetDesc.h"
 #include "llvm/MC/MCObjectWriter.h"
 
-using namespace llvm;
-
-namespace {
+namespace llvm {
 class ARMAsmBackendELF : public ARMAsmBackend {
 public:
   uint8_t OSABI;
@@ -30,6 +28,6 @@ public:
 
   std::optional<MCFixupKind> getFixupKind(StringRef Name) const override;
 };
-}
+} // namespace llvm
 
-#endif
+#endif // LLVM_LIB_TARGET_ARM_MCTARGETDESC_ELFARMASMBACKEND_H

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendWinCOFF.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendWinCOFF.h
@@ -6,14 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TARGET_ARM_ARMASMBACKENDWINCOFF_H
-#define LLVM_LIB_TARGET_ARM_ARMASMBACKENDWINCOFF_H
+#ifndef LLVM_LIB_TARGET_ARM_MCTARGETDESC_ARMASMBACKENDWINCOFF_H
+#define LLVM_LIB_TARGET_ARM_MCTARGETDESC_ARMASMBACKENDWINCOFF_H
 
 #include "ARMAsmBackend.h"
 #include "llvm/MC/MCObjectWriter.h"
-using namespace llvm;
 
-namespace {
+namespace llvm {
 class ARMAsmBackendWinCOFF : public ARMAsmBackend {
 public:
   ARMAsmBackendWinCOFF(const Target &T, bool isThumb)
@@ -23,6 +22,6 @@ public:
     return createARMWinCOFFObjectWriter();
   }
 };
-}
+} // namespace llvm
 
-#endif
+#endif // LLVM_LIB_TARGET_ARM_MCTARGETDESC_ARMASMBACKENDWINCOFF_H

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
@@ -12,7 +12,7 @@
 #include "RISCVTargetStreamer.h"
 #include "llvm/MC/MCELFStreamer.h"
 
-using namespace llvm;
+namespace llvm {
 
 class RISCVELFStreamer : public MCELFStreamer {
   void reset() override;
@@ -37,8 +37,6 @@ public:
   void emitFill(const MCExpr &NumBytes, uint64_t FillValue, SMLoc Loc) override;
   void emitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc) override;
 };
-
-namespace llvm {
 
 class RISCVTargetELFStreamer : public RISCVTargetStreamer {
 private:
@@ -75,5 +73,6 @@ MCELFStreamer *createRISCVELFStreamer(MCContext &C,
                                       std::unique_ptr<MCAsmBackend> MAB,
                                       std::unique_ptr<MCObjectWriter> MOW,
                                       std::unique_ptr<MCCodeEmitter> MCE);
-}
-#endif
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVELFSTREAMER_H

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
@@ -22,8 +22,6 @@
 #include "llvm/CodeGen/ScheduleDAG.h"
 #include <set>
 
-using namespace llvm;
-
 namespace llvm {
 
 /// A MachineSchedStrategy implementation for SystemZ post RA scheduling.

--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombineInternal.h
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombineInternal.h
@@ -20,8 +20,6 @@
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Support/KnownBits.h"
 
-using namespace llvm;
-
 //===----------------------------------------------------------------------===//
 // TruncInstCombine - looks for expression graphs dominated by trunc
 // instructions and for each eligible graph, it will create a reduced bit-width
@@ -137,4 +135,4 @@ private:
 };
 } // end namespace llvm.
 
-#endif
+#endif // LLVM_LIB_TRANSFORMS_AGGRESSIVEINSTCOMBINE_COMBINEINTERNAL_H

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -33,8 +33,6 @@
 #define DEBUG_TYPE "instcombine"
 #include "llvm/Transforms/Utils/InstructionWorklist.h"
 
-using namespace llvm::PatternMatch;
-
 // As a default, let's assume that we want to be aggressive,
 // and attempt to traverse with no limits in attempt to sink negation.
 static constexpr unsigned NegatorDefaultMaxDepth = ~0U;

--- a/llvm/lib/Transforms/InstCombine/InstCombineNegator.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineNegator.cpp
@@ -46,12 +46,8 @@
 #include <type_traits>
 #include <utility>
 
-namespace llvm {
-class DataLayout;
-class LLVMContext;
-} // namespace llvm
-
 using namespace llvm;
+using namespace llvm::PatternMatch;
 
 #define DEBUG_TYPE "instcombine"
 

--- a/llvm/unittests/CodeGen/MLRegAllocDevelopmentFeatures.cpp
+++ b/llvm/unittests/CodeGen/MLRegAllocDevelopmentFeatures.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 
+using namespace llvm;
 using testing::ContainerEq;
 using testing::Test;
 


### PR DESCRIPTION
- Eliminate top-level "using namespace" from some headers.