### PR TITLE
[lldb][test] Change unsupported cat -e to cat -v to work with lit internal shell

### DIFF
--- a/lldb/test/Shell/Driver/TestUseColor.test
+++ b/lldb/test/Shell/Driver/TestUseColor.test
@@ -1,7 +1,7 @@
 UNSUPPORTED: system-windows
 
 RUN: not %lldb -b -o 'settings set use-color true' -o 'settings show use-color' -o 'bogus' > %t 2>&1
-RUN: cat -e %t | FileCheck %s --check-prefix COLOR
+RUN: cat -v %t | FileCheck %s --check-prefix COLOR
 COLOR: use-color (boolean) = true
 # The [[ confuses FileCheck so regex match it.
 COLOR: {{.+}}0;1;31merror: {{.+}}0m'bogus' is not a valid command


### PR DESCRIPTION
This patch changes the test that uses the `cat -e` option to `cat -v` so that the test can be run using lit's internal shell. For  `cat`, the `-v` option prints non-printing characters in ^ and M- notation, while the `-e` option adds `$` to the end of lines in addition to printing non-printing characters in ^ and M- notation. This is an alternative patch to https://github.com/llvm/llvm-project/pull/102061, opting to rewrite the test that uses `cat -e` instead of extending support to the `-e` option.

Fixes https://github.com/llvm/llvm-project/issues/102377