### PR TITLE
[SimplifyCFG] Don't block sinking for allocas if no phi created

### DIFF
--- a/llvm/test/CodeGen/Hexagon/block-addr.ll
+++ b/llvm/test/CodeGen/Hexagon/block-addr.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=hexagon < %s | FileCheck %s
+; RUN: llc -march=hexagon -hexagon-initial-cfg-cleanup=0 < %s | FileCheck %s
 
 ; CHECK-DAG: r[[REG:[0-9]+]] = memw(r{{[0-9]+<<#[0-9]+}}+##.LJTI{{.*}})
 ; CHECK-DAG: jumpr r[[REG]]

--- a/llvm/test/DebugInfo/ARM/single-constant-use-preserves-dbgloc.ll
+++ b/llvm/test/DebugInfo/ARM/single-constant-use-preserves-dbgloc.ll
@@ -1,4 +1,4 @@
-; RUN: llc -filetype=asm -asm-verbose=0 < %s | FileCheck %s
+; RUN: llc -filetype=asm -asm-verbose=0 -arm-atomic-cfg-tidy=0 < %s | FileCheck %s
 
 ; int main()
 ; {

--- a/llvm/test/Transforms/SimplifyCFG/sink-and-convert-switch.ll
+++ b/llvm/test/Transforms/SimplifyCFG/sink-and-convert-switch.ll
@@ -9,23 +9,8 @@ define void @pr104567(i8 %x, ptr %f) {
 ; CHECK-NEXT:  [[START:.*:]]
 ; CHECK-NEXT:    [[Y:%.*]] = alloca [1 x i8], align 1
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(i64 1, ptr nonnull [[Y]])
-; CHECK-NEXT:    switch i8 [[X]], label %[[DEFAULT_UNREACHABLE:.*]] [
-; CHECK-NEXT:      i8 0, label %[[BB4:.*]]
-; CHECK-NEXT:      i8 1, label %[[BB3:.*]]
-; CHECK-NEXT:      i8 2, label %[[BB2:.*]]
-; CHECK-NEXT:    ]
-; CHECK:       [[DEFAULT_UNREACHABLE]]:
-; CHECK-NEXT:    unreachable
-; CHECK:       [[BB4]]:
-; CHECK-NEXT:    store i8 4, ptr [[Y]], align 1
-; CHECK-NEXT:    br label %[[BB5:.*]]
-; CHECK:       [[BB3]]:
-; CHECK-NEXT:    store i8 5, ptr [[Y]], align 1
-; CHECK-NEXT:    br label %[[BB5]]
-; CHECK:       [[BB2]]:
-; CHECK-NEXT:    store i8 6, ptr [[Y]], align 1
-; CHECK-NEXT:    br label %[[BB5]]
-; CHECK:       [[BB5]]:
+; CHECK-NEXT:    [[SWITCH_OFFSET:%.*]] = add nsw i8 [[X]], 4
+; CHECK-NEXT:    store i8 [[SWITCH_OFFSET]], ptr [[Y]], align 1
 ; CHECK-NEXT:    call void [[F]](ptr [[Y]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 1, ptr nonnull [[Y]])
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
SimplifyCFG sinking currently does not sink loads/stores of allocas, because historically SROA was unable to handle the resulting IR. Since then, SROA both learned to speculate loads/stores over selects and phis, *and* SimplifyCFG sinking has been deferred to the end of the function simplificatoin pipeline, which means that SROA happens before it.

As such, I believe that this workaround should no longer be necessary. Given how sensitive SimplifyCFG sinking seems to be, this patch takes a very conservative step towards removing this, by allowing sinking if we don't actually need to form a phi over the pointer argument.

This fixes https://github.com/llvm/llvm-project/issues/104567, where sinking a store to an escaped alloca allows converting a switch into arithmetic.