### PR TITLE
[LTO] Introduce getSourceModules (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -139,6 +139,10 @@ public:
         maybeAddDeclaration(FromModule, GUID);
     }
 
+    // Return the list of source modules sorted in the ascending alphabetical
+    // order.
+    SmallVector<StringRef, 0> getSourceModules() const;
+
     const ImportMapTyImpl &getImportMap() const { return ImportMap; }
 
   private:

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -354,10 +354,7 @@ void FunctionImporter::ImportMapTy::maybeAddDeclaration(
 
 SmallVector<StringRef, 0>
 FunctionImporter::ImportMapTy::getSourceModules() const {
-  SetVector<StringRef> ModuleSet;
-  for (const auto &[SrcMod, GUID] : ImportMap)
-    ModuleSet.insert(SrcMod);
-  SmallVector<StringRef, 0> Modules = ModuleSet.takeVector();
+  SmallVector<StringRef, 0> Modules(make_first_range(ImportMap));
   llvm::sort(Modules);
   return Modules;
 }

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -352,6 +352,16 @@ void FunctionImporter::ImportMapTy::maybeAddDeclaration(
   ImportMap[FromModule].try_emplace(GUID, GlobalValueSummary::Declaration);
 }
 
+SmallVector<StringRef, 0>
+FunctionImporter::ImportMapTy::getSourceModules() const {
+  SetVector<StringRef> ModuleSet;
+  for (const auto &[SrcMod, GUID] : ImportMap)
+    ModuleSet.insert(SrcMod);
+  SmallVector<StringRef, 0> Modules = ModuleSet.takeVector();
+  llvm::sort(Modules);
+  return Modules;
+}
+
 /// Import globals referenced by a function or other globals that are being
 /// imported, if importing such global is possible.
 class GlobalsImporter final {
@@ -1770,11 +1780,6 @@ Expected<bool> FunctionImporter::importFunctions(
   unsigned ImportedCount = 0, ImportedGVCount = 0;
 
   IRMover Mover(DestModule);
-  // Do the actual import of functions now, one Module at a time
-  std::set<StringRef> ModuleNameOrderedList;
-  for (const auto &FunctionsToImportPerModule : ImportList.getImportMap()) {
-    ModuleNameOrderedList.insert(FunctionsToImportPerModule.first);
-  }
 
   auto getImportType = [&](const FunctionsToImportTy &GUIDToImportType,
                            GlobalValue::GUID GUID)
@@ -1785,7 +1790,8 @@ Expected<bool> FunctionImporter::importFunctions(
     return Iter->second;
   };
 
-  for (const auto &Name : ModuleNameOrderedList) {
+  // Do the actual import of functions now, one Module at a time
+  for (const auto &Name : ImportList.getSourceModules()) {
     // Get the module for the import
     const auto &FunctionsToImportPerModule =
         ImportList.getImportMap().find(Name);


### PR DESCRIPTION
This patch introduces getSourceModules to compute the list of source
modules in the ascending alphabetical order.  The new function is
intended to hide implementation details of ImportMapTy while
simplifying FunctionImporter::importFunctions a little bit.
