### PR TITLE
[NFC][ADT] Format StringRefTest.cpp to fit in 80 columns.

### DIFF
--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -939,16 +939,17 @@ struct GetDoubleStrings {
   bool AllowInexact;
   bool ShouldFail;
   double D;
-} DoubleStrings[] = {{"0", false, false, 0.0},
-                     {"0.0", false, false, 0.0},
-                     {"-0.0", false, false, -0.0},
-                     {"123.45", false, true, 123.45},
-                     {"123.45", true, false, 123.45},
-                     {"1.8e308", true, false, std::numeric_limits<double>::infinity()},
-                     {"1.8e308", false, true, std::numeric_limits<double>::infinity()},
-                     {"0x0.0000000000001P-1023", false, true, 0.0},
-                     {"0x0.0000000000001P-1023", true, false, 0.0},
-                    };
+} DoubleStrings[] = {
+    {"0", false, false, 0.0},
+    {"0.0", false, false, 0.0},
+    {"-0.0", false, false, -0.0},
+    {"123.45", false, true, 123.45},
+    {"123.45", true, false, 123.45},
+    {"1.8e308", true, false, std::numeric_limits<double>::infinity()},
+    {"1.8e308", false, true, std::numeric_limits<double>::infinity()},
+    {"0x0.0000000000001P-1023", false, true, 0.0},
+    {"0x0.0000000000001P-1023", true, false, 0.0},
+};
 
 TEST(StringRefTest, getAsDouble) {
   for (const auto &Entry : DoubleStrings) {
@@ -1117,7 +1118,8 @@ TEST(StringRefTest, StringLiteral) {
   constexpr StringRef StringRefs[] = {"Foo", "Bar"};
   EXPECT_EQ(StringRef("Foo"), StringRefs[0]);
   EXPECT_EQ(3u, (std::integral_constant<size_t, StringRefs[0].size()>::value));
-  EXPECT_EQ(false, (std::integral_constant<bool, StringRefs[0].empty()>::value));
+  EXPECT_EQ(false,
+            (std::integral_constant<bool, StringRefs[0].empty()>::value));
   EXPECT_EQ(StringRef("Bar"), StringRefs[1]);
 
   constexpr StringLiteral Strings[] = {"Foo", "Bar"};


### PR DESCRIPTION
- Fix a few lines of code that exceeded 80 column width.