### PR TITLE
[GDBRemote] Fix processing of comma-separated memory region entries

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1632,17 +1632,9 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
             }
           }
         } else if (name == "type") {
-          std::string comma_sep_str = value.str();
-          size_t comma_pos;
-          while ((comma_pos = comma_sep_str.find(',')) != std::string::npos) {
-            comma_sep_str[comma_pos] = '\0';
-            if (comma_sep_str == "stack") {
+          for (llvm::StringRef entry : llvm::split(value, ',')) {
+            if (entry == "stack")
               region_info.SetIsStackMemory(MemoryRegionInfo::eYes);
-            }
-          }
-          // handle final (or only) type of "stack"
-          if (comma_sep_str == "stack") {
-            region_info.SetIsStackMemory(MemoryRegionInfo::eYes);
           }
         } else if (name == "error") {
           StringExtractorGDBRemote error_extractor(value);

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -343,24 +343,27 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   EXPECT_EQ(MemoryRegionInfo::eYes, region_info.GetExecutable());
   EXPECT_EQ("/foo/bar.so", region_info.GetName().GetStringRef());
   EXPECT_EQ(MemoryRegionInfo::eDontKnow, region_info.GetMemoryTagged());
+  EXPECT_EQ(MemoryRegionInfo::eDontKnow, region_info.IsStackMemory());
 
   result = std::async(std::launch::async, [&] {
     return client.GetMemoryRegionInfo(addr, region_info);
   });
 
   HandlePacket(server, "qMemoryRegionInfo:a000",
-               "start:a000;size:2000;flags:;");
+               "start:a000;size:2000;flags:;type:stack;");
   EXPECT_TRUE(result.get().Success());
   EXPECT_EQ(MemoryRegionInfo::eNo, region_info.GetMemoryTagged());
+  EXPECT_EQ(MemoryRegionInfo::eYes, region_info.IsStackMemory());
 
   result = std::async(std::launch::async, [&] {
     return client.GetMemoryRegionInfo(addr, region_info);
   });
 
   HandlePacket(server, "qMemoryRegionInfo:a000",
-               "start:a000;size:2000;flags: mt  zz mt  ;");
+               "start:a000;size:2000;flags: mt  zz mt  ;type:ha,ha,stack;");
   EXPECT_TRUE(result.get().Success());
   EXPECT_EQ(MemoryRegionInfo::eYes, region_info.GetMemoryTagged());
+  EXPECT_EQ(MemoryRegionInfo::eYes, region_info.IsStackMemory());
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfoInvalidResponse) {


### PR DESCRIPTION
The existing algorithm was performing the following comparisons for an `aaa,bbb,ccc,ddd`:

aaa\0bbb,ccc,ddd == "stack"
aaa\0bbb\0ccc,ddd == "stack"
aaa\0bbb\0ccc\0ddd == "stack"

Which wouldn't work. This commit just dispatches to a known algorithm implementation.