### PR TITLE
[mlir][Transforms][NFC] Dialect conversion: Remove redundant `ReplaceBlockArgRewrite`

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -1296,7 +1296,6 @@ Block *ConversionPatternRewriterImpl::applySignatureConversion(
         OpBuilder::InsertPoint(newBlock, newBlock->begin()), origArg.getLoc(),
         /*inputs=*/replArgs, origArgType, converter);
     mapping.map(origArg, argMat);
-    appendRewrite<ReplaceBlockArgRewrite>(block, origArg);
 
     Type legalOutputType;
     if (converter) {


### PR DESCRIPTION
There was a redundant `appendRewrite<ReplaceBlockArgRewrite>(block, origArg);` in `ConversionPatternRewriterImpl::applySignatureConversion` that had no effect.