### PR TITLE
[LTO] Use enum class for ImportFailureReason (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -42,7 +42,7 @@ public:
 
   /// The different reasons selectCallee will chose not to import a
   /// candidate.
-  enum ImportFailureReason {
+  enum class ImportFailureReason {
     None,
     // We can encounter a global variable instead of a function in rare
     // situations with SamplePGO. See comments where this failure type is


### PR DESCRIPTION
It turns out that all uses of the enum values here are already
qualified like FunctionImporter::ImportFailureReason::None, so we can
switch to enum class without touching the rest of the codebase.
