### PR TITLE
[lldb-dap] Implement value locations for function pointers

### DIFF
--- a/lldb/test/API/tools/lldb-dap/locations/Makefile
+++ b/lldb/test/API/tools/lldb-dap/locations/Makefile
@@ -1,3 +1,3 @@
-C_SOURCES := main.c
+CXX_SOURCES := main.cpp
 
 include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
+++ b/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
@@ -19,11 +19,11 @@ class TestDAP_locations(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
-        source = "main.c"
+        source = "main.cpp"
         self.source_path = os.path.join(os.getcwd(), source)
         self.set_source_breakpoints(
             source,
-            [line_number(source, "// BREAK HERE")],
+            [line_number(source, "break here")],
         )
         self.continue_to_next_stop()
 
@@ -36,5 +36,46 @@ class TestDAP_locations(lldbdap_testcase.DAPTestCaseBase):
             locals["var1"]["declarationLocationReference"]
         )
         self.assertTrue(loc_var1["success"])
-        self.assertTrue(loc_var1["body"]["source"]["path"].endswith("main.c"))
-        self.assertEqual(loc_var1["body"]["line"], 2)
+        self.assertTrue(loc_var1["body"]["source"]["path"].endswith("main.cpp"))
+        self.assertEqual(loc_var1["body"]["line"], 6)
+
+        # func_ptr has both a declaration and a valueLocation
+        self.assertIn("declarationLocationReference", locals["func_ptr"].keys())
+        self.assertIn("valueLocationReference", locals["func_ptr"].keys())
+        decl_loc_func_ptr = self.dap_server.request_locations(
+            locals["func_ptr"]["declarationLocationReference"]
+        )
+        self.assertTrue(decl_loc_func_ptr["success"])
+        self.assertTrue(
+            decl_loc_func_ptr["body"]["source"]["path"].endswith("main.cpp")
+        )
+        self.assertEqual(decl_loc_func_ptr["body"]["line"], 7)
+        val_loc_func_ptr = self.dap_server.request_locations(
+            locals["func_ptr"]["valueLocationReference"]
+        )
+        self.assertTrue(val_loc_func_ptr["success"])
+        self.assertTrue(val_loc_func_ptr["body"]["source"]["path"].endswith("main.cpp"))
+        self.assertEqual(val_loc_func_ptr["body"]["line"], 3)
+
+        # func_ref has both a declaration and a valueLocation
+        self.assertIn("declarationLocationReference", locals["func_ref"].keys())
+        self.assertIn("valueLocationReference", locals["func_ref"].keys())
+        decl_loc_func_ref = self.dap_server.request_locations(
+            locals["func_ref"]["declarationLocationReference"]
+        )
+        self.assertTrue(decl_loc_func_ref["success"])
+        self.assertTrue(
+            decl_loc_func_ref["body"]["source"]["path"].endswith("main.cpp")
+        )
+        self.assertEqual(decl_loc_func_ref["body"]["line"], 8)
+        val_loc_func_ref = self.dap_server.request_locations(
+            locals["func_ref"]["valueLocationReference"]
+        )
+        self.assertTrue(val_loc_func_ref["success"])
+        self.assertTrue(val_loc_func_ref["body"]["source"]["path"].endswith("main.cpp"))
+        self.assertEqual(val_loc_func_ref["body"]["line"], 3)
+
+        # `evaluate` responses for function pointers also have locations associated
+        eval_res = self.dap_server.request_evaluate("greet")
+        self.assertTrue(eval_res["success"])
+        self.assertIn("valueLocationReference", eval_res["body"].keys())

--- a/lldb/test/API/tools/lldb-dap/locations/main.c
+++ b/lldb/test/API/tools/lldb-dap/locations/main.c
@@ -1,5 +1,0 @@
-int main(void) {
-  int var1 = 1;
-  // BREAK HERE
-  return 0;
-}

--- a/lldb/test/API/tools/lldb-dap/locations/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/locations/main.cpp
@@ -6,6 +6,5 @@ int main(void) {
   int var1 = 1;
   void (*func_ptr)() = &greet;
   void (&func_ref)() = greet;
-  __builtin_printf("break here");
-  return 0;
+  return 0; // break here
 }

--- a/lldb/test/API/tools/lldb-dap/locations/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/locations/main.cpp
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+void greet() { printf("Hello"); }
+
+int main(void) {
+  int var1 = 1;
+  void (*func_ptr)() = &greet;
+  void (&func_ref)() = greet;
+  __builtin_printf("break here");
+  return 0;
+}

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -1198,10 +1198,9 @@ std::string VariableDescription::GetResult(llvm::StringRef context) {
   return description.trim().str();
 }
 
-bool HasValueLocation(lldb::SBValue v) {
-  if (!v.GetType().IsPointerType() && !v.GetType().IsReferenceType()) {
+bool ValuePointsToCode(lldb::SBValue v) {
+  if (!v.GetType().GetPointeeType().IsFunctionType())
     return false;
-  }
 
   lldb::addr_t addr = v.GetValueAsAddress();
   lldb::SBLineEntry line_entry =
@@ -1424,7 +1423,7 @@ llvm::json::Value CreateVariable(lldb::SBValue v, int64_t var_ref,
   if (v.GetDeclaration().IsValid())
     object.try_emplace("declarationLocationReference", PackLocation(var_ref, false));
 
-  if (HasValueLocation(v))
+  if (ValuePointsToCode(v))
     object.try_emplace("valueLocationReference", PackLocation(var_ref, true));
 
   if (lldb::addr_t addr = v.GetLoadAddress(); addr != LLDB_INVALID_ADDRESS)

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -1198,6 +1198,18 @@ std::string VariableDescription::GetResult(llvm::StringRef context) {
   return description.trim().str();
 }
 
+bool HasValueLocation(lldb::SBValue v) {
+  if (!v.GetType().IsPointerType() && !v.GetType().IsReferenceType()) {
+    return false;
+  }
+
+  lldb::addr_t addr = v.GetValueAsAddress();
+  lldb::SBLineEntry line_entry =
+      g_dap.target.ResolveLoadAddress(addr).GetLineEntry();
+
+  return line_entry.IsValid();
+}
+
 // "Variable": {
 //   "type": "object",
 //   "description": "A Variable is a name/value pair. Optionally a variable
@@ -1276,6 +1288,18 @@ std::string VariableDescription::GetResult(llvm::StringRef context) {
 //                       lifetime as the `variablesReference`. See 'Lifetime of
 //                       Object References' in the Overview section for
 //                       details."
+//     },
+//     "valueLocationReference": {
+//       "type": "integer",
+//       "description": "A reference that allows the client to request the
+//                       location where the variable's value is declared. For
+//                       example, if the variable contains a function pointer,
+//                       the adapter may be able to look up the function's
+//                       location. This should be present only if the adapter
+//                       is likely to be able to resolve the location.\n\nThis
+//                       reference shares the same lifetime as the
+//                       `variablesReference`. See 'Lifetime of Object
+//                       References' in the Overview section for details."
 //     },
 //
 //     "$__lldb_extensions": {
@@ -1390,7 +1414,10 @@ llvm::json::Value CreateVariable(lldb::SBValue v, int64_t var_ref,
     object.try_emplace("variablesReference", 0);
 
   if (v.GetDeclaration().IsValid())
-    object.try_emplace("declarationLocationReference", var_ref);
+    object.try_emplace("declarationLocationReference", var_ref << 1);
+
+  if (HasValueLocation(v))
+    object.try_emplace("valueLocationReference", (var_ref << 1) | 1);
 
   if (lldb::addr_t addr = v.GetLoadAddress(); addr != LLDB_INVALID_ADDRESS)
     object.try_emplace("memoryReference", EncodeMemoryReference(addr));
@@ -1416,8 +1443,8 @@ CreateRunInTerminalReverseRequest(const llvm::json::Object &launch_request,
                                   llvm::StringRef comm_file,
                                   lldb::pid_t debugger_pid) {
   llvm::json::Object run_in_terminal_args;
-  // This indicates the IDE to open an embedded terminal, instead of opening the
-  // terminal in a new window.
+  // This indicates the IDE to open an embedded terminal, instead of opening
+  // the terminal in a new window.
   run_in_terminal_args.try_emplace("kind", "integrated");
 
   auto launch_request_arguments = launch_request.getObject("arguments");

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -1210,11 +1210,11 @@ bool ValuePointsToCode(lldb::SBValue v) {
 }
 
 int64_t PackLocation(int64_t var_ref, bool is_value_location) {
-   return var_ref << 1 | is_value_location;
+  return var_ref << 1 | is_value_location;
 }
 
 std::pair<int64_t, bool> UnpackLocation(int64_t location_id) {
-   return std::pair{ location_id >> 1, location_id & 1};
+  return std::pair{location_id >> 1, location_id & 1};
 }
 
 // "Variable": {
@@ -1421,7 +1421,8 @@ llvm::json::Value CreateVariable(lldb::SBValue v, int64_t var_ref,
     object.try_emplace("variablesReference", 0);
 
   if (v.GetDeclaration().IsValid())
-    object.try_emplace("declarationLocationReference", PackLocation(var_ref, false));
+    object.try_emplace("declarationLocationReference",
+                       PackLocation(var_ref, false));
 
   if (ValuePointsToCode(v))
     object.try_emplace("valueLocationReference", PackLocation(var_ref, true));

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -1210,6 +1210,14 @@ bool HasValueLocation(lldb::SBValue v) {
   return line_entry.IsValid();
 }
 
+int64_t PackLocation(int64_t var_ref, bool is_value_location) {
+   return var_ref << 1 | is_value_location;
+}
+
+std::pair<int64_t, bool> UnpackLocation(int64_t location_id) {
+   return std::pair{ location_id >> 1, location_id & 1};
+}
+
 // "Variable": {
 //   "type": "object",
 //   "description": "A Variable is a name/value pair. Optionally a variable
@@ -1414,10 +1422,10 @@ llvm::json::Value CreateVariable(lldb::SBValue v, int64_t var_ref,
     object.try_emplace("variablesReference", 0);
 
   if (v.GetDeclaration().IsValid())
-    object.try_emplace("declarationLocationReference", var_ref << 1);
+    object.try_emplace("declarationLocationReference", PackLocation(var_ref, false));
 
   if (HasValueLocation(v))
-    object.try_emplace("valueLocationReference", (var_ref << 1) | 1);
+    object.try_emplace("valueLocationReference", PackLocation(var_ref, true));
 
   if (lldb::addr_t addr = v.GetLoadAddress(); addr != LLDB_INVALID_ADDRESS)
     object.try_emplace("memoryReference", EncodeMemoryReference(addr));

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -461,6 +461,13 @@ struct VariableDescription {
 /// Does the given variable have an associated value location?
 bool HasValueLocation(lldb::SBValue v);
 
+/// Pack a location into a single integer which we can send via
+/// the debug adapter protocol.
+int64_t PackLocation(int64_t var_ref, bool is_value_location);
+
+/// Reverse of `PackLocation`
+std::pair<int64_t, bool> UnpackLocation(int64_t location_id);
+
 /// Create a "Variable" object for a LLDB thread object.
 ///
 /// This function will fill in the following keys in the returned

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -458,6 +458,9 @@ struct VariableDescription {
   std::string GetResult(llvm::StringRef context);
 };
 
+/// Does the given variable have an associated value location?
+bool HasValueLocation(lldb::SBValue v);
+
 /// Create a "Variable" object for a LLDB thread object.
 ///
 /// This function will fill in the following keys in the returned

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -459,7 +459,7 @@ struct VariableDescription {
 };
 
 /// Does the given variable have an associated value location?
-bool HasValueLocation(lldb::SBValue v);
+bool ValuePointsToCode(lldb::SBValue v);
 
 /// Pack a location into a single integer which we can send via
 /// the debug adapter protocol.

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1642,7 +1642,7 @@ void request_evaluate(const llvm::json::Object &request) {
       EmplaceSafeString(body, "result", desc.GetResult(context));
       EmplaceSafeString(body, "type", desc.display_type_name);
       int64_t var_ref = 0;
-      if (value.MightHaveChildren() || HasValueLocation(value))
+      if (value.MightHaveChildren() || ValuePointsToCode(value))
          var_ref = g_dap.variables.InsertVariable(
           value, /*is_permanent=*/context == "repl");
       if (value.MightHaveChildren())
@@ -1652,7 +1652,7 @@ void request_evaluate(const llvm::json::Object &request) {
       if (lldb::addr_t addr = value.GetLoadAddress();
           addr != LLDB_INVALID_ADDRESS)
         body.try_emplace("memoryReference", EncodeMemoryReference(addr));
-      if (HasValueLocation(value))
+      if (ValuePointsToCode(value))
         body.try_emplace("valueLocationReference", var_ref);
     }
   }
@@ -3841,7 +3841,7 @@ void request_setVariable(const llvm::json::Object &request) {
       if (lldb::addr_t addr = variable.GetLoadAddress();
           addr != LLDB_INVALID_ADDRESS)
         body.try_emplace("memoryReference", EncodeMemoryReference(addr));
-      if (HasValueLocation(variable))
+      if (ValuePointsToCode(variable))
         body.try_emplace("valueLocationReference", new_var_ref);
     } else {
       EmplaceSafeString(body, "message", std::string(error.GetCString()));

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1643,8 +1643,8 @@ void request_evaluate(const llvm::json::Object &request) {
       EmplaceSafeString(body, "type", desc.display_type_name);
       int64_t var_ref = 0;
       if (value.MightHaveChildren() || ValuePointsToCode(value))
-         var_ref = g_dap.variables.InsertVariable(
-          value, /*is_permanent=*/context == "repl");
+        var_ref = g_dap.variables.InsertVariable(
+            value, /*is_permanent=*/context == "repl");
       if (value.MightHaveChildren())
         body.try_emplace("variablesReference", var_ref);
       else


### PR DESCRIPTION
This commit adds `valueLocationReference` to function pointers and function references. Thereby, users can navigate directly to the pointed-to function from within the "variables" pane.

In general, it would be useful to also a add similar location references also to member function pointers, `std::source_location`, `std::function`,  and many more. Doing so would require extending the formatters to provide such a source code location.

There were two RFCs about this a while ago:
https://discourse.llvm.org/t/rfc-extending-formatters-with-a-source-code-reference/68375
https://discourse.llvm.org/t/rfc-sbvalue-metadata-provider/68377/26

However, both RFCs ended without a conclusion. As such, this commit now implements the lowest-hanging fruit, i.e. function pointers. If people find it useful, I will revive the RFC afterwards.
