### PR TITLE
[Sparc] Add flags to enable errata workaround pass for GR712RC and UT700

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6148,6 +6148,10 @@ def mv8plus : Flag<["-"], "mv8plus">, Group<m_sparc_Features_Group>,
   HelpText<"Enable V8+ mode, allowing use of 64-bit V9 instructions in 32-bit code">;
 def mno_v8plus : Flag<["-"], "mno-v8plus">, Group<m_sparc_Features_Group>,
   HelpText<"Disable V8+ mode">;
+def mfix_gr712rc : Flag<["-"], "mfix-gr712rc">, Group<m_sparc_Features_Group>,
+  HelpText<"Enable workarounds for GR712RC errata">;
+def mfix_ut700 : Flag<["-"], "mfix-ut700">, Group<m_sparc_Features_Group>,
+  HelpText<"Enable workarounds for UT700 errata">;
 foreach i = 1 ... 7 in
   def ffixed_g#i : Flag<["-"], "ffixed-g"#i>, Group<m_sparc_Features_Group>,
     HelpText<"Reserve the G"#i#" register (SPARC only)">;

--- a/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
@@ -264,4 +264,17 @@ void sparc::getSparcTargetFeatures(const Driver &D, const ArgList &Args,
 
   if (Args.hasArg(options::OPT_ffixed_i5))
     Features.push_back("+reserve-i5");
+
+  if (Args.hasArg(options::OPT_mfix_gr712rc)) {
+    Features.push_back("+fix-tn0009");
+    Features.push_back("+fix-tn0011");
+    Features.push_back("+fix-tn0012");
+    Features.push_back("+fix-tn0013");
+  }
+
+  if (Args.hasArg(options::OPT_mfix_ut700)) {
+    Features.push_back("+fix-tn0009");
+    Features.push_back("+fix-tn0010");
+    Features.push_back("+fix-tn0013");
+  }
 }

--- a/clang/test/Driver/sparc-fix.c
+++ b/clang/test/Driver/sparc-fix.c
@@ -1,0 +1,12 @@
+// RUN: %clang -target sparc -mfix-gr712rc -### %s 2> %t
+// RUN: FileCheck --check-prefix=CHECK-FIX-GR712RC < %t %s
+// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0009"
+// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0011"
+// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0012"
+// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0013"
+
+// RUN: %clang -target sparc -mfix-ut700 -### %s 2> %t
+// RUN: FileCheck --check-prefix=CHECK-FIX-UT700 < %t %s
+// CHECK-FIX-UT700: "-target-feature" "+fix-tn0009"
+// CHECK-FIX-UT700: "-target-feature" "+fix-tn0010"
+// CHECK-FIX-UT700: "-target-feature" "+fix-tn0013"

--- a/clang/test/Driver/sparc-fix.c
+++ b/clang/test/Driver/sparc-fix.c
@@ -1,11 +1,11 @@
-// RUN: %clang -target sparc -mfix-gr712rc -### %s 2> %t
+// RUN: %clang --target=sparc -mfix-gr712rc -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-FIX-GR712RC < %t %s
 // CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0009"
 // CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0011"
 // CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0012"
 // CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0013"
 
-// RUN: %clang -target sparc -mfix-ut700 -### %s 2> %t
+// RUN: %clang --target=sparc -mfix-ut700 -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-FIX-UT700 < %t %s
 // CHECK-FIX-UT700: "-target-feature" "+fix-tn0009"
 // CHECK-FIX-UT700: "-target-feature" "+fix-tn0010"

--- a/clang/test/Driver/sparc-fix.c
+++ b/clang/test/Driver/sparc-fix.c
@@ -1,12 +1,5 @@
-// RUN: %clang --target=sparc -mfix-gr712rc -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-FIX-GR712RC < %t %s
-// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0009"
-// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0011"
-// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0012"
-// CHECK-FIX-GR712RC: "-target-feature" "+fix-tn0013"
+// RUN: %clang --target=sparc -mfix-gr712rc -### %s 2>&1 | FileCheck --check-prefix=GR712RC %s
+// GR712RC: "-target-feature" "+fix-tn0009" "-target-feature" "+fix-tn0011" "-target-feature" "+fix-tn0012" "-target-feature" "+fix-tn0013"
 
-// RUN: %clang --target=sparc -mfix-ut700 -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-FIX-UT700 < %t %s
-// CHECK-FIX-UT700: "-target-feature" "+fix-tn0009"
-// CHECK-FIX-UT700: "-target-feature" "+fix-tn0010"
-// CHECK-FIX-UT700: "-target-feature" "+fix-tn0013"
+// RUN: %clang --target=sparc -mfix-ut700 -### %s 2>&1 | FileCheck --check-prefix=UT700 %s
+// UT700: "-target-feature" "+fix-tn0009" "-target-feature" "+fix-tn0010" "-target-feature" "+fix-tn0013"


### PR DESCRIPTION
This adds the flags -mfix-gr712rc and -mfix-ut700 which enables the necessary errata workarounds for the GR712RC and UT700 processors. The functionality enabled by the flags is the same as the functionality provided by the corresponding GCC flags.