### PR TITLE
[clang-format] Add new option: WrapNamespaceBodyWithNewlines

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6843,6 +6843,48 @@ the configuration (without a prefix: ``Auto``).
 
   For example: BOOST_PP_STRINGIZE
 
+.. _WrapNamespaceBodyWithEmptyLines:
+
+**WrapNamespaceBodyWithEmptyLines** (``WrapNamespaceBodyWithEmptyLinesStyle``) :versionbadge:`clang-format 19` :ref:`¶ <WrapNamespaceBodyWithEmptyLines>`
+  Controls number of empty lines at the begging and at the end of
+  namespace definition.
+
+  Possible values:
+
+  * ``WNBWELS_Never`` (in configuration: ``Never``)
+    Removes all empty lines at the beginning and at the end of
+    namespace definition.
+
+    .. code-block:: c++
+
+      namespace N1 {
+      namespace N2
+        function();
+      }
+      }
+
+  * ``WNBWELS_Always`` (in configuration: ``Always``)
+    Always adds an empty line at the beginning and at the end of
+    namespace definition. MaxEmptyLinesToKeep is also applied, but
+    empty lines between consecutive namespace declarations are
+    always removed.
+
+    .. code-block:: c++
+
+      namespace N1 {
+      namespace N2 {
+
+        function();
+
+      }
+      }
+
+  * ``WNBWELS_Leave`` (in configuration: ``Leave``)
+    Keeps existing newlines at the beginning and at the end of
+    namespace definition using MaxEmptyLinesToKeep for formatting.
+
+
+
 .. END_FORMAT_STYLE_OPTIONS
 
 Adding additional style options

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6846,42 +6846,39 @@ the configuration (without a prefix: ``Auto``).
 .. _WrapNamespaceBodyWithEmptyLines:
 
 **WrapNamespaceBodyWithEmptyLines** (``WrapNamespaceBodyWithEmptyLinesStyle``) :versionbadge:`clang-format 20` :ref:`¶ <WrapNamespaceBodyWithEmptyLines>`
-  Controls number of empty lines at the begging and at the end of
-  namespace definition.
+  Wrap namespace body with empty lines.
 
   Possible values:
 
   * ``WNBWELS_Never`` (in configuration: ``Never``)
-    Removes all empty lines at the beginning and at the end of
-    namespace definition.
+    Remove all empty lines at the beginning and the end of namespace body.
 
     .. code-block:: c++
 
       namespace N1 {
       namespace N2
-        function();
+      function();
       }
       }
 
   * ``WNBWELS_Always`` (in configuration: ``Always``)
-    Always adds an empty line at the beginning and at the end of
-    namespace definition. MaxEmptyLinesToKeep is also applied, but
-    empty lines between consecutive namespace declarations are
-    always removed.
+    Always have at least one empty line at the beginning and the end of
+    namespace body except that the number of empty lines between consecutive
+    nested namespace definitions is not increased.
 
     .. code-block:: c++
 
       namespace N1 {
       namespace N2 {
 
-        function();
+      function();
 
       }
       }
 
   * ``WNBWELS_Leave`` (in configuration: ``Leave``)
-    Keeps existing newlines at the beginning and at the end of
-    namespace definition using MaxEmptyLinesToKeep for formatting.
+    Keep existing newlines at the beginning and the end of namespace body.
+    ``MaxEmptyLinesToKeep`` still applies.
 
 
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6845,7 +6845,7 @@ the configuration (without a prefix: ``Auto``).
 
 .. _WrapNamespaceBodyWithEmptyLines:
 
-**WrapNamespaceBodyWithEmptyLines** (``WrapNamespaceBodyWithEmptyLinesStyle``) :versionbadge:`clang-format 19` :ref:`¶ <WrapNamespaceBodyWithEmptyLines>`
+**WrapNamespaceBodyWithEmptyLines** (``WrapNamespaceBodyWithEmptyLinesStyle``) :versionbadge:`clang-format 20` :ref:`¶ <WrapNamespaceBodyWithEmptyLines>`
   Controls number of empty lines at the begging and at the end of
   namespace definition.
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1127,6 +1127,7 @@ clang-format
 - Adds ``AllowShortNamespacesOnASingleLine`` option.
 - Adds ``VariableTemplates`` option.
 - Adds support for bash globstar in ``.clang-format-ignore``.
+- Adds ``WrapNamespaceBodyWithEmptyLines`` option.
 
 libclang
 --------

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5143,6 +5143,43 @@ struct FormatStyle {
   /// \version 11
   std::vector<std::string> WhitespaceSensitiveMacros;
 
+  /// Different styles for modify number of empty lines in
+  /// the beginning and at the of end of namespaces.
+  enum WrapNamespaceBodyWithEmptyLinesStyle : int8_t {
+    /// Removes all empty lines at the beginning and at the end of
+    /// namespace definition.
+    /// \code
+    ///   namespace N1 {
+    ///   namespace N2
+    ///     function();
+    ///   }
+    ///   }
+    /// \endcode
+    WNBWELS_Never,
+    /// Always adds an empty line at the beginning and at the end of
+    /// namespace definition. MaxEmptyLinesToKeep is also applied, but
+    /// empty lines between consecutive namespace declarations are
+    /// always removed.
+    /// \code
+    ///   namespace N1 {
+    ///   namespace N2 {
+    ///
+    ///     function();
+    ///
+    ///   }
+    ///   }
+    /// \endcode
+    WNBWELS_Always,
+    /// Keeps existing newlines at the beginning and at the end of
+    /// namespace definition using MaxEmptyLinesToKeep for formatting.
+    WNBWELS_Leave
+  };
+
+  /// Controls number of empty lines at the begging and at the end of
+  /// namespace definition.
+  /// \version 19
+  WrapNamespaceBodyWithEmptyLinesStyle WrapNamespaceBodyWithEmptyLines;
+
   bool operator==(const FormatStyle &R) const {
     return AccessModifierOffset == R.AccessModifierOffset &&
            AlignAfterOpenBracket == R.AlignAfterOpenBracket &&
@@ -5326,7 +5363,8 @@ struct FormatStyle {
            UseTab == R.UseTab && VariableTemplates == R.VariableTemplates &&
            VerilogBreakBetweenInstancePorts ==
                R.VerilogBreakBetweenInstancePorts &&
-           WhitespaceSensitiveMacros == R.WhitespaceSensitiveMacros;
+           WhitespaceSensitiveMacros == R.WhitespaceSensitiveMacros &&
+           WrapNamespaceBodyWithEmptyLines == R.WrapNamespaceBodyWithEmptyLines;
   }
 
   std::optional<FormatStyle> GetLanguageStyle(LanguageKind Language) const;

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5177,7 +5177,7 @@ struct FormatStyle {
 
   /// Controls number of empty lines at the begging and at the end of
   /// namespace definition.
-  /// \version 19
+  /// \version 20
   WrapNamespaceBodyWithEmptyLinesStyle WrapNamespaceBodyWithEmptyLines;
 
   bool operator==(const FormatStyle &R) const {

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5143,40 +5143,36 @@ struct FormatStyle {
   /// \version 11
   std::vector<std::string> WhitespaceSensitiveMacros;
 
-  /// Different styles for modify number of empty lines in
-  /// the beginning and at the of end of namespaces.
+  /// Different styles for wrapping namespace body with empty lines.
   enum WrapNamespaceBodyWithEmptyLinesStyle : int8_t {
-    /// Removes all empty lines at the beginning and at the end of
-    /// namespace definition.
+    /// Remove all empty lines at the beginning and the end of namespace body.
     /// \code
     ///   namespace N1 {
     ///   namespace N2
-    ///     function();
+    ///   function();
     ///   }
     ///   }
     /// \endcode
     WNBWELS_Never,
-    /// Always adds an empty line at the beginning and at the end of
-    /// namespace definition. MaxEmptyLinesToKeep is also applied, but
-    /// empty lines between consecutive namespace declarations are
-    /// always removed.
+    /// Always have at least one empty line at the beginning and the end of
+    /// namespace body except that the number of empty lines between consecutive
+    /// nested namespace definitions is not increased.
     /// \code
     ///   namespace N1 {
     ///   namespace N2 {
     ///
-    ///     function();
+    ///   function();
     ///
     ///   }
     ///   }
     /// \endcode
     WNBWELS_Always,
-    /// Keeps existing newlines at the beginning and at the end of
-    /// namespace definition using MaxEmptyLinesToKeep for formatting.
+    /// Keep existing newlines at the beginning and the end of namespace body.
+    /// ``MaxEmptyLinesToKeep`` still applies.
     WNBWELS_Leave
   };
 
-  /// Controls number of empty lines at the begging and at the end of
-  /// namespace definition.
+  /// Wrap namespace body with empty lines.
   /// \version 20
   WrapNamespaceBodyWithEmptyLinesStyle WrapNamespaceBodyWithEmptyLines;
 

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -839,6 +839,18 @@ template <> struct ScalarEnumerationTraits<FormatStyle::UseTabStyle> {
   }
 };
 
+template <>
+struct ScalarEnumerationTraits<
+    FormatStyle::WrapNamespaceBodyWithEmptyLinesStyle> {
+  static void
+  enumeration(IO &IO,
+              FormatStyle::WrapNamespaceBodyWithEmptyLinesStyle &Value) {
+    IO.enumCase(Value, "Never", FormatStyle::WNBWELS_Never);
+    IO.enumCase(Value, "Always", FormatStyle::WNBWELS_Always);
+    IO.enumCase(Value, "Leave", FormatStyle::WNBWELS_Leave);
+  }
+};
+
 template <> struct MappingTraits<FormatStyle> {
   static void mapping(IO &IO, FormatStyle &Style) {
     // When reading, read the language first, we need it for getPredefinedStyle.
@@ -1171,6 +1183,8 @@ template <> struct MappingTraits<FormatStyle> {
                    Style.VerilogBreakBetweenInstancePorts);
     IO.mapOptional("WhitespaceSensitiveMacros",
                    Style.WhitespaceSensitiveMacros);
+    IO.mapOptional("WrapNamespaceBodyWithEmptyLines",
+                   Style.WrapNamespaceBodyWithEmptyLines);
 
     // If AlwaysBreakAfterDefinitionReturnType was specified but
     // BreakAfterReturnType was not, initialize the latter from the former for
@@ -1639,6 +1653,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.WhitespaceSensitiveMacros.push_back("NS_SWIFT_NAME");
   LLVMStyle.WhitespaceSensitiveMacros.push_back("PP_STRINGIZE");
   LLVMStyle.WhitespaceSensitiveMacros.push_back("STRINGIZE");
+  LLVMStyle.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Leave;
 
   LLVMStyle.PenaltyBreakAssignment = prec::Assignment;
   LLVMStyle.PenaltyBreakBeforeFirstCallParameter = 19;

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -46,8 +46,8 @@ bool LineEndsNamespaceScope(const AnnotatedLine *Line,
                             const SmallVectorImpl<AnnotatedLine *> &Lines) {
   if (!Line)
     return false;
-  const FormatToken *tok = Line->First;
-  if (!tok || tok->isNot(tok::r_brace))
+  const FormatToken *Tok = Line->First;
+  if (!Tok || Tok->isNot(tok::r_brace))
     return false;
   return getNamespaceToken(Line, Lines) != nullptr;
 }

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -1599,6 +1599,7 @@ static auto computeNewlines(const AnnotatedLine &Line,
       else if (!PreviousLine->startsWith(TT_NamespaceRBrace))
         Newlines = std::max(Newlines, 2u);
     }
+  }
 
   // Insert or remove empty line before access specifiers.
   if (PreviousLine && RootToken.isAccessSpecifier()) {

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -865,7 +865,6 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("SortUsingDeclarations: true", SortUsingDeclarations,
               FormatStyle::SUD_LexicographicNumeric);
 
-  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Leave;
   CHECK_PARSE("WrapNamespaceBodyWithEmptyLines: Never",
               WrapNamespaceBodyWithEmptyLines, FormatStyle::WNBWELS_Never);
   CHECK_PARSE("WrapNamespaceBodyWithEmptyLines: Always",

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -865,6 +865,14 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("SortUsingDeclarations: true", SortUsingDeclarations,
               FormatStyle::SUD_LexicographicNumeric);
 
+  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Leave;
+  CHECK_PARSE("WrapNamespaceBodyWithEmptyLines: Never",
+              WrapNamespaceBodyWithEmptyLines, FormatStyle::WNBWELS_Never);
+  CHECK_PARSE("WrapNamespaceBodyWithEmptyLines: Always",
+              WrapNamespaceBodyWithEmptyLines, FormatStyle::WNBWELS_Always);
+  CHECK_PARSE("WrapNamespaceBodyWithEmptyLines: Leave",
+              WrapNamespaceBodyWithEmptyLines, FormatStyle::WNBWELS_Leave);
+
   // FIXME: This is required because parsing a configuration simply overwrites
   // the first N elements of the list instead of resetting it.
   Style.ForEachMacros.clear();

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28460,7 +28460,9 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
   Style.CompactNamespaces = true;
 
   // Empty namespace
-  verifyNoChange("namespace N {\n};", Style);
+  verifyNoChange("namespace N {\n"
+                 "};",
+                 Style);
 
   // Single namespace
   verifyNoChange("namespace N {\n"
@@ -28490,19 +28492,23 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
   verifyNoChange("namespace N {};", Style);
 
   // Single namespace
-  verifyNoChange("namespace N {\n\n"
-                 "int f1(int a) { return 2 * a; }\n\n"
+  verifyNoChange("namespace N {\n"
+                 "\n"
+                 "int f1(int a) { return 2 * a; }\n"
+                 "\n"
                  "};",
                  Style);
 
   // Nested namespace
   verifyNoChange("namespace N1 {\n"
                  "namespace N2 {\n"
-                 "namespace N3 {\n\n"
+                 "namespace N3 {\n"
+                 "\n"
                  "int f1() {\n"
                  "  int a = 1;\n"
                  "  return a;\n"
-                 "}\n\n"
+                 "}\n"
+                 "\n"
                  "}\n"
                  "}\n"
                  "}",
@@ -28511,11 +28517,13 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
   Style.CompactNamespaces = true;
 
   // Nested namespace
-  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n\n"
+  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
+                 "\n"
                  "int f1() {\n"
                  "  int a = 1;\n"
                  "  return a;\n"
-                 "}\n\n"
+                 "}\n"
+                 "\n"
                  "}}}",
                  Style);
 
@@ -28526,30 +28534,44 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
   verifyNoChange("namespace N {};", Style);
 
   // Single namespace
-  verifyNoChange("namespace N {\n\n\n"
-                 "void function()\n\n\n"
+  verifyNoChange("namespace N {\n"
+                 "\n"
+                 "\n"
+                 "void function()\n"
+                 "\n"
+                 "\n"
                  "};",
                  Style);
 
   // Nested namespace
   verifyFormat("namespace N1 {\n"
                "namespace N2 {\n"
-               "namespace N3 {\n\n\n"
+               "namespace N3 {\n"
+               "\n"
+               "\n"
                "int f1() {\n"
                "  int a = 1;\n"
                "  return a;\n"
-               "}\n\n\n"
+               "}\n"
+               "\n"
+               "\n"
                "}\n"
                "}\n"
                "}",
                "namespace N1 {\n"
-               "namespace N2 {\n\n"
-               "namespace N3 {\n\n\n"
+               "namespace N2 {\n"
+               "\n"
+               "namespace N3 {\n"
+               "\n"
+               "\n"
                "int f1() {\n"
                "  int a = 1;\n"
                "  return a;\n"
-               "}\n\n\n"
-               "}\n\n"
+               "}\n"
+               "\n"
+               "\n"
+               "}\n"
+               "\n"
                "}\n"
                "}",
                Style);
@@ -28557,11 +28579,15 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
   Style.CompactNamespaces = true;
 
   // Nested namespace
-  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n\n\n"
+  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
+                 "\n"
+                 "\n"
                  "int f1() {\n"
                  "  int a = 1;\n"
                  "  return a;\n"
-                 "}\n\n\n"
+                 "}\n"
+                 "\n"
+                 "\n"
                  "}}}",
                  Style);
 }
@@ -28599,20 +28625,30 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesLeave) {
   Style.MaxEmptyLinesToKeep = 2;
 
   // Single namespace
-  verifyNoChange("namespace N {\n\n\n"
-                 "int f1(int a) { return 2 * a; }\n\n\n"
+  verifyNoChange("namespace N {\n"
+                 "\n"
+                 "\n"
+                 "int f1(int a) { return 2 * a; }\n"
+                 "\n"
+                 "\n"
                  "};",
                  Style);
 
   // Nested namespace
   verifyNoChange("namespace N1 {\n"
-                 "namespace N2 {\n\n"
-                 "namespace N3 {\n\n\n"
+                 "namespace N2 {\n"
+                 "\n"
+                 "namespace N3 {\n"
+                 "\n"
+                 "\n"
                  "int f1() {\n"
                  "  int a = 1;\n"
                  "  return a;\n"
-                 "}\n\n\n"
-                 "}\n\n"
+                 "}\n"
+                 "\n"
+                 "\n"
+                 "}\n"
+                 "\n"
                  "}\n"
                  "}",
                  Style);
@@ -28623,11 +28659,15 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesLeave) {
   verifyNoChange("namespace N {\n};", Style);
 
   // Nested namespace
-  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n\n\n"
+  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
+                 "\n"
+                 "\n"
                  "int f1() {\n"
                  "  int a = 1;\n"
                  "  return a;\n"
-                 "}\n\n\n"
+                 "}\n"
+                 "\n"
+                 "\n"
                  "}}}",
                  Style);
 }

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28430,6 +28430,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
 TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
   auto Style = getLLVMStyle();
   Style.FixNamespaceComments = false;
+  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Never;
 
   // Empty namespace.
   verifyFormat("namespace N {}", Style);
@@ -28511,21 +28512,6 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
                "}",
                Style);
 
-  // Removing empty lines.
-  verifyFormat("namespace N {\n"
-               "\n"
-               "int a = 1;\n"
-               "\n"
-               "}",
-               "namespace N {"
-               "\n"
-               "\n"
-               "int a = 1;\n"
-               "\n"
-               "\n"
-               "}",
-               Style);
-
   Style.CompactNamespaces = true;
 
   // Nested namespace.
@@ -28550,9 +28536,6 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
 
   Style.CompactNamespaces = false;
 
-  // Empty namespace.
-  verifyFormat("namespace N {}", Style);
-
   // Single namespace.
   verifyNoChange("namespace N {\n"
                  "\n"
@@ -28573,93 +28556,6 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
                  "\n"
                  "}\n"
                  "}",
-                 Style);
-}
-
-TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesLeave) {
-  auto Style = getLLVMStyle();
-  Style.FixNamespaceComments = false;
-
-  // Empty namespace.
-  verifyFormat("namespace N {}", Style);
-
-  // Single namespace.
-  verifyFormat("namespace N {\n"
-               "int f1(int a) { return 2 * a; }\n"
-               "}",
-               Style);
-
-  // Nested namespace.
-  verifyFormat("namespace N1 {\n"
-               "namespace N2 {\n"
-               "int a = 1;\n"
-               "}\n"
-               "}",
-               Style);
-
-  // Removing empty lines.
-  verifyFormat("namespace N {\n"
-               "\n"
-               "int a = 1;\n"
-               "\n"
-               "}",
-               "namespace N {\n"
-               "\n"
-               "\n"
-               "int a = 1;\n"
-               "\n"
-               "\n"
-               "}",
-               Style);
-
-  Style.MaxEmptyLinesToKeep = 0;
-
-  verifyFormat("namespace N {\n"
-               "int a = 1;\n"
-               "}",
-               "namespace N {\n"
-               "\n"
-               "\n"
-               "int a = 1;\n"
-               "\n"
-               "\n"
-               "}",
-               Style);
-
-  Style.MaxEmptyLinesToKeep = 2;
-
-  // Single namespace.
-  verifyNoChange("namespace N {\n"
-                 "\n"
-                 "\n"
-                 "int f1(int a) { return 2 * a; }\n"
-                 "\n"
-                 "\n"
-                 "}",
-                 Style);
-
-  // Nested namespace.
-  verifyNoChange("namespace N1 {\n"
-                 "namespace N2 {\n"
-                 "\n"
-                 "\n"
-                 "int a = 1;\n"
-                 "\n"
-                 "\n"
-                 "}\n"
-                 "}",
-                 Style);
-
-  Style.CompactNamespaces = true;
-
-  // Nested namespace.
-  verifyNoChange("namespace N1 { namespace N2 {\n"
-                 "\n"
-                 "\n"
-                 "int a = 1;\n"
-                 "\n"
-                 "\n"
-                 "}}",
                  Style);
 }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28428,226 +28428,223 @@ TEST_F(FormatTest, ShortNamespacesOption) {
 }
 
 TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
-  FormatStyle Style = getLLVMStyle();
+  auto Style = getLLVMStyle();
   Style.FixNamespaceComments = false;
-  Style.ShortNamespaceLines = 0;
-  Style.MaxEmptyLinesToKeep = 2;
-  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Never;
-  Style.CompactNamespaces = false;
 
-  // Empty namespace
-  verifyNoChange("namespace N {};", Style);
+  // Empty namespace.
+  verifyFormat("namespace N {}", Style);
 
-  // Single namespace
-  verifyNoChange("namespace N {\n"
-                 "int f1(int a) { return 2 * a; }\n"
-                 "};",
-                 Style);
+  // Single namespace.
+  verifyFormat("namespace N {\n"
+               "int f1(int a) { return 2 * a; }\n"
+               "}",
+               Style);
 
-  // Nested namespace
-  verifyNoChange("namespace N1 {\n"
-                 "namespace N2 {\n"
-                 "namespace N3 {\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
-                 "}\n"
-                 "}\n"
-                 "}\n"
-                 "}",
-                 Style);
-
-  Style.CompactNamespaces = true;
-
-  // Empty namespace
-  verifyNoChange("namespace N1 { namespace N2 {\n"
-                 "}};",
-                 Style);
-
-  // Single namespace
-  verifyNoChange("namespace N {\n"
-                 "int f1(int a) { return 2 * a; }\n"
-                 "};",
-                 Style);
-
-  // Nested namespace
-  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
-                 "}\n"
-                 "}}}",
-                 Style);
-}
-
-TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
-  FormatStyle Style = getLLVMStyle();
-  Style.FixNamespaceComments = false;
-  Style.ShortNamespaceLines = 0;
-  Style.MaxEmptyLinesToKeep = 0;
-  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Always;
-  Style.CompactNamespaces = false;
-
-  // Empty namespace
-  verifyNoChange("namespace N {};", Style);
-
-  // Single namespace
-  verifyNoChange("namespace N {\n"
-                 "\n"
-                 "int f1(int a) { return 2 * a; }\n"
-                 "\n"
-                 "};",
-                 Style);
-
-  // Nested namespace
-  verifyNoChange("namespace N1 {\n"
-                 "namespace N2 {\n"
-                 "namespace N3 {\n"
-                 "\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
-                 "}\n"
-                 "\n"
-                 "}\n"
-                 "}\n"
-                 "}",
-                 Style);
-
-  Style.CompactNamespaces = true;
-
-  // Nested namespace
-  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
-                 "\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
-                 "}\n"
-                 "\n"
-                 "}}}",
-                 Style);
-
-  Style.MaxEmptyLinesToKeep = 2;
-  Style.CompactNamespaces = false;
-
-  // Empty namespace
-  verifyNoChange("namespace N {};", Style);
-
-  // Single namespace
-  verifyNoChange("namespace N {\n"
-                 "\n"
-                 "\n"
-                 "void function()\n"
-                 "\n"
-                 "\n"
-                 "};",
-                 Style);
-
-  // Nested namespace
+  // Nested namespace.
   verifyFormat("namespace N1 {\n"
                "namespace N2 {\n"
-               "namespace N3 {\n"
-               "\n"
-               "\n"
-               "int f1() {\n"
-               "  int a = 1;\n"
-               "  return a;\n"
-               "}\n"
-               "\n"
-               "\n"
-               "}\n"
-               "}\n"
-               "}",
-               "namespace N1 {\n"
-               "namespace N2 {\n"
-               "\n"
-               "namespace N3 {\n"
-               "\n"
-               "\n"
-               "int f1() {\n"
-               "  int a = 1;\n"
-               "  return a;\n"
-               "}\n"
-               "\n"
-               "\n"
-               "}\n"
-               "\n"
+               "int a = 1;\n"
                "}\n"
                "}",
                Style);
 
   Style.CompactNamespaces = true;
 
-  // Nested namespace
-  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
+  verifyFormat("namespace N1 { namespace N2 {\n"
+               "int a = 1;\n"
+               "}}",
+               Style);
+
+  // Removing empty lines.
+  verifyFormat("namespace N {\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "}",
+               "namespace N {\n"
+               "\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "\n"
+               "}",
+               Style);
+
+  Style.MaxEmptyLinesToKeep = 0;
+
+  verifyFormat("namespace N {\n"
+               "int a = 1;\n"
+               "}",
+               "namespace N {\n"
+               "\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "\n"
+               "}",
+               Style);
+}
+
+TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
+  auto Style = getLLVMStyle();
+  Style.FixNamespaceComments = false;
+  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Always;
+
+  // Empty namespace.
+  verifyFormat("namespace N {}", Style);
+
+  // Single namespace.
+  verifyFormat("namespace N {\n"
+               "\n"
+               "int f1(int a) { return 2 * a; }\n"
+               "\n"
+               "}",
+               Style);
+
+  // Nested namespace.
+  verifyFormat("namespace N1 {\n"
+               "namespace N2 {\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "}\n"
+               "}",
+               Style);
+
+  // Removing empty lines.
+  verifyFormat("namespace N {\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "}",
+               "namespace N {"
+               "\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "\n"
+               "}",
+               Style);
+
+  Style.CompactNamespaces = true;
+
+  // Nested namespace.
+  verifyFormat("namespace N1 { namespace N2 {\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "}}",
+               Style);
+
+  Style.MaxEmptyLinesToKeep = 2;
+
+  // Nested namespace.
+  verifyNoChange("namespace N1 { namespace N2 {\n"
                  "\n"
                  "\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
+                 "int a = 1;\n"
+                 "\n"
+                 "\n"
+                 "}}",
+                 Style);
+
+  Style.CompactNamespaces = false;
+
+  // Empty namespace.
+  verifyFormat("namespace N {}", Style);
+
+  // Single namespace.
+  verifyNoChange("namespace N {\n"
+                 "\n"
+                 "\n"
+                 "int a = 1;\n"
+                 "\n"
+                 "\n"
+                 "}",
+                 Style);
+
+  // Nested namespace.
+  verifyNoChange("namespace N1 {\n"
+                 "namespace N2 {\n"
+                 "\n"
+                 "\n"
+                 "int a = 1;\n"
+                 "\n"
+                 "\n"
                  "}\n"
-                 "\n"
-                 "\n"
-                 "}}}",
+                 "}",
                  Style);
 }
 
 TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesLeave) {
-  FormatStyle Style = getLLVMStyle();
+  auto Style = getLLVMStyle();
   Style.FixNamespaceComments = false;
-  Style.ShortNamespaceLines = 0;
+
+  // Empty namespace.
+  verifyFormat("namespace N {}", Style);
+
+  // Single namespace.
+  verifyFormat("namespace N {\n"
+               "int f1(int a) { return 2 * a; }\n"
+               "}",
+               Style);
+
+  // Nested namespace.
+  verifyFormat("namespace N1 {\n"
+               "namespace N2 {\n"
+               "int a = 1;\n"
+               "}\n"
+               "}",
+               Style);
+
+  // Removing empty lines.
+  verifyFormat("namespace N {\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "}",
+               "namespace N {\n"
+               "\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "\n"
+               "}",
+               Style);
+
   Style.MaxEmptyLinesToKeep = 0;
-  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Leave;
-  Style.CompactNamespaces = false;
 
-  // Empty namespace
-  verifyNoChange("namespace N {};", Style);
-
-  // Single namespace
-  verifyNoChange("namespace N {\n"
-                 "int f1(int a) { return 2 * a; }\n"
-                 "};",
-                 Style);
-
-  // Nested namespace
-  verifyNoChange("namespace N1 {\n"
-                 "namespace N2 {\n"
-                 "namespace N3 {\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
-                 "}\n"
-                 "}\n"
-                 "}\n"
-                 "}",
-                 Style);
+  verifyFormat("namespace N {\n"
+               "int a = 1;\n"
+               "}",
+               "namespace N {\n"
+               "\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "\n"
+               "}",
+               Style);
 
   Style.MaxEmptyLinesToKeep = 2;
 
-  // Single namespace
+  // Single namespace.
   verifyNoChange("namespace N {\n"
                  "\n"
                  "\n"
                  "int f1(int a) { return 2 * a; }\n"
                  "\n"
                  "\n"
-                 "};",
+                 "}",
                  Style);
 
-  // Nested namespace
+  // Nested namespace.
   verifyNoChange("namespace N1 {\n"
                  "namespace N2 {\n"
                  "\n"
-                 "namespace N3 {\n"
                  "\n"
+                 "int a = 1;\n"
                  "\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
-                 "}\n"
-                 "\n"
-                 "\n"
-                 "}\n"
                  "\n"
                  "}\n"
                  "}",
@@ -28655,22 +28652,14 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesLeave) {
 
   Style.CompactNamespaces = true;
 
-  // Empty namespace
+  // Nested namespace.
   verifyNoChange("namespace N1 { namespace N2 {\n"
-                 "}};",
-                 Style);
-
-  // Nested namespace
-  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
                  "\n"
                  "\n"
-                 "int f1() {\n"
-                 "  int a = 1;\n"
-                 "  return a;\n"
-                 "}\n"
+                 "int a = 1;\n"
                  "\n"
                  "\n"
-                 "}}}",
+                 "}}",
                  Style);
 }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28427,6 +28427,211 @@ TEST_F(FormatTest, ShortNamespacesOption) {
       Style);
 }
 
+TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
+  FormatStyle Style = getLLVMStyle();
+  Style.FixNamespaceComments = false;
+  Style.ShortNamespaceLines = 0;
+  Style.MaxEmptyLinesToKeep = 2;
+  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Never;
+  Style.CompactNamespaces = false;
+
+  // Empty namespace
+  verifyNoChange("namespace N {};", Style);
+
+  // Single namespace
+  verifyNoChange("namespace N {\n"
+                 "int f1(int a) { return 2 * a; }\n"
+                 "};",
+                 Style);
+
+  // Nested namespace
+  verifyNoChange("namespace N1 {\n"
+                 "namespace N2 {\n"
+                 "namespace N3 {\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n"
+                 "}\n"
+                 "}\n"
+                 "}",
+                 Style);
+
+  Style.CompactNamespaces = true;
+
+  // Empty namespace
+  verifyNoChange("namespace N {\n};", Style);
+
+  // Single namespace
+  verifyNoChange("namespace N {\n"
+                 "int f1(int a) { return 2 * a; }\n"
+                 "};",
+                 Style);
+
+  // Nested namespace
+  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n"
+                 "}}}",
+                 Style);
+}
+
+TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
+  FormatStyle Style = getLLVMStyle();
+  Style.FixNamespaceComments = false;
+  Style.ShortNamespaceLines = 0;
+  Style.MaxEmptyLinesToKeep = 0;
+  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Always;
+  Style.CompactNamespaces = false;
+
+  // Empty namespace
+  verifyNoChange("namespace N {};", Style);
+
+  // Single namespace
+  verifyNoChange("namespace N {\n\n"
+                 "int f1(int a) { return 2 * a; }\n\n"
+                 "};",
+                 Style);
+
+  // Nested namespace
+  verifyNoChange("namespace N1 {\n"
+                 "namespace N2 {\n"
+                 "namespace N3 {\n\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n\n"
+                 "}\n"
+                 "}\n"
+                 "}",
+                 Style);
+
+  Style.CompactNamespaces = true;
+
+  // Nested namespace
+  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n\n"
+                 "}}}",
+                 Style);
+
+  Style.MaxEmptyLinesToKeep = 2;
+  Style.CompactNamespaces = false;
+
+  // Empty namespace
+  verifyNoChange("namespace N {};", Style);
+
+  // Single namespace
+  verifyNoChange("namespace N {\n\n\n"
+                 "void function()\n\n\n"
+                 "};",
+                 Style);
+
+  // Nested namespace
+  verifyFormat("namespace N1 {\n"
+               "namespace N2 {\n"
+               "namespace N3 {\n\n\n"
+               "int f1() {\n"
+               "  int a = 1;\n"
+               "  return a;\n"
+               "}\n\n\n"
+               "}\n"
+               "}\n"
+               "}",
+               "namespace N1 {\n"
+               "namespace N2 {\n\n"
+               "namespace N3 {\n\n\n"
+               "int f1() {\n"
+               "  int a = 1;\n"
+               "  return a;\n"
+               "}\n\n\n"
+               "}\n\n"
+               "}\n"
+               "}",
+               Style);
+
+  Style.CompactNamespaces = true;
+
+  // Nested namespace
+  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n\n\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n\n\n"
+                 "}}}",
+                 Style);
+}
+
+TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesLeave) {
+  FormatStyle Style = getLLVMStyle();
+  Style.FixNamespaceComments = false;
+  Style.ShortNamespaceLines = 0;
+  Style.MaxEmptyLinesToKeep = 0;
+  Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Leave;
+  Style.CompactNamespaces = false;
+
+  // Empty namespace
+  verifyNoChange("namespace N {};", Style);
+
+  // Single namespace
+  verifyNoChange("namespace N {\n"
+                 "int f1(int a) { return 2 * a; }\n"
+                 "};",
+                 Style);
+
+  // Nested namespace
+  verifyNoChange("namespace N1 {\n"
+                 "namespace N2 {\n"
+                 "namespace N3 {\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n"
+                 "}\n"
+                 "}\n"
+                 "}",
+                 Style);
+
+  Style.MaxEmptyLinesToKeep = 2;
+
+  // Single namespace
+  verifyNoChange("namespace N {\n\n\n"
+                 "int f1(int a) { return 2 * a; }\n\n\n"
+                 "};",
+                 Style);
+
+  // Nested namespace
+  verifyNoChange("namespace N1 {\n"
+                 "namespace N2 {\n\n"
+                 "namespace N3 {\n\n\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n\n\n"
+                 "}\n\n"
+                 "}\n"
+                 "}",
+                 Style);
+
+  Style.CompactNamespaces = true;
+
+  // Empty namespace
+  verifyNoChange("namespace N {\n};", Style);
+
+  // Nested namespace
+  verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n\n\n"
+                 "int f1() {\n"
+                 "  int a = 1;\n"
+                 "  return a;\n"
+                 "}\n\n\n"
+                 "}}}",
+                 Style);
+}
+
 } // namespace
 } // namespace test
 } // namespace format

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28430,6 +28430,7 @@ TEST_F(FormatTest, ShortNamespacesOption) {
 TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
   auto Style = getLLVMStyle();
   Style.FixNamespaceComments = false;
+  Style.MaxEmptyLinesToKeep = 2;
   Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Never;
 
   // Empty namespace.
@@ -28439,6 +28440,13 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
   verifyFormat("namespace N {\n"
                "int f1(int a) { return 2 * a; }\n"
                "}",
+               "namespace N {\n"
+               "\n"
+               "\n"
+               "int f1(int a) { return 2 * a; }\n"
+               "\n"
+               "\n"
+               "}",
                Style);
 
   // Nested namespace.
@@ -28447,6 +28455,17 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
                "int a = 1;\n"
                "}\n"
                "}",
+               "namespace N1 {\n"
+               "\n"
+               "\n"
+               "namespace N2 {\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "}\n"
+               "\n"
+               "\n"
+               "}",
                Style);
 
   Style.CompactNamespaces = true;
@@ -28454,39 +28473,20 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
   verifyFormat("namespace N1 { namespace N2 {\n"
                "int a = 1;\n"
                "}}",
-               Style);
-
-  // Removing empty lines.
-  verifyFormat("namespace N {\n"
-               "int a = 1;\n"
-               "}",
-               "namespace N {\n"
+               "namespace N1 { namespace N2 {\n"
                "\n"
                "\n"
                "int a = 1;\n"
                "\n"
                "\n"
-               "}",
-               Style);
-
-  Style.MaxEmptyLinesToKeep = 0;
-
-  verifyFormat("namespace N {\n"
-               "int a = 1;\n"
-               "}",
-               "namespace N {\n"
-               "\n"
-               "\n"
-               "int a = 1;\n"
-               "\n"
-               "\n"
-               "}",
+               "}}",
                Style);
 }
 
 TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
   auto Style = getLLVMStyle();
   Style.FixNamespaceComments = false;
+  Style.MaxEmptyLinesToKeep = 2;
   Style.WrapNamespaceBodyWithEmptyLines = FormatStyle::WNBWELS_Always;
 
   // Empty namespace.
@@ -28498,6 +28498,9 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
                "int f1(int a) { return 2 * a; }\n"
                "\n"
                "}",
+               "namespace N {\n"
+               "int f1(int a) { return 2 * a; }\n"
+               "}",
                Style);
 
   // Nested namespace.
@@ -28508,53 +28511,50 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesAlways) {
                "\n"
                "}\n"
                "}",
+               "namespace N1 {\n"
+               "namespace N2 {\n"
+               "int a = 1;\n"
+               "}\n"
+               "}",
+               Style);
+
+  verifyFormat("namespace N1 {\n"
+               "\n"
+               "namespace N2 {\n"
+               "\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "\n"
+               "}\n"
+               "\n"
+               "}",
+               "namespace N1 {\n"
+               "\n"
+               "namespace N2 {\n"
+               "\n"
+               "\n"
+               "\n"
+               "int a = 1;\n"
+               "\n"
+               "\n"
+               "\n"
+               "}\n"
+               "\n"
+               "}",
                Style);
 
   Style.CompactNamespaces = true;
 
-  // Nested namespace.
   verifyFormat("namespace N1 { namespace N2 {\n"
                "\n"
                "int a = 1;\n"
                "\n"
                "}}",
+               "namespace N1 { namespace N2 {\n"
+               "int a = 1;\n"
+               "}}",
                Style);
-
-  Style.MaxEmptyLinesToKeep = 2;
-
-  // Nested namespace.
-  verifyNoChange("namespace N1 { namespace N2 {\n"
-                 "\n"
-                 "\n"
-                 "int a = 1;\n"
-                 "\n"
-                 "\n"
-                 "}}",
-                 Style);
-
-  Style.CompactNamespaces = false;
-
-  // Single namespace.
-  verifyNoChange("namespace N {\n"
-                 "\n"
-                 "\n"
-                 "int a = 1;\n"
-                 "\n"
-                 "\n"
-                 "}",
-                 Style);
-
-  // Nested namespace.
-  verifyNoChange("namespace N1 {\n"
-                 "namespace N2 {\n"
-                 "\n"
-                 "\n"
-                 "int a = 1;\n"
-                 "\n"
-                 "\n"
-                 "}\n"
-                 "}",
-                 Style);
 }
 
 } // namespace

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28460,8 +28460,8 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
   Style.CompactNamespaces = true;
 
   // Empty namespace
-  verifyNoChange("namespace N {\n"
-                 "};",
+  verifyNoChange("namespace N1 { namespace N2 {\n"
+                 "}};",
                  Style);
 
   // Single namespace
@@ -28656,7 +28656,9 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesLeave) {
   Style.CompactNamespaces = true;
 
   // Empty namespace
-  verifyNoChange("namespace N {\n};", Style);
+  verifyNoChange("namespace N1 { namespace N2 {\n"
+                 "}};",
+                 Style);
 
   // Nested namespace
   verifyNoChange("namespace N1 { namespace N2 { namespace N3 {\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28458,9 +28458,7 @@ TEST_F(FormatTest, WrapNamespaceBodyWithEmptyLinesNever) {
 
   // Removing empty lines.
   verifyFormat("namespace N {\n"
-               "\n"
                "int a = 1;\n"
-               "\n"
                "}",
                "namespace N {\n"
                "\n"


### PR DESCRIPTION
I would like to suggest a new clang-format option for llvm-project - WrapNamespaceBodyWithNewlines. I think it can be added to upstream since it is used by many popular public repositories, for example, [ytsaurus](https://github.com/ytsaurus/ytsaurus/). You can look through their style guide at this page: https://github.com/ytsaurus/ytsaurus/blob/main/yt/styleguide/cpp.md#namespaces

As you can see from the name of the option it wraps the body of namespace with additional newlines turning this code:
```
namespace N {
int function();
} 
 ```
into that:
```
namespace N {

int function();

} 
 ```
Looking forward to your advices and recommendations