### PR TITLE
[llvm-profdata] Add block percent to detailed summary

### DIFF
--- a/compiler-rt/test/profile/Linux/Inputs/instrprof-value-merge.c
+++ b/compiler-rt/test/profile/Linux/Inputs/instrprof-value-merge.c
@@ -54,6 +54,8 @@ int main(int argc, char *argv[]) {
 // CHECK-NEXT: Total functions: 3
 // CHECK-NEXT: Maximum function count: 327
 // CHECK-NEXT: Maximum internal block count: 297
+// CHECK-NEXT: Total number of blocks: 8
+// CHECK-NEXT: Total count: 805
 // CHECK-NEXT: Statistics for indirect call sites profile:
 // CHECK-NEXT:   Total number of sites: 3
 // CHECK-NEXT:   Total number of sites with values: 3

--- a/compiler-rt/test/profile/Linux/binary-id.c
+++ b/compiler-rt/test/profile/Linux/binary-id.c
@@ -62,6 +62,8 @@ int main() {
 // BINARY-ID-RAW-PROF-NEXT: Total functions: 3
 // BINARY-ID-RAW-PROF-NEXT: Maximum function count: 1
 // BINARY-ID-RAW-PROF-NEXT: Maximum internal block count: 0
+// BINARY-ID-RAW-PROF-NEXT: Total number of blocks: 3
+// BINARY-ID-RAW-PROF-NEXT: Total count: 3
 // BINARY-ID-RAW-PROF-NEXT: Binary IDs:
 // BINARY-ID-RAW-PROF-NEXT: {{[0-9a-f]+}}
 
@@ -69,6 +71,8 @@ int main() {
 // BINARY-ID-MERGE-PROF-NEXT: Total functions: 3
 // BINARY-ID-MERGE-PROF-NEXT: Maximum function count: 3
 // BINARY-ID-MERGE-PROF-NEXT: Maximum internal block count: 0
+// BINARY-ID-MERGE-PROF-NEXT: Total number of blocks: 3
+// BINARY-ID-MERGE-PROF-NEXT: Total count: 9
 // BINARY-ID-MERGE-PROF-NEXT: Binary IDs:
 // BINARY-ID-MERGE-PROF-NEXT: {{[0-9a-f]+}}
 
@@ -76,6 +80,8 @@ int main() {
 // BINARY-ID-INDEXED-PROF-NEXT: Total functions: 3
 // BINARY-ID-INDEXED-PROF-NEXT: Maximum function count: 3
 // BINARY-ID-INDEXED-PROF-NEXT: Maximum internal block count: 0
+// BINARY-ID-INDEXED-PROF-NEXT: Total number of blocks: 3
+// BINARY-ID-INDEXED-PROF-NEXT: Total count: 9
 // BINARY-ID-INDEXED-PROF-NEXT: Binary IDs:
 // BINARY-ID-INDEXED-PROF-NEXT: {{[0-9a-f]+}}
 
@@ -83,6 +89,8 @@ int main() {
 // BINARY-ID-SHARE-RAW-PROF-NEXT: Total functions: 3
 // BINARY-ID-SHARE-RAW-PROF-NEXT: Maximum function count: 1
 // BINARY-ID-SHARE-RAW-PROF-NEXT: Maximum internal block count: 0
+// BINARY-ID-SHARE-RAW-PROF-NEXT: Total number of blocks: 3
+// BINARY-ID-SHARE-RAW-PROF-NEXT: Total count: 3
 // BINARY-ID-SHARE-RAW-PROF-NEXT: Binary IDs:
 // BINARY-ID-SHARE-RAW-PROF-NEXT: {{[0-9a-f]+}}
 // BINARY-ID-SHARE-RAW-PROF-NEXT: {{[0-9a-f]+}}
@@ -92,6 +100,8 @@ int main() {
 // BINARY-ID-SHARE-INDEXED-PROF-NEXT: Total functions: 3
 // BINARY-ID-SHARE-INDEXED-PROF-NEXT: Maximum function count: 1
 // BINARY-ID-SHARE-INDEXED-PROF-NEXT: Maximum internal block count: 0
+// BINARY-ID-SHARE-INDEXED-PROF-NEXT: Total number of blocks: 3
+// BINARY-ID-SHARE-INDEXED-PROF-NEXT: Total count: 3
 // BINARY-ID-SHARE-INDEXED-PROF-NEXT: Binary IDs:
 // BINARY-ID-SHARE-INDEXED-PROF-NEXT: {{[0-9a-f]+}}
 // BINARY-ID-SHARE-INDEXED-PROF-NEXT: {{[0-9a-f]+}}

--- a/compiler-rt/test/profile/Linux/profile-version.c
+++ b/compiler-rt/test/profile/Linux/profile-version.c
@@ -25,10 +25,14 @@ int main() {
 // RAW-PROF-NEXT: Total functions: 3
 // RAW-PROF-NEXT: Maximum function count: 1
 // RAW-PROF-NEXT: Maximum internal block count: 0
+// RAW-PROF-NEXT: Total number of blocks: 3
+// RAW-PROF-NEXT: Total count: 3
 // RAW-PROF-NEXT: Profile version: {{[0-9]+}}
 
 // INDEXED-PROF: Instrumentation level: Front-end
 // INDEXED-PROF-NEXT: Total functions: 3
 // INDEXED-PROF-NEXT: Maximum function count: 3
 // INDEXED-PROF-NEXT: Maximum internal block count: 0
+// INDEXED-PROF-NEXT: Total number of blocks: 3
+// INDEXED-PROF-NEXT: Total count: 9
 // INDEXED-PROF-NEXT: Profile version: {{[0-9]+}}

--- a/llvm/lib/IR/ProfileSummary.cpp
+++ b/llvm/lib/IR/ProfileSummary.cpp
@@ -251,7 +251,7 @@ ProfileSummary *ProfileSummary::getFromMD(Metadata *MD) {
 void ProfileSummary::printSummary(raw_ostream &OS) const {
   OS << "Total functions: " << NumFunctions << "\n";
   OS << "Maximum function count: " << MaxFunctionCount << "\n";
-  OS << "Maximum block count: " << MaxCount << "\n";
+  OS << "Maximum internal block count: " << MaxInternalCount << "\n";
   OS << "Total number of blocks: " << NumCounts << "\n";
   OS << "Total count: " << TotalCount << "\n";
 }
@@ -259,9 +259,10 @@ void ProfileSummary::printSummary(raw_ostream &OS) const {
 void ProfileSummary::printDetailedSummary(raw_ostream &OS) const {
   OS << "Detailed summary:\n";
   for (const auto &Entry : DetailedSummary) {
-    OS << Entry.NumCounts << " blocks with count >= " << Entry.MinCount
-       << " account for "
-       << format("%0.6g", (float)Entry.Cutoff / Scale * 100)
-       << " percentage of the total counts.\n";
+    OS << format("%lu blocks (%.2f%%) with count >= %lu account for %0.6g%% of "
+                 "the total counts.\n",
+                 Entry.NumCounts,
+                 NumCounts ? (100.f * Entry.NumCounts / NumCounts) : 0,
+                 Entry.MinCount, 100.f * Entry.Cutoff / Scale);
   }
 }

--- a/llvm/test/tools/llvm-profdata/cs-sample-nested-profile.test
+++ b/llvm/test/tools/llvm-profdata/cs-sample-nested-profile.test
@@ -153,47 +153,47 @@ RUN: llvm-profdata show -sample -detailed-summary %t3.proftext | FileCheck %s -c
 
 ; SUMMARY:      Total functions: 4
 ; SUMMARY-NEXT: Maximum function count: 32
-; SUMMARY-NEXT: Maximum block count: 362830
+; SUMMARY-NEXT: Maximum internal block count: 0
 ; SUMMARY-NEXT: Total number of blocks: 16
 ; SUMMARY-NEXT: Total count: 772562
 ; SUMMARY-NEXT: Detailed summary:
-; SUMMARY-NEXT: 1 blocks with count >= 362830 account for 1 percentage of the total counts.
-; SUMMARY-NEXT: 1 blocks with count >= 362830 account for 10 percentage of the total counts.
-; SUMMARY-NEXT: 1 blocks with count >= 362830 account for 20 percentage of the total counts.
-; SUMMARY-NEXT: 1 blocks with count >= 362830 account for 30 percentage of the total counts.
-; SUMMARY-NEXT: 1 blocks with count >= 362830 account for 40 percentage of the total counts.
-; SUMMARY-NEXT: 2 blocks with count >= 362805 account for 50 percentage of the total counts.
-; SUMMARY-NEXT: 2 blocks with count >= 362805 account for 60 percentage of the total counts.
-; SUMMARY-NEXT: 2 blocks with count >= 362805 account for 70 percentage of the total counts.
-; SUMMARY-NEXT: 2 blocks with count >= 362805 account for 80 percentage of the total counts.
-; SUMMARY-NEXT: 2 blocks with count >= 362805 account for 90 percentage of the total counts.
-; SUMMARY-NEXT: 3 blocks with count >= 23327 account for 95 percentage of the total counts.
-; SUMMARY-NEXT: 4 blocks with count >= 23324 account for 99 percentage of the total counts.
-; SUMMARY-NEXT: 4 blocks with count >= 23324 account for 99.9 percentage of the total counts.
-; SUMMARY-NEXT: 11 blocks with count >= 24 account for 99.99 percentage of the total counts.
-; SUMMARY-NEXT: 16 blocks with count >= 10 account for 99.999 percentage of the total counts.
-; SUMMARY-NEXT: 16 blocks with count >= 10 account for 99.9999 percentage of the total counts.
+; SUMMARY-NEXT: 1 blocks (6.25%) with count >= 362830 account for 1% of the total counts.
+; SUMMARY-NEXT: 1 blocks (6.25%) with count >= 362830 account for 10% of the total counts.
+; SUMMARY-NEXT: 1 blocks (6.25%) with count >= 362830 account for 20% of the total counts.
+; SUMMARY-NEXT: 1 blocks (6.25%) with count >= 362830 account for 30% of the total counts.
+; SUMMARY-NEXT: 1 blocks (6.25%) with count >= 362830 account for 40% of the total counts.
+; SUMMARY-NEXT: 2 blocks (12.50%) with count >= 362805 account for 50% of the total counts.
+; SUMMARY-NEXT: 2 blocks (12.50%) with count >= 362805 account for 60% of the total counts.
+; SUMMARY-NEXT: 2 blocks (12.50%) with count >= 362805 account for 70% of the total counts.
+; SUMMARY-NEXT: 2 blocks (12.50%) with count >= 362805 account for 80% of the total counts.
+; SUMMARY-NEXT: 2 blocks (12.50%) with count >= 362805 account for 90% of the total counts.
+; SUMMARY-NEXT: 3 blocks (18.75%) with count >= 23327 account for 95% of the total counts.
+; SUMMARY-NEXT: 4 blocks (25.00%) with count >= 23324 account for 99% of the total counts.
+; SUMMARY-NEXT: 4 blocks (25.00%) with count >= 23324 account for 99.9% of the total counts.
+; SUMMARY-NEXT: 11 blocks (68.75%) with count >= 24 account for 99.99% of the total counts.
+; SUMMARY-NEXT: 16 blocks (100.00%) with count >= 10 account for 99.999% of the total counts.
+; SUMMARY-NEXT: 16 blocks (100.00%) with count >= 10 account for 99.9999% of the total counts.
 
 
 ; SUMMARY-NEST:      Total functions: 4
 ; SUMMARY-NEST-NEXT: Maximum function count: 32
-; SUMMARY-NEST-NEXT: Maximum block count: 362830
+; SUMMARY-NEST-NEXT: Maximum internal block count: 0
 ; SUMMARY-NEST-NEXT: Total number of blocks: 15
 ; SUMMARY-NEST-NEXT: Total count: 772504
 ; SUMMARY-NEST-NEXT: Detailed summary:
-; SUMMARY-NEST-NEXT: 1 blocks with count >= 362830 account for 1 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 1 blocks with count >= 362830 account for 10 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 1 blocks with count >= 362830 account for 20 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 1 blocks with count >= 362830 account for 30 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 1 blocks with count >= 362830 account for 40 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 2 blocks with count >= 362805 account for 50 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 2 blocks with count >= 362805 account for 60 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 2 blocks with count >= 362805 account for 70 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 2 blocks with count >= 362805 account for 80 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 2 blocks with count >= 362805 account for 90 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 3 blocks with count >= 23327 account for 95 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 4 blocks with count >= 23324 account for 99 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 4 blocks with count >= 23324 account for 99.9 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 10 blocks with count >= 21 account for 99.99 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 15 blocks with count >= 10 account for 99.999 percentage of the total counts.
-; SUMMARY-NEST-NEXT: 15 blocks with count >= 10 account for 99.9999 percentage of the total counts.
+; SUMMARY-NEST-NEXT: 1 blocks (6.67%) with count >= 362830 account for 1% of the total counts.
+; SUMMARY-NEST-NEXT: 1 blocks (6.67%) with count >= 362830 account for 10% of the total counts.
+; SUMMARY-NEST-NEXT: 1 blocks (6.67%) with count >= 362830 account for 20% of the total counts.
+; SUMMARY-NEST-NEXT: 1 blocks (6.67%) with count >= 362830 account for 30% of the total counts.
+; SUMMARY-NEST-NEXT: 1 blocks (6.67%) with count >= 362830 account for 40% of the total counts.
+; SUMMARY-NEST-NEXT: 2 blocks (13.33%) with count >= 362805 account for 50% of the total counts.
+; SUMMARY-NEST-NEXT: 2 blocks (13.33%) with count >= 362805 account for 60% of the total counts.
+; SUMMARY-NEST-NEXT: 2 blocks (13.33%) with count >= 362805 account for 70% of the total counts.
+; SUMMARY-NEST-NEXT: 2 blocks (13.33%) with count >= 362805 account for 80% of the total counts.
+; SUMMARY-NEST-NEXT: 2 blocks (13.33%) with count >= 362805 account for 90% of the total counts.
+; SUMMARY-NEST-NEXT: 3 blocks (20.00%) with count >= 23327 account for 95% of the total counts.
+; SUMMARY-NEST-NEXT: 4 blocks (26.67%) with count >= 23324 account for 99% of the total counts.
+; SUMMARY-NEST-NEXT: 4 blocks (26.67%) with count >= 23324 account for 99.9% of the total counts.
+; SUMMARY-NEST-NEXT: 10 blocks (66.67%) with count >= 21 account for 99.99% of the total counts.
+; SUMMARY-NEST-NEXT: 15 blocks (100.00%) with count >= 10 account for 99.999% of the total counts.
+; SUMMARY-NEST-NEXT: 15 blocks (100.00%) with count >= 10 account for 99.9999% of the total counts.

--- a/llvm/test/tools/llvm-profdata/general.proftext
+++ b/llvm/test/tools/llvm-profdata/general.proftext
@@ -71,18 +71,18 @@ hex_hash
 # DETAILED-SUMMARY: Total number of blocks: 10
 # DETAILED-SUMMARY: Total count: 4539628424389557499
 # DETAILED-SUMMARY: Detailed summary:
-# DETAILED-SUMMARY: 3 blocks with count >= 576460752303423488 account for 80 percentage of the total counts.
-# DETAILED-SUMMARY: 4 blocks with count >= 288230376151711744 account for 90 percentage of the total counts.
-# DETAILED-SUMMARY: 4 blocks with count >= 288230376151711744 account for 95 percentage of the total counts.
-# DETAILED-SUMMARY: 6 blocks with count >= 72057594037927936 account for 99 percentage of the total counts.
-# DETAILED-SUMMARY: 6 blocks with count >= 72057594037927936 account for 99.9 percentage of the total counts.
-# DETAILED-SUMMARY: 6 blocks with count >= 72057594037927936 account for 99.99 percentage of the total counts.
-# DETAILED-SUMMARY: 6 blocks with count >= 72057594037927936 account for 99.999 percentage of the total counts.
+# DETAILED-SUMMARY: 3 blocks (30.00%) with count >= 576460752303423488 account for 80% of the total counts.
+# DETAILED-SUMMARY: 4 blocks (40.00%) with count >= 288230376151711744 account for 90% of the total counts.
+# DETAILED-SUMMARY: 4 blocks (40.00%) with count >= 288230376151711744 account for 95% of the total counts.
+# DETAILED-SUMMARY: 6 blocks (60.00%) with count >= 72057594037927936 account for 99% of the total counts.
+# DETAILED-SUMMARY: 6 blocks (60.00%) with count >= 72057594037927936 account for 99.9% of the total counts.
+# DETAILED-SUMMARY: 6 blocks (60.00%) with count >= 72057594037927936 account for 99.99% of the total counts.
+# DETAILED-SUMMARY: 6 blocks (60.00%) with count >= 72057594037927936 account for 99.999% of the total counts.
 
 # RUN: llvm-profdata show --detailed-summary --detailed-summary-cutoffs=600000 %t.profdata | FileCheck %s -check-prefix=DETAILED-SUMMARY-2
-# DETAILED-SUMMARY-2: 2 blocks with count >= 1152921504606846976 account for 60 percentage of the total counts.
+# DETAILED-SUMMARY-2: 2 blocks (28.57%) with count >= 1152921504606846976 account for 60% of the total counts.
 #
 # RUN: llvm-profdata show --detailed-summary --detailed-summary-cutoffs=600000,900000,999999 %t.profdata | FileCheck %s -check-prefix=DETAILED-SUMMARY-3
-# DETAILED-SUMMARY-3: 2 blocks with count >= 1152921504606846976 account for 60 percentage of the total counts.
-# DETAILED-SUMMARY-3: 4 blocks with count >= 288230376151711744 account for 90 percentage of the total counts.
-# DETAILED-SUMMARY-3: 6 blocks with count >= 72057594037927936 account for 99.9999 percentage of the total counts.
+# DETAILED-SUMMARY-3: 2 blocks (28.57%) with count >= 1152921504606846976 account for 60% of the total counts.
+# DETAILED-SUMMARY-3: 4 blocks (57.14%) with count >= 288230376151711744 account for 90% of the total counts.
+# DETAILED-SUMMARY-3: 6 blocks (85.71%) with count >= 72057594037927936 account for 99.9999% of the total counts.

--- a/llvm/test/tools/llvm-profdata/sample-summary.test
+++ b/llvm/test/tools/llvm-profdata/sample-summary.test
@@ -2,23 +2,23 @@
 
 ; CHECK: Total functions: 3
 ; CHECK-NEXT: Maximum function count: 1437
-; CHECK-NEXT: Maximum block count: 2080
+; CHECK-NEXT: Maximum internal block count: 0
 ; CHECK-NEXT: Total number of blocks: 11
 ; CHECK-NEXT: Total count: 12943
 ; CHECK-NEXT: Detailed summary:
-; CHECK-NEXT: 1 blocks with count >= 2080 account for 1 percentage of the total counts.
-; CHECK-NEXT: 1 blocks with count >= 2080 account for 10 percentage of the total counts.
-; CHECK-NEXT: 2 blocks with count >= 2064 account for 20 percentage of the total counts.
-; CHECK-NEXT: 2 blocks with count >= 2064 account for 30 percentage of the total counts.
-; CHECK-NEXT: 3 blocks with count >= 2000 account for 40 percentage of the total counts.
-; CHECK-NEXT: 4 blocks with count >= 1437 account for 50 percentage of the total counts.
-; CHECK-NEXT: 6 blocks with count >= 1075 account for 60 percentage of the total counts.
-; CHECK-NEXT: 6 blocks with count >= 1075 account for 70 percentage of the total counts.
-; CHECK-NEXT: 7 blocks with count >= 1000 account for 80 percentage of the total counts.
-; CHECK-NEXT: 11 blocks with count >= 534 account for 90 percentage of the total counts.
-; CHECK-NEXT: 11 blocks with count >= 534 account for 95 percentage of the total counts.
-; CHECK-NEXT: 11 blocks with count >= 534 account for 99 percentage of the total counts.
-; CHECK-NEXT: 11 blocks with count >= 534 account for 99.9 percentage of the total counts.
-; CHECK-NEXT: 11 blocks with count >= 534 account for 99.99 percentage of the total counts.
-; CHECK-NEXT: 11 blocks with count >= 534 account for 99.999 percentage of the total counts.
-; CHECK-NEXT: 11 blocks with count >= 534 account for 99.9999 percentage of the total counts.
+; CHECK-NEXT: 1 blocks (9.09%) with count >= 2080 account for 1% of the total counts.
+; CHECK-NEXT: 1 blocks (9.09%) with count >= 2080 account for 10% of the total counts.
+; CHECK-NEXT: 2 blocks (18.18%) with count >= 2064 account for 20% of the total counts.
+; CHECK-NEXT: 2 blocks (18.18%) with count >= 2064 account for 30% of the total counts.
+; CHECK-NEXT: 3 blocks (27.27%) with count >= 2000 account for 40% of the total counts.
+; CHECK-NEXT: 4 blocks (36.36%) with count >= 1437 account for 50% of the total counts.
+; CHECK-NEXT: 6 blocks (54.55%) with count >= 1075 account for 60% of the total counts.
+; CHECK-NEXT: 6 blocks (54.55%) with count >= 1075 account for 70% of the total counts.
+; CHECK-NEXT: 7 blocks (63.64%) with count >= 1000 account for 80% of the total counts.
+; CHECK-NEXT: 11 blocks (100.00%) with count >= 534 account for 90% of the total counts.
+; CHECK-NEXT: 11 blocks (100.00%) with count >= 534 account for 95% of the total counts.
+; CHECK-NEXT: 11 blocks (100.00%) with count >= 534 account for 99% of the total counts.
+; CHECK-NEXT: 11 blocks (100.00%) with count >= 534 account for 99.9% of the total counts.
+; CHECK-NEXT: 11 blocks (100.00%) with count >= 534 account for 99.99% of the total counts.
+; CHECK-NEXT: 11 blocks (100.00%) with count >= 534 account for 99.999% of the total counts.
+; CHECK-NEXT: 11 blocks (100.00%) with count >= 534 account for 99.9999% of the total counts.

--- a/llvm/test/tools/llvm-profdata/suppl-instr-with-sample.test
+++ b/llvm/test/tools/llvm-profdata/suppl-instr-with-sample.test
@@ -98,19 +98,19 @@ MIX5-NEXT: Maximum internal block count: 2000
 MIX5-NEXT: Total number of blocks: 9
 MIX5-NEXT: Total count: 6525
 MIX5-NEXT: Detailed summary:
-MIX5-NEXT: 1 blocks with count >= 3000 account for 1 percentage of the total counts.
-MIX5-NEXT: 1 blocks with count >= 3000 account for 10 percentage of the total counts.
-MIX5-NEXT: 1 blocks with count >= 3000 account for 20 percentage of the total counts.
-MIX5-NEXT: 1 blocks with count >= 3000 account for 30 percentage of the total counts.
-MIX5-NEXT: 1 blocks with count >= 3000 account for 40 percentage of the total counts.
-MIX5-NEXT: 2 blocks with count >= 2000 account for 50 percentage of the total counts.
-MIX5-NEXT: 2 blocks with count >= 2000 account for 60 percentage of the total counts.
-MIX5-NEXT: 2 blocks with count >= 2000 account for 70 percentage of the total counts.
-MIX5-NEXT: 3 blocks with count >= 1000 account for 80 percentage of the total counts.
-MIX5-NEXT: 3 blocks with count >= 1000 account for 90 percentage of the total counts.
-MIX5-NEXT: 4 blocks with count >= 500 account for 95 percentage of the total counts.
-MIX5-NEXT: 4 blocks with count >= 500 account for 99 percentage of the total counts.
-MIX5-NEXT: 6 blocks with count >= 12 account for 99.9 percentage of the total counts.
-MIX5-NEXT: 6 blocks with count >= 12 account for 99.99 percentage of the total counts.
-MIX5-NEXT: 6 blocks with count >= 12 account for 99.999 percentage of the total counts.
-MIX5-NEXT: 6 blocks with count >= 12 account for 99.9999 percentage of the total counts.
+MIX5-NEXT: 1 blocks (11.11%) with count >= 3000 account for 1% of the total counts.
+MIX5-NEXT: 1 blocks (11.11%) with count >= 3000 account for 10% of the total counts.
+MIX5-NEXT: 1 blocks (11.11%) with count >= 3000 account for 20% of the total counts.
+MIX5-NEXT: 1 blocks (11.11%) with count >= 3000 account for 30% of the total counts.
+MIX5-NEXT: 1 blocks (11.11%) with count >= 3000 account for 40% of the total counts.
+MIX5-NEXT: 2 blocks (22.22%) with count >= 2000 account for 50% of the total counts.
+MIX5-NEXT: 2 blocks (22.22%) with count >= 2000 account for 60% of the total counts.
+MIX5-NEXT: 2 blocks (22.22%) with count >= 2000 account for 70% of the total counts.
+MIX5-NEXT: 3 blocks (33.33%) with count >= 1000 account for 80% of the total counts.
+MIX5-NEXT: 3 blocks (33.33%) with count >= 1000 account for 90% of the total counts.
+MIX5-NEXT: 4 blocks (44.44%) with count >= 500 account for 95% of the total counts.
+MIX5-NEXT: 4 blocks (44.44%) with count >= 500 account for 99% of the total counts.
+MIX5-NEXT: 6 blocks (66.67%) with count >= 12 account for 99.9% of the total counts.
+MIX5-NEXT: 6 blocks (66.67%) with count >= 12 account for 99.99% of the total counts.
+MIX5-NEXT: 6 blocks (66.67%) with count >= 12 account for 99.999% of the total counts.
+MIX5-NEXT: 6 blocks (66.67%) with count >= 12 account for 99.9999% of the total counts.

--- a/llvm/test/tools/llvm-profdata/vtable-value-prof.test
+++ b/llvm/test/tools/llvm-profdata/vtable-value-prof.test
@@ -1,18 +1,18 @@
-; RUN: rm -rf %t && mkdir %t && cd %t
+; RUN: rm -rf %t && mkdir %t
 
 ; Generate indexed profiles from text profiles
-RUN: llvm-profdata merge --keep-vtable-symbols %S/Inputs/vtable-value-prof.proftext -o indexed.profdata
+RUN: llvm-profdata merge --keep-vtable-symbols %S/Inputs/vtable-value-prof.proftext -o %t/indexed.profdata
 
 ; Show indexed profiles
-RUN: llvm-profdata show --function=main --ic-targets --show-vtables indexed.profdata | FileCheck %s --check-prefix=INDEXED
+RUN: llvm-profdata show --function=main --ic-targets --show-vtables %t/indexed.profdata | FileCheck %s --check-prefix=INDEXED
 
 ; Show text profiles
 RUN: llvm-profdata show --function=main --ic-targets --show-vtables --text %S/Inputs/vtable-value-prof.proftext | FileCheck %s --check-prefix=ICTEXT
 
 ; Convert indexed profiles to its textual output and show it.
-RUN: llvm-profdata merge --keep-vtable-symbols --text -o text-from-indexed.proftext indexed.profdata
-RUN: llvm-profdata show --function=main --ic-targets --show-vtables text-from-indexed.proftext | FileCheck %s --check-prefix=INDEXED
-RUN: llvm-profdata show --function=main --ic-targets --show-vtables --text text-from-indexed.proftext | FileCheck %s --check-prefix=ICTEXT
+RUN: llvm-profdata merge --keep-vtable-symbols --text -o %t/text-from-indexed.proftext %t/indexed.profdata
+RUN: llvm-profdata show --function=main --ic-targets --show-vtables %t/text-from-indexed.proftext | FileCheck %s --check-prefix=INDEXED
+RUN: llvm-profdata show --function=main --ic-targets --show-vtables --text %t/text-from-indexed.proftext | FileCheck %s --check-prefix=ICTEXT
 
 INDEXED:      Counters:
 INDEXED-NEXT:   main:
@@ -35,6 +35,8 @@ INDEXED-NEXT: Functions shown: 1
 INDEXED-NEXT: Total functions: 6
 INDEXED-NEXT: Maximum function count: 1000
 INDEXED-NEXT: Maximum internal block count: 250
+INDEXED-NEXT: Total number of blocks: 8
+INDEXED-NEXT: Total count: 4001
 INDEXED-NEXT: Statistics for indirect call sites profile:
 INDEXED-NEXT:   Total number of sites: 2
 INDEXED-NEXT:   Total number of sites with values: 2

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -3012,15 +3012,13 @@ static int showInstrProfile(ShowFormat SFormat, raw_fd_ostream &OS) {
   OS << "\n";
   if (ShowAllFunctions || !FuncNameFilter.empty())
     OS << "Functions shown: " << ShownFunctions << "\n";
-  OS << "Total functions: " << PS->getNumFunctions() << "\n";
+  PS->printSummary(OS);
   if (ShowValueCutoff > 0) {
     OS << "Number of functions with maximum count (< " << ShowValueCutoff
        << "): " << BelowCutoffFunctions << "\n";
     OS << "Number of functions with maximum count (>= " << ShowValueCutoff
        << "): " << PS->getNumFunctions() - BelowCutoffFunctions << "\n";
   }
-  OS << "Maximum function count: " << PS->getMaxFunctionCount() << "\n";
-  OS << "Maximum internal block count: " << PS->getMaxInternalCount() << "\n";
 
   if (TopNFunctions) {
     std::vector<std::pair<std::string, uint64_t>> SortedHottestFuncs;
@@ -3050,11 +3048,8 @@ static int showInstrProfile(ShowFormat SFormat, raw_fd_ostream &OS) {
     showValueSitesStats(OS, IPVK_MemOPSize, VPStats[IPVK_MemOPSize]);
   }
 
-  if (ShowDetailedSummary) {
-    OS << "Total number of blocks: " << PS->getNumCounts() << "\n";
-    OS << "Total count: " << PS->getTotalCount() << "\n";
+  if (ShowDetailedSummary)
     PS->printDetailedSummary(OS);
-  }
 
   if (ShowBinaryIds)
     if (Error E = Reader->printBinaryIds(OS))


### PR DESCRIPTION
In the detailed summary, we want to report the fraction of total blocks that account for each percentile cutoff. Also, use `ProfileSummary::printSummary()` in Instr profiles for consistancy.