### PR TITLE
[LegalizeTypes] Use APInt::extractBits instead of getRawData. NFC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
@@ -1494,8 +1494,8 @@ void DAGTypeLegalizer::ExpandFloatRes_ConstantFP(SDNode *N, SDValue &Lo,
   APInt C = cast<ConstantFPSDNode>(N)->getValueAPF().bitcastToAPInt();
   SDLoc dl(N);
   const fltSemantics &Sem = NVT.getFltSemantics();
-  Lo = DAG.getConstantFP(APFloat(Sem, APInt(64, C.getRawData()[1])), dl, NVT);
-  Hi = DAG.getConstantFP(APFloat(Sem, APInt(64, C.getRawData()[0])), dl, NVT);
+  Lo = DAG.getConstantFP(APFloat(Sem, C.extractBits(64, 64)), dl, NVT);
+  Hi = DAG.getConstantFP(APFloat(Sem, C.extractBits(64, 0)), dl, NVT);
 }
 
 void DAGTypeLegalizer::ExpandFloatRes_Unary(SDNode *N, RTLIB::Libcall LC,


### PR DESCRIPTION
We shouldn't expose that APInt stores uint64_t values if we don't need to.