### PR TITLE
[sanitizer_common] Make sanitizer_linux.cpp kernel_stat* handling Lin…

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -35,7 +35,7 @@
 // access stat from asm/stat.h, without conflicting with definition in
 // sys/stat.h, we use this trick.  sparc64 is similar, using
 // syscall(__NR_stat64) and struct kernel_stat64.
-#  if SANITIZER_MIPS64 || SANITIZER_SPARC64
+#  if SANITIZER_LINUX && (SANITIZER_MIPS64 || SANITIZER_SPARC64)
 #    include <asm/unistd.h>
 #    include <sys/types.h>
 #    define stat kernel_stat


### PR DESCRIPTION
…ux-specific

fcd6bd5587cc376cd8f43b60d1c7d61fdfe0f535 broke the Solaris/sparcv9 buildbot:
```
compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:39:14: fatal error: 'asm/unistd.h' file not found
   39 | #    include <asm/unistd.h>
      |              ^~~~~~~~~~~~~~
```
That section should have been Linux-specific in the first place, which is what this patch does.

Tested on sparcv9-sun-solaris2.11.

(cherry picked from commit 16e9bb9cd7f50ae2ec7f29a80bc3b95f528bfdbf)