### PR TITLE
[clang] Keep using declarations at head of list in addOrReplaceDecl

### DIFF
--- a/clang/include/clang/AST/DeclContextInternals.h
+++ b/clang/include/clang/AST/DeclContextInternals.h
@@ -234,6 +234,15 @@ public:
         return;
       }
 
+      // Keep using declarations at the front of the list.
+      if (D->getIdentifierNamespace() & Decl::IDNS_Using) {
+        ASTContext &C = D->getASTContext();
+        DeclListNode *Node = C.AllocateDeclListNode(D);
+        Node->Rest = Data.getPointer();
+        Data.setPointer(Node);
+        return;
+      }
+
       // Add D after OldD.
       ASTContext &C = D->getASTContext();
       DeclListNode *Node = C.AllocateDeclListNode(OldD);
@@ -245,27 +254,50 @@ public:
     // FIXME: Move the assert before the single decl case when we fix the
     // duplication coming from the ASTReader reading builtin types.
     assert(!llvm::is_contained(getLookupResult(), D) && "Already exists!");
-    // Determine if this declaration is actually a redeclaration.
-    for (DeclListNode *N = getAsList(); /*return in loop*/;
-         N = N->Rest.dyn_cast<DeclListNode *>()) {
+
+    DeclListNode *Prev = nullptr;
+    for (DeclListNode *N = getAsList(); N;
+         Prev = N, N = N->Rest.dyn_cast<DeclListNode *>()) {
       if (D->declarationReplaces(N->D, IsKnownNewer)) {
         N->D = D;
         return;
       }
-      if (auto *ND = N->Rest.dyn_cast<NamedDecl *>()) {
-        if (D->declarationReplaces(ND, IsKnownNewer)) {
-          N->Rest = D;
-          return;
-        }
 
-        // Add D after ND.
+      // Keep using declarations at the front of the list.
+      if ((D->getIdentifierNamespace() & Decl::IDNS_Using) &&
+          N->D->getIdentifierNamespace() != Decl::IDNS_Using) {
         ASTContext &C = D->getASTContext();
-        DeclListNode *Node = C.AllocateDeclListNode(ND);
-        N->Rest = Node;
-        Node->Rest = D;
+        DeclListNode *Node = C.AllocateDeclListNode(D);
+        Node->Rest = N;
+        if (Prev)
+          Prev->Rest = Node;
+        else
+          Data.setPointer(Node);
         return;
       }
     }
+
+    // P->Rest must be the tail NamedDecl* at this point.
+    NamedDecl *N = Prev->Rest.get<NamedDecl *>();
+    if (D->declarationReplaces(N, IsKnownNewer)) {
+      Prev->Rest = D;
+      return;
+    }
+
+    // Keep using declarations at the front of the list.
+    if (D->getIdentifierNamespace() & Decl::IDNS_Using) {
+      ASTContext &C = D->getASTContext();
+      DeclListNode *Node = C.AllocateDeclListNode(D);
+      Node->Rest = Data.getPointer();
+      Data.setPointer(Node);
+      return;
+    }
+
+    // Add D after N.
+    ASTContext &C = D->getASTContext();
+    DeclListNode *Node = C.AllocateDeclListNode(N);
+    Prev->Rest = Node;
+    Node->Rest = D;
   }
 
   /// Add a declaration to the list without checking if it replaces anything.

--- a/clang/test/SemaCXX/PR105976.cpp
+++ b/clang/test/SemaCXX/PR105976.cpp
@@ -1,0 +1,52 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -verify-ignore-unexpected=note %s
+
+struct A1 {
+  void operator==(A1);
+};
+
+struct A2 {
+  void operator==(A2);
+};
+
+struct A3 {
+  void operator==(A3);
+};
+
+struct A4 : A1, A2 {
+  using A1::operator==;
+  using A2::operator==;
+};
+
+struct A5 : A3, A4 {};
+
+void A6() {
+  A5{} == A5{};
+  // expected-error@-1 {{member 'operator==' found in multiple base classes of different types}}
+  // expected-error@-2 {{use of overloaded operator '==' is ambiguous}}
+}
+
+
+struct B1 {
+  template <typename T> void operator==(T);
+};
+
+struct B2 {
+  template <typename T> void operator==(T);
+};
+
+struct B3 {
+  template <typename T> void operator==(T);
+};
+
+struct B4 : B1, B2 {
+  using B1::operator==;
+  using B2::operator==;
+};
+
+struct B5 : B3, B4 {};
+
+void B6() {
+  B5{} == B5{};
+  // expected-error@-1 {{member 'operator==' found in multiple base classes of different types}}
+  // expected-error@-2 {{use of overloaded operator '==' is ambiguous}}
+}


### PR DESCRIPTION
Fix #104883.
Fix #104800.

Thanks @Endilll for the reduced reproducer. Bisection points to 0cb7e7ca0c864e052bf49978f3bcd667c9e16930 as the faulty commit, but nothing there seems to indicate what the problem is. After some print debugging, `Decl` on [this line](https://github.com/llvm/llvm-project/blob/f22b1da8791edd557ce34c87190e329df2e1c892/clang/lib/Sema/SemaOverload.cpp#L7429) is a `UsingDecl`, not a `CXXMethodDecl`, and the cast fails.

Add a conditional case for `UsingDecl`.

I am not familiar with Clang/Sema so please make sure this fix makes sense.