### PR TITLE
[ADT] Fix a minor build error

### DIFF
--- a/llvm/unittests/ADT/FunctionExtrasTest.cpp
+++ b/llvm/unittests/ADT/FunctionExtrasTest.cpp
@@ -316,7 +316,7 @@ TEST(UniqueFunctionTest, InlineStorageWorks) {
   // We do assume a couple of implementation details of the unique_function here:
   //  - It can store certain small-enough payload inline
   //  - Inline storage size is at least >= sizeof(void*)
-  void *ptr;
+  void *ptr = nullptr;
   unique_function<void(void *)> UniqueFunctionWithInlineStorage{
       [ptr](void *self) {
         auto mid = reinterpret_cast<uintptr_t>(&ptr);


### PR DESCRIPTION
A quick follow-up fix for https://github.com/llvm/llvm-project/pull/99403

Buildbot [reported](https://lab.llvm.org/buildbot/#/builders/168/builds/2330) an error:

```
/home/buildbots/llvm-external-buildbots/workers/ppc64le-lld-multistage-test/ppc64le-lld-multistage-test/llvm-project/llvm/unittests/ADT/FunctionExtrasTest.cpp:320:8: error: variable 'ptr' is uninitialized when used here [-Werror,-Wuninitialized]
  320 |       [ptr](void *self) {
      |        ^~~
/home/buildbots/llvm-external-buildbots/workers/ppc64le-lld-multistage-test/ppc64le-lld-multistage-test/llvm-project/llvm/unittests/ADT/FunctionExtrasTest.cpp:318:12: note: initialize the variable 'ptr' to silence this warning
  318 |   void *ptr;
      |            ^
      |             = nullptr
1 error generated.
```

So that PR does exactly what's sugested.