### PR TITLE
Avoid exposing password and token from git repositories

### DIFF
--- a/llvm/cmake/modules/VersionFromVCS.cmake
+++ b/llvm/cmake/modules/VersionFromVCS.cmake
@@ -39,8 +39,14 @@ function(get_source_info path revision repository)
         OUTPUT_VARIABLE git_output
         ERROR_QUIET)
       if(git_result EQUAL 0)
-        string(STRIP "${git_output}" git_output)
-        set(${repository} ${git_output} PARENT_SCOPE)
+        # Avoid exposing sensitive data, e.g. usernames, passwords and
+        # private URLs.
+        string(FIND "${git_output}" "github.com/llvm/llvm-project" git_upstream)
+        if(git_upstream GREATER_EQUAL 0)
+          set(${repository} "https://github.com/llvm/llvm-project" PARENT_SCOPE)
+        else()
+          set(${repository} "forked repository" PARENT_SCOPE)
+        endif()
       else()
         set(${repository} ${path} PARENT_SCOPE)
       endif()

--- a/llvm/cmake/modules/VersionFromVCS.cmake
+++ b/llvm/cmake/modules/VersionFromVCS.cmake
@@ -45,10 +45,11 @@ function(get_source_info path revision repository)
         string(REGEX MATCH "https?://[^/]*:[^/]*@.*"
           http_password "${git_output}")
         if(http_password)
-          message(SEND_ERROR "The remote URL has an embedded password. \
-Remove the password from the URL or use \
+          message(SEND_ERROR "The git remote repository URL has an embedded \
+password. Remove the password from the URL or use \
 `-DLLVM_FORCE_VC_REPOSITORY=<URL without password>` in order to avoid \
-leaking your password.")
+leaking your password (see https://git-scm.com/docs/gitcredentials for \
+alternatives).")
         endif()
         # Github token formats are described at:
         # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats
@@ -56,10 +57,10 @@ leaking your password.")
           "https?://(gh[pousr]|github_pat)_[^/]+@github.com.*"
           github_token "${git_output}")
         if(github_token)
-          message(SEND_ERROR "The remote URL has an embedded Github Token. \
-Remove the token from the URL or use \
+          message(SEND_ERROR "The git remote repository URL has an embedded \
+Github Token. Remove the token from the URL or use \
 `-DLLVM_FORCE_VC_REPOSITORY=<URL without token>` in order to avoid leaking \
-your token.")
+your token (see https://git-scm.com/docs/gitcredentials for alternatives).")
         endif()
 
         string(STRIP "${git_output}" git_output)

--- a/llvm/cmake/modules/VersionFromVCS.cmake
+++ b/llvm/cmake/modules/VersionFromVCS.cmake
@@ -51,14 +51,14 @@ password. Remove the password from the URL or use \
 leaking your password (see https://git-scm.com/docs/gitcredentials for \
 alternatives).")
         endif()
-        # Github token formats are described at:
+        # GitHub token formats are described at:
         # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats
         string(REGEX MATCH
           "https?://(gh[pousr]|github_pat)_[^/]+@github.com.*"
           github_token "${git_output}")
         if(github_token)
           message(SEND_ERROR "The git remote repository URL has an embedded \
-Github Token. Remove the token from the URL or use \
+GitHub Token. Remove the token from the URL or use \
 `-DLLVM_FORCE_VC_REPOSITORY=<URL without token>` in order to avoid leaking \
 your token (see https://git-scm.com/docs/gitcredentials for alternatives).")
         endif()

--- a/llvm/cmake/modules/VersionFromVCS.cmake
+++ b/llvm/cmake/modules/VersionFromVCS.cmake
@@ -41,11 +41,9 @@ function(get_source_info path revision repository)
       if(git_result EQUAL 0)
         # Avoid exposing sensitive data, e.g. usernames, passwords and
         # private URLs.
-        string(FIND "${git_output}" "github.com/llvm/llvm-project" git_upstream)
-        if(git_upstream GREATER_EQUAL 0)
+        string(REGEX MATCH "github.com[/:]llvm/llvm-project" git_upstream "${git_output}")
+        if(git_upstream)
           set(${repository} "https://github.com/llvm/llvm-project" PARENT_SCOPE)
-        else()
-          set(${repository} "forked repository" PARENT_SCOPE)
         endif()
       else()
         set(${repository} ${path} PARENT_SCOPE)

--- a/llvm/cmake/modules/VersionFromVCS.cmake
+++ b/llvm/cmake/modules/VersionFromVCS.cmake
@@ -39,12 +39,31 @@ function(get_source_info path revision repository)
         OUTPUT_VARIABLE git_output
         ERROR_QUIET)
       if(git_result EQUAL 0)
-        # Avoid exposing sensitive data, e.g. usernames, passwords and
-        # private URLs.
-        string(REGEX MATCH "github.com[/:]llvm/llvm-project" git_upstream "${git_output}")
-        if(git_upstream)
-          set(${repository} "https://github.com/llvm/llvm-project" PARENT_SCOPE)
+        # Passwords or tokens should not be stored in the remote URL at the
+        # risk of being leaked. In case we find one, error out and teach the
+        # user the best practices.
+        string(REGEX MATCH "https?://[^/]*:[^/]*@.*"
+          http_password "${git_output}")
+        if(http_password)
+          message(SEND_ERROR "The remote URL has an embedded password. \
+Remove the password from the URL or use \
+`-DLLVM_FORCE_VC_REPOSITORY=<URL without password>` in order to avoid \
+leaking your password.")
         endif()
+        # Github token formats are described at:
+        # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats
+        string(REGEX MATCH
+          "https?://(gh[pousr]|github_pat)_[^/]+@github.com.*"
+          github_token "${git_output}")
+        if(github_token)
+          message(SEND_ERROR "The remote URL has an embedded Github Token. \
+Remove the token from the URL or use \
+`-DLLVM_FORCE_VC_REPOSITORY=<URL without token>` in order to avoid leaking \
+your token.")
+        endif()
+
+        string(STRIP "${git_output}" git_output)
+        set(${repository} ${git_output} PARENT_SCOPE)
       else()
         set(${repository} ${path} PARENT_SCOPE)
       endif()


### PR DESCRIPTION
Try to detect if the git remote URL has a password or a Github token and
return an error teaching the user how to avoid leaking their password or
token.