### PR TITLE
[lldb-dap] Fix disassembled ranges for `disassemble` request

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -674,11 +674,11 @@ class DebugCommunication(object):
         return self.send_recv(command_dict)
 
     def request_disassemble(
-        self, memoryReference, offset=-50, instructionCount=200, resolveSymbols=True
+        self, memoryReference, instructionOffset=0, instructionCount=10, resolveSymbols=True
     ):
         args_dict = {
             "memoryReference": memoryReference,
-            "offset": offset,
+            "instructionOffset": instructionOffset,
             "instructionCount": instructionCount,
             "resolveSymbols": resolveSymbols,
         }

--- a/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
+++ b/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
@@ -29,6 +29,14 @@ class TestDAP_disassemble(lldbdap_testcase.DAPTestCaseBase):
         )
         self.continue_to_next_stop()
 
+        stackFrames = self.get_stackFrames(
+            threadId=threadId, startFrame=frameIndex, levels=1
+        )
+        self.assertIsNotNone(stackFrames)
+
+        # XXX finish updating test case
+        memoryReference = stackFrames[0]["instructionPointerReference"]
+
         pc_assembly = self.disassemble(frameIndex=0)
         self.assertIn("location", pc_assembly, "Source location missing.")
         self.assertIn("instruction", pc_assembly, "Assembly instruction missing.")

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -3910,8 +3910,8 @@ void request_disassemble(const llvm::json::Object &request) {
     return;
   }
 
-  addr_ptr += GetSigned(arguments, "instructionOffset", 0);
-  lldb::SBAddress addr(addr_ptr, g_dap.target);
+  addr_ptr += GetSigned(arguments, "offset", 0);
+  lldb::SBAddress addr = g_dap.target.ResolveLoadAddress(addr_ptr);
   if (!addr.IsValid()) {
     response["success"] = false;
     response["message"] = "Memory reference not found in the current binary.";
@@ -3919,9 +3919,27 @@ void request_disassemble(const llvm::json::Object &request) {
     return;
   }
 
-  const auto inst_count = GetUnsigned(arguments, "instructionCount", 0);
-  lldb::SBInstructionList insts =
-      g_dap.target.ReadInstructions(addr, inst_count);
+  int64_t inst_offset = GetSigned(arguments, "instructionOffset", 0);
+  const int64_t inst_count = GetSigned(arguments, "instructionCount", 0);
+  if (inst_count < 0) {
+    response["success"] = false;
+    response["message"] = "Negative instruction count.";
+    g_dap.SendJSON(llvm::json::Value(std::move(response)));
+    return;
+  }
+
+  lldb::SBInstructionList insts;
+  if (lldb::SBFunction func = addr.GetFunction()) {
+    // First try to identify the function boundaries through debug information
+    insts = func.GetInstructions(g_dap.target);
+  } else if (lldb::SBSymbol sym = addr.GetSymbol()) {
+    // Try to identify the function boundaries through the symbol table
+    insts = sym.GetInstructions(g_dap.target);
+  } else {
+    // We could not identify the function. Just disassemble starting from the
+    // provided address.
+    insts = g_dap.target.ReadInstructions(addr, inst_offset + inst_count);
+  }
 
   if (!insts.IsValid()) {
     response["success"] = false;
@@ -3930,10 +3948,46 @@ void request_disassemble(const llvm::json::Object &request) {
     return;
   }
 
+  // Find the start offset in the disassembled function
+  ssize_t offset = 0;
+  while (insts.GetInstructionAtIndex(offset).GetAddress().GetLoadAddress(
+             g_dap.target) < addr.GetLoadAddress(g_dap.target))
+    ++offset;
+  offset += inst_offset;
+
+  // Format the disassembled instructions
   const bool resolveSymbols = GetBoolean(arguments, "resolveSymbols", false);
   llvm::json::Array instructions;
-  const auto num_insts = insts.GetSize();
-  for (size_t i = 0; i < num_insts; ++i) {
+  for (ssize_t i = offset; i < inst_count + offset; ++i) {
+    // Before the range of disassembled instructions?
+    if (i < 0) {
+      auto fake_addr =
+          insts.GetInstructionAtIndex(0).GetAddress().GetLoadAddress(
+              g_dap.target) -
+          offset + i;
+      llvm::json::Object disassembled_inst{
+          {"address", "0x" + llvm::utohexstr(fake_addr)},
+          {"instruction", "Instruction before disassembled address range"},
+          {"presentationHint", "invalid"},
+      };
+      instructions.emplace_back(std::move(disassembled_inst));
+      continue;
+    }
+    // Past the range of disassembled instructions?
+    if (static_cast<uint64_t>(i) >= insts.GetSize()) {
+      auto fake_addr = insts.GetInstructionAtIndex(insts.GetSize() - 1)
+                           .GetAddress()
+                           .GetLoadAddress(g_dap.target) -
+                       offset + i - insts.GetSize();
+      llvm::json::Object disassembled_inst{
+          {"address", "0x" + llvm::utohexstr(fake_addr)},
+          {"instruction", "Instruction after disassembled address range"},
+          {"presentationHint", "invalid"},
+      };
+      instructions.emplace_back(std::move(disassembled_inst));
+      continue;
+    }
+
     lldb::SBInstruction inst = insts.GetInstructionAtIndex(i);
     auto addr = inst.GetAddress();
     const auto inst_addr = addr.GetLoadAddress(g_dap.target);


### PR DESCRIPTION
This is a first draft PR which fixes #103021

The main issue was that the `instructionOffset` was handled as a byte offset and not as an instruction offset.

This commit also incorporates previous feedback from https://reviews.llvm.org/D140358: With this change, we are using symbols and DWARF debug information to find function boundaries and correctly start disassembling at this address.

TODO:
* Update test case
* Check if we can also support disassembling across functions

