### PR TITLE
[DebugInfo] Add expression decoding for `DW_OP_implicit_pointer`

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
@@ -113,8 +113,10 @@ static void dumpExpression(raw_ostream &OS, DIDumpOptions DumpOpts,
                            ArrayRef<uint8_t> Data, bool IsLittleEndian,
                            unsigned AddressSize, DWARFUnit *U) {
   DWARFDataExtractor Extractor(Data, IsLittleEndian, AddressSize);
-  DWARFExpression(Extractor, AddressSize, U->getFormat())
-      .print(OS, DumpOpts, U);
+  std::optional<dwarf::DwarfFormat> Format;
+  if (U)
+    Format = U->getFormat();
+  DWARFExpression(Extractor, AddressSize, Format).print(OS, DumpOpts, U);
 }
 
 bool DWARFLocationTable::dumpLocationList(

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
@@ -113,11 +113,8 @@ static void dumpExpression(raw_ostream &OS, DIDumpOptions DumpOpts,
                            ArrayRef<uint8_t> Data, bool IsLittleEndian,
                            unsigned AddressSize, DWARFUnit *U) {
   DWARFDataExtractor Extractor(Data, IsLittleEndian, AddressSize);
-  // Note. We do not pass any format to DWARFExpression, even if the
-  // corresponding unit is known. For now, there is only one operation,
-  // DW_OP_call_ref, which depends on the format; it is rarely used, and
-  // is unexpected in location tables.
-  DWARFExpression(Extractor, AddressSize).print(OS, DumpOpts, U);
+  DWARFExpression(Extractor, AddressSize, U->getFormat())
+      .print(OS, DumpOpts, U);
 }
 
 bool DWARFLocationTable::dumpLocationList(

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
@@ -90,6 +90,8 @@ static std::vector<Desc> getOpDescriptions() {
   Descriptions[DW_OP_implicit_value] =
       Desc(Op::Dwarf4, Op::SizeLEB, Op::SizeBlock);
   Descriptions[DW_OP_stack_value] = Desc(Op::Dwarf4);
+  Descriptions[DW_OP_implicit_pointer] =
+      Desc(Op::Dwarf5, Op::SizeRefAddr, Op::SignedSizeLEB);
   Descriptions[DW_OP_addrx] = Desc(Op::Dwarf5, Op::SizeLEB);
   Descriptions[DW_OP_constx] = Desc(Op::Dwarf5, Op::SizeLEB);
   Descriptions[DW_OP_entry_value] = Desc(Op::Dwarf5, Op::SizeLEB);

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_OP_implicit_pointer.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_OP_implicit_pointer.yaml
@@ -1,0 +1,87 @@
+# Test that we can decode `DW_OP_implicit_pointer` (0xa0)
+# RUN: yaml2obj %s | llvm-dwarfdump - | FileCheck %s
+
+# CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_location (DW_OP_implicit_pointer 0x2a +0)
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+DWARF:
+  debug_abbrev:
+    - Table:
+        - Code:            0x00000001
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_data2
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+        - Code:            0x00000002
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+            - Attribute:       DW_AT_frame_base
+              Form:            DW_FORM_exprloc
+        - Code:            0x00000003
+          Tag:             DW_TAG_formal_parameter
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_location
+              Form:            DW_FORM_exprloc
+        - Code:            0x00000004
+          Tag:             DW_TAG_variable
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_location
+              Form:            DW_FORM_exprloc
+  debug_info:
+    - Length:          52
+      Version:         5
+      UnitType:        DW_UT_compile
+      AbbrOffset:      0
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x00000001
+          Values:
+            - Value:           0x000000000000000C
+            - Value:           0x0000000100000F50
+            - Value:           0x0000000000000034
+        - AbbrCode:        0x00000002
+          Values:
+            - Value:           0x0000000100000F50
+            - Value:           0x0000000000000034
+            - Value:           0x0000000000000001
+              BlockData:
+                - 0x56
+        - AbbrCode:        0x00000003
+          Values:
+            - Value:           0x0000000000000002
+              BlockData:
+                - 0x91
+                - 0x78
+        - AbbrCode:        0x00000004
+          Values:
+            - Value:           0x0000000000000006
+              BlockData:
+                - 0xa0
+                - 0x2a
+                - 0x00
+                - 0x00
+                - 0x00
+                - 0x00
+        - AbbrCode:        0x00000000
+          Values:
+        - AbbrCode:        0x00000000
+          Values:
+...

--- a/llvm/test/tools/llvm-dwarfdump/X86/DW_OP_implicit_pointer.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/DW_OP_implicit_pointer.yaml
@@ -2,7 +2,7 @@
 # RUN: yaml2obj %s | llvm-dwarfdump - | FileCheck %s
 
 # CHECK:      DW_TAG_variable
-# CHECK-NEXT:   DW_AT_location (DW_OP_implicit_pointer 0x2a +0)
+# CHECK-NEXT:   DW_AT_location (DW_OP_implicit_pointer 0x2a +4)
 
 --- !ELF
 FileHeader:
@@ -74,12 +74,12 @@ DWARF:
           Values:
             - Value:           0x0000000000000006
               BlockData:
-                - 0xa0
-                - 0x2a
+                - 0xa0 # DW_OP_implicit_pointer
+                - 0x2a # Section offset of parameter in the previous entry
                 - 0x00
                 - 0x00
                 - 0x00
-                - 0x00
+                - 0x04 # Pointer references location 4 bytes into value of previous entry
         - AbbrCode:        0x00000000
           Values:
         - AbbrCode:        0x00000000


### PR DESCRIPTION
This allows `llvm-dwarfdump` to decode the DWARF 5 opcode `DW_OP_implicit_pointer` (0xa0). GCC makes use of this opcode in recent versions. LLVM contains some (unfinished) support as well. With existing usage in the ecosystem, adding decoding support here seems reasonable.