### PR TITLE
[GitHub] Run format job on stacked PRs

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'users/**'
 
 jobs:
   code_formatter:


### PR DESCRIPTION
Currently the formatter only runs for the main branch, which prevents the formatter from running for stacked PRs, which have to target user branches instead of main.

Disclaimer: I have never touched GH actions before, but this seemed like a simple fix. If this is completely wrong, feel free to close and I can file an issue instead.