### PR TITLE
[clang][dataflow] Collect local variables referenced within a functio…

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/ASTOps.h
+++ b/clang/include/clang/Analysis/FlowSensitive/ASTOps.h
@@ -139,6 +139,9 @@ struct ReferencedDecls {
   /// All variables with static storage duration, notably including static
   /// member variables and static variables declared within a function.
   llvm::DenseSet<const VarDecl *> Globals;
+  /// Local variables, not including parameters or static variables declared
+  /// within a function.
+  llvm::DenseSet<const VarDecl *> Locals;
   /// Free functions and member functions which are referenced (but not
   /// necessarily called).
   llvm::DenseSet<const FunctionDecl *> Functions;


### PR DESCRIPTION
…n/statement.

We don't need these for the same in-tree purposes as the other sets, i.e. for making sure we model these Decls that are declared outside the function, but we have an out-of-tree use for these sets that would benefit from this simple addition and would avoid duplicating so much of this code.