### PR TITLE
[libcxx][test] Add feature for platforms where long double is double

### DIFF
--- a/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
+++ b/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17, long-double-is-double
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// XFAIL: long-double-is-double
 
 // <compare>
 

--- a/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
+++ b/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
@@ -6,22 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
-// The following platforms have sizeof(long double) == sizeof(double), so this test doesn't apply to them.
-// This test does apply to aarch64 where Arm's AAPCS64 is followed. There they are different sizes.
-// XFAIL: target={{arm64|arm64e|armv(7|8)(l|m)?|powerpc|powerpc64}}-{{.+}}
-
-// MSVC configurations have long double equal to regular double on all
-// architectures.
-// XFAIL: target={{.+}}-pc-windows-msvc
-
-// ARM/AArch64 MinGW also has got long double equal to regular double, just
-// like MSVC (thus match both MinGW and MSVC here, for those architectures).
-// XFAIL: target={{aarch64|armv7}}-{{.*}}-windows-{{.+}}
-
-// Android's 32-bit x86 target has long double equal to regular double.
-// XFAIL: target=i686-{{.+}}-android{{.*}}
+// UNSUPPORTED: c++03, c++11, c++14, c++17, long-double-is-double
 
 // <compare>
 

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -227,6 +227,18 @@ DEFAULT_FEATURES = [
           """,
         ),
     ),
+    Feature(
+        name="long-double-is-double",
+        when=lambda cfg: sourceBuilds(
+            cfg,
+            """
+            int main(int, char**) {
+              static_assert(sizeof(long double) == sizeof(double));
+              return 0;
+            }
+          """,
+        ),
+    ),
     # Check for a Windows UCRT bug (fixed in UCRT/Windows 10.0.20348.0):
     # https://developercommunity.visualstudio.com/t/utf-8-locales-break-ctype-functions-for-wchar-type/1653678
     Feature(


### PR DESCRIPTION
Instead of having to match a whole bunch of different target names.