### PR TITLE
[flang] Silence an inappropriate warning

### DIFF
--- a/flang/lib/Semantics/definable.cpp
+++ b/flang/lib/Semantics/definable.cpp
@@ -127,7 +127,7 @@ static std::optional<parser::Message> WhyNotDefinableBase(parser::CharBlock at,
       (!IsPointer(ultimate) || (isWholeSymbol && isPointerDefinition))) {
     return BlameSymbol(
         at, "'%s' is an INTENT(IN) dummy argument"_en_US, original);
-  } else if (acceptAllocatable &&
+  } else if (acceptAllocatable && IsAllocatable(ultimate) &&
       !flags.test(DefinabilityFlag::SourcedAllocation)) {
     // allocating a function result doesn't count as a def'n
     // unless there's SOURCE=

--- a/flang/test/Semantics/undef-result01.f90
+++ b/flang/test/Semantics/undef-result01.f90
@@ -44,6 +44,11 @@ function basicAlloc()
   allocate(basicAlloc)
 end
 
+function allocPtr()
+  real, pointer :: allocPtr
+  allocate(allocPtr) ! good enough for pointer
+end
+
 function sourcedAlloc()
   real, allocatable :: sourcedAlloc
   allocate(sourcedAlloc, source=0.)


### PR DESCRIPTION
A bare ALLOCATE statement with no SOURCE= rightly earns a warning about an undefined function result, if that result is an allocatable that appears in the ALLOCATE.  But in the case of a pointer, where the warning should care more about the pointer's association status than the value of its target, a bare ALLOCATE should suffice to silence the warning.