### PR TITLE
[flang][cuda][driver] Make sure flang does not switch to cc1

### DIFF
--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -170,6 +170,9 @@ bool types::isAcceptedByFlang(ID Id) {
   case TY_LLVM_IR:
   case TY_LLVM_BC:
     return true;
+  case TY_PP_CUDA:
+  case TY_CUDA:
+    return true;
   }
 }
 

--- a/flang/test/Driver/cuda-option.f90
+++ b/flang/test/Driver/cuda-option.f90
@@ -1,5 +1,6 @@
 ! Test -fcuda option
 ! RUN: %flang_fc1 -cpp -x cuda -fdebug-unparse %s -o - | FileCheck %s
+! RUN: not %flang -cpp -x cuda %s -o - 2>&1 | FileCheck %s --check-prefix=MLIRERROR
 ! RUN: not %flang_fc1 -cpp %s -o - 2>&1 | FileCheck %s --check-prefix=ERROR
 program main
 #if _CUDA
@@ -12,4 +13,8 @@ end program
 ! CHECK: INTEGER :: var = 1
 ! CHECK: INTEGER, DEVICE :: dvar
 
-! ERROR: cuda-option.f90:8:19: error: expected end of statement
+! ERROR: cuda-option.f90:{{.*}}:{{.*}}: error: expected end of statement
+
+! The whole pipeline is not in place yet. It will currently fails at MLIR
+! translation level.
+! MLIRERROR: failed to legalize operation 'cuf.alloc'

--- a/flang/test/Driver/cuda-option.f90
+++ b/flang/test/Driver/cuda-option.f90
@@ -15,6 +15,6 @@ end program
 
 ! ERROR: cuda-option.f90:{{.*}}:{{.*}}: error: expected end of statement
 
-! The whole pipeline is not in place yet. It will currently fails at MLIR
+! The whole pipeline is not in place yet. It will currently fail at MLIR
 ! translation level.
 ! MLIRERROR: failed to legalize operation 'cuf.alloc'


### PR DESCRIPTION
Flang is switch to cc1 when we use `-x cuda`. Make sure we can use fc1 with cuda fortran input.

The current pipeline will fail at MLIR level for the moment. 

#104483