### PR TITLE
Add "clang-format-on-save-mode" minor mode to clang-format.el

### DIFF
--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -232,8 +232,6 @@ the function `buffer-file-name'."
 (defalias 'clang-format 'clang-format-region)
 
 ;; Format on save minor mode.
-;;
-;; Optional minor mode for formatting on save.
 
 (defun clang-format--on-save-buffer-hook ()
   "The hook to run on buffer saving to format the buffer."
@@ -259,7 +257,7 @@ the function `buffer-file-name'."
   (let ((filepath buffer-file-name))
     (cond
      (filepath
-      (null (null (locate-dominating-file (file-name-directory filepath) ".clang-format"))))
+      (not (null (locate-dominating-file (file-name-directory filepath) ".clang-format"))))
      (t
       nil))))
 

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -236,7 +236,7 @@ the function `buffer-file-name'."
 (defun clang-format--on-save-buffer-hook ()
   "The hook to run on buffer saving to format the buffer."
   ;; Demote errors as this is user configurable, we can't be sure it wont error.
-  (when (with-demoted-errors "clang-format-on-save: Error %S"
+  (when (with-demoted-errors "clang-format: Error %S"
           (funcall clang-format-on-save-p))
     (clang-format-buffer))
   ;; Continue to save.

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -70,6 +70,20 @@ in such buffers."
   :safe #'stringp)
 (make-variable-buffer-local 'clang-format-fallback-style)
 
+(defcustom clang-format-on-save-p 'clang-format-on-save-check-config-exists
+  "Only reformat on save if this function returns non-nil.
+
+You may wish to choose one of the following options:
+- `always': To always format on save.
+- `clang-format-on-save-check-config-exists':
+  Only reformat when \".clang-format\" exists.
+
+Otherwise you can set this to a user defined function."
+  :group 'clang-format
+  :type 'function
+  :risky t)
+(make-variable-buffer-local 'clang-format-on-save-p)
+
 (defun clang-format--extract (xml-node)
   "Extract replacements and cursor information from XML-NODE."
   (unless (and (listp xml-node) (eq (xml-node-name xml-node) 'replacements))
@@ -216,6 +230,51 @@ the function `buffer-file-name'."
 
 ;;;###autoload
 (defalias 'clang-format 'clang-format-region)
+
+;; Format on save minor mode.
+;;
+;; Optional minor mode for formatting on save.
+
+(defun clang-format--on-save-buffer-hook ()
+  "The hook to run on buffer saving to format the buffer."
+  ;; Demote errors as this is user configurable, we can't be sure it wont error.
+  (when (with-demoted-errors "clang-format-on-save: Error %S"
+          (funcall clang-format-on-save-p))
+    (clang-format-buffer))
+  ;; Continue to save.
+  nil)
+
+(defun clang-format--on-save-enable ()
+  "Disable the minor mode."
+  (add-hook 'before-save-hook #'clang-format--on-save-buffer-hook nil t))
+
+(defun clang-format--on-save-disable ()
+  "Enable the minor mode."
+  (remove-hook 'before-save-hook #'clang-format--on-save-buffer-hook t))
+
+;; Default value for `clang-format-on-save-p'.
+(defun clang-format-on-save-check-config-exists ()
+  "Return non-nil when `.clang-format' is found in a parent directory."
+  ;; Unlikely but possible this is nil.
+  (let ((filepath buffer-file-name))
+    (cond
+     (filepath
+      (null (null (locate-dominating-file (file-name-directory filepath) ".clang-format"))))
+     (t
+      nil))))
+
+;;;###autoload
+(define-minor-mode clang-format-on-save-mode
+  "Clang-format on save minor mode."
+  :global nil
+  :lighter ""
+  :keymap nil
+
+  (cond
+   (clang-format-on-save-mode
+    (clang-format--on-save-enable))
+   (t
+    (clang-format--on-save-disable))))
 
 (provide 'clang-format)
 ;;; clang-format.el ends here


### PR DESCRIPTION
Add an minor mode which can be optionally used to run clang-format on save.

Formatting before saving works well and is convenient to avoid having to remember to manually run clang format.

I've written this as it's own package but it's probably better if the functionality is supported by clang-format.el.
See: https://github.com/melpa/melpa/pull/8762