### PR TITLE
[libcxx][test] Disable large_tests for picolib builds

### DIFF
--- a/libcxx/cmake/caches/Armv7M-picolibc.cmake
+++ b/libcxx/cmake/caches/Armv7M-picolibc.cmake
@@ -30,7 +30,8 @@ set(LIBCXX_ENABLE_THREADS OFF CACHE BOOL "")
 set(LIBCXX_ENABLE_WIDE_CHARACTERS OFF CACHE BOOL "")
 set(LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
 # Long tests are prohibitively slow when run via emulation.
-set(LIBCXX_TEST_PARAMS "long_tests=False" CACHE STRING "")
+# Large tests won't fit in the memory of the emulated machine.
+set(LIBCXX_TEST_PARAMS "long_tests=False;large_tests=False" CACHE STRING "")
 set(LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
 set(LIBUNWIND_ENABLE_SHARED OFF CACHE BOOL "")
 set(LIBUNWIND_ENABLE_STATIC ON CACHE BOOL "")

--- a/libcxx/test/std/experimental/simd/simd.reference/reference_assignment.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.reference/reference_assignment.pass.cpp
@@ -8,8 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-// The machine emulated in tests does not have enough memory for code.
-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+// REQUIRES: large_tests
 
 // <experimental/simd>
 //


### PR DESCRIPTION
We had a few xfails due to memory limitations, so we should use the existing large_tests feature instead, and disable it for picolib runs.

There is one existing test, stringstream.members/gcount.pass.cpp, which requires large_tests. However it is also unsupported on 32 bit platforms, so we don't lose any coverage there.