### PR TITLE
[DXIL] Don't generate per-variable guards for DirectX

### DIFF
--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -94,6 +94,13 @@ public:
   BuiltinVaListKind getBuiltinVaListKind() const override {
     return TargetInfo::VoidPtrBuiltinVaList;
   }
+
+  void adjust(DiagnosticsEngine &Diags, LangOptions &Opts) override {
+    TargetInfo::adjust(Diags, Opts);
+    // The static values this addresses do not apply outside of the same thread
+    // This protection is neither available nor needed
+    Opts.ThreadsafeStatics = false;
+  }
 };
 
 } // namespace targets

--- a/clang/test/CodeGenHLSL/static-local-ctor.hlsl
+++ b/clang/test/CodeGenHLSL/static-local-ctor.hlsl
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -emit-llvm -o - -disable-llvm-passes %s | FileCheck %s
+
+// Verify that no per variable _Init_thread instructions are emitted for non-trivial static locals
+// These would normally be emitted by the MicrosoftCXXABI, but the DirectX backend should exlude them
+// Instead, check for the guardvar oparations that should protect the constructor initialization should
+// only take place once.
+
+RWBuffer<int> buf[10];
+
+void InitBuf(RWBuffer<int> buf) {
+  for (unsigned i; i < 100; i++)
+    buf[i] = 0;
+}
+
+// CHECK-NOT: _Init_thread_epoch
+// CHECK: define internal void @"?main@@YAXXZ"
+// CHECK-NEXT: entry:
+// CHECK-NEXT: [[Tmp1:%.*]] = alloca %"class.hlsl::RWBuffer"
+// CHECK-NEXT: [[Tmp2:%.*]] = load i32, ptr
+// CHECK-NEXT: [[Tmp3:%.*]] = and i32 [[Tmp2]], 1
+// CHECK-NEXT: [[Tmp4:%.*]] = icmp eq i32 [[Tmp3]], 0
+// CHECK-NEXT: br i1 [[Tmp4]]
+// CHECK-NOT: _Init_thread_header
+// CHECK: init:
+// CHECK-NEXT: = or i32 [[Tmp2]], 1
+// CHECK-NOT: _Init_thread_footer
+
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void main() {
+  // A non-trivially initialized static local will get checks to verify that it is generated just once
+  static RWBuffer<int> mybuf;
+  mybuf = buf[0];
+  InitBuf(mybuf);
+}
+

--- a/clang/test/CodeGenHLSL/static-local-ctor.hlsl
+++ b/clang/test/CodeGenHLSL/static-local-ctor.hlsl
@@ -8,7 +8,7 @@
 RWBuffer<int> buf[10];
 
 void InitBuf(RWBuffer<int> buf) {
-  for (unsigned i; i < 100; i++)
+  for (unsigned int i = 0; i < 100; i++)
     buf[i] = 0;
 }
 
@@ -29,7 +29,7 @@ void InitBuf(RWBuffer<int> buf) {
 [shader("compute")]
 [numthreads(1,1,1)]
 void main() {
-  // A non-trivially initialized static local will get checks to verify that it is generated just once
+  // A non-trivially constructed static local will get checks to verify that it is generated just once
   static RWBuffer<int> mybuf;
   mybuf = buf[0];
   InitBuf(mybuf);


### PR DESCRIPTION
Thread init guards are generated for local static variables when using the Microsoft CXX ABI. This ABI is also used for HLSL generation, but DXIL doesn't need the corresponding _Init_thread_header/footer calls and doesn't really have a way to handle them in its output targets.

This modifies the language ops when the target is DXIL to exclude this so that they won't be generated and an alternate guardvar method is used that is compatible with the usage.

Done to facilitate testing for #89806, but isn't really related