### PR TITLE
[MLIR] Expose API for setting output format enum on DefaultTimingManger

### DIFF
--- a/mlir/include/mlir/Support/Timing.h
+++ b/mlir/include/mlir/Support/Timing.h
@@ -430,6 +430,9 @@ public:
   /// Change the stream where the output will be printed to.
   void setOutput(std::unique_ptr<OutputStrategy> output);
 
+  /// Change the output format.
+  void setOutputFormat(OutputFormat format);
+
   /// Print and clear the timing results. Only call this when there are no more
   /// references to nested timers around, as printing post-processes and clears
   /// the timers.

--- a/mlir/lib/Support/Timing.cpp
+++ b/mlir/lib/Support/Timing.cpp
@@ -527,6 +527,14 @@ void DefaultTimingManager::setOutput(std::unique_ptr<OutputStrategy> output) {
   out = std::move(output);
 }
 
+/// Change the output format.
+void DefaultTimingManager::setOutputFormat(OutputFormat outputFormat) {
+  if (outputFormat == OutputFormat::Text)
+    setOutput(std::make_unique<OutputTextStrategy>(llvm::errs()));
+  else if (outputFormat == OutputFormat::Json)
+    setOutput(std::make_unique<OutputJsonStrategy>(llvm::errs()));
+}
+
 /// Print and clear the timing results.
 void DefaultTimingManager::print() {
   if (impl->enabled) {


### PR DESCRIPTION
This change allows for selecting the output format of the `DefaultTimingManager` through an API which was previously only accessible when running e.g. `mlir-opt --mlir-timing --mlir-output-format=<value>` at the command line. The use case is to be able to enable MLIR pass timing in situations when setting CL options is not viable. The `DefaultTimingManager` already allows for setting the `DisplayMode` in a similar manner.