### PR TITLE
[CMake] Install generated Clang .cfg file for cross ARM toolchains. NFC.

### DIFF
--- a/clang/cmake/caches/CrossWinToARMLinux.cmake
+++ b/clang/cmake/caches/CrossWinToARMLinux.cmake
@@ -268,6 +268,7 @@ set(LLVM_TOOLCHAIN_TOOLS
 
 set(LLVM_DISTRIBUTION_COMPONENTS
   clang
+  clang-configs
   lld
   LTO
   clang-format


### PR DESCRIPTION
Allow installation of <target>.cfg generated file together with the clang executables.