### PR TITLE
[clang][bytecode] Classify 1-bit unsigned integers as bool

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -135,9 +135,6 @@ std::optional<PrimType> Context::classify(QualType T) const {
   if (T->isAnyComplexType() || T->isVectorType())
     return std::nullopt;
 
-  if (const auto *ET = T->getAs<EnumType>())
-    return classify(ET->getDecl()->getIntegerType());
-
   if (T->isSignedIntegerOrEnumerationType()) {
     switch (Ctx.getIntWidth(T)) {
     case 64:
@@ -163,6 +160,9 @@ std::optional<PrimType> Context::classify(QualType T) const {
       return PT_Uint16;
     case 8:
       return PT_Uint8;
+    case 1:
+      // Might happen for enum types.
+      return PT_Bool;
     default:
       return PT_IntAP;
     }

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -295,4 +295,5 @@ void T1(void) {
                                                            // pedantic-warning {{use of GNU statement expression extension}}
 }
 
-
+enum teste1 test1f(void), (*test1)(void) = test1f; // pedantic-warning {{ISO C forbids forward references to 'enum' types}}
+enum teste1 { TEST1 };


### PR DESCRIPTION
This happens for enum types with bool parent types. isBooleanType() returns false for them however.

The previous version did the same thing by re-classifying the enum integer type, but that breaks with forward-declared enums.