### PR TITLE
[MLIR][Python] remove unused init python file

### DIFF
--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -34,7 +34,6 @@ declare_mlir_python_sources(MLIRPythonSources.Core.Python.Extras
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
   ADD_TO_PARENT MLIRPythonSources.Core.Python
   SOURCES
-    extras/__init__.py
     extras/types.py
     extras/meta.py
 )

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -34,6 +34,7 @@ declare_mlir_python_sources(MLIRPythonSources.Core.Python.Extras
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
   ADD_TO_PARENT MLIRPythonSources.Core.Python
   SOURCES
+    extras/__init__.py
     extras/types.py
     extras/meta.py
 )


### PR DESCRIPTION
remove unused `__init__.py` under `mlir/python/mlir/extras`