### PR TITLE
[IR] Check that arguments of naked function are not used

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2046,7 +2046,8 @@ example:
     attributes.
 ``naked``
     This attribute disables prologue / epilogue emission for the
-    function. This can have very system-specific consequences.
+    function. This can have very system-specific consequences. The arguments of
+    a ``naked`` function can not be referenced through IR values.
 ``"no-inline-line-tables"``
     When this attribute is set to true, the inliner discards source locations
     when inlining code and instead uses the source location of the call site.

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2777,6 +2777,10 @@ void Verifier::visitFunction(const Function &F) {
   Check(!Attrs.hasAttrSomewhere(Attribute::ElementType),
         "Attribute 'elementtype' can only be applied to a callsite.", &F);
 
+  if (Attrs.hasFnAttr(Attribute::Naked))
+    for (const Argument &Arg : F.args())
+      Check(Arg.use_empty(), "cannot use argument of naked function", &Arg);
+
   // Check that this function meets the restrictions on this calling convention.
   // Sometimes varargs is used for perfectly forwarding thunks, so some of these
   // restrictions can be lifted.

--- a/llvm/test/Instrumentation/ThreadSanitizer/tsan_basic.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/tsan_basic.ll
@@ -98,12 +98,12 @@ define void @SwiftErrorCall(ptr swifterror) sanitize_thread {
   ret void
 }
 
-; CHECK-LABEL: @NakedTest(ptr %a)
-; CHECK-NEXT:   call void @foo()
-; CHECK-NEXT:   %tmp1 = load i32, ptr %a, align 4
-; CHECK-NEXT:   ret i32 %tmp1
-define i32 @NakedTest(ptr %a) naked sanitize_thread {
-  call void @foo()
+; CHECK-LABEL: @NakedTest()
+; CHECK-NEXT:  %a = call ptr @foo()
+; CHECK-NEXT:  %tmp1 = load i32, ptr %a, align 4
+; CHECK-NEXT:  ret i32 %tmp1
+define i32 @NakedTest() naked sanitize_thread {
+  %a = call ptr @foo()
   %tmp1 = load i32, ptr %a, align 4
   ret i32 %tmp1
 }

--- a/llvm/test/Transforms/Attributor/nonnull.ll
+++ b/llvm/test/Transforms/Attributor/nonnull.ll
@@ -1048,10 +1048,8 @@ define internal void @naked(ptr dereferenceable(4) %a) naked {
 ; CHECK: Function Attrs: naked
 ; CHECK-LABEL: define {{[^@]+}}@naked
 ; CHECK-SAME: (ptr noundef nonnull dereferenceable(4) [[A:%.*]]) #[[ATTR11:[0-9]+]] {
-; CHECK-NEXT:    call void @use_i32_ptr(ptr nocapture nofree noundef nonnull [[A]])
 ; CHECK-NEXT:    ret void
 ;
-  call void @use_i32_ptr(ptr %a)
   ret void
 }
 ; Avoid nonnull as we do not touch optnone

--- a/llvm/test/Transforms/CodeExtractor/PartialInlineAttributes.ll
+++ b/llvm/test/Transforms/CodeExtractor/PartialInlineAttributes.ll
@@ -81,6 +81,6 @@ attributes #0 = {
 
 ; attributes to drop
 attributes #1 = {
-  alignstack=16 convergent inaccessiblememonly inaccessiblemem_or_argmemonly naked
+  alignstack=16 convergent inaccessiblememonly inaccessiblemem_or_argmemonly
   noreturn readonly argmemonly returns_twice speculatable "thunk"
 }

--- a/llvm/test/Transforms/FunctionAttrs/nonnull.ll
+++ b/llvm/test/Transforms/FunctionAttrs/nonnull.ll
@@ -1079,15 +1079,12 @@ define internal void @control(ptr dereferenceable(4) %a) {
 define internal void @naked(ptr dereferenceable(4) %a) naked {
 ; FNATTRS-LABEL: define internal void @naked(
 ; FNATTRS-SAME: ptr dereferenceable(4) [[A:%.*]]) #[[ATTR10:[0-9]+]] {
-; FNATTRS-NEXT:    call void @use_i32_ptr(ptr [[A]])
 ; FNATTRS-NEXT:    ret void
 ;
 ; ATTRIBUTOR-LABEL: define internal void @naked(
 ; ATTRIBUTOR-SAME: ptr nonnull dereferenceable(4) [[A:%.*]]) #[[ATTR11:[0-9]+]] {
-; ATTRIBUTOR-NEXT:    call void @use_i32_ptr(ptr [[A]])
 ; ATTRIBUTOR-NEXT:    ret void
 ;
-  call void @use_i32_ptr(ptr %a)
   ret void
 }
 ; Avoid nonnull as we do not touch optnone

--- a/llvm/test/Verifier/naked.ll
+++ b/llvm/test/Verifier/naked.ll
@@ -1,0 +1,8 @@
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: cannot use argument of naked function
+define void @test(ptr %ptr) naked {
+  getelementptr i8, ptr %ptr, i64 1
+  call void @llvm.trap()
+  unreachable
+}


### PR DESCRIPTION
Verify that the arguments of a naked function are not used. They can only be referenced via registers/stack in inline asm, not as IR values. Doing so will result in assertion failures in the backend.

There's probably more that we should verify, though I'm not completely sure what the constraints are (would it be correct to require that naked functions are exactly an inline asm call + unreachable, or is more allowed?)

Fixes https://github.com/llvm/llvm-project/issues/104718.