### PR TITLE
[clang] fix divide by zero in ComplexExprEvaluator

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -264,6 +264,7 @@ Bug Fixes to C++ Support
 - Properly reject defaulted copy/move assignment operators that have a non-reference explicit object parameter.
 - Clang now properly handles the order of attributes in `extern` blocks. (#GH101990).
 - Fixed an assertion failure by preventing null explicit object arguments from being deduced. (#GH102025).
+- Fixed a crash that occurred when dividing by zero in complex integer division. (#GH55390).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -264,10 +264,11 @@ Bug Fixes to C++ Support
 - Properly reject defaulted copy/move assignment operators that have a non-reference explicit object parameter.
 - Clang now properly handles the order of attributes in `extern` blocks. (#GH101990).
 - Fixed an assertion failure by preventing null explicit object arguments from being deduced. (#GH102025).
-- Fixed a crash that occurred when dividing by zero in complex integer division. (#GH55390).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fixed a crash that occurred when dividing by zero in complex integer division. (#GH55390).
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15570,8 +15570,7 @@ bool ComplexExprEvaluator::VisitBinaryOperator(const BinaryOperator *E) {
       ComplexValue LHS = Result;
       APSInt Den = RHS.getComplexIntReal() * RHS.getComplexIntReal() +
         RHS.getComplexIntImag() * RHS.getComplexIntImag();
-      if ((RHS.getComplexIntReal() == 0 && RHS.getComplexIntImag() == 0) ||
-          Den.isZero())
+      if (Den.isZero())
         return Error(E, diag::note_expr_divide_by_zero);
 
       Result.getComplexIntReal() =

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15567,12 +15567,13 @@ bool ComplexExprEvaluator::VisitBinaryOperator(const BinaryOperator *E) {
         HandleComplexComplexDiv(A, B, C, D, ResR, ResI);
       }
     } else {
-      if (RHS.getComplexIntReal() == 0 && RHS.getComplexIntImag() == 0)
-        return Error(E, diag::note_expr_divide_by_zero);
-
       ComplexValue LHS = Result;
       APSInt Den = RHS.getComplexIntReal() * RHS.getComplexIntReal() +
         RHS.getComplexIntImag() * RHS.getComplexIntImag();
+      if ((RHS.getComplexIntReal() == 0 && RHS.getComplexIntImag() == 0) ||
+          Den.isZero())
+        return Error(E, diag::note_expr_divide_by_zero);
+
       Result.getComplexIntReal() =
         (LHS.getComplexIntReal() * RHS.getComplexIntReal() +
          LHS.getComplexIntImag() * RHS.getComplexIntImag()) / Den;

--- a/clang/test/SemaCXX/complex-div.cpp
+++ b/clang/test/SemaCXX/complex-div.cpp
@@ -1,3 +1,0 @@
-// RUN: %clang_cc1 -fsyntax-only %s
-
-auto f() { return 43273096 / 65536j; }

--- a/clang/test/SemaCXX/complex-div.cpp
+++ b/clang/test/SemaCXX/complex-div.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -fsyntax-only %s
+
+auto f() { return 43273096 / 65536j; }

--- a/clang/test/SemaCXX/constant-expression-cxx11.cpp
+++ b/clang/test/SemaCXX/constant-expression-cxx11.cpp
@@ -1268,6 +1268,9 @@ constexpr complex_wrap makeComplexWrap(int re, int im) {
 static_assert(makeComplexWrap(1,0) == complex(1), "");
 static_assert(makeComplexWrap(1,0) != complex(0, 1), "");
 
+constexpr auto GH55390 = 1 / 65536j; // expected-note {{division by zero}} \
+                                     // expected-error {{constexpr variable 'GH55390' must be initialized by a constant expression}} \
+                                     // expected-warning {{imaginary constants are a GNU extension}}
 }
 
 namespace PR11595 {


### PR DESCRIPTION
fix: #55390.