### PR TITLE
[SPIR-V] Fix vload_half builtin argument count

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -1500,7 +1500,7 @@ foreach i = ["", "2", "3", "4", "8", "16"] in {
     defm : DemangledVectorLoadStoreBuiltin<"vload_half", 2, 2, 173>;
     defm : DemangledVectorLoadStoreBuiltin<"vstore_half", 3, 3, 175>;
   } else {
-    defm : DemangledVectorLoadStoreBuiltin<!strconcat("vload_half", i), 3, 3, 174>;
+    defm : DemangledVectorLoadStoreBuiltin<!strconcat("vload_half", i), 2, 2, 174>;
     defm : DemangledVectorLoadStoreBuiltin<!strconcat("vstore_half", i), 3, 3, 177>;
   }
   defm : DemangledVectorLoadStoreBuiltin<!strconcat("vload", i), 2, 2, 171>;

--- a/llvm/test/CodeGen/SPIRV/opencl/vload_halfn.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/vload_halfn.ll
@@ -1,0 +1,15 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#IMPORT:]] = OpExtInstImport "OpenCL.std"
+
+; CHECK: %[[#FLOAT:]] = OpTypeFloat 32
+; CHECK: %[[#V2FLOAT:]] = OpTypeVector %[[#FLOAT]] 2
+
+define void @test(i64 %a, ptr addrspace(1) %b) {
+; CHECK: %[[#]] = OpExtInst %[[#V2FLOAT:]] %[[#IMPORT]] vload_halfn %[[#]] %[[#]] 2
+  %c = call spir_func <2 x float> @_Z11vload_half2mPU3AS1KDh(i64 %a, ptr addrspace(1) %b)
+  ret void
+}
+
+declare <2 x float> @_Z11vload_half2mPU3AS1KDh(i64, ptr addrspace(1))


### PR DESCRIPTION
OpenCL's vload_half builtin expects two arguments, but the current TableGen definition expects three.
This change fixes the mismatch and adds a test to check this.