### PR TITLE
[Clang] Fix 'nvlink-wrapper' not ignoring `-plugin` like lld does

### DIFF
--- a/clang/test/Driver/nvlink-wrapper.c
+++ b/clang/test/Driver/nvlink-wrapper.c
@@ -78,3 +78,10 @@ int baz() { return y + x; }
 // RUN:   --lto-debug-pass-manager --lto-newpm-passes=forceattrs \
 // RUN:   -arch sm_52 -o a.out 2>&1 | FileCheck %s --check-prefix=PASSES
 // PASSES: Running pass: ForceFunctionAttrsPass
+
+//
+// Check that '-plugin` is ingored like in `ld.lld`
+//
+// RUN: clang-nvlink-wrapper --dry-run %t.o -plugin -arch sm_52 -o a.out \
+// RUN:   2>&1 | FileCheck %s --check-prefix=PLUGIN
+// PLUGIN-NOT: -plugin

--- a/clang/tools/clang-nvlink-wrapper/NVLinkOpts.td
+++ b/clang/tools/clang-nvlink-wrapper/NVLinkOpts.td
@@ -39,6 +39,9 @@ def library_S : Separate<["--", "-"], "library">, Flags<[HelpHidden]>,
 def library_EQ : Joined<["--", "-"], "library=">, Flags<[HelpHidden]>,
   Alias<library_path>;
 
+def plugin : Joined<["--", "-"], "plugin">, 
+  Flags<[HelpHidden, WrapperOnlyOption]>;
+
 def arch : Separate<["--", "-"], "arch">,
   HelpText<"Specify the 'sm_' name of the target architecture.">;
 def : Joined<["--", "-"], "plugin-opt=mcpu=">,


### PR DESCRIPTION
Summary:
This caused issues with
https://gitlab.e4s.io/uo-public/llvm-openmp-offloading/-/jobs/301520
because adding `-flto` caused it to pass `-plugin` sometimes, which
isn't supported.
