### PR TITLE
[MLGO] Remove Python <3.8 from unsupported config

### DIFF
--- a/llvm/test/CodeGen/MLRegAlloc/lit.local.cfg
+++ b/llvm/test/CodeGen/MLRegAlloc/lit.local.cfg
@@ -1,3 +1,0 @@
-import sys
-
-config.unsupported = sys.version_info.minor <= 8

--- a/llvm/test/Transforms/Inline/ML/lit.local.cfg
+++ b/llvm/test/Transforms/Inline/ML/lit.local.cfg
@@ -1,3 +1,0 @@
-import sys
-
-config.unsupported = sys.version_info.minor <= 8


### PR DESCRIPTION
Now that Python 3.8 is the minimum version supported by LLVM, we don't need to explicitly check that the python version we are using is greater than 3.8 in the MLGO tests.