### PR TITLE
[lldb-dap] Skip the lldb-dap output test on windows, it seems all the lldb-dap tests are disabled on windows.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
+++ b/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
@@ -8,6 +8,7 @@ import lldbdap_testcase
 
 
 class TestDAP_output(lldbdap_testcase.DAPTestCaseBase):
+    @skipIfWindows
     def test_output(self):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)


### PR DESCRIPTION
This should fix https://lab.llvm.org/buildbot/#/builders/141/builds/1747