### PR TITLE
[IR] Bump AttributeBitSet width to 16 bytes

### DIFF
--- a/llvm/lib/IR/AttributeImpl.h
+++ b/llvm/lib/IR/AttributeImpl.h
@@ -275,7 +275,7 @@ public:
 
 class AttributeBitSet {
   /// Bitset with a bit for each available attribute Attribute::AttrKind.
-  uint8_t AvailableAttrs[12] = {};
+  uint8_t AvailableAttrs[16] = {};
   static_assert(Attribute::EndAttrKinds <= sizeof(AvailableAttrs) * CHAR_BIT,
                 "Too many attributes");
 


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/issues/106134, we are bumping the width of this set to 16 bytes to accommodate more attributes. This allows us to have a total of 128 attributes instead of 96 as we stand today. 