### PR TITLE
[ARM] Fix missing ELF FPU attributes for fp-armv8-fullfp16-d16 

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -992,6 +992,10 @@ void ARMTargetELFStreamer::emitFPUDefaultAttributes() {
   // uses the FP_ARMV8_D16 build attribute.
   case ARM::FK_FPV5_SP_D16:
   case ARM::FK_FPV5_D16:
+  // FPv5 and FP-ARMv8 have the same instructions, so are modeled as one
+  // FPU, but there are two different names for it depending on the CPU.
+  case ARM::FK_FP_ARMV8_FULLFP16_SP_D16:
+  case ARM::FK_FP_ARMV8_FULLFP16_D16:
     S.setAttributeItem(ARMBuildAttrs::FP_arch, ARMBuildAttrs::AllowFPARMv8B,
                        /* OverwriteExisting= */ false);
     break;

--- a/llvm/test/MC/ARM/directive-fpu-multiple.s
+++ b/llvm/test/MC/ARM/directive-fpu-multiple.s
@@ -22,6 +22,8 @@
 	.fpu fpv5-d16
 	.fpu fpv5-sp-d16
 	.fpu fp-armv8
+	.fpu fp-armv8-fullfp16-d16
+	.fpu fp-armv8-fullfp16-sp-d16
 	.fpu neon
 	.fpu neon-fp16
 	.fpu neon-vfpv4

--- a/llvm/test/MC/ARM/directive-fpu-single-crypto-neon-fp-armv8.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-crypto-neon-fp-armv8.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu crypto-neon-fp-armv8
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: ARMv8-a FP
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-crypto-neon-fp-armv8.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-crypto-neon-fp-armv8.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: ARMv8-a FP
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-d16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: ARMv8-a FP-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-d16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu fp-armv8-fullfp16-d16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: ARMv8-a FP-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-sp-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-sp-d16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: ARMv8-a FP-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-sp-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fp-armv8-fullfp16-sp-d16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu fp-armv8-fullfp16-sp-d16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: ARMv8-a FP-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-fp-armv8.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fp-armv8.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: ARMv8-a FP
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-fp-armv8.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fp-armv8.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu fp-armv8
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: ARMv8-a FP
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-fpv4-sp-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fpv4-sp-d16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv4-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-fpv4-sp-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fpv4-sp-d16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu fpv4-sp-d16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv4-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-fpv5-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fpv5-d16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: ARMv8-a FP-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-fpv5-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fpv5-d16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu fpv5-d16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: ARMv8-a FP-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-fpv5-sp-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fpv5-sp-d16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu fpv5-sp-d16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: ARMv8-a FP-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-fpv5-sp-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-fpv5-sp-d16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: ARMv8-a FP-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-neon-fp-armv8.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon-fp-armv8.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu neon-fp-armv8
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: ARMv8-a FP
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-neon-fp-armv8.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon-fp-armv8.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: ARMv8-a FP
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-neon-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon-fp16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-neon-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon-fp16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu neon-fp16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-neon-vfpv4.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon-vfpv4.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv4
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-neon-vfpv4.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon-vfpv4.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu neon-vfpv4
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv4
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-neon.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-neon.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-neon.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu neon
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-none.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-none.s
@@ -7,3 +7,4 @@
   .fpu none
 
 @ CHECK-ATTR-NOT:     TagName: FP_arch
+

--- a/llvm/test/MC/ARM/directive-fpu-single-none.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-none.s
@@ -1,0 +1,9 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu none
+
+@ CHECK-ATTR-NOT:     TagName: FP_arch

--- a/llvm/test/MC/ARM/directive-fpu-single-vfp.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfp.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv2
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfp.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfp.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfp
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv2
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv2.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv2.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfp2
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv2
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv2.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv2.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv2
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16-fp16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfpv3-d16-fp16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16-fp16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfp3-d16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3-d16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3-fp16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfpv3-fp16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3-fp16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfp3
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd-fp16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfpv3xd-fp16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd-fp16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd-fp16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfpv3xd
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv3-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv3xd.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv3-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv4-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv4-d16.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv4-D16
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv4-d16.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv4-d16.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfpv4-d16
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv4-D16
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv4.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv4.s
@@ -12,3 +12,4 @@
 @ CHECK-ATTR:     Description: VFPv4
 @ CHECK-ATTR:   }
 @ CHECK-ATTR: }
+

--- a/llvm/test/MC/ARM/directive-fpu-single-vfpv4.s
+++ b/llvm/test/MC/ARM/directive-fpu-single-vfpv4.s
@@ -1,0 +1,14 @@
+@ Check a single .fpu directive.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ATTR
+
+  .fpu vfpv4
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: FP_arch
+@ CHECK-ATTR:     Description: VFPv4
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }


### PR DESCRIPTION
An assembly input with

>   .fpu fp-armv8-fullfp16-d16

crashes the compiler because the ELF FPU attribute emitter misses the
respective entry. This patch fixes this.

Interestingly, compiling with -mfpu=fp-armv8-fullfp16-d16 does not cause
the crash because FPv5_D16 is an alias in the compiler and

>   .fpu fpv5-d16

is emitted instead, which does not crash.

The existing .fpu directive test with multiple FPUs serves the purpose
of verifying that each possible FPU option is defined, but does not
trigger the crash because only the last .fpu directive goes effectively
down the code path. Therefore one test for each FPU is required.

Fixes #105674.