### PR TITLE
[compiler-rt][rtsan] Fix failing file permissions test

### DIFF
--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
@@ -193,25 +193,19 @@ TEST_F(RtsanFileTest, OpenatDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(func);
 }
 
-// FIXME: This fails on the build machines, but not locally!
-// see https://github.com/llvm/llvm-project/pull/105732#issuecomment-2310286530
-// Value of: st.st_mode & 0777
-// Expected: is equal to 420
-// Actual: 384
-// TEST_F(RtsanFileTest, OpenCreatesFileWithProperMode) {
-//   const int mode = S_IRGRP | S_IROTH | S_IRUSR | S_IWUSR;
-//
-//   const int fd = open(GetTemporaryFilePath(), O_CREAT | O_WRONLY, mode);
-//   ASSERT_THAT(fd, Ne(-1));
-//   close(fd);
-//
-//   struct stat st;
-//   ASSERT_THAT(stat(GetTemporaryFilePath(), &st), Eq(0));
-//
-//   // Mask st_mode to get permission bits only
-//
-//   //ASSERT_THAT(st.st_mode & 0777, Eq(mode)); FAILED ASSERTION
-// }
+TEST_F(RtsanFileTest, OpenCreatesFileWithProperMode) {
+  const int mode = S_IRGRP | S_IROTH | S_IRUSR | S_IWUSR;
+
+  const int fd = open(GetTemporaryFilePath(), O_CREAT | O_WRONLY, mode);
+  ASSERT_THAT(fd, Ne(-1));
+  close(fd);
+
+  struct stat st;
+  ASSERT_THAT(stat(GetTemporaryFilePath(), &st), Eq(0));
+
+  // Mask st_mode to get permission bits only
+  ASSERT_THAT(st.st_mode & 0777, Eq(mode));
+}
 
 TEST_F(RtsanFileTest, CreatDiesWhenRealtime) {
   auto func = [this]() { creat(GetTemporaryFilePath(), S_IWOTH | S_IROTH); };

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
@@ -194,6 +194,9 @@ TEST_F(RtsanFileTest, OpenatDiesWhenRealtime) {
 }
 
 TEST_F(RtsanFileTest, OpenCreatesFileWithProperMode) {
+  const mode_t existing_umask = umask(0);
+  umask(existing_umask);
+
   const int mode = S_IRGRP | S_IROTH | S_IRUSR | S_IWUSR;
 
   const int fd = open(GetTemporaryFilePath(), O_CREAT | O_WRONLY, mode);
@@ -204,7 +207,9 @@ TEST_F(RtsanFileTest, OpenCreatesFileWithProperMode) {
   ASSERT_THAT(stat(GetTemporaryFilePath(), &st), Eq(0));
 
   // Mask st_mode to get permission bits only
-  ASSERT_THAT(st.st_mode & 0777, Eq(mode));
+  const mode_t actual_mode = st.st_mode & 0777;
+  const mode_t expected_mode = mode & ~existing_umask;
+  ASSERT_THAT(actual_mode, Eq(expected_mode));
 }
 
 TEST_F(RtsanFileTest, CreatDiesWhenRealtime) {


### PR DESCRIPTION
This reverts:

d8d8d659685b114f31d1c42d6d18c3bc6d98b171

This test was failing with the assertion:
```
/build/buildbot/premerge-monolithic-linux/llvm-project/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp:198: Failure
Value of: st.st_mode & 0777
Expected: is equal to 420
  Actual: 384
```

To fix this bug, we need to record the delta between the existing umask and the requested file permissions. 

I have repro'd this on my local machine, which you can do by:
```
$ umask # look at the existing umask
0022 
$ umask 0077 # set it to the more restrictive umask
$ ninja check-rtsan
...
/Users/topher/code/radsan_cjappl/llvm-project/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp:198
Value of: st.st_mode & 0777
Expected: is equal to 420
  Actual: 384
...
$ git checkout $THIS_BRANCH
$ ninja check-rtsan
CLEAN :)
```
