### PR TITLE
[clang][bytecode] Fix IntegralAP::is{Positive,Negative}

### DIFF
--- a/clang/lib/AST/ByteCode/IntegralAP.h
+++ b/clang/lib/AST/ByteCode/IntegralAP.h
@@ -136,8 +136,16 @@ public:
   APValue toAPValue(const ASTContext &) const { return APValue(toAPSInt()); }
 
   bool isZero() const { return V.isZero(); }
-  bool isPositive() const { return V.isNonNegative(); }
-  bool isNegative() const { return !V.isNonNegative(); }
+  bool isPositive() const {
+    if constexpr (Signed)
+      return V.isNonNegative();
+    return true;
+  }
+  bool isNegative() const {
+    if constexpr (Signed)
+      return !V.isNonNegative();
+    return false;
+  }
   bool isMin() const { return V.isMinValue(); }
   bool isMax() const { return V.isMaxValue(); }
   static constexpr bool isSigned() { return Signed; }

--- a/clang/test/AST/ByteCode/intap.cpp
+++ b/clang/test/AST/ByteCode/intap.cpp
@@ -104,6 +104,15 @@ static_assert(INT128_MAX == 0, ""); // expected-error {{failed}} \
                                     // ref-note {{evaluates to '170141183460469231731687303715884105727 == 0'}}
 static const __int128_t INT128_MIN = -INT128_MAX - 1;
 
+
+namespace PointerArithmeticOverflow {
+  int n;
+  constexpr int *p = (&n + 1) + (unsigned __int128)-1; // expected-error {{constant expression}} \
+                                                       // expected-note {{cannot refer to element 3402}} \
+                                                       // ref-error {{constant expression}} \
+                                                       // ref-note {{cannot refer to element 3402}}
+}
+
 namespace i128 {
 
   constexpr int128_t I128_1 = 12;


### PR DESCRIPTION
This depends on signed-ness.