### PR TITLE
[CodeGen] Refactor DeadMIElim isDead and GISel isTriviallyDead

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1323,6 +1323,11 @@ public:
     return getOpcode() == TargetOpcode::ANNOTATION_LABEL;
   }
 
+  bool isLifetimeMarker() const {
+    return getOpcode() == TargetOpcode::LIFETIME_START ||
+           getOpcode() == TargetOpcode::LIFETIME_END;
+  }
+
   /// Returns true if the MachineInstr represents a label.
   bool isLabel() const {
     return isEHLabel() || isGCLabel() || isAnnotationLabel();
@@ -1726,6 +1731,10 @@ public:
   /// SawStore is set to true, it means that there is a store (or call) between
   /// the instruction's location and its intended destination.
   bool isSafeToMove(bool &SawStore) const;
+
+  /// Return true if this instruction can be considered dead if all of its
+  /// defined registers are dead.
+  bool canBeDead() const;
 
   /// Returns true if this instruction's memory access aliases the memory
   /// access of Other.

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1732,9 +1732,9 @@ public:
   /// the instruction's location and its intended destination.
   bool isSafeToMove(bool &SawStore) const;
 
-  /// Return true if this instruction can be considered dead if all of its
-  /// defined registers are dead.
-  bool canBeDead() const;
+  /// Return true if this instruction would be trivially dead if all of its
+  /// defined registers were dead.
+  bool wouldBeTriviallyDead() const;
 
   /// Returns true if this instruction's memory access aliases the memory
   /// access of Other.

--- a/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
+++ b/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
@@ -117,7 +117,7 @@ bool DeadMachineInstructionElimImpl::isDead(const MachineInstr *MI) const {
     return true;
 
   // If there are no defs with uses, the instruction might be dead.
-  return MI->canBeDead();
+  return MI->wouldBeTriviallyDead();
 }
 
 bool DeadMachineInstructionElimImpl::runImpl(MachineFunction &MF) {

--- a/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
+++ b/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
@@ -80,23 +80,9 @@ INITIALIZE_PASS(DeadMachineInstructionElim, DEBUG_TYPE,
                 "Remove dead machine instructions", false, false)
 
 bool DeadMachineInstructionElimImpl::isDead(const MachineInstr *MI) const {
-  // Technically speaking inline asm without side effects and no defs can still
-  // be deleted. But there is so much bad inline asm code out there, we should
-  // let them be.
-  if (MI->isInlineAsm())
-    return false;
-
-  // Don't delete frame allocation labels.
-  if (MI->getOpcode() == TargetOpcode::LOCAL_ESCAPE ||
-      MI->getOpcode() == TargetOpcode::FAKE_USE)
-    return false;
-
-  // Don't delete instructions with side effects.
-  bool SawStore = false;
-  if (!MI->isSafeToMove(SawStore) && !MI->isPHI())
-    return false;
-
-  // Examine each operand.
+  // Instructions without side-effects are dead iff they only define dead regs.
+  // This function is hot and this loop returns early in the common case,
+  // so only perform additional checks before this if absolutely necessary.
   for (const MachineOperand &MO : MI->all_defs()) {
     Register Reg = MO.getReg();
     if (Reg.isPhysical()) {
@@ -120,8 +106,18 @@ bool DeadMachineInstructionElimImpl::isDead(const MachineInstr *MI) const {
     }
   }
 
-  // If there are no defs with uses, the instruction is dead.
-  return true;
+  // Technically speaking inline asm without side effects and no defs can still
+  // be deleted. But there is so much bad inline asm code out there, we should
+  // let them be.
+  if (MI->isInlineAsm())
+    return false;
+
+  // FIXME: See issue #105950 for why LIFETIME markers are considered dead here.
+  if (MI->isLifetimeMarker())
+    return true;
+
+  // If there are no defs with uses, the instruction might be dead.
+  return MI->canBeDead();
 }
 
 bool DeadMachineInstructionElimImpl::runImpl(MachineFunction &MF) {

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -221,34 +221,15 @@ bool llvm::canReplaceReg(Register DstReg, Register SrcReg,
 
 bool llvm::isTriviallyDead(const MachineInstr &MI,
                            const MachineRegisterInfo &MRI) {
-  // FIXME: This logical is mostly duplicated with
-  // DeadMachineInstructionElim::isDead. Why is LOCAL_ESCAPE not considered in
-  // MachineInstr::isLabel?
-
-  // Don't delete frame allocation labels.
-  if (MI.getOpcode() == TargetOpcode::LOCAL_ESCAPE)
-    return false;
-  // Don't delete fake uses.
-  if (MI.getOpcode() == TargetOpcode::FAKE_USE)
-    return false;
-  // LIFETIME markers should be preserved even if they seem dead.
-  if (MI.getOpcode() == TargetOpcode::LIFETIME_START ||
-      MI.getOpcode() == TargetOpcode::LIFETIME_END)
-    return false;
-
-  // If we can move an instruction, we can remove it.  Otherwise, it has
-  // a side-effect of some sort.
-  bool SawStore = false;
-  if (!MI.isSafeToMove(SawStore) && !MI.isPHI())
-    return false;
-
-  // Instructions without side-effects are dead iff they only define dead vregs.
+  // Instructions without side-effects are dead iff they only define dead regs.
+  // This function is hot and this loop returns early in the common case,
+  // so only perform additional checks before this if absolutely necessary.
   for (const auto &MO : MI.all_defs()) {
     Register Reg = MO.getReg();
     if (Reg.isPhysical() || !MRI.use_nodbg_empty(Reg))
       return false;
   }
-  return true;
+  return MI.canBeDead();
 }
 
 static void reportGISelDiagnostic(DiagnosticSeverity Severity,

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -229,7 +229,7 @@ bool llvm::isTriviallyDead(const MachineInstr &MI,
     if (Reg.isPhysical() || !MRI.use_nodbg_empty(Reg))
       return false;
   }
-  return MI.canBeDead();
+  return MI.wouldBeTriviallyDead();
 }
 
 static void reportGISelDiagnostic(DiagnosticSeverity Severity,

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -1342,7 +1342,7 @@ bool MachineInstr::wouldBeTriviallyDead() const {
   // If we can move an instruction, we can remove it.  Otherwise, it has
   // a side-effect of some sort.
   bool SawStore = false;
-  return isSafeToMove(SawStore) || isPHI();
+  return isPHI() || isSafeToMove(SawStore);
 }
 
 static bool MemOperandsHaveAlias(const MachineFrameInfo &MFI, AAResults *AA,

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -1323,7 +1323,7 @@ bool MachineInstr::isSafeToMove(bool &SawStore) const {
   return true;
 }
 
-bool MachineInstr::canBeDead() const {
+bool MachineInstr::wouldBeTriviallyDead() const {
   // Don't delete frame allocation labels.
   // FIXME: Why is LOCAL_ESCAPE not considered in MachineInstr::isLabel?
   if (getOpcode() == TargetOpcode::LOCAL_ESCAPE)
@@ -1335,6 +1335,7 @@ bool MachineInstr::canBeDead() const {
     return false;
 
   // LIFETIME markers should be preserved.
+  // FIXME: Why are LIFETIME markers not considered in MachineInstr::isPosition?
   if (isLifetimeMarker())
     return false;
 

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -1342,10 +1342,7 @@ bool MachineInstr::wouldBeTriviallyDead() const {
   // If we can move an instruction, we can remove it.  Otherwise, it has
   // a side-effect of some sort.
   bool SawStore = false;
-  if (!isSafeToMove(SawStore) && !isPHI())
-    return false;
-
-  return true;
+  return isSafeToMove(SawStore) || isPHI();
 }
 
 static bool MemOperandsHaveAlias(const MachineFrameInfo &MFI, AAResults *AA,


### PR DESCRIPTION
Merge GlobalISel's isTriviallyDead and DeadMachineInstructionElim's isDead code and remove all unnecessary checks from the hot path by looping over the operands before doing any other checks. Please double-check if this ok for the loop in DeadMIElim.

See #105950 for why DeadMIElim needs to remove LIFETIME markers even though they probably shouldn't generally be considered dead.

https://llvm-compile-time-tracker.com/compare.php?from=3e763db81607c71d0bb2eb4c01721ac6965d8de7&to=0f4e84a3df0d9ceb9a449cfedc9888245f65c9bd&stat=instructions:u
