### PR TITLE
[flang][cuda] Do not lower PINNED variable in main program as global

### DIFF
--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -1247,7 +1247,6 @@ inline bool CanCUDASymbolHasSave(const Symbol &sym) {
   if (const auto *details =
           sym.GetUltimate().detailsIf<semantics::ObjectEntityDetails>()) {
     if (details->cudaDataAttr() &&
-        *details->cudaDataAttr() != common::CUDADataAttr::Pinned &&
         *details->cudaDataAttr() != common::CUDADataAttr::Unified) {
       return false;
     }

--- a/flang/test/Lower/CUDA/cuda-program-global.cuf
+++ b/flang/test/Lower/CUDA/cuda-program-global.cuf
@@ -6,6 +6,7 @@
 program test
   integer, device :: a(10)
   integer, unified :: u(10)
+  integer, allocatable, pinned :: p(:)
   integer :: b(10)
   integer :: i
   print*,i
@@ -16,6 +17,7 @@ end
 ! CHECK: fir.address_of(@_QFEb) : !fir.ref<!fir.array<10xi32>>
 ! CHECK: %[[ALLOCA:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
 ! CHECK: hlfir.declare %[[ALLOCA]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: cuf.alloc !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "p", data_attr = #cuf.cuda<pinned>, uniq_name = "_QFEp"} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 
 ! CHECK-NOT: fir.global internal @_QFEa {data_attr = #cuf.cuda<device>} : !fir.array<10xi32> {{{$}}
 ! CHECK: fir.global internal @_QFEb : !fir.array<10xi32> {{{$}}


### PR DESCRIPTION
Similar to #102512. Do not lower PINNED variable descriptors in program unit as globals but keep them local. 