### PR TITLE
[clang][NFC] Un-constify `MultiLevelTemplateArgumentList`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -356,8 +356,8 @@ static std::vector<FixItHint> handleReturnType(const FunctionDecl *Function,
   if (!TypeText)
     return {};
 
-  SmallVector<const Expr *, 3> ExistingConstraints;
-  Function->getAssociatedConstraints(ExistingConstraints);
+  SmallVector<Expr *, 3> ExistingConstraints;
+  const_cast<FunctionDecl *>(Function)->getAssociatedConstraints(ExistingConstraints);
   if (!ExistingConstraints.empty()) {
     // FIXME - Support adding new constraints to existing ones. Do we need to
     // consider subsumption?
@@ -404,8 +404,8 @@ handleTrailingTemplateType(const FunctionTemplateDecl *FunctionTemplate,
   if (!ConditionText)
     return {};
 
-  SmallVector<const Expr *, 3> ExistingConstraints;
-  Function->getAssociatedConstraints(ExistingConstraints);
+  SmallVector<Expr *, 3> ExistingConstraints;
+  const_cast<FunctionDecl *>(Function)->getAssociatedConstraints(ExistingConstraints);
   if (!ExistingConstraints.empty()) {
     // FIXME - Support adding new constraints to existing ones. Do we need to
     // consider subsumption?

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -2913,6 +2913,7 @@ public:
   /// If this function declaration is not a function template specialization,
   /// returns NULL.
   const TemplateArgumentList *getTemplateSpecializationArgs() const;
+  TemplateArgumentList *getTemplateSpecializationArgs();
 
   /// Retrieve the template argument list as written in the sources,
   /// if any.

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -2621,7 +2621,7 @@ public:
   ///
   /// Use this instead of getTrailingRequiresClause for concepts APIs that
   /// accept an ArrayRef of constraint expressions.
-  void getAssociatedConstraints(SmallVectorImpl<const Expr *> &AC) const {
+  void getAssociatedConstraints(SmallVectorImpl<Expr *> &AC) {
     if (auto *TRC = getTrailingRequiresClause())
       AC.push_back(TRC);
   }

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -275,12 +275,22 @@ public:
     return llvm::ArrayRef(data(), size());
   }
 
+  /// Produce this as a mutable array ref.
+  MutableArrayRef<TemplateArgument> asMutableArray() {
+    return llvm::MutableArrayRef(data(), size());
+  }
+
   /// Retrieve the number of template arguments in this
   /// template argument list.
   unsigned size() const { return NumArguments; }
 
   /// Retrieve a pointer to the template argument list.
   const TemplateArgument *data() const {
+    return const_cast<TemplateArgumentList *>(this)->data();
+  }
+
+  /// Retrieve a pointer to the template argument list.
+  TemplateArgument *data() {
     return getTrailingObjects<TemplateArgument>();
   }
 };

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -192,7 +192,7 @@ public:
   ///
   /// The constraints in the resulting list are to be treated as if in a
   /// conjunction ("and").
-  void getAssociatedConstraints(llvm::SmallVectorImpl<const Expr *> &AC) const;
+  void getAssociatedConstraints(llvm::SmallVectorImpl<Expr *> &AC);
 
   bool hasAssociatedConstraints() const;
 
@@ -428,7 +428,7 @@ public:
   /// including constraint-expressions derived from the requires-clause,
   /// trailing requires-clause (for functions and methods) and constrained
   /// template parameters.
-  void getAssociatedConstraints(llvm::SmallVectorImpl<const Expr *> &AC) const;
+  void getAssociatedConstraints(llvm::SmallVectorImpl<Expr *> &AC);
 
   bool hasAssociatedConstraints() const;
 
@@ -2143,7 +2143,7 @@ public:
   ///
   /// The constraints in the resulting list are to be treated as if in a
   /// conjunction ("and").
-  void getAssociatedConstraints(llvm::SmallVectorImpl<const Expr *> &AC) const {
+  void getAssociatedConstraints(llvm::SmallVectorImpl<Expr *> &AC) {
     TemplateParams->getAssociatedConstraints(AC);
   }
 
@@ -2915,7 +2915,7 @@ public:
   ///
   /// The constraints in the resulting list are to be treated as if in a
   /// conjunction ("and").
-  void getAssociatedConstraints(llvm::SmallVectorImpl<const Expr *> &AC) const {
+  void getAssociatedConstraints(llvm::SmallVectorImpl<Expr *> &AC) {
     TemplateParams->getAssociatedConstraints(AC);
   }
 

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -929,7 +929,8 @@ public:
   /// Although the C++ standard has no notion of the "injected" template
   /// arguments for a template, the notion is convenient when
   /// we need to perform substitutions inside the definition of a template.
-  ArrayRef<TemplateArgument> getInjectedTemplateArgs();
+  MutableArrayRef<TemplateArgument> getInjectedTemplateArgs();
+  ArrayRef<TemplateArgument> getInjectedTemplateArgs() const;
 
   using redecl_range = redeclarable_base::redecl_range;
   using redecl_iterator = redeclarable_base::redecl_iterator;
@@ -1829,7 +1830,7 @@ class ClassTemplateSpecializationDecl : public CXXRecordDecl,
 
     /// The template argument list deduced for the class template
     /// partial specialization itself.
-    const TemplateArgumentList *TemplateArgs;
+    TemplateArgumentList *TemplateArgs;
   };
 
   /// The template that this specialization specializes
@@ -1841,7 +1842,7 @@ class ClassTemplateSpecializationDecl : public CXXRecordDecl,
   SpecializationOrInstantiationInfo ExplicitInfo = nullptr;
 
   /// The template arguments used to describe this specialization.
-  const TemplateArgumentList *TemplateArgs;
+  TemplateArgumentList *TemplateArgs;
 
   /// The point where this template was instantiated (if any)
   SourceLocation PointOfInstantiation;
@@ -1891,8 +1892,11 @@ public:
 
   /// Retrieve the template arguments of the class template
   /// specialization.
-  const TemplateArgumentList &getTemplateArgs() const {
+  TemplateArgumentList &getTemplateArgs() {
     return *TemplateArgs;
+  }
+  const TemplateArgumentList &getTemplateArgs() const {
+    return const_cast<ClassTemplateSpecializationDecl *>(this)->getTemplateArgs();
   }
 
   void setTemplateArgs(TemplateArgumentList *Args) {
@@ -1986,19 +1990,22 @@ public:
   /// a class template partial specialization, this function will return the
   /// deduced template arguments for the class template partial specialization
   /// itself.
-  const TemplateArgumentList &getTemplateInstantiationArgs() const {
-    if (const auto *PartialSpec =
+  TemplateArgumentList &getTemplateInstantiationArgs() {
+    if (auto *PartialSpec =
             SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization *>())
       return *PartialSpec->TemplateArgs;
 
     return getTemplateArgs();
+  }
+  const TemplateArgumentList &getTemplateInstantiationArgs() const {
+    return const_cast<ClassTemplateSpecializationDecl *>(this)->getTemplateInstantiationArgs();
   }
 
   /// Note that this class template specialization is actually an
   /// instantiation of the given class template partial specialization whose
   /// template arguments have been deduced.
   void setInstantiationOf(ClassTemplatePartialSpecializationDecl *PartialSpec,
-                          const TemplateArgumentList *TemplateArgs) {
+                          TemplateArgumentList *TemplateArgs) {
     assert(!SpecializedTemplate.is<SpecializedPartialSpecialization*>() &&
            "Already set to a class template partial specialization!");
     auto *PS = new (getASTContext()) SpecializedPartialSpecialization();
@@ -2611,7 +2618,7 @@ class VarTemplateSpecializationDecl : public VarDecl,
 
     /// The template argument list deduced for the variable template
     /// partial specialization itself.
-    const TemplateArgumentList *TemplateArgs;
+    TemplateArgumentList *TemplateArgs;
   };
 
   /// The template that this specialization specializes.
@@ -2623,7 +2630,7 @@ class VarTemplateSpecializationDecl : public VarDecl,
   SpecializationOrInstantiationInfo ExplicitInfo = nullptr;
 
   /// The template arguments used to describe this specialization.
-  const TemplateArgumentList *TemplateArgs;
+  TemplateArgumentList *TemplateArgs;
 
   /// The point where this template was instantiated (if any).
   SourceLocation PointOfInstantiation;
@@ -2675,7 +2682,10 @@ public:
 
   /// Retrieve the template arguments of the variable template
   /// specialization.
-  const TemplateArgumentList &getTemplateArgs() const { return *TemplateArgs; }
+  TemplateArgumentList &getTemplateArgs() { return *TemplateArgs; }
+  const TemplateArgumentList &getTemplateArgs() const {
+    return const_cast<VarTemplateSpecializationDecl *>(this)->getTemplateArgs();
+  }
 
   /// Determine the kind of specialization that this
   /// declaration represents.
@@ -2751,19 +2761,22 @@ public:
   /// from a variable template partial specialization, this function will the
   /// return deduced template arguments for the variable template partial
   /// specialization itself.
-  const TemplateArgumentList &getTemplateInstantiationArgs() const {
+  TemplateArgumentList &getTemplateInstantiationArgs() {
     if (const auto *PartialSpec =
             SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization *>())
       return *PartialSpec->TemplateArgs;
 
     return getTemplateArgs();
   }
+  const TemplateArgumentList &getTemplateInstantiationArgs() const {
+    return const_cast<VarTemplateSpecializationDecl *>(this)->getTemplateArgs();
+  }
 
   /// Note that this variable template specialization is actually an
   /// instantiation of the given variable template partial specialization whose
   /// template arguments have been deduced.
   void setInstantiationOf(VarTemplatePartialSpecializationDecl *PartialSpec,
-                          const TemplateArgumentList *TemplateArgs) {
+                          TemplateArgumentList *TemplateArgs) {
     assert(!SpecializedTemplate.is<SpecializedPartialSpecialization *>() &&
            "Already set to a variable template partial specialization!");
     auto *PS = new (getASTContext()) SpecializedPartialSpecialization();
@@ -3217,9 +3230,12 @@ public:
   CreateDeserialized(const ASTContext &C, GlobalDeclID ID,
                      unsigned NumTemplateArgs);
 
-  ArrayRef<TemplateArgument> getTemplateArguments() const {
-    return ArrayRef<TemplateArgument>(getTrailingObjects<TemplateArgument>(),
+  MutableArrayRef<TemplateArgument> getTemplateArguments() {
+    return MutableArrayRef<TemplateArgument>(getTrailingObjects<TemplateArgument>(),
                                       NumTemplateArgs);
+  }
+  ArrayRef<TemplateArgument> getTemplateArguments() const {
+    return const_cast<ImplicitConceptSpecializationDecl *>(this)->getTemplateArguments();
   }
   void setTemplateArguments(ArrayRef<TemplateArgument> Converted);
 

--- a/clang/include/clang/AST/ExprConcepts.h
+++ b/clang/include/clang/AST/ExprConcepts.h
@@ -78,8 +78,11 @@ public:
          const ConstraintSatisfaction *Satisfaction, bool Dependent,
          bool ContainsUnexpandedParameterPack);
 
-  ArrayRef<TemplateArgument> getTemplateArguments() const {
+  MutableArrayRef<TemplateArgument> getTemplateArguments() {
     return SpecDecl->getTemplateArguments();
+  }
+  ArrayRef<TemplateArgument> getTemplateArguments() const {
+    return const_cast<ConceptSpecializationExpr *>(this)->getTemplateArguments();
   }
 
   ConceptReference *getConceptReference() const { return ConceptRef; }

--- a/clang/include/clang/AST/NestedNameSpecifier.h
+++ b/clang/include/clang/AST/NestedNameSpecifier.h
@@ -193,12 +193,15 @@ public:
   CXXRecordDecl *getAsRecordDecl() const;
 
   /// Retrieve the type stored in this nested name specifier.
-  const Type *getAsType() const {
+  Type *getAsType() {
     if (Prefix.getInt() == StoredTypeSpec ||
         Prefix.getInt() == StoredTypeSpecWithTemplate)
-      return (const Type *)Specifier;
+      return static_cast<Type *>(Specifier);
 
     return nullptr;
+  }
+  const Type *getAsType() const {
+    return const_cast<NestedNameSpecifier *>(this)->getAsType();
   }
 
   NestedNameSpecifierDependence getDependence() const;

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -6545,9 +6545,12 @@ public:
   /// Retrieve the name of the template that we are specializing.
   TemplateName getTemplateName() const { return Template; }
 
-  ArrayRef<TemplateArgument> template_arguments() const {
-    return {reinterpret_cast<const TemplateArgument *>(this + 1),
+  MutableArrayRef<TemplateArgument> template_arguments() {
+    return {reinterpret_cast<TemplateArgument *>(this + 1),
             TemplateSpecializationTypeBits.NumArgs};
+  }
+  ArrayRef<TemplateArgument> template_arguments() const {
+    return const_cast<TemplateSpecializationType *>(this)->template_arguments();
   }
 
   bool isSugared() const {

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -2813,6 +2813,9 @@ public:
   /// There are some specializations of this member template listed
   /// immediately following this class.
   template <typename T> const T *getAs() const;
+  template <typename T> T *getAs() {
+    return const_cast<T *>(const_cast<const Type *>(this)->getAs<T>());
+  }
 
   /// Member-template getAsAdjusted<specific type>. Look through specific kinds
   /// of sugar (parens, attributes, etc) for an instance of \<specific type>.
@@ -2993,6 +2996,7 @@ template <> const UsingType *Type::getAs() const;
 /// existing sugar until it reaches a TemplateSpecializationType or a
 /// non-sugared type.
 template <> const TemplateSpecializationType *Type::getAs() const;
+template <> TemplateSpecializationType *Type::getAs();
 
 /// This will check for an AttributedType by removing any existing sugar
 /// until it reaches an AttributedType or a non-sugared type.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11638,7 +11638,7 @@ public:
   TemplateArgumentLoc SubstDefaultTemplateArgumentIfAvailable(
       TemplateDecl *Template, SourceLocation TemplateLoc,
       SourceLocation RAngleLoc, Decl *Param,
-      ArrayRef<TemplateArgument> SugaredConverted,
+      MutableArrayRef<TemplateArgument> SugaredConverted,
       ArrayRef<TemplateArgument> CanonicalConverted, bool &HasDefaultArg);
 
   /// Returns the top most location responsible for the definition of \p N.
@@ -13676,7 +13676,7 @@ public:
   /// Usually this should not be used, and template argument deduction should be
   /// used in its place.
   FunctionDecl *InstantiateFunctionDeclaration(
-      FunctionTemplateDecl *FTD, const TemplateArgumentList *Args,
+      FunctionTemplateDecl *FTD, TemplateArgumentList *Args,
       SourceLocation Loc,
       CodeSynthesisContext::SynthesisKind CSC =
           CodeSynthesisContext::ExplicitTemplateArgumentSubstitution);
@@ -13705,7 +13705,7 @@ public:
                                      bool AtEndOfTU = false);
   VarTemplateSpecializationDecl *BuildVarTemplateInstantiation(
       VarTemplateDecl *VarTemplate, VarDecl *FromVar,
-      const TemplateArgumentList *PartialSpecArgs,
+      TemplateArgumentList *PartialSpecArgs,
       const TemplateArgumentListInfo &TemplateArgsInfo,
       SmallVectorImpl<TemplateArgument> &Converted,
       SourceLocation PointOfInstantiation,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12800,7 +12800,7 @@ public:
     union {
       /// The list of template arguments we are substituting, if they
       /// are not part of the entity.
-      const TemplateArgument *TemplateArgs;
+      TemplateArgument *TemplateArgs;
 
       /// The list of argument expressions in a synthesized call.
       const Expr *const *CallArgs;
@@ -12819,9 +12819,12 @@ public:
       CXXSpecialMemberKind SpecialMember;
     };
 
-    ArrayRef<TemplateArgument> template_arguments() const {
+    MutableArrayRef<TemplateArgument> template_arguments() {
       assert(Kind != DeclaringSpecialMember);
       return {TemplateArgs, NumTemplateArgs};
+    }
+    ArrayRef<TemplateArgument> template_arguments() const {
+      return const_cast<CodeSynthesisContext *>(this)->template_arguments();
     }
 
     /// The template deduction info object associated with the
@@ -12873,21 +12876,21 @@ public:
     /// Note that we are instantiating a type alias template declaration.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           TypeAliasTemplateDecl *Entity,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           SourceRange InstantiationRange = SourceRange());
 
     /// Note that we are instantiating a default argument in a
     /// template-id.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           TemplateParameter Param, TemplateDecl *Template,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           SourceRange InstantiationRange = SourceRange());
 
     /// Note that we are substituting either explicitly-specified or
     /// deduced template arguments during function template argument deduction.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           FunctionTemplateDecl *FunctionTemplate,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           CodeSynthesisContext::SynthesisKind Kind,
                           sema::TemplateDeductionInfo &DeductionInfo,
                           SourceRange InstantiationRange = SourceRange());
@@ -12896,7 +12899,7 @@ public:
     /// argument deduction for a class template declaration.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           TemplateDecl *Template,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           sema::TemplateDeductionInfo &DeductionInfo,
                           SourceRange InstantiationRange = SourceRange());
 
@@ -12905,7 +12908,7 @@ public:
     /// specialization.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           ClassTemplatePartialSpecializationDecl *PartialSpec,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           sema::TemplateDeductionInfo &DeductionInfo,
                           SourceRange InstantiationRange = SourceRange());
 
@@ -12914,7 +12917,7 @@ public:
     /// specialization.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           VarTemplatePartialSpecializationDecl *PartialSpec,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           sema::TemplateDeductionInfo &DeductionInfo,
                           SourceRange InstantiationRange = SourceRange());
 
@@ -12922,28 +12925,28 @@ public:
     /// parameter.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           ParmVarDecl *Param,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           SourceRange InstantiationRange = SourceRange());
 
     /// Note that we are substituting prior template arguments into a
     /// non-type parameter.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           NamedDecl *Template, NonTypeTemplateParmDecl *Param,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           SourceRange InstantiationRange);
 
     /// Note that we are substituting prior template arguments into a
     /// template template parameter.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           NamedDecl *Template, TemplateTemplateParmDecl *Param,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           SourceRange InstantiationRange);
 
     /// Note that we are checking the default template argument
     /// against the template parameter for a given template-id.
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           TemplateDecl *Template, NamedDecl *Param,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           SourceRange InstantiationRange);
 
     struct ConstraintsCheck {};
@@ -12952,7 +12955,7 @@ public:
     /// constraints).
     InstantiatingTemplate(Sema &SemaRef, SourceLocation PointOfInstantiation,
                           ConstraintsCheck, NamedDecl *Template,
-                          ArrayRef<TemplateArgument> TemplateArgs,
+                          MutableArrayRef<TemplateArgument> TemplateArgs,
                           SourceRange InstantiationRange);
 
     struct ConstraintSubstitution {};
@@ -13026,7 +13029,7 @@ public:
         Sema &SemaRef, CodeSynthesisContext::SynthesisKind Kind,
         SourceLocation PointOfInstantiation, SourceRange InstantiationRange,
         Decl *Entity, NamedDecl *Template = nullptr,
-        ArrayRef<TemplateArgument> TemplateArgs = std::nullopt,
+        MutableArrayRef<TemplateArgument> TemplateArgs = std::nullopt,
         sema::TemplateDeductionInfo *DeductionInfo = nullptr);
 
     InstantiatingTemplate(const InstantiatingTemplate &) = delete;
@@ -14458,7 +14461,7 @@ public:
 
   bool CheckInstantiatedFunctionTemplateConstraints(
       SourceLocation PointOfInstantiation, FunctionDecl *Decl,
-      ArrayRef<TemplateArgument> TemplateArgs,
+      MutableArrayRef<TemplateArgument> TemplateArgs,
       ConstraintSatisfaction &Satisfaction);
 
   /// \brief Emit diagnostics explaining why a constraint expression was deemed
@@ -14526,7 +14529,7 @@ private:
   /// function.
   bool
   SetupConstraintScope(FunctionDecl *FD,
-                       std::optional<ArrayRef<TemplateArgument>> TemplateArgs,
+                       std::optional<MutableArrayRef<TemplateArgument>> TemplateArgs,
                        const MultiLevelTemplateArgumentList &MLTAL,
                        LocalInstantiationScope &Scope);
 
@@ -14535,7 +14538,7 @@ private:
   /// LocalInstantiationScope to have the proper set of ParVarDecls configured.
   std::optional<MultiLevelTemplateArgumentList>
   SetupConstraintCheckingTemplateArgumentsAndScope(
-      FunctionDecl *FD, std::optional<ArrayRef<TemplateArgument>> TemplateArgs,
+      FunctionDecl *FD, std::optional<MutableArrayRef<TemplateArgument>> TemplateArgs,
       LocalInstantiationScope &Scope);
 
   ///@}

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13073,7 +13073,7 @@ public:
   /// arguments on an enclosing class template.
   MultiLevelTemplateArgumentList getTemplateInstantiationArgs(
       const NamedDecl *D, const DeclContext *DC = nullptr, bool Final = false,
-      std::optional<ArrayRef<TemplateArgument>> Innermost = std::nullopt,
+      std::optional<MutableArrayRef<TemplateArgument>> Innermost = std::nullopt,
       bool RelativeToPrimary = false, const FunctionDecl *Pattern = nullptr,
       bool ForConstraintInstantiation = false,
       bool SkipForSpecialization = false);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14352,7 +14352,7 @@ public:
   /// A diagnostic is emitted if it is not, false is returned, and
   /// PossibleNonPrimary will be set to true if the failure might be due to a
   /// non-primary expression being used as an atomic constraint.
-  bool CheckConstraintExpression(const Expr *CE, Token NextToken = Token(),
+  bool CheckConstraintExpression(Expr *CE, Token NextToken = Token(),
                                  bool *PossibleNonPrimary = nullptr,
                                  bool IsTrailingRequiresClause = false);
 
@@ -14481,7 +14481,7 @@ public:
                                 bool First = true);
 
   const NormalizedConstraint *getNormalizedAssociatedConstraints(
-      NamedDecl *ConstrainedDecl, ArrayRef<const Expr *> AssociatedConstraints);
+      NamedDecl *ConstrainedDecl, ArrayRef<Expr *> AssociatedConstraints);
 
   /// \brief Check whether the given declaration's associated constraints are
   /// at least as constrained than another declaration's according to the
@@ -14491,8 +14491,8 @@ public:
   /// at least constrained than D2, and false otherwise.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool IsAtLeastAsConstrained(NamedDecl *D1, MutableArrayRef<const Expr *> AC1,
-                              NamedDecl *D2, MutableArrayRef<const Expr *> AC2,
+  bool IsAtLeastAsConstrained(NamedDecl *D1, MutableArrayRef<Expr *> AC1,
+                              NamedDecl *D2, MutableArrayRef<Expr *> AC2,
                               bool &Result);
 
   /// If D1 was not at least as constrained as D2, but would've been if a pair
@@ -14500,8 +14500,8 @@ public:
   /// repeated in two separate places in code.
   /// \returns true if such a diagnostic was emitted, false otherwise.
   bool MaybeEmitAmbiguousAtomicConstraintsDiagnostic(
-      NamedDecl *D1, ArrayRef<const Expr *> AC1, NamedDecl *D2,
-      ArrayRef<const Expr *> AC2);
+      NamedDecl *D1, ArrayRef<Expr *> AC1, NamedDecl *D2,
+      ArrayRef<Expr *> AC2);
 
 private:
   /// Caches pairs of template-like decls whose associated constraints were

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13075,7 +13075,7 @@ public:
   /// encountering a lambda generic call operator, and continue looking for
   /// arguments on an enclosing class template.
   MultiLevelTemplateArgumentList getTemplateInstantiationArgs(
-      const NamedDecl *D, const DeclContext *DC = nullptr, bool Final = false,
+      NamedDecl *D, const DeclContext *DC = nullptr, bool Final = false,
       std::optional<MutableArrayRef<TemplateArgument>> Innermost = std::nullopt,
       bool RelativeToPrimary = false, const FunctionDecl *Pattern = nullptr,
       bool ForConstraintInstantiation = false,
@@ -14439,7 +14439,7 @@ public:
 
   // Calculates whether the friend function depends on an enclosing template for
   // the purposes of [temp.friend] p9.
-  bool FriendConstraintsDependOnEnclosingTemplate(const FunctionDecl *FD);
+  bool FriendConstraintsDependOnEnclosingTemplate(FunctionDecl *FD);
 
   /// \brief Ensure that the given template arguments satisfy the constraints
   /// associated with the given template, emitting a diagnostic if they do not.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11837,13 +11837,13 @@ public:
   // the named decl, or the important information we need about it in order to
   // do constraint comparisons.
   class TemplateCompareNewDeclInfo {
-    const NamedDecl *ND = nullptr;
+    NamedDecl *ND = nullptr;
     const DeclContext *DC = nullptr;
     const DeclContext *LexicalDC = nullptr;
     SourceLocation Loc;
 
   public:
-    TemplateCompareNewDeclInfo(const NamedDecl *ND) : ND(ND) {}
+    TemplateCompareNewDeclInfo(NamedDecl *ND) : ND(ND) {}
     TemplateCompareNewDeclInfo(const DeclContext *DeclCtx,
                                const DeclContext *LexicalDeclCtx,
                                SourceLocation Loc)
@@ -11858,7 +11858,10 @@ public:
     // for constraint comparison, so make sure we can check that.
     bool isInvalid() const { return !ND && !DC; }
 
-    const NamedDecl *getDecl() const { return ND; }
+    NamedDecl *getDecl() { return ND; }
+    const NamedDecl *getDecl() const { 
+      return const_cast<TemplateCompareNewDeclInfo *>(this)->getDecl();
+    }
 
     bool ContainsDecl(const NamedDecl *ND) const { return this->ND == ND; }
 
@@ -11898,7 +11901,7 @@ public:
   /// otherwise.
   bool TemplateParameterListsAreEqual(
       const TemplateCompareNewDeclInfo &NewInstFrom, TemplateParameterList *New,
-      const NamedDecl *OldInstFrom, TemplateParameterList *Old, bool Complain,
+      NamedDecl *OldInstFrom, TemplateParameterList *Old, bool Complain,
       TemplateParameterListEqualKind Kind,
       SourceLocation TemplateArgLoc = SourceLocation());
 
@@ -14432,7 +14435,7 @@ public:
   // for figuring out the relative 'depth' of the constraint. The depth of the
   // 'primary template' and the 'instantiated from' templates aren't necessarily
   // the same, such as a case when one is a 'friend' defined in a class.
-  bool AreConstraintExpressionsEqual(const NamedDecl *Old,
+  bool AreConstraintExpressionsEqual(NamedDecl *Old,
                                      const Expr *OldConstr,
                                      const TemplateCompareNewDeclInfo &New,
                                      const Expr *NewConstr);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14372,7 +14372,7 @@ public:
   /// \returns true if an error occurred and satisfaction could not be checked,
   /// false otherwise.
   bool CheckConstraintSatisfaction(
-      const NamedDecl *Template, ArrayRef<const Expr *> ConstraintExprs,
+      const NamedDecl *Template, ArrayRef<Expr *> ConstraintExprs,
       const MultiLevelTemplateArgumentList &TemplateArgLists,
       SourceRange TemplateIDRange, ConstraintSatisfaction &Satisfaction) {
     llvm::SmallVector<Expr *, 4> Converted;
@@ -14404,7 +14404,7 @@ public:
   /// \returns true if an error occurred and satisfaction could not be checked,
   /// false otherwise.
   bool CheckConstraintSatisfaction(
-      const NamedDecl *Template, ArrayRef<const Expr *> ConstraintExprs,
+      const NamedDecl *Template, ArrayRef<Expr *> ConstraintExprs,
       llvm::SmallVectorImpl<Expr *> &ConvertedConstraints,
       const MultiLevelTemplateArgumentList &TemplateArgList,
       SourceRange TemplateIDRange, ConstraintSatisfaction &Satisfaction);
@@ -14415,7 +14415,7 @@ public:
   /// occurred and satisfaction could not be determined.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool CheckConstraintSatisfaction(const Expr *ConstraintExpr,
+  bool CheckConstraintSatisfaction(Expr *ConstraintExpr,
                                    ConstraintSatisfaction &Satisfaction);
 
   /// Check whether the given function decl's trailing requires clause is
@@ -14424,7 +14424,7 @@ public:
   /// an error occurred and satisfaction could not be determined.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool CheckFunctionConstraints(const FunctionDecl *FD,
+  bool CheckFunctionConstraints(FunctionDecl *FD,
                                 ConstraintSatisfaction &Satisfaction,
                                 SourceLocation UsageLoc = SourceLocation(),
                                 bool ForOverloadResolution = false);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10391,7 +10391,7 @@ public:
 
   // Emit as a 'note' the specific overload candidate
   void NoteOverloadCandidate(
-      const NamedDecl *Found, const FunctionDecl *Fn,
+      const NamedDecl *Found, FunctionDecl *Fn,
       OverloadCandidateRewriteKind RewriteKind = OverloadCandidateRewriteKind(),
       QualType DestType = QualType(), bool TakingAddress = false);
 
@@ -10404,7 +10404,7 @@ public:
   /// optionally emitting a diagnostic if the address can't be taken.
   ///
   /// Returns false if taking the address of the function is illegal.
-  bool checkAddressOfFunctionIsAvailable(const FunctionDecl *Function,
+  bool checkAddressOfFunctionIsAvailable(FunctionDecl *Function,
                                          bool Complain = false,
                                          SourceLocation Loc = SourceLocation());
 

--- a/clang/include/clang/Sema/SemaConcept.h
+++ b/clang/include/clang/Sema/SemaConcept.h
@@ -163,9 +163,9 @@ struct NormalizedConstraint {
 
 private:
   static std::optional<NormalizedConstraint>
-  fromConstraintExprs(Sema &S, NamedDecl *D, ArrayRef<const Expr *> E);
+  fromConstraintExprs(Sema &S, NamedDecl *D, ArrayRef<Expr *> E);
   static std::optional<NormalizedConstraint>
-  fromConstraintExpr(Sema &S, NamedDecl *D, const Expr *E);
+  fromConstraintExpr(Sema &S, NamedDecl *D, Expr *E);
 };
 
 struct alignas(ConstraintAlignment) NormalizedConstraintPair {
@@ -191,7 +191,7 @@ struct alignas(ConstraintAlignment) FoldExpandedConstraint {
 
 const NormalizedConstraint *getNormalizedAssociatedConstraints(
     Sema &S, NamedDecl *ConstrainedDecl,
-    ArrayRef<const Expr *> AssociatedConstraints);
+    ArrayRef<Expr *> AssociatedConstraints);
 
 template <typename AtomicSubsumptionEvaluator>
 bool subsumes(const NormalForm &PDNF, const NormalForm &QCNF,
@@ -237,8 +237,8 @@ bool subsumes(const NormalForm &PDNF, const NormalForm &QCNF,
 }
 
 template <typename AtomicSubsumptionEvaluator>
-bool subsumes(Sema &S, NamedDecl *DP, ArrayRef<const Expr *> P, NamedDecl *DQ,
-              ArrayRef<const Expr *> Q, bool &Subsumes,
+bool subsumes(Sema &S, NamedDecl *DP, ArrayRef<Expr *> P, NamedDecl *DQ,
+              ArrayRef<Expr *> Q, bool &Subsumes,
               const AtomicSubsumptionEvaluator &E) {
   // C++ [temp.constr.order] p2
   //   In order to determine if a constraint P subsumes a constraint Q, P is

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -199,8 +199,7 @@ enum class TemplateSubstitutionKind : char {
       assert(NumRetainedOuterLevels <= Depth && Depth < getNumLevels());
       assert(Index <
              TemplateArgumentLists[getNumLevels() - Depth - 1].Args.size());
-      const_cast<TemplateArgument &>(
-          TemplateArgumentLists[getNumLevels() - Depth - 1].Args[Index]) = Arg;
+      TemplateArgumentLists[getNumLevels() - Depth - 1].Args[Index] = Arg;
     }
 
     /// Add a new outmost level to the multi-level template argument

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -76,7 +76,7 @@ enum class TemplateSubstitutionKind : char {
   class MultiLevelTemplateArgumentList {
     /// The template argument list at a certain template depth
 
-    using ArgList = ArrayRef<TemplateArgument>;
+    using ArgList = MutableArrayRef<TemplateArgument>;
     struct ArgumentListLevel {
       llvm::PointerIntPair<Decl *, 1, bool> AssociatedDeclAndFinal;
       ArgList Args;

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4162,6 +4162,11 @@ FunctionDecl::getTemplateSpecializationInfo() const {
 
 const TemplateArgumentList *
 FunctionDecl::getTemplateSpecializationArgs() const {
+  return const_cast<FunctionDecl *>(this)->getTemplateSpecializationArgs();
+}
+
+TemplateArgumentList *
+FunctionDecl::getTemplateSpecializationArgs() {
   if (FunctionTemplateSpecializationInfo *Info
         = TemplateOrSpecialization
             .dyn_cast<FunctionTemplateSpecializationInfo*>()) {

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -396,7 +396,7 @@ void RedeclarableTemplateDecl::addSpecializationImpl(
                                       SETraits::getDecl(Entry));
 }
 
-ArrayRef<TemplateArgument> RedeclarableTemplateDecl::getInjectedTemplateArgs() {
+MutableArrayRef<TemplateArgument> RedeclarableTemplateDecl::getInjectedTemplateArgs() {
   TemplateParameterList *Params = getTemplateParameters();
   auto *CommonPtr = getCommonPtr();
   if (!CommonPtr->InjectedArgs) {
@@ -409,7 +409,11 @@ ArrayRef<TemplateArgument> RedeclarableTemplateDecl::getInjectedTemplateArgs() {
               CommonPtr->InjectedArgs);
   }
 
-  return llvm::ArrayRef(CommonPtr->InjectedArgs, Params->size());
+  return llvm::MutableArrayRef(CommonPtr->InjectedArgs, Params->size());
+}
+
+ArrayRef<TemplateArgument> RedeclarableTemplateDecl::getInjectedTemplateArgs() const {
+  return const_cast<RedeclarableTemplateDecl *>(this)->getInjectedTemplateArgs();
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -225,14 +225,14 @@ static bool AdoptTemplateParameterList(TemplateParameterList *Params,
 }
 
 void TemplateParameterList::
-getAssociatedConstraints(llvm::SmallVectorImpl<const Expr *> &AC) const {
+getAssociatedConstraints(llvm::SmallVectorImpl<Expr *> &AC) {
   if (HasConstrainedParameters)
     for (const NamedDecl *Param : *this) {
       if (const auto *TTP = dyn_cast<TemplateTypeParmDecl>(Param)) {
         if (const auto *TC = TTP->getTypeConstraint())
           AC.push_back(TC->getImmediatelyDeclaredConstraint());
       } else if (const auto *NTTP = dyn_cast<NonTypeTemplateParmDecl>(Param)) {
-        if (const Expr *E = NTTP->getPlaceholderTypeConstraint())
+        if (Expr *E = NTTP->getPlaceholderTypeConstraint())
           AC.push_back(E);
       }
     }
@@ -277,10 +277,10 @@ TemplateDecl::TemplateDecl(Kind DK, DeclContext *DC, SourceLocation L,
 void TemplateDecl::anchor() {}
 
 void TemplateDecl::
-getAssociatedConstraints(llvm::SmallVectorImpl<const Expr *> &AC) const {
+getAssociatedConstraints(llvm::SmallVectorImpl<Expr *> &AC) {
   TemplateParams->getAssociatedConstraints(AC);
   if (auto *FD = dyn_cast_or_null<FunctionDecl>(getTemplatedDecl()))
-    if (const Expr *TRC = FD->getTrailingRequiresClause())
+    if (Expr *TRC = FD->getTrailingRequiresClause())
       AC.push_back(TRC);
 }
 

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -587,6 +587,10 @@ template <> const TemplateSpecializationType *Type::getAs() const {
   return getAsSugar<TemplateSpecializationType>(this);
 }
 
+template <> TemplateSpecializationType *Type::getAs() {
+  return const_cast<TemplateSpecializationType *>(getAsSugar<TemplateSpecializationType>(this));
+}
+
 template <> const AttributedType *Type::getAs() const {
   return getAsSugar<AttributedType>(this);
 }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -300,7 +300,7 @@ static bool BuiltinFunctionStart(Sema &S, CallExpr *TheCall) {
     return true;
   }
 
-  return !S.checkAddressOfFunctionIsAvailable(FD, /*Complain=*/true,
+  return !S.checkAddressOfFunctionIsAvailable(const_cast<FunctionDecl *>(FD), /*Complain=*/true,
                                               TheCall->getBeginLoc());
 }
 

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5569,19 +5569,19 @@ private:
 
   // Gets all the type constraint expressions that might apply to the type
   // variables associated with DC (as returned by getTemplatedEntity()).
-  static SmallVector<const Expr *, 1>
+  static SmallVector<Expr *, 1>
   constraintsForTemplatedEntity(DeclContext *DC) {
-    SmallVector<const Expr *, 1> Result;
+    SmallVector<Expr *, 1> Result;
     if (DC == nullptr)
       return Result;
     // Primary templates can have constraints.
-    if (const auto *TD = cast<Decl>(DC)->getDescribedTemplate())
+    if (auto *TD = cast<Decl>(DC)->getDescribedTemplate())
       TD->getAssociatedConstraints(Result);
     // Partial specializations may have constraints.
-    if (const auto *CTPSD =
+    if (auto *CTPSD =
             dyn_cast<ClassTemplatePartialSpecializationDecl>(DC))
       CTPSD->getAssociatedConstraints(Result);
-    if (const auto *VTPSD = dyn_cast<VarTemplatePartialSpecializationDecl>(DC))
+    if (auto *VTPSD = dyn_cast<VarTemplatePartialSpecializationDecl>(DC))
       VTPSD->getAssociatedConstraints(Result);
     return Result;
   }

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -583,7 +583,7 @@ static bool CheckConstraintSatisfaction(
     return false;
   }
 
-  ArrayRef<TemplateArgument> TemplateArgs =
+  MutableArrayRef<TemplateArgument> TemplateArgs =
       TemplateArgsLists.getNumSubstitutedLevels() > 0
           ? TemplateArgsLists.getOutermost()
           : MutableArrayRef<TemplateArgument> {};
@@ -750,7 +750,7 @@ bool Sema::addInstantiatedCapturesToScope(
 }
 
 bool Sema::SetupConstraintScope(
-    FunctionDecl *FD, std::optional<ArrayRef<TemplateArgument>> TemplateArgs,
+    FunctionDecl *FD, std::optional<MutableArrayRef<TemplateArgument>> TemplateArgs,
     const MultiLevelTemplateArgumentList &MLTAL,
     LocalInstantiationScope &Scope) {
   if (FD->isTemplateInstantiation() && FD->getPrimaryTemplate()) {
@@ -758,7 +758,7 @@ bool Sema::SetupConstraintScope(
     InstantiatingTemplate Inst(
         *this, FD->getPointOfInstantiation(),
         Sema::InstantiatingTemplate::ConstraintsCheck{}, PrimaryTemplate,
-        TemplateArgs ? *TemplateArgs : ArrayRef<TemplateArgument>{},
+        TemplateArgs ? *TemplateArgs : MutableArrayRef<TemplateArgument>{},
         SourceRange());
     if (Inst.isInvalid())
       return true;
@@ -804,7 +804,7 @@ bool Sema::SetupConstraintScope(
     InstantiatingTemplate Inst(
         *this, FD->getPointOfInstantiation(),
         Sema::InstantiatingTemplate::ConstraintsCheck{}, InstantiatedFrom,
-        TemplateArgs ? *TemplateArgs : ArrayRef<TemplateArgument>{},
+        TemplateArgs ? *TemplateArgs : MutableArrayRef<TemplateArgument>{},
         SourceRange());
     if (Inst.isInvalid())
       return true;
@@ -822,7 +822,7 @@ bool Sema::SetupConstraintScope(
 // constraint-instantiation and checking.
 std::optional<MultiLevelTemplateArgumentList>
 Sema::SetupConstraintCheckingTemplateArgumentsAndScope(
-    FunctionDecl *FD, std::optional<ArrayRef<TemplateArgument>> TemplateArgs,
+    FunctionDecl *FD, std::optional<MutableArrayRef<TemplateArgument>> TemplateArgs,
     LocalInstantiationScope &Scope) {
   MultiLevelTemplateArgumentList MLTAL;
 
@@ -1081,7 +1081,7 @@ bool Sema::EnsureTemplateArgumentListConstraints(
 
 bool Sema::CheckInstantiatedFunctionTemplateConstraints(
     SourceLocation PointOfInstantiation, FunctionDecl *Decl,
-    ArrayRef<TemplateArgument> TemplateArgs,
+    MutableArrayRef<TemplateArgument> TemplateArgs,
     ConstraintSatisfaction &Satisfaction) {
   // In most cases we're not going to have constraints, so check for that first.
   FunctionTemplateDecl *Template = Decl->getPrimaryTemplate();

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1485,7 +1485,7 @@ substituteParameterMappings(Sema &S, NormalizedConstraint &N,
 }
 
 static bool substituteParameterMappings(Sema &S, NormalizedConstraint &N,
-                                        const ConceptSpecializationExpr *CSE) {
+                                        ConceptSpecializationExpr *CSE) {
   MultiLevelTemplateArgumentList MLTAL = S.getTemplateInstantiationArgs(
       CSE->getNamedConcept(), CSE->getNamedConcept()->getLexicalDeclContext(),
       /*Final=*/false, CSE->getTemplateArguments(),
@@ -1575,7 +1575,7 @@ NormalizedConstraint::fromConstraintExpr(Sema &S, NamedDecl *D, const Expr *E) {
 
     return NormalizedConstraint(S.Context, std::move(*LHS), std::move(*RHS),
                                 BO.isAnd() ? CCK_Conjunction : CCK_Disjunction);
-  } else if (auto *CSE = dyn_cast<const ConceptSpecializationExpr>(E)) {
+  } else if (auto *CSE = dyn_cast<ConceptSpecializationExpr>(const_cast<Expr *>(E))) {
     const NormalizedConstraint *SubNF;
     {
       Sema::InstantiatingTemplate Inst(

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -910,7 +910,7 @@ bool Sema::CheckFunctionConstraints(const FunctionDecl *FD,
 // the purpose of seeing if they differ by constraints. This isn't the same as
 // getTemplateDepth, because it includes already instantiated parents.
 static unsigned
-CalculateTemplateDepthForConstraints(Sema &S, const NamedDecl *ND,
+CalculateTemplateDepthForConstraints(Sema &S, NamedDecl *ND,
                                      bool SkipForSpecialization = false) {
   MultiLevelTemplateArgumentList MLTAL = S.getTemplateInstantiationArgs(
       ND, ND->getLexicalDeclContext(), /*Final=*/false,
@@ -1031,7 +1031,7 @@ bool Sema::AreConstraintExpressionsEqual(const NamedDecl *Old,
   return ID1 == ID2;
 }
 
-bool Sema::FriendConstraintsDependOnEnclosingTemplate(const FunctionDecl *FD) {
+bool Sema::FriendConstraintsDependOnEnclosingTemplate(FunctionDecl *FD) {
   assert(FD->getFriendObjectKind() && "Must be a friend!");
 
   // The logic for non-templates is handled in ASTContext::isSameEntity, so we

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -950,7 +950,7 @@ namespace {
 } // namespace
 
 static const Expr *SubstituteConstraintExpressionWithoutSatisfaction(
-    Sema &S, const Sema::TemplateCompareNewDeclInfo &DeclInfo,
+    Sema &S, Sema::TemplateCompareNewDeclInfo DeclInfo,
     const Expr *ConstrExpr) {
   MultiLevelTemplateArgumentList MLTAL = S.getTemplateInstantiationArgs(
       DeclInfo.getDecl(), DeclInfo.getLexicalDeclContext(), /*Final=*/false,
@@ -1002,7 +1002,7 @@ static const Expr *SubstituteConstraintExpressionWithoutSatisfaction(
   return SubstConstr.get();
 }
 
-bool Sema::AreConstraintExpressionsEqual(const NamedDecl *Old,
+bool Sema::AreConstraintExpressionsEqual(NamedDecl *Old,
                                          const Expr *OldConstr,
                                          const TemplateCompareNewDeclInfo &New,
                                          const Expr *NewConstr) {

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -192,8 +192,8 @@ calculateConstraintSatisfaction(Sema &S, Expr *ConstraintExpr,
 
 template <typename ConstraintEvaluator>
 static ExprResult
-calculateConstraintSatisfaction(Sema &S, const Expr *LHS,
-                                OverloadedOperatorKind Op, const Expr *RHS,
+calculateConstraintSatisfaction(Sema &S, Expr *LHS,
+                                OverloadedOperatorKind Op, Expr *RHS,
                                 ConstraintSatisfaction &Satisfaction,
                                 const ConstraintEvaluator &Evaluator) {
   size_t EffectiveDetailEndIndex = Satisfaction.Details.size();
@@ -439,7 +439,7 @@ DiagRecursiveConstraintEval(Sema &S, llvm::FoldingSetNodeID &ID,
 
 static ExprResult calculateConstraintSatisfaction(
     Sema &S, const NamedDecl *Template, SourceLocation TemplateNameLoc,
-    const MultiLevelTemplateArgumentList &MLTAL, const Expr *ConstraintExpr,
+    const MultiLevelTemplateArgumentList &MLTAL, Expr *ConstraintExpr,
     ConstraintSatisfaction &Satisfaction) {
 
   struct ConstraintEvaluator {
@@ -574,7 +574,7 @@ static ExprResult calculateConstraintSatisfaction(
 }
 
 static bool CheckConstraintSatisfaction(
-    Sema &S, const NamedDecl *Template, ArrayRef<const Expr *> ConstraintExprs,
+    Sema &S, const NamedDecl *Template, ArrayRef<Expr *> ConstraintExprs,
     llvm::SmallVectorImpl<Expr *> &Converted,
     const MultiLevelTemplateArgumentList &TemplateArgsLists,
     SourceRange TemplateIDRange, ConstraintSatisfaction &Satisfaction) {
@@ -599,7 +599,7 @@ static bool CheckConstraintSatisfaction(
   if (Inst.isInvalid())
     return true;
 
-  for (const Expr *ConstraintExpr : ConstraintExprs) {
+  for (Expr *ConstraintExpr : ConstraintExprs) {
     ExprResult Res = calculateConstraintSatisfaction(
         S, Template, TemplateIDRange.getBegin(), TemplateArgsLists,
         ConstraintExpr, Satisfaction);
@@ -622,7 +622,7 @@ static bool CheckConstraintSatisfaction(
 }
 
 bool Sema::CheckConstraintSatisfaction(
-    const NamedDecl *Template, ArrayRef<const Expr *> ConstraintExprs,
+    const NamedDecl *Template, ArrayRef<Expr *> ConstraintExprs,
     llvm::SmallVectorImpl<Expr *> &ConvertedConstraints,
     const MultiLevelTemplateArgumentList &TemplateArgsLists,
     SourceRange TemplateIDRange, ConstraintSatisfaction &OutSatisfaction) {
@@ -690,7 +690,7 @@ bool Sema::CheckConstraintSatisfaction(
   return false;
 }
 
-bool Sema::CheckConstraintSatisfaction(const Expr *ConstraintExpr,
+bool Sema::CheckConstraintSatisfaction(Expr *ConstraintExpr,
                                        ConstraintSatisfaction &Satisfaction) {
 
   struct ConstraintEvaluator {
@@ -847,7 +847,7 @@ Sema::SetupConstraintCheckingTemplateArgumentsAndScope(
   return MLTAL;
 }
 
-bool Sema::CheckFunctionConstraints(const FunctionDecl *FD,
+bool Sema::CheckFunctionConstraints(FunctionDecl *FD,
                                     ConstraintSatisfaction &Satisfaction,
                                     SourceLocation UsageLoc,
                                     bool ForOverloadResolution) {

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -586,7 +586,7 @@ static bool CheckConstraintSatisfaction(
   ArrayRef<TemplateArgument> TemplateArgs =
       TemplateArgsLists.getNumSubstitutedLevels() > 0
           ? TemplateArgsLists.getOutermost()
-          : ArrayRef<TemplateArgument> {};
+          : MutableArrayRef<TemplateArgument> {};
   Sema::InstantiatingTemplate Inst(S, TemplateIDRange.getBegin(),
       Sema::InstantiatingTemplate::ConstraintsCheck{},
       const_cast<NamedDecl *>(Template), TemplateArgs, TemplateIDRange);
@@ -769,7 +769,7 @@ bool Sema::SetupConstraintScope(
     // the list of current template arguments to the list so that they also can
     // be picked out of the map.
     if (auto *SpecArgs = FD->getTemplateSpecializationArgs()) {
-      MultiLevelTemplateArgumentList JustTemplArgs(FD, SpecArgs->asArray(),
+      MultiLevelTemplateArgumentList JustTemplArgs(FD, SpecArgs->asMutableArray(),
                                                    /*Final=*/false);
       if (addInstantiatedParametersToScope(
               FD, PrimaryTemplate->getTemplatedDecl(), Scope, JustTemplArgs))

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18770,7 +18770,7 @@ static void SetEligibleMethods(Sema &S, CXXRecordDecl *Record,
     if (FunctionDecl *MF = OrigMethod->getInstantiatedFromMemberFunction())
       OrigMethod = cast<CXXMethodDecl>(MF);
 
-    const Expr *Constraints = OrigMethod->getTrailingRequiresClause();
+    Expr *Constraints = OrigMethod->getTrailingRequiresClause();
     bool AnotherMethodIsMoreConstrained = false;
     for (size_t j = 0; j < Methods.size(); j++) {
       if (i == j || !SatisfactionStatus[j])
@@ -18783,7 +18783,7 @@ static void SetEligibleMethods(Sema &S, CXXRecordDecl *Record,
                                              CSM))
         continue;
 
-      const Expr *OtherConstraints = OtherMethod->getTrailingRequiresClause();
+      Expr *OtherConstraints = OtherMethod->getTrailingRequiresClause();
       if (!OtherConstraints)
         continue;
       if (!Constraints) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -16579,7 +16579,7 @@ ExprResult Sema::ActOnEmbedExpr(SourceLocation EmbedKeywordLoc,
 }
 
 static bool maybeDiagnoseAssignmentToFunction(Sema &S, QualType DstType,
-                                              const Expr *SrcExpr) {
+                                              Expr *SrcExpr) {
   if (!DstType->isFunctionPointerType() ||
       !SrcExpr->getType()->isFunctionType())
     return false;

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -6271,7 +6271,7 @@ InitializationSequence::InitializationSequence(
 
 /// Tries to get a FunctionDecl out of `E`. If it succeeds and we can take the
 /// address of that function, this returns true. Otherwise, it returns false.
-static bool isExprAnUnaddressableFunction(Sema &S, const Expr *E) {
+static bool isExprAnUnaddressableFunction(Sema &S, Expr *E) {
   auto *DRE = dyn_cast<DeclRefExpr>(E);
   if (!DRE || !isa<FunctionDecl>(DRE->getDecl()))
     return false;

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -3718,7 +3718,7 @@ Sema::LookupLiteralOperator(Scope *S, LookupResult &R,
   // operator template, but not both.
   if (FoundRaw && FoundTemplate) {
     Diag(R.getNameLoc(), diag::err_ovl_ambiguous_call) << R.getLookupName();
-    for (const NamedDecl *D : R)
+    for (NamedDecl *D : R)
       NoteOverloadCandidate(D, D->getUnderlyingDecl()->getAsFunction());
     return LOLR_Error;
   }

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11088,12 +11088,12 @@ MaybeDiagnoseAmbiguousConstraints(Sema &S, ArrayRef<OverloadCandidate> Cands) {
   // source-level construct. This behavior is quite confusing and we should try
   // to help the user figure out what happened.
 
-  SmallVector<const Expr *, 3> FirstAC, SecondAC;
+  SmallVector<Expr *, 3> FirstAC, SecondAC;
   FunctionDecl *FirstCand = nullptr, *SecondCand = nullptr;
   for (auto I = Cands.begin(), E = Cands.end(); I != E; ++I) {
     if (!I->Function)
       continue;
-    SmallVector<const Expr *, 3> AC;
+    SmallVector<Expr *, 3> AC;
     if (auto *Template = I->Function->getPrimaryTemplate())
       Template->getAssociatedConstraints(AC);
     else

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -10966,7 +10966,7 @@ static bool checkAddressOfFunctionIsAvailable(Sema &S, const FunctionDecl *FD,
 
   if (FD->getTrailingRequiresClause()) {
     ConstraintSatisfaction Satisfaction;
-    if (S.CheckFunctionConstraints(FD, Satisfaction, Loc))
+    if (S.CheckFunctionConstraints(const_cast<FunctionDecl *>(FD), Satisfaction, Loc))
       return false;
     if (!Satisfaction.IsSatisfied) {
       if (Complain) {

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -10949,7 +10949,7 @@ static bool isFunctionAlwaysEnabled(const ASTContext &Ctx,
 ///   we in overload resolution?
 /// \param Loc - The location of the statement we're complaining about. Ignored
 ///   if we're not complaining, or if we're in overload resolution.
-static bool checkAddressOfFunctionIsAvailable(Sema &S, const FunctionDecl *FD,
+static bool checkAddressOfFunctionIsAvailable(Sema &S, FunctionDecl *FD,
                                               bool Complain,
                                               bool InOverloadResolution,
                                               SourceLocation Loc) {
@@ -10966,7 +10966,7 @@ static bool checkAddressOfFunctionIsAvailable(Sema &S, const FunctionDecl *FD,
 
   if (FD->getTrailingRequiresClause()) {
     ConstraintSatisfaction Satisfaction;
-    if (S.CheckFunctionConstraints(const_cast<FunctionDecl *>(FD), Satisfaction, Loc))
+    if (S.CheckFunctionConstraints(FD, Satisfaction, Loc))
       return false;
     if (!Satisfaction.IsSatisfied) {
       if (Complain) {
@@ -11012,13 +11012,13 @@ static bool checkAddressOfFunctionIsAvailable(Sema &S, const FunctionDecl *FD,
 }
 
 static bool checkAddressOfCandidateIsAvailable(Sema &S,
-                                               const FunctionDecl *FD) {
+                                               FunctionDecl *FD) {
   return checkAddressOfFunctionIsAvailable(S, FD, /*Complain=*/true,
                                            /*InOverloadResolution=*/true,
                                            /*Loc=*/SourceLocation());
 }
 
-bool Sema::checkAddressOfFunctionIsAvailable(const FunctionDecl *Function,
+bool Sema::checkAddressOfFunctionIsAvailable(FunctionDecl *Function,
                                              bool Complain,
                                              SourceLocation Loc) {
   return ::checkAddressOfFunctionIsAvailable(*this, Function, Complain,
@@ -11048,7 +11048,7 @@ static bool shouldSkipNotingLambdaConversionDecl(const FunctionDecl *Fn) {
 }
 
 // Notes the location of an overload candidate.
-void Sema::NoteOverloadCandidate(const NamedDecl *Found, const FunctionDecl *Fn,
+void Sema::NoteOverloadCandidate(const NamedDecl *Found, FunctionDecl *Fn,
                                  OverloadCandidateRewriteKind RewriteKind,
                                  QualType DestType, bool TakingAddress) {
   if (TakingAddress && !checkAddressOfCandidateIsAvailable(*this, Fn))
@@ -14024,7 +14024,7 @@ static ExprResult FinishOverloadedCallExpr(Sema &SemaRef, Scope *S, Expr *Fn,
     // If the user passes in a function that we can't take the address of, we
     // generally end up emitting really bad error messages. Here, we attempt to
     // emit better ones.
-    for (const Expr *Arg : Args) {
+    for (Expr *Arg : Args) {
       if (!Arg->getType()->isFunctionType())
         continue;
       if (auto *DRE = dyn_cast<DeclRefExpr>(Arg->IgnoreParenImpCasts())) {

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -7514,7 +7514,7 @@ Sema::BuildExpressionFromNonTypeTemplateArgument(const TemplateArgument &Arg,
 static bool MatchTemplateParameterKind(
     Sema &S, NamedDecl *New,
     const Sema::TemplateCompareNewDeclInfo &NewInstFrom, NamedDecl *Old,
-    const NamedDecl *OldInstFrom, bool Complain,
+    NamedDecl *OldInstFrom, bool Complain,
     Sema::TemplateParameterListEqualKind Kind, SourceLocation TemplateArgLoc) {
   // Check the actual kind (type, non-type, template).
   if (Old->getKind() != New->getKind()) {
@@ -7684,7 +7684,7 @@ void DiagnoseTemplateParameterListArityMismatch(Sema &S,
 
 bool Sema::TemplateParameterListsAreEqual(
     const TemplateCompareNewDeclInfo &NewInstFrom, TemplateParameterList *New,
-    const NamedDecl *OldInstFrom, TemplateParameterList *Old, bool Complain,
+    NamedDecl *OldInstFrom, TemplateParameterList *Old, bool Complain,
     TemplateParameterListEqualKind Kind, SourceLocation TemplateArgLoc) {
   if (Old->size() != New->size() && Kind != TPL_TemplateTemplateArgumentMatch) {
     if (Complain)

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -4190,7 +4190,7 @@ Sema::CheckVarTemplateId(VarTemplateDecl *Template, SourceLocation TemplateLoc,
   // the set of specializations, based on the closest partial specialization
   // that it represents. That is,
   VarDecl *InstantiationPattern = Template->getTemplatedDecl();
-  const TemplateArgumentList *PartialSpecArgs = nullptr;
+  TemplateArgumentList *PartialSpecArgs = nullptr;
   bool AmbiguousPartialSpec = false;
   typedef PartialSpecMatchResult MatchResult;
   SmallVector<MatchResult, 4> Matched;
@@ -4764,7 +4764,7 @@ bool Sema::CheckTemplateTypeArgument(
 static bool SubstDefaultTemplateArgument(
     Sema &SemaRef, TemplateDecl *Template, SourceLocation TemplateLoc,
     SourceLocation RAngleLoc, TemplateTypeParmDecl *Param,
-    ArrayRef<TemplateArgument> SugaredConverted,
+    MutableArrayRef<TemplateArgument> SugaredConverted,
     ArrayRef<TemplateArgument> CanonicalConverted,
     TemplateArgumentLoc &Output) {
   Output = Param->getDefaultArgument();
@@ -4824,7 +4824,7 @@ static bool SubstDefaultTemplateArgument(
 static bool SubstDefaultTemplateArgument(
     Sema &SemaRef, TemplateDecl *Template, SourceLocation TemplateLoc,
     SourceLocation RAngleLoc, NonTypeTemplateParmDecl *Param,
-    ArrayRef<TemplateArgument> SugaredConverted,
+    MutableArrayRef<TemplateArgument> SugaredConverted,
     ArrayRef<TemplateArgument> CanonicalConverted,
     TemplateArgumentLoc &Output) {
   Sema::InstantiatingTemplate Inst(SemaRef, TemplateLoc, Param, Template,
@@ -4874,7 +4874,7 @@ static bool SubstDefaultTemplateArgument(
 static TemplateName SubstDefaultTemplateArgument(
     Sema &SemaRef, TemplateDecl *Template, SourceLocation TemplateLoc,
     SourceLocation RAngleLoc, TemplateTemplateParmDecl *Param,
-    ArrayRef<TemplateArgument> SugaredConverted,
+    MutableArrayRef<TemplateArgument> SugaredConverted,
     ArrayRef<TemplateArgument> CanonicalConverted,
     NestedNameSpecifierLoc &QualifierLoc) {
   Sema::InstantiatingTemplate Inst(
@@ -4909,7 +4909,7 @@ static TemplateName SubstDefaultTemplateArgument(
 TemplateArgumentLoc Sema::SubstDefaultTemplateArgumentIfAvailable(
     TemplateDecl *Template, SourceLocation TemplateLoc,
     SourceLocation RAngleLoc, Decl *Param,
-    ArrayRef<TemplateArgument> SugaredConverted,
+    MutableArrayRef<TemplateArgument> SugaredConverted,
     ArrayRef<TemplateArgument> CanonicalConverted, bool &HasDefaultArg) {
   HasDefaultArg = false;
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -3864,7 +3864,7 @@ static void checkMoreSpecializedThanPrimary(Sema &S, PartialSpecDecl *Partial) {
   }
 
   S.NoteTemplateLocation(*Template);
-  SmallVector<const Expr *, 3> PartialAC, TemplateAC;
+  SmallVector<Expr *, 3> PartialAC, TemplateAC;
   Template->getAssociatedConstraints(TemplateAC);
   Partial->getAssociatedConstraints(PartialAC);
   S.MaybeEmitAmbiguousAtomicConstraintsDiagnostic(Partial, PartialAC, Template,
@@ -7167,7 +7167,7 @@ bool Sema::CheckTemplateTemplateArgument(TemplateTemplateParmDecl *Param,
       // C++20[temp.func.order]p2
       //   [...] If both deductions succeed, the partial ordering selects the
       // more constrained template (if one exists) as determined below.
-      SmallVector<const Expr *, 3> ParamsAC, TemplateAC;
+      SmallVector<Expr *, 3> ParamsAC, TemplateAC;
       Params->getAssociatedConstraints(ParamsAC);
       // C++2a[temp.arg.template]p3
       //   [...] In this comparison, if P is unconstrained, the constraints on A

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -3072,7 +3072,7 @@ CheckDeducedArgumentConstraints(Sema &S, TemplateDeclT *Template,
                                 ArrayRef<TemplateArgument> SugaredDeducedArgs,
                                 MutableArrayRef<TemplateArgument> CanonicalDeducedArgs,
                                 TemplateDeductionInfo &Info) {
-  llvm::SmallVector<const Expr *, 3> AssociatedConstraints;
+  llvm::SmallVector<Expr *, 3> AssociatedConstraints;
   Template->getAssociatedConstraints(AssociatedConstraints);
 
   std::optional<MutableArrayRef<TemplateArgument>> Innermost;
@@ -5717,7 +5717,7 @@ FunctionTemplateDecl *Sema::getMoreSpecializedTemplate(
       !Context.hasSameType(FD1->getReturnType(), FD2->getReturnType()))
     return nullptr;
 
-  llvm::SmallVector<const Expr *, 3> AC1, AC2;
+  llvm::SmallVector<Expr *, 3> AC1, AC2;
   FT1->getAssociatedConstraints(AC1);
   FT2->getAssociatedConstraints(AC2);
   bool AtLeastAsConstrained1, AtLeastAsConstrained2;
@@ -5822,7 +5822,7 @@ FunctionDecl *Sema::getMoreConstrainedFunction(FunctionDecl *FD1,
   if (FunctionDecl *P = FD2->getTemplateInstantiationPattern(false))
     F2 = P;
 
-  llvm::SmallVector<const Expr *, 1> AC1, AC2;
+  llvm::SmallVector<Expr *, 1> AC1, AC2;
   F1->getAssociatedConstraints(AC1);
   F2->getAssociatedConstraints(AC2);
   bool AtLeastAsConstrained1, AtLeastAsConstrained2;
@@ -6057,7 +6057,7 @@ getMoreSpecialized(Sema &S, QualType T1, QualType T2, TemplateLikeDecl *P1,
   if (!TemplateArgumentListAreEqual(S.getASTContext())(P1, P2))
     return nullptr;
 
-  llvm::SmallVector<const Expr *, 3> AC1, AC2;
+  llvm::SmallVector<Expr *, 3> AC1, AC2;
   P1->getAssociatedConstraints(AC1);
   P2->getAssociatedConstraints(AC2);
   bool AtLeastAsConstrained1, AtLeastAsConstrained2;

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -3075,7 +3075,7 @@ CheckDeducedArgumentConstraints(Sema &S, TemplateDeclT *Template,
   llvm::SmallVector<const Expr *, 3> AssociatedConstraints;
   Template->getAssociatedConstraints(AssociatedConstraints);
 
-  std::optional<ArrayRef<TemplateArgument>> Innermost;
+  std::optional<MutableArrayRef<TemplateArgument>> Innermost;
   // If we don't need to replace the deduced template arguments,
   // we can add them immediately as the inner-most argument list.
   if (!DeducedArgsNeedReplacement(Template))

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -3070,7 +3070,7 @@ template <typename TemplateDeclT>
 static TemplateDeductionResult
 CheckDeducedArgumentConstraints(Sema &S, TemplateDeclT *Template,
                                 ArrayRef<TemplateArgument> SugaredDeducedArgs,
-                                ArrayRef<TemplateArgument> CanonicalDeducedArgs,
+                                MutableArrayRef<TemplateArgument> CanonicalDeducedArgs,
                                 TemplateDeductionInfo &Info) {
   llvm::SmallVector<const Expr *, 3> AssociatedConstraints;
   Template->getAssociatedConstraints(AssociatedConstraints);
@@ -3524,7 +3524,7 @@ TemplateDeductionResult Sema::SubstituteExplicitTemplateArguments(
   ExtParameterInfoBuilder ExtParamInfos;
 
   MultiLevelTemplateArgumentList MLTAL(FunctionTemplate,
-                                       SugaredExplicitArgumentList->asArray(),
+                                       SugaredExplicitArgumentList->asMutableArray(),
                                        /*Final=*/true);
 
   // Instantiate the types of each of the function parameters given the
@@ -3877,7 +3877,7 @@ TemplateDeductionResult Sema::FinishTemplateArgumentDeduction(
     Owner = FD->getLexicalDeclContext();
   }
   MultiLevelTemplateArgumentList SubstArgs(
-      FunctionTemplate, CanonicalDeducedArgumentList->asArray(),
+      FunctionTemplate, CanonicalDeducedArgumentList->asMutableArray(),
       /*Final=*/false);
   Specialization = cast_or_null<FunctionDecl>(
       SubstDecl(FD, Owner, SubstArgs));

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -3766,7 +3766,7 @@ static TemplateDeductionResult instantiateExplicitSpecifierDeferred(
     Sema &S, FunctionDecl *Specialization,
     const MultiLevelTemplateArgumentList &SubstArgs,
     TemplateDeductionInfo &Info, FunctionTemplateDecl *FunctionTemplate,
-    ArrayRef<TemplateArgument> DeducedArgs) {
+    MutableArrayRef<TemplateArgument> DeducedArgs) {
   auto GetExplicitSpecifier = [](FunctionDecl *D) {
     return isa<CXXConstructorDecl>(D)
                ? cast<CXXConstructorDecl>(D)->getExplicitSpecifier()

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -272,7 +272,7 @@ Response HandleFunction(Sema &SemaRef, FunctionDecl *Function,
   } else if (TemplateArgumentList *TemplateArgs =
                  Function->getTemplateSpecializationArgs()) {
     // Add the template arguments for this specialization.
-    Result.addOuterTemplateArguments(const_cast<FunctionDecl *>(Function),
+    Result.addOuterTemplateArguments(Function,
                                      TemplateArgs->asMutableArray(),
                                      /*Final=*/false);
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -463,7 +463,7 @@ Response HandleGenericDeclContext(const Decl *CurDecl) {
 } // namespace
 
 MultiLevelTemplateArgumentList Sema::getTemplateInstantiationArgs(
-    const NamedDecl *ND, const DeclContext *DC, bool Final,
+    NamedDecl *ND, const DeclContext *DC, bool Final,
     std::optional<MutableArrayRef<TemplateArgument>> Innermost, bool RelativeToPrimary,
     const FunctionDecl *Pattern, bool ForConstraintInstantiation,
     bool SkipForSpecialization) {
@@ -472,13 +472,13 @@ MultiLevelTemplateArgumentList Sema::getTemplateInstantiationArgs(
   MultiLevelTemplateArgumentList Result;
 
   using namespace TemplateInstArgsHelpers;
-  Decl *CurDecl = const_cast<NamedDecl *>(ND);
+  Decl *CurDecl = ND;
 
   if (!CurDecl)
     CurDecl = Decl::castFromDeclContext(DC);
 
   if (Innermost) {
-    Result.addOuterTemplateArguments(const_cast<NamedDecl *>(ND), *Innermost, Final);
+    Result.addOuterTemplateArguments(ND, *Innermost, Final);
     // Populate placeholder template arguments for TemplateTemplateParmDecls.
     // This is essential for the case e.g.
     //

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -181,7 +181,7 @@ HandleVarTemplateSpec(const VarTemplateSpecializationDecl *VarTemplSpec,
           Specialized.dyn_cast<VarTemplatePartialSpecializationDecl *>()) {
     if (!SkipForSpecialization)
       Result.addOuterTemplateArguments(
-          Partial, VarTemplSpec->getTemplateInstantiationArgs().asArray(),
+          Partial, VarTemplSpec->getTemplateInstantiationArgs().asMutableArray(),
           /*Final=*/false);
     if (Partial->isMemberSpecialization())
       return Response::Done();
@@ -189,7 +189,7 @@ HandleVarTemplateSpec(const VarTemplateSpecializationDecl *VarTemplSpec,
     VarTemplateDecl *Tmpl = Specialized.get<VarTemplateDecl *>();
     if (!SkipForSpecialization)
       Result.addOuterTemplateArguments(
-          Tmpl, VarTemplSpec->getTemplateInstantiationArgs().asArray(),
+          Tmpl, VarTemplSpec->getTemplateInstantiationArgs().asMutableArray(),
           /*Final=*/false);
     if (Tmpl->isMemberSpecialization())
       return Response::Done();

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -341,7 +341,7 @@ Response HandleFunctionTemplateDecl(FunctionTemplateDecl *FTD,
 
     while (Type *Ty = NNS ? NNS->getAsType() : nullptr) {
       if (NNS->isInstantiationDependent()) {
-        if (auto *TSTy = const_cast<TemplateSpecializationType *>(Ty->getAs<TemplateSpecializationType>())) {
+        if (auto *TSTy = Ty->getAs<TemplateSpecializationType>()) {
           MutableArrayRef<TemplateArgument> Arguments = TSTy->template_arguments();
           // Prefer template arguments from the injected-class-type if possible.
           // For example,

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -497,7 +497,7 @@ static void instantiateOMPDeclareVariantAttr(
         if (!VariantFTD->isThisDeclarationADefinition())
           return;
         Sema::TentativeAnalysisScope Trap(S);
-        const TemplateArgumentList *TAL = TemplateArgumentList::CreateCopy(
+        TemplateArgumentList *TAL = TemplateArgumentList::CreateCopy(
             S.Context, TemplateArgs.getInnermost());
 
         auto *SubstFD = S.InstantiateFunctionDeclaration(VariantFTD, TAL,
@@ -1112,7 +1112,7 @@ Decl *TemplateDeclInstantiator::InstantiateTypeAliasTemplateDecl(
   Sema::InstantiatingTemplate InstTemplate(
       SemaRef, D->getBeginLoc(), D,
       D->getTemplateDepth() >= TemplateArgs.getNumLevels()
-          ? ArrayRef<TemplateArgument>()
+          ? MutableArrayRef<TemplateArgument>()
           : (TemplateArgs.begin() + TemplateArgs.getNumLevels() - 1 -
              D->getTemplateDepth())
                 ->Args);
@@ -4901,7 +4901,7 @@ bool TemplateDeclInstantiator::SubstDefaultedFunction(FunctionDecl *New,
 }
 
 FunctionDecl *Sema::InstantiateFunctionDeclaration(
-    FunctionTemplateDecl *FTD, const TemplateArgumentList *Args,
+    FunctionTemplateDecl *FTD, TemplateArgumentList *Args,
     SourceLocation Loc, CodeSynthesisContext::SynthesisKind CSC) {
   FunctionDecl *FD = FTD->getTemplatedDecl();
 
@@ -4911,7 +4911,7 @@ FunctionDecl *Sema::InstantiateFunctionDeclaration(
     return nullptr;
 
   ContextRAII SavedContext(*this, FD);
-  MultiLevelTemplateArgumentList MArgs(FTD, Args->asArray(),
+  MultiLevelTemplateArgumentList MArgs(FTD, Args->asMutableArray(),
                                        /*Final=*/false);
 
   return cast_or_null<FunctionDecl>(SubstDecl(FD, FD->getParent(), MArgs));
@@ -5252,7 +5252,7 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
 
 VarTemplateSpecializationDecl *Sema::BuildVarTemplateInstantiation(
     VarTemplateDecl *VarTemplate, VarDecl *FromVar,
-    const TemplateArgumentList *PartialSpecArgs,
+    TemplateArgumentList *PartialSpecArgs,
     const TemplateArgumentListInfo &TemplateArgsInfo,
     SmallVectorImpl<TemplateArgument> &Converted,
     SourceLocation PointOfInstantiation, LateInstantiatedAttrVec *LateAttrs,
@@ -5280,7 +5280,7 @@ VarTemplateSpecializationDecl *Sema::BuildVarTemplateInstantiation(
     assert(PartialSpecArgs);
     IsMemberSpec = PartialSpec->isMemberSpecialization();
     MultiLevelList.addOuterTemplateArguments(
-        PartialSpec, PartialSpecArgs->asArray(), /*Final=*/false);
+        PartialSpec, PartialSpecArgs->asMutableArray(), /*Final=*/false);
   } else {
     assert(VarTemplate == FromVar->getDescribedVarTemplate());
     IsMemberSpec = VarTemplate->isMemberSpecialization();

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -4906,7 +4906,7 @@ FunctionDecl *Sema::InstantiateFunctionDeclaration(
   FunctionDecl *FD = FTD->getTemplatedDecl();
 
   sema::TemplateDeductionInfo Info(Loc);
-  InstantiatingTemplate Inst(*this, Loc, FTD, Args->asArray(), CSC, Info);
+  InstantiatingTemplate Inst(*this, Loc, FTD, Args->asMutableArray(), CSC, Info);
   if (Inst.isInvalid())
     return nullptr;
 

--- a/clang/unittests/AST/SourceLocationTest.cpp
+++ b/clang/unittests/AST/SourceLocationTest.cpp
@@ -1094,8 +1094,8 @@ class ConceptSpecializationExprConceptReferenceRangeVerifier
 protected:
   SourceRange getRange(const VarTemplateDecl &Node) override {
     assert(Node.hasAssociatedConstraints());
-    SmallVector<const Expr *, 3> ACs;
-    Node.getAssociatedConstraints(ACs);
+    SmallVector<Expr *, 3> ACs;
+    const_cast<VarTemplateDecl &>(Node).getAssociatedConstraints(ACs);
     for (const Expr *Constraint : ACs) {
       if (const ConceptSpecializationExpr *CSConstraint =
               dyn_cast<ConceptSpecializationExpr>(Constraint)) {


### PR DESCRIPTION
As highlighted in https://github.com/llvm/llvm-project/pull/93493#issuecomment-2135880330, `MultiLevelTemplateArgumentList` (henceforth MLTAL) has to modify its arguments despite referring to them via `ArrayRef`, which is immutable and propagates `const` to its elements. This is required for (at least) pack expansion, and this use case was checked by @erichkeane who deemed it valid.

The ultimate goal of this PR is to remove `const_cast` from `MultiLevelTemplateArgumentList::setArgument()`. Said removal is known to get very viral through the template engine, though, and this is at least the third attempt to do this that I'm aware of. Previous two attempts were done locally by me and @mizvekov, but we both gave up eventually.

Changes in this patch are everything in-between said removal and six new "bad" `const_cast` that were inserted before this PR gets even worse than it already is.

The first "bad" `const_cast` was added to `BuiltinFunctionStart` in `SemaChecking.cpp:303`. There we acquire a pointer to `const FunctionDecl` from an `APValue`, and pass it to `Sema::checkAddressOfFunctionIsAvailable()` as a pointer to non-const `FunctionDecl`, which checks whether constrains are satisfied, and off we go. I found out that `APValue` is likely to be a can of worms no smaller than MLTAL, so I stopped out of pity to myself and sympathy to the reviewers.

The second "bad" `const_cast` was added to, somewhat surprisingly to me, `SourceLocation` unittests (`ConceptSpecializationExprConceptReferenceRangeVerifier::getRange()`, `SourceLocationTest.cpp:1098`). The test there is concerned with associated constrains of a variable template declaration, and off we go again. Changes there involve changing a signature of a virtual function that is overloaded ≈10 times. I decided that testing code is not important enough to add this many changes to this PR, so I slapped `const_cast` on it and proceeded to publish this PR.

The third and the fourth "bad" `const_cast`s were added to `Sema::getTemplateInstantiationArgs`. There we use a peculiar TU-local type `Response` https://github.com/llvm/llvm-project/blob/69f76c782b554a004078af6909c19a11e3846415/clang/lib/Sema/SemaTemplateInstantiate.cpp#L55-L56 that has several data members, but all of its member functions are `static` and return a new `Response` object instead of e.g. `Decl *`. I didn't see a obvious and localized way to deal with it, so I had to add two bad `const_cast`s on the usage side (`SemaTemplateInstantiate.cpp`, lines 492 and 535).

The fifth and the sixth bad `const_cast`s were added to `clang::tidy::modernize` `handleReturnType` and `handleTrailingTemplateType` (`UseConstraintsCheck.cpp` lines 360 and 408). This quickly gets into ASTMatchers, which again feels too much to get into in this PR.

On top of the usual ways to review this PR, per-commit view of this PR limits the number of rabbit holes you need to consider. A breadth-first view into the changes, if you like. Unfortunately, it was somewhat of an afterthought, so chunks are not even, they don't always build, and sometimes they add "bad" `const_cast`s that are removed in subsequent commits. I hope it helps.

I'd like to highlight that headers don't give you the full picture of changes to function signatures, because this affects a number of TU-local functions. One more type I'd like to bring your attention to is `Sema::TemplateCompareNewDeclInfo`. This type has a converting constructor from `NamedDecl *`, and was often passed as a temporary that binds to a `const` reference on the callee side. As we know, non-const references do not bind to temporaries, so I converted those cases into pass-by-value instead.

> Oh well, sorry I wasn't around to advise against it[.](https://github.com/llvm/llvm-project/pull/93493#issuecomment-2135891181)

@mizvekov Sorry, I'm bad at following advice sometimes 😁