### PR TITLE
[IR] Verify parameters of TargetExtTypes

### DIFF
--- a/llvm/test/Verifier/target-types.ll
+++ b/llvm/test/Verifier/target-types.ll
@@ -1,0 +1,8 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: Target type should have no parameters
+; CHECK-NEXT: target("aarch64.svcount", i32, 0)
+define void @test_alloca_svcount_ptr_int() {
+  %ptr = alloca target("aarch64.svcount", i32, 0)
+  ret void
+}


### PR DESCRIPTION
This just adds a place in the IR verifier to verify that TargetExtTypes
are well formed. As a start it checks that target("aarch64.svcount")
has no (type or integer) parameters.
