### PR TITLE
[NFC][TableGen] Refactor JSON and detailed record emitter

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -2328,8 +2328,8 @@ public:
   Init *resolve(Init *VarName) override;
 };
 
-void EmitDetailedRecords(RecordKeeper &RK, raw_ostream &OS);
-void EmitJSON(RecordKeeper &RK, raw_ostream &OS);
+void EmitDetailedRecords(const RecordKeeper &RK, raw_ostream &OS);
+void EmitJSON(const RecordKeeper &RK, raw_ostream &OS);
 
 } // end namespace llvm
 

--- a/llvm/lib/TableGen/DetailedRecordsBackend.cpp
+++ b/llvm/lib/TableGen/DetailedRecordsBackend.cpp
@@ -21,14 +21,8 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
-#include <map>
-#include <memory>
 #include <string>
 #include <utility>
-
-#define DEBUG_TYPE "detailed-records-backend"
-
-#define NL "\n"
 
 using namespace llvm;
 
@@ -36,21 +30,21 @@ namespace {
 
 class DetailedRecordsEmitter {
 private:
-  RecordKeeper &Records;
+  const RecordKeeper &Records;
 
 public:
-  DetailedRecordsEmitter(RecordKeeper &RK) : Records(RK) {}
+  explicit DetailedRecordsEmitter(const RecordKeeper &RK) : Records(RK) {}
 
   void run(raw_ostream &OS);
   void printReportHeading(raw_ostream &OS);
+  void printSectionHeading(StringRef Title, int Count, raw_ostream &OS);
   void printVariables(raw_ostream &OS);
   void printClasses(raw_ostream &OS);
   void printRecords(raw_ostream &OS);
-  void printSectionHeading(StringRef Title, int Count, raw_ostream &OS);
-  void printDefms(Record *Rec, raw_ostream &OS);
-  void printTemplateArgs(Record *Rec, raw_ostream &OS);
-  void printSuperclasses(Record *Rec, raw_ostream &OS);
-  void printFields(Record *Rec, raw_ostream &OS);
+  void printDefms(const Record &Rec, raw_ostream &OS);
+  void printTemplateArgs(const Record &Rec, raw_ostream &OS);
+  void printSuperclasses(const Record &Rec, raw_ostream &OS);
+  void printFields(const Record &Rec, raw_ostream &OS);
 }; // emitter class
 
 } // anonymous namespace
@@ -68,15 +62,21 @@ void DetailedRecordsEmitter::printReportHeading(raw_ostream &OS) {
   OS << formatv("DETAILED RECORDS for file {0}\n", Records.getInputFilename());
 }
 
+// Print a section heading with the name of the section and
+// the item count.
+void DetailedRecordsEmitter::printSectionHeading(StringRef Title, int Count,
+                                                 raw_ostream &OS) {
+  OS << formatv("\n{0} {1} ({2}) {0}\n", "--------------------", Title, Count);
+}
+
 // Print the global variables.
 void DetailedRecordsEmitter::printVariables(raw_ostream &OS) {
   const auto GlobalList = Records.getGlobals();
   printSectionHeading("Global Variables", GlobalList.size(), OS);
 
-  OS << NL;
-  for (const auto &Var : GlobalList) {
-    OS << Var.first << " = " << Var.second->getAsString() << NL;
-  }
+  OS << '\n';
+  for (const auto &Var : GlobalList)
+    OS << Var.first << " = " << Var.second->getAsString() << '\n';
 }
 
 // Print the classes, including the template arguments, superclasses,
@@ -85,13 +85,12 @@ void DetailedRecordsEmitter::printClasses(raw_ostream &OS) {
   const auto &ClassList = Records.getClasses();
   printSectionHeading("Classes", ClassList.size(), OS);
 
-  for (const auto &ClassPair : ClassList) {
-    auto *const Class = ClassPair.second.get();
+  for (const auto &[Name, Class] : ClassList) {
     OS << formatv("\n{0}  |{1}|\n", Class->getNameInitAsString(),
                   SrcMgr.getFormattedLocationNoOffset(Class->getLoc().front()));
-    printTemplateArgs(Class, OS);
-    printSuperclasses(Class, OS);
-    printFields(Class, OS);
+    printTemplateArgs(*Class, OS);
+    printSuperclasses(*Class, OS);
+    printFields(*Class, OS);
   }
 }
 
@@ -101,42 +100,33 @@ void DetailedRecordsEmitter::printRecords(raw_ostream &OS) {
   const auto &RecordList = Records.getDefs();
   printSectionHeading("Records", RecordList.size(), OS);
 
-  for (const auto &RecPair : RecordList) {
-    auto *const Rec = RecPair.second.get();
+  for (const auto &[DefName, Rec] : RecordList) {
     std::string Name = Rec->getNameInitAsString();
     OS << formatv("\n{0}  |{1}|\n", Name.empty() ? "\"\"" : Name,
                   SrcMgr.getFormattedLocationNoOffset(Rec->getLoc().front()));
-    printDefms(Rec, OS);
-    printSuperclasses(Rec, OS);
-    printFields(Rec, OS);
+    printDefms(*Rec, OS);
+    printSuperclasses(*Rec, OS);
+    printFields(*Rec, OS);
   }
-}
-
-// Print a section heading with the name of the section and
-// the item count.
-void DetailedRecordsEmitter::printSectionHeading(StringRef Title, int Count,
-                                                 raw_ostream &OS) {
-  OS << formatv("\n{0} {1} ({2}) {0}\n", "--------------------", Title, Count);
 }
 
 // Print the record's defm source locations, if any. Note that they
 // are stored in the reverse order of their invocation.
-void DetailedRecordsEmitter::printDefms(Record *Rec, raw_ostream &OS) {
-  const auto &LocList = Rec->getLoc();
+void DetailedRecordsEmitter::printDefms(const Record &Rec, raw_ostream &OS) {
+  const auto &LocList = Rec.getLoc();
   if (LocList.size() < 2)
     return;
 
   OS << "  Defm sequence:";
-  for (unsigned I = LocList.size() - 1; I >= 1; --I) {
-    OS << formatv(" |{0}|", SrcMgr.getFormattedLocationNoOffset(LocList[I]));
-  }
-  OS << NL;
+  for (const SMLoc Loc : reverse(LocList))
+    OS << formatv(" |{0}|", SrcMgr.getFormattedLocationNoOffset(Loc));
+  OS << '\n';
 }
 
 // Print the template arguments of a class.
-void DetailedRecordsEmitter::printTemplateArgs(Record *Rec,
+void DetailedRecordsEmitter::printTemplateArgs(const Record &Rec,
                                                raw_ostream &OS) {
-  ArrayRef<Init *> Args = Rec->getTemplateArgs();
+  ArrayRef<Init *> Args = Rec.getTemplateArgs();
   if (Args.empty()) {
     OS << "  Template args: (none)\n";
     return;
@@ -144,38 +134,38 @@ void DetailedRecordsEmitter::printTemplateArgs(Record *Rec,
 
   OS << "  Template args:\n";
   for (const Init *ArgName : Args) {
-    const RecordVal *Value = Rec->getValue(ArgName);
+    const RecordVal *Value = Rec.getValue(ArgName);
     assert(Value && "Template argument value not found.");
     OS << "    ";
     Value->print(OS, false);
-    OS << formatv("  |{0}|", SrcMgr.getFormattedLocationNoOffset(Value->getLoc()));
-    OS << NL;
+    OS << formatv("  |{0}|\n",
+                  SrcMgr.getFormattedLocationNoOffset(Value->getLoc()));
   }
 }
 
 // Print the superclasses of a class or record. Indirect superclasses
 // are enclosed in parentheses.
-void DetailedRecordsEmitter::printSuperclasses(Record *Rec, raw_ostream &OS) {
-  ArrayRef<std::pair<Record *, SMRange>> Superclasses = Rec->getSuperClasses();
+void DetailedRecordsEmitter::printSuperclasses(const Record &Rec,
+                                               raw_ostream &OS) {
+  ArrayRef<std::pair<Record *, SMRange>> Superclasses = Rec.getSuperClasses();
   if (Superclasses.empty()) {
     OS << "  Superclasses: (none)\n";
     return;
   }
 
   OS << "  Superclasses:";
-  for (const auto &SuperclassPair : Superclasses) {
-    auto *ClassRec = SuperclassPair.first;
-    if (Rec->hasDirectSuperClass(ClassRec))
+  for (const auto &[ClassRec, Loc] : Superclasses) {
+    if (Rec.hasDirectSuperClass(ClassRec))
       OS << formatv(" {0}", ClassRec->getNameInitAsString());
     else
       OS << formatv(" ({0})", ClassRec->getNameInitAsString());
   }
-  OS << NL;
+  OS << '\n';
 }
 
 // Print the fields of a class or record, including their source locations.
-void DetailedRecordsEmitter::printFields(Record *Rec, raw_ostream &OS) {
-  const auto &ValueList = Rec->getValues();
+void DetailedRecordsEmitter::printFields(const Record &Rec, raw_ostream &OS) {
+  const auto &ValueList = Rec.getValues();
   if (ValueList.empty()) {
     OS << "  Fields: (none)\n";
     return;
@@ -183,7 +173,7 @@ void DetailedRecordsEmitter::printFields(Record *Rec, raw_ostream &OS) {
 
   OS << "  Fields:\n";
   for (const RecordVal &Value : ValueList)
-    if (!Rec->isTemplateArg(Value.getNameInit())) {
+    if (!Rec.isTemplateArg(Value.getNameInit())) {
       OS << "    ";
       Value.print(OS, false);
       OS << formatv("  |{0}|\n",
@@ -191,13 +181,8 @@ void DetailedRecordsEmitter::printFields(Record *Rec, raw_ostream &OS) {
     }
 }
 
-namespace llvm {
-
 // This function is called by TableGen after parsing the files.
-
-void EmitDetailedRecords(RecordKeeper &RK, raw_ostream &OS) {
+void llvm::EmitDetailedRecords(const RecordKeeper &RK, raw_ostream &OS) {
   // Instantiate the emitter class and invoke run().
   DetailedRecordsEmitter(RK).run(OS);
 }
-
-} // namespace llvm

--- a/llvm/lib/TableGen/JSONBackend.cpp
+++ b/llvm/lib/TableGen/JSONBackend.cpp
@@ -26,43 +26,41 @@ namespace {
 
 class JSONEmitter {
 private:
-  RecordKeeper &Records;
+  const RecordKeeper &Records;
 
   json::Value translateInit(const Init &I);
 
 public:
-  JSONEmitter(RecordKeeper &R);
+  explicit JSONEmitter(const RecordKeeper &R) : Records(R) {}
 
   void run(raw_ostream &OS);
 };
 
 } // end anonymous namespace
 
-JSONEmitter::JSONEmitter(RecordKeeper &R) : Records(R) {}
-
 json::Value JSONEmitter::translateInit(const Init &I) {
-
   // Init subclasses that we return as JSON primitive values of one
   // kind or another.
 
-  if (isa<UnsetInit>(&I)) {
+  if (isa<UnsetInit>(&I))
     return nullptr;
-  } else if (auto *Bit = dyn_cast<BitInit>(&I)) {
+  if (const auto *Bit = dyn_cast<BitInit>(&I))
     return Bit->getValue() ? 1 : 0;
-  } else if (auto *Bits = dyn_cast<BitsInit>(&I)) {
-    json::Array array;
-    for (unsigned i = 0, limit = Bits->getNumBits(); i < limit; i++)
-      array.push_back(translateInit(*Bits->getBit(i)));
-    return std::move(array);
-  } else if (auto *Int = dyn_cast<IntInit>(&I)) {
+  if (const auto *Bits = dyn_cast<BitsInit>(&I)) {
+    json::Array Array;
+    for (unsigned Idx = 0, E = Bits->getNumBits(); Idx < E; ++Idx)
+      Array.push_back(translateInit(*Bits->getBit(Idx)));
+    return std::move(Array);
+  }
+  if (const auto *Int = dyn_cast<IntInit>(&I))
     return Int->getValue();
-  } else if (auto *Str = dyn_cast<StringInit>(&I)) {
+  if (const auto *Str = dyn_cast<StringInit>(&I))
     return Str->getValue();
-  } else if (auto *List = dyn_cast<ListInit>(&I)) {
-    json::Array array;
-    for (auto *val : *List)
-      array.push_back(translateInit(*val));
-    return std::move(array);
+  if (const auto *List = dyn_cast<ListInit>(&I)) {
+    json::Array Array;
+    for (const auto *Val : *List)
+      Array.push_back(translateInit(*Val));
+    return std::move(Array);
   }
 
   // Init subclasses that we return as JSON objects containing a
@@ -70,56 +68,58 @@ json::Value JSONEmitter::translateInit(const Init &I) {
   // translation back into TableGen input syntax that -print-records
   // would give.
 
-  json::Object obj;
-  obj["printable"] = I.getAsString();
+  json::Object Obj;
+  Obj["printable"] = I.getAsString();
 
-  if (auto *Def = dyn_cast<DefInit>(&I)) {
-    obj["kind"] = "def";
-    obj["def"] = Def->getDef()->getName();
-    return std::move(obj);
-  } else if (auto *Var = dyn_cast<VarInit>(&I)) {
-    obj["kind"] = "var";
-    obj["var"] = Var->getName();
-    return std::move(obj);
-  } else if (auto *VarBit = dyn_cast<VarBitInit>(&I)) {
-    if (auto *Var = dyn_cast<VarInit>(VarBit->getBitVar())) {
-      obj["kind"] = "varbit";
-      obj["var"] = Var->getName();
-      obj["index"] = VarBit->getBitNum();
-      return std::move(obj);
+  if (const auto *Def = dyn_cast<DefInit>(&I)) {
+    Obj["kind"] = "def";
+    Obj["def"] = Def->getDef()->getName();
+    return std::move(Obj);
+  }
+  if (const auto *Var = dyn_cast<VarInit>(&I)) {
+    Obj["kind"] = "var";
+    Obj["var"] = Var->getName();
+    return std::move(Obj);
+  }
+  if (const auto *VarBit = dyn_cast<VarBitInit>(&I)) {
+    if (const auto *Var = dyn_cast<VarInit>(VarBit->getBitVar())) {
+      Obj["kind"] = "varbit";
+      Obj["var"] = Var->getName();
+      Obj["index"] = VarBit->getBitNum();
+      return std::move(Obj);
     }
-  } else if (auto *Dag = dyn_cast<DagInit>(&I)) {
-    obj["kind"] = "dag";
-    obj["operator"] = translateInit(*Dag->getOperator());
+  }
+  if (const auto *Dag = dyn_cast<DagInit>(&I)) {
+    Obj["kind"] = "dag";
+    Obj["operator"] = translateInit(*Dag->getOperator());
     if (auto name = Dag->getName())
-      obj["name"] = name->getAsUnquotedString();
-    json::Array args;
-    for (unsigned i = 0, limit = Dag->getNumArgs(); i < limit; ++i) {
-      json::Array arg;
-      arg.push_back(translateInit(*Dag->getArg(i)));
-      if (auto argname = Dag->getArgName(i))
-        arg.push_back(argname->getAsUnquotedString());
+      Obj["name"] = name->getAsUnquotedString();
+    json::Array Args;
+    for (unsigned Idx = 0, E = Dag->getNumArgs(); Idx < E; ++Idx) {
+      json::Array Arg;
+      Arg.push_back(translateInit(*Dag->getArg(Idx)));
+      if (const auto ArgName = Dag->getArgName(Idx))
+        Arg.push_back(ArgName->getAsUnquotedString());
       else
-        arg.push_back(nullptr);
-      args.push_back(std::move(arg));
+        Arg.push_back(nullptr);
+      Args.push_back(std::move(Arg));
     }
-    obj["args"] = std::move(args);
-    return std::move(obj);
+    Obj["args"] = std::move(Args);
+    return std::move(Obj);
   }
 
   // Final fallback: anything that gets past here is simply given a
   // kind field of 'complex', and the only other field is the standard
   // 'printable' representation.
-
   assert(!I.isConcrete());
-  obj["kind"] = "complex";
-  return std::move(obj);
+  Obj["kind"] = "complex";
+  return std::move(Obj);
 }
 
 void JSONEmitter::run(raw_ostream &OS) {
-  json::Object root;
+  json::Object Root;
 
-  root["!tablegen_json_version"] = 1;
+  Root["!tablegen_json_version"] = 1;
 
   // Prepare the arrays that will list the instances of every class.
   // We mostly fill those in by iterating over the superclasses of
@@ -127,64 +127,59 @@ void JSONEmitter::run(raw_ostream &OS) {
   // class with no instances at all, so we do a preliminary iteration
   // over the classes, invoking std::map::operator[] to default-
   // construct the array for each one.
-  std::map<std::string, json::Array> instance_lists;
-  for (const auto &C : Records.getClasses()) {
-    const auto Name = C.second->getNameInitAsString();
-    (void)instance_lists[Name];
-  }
+  std::map<std::string, json::Array> InstanceLists;
+  for (const auto &[ClassName, ClassRec] : Records.getClasses())
+    InstanceLists.emplace(ClassRec->getNameInitAsString(), json::Array());
 
   // Main iteration over the defs.
-  for (const auto &D : Records.getDefs()) {
-    const auto Name = D.second->getNameInitAsString();
-    auto &Def = *D.second;
+  for (const auto &[DefName, Def] : Records.getDefs()) {
+    const std::string Name = Def->getNameInitAsString();
 
-    json::Object obj;
-    json::Array fields;
+    json::Object Obj;
+    json::Array Fields;
 
-    for (const RecordVal &RV : Def.getValues()) {
-      if (!Def.isTemplateArg(RV.getNameInit())) {
+    for (const RecordVal &RV : Def->getValues()) {
+      if (!Def->isTemplateArg(RV.getNameInit())) {
         auto Name = RV.getNameInitAsString();
         if (RV.isNonconcreteOK())
-          fields.push_back(Name);
-        obj[Name] = translateInit(*RV.getValue());
+          Fields.push_back(Name);
+        Obj[Name] = translateInit(*RV.getValue());
       }
     }
 
-    obj["!fields"] = std::move(fields);
+    Obj["!fields"] = std::move(Fields);
 
-    json::Array superclasses;
-    for (const auto &SuperPair : Def.getSuperClasses())
-      superclasses.push_back(SuperPair.first->getNameInitAsString());
-    obj["!superclasses"] = std::move(superclasses);
-
-    obj["!name"] = Name;
-    obj["!anonymous"] = Def.isAnonymous();
-
-    json::Array locs;
-    for (const SMLoc Loc : Def.getLoc())
-      locs.push_back(SrcMgr.getFormattedLocationNoOffset(Loc));
-    obj["!locs"] = std::move(locs);
-
-    root[Name] = std::move(obj);
-
+    json::Array SuperClasses;
     // Add this def to the instance list for each of its superclasses.
-    for (const auto &SuperPair : Def.getSuperClasses()) {
-      auto SuperName = SuperPair.first->getNameInitAsString();
-      instance_lists[SuperName].push_back(Name);
+    for (const auto &[SuperClass, Loc] : Def->getSuperClasses()) {
+      std::string SuperName = SuperClass->getNameInitAsString();
+      SuperClasses.push_back(SuperName);
+      InstanceLists[SuperName].push_back(Name);
     }
+
+    Obj["!superclasses"] = std::move(SuperClasses);
+
+    Obj["!name"] = Name;
+    Obj["!anonymous"] = Def->isAnonymous();
+
+    json::Array Locs;
+    for (const SMLoc Loc : Def->getLoc())
+      Locs.push_back(SrcMgr.getFormattedLocationNoOffset(Loc));
+    Obj["!locs"] = std::move(Locs);
+
+    Root[Name] = std::move(Obj);
   }
 
   // Make a JSON object from the std::map of instance lists.
-  json::Object instanceof;
-  for (auto kv: instance_lists)
-    instanceof[kv.first] = std::move(kv.second);
-  root["!instanceof"] = std::move(instanceof);
+  json::Object InstanceOf;
+  for (auto &[ClassName, Instances] : InstanceLists)
+    InstanceOf[ClassName] = std::move(Instances);
+  Root["!instanceof"] = std::move(InstanceOf);
 
   // Done. Write the output.
-  OS << json::Value(std::move(root)) << "\n";
+  OS << json::Value(std::move(Root)) << "\n";
 }
 
-namespace llvm {
-
-void EmitJSON(RecordKeeper &RK, raw_ostream &OS) { JSONEmitter(RK).run(OS); }
-} // end namespace llvm
+void llvm::EmitJSON(const RecordKeeper &RK, raw_ostream &OS) {
+  JSONEmitter(RK).run(OS);
+}


### PR DESCRIPTION
- Fix JSON and detailed record emitters to use const reference and pointers.
- Fix code to use C++ structured bindings and range based loops, include reverse() range for locations.
- Eliminate `NL` define for "\n".
- Change JSON emitter to populate `instance_list` in an earlier loop over superclasses instead of a separate loop.
- Rename variables in JSON emitter to conform to LLVM naming conventions.
- Eliminate unused headers in detailed record emitter.