### PR TITLE
[clang][compiler-rt][test] Removed dirname command substitutions from tests

### DIFF
--- a/clang/test/Driver/offload-packager.c
+++ b/clang/test/Driver/offload-packager.c
@@ -26,7 +26,7 @@
 // RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
 // RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a \
 // RUN:   --image=file=%t/elf.o,kind=hip,triple=amdgcn-amd-amdhsa,arch=gfx90c 
-// RUN: cd %t && clang-offload-packager %t/package --image=kind=openmp
+// RUN: clang-offload-packager %t/package --image=kind=openmp
 // RUN: diff *-nvptx64-nvidia-cuda-sm_70.0.o %t/elf.o; rm *-nvptx64-nvidia-cuda-sm_70.0.o
 // RUN: diff *-nvptx64-nvidia-cuda-sm_80.1.o %t/elf.o; rm *-nvptx64-nvidia-cuda-sm_80.1.o
 // RUN: diff *-amdgcn-amd-amdhsa-gfx908.2.o %t/elf.o; rm *-amdgcn-amd-amdhsa-gfx908.2.o

--- a/clang/test/Driver/offload-packager.c
+++ b/clang/test/Driver/offload-packager.c
@@ -3,63 +3,64 @@
 // REQUIRES: amdgpu-registered-target
 // UNSUPPORTED: system-windows
 
-// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.elf.o
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t/elf.o
 
 // Check that we can extract files from the packaged binary.
-// RUN: clang-offload-packager -o %t.out \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_80 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90c 
-// RUN: clang-offload-packager %t.out \
-// RUN:   --image=file=%t-sm_70.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
-// RUN:   --image=file=%t-gfx908.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908
-// RUN: diff %t-sm_70.o %t.elf.o
-// RUN: diff %t-gfx908.o %t.elf.o
+// RUN: clang-offload-packager -o %t/package.out \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_80 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90c 
+// RUN: clang-offload-packager %t/package.out \
+// RUN:   --image=file=%t/sm_70.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
+// RUN:   --image=file=%t/gfx908.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908
+// RUN: diff %t/sm_70.o %t/elf.o
+// RUN: diff %t/gfx908.o %t/elf.o
 
 // Check that we generate a new name if one is not given
-// RUN: clang-offload-packager -o %t \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_80 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a \
-// RUN:   --image=file=%t.elf.o,kind=hip,triple=amdgcn-amd-amdhsa,arch=gfx90c 
-// RUN: cd $(dirname "%t") && clang-offload-packager %t --image=kind=openmp
-// RUN: diff *-nvptx64-nvidia-cuda-sm_70.0.o %t.elf.o; rm *-nvptx64-nvidia-cuda-sm_70.0.o
-// RUN: diff *-nvptx64-nvidia-cuda-sm_80.1.o %t.elf.o; rm *-nvptx64-nvidia-cuda-sm_80.1.o
-// RUN: diff *-amdgcn-amd-amdhsa-gfx908.2.o %t.elf.o; rm *-amdgcn-amd-amdhsa-gfx908.2.o
-// RUN: diff *-amdgcn-amd-amdhsa-gfx90a.3.o %t.elf.o; rm *-amdgcn-amd-amdhsa-gfx90a.3.o
-// RUN: not diff *-amdgcn-amd-amdhsa-gfx90c.4.o %t.elf.o
+// RUN: clang-offload-packager -o %t/package \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_80 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a \
+// RUN:   --image=file=%t/elf.o,kind=hip,triple=amdgcn-amd-amdhsa,arch=gfx90c 
+// RUN: cd %t && clang-offload-packager %t/package --image=kind=openmp
+// RUN: diff *-nvptx64-nvidia-cuda-sm_70.0.o %t/elf.o; rm *-nvptx64-nvidia-cuda-sm_70.0.o
+// RUN: diff *-nvptx64-nvidia-cuda-sm_80.1.o %t/elf.o; rm *-nvptx64-nvidia-cuda-sm_80.1.o
+// RUN: diff *-amdgcn-amd-amdhsa-gfx908.2.o %t/elf.o; rm *-amdgcn-amd-amdhsa-gfx908.2.o
+// RUN: diff *-amdgcn-amd-amdhsa-gfx90a.3.o %t/elf.o; rm *-amdgcn-amd-amdhsa-gfx90a.3.o
+// RUN: not diff *-amdgcn-amd-amdhsa-gfx90c.4.o %t/elf.o
 
 // Check that we can extract from an ELF object file
-// RUN: clang-offload-packager -o %t.out \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70
-// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o -fembed-offload-object=%t.out
-// RUN: clang-offload-packager %t.out \
-// RUN:   --image=file=%t-sm_70.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
-// RUN:   --image=file=%t-gfx908.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908
-// RUN: diff %t-sm_70.o %t.elf.o
-// RUN: diff %t-gfx908.o %t.elf.o
+// RUN: clang-offload-packager -o %t/package.out \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t/package.o -fembed-offload-object=%t/package.out
+// RUN: clang-offload-packager %t/package.out \
+// RUN:   --image=file=%t/sm_70.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
+// RUN:   --image=file=%t/gfx908.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908
+// RUN: diff %t/sm_70.o %t/elf.o
+// RUN: diff %t/gfx908.o %t/elf.o
 
 // Check that we can extract from a bitcode file
-// RUN: clang-offload-packager -o %t.out \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70
-// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-llvm -o %t.bc -fembed-offload-object=%t.out
-// RUN: clang-offload-packager %t.out \
-// RUN:   --image=file=%t-sm_70.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
-// RUN:   --image=file=%t-gfx908.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908
-// RUN: diff %t-sm_70.o %t.elf.o
-// RUN: diff %t-gfx908.o %t.elf.o
+// RUN: clang-offload-packager -o %t/package.out \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-llvm -o %t/package.bc -fembed-offload-object=%t/package.out
+// RUN: clang-offload-packager %t/package.out \
+// RUN:   --image=file=%t/sm_70.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
+// RUN:   --image=file=%t/gfx908.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908
+// RUN: diff %t/sm_70.o %t/elf.o
+// RUN: diff %t/gfx908.o %t/elf.o
 
 // Check that we can extract from an archive file to an archive file.
-// RUN: clang-offload-packager -o %t.out \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
-// RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70
-// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o -fembed-offload-object=%t.out
-// RUN: llvm-ar rcs %t.a %t.o
-// RUN: clang-offload-packager %t.a --archive --image=file=%t-gfx908.a,arch=gfx908
-// RUN: llvm-ar t %t-gfx908.a 2>&1 | FileCheck %s
+// RUN: clang-offload-packager -o %t/package.out \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908 \
+// RUN:   --image=file=%t/elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t/package.o -fembed-offload-object=%t/package.out
+// RUN: llvm-ar rcs %t/package.a %t/package.o
+// RUN: clang-offload-packager %t/package.a --archive --image=file=%t/gfx908.a,arch=gfx908
+// RUN: llvm-ar t %t/gfx908.a 2>&1 | FileCheck %s
 // CHECK: {{.*}}.o

--- a/compiler-rt/test/hwasan/TestCases/hwasan_symbolize.cpp
+++ b/compiler-rt/test/hwasan/TestCases/hwasan_symbolize.cpp
@@ -1,8 +1,9 @@
-// RUN: %clang_hwasan -Wl,--build-id -g %s -o %t
-// RUN: echo '[{"prefix": "'"$(realpath $(dirname %s))"'/", "link": "http://test.invalid/{file}:{line}"}]' > %t.linkify
-// RUN: %env_hwasan_opts=symbolize=0 not %run %t 2>&1 | hwasan_symbolize --html --symbols $(dirname %t) --index | FileCheck %s
-// RUN: %env_hwasan_opts=symbolize=0 not %run %t 2>&1 | hwasan_symbolize --html --linkify %t.linkify --symbols $(dirname %t) --index | FileCheck --check-prefixes=CHECK,LINKIFY %s
-// RUN: %env_hwasan_opts=symbolize=0 not %run %t 2>&1 | hwasan_symbolize --symbols $(dirname %t) --index | FileCheck %s
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_hwasan -Wl,--build-id -g %s -o %t/symbolize.exe
+// RUN: echo '[{"prefix": "'"%S"'/", "link": "http://test.invalid/{file}:{line}"}]' > %t/symbolize.exe.linkify
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/symbolize.exe 2>&1 | hwasan_symbolize --html --symbols %t --index | FileCheck %s
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/symbolize.exe 2>&1 | hwasan_symbolize --html --linkify %t/symbolize.exe.linkify --symbols %t --index | FileCheck --check-prefixes=CHECK,LINKIFY %s
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/symbolize.exe 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s
 
 #include <sanitizer/hwasan_interface.h>
 #include <stdlib.h>

--- a/compiler-rt/test/hwasan/TestCases/hwasan_symbolize.cpp
+++ b/compiler-rt/test/hwasan/TestCases/hwasan_symbolize.cpp
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang_hwasan -Wl,--build-id -g %s -o %t/symbolize.exe
-// RUN: echo '[{"prefix": "'"%S"'/", "link": "http://test.invalid/{file}:{line}"}]' > %t/symbolize.exe.linkify
-// RUN: %env_hwasan_opts=symbolize=0 not %run %t/symbolize.exe 2>&1 | hwasan_symbolize --html --symbols %t --index | FileCheck %s
-// RUN: %env_hwasan_opts=symbolize=0 not %run %t/symbolize.exe 2>&1 | hwasan_symbolize --html --linkify %t/symbolize.exe.linkify --symbols %t --index | FileCheck --check-prefixes=CHECK,LINKIFY %s
-// RUN: %env_hwasan_opts=symbolize=0 not %run %t/symbolize.exe 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s
+// RUN: %clang_hwasan -Wl,--build-id -g %s -o %t/hwasan_symbolize_test
+// RUN: echo '[{"prefix": "'"%S"'/", "link": "http://test.invalid/{file}:{line}"}]' > %t/hwasan_symbolize_test.linkify
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_symbolize_test 2>&1 | hwasan_symbolize --html --symbols %t --index | FileCheck %s
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_symbolize_test 2>&1 | hwasan_symbolize --html --linkify %t/hwasan_symbolize_test.linkify --symbols %t --index | FileCheck --check-prefixes=CHECK,LINKIFY %s
+// RUN: %env_hwasan_opts=symbolize=0 not %run %t/hwasan_symbolize_test 2>&1 | hwasan_symbolize --symbols %t --index | FileCheck %s
 
 #include <sanitizer/hwasan_interface.h>
 #include <stdlib.h>


### PR DESCRIPTION
This patch rewrites tests in clang and compiler-rt that uses bash command substitution syntax $() to execute the dirname command. This is done so that the tests can be run using lit's internal shell.

Fixes https://github.com/llvm/llvm-project/issues/102384.