### PR TITLE
[mlir][tablegen] Fix tablegen bug with `Complex` class

### DIFF
--- a/mlir/include/mlir/IR/CommonTypeConstraints.td
+++ b/mlir/include/mlir/IR/CommonTypeConstraints.td
@@ -348,16 +348,16 @@ def F8E3M4 : Type<CPred<"$_self.isFloat8E3M4()">, "f8E3M4 type">,
 def AnyComplex : Type<CPred<"::llvm::isa<::mlir::ComplexType>($_self)">,
                       "complex-type", "::mlir::ComplexType">;
 
-class Complex<Type type>
+class Complex<Type elType>
     : ConfinedType<AnyComplex, [
           SubstLeaves<"$_self",
                       "::llvm::cast<::mlir::ComplexType>($_self).getElementType()",
-           type.predicate>],
-           "complex type with " # type.summary # " elements",
+           elType.predicate>],
+           "complex type with " # elType.summary # " elements",
            "::mlir::ComplexType">,
-      SameBuildabilityAs<type, "::mlir::ComplexType::get($_builder.get" # type #
+      SameBuildabilityAs<elType, "::mlir::ComplexType::get($_builder.get" # elType #
                                "Type())"> {
-  Type elementType = type;
+  Type elementType = elType;
 }
 
 class OpaqueType<string dialect, string name, string summary>


### PR DESCRIPTION
The `Complex` class in tablegen tries to store its element type, but due to a name collision it actually ends up storing the `type` field of the `ConfinedType` superclass, and so `elementType` is always set to `AnyComplex`.

This renames the field so that it gets correctly set.

@math-fehr 