### PR TITLE
[lldb] Updated TCPSocket to listen multiple ports on the same single thread

### DIFF
--- a/lldb/include/lldb/Host/common/TCPSocket.h
+++ b/lldb/include/lldb/Host/common/TCPSocket.h
@@ -24,6 +24,9 @@ public:
   // returns port number or 0 if error
   uint16_t GetLocalPortNumber() const;
 
+  // returns port numbers of all listening sockets
+  std::set<uint16_t> GetLocalPortNumbers() const;
+
   // returns ip address string or empty string if error
   std::string GetLocalIPAddress() const;
 

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -136,6 +136,19 @@ TEST_P(SocketTest, TCPListen0GetPort) {
   EXPECT_NE(sock.get()->GetLocalPortNumber(), 0);
 }
 
+TEST_P(SocketTest, TCPListen00GetPort) {
+  if (!HostSupportsIPv4())
+    return;
+  llvm::Expected<std::unique_ptr<TCPSocket>> sock =
+      Socket::TcpListen("10.10.12.3:0,0", false);
+  ASSERT_THAT_EXPECTED(sock, llvm::Succeeded());
+  ASSERT_TRUE(sock.get()->IsValid());
+  std::set<uint16_t> ports = sock.get()->GetLocalPortNumbers();
+  ASSERT_EQ(2, ports.size());
+  EXPECT_NE(*ports.begin(), 0);
+  EXPECT_NE(*std::next(ports.begin()), 0);
+}
+
 TEST_P(SocketTest, TCPGetConnectURI) {
   std::unique_ptr<TCPSocket> socket_a_up;
   std::unique_ptr<TCPSocket> socket_b_up;


### PR DESCRIPTION
Currently the class TCPSocket already contains a list of NativeSocket `m_listen_sockets` for different addresses. 
I just added different ports. So Accept() can wait for connections to different ports in a single thread.

This is the prerequisite for #104238 (see the implementation and usage of the class Acceptor).