### PR TITLE
libc: Remove `extern "C"` from main declarations

### DIFF
--- a/libc/benchmarks/gpu/LibcGpuBenchmarkMain.cpp
+++ b/libc/benchmarks/gpu/LibcGpuBenchmarkMain.cpp
@@ -1,6 +1,6 @@
 #include "LibcGpuBenchmark.h"
 
-extern "C" int main(int argc, char **argv, char **envp) {
+int main(int argc, char **argv, char **envp) {
   LIBC_NAMESPACE::benchmarks::Benchmark::run_benchmarks();
   return 0;
 }

--- a/libc/startup/gpu/amdgpu/start.cpp
+++ b/libc/startup/gpu/amdgpu/start.cpp
@@ -13,7 +13,7 @@
 #include "src/stdlib/atexit.h"
 #include "src/stdlib/exit.h"
 
-extern "C" int main(int argc, char **argv, char **envp);
+int main(int argc, char **argv, char **envp);
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/startup/gpu/nvptx/start.cpp
+++ b/libc/startup/gpu/nvptx/start.cpp
@@ -13,7 +13,7 @@
 #include "src/stdlib/atexit.h"
 #include "src/stdlib/exit.h"
 
-extern "C" int main(int argc, char **argv, char **envp);
+int main(int argc, char **argv, char **envp);
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/startup/linux/do_start.cpp
+++ b/libc/startup/linux/do_start.cpp
@@ -20,7 +20,7 @@
 #include <sys/mman.h>
 #include <sys/syscall.h>
 
-extern "C" int main(int argc, char **argv, char **envp);
+int main(int argc, char **argv, char **envp);
 
 extern "C" {
 // These arrays are present in the .init_array and .fini_array sections.

--- a/libc/test/IntegrationTest/test.h
+++ b/libc/test/IntegrationTest/test.h
@@ -83,6 +83,6 @@
 // tests, then we should not need to explicitly declare/define the main
 // function in individual integration tests. We will not need this macro
 // then.
-#define TEST_MAIN extern "C" int main
+#define TEST_MAIN int main
 
 #endif // LLVM_LIBC_UTILS_INTEGRATION_TEST_TEST_H

--- a/libc/test/UnitTest/LibcTestMain.cpp
+++ b/libc/test/UnitTest/LibcTestMain.cpp
@@ -43,7 +43,7 @@ TestOptions parseOptions(int argc, char **argv) {
 
 } // anonymous namespace
 
-extern "C" int main(int argc, char **argv, char **envp) {
+int main(int argc, char **argv, char **envp) {
   LIBC_NAMESPACE::testing::argc = argc;
   LIBC_NAMESPACE::testing::argv = argv;
   LIBC_NAMESPACE::testing::envp = envp;

--- a/libc/utils/HdrGen/PrototypeTestGen/PrototypeTestGen.cpp
+++ b/libc/utils/HdrGen/PrototypeTestGen/PrototypeTestGen.cpp
@@ -47,7 +47,7 @@ bool TestGeneratorMain(llvm::raw_ostream &OS, llvm::RecordKeeper &records) {
 
   OS << '\n';
 
-  OS << "extern \"C\" int main() {\n";
+  OS << "int main() {\n";
   for (const auto &entrypoint : EntrypointNamesOption) {
     if (entrypoint == "errno")
       continue;


### PR DESCRIPTION
This is invalid in C++, and clang recently started warning on it as of #101853 