### PR TITLE
[libc++][test] Fix `msvc_is_lock_free_macro_value()`

### DIFF
--- a/libcxx/test/support/atomic_helpers.h
+++ b/libcxx/test/support/atomic_helpers.h
@@ -30,7 +30,7 @@
 #  define TEST_ATOMIC_LONG_LOCK_FREE __GCC_ATOMIC_LONG_LOCK_FREE
 #  define TEST_ATOMIC_LLONG_LOCK_FREE __GCC_ATOMIC_LLONG_LOCK_FREE
 #  define TEST_ATOMIC_POINTER_LOCK_FREE __GCC_ATOMIC_POINTER_LOCK_FREE
-#elif TEST_COMPILER_MSVC
+#elif defined(TEST_COMPILER_MSVC)
 // This is lifted from STL/stl/inc/atomic on github for the purposes of
 // keeping the tests compiling for MSVC's STL. It's not a perfect solution
 // but at least the tests will keep running.

--- a/libcxx/test/support/atomic_helpers.h
+++ b/libcxx/test/support/atomic_helpers.h
@@ -37,8 +37,8 @@
 //
 // Note MSVC's STL never produces a type that is sometimes lock free, but not always lock free.
 template <class T, size_t Size = sizeof(T)>
-constexpr bool msvc_is_lock_free_macro_value() {
-  return (Size <= 8 && (Size & Size - 1) == 0) ? 2 : 0;
+constexpr int msvc_is_lock_free_macro_value() {
+  return (Size <= 8 && (Size & (Size - 1)) == 0) ? 2 : 0;
 }
 #  define TEST_ATOMIC_CHAR_LOCK_FREE ::msvc_is_lock_free_macro_value<char>()
 #  define TEST_ATOMIC_SHORT_LOCK_FREE ::msvc_is_lock_free_macro_value<short>()


### PR DESCRIPTION
Followup to #99570.

* `TEST_COMPILER_MSVC` must be tested for `defined`ness, as it is everywhere else.
  + Definition: https://github.com/llvm/llvm-project/blob/52a7116f5c6ada234f47f7794aaf501a3692b997/libcxx/test/support/test_macros.h#L71-L72
  + Example usage: https://github.com/llvm/llvm-project/blob/52a7116f5c6ada234f47f7794aaf501a3692b997/libcxx/test/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp#L248
  + Fixes: `llvm-project\libcxx\test\support\atomic_helpers.h(33): fatal error C1017: invalid integer constant expression`
* Fix bogus return type: `msvc_is_lock_free_macro_value()` returns `2` or `0`, so it needs to return `int`.
  + Fixes: `llvm-project\libcxx\test\support\atomic_helpers.h(41): warning C4305: 'return': truncation from 'int' to 'bool'`
* Clarity improvement: also add parens when mixing bitwise with arithmetic operators.
