### PR TITLE
[clang-format] Add `AllowShortNamespacesOnASingleLine` option

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -2088,6 +2088,12 @@ the configuration (without a prefix: ``Auto``).
   If ``true``, ``while (true) continue;`` can be put on a single
   line.
 
+.. _AllowShortNamespacesOnASingleLine:
+
+**AllowShortNamespacesOnASingleLine** (``Boolean``) :versionbadge:`clang-format 20` :ref:`¶ <AllowShortNamespacesOnASingleLine>`
+  If ``true``, ``namespace a { class b; }`` can be put on a single a single
+  line.
+
 .. _AlwaysBreakAfterDefinitionReturnType:
 
 **AlwaysBreakAfterDefinitionReturnType** (``DefinitionReturnTypeBreakingStyle``) :versionbadge:`clang-format 3.7` :ref:`¶ <AlwaysBreakAfterDefinitionReturnType>`

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -2091,8 +2091,7 @@ the configuration (without a prefix: ``Auto``).
 .. _AllowShortNamespacesOnASingleLine:
 
 **AllowShortNamespacesOnASingleLine** (``Boolean``) :versionbadge:`clang-format 20` :ref:`¶ <AllowShortNamespacesOnASingleLine>`
-  If ``true``, ``namespace a { class b; }`` can be put on a single a single
-  line.
+  If ``true``, ``namespace a { class b; }`` can be put on a single line.
 
 .. _AlwaysBreakAfterDefinitionReturnType:
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1122,6 +1122,8 @@ clang-format
 - Adds ``RemoveEmptyLinesInUnwrappedLines`` option.
 - Adds ``KeepFormFeed`` option and set it to ``true`` for ``GNU`` style.
 
+- Adds ``AllowShortNamespacesOnASingleLine`` option.
+
 libclang
 --------
 - Add ``clang_isBeforeInTranslationUnit``. Given two source locations, it determines

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1121,7 +1121,6 @@ clang-format
   ``Never``, and ``true`` to ``Always``.
 - Adds ``RemoveEmptyLinesInUnwrappedLines`` option.
 - Adds ``KeepFormFeed`` option and set it to ``true`` for ``GNU`` style.
-
 - Adds ``AllowShortNamespacesOnASingleLine`` option.
 
 libclang

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -988,6 +988,11 @@ struct FormatStyle {
   /// \version 3.7
   bool AllowShortLoopsOnASingleLine;
 
+  /// If ``true``, ``namespace a { class b; }`` can be put on a single a single
+  /// line.
+  /// \version 19
+  bool AllowShortNamespacesOnASingleLine;
+
   /// Different ways to break after the function definition return type.
   /// This option is **deprecated** and is retained for backwards compatibility.
   enum DefinitionReturnTypeBreakingStyle : int8_t {

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5172,7 +5172,8 @@ struct FormatStyle {
                R.AllowShortIfStatementsOnASingleLine &&
            AllowShortLambdasOnASingleLine == R.AllowShortLambdasOnASingleLine &&
            AllowShortLoopsOnASingleLine == R.AllowShortLoopsOnASingleLine &&
-           AllowShortNamespacesOnASingleLine == R.AllowShortNamespacesOnASingleLine &&
+           AllowShortNamespacesOnASingleLine ==
+               R.AllowShortNamespacesOnASingleLine &&
            AlwaysBreakBeforeMultilineStrings ==
                R.AlwaysBreakBeforeMultilineStrings &&
            AttributeMacros == R.AttributeMacros &&

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -988,8 +988,7 @@ struct FormatStyle {
   /// \version 3.7
   bool AllowShortLoopsOnASingleLine;
 
-  /// If ``true``, ``namespace a { class b; }`` can be put on a single a single
-  /// line.
+  /// If ``true``, ``namespace a { class b; }`` can be put on a single line.
   /// \version 20
   bool AllowShortNamespacesOnASingleLine;
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -990,7 +990,7 @@ struct FormatStyle {
 
   /// If ``true``, ``namespace a { class b; }`` can be put on a single a single
   /// line.
-  /// \version 19
+  /// \version 20
   bool AllowShortNamespacesOnASingleLine;
 
   /// Different ways to break after the function definition return type.

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5172,6 +5172,7 @@ struct FormatStyle {
                R.AllowShortIfStatementsOnASingleLine &&
            AllowShortLambdasOnASingleLine == R.AllowShortLambdasOnASingleLine &&
            AllowShortLoopsOnASingleLine == R.AllowShortLoopsOnASingleLine &&
+           AllowShortNamespacesOnASingleLine == R.AllowShortNamespacesOnASingleLine &&
            AlwaysBreakBeforeMultilineStrings ==
                R.AlwaysBreakBeforeMultilineStrings &&
            AttributeMacros == R.AttributeMacros &&

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -975,6 +975,8 @@ template <> struct MappingTraits<FormatStyle> {
                    Style.AllowShortLambdasOnASingleLine);
     IO.mapOptional("AllowShortLoopsOnASingleLine",
                    Style.AllowShortLoopsOnASingleLine);
+    IO.mapOptional("AllowShortNamespacesOnASingleLine",
+                   Style.AllowShortNamespacesOnASingleLine);
     IO.mapOptional("AlwaysBreakAfterDefinitionReturnType",
                    Style.AlwaysBreakAfterDefinitionReturnType);
     IO.mapOptional("AlwaysBreakBeforeMultilineStrings",
@@ -1480,6 +1482,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.AllowShortIfStatementsOnASingleLine = FormatStyle::SIS_Never;
   LLVMStyle.AllowShortLambdasOnASingleLine = FormatStyle::SLS_All;
   LLVMStyle.AllowShortLoopsOnASingleLine = false;
+  LLVMStyle.AllowShortNamespacesOnASingleLine = false;
   LLVMStyle.AlwaysBreakAfterDefinitionReturnType = FormatStyle::DRTBS_None;
   LLVMStyle.AlwaysBreakBeforeMultilineStrings = false;
   LLVMStyle.AttributeMacros.push_back("__capability");

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -361,8 +361,17 @@ private:
     const auto *FirstNonComment = TheLine->getFirstNonComment();
     if (!FirstNonComment)
       return 0;
+
     // FIXME: There are probably cases where we should use FirstNonComment
     // instead of TheLine->First.
+
+    if (TheLine->Last->is(tok::l_brace)) {
+      if (Style.AllowShortNamespacesOnASingleLine &&
+          TheLine->First->is(tok::kw_namespace)) {
+        if (unsigned result = tryMergeNamespace(I, E, Limit))
+          return result;
+      }
+    }
 
     if (Style.CompactNamespaces) {
       if (const auto *NSToken = TheLine->First->getNamespaceToken()) {
@@ -419,14 +428,6 @@ private:
     if (LastNonComment->is(TT_FunctionLBrace) &&
         TheLine->First != LastNonComment) {
       return MergeShortFunctions ? tryMergeSimpleBlock(I, E, Limit) : 0;
-    }
-
-    if (TheLine->Last->is(tok::l_brace)) {
-      if (Style.AllowShortNamespacesOnASingleLine &&
-          TheLine->First->is(tok::kw_namespace)) {
-        if (unsigned result = tryMergeNamespace(I, E, Limit))
-          return result;
-      }
     }
 
     // Try to merge a control statement block with left brace unwrapped.

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -648,20 +648,20 @@ private:
       if (I[1]->Last->is(TT_LineComment))
         return 0;
 
-      unsigned inner_limit = Limit - I[1]->Last->TotalLength - 3;
-      unsigned inner_result = tryMergeNamespace(I + 1, E, inner_limit);
-      if (!inner_result)
+      const unsigned InnerLimit = Limit - I[1]->Last->TotalLength - 3;
+      const unsigned MergedLines = tryMergeNamespace(I + 1, E, InnerLimit);
+      if (!MergedLines)
         return 0;
       // check if there is even a line after the inner result
-      if (I + 2 + inner_result >= E)
+      if (I + 2 + MergedLines >= E)
         return 0;
       // check that the line after the inner result starts with a closing brace
       // which we are permitted to merge into one line
-      if (I[2 + inner_result]->First->is(tok::r_brace) &&
-          !I[2 + inner_result]->First->MustBreakBefore &&
-          !I[1 + inner_result]->Last->is(TT_LineComment) &&
-          nextNLinesFitInto(I, I + 2 + inner_result + 1, Limit)) {
-        return 2 + inner_result;
+      if (I[2 + MergedLines]->First->is(tok::r_brace) &&
+          !I[2 + MergedLines]->First->MustBreakBefore &&
+          !I[1 + MergedLines]->Last->is(TT_LineComment) &&
+          nextNLinesFitInto(I, I + 2 + MergedLines + 1, Limit)) {
+        return 2 + MergedLines;
       }
       return 0;
     }

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -631,6 +631,7 @@ private:
                              unsigned Limit) {
     if (Limit == 0)
       return 0;
+
     assert(I[1]);
     const auto &L1 = *I[1];
     if (L1.InPPDirective != (*I)->InPPDirective ||

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -660,8 +660,7 @@ private:
         return 0;
       // Check that the line after the inner result starts with a closing brace
       // which we are permitted to merge into one line.
-      if (I[N]->First->is(tok::r_brace) &&
-          !I[N]->First->MustBreakBefore &&
+      if (I[N]->First->is(tok::r_brace) && !I[N]->First->MustBreakBefore &&
           !I[MergedLines + 1]->Last->is(tok::comment) &&
           nextNLinesFitInto(I, I + N + 1, Limit)) {
         return N;

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -653,7 +653,7 @@ private:
       assert(Limit >= I[1]->Last->TotalLength + 3);
       const unsigned InnerLimit = Limit - I[1]->Last->TotalLength - 3;
       const unsigned MergedLines = tryMergeNamespace(I + 1, E, InnerLimit);
-      if (!MergedLines)
+      if (MergedLines == 0)
         return 0;
       const auto N = MergedLines + 2;
       // Check if there is even a line after the inner result.

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -643,7 +643,7 @@ private:
       return 0;
 
     // Check if it's a namespace inside a namespace, and call recursively if so
-    // '3' is the sizes of the whitespace and closing brace for " _inner_ }"
+    // '3' is the sizes of the whitespace and closing brace for " _inner_ }".
     if (I[1]->First->is(tok::kw_namespace)) {
       if (I[1]->Last->is(TT_LineComment))
         return 0;
@@ -652,11 +652,11 @@ private:
       const unsigned MergedLines = tryMergeNamespace(I + 1, E, InnerLimit);
       if (!MergedLines)
         return 0;
-      // check if there is even a line after the inner result
-      if (I + 2 + MergedLines >= E)
+      // Check if there is even a line after the inner result.
+      if (std::distance(I, E) <= MergedLines + 2)
         return 0;
-      // check that the line after the inner result starts with a closing brace
-      // which we are permitted to merge into one line
+      // Check that the line after the inner result starts with a closing brace
+      // which we are permitted to merge into one line.
       if (I[2 + MergedLines]->First->is(tok::r_brace) &&
           !I[2 + MergedLines]->First->MustBreakBefore &&
           !I[1 + MergedLines]->Last->is(TT_LineComment) &&
@@ -669,7 +669,7 @@ private:
     // There's no inner namespace, so we are considering to merge at most one
     // line.
 
-    // The line which is in the namespace should end with semicolon
+    // The line which is in the namespace should end with semicolon.
     if (I[1]->Last->isNot(tok::semi))
       return 0;
 
@@ -984,15 +984,13 @@ private:
   bool nextNLinesFitInto(SmallVectorImpl<AnnotatedLine *>::const_iterator I,
                          SmallVectorImpl<AnnotatedLine *>::const_iterator E,
                          unsigned Limit) {
-    unsigned joinedLength = 0;
-    for (SmallVectorImpl<AnnotatedLine *>::const_iterator J = I + 1; J != E;
-         ++J) {
-
+    unsigned JoinedLength = 0;
+    for (auto J = I + 1; J != E; ++J) {
       if ((*J)->First->MustBreakBefore)
         return false;
 
-      joinedLength += 1 + (*J)->Last->TotalLength;
-      if (joinedLength > Limit)
+      JoinedLength += 1 + (*J)->Last->TotalLength;
+      if (JoinedLength > Limit)
         return false;
     }
     return true;

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -365,13 +365,12 @@ private:
     // FIXME: There are probably cases where we should use FirstNonComment
     // instead of TheLine->First.
 
-    if (TheLine->Last->is(tok::l_brace)) {
-      if (Style.AllowShortNamespacesOnASingleLine &&
-          TheLine->First->is(tok::kw_namespace)) {
-        unsigned result = tryMergeNamespace(I, E, Limit);
-        if (result > 0)
-          return result;
-      }
+    if (Style.AllowShortNamespacesOnASingleLine &&
+        TheLine->First->is(tok::kw_namespace) &&
+        TheLine->Last->is(tok::l_brace)) {
+      const auto result = tryMergeNamespace(I, E, Limit);
+      if (result > 0)
+        return result;
     }
 
     if (Style.CompactNamespaces) {

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -159,6 +159,7 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_BOOL(AllowShortCompoundRequirementOnASingleLine);
   CHECK_PARSE_BOOL(AllowShortEnumsOnASingleLine);
   CHECK_PARSE_BOOL(AllowShortLoopsOnASingleLine);
+  CHECK_PARSE_BOOL(AllowShortNamespacesOnASingleLine);
   CHECK_PARSE_BOOL(BinPackArguments);
   CHECK_PARSE_BOOL(BreakAdjacentStringLiterals);
   CHECK_PARSE_BOOL(BreakAfterJavaFieldAnnotations);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28414,20 +28414,6 @@ TEST_F(FormatTest, ShortNamespacesOption) {
                "}}} // extra",
                Style);
 
-  // No ColumnLimit, allows long nested one-liners, but also leaves multi-line
-  // instances alone.
-  Style.ColumnLimit = 0;
-  verifyFormat(
-      "namespace foo { namespace bar { namespace baz { class qux; } } }",
-      Style);
-
-  verifyNoChange("namespace foo {\n"
-                 "namespace bar { namespace baz { class qux; } }\n"
-                 "}",
-                 Style);
-
-  verifyFormat("namespace foo { namespace bar { class baz; } }", Style);
-
   // FIXME: Ideally AllowShortNamespacesOnASingleLine would disable the trailing
   // namespace comment from 'FixNamespaceComments', as it's not really necessary
   // in this scenario, but the two options work at very different layers of the

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28319,7 +28319,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
   Style.AllowShortNamespacesOnASingleLine = true;
   Style.FixNamespaceComments = false;
 
-  // Basic functionality
+  // Basic functionality.
   verifyFormat("namespace foo { class bar; }", Style);
   verifyFormat("namespace foo::bar { class baz; }", Style);
   verifyFormat("namespace { class bar; }", Style);
@@ -28329,13 +28329,13 @@ TEST_F(FormatTest, ShortNamespacesOption) {
                "}",
                Style);
 
-  // Trailing comments prevent merging
+  // Trailing comments prevent merging.
   verifyFormat("namespace foo {\n"
                "namespace baz { class qux; } // comment\n"
                "}",
                Style);
 
-  // Make sure code doesn't walk to far on unbalanced code
+  // Make sure code doesn't walk to far on unbalanced code.
   verifyFormat("namespace foo {", Style);
   verifyFormat("namespace foo {\n"
                "class baz;",
@@ -28344,7 +28344,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
                "namespace bar { class baz; }",
                Style);
 
-  // Nested namespaces
+  // Nested namespaces.
   verifyFormat("namespace foo { namespace bar { class baz; } }", Style);
   verifyFormat("namespace foo {\n"
                "namespace bar { class baz; }\n"
@@ -28352,7 +28352,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
                "}",
                Style);
 
-  // Varying inner content
+  // Varying inner content.
   verifyFormat("namespace foo {\n"
                "int f() { return 5; }\n"
                "}",
@@ -28360,15 +28360,15 @@ TEST_F(FormatTest, ShortNamespacesOption) {
   verifyFormat("namespace foo { template <T> struct bar; }", Style);
   verifyFormat("namespace foo { constexpr int num = 42; }", Style);
 
-  // Validate wrapping scenarios around the ColumnLimit
+  // Validate wrapping scenarios around the ColumnLimit.
   Style.ColumnLimit = 64;
 
-  // Validate just under the ColumnLimit
+  // Validate just under the ColumnLimit.
   verifyFormat(
       "namespace foo { namespace bar { namespace baz { class qux; } } }",
       Style);
 
-  // Validate just over the ColumnLimit
+  // Validate just over the ColumnLimit.
   verifyFormat("namespace foo {\n"
                "namespace bar { namespace baz { class quux; } }\n"
                "}",
@@ -28381,14 +28381,14 @@ TEST_F(FormatTest, ShortNamespacesOption) {
                "}",
                Style);
 
-  // Validate that the ColumnLimit logic accounts for trailing content as well
+  // Validate that the ColumnLimit logic accounts for trailing content as well.
   verifyFormat("namespace foo {\n"
                "namespace bar { namespace baz { class qux; } }\n"
                "} // extra",
                Style);
 
   // No ColumnLimit, allows long nested one-liners, but also leaves multi-line
-  // instances alone
+  // instances alone.
   Style.ColumnLimit = 0;
   verifyFormat("namespace foo { namespace bar { namespace baz { namespace qux "
                "{ class quux; } } } }",
@@ -28403,7 +28403,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
 
   // This option doesn't really work with FixNamespaceComments and nested
   // namespaces. Code should use the concatenated namespace syntax.  e.g.
-  // 'namespace foo::bar'
+  // 'namespace foo::bar'.
   Style.FixNamespaceComments = true;
 
   verifyFormat(
@@ -28413,7 +28413,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
       "namespace foo { namespace bar { namespace baz { class qux; } } }",
       Style);
 
-  // This option doesn't really make any sense with ShortNamespaceLines = 0
+  // This option doesn't really make any sense with ShortNamespaceLines = 0.
   Style.ShortNamespaceLines = 0;
 
   verifyFormat(

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28321,12 +28321,10 @@ TEST_F(FormatTest, KeepFormFeed) {
 }
 
 TEST_F(FormatTest, ShortNamespacesOption) {
-  auto BaseStyle = getLLVMStyle();
-  BaseStyle.AllowShortNamespacesOnASingleLine = true;
-  BaseStyle.FixNamespaceComments = false;
-  BaseStyle.CompactNamespaces = true;
-
-  auto Style = BaseStyle;
+  auto Style = getLLVMStyle();
+  Style.AllowShortNamespacesOnASingleLine = true;
+  Style.CompactNamespaces = true;
+  Style.FixNamespaceComments = false;
 
   // Basic functionality.
   verifyFormat("namespace foo { class bar; }", Style);
@@ -28358,7 +28356,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
   verifyFormat("namespace foo { namespace bar { class baz; } }", Style);
 
   // Without CompactNamespaces, we won't merge consecutive namespace
-  // declarations
+  // declarations.
   Style.CompactNamespaces = false;
   verifyFormat("namespace foo {\n"
                "namespace bar { class baz; }\n"
@@ -28371,7 +28369,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
                "}",
                Style);
 
-  Style = BaseStyle;
+  Style.CompactNamespaces = true;
 
   // Varying inner content.
   verifyFormat("namespace foo {\n"
@@ -28419,9 +28417,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
   // too long to fit within the ColumnLimit, reducing the how likely the line
   // will still fit on a single line. The recommendation for now is to use the
   // concatenated namespace syntax instead. e.g. 'namespace foo::bar'
-  Style = BaseStyle;
   Style.FixNamespaceComments = true;
-
   verifyFormat(
       "namespace foo { namespace bar { namespace baz {\n"
       "class qux;\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4476,6 +4476,7 @@ TEST_F(FormatTest, FormatsCompactNamespaces) {
                "int k; } // namespace out",
                Style);
 
+  Style.ColumnLimit = 41;
   verifyFormat("namespace A { namespace B { namespace C {\n"
                "}}} // namespace A::B::C",
                "namespace A { namespace B {\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28315,106 +28315,106 @@ TEST_F(FormatTest, KeepFormFeed) {
 }
 
 TEST_F(FormatTest, ShortNamespacesOption) {
-  FormatStyle style = getLLVMStyle();
-  style.AllowShortNamespacesOnASingleLine = true;
-  style.FixNamespaceComments = false;
+  FormatStyle Style = getLLVMStyle();
+  Style.AllowShortNamespacesOnASingleLine = true;
+  Style.FixNamespaceComments = false;
 
   // Basic functionality
-  verifyFormat("namespace foo { class bar; }", style);
-  verifyFormat("namespace foo::bar { class baz; }", style);
-  verifyFormat("namespace { class bar; }", style);
+  verifyFormat("namespace foo { class bar; }", Style);
+  verifyFormat("namespace foo::bar { class baz; }", Style);
+  verifyFormat("namespace { class bar; }", Style);
   verifyFormat("namespace foo {\n"
                "class bar;\n"
                "class baz;\n"
                "}",
-               style);
+               Style);
 
   // Trailing comments prevent merging
   verifyFormat("namespace foo {\n"
                "namespace baz { class qux; } // comment\n"
                "}",
-               style);
+               Style);
 
   // Make sure code doesn't walk to far on unbalanced code
-  verifyFormat("namespace foo {", style);
+  verifyFormat("namespace foo {", Style);
   verifyFormat("namespace foo {\n"
                "class baz;",
-               style);
+               Style);
   verifyFormat("namespace foo {\n"
                "namespace bar { class baz; }",
-               style);
+               Style);
 
   // Nested namespaces
-  verifyFormat("namespace foo { namespace bar { class baz; } }", style);
+  verifyFormat("namespace foo { namespace bar { class baz; } }", Style);
   verifyFormat("namespace foo {\n"
                "namespace bar { class baz; }\n"
                "namespace quar { class quaz; }\n"
                "}",
-               style);
+               Style);
 
   // Varying inner content
   verifyFormat("namespace foo {\n"
                "int f() { return 5; }\n"
                "}",
-               style);
-  verifyFormat("namespace foo { template <T> struct bar; }", style);
-  verifyFormat("namespace foo { constexpr int num = 42; }", style);
+               Style);
+  verifyFormat("namespace foo { template <T> struct bar; }", Style);
+  verifyFormat("namespace foo { constexpr int num = 42; }", Style);
 
   // Validate wrapping scenarios around the ColumnLimit
-  style.ColumnLimit = 64;
+  Style.ColumnLimit = 64;
 
   // Validate just under the ColumnLimit
   verifyFormat(
       "namespace foo { namespace bar { namespace baz { class qux; } } }",
-      style);
+      Style);
 
   // Validate just over the ColumnLimit
   verifyFormat("namespace foo {\n"
                "namespace bar { namespace baz { class quux; } }\n"
                "}",
-               style);
+               Style);
 
   verifyFormat("namespace foo {\n"
                "namespace bar {\n"
                "namespace baz { namespace qux { class quux; } }\n"
                "}\n"
                "}",
-               style);
+               Style);
 
   // Validate that the ColumnLimit logic accounts for trailing content as well
   verifyFormat("namespace foo {\n"
                "namespace bar { namespace baz { class qux; } }\n"
                "} // extra",
-               style);
+               Style);
 
   // No ColumnLimit, allows long nested one-liners, but also leaves multi-line
   // instances alone
-  style.ColumnLimit = 0;
+  Style.ColumnLimit = 0;
   verifyFormat("namespace foo { namespace bar { namespace baz { namespace qux "
                "{ class quux; } } } }",
-               style);
+               Style);
 
   verifyNoChange("namespace foo {\n"
                  "namespace bar {\n"
                  "namespace baz { namespace qux { class quux; } }\n"
                  "}\n"
                  "}",
-                 style);
+                 Style);
 
   // This option doesn't really work with FixNamespaceComments and nested
   // namespaces. Code should use the concatenated namespace syntax.  e.g.
   // 'namespace foo::bar'
-  style.FixNamespaceComments = true;
+  Style.FixNamespaceComments = true;
 
   verifyFormat(
       "namespace foo {\n"
       "namespace bar { namespace baz { class qux; } } // namespace bar\n"
       "} // namespace foo",
       "namespace foo { namespace bar { namespace baz { class qux; } } }",
-      style);
+      Style);
 
   // This option doesn't really make any sense with ShortNamespaceLines = 0
-  style.ShortNamespaceLines = 0;
+  Style.ShortNamespaceLines = 0;
 
   verifyFormat(
       "namespace foo {\n"
@@ -28423,7 +28423,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
       "} // namespace bar\n"
       "} // namespace foo",
       "namespace foo { namespace bar { namespace baz { class qux; } } }",
-      style);
+      Style);
 }
 
 } // namespace

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4484,7 +4484,7 @@ TEST_F(FormatTest, FormatsCompactNamespaces) {
                "} // namespace A",
                Style);
 
-  Style.ColumnLimit = 41;
+  Style.ColumnLimit = 40;
   verifyFormat("namespace aaaaaaaaaa {\n"
                "namespace bbbbbbbbbb {\n"
                "}} // namespace aaaaaaaaaa::bbbbbbbbbb",
@@ -4505,13 +4505,9 @@ TEST_F(FormatTest, FormatsCompactNamespaces) {
                "} // namespace aaaaaa",
                Style);
 
-  verifyFormat("namespace a { namespace b { namespace c {\n"
-               "}}} // namespace a::b::c",
-               Style);
-
   verifyFormat("namespace a { namespace b {\n"
-               "namespace cc {\n"
-               "}}} // namespace a::b::cc",
+               "namespace c {\n"
+               "}}} // namespace a::b::c",
                Style);
 
   Style.ColumnLimit = 80;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28407,7 +28407,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
 
   // If we can't merge an outer nested namespaces, but can merge an inner
   // nested namespace, then CompactNamespaces will merge the outer namespace
-  // first, preventing the merging of the inner namespace
+  // first, preventing the merging of the inner namespace.
   verifyFormat("namespace foo { namespace baz {\n"
                "class qux;\n"
                "} // comment\n"


### PR DESCRIPTION
This fixes #101363 which is a resurrection of a previously opened but never completed review: https://reviews.llvm.org/D11851

The feature is to allow code like the following not to be broken across multiple lines:

```
namespace foo { class bar; }
namespace foo { namespace bar { class baz; } }
```

Code like this is commonly used for forward declarations, which are ideally kept compact. This is also apparently the format that include-what-you-use will insert for forward declarations.

Also, fix an off-by-one error in `CompactNamespaces` code. For nested namespaces with 3 or more namespaces, it was incorrectly compacting lines which were 1 or two spaces over the `ColumnLimit`, leading to incorrect formatting results.