### PR TITLE
[SCCP] get rid of potentially dangling iterator

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
@@ -189,8 +189,8 @@ class InstCostVisitor : public InstVisitor<InstCostVisitor, Constant *> {
   // (some of their incoming values may have become constant or dead).
   SmallVector<Instruction *> PendingPHIs;
 
-  Value* LastVisitedUse = nullptr;
-  Constant* LastVisitedConstant = nullptr;
+  Value *LastVisitedUse = nullptr;
+  Constant *LastVisitedConstant = nullptr;
 
 public:
   InstCostVisitor(const DataLayout &DL, BlockFrequencyInfo &BFI,

--- a/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
@@ -189,7 +189,8 @@ class InstCostVisitor : public InstVisitor<InstCostVisitor, Constant *> {
   // (some of their incoming values may have become constant or dead).
   SmallVector<Instruction *> PendingPHIs;
 
-  ConstMap::iterator LastVisited;
+  Value* LastVisitedUse = nullptr;
+  Constant* LastVisitedConstant = nullptr;
 
 public:
   InstCostVisitor(const DataLayout &DL, BlockFrequencyInfo &BFI,

--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -430,8 +430,8 @@ Constant *InstCostVisitor::visitSelectInst(SelectInst &I) {
   if (I.getCondition() != LastVisitedUse)
     return nullptr;
 
-  Value *V = LastVisitedConstant->isZeroValue() ? I.getFalseValue()
-                                                : I.getTrueValue();
+  Value *V =
+      LastVisitedConstant->isZeroValue() ? I.getFalseValue() : I.getTrueValue();
   Constant *C = findConstantFor(V, KnownConstants);
   return C;
 }


### PR DESCRIPTION
getUserBonus took an iterator into KnownConstants, but then inserted
into it later in the function, which could resize the data-structure
(DenseMap is based on a vector, so is not iterator stable).

The iterator is not needed, because we never change the value of an
entry after inserting.
