### PR TITLE
[IR] Simplify comparisons with std::optional (NFC)

### DIFF
--- a/llvm/lib/IR/VectorBuilder.cpp
+++ b/llvm/lib/IR/VectorBuilder.cpp
@@ -96,8 +96,7 @@ Value *VectorBuilder::createVectorInstructionImpl(Intrinsic::ID VPID,
     // Insert mask and evl operands in between the instruction operands.
     for (size_t VPParamIdx = 0, ParamIdx = 0; VPParamIdx < NumVPParams;
          ++VPParamIdx) {
-      if ((MaskPosOpt && MaskPosOpt.value_or(NumVPParams) == VPParamIdx) ||
-          (VLenPosOpt && VLenPosOpt.value_or(NumVPParams) == VPParamIdx))
+      if (MaskPosOpt == VPParamIdx || VLenPosOpt == VPParamIdx)
         continue;
       assert(ParamIdx < NumInstParams);
       IntrinParams[VPParamIdx] = InstOpArray[ParamIdx++];


### PR DESCRIPTION
For variable X of type std::optional, X && X.value_or(Y) == Z is
equivalent to X == Z when Y != Z.
