### PR TITLE
[bazel] Fix mlir build broken by 681ae097.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -3338,25 +3338,6 @@ cc_library(
 )
 
 cc_library(
-    name = "TensorShardingInterfaceImpl",
-    srcs = ["lib/Dialect/Mesh/Interfaces/TensorShardingInterfaceImpl.cpp"],
-    hdrs = [
-        "include/mlir/Dialect/Mesh/IR/TensorShardingInterfaceImpl.h",
-    ],
-    includes = ["include"],
-    deps = [
-        ":DialectUtils",
-        ":IR",
-        ":MeshDialect",
-        ":MeshShardingInterface",
-        ":MeshShardingInterfaceIncGen",
-        ":Support",
-        ":TensorDialect",
-        "//llvm:Support",
-    ],
-)
-
-cc_library(
     name = "MeshDialect",
     srcs = ["lib/Dialect/Mesh/IR/MeshOps.cpp"],
     hdrs = [
@@ -4890,6 +4871,7 @@ cc_library(
         ":ROCDLToLLVMIRTranslation",
         ":SCFTransformOps",
         ":SparseTensorTransformOps",
+        ":TensorExtensions",
         ":TensorTransformOps",
         ":TransformDebugExtension",
         ":TransformIRDLExtension",
@@ -7600,6 +7582,7 @@ cc_library(
         "lib/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.cpp",
     ],
     hdrs = [
+        "include/mlir/Dialect/Tensor/IR/ShardingInterfaceImpl.h",
         "include/mlir/Dialect/Tensor/IR/Tensor.h",
         "include/mlir/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.h",
     ],
@@ -7666,6 +7649,23 @@ cc_library(
         ":TensorUtils",
         ":TilingInterface",
         ":ValueBoundsOpInterface",
+    ],
+)
+
+cc_library(
+    name = "TensorExtensions",
+    srcs = glob(["lib/Dialect/Tensor/Extensions/*.cpp"]),
+    hdrs = glob(["include/mlir/Dialect/Tensor/Extensions/*.h"]),
+    includes = ["include"],
+    deps = [
+        ":DialectUtils",
+        ":IR",
+        ":MeshDialect",
+        ":MeshShardingInterface",
+        ":MeshShardingInterfaceIncGen",
+        ":Support",
+        ":TensorDialect",
+        "//llvm:Support",
     ],
 )
 
@@ -9603,7 +9603,6 @@ cc_library(
         ":SparseTensorTransforms",
         ":TensorDialect",
         ":TensorInferTypeOpInterfaceImpl",
-        ":TensorShardingInterfaceImpl",
         ":TensorTilingInterfaceImpl",
         ":TensorTransformOps",
         ":TensorTransforms",


### PR DESCRIPTION
The cmake config creates two targets, `MLIRTensorMeshShardingExtensions` and `MLIRTensorAllExtensions`; but for bazel, with the `Func` dialect we only have a single `FuncExtensions`. Here I am following the `Func` dialect convension to only create a single `TensorExtensions`.