### PR TITLE
[clang-tidy] Use upper case letters for bool conversion suffix

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -43,10 +43,10 @@ StringRef getZeroLiteralToCompareWithForType(CastKind CastExprKind,
                                              ASTContext &Context) {
   switch (CastExprKind) {
   case CK_IntegralToBoolean:
-    return Type->isUnsignedIntegerType() ? "0u" : "0";
+    return Type->isUnsignedIntegerType() ? "0U" : "0";
 
   case CK_FloatingToBoolean:
-    return Context.hasSameType(Type, Context.FloatTy) ? "0.0f" : "0.0";
+    return Context.hasSameType(Type, Context.FloatTy) ? "0.0F" : "0.0";
 
   case CK_PointerToBoolean:
   case CK_MemberPointerToBoolean: // Fall-through on purpose.
@@ -202,13 +202,13 @@ StringRef getEquivalentForBoolLiteral(const CXXBoolLiteralExpr *BoolLiteral,
 
   if (DestType->isFloatingType()) {
     if (Context.hasSameType(DestType, Context.FloatTy)) {
-      return BoolLiteral->getValue() ? "1.0f" : "0.0f";
+      return BoolLiteral->getValue() ? "1.0F" : "0.0F";
     }
     return BoolLiteral->getValue() ? "1.0" : "0.0";
   }
 
   if (DestType->isUnsignedIntegerType()) {
-    return BoolLiteral->getValue() ? "1u" : "0u";
+    return BoolLiteral->getValue() ? "1U" : "0U";
   }
   return BoolLiteral->getValue() ? "1" : "0";
 }

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -405,13 +405,13 @@ void ImplicitBoolConversionCheck::handleCastFromBool(
 
     const auto EquivalentForBoolLiteral =
         getEquivalentForBoolLiteral(BoolLiteral, DestType, Context);
-    if (UseUpperCaseLiteralSuffix) {
+    if (UseUpperCaseLiteralSuffix)
       Diag << tooling::fixit::createReplacement(
           *Cast, EquivalentForBoolLiteral.upper());
-    } else {
+    else
       Diag << tooling::fixit::createReplacement(*Cast,
                                                 EquivalentForBoolLiteral);
-    }
+
   } else {
     fixGenericExprCastFromBool(Diag, Cast, Context, DestType.getAsString());
   }

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -74,7 +74,8 @@ bool isUnaryLogicalNotOperator(const Stmt *Statement) {
 
 void fixGenericExprCastToBool(DiagnosticBuilder &Diag,
                               const ImplicitCastExpr *Cast, const Stmt *Parent,
-                              ASTContext &Context, bool UseUpperCaseLiteralSuffix) {
+                              ASTContext &Context,
+                              bool UseUpperCaseLiteralSuffix) {
   // In case of expressions like (! integer), we should remove the redundant not
   // operator and use inverted comparison (integer == 0).
   bool InvertComparison =
@@ -121,7 +122,8 @@ void fixGenericExprCastToBool(DiagnosticBuilder &Diag,
   }
 
   EndLocInsertion += getZeroLiteralToCompareWithForType(
-      Cast->getCastKind(), SubExpr->getType(), Context, UseUpperCaseLiteralSuffix);
+      Cast->getCastKind(), SubExpr->getType(), Context,
+      UseUpperCaseLiteralSuffix);
 
   if (NeedOuterParens) {
     EndLocInsertion += ")";
@@ -264,7 +266,8 @@ ImplicitBoolConversionCheck::ImplicitBoolConversionCheck(
     : ClangTidyCheck(Name, Context),
       AllowIntegerConditions(Options.get("AllowIntegerConditions", false)),
       AllowPointerConditions(Options.get("AllowPointerConditions", false)),
-      UseUpperCaseLiteralSuffix(Options.get("UseUpperCaseLiteralSuffix", false)) {}
+      UseUpperCaseLiteralSuffix(
+          Options.get("UseUpperCaseLiteralSuffix", false)) {}
 
 void ImplicitBoolConversionCheck::storeOptions(
     ClangTidyOptions::OptionMap &Opts) {
@@ -395,7 +398,8 @@ void ImplicitBoolConversionCheck::handleCastToBool(const ImplicitCastExpr *Cast,
   if (!EquivalentLiteral.empty()) {
     Diag << tooling::fixit::createReplacement(*Cast, EquivalentLiteral);
   } else {
-    fixGenericExprCastToBool(Diag, Cast, Parent, Context, UseUpperCaseLiteralSuffix);
+    fixGenericExprCastToBool(Diag, Cast, Parent, Context,
+                             UseUpperCaseLiteralSuffix);
   }
 }
 

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -43,9 +43,9 @@ StringRef getZeroLiteralToCompareWithForType(CastKind CastExprKind,
                                              bool UseUpperCaseSuffix) {
   switch (CastExprKind) {
   case CK_IntegralToBoolean: {
-    if (Type->isUnsignedIntegerType()) {
+    if (Type->isUnsignedIntegerType())
       return UseUpperCaseSuffix ? "0U" : "0u";
-    }
+
     return "0";
   }
 
@@ -211,18 +211,18 @@ StringRef getEquivalentForBoolLiteral(const CXXBoolLiteralExpr *BoolLiteral,
 
   if (DestType->isFloatingType()) {
     if (Context.hasSameType(DestType, Context.FloatTy)) {
-      if (BoolLiteral->getValue()) {
+      if (BoolLiteral->getValue())
         return UseUpperCaseSuffix ? "1.0F" : "1.0f";
-      }
+
       return UseUpperCaseSuffix ? "0.0F" : "0.0f";
     }
     return BoolLiteral->getValue() ? "1.0" : "0.0";
   }
 
   if (DestType->isUnsignedIntegerType()) {
-    if (BoolLiteral->getValue()) {
+    if (BoolLiteral->getValue())
       return UseUpperCaseSuffix ? "1U" : "1u";
-    }
+
     return UseUpperCaseSuffix ? "0U" : "0u";
   }
   return BoolLiteral->getValue() ? "1" : "0";

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
@@ -36,6 +36,7 @@ private:
 
   const bool AllowIntegerConditions;
   const bool AllowPointerConditions;
+  const bool UseUpperCaseSuffix;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
@@ -36,7 +36,7 @@ private:
 
   const bool AllowIntegerConditions;
   const bool AllowPointerConditions;
-  const bool UseUpperCaseSuffix;
+  const bool UseUpperCaseLiteralSuffix;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -116,7 +116,7 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.
 
-- Added option `UseUpperCaseSuffix` to :doc:`readablility-implicit-bool-conversion
+- Added option `UseUpperCaseLiteralSuffix` to :doc:`readablility-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check to select the
   case of the literal suffix in fixes.
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -116,8 +116,9 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.
 
-- Added option `UseUpperCaseLiteralSuffix` to :doc:`readablility-implicit-bool-conversion
-  <clang-tidy/checks/readability/implicit-bool-conversion>` check to select the
+- Improved :doc:`readablility-implicit-bool-conversion
+  <clang-tidy/checks/readability/implicit-bool-conversion>` check
+  Added option `UseUpperCaseLiteralSuffix` to  to select the
   case of the literal suffix in fixes.
 
 Removed checks

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -117,8 +117,8 @@ Changes in existing checks
   remove `->`, when redundant `get()` is removed.
 
 - Added option `UseUpperCaseSuffix` to :doc:`readablility-implicit-bool-conversion
-  <clang-tidy/checks/readability/implicit-bool-conversion>` check specify the
-  case of the explicit literal
+  <clang-tidy/checks/readability/implicit-bool-conversion>` check to select the
+  case of the literal suffix in fixes.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -116,6 +116,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.
 
+- Added option `UseUpperCaseSuffix` to :doc:`readablility-implicit-bool-conversion
+  <clang-tidy/checks/readability/implicit-bool-conversion>` check specify the
+  case of the explicit literal
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -118,7 +118,7 @@ Changes in existing checks
 
 - Improved :doc:`readablility-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check
-  Added option `UseUpperCaseLiteralSuffix` to  to select the
+  by adding the option `UseUpperCaseLiteralSuffix` to select the
   case of the literal suffix in fixes.
 
 Removed checks

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -112,14 +112,14 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-std-print>` check to support replacing
   member function calls too.
 
-- Improved :doc:`readability-redundant-smartptr-get
-  <clang-tidy/checks/readability/redundant-smartptr-get>` check to
-  remove `->`, when redundant `get()` is removed.
-
 - Improved :doc:`readablility-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check
   by adding the option `UseUpperCaseLiteralSuffix` to select the
   case of the literal suffix in fixes.
+
+- Improved :doc:`readability-redundant-smartptr-get
+  <clang-tidy/checks/readability/redundant-smartptr-get>` check to
+  remove `->`, when redundant `get()` is removed.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -134,7 +134,7 @@ Options
    When `true`, the check will allow conditional pointer conversions. Default
    is `false`.
 
-.. option::  UseUpperCaseSuffix
+.. option::  UseUpperCaseLiteralSuffix
 
    When `true`, the replacements will use an uppercase literal suffix in the
    provided fixes.
@@ -147,4 +147,4 @@ Example
   uint32_t foo;
   if (foo) {}
   // ^ propose replacement default: if (foo != 0u) {}
-  // ^ propose replacement with option `UseUpperCaseSuffix`: if (foo != 0U) {}
+  // ^ propose replacement with option `UseUpperCaseLiteralSuffix`: if (foo != 0U) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -136,8 +136,8 @@ Options
 
 .. option::  UseUpperCaseSuffix
 
-   When `true`, the check will allow new explicit conversion use an uppercase
-   suffix when it applies.
+   When `true`, the replacements will use an uppercase literal suffix in the
+   provided fixes.
 
 Example
 ^^^^^^^

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -137,14 +137,13 @@ Options
 .. option::  UseUpperCaseLiteralSuffix
 
    When `true`, the replacements will use an uppercase literal suffix in the
-   provided fixes.
+   provided fixes. Default a lowercase literal suffix is used.
 
-Example
-^^^^^^^
+    Example
 
-.. code-block:: c++
+    .. code-block:: c++
 
-  uint32_t foo;
-  if (foo) {}
-  // ^ propose replacement default: if (foo != 0u) {}
-  // ^ propose replacement with option `UseUpperCaseLiteralSuffix`: if (foo != 0U) {}
+      uint32_t foo;
+      if (foo) {}
+      // ^ propose replacement default: if (foo != 0u) {}
+      // ^ propose replacement with option `UseUpperCaseLiteralSuffix`: if (foo != 0U) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -137,7 +137,7 @@ Options
 .. option::  UseUpperCaseLiteralSuffix
 
    When `true`, the replacements will use an uppercase literal suffix in the
-   provided fixes. Default a lowercase literal suffix is used.
+   provided fixes. Default is `false`.
 
     Example
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -133,3 +133,18 @@ Options
 
    When `true`, the check will allow conditional pointer conversions. Default
    is `false`.
+
+.. option::  UseUpperCaseSuffix
+
+   When `true`, the check will allow new explicit conversion use an uppercase
+   suffix when it applies.
+
+Example
+^^^^^^^
+
+.. code-block:: c++
+
+  uint32_t foo;
+  if (foo) {}
+  // ^ propose replacement default: if (foo != 0u) {}
+  // ^ propose replacement with option `UseUpperCaseSuffix`: if (foo != 0U) {}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -94,7 +94,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTakingUnsignedLong(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: implicit conversion 'bool' -> 'unsigned long'
-  // CHECK-FIXES: functionTakingUnsignedLong(0U);
+  // CHECK-FIXES: functionTakingUnsignedLong(0u);
 
   functionTakingSignedChar(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: implicit conversion 'bool' -> 'signed char'
@@ -102,7 +102,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTakingFloat(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'float'
-  // CHECK-FIXES: functionTakingFloat(0.0F);
+  // CHECK-FIXES: functionTakingFloat(0.0f);
 
   functionTakingDouble(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'bool' -> 'double'
@@ -159,12 +159,12 @@ void implicitConversionToBoolSimpleCases() {
   unsigned long unsignedLong = 10;
   functionTakingBool(unsignedLong);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'unsigned long' -> 'bool'
-  // CHECK-FIXES: functionTakingBool(unsignedLong != 0U);
+  // CHECK-FIXES: functionTakingBool(unsignedLong != 0u);
 
   float floating = 0.0f;
   functionTakingBool(floating);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTakingBool(floating != 0.0F);
+  // CHECK-FIXES: functionTakingBool(floating != 0.0f);
 
   double doubleFloating = 1.0f;
   functionTakingBool(doubleFloating);
@@ -193,7 +193,7 @@ void implicitConversionToBoolInSingleExpressions() {
   bool boolComingFromFloat;
   boolComingFromFloat = floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: boolComingFromFloat = (floating != 0.0F);
+  // CHECK-FIXES: boolComingFromFloat = (floating != 0.0f);
 
   signed char character = 'a';
   bool boolComingFromChar;
@@ -231,7 +231,7 @@ bool implicitConversionToBoolInReturnValue() {
   float floating = 1.0f;
   return floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: return floating != 0.0F;
+  // CHECK-FIXES: return floating != 0.0f;
 }
 
 void implicitConversionToBoolFromLiterals() {
@@ -287,7 +287,7 @@ void implicitConversionToBoolFromUnaryMinusAndZeroLiterals() {
 
   functionTakingBool(-0.0f);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTakingBool((-0.0f) != 0.0F);
+  // CHECK-FIXES: functionTakingBool((-0.0f) != 0.0f);
 
   functionTakingBool(-0.0);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'double' -> 'bool'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -1,7 +1,7 @@
 // RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t -- -- -std=c23
 // RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
-// RUN:         readability-implicit-bool-conversion.UseUpperCaseSuffix: true \
+// RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
 // RUN:     }}' -- -std=c23
 
 #undef NULL

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -94,7 +94,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTakingUnsignedLong(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: implicit conversion 'bool' -> 'unsigned long'
-  // CHECK-FIXES: functionTakingUnsignedLong(0u);
+  // CHECK-FIXES: functionTakingUnsignedLong(0U);
 
   functionTakingSignedChar(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: implicit conversion 'bool' -> 'signed char'
@@ -102,7 +102,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTakingFloat(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'float'
-  // CHECK-FIXES: functionTakingFloat(0.0f);
+  // CHECK-FIXES: functionTakingFloat(0.0F);
 
   functionTakingDouble(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'bool' -> 'double'
@@ -159,12 +159,12 @@ void implicitConversionToBoolSimpleCases() {
   unsigned long unsignedLong = 10;
   functionTakingBool(unsignedLong);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'unsigned long' -> 'bool'
-  // CHECK-FIXES: functionTakingBool(unsignedLong != 0u);
+  // CHECK-FIXES: functionTakingBool(unsignedLong != 0U);
 
   float floating = 0.0f;
   functionTakingBool(floating);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTakingBool(floating != 0.0f);
+  // CHECK-FIXES: functionTakingBool(floating != 0.0F);
 
   double doubleFloating = 1.0f;
   functionTakingBool(doubleFloating);
@@ -193,7 +193,7 @@ void implicitConversionToBoolInSingleExpressions() {
   bool boolComingFromFloat;
   boolComingFromFloat = floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: boolComingFromFloat = (floating != 0.0f);
+  // CHECK-FIXES: boolComingFromFloat = (floating != 0.0F);
 
   signed char character = 'a';
   bool boolComingFromChar;
@@ -231,7 +231,7 @@ bool implicitConversionToBoolInReturnValue() {
   float floating = 1.0f;
   return floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: return floating != 0.0f;
+  // CHECK-FIXES: return floating != 0.0F;
 }
 
 void implicitConversionToBoolFromLiterals() {
@@ -287,7 +287,7 @@ void implicitConversionToBoolFromUnaryMinusAndZeroLiterals() {
 
   functionTakingBool(-0.0f);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTakingBool((-0.0f) != 0.0f);
+  // CHECK-FIXES: functionTakingBool((-0.0f) != 0.0F);
 
   functionTakingBool(-0.0);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'double' -> 'bool'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -1,4 +1,8 @@
 // RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t -- -- -std=c23
+// RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
+// RUN:     -config='{CheckOptions: { \
+// RUN:         readability-implicit-bool-conversion.UseUpperCaseSuffix: true \
+// RUN:     }}' -- -std=c23
 
 #undef NULL
 #define NULL 0L
@@ -95,6 +99,7 @@ void implicitConversionFromBoolLiterals() {
   functionTakingUnsignedLong(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: implicit conversion 'bool' -> 'unsigned long'
   // CHECK-FIXES: functionTakingUnsignedLong(0u);
+  // CHECK-FIXES-UPPER-CASE: functionTakingUnsignedLong(0U);
 
   functionTakingSignedChar(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: implicit conversion 'bool' -> 'signed char'
@@ -103,6 +108,7 @@ void implicitConversionFromBoolLiterals() {
   functionTakingFloat(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'float'
   // CHECK-FIXES: functionTakingFloat(0.0f);
+  // CHECK-FIXES-UPPER-CASE: functionTakingFloat(0.0F);
 
   functionTakingDouble(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'bool' -> 'double'
@@ -160,11 +166,13 @@ void implicitConversionToBoolSimpleCases() {
   functionTakingBool(unsignedLong);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'unsigned long' -> 'bool'
   // CHECK-FIXES: functionTakingBool(unsignedLong != 0u);
+  // CHECK-FIXES-UPPER-CASE: functionTakingBool(unsignedLong != 0U);
 
   float floating = 0.0f;
   functionTakingBool(floating);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: functionTakingBool(floating != 0.0f);
+  // CHECK-FIXES-UPPER-CASE: functionTakingBool(floating != 0.0F);
 
   double doubleFloating = 1.0f;
   functionTakingBool(doubleFloating);
@@ -194,6 +202,7 @@ void implicitConversionToBoolInSingleExpressions() {
   boolComingFromFloat = floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: boolComingFromFloat = (floating != 0.0f);
+  // CHECK-FIXES-UPPER-CASE: boolComingFromFloat = (floating != 0.0F);
 
   signed char character = 'a';
   bool boolComingFromChar;
@@ -288,6 +297,7 @@ void implicitConversionToBoolFromUnaryMinusAndZeroLiterals() {
   functionTakingBool(-0.0f);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: functionTakingBool((-0.0f) != 0.0f);
+  // CHECK-FIXES-UPPER-CASE: functionTakingBool((-0.0f) != 0.0F);
 
   functionTakingBool(-0.0);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: implicit conversion 'double' -> 'bool'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -98,7 +98,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTaking<unsigned long>(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: implicit conversion 'bool' -> 'unsigned long'
-  // CHECK-FIXES: functionTaking<unsigned long>(0u);
+  // CHECK-FIXES: functionTaking<unsigned long>(0U);
 
   functionTaking<signed char>(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: implicit conversion 'bool' -> 'signed char'
@@ -106,7 +106,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTaking<float>(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: implicit conversion 'bool' -> 'float'
-  // CHECK-FIXES: functionTaking<float>(0.0f);
+  // CHECK-FIXES: functionTaking<float>(0.0F);
 
   functionTaking<double>(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: implicit conversion 'bool' -> 'double'
@@ -177,14 +177,14 @@ void implicitConversionToBoolSimpleCases() {
   unsigned long unsignedLong = 10;
   functionTaking<bool>(unsignedLong);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'unsigned long' -> 'bool'
-  // CHECK-FIXES: functionTaking<bool>(unsignedLong != 0u);
+  // CHECK-FIXES: functionTaking<bool>(unsignedLong != 0U);
 
-  float floating = 0.0f;
+  float floating = 0.0F;
   functionTaking<bool>(floating);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTaking<bool>(floating != 0.0f);
+  // CHECK-FIXES: functionTaking<bool>(floating != 0.0F);
 
-  double doubleFloating = 1.0f;
+  double doubleFloating = 1.0F;
   functionTaking<bool>(doubleFloating);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'double' -> 'bool'
   // CHECK-FIXES: functionTaking<bool>(doubleFloating != 0.0);
@@ -211,10 +211,10 @@ void implicitConversionToBoolInSingleExpressions() {
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: implicit conversion 'int' -> 'bool'
   // CHECK-FIXES: bool boolComingFromInt = integer != 0;
 
-  float floating = 10.0f;
+  float floating = 10.0F;
   bool boolComingFromFloat = floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: bool boolComingFromFloat = floating != 0.0f;
+  // CHECK-FIXES: bool boolComingFromFloat = floating != 0.0F;
 
   signed char character = 'a';
   bool boolComingFromChar = character;
@@ -239,7 +239,7 @@ void implicitConversionToBoolInComplexExpressions() {
   float floating = 0.2f;
   bool boolComingFromFloating = floating - 0.3f || boolean;
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: bool boolComingFromFloating = ((floating - 0.3f) != 0.0f) || boolean;
+  // CHECK-FIXES: bool boolComingFromFloating = ((floating - 0.3f) != 0.0F) || boolean;
 
   double doubleFloating = 0.3;
   bool boolComingFromDoubleFloating = (doubleFloating - 0.4) && boolean;
@@ -253,10 +253,10 @@ void implicitConversionInNegationExpressions() {
   // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: implicit conversion 'int' -> 'bool'
   // CHECK-FIXES: bool boolComingFromNegatedInt = integer == 0;
 
-  float floating = 10.0f;
+  float floating = 10.0F;
   bool boolComingFromNegatedFloat = ! floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: bool boolComingFromNegatedFloat = floating == 0.0f;
+  // CHECK-FIXES: bool boolComingFromNegatedFloat = floating == 0.0F;
 
   signed char character = 'a';
   bool boolComingFromNegatedChar = (! character);
@@ -283,7 +283,7 @@ void implicitConversionToBoolInControlStatements() {
   float floating = 0.3f;
   while (floating) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: while (floating != 0.0f) {}
+  // CHECK-FIXES: while (floating != 0.0F) {}
 
   double doubleFloating = 0.4;
   do {} while (doubleFloating);
@@ -295,7 +295,7 @@ bool implicitConversionToBoolInReturnValue() {
   float floating = 1.0f;
   return floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: return floating != 0.0f;
+  // CHECK-FIXES: return floating != 0.0F;
 }
 
 void implicitConversionToBoolFromLiterals() {
@@ -354,7 +354,7 @@ void implicitConversionToBoolFromUnaryMinusAndZeroLiterals() {
 
   functionTaking<bool>(-0.0f);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTaking<bool>((-0.0f) != 0.0f);
+  // CHECK-FIXES: functionTaking<bool>((-0.0f) != 0.0F);
 
   functionTaking<bool>(-0.0);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'double' -> 'bool'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -1,4 +1,8 @@
 // RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
+// RUN:     -config='{CheckOptions: { \
+// RUN:         readability-implicit-bool-conversion.UseUpperCaseSuffix: true \
+// RUN:     }}'
 
 // We need NULL macro, but some buildbots don't like including <cstddef> header
 // This is a portable way of getting it to work
@@ -99,6 +103,7 @@ void implicitConversionFromBoolLiterals() {
   functionTaking<unsigned long>(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: implicit conversion 'bool' -> 'unsigned long'
   // CHECK-FIXES: functionTaking<unsigned long>(0u);
+  // CHECK-FIXES-UPPER-CASE: functionTaking<unsigned long>(0U);
 
   functionTaking<signed char>(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: implicit conversion 'bool' -> 'signed char'
@@ -107,6 +112,7 @@ void implicitConversionFromBoolLiterals() {
   functionTaking<float>(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: implicit conversion 'bool' -> 'float'
   // CHECK-FIXES: functionTaking<float>(0.0f);
+  // CHECK-FIXES-UPPER-CASE: functionTaking<float>(0.0F);
 
   functionTaking<double>(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: implicit conversion 'bool' -> 'double'
@@ -178,11 +184,13 @@ void implicitConversionToBoolSimpleCases() {
   functionTaking<bool>(unsignedLong);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'unsigned long' -> 'bool'
   // CHECK-FIXES: functionTaking<bool>(unsignedLong != 0u);
+  // CHECK-FIXES-UPPER-CASE: functionTaking<bool>(unsignedLong != 0U);
 
   float floating = 0.0f;
   functionTaking<bool>(floating);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: functionTaking<bool>(floating != 0.0f);
+  // CHECK-FIXES-UPPER-CASE: functionTaking<bool>(floating != 0.0F);
 
   double doubleFloating = 1.0f;
   functionTaking<bool>(doubleFloating);
@@ -215,6 +223,7 @@ void implicitConversionToBoolInSingleExpressions() {
   bool boolComingFromFloat = floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: bool boolComingFromFloat = floating != 0.0f;
+  // CHECK-FIXES-UPPER-CASE: bool boolComingFromFloat = floating != 0.0F;
 
   signed char character = 'a';
   bool boolComingFromChar = character;
@@ -240,6 +249,7 @@ void implicitConversionToBoolInComplexExpressions() {
   bool boolComingFromFloating = floating - 0.3f || boolean;
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: bool boolComingFromFloating = ((floating - 0.3f) != 0.0f) || boolean;
+  // CHECK-FIXES-UPPER-CASE: bool boolComingFromFloating = ((floating - 0.3f) != 0.0F) || boolean;
 
   double doubleFloating = 0.3;
   bool boolComingFromDoubleFloating = (doubleFloating - 0.4) && boolean;
@@ -257,6 +267,7 @@ void implicitConversionInNegationExpressions() {
   bool boolComingFromNegatedFloat = ! floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: bool boolComingFromNegatedFloat = floating == 0.0f;
+  // CHECK-FIXES-UPPER-CASE: bool boolComingFromNegatedFloat = floating == 0.0F;
 
   signed char character = 'a';
   bool boolComingFromNegatedChar = (! character);
@@ -284,6 +295,7 @@ void implicitConversionToBoolInControlStatements() {
   while (floating) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: while (floating != 0.0f) {}
+  // CHECK-FIXES-UPPER-CASE: while (floating != 0.0F) {}
 
   double doubleFloating = 0.4;
   do {} while (doubleFloating);
@@ -296,6 +308,7 @@ bool implicitConversionToBoolInReturnValue() {
   return floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: return floating != 0.0f;
+  // CHECK-FIXES-UPPER-CASE: return floating != 0.0F;
 }
 
 void implicitConversionToBoolFromLiterals() {
@@ -355,6 +368,7 @@ void implicitConversionToBoolFromUnaryMinusAndZeroLiterals() {
   functionTaking<bool>(-0.0f);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'float' -> 'bool'
   // CHECK-FIXES: functionTaking<bool>((-0.0f) != 0.0f);
+  // CHECK-FIXES-UPPER-CASE: functionTaking<bool>((-0.0f) != 0.0F);
 
   functionTaking<bool>(-0.0);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'double' -> 'bool'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -1,7 +1,7 @@
 // RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t
 // RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
-// RUN:         readability-implicit-bool-conversion.UseUpperCaseSuffix: true \
+// RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
 // RUN:     }}'
 
 // We need NULL macro, but some buildbots don't like including <cstddef> header

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -98,7 +98,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTaking<unsigned long>(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: implicit conversion 'bool' -> 'unsigned long'
-  // CHECK-FIXES: functionTaking<unsigned long>(0U);
+  // CHECK-FIXES: functionTaking<unsigned long>(0u);
 
   functionTaking<signed char>(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: implicit conversion 'bool' -> 'signed char'
@@ -106,7 +106,7 @@ void implicitConversionFromBoolLiterals() {
 
   functionTaking<float>(false);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: implicit conversion 'bool' -> 'float'
-  // CHECK-FIXES: functionTaking<float>(0.0F);
+  // CHECK-FIXES: functionTaking<float>(0.0f);
 
   functionTaking<double>(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: implicit conversion 'bool' -> 'double'
@@ -177,14 +177,14 @@ void implicitConversionToBoolSimpleCases() {
   unsigned long unsignedLong = 10;
   functionTaking<bool>(unsignedLong);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'unsigned long' -> 'bool'
-  // CHECK-FIXES: functionTaking<bool>(unsignedLong != 0U);
+  // CHECK-FIXES: functionTaking<bool>(unsignedLong != 0u);
 
-  float floating = 0.0F;
+  float floating = 0.0f;
   functionTaking<bool>(floating);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTaking<bool>(floating != 0.0F);
+  // CHECK-FIXES: functionTaking<bool>(floating != 0.0f);
 
-  double doubleFloating = 1.0F;
+  double doubleFloating = 1.0f;
   functionTaking<bool>(doubleFloating);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'double' -> 'bool'
   // CHECK-FIXES: functionTaking<bool>(doubleFloating != 0.0);
@@ -211,10 +211,10 @@ void implicitConversionToBoolInSingleExpressions() {
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: implicit conversion 'int' -> 'bool'
   // CHECK-FIXES: bool boolComingFromInt = integer != 0;
 
-  float floating = 10.0F;
+  float floating = 10.0f;
   bool boolComingFromFloat = floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: bool boolComingFromFloat = floating != 0.0F;
+  // CHECK-FIXES: bool boolComingFromFloat = floating != 0.0f;
 
   signed char character = 'a';
   bool boolComingFromChar = character;
@@ -239,7 +239,7 @@ void implicitConversionToBoolInComplexExpressions() {
   float floating = 0.2f;
   bool boolComingFromFloating = floating - 0.3f || boolean;
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: bool boolComingFromFloating = ((floating - 0.3f) != 0.0F) || boolean;
+  // CHECK-FIXES: bool boolComingFromFloating = ((floating - 0.3f) != 0.0f) || boolean;
 
   double doubleFloating = 0.3;
   bool boolComingFromDoubleFloating = (doubleFloating - 0.4) && boolean;
@@ -253,10 +253,10 @@ void implicitConversionInNegationExpressions() {
   // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: implicit conversion 'int' -> 'bool'
   // CHECK-FIXES: bool boolComingFromNegatedInt = integer == 0;
 
-  float floating = 10.0F;
+  float floating = 10.0f;
   bool boolComingFromNegatedFloat = ! floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: bool boolComingFromNegatedFloat = floating == 0.0F;
+  // CHECK-FIXES: bool boolComingFromNegatedFloat = floating == 0.0f;
 
   signed char character = 'a';
   bool boolComingFromNegatedChar = (! character);
@@ -283,7 +283,7 @@ void implicitConversionToBoolInControlStatements() {
   float floating = 0.3f;
   while (floating) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: while (floating != 0.0F) {}
+  // CHECK-FIXES: while (floating != 0.0f) {}
 
   double doubleFloating = 0.4;
   do {} while (doubleFloating);
@@ -295,7 +295,7 @@ bool implicitConversionToBoolInReturnValue() {
   float floating = 1.0f;
   return floating;
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: return floating != 0.0F;
+  // CHECK-FIXES: return floating != 0.0f;
 }
 
 void implicitConversionToBoolFromLiterals() {
@@ -354,7 +354,7 @@ void implicitConversionToBoolFromUnaryMinusAndZeroLiterals() {
 
   functionTaking<bool>(-0.0f);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'float' -> 'bool'
-  // CHECK-FIXES: functionTaking<bool>((-0.0f) != 0.0F);
+  // CHECK-FIXES: functionTaking<bool>((-0.0f) != 0.0f);
 
   functionTaking<bool>(-0.0);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: implicit conversion 'double' -> 'bool'


### PR DESCRIPTION
When readability-implicit-bool-conversion-check and readability-uppercase-literal-suffix-check is enabled this will cause you to apply a fix twice

from (!i) -> (i == 0u) to (i == 0U) twice instead will skip the middle one


For some reason GitHub decided to close the original pull request when I moved the commits to another branch. 
Original pullrequest #102831