### PR TITLE
[polly][llvm-lit] Enabled lit internal shell for polly test suite

### DIFF
--- a/polly/test/UnitIsl/lit.cfg
+++ b/polly/test/UnitIsl/lit.cfg
@@ -16,8 +16,15 @@ config.name = 'Polly - isl unit tests'
 #
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
-execute_external = platform.system() != 'Windows'
-config.test_format = lit.formats.ShTest(execute_external)
+#
+# We prefer the lit internal shell which provides a better user experience on failures
+# unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+  use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+
+config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.sh']

--- a/polly/test/lit.cfg
+++ b/polly/test/lit.cfg
@@ -19,8 +19,15 @@ config.name = 'Polly'
 #
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
-execute_external = platform.system() != 'Windows'
-config.test_format = lit.formats.ShTest(execute_external)
+#
+# We prefer the lit internal shell which provides a better user experience on failures
+# unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+  use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+
+config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.ll']


### PR DESCRIPTION
This patch sets lit's internal shell to be the default shell when running polly tests.

This is one of the milestones to resolving the meta-issue: https://github.com/llvm/llvm-project/issues/102704.