### PR TITLE
[docs] Revise the doc for __builtin_allow_runtime_check

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3571,8 +3571,8 @@ permitted checks can differ and are controlled by the compiler options.
 Options to control checks:
 
 * ``-mllvm -lower-allow-check-percentile-cutoff-hot=N``: Disable checks in hot
-  code marked by the profile summary with a hotness cutoff in the range ``[0,
-  999999]`` (a larger N disables more checks).
+  code marked by the profile summary with a hotness cutoff in the range
+  ``[0, 999999]`` (a larger N disables more checks).
 * ``-mllvm -lower-allow-check-random-rate=P``: Keep a check with probability P,
   a floating point number in the range ``[0.0, 1.0]``.
 * If both options are specified, a check is disabled if either condition is satisfied.
@@ -3582,7 +3582,8 @@ Parameter ``kind``, currently unused, is a string literal specifying the check
 kind. Future compiler versions may use this to allow for more granular control,
 such as applying different hotness cutoffs to different check kinds.
 
-Use ``__has_builtin(__builtin_allow_runtime_check)`` to determine if this intrinsic is supported.
+Use ``__has_builtin(__builtin_allow_runtime_check)`` to determine if this
+builtin function is supported.
 
 ``__builtin_nondeterministic_value``
 ------------------------------------

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3582,8 +3582,7 @@ Parameter ``kind``, currently unused, is a string literal specifying the check
 kind. Future compiler versions may use this to allow for more granular control,
 such as applying different hotness cutoffs to different check kinds.
 
-Use ``__has_builtin(__builtin_allow_runtime_check)`` to determine if this
-builtin function is supported.
+Query for this feature with ``__has_builtin(__builtin_allow_runtime_check)``.
 
 ``__builtin_nondeterministic_value``
 ------------------------------------

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3565,10 +3565,8 @@ program location should be executed. It is expected to be used to implement
 intrinsic.
 
 The ``__builtin_allow_runtime_check()`` can be used within constrol structures
-like ``if`` to guard expensive runtime checks. The specific rules for selecting
-permitted checks can differ and are controlled by the compiler options.
-
-Options to control checks:
+like ``if`` to guard expensive runtime checks. The return value is determined
+by the following compiler options and may differ per call site:
 
 * ``-mllvm -lower-allow-check-percentile-cutoff-hot=N``: Disable checks in hot
   code marked by the profile summary with a hotness cutoff in the range

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -3540,7 +3540,7 @@ the debugging experience.
 ``__builtin_allow_runtime_check``
 ---------------------------------
 
-``__builtin_allow_runtime_check`` return true if the check at the current
+``__builtin_allow_runtime_check`` returns true if the check at the current
 program location should be executed. It is expected to be used to implement
 ``assert`` like checks which can be safely removed by optimizer.
 
@@ -3560,30 +3560,29 @@ program location should be executed. It is expected to be used to implement
 
 **Description**
 
-``__builtin_allow_runtime_check`` is lowered to ` ``llvm.allow.runtime.check``
+``__builtin_allow_runtime_check`` is lowered to the `llvm.allow.runtime.check
 <https://llvm.org/docs/LangRef.html#llvm-allow-runtime-check-intrinsic>`_
-builtin.
+intrinsic.
 
-The ``__builtin_allow_runtime_check()`` is expected to be used with control
-flow conditions such as in ``if`` to guard expensive runtime checks. The
-specific rules for selecting permitted checks can differ and are controlled by
-the compiler options.
+The ``__builtin_allow_runtime_check()`` can be used within constrol structures
+like ``if`` to guard expensive runtime checks. The specific rules for selecting
+permitted checks can differ and are controlled by the compiler options.
 
-Flags to control checks:
-* ``-mllvm -lower-allow-check-percentile-cutoff-hot=N`` where N is PGO hotness
-cutoff in range ``[0, 999999]`` to disallow checks in hot code.
-* ``-mllvm -lower-allow-check-random-rate=P`` where P is number in range
-``[0.0, 1.0]`` representation probability of keeping a check.
-* If both flags are specified, ``-lower-allow-check-random-rate`` takes
-precedence.
-* If none is specified, ``__builtin_allow_runtime_check`` is lowered as
-``true``, allowing all checks.
+Options to control checks:
 
-Parameter ``kind`` is a string literal representing a user selected kind for
-guarded check. It's unused now. It will enable kind-specific lowering in future.
-E.g. a higher hotness cutoff can be used for more expensive kind of check.
+* ``-mllvm -lower-allow-check-percentile-cutoff-hot=N``: Disable checks in hot
+  code marked by the profile summary with a hotness cutoff in the range ``[0,
+  999999]`` (a larger N disables more checks).
+* ``-mllvm -lower-allow-check-random-rate=P``: Keep a check with probability P,
+  a floating point number in the range ``[0.0, 1.0]``.
+* If both options are specified, a check is disabled if either condition is satisfied.
+* If neither is specified, all checks are allowed.
 
-Query for this feature with ``__has_builtin(__builtin_allow_runtime_check)``.
+Parameter ``kind``, currently unused, is a string literal specifying the check
+kind. Future compiler versions may use this to allow for more granular control,
+such as applying different hotness cutoffs to different check kinds.
+
+Use ``__has_builtin(__builtin_allow_runtime_check)`` to determine if this intrinsic is supported.
 
 ``__builtin_nondeterministic_value``
 ------------------------------------


### PR DESCRIPTION
Fix list formatting, improve the wording, and fix the description when
both options (note: prefer "option" to "flag" when arguments are
supported) are specified.
