### PR TITLE
[mlir] [tablegen] Make `hasSummary` and `hasDescription` useful

### DIFF
--- a/mlir/lib/TableGen/Operator.cpp
+++ b/mlir/lib/TableGen/Operator.cpp
@@ -798,14 +798,14 @@ const InferredResultType &Operator::getInferredResultType(int index) const {
 ArrayRef<SMLoc> Operator::getLoc() const { return def.getLoc(); }
 
 bool Operator::hasDescription() const {
-  return def.getValue("description") != nullptr;
+  return !getDescription().trim().empty();
 }
 
 StringRef Operator::getDescription() const {
   return def.getValueAsString("description");
 }
 
-bool Operator::hasSummary() const { return def.getValue("summary") != nullptr; }
+bool Operator::hasSummary() const { return !getSummary().trim().empty(); }
 
 StringRef Operator::getSummary() const {
   return def.getValueAsString("summary");


### PR DESCRIPTION
The `hasSummary` and `hasDescription` functions are currently useless as they check if the corresponding `summary` and `description` are present. However, these values are set to a default value of `""`, and so these functions always return true.

This PR changes these functions to check if the summary and description are just whitespace, which is presumably closer to their original intent.

@math-fehr 
@zero9178 