### PR TITLE
[flang] Fix parser crash

### DIFF
--- a/flang/lib/Parser/io-parsers.cpp
+++ b/flang/lib/Parser/io-parsers.cpp
@@ -27,7 +27,8 @@ TYPE_PARSER(construct<IoUnit>(variable / lookAhead(space / ",);\n"_ch)) ||
     construct<IoUnit>(fileUnitNumber) || construct<IoUnit>(star))
 
 // R1202 file-unit-number -> scalar-int-expr
-TYPE_PARSER(construct<FileUnitNumber>(scalarIntExpr / !"="_tok))
+TYPE_PARSER(construct<FileUnitNumber>(
+    scalarIntExpr / (lookAhead(space >> ",)"_ch) || atEndOfStmt)))
 
 // R1204 open-stmt -> OPEN ( connect-spec-list )
 TYPE_CONTEXT_PARSER("OPEN statement"_en_US,

--- a/flang/test/Parser/recovery05.f90
+++ b/flang/test/Parser/recovery05.f90
@@ -1,0 +1,5 @@
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+continue
+! CHECK: error: expected end of statement
+flush iostat=1
+end


### PR DESCRIPTION
The production for a bare file unit number in an I/O statement checks that the scalar integer expression isn't followed by "=", in order to disambiguate FLUSHN from FLUSHN=1, and to not treat a control specifier keyword as an integer expression.  The implementation of this check used !"="_tok, which has the side effect of producing no error message; this can lead to a parsing crash later when a failed parse of an erroneous program is found to have produced no errors.  Rewrite as a lookAhead call for those characters that acually can follow a bare unit number.

Fixes https://github.com/llvm/llvm-project/issues/105779.