### PR TITLE
[BOLT][test] Removed the use of parentheses in BOLT tests with lit internal shell

### DIFF
--- a/bolt/test/X86/end-symbol.test
+++ b/bolt/test/X86/end-symbol.test
@@ -1,7 +1,9 @@
 # RUN: yaml2obj %p/Inputs/plt-sec.yaml &> %t.exe
 # RUN: llvm-bolt %t.exe -o %t.out
-# RUN: (llvm-readelf --program-headers %t.out | grep LOAD | tail -n 1 ; llvm-nm %t.out) \
-# RUN:   | FileCheck %s
+
+# RUN: llvm-readelf --program-headers %t.out | grep LOAD | tail -n 1 > %t.load
+# RUN: llvm-nm %t.out >> %t.load
+# RUN: FileCheck %s < %t.load
 
 ## Check that llvm-bolt correctly updates _end symbol to match the end of the
 ## last loadable segment.

--- a/bolt/test/X86/instrumentation-eh_frame_hdr.cpp
+++ b/bolt/test/X86/instrumentation-eh_frame_hdr.cpp
@@ -6,8 +6,9 @@
 // RUN: %clangxx %cxxflags -static -Wl,-q %s -o %t.exe -Wl,--entry=_start
 // RUN: llvm-bolt %t.exe -o %t.instr -instrument \
 // RUN:   --instrumentation-file=%t.fdata -instrumentation-sleep-time=1
-// RUN: (llvm-readelf -SW %t.instr | grep -v bolt; llvm-readelf -lW %t.instr | \
-// RUN:   grep LOAD | tail -n 1) | FileCheck %s
+// RUN: llvm-readelf -SW %t.instr | grep -v bolt > %t.sections
+// RUN: llvm-readelf -lW %t.instr | grep LOAD | tail -n 1 >> %t.sections
+// RUN: FileCheck %s < %t.sections
 
 // CHECK: {{.*}} .eh_frame_hdr PROGBITS [[#%x, EH_ADDR:]]
 // CHECK: LOAD 0x[[#%x, LD_OFFSET:]] 0x[[#%x, LD_VADDR:]] 0x[[#%x, LD_FSIZE:]]


### PR DESCRIPTION
This patch addresses compatibility issues with the lit internal shell by removing the use of subshell execution (parentheses and subshell syntax) in the `BOLT` tests. The lit internal shell does not support parentheses, so the tests have been refactored to use separate command invocations, with outputs redirected to temporary files where necessary.

This change is relevant for enabling the lit internal shell by default, as outlined in [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179)

fixes: #102401