### PR TITLE
[libc++] Adjust armv7 XFAIL target triple for the setfill_wchar_max test.

### DIFF
--- a/libcxx/test/std/input.output/iostream.format/std.manip/setfill_wchar_max.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/std.manip/setfill_wchar_max.pass.cpp
@@ -15,7 +15,7 @@
 // version 2 implementation fixes the problem.
 
 // XFAIL: target={{.*}}-windows{{.*}} && libcpp-abi-version=1
-// XFAIL: target=armv{{7|8}}l{{.*}}-linux-gnueabihf && libcpp-abi-version=1
+// XFAIL: target=armv{{7|8}}{{l?}}{{.*}}-linux-gnueabihf && libcpp-abi-version=1
 // XFAIL: target=aarch64{{.*}}-linux-gnu && libcpp-abi-version=1
 
 #include <iomanip>


### PR DESCRIPTION
Also allow XFAIL for armv7-*-linux-gnueabihf targets, not only for armv7l-*.