### PR TITLE
[compiler-rt] Define `__STDC_FORMAT_MACROS` to ensure `PRId64` is available

### DIFF
--- a/compiler-rt/lib/scudo/standalone/timing.h
+++ b/compiler-rt/lib/scudo/standalone/timing.h
@@ -14,6 +14,10 @@
 #include "string_utils.h"
 #include "thread_annotations.h"
 
+#ifndef __STDC_FORMAT_MACROS
+// Ensure PRId64 macro is available
+#define __STDC_FORMAT_MACROS 1
+#endif
 #include <inttypes.h>
 #include <string.h>
 


### PR DESCRIPTION
In https://github.com/JuliaPackaging/Yggdrasil/pull/9246#issuecomment-2284894139 we ran into
```
[20:54:03] [ 65%] Building CXX object lib/scudo/standalone/CMakeFiles/RTScudoStandalone.x86_64.dir/timing.cpp.o
[20:54:03] cd /workspace/srcdir/compiler-rt-17.0.6.src/build/lib/scudo/standalone && /opt/bin/x86_64-linux-gnu-libgfortran5-cxx11/x86_64-linux-gnu-g++ --sysroot=/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/  -I/workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/../.. -I/workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/include -Wall -Wno-unused-parameter -O3 -DNDEBUG -m64 -Werror=conversion -Wall -Wextra -pedantic -g -nostdinc++ -fvisibility=hidden -fno-exceptions -Wno-pedantic -fno-lto -O3 -fno-omit-frame-pointer -DGWP_ASAN_HOOKS -std=c++17 -MD -MT lib/scudo/standalone/CMakeFiles/RTScudoStandalone.x86_64.dir/timing.cpp.o -MF CMakeFiles/RTScudoStandalone.x86_64.dir/timing.cpp.o.d -o CMakeFiles/RTScudoStandalone.x86_64.dir/timing.cpp.o -c /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.cpp
[...]
[20:54:03] In file included from /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.cpp:9:
[20:54:03] /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.h: In member function ‘void scudo::TimingManager::printImpl(scudo::ScopedString&, scudo::u32, scudo::u32)’:
[20:54:03] /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.h:182:21: error: expected ‘)’ before ‘PRId64’
[20:54:03]      Str.append("%14" PRId64 ".%" PRId64 "(ns) %-11s", Integral, Fraction, " ");
[20:54:03]                ~     ^~~~~~~
[20:54:03]                      )
[20:54:03] /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.h:182:16: warning: conversion lacks type at end of format [-Wformat=]
[20:54:03]      Str.append("%14" PRId64 ".%" PRId64 "(ns) %-11s", Integral, Fraction, " ");
[20:54:03]                 ^~~~~
[20:54:03] /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.h:182:16: warning: too many arguments for format [-Wformat-extra-args]
[20:54:03] /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.h:186:23: error: expected ‘)’ before ‘PRId64’
[20:54:03]      Str.append("%s (%" PRId64 ")\n", Timers[HandleId].Name, Occurrence);
[20:54:03]                ~       ^~~~~~~
[20:54:03]                        )
[20:54:03] /workspace/srcdir/compiler-rt-17.0.6.src/lib/scudo/standalone/timing.h:186:16: warning: spurious trailing ‘%’ in format [-Wformat=]
[20:54:03]      Str.append("%s (%" PRId64 ")\n", Timers[HandleId].Name, Occurrence);
[20:54:03]                 ^~~~~~~
```
when compiling compiler-rt with GCC 8.  This was resolved by defining `__STDC_FORMAT_MACROS`.