### PR TITLE
[mlir][EmitC] Do not convert illegal types in EmitC

### DIFF
--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitCPass.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitCPass.cpp
@@ -33,9 +33,9 @@ struct ConvertMemRefToEmitCPass
 
     // Fallback for other types.
     converter.addConversion([](Type type) -> std::optional<Type> {
-      if (isa<MemRefType>(type))
-        return {};
-      return type;
+      if (emitc::isSupportedEmitCType(type))
+        return type;
+      return {};
     });
 
     populateMemRefToEmitCTypeConversion(converter);

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-failed.mlir
@@ -43,3 +43,19 @@ func.func @zero_rank() {
 
 // expected-error@+1 {{failed to legalize operation 'memref.global'}}
 memref.global "nested" constant @nested_global : memref<3x7xf32>
+
+// -----
+
+func.func @unsupported_type_f16() {
+  // expected-error@+1 {{failed to legalize operation 'memref.alloca'}}
+  %0 = memref.alloca() : memref<4xf16>
+  return
+}
+
+// -----
+
+func.func @unsupported_type_i4() {
+  // expected-error@+1 {{failed to legalize operation 'memref.alloca'}}
+  %0 = memref.alloca() : memref<4xi4>
+  return
+}


### PR DESCRIPTION
This patch adds check for unsupported types in emitc, which fixes a crash. Fix #103706.