### PR TITLE
[libc][math][c23] Optimize fabsf16 on x86 with Clang

### DIFF
--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -563,10 +563,12 @@ add_entrypoint_object(
   HDRS
     ../fabsf16.h
   DEPENDS
-    libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
+    libc.src.__support.FPUtil.fp_bits
     libc.src.__support.macros.properties.architectures
     libc.src.__support.macros.properties.compiler
+    libc.src.__support.macros.properties.cpu_features
+    libc.src.__support.macros.properties.types
   COMPILE_OPTIONS
     -O3
   FLAGS

--- a/libc/src/math/generic/fabsf16.cpp
+++ b/libc/src/math/generic/fabsf16.cpp
@@ -8,19 +8,30 @@
 
 #include "src/math/fabsf16.h"
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
 #include "src/__support/macros/properties/compiler.h"
+#include "src/__support/macros/properties/cpu_features.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(float16, fabsf16, (float16 x)) {
-  // For x86, GCC generates better code from the generic implementation.
-  // https://godbolt.org/z/K9orM4hTa
 #if defined(__LIBC_MISC_MATH_BASIC_OPS_OPT) &&                                 \
-    !(defined(LIBC_TARGET_ARCH_IS_X86) && defined(LIBC_COMPILER_IS_GCC))
+    defined(LIBC_TARGET_CPU_HAS_FAST_FLOAT16_OPS)
   return __builtin_fabsf16(x);
+#elif defined(LIBC_TARGET_ARCH_IS_X86) && defined(LIBC_COMPILER_IS_CLANG)
+  // Prevent Clang from generating calls to slow soft-float conversion
+  // functions on x86. See https://godbolt.org/z/hvo6jbnGz.
+
+  using FPBits = fputil::FPBits<float16>;
+  using StorageType = typename FPBits::StorageType;
+
+  static constexpr volatile StorageType ABS_MASK = FPBits::EXP_SIG_MASK;
+
+  return FPBits(static_cast<StorageType>(FPBits(x).uintval() & ABS_MASK))
+      .get_val();
 #else
   return fputil::abs(x);
 #endif


### PR DESCRIPTION
Works around optimizations introduced in LLVM 17 and 18 that slow down
`fputil::abs<float16>()` on x86.
