### PR TITLE
[analyzer] Do not reason about locations passed as inline asm input

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3808,8 +3808,8 @@ void ExprEngine::VisitGCCAsmStmt(const GCCAsmStmt *A, ExplodedNode *Pred,
   }
 
   // Do not reason about locations passed inside inline assembly.
-  for (const Expr *O : A->inputs()) {
-    SVal X = state->getSVal(O, Pred->getLocationContext());
+  for (const Expr *I : A->inputs()) {
+    SVal X = state->getSVal(I, Pred->getLocationContext());
 
     if (std::optional<Loc> LV = X.getAs<Loc>())
       state = state->bindLoc(*LV, UnknownVal(), Pred->getLocationContext());

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3807,6 +3807,14 @@ void ExprEngine::VisitGCCAsmStmt(const GCCAsmStmt *A, ExplodedNode *Pred,
       state = state->bindLoc(*LV, UnknownVal(), Pred->getLocationContext());
   }
 
+  // Do not reason about locations passed inside inline assembly.
+  for (const Expr *O : A->inputs()) {
+    SVal X = state->getSVal(O, Pred->getLocationContext());
+
+    if (std::optional<Loc> LV = X.getAs<Loc>())
+      state = state->bindLoc(*LV, UnknownVal(), Pred->getLocationContext());
+  }
+
   Bldr.generateNode(A, Pred, state);
 }
 

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker debug.ExprInspection -fheinous-gnu-extensions -w %s -verify
+// RUN: %clang_analyze_cc1 -triple=x86_64-unknown-unknown \
+// RUN:      -analyzer-checker debug.ExprInspection,core -fheinous-gnu-extensions -w %s -verify
 
 int clang_analyzer_eval(int);
 
@@ -9,4 +10,37 @@ void testRValueOutput() {
   __asm__("" : "=r"(((int)(global))));  // don't crash on rvalue output operand
   clang_analyzer_eval(global == 1); // expected-warning{{UNKNOWN}}
   clang_analyzer_eval(ref == 1);    // expected-warning{{UNKNOWN}}
+}
+
+void *MyMemcpy(void *d, const void *s, const int n) {
+  asm volatile (
+    "cld\n rep movsb\n"
+    :: "S" (s), "D" (d), "c" (n) : "memory"
+  );
+
+  return d;
+}
+
+void testInlineAsmMemcpy(void)
+{
+    int a, b = 10, c;
+
+    MyMemcpy(&a, &b, sizeof(b));
+    c = a; // no-warning
+}
+
+void testInlineAsmMemcpyArray(void)
+{
+    int a[10], b[10] = {}, c;
+
+    MyMemcpy(&a, &b, sizeof(b));
+    c = a[8]; // no-warning
+}
+
+void testInlineAsmMemcpyUninit(void)
+{
+    int a[10], b[10] = {}, c;
+
+    MyMemcpy(&a[1], &b[1], sizeof(b) - sizeof(b[1]));
+    c = a[0]; // expected-warning{{Assigned value is garbage or undefined}}
 }

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -17,14 +17,12 @@ void *MyMemcpy(void *d, const void *s, const int n) {
     "cld\n rep movsb\n"
     :: "S" (s), "D" (d), "c" (n) : "memory"
   );
-
   return d;
 }
 
 void testInlineAsmMemcpy(void)
 {
     int a, b = 10, c;
-
     MyMemcpy(&a, &b, sizeof(b));
     c = a; // no-warning
 }
@@ -32,7 +30,6 @@ void testInlineAsmMemcpy(void)
 void testInlineAsmMemcpyArray(void)
 {
     int a[10], b[10] = {}, c;
-
     MyMemcpy(&a, &b, sizeof(b));
     c = a[8]; // no-warning
 }
@@ -40,7 +37,6 @@ void testInlineAsmMemcpyArray(void)
 void testInlineAsmMemcpyUninit(void)
 {
     int a[10], b[10] = {}, c;
-
     MyMemcpy(&a[1], &b[1], sizeof(b) - sizeof(b[1]));
     c = a[0]; // expected-warning{{Assigned value is garbage or undefined}}
 }


### PR DESCRIPTION
If pointer is passed as input operand for inline assembly, it's possible that asm block will change memory behind this pointer. So if pointer is passed inside inline asm block, it's better to not guess and assume memory has unknown state.

Without such change, we observed a lot of FP with hand-written `memcpy` and friends.