### PR TITLE
[clang-tidy] Fix modernize-use-std-format lit test signature

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format.cpp
@@ -11,9 +11,8 @@
 
 namespace absl
 {
-// Use const char * for the format since the real type is hard to mock up.
-template <typename... Args>
-std::string StrFormat(const char *format, const Args&... args);
+template <typename S, typename... Args>
+std::string StrFormat(const S &format, const Args&... args);
 } // namespace absl
 
 template <typename T>


### PR DESCRIPTION
My fix for my original fix of issue #92896 in
666d224248707f373577b5b049b5b0229100006c modified the function signature for fmt::sprintf to more accurately match the real implementation in libfmt but failed to do the same for absl::StrFormat. The latter fix applied equally well to absl::StrFormat so it's important that its test verifies that the bug is fixed too.