### PR TITLE
[mlir][vector] Populate sink patterns in apply_patterns.vector.reduction_to_contract

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
+++ b/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
@@ -410,7 +410,7 @@ def ApplyFoldElementwiseToVectorPatternsOp : Op<Transform_Dialect,
     "apply_patterns.vector.elementwise_to_vector",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
   let description = [{
-    Collect a set of patterns that fold elementwise op on vectors to the vector 
+    Collect a set of patterns that fold elementwise op on vectors to the vector
     dialect.
   }];
 
@@ -426,8 +426,9 @@ def ApplyVectorReductionToContractPatternsOp : Op<Transform_Dialect,
       - CombineContractBroadcast
       - CombineContractABTranspose
       - CombineContractResultTranspose
-      - ReorderCastOpsOnBroadcast
       - ReorderElementwiseOpsOnTranspose
+      - ReorderElementwiseOpsOnBroadcast
+      - ReorderCastOpsOnBroadcast
 
     These patterns have the effect of rewriting a vector.multi_reduce into a
     vector.contract.

--- a/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
+++ b/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
@@ -67,6 +67,7 @@ void transform::ApplyFoldElementwiseToVectorPatternsOp::populatePatterns(
 void transform::ApplyVectorReductionToContractPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
   vector::populateVectorReductionToContractPatterns(patterns);
+  vector::populateSinkVectorOpsPatterns(patterns);
 }
 
 void transform::ApplyLowerCreateMaskPatternsOp::populatePatterns(


### PR DESCRIPTION
This restores the functionality to before: https://github.com/llvm/llvm-project/commit/42944da5ba7617bbc02f341e9ef401c325310a73
This fixes a buildbot failure: https://lab.llvm.org/buildbot/#/builders/143/builds/1487