### PR TITLE
[clang-cl] [AST] Fix MS 1920+ placeholder return type mangling for lambdas

### DIFF
--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -2967,13 +2967,12 @@ void MicrosoftCXXNameMangler::mangleFunctionType(const FunctionType *T,
       mangleType(ResultType, Range, QMM_Result);
     } else if (IsInLambda) {
       if (const auto *AT = ResultType->getContainedAutoType()) {
-        assert(AT->getKeyword() == AutoTypeKeyword::Auto &&
-               "should only need to mangle auto!");
-        (void)AT;
+        assert(AT->getKeyword() != AutoTypeKeyword::GNUAutoType &&
+               "shouldn't need to mangle __auto_type!");
         Out << '?';
         mangleQualifiers(ResultType.getLocalQualifiers(), /*IsMember=*/false);
         Out << '?';
-        mangleSourceName("<auto>");
+        mangleSourceName(AT->isDecltypeAuto() ? "<decltype-auto>" : "<auto>");
         Out << '@';
       } else {
         Out << '@';

--- a/clang/test/CodeGenCXX/mangle-ms-auto-return.cpp
+++ b/clang/test/CodeGenCXX/mangle-ms-auto-return.cpp
@@ -215,6 +215,8 @@ void test_template_decltypeauto() {
 // Still want to use clang's custom mangling for lambdas to keep backwards compatibility until
 // MSVC lambda name mangling has been deciphered.
 void test_lambda() {
+  int i = 0;
+
   auto lambdaIntRetAuto = []() { return 0; };
   lambdaIntRetAuto();
   // CHECK: call {{.*}} @"??R<lambda_1>@?0??test_lambda@@YAXXZ@QEBA?A?<auto>@@XZ"
@@ -226,6 +228,18 @@ void test_lambda() {
   auto lambdaGenericIntIntRetAuto = [](auto a) { return a; };
   lambdaGenericIntIntRetAuto(0);
   // CHECK: call {{.*}} @"??$?RH@<lambda_0>@?0??test_lambda@@YAXXZ@QEBA?A?<auto>@@H@Z"
+
+  auto lambdaRetTrailingAuto = []() -> auto { return 0; };
+  lambdaRetTrailingAuto();
+  // CHECK: call {{.*}} @"??R<lambda_3>@?0??test_lambda@@YAXXZ@QEBA?A?<auto>@@XZ"
+
+  auto lambdaRetTrailingDecltypeAuto = []() -> decltype(auto) { return 0; };
+  lambdaRetTrailingDecltypeAuto();
+  // CHECK: call {{.*}} @"??R<lambda_4>@?0??test_lambda@@YAXXZ@QEBA?A?<decltype-auto>@@XZ"
+
+  auto lambdaRetTrailingRefCollapse = [](int x) -> auto&& { return x; };
+  lambdaRetTrailingRefCollapse(i);
+  // CHECK: call {{.*}} @"??R<lambda_5>@?0??test_lambda@@YAXXZ@QEBA?A?<auto>@@H@Z"
 }
 
 auto TestTrailingInt() -> int {


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/104722.

Missed handling `decltype(auto)` trailing return types for lambdas.
This was a mistake and regression on my part with my PR, https://github.com/llvm/llvm-project/pull/104722.

Added some missing unit tests to test for the various placeholder trailing return types in lambdas.