### PR TITLE
[libc][math] Fix missing LIBC_INLINE on exp_range_reduction() function

### DIFF
--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1367,6 +1367,7 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
+    libc.src.__support.macros.attributes
     libc.src.__support.macros.optimization
   COMPILE_OPTIONS
     -O3

--- a/libc/src/math/generic/expxf16.h
+++ b/libc/src/math/generic/expxf16.h
@@ -13,6 +13,7 @@
 #include "src/__support/FPUtil/PolyEval.h"
 #include "src/__support/FPUtil/multiply_add.h"
 #include "src/__support/FPUtil/nearest_integer.h"
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include <stdint.h>
 
@@ -45,7 +46,7 @@ struct ExpRangeReduction {
   float exp_lo;
 };
 
-ExpRangeReduction exp_range_reduction(float16 x) {
+LIBC_INLINE ExpRangeReduction exp_range_reduction(float16 x) {
   // For -18 < x < 12, to compute exp(x), we perform the following range
   // reduction: find hi, mid, lo, such that:
   //   x = hi + mid + lo, in which


### PR DESCRIPTION
See Buildbot failure:
https://lab.llvm.org/buildbot/#/builders/73/builds/3669.
