### PR TITLE
[llvm-lit][test] Precommit tests for curly braces in lit internal shell

### DIFF
--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-close-only.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-close-only.txt
@@ -1,0 +1,2 @@
+## Test closing brace without open brace.
+# RUN: echo foo; }

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-error.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-error.txt
@@ -1,0 +1,7 @@
+## Test errors on curly brace syntax.
+
+## Test open brace without closing brace.
+# RUN: { echo foo
+
+## Test closing brace without open brace.
+# RUN: echo foo; }

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-error.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-error.txt
@@ -1,7 +1,0 @@
-## Test errors on curly brace syntax.
-
-## Test open brace without closing brace.
-# RUN: { echo foo
-
-## Test closing brace without open brace.
-# RUN: echo foo; }

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-open-only.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace-open-only.txt
@@ -1,0 +1,2 @@
+## Test open brace without closing brace.
+# RUN: { echo foo

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
@@ -1,0 +1,12 @@
+## Test curly braces used in grouping commands.
+
+## Test one command inside curly brace.
+# RUN: { echo bar; } | FileCheck --check-prefix=ONE-CMD %s
+
+# ONE-CMD: bar
+
+## Test two commands inside curly brace.
+# RUN: { echo foo; echo bar; } | FileCheck --check-prefix=TWO-CMDS %s
+
+# TWO-CMDS: foo
+# TWO-CMDS: bar

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
@@ -10,3 +10,11 @@
 
 # TWO-CMDS: foo
 # TWO-CMDS: bar
+
+## Test nested curly brace.
+# RUN: { echo foo; { echo bar; echo baz; }; } | FileCheck --check-prefix=NESTED %s
+# RUN: { { echo foo; echo bar; }; echo baz; } | FileCheck --check-prefix=NESTED %s
+
+# NESTED: foo
+# NESTED: bar
+# NESTED: baz

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
@@ -12,9 +12,8 @@
 # TWO-CMDS: bar
 
 ## Test nested curly brace.
-# RUN: { echo foo; { echo bar; echo baz; }; } | FileCheck --check-prefix=NESTED %s
-# RUN: { { echo foo; echo bar; }; echo baz; } | FileCheck --check-prefix=NESTED %s
+# RUN: { echo foo > %t/temp.txt; { echo bar; echo baz; }; cat %t/temp.txt; } | FileCheck --check-prefix=NESTED %s
 
-# NESTED: foo
 # NESTED: bar
 # NESTED: baz
+# NESTED: foo

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/curly-brace.txt
@@ -8,12 +8,12 @@
 ## Test two commands inside curly brace.
 # RUN: { echo foo; echo bar; } | FileCheck --check-prefix=TWO-CMDS %s
 
-# TWO-CMDS: foo
-# TWO-CMDS: bar
+#      TWO-CMDS: foo
+# TWO-CMDS-NEXT: bar
 
 ## Test nested curly brace.
-# RUN: { echo foo > %t/temp.txt; { echo bar; echo baz; }; cat %t/temp.txt; } | FileCheck --check-prefix=NESTED %s
+# RUN: { echo foo > %t; { echo bar; echo baz; }; cat %t; } | FileCheck --check-prefix=NESTED %s
 
-# NESTED: bar
-# NESTED: baz
-# NESTED: foo
+#      NESTED: bar
+# NESTED-NEXT: baz
+# NESTED-NEXT: foo

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -28,6 +28,12 @@
 
 # CHECK: PASS: shtest-shell :: continuations.txt
 
+# CHECK: FAIL: shtest-shell :: curly-brace.txt
+# CHECK: # executed command: '{' echo bar
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | '{': command not found
+# CHECK: error: command failed with exit status: 127
+
 # CHECK: PASS: shtest-shell :: dev-null.txt
 
 #      CHECK: FAIL: shtest-shell :: diff-b.txt
@@ -635,4 +641,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (36)
+# CHECK: Failed Tests (37)

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -4,7 +4,7 @@
 # FIXME: Temporarily dump test output so we can debug failing tests on
 # buildbots.
 # RUN: cat %t.out
-# RUN: FileCheck --input-file %t.out %s
+# RUN: FileCheck --input-file %t.out %s --dump-input-context=1000
 #
 # Test again in non-UTF shell to catch potential errors with python 2 seen
 # on stdout-encoding.txt
@@ -27,6 +27,12 @@
 # CHECK: ***
 
 # CHECK: PASS: shtest-shell :: continuations.txt
+
+# CHECK: FAIL: shtest-shell :: curly-brace-error.txt
+# CHECK: # executed command: '{' echo foo
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | '{': command not found
+# CHECK: error: command failed with exit status: 127
 
 # CHECK: FAIL: shtest-shell :: curly-brace.txt
 # CHECK: # executed command: '{' echo bar
@@ -641,4 +647,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (37)
+# CHECK: Failed Tests (38)

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -4,7 +4,7 @@
 # FIXME: Temporarily dump test output so we can debug failing tests on
 # buildbots.
 # RUN: cat %t.out
-# RUN: FileCheck --input-file %t.out %s --dump-input-context=1000
+# RUN: FileCheck --input-file %t.out %s
 #
 # Test again in non-UTF shell to catch potential errors with python 2 seen
 # on stdout-encoding.txt
@@ -28,7 +28,13 @@
 
 # CHECK: PASS: shtest-shell :: continuations.txt
 
-# CHECK: FAIL: shtest-shell :: curly-brace-error.txt
+# CHECK: FAIL: shtest-shell :: curly-brace-close-only.txt
+# CHECK: # executed command: '}'
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | '}': command not found
+# CHECK: error: command failed with exit status: 127
+
+# CHECK: FAIL: shtest-shell :: curly-brace-open-only.txt
 # CHECK: # executed command: '{' echo foo
 # CHECK-NEXT: # .---command stderr------------
 # CHECK-NEXT: # | '{': command not found
@@ -647,4 +653,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (38)
+# CHECK: Failed Tests (39)


### PR DESCRIPTION
This patch creates tests to check lit's failure to execute curly braces {}. This is a prequisite patch to https://github.com/llvm/llvm-project/pull/102830.