### PR TITLE
[llvm][DWARFLinker] Don't attach DW_AT_dwo_id to CUs

### DIFF
--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -1412,6 +1412,12 @@ unsigned DWARFLinker::DIECloner::cloneScalarAttribute(
     unsigned AttrSize, AttributesInfo &Info) {
   uint64_t Value;
 
+  // We don't emit any skeleton CUs with dsymutil. So avoid emitting
+  // a redundant DW_AT_GNU_dwo_id on the non-skeleton CU.
+  if (AttrSpec.Attr == dwarf::DW_AT_GNU_dwo_id ||
+      AttrSpec.Attr == dwarf::DW_AT_dwo_id)
+    return 0;
+
   // Check for the offset to the macro table. If offset is incorrect then we
   // need to remove the attribute.
   if (AttrSpec.Attr == dwarf::DW_AT_macro_info) {

--- a/llvm/test/tools/dsymutil/X86/modules.m
+++ b/llvm/test/tools/dsymutil/X86/modules.m
@@ -31,6 +31,7 @@ EOF
 #ifdef BAR_H
 // ---------------------------------------------------------------------
 // CHECK:            DW_TAG_compile_unit
+// CHECK-NOT:          DW_AT_GNU_dwo_id
 // CHECK-NOT:        DW_TAG
 // CHECK:              DW_TAG_module
 // CHECK-NEXT:           DW_AT_name{{.*}}"Bar"
@@ -55,6 +56,7 @@ struct PruneMeNot;
 #ifdef FOO_H
 // ---------------------------------------------------------------------
 // CHECK:               DW_TAG_compile_unit
+// CHECK-NOT:             DW_AT_GNU_dwo_id
 // CHECK-NOT:             DW_TAG
 // CHECK: 0x0[[FOO:.*]]:  DW_TAG_module
 // CHECK-NEXT:              DW_AT_name{{.*}}"Foo"
@@ -92,8 +94,9 @@ Bar odr_violation = { 42 };
 #else
 // ---------------------------------------------------------------------
 
-// CHECK:  DW_TAG_compile_unit
-// CHECK:    DW_AT_low_pc
+// CHECK:    DW_TAG_compile_unit
+// CHECK-NOT:  DW_AT_GNU_dwo_id
+// CHECK:      DW_AT_low_pc
 // CHECK-NOT:  DW_TAG_module
 // CHECK-NOT:  DW_TAG_typedef
 //
@@ -130,8 +133,9 @@ int main(int argc, char **argv) {
 #endif
 #endif
 
-// CHECK: DW_TAG_compile_unit
-// CHECK:   DW_AT_name {{.*}}"odr_violation.c"
+// CHECK:     DW_TAG_compile_unit
+// CHECK-NOT:   DW_AT_GNU_dwo_id
+// CHECK:       DW_AT_name {{.*}}"odr_violation.c"
 // CHECK: DW_TAG_variable
 // CHECK:   DW_AT_name {{.*}}"odr_violation"
 // CHECK:   DW_AT_type [DW_FORM_ref4] ({{.*}}{0x{{0*}}[[BAR2:.*]]}


### PR DESCRIPTION
This fixes a verifier error uncovered as a result of https://github.com/llvm/llvm-project/pull/101775.

When compiling with `-gmodules`, Clang will create a skeleton CU that contains a `DW_AT_dwo_id` and a `DW_AT_dwo_name` corresponding to the path of the `.pcm` that carries the type definitions referenced in the non-skeleton CU (see the [gmodules LLDB docs](https://lldb.llvm.org/resources/extensions.html) for more details). The non-skeleton CU will also contain a `DW_AT_dwo_id` that matches that of the skeleton.

`dsymutil` effectively undoes the `-gmodules` work, replacing all the module type references with definitions. I.e., we no longer create a skeleton `.dwo` CU.

Prior to this patch `dsymutil` did not strip out the `DW_AT_dwo_id` on the non-skeleton CU. This now (since https://github.com/llvm/llvm-project/pull/101775) causes verification errors such as:
```
Verifying .debug_names...
error: Name Index @ 0x0: Entry @ 0x9a unable to load .dwo file "None"
for DWARF unit @ 0x0.
error: output verification failed for x86_64
make: *** [a.out.dSYM] Error 1
```
...because the verifier sees the DWO ID but can't find a matching `.dwo` unit.

This patch simply strips the `DW_AT_dwo_id` from the main CU.