### PR TITLE
[Clang][AArch64] Fix typo with colon-separated syntax for system registers

### DIFF
--- a/clang/lib/Sema/SemaARM.cpp
+++ b/clang/lib/Sema/SemaARM.cpp
@@ -248,16 +248,16 @@ bool SemaARM::BuiltinARMSpecialReg(unsigned BuiltinID, CallExpr *TheCall,
       }
     }
 
-    SmallVector<int, 5> Ranges;
+    SmallVector<int, 5> FieldBitWidths;
     if (FiveFields)
-      Ranges.append({IsAArch64Builtin ? 1 : 15, 7, 15, 15, 7});
+      FieldBitWidths.append({IsAArch64Builtin ? 2 : 4, 3, 4, 4, 3});
     else
-      Ranges.append({15, 7, 15});
+      FieldBitWidths.append({4, 3, 4});
 
     for (unsigned i = 0; i < Fields.size(); ++i) {
       int IntField;
       ValidString &= !Fields[i].getAsInteger(10, IntField);
-      ValidString &= (IntField >= 0 && IntField <= Ranges[i]);
+      ValidString &= (IntField >= 0 && IntField < (1 << FieldBitWidths[i]));
     }
 
     if (!ValidString)

--- a/clang/test/Sema/aarch64-special-register.c
+++ b/clang/test/Sema/aarch64-special-register.c
@@ -116,6 +116,13 @@ unsigned long rsr64_6(void) {
   return __builtin_arm_rsr64("0:1:16:16:2"); //expected-error {{invalid special register for builtin}}
 }
 
+void rsr64_7(unsigned long *r) {
+  // The following three instructions should produce the same assembly.
+  r[0] = __builtin_arm_rsr64("ICC_CTLR_EL3");
+  r[1] = __builtin_arm_rsr64("s3_6_c12_c12_4");
+  r[2] = __builtin_arm_rsr64("3:6:12:12:4");
+}
+
 __uint128_t rsr128_3(void) {
   return __builtin_arm_rsr128("0:1:2"); //expected-error {{invalid special register for builtin}}
 }


### PR DESCRIPTION
The range for Op0 was set to 1 instead of 3.

The description of e493f177eeee84a9c6000ca7c92499233490f1d1 visually explains the encoding of implementation-defined system registers.

https://github.com/llvm/llvm-project/blob/796787d07c30cb9448e1f9ff3f3da06c2fc96ccd/llvm/lib/Target/AArch64/AArch64SystemOperands.td#L658-L674

Gobolt: https://godbolt.org/z/WK9PqPvGE