### PR TITLE
[flang][driver] apply mlir pass options immediately after lowering

### DIFF
--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -323,6 +323,7 @@ bool CodeGenAction::beginSourceFileAction() {
   // run the default passes.
   mlir::PassManager pm((*mlirModule)->getName(),
                        mlir::OpPassManager::Nesting::Implicit);
+  (void)mlir::applyPassManagerCLOptions(pm);
   // Add OpenMP-related passes
   // WARNING: These passes must be run immediately after the lowering to ensure
   // that the FIR is correct with respect to OpenMP operations/attributes.

--- a/flang/test/Driver/mlir-debug-pass-pipeline.f90
+++ b/flang/test/Driver/mlir-debug-pass-pipeline.f90
@@ -23,6 +23,9 @@ end program
 ! DEBUG-ERR-NOT: Pass statistics report
 
 ! ALL: Pass statistics report
+! ALL: Fortran::lower::VerifierPass
+
+! ALL: Pass statistics report
 
 ! ALL: Fortran::lower::VerifierPass
 ! ALL-NEXT: Pipeline Collection : ['fir.global', 'func.func', 'omp.declare_reduction', 'omp.private']

--- a/flang/test/Driver/mlir-pass-pipeline.f90
+++ b/flang/test/Driver/mlir-pass-pipeline.f90
@@ -10,6 +10,9 @@
 end program
 
 ! ALL: Pass statistics report
+! ALL: Fortran::lower::VerifierPass
+
+! ALL: Pass statistics report
 
 ! ALL: Fortran::lower::VerifierPass
 ! O2-NEXT: Canonicalizer

--- a/flang/test/Driver/mmlir-opts-vs-opts.f90
+++ b/flang/test/Driver/mmlir-opts-vs-opts.f90
@@ -1,0 +1,8 @@
+! Verify that mlir pass options are only accessible under `-mmlir`.
+
+!RUN: %flang_fc1 -emit-hlfir -mmlir --mlir-pass-statistics %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=MMLIR
+!RUN: not %flang_fc1 -emit-hlfir -mlir-pass-statistics %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=NOMMLIR
+
+!MMLIR: Pass statistics report
+!NOMMLIR: error: unknown argument: '-mlir-pass-statistics'
+end

--- a/flang/test/Driver/mmlir-opts-vs-opts.f90
+++ b/flang/test/Driver/mmlir-opts-vs-opts.f90
@@ -1,6 +1,6 @@
 ! Verify that mlir pass options are only accessible under `-mmlir`.
 
-!RUN: %flang_fc1 -emit-hlfir -mmlir --mlir-pass-statistics %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=MMLIR
+!RUN: %flang_fc1 -emit-hlfir -mmlir -mlir-pass-statistics %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=MMLIR
 !RUN: not %flang_fc1 -emit-hlfir -mlir-pass-statistics %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=NOMMLIR
 
 !MMLIR: Pass statistics report


### PR DESCRIPTION
The verification pass is run right after lowering with its own pass manager by flang driver, but the mlir command line options were not applied to this pass manager.

This prevented options like `-mmlir --mlir-pass-pipeline-crash-reproducer="crash.fir"` or `-mmlir --mlir-print-ir-after-failure` to work when a verifier error was hit right after lowering, while these options are useful to investigate/reproduce internal errors.

Note that the change in the pipeline tests is not showing a new pass being run: the pass was already run, but `-mmlir --mlir-pass-statistics` was not applied when the initial verification pass was run.

Note that when we deal with compiler performance, we will probably want to run the verification pass only once after the initial lowering (this patch shows that it is called twice in a raw: once after the initial lowering, once at the beginning of FIR to LLVM IR lowering).