### PR TITLE
[LLDB][OSX] Removed semi colon generating a warning during build

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -128,7 +128,7 @@ FileSpec HostInfoMacOSX::GetProgramFileSpec() {
 static bool ResolveAndVerifyCandidateSupportDir(FileSpec &path) {
   FileSystem::Instance().Resolve(path);
   return FileSystem::Instance().IsDirectory(path);
-};
+}
 
 bool HostInfoMacOSX::ComputeSupportExeDirectory(FileSpec &file_spec) {
   FileSpec lldb_file_spec = GetShlibDir();


### PR DESCRIPTION
Singular warning I noticed when compiling lldb.