### PR TITLE
[clang-tidy] Consider `readability-uppercase-literal-suffix` when dealing with `readability-implicit-bool-conversion`.

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
@@ -36,6 +36,7 @@ private:
 
   const bool AllowIntegerConditions;
   const bool AllowPointerConditions;
+  const bool IsUseUppercaseSuffixEnabled;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-uppercase.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-uppercase.cpp
@@ -1,0 +1,21 @@
+// RUN: %check_clang_tidy %s readability-implicit-bool-conversion,readability-uppercase-literal-suffix %t
+
+bool implicitConversionToBoolInReturnValue() {
+  float floating = 1.0F;
+  return floating;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
+  // CHECK-FIXES: return floating != 0.0F;
+}
+
+void functionTakingUnsignedLong(unsigned long);
+void functionTakingFloat(float);
+
+void implicitConversionFromBoolLiterals() {
+  functionTakingUnsignedLong(false);
+  // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: implicit conversion 'bool' -> 'unsigned long'
+  // CHECK-FIXES: functionTakingUnsignedLong(0U);
+
+  functionTakingFloat(false);
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'float'
+  // CHECK-FIXES: functionTakingFloat(0.0F);
+}


### PR DESCRIPTION
close: #40544.