### PR TITLE
[RISCV] Mark symbols used in inline asm for relocations as referenced

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -396,6 +396,15 @@ bool RISCVAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
     OS << MCO.getImm();
   else if (Offset.isGlobal() || Offset.isBlockAddress() || Offset.isMCSymbol())
     OS << *MCO.getExpr();
+
+  if (Offset.isMCSymbol())
+    MMI->getContext().registerInlineAsmLabel(Offset.getMCSymbol());
+  if (Offset.isBlockAddress()) {
+    const BlockAddress *BA = Offset.getBlockAddress();
+    MCSymbol *Sym = GetBlockAddressSymbol(BA);
+    MMI->getContext().registerInlineAsmLabel(Sym);
+  }
+
   OS << "(" << RISCVInstPrinter::getRegisterName(AddrReg.getReg()) << ")";
   return false;
 }

--- a/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
+++ b/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
@@ -129,41 +129,23 @@ define void @constraint_m_with_global_1() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_global_1:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi0)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_m_with_global_1:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi0:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi0)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_global_1:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi0)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_global_1:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi00)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_global_1:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi00)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_m_with_global_1:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi0:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi0)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) @eg)
   ret void
 }
@@ -185,41 +167,23 @@ define void @constraint_m_with_global_2() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_global_2:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi1:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi1)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_m_with_global_2:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi1:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi1)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_global_2:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi1:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi1)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_global_2:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi1:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi110)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_global_2:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi1:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi110)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_m_with_global_2:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi1:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi1)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 1))
   ret void
 }
@@ -241,41 +205,23 @@ define void @constraint_m_with_global_3() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_global_3:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi2:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi2)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_m_with_global_3:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi2:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi2)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_global_3:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi2:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi2)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_global_3:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi2:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi210)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_global_3:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi2:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi210)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_m_with_global_3:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi2:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi2)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 2000))
   ret void
 }
@@ -407,89 +353,47 @@ define void @constraint_m_with_extern_weak_global_3() nounwind {
 }
 
 define void @constraint_m_with_local_1() nounwind {
-; RV32I-NO-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV32I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-NO-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp0)
-; RV32I-NO-INTEGRATED-NEXT:    #APP
-; RV32I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp0)(a0)
-; RV32I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-NO-INTEGRATED-NEXT:    ret
+; RV32I-LABEL: constraint_m_with_local_1:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp0: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp0)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp0)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
 ;
-; RV64I-NO-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV64I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-NO-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp0)
-; RV64I-NO-INTEGRATED-NEXT:    #APP
-; RV64I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp0)(a0)
-; RV64I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-NO-INTEGRATED-NEXT:    ret
+; RV64I-LABEL: constraint_m_with_local_1:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp0: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp0)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp0)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi6:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi6)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_m_with_local_1:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp0: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi6:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi6)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi6:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi6)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV32I-INTEGRATED:       # %bb.0: # %entry
-; RV32I-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV32I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp0)
-; RV32I-INTEGRATED-NEXT:    #APP
-; RV32I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp00)(a0)
-; RV32I-INTEGRATED-NEXT:    #NO_APP
-; RV32I-INTEGRATED-NEXT:    ret
-;
-; RV64I-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV64I-INTEGRATED:       # %bb.0: # %entry
-; RV64I-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV64I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp0)
-; RV64I-INTEGRATED-NEXT:    #APP
-; RV64I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp00)(a0)
-; RV64I-INTEGRATED-NEXT:    #NO_APP
-; RV64I-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi6:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi60)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_local_1:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Ltmp0: # Block address taken
-; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi6:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi60)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_m_with_local_1:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp0: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi6:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi6)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
 entry:
   br label %label
 
@@ -499,89 +403,47 @@ label:
 }
 
 define void @constraint_m_with_local_2() nounwind {
-; RV32I-NO-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV32I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-NO-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp1+4)
-; RV32I-NO-INTEGRATED-NEXT:    #APP
-; RV32I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp1+4)(a0)
-; RV32I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-NO-INTEGRATED-NEXT:    ret
+; RV32I-LABEL: constraint_m_with_local_2:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp1: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp1+4)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp1+4)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
 ;
-; RV64I-NO-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV64I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-NO-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp1+4)
-; RV64I-NO-INTEGRATED-NEXT:    #APP
-; RV64I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp1+4)(a0)
-; RV64I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-NO-INTEGRATED-NEXT:    ret
+; RV64I-LABEL: constraint_m_with_local_2:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp1: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp1+4)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp1+4)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi7:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi7)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_m_with_local_2:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp1: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi7:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi7)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi7:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi7)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV32I-INTEGRATED:       # %bb.0: # %entry
-; RV32I-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV32I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp1+4)
-; RV32I-INTEGRATED-NEXT:    #APP
-; RV32I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp10+4)(a0)
-; RV32I-INTEGRATED-NEXT:    #NO_APP
-; RV32I-INTEGRATED-NEXT:    ret
-;
-; RV64I-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV64I-INTEGRATED:       # %bb.0: # %entry
-; RV64I-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV64I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp1+4)
-; RV64I-INTEGRATED-NEXT:    #APP
-; RV64I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp10+4)(a0)
-; RV64I-INTEGRATED-NEXT:    #NO_APP
-; RV64I-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi7:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi70)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_local_2:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Ltmp1: # Block address taken
-; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi7:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi70)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_m_with_local_2:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp1: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi7:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1+4)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi7)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
 entry:
   br label %label
 
@@ -591,89 +453,47 @@ label:
 }
 
 define void @constraint_m_with_local_3() nounwind {
-; RV32I-NO-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV32I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-NO-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp2+2000)
-; RV32I-NO-INTEGRATED-NEXT:    #APP
-; RV32I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp2+2000)(a0)
-; RV32I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-NO-INTEGRATED-NEXT:    ret
+; RV32I-LABEL: constraint_m_with_local_3:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp2: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp2+2000)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp2+2000)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
 ;
-; RV64I-NO-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV64I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-NO-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp2+2000)
-; RV64I-NO-INTEGRATED-NEXT:    #APP
-; RV64I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp2+2000)(a0)
-; RV64I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-NO-INTEGRATED-NEXT:    ret
+; RV64I-LABEL: constraint_m_with_local_3:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp2: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp2+2000)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp2+2000)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi8:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi8)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_m_with_local_3:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp2: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi8:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi8)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi8:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi8)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV32I-INTEGRATED:       # %bb.0: # %entry
-; RV32I-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV32I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp2+2000)
-; RV32I-INTEGRATED-NEXT:    #APP
-; RV32I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp20+2000)(a0)
-; RV32I-INTEGRATED-NEXT:    #NO_APP
-; RV32I-INTEGRATED-NEXT:    ret
-;
-; RV64I-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV64I-INTEGRATED:       # %bb.0: # %entry
-; RV64I-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV64I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp2+2000)
-; RV64I-INTEGRATED-NEXT:    #APP
-; RV64I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp20+2000)(a0)
-; RV64I-INTEGRATED-NEXT:    #NO_APP
-; RV64I-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi8:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi80)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_local_3:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Ltmp2: # Block address taken
-; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi8:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi80)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_m_with_local_3:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp2: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi8:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2+2000)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi8)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
 entry:
   br label %label
 
@@ -740,8 +560,8 @@ define void @constraint_m_with_multi_operands() nounwind {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi9:
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi90)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi90)(a0)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi9)(a0)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi9)(a0)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
 ;
@@ -750,8 +570,8 @@ define void @constraint_m_with_multi_operands() nounwind {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi9:
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi90)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi90)(a0)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi9)(a0)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi9)(a0)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
   call void asm "sw zero, $0; sw zero, $1", "=*m,=*m"(ptr elementtype(i32) @eg, ptr elementtype(i32) @eg)
@@ -781,53 +601,29 @@ define void @constraint_m_with_multi_asm() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_multi_asm:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi10:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_m_with_multi_asm:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi10:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_m_with_multi_asm:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi10:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_multi_asm:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi10:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi100)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi100)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_m_with_multi_asm:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi10:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi100)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi100)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_m_with_multi_asm:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi10:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi10)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) @eg)
   call void asm "sw zero, $0", "=*m"(ptr elementtype(i32) @eg)
   ret void
@@ -935,8 +731,8 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi11:
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi111)(a1)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi111)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi11)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi11)(a1)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB14_2
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
@@ -953,8 +749,8 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi11:
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi111)(a1)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi111)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi11)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi11)(a1)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB14_2
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
@@ -1101,12 +897,12 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi12:
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi120)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB15_3
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi120)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB15_3
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
@@ -1123,12 +919,12 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi12:
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi120)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB15_3
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi120)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi12)(a1)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB15_3
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
@@ -1262,41 +1058,23 @@ define void @constraint_o_with_global_1() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_global_1:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi13:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi13)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_o_with_global_1:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi13:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi13)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_global_1:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi13:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi13)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_global_1:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi13:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi130)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_global_1:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi13:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi130)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_o_with_global_1:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi13:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi13)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) @eg)
   ret void
 }
@@ -1318,41 +1096,23 @@ define void @constraint_o_with_global_2() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_global_2:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi14:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi14)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_o_with_global_2:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi14:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi14)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_global_2:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi14:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi14)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_global_2:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi14:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi140)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_global_2:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi14:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+4)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi140)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_o_with_global_2:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi14:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+4)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi14)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 1))
   ret void
 }
@@ -1374,41 +1134,23 @@ define void @constraint_o_with_global_3() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_global_3:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi15:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi15)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_o_with_global_3:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi15:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi15)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_global_3:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi15:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi15)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_global_3:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi15:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi150)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_global_3:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi15:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi150)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_o_with_global_3:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi15:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi15)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) getelementptr ([400000 x i32], ptr @eg, i32 0, i32 2000))
   ret void
 }
@@ -1562,53 +1304,29 @@ define void @constraint_o_with_multi_asm() nounwind {
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_multi_asm:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi19:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_o_with_multi_asm:
+; RV32I-MEDIUM:       # %bb.0:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi19:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_multi_asm:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi19:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_multi_asm:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi19:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi190)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi190)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_multi_asm:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0:
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi19:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi190)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi190)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_o_with_multi_asm:
+; RV64I-MEDIUM:       # %bb.0:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi19:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi19)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) @eg)
   call void asm "sw zero, $0", "=*o"(ptr elementtype(i32) @eg)
   ret void
@@ -1716,8 +1434,8 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi20:
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi200)(a1)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi200)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a1)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB26_2
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
@@ -1734,8 +1452,8 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi20:
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi200)(a1)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi200)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi20)(a1)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB26_2
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal
@@ -1882,12 +1600,12 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi21:
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi211)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi21)(a1)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB27_3
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal0
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi211)(a1)
+; RV32I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi21)(a1)
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB27_3
 ; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
@@ -1904,12 +1622,12 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi21:
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a1, %pcrel_hi(eg)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi211)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi21)(a1)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB27_3
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %normal0
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi211)(a1)
+; RV64I-MEDIUM-INTEGRATED-NEXT:    sw zero, %pcrel_lo(.Lpcrel_hi21)(a1)
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    beqz a0, .LBB27_3
 ; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
 ; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.2: # %normal1
@@ -1934,89 +1652,47 @@ fail:
 }
 
 define void @constraint_o_with_local_1() nounwind {
-; RV32I-NO-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV32I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-NO-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp3)
-; RV32I-NO-INTEGRATED-NEXT:    #APP
-; RV32I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp3)(a0)
-; RV32I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-NO-INTEGRATED-NEXT:    ret
+; RV32I-LABEL: constraint_o_with_local_1:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp3: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp3)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp3)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
 ;
-; RV64I-NO-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV64I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-NO-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp3)
-; RV64I-NO-INTEGRATED-NEXT:    #APP
-; RV64I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp3)(a0)
-; RV64I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-NO-INTEGRATED-NEXT:    ret
+; RV64I-LABEL: constraint_o_with_local_1:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp3: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp3)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp3)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi22:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi22)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_o_with_local_1:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp3: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi22:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi22)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi22:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi22)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV32I-INTEGRATED:       # %bb.0: # %entry
-; RV32I-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV32I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp3)
-; RV32I-INTEGRATED-NEXT:    #APP
-; RV32I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp30)(a0)
-; RV32I-INTEGRATED-NEXT:    #NO_APP
-; RV32I-INTEGRATED-NEXT:    ret
-;
-; RV64I-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV64I-INTEGRATED:       # %bb.0: # %entry
-; RV64I-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV64I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp3)
-; RV64I-INTEGRATED-NEXT:    #APP
-; RV64I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp30)(a0)
-; RV64I-INTEGRATED-NEXT:    #NO_APP
-; RV64I-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi22:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi220)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_local_1:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Ltmp3: # Block address taken
-; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi22:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi220)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_o_with_local_1:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp3: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi22:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi22)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
 entry:
   br label %label
 
@@ -2026,89 +1702,47 @@ label:
 }
 
 define void @constraint_o_with_local_2() nounwind {
-; RV32I-NO-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV32I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-NO-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp4+4)
-; RV32I-NO-INTEGRATED-NEXT:    #APP
-; RV32I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp4+4)(a0)
-; RV32I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-NO-INTEGRATED-NEXT:    ret
+; RV32I-LABEL: constraint_o_with_local_2:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp4: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp4+4)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp4+4)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
 ;
-; RV64I-NO-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV64I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-NO-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp4+4)
-; RV64I-NO-INTEGRATED-NEXT:    #APP
-; RV64I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp4+4)(a0)
-; RV64I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-NO-INTEGRATED-NEXT:    ret
+; RV64I-LABEL: constraint_o_with_local_2:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp4: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp4+4)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp4+4)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi23:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi23)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_o_with_local_2:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp4: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi23:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi23)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi23:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi23)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV32I-INTEGRATED:       # %bb.0: # %entry
-; RV32I-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV32I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp4+4)
-; RV32I-INTEGRATED-NEXT:    #APP
-; RV32I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp40+4)(a0)
-; RV32I-INTEGRATED-NEXT:    #NO_APP
-; RV32I-INTEGRATED-NEXT:    ret
-;
-; RV64I-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV64I-INTEGRATED:       # %bb.0: # %entry
-; RV64I-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV64I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp4+4)
-; RV64I-INTEGRATED-NEXT:    #APP
-; RV64I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp40+4)(a0)
-; RV64I-INTEGRATED-NEXT:    #NO_APP
-; RV64I-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi23:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi230)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_local_2:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Ltmp4: # Block address taken
-; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi23:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi230)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_o_with_local_2:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp4: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi23:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4+4)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi23)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
 entry:
   br label %label
 
@@ -2118,89 +1752,47 @@ label:
 }
 
 define void @constraint_o_with_local_3() nounwind {
-; RV32I-NO-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV32I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-NO-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV32I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp5+2000)
-; RV32I-NO-INTEGRATED-NEXT:    #APP
-; RV32I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp5+2000)(a0)
-; RV32I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-NO-INTEGRATED-NEXT:    ret
+; RV32I-LABEL: constraint_o_with_local_3:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp5: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp5+2000)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp5+2000)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
 ;
-; RV64I-NO-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV64I-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-NO-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV64I-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-NO-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp5+2000)
-; RV64I-NO-INTEGRATED-NEXT:    #APP
-; RV64I-NO-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp5+2000)(a0)
-; RV64I-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-NO-INTEGRATED-NEXT:    ret
+; RV64I-LABEL: constraint_o_with_local_3:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp5: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp5+2000)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp5+2000)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
 ;
-; RV32I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV32I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi24:
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi24)(a0)
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-NO-INTEGRATED-NEXT:    ret
+; RV32I-MEDIUM-LABEL: constraint_o_with_local_3:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp5: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi24:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi24)(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
 ;
-; RV64I-MEDIUM-NO-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV64I-MEDIUM-NO-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:  .Lpcrel_hi24:
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi24)(a0)
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-NO-INTEGRATED-NEXT:    ret
-;
-; RV32I-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV32I-INTEGRATED:       # %bb.0: # %entry
-; RV32I-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV32I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp5+2000)
-; RV32I-INTEGRATED-NEXT:    #APP
-; RV32I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp50+2000)(a0)
-; RV32I-INTEGRATED-NEXT:    #NO_APP
-; RV32I-INTEGRATED-NEXT:    ret
-;
-; RV64I-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV64I-INTEGRATED:       # %bb.0: # %entry
-; RV64I-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV64I-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-INTEGRATED-NEXT:    lui a0, %hi(.Ltmp5+2000)
-; RV64I-INTEGRATED-NEXT:    #APP
-; RV64I-INTEGRATED-NEXT:    lw zero, %lo(.Ltmp50+2000)(a0)
-; RV64I-INTEGRATED-NEXT:    #NO_APP
-; RV64I-INTEGRATED-NEXT:    ret
-;
-; RV32I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV32I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV32I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV32I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi24:
-; RV32I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi240)(a0)
-; RV32I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV32I-MEDIUM-INTEGRATED-NEXT:    ret
-;
-; RV64I-MEDIUM-INTEGRATED-LABEL: constraint_o_with_local_3:
-; RV64I-MEDIUM-INTEGRATED:       # %bb.0: # %entry
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Ltmp5: # Block address taken
-; RV64I-MEDIUM-INTEGRATED-NEXT:  # %bb.1: # %label
-; RV64I-MEDIUM-INTEGRATED-NEXT:  .Lpcrel_hi24:
-; RV64I-MEDIUM-INTEGRATED-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi240)(a0)
-; RV64I-MEDIUM-INTEGRATED-NEXT:    #NO_APP
-; RV64I-MEDIUM-INTEGRATED-NEXT:    ret
+; RV64I-MEDIUM-LABEL: constraint_o_with_local_3:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp5: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi24:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5+2000)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, %pcrel_lo(.Lpcrel_hi24)(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
 entry:
   br label %label
 


### PR DESCRIPTION
Commit 5cd8d53cac00f taught RISCVMergeBaseOffset to handle inline asm, however
there is at least one case uncovered for integrated as.

In the example below compiler generates pcrel relocation (mcmodel=medany)
```
    volatile double double_val = 1.0;
    void foo() {
        asm volatile("fld f0, %0 \n\t" : : "m"(double_val) : "memory");
    }
```

And fails with the folliwng error
```
    error: could not find corresponding %pcrel_hi
          |       "fld f0, %0 \n\t"
    <inline asm>:1:2: note: instantiated into assembly here
          |         fld f0, %pcrel_lo(.Lpcrel_hi0)(a0)
```

After transformations MachineFunction contains inline asm instructions with
'.Lpcrel_hi0' symbol that is not defined in inline asm, but referenced.
```
   ... = AUIPC ...(riscv-pcrel-hi) @double_val, pre-instr-symbol <mcsymbol .Lpcrel_hi0>
   INLINEASM &"fld f0, $0 \0A\09" ... target-flags(riscv-pcrel-lo) <mcsymbol .Lpcrel_hi0>
```

So, when AsmParser processes 'fld', it has to create a new symbol as
'.Lpcrel_hi0' already exists but not known to be referenced in inline asm.
AsmParser avoids conflicts by renaming referenced by 'fld' symbol with
'.Lpcrel_hi00' name which does not exist. Resulting erroneous asm
```
    .Lpcrel_hi0:
        auipc   a0, %pcrel_hi(double_val)
        #APP
        fld     ft0, %pcrel_lo(.Lpcrel_hi00)(a0)
```

This change adds symbols used in memory operands to the list of referenced ones.

Godbolt link: https://godbolt.org/z/aqrrsWKoK -- on the left you can find incorrect labels for the integrated-as and on the right an error when compiling to the binary object.

Note that I change tests in the first commit and the second commit shows the real difference after the fix.
