### PR TITLE
[flang][test] Restrict Semantics/kinds04_q10.f90 to x86_64

### DIFF
--- a/flang/test/Semantics/kinds04_q10.f90
+++ b/flang/test/Semantics/kinds04_q10.f90
@@ -8,7 +8,7 @@
 ! This test is for x86_64, where exponent-letter 'q' is for
 ! 10-byte extended precision
 ! UNSUPPORTED: system-windows, system-aix
-! REQUIRES: x86-registered-target
+! REQUIRES: target=x86_64{{.*}}
 
 subroutine s(var)
   real :: realvar1 = 4.0E6_4


### PR DESCRIPTION
`Flang :: Semantics/kinds04_q10.f90` `FAIL`s on SPARC, both Solaris/sparcv9 and Linux/sparc64:
```
actual at 16: invalid argument on REAL(10) to REAL(4) conversion
actual at 20: invalid argument on REAL(10) to REAL(4) conversion
actual at 24: invalid argument on REAL(10) to REAL(4) conversion
actual at 31: invalid argument on REAL(10) to REAL(8) conversion
actual at 37: invalid argument on REAL(10) to REAL(8) conversion
```
This seems to be the same issue recently seen in PR #102890: even though the target in question supports `REAL(10)`, the host does not.

Therefore this patch restricts the test to `x86_64`.

Tested on `sparcv9-sun-solaris2.11`, `sparc64-unknown-linux-gnu`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.