### PR TITLE
[mlir][StorageUniquer] Restore old signature for default implementaion of verifyInvariants.

### DIFF
--- a/mlir/include/mlir/IR/StorageUniquerSupport.h
+++ b/mlir/include/mlir/IR/StorageUniquerSupport.h
@@ -226,9 +226,7 @@ protected:
 
   /// Default implementation that just returns success.
   template <typename... Args>
-  static LogicalResult
-  verifyInvariants(function_ref<InFlightDiagnostic()> emitErrorFn,
-                   Args... args) {
+  static LogicalResult verifyInvariants(Args... args) {
     return success();
   }
 


### PR DESCRIPTION
PR #102326 changed the prototype of the default implementation of verify to include emitErrorFn.

This breaks automatic derivation in consumer attributes, such as https://github.com/tensorflow/runtime/blob/60277ba976739502e45ad26585e071568fa44af1/include/tfrt/core_runtime/opdefs/attributes.h#L53.

This PR simply restores the signature to what it was prior to PR #102326.