### PR TITLE
[Flang]: Use actual endianness for Integer<80>

### DIFF
--- a/flang/include/flang/Evaluate/integer.h
+++ b/flang/include/flang/Evaluate/integer.h
@@ -1056,8 +1056,9 @@ extern template class Integer<16>;
 extern template class Integer<32>;
 extern template class Integer<64>;
 using X87IntegerContainer =
-    Integer<80, true, 16, std::uint16_t, std::uint32_t, 128>;
-extern template class Integer<80, true, 16, std::uint16_t, std::uint32_t, 128>;
+    Integer<80, isHostLittleEndian, 16, std::uint16_t, std::uint32_t, 128>;
+extern template class Integer<80, isHostLittleEndian, 16, std::uint16_t,
+    std::uint32_t, 128>;
 extern template class Integer<128>;
 } // namespace Fortran::evaluate::value
 #endif // FORTRAN_EVALUATE_INTEGER_H_

--- a/flang/lib/Evaluate/integer.cpp
+++ b/flang/lib/Evaluate/integer.cpp
@@ -14,7 +14,8 @@ template class Integer<8>;
 template class Integer<16>;
 template class Integer<32>;
 template class Integer<64>;
-template class Integer<80, true, 16, std::uint16_t, std::uint32_t, 128>;
+template class Integer<80, isHostLittleEndian, 16, std::uint16_t, std::uint32_t,
+    128>;
 template class Integer<128>;
 
 // Sanity checks against misconfiguration bugs


### PR DESCRIPTION
This PR is to use the actual endianness of the platform when instantiate Integer<80> so that AIX (big-endian) will not get confused.