### PR TITLE
Fix typo in SanitizerCoverage.rst

### DIFF
--- a/clang/docs/SanitizerCoverage.rst
+++ b/clang/docs/SanitizerCoverage.rst
@@ -37,7 +37,7 @@ The compiler will also insert calls to a module constructor:
    __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop);
 
 With an additional ``...=trace-pc,indirect-calls`` flag
-``__sanitizer_cov_trace_pc_indirect(void *callee)`` will be inserted on every indirect call.
+``__sanitizer_cov_trace_pc_indir(void *callee)`` will be inserted on every indirect call.
 
 The functions `__sanitizer_cov_trace_pc_*` should be defined by the user.
 

--- a/clang/docs/SanitizerCoverage.rst
+++ b/clang/docs/SanitizerCoverage.rst
@@ -200,7 +200,7 @@ Tracing PCs
 With ``-fsanitize-coverage=trace-pc`` the compiler will insert
 ``__sanitizer_cov_trace_pc()`` on every edge.
 With an additional ``...=trace-pc,indirect-calls`` flag
-``__sanitizer_cov_trace_pc_indirect(void *callee)`` will be inserted on every indirect call.
+``__sanitizer_cov_trace_pc_indir(void *callee)`` will be inserted on every indirect call.
 These callbacks are not implemented in the Sanitizer run-time and should be defined
 by the user.
 This mechanism is used for fuzzing the Linux kernel


### PR DESCRIPTION
The callback for indirect calls is `__sanitizer_cov_trace_pc_indir`, not `__sanitizer_cov_trace_pc_indirect`.

See: https://github.com/llvm/llvm-project/blob/de5ea2d122c31e1551654ff506c33df299f351b8/compiler-rt/lib/sanitizer_common/sanitizer_interface_internal.h#L120