### PR TITLE
[libc++][test] Do not test Clang bug in `is_constructible.pass.cpp`

### DIFF
--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
@@ -228,7 +228,7 @@ int main(int, char**)
     // But the rvalue to lvalue reference binding isn't allowed according to
     // [over.match.ref] despite Clang accepting it.
     test_is_constructible<int&, ExplicitTo<int&>>();
-#ifndef __clang__
+#ifndef TEST_COMPILER_CLANG
     test_is_not_constructible<const int&, ExplicitTo<int&&>>();
 #endif
 

--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
@@ -228,8 +228,8 @@ int main(int, char**)
     // But the rvalue to lvalue reference binding isn't allowed according to
     // [over.match.ref] despite Clang accepting it.
     test_is_constructible<int&, ExplicitTo<int&>>();
-#ifndef TEST_COMPILER_GCC
-    test_is_constructible<const int&, ExplicitTo<int&&>>();
+#ifndef __clang__
+    test_is_not_constructible<const int&, ExplicitTo<int&&>>();
 #endif
 
     static_assert(std::is_constructible<int&&, ExplicitTo<int&&>>::value, "");


### PR DESCRIPTION
A comment in `is_constructible.pass.cpp` suggests that Clang is non-conforming in accepting construction of `const int&` from `ExplicitTo<int&&>`.

https://github.com/llvm/llvm-project/blob/3ef64f7ab5b8651eab500cd944984379fce5f639/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp#L225-L229

This PR changes the test to expect the standard-conforming behavior, which makes the test pass on MSVC.