### PR TITLE
[flang] Silence warning when inappropriate

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -56,6 +56,10 @@ static void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
         "%VAL argument must be a scalar numeric or logical expression"_err_en_US);
   }
   if (const auto *expr{arg.UnwrapExpr()}) {
+    if (const Symbol * base{GetFirstSymbol(*expr)};
+        base && IsFunctionResult(*base)) {
+      context.NoteDefinedSymbol(*base);
+    }
     if (IsBOZLiteral(*expr)) {
       messages.Say("BOZ argument requires an explicit interface"_err_en_US);
     } else if (evaluate::IsNullPointer(*expr)) {
@@ -78,10 +82,6 @@ static void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
       if (symbol.attrs().test(Attr::VOLATILE)) {
         messages.Say(
             "VOLATILE argument requires an explicit interface"_err_en_US);
-      }
-      if (const Symbol & base{named->GetFirstSymbol()};
-          IsFunctionResult(base)) {
-        context.NoteDefinedSymbol(base);
       }
     } else if (auto argChars{characteristics::DummyArgument::FromActual(
                    "actual argument", *expr, context.foldingContext(),

--- a/flang/test/Semantics/undef-result01.f90
+++ b/flang/test/Semantics/undef-result01.f90
@@ -148,3 +148,8 @@ function defdByAssociate()
     s = 1.
   end associate
 end
+
+function defdByElementArgToImplicit() result(r)
+  real r(1)
+  call define(r(1))
+end


### PR DESCRIPTION
When a function returns an array, using an element of that array is an actual argument in a procedure reference with an implicit interface should suffice to avoid a warning about an undefined function result.