### PR TITLE
[DebugInfo][DWARF] Set is_stmt on first non-line-0 instruction in BB

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2119,9 +2119,12 @@ void DwarfDebug::beginInstruction(const MachineInstr *MI) {
     PrologEndLoc = DebugLoc();
   }
   // If the line changed, we call that a new statement; unless we went to
-  // line 0 and came back, in which case it is not a new statement.
+  // line 0 and came back, in which case it is not a new statement. We also
+  // mark is_stmt for the first non-0 line in each BB, in case a predecessor BB
+  // ends with a different line.
   unsigned OldLine = PrevInstLoc ? PrevInstLoc.getLine() : LastAsmLine;
-  if (DL.getLine() && DL.getLine() != OldLine)
+  if (DL.getLine() &&
+      (DL.getLine() != OldLine || PrevInstBB != MI->getParent()))
     Flags |= DWARF2_FLAG_IS_STMT;
 
   const MDNode *Scope = DL.getScope();

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2061,10 +2061,8 @@ void DwarfDebug::beginInstruction(const MachineInstr *MI) {
   unsigned LastAsmLine =
       Asm->OutStreamer->getContext().getCurrentDwarfLoc().getLine();
 
-  bool PrevInstInSameSection =
-      (!PrevInstBB ||
-       PrevInstBB->getSectionID() == MI->getParent()->getSectionID());
-  if (DL == PrevInstLoc && PrevInstInSameSection) {
+  bool PrevInstInDiffBB = PrevInstBB && PrevInstBB != MI->getParent();
+  if (DL == PrevInstLoc && !PrevInstInDiffBB) {
     // If we have an ongoing unspecified location, nothing to do here.
     if (!DL)
       return;
@@ -2093,8 +2091,7 @@ void DwarfDebug::beginInstruction(const MachineInstr *MI) {
     //   possibly debug information; we want it to have a source location.
     // - Instruction is at the top of a block; we don't want to inherit the
     //   location from the physically previous (maybe unrelated) block.
-    if (UnknownLocations == Enable || PrevLabel ||
-        (PrevInstBB && PrevInstBB != MI->getParent())) {
+    if (UnknownLocations == Enable || PrevLabel || PrevInstInDiffBB) {
       // Preserve the file and column numbers, if we can, to save space in
       // the encoded line table.
       // Do not update PrevInstLoc, it remembers the last non-0 line.
@@ -2123,8 +2120,7 @@ void DwarfDebug::beginInstruction(const MachineInstr *MI) {
   // mark is_stmt for the first non-0 line in each BB, in case a predecessor BB
   // ends with a different line.
   unsigned OldLine = PrevInstLoc ? PrevInstLoc.getLine() : LastAsmLine;
-  if (DL.getLine() &&
-      (DL.getLine() != OldLine || PrevInstBB != MI->getParent()))
+  if (DL.getLine() && (DL.getLine() != OldLine || PrevInstInDiffBB))
     Flags |= DWARF2_FLAG_IS_STMT;
 
   const MDNode *Scope = DL.getScope();

--- a/llvm/test/CodeGen/Thumb2/pr52817.ll
+++ b/llvm/test/CodeGen/Thumb2/pr52817.ll
@@ -24,6 +24,7 @@ define i32 @test(ptr %arg, ptr %arg1, ptr %arg2) #0 !dbg !6 {
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:  LBB0_1: @ %bb3
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    .loc 1 0 0 is_stmt 0 @ :0:0
 ; CHECK-NEXT:    adds r5, r3, #1
 ; CHECK-NEXT:    str.w lr, [r2]
 ; CHECK-NEXT:    cmp.w lr, #0
@@ -36,7 +37,7 @@ define i32 @test(ptr %arg, ptr %arg1, ptr %arg2) #0 !dbg !6 {
 ; CHECK-NEXT:    movne r6, #0
 ; CHECK-NEXT:  Ltmp0:
 ; CHECK-NEXT:    @DEBUG_VALUE: test:this <- [DW_OP_LLVM_arg 0, DW_OP_plus_uconst 135168, DW_OP_LLVM_arg 1, DW_OP_constu 4, DW_OP_mul, DW_OP_plus, DW_OP_plus_uconst 4, DW_OP_stack_value] $r0, $r5
-; CHECK-NEXT:    .loc 1 28 24 prologue_end @ test.cpp:28:24
+; CHECK-NEXT:    .loc 1 28 24 prologue_end is_stmt 1 @ test.cpp:28:24
 ; CHECK-NEXT:    strne.w r6, [r8]
 ; CHECK-NEXT:    moveq r6, #1
 ; CHECK-NEXT:    ldr r4, [r4, #4]

--- a/llvm/test/CodeGen/X86/fsafdo_test1.ll
+++ b/llvm/test/CodeGen/X86/fsafdo_test1.ll
@@ -4,9 +4,9 @@
 ; Check that fs-afdo discriminators are generated.
 ; V01: .loc    1 7 3 is_stmt 0 discriminator 2 # foo.c:7:3
 ; V01: .loc    1 9 5 is_stmt 1 discriminator 2 # foo.c:9:5
-; V0: .loc    1 9 5 discriminator 11266 # foo.c:9:5
+; V0: .loc    1 9 5 is_stmt 1 discriminator 11266 # foo.c:9:5
 ; V0: .loc    1 7 3 is_stmt 1 discriminator 11266 # foo.c:7:3
-; V1: .loc    1 9 5 discriminator 514 # foo.c:9:5
+; V1: .loc    1 9 5 is_stmt 1 discriminator 514 # foo.c:9:5
 ; V1: .loc    1 7 3 is_stmt 1 discriminator 258 # foo.c:7:3
 ; Check that variable __llvm_fs_discriminator__ is generated.
 ; V01: .type   __llvm_fs_discriminator__,@object # @__llvm_fs_discriminator__

--- a/llvm/test/CodeGen/X86/fsafdo_test4.ll
+++ b/llvm/test/CodeGen/X86/fsafdo_test4.ll
@@ -7,8 +7,8 @@
 ; CHECK: .loc    1 0 3 # foo.c:0:3
 ; CHECK: .loc    1 9 5 is_stmt 1 discriminator 2 # foo.c:9:5
 ; CHECK: .loc    1 0 5 is_stmt 0 # :0:5
-; CHECK: .loc    1 9 5 discriminator 2 # foo.c:9:5
-; CHECK: .loc    1 0 5 # :0:5
+; CHECK: .loc    1 9 5 is_stmt 1 discriminator 2 # foo.c:9:5
+; CHECK: .loc    1 0 5 is_stmt 0 # :0:5
 ; CHECK: .loc	   1 7 3 is_stmt 1 discriminator 2 # foo.c:7:3
 ; CHECK: .loc    1 14 3 # foo.c:14:3
 ; Check that variable __llvm_fs_discriminator__ is NOT generated.

--- a/llvm/test/DebugInfo/Generic/is_stmt-at-block-start.ll
+++ b/llvm/test/DebugInfo/Generic/is_stmt-at-block-start.ll
@@ -1,0 +1,38 @@
+;; Checks that when an instruction at the start of a BasicBlock has the same
+;; DebugLoc as the instruction at the end of the previous BasicBlock, we add
+;; is_stmt to the new line, to ensure that we still step on it if we arrive from
+;; a BasicBlock other than the immediately preceding one.
+
+; RUN: %llc_dwarf -O0 -filetype=obj < %s | llvm-dwarfdump --debug-line - | FileCheck %s
+
+; CHECK:      {{0x[0-9a-f]+}}     13      5 {{.+}} is_stmt
+; CHECK-NEXT: {{0x[0-9a-f]+}}     13     25 {{.+}} is_stmt
+
+define void @_Z1fi(i1 %cond) !dbg !21 {
+entry:
+  br i1 %cond, label %if.then2, label %if.else4
+
+if.then2:                                         ; preds = %entry
+  br label %if.end8, !dbg !24
+
+if.else4:                                         ; preds = %entry
+  %0 = load i32, ptr null, align 4, !dbg !28
+  %call5 = call i1 null(i32 %0)
+  ret void
+
+if.end8:                                          ; preds = %if.then2
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!20}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 20.0.0", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.cpp", directory: "/home/gbtozers/dev/upstream-llvm")
+!20 = !{i32 2, !"Debug Info Version", i32 3}
+!21 = distinct !DISubprogram(name: "f", linkageName: "_Z1fi", scope: !1, file: !1, line: 7, type: !22, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!22 = distinct !DISubroutineType(types: !23)
+!23 = !{null}
+!24 = !DILocation(line: 13, column: 5, scope: !25)
+!25 = distinct !DILexicalBlock(scope: !21, file: !1, line: 11, column: 27)
+!28 = !DILocation(line: 13, column: 25, scope: !25)

--- a/llvm/test/DebugInfo/Generic/is_stmt-at-block-start.ll
+++ b/llvm/test/DebugInfo/Generic/is_stmt-at-block-start.ll
@@ -6,7 +6,7 @@
 ; RUN: %llc_dwarf -O0 -filetype=obj < %s | llvm-dwarfdump --debug-line - | FileCheck %s
 
 ; CHECK:      {{0x[0-9a-f]+}}     13      5 {{.+}} is_stmt
-; CHECK-NEXT: {{0x[0-9a-f]+}}     13     25 {{.+}} is_stmt
+; CHECK-NEXT: {{0x[0-9a-f]+}}     13      5 {{.+}} is_stmt
 
 define void @_Z1fi(i1 %cond) !dbg !21 {
 entry:
@@ -16,7 +16,7 @@ if.then2:                                         ; preds = %entry
   br label %if.end8, !dbg !24
 
 if.else4:                                         ; preds = %entry
-  %0 = load i32, ptr null, align 4, !dbg !28
+  %0 = load i32, ptr null, align 4, !dbg !24
   %call5 = call i1 null(i32 %0)
   ret void
 
@@ -35,4 +35,3 @@ if.end8:                                          ; preds = %if.then2
 !23 = !{null}
 !24 = !DILocation(line: 13, column: 5, scope: !25)
 !25 = distinct !DILexicalBlock(scope: !21, file: !1, line: 11, column: 27)
-!28 = !DILocation(line: 13, column: 25, scope: !25)

--- a/llvm/test/DebugInfo/MIR/X86/empty-inline.mir
+++ b/llvm/test/DebugInfo/MIR/X86/empty-inline.mir
@@ -14,7 +14,9 @@
 # CHECK: Address            Line   Column File   ISA Discriminator OpIndex Flags
 # CHECK-NEXT:                ---
 # CHECK-NEXT:                 25      0      1   0             0         0 is_stmt
+# CHECK-NEXT:                  0      0      1   0             0         0
 # CHECK-NEXT:                 29     28      1   0             0         0 is_stmt prologue_end
+# CHECK-NEXT:                 29     28      1   0             0         0 is_stmt
 # CHECK-NEXT:                 29     28      1   0             0         0 is_stmt end_sequence
 --- |
   source_filename = "t.ll"

--- a/llvm/test/DebugInfo/X86/discriminator.ll
+++ b/llvm/test/DebugInfo/X86/discriminator.ll
@@ -59,4 +59,4 @@ attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "frame-pointer"=
 
 ; CHECK: Address            Line   Column File   ISA Discriminator OpIndex Flags
 ; CHECK: ------------------ ------ ------ ------ --- ------------- ------- -------------
-; CHECK: 0x000000000000000a      2      0      1   0            42       0 {{$}}
+; CHECK: 0x000000000000000a      2      0      1   0            42       0 is_stmt{{$}}


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/104695

This patch adds the is_stmt flag to line table entries for the first instruction with a non-0 line location in each basic block, to ensure that it will be used for stepping even if the last instruction in the previous basic block had the same line number; this is important for cases where the new BB is reachable from BBs other than the preceding block.