### PR TITLE
Fix a warning for -Wcovered-switch-default

### DIFF
--- a/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
+++ b/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
@@ -346,8 +346,6 @@ int llvm_cgdata_main(int argc, char **argvNonConst, const llvm::ToolContext &) {
     return merge_main(argc, argv);
   case CGDataAction::Show:
     return show_main(argc, argv);
-  default:
-    llvm_unreachable("unrecognized action");
   }
 
   return 1;


### PR DESCRIPTION
This fixes a build break from [llvm/llvm-project] Reland [CGData] llvm-cgdata #89884 (PR #101461)