### PR TITLE
Fixes and closes issues, #53390 and #58710. Added new controls to IndentNamespaceAliases, IndentUsingDeclarations and DecorateReflowedComments.

### DIFF
--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2822,6 +2822,46 @@ struct FormatStyle {
   /// \version 11
   IndentExternBlockStyle IndentExternBlock;
 
+  /// IndentNamespaceAliases is the type of indenting of namespace aliases
+  /// irrespective of NamespaceIndentation.
+  bool IndentNamespaceAliases;
+
+  /// IndentUsingDeclarations is the type of indenting of using declarations
+  /// irrespective of NamespaceIndentation.
+  bool IndentUsingDeclarations;
+
+  enum DecorateReflowedCommentsStyle : int8_t {
+    /// Never:
+    /// don't use any decorator
+    /// \code
+    /// /* blah blah blah blah blah blah blah blah blah blah blah blah blah
+    ///    blah blah blah blah blah blah blah blah */
+    /// \endcode
+    DRC_Never,
+    /// Always:
+    /// Always decorate with the decorator
+    /// \code
+    /// /* blah blah blah blah blah blah blah blah blah blah blah blah blah
+    ///  * blah blah blah blah blah blah blah blah */
+    /// \endcode
+    DRC_Always,
+    /// FirstInLine:
+    /// Use decoration only for First in line block comments
+    /// \code
+    /// using namespace std; /* blah blah blah blah blah blah blah blah blah
+    ///                         blah blah blah */
+    ///
+    /// /* blah blah blah blah blah blah blah blah blah blah blah blah blah
+    ///  * blah blah blah blah blah blah blah blah */
+    /// using namespace std;
+    /// \endcode
+    DRC_FirstInLineOnly
+  };
+
+  /// reflowed block comments decoration style
+  /// \version 17
+  DecorateReflowedCommentsStyle DecorateReflowedComments;
+
   /// Options for indenting preprocessor directives.
   enum PPDirectiveIndentStyle : int8_t {
     /// Does not indent any directives.
@@ -5104,6 +5144,9 @@ struct FormatStyle {
            IndentCaseBlocks == R.IndentCaseBlocks &&
            IndentCaseLabels == R.IndentCaseLabels &&
            IndentExternBlock == R.IndentExternBlock &&
+           IndentNamespaceAliases == R.IndentNamespaceAliases &&
+           IndentUsingDeclarations == R.IndentUsingDeclarations &&
+           DecorateReflowedComments == R.DecorateReflowedComments &&
            IndentGotoLabels == R.IndentGotoLabels &&
            IndentPPDirectives == R.IndentPPDirectives &&
            IndentRequiresClause == R.IndentRequiresClause &&

--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -517,10 +517,12 @@ BreakableBlockComment::BreakableBlockComment(
   }
 
   Decoration = "* ";
-  if (Lines.size() == 1 && !FirstInLine) {
+  if ((Style.DecorateReflowedComments == FormatStyle::DRC_Never) ||
+      (!FirstInLine &&
+       (Style.DecorateReflowedComments == FormatStyle::DRC_FirstInLineOnly))) {
     // Comments for which FirstInLine is false can start on arbitrary column,
     // and available horizontal space can be too small to align consecutive
-    // lines with the first one.
+    // lines with the first one. Also if decoration is explicitly turned off.
     // FIXME: We could, probably, align them to current indentation level, but
     // now we just wrap them without stars.
     Decoration = "";

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -449,6 +449,16 @@ struct ScalarEnumerationTraits<FormatStyle::NamespaceIndentationKind> {
   }
 };
 
+template <>
+struct ScalarEnumerationTraits<FormatStyle::DecorateReflowedCommentsStyle> {
+  static void enumeration(IO &IO,
+                          FormatStyle::DecorateReflowedCommentsStyle &Value) {
+    IO.enumCase(Value, "Never", FormatStyle::DRC_Never);
+    IO.enumCase(Value, "Always", FormatStyle::DRC_Always);
+    IO.enumCase(Value, "FirstInLineOnly", FormatStyle::DRC_FirstInLineOnly);
+  }
+};
+
 template <> struct ScalarEnumerationTraits<FormatStyle::OperandAlignmentStyle> {
   static void enumeration(IO &IO, FormatStyle::OperandAlignmentStyle &Value) {
     IO.enumCase(Value, "DontAlign", FormatStyle::OAS_DontAlign);
@@ -1014,6 +1024,9 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("IndentCaseBlocks", Style.IndentCaseBlocks);
     IO.mapOptional("IndentCaseLabels", Style.IndentCaseLabels);
     IO.mapOptional("IndentExternBlock", Style.IndentExternBlock);
+    IO.mapOptional("IndentNamespaceAliases", Style.IndentNamespaceAliases);
+    IO.mapOptional("IndentUsingDeclarations", Style.IndentUsingDeclarations);
+    IO.mapOptional("DecorateReflowedComments", Style.DecorateReflowedComments);
     IO.mapOptional("IndentGotoLabels", Style.IndentGotoLabels);
     IO.mapOptional("IndentPPDirectives", Style.IndentPPDirectives);
     IO.mapOptional("IndentRequiresClause", Style.IndentRequiresClause);
@@ -1524,6 +1537,9 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.IndentCaseBlocks = false;
   LLVMStyle.IndentCaseLabels = false;
   LLVMStyle.IndentExternBlock = FormatStyle::IEBS_AfterExternBlock;
+  LLVMStyle.IndentNamespaceAliases = false;
+  LLVMStyle.IndentUsingDeclarations = false;
+  LLVMStyle.DecorateReflowedComments = FormatStyle::DRC_FirstInLineOnly;
   LLVMStyle.IndentGotoLabels = true;
   LLVMStyle.IndentPPDirectives = FormatStyle::PPDIS_None;
   LLVMStyle.IndentRequiresClause = true;

--- a/clang/lib/Format/UnwrappedLineParser.h
+++ b/clang/lib/Format/UnwrappedLineParser.h
@@ -120,6 +120,7 @@ private:
   void reset();
   void parseFile();
   bool precededByCommentOrPPDirective() const;
+  void parseStmt(bool keepIndentation);
   bool parseLevel(const FormatToken *OpeningBrace = nullptr,
                   IfStmtKind *IfKind = nullptr,
                   FormatToken **IfLeftBrace = nullptr);


### PR DESCRIPTION
Issue #53390 was reported to have an option to control indenting namespace aliases independently of NamespaceIndentation, added this feature.

Issue #58710 was reported to have an option to control the decoration of the block comments, added this feature.