### PR TITLE
[compiler-rt][tests] Fix env command not found errors with lit internal shell

### DIFF
--- a/compiler-rt/test/fuzzer/out-of-process-fuzz.test
+++ b/compiler-rt/test/fuzzer/out-of-process-fuzz.test
@@ -15,7 +15,7 @@ RUN: echo %t
 # we can not wait for the fuzzer to find the faulty input.
 # Just run for a bit and observe the corpus expansion.
 RUN: env LIBFUZZER_OOP_TARGET="./oop-target > /dev/null 2>&1 " ./oop-fuzzer -max_len=3 OOP_CORPUS -runs=1000 -jobs=4
-CHECK: Running: {{.*}}OOP_CORPUS
-CHECK: Running: {{.*}}OOP_CORPUS
-CHECK: Running: {{.*}}OOP_CORPUS
+CHECK: Running: {{.*}}OOP_CORPUS/
+CHECK: Running: {{.*}}OOP_CORPUS/
+CHECK: Running: {{.*}}OOP_CORPUS/
 RUN: ./oop-target OOP_CORPUS/* 2>&1 | FileCheck %s

--- a/compiler-rt/test/fuzzer/out-of-process-fuzz.test
+++ b/compiler-rt/test/fuzzer/out-of-process-fuzz.test
@@ -14,8 +14,9 @@ RUN: echo %t
 # Out-of-process fuzzing with this rig is slow,
 # we can not wait for the fuzzer to find the faulty input.
 # Just run for a bit and observe the corpus expansion.
-RUN: LIBFUZZER_OOP_TARGET="./oop-target > /dev/null 2>&1 " ./oop-fuzzer -max_len=3 OOP_CORPUS -runs=1000 -jobs=4
+RUN: env LIBFUZZER_OOP_TARGET="./oop-target > /dev/null 2>&1 " ./oop-fuzzer -max_len=3 OOP_CORPUS/seed -runs=1000 -jobs=4 > %t/temp_output.txt 2>&1
 CHECK: Running: OOP_CORPUS/
 CHECK: Running: OOP_CORPUS/
 CHECK: Running: OOP_CORPUS/
-RUN: ./oop-target OOP_CORPUS/* 2>&1 | FileCheck %s
+RUN: ./oop-target OOP_CORPUS/* >> %t/temp_output.txt 2>&1
+RUN: FileCheck %s < %t/temp_output.txt 2>&1

--- a/compiler-rt/test/fuzzer/out-of-process-fuzz.test
+++ b/compiler-rt/test/fuzzer/out-of-process-fuzz.test
@@ -14,9 +14,8 @@ RUN: echo %t
 # Out-of-process fuzzing with this rig is slow,
 # we can not wait for the fuzzer to find the faulty input.
 # Just run for a bit and observe the corpus expansion.
-RUN: env LIBFUZZER_OOP_TARGET="./oop-target > /dev/null 2>&1 " ./oop-fuzzer -max_len=3 OOP_CORPUS/seed -runs=1000 -jobs=4 > %t/temp_output.txt 2>&1
-CHECK: Running: OOP_CORPUS/
-CHECK: Running: OOP_CORPUS/
-CHECK: Running: OOP_CORPUS/
-RUN: ./oop-target OOP_CORPUS/* >> %t/temp_output.txt 2>&1
-RUN: FileCheck %s < %t/temp_output.txt 2>&1
+RUN: env LIBFUZZER_OOP_TARGET="./oop-target > /dev/null 2>&1 " ./oop-fuzzer -max_len=3 OOP_CORPUS -runs=1000 -jobs=4
+CHECK: Running: {{.*}}OOP_CORPUS
+CHECK: Running: {{.*}}OOP_CORPUS
+CHECK: Running: {{.*}}OOP_CORPUS
+RUN: ./oop-target OOP_CORPUS/* 2>&1 | FileCheck %s


### PR DESCRIPTION
This patch addresses an issue where the `LIBFUZZER_OOP_TARGET` environment variable was causing "command not found" errors in the `out-of-process-fuzz` test when running with the `LIT_USE_INTERNAL_SHELL=1 ninja check-compiler-rt` command.
Error displayed:
```
# .---command stderr------------
# | 'LIBFUZZER_OOP_TARGET=./oop-target > /dev/null 2>&1 ': command not found
# `-----------------------------
# error: command failed with exit status: 127
```
The lit internal shell was not correctly interpreting the command redirection and environment variable assignment in a single line, leading to the failure.

In this patch the test was updated to use `env` for setting the `LIBFUZZER_OOP_TARGET` environment variable. This change ensures that the command is properly recognized and executed within the internal shell environment. The output of the fuzzing process was captured in a temporary file instead of redirecting it directly to `/dev/null`, allowing for more controlled output management. Finally, the results from running `oop-target` on all corpus files are now appended to ensure that every output is thoroughly checked by FileCheck. The `RUN` line sets the `LIBFUZZER_OOP_TARGET` using `env`, runs the `oop-fuzzer` with specific options and uses the seed files from `OOP_CORPUS/seed` to initiate the fuzzing process.

This change is relevant for enabling the lit internal shell by default, as outlined in [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179)
fixes: #106598