### PR TITLE
[PS5][Driver] Link main components with -pie by default

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -237,7 +237,7 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!D.SysRoot.empty())
     CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));
 
-  // Default to PIE for non-static main components.
+  // Default to PIE for non-static executables.
   const bool PIE =
       !Args.hasArg(options::OPT_r, options::OPT_shared, options::OPT_static);
   if (Args.hasFlag(options::OPT_pie, options::OPT_no_pie, PIE))

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -237,7 +237,10 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!D.SysRoot.empty())
     CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));
 
-  if (Args.hasArg(options::OPT_pie))
+  // Default to PIE for non-static main components.
+  const bool PIE =
+      !Args.hasArg(options::OPT_r, options::OPT_shared, options::OPT_static);
+  if (Args.hasFlag(options::OPT_pie, options::OPT_no_pie, PIE))
     CmdArgs.push_back("-pie");
 
   if (Args.hasArg(options::OPT_static))

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -7,11 +7,12 @@
 
 // RUN: %clang --target=x86_64-scei-ps5 -no-pie %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
 // RUN: %clang --target=x86_64-scei-ps5 -r %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
-// RUN: %clang --target=x86_64-scei-ps5 -shared %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+// RUN: %clang --target=x86_64-scei-ps5 -shared %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE,CHECK-SHARED %s
 // RUN: %clang --target=x86_64-scei-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
 
 // CHECK-NO-PIE: {{ld(\.exe)?}}"
 // CHECK-NO-PIE-NOT: "-pie"
+// CHECK-SHARED: "--shared"
 
 // Test that -static is forwarded to the linker
 

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -1,3 +1,18 @@
+// Test that PIE is the default for main components
+
+// RUN: %clang --target=x86_64-scei-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-PIE %s
+
+// CHECK-PIE: {{ld(\.exe)?}}"
+// CHECK-PIE-SAME: "-pie"
+
+// RUN: %clang --target=x86_64-scei-ps5 -no-pie %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+// RUN: %clang --target=x86_64-scei-ps5 -r %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+// RUN: %clang --target=x86_64-scei-ps5 -shared %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+// RUN: %clang --target=x86_64-scei-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+
+// CHECK-NO-PIE: {{ld(\.exe)?}}"
+// CHECK-NO-PIE-NOT: "-pie"
+
 // Test that -static is forwarded to the linker
 
 // RUN: %clang --target=x86_64-scei-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s


### PR DESCRIPTION
The PS5 linker currently forces `-pie` for typical link jobs. Have the driver pass `pie` under the same conditions. With this change we can remove our private linker patch and also allow `-no-pie` to have an effect.

SIE tracker: TOOLCHAIN-16704