### PR TITLE
[APInt] Correct backwards static_assert condition.

### DIFF
--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -496,14 +496,14 @@ uint64_t APInt::extractBitsAsZExtValue(unsigned numBits,
   if (isSingleWord())
     return (U.VAL >> bitPosition) & maskBits;
 
+  static_assert(APINT_BITS_PER_WORD >= 64,
+                "This code assumes only two words affected");
   unsigned loBit = whichBit(bitPosition);
   unsigned loWord = whichWord(bitPosition);
   unsigned hiWord = whichWord(bitPosition + numBits - 1);
   if (loWord == hiWord)
     return (U.pVal[loWord] >> loBit) & maskBits;
 
-  static_assert(APINT_BITS_PER_WORD <= 64,
-                "This code assumes only two words affected");
   uint64_t retBits = U.pVal[loWord] >> loBit;
   retBits |= U.pVal[hiWord] << (APINT_BITS_PER_WORD - loBit);
   retBits &= maskBits;


### PR DESCRIPTION
In order to guarantee that extracting 64 bits doesn't require more than 2 words, the word size would need to be 64 bits or more. If the word size was smaller than 64, like 32, you may need to read 3 words to get 64 bits.