### PR TITLE
[SPARC][IAS] Add `illtrap` alias for `unimp`

### DIFF
--- a/llvm/lib/Target/Sparc/SparcInstrAliases.td
+++ b/llvm/lib/Target/Sparc/SparcInstrAliases.td
@@ -601,7 +601,7 @@ def : InstAlias<"flush", (FLUSH), 0>;
 // unimp -> unimp 0
 def : InstAlias<"unimp", (UNIMP 0), 0>;
 
-// Not in spec, but we follow GNU & Solaris behavior of having `illtrap`
+// Not in spec, but we follow Solaris behavior of having `illtrap`
 // interchangeable with `unimp` all the time.
 def : MnemonicAlias<"illtrap", "unimp">;
 

--- a/llvm/lib/Target/Sparc/SparcInstrAliases.td
+++ b/llvm/lib/Target/Sparc/SparcInstrAliases.td
@@ -601,6 +601,10 @@ def : InstAlias<"flush", (FLUSH), 0>;
 // unimp -> unimp 0
 def : InstAlias<"unimp", (UNIMP 0), 0>;
 
+// Not in spec, but we follow GNU & Solaris behavior of having `illtrap`
+// interchangeable with `unimp` all the time.
+def : MnemonicAlias<"illtrap", "unimp">;
+
 def : MnemonicAlias<"iflush", "flush">;
 
 def : MnemonicAlias<"stub", "stb">;

--- a/llvm/test/MC/Sparc/sparc-misc-instructions.s
+++ b/llvm/test/MC/Sparc/sparc-misc-instructions.s
@@ -6,3 +6,9 @@
 
         ! CHECK: unimp 0   ! encoding: [0x00,0x00,0x00,0x00]
         unimp 0
+
+        ! CHECK: unimp 0   ! encoding: [0x00,0x00,0x00,0x00]
+        illtrap
+
+        ! CHECK: unimp 0   ! encoding: [0x00,0x00,0x00,0x00]
+        illtrap 0


### PR DESCRIPTION
This follows Solaris behavior of allowing both mnemonics all the time.

Fixes https://github.com/llvm/llvm-project/issues/105639.