### PR TITLE
[NFC][Support] Move ModRef/MemoryEffects printers to their own file

### DIFF
--- a/llvm/include/llvm/Support/ModRef.h
+++ b/llvm/include/llvm/Support/ModRef.h
@@ -1,4 +1,4 @@
-//===--- ModRef.h - Memory effect modelling ---------------------*- C++ -*-===//
+//===--- ModRef.h - Memory effect modeling ----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -423,42 +423,6 @@ raw_ostream &llvm::operator<<(raw_ostream &OS, AliasResult AR) {
   return OS;
 }
 
-raw_ostream &llvm::operator<<(raw_ostream &OS, ModRefInfo MR) {
-  switch (MR) {
-  case ModRefInfo::NoModRef:
-    OS << "NoModRef";
-    break;
-  case ModRefInfo::Ref:
-    OS << "Ref";
-    break;
-  case ModRefInfo::Mod:
-    OS << "Mod";
-    break;
-  case ModRefInfo::ModRef:
-    OS << "ModRef";
-    break;
-  }
-  return OS;
-}
-
-raw_ostream &llvm::operator<<(raw_ostream &OS, MemoryEffects ME) {
-  for (IRMemLocation Loc : MemoryEffects::locations()) {
-    switch (Loc) {
-    case IRMemLocation::ArgMem:
-      OS << "ArgMem: ";
-      break;
-    case IRMemLocation::InaccessibleMem:
-      OS << "InaccessibleMem: ";
-      break;
-    case IRMemLocation::Other:
-      OS << "Other: ";
-      break;
-    }
-    OS << ME.getModRef(Loc) << ", ";
-  }
-  return OS;
-}
-
 //===----------------------------------------------------------------------===//
 // Helper method implementation
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -205,6 +205,7 @@ add_llvm_component_library(LLVMSupport
   MemAlloc.cpp
   MemoryBuffer.cpp
   MemoryBufferRef.cpp
+  ModRef.cpp
   MD5.cpp
   MSP430Attributes.cpp
   MSP430AttributeParser.cpp

--- a/llvm/lib/Support/ModRef.cpp
+++ b/llvm/lib/Support/ModRef.cpp
@@ -1,0 +1,51 @@
+//===--- ModRef.cpp - Memory effect modeling --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements ModRef and MemoryEffects misc functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/ModRef.h"
+
+using namespace llvm;
+
+raw_ostream &llvm::operator<<(raw_ostream &OS, ModRefInfo MR) {
+  switch (MR) {
+  case ModRefInfo::NoModRef:
+    OS << "NoModRef";
+    break;
+  case ModRefInfo::Ref:
+    OS << "Ref";
+    break;
+  case ModRefInfo::Mod:
+    OS << "Mod";
+    break;
+  case ModRefInfo::ModRef:
+    OS << "ModRef";
+    break;
+  }
+  return OS;
+}
+
+raw_ostream &llvm::operator<<(raw_ostream &OS, MemoryEffects ME) {
+  for (IRMemLocation Loc : MemoryEffects::locations()) {
+    switch (Loc) {
+    case IRMemLocation::ArgMem:
+      OS << "ArgMem: ";
+      break;
+    case IRMemLocation::InaccessibleMem:
+      OS << "InaccessibleMem: ";
+      break;
+    case IRMemLocation::Other:
+      OS << "Other: ";
+      break;
+    }
+    OS << ME.getModRef(Loc) << ", ";
+  }
+  return OS;
+}


### PR DESCRIPTION
- Move raw_ostream << operators for `ModRef` and `MemoryEffects` to a new ModRef.cpp file under llvm/Support (instead of AliasAnalysis.cpp)

- This enables calling these operators from `Core` files like Instructions.cpp (for instance for debugging). Currently, they live in `LLVMAnalysis` which cannot be linked with `Core`.