### PR TITLE
[SandboxIR] Implement AtomicRMWInst

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIRValues.def
+++ b/llvm/include/llvm/SandboxIR/SandboxIRValues.def
@@ -68,6 +68,7 @@ DEF_INSTR(BinaryOperator, OPCODES(\
                          OP(Or)   \
                          OP(Xor)  \
                          ),                 BinaryOperator)
+DEF_INSTR(AtomicRMW,     OP(AtomicRMW),     AtomicRMWInst)
 DEF_INSTR(AtomicCmpXchg, OP(AtomicCmpXchg), AtomicCmpXchgInst)
 DEF_INSTR(Alloca,         OP(Alloca),         AllocaInst)
 DEF_INSTR(Cast,   OPCODES(\


### PR DESCRIPTION
This patch implements sandboxir::AtomicRMWInst mirroring llvm::AtomicRMWInst.