### PR TITLE
[libc] Fix generated header definitions in cmake

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -420,19 +420,21 @@ add_header_macro(
     .llvm-libc-types.posix_spawn_file_actions_t
 )
 
-add_gen_header(
+add_header_macro(
   link
-  DEF_FILE link.h.def
-  GEN_HDR link.h
+  ../libc/newhdrgen/yaml/link.yaml
+  link.h.def
+  link.h
   DEPENDS
     .llvm_libc_common_h
     .llvm-libc-macros.link_macros
 )
 
-add_gen_header(
+add_header_macro(
   elf
-  DEF_FILE elf.h.def
-  GEN_HDR elf.h
+  ../libc/newhdrgen/yaml/elf.yaml
+  elf.h.def
+  elf.h
   DEPENDS
     .llvm-libc-macros.elf_macros
 )


### PR DESCRIPTION
Some new headers were not being properly built with
new headergen, since they were using the old "add_gen_header" instead of
the new "add_header_macro". This patch fixes the issue.
