### PR TITLE
[SelectionDAG] Use size_t for ResNo in SDValue.

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -146,7 +146,7 @@ class SDValue {
   friend struct DenseMapInfo<SDValue>;
 
   SDNode *Node = nullptr; // The node defining the value we are using.
-  uintptr_t ResNo = 0;       // Which return value of the node we are using.
+  size_t ResNo = 0;       // Which return value of the node we are using.
 
 public:
   SDValue() = default;

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -146,7 +146,7 @@ class SDValue {
   friend struct DenseMapInfo<SDValue>;
 
   SDNode *Node = nullptr; // The node defining the value we are using.
-  unsigned ResNo = 0;     // Which return value of the node we are using.
+  uintptr_t ResNo = 0;       // Which return value of the node we are using.
 
 public:
   SDValue() = default;


### PR DESCRIPTION
This uses up the padding bytes at the end of SDValue on 64-bit hosts.

This reduces compile and binary size according to these results https://llvm-compile-time-tracker.com/compare.php?from=6e0fc155782ff5307245a85c7b037a2998ec6c86&to=75ea202907d75e9e5362c487466e956036beeefc&stat=instructions:u