### PR TITLE
[analyzer] [MallocChecker] suspect all release functions as candidate for suppression

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -3676,7 +3676,7 @@ PathDiagnosticPieceRef MallocBugVisitor::VisitNode(const ExplodedNode *N,
             }
 
             // Switch suspection to outer destructor to catch patterns like:
-            // (note that class name is special to bypass
+            // (note that class name is distorted to bypass
             // isReferenceCountingPointerDestructor() logic)
             //
             // SmartPointr::~SmartPointr() {

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -3552,8 +3552,8 @@ PathDiagnosticPieceRef MallocBugVisitor::VisitNode(const ExplodedNode *N,
   const LocationContext *CurrentLC = N->getLocationContext();
 
   // If we find an atomic fetch_add or fetch_sub within the function in which
-  // the pointer was released (before the release), this is likely a release point
-  // of reference-counted object (like shared pointer).
+  // the pointer was released (before the release), this is likely a release
+  // point of reference-counted object (like shared pointer).
   //
   // Because we don't model atomics, and also because we don't know that the
   // original reference count is positive, we should not report use-after-frees
@@ -3567,7 +3567,8 @@ PathDiagnosticPieceRef MallocBugVisitor::VisitNode(const ExplodedNode *N,
       if (Op == AtomicExpr::AO__c11_atomic_fetch_add ||
           Op == AtomicExpr::AO__c11_atomic_fetch_sub) {
         BR.markInvalid(getTag(), S);
-        // After report is considered invalid there is no need to proceed futher.
+        // After report is considered invalid there is no need to proceed
+        // futher.
         return nullptr;
       }
     } else if (const auto *CE = dyn_cast<CallExpr>(S)) {
@@ -3666,14 +3667,16 @@ PathDiagnosticPieceRef MallocBugVisitor::VisitNode(const ExplodedNode *N,
               // object, so suppress the report for now.
               BR.markInvalid(getTag(), DD);
 
-              // After report is considered invalid there is no need to proceed futher.
+              // After report is considered invalid there is no need to proceed
+              // futher.
               return nullptr;
             }
 
             // Switch suspection to outer destructor to catch patterns like:
             //
             // SmartPointr::~SmartPointr() {
-            //  if (__c11_atomic_fetch_sub(refcount, 1, memory_order_relaxed) == 1)
+            //  if (__c11_atomic_fetch_sub(refcount, 1, memory_order_relaxed) ==
+            //  1)
             //    release_resources();
             // }
             // void SmartPointr::release_resources() {
@@ -3683,15 +3686,15 @@ PathDiagnosticPieceRef MallocBugVisitor::VisitNode(const ExplodedNode *N,
             // This way ReleaseFunctionLC will point to outermost destructor and
             // it would be possible to catch wider range of FP.
             //
-            // NOTE: it would be great to support smth like that in C, since currently
-            // patterns like following won't be supressed:
-	    //
-	    // void doFree(struct Data *data) { free(data); }
-	    // void putData(struct Data *data)
-	    // {
-	    //   if (refPut(data))
-	    //     doFree(data);
-	    // }
+            // NOTE: it would be great to support smth like that in C, since
+            // currently patterns like following won't be supressed:
+            //
+            // void doFree(struct Data *data) { free(data); }
+            // void putData(struct Data *data)
+            // {
+            //   if (refPut(data))
+            //     doFree(data);
+            // }
             ReleaseFunctionLC = LC->getStackFrame();
           }
         }

--- a/clang/test/Analysis/malloc-refcounted.c
+++ b/clang/test/Analysis/malloc-refcounted.c
@@ -1,7 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.Malloc -verify %s
 //
 
-typedef unsigned long size_t;
+typedef __SIZE_TYPE__ size_t;
 
 typedef enum memory_order {
   memory_order_relaxed = __ATOMIC_RELAXED,

--- a/clang/test/Analysis/malloc-refcounted.c
+++ b/clang/test/Analysis/malloc-refcounted.c
@@ -1,0 +1,80 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.Malloc -verify %s
+//
+
+typedef unsigned long size_t;
+
+typedef enum memory_order {
+  memory_order_relaxed = __ATOMIC_RELAXED,
+} memory_order;
+
+void *calloc(size_t, size_t);
+void free(void *);
+
+struct SomeData {
+  int i;
+  _Atomic int ref;
+};
+
+static struct SomeData *alloc_data(void)
+{
+  struct SomeData *data = calloc(sizeof(*data), 1);
+
+  __c11_atomic_store(&data->ref, 2, memory_order_relaxed);
+  return data;
+}
+
+static void put_data(struct SomeData *data)
+{
+ if (__c11_atomic_fetch_sub(&data->ref, 1, memory_order_relaxed) == 1)
+   free(data);
+}
+
+static int dec_refcounter(struct SomeData *data)
+{
+  return __c11_atomic_fetch_sub(&data->ref, 1, memory_order_relaxed) == 1;
+}
+
+static void put_data_nested(struct SomeData *data)
+{
+  if (dec_refcounter(data))
+    free(data);
+}
+
+static void put_data_uncond(struct SomeData *data)
+{
+  free(data);
+}
+
+static void put_data_unrelated_atomic(struct SomeData *data)
+{
+  free(data);
+  __c11_atomic_fetch_sub(&data->ref, 1, memory_order_relaxed);
+}
+
+void test_no_uaf(void)
+{
+  struct SomeData *data = alloc_data();
+  put_data(data);
+  data->i += 1; // no warning
+}
+
+void test_no_uaf_nested(void)
+{
+  struct SomeData *data = alloc_data();
+  put_data_nested(data);
+  data->i += 1; // no warning
+}
+
+void test_uaf(void)
+{
+  struct SomeData *data = alloc_data();
+  put_data_uncond(data);
+  data->i += 1; // expected-warning{{Use of memory after it is freed}}
+}
+
+void test_no_uaf_atomic_after(void)
+{
+  struct SomeData *data = alloc_data();
+  put_data_unrelated_atomic(data);
+  data->i += 1; // expected-warning{{Use of memory after it is freed}}
+}


### PR DESCRIPTION
Current MalloChecker logic suppresses FP caused by refcounting only for C++ destructors. The same pattern occurs a lot in C in objects with intrusive refcounting. See #104229 for code example.

To extend current logic to C, suspect all release functions as candidate for suppression.

Closes: #104229