### PR TITLE
[IR] Cache llvm.module.flags metadata in Module

### DIFF
--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -202,6 +202,9 @@ private:
                              ///< ID and FunctionType maps to the extension that
                              ///< is used to make the intrinsic name unique.
 
+  /// llvm.module.flags metadata
+  NamedMDNode *ModuleFlags = nullptr;
+
   friend class Constant;
 
 /// @}
@@ -528,7 +531,7 @@ public:
 
   /// Returns the NamedMDNode in the module that represents module-level flags.
   /// This method returns null if there are no module-level flags.
-  NamedMDNode *getModuleFlagsMetadata() const;
+  NamedMDNode *getModuleFlagsMetadata() const { return ModuleFlags; }
 
   /// Returns the NamedMDNode in the module that represents module-level flags.
   /// If module-level flags aren't found, it creates the named metadata that

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -272,6 +272,8 @@ NamedMDNode *Module::getOrInsertNamedMetadata(StringRef Name) {
     NMD = new NamedMDNode(Name);
     NMD->setParent(this);
     insertNamedMDNode(NMD);
+    if (Name == "llvm.module.flags")
+      ModuleFlags = NMD;
   }
   return NMD;
 }
@@ -280,6 +282,8 @@ NamedMDNode *Module::getOrInsertNamedMetadata(StringRef Name) {
 /// delete it.
 void Module::eraseNamedMetadata(NamedMDNode *NMD) {
   NamedMDSymTab.erase(NMD->getName());
+  if (NMD == ModuleFlags)
+    ModuleFlags = nullptr;
   eraseNamedMDNode(NMD);
 }
 
@@ -323,17 +327,12 @@ Metadata *Module::getModuleFlag(StringRef Key) const {
   return nullptr;
 }
 
-/// getModuleFlagsMetadata - Returns the NamedMDNode in the module that
-/// represents module-level flags. This method returns null if there are no
-/// module-level flags.
-NamedMDNode *Module::getModuleFlagsMetadata() const {
-  return getNamedMetadata("llvm.module.flags");
-}
-
 /// getOrInsertModuleFlagsMetadata - Returns the NamedMDNode in the module that
 /// represents module-level flags. If module-level flags aren't found, it
 /// creates the named metadata that contains them.
 NamedMDNode *Module::getOrInsertModuleFlagsMetadata() {
+  if (ModuleFlags)
+    return ModuleFlags;
   return getOrInsertNamedMetadata("llvm.module.flags");
 }
 


### PR DESCRIPTION
This metadata is queried quite often, so avoiding frequent lookups in
the hash map is beneficial. Therefore, cache the metadata node directly
in the module.
