### PR TITLE
[DXIL][Analysis] Collect Function properties in Metadata Analysis

### DIFF
--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_ANALYSIS_DXILMETADATA_H
 #define LLVM_ANALYSIS_DXILMETADATA_H
 
+#include "llvm/IR/Function.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/VersionTuple.h"
@@ -19,12 +20,16 @@ namespace llvm {
 
 namespace dxil {
 
+struct FunctionProperties {
+  unsigned NumThreads[3];
+};
+
 struct ModuleMetadataInfo {
   VersionTuple DXILVersion{};
   VersionTuple ShaderModelVersion{};
   Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
   VersionTuple ValidatorVersion{};
-
+  std::unordered_map<Function *, FunctionProperties> FunctionPropertyMap{};
   void print(raw_ostream &OS) const;
 };
 

--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -21,6 +21,8 @@ namespace llvm {
 namespace dxil {
 
 struct FunctionProperties {
+  // Specific target shader stage may be specified for entry functions
+  Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
   unsigned NumThreads[3];
 };
 

--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -28,7 +28,7 @@ struct EntryProperties {
   unsigned NumThreadsY{0}; // Y component
   unsigned NumThreadsZ{0}; // Z component
 
-  EntryProperties(const Function &Fn) : Entry(&Fn){};
+  EntryProperties(const Function &Fn) : Entry(&Fn) {};
 };
 
 struct ModuleMetadataInfo {

--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_ANALYSIS_DXILMETADATA_H
 #define LLVM_ANALYSIS_DXILMETADATA_H
 
-#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
@@ -22,11 +22,14 @@ namespace llvm {
 namespace dxil {
 
 struct EntryProperties {
+  const Function *Entry;
   // Specific target shader stage may be specified for entry functions
   Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
-  unsigned NumThreadsX; // X component
-  unsigned NumThreadsY; // Y component
-  unsigned NumThreadsZ; // Z component
+  unsigned NumThreadsX{0}; // X component
+  unsigned NumThreadsY{0}; // Y component
+  unsigned NumThreadsZ{0}; // Z component
+
+  EntryProperties(const Function &Fn) : Entry(&Fn){};
 };
 
 struct ModuleMetadataInfo {
@@ -34,7 +37,7 @@ struct ModuleMetadataInfo {
   VersionTuple ShaderModelVersion{};
   Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
   VersionTuple ValidatorVersion{};
-  MapVector<Function *, EntryProperties> EntryPropertyMap;
+  SmallVector<EntryProperties, 4> EntryPropertyVec{};
   void print(raw_ostream &OS) const;
 };
 

--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -10,15 +10,14 @@
 #define LLVM_ANALYSIS_DXILMETADATA_H
 
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/IR/Function.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/TargetParser/Triple.h"
-#include <memory>
 
 namespace llvm {
 
+class Function;
 namespace dxil {
 
 struct EntryProperties {
@@ -37,7 +36,7 @@ struct ModuleMetadataInfo {
   VersionTuple ShaderModelVersion{};
   Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
   VersionTuple ValidatorVersion{};
-  SmallVector<EntryProperties, 4> EntryPropertyVec{};
+  SmallVector<EntryProperties> EntryPropertyVec{};
   void print(raw_ostream &OS) const;
 };
 

--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_ANALYSIS_DXILMETADATA_H
 #define LLVM_ANALYSIS_DXILMETADATA_H
 
+#include "llvm/ADT/MapVector.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
@@ -20,10 +21,12 @@ namespace llvm {
 
 namespace dxil {
 
-struct FunctionProperties {
+struct EntryProperties {
   // Specific target shader stage may be specified for entry functions
   Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
-  unsigned NumThreads[3];
+  unsigned NumThreadsX; // X component
+  unsigned NumThreadsY; // Y component
+  unsigned NumThreadsZ; // Z component
 };
 
 struct ModuleMetadataInfo {
@@ -31,7 +34,7 @@ struct ModuleMetadataInfo {
   VersionTuple ShaderModelVersion{};
   Triple::EnvironmentType ShaderStage = Triple::UnknownEnvironment;
   VersionTuple ValidatorVersion{};
-  std::unordered_map<Function *, FunctionProperties> FunctionPropertyMap{};
+  MapVector<Function *, EntryProperties> EntryPropertyMap;
   void print(raw_ostream &OS) const;
 };
 

--- a/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
+++ b/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
@@ -77,7 +77,7 @@ void ModuleMetadataInfo::print(raw_ostream &OS) const {
   OS << "Target Shader Stage : " << Triple::getEnvironmentTypeName(ShaderStage)
      << "\n";
   OS << "Validator Version : " << ValidatorVersion.getAsString() << "\n";
-  for (const auto EP : EntryPropertyVec) {
+  for (const auto &EP : EntryPropertyVec) {
     OS << " " << EP.Entry->getName() << "\n";
     OS << "  Function Shader Stage : "
        << Triple::getEnvironmentTypeName(EP.ShaderStage) << "\n";

--- a/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
+++ b/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
@@ -16,8 +16,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/ErrorHandling.h"
-#include <memory>
-#include <utility>
 
 #define DEBUG_TYPE "dxil-metadata-analysis"
 
@@ -60,7 +58,8 @@ static ModuleMetadataInfo collectMetadataInfo(Module &M) {
       NumThreadsStr.split(NumThreadsVec, ',');
       assert(NumThreadsVec.size() == 3 && "Invalid numthreads specified");
       // Read in the three component values of numthreads
-      bool Success = llvm::to_integer(NumThreadsVec[0], EFP.NumThreadsX, 10);
+      [[maybe_unused]] bool Success =
+          llvm::to_integer(NumThreadsVec[0], EFP.NumThreadsX, 10);
       assert(Success && "Failed to parse X component of numthreads");
       Success = llvm::to_integer(NumThreadsVec[1], EFP.NumThreadsY, 10);
       assert(Success && "Failed to parse Y component of numthreads");
@@ -78,11 +77,12 @@ void ModuleMetadataInfo::print(raw_ostream &OS) const {
   OS << "Target Shader Stage : " << Triple::getEnvironmentTypeName(ShaderStage)
      << "\n";
   OS << "Validator Version : " << ValidatorVersion.getAsString() << "\n";
-  for (const auto [Ent, SS, NX, NY, NZ] : EntryPropertyVec) {
-    OS << " " << Ent->getName() << "\n";
-    OS << "  Function Shader Stage : " << Triple::getEnvironmentTypeName(SS)
-       << "\n";
-    OS << "  NumThreads: " << NX << "," << NY << "," << NZ << "\n";
+  for (const auto EP : EntryPropertyVec) {
+    OS << " " << EP.Entry->getName() << "\n";
+    OS << "  Function Shader Stage : "
+       << Triple::getEnvironmentTypeName(EP.ShaderStage) << "\n";
+    OS << "  NumThreads: " << EP.NumThreadsX << "," << EP.NumThreadsY << ","
+       << EP.NumThreadsZ << "\n";
   }
 }
 

--- a/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
+++ b/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
@@ -39,41 +39,41 @@ static ModuleMetadataInfo collectMetadataInfo(Module &M) {
         VersionTuple(MajorMD->getZExtValue(), MinorMD->getZExtValue());
   }
 
-    // For all HLSL Shader functions
-    for (auto &F : M.functions()) {
-      if (!F.hasFnAttribute("hlsl.shader"))
-        continue;
+  // For all HLSL Shader functions
+  for (auto &F : M.functions()) {
+    if (!F.hasFnAttribute("hlsl.shader"))
+      continue;
 
-      FunctionProperties EFP{};
-      // Get "hlsl.shader" attribute
-      Attribute EntryAttr = F.getFnAttribute("hlsl.shader");
-      StringRef EntryProfile = EntryAttr.getValueAsString();
-      Triple T("", "", "", EntryProfile);
-      EFP.ShaderStage = T.getEnvironment();
-      // Get numthreads attribute value, if one exists
-      StringRef NumThreadsStr =
-          F.getFnAttribute("hlsl.numthreads").getValueAsString();
-      if (!NumThreadsStr.empty()) {
-        SmallVector<StringRef> NumThreadsVec;
-        NumThreadsStr.split(NumThreadsVec, ',');
-        if (NumThreadsVec.size() != 3) {
-          report_fatal_error(Twine(F.getName()) +
-                                 ": Invalid numthreads specified",
-                             /* gen_crash_diag */ false);
-        }
-        auto Zip =
-            llvm::zip(NumThreadsVec, MutableArrayRef<unsigned>(EFP.NumThreads));
-        for (auto It : Zip) {
-          StringRef Str = std::get<0>(It);
-          APInt V;
-          assert(!Str.getAsInteger(10, V) &&
-                 "Failed to parse numthreads components as integer values");
-          unsigned &Num = std::get<1>(It);
-          Num = V.getLimitedValue();
-        }
+    FunctionProperties EFP{};
+    // Get "hlsl.shader" attribute
+    Attribute EntryAttr = F.getFnAttribute("hlsl.shader");
+    StringRef EntryProfile = EntryAttr.getValueAsString();
+    Triple T("", "", "", EntryProfile);
+    EFP.ShaderStage = T.getEnvironment();
+    // Get numthreads attribute value, if one exists
+    StringRef NumThreadsStr =
+        F.getFnAttribute("hlsl.numthreads").getValueAsString();
+    if (!NumThreadsStr.empty()) {
+      SmallVector<StringRef> NumThreadsVec;
+      NumThreadsStr.split(NumThreadsVec, ',');
+      if (NumThreadsVec.size() != 3) {
+        report_fatal_error(Twine(F.getName()) +
+                               ": Invalid numthreads specified",
+                           /* gen_crash_diag */ false);
       }
-      MMDAI.FunctionPropertyMap.emplace(std::make_pair(std::addressof(F), EFP));
+      auto Zip =
+          llvm::zip(NumThreadsVec, MutableArrayRef<unsigned>(EFP.NumThreads));
+      for (auto It : Zip) {
+        StringRef Str = std::get<0>(It);
+        APInt V;
+        assert(!Str.getAsInteger(10, V) &&
+               "Failed to parse numthreads components as integer values");
+        unsigned &Num = std::get<1>(It);
+        Num = V.getLimitedValue();
+      }
     }
+    MMDAI.FunctionPropertyMap.emplace(std::make_pair(std::addressof(F), EFP));
+  }
   return MMDAI;
 }
 

--- a/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.0.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.0.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.0-vertex"
+
+; CHECK: Shader Model Version : 6.0
+; CHECK-NEXT: DXIL Version : 1.0
+; CHECK-NEXT: Shader Stage : vertex
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:   Function Shader Stage : vertex
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="vertex" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.8.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.8.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.8-compute"
+
+; CHECK: Shader Model Version : 6.8
+; CHECK-NEXT: DXIL Version : 1.8
+; CHECK-NEXT: Shader Stage : compute
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:   Function Shader Stage : compute
+; CHECK-NEXT: NumThreads: 1,2,1
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/entry-properties.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/entry-properties.ll
@@ -1,0 +1,36 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.8-library"
+
+; CHECK: Shader Model Version : 6.8
+; CHECK-NEXT: DXIL Version : 1.8
+; CHECK-NEXT: Target Shader Stage : library
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry_as
+; CHECK-NEXT:   Function Shader Stage : amplification
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: entry_ms
+; CHECK-NEXT:   Function Shader Stage : mesh
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: entry_cs
+; CHECK-NEXT:   Function Shader Stage : compute
+; CHECK-NEXT:   NumThreads: 1,2,1
+; CHECK-EMPTY:
+
+define void @entry_as() #0 {
+entry:
+  ret void
+}
+
+define i32 @entry_ms(i32 %a) #1 {
+entry:
+  ret i32 %a
+}
+
+define float @entry_cs(float %f) #3 {
+entry:
+  ret float %f
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="amplification" }
+attributes #1 = { noinline nounwind "hlsl.shader"="mesh" }
+attributes #3 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-as.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-as.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6-amplification"
+
+; CHECK: Shader Model Version : 6
+; CHECK-NEXT: DXIL Version : 1.0
+; CHECK-NEXT: Target Shader Stage : amplification
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : amplification
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="amplification" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs-val-ver-0.0.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs-val-ver-0.0.ll
@@ -1,0 +1,23 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }
+
+!dx.valver = !{!0}
+
+!0 = !{i32 0, i32 0}
+
+; CHECK: Shader Model Version : 6.6
+; CHECK-NEXT: DXIL Version : 1.6
+; CHECK-NEXT: Target Shader Stage : compute
+; CHECK-NEXT: Validator Version : 0.0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : compute
+; CHECK-NEXT:   NumThreads: 1,2,1
+; CHECK-EMPTY:

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs.ll
@@ -1,0 +1,19 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+; CHECK: Shader Model Version : 6.6
+; CHECK-NEXT: DXIL Version : 1.6
+; CHECK-NEXT: Target Shader Stage : compute
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : compute
+; CHECK-NEXT:   NumThreads: 1,2,1
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-gs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-gs.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.6-geometry"
+
+; CHECK: Shader Model Version : 6.6
+; CHECK-NEXT: DXIL Version : 1.6
+; CHECK-NEXT: Shader Stage : geometry
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : geometry
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="geometry" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-hs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-hs.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.6-hull"
+
+; CHECK: Shader Model Version : 6.6
+; CHECK-NEXT: DXIL Version : 1.6
+; CHECK-NEXT: Target Shader Stage : hull
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : hull
+; CHECK-NEXT:  NumThreads: 0,0,0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="hull" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ms.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ms.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.6-mesh"
+
+; CHECK: Shader Model Version : 6.6
+; CHECK-NEXT: DXIL Version : 1.6
+; CHECK-NEXT: Shader Stage : mesh
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : mesh
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="mesh" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ps.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ps.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel5.0-pixel"
+
+; CHECK: Shader Model Version : 5.0
+; CHECK-NEXT: DXIL Version : 1.0
+; CHECK-NEXT: Shader Stage : pixel
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : pixel
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="pixel" }

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-vs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-vs.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel-vertex"
+
+; CHECK: Shader Model Version : 0
+; CHECK-NEXT: DXIL Version : 1.0
+; CHECK-NEXT: Shader Stage : vertex
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:  Function Shader Stage : vertex
+; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "hlsl.shader"="vertex" }

--- a/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.0.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -passes=dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel6.0-vertex"
 
 ; CHECK: !dx.version = !{![[DXVER:[0-9]+]]}
 ; CHECK: ![[DXVER]] = !{i32 1, i32 0}
-
-; ANALYSIS: Shader Model Version : 6.0
-; ANALYSIS-NEXT: DXIL Version : 1.0
-; ANALYSIS-NEXT: Shader Stage : vertex
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: 0,0,0
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.0.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel6.0-vertex"
 ; ANALYSIS-NEXT: DXIL Version : 1.0
 ; ANALYSIS-NEXT: Shader Stage : vertex
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: 0,0,0
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.8.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.8.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel6.8-compute"
 ; ANALYSIS-NEXT: DXIL Version : 1.8
 ; ANALYSIS-NEXT: Shader Stage : compute
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: NumThreads: 1,2,1
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.8.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/dxilVer-1.8.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -passes=dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel6.8-compute"
 
 ; CHECK: !dx.version = !{![[DXVER:[0-9]+]]}
 ; CHECK: ![[DXVER]] = !{i32 1, i32 8}
-
-; ANALYSIS: Shader Model Version : 6.8
-; ANALYSIS-NEXT: DXIL Version : 1.8
-; ANALYSIS-NEXT: Shader Stage : compute
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: NumThreads: 1,2,1
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-as.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-as.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel6-amplification"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"as", i32 6, i32 0}
-
-; ANALYSIS: Shader Model Version : 6
-; ANALYSIS-NEXT: DXIL Version : 1.0
-; ANALYSIS-NEXT: Shader Stage : amplification
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: 0,0,0
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-as.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-as.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel6-amplification"
 ; ANALYSIS-NEXT: DXIL Version : 1.0
 ; ANALYSIS-NEXT: Shader Stage : amplification
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: 0,0,0
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
@@ -19,5 +19,7 @@ attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" 
 ; ANALYSIS: Shader Model Version : 6.6
 ; ANALYSIS-NEXT: DXIL Version : 1.6
 ; ANALYSIS-NEXT: Shader Stage : compute
-; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: Validator Version : 0.0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT:   NumThreads: 1,2,1
 ; ANALYSIS-EMPTY:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
@@ -1,5 +1,4 @@
 ; RUN: opt -S -dxil-prepare  %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 
 target triple = "dxil-pc-shadermodel6.6-compute"
 
@@ -15,11 +14,3 @@ attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" 
 !dx.valver = !{!0}
 
 !0 = !{i32 0, i32 0}
-
-; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS-NEXT: DXIL Version : 1.6
-; ANALYSIS-NEXT: Shader Stage : compute
-; ANALYSIS-NEXT: Validator Version : 0.0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT:   NumThreads: 1,2,1
-; ANALYSIS-EMPTY:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
@@ -11,6 +11,8 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 ; ANALYSIS-NEXT: DXIL Version : 1.6
 ; ANALYSIS-NEXT: Shader Stage : compute
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT:   NumThreads: 1,2,1
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
@@ -1,19 +1,10 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
 ; RUN: opt -S -dxil-prepare  %s | FileCheck %s  --check-prefix=REMOVE_EXTRA_ATTRIBUTE
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 
 target triple = "dxil-pc-shadermodel6.6-compute"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"cs", i32 6, i32 6}
-
-; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS-NEXT: DXIL Version : 1.6
-; ANALYSIS-NEXT: Shader Stage : compute
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT:   NumThreads: 1,2,1
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-gs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-gs.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel6.6-geometry"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"gs", i32 6, i32 6}
-
-; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS-NEXT: DXIL Version : 1.6
-; ANALYSIS-NEXT: Shader Stage : geometry
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: 0,0,0
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-gs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-gs.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel6.6-geometry"
 ; ANALYSIS-NEXT: DXIL Version : 1.6
 ; ANALYSIS-NEXT: Shader Stage : geometry
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: 0,0,0
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-hs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-hs.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel6.6-hull"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"hs", i32 6, i32 6}
-
-; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS-NEXT: DXIL Version : 1.6
-; ANALYSIS-NEXT: Shader Stage : hull
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: 0,0,0
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-hs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-hs.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel6.6-hull"
 ; ANALYSIS-NEXT: DXIL Version : 1.6
 ; ANALYSIS-NEXT: Shader Stage : hull
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: 0,0,0
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-lib.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-lib.ll
@@ -1,12 +1,6 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel6.3-library"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"lib", i32 6, i32 3}
 
-; ANALYSIS: Shader Model Version : 6.3
-; ANALYSIS-NEXT: DXIL Version : 1.3
-; ANALYSIS-NEXT: Shader Stage : library
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-EMPTY:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ms.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ms.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel6.6-mesh"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"ms", i32 6, i32 6}
-
-; ANALYSIS: Shader Model Version : 6.6
-; ANALYSIS-NEXT: DXIL Version : 1.6
-; ANALYSIS-NEXT: Shader Stage : mesh
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: 0,0,0
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ms.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ms.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel6.6-mesh"
 ; ANALYSIS-NEXT: DXIL Version : 1.6
 ; ANALYSIS-NEXT: Shader Stage : mesh
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: 0,0,0
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ps.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ps.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel5.0-pixel"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"ps", i32 5, i32 0}
-
-; ANALYSIS: Shader Model Version : 5.0
-; ANALYSIS-NEXT: DXIL Version : 1.0
-; ANALYSIS-NEXT: Shader Stage : pixel
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: 0,0,0
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ps.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-ps.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel5.0-pixel"
 ; ANALYSIS-NEXT: DXIL Version : 1.0
 ; ANALYSIS-NEXT: Shader Stage : pixel
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: 0,0,0
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-vs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-vs.ll
@@ -9,6 +9,8 @@ target triple = "dxil-pc-shadermodel-vertex"
 ; ANALYSIS-NEXT: DXIL Version : 1.0
 ; ANALYSIS-NEXT: Shader Stage : vertex
 ; ANALYSIS-NEXT: Validator Version : 0
+; ANALYSIS-NEXT: void entry()
+; ANALYSIS-NEXT: 0,0,0
 ; ANALYSIS-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-vs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-vs.ll
@@ -1,17 +1,8 @@
 ; RUN: opt -S -dxil-translate-metadata %s | FileCheck %s
-; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s --check-prefix=ANALYSIS
 target triple = "dxil-pc-shadermodel-vertex"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
 ; CHECK: ![[SM]] = !{!"vs", i32 0, i32 0}
-
-; ANALYSIS: Shader Model Version : 0
-; ANALYSIS-NEXT: DXIL Version : 1.0
-; ANALYSIS-NEXT: Shader Stage : vertex
-; ANALYSIS-NEXT: Validator Version : 0
-; ANALYSIS-NEXT: void entry()
-; ANALYSIS-NEXT: 0,0,0
-; ANALYSIS-EMPTY:
 
 define void @entry() #0 {
 entry:


### PR DESCRIPTION
Basic infrastructure to collect Function properties in Metadata Analysis
- Add a `SmallVector` of entry properties to the metadata information.
- Add a structure to represent function properties. Currently `numthreads` and shader kind properties of shader entry functions are represented.