### PR TITLE
[GDBRemote] Handle 'heap' memory region info type

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1638,7 +1638,7 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
           for (llvm::StringRef entry : llvm::split(value, ',')) {
             if (entry == "stack")
               region_info.SetIsStackMemory(MemoryRegionInfo::eYes);
-            if (entry == "heap")
+            else if (entry == "heap")
               region_info.SetIsStackMemory(MemoryRegionInfo::eNo);
           }
         } else if (name == "error") {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1638,6 +1638,8 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
           for (llvm::StringRef entry : llvm::split(value, ',')) {
             if (entry == "stack")
               region_info.SetIsStackMemory(MemoryRegionInfo::eYes);
+            if (entry == "heap")
+              region_info.SetIsStackMemory(MemoryRegionInfo::eNo);
           }
         } else if (name == "error") {
           StringExtractorGDBRemote error_extractor(value);

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -364,6 +364,15 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   EXPECT_TRUE(result.get().Success());
   EXPECT_EQ(MemoryRegionInfo::eYes, region_info.GetMemoryTagged());
   EXPECT_EQ(MemoryRegionInfo::eYes, region_info.IsStackMemory());
+
+  result = std::async(std::launch::async, [&] {
+    return client.GetMemoryRegionInfo(addr, region_info);
+  });
+
+  HandlePacket(server, "qMemoryRegionInfo:a000",
+               "start:a000;size:2000;type:heap;");
+  EXPECT_TRUE(result.get().Success());
+  EXPECT_EQ(MemoryRegionInfo::eNo, region_info.IsStackMemory());
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfoInvalidResponse) {


### PR DESCRIPTION
This should cause the memory region info "is stack" field to be set to "no".