### PR TITLE
[scudo] Make comment compatible with gcc

### DIFF
--- a/compiler-rt/lib/scudo/standalone/secondary.h
+++ b/compiler-rt/lib/scudo/standalone/secondary.h
@@ -426,7 +426,7 @@ public:
     //  The difference between the retrieved memory chunk and the request
     //  size is at most MaxAllowedFragmentedPages
     //
-    //  / MaxAllowedFragmentedPages * PageSize \
+    //  / MaxAllowedFragmentedPages * PageSize \.
     // +--------------------------+-------------+
     // |                          |             |
     // +--------------------------+-------------+

--- a/compiler-rt/lib/scudo/standalone/secondary.h
+++ b/compiler-rt/lib/scudo/standalone/secondary.h
@@ -426,7 +426,7 @@ public:
     //  The difference between the retrieved memory chunk and the request
     //  size is at most MaxAllowedFragmentedPages
     //
-    //  / MaxAllowedFragmentedPages * PageSize \.
+    // +- MaxAllowedFragmentedPages * PageSize -+
     // +--------------------------+-------------+
     // |                          |             |
     // +--------------------------+-------------+


### PR DESCRIPTION
gcc interprets a backslash '\\' as the last char before a new line as a line continuation character, even in a comment context. This can produce an "error: multi-line comment [-Werror=comment]".

This PR places an innocuous '.' following the '\' so that the comment can compile with gcc.