### PR TITLE
[libc] Add definitions for totalordermag(,f, l, f128), dsqrt(l, f128), fsqrt(, l, f128) to math.yaml.

### DIFF
--- a/libc/newhdrgen/yaml/math.yaml
+++ b/libc/newhdrgen/yaml/math.yaml
@@ -214,6 +214,12 @@ functions:
     arguments:
       - type: long double
       - type: long double
+  - name: dsqrtl
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: long double
   - name: erff
     standards:
       - stdc
@@ -1195,6 +1201,18 @@ functions:
       - type: long double
       - type: int
       - type: unsigned int
+  - name: fsqrt
+    standards:
+      - stdc
+    return_type: float type
+    arguments:
+      - type: double
+  - name: fsqrtl
+    standards:
+      - stdc
+    return_type: float
+    arguments:
+      - type: long double 
   - name: fsub
     standards:
       - stdc
@@ -2323,6 +2341,27 @@ functions:
     arguments:
       - type: const long double *
       - type: const long double *
+  - name: totalordermag
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: double *
+      - type: double *
+  - name: totalordermagf
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float *
+      - type: float *
+  - name: totalordermagl
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: long double *
+      - type: long double *
   - name: totalordermagf16
     standards:
       - stdc

--- a/libc/newhdrgen/yaml/math.yaml
+++ b/libc/newhdrgen/yaml/math.yaml
@@ -220,6 +220,14 @@ functions:
     return_type: double
     arguments:
       - type: long double
+  - name: dsqrtf128
+    standards:
+      - llvm_libc_ext
+    return_type: double
+    arguments:
+      - type: float128
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
   - name: erff
     standards:
       - stdc
@@ -1220,6 +1228,13 @@ functions:
     arguments:
       - type: double
       - type: double
+  - name: fsqrtf128
+    standards:
+      - llvm_libc_ext
+    return_type: float
+    arguments:
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
   - name: fsubf128
     standards:
       - llvm_libc_ext
@@ -2362,6 +2377,14 @@ functions:
     arguments:
       - type: long double *
       - type: long double *
+  - name: totalordermagf128
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float128 *
+      - type: float128 *
+    guard: LIBC_TYPES_HAS_FLOAT128
   - name: totalordermagf16
     standards:
       - stdc

--- a/libc/newhdrgen/yaml/math.yaml
+++ b/libc/newhdrgen/yaml/math.yaml
@@ -1220,14 +1220,7 @@ functions:
       - stdc
     return_type: float
     arguments:
-      - type: long double 
-  - name: fsub
-    standards:
-      - stdc
-    return_type: float
-    arguments:
-      - type: double
-      - type: double
+      - type: long double
   - name: fsqrtf128
     standards:
       - llvm_libc_ext
@@ -1235,6 +1228,13 @@ functions:
     arguments:
       - type: float128
     guard: LIBC_TYPES_HAS_FLOAT128
+  - name: fsub
+    standards:
+      - stdc
+    return_type: float
+    arguments:
+      - type: double
+      - type: double
   - name: fsubf128
     standards:
       - llvm_libc_ext


### PR DESCRIPTION
Added auto function hdrgen specification for functions: totalordermagf, dsqrtl, fsqrt, fsqrtl