### PR TITLE
[cmake] Set up llvm-ml as ASM_MASM tool in WinMsvc.cmake

### DIFF
--- a/llvm/cmake/platforms/WinMsvc.cmake
+++ b/llvm/cmake/platforms/WinMsvc.cmake
@@ -240,6 +240,7 @@ set(CMAKE_C_COMPILER "${LLVM_NATIVE_TOOLCHAIN}/bin/clang-cl" CACHE FILEPATH "")
 set(CMAKE_CXX_COMPILER "${LLVM_NATIVE_TOOLCHAIN}/bin/clang-cl" CACHE FILEPATH "")
 set(CMAKE_LINKER "${LLVM_NATIVE_TOOLCHAIN}/bin/lld-link" CACHE FILEPATH "")
 set(CMAKE_AR "${LLVM_NATIVE_TOOLCHAIN}/bin/llvm-lib" CACHE FILEPATH "")
+set(CMAKE_ASM_MASM_COMPILER "${LLVM_NATIVE_TOOLCHAIN}/bin/llvm-ml" CACHE FILEPATH "")
 
 # Even though we're cross-compiling, we need some native tools (e.g. llvm-tblgen), and those
 # native tools have to be built before we can start doing the cross-build.  LLVM supports
@@ -275,6 +276,9 @@ endif()
 string(REPLACE ";" " " COMPILE_FLAGS "${COMPILE_FLAGS}")
 string(APPEND CMAKE_C_FLAGS_INIT " ${COMPILE_FLAGS}")
 string(APPEND CMAKE_CXX_FLAGS_INIT " ${COMPILE_FLAGS}")
+if(TRIPLE_ARCH STREQUAL "x86_64")
+  string(APPEND CMAKE_ASM_MASM_FLAGS_INIT " -m64")
+endif()
 
 set(LINK_FLAGS
     # Prevent CMake from attempting to invoke mt.exe. It only recognizes the slashed form and not the dashed form.


### PR DESCRIPTION
Nowadays, an ASM_MASM tool is required for building the BLAKE3 assembly in llvm/lib/Support - the llvm-ml tool can do this.