### PR TITLE
[LangRef] Update the semantic of `experimental.get.vector.length`

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -19648,8 +19648,7 @@ Let ``%max_lanes`` be the number of lanes in the type described by ``%vf`` and
 ``%scalable``, here are the constraints on the returned value:
 - If ``%cnt`` equals to 0, returns 0.
 - The returned value is always less or equal to ``%max_lanes``.
-- The returned value is always larger or equal to
-  ``ceil(%cnt / ceil(%cnt / %max_lanes))``.
+- The returned value is always larger or equal to ``ceil(%cnt / ceil(%cnt / %max_lanes))``.
   - This implies that if ``%cnt`` is non-zero, the result should be non-zero
     as well.
   - This also implies that if ``%cnt`` is less than ``%max_lanes``, it has to

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -19634,7 +19634,7 @@ vectorization factor should be multiplied by vscale.
 Semantics:
 """"""""""
 
-Returns a positive i32 value (explicit vector length) that is unknown at compile
+Returns a non-negative i32 value (explicit vector length) that is unknown at compile
 time and depends on the hardware specification.
 If the result value does not fit in the result type, then the result is
 a :ref:`poison value <poisonvalues>`.
@@ -19646,16 +19646,18 @@ count reaches zero.
 
 Let ``%max_lanes`` be the number of lanes in the type described by ``%vf`` and
 ``%scalable``, here are the constraints on the returned value:
-- If ``%cnt`` equals to 0, returns 0.
-- The returned value is always less or equal to ``%max_lanes``.
-- The returned value is always larger or equal to ``ceil(%cnt / ceil(%cnt / %max_lanes))``.
-  - This implies that if ``%cnt`` is non-zero, the result should be non-zero
-    as well.
-  - This also implies that if ``%cnt`` is less than ``%max_lanes``, it has to
-    return ``%cnt``.
-- The returned values decrease monotonically in each loop iteration. That is,
-  the returned value of a iteration is at least as large as that of any later
-  iterations.
+
+-  If ``%cnt`` equals to 0, returns 0.
+-  The returned value is always less than or equal to ``%max_lanes``.
+-  The returned value is always greater than or equal to ``ceil(%cnt / ceil(%cnt / %max_lanes))``.
+-  The returned values decrease monotonically in each loop iteration. That is,
+   the returned value of a iteration is at least as large as that of any later
+   iterations.
+
+Note that it has the following implications:
+
+-  If ``%cnt`` is non-zero, the result should be non-zero as well.
+-  If ``%cnt`` is less than ``%max_lanes``, it has to return ``%cnt``.
 
 '``llvm.experimental.vector.partial.reduce.add.*``' Intrinsic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -19649,15 +19649,18 @@ Let ``%max_lanes`` be the number of lanes in the type described by ``%vf`` and
 
 -  If ``%cnt`` equals to 0, returns 0.
 -  The returned value is always less than or equal to ``%max_lanes``.
--  The returned value is always greater than or equal to ``ceil(%cnt / ceil(%cnt / %max_lanes))``.
--  The returned values decrease monotonically in each loop iteration. That is,
-   the returned value of a iteration is at least as large as that of any later
-   iterations.
+-  The returned value is always greater than or equal to ``ceil(%cnt / ceil(%cnt / %max_lanes))``,
+   if ``%cnt`` is non-zero.
+-  The returned values are monotonically non-increasing in each loop iteration. That is,
+   the returned value of an iteration is at least as large as that of any later
+   iteration.
 
 Note that it has the following implications:
 
--  If ``%cnt`` is non-zero, the result should be non-zero as well.
--  If ``%cnt`` is less than ``%max_lanes``, it has to return ``%cnt``.
+-  For a loop that uses this intrinsic, the number of iterations is equal to
+   ``ceil(%C / %max_lanes)`` where ``%C`` is the initial ``%cnt`` value.
+-  If ``%cnt`` is non-zero, the return value is non-zero as well.
+-  If ``%cnt`` is less than or equal to ``%max_lanes``, the return value is equal to ``%cnt``.
 
 '``llvm.experimental.vector.partial.reduce.add.*``' Intrinsic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -19644,13 +19644,19 @@ in order to get the number of elements to process on each loop iteration. The
 result should be used to decrease the count for the next iteration until the
 count reaches zero.
 
-If the count is larger than the number of lanes in the type described by the
-last 2 arguments, this intrinsic may return a value less than the number of
-lanes implied by the type. The result will be at least as large as the result
-will be on any later loop iteration.
-
-This intrinsic will only return 0 if the input count is also 0. A non-zero input
-count will produce a non-zero result.
+Let ``%max_lanes`` be the number of lanes in the type described by ``%vf`` and
+``%scalable``, here are the constraints on the returned value:
+- If ``%cnt`` equals to 0, returns 0.
+- The returned value is always less or equal to ``%max_lanes``.
+- The returned value is always larger or equal to
+  ``ceil(%cnt / ceil(%cnt / %max_lanes))``.
+  - This implies that if ``%cnt`` is non-zero, the result should be non-zero
+    as well.
+  - This also implies that if ``%cnt`` is less than ``%max_lanes``, it has to
+    return ``%cnt``.
+- The returned values decrease monotonically in each loop iteration. That is,
+  the returned value of a iteration is at least as large as that of any later
+  iterations.
 
 '``llvm.experimental.vector.partial.reduce.add.*``' Intrinsic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The previous semantics of `llvm.experimental.get.vector.length` was too permissive such that it gave optimizers a hard time on anything related to the number of iterations of VP-vectorized loops.

This patch tries to address this by assigning it a set of stricter semantics similar to that of RVV's VSETVLI instructions, while being not too RISC-V specific and leaving room for other (future) targets.