### PR TITLE
[ADT] Series of improvements to SmallSet

### DIFF
--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -118,9 +118,9 @@ public:
 
   SmallSetIterator &operator++() { // Preincrement
     if (IsSmall)
-      VecIter++;
+      ++VecIter;
     else
-      SetIter++;
+      ++SetIter;
     return *this;
   }
 

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -175,26 +175,10 @@ public:
   /// Returns a pair. The first value of it is an iterator to the inserted
   /// element or the existing element in the set. The second value is true
   /// if the element is inserted (it was not in the set before).
-  std::pair<const_iterator, bool> insert(const T &V) {
-    if (!isSmall()) {
-      auto [I, Inserted] = Set.insert(V);
-      return std::make_pair(const_iterator(I), Inserted);
-    }
+  std::pair<const_iterator, bool> insert(const T &V) { return insertImpl(V); }
 
-    VIterator I = vfind(V);
-    if (I != Vector.end())    // Don't reinsert if it already exists.
-      return std::make_pair(const_iterator(I), false);
-    if (Vector.size() < N) {
-      Vector.push_back(V);
-      return std::make_pair(const_iterator(std::prev(Vector.end())), true);
-    }
-
-    // Otherwise, grow from vector to set.
-    while (!Vector.empty()) {
-      Set.insert(Vector.back());
-      Vector.pop_back();
-    }
-    return std::make_pair(const_iterator(Set.insert(V).first), true);
+  std::pair<const_iterator, bool> insert(T &&V) {
+    return insertImpl(std::move(V));
   }
 
   template <typename IterT>
@@ -246,6 +230,31 @@ private:
       if (*I == V)
         return I;
     return Vector.end();
+  }
+
+  template <typename ArgType>
+  std::pair<const_iterator, bool> insertImpl(ArgType &&V) {
+    static_assert(std::is_convertible_v<ArgType, T>,
+                  "ArgType must be convertible to T!");
+    if (!isSmall()) {
+      auto [I, Inserted] = Set.insert(std::forward<ArgType>(V));
+      return std::make_pair(const_iterator(I), Inserted);
+    }
+
+    VIterator I = vfind(V);
+    if (I != Vector.end()) // Don't reinsert if it already exists.
+      return std::make_pair(const_iterator(I), false);
+    if (Vector.size() < N) {
+      Vector.push_back(std::forward<ArgType>(V));
+      return std::make_pair(const_iterator(std::prev(Vector.end())), true);
+    }
+
+    // Otherwise, grow from vector to set.
+    Set.insert(std::make_move_iterator(Vector.begin()),
+               std::make_move_iterator(Vector.end()));
+    Vector.clear();
+    return std::make_pair(
+        const_iterator(Set.insert(std::forward<ArgType>(V)).first), true);
   }
 };
 

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -14,14 +14,13 @@
 #ifndef LLVM_ADT_SMALLSET_H
 #define LLVM_ADT_SMALLSET_H
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator.h"
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/type_traits.h"
 #include <cstddef>
 #include <functional>
+#include <initializer_list>
 #include <set>
 #include <type_traits>
 #include <utility>
@@ -155,6 +154,22 @@ public:
   using const_iterator = SmallSetIterator<T, N, C>;
 
   SmallSet() = default;
+  SmallSet(const SmallSet &) = default;
+  SmallSet(SmallSet &&) = default;
+
+  template <typename IterT> explicit SmallSet(IterT Begin, IterT End) {
+    this->insert(Begin, End);
+  }
+
+  template <typename RangeT>
+  explicit SmallSet(const iterator_range<RangeT> &R) {
+    this->insert(R.begin(), R.end());
+  }
+
+  SmallSet(std::initializer_list<T> L) { this->insert(L.begin(), L.end()); }
+
+  SmallSet &operator=(const SmallSet &) = default;
+  SmallSet &operator=(SmallSet &&) = default;
 
   [[nodiscard]] bool empty() const { return Vector.empty() && Set.empty(); }
 

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -46,24 +46,24 @@ private:
     VecIterTy VecIter;
   };
 
-  bool isSmall;
+  bool IsSmall;
 
 public:
-  SmallSetIterator(SetIterTy SetIter) : SetIter(SetIter), isSmall(false) {}
+  SmallSetIterator(SetIterTy SetIter) : SetIter(SetIter), IsSmall(false) {}
 
-  SmallSetIterator(VecIterTy VecIter) : VecIter(VecIter), isSmall(true) {}
+  SmallSetIterator(VecIterTy VecIter) : VecIter(VecIter), IsSmall(true) {}
 
   // Spell out destructor, copy/move constructor and assignment operators for
   // MSVC STL, where set<T>::const_iterator is not trivially copy constructible.
   ~SmallSetIterator() {
-    if (isSmall)
+    if (IsSmall)
       VecIter.~VecIterTy();
     else
       SetIter.~SetIterTy();
   }
 
-  SmallSetIterator(const SmallSetIterator &Other) : isSmall(Other.isSmall) {
-    if (isSmall)
+  SmallSetIterator(const SmallSetIterator &Other) : IsSmall(Other.IsSmall) {
+    if (IsSmall)
       VecIter = Other.VecIter;
     else
       // Use placement new, to make sure SetIter is properly constructed, even
@@ -71,8 +71,8 @@ public:
       new (&SetIter) SetIterTy(Other.SetIter);
   }
 
-  SmallSetIterator(SmallSetIterator &&Other) : isSmall(Other.isSmall) {
-    if (isSmall)
+  SmallSetIterator(SmallSetIterator &&Other) : IsSmall(Other.IsSmall) {
+    if (IsSmall)
       VecIter = std::move(Other.VecIter);
     else
       // Use placement new, to make sure SetIter is properly constructed, even
@@ -83,11 +83,11 @@ public:
   SmallSetIterator& operator=(const SmallSetIterator& Other) {
     // Call destructor for SetIter, so it gets properly destroyed if it is
     // not trivially destructible in case we are setting VecIter.
-    if (!isSmall)
+    if (!IsSmall)
       SetIter.~SetIterTy();
 
-    isSmall = Other.isSmall;
-    if (isSmall)
+    IsSmall = Other.IsSmall;
+    if (IsSmall)
       VecIter = Other.VecIter;
     else
       new (&SetIter) SetIterTy(Other.SetIter);
@@ -97,11 +97,11 @@ public:
   SmallSetIterator& operator=(SmallSetIterator&& Other) {
     // Call destructor for SetIter, so it gets properly destroyed if it is
     // not trivially destructible in case we are setting VecIter.
-    if (!isSmall)
+    if (!IsSmall)
       SetIter.~SetIterTy();
 
-    isSmall = Other.isSmall;
-    if (isSmall)
+    IsSmall = Other.IsSmall;
+    if (IsSmall)
       VecIter = std::move(Other.VecIter);
     else
       new (&SetIter) SetIterTy(std::move(Other.SetIter));
@@ -109,22 +109,22 @@ public:
   }
 
   bool operator==(const SmallSetIterator &RHS) const {
-    if (isSmall != RHS.isSmall)
+    if (IsSmall != RHS.IsSmall)
       return false;
-    if (isSmall)
+    if (IsSmall)
       return VecIter == RHS.VecIter;
     return SetIter == RHS.SetIter;
   }
 
   SmallSetIterator &operator++() { // Preincrement
-    if (isSmall)
+    if (IsSmall)
       VecIter++;
     else
       SetIter++;
     return *this;
   }
 
-  const T &operator*() const { return isSmall ? *VecIter : *SetIter; }
+  const T &operator*() const { return IsSmall ? *VecIter : *SetIter; }
 };
 
 /// SmallSet - This maintains a set of unique values, optimizing for the case

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -167,9 +167,8 @@ public:
     if (isSmall()) {
       // Since the collection is small, just do a linear search.
       return vfind(V) == Vector.end() ? 0 : 1;
-    } else {
-      return Set.count(V);
     }
+    return Set.count(V);
   }
 
   /// insert - Insert an element into the set if it isn't already there.

--- a/llvm/unittests/ADT/SmallSetTest.cpp
+++ b/llvm/unittests/ADT/SmallSetTest.cpp
@@ -17,6 +17,66 @@
 
 using namespace llvm;
 
+TEST(SmallSetTest, ConstructorIteratorPair) {
+  auto L = {1, 2, 3, 4, 5};
+  SmallSet<int, 4> S(std::begin(L), std::end(L));
+  for (int Value : L)
+    EXPECT_TRUE(S.contains(Value));
+}
+
+TEST(SmallSet, ConstructorRange) {
+  auto L = {1, 2, 3, 4, 5};
+
+  SmallSet<int, 4> S(llvm::make_range(std::begin(L), std::end(L)));
+  for (int Value : L)
+    EXPECT_TRUE(S.contains(Value));
+}
+
+TEST(SmallSet, ConstructorInitializerList) {
+  auto L = {1, 2, 3, 4, 5};
+  SmallSet<int, 4> S = {1, 2, 3, 4, 5};
+  for (int Value : L)
+    EXPECT_TRUE(S.contains(Value));
+}
+
+TEST(SmallSet, CopyConstructor) {
+  SmallSet<int, 4> S = {1, 2, 3};
+  SmallSet<int, 4> T = S;
+
+  EXPECT_EQ(S, T);
+}
+
+TEST(SmallSet, MoveConstructor) {
+  auto L = {1, 2, 3};
+  SmallSet<int, 4> S = L;
+  SmallSet<int, 4> T = std::move(S);
+
+  EXPECT_TRUE(T.size() == L.size());
+  for (int Value : L) {
+    EXPECT_TRUE(T.contains(Value));
+  }
+}
+
+TEST(SmallSet, CopyAssignment) {
+  SmallSet<int, 4> S = {1, 2, 3};
+  SmallSet<int, 4> T;
+  T = S;
+
+  EXPECT_EQ(S, T);
+}
+
+TEST(SmallSet, MoveAssignment) {
+  auto L = {1, 2, 3};
+  SmallSet<int, 4> S = L;
+  SmallSet<int, 4> T;
+  T = std::move(S);
+
+  EXPECT_TRUE(T.size() == L.size());
+  for (int Value : L) {
+    EXPECT_TRUE(T.contains(Value));
+  }
+}
+
 TEST(SmallSetTest, Insert) {
 
   SmallSet<int, 4> s1;


### PR DESCRIPTION
This PR introduces a series of improvements to the SmallSet data structure.
 - Use universal reference/perfect forwarding in `SmallSet::insert` interface.
 - Introduction of several new API functions:
   - Constructor that takes pair of iterators.
   - Constructor that takes a range.
   - Constructor that takes an initializer list.
   - Copy constructor.
   - Move constructor.
   - Copy assignment operator.
   - Move assignment operator.
 - Style warnings fixes.
 - Modernisation of code using newer C++ constructs.