### PR TITLE
[lldb-dap] Mark hidden frames as "subtle"

### DIFF
--- a/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/Makefile
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
@@ -1,0 +1,29 @@
+"""
+Test lldb-dap stack trace response
+"""
+
+
+import dap_server
+from lldbsuite.test.decorators import *
+
+import lldbdap_testcase
+from lldbsuite.test.lldbtest import *
+
+
+class TestDAP_subtleFrames(lldbdap_testcase.DAPTestCaseBase):
+    @add_test_categories(["libc++"])
+    def test_subtleFrames(self):
+        """
+        Internal stack frames (such as the ones used by `std::function`) are marked as "subtle".
+        """
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        source = "main.cpp"
+        self.set_source_breakpoints(source, [line_number(source, "BREAK HERE")])
+        self.continue_to_next_stop()
+
+        frames = self.get_stackFrames()
+        for f in frames:
+            if "__function" in f["name"]:
+                self.assertEqual(f["presentationHint"], "subtle")
+        self.assertTrue(any(f.get("presentationHint") == "subtle" for f in frames))

--- a/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/main.cpp
@@ -1,0 +1,13 @@
+#include <functional>
+#include <iostream>
+
+void greet() {
+  // BREAK HERE
+  std::cout << "Hello\n";
+}
+
+int main() {
+  std::function<void()> func{greet};
+  func();
+  return 0;
+}

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -763,6 +763,9 @@ llvm::json::Value CreateStackFrame(lldb::SBFrame &frame) {
     object.try_emplace("instructionPointerReference", formatted_addr);
   }
 
+  if (frame.IsArtificial() || frame.IsHidden())
+    object.try_emplace("presentationHint", "subtle");
+
   return llvm::json::Value(std::move(object));
 }
 


### PR DESCRIPTION
This commit takes advantage of the recently introduced `SBFrame::IsHidden` to show those hidden frames as "subtle" frames in the UI. E.g., VS Code hides those stack frames by default, and renders them as grayed out frames, in case the user decides to show them in the stack trace