### PR TITLE
[test-release.sh] Increase ninja keep going tasks

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -564,7 +564,7 @@ function test_llvmCore() {
     if [ ${MAKE} = 'ninja' ]; then
       # Ninja doesn't have a documented "keep-going-forever" mode, we need to
       # set a limit on how many jobs can fail before we give up.
-      KeepGoing="-k 100"
+      KeepGoing="-k 100000"
     fi
 
     cd $ObjDir


### PR DESCRIPTION
The intent of this code is to keep going "forever", limiting to 100 tasks isn't suitable in release testing. The llvm-test-suite repo has ~11k actions today, so we at least want to be larger than that. I don't see a reason to limit to something closer.