### PR TITLE
[DataLayout] Move `operator=` to cpp file (NFC)

### DIFF
--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -120,10 +120,10 @@ private:
   bool BigEndian;
 
   unsigned AllocaAddrSpace;
-  MaybeAlign StackNaturalAlign;
   unsigned ProgramAddrSpace;
   unsigned DefaultGlobalsAddrSpace;
 
+  MaybeAlign StackNaturalAlign;
   MaybeAlign FunctionPtrAlign;
   FunctionPtrAlignType TheFunctionPtrAlignType;
 
@@ -139,6 +139,7 @@ private:
   };
   ManglingModeT ManglingMode;
 
+  // FIXME: `unsigned char` truncates the value parsed by `parseSpecifier`.
   SmallVector<unsigned char, 8> LegalIntWidths;
 
   /// Primitive type alignment data. This is sorted by type and bit
@@ -201,26 +202,7 @@ public:
 
   ~DataLayout(); // Not virtual, do not subclass this class
 
-  DataLayout &operator=(const DataLayout &DL) {
-    clear();
-    StringRepresentation = DL.StringRepresentation;
-    BigEndian = DL.isBigEndian();
-    AllocaAddrSpace = DL.AllocaAddrSpace;
-    StackNaturalAlign = DL.StackNaturalAlign;
-    FunctionPtrAlign = DL.FunctionPtrAlign;
-    TheFunctionPtrAlignType = DL.TheFunctionPtrAlignType;
-    ProgramAddrSpace = DL.ProgramAddrSpace;
-    DefaultGlobalsAddrSpace = DL.DefaultGlobalsAddrSpace;
-    ManglingMode = DL.ManglingMode;
-    LegalIntWidths = DL.LegalIntWidths;
-    IntAlignments = DL.IntAlignments;
-    FloatAlignments = DL.FloatAlignments;
-    VectorAlignments = DL.VectorAlignments;
-    StructAlignment = DL.StructAlignment;
-    Pointers = DL.Pointers;
-    NonIntegralAddressSpaces = DL.NonIntegralAddressSpaces;
-    return *this;
-  }
+  DataLayout &operator=(const DataLayout &Other);
 
   bool operator==(const DataLayout &Other) const;
   bool operator!=(const DataLayout &Other) const { return !(*this == Other); }

--- a/llvm/lib/IR/DataLayout.cpp
+++ b/llvm/lib/IR/DataLayout.cpp
@@ -220,6 +220,45 @@ void DataLayout::reset(StringRef Desc) {
     return report_fatal_error(std::move(Err));
 }
 
+DataLayout &DataLayout::operator=(const DataLayout &Other) {
+  clear();
+  StringRepresentation = Other.StringRepresentation;
+  BigEndian = Other.BigEndian;
+  AllocaAddrSpace = Other.AllocaAddrSpace;
+  ProgramAddrSpace = Other.ProgramAddrSpace;
+  DefaultGlobalsAddrSpace = Other.DefaultGlobalsAddrSpace;
+  StackNaturalAlign = Other.StackNaturalAlign;
+  FunctionPtrAlign = Other.FunctionPtrAlign;
+  TheFunctionPtrAlignType = Other.TheFunctionPtrAlignType;
+  ManglingMode = Other.ManglingMode;
+  LegalIntWidths = Other.LegalIntWidths;
+  IntAlignments = Other.IntAlignments;
+  FloatAlignments = Other.FloatAlignments;
+  VectorAlignments = Other.VectorAlignments;
+  StructAlignment = Other.StructAlignment;
+  Pointers = Other.Pointers;
+  NonIntegralAddressSpaces = Other.NonIntegralAddressSpaces;
+  return *this;
+}
+
+bool DataLayout::operator==(const DataLayout &Other) const {
+  // NOTE: StringRepresentation might differ, it is not canonicalized.
+  // FIXME: NonIntegralAddressSpaces isn't compared.
+  return BigEndian == Other.BigEndian &&
+         AllocaAddrSpace == Other.AllocaAddrSpace &&
+         ProgramAddrSpace == Other.ProgramAddrSpace &&
+         DefaultGlobalsAddrSpace == Other.DefaultGlobalsAddrSpace &&
+         StackNaturalAlign == Other.StackNaturalAlign &&
+         FunctionPtrAlign == Other.FunctionPtrAlign &&
+         TheFunctionPtrAlignType == Other.TheFunctionPtrAlignType &&
+         ManglingMode == Other.ManglingMode &&
+         LegalIntWidths == Other.LegalIntWidths &&
+         IntAlignments == Other.IntAlignments &&
+         FloatAlignments == Other.FloatAlignments &&
+         VectorAlignments == Other.VectorAlignments &&
+         StructAlignment == Other.StructAlignment && Pointers == Other.Pointers;
+}
+
 Expected<DataLayout> DataLayout::parse(StringRef LayoutDescription) {
   DataLayout Layout("");
   if (Error Err = Layout.parseSpecifier(LayoutDescription))
@@ -555,25 +594,6 @@ DataLayout::DataLayout(const Module *M) {
 }
 
 void DataLayout::init(const Module *M) { *this = M->getDataLayout(); }
-
-bool DataLayout::operator==(const DataLayout &Other) const {
-  bool Ret = BigEndian == Other.BigEndian &&
-             AllocaAddrSpace == Other.AllocaAddrSpace &&
-             StackNaturalAlign == Other.StackNaturalAlign &&
-             ProgramAddrSpace == Other.ProgramAddrSpace &&
-             DefaultGlobalsAddrSpace == Other.DefaultGlobalsAddrSpace &&
-             FunctionPtrAlign == Other.FunctionPtrAlign &&
-             TheFunctionPtrAlignType == Other.TheFunctionPtrAlignType &&
-             ManglingMode == Other.ManglingMode &&
-             LegalIntWidths == Other.LegalIntWidths &&
-             IntAlignments == Other.IntAlignments &&
-             FloatAlignments == Other.FloatAlignments &&
-             VectorAlignments == Other.VectorAlignments &&
-             StructAlignment == Other.StructAlignment &&
-             Pointers == Other.Pointers;
-  // Note: getStringRepresentation() might differs, it is not canonicalized
-  return Ret;
-}
 
 static SmallVectorImpl<LayoutAlignElem>::const_iterator
 findAlignmentLowerBound(const SmallVectorImpl<LayoutAlignElem> &Alignments,


### PR DESCRIPTION
`DataLayout` isn't exactly cheap to copy (448 bytes on a 64-bit host). Move `operator=` to cpp file to improve compilation time. Also move `operator==` closer to `operator=` and add a couple of FIXMEs.