### PR TITLE
[mlir] NFC: add missing 'FloatType' to core Python stub file

### DIFF
--- a/mlir/python/mlir/_mlir_libs/_mlir/ir.pyi
+++ b/mlir/python/mlir/_mlir_libs/_mlir/ir.pyi
@@ -129,6 +129,7 @@ __all__ = [
     "Float8E5M2Type",
     "FloatAttr",
     "FloatTF32Type",
+    "FloatType",
     "FunctionType",
     "IndexType",
     "InferShapedTypeOpInterface",


### PR DESCRIPTION

The stub class for `FloatType` is present in `ir.pyi`, but it is missing from the `__all__` export list. 