### PR TITLE
[clang][bytecode] Fix void unary * operators

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5145,7 +5145,7 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
     // We should already have a pointer when we get here.
     return this->delegate(SubExpr);
   case UO_Deref: // *x
-    if (DiscardResult)
+    if (DiscardResult || E->getType()->isVoidType())
       return this->discard(SubExpr);
     return this->visit(SubExpr);
   case UO_Not: // ~x

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fcxx-exceptions -std=c++20 -fexperimental-new-constant-interpreter -verify %s
-// RUN: %clang_cc1 -fcxx-exceptions -std=c++20 -verify=ref %s
+// RUN: %clang_cc1 -fcxx-exceptions -std=c++20 -fexperimental-new-constant-interpreter -verify=expected,both %s
+// RUN: %clang_cc1 -fcxx-exceptions -std=c++20 -verify=ref,both %s
 
 namespace Throw {
 
@@ -65,4 +65,9 @@ namespace Casts {
                                                // ref-error {{must be initialized by a constant expression}} \
                                                // ref-note {{reinterpret_cast is not allowed}}
 
+  void func() {
+    struct B {};
+    B b;
+    (void)*reinterpret_cast<void*>(&b); // both-error {{indirection not permitted on operand of type 'void *'}}
+  }
 }


### PR DESCRIPTION
Discard the subexpr.