### PR TITLE
[libcxx][test] Skip sys_info zdump test when zdump was built with 32 bit time_t

### DIFF
--- a/libcxx/test/std/time/time.zone/time.zone.timezone/time.zone.members/sys_info.zdump.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.timezone/time.zone.members/sys_info.zdump.pass.cpp
@@ -7,14 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: no-filesystem, no-localization, no-tzdb, has-no-zdump
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb, has-no-zdump, zdump-time_t-32bit
 // REQUIRES: long_tests
 
 // XFAIL: libcpp-has-no-experimental-tzdb
 // XFAIL: availability-tzdb-missing
-
-// TODO TZDB Investigate
-// UNSUPPORTED: target={{armv(7|8)l-linux-gnueabihf}}
 
 #include <chrono>
 #include <format>

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -352,6 +352,18 @@ DEFAULT_FEATURES = [
         name="has-no-zdump",
         when=lambda cfg: runScriptExitCode(cfg, ["zdump --version"]) != 0,
     ),
+    # zdump built with 32 bit time_t will truncate times into the 32 bit range.
+    # Starting with glibc 2.34, some architectures, like armhf, started building
+    # zdump with time_t as 64 bit which allows it to handle the maximum range.
+    # If zdump was built with time_t 64 bit, it will show the 1869 entries for
+    # this zone, which would be out of range for 32 bit.
+    Feature(
+        name="zdump-time_t-32bit",
+        when=lambda cfg: runScriptExitCode(
+            cfg, ["zdump -V -c1800,2100 Africa/Addis_Ababa | grep -q 1869"]
+        )
+        != 0,
+    ),
 ]
 
 # Deduce and add the test features that that are implied by the #defines in

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -359,7 +359,10 @@ DEFAULT_FEATURES = [
     # this zone, which would be out of range for 32 bit.
     Feature(
         name="zdump-time_t-32bit",
-        when=lambda cfg: runScriptExitCode(
+        when=lambda cfg: BooleanExpression.evaluate(
+            "!has-no-zdump", cfg.available_features
+        )
+        and runScriptExitCode(
             cfg, ["zdump -V -c1800,2100 Africa/Addis_Ababa | grep -q 1869"]
         )
         != 0,


### PR DESCRIPTION
This test started passing on Armhf Ubuntu Jammy, but fails on Focal. This is due to extra output from zdump on Jammy, which makes it match the information libcxx gets from the time zone database.

Focal:
```
$ zdump --version
zdump (Ubuntu GLIBC 2.31-0ubuntu9.16) 2.31
tzdata/focal-updates,now 2024a-0ubuntu0.20.04.1 all [installed,automatic]
$ zdump -V -c1800,2100 Africa/Addis_Ababa
Africa/Addis_Ababa  Mon May  4 21:24:39 1936 UT = Mon May  4 23:59:59 1936 ADMT isdst=0 gmtoff=9320
Africa/Addis_Ababa  Mon May  4 21:24:40 1936 UT = Tue May  5 00:24:40 1936 EAT isdst=0 gmtoff=10800
```
Jammy:
```
$ zdump --version
zdump (Ubuntu GLIBC 2.35-0ubuntu3.8) 2.35
tzdata/jammy-updates,now 2024a-0ubuntu0.22.04.1 all [installed,automatic]
$ zdump -V -c1800,2100 Africa/Addis_Ababa
Africa/Addis_Ababa  Fri Dec 31 21:25:11 1869 UT = Fri Dec 31 23:59:59 1869 LMT isdst=0 gmtoff=9288
Africa/Addis_Ababa  Fri Dec 31 21:25:12 1869 UT = Sat Jan  1 00:00:32 1870 ADMT isdst=0 gmtoff=9320
Africa/Addis_Ababa  Mon May  4 21:24:39 1936 UT = Mon May  4 23:59:59 1936 ADMT isdst=0 gmtoff=9320
Africa/Addis_Ababa  Mon May  4 21:24:40 1936 UT = Tue May  5 00:24:40 1936 EAT isdst=0 gmtoff=10800
```
(lots more zones have differences)

This is due to zdump being built with time_t as 32 bit on armhf in glibc 2.31. The input years get truncated into the 32 bit range, putting some entries outside the possible range.

In glibc 2.34 this changed so that zdump has time_t as 64 bit on armhf, so it shows all the entries.

https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=d488874aba371b2bfa1d99fb607eb653fdd19e17;hb=HEAD#l1331

```
* Add support for 64-bit time_t on configurations like x86 where time_t
  is traditionally 32-bit.  Although time_t still defaults to 32-bit on
  these configurations, this default may change in future versions.
  This is enabled with the _TIME_BITS preprocessor macro set to 64 and is
  only supported when LFS (_FILE_OFFSET_BITS=64) is also enabled.  It is
  only enabled for Linux and the full support requires a minimum kernel
  version of 5.1.
```

This commit adds a test feature to detect this change. The alternative is to disable it on any armhf Linux, which seems too broad to me.