### PR TITLE
[SCCP] Propagate non-null pointers

### DIFF
--- a/llvm/test/Transforms/SCCP/pointer-nonnull.ll
+++ b/llvm/test/Transforms/SCCP/pointer-nonnull.ll
@@ -14,8 +14,7 @@ define i1 @test_no_attr(ptr %p) {
 define i1 @test_nonnull(ptr nonnull %p) {
 ; CHECK-LABEL: define i1 @test_nonnull(
 ; CHECK-SAME: ptr nonnull [[P:%.*]]) {
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne ptr [[P]], null
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %cmp = icmp ne ptr %p, null
   ret i1 %cmp
@@ -24,8 +23,7 @@ define i1 @test_nonnull(ptr nonnull %p) {
 define i1 @test_nonnull_eq(ptr nonnull %p) {
 ; CHECK-LABEL: define i1 @test_nonnull_eq(
 ; CHECK-SAME: ptr nonnull [[P:%.*]]) {
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[P]], null
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 false
 ;
   %cmp = icmp eq ptr %p, null
   ret i1 %cmp
@@ -34,8 +32,7 @@ define i1 @test_nonnull_eq(ptr nonnull %p) {
 define i1 @test_dereferenceable(ptr dereferenceable(4) %p) {
 ; CHECK-LABEL: define i1 @test_dereferenceable(
 ; CHECK-SAME: ptr dereferenceable(4) [[P:%.*]]) {
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne ptr [[P]], null
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %cmp = icmp ne ptr %p, null
   ret i1 %cmp
@@ -57,8 +54,7 @@ define i1 @test_gep_nuw(ptr nonnull %p, i64 %x) {
 ; CHECK-LABEL: define i1 @test_gep_nuw(
 ; CHECK-SAME: ptr nonnull [[P:%.*]], i64 [[X:%.*]]) {
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr nuw i8, ptr [[P]], i64 [[X]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne ptr [[GEP]], null
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %gep = getelementptr nuw i8, ptr %p, i64 %x
   %cmp = icmp ne ptr %gep, null
@@ -69,8 +65,7 @@ define i1 @test_gep_inbounds(ptr nonnull %p, i64 %x) {
 ; CHECK-LABEL: define i1 @test_gep_inbounds(
 ; CHECK-SAME: ptr nonnull [[P:%.*]], i64 [[X:%.*]]) {
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds i8, ptr [[P]], i64 [[X]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne ptr [[GEP]], null
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %gep = getelementptr inbounds i8, ptr %p, i64 %x
   %cmp = icmp ne ptr %gep, null
@@ -94,8 +89,7 @@ define i1 @test_select(i1 %c, ptr nonnull %p, i64 %x) {
 ; CHECK-SAME: i1 [[C:%.*]], ptr nonnull [[P:%.*]], i64 [[X:%.*]]) {
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr nuw i8, ptr [[P]], i64 [[X]]
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C]], ptr [[P]], ptr [[GEP]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne ptr [[SEL]], null
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %gep = getelementptr nuw i8, ptr %p, i64 %x
   %sel = select i1 %c, ptr %p, ptr %gep
@@ -127,8 +121,7 @@ define i1 @test_phi(i1 %c, ptr nonnull %p, i64 %x) {
 ; CHECK-NEXT:    br label %[[JOIN]]
 ; CHECK:       [[JOIN]]:
 ; CHECK-NEXT:    [[PHI:%.*]] = phi ptr [ [[P]], %[[ENTRY]] ], [ [[GEP]], %[[IF]] ]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne ptr [[PHI]], null
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
 entry:
   br i1 %c, label %if, label %join


### PR DESCRIPTION
Add NotConstant(Null) roots for nonnull arguments and then propagate them through nuw/inbounds GEPs.

Having this functionality in SCCP is useful because it allows reliably eliminating null comparisons, independently of how deeply nested they are in selects/phis. This handles cases that would hit a cutoff in ValueTracking otherwise.

The implementation is something of a MVP, there are a number of obvious extensions (e.g. allocas are also non-null).