### PR TITLE
[clang][bytecode] Fix 'if consteval' in non-constant contexts

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4355,11 +4355,6 @@ bool Compiler<Emitter>::visitReturnStmt(const ReturnStmt *RS) {
 }
 
 template <class Emitter> bool Compiler<Emitter>::visitIfStmt(const IfStmt *IS) {
-  if (IS->isNonNegatedConsteval())
-    return visitStmt(IS->getThen());
-  if (IS->isNegatedConsteval())
-    return IS->getElse() ? visitStmt(IS->getElse()) : true;
-
   if (auto *CondInit = IS->getInit())
     if (!visitStmt(CondInit))
       return false;
@@ -4368,8 +4363,19 @@ template <class Emitter> bool Compiler<Emitter>::visitIfStmt(const IfStmt *IS) {
     if (!visitDeclStmt(CondDecl))
       return false;
 
-  if (!this->visitBool(IS->getCond()))
-    return false;
+  // Compile condition.
+  if (IS->isNonNegatedConsteval()) {
+    if (!this->emitIsConstantContext(IS))
+      return false;
+  } else if (IS->isNegatedConsteval()) {
+    if (!this->emitIsConstantContext(IS))
+      return false;
+    if (!this->emitInv(IS))
+      return false;
+  } else {
+    if (!this->visitBool(IS->getCond()))
+      return false;
+  }
 
   if (const Stmt *Else = IS->getElse()) {
     LabelTy LabelElse = this->getLabel();

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -3048,6 +3048,11 @@ static inline bool Free(InterpState &S, CodePtr OpPC, bool DeleteIsArrayForm) {
                              BlockDesc, Source);
 }
 
+static inline bool IsConstantContext(InterpState &S, CodePtr OpPC) {
+  S.Stk.push<Boolean>(Boolean::from(S.inConstantContext()));
+  return true;
+}
+
 inline bool CheckLiteralType(InterpState &S, CodePtr OpPC, const Type *T) {
   assert(T);
   assert(!S.getLangOpts().CPlusPlus23);

--- a/clang/lib/AST/ByteCode/Opcodes.td
+++ b/clang/lib/AST/ByteCode/Opcodes.td
@@ -780,3 +780,5 @@ def AllocCN : Opcode {
 def Free : Opcode {
   let Args = [ArgBool];
 }
+
+def IsConstantContext: Opcode;

--- a/clang/test/CodeGenCXX/cxx2b-consteval-if.cpp
+++ b/clang/test/CodeGenCXX/cxx2b-consteval-if.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c++23 %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c++23 %s -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s
 
 void should_be_used_1();
 void should_be_used_2();


### PR DESCRIPTION
The previous code made this a compile-time decision but it's not.