### PR TITLE
[AMDGPU][llvm-split] Fix another division by zero

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
@@ -568,12 +568,13 @@ doPartitioning(SplitModuleLogger &SML, Module &M, unsigned NumParts,
   }
 
   if (SML) {
+    CostType ModuleCostOr1 = ModuleCost ? ModuleCost : 1;
     for (const auto &[Idx, Part] : enumerate(Partitions)) {
       CostType Cost = 0;
       for (auto *Fn : Part)
         Cost += FnCosts.at(Fn);
       SML << "P" << Idx << " has a total cost of " << Cost << " ("
-          << format("%0.2f", (float(Cost) / ModuleCost) * 100)
+          << format("%0.2f", (float(Cost) / ModuleCostOr1) * 100)
           << "% of source module)\n";
     }
 

--- a/llvm/test/tools/llvm-split/AMDGPU/declarations-debug.ll
+++ b/llvm/test/tools/llvm-split/AMDGPU/declarations-debug.ll
@@ -1,0 +1,12 @@
+; RUN: llvm-split -o %t %s -j 2 -mtriple amdgcn-amd-amdhsa --debug
+
+; REQUIRES: asserts
+
+; CHECK: --Partitioning Starts--
+; CHECK: P0 has a total cost of 0 (0.00% of source module)
+; CHECK: P1 has a total cost of 0 (0.00% of source module)
+; CHECK: --Partitioning Done--
+
+declare void @A()
+
+declare void @B()


### PR DESCRIPTION
Somehow I missed this in #98888. It requires a log file, or the debug flag to be passed.