### PR TITLE
Reland "[asan] Catch `initialization-order-fiasco` in modules without globals""

### DIFF
--- a/compiler-rt/test/asan/TestCases/initialization-bug-no-global.cpp
+++ b/compiler-rt/test/asan/TestCases/initialization-bug-no-global.cpp
@@ -1,9 +1,6 @@
 // RUN: %clangxx_asan %min_macos_deployment_target=10.11 -O0 %s %p/Helpers/initialization-bug-extra.cpp -o %t
 // RUN: %env_asan_opts=check_initialization_order=true:strict_init_order=true not %run %t 2>&1 | FileCheck %s
 
-// Not implemented.
-// XFAIL: *
-
 // Do not test with optimization -- the error may be optimized away.
 
 // FIXME: https://code.google.com/p/address-sanitizer/issues/detail?id=186

--- a/llvm/test/Instrumentation/AddressSanitizer/instrument_initializer_without_global.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/instrument_initializer_without_global.ll
@@ -18,7 +18,9 @@ define internal void @__late_ctor() sanitize_address section ".text.startup" {
 ; CHECK-LABEL: define internal void @__late_ctor(
 ; CHECK-SAME: ) #[[ATTR1:[0-9]+]] section ".text.startup" {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    call void @__asan_before_dynamic_init(i64 ptrtoint (ptr @___asan_gen_ to i64))
 ; CHECK-NEXT:    call void @initializer()
+; CHECK-NEXT:    call void @__asan_after_dynamic_init()
 ; CHECK-NEXT:    ret void
 ;
 ; NOINIT-LABEL: define internal void @__late_ctor(


### PR DESCRIPTION
Re-land https://github.com/llvm/llvm-project/pull/104621