### PR TITLE
[PS5][clang][test] x86_64-scei-ps5 -> x86_64-sie-ps5 in tests

### DIFF
--- a/clang/test/CodeGen/tls-maxalign-modflag.c
+++ b/clang/test/CodeGen/tls-maxalign-modflag.c
@@ -2,7 +2,7 @@
 
 // Test that we get the module flag TLSMaxAlign on the PS platforms.
 // RUN: %clang_cc1 -triple x86_64-scei-ps4 -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-scei-ps5 -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-sie-ps5 -emit-llvm -o - %s | FileCheck %s
 
 int main(void) {
   return 0;

--- a/clang/test/CodeGenCXX/windows-itanium-init-guard.cpp
+++ b/clang/test/CodeGenCXX/windows-itanium-init-guard.cpp
@@ -11,9 +11,9 @@
 // RUN: %clang_cc1 -emit-llvm -triple x86_64-scei-ps4 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI="__declspec(dllexport)" | FileCheck %s --check-prefixes=EXPORT
 // RUN: %clang_cc1 -emit-llvm -triple x86_64-scei-ps4 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI="__declspec(dllimport)" | FileCheck %s --check-prefixes=IMPORT
 
-// RUN: %clang_cc1 -emit-llvm -triple x86_64-scei-ps5 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI= | FileCheck %s --check-prefixes=NONE
-// RUN: %clang_cc1 -emit-llvm -triple x86_64-scei-ps5 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI="__declspec(dllexport)" | FileCheck %s --check-prefixes=EXPORT
-// RUN: %clang_cc1 -emit-llvm -triple x86_64-scei-ps5 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI="__declspec(dllimport)" | FileCheck %s --check-prefixes=IMPORT
+// RUN: %clang_cc1 -emit-llvm -triple x86_64-sie-ps5 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI= | FileCheck %s --check-prefixes=NONE
+// RUN: %clang_cc1 -emit-llvm -triple x86_64-sie-ps5 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI="__declspec(dllexport)" | FileCheck %s --check-prefixes=EXPORT
+// RUN: %clang_cc1 -emit-llvm -triple x86_64-sie-ps5 -fdeclspec %s -O1 -disable-llvm-passes -o - -DAPI="__declspec(dllimport)" | FileCheck %s --check-prefixes=IMPORT
 
 //NONE: @_ZZN3foo3GetEvE9Singleton = linkonce_odr {{(dso_local )?}}global
 //NONE: @_ZGVZN3foo3GetEvE9Singleton = linkonce_odr {{(dso_local )?}}global

--- a/clang/test/Driver/debug-options.c
+++ b/clang/test/Driver/debug-options.c
@@ -138,9 +138,9 @@
 // RUN:             | FileCheck -check-prefix=LDGARANGE %s
 // RUN: %clang -### %s -g -flto=full -target x86_64-scei-ps4 2>&1 \
 // RUN:             | FileCheck -check-prefix=LDGARANGE %s
-// RUN: %clang -### %s -g -flto -target x86_64-scei-ps5 2>&1 \
+// RUN: %clang -### %s -g -flto -target x86_64-sie-ps5 2>&1 \
 // RUN:             | FileCheck -check-prefix=LDGARANGE %s
-// RUN: %clang -### %s -g -target x86_64-scei-ps5 2>&1 \
+// RUN: %clang -### %s -g -target x86_64-sie-ps5 2>&1 \
 // RUN:             | FileCheck -check-prefix=LDGARANGE %s
 
 // On the AIX, -g defaults to limited debug info.

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -1,14 +1,14 @@
 // Test that PIE is the default for main components
 
-// RUN: %clang --target=x86_64-scei-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-PIE %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-PIE %s
 
 // CHECK-PIE: {{ld(\.exe)?}}"
 // CHECK-PIE-SAME: "-pie"
 
-// RUN: %clang --target=x86_64-scei-ps5 -no-pie %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
-// RUN: %clang --target=x86_64-scei-ps5 -r %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
-// RUN: %clang --target=x86_64-scei-ps5 -shared %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE,CHECK-SHARED %s
-// RUN: %clang --target=x86_64-scei-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+// RUN: %clang --target=x86_64-sie-ps5 -no-pie %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+// RUN: %clang --target=x86_64-sie-ps5 -r %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
+// RUN: %clang --target=x86_64-sie-ps5 -shared %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE,CHECK-SHARED %s
+// RUN: %clang --target=x86_64-sie-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-PIE %s
 
 // CHECK-NO-PIE: {{ld(\.exe)?}}"
 // CHECK-NO-PIE-NOT: "-pie"
@@ -16,15 +16,15 @@
 
 // Test that -static is forwarded to the linker
 
-// RUN: %clang --target=x86_64-scei-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s
+// RUN: %clang --target=x86_64-sie-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s
 
 // CHECK-STATIC: {{ld(\.exe)?}}"
 // CHECK-STATIC-SAME: "-static"
 
 // Test the driver's control over the JustMyCode behavior with linker flags.
 
-// RUN: %clang --target=x86_64-scei-ps5 -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-LIB %s
-// RUN: %clang --target=x86_64-scei-ps5 -flto -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-LIB %s
+// RUN: %clang --target=x86_64-sie-ps5 -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-LIB %s
+// RUN: %clang --target=x86_64-sie-ps5 -flto -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-LIB %s
 
 // CHECK: -plugin-opt=-enable-jmc-instrument
 
@@ -33,7 +33,7 @@
 
 // Test the driver's control over the -fcrash-diagnostics-dir behavior with linker flags.
 
-// RUN: %clang --target=x86_64-scei-ps5 -fcrash-diagnostics-dir=mydumps %s -### 2>&1 | FileCheck --check-prefixes=CHECK-DIAG %s
-// RUN: %clang --target=x86_64-scei-ps5 -flto -fcrash-diagnostics-dir=mydumps %s -### 2>&1 | FileCheck --check-prefixes=CHECK-DIAG %s
+// RUN: %clang --target=x86_64-sie-ps5 -fcrash-diagnostics-dir=mydumps %s -### 2>&1 | FileCheck --check-prefixes=CHECK-DIAG %s
+// RUN: %clang --target=x86_64-sie-ps5 -flto -fcrash-diagnostics-dir=mydumps %s -### 2>&1 | FileCheck --check-prefixes=CHECK-DIAG %s
 
 // CHECK-DIAG: -plugin-opt=-crash-diagnostics-dir=mydumps


### PR DESCRIPTION
`x86_64-sie-ps5` is the triple we share with PS5 toolchain users who have reason to care about such things. The vast majority of PS5 checks and tests already use this variant. Quashing the handful of stragglers will help prevent future copy+paste of the discouraged variant.