### PR TITLE
[Docs] Use cacheable myst_heading_slug_func value

### DIFF
--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -57,10 +57,8 @@ except ImportError:
         raise
 
 # Automatic anchors for markdown titles
-from llvm_slug import make_slug
-
 myst_heading_anchors = 6
-myst_heading_slug_func = make_slug
+myst_heading_slug_func = "llvm_slug.make_slug"
 
 autodoc_default_options = {"special-members": True}
 

--- a/llvm/docs/conf.py
+++ b/llvm/docs/conf.py
@@ -40,10 +40,8 @@ except ImportError:
         raise
 
 # Automatic anchors for markdown titles
-from llvm_slug import make_slug
-
 myst_heading_anchors = 6
-myst_heading_slug_func = make_slug
+myst_heading_slug_func = "llvm_slug.make_slug"
 
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Avoid creating an uncacheable conf variable by using a string instead of
a function reference. Also has the effect of avoiding triggering the
"config.cache" sphinx warning.

Requires myst_parser 0.19.0 (specifically
https://github.com/executablebooks/MyST-Parser/pull/696) which is over a
year old by now. Do we mandate any minimum version for these
dependencies?
