### PR TITLE
[libc] Add osutils for Windows and make libc and its tests build on Windows target

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -206,5 +206,12 @@ if(explicit_target_triple AND
   endif()
 endif()
 
+
+# Windows does not support full mode build.
+if (LIBC_TARGET_OS_IS_WINDOWS AND LLVM_LIBC_FULL_BUILD)
+  message(FATAL_ERROR "Windows does not support full mode build.")
+endif ()
+
+
 message(STATUS
         "Building libc for ${LIBC_TARGET_ARCHITECTURE} on ${LIBC_TARGET_OS}")

--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -13,7 +13,8 @@
 
 #if defined(__FLT16_MANT_DIG__) &&                                             \
     (!defined(__GNUC__) || __GNUC__ >= 13 || defined(__clang__)) &&            \
-    !defined(__arm__) && !defined(_M_ARM) && !defined(__riscv)
+    !defined(__arm__) && !defined(_M_ARM) && !defined(__riscv) &&              \
+    !defined(_WIN32)
 #define LIBC_TYPES_HAS_FLOAT16
 
 // TODO: This would no longer be required if HdrGen let us guard function

--- a/libc/include/llvm-libc-macros/stdckdint-macros.h
+++ b/libc/include/llvm-libc-macros/stdckdint-macros.h
@@ -10,8 +10,10 @@
 #define LLVM_LIBC_MACROS_STDCKDINT_MACROS_H
 
 // We need to use __builtin_*_overflow from GCC/Clang to implement the overflow
-// macros. Check __GNUC__ for availability of such builtins.
-#ifdef __GNUC__
+// macros. Check __GNUC__ or __clang__ for availability of such builtins.
+// Note that clang-cl defines __clang__ only and does not define __GNUC__ so we
+// have to check for both.
+#if defined(__GNUC__) || defined(__clang__)
 // clang/gcc overlay may provides similar macros, we need to avoid redefining
 // them.
 #ifndef __STDC_VERSION_STDCKDINT_H__

--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -199,4 +199,5 @@ add_object_library(
   DEPENDS
     libc.include.stdlib
     libc.src.__support.common
+    libc.src.__support.macros.properties.os
 )

--- a/libc/src/__support/CPP/new.cpp
+++ b/libc/src/__support/CPP/new.cpp
@@ -16,15 +16,29 @@ void operator delete(void *mem, std::align_val_t) noexcept { ::free(mem); }
 void operator delete(void *mem, size_t) noexcept { ::free(mem); }
 
 void operator delete(void *mem, size_t, std::align_val_t) noexcept {
+#ifdef LIBC_TARGET_OS_IS_WINDOWS
+  ::_aligned_free(mem);
+#else
   ::free(mem);
+#endif
 }
 
 void operator delete[](void *mem) noexcept { ::free(mem); }
 
-void operator delete[](void *mem, std::align_val_t) noexcept { ::free(mem); }
+void operator delete[](void *mem, std::align_val_t) noexcept {
+#ifdef LIBC_TARGET_OS_IS_WINDOWS
+  ::_aligned_free(mem);
+#else
+  ::free(mem);
+#endif
+}
 
 void operator delete[](void *mem, size_t) noexcept { ::free(mem); }
 
 void operator delete[](void *mem, size_t, std::align_val_t) noexcept {
+#ifdef LIBC_TARGET_OS_IS_WINDOWS
+  ::_aligned_free(mem);
+#else
   ::free(mem);
+#endif
 }

--- a/libc/src/__support/OSUtil/io.h
+++ b/libc/src/__support/OSUtil/io.h
@@ -19,6 +19,8 @@
 #include "linux/io.h"
 #elif defined(__Fuchsia__)
 #include "fuchsia/io.h"
+#elif defined(_WIN32)
+#include "windows/io.h"
 #elif defined(__ELF__)
 // TODO: Ideally we would have LIBC_TARGET_OS_IS_BAREMETAL.
 #include "baremetal/io.h"

--- a/libc/src/__support/OSUtil/windows/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/windows/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_object_library(
+  windows_util
+  SRCS
+    exit.cpp
+    io.cpp
+  HDRS
+    io.h
+  DEPENDS
+    libc.src.__support.macros.config
+)

--- a/libc/src/__support/OSUtil/windows/exit.cpp
+++ b/libc/src/__support/OSUtil/windows/exit.cpp
@@ -1,0 +1,23 @@
+//===-- Windows implementation of an exit function ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/macros/config.h"
+
+// On Windows we cannot make direct syscalls since Microsoft changes system call
+// IDs periodically. We must rely on functions exported from ntdll.dll or
+// kernel32.dll to invoke system service procedures.
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+namespace LIBC_NAMESPACE_DECL {
+namespace internal {
+
+[[noreturn]] void exit(int status) { ::ExitProcess(status); }
+
+} // namespace internal
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/OSUtil/windows/io.cpp
+++ b/libc/src/__support/OSUtil/windows/io.cpp
@@ -1,0 +1,25 @@
+//===------------- Windows implementation of IO utils -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "io.h"
+#include "src/__support/macros/config.h"
+
+// On Windows we cannot make direct syscalls since Microsoft changes system call
+// IDs periodically. We must rely on functions exported from ntdll.dll or
+// kernel32.dll to invoke system service procedures.
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+void write_to_stderr(cpp::string_view msg) {
+  ::HANDLE stream = ::GetStdHandle(STD_ERROR_HANDLE);
+  ::WriteFile(stream, msg.data(), msg.size(), nullptr, nullptr);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/OSUtil/windows/io.h
+++ b/libc/src/__support/OSUtil/windows/io.h
@@ -1,0 +1,21 @@
+//===------------- Windows implementation of IO utils -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_WINDOWS_IO_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_WINDOWS_IO_H
+
+#include "src/__support/CPP/string_view.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+void write_to_stderr(cpp::string_view msg);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_WINDOWS_IO_H

--- a/libc/src/__support/macros/properties/types.h
+++ b/libc/src/__support/macros/properties/types.h
@@ -35,7 +35,7 @@
 #endif // UINT64_MAX
 
 // int128 / uint128 support
-#if defined(__SIZEOF_INT128__)
+#if defined(__SIZEOF_INT128__) && !defined(LIBC_TARGET_OS_IS_WINDOWS)
 #define LIBC_TYPES_HAS_INT128
 #endif // defined(__SIZEOF_INT128__)
 

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -140,9 +140,14 @@ add_libc_test(
     arg_list_test.cpp
   DEPENDS
     libc.src.__support.arg_list
+    libc.src.__support.macros.properties.os
 )
 
-if(NOT LIBC_TARGET_ARCHITECTURE_IS_NVPTX)
+# TODO: clang-cl generates calls into runtime library functions to
+# handle 128-bit integer arithmetics and conversions which are not yet
+# available on Windows. Re-enable 128-bit integer support on Windows once
+# these functions are ready.
+if(NOT LIBC_TARGET_ARCHITECTURE_IS_NVPTX AND NOT LIBC_TARGET_OS_IS_WINDOWS)
   add_libc_test(
     big_int_test
     SUITE

--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -25,6 +25,7 @@ add_libc_test(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.fpbits_str
     libc.src.__support.integer_literals
+    libc.src.__support.macros.properties.types
     libc.src.__support.sign
 )
 

--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -9,6 +9,7 @@
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/fpbits_str.h"
 #include "src/__support/integer_literals.h"
+#include "src/__support/macros/properties/types.h"
 #include "src/__support/sign.h" // Sign
 #include "test/UnitTest/Test.h"
 
@@ -425,12 +426,9 @@ TEST(LlvmLibcFPBitsTest, DoubleType) {
   EXPECT_EQ(quiet_nan.is_quiet_nan(), true);
 }
 
-#ifdef LIBC_TARGET_ARCH_IS_X86
+#ifdef LIBC_TYPES_LONG_DOUBLE_IS_X86_FLOAT80
 TEST(LlvmLibcFPBitsTest, X86LongDoubleType) {
   using LongDoubleBits = FPBits<long double>;
-
-  if constexpr (sizeof(long double) == sizeof(double))
-    return; // The tests for the "double" type cover for this case.
 
   EXPECT_STREQ(LIBC_NAMESPACE::str(LongDoubleBits::inf(Sign::POS)).c_str(),
                "(+Infinity)");

--- a/libc/test/src/__support/arg_list_test.cpp
+++ b/libc/test/src/__support/arg_list_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/arg_list.h"
+#include "src/__support/macros/properties/os.h"
 
 #include "test/UnitTest/Test.h"
 
@@ -120,7 +121,7 @@ TEST(LlvmLibcArgListTest, TestStructTypes) {
 }
 
 // Test vector extensions from clang.
-#if __has_attribute(ext_vector_type)
+#if !defined(LIBC_TARGET_OS_IS_WINDOWS) && __has_attribute(ext_vector_type)
 
 using int1 = int __attribute__((ext_vector_type(1)));
 using int2 = int __attribute__((ext_vector_type(2)));

--- a/libc/test/src/fenv/CMakeLists.txt
+++ b/libc/test/src/fenv/CMakeLists.txt
@@ -41,6 +41,7 @@ add_libc_unittest(
     libc.src.fenv.fesetenv
     libc.src.fenv.fesetround
     libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.macros.properties.os
   LINK_LIBRARIES
     LibcFPTestHelpers
 )

--- a/libc/test/src/fenv/getenv_and_setenv_test.cpp
+++ b/libc/test/src/fenv/getenv_and_setenv_test.cpp
@@ -13,6 +13,7 @@
 #include "src/fenv/fesetround.h"
 
 #include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/macros/properties/os.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/Test.h"
 
@@ -20,6 +21,7 @@
 
 using LlvmLibcFEnvTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
+#ifndef LIBC_TARGET_OS_IS_WINDOWS
 TEST_F(LlvmLibcFEnvTest, GetEnvAndSetEnv) {
   // We will disable all exceptions to prevent invocation of the exception
   // handler.
@@ -71,8 +73,9 @@ TEST_F(LlvmLibcFEnvTest, Set_FE_DFL_ENV) {
   int rm = LIBC_NAMESPACE::fegetround();
   EXPECT_EQ(rm, FE_TONEAREST);
 }
+#endif
 
-#ifdef _WIN32
+#ifdef LIBC_TARGET_OS_IS_WINDOWS
 TEST_F(LlvmLibcFEnvTest, Windows_Set_Get_Test) {
   // If a valid fenv_t is written, then reading it back out should be identical.
   fenv_t setEnv = {0x7e00053e, 0x0f00000f};

--- a/libc/test/src/math/smoke/AddTest.h
+++ b/libc/test/src/math/smoke/AddTest.h
@@ -12,6 +12,7 @@
 #include "hdr/errno_macros.h"
 #include "hdr/fenv_macros.h"
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/macros/properties/os.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -53,6 +54,7 @@ public:
   }
 
   void test_range_errors(AddFunc func) {
+#ifndef LIBC_TARGET_OS_IS_WINDOWS
     using namespace LIBC_NAMESPACE::fputil::testing;
 
     if (ForceRoundingMode r(RoundingMode::Nearest); r.success) {
@@ -121,6 +123,7 @@ public:
           FE_UNDERFLOW | FE_INEXACT);
       EXPECT_MATH_ERRNO(ERANGE);
     }
+#endif
   }
 
   void test_inexact_results(AddFunc func) {

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -153,6 +153,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.fadd
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -168,6 +169,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.faddl
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -183,6 +185,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.faddf128
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -424,6 +427,7 @@ add_fp_unittest(
     libc.src.errno.errno
     libc.hdr.fenv_macros
     libc.src.math.dsubl
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -438,6 +442,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.dsubf128
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4169,6 +4174,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16add
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4183,6 +4189,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16addf
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4197,6 +4204,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16addl
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4211,6 +4219,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16addf128
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4225,6 +4234,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16sub
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4239,6 +4249,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16subf
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4253,6 +4264,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16subl
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4267,6 +4279,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.f16subf128
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4548,6 +4561,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.fsub
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4562,6 +4576,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.fsubl
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4576,6 +4591,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.fsubf128
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4749,6 +4765,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.daddl
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(
@@ -4763,6 +4780,7 @@ add_fp_unittest(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.math.daddf128
+    libc.src.__support.macros.properties.os
 )
 
 add_fp_unittest(

--- a/libc/test/src/math/smoke/SubTest.h
+++ b/libc/test/src/math/smoke/SubTest.h
@@ -11,6 +11,7 @@
 
 #include "hdr/errno_macros.h"
 #include "hdr/fenv_macros.h"
+#include "src/__support/macros/properties/os.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -52,6 +53,7 @@ public:
   }
 
   void test_range_errors(SubFunc func) {
+#ifndef LIBC_TARGET_OS_IS_WINDOWS
     using namespace LIBC_NAMESPACE::fputil::testing;
 
     if (ForceRoundingMode r(RoundingMode::Nearest); r.success) {
@@ -123,6 +125,7 @@ public:
                                   FE_UNDERFLOW | FE_INEXACT);
       EXPECT_MATH_ERRNO(ERANGE);
     }
+#endif
   }
 
   void test_inexact_results(SubFunc func) {

--- a/libc/test/src/string/memory_utils/CMakeLists.txt
+++ b/libc/test/src/string/memory_utils/CMakeLists.txt
@@ -12,6 +12,7 @@ add_libc_test(
     libc.src.__support.CPP.array
     libc.src.__support.CPP.cstddef
     libc.src.__support.CPP.span
+    libc.src.__support.macros.properties.os
     libc.src.__support.macros.properties.types
     libc.src.__support.macros.sanitizer
     libc.src.string.memory_utils.memory_utils

--- a/libc/test/src/string/memory_utils/op_tests.cpp
+++ b/libc/test/src/string/memory_utils/op_tests.cpp
@@ -8,6 +8,7 @@
 
 #include "memory_check_utils.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/os.h"
 #include "src/__support/macros/properties/types.h" // LIBC_TYPES_HAS_INT64
 #include "src/string/memory_utils/op_aarch64.h"
 #include "src/string/memory_utils/op_builtin.h"
@@ -294,7 +295,7 @@ TYPED_TEST(LlvmLibcOpTest, Bcmp, BcmpImplementations) {
 #endif // LIBC_TARGET_ARCH_IS_X86_64
 
 using MemcmpImplementations = testing::TypeList<
-#ifdef LIBC_TARGET_ARCH_IS_X86_64
+#if defined(LIBC_TARGET_ARCH_IS_X86_64) && !defined(LIBC_TARGET_OS_IS_WINDOWS)
 #ifdef __SSE2__
     generic::Memcmp<__m128i>, //
 #endif


### PR DESCRIPTION
This PR first adds osutils for Windows, and changes some libc code to make libc and its tests build on the Windows target. It then temporarily disables some libc tests that are currently problematic on Windows.

Specifically, the changes besides the addition of osutils include:

- Macro `LIBC_TYPES_HAS_FLOAT16` is disabled on Windows. `clang-cl` generates calls to functions in `compiler-rt` to handle float16 arithmetic and these functions are currently not linked in on Windows.
- Macro `LIBC_TYPES_HAS_INT128` is disabled on Windows.
- The invocation to `::aligned_malloc` is changed to an invocation to `::_aligned_malloc`.
- The following unit tests are temporarily disabled because they currently fail on Windows:
  - `test.src.__support.big_int_test`
  - `test.src.__support.arg_list_test`
  - `test.src.fenv.getenv_and_setenv_test`
  - Tests involving `__m128i`, `__m256i`, and `__m512i` in `test.src.string.memory_utils.op_tests.cpp`
  - `test_range_errors` in `libc/test/src/math/smoke/AddTest.h` and `libc/test/src/math/smoke/SubTest.h`