### PR TITLE
[clang] Add a new test for CWG2091

### DIFF
--- a/clang/test/CXX/drs/cwg20xx.cpp
+++ b/clang/test/CXX/drs/cwg20xx.cpp
@@ -401,11 +401,34 @@ namespace cwg2083 { // cwg2083: partial
 #endif
 }
 
-namespace cwg2091 { // cwg2091: 2.7
+namespace cwg2091 { // cwg2091: 10
 template<int &> struct X;
 template<int &N> void f(X<N>&);
 int n;
 void g(X<n> &x) { f(x); }
+
+namespace GH42233 {
+enum E { I };
+
+class AA { };
+E EV[1] = {I};
+
+template<class ENUM, const ENUM* const VALUES>
+struct S
+{
+	template< class E, const E* const V>
+		friend AA& operator<<( AA& os, const S<E,V>& e );
+};
+
+int f()
+{
+	S< E, EV > x;
+
+	AA a;
+	a << x;
+	return 0;
+}
+} // namespace GH42233
 } // namespace cwg2091 
 
 namespace cwg2094 { // cwg2094: 5

--- a/clang/test/CXX/drs/cwg20xx.cpp
+++ b/clang/test/CXX/drs/cwg20xx.cpp
@@ -416,17 +416,17 @@ E EV[1] = {I};
 template<class ENUM, const ENUM* const VALUES>
 struct S
 {
-	template< class E, const E* const V>
-		friend AA& operator<<( AA& os, const S<E,V>& e );
+  template< class E, const E* const V>
+    friend AA& operator<<( AA& os, const S<E,V>& e );
 };
 
 int f()
 {
-	S< E, EV > x;
+  S< E, EV > x;
 
-	AA a;
-	a << x;
-	return 0;
+  AA a;
+  a << x;
+  return 0;
 }
 } // namespace GH42233
 } // namespace cwg2091 

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -12361,7 +12361,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2091.html">2091</a></td>
     <td>CD4</td>
     <td>Deducing reference non-type template arguments</td>
-    <td class="full" align="center">Clang 2.7</td>
+    <td class="full" align="center">Clang 10</td>
   </tr>
   <tr id="2092">
     <td><a href="https://cplusplus.github.io/CWG/issues/2092.html">2092</a></td>


### PR DESCRIPTION
This patch adds a test from https://github.com/llvm/llvm-project/issues/42233, and updates CWG2091 status from `2.7` to `10`.