### PR TITLE
[clang-tidy] Update TODO comment check

### DIFF
--- a/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
@@ -9,7 +9,7 @@
 #include "TodoCommentCheck.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
-#include <list>
+#include <array>
 #include <optional>
 
 namespace clang::tidy::google::readability {

--- a/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
@@ -9,6 +9,7 @@
 #include "TodoCommentCheck.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
+#include <list>
 #include <optional>
 
 namespace clang::tidy::google::readability {
@@ -17,21 +18,29 @@ class TodoCommentCheck::TodoCommentHandler : public CommentHandler {
 public:
   TodoCommentHandler(TodoCommentCheck &Check, std::optional<std::string> User)
       : Check(Check), User(User ? *User : "unknown"),
-        TodoMatch("^// *TODO *(\\(.*\\))?:?( )?(.*)$") {}
+        TodoMatches{llvm::Regex("^// TODO: (.*) - (.*)$"),
+                    llvm::Regex("^// *TODO *(\\(.*\\))?:? ?(.*)$")} {}
 
   bool HandleComment(Preprocessor &PP, SourceRange Range) override {
     StringRef Text =
         Lexer::getSourceText(CharSourceRange::getCharRange(Range),
                              PP.getSourceManager(), PP.getLangOpts());
 
+    bool Found = false;
     SmallVector<StringRef, 4> Matches;
-    if (!TodoMatch.match(Text, &Matches))
+    for (const llvm::Regex &TodoMatch : TodoMatches) {
+      if (TodoMatch.match(Text, &Matches)) {
+        Found = true;
+        break;
+      }
+    }
+    if (!Found)
       return false;
 
-    StringRef Username = Matches[1];
-    StringRef Comment = Matches[3];
+    StringRef Info = Matches[1];
+    StringRef Comment = Matches[2];
 
-    if (!Username.empty())
+    if (!Info.empty())
       return false;
 
     std::string NewText = ("// TODO(" + Twine(User) + "): " + Comment).str();
@@ -45,7 +54,7 @@ public:
 private:
   TodoCommentCheck &Check;
   std::string User;
-  llvm::Regex TodoMatch;
+  std::array<llvm::Regex, 2> TodoMatches;
 };
 
 TodoCommentCheck::TodoCommentCheck(StringRef Name, ClangTidyContext *Context)

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo.cpp
@@ -24,3 +24,7 @@
 // TODO(b/12345): find the holy grail
 // TODO (b/12345): allow spaces before parentheses
 // TODO(asdf) allow missing semicolon
+// TODO: bug 12345678 - Remove this after the 2047q4 compatibility window expires.
+// TODO: example.com/my-design-doc - Manually fix up this code the next time it's touched.
+// TODO(bug 12345678): Update this list after the Foo service is turned down.
+// TODO(John): Use a "\*" here for concatenation operator.

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo.cpp
@@ -25,4 +25,4 @@
 // TODO (b/12345): allow spaces before parentheses
 // TODO(asdf) allow missing semicolon
 // TODO: b/12345 - solve the collatz conjecture
-// TODO: foo - barW
+// TODO: foo - bar

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-todo.cpp
@@ -24,7 +24,5 @@
 // TODO(b/12345): find the holy grail
 // TODO (b/12345): allow spaces before parentheses
 // TODO(asdf) allow missing semicolon
-// TODO: bug 12345678 - Remove this after the 2047q4 compatibility window expires.
-// TODO: example.com/my-design-doc - Manually fix up this code the next time it's touched.
-// TODO(bug 12345678): Update this list after the Foo service is turned down.
-// TODO(John): Use a "\*" here for concatenation operator.
+// TODO: b/12345 - solve the collatz conjecture
+// TODO: foo - barW


### PR DESCRIPTION
The doc for google-readability-todo reference lists two styles of TODO comments:
https://google.github.io/styleguide/cppguide.html#TODO_Comments

Previously, only `TODO(info): comment` were supported.
After this PR, `TODO: info - comment` are also supported.