### PR TITLE
Revert "Speculative fix for asan/TestCases/Darwin/cstring_section.c"

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/cstring_section.c
+++ b/compiler-rt/test/asan/TestCases/Darwin/cstring_section.c
@@ -6,9 +6,9 @@
 // Check that "Hello.\n" is in __asan_cstring and not in __cstring.
 // CHECK: Contents of section {{.*}}__asan_cstring:
 // CHECK: 48656c6c {{.*}} Hello.
-// CHECK: Contents of section {{.*}}__cstring:
-// CHECK-NOT: 48656c6c {{.*}} Hello.
 // CHECK: Contents of section {{.*}}__const:
+// CHECK-NOT: 48656c6c {{.*}} Hello.
+// CHECK: Contents of section {{.*}}__cstring:
 // CHECK-NOT: 48656c6c {{.*}} Hello.
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
This fix is not enough, and the breaking patch was reverted with 2704b804bec50c2b016bf678bd534c330ec655b6.

This reverts commit bf71c64839c0082e761a4f070ed92e01ced0187c.
