### PR TITLE
[libunwind] Stop installing the mach-o module map

### DIFF
--- a/libunwind/include/CMakeLists.txt
+++ b/libunwind/include/CMakeLists.txt
@@ -3,7 +3,6 @@ set(files
     libunwind.h
     libunwind.modulemap
     mach-o/compact_unwind_encoding.h
-    mach-o/compact_unwind_encoding.modulemap
     unwind_arm_ehabi.h
     unwind_itanium.h
     unwind.h

--- a/libunwind/include/mach-o/compact_unwind_encoding.modulemap
+++ b/libunwind/include/mach-o/compact_unwind_encoding.modulemap
@@ -1,4 +1,0 @@
-module MachO.compact_unwind_encoding [system] {
-  header "compact_unwind_encoding.h"
-  export *
-}


### PR DESCRIPTION
libunwind shouldn't know that compact_unwind_encoding.h is part of a MachO module that it doesn't own. Delete the mach-o module map, and let whatever is in charge of the mach-o directory be the one to say how its module is organized and where compact_unwind_encoding.h fits in.