### PR TITLE
[llvm-lit] Precommit Tests for implementing the `unset` command in lit internal shell

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -570,6 +570,14 @@ def executeBuiltinColon(cmd, cmd_shenv):
     return ShellCommandResult(cmd, "", "", 0, False)
 
 
+def executeBuiltinUnset(cmd, shenv):
+    """executeBuiltinUnset - Handle the 'unset' command."""
+    raise InternalShellError(
+        cmd,
+        "'unset' command is not supported by the lit internal shell. Please use 'env -u VARIABLE' to unset environment variables.",
+    )
+
+
 def processRedirects(cmd, stdin_source, cmd_shenv, opened_files):
     """Return the standard fds for cmd after applying redirects
 
@@ -720,6 +728,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         "pushd": executeBuiltinPushd,
         "rm": executeBuiltinRm,
         ":": executeBuiltinColon,
+        "unset": executeBuiltinUnset,
     }
     # To avoid deadlock, we use a single stderr stream for piped
     # output. This is null until we have seen some output using

--- a/llvm/utils/lit/tests/Inputs/shtest-unset/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-unset/lit.cfg
@@ -1,0 +1,10 @@
+import lit.formats
+
+config.name = "shtest-unset"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+config.environment["FOO"] = "1"
+config.environment["BAR"] = "2"
+config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))

--- a/llvm/utils/lit/tests/Inputs/shtest-unset/unset-multiple-variables.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-unset/unset-multiple-variables.txt
@@ -1,0 +1,3 @@
+## Tests the 'unset' command with multiple variables.
+
+# RUN: unset FOO BAR

--- a/llvm/utils/lit/tests/Inputs/shtest-unset/unset-no-args.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-unset/unset-no-args.txt
@@ -1,0 +1,3 @@
+## Tests the 'unset' command when no arguments are provided.
+
+# RUN: unset

--- a/llvm/utils/lit/tests/Inputs/shtest-unset/unset-nonexistent-variable.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-unset/unset-nonexistent-variable.txt
@@ -1,0 +1,3 @@
+## Test the behavior of the 'unset' command when trying to unset a variable that does not exist.
+
+# RUN: unset NONEXISTENT

--- a/llvm/utils/lit/tests/Inputs/shtest-unset/unset-variable.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-unset/unset-variable.txt
@@ -1,0 +1,3 @@
+## Tests the 'unset' command with a single variable
+
+# RUN: unset FOO

--- a/llvm/utils/lit/tests/shtest-unset.py
+++ b/llvm/utils/lit/tests/shtest-unset.py
@@ -1,0 +1,42 @@
+## Check that the 'unset' command fails as expected for various tests.
+
+# RUN: not %{lit} -a -v %{inputs}/shtest-unset \
+# RUN: | FileCheck -match-full-lines %s
+#
+# END.
+
+## Check that the 'unset' command's expected failures.
+
+# CHECK: -- Testing: 4 tests{{.*}}
+
+# CHECK: FAIL: shtest-unset :: unset-multiple-variables.txt{{.*}}
+# CHECK: unset FOO BAR
+# CHECK-NEXT: # executed command: unset FOO BAR
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | 'unset': command not found
+# CHECK: # error: command failed with exit status: 127
+
+# CHECK: FAIL: shtest-unset :: unset-no-args.txt{{.*}}
+# CHECK: unset
+# CHECK-NEXT: # executed command: unset
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | 'unset': command not found
+# CHECK: # error: command failed with exit status: 127
+
+# CHECK: FAIL: shtest-unset :: unset-nonexistent-variable.txt{{.*}}
+# CHECK: unset NONEXISTENT
+# CHECK-NEXT: # executed command: unset NONEXISTENT
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | 'unset': command not found
+# CHECK: # error: command failed with exit status: 127
+
+# CHECK: FAIL: shtest-unset :: unset-variable.txt{{.*}}
+# CHECK: unset FOO
+# CHECK-NEXT: # executed command: unset FOO
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | 'unset': command not found
+# CHECK: # error: command failed with exit status: 127
+
+# CHECK: Total Discovered Tests: 4
+# CHECK: Failed: 4 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK-NOT: {{.}}

--- a/llvm/utils/lit/tests/shtest-unset.py
+++ b/llvm/utils/lit/tests/shtest-unset.py
@@ -13,28 +13,28 @@
 # CHECK: unset FOO BAR
 # CHECK-NEXT: # executed command: unset FOO BAR
 # CHECK-NEXT: # .---command stderr------------
-# CHECK-NEXT: # | 'unset': command not found
+# CHECK-NEXT: # | 'unset' command is not supported by the lit internal shell. Please use 'env -u VARIABLE' to unset environment variables.
 # CHECK: # error: command failed with exit status: 127
 
 # CHECK: FAIL: shtest-unset :: unset-no-args.txt{{.*}}
 # CHECK: unset
 # CHECK-NEXT: # executed command: unset
 # CHECK-NEXT: # .---command stderr------------
-# CHECK-NEXT: # | 'unset': command not found
+# CHECK-NEXT: # | 'unset' command is not supported by the lit internal shell. Please use 'env -u VARIABLE' to unset environment variables.
 # CHECK: # error: command failed with exit status: 127
 
 # CHECK: FAIL: shtest-unset :: unset-nonexistent-variable.txt{{.*}}
 # CHECK: unset NONEXISTENT
 # CHECK-NEXT: # executed command: unset NONEXISTENT
 # CHECK-NEXT: # .---command stderr------------
-# CHECK-NEXT: # | 'unset': command not found
+# CHECK-NEXT: # | 'unset' command is not supported by the lit internal shell. Please use 'env -u VARIABLE' to unset environment variables.
 # CHECK: # error: command failed with exit status: 127
 
 # CHECK: FAIL: shtest-unset :: unset-variable.txt{{.*}}
 # CHECK: unset FOO
 # CHECK-NEXT: # executed command: unset FOO
 # CHECK-NEXT: # .---command stderr------------
-# CHECK-NEXT: # | 'unset': command not found
+# CHECK-NEXT: # | 'unset' command is not supported by the lit internal shell. Please use 'env -u VARIABLE' to unset environment variables.
 # CHECK: # error: command failed with exit status: 127
 
 # CHECK: Total Discovered Tests: 4


### PR DESCRIPTION
This patch introduces a suite of tests designed to verify the current behavior of the `unset` command within the lit internal shell. As it stands, the `unset` command is not recognized or supported in this environment, resulting in expected failures with specific error messages and exit codes. These tests are intentionally failing to reflect the current state. Additionally, I have added the `executeBuiltinUnset` function, which raises an `InternalShellError` with a clear message advising users to use `env -u VARIABLE` as an alternative since the `unset` command is not supported by the lit internal shell.

This change is relevant for [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179/3) 