### PR TITLE
[NFC] Use stable_hash_combine instead of hash_combine

### DIFF
--- a/llvm/lib/CodeGen/MachineStableHash.cpp
+++ b/llvm/lib/CodeGen/MachineStableHash.cpp
@@ -63,10 +63,10 @@ stable_hash llvm::stableHashValue(const MachineOperand &MO) {
   case MachineOperand::MO_Register:
     if (MO.getReg().isVirtual()) {
       const MachineRegisterInfo &MRI = MO.getParent()->getMF()->getRegInfo();
-      SmallVector<unsigned> DefOpcodes;
+      SmallVector<stable_hash> DefOpcodes;
       for (auto &Def : MRI.def_instructions(MO.getReg()))
         DefOpcodes.push_back(Def.getOpcode());
-      return hash_combine_range(DefOpcodes.begin(), DefOpcodes.end());
+      return stable_hash_combine_range(DefOpcodes.begin(), DefOpcodes.end());
     }
 
     // Register operands don't have target flags.
@@ -80,7 +80,7 @@ stable_hash llvm::stableHashValue(const MachineOperand &MO) {
                            : MO.getFPImm()->getValueAPF().bitcastToAPInt();
     auto ValHash =
         stable_hash_combine_array(Val.getRawData(), Val.getNumWords());
-    return hash_combine(MO.getType(), MO.getTargetFlags(), ValHash);
+    return stable_hash_combine(MO.getType(), MO.getTargetFlags(), ValHash);
   }
 
   case MachineOperand::MO_MachineBasicBlock:
@@ -112,8 +112,8 @@ stable_hash llvm::stableHashValue(const MachineOperand &MO) {
                                MO.getIndex());
 
   case MachineOperand::MO_ExternalSymbol:
-    return hash_combine(MO.getType(), MO.getTargetFlags(), MO.getOffset(),
-                        xxh3_64bits(MO.getSymbolName()));
+    return stable_hash_combine(MO.getType(), MO.getTargetFlags(),
+                               MO.getOffset(), xxh3_64bits(MO.getSymbolName()));
 
   case MachineOperand::MO_RegisterMask:
   case MachineOperand::MO_RegisterLiveOut: {
@@ -126,15 +126,16 @@ stable_hash llvm::stableHashValue(const MachineOperand &MO) {
           const uint32_t *RegMask = MO.getRegMask();
           std::vector<llvm::stable_hash> RegMaskHashes(RegMask,
                                                        RegMask + RegMaskSize);
-          return hash_combine(MO.getType(), MO.getTargetFlags(),
-                              stable_hash_combine_array(RegMaskHashes.data(),
-                                                        RegMaskHashes.size()));
+          return stable_hash_combine(
+              MO.getType(), MO.getTargetFlags(),
+              stable_hash_combine_array(RegMaskHashes.data(),
+                                        RegMaskHashes.size()));
         }
       }
     }
 
     assert(0 && "MachineOperand not associated with any MachineFunction");
-    return hash_combine(MO.getType(), MO.getTargetFlags());
+    return stable_hash_combine(MO.getType(), MO.getTargetFlags());
   }
 
   case MachineOperand::MO_ShuffleMask: {
@@ -144,14 +145,15 @@ stable_hash llvm::stableHashValue(const MachineOperand &MO) {
         MO.getShuffleMask(), std::back_inserter(ShuffleMaskHashes),
         [](int S) -> llvm::stable_hash { return llvm::stable_hash(S); });
 
-    return hash_combine(MO.getType(), MO.getTargetFlags(),
-                        stable_hash_combine_array(ShuffleMaskHashes.data(),
-                                                  ShuffleMaskHashes.size()));
+    return stable_hash_combine(
+        MO.getType(), MO.getTargetFlags(),
+        stable_hash_combine_array(ShuffleMaskHashes.data(),
+                                  ShuffleMaskHashes.size()));
   }
   case MachineOperand::MO_MCSymbol: {
     auto SymbolName = MO.getMCSymbol()->getName();
-    return hash_combine(MO.getType(), MO.getTargetFlags(),
-                        xxh3_64bits(SymbolName));
+    return stable_hash_combine(MO.getType(), MO.getTargetFlags(),
+                               xxh3_64bits(SymbolName));
   }
   case MachineOperand::MO_CFIIndex:
     return stable_hash_combine(MO.getType(), MO.getTargetFlags(),


### PR DESCRIPTION
I found the current stable hash is not deterministic across multiple runs on a specific platform. This is becauses it uses `hash_combine` instead of `stable_hash_combine`.