### PR TITLE
[mlir][test] XFAIL little-endian-only tests on SPARC

### DIFF
--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-le-specific.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-le-specific.mlir
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: target=s390x-{{.*}}
+// XFAIL: target={{(s390x|sparc.*)-.*}}
 
 module attributes {
   spirv.target_env = #spirv.target_env<

--- a/mlir/test/IR/elements-attr-interface.mlir
+++ b/mlir/test/IR/elements-attr-interface.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s -test-elements-attr-interface -verify-diagnostics
 
 // Parsing external resources does not work on big-endian platforms currently
-// XFAIL: target=s390x-{{.*}}
+// XFAIL: target={{(s390x|sparc.*)-.*}}
 
 // This test contains various `ElementsAttr` attributes, and tests the support
 // for iterating the values of these attributes using various native C++ types.

--- a/mlir/test/Target/LLVMIR/llvmir-le-specific.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-le-specific.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-translate -mlir-to-llvmir -split-input-file %s | FileCheck %s
 
 // Decoding the attribute does not work on big-endian platforms currently
-// XFAIL: target=s390x-{{.*}}
+// XFAIL: target={{(s390x|sparc.*)-.*}}
 
 // CHECK{LITERAL}: @dense_resource_tensor_constant = internal constant [5 x float] [float 0x3FCA034080000000, float 0xBFD0466300000000, float 0xBFD75DDF80000000, float 0xBFDE074F40000000, float 0x3FDDD3A1C0000000]
 llvm.mlir.global internal constant @dense_resource_tensor_constant(dense_resource<dense_resource_test_5xf32> : tensor<5xf32>) : !llvm.array<5 x f32>


### PR DESCRIPTION
3 MLIR tests `FAIL` on SPARC, both Solaris/sparcv9 and Linux/sparc64:
```
  MLIR :: Conversion/ArithToSPIRV/arith-to-spirv-le-specific.mlir
  MLIR :: IR/elements-attr-interface.mlir
  MLIR :: Target/LLVMIR/llvmir-le-specific.mlir
```
The issue is always the same: the tests in question are little-endian-only currently, so this patch `XFAIL`s them on `sparc*` as is already done for `s390x`.

Tested on `sparcv9-sun-solaris2.11`, `sparc64-unknown-linux-gnu`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.