### PR TITLE
[llvm-exegesis][unittests] Also disable SubprocessMemoryTest on SPARC

### DIFF
--- a/llvm/unittests/tools/llvm-exegesis/X86/SubprocessMemoryTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SubprocessMemoryTest.cpp
@@ -24,9 +24,8 @@
 namespace llvm {
 namespace exegesis {
 
-// The tests are only supported on little endian systems.
 #if defined(__linux__) && !defined(__ANDROID__) &&                             \
-    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    !(defined(__powerpc__) || defined(__s390x__) || defined(__sparc__))
 
 // This needs to be updated anytime a test is added or removed from the test
 // suite.
@@ -107,7 +106,12 @@ TEST_F(SubprocessMemoryTest, DefinitionFillsCompletely) {
   checkSharedMemoryDefinition(getSharedMemoryName(2, 2), 4096, Test3Expected);
 }
 
+// The following test is only supported on little endian systems.
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+TEST_F(SubprocessMemoryTest, DISABLED_DefinitionEndTruncation) {
+#else
 TEST_F(SubprocessMemoryTest, DefinitionEndTruncation) {
+#endif
   testCommon({{"test1", {APInt(48, 0xaabbccddeeff), 4096, 0}}}, 3);
   std::vector<uint8_t> Test1Expected(512, 0);
   // order is reversed since we're assuming a little endian system.
@@ -135,8 +139,7 @@ TEST_F(SubprocessMemoryTest, DefinitionEndTruncation) {
   checkSharedMemoryDefinition(getSharedMemoryName(3, 0), 4096, Test1Expected);
 }
 
-#endif // defined(__linux__) && !defined(__ANDROID__) && __BYTE_ORDER__ ==
-       // __ORDER_LITTLE_ENDIAN__
+#endif // __linux__ && !__ANDROID__ && !(__powerpc__ || __s390x__ || __sparc__)
 
 } // namespace exegesis
 } // namespace llvm

--- a/llvm/unittests/tools/llvm-exegesis/X86/SubprocessMemoryTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SubprocessMemoryTest.cpp
@@ -24,7 +24,9 @@
 namespace llvm {
 namespace exegesis {
 
-#if defined(__linux__) && !defined(__ANDROID__)
+// The tests are only supported on little endian systems.
+#if defined(__linux__) && !defined(__ANDROID__) &&                             \
+    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 
 // This needs to be updated anytime a test is added or removed from the test
 // suite.
@@ -77,20 +79,12 @@ protected:
 // memory calls not working in some cases, so they have been disabled.
 // TODO(boomanaiden154): Investigate and fix this issue on PPC.
 
-#if defined(__powerpc__) || defined(__s390x__)
-TEST_F(SubprocessMemoryTest, DISABLED_OneDefinition) {
-#else
 TEST_F(SubprocessMemoryTest, OneDefinition) {
-#endif
   testCommon({{"test1", {APInt(8, 0xff), 4096, 0}}}, 0);
   checkSharedMemoryDefinition(getSharedMemoryName(0, 0), 4096, {0xff});
 }
 
-#if defined(__powerpc__) || defined(__s390x__)
-TEST_F(SubprocessMemoryTest, DISABLED_MultipleDefinitions) {
-#else
 TEST_F(SubprocessMemoryTest, MultipleDefinitions) {
-#endif
   testCommon({{"test1", {APInt(8, 0xaa), 4096, 0}},
               {"test2", {APInt(8, 0xbb), 4096, 1}},
               {"test3", {APInt(8, 0xcc), 4096, 2}}},
@@ -100,11 +94,7 @@ TEST_F(SubprocessMemoryTest, MultipleDefinitions) {
   checkSharedMemoryDefinition(getSharedMemoryName(1, 2), 4096, {0xcc});
 }
 
-#if defined(__powerpc__) || defined(__s390x__)
-TEST_F(SubprocessMemoryTest, DISABLED_DefinitionFillsCompletely) {
-#else
 TEST_F(SubprocessMemoryTest, DefinitionFillsCompletely) {
-#endif
   testCommon({{"test1", {APInt(8, 0xaa), 4096, 0}},
               {"test2", {APInt(16, 0xbbbb), 4096, 1}},
               {"test3", {APInt(24, 0xcccccc), 4096, 2}}},
@@ -117,12 +107,7 @@ TEST_F(SubprocessMemoryTest, DefinitionFillsCompletely) {
   checkSharedMemoryDefinition(getSharedMemoryName(2, 2), 4096, Test3Expected);
 }
 
-// The following test is only supported on little endian systems.
-#if defined(__powerpc__) || defined(__s390x__) || __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-TEST_F(SubprocessMemoryTest, DISABLED_DefinitionEndTruncation) {
-#else
 TEST_F(SubprocessMemoryTest, DefinitionEndTruncation) {
-#endif
   testCommon({{"test1", {APInt(48, 0xaabbccddeeff), 4096, 0}}}, 3);
   std::vector<uint8_t> Test1Expected(512, 0);
   // order is reversed since we're assuming a little endian system.
@@ -150,7 +135,8 @@ TEST_F(SubprocessMemoryTest, DefinitionEndTruncation) {
   checkSharedMemoryDefinition(getSharedMemoryName(3, 0), 4096, Test1Expected);
 }
 
-#endif // defined(__linux__) && !defined(__ANDROID__)
+#endif // defined(__linux__) && !defined(__ANDROID__) && __BYTE_ORDER__ ==
+       // __ORDER_LITTLE_ENDIAN__
 
 } // namespace exegesis
 } // namespace llvm


### PR DESCRIPTION
Three `llvm-exegesis` tests
```
  LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/SubprocessMemoryTest/DefinitionFillsCompletely
  LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/SubprocessMemoryTest/MultipleDefinitions
  LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/SubprocessMemoryTest/OneDefinition
```
`FAIL` on Linux/sparc64 like
```
llvm/unittests/tools/llvm-exegesis/X86/SubprocessMemoryTest.cpp:68: Failure
Expected equality of these values:
  SharedMemoryMapping[I]
    Which is: '\0'
  ExpectedValue[I]
    Which is: '\xAA' (170)
```
It seems like this test only works on little-endian hosts: three sub-tests are already disabled on powerpc and s390x (both big-endian), and the fourth is additionally guarded against big-endian hosts (making the other guards unnecessary).

However, since it's not been analyzed if this is really an endianess issue, this patch disables the whole test on powerpc and s390x as before adding sparc to the mix.

Tested on `sparc64-unknown-linux-gnu` and `x86_64-pc-linux-gnu`.