### PR TITLE
[test-release.sh] Fix python 3.12 compatibility

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -647,7 +647,7 @@ if [ $do_test_suite = "yes" ]; then
   TestSuiteSrcDir="$BuildDir/llvm-test-suite"
 
   ${venv} $SandboxDir
-  $SandboxDir/bin/python $BuildDir/llvm-project/llvm/utils/lit/setup.py install
+  $SandboxDir/bin/python -m pip install $BuildDir/llvm-project/llvm/utils/lit
   mkdir -p $TestSuiteBuildDir
 fi
 


### PR DESCRIPTION
Virtual environments in python 3.12 no longer installs setuptools by default in order to push people towards newer syntax for installing packages. This new syntax is also compatible with python 3.8 which is the current lowest supported version mentioned in the docs.

Docs: https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#what-commands-should-be-used-instead

Fixes: https://github.com/llvm/llvm-project/issues/90197