### PR TITLE
[clang][bytecode] Reject void InitListExpr differently

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1344,6 +1344,14 @@ bool Compiler<Emitter>::VisitArraySubscriptExpr(const ArraySubscriptExpr *E) {
 template <class Emitter>
 bool Compiler<Emitter>::visitInitList(ArrayRef<const Expr *> Inits,
                                       const Expr *ArrayFiller, const Expr *E) {
+
+  QualType QT = E->getType();
+  if (const auto *AT = QT->getAs<AtomicType>())
+    QT = AT->getValueType();
+
+  if (!DiscardResult && QT->isVoidType())
+    return this->emitInvalid(E);
+
   // Handle discarding first.
   if (DiscardResult) {
     for (const Expr *Init : Inits) {
@@ -1352,13 +1360,6 @@ bool Compiler<Emitter>::visitInitList(ArrayRef<const Expr *> Inits,
     }
     return true;
   }
-
-  QualType QT = E->getType();
-  if (const auto *AT = QT->getAs<AtomicType>())
-    QT = AT->getValueType();
-
-  if (QT->isVoidType())
-    return this->emitInvalid(E);
 
   // Primitive values.
   if (std::optional<PrimType> T = classify(QT)) {
@@ -3275,9 +3276,12 @@ template <class Emitter> bool Compiler<Emitter>::visit(const Expr *E) {
   if (E->getType().isNull())
     return false;
 
+  if (E->getType()->isVoidType())
+    return this->discard(E);
+
   // Create local variable to hold the return value.
-  if (!E->getType()->isVoidType() && !E->isGLValue() &&
-      !E->getType()->isAnyComplexType() && !classify(E->getType())) {
+  if (!E->isGLValue() && !E->getType()->isAnyComplexType() &&
+      !classify(E->getType())) {
     std::optional<unsigned> LocalIndex = allocateLocal(E);
     if (!LocalIndex)
       return false;
@@ -5171,7 +5175,7 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
     // We should already have a pointer when we get here.
     return this->delegate(SubExpr);
   case UO_Deref: // *x
-    if (DiscardResult || E->getType()->isVoidType())
+    if (DiscardResult)
       return this->discard(SubExpr);
     return this->visit(SubExpr);
   case UO_Not: // ~x

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -298,7 +298,6 @@ void T1(void) {
 enum teste1 test1f(void), (*test1)(void) = test1f; // pedantic-warning {{ISO C forbids forward references to 'enum' types}}
 enum teste1 { TEST1 };
 
-
 void func(void) {
   _Static_assert(func + 1 - func == 1, ""); // pedantic-warning {{arithmetic on a pointer to the function type}} \
                                             // pedantic-warning {{arithmetic on pointers to the function type}} \
@@ -312,4 +311,10 @@ void func(void) {
                                // pedantic-warning {{arithmetic on a pointer to the function type}}
   func - 0xdead000000000000UL; // all-warning {{expression result unused}} \
                                // pedantic-warning {{arithmetic on a pointer to the function type}}
+}
+
+void foo3 (void)
+{
+ void* x = 0;
+ void* y = &*x;
 }


### PR DESCRIPTION
This reverts c79d1fa540390f6e37e1ea326153559eeadd0de6 and 125aa10b3d645bd26523a1bc321bb2e6b1cf04e1

Instead, just only use emitInvalid() for void InitListExprs if we're not discarding them.