### PR TITLE
[flang] Silence spurious errors from benign USE errors

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -256,6 +256,9 @@ static bool IsBlockData(const Symbol &symbol) {
 }
 
 void CheckHelper::Check(const Symbol &symbol) {
+  if (symbol.has<UseErrorDetails>()) {
+    return;
+  }
   if (symbol.name().size() > common::maxNameLen &&
       &symbol == &symbol.GetUltimate()) {
     if (context_.ShouldWarn(common::LanguageFeature::LongNames)) {

--- a/flang/test/Semantics/resolve82.f90
+++ b/flang/test/Semantics/resolve82.f90
@@ -34,6 +34,7 @@ module m
   real y
   common /blk/ y
   protected y
+  logical,protected,external,pointer :: z
 
 contains
 
@@ -60,3 +61,8 @@ contains
     end subroutine testProcDecl
 
 end module m
+
+subroutine subb()
+  !Ensure no spurious error from a benign UseError
+  use m, testProcDecl=>z
+end


### PR DESCRIPTION
When USE association encounters a conflict that can't be resolved, it produces a "UseError" symbol that will trigger an error message if that symbol is ever actually used. UseError symbols that aren't used are benign.

Ensure that UseError symbols don't run the gamut of declaration checking.  They were getting through, and could lead to spurious error messages.

Fixes https://github.com/llvm/llvm-project/issues/106020.