### PR TITLE
[RISCV] Add isel optimization for (and (sra y, c2), c1) to recover regression from #101751.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -3053,7 +3053,7 @@ bool RISCVDAGToDAGISel::selectSHXADDOp(SDValue N, unsigned ShAmt,
         unsigned XLen = Subtarget->getXLen();
         unsigned Leading = XLen - llvm::bit_width(Mask);
         unsigned Trailing = llvm::countr_zero(Mask);
-        if (C2 > Leading && Trailing == ShAmt) {
+        if (C2 > Leading && Leading > 0 && Trailing == ShAmt) {
           SDLoc DL(N);
           EVT VT = N.getValueType();
           Val = SDValue(CurDAG->getMachineNode(

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1486,7 +1486,7 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
       if (isShiftedMask_64(C1) && !Skip) {
         unsigned Leading = XLen - llvm::bit_width(C1);
         unsigned Trailing = llvm::countr_zero(C1);
-        if (C2 > Leading && Trailing > 0) {
+        if (C2 > Leading && Leading > 0 && Trailing > 0) {
           SDNode *SRAI = CurDAG->getMachineNode(
               RISCV::SRAI, DL, VT, N0.getOperand(0),
               CurDAG->getTargetConstant(C2 - Leading, DL, VT));

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -3027,7 +3027,7 @@ bool RISCVDAGToDAGISel::selectSHXADDOp(SDValue N, unsigned ShAmt,
       // Look for (and (sra y, c2), c1) where c1 is a shifted mask with c3
       // leading zeros and c4 trailing zeros. If c2 is greater than c3, we can
       // use (srli (srai y, c2 - c3), c3 + c4) followed by a SHXADD with c4 as
-      // the X ammount.
+      // the X amount.
       if (isShiftedMask_64(Mask)) {
         unsigned XLen = Subtarget->getXLen();
         unsigned Leading = XLen - llvm::bit_width(Mask);

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1483,7 +1483,7 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
       // Look for (and (sra y, c2), c1) where c1 is a shifted mask with c3
       // leading zeros and c4 trailing zeros. If c2 is greater than c3, we can
       // use (slli (srli (srai y, c2 - c3), c3 + c4), c4).
-      if (isShiftedMask_64(C1)) {
+      if (isShiftedMask_64(C1) && !Skip) {
         unsigned Leading = XLen - llvm::bit_width(C1);
         unsigned Trailing = llvm::countr_zero(C1);
         if (C2 > Leading && Trailing > 0) {

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -3043,7 +3043,7 @@ entry:
 ; Negative to make sure the peephole added for srai_srli_slli and
 ; srai_srli_sh3add doesn't break this.
 define i64 @srai_lui_and(i64 %x) nounwind {
-; CHECK-LABEL: srai_and:
+; CHECK-LABEL: srai_lui_and:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    srai a0, a0, 8
 ; CHECK-NEXT:    lui a1, 1048574

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -2992,10 +2992,9 @@ entry:
 define ptr @srai_srli_sh3add(ptr %0, i64 %1) nounwind {
 ; RV64I-LABEL: srai_srli_sh3add:
 ; RV64I:       # %bb.0: # %entry
-; RV64I-NEXT:    srai a1, a1, 35
-; RV64I-NEXT:    li a2, -57
-; RV64I-NEXT:    srli a2, a2, 3
-; RV64I-NEXT:    and a1, a1, a2
+; RV64I-NEXT:    srai a1, a1, 32
+; RV64I-NEXT:    srli a1, a1, 6
+; RV64I-NEXT:    slli a1, a1, 3
 ; RV64I-NEXT:    add a0, a0, a1
 ; RV64I-NEXT:    ret
 ;
@@ -3009,5 +3008,20 @@ entry:
   %2 = ashr i64 %1, 32
   %3 = lshr i64 %2, 6
   %4 = getelementptr i64, ptr %0, i64 %3
+  ret ptr %4
+}
+
+define ptr @srai_srli_slli(ptr %0, i64 %1) nounwind {
+; CHECK-LABEL: srai_srli_slli:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai a1, a1, 32
+; CHECK-NEXT:    srli a1, a1, 6
+; CHECK-NEXT:    slli a1, a1, 4
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %2 = ashr i64 %1, 32
+  %3 = lshr i64 %2, 6
+  %4 = getelementptr i128, ptr %0, i64 %3
   ret ptr %4
 }

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -2988,3 +2988,26 @@ entry:
   %2 = and i64 %1, 34359738360
   ret i64 %2
 }
+
+define ptr @srai_srli_sh3add(ptr %0, i64 %1) nounwind {
+; RV64I-LABEL: srai_srli_sh3add:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:    srai a1, a1, 35
+; RV64I-NEXT:    li a2, -57
+; RV64I-NEXT:    srli a2, a2, 3
+; RV64I-NEXT:    and a1, a1, a2
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: srai_srli_sh3add:
+; RV64ZBA:       # %bb.0: # %entry
+; RV64ZBA-NEXT:    srai a1, a1, 32
+; RV64ZBA-NEXT:    srli a1, a1, 6
+; RV64ZBA-NEXT:    sh3add a0, a1, a0
+; RV64ZBA-NEXT:    ret
+entry:
+  %2 = ashr i64 %1, 32
+  %3 = lshr i64 %2, 6
+  %4 = getelementptr i64, ptr %0, i64 %3
+  ret ptr %4
+}

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -3025,3 +3025,32 @@ entry:
   %4 = getelementptr i128, ptr %0, i64 %3
   ret ptr %4
 }
+
+; Negative to make sure the peephole added for srai_srli_slli and
+; srai_srli_sh3add doesn't break this.
+define i64 @srai_andi(i64 %x) nounwind {
+; CHECK-LABEL: srai_andi:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai a0, a0, 8
+; CHECK-NEXT:    andi a0, a0, -8
+; CHECK-NEXT:    ret
+entry:
+  %y = ashr i64 %x, 8
+  %z = and i64 %y, -8
+  ret i64 %z
+}
+
+; Negative to make sure the peephole added for srai_srli_slli and
+; srai_srli_sh3add doesn't break this.
+define i64 @srai_lui_and(i64 %x) nounwind {
+; CHECK-LABEL: srai_and:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai a0, a0, 8
+; CHECK-NEXT:    lui a1, 1048574
+; CHECK-NEXT:    and a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %y = ashr i64 %x, 8
+  %z = and i64 %y, -8192
+  ret i64 %z
+}


### PR DESCRIPTION
If c1 is a shifted mask with c3 leading zeros and c4 trailing zeros. If c2 is greater than c3, we can use (srli (srai y, c2 - c3), c3 + c4) followed by a SHXADD with c4 as the X amount.

Without Zba we can use (slli (srli (srai y, c2 - c3), c3 + c4), c4).
Alive2: https://alive2.llvm.org/ce/z/AwhheR
