### PR TITLE
[flang] Fix test on ppc64le & aarch64

### DIFF
--- a/flang/test/Evaluate/fold-nearest.f90
+++ b/flang/test/Evaluate/fold-nearest.f90
@@ -92,20 +92,23 @@ module m3
   logical, parameter :: test_14 = .not. (x14 == x14)
 end module
 
-#if 0
-! Currently failing on ppc64le and aarch64, debugging...
 module m4
+  use ieee_arithmetic
+  real(2), parameter :: neg_inf_2 = real(z'fc00',2)
+  real(2), parameter :: neg_huge_2 = real(z'fbff',2)
+  real(3), parameter :: neg_huge_3 = real(z'ff7f',3)
+  logical, parameter :: test_1 = ieee_next_after(neg_inf_2, neg_huge_3) == neg_huge_2
+end module
+
+#if __x86_64__
+module m5
   use ieee_arithmetic
   real(8), parameter :: neg_inf_8  = real(z'fff0000000000000',8)
   real(8), parameter :: neg_huge_8 = real(z'ffefffffffffffff',8)
   real(10), parameter :: neg_one_10 = real(z'bfff8000000000000000',10)
   real(10), parameter :: neg_inf_10 = real(z'ffff8000000000000000',10)
-  real(2), parameter :: neg_inf_2 = real(z'fc00',2)
-  real(2), parameter :: neg_huge_2 = real(z'fbff',2)
-  real(3), parameter :: neg_huge_3 = real(z'ff7f',3)
-  logical, parameter :: test_1 = ieee_next_after(neg_inf_8,neg_one_10) == neg_huge_8
-  logical, parameter :: test_2 = ieee_next_after(neg_inf_2, neg_huge_3) == neg_huge_2
-  logical, parameter :: test_3 = ieee_next_after(neg_one_10, neg_inf_10) == &
+  logical, parameter :: test_1 = ieee_next_after(neg_inf_8, neg_one_10) == neg_huge_8
+  logical, parameter :: test_2 = ieee_next_after(neg_one_10, neg_inf_10) == &
                                  real(z'bfff8000000000000001', 10)
 end module
 #endif


### PR DESCRIPTION
Don't try to fold x87 extended precision operations in a test unless it's targeting x86-64.