### PR TITLE
[M68k] Remove use of APInt::getRawData(). NFC

### DIFF
--- a/llvm/lib/Target/M68k/MCTargetDesc/M68kMCCodeEmitter.cpp
+++ b/llvm/lib/Target/M68k/MCTargetDesc/M68kMCCodeEmitter.cpp
@@ -236,15 +236,11 @@ void M68kMCCodeEmitter::encodeInstruction(const MCInst &MI,
   APInt Scratch(64, 0U); // One APInt word is enough.
   getBinaryCodeForInstr(MI, Fixups, EncodedInst, Scratch, STI);
 
-  ArrayRef<uint64_t> Data(EncodedInst.getRawData(), EncodedInst.getNumWords());
-  int64_t InstSize = EncodedInst.getBitWidth();
-  for (uint64_t Word : Data) {
-    for (int i = 0; i < 4 && InstSize > 0; ++i, InstSize -= 16) {
-      support::endian::write<uint16_t>(CB, static_cast<uint16_t>(Word),
-                                       llvm::endianness::big);
-      Word >>= 16;
-    }
-  }
+  unsigned InstSize = EncodedInst.getBitWidth();
+  for (unsigned i = 0; i != InstSize; i += 16)
+    support::endian::write<uint16_t>(
+        CB, static_cast<uint16_t>(EncodedInst.extractBitsAsZExtValue(16, i)),
+        llvm::endianness::big);
 }
 
 MCCodeEmitter *llvm::createM68kMCCodeEmitter(const MCInstrInfo &MCII,


### PR DESCRIPTION
getRawData exposes some internal details of APInt.

The code was iterating over the uint64_t pieces and then iterating breaking them into 4 uint16_t pieces.

This patch changes the code to extract 16-bit pieces directly from the APInt without using getRawData.