### PR TITLE
[PowerPC] Fix mask for __st[d/w/h/b]cx builtins

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -2016,9 +2016,9 @@ def SLBSYNC : XForm_0<31, 338, (outs), (ins), "slbsync", IIC_SprSLBSYNC, []>;
 } // IsISA3_0
 
 def : Pat<(int_ppc_stdcx ForceXForm:$dst, g8rc:$A),
-          (STDCX g8rc:$A, ForceXForm:$dst)>;
+          (RLWINM (STDCX g8rc:$A, ForceXForm:$dst), 31, 1, 31)>;
 def : Pat<(PPCStoreCond ForceXForm:$dst, g8rc:$A, 8),
-          (STDCX g8rc:$A, ForceXForm:$dst)>;
+          (RLWINM (STDCX g8rc:$A, ForceXForm:$dst), 31, 1, 31)>;
 
 def : Pat<(i64 (int_ppc_mfspr timm:$SPR)),
           (MFSPR8 $SPR)>;

--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -2016,9 +2016,9 @@ def SLBSYNC : XForm_0<31, 338, (outs), (ins), "slbsync", IIC_SprSLBSYNC, []>;
 } // IsISA3_0
 
 def : Pat<(int_ppc_stdcx ForceXForm:$dst, g8rc:$A),
-          (RLWINM (STDCX g8rc:$A, ForceXForm:$dst), 31, 1, 31)>;
+          (RLWINM (STDCX g8rc:$A, ForceXForm:$dst), 31, 31, 31)>;
 def : Pat<(PPCStoreCond ForceXForm:$dst, g8rc:$A, 8),
-          (RLWINM (STDCX g8rc:$A, ForceXForm:$dst), 31, 1, 31)>;
+          (RLWINM (STDCX g8rc:$A, ForceXForm:$dst), 31, 31, 31)>;
 
 def : Pat<(i64 (int_ppc_mfspr timm:$SPR)),
           (MFSPR8 $SPR)>;

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -5288,13 +5288,13 @@ def : Pat<(i64 (bitreverse i64:$A)),
   (OR8 (RLDICR DWBytes7654.DWord, 32, 31), DWBytes3210.DWord)>;
 
 def : Pat<(int_ppc_stwcx ForceXForm:$dst, gprc:$A),
-          (STWCX gprc:$A, ForceXForm:$dst)>;
+          (RLWINM (STWCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
 def : Pat<(PPCStoreCond ForceXForm:$dst, gprc:$A, 4),
-          (STWCX gprc:$A, ForceXForm:$dst)>;
+          (RLWINM (STWCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
 def : Pat<(int_ppc_stbcx ForceXForm:$dst, gprc:$A),
-          (STBCX gprc:$A, ForceXForm:$dst)>;
+          (RLWINM (STBCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
 def : Pat<(PPCStoreCond ForceXForm:$dst, gprc:$A, 1),
-          (STBCX gprc:$A, ForceXForm:$dst)>;
+          (RLWINM (STBCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
 
 def : Pat<(int_ppc_fcfid f64:$A),
         (XSCVSXDDP $A)>;
@@ -5324,9 +5324,9 @@ def : Pat<(int_ppc_mtmsr gprc:$RS),
 
 let Predicates = [IsISA2_07] in {
   def : Pat<(int_ppc_sthcx ForceXForm:$dst, gprc:$A),
-            (STHCX gprc:$A, ForceXForm:$dst)>;
+            (RLWINM (STHCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
   def : Pat<(PPCStoreCond ForceXForm:$dst, gprc:$A, 2),
-            (STHCX gprc:$A, ForceXForm:$dst)>;
+            (RLWINM (STHCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
 }
 def : Pat<(int_ppc_dcbtstt ForceXForm:$dst),
           (DCBTST 16, ForceXForm:$dst)>;

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -5288,13 +5288,13 @@ def : Pat<(i64 (bitreverse i64:$A)),
   (OR8 (RLDICR DWBytes7654.DWord, 32, 31), DWBytes3210.DWord)>;
 
 def : Pat<(int_ppc_stwcx ForceXForm:$dst, gprc:$A),
-          (RLWINM (STWCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
+          (RLWINM (STWCX gprc:$A, ForceXForm:$dst), 31, 31, 31)>;
 def : Pat<(PPCStoreCond ForceXForm:$dst, gprc:$A, 4),
-          (RLWINM (STWCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
+          (RLWINM (STWCX gprc:$A, ForceXForm:$dst), 31, 31, 31)>;
 def : Pat<(int_ppc_stbcx ForceXForm:$dst, gprc:$A),
-          (RLWINM (STBCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
+          (RLWINM (STBCX gprc:$A, ForceXForm:$dst), 31, 31, 31)>;
 def : Pat<(PPCStoreCond ForceXForm:$dst, gprc:$A, 1),
-          (RLWINM (STBCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
+          (RLWINM (STBCX gprc:$A, ForceXForm:$dst), 31, 31, 31)>;
 
 def : Pat<(int_ppc_fcfid f64:$A),
         (XSCVSXDDP $A)>;
@@ -5324,9 +5324,9 @@ def : Pat<(int_ppc_mtmsr gprc:$RS),
 
 let Predicates = [IsISA2_07] in {
   def : Pat<(int_ppc_sthcx ForceXForm:$dst, gprc:$A),
-            (RLWINM (STHCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
+            (RLWINM (STHCX gprc:$A, ForceXForm:$dst), 31, 31, 31)>;
   def : Pat<(PPCStoreCond ForceXForm:$dst, gprc:$A, 2),
-            (RLWINM (STHCX gprc:$A, ForceXForm:$dst), 31, 1, 31)>;
+            (RLWINM (STHCX gprc:$A, ForceXForm:$dst), 31, 31, 31)>;
 }
 def : Pat<(int_ppc_dcbtstt ForceXForm:$dst),
           (DCBTST 16, ForceXForm:$dst)>;

--- a/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond-64bit-only.ll
+++ b/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond-64bit-only.ll
@@ -26,7 +26,7 @@ define dso_local i64 @test_stdcx(ptr %a, i64 %b) {
 ; CHECK-NEXT:    stdcx. 4, 0, 3
 ; CHECK-NEXT:    mfocrf 3, 128
 ; CHECK-NEXT:    srwi 3, 3, 28
-; CHECK-NEXT:    extsw 3, 3
+; CHECK-NEXT:    srwi 3, 3, 1
 ; CHECK-NEXT:    blr
 entry:
   %0 = tail call i32 @llvm.ppc.stdcx(ptr %a, i64 %b)

--- a/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond-64bit-only.ll
+++ b/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond-64bit-only.ll
@@ -26,7 +26,7 @@ define dso_local i64 @test_stdcx(ptr %a, i64 %b) {
 ; CHECK-NEXT:    stdcx. 4, 0, 3
 ; CHECK-NEXT:    mfocrf 3, 128
 ; CHECK-NEXT:    srwi 3, 3, 28
-; CHECK-NEXT:    srwi 3, 3, 1
+; CHECK-NEXT:    rlwinm 3, 3, 31, 31, 31
 ; CHECK-NEXT:    blr
 entry:
   %0 = tail call i32 @llvm.ppc.stdcx(ptr %a, i64 %b)

--- a/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond.ll
+++ b/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond.ll
@@ -36,7 +36,7 @@ define dso_local signext i32 @test_stwcx(ptr %a, i32 signext %b) {
 ; CHECK-64-NEXT:    stwcx. 4, 0, 3
 ; CHECK-64-NEXT:    mfocrf 3, 128
 ; CHECK-64-NEXT:    srwi 3, 3, 28
-; CHECK-64-NEXT:    srwi 3, 3, 1
+; CHECK-64-NEXT:    rlwinm 3, 3, 31, 31, 31
 ; CHECK-64-NEXT:    blr
 ;
 ; CHECK-32-LABEL: test_stwcx:
@@ -44,7 +44,7 @@ define dso_local signext i32 @test_stwcx(ptr %a, i32 signext %b) {
 ; CHECK-32-NEXT:    stwcx. 4, 0, 3
 ; CHECK-32-NEXT:    mfocrf 3, 128
 ; CHECK-32-NEXT:    srwi 3, 3, 28
-; CHECK-32-NEXT:    srwi 3, 3, 1
+; CHECK-32-NEXT:    rlwinm 3, 3, 31, 31, 31
 ; CHECK-32-NEXT:    blr
 entry:
   %0 = tail call i32 @llvm.ppc.stwcx(ptr %a, i32 %b)
@@ -58,7 +58,7 @@ define dso_local signext i32 @test_sthcx(ptr %a, i16 signext %val) {
 ; CHECK-64-NEXT:    sthcx. 4, 0, 3
 ; CHECK-64-NEXT:    mfocrf 3, 128
 ; CHECK-64-NEXT:    srwi 3, 3, 28
-; CHECK-64-NEXT:    srwi 3, 3, 1
+; CHECK-64-NEXT:    rlwinm 3, 3, 31, 31, 31
 ; CHECK-64-NEXT:    blr
 ;
 ; CHECK-32-LABEL: test_sthcx:
@@ -66,7 +66,7 @@ define dso_local signext i32 @test_sthcx(ptr %a, i16 signext %val) {
 ; CHECK-32-NEXT:    sthcx. 4, 0, 3
 ; CHECK-32-NEXT:    mfocrf 3, 128
 ; CHECK-32-NEXT:    srwi 3, 3, 28
-; CHECK-32-NEXT:    srwi 3, 3, 1
+; CHECK-32-NEXT:    rlwinm 3, 3, 31, 31, 31
 ; CHECK-32-NEXT:    blr
 entry:
   %0 = sext i16 %val to i32
@@ -81,7 +81,7 @@ define signext i32 @test_stbcx(ptr %addr, i8 signext %val) {
 ; CHECK-64-NEXT:    stbcx. 4, 0, 3
 ; CHECK-64-NEXT:    mfocrf 3, 128
 ; CHECK-64-NEXT:    srwi 3, 3, 28
-; CHECK-64-NEXT:    srwi 3, 3, 1
+; CHECK-64-NEXT:    rlwinm 3, 3, 31, 31, 31
 ; CHECK-64-NEXT:    blr
 ;
 ; CHECK-32-LABEL: test_stbcx:
@@ -89,7 +89,7 @@ define signext i32 @test_stbcx(ptr %addr, i8 signext %val) {
 ; CHECK-32-NEXT:    stbcx. 4, 0, 3
 ; CHECK-32-NEXT:    mfocrf 3, 128
 ; CHECK-32-NEXT:    srwi 3, 3, 28
-; CHECK-32-NEXT:    srwi 3, 3, 1
+; CHECK-32-NEXT:    rlwinm 3, 3, 31, 31, 31
 ; CHECK-32-NEXT:    blr
 entry:
   %conv = sext i8 %val to i32

--- a/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond.ll
+++ b/llvm/test/CodeGen/PowerPC/builtins-ppc-xlcompat-LoadReserve-StoreCond.ll
@@ -36,7 +36,7 @@ define dso_local signext i32 @test_stwcx(ptr %a, i32 signext %b) {
 ; CHECK-64-NEXT:    stwcx. 4, 0, 3
 ; CHECK-64-NEXT:    mfocrf 3, 128
 ; CHECK-64-NEXT:    srwi 3, 3, 28
-; CHECK-64-NEXT:    extsw 3, 3
+; CHECK-64-NEXT:    srwi 3, 3, 1
 ; CHECK-64-NEXT:    blr
 ;
 ; CHECK-32-LABEL: test_stwcx:
@@ -44,6 +44,7 @@ define dso_local signext i32 @test_stwcx(ptr %a, i32 signext %b) {
 ; CHECK-32-NEXT:    stwcx. 4, 0, 3
 ; CHECK-32-NEXT:    mfocrf 3, 128
 ; CHECK-32-NEXT:    srwi 3, 3, 28
+; CHECK-32-NEXT:    srwi 3, 3, 1
 ; CHECK-32-NEXT:    blr
 entry:
   %0 = tail call i32 @llvm.ppc.stwcx(ptr %a, i32 %b)
@@ -57,7 +58,7 @@ define dso_local signext i32 @test_sthcx(ptr %a, i16 signext %val) {
 ; CHECK-64-NEXT:    sthcx. 4, 0, 3
 ; CHECK-64-NEXT:    mfocrf 3, 128
 ; CHECK-64-NEXT:    srwi 3, 3, 28
-; CHECK-64-NEXT:    extsw 3, 3
+; CHECK-64-NEXT:    srwi 3, 3, 1
 ; CHECK-64-NEXT:    blr
 ;
 ; CHECK-32-LABEL: test_sthcx:
@@ -65,6 +66,7 @@ define dso_local signext i32 @test_sthcx(ptr %a, i16 signext %val) {
 ; CHECK-32-NEXT:    sthcx. 4, 0, 3
 ; CHECK-32-NEXT:    mfocrf 3, 128
 ; CHECK-32-NEXT:    srwi 3, 3, 28
+; CHECK-32-NEXT:    srwi 3, 3, 1
 ; CHECK-32-NEXT:    blr
 entry:
   %0 = sext i16 %val to i32
@@ -79,7 +81,7 @@ define signext i32 @test_stbcx(ptr %addr, i8 signext %val) {
 ; CHECK-64-NEXT:    stbcx. 4, 0, 3
 ; CHECK-64-NEXT:    mfocrf 3, 128
 ; CHECK-64-NEXT:    srwi 3, 3, 28
-; CHECK-64-NEXT:    extsw 3, 3
+; CHECK-64-NEXT:    srwi 3, 3, 1
 ; CHECK-64-NEXT:    blr
 ;
 ; CHECK-32-LABEL: test_stbcx:
@@ -87,6 +89,7 @@ define signext i32 @test_stbcx(ptr %addr, i8 signext %val) {
 ; CHECK-32-NEXT:    stbcx. 4, 0, 3
 ; CHECK-32-NEXT:    mfocrf 3, 128
 ; CHECK-32-NEXT:    srwi 3, 3, 28
+; CHECK-32-NEXT:    srwi 3, 3, 1
 ; CHECK-32-NEXT:    blr
 entry:
   %conv = sext i8 %val to i32


### PR DESCRIPTION
These builtins are currently returning CR0 which will have the format [0, 0, flag_true_if_saved, XER].
We only want to return flag_true_if_saved. This patch adds a shift to remove the XER bit before returning.