### PR TITLE
[Flang][runtime] Set -target to ignore LLVM_DEFAULT_TARGET_TRIPLE

### DIFF
--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -84,7 +84,10 @@ if (NOT CMAKE_CROSSCOMPILING)
     set(include_in_link FALSE)
     if(${filename} IN_LIST MODULES_WITH_IMPLEMENTATION)
       set(object_output "${CMAKE_CURRENT_BINARY_DIR}/${filename}${CMAKE_CXX_OUTPUT_EXTENSION}")
-      set(compile_with -c -o ${object_output})
+      # flang-new defaults to LLVM_DEFAULT_TARGET_TRIPLE as target, but
+      # currently we can build the runtime for the same target as the host
+      # compiler.
+      set(compile_with -target ${LLVM_TARGET_TRIPLE} -c -o ${object_output})
       set(include_in_link TRUE)
     endif()
 

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -87,7 +87,7 @@ if (NOT CMAKE_CROSSCOMPILING)
       # flang-new defaults to LLVM_DEFAULT_TARGET_TRIPLE as target, but
       # currently we can build the runtime for the same target as the host
       # compiler.
-      set(compile_with -target ${LLVM_TARGET_TRIPLE} -c -o ${object_output})
+      set(compile_with -target ${LLVM_HOST_TRIPLE} -c -o ${object_output})
       set(include_in_link TRUE)
     endif()
 


### PR DESCRIPTION
Currently the runtime is always built with the host compiler, to the same target as the host compiler compiles to, but Flang will be built compiling to `LLVM_DEFAULT_TARGET_TRIPLE`. To still build Fortran modules for the host, we must ignore `LLVM_DEFAULT_TARGET_TRIPLE` and explicitly pass the `-target` instead.

If the host compiler is also already a cross-compiler, then executing `flang-new` itself will already fail miserably unless the platform is setup with multilib support.