### PR TITLE
[OpenMPOpt] Initialize OpenMPIRBuilderConfig::IsGPU flag

### DIFF
--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -286,6 +286,19 @@ struct OMPInformationCache : public InformationCache {
         OpenMPPostLink(OpenMPPostLink) {
 
     OMPBuilder.Config.IsTargetDevice = isOpenMPDevice(OMPBuilder.M);
+    const Triple T(OMPBuilder.M.getTargetTriple());
+    switch (T.getArch()) {
+    case llvm::Triple::nvptx:
+    case llvm::Triple::nvptx64:
+    case llvm::Triple::amdgcn:
+      assert(OMPBuilder.Config.IsTargetDevice &&
+             "OpenMP AMDGPU/NVPTX is only prepared to deal with device code.");
+      OMPBuilder.Config.IsGPU = true;
+      break;
+    default:
+      OMPBuilder.Config.IsGPU = false;
+      break;
+    }
     OMPBuilder.initialize();
     initializeRuntimeFunctions(M);
     initializeInternalControlVars();


### PR DESCRIPTION
This patch ensures the `IsGPU` flag is set by the OpenMPOpt pass, so that it can be relied upon by `OpenMPIRBuilder` methods when called by that pass as well.

Since currently there are very limited callers for the `OpenMPIRBuilder::isGPU()` method, no assertions are being triggered by the lack of initialization of this flag. However, when more offloading-related features are implemented, it will eventually start happening.