### PR TITLE
(lldb) Fix build break for Windows (`PATH_MAX`)

### DIFF
--- a/lldb/source/Utility/RealpathPrefixes.cpp
+++ b/lldb/source/Utility/RealpathPrefixes.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Utility/RealpathPrefixes.h"
 
+#include "lldb/Host/PosixApi.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"


### PR DESCRIPTION
Fix build break for Windows, caused by a [previous patch](https://github.com/llvm/llvm-project/pull/102223) using `PATH_MAX` which is undefined in Windows.

The fix is to `#include "lldb/Host/PosixApi.h"` in the source file.