### PR TITLE
[clang][AIX] Fix -print-runtime-dir on AIX

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -831,8 +831,8 @@ std::optional<std::string> ToolChain::getRuntimePath() const {
   llvm::sys::path::append(P, "lib");
   if (auto Ret = getTargetSubDirPath(P))
     return Ret;
-  // Darwin does not use per-target runtime directory.
-  if (Triple.isOSDarwin())
+  // Darwin and AIX does not use per-target runtime directory.
+  if (Triple.isOSDarwin() || Triple.isOSAIX())
     return {};
   llvm::sys::path::append(P, Triple.str());
   return std::string(P);

--- a/clang/test/Driver/aix-print-runtime-dir.c
+++ b/clang/test/Driver/aix-print-runtime-dir.c
@@ -1,0 +1,11 @@
+// Test output of -print-runtime-dir on AIX
+
+// RUN: %clang -print-runtime-dir --target=powerpc-ibm-aix \
+// RUN:        -resource-dir=%S/Inputs/resource_dir \
+// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR %s
+
+// RUN: %clang -print-runtime-dir --target=powerpc64-ibm-aix \
+// RUN:        -resource-dir=%S/Inputs/resource_dir \
+// RUN:      | FileCheck --check-prefix=PRINT-RUNTIME-DIR %s
+
+// PRINT-RUNTIME-DIR: lib{{/|\\}}aix{{$}}


### PR DESCRIPTION
Currently the option prints a path to a nonexistent directory with the full triple, `lib/powerpc64-ibm-aix7.2.0.0`. It should only be `lib/aix`. 