### PR TITLE
[NFC] Fix typo: "wererenamed" to "were renamed"

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1056,7 +1056,7 @@ def : InstAlias<"sltu $rd, $rs1, $imm12",
 
 def : MnemonicAlias<"move", "mv">;
 
-// The SCALL and SBREAK instructions wererenamed to ECALL and EBREAK in
+// The SCALL and SBREAK instructions were renamed to ECALL and EBREAK in
 // version 2.1 of the user-level ISA. Like the GNU toolchain, we still accept
 // the old name for backwards compatibility.
 def : MnemonicAlias<"scall", "ecall">;


### PR DESCRIPTION
This commit corrects a typo in a comment from "wererenamed" to "were renamed". No functional changes.