### PR TITLE
[libc] Include startup code when installing all

### DIFF
--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -138,6 +138,5 @@ foreach(target IN LISTS startup_components)
   install(FILES $<TARGET_OBJECTS:${fq_target_name}>
           DESTINATION ${LIBC_INSTALL_LIBRARY_DIR}
           RENAME $<TARGET_PROPERTY:${fq_target_name},OUTPUT_NAME>
-          EXCLUDE_FROM_ALL
           COMPONENT libc)
 endforeach()


### PR DESCRIPTION
Previously the libc startup code was marked `EXCLUDE_FROM_ALL` due to
build issues. This patch removes that as no longer necessary.
