### PR TITLE
[flang][runtime] Add build-time flags to runtime to adjust SELECTED_x_KIND()

### DIFF
--- a/flang/runtime/numeric.cpp
+++ b/flang/runtime/numeric.cpp
@@ -105,7 +105,7 @@ inline RT_API_ATTRS CppTypeFor<TypeCategory::Integer, 4> SelectedIntKind(T x) {
     return 4;
   } else if (x <= 18) {
     return 8;
-#ifdef __SIZEOF_INT128__
+#if defined __SIZEOF_INT128__ && !defined FLANG_RUNTIME_NO_INTEGER_16
   } else if (x <= 38) {
     return 16;
 #endif
@@ -137,23 +137,35 @@ inline RT_API_ATTRS CppTypeFor<TypeCategory::Integer, 4> SelectedRealKind(
     return -5;
   }
 
+#ifndef FLANG_RUNTIME_NO_REAL_2
+  constexpr bool hasReal2{true};
+#else
+  constexpr bool hasReal2{false};
+#endif
+#if defined LDBL_MANT_DIG == 64 && !defined FLANG_RUNTIME_NO_REAL_10
+  constexpr bool hasReal10{true};
+#else
+  constexpr bool hasReal10{false};
+#endif
+#if (LDBL_MANT_DIG == 64 || LDBL_MANT_DIG == 113) && \
+    !defined FLANG_RUNTIME_NO_REAL_16
+  constexpr bool hasReal16{true};
+#else
+  constexpr bool hasReal16{false};
+#endif
+
   int error{0};
   int kind{0};
-  if (p <= 3) {
+  if (hasReal2 && p <= 3) {
     kind = 2;
   } else if (p <= 6) {
     kind = 4;
   } else if (p <= 15) {
     kind = 8;
-#if LDBL_MANT_DIG == 64
-  } else if (p <= 18) {
+  } else if (hasReal10 && p <= 18) {
     kind = 10;
-  } else if (p <= 33) {
+  } else if (hasReal16 && p <= 33) {
     kind = 16;
-#elif LDBL_MANT_DIG == 113
-  } else if (p <= 33) {
-    kind = 16;
-#endif
   } else {
     error -= 1;
   }
@@ -164,13 +176,10 @@ inline RT_API_ATTRS CppTypeFor<TypeCategory::Integer, 4> SelectedRealKind(
     kind = kind < 3 ? (p == 3 ? 4 : 3) : kind;
   } else if (r <= 307) {
     kind = kind < 8 ? 8 : kind;
-#if LDBL_MANT_DIG == 64
-  } else if (r <= 4931) {
+  } else if (hasReal10 && r <= 4931) {
     kind = kind < 10 ? 10 : kind;
-#elif LDBL_MANT_DIG == 113
-  } else if (r <= 4931) {
+  } else if (hasReal16 && r <= 4931) {
     kind = kind < 16 ? 16 : kind;
-#endif
   } else {
     error -= 2;
   }


### PR DESCRIPTION
Add FLANG_RUNTIME_NO_INTEGER_16 and FLANG_RUNTIME_NO_REAL_{2,10,16} to allow one to disable those kinds from being returned from SELECTED_INT_KIND and SELECTED_REAL_KIND even if they are actually available in the C++ build compiler.