### PR TITLE
[HLSL] Flesh out basic type typedefs

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_basic_types.h
+++ b/clang/lib/Headers/hlsl/hlsl_basic_types.h
@@ -23,51 +23,97 @@ namespace hlsl {
 // 16-bit integer.
 typedef unsigned short uint16_t;
 typedef short int16_t;
+
+// 16-bit floating point.
+typedef half float16_t;
 #endif
+
+// 32-bit integer.
+typedef int int32_t;
 
 // unsigned 32-bit integer.
 typedef unsigned int uint;
+typedef unsigned int uint32_t;
+
+// 32-bit floating point.
+typedef float float32_t;
 
 // 64-bit integer.
 typedef unsigned long uint64_t;
 typedef long int64_t;
 
+// 64-bit floating point
+typedef double float64_t;
+
 // built-in vector data types:
 
 #ifdef __HLSL_ENABLE_16_BIT
+typedef vector<int16_t, 1> int16_t1;
 typedef vector<int16_t, 2> int16_t2;
 typedef vector<int16_t, 3> int16_t3;
 typedef vector<int16_t, 4> int16_t4;
+typedef vector<uint16_t, 1> uint16_t1;
 typedef vector<uint16_t, 2> uint16_t2;
 typedef vector<uint16_t, 3> uint16_t3;
 typedef vector<uint16_t, 4> uint16_t4;
 #endif
+typedef vector<bool, 1> bool1;
 typedef vector<bool, 2> bool2;
 typedef vector<bool, 3> bool3;
 typedef vector<bool, 4> bool4;
+typedef vector<int, 1> int1;
 typedef vector<int, 2> int2;
 typedef vector<int, 3> int3;
 typedef vector<int, 4> int4;
+typedef vector<uint, 1> uint1;
 typedef vector<uint, 2> uint2;
 typedef vector<uint, 3> uint3;
 typedef vector<uint, 4> uint4;
+typedef vector<int32_t, 1> int32_t1;
+typedef vector<int32_t, 2> int32_t2;
+typedef vector<int32_t, 3> int32_t3;
+typedef vector<int32_t, 4> int32_t4;
+typedef vector<uint32_t, 1> uint32_t1;
+typedef vector<uint32_t, 2> uint32_t2;
+typedef vector<uint32_t, 3> uint32_t3;
+typedef vector<uint32_t, 4> uint32_t4;
+typedef vector<int64_t, 1> int64_t1;
 typedef vector<int64_t, 2> int64_t2;
 typedef vector<int64_t, 3> int64_t3;
 typedef vector<int64_t, 4> int64_t4;
+typedef vector<uint64_t, 1> uint64_t1;
 typedef vector<uint64_t, 2> uint64_t2;
 typedef vector<uint64_t, 3> uint64_t3;
 typedef vector<uint64_t, 4> uint64_t4;
 
+typedef vector<half, 1> half1;
 typedef vector<half, 2> half2;
 typedef vector<half, 3> half3;
 typedef vector<half, 4> half4;
-
+typedef vector<float, 1> float1;
 typedef vector<float, 2> float2;
 typedef vector<float, 3> float3;
 typedef vector<float, 4> float4;
+typedef vector<double, 1> double1;
 typedef vector<double, 2> double2;
 typedef vector<double, 3> double3;
 typedef vector<double, 4> double4;
+
+#ifdef __HLSL_ENABLE_16_BIT
+typedef vector<float16_t, 1> float16_t1;
+typedef vector<float16_t, 2> float16_t2;
+typedef vector<float16_t, 3> float16_t3;
+typedef vector<float16_t, 4> float16_t4;
+#endif
+
+typedef vector<float32_t, 1> float32_t1;
+typedef vector<float32_t, 2> float32_t2;
+typedef vector<float32_t, 3> float32_t3;
+typedef vector<float32_t, 4> float32_t4;
+typedef vector<float64_t, 1> float64_t1;
+typedef vector<float64_t, 2> float64_t2;
+typedef vector<float64_t, 3> float64_t3;
+typedef vector<float64_t, 4> float64_t4;
 
 } // namespace hlsl
 

--- a/clang/test/SemaHLSL/Types/typedefs.hlsl
+++ b/clang/test/SemaHLSL/Types/typedefs.hlsl
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.4-library -finclude-default-header -verify -fnative-half-type %s
+// RUN: %clang_cc1 -triple spirv-linux-vulkan-library -finclude-default-header -verify -fnative-half-type %s
+
+// expected-no-diagnostics
+#define SizeCheck(Ty, SizeInBits)                                              \
+  _Static_assert(sizeof(Ty) == SizeInBits / 8, #Ty " is " #SizeInBits "-bit"); \
+  _Static_assert(sizeof(Ty##1) == (SizeInBits * 1) / 8, #Ty "1 is 1x" #SizeInBits "-bit"); \
+  _Static_assert(__builtin_vectorelements(Ty##1) == 1, #Ty "1 is has 1 " #SizeInBits "-bit element"); \
+  _Static_assert(sizeof(Ty##2) == (SizeInBits * 2) / 8, #Ty "2 is 2x" #SizeInBits "-bit"); \
+  _Static_assert(__builtin_vectorelements(Ty##2) == 2, #Ty "2 is has 2 " #SizeInBits "-bit element"); \
+  _Static_assert(sizeof(Ty##3) == (SizeInBits * 3) / 8, #Ty "3 is 3x" #SizeInBits "-bit"); \
+  _Static_assert(__builtin_vectorelements(Ty##3) == 3, #Ty "3 is has 3 " #SizeInBits "-bit element"); \
+  _Static_assert(sizeof(Ty##4) == (SizeInBits * 4) / 8, #Ty "4 is 4x" #SizeInBits "-bit"); \
+  _Static_assert(__builtin_vectorelements(Ty##4) == 4, #Ty "4 is has 4 " #SizeInBits "-bit element");
+
+SizeCheck(int16_t, 16);
+SizeCheck(uint16_t, 16);
+SizeCheck(half, 16);
+SizeCheck(float16_t, 16);
+
+SizeCheck(int, 32);
+SizeCheck(uint, 32);
+SizeCheck(int32_t, 32);
+SizeCheck(uint32_t, 32);
+SizeCheck(float, 32);
+SizeCheck(float32_t, 32);
+
+SizeCheck(int64_t, 64);
+SizeCheck(uint64_t, 64);
+SizeCheck(double, 64);
+SizeCheck(float64_t, 64);

--- a/clang/test/SemaHLSL/Types/typedefs.hlsl
+++ b/clang/test/SemaHLSL/Types/typedefs.hlsl
@@ -8,10 +8,13 @@
   _Static_assert(__builtin_vectorelements(Ty##1) == 1, #Ty "1 is has 1 " #SizeInBits "-bit element"); \
   _Static_assert(sizeof(Ty##2) == (SizeInBits * 2) / 8, #Ty "2 is 2x" #SizeInBits "-bit"); \
   _Static_assert(__builtin_vectorelements(Ty##2) == 2, #Ty "2 is has 2 " #SizeInBits "-bit element"); \
-  _Static_assert(sizeof(Ty##3) == (SizeInBits * 3) / 8, #Ty "3 is 3x" #SizeInBits "-bit"); \
   _Static_assert(__builtin_vectorelements(Ty##3) == 3, #Ty "3 is has 3 " #SizeInBits "-bit element"); \
   _Static_assert(sizeof(Ty##4) == (SizeInBits * 4) / 8, #Ty "4 is 4x" #SizeInBits "-bit"); \
   _Static_assert(__builtin_vectorelements(Ty##4) == 4, #Ty "4 is has 4 " #SizeInBits "-bit element");
+
+// FIXME: https://github.com/llvm/llvm-project/issues/104503 - 3 element vectors
+// should be the size of 3 elements not padded to 4.
+// _Static_assert(sizeof(Ty##3) == (SizeInBits * 3) / 8, #Ty "3 is 3x" #SizeInBits "-bit");
 
 SizeCheck(int16_t, 16);
 SizeCheck(uint16_t, 16);


### PR DESCRIPTION
We had a few missing typedefs that are supported by DXC. Specifically 1-element vectors, size-explicit 32-bit types and size-explicit floating point types.

This adds the typedefs and a test file that just verifies the expected sizes and vector element counts.

I needed to add some of these missing typedefs to address #102964, and thought instead I should try and be a bit comprehensive and put it in a separate PR.

Nothing complicated here, just typedefs and static asserts to verify them.