### PR TITLE
Bump CI container clang version to 18.1.8

### DIFF
--- a/.github/workflows/containers/github-action-ci/stage1.Dockerfile
+++ b/.github/workflows/containers/github-action-ci/stage1.Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/ubuntu:22.04 as base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base as stage1-toolchain
-ENV LLVM_VERSION=17.0.6
+ENV LLVM_VERSION=18.1.8
 
 RUN apt-get update && \
     apt-get install -y \
@@ -21,11 +21,9 @@ WORKDIR /llvm-project-llvmorg-$LLVM_VERSION
 
 COPY bootstrap.patch /
 
-# TODO(boomanaiden154): Remove the patch pulled from a LLVM PR once we bump
-# the toolchain to version 18 and the patch is in-tree.
 # TODO(boomanaiden154): Remove the bootstrap patch once we unsplit the build
 # and no longer need to explicitly build the stage2 dependencies.
-RUN curl https://github.com/llvm/llvm-project/commit/dd0356d741aefa25ece973d6cc4b55dcb73b84b4.patch | patch -p1 && cat /bootstrap.patch | patch -p1
+RUN cat /bootstrap.patch | patch -p1
 
 RUN mkdir build
 


### PR DESCRIPTION
This patch bumps the CI container LLVM version to 18.1.8. This should've been bumped a while ago, but I just noticed that it was out of date. This also allows us to drop a patch that we manually had to add as it is by default included in v18.