### PR TITLE
[llvm-lit] Support curly brace syntax in lit internal shell

### DIFF
--- a/llvm/utils/lit/lit/ShCommands.py
+++ b/llvm/utils/lit/lit/ShCommands.py
@@ -92,14 +92,15 @@ class Pipeline:
 
 
 class Seq:
-    def __init__(self, lhs, op, rhs):
+    def __init__(self, lhs, op, rhs, seq_type):
         assert op in (";", "&", "||", "&&")
         self.op = op
         self.lhs = lhs
         self.rhs = rhs
+        self.type = seq_type
 
     def __repr__(self):
-        return "Seq(%r, %r, %r)" % (self.lhs, self.op, self.rhs)
+        return "Seq(%r, %r, %r, %r)" % (self.lhs, self.op, self.rhs, self.type)
 
     def __eq__(self, other):
         if not isinstance(other, Seq):

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1056,7 +1056,7 @@ def executeScriptInternal(
             ln = command
         try:
             cmds.append(
-                ShUtil.ShParser(ln, litConfig.isWindows, test.config.pipefail).parse()
+                ShUtil.ShParser(ln, litConfig.isWindows, test.config.pipefail).parse(None)
             )
         except:
             raise ScriptFatal(


### PR DESCRIPTION
This patch implements parsing and execution of a series of commands grouped in curly braces in lit's internal shell. This addresses goals mentioned in this RFC: https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179.

Fixes https://github.com/llvm/llvm-project/issues/102382