### PR TITLE
[analyzer] Detect leaks of stack addresses via output params, indirect globals 3/3

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -286,6 +286,10 @@ public:
             const Stmt *DiagnosticStmt = nullptr,
             ProgramPoint::Kind K = ProgramPoint::PreStmtPurgeDeadSymbolsKind);
 
+  // A tag to track convenience transitions, which can be removed at cleanup.
+  // This tag applies to a node created after removeDead.
+  static const ProgramPointTag* cleanupNodeTag();
+
   /// processCFGElement - Called by CoreEngine. Used to generate new successor
   ///  nodes by processing the 'effects' of a CFG element.
   void processCFGElement(const CFGElement E, ExplodedNode *Pred,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -286,9 +286,9 @@ public:
             const Stmt *DiagnosticStmt = nullptr,
             ProgramPoint::Kind K = ProgramPoint::PreStmtPurgeDeadSymbolsKind);
 
-  // A tag to track convenience transitions, which can be removed at cleanup.
-  // This tag applies to a node created after removeDead.
-  static const ProgramPointTag* cleanupNodeTag();
+  /// A tag to track convenience transitions, which can be removed at cleanup.
+  /// This tag applies to a node created after removeDead.
+  static const ProgramPointTag *cleanupNodeTag();
 
   /// processCFGElement - Called by CoreEngine. Used to generate new successor
   ///  nodes by processing the 'effects' of a CFG element.

--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -305,12 +305,12 @@ static const MemSpaceRegion *getStackOrGlobalSpaceRegion(const MemRegion *R) {
   return nullptr;
 }
 
-const MemRegion *getOriginBaseRegion(const MemRegion *Referrer) {
-  Referrer = Referrer->getBaseRegion();
-  while (const auto *SymReg = dyn_cast<SymbolicRegion>(Referrer)) {
-    Referrer = SymReg->getSymbol()->getOriginRegion()->getBaseRegion();
+const MemRegion *getOriginBaseRegion(const MemRegion *Reg) {
+  Reg = Reg->getBaseRegion();
+  while (const auto *SymReg = dyn_cast<SymbolicRegion>(Reg)) {
+    Reg = SymReg->getSymbol()->getOriginRegion()->getBaseRegion();
   }
-  return Referrer;
+  return Reg;
 }
 
 std::optional<std::string> printReferrer(const MemRegion *Referrer) {

--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -372,9 +372,8 @@ void StackAddrEscapeChecker::checkEndFunction(const ReturnStmt *RS,
   bool ExitingTopFrame =
       Ctx.getPredecessor()->getLocationContext()->inTopFrame();
 
-  if (ExitingTopFrame && Node->getLocation().getTag() &&
-      Node->getLocation().getTag()->getTagDescription() ==
-          "ExprEngine : Clean Node" &&
+  if (ExitingTopFrame &&
+      Node->getLocation().getTag() == ExprEngine::cleanupNodeTag() &&
       Node->getFirstPred()) {
     // When finishing analysis of a top-level function, engine proactively
     // removes dead symbols thus preventing this checker from looking through

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -376,7 +376,7 @@ const Stmt *ExplodedNode::getNextStmtForDiagnostics() const {
 
 const Stmt *ExplodedNode::getPreviousStmtForDiagnostics() const {
   for (const ExplodedNode *N = getFirstPred(); N; N = N->getFirstPred())
-    if (const Stmt *S = N->getStmtForDiagnostics())
+    if (const Stmt *S = N->getStmtForDiagnostics(); S && !isa<CompoundStmt>(S))
       return S;
 
   return nullptr;

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1072,8 +1072,6 @@ void ExprEngine::removeDead(ExplodedNode *Pred, ExplodedNodeSet &Out,
       CleanedState, SFC, SymReaper);
 
   // Process any special transfer function for dead symbols.
-  // A tag to track convenience transitions, which can be removed at cleanup.
-  static SimpleProgramPointTag cleanupTag(TagProviderName, "Clean Node");
   // Call checkers with the non-cleaned state so that they could query the
   // values of the soon to be dead symbols.
   ExplodedNodeSet CheckedSet;
@@ -1102,8 +1100,13 @@ void ExprEngine::removeDead(ExplodedNode *Pred, ExplodedNodeSet &Out,
     // generate a transition to that state.
     ProgramStateRef CleanedCheckerSt =
         StateMgr.getPersistentStateWithGDM(CleanedState, CheckerState);
-    Bldr.generateNode(DiagnosticStmt, I, CleanedCheckerSt, &cleanupTag, K);
+    Bldr.generateNode(DiagnosticStmt, I, CleanedCheckerSt, cleanupNodeTag(), K);
   }
+}
+
+const ProgramPointTag* ExprEngine::cleanupNodeTag() {
+  static SimpleProgramPointTag cleanupTag(TagProviderName, "Clean Node");
+  return &cleanupTag;
 }
 
 void ExprEngine::ProcessStmt(const Stmt *currStmt, ExplodedNode *Pred) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1104,7 +1104,7 @@ void ExprEngine::removeDead(ExplodedNode *Pred, ExplodedNodeSet &Out,
   }
 }
 
-const ProgramPointTag* ExprEngine::cleanupNodeTag() {
+const ProgramPointTag *ExprEngine::cleanupNodeTag() {
   static SimpleProgramPointTag cleanupTag(TagProviderName, "Clean Node");
   return &cleanupTag;
 }

--- a/clang/test/Analysis/copy-elision.cpp
+++ b/clang/test/Analysis/copy-elision.cpp
@@ -158,19 +158,19 @@ ClassWithoutDestructor make1(AddressVector<ClassWithoutDestructor> &v) {
   return ClassWithoutDestructor(v);
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
 object of type 'ClassWithoutDestructor' is still \
-referred to by the stack variable 'v' upon returning to the caller}}
+referred to by the caller variable 'v' upon returning to the caller}}
 }
 ClassWithoutDestructor make2(AddressVector<ClassWithoutDestructor> &v) {
   return make1(v);
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
 object of type 'ClassWithoutDestructor' is still \
-referred to by the stack variable 'v' upon returning to the caller}}
+referred to by the caller variable 'v' upon returning to the caller}}
 }
 ClassWithoutDestructor make3(AddressVector<ClassWithoutDestructor> &v) {
   return make2(v);
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
 object of type 'ClassWithoutDestructor' is still \
-referred to by the stack variable 'v' upon returning to the caller}}
+referred to by the caller variable 'v' upon returning to the caller}}
 }
 
 void testMultipleReturns() {
@@ -193,7 +193,7 @@ void testMultipleReturns() {
 void consume(ClassWithoutDestructor c) {
   c.push();
   // expected-warning@-1 {{Address of stack memory associated with local \
-variable 'c' is still referred to by the stack variable 'v' upon returning \
+variable 'c' is still referred to by the caller variable 'v' upon returning \
 to the caller}}
 }
 
@@ -267,7 +267,7 @@ struct TestCtorInitializer {
     : c(ClassWithDestructor(v)) {}
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
 object of type 'ClassWithDestructor' is still referred \
-to by the stack variable 'v' upon returning to the caller}}
+to by the caller variable 'v' upon returning to the caller}}
 };
 
 void testCtorInitializer() {
@@ -303,19 +303,19 @@ ClassWithDestructor make1(AddressVector<ClassWithDestructor> &v) {
   return ClassWithDestructor(v);
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
 object of type 'ClassWithDestructor' is still referred \
-to by the stack variable 'v' upon returning to the caller}}
+to by the caller variable 'v' upon returning to the caller}}
 }
 ClassWithDestructor make2(AddressVector<ClassWithDestructor> &v) {
   return make1(v);
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
 object of type 'ClassWithDestructor' is still referred \
-to by the stack variable 'v' upon returning to the caller}}
+to by the caller variable 'v' upon returning to the caller}}
 }
 ClassWithDestructor make3(AddressVector<ClassWithDestructor> &v) {
   return make2(v);
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
 object of type 'ClassWithDestructor' is still referred \
-to by the stack variable 'v' upon returning to the caller}}
+to by the caller variable 'v' upon returning to the caller}}
 }
 
 void testMultipleReturnsWithDestructors() {
@@ -360,7 +360,7 @@ void testMultipleReturnsWithDestructors() {
 void consume(ClassWithDestructor c) {
   c.push();
   // expected-warning@-1 {{Address of stack memory associated with local \
-variable 'c' is still referred to by the stack variable 'v' upon returning \
+variable 'c' is still referred to by the caller variable 'v' upon returning \
 to the caller}}
 }
 
@@ -407,7 +407,7 @@ struct Foo {
 Foo make1(Foo **r) {
   return Foo(r);
   // no-elide-warning@-1 {{Address of stack memory associated with temporary \
-object of type 'Foo' is still referred to by the stack \
+object of type 'Foo' is still referred to by the caller \
 variable 'z' upon returning to the caller}}
 }
 

--- a/clang/test/Analysis/incorrect-checker-names.cpp
+++ b/clang/test/Analysis/incorrect-checker-names.cpp
@@ -16,5 +16,5 @@ char const *p;
 void f0() {
   char const str[] = "This will change";
   p = str;
-} // expected-warning{{Address of stack memory associated with local variable 'str' is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
-// expected-note@-1{{Address of stack memory associated with local variable 'str' is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference}}
+} // expected-warning@-1{{Address of stack memory associated with local variable 'str' is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
+// expected-note@-2{{Address of stack memory associated with local variable 'str' is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference}}

--- a/clang/test/Analysis/loop-block-counts.c
+++ b/clang/test/Analysis/loop-block-counts.c
@@ -6,7 +6,7 @@ void callee(void **p) {
   int x;
   *p = &x;
   // expected-warning@-1 {{Address of stack memory associated with local \
-variable 'x' is still referred to by the stack variable 'arr' upon \
+variable 'x' is still referred to by the caller variable 'arr' upon \
 returning to the caller}}
 }
 

--- a/clang/test/Analysis/stack-addr-ps.c
+++ b/clang/test/Analysis/stack-addr-ps.c
@@ -98,13 +98,13 @@ void callTestRegister(void) {
 
 void top_level_leaking(int **out) {
   int local = 42;
-  *out = &local; // no-warning FIXME
+  *out = &local; // expected-warning{{Address of stack memory associated with local variable 'local' is still referred to by the caller variable 'out'}}
 }
 
 void callee_leaking_via_param(int **out) {
   int local = 1;
   *out = &local;
-  // expected-warning@-1{{Address of stack memory associated with local variable 'local' is still referred to by the stack variable 'ptr'}}
+  // expected-warning@-1{{Address of stack memory associated with local variable 'local' is still referred to by the caller variable 'ptr'}}
 }
 
 void caller_for_leaking_callee() {
@@ -115,7 +115,7 @@ void caller_for_leaking_callee() {
 void callee_nested_leaking(int **out) {
   int local = 1;
   *out = &local;
-  // expected-warning@-1{{Address of stack memory associated with local variable 'local' is still referred to by the stack variable 'ptr'}}
+  // expected-warning@-1{{Address of stack memory associated with local variable 'local' is still referred to by the caller variable 'ptr'}}
 }
 
 void caller_mid_for_nested_leaking(int **mid) {

--- a/clang/test/Analysis/stack-addr-ps.cpp
+++ b/clang/test/Analysis/stack-addr-ps.cpp
@@ -143,7 +143,7 @@ void write_stack_address_to(char **q) {
   char local;
   *q = &local;
   // expected-warning@-1 {{Address of stack memory associated with local \
-variable 'local' is still referred to by the stack variable 'p' upon \
+variable 'local' is still referred to by the caller variable 'p' upon \
 returning to the caller}}
 }
 
@@ -188,14 +188,14 @@ void* global_ptr;
 
 void global_direct_pointer() {
   int local = 42;
-  global_ptr = &local;
-} // expected-warning{{local variable 'local' is still referred to by the global variable 'global_ptr'}}
+  global_ptr = &local; // expected-warning{{local variable 'local' is still referred to by the global variable 'global_ptr'}}
+}
 
 void static_direct_pointer_top() {
   int local = 42;
   static int* p = &local;
-  (void)p;
-} // expected-warning{{local variable 'local' is still referred to by the static variable 'p'}}
+  (void)p; // expected-warning{{local variable 'local' is still referred to by the static variable 'p'}}
+}
 
 void static_direct_pointer_callee() {
   int local = 42;
@@ -219,7 +219,7 @@ void lambda_to_context_direct_pointer() {
   int *p = nullptr;
   auto lambda = [&] {
     int local = 42;
-    p = &local; // expected-warning{{local variable 'local' is still referred to by the stack variable 'p'}}
+    p = &local; // expected-warning{{local variable 'local' is still referred to by the caller variable 'p'}}
   };
   lambda();
   (void)p;
@@ -245,7 +245,7 @@ void lambda_to_context_direct_pointer_lifetime_extended() {
   int *p = nullptr;
   auto lambda = [&] {
     int&& local = 42;
-    p = &local; // expected-warning{{'int' lifetime extended by local variable 'local' is still referred to by the stack variable 'p'}}
+    p = &local; // expected-warning{{'int' lifetime extended by local variable 'local' is still referred to by the caller variable 'p'}}
   };
   lambda();
   (void)p;
@@ -254,7 +254,7 @@ void lambda_to_context_direct_pointer_lifetime_extended() {
 template<typename Callback>
 void lambda_param_capture_direct_pointer_callee(Callback& callee) {
   int local = 42;
-  callee(local); // expected-warning{{'local' is still referred to by the stack variable 'p'}}
+  callee(local); // expected-warning{{'local' is still referred to by the caller variable 'p'}}
 }
 
 void lambda_param_capture_direct_pointer_caller() {
@@ -279,19 +279,19 @@ void** global_pp;
 void global_ptr_local_to_ptr() {
   int local = 42;
   int* p = &local;
-  global_pp = (void**)&p;
-} // expected-warning{{local variable 'p' is still referred to by the global variable 'global_pp'}}
+  global_pp = (void**)&p; // expected-warning{{local variable 'p' is still referred to by the global variable 'global_pp'}}
+}
 
 void global_ptr_to_ptr() {
   int local = 42;
-  *global_pp = &local; // no-warning FIXME
+  *global_pp = &local; // expected-warning{{local variable 'local' is still referred to by the global variable 'global_pp'}}
 }
 
 void *** global_ppp;
 
 void global_ptr_to_ptr_to_ptr() {
   int local = 42;
-  **global_ppp = &local; // no-warning FIXME
+  **global_ppp = &local; // expected-warning{{local variable 'local' is still referred to by the global variable 'global_ppp'}}
 }
 
 void** get_some_pp();
@@ -304,12 +304,12 @@ void static_ptr_to_ptr() {
 
 void param_ptr_to_ptr_top(void** pp) {
   int local = 42;
-  *pp = &local; // no-warning FIXME
+  *pp = &local; // expected-warning{{local variable 'local' is still referred to by the caller variable 'pp'}}
 }
 
 void param_ptr_to_ptr_callee(void** pp) {
   int local = 42;
-  *pp = &local; // expected-warning{{local variable 'local' is still referred to by the stack variable 'p'}}
+  *pp = &local; // expected-warning{{local variable 'local' is still referred to by the caller variable 'p'}}
 }
 
 void param_ptr_to_ptr_caller() {
@@ -319,12 +319,12 @@ void param_ptr_to_ptr_caller() {
 
 void param_ptr_to_ptr_to_ptr_top(void*** ppp) {
   int local = 42;
-  **ppp = &local; // no-warning FIXME
+  **ppp = &local; // expected-warning {{local variable 'local' is still referred to by the caller variable 'ppp'}}
 }
 
 void param_ptr_to_ptr_to_ptr_callee(void*** ppp) {
   int local = 42;
-  **ppp = &local; // expected-warning{{local variable 'local' is still referred to by the stack variable 'pp'}}
+  **ppp = &local; // expected-warning{{local variable 'local' is still referred to by the caller variable 'pp'}}
 }
 
 void param_ptr_to_ptr_to_ptr_caller(void** pp) {
@@ -334,7 +334,7 @@ void param_ptr_to_ptr_to_ptr_caller(void** pp) {
 void lambda_to_context_ptr_to_ptr(int **pp) {
   auto lambda = [&] {
     int local = 42;
-    *pp = &local; // expected-warning{{local variable 'local' is still referred to by the stack variable 'pp'}}
+    *pp = &local; // expected-warning{{local variable 'local' is still referred to by the caller variable 'pp'}}
   };
   lambda();
   (void)*pp;
@@ -342,7 +342,7 @@ void lambda_to_context_ptr_to_ptr(int **pp) {
 
 void param_ptr_to_ptr_fptr(int **pp) {
   int local = 42;
-  *pp = &local; // expected-warning{{local variable 'local' is still referred to by the stack variable 'p'}}
+  *pp = &local; // expected-warning{{local variable 'local' is still referred to by the caller variable 'p'}}
 }
 
 void param_ptr_to_ptr_fptr_caller(void (*fptr)(int**)) {
@@ -363,7 +363,7 @@ void*& global_rtp = *make_ptr_to_ptr();
 void global_ref_to_ptr() {
   int local = 42;
   int* p = &local;
-  global_rtp = p; // no-warning FIXME
+  global_rtp = p; // expected-warning{{local variable 'local' is still referred to by the global variable 'global_rtp'}}
 }
 
 void static_ref_to_ptr() {
@@ -376,13 +376,13 @@ void static_ref_to_ptr() {
 void param_ref_to_ptr_top(void*& rp) {
   int local = 42;
   int* p = &local;
-  rp = p; // no-warning FIXME
+  rp = p; // expected-warning{{local variable 'local' is still referred to by the caller variable 'rp'}}
 }
 
 void param_ref_to_ptr_callee(void*& rp) {
   int local = 42;
   int* p = &local;
-  rp = p; // expected-warning{{local variable 'local' is still referred to by the stack variable 'p'}}
+  rp = p; // expected-warning{{local variable 'local' is still referred to by the caller variable 'p'}}
 }
 
 void param_ref_to_ptr_caller() {
@@ -418,26 +418,26 @@ void* global_aop[2];
 void global_arr_of_ptr() {
   int local = 42;
   int* p = &local;
-  global_aop[1] = p;
-} // expected-warning{{local variable 'local' is still referred to by the global variable 'global_aop'}}
+  global_aop[1] = p; // expected-warning{{local variable 'local' is still referred to by the global variable 'global_aop'}}
+}
 
 void static_arr_of_ptr() {
   int local = 42;
   static void* arr[2];
   arr[1] = &local;
-  (void)arr[1];
-} // expected-warning{{local variable 'local' is still referred to by the static variable 'arr'}}
+  (void)arr[1]; // expected-warning{{local variable 'local' is still referred to by the static variable 'arr'}}
+}
 
 void param_arr_of_ptr_top(void* arr[2]) {
   int local = 42;
   int* p = &local;
-  arr[1] = p; // no-warning FIXME
+  arr[1] = p; // expected-warning{{local variable 'local' is still referred to by the caller variable 'arr'}}
 }
 
 void param_arr_of_ptr_callee(void* arr[2]) {
   int local = 42;
   int* p = &local;
-  arr[1] = p; // expected-warning{{local variable 'local' is still referred to by the stack variable 'arrStack'}}
+  arr[1] = p; // expected-warning{{local variable 'local' is still referred to by the caller variable 'arrStack'}}
 }
 
 void param_arr_of_ptr_caller() {
@@ -474,26 +474,26 @@ void* global_aop[2];
 void global_arr_of_ptr(int idx) {
   int local = 42;
   int* p = &local;
-  global_aop[idx] = p;
-} // expected-warning{{local variable 'local' is still referred to by the global variable 'global_aop'}}
+  global_aop[idx] = p; // expected-warning{{local variable 'local' is still referred to by the global variable 'global_aop'}}
+}
 
 void static_arr_of_ptr(int idx) {
   int local = 42;
   static void* arr[2];
   arr[idx] = &local;
-  (void)arr[idx];
-} // expected-warning{{local variable 'local' is still referred to by the static variable 'arr'}}
+  (void)arr[idx]; // expected-warning{{local variable 'local' is still referred to by the static variable 'arr'}}
+}
 
 void param_arr_of_ptr_top(void* arr[2], int idx) {
   int local = 42;
   int* p = &local;
-  arr[idx] = p; // no-warning FIXME
+  arr[idx] = p; // expected-warning{{local variable 'local' is still referred to by the caller variable 'arr'}}
 }
 
 void param_arr_of_ptr_callee(void* arr[2], int idx) {
   int local = 42;
   int* p = &local;
-  arr[idx] = p; // expected-warning{{local variable 'local' is still referred to by the stack variable 'arrStack'}}
+  arr[idx] = p; // expected-warning{{local variable 'local' is still referred to by the caller variable 'arrStack'}}
 }
 
 void param_arr_of_ptr_caller(int idx) {
@@ -519,7 +519,7 @@ S returned_struct_with_ptr_callee() {
   int local = 42;
   S s;
   s.p = &local;
-  return s; // expected-warning{{'local' is still referred to by the stack variable 's'}}
+  return s; // expected-warning{{'local' is still referred to by the caller variable 's'}}
 }
 
 void returned_struct_with_ptr_caller() {
@@ -531,15 +531,15 @@ S global_s;
 
 void global_struct_with_ptr() {
   int local = 42;
-  global_s.p = &local;
-} // expected-warning{{'local' is still referred to by the global variable 'global_s'}}
+  global_s.p = &local; // expected-warning{{'local' is still referred to by the global variable 'global_s'}}
+}
 
 void static_struct_with_ptr() {
   int local = 42;
   static S s;
   s.p = &local;
-  (void)s.p;
-} // expected-warning{{'local' is still referred to by the static variable 's'}}
+  (void)s.p; // expected-warning{{'local' is still referred to by the static variable 's'}}
+}
 } // namespace leaking_via_struct_with_ptr
 
 namespace leaking_via_ref_to_struct_with_ptr {
@@ -551,7 +551,7 @@ S &global_s = *(new S);
 
 void global_ref_to_struct_with_ptr() {
   int local = 42;
-  global_s.p = &local; // no-warning FIXME
+  global_s.p = &local; // expected-warning{{'local' is still referred to by the global variable 'global_s'}}
 }
 
 void static_ref_to_struct_with_ptr() {
@@ -563,12 +563,12 @@ void static_ref_to_struct_with_ptr() {
 
 void param_ref_to_struct_with_ptr_top(S &s) {
   int local = 42;
-  s.p = &local; // no-warning FIXME
+  s.p = &local; // expected-warning{{'local' is still referred to by the caller variable 's'}}
 }
 
 void param_ref_to_struct_with_ptr_callee(S &s) {
   int local = 42;
-  s.p = &local; // expected-warning{{'local' is still referred to by the stack variable 'sStack'}}
+  s.p = &local; // expected-warning{{'local' is still referred to by the caller variable 'sStack'}}
 }
 
 void param_ref_to_struct_with_ptr_caller() {
@@ -579,7 +579,7 @@ void param_ref_to_struct_with_ptr_caller() {
 template<typename Callable>
 void lambda_param_capture_callee(Callable& callee) {
   int local = 42;
-  callee(local); // expected-warning{{'local' is still referred to by the stack variable 'p'}}
+  callee(local); // expected-warning{{'local' is still referred to by the caller variable 'p'}}
 }
 
 void lambda_param_capture_caller() {
@@ -619,7 +619,7 @@ S* global_s;
 
 void global_ptr_to_struct_with_ptr() {
   int local = 42;
-  global_s->p = &local; // no-warning FIXME
+  global_s->p = &local; // expected-warning{{'local' is still referred to by the global variable 'global_s'}}
 }
 
 void static_ptr_to_struct_with_ptr_new() {
@@ -639,12 +639,12 @@ void static_ptr_to_struct_with_ptr_generated() {
 
 void param_ptr_to_struct_with_ptr_top(S* s) {
   int local = 42;
-  s->p = &local; // no-warning FIXME
+  s->p = &local; // expected-warning{{'local' is still referred to by the caller variable 's'}}
 }
 
 void param_ptr_to_struct_with_ptr_callee(S* s) {
   int local = 42;
-  s->p = &local; // expected-warning{{'local' is still referred to by the stack variable 's'}}
+  s->p = &local; // expected-warning{{'local' is still referred to by the caller variable 's'}}
 }
 
 void param_ptr_to_struct_with_ptr_caller() {
@@ -682,8 +682,8 @@ S global_s[2];
 
 void global_ptr_to_struct_with_ptr() {
   int local = 42;
-  global_s[1].p = &local;
-} // expected-warning{{'local' is still referred to by the global variable 'global_s'}}
+  global_s[1].p = &local; // expected-warning{{'local' is still referred to by the global variable 'global_s'}}
+}
 
 void static_ptr_to_struct_with_ptr_new() {
   int local = 42;
@@ -702,12 +702,12 @@ void static_ptr_to_struct_with_ptr_generated() {
 
 void param_ptr_to_struct_with_ptr_top(S s[2]) {
   int local = 42;
-  s[1].p = &local; // no-warning FIXME
+  s[1].p = &local; // expected-warning{{'local' is still referred to by the caller variable 's'}}
 }
 
 void param_ptr_to_struct_with_ptr_callee(S s[2]) {
   int local = 42;
-  s[1].p = &local; // expected-warning{{'local' is still referred to by the stack variable 's'}}
+  s[1].p = &local; // expected-warning{{'local' is still referred to by the caller variable 's'}}
 }
 
 void param_ptr_to_struct_with_ptr_caller() {
@@ -727,17 +727,17 @@ NestedAndTransitive global_nat;
 
 void global_nested_and_transitive() {
   int local = 42;
-  *global_nat.next[2]->next[1]->p = &local; // no-warning FIXME
+  *global_nat.next[2]->next[1]->p = &local; // expected-warning{{'local' is still referred to by the global variable 'global_nat'}}
 }
 
 void param_nested_and_transitive_top(NestedAndTransitive* nat) {
   int local = 42;
-  *nat->next[2]->next[1]->p = &local; // no-warning FIXME
+  *nat->next[2]->next[1]->p = &local; // expected-warning{{'local' is still referred to by the caller variable 'nat'}}
 }
 
 void param_nested_and_transitive_callee(NestedAndTransitive* nat) {
   int local = 42;
-  *nat->next[2]->next[1]->p = &local;  // expected-warning{{local variable 'local' is still referred to by the stack variable 'natCaller'}}
+  *nat->next[2]->next[1]->p = &local; // expected-warning{{'local' is still referred to by the caller variable 'natCaller'}}
 }
 
 void param_nested_and_transitive_caller(NestedAndTransitive natCaller) {
@@ -769,7 +769,7 @@ void leaker(int ***leakerArg) {
     // is no longer relevant.
     // The message must refer to 'original_arg' instead, but there is no easy way to
     // connect the SymRegion stored in 'original_arg' and 'original_arg' as variable.
-    **leakerArg = &local; // expected-warning{{ 'local' is still referred to by the stack variable 'arg'}}
+    **leakerArg = &local; // expected-warning{{ 'local' is still referred to by the caller variable 'arg'}}
 }
 
 int **tweak();
@@ -780,3 +780,14 @@ void foo(int **arg) {
     leaker(&original_arg);
 }
 } // namespace origin_region_limitation
+
+namespace leaking_via_indirect_global_invalidated {
+void** global_pp;
+void opaque();
+void global_ptr_to_ptr() {
+  int local = 42;
+  *global_pp = &local;
+  opaque();
+  *global_pp = nullptr;
+}
+} // namespace leaking_via_indirect_global_invalidated

--- a/clang/test/Analysis/stack-capture-leak-no-arc.mm
+++ b/clang/test/Analysis/stack-capture-leak-no-arc.mm
@@ -40,7 +40,7 @@ dispatch_block_t test_block_inside_block_async_leak() {
 // called.
 void output_block(dispatch_block_t * blk) {
   int x = 0;
-  *blk = ^{ f(x); }; // expected-warning {{Address of stack-allocated block declared on line 43 is still referred to by the stack variable 'blk' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
+  *blk = ^{ f(x); }; // expected-warning {{Address of stack-allocated block declared on line 43 is still referred to by the caller variable 'blk' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
 }
 
 // The block literal captures nothing thus is treated as a constant.
@@ -54,7 +54,7 @@ void test_block_leak() {
   __block dispatch_block_t blk;
   int x = 0;
   dispatch_block_t p = ^{
-    blk = ^{ // expected-warning {{Address of stack-allocated block declared on line 57 is still referred to by the stack variable 'blk' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
+    blk = ^{ // expected-warning {{Address of stack-allocated block declared on line 57 is still referred to by the caller variable 'blk' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]}}
       f(x);
     };
   };

--- a/clang/test/Analysis/stackaddrleak.c
+++ b/clang/test/Analysis/stackaddrleak.c
@@ -7,7 +7,7 @@ char const *p;
 void f0(void) {
   char const str[] = "This will change";
   p = str;
-}  // expected-warning{{Address of stack memory associated with local variable 'str' is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference}}
+} // expected-warning@-1{{Address of stack memory associated with local variable 'str' is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference}}
 
 void f1(void) {
   char const str[] = "This will change";
@@ -17,7 +17,7 @@ void f1(void) {
 
 void f2(void) {
   p = (const char *) __builtin_alloca(12);
-} // expected-warning{{Address of stack memory allocated by call to alloca() on line 19 is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference}}
+} // expected-warning@-1{{Address of stack memory allocated by call to alloca() on line 19 is still referred to by the global variable 'p' upon returning to the caller.  This will be a dangling reference}}
 
 // PR 7383 - previously the stack address checker would crash on this example
 //  because it would attempt to do a direct load from 'pr7383_list'. 
@@ -33,7 +33,7 @@ void test_multi_return(void) {
   int x;
   a = &x;
   b = &x;
-} // expected-warning{{Address of stack memory associated with local variable 'x' is still referred to by the static variable 'a' upon returning}} expected-warning{{Address of stack memory associated with local variable 'x' is still referred to by the static variable 'b' upon returning}}
+} // expected-warning@-1{{Address of stack memory associated with local variable 'x' is still referred to by the static variable 'a' upon returning}} expected-warning@-1{{Address of stack memory associated with local variable 'x' is still referred to by the static variable 'b' upon returning}}
 
 intptr_t returnAsNonLoc(void) {
   int x;
@@ -49,7 +49,7 @@ void assignAsNonLoc(void) {
   extern intptr_t ip;
   int x;
   ip = (intptr_t)&x;
-} // expected-warning{{Address of stack memory associated with local variable 'x' is still referred to by the global variable 'ip' upon returning}}
+} // expected-warning@-1{{Address of stack memory associated with local variable 'x' is still referred to by the global variable 'ip' upon returning}}
 
 void assignAsBool(void) {
   extern bool b;


### PR DESCRIPTION
Fix some false negatives of StackAddrEscapeChecker:
- Output parameters
  ```
  void top(int **out) {
    int local = 42;
    *out = &local; // Noncompliant
  }
  ```
- Indirect global pointers
  ```
  int **global;

  void top() {
    int local = 42;
    *global = &local; // Noncompliant
  }
  ```

Note that now StackAddrEscapeChecker produces a diagnostic if a function
with an output parameter is analyzed as top-level or as a callee. I took
special care to make sure the reports point to the same primary location
and, in many cases, feature the same primary message. That is the
motivation to modify Core/BugReporter.cpp and Core/ExplodedGraph.cpp

To avoid false positive reports when a global indirect pointer is
assigned a local address, invalidated, and then reset, I rely on the
fact that the invalidation symbol will be a DerivedSymbol of a
ConjuredSymbol that refers to the same memory region.

The checker still has a false negative for non-trivial escaping via a
returned value. It requires a more sophisticated traversal akin to
scanReachableSymbols, which out of the scope of this change.

CPP-4734

---------

This is the last of the 3 stacked PRs, it must not be merged before https://github.com/llvm/llvm-project/pull/105652 and https://github.com/llvm/llvm-project/pull/105653