### PR TITLE
[mlir][OpenMP][NFC] clean up optional reduction region parsing

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -1576,11 +1576,11 @@ def DeclareReductionOp : OpenMP_Op<"declare_reduction", [IsolatedFromAbove,
                         AnyRegion:$cleanupRegion);
 
   let assemblyFormat = "$sym_name `:` $type attr-dict-with-keyword "
-                       "custom<AllocReductionRegion>($allocRegion) "
+                       "( `alloc` $allocRegion^ )? "
                        "`init` $initializerRegion "
                        "`combiner` $reductionRegion "
-                       "custom<AtomicReductionRegion>($atomicReductionRegion) "
-                       "custom<CleanupReductionRegion>($cleanupRegion)";
+                       "( `atomic` $atomicReductionRegion^ )? "
+                       "( `cleanup` $cleanupRegion^ )? ";
 
   let extraClassDeclaration = [{
     PointerLikeType getAccumulatorType() {

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -1883,52 +1883,6 @@ LogicalResult DistributeOp::verify() {
 // DeclareReductionOp
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseOptionalReductionRegion(OpAsmParser &parser,
-                                                Region &region,
-                                                StringRef keyword) {
-  if (parser.parseOptionalKeyword(keyword))
-    return success();
-  return parser.parseRegion(region);
-}
-
-static void printOptionalReductionRegion(OpAsmPrinter &printer, Region &region,
-                                         StringRef keyword) {
-  if (region.empty())
-    return;
-  printer << keyword << " ";
-  printer.printRegion(region);
-}
-
-static ParseResult parseAllocReductionRegion(OpAsmParser &parser,
-                                             Region &region) {
-  return parseOptionalReductionRegion(parser, region, "alloc");
-}
-
-static void printAllocReductionRegion(OpAsmPrinter &printer,
-                                      DeclareReductionOp op, Region &region) {
-  printOptionalReductionRegion(printer, region, "alloc");
-}
-
-static ParseResult parseAtomicReductionRegion(OpAsmParser &parser,
-                                              Region &region) {
-  return parseOptionalReductionRegion(parser, region, "atomic");
-}
-
-static void printAtomicReductionRegion(OpAsmPrinter &printer,
-                                       DeclareReductionOp op, Region &region) {
-  printOptionalReductionRegion(printer, region, "atomic");
-}
-
-static ParseResult parseCleanupReductionRegion(OpAsmParser &parser,
-                                               Region &region) {
-  return parseOptionalReductionRegion(parser, region, "cleanup");
-}
-
-static void printCleanupReductionRegion(OpAsmPrinter &printer,
-                                        DeclareReductionOp op, Region &region) {
-  printOptionalReductionRegion(printer, region, "cleanup");
-}
-
 LogicalResult DeclareReductionOp::verifyRegions() {
   if (!getAllocRegion().empty()) {
     for (YieldOp yieldOp : getAllocRegion().getOps<YieldOp>()) {


### PR DESCRIPTION
This can be handled in ODS instead of writing custom parsing/printing code.

Thanks for the idea @skatrak