### PR TITLE
[SPIRV] Fix build after change in transitive includes

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -24,6 +24,7 @@
 #include "llvm/IR/TypedPointerType.h"
 
 #include <queue>
+#include <unordered_set>
 
 // This pass performs the following transformation on LLVM IR level required
 // for the following translation to SPIR-V:


### PR DESCRIPTION
An unordered_set include was removed from a header in 04ebd1907c05 "[MC][NFC] Statically allocate storage for decoded pseudo probes and function records (#102789)", but SPIRVEmitIntrinsics was getting the definition from that transitive include. Fix the build by including the header explicitly.