### PR TITLE
Emit `BeginSourceFile` failure with `elog`.

### DIFF
--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -512,8 +512,8 @@ ParsedAST::build(llvm::StringRef Filename, const ParseInputs &Inputs,
   auto Action = std::make_unique<ClangdFrontendAction>();
   const FrontendInputFile &MainInput = Clang->getFrontendOpts().Inputs[0];
   if (!Action->BeginSourceFile(*Clang, MainInput)) {
-    log("BeginSourceFile() failed when building AST for {0}",
-        MainInput.getFile());
+    elog("BeginSourceFile() failed when building AST for {0}",
+         MainInput.getFile());
     return std::nullopt;
   }
   // If we saw an include guard in the preamble section of the main file,


### PR DESCRIPTION
There are 3 ways in which `ParseAST::build` can fail and return `std::nullopt`. 2 of the ways we emit the error message using `elog`, but for the 3rd way, `log` is used. We should emit all 3 of these reasons with `elog`.