### PR TITLE
[LLVM][Transforms] Correct LoopSimplify unique block placement.

### DIFF
--- a/llvm/lib/Transforms/Utils/LoopSimplify.cpp
+++ b/llvm/lib/Transforms/Utils/LoopSimplify.cpp
@@ -389,7 +389,7 @@ static BasicBlock *insertUniqueBackedgeBlock(Loop *L, BasicBlock *Preheader,
                     << BEBlock->getName() << "\n");
 
   // Move the new backedge block to right after the last backedge block.
-  Function::iterator InsertPos = ++BackedgeBlocks.back()->getIterator();
+  Function::iterator InsertPos = ++BackedgeBlocks.front()->getIterator();
   F->splice(InsertPos, F, BEBlock->getIterator());
 
   // Now that the block has been inserted into the function, create PHI nodes in

--- a/llvm/test/Analysis/MemorySSA/pr43427.ll
+++ b/llvm/test/Analysis/MemorySSA/pr43427.ll
@@ -22,15 +22,15 @@
 ; CHECK-NEXT: MemoryUse([[NO2]])
 ; CHECK-NEXT:  %cleanup.dest = load i32, ptr undef, align 1
 
-; CHECK: lbl1.backedge:
-; CHECK-NEXT:  [[NO9]] = MemoryPhi({cleanup,[[NO7]]},{if.else,2})
-; CHECK-NEXT:   br label %lbl1
-
 ; CHECK: cleanup.cont:
 ; CHECK-NEXT: ; [[NO6:.*]] = MemoryDef([[NO7]])
 ; CHECK-NEXT:   store i16 undef, ptr %e, align 1
 ; CHECK-NEXT:  3 = MemoryDef([[NO6]])
 ; CHECK-NEXT:   call void @llvm.lifetime.end.p0(i64 1, ptr null)
+
+; CHECK: lbl1.backedge:
+; CHECK-NEXT:  [[NO9]] = MemoryPhi({cleanup,[[NO7]]},{if.else,2})
+; CHECK-NEXT:   br label %lbl1
 
 define void @f() {
 entry:

--- a/llvm/test/CodeGen/X86/fold-loop-of-urem.ll
+++ b/llvm/test/CodeGen/X86/fold-loop-of-urem.ll
@@ -914,7 +914,7 @@ define void @simple_urem_multi_latch_non_canonical(i32 %N, i32 %rem_amt) nounwin
 ; CHECK-NEXT:    xorl %r13d, %r13d
 ; CHECK-NEXT:    jmp .LBB15_2
 ; CHECK-NEXT:    .p2align 4, 0x90
-; CHECK-NEXT:  .LBB15_3: # %for.body.backedge
+; CHECK-NEXT:  .LBB15_4: # %for.body.backedge
 ; CHECK-NEXT:    # in Loop: Header=BB15_2 Depth=1
 ; CHECK-NEXT:    incl %r14d
 ; CHECK-NEXT:    cmpl %ebx, %r14d
@@ -928,12 +928,12 @@ define void @simple_urem_multi_latch_non_canonical(i32 %N, i32 %rem_amt) nounwin
 ; CHECK-NEXT:    movl %eax, %r15d
 ; CHECK-NEXT:    callq do_stuff0@PLT
 ; CHECK-NEXT:    testb $1, %r15b
-; CHECK-NEXT:    je .LBB15_3
-; CHECK-NEXT:  # %bb.4: # %for.body0
+; CHECK-NEXT:    je .LBB15_4
+; CHECK-NEXT:  # %bb.3: # %for.body0
 ; CHECK-NEXT:    # in Loop: Header=BB15_2 Depth=1
 ; CHECK-NEXT:    callq do_stuff1@PLT
 ; CHECK-NEXT:    cmpl %r13d, %ebp
-; CHECK-NEXT:    jne .LBB15_3
+; CHECK-NEXT:    jne .LBB15_4
 ; CHECK-NEXT:  # %bb.5:
 ; CHECK-NEXT:    addq $8, %rsp
 ; CHECK-NEXT:    popq %rbx

--- a/llvm/test/Transforms/IndVarSimplify/2011-10-27-lftrnull.ll
+++ b/llvm/test/Transforms/IndVarSimplify/2011-10-27-lftrnull.ll
@@ -11,12 +11,12 @@ define void @test() nounwind {
 ; CHECK-NEXT:    br label [[WHILE_COND:%.*]]
 ; CHECK:       while.cond.loopexit:
 ; CHECK-NEXT:    br label [[WHILE_COND_BACKEDGE:%.*]]
+; CHECK:       while.cond.backedge:
+; CHECK-NEXT:    br label [[WHILE_COND]]
 ; CHECK:       while.cond:
 ; CHECK-NEXT:    br i1 true, label [[WHILE_END:%.*]], label [[WHILE_BODY:%.*]]
 ; CHECK:       while.body:
 ; CHECK-NEXT:    br i1 undef, label [[IF_THEN165:%.*]], label [[WHILE_COND_BACKEDGE]]
-; CHECK:       while.cond.backedge:
-; CHECK-NEXT:    br label [[WHILE_COND]]
 ; CHECK:       if.then165:
 ; CHECK-NEXT:    br i1 undef, label [[WHILE_COND_BACKEDGE]], label [[FOR_BODY_LR_PH_I81:%.*]]
 ; CHECK:       for.body.lr.ph.i81:

--- a/llvm/test/Transforms/IndVarSimplify/invalidate-modified-lcssa-phi.ll
+++ b/llvm/test/Transforms/IndVarSimplify/invalidate-modified-lcssa-phi.ll
@@ -11,6 +11,8 @@ define void @test(i1 %c) {
 ; CHECK-NEXT:    br label [[HEADER_1:%.*]]
 ; CHECK:       header.1.loopexit:
 ; CHECK-NEXT:    br label [[HEADER_1_BACKEDGE:%.*]]
+; CHECK:       header.1.backedge:
+; CHECK-NEXT:    br label [[HEADER_1]]
 ; CHECK:       header.1:
 ; CHECK-NEXT:    br label [[HEADER_2:%.*]]
 ; CHECK:       header.2:
@@ -19,8 +21,6 @@ define void @test(i1 %c) {
 ; CHECK-NEXT:    br label [[HEADER_1_LOOPEXIT:%.*]]
 ; CHECK:       latch.2:
 ; CHECK-NEXT:    br label [[HEADER_1_BACKEDGE]]
-; CHECK:       header.1.backedge:
-; CHECK-NEXT:    br label [[HEADER_1]]
 ;
 entry:
   br label %header.1

--- a/llvm/test/Transforms/IndVarSimplify/rewrite-loop-exit-value.ll
+++ b/llvm/test/Transforms/IndVarSimplify/rewrite-loop-exit-value.ll
@@ -70,10 +70,10 @@ define i32 @test3(ptr %var) {
 ; CHECK-NEXT:    [[INDVAR]] = add i32 [[PHI_INDVAR]], 1
 ; CHECK-NEXT:    [[COND2:%.*]] = icmp eq i32 [[INDVAR]], 10
 ; CHECK-NEXT:    br i1 [[COND2]], label [[HEADER_BACKEDGE]], label [[BODY:%.*]]
-; CHECK:       header.backedge:
-; CHECK-NEXT:    br label [[HEADER]]
 ; CHECK:       body:
 ; CHECK-NEXT:    br i1 [[COND1]], label [[HEADER_BACKEDGE]], label [[EXIT:%.*]]
+; CHECK:       header.backedge:
+; CHECK-NEXT:    br label [[HEADER]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret i32 [[PHI_INDVAR]]
 ;

--- a/llvm/test/Transforms/LICM/hoist-mustexec.ll
+++ b/llvm/test/Transforms/LICM/hoist-mustexec.ll
@@ -501,11 +501,11 @@ define i32 @test-multiple-latch(ptr noalias nocapture readonly %a) nounwind uwta
 ; CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[IV]], 1
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[ADD]], 0
 ; CHECK-NEXT:    br i1 [[CMP]], label [[CONTINUE2:%.*]], label [[FOR_BODY_BACKEDGE]]
-; CHECK:       for.body.backedge:
-; CHECK-NEXT:    br label [[FOR_BODY]]
 ; CHECK:       continue2:
 ; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp eq i32 [[INC]], 1000
 ; CHECK-NEXT:    br i1 [[EXITCOND]], label [[FOR_COND_CLEANUP:%.*]], label [[FOR_BODY_BACKEDGE]]
+; CHECK:       for.body.backedge:
+; CHECK-NEXT:    br label [[FOR_BODY]]
 ; CHECK:       for.cond.cleanup:
 ; CHECK-NEXT:    [[ADD_LCSSA:%.*]] = phi i32 [ [[ADD]], [[CONTINUE2]] ]
 ; CHECK-NEXT:    ret i32 [[ADD_LCSSA]]

--- a/llvm/test/Transforms/LoopSimplify/preserve-llvm-loop-metadata.ll
+++ b/llvm/test/Transforms/LoopSimplify/preserve-llvm-loop-metadata.ll
@@ -30,11 +30,11 @@ while.end:                                        ; preds = %while.cond
 ; CHECK: if.then
 ; CHECK-NOT: br {{.*}}!llvm.loop{{.*}}
 
-; CHECK: while.cond.backedge:
-; CHECK: br label %while.cond, !llvm.loop !0
-
 ; CHECK: if.else
 ; CHECK-NOT: br {{.*}}!llvm.loop{{.*}}
+
+; CHECK: while.cond.backedge:
+; CHECK: br label %while.cond, !llvm.loop !0
 
 ; CHECK-LABEL: @test2
 ; CHECK: for.body:

--- a/llvm/test/Transforms/LoopSimplify/unique-backedge-block-position.ll
+++ b/llvm/test/Transforms/LoopSimplify/unique-backedge-block-position.ll
@@ -1,0 +1,32 @@
+; RUN: opt < %s -passes='loop-simplify' -S | FileCheck %s
+
+; llvm/llvm-project#15968: loop-simplify's insertUniqueBackedgeBlock inserted
+; in the middle of blocks, instead of past the final backedge (as documented)
+
+; CHECK: define void @test_function
+define void @test_function() {
+entry:
+  br label %loop_header
+
+; CHECK: loop_header:
+loop_header:
+  %i = phi i32 [ 0, %entry ], [ %next_value_1, %backedge_block_1 ], [ %next_value_2, %backedge_block_2 ]
+
+  %condition = icmp slt i32 %i, 5
+  br i1 %condition, label %backedge_block_1, label %backedge_block_2
+
+; CHECK: backedge_block_1:
+backedge_block_1:
+  %next_value_1 = add i32 %i, 1
+  br label %loop_header
+
+; CHECK: backedge_block_2:
+backedge_block_2:
+  %next_value_2 = add i32 %i, 2
+  br label %loop_header
+
+; CHECK: loop_header.backedge:
+
+loop_exit:
+  ret void
+}

--- a/llvm/test/Transforms/LoopSimplifyCFG/constant-fold-branch.ll
+++ b/llvm/test/Transforms/LoopSimplifyCFG/constant-fold-branch.ll
@@ -16,12 +16,12 @@ define i32 @dead_backedge_test_branch_loop(i32 %end) {
 ; CHECK-NEXT:    [[I_1:%.*]] = add i32 [[I]], 1
 ; CHECK-NEXT:    [[CMP1:%.*]] = icmp slt i32 [[I_1]], 100
 ; CHECK-NEXT:    br i1 [[CMP1]], label [[HEADER_BACKEDGE]], label [[DEAD_BACKEDGE:%.*]]
-; CHECK:       header.backedge:
-; CHECK-NEXT:    [[I_BE]] = phi i32 [ [[I_1]], [[HEADER]] ], [ [[I_2:%.*]], [[DEAD_BACKEDGE]] ]
-; CHECK-NEXT:    br label [[HEADER]]
 ; CHECK:       dead_backedge:
-; CHECK-NEXT:    [[I_2]] = add i32 [[I_1]], 10
+; CHECK-NEXT:    [[I_2:%.*]] = add i32 [[I_1]], 10
 ; CHECK-NEXT:    br i1 false, label [[HEADER_BACKEDGE]], label [[EXIT:%.*]]
+; CHECK:       header.backedge:
+; CHECK-NEXT:    [[I_BE]] = phi i32 [ [[I_1]], [[HEADER]] ], [ [[I_2]], [[DEAD_BACKEDGE]] ]
+; CHECK-NEXT:    br label [[HEADER]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    [[I_2_LCSSA:%.*]] = phi i32 [ [[I_2]], [[DEAD_BACKEDGE]] ]
 ; CHECK-NEXT:    ret i32 [[I_2_LCSSA]]
@@ -53,14 +53,14 @@ define i32 @dead_backedge_test_switch_loop(i32 %end) {
 ; CHECK-NEXT:    [[I_1:%.*]] = add i32 [[I]], 1
 ; CHECK-NEXT:    [[CMP1:%.*]] = icmp slt i32 [[I_1]], 100
 ; CHECK-NEXT:    br i1 [[CMP1]], label [[HEADER_BACKEDGE]], label [[DEAD_BACKEDGE:%.*]]
-; CHECK:       header.backedge:
-; CHECK-NEXT:    [[I_BE]] = phi i32 [ [[I_1]], [[HEADER]] ], [ [[I_2:%.*]], [[DEAD_BACKEDGE]] ]
-; CHECK-NEXT:    br label [[HEADER]]
 ; CHECK:       dead_backedge:
-; CHECK-NEXT:    [[I_2]] = add i32 [[I_1]], 10
+; CHECK-NEXT:    [[I_2:%.*]] = add i32 [[I_1]], 10
 ; CHECK-NEXT:    switch i32 1, label [[EXIT:%.*]] [
 ; CHECK-NEXT:    i32 0, label [[HEADER_BACKEDGE]]
 ; CHECK-NEXT:    ]
+; CHECK:       header.backedge:
+; CHECK-NEXT:    [[I_BE]] = phi i32 [ [[I_1]], [[HEADER]] ], [ [[I_2]], [[DEAD_BACKEDGE]] ]
+; CHECK-NEXT:    br label [[HEADER]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    [[I_2_LCSSA:%.*]] = phi i32 [ [[I_2]], [[DEAD_BACKEDGE]] ]
 ; CHECK-NEXT:    ret i32 [[I_2_LCSSA]]
@@ -2178,10 +2178,10 @@ define i32 @intermediate_complex_subloop_branch_from_inner_to_parent(i1 %cond1, 
 ; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP:%.*]]
 ; CHECK:       intermediate_loop:
 ; CHECK-NEXT:    br i1 [[COND3:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE:%.*]], label [[INTERMEDIATE_BLOCK:%.*]]
-; CHECK:       intermediate_loop.backedge:
-; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_block:
 ; CHECK-NEXT:    br i1 [[COND2:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE]], label [[INTERMEDIATE_EXIT:%.*]]
+; CHECK:       intermediate_loop.backedge:
+; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_exit:
 ; CHECK-NEXT:    br i1 false, label [[LOOP_3_BACKEDGE]], label [[LOOP_2_BACKEDGE]]
 ; CHECK:       loop_3_backedge:
@@ -2261,10 +2261,10 @@ define i32 @intermediate_complex_subloop_switch_from_inner_to_parent(i1 %cond1, 
 ; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP:%.*]]
 ; CHECK:       intermediate_loop:
 ; CHECK-NEXT:    br i1 [[COND3:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE:%.*]], label [[INTERMEDIATE_BLOCK:%.*]]
-; CHECK:       intermediate_loop.backedge:
-; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_block:
 ; CHECK-NEXT:    br i1 [[COND2:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE]], label [[INTERMEDIATE_EXIT:%.*]]
+; CHECK:       intermediate_loop.backedge:
+; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_exit:
 ; CHECK-NEXT:    switch i32 1, label [[LOOP_2_BACKEDGE]] [
 ; CHECK-NEXT:    i32 0, label [[LOOP_3_BACKEDGE]]
@@ -2347,10 +2347,10 @@ define i32 @intermediate_complex_subloop_branch_from_inner_to_grandparent(i1 %co
 ; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP:%.*]]
 ; CHECK:       intermediate_loop:
 ; CHECK-NEXT:    br i1 [[COND3:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE:%.*]], label [[INTERMEDIATE_BLOCK:%.*]]
-; CHECK:       intermediate_loop.backedge:
-; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_block:
 ; CHECK-NEXT:    br i1 [[COND2:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE]], label [[INTERMEDIATE_EXIT:%.*]]
+; CHECK:       intermediate_loop.backedge:
+; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_exit:
 ; CHECK-NEXT:    br i1 false, label [[LOOP_3_BACKEDGE]], label [[LOOP_1_BACKEDGE_LOOPEXIT:%.*]]
 ; CHECK:       loop_3_backedge:
@@ -2434,10 +2434,10 @@ define i32 @intermediate_complex_subloop_switch_from_inner_to_grandparent(i1 %co
 ; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP:%.*]]
 ; CHECK:       intermediate_loop:
 ; CHECK-NEXT:    br i1 [[COND3:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE:%.*]], label [[INTERMEDIATE_BLOCK:%.*]]
-; CHECK:       intermediate_loop.backedge:
-; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_block:
 ; CHECK-NEXT:    br i1 [[COND2:%.*]], label [[INTERMEDIATE_LOOP_BACKEDGE]], label [[INTERMEDIATE_EXIT:%.*]]
+; CHECK:       intermediate_loop.backedge:
+; CHECK-NEXT:    br label [[INTERMEDIATE_LOOP]]
 ; CHECK:       intermediate_exit:
 ; CHECK-NEXT:    switch i32 1, label [[LOOP_1_BACKEDGE_LOOPEXIT:%.*]] [
 ; CHECK-NEXT:    i32 0, label [[LOOP_3_BACKEDGE]]

--- a/llvm/test/Transforms/LoopStrengthReduce/X86/incorrect-offset-scaling.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/X86/incorrect-offset-scaling.ll
@@ -11,10 +11,10 @@ define void @incorrect_offset_scaling(i1 %c, i1 %c2, i1 %c3, ptr %p, i64, ptr) {
 ; CHECK-NEXT:    br label [[L:%.*]]
 ; CHECK:       L.loopexit:
 ; CHECK-NEXT:    br label [[L_BACKEDGE:%.*]]
-; CHECK:       L:
-; CHECK-NEXT:    br i1 [[C]], label [[L_BACKEDGE]], label [[L1_PREHEADER:%.*]]
 ; CHECK:       L.backedge:
 ; CHECK-NEXT:    br label [[L]]
+; CHECK:       L:
+; CHECK-NEXT:    br i1 [[C]], label [[L_BACKEDGE]], label [[L1_PREHEADER:%.*]]
 ; CHECK:       L1.preheader:
 ; CHECK-NEXT:    br label [[L1:%.*]]
 ; CHECK:       L1:

--- a/llvm/test/Transforms/LoopVectorize/create-induction-resume.ll
+++ b/llvm/test/Transforms/LoopVectorize/create-induction-resume.ll
@@ -34,13 +34,13 @@ define void @test(i32 %arg, i32 %L1.limit, i32 %L2.switch, i1 %c, ptr %dst) {
 ; CHECK-NEXT:    br label [[L2_HEADER:%.*]]
 ; CHECK:       L2.header.loopexit:
 ; CHECK-NEXT:    br label [[L2_HEADER_BACKEDGE:%.*]]
+; CHECK:       L2.header.backedge:
+; CHECK-NEXT:    br label [[L2_HEADER]]
 ; CHECK:       L2.header:
 ; CHECK-NEXT:    switch i32 [[L2_SWITCH:%.*]], label [[L2_HEADER_BACKEDGE]] [
 ; CHECK-NEXT:      i32 8, label [[L2_EXIT:%.*]]
 ; CHECK-NEXT:      i32 20, label [[L2_INNER_HEADER_PREHEADER:%.*]]
 ; CHECK-NEXT:    ]
-; CHECK:       L2.header.backedge:
-; CHECK-NEXT:    br label [[L2_HEADER]]
 ; CHECK:       L2.Inner.header.preheader:
 ; CHECK-NEXT:    br i1 false, label [[SCALAR_PH:%.*]], label [[VECTOR_PH:%.*]]
 ; CHECK:       vector.ph:

--- a/llvm/test/Transforms/LoopVectorize/loop-form.ll
+++ b/llvm/test/Transforms/LoopVectorize/loop-form.ll
@@ -1023,14 +1023,14 @@ define i32 @multiple_latch2(ptr %p) {
 ; CHECK-NEXT:    [[INC]] = add nsw i32 [[I_02]], 1
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[INC]], 16
 ; CHECK-NEXT:    br i1 [[CMP]], label [[FOR_BODY_BACKEDGE]], label [[FOR_SECOND:%.*]]
-; CHECK:       for.body.backedge:
-; CHECK-NEXT:    br label [[FOR_BODY]]
 ; CHECK:       for.second:
 ; CHECK-NEXT:    [[IPROM:%.*]] = sext i32 [[I_02]] to i64
 ; CHECK-NEXT:    [[B:%.*]] = getelementptr inbounds i16, ptr [[P:%.*]], i64 [[IPROM]]
 ; CHECK-NEXT:    store i16 0, ptr [[B]], align 4
 ; CHECK-NEXT:    [[CMPS:%.*]] = icmp sgt i32 [[INC]], 16
 ; CHECK-NEXT:    br i1 [[CMPS]], label [[FOR_BODY_BACKEDGE]], label [[FOR_END:%.*]]
+; CHECK:       for.body.backedge:
+; CHECK-NEXT:    br label [[FOR_BODY]]
 ; CHECK:       for.end:
 ; CHECK-NEXT:    ret i32 0
 ;
@@ -1042,14 +1042,14 @@ define i32 @multiple_latch2(ptr %p) {
 ; TAILFOLD-NEXT:    [[INC]] = add nsw i32 [[I_02]], 1
 ; TAILFOLD-NEXT:    [[CMP:%.*]] = icmp slt i32 [[INC]], 16
 ; TAILFOLD-NEXT:    br i1 [[CMP]], label [[FOR_BODY_BACKEDGE]], label [[FOR_SECOND:%.*]]
-; TAILFOLD:       for.body.backedge:
-; TAILFOLD-NEXT:    br label [[FOR_BODY]]
 ; TAILFOLD:       for.second:
 ; TAILFOLD-NEXT:    [[IPROM:%.*]] = sext i32 [[I_02]] to i64
 ; TAILFOLD-NEXT:    [[B:%.*]] = getelementptr inbounds i16, ptr [[P:%.*]], i64 [[IPROM]]
 ; TAILFOLD-NEXT:    store i16 0, ptr [[B]], align 4
 ; TAILFOLD-NEXT:    [[CMPS:%.*]] = icmp sgt i32 [[INC]], 16
 ; TAILFOLD-NEXT:    br i1 [[CMPS]], label [[FOR_BODY_BACKEDGE]], label [[FOR_END:%.*]]
+; TAILFOLD:       for.body.backedge:
+; TAILFOLD-NEXT:    br label [[FOR_BODY]]
 ; TAILFOLD:       for.end:
 ; TAILFOLD-NEXT:    ret i32 0
 ;

--- a/llvm/test/Transforms/LoopVectorize/predicate-switch.ll
+++ b/llvm/test/Transforms/LoopVectorize/predicate-switch.ll
@@ -346,8 +346,6 @@ define void @switch_to_header(ptr %start) {
 ; IC1-NEXT:      i64 120, label %[[LOOP_HEADER_BACKEDGE]]
 ; IC1-NEXT:      i64 100, label %[[LOOP_LATCH]]
 ; IC1-NEXT:    ]
-; IC1:       [[LOOP_HEADER_BACKEDGE]]:
-; IC1-NEXT:    br label %[[LOOP_HEADER]]
 ; IC1:       [[IF_THEN:.*:]]
 ; IC1-NEXT:    [[GEP:%.*]] = getelementptr inbounds i64, ptr [[START]], i64 poison
 ; IC1-NEXT:    store i64 42, ptr [[GEP]], align 1
@@ -355,6 +353,8 @@ define void @switch_to_header(ptr %start) {
 ; IC1:       [[LOOP_LATCH]]:
 ; IC1-NEXT:    [[CMP:%.*]] = icmp eq i64 [[IV_NEXT]], 100
 ; IC1-NEXT:    br i1 [[CMP]], label %[[EXIT:.*]], label %[[LOOP_HEADER_BACKEDGE]]
+; IC1:       [[LOOP_HEADER_BACKEDGE]]:
+; IC1-NEXT:    br label %[[LOOP_HEADER]]
 ; IC1:       [[EXIT]]:
 ; IC1-NEXT:    ret void
 ;
@@ -369,8 +369,6 @@ define void @switch_to_header(ptr %start) {
 ; IC2-NEXT:      i64 120, label %[[LOOP_HEADER_BACKEDGE]]
 ; IC2-NEXT:      i64 100, label %[[LOOP_LATCH]]
 ; IC2-NEXT:    ]
-; IC2:       [[LOOP_HEADER_BACKEDGE]]:
-; IC2-NEXT:    br label %[[LOOP_HEADER]]
 ; IC2:       [[IF_THEN:.*:]]
 ; IC2-NEXT:    [[GEP:%.*]] = getelementptr inbounds i64, ptr [[START]], i64 poison
 ; IC2-NEXT:    store i64 42, ptr [[GEP]], align 1
@@ -378,6 +376,8 @@ define void @switch_to_header(ptr %start) {
 ; IC2:       [[LOOP_LATCH]]:
 ; IC2-NEXT:    [[CMP:%.*]] = icmp eq i64 [[IV_NEXT]], 100
 ; IC2-NEXT:    br i1 [[CMP]], label %[[EXIT:.*]], label %[[LOOP_HEADER_BACKEDGE]]
+; IC2:       [[LOOP_HEADER_BACKEDGE]]:
+; IC2-NEXT:    br label %[[LOOP_HEADER]]
 ; IC2:       [[EXIT]]:
 ; IC2-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/LoopVectorize/skeleton-lcssa-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/skeleton-lcssa-crash.ll
@@ -12,8 +12,6 @@ define i16 @test(ptr %arg, i64 %N) {
 ; CHECK-NEXT:    [[L_2:%.*]] = load ptr, ptr [[ARG]], align 8
 ; CHECK-NEXT:    [[C_1:%.*]] = call i1 @cond()
 ; CHECK-NEXT:    br i1 [[C_1]], label [[OUTER_BACKEDGE:%.*]], label [[INNER_PREHEADER:%.*]]
-; CHECK:       outer.backedge:
-; CHECK-NEXT:    br label [[OUTER]]
 ; CHECK:       inner.preheader:
 ; CHECK-NEXT:    br label [[INNER:%.*]]
 ; CHECK:       inner:
@@ -66,6 +64,8 @@ define i16 @test(ptr %arg, i64 %N) {
 ; CHECK-NEXT:    br i1 [[C_4]], label [[EXIT_LOOPEXIT1:%.*]], label [[INNER]]
 ; CHECK:       outer.latch:
 ; CHECK-NEXT:    br label [[OUTER_BACKEDGE]]
+; CHECK:       outer.backedge:
+; CHECK-NEXT:    br label [[OUTER]]
 ; CHECK:       loop.3:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ [[IV_NEXT:%.*]], [[LOOP_3]] ], [ [[BC_RESUME_VAL]], [[SCALAR_PH]] ]
 ; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i64 [[IV]], 1

--- a/llvm/test/Transforms/SimpleLoopUnswitch/invalidate-block-and-loop-dispositions.ll
+++ b/llvm/test/Transforms/SimpleLoopUnswitch/invalidate-block-and-loop-dispositions.ll
@@ -92,10 +92,10 @@ define void @test_pr58158(i1 %c.1) {
 ; CHECK-NEXT:    br label [[OUTER_US]]
 ; CHECK:       entry.split:
 ; CHECK-NEXT:    br label [[OUTER:%.*]]
-; CHECK:       outer:
-; CHECK-NEXT:    br label [[OUTER_BACKEDGE:%.*]]
 ; CHECK:       outer.backedge:
 ; CHECK-NEXT:    br label [[OUTER]]
+; CHECK:       outer:
+; CHECK-NEXT:    br label [[OUTER_BACKEDGE:%.*]]
 ;
 entry:
   %call = tail call i16 @bar()

--- a/llvm/test/Transforms/SimpleLoopUnswitch/nontrivial-unswitch-freeze.ll
+++ b/llvm/test/Transforms/SimpleLoopUnswitch/nontrivial-unswitch-freeze.ll
@@ -631,10 +631,10 @@ define i32 @test10a(ptr %ptr, i1 %cond, ptr %a.ptr) {
 ; CHECK:       loop_a:
 ; CHECK-NEXT:    [[V2:%.*]] = load i1, ptr [[PTR]], align 1
 ; CHECK-NEXT:    br i1 [[V2]], label [[LOOP_EXIT_SPLIT:%.*]], label [[LOOP_BEGIN_BACKEDGE:%.*]]
-; CHECK:       loop_begin.backedge:
-; CHECK-NEXT:    br label [[LOOP_BEGIN]]
 ; CHECK:       loop_b:
 ; CHECK-NEXT:    br label [[LOOP_BEGIN_BACKEDGE]]
+; CHECK:       loop_begin.backedge:
+; CHECK-NEXT:    br label [[LOOP_BEGIN]]
 ; CHECK:       loop_exit.split:
 ; CHECK-NEXT:    [[A_LCSSA:%.*]] = phi i32 [ [[A]], [[LOOP_A]] ]
 ; CHECK-NEXT:    br label [[LOOP_EXIT]]
@@ -696,11 +696,11 @@ define i32 @test10b(ptr %ptr, i1 %cond, ptr %a.ptr) {
 ; CHECK:       loop_a:
 ; CHECK-NEXT:    [[V2:%.*]] = load i1, ptr [[PTR]], align 1
 ; CHECK-NEXT:    br i1 [[V2]], label [[LOOP_BEGIN_BACKEDGE:%.*]], label [[LOOP_EXIT_SPLIT_LOOPEXIT:%.*]]
-; CHECK:       loop_begin.backedge:
-; CHECK-NEXT:    br label [[LOOP_BEGIN]]
 ; CHECK:       loop_b:
 ; CHECK-NEXT:    [[A_LCSSA1:%.*]] = phi i32 [ [[A]], [[LOOP_BEGIN]] ]
 ; CHECK-NEXT:    br label [[LOOP_EXIT_SPLIT:%.*]]
+; CHECK:       loop_begin.backedge:
+; CHECK-NEXT:    br label [[LOOP_BEGIN]]
 ; CHECK:       loop_exit.split.loopexit:
 ; CHECK-NEXT:    [[A_LCSSA_PH:%.*]] = phi i32 [ [[A]], [[LOOP_A]] ]
 ; CHECK-NEXT:    br label [[LOOP_EXIT_SPLIT]]

--- a/llvm/test/Transforms/SimpleLoopUnswitch/nontrivial-unswitch.ll
+++ b/llvm/test/Transforms/SimpleLoopUnswitch/nontrivial-unswitch.ll
@@ -1542,11 +1542,11 @@ loop_b:
 ; CHECK-NEXT:    %[[V:.*]] = load i1, ptr %ptr
 ; CHECK-NEXT:    br i1 %[[V]], label %loop_exit.split, label %loop_begin.backedge
 ;
-; CHECK:       loop_begin.backedge:
-; CHECK-NEXT:    br label %loop_begin
-;
 ; CHECK:       loop_b:
 ; CHECK-NEXT:    br label %loop_begin.backedge
+;
+; CHECK:       loop_begin.backedge:
+; CHECK-NEXT:    br label %loop_begin
 ;
 ; CHECK:       loop_exit.split:
 ; CHECK-NEXT:    %[[A_LCSSA:.*]] = phi i32 [ %[[A]], %loop_a ]
@@ -1618,12 +1618,12 @@ loop_b:
 ; CHECK-NEXT:    %[[V:.*]] = load i1, ptr %ptr
 ; CHECK-NEXT:    br i1 %[[V]], label %loop_begin.backedge, label %loop_exit.split.loopexit
 ;
-; CHECK:       loop_begin.backedge:
-; CHECK-NEXT:    br label %loop_begin
-;
 ; CHECK:       loop_b:
 ; CHECK-NEXT:    %[[A_LCSSA_B:.*]] = phi i32 [ %[[A]], %loop_begin ]
 ; CHECK-NEXT:    br label %loop_exit.split
+;
+; CHECK:       loop_begin.backedge:
+; CHECK-NEXT:    br label %loop_begin
 ;
 ; CHECK:       loop_exit.split.loopexit:
 ; CHECK-NEXT:    %[[A_LCSSA_A:.*]] = phi i32 [ %[[A]], %loop_a ]


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/issues/15968, I noticed that a comment in LoopSimplify ("move the new backedge block to right after the last backedge block") didn't match reality, because `predecessors()` is sorted from back to front.

Example:

```llvm
define void @test_function() {
entry:
  br label %loop_header

loop_header:
  %i = phi i32 [ 0, %entry ], [ %next_value_1, %backedge_block_1 ], [ %next_value_2, %backedge_block_2 ]

  %condition = icmp slt i32 %i, 5
  br i1 %condition, label %backedge_block_1, label %backedge_block_2

backedge_block_1:
  %next_value_1 = add i32 %i, 1
  br label %loop_header

backedge_block_2:
  %next_value_2 = add i32 %i, 2
  br label %loop_header

loop_exit:
  ret void
}
```

Before:

```llvm
backedge_block_1:                                 ; preds = %loop_header
  %next_value_1 = add i32 %i, 1
  br label %loop_header.backedge

loop_header.backedge:                             ; preds = %backedge_block_1, %backedge_block_2
  %i.be = phi i32 [ %next_value_1, %backedge_block_1 ], [ %next_value_2, %backedge_block_2 ]
  br label %loop_header

backedge_block_2:                                 ; preds = %loop_header
  %next_value_2 = add i32 %i, 2
  br label %loop_header.backedge
```

After:

```llvm
backedge_block_1:                                 ; preds = %loop_header
  %next_value_1 = add i32 %i, 1
  br label %loop_header.backedge

backedge_block_2:                                 ; preds = %loop_header
  %next_value_2 = add i32 %i, 2
  br label %loop_header.backedge

loop_header.backedge:                             ; preds = %backedge_block_1, %backedge_block_2
  %i.be = phi i32 [ %next_value_1, %backedge_block_1 ], [ %next_value_2, %backedge_block_2 ]
  br label %loop_header
```

Fixes https://github.com/llvm/llvm-project/issues/15968