### PR TITLE
[flang][test] Restrict Evaluate/fold-out_of_range.f90 to x86_64

### DIFF
--- a/flang/test/Evaluate/fold-out_of_range.f90
+++ b/flang/test/Evaluate/fold-out_of_range.f90
@@ -1,5 +1,6 @@
-! RUN: %python %S/test_folding.py %s %flang_fc1 -pedantic
-! UNSUPPORTED: target={{(arm|aarch64|powerpc|sparc).*}}, system-windows
+! RUN: %python %S/test_folding.py %s %flang_fc1 -pedantic -triple x86_64-unknown-linux-gnu
+! UNSUPPORTED: system-windows
+! REQUIRES: target=x86_64{{.*}}
 ! Tests folding of OUT_OF_RANGE().
 module m
   integer(1),  parameter :: i1v(*)  = [ -huge(1_1)  - 1_1,  huge(1_1) ]

--- a/flang/test/Evaluate/fold-out_of_range.f90
+++ b/flang/test/Evaluate/fold-out_of_range.f90
@@ -1,5 +1,5 @@
 ! RUN: %python %S/test_folding.py %s %flang_fc1 -pedantic
-! UNSUPPORTED: target=powerpc{{.*}}, target=aarch{{.*}}, target=arm{{.*}}, system-windows, system-solaris
+! UNSUPPORTED: target={{(arm|aarch64|powerpc|sparc).*}}, system-windows
 ! Tests folding of OUT_OF_RANGE().
 module m
   integer(1),  parameter :: i1v(*)  = [ -huge(1_1)  - 1_1,  huge(1_1) ]


### PR DESCRIPTION
`Flang :: Evaluate/fold-out_of_range.f90` currently `FAIL`s on Linux/sparc64.  This seems to be the same issue that led to disabling the test on Solaris in 27549ee989d7e0803d41c206cf636f0b689210f1.  In fact, the generic Solaris disablement was over-eager: the test `PASS`es just fine on Solaris/amd64.

Since the use of `REAL*10` makes the test x86-specific, this patch actually implements that requirement.

Tested on `sparc64-unknown-linux-gnu`, `sparcv9-sun-solaris2.11`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.