### PR TITLE
[libc] Add definition for `atan2l` on 64-bit long double platforms

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -248,6 +248,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atan2
     libc.src.math.atan2f
+    libc.src.math.atan2l
     libc.src.math.atanf
     libc.src.math.atanh
     libc.src.math.atanhf

--- a/libc/newhdrgen/yaml/math.yaml
+++ b/libc/newhdrgen/yaml/math.yaml
@@ -37,6 +37,13 @@ functions:
     return_type: float
     arguments:
       - type: float
+  - name: atan2
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: double
+      - type: double
   - name: atan2f
     standards:
       - stdc
@@ -44,6 +51,13 @@ functions:
     arguments:
       - type: float
       - type: float
+  - name: atan2l
+    standards:
+      - stdc
+    return_type: long double
+    arguments:
+      - type: long double
+      - type: long double
   - name: atanf
     standards:
       - stdc

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -715,6 +715,7 @@ def StdC : StandardSpec<"stdc"> {
 
           FunctionSpec<"atan2", RetValSpec<DoubleType>, [ArgSpec<DoubleType>, ArgSpec<DoubleType>]>,
           FunctionSpec<"atan2f", RetValSpec<FloatType>, [ArgSpec<FloatType>, ArgSpec<FloatType>]>,
+          FunctionSpec<"atan2l", RetValSpec<LongDoubleType>, [ArgSpec<LongDoubleType>, ArgSpec<LongDoubleType>]>,
 
           FunctionSpec<"acoshf", RetValSpec<FloatType>, [ArgSpec<FloatType>]>,
           FunctionSpec<"asinhf", RetValSpec<FloatType>, [ArgSpec<FloatType>]>,

--- a/libc/src/math/CMakeLists.txt
+++ b/libc/src/math/CMakeLists.txt
@@ -55,6 +55,7 @@ add_math_entrypoint_object(atanf)
 
 add_math_entrypoint_object(atan2)
 add_math_entrypoint_object(atan2f)
+add_math_entrypoint_object(atan2l)
 
 add_math_entrypoint_object(atanh)
 add_math_entrypoint_object(atanhf)

--- a/libc/src/math/atan2l.h
+++ b/libc/src/math/atan2l.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for atan2l ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_MATH_ATAN2L_H
+#define LLVM_LIBC_SRC_MATH_ATAN2L_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+long double atan2l(long double x, long double y);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_MATH_ATAN2L_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -4230,6 +4230,17 @@ add_entrypoint_object(
     libc.src.__support.macros.optimization
 )
 
+add_entrypoint_object(
+  atan2l
+  SRCS
+    atan2l.cpp
+  HDRS
+    ../atan2l.h
+  COMPILE_OPTIONS
+    -O3
+  DEPENDS
+    .atan2
+)
 
 add_entrypoint_object(
   scalbln

--- a/libc/src/math/generic/atan2l.cpp
+++ b/libc/src/math/generic/atan2l.cpp
@@ -1,0 +1,26 @@
+//===-- Extended-precision atan2 function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/atan2l.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/properties/types.h"
+#include "src/math/atan2.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Implement this for extended precision.
+LLVM_LIBC_FUNCTION(long double, atan2l, (long double y, long double x)) {
+#if defined(LIBC_TYPES_LONG_DOUBLE_IS_FLOAT64)
+  return static_cast<long double>(
+      atan2(static_cast<double>(y), static_cast<double>(x)));
+#else
+#error "Extended precision is not yet supported"
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Summary:
This just adds `atan2l` for platforms that can implement it as an alias
to `atan2`.
