### PR TITLE
[sanitizer] add null check

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -235,6 +235,7 @@ void InitTlsSize() {
 #    if defined(__aarch64__) || defined(__x86_64__) || \
         defined(__powerpc64__) || defined(__loongarch__)
   void *get_tls_static_info = dlsym(RTLD_NEXT, "_dl_get_tls_static_info");
+  CHECK_NE(get_tls_static_info, nullptr);
   size_t tls_align;
   ((void (*)(size_t *, size_t *))get_tls_static_info)(&g_tls_size, &tls_align);
 #    endif


### PR DESCRIPTION
`dlsym()` could return nullptr, we should check the return value before using it.