### PR TITLE
[mlir][spirv] Fix incorrect metadata in SPIR-V Header

### DIFF
--- a/mlir/lib/Target/SPIRV/SPIRVBinaryUtils.cpp
+++ b/mlir/lib/Target/SPIRV/SPIRVBinaryUtils.cpp
@@ -52,7 +52,7 @@ void spirv::appendModuleHeader(SmallVectorImpl<uint32_t> &header,
   // +-------------------------------------------------------------------------+
   header.push_back(spirv::kMagicNumber);
   header.push_back((majorVersion << 16) | (minorVersion << 8));
-  header.push_back(kGeneratorNumber);
+  header.push_back((kGeneratorNumber << 16) | LLVM_VERSION_MAJOR);
   header.push_back(idBound); // <id> bound
   header.push_back(0);       // Schema (reserved word)
 }


### PR DESCRIPTION
SRIP-V Generator Magic Number is a 32 bit word: The high order 16 bits are a tool ID. The low order 16 bits are for verion number, currently the tool id is not on the high order 16 bit so it must shifed

fixes: #99071