### PR TITLE
[llvm-lit] Fix `TypeError` string argument expected  in lit's internal shell

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -217,8 +217,8 @@ def expand_glob(arg, cwd):
 
 
 def expand_glob_expressions(args, cwd):
-    result = [args[0]]
-    for arg in args[1:]:
+    result = []
+    for arg in args:
         result.extend(expand_glob(arg, cwd))
     return result
 
@@ -776,8 +776,8 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         # FIXME: Standardize on the builtin echo implementation. We can use a
         # temporary file to sidestep blocking pipe write issues.
 
-        # Ensure args[0] is hashable.
-        args[0] = expand_glob(args[0], cmd_shenv.cwd)[0]
+        # Expand all glob expressions
+        args = expand_glob_expressions(args, cmd_shenv.cwd)
 
         inproc_builtin = inproc_builtins.get(args[0], None)
         if inproc_builtin and (args[0] != "echo" or len(cmd.commands) == 1):
@@ -874,9 +874,6 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
                     f.close()
                     named_temp_files.append(f.name)
                     args[i] = arg.replace(kDevNull, f.name)
-
-        # Expand all glob expressions
-        args = expand_glob_expressions(args, cmd_shenv.cwd)
 
         # On Windows, do our own command line quoting for better compatibility
         # with some core utility distributions.

--- a/llvm/utils/lit/tests/shtest-glob.py
+++ b/llvm/utils/lit/tests/shtest-glob.py
@@ -5,8 +5,7 @@
 #
 # END.
 
-# CHECK: UNRESOLVED: shtest-glob :: glob-echo.txt ({{[^)]*}})
-# CHECK: TypeError: string argument expected, got 'GlobItem'
+# CHECK: PASS: shtest-glob :: glob-echo.txt ({{[^)]*}})
 
 # CHECK: FAIL: shtest-glob :: glob-mkdir.txt ({{[^)]*}})
 # CHECK: # error: command failed with exit status: 1


### PR DESCRIPTION
This patch addresses an issue encountered when running the BOLT test suite with the lit internal shell using the command: 
```
LIT_USE_INTERNAL_SHELL=1 ninja check-bolt
```
During execution, the following error was observed:
```
File "/usr/local/google/home/harinidonthula/llvm-project/llvm/utils/lit/lit/TestRunner.py", line 416, in executeBuiltinEcho
    stdout.write(encode(maybeUnescape(args[-1])))
TypeError: string argument expected, got 'GlobItem'
```
This error occurs because the `executeBuiltinEcho` function in the lit testing framework expects a string to be passed to `stdout.write`, but it received a `GlobItem` object instead. The `GlobItem` represents an unexpanded glob pattern that needs to be converted to a string before being processed.

This patch modifies the `expand_glob_expressions` function in `TestRunner.py` to expand all arguments instead of just the first one. Previously, only `args[0]` was expanded for glob expressions, which could lead to unexpected behavior when multiple arguments needed glob expansion.

Changes:
- The loop in `expand_glob_expressions` now iterates over all arguments instead of starting from the second one.
- The call to `expand_glob_expressions` has been moved earlier in the `_executeShCmd` function to ensure all arguments are expanded before any processing.
- Removed the previous separate expansion for args[0] as it is now redundant.
- Updated the `shtest-glob.py` test to check for the correct behavior, changing the expected output from `UNRESOLVED` to `PASS`.

These changes ensure that all glob expressions are properly expanded across all command arguments, improving the robustness and correctness of the lit internal shell.

This change is relevant for [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179/3)  
fixes: #102693