### PR TITLE
[SLP]Do not count extractelement costs in unreachable/landing pad blocks.

### DIFF
--- a/llvm/test/Transforms/SLPVectorizer/X86/same-scalar-in-same-phi-extract.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/same-scalar-in-same-phi-extract.ll
@@ -5,7 +5,6 @@ define void @test(i32 %arg) {
 ; CHECK-LABEL: define void @test(
 ; CHECK-SAME: i32 [[ARG:%.*]]) {
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[ARG]] to i64
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i32> <i32 poison, i32 0>, i32 [[ARG]], i32 0
 ; CHECK-NEXT:    br label [[BB2:%.*]]
 ; CHECK:       bb2:
@@ -15,6 +14,8 @@ define void @test(i32 %arg) {
 ; CHECK-NEXT:      i32 1, label [[BB4:%.*]]
 ; CHECK-NEXT:    ]
 ; CHECK:       bb3:
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x i32> [[TMP0]], i32 0
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[TMP1]] to i64
 ; CHECK-NEXT:    switch i32 0, label [[BB10]] [
 ; CHECK-NEXT:      i32 18, label [[BB7:%.*]]
 ; CHECK-NEXT:      i32 1, label [[BB7]]


### PR DESCRIPTION
If the external user of the scalar to be extract is in
unreachable/landing pad block, we can skip counting their cost.
