### PR TITLE
[NFC][VPlan] Trim extra spaces in `VPDerivedIVRecipe::print` during debugging

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1455,7 +1455,7 @@ void VPDerivedIVRecipe::print(raw_ostream &O, const Twine &Indent,
                               VPSlotTracker &SlotTracker) const {
   O << Indent;
   printAsOperand(O, SlotTracker);
-  O << Indent << "= DERIVED-IV ";
+  O << " = DERIVED-IV ";
   getStartValue()->printAsOperand(O, SlotTracker);
   O << " + ";
   getOperand(1)->printAsOperand(O, SlotTracker);


### PR DESCRIPTION
before:
```
    EMIT vp<%3> = CANONICAL-INDUCTION ir<0>, vp<%8>
    vp<%4>    = DERIVED-IV ir<%n> + vp<%3> * ir<-1>
    vp<%5> = SCALAR-STEPS vp<%4>, ir<-1>
```

after:
```
    EMIT vp<%3> = CANONICAL-INDUCTION ir<0>, vp<%8>
    vp<%4> = DERIVED-IV ir<%n> + vp<%3> * ir<-1>
    vp<%5> = SCALAR-STEPS vp<%4>, ir<-1>
```