### PR TITLE
[DataLayout] Split StructAlignment into two fields (NFC)

### DIFF
--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -147,7 +147,6 @@ private:
   AlignmentsTy IntAlignments;
   AlignmentsTy FloatAlignments;
   AlignmentsTy VectorAlignments;
-  LayoutAlignElem StructAlignment;
 
   /// The string representation used to create this DataLayout
   std::string StringRepresentation;
@@ -156,6 +155,10 @@ private:
   PointersTy Pointers;
 
   const PointerAlignElem &getPointerAlignElem(uint32_t AddressSpace) const;
+
+  // Struct type ABI and preferred alignments. The default spec is "a:8:64".
+  Align StructABIAlignment = Align::Constant<1>();
+  Align StructPrefAlignment = Align::Constant<8>();
 
   // The StructType -> StructLayout map.
   mutable void *LayoutMap = nullptr;


### PR DESCRIPTION
Aggregate type specification doesn't have the size component. Don't abuse LayoutAlignElem to avoid confusion.