### PR TITLE
[flang] Fix crash in semantics

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -3131,7 +3131,7 @@ void ModuleVisitor::DoAddUse(SourceName location, SourceName localName,
     combinedDerivedType = useDerivedType;
   } else {
     const Scope *localScope{localDerivedType->scope()};
-    const Scope *useScope{useDerivedType->scope()};
+    const Scope *useScope{useDerivedType->GetUltimate().scope()};
     if (localScope && useScope && localScope->derivedTypeSpec() &&
         useScope->derivedTypeSpec() &&
         evaluate::AreSameDerivedType(
@@ -3307,7 +3307,12 @@ void ModuleVisitor::DoAddUse(SourceName location, SourceName localName,
     AddGenericUse(newUseGeneric, localName, useUltimate);
     newUseGeneric.AddUse(*localSymbol);
     if (combinedDerivedType) {
-      newUseGeneric.set_derivedType(*const_cast<Symbol *>(combinedDerivedType));
+      if (const auto *oldDT{newUseGeneric.derivedType()}) {
+        CHECK(&oldDT->GetUltimate() == &combinedDerivedType->GetUltimate());
+      } else {
+        newUseGeneric.set_derivedType(
+            *const_cast<Symbol *>(combinedDerivedType));
+      }
     }
     if (combinedProcedure) {
       newUseGeneric.set_specific(*const_cast<Symbol *>(combinedProcedure));

--- a/flang/test/Semantics/generic09.f90
+++ b/flang/test/Semantics/generic09.f90
@@ -1,0 +1,47 @@
+! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+module m1
+  type foo
+    integer n
+    integer :: m = 1
+  end type
+end
+
+module m2
+  use m1
+  interface foo
+    module procedure f1
+  end interface
+ contains
+  type(foo) function f1(a)
+    real, intent(in) :: a
+    f1%n = a
+    f1%m = 2
+  end
+end
+
+module m3
+  use m2
+  interface foo
+    module procedure f2
+  end interface
+ contains
+  type(foo) function f2(a)
+    double precision, intent(in) :: a
+    f2%n = a
+    f2%m = 3
+  end
+end
+
+program main
+  use m3
+  type(foo) x
+!CHECK: foo(n=1_4,m=1_4)
+  x = foo(1)
+  print *, x
+!CHECK: f1(2._4)
+  x = foo(2.)
+  print *, x
+!CHECK: f2(3._8)
+  x = foo(3.d0)
+  print *, x
+end


### PR DESCRIPTION
Semantics crashes when merging a USE-associated derived type with a local generic procedure interface of the same name.  (The other direction works.)