### PR TITLE
[clang][driver] Fix -print-target-triple OS version for apple targets

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2271,8 +2271,7 @@ bool Driver::HandleImmediateArgs(Compilation &C) {
     return false;
   }
 
-  if (C.getArgs().hasArg(options::OPT_print_libgcc_file_name)) {
-    ToolChain::RuntimeLibType RLT = TC.GetRuntimeLibType(C.getArgs());
+  auto initializeTargets = [&]() {
     const llvm::Triple Triple(TC.ComputeEffectiveClangTriple(C.getArgs()));
     // The 'Darwin' toolchain is initialized only when its arguments are
     // computed. Get the default arguments for OFK_None to ensure that
@@ -2282,6 +2281,12 @@ bool Driver::HandleImmediateArgs(Compilation &C) {
     // FIXME: For some more esoteric targets the default toolchain is not the
     //        correct one.
     C.getArgsForToolChain(&TC, Triple.getArchName(), Action::OFK_None);
+    return Triple;
+  };
+
+  if (C.getArgs().hasArg(options::OPT_print_libgcc_file_name)) {
+    ToolChain::RuntimeLibType RLT = TC.GetRuntimeLibType(C.getArgs());
+    const llvm::Triple Triple = initializeTargets();
     RegisterEffectiveTriple TripleRAII(TC, Triple);
     switch (RLT) {
     case ToolChain::RLT_CompilerRT:
@@ -2325,7 +2330,9 @@ bool Driver::HandleImmediateArgs(Compilation &C) {
   }
 
   if (C.getArgs().hasArg(options::OPT_print_target_triple)) {
-    llvm::outs() << TC.getTripleString() << "\n";
+    initializeTargets();
+    llvm::Triple Triple(TC.ComputeEffectiveClangTriple(C.getArgs()));
+    llvm::outs() << Triple.getTriple() << "\n";
     return false;
   }
 

--- a/clang/test/Driver/darwin-print-target-triple.c
+++ b/clang/test/Driver/darwin-print-target-triple.c
@@ -1,0 +1,42 @@
+// Test the output of -print-target-triple on Darwin.
+// See https://github.com/llvm/llvm-project/issues/61762
+
+//
+// All platforms
+//
+
+// RUN: %clang -print-target-triple \
+// RUN:     --target=x86_64-apple-macos -mmacos-version-min=15 \
+// RUN:     -resource-dir=%S/Inputs/resource_dir 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-MACOS %s
+// CHECK-CLANGRT-MACOS: x86_64-apple-macosx15.0.0
+
+// RUN: %clang -print-target-triple \
+// RUN:     --target=arm64-apple-ios -mios-version-min=9 \
+// RUN:     -resource-dir=%S/Inputs/resource_dir 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-IOS %s
+// CHECK-CLANGRT-IOS: arm64-apple-ios9.0.0
+
+// RUN: %clang -print-target-triple \
+// RUN:     --target=arm64-apple-watchos -mwatchos-version-min=3 \
+// RUN:     -resource-dir=%S/Inputs/resource_dir 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-WATCHOS %s
+// CHECK-CLANGRT-WATCHOS: arm64-apple-watchos3.0.0
+
+// RUN: %clang -print-target-triple \
+// RUN:     --target=armv7k-apple-watchos -mwatchos-version-min=3 \
+// RUN:     -resource-dir=%S/Inputs/resource_dir 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-WATCHOS-ARMV7K %s
+// CHECK-CLANGRT-WATCHOS-ARMV7K: thumbv7-apple-watchos3.0.0
+
+// RUN: %clang -print-target-triple \
+// RUN:     --target=arm64-apple-tvos -mtvos-version-min=1\
+// RUN:     -resource-dir=%S/Inputs/resource_dir 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-TVOS %s
+// CHECK-CLANGRT-TVOS: arm64-apple-tvos1.0.0
+
+// RUN: %clang -print-target-triple \
+// RUN:     --target=arm64-apple-driverkit \
+// RUN:     -resource-dir=%S/Inputs/resource_dir 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-DRIVERKIT %s
+// CHECK-CLANGRT-DRIVERKIT: arm64-apple-driverkit19.0.0


### PR DESCRIPTION
The target needs to be initialized in order to compute the correct target triple from the command line. Without initialized targets the OS component of the triple might not reflect what would be computed by the driver for an actual compiler invocation.

Fixes https://github.com/llvm/llvm-project/issues/61762