### PR TITLE
[compiler-rt][test] Rewrote test to remove curly braces

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
+++ b/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
@@ -1,7 +1,10 @@
 // RUN: %clangxx_asan -xc++ -shared -fPIC -o %t.so - < %s
 // RUN: %clang_asan %s -o %t.out -ldl
 //
-// RUN: env ASAN_OPTIONS=verbosity=1 %t.out %t.so 2>&1 | FileCheck %s || :
+// The program can potentially return a non-zero exit code, so use || : to
+// ensure command returns true
+// RUN: env ASAN_OPTIONS=verbosity=1 %t.out %t.so &> %t_env || :
+// RUN: FileCheck %s < %t_env
 //
 // CHECK: AddressSanitizer: failed to intercept '__cxa_throw'
 //

--- a/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
+++ b/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
@@ -1,7 +1,7 @@
 // RUN: %clangxx_asan -xc++ -shared -fPIC -o %t.so - < %s
 // RUN: %clang_asan %s -o %t.out -ldl
 //
-// RUN: { env ASAN_OPTIONS=verbosity=1 %t.out %t.so || : ; } 2>&1 | FileCheck %s
+// RUN: env ASAN_OPTIONS=verbosity=1 %t.out %t.so 2>&1 | FileCheck %s || :
 //
 // CHECK: AddressSanitizer: failed to intercept '__cxa_throw'
 //

--- a/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
+++ b/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
@@ -1,8 +1,6 @@
 // RUN: %clangxx_asan -xc++ -shared -fPIC -o %t.so - < %s
 // RUN: %clang_asan %s -o %t.out -ldl
 //
-// The program can potentially return a non-zero exit code, so use || : to
-// ensure command returns true
 // RUN: env ASAN_OPTIONS=verbosity=1 not %t.out %t.so 2>&1 | FileCheck %s
 //
 // CHECK: AddressSanitizer: failed to intercept '__cxa_throw'

--- a/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
+++ b/compiler-rt/test/asan/TestCases/Linux/dlopen-mixed-c-cxx.c
@@ -3,8 +3,7 @@
 //
 // The program can potentially return a non-zero exit code, so use || : to
 // ensure command returns true
-// RUN: env ASAN_OPTIONS=verbosity=1 %t.out %t.so &> %t_env || :
-// RUN: FileCheck %s < %t_env
+// RUN: env ASAN_OPTIONS=verbosity=1 not %t.out %t.so 2>&1 | FileCheck %s
 //
 // CHECK: AddressSanitizer: failed to intercept '__cxa_throw'
 //


### PR DESCRIPTION
This patch removes curly braces from a test, as lit's internal shell implementation does not support curly brace syntax.

Fixes https://github.com/llvm/llvm-project/issues/102382.