### PR TITLE
[TableGen] Refactor SequenceToOffsetTable class

### DIFF
--- a/llvm/utils/TableGen/Basic/SequenceToOffsetTable.h
+++ b/llvm/utils/TableGen/Basic/SequenceToOffsetTable.h
@@ -15,20 +15,20 @@
 #ifndef LLVM_UTILS_TABLEGEN_BASIC_SEQUENCETOOFFSETTABLE_H
 #define LLVM_UTILS_TABLEGEN_BASIC_SEQUENCETOOFFSETTABLE_H
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
-#include <cctype>
 #include <functional>
 #include <map>
 
 namespace llvm {
-extern llvm::cl::opt<bool> EmitLongStrLiterals;
+extern cl::opt<bool> EmitLongStrLiterals;
 
-static inline void printChar(raw_ostream &OS, char C) {
+inline void printChar(raw_ostream &OS, char C) {
   unsigned char UC(C);
-  if (isalnum(UC) || ispunct(UC)) {
+  if (isAlnum(UC) || isPunct(UC)) {
     OS << '\'';
     if (C == '\\' || C == '\'')
       OS << '\\';
@@ -126,7 +126,7 @@ public:
   /// initializer, where each element is a C string literal terminated by
   /// `\0`. Falls back to emitting a comma-separated integer list if
   /// `EmitLongStrLiterals` is false
-  void emitStringLiteralDef(raw_ostream &OS, const llvm::Twine &Decl) const {
+  void emitStringLiteralDef(raw_ostream &OS, const Twine &Decl) const {
     assert(Entries && "Call layout() before emitStringLiteralDef()");
     if (!EmitLongStrLiterals) {
       OS << Decl << " = {\n";
@@ -140,9 +140,9 @@ public:
        << "#pragma GCC diagnostic ignored \"-Woverlength-strings\"\n"
        << "#endif\n"
        << Decl << " = {\n";
-    for (auto I : Seqs) {
-      OS << "  /* " << I.second << " */ \"";
-      OS.write_escaped(I.first);
+    for (const auto &[Seq, Offset] : Seqs) {
+      OS << "  /* " << Offset << " */ \"";
+      OS.write_escaped(Seq);
       OS << "\\0\"\n";
     }
     OS << "};\n"
@@ -156,13 +156,10 @@ public:
   void emit(raw_ostream &OS, void (*Print)(raw_ostream &, ElemT),
             const char *Term = "0") const {
     assert((empty() || Entries) && "Call layout() before emit()");
-    for (typename SeqMap::const_iterator I = Seqs.begin(), E = Seqs.end();
-         I != E; ++I) {
-      OS << "  /* " << I->second << " */ ";
-      for (typename SeqT::const_iterator SI = I->first.begin(),
-                                         SE = I->first.end();
-           SI != SE; ++SI) {
-        Print(OS, *SI);
+    for (const auto &[Seq, Offset] : Seqs) {
+      OS << "  /* " << Offset << " */ ";
+      for (const ElemT &Element : Seq) {
+        Print(OS, Element);
         OS << ", ";
       }
       OS << Term << ",\n";


### PR DESCRIPTION
- Replace use of std::isalnum/ispunct with StringExtras version to avoid possibly locale dependent behavior.
- Remove `static` from printChar (do its deduplicated when linking).
- Use range based for loops and structured bindings.
- No need to use `llvm::` for code in llvm namespace.