### PR TITLE
[libc][gpu] Remove Unused Imports in Sin Benchmarks

### DIFF
--- a/libc/benchmarks/gpu/src/math/sin_benchmark.cpp
+++ b/libc/benchmarks/gpu/src/math/sin_benchmark.cpp
@@ -1,9 +1,5 @@
 #include "benchmarks/gpu/LibcGpuBenchmark.h"
 
-#include "src/__support/CPP/array.h"
-#include "src/__support/CPP/bit.h"
-#include "src/__support/CPP/functional.h"
-#include "src/__support/FPUtil/FPBits.h"
 #include "src/math/sin.h"
 #include "src/math/sinf.h"
 #include "src/stdlib/rand.h"


### PR DESCRIPTION
This PR removes unused imports in the `sin()` benchmarks.