### PR TITLE
[flang] Silence spurious error

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1797,6 +1797,9 @@ void AttrsVisitor::SetBindNameOn(Symbol &symbol) {
     }
     auto last{label->find_last_not_of(" ")};
     label = label->substr(first, last - first + 1);
+  } else if (symbol.GetIsExplicitBindName()) {
+    // don't try to override explicit binding name with default
+    return;
   } else if (ClassifyProcedure(symbol) == ProcedureDefinitionClass::Internal) {
     // BIND(C) does not give an implicit binding label to internal procedures.
     return;

--- a/flang/test/Semantics/declarations03.f90
+++ b/flang/test/Semantics/declarations03.f90
@@ -50,6 +50,9 @@ module m
   !ERROR: BIND_C attribute was already specified on 's5'
   integer, bind(c, name="ss2") :: s5
 
+  integer, bind(c, name="s6explicit") :: s6
+  dimension s6(10) ! caused spurious error
+
 end
 
 subroutine common1()


### PR DESCRIPTION
Don't attempt to give an object a default binding label when it shows up in a declaration after it has already been given an explicit binding label in an earlier declaration.

Fixes https://github.com/llvm/llvm-project/issues/106019.