### PR TITLE
[flang][driver] Add pre-processing type for Fortran pre-processed files

### DIFF
--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -79,7 +79,17 @@ TYPE("c++-module-cpp-output",    PP_CXXModule, INVALID,         "iim",    phases
 TYPE("ada",                      Ada,          INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("assembler",                PP_Asm,       INVALID,         "s",      phases::Assemble, phases::Link)
 TYPE("assembler-with-cpp",       Asm,          PP_Asm,          "S",      phases::Preprocess, phases::Assemble, phases::Link)
-TYPE("f95",                      PP_Fortran,   INVALID,         "i",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+
+// Note: The `phases::Preprocess` phase is added to ".i" (i.e. Fortran
+// pre-processed) files. The reason is that the pre-processor "phase" has to be
+// re-run to make sure that e.g. the include flags (i.e. `-I <dir>`) are
+// preserved. That's because these include paths will contain module files and,
+// unlike C header files, these module files wouldn't be included in the
+// pre-processed file. In particular, we need to add the search paths for these
+// modules when Flang needs to emit pre-processed files. Therefore, the
+// `PP_TYPE` is set to `PP_Fortran` so that the driver is fine with
+// "pre-processing a pre-processed file".
+TYPE("f95",                      PP_Fortran,   PP_Fortran,      "i",      phases::Preprocess, phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("f95-cpp-input",            Fortran,      PP_Fortran,      nullptr,  phases::Preprocess, phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("java",                     Java,         INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 

--- a/flang/test/Driver/save-temps-use-module.f90
+++ b/flang/test/Driver/save-temps-use-module.f90
@@ -1,0 +1,26 @@
+! Tests that `--save-temps` works properly when a module from a non standard dir
+! is included with `-I/...`.
+
+! RUN: rm -rf %t && split-file %s %t
+! RUN: mkdir %t/mod_inc_dir
+! RUN: mv %t/somemodule.mod %t/mod_inc_dir
+! RUN: %flang -S -emit-llvm --save-temps=obj -I%t/mod_inc_dir -fno-integrated-as \
+! RUN:   %t/ModuleUser.f90 -o %t/ModuleUser
+! RUN: ls %t | FileCheck %s
+
+! Verify that the temp file(s) were written to disk.
+! CHECK: ModuleUser.i
+
+!--- somemodule.mod
+!mod$ v1 sum:e9e8fd2bd49e8daa
+module SomeModule
+
+end module SomeModule
+!--- ModuleUser.f90
+
+module User
+  use SomeModule
+end module User
+
+program dummy
+end program


### PR DESCRIPTION
When using `--save-temps`, flang-new emits (among other things) an `<input>.i` file. These `.i` files are pre-processed Fortran files containing information about the modules referenced by the input source (these files are emitted by: `Parsing::EmitPreprocessedSource`).

This diff allows `.i` files emitted by flang-new to be treated as valid files in the pre-processing phase. This, in turn, allows flang-new to add pre-processing options (e.g. `-I`) when launching compilation jobs for these files.

This solves a bug when using `--save-temps` with source files that include modules from non-standard directories, for example:
```
flang-new -c --save-temps -I/tmp/module_dir -fno-integrated-as \
  /tmp/ModuleUser.f90
```
The problem was that `.i` files were treated as "binary" files and therefore the return value for `types::getPreprocessedType(InputType)` in `Flang::ConstructJob(...)` was `types::TY_INVALID`.