### PR TITLE
[libc++][NFC] Don't explicitly provide propagate_on_container_swap when calling __swap_allocator

### DIFF
--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -620,8 +620,7 @@ inline void __forward_list_base<_Tp, _Alloc>::swap(__forward_list_base& __x)
     _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
 #endif
 {
-  std::__swap_allocator(
-      __alloc(), __x.__alloc(), integral_constant<bool, __node_traits::propagate_on_container_swap::value>());
+  std::__swap_allocator(__alloc(), __x.__alloc());
   using std::swap;
   swap(__before_begin()->__next_, __x.__before_begin()->__next_);
 }

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -1821,8 +1821,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::swap(vector& __x)
   std::swap(this->__begin_, __x.__begin_);
   std::swap(this->__end_, __x.__end_);
   std::swap(this->__end_cap(), __x.__end_cap());
-  std::__swap_allocator(
-      this->__alloc(), __x.__alloc(), integral_constant<bool, __alloc_traits::propagate_on_container_swap::value>());
+  std::__swap_allocator(this->__alloc(), __x.__alloc());
 }
 
 template <class _Tp, class _Allocator>
@@ -2820,8 +2819,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::swap(vector& __x)
   std::swap(this->__begin_, __x.__begin_);
   std::swap(this->__size_, __x.__size_);
   std::swap(this->__cap(), __x.__cap());
-  std::__swap_allocator(
-      this->__alloc(), __x.__alloc(), integral_constant<bool, __alloc_traits::propagate_on_container_swap::value>());
+  std::__swap_allocator(this->__alloc(), __x.__alloc());
 }
 
 template <class _Allocator>


### PR DESCRIPTION
`__swap_allocator` does this automatically when not providing it explicitly, so this is just more code without any benefit.
