### PR TITLE
[lldb] Disable the API test TestCppBitfields on Windows

### DIFF
--- a/lldb/test/API/lang/cpp/bitfields/TestCppBitfields.py
+++ b/lldb/test/API/lang/cpp/bitfields/TestCppBitfields.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 
 class CppBitfieldsTestCase(TestBase):
     @no_debug_info_test
+    @skipIf(oslist=["windows"], bugnumber="github.com/llvm/llvm-project/issues/105019")
     def test_bitfields(self):
         self.build()
         lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
This test causes the assert in clang CodeGen and python crashes with the error code 0x80000003. See #105019 for more details. Note the similar test lldb/test/API/lang/c/bitfields/TestBitfields.py is already disabled on Windows.