### PR TITLE
[libc] Define 'size_t' in `time.h` and `uchar.h`

### DIFF
--- a/libc/include/time.h.def
+++ b/libc/include/time.h.def
@@ -11,8 +11,6 @@
 
 #include "__llvm-libc-common.h"
 #include "llvm-libc-macros/time-macros.h"
-#include "llvm-libc-types/clock_t.h"
-#include "llvm-libc-types/clockid_t.h"
 
 %%public_api()
 

--- a/libc/include/uchar.h.def
+++ b/libc/include/uchar.h.def
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_UCHAR_H
 
 #include "__llvm-libc-common.h"
-#include "llvm-libc-types/mbstate_t.h"
 
 %%public_api()
 

--- a/libc/newhdrgen/yaml/time.yaml
+++ b/libc/newhdrgen/yaml/time.yaml
@@ -7,6 +7,7 @@ types:
   - type_name: struct_tm
   - type_name: time_t
   - type_name: clock_t
+  - type_name: size_t
 enums: []
 objects: []
 functions:

--- a/libc/newhdrgen/yaml/uchar.yaml
+++ b/libc/newhdrgen/yaml/uchar.yaml
@@ -7,6 +7,7 @@ types:
   - type_name: char16_t
   - type_name: char8_t
   - type_name: mbstate_t
+  - type_name: size_t
 enums: []
 objects: []
 functions: []

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -1475,6 +1475,7 @@ def StdC : StandardSpec<"stdc"> {
          StructTmType,
          StructTimeSpec,
          TimeTType,
+         SizeTType,
       ],
       [], // Enumerations
       [
@@ -1562,6 +1563,7 @@ def StdC : StandardSpec<"stdc"> {
         Char8TType,
         Char16TType,
         Char32TType,
+        SizeTType,
       ],
       [], // Enumerations
       []


### PR DESCRIPTION
Summary:
The standard says the following: The <time.h> header shall define the
clock_t, size_t, time_t, types as described in <sys/types.h>. I couldn't
find one for `uchar.h` but it needs it once we define things like
`mbrtoc8`.
