### PR TITLE
[LLVM][NVPTX] Add support for brkpt instruction

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -648,6 +648,8 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
 
   // TRAP can be lowered to PTX trap
   setOperationAction(ISD::TRAP, MVT::Other, Legal);
+  // DEBUGTRAP can be lowered to PTX brkpt
+  setOperationAction(ISD::DEBUGTRAP, MVT::Other, Legal);
 
   // Register custom handling for vector loads/stores
   for (MVT VT : MVT::fixedlen_vector_valuetypes()) {

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -3844,6 +3844,8 @@ def Callseq_End :
 // Emit an `exit` as well to convey to ptxas that `trap` exits the CFG.
 // This won't be necessary in a future version of ptxas.
 def trapinst : NVPTXInst<(outs), (ins), "trap; exit;", [(trap)]>;
+// brkpt instruction
+def debugtrapinst : NVPTXInst<(outs), (ins), "brkpt;", [(debugtrap)]>;
 
 // Call prototype wrapper
 def SDTCallPrototype : SDTypeProfile<0, 1, [SDTCisInt<0>]>;

--- a/llvm/test/CodeGen/NVPTX/brkpt.ll
+++ b/llvm/test/CodeGen/NVPTX/brkpt.ll
@@ -1,0 +1,8 @@
+; RUN: llc -o - -march=nvptx64 %s | FileCheck %s
+
+; CHECK-LABEL: .func breakpoint
+define void @breakpoint() {
+  ; CHECK: brkpt;
+  call void @llvm.debugtrap()
+  ret void
+}


### PR DESCRIPTION
This commit adds NVPTX codegen support for brkpt instruction (https://docs.nvidia.com/cuda/parallel-thread-execution/#miscellaneous-instructions-brkpt) with test under CodeGen/NVPTX/brkpt.ll