### PR TITLE
[LLDB][OSX] Add a fallback support exe directory

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -124,6 +124,12 @@ FileSpec HostInfoMacOSX::GetProgramFileSpec() {
   return g_program_filespec;
 }
 
+/// Resolve the given candidate support dir and return true if it's valid.
+static bool ResolveAndVerifyCandidateSupportDir(FileSpec &path) {
+  FileSystem::Instance().Resolve(path);
+  return FileSystem::Instance().IsDirectory(path);
+};
+
 bool HostInfoMacOSX::ComputeSupportExeDirectory(FileSpec &file_spec) {
   FileSpec lldb_file_spec = GetShlibDir();
   if (!lldb_file_spec)
@@ -144,16 +150,24 @@ bool HostInfoMacOSX::ComputeSupportExeDirectory(FileSpec &file_spec) {
 #endif
   } else {
     // Find the bin path relative to the lib path where the cmake-based
-    // OS X .dylib lives.  This is not going to work if the bin and lib
-    // dir are not both in the same dir.
+    // OS X .dylib lives. We try looking first at a possible sibling `bin`
+    // directory, and then at the `lib` directory itself. This last case is
+    // useful for supporting build systems like Bazel which in many cases prefer
+    // to place support binaries right next to dylibs.
     //
-    // It is not going to work to do it by the executable path either,
+    // It is not going to work to do it by the executable path,
     // as in the case of a python script, the executable is python, not
     // the lldb driver.
-    raw_path.append("/../bin");
-    FileSpec support_dir_spec(raw_path);
-    FileSystem::Instance().Resolve(support_dir_spec);
-    if (!FileSystem::Instance().IsDirectory(support_dir_spec)) {
+    FileSpec support_dir_spec_lib(raw_path);
+    FileSpec support_dir_spec_bin =
+        support_dir_spec_lib.CopyByAppendingPathComponent("/../bin");
+    FileSpec support_dir_spec;
+
+    if (ResolveAndVerifyCandidateSupportDir(support_dir_spec_bin)) {
+      support_dir_spec = support_dir_spec_bin;
+    } else if (ResolveAndVerifyCandidateSupportDir(support_dir_spec_lib)) {
+      support_dir_spec = support_dir_spec_lib;
+    } else {
       Log *log = GetLog(LLDBLog::Host);
       LLDB_LOG(log, "failed to find support directory");
       return false;


### PR DESCRIPTION
LLDB on OSX is looking at a `bin` directory sibling to the `lib` one that contains liblldb for its supporting executables. This works well for CMake, however, for other build systems like bazel, it's not that easy to have that build structure, for which it's much easier to also use the `lib` directory as a fallback under the absence of `bin`.
This shouldn't break anything, but instead should make it a bit easier for LLDB to work with different build systems and folder structures.
