### PR TITLE
[include-cleaner] Turn new/delete usages to ambiguous references

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -351,11 +351,11 @@ public:
   }
 
   bool VisitCXXNewExpr(CXXNewExpr *E) {
-    report(E->getExprLoc(), E->getOperatorNew());
+    report(E->getExprLoc(), E->getOperatorNew(), RefType::Ambiguous);
     return true;
   }
   bool VisitCXXDeleteExpr(CXXDeleteExpr *E) {
-    report(E->getExprLoc(), E->getOperatorDelete());
+    report(E->getExprLoc(), E->getOperatorDelete(), RefType::Ambiguous);
     return true;
   }
 };

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -557,9 +557,9 @@ TEST(WalkAST, FriendDecl) {
 }
 
 TEST(WalkAST, OperatorNewDelete) {
-  testWalk("void* $explicit^operator new(decltype(sizeof(int)), void*);",
+  testWalk("void* $ambiguous^operator new(decltype(sizeof(int)), void*);",
            "struct Bar { void foo() { Bar b; ^new (&b) Bar; } };");
-  testWalk("struct A { static void $explicit^operator delete(void*); };",
+  testWalk("struct A { static void $ambiguous^operator delete(void*); };",
            "void foo() { A a; ^delete &a; }");
 }
 } // namespace


### PR DESCRIPTION
In practice most of these expressions just resolve to implicitly
provided `operator new` and standard says it's not necessary to include
`<new>` for that.
Hence this is resulting in a lot of churn in cases where inclusion of
`<new>` doesn't matter, and might even be undesired by the developer.

By switching to an ambiguous reference we try to find a middle ground
here, ensuring that we don't drop providers of `operator new` when the
developer explicitly listed them in the includes, and chose to believe
it's the implicitly provided `operator new` and don't insert an include
in other cases.
