### PR TITLE
[compiler-rt][test] Add `env` command to fix command not found errors in compiler-rt with lit internal shell

### DIFF
--- a/compiler-rt/test/nsan/Posix/tls_reuse.c
+++ b/compiler-rt/test/nsan/Posix/tls_reuse.c
@@ -1,6 +1,6 @@
 /// The static TLS block is reused among by threads. The shadow is cleared.
 // RUN: %clang_nsan %s -o %t
-// RUN: NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 %run %t
+// RUN: env NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 %run %t
 
 #include <pthread.h>
 #include <stdio.h>

--- a/compiler-rt/test/nsan/nan.cpp
+++ b/compiler-rt/test/nsan/nan.cpp
@@ -1,11 +1,11 @@
 // RUN: %clangxx_nsan -O0 -g %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
 
 // RUN: %clangxx_nsan -O3 -g %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
 
 // RUN: %clangxx_nsan -O0 -g %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=1 not %run %t
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=1 not %run %t
 
 #include <cmath>
 #include <cstdio>

--- a/compiler-rt/test/nsan/softmax.cpp
+++ b/compiler-rt/test/nsan/softmax.cpp
@@ -1,14 +1,14 @@
 // RUN: %clangxx_nsan -O0 -g -DSOFTMAX=softmax %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0,log2_max_relative_error=19 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0,log2_max_relative_error=19 %run %t 2>&1 | FileCheck %s
 
 // RUN: %clangxx_nsan -O3 -g -DSOFTMAX=softmax %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0,log2_max_relative_error=19 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0,log2_max_relative_error=19 %run %t 2>&1 | FileCheck %s
 
 // RUN: %clangxx_nsan -O0 -g -DSOFTMAX=stable_softmax %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=1,log2_max_relative_error=19 %run %t 
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=1,log2_max_relative_error=19 %run %t 
 
 // RUN: %clangxx_nsan -O3 -g -DSOFTMAX=stable_softmax %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=1,log2_max_relative_error=19 %run %t
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=1,log2_max_relative_error=19 %run %t
 
 #include<iostream>
 #include<vector>

--- a/compiler-rt/test/nsan/sum.cpp
+++ b/compiler-rt/test/nsan/sum.cpp
@@ -1,14 +1,14 @@
 // RUN: %clangxx_nsan -O0 -mllvm -nsan-shadow-type-mapping=dqq -g -DSUM=NaiveSum -DFLT=float %s -o %t
-// RUN: NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 not %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 not %run %t 2>&1 | FileCheck %s
 
 // RUN: %clangxx_nsan -O3 -mllvm -nsan-shadow-type-mapping=dqq -g -DSUM=NaiveSum -DFLT=float %s -o %t
-// RUN: NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 not %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 not %run %t 2>&1 | FileCheck %s
 
 // RUN: %clangxx_nsan -O0 -mllvm -nsan-shadow-type-mapping=dqq -g -DSUM=KahanSum -DFLT=float %s -o %t
-// RUN: NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 %run %t
+// RUN: env NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 %run %t
 
 // RUN: %clangxx_nsan -O3 -mllvm -nsan-shadow-type-mapping=dqq -g -DSUM=KahanSum -DFLT=float %s -o %t
-// RUN: NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 %run %t
+// RUN: env NSAN_OPTIONS=halt_on_error=1,log2_max_relative_error=19 %run %t
 
 #include <chrono>
 #include <iostream>

--- a/compiler-rt/test/nsan/vec_sqrt_ext.cpp
+++ b/compiler-rt/test/nsan/vec_sqrt_ext.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx_nsan -O0 -g -mavx %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
 // RUN: %clangxx_nsan -O3 -g -mavx %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
 #include <iostream>
 #include <cmath>
 


### PR DESCRIPTION
There are several files in the compiler-rt subproject that have command not found errors. This patch uses the `env` command to properly set the environment variables correctly when using the lit internal shell.
fixes: #106598
[This change is relevant [RFC] Enabling the lit internal shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179) 