### PR TITLE
 Add release note about ABI implementation changes for _BitInt on Arm

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1221,6 +1221,9 @@ Arm and AArch64 Support
    ``-mabi=pauthtest`` option or via specifying ``pauthtest`` environment part of
    target triple.
 
+ - The C23 ``_BitInt`` implementation has been brought into compliance
+   with AAPCS32 and AAPCS64.
+
 Android Support
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Add release note that LLVM 19 _BitInt  implementation is fully compliant with AAPCS32 and AAPCS64 when targeting Arm.
