### PR TITLE
[Clang][NFC] Fix potential null dereference in encodeTypeForFunctionPointerAuth

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3279,7 +3279,7 @@ static void encodeTypeForFunctionPointerAuth(const ASTContext &Ctx,
 
   case Type::MemberPointer: {
     OS << "M";
-    const auto *MPT = T->getAs<MemberPointerType>();
+    const auto *MPT = T->castAs<MemberPointerType>();
     encodeTypeForFunctionPointerAuth(Ctx, OS, QualType(MPT->getClass(), 0));
     encodeTypeForFunctionPointerAuth(Ctx, OS, MPT->getPointeeType());
     return;


### PR DESCRIPTION
This patch replaces getAs with castAs in encodeTypeForFunctionPointerAuth to prevent dereferencing a potential null pointer, enhancing type safety as reported by static analyzer tool.