### PR TITLE
[flang][Driver] Add support for -mllvm -print-pipeline-passes

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1095,6 +1095,8 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       TheModule->addModuleFlag(llvm::Module::Error, "UnifiedLTO", uint32_t(1));
   }
 
+  // FIXME: This should eventually be replaced by a first-class driver option.
+  // This should be done for both clang and flang simultaneously.
   // Print a textual, '-passes=' compatible, representation of pipeline if
   // requested.
   if (PrintPipelinePasses) {

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -1019,6 +1019,8 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
   else if (action == BackendActionTy::Backend_EmitLL)
     mpm.addPass(llvm::PrintModulePass(os));
 
+  // FIXME: This should eventually be replaced by a first-class driver option.
+  // This should be done for both flang and clang simultaneously.
   // Print a textual, '-passes=' compatible, representation of pipeline if
   // requested. In this case, don't run the passes. This mimics the behavior of
   // clang.

--- a/flang/test/Driver/print-pipeline-passes.f90
+++ b/flang/test/Driver/print-pipeline-passes.f90
@@ -1,9 +1,6 @@
-! Test that -print-pipeline-passes works in flang
+! RUN: %flang_fc1 -mllvm -print-pipeline-passes -emit-llvm-bc -o /dev/null -O0 %s 2>&1 | FileCheck %s
 
-! RUN: %flang_fc1 -triple x86_64-unknown-linux-gnu -emit-llvm-bc -o /dev/null -mllvm -print-pipeline-passes -O0 %s 2>&1 | FileCheck %s
-
-! Don't try to check all passes, just a few to make sure that something is
-! actually printed.
+! Just check a few passes to ensure that something reasonable is being printed.
 ! CHECK: always-inline
 ! CHECK-SAME: annotation-remarks
 

--- a/flang/test/Driver/print-pipeline-passes.f90
+++ b/flang/test/Driver/print-pipeline-passes.f90
@@ -1,0 +1,10 @@
+! Test that -print-pipeline-passes works in flang
+
+! RUN: %flang_fc1 -triple x86_64-unknown-linux-gnu -emit-llvm-bc -o /dev/null -mllvm -print-pipeline-passes -O0 %s 2>&1 | FileCheck %s
+
+! Don't try to check all passes, just a few to make sure that something is
+! actually printed.
+! CHECK: always-inline
+! CHECK-SAME: annotation-remarks
+
+end program


### PR DESCRIPTION
The behavior deliberately mimics that of clang.