### PR TITLE
[mlir] Fix misleading comment for type trait

### DIFF
--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -289,7 +289,7 @@ protected:
   using Pattern::Pattern;
 
 private:
-  /// Trait to check if T provides a `getOperationName` method.
+  /// Trait to check if T provides a `initialize` method.
   template <typename T, typename... Args>
   using has_initialize = decltype(std::declval<T>().initialize());
   template <typename T>


### PR DESCRIPTION
We are using `has_initialize` to check the class has `initialize` function instead of the `getOperationName` function.