### PR TITLE
[NVPTX] Fix typo causing GCC warning

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
@@ -1974,8 +1974,7 @@ bool NVPTXDAGToDAGISel::tryStore(SDNode *N) {
     Ops.append({BasePtr, Chain});
   }
 
-  SDNode *NVPTXST = NVPTXST =
-      CurDAG->getMachineNode(*Opcode, DL, MVT::Other, Ops);
+  SDNode *NVPTXST = CurDAG->getMachineNode(*Opcode, DL, MVT::Other, Ops);
 
   if (!NVPTXST)
     return false;


### PR DESCRIPTION
Solves typo found by @mikaelholmen here: https://github.com/llvm/llvm-project/pull/98551#discussion_r1714824883