### PR TITLE
[TableGen] Sign extend constants based on size for EmitIntegerMatcher.

### DIFF
--- a/llvm/utils/TableGen/Common/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.h
@@ -836,7 +836,8 @@ class EmitIntegerMatcher : public Matcher {
 
 public:
   EmitIntegerMatcher(int64_t val, MVT::SimpleValueType vt)
-      : Matcher(EmitInteger), Val(val), VT(vt) {}
+      : Matcher(EmitInteger), Val(SignExtend64(val, MVT(vt).getSizeInBits())),
+        VT(vt) {}
 
   int64_t getValue() const { return Val; }
   MVT::SimpleValueType getVT() const { return VT; }


### PR DESCRIPTION
I'm planning to add a getSignedConstant to SelectionDAG and use it for EmitInteger in SelectionDAGISel which already uses int64_t. getSignedConstant will verify that the constant has the correct number of significant bits for the VT.

This patch ensures that tablegen emits constants in this form.

It does reduce X86GenDAGISel.inc by a few bytes.