### PR TITLE
[GlobalISel] Combiner: Fix warning after #102163

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/Combiner.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Combiner.cpp
@@ -217,9 +217,8 @@ Combiner::WorkListMaintainer::create(Level Lvl, WorkListTy &WorkList,
   case Level::SinglePass:
     return std::make_unique<WorkListMaintainerImpl<Level::SinglePass>>(WorkList,
                                                                        MRI);
-  default:
-    llvm_unreachable("Illegal ObserverLevel");
   }
+  llvm_unreachable("Illegal ObserverLevel");
 }
 
 Combiner::Combiner(MachineFunction &MF, CombinerInfo &CInfo,


### PR DESCRIPTION
Default case in covered switches is illegal.
https://llvm.org/docs/CodingStandards.html#don-t-use-default-labels-in-fully-covered-switches-over-enumerations
