### PR TITLE
[LTO] Turn ImportMapTy into a proper class (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -96,19 +96,28 @@ public:
                std::tuple<unsigned, const GlobalValueSummary *,
                           std::unique_ptr<ImportFailureInfo>>>;
 
-  /// The map contains an entry for every module to import from, the key being
-  /// the module identifier to pass to the ModuleLoader. The value is the set of
-  /// functions to import. The module identifier strings must be owned
-  /// elsewhere, typically by the in-memory ModuleSummaryIndex the importing
-  /// decisions are made from (the module path for each summary is owned by the
-  /// index's module path string table).
+  /// The map maintains the list of imports.  Conceptually, it is a collection
+  /// of tuples of the form:
+  ///
+  ///   (The name of the source module, GUID, Definition/Declaration)
+  ///
+  /// The name of the source module is the module identifier to pass to the
+  /// ModuleLoader.  The module identifier strings must be owned elsewhere,
+  /// typically by the in-memory ModuleSummaryIndex the importing decisions are
+  /// made from (the module path for each summary is owned by the index's module
+  /// path string table).
   class ImportMapTy {
   public:
     using ImportMapTyImpl = DenseMap<StringRef, FunctionsToImportTy>;
 
     enum class AddDefinitionStatus {
+      // No change was made to the list of imports or whether each import should
+      // be imported as a declaration or definition.
       NoChange,
+      // Successfully added the given GUID to be imported as a definition. There
+      // was no existing entry with the same GUID as a declaration.
       Inserted,
+      // An existing with the given GUID was changed to a definition.
       ChangedToDefinition,
     };
 

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -177,7 +177,8 @@ std::string llvm::computeLTOCacheKey(
   // Include the hash for every module we import functions from. The set of
   // imported symbols for each module may affect code generation and is
   // sensitive to link order, so include that as well.
-  using ImportMapIteratorTy = FunctionImporter::ImportMapTy::const_iterator;
+  using ImportMapIteratorTy =
+      FunctionImporter::ImportMapTy::ImportMapTyImpl::const_iterator;
   struct ImportModule {
     ImportMapIteratorTy ModIt;
     const ModuleSummaryIndex::ModuleInfo *ModInfo;
@@ -191,10 +192,10 @@ std::string llvm::computeLTOCacheKey(
   };
 
   std::vector<ImportModule> ImportModulesVector;
-  ImportModulesVector.reserve(ImportList.size());
+  ImportModulesVector.reserve(ImportList.getImportMap().size());
 
-  for (ImportMapIteratorTy It = ImportList.begin(); It != ImportList.end();
-       ++It) {
+  for (ImportMapIteratorTy It = ImportList.getImportMap().begin();
+       It != ImportList.getImportMap().end(); ++It) {
     ImportModulesVector.push_back({It, Index.getModule(It->getFirst())});
   }
   // Order using module hash, to be both independent of module name and

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -726,8 +726,7 @@ bool lto::initImportList(const Module &M,
       if (Summary->modulePath() == M.getModuleIdentifier())
         continue;
       // Add an entry to provoke importing by thinBackend.
-      FunctionImporter::addGUID(ImportList, Summary->modulePath(), GUID,
-                                Summary->importType());
+      ImportList.addGUID(Summary->modulePath(), GUID, Summary->importType());
     }
   }
   return true;

--- a/llvm/tools/llvm-link/llvm-link.cpp
+++ b/llvm/tools/llvm-link/llvm-link.cpp
@@ -381,9 +381,8 @@ static bool importFunctions(const char *argv0, Module &DestModule) {
     // definition, so make the import type definition directly.
     // FIXME: A follow-up patch should add test coverage for import declaration
     // in `llvm-link` CLI (e.g., by introducing a new command line option).
-    FunctionImporter::addDefinition(
-        ImportList, FileNameStringCache.insert(FileName).first->getKey(),
-        F->getGUID());
+    ImportList.addDefinition(
+        FileNameStringCache.insert(FileName).first->getKey(), F->getGUID());
   }
   auto CachedModuleLoader = [&](StringRef Identifier) {
     return ModuleLoaderCache.takeModule(std::string(Identifier));


### PR DESCRIPTION
This patch turns type alias ImportMapTy into a proper class to provide
a more intuitive interface like:

  ImportList.addDefinition(...)

as opposed to:

  FunctionImporter::addDefinition(ImportList, ...)

Also, this patch requires all non-const accesses to go through
addDefinition, maybeAddDeclaration, and addGUID while providing const
accesses via:

  const ImportMapTyImpl &getImportMap() const { return ImportMap; }

I realize ImportMapTy may not be the best name as a class (maybe OK as
a type alias).  I am not renaming ImportMapTy in this patch at least
because there are 47 mentions of ImportMapTy under llvm/.
