### PR TITLE
[compiler-rt][test] Add REQUIRES: shell to compiler-rt tests that use the `ulimit` command

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/allocator_oom_test.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/allocator_oom_test.cpp
@@ -31,7 +31,7 @@
 // ASan shadow memory on s390 is too large for this test.
 // AArch64 bots fail on this test.
 // TODO(alekseys): Android lit do not run ulimit on device.
-// REQUIRES: shadow-scale-3
+// REQUIRES: shell, shadow-scale-3
 // UNSUPPORTED: android, target={{(s390|aarch64|powerpc64le).*}}
 
 #include <stdlib.h>

--- a/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: shell
 // Check that UAR mode can handle very deep recusrion.
+// REQUIRES: shell
 // RUN: %clangxx_asan -O2 %s -o %t
 // RUN: ulimit -s 4096
 // RUN: %env_asan_opts=detect_stack_use_after_return=1 %run %t 2>&1 | FileCheck %s

--- a/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: shell
 // Check that UAR mode can handle very deep recusrion.
 // RUN: %clangxx_asan -O2 %s -o %t
 // RUN: ulimit -s 4096

--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -1,6 +1,5 @@
 REQUIRES: shell
 XFAIL: ios
-UNSUPPORTED: target={{.*windows.*}}
 RUN: %cpp_compiler %S/FullCoverageSetTest.cpp -o %t-FullCoverageSetTest
 
 RUN: rm -rf  %tmp/T1 %tmp/T2

--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -1,3 +1,4 @@
+REQUIRES: shell
 XFAIL: ios
 UNSUPPORTED: target={{.*windows.*}}
 RUN: %cpp_compiler %S/FullCoverageSetTest.cpp -o %t-FullCoverageSetTest

--- a/compiler-rt/test/fuzzer/ulimit.test
+++ b/compiler-rt/test/fuzzer/ulimit.test
@@ -1,4 +1,5 @@
 # FIXME: Disabled on Windows for now because Windows has no ulimit command.
+REQUIRES: shell
 UNSUPPORTED: target={{.*windows.*}}
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 RUN: ulimit -s 1000

--- a/compiler-rt/test/fuzzer/ulimit.test
+++ b/compiler-rt/test/fuzzer/ulimit.test
@@ -1,6 +1,4 @@
-# FIXME: Disabled on Windows for now because Windows has no ulimit command.
 REQUIRES: shell
-UNSUPPORTED: target={{.*windows.*}}
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 RUN: ulimit -s 1000
 RUN: not %run %t-SimpleTest

--- a/compiler-rt/test/hwasan/TestCases/print-memory-usage.c
+++ b/compiler-rt/test/hwasan/TestCases/print-memory-usage.c
@@ -1,5 +1,5 @@
-// REQUIRES: shell
 // Tests __hwasan_print_memory_usage.
+// REQUIRES: shell
 // RUN: %clang_hwasan %s -o %t
 // RUN: ulimit -s 1000
 // RUN: %run %t 2>&1 | FileCheck %s

--- a/compiler-rt/test/hwasan/TestCases/print-memory-usage.c
+++ b/compiler-rt/test/hwasan/TestCases/print-memory-usage.c
@@ -1,3 +1,4 @@
+// REQUIRES: shell
 // Tests __hwasan_print_memory_usage.
 // RUN: %clang_hwasan %s -o %t
 // RUN: ulimit -s 1000

--- a/compiler-rt/test/msan/Linux/reexec_unlimited_stack.cpp
+++ b/compiler-rt/test/msan/Linux/reexec_unlimited_stack.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: shell
 // MSAN re-execs on unlimited stacks. We use that to verify ReExec() uses the
 // right path.
 // RUN: %clangxx_msan -O0 %s -o %t && ulimit -s unlimited && %run %t | FileCheck %s

--- a/compiler-rt/test/msan/Linux/reexec_unlimited_stack.cpp
+++ b/compiler-rt/test/msan/Linux/reexec_unlimited_stack.cpp
@@ -1,6 +1,6 @@
-// REQUIRES: shell
 // MSAN re-execs on unlimited stacks. We use that to verify ReExec() uses the
 // right path.
+// REQUIRES: shell
 // RUN: %clangxx_msan -O0 %s -o %t && ulimit -s unlimited && %run %t | FileCheck %s
 
 #include <stdio.h>


### PR DESCRIPTION
This patch adds the `REQUIRES: shell`  directive to six test files that use the `ulimit` command, ensuring these tests are only run in environments where a full POSIX-compliant shell is available. The lit internal shell does not use or support the `ulimit` command, which causes failures when running tests with  `LIT_USE_INTERNAL_SHELL=1 ninja check-compiler-rt`
Specifically, one of the errors encountered is: 
```
# RUN: at line 4
ulimit -s 1000
# executed command: ulimit -s 1000
# .---command stderr------------
# | 'ulimit': command not found
# `-----------------------------
# error: command failed with exit status: 127
```
Since, the lit internal shell doesn't support `ulimit`, adding this requirement prevents these tests from failing in the lit internal shell, thereby improving the reliability of the test suite in environments where the full shell is not available.

This change is relevant for [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179/3)  
fixes:  #102398