### PR TITLE
Reapply "[HWASan] symbolize stack overflows" (#102951)

### DIFF
--- a/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
+++ b/compiler-rt/lib/hwasan/scripts/hwasan_symbolize
@@ -109,6 +109,10 @@ class Symbolizer:
     self.__html = False
     self.__last_access_address = None
     self.__last_access_tag = None
+    self.__tag_dump = []
+    self.__tag_dump_match_idx = None
+    self.__matched_stack_uas = False
+    self.__offsets = []
 
   def enable_html(self, enable):
     self.__html = enable
@@ -311,6 +315,34 @@ class Symbolizer:
     if match:
       self.__last_access_tag = int(match.group(2), 16)
 
+  def process_tag_dump_line(self, line, ignore_tags=False):
+    m = re.match(r'.*?(0x[0-9a-f]+):' + '([ ]*[\[ ][0-9a-f][0-9a-f]\]?)' * 16, line)
+    if m is None:
+      return False
+    addr = m.group(1)
+    tags = m.group(*range(2, 18))
+    fault = [i for i, x in enumerate(tags) if '[' in x]
+    if fault:
+      self.__tag_dump_match_idx = len(self.__tag_dump) + fault[0]
+    self.__tag_dump.extend(int(x.strip(' [').rstrip('] '), 16) for x in tags)
+    return True
+
+  def finish_tag_dump(self):
+    if self.__matched_stack_uas or self.__tag_dump_match_idx is None:
+      return
+    for offset, size, local in sorted(self.__offsets, key=lambda x: abs(x[0])):
+      idx = self.__tag_dump_match_idx - offset // 16
+      if idx < 0 or idx > len(self.__tag_dump):
+        continue
+      if self.__tag_dump[idx] == self.__last_access_tag:
+        self.print('')
+        self.print('Potentially referenced stack object:')
+        if offset > 0:
+          self.print('  %d bytes after a variable "%s" in stack frame of function "%s"' % (offset - size, local[2], local[0]))
+        if offset < 0:
+          self.print('  %d bytes before a variable "%s" in stack frame of function "%s"' % (-offset, local[2], local[0]))
+        self.print('  at %s' % (local[1],))
+
   def process_stack_history(self, line, ignore_tags=False):
     if self.__last_access_address is None or self.__last_access_tag is None:
       return
@@ -336,16 +368,18 @@ class Symbolizer:
         size = local[4]
         if frame_offset is None or size is None:
           continue
-        obj_offset = (self.__last_access_address - fp - frame_offset) & fp_mask
-        if obj_offset >= size:
-          continue
+        obj_offset = (self.__last_access_address & fp_mask) - ((fp & fp_mask) + frame_offset)
         tag_offset = local[5]
         if not ignore_tags and (tag_offset is None or base_tag ^ tag_offset != self.__last_access_tag):
+          continue
+        if obj_offset < 0 or obj_offset >= size:
+          self.__offsets.append((obj_offset, size, local))
           continue
         self.print('')
         self.print('Potentially referenced stack object:')
         self.print('  %d bytes inside a variable "%s" in stack frame of function "%s"' % (obj_offset, local[2], local[0]))
         self.print('  at %s' % (local[1],))
+        self.__matched_stack_uas = True
       return True
     return False
 
@@ -456,9 +490,18 @@ def main():
       sys.exit(1)
     symbolizer.read_linkify(args.linkify)
 
+  tag_dump = False
   for line in sys.stdin:
     if sys.version_info.major < 3:
       line = line.decode('utf-8')
+    if tag_dump:
+      tag_dump = symbolizer.process_tag_dump_line(line)
+      if tag_dump:
+        continue
+      symbolizer.finish_tag_dump()
+    if 'Memory tags around the buggy address' in line:
+      tag_dump = True
+
     symbolizer.save_access_address(line)
     if symbolizer.process_stack_history(line, ignore_tags=args.ignore_tags):
       continue

--- a/compiler-rt/test/hwasan/TestCases/hwasan_symbolize_stack_overflow.cpp
+++ b/compiler-rt/test/hwasan/TestCases/hwasan_symbolize_stack_overflow.cpp
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t; mkdir %t
+// RUN: %clang_hwasan -Wl,--build-id -g %s -o %t/hwasan_overflow
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_overflow 16 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s --check-prefixes=CHECK,AFTER0
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_overflow 17 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s --check-prefixes=CHECK,AFTER1
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_overflow -1 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s --check-prefixes=CHECK,BEFORE1
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_overflow -17 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s --check-prefixes=CHECK,BEFORE17
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_overflow 1016 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s --check-prefixes=CHECK,AFTER1000
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_overflow -1000 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s --check-prefixes=CHECK,BEFORE1000
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_overflow 1000000 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s --check-prefixes=TOOFAR
+
+// REQUIRES: aarch64-target-arch
+
+#include <stdlib.h>
+
+static volatile char sink;
+
+int main(int argc, char **argv) {
+  volatile char x[16];
+  sink = x[atoi(argv[1])];
+  // TOOFAR-NOT: Potentially referenced stack object:
+  // CHECK: Potentially referenced stack object:
+  // AFTER0:   0 bytes after a variable "x" in stack frame of function "main"
+  // AFTER1:   1 bytes after a variable "x" in stack frame of function "main"
+  // BEFORE1:   1 bytes before a variable "x" in stack frame of function "main"
+  // BEFORE17:   17 bytes before a variable "x" in stack frame of function "main"
+  // BEFORE1000:   1000 bytes before a variable "x" in stack frame of function "main"
+  // AFTER1000:   1000 bytes after a variable "x" in stack frame of function "main"
+  // CHECK:   at {{.*}}hwasan_symbolize_stack_overflow.cpp:[[@LINE-10]]
+  return 0;
+}


### PR DESCRIPTION
This reverts commit d4f6fcf5aaa0911a91317c0b06779f13077d6b58.

Relanding with fixed obj_offset calculation (precedence of operations was wrong),
and the suggestion in https://github.com/llvm/llvm-project/pull/95308#discussion_r1714317539