### PR TITLE
[lldb][dotest] Add an arg to add DLL search paths.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -219,6 +219,10 @@ def parseOptionsAndInitTestdirs():
     except:
         raise
 
+    if args.dll_directory:
+        for dir in args.dll_directory:
+            os.add_dll_directory(dir)
+
     if args.unset_env_varnames:
         for env_var in args.unset_env_varnames:
             if env_var in os.environ:

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -321,6 +321,12 @@ def create_parser():
         action="append",
         help="Specify an environment variable to set to the given value for the inferior.",
     )
+    # See https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew.
+    group.add_argument(
+        "--dll-directory",
+        action="append",
+        help="Specify a directory to include when searching for .dll files. This can be passed multiple times.",
+    )
     X(
         "-v",
         "Do verbose mode of unittest framework (print out each test case invocation)",


### PR DESCRIPTION
In python 3.8 PATH is no longer used to search for DLLs on Windows. When building Swift's patched version of LLDB this prevents LLDB from starting up, because it cannot find DLLs like swiftCore.dll, cmark-gfm.dll, etc. This PR adds a flag that can be passed to manually add specific directories as DLL search paths. This is preferred over simply expanding all directories in PATH which would recreate the code-injection security issues that the Python 3.8 change was [designed to address](https://github.com/python/cpython/issues/80266).

For context in this change to Python 3.8, see: https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew

Fixes https://github.com/llvm/llvm-project/issues/46235

Related to https://github.com/swiftlang/llvm-project/issues/9141