### PR TITLE
[HLSL] update default validator version to 1.8.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8836,7 +8836,7 @@ def dxil_validator_version : Option<["/", "-"], "validator-version", KIND_SEPARA
   Visibility<[DXCOption, ClangOption, CC1Option]>,
   HelpText<"Override validator version for module. Format: <major.minor>;"
            "Default: DXIL.dll version or current internal version">,
-  MarshallingInfoString<TargetOpts<"DxilValidatorVersion">>;
+  MarshallingInfoString<TargetOpts<"DxilValidatorVersion">, "\"1.8\"">;
 def target_profile : DXCJoinedOrSeparate<"T">, MetaVarName<"<profile>">,
   HelpText<"Set target profile">,
   Values<"ps_6_0, ps_6_1, ps_6_2, ps_6_3, ps_6_4, ps_6_5, ps_6_6, ps_6_7,"

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -283,14 +283,6 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     DAL->append(A);
   }
 
-  // Add default validator version if not set.
-  // TODO: remove this once read validator version from validator.
-  if (!DAL->hasArg(options::OPT_dxil_validator_version)) {
-    const StringRef DefaultValidatorVer = "1.7";
-    DAL->AddSeparateArg(nullptr,
-                        Opts.getOption(options::OPT_dxil_validator_version),
-                        DefaultValidatorVer);
-  }
   if (!DAL->hasArg(options::OPT_O_Group)) {
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_O), "3");
   }

--- a/clang/test/CodeGenHLSL/default_validator_version.hlsl
+++ b/clang/test/CodeGenHLSL/default_validator_version.hlsl
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -xhlsl -o - %s | FileCheck %s
+
+// CHECK:!dx.valver = !{![[valver:[0-9]+]]}
+// CHECK:![[valver]] = !{i32 1, i32 8}
+
+float bar(float a, float b);
+
+float foo(float a, float b) {
+  return bar(a, b);
+}


### PR DESCRIPTION
Change default validator version to 1.8 in Options.td. 
Remove the default value set in HLSL.cpp.

Fixes #102963

This also helps #99910.