### PR TITLE
[compiler-rt][test] Add REQUIRES: shell to focus-function.test with for-loop

### DIFF
--- a/compiler-rt/test/fuzzer/focus-function.test
+++ b/compiler-rt/test/fuzzer/focus-function.test
@@ -1,6 +1,7 @@
 # Tests -focus_function
 #
 # TODO: don't require linux.
+# Requires full shell support for the `for` loop syntax.
 # REQUIRES: shell, linux
 UNSUPPORTED: target=aarch64{{.*}}
 

--- a/compiler-rt/test/fuzzer/focus-function.test
+++ b/compiler-rt/test/fuzzer/focus-function.test
@@ -1,7 +1,7 @@
 # Tests -focus_function
 #
 # TODO: don't require linux.
-# REQUIRES: linux
+# REQUIRES: shell, linux
 UNSUPPORTED: target=aarch64{{.*}}
 
 RUN: %cpp_compiler %S/OnlySomeBytesTest.cpp -o %t-exe


### PR DESCRIPTION
 This patch adds `REQUIRES: shell` to the `focus-function.test` because the lit internal shell does not support the for loop syntax. This will make the test file unsupported when running llvm-lit with its internal shell implementation, which is enabled by turning on the `LIT_USE_INTERNAL_SHELL=1`. 

fixes: #102380