### PR TITLE
[Symbolizer, DebugInfo] Clean up LLVMSymbolizer API: const string& -> StringRef

### DIFF
--- a/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -77,7 +77,7 @@ public:
   // Overloads accepting ObjectFile does not support COFF currently
   Expected<DILineInfo> symbolizeCode(const ObjectFile &Obj,
                                      object::SectionedAddress ModuleOffset);
-  Expected<DILineInfo> symbolizeCode(const std::string &ModuleName,
+  Expected<DILineInfo> symbolizeCode(StringRef ModuleName,
                                      object::SectionedAddress ModuleOffset);
   Expected<DILineInfo> symbolizeCode(ArrayRef<uint8_t> BuildID,
                                      object::SectionedAddress ModuleOffset);
@@ -85,7 +85,7 @@ public:
   symbolizeInlinedCode(const ObjectFile &Obj,
                        object::SectionedAddress ModuleOffset);
   Expected<DIInliningInfo>
-  symbolizeInlinedCode(const std::string &ModuleName,
+  symbolizeInlinedCode(StringRef ModuleName,
                        object::SectionedAddress ModuleOffset);
   Expected<DIInliningInfo>
   symbolizeInlinedCode(ArrayRef<uint8_t> BuildID,
@@ -93,14 +93,14 @@ public:
 
   Expected<DIGlobal> symbolizeData(const ObjectFile &Obj,
                                    object::SectionedAddress ModuleOffset);
-  Expected<DIGlobal> symbolizeData(const std::string &ModuleName,
+  Expected<DIGlobal> symbolizeData(StringRef ModuleName,
                                    object::SectionedAddress ModuleOffset);
   Expected<DIGlobal> symbolizeData(ArrayRef<uint8_t> BuildID,
                                    object::SectionedAddress ModuleOffset);
   Expected<std::vector<DILocal>>
   symbolizeFrame(const ObjectFile &Obj, object::SectionedAddress ModuleOffset);
   Expected<std::vector<DILocal>>
-  symbolizeFrame(const std::string &ModuleName,
+  symbolizeFrame(StringRef ModuleName,
                  object::SectionedAddress ModuleOffset);
   Expected<std::vector<DILocal>>
   symbolizeFrame(ArrayRef<uint8_t> BuildID,
@@ -109,7 +109,7 @@ public:
   Expected<std::vector<DILineInfo>>
   findSymbol(const ObjectFile &Obj, StringRef Symbol, uint64_t Offset);
   Expected<std::vector<DILineInfo>>
-  findSymbol(const std::string &ModuleName, StringRef Symbol, uint64_t Offset);
+  findSymbol(StringRef ModuleName, StringRef Symbol, uint64_t Offset);
   Expected<std::vector<DILineInfo>>
   findSymbol(ArrayRef<uint8_t> BuildID, StringRef Symbol, uint64_t Offset);
 
@@ -133,7 +133,7 @@ public:
   /// only reported once. Subsequent calls to get module info for a module that
   /// failed to load will return nullptr.
   Expected<SymbolizableModule *>
-  getOrCreateModuleInfo(const std::string &ModuleName);
+  getOrCreateModuleInfo(StringRef ModuleName);
 
 private:
   // Bundles together object file with code/data and object file with
@@ -210,7 +210,7 @@ private:
       ObjectPairForPathArch;
 
   /// Contains parsed binary for each path, or parsing error.
-  std::map<std::string, CachedBinary> BinaryForPath;
+  std::map<std::string, CachedBinary, std::less<>> BinaryForPath;
 
   /// A list of cached binaries in LRU order.
   simple_ilist<CachedBinary> LRUBinaries;

--- a/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -100,8 +100,7 @@ public:
   Expected<std::vector<DILocal>>
   symbolizeFrame(const ObjectFile &Obj, object::SectionedAddress ModuleOffset);
   Expected<std::vector<DILocal>>
-  symbolizeFrame(StringRef ModuleName,
-                 object::SectionedAddress ModuleOffset);
+  symbolizeFrame(StringRef ModuleName, object::SectionedAddress ModuleOffset);
   Expected<std::vector<DILocal>>
   symbolizeFrame(ArrayRef<uint8_t> BuildID,
                  object::SectionedAddress ModuleOffset);
@@ -132,8 +131,7 @@ public:
   /// Only one attempt is made to load a module, and errors during loading are
   /// only reported once. Subsequent calls to get module info for a module that
   /// failed to load will return nullptr.
-  Expected<SymbolizableModule *>
-  getOrCreateModuleInfo(StringRef ModuleName);
+  Expected<SymbolizableModule *> getOrCreateModuleInfo(StringRef ModuleName);
 
 private:
   // Bundles together object file with code/data and object file with

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -87,7 +87,7 @@ LLVMSymbolizer::symbolizeCode(const ObjectFile &Obj,
 }
 
 Expected<DILineInfo>
-LLVMSymbolizer::symbolizeCode(const std::string &ModuleName,
+LLVMSymbolizer::symbolizeCode(StringRef ModuleName,
                               object::SectionedAddress ModuleOffset) {
   return symbolizeCodeCommon(ModuleName, ModuleOffset);
 }
@@ -138,7 +138,7 @@ LLVMSymbolizer::symbolizeInlinedCode(const ObjectFile &Obj,
 }
 
 Expected<DIInliningInfo>
-LLVMSymbolizer::symbolizeInlinedCode(const std::string &ModuleName,
+LLVMSymbolizer::symbolizeInlinedCode(StringRef ModuleName,
                                      object::SectionedAddress ModuleOffset) {
   return symbolizeInlinedCodeCommon(ModuleName, ModuleOffset);
 }
@@ -183,7 +183,7 @@ LLVMSymbolizer::symbolizeData(const ObjectFile &Obj,
 }
 
 Expected<DIGlobal>
-LLVMSymbolizer::symbolizeData(const std::string &ModuleName,
+LLVMSymbolizer::symbolizeData(StringRef ModuleName,
                               object::SectionedAddress ModuleOffset) {
   return symbolizeDataCommon(ModuleName, ModuleOffset);
 }
@@ -224,7 +224,7 @@ LLVMSymbolizer::symbolizeFrame(const ObjectFile &Obj,
 }
 
 Expected<std::vector<DILocal>>
-LLVMSymbolizer::symbolizeFrame(const std::string &ModuleName,
+LLVMSymbolizer::symbolizeFrame(StringRef ModuleName,
                                object::SectionedAddress ModuleOffset) {
   return symbolizeFrameCommon(ModuleName, ModuleOffset);
 }
@@ -272,7 +272,7 @@ LLVMSymbolizer::findSymbol(const ObjectFile &Obj, StringRef Symbol,
 }
 
 Expected<std::vector<DILineInfo>>
-LLVMSymbolizer::findSymbol(const std::string &ModuleName, StringRef Symbol,
+LLVMSymbolizer::findSymbol(StringRef ModuleName, StringRef Symbol,
                            uint64_t Offset) {
   return findSymbolCommon(ModuleName, Symbol, Offset);
 }
@@ -604,13 +604,13 @@ LLVMSymbolizer::createModuleInfo(const ObjectFile *Obj,
 }
 
 Expected<SymbolizableModule *>
-LLVMSymbolizer::getOrCreateModuleInfo(const std::string &ModuleName) {
-  std::string BinaryName = ModuleName;
-  std::string ArchName = Opts.DefaultArch;
+LLVMSymbolizer::getOrCreateModuleInfo(StringRef ModuleName) {
+  StringRef BinaryName = ModuleName;
+  StringRef ArchName = Opts.DefaultArch;
   size_t ColonPos = ModuleName.find_last_of(':');
   // Verify that substring after colon form a valid arch name.
   if (ColonPos != std::string::npos) {
-    std::string ArchStr = ModuleName.substr(ColonPos + 1);
+    StringRef ArchStr = ModuleName.substr(ColonPos + 1);
     if (Triple(ArchStr).getArch() != Triple::UnknownArch) {
       BinaryName = ModuleName.substr(0, ColonPos);
       ArchName = ArchStr;
@@ -623,7 +623,8 @@ LLVMSymbolizer::getOrCreateModuleInfo(const std::string &ModuleName) {
     return I->second.get();
   }
 
-  auto ObjectsOrErr = getOrCreateObjectPair(BinaryName, ArchName);
+  auto ObjectsOrErr =
+      getOrCreateObjectPair(std::string{BinaryName}, std::string{ArchName});
   if (!ObjectsOrErr) {
     // Failed to find valid object file.
     Modules.emplace(ModuleName, std::unique_ptr<SymbolizableModule>());


### PR DESCRIPTION
Nothing in the affected code depends on the `ModuleName` being null-terminated,
so take it by `StringRef` instead of `const std::string &`.

This change simplifies API consumption, since one doesn't always have a `std::string` at the call site (might have `std::string_view` instead), and also gives some minor performance improvements by removing string-copies in the cache-hit path of `getOrCreateModuleInfo`.
