### PR TITLE
[libc++][string] Remove potential non-trailing 0-length array

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -760,7 +760,7 @@ struct __short_impl {
 
 template <class _CharT, size_t __min_cap>
 struct __short_impl<_CharT, __min_cap, 0> {
-  value_type __data_[__min_cap];
+  _CharT __data_[__min_cap];
   unsigned char __size_    : 7;
   unsigned char __is_long_ : 1;
 };

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -749,40 +749,31 @@ struct __can_be_converted_to_string_view
 struct __uninitialized_size_tag {};
 struct __init_with_sentinel_tag {};
 
-#ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
+template <size_t _PaddingSize>
+struct __padding {
+  char __padding_[_PaddingSize];
+};
+
+template <>
+struct __padding<0> {};
+
 template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
 struct __short_layout_alternate {
   _CharT __data_[__min_cap];
-  unsigned char __padding_[_Padding];
+  _LIBCPP_NO_UNIQUE_ADDRESS __padding<_Padding> __padding_;
   unsigned char __size_    : 7;
   unsigned char __is_long_ : 1;
 };
 
-template <class _CharT, size_t __min_cap>
-struct __short_layout_alternate<_CharT, __min_cap, 0> {
-  _CharT __data_[__min_cap];
-  unsigned char __size_    : 7;
-  unsigned char __is_long_ : 1;
-};
-#else
 template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
 struct __short_layout_classic {
   struct _LIBCPP_PACKED {
     unsigned char __is_long_ : 1;
     unsigned char __size_    : 7;
   };
-  char __padding_[_Padding];
+  _LIBCPP_NO_UNIQUE_ADDRESS __padding<_Padding> __padding_;
   _CharT __data_[__min_cap];
 };
-template <class _CharT, size_t __min_cap>
-struct __short_layout_classic<_CharT, __min_cap, 0> {
-  struct _LIBCPP_PACKED {
-    unsigned char __is_long_ : 1;
-    unsigned char __size_    : 7;
-  };
-  _CharT __data_[__min_cap];
-};
-#endif
 
 template <class _CharT, class _Traits, class _Allocator>
 class basic_string {

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -757,21 +757,21 @@ struct __padding {
 template <>
 struct __padding<0> {};
 
-template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
+template <class _CharT, size_t __min_cap>
 struct __short_layout_alternate {
   _CharT __data_[__min_cap];
-  _LIBCPP_NO_UNIQUE_ADDRESS __padding<_Padding> __padding_;
+  _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(_CharT) - 1> __padding_;
   unsigned char __size_    : 7;
   unsigned char __is_long_ : 1;
 };
 
-template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
+template <class _CharT, size_t __min_cap>
 struct __short_layout_classic {
   struct _LIBCPP_PACKED {
     unsigned char __is_long_ : 1;
     unsigned char __size_    : 7;
   };
-  _LIBCPP_NO_UNIQUE_ADDRESS __padding<_Padding> __padding_;
+  _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(_CharT) - 1> __padding_;
   _CharT __data_[__min_cap];
 };
 

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -859,6 +859,13 @@ private:
 
   enum { __min_cap = (sizeof(__long) - 1) / sizeof(value_type) > 2 ? (sizeof(__long) - 1) / sizeof(value_type) : 2 };
 
+  struct __short {
+    value_type __data_[__min_cap];
+    _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(value_type) - 1> __padding_;
+    unsigned char __size_    : 7;
+    unsigned char __is_long_ : 1;
+  };
+
   // The __endian_factor is required because the field we use to store the size
   // has one fewer bit than it would if it were not a bitfield.
   //
@@ -901,16 +908,6 @@ private:
 
   enum { __min_cap = (sizeof(__long) - 1) / sizeof(value_type) > 2 ? (sizeof(__long) - 1) / sizeof(value_type) : 2 };
 
-#endif // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
-
-#ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
-  struct __short {
-    value_type __data_[__min_cap];
-    _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(value_type) - 1> __padding_;
-    unsigned char __size_    : 7;
-    unsigned char __is_long_ : 1;
-  };
-#else
   struct __short {
     struct _LIBCPP_PACKED {
       unsigned char __is_long_ : 1;
@@ -919,7 +916,9 @@ private:
     _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(value_type) - 1> __padding_;
     value_type __data_[__min_cap];
   };
-#endif
+
+#endif // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
+
   static_assert(sizeof(__short) == (sizeof(value_type) * (__min_cap + 1)), "__short has an unexpected size.");
 
   union __rep {

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -751,7 +751,7 @@ struct __init_with_sentinel_tag {};
 
 #ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
 template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
-struct __short_impl {
+struct __short_layout_alternate {
   _CharT __data_[__min_cap];
   unsigned char __padding_[_Padding];
   unsigned char __size_    : 7;
@@ -759,14 +759,14 @@ struct __short_impl {
 };
 
 template <class _CharT, size_t __min_cap>
-struct __short_impl<_CharT, __min_cap, 0> {
+struct __short_layout_alternate<_CharT, __min_cap, 0> {
   _CharT __data_[__min_cap];
   unsigned char __size_    : 7;
   unsigned char __is_long_ : 1;
 };
 #else
 template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
-struct __short_impl {
+struct __short_layout_classic {
   struct _LIBCPP_PACKED {
     unsigned char __is_long_ : 1;
     unsigned char __size_    : 7;
@@ -775,7 +775,7 @@ struct __short_impl {
   _CharT __data_[__min_cap];
 };
 template <class _CharT, size_t __min_cap>
-struct __short_impl<_CharT, __min_cap, 0> {
+struct __short_layout_classic<_CharT, __min_cap, 0> {
   struct _LIBCPP_PACKED {
     unsigned char __is_long_ : 1;
     unsigned char __size_    : 7;
@@ -930,7 +930,11 @@ private:
 
 #endif // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
 
-  using __short = __short_impl<value_type, __min_cap>;
+#ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
+  using __short = __short_layout_alternate<value_type, __min_cap>;
+#else
+  using __short = __short_layout_classic<value_type, __min_cap>;
+#endif
   static_assert(sizeof(__short) == (sizeof(value_type) * (__min_cap + 1)), "__short has an unexpected size.");
 
   union __rep {

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -757,24 +757,6 @@ struct __padding {
 template <>
 struct __padding<0> {};
 
-template <class _CharT, size_t __min_cap>
-struct __short_layout_alternate {
-  _CharT __data_[__min_cap];
-  _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(_CharT) - 1> __padding_;
-  unsigned char __size_    : 7;
-  unsigned char __is_long_ : 1;
-};
-
-template <class _CharT, size_t __min_cap>
-struct __short_layout_classic {
-  struct _LIBCPP_PACKED {
-    unsigned char __is_long_ : 1;
-    unsigned char __size_    : 7;
-  };
-  _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(_CharT) - 1> __padding_;
-  _CharT __data_[__min_cap];
-};
-
 template <class _CharT, class _Traits, class _Allocator>
 class basic_string {
 private:
@@ -922,9 +904,21 @@ private:
 #endif // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
 
 #ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
-  using __short = __short_layout_alternate<value_type, __min_cap>;
+  struct __short {
+    value_type __data_[__min_cap];
+    _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(value_type) - 1> __padding_;
+    unsigned char __size_    : 7;
+    unsigned char __is_long_ : 1;
+  };
 #else
-  using __short = __short_layout_classic<value_type, __min_cap>;
+  struct __short {
+    struct _LIBCPP_PACKED {
+      unsigned char __is_long_ : 1;
+      unsigned char __size_    : 7;
+    };
+    _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(value_type) - 1> __padding_;
+    value_type __data_[__min_cap];
+  };
 #endif
   static_assert(sizeof(__short) == (sizeof(value_type) * (__min_cap + 1)), "__short has an unexpected size.");
 

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -749,6 +749,41 @@ struct __can_be_converted_to_string_view
 struct __uninitialized_size_tag {};
 struct __init_with_sentinel_tag {};
 
+#ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
+template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
+struct __short_impl {
+  _CharT __data_[__min_cap];
+  unsigned char __padding_[_Padding];
+  unsigned char __size_    : 7;
+  unsigned char __is_long_ : 1;
+};
+
+template <class _CharT, size_t __min_cap>
+struct __short_impl<_CharT, __min_cap, 0> {
+  value_type __data_[__min_cap];
+  unsigned char __size_    : 7;
+  unsigned char __is_long_ : 1;
+};
+#else
+template <class _CharT, size_t __min_cap, size_t _Padding = sizeof(_CharT) - 1>
+struct __short_impl {
+  struct _LIBCPP_PACKED {
+    unsigned char __is_long_ : 1;
+    unsigned char __size_    : 7;
+  };
+  char __padding_[_Padding];
+  _CharT __data_[__min_cap];
+};
+template <class _CharT, size_t __min_cap>
+struct __short_impl<_CharT, __min_cap, 0> {
+  struct _LIBCPP_PACKED {
+    unsigned char __is_long_ : 1;
+    unsigned char __size_    : 7;
+  };
+  _CharT __data_[__min_cap];
+};
+#endif
+
 template <class _CharT, class _Traits, class _Allocator>
 class basic_string {
 private:
@@ -851,13 +886,6 @@ private:
 
   enum { __min_cap = (sizeof(__long) - 1) / sizeof(value_type) > 2 ? (sizeof(__long) - 1) / sizeof(value_type) : 2 };
 
-  struct __short {
-    value_type __data_[__min_cap];
-    unsigned char __padding_[sizeof(value_type) - 1];
-    unsigned char __size_    : 7;
-    unsigned char __is_long_ : 1;
-  };
-
   // The __endian_factor is required because the field we use to store the size
   // has one fewer bit than it would if it were not a bitfield.
   //
@@ -900,17 +928,9 @@ private:
 
   enum { __min_cap = (sizeof(__long) - 1) / sizeof(value_type) > 2 ? (sizeof(__long) - 1) / sizeof(value_type) : 2 };
 
-  struct __short {
-    struct _LIBCPP_PACKED {
-      unsigned char __is_long_ : 1;
-      unsigned char __size_    : 7;
-    };
-    char __padding_[sizeof(value_type) - 1];
-    value_type __data_[__min_cap];
-  };
-
 #endif // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
 
+  using __short = __short_impl<value_type, __min_cap>;
   static_assert(sizeof(__short) == (sizeof(value_type) * (__min_cap + 1)), "__short has an unexpected size.");
 
   union __rep {


### PR DESCRIPTION
It is a violation of the standard to use 0 length arrays, especially when not at the end of a structure (not a FAM GNU extension). Compiler generally accept it, but it's probably better to have a conforming implementation.