### PR TITLE
[HIP] search fatbin symbols for libs passed by -l

### DIFF
--- a/clang/test/Driver/hip-toolchain-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-rdc.hip
@@ -20,6 +20,29 @@
 // RUN:   %S/Inputs/hip_multiple_inputs/b.hip \
 // RUN: 2>&1 | FileCheck -check-prefixes=CHECK,MSVC %s
 
+// Test fatbin symbol search for -l libraries.
+
+// RUN: touch librdctest.a rdctest2.bin
+// RUN: %clang -### --target=x86_64-linux-gnu -v \
+// RUN:   -fgpu-rdc -nogpuinc -nogpulib \
+// RUN:   --no-offload-new-driver -L. -lrdctest -l:rdctest2.bin \
+// RUN:   %s \
+// RUN: 2>&1 | FileCheck -check-prefixes=LIB,LNX-LIB %s
+// RUN: rm librdctest.a rdctest2.bin
+
+// RUN: touch rdctest.lib rdctest2.bin
+// RUN: %clang -### --target=x86_64-pc-windows-msvc -v \
+// RUN:   -fgpu-rdc -nogpuinc -nogpulib \
+// RUN:   --no-offload-new-driver -L. -lrdctest -l:rdctest2.bin \
+// RUN:   %s \
+// RUN: 2>&1 | FileCheck -check-prefixes=LIB,MSVC-LIB %s
+// RUN: rm rdctest.lib rdctest2.bin
+
+// LIB: HIP fatbin symbol search uses library path: .
+// LIB: HIP fatbin symbol search found library: .{{/|\\}}rdctest2.bin
+// LNX-LIB: HIP fatbin symbol search found library: .{{/|\\}}librdctest.a
+// MSVC-LIB: HIP fatbin symbol search found library: .{{/|\\}}rdctest.lib
+
 // check HIP fatbin and gpubin handle symbols and code object alignment in dumped llvm-mc input
 // CHECK: Found undefined HIP fatbin symbol: __hip_fatbin_[[ID1:[0-9a-f]+]]
 // CHECK: Found undefined HIP fatbin symbol: __hip_fatbin_[[ID2:[0-9a-f]+]]


### PR DESCRIPTION
For -fgpu-rdc linking, clang needs to collect undefined fatbin symbols and resolve them to the embedded fatbin.

This has been done for object files and archive files passed as input files to clang.

However, the same action is not performed for archive files passed through -l options, which causes missing symbols.

This patch adds that.