### PR TITLE
[flang] Support read-only access to an anonymous unit

### DIFF
--- a/flang/runtime/external-unit.cpp
+++ b/flang/runtime/external-unit.cpp
@@ -65,9 +65,13 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
   bool exists{false};
   ExternalFileUnit *result{GetUnitMap().LookUpOrCreate(unit, handler, exists)};
   if (result && !exists) {
+    common::optional<Action> action;
+    if (dir == Direction::Output) {
+      action = Action::ReadWrite;
+    }
     if (!result->OpenAnonymousUnit(
             dir == Direction::Input ? OpenStatus::Unknown : OpenStatus::Replace,
-            Action::ReadWrite, Position::Rewind, Convert::Unknown, handler)) {
+            action, Position::Rewind, Convert::Unknown, handler)) {
       // fort.N isn't a writable file
       if (ExternalFileUnit * closed{LookUpForClose(result->unitNumber())}) {
         closed->DestroyClosed();


### PR DESCRIPTION
Don't require the "fort.123" file implicitly opened by READ(123, ... to be writable.