### PR TITLE
[TableGen] Detect invalid -D arguments and fail

### DIFF
--- a/llvm/test/TableGen/invalid-macro-name-command-line.td
+++ b/llvm/test/TableGen/invalid-macro-name-command-line.td
@@ -1,0 +1,9 @@
+// RUN: not llvm-tblgen %s -DMACRO=1 2>&1 | FileCheck %s --check-prefix=CHECK-TEST-1
+// RUN: not llvm-tblgen %s -D0MAC 2>&1 | FileCheck %s --check-prefix=CHECK-TEST-2
+// RUN: not llvm-tblgen %s -D_MAC# 2>&1 | FileCheck %s --check-prefix=CHECK-TEST-3
+// RUN: not llvm-tblgen %s -D 2>&1 | FileCheck %s --check-prefix=CHECK-TEST-4
+
+// CHECK-TEST-1: error: Invalid macro name `MACRO=1` specified on command line
+// CHECK-TEST-2: error: Invalid macro name `0MAC` specified on command line
+// CHECK-TEST-3: error: Invalid macro name `_MAC#` specified on command line
+// CHECK-TEST-4: for the -D option: requires a value!


### PR DESCRIPTION
- Detect invalid macro names specified on command line and fail if one found.
- Specifically, -DXYZ=1 for example, will fail instead is being silently accepted.