### PR TITLE
[llvm-lit] Add REQUIRES: shell to BOLT permission test for lit internal shell

### DIFF
--- a/bolt/test/permission.test
+++ b/bolt/test/permission.test
@@ -4,7 +4,7 @@
 # This test performs a logical AND operation on the results of the `stat -c %a
 # %t.bolt` and `umask` commands (both results are displayed in octal), and
 # checks whether the result is equal to 0.
-REQUIRES: system-linux
+REQUIRES: shell, system-linux
 
 RUN: %clang %cflags %p/Inputs/hello.c -o %t -Wl,-q
 RUN: llvm-bolt %t -o %t.bolt


### PR DESCRIPTION
This patch adds the `REQUIRES: shell` directive to the BOLT permission test to ensure it only runs in environments with a full-featured Unix-like shell. This change is necessary because the test relies on advanced shell capabilities that are not supported by lit's internal shell.

**Reasoning:**  The BOLT permission test uses features like running commands in the background with `&`, performing arithmetic operations, and handling special number formats (octal). These features require a more capable shell than what lit's internal shell provides. Without a proper shell, the test could fail or behave unpredictably.

Previously, this test was causing an `AttributeError` due to incompatibilities with lit's internal shell. By enforcing the use of an external shell with the `REQUIRES: shell` directive, this patch addresses the issue temporarily. This approach fixes the problem for now, and when we later revisit and remove the `REQUIRES: shell` directive, we can implement a more robust solution to fully support these features in the internal shell.


This change is relevant for enabling the lit internal shell by default, as outlined in [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179)

fixes: #102399