### PR TITLE
[MC][AsmLexer] 'LexToken()': fix potential buffer overflow.

### DIFF
--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -752,10 +752,10 @@ AsmToken AsmLexer::LexToken() {
       return LexLineComment();
   }
 
-  if (isAtStartOfComment(TokStart))
+  if (CurChar != EOF && isAtStartOfComment(TokStart))
     return LexLineComment();
 
-  if (isAtStatementSeparator(TokStart)) {
+  if (CurChar != EOF && isAtStatementSeparator(TokStart)) {
     CurPtr += strlen(MAI.getSeparatorString()) - 1;
     IsAtStartOfLine = true;
     IsAtStartOfStatement = true;


### PR DESCRIPTION
When the 'CurPtr' points to the 'EOF', calling either 'isAtStartOfComment', or 'isAtStatementSeparator' leads to dereferencing of 'CurBuf.end()'.
Usually this issue is hidden, as the AsmParser receives a source code via MemoryBuffer object with the null-terminating symbol, but the null-terminator is not required for AsmParser logic.