### PR TITLE
[libcxx] [test] Mark gdb_pretty_printer_test.sh.cpp as unsupported on Windows

### DIFF
--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
@@ -20,6 +20,9 @@
 // support gdb anymore, favoring lldb instead.
 // UNSUPPORTED: android
 
+// This test doesn't work as such on Windows.
+// UNSUPPORTED: windows
+
 // RUN: %{cxx} %{flags} %s -o %t.exe %{compile_flags} -g %{link_flags}
 // Ensure locale-independence for unicode tests.
 // RUN: env LANG=en_US.UTF-8 %{gdb} -nx -batch -iex "set autoload off" -ex "source %S/../../../utils/gdb/libcxx/printers.py" -ex "python register_libcxx_printer_loader()" -ex "source %S/gdb_pretty_printer_test.py" %t.exe


### PR DESCRIPTION
In practice, this test hasn't been run by any of the Windows configurations so far, because it has been excluded by the "UNSUPPORTED: clang-18, clang-19" line - but it does end up failing if running with e.g. clang-20 on Windows.

As the test fails on more fundamental issues on Windows, mark it outright unsupported on this platform; this fixes testing libcxx with a recent nightly version of Clang from git main.