### PR TITLE
[compiler-rt][AArch64][Android] Use getauxval on Android.

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/sme-abi-init.c
+++ b/compiler-rt/lib/builtins/aarch64/sme-abi-init.c
@@ -20,7 +20,7 @@ _Bool __aarch64_has_sme_and_tpidr2_el0;
 #else
 #define getauxval(x) 0
 #endif
-#include "cpumodel/aarch64/hwcap.inc"
+#include "../cpu_model/aarch64/hwcap.inc"
 
 static _Bool has_sme(void) { return getauxval(AT_HWCAP2) & HWCAP2_SME; }
 

--- a/compiler-rt/lib/builtins/aarch64/sme-abi-init.c
+++ b/compiler-rt/lib/builtins/aarch64/sme-abi-init.c
@@ -7,29 +7,22 @@ _Bool __aarch64_has_sme_and_tpidr2_el0;
 
 // We have multiple ways to check that the function has SME, depending on our
 // target.
-// * For Linux/glibc we can use __getauxval().
+// * For Linux/Glibc we can use getauxval().
 // * For Android we can use getauxval().
 // * For newlib we can use __aarch64_sme_accessible().
 
 #if defined(__linux__)
 
-#ifndef AT_HWCAP2
-#define AT_HWCAP2 26
-#endif
-
-#ifndef HWCAP2_SME
-#define HWCAP2_SME (1 << 23)
-#endif
-
-#ifdef __ANDROID__
-extern unsigned long int getauxval(unsigned long int);
-#define GETAUXVAL(x) getauxval(x)
+#if defined(__ANDROID__)
+#include <sys/auxv.h>
+#elif __has_include(<sys/auxv.h>)
+#include <sys/auxv.h>
 #else
-extern unsigned long int __getauxval (unsigned long int);
-#define GETAUXVAL(x) __getauxval(x)
+#define getauxval(x) 0
 #endif
+#include "cpumodel/aarch64/hwcap.inc"
 
-static _Bool has_sme(void) { return GETAUXVAL(AT_HWCAP2) & HWCAP2_SME; }
+static _Bool has_sme(void) { return getauxval(AT_HWCAP2) & HWCAP2_SME; }
 
 #else  // defined(__linux__)
 

--- a/compiler-rt/lib/builtins/aarch64/sme-abi-init.c
+++ b/compiler-rt/lib/builtins/aarch64/sme-abi-init.c
@@ -7,7 +7,8 @@ _Bool __aarch64_has_sme_and_tpidr2_el0;
 
 // We have multiple ways to check that the function has SME, depending on our
 // target.
-// * For Linux we can use __getauxval().
+// * For Linux/glibc we can use __getauxval().
+// * For Android we can use getauxval().
 // * For newlib we can use __aarch64_sme_accessible().
 
 #if defined(__linux__)
@@ -20,11 +21,15 @@ _Bool __aarch64_has_sme_and_tpidr2_el0;
 #define HWCAP2_SME (1 << 23)
 #endif
 
+#ifdef __ANDROID__
+extern unsigned long int getauxval(unsigned long int);
+#define GETAUXVAL(x) getauxval(x)
+#else
 extern unsigned long int __getauxval (unsigned long int);
+#define GETAUXVAL(x) __getauxval(x)
+#endif
 
-static _Bool has_sme(void) {
-  return __getauxval(AT_HWCAP2) & HWCAP2_SME;
-}
+static _Bool has_sme(void) { return GETAUXVAL(AT_HWCAP2) & HWCAP2_SME; }
 
 #else  // defined(__linux__)
 


### PR DESCRIPTION
__getauxval is a libgcc function that doesn't exist on Android.