### PR TITLE
Revert "[Object][x86-64] Add support for `R_X86_64_GLOB_DAT` relocations. (#103029)"

### DIFF
--- a/llvm/lib/Object/RelocationResolver.cpp
+++ b/llvm/lib/Object/RelocationResolver.cpp
@@ -47,7 +47,6 @@ static bool supportsX86_64(uint64_t Type) {
   case ELF::R_X86_64_PC64:
   case ELF::R_X86_64_32:
   case ELF::R_X86_64_32S:
-  case ELF::R_X86_64_GLOB_DAT:
     return true;
   default:
     return false;
@@ -69,8 +68,6 @@ static uint64_t resolveX86_64(uint64_t Type, uint64_t Offset, uint64_t S,
   case ELF::R_X86_64_32:
   case ELF::R_X86_64_32S:
     return (S + Addend) & 0xFFFFFFFF;
-  case ELF::R_X86_64_GLOB_DAT:
-    return S;
   default:
     llvm_unreachable("Invalid relocation type");
   }


### PR DESCRIPTION
This reverts commit 5ae9faa538d100ab38f6f4f99c924de0e4270272.

RelocationResolver is only supposed to handle static relocation types.
Introducing GLOB_DAT could negatively impact other RelocationResolver
users who solely handle static relocations and want to report errors for
dynamic relocations.

If GLOB_DAT is the sole required relocation, explicitly checking for it
in the caller would be more reliable. Additionally, the caller should
handle GLOB_DAT on other architectures.
