### PR TITLE
[clang][Interp] Fix classifying enum types

### DIFF
--- a/clang/lib/AST/Interp/Context.cpp
+++ b/clang/lib/AST/Interp/Context.cpp
@@ -135,6 +135,9 @@ std::optional<PrimType> Context::classify(QualType T) const {
   if (T->isAnyComplexType() || T->isVectorType())
     return std::nullopt;
 
+  if (const auto *ET = T->getAs<EnumType>())
+    return classify(ET->getDecl()->getIntegerType());
+
   if (T->isSignedIntegerOrEnumerationType()) {
     switch (Ctx.getIntWidth(T)) {
     case 64:

--- a/clang/test/AST/Interp/enums.cpp
+++ b/clang/test/AST/Interp/enums.cpp
@@ -48,3 +48,8 @@ constexpr EC getB() {
 
 
 static_assert(getB() == EC::B, "");
+
+namespace B {
+  enum E : bool { Zero, One };
+  static_assert((int)(E)2 == 1, "");
+} // namespace B


### PR DESCRIPTION
We used to always return PT_IntAP(s) for them.