### PR TITLE
[MLIR][EmitC] Allow ptrdiff_t as result in sub op

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -895,7 +895,7 @@ def EmitC_SubOp : EmitC_BinaryOp<"sub", [CExpression]> {
     %0 = emitc.sub %arg0, %arg1 : (i32, i32) -> i32
     %1 = emitc.sub %arg2, %arg3 : (!emitc.ptr<f32>, i32) -> !emitc.ptr<f32>
     %2 = emitc.sub %arg4, %arg5 : (!emitc.ptr<i32>, !emitc.ptr<i32>)
-        -> !emitc.opaque<"ptrdiff_t">
+        -> !emitc.ptrdiff_t
     ```
     ```c++
     // Code emitted for the operations above.

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -798,9 +798,9 @@ LogicalResult SubOp::verify() {
                        "type if lhs is a pointer");
 
   if (isa<emitc::PointerType>(lhsType) && isa<emitc::PointerType>(rhsType) &&
-      !isa<IntegerType, emitc::OpaqueType>(resultType))
-    return emitOpError("requires that the result is an integer or of opaque "
-                       "type if lhs and rhs are pointers");
+      !isa<IntegerType, emitc::PtrDiffTType, emitc::OpaqueType>(resultType))
+    return emitOpError("requires that the result is an integer, ptrdiff_t or "
+                       "of opaque type if lhs and rhs are pointers");
   return success();
 }
 

--- a/mlir/test/Dialect/EmitC/invalid_ops.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_ops.mlir
@@ -219,7 +219,7 @@ func.func @sub_pointer_float(%arg0: !emitc.ptr<f32>, %arg1: f32) {
 // -----
 
 func.func @sub_pointer_pointer(%arg0: !emitc.ptr<f32>, %arg1: !emitc.ptr<f32>) {
-    // expected-error @+1 {{'emitc.sub' op requires that the result is an integer or of opaque type if lhs and rhs are pointers}}
+    // expected-error @+1 {{'emitc.sub' op requires that the result is an integer, ptrdiff_t or of opaque type if lhs and rhs are pointers}}
     %1 = "emitc.sub" (%arg0, %arg1) : (!emitc.ptr<f32>, !emitc.ptr<f32>) -> !emitc.ptr<f32>
     return
 }

--- a/mlir/test/Dialect/EmitC/ops.mlir
+++ b/mlir/test/Dialect/EmitC/ops.mlir
@@ -114,6 +114,7 @@ func.func @sub_pointer(%arg0: !emitc.ptr<f32>, %arg1: i32, %arg2: !emitc.opaque<
   %2 = "emitc.sub" (%arg0, %arg2) : (!emitc.ptr<f32>, !emitc.opaque<"unsigned int">) -> !emitc.ptr<f32>
   %3 = "emitc.sub" (%arg0, %arg3) : (!emitc.ptr<f32>, !emitc.ptr<f32>) -> !emitc.opaque<"ptrdiff_t">
   %4 = "emitc.sub" (%arg0, %arg3) : (!emitc.ptr<f32>, !emitc.ptr<f32>) -> i32
+  %5 = "emitc.sub" (%arg0, %arg3) : (!emitc.ptr<f32>, !emitc.ptr<f32>) -> !emitc.ptrdiff_t
   return
 }
 


### PR DESCRIPTION
This explicitly allows the `emitc.ptrdiff_t` type for the result of substrating two pointers and changes the example accordingly.