### PR TITLE
[LTO] Introduce helper functions to add GUIDs to ImportList (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -122,7 +122,7 @@ public:
   /// Import functions in Module \p M based on the supplied import list.
   Expected<bool> importFunctions(Module &M, const ImportMapTy &ImportList);
 
-  enum AddDefinitionStatus {
+  enum class AddDefinitionStatus {
     NoChange,
     Inserted,
     ChangedToDefinition,

--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -122,6 +122,33 @@ public:
   /// Import functions in Module \p M based on the supplied import list.
   Expected<bool> importFunctions(Module &M, const ImportMapTy &ImportList);
 
+  enum AddDefinitionStatus {
+    NoChange,
+    Inserted,
+    ChangedToDefinition,
+  };
+
+  // Add the given GUID to ImportList as a definition.  If the same GUID has
+  // been added as a declaration previously, that entry is overridden.
+  static AddDefinitionStatus addDefinition(ImportMapTy &ImportList,
+                                           StringRef FromModule,
+                                           GlobalValue::GUID GUID);
+
+  // Add the given GUID to ImportList as a declaration.  If the same GUID has
+  // been added as a definition previously, that entry takes precedence, and no
+  // change is made.
+  static void maybeAddDeclaration(ImportMapTy &ImportList, StringRef FromModule,
+                                  GlobalValue::GUID GUID);
+
+  static void addGUID(ImportMapTy &ImportList, StringRef FromModule,
+                      GlobalValue::GUID GUID,
+                      GlobalValueSummary::ImportKind ImportKind) {
+    if (ImportKind == GlobalValueSummary::Definition)
+      addDefinition(ImportList, FromModule, GUID);
+    else
+      maybeAddDeclaration(ImportList, FromModule, GUID);
+  }
+
 private:
   /// The summaries index used to trigger importing.
   const ModuleSummaryIndex &Index;

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -726,14 +726,8 @@ bool lto::initImportList(const Module &M,
       if (Summary->modulePath() == M.getModuleIdentifier())
         continue;
       // Add an entry to provoke importing by thinBackend.
-      // Try emplace the entry first. If an entry with the same key already
-      // exists, set the value to 'std::min(existing-value, new-value)' to make
-      // sure a definition takes precedence over a declaration.
-      auto [Iter, Inserted] = ImportList[Summary->modulePath()].try_emplace(
-          GUID, Summary->importType());
-
-      if (!Inserted)
-        Iter->second = std::min(Iter->second, Summary->importType());
+      FunctionImporter::addGUID(ImportList, Summary->modulePath(), GUID,
+                                Summary->importType());
     }
   }
   return true;

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -337,14 +337,14 @@ using EdgeInfo = std::tuple<const FunctionSummary *, unsigned /* Threshold */>;
 FunctionImporter::AddDefinitionStatus
 FunctionImporter::addDefinition(ImportMapTy &ImportList, StringRef FromModule,
                                 GlobalValue::GUID GUID) {
-  auto [It, Ins] =
+  auto [It, Inserted] =
       ImportList[FromModule].try_emplace(GUID, GlobalValueSummary::Definition);
-  if (Ins)
-    return FunctionImporter::Inserted;
+  if (Inserted)
+    return AddDefinitionStatus::Inserted;
   if (It->second == GlobalValueSummary::Definition)
-    return FunctionImporter::NoChange;
+    return AddDefinitionStatus::NoChange;
   It->second = GlobalValueSummary::Definition;
-  return FunctionImporter::ChangedToDefinition;
+  return AddDefinitionStatus::ChangedToDefinition;
 }
 
 void FunctionImporter::maybeAddDeclaration(ImportMapTy &ImportList,
@@ -413,7 +413,7 @@ class GlobalsImporter final {
         // Otherwise, definition should take precedence over declaration.
         if (FunctionImporter::addDefinition(
                 ImportList, RefSummary->modulePath(), VI.getGUID()) !=
-            FunctionImporter::Inserted)
+            FunctionImporter::AddDefinitionStatus::Inserted)
           break;
 
         // Only update stat and exports if we haven't already imported this
@@ -954,7 +954,7 @@ static void computeImportForFunction(
       // status.
       if (FunctionImporter::addDefinition(ImportList, ExportModulePath,
                                           VI.getGUID()) !=
-          FunctionImporter::NoChange) {
+          FunctionImporter::AddDefinitionStatus::NoChange) {
         NumImportedFunctionsThinLink++;
         if (IsHotCallsite)
           NumImportedHotFunctionsThinLink++;

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -897,10 +897,7 @@ static void computeImportForFunction(
         if (ImportDeclaration && SummaryForDeclImport) {
           StringRef DeclSourceModule = SummaryForDeclImport->modulePath();
 
-          // Since definition takes precedence over declaration for the same VI,
-          // try emplace <VI, declaration> pair without checking insert result.
-          // If insert doesn't happen, there must be an existing entry keyed by
-          // VI. Note `ExportLists` only keeps track of exports due to imported
+          // Note `ExportLists` only keeps track of exports due to imported
           // definitions.
           FunctionImporter::maybeAddDeclaration(ImportList, DeclSourceModule,
                                                 VI.getGUID());

--- a/llvm/tools/llvm-link/llvm-link.cpp
+++ b/llvm/tools/llvm-link/llvm-link.cpp
@@ -381,9 +381,9 @@ static bool importFunctions(const char *argv0, Module &DestModule) {
     // definition, so make the import type definition directly.
     // FIXME: A follow-up patch should add test coverage for import declaration
     // in `llvm-link` CLI (e.g., by introducing a new command line option).
-    auto &Entry =
-        ImportList[FileNameStringCache.insert(FileName).first->getKey()];
-    Entry[F->getGUID()] = GlobalValueSummary::Definition;
+    FunctionImporter::addDefinition(
+        ImportList, FileNameStringCache.insert(FileName).first->getKey(),
+        F->getGUID());
   }
   auto CachedModuleLoader = [&](StringRef Identifier) {
     return ModuleLoaderCache.takeModule(std::string(Identifier));


### PR DESCRIPTION
The new helper functions make the intent clearer while hiding
implementation details, including how we handle previously added
entries.  Note that:

- If we are adding a GUID as a GlobalValueSummary::Definition, then we
  override a previously added GlobalValueSummary::Declaration entry
  for the same GUID.

- If we are adding a GUID as a GlobalValueSummary::Declaration, then a
  previously added GlobalValueSummary::Definition entry for the same
  GUID takes precedence, and no change is made.
