### PR TITLE
[SDAG] Target intrinsics have chain if !WillReturn

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5232,7 +5232,7 @@ void SelectionDAGBuilder::visitTargetIntrinsic(const CallInst &I,
   // readnone, but the lowering code will expect the chain based on the
   // definition.
   const Function *F = I.getCalledFunction();
-  bool HasChain = !F->doesNotAccessMemory();
+  bool HasChain = !F->doesNotAccessMemory() || !F->willReturn();
   bool OnlyLoad =
       HasChain && F->onlyReadsMemory() && F->willReturn() && F->doesNotThrow();
 


### PR DESCRIPTION
An intrinsic is assumed to have side effects if it does not have the WillReturn attribute, so it should have a chain.