### PR TITLE
[MLIR] Fix inverted logic of LIT_USE_INTERNAL_SHELL

### DIFF
--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -23,7 +23,7 @@ config.name = "MLIR"
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-  use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+  use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 


### PR DESCRIPTION
The value of `LIT_USE_INTERNAL_SHELL` is inverted although it is not supposed to. The inversion was introduced in #65415.

Assume the environment variable `LIT_USE_INTERNAL_SHELL=0` (i.e. use `/bin/sh`) is set:
```py
use_lit_shell = True                                          # Use internal shell
lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")      # lit_shell_env = "0", i.e. use /bin/sh
if lit_shell_env:
  use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)  # use_lit_shell = not bool("0") = True, i.e. use internal shell

config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell) # execute_external = not True = False, i.e. use internal shell even though we explicitly switched off using `LIT_USE_INTERNAL_SHELL=0`.
```