### PR TITLE
[Support] Do not ignore unterminated open { in formatv

### DIFF
--- a/llvm/lib/Support/FormatVariadic.cpp
+++ b/llvm/lib/Support/FormatVariadic.cpp
@@ -107,15 +107,18 @@ formatv_object_base::splitLiteralAndReplacement(StringRef Fmt) {
       StringRef Right = Fmt.drop_front(NumEscapedBraces * 2);
       return std::make_pair(ReplacementItem{Middle}, Right);
     }
-    // An unterminated open brace is undefined.  We treat the rest of the string
-    // as a literal replacement, but we assert to indicate that this is
-    // undefined and that we consider it an error.
+    // An unterminated open brace is undefined. Assert to indicate that this is
+    // undefined and that we consider it an error. When asserts are disabled,
+    // build a replacement item with an error message.
     std::size_t BC = Fmt.find_first_of('}');
     if (BC == StringRef::npos) {
       assert(
           false &&
-          "Unterminated brace sequence.  Escape with {{ for a literal brace.");
-      return std::make_pair(ReplacementItem{Fmt}, StringRef());
+          "Unterminated brace sequence. Escape with {{ for a literal brace.");
+      return std::make_pair(
+          ReplacementItem{"Unterminated brace sequence. Escape with {{ for a "
+                          "literal brace."},
+          StringRef());
     }
 
     // Even if there is a closing brace, if there is another open brace before


### PR DESCRIPTION
- When an unterminated open { is detected in the format string, instead of asserting and ignoring the error, replace that string with another to indicate the error, and remove the assert as well.
- This will make the error evident in both assert and release builds and make observing the error more convenient (as several uses of this function are in TableGen and it is often built in release mode even in debug builds)