### PR TITLE
[lldb][Windows] Fixed the API test breakpoint_with_realpath_and_source_map

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/breakpoint_with_realpath_and_source_map/TestBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_with_realpath_and_source_map/TestBreakpoint.py
@@ -32,6 +32,7 @@ class BreakpointTestCase(TestBase):
         self.assertTrue(target, VALID_TARGET)
 
     @skipIf(oslist=["windows"])
+    @skipIf(hostoslist=["windows"])
     def test_file_line_breakpoint_realpath_and_source_map(self):
         """Test file/line breakpoint with realpathing and source-mapping."""
         self.buildAndCreateTarget()


### PR DESCRIPTION
This test is already disabled for Windows because of symlinks. Disable it for cross build on Windows host too.