### PR TITLE
[Clang] Fix ICE in SemaOpenMP with structured binding

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -1256,16 +1256,8 @@ static const ValueDecl *getCanonicalDecl(const ValueDecl *D) {
   if (const auto *CED = dyn_cast<OMPCapturedExprDecl>(D))
     if (const auto *ME = dyn_cast<MemberExpr>(getExprAsWritten(CED->getInit())))
       D = ME->getMemberDecl();
-  const auto *VD = dyn_cast<VarDecl>(D);
-  const auto *FD = dyn_cast<FieldDecl>(D);
-  if (VD != nullptr) {
-    VD = VD->getCanonicalDecl();
-    D = VD;
-  } else {
-    assert(FD);
-    FD = FD->getCanonicalDecl();
-    D = FD;
-  }
+
+  D = cast<ValueDecl>(D->getCanonicalDecl());
   return D;
 }
 

--- a/clang/test/SemaOpenMP/gh104810.cpp
+++ b/clang/test/SemaOpenMP/gh104810.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fopenmp -fsyntax-only %s
+
+// expected-no-diagnostics
+struct S {
+  int i;
+};
+
+auto [a] = S{1};
+
+void foo() {
+    a;
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/104810.

Clang currently crashes on the following program:
```
struct S {
  int i;
};

auto [a] = S{1};

void foo() {
    a;
}
```
when `-fopenmp` is enabled. 

Because `a` is neither `VarDecl` nor `FieldDecl`. It's a `BindingDecl` that's not handled in `SemaOpenMP.cpp`'s `getCanonicalDecl`. It appears to me that this pattern matching is merely just for a refined return type of the overrides. It can also be achieved with just using the virtual `Decl::getCanonicalDecl()` instead. Do the final casting should be safe for `ValueDecl`s.