### PR TITLE
[MC] Remove Darwin SDK/Version from ObjFileInfo

### DIFF
--- a/llvm/include/llvm/MC/MCObjectFileInfo.h
+++ b/llvm/include/llvm/MC/MCObjectFileInfo.h
@@ -458,9 +458,6 @@ public:
 private:
   bool PositionIndependent = false;
   MCContext *Ctx = nullptr;
-  VersionTuple SDKVersion;
-  std::optional<Triple> DarwinTargetVariantTriple;
-  VersionTuple DarwinTargetVariantSDKVersion;
 
   void initMachOMCObjectFileInfo(const Triple &T);
   void initELFMCObjectFileInfo(const Triple &T, bool Large);
@@ -471,29 +468,6 @@ private:
   void initXCOFFMCObjectFileInfo(const Triple &T);
   void initDXContainerObjectFileInfo(const Triple &T);
   MCSection *getDwarfComdatSection(const char *Name, uint64_t Hash) const;
-
-public:
-  void setSDKVersion(const VersionTuple &TheSDKVersion) {
-    SDKVersion = TheSDKVersion;
-  }
-
-  const VersionTuple &getSDKVersion() const { return SDKVersion; }
-
-  void setDarwinTargetVariantTriple(const Triple &T) {
-    DarwinTargetVariantTriple = T;
-  }
-
-  const Triple *getDarwinTargetVariantTriple() const {
-    return DarwinTargetVariantTriple ? &*DarwinTargetVariantTriple : nullptr;
-  }
-
-  void setDarwinTargetVariantSDKVersion(const VersionTuple &TheSDKVersion) {
-    DarwinTargetVariantSDKVersion = TheSDKVersion;
-  }
-
-  const VersionTuple &getDarwinTargetVariantSDKVersion() const {
-    return DarwinTargetVariantSDKVersion;
-  }
 };
 
 } // end namespace llvm

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -533,14 +533,8 @@ MCStreamer *llvm::createMachOStreamer(MCContext &Context,
                                       std::unique_ptr<MCCodeEmitter> &&CE,
                                       bool DWARFMustBeAtTheEnd,
                                       bool LabelSections) {
-  MCMachOStreamer *S = new MCMachOStreamer(
-      Context, std::move(MAB), std::move(OW), std::move(CE), LabelSections);
-  const Triple &Target = Context.getTargetTriple();
-  S->emitVersionForTarget(
-      Target, Context.getObjectFileInfo()->getSDKVersion(),
-      Context.getObjectFileInfo()->getDarwinTargetVariantTriple(),
-      Context.getObjectFileInfo()->getDarwinTargetVariantSDKVersion());
-  return S;
+  return new MCMachOStreamer(Context, std::move(MAB), std::move(OW),
+                             std::move(CE), LabelSections);
 }
 
 // The AddrSig section uses a series of relocations to refer to the symbols that

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -109,7 +109,6 @@ initializeRecordStreamer(const Module &M,
   MCContext MCCtx(TT, MAI.get(), MRI.get(), STI.get(), &SrcMgr);
   std::unique_ptr<MCObjectFileInfo> MOFI(
       T->createMCObjectFileInfo(MCCtx, /*PIC=*/false));
-  MOFI->setSDKVersion(M.getSDKVersion());
   MCCtx.setObjectFileInfo(MOFI.get());
   RecordStreamer Streamer(MCCtx, M);
   T->createNullTargetStreamer(Streamer);

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -559,6 +559,9 @@ int main(int argc, char **argv) {
         std::unique_ptr<MCCodeEmitter>(CE), *STI));
     if (NoExecStack)
       Str->initSections(true, *STI);
+    if (TheTriple.isOSBinFormatMachO() && TheTriple.isOSDarwin())
+      Str->emitVersionForTarget(TheTriple, VersionTuple(), nullptr,
+                                VersionTuple());
   }
 
   int Res = 1;

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -559,9 +559,8 @@ int main(int argc, char **argv) {
         std::unique_ptr<MCCodeEmitter>(CE), *STI));
     if (NoExecStack)
       Str->initSections(true, *STI);
-    if (TheTriple.isOSBinFormatMachO() && TheTriple.isOSDarwin())
-      Str->emitVersionForTarget(TheTriple, VersionTuple(), nullptr,
-                                VersionTuple());
+    Str->emitVersionForTarget(TheTriple, VersionTuple(), nullptr,
+                              VersionTuple());
   }
 
   int Res = 1;


### PR DESCRIPTION
There's only a single user (MCMachOStreamer), so it makes more sense to move the version emission to the source of the data.

(Not sure whether we want this, but I don't see benefits in storing this information in the MCObjectFileInfo.)