### PR TITLE
[llvm-lit][test] Resolved typo in raising InternalShellError for export command in lit's internal shell

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/high-address-dereference.c
+++ b/compiler-rt/test/asan/TestCases/Posix/high-address-dereference.c
@@ -5,12 +5,11 @@
 
 // REQUIRES: x86_64-target-arch
 // RUN: %clang_asan %s -o %t
-// RUN: export %env_asan_opts=print_scariness=1
-// RUN: not %run %t 0x0000000000000000 2>&1 | FileCheck %s --check-prefixes=ZERO,HINT-PAGE0
-// RUN: not %run %t 0x0000000000000FFF 2>&1 | FileCheck %s --check-prefixes=LOW1,HINT-PAGE0
-// RUN: not %run %t 0x0000000000001000 2>&1 | FileCheck %s --check-prefixes=LOW2,HINT-NONE
-// RUN: not %run %t 0x4141414141414141 2>&1 | FileCheck %s --check-prefixes=HIGH,HINT-HIGHADDR
-// RUN: not %run %t 0xFFFFFFFFFFFFFFFF 2>&1 | FileCheck %s --check-prefixes=MAX,HINT-HIGHADDR
+// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x0000000000000000 2>&1 | FileCheck %s --check-prefixes=ZERO,HINT-PAGE0
+// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x0000000000000FFF 2>&1 | FileCheck %s --check-prefixes=LOW1,HINT-PAGE0
+// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x0000000000001000 2>&1 | FileCheck %s --check-prefixes=LOW2,HINT-NONE
+// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x4141414141414141 2>&1 | FileCheck %s --check-prefixes=HIGH,HINT-HIGHADDR
+// RUN: %env_asan_opts=print_scariness=1 not %run %t 0xFFFFFFFFFFFFFFFF 2>&1 | FileCheck %s --check-prefixes=MAX,HINT-HIGHADDR
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/compiler-rt/test/asan/TestCases/Posix/high-address-dereference.c
+++ b/compiler-rt/test/asan/TestCases/Posix/high-address-dereference.c
@@ -5,11 +5,12 @@
 
 // REQUIRES: x86_64-target-arch
 // RUN: %clang_asan %s -o %t
-// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x0000000000000000 2>&1 | FileCheck %s --check-prefixes=ZERO,HINT-PAGE0
-// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x0000000000000FFF 2>&1 | FileCheck %s --check-prefixes=LOW1,HINT-PAGE0
-// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x0000000000001000 2>&1 | FileCheck %s --check-prefixes=LOW2,HINT-NONE
-// RUN: %env_asan_opts=print_scariness=1 not %run %t 0x4141414141414141 2>&1 | FileCheck %s --check-prefixes=HIGH,HINT-HIGHADDR
-// RUN: %env_asan_opts=print_scariness=1 not %run %t 0xFFFFFFFFFFFFFFFF 2>&1 | FileCheck %s --check-prefixes=MAX,HINT-HIGHADDR
+// RUN: export %env_asan_opts=print_scariness=1
+// RUN: not %run %t 0x0000000000000000 2>&1 | FileCheck %s --check-prefixes=ZERO,HINT-PAGE0
+// RUN: not %run %t 0x0000000000000FFF 2>&1 | FileCheck %s --check-prefixes=LOW1,HINT-PAGE0
+// RUN: not %run %t 0x0000000000001000 2>&1 | FileCheck %s --check-prefixes=LOW2,HINT-NONE
+// RUN: not %run %t 0x4141414141414141 2>&1 | FileCheck %s --check-prefixes=HIGH,HINT-HIGHADDR
+// RUN: not %run %t 0xFFFFFFFFFFFFFFFF 2>&1 | FileCheck %s --check-prefixes=MAX,HINT-HIGHADDR
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -356,7 +356,7 @@ def executeBuiltinPopd(cmd, shenv):
 def executeBuiltinExport(cmd, shenv):
     """executeBuiltinExport - Set an environment variable."""
     if len(cmd.args) != 2:
-        raise InternalShellError("'export' supports only one argument")
+        raise InternalShellError(cmd, "'export' supports only one argument")
     updateEnv(shenv, cmd.args)
     return ShellCommandResult(cmd, "", "", 0, False)
 

--- a/llvm/utils/lit/tests/Inputs/shtest-export/export-too-many-args.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-export/export-too-many-args.txt
@@ -1,0 +1,2 @@
+## Test export command with too many arguments.
+# RUN: export FOO=1 BAR=2

--- a/llvm/utils/lit/tests/Inputs/shtest-export/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-export/lit.cfg
@@ -1,0 +1,7 @@
+import lit.formats
+
+config.name = "shtest-export"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None

--- a/llvm/utils/lit/tests/shtest-export.py
+++ b/llvm/utils/lit/tests/shtest-export.py
@@ -1,0 +1,12 @@
+## Test the export command.
+
+# RUN: not %{lit} -a -v %{inputs}/shtest-export \
+# RUN: | FileCheck -match-full-lines %s
+#
+# END.
+
+# CHECK: FAIL: shtest-export :: export-too-many-args.txt {{.*}}
+# CHECK: export FOO=1 BAR=2
+# CHECK: # executed command: export FOO=1 BAR=2
+# CHECK: # | 'export' supports only one argument
+# CHECK: # error: command failed with exit status: {{.*}}


### PR DESCRIPTION
This patch fixes the incorrect usage of lit's built-in `export` command. There is a typo in raising the error itself where the error being raised had the wrong number of parameters passed in.

Fixes https://github.com/llvm/llvm-project/issues/102386.