### PR TITLE
[compiler-rt][test] Added REQUIRES:shell to fuzzer test with for-loop

### DIFF
--- a/compiler-rt/test/fuzzer/features_dir.test
+++ b/compiler-rt/test/fuzzer/features_dir.test
@@ -1,5 +1,5 @@
 # Tests -features_dir=F
-# REQUIRES: shell
+# REQUIRES: linux, shell
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 RUN: rm -rf %t-C %t-F
 RUN: mkdir %t-C %t-F

--- a/compiler-rt/test/fuzzer/features_dir.test
+++ b/compiler-rt/test/fuzzer/features_dir.test
@@ -1,5 +1,5 @@
 # Tests -features_dir=F
-# REQUIRES: linux
+# REQUIRES: shell
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 RUN: rm -rf %t-C %t-F
 RUN: mkdir %t-C %t-F


### PR DESCRIPTION
This patch makes the features_dir.test file require a shell when running. This will make the test file unsupported when running llvm-lit with its internal shell implementation, which is enabled by turning on the LIT_USE_INTERNAL_SHELL environment variable. Lit's internal shell currently does not support for-loop syntax.

Fixes https://github.com/llvm/llvm-project/issues/102380.