### PR TITLE
[lldb] PopulatePrpsInfoTest can fail due to hardcoded priority value

### DIFF
--- a/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
+++ b/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <mutex>
+#include <sys/resource.h>
 #include <unistd.h>
 
 using namespace lldb_private;
@@ -120,7 +121,10 @@ TEST_F(ElfCoreTest, PopulatePrpsInfoTest) {
   ASSERT_EQ(prpsinfo_opt->pr_state, 0);
   ASSERT_EQ(prpsinfo_opt->pr_sname, 'R');
   ASSERT_EQ(prpsinfo_opt->pr_zomb, 0);
-  ASSERT_EQ(prpsinfo_opt->pr_nice, 0);
+  int priority = getpriority(PRIO_PROCESS, getpid());
+  if (priority == -1)
+    ASSERT_EQ(errno, 0);
+  ASSERT_EQ(prpsinfo_opt->pr_nice, priority);
   ASSERT_EQ(prpsinfo_opt->pr_flag, 0UL);
   ASSERT_EQ(prpsinfo_opt->pr_uid, getuid());
   ASSERT_EQ(prpsinfo_opt->pr_gid, getgid());


### PR DESCRIPTION
In implementing this test one of the assertions assumes that the priority is the default in linux (0) but, evidently, some of the build runners prioritize the test to, at least, 5. This ensures that regardless of the priority the test passes by validating that its the process's priority
```
fgrim@host001 :~/llvm-project/debug_build> nice -n 15 tools/lldb/unittests/Process/elf-core/ProcessElfCoreTests
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from ElfCoreTest
[ RUN      ] ElfCoreTest.PopulatePrpsInfoTest
[       OK ] ElfCoreTest.PopulatePrpsInfoTest (4 ms)
[ RUN      ] ElfCoreTest.PopulatePrStatusTest
[       OK ] ElfCoreTest.PopulatePrStatusTest (3 ms)
[----------] 2 tests from ElfCoreTest (7 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (8 ms total)
[  PASSED  ] 2 tests.
===(10:03)===
fgrim@host001 :~/llvm-project/debug_build>
```