### PR TITLE
[AMDGPU][CodeGen][True16][Test] add test files for gfx11 vop1 instructions in true16/fake16 format

### DIFF
--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vop1-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vop1-fake16.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,+real-true16 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-real-true16 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
 
 v_bfrev_b32_e64 v5, v1
 // GFX11: encoding: [0x05,0x00,0xb8,0xd5,0x01,0x01,0x00,0x00]


### PR DESCRIPTION
This is a NFC change to add tests for true16/fake16 flow. We need to have two sets of asm/disasm tests for true16 and fake16 flow and this patch is adding the missing one. The naming convension is that true16 filename is the default one while the fake16 filename has "fake16" attached to it.

This patch
1. add true16 and fake16 version for vop3_from_vop1 test file
2. rename a test file to keep a consistant naming pattern

The true16 test file will be updated when more true16 commands are supported in the up coming patches