### PR TITLE
[lldb] Conditionalize context_switch attribute based on kernel version

### DIFF
--- a/lldb/source/Plugins/Process/Linux/Perf.cpp
+++ b/lldb/source/Plugins/Process/Linux/Perf.cpp
@@ -342,7 +342,9 @@ lldb_private::process_linux::CreateContextSwitchTracePerfEvent(
   attr.size = sizeof(attr);
   attr.sample_type = PERF_SAMPLE_TID | PERF_SAMPLE_TIME;
   attr.type = PERF_TYPE_SOFTWARE;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
   attr.context_switch = 1;
+#endif
   attr.exclude_kernel = 1;
   attr.sample_id_all = 1;
   attr.exclude_hv = 1;


### PR DESCRIPTION
Close: #105705

I build llvm toolchain with `linux-headers 4.2`, but get error, while compiling lldb
```
llvm-project/lldb/source/Plugins/Process/Linux/Perf.cpp:345:8: error: 'struct perf_event_attr' has no member named 'context_switch' attr.context_switch = 1%3b
```
can we replace or disable this functionality in lldb with older `linux-headers`?

https://man7.org/linux/man-pages/man2/perf_event_open.2.html
context_switch (since Linux 4.3)