### PR TITLE
[libc] Fix `INFINITY` being defined as a double

### DIFF
--- a/libc/include/llvm-libc-macros/math-macros.h
+++ b/libc/include/llvm-libc-macros/math-macros.h
@@ -28,7 +28,7 @@
 
 #define HUGE_VAL __builtin_huge_val()
 #define HUGE_VALF __builtin_huge_valf()
-#define INFINITY __builtin_inf()
+#define INFINITY __builtin_inff()
 #define NAN __builtin_nanf("")
 
 #define FP_ILOGB0 (-INT_MAX - 1)


### PR DESCRIPTION
Summary:
If the implementation supports floating-point infinities, the macro
INFINITY expands to constant expression of type float which evaluates to
positive or unsigned infinity.

Currently this is a double, this makes it a float.
