### PR TITLE
[lldb-dap] Expose log path in extension settings

### DIFF
--- a/lldb/tools/lldb-dap/package-lock.json
+++ b/lldb/tools/lldb-dap/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lldb-dap",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lldb-dap",
-      "version": "0.2.0",
+      "version": "0.2.4",
       "license": "Apache 2.0 License with LLVM exceptions",
       "devDependencies": {
         "@types/node": "^18.11.18",

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lldb-dap",
   "displayName": "LLDB DAP",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "llvm-vs-code-extensions",
   "homepage": "https://lldb.llvm.org",
   "description": "LLDB debugging from VSCode",
@@ -73,6 +73,11 @@
           "scope": "resource",
           "type": "string",
           "description": "The path to the lldb-dap binary."
+        },
+        "lldb-dap.log-path": {
+          "scope": "resource",
+          "type": "string",
+          "description": "The log path for lldb-dap (if any)"
         }
       }
     },


### PR DESCRIPTION
lldb-dap already supports a log file which can be enabled by setting the `LLDBDAP_LOG` environment variable. With this commit, the log location can be set directly through the VS-Code extension settings.

Also, this commit bumps the version number, such that the new VS Code extension gets published to the Marketplace.
