### PR TITLE
[TableGen] Resolve References at top level

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -4460,8 +4460,13 @@ bool TGParser::ParseDump(MultiClass *CurMultiClass, Record *CurRec) {
 
   if (CurRec)
     CurRec->addDump(Loc, Message);
-  else
-    addEntry(std::make_unique<Record::DumpInfo>(Loc, Message));
+  else {
+    HasReferenceResolver resolver{nullptr};
+    resolver.setFinal(true);
+    // force a resolution with a dummy resolver
+    Init *ResolvedMessage = Message->resolveReferences(resolver);
+    addEntry(std::make_unique<Record::DumpInfo>(Loc, ResolvedMessage));
+  }
 
   return false;
 }

--- a/llvm/test/TableGen/dump.td
+++ b/llvm/test/TableGen/dump.td
@@ -101,3 +101,6 @@ def Three : BaseClassForSet;
 }
 // CHECK: [[FILE]]:[[@LINE+1]]:1: note: TheSet = [Subset_One, Subset_Two, Three]
 dump "TheSet = " # !repr(TheSet);
+
+// CHECK: [[FILE]]:[[@LINE+1]]:1: note: 0
+dump !repr(!exists<BaseClassForSet>("non-existent-record"));


### PR DESCRIPTION
Add a dummy resolver to resolve references outside records. This invokes Fold() with isFinal to force resolution.

Fixes #102447