### PR TITLE
[clang-repl] Fix PCH with delayed template parsing

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -1887,6 +1887,7 @@ Token ASTReader::ReadToken(ModuleFile &M, const RecordDataImpl &Record,
     case tok::annot_pragma_unused:
     case tok::annot_pragma_openacc:
     case tok::annot_pragma_openacc_end:
+    case tok::annot_repl_input_end:
       break;
     default:
       llvm_unreachable("missing deserialization code for annotation token");

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -4734,6 +4734,7 @@ void ASTWriter::AddToken(const Token &Tok, RecordDataImpl &Record) {
     case tok::annot_pragma_unused:
     case tok::annot_pragma_openacc:
     case tok::annot_pragma_openacc_end:
+    case tok::annot_repl_input_end:
       break;
     default:
       llvm_unreachable("missing serialization code for annotation token");

--- a/clang/test/Interpreter/delayed-template-parsing-pch.cpp
+++ b/clang/test/Interpreter/delayed-template-parsing-pch.cpp
@@ -1,0 +1,25 @@
+// Test the setup without incremental extensions first
+// RUN: %clang_cc1 -std=c++17 -fdelayed-template-parsing -fpch-instantiate-templates %s -emit-pch -o %t.pch -verify
+// RUN: %clang_cc1 -std=c++17 -fdelayed-template-parsing -include-pch %t.pch %s -verify
+
+// RUN: %clang_cc1 -std=c++17 -fdelayed-template-parsing -fincremental-extensions -fpch-instantiate-templates %s -emit-pch -o %t.incremental.pch -verify
+// RUN: %clang_cc1 -std=c++17 -fdelayed-template-parsing -fincremental-extensions -include-pch %t.incremental.pch %s -verify
+
+// expected-no-diagnostics
+
+#ifndef PCH
+#define PCH
+
+// Have one template that is instantiated in the PCH (via the passed option
+// -fpch-instantiate-templates) and then serialized
+template <typename T> T ft1() { return 0; }
+inline int f1() { return ft1<int>(); }
+
+// Have a second late-parsed template that needs to be deserialized
+template <typename T> T ft2() { return 0; }
+
+#else
+
+int f2() { return ft2<int>(); }
+
+#endif


### PR DESCRIPTION
When instantiating a delayed template, the recorded token stream is passed to `Parser::ParseLateTemplatedFuncDef` which will append the current token "so it doesn't get lost". With incremental extensions enabled, this is `repl_input_end` which subsequently needs support for (de)serialization.