### PR TITLE
[lld][ELF] Combine uniqued small data sections

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -106,10 +106,13 @@ static StringRef getOutputSectionName(const InputSectionBase *s) {
     return ".text";
   }
 
-  for (StringRef v :
-       {".data.rel.ro", ".data", ".rodata", ".bss.rel.ro", ".bss", ".ldata",
-        ".lrodata", ".lbss", ".gcc_except_table", ".init_array", ".fini_array",
-        ".tbss", ".tdata", ".ARM.exidx", ".ARM.extab", ".ctors", ".dtors"})
+  for (StringRef v : {".data.rel.ro", ".data",       ".rodata",
+                      ".bss.rel.ro",  ".bss",        ".ldata",
+                      ".lrodata",     ".lbss",       ".gcc_except_table",
+                      ".init_array",  ".fini_array", ".tbss",
+                      ".tdata",       ".ARM.exidx",  ".ARM.extab",
+                      ".ctors",       ".dtors",      ".sbss",
+                      ".sdata",       ".srodata"})
     if (isSectionPrefix(v, s->name))
       return v;
 

--- a/lld/test/ELF/riscv-section-layout.s
+++ b/lld/test/ELF/riscv-section-layout.s
@@ -15,12 +15,13 @@
 # RUN: ld.lld -pie %t.64s.o -o %t.64s
 # RUN: llvm-readelf -S -sX %t.64s | FileCheck %s
 
-# NOSDATA:      .text
+# NOSDATA:      .rodata  PROGBITS
+# NOSDATA-NEXT: .text    PROGBITS
 # NOSDATA-NEXT: .tdata   PROGBITS [[#%x,TDATA:]]
-# NOSDATA-NEXT: .tbss
-# NOSDATA-NEXT: .dynamic
-# NOSDATA-NEXT: .got
-# NOSDATA-NEXT: .relro_padding
+# NOSDATA-NEXT: .tbss    NOBITS
+# NOSDATA-NEXT: .dynamic DYNAMIC
+# NOSDATA-NEXT: .got     PROGBITS
+# NOSDATA-NEXT: .relro_padding NOBITS
 # NOSDATA-NEXT: .data    PROGBITS [[#%x,DATA:]]
 # NOSDATA-NEXT: .bss     NOBITS   [[#%x,BSS:]]
 
@@ -33,16 +34,18 @@
 # NOSDATA-DAG:  [[#]]: {{0*}}[[#BSS]]         0 NOTYPE  GLOBAL DEFAULT [[#]] (.bss) __bss_start
 # NOSDATA-DAG:  [[#]]: {{0*}}800              0 NOTYPE  GLOBAL DEFAULT  1 (.dynsym) __global_pointer$
 
-# CHECK:      .text
-# CHECK-NEXT: .tdata
-# CHECK-NEXT: .tbss
-# CHECK-NEXT: .dynamic
-# CHECK-NEXT: .got
-# CHECK-NEXT: .relro_padding
-# CHECK-NEXT: .data
+# CHECK:      .rodata    PROGBITS
+# CHECK-NEXT: .srodata   PROGBITS
+# CHECK-NEXT: .text      PROGBITS
+# CHECK-NEXT: .tdata     PROGBITS
+# CHECK-NEXT: .tbss      NOBITS
+# CHECK-NEXT: .dynamic   DYNAMIC
+# CHECK-NEXT: .got       PROGBITS
+# CHECK-NEXT: .relro_padding NOBITS
+# CHECK-NEXT: .data      PROGBITS
 # CHECK-NEXT: .sdata     PROGBITS [[#%x,SDATA:]]
 # CHECK-NEXT: .sbss      NOBITS   [[#%x,SBSS:]]
-# CHECK-NEXT: .bss
+# CHECK-NEXT: .bss       NOBITS
 
 # CHECK-DAG:  [[#]]: {{0*}}[[#SBSS]]        0 NOTYPE  GLOBAL DEFAULT [[#]] (.sdata) _edata
 # CHECK-DAG:  [[#]]: {{0*}}[[#SBSS]]        0 NOTYPE  GLOBAL DEFAULT [[#]] (.sbss) __bss_start
@@ -51,11 +54,16 @@
 .globl _etext, _edata, __bss_start
   lla gp, __global_pointer$
 
+.section .rodata,"a",@progbits; .space 1
 .section .data,"aw",@progbits; .long _GLOBAL_OFFSET_TABLE_ - .
 .section .bss,"aw",@nobits; .space 1
 .section .tdata,"awT",@progbits; .space 1
 .section .tbss,"awT",@nobits; .space 1
 .ifdef SDATA
 .section .sdata,"aw",@progbits; .space 1
+.section .sdata.suffix,"aw",@progbits; .space 1
 .section .sbss,"aw",@nobits; .space 1
+.section .sbss.suffix,"aw",@nobits; .space 1
+.section .srodata,"a",@progbits; .space 1
+.section .srodata.suffix,"a",@progbits; .space 1
 .endif

--- a/lld/test/ELF/section-name.s
+++ b/lld/test/ELF/section-name.s
@@ -41,19 +41,34 @@ _start:
 .byte 0
 .section .tdata.foo,"aGwT",@progbits,foo,comdat
 .byte 0
+.section .sdata,"aw"
+.byte 0
+.section .sdata.foo,"aw"
+.byte 0
+.section .sbss,"aw",@nobits
+.byte 0
+.section .sbss.foo,"aw",@nobits
+.byte 0
+.section .srodata,"a"
+.byte 0
+.section .srodata.foo,"a"
+.byte 0
 
 // CHECK:      .rodata           00000002
 // CHECK-NEXT: .gcc_except_table 00000001
+// CHECK-NEXT: .srodata          00000002
 // CHECK-NEXT: .text             00000002
 // CHECK-NEXT: .tdata            00000001
 // CHECK-NEXT: .tbss             00000001
 // CHECK-NEXT: .data.rel.ro      00000004
-// CHECK-NEXT: .relro_padding    00000df5
+// CHECK-NEXT: .relro_padding    00000df1
 // CHECK-NEXT: .data             00000002
 // CHECK-NEXT: .foo.a            00000001
 // CHECK-NEXT: .foo              00000001
+// CHECK-NEXT: .sdata            00000002
 // CHECK-NEXT: .bss              00000002
+// CHECK-NEXT: .sbss             00000002
 // CHECK-NEXT: .comment          00000008
 // CHECK-NEXT: .symtab           00000030
-// CHECK-NEXT: .shstrtab         00000084
+// CHECK-NEXT: .shstrtab         0000009a
 // CHECK-NEXT: .strtab           00000008


### PR DESCRIPTION
RISC-V GCC with `-fdata-sections` will emit `.sbss.<name>`,
`.srodata.<name>`, and `.sdata.<name>` sections for small data items of
different kinds. Clang/LLVM already emits `.srodata.*` sections, and we
intend to emit the other two section name patterns in #87040.

This change ensures that any input sections starting `.sbss` are
combined into one output section called `.sbss`, and the same
respectively for `.srodata` and `.sdata`. This also allows the existing
RISC-V specific code for determining an output order for `.sbss` and
`.sdata` sections to apply to placing the sections.

---

@topperc I think this is the only change needed, because with this change the code in Writer.cpp will only have to deal with output sections named `.sbss` or `.sdata`, rather than also sections prefixed with those.