### PR TITLE
[flang] Silence spurious error

### DIFF
--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -1558,8 +1558,9 @@ bool IsAutomaticallyDestroyed(const Symbol &symbol) {
   return symbol.has<ObjectEntityDetails>() &&
       (symbol.owner().kind() == Scope::Kind::Subprogram ||
           symbol.owner().kind() == Scope::Kind::BlockConstruct) &&
-      (!IsDummy(symbol) || IsIntentOut(symbol)) && !IsPointer(symbol) &&
-      !IsSaved(symbol) && !FindCommonBlockContaining(symbol);
+      !IsNamedConstant(symbol) && (!IsDummy(symbol) || IsIntentOut(symbol)) &&
+      !IsPointer(symbol) && !IsSaved(symbol) &&
+      !FindCommonBlockContaining(symbol);
 }
 
 const std::optional<parser::Name> &MaybeGetNodeName(

--- a/flang/test/Semantics/declarations05.f90
+++ b/flang/test/Semantics/declarations05.f90
@@ -29,6 +29,7 @@ module m
     type(t1) x1
     !WARNING: 'x1a' of derived type 't1' does not have a FINAL subroutine for its rank (1)
     type(t1), allocatable :: x1a(:)
+    type(t1), parameter :: namedConst = t1() ! ok
     !ERROR: 'x2' may not be a local variable in a pure subprogram
     !BECAUSE: 'x2' has an impure FINAL procedure 'final'
     type(t2) x2


### PR DESCRIPTION
Don't complain about a local object with an impure final procedure in a pure subprogram when the local object is a named constant.

Fixes https://github.com/llvm/llvm-project/issues/104796.