### PR TITLE
[NFC] Replace bool <= bool comparison

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -509,7 +509,7 @@ NarrowingKind StandardConversionSequence::getNarrowingKind(
     constexpr auto CanRepresentAll = [](bool FromSigned, unsigned FromWidth,
                                         bool ToSigned, unsigned ToWidth) {
       return (FromWidth < ToWidth + (FromSigned == ToSigned)) &&
-             (FromSigned <= ToSigned);
+             !(FromSigned && !ToSigned);
     };
 
     if (CanRepresentAll(FromSigned, FromWidth, ToSigned, ToWidth))
@@ -542,7 +542,7 @@ NarrowingKind StandardConversionSequence::getNarrowingKind(
       // If the bit-field width was dependent, it might end up being small
       // enough to fit in the target type (unless the target type is unsigned
       // and the source type is signed, in which case it will never fit)
-      if (DependentBitField && (FromSigned <= ToSigned))
+      if (DependentBitField && !(FromSigned && !ToSigned))
         return NK_Dependent_Narrowing;
 
       // Otherwise, such a conversion is always narrowing


### PR DESCRIPTION
Static analyser tool cppcheck flags ordered comparison with `bool`s. Replace with equivalent logical operators to prevent this.

Closes #102912