### PR TITLE
[clang][bytecode] Fix initializing base casts

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -214,7 +214,7 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
     unsigned DerivedOffset = collectBaseOffset(QualType(ToMP->getClass(), 0),
                                                QualType(FromMP->getClass(), 0));
 
-    if (!this->visit(SubExpr))
+    if (!this->delegate(SubExpr))
       return false;
 
     return this->emitGetMemberPtrBasePop(DerivedOffset, CE);
@@ -229,14 +229,14 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
     unsigned DerivedOffset = collectBaseOffset(QualType(FromMP->getClass(), 0),
                                                QualType(ToMP->getClass(), 0));
 
-    if (!this->visit(SubExpr))
+    if (!this->delegate(SubExpr))
       return false;
     return this->emitGetMemberPtrBasePop(-DerivedOffset, CE);
   }
 
   case CK_UncheckedDerivedToBase:
   case CK_DerivedToBase: {
-    if (!this->visit(SubExpr))
+    if (!this->delegate(SubExpr))
       return false;
 
     const auto extractRecordDecl = [](QualType Ty) -> const CXXRecordDecl * {
@@ -265,7 +265,7 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
   }
 
   case CK_BaseToDerived: {
-    if (!this->visit(SubExpr))
+    if (!this->delegate(SubExpr))
       return false;
 
     unsigned DerivedOffset =

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1568,7 +1568,7 @@ inline bool GetPtrBase(InterpState &S, CodePtr OpPC, uint32_t Off) {
   if (!CheckSubobject(S, OpPC, Ptr, CSK_Base))
     return false;
   const Pointer &Result = Ptr.atField(Off);
-  if (Result.isPastEnd())
+  if (Result.isPastEnd() || !Result.isBaseClass())
     return false;
   S.Stk.push<Pointer>(Result);
   return true;
@@ -1581,7 +1581,7 @@ inline bool GetPtrBasePop(InterpState &S, CodePtr OpPC, uint32_t Off) {
   if (!CheckSubobject(S, OpPC, Ptr, CSK_Base))
     return false;
   const Pointer &Result = Ptr.atField(Off);
-  if (Result.isPastEnd())
+  if (Result.isPastEnd() || !Result.isBaseClass())
     return false;
   S.Stk.push<Pointer>(Result);
   return true;

--- a/clang/test/Modules/merge-using-decls.cpp
+++ b/clang/test/Modules/merge-using-decls.cpp
@@ -8,6 +8,7 @@
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -x c++ -I%S/Inputs/merge-using-decls -verify -std=c++11 %s -DORDER=2
 
 // RUN: %clang_cc1 -fexperimental-new-constant-interpreter -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -x c++ -I%S/Inputs/merge-using-decls -verify -std=c++17 %s -DORDER=2
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -fmodules -fimplicit-module-maps -fexperimental-new-constant-interpreter -fmodules-cache-path=%t -x c++ -I%S/Inputs/merge-using-decls -verify -std=c++98 %s -DORDER=1
 
 #if ORDER == 1
 #include "a.h"


### PR DESCRIPTION
Use delegate() there. To fix a follow-up problem, abort when a cast ends up on a valid Pointer that isn't a base class.