### PR TITLE
[compiler-rt][test] Change tests to remove the use of `unset` command in lit internal shell 

### DIFF
--- a/compiler-rt/test/fuzzer/afl-driver-close-fd-mask.test
+++ b/compiler-rt/test/fuzzer/afl-driver-close-fd-mask.test
@@ -3,29 +3,28 @@ RUN: %no_fuzzer_cpp_compiler %S/AFLDriverTest.cpp %libfuzzer_src/afl/afl_driver.
 
 ; Test that not specifying AFL_DRIVER_CLOSE_FD_MASK works as intended.
 RUN: echo -n "abc" > %t.file3
-RUN: unset AFL_DRIVER_CLOSE_FD_MASK
-RUN: %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=STDERR,STDOUT
+RUN: env -u AFL_DRIVER_CLOSE_FD_MASK %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=STDERR,STDOUT
 STDOUT: STDOUT MESSAGE
 STDERR: STDERR MESSAGE
 
 ; Test that stdout is closed properly.
-RUN: AFL_DRIVER_CLOSE_FD_MASK=1 %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=NOT_STDOUT,STDERR
+RUN: env AFL_DRIVER_CLOSE_FD_MASK=1 %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=NOT_STDOUT,STDERR
 NOT_STDOUT-NOT: STDOUT MESSAGE
 
 ; Test that stderr is closed properly.
-RUN: AFL_DRIVER_CLOSE_FD_MASK=2 %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=NOT_STDERR,STDOUT
+RUN: env AFL_DRIVER_CLOSE_FD_MASK=2 %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=NOT_STDERR,STDOUT
 NOT_STDERR-NOT: STDERR MESSAGE
 
 ; Test that both are closed properly.
-RUN: AFL_DRIVER_CLOSE_FD_MASK=3 %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=NOT_STDERR,NOT_STDOUT
+RUN: env AFL_DRIVER_CLOSE_FD_MASK=3 %run %t-AFLDriverTest < %t.file3 2>&1 | FileCheck %s --check-prefixes=NOT_STDERR,NOT_STDOUT
 
 ; Test that a stack is printed when we close stderr
 RUN: echo -n "abcd" > %t.file4
-RUN: AFL_DRIVER_CLOSE_FD_MASK=2 not %run %t-AFLDriverTest < %t.file4 2>&1  | FileCheck %s --check-prefixes=ASAN_CRASH,STDOUT,NOT_STDERR
+RUN: env AFL_DRIVER_CLOSE_FD_MASK=2 not %run %t-AFLDriverTest < %t.file4 2>&1  | FileCheck %s --check-prefixes=ASAN_CRASH,STDOUT,NOT_STDERR
 ASAN_CRASH: ERROR: AddressSanitizer
 
 ; Test that a stack is written to the stderr duplicate file when we close stderr
 ; and specify a duplicate.
 RUN: rm -f %t.stderr
-RUN: AFL_DRIVER_STDERR_DUPLICATE_FILENAME=%t.stderr AFL_DRIVER_CLOSE_FD_MASK=2 not %run %t-AFLDriverTest < %t.file4
+RUN: env AFL_DRIVER_STDERR_DUPLICATE_FILENAME=%t.stderr AFL_DRIVER_CLOSE_FD_MASK=2 not %run %t-AFLDriverTest < %t.file4
 RUN: cat %t.stderr | FileCheck %s --check-prefixes=ASAN_CRASH,NOT_STDERR

--- a/compiler-rt/test/fuzzer/afl-driver-stderr.test
+++ b/compiler-rt/test/fuzzer/afl-driver-stderr.test
@@ -4,12 +4,11 @@ XFAIL: ios
 RUN: %no_fuzzer_cpp_compiler %S/AFLDriverTest.cpp %libfuzzer_src/afl/afl_driver.cpp -o %t-AFLDriverTest
 
 ; Test that not specifying a stderr file isn't broken.
-RUN: unset AFL_DRIVER_STDERR_DUPLICATE_FILENAME
-RUN: %run %t-AFLDriverTest
+RUN: env -u AFL_DRIVER_STDERR_DUPLICATE_FILENAME %run %t-AFLDriverTest
 
 ; Test that specifying an invalid file causes a crash.
-RUN: ASAN_OPTIONS= AFL_DRIVER_STDERR_DUPLICATE_FILENAME="%T" not --crash %run %t-AFLDriverTest
+RUN: env ASAN_OPTIONS= AFL_DRIVER_STDERR_DUPLICATE_FILENAME="%T" not --crash %run %t-AFLDriverTest
 
 ; Test that a file is created when specified as the duplicate stderr.
-RUN: AFL_DRIVER_STDERR_DUPLICATE_FILENAME=%t %run %t-AFLDriverTest
+RUN: env AFL_DRIVER_STDERR_DUPLICATE_FILENAME=%t %run %t-AFLDriverTest
 RUN: stat %t


### PR DESCRIPTION
This patch rewrites tests to remove the use of the `unset` command, which is not supported in the lit internal shell. The tests now use the `env -u` to unset environment variables.

The `unset` command is used in shell environments to remove the environment variable. However, because the lit internal shell does not support the `unset` command, using it in tests would result in errors or other unexpected behavior. To overcome this limitation, the tests have been updated to use the `env -u` command instead. `env -u` is supported by lit and effectively removes specified environment variables. This allows the tests to achieve the same goal of unsetting environment variables while ensuring compatibility with the lit internal shell.

This change is relevant for [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179/3)  
Fixes: #102397 
