### PR TITLE
[clang][ASTImporter] set nonnull type for var specialized from lambda template

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6613,10 +6613,9 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
     // to adopt template parameters.
     // updateLookupTableForTemplateParameters(**ToTPListOrErr);
   } else { // Full specialization
-    if (GetImportedOrCreateDecl(D2, D, Importer.getToContext(), DC,
-                                *BeginLocOrErr, *IdLocOrErr, VarTemplate,
-                                ToTmpTy, nullptr, D->getStorageClass(),
-                                TemplateArgs))
+    if (GetImportedOrCreateDecl(
+            D2, D, Importer.getToContext(), DC, *BeginLocOrErr, *IdLocOrErr,
+            VarTemplate, ToTmpTy, nullptr, D->getStorageClass(), TemplateArgs))
       return D2;
   }
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6582,6 +6582,8 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
       return std::move(Err);
   }
 
+  QualType ToTmpTy = Importer.getToContext().IntTy;
+  ToTmpTy = ToTmpTy.withCVRQualifiers(D->getType().getCVRQualifiers());
   using PartVarSpecDecl = VarTemplatePartialSpecializationDecl;
   // Create a new specialization.
   if (auto *FromPartial = dyn_cast<PartVarSpecDecl>(D)) {
@@ -6592,7 +6594,7 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
     PartVarSpecDecl *ToPartial;
     if (GetImportedOrCreateDecl(ToPartial, D, Importer.getToContext(), DC,
                                 *BeginLocOrErr, *IdLocOrErr, *ToTPListOrErr,
-                                VarTemplate, QualType(), nullptr,
+                                VarTemplate, ToTmpTy, nullptr,
                                 D->getStorageClass(), TemplateArgs))
       return ToPartial;
 
@@ -6613,7 +6615,7 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
   } else { // Full specialization
     if (GetImportedOrCreateDecl(D2, D, Importer.getToContext(), DC,
                                 *BeginLocOrErr, *IdLocOrErr, VarTemplate,
-                                QualType(), nullptr, D->getStorageClass(),
+                                ToTmpTy, nullptr, D->getStorageClass(),
                                 TemplateArgs))
       return D2;
   }

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -9919,6 +9919,19 @@ TEST_P(ImportTemplateParmDeclDefaultValue, ImportExistingVarTemplate) {
   testImport(FromLastD);
 }
 
+TEST_P(ASTImporterOptionSpecificTestBase, VarTemplatedLambdaInGlobalScope) {
+  Decl *FromTU = getTuDecl(
+      R"(
+        namespace { template <typename> auto m = [] {}; }
+        void bar() { auto n = m<int>; }
+      )",
+      Lang_CXX14, "input0.cc");
+  FunctionDecl *FromF = FirstDeclMatcher<FunctionDecl>().match(
+      FromTU, functionDecl(hasName("bar")));
+  FunctionDecl *ToF = Import(FromF, Lang_CXX14);
+  EXPECT_TRUE(ToF);
+}
+
 INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ASTImporterLookupTableTest,
                          DefaultTestValuesForRunOptions);
 

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -9919,7 +9919,7 @@ TEST_P(ImportTemplateParmDeclDefaultValue, ImportExistingVarTemplate) {
   testImport(FromLastD);
 }
 
-TEST_P(ASTImporterOptionSpecificTestBase, VarTemplatedLambdaInGlobalScope) {
+TEST_P(ASTImporterOptionSpecificTestBase, VarTemplatedLambdaWithCircularDeps) {
   Decl *FromTU = getTuDecl(
       R"(
         namespace { template <typename> auto m = [] {}; }


### PR DESCRIPTION
There's circular deps here when importing btw VarTemplateSpecializationDecl (m) and its type.

VarDecl is created with a null type QualType(), and the importing of its type will leads to linkage computation (for the templated lambda) which depends on the var's type (not yet imported).

This fix uses a non-null type instead of a null one. But this seems still cannot ensure the computation is correct.

Fixes #104622 