### PR TITLE
[libc] move newheadergen back to safe_load

### DIFF
--- a/libc/newhdrgen/yaml_to_classes.py
+++ b/libc/newhdrgen/yaml_to_classes.py
@@ -118,7 +118,7 @@ def load_yaml_file(yaml_file, header_class, entry_points):
         HeaderFile: An instance of HeaderFile populated with the data.
     """
     with open(yaml_file, "r") as f:
-        yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+        yaml_data = yaml.safe_load(f)
     return yaml_to_classes(yaml_data, header_class, entry_points)
 
 
@@ -173,7 +173,7 @@ def add_function_to_yaml(yaml_file, function_details):
     new_function = parse_function_details(function_details)
 
     with open(yaml_file, "r") as f:
-        yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+        yaml_data = yaml.safe_load(f)
     if "functions" not in yaml_data:
         yaml_data["functions"] = []
 


### PR DESCRIPTION
In #100024 we moved from safe_load to load for reading the yaml in
newheadergen due to dependency issues. Those should be resolved by now
so this should be a simple safety improvement.
