### PR TITLE
[BOLT] Reduce CFI warning verbosity

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -2502,7 +2502,7 @@ void BinaryFunction::annotateCFIState() {
     }
   }
 
-  if (!StateStack.empty()) {
+  if (opts::Verbosity >= 1 && !StateStack.empty()) {
     BC.errs() << "BOLT-WARNING: non-empty CFI stack at the end of " << *this
               << '\n';
   }


### PR DESCRIPTION
CFI programs may have more saves than restores and this is completely benign from BOLT's perspective. Reduce the verbosity and print the warning only under `-v=1` and above.