### PR TITLE
[NFC][TableGen] Emit more readable builtin string table

### DIFF
--- a/llvm/utils/TableGen/IntrinsicEmitter.cpp
+++ b/llvm/utils/TableGen/IntrinsicEmitter.cpp
@@ -669,9 +669,7 @@ Intrinsic::getIntrinsicFor{1}Builtin(StringRef TargetPrefix,
   }
 
   if (!Table.empty()) {
-    OS << "  static constexpr char BuiltinNames[] = {\n";
-    Table.EmitCharArray(OS);
-    OS << "  };\n\n";
+    Table.EmitStringLiteralDef(OS, "static constexpr char BuiltinNames[]");
 
     OS << R"(
   struct BuiltinEntry {


### PR DESCRIPTION
- Add `EmitStringLiteralDef` to StringToOffsetTable class to emit more readable string table.
- Use that in `EmitIntrinsicToBuiltinMap`.