### PR TITLE
[AArch64] Bail out for scalable vecs in areExtractShuffleVectors

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -16149,6 +16149,10 @@ static bool isSplatShuffle(Value *V) {
 /// or upper half of the vector elements.
 static bool areExtractShuffleVectors(Value *Op1, Value *Op2,
                                      bool AllowSplat = false) {
+  // Scalable types can't be extract shuffle vectors.
+  if (Op1->getType()->isScalableTy() || Op2->getType()->isScalableTy())
+    return false;
+
   auto areTypesHalfed = [](Value *FullV, Value *HalfV) {
     auto *FullTy = FullV->getType();
     auto *HalfTy = HalfV->getType();

--- a/llvm/test/Transforms/CodeGenPrepare/AArch64/sink-free-instructions.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/AArch64/sink-free-instructions.ll
@@ -984,3 +984,22 @@ if.else:
   ret <5 x float> %r.4
 }
 
+; This ran in an assert in `areExtractShuffleVectors`.
+define <vscale x 8 x i16> @scalable_types_cannot_be_extract_shuffle() {
+; CHECK-LABEL: @scalable_types_cannot_be_extract_shuffle(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[BROADCAST_SPLAT68:%.*]] = shufflevector <vscale x 8 x i8> zeroinitializer, <vscale x 8 x i8> poison, <vscale x 8 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = zext <vscale x 8 x i8> [[BROADCAST_SPLAT68]] to <vscale x 8 x i16>
+; CHECK-NEXT:    [[BROADCAST_SPLAT70:%.*]] = shufflevector <vscale x 8 x i8> zeroinitializer, <vscale x 8 x i8> poison, <vscale x 8 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = zext <vscale x 8 x i8> [[BROADCAST_SPLAT70]] to <vscale x 8 x i16>
+; CHECK-NEXT:    [[TMP2:%.*]] = sub <vscale x 8 x i16> [[TMP0]], [[TMP1]]
+; CHECK-NEXT:    ret <vscale x 8 x i16> [[TMP2]]
+;
+entry:
+  %broadcast.splat68 = shufflevector <vscale x 8 x i8> zeroinitializer, <vscale x 8 x i8> poison, <vscale x 8 x i32> zeroinitializer
+  %0 = zext <vscale x 8 x i8> %broadcast.splat68 to <vscale x 8 x i16>
+  %broadcast.splat70 = shufflevector <vscale x 8 x i8> zeroinitializer, <vscale x 8 x i8> poison, <vscale x 8 x i32> zeroinitializer
+  %1 = zext <vscale x 8 x i8> %broadcast.splat70 to <vscale x 8 x i16>
+  %2 = sub <vscale x 8 x i16> %0, %1
+  ret <vscale x 8 x i16> %2
+}


### PR DESCRIPTION
The added test triggers this assert in `areExtractShuffleVectors` that is called from `shouldSinkOperands`:

Assertion `(!isScalable() || isZero()) && "Request for a fixed element count on a scalable object"' failed.

I don't think scalable types can be extract shuffles, so bail early if this is the case.