### PR TITLE
[ELF,test] Improve error-handling-script-linux.test

### DIFF
--- a/lld/test/ELF/error-handling-script-linux.test
+++ b/lld/test/ELF/error-handling-script-linux.test
@@ -1,46 +1,56 @@
-#!/bin/sh
 # REQUIRES: x86
 # UNSUPPORTED: system-windows
 
-# RUN: llvm-mc -filetype=obj -triple=x86_64 /dev/null -o %t0.o
-# RUN: not ld.lld -o /dev/null -lidontexist --error-handling-script=%s %t0.o 2>&1 |\
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: chmod +x a.sh
+# RUN: llvm-mc -filetype=obj -triple=x86_64 /dev/null -o 0.o
+# RUN: not ld.lld -lidontexist --error-handling-script=%t/a.sh 0.o 2>&1 |\
 # RUN:   FileCheck --check-prefix=CHECK-LIB %s
-# RUN: not ld.lld -o /dev/null -lidontexist --error-handling-script=%s.nope %t0.o 2>&1 |\
-# RUN:   FileCheck --check-prefix=CHECK-SCRIPT-DOES-NOT-EXIST -DFILE=%s.nope %s
+# RUN: not ld.lld -lidontexist --error-handling-script=./notexist 0.o 2>&1 |\
+# RUN:   FileCheck --check-prefix=CHECK-SCRIPT-DOES-NOT-EXIST %s
 
-# RUN: echo 'bar: movl a(%rip), %eax' | llvm-mc -filetype=obj -triple=x86_64 - -o %t1.o
-# RUN: not ld.lld -o /dev/null --error-handling-script=%s %t1.o 2>&1 |\
+# RUN: llvm-mc -filetype=obj -triple=x86_64 1.s -o 1.o
+# RUN: not ld.lld --error-handling-script=./a.sh 1.o 2>&1 |\
 # RUN:   FileCheck --check-prefix=CHECK-SYM-C %s
 
-# RUN: echo 'bar: movl _Z1av(%rip), %eax' | llvm-mc -filetype=obj -triple=x86_64 - -o %t2.o
-# RUN: not ld.lld -o /dev/null --demangle --error-handling-script=%s %t2.o 2>&1 |\
+# RUN: llvm-mc -filetype=obj -triple=x86_64 2.s -o 2.o
+# RUN: not ld.lld --demangle --error-handling-script=./a.sh 2.o 2>&1 |\
 # RUN:   FileCheck --check-prefix=CHECK-SYM-CXX-DEMANGLE %s
-# RUN: not ld.lld -o /dev/null --no-demangle --error-handling-script=%s %t2.o 2>&1 |\
+# RUN: not ld.lld --no-demangle --error-handling-script=./a.sh 2.o 2>&1 |\
 # RUN:   FileCheck --check-prefix=CHECK-SYM-CXX-NO-DEMANGLE %s
 
-# RUN: { echo 'a_: ret'; echo 'bar: movl a(%rip), %eax' ; } | llvm-mc -filetype=obj -triple=x86_64 - -o %t3.o
-# RUN: not ld.lld -o /dev/null --error-handling-script=%s %t3.o 2>&1 |\
-# RUN:   FileCheck --check-prefix=CHECK-SYM-C-CORRECTION -DOBJ=%t3.o %s
+# RUN: llvm-mc -filetype=obj -triple=x86_64 3.s -o 3.o
+# RUN: not ld.lld --error-handling-script=%t/a.sh 3.o 2>&1 |\
+# RUN:   FileCheck --check-prefix=CHECK-SYM-C-CORRECTION %s
 
 # CHECK-LIB:      script: info: called with missing-lib idontexist
-# CHECK-LIB-NEXT: ld.lld: error: unable to find library -lidontexist
+# CHECK-LIB-NEXT: error: unable to find library -lidontexist
 
-# CHECK-SCRIPT-DOES-NOT-EXIST:      ld.lld: error: unable to find library -lidontexist
-# CHECK-SCRIPT-DOES-NOT-EXIST-NEXT: ld.lld: error: error handling script '[[FILE]]' failed to execute
+# CHECK-SCRIPT-DOES-NOT-EXIST:      error: unable to find library -lidontexist
+# CHECK-SCRIPT-DOES-NOT-EXIST-NEXT: error: error handling script './notexist' failed to execute
 
 # CHECK-SYM-C:      script: info: called with undefined-symbol a
-# CHECK-SYM-C-NEXT: ld.lld: error: undefined symbol: a
+# CHECK-SYM-C-NEXT: error: undefined symbol: a
 
 # CHECK-SYM-CXX-DEMANGLE:      script: info: called with undefined-symbol _Z1av
-# CHECK-SYM-CXX-DEMANGLE-NEXT: ld.lld: error: undefined symbol: a()
+# CHECK-SYM-CXX-DEMANGLE-NEXT: error: undefined symbol: a()
 
 # CHECK-SYM-CXX-NO-DEMANGLE:      script: info: called with undefined-symbol _Z1av
-# CHECK-SYM-CXX-NO-DEMANGLE-NEXT: ld.lld: error: undefined symbol: _Z1av
+# CHECK-SYM-CXX-NO-DEMANGLE-NEXT: error: undefined symbol: _Z1av
 
 # CHECK-SYM-C-CORRECTION:      script: info: called with undefined-symbol a
-# CHECK-SYM-C-CORRECTION-NEXT: ld.lld: error: undefined symbol: a
-# CHECK-SYM-C-CORRECTION-NEXT: >>> referenced by [[OBJ]]:
+# CHECK-SYM-C-CORRECTION-NEXT: error: undefined symbol: a
+# CHECK-SYM-C-CORRECTION-NEXT: >>> referenced by 3.o:
 # CHECK-SYM-C-CORRECTION-NEXT: >>> did you mean: a_
 
+#--- 1.s
+bar: movl a(%rip), %eax
+#--- 2.s
+bar: movl _Z1av(%rip), %eax
+#--- 3.s
+a_: ret
+bar: movl a(%rip), %eax
 
+#--- a.sh
+#!/bin/sh
 echo "script: info: called with $*"

--- a/lld/test/ELF/error-handling-script-linux.test
+++ b/lld/test/ELF/error-handling-script-linux.test
@@ -5,7 +5,7 @@
 # RUN: chmod +x a.sh
 # RUN: llvm-mc -filetype=obj -triple=x86_64 /dev/null -o 0.o
 # RUN: not ld.lld -lidontexist --error-handling-script=%t/a.sh 0.o 2>&1 |\
-# RUN:   FileCheck --check-prefix=CHECK-LIB %s
+# RUN:   FileCheck --check-prefix=CHECK-LIB %s --match-full-lines --strict-whitespace
 # RUN: not ld.lld -lidontexist --error-handling-script=./notexist 0.o 2>&1 |\
 # RUN:   FileCheck --check-prefix=CHECK-SCRIPT-DOES-NOT-EXIST %s
 
@@ -23,8 +23,8 @@
 # RUN: not ld.lld --error-handling-script=%t/a.sh 3.o 2>&1 |\
 # RUN:   FileCheck --check-prefix=CHECK-SYM-C-CORRECTION %s
 
-# CHECK-LIB:      script: info: called with missing-lib idontexist
-# CHECK-LIB-NEXT: error: unable to find library -lidontexist
+#      CHECK-LIB:script: info: called with missing-lib idontexist
+# CHECK-LIB-NEXT:{{.*}}error: unable to find library -lidontexist
 
 # CHECK-SCRIPT-DOES-NOT-EXIST:      error: unable to find library -lidontexist
 # CHECK-SCRIPT-DOES-NOT-EXIST-NEXT: error: error handling script './notexist' failed to execute
@@ -44,12 +44,12 @@
 # CHECK-SYM-C-CORRECTION-NEXT: >>> did you mean: a_
 
 #--- 1.s
-bar: movl a(%rip), %eax
+movl a(%rip), %eax
 #--- 2.s
-bar: movl _Z1av(%rip), %eax
+movl _Z1av(%rip), %eax
 #--- 3.s
 a_: ret
-bar: movl a(%rip), %eax
+movl a(%rip), %eax
 
 #--- a.sh
 #!/bin/sh

--- a/lld/test/ELF/error-handling-script-windows.bat
+++ b/lld/test/ELF/error-handling-script-windows.bat
@@ -6,10 +6,10 @@
 :: RUN:   FileCheck --check-prefix=CHECK-SCRIPT-DOES-NOT-EXIST -DFILE=%s.nope %s
 ::
 :: CHECK-LIB:      script: info: called with missing-lib idontexist
-:: CHECK-LIB-NEXT: ld.lld: error: unable to find library -lidontexist
+:: CHECK-LIB-NEXT: error: unable to find library -lidontexist
 
-:: CHECK-SCRIPT-DOES-NOT-EXIST:      ld.lld: error: unable to find library -lidontexist
-:: CHECK-SCRIPT-DOES-NOT-EXIST-NEXT: ld.lld: error: error handling script '[[FILE]]' failed to execute
+:: CHECK-SCRIPT-DOES-NOT-EXIST:      error: unable to find library -lidontexist
+:: CHECK-SCRIPT-DOES-NOT-EXIST-NEXT: error: error handling script '[[FILE]]' failed to execute
 
 @echo off
 echo "script: info: called with %*"


### PR DESCRIPTION
* Use split-file
* Remove -o /dev/null
* Avoid `{ list; }` compound command not supported by the lit internal shell (#102382)
* Don't test "ld.lld" before "error:" as per convention
