### PR TITLE
[DirectX] Add missing Analysis usage to DXILResourceMDWrapper

### DIFF
--- a/llvm/lib/Target/DirectX/DXILResourceAnalysis.h
+++ b/llvm/lib/Target/DirectX/DXILResourceAnalysis.h
@@ -57,6 +57,10 @@ public:
   /// Calculate the DXILResource for the module.
   bool runOnModule(Module &M) override;
 
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+  }
+
   void print(raw_ostream &O, const Module *M = nullptr) const override;
 };
 } // namespace llvm


### PR DESCRIPTION
This analysis can't be used with other analyses if this isn't set.
