### PR TITLE
Build SanitizerCommon if ctx_profile enabled

### DIFF
--- a/compiler-rt/lib/CMakeLists.txt
+++ b/compiler-rt/lib/CMakeLists.txt
@@ -9,7 +9,7 @@ include(SanitizerUtils)
 #
 #TODO: Refactor sanitizer_common into smaller pieces (e.g. flag parsing, utils).
 if (COMPILER_RT_HAS_SANITIZER_COMMON AND
-    (COMPILER_RT_BUILD_SANITIZERS OR COMPILER_RT_BUILD_XRAY OR COMPILER_RT_BUILD_MEMPROF))
+    (COMPILER_RT_BUILD_SANITIZERS OR COMPILER_RT_BUILD_XRAY OR COMPILER_RT_BUILD_MEMPROF OR COMPILER_RT_BUILD_CTX_PROFILE))
   add_subdirectory(sanitizer_common)
 endif()
 


### PR DESCRIPTION
ctx_profile has a dependency on SanitizerCommon, so make sure it is built even if we otherwise disable sanitizers.

Otherwise there are errors like these:

    CMake Error at /home/npopov/repos/llvm-project/compiler-rt/cmake/Modules/AddCompilerRT.cmake:357 (add_library):
      Error evaluating generator expression:

        $<TARGET_OBJECTS:RTSanitizerCommon.x86_64>

      Objects of target "RTSanitizerCommon.x86_64" referenced but no such target
      exists.
    Call Stack (most recent call first):
      /home/npopov/repos/llvm-project/compiler-rt/lib/ctx_profile/CMakeLists.txt:25 (add_compiler_rt_runtime)