### PR TITLE
[clang][Interp] Handle union copy/move ctors

### DIFF
--- a/clang/test/AST/Interp/unions.cpp
+++ b/clang/test/AST/Interp/unions.cpp
@@ -346,5 +346,16 @@ namespace IndirectField {
   static_assert(s2.f == 7, "");
 }
 
+namespace CopyCtor {
+  union U {
+    int a;
+    int b;
+  };
 
+  constexpr U x = {42};
+  constexpr U y = x;
+  static_assert(y.a == 42, "");
+  static_assert(y.b == 42, ""); // both-error {{constant expression}} \
+                                // both-note {{'b' of union with active member 'a'}}
+}
 #endif


### PR DESCRIPTION
They don't have a body and we need to implement them ourselves. Use the Memcpy op to do that.