### PR TITLE
[clang][test] Rewrote test using command substitution to work with lit internal shell syntax

### DIFF
--- a/clang/test/Modules/compare-file-size.py
+++ b/clang/test/Modules/compare-file-size.py
@@ -1,0 +1,22 @@
+import argparse
+import os
+
+def get_file_size(file_path):
+    try:
+        return os.path.getsize(file_path)
+    except:
+        print(f"Unable to get file size of {file_path}")
+        return None
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("file1", type=str)
+    parser.add_argument("file2", type=str)
+
+    args = parser.parse_args()
+
+    return get_file_size(args.file1) < get_file_size(args.file2)
+
+if __name__ == "__main__":
+    main()

--- a/clang/test/Modules/compare-file-size.py
+++ b/clang/test/Modules/compare-file-size.py
@@ -1,22 +1,14 @@
+# This program takes in two file path arguments and returns true if the
+# file size of the first file is smaller than the file size of the second file
+
 import argparse
 import os
 
-def get_file_size(file_path):
-    try:
-        return os.path.getsize(file_path)
-    except:
-        print(f"Unable to get file size of {file_path}")
-        return None
+parser = argparse.ArgumentParser()
 
-def main():
-    parser = argparse.ArgumentParser()
+parser.add_argument("file1", type=str)
+parser.add_argument("file2", type=str)
 
-    parser.add_argument("file1", type=str)
-    parser.add_argument("file2", type=str)
+args = parser.parse_args()
 
-    args = parser.parse_args()
-
-    return get_file_size(args.file1) < get_file_size(args.file2)
-
-if __name__ == "__main__":
-    main()
+return os.path.getsize(args.file1) < os.path.getsize(args.file2)

--- a/clang/test/Modules/compare-file-size.py
+++ b/clang/test/Modules/compare-file-size.py
@@ -1,5 +1,5 @@
-# This program takes in two file path arguments and returns true if the
-# file size of the first file is smaller than the file size of the second file
+# This program takes in two file path arguments in the form 'compare-file-size.py file1 file2'
+# Returns true if the file size of the file1 is smaller than the file size of file2
 
 import argparse
 import os

--- a/clang/test/Modules/compare-file-size.py
+++ b/clang/test/Modules/compare-file-size.py
@@ -4,11 +4,15 @@
 import argparse
 import os
 
-parser = argparse.ArgumentParser()
+def main():
+    parser = argparse.ArgumentParser()
 
-parser.add_argument("file1", type=str)
-parser.add_argument("file2", type=str)
+    parser.add_argument("file1", type=str)
+    parser.add_argument("file2", type=str)
 
-args = parser.parse_args()
+    args = parser.parse_args()
 
-return os.path.getsize(args.file1) < os.path.getsize(args.file2)
+    return os.path.getsize(args.file1) < os.path.getsize(args.file2)
+
+if __name__ == '__main__':
+    main()

--- a/clang/test/Modules/compare-file-size.py
+++ b/clang/test/Modules/compare-file-size.py
@@ -4,6 +4,7 @@
 import argparse
 import os
 
+
 def main():
     parser = argparse.ArgumentParser()
 
@@ -14,5 +15,6 @@ def main():
 
     return os.path.getsize(args.file1) < os.path.getsize(args.file2)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/clang/test/Modules/reduced-bmi-size.cppm
+++ b/clang/test/Modules/reduced-bmi-size.cppm
@@ -10,6 +10,6 @@
 // RUN: %clang_cc1 -std=c++20 -emit-module-interface %s -o %t/a.pcm
 // RUN: %clang_cc1 -std=c++20 -emit-reduced-module-interface %s -o %t/a.reduced.pcm
 //
-// RUN: %{python} %S/compare-file-size.py %t/a.pcm %t/a.reduced.pcm
+// RUN: %python %S/compare-file-size.py %t/a.pcm %t/a.reduced.pcm
 
 export module a;

--- a/clang/test/Modules/reduced-bmi-size.cppm
+++ b/clang/test/Modules/reduced-bmi-size.cppm
@@ -10,7 +10,6 @@
 // RUN: %clang_cc1 -std=c++20 -emit-module-interface %s -o %t/a.pcm
 // RUN: %clang_cc1 -std=c++20 -emit-reduced-module-interface %s -o %t/a.reduced.pcm
 //
-// %s implies the current source file. So we can't use it directly.
-// RUN: [ $(stat -c%\s "%t/a.pcm") -le $(stat -c%\s "%t/a.reduced.pcm") ]
+// RUN: %{python} %S/compare-file-size.py %t/a.pcm %t/a.reduced.pcm
 
 export module a;

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -74,6 +74,8 @@ config.substitutions.append(("%target_triple", config.target_triple))
 
 config.substitutions.append(("%PATH%", config.environment["PATH"]))
 
+config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))
+
 
 # For each occurrence of a clang tool name, replace it with the full path to
 # the build directory holding that tool.  We explicitly specify the directories

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -74,8 +74,6 @@ config.substitutions.append(("%target_triple", config.target_triple))
 
 config.substitutions.append(("%PATH%", config.environment["PATH"]))
 
-config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))
-
 
 # For each occurrence of a clang tool name, replace it with the full path to
 # the build directory holding that tool.  We explicitly specify the directories


### PR DESCRIPTION
This patch rewrites a test that uses command substitution `$()` and the `stat` command, which are not supported by lit's internal shell. Instead of using this syntax to perform the file size comparison done in this test, a Python script is used instead to perform the same operation.

Fixes https://github.com/llvm/llvm-project/issues/102384.