### PR TITLE
[lldb] unique_ptr-ify some GetUserExpression APIs.

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -495,7 +495,7 @@ public:
     return IsPointerOrReferenceType(type, nullptr);
   }
 
-  virtual UserExpression *GetUserExpression(
+  virtual std::unique_ptr<UserExpression> GetUserExpression(
       llvm::StringRef expr, llvm::StringRef prefix, SourceLanguage language,
       Expression::ResultType desired_type,
       const EvaluateExpressionOptions &options, ValueObject *ctx_obj) {

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1174,7 +1174,7 @@ public:
   // parameters have the same meaning as for the UserExpression constructor.
   // Returns a new-ed object which the caller owns.
 
-  UserExpression *
+  std::unique_ptr<UserExpression>
   GetUserExpressionForLanguage(llvm::StringRef expr, llvm::StringRef prefix,
                                SourceLanguage language,
                                Expression::ResultType desired_type,

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -251,9 +251,9 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
     if (comp_unit)
       language = comp_unit->GetLanguage();
 
-    m_user_expression_sp.reset(GetTarget().GetUserExpressionForLanguage(
+    m_user_expression_sp = GetTarget().GetUserExpressionForLanguage(
         condition_text, llvm::StringRef(), language, Expression::eResultTypeAny,
-        EvaluateExpressionOptions(), nullptr, error));
+        EvaluateExpressionOptions(), nullptr, error);
     if (error.Fail()) {
       LLDB_LOGF(log, "Error getting condition expression: %s.",
                 error.AsCString());

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -463,9 +463,9 @@ void Watchpoint::SetCondition(const char *condition) {
   } else {
     // Pass nullptr for expr_prefix (no translation-unit level definitions).
     Status error;
-    m_condition_up.reset(m_target.GetUserExpressionForLanguage(
+    m_condition_up = m_target.GetUserExpressionForLanguage(
         condition, {}, {}, UserExpression::eResultTypeAny,
-        EvaluateExpressionOptions(), nullptr, error));
+        EvaluateExpressionOptions(), nullptr, error);
     if (error.Fail()) {
       // FIXME: Log something...
       m_condition_up.reset();

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -9741,7 +9741,7 @@ void ScratchTypeSystemClang::Dump(llvm::raw_ostream &output) {
   }
 }
 
-UserExpression *ScratchTypeSystemClang::GetUserExpression(
+std::unique_ptr<UserExpression> ScratchTypeSystemClang::GetUserExpression(
     llvm::StringRef expr, llvm::StringRef prefix, SourceLanguage language,
     Expression::ResultType desired_type,
     const EvaluateExpressionOptions &options, ValueObject *ctx_obj) {
@@ -9749,8 +9749,8 @@ UserExpression *ScratchTypeSystemClang::GetUserExpression(
   if (!target_sp)
     return nullptr;
 
-  return new ClangUserExpression(*target_sp.get(), expr, prefix, language,
-                                 desired_type, options, ctx_obj);
+  return std::make_unique<ClangUserExpression>(
+      *target_sp.get(), expr, prefix, language, desired_type, options, ctx_obj);
 }
 
 FunctionCaller *ScratchTypeSystemClang::GetFunctionCaller(

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -1299,12 +1299,10 @@ public:
   /// \see lldb_private::TypeSystem::Dump
   void Dump(llvm::raw_ostream &output) override;
 
-  UserExpression *GetUserExpression(llvm::StringRef expr,
-                                    llvm::StringRef prefix,
-                                    SourceLanguage language,
-                                    Expression::ResultType desired_type,
-                                    const EvaluateExpressionOptions &options,
-                                    ValueObject *ctx_obj) override;
+  std::unique_ptr<UserExpression> GetUserExpression(
+      llvm::StringRef expr, llvm::StringRef prefix, SourceLanguage language,
+      Expression::ResultType desired_type,
+      const EvaluateExpressionOptions &options, ValueObject *ctx_obj) override;
 
   FunctionCaller *GetFunctionCaller(const CompilerType &return_type,
                                     const Address &function_address,

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2511,7 +2511,7 @@ Target::GetPersistentExpressionStateForLanguage(lldb::LanguageType language) {
   return nullptr;
 }
 
-UserExpression *Target::GetUserExpressionForLanguage(
+std::unique_ptr<UserExpression> Target::GetUserExpressionForLanguage(
     llvm::StringRef expr, llvm::StringRef prefix, SourceLanguage language,
     Expression::ResultType desired_type,
     const EvaluateExpressionOptions &options, ValueObject *ctx_obj,
@@ -2534,8 +2534,8 @@ UserExpression *Target::GetUserExpressionForLanguage(
     return nullptr;
   }
 
-  auto *user_expr = ts->GetUserExpression(expr, prefix, language, desired_type,
-                                          options, ctx_obj);
+  auto user_expr = ts->GetUserExpression(expr, prefix, language, desired_type,
+                                         options, ctx_obj);
   if (!user_expr)
     error.SetErrorStringWithFormat(
         "Could not create an expression for language %s",


### PR DESCRIPTION
These methods already returned a uniquely owned object, this just makes them self-documenting.