### PR TITLE
[lld][WebAssembly] Report unsupported PIC relocations as errors

### DIFF
--- a/lld/test/wasm/unsupported-pic-relocations.s
+++ b/lld/test/wasm/unsupported-pic-relocations.s
@@ -1,0 +1,47 @@
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
+
+# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=report-all 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --warn-unresolved-symbols 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=ignore-all 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
+# RUN:   FileCheck %s
+
+.globaltype __memory_base, i32, immutable
+.globaltype	__table_base, i32, immutable
+
+.functype external_func () -> ()
+
+call_undefined_function:
+    .functype call_undefined_function () -> ()
+    global.get  __table_base
+    i32.const external_func@TBREL
+    # CHECK: error: {{.*}}.o: relocation R_WASM_TABLE_INDEX_REL_SLEB is not supported against an undefined symbol `external_func`
+    i32.add
+    call_indirect () -> ()
+    end_function
+    
+access_undefined_data:
+    .functype access_undefined_data () -> ()
+    global.get  __memory_base
+    i32.const external_data@MBREL
+    # CHECK: error: {{.*}}.o: relocation R_WASM_MEMORY_ADDR_REL_SLEB is not supported against an undefined symbol `external_data`
+    i32.add
+    i32.load 0
+    drop
+    end_function
+
+.globl _start
+_start:
+    .functype _start () -> ()
+    call call_undefined_function
+    call access_undefined_data
+    end_function

--- a/lld/test/wasm/unsupported-pic-relocations.s
+++ b/lld/test/wasm/unsupported-pic-relocations.s
@@ -15,33 +15,25 @@
 # RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
 # RUN:   FileCheck %s
 
-.globaltype __memory_base, i32, immutable
-.globaltype	__table_base, i32, immutable
-
 .functype external_func () -> ()
 
-call_undefined_function:
-    .functype call_undefined_function () -> ()
-    global.get  __table_base
+use_undefined_function:
+    .functype use_undefined_function () -> ()
     i32.const external_func@TBREL
     # CHECK: error: {{.*}}.o: relocation R_WASM_TABLE_INDEX_REL_SLEB is not supported against an undefined symbol `external_func`
-    i32.add
-    call_indirect () -> ()
+    drop
     end_function
     
-access_undefined_data:
-    .functype access_undefined_data () -> ()
-    global.get  __memory_base
+use_undefined_data:
+    .functype use_undefined_data () -> ()
     i32.const external_data@MBREL
     # CHECK: error: {{.*}}.o: relocation R_WASM_MEMORY_ADDR_REL_SLEB is not supported against an undefined symbol `external_data`
-    i32.add
-    i32.load 0
     drop
     end_function
 
 .globl _start
 _start:
     .functype _start () -> ()
-    call call_undefined_function
-    call access_undefined_data
+    call use_undefined_function
+    call use_undefined_data
     end_function

--- a/lld/test/wasm/unsupported-pic-relocations64.s
+++ b/lld/test/wasm/unsupported-pic-relocations64.s
@@ -1,0 +1,48 @@
+# RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-unknown -o %t.o %s
+
+# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=report-all 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --warn-unresolved-symbols 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=ignore-all 2>&1 | \
+# RUN:   FileCheck %s
+
+# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
+# RUN:   FileCheck %s
+
+.globaltype __memory_base, i64, immutable
+.globaltype	__table_base, i64, immutable
+
+.functype external_func () -> ()
+
+call_undefined_function:
+    .functype call_undefined_function () -> ()
+    global.get  __table_base
+    i64.const external_func@TBREL
+    # CHECK: error: {{.*}}.o: relocation R_WASM_TABLE_INDEX_REL_SLEB64 is not supported against an undefined symbol `external_func`
+    i64.add
+    i32.wrap_i64 # Remove when table64 is supported
+    call_indirect () -> ()
+    end_function
+    
+access_undefined_data:
+    .functype access_undefined_data () -> ()
+    global.get  __memory_base
+    i64.const external_data@MBREL
+    # CHECK: error: {{.*}}.o: relocation R_WASM_MEMORY_ADDR_REL_SLEB64 is not supported against an undefined symbol `external_data`
+    i64.add
+    i64.load 0
+    drop
+    end_function
+
+.globl _start
+_start:
+    .functype _start () -> ()
+    call call_undefined_function
+    call access_undefined_data
+    end_function

--- a/lld/test/wasm/unsupported-pic-relocations64.s
+++ b/lld/test/wasm/unsupported-pic-relocations64.s
@@ -15,34 +15,25 @@
 # RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
 # RUN:   FileCheck %s
 
-.globaltype __memory_base, i64, immutable
-.globaltype	__table_base, i64, immutable
-
 .functype external_func () -> ()
 
-call_undefined_function:
-    .functype call_undefined_function () -> ()
-    global.get  __table_base
+use_undefined_function:
+    .functype use_undefined_function () -> ()
     i64.const external_func@TBREL
     # CHECK: error: {{.*}}.o: relocation R_WASM_TABLE_INDEX_REL_SLEB64 is not supported against an undefined symbol `external_func`
-    i64.add
-    i32.wrap_i64 # Remove when table64 is supported
-    call_indirect () -> ()
+    drop
     end_function
     
-access_undefined_data:
-    .functype access_undefined_data () -> ()
-    global.get  __memory_base
+use_undefined_data:
+    .functype use_undefined_data () -> ()
     i64.const external_data@MBREL
     # CHECK: error: {{.*}}.o: relocation R_WASM_MEMORY_ADDR_REL_SLEB64 is not supported against an undefined symbol `external_data`
-    i64.add
-    i64.load 0
     drop
     end_function
 
 .globl _start
 _start:
     .functype _start () -> ()
-    call call_undefined_function
-    call access_undefined_data
+    call use_undefined_function
+    call use_undefined_data
     end_function

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -179,9 +179,9 @@ void scanRelocations(InputChunk *chunk) {
       case R_WASM_TABLE_INDEX_REL_SLEB64:
       case R_WASM_MEMORY_ADDR_REL_SLEB:
       case R_WASM_MEMORY_ADDR_REL_SLEB64:
-        // These relocation types are only present in the code section and
-        // are not supported for undefined symbols. It would require replacing
-        // the constant by using a GOT global.
+        // These relocation types are for symbols that exists relative to
+        // `__memory_base` or `__table_base` and as such only make sense for
+        // defined symbols.
         error(toString(file) + ": relocation " + relocTypeToString(reloc.Type) +
               " is not supported against an undefined symbol `" +
               toString(*sym) + "`");

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -170,6 +170,19 @@ void scanRelocations(InputChunk *chunk) {
         if (requiresGOTAccess(sym))
           addGOTEntry(sym);
         break;
+      case R_WASM_TABLE_INDEX_REL_SLEB:
+      case R_WASM_TABLE_INDEX_REL_SLEB64:
+      case R_WASM_MEMORY_ADDR_REL_SLEB:
+      case R_WASM_MEMORY_ADDR_REL_SLEB64:
+        // These relocation types are only present in the code section and
+        // are not supported. It would require replacing the constant by using
+        // a GOT global.
+        if (sym->isUndefined())
+          error(toString(file) + ": relocation " +
+                relocTypeToString(reloc.Type) +
+                " is not supported against an undefined symbol `" +
+                toString(*sym) + "`");
+        break;
       }
     }
 

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -170,18 +170,21 @@ void scanRelocations(InputChunk *chunk) {
         if (requiresGOTAccess(sym))
           addGOTEntry(sym);
         break;
+      }
+    }
+
+    if (sym->isUndefined()) {
+      switch (reloc.Type) {
       case R_WASM_TABLE_INDEX_REL_SLEB:
       case R_WASM_TABLE_INDEX_REL_SLEB64:
       case R_WASM_MEMORY_ADDR_REL_SLEB:
       case R_WASM_MEMORY_ADDR_REL_SLEB64:
         // These relocation types are only present in the code section and
-        // are not supported. It would require replacing the constant by using
-        // a GOT global.
-        if (sym->isUndefined())
-          error(toString(file) + ": relocation " +
-                relocTypeToString(reloc.Type) +
-                " is not supported against an undefined symbol `" +
-                toString(*sym) + "`");
+        // are not supported for undefined symbols. It would require replacing
+        // the constant by using a GOT global.
+        error(toString(file) + ": relocation " + relocTypeToString(reloc.Type) +
+              " is not supported against an undefined symbol `" +
+              toString(*sym) + "`");
         break;
       }
     }


### PR DESCRIPTION
`WASM_MEMORY_ADDR_REL_` and `WASM_TABLE_INDEX_REL_` relocations against **undefined symbols** are not supported and, except for `UnresolvedPolicy::ReportError`, lead to incorrect Wasm code, such as invalid data address or invalid table index that cannot be patched during later dynamic Wasm linking with modules declaring those symbols. This is different to other relocations that support undefined symbols by declaring correspond Wasm imports.

For more robust behavior, `wasm-ld` should probably report an error for such unsupported PIC relocations, independent of the `UnresolvedPolicy`.
