### PR TITLE
Don't compile in unsupported assembly symbols

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/sme-libc-mem-routines.S
+++ b/compiler-rt/lib/builtins/aarch64/sme-libc-mem-routines.S
@@ -54,6 +54,8 @@
    The loop tail is handled by always copying 64 bytes from the end.
 */
 
+.arch armv8+fp+simd
+
 DEFINE_COMPILERRT_OUTLINE_FUNCTION_UNMANGLED(__arm_sc_memcpy)
         add     srcend1, src, count
         add     dstend1, dstin, count


### PR DESCRIPTION
sme-libc-mem-routines.S contains instructions like "fmov d0, x1" or "mov
x1, v0.D[0]" that require architecture to support armv8 fp and neon.
