### PR TITLE
[flang] Handle pp-directives better in line continuation

### DIFF
--- a/flang/test/Preprocessing/line-in-contin.F90
+++ b/flang/test/Preprocessing/line-in-contin.F90
@@ -1,8 +1,10 @@
-! RUN: %flang_fc1 -E %s 2>&1 | FileCheck %s
-! CHECK: call foo( 0.)
-! CHECK: call foo( 1.)
-! CHECK: call foo( 2.)
-! CHECK: call foo( 3.)
+! RUN: %flang_fc1 -fopenmp -E %s 2>&1 | FileCheck %s
+! CHECK: call foo(0.)
+! CHECK: call foo(1.)
+! CHECK: call foo(2.)
+! CHECK: call foo(3.)
+! CHECK: !$omp parallel do default(none) private(j)
+! CHECK: !$omp end parallel do
 call foo( &
 # 100 "bar.h"
          & 0.)
@@ -17,4 +19,16 @@ call foo( &
 # 103 "bar.h"
          & 3. &
     )
+!$omp parallel do &
+#ifdef undef
+!$omp garbage &
+#else
+!$omp default(none) &
+#endif
+!$omp private(j)
+  do j=1,100
+  end do
+!$omp end &
+# 104 "bar.h"
+!$omp parallel do
 end


### PR DESCRIPTION
The code for detecting and processing some preprocessing directives (conditional compilation and #line) while skipping comments between one source or compiler directive line and its continuations wasn't correctly handling the case of such a directive following an explicit ampersand.

Fixes https://github.com/llvm/llvm-project/issues/100730 and https://github.com/llvm/llvm-project/issues/100345.