### PR TITLE
[X86][MC] Remove CMPCCXADD's CondCode flavor.

### DIFF
--- a/clang/test/CodeGen/X86/cmpccxadd-builtins.c
+++ b/clang/test/CodeGen/X86/cmpccxadd-builtins.c
@@ -52,50 +52,50 @@ long long test_cmplxadd64(void *__A, long long __B, long long __C) {
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_NB);
 }
 
-int test_cmpnbexadd32(void *__A, int __B, int __C) {
-  // CHECK-LABEL: @test_cmpnbexadd32(
+int test_cmpaxadd32(void *__A, int __B, int __C) {
+  // CHECK-LABEL: @test_cmpaxadd32(
   // CHECK: call i32 @llvm.x86.cmpccxadd32(ptr %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 4)
   return _cmpccxadd_epi32(__A, __B, __C, _CMPCCX_Z);
 }
 
-long long test_cmpnbexadd64(void *__A, long long __B, long long __C) {
-  // CHECK-LABEL: @test_cmpnbexadd64(
+long long test_cmpaxadd64(void *__A, long long __B, long long __C) {
+  // CHECK-LABEL: @test_cmpaxadd64(
   // CHECK: call i64 @llvm.x86.cmpccxadd64(ptr %{{.*}}, i64 %{{.*}}, i64 %{{.*}}, i32 4)
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_Z);
 }
 
-int test_cmpnbxadd32(void *__A, int __B, int __C) {
-  // CHECK-LABEL: @test_cmpnbxadd32(
+int test_cmpaexadd32(void *__A, int __B, int __C) {
+  // CHECK-LABEL: @test_cmpaexadd32(
   // CHECK: call i32 @llvm.x86.cmpccxadd32(ptr %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 5)
   return _cmpccxadd_epi32(__A, __B, __C, _CMPCCX_NZ);
 }
 
-long long test_cmpnbxadd64(void *__A, long long __B, long long __C) {
-  // CHECK-LABEL: @test_cmpnbxadd64(
+long long test_cmpaexadd64(void *__A, long long __B, long long __C) {
+  // CHECK-LABEL: @test_cmpaexadd64(
   // CHECK: call i64 @llvm.x86.cmpccxadd64(ptr %{{.*}}, i64 %{{.*}}, i64 %{{.*}}, i32 5)
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_NZ);
 }
 
-int test_cmpnlexadd32(void *__A, int __B, int __C) {
-  // CHECK-LABEL: @test_cmpnlexadd32(
+int test_cmpgxadd32(void *__A, int __B, int __C) {
+  // CHECK-LABEL: @test_cmpgxadd32(
   // CHECK: call i32 @llvm.x86.cmpccxadd32(ptr %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 6)
   return _cmpccxadd_epi32(__A, __B, __C, _CMPCCX_BE);
 }
 
-long long test_cmpnlexadd64(void *__A, long long __B, long long __C) {
-  // CHECK-LABEL: @test_cmpnlexadd64(
+long long test_cmpgxadd64(void *__A, long long __B, long long __C) {
+  // CHECK-LABEL: @test_cmpgxadd64(
   // CHECK: call i64 @llvm.x86.cmpccxadd64(ptr %{{.*}}, i64 %{{.*}}, i64 %{{.*}}, i32 6)
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_BE);
 }
 
-int test_cmpnlxadd32(void *__A, int __B, int __C) {
-  // CHECK-LABEL: @test_cmpnlxadd32(
+int test_cmpgexadd32(void *__A, int __B, int __C) {
+  // CHECK-LABEL: @test_cmpgexadd32(
   // CHECK: call i32 @llvm.x86.cmpccxadd32(ptr %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 7)
   return _cmpccxadd_epi32(__A, __B, __C, _CMPCCX_NBE);
 }
 
-long long test_cmpnlxadd64(void *__A, long long __B, long long __C) {
-  // CHECK-LABEL: @test_cmpnlxadd64(
+long long test_cmpgexadd64(void *__A, long long __B, long long __C) {
+  // CHECK-LABEL: @test_cmpgexadd64(
   // CHECK: call i64 @llvm.x86.cmpccxadd64(ptr %{{.*}}, i64 %{{.*}}, i64 %{{.*}}, i32 7)
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_NBE);
 }
@@ -136,14 +136,14 @@ long long test_cmpnsxadd64(void *__A, long long __B, long long __C) {
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_P);
 }
 
-int test_cmpnzxadd32(void *__A, int __B, int __C) {
-  // CHECK-LABEL: @test_cmpnzxadd32(
+int test_cmpnexadd32(void *__A, int __B, int __C) {
+  // CHECK-LABEL: @test_cmpnexadd32(
   // CHECK: call i32 @llvm.x86.cmpccxadd32(ptr %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 11)
   return _cmpccxadd_epi32(__A, __B, __C, _CMPCCX_NP);
 }
 
-long long test_cmpnzxadd64(void *__A, long long __B, long long __C) {
-  // CHECK-LABEL: @test_cmpnzxadd64(
+long long test_cmpnexadd64(void *__A, long long __B, long long __C) {
+  // CHECK-LABEL: @test_cmpnexadd64(
   // CHECK: call i64 @llvm.x86.cmpccxadd64(ptr %{{.*}}, i64 %{{.*}}, i64 %{{.*}}, i32 11)
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_NP);
 }
@@ -184,14 +184,14 @@ long long test_cmpsxadd64(void *__A, long long __B, long long __C) {
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_LE);
 }
 
-int test_cmpzxadd32(void *__A, int __B, int __C) {
-  // CHECK-LABEL: @test_cmpzxadd32(
+int test_cmpexadd32(void *__A, int __B, int __C) {
+  // CHECK-LABEL: @test_cmpexadd32(
   // CHECK: call i32 @llvm.x86.cmpccxadd32(ptr %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 15)
   return _cmpccxadd_epi32(__A, __B, __C, _CMPCCX_NLE);
 }
 
-long long test_cmpzxadd64(void *__A, long long __B, long long __C) {
-  // CHECK-LABEL: @test_cmpzxadd64(
+long long test_cmpexadd64(void *__A, long long __B, long long __C) {
+  // CHECK-LABEL: @test_cmpexadd64(
   // CHECK: call i64 @llvm.x86.cmpccxadd64(ptr %{{.*}}, i64 %{{.*}}, i64 %{{.*}}, i32 15)
   return _cmpccxadd_epi64(__A, __B, __C, _CMPCCX_NLE);
 }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86InstPrinterCommon.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86InstPrinterCommon.cpp
@@ -30,7 +30,6 @@ void X86InstPrinterCommon::printCondCode(const MCInst *MI, unsigned Op,
                                          raw_ostream &O) {
   int64_t Imm = MI->getOperand(Op).getImm();
   unsigned Opc = MI->getOpcode();
-  bool IsCMPCCXADD = X86::isCMPCCXADD(Opc);
   bool IsCCMPOrCTEST = X86::isCCMPCC(Opc) || X86::isCTESTCC(Opc);
 
   // clang-format off
@@ -39,19 +38,19 @@ void X86InstPrinterCommon::printCondCode(const MCInst *MI, unsigned Op,
   case    0: O << "o";  break;
   case    1: O << "no"; break;
   case    2: O << "b";  break;
-  case    3: O << (IsCMPCCXADD ? "nb" : "ae"); break;
-  case    4: O << (IsCMPCCXADD ?  "z" :  "e"); break;
-  case    5: O << (IsCMPCCXADD ? "nz" : "ne"); break;
+  case    3: O << "ae"; break;
+  case    4: O << "e";  break;
+  case    5: O << "ne"; break;
   case    6: O << "be"; break;
-  case    7: O << (IsCMPCCXADD ? "nbe" : "a"); break;
+  case    7: O << "a";  break;
   case    8: O << "s";  break;
   case    9: O << "ns"; break;
   case  0xa: O << (IsCCMPOrCTEST ? "t" : "p");  break;
   case  0xb: O << (IsCCMPOrCTEST ? "f" : "np"); break;
   case  0xc: O << "l";  break;
-  case  0xd: O << (IsCMPCCXADD ? "nl" : "ge"); break;
+  case  0xd: O << "ge"; break;
   case  0xe: O << "le"; break;
-  case  0xf: O << (IsCMPCCXADD ? "nle" : "g"); break;
+  case  0xf: O << "g";  break;
   }
   // clang-format on
 }

--- a/llvm/test/CodeGen/X86/cmpccxadd-intrinsics.ll
+++ b/llvm/test/CodeGen/X86/cmpccxadd-intrinsics.ll
@@ -112,13 +112,13 @@ define dso_local i32 @test_cmplxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
 ; CHECK-LABEL: test_cmplxadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; CHECK-NEXT:    cmpnbxadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe3,0x07]
+; CHECK-NEXT:    cmpaexadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe3,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
 ; EGPR-LABEL: test_cmplxadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; EGPR-NEXT:    cmpnbxadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe3,0x07]
+; EGPR-NEXT:    cmpaexadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe3,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i32 @llvm.x86.cmpccxadd32(ptr %__A, i32 %__B, i32 %__C, i32 3)
@@ -129,95 +129,95 @@ define dso_local i64 @test_cmplxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
 ; CHECK-LABEL: test_cmplxadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; CHECK-NEXT:    cmpnbxadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe3,0x07]
+; CHECK-NEXT:    cmpaexadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe3,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
 ; EGPR-LABEL: test_cmplxadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; EGPR-NEXT:    cmpnbxadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe3,0x07]
+; EGPR-NEXT:    cmpaexadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe3,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i64 @llvm.x86.cmpccxadd64(ptr %__A, i64 %__B, i64 %__C, i32 3)
   ret i64 %0
 }
 
-define dso_local i32 @test_cmpnbexadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
-; CHECK-LABEL: test_cmpnbexadd32:
+define dso_local i32 @test_cmpaxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
+; CHECK-LABEL: test_cmpaxadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; CHECK-NEXT:    cmpzxadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe4,0x07]
+; CHECK-NEXT:    cmpexadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe4,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnbexadd32:
+; EGPR-LABEL: test_cmpaxadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; EGPR-NEXT:    cmpzxadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe4,0x07]
+; EGPR-NEXT:    cmpexadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe4,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i32 @llvm.x86.cmpccxadd32(ptr %__A, i32 %__B, i32 %__C, i32 4)
   ret i32 %0
 }
 
-define dso_local i64 @test_cmpnbexadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
-; CHECK-LABEL: test_cmpnbexadd64:
+define dso_local i64 @test_cmpaxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
+; CHECK-LABEL: test_cmpaxadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; CHECK-NEXT:    cmpzxadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe4,0x07]
+; CHECK-NEXT:    cmpexadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe4,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnbexadd64:
+; EGPR-LABEL: test_cmpaxadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; EGPR-NEXT:    cmpzxadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe4,0x07]
+; EGPR-NEXT:    cmpexadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe4,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i64 @llvm.x86.cmpccxadd64(ptr %__A, i64 %__B, i64 %__C, i32 4)
   ret i64 %0
 }
 
-define dso_local i32 @test_cmpnbxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
-; CHECK-LABEL: test_cmpnbxadd32:
+define dso_local i32 @test_cmpaexadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
+; CHECK-LABEL: test_cmpaexadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; CHECK-NEXT:    cmpnzxadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe5,0x07]
+; CHECK-NEXT:    cmpnexadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe5,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnbxadd32:
+; EGPR-LABEL: test_cmpaexadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; EGPR-NEXT:    cmpnzxadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe5,0x07]
+; EGPR-NEXT:    cmpnexadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe5,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i32 @llvm.x86.cmpccxadd32(ptr %__A, i32 %__B, i32 %__C, i32 5)
   ret i32 %0
 }
 
-define dso_local i64 @test_cmpnbxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
-; CHECK-LABEL: test_cmpnbxadd64:
+define dso_local i64 @test_cmpaexadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
+; CHECK-LABEL: test_cmpaexadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; CHECK-NEXT:    cmpnzxadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe5,0x07]
+; CHECK-NEXT:    cmpnexadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe5,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnbxadd64:
+; EGPR-LABEL: test_cmpaexadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; EGPR-NEXT:    cmpnzxadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe5,0x07]
+; EGPR-NEXT:    cmpnexadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe5,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i64 @llvm.x86.cmpccxadd64(ptr %__A, i64 %__B, i64 %__C, i32 5)
   ret i64 %0
 }
 
-define dso_local i32 @test_cmpnlexadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
-; CHECK-LABEL: test_cmpnlexadd32:
+define dso_local i32 @test_cmpgxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
+; CHECK-LABEL: test_cmpgxadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; CHECK-NEXT:    cmpbexadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe6,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnlexadd32:
+; EGPR-LABEL: test_cmpgxadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; EGPR-NEXT:    cmpbexadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe6,0x07]
@@ -227,14 +227,14 @@ entry:
   ret i32 %0
 }
 
-define dso_local i64 @test_cmpnlexadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
-; CHECK-LABEL: test_cmpnlexadd64:
+define dso_local i64 @test_cmpgxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
+; CHECK-LABEL: test_cmpgxadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; CHECK-NEXT:    cmpbexadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe6,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnlexadd64:
+; EGPR-LABEL: test_cmpgxadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; EGPR-NEXT:    cmpbexadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe6,0x07]
@@ -244,34 +244,34 @@ entry:
   ret i64 %0
 }
 
-define dso_local i32 @test_cmpnlxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
-; CHECK-LABEL: test_cmpnlxadd32:
+define dso_local i32 @test_cmpgexadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
+; CHECK-LABEL: test_cmpgexadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; CHECK-NEXT:    cmpnbexadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe7,0x07]
+; CHECK-NEXT:    cmpaxadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xe7,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnlxadd32:
+; EGPR-LABEL: test_cmpgexadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; EGPR-NEXT:    cmpnbexadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe7,0x07]
+; EGPR-NEXT:    cmpaxadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xe7,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i32 @llvm.x86.cmpccxadd32(ptr %__A, i32 %__B, i32 %__C, i32 7)
   ret i32 %0
 }
 
-define dso_local i64 @test_cmpnlxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
-; CHECK-LABEL: test_cmpnlxadd64:
+define dso_local i64 @test_cmpgexadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
+; CHECK-LABEL: test_cmpgexadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; CHECK-NEXT:    cmpnbexadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe7,0x07]
+; CHECK-NEXT:    cmpaxadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xe7,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnlxadd64:
+; EGPR-LABEL: test_cmpgexadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; EGPR-NEXT:    cmpnbexadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe7,0x07]
+; EGPR-NEXT:    cmpaxadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xe7,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i64 @llvm.x86.cmpccxadd64(ptr %__A, i64 %__B, i64 %__C, i32 7)
@@ -380,14 +380,14 @@ entry:
   ret i64 %0
 }
 
-define dso_local i32 @test_cmpnzxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
-; CHECK-LABEL: test_cmpnzxadd32:
+define dso_local i32 @test_cmpnexadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
+; CHECK-LABEL: test_cmpnexadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; CHECK-NEXT:    cmpnpxadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xeb,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnzxadd32:
+; EGPR-LABEL: test_cmpnexadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; EGPR-NEXT:    cmpnpxadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xeb,0x07]
@@ -397,14 +397,14 @@ entry:
   ret i32 %0
 }
 
-define dso_local i64 @test_cmpnzxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
-; CHECK-LABEL: test_cmpnzxadd64:
+define dso_local i64 @test_cmpnexadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
+; CHECK-LABEL: test_cmpnexadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; CHECK-NEXT:    cmpnpxadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xeb,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpnzxadd64:
+; EGPR-LABEL: test_cmpnexadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; EGPR-NEXT:    cmpnpxadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xeb,0x07]
@@ -452,13 +452,13 @@ define dso_local i32 @test_cmppxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
 ; CHECK-LABEL: test_cmppxadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; CHECK-NEXT:    cmpnlxadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xed,0x07]
+; CHECK-NEXT:    cmpgexadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xed,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
 ; EGPR-LABEL: test_cmppxadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; EGPR-NEXT:    cmpnlxadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xed,0x07]
+; EGPR-NEXT:    cmpgexadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xed,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i32 @llvm.x86.cmpccxadd32(ptr %__A, i32 %__B, i32 %__C, i32 13)
@@ -469,13 +469,13 @@ define dso_local i64 @test_cmppxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
 ; CHECK-LABEL: test_cmppxadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; CHECK-NEXT:    cmpnlxadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xed,0x07]
+; CHECK-NEXT:    cmpgexadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xed,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
 ; EGPR-LABEL: test_cmppxadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; EGPR-NEXT:    cmpnlxadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xed,0x07]
+; EGPR-NEXT:    cmpgexadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xed,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i64 @llvm.x86.cmpccxadd64(ptr %__A, i64 %__B, i64 %__C, i32 13)
@@ -516,34 +516,34 @@ entry:
   ret i64 %0
 }
 
-define dso_local i32 @test_cmpzxadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
-; CHECK-LABEL: test_cmpzxadd32:
+define dso_local i32 @test_cmpexadd32(ptr %__A, i32 %__B, i32 %__C) nounwind {
+; CHECK-LABEL: test_cmpexadd32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; CHECK-NEXT:    cmpnlexadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xef,0x07]
+; CHECK-NEXT:    cmpgxadd %edx, %eax, (%rdi) # encoding: [0xc4,0xe2,0x69,0xef,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpzxadd32:
+; EGPR-LABEL: test_cmpexadd32:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; EGPR-NEXT:    cmpnlexadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xef,0x07]
+; EGPR-NEXT:    cmpgxadd %edx, %eax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x69,0xef,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i32 @llvm.x86.cmpccxadd32(ptr %__A, i32 %__B, i32 %__C, i32 15)
   ret i32 %0
 }
 
-define dso_local i64 @test_cmpzxadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
-; CHECK-LABEL: test_cmpzxadd64:
+define dso_local i64 @test_cmpexadd64(ptr %__A, i64 %__B, i64 %__C) nounwind {
+; CHECK-LABEL: test_cmpexadd64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; CHECK-NEXT:    cmpnlexadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xef,0x07]
+; CHECK-NEXT:    cmpgxadd %rdx, %rax, (%rdi) # encoding: [0xc4,0xe2,0xe9,0xef,0x07]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
 ;
-; EGPR-LABEL: test_cmpzxadd64:
+; EGPR-LABEL: test_cmpexadd64:
 ; EGPR:       # %bb.0: # %entry
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
-; EGPR-NEXT:    cmpnlexadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xef,0x07]
+; EGPR-NEXT:    cmpgxadd %rdx, %rax, (%rdi) # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xe9,0xef,0x07]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
 entry:
   %0 = tail call i64 @llvm.x86.cmpccxadd64(ptr %__A, i64 %__B, i64 %__C, i32 15)

--- a/llvm/test/MC/Disassembler/X86/apx/cmpccxadd.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/cmpccxadd.txt
@@ -1,20 +1,20 @@
 # RUN: llvm-mc --disassemble %s -triple=x86_64 | FileCheck %s --check-prefixes=ATT
 # RUN: llvm-mc --disassemble %s -triple=x86_64 -x86-asm-syntax=intel --output-asm-variant=1 | FileCheck %s --check-prefixes=INTEL
 
-# ATT:   cmpnbexadd	%ecx, %edx, 123(%rax,%rbx,4)
-# INTEL: cmpnbexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# ATT:   cmpaxadd	%ecx, %edx, 123(%rax,%rbx,4)
+# INTEL: cmpaxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 0x62,0xf2,0x75,0x08,0xe7,0x54,0x98,0x7b
 
-# ATT:   cmpnbexadd	%r9, %r15, 123(%rax,%rbx,4)
-# INTEL: cmpnbexadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# ATT:   cmpaxadd	%r9, %r15, 123(%rax,%rbx,4)
+# INTEL: cmpaxadd	qword ptr [rax + 4*rbx + 123], r15, r9
 0x62,0x72,0xb5,0x08,0xe7,0x7c,0x98,0x7b
 
-# ATT:   cmpnbexadd	%r18d, %r22d, 291(%r28,%r29,4)
-# INTEL: cmpnbexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# ATT:   cmpaxadd	%r18d, %r22d, 291(%r28,%r29,4)
+# INTEL: cmpaxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 0x62,0x8a,0x69,0x00,0xe7,0xb4,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnbexadd	%r19, %r23, 291(%r28,%r29,4)
-# INTEL: cmpnbexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# ATT:   cmpaxadd	%r19, %r23, 291(%r28,%r29,4)
+# INTEL: cmpaxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 0x62,0x8a,0xe1,0x00,0xe7,0xbc,0xac,0x23,0x01,0x00,0x00
 
 # ATT:   cmpbexadd	%ecx, %edx, 123(%rax,%rbx,4)
@@ -49,52 +49,52 @@
 # INTEL: cmpbxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 0x62,0x8a,0xe1,0x00,0xe2,0xbc,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpzxadd	%ecx, %edx, 123(%rax,%rbx,4)
-# INTEL: cmpzxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# ATT:   cmpexadd	%ecx, %edx, 123(%rax,%rbx,4)
+# INTEL: cmpexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 0x62,0xf2,0x75,0x08,0xe4,0x54,0x98,0x7b
 
-# ATT:   cmpzxadd	%r9, %r15, 123(%rax,%rbx,4)
-# INTEL: cmpzxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# ATT:   cmpexadd	%r9, %r15, 123(%rax,%rbx,4)
+# INTEL: cmpexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 0x62,0x72,0xb5,0x08,0xe4,0x7c,0x98,0x7b
 
-# ATT:   cmpzxadd	%r18d, %r22d, 291(%r28,%r29,4)
-# INTEL: cmpzxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# ATT:   cmpexadd	%r18d, %r22d, 291(%r28,%r29,4)
+# INTEL: cmpexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 0x62,0x8a,0x69,0x00,0xe4,0xb4,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpzxadd	%r19, %r23, 291(%r28,%r29,4)
-# INTEL: cmpzxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# ATT:   cmpexadd	%r19, %r23, 291(%r28,%r29,4)
+# INTEL: cmpexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 0x62,0x8a,0xe1,0x00,0xe4,0xbc,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlxadd	%ecx, %edx, 123(%rax,%rbx,4)
-# INTEL: cmpnlxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# ATT:   cmpgexadd	%ecx, %edx, 123(%rax,%rbx,4)
+# INTEL: cmpgexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 0x62,0xf2,0x75,0x08,0xed,0x54,0x98,0x7b
 
-# ATT:   cmpnlxadd	%r9, %r15, 123(%rax,%rbx,4)
-# INTEL: cmpnlxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# ATT:   cmpgexadd	%r9, %r15, 123(%rax,%rbx,4)
+# INTEL: cmpgexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 0x62,0x72,0xb5,0x08,0xed,0x7c,0x98,0x7b
 
-# ATT:   cmpnlxadd	%r18d, %r22d, 291(%r28,%r29,4)
-# INTEL: cmpnlxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# ATT:   cmpgexadd	%r18d, %r22d, 291(%r28,%r29,4)
+# INTEL: cmpgexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 0x62,0x8a,0x69,0x00,0xed,0xb4,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlxadd	%r19, %r23, 291(%r28,%r29,4)
-# INTEL: cmpnlxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# ATT:   cmpgexadd	%r19, %r23, 291(%r28,%r29,4)
+# INTEL: cmpgexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 0x62,0x8a,0xe1,0x00,0xed,0xbc,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlexadd	%ecx, %edx, 123(%rax,%rbx,4)
-# INTEL: cmpnlexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# ATT:   cmpgxadd	%ecx, %edx, 123(%rax,%rbx,4)
+# INTEL: cmpgxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 0x62,0xf2,0x75,0x08,0xef,0x54,0x98,0x7b
 
-# ATT:   cmpnlexadd	%r9, %r15, 123(%rax,%rbx,4)
-# INTEL: cmpnlexadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# ATT:   cmpgxadd	%r9, %r15, 123(%rax,%rbx,4)
+# INTEL: cmpgxadd	qword ptr [rax + 4*rbx + 123], r15, r9
 0x62,0x72,0xb5,0x08,0xef,0x7c,0x98,0x7b
 
-# ATT:   cmpnlexadd	%r18d, %r22d, 291(%r28,%r29,4)
-# INTEL: cmpnlexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# ATT:   cmpgxadd	%r18d, %r22d, 291(%r28,%r29,4)
+# INTEL: cmpgxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 0x62,0x8a,0x69,0x00,0xef,0xb4,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlexadd	%r19, %r23, 291(%r28,%r29,4)
-# INTEL: cmpnlexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# ATT:   cmpgxadd	%r19, %r23, 291(%r28,%r29,4)
+# INTEL: cmpgxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 0x62,0x8a,0xe1,0x00,0xef,0xbc,0xac,0x23,0x01,0x00,0x00
 
 # ATT:   cmplexadd	%ecx, %edx, 123(%rax,%rbx,4)
@@ -129,20 +129,20 @@
 # INTEL: cmplxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 0x62,0x8a,0xe1,0x00,0xec,0xbc,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnzxadd	%ecx, %edx, 123(%rax,%rbx,4)
-# INTEL: cmpnzxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# ATT:   cmpnexadd	%ecx, %edx, 123(%rax,%rbx,4)
+# INTEL: cmpnexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 0x62,0xf2,0x75,0x08,0xe5,0x54,0x98,0x7b
 
-# ATT:   cmpnzxadd	%r9, %r15, 123(%rax,%rbx,4)
-# INTEL: cmpnzxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# ATT:   cmpnexadd	%r9, %r15, 123(%rax,%rbx,4)
+# INTEL: cmpnexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 0x62,0x72,0xb5,0x08,0xe5,0x7c,0x98,0x7b
 
-# ATT:   cmpnzxadd	%r18d, %r22d, 291(%r28,%r29,4)
-# INTEL: cmpnzxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# ATT:   cmpnexadd	%r18d, %r22d, 291(%r28,%r29,4)
+# INTEL: cmpnexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 0x62,0x8a,0x69,0x00,0xe5,0xb4,0xac,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnzxadd	%r19, %r23, 291(%r28,%r29,4)
-# INTEL: cmpnzxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# ATT:   cmpnexadd	%r19, %r23, 291(%r28,%r29,4)
+# INTEL: cmpnexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 0x62,0x8a,0xe1,0x00,0xe5,0xbc,0xac,0x23,0x01,0x00,0x00
 
 # ATT:   cmpnoxadd	%ecx, %edx, 123(%rax,%rbx,4)

--- a/llvm/test/MC/Disassembler/X86/cmpccxadd-64.txt
+++ b/llvm/test/MC/Disassembler/X86/cmpccxadd-64.txt
@@ -193,196 +193,196 @@
 # INTEL: cmplxadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xec,0x8a,0x00,0xfc,0xff,0xff
 
-# ATT:   cmpnbexadd %eax, %ecx, 268435456(%rbp,%r14,8)
-# INTEL: cmpnbexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+# ATT:   cmpaxadd %eax, %ecx, 268435456(%rbp,%r14,8)
+# INTEL: cmpaxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 0xc4,0xa2,0x79,0xe7,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnbexadd %eax, %ecx, 291(%r8,%rax,4)
-# INTEL: cmpnbexadd dword ptr [r8 + 4*rax + 291], ecx, eax
+# ATT:   cmpaxadd %eax, %ecx, 291(%r8,%rax,4)
+# INTEL: cmpaxadd dword ptr [r8 + 4*rax + 291], ecx, eax
 0xc4,0xc2,0x79,0xe7,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnbexadd %eax, %ecx, (%rip)
-# INTEL: cmpnbexadd dword ptr [rip], ecx, eax
+# ATT:   cmpaxadd %eax, %ecx, (%rip)
+# INTEL: cmpaxadd dword ptr [rip], ecx, eax
 0xc4,0xe2,0x79,0xe7,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnbexadd  %eax, %ecx, -128(,%rbp,2)
-# INTEL: cmpnbexadd dword ptr [2*rbp - 128], ecx, eax
+# ATT:   cmpaxadd  %eax, %ecx, -128(,%rbp,2)
+# INTEL: cmpaxadd dword ptr [2*rbp - 128], ecx, eax
 0xc4,0xe2,0x79,0xe7,0x0c,0x6d,0x80,0xff,0xff,0xff
 
-# ATT:   cmpnbexadd %eax, %ecx, 508(%rcx)
-# INTEL: cmpnbexadd dword ptr [rcx + 508], ecx, eax
+# ATT:   cmpaxadd %eax, %ecx, 508(%rcx)
+# INTEL: cmpaxadd dword ptr [rcx + 508], ecx, eax
 0xc4,0xe2,0x79,0xe7,0x89,0xfc,0x01,0x00,0x00
 
-# ATT:   cmpnbexadd %eax, %ecx, -512(%rdx)
-# INTEL: cmpnbexadd dword ptr [rdx - 512], ecx, eax
+# ATT:   cmpaxadd %eax, %ecx, -512(%rdx)
+# INTEL: cmpaxadd dword ptr [rdx - 512], ecx, eax
 0xc4,0xe2,0x79,0xe7,0x8a,0x00,0xfe,0xff,0xff
 
-# ATT:   cmpnbexadd  %r10, %r9, 268435456(%rbp,%r14,8)
-# INTEL: cmpnbexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+# ATT:   cmpaxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+# INTEL: cmpaxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 0xc4,0x22,0xa9,0xe7,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnbexadd %r10, %r9, 291(%r8,%rax,4)
-# INTEL: cmpnbexadd qword ptr [r8 + 4*rax + 291], r9, r10
+# ATT:   cmpaxadd %r10, %r9, 291(%r8,%rax,4)
+# INTEL: cmpaxadd qword ptr [r8 + 4*rax + 291], r9, r10
 0xc4,0x42,0xa9,0xe7,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnbexadd %r10, %r9, (%rip)
-# INTEL: cmpnbexadd qword ptr [rip], r9, r10
+# ATT:   cmpaxadd %r10, %r9, (%rip)
+# INTEL: cmpaxadd qword ptr [rip], r9, r10
 0xc4,0x62,0xa9,0xe7,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnbexadd %r10, %r9, -256(,%rbp,2)
-# INTEL: cmpnbexadd qword ptr [2*rbp - 256], r9, r10
+# ATT:   cmpaxadd %r10, %r9, -256(,%rbp,2)
+# INTEL: cmpaxadd qword ptr [2*rbp - 256], r9, r10
 0xc4,0x62,0xa9,0xe7,0x0c,0x6d,0x00,0xff,0xff,0xff
 
-# ATT:   cmpnbexadd %r10, %r9, 1016(%rcx)
-# INTEL: cmpnbexadd qword ptr [rcx + 1016], r9, r10
+# ATT:   cmpaxadd %r10, %r9, 1016(%rcx)
+# INTEL: cmpaxadd qword ptr [rcx + 1016], r9, r10
 0xc4,0x62,0xa9,0xe7,0x89,0xf8,0x03,0x00,0x00
 
-# ATT:   cmpnbexadd %r10, %r9, -1024(%rdx)
-# INTEL: cmpnbexadd qword ptr [rdx - 1024], r9, r10
+# ATT:   cmpaxadd %r10, %r9, -1024(%rdx)
+# INTEL: cmpaxadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xe7,0x8a,0x00,0xfc,0xff,0xff
 
-# ATT:   cmpnbxadd %eax, %ecx, 268435456(%rbp,%r14,8)
-# INTEL: cmpnbxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+# ATT:   cmpaexadd %eax, %ecx, 268435456(%rbp,%r14,8)
+# INTEL: cmpaexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 0xc4,0xa2,0x79,0xe3,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnbxadd %eax, %ecx, 291(%r8,%rax,4)
-# INTEL: cmpnbxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+# ATT:   cmpaexadd %eax, %ecx, 291(%r8,%rax,4)
+# INTEL: cmpaexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 0xc4,0xc2,0x79,0xe3,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnbxadd %eax, %ecx, (%rip)
-# INTEL: cmpnbxadd dword ptr [rip], ecx, eax
+# ATT:   cmpaexadd %eax, %ecx, (%rip)
+# INTEL: cmpaexadd dword ptr [rip], ecx, eax
 0xc4,0xe2,0x79,0xe3,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnbxadd %eax, %ecx, -128(,%rbp,2)
-# INTEL: cmpnbxadd dword ptr [2*rbp - 128], ecx, eax
+# ATT:   cmpaexadd %eax, %ecx, -128(,%rbp,2)
+# INTEL: cmpaexadd dword ptr [2*rbp - 128], ecx, eax
 0xc4,0xe2,0x79,0xe3,0x0c,0x6d,0x80,0xff,0xff,0xff
 
-# ATT:   cmpnbxadd %eax, %ecx, 508(%rcx)
-# INTEL: cmpnbxadd dword ptr [rcx + 508], ecx, eax
+# ATT:   cmpaexadd %eax, %ecx, 508(%rcx)
+# INTEL: cmpaexadd dword ptr [rcx + 508], ecx, eax
 0xc4,0xe2,0x79,0xe3,0x89,0xfc,0x01,0x00,0x00
 
-# ATT:   cmpnbxadd %eax, %ecx, -512(%rdx)
-# INTEL: cmpnbxadd dword ptr [rdx - 512], ecx, eax
+# ATT:   cmpaexadd %eax, %ecx, -512(%rdx)
+# INTEL: cmpaexadd dword ptr [rdx - 512], ecx, eax
 0xc4,0xe2,0x79,0xe3,0x8a,0x00,0xfe,0xff,0xff
 
-# ATT:   cmpnbxadd %r10, %r9, 268435456(%rbp,%r14,8)
-# INTEL: cmpnbxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+# ATT:   cmpaexadd %r10, %r9, 268435456(%rbp,%r14,8)
+# INTEL: cmpaexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 0xc4,0x22,0xa9,0xe3,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnbxadd %r10, %r9, 291(%r8,%rax,4)
-# INTEL: cmpnbxadd qword ptr [r8 + 4*rax + 291], r9, r10
+# ATT:   cmpaexadd %r10, %r9, 291(%r8,%rax,4)
+# INTEL: cmpaexadd qword ptr [r8 + 4*rax + 291], r9, r10
 0xc4,0x42,0xa9,0xe3,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnbxadd %r10, %r9, (%rip)
-# INTEL: cmpnbxadd qword ptr [rip], r9, r10
+# ATT:   cmpaexadd %r10, %r9, (%rip)
+# INTEL: cmpaexadd qword ptr [rip], r9, r10
 0xc4,0x62,0xa9,0xe3,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnbxadd %r10, %r9, -256(,%rbp,2)
-# INTEL: cmpnbxadd qword ptr [2*rbp - 256], r9, r10
+# ATT:   cmpaexadd %r10, %r9, -256(,%rbp,2)
+# INTEL: cmpaexadd qword ptr [2*rbp - 256], r9, r10
 0xc4,0x62,0xa9,0xe3,0x0c,0x6d,0x00,0xff,0xff,0xff
 
-# ATT:   cmpnbxadd %r10, %r9, 1016(%rcx)
-# INTEL: cmpnbxadd qword ptr [rcx + 1016], r9, r10
+# ATT:   cmpaexadd %r10, %r9, 1016(%rcx)
+# INTEL: cmpaexadd qword ptr [rcx + 1016], r9, r10
 0xc4,0x62,0xa9,0xe3,0x89,0xf8,0x03,0x00,0x00
 
-# ATT:   cmpnbxadd %r10, %r9, -1024(%rdx)
-# INTEL: cmpnbxadd qword ptr [rdx - 1024], r9, r10
+# ATT:   cmpaexadd %r10, %r9, -1024(%rdx)
+# INTEL: cmpaexadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xe3,0x8a,0x00,0xfc,0xff,0xff
 
-# ATT:   cmpnlexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
-# INTEL: cmpnlexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+# ATT:   cmpgxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+# INTEL: cmpgxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 0xc4,0xa2,0x79,0xef,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnlexadd  %eax, %ecx, 291(%r8,%rax,4)
-# INTEL: cmpnlexadd dword ptr [r8 + 4*rax + 291], ecx, eax
+# ATT:   cmpgxadd  %eax, %ecx, 291(%r8,%rax,4)
+# INTEL: cmpgxadd dword ptr [r8 + 4*rax + 291], ecx, eax
 0xc4,0xc2,0x79,0xef,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlexadd  %eax, %ecx, (%rip)
-# INTEL: cmpnlexadd dword ptr [rip], ecx, eax
+# ATT:   cmpgxadd  %eax, %ecx, (%rip)
+# INTEL: cmpgxadd dword ptr [rip], ecx, eax
 0xc4,0xe2,0x79,0xef,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnlexadd  %eax, %ecx, -128(,%rbp,2)
-# INTEL: cmpnlexadd dword ptr [2*rbp - 128], ecx, eax
+# ATT:   cmpgxadd  %eax, %ecx, -128(,%rbp,2)
+# INTEL: cmpgxadd dword ptr [2*rbp - 128], ecx, eax
 0xc4,0xe2,0x79,0xef,0x0c,0x6d,0x80,0xff,0xff,0xff
 
-# ATT:   cmpnlexadd  %eax, %ecx, 508(%rcx)
-# INTEL: cmpnlexadd dword ptr [rcx + 508], ecx, eax
+# ATT:   cmpgxadd  %eax, %ecx, 508(%rcx)
+# INTEL: cmpgxadd dword ptr [rcx + 508], ecx, eax
 0xc4,0xe2,0x79,0xef,0x89,0xfc,0x01,0x00,0x00
 
-# ATT:   cmpnlexadd  %eax, %ecx, -512(%rdx)
-# INTEL: cmpnlexadd dword ptr [rdx - 512], ecx, eax
+# ATT:   cmpgxadd  %eax, %ecx, -512(%rdx)
+# INTEL: cmpgxadd dword ptr [rdx - 512], ecx, eax
 0xc4,0xe2,0x79,0xef,0x8a,0x00,0xfe,0xff,0xff
 
-# ATT:   cmpnlexadd  %r10, %r9, 268435456(%rbp,%r14,8)
-# INTEL: cmpnlexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+# ATT:   cmpgxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+# INTEL: cmpgxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 0xc4,0x22,0xa9,0xef,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnlexadd  %r10, %r9, 291(%r8,%rax,4)
-# INTEL: cmpnlexadd qword ptr [r8 + 4*rax + 291], r9, r10
+# ATT:   cmpgxadd  %r10, %r9, 291(%r8,%rax,4)
+# INTEL: cmpgxadd qword ptr [r8 + 4*rax + 291], r9, r10
 0xc4,0x42,0xa9,0xef,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlexadd  %r10, %r9, (%rip)
-# INTEL: cmpnlexadd qword ptr [rip], r9, r10
+# ATT:   cmpgxadd  %r10, %r9, (%rip)
+# INTEL: cmpgxadd qword ptr [rip], r9, r10
 0xc4,0x62,0xa9,0xef,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnlexadd  %r10, %r9, -256(,%rbp,2)
-# INTEL: cmpnlexadd qword ptr [2*rbp - 256], r9, r10
+# ATT:   cmpgxadd  %r10, %r9, -256(,%rbp,2)
+# INTEL: cmpgxadd qword ptr [2*rbp - 256], r9, r10
 0xc4,0x62,0xa9,0xef,0x0c,0x6d,0x00,0xff,0xff,0xff
 
-# ATT:   cmpnlexadd  %r10, %r9, 1016(%rcx)
-# INTEL: cmpnlexadd qword ptr [rcx + 1016], r9, r10
+# ATT:   cmpgxadd  %r10, %r9, 1016(%rcx)
+# INTEL: cmpgxadd qword ptr [rcx + 1016], r9, r10
 0xc4,0x62,0xa9,0xef,0x89,0xf8,0x03,0x00,0x00
 
-# ATT:   cmpnlexadd  %r10, %r9, -1024(%rdx)
-# INTEL: cmpnlexadd qword ptr [rdx - 1024], r9, r10
+# ATT:   cmpgxadd  %r10, %r9, -1024(%rdx)
+# INTEL: cmpgxadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xef,0x8a,0x00,0xfc,0xff,0xff
 
-# ATT:   cmpnlxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
-# INTEL: cmpnlxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+# ATT:   cmpgexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+# INTEL: cmpgexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 0xc4,0xa2,0x79,0xed,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnlxadd  %eax, %ecx, 291(%r8,%rax,4)
-# INTEL: cmpnlxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+# ATT:   cmpgexadd  %eax, %ecx, 291(%r8,%rax,4)
+# INTEL: cmpgexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 0xc4,0xc2,0x79,0xed,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlxadd  %eax, %ecx, (%rip)
-# INTEL: cmpnlxadd dword ptr [rip], ecx, eax
+# ATT:   cmpgexadd  %eax, %ecx, (%rip)
+# INTEL: cmpgexadd dword ptr [rip], ecx, eax
 0xc4,0xe2,0x79,0xed,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnlxadd  %eax, %ecx, -128(,%rbp,2)
-# INTEL: cmpnlxadd dword ptr [2*rbp - 128], ecx, eax
+# ATT:   cmpgexadd  %eax, %ecx, -128(,%rbp,2)
+# INTEL: cmpgexadd dword ptr [2*rbp - 128], ecx, eax
 0xc4,0xe2,0x79,0xed,0x0c,0x6d,0x80,0xff,0xff,0xff
 
-# ATT:   cmpnlxadd  %eax, %ecx, 508(%rcx)
-# INTEL: cmpnlxadd dword ptr [rcx + 508], ecx, eax
+# ATT:   cmpgexadd  %eax, %ecx, 508(%rcx)
+# INTEL: cmpgexadd dword ptr [rcx + 508], ecx, eax
 0xc4,0xe2,0x79,0xed,0x89,0xfc,0x01,0x00,0x00
 
-# ATT:   cmpnlxadd  %eax, %ecx, -512(%rdx)
-# INTEL: cmpnlxadd dword ptr [rdx - 512], ecx, eax
+# ATT:   cmpgexadd  %eax, %ecx, -512(%rdx)
+# INTEL: cmpgexadd dword ptr [rdx - 512], ecx, eax
 0xc4,0xe2,0x79,0xed,0x8a,0x00,0xfe,0xff,0xff
 
-# ATT:   cmpnlxadd  %r10, %r9, 268435456(%rbp,%r14,8)
-# INTEL: cmpnlxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+# ATT:   cmpgexadd  %r10, %r9, 268435456(%rbp,%r14,8)
+# INTEL: cmpgexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 0xc4,0x22,0xa9,0xed,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnlxadd  %r10, %r9, 291(%r8,%rax,4)
-# INTEL: cmpnlxadd qword ptr [r8 + 4*rax + 291], r9, r10
+# ATT:   cmpgexadd  %r10, %r9, 291(%r8,%rax,4)
+# INTEL: cmpgexadd qword ptr [r8 + 4*rax + 291], r9, r10
 0xc4,0x42,0xa9,0xed,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnlxadd  %r10, %r9, (%rip)
-# INTEL: cmpnlxadd qword ptr [rip], r9, r10
+# ATT:   cmpgexadd  %r10, %r9, (%rip)
+# INTEL: cmpgexadd qword ptr [rip], r9, r10
 0xc4,0x62,0xa9,0xed,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnlxadd  %r10, %r9, -256(,%rbp,2)
-# INTEL: cmpnlxadd qword ptr [2*rbp - 256], r9, r10
+# ATT:   cmpgexadd  %r10, %r9, -256(,%rbp,2)
+# INTEL: cmpgexadd qword ptr [2*rbp - 256], r9, r10
 0xc4,0x62,0xa9,0xed,0x0c,0x6d,0x00,0xff,0xff,0xff
 
-# ATT:   cmpnlxadd  %r10, %r9, 1016(%rcx)
-# INTEL: cmpnlxadd qword ptr [rcx + 1016], r9, r10
+# ATT:   cmpgexadd  %r10, %r9, 1016(%rcx)
+# INTEL: cmpgexadd qword ptr [rcx + 1016], r9, r10
 0xc4,0x62,0xa9,0xed,0x89,0xf8,0x03,0x00,0x00
 
-# ATT:   cmpnlxadd  %r10, %r9, -1024(%rdx)
-# INTEL: cmpnlxadd qword ptr [rdx - 1024], r9, r10
+# ATT:   cmpgexadd  %r10, %r9, -1024(%rdx)
+# INTEL: cmpgexadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xed,0x8a,0x00,0xfc,0xff,0xff
 
 # ATT:   cmpnoxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
@@ -529,52 +529,52 @@
 # INTEL: cmpnsxadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xe9,0x8a,0x00,0xfc,0xff,0xff
 
-# ATT:   cmpnzxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
-# INTEL: cmpnzxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+# ATT:   cmpnexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+# INTEL: cmpnexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 0xc4,0xa2,0x79,0xe5,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnzxadd  %eax, %ecx, 291(%r8,%rax,4)
-# INTEL: cmpnzxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+# ATT:   cmpnexadd  %eax, %ecx, 291(%r8,%rax,4)
+# INTEL: cmpnexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 0xc4,0xc2,0x79,0xe5,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnzxadd  %eax, %ecx, (%rip)
-# INTEL: cmpnzxadd dword ptr [rip], ecx, eax
+# ATT:   cmpnexadd  %eax, %ecx, (%rip)
+# INTEL: cmpnexadd dword ptr [rip], ecx, eax
 0xc4,0xe2,0x79,0xe5,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnzxadd  %eax, %ecx, -128(,%rbp,2)
-# INTEL: cmpnzxadd dword ptr [2*rbp - 128], ecx, eax
+# ATT:   cmpnexadd  %eax, %ecx, -128(,%rbp,2)
+# INTEL: cmpnexadd dword ptr [2*rbp - 128], ecx, eax
 0xc4,0xe2,0x79,0xe5,0x0c,0x6d,0x80,0xff,0xff,0xff
 
-# ATT:   cmpnzxadd  %eax, %ecx, 508(%rcx)
-# INTEL: cmpnzxadd dword ptr [rcx + 508], ecx, eax
+# ATT:   cmpnexadd  %eax, %ecx, 508(%rcx)
+# INTEL: cmpnexadd dword ptr [rcx + 508], ecx, eax
 0xc4,0xe2,0x79,0xe5,0x89,0xfc,0x01,0x00,0x00
 
-# ATT:   cmpnzxadd  %eax, %ecx, -512(%rdx)
-# INTEL: cmpnzxadd dword ptr [rdx - 512], ecx, eax
+# ATT:   cmpnexadd  %eax, %ecx, -512(%rdx)
+# INTEL: cmpnexadd dword ptr [rdx - 512], ecx, eax
 0xc4,0xe2,0x79,0xe5,0x8a,0x00,0xfe,0xff,0xff
 
-# ATT:   cmpnzxadd  %r10, %r9, 268435456(%rbp,%r14,8)
-# INTEL: cmpnzxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+# ATT:   cmpnexadd  %r10, %r9, 268435456(%rbp,%r14,8)
+# INTEL: cmpnexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 0xc4,0x22,0xa9,0xe5,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpnzxadd  %r10, %r9, 291(%r8,%rax,4)
-# INTEL: cmpnzxadd qword ptr [r8 + 4*rax + 291], r9, r10
+# ATT:   cmpnexadd  %r10, %r9, 291(%r8,%rax,4)
+# INTEL: cmpnexadd qword ptr [r8 + 4*rax + 291], r9, r10
 0xc4,0x42,0xa9,0xe5,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpnzxadd  %r10, %r9, (%rip)
-# INTEL: cmpnzxadd qword ptr [rip], r9, r10
+# ATT:   cmpnexadd  %r10, %r9, (%rip)
+# INTEL: cmpnexadd qword ptr [rip], r9, r10
 0xc4,0x62,0xa9,0xe5,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpnzxadd  %r10, %r9, -256(,%rbp,2)
-# INTEL: cmpnzxadd qword ptr [2*rbp - 256], r9, r10
+# ATT:   cmpnexadd  %r10, %r9, -256(,%rbp,2)
+# INTEL: cmpnexadd qword ptr [2*rbp - 256], r9, r10
 0xc4,0x62,0xa9,0xe5,0x0c,0x6d,0x00,0xff,0xff,0xff
 
-# ATT:   cmpnzxadd  %r10, %r9, 1016(%rcx)
-# INTEL: cmpnzxadd qword ptr [rcx + 1016], r9, r10
+# ATT:   cmpnexadd  %r10, %r9, 1016(%rcx)
+# INTEL: cmpnexadd qword ptr [rcx + 1016], r9, r10
 0xc4,0x62,0xa9,0xe5,0x89,0xf8,0x03,0x00,0x00
 
-# ATT:   cmpnzxadd  %r10, %r9, -1024(%rdx)
-# INTEL: cmpnzxadd qword ptr [rdx - 1024], r9, r10
+# ATT:   cmpnexadd  %r10, %r9, -1024(%rdx)
+# INTEL: cmpnexadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xe5,0x8a,0x00,0xfc,0xff,0xff
 
 # ATT:   cmpoxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
@@ -721,52 +721,52 @@
 # INTEL: cmpsxadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xe8,0x8a,0x00,0xfc,0xff,0xff
 
-# ATT:   cmpzxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
-# INTEL: cmpzxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+# ATT:   cmpexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+# INTEL: cmpexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 0xc4,0xa2,0x79,0xe4,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpzxadd  %eax, %ecx, 291(%r8,%rax,4)
-# INTEL: cmpzxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+# ATT:   cmpexadd  %eax, %ecx, 291(%r8,%rax,4)
+# INTEL: cmpexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 0xc4,0xc2,0x79,0xe4,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpzxadd  %eax, %ecx, (%rip)
-# INTEL: cmpzxadd dword ptr [rip], ecx, eax
+# ATT:   cmpexadd  %eax, %ecx, (%rip)
+# INTEL: cmpexadd dword ptr [rip], ecx, eax
 0xc4,0xe2,0x79,0xe4,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpzxadd  %eax, %ecx, -128(,%rbp,2)
-# INTEL: cmpzxadd dword ptr [2*rbp - 128], ecx, eax
+# ATT:   cmpexadd  %eax, %ecx, -128(,%rbp,2)
+# INTEL: cmpexadd dword ptr [2*rbp - 128], ecx, eax
 0xc4,0xe2,0x79,0xe4,0x0c,0x6d,0x80,0xff,0xff,0xff
 
-# ATT:   cmpzxadd  %eax, %ecx, 508(%rcx)
-# INTEL: cmpzxadd dword ptr [rcx + 508], ecx, eax
+# ATT:   cmpexadd  %eax, %ecx, 508(%rcx)
+# INTEL: cmpexadd dword ptr [rcx + 508], ecx, eax
 0xc4,0xe2,0x79,0xe4,0x89,0xfc,0x01,0x00,0x00
 
-# ATT:   cmpzxadd  %eax, %ecx, -512(%rdx)
-# INTEL: cmpzxadd dword ptr [rdx - 512], ecx, eax
+# ATT:   cmpexadd  %eax, %ecx, -512(%rdx)
+# INTEL: cmpexadd dword ptr [rdx - 512], ecx, eax
 0xc4,0xe2,0x79,0xe4,0x8a,0x00,0xfe,0xff,0xff
 
-# ATT:   cmpzxadd  %r10, %r9, 268435456(%rbp,%r14,8)
-# INTEL: cmpzxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+# ATT:   cmpexadd  %r10, %r9, 268435456(%rbp,%r14,8)
+# INTEL: cmpexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 0xc4,0x22,0xa9,0xe4,0x8c,0xf5,0x00,0x00,0x00,0x10
 
-# ATT:   cmpzxadd  %r10, %r9, 291(%r8,%rax,4)
-# INTEL: cmpzxadd qword ptr [r8 + 4*rax + 291], r9, r10
+# ATT:   cmpexadd  %r10, %r9, 291(%r8,%rax,4)
+# INTEL: cmpexadd qword ptr [r8 + 4*rax + 291], r9, r10
 0xc4,0x42,0xa9,0xe4,0x8c,0x80,0x23,0x01,0x00,0x00
 
-# ATT:   cmpzxadd  %r10, %r9, (%rip)
-# INTEL: cmpzxadd qword ptr [rip], r9, r10
+# ATT:   cmpexadd  %r10, %r9, (%rip)
+# INTEL: cmpexadd qword ptr [rip], r9, r10
 0xc4,0x62,0xa9,0xe4,0x0d,0x00,0x00,0x00,0x00
 
-# ATT:   cmpzxadd  %r10, %r9, -256(,%rbp,2)
-# INTEL: cmpzxadd qword ptr [2*rbp - 256], r9, r10
+# ATT:   cmpexadd  %r10, %r9, -256(,%rbp,2)
+# INTEL: cmpexadd qword ptr [2*rbp - 256], r9, r10
 0xc4,0x62,0xa9,0xe4,0x0c,0x6d,0x00,0xff,0xff,0xff
 
-# ATT:   cmpzxadd  %r10, %r9, 1016(%rcx)
-# INTEL: cmpzxadd qword ptr [rcx + 1016], r9, r10
+# ATT:   cmpexadd  %r10, %r9, 1016(%rcx)
+# INTEL: cmpexadd qword ptr [rcx + 1016], r9, r10
 0xc4,0x62,0xa9,0xe4,0x89,0xf8,0x03,0x00,0x00
 
-# ATT:   cmpzxadd  %r10, %r9, -1024(%rdx)
-# INTEL: cmpzxadd qword ptr [rdx - 1024], r9, r10
+# ATT:   cmpexadd  %r10, %r9, -1024(%rdx)
+# INTEL: cmpexadd qword ptr [rdx - 1024], r9, r10
 0xc4,0x62,0xa9,0xe4,0x8a,0x00,0xfc,0xff,0xff
 
 # ATT:   cmpbexadd  %ecx, %r8d, (%rip)

--- a/llvm/test/MC/X86/apx/cmpccxadd-att.s
+++ b/llvm/test/MC/X86/apx/cmpccxadd-att.s
@@ -3,21 +3,21 @@
 
 # ERROR-COUNT-60: error:
 # ERROR-NOT: error:
-# CHECK: {evex}	cmpnbexadd	%ecx, %edx, 123(%eax,%ebx,4)
+# CHECK: {evex}	cmpaxadd	%ecx, %edx, 123(%eax,%ebx,4)
 # CHECK: encoding: [0x67,0x62,0xf2,0x75,0x08,0xe7,0x54,0x98,0x7b]
-         {evex}	cmpnbexadd	%ecx, %edx, 123(%eax,%ebx,4)
+         {evex}	cmpaxadd	%ecx, %edx, 123(%eax,%ebx,4)
 
-# CHECK: {evex}	cmpnbexadd	%r9, %r15, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpaxadd	%r9, %r15, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xe7,0x7c,0x98,0x7b]
-         {evex}	cmpnbexadd	%r9, %r15, 123(%rax,%rbx,4)
+         {evex}	cmpaxadd	%r9, %r15, 123(%rax,%rbx,4)
 
-# CHECK: cmpnbexadd	%r18d, %r22d, 291(%r28,%r29,4)
+# CHECK: cmpaxadd	%r18d, %r22d, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xe7,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnbexadd	%r18d, %r22d, 291(%r28,%r29,4)
+         cmpaxadd	%r18d, %r22d, 291(%r28,%r29,4)
 
-# CHECK: cmpnbexadd	%r19, %r23, 291(%r28,%r29,4)
+# CHECK: cmpaxadd	%r19, %r23, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe7,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnbexadd	%r19, %r23, 291(%r28,%r29,4)
+         cmpaxadd	%r19, %r23, 291(%r28,%r29,4)
 
 # CHECK: {evex}	cmpbexadd	%ecx, %edx, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe6,0x54,0x98,0x7b]
@@ -51,53 +51,53 @@
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe2,0xbc,0xac,0x23,0x01,0x00,0x00]
          cmpbxadd	%r19, %r23, 291(%r28,%r29,4)
 
-# CHECK: {evex}	cmpzxadd	%ecx, %edx, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpexadd	%ecx, %edx, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe4,0x54,0x98,0x7b]
-         {evex}	cmpzxadd	%ecx, %edx, 123(%rax,%rbx,4)
+         {evex}	cmpexadd	%ecx, %edx, 123(%rax,%rbx,4)
 
-# CHECK: {evex}	cmpzxadd	%r9, %r15, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpexadd	%r9, %r15, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xe4,0x7c,0x98,0x7b]
-         {evex}	cmpzxadd	%r9, %r15, 123(%rax,%rbx,4)
+         {evex}	cmpexadd	%r9, %r15, 123(%rax,%rbx,4)
 
-# CHECK: cmpzxadd	%r18d, %r22d, 291(%r28,%r29,4)
+# CHECK: cmpexadd	%r18d, %r22d, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xe4,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpzxadd	%r18d, %r22d, 291(%r28,%r29,4)
+         cmpexadd	%r18d, %r22d, 291(%r28,%r29,4)
 
-# CHECK: cmpzxadd	%r19, %r23, 291(%r28,%r29,4)
+# CHECK: cmpexadd	%r19, %r23, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe4,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpzxadd	%r19, %r23, 291(%r28,%r29,4)
+         cmpexadd	%r19, %r23, 291(%r28,%r29,4)
 
-# CHECK: {evex}	cmpnlxadd	%ecx, %edx, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpgexadd	%ecx, %edx, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xed,0x54,0x98,0x7b]
-         {evex}	cmpnlxadd	%ecx, %edx, 123(%rax,%rbx,4)
+         {evex}	cmpgexadd	%ecx, %edx, 123(%rax,%rbx,4)
 
-# CHECK: {evex}	cmpnlxadd	%r9, %r15, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpgexadd	%r9, %r15, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xed,0x7c,0x98,0x7b]
-         {evex}	cmpnlxadd	%r9, %r15, 123(%rax,%rbx,4)
+         {evex}	cmpgexadd	%r9, %r15, 123(%rax,%rbx,4)
 
-# CHECK: cmpnlxadd	%r18d, %r22d, 291(%r28,%r29,4)
+# CHECK: cmpgexadd	%r18d, %r22d, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xed,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnlxadd	%r18d, %r22d, 291(%r28,%r29,4)
+         cmpgexadd	%r18d, %r22d, 291(%r28,%r29,4)
 
-# CHECK: cmpnlxadd	%r19, %r23, 291(%r28,%r29,4)
+# CHECK: cmpgexadd	%r19, %r23, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xed,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnlxadd	%r19, %r23, 291(%r28,%r29,4)
+         cmpgexadd	%r19, %r23, 291(%r28,%r29,4)
 
-# CHECK: {evex}	cmpnlexadd	%ecx, %edx, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpgxadd	%ecx, %edx, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xef,0x54,0x98,0x7b]
-         {evex}	cmpnlexadd	%ecx, %edx, 123(%rax,%rbx,4)
+         {evex}	cmpgxadd	%ecx, %edx, 123(%rax,%rbx,4)
 
-# CHECK: {evex}	cmpnlexadd	%r9, %r15, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpgxadd	%r9, %r15, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xef,0x7c,0x98,0x7b]
-         {evex}	cmpnlexadd	%r9, %r15, 123(%rax,%rbx,4)
+         {evex}	cmpgxadd	%r9, %r15, 123(%rax,%rbx,4)
 
-# CHECK: cmpnlexadd	%r18d, %r22d, 291(%r28,%r29,4)
+# CHECK: cmpgxadd	%r18d, %r22d, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xef,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnlexadd	%r18d, %r22d, 291(%r28,%r29,4)
+         cmpgxadd	%r18d, %r22d, 291(%r28,%r29,4)
 
-# CHECK: cmpnlexadd	%r19, %r23, 291(%r28,%r29,4)
+# CHECK: cmpgxadd	%r19, %r23, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xef,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnlexadd	%r19, %r23, 291(%r28,%r29,4)
+         cmpgxadd	%r19, %r23, 291(%r28,%r29,4)
 
 # CHECK: {evex}	cmplexadd	%ecx, %edx, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xee,0x54,0x98,0x7b]
@@ -131,21 +131,21 @@
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xec,0xbc,0xac,0x23,0x01,0x00,0x00]
          cmplxadd	%r19, %r23, 291(%r28,%r29,4)
 
-# CHECK: {evex}	cmpnzxadd	%ecx, %edx, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpnexadd	%ecx, %edx, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe5,0x54,0x98,0x7b]
-         {evex}	cmpnzxadd	%ecx, %edx, 123(%rax,%rbx,4)
+         {evex}	cmpnexadd	%ecx, %edx, 123(%rax,%rbx,4)
 
-# CHECK: {evex}	cmpnzxadd	%r9, %r15, 123(%rax,%rbx,4)
+# CHECK: {evex}	cmpnexadd	%r9, %r15, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xe5,0x7c,0x98,0x7b]
-         {evex}	cmpnzxadd	%r9, %r15, 123(%rax,%rbx,4)
+         {evex}	cmpnexadd	%r9, %r15, 123(%rax,%rbx,4)
 
-# CHECK: cmpnzxadd	%r18d, %r22d, 291(%r28,%r29,4)
+# CHECK: cmpnexadd	%r18d, %r22d, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xe5,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnzxadd	%r18d, %r22d, 291(%r28,%r29,4)
+         cmpnexadd	%r18d, %r22d, 291(%r28,%r29,4)
 
-# CHECK: cmpnzxadd	%r19, %r23, 291(%r28,%r29,4)
+# CHECK: cmpnexadd	%r19, %r23, 291(%r28,%r29,4)
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe5,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnzxadd	%r19, %r23, 291(%r28,%r29,4)
+         cmpnexadd	%r19, %r23, 291(%r28,%r29,4)
 
 # CHECK: {evex}	cmpnoxadd	%ecx, %edx, 123(%rax,%rbx,4)
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe1,0x54,0x98,0x7b]

--- a/llvm/test/MC/X86/apx/cmpccxadd-intel.s
+++ b/llvm/test/MC/X86/apx/cmpccxadd-intel.s
@@ -1,20 +1,20 @@
 # RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
 
-# CHECK: {evex}	cmpnbexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# CHECK: {evex}	cmpaxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe7,0x54,0x98,0x7b]
-         {evex}	cmpnbexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+         {evex}	cmpaxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 
-# CHECK: {evex}	cmpnbexadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# CHECK: {evex}	cmpaxadd	qword ptr [rax + 4*rbx + 123], r15, r9
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xe7,0x7c,0x98,0x7b]
-         {evex}	cmpnbexadd	qword ptr [rax + 4*rbx + 123], r15, r9
+         {evex}	cmpaxadd	qword ptr [rax + 4*rbx + 123], r15, r9
 
-# CHECK: cmpnbexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# CHECK: cmpaxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xe7,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnbexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+         cmpaxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 
-# CHECK: cmpnbexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# CHECK: cmpaxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe7,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnbexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+         cmpaxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 
 # CHECK: {evex}	cmpbexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe6,0x54,0x98,0x7b]
@@ -48,53 +48,53 @@
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe2,0xbc,0xac,0x23,0x01,0x00,0x00]
          cmpbxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 
-# CHECK: {evex}	cmpzxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# CHECK: {evex}	cmpexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe4,0x54,0x98,0x7b]
-         {evex}	cmpzxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+         {evex}	cmpexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 
-# CHECK: {evex}	cmpzxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# CHECK: {evex}	cmpexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xe4,0x7c,0x98,0x7b]
-         {evex}	cmpzxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+         {evex}	cmpexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 
-# CHECK: cmpzxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# CHECK: cmpexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xe4,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpzxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+         cmpexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 
-# CHECK: cmpzxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# CHECK: cmpexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe4,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpzxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+         cmpexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 
-# CHECK: {evex}	cmpnlxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# CHECK: {evex}	cmpgexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xed,0x54,0x98,0x7b]
-         {evex}	cmpnlxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+         {evex}	cmpgexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 
-# CHECK: {evex}	cmpnlxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# CHECK: {evex}	cmpgexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xed,0x7c,0x98,0x7b]
-         {evex}	cmpnlxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+         {evex}	cmpgexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 
-# CHECK: cmpnlxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# CHECK: cmpgexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xed,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnlxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+         cmpgexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 
-# CHECK: cmpnlxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# CHECK: cmpgexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xed,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnlxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+         cmpgexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 
-# CHECK: {evex}	cmpnlexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# CHECK: {evex}	cmpgxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xef,0x54,0x98,0x7b]
-         {evex}	cmpnlexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+         {evex}	cmpgxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 
-# CHECK: {evex}	cmpnlexadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# CHECK: {evex}	cmpgxadd	qword ptr [rax + 4*rbx + 123], r15, r9
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xef,0x7c,0x98,0x7b]
-         {evex}	cmpnlexadd	qword ptr [rax + 4*rbx + 123], r15, r9
+         {evex}	cmpgxadd	qword ptr [rax + 4*rbx + 123], r15, r9
 
-# CHECK: cmpnlexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# CHECK: cmpgxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xef,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnlexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+         cmpgxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 
-# CHECK: cmpnlexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# CHECK: cmpgxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xef,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnlexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+         cmpgxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 
 # CHECK: {evex}	cmplexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xee,0x54,0x98,0x7b]
@@ -128,21 +128,21 @@
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xec,0xbc,0xac,0x23,0x01,0x00,0x00]
          cmplxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 
-# CHECK: {evex}	cmpnzxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+# CHECK: {evex}	cmpnexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe5,0x54,0x98,0x7b]
-         {evex}	cmpnzxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
+         {evex}	cmpnexadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 
-# CHECK: {evex}	cmpnzxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+# CHECK: {evex}	cmpnexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 # CHECK: encoding: [0x62,0x72,0xb5,0x08,0xe5,0x7c,0x98,0x7b]
-         {evex}	cmpnzxadd	qword ptr [rax + 4*rbx + 123], r15, r9
+         {evex}	cmpnexadd	qword ptr [rax + 4*rbx + 123], r15, r9
 
-# CHECK: cmpnzxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+# CHECK: cmpnexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 # CHECK: encoding: [0x62,0x8a,0x69,0x00,0xe5,0xb4,0xac,0x23,0x01,0x00,0x00]
-         cmpnzxadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
+         cmpnexadd	dword ptr [r28 + 4*r29 + 291], r22d, r18d
 
-# CHECK: cmpnzxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+# CHECK: cmpnexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 # CHECK: encoding: [0x62,0x8a,0xe1,0x00,0xe5,0xbc,0xac,0x23,0x01,0x00,0x00]
-         cmpnzxadd	qword ptr [r28 + 4*r29 + 291], r23, r19
+         cmpnexadd	qword ptr [r28 + 4*r29 + 291], r23, r19
 
 # CHECK: {evex}	cmpnoxadd	dword ptr [rax + 4*rbx + 123], edx, ecx
 # CHECK: encoding: [0x62,0xf2,0x75,0x08,0xe1,0x54,0x98,0x7b]

--- a/llvm/test/MC/X86/cmpccxadd-att-alias.s
+++ b/llvm/test/MC/X86/cmpccxadd-att-alias.s
@@ -1,28 +1,28 @@
 // RUN: llvm-mc -triple x86_64 --show-encoding %s | FileCheck %s
 
-// CHECK: cmpnbxadd  %eax, %ecx, (%rip)
+// CHECK: cmpaexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0d,0x00,0x00,0x00,0x00]
-          cmpaexadd  %eax, %ecx, (%rip)
+          cmpnbxadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpzxadd  %eax, %ecx, (%rip)
+// CHECK: cmpexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x0d,0x00,0x00,0x00,0x00]
-          cmpexadd  %eax, %ecx, (%rip)
+          cmpzxadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnzxadd  %eax, %ecx, (%rip)
+// CHECK: cmpnexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x0d,0x00,0x00,0x00,0x00]
-          cmpnexadd  %eax, %ecx, (%rip)
+          cmpnzxadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnbexadd  %eax, %ecx, (%rip)
+// CHECK: cmpaxadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x0d,0x00,0x00,0x00,0x00]
-          cmpaxadd  %eax, %ecx, (%rip)
+          cmpnbexadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnlxadd  %eax, %ecx, (%rip)
+// CHECK: cmpgexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x0d,0x00,0x00,0x00,0x00]
-          cmpgexadd  %eax, %ecx, (%rip)
+          cmpnlxadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnlexadd  %eax, %ecx, (%rip)
+// CHECK: cmpgxadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x0d,0x00,0x00,0x00,0x00]
-          cmpgxadd  %eax, %ecx, (%rip)
+          cmpnlexadd  %eax, %ecx, (%rip)
 
 // CHECK: cmpbxadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe2,0x0d,0x00,0x00,0x00,0x00]
@@ -32,7 +32,7 @@
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe2,0x0d,0x00,0x00,0x00,0x00]
           cmpnaexadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnbxadd  %eax, %ecx, (%rip)
+// CHECK: cmpaexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0d,0x00,0x00,0x00,0x00]
           cmpncxadd  %eax, %ecx, (%rip)
 

--- a/llvm/test/MC/X86/cmpccxadd-att.s
+++ b/llvm/test/MC/X86/cmpccxadd-att.s
@@ -196,197 +196,197 @@
 // CHECK: encoding: [0xc4,0x62,0xa9,0xec,0x8a,0x00,0xfc,0xff,0xff]
           cmplxadd  %r10, %r9, -1024(%rdx)
 
-// CHECK: cmpnbexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+// CHECK: cmpaxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe7,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+          cmpaxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnbexadd  %eax, %ecx, 291(%r8,%rax,4)
+// CHECK: cmpaxadd  %eax, %ecx, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe7,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbexadd  %eax, %ecx, 291(%r8,%rax,4)
+          cmpaxadd  %eax, %ecx, 291(%r8,%rax,4)
 
-// CHECK: cmpnbexadd  %eax, %ecx, (%rip)
+// CHECK: cmpaxadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbexadd  %eax, %ecx, (%rip)
+          cmpaxadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnbexadd  %eax, %ecx, -128(,%rbp,2)
+// CHECK: cmpaxadd  %eax, %ecx, -128(,%rbp,2)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnbexadd  %eax, %ecx, -128(,%rbp,2)
+          cmpaxadd  %eax, %ecx, -128(,%rbp,2)
 
-// CHECK: cmpnbexadd  %eax, %ecx, 508(%rcx)
+// CHECK: cmpaxadd  %eax, %ecx, 508(%rcx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x89,0xfc,0x01,0x00,0x00]
-          cmpnbexadd  %eax, %ecx, 508(%rcx)
+          cmpaxadd  %eax, %ecx, 508(%rcx)
 
-// CHECK: cmpnbexadd  %eax, %ecx, -512(%rdx)
+// CHECK: cmpaxadd  %eax, %ecx, -512(%rdx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnbexadd  %eax, %ecx, -512(%rdx)
+          cmpaxadd  %eax, %ecx, -512(%rdx)
 
-// CHECK: cmpnbexadd  %r10, %r9, 268435456(%rbp,%r14,8)
+// CHECK: cmpaxadd  %r10, %r9, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe7,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbexadd  %r10, %r9, 268435456(%rbp,%r14,8)
+          cmpaxadd  %r10, %r9, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnbexadd  %r10, %r9, 291(%r8,%rax,4)
+// CHECK: cmpaxadd  %r10, %r9, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe7,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbexadd  %r10, %r9, 291(%r8,%rax,4)
+          cmpaxadd  %r10, %r9, 291(%r8,%rax,4)
 
-// CHECK: cmpnbexadd  %r10, %r9, (%rip)
+// CHECK: cmpaxadd  %r10, %r9, (%rip)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbexadd  %r10, %r9, (%rip)
+          cmpaxadd  %r10, %r9, (%rip)
 
-// CHECK: cmpnbexadd  %r10, %r9, -256(,%rbp,2)
+// CHECK: cmpaxadd  %r10, %r9, -256(,%rbp,2)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnbexadd  %r10, %r9, -256(,%rbp,2)
+          cmpaxadd  %r10, %r9, -256(,%rbp,2)
 
-// CHECK: cmpnbexadd  %r10, %r9, 1016(%rcx)
+// CHECK: cmpaxadd  %r10, %r9, 1016(%rcx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x89,0xf8,0x03,0x00,0x00]
-          cmpnbexadd  %r10, %r9, 1016(%rcx)
+          cmpaxadd  %r10, %r9, 1016(%rcx)
 
-// CHECK: cmpnbexadd  %r10, %r9, -1024(%rdx)
+// CHECK: cmpaxadd  %r10, %r9, -1024(%rdx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnbexadd  %r10, %r9, -1024(%rdx)
+          cmpaxadd  %r10, %r9, -1024(%rdx)
 
-// CHECK: cmpnbxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+// CHECK: cmpaexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe3,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+          cmpaexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnbxadd  %eax, %ecx, 291(%r8,%rax,4)
+// CHECK: cmpaexadd  %eax, %ecx, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe3,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbxadd  %eax, %ecx, 291(%r8,%rax,4)
+          cmpaexadd  %eax, %ecx, 291(%r8,%rax,4)
 
-// CHECK: cmpnbxadd  %eax, %ecx, (%rip)
+// CHECK: cmpaexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbxadd  %eax, %ecx, (%rip)
+          cmpaexadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnbxadd  %eax, %ecx, -128(,%rbp,2)
+// CHECK: cmpaexadd  %eax, %ecx, -128(,%rbp,2)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnbxadd  %eax, %ecx, -128(,%rbp,2)
+          cmpaexadd  %eax, %ecx, -128(,%rbp,2)
 
-// CHECK: cmpnbxadd  %eax, %ecx, 508(%rcx)
+// CHECK: cmpaexadd  %eax, %ecx, 508(%rcx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x89,0xfc,0x01,0x00,0x00]
-          cmpnbxadd  %eax, %ecx, 508(%rcx)
+          cmpaexadd  %eax, %ecx, 508(%rcx)
 
-// CHECK: cmpnbxadd  %eax, %ecx, -512(%rdx)
+// CHECK: cmpaexadd  %eax, %ecx, -512(%rdx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnbxadd  %eax, %ecx, -512(%rdx)
+          cmpaexadd  %eax, %ecx, -512(%rdx)
 
-// CHECK: cmpnbxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+// CHECK: cmpaexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe3,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+          cmpaexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnbxadd  %r10, %r9, 291(%r8,%rax,4)
+// CHECK: cmpaexadd  %r10, %r9, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe3,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbxadd  %r10, %r9, 291(%r8,%rax,4)
+          cmpaexadd  %r10, %r9, 291(%r8,%rax,4)
 
-// CHECK: cmpnbxadd  %r10, %r9, (%rip)
+// CHECK: cmpaexadd  %r10, %r9, (%rip)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbxadd  %r10, %r9, (%rip)
+          cmpaexadd  %r10, %r9, (%rip)
 
-// CHECK: cmpnbxadd  %r10, %r9, -256(,%rbp,2)
+// CHECK: cmpaexadd  %r10, %r9, -256(,%rbp,2)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnbxadd  %r10, %r9, -256(,%rbp,2)
+          cmpaexadd  %r10, %r9, -256(,%rbp,2)
 
-// CHECK: cmpnbxadd  %r10, %r9, 1016(%rcx)
+// CHECK: cmpaexadd  %r10, %r9, 1016(%rcx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x89,0xf8,0x03,0x00,0x00]
-          cmpnbxadd  %r10, %r9, 1016(%rcx)
+          cmpaexadd  %r10, %r9, 1016(%rcx)
 
-// CHECK: cmpnbxadd  %r10, %r9, -1024(%rdx)
+// CHECK: cmpaexadd  %r10, %r9, -1024(%rdx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnbxadd  %r10, %r9, -1024(%rdx)
+          cmpaexadd  %r10, %r9, -1024(%rdx)
 
-// CHECK: cmpnlexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+// CHECK: cmpgxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xef,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+          cmpgxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnlexadd  %eax, %ecx, 291(%r8,%rax,4)
+// CHECK: cmpgxadd  %eax, %ecx, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0xc2,0x79,0xef,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlexadd  %eax, %ecx, 291(%r8,%rax,4)
+          cmpgxadd  %eax, %ecx, 291(%r8,%rax,4)
 
-// CHECK: cmpnlexadd  %eax, %ecx, (%rip)
+// CHECK: cmpgxadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlexadd  %eax, %ecx, (%rip)
+          cmpgxadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnlexadd  %eax, %ecx, -128(,%rbp,2)
+// CHECK: cmpgxadd  %eax, %ecx, -128(,%rbp,2)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnlexadd  %eax, %ecx, -128(,%rbp,2)
+          cmpgxadd  %eax, %ecx, -128(,%rbp,2)
 
-// CHECK: cmpnlexadd  %eax, %ecx, 508(%rcx)
+// CHECK: cmpgxadd  %eax, %ecx, 508(%rcx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x89,0xfc,0x01,0x00,0x00]
-          cmpnlexadd  %eax, %ecx, 508(%rcx)
+          cmpgxadd  %eax, %ecx, 508(%rcx)
 
-// CHECK: cmpnlexadd  %eax, %ecx, -512(%rdx)
+// CHECK: cmpgxadd  %eax, %ecx, -512(%rdx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnlexadd  %eax, %ecx, -512(%rdx)
+          cmpgxadd  %eax, %ecx, -512(%rdx)
 
-// CHECK: cmpnlexadd  %r10, %r9, 268435456(%rbp,%r14,8)
+// CHECK: cmpgxadd  %r10, %r9, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0x22,0xa9,0xef,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlexadd  %r10, %r9, 268435456(%rbp,%r14,8)
+          cmpgxadd  %r10, %r9, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnlexadd  %r10, %r9, 291(%r8,%rax,4)
+// CHECK: cmpgxadd  %r10, %r9, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0x42,0xa9,0xef,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlexadd  %r10, %r9, 291(%r8,%rax,4)
+          cmpgxadd  %r10, %r9, 291(%r8,%rax,4)
 
-// CHECK: cmpnlexadd  %r10, %r9, (%rip)
+// CHECK: cmpgxadd  %r10, %r9, (%rip)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlexadd  %r10, %r9, (%rip)
+          cmpgxadd  %r10, %r9, (%rip)
 
-// CHECK: cmpnlexadd  %r10, %r9, -256(,%rbp,2)
+// CHECK: cmpgxadd  %r10, %r9, -256(,%rbp,2)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnlexadd  %r10, %r9, -256(,%rbp,2)
+          cmpgxadd  %r10, %r9, -256(,%rbp,2)
 
-// CHECK: cmpnlexadd  %r10, %r9, 1016(%rcx)
+// CHECK: cmpgxadd  %r10, %r9, 1016(%rcx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x89,0xf8,0x03,0x00,0x00]
-          cmpnlexadd  %r10, %r9, 1016(%rcx)
+          cmpgxadd  %r10, %r9, 1016(%rcx)
 
-// CHECK: cmpnlexadd  %r10, %r9, -1024(%rdx)
+// CHECK: cmpgxadd  %r10, %r9, -1024(%rdx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnlexadd  %r10, %r9, -1024(%rdx)
+          cmpgxadd  %r10, %r9, -1024(%rdx)
 
-// CHECK: cmpnlxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+// CHECK: cmpgexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xed,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+          cmpgexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnlxadd  %eax, %ecx, 291(%r8,%rax,4)
+// CHECK: cmpgexadd  %eax, %ecx, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0xc2,0x79,0xed,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlxadd  %eax, %ecx, 291(%r8,%rax,4)
+          cmpgexadd  %eax, %ecx, 291(%r8,%rax,4)
 
-// CHECK: cmpnlxadd  %eax, %ecx, (%rip)
+// CHECK: cmpgexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlxadd  %eax, %ecx, (%rip)
+          cmpgexadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnlxadd  %eax, %ecx, -128(,%rbp,2)
+// CHECK: cmpgexadd  %eax, %ecx, -128(,%rbp,2)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnlxadd  %eax, %ecx, -128(,%rbp,2)
+          cmpgexadd  %eax, %ecx, -128(,%rbp,2)
 
-// CHECK: cmpnlxadd  %eax, %ecx, 508(%rcx)
+// CHECK: cmpgexadd  %eax, %ecx, 508(%rcx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x89,0xfc,0x01,0x00,0x00]
-          cmpnlxadd  %eax, %ecx, 508(%rcx)
+          cmpgexadd  %eax, %ecx, 508(%rcx)
 
-// CHECK: cmpnlxadd  %eax, %ecx, -512(%rdx)
+// CHECK: cmpgexadd  %eax, %ecx, -512(%rdx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnlxadd  %eax, %ecx, -512(%rdx)
+          cmpgexadd  %eax, %ecx, -512(%rdx)
 
-// CHECK: cmpnlxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+// CHECK: cmpgexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0x22,0xa9,0xed,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+          cmpgexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnlxadd  %r10, %r9, 291(%r8,%rax,4)
+// CHECK: cmpgexadd  %r10, %r9, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0x42,0xa9,0xed,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlxadd  %r10, %r9, 291(%r8,%rax,4)
+          cmpgexadd  %r10, %r9, 291(%r8,%rax,4)
 
-// CHECK: cmpnlxadd  %r10, %r9, (%rip)
+// CHECK: cmpgexadd  %r10, %r9, (%rip)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlxadd  %r10, %r9, (%rip)
+          cmpgexadd  %r10, %r9, (%rip)
 
-// CHECK: cmpnlxadd  %r10, %r9, -256(,%rbp,2)
+// CHECK: cmpgexadd  %r10, %r9, -256(,%rbp,2)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnlxadd  %r10, %r9, -256(,%rbp,2)
+          cmpgexadd  %r10, %r9, -256(,%rbp,2)
 
-// CHECK: cmpnlxadd  %r10, %r9, 1016(%rcx)
+// CHECK: cmpgexadd  %r10, %r9, 1016(%rcx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x89,0xf8,0x03,0x00,0x00]
-          cmpnlxadd  %r10, %r9, 1016(%rcx)
+          cmpgexadd  %r10, %r9, 1016(%rcx)
 
-// CHECK: cmpnlxadd  %r10, %r9, -1024(%rdx)
+// CHECK: cmpgexadd  %r10, %r9, -1024(%rdx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnlxadd  %r10, %r9, -1024(%rdx)
+          cmpgexadd  %r10, %r9, -1024(%rdx)
 
 // CHECK: cmpnoxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe1,0x8c,0xf5,0x00,0x00,0x00,0x10]
@@ -532,53 +532,53 @@
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe9,0x8a,0x00,0xfc,0xff,0xff]
           cmpnsxadd  %r10, %r9, -1024(%rdx)
 
-// CHECK: cmpnzxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+// CHECK: cmpnexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe5,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnzxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+          cmpnexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnzxadd  %eax, %ecx, 291(%r8,%rax,4)
+// CHECK: cmpnexadd  %eax, %ecx, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe5,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnzxadd  %eax, %ecx, 291(%r8,%rax,4)
+          cmpnexadd  %eax, %ecx, 291(%r8,%rax,4)
 
-// CHECK: cmpnzxadd  %eax, %ecx, (%rip)
+// CHECK: cmpnexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x0d,0x00,0x00,0x00,0x00]
-          cmpnzxadd  %eax, %ecx, (%rip)
+          cmpnexadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpnzxadd  %eax, %ecx, -128(,%rbp,2)
+// CHECK: cmpnexadd  %eax, %ecx, -128(,%rbp,2)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnzxadd  %eax, %ecx, -128(,%rbp,2)
+          cmpnexadd  %eax, %ecx, -128(,%rbp,2)
 
-// CHECK: cmpnzxadd  %eax, %ecx, 508(%rcx)
+// CHECK: cmpnexadd  %eax, %ecx, 508(%rcx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x89,0xfc,0x01,0x00,0x00]
-          cmpnzxadd  %eax, %ecx, 508(%rcx)
+          cmpnexadd  %eax, %ecx, 508(%rcx)
 
-// CHECK: cmpnzxadd  %eax, %ecx, -512(%rdx)
+// CHECK: cmpnexadd  %eax, %ecx, -512(%rdx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnzxadd  %eax, %ecx, -512(%rdx)
+          cmpnexadd  %eax, %ecx, -512(%rdx)
 
-// CHECK: cmpnzxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+// CHECK: cmpnexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe5,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnzxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+          cmpnexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpnzxadd  %r10, %r9, 291(%r8,%rax,4)
+// CHECK: cmpnexadd  %r10, %r9, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe5,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnzxadd  %r10, %r9, 291(%r8,%rax,4)
+          cmpnexadd  %r10, %r9, 291(%r8,%rax,4)
 
-// CHECK: cmpnzxadd  %r10, %r9, (%rip)
+// CHECK: cmpnexadd  %r10, %r9, (%rip)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x0d,0x00,0x00,0x00,0x00]
-          cmpnzxadd  %r10, %r9, (%rip)
+          cmpnexadd  %r10, %r9, (%rip)
 
-// CHECK: cmpnzxadd  %r10, %r9, -256(,%rbp,2)
+// CHECK: cmpnexadd  %r10, %r9, -256(,%rbp,2)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnzxadd  %r10, %r9, -256(,%rbp,2)
+          cmpnexadd  %r10, %r9, -256(,%rbp,2)
 
-// CHECK: cmpnzxadd  %r10, %r9, 1016(%rcx)
+// CHECK: cmpnexadd  %r10, %r9, 1016(%rcx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x89,0xf8,0x03,0x00,0x00]
-          cmpnzxadd  %r10, %r9, 1016(%rcx)
+          cmpnexadd  %r10, %r9, 1016(%rcx)
 
-// CHECK: cmpnzxadd  %r10, %r9, -1024(%rdx)
+// CHECK: cmpnexadd  %r10, %r9, -1024(%rdx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnzxadd  %r10, %r9, -1024(%rdx)
+          cmpnexadd  %r10, %r9, -1024(%rdx)
 
 // CHECK: cmpoxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe0,0x8c,0xf5,0x00,0x00,0x00,0x10]
@@ -724,53 +724,53 @@
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe8,0x8a,0x00,0xfc,0xff,0xff]
           cmpsxadd  %r10, %r9, -1024(%rdx)
 
-// CHECK: cmpzxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+// CHECK: cmpexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe4,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpzxadd  %eax, %ecx, 268435456(%rbp,%r14,8)
+          cmpexadd  %eax, %ecx, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpzxadd  %eax, %ecx, 291(%r8,%rax,4)
+// CHECK: cmpexadd  %eax, %ecx, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe4,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpzxadd  %eax, %ecx, 291(%r8,%rax,4)
+          cmpexadd  %eax, %ecx, 291(%r8,%rax,4)
 
-// CHECK: cmpzxadd  %eax, %ecx, (%rip)
+// CHECK: cmpexadd  %eax, %ecx, (%rip)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x0d,0x00,0x00,0x00,0x00]
-          cmpzxadd  %eax, %ecx, (%rip)
+          cmpexadd  %eax, %ecx, (%rip)
 
-// CHECK: cmpzxadd  %eax, %ecx, -128(,%rbp,2)
+// CHECK: cmpexadd  %eax, %ecx, -128(,%rbp,2)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpzxadd  %eax, %ecx, -128(,%rbp,2)
+          cmpexadd  %eax, %ecx, -128(,%rbp,2)
 
-// CHECK: cmpzxadd  %eax, %ecx, 508(%rcx)
+// CHECK: cmpexadd  %eax, %ecx, 508(%rcx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x89,0xfc,0x01,0x00,0x00]
-          cmpzxadd  %eax, %ecx, 508(%rcx)
+          cmpexadd  %eax, %ecx, 508(%rcx)
 
-// CHECK: cmpzxadd  %eax, %ecx, -512(%rdx)
+// CHECK: cmpexadd  %eax, %ecx, -512(%rdx)
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x8a,0x00,0xfe,0xff,0xff]
-          cmpzxadd  %eax, %ecx, -512(%rdx)
+          cmpexadd  %eax, %ecx, -512(%rdx)
 
-// CHECK: cmpzxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+// CHECK: cmpexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe4,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpzxadd  %r10, %r9, 268435456(%rbp,%r14,8)
+          cmpexadd  %r10, %r9, 268435456(%rbp,%r14,8)
 
-// CHECK: cmpzxadd  %r10, %r9, 291(%r8,%rax,4)
+// CHECK: cmpexadd  %r10, %r9, 291(%r8,%rax,4)
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe4,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpzxadd  %r10, %r9, 291(%r8,%rax,4)
+          cmpexadd  %r10, %r9, 291(%r8,%rax,4)
 
-// CHECK: cmpzxadd  %r10, %r9, (%rip)
+// CHECK: cmpexadd  %r10, %r9, (%rip)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x0d,0x00,0x00,0x00,0x00]
-          cmpzxadd  %r10, %r9, (%rip)
+          cmpexadd  %r10, %r9, (%rip)
 
-// CHECK: cmpzxadd  %r10, %r9, -256(,%rbp,2)
+// CHECK: cmpexadd  %r10, %r9, -256(,%rbp,2)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpzxadd  %r10, %r9, -256(,%rbp,2)
+          cmpexadd  %r10, %r9, -256(,%rbp,2)
 
-// CHECK: cmpzxadd  %r10, %r9, 1016(%rcx)
+// CHECK: cmpexadd  %r10, %r9, 1016(%rcx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x89,0xf8,0x03,0x00,0x00]
-          cmpzxadd  %r10, %r9, 1016(%rcx)
+          cmpexadd  %r10, %r9, 1016(%rcx)
 
-// CHECK: cmpzxadd  %r10, %r9, -1024(%rdx)
+// CHECK: cmpexadd  %r10, %r9, -1024(%rdx)
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x8a,0x00,0xfc,0xff,0xff]
-          cmpzxadd  %r10, %r9, -1024(%rdx)
+          cmpexadd  %r10, %r9, -1024(%rdx)
 
 // CHECK: cmpbexadd  %ecx, %r8d, (%rip)
 // CHECK: encoding: [0xc4,0x62,0x71,0xe6,0x05,0x00,0x00,0x00,0x00]

--- a/llvm/test/MC/X86/cmpccxadd-intel-alias.s
+++ b/llvm/test/MC/X86/cmpccxadd-intel-alias.s
@@ -1,28 +1,28 @@
 // RUN: llvm-mc -triple x86_64 -x86-asm-syntax=intel -output-asm-variant=1 --show-encoding %s | FileCheck %s
 
-// CHECK: cmpnbxadd dword ptr [rip], ecx, eax
+// CHECK: cmpaexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0d,0x00,0x00,0x00,0x00]
-          cmpaexadd dword ptr [rip], ecx, eax
+          cmpnbxadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpzxadd dword ptr [rip], ecx, eax
+// CHECK: cmpexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x0d,0x00,0x00,0x00,0x00]
-          cmpexadd dword ptr [rip], ecx, eax
+          cmpzxadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnzxadd dword ptr [rip], ecx, eax
+// CHECK: cmpnexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x0d,0x00,0x00,0x00,0x00]
-          cmpnexadd dword ptr [rip], ecx, eax
+          cmpnzxadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnbexadd dword ptr [rip], ecx, eax
+// CHECK: cmpaxadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x0d,0x00,0x00,0x00,0x00]
-          cmpaxadd dword ptr [rip], ecx, eax
+          cmpnbexadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnlxadd dword ptr [rip], ecx, eax
+// CHECK: cmpgexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x0d,0x00,0x00,0x00,0x00]
-          cmpgexadd dword ptr [rip], ecx, eax
+          cmpnlxadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnlexadd dword ptr [rip], ecx, eax
+// CHECK: cmpgxadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x0d,0x00,0x00,0x00,0x00]
-          cmpgxadd dword ptr [rip], ecx, eax
+          cmpnlexadd dword ptr [rip], ecx, eax
 
 // CHECK: cmpbxadd  dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe2,0x0d,0x00,0x00,0x00,0x00]
@@ -32,7 +32,7 @@
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe2,0x0d,0x00,0x00,0x00,0x00]
           cmpnaexadd  dword ptr [rip], ecx, eax
 
-// CHECK: cmpnbxadd  dword ptr [rip], ecx, eax
+// CHECK: cmpaexadd  dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0d,0x00,0x00,0x00,0x00]
           cmpncxadd  dword ptr [rip], ecx, eax
 

--- a/llvm/test/MC/X86/cmpccxadd-intel.s
+++ b/llvm/test/MC/X86/cmpccxadd-intel.s
@@ -192,197 +192,197 @@
 // CHECK: encoding: [0xc4,0x62,0xa9,0xec,0x8a,0x00,0xfc,0xff,0xff]
           cmplxadd qword ptr [rdx - 1024], r9, r10
 
-// CHECK: cmpnbexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+// CHECK: cmpaxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe7,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+          cmpaxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 
-// CHECK: cmpnbexadd dword ptr [r8 + 4*rax + 291], ecx, eax
+// CHECK: cmpaxadd dword ptr [r8 + 4*rax + 291], ecx, eax
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe7,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbexadd dword ptr [r8 + 4*rax + 291], ecx, eax
+          cmpaxadd dword ptr [r8 + 4*rax + 291], ecx, eax
 
-// CHECK: cmpnbexadd dword ptr [rip], ecx, eax
+// CHECK: cmpaxadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbexadd dword ptr [rip], ecx, eax
+          cmpaxadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnbexadd dword ptr [2*rbp - 128], ecx, eax
+// CHECK: cmpaxadd dword ptr [2*rbp - 128], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnbexadd dword ptr [2*rbp - 128], ecx, eax
+          cmpaxadd dword ptr [2*rbp - 128], ecx, eax
 
-// CHECK: cmpnbexadd dword ptr [rcx + 508], ecx, eax
+// CHECK: cmpaxadd dword ptr [rcx + 508], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x89,0xfc,0x01,0x00,0x00]
-          cmpnbexadd dword ptr [rcx + 508], ecx, eax
+          cmpaxadd dword ptr [rcx + 508], ecx, eax
 
-// CHECK: cmpnbexadd dword ptr [rdx - 512], ecx, eax
+// CHECK: cmpaxadd dword ptr [rdx - 512], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe7,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnbexadd dword ptr [rdx - 512], ecx, eax
+          cmpaxadd dword ptr [rdx - 512], ecx, eax
 
-// CHECK: cmpnbexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+// CHECK: cmpaxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe7,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+          cmpaxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 
-// CHECK: cmpnbexadd qword ptr [r8 + 4*rax + 291], r9, r10
+// CHECK: cmpaxadd qword ptr [r8 + 4*rax + 291], r9, r10
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe7,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbexadd qword ptr [r8 + 4*rax + 291], r9, r10
+          cmpaxadd qword ptr [r8 + 4*rax + 291], r9, r10
 
-// CHECK: cmpnbexadd qword ptr [rip], r9, r10
+// CHECK: cmpaxadd qword ptr [rip], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbexadd qword ptr [rip], r9, r10
+          cmpaxadd qword ptr [rip], r9, r10
 
-// CHECK: cmpnbexadd qword ptr [2*rbp - 256], r9, r10
+// CHECK: cmpaxadd qword ptr [2*rbp - 256], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnbexadd qword ptr [2*rbp - 256], r9, r10
+          cmpaxadd qword ptr [2*rbp - 256], r9, r10
 
-// CHECK: cmpnbexadd qword ptr [rcx + 1016], r9, r10
+// CHECK: cmpaxadd qword ptr [rcx + 1016], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x89,0xf8,0x03,0x00,0x00]
-          cmpnbexadd qword ptr [rcx + 1016], r9, r10
+          cmpaxadd qword ptr [rcx + 1016], r9, r10
 
-// CHECK: cmpnbexadd qword ptr [rdx - 1024], r9, r10
+// CHECK: cmpaxadd qword ptr [rdx - 1024], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe7,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnbexadd qword ptr [rdx - 1024], r9, r10
+          cmpaxadd qword ptr [rdx - 1024], r9, r10
 
-// CHECK: cmpnbxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+// CHECK: cmpaexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe3,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+          cmpaexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 
-// CHECK: cmpnbxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+// CHECK: cmpaexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe3,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+          cmpaexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 
-// CHECK: cmpnbxadd dword ptr [rip], ecx, eax
+// CHECK: cmpaexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbxadd dword ptr [rip], ecx, eax
+          cmpaexadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnbxadd dword ptr [2*rbp - 128], ecx, eax
+// CHECK: cmpaexadd dword ptr [2*rbp - 128], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnbxadd dword ptr [2*rbp - 128], ecx, eax
+          cmpaexadd dword ptr [2*rbp - 128], ecx, eax
 
-// CHECK: cmpnbxadd dword ptr [rcx + 508], ecx, eax
+// CHECK: cmpaexadd dword ptr [rcx + 508], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x89,0xfc,0x01,0x00,0x00]
-          cmpnbxadd dword ptr [rcx + 508], ecx, eax
+          cmpaexadd dword ptr [rcx + 508], ecx, eax
 
-// CHECK: cmpnbxadd dword ptr [rdx - 512], ecx, eax
+// CHECK: cmpaexadd dword ptr [rdx - 512], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe3,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnbxadd dword ptr [rdx - 512], ecx, eax
+          cmpaexadd dword ptr [rdx - 512], ecx, eax
 
-// CHECK: cmpnbxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+// CHECK: cmpaexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe3,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnbxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+          cmpaexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 
-// CHECK: cmpnbxadd qword ptr [r8 + 4*rax + 291], r9, r10
+// CHECK: cmpaexadd qword ptr [r8 + 4*rax + 291], r9, r10
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe3,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnbxadd qword ptr [r8 + 4*rax + 291], r9, r10
+          cmpaexadd qword ptr [r8 + 4*rax + 291], r9, r10
 
-// CHECK: cmpnbxadd qword ptr [rip], r9, r10
+// CHECK: cmpaexadd qword ptr [rip], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x0d,0x00,0x00,0x00,0x00]
-          cmpnbxadd qword ptr [rip], r9, r10
+          cmpaexadd qword ptr [rip], r9, r10
 
-// CHECK: cmpnbxadd qword ptr [2*rbp - 256], r9, r10
+// CHECK: cmpaexadd qword ptr [2*rbp - 256], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnbxadd qword ptr [2*rbp - 256], r9, r10
+          cmpaexadd qword ptr [2*rbp - 256], r9, r10
 
-// CHECK: cmpnbxadd qword ptr [rcx + 1016], r9, r10
+// CHECK: cmpaexadd qword ptr [rcx + 1016], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x89,0xf8,0x03,0x00,0x00]
-          cmpnbxadd qword ptr [rcx + 1016], r9, r10
+          cmpaexadd qword ptr [rcx + 1016], r9, r10
 
-// CHECK: cmpnbxadd qword ptr [rdx - 1024], r9, r10
+// CHECK: cmpaexadd qword ptr [rdx - 1024], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe3,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnbxadd qword ptr [rdx - 1024], r9, r10
+          cmpaexadd qword ptr [rdx - 1024], r9, r10
 
-// CHECK: cmpnlexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+// CHECK: cmpgxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xef,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+          cmpgxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 
-// CHECK: cmpnlexadd dword ptr [r8 + 4*rax + 291], ecx, eax
+// CHECK: cmpgxadd dword ptr [r8 + 4*rax + 291], ecx, eax
 // CHECK: encoding: [0xc4,0xc2,0x79,0xef,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlexadd dword ptr [r8 + 4*rax + 291], ecx, eax
+          cmpgxadd dword ptr [r8 + 4*rax + 291], ecx, eax
 
-// CHECK: cmpnlexadd dword ptr [rip], ecx, eax
+// CHECK: cmpgxadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlexadd dword ptr [rip], ecx, eax
+          cmpgxadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnlexadd dword ptr [2*rbp - 128], ecx, eax
+// CHECK: cmpgxadd dword ptr [2*rbp - 128], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnlexadd dword ptr [2*rbp - 128], ecx, eax
+          cmpgxadd dword ptr [2*rbp - 128], ecx, eax
 
-// CHECK: cmpnlexadd dword ptr [rcx + 508], ecx, eax
+// CHECK: cmpgxadd dword ptr [rcx + 508], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x89,0xfc,0x01,0x00,0x00]
-          cmpnlexadd dword ptr [rcx + 508], ecx, eax
+          cmpgxadd dword ptr [rcx + 508], ecx, eax
 
-// CHECK: cmpnlexadd dword ptr [rdx - 512], ecx, eax
+// CHECK: cmpgxadd dword ptr [rdx - 512], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xef,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnlexadd dword ptr [rdx - 512], ecx, eax
+          cmpgxadd dword ptr [rdx - 512], ecx, eax
 
-// CHECK: cmpnlexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+// CHECK: cmpgxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 // CHECK: encoding: [0xc4,0x22,0xa9,0xef,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+          cmpgxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 
-// CHECK: cmpnlexadd qword ptr [r8 + 4*rax + 291], r9, r10
+// CHECK: cmpgxadd qword ptr [r8 + 4*rax + 291], r9, r10
 // CHECK: encoding: [0xc4,0x42,0xa9,0xef,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlexadd qword ptr [r8 + 4*rax + 291], r9, r10
+          cmpgxadd qword ptr [r8 + 4*rax + 291], r9, r10
 
-// CHECK: cmpnlexadd qword ptr [rip], r9, r10
+// CHECK: cmpgxadd qword ptr [rip], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlexadd qword ptr [rip], r9, r10
+          cmpgxadd qword ptr [rip], r9, r10
 
-// CHECK: cmpnlexadd qword ptr [2*rbp - 256], r9, r10
+// CHECK: cmpgxadd qword ptr [2*rbp - 256], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnlexadd qword ptr [2*rbp - 256], r9, r10
+          cmpgxadd qword ptr [2*rbp - 256], r9, r10
 
-// CHECK: cmpnlexadd qword ptr [rcx + 1016], r9, r10
+// CHECK: cmpgxadd qword ptr [rcx + 1016], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x89,0xf8,0x03,0x00,0x00]
-          cmpnlexadd qword ptr [rcx + 1016], r9, r10
+          cmpgxadd qword ptr [rcx + 1016], r9, r10
 
-// CHECK: cmpnlexadd qword ptr [rdx - 1024], r9, r10
+// CHECK: cmpgxadd qword ptr [rdx - 1024], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xef,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnlexadd qword ptr [rdx - 1024], r9, r10
+          cmpgxadd qword ptr [rdx - 1024], r9, r10
 
-// CHECK: cmpnlxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+// CHECK: cmpgexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xed,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+          cmpgexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 
-// CHECK: cmpnlxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+// CHECK: cmpgexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 // CHECK: encoding: [0xc4,0xc2,0x79,0xed,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+          cmpgexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 
-// CHECK: cmpnlxadd dword ptr [rip], ecx, eax
+// CHECK: cmpgexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlxadd dword ptr [rip], ecx, eax
+          cmpgexadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnlxadd dword ptr [2*rbp - 128], ecx, eax
+// CHECK: cmpgexadd dword ptr [2*rbp - 128], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnlxadd dword ptr [2*rbp - 128], ecx, eax
+          cmpgexadd dword ptr [2*rbp - 128], ecx, eax
 
-// CHECK: cmpnlxadd dword ptr [rcx + 508], ecx, eax
+// CHECK: cmpgexadd dword ptr [rcx + 508], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x89,0xfc,0x01,0x00,0x00]
-          cmpnlxadd dword ptr [rcx + 508], ecx, eax
+          cmpgexadd dword ptr [rcx + 508], ecx, eax
 
-// CHECK: cmpnlxadd dword ptr [rdx - 512], ecx, eax
+// CHECK: cmpgexadd dword ptr [rdx - 512], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xed,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnlxadd dword ptr [rdx - 512], ecx, eax
+          cmpgexadd dword ptr [rdx - 512], ecx, eax
 
-// CHECK: cmpnlxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+// CHECK: cmpgexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 // CHECK: encoding: [0xc4,0x22,0xa9,0xed,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnlxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+          cmpgexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 
-// CHECK: cmpnlxadd qword ptr [r8 + 4*rax + 291], r9, r10
+// CHECK: cmpgexadd qword ptr [r8 + 4*rax + 291], r9, r10
 // CHECK: encoding: [0xc4,0x42,0xa9,0xed,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnlxadd qword ptr [r8 + 4*rax + 291], r9, r10
+          cmpgexadd qword ptr [r8 + 4*rax + 291], r9, r10
 
-// CHECK: cmpnlxadd qword ptr [rip], r9, r10
+// CHECK: cmpgexadd qword ptr [rip], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x0d,0x00,0x00,0x00,0x00]
-          cmpnlxadd qword ptr [rip], r9, r10
+          cmpgexadd qword ptr [rip], r9, r10
 
-// CHECK: cmpnlxadd qword ptr [2*rbp - 256], r9, r10
+// CHECK: cmpgexadd qword ptr [2*rbp - 256], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnlxadd qword ptr [2*rbp - 256], r9, r10
+          cmpgexadd qword ptr [2*rbp - 256], r9, r10
 
-// CHECK: cmpnlxadd qword ptr [rcx + 1016], r9, r10
+// CHECK: cmpgexadd qword ptr [rcx + 1016], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x89,0xf8,0x03,0x00,0x00]
-          cmpnlxadd qword ptr [rcx + 1016], r9, r10
+          cmpgexadd qword ptr [rcx + 1016], r9, r10
 
-// CHECK: cmpnlxadd qword ptr [rdx - 1024], r9, r10
+// CHECK: cmpgexadd qword ptr [rdx - 1024], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xed,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnlxadd qword ptr [rdx - 1024], r9, r10
+          cmpgexadd qword ptr [rdx - 1024], r9, r10
 
 // CHECK: cmpnoxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe1,0x8c,0xf5,0x00,0x00,0x00,0x10]
@@ -528,53 +528,53 @@
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe9,0x8a,0x00,0xfc,0xff,0xff]
           cmpnsxadd qword ptr [rdx - 1024], r9, r10
 
-// CHECK: cmpnzxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+// CHECK: cmpnexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe5,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnzxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+          cmpnexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 
-// CHECK: cmpnzxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+// CHECK: cmpnexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe5,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnzxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+          cmpnexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 
-// CHECK: cmpnzxadd dword ptr [rip], ecx, eax
+// CHECK: cmpnexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x0d,0x00,0x00,0x00,0x00]
-          cmpnzxadd dword ptr [rip], ecx, eax
+          cmpnexadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpnzxadd dword ptr [2*rbp - 128], ecx, eax
+// CHECK: cmpnexadd dword ptr [2*rbp - 128], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpnzxadd dword ptr [2*rbp - 128], ecx, eax
+          cmpnexadd dword ptr [2*rbp - 128], ecx, eax
 
-// CHECK: cmpnzxadd dword ptr [rcx + 508], ecx, eax
+// CHECK: cmpnexadd dword ptr [rcx + 508], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x89,0xfc,0x01,0x00,0x00]
-          cmpnzxadd dword ptr [rcx + 508], ecx, eax
+          cmpnexadd dword ptr [rcx + 508], ecx, eax
 
-// CHECK: cmpnzxadd dword ptr [rdx - 512], ecx, eax
+// CHECK: cmpnexadd dword ptr [rdx - 512], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe5,0x8a,0x00,0xfe,0xff,0xff]
-          cmpnzxadd dword ptr [rdx - 512], ecx, eax
+          cmpnexadd dword ptr [rdx - 512], ecx, eax
 
-// CHECK: cmpnzxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+// CHECK: cmpnexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe5,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpnzxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+          cmpnexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 
-// CHECK: cmpnzxadd qword ptr [r8 + 4*rax + 291], r9, r10
+// CHECK: cmpnexadd qword ptr [r8 + 4*rax + 291], r9, r10
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe5,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpnzxadd qword ptr [r8 + 4*rax + 291], r9, r10
+          cmpnexadd qword ptr [r8 + 4*rax + 291], r9, r10
 
-// CHECK: cmpnzxadd qword ptr [rip], r9, r10
+// CHECK: cmpnexadd qword ptr [rip], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x0d,0x00,0x00,0x00,0x00]
-          cmpnzxadd qword ptr [rip], r9, r10
+          cmpnexadd qword ptr [rip], r9, r10
 
-// CHECK: cmpnzxadd qword ptr [2*rbp - 256], r9, r10
+// CHECK: cmpnexadd qword ptr [2*rbp - 256], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpnzxadd qword ptr [2*rbp - 256], r9, r10
+          cmpnexadd qword ptr [2*rbp - 256], r9, r10
 
-// CHECK: cmpnzxadd qword ptr [rcx + 1016], r9, r10
+// CHECK: cmpnexadd qword ptr [rcx + 1016], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x89,0xf8,0x03,0x00,0x00]
-          cmpnzxadd qword ptr [rcx + 1016], r9, r10
+          cmpnexadd qword ptr [rcx + 1016], r9, r10
 
-// CHECK: cmpnzxadd qword ptr [rdx - 1024], r9, r10
+// CHECK: cmpnexadd qword ptr [rdx - 1024], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe5,0x8a,0x00,0xfc,0xff,0xff]
-          cmpnzxadd qword ptr [rdx - 1024], r9, r10
+          cmpnexadd qword ptr [rdx - 1024], r9, r10
 
 // CHECK: cmpoxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe0,0x8c,0xf5,0x00,0x00,0x00,0x10]
@@ -720,53 +720,53 @@
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe8,0x8a,0x00,0xfc,0xff,0xff]
           cmpsxadd qword ptr [rdx - 1024], r9, r10
 
-// CHECK: cmpzxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+// CHECK: cmpexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 // CHECK: encoding: [0xc4,0xa2,0x79,0xe4,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpzxadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
+          cmpexadd dword ptr [rbp + 8*r14 + 268435456], ecx, eax
 
-// CHECK: cmpzxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+// CHECK: cmpexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 // CHECK: encoding: [0xc4,0xc2,0x79,0xe4,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpzxadd dword ptr [r8 + 4*rax + 291], ecx, eax
+          cmpexadd dword ptr [r8 + 4*rax + 291], ecx, eax
 
-// CHECK: cmpzxadd dword ptr [rip], ecx, eax
+// CHECK: cmpexadd dword ptr [rip], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x0d,0x00,0x00,0x00,0x00]
-          cmpzxadd dword ptr [rip], ecx, eax
+          cmpexadd dword ptr [rip], ecx, eax
 
-// CHECK: cmpzxadd dword ptr [2*rbp - 128], ecx, eax
+// CHECK: cmpexadd dword ptr [2*rbp - 128], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x0c,0x6d,0x80,0xff,0xff,0xff]
-          cmpzxadd dword ptr [2*rbp - 128], ecx, eax
+          cmpexadd dword ptr [2*rbp - 128], ecx, eax
 
-// CHECK: cmpzxadd dword ptr [rcx + 508], ecx, eax
+// CHECK: cmpexadd dword ptr [rcx + 508], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x89,0xfc,0x01,0x00,0x00]
-          cmpzxadd dword ptr [rcx + 508], ecx, eax
+          cmpexadd dword ptr [rcx + 508], ecx, eax
 
-// CHECK: cmpzxadd dword ptr [rdx - 512], ecx, eax
+// CHECK: cmpexadd dword ptr [rdx - 512], ecx, eax
 // CHECK: encoding: [0xc4,0xe2,0x79,0xe4,0x8a,0x00,0xfe,0xff,0xff]
-          cmpzxadd dword ptr [rdx - 512], ecx, eax
+          cmpexadd dword ptr [rdx - 512], ecx, eax
 
-// CHECK: cmpzxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+// CHECK: cmpexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 // CHECK: encoding: [0xc4,0x22,0xa9,0xe4,0x8c,0xf5,0x00,0x00,0x00,0x10]
-          cmpzxadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
+          cmpexadd qword ptr [rbp + 8*r14 + 268435456], r9, r10
 
-// CHECK: cmpzxadd qword ptr [r8 + 4*rax + 291], r9, r10
+// CHECK: cmpexadd qword ptr [r8 + 4*rax + 291], r9, r10
 // CHECK: encoding: [0xc4,0x42,0xa9,0xe4,0x8c,0x80,0x23,0x01,0x00,0x00]
-          cmpzxadd qword ptr [r8 + 4*rax + 291], r9, r10
+          cmpexadd qword ptr [r8 + 4*rax + 291], r9, r10
 
-// CHECK: cmpzxadd qword ptr [rip], r9, r10
+// CHECK: cmpexadd qword ptr [rip], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x0d,0x00,0x00,0x00,0x00]
-          cmpzxadd qword ptr [rip], r9, r10
+          cmpexadd qword ptr [rip], r9, r10
 
-// CHECK: cmpzxadd qword ptr [2*rbp - 256], r9, r10
+// CHECK: cmpexadd qword ptr [2*rbp - 256], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x0c,0x6d,0x00,0xff,0xff,0xff]
-          cmpzxadd qword ptr [2*rbp - 256], r9, r10
+          cmpexadd qword ptr [2*rbp - 256], r9, r10
 
-// CHECK: cmpzxadd qword ptr [rcx + 1016], r9, r10
+// CHECK: cmpexadd qword ptr [rcx + 1016], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x89,0xf8,0x03,0x00,0x00]
-          cmpzxadd qword ptr [rcx + 1016], r9, r10
+          cmpexadd qword ptr [rcx + 1016], r9, r10
 
-// CHECK: cmpzxadd qword ptr [rdx - 1024], r9, r10
+// CHECK: cmpexadd qword ptr [rdx - 1024], r9, r10
 // CHECK: encoding: [0xc4,0x62,0xa9,0xe4,0x8a,0x00,0xfc,0xff,0xff]
-          cmpzxadd qword ptr [rdx - 1024], r9, r10
+          cmpexadd qword ptr [rdx - 1024], r9, r10
 
 // CHECK: cmpbexadd dword ptr [rip], r8d, ecx
 // CHECK: encoding: [0xc4,0x62,0x71,0xe6,0x05,0x00,0x00,0x00,0x00]


### PR DESCRIPTION
To align with gas's latest changes.
relate gas patch: https://sourceware.org/pipermail/binutils/2024-May/134360.html
