### PR TITLE
[DXIL][Analysis] Add validator version to info collected by Module Metadata Analysis 

### DIFF
--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -23,6 +23,7 @@ struct ModuleMetadataInfo {
   VersionTuple DXILVersion{};
   VersionTuple ShaderModelVersion{};
   Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
+  VersionTuple ValidatorVersion{};
 
   void print(raw_ostream &OS) const;
 };

--- a/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
+++ b/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
@@ -25,6 +25,14 @@ static ModuleMetadataInfo collectMetadataInfo(Module &M) {
   MMDAI.DXILVersion = TT.getDXILVersion();
   MMDAI.ShaderModelVersion = TT.getOSVersion();
   MMDAI.ShaderStage = TT.getEnvironment();
+  NamedMDNode *ValidatorVerNode = M.getNamedMetadata("dx.valver");
+  if (ValidatorVerNode) {
+    auto *ValVerMD = cast<MDNode>(ValidatorVerNode->getOperand(0));
+    auto *MajorMD = mdconst::extract<ConstantInt>(ValVerMD->getOperand(0));
+    auto *MinorMD = mdconst::extract<ConstantInt>(ValVerMD->getOperand(1));
+    MMDAI.ValidatorVersion =
+        VersionTuple(MajorMD->getZExtValue(), MinorMD->getZExtValue());
+  }
   return MMDAI;
 }
 
@@ -33,6 +41,7 @@ void ModuleMetadataInfo::print(raw_ostream &OS) const {
   OS << "DXIL Version : " << DXILVersion.getAsString() << "\n";
   OS << "Shader Stage : " << Triple::getEnvironmentTypeName(ShaderStage)
      << "\n";
+  OS << "Validator Version : " << ValidatorVersion.getAsString() << "\n";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.0.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel6.0-vertex"
 ; CHECK: ![[DXVER]] = !{i32 1, i32 0}
 
 ; ANALYSIS: Shader Model Version : 6.0
-; ANALYSIS: DXIL Version : 1.0
-; ANALYSIS: Shader Stage : vertex
+; ANALYSIS-NEXT: DXIL Version : 1.0
+; ANALYSIS-NEXT: Shader Stage : vertex
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.8.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.8.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel6.8-compute"
 ; CHECK: ![[DXVER]] = !{i32 1, i32 8}
 
 ; ANALYSIS: Shader Model Version : 6.8
-; ANALYSIS: DXIL Version : 1.8
-; ANALYSIS: Shader Stage : compute
+; ANALYSIS-NEXT: DXIL Version : 1.8
+; ANALYSIS-NEXT: Shader Stage : compute
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/empty-valver1.8.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/empty-valver1.8.ll
@@ -1,0 +1,32 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
+target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
+target triple = "dxilv1.6-unknown-shadermodel6.6-compute"
+
+; ANALYSIS: Shader Model Version : 6.6
+; ANALYSIS-NEXT: DXIL Version : 1.6
+; ANALYSIS-NEXT: Shader Stage : compute
+; ANALYSIS-NEXT: Validator Version : 1.8
+; ANALYSIS-EMPTY:
+
+; Function Attrs: nounwind memory(none)
+define void @main() local_unnamed_addr #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind memory(none) }
+
+!dx.valver = !{!0}
+!dx.shaderModel = !{!2}
+!dx.version = !{!3}
+!dx.entryPoints = !{!4}
+!llvm.module.flags = !{!7, !8}
+
+!0 = !{i32 1, i32 8}
+!2 = !{!"cs", i32 6, i32 6}
+!3 = !{i32 1, i32 6}
+!4 = !{ptr @main, !"main", null, null, !5}
+!5 = !{i32 4, !6}
+!6 = !{i32 1, i32 1, i32 1}
+!7 = !{i32 1, !"wchar_size", i32 4}
+!8 = !{i32 2, !"frame-pointer", i32 2}

--- a/llvm/test/CodeGen/DirectX/Metadata/empty-valver1.8.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/empty-valver1.8.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
-target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
-target triple = "dxilv1.6-unknown-shadermodel6.6-compute"
+; Verify correctness of Shader Model version, DXIL version, Shader stage and Validator version
+; obtained by Module Metadata Analysis pass from the metadata specified in the source.
 
 ; ANALYSIS: Shader Model Version : 6.6
 ; ANALYSIS-NEXT: DXIL Version : 1.6
@@ -19,14 +19,7 @@ attributes #0 = { nounwind memory(none) }
 !dx.valver = !{!0}
 !dx.shaderModel = !{!2}
 !dx.version = !{!3}
-!dx.entryPoints = !{!4}
-!llvm.module.flags = !{!7, !8}
 
 !0 = !{i32 1, i32 8}
 !2 = !{!"cs", i32 6, i32 6}
 !3 = !{i32 1, i32 6}
-!4 = !{ptr @main, !"main", null, null, !5}
-!5 = !{i32 4, !6}
-!6 = !{i32 1, i32 1, i32 1}
-!7 = !{i32 1, !"wchar_size", i32 4}
-!8 = !{i32 2, !"frame-pointer", i32 2}

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-as.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-as.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel6-amplification"
 ; CHECK: ![[SM]] = !{!"as", i32 6, i32 0}
 
 ; ANALYSIS: Shader Model Version : 6
-; ANALYSIS: DXIL Version : 1.0
-; ANALYSIS: Shader Stage : amplification
+; ANALYSIS-NEXT: DXIL Version : 1.0
+; ANALYSIS-NEXT: Shader Stage : amplification
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
@@ -17,5 +17,7 @@ attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" 
 !0 = !{i32 0, i32 0}
 
 ; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS: DXIL Version : 1.6
-; ANALYSIS: Shader Stage : compute
+; ANALYSIS-NEXT: DXIL Version : 1.6
+; ANALYSIS-NEXT: Shader Stage : compute
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
@@ -8,8 +8,10 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 ; CHECK: ![[SM]] = !{!"cs", i32 6, i32 6}
 
 ; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS: DXIL Version : 1.6
-; ANALYSIS: Shader Stage : compute
+; ANALYSIS-NEXT: DXIL Version : 1.6
+; ANALYSIS-NEXT: Shader Stage : compute
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-gs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-gs.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel6.6-geometry"
 ; CHECK: ![[SM]] = !{!"gs", i32 6, i32 6}
 
 ; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS: DXIL Version : 1.6
-; ANALYSIS: Shader Stage : geometry
+; ANALYSIS-NEXT: DXIL Version : 1.6
+; ANALYSIS-NEXT: Shader Stage : geometry
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-hs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-hs.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel6.6-hull"
 ; CHECK: ![[SM]] = !{!"hs", i32 6, i32 6}
 
 ; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS: DXIL Version : 1.6
-; ANALYSIS: Shader Stage : hull
+; ANALYSIS-NEXT: DXIL Version : 1.6
+; ANALYSIS-NEXT: Shader Stage : hull
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-lib.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-lib.ll
@@ -6,5 +6,7 @@ target triple = "dxil-pc-shadermodel6.3-library"
 ; CHECK: ![[SM]] = !{!"lib", i32 6, i32 3}
 
 ; ANALYSIS: Shader Model Version : 6.3
-; ANALYSIS: DXIL Version : 1.3
-; ANALYSIS: Shader Stage : library
+; ANALYSIS-NEXT: DXIL Version : 1.3
+; ANALYSIS-NEXT: Shader Stage : library
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ms.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ms.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel6.6-mesh"
 ; CHECK: ![[SM]] = !{!"ms", i32 6, i32 6}
 
 ; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS: DXIL Version : 1.6
-; ANALYSIS: Shader Stage : mesh
+; ANALYSIS-NEXT: DXIL Version : 1.6
+; ANALYSIS-NEXT: Shader Stage : mesh
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ps.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ps.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel5.0-pixel"
 ; CHECK: ![[SM]] = !{!"ps", i32 5, i32 0}
 
 ; ANALYSIS: Shader Model Version : 5.0
-; ANALYSIS: DXIL Version : 1.0
-; ANALYSIS: Shader Stage : pixel
+; ANALYSIS-NEXT: DXIL Version : 1.0
+; ANALYSIS-NEXT: Shader Stage : pixel
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-vs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-vs.ll
@@ -6,8 +6,10 @@ target triple = "dxil-pc-shadermodel-vertex"
 ; CHECK: ![[SM]] = !{!"vs", i32 0, i32 0}
 
 ; ANALYSIS: Shader Model Version : 0
-; ANALYSIS: DXIL Version : 1.0
-; ANALYSIS: Shader Stage : vertex
+; ANALYSIS-NEXT: DXIL Version : 1.0
+; ANALYSIS-NEXT: Shader Stage : vertex
+; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:


### PR DESCRIPTION
Add Validator Version to information collected by Module Metadata Analysis pass. An earlier change (#104040) added a default hardcoded value for validator version to be associated with DXIL module created during HLSL source compilation.

Tests to verify validator version info collected
 - Updated existing tests
 - Added a test with validator version specified in DXIL metadata