### PR TITLE
[LLVM][NewPM] Add C API for running the pipeline on a single function.

### DIFF
--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -157,6 +157,12 @@ Changes to the C API
   * ``LLVMGetNamedFunctionWithLength``
   * ``LLVMGetNamedGlobalWithLength``
 
+* The new pass manager can now be invoked with a custom alias analysis pipeline, using
+  the ``LLVMPassBuilderOptionsSetAAPipeline`` function.
+
+* It is now also possible to run the new pass manager on a single function, by calling
+  ``LLVMRunPassesOnFunction`` instead of ``LLVMRunPasses``.
+
 Changes to the CodeGen infrastructure
 -------------------------------------
 

--- a/llvm/include/llvm-c/Transforms/PassBuilder.h
+++ b/llvm/include/llvm-c/Transforms/PassBuilder.h
@@ -51,6 +51,16 @@ LLVMErrorRef LLVMRunPasses(LLVMModuleRef M, const char *Passes,
                            LLVMPassBuilderOptionsRef Options);
 
 /**
+ * Construct and run a set of passes over a function
+ *
+ * This function behaves the same as LLVMRunPasses, but operates on a single
+ * function instead of an entire module.
+ */
+LLVMErrorRef LLVMRunPassesOnFunction(LLVMValueRef F, const char *Passes,
+                                     LLVMTargetMachineRef TM,
+                                     LLVMPassBuilderOptionsRef Options);
+
+/**
  * Create a new set of options for a PassBuilder
  *
  * Ownership of the returned instance is given to the client, and they are

--- a/llvm/include/llvm-c/Transforms/PassBuilder.h
+++ b/llvm/include/llvm-c/Transforms/PassBuilder.h
@@ -51,7 +51,7 @@ LLVMErrorRef LLVMRunPasses(LLVMModuleRef M, const char *Passes,
                            LLVMPassBuilderOptionsRef Options);
 
 /**
- * Construct and run a set of passes over a function
+ * Construct and run a set of passes over a function.
  *
  * This function behaves the same as LLVMRunPasses, but operates on a single
  * function instead of an entire module.

--- a/llvm/unittests/Passes/PassBuilderBindings/PassBuilderBindingsTest.cpp
+++ b/llvm/unittests/Passes/PassBuilderBindings/PassBuilderBindingsTest.cpp
@@ -35,6 +35,9 @@ class PassBuilderCTest : public testing::Test {
     LLVMDisposeMessage(Triple);
     Context = LLVMContextCreate();
     Module = LLVMModuleCreateWithNameInContext("test", Context);
+    LLVMTypeRef FT =
+        LLVMFunctionType(LLVMVoidTypeInContext(Context), nullptr, 0, 0);
+    Function = LLVMAddFunction(Module, "test", FT);
   }
 
   void TearDown() override {
@@ -52,6 +55,7 @@ class PassBuilderCTest : public testing::Test {
 public:
   LLVMTargetMachineRef TM;
   LLVMModuleRef Module;
+  LLVMValueRef Function;
   LLVMContextRef Context;
 };
 
@@ -63,7 +67,6 @@ TEST_F(PassBuilderCTest, Basic) {
   LLVMPassBuilderOptionsSetAAPipeline(Options, "basic-aa");
   if (LLVMErrorRef E = LLVMRunPasses(Module, "default<O2>", TM, Options)) {
     char *Msg = LLVMGetErrorMessage(E);
-    LLVMConsumeError(E);
     LLVMDisposePassBuilderOptions(Options);
     FAIL() << "Failed to run passes: " << Msg;
   }
@@ -78,5 +81,16 @@ TEST_F(PassBuilderCTest, InvalidPassIsError) {
   ASSERT_TRUE(E2);
   LLVMConsumeError(E1);
   LLVMConsumeError(E2);
+  LLVMDisposePassBuilderOptions(Options);
+}
+
+TEST_F(PassBuilderCTest, Function) {
+  LLVMPassBuilderOptionsRef Options = LLVMCreatePassBuilderOptions();
+  if (LLVMErrorRef E =
+          LLVMRunPassesOnFunction(Function, "no-op-function", TM, Options)) {
+    char *Msg = LLVMGetErrorMessage(E);
+    LLVMDisposePassBuilderOptions(Options);
+    FAIL() << "Failed to run passes on function: " << Msg;
+  }
   LLVMDisposePassBuilderOptions(Options);
 }


### PR DESCRIPTION
By adding a new entrypoint, `LLVMRunPassesOnFunction`, as suggested in https://discourse.llvm.org/t/newpm-c-api-questions/80598.

Also removes erroneous `LLVMConsumeError`s from the pass builder unit tests as the string conversion already consumes the error, causing an abort when the test would fail:

```
[----------] 1 test from PassBuilderCTest
[ RUN      ] PassBuilderCTest.Function
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  PassesBindingsTests      0x00000001043ebb50 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 88
1  PassesBindingsTests      0x00000001043ec134 PrintStackTraceSignalHandler(void*) + 28
2  PassesBindingsTests      0x00000001043e9c78 llvm::sys::RunSignalHandlers() + 152
3  PassesBindingsTests      0x00000001043ed640 SignalHandler(int) + 276
4  libsystem_platform.dylib 0x000000019bab6584 _sigtramp + 56
5  PassesBindingsTests      0x000000010421c470 bool llvm::ErrorInfoBase::isA<llvm::ErrorList>() const + 28
6  PassesBindingsTests      0x000000010421c01c llvm::Error llvm::handleErrors<llvm::consumeError(llvm::Error)::'lambda'(llvm::ErrorInfoBase const&)>(llvm::Error, llvm::consumeError(llvm::Error)::'lambda'(llvm::ErrorInfoBase const&)&&) + 112
7  PassesBindingsTests      0x000000010421bed0 void llvm::handleAllErrors<llvm::consumeError(llvm::Error)::'lambda'(llvm::ErrorInfoBase const&)>(llvm::Error, llvm::consumeError(llvm::Error)::'lambda'(llvm::ErrorInfoBase const&)&&) + 68
8  PassesBindingsTests      0x00000001042162c0 llvm::consumeError(llvm::Error) + 48
9  PassesBindingsTests      0x00000001042aaae8 LLVMConsumeError + 40
10 PassesBindingsTests      0x00000001041cdfa0 PassBuilderCTest_Function_Test::TestBody() + 112
```