### PR TITLE
[CI][libclang] Add PR autolabeling for libclang

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -994,6 +994,8 @@ clang:as-a-library:
   - clang/tools/libclang/**
   - clang/bindings/**
   - clang/include/clang-c/**
+  - clang/test/LibClang/**
+  - clang/unittest/libclang/**
 
 openmp:libomp:
   - any: ['openmp/**', '!openmp/libomptarget/**']

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -990,6 +990,11 @@ clang:openmp:
   - llvm/unittests/Frontend/OpenMP*
   - llvm/test/Transforms/OpenMP/**
 
+clang:as-a-library:
+  - clang/tools/libclang/**
+  - clang/bindings/**
+  - clang/include/clang-c/**
+
 openmp:libomp:
   - any: ['openmp/**', '!openmp/libomptarget/**']
 


### PR DESCRIPTION
This automatically adds the `clang:as-a-library` label on PRs for the C and Python bindings and the libclang library