### PR TITLE
[llvm-c-test] Rename --test-dibuilder-debuginfo-format to `--test-dibuilder`

### DIFF
--- a/llvm/test/Bindings/llvm-c/debug_info_new_format.ll
+++ b/llvm/test/Bindings/llvm-c/debug_info_new_format.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-c-test --test-dibuilder-debuginfo-format | FileCheck %s
+; RUN: llvm-c-test --test-dibuilder | FileCheck %s
 ;; Duplicate of debug_info.ll using debug records instead of intrinsics.
 
 ; CHECK: ; ModuleID = 'debuginfo.c'

--- a/llvm/tools/llvm-c-test/main.c
+++ b/llvm/tools/llvm-c-test/main.c
@@ -109,8 +109,7 @@ int main(int argc, char **argv) {
     return llvm_echo();
   } else if (argc == 2 && !strcmp(argv[1], "--test-diagnostic-handler")) {
     return llvm_test_diagnostic_handler();
-  } else if (argc == 2 &&
-             !strcmp(argv[1], "--test-dibuilder-debuginfo-format")) {
+  } else if (argc == 2 && !strcmp(argv[1], "--test-dibuilder")) {
     return llvm_test_dibuilder();
   } else {
     print_usage();


### PR DESCRIPTION
The former name was introduced during the split between debug info intrinsic and `DbgRecord`. Before the split, it was named `--test-dibuilder`.

However, the full migration to `DbgRecord` happened already and we have just one test suite related to building debug info using LLVM-C API. Therefore, it makes sense to rename it back to `--test-dibuilder`.