### PR TITLE
[SPIR-V] Sort basic blocks to match the SPIR-V spec

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -187,6 +187,8 @@ void sortBlocks(MachineFunction &MF) {
   MachineDominatorTree MDT(MF);
 
   std::unordered_map<MachineBasicBlock *, size_t> Order;
+  Order.reserve(MF.size());
+
   size_t Index = 0;
   visit(MF, [&Order, &Index](MachineBasicBlock *MBB) { Order[MBB] = Index++; });
 

--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -19,11 +19,13 @@
 #include "SPIRVUtils.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/CodeGen/MachinePostDominators.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/IntrinsicsSPIRV.h"
 #include "llvm/Target/TargetIntrinsicInfo.h"
+#include <stack>
 
 #define DEBUG_TYPE "spirv-postlegalizer"
 
@@ -150,6 +152,51 @@ static void processNewInstrs(MachineFunction &MF, SPIRVGlobalRegistry *GR,
   }
 }
 
+// Do a preorder traversal of the CFG starting from the BB |Start|.
+// point. Calls |op| on each basic block encountered during the traversal.
+void visit(MachineFunction &MF, MachineBasicBlock &Start,
+           std::function<void(MachineBasicBlock *)> op) {
+  std::stack<MachineBasicBlock *> ToVisit;
+  SmallPtrSet<MachineBasicBlock *, 8> Seen;
+
+  ToVisit.push(&Start);
+  Seen.insert(ToVisit.top());
+  while (ToVisit.size() != 0) {
+    MachineBasicBlock *MBB = ToVisit.top();
+    ToVisit.pop();
+
+    op(MBB);
+
+    for (auto Succ : MBB->successors()) {
+      if (Seen.contains(Succ))
+        continue;
+      ToVisit.push(Succ);
+      Seen.insert(Succ);
+    }
+  }
+}
+
+// Do a preorder traversal of the CFG starting from the given function's entry
+// point. Calls |op| on each basic block encountered during the traversal.
+void visit(MachineFunction &MF, std::function<void(MachineBasicBlock *)> op) {
+  visit(MF, *MF.begin(), op);
+}
+
+// Sorts basic blocks by dominance to respect the SPIR-V spec.
+void sortBlocks(MachineFunction &MF) {
+  MachineDominatorTree MDT(MF);
+
+  std::unordered_map<MachineBasicBlock *, size_t> Order;
+  size_t Index = 0;
+  visit(MF, [&Order, &Index](MachineBasicBlock *MBB) { Order[MBB] = Index++; });
+
+  auto Comparator = [&Order](MachineBasicBlock &LHS, MachineBasicBlock &RHS) {
+    return Order[&LHS] < Order[&RHS];
+  };
+
+  MF.sort(Comparator);
+}
+
 bool SPIRVPostLegalizer::runOnMachineFunction(MachineFunction &MF) {
   // Initialize the type registry.
   const SPIRVSubtarget &ST = MF.getSubtarget<SPIRVSubtarget>();
@@ -158,6 +205,7 @@ bool SPIRVPostLegalizer::runOnMachineFunction(MachineFunction &MF) {
   MachineIRBuilder MIB(MF);
 
   processNewInstrs(MF, GR, MIB);
+  sortBlocks(MF);
 
   return true;
 }

--- a/llvm/test/CodeGen/SPIRV/block-ordering.ll
+++ b/llvm/test/CodeGen/SPIRV/block-ordering.ll
@@ -1,0 +1,30 @@
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Checks SPIR-V blocks are correctly reordered so that dominators shows up
+; before others in the binary layout.
+
+define void @main() {
+; CHECK: OpLabel
+; CHECK: OpBranch %[[#l1:]]
+
+; CHECK: %[[#l1]] = OpLabel
+; CHECK:            OpBranch %[[#l2:]]
+
+; CHECK: %[[#l2]] = OpLabel
+; CHECK:            OpBranch %[[#end:]]
+
+; CHECK: %[[#end]] = OpLabel
+; CHECK:             OpReturn
+entry:
+  br label %l1
+
+l2:
+  br label %end
+
+l1:
+  br label %l2
+
+end:
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/branching/OpSwitchBranches.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/OpSwitchBranches.ll
@@ -10,32 +10,38 @@ entry:
     i32 3, label %case3
   ]
 
-; CHECK-SPIRV:      %[[#CASE1]] = OpLabel
 case1:
   store i32 1, ptr %alloc
-; CHECK-SPIRV:      OpBranch %[[#END:]]
   br label %end
 
-; CHECK-SPIRV:      %[[#CASE2]] = OpLabel
 case2:
   store i32 2, ptr %alloc
-; CHECK-SPIRV:      OpBranch %[[#END]]
   br label %end
 
-; CHECK-SPIRV:      %[[#CASE3]] = OpLabel
 case3:
   store i32 3, ptr %alloc
-; CHECK-SPIRV:      OpBranch %[[#END]]
   br label %end
 
-; CHECK-SPIRV:      %[[#DEFAULT]] = OpLabel
 default:
   store i32 0, ptr %alloc
-; CHECK-SPIRV:      OpBranch %[[#END]]
   br label %end
 
-; CHECK-SPIRV:      %[[#END]] = OpLabel
 end:
   %result = load i32, ptr %alloc
   ret i32 %result
+
+; CHECK-SPIRV:      %[[#CASE3]] = OpLabel
+; CHECK-SPIRV:      OpBranch %[[#END:]]
+
+; CHECK-SPIRV:      %[[#END]] = OpLabel
+; CHECK-SPIRV:                  OpReturnValue
+
+; CHECK-SPIRV:      %[[#CASE2]] = OpLabel
+; CHECK-SPIRV:      OpBranch %[[#END]]
+
+; CHECK-SPIRV:      %[[#CASE1]] = OpLabel
+; CHECK-SPIRV:      OpBranch %[[#END]]
+
+; CHECK-SPIRV:      %[[#DEFAULT]] = OpLabel
+; CHECK-SPIRV:      OpBranch %[[#END]]
 }

--- a/llvm/test/CodeGen/SPIRV/branching/Two_OpSwitch_same_register.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/Two_OpSwitch_same_register.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 define spir_kernel void @test_two_switch_same_register(i32 %value) {
 ; CHECK-SPIRV:      OpSwitch %[[#REGISTER:]] %[[#DEFAULT1:]] 1 %[[#CASE1:]] 0 %[[#CASE2:]]
@@ -7,36 +8,42 @@ define spir_kernel void @test_two_switch_same_register(i32 %value) {
     i32 0, label %case2
   ]
 
-; CHECK-SPIRV:      %[[#CASE1]] = OpLabel
 case1:
-; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT1]]
   br label %default1
 
-; CHECK-SPIRV:      %[[#CASE2]] = OpLabel
 case2:
-; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT1]]
   br label %default1
 
-; CHECK-SPIRV:      %[[#DEFAULT1]] = OpLabel
 default1:
-; CHECK-SPIRV-NEXT:      OpSwitch %[[#REGISTER]] %[[#DEFAULT2:]] 0 %[[#CASE3:]] 1 %[[#CASE4:]]
   switch i32 %value, label %default2 [
     i32 0, label %case3
     i32 1, label %case4
   ]
 
-; CHECK-SPIRV:      %[[#CASE3]] = OpLabel
 case3:
-; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT2]]
   br label %default2
 
-; CHECK-SPIRV:      %[[#CASE4]] = OpLabel
 case4:
-; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT2]]
   br label %default2
+
+default2:
+  ret void
+
+; CHECK-SPIRV:      %[[#CASE2]] = OpLabel
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT1]]
+
+; CHECK-SPIRV:      %[[#CASE1]] = OpLabel
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT1]]
+
+; CHECK-SPIRV:      %[[#DEFAULT1]] = OpLabel
+; CHECK-SPIRV-NEXT:      OpSwitch %[[#REGISTER]] %[[#DEFAULT2:]] 0 %[[#CASE3:]] 1 %[[#CASE4:]]
+
+; CHECK-SPIRV:      %[[#CASE4:]] = OpLabel
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT2]]
+
+; CHECK-SPIRV:      %[[#CASE3]] = OpLabel
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT2]]
 
 ; CHECK-SPIRV:      %[[#DEFAULT2]] = OpLabel
-default2:
 ; CHECK-SPIRV-NEXT: OpReturn
-  ret void
 }

--- a/llvm/test/CodeGen/SPIRV/branching/if-merging.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/if-merging.ll
@@ -37,15 +37,16 @@ merge_label:
 ; CHECK: [[COND:%.+]] = OpIEqual [[BOOL]] [[A]] [[B]]
 ; CHECK: OpBranchConditional [[COND]] [[TRUE_LABEL:%.+]] [[FALSE_LABEL:%.+]]
 
-; CHECK: [[TRUE_LABEL]] = OpLabel
-; CHECK: [[V1:%.+]] = OpFunctionCall [[I32]] [[FOO]]
-; CHECK: OpBranch [[MERGE_LABEL:%.+]]
-
 ; CHECK: [[FALSE_LABEL]] = OpLabel
 ; CHECK: [[V2:%.+]] = OpFunctionCall [[I32]] [[BAR]]
-; CHECK: OpBranch [[MERGE_LABEL]]
+; CHECK: OpBranch [[MERGE_LABEL:%.+]]
 
 ; CHECK: [[MERGE_LABEL]] = OpLabel
-; CHECK-NEXT: [[V:%.+]] = OpPhi [[I32]] [[V1]] [[TRUE_LABEL]] [[V2]] [[FALSE_LABEL]]
+; CHECK-NEXT: [[V:%.+]] = OpPhi [[I32]] [[V1:%.+]] [[TRUE_LABEL]] [[V2]] [[FALSE_LABEL]]
 ; CHECK: OpReturnValue [[V]]
+
+; CHECK: [[TRUE_LABEL]] = OpLabel
+; CHECK: [[V1]] = OpFunctionCall [[I32]] [[FOO]]
+; CHECK: OpBranch [[MERGE_LABEL]]
+
 ; CHECK-NEXT: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/branching/if-non-merging.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/if-non-merging.ll
@@ -21,7 +21,7 @@ false_label:
 ; CHECK: [[ENTRY:%.+]] = OpLabel
 ; CHECK: [[COND:%.+]] = OpIEqual [[BOOL]] [[A]] [[B]]
 ; CHECK: OpBranchConditional [[COND]] [[TRUE_LABEL:%.+]] [[FALSE_LABEL:%.+]]
-; CHECK: [[TRUE_LABEL]] = OpLabel
-; CHECK: OpReturnValue [[TRUE]]
 ; CHECK: [[FALSE_LABEL]] = OpLabel
 ; CHECK: OpReturnValue [[FALSE]]
+; CHECK: [[TRUE_LABEL]] = OpLabel
+; CHECK: OpReturnValue [[TRUE]]

--- a/llvm/test/CodeGen/SPIRV/branching/switch-range-check.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/switch-range-check.ll
@@ -2,11 +2,15 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK: OpFunction
+; CHECK: OpBranchConditional %[[#]] %[[#if_then:]] %[[#if_end:]]
+; CHECK: %[[#if_end]] = OpLabel
 ; CHECK: %[[#Var:]] = OpPhi
 ; CHECK: OpSwitch %[[#Var]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]]
-; CHECK-COUNT-11: OpBranch
+; CHECK-COUNT-11: OpLabel
 ; CHECK-NOT: OpBranch
 ; CHECK: OpReturn
+; CHECK: %[[#if_then]] = OpLabel
+; CHECK: OpBranch %[[#if_end]]
 ; CHECK-NEXT: OpFunctionEnd
 
 define spir_func void @foo(i64 noundef %addr, i64 noundef %as) {

--- a/llvm/test/CodeGen/SPIRV/phi-ptrcast-dominate.ll
+++ b/llvm/test/CodeGen/SPIRV/phi-ptrcast-dominate.ll
@@ -6,30 +6,10 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
+
 ; CHECK-DAG: OpName %[[#Case1:]] "case1"
 ; CHECK-DAG: OpName %[[#Case2:]] "case2"
 ; CHECK-DAG: OpName %[[#Case3:]] "case3"
-; CHECK: %[[#Case1]] = OpFunction
-; CHECK: OpBranchConditional
-; CHECK: OpPhi
-; CHECK: OpBranch
-; CHECK-COUNT-2: OpBranchConditional
-; CHECK: OpFunctionEnd
-; CHECK: %[[#Case2]] = OpFunction
-; CHECK: OpBranchConditional
-; CHECK: OpPhi
-; CHECK: OpBranch
-; CHECK-COUNT-2: OpBranchConditional
-; CHECK: OpFunctionEnd
-; CHECK: %[[#Case3]] = OpFunction
-; CHECK: OpBranchConditional
-; CHECK: OpPhi
-; CHECK: OpBranch
-; CHECK: OpInBoundsPtrAccessChain
-; CHECK: OpBranchConditional
-; CHECK: OpInBoundsPtrAccessChain
-; CHECK: OpBranchConditional
-; CHECK: OpFunctionEnd
 
 %struct1 = type { i64 }
 %struct2 = type { i64, i64 }
@@ -37,58 +17,92 @@
 @.str.1 = private unnamed_addr addrspace(1) constant [3 x i8] c"OK\00", align 1
 @.str.2 = private unnamed_addr addrspace(1) constant [6 x i8] c"WRONG\00", align 1
 
+; CHECK: %[[#Case1]] = OpFunction
 define spir_func void @case1(i1 %b1, i1 %b2, i1 %b3) {
 entry:
+; CHECK: OpBranchConditional %[[#]] %[[#l1:]] %[[#l2:]]
   br i1 %b1, label %l1, label %l2
 
 l1:
   %str = phi ptr addrspace(1) [ @.str.1, %entry ], [ @.str.2, %l2 ], [ @.str.2, %l3 ]
   br label %exit
 
+; CHECK: %[[#l2]] = OpLabel
+; CHECK:            OpBranchConditional %[[#]] %[[#l1:]] %[[#l3:]]
 l2:
   br i1 %b2, label %l1, label %l3
 
+; CHECK: %[[#l3]] = OpLabel
+; CHECK:            OpBranchConditional %[[#]] %[[#l1:]] %[[#exit:]]
 l3:
   br i1 %b3, label %l1, label %exit
 
+; CHECK: %[[#exit]] = OpLabel
+; CHECK:              OpReturn
 exit:
   ret void
+
+; CHECK:      %[[#l1]] = OpLabel
+; CHECK-NEXT:            OpPhi
+; CHECK:                 OpBranch %[[#exit:]]
 }
 
+; CHECK: %[[#Case2]] = OpFunction
 define spir_func void @case2(i1 %b1, i1 %b2, i1 %b3, ptr addrspace(1) byval(%struct1) %str1, ptr addrspace(1) byval(%struct2) %str2) {
 entry:
+; CHECK: OpBranchConditional %[[#]] %[[#l1:]] %[[#l2:]]
   br i1 %b1, label %l1, label %l2
 
 l1:
   %str = phi ptr addrspace(1) [ %str1, %entry ], [ %str2, %l2 ], [ %str2, %l3 ]
   br label %exit
 
+; CHECK: %[[#l2]] = OpLabel
+; CHECK:            OpBranchConditional %[[#]] %[[#l1:]] %[[#l3:]]
 l2:
   br i1 %b2, label %l1, label %l3
 
+; CHECK: %[[#l3]] = OpLabel
+; CHECK:            OpBranchConditional %[[#]] %[[#l1:]] %[[#exit:]]
 l3:
   br i1 %b3, label %l1, label %exit
 
+; CHECK: %[[#exit]] = OpLabel
+; CHECK:              OpReturn
 exit:
   ret void
 }
 
+; CHECK: %[[#Case3]] = OpFunction
 define spir_func void @case3(i1 %b1, i1 %b2, i1 %b3, ptr addrspace(1) byval(%struct1) %_arg_str1, ptr addrspace(1) byval(%struct2) %_arg_str2) {
 entry:
   br i1 %b1, label %l1, label %l2
 
+; CHECK: OpBranchConditional %[[#]] %[[#l1:]] %[[#l2:]]
 l1:
   %str = phi ptr addrspace(1) [ %_arg_str1, %entry ], [ %str2, %l2 ], [ %str3, %l3 ]
   br label %exit
 
+; CHECK: %[[#l2]] = OpLabel
+; CHECK:            OpInBoundsPtrAccessChain
+; CHECK:            OpBranchConditional %[[#]] %[[#l1:]] %[[#l3:]]
 l2:
   %str2 = getelementptr inbounds %struct2, ptr addrspace(1) %_arg_str2, i32 1
   br i1 %b2, label %l1, label %l3
 
+; CHECK: %[[#l3]] = OpLabel
+; CHECK:            OpInBoundsPtrAccessChain
+; CHECK:            OpBranchConditional %[[#]] %[[#l1:]] %[[#exit:]]
 l3:
   %str3 = getelementptr inbounds %struct2, ptr addrspace(1) %_arg_str2, i32 2
   br i1 %b3, label %l1, label %exit
 
+; CHECK: %[[#exit]] = OpLabel
+; CHECK:              OpReturn
 exit:
   ret void
+
+; CHECK:      %[[#l1]] = OpLabel
+; CHECK-NEXT:            OpPhi
+; CHECK:                 OpBranch %[[#exit:]]
 }

--- a/llvm/test/CodeGen/SPIRV/scfg-add-pre-headers.ll
+++ b/llvm/test/CodeGen/SPIRV/scfg-add-pre-headers.ll
@@ -18,14 +18,34 @@ define void @main() #1 {
 ; CHECK-DAG:   %[[#l2_pre]] = OpLabel
 ; CHECK-NEXT:                 OpBranch %[[#l2_header:]]
 
-; CHECK-DAG:   %[[#l1_pre]] = OpLabel
-; CHECK-NEXT:                 OpBranch %[[#l1_header:]]
+; CHECK-DAG:    %[[#l2_header]] = OpLabel
+; CHECK-NEXT:                     OpBranchConditional %[[#cond]] %[[#l2_body:]] %[[#l2_end:]]
+
+; CHECK-DAG:   %[[#l2_end]] = OpLabel
+; CHECK-NEXT:                 OpBranch %[[#end:]]
+
+; CHECK-DAG:       %[[#end]] = OpLabel
+; CHECK-NEXT:                  OpReturn
+
+; CHECK-DAG:   %[[#l2_body]] = OpLabel
+; CHECK-NEXT:                  OpBranch %[[#l2_continue:]]
+
+; CHECK-DAG:   %[[#l2_continue]] = OpLabel
+; CHECK-NEXT:                      OpBranch %[[#l2_header]]
 
 l1:
   %tl1 = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token %t1) ]
   br i1 %1, label %l1_body, label %l1_end
+
+; CHECK-DAG:   %[[#l1_pre]] = OpLabel
+; CHECK-NEXT:                 OpBranch %[[#l1_header:]]
+
 ; CHECK-DAG:    %[[#l1_header]] = OpLabel
 ; CHECK-NEXT:                     OpBranchConditional %[[#cond]] %[[#l1_body:]] %[[#l1_end:]]
+
+; CHECK-DAG:   %[[#l1_end]] = OpLabel
+; CHECK-DAG:         %[[#]] = OpLoad %[[#]] %[[#SubgroupLocalInvocationId]]
+; CHECK-NEXT:                 OpBranch %[[#end]]
 
 l1_body:
   br label %l1_continue
@@ -40,35 +60,22 @@ l1_continue:
 l1_end:
   %call = call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %tl1) ]
   br label %end
-; CHECK-DAG:   %[[#l1_end]] = OpLabel
-; CHECK-DAG:         %[[#]] = OpLoad %[[#]] %[[#SubgroupLocalInvocationId]]
-; CHECK-NEXT:                 OpBranch %[[#end:]]
 
 l2:
   %tl2 = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token %t1) ]
   br i1 %1, label %l2_body, label %l2_end
-; CHECK-DAG:    %[[#l2_header]] = OpLabel
-; CHECK-NEXT:                     OpBranchConditional %[[#cond]] %[[#l2_body:]] %[[#l2_end:]]
 
 l2_body:
   br label %l2_continue
-; CHECK-DAG:   %[[#l2_body]] = OpLabel
-; CHECK-NEXT:                  OpBranch %[[#l2_continue:]]
 
 l2_continue:
   br label %l2
-; CHECK-DAG:   %[[#l2_continue]] = OpLabel
-; CHECK-NEXT:                      OpBranch %[[#l2_header]]
 
 l2_end:
   br label %end
-; CHECK-DAG:   %[[#l2_end]] = OpLabel
-; CHECK-NEXT:                 OpBranch %[[#end:]]
 
 end:
   ret void
-; CHECK-DAG:       %[[#end]] = OpLabel
-; CHECK-NEXT:                  OpReturn
 }
 
 attributes #1 = { "hlsl.numthreads"="4,8,16" "hlsl.shader"="compute" convergent }

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-break.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-break.ll
@@ -33,6 +33,19 @@ while.cond:
   %cmp = icmp ne i32 %2, 10
   br i1 %cmp, label %while.body, label %while.end
 
+; CHECK:   %[[#new_end]] = OpLabel
+; CHECK:    %[[#route:]] = OpPhi %[[#int_ty]] %[[#int_1]] %[[#while_cond]] %[[#int_0]] %[[#while_body]]
+; CHECK:                   OpSwitch %[[#route]] %[[#if_then:]] 1 %[[#while_end_loopexit:]]
+
+; CHECK:   %[[#while_end_loopexit]] = OpLabel
+; CHECK:                              OpBranch %[[#while_end:]]
+
+; CHECK:   %[[#while_end]] = OpLabel
+; CHECK:                     OpReturn
+
+; CHECK:   %[[#if_then]] = OpLabel
+; CHECK:                   OpBranch %[[#while_end]]
+
 ; CHECK:   %[[#while_body]] = OpLabel
 ; CHECK-NEXT:    %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]] Aligned 1
 ; CHECK-NEXT:                 OpStore %[[#idx]] %[[#tmp]] Aligned 4
@@ -46,8 +59,6 @@ while.body:
   %cmp1 = icmp eq i32 %4, 0
   br i1 %cmp1, label %if.then, label %if.end
 
-; CHECK:   %[[#if_then:]] = OpLabel
-; CHECK:                    OpBranch %[[#while_end:]]
 if.then:
   br label %while.end
 
@@ -56,17 +67,9 @@ if.then:
 if.end:
   br label %while.cond
 
-; CHECK:   %[[#while_end_loopexit:]] = OpLabel
-; CHECK:                               OpBranch %[[#while_end]]
-
-; CHECK:   %[[#while_end]] = OpLabel
-; CHECK:                     OpReturn
 while.end:
   ret void
 
-; CHECK:   %[[#new_end]] = OpLabel
-; CHECK:    %[[#route:]] = OpPhi %[[#int_ty]] %[[#int_1]] %[[#while_cond]] %[[#int_0]] %[[#while_body]]
-; CHECK:                   OpSwitch %[[#route]] %[[#if_then]] 1 %[[#while_end_loopexit]]
 }
 
 declare token @llvm.experimental.convergence.entry() #2

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-multiple-break.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-multiple-break.ll
@@ -34,12 +34,28 @@ while.cond:
   %cmp = icmp ne i32 %2, 10
   br i1 %cmp, label %while.body, label %while.end
 
+; CHECK:   %[[#new_end]] = OpLabel
+; CHECK:    %[[#route:]] = OpPhi %[[#int_ty]] %[[#int_2]] %[[#while_cond]] %[[#int_0]] %[[#while_body]] %[[#int_1]] %[[#if_end:]]
+; CHECK:                   OpSwitch %[[#route]] %[[#if_then:]] 1 %[[#if_then2:]] 2 %[[#while_end_loopexit:]]
+
+; CHECK:   %[[#while_end_loopexit]] = OpLabel
+; CHECK:                               OpBranch %[[#while_end:]]
+
+; CHECK:   %[[#while_end]] = OpLabel
+; CHECK:                     OpReturn
+
+; CHECK:   %[[#if_then2]] = OpLabel
+; CHECK:                     OpBranch %[[#while_end]]
+
+; CHECK:   %[[#if_then]] = OpLabel
+; CHECK:                    OpBranch %[[#while_end]]
+
 ; CHECK:   %[[#while_body]] = OpLabel
 ; CHECK-NEXT:    %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]] Aligned 1
 ; CHECK-NEXT:                 OpStore %[[#idx]] %[[#tmp]] Aligned 4
 ; CHECK-NEXT:    %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
 ; CHECK-NEXT:   %[[#cmp1:]] = OpIEqual %[[#bool_ty]] %[[#tmp]] %[[#int_0]]
-; CHECK:                      OpBranchConditional %[[#cmp1]] %[[#new_end]] %[[#if_end:]]
+; CHECK:                      OpBranchConditional %[[#cmp1]] %[[#new_end]] %[[#if_end]]
 while.body:
   %3 = call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %1) ]
   store i32 %3, ptr %idx, align 4
@@ -47,8 +63,6 @@ while.body:
   %cmp1 = icmp eq i32 %4, 0
   br i1 %cmp1, label %if.then, label %if.end
 
-; CHECK:   %[[#if_then:]] = OpLabel
-; CHECK:                    OpBranch %[[#while_end:]]
 if.then:
   br label %while.end
 
@@ -65,8 +79,6 @@ if.end:
   %cmp2 = icmp eq i32 %6, 0
   br i1 %cmp2, label %if.then2, label %if.end2
 
-; CHECK:   %[[#if_then2:]] = OpLabel
-; CHECK:                     OpBranch %[[#while_end:]]
 if.then2:
   br label %while.end
 
@@ -75,17 +87,10 @@ if.then2:
 if.end2:
   br label %while.cond
 
-; CHECK:   %[[#while_end_loopexit:]] = OpLabel
-; CHECK:                               OpBranch %[[#while_end]]
 
-; CHECK:   %[[#while_end]] = OpLabel
-; CHECK:                     OpReturn
 while.end:
   ret void
 
-; CHECK:   %[[#new_end]] = OpLabel
-; CHECK:    %[[#route:]] = OpPhi %[[#int_ty]] %[[#int_2]] %[[#while_cond]] %[[#int_0]] %[[#while_body]] %[[#int_1]] %[[#if_end]]
-; CHECK:                   OpSwitch %[[#route]] %[[#if_then]] 1 %[[#if_then2]] 2 %[[#while_end_loopexit]]
 }
 
 declare token @llvm.experimental.convergence.entry() #2

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-simple-while-identity.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-simple-while-identity.ll
@@ -21,6 +21,9 @@ while.cond:
   %cmp = icmp ne i32 %2, 0
   br i1 %cmp, label %while.body, label %while.end
 
+; CHECK:   %[[#while_end]] = OpLabel
+; CHECK-NEXT:                     OpReturn
+
 ; CHECK:   %[[#while_body]] = OpLabel
 ; CHECK:                      OpBranch %[[#while_cond]]
 while.body:
@@ -28,8 +31,6 @@ while.body:
   store i32 %3, ptr %idx, align 4
   br label %while.cond
 
-     ; CHECK:   %[[#while_end]] = OpLabel
-; CHECK-NEXT:                     OpReturn
 while.end:
   ret void
 }


### PR DESCRIPTION
The SPIR-V spec required basic blocks to respect some kind of ordering (A block dominating another cannot be after in the binary layout).