### PR TITLE
[lldb-dap] When sending a DAP Output Event break each message into separate lines.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -202,6 +202,11 @@ class DAPTestCaseBase(TestBase):
             "console", timeout_secs=timeout_secs, pattern=pattern
         )
 
+    def collect_stdout(self, timeout_secs, pattern=None):
+        return self.dap_server.collect_output(
+            "stdout", timeout_secs=timeout_secs, pattern=pattern
+        )
+
     def get_local_as_int(self, name, threadId=None):
         value = self.dap_server.get_local_variable_value(name, threadId=threadId)
         # 'value' may have the variable value and summary.

--- a/lldb/test/API/tools/lldb-dap/output/Makefile
+++ b/lldb/test/API/tools/lldb-dap/output/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
+++ b/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
@@ -1,0 +1,37 @@
+"""
+Test lldb-dap output events
+"""
+
+import dap_server
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+import lldbdap_testcase
+import re
+
+
+class TestDAP_output(lldbdap_testcase.DAPTestCaseBase):
+    def test_output(self):
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        source = "main.c"
+        main_source_path = self.getSourcePath(source)
+        lines = [line_number(source, "// breakpoint 1")]
+        breakpoint_ids = self.set_source_breakpoints(source, lines)
+        self.continue_to_breakpoints(breakpoint_ids)
+        
+        output = self.collect_stdout(
+            timeout_secs=1.0,
+            pattern="abcdef"
+        )
+        self.assertTrue(output and len(output) > 0, "expect no program output")
+
+        self.continue_to_exit()
+        
+        output += self.get_stdout(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        self.assertTrue(output and len(output) > 0, "expect no program output")
+        self.assertIn(
+            "abcdefghi\r\nhello world\r\n",
+            output,
+            'full output not found in: ' + output
+        )        

--- a/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
+++ b/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
@@ -2,12 +2,9 @@
 Test lldb-dap output events
 """
 
-import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import lldbutil
 import lldbdap_testcase
-import re
 
 
 class TestDAP_output(lldbdap_testcase.DAPTestCaseBase):
@@ -15,15 +12,12 @@ class TestDAP_output(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         source = "main.c"
-        main_source_path = self.getSourcePath(source)
         lines = [line_number(source, "// breakpoint 1")]
         breakpoint_ids = self.set_source_breakpoints(source, lines)
         self.continue_to_breakpoints(breakpoint_ids)
         
-        output = self.collect_stdout(
-            timeout_secs=1.0,
-            pattern="abcdef"
-        )
+        # Ensure partial messages are still sent.
+        output = self.collect_stdout(timeout_secs=1.0, pattern="abcdef")
         self.assertTrue(output and len(output) > 0, "expect no program output")
 
         self.continue_to_exit()
@@ -33,5 +27,5 @@ class TestDAP_output(lldbdap_testcase.DAPTestCaseBase):
         self.assertIn(
             "abcdefghi\r\nhello world\r\n",
             output,
-            'full output not found in: ' + output
-        )        
+            'full output not found in: ' + output,
+        )

--- a/lldb/test/API/tools/lldb-dap/output/main.c
+++ b/lldb/test/API/tools/lldb-dap/output/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main() {
+  printf("abc");
+  printf("def");
+  printf("ghi\n");
+  printf("hello world\n"); // breakpoint 1
+  return 0;
+}

--- a/lldb/test/API/tools/lldb-dap/output/main.c
+++ b/lldb/test/API/tools/lldb-dap/output/main.c
@@ -3,6 +3,7 @@
 #include <unistd.h>
 
 int main() {
+  // Ensure multiple partial lines are detected and sent.
   printf("abc");
   printf("def");
   printf("ghi\n");

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -294,8 +294,6 @@ void DAP::SendOutput(OutputType o, const llvm::StringRef output) {
   if (output.empty())
     return;
 
-  llvm::json::Object event(CreateEventObject("output"));
-  llvm::json::Object body;
   const char *category = nullptr;
   switch (o) {
   case OutputType::Console:
@@ -311,10 +309,22 @@ void DAP::SendOutput(OutputType o, const llvm::StringRef output) {
     category = "telemetry";
     break;
   }
-  body.try_emplace("category", category);
-  EmplaceSafeString(body, "output", output.str());
-  event.try_emplace("body", std::move(body));
-  SendJSON(llvm::json::Value(std::move(event)));
+
+  // Send each line of output as an individual event, including the newline if
+  // present.
+  ::size_t idx = 0;
+  do {
+    ::size_t end = output.find('\n', idx);
+    if (end == llvm::StringRef::npos)
+      end = output.size() - 1;
+    llvm::json::Object event(CreateEventObject("output"));
+    llvm::json::Object body;
+    body.try_emplace("category", category);
+    EmplaceSafeString(body, "output", output.slice(idx, end + 1).str());
+    event.try_emplace("body", std::move(body));
+    SendJSON(llvm::json::Value(std::move(event)));
+    idx = end + 1;
+  } while (idx < output.size());
 }
 
 // interface ProgressStartEvent extends Event {

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -68,7 +68,11 @@ namespace lldb_dap {
 
 typedef llvm::DenseMap<uint32_t, SourceBreakpoint> SourceBreakpointMap;
 typedef llvm::StringMap<FunctionBreakpoint> FunctionBreakpointMap;
+
 enum class OutputType { Console, Stdout, Stderr, Telemetry };
+
+/// Buffer size for handling output events.
+constexpr uint64_t OutputBufferSize = (1u << 12);
 
 enum DAPBroadcasterBits {
   eBroadcastBitStopEventThread = 1u << 0,

--- a/lldb/tools/lldb-dap/OutputRedirector.cpp
+++ b/lldb/tools/lldb-dap/OutputRedirector.cpp
@@ -13,10 +13,9 @@
 #include <unistd.h>
 #endif
 
-#include "llvm/ADT/StringRef.h"
 #include "DAP.h"
 #include "OutputRedirector.h"
-
+#include "llvm/ADT/StringRef.h"
 
 using namespace llvm;
 

--- a/lldb/tools/lldb-dap/OutputRedirector.cpp
+++ b/lldb/tools/lldb-dap/OutputRedirector.cpp
@@ -13,8 +13,10 @@
 #include <unistd.h>
 #endif
 
-#include "OutputRedirector.h"
 #include "llvm/ADT/StringRef.h"
+#include "DAP.h"
+#include "OutputRedirector.h"
+
 
 using namespace llvm;
 
@@ -42,7 +44,7 @@ Error RedirectFd(int fd, std::function<void(llvm::StringRef)> callback) {
 
   int read_fd = new_fd[0];
   std::thread t([read_fd, callback]() {
-    char buffer[4096];
+    char buffer[OutputBufferSize];
     while (true) {
       ssize_t bytes_count = read(read_fd, &buffer, sizeof(buffer));
       if (bytes_count == 0)

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -399,7 +399,7 @@ void SendProcessEvent(LaunchMethod launch_method) {
 // Grab any STDOUT and STDERR from the process and send it up to VS Code
 // via an "output" event to the "stdout" and "stderr" categories.
 void SendStdOutStdErr(lldb::SBProcess &process) {
-  char buffer[1024];
+  char buffer[4096];
   size_t count;
   while ((count = process.GetSTDOUT(buffer, sizeof(buffer))) > 0)
     g_dap.SendOutput(OutputType::Stdout, llvm::StringRef(buffer, count));

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -399,7 +399,7 @@ void SendProcessEvent(LaunchMethod launch_method) {
 // Grab any STDOUT and STDERR from the process and send it up to VS Code
 // via an "output" event to the "stdout" and "stderr" categories.
 void SendStdOutStdErr(lldb::SBProcess &process) {
-  char buffer[4096];
+  char buffer[OutputBufferSize];
   size_t count;
   while ((count = process.GetSTDOUT(buffer, sizeof(buffer))) > 0)
     g_dap.SendOutput(OutputType::Stdout, llvm::StringRef(buffer, count));


### PR DESCRIPTION
Previously, when output like `"hello\nworld\n"` was produced by lldb (or the process) the message would be sent as a single Output event. By being a single event this causes VS Code to treat this as a single message in the console when handling displaying and filtering in the Debug Console.

Instead, with these changes we send each line as its own event. This results in VS Code representing each line of output from lldb-dap as an individual output message.

Resolves #105444
