### PR TITLE
[clang][NFC] sort C standards on status page in reverse chronological order

### DIFF
--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -37,9 +37,24 @@
  <th>Available in Clang?</th>
 </tr>
 <tr>
- <td><a href="#c89">C89</a></td>
- <td><tt>-std=c89</tt></td>
- <td class="full" align="center">Yes</td>
+ <td><a href="#c2y">C2y</a></td>
+ <td><tt>-std=c2y</tt></td>
+ <td class="partial" align="center">Partial</td>
+</tr>
+<tr>
+ <td><a href="#c2x">C23</a></td>
+ <td><tt>-std=c23</tt></td>
+ <td class="partial" align="center">Partial</td>
+</tr>
+<tr>
+ <td><a href="#c17">C17</a></td>
+ <td><tt>-std=c17</tt></td>
+ <td class="partial" align="center">Partial</td>
+</tr>
+<tr>
+ <td><a href="#c11">C11</a></td>
+ <td><tt>-std=c11</tt></td>
+ <td class="partial" align="center">Partial</td>
 </tr>
 <tr>
  <td><a href="#c99">C99</a></td>
@@ -55,24 +70,9 @@
       back to 3.0. -->
 </tr>
 <tr>
- <td><a href="#c11">C11</a></td>
- <td><tt>-std=c11</tt></td>
- <td class="partial" align="center">Partial</td>
-</tr>
-<tr>
- <td><a href="#c17">C17</a></td>
- <td><tt>-std=c17</tt></td>
- <td class="partial" align="center">Partial</td>
-</tr>
-<tr>
- <td><a href="#c2x">C23</a></td>
- <td><tt>-std=c23</tt></td>
- <td class="partial" align="center">Partial</td>
-</tr>
-<tr>
- <td><a href="#c2y">C2y</a></td>
- <td><tt>-std=c2y</tt></td>
- <td class="partial" align="center">Partial</td>
+ <td><a href="#c89">C89</a></td>
+ <td><tt>-std=c89</tt></td>
+ <td class="full" align="center">Yes</td>
 </tr>
 </table>
 
@@ -89,546 +89,86 @@ they become available.</p>
 the "c", "c99", "c11", "c17", "c23", and "c2y" labels to track known bugs with Clang's language
 conformance.</p>
 
-<h2 id="c89">C89 implementation status</h2>
+<h2 id="c2y">C2y implementation status</h2>
 
-<p>Clang implements all of the ISO 9899:1990 (C89) standard.</p>
-<p>You can use Clang in C89 mode with the <code>-std=c89</code> or <code>-std=c90</code> options.</p>
+<p>Clang has support for some of the features of the C standard following C23, informally referred to as C2y.</p>
 
-<h2 id="c99">C99 implementation status</h2>
+<p>You can use Clang in C2y mode with the <code>-std=c2y</code> option (available in Clang 19 and later).</p>
 
-<p>Clang implements all of the ISO 9899:1999 (C99) standard.</p>
-<p>Note, the list of C99 features comes from the C99 committee draft. Not all C99 documents are publicly available, so the documents referenced in this section may be inaccurate, unknown, or not linked.</p>
-<!-- https://www.open-std.org/jtc1/sc22/wg14/www/docs/n874.htm contains the
-     final editor's report of what's been added to C99, but it includes more
-     papers than are worth listing because it includes editorial and cleanup
-     proposals in addition to feature proposals. When a paper is not available,
-     I list the paper number from the editor's report, but do not hyperlink it.
-     When I can't map the feature back to a paper, I mark it as unknown. -->
-<p>You can use Clang in C99 mode with the <code>-std=c99</code> option.</p>
-
-<details>
+<details open>
 <summary>List of features and minimum Clang version with support</summary>
 
 <table width="689" border="1" cellspacing="0">
  <tr>
     <th>Language Feature</th>
-    <th>C99 Proposal</th>
+    <th>C2y Proposal</th>
     <th>Available in Clang?</th>
  </tr>
+    <!-- Strasbourg 2024 Papers -->
     <tr>
-      <td>restricted character set support via digraphs and &lt;iso646.h&gt;</td>
-      <td>Unknown</td>
+      <td>Sequential hexdigits</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3192.pdf">N3192</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
+    <!-- Jun 2024 Papers -->
     <tr>
-      <td>more precise aliasing rules via effective type</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>restricted pointers</td>
-      <td>N448</td>
-      <td class="partial" align="center">
-        <details><summary>Partial</summary>
-          Clang's support for <code>restrict</code> is fully conforming but
-          considered only partially implemented. Clang implements all of the
-          constraints required for <code>restrict</code> support, but LLVM only
-          supports <code>restrict</code> optimization semantics for restricted
-          pointers used as function parameters; it does not fully support the
-          semantics for restrict on local variables or data members.
-        </details>
-      </td>
-    </tr>
-    <tr>
-      <td>variable length arrays</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n683.htm">N683</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>flexible array members</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>static and type qualifiers in parameter array declarators</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>complex and imaginary support in &lt;complex.h&gt;</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n693.ps">N693</a></td>
-      <td class="partial" align="center">
-        <details><summary>Partial</summary>
-          Clang supports <code>_Complex</code> type specifiers but does not
-          support <code>_Imaginary</code> type specifiers. Support for
-          <code>_Imaginary</code> is optional in C99 and Clang does not claim
-          conformance to Annex G.<br />
-          <br />
-          <code>_Complex</code> support requires an underlying support library
-          such as compiler-rt to provide functions like <code>__divsc3</code>,
-          but compiler-rt is not supported on Windows.
-        </details>
-      </td>
-    </tr>
-    <tr>
-      <td>type-generic math macros in &lt;tgmath.h&gt;</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n693.ps">N693</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>the long long int type</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n601.ps">N601</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>increase minimum translation limits</td>
-      <td>N590</td>
-      <td class="full" align="center">Clang 3.2</td>
-    </tr>
-    <tr>
-      <td>additional floating-point characteristics in &lt;float.h&gt;</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Clang 16</td>
-    </tr>
-    <tr id="implicit int">
-      <td rowspan="4">remove implicit int</td>
-    </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n635.htm">N635</a></td>
-        <td class="full" align="center">Yes</td>
-      </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n692.htm">N692</a></td>
-        <td class="full" align="center">Yes</td>
-      </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n722.htm">N722</a></td>
-        <td class="full" align="center">Yes</td>
-      </tr>
-    <tr>
-      <td>reliable integer division</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n617.htm">N617</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>universal character names (\u and \U)</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>extended identifiers</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n717.htm">N717</a></td>
+      <td>Generic selection expression with a type operand</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3260.pdf">N3260</a></td>
       <td class="full" align="center">Clang 17</td>
     </tr>
     <tr>
-      <td>hexadecimal floating-point constants</td>
-      <td>N308</td>
-      <!-- This is a total guess. N874 makes no mention of N308 being accepted,
-           but it does mention *use* of hexadecimal floating-point constants in
-           the Menlo Park minutes associated with N787. -->
+      <td>Round-trip rounding</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3232.pdf">N3232</a></td>
+      <td class="full" align="center">Yes</td>
+      <!-- editorial changes, no tests required -->
+    </tr>
+    <tr>
+      <td>Accessing byte arrays</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3254.pdf">N3254</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>compound literals</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n716.htm">N716</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>designated initializers</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n494.pdf">N494</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>// comments</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n644.htm">N644</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>extended integer types and library functions in &lt;inttypes.h&gt; and &lt;stdint.h&gt;</td>
-      <td>Unknown</td>
-      <!-- Seems to be related to https://www.open-std.org/jtc1/sc22/wg14/www/docs/n788.htm
-           but that does not have any content for stdint.h. The next paper I could find on
-           the topic was https://www.open-std.org/jtc1/sc22/wg14/www/docs/n851.htm but that
-           implies stdint.h was already added. -->
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>remove implicit function declaration</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n636.htm">N636</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>preprocessor arithmetic done in intmax_t/uintmax_t</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n736.htm">N736</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>mixed declarations and code</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n740.htm">N740</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>new block scopes for selection and iteration statements</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>integer constant type rules</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n629.htm">N629</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>integer promotion rules</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n725.htm">N725</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>macros with a variable number of arguments</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n707.htm">N707</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>IEC 60559 support</td>
-      <td>Unknown</td>
+      <td>Slay some earthly demons I</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3244.pdf">N3244</a></td>
       <td class="partial" align="center">
+      <!-- Voted in:
+             Annex J Item 21 (including additional change)
+             Annex J Item 56
+             Annex J Item 57 Option 1
+             Annex J Item 67
+             Annex J Item 69 (alternative wording for semantics)
+      -->
         <details><summary>Partial</summary>
-          Clang supports much of the language requirements for Annex F, but
-          full conformance is only possible to determine when considering the
-          compiler's language support, the C runtime library's math library
-          support, and the target system's floating-point environment support.
-          Clang does not currently raise an "invalid" floating-point exception
-          on certain conversions, does not raise floating-point exceptions for
-          arithmetic constant expressions, and other corner cases. Note, Clang
-          does not define <code>__STDC_IEC_559__</code> because the compiler
-          does not fully conform. However, some C standard library
-          implementations
-          (<a href="https://sourceware.org/git/?p=glibc.git;a=blob;f=include/stdc-predef.h">
-          glibc</a>, <a href="https://git.musl-libc.org/cgit/musl/tree/include/stdc-predef.h">
-          musl</a> will define the macro regardless of compiler support unless
-          the compiler defines <code>__GCC_IEC_559</code>, which Clang does not
-          currently define.<br>
-          Additionally, Clang intentionally will not conform to Annex F on
-          32-bit x86 without SSE2 due to the behavior of floating-point
-          operations in x87.
+          Clang does not document the implementation-defined behavior for decay
+          of an array with the register storage class specifier. Clang does not
+          diagnose an <code>extern inline</code> function with no definition in
+          the TU. Clang accepts and rejects redeclarations with/without an
+          alignment specifier, depending on the order of the declarations.
         </details>
       </td>
     </tr>
     <tr>
-      <td>trailing comma allowed in enum declaration</td>
-      <td>Unknown</td>
+      <td>Support ++ and -- on complex values</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3259.pdf">N3259</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>inline functions</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n741.htm">N741</a></td>
+      <td>Usability of a byte-wise copy of va_list</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3262.pdf">N3262</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>boolean type in &lt;stdbool.h&gt;</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n815.htm">N815</a></td>
-      <td class="full" align="center">Yes</td>
+      <td>alignof of an incomplete array type</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3273.pdf">N3273</a></td>
+      <td class="full" align="center">Clang 3.5</td>
     </tr>
     <tr>
-      <td>idempotent type qualifiers</td>
-      <td>N505</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>empty macro arguments</td>
-      <td>N570</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>additional predefined macro names</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Yes</td>
-      <!-- It is unknown which paper brought in this change, which was listed in
-           the C99 front matter. After hunting around for what these changes are,
-           I found a mention in the C99 rationale document that implementers who
-           wish to add their own predefined macros must not start them with
-           __STDC_, which was a new restriction in C99. As best I can tell, that
-           is what this particular feature is about. -->
-    </tr>
-    <tr>
-      <td>_Pragma preprocessing operator</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n634.ps">N634</a></td>
-      <!-- This may not be quite right as it proposes a `pragma` operator and
-           not a _Pragma operator. However, I didn't see further papers on the
-           renamed form, so I assume this was accepted with modification. -->
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr id="standard pragmas">
-      <td rowspan="3">standard pragmas</td>
-    </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n631.htm">N631</a></td>
-        <td class="full" align="center">Yes</td>
-      </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n696.ps">N696</a></td>
-        <td class="full" align="center">Yes</td>
-      </tr>
-    <tr>
-      <td>__func__ predefined identifier</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n611.ps">N611</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>va_copy macro</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n671.htm">N671</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>remove deprecation of aliased array parameters</td>
-      <td>Unknown</td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>conversion of array to pointer not limited to lvalues</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n835.pdf">N835</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>relaxed constraints on aggregate and union initialization</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n782.htm">N782</a></td>
-      <td class="full" align="center">Clang 3.4</td>
-    </tr>
-    <tr>
-      <td>relaxed restrictions on portable header names</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n772.htm">N772</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>return without an expression not permitted in function that returns a value</td>
-      <td>Unknown</td>
+      <td>Remove imaginary types</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3274.pdf">N3274</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
 </table>
 </details>
-
-<h2 id="c11">C11 implementation status</h2>
-
-<p>Clang implements a significant portion of the ISO 9899:2011 (C11) standard, but the status of individual proposals is still under investigation.</p>
-<p>You can use Clang in C11 mode with the <code>-std=c11</code> option (use <code>-std=c1x</code> in Clang 3.0 and earlier).</p>
-
-<details>
-<summary>List of features and minimum Clang version with support</summary>
-
-<table width="689" border="1" cellspacing="0">
- <tr>
-    <th>Language Feature</th>
-    <th>C11 Proposal</th>
-    <th>Available in Clang?</th>
- </tr>
-    <tr>
-      <td>A finer-grained specification for sequencing</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1252.htm">N1252</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-    <tr>
-      <td>Clarification of expressions</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1282.pdf">N1282</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Extending the lifetime of temporary objects (factored approach)</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1285.htm">N1285</a></td>
-      <td class="none" align="center">No</td>
-    </tr>
-    <tr>
-      <td>Requiring signed char to have no padding bits</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1310.htm">N1310</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Initializing static or external variables</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1311.pdf">N1311</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Conversion between pointers and floating types</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1316.htm">N1316</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Adding TR 19769 to the C Standard Library</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1326.pdf">N1326</a></td>
-      <td class="full" align="center">Clang 3.3</td>
-    </tr>
-    <tr>
-      <td>Static assertions</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1330.pdf">N1330</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Parallel memory sequencing model proposal</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1349.htm">N1349</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-    <tr>
-      <td>_Bool bit-fields</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1356.htm">N1356</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Technical corrigendum for C1X</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1359.htm">N1359</a></td>
-      <td class="full" align="center">Yes</td>
-      <!-- The DRs listed in the paper are individually tested in clang/test/C/drs/dr3xx.c and others -->
-    </tr>
-    <tr>
-      <td>Benign typedef redefinition</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1360.htm">N1360</a></td>
-      <td class="full" align="center">Clang 3.1</td>
-    </tr>
-    <tr>
-      <td>Thread-local storage</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1364.htm">N1364</a></td>
-      <td class="full" align="center">Clang 3.3</td>
-    </tr>
-    <tr>
-      <td>Constant expressions</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1365.htm">N1365</a></td>
-      <td class="full" align="center">Clang 16</td>
-    </tr>
-    <tr>
-      <td>Contractions and expression evaluation methods</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1367.htm">N1367</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-    <tr>
-      <td>Floating-point to int/_Bool conversions</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1391.htm">N1391</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Wide function returns (alternate proposal)</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1396.htm">N1396</a></td>
-      <td class="full" align="center">
-        <details><summary>Yes*</summary>
-        Clang conforms to this paper on all targets except 32-bit x86 without
-        SSE2. However, Clang does not claim conformance to Annex F on any
-        target and does not intend to ever conform to Annex F on that specific
-        target, so no changes are needed to conform to this paper.
-        </details>
-      </td>
-    </tr>
-    <tr id="alignment">
-      <td rowspan="3">Alignment</td>
-    </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1397.htm">N1397</a></td>
-        <td class="full" align="center">Clang 3.2</td>
-      </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1447.htm">N1447</a></td>
-        <td class="full" align="center">Clang 3.2</td>
-      </tr>
-    <tr>
-      <td>Anonymous member-structures and unions (modulo "name lookup")</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1406.pdf">N1406</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Completeness of types</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1439.pdf">N1439</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Generic macro facility</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1441.htm">N1441</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Dependency ordering for C memory model</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1444.htm">N1444</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-    <tr>
-      <td>Subsetting the standard</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1460.htm">N1460</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Assumed types in F.9.2</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1468.htm">N1468</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-    <tr>
-      <td>Supporting the 'noreturn' property in C1x</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1478.htm">N1478</a></td>
-      <td class="full" align="center">Clang 3.3</td>
-    </tr>
-    <tr>
-      <td>Updates to C++ memory model based on formalization</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1480.htm">N1480</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-    <tr>
-      <td>Explicit initializers for atomics</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1482.htm">N1482</a></td>
-      <td class="full" align="center">Clang 4</td>
-    </tr>
-    <tr>
-      <td>Atomics proposal (minus ternary op)</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1485.pdf">N1485</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>UTF-8 string literals</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1488.htm">N1488</a></td>
-      <td class="full" align="center">Clang 3.3</td>
-    </tr>
-    <tr>
-      <td>Optimizing away infinite loops</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1509.pdf">N1509</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Conditional normative status for Annex G</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1514.pdf">N1514</a></td>
-      <td class="full" align="center">Yes <a href="#annex-g">(1)</a></td>
-    </tr>
-    <tr>
-      <td>Creation of complex value</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1464.htm">N1464</a></td>
-      <td class="full" align="center">Clang 12</td>
-    </tr>
-    <tr>
-      <td>Recommendations for extended identifier characters for C and C++</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1518.htm">N1518</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-    <tr>
-      <td>Atomic C1x/C++0x compatibility refinements (1st part only)</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1526.pdf">N1526</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Atomic bitfields implementation defined</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1530.pdf">N1530</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Small fix for the effect of alignment on struct/union type compatibility</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1532.htm">N1532</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>Clarification for wide evaluation</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1531.pdf">N1531</a></td>
-      <td class="unknown" align="center">Unknown</td>
-    </tr>
-</table>
-<span id="annex-g">(1): Clang does not implement Annex G, so our conditional support
-conforms by not defining the <code>__STDC_IEC_559_COMPLEX__</code> macro.
-</span>
-</details>
-
-<h2 id="c17">C17 implementation status</h2>
-
-<p>There are no major changes in this edition, only technical corrections and clarifications that are tracked by Defect Report.</p>
-<p>You can use Clang in C17 mode with the <code>-std=c17</code> or <code>-std=c18</code> options (available in Clang 6 and later).</p>
 
 <h2 id="c2x">C23 implementation status</h2>
 
@@ -1235,86 +775,546 @@ conforms by not defining the <code>__STDC_IEC_559_COMPLEX__</code> macro.
 </table>
 </details>
 
-<h2 id="c2y">C2y implementation status</h2>
+<h2 id="c17">C17 implementation status</h2>
 
-<p>Clang has support for some of the features of the C standard following C23, informally referred to as C2y.</p>
+<p>There are no major changes in this edition, only technical corrections and clarifications that are tracked by Defect Report.</p>
+<p>You can use Clang in C17 mode with the <code>-std=c17</code> or <code>-std=c18</code> options (available in Clang 6 and later).</p>
 
-<p>You can use Clang in C2y mode with the <code>-std=c2y</code> option (available in Clang 19 and later).</p>
+<h2 id="c11">C11 implementation status</h2>
 
-<details open>
+<p>Clang implements a significant portion of the ISO 9899:2011 (C11) standard, but the status of individual proposals is still under investigation.</p>
+<p>You can use Clang in C11 mode with the <code>-std=c11</code> option (use <code>-std=c1x</code> in Clang 3.0 and earlier).</p>
+
+<details>
 <summary>List of features and minimum Clang version with support</summary>
 
 <table width="689" border="1" cellspacing="0">
  <tr>
     <th>Language Feature</th>
-    <th>C2y Proposal</th>
+    <th>C11 Proposal</th>
     <th>Available in Clang?</th>
  </tr>
-    <!-- Strasbourg 2024 Papers -->
     <tr>
-      <td>Sequential hexdigits</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3192.pdf">N3192</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <!-- Jun 2024 Papers -->
-    <tr>
-      <td>Generic selection expression with a type operand</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3260.pdf">N3260</a></td>
-      <td class="full" align="center">Clang 17</td>
+      <td>A finer-grained specification for sequencing</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1252.htm">N1252</a></td>
+      <td class="unknown" align="center">Unknown</td>
     </tr>
     <tr>
-      <td>Round-trip rounding</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3232.pdf">N3232</a></td>
-      <td class="full" align="center">Yes</td>
-      <!-- editorial changes, no tests required -->
-    </tr>
-    <tr>
-      <td>Accessing byte arrays</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3254.pdf">N3254</a></td>
+      <td>Clarification of expressions</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1282.pdf">N1282</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>Slay some earthly demons I</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3244.pdf">N3244</a></td>
+      <td>Extending the lifetime of temporary objects (factored approach)</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1285.htm">N1285</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>Requiring signed char to have no padding bits</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1310.htm">N1310</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Initializing static or external variables</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1311.pdf">N1311</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Conversion between pointers and floating types</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1316.htm">N1316</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Adding TR 19769 to the C Standard Library</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1326.pdf">N1326</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Static assertions</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1330.pdf">N1330</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Parallel memory sequencing model proposal</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1349.htm">N1349</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>_Bool bit-fields</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1356.htm">N1356</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Technical corrigendum for C1X</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1359.htm">N1359</a></td>
+      <td class="full" align="center">Yes</td>
+      <!-- The DRs listed in the paper are individually tested in clang/test/C/drs/dr3xx.c and others -->
+    </tr>
+    <tr>
+      <td>Benign typedef redefinition</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1360.htm">N1360</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Thread-local storage</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1364.htm">N1364</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Constant expressions</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1365.htm">N1365</a></td>
+      <td class="full" align="center">Clang 16</td>
+    </tr>
+    <tr>
+      <td>Contractions and expression evaluation methods</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1367.htm">N1367</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Floating-point to int/_Bool conversions</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1391.htm">N1391</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Wide function returns (alternate proposal)</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1396.htm">N1396</a></td>
+      <td class="full" align="center">
+        <details><summary>Yes*</summary>
+        Clang conforms to this paper on all targets except 32-bit x86 without
+        SSE2. However, Clang does not claim conformance to Annex F on any
+        target and does not intend to ever conform to Annex F on that specific
+        target, so no changes are needed to conform to this paper.
+        </details>
+      </td>
+    </tr>
+    <tr id="alignment">
+      <td rowspan="3">Alignment</td>
+    </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1397.htm">N1397</a></td>
+        <td class="full" align="center">Clang 3.2</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1447.htm">N1447</a></td>
+        <td class="full" align="center">Clang 3.2</td>
+      </tr>
+    <tr>
+      <td>Anonymous member-structures and unions (modulo "name lookup")</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1406.pdf">N1406</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Completeness of types</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1439.pdf">N1439</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Generic macro facility</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1441.htm">N1441</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Dependency ordering for C memory model</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1444.htm">N1444</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Subsetting the standard</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1460.htm">N1460</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Assumed types in F.9.2</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1468.htm">N1468</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Supporting the 'noreturn' property in C1x</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1478.htm">N1478</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Updates to C++ memory model based on formalization</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1480.htm">N1480</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Explicit initializers for atomics</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1482.htm">N1482</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+    <tr>
+      <td>Atomics proposal (minus ternary op)</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1485.pdf">N1485</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>UTF-8 string literals</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1488.htm">N1488</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Optimizing away infinite loops</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1509.pdf">N1509</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Conditional normative status for Annex G</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1514.pdf">N1514</a></td>
+      <td class="full" align="center">Yes <a href="#annex-g">(1)</a></td>
+    </tr>
+    <tr>
+      <td>Creation of complex value</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1464.htm">N1464</a></td>
+      <td class="full" align="center">Clang 12</td>
+    </tr>
+    <tr>
+      <td>Recommendations for extended identifier characters for C and C++</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1518.htm">N1518</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Atomic C1x/C++0x compatibility refinements (1st part only)</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1526.pdf">N1526</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Atomic bitfields implementation defined</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1530.pdf">N1530</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Small fix for the effect of alignment on struct/union type compatibility</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1532.htm">N1532</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>Clarification for wide evaluation</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1531.pdf">N1531</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+</table>
+<span id="annex-g">(1): Clang does not implement Annex G, so our conditional support
+conforms by not defining the <code>__STDC_IEC_559_COMPLEX__</code> macro.
+</span>
+</details>
+
+<h2 id="c99">C99 implementation status</h2>
+
+<p>Clang implements all of the ISO 9899:1999 (C99) standard.</p>
+<p>Note, the list of C99 features comes from the C99 committee draft. Not all C99 documents are publicly available, so the documents referenced in this section may be inaccurate, unknown, or not linked.</p>
+<!-- https://www.open-std.org/jtc1/sc22/wg14/www/docs/n874.htm contains the
+     final editor's report of what's been added to C99, but it includes more
+     papers than are worth listing because it includes editorial and cleanup
+     proposals in addition to feature proposals. When a paper is not available,
+     I list the paper number from the editor's report, but do not hyperlink it.
+     When I can't map the feature back to a paper, I mark it as unknown. -->
+<p>You can use Clang in C99 mode with the <code>-std=c99</code> option.</p>
+
+<details>
+<summary>List of features and minimum Clang version with support</summary>
+
+<table width="689" border="1" cellspacing="0">
+ <tr>
+    <th>Language Feature</th>
+    <th>C99 Proposal</th>
+    <th>Available in Clang?</th>
+ </tr>
+    <tr>
+      <td>restricted character set support via digraphs and &lt;iso646.h&gt;</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>more precise aliasing rules via effective type</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>restricted pointers</td>
+      <td>N448</td>
       <td class="partial" align="center">
-      <!-- Voted in:
-             Annex J Item 21 (including additional change)
-             Annex J Item 56
-             Annex J Item 57 Option 1
-             Annex J Item 67
-             Annex J Item 69 (alternative wording for semantics)
-      -->
         <details><summary>Partial</summary>
-          Clang does not document the implementation-defined behavior for decay
-          of an array with the register storage class specifier. Clang does not
-          diagnose an <code>extern inline</code> function with no definition in
-          the TU. Clang accepts and rejects redeclarations with/without an
-          alignment specifier, depending on the order of the declarations.
+          Clang's support for <code>restrict</code> is fully conforming but
+          considered only partially implemented. Clang implements all of the
+          constraints required for <code>restrict</code> support, but LLVM only
+          supports <code>restrict</code> optimization semantics for restricted
+          pointers used as function parameters; it does not fully support the
+          semantics for restrict on local variables or data members.
         </details>
       </td>
     </tr>
     <tr>
-      <td>Support ++ and -- on complex values</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3259.pdf">N3259</a></td>
+      <td>variable length arrays</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n683.htm">N683</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>Usability of a byte-wise copy of va_list</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3262.pdf">N3262</a></td>
+      <td>flexible array members</td>
+      <td>Unknown</td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>alignof of an incomplete array type</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3273.pdf">N3273</a></td>
-      <td class="full" align="center">Clang 3.5</td>
+      <td>static and type qualifiers in parameter array declarators</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>Remove imaginary types</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3274.pdf">N3274</a></td>
+      <td>complex and imaginary support in &lt;complex.h&gt;</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n693.ps">N693</a></td>
+      <td class="partial" align="center">
+        <details><summary>Partial</summary>
+          Clang supports <code>_Complex</code> type specifiers but does not
+          support <code>_Imaginary</code> type specifiers. Support for
+          <code>_Imaginary</code> is optional in C99 and Clang does not claim
+          conformance to Annex G.<br />
+          <br />
+          <code>_Complex</code> support requires an underlying support library
+          such as compiler-rt to provide functions like <code>__divsc3</code>,
+          but compiler-rt is not supported on Windows.
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td>type-generic math macros in &lt;tgmath.h&gt;</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n693.ps">N693</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>the long long int type</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n601.ps">N601</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>increase minimum translation limits</td>
+      <td>N590</td>
+      <td class="full" align="center">Clang 3.2</td>
+    </tr>
+    <tr>
+      <td>additional floating-point characteristics in &lt;float.h&gt;</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Clang 16</td>
+    </tr>
+    <tr id="implicit int">
+      <td rowspan="4">remove implicit int</td>
+    </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n635.htm">N635</a></td>
+        <td class="full" align="center">Yes</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n692.htm">N692</a></td>
+        <td class="full" align="center">Yes</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n722.htm">N722</a></td>
+        <td class="full" align="center">Yes</td>
+      </tr>
+    <tr>
+      <td>reliable integer division</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n617.htm">N617</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>universal character names (\u and \U)</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>extended identifiers</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n717.htm">N717</a></td>
+      <td class="full" align="center">Clang 17</td>
+    </tr>
+    <tr>
+      <td>hexadecimal floating-point constants</td>
+      <td>N308</td>
+      <!-- This is a total guess. N874 makes no mention of N308 being accepted,
+           but it does mention *use* of hexadecimal floating-point constants in
+           the Menlo Park minutes associated with N787. -->
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>compound literals</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n716.htm">N716</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>designated initializers</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n494.pdf">N494</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>// comments</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n644.htm">N644</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>extended integer types and library functions in &lt;inttypes.h&gt; and &lt;stdint.h&gt;</td>
+      <td>Unknown</td>
+      <!-- Seems to be related to https://www.open-std.org/jtc1/sc22/wg14/www/docs/n788.htm
+           but that does not have any content for stdint.h. The next paper I could find on
+           the topic was https://www.open-std.org/jtc1/sc22/wg14/www/docs/n851.htm but that
+           implies stdint.h was already added. -->
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>remove implicit function declaration</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n636.htm">N636</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>preprocessor arithmetic done in intmax_t/uintmax_t</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n736.htm">N736</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>mixed declarations and code</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n740.htm">N740</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>new block scopes for selection and iteration statements</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>integer constant type rules</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n629.htm">N629</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>integer promotion rules</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n725.htm">N725</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>macros with a variable number of arguments</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n707.htm">N707</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>IEC 60559 support</td>
+      <td>Unknown</td>
+      <td class="partial" align="center">
+        <details><summary>Partial</summary>
+          Clang supports much of the language requirements for Annex F, but
+          full conformance is only possible to determine when considering the
+          compiler's language support, the C runtime library's math library
+          support, and the target system's floating-point environment support.
+          Clang does not currently raise an "invalid" floating-point exception
+          on certain conversions, does not raise floating-point exceptions for
+          arithmetic constant expressions, and other corner cases. Note, Clang
+          does not define <code>__STDC_IEC_559__</code> because the compiler
+          does not fully conform. However, some C standard library
+          implementations
+          (<a href="https://sourceware.org/git/?p=glibc.git;a=blob;f=include/stdc-predef.h">
+          glibc</a>, <a href="https://git.musl-libc.org/cgit/musl/tree/include/stdc-predef.h">
+          musl</a> will define the macro regardless of compiler support unless
+          the compiler defines <code>__GCC_IEC_559</code>, which Clang does not
+          currently define.<br>
+          Additionally, Clang intentionally will not conform to Annex F on
+          32-bit x86 without SSE2 due to the behavior of floating-point
+          operations in x87.
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td>trailing comma allowed in enum declaration</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>inline functions</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n741.htm">N741</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>boolean type in &lt;stdbool.h&gt;</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n815.htm">N815</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>idempotent type qualifiers</td>
+      <td>N505</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>empty macro arguments</td>
+      <td>N570</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>additional predefined macro names</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
+      <!-- It is unknown which paper brought in this change, which was listed in
+           the C99 front matter. After hunting around for what these changes are,
+           I found a mention in the C99 rationale document that implementers who
+           wish to add their own predefined macros must not start them with
+           __STDC_, which was a new restriction in C99. As best I can tell, that
+           is what this particular feature is about. -->
+    </tr>
+    <tr>
+      <td>_Pragma preprocessing operator</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n634.ps">N634</a></td>
+      <!-- This may not be quite right as it proposes a `pragma` operator and
+           not a _Pragma operator. However, I didn't see further papers on the
+           renamed form, so I assume this was accepted with modification. -->
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr id="standard pragmas">
+      <td rowspan="3">standard pragmas</td>
+    </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n631.htm">N631</a></td>
+        <td class="full" align="center">Yes</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n696.ps">N696</a></td>
+        <td class="full" align="center">Yes</td>
+      </tr>
+    <tr>
+      <td>__func__ predefined identifier</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n611.ps">N611</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>va_copy macro</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n671.htm">N671</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>remove deprecation of aliased array parameters</td>
+      <td>Unknown</td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>conversion of array to pointer not limited to lvalues</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n835.pdf">N835</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>relaxed constraints on aggregate and union initialization</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n782.htm">N782</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>relaxed restrictions on portable header names</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n772.htm">N772</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td>return without an expression not permitted in function that returns a value</td>
+      <td>Unknown</td>
       <td class="full" align="center">Yes</td>
     </tr>
 </table>
 </details>
+
+<h2 id="c89">C89 implementation status</h2>
+
+<p>Clang implements all of the ISO 9899:1990 (C89) standard.</p>
+<p>You can use Clang in C89 mode with the <code>-std=c89</code> or <code>-std=c90</code> options.</p>
 
 </div>
 </body>

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -785,7 +785,7 @@ conformance.</p>
 <p>Clang implements a significant portion of the ISO 9899:2011 (C11) standard, but the status of individual proposals is still under investigation.</p>
 <p>You can use Clang in C11 mode with the <code>-std=c11</code> option (use <code>-std=c1x</code> in Clang 3.0 and earlier).</p>
 
-<details>
+<details open>
 <summary>List of features and minimum Clang version with support</summary>
 
 <table width="689" border="1" cellspacing="0">
@@ -1011,7 +1011,7 @@ conforms by not defining the <code>__STDC_IEC_559_COMPLEX__</code> macro.
      When I can't map the feature back to a paper, I mark it as unknown. -->
 <p>You can use Clang in C99 mode with the <code>-std=c99</code> option.</p>
 
-<details>
+<details open>
 <summary>List of features and minimum Clang version with support</summary>
 
 <table width="689" border="1" cellspacing="0">


### PR DESCRIPTION
Put the newest standards first, same as for the [C++ status page](https://clang.llvm.org/cxx_status.html).

The diff is pretty busted, but I swear I copy & pasted faithfully 😅 

The only change beyond shuffling sections around is unfolding the sections for C99/C11 (6dbce28763153ca20138b139b9455056f173ee22), which isn't necessary anymore now that they're safely tucked away towards the end of the page.