### PR TITLE
Fix the behavior of __COUNT__ macros when PCH is enabled

### DIFF
--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -372,12 +372,14 @@ private:
 
   bool Parse(std::shared_ptr<PCHContainerOperations> PCHContainerOps,
              std::unique_ptr<llvm::MemoryBuffer> OverrideMainBuffer,
-             IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS);
+             IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
+             unsigned PCHCountValue = 0);
 
   std::unique_ptr<llvm::MemoryBuffer> getMainBufferWithPrecompiledPreamble(
       std::shared_ptr<PCHContainerOperations> PCHContainerOps,
       CompilerInvocation &PreambleInvocationIn,
-      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS, bool AllowRebuild = true,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
+      unsigned *CountValueAtFinish = nullptr, bool AllowRebuild = true,
       unsigned MaxLines = 0);
   void RealizeTopLevelDeclsFromPreamble();
 

--- a/clang/include/clang/Frontend/FrontendAction.h
+++ b/clang/include/clang/Frontend/FrontendAction.h
@@ -178,6 +178,9 @@ public:
   /// details.
   virtual bool isModelParsingAction() const { return false; }
 
+  /// Do we need to reuse existing preprocessor?
+  virtual bool reuseExistingPreprocessor() const { return false; }
+
   /// Does this action only use the preprocessor?
   ///
   /// If so no AST context will be created and this action will be invalid

--- a/clang/include/clang/Frontend/PrecompiledPreamble.h
+++ b/clang/include/clang/Frontend/PrecompiledPreamble.h
@@ -102,6 +102,9 @@ public:
   /// be used for logging and debugging purposes only.
   std::size_t getSize() const;
 
+  /// Returns the value of __COUNT__ macro when the process finished.
+  unsigned getCountValue() const { return CountValueAtFinish; }
+
   /// Returned string is not null-terminated.
   llvm::StringRef getContents() const {
     return {PreambleBytes.data(), PreambleBytes.size()};
@@ -137,7 +140,7 @@ private:
                       std::vector<char> PreambleBytes,
                       bool PreambleEndsAtStartOfLine,
                       llvm::StringMap<PreambleFileHash> FilesInPreamble,
-                      llvm::StringSet<> MissingFiles);
+                      llvm::StringSet<> MissingFiles, unsigned CountPreamble);
 
   /// Data used to determine if a file used in the preamble has been changed.
   struct PreambleFileHash {
@@ -205,6 +208,8 @@ private:
   std::vector<char> PreambleBytes;
   /// See PreambleBounds::PreambleEndsAtStartOfLine
   bool PreambleEndsAtStartOfLine;
+  /// __COUNT__ macro value when the preamble finished building.
+  unsigned CountValueAtFinish;
 };
 
 /// A set of callbacks to gather useful information while building a preamble.

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -816,7 +816,8 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
 
   // Set up the preprocessor if needed. When parsing model files the
   // preprocessor of the original source is reused.
-  if (!isModelParsingAction())
+  if (!CI.hasPreprocessor() ||
+      (!isModelParsingAction() && !reuseExistingPreprocessor()))
     CI.createPreprocessor(getTranslationUnitKind());
 
   // Inform the diagnostic client we are processing a source file.

--- a/clang/lib/Frontend/PrecompiledPreamble.cpp
+++ b/clang/lib/Frontend/PrecompiledPreamble.cpp
@@ -571,11 +571,12 @@ llvm::ErrorOr<PrecompiledPreamble> PrecompiledPreamble::Build(
   // Shrinking the storage requires extra temporary memory.
   // Destroying clang first reduces peak memory usage.
   CICleanup.unregister();
+  unsigned CountValue = Clang->getPreprocessor().getCounterValue();
   Clang.reset();
   Storage->shrink();
   return PrecompiledPreamble(
       std::move(Storage), std::move(PreambleBytes), PreambleEndsAtStartOfLine,
-      std::move(FilesInPreamble), std::move(MissingFiles));
+      std::move(FilesInPreamble), std::move(MissingFiles), CountValue);
 }
 
 PreambleBounds PrecompiledPreamble::getBounds() const {
@@ -728,11 +729,12 @@ PrecompiledPreamble::PrecompiledPreamble(
     std::unique_ptr<PCHStorage> Storage, std::vector<char> PreambleBytes,
     bool PreambleEndsAtStartOfLine,
     llvm::StringMap<PreambleFileHash> FilesInPreamble,
-    llvm::StringSet<> MissingFiles)
+    llvm::StringSet<> MissingFiles, unsigned CountValue)
     : Storage(std::move(Storage)), FilesInPreamble(std::move(FilesInPreamble)),
       MissingFiles(std::move(MissingFiles)),
       PreambleBytes(std::move(PreambleBytes)),
-      PreambleEndsAtStartOfLine(PreambleEndsAtStartOfLine) {
+      PreambleEndsAtStartOfLine(PreambleEndsAtStartOfLine),
+      CountValueAtFinish(CountValue) {
   assert(this->Storage != nullptr);
 }
 

--- a/clang/unittests/Frontend/ASTUnitTest.cpp
+++ b/clang/unittests/Frontend/ASTUnitTest.cpp
@@ -210,4 +210,64 @@ TEST_F(ASTUnitTest, LoadFromCommandLineWorkingDirectory) {
   ASSERT_EQ(FM.getFileSystemOpts().WorkingDir, WorkingDir.str());
 }
 
+TEST_F(ASTUnitTest, PCHCount) {
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> InMemoryFs =
+      new llvm::vfs::InMemoryFileSystem();
+
+  InMemoryFs->addFile("header.h", 0, llvm::MemoryBuffer::getMemBuffer(R"cpp(
+      #define __DEFINE_FUNCTION(i) \
+        int function_ ## i (void) { return 0; }
+      #define _DEFINE_FUNCTION(i) __DEFINE_FUNCTION(i)
+      #define DEFINE_FUNCTION      _DEFINE_FUNCTION(__COUNTER__)
+      DEFINE_FUNCTION;\n";
+    )cpp"));
+
+  InMemoryFs->addFile("test.cpp", 0, llvm::MemoryBuffer::getMemBuffer(R"cpp(
+      #include "header.h"
+      DEFINE_FUNCTION;
+      int main(void)
+      {
+        function_0();
+        function_1();
+        return 0;
+      }
+    )cpp"));
+
+  const char *Args[] = {"clang", "test.cpp"};
+  Diags = CompilerInstance::createDiagnostics(new DiagnosticOptions());
+  CreateInvocationOptions CIOpts;
+  CIOpts.Diags = Diags;
+  CInvok = createInvocation(Args, std::move(CIOpts));
+  ASSERT_TRUE(CInvok);
+
+  FileManager *FileMgr = new FileManager(FileSystemOptions(), InMemoryFs);
+  PCHContainerOps = std::make_shared<PCHContainerOperations>();
+
+  auto AU = ASTUnit::LoadFromCompilerInvocation(
+      CInvok, PCHContainerOps, Diags, FileMgr, false, CaptureDiagsKind::None, 1,
+      TU_Complete, false, false, false);
+  ASSERT_TRUE(AU);
+
+  /* Check if the AU is free of errors.  */
+  const DiagnosticsEngine &de = AU->getDiagnostics();
+  ASSERT_TRUE(de.hasErrorOccurred());
+
+  /* Make sure we have the two functions.  */
+  bool functions[2] = {false, false};
+  for (auto it = AU->top_level_begin(); it != AU->top_level_end(); ++it) {
+    if (FunctionDecl *fdecl = dyn_cast<FunctionDecl>(*it)) {
+      if (fdecl->getName() == "function_0") {
+        functions[0] = true;
+      }
+
+      if (fdecl->getName() == "function_1") {
+        functions[1] = true;
+      }
+    }
+  }
+
+  ASSERT_TRUE(functions[0]);
+  ASSERT_TRUE(functions[1]);
+}
+
 } // anonymous namespace


### PR DESCRIPTION
Previoulsy, calling `ASTUnit::LoadFromCompilerInvocation` with `PrecompilePreambleAfterNParses > 0` caused the `__COUNT__` macro value to be restarted.  This commit fixes this by remembering the value of this macro when the PCH finished parsing.