### PR TITLE
[Object][x86-64] Add support for `R_X86_64_GLOB_DAT` relocations.

### DIFF
--- a/llvm/lib/Object/RelocationResolver.cpp
+++ b/llvm/lib/Object/RelocationResolver.cpp
@@ -47,6 +47,7 @@ static bool supportsX86_64(uint64_t Type) {
   case ELF::R_X86_64_PC64:
   case ELF::R_X86_64_32:
   case ELF::R_X86_64_32S:
+  case ELF::R_X86_64_GLOB_DAT:
     return true;
   default:
     return false;
@@ -68,6 +69,8 @@ static uint64_t resolveX86_64(uint64_t Type, uint64_t Offset, uint64_t S,
   case ELF::R_X86_64_32:
   case ELF::R_X86_64_32S:
     return (S + Addend) & 0xFFFFFFFF;
+  case ELF::R_X86_64_GLOB_DAT:
+    return S;
   default:
     llvm_unreachable("Invalid relocation type");
   }


### PR DESCRIPTION
Add support for `R_X86_64_GLOB_DAT` relocations to the relocation resolver.

rdar://133510292