### PR TITLE
[compiler-rt][test] Expand and Rewrite Tests for lit Internal Shell Compatibility

### DIFF
--- a/compiler-rt/test/profile/Linux/counter_promo_for.c
+++ b/compiler-rt/test/profile/Linux/counter_promo_for.c
@@ -12,7 +12,9 @@
 // RUN: %run %t.nopromo.gen
 // RUN: llvm-profdata merge -o %t.nopromo.profdata %t.nopromo.prof/
 // RUN: llvm-profdata show --counts --all-functions %t.nopromo.profdata  > %t.nopromo.dump
-// RUN: diff <(llvm-profdata show %t.promo.profdata) <(llvm-profdata show %t.nopromo.profdata)
+// RUN: llvm-profdata show %t.promo.profdata > %t.promo.dump
+// RUN: llvm-profdata show %t.nopromo.profdata > %t.nopromo.dump
+// RUN: diff %t.promo.dump %t.nopromo.dump
 
 int g;
 __attribute__((noinline)) void bar(int i) { g += i; }

--- a/compiler-rt/test/profile/Linux/counter_promo_nest.c
+++ b/compiler-rt/test/profile/Linux/counter_promo_nest.c
@@ -10,7 +10,9 @@
 // RUN: %run %t.nopromo.gen
 // RUN: llvm-profdata merge -o %t.nopromo.profdata %t.nopromo.prof/
 // RUN: llvm-profdata show --counts --all-functions %t.nopromo.profdata  > %t.nopromo.dump
-// RUN: diff <(llvm-profdata show %t.promo.profdata) <(llvm-profdata show %t.nopromo.profdata)
+// RUN: llvm-profdata show %t.promo.profdata > %t.promo.dump
+// RUN: llvm-profdata show %t.nopromo.profdata > %t.nopromo.dump
+// RUN: diff %t.promo.dump %t.nopromo.dump
 int g;
 __attribute__((noinline)) void bar() {
  g++;

--- a/compiler-rt/test/profile/Linux/counter_promo_while.c
+++ b/compiler-rt/test/profile/Linux/counter_promo_while.c
@@ -12,7 +12,9 @@
 // RUN: %run %t.nopromo.gen
 // RUN: llvm-profdata merge -o %t.nopromo.profdata %t.nopromo.prof/
 // RUN: llvm-profdata show --counts --all-functions %t.nopromo.profdata  > %t.nopromo.dump
-// RUN: diff <(llvm-profdata show %t.promo.profdata) <(llvm-profdata show %t.nopromo.profdata)
+// RUN: llvm-profdata show %t.promo.profdata > %t.promo.dump
+// RUN: llvm-profdata show %t.nopromo.profdata > %t.nopromo.dump
+// RUN: diff %t.promo.dump %t.nopromo.dump
 int g;
 __attribute__((noinline)) void bar(int i) { g += i; }
 __attribute__((noinline)) void foo(int n, int N) {

--- a/compiler-rt/test/profile/Linux/instrprof-debug-info-correlate.c
+++ b/compiler-rt/test/profile/Linux/instrprof-debug-info-correlate.c
@@ -7,13 +7,17 @@
 // RUN: env LLVM_PROFILE_FILE=%t.d4.proflite %run %t.d4
 // RUN: llvm-profdata merge -o %t.d4.profdata --debug-info=%t.d4 %t.d4.proflite
 
-// RUN: diff <(llvm-profdata show --all-functions --counts %t.normal.profdata) <(llvm-profdata show --all-functions --counts %t.d4.profdata)
+// RUN: llvm-profdata show --all-functions --counts %t.normal.profdata > %t.normal.dump
+// RUN: llvm-profdata show --all-functions --counts %t.d4.profdata > %t.d4.dump
+// RUN: diff %t.normal.dump %t.d4.dump
 
 // RUN: %clang_pgogen -o %t -g -mllvm --debug-info-correlate -mllvm --disable-vp=true %S/../Inputs/instrprof-debug-info-correlate-main.cpp %S/../Inputs/instrprof-debug-info-correlate-foo.cpp
 // RUN: env LLVM_PROFILE_FILE=%t.proflite %run %t
 // RUN: llvm-profdata merge -o %t.profdata --debug-info=%t %t.proflite
 
-// RUN: diff <(llvm-profdata show --all-functions --counts %t.normal.profdata) <(llvm-profdata show --all-functions --counts %t.profdata)
+// RUN: llvm-profdata show --all-functions --counts %t.normal.profdata > %t.normal2.dump
+// RUN: llvm-profdata show --all-functions --counts %t.profdata > %t.prof.dump
+// RUN: diff %t.normal2.dump %t.prof.dump
 
 // RUN: %clang_pgogen -o %t.cov -g -mllvm --debug-info-correlate -mllvm -pgo-function-entry-coverage -mllvm --disable-vp=true %S/../Inputs/instrprof-debug-info-correlate-main.cpp %S/../Inputs/instrprof-debug-info-correlate-foo.cpp
 // RUN: env LLVM_PROFILE_FILE=%t.cov.proflite %run %t.cov
@@ -23,7 +27,9 @@
 // RUN: env LLVM_PROFILE_FILE=%t.cov.profraw %run %t.cov.normal
 // RUN: llvm-profdata merge -o %t.cov.normal.profdata %t.cov.profraw
 
-// RUN: diff <(llvm-profdata show --all-functions --counts %t.cov.normal.profdata) <(llvm-profdata show --all-functions --counts %t.cov.profdata)
+// RUN: llvm-profdata show --all-functions --counts %t.cov.normal.profdata > %t.cov.normal.dump
+// RUN: llvm-profdata show --all-functions --counts %t.cov.profdata > %t.cov.dump
+// RUN: diff %t.cov.normal.dump %t.cov.dump
 
 // Test debug info correlate with online merging.
 
@@ -36,11 +42,15 @@
 // RUN: env LLVM_PROFILE_FILE=%t.profdir/%m.proflite %run %t
 // RUN: llvm-profdata merge -o %t.profdata --debug-info=%t %t.profdir/
 
-// RUN: diff <(llvm-profdata show --all-functions --counts %t.normal.profdata) <(llvm-profdata show --all-functions --counts %t.profdata)
+// RUN: llvm-profdata show --all-functions --counts %t.normal.profdata > %t.normal3.dump
+// RUN: llvm-profdata show --all-functions --counts %t.profdata > %t.prof3.dump
+// RUN: diff %t.normal3.dump %t.prof3.dump
 
 // RUN: rm -rf %t.profdir && mkdir %t.profdir
 // RUN: env LLVM_PROFILE_FILE=%t.profdir/%m.cov.proflite %run %t.cov
 // RUN: env LLVM_PROFILE_FILE=%t.profdir/%m.cov.proflite %run %t.cov
 // RUN: llvm-profdata merge -o %t.cov.profdata --debug-info=%t.cov %t.profdir/
 
-// RUN: diff <(llvm-profdata show --all-functions --counts %t.cov.normal.profdata) <(llvm-profdata show --all-functions --counts %t.cov.profdata)
+// RUN: llvm-profdata show --all-functions --counts %t.cov.normal.profdata > %t.cov.normal2.dump
+// RUN: llvm-profdata show --all-functions --counts %t.cov.profdata > %t.cov2.dump
+// RUN: diff %t.cov.normal2.dump %t.cov2.dump


### PR DESCRIPTION
This patch addresses compatibility issues with the lit internal shell by expanding and rewriting test scripts in the compiler-rt subproject. These changes were prompted by the FileNotFound unresolved errors encountered during the testing process, specifically when running the command `LIT_USE_INTERNAL_SHELL=1 ninja check compiler-rt`.

**Why the error occurred:**
The error occurred because the original test scripts used process substitution `(<(...))` in their diff commands. Process substitution creates temporary files or FIFOs to hold command output, and these are then passed to `diff`. However, the lit internal shell, which is more limited than a typical shell like `bash`, does not support process substitution. When lit tries to execute these commands, it is unable to create or access the temporary files or FIFOs generated by process substitution. As a result, lit attempts to open a file or directory that doesn't exist, leading to the `FileNotFoundError`.

**Changes Made:**

- Instead of using process substitution, the commands now explicitly redirect the output of `llvm-profdata show` to temporary files before performing the `diff` comparison. This ensures that the lit internal shell can correctly find and open these files, resolving the `FileNotFoundError`.

[This change is relevant [RFC] Enabling the lit internal shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179) 
fixes: #106111
