### PR TITLE
[flang][test] Run Driver/fveclib-codegen.f90 for aarch64 and x86_64

### DIFF
--- a/flang/test/Driver/fveclib-codegen.f90
+++ b/flang/test/Driver/fveclib-codegen.f90
@@ -1,7 +1,8 @@
 ! test that -fveclib= is passed to the backend
 ! -target aarch64 so that ArmPL is available
-! RUN: %flang -S -Ofast -fveclib=LIBMVEC -o - %s | FileCheck %s
-! RUN: %flang -S -Ofast -fveclib=NoLibrary -o - %s | FileCheck %s --check-prefix=NOLIB
+! REQUIRES: x86-registered-target
+! RUN: %flang -S -Ofast -target x86_64-unknown-linux-gnu -fveclib=LIBMVEC -o - %s | FileCheck %s
+! RUN: %flang -S -Ofast -target x86_64-unknown-linux-gnu -fveclib=NoLibrary -o - %s | FileCheck %s --check-prefix=NOLIB
 
 subroutine sb(a, b)
   real :: a(:), b(:)

--- a/flang/test/Driver/fveclib-codegen.f90
+++ b/flang/test/Driver/fveclib-codegen.f90
@@ -1,8 +1,8 @@
 ! test that -fveclib= is passed to the backend
 ! -target aarch64 so that ArmPL is available
-! REQUIRES: x86-registered-target
-! RUN: %flang -S -Ofast -target x86_64-unknown-linux-gnu -fveclib=LIBMVEC -o - %s | FileCheck %s
-! RUN: %flang -S -Ofast -target x86_64-unknown-linux-gnu -fveclib=NoLibrary -o - %s | FileCheck %s --check-prefix=NOLIB
+! RUN: %if aarch64-registered-target %{ %flang -S -Ofast -target aarch64-unknown-linux-gnu -fveclib=LIBMVEC -o - %s | FileCheck %s %}
+! RUN: %if x86-registered-target %{ %flang -S -Ofast -target x86_64-unknown-linux-gnu -fveclib=LIBMVEC -o - %s | FileCheck %s %}
+! RUN: %flang -S -Ofast -fveclib=NoLibrary -o - %s | FileCheck %s --check-prefix=NOLIB
 
 subroutine sb(a, b)
   real :: a(:), b(:)


### PR DESCRIPTION
`Flang :: Driver/fveclib-codegen.f90` currently `FAIL`s on SPARC, both Solaris/sparcv9 and Linux/sparc64:
```
bin/flang-new -S -Ofast -fveclib=LIBMVEC -o - /vol/llvm/src/llvm-project/local/flang/test/Driver/fveclib-codegen.f90

flang/test/Driver/fveclib-codegen.f90:11:10: error: CHECK: expected string not found in input
! CHECK: _ZGVbN4vv_powf
         ^
```
The code in question only contains calls to `powf`.  Given that `glibc` only supports `libmvec` on `aarch64` and `x86_64`,  this test targets only those if possible.

Tested on `sparcv9-sun-solaris2.11`, `sparc64-unknown-linux-gnu`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.