### PR TITLE
[AMDGPU][GlobalISel] Disable fixed-point iteration in all Combiners

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
@@ -499,7 +499,11 @@ bool AMDGPUPostLegalizerCombiner::runOnMachineFunction(MachineFunction &MF) {
 
   CombinerInfo CInfo(/*AllowIllegalOps*/ false, /*ShouldLegalizeIllegal*/ true,
                      LI, EnableOpt, F.hasOptSize(), F.hasMinSize());
-
+  // Disable fixed-point iteration to reduce compile-time
+  CInfo.MaxIterations = 1;
+  CInfo.ObserverLvl = CombinerInfo::ObserverLevel::SinglePass;
+  // Legalizer performs DCE, so a full DCE pass is unnecessary.
+  CInfo.EnableFullDCE = false;
   AMDGPUPostLegalizerCombinerImpl Impl(MF, CInfo, TPC, *KB, /*CSEInfo*/ nullptr,
                                        RuleConfig, ST, MDT, LI);
   return Impl.combineMachineInstrs();

--- a/llvm/lib/Target/AMDGPU/AMDGPUPreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPreLegalizerCombiner.cpp
@@ -276,6 +276,12 @@ bool AMDGPUPreLegalizerCombiner::runOnMachineFunction(MachineFunction &MF) {
                 : &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
   CombinerInfo CInfo(/*AllowIllegalOps*/ true, /*ShouldLegalizeIllegal*/ false,
                      nullptr, EnableOpt, F.hasOptSize(), F.hasMinSize());
+  // Disable fixed-point iteration to reduce compile-time
+  CInfo.MaxIterations = 1;
+  CInfo.ObserverLvl = CombinerInfo::ObserverLevel::SinglePass;
+  // This is the first Combiner, so the input IR might contain dead
+  // instructions.
+  CInfo.EnableFullDCE = true;
   AMDGPUPreLegalizerCombinerImpl Impl(MF, CInfo, TPC, *KB, CSEInfo, RuleConfig,
                                       STI, MDT, STI.getLegalizerInfo());
   return Impl.combineMachineInstrs();

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
@@ -454,6 +454,12 @@ bool AMDGPURegBankCombiner::runOnMachineFunction(MachineFunction &MF) {
 
   CombinerInfo CInfo(/*AllowIllegalOps*/ false, /*ShouldLegalizeIllegal*/ true,
                      LI, EnableOpt, F.hasOptSize(), F.hasMinSize());
+  // Disable fixed-point iteration to reduce compile-time
+  CInfo.MaxIterations = 1;
+  CInfo.ObserverLvl = CombinerInfo::ObserverLevel::SinglePass;
+  // RegBankSelect seems not to leave dead instructions, so a full DCE pass is
+  // unnecessary.
+  CInfo.EnableFullDCE = false;
   AMDGPURegBankCombinerImpl Impl(MF, CInfo, TPC, *KB, /*CSEInfo*/ nullptr,
                                  RuleConfig, ST, MDT, LI);
   return Impl.combineMachineInstrs();

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/postlegalizercombiner-and.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/postlegalizercombiner-and.mir
@@ -203,6 +203,7 @@ body:             |
     ; CHECK-LABEL: name: remove_and_65535_groupstaticsize
     ; CHECK: liveins: $vgpr0_vgpr1
     ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %ptr:_(p1) = COPY $vgpr0_vgpr1
     ; CHECK-NEXT: %lds_size:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.groupstaticsize)
     ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
     ; CHECK-NEXT: %and:_(s32) = G_AND %lds_size, %mask
@@ -225,6 +226,7 @@ body:             |
     ; CHECK-LABEL: name: remove_and_131071_groupstaticsize
     ; CHECK: liveins: $vgpr0_vgpr1
     ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %ptr:_(p1) = COPY $vgpr0_vgpr1
     ; CHECK-NEXT: %lds_size:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.groupstaticsize)
     ; CHECK-NEXT: $vgpr0 = COPY %lds_size(s32)
     %ptr:_(p1) = COPY $vgpr0_vgpr1
@@ -245,6 +247,7 @@ body:             |
     ; CHECK-LABEL: name: no_remove_and_65536_groupstaticsize
     ; CHECK: liveins: $vgpr0_vgpr1
     ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %ptr:_(p1) = COPY $vgpr0_vgpr1
     ; CHECK-NEXT: %lds_size:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.groupstaticsize)
     ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65536
     ; CHECK-NEXT: %and:_(s32) = G_AND %lds_size, %mask
@@ -267,6 +270,7 @@ body:             |
     ; CHECK-LABEL: name: no_remove_and_32767_groupstaticsize
     ; CHECK: liveins: $vgpr0_vgpr1
     ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %ptr:_(p1) = COPY $vgpr0_vgpr1
     ; CHECK-NEXT: %lds_size:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.groupstaticsize)
     ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 32767
     ; CHECK-NEXT: %and:_(s32) = G_AND %lds_size, %mask
@@ -291,6 +295,8 @@ body:             |
     ; CHECK-LABEL: name: remove_and_umin_lhs_only
     ; CHECK: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4
     ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %ptr0:_(p1) = COPY $vgpr0_vgpr1
+    ; CHECK-NEXT: %ptr1:_(p1) = COPY $vgpr2_vgpr3
     ; CHECK-NEXT: %val:_(s32) = COPY $vgpr4
     ; CHECK-NEXT: %k255:_(s32) = G_CONSTANT i32 255
     ; CHECK-NEXT: %umin0:_(s32) = G_UMIN %val, %k255
@@ -316,6 +322,8 @@ body:             |
     ; CHECK-LABEL: name: remove_and_umin_rhs_only
     ; CHECK: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4
     ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %ptr0:_(p1) = COPY $vgpr0_vgpr1
+    ; CHECK-NEXT: %ptr1:_(p1) = COPY $vgpr2_vgpr3
     ; CHECK-NEXT: %val:_(s32) = COPY $vgpr4
     ; CHECK-NEXT: %k255:_(s32) = G_CONSTANT i32 255
     ; CHECK-NEXT: %umin0:_(s32) = G_UMIN %val, %k255


### PR DESCRIPTION
Disable fixed-point iteration in all AMDGPU Combiners after #102163.

This saves around 2% compile time in ad hoc testing on some large
graphics shaders. I did not notice any regressions in the generated
code, just a bunch of harmless differences in instruction selection and
register allocation.
