### PR TITLE
[libc++] Add a few basic tests for C++ / Swift interoperation

### DIFF
--- a/libcxx/test/libcxx/vendor/apple/swift-interop.sh.cpp
+++ b/libcxx/test/libcxx/vendor/apple/swift-interop.sh.cpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// This test requires access to the Swift compiler, which we assume is only available on Apple
+// platforms for now.
+// REQUIRES: buildhost=darwin
+
+// std::string basic test
+// RUN: swiftc -cxx-interoperability-mode=default %S/swift-interop/string/main.swift -o %t.string.exe \
+// RUN:   -Xcc -nostdinc++ -Xcc -nostdlib++ -Xcc -isystem -Xcc "%{include-dir}"
+// RUN: %{exec} %t.string.exe
+
+// std::vector test with a modulemap
+// RUN: swiftc -cxx-interoperability-mode=default %S/swift-interop/vector/main.swift -o %t.vector.exe \
+// RUN:   -Xcc -nostdinc++ -Xcc -nostdlib++ -Xcc -isystem -Xcc "%{include-dir}" -Xcc -I -Xcc %S/swift-interop/vector
+// RUN: %{exec} %t.vector.exe

--- a/libcxx/test/libcxx/vendor/apple/swift-interop/string/main.swift
+++ b/libcxx/test/libcxx/vendor/apple/swift-interop/string/main.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+import CxxStdlib
+
+let s: std.string = "abc123"
+
+for char in s { print(char) }

--- a/libcxx/test/libcxx/vendor/apple/swift-interop/vector/header.h
+++ b/libcxx/test/libcxx/vendor/apple/swift-interop/vector/header.h
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+
+using VectorOfInt = std::vector<int>;
+
+inline VectorOfInt getStdVector() { return {1, 2, 3}; }

--- a/libcxx/test/libcxx/vendor/apple/swift-interop/vector/main.swift
+++ b/libcxx/test/libcxx/vendor/apple/swift-interop/vector/main.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+import MyCxxDep // no explicit import of CxxStdlib
+
+let vec = getStdVector()
+
+for it in vec { print(it) }

--- a/libcxx/test/libcxx/vendor/apple/swift-interop/vector/module.modulemap
+++ b/libcxx/test/libcxx/vendor/apple/swift-interop/vector/module.modulemap
@@ -1,0 +1,4 @@
+module MyCxxDep {
+    header "header.h"
+    export *
+}


### PR DESCRIPTION
These tests are only enabled on Apple platforms. The purpose of these tests is to ensure that we don't break existing functionality powered by Clang modules as we refactor the modulemap, since Swift interop greatly exercises libc++'s support for Clang modules.

In particular, adding these tests to libc++ is not an official statement of support from libc++ towards Swift interop (which would require a community consensus that I am not pursuing at this time), but rather a way for us to find out when we unexpectedly break things so we can decide how / whether we want to address such breakage.

Once the refactoring of the modulemap started in #98214 is mostly done, it would be reasonable to remove these tests unless libc++ wants to pursue support for Swift interop more officially.