### PR TITLE
[DataLayout] Remove `clear` and `reset` methods (NFC)

### DIFF
--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -185,14 +185,10 @@ private:
   /// if the string is malformed.
   Error parseSpecifier(StringRef Desc);
 
-  // Free all internal data structures.
-  void clear();
-
 public:
-  /// Constructs a DataLayout from a specification string. See reset().
-  explicit DataLayout(StringRef LayoutDescription) {
-    reset(LayoutDescription);
-  }
+  /// Constructs a DataLayout from a specification string.
+  /// WARNING: Aborts execution if the string is malformed. Use parse() instead.
+  explicit DataLayout(StringRef LayoutString);
 
   DataLayout(const DataLayout &DL) { *this = DL; }
 
@@ -202,9 +198,6 @@ public:
 
   bool operator==(const DataLayout &Other) const;
   bool operator!=(const DataLayout &Other) const { return !(*this == Other); }
-
-  /// Parse a data layout string (with fallback to default values).
-  void reset(StringRef LayoutDescription);
 
   /// Parse a data layout string and return the layout. Return an error
   /// description on failure.

--- a/llvm/lib/IR/DataLayout.cpp
+++ b/llvm/lib/IR/DataLayout.cpp
@@ -120,7 +120,7 @@ unsigned StructLayout::getElementContainingOffset(uint64_t FixedOffset) const {
 namespace {
 
 class StructLayoutMap {
-  using LayoutInfoTy = DenseMap<StructType*, StructLayout*>;
+  using LayoutInfoTy = DenseMap<StructType *, StructLayout *>;
   LayoutInfoTy LayoutInfo;
 
 public:
@@ -133,9 +133,7 @@ public:
     }
   }
 
-  StructLayout *&operator[](StructType *STy) {
-    return LayoutInfo[STy];
-  }
+  StructLayout *&operator[](StructType *STy) { return LayoutInfo[STy]; }
 };
 
 } // end anonymous namespace

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -388,9 +388,7 @@ void Module::setModuleFlag(ModFlagBehavior Behavior, StringRef Key,
   setModuleFlag(Behavior, Key, ConstantInt::get(Int32Ty, Val));
 }
 
-void Module::setDataLayout(StringRef Desc) {
-  DL.reset(Desc);
-}
+void Module::setDataLayout(StringRef Desc) { DL = DataLayout(Desc); }
 
 void Module::setDataLayout(const DataLayout &Other) { DL = Other; }
 

--- a/llvm/unittests/IR/DataLayoutTest.cpp
+++ b/llvm/unittests/IR/DataLayoutTest.cpp
@@ -19,6 +19,23 @@ using namespace llvm;
 
 namespace {
 
+TEST(DataLayoutTest, CopyAssignmentInvalidatesStructLayout) {
+  DataLayout DL1 = cantFail(DataLayout::parse("p:32:32"));
+  DataLayout DL2 = cantFail(DataLayout::parse("p:64:64"));
+
+  LLVMContext Ctx;
+  StructType *Ty = StructType::get(PointerType::getUnqual(Ctx));
+
+  // Initialize struct layout caches.
+  EXPECT_EQ(DL1.getStructLayout(Ty)->getAlignment(), Align(4));
+  EXPECT_EQ(DL2.getStructLayout(Ty)->getAlignment(), Align(8));
+
+  // The copy should invalidate DL1's cache.
+  DL1 = DL2;
+  EXPECT_EQ(DL1.getStructLayout(Ty)->getAlignment(), Align(8));
+  EXPECT_EQ(DL2.getStructLayout(Ty)->getAlignment(), Align(8));
+}
+
 TEST(DataLayoutTest, FunctionPtrAlign) {
   EXPECT_EQ(MaybeAlign(0), DataLayout("").getFunctionPtrAlign());
   EXPECT_EQ(MaybeAlign(1), DataLayout("Fi8").getFunctionPtrAlign());

--- a/llvm/unittests/IR/DataLayoutTest.cpp
+++ b/llvm/unittests/IR/DataLayoutTest.cpp
@@ -27,12 +27,16 @@ TEST(DataLayoutTest, CopyAssignmentInvalidatesStructLayout) {
   StructType *Ty = StructType::get(PointerType::getUnqual(Ctx));
 
   // Initialize struct layout caches.
+  EXPECT_EQ(DL1.getStructLayout(Ty)->getSizeInBits(), 32U);
   EXPECT_EQ(DL1.getStructLayout(Ty)->getAlignment(), Align(4));
+  EXPECT_EQ(DL2.getStructLayout(Ty)->getSizeInBits(), 64U);
   EXPECT_EQ(DL2.getStructLayout(Ty)->getAlignment(), Align(8));
 
   // The copy should invalidate DL1's cache.
   DL1 = DL2;
+  EXPECT_EQ(DL1.getStructLayout(Ty)->getSizeInBits(), 64U);
   EXPECT_EQ(DL1.getStructLayout(Ty)->getAlignment(), Align(8));
+  EXPECT_EQ(DL2.getStructLayout(Ty)->getSizeInBits(), 64U);
   EXPECT_EQ(DL2.getStructLayout(Ty)->getAlignment(), Align(8));
 }
 


### PR DESCRIPTION
`clear` was never necessary as it is always called on a fresh instance of the class or just before freeing an instance's memory. `reset` is effectively the same as the constructor.