### PR TITLE
[TableGen] Fix build failure by using int type for NextChar

### DIFF
--- a/llvm/lib/TableGen/TGLexer.cpp
+++ b/llvm/lib/TableGen/TGLexer.cpp
@@ -644,7 +644,7 @@ tgtok::TokKind TGLexer::prepIsDirective() const {
   for (const auto [Kind, Word] : PreprocessorDirs) {
     if (StringRef(CurPtr, Word.size()) != Word)
       continue;
-    char NextChar = peekNextChar(Word.size());
+    int NextChar = peekNextChar(Word.size());
 
     // Check for whitespace after the directive. If there is no whitespace,
     // then we do not recognize it as a preprocessing directive.


### PR DESCRIPTION
- Fixes an issue in https://github.com/llvm/llvm-project/pull/102967, 
   which inddvertently changed the type of `NextChar` from int to char, causing ppc64le build failures.