### PR TITLE
[test-release.sh] Fix sed encoding issues on macOS

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -755,8 +755,8 @@ for Flavor in $Flavors ; do
             # case there are build paths in the debug info. Do the same sub-
             # stitution on both files in case the string occurrs naturally.
             if ! cmp -s \
-                <(env LC_CTYPE=C sed -e 's,Phase1,Phase2,g' -e 's,Phase2,Phase3,g' $p2) \
-                <(env LC_CTYPE=C sed -e 's,Phase1,Phase2,g' -e 's,Phase2,Phase3,g' $p3) \
+                <(env LC_ALL=C sed -e 's,Phase1,Phase2,g' -e 's,Phase2,Phase3,g' $p2) \
+                <(env LC_ALL=C sed -e 's,Phase1,Phase2,g' -e 's,Phase2,Phase3,g' $p3) \
                 16 16; then
                 echo "file `basename $p2` differs between phase 2 and phase 3"
             fi


### PR DESCRIPTION
When using bsd sed that ships with macOS on the object files for comparison, every command would error with

```
sed: RE error: illegal byte sequence
```

This was potentially fixed for an older version in 6c52b02e7d0df765da608d8119ae8a20de142cff but even the commands in the example there still have this error. You can repro this with any binary:

```
$ sed s/a/b/ /bin/ls >/dev/null
sed: RE error: illegal byte sequence
```

Where LC_CTYPE appears to no longer solve the issue:

```
$ LC_CTYPE=C sed s/a/b/ /bin/ls >/dev/null
sed: RE error: illegal byte sequence
```

But this change with LC_ALL does:

```
$ LC_ALL=C sed s/a/b/ /bin/ls >/dev/null; echo $?
0
```

It seems like the difference here is that if you have LC_ALL set to something else, LC_CTYPE does not override it. More info: https://stackoverflow.com/a/23584470/902968