### PR TITLE
[mlir] [dataflow] Add a loadAnalysis method to the dataflow analysis

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h
@@ -106,6 +106,10 @@ public:
                       ArrayRef<Lattice<ConstantValue> *> results) override;
 
   void setToEntryState(Lattice<ConstantValue> *lattice) override;
+
+  static void loadAnalysis(DataFlowSolver &solver) {
+    solver.load<SparseConstantPropagation>();
+  }
 };
 
 } // end namespace dataflow

--- a/mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h
@@ -15,6 +15,7 @@
 #ifndef MLIR_ANALYSIS_DATAFLOW_DEADCODEANALYSIS_H
 #define MLIR_ANALYSIS_DATAFLOW_DEADCODEANALYSIS_H
 
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -183,6 +184,11 @@ public:
   /// Visit an operation with control-flow semantics and deduce which of its
   /// successors are live.
   LogicalResult visit(ProgramPoint point) override;
+
+  static void loadAnalysis(DataFlowSolver &solver) {
+    solver.load<SparseConstantPropagation>();
+    solver.load<DeadCodeAnalysis>();
+  }
 
 private:
   /// Find and mark symbol callables with potentially unknown callsites as

--- a/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
@@ -18,6 +18,8 @@
 #ifndef MLIR_ANALYSIS_DATAFLOW_INTEGERANGEANALYSIS_H
 #define MLIR_ANALYSIS_DATAFLOW_INTEGERANGEANALYSIS_H
 
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 
@@ -68,6 +70,12 @@ public:
   visitNonControlFlowArguments(Operation *op, const RegionSuccessor &successor,
                                ArrayRef<IntegerValueRangeLattice *> argLattices,
                                unsigned firstIndex) override;
+
+  static void loadAnalysis(DataFlowSolver &solver) {
+    solver.load<SparseConstantPropagation>();
+    solver.load<DeadCodeAnalysis>();
+    solver.load<IntegerRangeAnalysis>();
+  }
 };
 
 } // end namespace dataflow

--- a/mlir/include/mlir/Analysis/DataFlow/LivenessAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/LivenessAnalysis.h
@@ -23,7 +23,7 @@
 #ifndef MLIR_ANALYSIS_DATAFLOW_LIVENESSANALYSIS_H
 #define MLIR_ANALYSIS_DATAFLOW_LIVENESSANALYSIS_H
 
-#include <mlir/Analysis/DataFlow/SparseAnalysis.h>
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include <optional>
 
 namespace mlir::dataflow {

--- a/mlir/test/lib/Analysis/DataFlow/TestDenseBackwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestDenseBackwardDataFlowAnalysis.cpp
@@ -262,10 +262,8 @@ struct TestNextAccessPass
 
     auto config = DataFlowConfig().setInterprocedural(interprocedural);
     DataFlowSolver solver(config);
-    solver.load<DeadCodeAnalysis>();
+    UnderlyingValueAnalysis::loadAnalysis(solver);
     solver.load<NextAccessAnalysis>(symbolTable, assumeFuncReads);
-    solver.load<SparseConstantPropagation>();
-    solver.load<UnderlyingValueAnalysis>();
     if (failed(solver.initializeAndRun(op))) {
       emitError(op->getLoc(), "dataflow solver failed");
       return signalPassFailure();

--- a/mlir/test/lib/Analysis/DataFlow/TestDenseDataFlowAnalysis.h
+++ b/mlir/test/lib/Analysis/DataFlow/TestDenseDataFlowAnalysis.h
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/IR/Value.h"
@@ -219,6 +221,12 @@ public:
       value = underlyingValue;
     } while (true);
     return value;
+  }
+
+  static void loadAnalysis(DataFlowSolver &solver) {
+    solver.load<SparseConstantPropagation>();
+    solver.load<DeadCodeAnalysis>();
+    solver.load<UnderlyingValueAnalysis>();
   }
 };
 

--- a/mlir/test/lib/Analysis/DataFlow/TestSparseBackwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestSparseBackwardDataFlowAnalysis.cpp
@@ -181,8 +181,7 @@ struct TestWrittenToPass
     SymbolTableCollection symbolTable;
 
     DataFlowSolver solver(DataFlowConfig().setInterprocedural(interprocedural));
-    solver.load<DeadCodeAnalysis>();
-    solver.load<SparseConstantPropagation>();
+    DeadCodeAnalysis::loadAnalysis(solver);
     solver.load<WrittenToAnalysis>(symbolTable, assumeFuncWrites);
     if (failed(solver.initializeAndRun(op)))
       return signalPassFailure();


### PR DESCRIPTION
Dataflow analyses often depend on each other, requiring manual selection of analyses to load in order to obtain desired analysis results. As the number of analyses in the downstream repo increases, maintaining relationships between analyses at call sites becomes increasingly redundant. This submission proposes adding a loadAnalysis method to the dataflow analysis to internally manage dependencies on other analyses.