### PR TITLE
[lit] Export env vars in script to avoid pruning

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1227,9 +1227,13 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
         if test.config.pipefail:
             f.write(b"set -o pipefail;" if mode == "wb" else "set -o pipefail;")
 
+        # Manually export any DYLD_* variables used by dyld on macOS because
+        # otherwise they are lost when the shell executable is run, before the
+        # lit test is executed.
         env_str = "\n".join(
             "export {}={};".format(k, shlex.quote(v))
             for k, v in test.config.environment.items()
+            if k.startswith("DYLD_")
         )
         f.write(bytes(env_str, "utf-8") if mode == "wb" else env_str)
         f.write(b"set -x;" if mode == "wb" else "set -x;")

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1227,8 +1227,10 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
         if test.config.pipefail:
             f.write(b"set -o pipefail;" if mode == "wb" else "set -o pipefail;")
 
-        env_str = "\n".join("export {}={};".format(k, shlex.quote(v))
-                            for k, v in test.config.environment.items())
+        env_str = "\n".join(
+            "export {}={};".format(k, shlex.quote(v))
+            for k, v in test.config.environment.items()
+        )
         f.write(bytes(env_str, "utf-8") if mode == "wb" else env_str)
         f.write(b"set -x;" if mode == "wb" else "set -x;")
 

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1226,11 +1226,11 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
                     commands[i] += f" && {{ {command}; }}"
         if test.config.pipefail:
             f.write(b"set -o pipefail;" if mode == "wb" else "set -o pipefail;")
-        f.write(b"set -x;" if mode == "wb" else "set -x;")
 
         env_str = "\n".join("export {}={};".format(k, shlex.quote(v))
                             for k, v in test.config.environment.items())
         f.write(bytes(env_str, "utf-8") if mode == "wb" else env_str)
+        f.write(b"set -x;" if mode == "wb" else "set -x;")
 
         if sys.version_info > (3, 0) and mode == "wb":
             f.write(bytes("{ " + "; } &&\n{ ".join(commands) + "; }", "utf-8"))

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1237,7 +1237,6 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
         )
         f.write(bytes(env_str, "utf-8") if mode == "wb" else env_str)
         f.write(b"set -x;" if mode == "wb" else "set -x;")
-
         if sys.version_info > (3, 0) and mode == "wb":
             f.write(bytes("{ " + "; } &&\n{ ".join(commands) + "; }", "utf-8"))
         else:

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1227,6 +1227,11 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
         if test.config.pipefail:
             f.write(b"set -o pipefail;" if mode == "wb" else "set -o pipefail;")
         f.write(b"set -x;" if mode == "wb" else "set -x;")
+
+        env_str = "\n".join("export {}={};".format(k, shlex.quote(v))
+                            for k, v in test.config.environment.items())
+        f.write(bytes(env_str, "utf-8") if mode == "wb" else env_str)
+
         if sys.version_info > (3, 0) and mode == "wb":
             f.write(bytes("{ " + "; } &&\n{ ".join(commands) + "; }", "utf-8"))
         else:


### PR DESCRIPTION
On macOS the dynamic loader prunes dyld specific environment variables such as `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, etc. If these are set in the lit config it's safe to assume that the user actually wanted their subprocesses to run with these variables, versus the python interpreter that gets executed with them before they are pruned. This change exports all known variables in the shell script instead of relying on them being passed through.