### PR TITLE
[PowerPC] Generate one branch instruction if one block is required

### DIFF
--- a/llvm/test/CodeGen/PowerPC/crbit-asm.ll
+++ b/llvm/test/CodeGen/PowerPC/crbit-asm.ll
@@ -31,9 +31,8 @@ define zeroext i1 @testi1(i1 zeroext %b1, i1 zeroext %b2) #0 {
 ; CHECK-NO-ISEL-NEXT:    #APP
 ; CHECK-NO-ISEL-NEXT:    crand 20, 20, 1
 ; CHECK-NO-ISEL-NEXT:    #NO_APP
-; CHECK-NO-ISEL-NEXT:    bc 12, 20, .LBB0_1
-; CHECK-NO-ISEL-NEXT:    blr
-; CHECK-NO-ISEL-NEXT:  .LBB0_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bclr 4, 20, 0
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT:    blr
 entry:
@@ -68,9 +67,8 @@ define signext i32 @testi32(i32 signext %b1, i32 signext %b2) #0 {
 ; CHECK-NO-ISEL-NEXT:    #APP
 ; CHECK-NO-ISEL-NEXT:    crand 20, 20, 1
 ; CHECK-NO-ISEL-NEXT:    #NO_APP
-; CHECK-NO-ISEL-NEXT:    bc 12, 20, .LBB1_1
-; CHECK-NO-ISEL-NEXT:    blr
-; CHECK-NO-ISEL-NEXT:  .LBB1_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bclr 4, 20, 0
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT:    blr
 entry:
@@ -106,9 +104,8 @@ define zeroext i8 @testi8(i8 zeroext %b1, i8 zeroext %b2) #0 {
 ; CHECK-NO-ISEL-NEXT:    #APP
 ; CHECK-NO-ISEL-NEXT:    crand 20, 20, 1
 ; CHECK-NO-ISEL-NEXT:    #NO_APP
-; CHECK-NO-ISEL-NEXT:    bc 12, 20, .LBB2_1
-; CHECK-NO-ISEL-NEXT:    blr
-; CHECK-NO-ISEL-NEXT:  .LBB2_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bclr 4, 20, 0
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/crbits.ll
+++ b/llvm/test/CodeGen/PowerPC/crbits.ll
@@ -36,9 +36,8 @@ define zeroext i1 @test1(float %v1, float %v2) #0 {
 ; CHECK-NO-ISEL-NEXT:    fcmpu 0, 2, 0
 ; CHECK-NO-ISEL-NEXT:    crnor 21, 7, 1
 ; CHECK-NO-ISEL-NEXT:    crnand 20, 20, 21
-; CHECK-NO-ISEL-NEXT:    bc 12, 20, .LBB0_1
-; CHECK-NO-ISEL-NEXT:    blr
-; CHECK-NO-ISEL-NEXT:  .LBB0_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bclr 4, 20, 0
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    li 3, 0
 ; CHECK-NO-ISEL-NEXT:    blr
 ;
@@ -87,9 +86,8 @@ define zeroext i1 @test2(float %v1, float %v2) #0 {
 ; CHECK-NO-ISEL-NEXT:    fcmpu 0, 2, 0
 ; CHECK-NO-ISEL-NEXT:    crnor 21, 7, 1
 ; CHECK-NO-ISEL-NEXT:    creqv 20, 20, 21
-; CHECK-NO-ISEL-NEXT:    bc 12, 20, .LBB1_1
-; CHECK-NO-ISEL-NEXT:    blr
-; CHECK-NO-ISEL-NEXT:  .LBB1_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bclr 4, 20, 0
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    li 3, 0
 ; CHECK-NO-ISEL-NEXT:    blr
 ;
@@ -142,9 +140,8 @@ define zeroext i1 @test3(float %v1, float %v2, i32 signext %x) #0 {
 ; CHECK-NO-ISEL-NEXT:    cmpwi 5, -2
 ; CHECK-NO-ISEL-NEXT:    crandc 21, 21, 2
 ; CHECK-NO-ISEL-NEXT:    creqv 20, 20, 21
-; CHECK-NO-ISEL-NEXT:    bc 12, 20, .LBB2_1
-; CHECK-NO-ISEL-NEXT:    blr
-; CHECK-NO-ISEL-NEXT:  .LBB2_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bclr 4, 20, 0
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    li 3, 0
 ; CHECK-NO-ISEL-NEXT:    blr
 ;
@@ -332,9 +329,8 @@ define signext i32 @exttest7(i32 signext %a) #0 {
 ; CHECK-NO-ISEL-NEXT:    cmplwi 3, 5
 ; CHECK-NO-ISEL-NEXT:    li 3, 8
 ; CHECK-NO-ISEL-NEXT:    li 4, 7
-; CHECK-NO-ISEL-NEXT:    bc 12, 2, .LBB7_1
-; CHECK-NO-ISEL-NEXT:    blr
-; CHECK-NO-ISEL-NEXT:  .LBB7_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bclr 4, 2, 0
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT:    blr
 ;
@@ -369,9 +365,8 @@ define zeroext i32 @exttest8() #0 {
 ; CHECK-NO-ISEL-NEXT:    subfic 3, 3, 80
 ; CHECK-NO-ISEL-NEXT:    rldicl 3, 3, 63, 1
 ; CHECK-NO-ISEL-NEXT:    cmplwi 3, 80
-; CHECK-NO-ISEL-NEXT:    bc 12, 1, .LBB8_1
-; CHECK-NO-ISEL-NEXT:    b .LBB8_2
-; CHECK-NO-ISEL-NEXT:  .LBB8_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bc 4, 1, .LBB8_2
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    li 3, 0
 ; CHECK-NO-ISEL-NEXT:  .LBB8_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    clrldi 3, 3, 32

--- a/llvm/test/CodeGen/PowerPC/expand-contiguous-isel.ll
+++ b/llvm/test/CodeGen/PowerPC/expand-contiguous-isel.ll
@@ -134,9 +134,9 @@ _ZNK4llvm9StringRef6substrEmm.exit:
 ; Unecessary ISEL (all the registers are the same) is always removed
 ; CHECK-GEN-ISEL-TRUE-NOT: iseleq [[SAME:r[0-9]+]], [[SAME]], [[SAME]]
 ; CHECK-GEN-ISEL-TRUE: iseleq [[SAME:r[0-9]+]], {{r[0-9]+}}, [[SAME]]
-; CHECK: bc 12, eq, [[TRUE:.LBB[0-9]+]]
-; CHECK-NEXT: b [[SUCCESSOR:.LBB[0-9]+]]
-; CHECK-NEXT: [[TRUE]]
+; CHECK: bc 12, lt, [[TRUE:.LBB[0-9]+]]
+; CHECK: b [[SUCCESSOR:.LBB[0-9]+]]
+; CHECK: [[TRUE]]
 ; CHECK-NEXT: # in Loop: Header
 ; CHECK-NEXT: addi {{r[0-9]+}}, {{r[0-9]+}}, 0
 ; CHECK-NEXT: [[SUCCESSOR]]

--- a/llvm/test/CodeGen/PowerPC/expand-isel-1.mir
+++ b/llvm/test/CodeGen/PowerPC/expand-isel-1.mir
@@ -46,10 +46,9 @@ body:             |
     $cr0 = CMPWI $r3, 0
     $r0 = ISEL $zero, $r0, $cr0gt
     ; CHECK-LABEL: testExpandISEL
-    ; CHECK: BC $cr0gt, %[[TRUE:bb.[0-9]+]]
-    ; CHECK-NEXT: B %[[SUCCESSOR:bb.[0-9]+]]
-    ; CHECK: [[TRUE]]
+    ; CHECK: BCn $cr0gt, %[[SUCCESSOR:bb.[0-9]+]]
     ; CHECK: $r0 = ADDI $zero, 0
+    ; CHECK: [[SUCCESSOR]]
 
     $x3 = EXTSW_32_64 $r0
 

--- a/llvm/test/CodeGen/PowerPC/expand-isel-5.mir
+++ b/llvm/test/CodeGen/PowerPC/expand-isel-5.mir
@@ -45,10 +45,9 @@ body:             |
     $r5 = ADDI $r3, 1
     $cr0 = CMPWI $r3, 0
     $r0 = ISEL $r5, $r0, $cr0gt
-    ; CHECK: BC $cr0gt, %[[TRUE:bb.[0-9]+]]
-    ; CHECK: B %[[SUCCESSOR:bb.[0-9]+]]
-    ; CHECK: [[TRUE]]
+    ; CHECK: BCn $cr0gt, %[[SUCCESSOR:bb.[0-9]+]]
     ; CHECK: $r0 = ADDI $r5, 0
+    ; CHECK: [[SUCCESSOR]]
     $x3 = EXTSW_32_64 $r0
 
 ...

--- a/llvm/test/CodeGen/PowerPC/expand-isel.ll
+++ b/llvm/test/CodeGen/PowerPC/expand-isel.ll
@@ -31,9 +31,8 @@ entry:
 
 ; CHECK-LABEL: @testExpandISELToIf
 ; CHECK: cmpwi	 r3, 0
-; CHECK-NEXT: bc 12, gt, [[TRUE:.LBB[0-9]+]]
-; CHECK-NEXT: blr
-; CHECK-NEXT:  [[TRUE]]
+; CHECK-NEXT: bclr 4, gt, 0
+; CHECK-NEXT: # %bb.1: # %entry
 ; CHECK-NEXT: addi r3, r4, 0
 ; CHECK-NEXT: blr
 }
@@ -155,9 +154,8 @@ entry:
 
 ; CHECK-LABEL: @testExpandISELsTo0ORI2ADDIs
 ; CHECK: cmpwi r7, 0
-; CHECK-NEXT: bc 12, gt, [[TRUE:.LBB[0-9]+]]
-; CHECK-NEXT: b [[SUCCESSOR:.LBB[0-9]+]]
-; CHECK-NEXT:  [[TRUE]]
+; CHECK-NEXT: bc 4, gt, [[SUCCESSOR:.LBB[0-9]+]]
+; CHECK-NEXT: # %bb.1: # %entry
 ; CHECK-NEXT: addi r4, r3, 0
 ; CHECK-NEXT: addi r6, r5, 0
 ; CHECK-NEXT:  [[SUCCESSOR]]

--- a/llvm/test/CodeGen/PowerPC/fold-zero.ll
+++ b/llvm/test/CodeGen/PowerPC/fold-zero.ll
@@ -14,9 +14,8 @@ define i32 @test1(i1 %a, i32 %c) nounwind  {
 ; CHECK: blr
 ; CHECK-NO-ISEL-LABEL: @test1
 ; CHECK-NO-ISEL: li 3, 0
-; CHECK-NO-ISEL-NEXT: bc 12, 1, [[TRUE:.LBB[0-9]+]]
-; CHECK-NO-ISEL-NEXT: blr
-; CHECK-NO-ISEL-NEXT: [[TRUE]]
+; CHECK-NO-ISEL-NEXT: bclr 4, 1, 0
+; CHECK-NO-ISEL-NEXT: # %bb.1:
 ; CHECK-NO-ISEL-NEXT: addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT: blr
 }

--- a/llvm/test/CodeGen/PowerPC/i1-ext-fold.ll
+++ b/llvm/test/CodeGen/PowerPC/i1-ext-fold.ll
@@ -19,8 +19,8 @@ entry:
 ; CHECK: isellt 3, [[REG2]], [[REG1]]
 ; CHECK: blr
 
-; CHECK-NO-ISEL: bc 12, 0,
-; CHECK-NO-ISEL: blr
+; CHECK-NO-ISEL: bclr 4, 0, 0
+; CHECK-NO-ISEL: # %bb.1: # %entry
 ; CHECK-NO-ISEL: addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT: blr
 }
@@ -42,9 +42,9 @@ entry:
 ; CHECK: isellt 3, [[REG2]], [[REG1]]
 ; CHECK: blr
 
-; CHECK-NO-ISEL: bc 12, 0,
-; CHECK-NO-ISEL: blr
-; CHECK-NO-ISEL: addi 3, 4, 0
+; CHECK-NO-ISEL: bclr 4, 0, 0
+; CHECK-NO-ISEL-NEXT: # %bb.1: # %entry
+; CHECK-NO-ISEL-NEXT: addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT: blr
 }
 
@@ -63,9 +63,8 @@ entry:
 ; CHECK: iselgt 3, 0, [[REG1]]
 ; CHECK: blr
 
-; CHECK-NO-ISEL: bc 12, 1, [[TRUE:.LBB[0-9]+]]
-; CHECK-NO-ISEL-NEXT: blr
-; CHECK-NO-ISEL-NEXT: [[TRUE]]
+; CHECK-NO-ISEL: bclr 4, 1, 0 
+; CHECK-NO-ISEL-NEXT: # %bb.1: # %entry 
 ; CHECK-NO-ISEL-NEXT: li 3, 0
 ; CHECK-NO-ISEL-NEXT: blr
 }

--- a/llvm/test/CodeGen/PowerPC/i64_fp_round.ll
+++ b/llvm/test/CodeGen/PowerPC/i64_fp_round.ll
@@ -20,9 +20,8 @@ entry:
 ; CHECK: cmpldi [[REG2]], 1
 ; CHECK: iselgt [[REG3:[0-9]+]], {{[0-9]+}}, 3
 ; CHECK-NO-ISEL: rldicr [[REG2:[0-9]+]], {{[0-9]+}}, 0, 52
-; CHECK-NO-ISEL: bc 12, 1, [[TRUE:.LBB[0-9]+]]
-; CHECK-NO-ISEL: b [[SUCCESSOR:.LBB[0-9]+]]
-; CHECK-NO-ISEL-NEXT: [[TRUE]]
+; CHECK-NO-ISEL: bc 4, 1, [[SUCCESSOR:.LBB[0-9]+]]
+; CHECK-NO-ISEL: # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT: addi {{[0-9]+}}, [[REG2]], 0
 ; CHECK-NO-ISEL-NEXT: [[SUCCESSOR]]
 ; CHECK-NO-ISEL: std {{[0-9]+}}, -{{[0-9]+}}(1)

--- a/llvm/test/CodeGen/PowerPC/ifcvt.ll
+++ b/llvm/test/CodeGen/PowerPC/ifcvt.ll
@@ -26,7 +26,6 @@ cond.false:                                       ; preds = %sw.epilog
 ; CHECK: iselgt {{[0-9]+}}, [[REG]], [[REG2]]
 ; CHECK-NO-ISEL: bc 12, 1, [[TRUE:.LBB[0-9]+]]
 ; CHECK-NO-ISEL: ori 5, 6, 0
-; CHECK-NO-ISEL-NEXT: b [[SUCCESSOR:.LBB[0-9]+]]
 ; CHECK-NO-ISEL: [[TRUE]]
 ; CHECK-NO-ISEL: extsh 5, 5
 ; CHECK-NO-ISEL-NEXT: add 3, 3, 5

--- a/llvm/test/CodeGen/PowerPC/optcmp.ll
+++ b/llvm/test/CodeGen/PowerPC/optcmp.ll
@@ -21,7 +21,6 @@ define signext i32 @foo(i32 signext %a, i32 signext %b, ptr nocapture %c) #0 {
 ; CHECK-NO-ISEL-NEXT:    bc 12, 1, .LBB0_2
 ; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    ori 3, 4, 0
-; CHECK-NO-ISEL-NEXT:    b .LBB0_2
 ; CHECK-NO-ISEL-NEXT:  .LBB0_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    stw 6, 0(5)
 ; CHECK-NO-ISEL-NEXT:    blr
@@ -77,7 +76,6 @@ define i64 @fool(i64 %a, i64 %b, ptr nocapture %c) #0 {
 ; CHECK-NO-ISEL-NEXT:    bc 12, 1, .LBB2_2
 ; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    ori 3, 4, 0
-; CHECK-NO-ISEL-NEXT:    b .LBB2_2
 ; CHECK-NO-ISEL-NEXT:  .LBB2_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    std 6, 0(5)
 ; CHECK-NO-ISEL-NEXT:    blr
@@ -100,9 +98,8 @@ define i64 @foolb(i64 %a, i64 %b, ptr nocapture %c) #0 {
 ; CHECK-NO-ISEL-LABEL: foolb:
 ; CHECK-NO-ISEL:       # %bb.0: # %entry
 ; CHECK-NO-ISEL-NEXT:    sub. 6, 3, 4
-; CHECK-NO-ISEL-NEXT:    bc 12, 1, .LBB3_1
-; CHECK-NO-ISEL-NEXT:    b .LBB3_2
-; CHECK-NO-ISEL-NEXT:  .LBB3_1: # %entry
+; CHECK-NO-ISEL-NEXT:    bc 4, 1, .LBB3_2
+; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    addi 3, 4, 0
 ; CHECK-NO-ISEL-NEXT:  .LBB3_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    std 6, 0(5)
@@ -129,7 +126,6 @@ define i64 @foolc(i64 %a, i64 %b, ptr nocapture %c) #0 {
 ; CHECK-NO-ISEL-NEXT:    bc 12, 0, .LBB4_2
 ; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    ori 3, 4, 0
-; CHECK-NO-ISEL-NEXT:    b .LBB4_2
 ; CHECK-NO-ISEL-NEXT:  .LBB4_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    std 6, 0(5)
 ; CHECK-NO-ISEL-NEXT:    blr
@@ -155,7 +151,6 @@ define i64 @foold(i64 %a, i64 %b, ptr nocapture %c) #0 {
 ; CHECK-NO-ISEL-NEXT:    bc 12, 1, .LBB5_2
 ; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    ori 3, 4, 0
-; CHECK-NO-ISEL-NEXT:    b .LBB5_2
 ; CHECK-NO-ISEL-NEXT:  .LBB5_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    std 6, 0(5)
 ; CHECK-NO-ISEL-NEXT:    blr
@@ -181,7 +176,6 @@ define i64 @foold2(i64 %a, i64 %b, ptr nocapture %c) #0 {
 ; CHECK-NO-ISEL-NEXT:    bc 12, 0, .LBB6_2
 ; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    ori 3, 4, 0
-; CHECK-NO-ISEL-NEXT:    b .LBB6_2
 ; CHECK-NO-ISEL-NEXT:  .LBB6_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    std 6, 0(5)
 ; CHECK-NO-ISEL-NEXT:    blr
@@ -339,7 +333,6 @@ define signext i64 @fooct(i64 signext %a, i64 signext %b, ptr nocapture %c) #0 {
 ; CHECK-NO-ISEL-NEXT:    bc 12, 1, .LBB10_2
 ; CHECK-NO-ISEL-NEXT:  # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT:    ori 3, 4, 0
-; CHECK-NO-ISEL-NEXT:    b .LBB10_2
 ; CHECK-NO-ISEL-NEXT:  .LBB10_2: # %entry
 ; CHECK-NO-ISEL-NEXT:    std 6, 0(5)
 ; CHECK-NO-ISEL-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/p8-isel-sched.ll
+++ b/llvm/test/CodeGen/PowerPC/p8-isel-sched.ll
@@ -28,7 +28,6 @@ entry:
 ; CHECK-NO-ISEL-LABEL: @foo
 ; CHECK: isel
 ; CHECK-NO-ISEL: bc 12, 2, [[TRUE:.LBB[0-9]+]]
-; CHECK-NO-ISEL: b [[SUCCESSOR:.LBB[0-9]+]]
 ; CHECK-NO-ISEL: [[TRUE]]
 ; CHECK-NO-ISEL: addi {{[0-9]+}}, {{[0-9]+}}, -2
 ; CHECK: addi

--- a/llvm/test/CodeGen/PowerPC/ppc-crbits-onoff.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc-crbits-onoff.ll
@@ -18,10 +18,10 @@ entry:
 ; CHECK-DAG: li [[REG2:[0-9]+]], 1
 ; CHECK-DAG: cntlzw [[REG3:[0-9]+]],
 ; CHECK: iseleq [[REG4:[0-9]+]], 0, [[REG2]]
-; CHECK-NO-ISEL: bc 12, 2, [[TRUE:.LBB[0-9]+]]
-; CHECK-NO-ISEL-NEXT: b [[SUCCESSOR:.LBB[0-9]+]]
-; CHECK-NO-ISEL: [[TRUE]]
+; CHECK-NO-ISEL: bc 4, 2, [[SUCCESSOR:.LBB[0-9]+]]
+; CHECK-NO-ISEL-NEXT: # %bb.1: # %entry
 ; CHECK-NO-ISEL-NEXT: li 3, 0
+; CHECK-NO-ISEL-NEXT: [[SUCCESSOR]]
 ; CHECK: and 3, [[REG4]], [[REG3]]
 ; CHECK: blr
 }

--- a/llvm/test/CodeGen/PowerPC/subreg-postra.ll
+++ b/llvm/test/CodeGen/PowerPC/subreg-postra.ll
@@ -152,7 +152,7 @@ wait_on_buffer.exit1319:                          ; preds = %while.body392
 ; CHECK: iselgt {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
 ; CHECK-NO-ISEL: bc 12, 1, [[TRUE:.LBB[0-9]+]]
 ; CHECK-NO-ISEL: ori 5, 3, 0
-; CHECK-NO-ISEL: b [[SUCCESSOR:.LBB[0-9]+]]
+; CHECK-NO-ISEL-NEXT: [[TRUE]]
 
 
 while.end418:                                     ; preds = %wait_on_buffer.exit1319, %do.body378


### PR DESCRIPTION
PPCExpandIsel pass generates two branch instructions if true and/or false block are required. Enable generating one branch instruction if either true or false block is required, but not both.