### PR TITLE
[libc] Fix warning on 'extern "C" int main' in test suite

### DIFF
--- a/libc/test/UnitTest/LibcTestMain.cpp
+++ b/libc/test/UnitTest/LibcTestMain.cpp
@@ -43,7 +43,15 @@ TestOptions parseOptions(int argc, char **argv) {
 
 } // anonymous namespace
 
-extern "C" int main(int argc, char **argv, char **envp) {
+// The C++ standard forbids declaring the main function with a linkage specifier
+// outisde of 'freestanding' mode, only define the linkage for hermetic tests.
+#if __STDC_HOSTED__
+#define TEST_MAIN int main
+#else
+#define TEST_MAIN extern "C" int main
+#endif
+
+TEST_MAIN(int argc, char **argv, char **envp) {
   LIBC_NAMESPACE::testing::argc = argc;
   LIBC_NAMESPACE::testing::argv = argv;
   LIBC_NAMESPACE::testing::envp = envp;


### PR DESCRIPTION
Summary:
According to the C++ standard, The main function shall not be declared
with a linkage-specification. after some changes in
https://github.com/llvm/llvm-project/pull/101853 this started emitting
warnings when building / testing the C library. This source file is
shared with the overlay tests as well as the full build tests. The full
build tests are compiled with `-ffreestanding`, as are all the startup /
integration files. The standard says freestanding environment are all
implementation defined, so this is valid in those cases. This patch
simply prevents adding the linkage when we are compiling unit tests,
which are hosted. This is a continuation on
https://github.com/llvm/llvm-project/pull/102825.
