### PR TITLE
[lldb-dap] Implement `StepGranularity` for "next" and "step-in"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -826,7 +826,11 @@ class DebugCommunication(object):
     def request_stepIn(self, threadId, targetId, granularity="statement"):
         if self.exit_status is not None:
             raise ValueError("request_stepIn called after process exited")
-        args_dict = {"threadId": threadId, "targetId": targetId, "granularity": granularity}
+        args_dict = {
+            "threadId": threadId,
+            "targetId": targetId,
+            "granularity": granularity,
+        }
         command_dict = {"command": "stepIn", "type": "request", "arguments": args_dict}
         return self.send_recv(command_dict)
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -816,17 +816,17 @@ class DebugCommunication(object):
             self.wait_for_event(filter=["process", "initialized"])
         return response
 
-    def request_next(self, threadId):
+    def request_next(self, threadId, granularity="statement"):
         if self.exit_status is not None:
             raise ValueError("request_continue called after process exited")
-        args_dict = {"threadId": threadId}
+        args_dict = {"threadId": threadId, "granularity": granularity}
         command_dict = {"command": "next", "type": "request", "arguments": args_dict}
         return self.send_recv(command_dict)
 
-    def request_stepIn(self, threadId, targetId):
+    def request_stepIn(self, threadId, targetId, granularity="statement"):
         if self.exit_status is not None:
             raise ValueError("request_stepIn called after process exited")
-        args_dict = {"threadId": threadId, "targetId": targetId}
+        args_dict = {"threadId": threadId, "targetId": targetId, "granularity": granularity}
         command_dict = {"command": "stepIn", "type": "request", "arguments": args_dict}
         return self.send_recv(command_dict)
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -222,8 +222,12 @@ class DAPTestCaseBase(TestBase):
         """Set a top level global variable only."""
         return self.dap_server.request_setVariable(2, name, str(value), id=id)
 
-    def stepIn(self, threadId=None, targetId=None, waitForStop=True, granularity="statement"):
-        self.dap_server.request_stepIn(threadId=threadId, targetId=targetId, granularity=granularity)
+    def stepIn(
+        self, threadId=None, targetId=None, waitForStop=True, granularity="statement"
+    ):
+        self.dap_server.request_stepIn(
+            threadId=threadId, targetId=targetId, granularity=granularity
+        )
         if waitForStop:
             return self.dap_server.wait_for_stopped()
         return None

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -222,14 +222,14 @@ class DAPTestCaseBase(TestBase):
         """Set a top level global variable only."""
         return self.dap_server.request_setVariable(2, name, str(value), id=id)
 
-    def stepIn(self, threadId=None, targetId=None, waitForStop=True):
-        self.dap_server.request_stepIn(threadId=threadId, targetId=targetId)
+    def stepIn(self, threadId=None, targetId=None, waitForStop=True, granularity="statement"):
+        self.dap_server.request_stepIn(threadId=threadId, targetId=targetId, granularity=granularity)
         if waitForStop:
             return self.dap_server.wait_for_stopped()
         return None
 
-    def stepOver(self, threadId=None, waitForStop=True):
-        self.dap_server.request_next(threadId=threadId)
+    def stepOver(self, threadId=None, waitForStop=True, granularity="statement"):
+        self.dap_server.request_next(threadId=threadId, granularity=granularity)
         if waitForStop:
             return self.dap_server.wait_for_stopped()
         return None

--- a/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
+++ b/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
@@ -68,5 +68,14 @@ class TestDAP_step(lldbdap_testcase.DAPTestCaseBase):
                     self.assertEqual(x4, x3, "verify step over variable")
                     self.assertGreater(line4, line3, "verify step over line")
                     self.assertEqual(src1, src4, "verify step over source")
+
+                    # Step a single assembly instruction.
+                    # Unfortunately, there is no portable way to verify the correct
+                    # stepping behavior here, because the generated assembly code
+                    # depends highly on the compiler, its version, the operating
+                    # system, and many more factors.
+                    self.stepOver(threadId=tid, waitForStop=True, granularity="instruction")
+                    self.stepIn(threadId=tid, waitForStop=True, granularity="instruction")
+
                     # only step one thread that is at the breakpoint and stop
                     break

--- a/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
+++ b/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
@@ -74,8 +74,12 @@ class TestDAP_step(lldbdap_testcase.DAPTestCaseBase):
                     # stepping behavior here, because the generated assembly code
                     # depends highly on the compiler, its version, the operating
                     # system, and many more factors.
-                    self.stepOver(threadId=tid, waitForStop=True, granularity="instruction")
-                    self.stepIn(threadId=tid, waitForStop=True, granularity="instruction")
+                    self.stepOver(
+                        threadId=tid, waitForStop=True, granularity="instruction"
+                    )
+                    self.stepIn(
+                        threadId=tid, waitForStop=True, granularity="instruction"
+                    )
 
                     # only step one thread that is at the breakpoint and stop
                     break

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1677,6 +1677,9 @@ void request_initialize(const llvm::json::Object &request) {
   body.try_emplace("supportsCompletionsRequest", true);
   // The debug adapter supports the disassembly request.
   body.try_emplace("supportsDisassembleRequest", true);
+  // The debug adapter supports stepping granularities (argument `granularity`)
+  // for the stepping requests.
+  body.try_emplace("supportsSteppingGranularity", true);
 
   llvm::json::Array completion_characters;
   completion_characters.emplace_back(".");
@@ -1985,6 +1988,13 @@ void request_launch(const llvm::json::Object &request) {
   g_dap.SendJSON(CreateEventObject("initialized"));
 }
 
+// Check if the step-granularity is `instruction`
+static bool hasInstructionGranularity(const llvm::json::Object &requestArgs) {
+  if (std::optional<llvm::StringRef> value = requestArgs.getString("granularity"))
+    return value == "instruction";
+  return false;
+}
+
 // "NextRequest": {
 //   "allOf": [ { "$ref": "#/definitions/Request" }, {
 //     "type": "object",
@@ -2012,6 +2022,10 @@ void request_launch(const llvm::json::Object &request) {
 //     "threadId": {
 //       "type": "integer",
 //       "description": "Execute 'next' for this thread."
+//     },
+//     "granularity": {
+//       "$ref": "#/definitions/SteppingGranularity",
+//       "description": "Stepping granularity. If no granularity is specified, a granularity of `statement` is assumed."
 //     }
 //   },
 //   "required": [ "threadId" ]
@@ -2032,7 +2046,11 @@ void request_next(const llvm::json::Object &request) {
     // Remember the thread ID that caused the resume so we can set the
     // "threadCausedFocus" boolean value in the "stopped" events.
     g_dap.focus_tid = thread.GetThreadID();
-    thread.StepOver();
+    if (hasInstructionGranularity(*arguments)) {
+      thread.StepInstruction(/*step_over=*/ true);
+    } else {
+      thread.StepOver();
+    }
   } else {
     response["success"] = llvm::json::Value(false);
   }
@@ -3193,7 +3211,10 @@ void request_stackTrace(const llvm::json::Object &request) {
 //     "targetId": {
 //       "type": "integer",
 //       "description": "Optional id of the target to step into."
-//     }
+//     },
+//     "granularity": {
+//       "$ref": "#/definitions/SteppingGranularity",
+//       "description": "Stepping granularity. If no granularity is specified, a granularity of `statement` is assumed."
 //   },
 //   "required": [ "threadId" ]
 // },
@@ -3223,7 +3244,11 @@ void request_stepIn(const llvm::json::Object &request) {
     // Remember the thread ID that caused the resume so we can set the
     // "threadCausedFocus" boolean value in the "stopped" events.
     g_dap.focus_tid = thread.GetThreadID();
-    thread.StepInto(step_in_target.c_str(), run_mode);
+    if (hasInstructionGranularity(*arguments)) {
+      thread.StepInstruction(/*step_over=*/ false);
+    } else {
+      thread.StepInto(step_in_target.c_str(), run_mode);
+    }
   } else {
     response["success"] = llvm::json::Value(false);
   }

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -3218,6 +3218,7 @@ void request_stackTrace(const llvm::json::Object &request) {
 //       "$ref": "#/definitions/SteppingGranularity",
 //       "description": "Stepping granularity. If no granularity is specified, a
 //                       granularity of `statement` is assumed."
+//     }
 //   },
 //   "required": [ "threadId" ]
 // },

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1990,7 +1990,8 @@ void request_launch(const llvm::json::Object &request) {
 
 // Check if the step-granularity is `instruction`
 static bool hasInstructionGranularity(const llvm::json::Object &requestArgs) {
-  if (std::optional<llvm::StringRef> value = requestArgs.getString("granularity"))
+  if (std::optional<llvm::StringRef> value =
+          requestArgs.getString("granularity"))
     return value == "instruction";
   return false;
 }
@@ -2025,7 +2026,8 @@ static bool hasInstructionGranularity(const llvm::json::Object &requestArgs) {
 //     },
 //     "granularity": {
 //       "$ref": "#/definitions/SteppingGranularity",
-//       "description": "Stepping granularity. If no granularity is specified, a granularity of `statement` is assumed."
+//       "description": "Stepping granularity. If no granularity is specified, a
+//                       granularity of `statement` is assumed."
 //     }
 //   },
 //   "required": [ "threadId" ]
@@ -2047,7 +2049,7 @@ void request_next(const llvm::json::Object &request) {
     // "threadCausedFocus" boolean value in the "stopped" events.
     g_dap.focus_tid = thread.GetThreadID();
     if (hasInstructionGranularity(*arguments)) {
-      thread.StepInstruction(/*step_over=*/ true);
+      thread.StepInstruction(/*step_over=*/true);
     } else {
       thread.StepOver();
     }
@@ -3214,7 +3216,8 @@ void request_stackTrace(const llvm::json::Object &request) {
 //     },
 //     "granularity": {
 //       "$ref": "#/definitions/SteppingGranularity",
-//       "description": "Stepping granularity. If no granularity is specified, a granularity of `statement` is assumed."
+//       "description": "Stepping granularity. If no granularity is specified, a
+//                       granularity of `statement` is assumed."
 //   },
 //   "required": [ "threadId" ]
 // },
@@ -3245,7 +3248,7 @@ void request_stepIn(const llvm::json::Object &request) {
     // "threadCausedFocus" boolean value in the "stopped" events.
     g_dap.focus_tid = thread.GetThreadID();
     if (hasInstructionGranularity(*arguments)) {
-      thread.StepInstruction(/*step_over=*/ false);
+      thread.StepInstruction(/*step_over=*/false);
     } else {
       thread.StepInto(step_in_target.c_str(), run_mode);
     }


### PR DESCRIPTION
VS Code requests the `instruction` stepping granularity if the assembly view is currently focused. By implementing `StepGranularity`, we can hence properly single-step through assembly code.