### PR TITLE
[bazel] Fix cyclic dependencies for macos

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -469,7 +469,7 @@ cc_library(
         "include/lldb/Host/posix/*.h",
     ]),
     strip_include_prefix = "include",
-    deps = [":Utility"],
+    deps = [":UtilityHeaders"],
 )
 
 cc_library(
@@ -484,7 +484,7 @@ cc_library(
         "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    deps = [":Utility"],
+    deps = [":UtilityHeaders"],
 )
 
 objc_library(
@@ -502,7 +502,7 @@ objc_library(
         ":Headers",
         ":HostMacOSXHeaders",
         ":HostMacOSXPrivateHeaders",
-        ":Utility",
+        ":UtilityHeaders",
         "//llvm:Support",
         "//llvm:TargetParser",
     ],


### PR DESCRIPTION
Similar to https://github.com/llvm/llvm-project/pull/104481. Replace more "Utility" dependencies with "UtilityHeaders" to avoid cyclic dependency when building on macos.