### PR TITLE
[lldb][test] Workaround older systems that lack gettid

### DIFF
--- a/lldb/unittests/Process/elf-core/CMakeLists.txt
+++ b/lldb/unittests/Process/elf-core/CMakeLists.txt
@@ -1,3 +1,6 @@
+include(CheckSymbolExists)
+include(CMakePushCheckState)
+
 add_lldb_unittest(ProcessElfCoreTests
   ThreadElfCoreTest.cpp
 
@@ -13,3 +16,11 @@ add_lldb_unittest(ProcessElfCoreTests
   LINK_COMPONENTS
     Support
   )
+
+cmake_push_check_state()
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_symbol_exists(gettid "unistd.h" HAVE_GETTID)
+if(HAVE_GETTID)
+  target_compile_definitions(ProcessElfCoreTests PRIVATE HAVE_GETTID)
+endif()
+cmake_pop_check_state()

--- a/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
+++ b/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
@@ -23,6 +23,11 @@
 #include <mutex>
 #include <unistd.h>
 
+#ifndef HAVE_GETTID
+#include <sys/syscall.h>
+pid_t gettid() { return ((pid_t)syscall(SYS_gettid)); }
+#endif
+
 using namespace lldb_private;
 
 namespace {


### PR DESCRIPTION
Older glibc versions do not provide `gettid`. Provide our own `gettid` in these cases.

Fixes a build failure caused by #104109.