### PR TITLE
[BOLT] Improve BinaryFunction::inferFallThroughCounts()

### DIFF
--- a/bolt/lib/Core/BinaryFunctionProfile.cpp
+++ b/bolt/lib/Core/BinaryFunctionProfile.cpp
@@ -336,7 +336,8 @@ void BinaryFunction::inferFallThroughCounts() {
       if (SuccBI.Count == 0) {
         SuccBI.Count = Inferred;
         SuccBI.MispredictedCount = BinaryBasicBlock::COUNT_INFERRED;
-        Succ->ExecutionCount += Inferred;
+        Succ->ExecutionCount =
+            std::max(Succ->getKnownExecutionCount(), Inferred);
       }
     }
   }

--- a/bolt/test/X86/infer-fall-throughs.s
+++ b/bolt/test/X86/infer-fall-throughs.s
@@ -1,0 +1,71 @@
+## Test that infer-fall-throughs would correctly infer the wrong fall-through
+## edge count in the example
+
+# RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %s -o %t.o
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: llvm-strip --strip-unneeded %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --split-functions \
+# RUN:         --print-split --print-only=chain --data=%t.fdata \
+# RUN:         --reorder-blocks=none \
+# RUN:     2>&1 | FileCheck --check-prefix=WITHOUTINFERENCE %s
+# RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --infer-fall-throughs \
+# RUN:         --print-split --print-only=chain --data=%t.fdata \
+# RUN:         --reorder-blocks=none \
+# RUN:     2>&1 | FileCheck --check-prefix=CORRECTINFERENCE %s
+
+
+# WITHOUTINFERENCE: Binary Function "chain" after split-functions
+# WITHOUTINFERENCE: {{^\.LBB00}}
+# WITHOUTINFERENCE: Successors: .Ltmp0 (mispreds: 0, count: 10), .LFT0 (mispreds: 0, count: 0)
+# WITHOUTINFERENCE: {{^\.LFT0}}
+# WITHOUTINFERENCE: Exec Count : 490
+
+# CORRECTINFERENCE: Binary Function "chain" after split-functions
+# CORRECTINFERENCE: {{^\.LBB00}}
+# CORRECTINFERENCE: Successors: .Ltmp0 (mispreds: 0, count: 10), .LFT0 (inferred count: 490)
+# CORRECTINFERENCE: {{^\.LFT0}}
+# CORRECTINFERENCE: Exec Count : 490
+
+
+        .text
+        .globl  chain
+        .type   chain, @function
+chain:
+        pushq   %rbp
+        movq    %rsp, %rbp
+        cmpl    $2, %edi
+LLstart:
+        jge     LLless
+# FDATA: 1 chain #LLstart# 1 chain #LLless# 0 10
+# FDATA: 1 chain #LLstart# 1 chain #LLmore# 0 0
+LLmore:
+        movl    $5, %eax
+LLmore_LLexit:
+        jmp     LLexit
+# FDATA: 1 chain #LLmore_LLexit# 1 chain #LLexit# 0 490
+LLless:
+        movl    $10, %eax
+LLdummy:
+        jmp     LLexit
+# FDATA: 1 chain #LLdummy# 1 chain #LLexit# 0 10
+LLexit:
+        popq    %rbp
+        ret
+LLchain_end:
+        .size   chain, LLchain_end-chain
+
+
+        .globl  main
+        .type   main, @function
+main:
+        pushq   %rbp
+        movq    %rsp, %rbp
+        movl    $1, %edi
+LLmain_chain:
+        call    chain
+# FDATA: 1 main #LLmain_chain# 1 chain 0 0 500
+        movl    $4, %edi
+        retq
+.Lmain_end:
+        .size   main, .Lmain_end-main

--- a/bolt/test/X86/infer-fall-throughs.s
+++ b/bolt/test/X86/infer-fall-throughs.s
@@ -33,17 +33,14 @@ LLmain_LLstart:
         jmp     LLstart
 # FDATA: 1 main #LLmain_LLstart# 1 main #LLstart# 0 500
 LLstart:
-        jge     LLless
-# FDATA: 1 main #LLstart# 1 main #LLless# 0 10
+        jge     LLexit
+# FDATA: 1 main #LLstart# 1 main #LLexit# 0 10
 # FDATA: 1 main #LLstart# 1 main #LLmore# 0 0
 LLmore:
         movl    $5, %eax
 LLmore_LLexit:
         jmp     LLexit
 # FDATA: 1 main #LLmore_LLexit# 1 main #LLexit# 0 490
-LLless:
-        jmp     LLexit
-# FDATA: 1 main #LLless# 1 main #LLexit# 0 10
 LLexit:
         ret
 .LLmain_end:

--- a/bolt/test/X86/infer-fall-throughs.s
+++ b/bolt/test/X86/infer-fall-throughs.s
@@ -38,9 +38,7 @@ LLstart:
 # FDATA: 1 main #LLstart# 1 main #LLmore# 0 0
 LLmore:
         movl    $5, %eax
-LLmore_LLexit:
-        jmp     LLexit
-# FDATA: 1 main #LLmore_LLexit# 1 main #LLexit# 0 490
+# FDATA: 1 main #LLmore# 1 main #LLexit# 0 490
 LLexit:
         ret
 .LLmain_end:


### PR DESCRIPTION
This PR improves how basic block execution count is updated when using the BOLT option `-infer-fall-throughs`. Previously, if a 0-count fall-through edge is assigned a positive inferred count N, then the successor block's execution count will be incremented by N. Since the successor's execution count is calculated using information besides inflow sum (such as outflow sum), it likely is already correct, and incrementing it by an additional N would be wrong. This PR improves how the successor's execution count is updated by using the max over its current count and N. 