### PR TITLE
[libc] Fix file collision causing test flake

### DIFF
--- a/libc/test/src/stdio/vfscanf_test.cpp
+++ b/libc/test/src/stdio/vfscanf_test.cpp
@@ -43,8 +43,8 @@ static int call_vfscanf(::FILE *stream, const char *__restrict format, ...) {
   return ret;
 }
 
-TEST(LlvmLibcFScanfTest, WriteToFile) {
-  const char *FILENAME = "fscanf_output.test";
+TEST(LlvmLibcVFScanfTest, WriteToFile) {
+  const char *FILENAME = "vfscanf_output.test";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
   ::FILE *file = scanf_test::fopen(FILE_PATH, "w");
   ASSERT_FALSE(file == nullptr);


### PR DESCRIPTION
In patch #105293 tests for vfscanf were added, meant to be identical to
the fscanf tests. Unfortunately, the author forgot to rename the target
file causing an occasional test flake where one test writes to the file
while the other is trying to read it. This patch fixes the issue by
renaming the target test file for the vfscanf test.
