### PR TITLE
[clang][driver] Don't warn when -S and -c are used together without -fsyntax-only

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -377,6 +377,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
   // -S only runs up to the backend.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_S))) {
     FinalPhase = phases::Backend;
+    DAL.ClaimAllArgs(options::OPT_c);
 
   // -c compilation only runs up to the assembler.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_c))) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -380,7 +380,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
     // Avoid unused argument warnings when combining -S and -c.
     DAL.ClaimAllArgs(options::OPT_c);
 
-  // -c compilation only runs up to the assembler.
+    // -c compilation only runs up to the assembler.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_c))) {
     FinalPhase = phases::Assemble;
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -377,6 +377,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
   // -S only runs up to the backend.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_S))) {
     FinalPhase = phases::Backend;
+    // Avoid unused argument warnings when combining -S and -c.
     DAL.ClaimAllArgs(options::OPT_c);
 
   // -c compilation only runs up to the assembler.

--- a/clang/test/Driver/warn-fsyntax-only.c
+++ b/clang/test/Driver/warn-fsyntax-only.c
@@ -1,7 +1,14 @@
 // RUN: %clang --target=x86_64 -fsyntax-only -E %s 2>&1 | FileCheck %s --check-prefix=CHECK-PP
 // RUN: %clang --target=x86_64 -fsyntax-only -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-ASM
 // RUN: %clang --target=x86_64 -fsyntax-only -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-OBJ
+// RUN: %clang --target=x86_64 -fsyntax-only -S -c %s 2>&1 | FileCheck %s --check-prefixes=CHECK-ASM,CHECK-OBJ
 
 // CHECK-PP:  warning: argument unused during compilation: '-fsyntax-only' [-Wunused-command-line-argument]
 // CHECK-ASM: warning: argument unused during compilation: '-S' [-Wunused-command-line-argument]
 // CHECK-OBJ: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
+
+/// Test that -S and -c don't result in a warning, without -fsyntax-only.
+// RUN: %clang -S -c %s -### 2>&1 | FileCheck %s --check-prefix=NO-SYNTAX-ONLY --implicit-check-not=warning
+// NO-SYNTAX-ONLY: "-cc1"
+// NO-SYNTAX-ONLY-SAME: "-S"
+// NO-SYNTAX-ONLY-SAME: "c"


### PR DESCRIPTION
Claim `-c` when using `-S`, so that we don't warn for unused arguments
when they are used together without `-fsyntax-only`.

Fixes #104347
