### PR TITLE
[bazel] Enable more lit self tests

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel
@@ -34,7 +34,14 @@ expand_template(
         ] + glob(["Inputs/**"]),
     )
     for src in glob(
-        ["*/*.py"],
-        exclude = ["Inputs/**"],
+        ["**/*.py"],
+        exclude = [
+            "Inputs/**",
+            "discovery.py",  # TODO: debug and re-enable
+            "max-time.py",
+            "selecting.py",
+            "shtest-recursive-substitution.py",
+            "use-llvm-tool.py",
+        ],
     )
 ]


### PR DESCRIPTION
I assume the intent of the initial `*/*.py` was to also collect things
in `*.py`, but that's not what bazel does unless you use `**/*.py` which
is what we're doing now. A few of these tests fail so I explicitly
disabled them until someone has time to debug.
