### PR TITLE
[C23] Update status page for TS 18661 integration

### DIFF
--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -216,11 +216,7 @@ conformance.</p>
       </tr>
       <tr> <!-- Pre-Oct 2019 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2341.pdf">N2341</a></td>
-        <td class="unknown" align="center">Unknown</td>
-      </tr>
-      <tr> <!-- Pre-Oct 2019 -->
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2401.pdf">N2401</a></td>
-        <td class="unknown" align="center">Unknown</td>
+        <td class="none" align="center">No</td>
       </tr>
       <tr> <!-- Pre-Oct 2019 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2359.pdf">N2359</a></td>
@@ -228,23 +224,23 @@ conformance.</p>
       </tr>
       <tr> <!-- Nov 2020 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2546.pdf">N2546</a></td>
-        <td class="unknown" align="center">Unknown</td>
+        <td class="none" align="center">No</td>
       </tr>
       <tr>
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2580.htm">N2580</a></td>
-        <td class="unknown" align="center">Unknown</td>
+        <td class="none" align="center">No</td>
       </tr>
       <tr> <!-- Apr 2021 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2640.htm">N2640</a></td>
-        <td class="unknown" align="center">Unknown</td>
+        <td class="none" align="center">No</td>
       </tr>
       <tr> <!-- Sep 2021 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2755.htm">N2755</a></td>
-        <td class="unknown" align="center">Unknown</td>
+        <td class="none" align="center">No</td>
       </tr>
       <tr> <!-- Feb 2022 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2931.pdf">N2931</a></td>
-        <td class="unknown" align="center">Unknown</td>
+        <td class="none" align="center">No</td>
       </tr>
     <tr>
       <td>Preprocessor line numbers unspecified</td>

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -226,13 +226,9 @@ conformance.</p>
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2546.pdf">N2546</a></td>
         <td class="none" align="center">No</td>
       </tr>
-      <tr>
-        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2580.htm">N2580</a></td>
-        <td class="none" align="center">No</td>
-      </tr>
       <tr> <!-- Apr 2021 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2640.htm">N2640</a></td>
-        <td class="none" align="center">No</td>
+        <td class="full" align="center">Yes</td>
       </tr>
       <tr> <!-- Sep 2021 -->
         <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2755.htm">N2755</a></td>


### PR DESCRIPTION
WG14 N2401 was removed from the list because it was library-only changes that don't impact the compiler.

Everything having to do with decimal floating-point types was changed to No because we do not currently have any support for those.

WG14 N2314 remains Unknown because it has changes to Annex F for binary floating-point types.