### PR TITLE
[asan] Change Apple back to fixed allocator base address

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -189,7 +189,13 @@ const uptr kAllocatorSize = 0x40000000000ULL;  // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
 #    endif  // SANITIZER_RISCV64
 #  else     // SANITIZER_FUCHSIA
+
+#    if SANITIZER_APPLE
+const uptr kAllocatorSpace = 0x600000000000ULL;
+#    else   // SANITIZER_APPLE
 const uptr kAllocatorSpace = ~(uptr)0;
+#    endif  // SANITIZER_APPLE
+
 #    if defined(__powerpc64__)
 const uptr kAllocatorSize  =  0x20000000000ULL;  // 2T.
 typedef DefaultSizeClassMap SizeClassMap;


### PR DESCRIPTION
This partially reverts https://github.com/llvm/llvm-project/pull/98511
- specifically, the SANITIZER_APPLE case - because of a suspected breakage for clang on Mac (https://g-issues.chromium.org/issues/360160858; https://github.com/llvm/llvm-project/pull/98511#issuecomment-2296749757).