### PR TITLE
[RISCV] Add NutShell RV32/64 processors definition

### DIFF
--- a/clang/test/Driver/riscv-cpus.c
+++ b/clang/test/Driver/riscv-cpus.c
@@ -1,5 +1,23 @@
 // Check target CPUs are correctly passed.
 
+// RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=nutshell-rv32 | FileCheck -check-prefix=MCPU-NUTSHELL32 %s
+// MCPU-NUTSHELL32: "-nostdsysteminc" "-target-cpu" "nutshell-rv32"
+// MCPU-NUTSHELL32-SAME: "-target-feature" "+m"
+// MCPU-NUTSHELL32-SAME: "-target-feature" "+a"
+// MCPU-NUTSHELL32-SAME: "-target-feature" "+c"
+// MCPU-NUTSHELL32-SAME: "-target-feature" "+zicsr"
+// MCPU-NUTSHELL32-SAME: "-target-feature" "+zifencei"
+// MCPU-NUTSHELL32-SMAE: "-target-abi" "ilp32"
+
+// RUN: %clang --target=riscv64 -### -c %s 2>&1 -mcpu=nutshell-rv64 | FileCheck -check-prefix=MCPU-NUTSHELL64 %s
+// MCPU-NUTSHELL64: "-nostdsysteminc" "-target-cpu" "nutshell-rv64"
+// MCPU-NUTSHELL64-SAME: "-target-feature" "+m"
+// MCPU-NUTSHELL64-SAME: "-target-feature" "+a"
+// MCPU-NUTSHELL64-SAME: "-target-feature" "+c"
+// MCPU-NUTSHELL64-SAME: "-target-feature" "+zicsr"
+// MCPU-NUTSHELL64-SAME: "-target-feature" "+zifencei"
+// MCPU-NUTSHELL64-SMAE: "-target-abi" "lp64"
+
 // RUN: %clang --target=riscv32 -### -c %s 2>&1 -mcpu=rocket-rv32 | FileCheck -check-prefix=MCPU-ROCKET32 %s
 // MCPU-ROCKET32: "-nostdsysteminc" "-target-cpu" "rocket-rv32"
 // MCPU-ROCKET32: "-target-feature" "+zicsr" "-target-feature" "+zifencei"

--- a/clang/test/Misc/target-invalid-cpu-note.c
+++ b/clang/test/Misc/target-invalid-cpu-note.c
@@ -81,16 +81,16 @@
 
 // RUN: not %clang_cc1 -triple riscv32 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV32
 // RISCV32: error: unknown target CPU 'not-a-cpu'
-// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32, syntacore-scr4-rv32, syntacore-scr5-rv32{{$}}
+// RISCV32-NEXT: note: valid target CPU values are: generic-rv32, nutshell-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32, syntacore-scr4-rv32, syntacore-scr5-rv32{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix RISCV64
 // RISCV64: error: unknown target CPU 'not-a-cpu'
-// RISCV64-NEXT: note: valid target CPU values are: generic-rv64, rocket-rv64, sifive-p450, sifive-p470, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, syntacore-scr4-rv64, syntacore-scr5-rv64, veyron-v1, xiangshan-nanhu{{$}}
+// RISCV64-NEXT: note: valid target CPU values are: generic-rv64, nutshell-rv64, rocket-rv64, sifive-p450, sifive-p470, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, syntacore-scr4-rv64, syntacore-scr5-rv64, veyron-v1, xiangshan-nanhu{{$}}
 
 // RUN: not %clang_cc1 -triple riscv32 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV32
 // TUNE-RISCV32: error: unknown target CPU 'not-a-cpu'
-// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32, syntacore-scr4-rv32, syntacore-scr5-rv32, generic, rocket, sifive-7-series{{$}}
+// TUNE-RISCV32-NEXT: note: valid target CPU values are: generic-rv32, nutshell-rv32, rocket-rv32, sifive-e20, sifive-e21, sifive-e24, sifive-e31, sifive-e34, sifive-e76, syntacore-scr1-base, syntacore-scr1-max, syntacore-scr3-rv32, syntacore-scr4-rv32, syntacore-scr5-rv32, generic, rocket, sifive-7-series{{$}}
 
 // RUN: not %clang_cc1 -triple riscv64 -tune-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix TUNE-RISCV64
 // TUNE-RISCV64: error: unknown target CPU 'not-a-cpu'
-// TUNE-RISCV64-NEXT: note: valid target CPU values are: generic-rv64, rocket-rv64, sifive-p450, sifive-p470, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, syntacore-scr4-rv64, syntacore-scr5-rv64, veyron-v1, xiangshan-nanhu, generic, rocket, sifive-7-series{{$}}
+// TUNE-RISCV64-NEXT: note: valid target CPU values are: generic-rv64, nutshell-rv64, rocket-rv64, sifive-p450, sifive-p470, sifive-p670, sifive-s21, sifive-s51, sifive-s54, sifive-s76, sifive-u54, sifive-u74, sifive-x280, spacemit-x60, syntacore-scr3-rv64, syntacore-scr4-rv64, syntacore-scr5-rv64, veyron-v1, xiangshan-nanhu, generic, rocket, sifive-7-series{{$}}

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -107,6 +107,7 @@ Changes to the RISC-V Backend
   the required alignment space with a sequence of `0x0` bytes (the requested
   fill value) rather than NOPs.
 * Added Syntacore SCR4 and SCR5 CPUs: ``-mcpu=syntacore-scr4/5-rv32/64``
+* Added NutShell CPUs: ``-mcpu=nutshell-rv32/64``
 * ``-mcpu=sifive-p470`` was added.
 * Fixed length vector support using RVV instructions now requires VLEN>=64. This
   means Zve32x and Zve32f will also require Zvl64b. The prior support was

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -71,6 +71,28 @@ def GENERIC_RV64 : RISCVProcessorModel<"generic-rv64",
 // to change to the appropriate rv32/rv64 version.
 def GENERIC : RISCVTuneProcessorModel<"generic", NoSchedModel>, GenericTuneInfo;
 
+def NUTSHELL_RV32 : RISCVProcessorModel<"nutshell-rv32",
+                                        NoSchedModel,
+                                        [Feature32Bit,
+                                         FeatureStdExtI,
+                                         FeatureStdExtM,
+                                         FeatureStdExtA,
+                                         FeatureStdExtC,
+                                         FeatureStdExtZicsr,
+                                         FeatureStdExtZifencei
+                                        ]>;
+
+def NUTSHELL_RV64 : RISCVProcessorModel<"nutshell-rv64",
+                                        NoSchedModel,
+                                        [Feature64Bit,
+                                         FeatureStdExtI,
+                                         FeatureStdExtM,
+                                         FeatureStdExtA,
+                                         FeatureStdExtC,
+                                         FeatureStdExtZicsr,
+                                         FeatureStdExtZifencei
+                                        ]>;
+
 def ROCKET_RV32 : RISCVProcessorModel<"rocket-rv32",
                                       RocketModel,
                                       [Feature32Bit,


### PR DESCRIPTION
NutShell is an open-source Linux-compatible RISC-V processor, it supports riscv64/32.
Overview: https://github.com/OSCPU/NutShell

This PR add two CPUs:
- `nutshell-rv32`: rv32imac_zicsr_zifencei
- `nutshell-rv64`: rv64imac_zicsr_zifencei