### PR TITLE
[lldb] Turn lldb_private::Status into a value type.

### DIFF
--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -306,11 +306,11 @@ PythonObject lldb_private::python::SWIGBridge::LLDBSwigPythonCreateScriptedStopH
     const char *session_dictionary_name, const StructuredDataImpl &args_impl,
     Status &error) {
   if (python_class_name == NULL || python_class_name[0] == '\0') {
-    error.SetErrorString("Empty class name.");
+    error = Status::FromErrorString("Empty class name.");
     return PythonObject();
   }
   if (!session_dictionary_name) {
-    error.SetErrorString("No session dictionary");
+    error = Status::FromErrorString("No session dictionary");
     return PythonObject();
   }
 
@@ -322,7 +322,7 @@ PythonObject lldb_private::python::SWIGBridge::LLDBSwigPythonCreateScriptedStopH
       python_class_name, dict);
 
   if (!pfunc.IsAllocated()) {
-    error.SetErrorStringWithFormat("Could not find class: %s.",
+    error = Status::FromErrorStringWithFormat("Could not find class: %s.",
                                    python_class_name);
     return PythonObject();
   }
@@ -337,7 +337,7 @@ PythonObject lldb_private::python::SWIGBridge::LLDBSwigPythonCreateScriptedStopH
       if (auto args_info = callback_func.GetArgInfo()) {
         size_t num_args = (*args_info).max_positional_args;
         if (num_args != 2) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "Wrong number of args for "
               "handle_stop callback, should be 2 (excluding self), got: %zu",
               num_args);
@@ -345,15 +345,17 @@ PythonObject lldb_private::python::SWIGBridge::LLDBSwigPythonCreateScriptedStopH
         } else
           return result;
       } else {
-        error.SetErrorString("Couldn't get num arguments for handle_stop "
-                             "callback.");
+        error = Status::FromErrorString(
+            "Couldn't get num arguments for handle_stop "
+            "callback.");
         return PythonObject();
       }
       return result;
     } else {
-      error.SetErrorStringWithFormat("Class \"%s\" is missing the required "
-                                     "handle_stop callback.",
-                                     python_class_name);
+      error = Status::FromErrorStringWithFormat(
+          "Class \"%s\" is missing the required "
+          "handle_stop callback.",
+          python_class_name);
     }
   }
   return PythonObject();

--- a/lldb/include/lldb/Core/StructuredDataImpl.h
+++ b/lldb/include/lldb/Core/StructuredDataImpl.h
@@ -50,38 +50,28 @@ public:
   }
 
   Status GetAsJSON(Stream &stream) const {
-    Status error;
-
-    if (!m_data_sp) {
-      error.SetErrorString("No structured data.");
-      return error;
-    }
+    if (!m_data_sp)
+      return Status::FromErrorString("No structured data.");
 
     llvm::json::OStream s(stream.AsRawOstream());
     m_data_sp->Serialize(s);
-    return error;
+    return Status();
   }
 
   Status GetDescription(Stream &stream) const {
-    Status error;
-
-    if (!m_data_sp) {
-      error.SetErrorString("Cannot pretty print structured data: "
-                           "no data to print.");
-      return error;
-    }
+    if (!m_data_sp)
+      return Status::FromErrorString("Cannot pretty print structured data: "
+                                     "no data to print.");
 
     // Grab the plugin
     lldb::StructuredDataPluginSP plugin_sp = m_plugin_wp.lock();
 
     // If there's no plugin, call underlying data's dump method:
     if (!plugin_sp) {
-      if (!m_data_sp) {
-        error.SetErrorString("No data to describe.");
-        return error;
-      }
+      if (!m_data_sp)
+        return Status::FromErrorString("No data to describe.");
       m_data_sp->GetDescription(stream);
-      return error;
+      return Status();
     }
     // Get the data's description.
     return plugin_sp->GetDescription(m_data_sp, stream);

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedInterface.h
@@ -48,7 +48,7 @@ public:
           llvm::Twine(llvm::Twine(" (") + llvm::Twine(detailed_error) +
                       llvm::Twine(")"))
               .str();
-    error.SetErrorString(full_error_message);
+    error = Status(std::move(full_error_message));
     return {};
   }
 

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedPlatformInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedPlatformInterface.h
@@ -31,15 +31,18 @@ public:
   }
 
   virtual Status AttachToProcess(lldb::ProcessAttachInfoSP attach_info) {
-    return Status("ScriptedPlatformInterface cannot attach to a process");
+    return Status::FromErrorString(
+        "ScriptedPlatformInterface cannot attach to a process");
   }
 
   virtual Status LaunchProcess(lldb::ProcessLaunchInfoSP launch_info) {
-    return Status("ScriptedPlatformInterface cannot launch process");
+    return Status::FromErrorString(
+        "ScriptedPlatformInterface cannot launch process");
   }
 
   virtual Status KillProcess(lldb::pid_t pid) {
-    return Status("ScriptedPlatformInterface cannot kill process");
+    return Status::FromErrorString(
+        "ScriptedPlatformInterface cannot kill process");
   }
 };
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedProcessInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedProcessInterface.h
@@ -29,23 +29,28 @@ public:
   virtual StructuredData::DictionarySP GetCapabilities() { return {}; }
 
   virtual Status Attach(const ProcessAttachInfo &attach_info) {
-    return Status("ScriptedProcess did not attach");
+    return Status::FromErrorString("ScriptedProcess did not attach");
   }
 
-  virtual Status Launch() { return Status("ScriptedProcess did not launch"); }
+  virtual Status Launch() {
+    return Status::FromErrorString("ScriptedProcess did not launch");
+  }
 
-  virtual Status Resume() { return Status("ScriptedProcess did not resume"); }
+  virtual Status Resume() {
+    return Status::FromErrorString("ScriptedProcess did not resume");
+  }
 
   virtual std::optional<MemoryRegionInfo>
   GetMemoryRegionContainingAddress(lldb::addr_t address, Status &error) {
-    error.SetErrorString("ScriptedProcess have no memory region.");
+    error = Status::FromErrorString("ScriptedProcess have no memory region.");
     return {};
   }
 
   virtual StructuredData::DictionarySP GetThreadsInfo() { return {}; }
 
   virtual bool CreateBreakpoint(lldb::addr_t addr, Status &error) {
-    error.SetErrorString("ScriptedProcess don't support creating breakpoints.");
+    error = Status::FromErrorString(
+        "ScriptedProcess don't support creating breakpoints.");
     return {};
   }
 

--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -119,7 +119,8 @@ public:
   virtual lldb::OptionValueSP GetSubValue(const ExecutionContext *exe_ctx,
                                           llvm::StringRef name,
                                           Status &error) const {
-    error.SetErrorStringWithFormatv("'{0}' is not a valid subvalue", name);
+    error = Status::FromErrorStringWithFormatv("'{0}' is not a valid subvalue",
+                                               name);
     return lldb::OptionValueSP();
   }
 

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -176,25 +176,19 @@ public:
   virtual Status ExecuteMultipleLines(
       const char *in_string,
       const ExecuteScriptOptions &options = ExecuteScriptOptions()) {
-    Status error;
-    error.SetErrorString("not implemented");
-    return error;
+    return Status::FromErrorString("not implemented");
   }
 
   virtual Status
   ExportFunctionDefinitionToInterpreter(StringList &function_def) {
-    Status error;
-    error.SetErrorString("not implemented");
-    return error;
+    return Status::FromErrorString("not implemented");
   }
 
   virtual Status GenerateBreakpointCommandCallbackData(StringList &input,
                                                        std::string &output,
                                                        bool has_extra_args,
                                                        bool is_callback) {
-    Status error;
-    error.SetErrorString("not implemented");
-    return error;
+    return Status::FromErrorString("not implemented");
   }
 
   virtual bool GenerateWatchpointCommandCallbackData(StringList &input,
@@ -280,8 +274,9 @@ public:
   virtual StructuredData::GenericSP
   CreateScriptedStopHook(lldb::TargetSP target_sp, const char *class_name,
                          const StructuredDataImpl &args_data, Status &error) {
-    error.SetErrorString("Creating scripted stop-hooks with the current "
-                         "script interpreter is not supported.");
+    error =
+        Status::FromErrorString("Creating scripted stop-hooks with the current "
+                                "script interpreter is not supported.");
     return StructuredData::GenericSP();
   }
 
@@ -308,9 +303,7 @@ public:
   virtual Status GenerateFunction(const char *signature,
                                   const StringList &input,
                                   bool is_callback) {
-    Status error;
-    error.SetErrorString("unimplemented");
-    return error;
+    return Status::FromErrorString("not implemented");
   }
 
   virtual void CollectDataForBreakpointCommandCallback(
@@ -329,18 +322,14 @@ public:
   virtual Status SetBreakpointCommandCallback(BreakpointOptions &bp_options,
                                               const char *callback_text,
                                               bool is_callback) {
-    Status error;
-    error.SetErrorString("unimplemented");
-    return error;
+    return Status::FromErrorString("not implemented");
   }
 
   /// This one is for deserialization:
   virtual Status SetBreakpointCommandCallback(
       BreakpointOptions &bp_options,
       std::unique_ptr<BreakpointOptions::CommandData> &data_up) {
-    Status error;
-    error.SetErrorString("unimplemented");
-    return error;
+    return Status::FromErrorString("not implemented");
   }
 
   Status SetBreakpointCommandCallbackFunction(
@@ -352,9 +341,7 @@ public:
   SetBreakpointCommandCallbackFunction(BreakpointOptions &bp_options,
                                        const char *function_name,
                                        StructuredData::ObjectSP extra_args_sp) {
-    Status error;
-    error.SetErrorString("unimplemented");
-    return error;
+    return Status::FromErrorString("not implemented");
   }
 
   /// Set a one-liner as the callback for the watchpoint.
@@ -453,33 +440,33 @@ public:
   virtual bool RunScriptFormatKeyword(const char *impl_function,
                                       Process *process, std::string &output,
                                       Status &error) {
-    error.SetErrorString("unimplemented");
+    error = Status::FromErrorString("unimplemented");
     return false;
   }
 
   virtual bool RunScriptFormatKeyword(const char *impl_function, Thread *thread,
                                       std::string &output, Status &error) {
-    error.SetErrorString("unimplemented");
+    error = Status::FromErrorString("unimplemented");
     return false;
   }
 
   virtual bool RunScriptFormatKeyword(const char *impl_function, Target *target,
                                       std::string &output, Status &error) {
-    error.SetErrorString("unimplemented");
+    error = Status::FromErrorString("unimplemented");
     return false;
   }
 
   virtual bool RunScriptFormatKeyword(const char *impl_function,
                                       StackFrame *frame, std::string &output,
                                       Status &error) {
-    error.SetErrorString("unimplemented");
+    error = Status::FromErrorString("unimplemented");
     return false;
   }
 
   virtual bool RunScriptFormatKeyword(const char *impl_function,
                                       ValueObject *value, std::string &output,
                                       Status &error) {
-    error.SetErrorString("unimplemented");
+    error = Status::FromErrorString("unimplemented");
     return false;
   }
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -617,10 +617,8 @@ public:
   virtual Status LoadCore();
 
   virtual Status DoLoadCore() {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support loading core files.", GetPluginName());
-    return error;
   }
 
   /// The "ShadowListener" for a process is just an ordinary Listener that
@@ -993,9 +991,7 @@ public:
   /// \return
   ///     Returns an error object.
   virtual Status DoConnectRemote(llvm::StringRef remote_url) {
-    Status error;
-    error.SetErrorString("remote connections are not supported");
-    return error;
+    return Status::FromErrorString("remote connections are not supported");
   }
 
   /// Attach to an existing process using a process ID.
@@ -1014,11 +1010,9 @@ public:
   /// hanming : need flag
   virtual Status DoAttachToProcessWithID(lldb::pid_t pid,
                                          const ProcessAttachInfo &attach_info) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support attaching to a process by pid",
         GetPluginName());
-    return error;
   }
 
   /// Attach to an existing process using a partial process name.
@@ -1037,9 +1031,7 @@ public:
   virtual Status
   DoAttachToProcessWithName(const char *process_name,
                             const ProcessAttachInfo &attach_info) {
-    Status error;
-    error.SetErrorString("attach by name is not supported");
-    return error;
+    return Status::FromErrorString("attach by name is not supported");
   }
 
   /// Called after attaching a process.
@@ -1104,10 +1096,8 @@ public:
   ///     An Status instance indicating success or failure of the
   ///     operation.
   virtual Status DoLaunch(Module *exe_module, ProcessLaunchInfo &launch_info) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support launching processes", GetPluginName());
-    return error;
   }
 
   /// Called after launching a process.
@@ -1139,10 +1129,8 @@ public:
   /// \see Thread:Step()
   /// \see Thread:Suspend()
   virtual Status DoResume() {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support resuming processes", GetPluginName());
-    return error;
   }
 
   /// Called after resuming a process.
@@ -1174,10 +1162,8 @@ public:
   ///     Returns \b true if the process successfully halts, \b false
   ///     otherwise.
   virtual Status DoHalt(bool &caused_stop) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support halting processes", GetPluginName());
-    return error;
   }
 
   /// Called after halting a process.
@@ -1200,11 +1186,9 @@ public:
   ///     Returns \b true if the process successfully detaches, \b
   ///     false otherwise.
   virtual Status DoDetach(bool keep_stopped) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support detaching from processes",
         GetPluginName());
-    return error;
   }
 
   /// Called after detaching from a process.
@@ -1231,11 +1215,9 @@ public:
   /// \return
   ///     Returns an error object.
   virtual Status DoSignal(int signal) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support sending signals to processes",
         GetPluginName());
-    return error;
   }
 
   virtual Status WillDestroy() { return Status(); }
@@ -1689,7 +1671,7 @@ public:
   ///     The number of bytes that were actually written.
   virtual size_t DoWriteMemory(lldb::addr_t vm_addr, const void *buf,
                                size_t size, Status &error) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "error: {0} does not support writing to processes", GetPluginName());
     return 0;
   }
@@ -1772,7 +1754,7 @@ public:
 
   virtual lldb::addr_t DoAllocateMemory(size_t size, uint32_t permissions,
                                         Status &error) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "error: {0} does not support allocating in the debug process",
         GetPluginName());
     return LLDB_INVALID_ADDRESS;
@@ -2039,11 +2021,9 @@ public:
   /// \return
   ///     \b true if the memory was deallocated, \b false otherwise.
   virtual Status DoDeallocateMemory(lldb::addr_t ptr) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support deallocating in the debug process",
         GetPluginName());
-    return error;
   }
 
   /// The public interface to deallocating memory in the process.
@@ -2136,7 +2116,7 @@ public:
   ///     less than \a buf_size, another call to this function should
   ///     be made to write the rest of the data.
   virtual size_t PutSTDIN(const char *buf, size_t buf_size, Status &error) {
-    error.SetErrorString("stdin unsupported");
+    error = Status::FromErrorString("stdin unsupported");
     return 0;
   }
 
@@ -2159,17 +2139,13 @@ public:
   size_t GetSoftwareBreakpointTrapOpcode(BreakpointSite *bp_site);
 
   virtual Status EnableBreakpointSite(BreakpointSite *bp_site) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support enabling breakpoints", GetPluginName());
-    return error;
   }
 
   virtual Status DisableBreakpointSite(BreakpointSite *bp_site) {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support disabling breakpoints", GetPluginName());
-    return error;
   }
 
   // This is implemented completely using the lldb::Process API. Subclasses
@@ -2526,8 +2502,8 @@ void PruneThreadPlans();
   bool CurrentThreadIsPrivateStateThread();
 
   virtual Status SendEventData(const char *data) {
-    Status return_error("Sending an event is not supported for this process.");
-    return return_error;
+    return Status::FromErrorString(
+        "Sending an event is not supported for this process.");
   }
 
   lldb::ThreadCollectionSP GetHistoryThreads(lldb::addr_t addr);
@@ -2575,7 +2551,7 @@ void PruneThreadPlans();
   ///     processes address space, LLDB_INVALID_ADDRESS otherwise.
   virtual Status GetFileLoadAddress(const FileSpec &file, bool &is_loaded,
                                     lldb::addr_t &load_addr) {
-    return Status("Not supported");
+    return Status::FromErrorString("Not supported");
   }
 
   /// Fetch process defined metadata.
@@ -2861,7 +2837,8 @@ protected:
   ///     An error value.
   virtual Status DoGetMemoryRegionInfo(lldb::addr_t load_addr,
                                        MemoryRegionInfo &range_info) {
-    return Status("Process::DoGetMemoryRegionInfo() not supported");
+    return Status::FromErrorString(
+        "Process::DoGetMemoryRegionInfo() not supported");
   }
 
   /// Provide an override value in the subclass for lldb's
@@ -3060,10 +3037,8 @@ protected:
   ///     Status telling you whether the write succeeded.
   virtual Status DoWriteMemoryTags(lldb::addr_t addr, size_t len, int32_t type,
                                    const std::vector<uint8_t> &tags) {
-    Status status;
-    status.SetErrorStringWithFormatv("{0} does not support writing memory tags",
-                                     GetPluginName());
-    return status;
+    return Status::FromErrorStringWithFormatv(
+        "{0} does not support writing memory tags", GetPluginName());
   }
 
   // Type definitions

--- a/lldb/include/lldb/Target/ProcessTrace.h
+++ b/lldb/include/lldb/Target/ProcessTrace.h
@@ -48,10 +48,8 @@ public:
   void RefreshStateAfterStop() override;
 
   Status WillResume() override {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support resuming processes", GetPluginName());
-    return error;
   }
 
   bool WarnBeforeDetach() const override { return false; }

--- a/lldb/include/lldb/Utility/Status.h
+++ b/lldb/include/lldb/Utility/Status.h
@@ -56,18 +56,38 @@ public:
   ///
   /// \param[in] type
   ///     The type for \a err.
-  explicit Status(ValueType err,
-                  lldb::ErrorType type = lldb::eErrorTypeGeneric);
+  explicit Status(ValueType err, lldb::ErrorType type = lldb::eErrorTypeGeneric,
+                  std::string msg = {});
 
   Status(std::error_code EC);
 
-  explicit Status(const char *format, ...)
-      __attribute__((format(printf, 2, 3)));
+  /// Create a generic error with the message \c err_str.
+  explicit Status(std::string err_str);
+
+  static Status FromErrorString(const char *str) {
+    if (str)
+      return Status(std::string(str));
+    return Status(std::string("null error"));
+  }
+
+  static Status FromErrorStringWithFormat(const char *format, ...)
+      __attribute__((format(printf, 1, 2)));
 
   template <typename... Args>
-  static Status createWithFormat(const char *format, Args &&...args) {
+  static Status FromErrorStringWithFormatv(const char *format, Args &&...args) {
     return Status(llvm::formatv(format, std::forward<Args>(args)...));
   }
+
+  static Status FromExpressionError(lldb::ExpressionResults result,
+                                    std::string msg) {
+    return Status(result, lldb::eErrorTypeExpression, msg);
+  }
+
+  /// Set the current error to errno.
+  ///
+  /// Update the error value to be \c errno and update the type to be \c
+  /// Status::POSIX.
+  static Status FromErrno();
 
   ~Status();
 
@@ -114,62 +134,6 @@ public:
   ///     The error type enumeration value.
   lldb::ErrorType GetType() const;
 
-  void SetExpressionError(lldb::ExpressionResults, const char *mssg);
-
-  int SetExpressionErrorWithFormat(lldb::ExpressionResults, const char *format,
-                                   ...) __attribute__((format(printf, 3, 4)));
-
-  /// Set accessor with an error value and type.
-  ///
-  /// Set accessor for the error value to \a err and the error type to \a
-  /// type.
-  ///
-  /// \param[in] err
-  ///     A mach error code.
-  ///
-  /// \param[in] type
-  ///     The type for \a err.
-  void SetError(ValueType err, lldb::ErrorType type);
-
-  /// Set the current error to errno.
-  ///
-  /// Update the error value to be \c errno and update the type to be \c
-  /// Status::POSIX.
-  void SetErrorToErrno();
-
-  /// Set the current error to a generic error.
-  ///
-  /// Update the error value to be \c LLDB_GENERIC_ERROR and update the type
-  /// to be \c Status::Generic.
-  void SetErrorToGenericError();
-
-  /// Set the current error string to \a err_str.
-  ///
-  /// Set accessor for the error string value for a generic errors, or to
-  /// supply additional details above and beyond the standard error strings
-  /// that the standard type callbacks typically provide. This allows custom
-  /// strings to be supplied as an error explanation. The error string value
-  /// will remain until the error value is cleared or a new error value/type
-  /// is assigned.
-  ///
-  /// \param err_str
-  ///     The new custom error string to copy and cache.
-  void SetErrorString(llvm::StringRef err_str);
-
-  /// Set the current error string to a formatted error string.
-  ///
-  /// \param format
-  ///     A printf style format string
-  int SetErrorStringWithFormat(const char *format, ...)
-      __attribute__((format(printf, 2, 3)));
-
-  int SetErrorStringWithVarArg(const char *format, va_list args);
-
-  template <typename... Args>
-  void SetErrorStringWithFormatv(const char *format, Args &&... args) {
-    SetErrorString(llvm::formatv(format, std::forward<Args>(args)...).str());
-  }
-
   /// Test for success condition.
   ///
   /// Returns true if the error code in this object is considered a successful
@@ -187,11 +151,6 @@ protected:
   lldb::ErrorType m_type = lldb::eErrorTypeInvalid;
   /// A string representation of the error code.
   mutable std::string m_string;
-private:
-  explicit Status(const llvm::formatv_object_base &payload) {
-    SetErrorToGenericError();
-    m_string = payload.str();
-  }
 };
 
 } // namespace lldb_private
@@ -201,7 +160,7 @@ template <> struct format_provider<lldb_private::Status> {
   static void format(const lldb_private::Status &error, llvm::raw_ostream &OS,
                      llvm::StringRef Options);
 };
-}
+} // namespace llvm
 
 #define LLDB_ERRORF(status, fmt, ...)                                          \
   do {                                                                         \

--- a/lldb/source/API/SBBreakpoint.cpp
+++ b/lldb/source/API/SBBreakpoint.cpp
@@ -540,17 +540,18 @@ SBError SBBreakpoint::AddLocation(SBAddress &address) {
   SBError error;
 
   if (!address.IsValid()) {
-    error.SetErrorString("Can't add an invalid address.");
+    error = Status::FromErrorString("Can't add an invalid address.");
     return error;
   }
 
   if (!bkpt_sp) {
-    error.SetErrorString("No breakpoint to add a location to.");
+    error = Status::FromErrorString("No breakpoint to add a location to.");
     return error;
   }
 
   if (!llvm::isa<BreakpointResolverScripted>(bkpt_sp->GetResolver().get())) {
-    error.SetErrorString("Only a scripted resolver can add locations.");
+    error =
+        Status::FromErrorString("Only a scripted resolver can add locations.");
     return error;
   }
 
@@ -560,8 +561,8 @@ SBError SBBreakpoint::AddLocation(SBAddress &address) {
     StreamString s;
     address.get()->Dump(&s, &bkpt_sp->GetTarget(),
                         Address::DumpStyleModuleWithFileAddress);
-    error.SetErrorStringWithFormat("Address: %s didn't pass the filter.",
-                                   s.GetData());
+    error = Status::FromErrorStringWithFormat(
+        "Address: %s didn't pass the filter.", s.GetData());
   }
   return error;
 }
@@ -623,7 +624,7 @@ SBError SBBreakpoint::SetScriptCallbackFunction(
                                                    ->GetObjectSP());
     sb_error.SetError(error);
   } else
-    sb_error.SetErrorString("invalid breakpoint");
+    sb_error = Status::FromErrorString("invalid breakpoint");
 
   return sb_error;
 }
@@ -646,7 +647,7 @@ SBError SBBreakpoint::SetScriptCallbackBody(const char *callback_body_text) {
                                            /*is_callback=*/false);
     sb_error.SetError(error);
   } else
-    sb_error.SetErrorString("invalid breakpoint");
+    sb_error = Status::FromErrorString("invalid breakpoint");
 
   return sb_error;
 }
@@ -671,7 +672,7 @@ SBError SBBreakpoint::AddNameWithErrorHandling(const char *new_name) {
     bkpt_sp->GetTarget().AddNameToBreakpoint(bkpt_sp, new_name, error);
     status.SetError(error);
   } else {
-    status.SetErrorString("invalid breakpoint");
+    status = Status::FromErrorString("invalid breakpoint");
   }
 
   return status;

--- a/lldb/source/API/SBBreakpointLocation.cpp
+++ b/lldb/source/API/SBBreakpointLocation.cpp
@@ -241,7 +241,7 @@ SBError SBBreakpointLocation::SetScriptCallbackFunction(
                                                    ->GetObjectSP());
       sb_error.SetError(error);
     } else
-      sb_error.SetErrorString("invalid breakpoint");
+      sb_error = Status::FromErrorString("invalid breakpoint");
 
     return sb_error;
 }
@@ -266,7 +266,7 @@ SBBreakpointLocation::SetScriptCallbackBody(const char *callback_body_text) {
                                            /*is_callback=*/false);
     sb_error.SetError(error);
   } else
-    sb_error.SetErrorString("invalid breakpoint");
+    sb_error = Status::FromErrorString("invalid breakpoint");
 
   return sb_error;
 }

--- a/lldb/source/API/SBBreakpointName.cpp
+++ b/lldb/source/API/SBBreakpointName.cpp
@@ -562,7 +562,7 @@ SBError SBBreakpointName::SetScriptCallbackFunction(
   SBError sb_error;
   BreakpointName *bp_name = GetBreakpointName();
   if (!bp_name) {
-    sb_error.SetErrorString("unrecognized breakpoint name");
+    sb_error = Status::FromErrorString("unrecognized breakpoint name");
     return sb_error;
   }
 

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -198,18 +198,21 @@ lldb::SBError SBDebugger::InitializeWithErrorHandling() {
         if (init_func(debugger_sb))
           return dynlib;
         else
-          error.SetErrorString("plug-in refused to load "
-                               "(lldb::PluginInitialize(lldb::SBDebugger) "
-                               "returned false)");
+          error = Status::FromErrorString(
+              "plug-in refused to load "
+              "(lldb::PluginInitialize(lldb::SBDebugger) "
+              "returned false)");
       } else {
-        error.SetErrorString("plug-in is missing the required initialization: "
-                             "lldb::PluginInitialize(lldb::SBDebugger)");
+        error = Status::FromErrorString(
+            "plug-in is missing the required initialization: "
+            "lldb::PluginInitialize(lldb::SBDebugger)");
       }
     } else {
       if (FileSystem::Instance().Exists(spec))
-        error.SetErrorString("this file does not represent a loadable dylib");
+        error = Status::FromErrorString(
+            "this file does not represent a loadable dylib");
       else
-        error.SetErrorString("no such file");
+        error = Status::FromErrorString("no such file");
     }
     return llvm::sys::DynamicLibrary();
   };
@@ -370,18 +373,18 @@ SBError SBDebugger::SetInputString(const char *data) {
   LLDB_INSTRUMENT_VA(this, data);
   SBError sb_error;
   if (data == nullptr) {
-    sb_error.SetErrorString("String data is null");
+    sb_error = Status::FromErrorString("String data is null");
     return sb_error;
   }
 
   size_t size = strlen(data);
   if (size == 0) {
-    sb_error.SetErrorString("String data is empty");
+    sb_error = Status::FromErrorString("String data is empty");
     return sb_error;
   }
 
   if (!m_opaque_sp) {
-    sb_error.SetErrorString("invalid debugger");
+    sb_error = Status::FromErrorString("invalid debugger");
     return sb_error;
   }
 
@@ -397,11 +400,11 @@ SBError SBDebugger::SetInputFile(SBFile file) {
 
   SBError error;
   if (!m_opaque_sp) {
-    error.ref().SetErrorString("invalid debugger");
+    error.ref() = Status::FromErrorString("invalid debugger");
     return error;
   }
   if (!file) {
-    error.ref().SetErrorString("invalid file");
+    error.ref() = Status::FromErrorString("invalid file");
     return error;
   }
   m_opaque_sp->SetInputFile(file.m_opaque_sp);
@@ -427,11 +430,11 @@ SBError SBDebugger::SetOutputFile(SBFile file) {
   LLDB_INSTRUMENT_VA(this, file);
   SBError error;
   if (!m_opaque_sp) {
-    error.ref().SetErrorString("invalid debugger");
+    error.ref() = Status::FromErrorString("invalid debugger");
     return error;
   }
   if (!file) {
-    error.ref().SetErrorString("invalid file");
+    error.ref() = Status::FromErrorString("invalid file");
     return error;
   }
   m_opaque_sp->SetOutputFile(file.m_opaque_sp);
@@ -452,11 +455,11 @@ SBError SBDebugger::SetErrorFile(SBFile file) {
   LLDB_INSTRUMENT_VA(this, file);
   SBError error;
   if (!m_opaque_sp) {
-    error.ref().SetErrorString("invalid debugger");
+    error.ref() = Status::FromErrorString("invalid debugger");
     return error;
   }
   if (!file) {
-    error.ref().SetErrorString("invalid file");
+    error.ref() = Status::FromErrorString("invalid file");
     return error;
   }
   m_opaque_sp->SetErrorFile(file.m_opaque_sp);
@@ -845,7 +848,7 @@ lldb::SBTarget SBDebugger::CreateTarget(const char *filename,
     if (sb_error.Success())
       sb_target.SetSP(target_sp);
   } else {
-    sb_error.SetErrorString("invalid debugger");
+    sb_error = Status::FromErrorString("invalid debugger");
   }
 
   Log *log = GetLog(LLDBLog::API);
@@ -913,7 +916,8 @@ SBTarget SBDebugger::CreateTargetWithFileAndArch(const char *filename,
             *m_opaque_sp, filename, arch, eLoadDependentsYes, platform_sp,
             target_sp);
       else
-        error.SetErrorStringWithFormat("invalid arch_cstr: %s", arch_cstr);
+        error = Status::FromErrorStringWithFormat("invalid arch_cstr: %s",
+                                                  arch_cstr);
     }
     if (error.Success())
       sb_target.SetSP(target_sp);
@@ -1301,7 +1305,7 @@ SBError SBDebugger::RunREPL(lldb::LanguageType language,
   if (m_opaque_sp)
     error.ref() = m_opaque_sp->RunREPL(language, repl_options);
   else
-    error.SetErrorString("invalid debugger");
+    error = Status::FromErrorString("invalid debugger");
   return error;
 }
 
@@ -1352,8 +1356,8 @@ SBError SBDebugger::SetInternalVariable(const char *var_name, const char *value,
     error = debugger_sp->SetPropertyValue(&exe_ctx, eVarSetOperationAssign,
                                           var_name, value);
   } else {
-    error.SetErrorStringWithFormat("invalid debugger instance name '%s'",
-                                   debugger_instance_name);
+    error = Status::FromErrorStringWithFormat(
+        "invalid debugger instance name '%s'", debugger_instance_name);
   }
   if (error.Fail())
     sb_error.SetError(error);
@@ -1521,12 +1525,12 @@ SBError SBDebugger::SetCurrentPlatform(const char *platform_name_cstr) {
       if (PlatformSP platform_sp = platforms.GetOrCreate(platform_name_cstr))
         platforms.SetSelectedPlatform(platform_sp);
       else
-        sb_error.ref().SetErrorString("platform not found");
+        sb_error.ref() = Status::FromErrorString("platform not found");
     } else {
-      sb_error.ref().SetErrorString("invalid platform name");
+      sb_error.ref() = Status::FromErrorString("invalid platform name");
     }
   } else {
-    sb_error.ref().SetErrorString("invalid debugger");
+    sb_error.ref() = Status::FromErrorString("invalid debugger");
   }
   return sb_error;
 }

--- a/lldb/source/API/SBError.cpp
+++ b/lldb/source/API/SBError.cpp
@@ -11,6 +11,7 @@
 #include "lldb/API/SBStream.h"
 #include "lldb/Utility/Instrumentation.h"
 #include "lldb/Utility/Status.h"
+#include "lldb/Utility/VASPrintf.h"
 
 #include <cstdarg>
 
@@ -107,7 +108,7 @@ void SBError::SetError(uint32_t err, ErrorType type) {
   LLDB_INSTRUMENT_VA(this, err, type);
 
   CreateIfNeeded();
-  m_opaque_up->SetError(err, type);
+  *m_opaque_up = Status(err, type);
 }
 
 void SBError::SetError(const Status &lldb_error) {
@@ -119,30 +120,36 @@ void SBError::SetErrorToErrno() {
   LLDB_INSTRUMENT_VA(this);
 
   CreateIfNeeded();
-  m_opaque_up->SetErrorToErrno();
+  *m_opaque_up = Status::FromErrno();
 }
 
 void SBError::SetErrorToGenericError() {
   LLDB_INSTRUMENT_VA(this);
 
   CreateIfNeeded();
-  m_opaque_up->SetErrorToGenericError();
+  *m_opaque_up = Status(std::string("generic error"));
 }
 
 void SBError::SetErrorString(const char *err_str) {
   LLDB_INSTRUMENT_VA(this, err_str);
 
   CreateIfNeeded();
-  m_opaque_up->SetErrorString(err_str);
+  *m_opaque_up = Status::FromErrorString(err_str);
 }
 
 int SBError::SetErrorStringWithFormat(const char *format, ...) {
   CreateIfNeeded();
+  std::string string;
   va_list args;
   va_start(args, format);
-  int num_chars = m_opaque_up->SetErrorStringWithVarArg(format, args);
+  if (format != nullptr && format[0]) {
+    llvm::SmallString<1024> buf;
+    VASprintf(buf, format, args);
+    string = std::string(buf.str());
+    *m_opaque_up = Status(std::move(string));
+  }
   va_end(args);
-  return num_chars;
+  return string.size();
 }
 
 bool SBError::IsValid() const {

--- a/lldb/source/API/SBFile.cpp
+++ b/lldb/source/API/SBFile.cpp
@@ -59,7 +59,7 @@ SBError SBFile::Read(uint8_t *buf, size_t num_bytes, size_t *bytes_read) {
 
   SBError error;
   if (!m_opaque_sp) {
-    error.SetErrorString("invalid SBFile");
+    error = Status::FromErrorString("invalid SBFile");
     *bytes_read = 0;
   } else {
     Status status = m_opaque_sp->Read(buf, num_bytes);
@@ -75,7 +75,7 @@ SBError SBFile::Write(const uint8_t *buf, size_t num_bytes,
 
   SBError error;
   if (!m_opaque_sp) {
-    error.SetErrorString("invalid SBFile");
+    error = Status::FromErrorString("invalid SBFile");
     *bytes_written = 0;
   } else {
     Status status = m_opaque_sp->Write(buf, num_bytes);
@@ -90,7 +90,7 @@ SBError SBFile::Flush() {
 
   SBError error;
   if (!m_opaque_sp) {
-    error.SetErrorString("invalid SBFile");
+    error = Status::FromErrorString("invalid SBFile");
   } else {
     Status status = m_opaque_sp->Flush();
     error.SetError(status);

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -1031,8 +1031,8 @@ SBValue SBFrame::EvaluateExpression(const char *expr) {
     return EvaluateExpression(expr, options);
   } else {
     Status error;
-    error.SetErrorString("can't evaluate expressions when the "
-                           "process is running.");
+    error = Status::FromErrorString("can't evaluate expressions when the "
+                                    "process is running.");
     ValueObjectSP error_val_sp = ValueObjectConstResult::Create(nullptr, error);
     result.SetSP(error_val_sp, false);
   }
@@ -1127,14 +1127,14 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
       }
     } else {
       Status error;
-      error.SetErrorString("can't evaluate expressions when the "
-                           "process is running.");
+      error = Status::FromErrorString("can't evaluate expressions when the "
+                                      "process is running.");
       expr_value_sp = ValueObjectConstResult::Create(nullptr, error);
       expr_result.SetSP(expr_value_sp, false);
     }
   } else {
       Status error;
-      error.SetErrorString("sbframe object is not valid.");
+      error = Status::FromErrorString("sbframe object is not valid.");
       expr_value_sp = ValueObjectConstResult::Create(nullptr, error);
       expr_result.SetSP(expr_value_sp, false);
   }

--- a/lldb/source/API/SBPlatform.cpp
+++ b/lldb/source/API/SBPlatform.cpp
@@ -386,7 +386,7 @@ SBError SBPlatform::ConnectRemote(SBPlatformConnectOptions &connect_options) {
     args.AppendArgument(connect_options.GetURL());
     sb_error.ref() = platform_sp->ConnectRemote(args);
   } else {
-    sb_error.SetErrorString("invalid platform");
+    sb_error = Status::FromErrorString("invalid platform");
   }
   return sb_error;
 }
@@ -503,7 +503,7 @@ SBError SBPlatform::Get(SBFileSpec &src, SBFileSpec &dst) {
   if (platform_sp) {
     sb_error.ref() = platform_sp->GetFile(src.ref(), dst.ref());
   } else {
-    sb_error.SetErrorString("invalid platform");
+    sb_error = Status::FromErrorString("invalid platform");
   }
   return sb_error;
 }
@@ -523,10 +523,8 @@ SBError SBPlatform::Put(SBFileSpec &src, SBFileSpec &dst) {
       return platform_sp->PutFile(src.ref(), dst.ref(), permissions);
     }
 
-    Status error;
-    error.SetErrorStringWithFormat("'src' argument doesn't exist: '%s'",
-                                   src.ref().GetPath().c_str());
-    return error;
+    return Status::FromErrorStringWithFormat(
+        "'src' argument doesn't exist: '%s'", src.ref().GetPath().c_str());
   });
 }
 
@@ -537,8 +535,8 @@ SBError SBPlatform::Install(SBFileSpec &src, SBFileSpec &dst) {
       return platform_sp->Install(src.ref(), dst.ref());
 
     Status error;
-    error.SetErrorStringWithFormat("'src' argument doesn't exist: '%s'",
-                                   src.ref().GetPath().c_str());
+    error = Status::FromErrorStringWithFormat(
+        "'src' argument doesn't exist: '%s'", src.ref().GetPath().c_str());
     return error;
   });
 }
@@ -549,7 +547,7 @@ SBError SBPlatform::Run(SBPlatformShellCommand &shell_command) {
       [&](const lldb::PlatformSP &platform_sp) {
         const char *command = shell_command.GetCommand();
         if (!command)
-          return Status("invalid shell command (empty)");
+          return Status::FromErrorString("invalid shell command (empty)");
 
         if (shell_command.GetWorkingDirectory() == nullptr) {
           std::string platform_working_dir =
@@ -592,11 +590,11 @@ SBProcess SBPlatform::Attach(SBAttachInfo &attach_info,
       return SBProcess(process_sp);
     }
 
-    error.SetErrorString("not connected");
+    error = Status::FromErrorString("not connected");
     return {};
   }
 
-  error.SetErrorString("invalid platform");
+  error = Status::FromErrorString("invalid platform");
   return {};
 }
 
@@ -606,11 +604,11 @@ SBProcessInfoList SBPlatform::GetAllProcesses(SBError &error) {
       ProcessInstanceInfoList list = platform_sp->GetAllProcesses();
       return SBProcessInfoList(list);
     }
-    error.SetErrorString("not connected");
+    error = Status::FromErrorString("not connected");
     return {};
   }
 
-  error.SetErrorString("invalid platform");
+  error = Status::FromErrorString("invalid platform");
   return {};
 }
 
@@ -629,9 +627,9 @@ SBError SBPlatform::ExecuteConnected(
     if (platform_sp->IsConnected())
       sb_error.ref() = func(platform_sp);
     else
-      sb_error.SetErrorString("not connected");
+      sb_error = Status::FromErrorString("not connected");
   } else
-    sb_error.SetErrorString("invalid platform");
+    sb_error = Status::FromErrorString("invalid platform");
 
   return sb_error;
 }
@@ -645,7 +643,7 @@ SBError SBPlatform::MakeDirectory(const char *path, uint32_t file_permissions) {
     sb_error.ref() =
         platform_sp->MakeDirectory(FileSpec(path), file_permissions);
   } else {
-    sb_error.SetErrorString("invalid platform");
+    sb_error = Status::FromErrorString("invalid platform");
   }
   return sb_error;
 }
@@ -672,7 +670,7 @@ SBError SBPlatform::SetFilePermissions(const char *path,
     sb_error.ref() =
         platform_sp->SetFilePermissions(FileSpec(path), file_permissions);
   } else {
-    sb_error.SetErrorString("invalid platform");
+    sb_error = Status::FromErrorString("invalid platform");
   }
   return sb_error;
 }

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -152,10 +152,11 @@ bool SBProcess::RemoteLaunch(char const **argv, char const **envp,
         launch_info.GetEnvironment() = Environment(envp);
       error.SetError(process_sp->Launch(launch_info));
     } else {
-      error.SetErrorString("must be in eStateConnected to call RemoteLaunch");
+      error = Status::FromErrorString(
+          "must be in eStateConnected to call RemoteLaunch");
     }
   } else {
-    error.SetErrorString("unable to attach pid");
+    error = Status::FromErrorString("unable to attach pid");
   }
 
   return error.Success();
@@ -174,11 +175,11 @@ bool SBProcess::RemoteAttachToProcessWithID(lldb::pid_t pid,
       attach_info.SetProcessID(pid);
       error.SetError(process_sp->Attach(attach_info));
     } else {
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "must be in eStateConnected to call RemoteAttachToProcessWithID");
     }
   } else {
-    error.SetErrorString("unable to attach pid");
+    error = Status::FromErrorString("unable to attach pid");
   }
 
   return error.Success();
@@ -577,7 +578,7 @@ SBError SBProcess::Continue() {
     else
       sb_error.ref() = process_sp->ResumeSynchronous(nullptr);
   } else
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
 
   return sb_error;
 }
@@ -592,7 +593,7 @@ SBError SBProcess::Destroy() {
         process_sp->GetTarget().GetAPIMutex());
     sb_error.SetError(process_sp->Destroy(false));
   } else
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
 
   return sb_error;
 }
@@ -607,7 +608,7 @@ SBError SBProcess::Stop() {
         process_sp->GetTarget().GetAPIMutex());
     sb_error.SetError(process_sp->Halt());
   } else
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
 
   return sb_error;
 }
@@ -622,7 +623,7 @@ SBError SBProcess::Kill() {
         process_sp->GetTarget().GetAPIMutex());
     sb_error.SetError(process_sp->Destroy(true));
   } else
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
 
   return sb_error;
 }
@@ -645,7 +646,7 @@ SBError SBProcess::Detach(bool keep_stopped) {
         process_sp->GetTarget().GetAPIMutex());
     sb_error.SetError(process_sp->Detach(keep_stopped));
   } else
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
 
   return sb_error;
 }
@@ -660,7 +661,7 @@ SBError SBProcess::Signal(int signo) {
         process_sp->GetTarget().GetAPIMutex());
     sb_error.SetError(process_sp->Signal(signo));
   } else
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
 
   return sb_error;
 }
@@ -819,12 +820,12 @@ lldb::SBAddressRangeList SBProcess::FindRangesInMemory(
 
   ProcessSP process_sp(GetSP());
   if (!process_sp) {
-    error.SetErrorString("SBProcess is invalid");
+    error = Status::FromErrorString("SBProcess is invalid");
     return matches;
   }
   Process::StopLocker stop_locker;
   if (!stop_locker.TryLock(&process_sp->GetRunLock())) {
-    error.SetErrorString("process is running");
+    error = Status::FromErrorString("process is running");
     return matches;
   }
   std::lock_guard<std::recursive_mutex> guard(
@@ -843,13 +844,13 @@ lldb::addr_t SBProcess::FindInMemory(const void *buf, uint64_t size,
   ProcessSP process_sp(GetSP());
 
   if (!process_sp) {
-    error.SetErrorString("SBProcess is invalid");
+    error = Status::FromErrorString("SBProcess is invalid");
     return LLDB_INVALID_ADDRESS;
   }
 
   Process::StopLocker stop_locker;
   if (!stop_locker.TryLock(&process_sp->GetRunLock())) {
-    error.SetErrorString("process is running");
+    error = Status::FromErrorString("process is running");
     return LLDB_INVALID_ADDRESS;
   }
 
@@ -864,7 +865,7 @@ size_t SBProcess::ReadMemory(addr_t addr, void *dst, size_t dst_len,
   LLDB_INSTRUMENT_VA(this, addr, dst, dst_len, sb_error);
 
   if (!dst) {
-    sb_error.SetErrorStringWithFormat(
+    sb_error = Status::FromErrorStringWithFormat(
         "no buffer provided to read %zu bytes into", dst_len);
     return 0;
   }
@@ -880,10 +881,10 @@ size_t SBProcess::ReadMemory(addr_t addr, void *dst, size_t dst_len,
           process_sp->GetTarget().GetAPIMutex());
       bytes_read = process_sp->ReadMemory(addr, dst, dst_len, sb_error.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
 
   return bytes_read;
@@ -903,10 +904,10 @@ size_t SBProcess::ReadCStringFromMemory(addr_t addr, void *buf, size_t size,
       bytes_read = process_sp->ReadCStringFromMemory(addr, (char *)buf, size,
                                                      sb_error.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
   return bytes_read;
 }
@@ -925,10 +926,10 @@ uint64_t SBProcess::ReadUnsignedFromMemory(addr_t addr, uint32_t byte_size,
       value = process_sp->ReadUnsignedIntegerFromMemory(addr, byte_size, 0,
                                                         sb_error.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
   return value;
 }
@@ -946,10 +947,10 @@ lldb::addr_t SBProcess::ReadPointerFromMemory(addr_t addr,
           process_sp->GetTarget().GetAPIMutex());
       ptr = process_sp->ReadPointerFromMemory(addr, sb_error.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
   return ptr;
 }
@@ -970,7 +971,7 @@ size_t SBProcess::WriteMemory(addr_t addr, const void *src, size_t src_len,
       bytes_written =
           process_sp->WriteMemory(addr, src, src_len, sb_error.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   }
 
@@ -1045,10 +1046,11 @@ SBProcess::GetNumSupportedHardwareWatchpoints(lldb::SBError &sb_error) const {
     if (actual_num) {
       num = *actual_num;
     } else {
-      sb_error.SetErrorString("Unable to determine number of watchpoints");
+      sb_error =
+          Status::FromErrorString("Unable to determine number of watchpoints");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
   return num;
 }
@@ -1075,10 +1077,10 @@ uint32_t SBProcess::LoadImage(const lldb::SBFileSpec &sb_local_image_spec,
       return platform_sp->LoadImage(process_sp.get(), *sb_local_image_spec,
                                     *sb_remote_image_spec, sb_error.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("process is invalid");
+    sb_error = Status::FromErrorString("process is invalid");
   }
   return LLDB_INVALID_IMAGE_TOKEN;
 }
@@ -1109,10 +1111,10 @@ uint32_t SBProcess::LoadImageUsingPaths(const lldb::SBFileSpec &image_spec,
         loaded_path = loaded_spec;
       return token;
     } else {
-      error.SetErrorString("process is running");
+      error = Status::FromErrorString("process is running");
     }
   } else {
-    error.SetErrorString("process is invalid");
+    error = Status::FromErrorString("process is invalid");
   }
 
   return LLDB_INVALID_IMAGE_TOKEN;
@@ -1132,10 +1134,10 @@ lldb::SBError SBProcess::UnloadImage(uint32_t image_token) {
       sb_error.SetError(
           platform_sp->UnloadImage(process_sp.get(), image_token));
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else
-    sb_error.SetErrorString("invalid process");
+    sb_error = Status::FromErrorString("invalid process");
   return sb_error;
 }
 
@@ -1151,10 +1153,10 @@ lldb::SBError SBProcess::SendEventData(const char *event_data) {
           process_sp->GetTarget().GetAPIMutex());
       sb_error.SetError(process_sp->SendEventData(event_data));
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else
-    sb_error.SetErrorString("invalid process");
+    sb_error = Status::FromErrorString("invalid process");
   return sb_error;
 }
 
@@ -1243,7 +1245,7 @@ lldb::SBError SBProcess::SaveCore(SBSaveCoreOptions &options) {
   lldb::SBError error;
   ProcessSP process_sp(GetSP());
   if (!process_sp) {
-    error.SetErrorString("SBProcess is invalid");
+    error = Status::FromErrorString("SBProcess is invalid");
     return error;
   }
 
@@ -1251,7 +1253,7 @@ lldb::SBError SBProcess::SaveCore(SBSaveCoreOptions &options) {
       process_sp->GetTarget().GetAPIMutex());
 
   if (process_sp->GetState() != eStateStopped) {
-    error.SetErrorString("the process is not stopped");
+    error = Status::FromErrorString("the process is not stopped");
     return error;
   }
 
@@ -1276,10 +1278,10 @@ SBProcess::GetMemoryRegionInfo(lldb::addr_t load_addr,
       sb_error.ref() =
           process_sp->GetMemoryRegionInfo(load_addr, sb_region_info.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
   return sb_error;
 }
@@ -1429,10 +1431,10 @@ lldb::addr_t SBProcess::AllocateMemory(size_t size, uint32_t permissions,
           process_sp->GetTarget().GetAPIMutex());
       addr = process_sp->AllocateMemory(size, permissions, sb_error.ref());
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
   return addr;
 }
@@ -1450,10 +1452,10 @@ lldb::SBError SBProcess::DeallocateMemory(lldb::addr_t ptr) {
       Status error = process_sp->DeallocateMemory(ptr);
       sb_error.SetError(error);
     } else {
-      sb_error.SetErrorString("process is running");
+      sb_error = Status::FromErrorString("process is running");
     }
   } else {
-    sb_error.SetErrorString("SBProcess is invalid");
+    sb_error = Status::FromErrorString("SBProcess is invalid");
   }
   return sb_error;
 }

--- a/lldb/source/API/SBStructuredData.cpp
+++ b/lldb/source/API/SBStructuredData.cpp
@@ -92,7 +92,7 @@ lldb::SBError SBStructuredData::SetFromJSON(lldb::SBStream &stream) {
   };
 
   if (!json_obj || llvm::is_contained(unsupported_type, json_obj->GetType()))
-    error.SetErrorString("Invalid Syntax");
+    error = Status::FromErrorString("Invalid Syntax");
   return error;
 }
 

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -85,8 +85,9 @@ static Status AttachToProcess(ProcessAttachInfo &attach_info, Target &target) {
       // listener, so if a valid listener is supplied, we need to error out to
       // let the client know.
       if (attach_info.GetListener())
-        return Status("process is connected and already has a listener, pass "
-                      "empty listener");
+        return Status::FromErrorString(
+            "process is connected and already has a listener, pass "
+            "empty listener");
     }
   }
 
@@ -452,7 +453,7 @@ lldb::SBProcess SBTarget::Attach(SBAttachInfo &sb_attach_info, SBError &error) {
         if (platform_sp->GetProcessInfo(attach_pid, instance_info)) {
           attach_info.SetUserID(instance_info.GetEffectiveUserID());
         } else {
-          error.ref().SetErrorStringWithFormat(
+          error.ref() = Status::FromErrorStringWithFormat(
               "no process found with process ID %" PRIu64, attach_pid);
           return sb_process;
         }
@@ -1655,7 +1656,7 @@ SBError SBTarget::SetLabel(const char *label) {
 
   TargetSP target_sp(GetSP());
   if (!target_sp)
-    return Status("Couldn't get internal target object.");
+    return Status::FromErrorString("Couldn't get internal target object.");
 
   return Status(target_sp->SetLabel(label));
 }
@@ -2323,8 +2324,8 @@ lldb::SBValue SBTarget::EvaluateExpression(const char *expr,
           target->EvaluateExpression(expr, frame, expr_value_sp, options.ref());
         } else {
           Status error;
-          error.SetErrorString("can't evaluate expressions when the "
-                               "process is running.");
+          error = Status::FromErrorString("can't evaluate expressions when the "
+                                          "process is running.");
           expr_value_sp = ValueObjectConstResult::Create(nullptr, error);
         }
       } else {

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -499,13 +499,13 @@ SBError SBThread::ResumeNewPlan(ExecutionContext &exe_ctx,
 
   Process *process = exe_ctx.GetProcessPtr();
   if (!process) {
-    sb_error.SetErrorString("No process in SBThread::ResumeNewPlan");
+    sb_error = Status::FromErrorString("No process in SBThread::ResumeNewPlan");
     return sb_error;
   }
 
   Thread *thread = exe_ctx.GetThreadPtr();
   if (!thread) {
-    sb_error.SetErrorString("No thread in SBThread::ResumeNewPlan");
+    sb_error = Status::FromErrorString("No thread in SBThread::ResumeNewPlan");
     return sb_error;
   }
 
@@ -541,7 +541,7 @@ void SBThread::StepOver(lldb::RunMode stop_other_threads, SBError &error) {
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!exe_ctx.HasThreadScope()) {
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
     return;
   }
 
@@ -588,7 +588,7 @@ void SBThread::StepInto(const char *target_name, uint32_t end_line,
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!exe_ctx.HasThreadScope()) {
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
     return;
   }
 
@@ -625,7 +625,7 @@ void SBThread::StepInto(const char *target_name, uint32_t end_line,
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
   else
-    error.SetErrorString(new_plan_status.AsCString());
+    error = Status::FromErrorString(new_plan_status.AsCString());
 }
 
 void SBThread::StepOut() {
@@ -642,7 +642,7 @@ void SBThread::StepOut(SBError &error) {
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!exe_ctx.HasThreadScope()) {
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
     return;
   }
 
@@ -660,7 +660,7 @@ void SBThread::StepOut(SBError &error) {
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
   else
-    error.SetErrorString(new_plan_status.AsCString());
+    error = Status::FromErrorString(new_plan_status.AsCString());
 }
 
 void SBThread::StepOutOfFrame(SBFrame &sb_frame) {
@@ -677,14 +677,14 @@ void SBThread::StepOutOfFrame(SBFrame &sb_frame, SBError &error) {
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!sb_frame.IsValid()) {
-    error.SetErrorString("passed invalid SBFrame object");
+    error = Status::FromErrorString("passed invalid SBFrame object");
     return;
   }
 
   StackFrameSP frame_sp(sb_frame.GetFrameSP());
 
   if (!exe_ctx.HasThreadScope()) {
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
     return;
   }
 
@@ -692,7 +692,7 @@ void SBThread::StepOutOfFrame(SBFrame &sb_frame, SBError &error) {
   bool stop_other_threads = false;
   Thread *thread = exe_ctx.GetThreadPtr();
   if (sb_frame.GetThread().GetThreadID() != thread->GetID()) {
-    error.SetErrorString("passed a frame from another thread");
+    error = Status::FromErrorString("passed a frame from another thread");
     return;
   }
 
@@ -704,7 +704,7 @@ void SBThread::StepOutOfFrame(SBFrame &sb_frame, SBError &error) {
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
   else
-    error.SetErrorString(new_plan_status.AsCString());
+    error = Status::FromErrorString(new_plan_status.AsCString());
 }
 
 void SBThread::StepInstruction(bool step_over) {
@@ -721,7 +721,7 @@ void SBThread::StepInstruction(bool step_over, SBError &error) {
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!exe_ctx.HasThreadScope()) {
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
     return;
   }
 
@@ -733,7 +733,7 @@ void SBThread::StepInstruction(bool step_over, SBError &error) {
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
   else
-    error.SetErrorString(new_plan_status.AsCString());
+    error = Status::FromErrorString(new_plan_status.AsCString());
 }
 
 void SBThread::RunToAddress(lldb::addr_t addr) {
@@ -750,7 +750,7 @@ void SBThread::RunToAddress(lldb::addr_t addr, SBError &error) {
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!exe_ctx.HasThreadScope()) {
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
     return;
   }
 
@@ -768,7 +768,7 @@ void SBThread::RunToAddress(lldb::addr_t addr, SBError &error) {
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
   else
-    error.SetErrorString(new_plan_status.AsCString());
+    error = Status::FromErrorString(new_plan_status.AsCString());
 }
 
 SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
@@ -788,7 +788,7 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
     Thread *thread = exe_ctx.GetThreadPtr();
 
     if (line == 0) {
-      sb_error.SetErrorString("invalid line argument");
+      sb_error = Status::FromErrorString("invalid line argument");
       return sb_error;
     }
 
@@ -804,7 +804,7 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
 
     SymbolContext frame_sc;
     if (!frame_sp) {
-      sb_error.SetErrorString("no valid frames in thread to step");
+      sb_error = Status::FromErrorString("no valid frames in thread to step");
       return sb_error;
     }
 
@@ -814,7 +814,7 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
         eSymbolContextLineEntry | eSymbolContextSymbol);
 
     if (frame_sc.comp_unit == nullptr) {
-      sb_error.SetErrorStringWithFormat(
+      sb_error = Status::FromErrorStringWithFormat(
           "frame %u doesn't have debug information", frame_sp->GetFrameIndex());
       return sb_error;
     }
@@ -827,7 +827,8 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
       if (frame_sc.line_entry.IsValid())
         step_file_spec = frame_sc.line_entry.GetFile();
       else {
-        sb_error.SetErrorString("invalid file argument or no file for frame");
+        sb_error = Status::FromErrorString(
+            "invalid file argument or no file for frame");
         return sb_error;
       }
     }
@@ -865,10 +866,11 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
     if (step_over_until_addrs.empty()) {
       if (all_in_function) {
         step_file_spec.GetPath(path, sizeof(path));
-        sb_error.SetErrorStringWithFormat("No line entries for %s:%u", path,
-                                          line);
+        sb_error = Status::FromErrorStringWithFormat(
+            "No line entries for %s:%u", path, line);
       } else
-        sb_error.SetErrorString("step until target not in current function");
+        sb_error = Status::FromErrorString(
+            "step until target not in current function");
     } else {
       Status new_plan_status;
       ThreadPlanSP new_plan_sp(thread->QueueThreadPlanForStepUntil(
@@ -879,10 +881,10 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
       if (new_plan_status.Success())
         sb_error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
       else
-        sb_error.SetErrorString(new_plan_status.AsCString());
+        sb_error = Status::FromErrorString(new_plan_status.AsCString());
     }
   } else {
-    sb_error.SetErrorString("this SBThread object is invalid");
+    sb_error = Status::FromErrorString("this SBThread object is invalid");
   }
   return sb_error;
 }
@@ -913,7 +915,7 @@ SBError SBThread::StepUsingScriptedThreadPlan(const char *script_class_name,
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!exe_ctx.HasThreadScope()) {
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
     return error;
   }
 
@@ -925,7 +927,7 @@ SBError SBThread::StepUsingScriptedThreadPlan(const char *script_class_name,
       false, script_class_name, obj_sp, false, new_plan_status);
 
   if (new_plan_status.Fail()) {
-    error.SetErrorString(new_plan_status.AsCString());
+    error = Status::FromErrorString(new_plan_status.AsCString());
     return error;
   }
 
@@ -935,7 +937,7 @@ SBError SBThread::StepUsingScriptedThreadPlan(const char *script_class_name,
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
   else
-    error.SetErrorString(new_plan_status.AsCString());
+    error = Status::FromErrorString(new_plan_status.AsCString());
 
   return error;
 }
@@ -949,7 +951,7 @@ SBError SBThread::JumpToLine(lldb::SBFileSpec &file_spec, uint32_t line) {
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   if (!exe_ctx.HasThreadScope()) {
-    sb_error.SetErrorString("this SBThread object is invalid");
+    sb_error = Status::FromErrorString("this SBThread object is invalid");
     return sb_error;
   }
 
@@ -1015,10 +1017,10 @@ bool SBThread::Suspend(SBError &error) {
       exe_ctx.GetThreadPtr()->SetResumeState(eStateSuspended);
       result = true;
     } else {
-      error.SetErrorString("process is running");
+      error = Status::FromErrorString("process is running");
     }
   } else
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
   return result;
 }
 
@@ -1043,10 +1045,10 @@ bool SBThread::Resume(SBError &error) {
       exe_ctx.GetThreadPtr()->SetResumeState(eStateRunning, override_suspend);
       result = true;
     } else {
-      error.SetErrorString("process is running");
+      error = Status::FromErrorString("process is running");
     }
   } else
-    error.SetErrorString("this SBThread object is invalid");
+    error = Status::FromErrorString("this SBThread object is invalid");
   return result;
 }
 
@@ -1245,7 +1247,7 @@ SBError SBThread::GetDescriptionWithFormat(const SBFormat &format,
 
   SBError error;
   if (!format) {
-    error.SetErrorString("The provided SBFormat object is invalid");
+    error = Status::FromErrorString("The provided SBFormat object is invalid");
     return error;
   }
 
@@ -1259,7 +1261,7 @@ SBError SBThread::GetDescriptionWithFormat(const SBFormat &format,
     }
   }
 
-  error.SetErrorStringWithFormat(
+  error = Status::FromErrorStringWithFormat(
       "It was not possible to generate a thread description with the given "
       "format string '%s'",
       format.GetFormatEntrySP()->string.c_str());

--- a/lldb/source/API/SBTrace.cpp
+++ b/lldb/source/API/SBTrace.cpp
@@ -36,7 +36,7 @@ SBTrace SBTrace::LoadTraceFromFile(SBError &error, SBDebugger &debugger,
       debugger.ref(), trace_description_file.ref());
 
   if (!trace_or_err) {
-    error.SetErrorString(toString(trace_or_err.takeError()).c_str());
+    error = Status::FromErrorString(toString(trace_or_err.takeError()).c_str());
     return SBTrace();
   }
 
@@ -47,11 +47,11 @@ SBTraceCursor SBTrace::CreateNewCursor(SBError &error, SBThread &thread) {
   LLDB_INSTRUMENT_VA(this, error, thread);
 
   if (!m_opaque_sp) {
-    error.SetErrorString("error: invalid trace");
+    error = Status::FromErrorString("error: invalid trace");
     return SBTraceCursor();
   }
   if (!thread.get()) {
-    error.SetErrorString("error: invalid thread");
+    error = Status::FromErrorString("error: invalid thread");
     return SBTraceCursor();
   }
 
@@ -59,7 +59,8 @@ SBTraceCursor SBTrace::CreateNewCursor(SBError &error, SBThread &thread) {
           m_opaque_sp->CreateNewCursor(*thread.get())) {
     return SBTraceCursor(std::move(*trace_cursor_sp));
   } else {
-    error.SetErrorString(llvm::toString(trace_cursor_sp.takeError()).c_str());
+    error = Status::FromErrorString(
+        llvm::toString(trace_cursor_sp.takeError()).c_str());
     return SBTraceCursor();
   }
 }
@@ -72,12 +73,13 @@ SBFileSpec SBTrace::SaveToDisk(SBError &error, const SBFileSpec &bundle_dir,
   SBFileSpec file_spec;
 
   if (!m_opaque_sp)
-    error.SetErrorString("error: invalid trace");
+    error = Status::FromErrorString("error: invalid trace");
   else if (Expected<FileSpec> desc_file =
                m_opaque_sp->SaveToDisk(bundle_dir.ref(), compact))
     file_spec.SetFileSpec(*desc_file);
   else
-    error.SetErrorString(llvm::toString(desc_file.takeError()).c_str());
+    error =
+        Status::FromErrorString(llvm::toString(desc_file.takeError()).c_str());
 
   return file_spec;
 }
@@ -94,10 +96,10 @@ SBError SBTrace::Start(const SBStructuredData &configuration) {
   LLDB_INSTRUMENT_VA(this, configuration);
   SBError error;
   if (!m_opaque_sp)
-    error.SetErrorString("error: invalid trace");
+    error = Status::FromErrorString("error: invalid trace");
   else if (llvm::Error err =
                m_opaque_sp->Start(configuration.m_impl_up->GetObjectSP()))
-    error.SetErrorString(llvm::toString(std::move(err)).c_str());
+    error = Status::FromErrorString(llvm::toString(std::move(err)).c_str());
   return error;
 }
 
@@ -107,12 +109,12 @@ SBError SBTrace::Start(const SBThread &thread,
 
   SBError error;
   if (!m_opaque_sp)
-    error.SetErrorString("error: invalid trace");
+    error = Status::FromErrorString("error: invalid trace");
   else {
     if (llvm::Error err =
             m_opaque_sp->Start(std::vector<lldb::tid_t>{thread.GetThreadID()},
                                configuration.m_impl_up->GetObjectSP()))
-      error.SetErrorString(llvm::toString(std::move(err)).c_str());
+      error = Status::FromErrorString(llvm::toString(std::move(err)).c_str());
   }
 
   return error;
@@ -122,9 +124,9 @@ SBError SBTrace::Stop() {
   LLDB_INSTRUMENT_VA(this);
   SBError error;
   if (!m_opaque_sp)
-    error.SetErrorString("error: invalid trace");
+    error = Status::FromErrorString("error: invalid trace");
   else if (llvm::Error err = m_opaque_sp->Stop())
-    error.SetErrorString(llvm::toString(std::move(err)).c_str());
+    error = Status::FromErrorString(llvm::toString(std::move(err)).c_str());
   return error;
 }
 
@@ -132,9 +134,9 @@ SBError SBTrace::Stop(const SBThread &thread) {
   LLDB_INSTRUMENT_VA(this, thread);
   SBError error;
   if (!m_opaque_sp)
-    error.SetErrorString("error: invalid trace");
+    error = Status::FromErrorString("error: invalid trace");
   else if (llvm::Error err = m_opaque_sp->Stop({thread.GetThreadID()}))
-    error.SetErrorString(llvm::toString(std::move(err)).c_str());
+    error = Status::FromErrorString(llvm::toString(std::move(err)).c_str());
   return error;
 }
 

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -107,7 +107,7 @@ public:
                             std::unique_lock<std::recursive_mutex> &lock,
                             Status &error) {
     if (!m_valobj_sp) {
-      error.SetErrorString("invalid value object");
+      error = Status::FromErrorString("invalid value object");
       return m_valobj_sp;
     }
 
@@ -128,7 +128,7 @@ public:
       // We don't allow people to play around with ValueObject if the process
       // is running. If you want to look at values, pause the process, then
       // look.
-      error.SetErrorString("process must be stopped.");
+      error = Status::FromErrorString("process must be stopped.");
       return ValueObjectSP();
     }
 
@@ -145,7 +145,7 @@ public:
     }
 
     if (!value_sp)
-      error.SetErrorString("invalid value object");
+      error = Status::FromErrorString("invalid value object");
     if (!m_name.IsEmpty())
       value_sp->SetName(m_name);
 
@@ -272,8 +272,8 @@ SBError SBValue::GetError() {
   if (value_sp)
     sb_error.SetError(value_sp->GetError());
   else
-    sb_error.SetErrorStringWithFormat("error: %s",
-                                      locker.GetError().AsCString());
+    sb_error = Status::FromErrorStringWithFormat("error: %s",
+                                                 locker.GetError().AsCString());
 
   return sb_error;
 }
@@ -467,8 +467,8 @@ bool SBValue::SetValueFromCString(const char *value_str, lldb::SBError &error) {
   if (value_sp) {
     success = value_sp->SetValueFromCString(value_str, error.ref());
   } else
-    error.SetErrorStringWithFormat("Could not get value: %s",
-                                   locker.GetError().AsCString());
+    error = Status::FromErrorStringWithFormat("Could not get value: %s",
+                                              locker.GetError().AsCString());
 
   return success;
 }
@@ -876,11 +876,11 @@ int64_t SBValue::GetValueAsSigned(SBError &error, int64_t fail_value) {
     uint64_t ret_val = fail_value;
     ret_val = value_sp->GetValueAsSigned(fail_value, &success);
     if (!success)
-      error.SetErrorString("could not resolve value");
+      error = Status::FromErrorString("could not resolve value");
     return ret_val;
   } else
-    error.SetErrorStringWithFormat("could not get SBValue: %s",
-                                   locker.GetError().AsCString());
+    error = Status::FromErrorStringWithFormat("could not get SBValue: %s",
+                                              locker.GetError().AsCString());
 
   return fail_value;
 }
@@ -896,11 +896,11 @@ uint64_t SBValue::GetValueAsUnsigned(SBError &error, uint64_t fail_value) {
     uint64_t ret_val = fail_value;
     ret_val = value_sp->GetValueAsUnsigned(fail_value, &success);
     if (!success)
-      error.SetErrorString("could not resolve value");
+      error = Status::FromErrorString("could not resolve value");
     return ret_val;
   } else
-    error.SetErrorStringWithFormat("could not get SBValue: %s",
-                                   locker.GetError().AsCString());
+    error = Status::FromErrorStringWithFormat("could not get SBValue: %s",
+                                              locker.GetError().AsCString());
 
   return fail_value;
 }
@@ -1079,7 +1079,7 @@ lldb::ValueObjectSP SBValue::GetSP(ValueLocker &locker) const {
   if (!m_opaque_sp || (!m_opaque_sp->IsValid()
       && (m_opaque_sp->GetRootSP()
           && !m_opaque_sp->GetRootSP()->GetError().Fail()))) {
-    locker.GetError().SetErrorString("No value");
+    locker.GetError() = Status::FromErrorString("No value");
     return ValueObjectSP();
   }
   return locker.GetLockedSP(*m_opaque_sp.get());
@@ -1384,7 +1384,7 @@ bool SBValue::SetData(lldb::SBData &data, SBError &error) {
     DataExtractor *data_extractor = data.get();
 
     if (!data_extractor) {
-      error.SetErrorString("No data to set");
+      error = Status::FromErrorString("No data to set");
       ret = false;
     } else {
       Status set_error;
@@ -1392,13 +1392,13 @@ bool SBValue::SetData(lldb::SBData &data, SBError &error) {
       value_sp->SetData(*data_extractor, set_error);
 
       if (!set_error.Success()) {
-        error.SetErrorStringWithFormat("Couldn't set data: %s",
-                                       set_error.AsCString());
+        error = Status::FromErrorStringWithFormat("Couldn't set data: %s",
+                                                  set_error.AsCString());
         ret = false;
       }
     }
   } else {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't set data: could not get SBValue: %s",
         locker.GetError().AsCString());
     ret = false;
@@ -1491,10 +1491,11 @@ lldb::SBWatchpoint SBValue::Watch(bool resolve_location, bool read, bool write,
       }
     }
   } else if (target_sp) {
-    error.SetErrorStringWithFormat("could not get SBValue: %s",
-                                   locker.GetError().AsCString());
+    error = Status::FromErrorStringWithFormat("could not get SBValue: %s",
+                                              locker.GetError().AsCString());
   } else {
-    error.SetErrorString("could not set watchpoint, a target is required");
+    error = Status::FromErrorString(
+        "could not set watchpoint, a target is required");
   }
 
   return sb_watchpoint;

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -128,7 +128,8 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
   StructuredData::Dictionary *breakpoint_dict = object_data->GetAsDictionary();
 
   if (!breakpoint_dict || !breakpoint_dict->IsValid()) {
-    error.SetErrorString("Can't deserialize from an invalid data object.");
+    error = Status::FromErrorString(
+        "Can't deserialize from an invalid data object.");
     return result_sp;
   }
 
@@ -136,7 +137,8 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
   bool success = breakpoint_dict->GetValueForKeyAsDictionary(
       BreakpointResolver::GetSerializationKey(), resolver_dict);
   if (!success) {
-    error.SetErrorString("Breakpoint data missing toplevel resolver key");
+    error = Status::FromErrorString(
+        "Breakpoint data missing toplevel resolver key");
     return result_sp;
   }
 
@@ -145,9 +147,8 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
       BreakpointResolver::CreateFromStructuredData(*resolver_dict,
                                                    create_error);
   if (create_error.Fail()) {
-    error.SetErrorStringWithFormat(
-        "Error creating breakpoint resolver from data: %s.",
-        create_error.AsCString());
+    error = Status::FromErrorStringWithFormatv(
+        "Error creating breakpoint resolver from data: {0}.", create_error);
     return result_sp;
   }
 
@@ -162,7 +163,7 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
     filter_sp = SearchFilter::CreateFromStructuredData(target_sp, *filter_dict,
         create_error);
     if (create_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Error creating breakpoint filter from data: %s.",
           create_error.AsCString());
       return result_sp;
@@ -178,7 +179,7 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
     options_up = BreakpointOptions::CreateFromStructuredData(
         target, *options_dict, create_error);
     if (create_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Error creating breakpoint options from data: %s.",
           create_error.AsCString());
       return result_sp;

--- a/lldb/source/Breakpoint/BreakpointID.cpp
+++ b/lldb/source/Breakpoint/BreakpointID.cpp
@@ -92,24 +92,26 @@ bool BreakpointID::StringIsBreakpointName(llvm::StringRef str, Status &error) {
   error.Clear();
   if (str.empty())
   {
-    error.SetErrorString("Empty breakpoint names are not allowed");
+    error = Status::FromErrorString("Empty breakpoint names are not allowed");
     return false;
   }
 
   // First character must be a letter or _
   if (!isalpha(str[0]) && str[0] != '_')
   {
-    error.SetErrorStringWithFormat("Breakpoint names must start with a "
-                                   "character or underscore: %s",
-                                   str.str().c_str());
+    error =
+        Status::FromErrorStringWithFormatv("Breakpoint names must start with a "
+                                           "character or underscore: {0}",
+                                           str);
     return false;
   }
 
   // Cannot contain ., -, or space.
   if (str.find_first_of(".- ") != llvm::StringRef::npos) {
-    error.SetErrorStringWithFormat("Breakpoint names cannot contain "
-                                   "'.' or '-' or spaces: \"%s\"",
-                                   str.str().c_str());
+    error =
+        Status::FromErrorStringWithFormatv("Breakpoint names cannot contain "
+                                           "'.' or '-' or spaces: \"{0}\"",
+                                           str);
     return false;
   }
 

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -264,7 +264,7 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
     if (!m_user_expression_sp->Parse(diagnostics, exe_ctx,
                                      eExecutionPolicyOnlyWhenNeeded, true,
                                      false)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't parse conditional expression:\n%s",
           diagnostics.GetString().c_str());
       m_user_expression_sp.reset();
@@ -299,7 +299,7 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
 
   if (result_code == eExpressionCompleted) {
     if (!result_variable_sp) {
-      error.SetErrorString("Expression did not return a result");
+      error = Status::FromErrorString("Expression did not return a result");
       return false;
     }
 
@@ -312,19 +312,20 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
           LLDB_LOGF(log, "Condition successfully evaluated, result is %s.\n",
                     ret ? "true" : "false");
         } else {
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "Failed to get an integer result from the expression");
           ret = false;
         }
       }
     } else {
       ret = false;
-      error.SetErrorString("Failed to get any result from the expression");
+      error = Status::FromErrorString(
+          "Failed to get any result from the expression");
     }
   } else {
     ret = false;
-    error.SetErrorStringWithFormat("Couldn't execute expression:\n%s",
-                                   diagnostics.GetString().c_str());
+    error = Status::FromErrorStringWithFormat(
+        "Couldn't execute expression:\n%s", diagnostics.GetString().c_str());
   }
 
   return ret;

--- a/lldb/source/Breakpoint/BreakpointOptions.cpp
+++ b/lldb/source/Breakpoint/BreakpointOptions.cpp
@@ -70,14 +70,14 @@ BreakpointOptions::CommandData::CreateFromStructuredData(
       GetKey(OptionNames::Interpreter), interpreter_str);
 
   if (!success) {
-    error.SetErrorString("Missing command language value.");
+    error = Status::FromErrorString("Missing command language value.");
     return data_up;
   }
 
   interp_language = ScriptInterpreter::StringToLanguage(interpreter_str);
   if (interp_language == eScriptLanguageUnknown) {
-    error.SetErrorStringWithFormatv("Unknown breakpoint command language: {0}.",
-                                    interpreter_str);
+    error = Status::FromErrorStringWithFormatv(
+        "Unknown breakpoint command language: {0}.", interpreter_str);
     return data_up;
   }
   data_up->interpreter = interp_language;
@@ -230,7 +230,8 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
   if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsBoolean(key, enabled);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not a boolean.", key);
+      error =
+          Status::FromErrorStringWithFormat("%s key is not a boolean.", key);
       return nullptr;
     }
     set_options.Set(eEnabled);
@@ -240,7 +241,8 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
   if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsBoolean(key, one_shot);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not a boolean.", key);
+      error =
+          Status::FromErrorStringWithFormat("%s key is not a boolean.", key);
       return nullptr;
       }
       set_options.Set(eOneShot);
@@ -250,7 +252,8 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
   if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsBoolean(key, auto_continue);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not a boolean.", key);
+      error =
+          Status::FromErrorStringWithFormat("%s key is not a boolean.", key);
       return nullptr;
       }
       set_options.Set(eAutoContinue);
@@ -260,7 +263,8 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
   if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsInteger(key, ignore_count);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not an integer.", key);
+      error =
+          Status::FromErrorStringWithFormat("%s key is not an integer.", key);
       return nullptr;
     }
     set_options.Set(eIgnoreCount);
@@ -270,7 +274,8 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
   if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsString(key, condition_ref);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not an string.", key);
+      error =
+          Status::FromErrorStringWithFormat("%s key is not an string.", key);
       return nullptr;
     }
     set_options.Set(eCondition);
@@ -284,7 +289,7 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
     Status cmds_error;
     cmd_data_up = CommandData::CreateFromStructuredData(*cmds_dict, cmds_error);
     if (cmds_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Failed to deserialize breakpoint command options: %s.",
           cmds_error.AsCString());
       return nullptr;
@@ -300,12 +305,12 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
     else {
       ScriptInterpreter *interp = target.GetDebugger().GetScriptInterpreter();
       if (!interp) {
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "Can't set script commands - no script interpreter");
         return nullptr;
       }
       if (interp->GetLanguage() != cmd_data_up->interpreter) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "Current script language doesn't match breakpoint's language: %s",
             ScriptInterpreter::LanguageToString(cmd_data_up->interpreter)
                 .c_str());
@@ -315,8 +320,8 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
       script_error =
           interp->SetBreakpointCommandCallback(*bp_options, cmd_data_up);
       if (script_error.Fail()) {
-        error.SetErrorStringWithFormat("Error generating script callback: %s.",
-                                       error.AsCString());
+        error = Status::FromErrorStringWithFormat(
+            "Error generating script callback: %s.", error.AsCString());
         return nullptr;
       }
     }
@@ -331,7 +336,7 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
         ThreadSpec::CreateFromStructuredData(*thread_spec_dict,
                                              thread_spec_error);
     if (thread_spec_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Failed to deserialize breakpoint thread spec options: %s.",
           thread_spec_error.AsCString());
       return nullptr;

--- a/lldb/source/Breakpoint/BreakpointPrecondition.cpp
+++ b/lldb/source/Breakpoint/BreakpointPrecondition.cpp
@@ -20,7 +20,6 @@ void BreakpointPrecondition::GetDescription(Stream &stream,
                                             lldb::DescriptionLevel level) {}
 
 Status BreakpointPrecondition::ConfigurePrecondition(Args &args) {
-  Status error;
-  error.SetErrorString("Base breakpoint precondition has no options.");
-  return error;
+  return Status::FromErrorString(
+      "Base breakpoint precondition has no options.");
 }

--- a/lldb/source/Breakpoint/BreakpointResolver.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolver.cpp
@@ -74,7 +74,8 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
     const StructuredData::Dictionary &resolver_dict, Status &error) {
   BreakpointResolverSP result_sp;
   if (!resolver_dict.IsValid()) {
-    error.SetErrorString("Can't deserialize from an invalid data object.");
+    error = Status::FromErrorString(
+        "Can't deserialize from an invalid data object.");
     return result_sp;
   }
 
@@ -84,14 +85,15 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
       GetSerializationSubclassKey(), subclass_name);
 
   if (!success) {
-    error.SetErrorString("Resolver data missing subclass resolver key");
+    error =
+        Status::FromErrorString("Resolver data missing subclass resolver key");
     return result_sp;
   }
 
   ResolverTy resolver_type = NameToResolverTy(subclass_name);
   if (resolver_type == UnknownResolver) {
-    error.SetErrorStringWithFormatv("Unknown resolver type: {0}.",
-                                    subclass_name);
+    error = Status::FromErrorStringWithFormatv("Unknown resolver type: {0}.",
+                                               subclass_name);
     return result_sp;
   }
 
@@ -99,7 +101,8 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
   success = resolver_dict.GetValueForKeyAsDictionary(
       GetSerializationSubclassOptionsKey(), subclass_options);
   if (!success || !subclass_options || !subclass_options->IsValid()) {
-    error.SetErrorString("Resolver data missing subclass options key.");
+    error =
+        Status::FromErrorString("Resolver data missing subclass options key.");
     return result_sp;
   }
 
@@ -107,7 +110,8 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
   success = subclass_options->GetValueForKeyAsInteger(
       GetKey(OptionNames::Offset), offset);
   if (!success) {
-    error.SetErrorString("Resolver data missing offset options key.");
+    error =
+        Status::FromErrorString("Resolver data missing offset options key.");
     return result_sp;
   }
 
@@ -133,7 +137,7 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
         *subclass_options, error);
     break;
   case ExceptionResolver:
-    error.SetErrorString("Exception resolvers are hard.");
+    error = Status::FromErrorString("Exception resolvers are hard.");
     break;
   default:
     llvm_unreachable("Should never get an unresolvable resolver type.");

--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -40,7 +40,8 @@ BreakpointResolverSP BreakpointResolverAddress::CreateFromStructuredData(
   success = options_dict.GetValueForKeyAsInteger(
       GetKey(OptionNames::AddressOffset), addr_offset);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find address offset entry.");
+    error = Status::FromErrorString(
+        "BRFL::CFSD: Couldn't find address offset entry.");
     return nullptr;
   }
   Address address(addr_offset);
@@ -50,7 +51,8 @@ BreakpointResolverSP BreakpointResolverAddress::CreateFromStructuredData(
     success = options_dict.GetValueForKeyAsString(
         GetKey(OptionNames::ModuleName), module_name);
     if (!success) {
-      error.SetErrorString("BRA::CFSD: Couldn't read module name entry.");
+      error = Status::FromErrorString(
+          "BRA::CFSD: Couldn't read module name entry.");
       return nullptr;
     }
     module_filespec.SetFile(module_name, FileSpec::Style::native);

--- a/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -46,14 +46,16 @@ BreakpointResolverSP BreakpointResolverFileLine::CreateFromStructuredData(
   success = options_dict.GetValueForKeyAsString(GetKey(OptionNames::FileName),
                                                 filename);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find filename entry.");
+    error =
+        Status::FromErrorString("BRFL::CFSD: Couldn't find filename entry.");
     return nullptr;
   }
 
   success = options_dict.GetValueForKeyAsInteger(
       GetKey(OptionNames::LineNumber), line);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find line number entry.");
+    error =
+        Status::FromErrorString("BRFL::CFSD: Couldn't find line number entry.");
     return nullptr;
   }
 
@@ -67,21 +69,24 @@ BreakpointResolverSP BreakpointResolverFileLine::CreateFromStructuredData(
   success = options_dict.GetValueForKeyAsBoolean(GetKey(OptionNames::Inlines),
                                                  check_inlines);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find check inlines entry.");
+    error = Status::FromErrorString(
+        "BRFL::CFSD: Couldn't find check inlines entry.");
     return nullptr;
   }
 
   success = options_dict.GetValueForKeyAsBoolean(
       GetKey(OptionNames::SkipPrologue), skip_prologue);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find skip prologue entry.");
+    error = Status::FromErrorString(
+        "BRFL::CFSD: Couldn't find skip prologue entry.");
     return nullptr;
   }
 
   success = options_dict.GetValueForKeyAsBoolean(
       GetKey(OptionNames::ExactMatch), exact_match);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find exact match entry.");
+    error =
+        Status::FromErrorString("BRFL::CFSD: Couldn't find exact match entry.");
     return nullptr;
   }
 

--- a/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
@@ -34,7 +34,7 @@ BreakpointResolverSP BreakpointResolverFileRegex::CreateFromStructuredData(
   success = options_dict.GetValueForKeyAsString(
       GetKey(OptionNames::RegexString), regex_string);
   if (!success) {
-    error.SetErrorString("BRFR::CFSD: Couldn't find regex entry.");
+    error = Status::FromErrorString("BRFR::CFSD: Couldn't find regex entry.");
     return nullptr;
   }
   RegularExpression regex(regex_string);
@@ -43,7 +43,8 @@ BreakpointResolverSP BreakpointResolverFileRegex::CreateFromStructuredData(
   success = options_dict.GetValueForKeyAsBoolean(
       GetKey(OptionNames::ExactMatch), exact_match);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find exact match entry.");
+    error =
+        Status::FromErrorString("BRFL::CFSD: Couldn't find exact match entry.");
     return nullptr;
   }
 
@@ -58,8 +59,8 @@ BreakpointResolverSP BreakpointResolverFileRegex::CreateFromStructuredData(
       std::optional<llvm::StringRef> maybe_name =
           names_array->GetItemAtIndexAsString(i);
       if (!maybe_name) {
-        error.SetErrorStringWithFormat(
-            "BRFR::CFSD: Malformed element %zu in the names array.", i);
+        error = Status::FromErrorStringWithFormatv(
+            "BRFR::CFSD: Malformed element {0} in the names array.", i);
         return nullptr;
       }
       names_set.insert(std::string(*maybe_name));

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -95,8 +95,8 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
   if (success) {
     language = Language::GetLanguageTypeFromString(language_name);
     if (language == eLanguageTypeUnknown) {
-      error.SetErrorStringWithFormatv("BRN::CFSD: Unknown language: {0}.",
-                                      language_name);
+      error = Status::FromErrorStringWithFormatv(
+          "BRN::CFSD: Unknown language: {0}.", language_name);
       return nullptr;
     }
   }
@@ -105,7 +105,7 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
   success =
       options_dict.GetValueForKeyAsInteger(GetKey(OptionNames::Offset), offset);
   if (!success) {
-    error.SetErrorString("BRN::CFSD: Missing offset entry.");
+    error = Status::FromErrorString("BRN::CFSD: Missing offset entry.");
     return nullptr;
   }
 
@@ -113,7 +113,7 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
   success = options_dict.GetValueForKeyAsBoolean(
       GetKey(OptionNames::SkipPrologue), skip_prologue);
   if (!success) {
-    error.SetErrorString("BRN::CFSD: Missing Skip prologue entry.");
+    error = Status::FromErrorString("BRN::CFSD: Missing Skip prologue entry.");
     return nullptr;
   }
 
@@ -129,26 +129,27 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
     success = options_dict.GetValueForKeyAsArray(
         GetKey(OptionNames::SymbolNameArray), names_array);
     if (!success) {
-      error.SetErrorString("BRN::CFSD: Missing symbol names entry.");
+      error = Status::FromErrorString("BRN::CFSD: Missing symbol names entry.");
       return nullptr;
     }
     StructuredData::Array *names_mask_array;
     success = options_dict.GetValueForKeyAsArray(
         GetKey(OptionNames::NameMaskArray), names_mask_array);
     if (!success) {
-      error.SetErrorString("BRN::CFSD: Missing symbol names mask entry.");
+      error = Status::FromErrorString(
+          "BRN::CFSD: Missing symbol names mask entry.");
       return nullptr;
     }
 
     size_t num_elem = names_array->GetSize();
     if (num_elem != names_mask_array->GetSize()) {
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "BRN::CFSD: names and names mask arrays have different sizes.");
       return nullptr;
     }
 
     if (num_elem == 0) {
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "BRN::CFSD: no name entry in a breakpoint by name breakpoint.");
       return nullptr;
     }
@@ -158,13 +159,15 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
       std::optional<llvm::StringRef> maybe_name =
           names_array->GetItemAtIndexAsString(i);
       if (!maybe_name) {
-        error.SetErrorString("BRN::CFSD: name entry is not a string.");
+        error =
+            Status::FromErrorString("BRN::CFSD: name entry is not a string.");
         return nullptr;
       }
       auto maybe_fnt = names_mask_array->GetItemAtIndexAsInteger<
           std::underlying_type<FunctionNameType>::type>(i);
       if (!maybe_fnt) {
-        error.SetErrorString("BRN::CFSD: name mask entry is not an integer.");
+        error = Status::FromErrorString(
+            "BRN::CFSD: name mask entry is not an integer.");
         return nullptr;
       }
       names.push_back(std::string(*maybe_name));

--- a/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
@@ -66,7 +66,8 @@ BreakpointResolverSP BreakpointResolverScripted::CreateFromStructuredData(
   success = options_dict.GetValueForKeyAsString(
       GetKey(OptionNames::PythonClassName), class_name);
   if (!success) {
-    error.SetErrorString("BRFL::CFSD: Couldn't find class name entry.");
+    error =
+        Status::FromErrorString("BRFL::CFSD: Couldn't find class name entry.");
     return nullptr;
   }
   // The Python function will actually provide the search depth, this is a

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -278,9 +278,8 @@ are no syntax errors may indicate that a function was declared but never called.
         m_stop_on_error =
             OptionArgParser::ToBoolean(option_arg, false, &success);
         if (!success)
-          error.SetErrorStringWithFormat(
-              "invalid value for stop-on-error: \"%s\"",
-              option_arg.str().c_str());
+          return Status::FromErrorStringWithFormatv(
+              "invalid value for stop-on-error: \"{0}\"", option_arg);
       } break;
 
       case 'D':

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -51,13 +51,13 @@ Status CommandObjectDisassemble::CommandOptions::SetOptionValue(
 
   case 'C':
     if (option_arg.getAsInteger(0, num_lines_context))
-      error.SetErrorStringWithFormat("invalid num context lines string: \"%s\"",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid num context lines string: \"%s\"", option_arg.str().c_str());
     break;
 
   case 'c':
     if (option_arg.getAsInteger(0, num_instructions))
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "invalid num of instructions string: \"%s\"",
           option_arg.str().c_str());
     break;
@@ -114,8 +114,9 @@ Status CommandObjectDisassemble::CommandOptions::SetOptionValue(
                           llvm::Triple::x86_64)) {
       flavor_string.assign(std::string(option_arg));
     } else
-      error.SetErrorStringWithFormat("Disassembler flavors are currently only "
-                                     "supported for x86 and x86_64 targets.");
+      error = Status::FromErrorStringWithFormat(
+          "Disassembler flavors are currently only "
+          "supported for x86 and x86_64 targets.");
     break;
   }
 

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -52,7 +52,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
                   option_arg.str().c_str());
 
       Language::PrintSupportedLanguagesForExpressions(sstr, "  ", "\n");
-      error.SetErrorString(sstr.GetString());
+      error = Status(sstr.GetString().str());
     }
     break;
 
@@ -61,7 +61,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     bool result;
     result = OptionArgParser::ToBoolean(option_arg, true, &success);
     if (!success)
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "invalid all-threads value setting: \"%s\"",
           option_arg.str().c_str());
     else
@@ -74,7 +74,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     if (success)
       ignore_breakpoints = tmp_value;
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "could not convert \"%s\" to a boolean value.",
           option_arg.str().c_str());
     break;
@@ -86,7 +86,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     if (success)
       allow_jit = tmp_value;
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "could not convert \"%s\" to a boolean value.",
           option_arg.str().c_str());
     break;
@@ -95,8 +95,8 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
   case 't':
     if (option_arg.getAsInteger(0, timeout)) {
       timeout = 0;
-      error.SetErrorStringWithFormat("invalid timeout setting \"%s\"",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid timeout setting \"%s\"", option_arg.str().c_str());
     }
     break;
 
@@ -106,7 +106,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     if (success)
       unwind_on_error = tmp_value;
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "could not convert \"%s\" to a boolean value.",
           option_arg.str().c_str());
     break;
@@ -121,7 +121,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
         OptionArgParser::ToOptionEnum(
             option_arg, GetDefinitions()[option_idx].enum_values, 0, error);
     if (!error.Success())
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "unrecognized value for description-verbosity '%s'",
           option_arg.str().c_str());
     break;
@@ -142,7 +142,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     if (success)
       auto_apply_fixits = tmp_value ? eLazyBoolYes : eLazyBoolNo;
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "could not convert \"%s\" to a boolean value.",
           option_arg.str().c_str());
     break;
@@ -155,7 +155,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     if (success)
       suppress_persistent_result = !persist_result ? eLazyBoolYes : eLazyBoolNo;
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "could not convert \"%s\" to a boolean value.",
           option_arg.str().c_str());
     break;
@@ -392,9 +392,9 @@ CanBeUsedForElementCountPrinting(ValueObject &valobj) {
   CompilerType type(valobj.GetCompilerType());
   CompilerType pointee;
   if (!type.IsPointerType(&pointee))
-    return Status("as it does not refer to a pointer");
+    return Status::FromErrorString("as it does not refer to a pointer");
   if (pointee.IsVoidType())
-    return Status("as it refers to a pointer to void");
+    return Status::FromErrorString("as it refers to a pointer to void");
   return Status();
 }
 
@@ -650,7 +650,7 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
           io_handler_sp->SetIsDone(false);
           debugger.RunIOHandlerAsync(io_handler_sp);
         } else {
-          repl_error.SetErrorStringWithFormat(
+          repl_error = Status::FromErrorStringWithFormat(
               "Couldn't create a REPL for %s",
               Language::GetNameForLanguageType(m_command_options.language));
           result.SetError(repl_error);

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -68,8 +68,8 @@ public:
         address.emplace();
         if (option_arg.getAsInteger(0, *address)) {
           address.reset();
-          error.SetErrorStringWithFormat("invalid address argument '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid address argument '%s'", option_arg.str().c_str());
         }
       } break;
 
@@ -77,8 +77,8 @@ public:
         offset.emplace();
         if (option_arg.getAsInteger(0, *offset)) {
           offset.reset();
-          error.SetErrorStringWithFormat("invalid offset argument '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid offset argument '%s'", option_arg.str().c_str());
         }
       } break;
 
@@ -224,8 +224,8 @@ public:
       case 'r': {
         int32_t offset = 0;
         if (option_arg.getAsInteger(0, offset) || offset == INT32_MIN) {
-          error.SetErrorStringWithFormat("invalid frame offset argument '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid frame offset argument '%s'", option_arg.str().c_str());
         } else
           relative_frame_offset = offset;
         break;
@@ -748,7 +748,7 @@ private:
         if (success) {
           m_first_instruction_only = value;
         } else {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid boolean value '%s' passed for -f option",
               option_arg.str().c_str());
         }

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -99,14 +99,12 @@ public:
         handler = (LogHandlerKind)OptionArgParser::ToOptionEnum(
             option_arg, GetDefinitions()[option_idx].enum_values, 0, error);
         if (!error.Success())
-          error.SetErrorStringWithFormat(
-              "unrecognized value for log handler '%s'",
-              option_arg.str().c_str());
+          return Status::FromErrorStringWithFormatv(
+              "unrecognized value for log handler '{0}'", option_arg);
         break;
       case 'b':
-        error =
-            buffer_size.SetValueFromString(option_arg, eVarSetOperationAssign);
-        break;
+        return buffer_size.SetValueFromString(option_arg,
+                                              eVarSetOperationAssign);
       case 'v':
         log_options |= LLDB_LOG_OPTION_VERBOSE;
         break;

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -68,7 +68,7 @@ public:
     case 'l':
       error = m_num_per_line.SetValueFromString(option_value);
       if (m_num_per_line.GetCurrentValue() == 0)
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid value for --num-per-line option '%s'",
             option_value.str().c_str());
       break;
@@ -176,7 +176,7 @@ public:
     case eFormatBytesWithASCII:
       if (byte_size_option_set) {
         if (byte_size_value > 1)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "display format (bytes/bytes with ASCII) conflicts with the "
               "specified byte size %" PRIu64 "\n"
               "\tconsider using a different display format or don't specify "
@@ -913,12 +913,12 @@ public:
 
       case 'c':
         if (m_count.SetValueFromString(option_value).Fail())
-          error.SetErrorString("unrecognized value for count");
+          error = Status::FromErrorString("unrecognized value for count");
         break;
 
       case 'o':
         if (m_offset.SetValueFromString(option_value).Fail())
-          error.SetErrorString("unrecognized value for dump-offset");
+          error = Status::FromErrorString("unrecognized value for dump-offset");
         break;
 
       default:
@@ -1150,16 +1150,16 @@ public:
         FileSystem::Instance().Resolve(m_infile);
         if (!FileSystem::Instance().Exists(m_infile)) {
           m_infile.Clear();
-          error.SetErrorStringWithFormat("input file does not exist: '%s'",
-                                         option_value.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "input file does not exist: '%s'", option_value.str().c_str());
         }
         break;
 
       case 'o': {
         if (option_value.getAsInteger(0, m_infile_offset)) {
           m_infile_offset = 0;
-          error.SetErrorStringWithFormat("invalid offset string '%s'",
-                                         option_value.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid offset string '%s'", option_value.str().c_str());
         }
       } break;
 

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -78,16 +78,16 @@ public:
     case 'v': {
       if (option_arg.getAsInteger(8, m_permissions)) {
         m_permissions = 0777;
-        error.SetErrorStringWithFormat("invalid value for permissions: %s",
-                                       option_arg.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid value for permissions: %s", option_arg.str().c_str());
       }
 
     } break;
     case 's': {
       mode_t perms = ParsePermissionString(option_arg);
       if (perms == (mode_t)-1)
-        error.SetErrorStringWithFormat("invalid value for permissions: %s",
-                                       option_arg.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid value for permissions: %s", option_arg.str().c_str());
       else
         m_permissions = perms;
     } break;
@@ -609,13 +609,13 @@ protected:
       switch (short_option) {
       case 'o':
         if (option_arg.getAsInteger(0, m_offset))
-          error.SetErrorStringWithFormat("invalid offset: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid offset: '%s'",
+                                                    option_arg.str().c_str());
         break;
       case 'c':
         if (option_arg.getAsInteger(0, m_count))
-          error.SetErrorStringWithFormat("invalid offset: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid offset: '%s'",
+                                                    option_arg.str().c_str());
         break;
       default:
         llvm_unreachable("Unimplemented option");
@@ -702,8 +702,8 @@ protected:
       switch (short_option) {
       case 'o':
         if (option_arg.getAsInteger(0, m_offset))
-          error.SetErrorStringWithFormat("invalid offset: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid offset: '%s'",
+                                                    option_arg.str().c_str());
         break;
       case 'd':
         m_data.assign(std::string(option_arg));
@@ -1328,14 +1328,14 @@ protected:
       case 'p': {
         match_info.GetProcessInfo().SetProcessID(id);
         if (!success)
-          error.SetErrorStringWithFormat("invalid process ID string: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid process ID string: '%s'", option_arg.str().c_str());
         break;
       }
       case 'P':
         match_info.GetProcessInfo().SetParentProcessID(id);
         if (!success)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid parent process ID string: '%s'",
               option_arg.str().c_str());
         break;
@@ -1343,15 +1343,15 @@ protected:
       case 'u':
         match_info.GetProcessInfo().SetUserID(success ? id : UINT32_MAX);
         if (!success)
-          error.SetErrorStringWithFormat("invalid user ID string: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid user ID string: '%s'", option_arg.str().c_str());
         break;
 
       case 'U':
         match_info.GetProcessInfo().SetEffectiveUserID(success ? id
                                                                : UINT32_MAX);
         if (!success)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid effective user ID string: '%s'",
               option_arg.str().c_str());
         break;
@@ -1359,15 +1359,15 @@ protected:
       case 'g':
         match_info.GetProcessInfo().SetGroupID(success ? id : UINT32_MAX);
         if (!success)
-          error.SetErrorStringWithFormat("invalid group ID string: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid group ID string: '%s'", option_arg.str().c_str());
         break;
 
       case 'G':
         match_info.GetProcessInfo().SetEffectiveGroupID(success ? id
                                                                 : UINT32_MAX);
         if (!success)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid effective group ID string: '%s'",
               option_arg.str().c_str());
         break;
@@ -1630,7 +1630,7 @@ public:
       case 't':
         uint32_t timeout_sec;
         if (option_arg.getAsInteger(10, timeout_sec))
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "could not convert \"%s\" to a numeric value.",
               option_arg.str().c_str());
         else
@@ -1638,7 +1638,7 @@ public:
         break;
       case 's': {
         if (option_arg.empty()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "missing shell interpreter path for option -i|--interpreter.");
           return error;
         }
@@ -1734,7 +1734,7 @@ public:
     } else {
       result.GetOutputStream().Printf(
           "error: cannot run remote shell commands without a platform\n");
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "error: cannot run remote shell commands without a platform");
     }
 

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -453,7 +453,7 @@ protected:
       switch (short_option) {
       case 'i':
         if (option_arg.getAsInteger(0, m_ignore))
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid value for ignore option: \"%s\", should be a number.",
               option_arg.str().c_str());
         break;
@@ -744,8 +744,8 @@ public:
         bool success;
         tmp_result = OptionArgParser::ToBoolean(option_arg, false, &success);
         if (!success)
-          error.SetErrorStringWithFormat("invalid boolean option: \"%s\"",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid boolean option: \"%s\"", option_arg.str().c_str());
         else {
           if (tmp_result)
             m_keep_stopped = eLazyBoolYes;

--- a/lldb/source/Commands/CommandObjectScripting.cpp
+++ b/lldb/source/Commands/CommandObjectScripting.cpp
@@ -56,8 +56,8 @@ public:
             option_arg, GetDefinitions()[option_idx].enum_values,
             eScriptLanguageNone, error);
         if (!error.Success())
-          error.SetErrorStringWithFormat("unrecognized value for language '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "unrecognized value for language '%s'", option_arg.str().c_str());
         break;
       default:
         llvm_unreachable("Unimplemented option");
@@ -159,7 +159,7 @@ public:
             option_arg, GetDefinitions()[option_idx].enum_values,
             eScriptLanguageNone, error);
         if (!error.Success())
-          error.SetErrorStringWithFormatv(
+          error = Status::FromErrorStringWithFormatv(
               "unrecognized value for language '{0}'", option_arg);
         break;
       default:

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -50,20 +50,20 @@ class CommandObjectSourceInfo : public CommandObjectParsed {
       switch (short_option) {
       case 'l':
         if (option_arg.getAsInteger(0, start_line))
-          error.SetErrorStringWithFormat("invalid line number: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid line number: '%s'",
+                                                    option_arg.str().c_str());
         break;
 
       case 'e':
         if (option_arg.getAsInteger(0, end_line))
-          error.SetErrorStringWithFormat("invalid line number: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid line number: '%s'",
+                                                    option_arg.str().c_str());
         break;
 
       case 'c':
         if (option_arg.getAsInteger(0, num_lines))
-          error.SetErrorStringWithFormat("invalid line count: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid line count: '%s'",
+                                                    option_arg.str().c_str());
         break;
 
       case 'f':
@@ -612,14 +612,14 @@ class CommandObjectSourceList : public CommandObjectParsed {
       switch (short_option) {
       case 'l':
         if (option_arg.getAsInteger(0, start_line))
-          error.SetErrorStringWithFormat("invalid line number: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid line number: '%s'",
+                                                    option_arg.str().c_str());
         break;
 
       case 'c':
         if (option_arg.getAsInteger(0, num_lines))
-          error.SetErrorStringWithFormat("invalid line count: '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid line count: '%s'",
+                                                    option_arg.str().c_str());
         break;
 
       case 'f':
@@ -649,9 +649,8 @@ class CommandObjectSourceList : public CommandObjectParsed {
         OptionValueFileColonLine value;
         Status fcl_err = value.SetValueFromString(option_arg);
         if (!fcl_err.Success()) {
-          error.SetErrorStringWithFormat(
-              "Invalid value for file:line specifier: %s",
-              fcl_err.AsCString());
+          error = Status::FromErrorStringWithFormat(
+              "Invalid value for file:line specifier: %s", fcl_err.AsCString());
         } else {
           file_name = value.GetFileSpec().GetPath();
           start_line = value.GetLineNumber();

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -186,8 +186,8 @@ public:
       if (error.Success())
         m_load_dependent_files = tmp_load_dependents;
     } else {
-      error.SetErrorStringWithFormat("unrecognized short option '%c'",
-                                     short_option);
+      error = Status::FromErrorStringWithFormat(
+          "unrecognized short option '%c'", short_option);
     }
 
     return error;
@@ -3461,8 +3461,8 @@ public:
         m_addr = OptionArgParser::ToAddress(execution_context, option_arg,
                                             LLDB_INVALID_ADDRESS, &error);
         if (m_addr == LLDB_INVALID_ADDRESS)
-          error.SetErrorStringWithFormat("invalid address string '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid address string '%s'", option_arg.str().c_str());
         break;
       }
 
@@ -3805,8 +3805,8 @@ public:
 
       case 'o':
         if (option_arg.getAsInteger(0, m_offset))
-          error.SetErrorStringWithFormat("invalid offset string '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid offset string '%s'", option_arg.str().c_str());
         break;
 
       case 's':
@@ -3825,10 +3825,10 @@ public:
 
       case 'l':
         if (option_arg.getAsInteger(0, m_line_number))
-          error.SetErrorStringWithFormat("invalid line number string '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid line number string '%s'", option_arg.str().c_str());
         else if (m_line_number == 0)
-          error.SetErrorString("zero is an invalid line number");
+          error = Status::FromErrorString("zero is an invalid line number");
         m_type = eLookupTypeFileLine;
         break;
 
@@ -3886,8 +3886,9 @@ public:
     Status OptionParsingFinished(ExecutionContext *execution_context) override {
       Status status;
       if (m_all_ranges && !m_verbose) {
-        status.SetErrorString("--show-variable-ranges must be used in "
-                              "conjunction with --verbose.");
+        status =
+            Status::FromErrorString("--show-variable-ranges must be used in "
+                                    "conjunction with --verbose.");
       }
       return status;
     }
@@ -4709,8 +4710,8 @@ public:
 
       case 'e':
         if (option_arg.getAsInteger(0, m_line_end)) {
-          error.SetErrorStringWithFormat("invalid end line number: \"%s\"",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid end line number: \"%s\"", option_arg.str().c_str());
           break;
         }
         m_sym_ctx_specified = true;
@@ -4722,14 +4723,14 @@ public:
         if (success) {
           m_auto_continue = value;
         } else
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid boolean value '%s' passed for -G option",
               option_arg.str().c_str());
       } break;
       case 'l':
         if (option_arg.getAsInteger(0, m_line_start)) {
-          error.SetErrorStringWithFormat("invalid start line number: \"%s\"",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid start line number: \"%s\"", option_arg.str().c_str());
           break;
         }
         m_sym_ctx_specified = true;
@@ -4757,8 +4758,8 @@ public:
 
       case 't':
         if (option_arg.getAsInteger(0, m_thread_id))
-          error.SetErrorStringWithFormat("invalid thread id string '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid thread id string '%s'", option_arg.str().c_str());
         m_thread_specified = true;
         break;
 
@@ -4774,8 +4775,8 @@ public:
 
       case 'x':
         if (option_arg.getAsInteger(0, m_thread_index))
-          error.SetErrorStringWithFormat("invalid thread index string '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid thread index string '%s'", option_arg.str().c_str());
         m_thread_specified = true;
         break;
 

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -66,7 +66,7 @@ public:
       case 'c':
         if (option_arg.getAsInteger(0, m_count)) {
           m_count = UINT32_MAX;
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid integer value for option '%c': %s", short_option,
               option_arg.data());
         }
@@ -76,7 +76,7 @@ public:
         break;
       case 's':
         if (option_arg.getAsInteger(0, m_start))
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid integer value for option '%c': %s", short_option,
               option_arg.data());
         break;
@@ -85,7 +85,7 @@ public:
         m_extended_backtrace =
             OptionArgParser::ToBoolean(option_arg, false, &success);
         if (!success)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid boolean value for option '%c': %s", short_option,
               option_arg.data());
       } break;
@@ -286,7 +286,7 @@ public:
       bool avoid_no_debug =
           OptionArgParser::ToBoolean(option_arg, true, &success);
       if (!success)
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid boolean value for option '%c': %s", short_option,
             option_arg.data());
       else {
@@ -299,7 +299,7 @@ public:
       bool avoid_no_debug =
           OptionArgParser::ToBoolean(option_arg, true, &success);
       if (!success)
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid boolean value for option '%c': %s", short_option,
             option_arg.data());
       else {
@@ -309,7 +309,7 @@ public:
 
     case 'c':
       if (option_arg.getAsInteger(0, m_step_count))
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid integer value for option '%c': %s", short_option,
             option_arg.data());
       break;
@@ -326,8 +326,8 @@ public:
         break;
       }
       if (option_arg.getAsInteger(0, m_end_line))
-        error.SetErrorStringWithFormat("invalid end line number '%s'",
-                                       option_arg.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid end line number '%s'", option_arg.str().c_str());
       break;
 
     case 'r':
@@ -817,15 +817,15 @@ public:
       case 't':
         if (option_arg.getAsInteger(0, m_thread_idx)) {
           m_thread_idx = LLDB_INVALID_INDEX32;
-          error.SetErrorStringWithFormat("invalid thread index '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid thread index '%s'",
+                                                    option_arg.str().c_str());
         }
         break;
       case 'f':
         if (option_arg.getAsInteger(0, m_frame_idx)) {
           m_frame_idx = LLDB_INVALID_FRAME_ID;
-          error.SetErrorStringWithFormat("invalid frame index '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid frame index '%s'",
+                                                    option_arg.str().c_str());
         }
         break;
       case 'm': {
@@ -1118,7 +1118,8 @@ public:
       case 't': {
         if (option_arg.getAsInteger(0, m_thread_id)) {
           m_thread_id = LLDB_INVALID_THREAD_ID;
-          return Status("Invalid thread ID: '%s'.", option_arg.str().c_str());
+          return Status::FromErrorStringWithFormat("Invalid thread ID: '%s'.",
+                                                   option_arg.str().c_str());
         }
         break;
       }
@@ -1489,7 +1490,7 @@ public:
         if (success)
           m_from_expression = tmp_value;
         else {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid boolean value '%s' for 'x' option",
               option_arg.str().c_str());
         }
@@ -1641,15 +1642,17 @@ public:
       case 'f':
         m_filenames.AppendIfUnique(FileSpec(option_arg));
         if (m_filenames.GetSize() > 1)
-          return Status("only one source file expected.");
+          return Status::FromErrorString("only one source file expected.");
         break;
       case 'l':
         if (option_arg.getAsInteger(0, m_line_num))
-          return Status("invalid line number: '%s'.", option_arg.str().c_str());
+          return Status::FromErrorStringWithFormat("invalid line number: '%s'.",
+                                                   option_arg.str().c_str());
         break;
       case 'b':
         if (option_arg.getAsInteger(0, m_line_offset))
-          return Status("invalid line offset: '%s'.", option_arg.str().c_str());
+          return Status::FromErrorStringWithFormat("invalid line offset: '%s'.",
+                                                   option_arg.str().c_str());
         break;
       case 'a':
         m_load_addr = OptionArgParser::ToAddress(execution_context, option_arg,
@@ -1774,7 +1777,8 @@ public:
       case 't':
         lldb::tid_t tid;
         if (option_arg.getAsInteger(0, tid))
-          return Status("invalid tid: '%s'.", option_arg.str().c_str());
+          return Status::FromErrorStringWithFormat("invalid tid: '%s'.",
+                                                   option_arg.str().c_str());
         m_tids.push_back(tid);
         break;
       case 'u':
@@ -2235,7 +2239,7 @@ public:
         int32_t count;
         if (option_arg.empty() || option_arg.getAsInteger(0, count) ||
             count < 0)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid integer value for option '%s'",
               option_arg.str().c_str());
         else
@@ -2249,7 +2253,7 @@ public:
       case 's': {
         int32_t skip;
         if (option_arg.empty() || option_arg.getAsInteger(0, skip) || skip < 0)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid integer value for option '%s'",
               option_arg.str().c_str());
         else
@@ -2259,7 +2263,7 @@ public:
       case 'i': {
         uint64_t id;
         if (option_arg.empty() || option_arg.getAsInteger(0, id))
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid integer value for option '%s'",
               option_arg.str().c_str());
         else

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -312,8 +312,8 @@ private:
       case 'C':
         m_cascade = OptionArgParser::ToBoolean(option_arg, true, &success);
         if (!success)
-          error.SetErrorStringWithFormat("invalid value for cascade: %s",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid value for cascade: %s", option_arg.str().c_str());
         break;
       case 'P':
         handwrite_python = true;
@@ -333,14 +333,14 @@ private:
         break;
       case 'x':
         if (m_match_type == eFormatterMatchCallback)
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "can't use --regex and --recognizer-function at the same time");
         else
           m_match_type = eFormatterMatchRegex;
         break;
       case '\x01':
         if (m_match_type == eFormatterMatchRegex)
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "can't use --regex and --recognizer-function at the same time");
         else
           m_match_type = eFormatterMatchCallback;
@@ -543,8 +543,8 @@ private:
       case 'C':
         m_cascade = OptionArgParser::ToBoolean(option_value, true, &success);
         if (!success)
-          error.SetErrorStringWithFormat("invalid value for cascade: %s",
-                                         option_value.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid value for cascade: %s", option_value.str().c_str());
         break;
       case 'p':
         m_skip_pointers = true;
@@ -1148,8 +1148,8 @@ Status CommandObjectTypeSummaryAdd::CommandOptions::SetOptionValue(
   case 'C':
     m_flags.SetCascades(OptionArgParser::ToBoolean(option_arg, true, &success));
     if (!success)
-      error.SetErrorStringWithFormat("invalid value for cascade: %s",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid value for cascade: %s",
+                                                option_arg.str().c_str());
     break;
   case 'e':
     m_flags.SetDontShowChildren(false);
@@ -1174,14 +1174,14 @@ Status CommandObjectTypeSummaryAdd::CommandOptions::SetOptionValue(
     break;
   case 'x':
     if (m_match_type == eFormatterMatchCallback)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "can't use --regex and --recognizer-function at the same time");
     else
       m_match_type = eFormatterMatchRegex;
     break;
   case '\x01':
     if (m_match_type == eFormatterMatchRegex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "can't use --regex and --recognizer-function at the same time");
     else
       m_match_type = eFormatterMatchCallback;
@@ -1577,7 +1577,7 @@ bool CommandObjectTypeSummaryAdd::AddSummary(ConstString type_name,
     RegularExpression typeRX(type_name.GetStringRef());
     if (!typeRX.IsValid()) {
       if (error)
-        error->SetErrorString(
+        *error = Status::FromErrorString(
             "regex format error (maybe this is not really a regex?)");
       return false;
     }
@@ -1587,7 +1587,7 @@ bool CommandObjectTypeSummaryAdd::AddSummary(ConstString type_name,
     const char *function_name = type_name.AsCString();
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
     if (interpreter && !interpreter->CheckObjectExists(function_name)) {
-      error->SetErrorStringWithFormat(
+      *error = Status::FromErrorStringWithFormat(
           "The provided recognizer function \"%s\" does not exist - "
           "please define it before attempting to use this summary.\n",
           function_name);
@@ -1764,8 +1764,8 @@ class CommandObjectTypeCategoryEnable : public CommandObjectParsed {
         if (!option_arg.empty()) {
           m_language = Language::GetLanguageTypeFromString(option_arg);
           if (m_language == lldb::eLanguageTypeUnknown)
-            error.SetErrorStringWithFormat("unrecognized language '%s'",
-                                           option_arg.str().c_str());
+            error = Status::FromErrorStringWithFormat(
+                "unrecognized language '%s'", option_arg.str().c_str());
         }
         break;
       default:
@@ -1906,8 +1906,8 @@ class CommandObjectTypeCategoryDisable : public CommandObjectParsed {
         if (!option_arg.empty()) {
           m_language = Language::GetLanguageTypeFromString(option_arg);
           if (m_language == lldb::eLanguageTypeUnknown)
-            error.SetErrorStringWithFormat("unrecognized language '%s'",
-                                           option_arg.str().c_str());
+            error = Status::FromErrorStringWithFormat(
+                "unrecognized language '%s'", option_arg.str().c_str());
         }
         break;
       default:
@@ -2227,9 +2227,10 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
     if (category->AnyMatches(candidate_type, eFormatCategoryItemFilter,
                              false)) {
       if (error)
-        error->SetErrorStringWithFormat("cannot add synthetic for type %s when "
-                                        "filter is defined in same category!",
-                                        type_name.AsCString());
+        *error = Status::FromErrorStringWithFormat(
+            "cannot add synthetic for type %s when "
+            "filter is defined in same category!",
+            type_name.AsCString());
       return false;
     }
   }
@@ -2238,7 +2239,7 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
     RegularExpression typeRX(type_name.GetStringRef());
     if (!typeRX.IsValid()) {
       if (error)
-        error->SetErrorString(
+        *error = Status::FromErrorString(
             "regex format error (maybe this is not really a regex?)");
       return false;
     }
@@ -2248,7 +2249,7 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
     const char *function_name = type_name.AsCString();
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
     if (interpreter && !interpreter->CheckObjectExists(function_name)) {
-      error->SetErrorStringWithFormat(
+      *error = Status::FromErrorStringWithFormat(
           "The provided recognizer function \"%s\" does not exist - "
           "please define it before attempting to use this summary.\n",
           function_name);
@@ -2283,8 +2284,8 @@ private:
       case 'C':
         m_cascade = OptionArgParser::ToBoolean(option_arg, true, &success);
         if (!success)
-          error.SetErrorStringWithFormat("invalid value for cascade: %s",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "invalid value for cascade: %s", option_arg.str().c_str());
         break;
       case 'c':
         m_expr_paths.push_back(std::string(option_arg));
@@ -2368,10 +2369,11 @@ private:
       if (category->AnyMatches(candidate_type, eFormatCategoryItemSynth,
                                false)) {
         if (error)
-          error->SetErrorStringWithFormat("cannot add filter for type %s when "
-                                          "synthetic is defined in same "
-                                          "category!",
-                                          type_name.AsCString());
+          *error = Status::FromErrorStringWithFormat(
+              "cannot add filter for type %s when "
+              "synthetic is defined in same "
+              "category!",
+              type_name.AsCString());
         return false;
       }
     }
@@ -2382,7 +2384,7 @@ private:
       RegularExpression typeRX(type_name.GetStringRef());
       if (!typeRX.IsValid()) {
         if (error)
-          error->SetErrorString(
+          *error = Status::FromErrorString(
               "regex format error (maybe this is not really a regex?)");
         return false;
       }

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -559,8 +559,8 @@ public:
       switch (short_option) {
       case 'i':
         if (option_arg.getAsInteger(0, m_ignore_count))
-          error.SetErrorStringWithFormat("invalid ignore count '%s'",
-                                         option_arg.str().c_str());
+          error = Status::FromErrorStringWithFormat("invalid ignore count '%s'",
+                                                    option_arg.str().c_str());
         break;
       default:
         llvm_unreachable("Unimplemented option");

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -309,9 +309,8 @@ are no syntax errors may indicate that a function was declared but never called.
         m_stop_on_error =
             OptionArgParser::ToBoolean(option_arg, false, &success);
         if (!success)
-          error.SetErrorStringWithFormat(
-              "invalid value for stop-on-error: \"%s\"",
-              option_arg.str().c_str());
+          return Status::FromErrorStringWithFormatv(
+              "invalid value for stop-on-error: \"{0}\"", option_arg);
       } break;
 
       case 'F':

--- a/lldb/source/Commands/CommandOptionsProcessAttach.cpp
+++ b/lldb/source/Commands/CommandOptionsProcessAttach.cpp
@@ -41,8 +41,8 @@ Status CommandOptionsProcessAttach::SetOptionValue(
   case 'p': {
     lldb::pid_t pid;
     if (option_arg.getAsInteger(0, pid)) {
-      error.SetErrorStringWithFormat("invalid process ID '%s'",
-                                     option_arg.str().c_str());
+      return Status::FromErrorStringWithFormatv("invalid process ID '{0}'",
+                                                option_arg);
     } else {
       attach_info.SetProcessID(pid);
     }

--- a/lldb/source/Commands/CommandOptionsProcessLaunch.cpp
+++ b/lldb/source/Commands/CommandOptionsProcessLaunch.cpp
@@ -107,7 +107,7 @@ Status CommandOptionsProcessLaunch::SetOptionValue(
     if (success)
       disable_aslr = disable_aslr_arg ? eLazyBoolYes : eLazyBoolNo;
     else
-      error.SetErrorStringWithFormat(
+      return Status::FromErrorStringWithFormat(
           "Invalid boolean value for disable-aslr option: '%s'",
           option_arg.empty() ? "<null>" : option_arg.str().c_str());
     break;
@@ -121,7 +121,7 @@ Status CommandOptionsProcessLaunch::SetOptionValue(
     if (success)
       launch_info.SetShellExpandArguments(expand_args);
     else
-      error.SetErrorStringWithFormat(
+      return Status::FromErrorStringWithFormat(
           "Invalid boolean value for shell-expand-args option: '%s'",
           option_arg.empty() ? "<null>" : option_arg.str().c_str());
     break;
@@ -139,9 +139,8 @@ Status CommandOptionsProcessLaunch::SetOptionValue(
     break;
 
   default:
-    error.SetErrorStringWithFormat("unrecognized short option character '%c'",
-                                   short_option);
-    break;
+    return Status::FromErrorStringWithFormat(
+        "unrecognized short option character '%c'", short_option);
   }
   return error;
 }

--- a/lldb/source/Core/Communication.cpp
+++ b/lldb/source/Core/Communication.cpp
@@ -48,7 +48,7 @@ ConnectionStatus Communication::Connect(const char *url, Status *error_ptr) {
   if (connection_sp)
     return connection_sp->Connect(url, error_ptr);
   if (error_ptr)
-    error_ptr->SetErrorString("Invalid connection.");
+    *error_ptr = Status::FromErrorString("Invalid connection.");
   return eConnectionStatusNoConnection;
 }
 
@@ -109,7 +109,7 @@ size_t Communication::Write(const void *src, size_t src_len,
     return connection_sp->Write(src, src_len, status, error_ptr);
 
   if (error_ptr)
-    error_ptr->SetErrorString("Invalid connection.");
+    *error_ptr = Status::FromErrorString("Invalid connection.");
   status = eConnectionStatusNoConnection;
   return 0;
 }
@@ -133,7 +133,7 @@ size_t Communication::ReadFromConnection(void *dst, size_t dst_len,
     return connection_sp->Read(dst, dst_len, timeout, status, error_ptr);
 
   if (error_ptr)
-    error_ptr->SetErrorString("Invalid connection.");
+    *error_ptr = Status::FromErrorString("Invalid connection.");
   status = eConnectionStatusNoConnection;
   return 0;
 }

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -655,7 +655,7 @@ bool Debugger::LoadPlugin(const FileSpec &spec, Status &error) {
     // The g_load_plugin_callback is registered in SBDebugger::Initialize() and
     // if the public API layer isn't available (code is linking against all of
     // the internal LLDB static libraries), then we can't load plugins
-    error.SetErrorString("Public API layer is not available");
+    error = Status::FromErrorString("Public API layer is not available");
   }
   return false;
 }
@@ -1002,18 +1002,18 @@ Status Debugger::SetInputString(const char *data) {
   int fds[2] = {-1, -1};
 
   if (data == nullptr) {
-    result.SetErrorString("String data is null");
+    result = Status::FromErrorString("String data is null");
     return result;
   }
 
   size_t size = strlen(data);
   if (size == 0) {
-    result.SetErrorString("String data is empty");
+    result = Status::FromErrorString("String data is empty");
     return result;
   }
 
   if (OpenPipe(fds, size) != 0) {
-    result.SetErrorString(
+    result = Status::FromErrorString(
         "can't create pipe file descriptors for LLDB commands");
     return result;
   }
@@ -1028,9 +1028,10 @@ Status Debugger::SetInputString(const char *data) {
   // handle.
   FILE *commands_file = fdopen(fds[READ], "rb");
   if (commands_file == nullptr) {
-    result.SetErrorStringWithFormat("fdopen(%i, \"rb\") failed (errno = %i) "
-                                    "when trying to open LLDB commands pipe",
-                                    fds[READ], errno);
+    result = Status::FromErrorStringWithFormat(
+        "fdopen(%i, \"rb\") failed (errno = %i) "
+        "when trying to open LLDB commands pipe",
+        fds[READ], errno);
     llvm::sys::Process::SafelyCloseFileDescriptor(fds[READ]);
     return result;
   }
@@ -2201,11 +2202,11 @@ Status Debugger::RunREPL(LanguageType language, const char *repl_options) {
     if (auto single_lang = repl_languages.GetSingularLanguage()) {
       language = *single_lang;
     } else if (repl_languages.Empty()) {
-      err.SetErrorString(
+      err = Status::FromErrorString(
           "LLDB isn't configured with REPL support for any languages.");
       return err;
     } else {
-      err.SetErrorString(
+      err = Status::FromErrorString(
           "Multiple possible REPL languages.  Please specify a language.");
       return err;
     }
@@ -2221,8 +2222,9 @@ Status Debugger::RunREPL(LanguageType language, const char *repl_options) {
   }
 
   if (!repl_sp) {
-    err.SetErrorStringWithFormat("couldn't find a REPL for %s",
-                                 Language::GetNameForLanguageType(language));
+    err = Status::FromErrorStringWithFormat(
+        "couldn't find a REPL for %s",
+        Language::GetNameForLanguageType(language));
     return err;
   }
 

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1960,14 +1960,16 @@ static Status ParseEntry(const llvm::StringRef &format_str,
                               "access one of its children: ",
                               entry_def->name);
             DumpCommaSeparatedChildEntryNames(error_strm, entry_def);
-            error.SetErrorStringWithFormat("%s", error_strm.GetData());
+            error =
+                Status::FromErrorStringWithFormat("%s", error_strm.GetData());
           } else if (sep_char == ':') {
             // Any value whose separator is a with a ':' means this value has a
             // string argument that needs to be stored in the entry (like
             // "${script.var:}"). In this case the string value is the empty
             // string which is ok.
           } else {
-            error.SetErrorStringWithFormat("%s", "invalid entry definitions");
+            error = Status::FromErrorStringWithFormat(
+                "%s", "invalid entry definitions");
           }
         }
       } else {
@@ -1979,7 +1981,7 @@ static Status ParseEntry(const llvm::StringRef &format_str,
           // "${script.var:modulename.function}")
           entry.string = value.str();
         } else {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "'%s' followed by '%s' but it has no children", key.str().c_str(),
               value.str().c_str());
         }
@@ -1996,7 +1998,7 @@ static Status ParseEntry(const llvm::StringRef &format_str,
     error_strm.Printf("invalid member '%s' in '%s'. Valid members are: ",
                       key.str().c_str(), parent->name);
   DumpCommaSeparatedChildEntryNames(error_strm, parent);
-  error.SetErrorStringWithFormat("%s", error_strm.GetData());
+  error = Status::FromErrorStringWithFormat("%s", error_strm.GetData());
   return error;
 }
 
@@ -2064,7 +2066,7 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
 
     case '}':
       if (depth == 0)
-        error.SetErrorString("unmatched '}' character");
+        error = Status::FromErrorString("unmatched '}' character");
       else
         format =
             format
@@ -2074,7 +2076,7 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
     case '\\': {
       format = format.drop_front(); // Skip the '\' character
       if (format.empty()) {
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "'\\' character was not followed by another character");
         return error;
       }
@@ -2128,7 +2130,8 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
           if (octal_value <= UINT8_MAX) {
             parent_entry.AppendChar((char)octal_value);
           } else {
-            error.SetErrorString("octal number is larger than a single byte");
+            error = Status::FromErrorString(
+                "octal number is larger than a single byte");
             return error;
           }
         }
@@ -2153,7 +2156,8 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
           if (hex_value <= UINT8_MAX) {
             parent_entry.AppendChar((char)hex_value);
           } else {
-            error.SetErrorString("hex number is larger than a single byte");
+            error = Status::FromErrorString(
+                "hex number is larger than a single byte");
             return error;
           }
         } else {
@@ -2249,8 +2253,8 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
               } else if (entry.printf_format == "tid") {
                 verify_is_thread_id = true;
               } else {
-                error.SetErrorStringWithFormat("invalid format: '%s'",
-                                               entry.printf_format.c_str());
+                error = Status::FromErrorStringWithFormat(
+                    "invalid format: '%s'", entry.printf_format.c_str());
                 return error;
               }
             }
@@ -2276,8 +2280,8 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
         if (entry_string.contains(':')) {
           auto [_, llvm_format] = entry_string.split(':');
           if (!llvm_format.empty() && !LLVMFormatPattern.match(llvm_format)) {
-            error.SetErrorStringWithFormat("invalid llvm format: '%s'",
-                                           llvm_format.data());
+            error = Status::FromErrorStringWithFormat(
+                "invalid llvm format: '%s'", llvm_format.data());
             return error;
           }
         }
@@ -2285,8 +2289,9 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
         if (verify_is_thread_id) {
           if (entry.type != Entry::Type::ThreadID &&
               entry.type != Entry::Type::ThreadProtocolID) {
-            error.SetErrorString("the 'tid' format can only be used on "
-                                 "${thread.id} and ${thread.protocol_id}");
+            error = Status::FromErrorString(
+                "the 'tid' format can only be used on "
+                "${thread.id} and ${thread.protocol_id}");
           }
         }
 
@@ -2305,7 +2310,7 @@ static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
           // Make sure someone didn't try to dereference anything but ${var}
           // or ${svar}
           if (entry.deref) {
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "${%s} can't be dereferenced, only ${var} and ${svar} can.",
                 variable.str().c_str());
             return error;
@@ -2342,7 +2347,7 @@ Status FormatEntity::ExtractVariableInfo(llvm::StringRef &format_str,
     // Strip off elements and the formatting and the trailing '}'
     format_str = format_str.substr(paren_pos + 1);
   } else {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "missing terminating '}' character for '${%s'",
         format_str.str().c_str());
   }

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -298,7 +298,7 @@ ObjectFile *Module::GetMemoryObjectFile(const lldb::ProcessSP &process_sp,
                                         lldb::addr_t header_addr, Status &error,
                                         size_t size_to_read) {
   if (m_objfile_sp) {
-    error.SetErrorString("object file already exists");
+    error = Status::FromErrorString("object file already exists");
   } else {
     std::lock_guard<std::recursive_mutex> guard(m_mutex);
     if (process_sp) {
@@ -330,14 +330,15 @@ ObjectFile *Module::GetMemoryObjectFile(const lldb::ProcessSP &process_sp,
 
           m_unwind_table.ModuleWasUpdated();
         } else {
-          error.SetErrorString("unable to find suitable object file plug-in");
+          error = Status::FromErrorString(
+              "unable to find suitable object file plug-in");
         }
       } else {
-        error.SetErrorStringWithFormat("unable to read header from memory: %s",
-                                       readmem_error.AsCString());
+        error = Status::FromErrorStringWithFormat(
+            "unable to read header from memory: %s", readmem_error.AsCString());
       }
     } else {
-      error.SetErrorString("invalid process");
+      error = Status::FromErrorString("invalid process");
     }
   }
   return m_objfile_sp.get();
@@ -1427,7 +1428,7 @@ bool Module::IsLoadedInTarget(Target *target) {
 bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
                                            Stream &feedback_stream) {
   if (!target) {
-    error.SetErrorString("invalid destination Target");
+    error = Status::FromErrorString("invalid destination Target");
     return false;
   }
 
@@ -1444,7 +1445,7 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
     PlatformSP platform_sp(target->GetPlatform());
 
     if (!platform_sp) {
-      error.SetErrorString("invalid Platform");
+      error = Status::FromErrorString("invalid Platform");
       return false;
     }
 
@@ -1482,7 +1483,7 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
           }
         }
       } else {
-        error.SetErrorString("invalid ScriptInterpreter");
+        error = Status::FromErrorString("invalid ScriptInterpreter");
         return false;
       }
     }

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -938,16 +938,16 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
 
         if (arch.IsValid()) {
           if (!uuid_str.empty())
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "'%s' does not contain the %s architecture and UUID %s", path,
                 arch.GetArchitectureName(), uuid_str.c_str());
           else
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "'%s' does not contain the %s architecture.", path,
                 arch.GetArchitectureName());
         }
       } else {
-        error.SetErrorStringWithFormat("'%s' does not exist", path);
+        error = Status::FromErrorStringWithFormat("'%s' does not exist", path);
       }
       if (error.Fail())
         module_sp.reset();
@@ -1006,21 +1006,22 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
 
         if (located_binary_modulespec.GetFileSpec()) {
           if (arch.IsValid())
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "unable to open %s architecture in '%s'",
                 arch.GetArchitectureName(), path);
           else
-            error.SetErrorStringWithFormat("unable to open '%s'", path);
+            error =
+                Status::FromErrorStringWithFormat("unable to open '%s'", path);
         } else {
           std::string uuid_str;
           if (uuid_ptr && uuid_ptr->IsValid())
             uuid_str = uuid_ptr->GetAsString();
 
           if (!uuid_str.empty())
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "cannot locate a module for UUID '%s'", uuid_str.c_str());
           else
-            error.SetErrorString("cannot locate a module");
+            error = Status::FromErrorString("cannot locate a module");
         }
       }
     }
@@ -1050,12 +1051,13 @@ bool ModuleList::LoadScriptingResourcesInTarget(Target *target,
       if (!module->LoadScriptingResourceInTarget(target, error,
                                                  feedback_stream)) {
         if (error.Fail() && error.AsCString()) {
-          error.SetErrorStringWithFormat("unable to load scripting data for "
-                                         "module %s - error reported was %s",
-                                         module->GetFileSpec()
-                                             .GetFileNameStrippingExtension()
-                                             .GetCString(),
-                                         error.AsCString());
+          error = Status::FromErrorStringWithFormat(
+              "unable to load scripting data for "
+              "module %s - error reported was %s",
+              module->GetFileSpec()
+                  .GetFileNameStrippingExtension()
+                  .GetCString(),
+              error.AsCString());
           errors.push_back(error);
 
           if (!continue_on_error)

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -705,12 +705,12 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
                                lldb_private::SaveCoreOptions &options) {
   Status error;
   if (!options.GetOutputFile()) {
-    error.SetErrorString("No output file specified");
+    error = Status::FromErrorString("No output file specified");
     return error;
   }
 
   if (!process_sp) {
-    error.SetErrorString("Invalid process");
+    error = Status::FromErrorString("Invalid process");
     return error;
   }
 
@@ -741,7 +741,7 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
   // Check to see if any of the object file plugins tried and failed to save.
   // If none ran, set the error message.
   if (error.Success())
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "no ObjectFile plugins were able to save a core for this process");
   return error;
 }

--- a/lldb/source/Core/SearchFilter.cpp
+++ b/lldb/source/Core/SearchFilter.cpp
@@ -80,7 +80,8 @@ SearchFilterSP SearchFilter::CreateFromStructuredData(
     Status &error) {
   SearchFilterSP result_sp;
   if (!filter_dict.IsValid()) {
-    error.SetErrorString("Can't deserialize from an invalid data object.");
+    error = Status::FromErrorString(
+        "Can't deserialize from an invalid data object.");
     return result_sp;
   }
 
@@ -89,13 +90,14 @@ SearchFilterSP SearchFilter::CreateFromStructuredData(
   bool success = filter_dict.GetValueForKeyAsString(
       GetSerializationSubclassKey(), subclass_name);
   if (!success) {
-    error.SetErrorString("Filter data missing subclass key");
+    error = Status::FromErrorString("Filter data missing subclass key");
     return result_sp;
   }
 
   FilterTy filter_type = NameToFilterTy(subclass_name);
   if (filter_type == UnknownFilter) {
-    error.SetErrorStringWithFormatv("Unknown filter type: {0}.", subclass_name);
+    error = Status::FromErrorStringWithFormatv("Unknown filter type: {0}.",
+                                               subclass_name);
     return result_sp;
   }
 
@@ -103,7 +105,8 @@ SearchFilterSP SearchFilter::CreateFromStructuredData(
   success = filter_dict.GetValueForKeyAsDictionary(
       GetSerializationSubclassOptionsKey(), subclass_options);
   if (!success || !subclass_options || !subclass_options->IsValid()) {
-    error.SetErrorString("Filter data missing subclass options key.");
+    error =
+        Status::FromErrorString("Filter data missing subclass options key.");
     return result_sp;
   }
 
@@ -125,7 +128,8 @@ SearchFilterSP SearchFilter::CreateFromStructuredData(
         target_sp, *subclass_options, error);
     break;
   case Exception:
-    error.SetErrorString("Can't serialize exception breakpoints yet.");
+    error =
+        Status::FromErrorString("Can't serialize exception breakpoints yet.");
     break;
   default:
     llvm_unreachable("Should never get an uresolvable filter type.");
@@ -460,13 +464,14 @@ SearchFilterSP SearchFilterByModule::CreateFromStructuredData(
   bool success = data_dict.GetValueForKeyAsArray(GetKey(OptionNames::ModList),
                                                  modules_array);
   if (!success) {
-    error.SetErrorString("SFBM::CFSD: Could not find the module list key.");
+    error = Status::FromErrorString(
+        "SFBM::CFSD: Could not find the module list key.");
     return nullptr;
   }
 
   size_t num_modules = modules_array->GetSize();
   if (num_modules > 1) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "SFBM::CFSD: Only one modules allowed for SearchFilterByModule.");
     return nullptr;
   }
@@ -474,7 +479,8 @@ SearchFilterSP SearchFilterByModule::CreateFromStructuredData(
   std::optional<llvm::StringRef> maybe_module =
       modules_array->GetItemAtIndexAsString(0);
   if (!maybe_module) {
-    error.SetErrorString("SFBM::CFSD: filter module item not a string.");
+    error =
+        Status::FromErrorString("SFBM::CFSD: filter module item not a string.");
     return nullptr;
   }
   FileSpec module_spec(*maybe_module);
@@ -599,7 +605,7 @@ SearchFilterSP SearchFilterByModuleList::CreateFromStructuredData(
     std::optional<llvm::StringRef> maybe_module =
         modules_array->GetItemAtIndexAsString(i);
     if (!maybe_module) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "SFBM::CFSD: filter module item %zu not a string.", i);
       return nullptr;
     }
@@ -647,7 +653,7 @@ lldb::SearchFilterSP SearchFilterByModuleListAndCU::CreateFromStructuredData(
       std::optional<llvm::StringRef> maybe_module =
           modules_array->GetItemAtIndexAsString(i);
       if (!maybe_module) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "SFBM::CFSD: filter module item %zu not a string.", i);
         return result_sp;
       }
@@ -659,7 +665,8 @@ lldb::SearchFilterSP SearchFilterByModuleListAndCU::CreateFromStructuredData(
   success =
       data_dict.GetValueForKeyAsArray(GetKey(OptionNames::CUList), cus_array);
   if (!success) {
-    error.SetErrorString("SFBM::CFSD: Could not find the CU list key.");
+    error =
+        Status::FromErrorString("SFBM::CFSD: Could not find the CU list key.");
     return result_sp;
   }
 
@@ -669,7 +676,7 @@ lldb::SearchFilterSP SearchFilterByModuleListAndCU::CreateFromStructuredData(
     std::optional<llvm::StringRef> maybe_cu =
         cus_array->GetItemAtIndexAsString(i);
     if (!maybe_cu) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "SFBM::CFSD: filter CU item %zu not a string.", i);
       return nullptr;
     }

--- a/lldb/source/Core/ThreadedCommunication.cpp
+++ b/lldb/source/Core/ThreadedCommunication.cpp
@@ -92,14 +92,14 @@ size_t ThreadedCommunication::Read(void *dst, size_t dst_len,
     }
     if (timeout && timeout->count() == 0) {
       if (error_ptr)
-        error_ptr->SetErrorString("Timed out.");
+        *error_ptr = Status::FromErrorString("Timed out.");
       status = eConnectionStatusTimedOut;
       return 0;
     }
 
     if (!m_connection_sp) {
       if (error_ptr)
-        error_ptr->SetErrorString("Invalid connection.");
+        *error_ptr = Status::FromErrorString("Invalid connection.");
       status = eConnectionStatusNoConnection;
       return 0;
     }
@@ -126,7 +126,7 @@ size_t ThreadedCommunication::Read(void *dst, size_t dst_len,
     } else {
       if (!listener_sp->GetEvent(event_sp, timeout)) {
         if (error_ptr)
-          error_ptr->SetErrorString("Timed out.");
+          *error_ptr = Status::FromErrorString("Timed out.");
         status = eConnectionStatusTimedOut;
         return 0;
       }

--- a/lldb/source/Core/UserSettingsController.cpp
+++ b/lldb/source/Core/UserSettingsController.cpp
@@ -53,9 +53,7 @@ Status Properties::SetPropertyValue(const ExecutionContext *exe_ctx,
   OptionValuePropertiesSP properties_sp(GetValueProperties());
   if (properties_sp)
     return properties_sp->SetSubValue(exe_ctx, op, path, value);
-  Status error;
-  error.SetErrorString("no properties");
-  return error;
+  return Status::FromErrorString("no properties");
 }
 
 void Properties::DumpAllPropertyValues(const ExecutionContext *exe_ctx,
@@ -90,9 +88,7 @@ Status Properties::DumpPropertyValue(const ExecutionContext *exe_ctx,
     return properties_sp->DumpPropertyValue(exe_ctx, strm, property_path,
                                             dump_mask, is_json);
   }
-  Status error;
-  error.SetErrorString("empty property list");
-  return error;
+  return Status::FromErrorString("empty property list");
 }
 
 size_t

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -232,7 +232,7 @@ uint64_t Value::GetValueByteSize(Status *error_ptr, ExecutionContext *exe_ctx) {
   }
   }
   if (error_ptr && error_ptr->Success())
-    error_ptr->SetErrorString("Unable to determine byte size.");
+    *error_ptr = Status::FromErrorString("Unable to determine byte size.");
   return 0;
 }
 
@@ -329,7 +329,7 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
 
   switch (m_value_type) {
   case ValueType::Invalid:
-    error.SetErrorString("invalid value");
+    error = Status::FromErrorString("invalid value");
     break;
   case ValueType::Scalar: {
     data.SetByteOrder(endian::InlHostByteOrder());
@@ -348,12 +348,13 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
         return error; // Success;
     }
 
-    error.SetErrorString("extracting data from value failed");
+    error = Status::FromErrorString("extracting data from value failed");
     break;
   }
   case ValueType::LoadAddress:
     if (exe_ctx == nullptr) {
-      error.SetErrorString("can't read load address (no execution context)");
+      error = Status::FromErrorString(
+          "can't read load address (no execution context)");
     } else {
       Process *process = exe_ctx->GetProcessPtr();
       if (process == nullptr || !process->IsAlive()) {
@@ -375,7 +376,8 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
               address = LLDB_INVALID_ADDRESS;
           }
         } else {
-          error.SetErrorString("can't read load address (invalid process)");
+          error = Status::FromErrorString(
+              "can't read load address (invalid process)");
         }
       } else {
         address = m_value.ULongLong(LLDB_INVALID_ADDRESS);
@@ -390,13 +392,15 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
 
   case ValueType::FileAddress:
     if (exe_ctx == nullptr) {
-      error.SetErrorString("can't read file address (no execution context)");
+      error = Status::FromErrorString(
+          "can't read file address (no execution context)");
     } else if (exe_ctx->GetTargetPtr() == nullptr) {
-      error.SetErrorString("can't read file address (invalid target)");
+      error =
+          Status::FromErrorString("can't read file address (invalid target)");
     } else {
       address = m_value.ULongLong(LLDB_INVALID_ADDRESS);
       if (address == LLDB_INVALID_ADDRESS) {
-        error.SetErrorString("invalid file address");
+        error = Status::FromErrorString("invalid file address");
       } else {
         if (module == nullptr) {
           // The only thing we can currently lock down to a module so that we
@@ -446,24 +450,24 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
 
             if (module) {
               if (variable)
-                error.SetErrorStringWithFormat(
+                error = Status::FromErrorStringWithFormat(
                     "unable to resolve the module for file address 0x%" PRIx64
                     " for variable '%s' in %s",
                     address, variable->GetName().AsCString(""),
                     module->GetFileSpec().GetPath().c_str());
               else
-                error.SetErrorStringWithFormat(
+                error = Status::FromErrorStringWithFormat(
                     "unable to resolve the module for file address 0x%" PRIx64
                     " in %s",
                     address, module->GetFileSpec().GetPath().c_str());
             } else {
               if (variable)
-                error.SetErrorStringWithFormat(
+                error = Status::FromErrorStringWithFormat(
                     "unable to resolve the module for file address 0x%" PRIx64
                     " for variable '%s'",
                     address, variable->GetName().AsCString(""));
               else
-                error.SetErrorStringWithFormat(
+                error = Status::FromErrorStringWithFormat(
                     "unable to resolve the module for file address 0x%" PRIx64,
                     address);
             }
@@ -471,7 +475,7 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
         } else {
           // Can't convert a file address to anything valid without more
           // context (which Module it came from)
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "can't read memory from file address without more context");
         }
       }
@@ -500,9 +504,9 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
     return error;
 
   if (address == LLDB_INVALID_ADDRESS) {
-    error.SetErrorStringWithFormat("invalid %s address",
-                                   address_type == eAddressTypeHost ? "host"
-                                                                    : "load");
+    error = Status::FromErrorStringWithFormat(
+        "invalid %s address",
+        address_type == eAddressTypeHost ? "host" : "load");
     return error;
   }
 
@@ -529,7 +533,8 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
     if (address_type == eAddressTypeHost) {
       // The address is an address in this process, so just copy it.
       if (address == 0) {
-        error.SetErrorString("trying to read from host address of 0.");
+        error =
+            Status::FromErrorString("trying to read from host address of 0.");
         return error;
       }
       memcpy(dst, reinterpret_cast<uint8_t *>(address), byte_size);
@@ -540,7 +545,7 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
         if (exe_ctx->GetTargetRef().ReadMemory(file_so_addr, dst, byte_size,
                                                error, force_live_memory) !=
             byte_size) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "read memory from 0x%" PRIx64 " failed", (uint64_t)address);
         }
       } else {
@@ -554,21 +559,21 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
           const size_t bytes_read =
               process->ReadMemory(address, dst, byte_size, error);
           if (bytes_read != byte_size)
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "read memory from 0x%" PRIx64 " failed (%u of %u bytes read)",
                 (uint64_t)address, (uint32_t)bytes_read, (uint32_t)byte_size);
         } else {
-          error.SetErrorStringWithFormat("read memory from 0x%" PRIx64
-                                         " failed (invalid process)",
-                                         (uint64_t)address);
+          error = Status::FromErrorStringWithFormat(
+              "read memory from 0x%" PRIx64 " failed (invalid process)",
+              (uint64_t)address);
         }
       }
     } else {
-      error.SetErrorStringWithFormat("unsupported AddressType value (%i)",
-                                     address_type);
+      error = Status::FromErrorStringWithFormat(
+          "unsupported AddressType value (%i)", address_type);
     }
   } else {
-    error.SetErrorString("out of memory");
+    error = Status::FromErrorString("out of memory");
   }
 
   return error;

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -195,7 +195,7 @@ bool ValueObject::UpdateValueIfNeeded(bool update_format) {
       }
 
     } else {
-      m_error.SetErrorString("out of scope");
+      m_error = Status::FromErrorString("out of scope");
     }
   }
   return m_error.Success();
@@ -362,7 +362,7 @@ bool ValueObject::IsLogicalTrue(Status &error) {
   Scalar scalar_value;
 
   if (!ResolveValue(scalar_value)) {
-    error.SetErrorString("failed to get a scalar result");
+    error = Status::FromErrorString("failed to get a scalar result");
     return false;
   }
 
@@ -780,7 +780,7 @@ bool ValueObject::SetData(DataExtractor &data, Status &error) {
   // Make sure our value is up to date first so that our location and location
   // type is valid.
   if (!UpdateValueIfNeeded(false)) {
-    error.SetErrorString("unable to read value");
+    error = Status::FromErrorString("unable to read value");
     return false;
   }
 
@@ -793,15 +793,15 @@ bool ValueObject::SetData(DataExtractor &data, Status &error) {
 
   switch (value_type) {
   case Value::ValueType::Invalid:
-    error.SetErrorString("invalid location");
+    error = Status::FromErrorString("invalid location");
     return false;
   case Value::ValueType::Scalar: {
     Status set_error =
         m_value.GetScalar().SetValueFromData(data, encoding, byte_size);
 
     if (!set_error.Success()) {
-      error.SetErrorStringWithFormat("unable to set scalar value: %s",
-                                     set_error.AsCString());
+      error = Status::FromErrorStringWithFormat(
+          "unable to set scalar value: %s", set_error.AsCString());
       return false;
     }
   } break;
@@ -817,7 +817,7 @@ bool ValueObject::SetData(DataExtractor &data, Status &error) {
       if (!error.Success())
         return false;
       if (bytes_written != byte_size) {
-        error.SetErrorString("unable to write value to memory");
+        error = Status::FromErrorString("unable to write value to memory");
         return false;
       }
     }
@@ -861,7 +861,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
 
   if (!target) {
     s << "<no target to read from>";
-    error.SetErrorString("no target to read from");
+    error = Status::FromErrorString("no target to read from");
     CopyStringDataToBufferSP(s, buffer_sp);
     return {0, was_capped};
   }
@@ -903,7 +903,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
         const char *cstr = GetDataExtractor().PeekCStr(0);
         if (cstr == nullptr) {
           s << "<invalid address>";
-          error.SetErrorString("invalid address");
+          error = Status::FromErrorString("invalid address");
           CopyStringDataToBufferSP(s, buffer_sp);
           return {0, was_capped};
         }
@@ -912,7 +912,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
         return {cstr_len, was_capped};
       } else {
         s << "<invalid address>";
-        error.SetErrorString("invalid address");
+        error = Status::FromErrorString("invalid address");
         CopyStringDataToBufferSP(s, buffer_sp);
         return {0, was_capped};
       }
@@ -982,7 +982,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
       }
     }
   } else {
-    error.SetErrorString("not a string object");
+    error = Status::FromErrorString("not a string object");
     s << "<not a string object>";
   }
   CopyStringDataToBufferSP(s, buffer_sp);
@@ -1185,14 +1185,16 @@ void ValueObject::SetValueFromInteger(const llvm::APInt &value, Status &error) {
   if (!val_type.IsInteger() && !val_type.IsUnscopedEnumerationType() &&
       !val_type.IsFloat() && !val_type.IsPointerType() &&
       !val_type.IsScalarType()) {
-    error.SetErrorString("current value object is not an integer objet");
+    error =
+        Status::FromErrorString("current value object is not an integer objet");
     return;
   }
 
   // Verify the current object is not actually associated with any program
   // variable.
   if (GetVariable()) {
-    error.SetErrorString("current value object is not a temporary object");
+    error = Status::FromErrorString(
+        "current value object is not a temporary object");
     return;
   }
 
@@ -1202,7 +1204,7 @@ void ValueObject::SetValueFromInteger(const llvm::APInt &value, Status &error) {
   if (auto temp = GetCompilerType().GetByteSize(target.get()))
     byte_size = temp.value();
   if (value.getBitWidth() != byte_size * CHAR_BIT) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "illegal argument: new value should be of the same size");
     return;
   }
@@ -1222,14 +1224,16 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
   if (!val_type.IsInteger() && !val_type.IsUnscopedEnumerationType() &&
       !val_type.IsFloat() && !val_type.IsPointerType() &&
       !val_type.IsScalarType()) {
-    error.SetErrorString("current value object is not an integer objet");
+    error =
+        Status::FromErrorString("current value object is not an integer objet");
     return;
   }
 
   // Verify the current object is not actually associated with any program
   // variable.
   if (GetVariable()) {
-    error.SetErrorString("current value object is not a temporary object");
+    error = Status::FromErrorString(
+        "current value object is not a temporary object");
     return;
   }
 
@@ -1237,7 +1241,7 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
   CompilerType new_val_type = new_val_sp->GetCompilerType();
   if (!new_val_type.IsInteger() && !new_val_type.IsFloat() &&
       !new_val_type.IsPointerType()) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "illegal argument: new value should be of the same size");
     return;
   }
@@ -1247,13 +1251,13 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
     if (value_or_err)
       SetValueFromInteger(*value_or_err, error);
     else
-      error.SetErrorString("error getting APSInt from new_val_sp");
+      error = Status::FromErrorString("error getting APSInt from new_val_sp");
   } else if (new_val_type.IsFloat()) {
     auto value_or_err = new_val_sp->GetValueAsAPFloat();
     if (value_or_err)
       SetValueFromInteger(value_or_err->bitcastToAPInt(), error);
     else
-      error.SetErrorString("error getting APFloat from new_val_sp");
+      error = Status::FromErrorString("error getting APFloat from new_val_sp");
   } else if (new_val_type.IsPointerType()) {
     bool success = true;
     uint64_t int_val = new_val_sp->GetValueAsUnsigned(0, &success);
@@ -1264,7 +1268,7 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
         num_bits = temp.value();
       SetValueFromInteger(llvm::APInt(num_bits, int_val), error);
     } else
-      error.SetErrorString("error converting new_val_sp to integer");
+      error = Status::FromErrorString("error converting new_val_sp to integer");
   }
 }
 
@@ -1633,7 +1637,7 @@ bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
   // Make sure our value is up to date first so that our location and location
   // type is valid.
   if (!UpdateValueIfNeeded(false)) {
-    error.SetErrorString("unable to read value");
+    error = Status::FromErrorString("unable to read value");
     return false;
   }
 
@@ -1669,7 +1673,7 @@ bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
           if (!error.Success())
             return false;
           if (bytes_written != byte_size) {
-            error.SetErrorString("unable to write value to memory");
+            error = Status::FromErrorString("unable to write value to memory");
             return false;
           }
         }
@@ -1692,7 +1696,7 @@ bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
 
       } break;
       case Value::ValueType::Invalid:
-        error.SetErrorString("invalid location");
+        error = Status::FromErrorString("invalid location");
         return false;
       case Value::ValueType::FileAddress:
       case Value::ValueType::Scalar:
@@ -1703,7 +1707,7 @@ bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
     }
   } else {
     // We don't support setting things bigger than a scalar at present.
-    error.SetErrorString("unable to write aggregate data type");
+    error = Status::FromErrorString("unable to write aggregate data type");
     return false;
   }
 
@@ -2880,13 +2884,13 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
     GetExpressionPath(strm);
 
     if (is_pointer_or_reference_type)
-      error.SetErrorStringWithFormat("dereference failed: (%s) %s",
-                                     GetTypeName().AsCString("<invalid type>"),
-                                     strm.GetData());
+      error = Status::FromErrorStringWithFormat(
+          "dereference failed: (%s) %s",
+          GetTypeName().AsCString("<invalid type>"), strm.GetData());
     else
-      error.SetErrorStringWithFormat("not a pointer or reference type: (%s) %s",
-                                     GetTypeName().AsCString("<invalid type>"),
-                                     strm.GetData());
+      error = Status::FromErrorStringWithFormat(
+          "not a pointer or reference type: (%s) %s",
+          GetTypeName().AsCString("<invalid type>"), strm.GetData());
     return ValueObjectSP();
   }
 }
@@ -2904,8 +2908,8 @@ ValueObjectSP ValueObject::AddressOf(Status &error) {
     case eAddressTypeInvalid: {
       StreamString expr_path_strm;
       GetExpressionPath(expr_path_strm);
-      error.SetErrorStringWithFormat("'%s' is not in memory",
-                                     expr_path_strm.GetData());
+      error = Status::FromErrorStringWithFormat("'%s' is not in memory",
+                                                expr_path_strm.GetData());
     } break;
 
     case eAddressTypeFile:
@@ -2927,8 +2931,8 @@ ValueObjectSP ValueObject::AddressOf(Status &error) {
   } else {
     StreamString expr_path_strm;
     GetExpressionPath(expr_path_strm);
-    error.SetErrorStringWithFormat("'%s' doesn't have a valid address",
-                                   expr_path_strm.GetData());
+    error = Status::FromErrorStringWithFormat(
+        "'%s' doesn't have a valid address", expr_path_strm.GetData());
   }
 
   return m_addr_of_valobj_sp;
@@ -2964,8 +2968,9 @@ ValueObjectSP ValueObject::Cast(const CompilerType &compiler_type) {
       || m_value.GetValueType() == Value::ValueType::LoadAddress)
         return DoCast(compiler_type);
 
-  error.SetErrorString("Can only cast to a type that is equal to or smaller "
-                       "than the orignal type.");
+  error = Status::FromErrorString(
+      "Can only cast to a type that is equal to or smaller "
+      "than the orignal type.");
 
   return ValueObjectConstResult::Create(
       ExecutionContext(GetExecutionContextRef()).GetBestExecutionContextScope(),
@@ -3171,12 +3176,13 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
   bool is_integer = GetCompilerType().IsInteger();
 
   if (!type.IsScalarType()) {
-    m_error.SetErrorString("target type must be a scalar");
+    m_error = Status::FromErrorString("target type must be a scalar");
     return GetSP();
   }
 
   if (!is_scalar && !is_enum && !is_pointer) {
-    m_error.SetErrorString("argument must be a scalar, enum, or pointer");
+    m_error =
+        Status::FromErrorString("argument must be a scalar, enum, or pointer");
     return GetSP();
   }
 
@@ -3190,11 +3196,12 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
 
   if (is_pointer) {
     if (!type.IsInteger() && !type.IsBoolean()) {
-      m_error.SetErrorString("target type must be an integer or boolean");
+      m_error =
+          Status::FromErrorString("target type must be an integer or boolean");
       return GetSP();
     }
     if (!type.IsBoolean() && type_byte_size < val_byte_size) {
-      m_error.SetErrorString(
+      m_error = Status::FromErrorString(
           "target type cannot be smaller than the pointer type");
       return GetSP();
     }
@@ -3210,7 +3217,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         return ValueObject::CreateValueObjectFromBool(
             target, !float_value_or_err->isZero(), "result");
       else {
-        m_error.SetErrorStringWithFormat(
+        m_error = Status::FromErrorStringWithFormat(
             "cannot get value as APFloat: %s",
             llvm::toString(float_value_or_err.takeError()).c_str());
         return GetSP();
@@ -3229,7 +3236,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         return ValueObject::CreateValueObjectFromAPInt(target, ext, type,
                                                        "result");
       } else {
-        m_error.SetErrorStringWithFormat(
+        m_error = Status::FromErrorStringWithFormat(
             "cannot get value as APSInt: %s",
             llvm::toString(int_value_or_err.takeError()).c_str());
         ;
@@ -3247,7 +3254,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         // Casting floating point values that are out of bounds of the target
         // type is undefined behaviour.
         if (status & llvm::APFloatBase::opInvalidOp) {
-          m_error.SetErrorStringWithFormat(
+          m_error = Status::FromErrorStringWithFormat(
               "invalid type cast detected: %s",
               llvm::toString(float_value_or_err.takeError()).c_str());
           return GetSP();
@@ -3270,7 +3277,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                          "result");
       } else {
-        m_error.SetErrorStringWithFormat(
+        m_error = Status::FromErrorStringWithFormat(
             "cannot get value as APSInt: %s",
             llvm::toString(int_value_or_err.takeError()).c_str());
         return GetSP();
@@ -3285,7 +3292,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
           return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                            "result");
         } else {
-          m_error.SetErrorStringWithFormat(
+          m_error = Status::FromErrorStringWithFormat(
               "cannot get value as APSInt: %s",
               llvm::toString(int_value_or_err.takeError()).c_str());
           return GetSP();
@@ -3300,7 +3307,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
           return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                            "result");
         } else {
-          m_error.SetErrorStringWithFormat(
+          m_error = Status::FromErrorStringWithFormat(
               "cannot get value as APFloat: %s",
               llvm::toString(float_value_or_err.takeError()).c_str());
           return GetSP();
@@ -3309,7 +3316,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
     }
   }
 
-  m_error.SetErrorString("Unable to perform requested cast");
+  m_error = Status::FromErrorString("Unable to perform requested cast");
   return GetSP();
 }
 
@@ -3319,12 +3326,13 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
   bool is_float = GetCompilerType().IsFloat();
 
   if (!is_enum && !is_integer && !is_float) {
-    m_error.SetErrorString("argument must be an integer, a float, or an enum");
+    m_error = Status::FromErrorString(
+        "argument must be an integer, a float, or an enum");
     return GetSP();
   }
 
   if (!type.IsEnumerationType()) {
-    m_error.SetErrorString("target type must be an enum");
+    m_error = Status::FromErrorString("target type must be an enum");
     return GetSP();
   }
 
@@ -3344,7 +3352,7 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
       // Casting floating point values that are out of bounds of the target
       // type is undefined behaviour.
       if (status & llvm::APFloatBase::opInvalidOp) {
-        m_error.SetErrorStringWithFormat(
+        m_error = Status::FromErrorStringWithFormat(
             "invalid type cast detected: %s",
             llvm::toString(value_or_err.takeError()).c_str());
         return GetSP();
@@ -3352,7 +3360,7 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
       return ValueObject::CreateValueObjectFromAPInt(target, integer, type,
                                                      "result");
     } else {
-      m_error.SetErrorString("cannot get value as APFloat");
+      m_error = Status::FromErrorString("cannot get value as APFloat");
       return GetSP();
     }
   } else {
@@ -3363,13 +3371,13 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
       return ValueObject::CreateValueObjectFromAPInt(target, ext, type,
                                                      "result");
     } else {
-      m_error.SetErrorStringWithFormat(
+      m_error = Status::FromErrorStringWithFormat(
           "cannot get value as APSInt: %s",
           llvm::toString(value_or_err.takeError()).c_str());
       return GetSP();
     }
   }
-  m_error.SetErrorString("Cannot perform requested cast");
+  m_error = Status::FromErrorString("Cannot perform requested cast");
   return GetSP();
 }
 

--- a/lldb/source/Core/ValueObjectChild.cpp
+++ b/lldb/source/Core/ValueObjectChild.cpp
@@ -151,9 +151,9 @@ bool ValueObjectChild::UpdateValue() {
       case Value::ValueType::HostAddress: {
         lldb::addr_t addr = m_value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
         if (addr == LLDB_INVALID_ADDRESS) {
-          m_error.SetErrorString("parent address is invalid.");
+          m_error = Status::FromErrorString("parent address is invalid.");
         } else if (addr == 0) {
-          m_error.SetErrorString("parent is NULL");
+          m_error = Status::FromErrorString("parent is NULL");
         } else {
           // If a bitfield doesn't fit into the child_byte_size'd window at
           // child_byte_offset, move the window forward until it fits.  The
@@ -208,11 +208,12 @@ bool ValueObjectChild::UpdateValue() {
       }
 
     } else {
-      m_error.SetErrorStringWithFormat("parent failed to evaluate: %s",
-                                       parent->GetError().AsCString());
+      m_error = Status::FromErrorStringWithFormat(
+          "parent failed to evaluate: %s", parent->GetError().AsCString());
     }
   } else {
-    m_error.SetErrorString("ValueObjectChild has a NULL parent ValueObject.");
+    m_error = Status::FromErrorString(
+        "ValueObjectChild has a NULL parent ValueObject.");
   }
 
   return m_error.Success();

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -212,7 +212,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
       SetValueDidChange(true);
     ClearDynamicTypeInformation();
     m_dynamic_type_info.Clear();
-    m_error.SetErrorString("no dynamic type found");
+    m_error = Status::FromErrorString("no dynamic type found");
     return false;
   }
 
@@ -286,7 +286,7 @@ bool ValueObjectDynamicValue::IsInScope() { return m_parent->IsInScope(); }
 bool ValueObjectDynamicValue::SetValueFromCString(const char *value_str,
                                                   Status &error) {
   if (!UpdateValueIfNeeded(false)) {
-    error.SetErrorString("unable to read value");
+    error = Status::FromErrorString("unable to read value");
     return false;
   }
 
@@ -294,7 +294,7 @@ bool ValueObjectDynamicValue::SetValueFromCString(const char *value_str,
   uint64_t parent_value = m_parent->GetValueAsUnsigned(UINT64_MAX);
 
   if (my_value == UINT64_MAX || parent_value == UINT64_MAX) {
-    error.SetErrorString("unable to read value");
+    error = Status::FromErrorString("unable to read value");
     return false;
   }
 
@@ -306,7 +306,7 @@ bool ValueObjectDynamicValue::SetValueFromCString(const char *value_str,
   if (my_value != parent_value) {
     // but NULL'ing out a value should always be allowed
     if (strcmp(value_str, "0")) {
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "unable to modify dynamic value, use 'expression' command");
       return false;
     }
@@ -319,7 +319,7 @@ bool ValueObjectDynamicValue::SetValueFromCString(const char *value_str,
 
 bool ValueObjectDynamicValue::SetData(DataExtractor &data, Status &error) {
   if (!UpdateValueIfNeeded(false)) {
-    error.SetErrorString("unable to read value");
+    error = Status::FromErrorString("unable to read value");
     return false;
   }
 
@@ -327,7 +327,7 @@ bool ValueObjectDynamicValue::SetData(DataExtractor &data, Status &error) {
   uint64_t parent_value = m_parent->GetValueAsUnsigned(UINT64_MAX);
 
   if (my_value == UINT64_MAX || parent_value == UINT64_MAX) {
-    error.SetErrorString("unable to read value");
+    error = Status::FromErrorString("unable to read value");
     return false;
   }
 
@@ -341,7 +341,7 @@ bool ValueObjectDynamicValue::SetData(DataExtractor &data, Status &error) {
     lldb::offset_t offset = 0;
 
     if (data.GetAddress(&offset) != 0) {
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "unable to modify dynamic value, use 'expression' command");
       return false;
     }

--- a/lldb/source/Core/ValueObjectMemory.cpp
+++ b/lldb/source/Core/ValueObjectMemory.cpp
@@ -173,7 +173,7 @@ bool ValueObjectMemory::UpdateValue() {
 
     switch (value_type) {
     case Value::ValueType::Invalid:
-      m_error.SetErrorString("Invalid value");
+      m_error = Status::FromErrorString("Invalid value");
       return false;
     case Value::ValueType::Scalar:
       // The variable value is in the Scalar value inside the m_value. We can

--- a/lldb/source/Core/ValueObjectRegister.cpp
+++ b/lldb/source/Core/ValueObjectRegister.cpp
@@ -109,7 +109,7 @@ bool ValueObjectRegisterSet::UpdateValue() {
     SetValueIsValid(true);
   } else {
     SetValueIsValid(false);
-    m_error.SetErrorToGenericError();
+    m_error = Status::FromErrorString("no register context");
     m_children.Clear();
   }
   return m_error.Success();
@@ -258,7 +258,7 @@ bool ValueObjectRegister::UpdateValue() {
   }
 
   SetValueIsValid(false);
-  m_error.SetErrorToGenericError();
+  m_error = Status::FromErrorString("no register context");
   return false;
 }
 
@@ -271,7 +271,7 @@ bool ValueObjectRegister::SetValueFromCString(const char *value_str,
     return false;
 
   if (!m_reg_ctx_sp->WriteRegister(&m_reg_info, m_reg_value)) {
-    error.SetErrorString("unable to write back to register");
+    error = Status::FromErrorString("unable to write back to register");
     return false;
   }
 
@@ -285,7 +285,7 @@ bool ValueObjectRegister::SetData(DataExtractor &data, Status &error) {
     return false;
 
   if (!m_reg_ctx_sp->WriteRegister(&m_reg_info, m_reg_value)) {
-    error.SetErrorString("unable to write back to register");
+    error = Status::FromErrorString("unable to write back to register");
     return false;
   }
 

--- a/lldb/source/Core/ValueObjectVTable.cpp
+++ b/lldb/source/Core/ValueObjectVTable.cpp
@@ -51,25 +51,25 @@ protected:
     m_value.Clear();
     ValueObject *parent = GetParent();
     if (!parent) {
-      m_error.SetErrorString("owning vtable object not valid");
+      m_error = Status::FromErrorString("owning vtable object not valid");
       return false;
     }
 
     addr_t parent_addr = parent->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
     if (parent_addr == LLDB_INVALID_ADDRESS) {
-      m_error.SetErrorString("invalid vtable address");
+      m_error = Status::FromErrorString("invalid vtable address");
       return false;
     }
 
     ProcessSP process_sp = GetProcessSP();
     if (!process_sp) {
-      m_error.SetErrorString("no process");
+      m_error = Status::FromErrorString("no process");
       return false;
     }
 
     TargetSP target_sp = GetTargetSP();
     if (!target_sp) {
-      m_error.SetErrorString("no target");
+      m_error = Status::FromErrorString("no target");
       return false;
     }
 
@@ -78,7 +78,7 @@ protected:
     addr_t vfunc_ptr =
         process_sp->ReadPointerFromMemory(vtable_entry_addr, m_error);
     if (m_error.Fail()) {
-      m_error.SetErrorStringWithFormat(
+      m_error = Status::FromErrorStringWithFormat(
           "failed to read virtual function entry 0x%16.16" PRIx64,
           vtable_entry_addr);
       return false;
@@ -196,13 +196,13 @@ bool ValueObjectVTable::UpdateValue() {
   m_num_vtable_entries = 0;
   ValueObject *parent = GetParent();
   if (!parent) {
-    m_error.SetErrorString("no parent object");
+    m_error = Status::FromErrorString("no parent object");
     return false;
   }
 
   ProcessSP process_sp = GetProcessSP();
   if (!process_sp) {
-    m_error.SetErrorString("no process");
+    m_error = Status::FromErrorString("no process");
     return false;
   }
 
@@ -210,7 +210,7 @@ bool ValueObjectVTable::UpdateValue() {
   LanguageRuntime *language_runtime = process_sp->GetLanguageRuntime(language);
 
   if (language_runtime == nullptr) {
-    m_error.SetErrorStringWithFormat(
+    m_error = Status::FromErrorStringWithFormat(
         "no language runtime support for the language \"%s\"",
         Language::GetNameForLanguageType(language));
     return false;
@@ -230,7 +230,7 @@ bool ValueObjectVTable::UpdateValue() {
 
   m_vtable_symbol = vtable_info_or_err->symbol;
   if (!m_vtable_symbol) {
-    m_error.SetErrorStringWithFormat(
+    m_error = Status::FromErrorStringWithFormat(
         "no vtable symbol found containing 0x%" PRIx64, vtable_start_addr);
     return false;
   }
@@ -240,7 +240,7 @@ bool ValueObjectVTable::UpdateValue() {
 
   // Calculate the number of entries
   if (!m_vtable_symbol->GetByteSizeIsValid()) {
-    m_error.SetErrorStringWithFormat(
+    m_error = Status::FromErrorStringWithFormat(
         "vtable symbol \"%s\" doesn't have a valid size",
         m_vtable_symbol->GetMangled().GetDemangledName().GetCString());
     return false;

--- a/lldb/source/Core/ValueObjectVariable.cpp
+++ b/lldb/source/Core/ValueObjectVariable.cpp
@@ -142,7 +142,7 @@ bool ValueObjectVariable::UpdateValue() {
         m_value.SetBytes(m_data.GetDataStart(), m_data.GetByteSize());
       m_value.SetContext(Value::ContextType::Variable, variable);
     } else
-      m_error.SetErrorString("empty constant data");
+      m_error = Status::FromErrorString("empty constant data");
     // constant bytes can't be edited - sorry
     m_resolved_value.SetContext(Value::ContextType::Invalid, nullptr);
   } else {
@@ -204,7 +204,7 @@ bool ValueObjectVariable::UpdateValue() {
 
       switch (value_type) {
       case Value::ValueType::Invalid:
-        m_error.SetErrorString("invalid value");
+        m_error = Status::FromErrorString("invalid value");
         break;
       case Value::ValueType::Scalar:
         // The variable value is in the Scalar value inside the m_value. We can
@@ -365,7 +365,7 @@ const char *ValueObjectVariable::GetLocationAsCString() {
 bool ValueObjectVariable::SetValueFromCString(const char *value_str,
                                               Status &error) {
   if (!UpdateValueIfNeeded()) {
-    error.SetErrorString("unable to update value before writing");
+    error = Status::FromErrorString("unable to update value before writing");
     return false;
   }
 
@@ -375,7 +375,7 @@ bool ValueObjectVariable::SetValueFromCString(const char *value_str,
     RegisterContext *reg_ctx = exe_ctx.GetRegisterContext();
     RegisterValue reg_value;
     if (!reg_info || !reg_ctx) {
-      error.SetErrorString("unable to retrieve register info");
+      error = Status::FromErrorString("unable to retrieve register info");
       return false;
     }
     error = reg_value.SetValueFromString(reg_info, llvm::StringRef(value_str));
@@ -385,7 +385,7 @@ bool ValueObjectVariable::SetValueFromCString(const char *value_str,
       SetNeedsUpdate();
       return true;
     } else {
-      error.SetErrorString("unable to write back to register");
+      error = Status::FromErrorString("unable to write back to register");
       return false;
     }
   } else
@@ -394,7 +394,7 @@ bool ValueObjectVariable::SetValueFromCString(const char *value_str,
 
 bool ValueObjectVariable::SetData(DataExtractor &data, Status &error) {
   if (!UpdateValueIfNeeded()) {
-    error.SetErrorString("unable to update value before writing");
+    error = Status::FromErrorString("unable to update value before writing");
     return false;
   }
 
@@ -404,7 +404,7 @@ bool ValueObjectVariable::SetData(DataExtractor &data, Status &error) {
     RegisterContext *reg_ctx = exe_ctx.GetRegisterContext();
     RegisterValue reg_value;
     if (!reg_info || !reg_ctx) {
-      error.SetErrorString("unable to retrieve register info");
+      error = Status::FromErrorString("unable to retrieve register info");
       return false;
     }
     error = reg_value.SetValueFromData(*reg_info, data, 0, true);
@@ -414,7 +414,7 @@ bool ValueObjectVariable::SetData(DataExtractor &data, Status &error) {
       SetNeedsUpdate();
       return true;
     } else {
-      error.SetErrorString("unable to write back to register");
+      error = Status::FromErrorString("unable to write back to register");
       return false;
     }
   } else

--- a/lldb/source/Expression/ExpressionParser.cpp
+++ b/lldb/source/Expression/ExpressionParser.cpp
@@ -35,13 +35,14 @@ ExpressionParser::RunStaticInitializers(IRExecutionUnitSP &execution_unit_sp,
   Status err;
 
   if (!execution_unit_sp.get()) {
-    err.SetErrorString(
+    err = Status::FromErrorString(
         "can't run static initializers for a NULL execution unit");
     return err;
   }
 
   if (!exe_ctx.HasThreadScope()) {
-    err.SetErrorString("can't run static initializers without a thread");
+    err = Status::FromErrorString(
+        "can't run static initializers without a thread");
     return err;
   }
 
@@ -62,8 +63,9 @@ ExpressionParser::RunStaticInitializers(IRExecutionUnitSP &execution_unit_sp,
             exe_ctx, call_static_initializer, options, execution_errors);
 
     if (results != eExpressionCompleted) {
-      err.SetErrorStringWithFormat("couldn't run static initializer: %s",
-                                   execution_errors.GetString().c_str());
+      err = Status::FromErrorStringWithFormat(
+          "couldn't run static initializer: %s",
+          execution_errors.GetString().c_str());
       return err;
     }
   }

--- a/lldb/source/Expression/IRInterpreter.cpp
+++ b/lldb/source/Expression/IRInterpreter.cpp
@@ -530,8 +530,7 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
     if (f.begin() != f.end()) {
       if (saw_function_with_body) {
         LLDB_LOGF(log, "More than one function in the module has a body");
-        error.SetErrorToGenericError();
-        error.SetErrorString(too_many_functions_error);
+        error = lldb_private::Status::FromErrorString(too_many_functions_error);
         return false;
       }
       saw_function_with_body = true;
@@ -544,8 +543,7 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
       switch (ii.getOpcode()) {
       default: {
         LLDB_LOGF(log, "Unsupported instruction: %s", PrintValue(&ii).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(unsupported_opcode_error);
+        error = lldb_private::Status::FromErrorString(unsupported_opcode_error);
         return false;
       }
       case Instruction::Add:
@@ -558,16 +556,16 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
         CallInst *call_inst = dyn_cast<CallInst>(&ii);
 
         if (!call_inst) {
-          error.SetErrorToGenericError();
-          error.SetErrorString(interpreter_internal_error);
+          error =
+              lldb_private::Status::FromErrorString(interpreter_internal_error);
           return false;
         }
 
         if (!CanIgnoreCall(call_inst) && !support_function_calls) {
           LLDB_LOGF(log, "Unsupported instruction: %s",
                     PrintValue(&ii).c_str());
-          error.SetErrorToGenericError();
-          error.SetErrorString(unsupported_opcode_error);
+          error =
+              lldb_private::Status::FromErrorString(unsupported_opcode_error);
           return false;
         }
       } break;
@@ -578,8 +576,8 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
         CmpInst *cmp_inst = dyn_cast<CmpInst>(&ii);
 
         if (!cmp_inst) {
-          error.SetErrorToGenericError();
-          error.SetErrorString(interpreter_internal_error);
+          error =
+              lldb_private::Status::FromErrorString(interpreter_internal_error);
           return false;
         }
 
@@ -588,8 +586,8 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
           LLDB_LOGF(log, "Unsupported ICmp predicate: %s",
                     PrintValue(&ii).c_str());
 
-          error.SetErrorToGenericError();
-          error.SetErrorString(unsupported_opcode_error);
+          error =
+              lldb_private::Status::FromErrorString(unsupported_opcode_error);
           return false;
         }
         case CmpInst::FCMP_OEQ:
@@ -650,7 +648,8 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
         case Type::ScalableVectorTyID: {
           LLDB_LOGF(log, "Unsupported operand type: %s",
                     PrintType(operand_type).c_str());
-          error.SetErrorString(unsupported_operand_error);
+          error =
+              lldb_private::Status::FromErrorString(unsupported_operand_error);
           return false;
         }
         }
@@ -662,7 +661,8 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
         if (operand_type->getPrimitiveSizeInBits() > 64) {
           LLDB_LOGF(log, "Unsupported operand type: %s",
                     PrintType(operand_type).c_str());
-          error.SetErrorString(unsupported_operand_error);
+          error =
+              lldb_private::Status::FromErrorString(unsupported_operand_error);
           return false;
         }
 
@@ -670,7 +670,8 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
           if (!CanResolveConstant(constant)) {
             LLDB_LOGF(log, "Unsupported constant: %s",
                       PrintValue(constant).c_str());
-            error.SetErrorString(unsupported_operand_error);
+            error = lldb_private::Status::FromErrorString(
+                unsupported_operand_error);
             return false;
           }
         }
@@ -709,7 +710,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
                               stack_frame_top);
 
   if (frame.m_frame_process_address == LLDB_INVALID_ADDRESS) {
-    error.SetErrorString("Couldn't allocate stack frame");
+    error =
+        lldb_private::Status::FromErrorString("Couldn't allocate stack frame");
   }
 
   int arg_index = 0;
@@ -718,7 +720,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
                                     ae = function.arg_end();
        ai != ae; ++ai, ++arg_index) {
     if (args.size() <= static_cast<size_t>(arg_index)) {
-      error.SetErrorString("Not enough arguments passed in to function");
+      error = lldb_private::Status::FromErrorString(
+          "Not enough arguments passed in to function");
       return false;
     }
 
@@ -742,8 +745,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
   while (frame.m_ii != frame.m_ie) {
     // Timeout reached: stop interpreting.
     if (end_time && clock::now() >= *end_time) {
-      error.SetErrorToGenericError();
-      error.SetErrorString(timeout_error);
+      error = lldb_private::Status::FromErrorString(timeout_error);
       return false;
     }
 
@@ -751,8 +753,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
     if (target) {
       if (INTERRUPT_REQUESTED(target->GetDebugger(),
                               "Interrupted in IR interpreting.")) {
-        error.SetErrorToGenericError();
-        error.SetErrorString(interrupt_error);
+        error = lldb_private::Status::FromErrorString(interrupt_error);
         return false;
       }
     }
@@ -789,8 +790,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
             log,
             "getOpcode() returns %s, but instruction is not a BinaryOperator",
             inst->getOpcodeName());
-        error.SetErrorToGenericError();
-        error.SetErrorString(interpreter_internal_error);
+        error =
+            lldb_private::Status::FromErrorString(interpreter_internal_error);
         return false;
       }
 
@@ -802,15 +803,13 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!frame.EvaluateValue(L, lhs, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(lhs).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
       if (!frame.EvaluateValue(R, rhs, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(rhs).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -890,8 +889,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       if (alloca_inst->isArrayAllocation()) {
         LLDB_LOGF(log,
                   "AllocaInsts are not handled if isArrayAllocation() is true");
-        error.SetErrorToGenericError();
-        error.SetErrorString(unsupported_opcode_error);
+        error = lldb_private::Status::FromErrorString(unsupported_opcode_error);
         return false;
       }
 
@@ -909,8 +907,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (R == LLDB_INVALID_ADDRESS) {
         LLDB_LOGF(log, "Couldn't allocate memory for an AllocaInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_allocation_error);
+        error = lldb_private::Status::FromErrorString(memory_allocation_error);
         return false;
       }
 
@@ -919,8 +916,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       if (P == LLDB_INVALID_ADDRESS) {
         LLDB_LOGF(log,
                   "Couldn't allocate the result pointer for an AllocaInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_allocation_error);
+        error = lldb_private::Status::FromErrorString(memory_allocation_error);
         return false;
       }
 
@@ -930,8 +926,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!write_error.Success()) {
         LLDB_LOGF(log, "Couldn't write the result pointer for an AllocaInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_write_error);
+        error = lldb_private::Status::FromErrorString(memory_write_error);
         lldb_private::Status free_error;
         execution_unit.Free(P, free_error);
         execution_unit.Free(R, free_error);
@@ -956,8 +951,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!frame.EvaluateValue(S, source, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(source).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -972,8 +966,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!frame.EvaluateValue(S, source, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(source).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -993,8 +986,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
         if (!frame.EvaluateValue(C, condition, module)) {
           LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(condition).c_str());
-          error.SetErrorToGenericError();
-          error.SetErrorString(bad_value_error);
+          error = lldb_private::Status::FromErrorString(bad_value_error);
           return false;
         }
 
@@ -1023,8 +1015,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
         LLDB_LOGF(log,
                   "Encountered PHI node without having jumped from another "
                   "basic block");
-        error.SetErrorToGenericError();
-        error.SetErrorString(interpreter_internal_error);
+        error =
+            lldb_private::Status::FromErrorString(interpreter_internal_error);
         return false;
       }
 
@@ -1032,8 +1024,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       lldb_private::Scalar result;
       if (!frame.EvaluateValue(result, value, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(value).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
       frame.AssignValue(inst, result, module);
@@ -1055,8 +1046,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       if (!frame.EvaluateValue(P, pointer_operand, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s",
                   PrintValue(pointer_operand).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -1077,8 +1067,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
           if (!frame.EvaluateValue(I, *ii, module)) {
             LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(*ii).c_str());
-            error.SetErrorToGenericError();
-            error.SetErrorString(bad_value_error);
+            error = lldb_private::Status::FromErrorString(bad_value_error);
             return false;
           }
 
@@ -1120,15 +1109,13 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!frame.EvaluateValue(L, lhs, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(lhs).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
       if (!frame.EvaluateValue(R, rhs, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(rhs).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -1217,8 +1204,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!frame.EvaluateValue(I, src_operand, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(src_operand).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -1239,8 +1225,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!frame.EvaluateValue(I, src_operand, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(src_operand).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -1261,8 +1246,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!frame.EvaluateValue(I, src_operand, module)) {
         LLDB_LOGF(log, "Couldn't evaluate %s", PrintValue(src_operand).c_str());
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -1290,15 +1274,13 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (D == LLDB_INVALID_ADDRESS) {
         LLDB_LOGF(log, "LoadInst's value doesn't resolve to anything");
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
       if (P == LLDB_INVALID_ADDRESS) {
         LLDB_LOGF(log, "LoadInst's pointer doesn't resolve to anything");
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -1308,8 +1290,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!read_error.Success()) {
         LLDB_LOGF(log, "Couldn't read the address to be loaded for a LoadInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_read_error);
+        error = lldb_private::Status::FromErrorString(memory_read_error);
         return false;
       }
 
@@ -1322,8 +1303,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
                                 read_error);
       if (!read_error.Success()) {
         LLDB_LOGF(log, "Couldn't read from a region on behalf of a LoadInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_read_error);
+        error = lldb_private::Status::FromErrorString(memory_read_error);
         return false;
       }
 
@@ -1332,8 +1312,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
                                  write_error);
       if (!write_error.Success()) {
         LLDB_LOGF(log, "Couldn't write to a region on behalf of a LoadInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_write_error);
+        error = lldb_private::Status::FromErrorString(memory_write_error);
         return false;
       }
 
@@ -1364,15 +1343,13 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (D == LLDB_INVALID_ADDRESS) {
         LLDB_LOGF(log, "StoreInst's value doesn't resolve to anything");
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
       if (P == LLDB_INVALID_ADDRESS) {
         LLDB_LOGF(log, "StoreInst's pointer doesn't resolve to anything");
-        error.SetErrorToGenericError();
-        error.SetErrorString(bad_value_error);
+        error = lldb_private::Status::FromErrorString(bad_value_error);
         return false;
       }
 
@@ -1382,8 +1359,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       if (!read_error.Success()) {
         LLDB_LOGF(log, "Couldn't read the address to be loaded for a LoadInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_read_error);
+        error = lldb_private::Status::FromErrorString(memory_read_error);
         return false;
       }
 
@@ -1396,8 +1372,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
                                 read_error);
       if (!read_error.Success()) {
         LLDB_LOGF(log, "Couldn't read from a region on behalf of a StoreInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_read_error);
+        error = lldb_private::Status::FromErrorString(memory_read_error);
         return false;
       }
 
@@ -1406,8 +1381,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
                                  write_error);
       if (!write_error.Success()) {
         LLDB_LOGF(log, "Couldn't write to a region on behalf of a StoreInst");
-        error.SetErrorToGenericError();
-        error.SetErrorString(memory_write_error);
+        error = lldb_private::Status::FromErrorString(memory_write_error);
         return false;
       }
 
@@ -1427,30 +1401,30 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       // Get the return type
       llvm::Type *returnType = call_inst->getType();
       if (returnType == nullptr) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("unable to access return type");
+        error = lldb_private::Status::FromErrorString(
+            "unable to access return type");
         return false;
       }
 
       // Work with void, integer and pointer return types
       if (!returnType->isVoidTy() && !returnType->isIntegerTy() &&
           !returnType->isPointerTy()) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("return type is not supported");
+        error = lldb_private::Status::FromErrorString(
+            "return type is not supported");
         return false;
       }
 
       // Check we can actually get a thread
       if (exe_ctx.GetThreadPtr() == nullptr) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("unable to acquire thread");
+        error =
+            lldb_private::Status::FromErrorString("unable to acquire thread");
         return false;
       }
 
       // Make sure we have a valid process
       if (!process) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("unable to get the process");
+        error =
+            lldb_private::Status::FromErrorString("unable to get the process");
         return false;
       }
 
@@ -1459,8 +1433,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       const llvm::Value *val = call_inst->getCalledOperand();
 
       if (!frame.EvaluateValue(I, val, module)) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("unable to get address of function");
+        error = lldb_private::Status::FromErrorString(
+            "unable to get address of function");
         return false;
       }
       lldb_private::Address funcAddr(I.ULongLong(LLDB_INVALID_ADDRESS));
@@ -1476,8 +1450,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       // We work with a fixed array of 16 arguments which is our upper limit
       static lldb_private::ABI::CallArgument rawArgs[16];
       if (numArgs >= 16) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("function takes too many arguments");
+        error = lldb_private::Status::FromErrorString(
+            "function takes too many arguments");
         return false;
       }
 
@@ -1490,16 +1464,16 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
         // Ensure that this argument is an supported type
         if (!arg_ty->isIntegerTy() && !arg_ty->isPointerTy()) {
-          error.SetErrorToGenericError();
-          error.SetErrorStringWithFormat("argument %d must be integer type", i);
+          error = lldb_private::Status::FromErrorStringWithFormat(
+              "argument %d must be integer type", i);
           return false;
         }
 
         // Extract the arguments value
         lldb_private::Scalar tmp_op = 0;
         if (!frame.EvaluateValue(tmp_op, arg_op, module)) {
-          error.SetErrorToGenericError();
-          error.SetErrorStringWithFormat("unable to evaluate argument %d", i);
+          error = lldb_private::Status::FromErrorStringWithFormat(
+              "unable to evaluate argument %d", i);
           return false;
         }
 
@@ -1547,8 +1521,7 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
       // Check if the plan is valid
       lldb_private::StreamString ss;
       if (!call_plan_sp || !call_plan_sp->ValidatePlan(&ss)) {
-        error.SetErrorToGenericError();
-        error.SetErrorStringWithFormat(
+        error = lldb_private::Status::FromErrorStringWithFormat(
             "unable to make ThreadPlanCallFunctionUsingABI for 0x%llx",
             I.ULongLong());
         return false;
@@ -1562,8 +1535,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
       // Check that the thread plan completed successfully
       if (res != lldb::ExpressionResults::eExpressionCompleted) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("ThreadPlanCallFunctionUsingABI failed");
+        error = lldb_private::Status::FromErrorString(
+            "ThreadPlanCallFunctionUsingABI failed");
         return false;
       }
 
@@ -1583,8 +1556,8 @@ bool IRInterpreter::Interpret(llvm::Module &module, llvm::Function &function,
 
         // Check if the return value is valid
         if (vobj == nullptr || !retVal) {
-          error.SetErrorToGenericError();
-          error.SetErrorString("unable to get the return value");
+          error = lldb_private::Status::FromErrorString(
+              "unable to get the return value");
           return false;
         }
 

--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -347,14 +347,13 @@ lldb::addr_t IRMemoryMap::Malloc(size_t size, uint8_t alignment,
 
   switch (policy) {
   default:
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't malloc: invalid allocation policy");
+    error =
+        Status::FromErrorString("Couldn't malloc: invalid allocation policy");
     return LLDB_INVALID_ADDRESS;
   case eAllocationPolicyHostOnly:
     allocation_address = FindSpace(allocation_size);
     if (allocation_address == LLDB_INVALID_ADDRESS) {
-      error.SetErrorToGenericError();
-      error.SetErrorString("Couldn't malloc: address space is full");
+      error = Status::FromErrorString("Couldn't malloc: address space is full");
       return LLDB_INVALID_ADDRESS;
     }
     break;
@@ -384,8 +383,8 @@ lldb::addr_t IRMemoryMap::Malloc(size_t size, uint8_t alignment,
       policy = eAllocationPolicyHostOnly;
       allocation_address = FindSpace(allocation_size);
       if (allocation_address == LLDB_INVALID_ADDRESS) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("Couldn't malloc: address space is full");
+        error =
+            Status::FromErrorString("Couldn't malloc: address space is full");
         return LLDB_INVALID_ADDRESS;
       }
     }
@@ -404,15 +403,14 @@ lldb::addr_t IRMemoryMap::Malloc(size_t size, uint8_t alignment,
         if (!error.Success())
           return LLDB_INVALID_ADDRESS;
       } else {
-        error.SetErrorToGenericError();
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "Couldn't malloc: process doesn't support allocating memory");
         return LLDB_INVALID_ADDRESS;
       }
     } else {
-      error.SetErrorToGenericError();
-      error.SetErrorString("Couldn't malloc: process doesn't exist, and this "
-                           "memory must be in the process");
+      error = Status::FromErrorString(
+          "Couldn't malloc: process doesn't exist, and this "
+          "memory must be in the process");
       return LLDB_INVALID_ADDRESS;
     }
     break;
@@ -466,8 +464,7 @@ void IRMemoryMap::Leak(lldb::addr_t process_address, Status &error) {
   AllocationMap::iterator iter = m_allocations.find(process_address);
 
   if (iter == m_allocations.end()) {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't leak: allocation doesn't exist");
+    error = Status::FromErrorString("Couldn't leak: allocation doesn't exist");
     return;
   }
 
@@ -482,8 +479,7 @@ void IRMemoryMap::Free(lldb::addr_t process_address, Status &error) {
   AllocationMap::iterator iter = m_allocations.find(process_address);
 
   if (iter == m_allocations.end()) {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't free: allocation doesn't exist");
+    error = Status::FromErrorString("Couldn't free: allocation doesn't exist");
     return;
   }
 
@@ -557,9 +553,9 @@ void IRMemoryMap::WriteMemory(lldb::addr_t process_address,
       return;
     }
 
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't write: no allocation contains the target "
-                         "range and the process doesn't exist");
+    error = Status::FromErrorString(
+        "Couldn't write: no allocation contains the target "
+        "range and the process doesn't exist");
     return;
   }
 
@@ -571,21 +567,19 @@ void IRMemoryMap::WriteMemory(lldb::addr_t process_address,
 
   switch (allocation.m_policy) {
   default:
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't write: invalid allocation policy");
+    error =
+        Status::FromErrorString("Couldn't write: invalid allocation policy");
     return;
   case eAllocationPolicyHostOnly:
     if (!allocation.m_data.GetByteSize()) {
-      error.SetErrorToGenericError();
-      error.SetErrorString("Couldn't write: data buffer is empty");
+      error = Status::FromErrorString("Couldn't write: data buffer is empty");
       return;
     }
     ::memcpy(allocation.m_data.GetBytes() + offset, bytes, size);
     break;
   case eAllocationPolicyMirror:
     if (!allocation.m_data.GetByteSize()) {
-      error.SetErrorToGenericError();
-      error.SetErrorString("Couldn't write: data buffer is empty");
+      error = Status::FromErrorString("Couldn't write: data buffer is empty");
       return;
     }
     ::memcpy(allocation.m_data.GetBytes() + offset, bytes, size);
@@ -632,13 +626,11 @@ void IRMemoryMap::WriteScalarToMemory(lldb::addr_t process_address,
     if (mem_size > 0) {
       return WriteMemory(process_address, buf, mem_size, error);
     } else {
-      error.SetErrorToGenericError();
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "Couldn't write scalar: failed to get scalar as memory data");
     }
   } else {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't write scalar: its size was zero");
+    error = Status::FromErrorString("Couldn't write scalar: its size was zero");
   }
 }
 
@@ -673,9 +665,9 @@ void IRMemoryMap::ReadMemory(uint8_t *bytes, lldb::addr_t process_address,
       return;
     }
 
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't read: no allocation contains the target "
-                         "range, and neither the process nor the target exist");
+    error = Status::FromErrorString(
+        "Couldn't read: no allocation contains the target "
+        "range, and neither the process nor the target exist");
     return;
   }
 
@@ -684,8 +676,8 @@ void IRMemoryMap::ReadMemory(uint8_t *bytes, lldb::addr_t process_address,
   uint64_t offset = process_address - allocation.m_process_start;
 
   if (offset > allocation.m_size) {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't read: data is not in the allocation");
+    error =
+        Status::FromErrorString("Couldn't read: data is not in the allocation");
     return;
   }
 
@@ -693,18 +685,16 @@ void IRMemoryMap::ReadMemory(uint8_t *bytes, lldb::addr_t process_address,
 
   switch (allocation.m_policy) {
   default:
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't read: invalid allocation policy");
+    error = Status::FromErrorString("Couldn't read: invalid allocation policy");
     return;
   case eAllocationPolicyHostOnly:
     if (!allocation.m_data.GetByteSize()) {
-      error.SetErrorToGenericError();
-      error.SetErrorString("Couldn't read: data buffer is empty");
+      error = Status::FromErrorString("Couldn't read: data buffer is empty");
       return;
     }
     if (allocation.m_data.GetByteSize() < offset + size) {
-      error.SetErrorToGenericError();
-      error.SetErrorString("Couldn't read: not enough underlying data");
+      error =
+          Status::FromErrorString("Couldn't read: not enough underlying data");
       return;
     }
 
@@ -718,8 +708,7 @@ void IRMemoryMap::ReadMemory(uint8_t *bytes, lldb::addr_t process_address,
         return;
     } else {
       if (!allocation.m_data.GetByteSize()) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("Couldn't read: data buffer is empty");
+        error = Status::FromErrorString("Couldn't read: data buffer is empty");
         return;
       }
       ::memcpy(bytes, allocation.m_data.GetBytes() + offset, size);
@@ -765,8 +754,7 @@ void IRMemoryMap::ReadScalarFromMemory(Scalar &scalar,
 
     switch (size) {
     default:
-      error.SetErrorToGenericError();
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't read scalar: unsupported size %" PRIu64, (uint64_t)size);
       return;
     case 1:
@@ -783,8 +771,7 @@ void IRMemoryMap::ReadScalarFromMemory(Scalar &scalar,
       break;
     }
   } else {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't read scalar: its size was zero");
+    error = Status::FromErrorString("Couldn't read scalar: its size was zero");
   }
 }
 
@@ -812,8 +799,7 @@ void IRMemoryMap::GetMemoryData(DataExtractor &extractor,
     AllocationMap::iterator iter = FindAllocation(process_address, size);
 
     if (iter == m_allocations.end()) {
-      error.SetErrorToGenericError();
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't find an allocation containing [0x%" PRIx64 "..0x%" PRIx64
           ")",
           process_address, process_address + size);
@@ -824,21 +810,19 @@ void IRMemoryMap::GetMemoryData(DataExtractor &extractor,
 
     switch (allocation.m_policy) {
     default:
-      error.SetErrorToGenericError();
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "Couldn't get memory data: invalid allocation policy");
       return;
     case eAllocationPolicyProcessOnly:
-      error.SetErrorToGenericError();
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "Couldn't get memory data: memory is only in the target");
       return;
     case eAllocationPolicyMirror: {
       lldb::ProcessSP process_sp = m_process_wp.lock();
 
       if (!allocation.m_data.GetByteSize()) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("Couldn't get memory data: data buffer is empty");
+        error = Status::FromErrorString(
+            "Couldn't get memory data: data buffer is empty");
         return;
       }
       if (process_sp) {
@@ -855,8 +839,8 @@ void IRMemoryMap::GetMemoryData(DataExtractor &extractor,
     } break;
     case eAllocationPolicyHostOnly:
       if (!allocation.m_data.GetByteSize()) {
-        error.SetErrorToGenericError();
-        error.SetErrorString("Couldn't get memory data: data buffer is empty");
+        error = Status::FromErrorString(
+            "Couldn't get memory data: data buffer is empty");
         return;
       }
       uint64_t offset = process_address - allocation.m_process_start;
@@ -865,8 +849,8 @@ void IRMemoryMap::GetMemoryData(DataExtractor &extractor,
       return;
     }
   } else {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't get memory data: its size was zero");
+    error =
+        Status::FromErrorString("Couldn't get memory data: its size was zero");
     return;
   }
 }

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -83,7 +83,7 @@ public:
         IRMemoryMap::eAllocationPolicyMirror, zero_memory, allocate_error);
 
     if (!allocate_error.Success()) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't allocate a memory area to store %s: %s",
           m_persistent_variable_sp->GetName().GetCString(),
           allocate_error.AsCString());
@@ -121,7 +121,7 @@ public:
                     write_error);
 
     if (!write_error.Success()) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't write %s to the target: %s",
           m_persistent_variable_sp->GetName().AsCString(),
           write_error.AsCString());
@@ -140,7 +140,7 @@ public:
     m_persistent_variable_sp->m_live_sp.reset();
 
     if (!deallocate_error.Success()) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't deallocate memory for %s: %s",
           m_persistent_variable_sp->GetName().GetCString(),
           deallocate_error.AsCString());
@@ -185,13 +185,13 @@ public:
           map.GetAddressByteSize(), write_error);
 
       if (!write_error.Success()) {
-        err.SetErrorStringWithFormat(
+        err = Status::FromErrorStringWithFormat(
             "couldn't write the location of %s to memory: %s",
             m_persistent_variable_sp->GetName().AsCString(),
             write_error.AsCString());
       }
     } else {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "no materialization happened for persistent variable %s",
           m_persistent_variable_sp->GetName().AsCString());
       return;
@@ -235,7 +235,7 @@ public:
         map.ReadPointerFromMemory(&location, load_addr, read_error);
 
         if (!read_error.Success()) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "couldn't read the address of program-allocated variable %s: %s",
               m_persistent_variable_sp->GetName().GetCString(),
               read_error.AsCString());
@@ -270,7 +270,7 @@ public:
                              .ULongLong();
 
       if (!m_persistent_variable_sp->m_live_sp) {
-        err.SetErrorStringWithFormat(
+        err = Status::FromErrorStringWithFormat(
             "couldn't find the memory area used to store %s",
             m_persistent_variable_sp->GetName().GetCString());
         return;
@@ -278,7 +278,7 @@ public:
 
       if (m_persistent_variable_sp->m_live_sp->GetValue()
               .GetValueAddressType() != eAddressTypeLoad) {
-        err.SetErrorStringWithFormat(
+        err = Status::FromErrorStringWithFormat(
             "the address of the memory area for %s is in an incorrect format",
             m_persistent_variable_sp->GetName().GetCString());
         return;
@@ -305,7 +305,7 @@ public:
                        read_error);
 
         if (!read_error.Success()) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "couldn't read the contents of %s from memory: %s",
               m_persistent_variable_sp->GetName().GetCString(),
               read_error.AsCString());
@@ -316,7 +316,7 @@ public:
             ~ExpressionVariable::EVNeedsFreezeDry;
       }
     } else {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "no dematerialization happened for persistent variable %s",
           m_persistent_variable_sp->GetName().AsCString());
       return;
@@ -457,7 +457,7 @@ public:
     lldb::ValueObjectSP valobj_sp = SetupValueObject(scope);
 
     if (!valobj_sp) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't get a value object for variable %s", GetName().AsCString());
       return;
     }
@@ -465,9 +465,9 @@ public:
     Status valobj_error = valobj_sp->GetError();
 
     if (valobj_error.Fail()) {
-      err.SetErrorStringWithFormat("couldn't get the value of variable %s: %s",
-                                   GetName().AsCString(),
-                                   valobj_error.AsCString());
+      err = Status::FromErrorStringWithFormat(
+          "couldn't get the value of variable %s: %s", GetName().AsCString(),
+          valobj_error.AsCString());
       return;
     }
 
@@ -477,7 +477,7 @@ public:
       valobj_sp->GetData(valobj_extractor, extract_error);
 
       if (!extract_error.Success()) {
-        err.SetErrorStringWithFormat(
+        err = Status::FromErrorStringWithFormat(
             "couldn't read contents of reference variable %s: %s",
             GetName().AsCString(), extract_error.AsCString());
         return;
@@ -490,10 +490,10 @@ public:
       map.WritePointerToMemory(load_addr, reference_addr, write_error);
 
       if (!write_error.Success()) {
-        err.SetErrorStringWithFormat("couldn't write the contents of reference "
-                                     "variable %s to memory: %s",
-                                     GetName().AsCString(),
-                                     write_error.AsCString());
+        err = Status::FromErrorStringWithFormat(
+            "couldn't write the contents of reference "
+            "variable %s to memory: %s",
+            GetName().AsCString(), write_error.AsCString());
         return;
       }
     } else {
@@ -506,7 +506,7 @@ public:
         map.WritePointerToMemory(load_addr, addr_of_valobj, write_error);
 
         if (!write_error.Success()) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "couldn't write the address of variable %s to memory: %s",
               GetName().AsCString(), write_error.AsCString());
           return;
@@ -516,14 +516,14 @@ public:
         Status extract_error;
         valobj_sp->GetData(data, extract_error);
         if (!extract_error.Success()) {
-          err.SetErrorStringWithFormat("couldn't get the value of %s: %s",
-                                       GetName().AsCString(),
-                                       extract_error.AsCString());
+          err = Status::FromErrorStringWithFormat(
+              "couldn't get the value of %s: %s", GetName().AsCString(),
+              extract_error.AsCString());
           return;
         }
 
         if (m_temporary_allocation != LLDB_INVALID_ADDRESS) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "trying to create a temporary region for %s but one exists",
               GetName().AsCString());
           return;
@@ -531,11 +531,12 @@ public:
 
         if (data.GetByteSize() < GetByteSize(scope)) {
           if (data.GetByteSize() == 0 && !LocationExpressionIsValid()) {
-            err.SetErrorStringWithFormat("the variable '%s' has no location, "
-                                         "it may have been optimized out",
-                                         GetName().AsCString());
+            err = Status::FromErrorStringWithFormat(
+                "the variable '%s' has no location, "
+                "it may have been optimized out",
+                GetName().AsCString());
           } else {
-            err.SetErrorStringWithFormat(
+            err = Status::FromErrorStringWithFormat(
                 "size of variable %s (%" PRIu64
                 ") is larger than the ValueObject's size (%" PRIu64 ")",
                 GetName().AsCString(), GetByteSize(scope).value_or(0),
@@ -546,8 +547,8 @@ public:
 
         std::optional<size_t> opt_bit_align = GetTypeBitAlign(scope);
         if (!opt_bit_align) {
-          err.SetErrorStringWithFormat("can't get the type alignment for %s",
-                                       GetName().AsCString());
+          err = Status::FromErrorStringWithFormat(
+              "can't get the type alignment for %s", GetName().AsCString());
           return;
         }
 
@@ -567,7 +568,7 @@ public:
                                                            data.GetByteSize());
 
         if (!alloc_error.Success()) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "couldn't allocate a temporary region for %s: %s",
               GetName().AsCString(), alloc_error.AsCString());
           return;
@@ -579,7 +580,7 @@ public:
                         data.GetByteSize(), write_error);
 
         if (!write_error.Success()) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "couldn't write to the temporary region for %s: %s",
               GetName().AsCString(), write_error.AsCString());
           return;
@@ -591,7 +592,7 @@ public:
                                  pointer_write_error);
 
         if (!pointer_write_error.Success()) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "couldn't write the address of the temporary region for %s: %s",
               GetName().AsCString(), pointer_write_error.AsCString());
         }
@@ -621,7 +622,7 @@ public:
       lldb::ValueObjectSP valobj_sp = SetupValueObject(scope);
 
       if (!valobj_sp) {
-        err.SetErrorStringWithFormat(
+        err = Status::FromErrorStringWithFormat(
             "couldn't get a value object for variable %s",
             GetName().AsCString());
         return;
@@ -635,8 +636,8 @@ public:
                         valobj_sp->GetByteSize().value_or(0), extract_error);
 
       if (!extract_error.Success()) {
-        err.SetErrorStringWithFormat("couldn't get the data for variable %s",
-                                     GetName().AsCString());
+        err = Status::FromErrorStringWithFormat(
+            "couldn't get the data for variable %s", GetName().AsCString());
         return;
       }
 
@@ -656,7 +657,7 @@ public:
         valobj_sp->SetData(data, set_error);
 
         if (!set_error.Success()) {
-          err.SetErrorStringWithFormat(
+          err = Status::FromErrorStringWithFormat(
               "couldn't write the new contents of %s back into the variable",
               GetName().AsCString());
           return;
@@ -668,7 +669,7 @@ public:
       map.Free(m_temporary_allocation, free_error);
 
       if (!free_error.Success()) {
-        err.SetErrorStringWithFormat(
+        err = Status::FromErrorStringWithFormat(
             "couldn't free the temporary region for %s: %s",
             GetName().AsCString(), free_error.AsCString());
         return;
@@ -924,8 +925,9 @@ public:
                    lldb::addr_t process_address, Status &err) override {
     if (!m_is_program_reference) {
       if (m_temporary_allocation != LLDB_INVALID_ADDRESS) {
-        err.SetErrorString("Trying to create a temporary region for the result "
-                           "but one exists");
+        err = Status::FromErrorString(
+            "Trying to create a temporary region for the result "
+            "but one exists");
         return;
       }
 
@@ -937,15 +939,16 @@ public:
 
       std::optional<uint64_t> byte_size = m_type.GetByteSize(exe_scope);
       if (!byte_size) {
-        err.SetErrorStringWithFormat("can't get size of type \"%s\"",
-                                     m_type.GetTypeName().AsCString());
+        err = Status::FromErrorStringWithFormat(
+            "can't get size of type \"%s\"", m_type.GetTypeName().AsCString());
         return;
       }
 
       std::optional<size_t> opt_bit_align = m_type.GetTypeBitAlign(exe_scope);
       if (!opt_bit_align) {
-        err.SetErrorStringWithFormat("can't get the alignment of type  \"%s\"",
-                                     m_type.GetTypeName().AsCString());
+        err = Status::FromErrorStringWithFormat(
+            "can't get the alignment of type  \"%s\"",
+            m_type.GetTypeName().AsCString());
         return;
       }
 
@@ -961,7 +964,7 @@ public:
       m_temporary_allocation_size = *byte_size;
 
       if (!alloc_error.Success()) {
-        err.SetErrorStringWithFormat(
+        err = Status::FromErrorStringWithFormat(
             "couldn't allocate a temporary region for the result: %s",
             alloc_error.AsCString());
         return;
@@ -973,9 +976,10 @@ public:
                                pointer_write_error);
 
       if (!pointer_write_error.Success()) {
-        err.SetErrorStringWithFormat("couldn't write the address of the "
-                                     "temporary region for the result: %s",
-                                     pointer_write_error.AsCString());
+        err = Status::FromErrorStringWithFormat(
+            "couldn't write the address of the "
+            "temporary region for the result: %s",
+            pointer_write_error.AsCString());
       }
     }
   }
@@ -990,8 +994,9 @@ public:
       exe_scope = map.GetBestExecutionContextScope();
 
     if (!exe_scope) {
-      err.SetErrorString("Couldn't dematerialize a result variable: invalid "
-                         "execution context scope");
+      err = Status::FromErrorString(
+          "Couldn't dematerialize a result variable: invalid "
+          "execution context scope");
       return;
     }
 
@@ -1002,15 +1007,17 @@ public:
     map.ReadPointerFromMemory(&address, load_addr, read_error);
 
     if (!read_error.Success()) {
-      err.SetErrorString("Couldn't dematerialize a result variable: couldn't "
-                         "read its address");
+      err = Status::FromErrorString(
+          "Couldn't dematerialize a result variable: couldn't "
+          "read its address");
       return;
     }
 
     lldb::TargetSP target_sp = exe_scope->CalculateTarget();
 
     if (!target_sp) {
-      err.SetErrorString("Couldn't dematerialize a result variable: no target");
+      err = Status::FromErrorString(
+          "Couldn't dematerialize a result variable: no target");
       return;
     }
 
@@ -1018,26 +1025,29 @@ public:
         target_sp->GetScratchTypeSystemForLanguage(m_type.GetMinimumLanguage());
 
     if (auto error = type_system_or_err.takeError()) {
-      err.SetErrorStringWithFormat("Couldn't dematerialize a result variable: "
-                                   "couldn't get the corresponding type "
-                                   "system: %s",
-                                   llvm::toString(std::move(error)).c_str());
+      err = Status::FromErrorStringWithFormat(
+          "Couldn't dematerialize a result variable: "
+          "couldn't get the corresponding type "
+          "system: %s",
+          llvm::toString(std::move(error)).c_str());
       return;
     }
     auto ts = *type_system_or_err;
     if (!ts) {
-      err.SetErrorStringWithFormat("Couldn't dematerialize a result variable: "
-                                   "couldn't corresponding type system is "
-                                   "no longer live.");
+      err = Status::FromErrorStringWithFormat(
+          "Couldn't dematerialize a result variable: "
+          "couldn't corresponding type system is "
+          "no longer live.");
       return;
     }
     PersistentExpressionState *persistent_state =
         ts->GetPersistentExpressionState();
 
     if (!persistent_state) {
-      err.SetErrorString("Couldn't dematerialize a result variable: "
-                         "corresponding type system doesn't handle persistent "
-                         "variables");
+      err = Status::FromErrorString(
+          "Couldn't dematerialize a result variable: "
+          "corresponding type system doesn't handle persistent "
+          "variables");
       return;
     }
 
@@ -1049,9 +1059,10 @@ public:
         exe_scope, name, m_type, map.GetByteOrder(), map.GetAddressByteSize());
 
     if (!ret) {
-      err.SetErrorStringWithFormat("couldn't dematerialize a result variable: "
-                                   "failed to make persistent variable %s",
-                                   name.AsCString());
+      err = Status::FromErrorStringWithFormat(
+          "couldn't dematerialize a result variable: "
+          "failed to make persistent variable %s",
+          name.AsCString());
       return;
     }
 
@@ -1080,7 +1091,7 @@ public:
     map.ReadMemory(pvar_data, address, pvar_byte_size, read_error);
 
     if (!read_error.Success()) {
-      err.SetErrorString(
+      err = Status::FromErrorString(
           "Couldn't dematerialize a result variable: couldn't read its memory");
       return;
     }
@@ -1230,7 +1241,7 @@ public:
       target_sp = map.GetBestExecutionContextScope()->CalculateTarget();
 
     if (!target_sp) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't resolve symbol %s because there is no target",
           m_symbol.GetName().AsCString());
       return;
@@ -1246,7 +1257,7 @@ public:
     map.WritePointerToMemory(load_addr, resolved_address, pointer_write_error);
 
     if (!pointer_write_error.Success()) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't write the address of symbol %s: %s",
           m_symbol.GetName().AsCString(), pointer_write_error.AsCString());
       return;
@@ -1340,7 +1351,7 @@ public:
     RegisterValue reg_value;
 
     if (!frame_sp.get()) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't materialize register %s without a stack frame",
           m_register_info.name);
       return;
@@ -1349,21 +1360,21 @@ public:
     lldb::RegisterContextSP reg_context_sp = frame_sp->GetRegisterContext();
 
     if (!reg_context_sp->ReadRegister(&m_register_info, reg_value)) {
-      err.SetErrorStringWithFormat("couldn't read the value of register %s",
-                                   m_register_info.name);
+      err = Status::FromErrorStringWithFormat(
+          "couldn't read the value of register %s", m_register_info.name);
       return;
     }
 
     DataExtractor register_data;
 
     if (!reg_value.GetData(register_data)) {
-      err.SetErrorStringWithFormat("couldn't get the data for register %s",
-                                   m_register_info.name);
+      err = Status::FromErrorStringWithFormat(
+          "couldn't get the data for register %s", m_register_info.name);
       return;
     }
 
     if (register_data.GetByteSize() != m_register_info.byte_size) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "data for register %s had size %llu but we expected %llu",
           m_register_info.name, (unsigned long long)register_data.GetByteSize(),
           (unsigned long long)m_register_info.byte_size);
@@ -1379,7 +1390,7 @@ public:
                     register_data.GetByteSize(), write_error);
 
     if (!write_error.Success()) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't write the contents of register %s: %s",
           m_register_info.name, write_error.AsCString());
       return;
@@ -1405,7 +1416,7 @@ public:
     DataExtractor register_data;
 
     if (!frame_sp.get()) {
-      err.SetErrorStringWithFormat(
+      err = Status::FromErrorStringWithFormat(
           "couldn't dematerialize register %s without a stack frame",
           m_register_info.name);
       return;
@@ -1417,9 +1428,9 @@ public:
                       extract_error);
 
     if (!extract_error.Success()) {
-      err.SetErrorStringWithFormat("couldn't get the data for register %s: %s",
-                                   m_register_info.name,
-                                   extract_error.AsCString());
+      err = Status::FromErrorStringWithFormat(
+          "couldn't get the data for register %s: %s", m_register_info.name,
+          extract_error.AsCString());
       return;
     }
 
@@ -1438,8 +1449,8 @@ public:
                                  register_data.GetByteOrder());
 
     if (!reg_context_sp->WriteRegister(&m_register_info, register_value)) {
-      err.SetErrorStringWithFormat("couldn't write the value of register %s",
-                                   m_register_info.name);
+      err = Status::FromErrorStringWithFormat(
+          "couldn't write the value of register %s", m_register_info.name);
       return;
     }
   }
@@ -1508,16 +1519,16 @@ Materializer::Materialize(lldb::StackFrameSP &frame_sp, IRMemoryMap &map,
   DematerializerSP dematerializer_sp = m_dematerializer_wp.lock();
 
   if (dematerializer_sp) {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't materialize: already materialized");
+    error =
+        Status::FromErrorString("Couldn't materialize: already materialized");
   }
 
   DematerializerSP ret(
       new Dematerializer(*this, frame_sp, map, process_address));
 
   if (!exe_scope) {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't materialize: target doesn't exist");
+    error =
+        Status::FromErrorString("Couldn't materialize: target doesn't exist");
   }
 
   for (EntityUP &entity_up : m_entities) {
@@ -1556,13 +1567,12 @@ void Materializer::Dematerializer::Dematerialize(Status &error,
     exe_scope = m_map->GetBestExecutionContextScope();
 
   if (!IsValid()) {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't dematerialize: invalid dematerializer");
+    error = Status::FromErrorString(
+        "Couldn't dematerialize: invalid dematerializer");
   }
 
   if (!exe_scope) {
-    error.SetErrorToGenericError();
-    error.SetErrorString("Couldn't dematerialize: target is gone");
+    error = Status::FromErrorString("Couldn't dematerialize: target is gone");
   } else {
     if (Log *log = GetLog(LLDBLog::Expressions)) {
       LLDB_LOGF(log,

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -102,7 +102,7 @@ lldb::ValueObjectSP UserExpression::GetObjectPointerValueObject(
   err.Clear();
 
   if (!frame_sp) {
-    err.SetErrorStringWithFormatv(
+    err = Status::FromErrorStringWithFormatv(
         "Couldn't load '{0}' because the context is incomplete", object_name);
     return {};
   }
@@ -131,7 +131,7 @@ lldb::addr_t UserExpression::GetObjectPointer(lldb::StackFrameSP frame_sp,
   lldb::addr_t ret = valobj_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
 
   if (ret == LLDB_INVALID_ADDRESS) {
-    err.SetErrorStringWithFormatv(
+    err = Status::FromErrorStringWithFormatv(
         "Couldn't load '{0}' because its value couldn't be evaluated",
         object_name);
     return LLDB_INVALID_ADDRESS;
@@ -155,7 +155,8 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
     if (!(ctx_obj->GetTypeInfo() & ctx_type_mask)) {
       LLDB_LOG(log, "== [UserExpression::Evaluate] Passed a context object of "
                     "an invalid type, can't run expressions.");
-      error.SetErrorString("a context object of an invalid type passed");
+      error =
+          Status::FromErrorString("a context object of an invalid type passed");
       return lldb::eExpressionSetupError;
     }
   }
@@ -167,7 +168,7 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
       LLDB_LOG(log, "== [UserExpression::Evaluate] Passed a context object of "
                     "a reference type that can't be dereferenced, can't run "
                     "expressions.");
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "passed context object of an reference type cannot be deferenced");
       return lldb::eExpressionSetupError;
     }
@@ -186,7 +187,7 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
   if (!target) {
     LLDB_LOG(log, "== [UserExpression::Evaluate] Passed a NULL target, can't "
                   "run expressions.");
-    error.SetErrorString("expression passed a null target");
+    error = Status::FromErrorString("expression passed a null target");
     return lldb::eExpressionSetupError;
   }
 
@@ -196,7 +197,8 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
     LLDB_LOG(log, "== [UserExpression::Evaluate] No process, but the policy is "
                   "eExecutionPolicyAlways");
 
-    error.SetErrorString("expression needed to run but couldn't: no process");
+    error = Status::FromErrorString(
+        "expression needed to run but couldn't: no process");
 
     return execution_results;
   }
@@ -204,7 +206,7 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
   // Since we might need to allocate memory, we need to be stopped to run
   // an expression.
   if (process != nullptr && process->GetState() != lldb::eStateStopped) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "unable to evaluate expression while the process is {0}: the process "
         "must be stopped because the expression might require allocating "
         "memory.",
@@ -266,7 +268,8 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
   const bool generate_debug_info = options.GetGenerateDebugInfo();
 
   if (options.InvokeCancelCallback(lldb::eExpressionEvaluationParse)) {
-    error.SetErrorString("expression interrupted by callback before parse");
+    error = Status::FromErrorString(
+        "expression interrupted by callback before parse");
     result_valobj_sp = ValueObjectConstResult::Create(
         exe_ctx.GetBestExecutionContextScope(), error);
     return lldb::eExpressionInterrupted;
@@ -336,7 +339,7 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
             !fixed_expression->empty())
           os << "\nfixed expression suggested:\n  " << *fixed_expression;
       }
-      error.SetExpressionError(execution_results, msg.c_str());
+      error = Status::FromExpressionError(execution_results, msg);
     }
   }
 
@@ -349,14 +352,15 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
                     "is not constant ==");
 
       if (!diagnostic_manager.Diagnostics().size())
-        error.SetExpressionError(lldb::eExpressionSetupError,
-                                 "expression needed to run but couldn't");
+        error = Status::FromExpressionError(
+            lldb::eExpressionSetupError,
+            "expression needed to run but couldn't");
     } else if (execution_policy == eExecutionPolicyTopLevel) {
-      error.SetError(UserExpression::kNoResult, lldb::eErrorTypeGeneric);
+      error = Status(UserExpression::kNoResult, lldb::eErrorTypeGeneric);
       return lldb::eExpressionCompleted;
     } else {
       if (options.InvokeCancelCallback(lldb::eExpressionEvaluationExecution)) {
-        error.SetExpressionError(
+        error = Status::FromExpressionError(
             lldb::eExpressionInterrupted,
             "expression interrupted by callback before execution");
         result_valobj_sp = ValueObjectConstResult::Create(
@@ -377,11 +381,11 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
                       "abnormally ==");
 
         if (!diagnostic_manager.Diagnostics().size())
-          error.SetExpressionError(
+          error = Status::FromExpressionError(
               execution_results, "expression failed to execute, unknown error");
         else
-          error.SetExpressionError(execution_results,
-                                   diagnostic_manager.GetString().c_str());
+          error = Status::FromExpressionError(execution_results,
+                                              diagnostic_manager.GetString());
       } else {
         if (expr_result) {
           result_valobj_sp = expr_result->GetValueObject();
@@ -396,14 +400,14 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
           LLDB_LOG(log, "== [UserExpression::Evaluate] Execution completed "
                         "normally with no result ==");
 
-          error.SetError(UserExpression::kNoResult, lldb::eErrorTypeGeneric);
+          error = Status(UserExpression::kNoResult, lldb::eErrorTypeGeneric);
         }
       }
     }
   }
 
   if (options.InvokeCancelCallback(lldb::eExpressionEvaluationComplete)) {
-    error.SetExpressionError(
+    error = Status::FromExpressionError(
         lldb::eExpressionInterrupted,
         "expression interrupted by callback after complete");
     return lldb::eExpressionInterrupted;

--- a/lldb/source/Expression/UtilityFunction.cpp
+++ b/lldb/source/Expression/UtilityFunction.cpp
@@ -61,13 +61,14 @@ FunctionCaller *UtilityFunction::MakeFunctionCaller(
 
   ProcessSP process_sp = m_jit_process_wp.lock();
   if (!process_sp) {
-    error.SetErrorString("Can't make a function caller without a process.");
+    error = Status::FromErrorString(
+        "Can't make a function caller without a process.");
     return nullptr;
   }
   // Since we might need to allocate memory and maybe call code to make
   // the caller, we need to be stopped.
   if (process_sp->GetState() != lldb::eStateStopped) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "Can't make a function caller while the process is {0}: the process "
         "must be stopped to allocate memory.",
         StateAsCString(process_sp->GetState()));
@@ -92,7 +93,7 @@ FunctionCaller *UtilityFunction::MakeFunctionCaller(
     unsigned num_errors =
         m_caller_up->CompileFunction(thread_to_use_sp, diagnostics);
     if (num_errors) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Error compiling %s caller function: \"%s\".",
           m_function_name.c_str(), diagnostics.GetString().c_str());
       m_caller_up.reset();
@@ -103,7 +104,7 @@ FunctionCaller *UtilityFunction::MakeFunctionCaller(
     ExecutionContext exe_ctx(process_sp);
 
     if (!m_caller_up->WriteFunctionWrapper(exe_ctx, diagnostics)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Error inserting caller function for %s: \"%s\".",
           m_function_name.c_str(), diagnostics.GetString().c_str());
       m_caller_up.reset();

--- a/lldb/source/Host/common/File.cpp
+++ b/lldb/source/Host/common/File.cpp
@@ -240,7 +240,7 @@ uint32_t File::GetPermissions(Status &error) const {
   }
   struct stat file_stats;
   if (::fstat(fd, &file_stats) == -1) {
-    error.SetErrorToErrno();
+    error = Status::FromErrno();
     return 0;
   }
   error.Clear();
@@ -320,7 +320,7 @@ Status NativeFile::Close() {
   if (StreamIsValidUnlocked()) {
     if (m_own_stream) {
       if (::fclose(m_stream) == EOF)
-        error.SetErrorToErrno();
+        error = Status::FromErrno();
     } else {
       File::OpenOptions rw =
           m_options & (File::eOpenOptionReadOnly | File::eOpenOptionWriteOnly |
@@ -328,14 +328,14 @@ Status NativeFile::Close() {
 
       if (rw == eOpenOptionWriteOnly || rw == eOpenOptionReadWrite) {
         if (::fflush(m_stream) == EOF)
-          error.SetErrorToErrno();
+          error = Status::FromErrno();
       }
     }
   }
 
   if (DescriptorIsValidUnlocked() && m_own_descriptor) {
     if (::close(m_descriptor) != 0)
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
   }
 
   m_stream = kInvalidStream;
@@ -354,28 +354,28 @@ Status NativeFile::GetFileSpec(FileSpec &file_spec) const {
   if (IsValid()) {
     char path[PATH_MAX];
     if (::fcntl(GetDescriptor(), F_GETPATH, path) == -1)
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
     else
       file_spec.SetFile(path, FileSpec::Style::native);
   } else {
-    error.SetErrorString("invalid file handle");
+    error = Status::FromErrorString("invalid file handle");
   }
 #elif defined(__linux__)
   char proc[64];
   char path[PATH_MAX];
   if (::snprintf(proc, sizeof(proc), "/proc/self/fd/%d", GetDescriptor()) < 0)
-    error.SetErrorString("cannot resolve file descriptor");
+    error = Status::FromErrorString("cannot resolve file descriptor");
   else {
     ssize_t len;
     if ((len = ::readlink(proc, path, sizeof(path) - 1)) == -1)
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
     else {
       path[len] = '\0';
       file_spec.SetFile(path, FileSpec::Style::native);
     }
   }
 #else
-  error.SetErrorString(
+  error = Status::FromErrorString(
       "NativeFile::GetFileSpec is not supported on this platform");
 #endif
 
@@ -391,7 +391,7 @@ off_t NativeFile::SeekFromStart(off_t offset, Status *error_ptr) {
 
     if (error_ptr) {
       if (result == -1)
-        error_ptr->SetErrorToErrno();
+        *error_ptr = Status::FromErrno();
       else
         error_ptr->Clear();
     }
@@ -403,7 +403,7 @@ off_t NativeFile::SeekFromStart(off_t offset, Status *error_ptr) {
 
     if (error_ptr) {
       if (result == -1)
-        error_ptr->SetErrorToErrno();
+        *error_ptr = Status::FromErrno();
       else
         error_ptr->Clear();
     }
@@ -411,7 +411,7 @@ off_t NativeFile::SeekFromStart(off_t offset, Status *error_ptr) {
   }
 
   if (error_ptr)
-    error_ptr->SetErrorString("invalid file handle");
+    *error_ptr = Status::FromErrorString("invalid file handle");
   return result;
 }
 
@@ -422,7 +422,7 @@ off_t NativeFile::SeekFromCurrent(off_t offset, Status *error_ptr) {
 
     if (error_ptr) {
       if (result == -1)
-        error_ptr->SetErrorToErrno();
+        *error_ptr = Status::FromErrno();
       else
         error_ptr->Clear();
     }
@@ -434,7 +434,7 @@ off_t NativeFile::SeekFromCurrent(off_t offset, Status *error_ptr) {
 
     if (error_ptr) {
       if (result == -1)
-        error_ptr->SetErrorToErrno();
+        *error_ptr = Status::FromErrno();
       else
         error_ptr->Clear();
     }
@@ -442,7 +442,7 @@ off_t NativeFile::SeekFromCurrent(off_t offset, Status *error_ptr) {
   }
 
   if (error_ptr)
-    error_ptr->SetErrorString("invalid file handle");
+    *error_ptr = Status::FromErrorString("invalid file handle");
   return result;
 }
 
@@ -453,7 +453,7 @@ off_t NativeFile::SeekFromEnd(off_t offset, Status *error_ptr) {
 
     if (error_ptr) {
       if (result == -1)
-        error_ptr->SetErrorToErrno();
+        *error_ptr = Status::FromErrno();
       else
         error_ptr->Clear();
     }
@@ -465,14 +465,14 @@ off_t NativeFile::SeekFromEnd(off_t offset, Status *error_ptr) {
 
     if (error_ptr) {
       if (result == -1)
-        error_ptr->SetErrorToErrno();
+        *error_ptr = Status::FromErrno();
       else
         error_ptr->Clear();
     }
   }
 
   if (error_ptr)
-    error_ptr->SetErrorString("invalid file handle");
+    *error_ptr = Status::FromErrorString("invalid file handle");
   return result;
 }
 
@@ -480,14 +480,14 @@ Status NativeFile::Flush() {
   Status error;
   if (ValueGuard stream_guard = StreamIsValid()) {
     if (llvm::sys::RetryAfterSignal(EOF, ::fflush, m_stream) == EOF)
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
     return error;
   }
 
   {
     ValueGuard descriptor_guard = DescriptorIsValid();
     if (!descriptor_guard)
-      error.SetErrorString("invalid file handle");
+      error = Status::FromErrorString("invalid file handle");
   }
   return error;
 }
@@ -501,10 +501,10 @@ Status NativeFile::Sync() {
       error.SetErrorToGenericError();
 #else
     if (llvm::sys::RetryAfterSignal(-1, ::fsync, m_descriptor) == -1)
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
 #endif
   } else {
-    error.SetErrorString("invalid file handle");
+    error = Status::FromErrorString("invalid file handle");
   }
   return error;
 }
@@ -553,7 +553,7 @@ Status NativeFile::Read(void *buf, size_t &num_bytes) {
     bytes_read =
         llvm::sys::RetryAfterSignal(-1, ::read, m_descriptor, buf, num_bytes);
     if (bytes_read == -1) {
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
       num_bytes = 0;
     } else
       num_bytes = bytes_read;
@@ -565,9 +565,9 @@ Status NativeFile::Read(void *buf, size_t &num_bytes) {
 
     if (bytes_read == 0) {
       if (::feof(m_stream))
-        error.SetErrorString("feof");
+        error = Status::FromErrorString("feof");
       else if (::ferror(m_stream))
-        error.SetErrorString("ferror");
+        error = Status::FromErrorString("ferror");
       num_bytes = 0;
     } else
       num_bytes = bytes_read;
@@ -575,7 +575,7 @@ Status NativeFile::Read(void *buf, size_t &num_bytes) {
   }
 
   num_bytes = 0;
-  error.SetErrorString("invalid file handle");
+  error = Status::FromErrorString("invalid file handle");
   return error;
 }
 
@@ -617,7 +617,7 @@ Status NativeFile::Write(const void *buf, size_t &num_bytes) {
     bytes_written =
         llvm::sys::RetryAfterSignal(-1, ::write, m_descriptor, buf, num_bytes);
     if (bytes_written == -1) {
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
       num_bytes = 0;
     } else
       num_bytes = bytes_written;
@@ -629,9 +629,9 @@ Status NativeFile::Write(const void *buf, size_t &num_bytes) {
 
     if (bytes_written == 0) {
       if (::feof(m_stream))
-        error.SetErrorString("feof");
+        error = Status::FromErrorString("feof");
       else if (::ferror(m_stream))
-        error.SetErrorString("ferror");
+        error = Status::FromErrorString("ferror");
       num_bytes = 0;
     } else
       num_bytes = bytes_written;
@@ -639,7 +639,7 @@ Status NativeFile::Write(const void *buf, size_t &num_bytes) {
   }
 
   num_bytes = 0;
-  error.SetErrorString("invalid file handle");
+  error = Status::FromErrorString("invalid file handle");
   return error;
 }
 
@@ -683,14 +683,14 @@ Status NativeFile::Read(void *buf, size_t &num_bytes, off_t &offset) {
         llvm::sys::RetryAfterSignal(-1, ::pread, fd, buf, num_bytes, offset);
     if (bytes_read < 0) {
       num_bytes = 0;
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
     } else {
       offset += bytes_read;
       num_bytes = bytes_read;
     }
   } else {
     num_bytes = 0;
-    error.SetErrorString("invalid file handle");
+    error = Status::FromErrorString("invalid file handle");
   }
 #else
   std::lock_guard<std::mutex> guard(offset_access_mutex);
@@ -743,7 +743,7 @@ Status NativeFile::Write(const void *buf, size_t &num_bytes, off_t &offset) {
         llvm::sys::RetryAfterSignal(-1, ::pwrite, m_descriptor, buf, num_bytes, offset);
     if (bytes_written < 0) {
       num_bytes = 0;
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
     } else {
       offset += bytes_written;
       num_bytes = bytes_written;
@@ -762,7 +762,7 @@ Status NativeFile::Write(const void *buf, size_t &num_bytes, off_t &offset) {
 #endif
   } else {
     num_bytes = 0;
-    error.SetErrorString("invalid file handle");
+    error = Status::FromErrorString("invalid file handle");
   }
   return error;
 }

--- a/lldb/source/Host/common/FileCache.cpp
+++ b/lldb/source/Host/common/FileCache.cpp
@@ -27,7 +27,7 @@ lldb::user_id_t FileCache::OpenFile(const FileSpec &file_spec,
                                     File::OpenOptions flags, uint32_t mode,
                                     Status &error) {
   if (!file_spec) {
-    error.SetErrorString("empty path");
+    error = Status::FromErrorString("empty path");
     return UINT64_MAX;
   }
   auto file = FileSystem::Instance().Open(file_spec, flags, mode);
@@ -42,17 +42,18 @@ lldb::user_id_t FileCache::OpenFile(const FileSpec &file_spec,
 
 bool FileCache::CloseFile(lldb::user_id_t fd, Status &error) {
   if (fd == UINT64_MAX) {
-    error.SetErrorString("invalid file descriptor");
+    error = Status::FromErrorString("invalid file descriptor");
     return false;
   }
   FDToFileMap::iterator pos = m_cache.find(fd);
   if (pos == m_cache.end()) {
-    error.SetErrorStringWithFormat("invalid host file descriptor %" PRIu64, fd);
+    error = Status::FromErrorStringWithFormat(
+        "invalid host file descriptor %" PRIu64, fd);
     return false;
   }
   FileUP &file_up = pos->second;
   if (!file_up) {
-    error.SetErrorString("invalid host backing file");
+    error = Status::FromErrorString("invalid host backing file");
     return false;
   }
   error = file_up->Close();
@@ -64,17 +65,18 @@ uint64_t FileCache::WriteFile(lldb::user_id_t fd, uint64_t offset,
                               const void *src, uint64_t src_len,
                               Status &error) {
   if (fd == UINT64_MAX) {
-    error.SetErrorString("invalid file descriptor");
+    error = Status::FromErrorString("invalid file descriptor");
     return UINT64_MAX;
   }
   FDToFileMap::iterator pos = m_cache.find(fd);
   if (pos == m_cache.end()) {
-    error.SetErrorStringWithFormat("invalid host file descriptor %" PRIu64, fd);
+    error = Status::FromErrorStringWithFormat(
+        "invalid host file descriptor %" PRIu64, fd);
     return false;
   }
   FileUP &file_up = pos->second;
   if (!file_up) {
-    error.SetErrorString("invalid host backing file");
+    error = Status::FromErrorString("invalid host backing file");
     return UINT64_MAX;
   }
   if (static_cast<uint64_t>(file_up->SeekFromStart(offset, &error)) != offset ||
@@ -90,17 +92,18 @@ uint64_t FileCache::WriteFile(lldb::user_id_t fd, uint64_t offset,
 uint64_t FileCache::ReadFile(lldb::user_id_t fd, uint64_t offset, void *dst,
                              uint64_t dst_len, Status &error) {
   if (fd == UINT64_MAX) {
-    error.SetErrorString("invalid file descriptor");
+    error = Status::FromErrorString("invalid file descriptor");
     return UINT64_MAX;
   }
   FDToFileMap::iterator pos = m_cache.find(fd);
   if (pos == m_cache.end()) {
-    error.SetErrorStringWithFormat("invalid host file descriptor %" PRIu64, fd);
+    error = Status::FromErrorStringWithFormat(
+        "invalid host file descriptor %" PRIu64, fd);
     return false;
   }
   FileUP &file_up = pos->second;
   if (!file_up) {
-    error.SetErrorString("invalid host backing file");
+    error = Status::FromErrorString("invalid host backing file");
     return UINT64_MAX;
   }
   if (static_cast<uint64_t>(file_up->SeekFromStart(offset, &error)) != offset ||

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -501,11 +501,12 @@ Status Host::RunShellCommand(llvm::StringRef shell_path, const Args &args,
   const lldb::pid_t pid = launch_info.GetProcessID();
 
   if (error.Success() && pid == LLDB_INVALID_PROCESS_ID)
-    error.SetErrorString("failed to get process ID");
+    error = Status::FromErrorString("failed to get process ID");
 
   if (error.Success()) {
     if (!shell_info_sp->process_reaped.WaitForValueEqualTo(true, timeout)) {
-      error.SetErrorString("timed out waiting for shell command to complete");
+      error = Status::FromErrorString(
+          "timed out waiting for shell command to complete");
 
       // Kill the process since it didn't complete within the timeout specified
       Kill(pid, SIGKILL);
@@ -525,7 +526,7 @@ Status Host::RunShellCommand(llvm::StringRef shell_path, const Args &args,
             FileSystem::Instance().GetByteSize(output_file_spec);
         if (file_size > 0) {
           if (file_size > command_output_ptr->max_size()) {
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "shell command output is too large to fit into a std::string");
           } else {
             WritableDataBufferSP Buffer =

--- a/lldb/source/Host/common/LockFileBase.cpp
+++ b/lldb/source/Host/common/LockFileBase.cpp
@@ -11,9 +11,11 @@
 using namespace lldb;
 using namespace lldb_private;
 
-static Status AlreadyLocked() { return Status("Already locked"); }
+static Status AlreadyLocked() {
+  return Status::FromErrorString("Already locked");
+}
 
-static Status NotLocked() { return Status("Not locked"); }
+static Status NotLocked() { return Status::FromErrorString("Not locked"); }
 
 LockFileBase::LockFileBase(int fd)
     : m_fd(fd), m_locked(false), m_start(0), m_len(0) {}
@@ -62,7 +64,7 @@ bool LockFileBase::IsValidFile() const { return m_fd != -1; }
 Status LockFileBase::DoLock(const Locker &locker, const uint64_t start,
                             const uint64_t len) {
   if (!IsValidFile())
-    return Status("File is invalid");
+    return Status::FromErrorString("File is invalid");
 
   if (IsLocked())
     return AlreadyLocked();

--- a/lldb/source/Host/common/MonitoringProcessLauncher.cpp
+++ b/lldb/source/Host/common/MonitoringProcessLauncher.cpp
@@ -39,8 +39,8 @@ MonitoringProcessLauncher::LaunchProcess(const ProcessLaunchInfo &launch_info,
     FileSystem::Instance().ResolveExecutableLocation(exe_spec);
 
   if (!fs.Exists(exe_spec)) {
-    error.SetErrorStringWithFormatv("executable doesn't exist: '{0}'",
-                                    exe_spec);
+    error = Status::FromErrorStringWithFormatv(
+        "executable doesn't exist: '{0}'", exe_spec);
     return HostProcess();
   }
 
@@ -57,14 +57,16 @@ MonitoringProcessLauncher::LaunchProcess(const ProcessLaunchInfo &launch_info,
     llvm::Expected<HostThread> maybe_thread =
         process.StartMonitoring(launch_info.GetMonitorProcessCallback());
     if (!maybe_thread)
-      error.SetErrorStringWithFormatv("failed to launch host thread: {}",
-                                      llvm::toString(maybe_thread.takeError()));
+      error = Status::FromErrorStringWithFormatv(
+          "failed to launch host thread: {}",
+          llvm::toString(maybe_thread.takeError()));
     if (log)
       log->PutCString("started monitoring child process.");
   } else {
     // Invalid process ID, something didn't go well
     if (error.Success())
-      error.SetErrorString("process launch failed for unknown reasons");
+      error =
+          Status::FromErrorString("process launch failed for unknown reasons");
   }
   return process;
 }

--- a/lldb/source/Host/common/NativeProcessProtocol.cpp
+++ b/lldb/source/Host/common/NativeProcessProtocol.cpp
@@ -34,7 +34,7 @@ NativeProcessProtocol::NativeProcessProtocol(lldb::pid_t pid, int terminal_fd,
 lldb_private::Status NativeProcessProtocol::Interrupt() {
   Status error;
 #if !defined(SIGSTOP)
-  error.SetErrorString("local host does not support signaling");
+  error = Status::FromErrorString("local host does not support signaling");
   return error;
 #else
   return Signal(SIGSTOP);
@@ -51,20 +51,20 @@ lldb_private::Status
 NativeProcessProtocol::GetMemoryRegionInfo(lldb::addr_t load_addr,
                                            MemoryRegionInfo &range_info) {
   // Default: not implemented.
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 lldb_private::Status
 NativeProcessProtocol::ReadMemoryTags(int32_t type, lldb::addr_t addr,
                                       size_t len, std::vector<uint8_t> &tags) {
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 lldb_private::Status
 NativeProcessProtocol::WriteMemoryTags(int32_t type, lldb::addr_t addr,
                                        size_t len,
                                        const std::vector<uint8_t> &tags) {
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 std::optional<WaitStatus> NativeProcessProtocol::GetExitStatus() {
@@ -248,7 +248,8 @@ Status NativeProcessProtocol::SetHardwareBreakpoint(lldb::addr_t addr,
 
   if (hw_debug_cap == std::nullopt || hw_debug_cap->first == 0 ||
       hw_debug_cap->first <= m_hw_breakpoints_map.size())
-    return Status("Target does not have required no of hardware breakpoints");
+    return Status::FromErrorString(
+        "Target does not have required no of hardware breakpoints");
 
   // Vector below stores all thread pointer for which we have we successfully
   // set this hardware breakpoint. If any of the current process threads fails
@@ -360,7 +361,7 @@ Status NativeProcessProtocol::RemoveSoftwareBreakpoint(lldb::addr_t addr) {
   LLDB_LOG(log, "addr = {0:x}", addr);
   auto it = m_software_breakpoints.find(addr);
   if (it == m_software_breakpoints.end())
-    return Status("Breakpoint not found.");
+    return Status::FromErrorString("Breakpoint not found.");
   assert(it->second.ref_count > 0);
   if (--it->second.ref_count > 0)
     return Status();
@@ -377,15 +378,16 @@ Status NativeProcessProtocol::RemoveSoftwareBreakpoint(lldb::addr_t addr) {
   error =
       ReadMemory(addr, curr_break_op.data(), curr_break_op.size(), bytes_read);
   if (error.Fail() || bytes_read < curr_break_op.size()) {
-    return Status("addr=0x%" PRIx64
-                  ": tried to read %zu bytes but only read %zu",
-                  addr, curr_break_op.size(), bytes_read);
+    return Status::FromErrorStringWithFormat(
+        "addr=0x%" PRIx64 ": tried to read %zu bytes but only read %zu", addr,
+        curr_break_op.size(), bytes_read);
   }
   const auto &saved = it->second.saved_opcodes;
   // Make sure the breakpoint opcode exists at this address
   if (llvm::ArrayRef(curr_break_op) != it->second.breakpoint_opcodes) {
     if (curr_break_op != it->second.saved_opcodes)
-      return Status("Original breakpoint trap is no longer in memory.");
+      return Status::FromErrorString(
+          "Original breakpoint trap is no longer in memory.");
     LLDB_LOG(log,
              "Saved opcodes ({0:@[x]}) have already been restored at {1:x}.",
              llvm::make_range(saved.begin(), saved.end()), addr);
@@ -395,9 +397,9 @@ Status NativeProcessProtocol::RemoveSoftwareBreakpoint(lldb::addr_t addr) {
     size_t bytes_written = 0;
     error = WriteMemory(addr, saved.data(), saved.size(), bytes_written);
     if (error.Fail() || bytes_written < saved.size()) {
-      return Status("addr=0x%" PRIx64
-                    ": tried to write %zu bytes but only wrote %zu",
-                    addr, saved.size(), bytes_written);
+      return Status::FromErrorStringWithFormat(
+          "addr=0x%" PRIx64 ": tried to write %zu bytes but only wrote %zu",
+          addr, saved.size(), bytes_written);
     }
 
     // Verify that our original opcode made it back to the inferior
@@ -406,9 +408,10 @@ Status NativeProcessProtocol::RemoveSoftwareBreakpoint(lldb::addr_t addr) {
     error = ReadMemory(addr, verify_opcode.data(), verify_opcode.size(),
                        verify_bytes_read);
     if (error.Fail() || verify_bytes_read < verify_opcode.size()) {
-      return Status("addr=0x%" PRIx64
-                    ": tried to read %zu verification bytes but only read %zu",
-                    addr, verify_opcode.size(), verify_bytes_read);
+      return Status::FromErrorStringWithFormat(
+          "addr=0x%" PRIx64
+          ": tried to read %zu verification bytes but only read %zu",
+          addr, verify_opcode.size(), verify_bytes_read);
     }
     if (verify_opcode != saved)
       LLDB_LOG(log, "Restoring bytes at {0:x}: {1:@[x]}", addr,

--- a/lldb/source/Host/common/NativeRegisterContext.cpp
+++ b/lldb/source/Host/common/NativeRegisterContext.cpp
@@ -216,7 +216,7 @@ NativeRegisterContext::ReadRegisterAsUnsigned(const RegisterInfo *reg_info,
 Status NativeRegisterContext::WriteRegisterFromUnsigned(uint32_t reg,
                                                         uint64_t uval) {
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("Write register failed: reg is invalid");
+    return Status::FromErrorString("Write register failed: reg is invalid");
   return WriteRegisterFromUnsigned(GetRegisterInfoAtIndex(reg), uval);
 }
 
@@ -225,11 +225,11 @@ NativeRegisterContext::WriteRegisterFromUnsigned(const RegisterInfo *reg_info,
                                                  uint64_t uval) {
   assert(reg_info);
   if (!reg_info)
-    return Status("reg_info is nullptr");
+    return Status::FromErrorString("reg_info is nullptr");
 
   RegisterValue value;
   if (!value.SetUInt(uval, reg_info->byte_size))
-    return Status("RegisterValue::SetUInt () failed");
+    return Status::FromErrorString("RegisterValue::SetUInt () failed");
 
   return WriteRegister(reg_info, value);
 }
@@ -246,7 +246,7 @@ uint32_t NativeRegisterContext::SetHardwareBreakpoint(lldb::addr_t addr,
 }
 
 Status NativeRegisterContext::ClearAllHardwareBreakpoints() {
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 bool NativeRegisterContext::ClearHardwareBreakpoint(uint32_t hw_idx) {
@@ -256,7 +256,7 @@ bool NativeRegisterContext::ClearHardwareBreakpoint(uint32_t hw_idx) {
 Status NativeRegisterContext::GetHardwareBreakHitIndex(uint32_t &bp_index,
                                                        lldb::addr_t trap_addr) {
   bp_index = LLDB_INVALID_INDEX32;
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 uint32_t NativeRegisterContext::NumSupportedHardwareWatchpoints() { return 0; }
@@ -272,28 +272,28 @@ bool NativeRegisterContext::ClearHardwareWatchpoint(uint32_t hw_index) {
 }
 
 Status NativeRegisterContext::ClearWatchpointHit(uint32_t hw_index) {
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 Status NativeRegisterContext::ClearAllHardwareWatchpoints() {
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 Status NativeRegisterContext::IsWatchpointHit(uint32_t wp_index, bool &is_hit) {
   is_hit = false;
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 Status NativeRegisterContext::GetWatchpointHitIndex(uint32_t &wp_index,
                                                     lldb::addr_t trap_addr) {
   wp_index = LLDB_INVALID_INDEX32;
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 Status NativeRegisterContext::IsWatchpointVacant(uint32_t wp_index,
                                                  bool &is_vacant) {
   is_vacant = false;
-  return Status("not implemented");
+  return Status::FromErrorString("not implemented");
 }
 
 lldb::addr_t NativeRegisterContext::GetWatchpointAddress(uint32_t wp_index) {
@@ -311,7 +311,7 @@ Status NativeRegisterContext::ReadRegisterValueFromMemory(
     RegisterValue &reg_value) {
   Status error;
   if (reg_info == nullptr) {
-    error.SetErrorString("invalid register info argument.");
+    error = Status::FromErrorString("invalid register info argument.");
     return error;
   }
 
@@ -334,7 +334,7 @@ Status NativeRegisterContext::ReadRegisterValueFromMemory(
   const size_t dst_len = reg_info->byte_size;
 
   if (src_len > dst_len) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%" PRIu64 " bytes is too big to store in register %s (%" PRIu64
         " bytes)",
         static_cast<uint64_t>(src_len), reg_info->name,
@@ -354,9 +354,9 @@ Status NativeRegisterContext::ReadRegisterValueFromMemory(
   // Make sure the memory read succeeded...
   if (bytes_read != src_len) {
     // This might happen if we read _some_ bytes but not all
-    error.SetErrorStringWithFormat("read %" PRIu64 " of %" PRIu64 " bytes",
-                                   static_cast<uint64_t>(bytes_read),
-                                   static_cast<uint64_t>(src_len));
+    error = Status::FromErrorStringWithFormat(
+        "read %" PRIu64 " of %" PRIu64 " bytes",
+        static_cast<uint64_t>(bytes_read), static_cast<uint64_t>(src_len));
     return error;
   }
 
@@ -376,7 +376,7 @@ Status NativeRegisterContext::WriteRegisterValueToMemory(
     const RegisterValue &reg_value) {
   Status error;
   if (reg_info == nullptr) {
-    error.SetErrorString("Invalid register info argument.");
+    error = Status::FromErrorString("Invalid register info argument.");
     return error;
   }
 
@@ -391,7 +391,7 @@ Status NativeRegisterContext::WriteRegisterValueToMemory(
 
   if (error.Success()) {
     if (bytes_copied == 0) {
-      error.SetErrorString("byte copy failed.");
+      error = Status::FromErrorString("byte copy failed.");
     } else {
       size_t bytes_written;
       error = process.WriteMemory(dst_addr, dst.data(), bytes_copied,
@@ -401,10 +401,10 @@ Status NativeRegisterContext::WriteRegisterValueToMemory(
 
       if (bytes_written != bytes_copied) {
         // This might happen if we read _some_ bytes but not all
-        error.SetErrorStringWithFormat("only wrote %" PRIu64 " of %" PRIu64
-                                       " bytes",
-                                       static_cast<uint64_t>(bytes_written),
-                                       static_cast<uint64_t>(bytes_copied));
+        error = Status::FromErrorStringWithFormat(
+            "only wrote %" PRIu64 " of %" PRIu64 " bytes",
+            static_cast<uint64_t>(bytes_written),
+            static_cast<uint64_t>(bytes_copied));
       }
     }
   }

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -333,10 +333,10 @@ bool ProcessLaunchInfo::ConvertArgumentsForLaunchingInShell(
       m_arguments = shell_arguments;
       return true;
     } else {
-      error.SetErrorString("invalid shell path");
+      error = Status::FromErrorString("invalid shell path");
     }
   } else {
-    error.SetErrorString("not launching in shell");
+    error = Status::FromErrorString("not launching in shell");
   }
   return false;
 }

--- a/lldb/source/Host/common/Socket.cpp
+++ b/lldb/source/Host/common/Socket.cpp
@@ -98,7 +98,8 @@ Status SharedSocket::CompleteSending(lldb::pid_t child_pid) {
   if (::WSADuplicateSocket(m_socket, child_pid, &protocol_info) ==
       SOCKET_ERROR) {
     int last_error = ::WSAGetLastError();
-    return Status("WSADuplicateSocket() failed, error: %d", last_error);
+    return Status::FromErrorStringWithFormat(
+        "WSADuplicateSocket() failed, error: %d", last_error);
   }
 
   size_t num_bytes;
@@ -108,8 +109,8 @@ Status SharedSocket::CompleteSending(lldb::pid_t child_pid) {
   if (error.Fail())
     return error;
   if (num_bytes != sizeof(protocol_info))
-    return Status("WriteWithTimeout(WSAPROTOCOL_INFO) failed: %d bytes",
-                  num_bytes);
+    return Status::FromErrorStringWithFormat(
+        "WriteWithTimeout(WSAPROTOCOL_INFO) failed: %d bytes", num_bytes);
 #endif
   return Status();
 }
@@ -136,8 +137,8 @@ Status SharedSocket::GetNativeSocket(shared_fd_t fd, NativeSocket &socket) {
   socket = ::WSASocket(FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO,
                        FROM_PROTOCOL_INFO, &protocol_info, 0, 0);
   if (socket == INVALID_SOCKET) {
-    return Status("WSASocket(FROM_PROTOCOL_INFO) failed: error %d",
-                  ::WSAGetLastError());
+    return Status::FromErrorStringWithFormat(
+        "WSASocket(FROM_PROTOCOL_INFO) failed: error %d", ::WSAGetLastError());
   }
   return Status();
 #else
@@ -231,7 +232,7 @@ std::unique_ptr<Socket> Socket::Create(const SocketProtocol protocol,
     socket_up =
         std::make_unique<DomainSocket>(true, child_processes_inherit);
 #else
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "Unix domain sockets are not supported on this platform.");
 #endif
     break;
@@ -240,7 +241,7 @@ std::unique_ptr<Socket> Socket::Create(const SocketProtocol protocol,
     socket_up =
         std::make_unique<AbstractSocket>(child_processes_inherit);
 #else
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "Abstract domain sockets are not supported on this platform.");
 #endif
     break;
@@ -422,7 +423,7 @@ void Socket::SetLastError(Status &error) {
 #if defined(_WIN32)
   error.SetError(::WSAGetLastError(), lldb::eErrorTypeWin32);
 #else
-  error.SetErrorToErrno();
+  error = Status::FromErrno();
 #endif
 }
 

--- a/lldb/source/Host/common/TCPSocket.cpp
+++ b/lldb/source/Host/common/TCPSocket.cpp
@@ -183,7 +183,7 @@ Status TCPSocket::Connect(llvm::StringRef name) {
     return error;
   }
 
-  error.SetErrorString("Failed to connect port");
+  error = Status::FromErrorString("Failed to connect port");
   return error;
 }
 
@@ -257,7 +257,7 @@ void TCPSocket::CloseListenSockets() {
 Status TCPSocket::Accept(Socket *&conn_socket) {
   Status error;
   if (m_listen_sockets.size() == 0) {
-    error.SetErrorString("No open listening sockets!");
+    error = Status::FromErrorString("No open listening sockets!");
     return error;
   }
 

--- a/lldb/source/Host/common/UDPSocket.cpp
+++ b/lldb/source/Host/common/UDPSocket.cpp
@@ -40,15 +40,15 @@ size_t UDPSocket::Send(const void *buf, const size_t num_bytes) {
 }
 
 Status UDPSocket::Connect(llvm::StringRef name) {
-  return Status("%s", g_not_supported_error);
+  return Status::FromErrorStringWithFormat("%s", g_not_supported_error);
 }
 
 Status UDPSocket::Listen(llvm::StringRef name, int backlog) {
-  return Status("%s", g_not_supported_error);
+  return Status::FromErrorStringWithFormat("%s", g_not_supported_error);
 }
 
 Status UDPSocket::Accept(Socket *&socket) {
-  return Status("%s", g_not_supported_error);
+  return Status::FromErrorStringWithFormat("%s", g_not_supported_error);
 }
 
 llvm::Expected<std::unique_ptr<UDPSocket>>
@@ -75,7 +75,7 @@ UDPSocket::Connect(llvm::StringRef name, bool child_processes_inherit) {
   int err = ::getaddrinfo(host_port->hostname.c_str(), std::to_string(host_port->port).c_str(), &hints,
                           &service_info_list);
   if (err != 0) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
 #if defined(_WIN32) && defined(UNICODE)
         "getaddrinfo(%s, %d, &hints, &info) returned error %i (%S)",
 #else
@@ -113,7 +113,7 @@ UDPSocket::Connect(llvm::StringRef name, bool child_processes_inherit) {
                                      : bind_addr.SetToAnyAddress(kDomain, host_port->port);
 
   if (!bind_addr_success) {
-    error.SetErrorString("Failed to get hostspec to bind for");
+    error = Status::FromErrorString("Failed to get hostspec to bind for");
     return error.ToError();
   }
 

--- a/lldb/source/Host/freebsd/Host.cpp
+++ b/lldb/source/Host/freebsd/Host.cpp
@@ -244,5 +244,5 @@ bool Host::GetProcessInfo(lldb::pid_t pid, ProcessInstanceInfo &process_info) {
 Environment Host::GetEnvironment() { return Environment(environ); }
 
 Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }

--- a/lldb/source/Host/linux/Host.cpp
+++ b/lldb/source/Host/linux/Host.cpp
@@ -414,7 +414,7 @@ bool Host::GetProcessInfo(lldb::pid_t pid, ProcessInstanceInfo &process_info) {
 Environment Host::GetEnvironment() { return Environment(environ); }
 
 Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 std::optional<lldb::pid_t> lldb_private::getPIDForTID(lldb::pid_t tid) {

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -208,21 +208,23 @@ LaunchInNewTerminalWithAppleScript(const char *exe_path,
   Status error;
   char unix_socket_name[PATH_MAX] = "/tmp/XXXXXX";
   if (::mktemp(unix_socket_name) == NULL) {
-    error.SetErrorString("failed to make temporary path for a unix socket");
+    error = Status::FromErrorString(
+        "failed to make temporary path for a unix socket");
     return error;
   }
 
   StreamString command;
   FileSpec darwin_debug_file_spec = HostInfo::GetSupportExeDir();
   if (!darwin_debug_file_spec) {
-    error.SetErrorString("can't locate the 'darwin-debug' executable");
+    error =
+        Status::FromErrorString("can't locate the 'darwin-debug' executable");
     return error;
   }
 
   darwin_debug_file_spec.SetFilename("darwin-debug");
 
   if (!FileSystem::Instance().Exists(darwin_debug_file_spec)) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "the 'darwin-debug' executable doesn't exists at '%s'",
         darwin_debug_file_spec.GetPath().c_str());
     return error;
@@ -783,8 +785,8 @@ static Status getXPCAuthorization(ProcessLaunchInfo &launch_info) {
         AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment,
                             kAuthorizationFlagDefaults, &authorizationRef);
     if (createStatus != errAuthorizationSuccess) {
-      error.SetError(1, eErrorTypeGeneric);
-      error.SetErrorString("Can't create authorizationRef.");
+      error = Status(1, eErrorTypeGeneric);
+      error = Status::FromErrorString("Can't create authorizationRef.");
       LLDB_LOG(log, "error: {0}", error);
       return error;
     }
@@ -835,8 +837,8 @@ static Status getXPCAuthorization(ProcessLaunchInfo &launch_info) {
       // logged in to the current audit session, we will need the trick in gdb
       // where
       // we ask the user to type in the root passwd in the terminal.
-      error.SetError(2, eErrorTypeGeneric);
-      error.SetErrorStringWithFormat(
+      error = Status(2, eErrorTypeGeneric);
+      error = Status::FromErrorStringWithFormat(
           "Launching as root needs root authorization.");
       LLDB_LOG(log, "error: {0}", error);
 
@@ -908,16 +910,17 @@ static Status LaunchProcessXPC(const char *exe_path,
         errAuthorizationSuccess) {
       send_auth = true;
     } else {
-      error.SetError(3, eErrorTypeGeneric);
-      error.SetErrorStringWithFormat("Launching root via XPC needs to "
-                                     "externalize authorization reference.");
+      error = Status(3, eErrorTypeGeneric);
+      error = Status::FromErrorStringWithFormat(
+          "Launching root via XPC needs to "
+          "externalize authorization reference.");
       LLDB_LOG(log, "error: {0}", error);
       return error;
     }
     xpc_service = LaunchUsingXPCRightName;
   } else {
-    error.SetError(4, eErrorTypeGeneric);
-    error.SetErrorStringWithFormat(
+    error = Status(4, eErrorTypeGeneric);
+    error = Status::FromErrorStringWithFormat(
         "Launching via XPC is only currently available for root.");
     LLDB_LOG(log, "error: {0}", error);
     return error;
@@ -999,8 +1002,8 @@ static Status LaunchProcessXPC(const char *exe_path,
       int errorCode =
           xpc_dictionary_get_int64(reply, LauncherXPCServiceCodeTypeKey);
 
-      error.SetError(errorCode, eErrorTypeGeneric);
-      error.SetErrorStringWithFormat(
+      error = Status(errorCode, eErrorTypeGeneric);
+      error = Status::FromErrorStringWithFormat(
           "Problems with launching via XPC. Error type : %i, code : %i",
           errorType, errorCode);
       LLDB_LOG(log, "error: {0}", error);
@@ -1011,8 +1014,8 @@ static Status LaunchProcessXPC(const char *exe_path,
       }
     }
   } else if (returnType == XPC_TYPE_ERROR) {
-    error.SetError(5, eErrorTypeGeneric);
-    error.SetErrorStringWithFormat(
+    error = Status(5, eErrorTypeGeneric);
+    error = Status::FromErrorStringWithFormat(
         "Problems with launching via XPC. XPC error : %s",
         xpc_dictionary_get_string(reply, XPC_ERROR_KEY_DESCRIPTION));
     LLDB_LOG(log, "error: {0}", error);
@@ -1040,10 +1043,10 @@ static bool AddPosixSpawnFileAction(void *_file_actions, const FileAction *info,
 
   case FileAction::eFileActionClose:
     if (info->GetFD() == -1)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "invalid fd for posix_spawn_file_actions_addclose(...)");
     else {
-      error.SetError(
+      error = Status(
           ::posix_spawn_file_actions_addclose(file_actions, info->GetFD()),
           eErrorTypePOSIX);
       if (error.Fail())
@@ -1056,16 +1059,16 @@ static bool AddPosixSpawnFileAction(void *_file_actions, const FileAction *info,
 
   case FileAction::eFileActionDuplicate:
     if (info->GetFD() == -1)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "invalid fd for posix_spawn_file_actions_adddup2(...)");
     else if (info->GetActionArgument() == -1)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "invalid duplicate fd for posix_spawn_file_actions_adddup2(...)");
     else {
-      error.SetError(
-          ::posix_spawn_file_actions_adddup2(file_actions, info->GetFD(),
-                                             info->GetActionArgument()),
-          eErrorTypePOSIX);
+      error =
+          Status(::posix_spawn_file_actions_adddup2(file_actions, info->GetFD(),
+                                                    info->GetActionArgument()),
+                 eErrorTypePOSIX);
       if (error.Fail())
         LLDB_LOG(log,
                  "error: {0}, posix_spawn_file_actions_adddup2 "
@@ -1076,7 +1079,7 @@ static bool AddPosixSpawnFileAction(void *_file_actions, const FileAction *info,
 
   case FileAction::eFileActionOpen:
     if (info->GetFD() == -1)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "invalid fd in posix_spawn_file_actions_addopen(...)");
     else {
       int oflag = info->GetActionArgument();
@@ -1086,7 +1089,7 @@ static bool AddPosixSpawnFileAction(void *_file_actions, const FileAction *info,
       if (oflag & O_CREAT)
         mode = 0640;
 
-      error.SetError(::posix_spawn_file_actions_addopen(
+      error = Status(::posix_spawn_file_actions_addopen(
                          file_actions, info->GetFD(),
                          info->GetPath().str().c_str(), oflag, mode),
                      eErrorTypePOSIX);
@@ -1109,7 +1112,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
   Log *log(GetLog(LLDBLog::Host | LLDBLog::Process));
 
   posix_spawnattr_t attr;
-  error.SetError(::posix_spawnattr_init(&attr), eErrorTypePOSIX);
+  error = Status(::posix_spawnattr_init(&attr), eErrorTypePOSIX);
 
   if (error.Fail()) {
     LLDB_LOG(log, "error: {0}, ::posix_spawnattr_init ( &attr )", error);
@@ -1129,7 +1132,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
 
   short flags = GetPosixspawnFlags(launch_info);
 
-  error.SetError(::posix_spawnattr_setflags(&attr, flags), eErrorTypePOSIX);
+  error = Status(::posix_spawnattr_setflags(&attr, flags), eErrorTypePOSIX);
   if (error.Fail()) {
     LLDB_LOG(log,
              "error: {0}, ::posix_spawnattr_setflags ( &attr, flags={1:x} )",
@@ -1153,7 +1156,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
   //  its parent.
   if (is_graphical && launch_info.GetFlags().Test(eLaunchFlagDebug) &&
       !launch_info.GetFlags().Test(eLaunchFlagInheritTCCFromParent)) {
-    error.SetError(setup_posix_spawn_responsible_flag(&attr), eErrorTypePOSIX);
+    error = Status(setup_posix_spawn_responsible_flag(&attr), eErrorTypePOSIX);
     if (error.Fail()) {
       LLDB_LOG(log, "error: {0}, setup_posix_spawn_responsible_flag(&attr)",
                error);
@@ -1184,7 +1187,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
           (posix_spawnattr_setarchpref_np_t)dlsym(
               RTLD_DEFAULT, "posix_spawnattr_setarchpref_np");
       if (set_cpu_subtype && posix_spawnattr_setarchpref_np_fn) {
-        error.SetError((*posix_spawnattr_setarchpref_np_fn)(
+        error = Status((*posix_spawnattr_setarchpref_np_fn)(
                            &attr, 1, &cpu_type, &cpu_subtype, &ocount),
                        eErrorTypePOSIX);
         if (error.Fail())
@@ -1196,7 +1199,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
         if (error.Fail() || ocount != 1)
           return error;
       } else {
-        error.SetError(
+        error = Status(
             ::posix_spawnattr_setbinpref_np(&attr, 1, &cpu_type, &ocount),
             eErrorTypePOSIX);
         if (error.Fail())
@@ -1230,15 +1233,16 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
     std::string working_dir_path = working_dir.GetPath();
     if (__pthread_chdir(working_dir_path.c_str()) < 0) {
       if (errno == ENOENT) {
-        error.SetErrorStringWithFormat("No such file or directory: %s",
-                                       working_dir_path.c_str());
+        error = Status::FromErrorStringWithFormat(
+            "No such file or directory: %s", working_dir_path.c_str());
       } else if (errno == ENOTDIR) {
-        error.SetErrorStringWithFormat("Path doesn't name a directory: %s",
-                                       working_dir_path.c_str());
+        error = Status::FromErrorStringWithFormat(
+            "Path doesn't name a directory: %s", working_dir_path.c_str());
       } else {
-        error.SetErrorStringWithFormat("An unknown error occurred when "
-                                       "changing directory for process "
-                                       "execution.");
+        error =
+            Status::FromErrorStringWithFormat("An unknown error occurred when "
+                                              "changing directory for process "
+                                              "execution.");
       }
       return error;
     }
@@ -1248,8 +1252,8 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
   const size_t num_file_actions = launch_info.GetNumFileActions();
   if (num_file_actions > 0) {
     posix_spawn_file_actions_t file_actions;
-    error.SetError(::posix_spawn_file_actions_init(&file_actions),
-                   eErrorTypePOSIX);
+    error =
+        Status(::posix_spawn_file_actions_init(&file_actions), eErrorTypePOSIX);
     if (error.Fail()) {
       LLDB_LOG(log,
                "error: {0}, ::posix_spawn_file_actions_init ( &file_actions )",
@@ -1271,7 +1275,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
       }
     }
 
-    error.SetError(
+    error = Status(
         ::posix_spawnp(&result_pid, exe_path, &file_actions, &attr, argv, envp),
         eErrorTypePOSIX);
 
@@ -1289,9 +1293,9 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
     }
 
   } else {
-    error.SetError(
-        ::posix_spawnp(&result_pid, exe_path, NULL, &attr, argv, envp),
-        eErrorTypePOSIX);
+    error =
+        Status(::posix_spawnp(&result_pid, exe_path, NULL, &attr, argv, envp),
+               eErrorTypePOSIX);
 
     if (error.Fail()) {
       LLDB_LOG(log,
@@ -1343,8 +1347,8 @@ Status Host::LaunchProcess(ProcessLaunchInfo &launch_info) {
     FileSystem::Instance().ResolveExecutableLocation(exe_spec);
 
   if (!fs.Exists(exe_spec)) {
-    error.SetErrorStringWithFormatv("executable doesn't exist: '{0}'",
-                                    exe_spec);
+    error = Status::FromErrorStringWithFormatv(
+        "executable doesn't exist: '{0}'", exe_spec);
     return error;
   }
 
@@ -1353,8 +1357,9 @@ Status Host::LaunchProcess(ProcessLaunchInfo &launch_info) {
     return LaunchInNewTerminalWithAppleScript(exe_spec.GetPath().c_str(),
                                               launch_info);
 #else
-    error.SetErrorString("launching a process in a new terminal is not "
-                         "supported on iOS devices");
+    error =
+        Status::FromErrorString("launching a process in a new terminal is not "
+                                "supported on iOS devices");
     return error;
 #endif
   }
@@ -1379,7 +1384,8 @@ Status Host::LaunchProcess(ProcessLaunchInfo &launch_info) {
   } else {
     // Invalid process ID, something didn't go well
     if (error.Success())
-      error.SetErrorString("process launch failed for unknown reasons");
+      error =
+          Status::FromErrorString("process launch failed for unknown reasons");
   }
   return error;
 }
@@ -1401,13 +1407,14 @@ Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
     if (!argdumper_exists) {
       expand_tool_spec = HostInfo::GetSupportExeDir();
       if (!expand_tool_spec) {
-        error.SetErrorString("could not get support executable directory for "
-                             "lldb-argdumper tool");
+        error = Status::FromErrorString(
+            "could not get support executable directory for "
+            "lldb-argdumper tool");
         return error;
       }
       expand_tool_spec.AppendPathComponent("lldb-argdumper");
       if (!FileSystem::Instance().Exists(expand_tool_spec)) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "could not find the lldb-argdumper tool: %s",
             expand_tool_spec.GetPath().c_str());
         return error;
@@ -1427,7 +1434,7 @@ Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
     if (!FileSystem::Instance().Exists(cwd)) {
       char *wd = getcwd(nullptr, 0);
       if (wd == nullptr) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "cwd does not exist; cannot launch with shell argument expansion");
         return error;
       } else {
@@ -1446,32 +1453,32 @@ Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
       return e;
 
     if (status != 0) {
-      error.SetErrorStringWithFormat("lldb-argdumper exited with error %d",
-                                     status);
+      error = Status::FromErrorStringWithFormat(
+          "lldb-argdumper exited with error %d", status);
       return error;
     }
 
     auto data_sp = StructuredData::ParseJSON(output);
     if (!data_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 
     auto dict_sp = data_sp->GetAsDictionary();
     if (!data_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 
     auto args_sp = dict_sp->GetObjectForDotSeparatedPath("arguments");
     if (!args_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 
     auto args_array_sp = args_sp->GetAsArray();
     if (!args_array_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 

--- a/lldb/source/Host/netbsd/HostNetBSD.cpp
+++ b/lldb/source/Host/netbsd/HostNetBSD.cpp
@@ -269,5 +269,5 @@ bool Host::GetProcessInfo(lldb::pid_t pid, ProcessInstanceInfo &process_info) {
 }
 
 Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }

--- a/lldb/source/Host/openbsd/Host.cpp
+++ b/lldb/source/Host/openbsd/Host.cpp
@@ -215,5 +215,5 @@ bool Host::GetProcessInfo(lldb::pid_t pid, ProcessInstanceInfo &process_info) {
 }
 
 Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }

--- a/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
+++ b/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
@@ -140,7 +140,7 @@ ConnectionFileDescriptor::Connect(llvm::StringRef path,
 
   if (path.empty()) {
     if (error_ptr)
-      error_ptr->SetErrorString("invalid connect arguments");
+      *error_ptr = Status::FromErrorString("invalid connect arguments");
     return eConnectionStatusError;
   }
 
@@ -177,8 +177,8 @@ ConnectionFileDescriptor::Connect(llvm::StringRef path,
   }
 
   if (error_ptr)
-    error_ptr->SetErrorStringWithFormat("unsupported connection URL: '%s'",
-                                        path.str().c_str());
+    *error_ptr = Status::FromErrorStringWithFormat(
+        "unsupported connection URL: '%s'", path.str().c_str());
   return eConnectionStatusError;
 }
 
@@ -256,7 +256,8 @@ size_t ConnectionFileDescriptor::Read(void *dst, size_t dst_len,
               "connection lock.",
               static_cast<void *>(this));
     if (error_ptr)
-      error_ptr->SetErrorString("failed to get the connection lock for read.");
+      *error_ptr = Status::FromErrorString(
+          "failed to get the connection lock for read.");
 
     status = eConnectionStatusTimedOut;
     return 0;
@@ -264,7 +265,7 @@ size_t ConnectionFileDescriptor::Read(void *dst, size_t dst_len,
 
   if (m_shutting_down) {
     if (error_ptr)
-      error_ptr->SetErrorString("shutting down");
+      *error_ptr = Status::FromErrorString("shutting down");
     status = eConnectionStatusError;
     return 0;
   }
@@ -364,14 +365,14 @@ size_t ConnectionFileDescriptor::Write(const void *src, size_t src_len,
 
   if (!IsConnected()) {
     if (error_ptr)
-      error_ptr->SetErrorString("not connected");
+      *error_ptr = Status::FromErrorString("not connected");
     status = eConnectionStatusNoConnection;
     return 0;
   }
 
   if (m_shutting_down) {
     if (error_ptr)
-      error_ptr->SetErrorString("shutting down");
+      *error_ptr = Status::FromErrorString("shutting down");
     status = eConnectionStatusError;
     return 0;
   }
@@ -528,7 +529,7 @@ ConnectionFileDescriptor::BytesAvailable(const Timeout<std::micro> &timeout,
   }
 
   if (error_ptr)
-    error_ptr->SetErrorString("not connected");
+    *error_ptr = Status::FromErrorString("not connected");
   return eConnectionStatusLostConnection;
 }
 
@@ -679,8 +680,8 @@ ConnectionFileDescriptor::ConnectFD(llvm::StringRef s,
     int flags = ::fcntl(fd, F_GETFL, 0);
     if (flags == -1 || errno == EBADF) {
       if (error_ptr)
-        error_ptr->SetErrorStringWithFormat("stale file descriptor: %s",
-                                            s.str().c_str());
+        *error_ptr = Status::FromErrorStringWithFormat(
+            "stale file descriptor: %s", s.str().c_str());
       m_io_sp.reset();
       return eConnectionStatusError;
     } else {
@@ -710,8 +711,8 @@ ConnectionFileDescriptor::ConnectFD(llvm::StringRef s,
   }
 
   if (error_ptr)
-    error_ptr->SetErrorStringWithFormat("invalid file descriptor: \"%s\"",
-                                        s.str().c_str());
+    *error_ptr = Status::FromErrorStringWithFormat(
+        "invalid file descriptor: \"%s\"", s.str().c_str());
   m_io_sp.reset();
   return eConnectionStatusError;
 #endif // LLDB_ENABLE_POSIX
@@ -727,7 +728,7 @@ ConnectionStatus ConnectionFileDescriptor::ConnectFile(
   int fd = FileSystem::Instance().Open(addr_str.c_str(), O_RDWR);
   if (fd == -1) {
     if (error_ptr)
-      error_ptr->SetErrorToErrno();
+      *error_ptr = Status::FromErrno();
     return eConnectionStatusError;
   }
 
@@ -777,7 +778,7 @@ ConnectionStatus ConnectionFileDescriptor::ConnectSerialPort(
   int fd = FileSystem::Instance().Open(path.str().c_str(), O_RDWR);
   if (fd == -1) {
     if (error_ptr)
-      error_ptr->SetErrorToErrno();
+      *error_ptr = Status::FromErrno();
     return eConnectionStatusError;
   }
 

--- a/lldb/source/Host/posix/DomainSocket.cpp
+++ b/lldb/source/Host/posix/DomainSocket.cpp
@@ -74,7 +74,7 @@ Status DomainSocket::Connect(llvm::StringRef name) {
   sockaddr_un saddr_un;
   socklen_t saddr_un_len;
   if (!SetSockAddr(name, GetNameOffset(), &saddr_un, saddr_un_len))
-    return Status("Failed to set socket address");
+    return Status::FromErrorString("Failed to set socket address");
 
   Status error;
   m_socket = CreateSocket(kDomain, kType, 0, m_child_processes_inherit, error);
@@ -91,7 +91,7 @@ Status DomainSocket::Listen(llvm::StringRef name, int backlog) {
   sockaddr_un saddr_un;
   socklen_t saddr_un_len;
   if (!SetSockAddr(name, GetNameOffset(), &saddr_un, saddr_un_len))
-    return Status("Failed to set socket address");
+    return Status::FromErrorString("Failed to set socket address");
 
   DeleteSocketFile(name);
 

--- a/lldb/source/Host/posix/HostProcessPosix.cpp
+++ b/lldb/source/Host/posix/HostProcessPosix.cpp
@@ -30,9 +30,8 @@ HostProcessPosix::~HostProcessPosix() = default;
 
 Status HostProcessPosix::Signal(int signo) const {
   if (m_process == kInvalidPosixProcess) {
-    Status error;
-    error.SetErrorString("HostProcessPosix refers to an invalid process");
-    return error;
+    return Status::FromErrorString(
+        "HostProcessPosix refers to an invalid process");
   }
 
   return HostProcessPosix::Signal(m_process, signo);
@@ -42,7 +41,7 @@ Status HostProcessPosix::Signal(lldb::process_t process, int signo) {
   Status error;
 
   if (-1 == ::kill(process, signo))
-    error.SetErrorToErrno();
+    return Status::FromErrno();
 
   return error;
 }

--- a/lldb/source/Host/posix/HostThreadPosix.cpp
+++ b/lldb/source/Host/posix/HostThreadPosix.cpp
@@ -26,11 +26,11 @@ Status HostThreadPosix::Join(lldb::thread_result_t *result) {
   Status error;
   if (IsJoinable()) {
     int err = ::pthread_join(m_thread, result);
-    error.SetError(err, lldb::eErrorTypePOSIX);
+    error = Status(err, lldb::eErrorTypePOSIX);
   } else {
     if (result)
       *result = nullptr;
-    error.SetError(EINVAL, eErrorTypePOSIX);
+    error = Status(EINVAL, eErrorTypePOSIX);
   }
 
   Reset();
@@ -44,7 +44,7 @@ Status HostThreadPosix::Cancel() {
     llvm_unreachable("someone is calling HostThread::Cancel()");
 #else
     int err = ::pthread_cancel(m_thread);
-    error.SetError(err, eErrorTypePOSIX);
+    error = Status(err, eErrorTypePOSIX);
 #endif
   }
   return error;
@@ -54,7 +54,7 @@ Status HostThreadPosix::Detach() {
   Status error;
   if (IsJoinable()) {
     int err = ::pthread_detach(m_thread);
-    error.SetError(err, eErrorTypePOSIX);
+    error = Status(err, eErrorTypePOSIX);
   }
   Reset();
   return error;

--- a/lldb/source/Host/posix/LockFilePosix.cpp
+++ b/lldb/source/Host/posix/LockFilePosix.cpp
@@ -26,11 +26,10 @@ static Status fileLock(int fd, int cmd, int lock_type, const uint64_t start,
   fl.l_len = len;
   fl.l_pid = ::getpid();
 
-  Status error;
   if (llvm::sys::RetryAfterSignal(-1, ::fcntl, fd, cmd, &fl) == -1)
-    error.SetErrorToErrno();
+    return Status::FromErrno();
 
-  return error;
+  return Status();
 }
 
 LockFilePosix::LockFilePosix(int fd) : LockFileBase(fd) {}

--- a/lldb/source/Host/posix/MainLoopPosix.cpp
+++ b/lldb/source/Host/posix/MainLoopPosix.cpp
@@ -258,15 +258,16 @@ MainLoopPosix::ReadHandleUP
 MainLoopPosix::RegisterReadObject(const IOObjectSP &object_sp,
                                  const Callback &callback, Status &error) {
   if (!object_sp || !object_sp->IsValid()) {
-    error.SetErrorString("IO object is not valid.");
+    error = Status::FromErrorString("IO object is not valid.");
     return nullptr;
   }
 
   const bool inserted =
       m_read_fds.insert({object_sp->GetWaitableHandle(), callback}).second;
   if (!inserted) {
-    error.SetErrorStringWithFormat("File descriptor %d already monitored.",
-                                   object_sp->GetWaitableHandle());
+    error = Status::FromErrorStringWithFormat(
+        "File descriptor %d already monitored.",
+        object_sp->GetWaitableHandle());
     return nullptr;
   }
 

--- a/lldb/source/Host/posix/PipePosix.cpp
+++ b/lldb/source/Host/posix/PipePosix.cpp
@@ -91,7 +91,7 @@ Status PipePosix::CreateNew(bool child_processes_inherit) {
 #ifdef FD_CLOEXEC
     if (!child_processes_inherit) {
       if (!SetCloexecFlag(m_fds[0]) || !SetCloexecFlag(m_fds[1])) {
-        error.SetErrorToErrno();
+        error = Status::FromErrno();
         CloseUnlocked();
         return error;
       }
@@ -101,7 +101,7 @@ Status PipePosix::CreateNew(bool child_processes_inherit) {
   }
 #endif
 
-  error.SetErrorToErrno();
+  error = Status::FromErrno();
   m_fds[READ] = PipePosix::kInvalidDescriptor;
   m_fds[WRITE] = PipePosix::kInvalidDescriptor;
   return error;
@@ -110,12 +110,11 @@ Status PipePosix::CreateNew(bool child_processes_inherit) {
 Status PipePosix::CreateNew(llvm::StringRef name, bool child_process_inherit) {
   std::scoped_lock<std::mutex, std::mutex> guard(m_read_mutex, m_write_mutex);
   if (CanReadUnlocked() || CanWriteUnlocked())
-    return Status("Pipe is already opened");
+    return Status::FromErrorString("Pipe is already opened");
 
   Status error;
   if (::mkfifo(name.str().c_str(), 0660) != 0)
-    error.SetErrorToErrno();
-
+    error = Status::FromErrno();
   return error;
 }
 
@@ -149,7 +148,7 @@ Status PipePosix::OpenAsReader(llvm::StringRef name,
   std::scoped_lock<std::mutex, std::mutex> guard(m_read_mutex, m_write_mutex);
 
   if (CanReadUnlocked() || CanWriteUnlocked())
-    return Status("Pipe is already opened");
+    return Status::FromErrorString("Pipe is already opened");
 
   int flags = O_RDONLY | O_NONBLOCK;
   if (!child_process_inherit)
@@ -160,7 +159,7 @@ Status PipePosix::OpenAsReader(llvm::StringRef name,
   if (fd != -1)
     m_fds[READ] = fd;
   else
-    error.SetErrorToErrno();
+    error = Status::FromErrno();
 
   return error;
 }
@@ -171,7 +170,7 @@ PipePosix::OpenAsWriterWithTimeout(llvm::StringRef name,
                                    const std::chrono::microseconds &timeout) {
   std::lock_guard<std::mutex> guard(m_write_mutex);
   if (CanReadUnlocked() || CanWriteUnlocked())
-    return Status("Pipe is already opened");
+    return Status::FromErrorString("Pipe is already opened");
 
   int flags = O_WRONLY | O_NONBLOCK;
   if (!child_process_inherit)
@@ -184,7 +183,8 @@ PipePosix::OpenAsWriterWithTimeout(llvm::StringRef name,
     if (timeout != microseconds::zero()) {
       const auto dur = duration_cast<microseconds>(finish_time - Now()).count();
       if (dur <= 0)
-        return Status("timeout exceeded - reader hasn't opened so far");
+        return Status::FromErrorString(
+            "timeout exceeded - reader hasn't opened so far");
     }
 
     errno = 0;
@@ -327,7 +327,7 @@ Status PipePosix::ReadWithTimeout(void *buf, size_t size,
       } else if (errno == EINTR) {
         continue;
       } else {
-        error.SetErrorToErrno();
+        error = Status::FromErrno();
         break;
       }
     }
@@ -361,7 +361,7 @@ Status PipePosix::WriteWithTimeout(const void *buf, size_t size,
       } else if (errno == EINTR) {
         continue;
       } else {
-        error.SetErrorToErrno();
+        error = Status::FromErrno();
       }
     }
   }

--- a/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
+++ b/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
@@ -269,8 +269,8 @@ ProcessLauncherPosixFork::LaunchProcess(const ProcessLaunchInfo &launch_info,
   ::pid_t pid = ::fork();
   if (pid == -1) {
     // Fork failed
-    error.SetErrorStringWithFormatv("Fork failed with error message: {0}",
-                                    llvm::sys::StrError());
+    error = Status::FromErrorStringWithFormatv(
+        "Fork failed with error message: {0}", llvm::sys::StrError());
     return HostProcess(LLDB_INVALID_PROCESS_ID);
   }
   if (pid == 0) {
@@ -297,7 +297,7 @@ ProcessLauncherPosixFork::LaunchProcess(const ProcessLaunchInfo &launch_info,
   if (buf.empty())
     return HostProcess(pid); // No error. We're done.
 
-  error.SetErrorString(buf);
+  error = Status(buf.str().str());
 
   llvm::sys::RetryAfterSignal(-1, waitpid, pid, nullptr, 0);
 

--- a/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
@@ -34,7 +34,7 @@ public:
   }
 
   void Set(size_t bytes, ConnectionStatus status, llvm::StringRef error_msg) {
-    m_error.SetErrorString(error_msg.data());
+    m_error = Status::FromErrorString(error_msg.data());
     m_bytes = bytes;
     m_status = status;
   }

--- a/lldb/source/Host/windows/FileSystem.cpp
+++ b/lldb/source/Host/windows/FileSystem.cpp
@@ -32,7 +32,7 @@ Status FileSystem::Symlink(const FileSpec &src, const FileSpec &dst) {
   std::wstring wsrc, wdst;
   if (!llvm::ConvertUTF8toWide(src.GetPath(), wsrc) ||
       !llvm::ConvertUTF8toWide(dst.GetPath(), wdst))
-    error.SetErrorString(PATH_CONVERSION_ERROR);
+    error = Status::FromErrorString(PATH_CONVERSION_ERROR);
   if (error.Fail())
     return error;
   DWORD attrib = ::GetFileAttributesW(wdst.c_str());
@@ -52,7 +52,7 @@ Status FileSystem::Readlink(const FileSpec &src, FileSpec &dst) {
   Status error;
   std::wstring wsrc;
   if (!llvm::ConvertUTF8toWide(src.GetPath(), wsrc)) {
-    error.SetErrorString(PATH_CONVERSION_ERROR);
+    error = Status::FromErrorString(PATH_CONVERSION_ERROR);
     return error;
   }
 
@@ -73,7 +73,7 @@ Status FileSystem::Readlink(const FileSpec &src, FileSpec &dst) {
   if (result == 0)
     error.SetError(::GetLastError(), lldb::eErrorTypeWin32);
   else if (!llvm::convertWideToUTF8(buf.data(), path))
-    error.SetErrorString(PATH_CONVERSION_ERROR);
+    error = Status::FromErrorString(PATH_CONVERSION_ERROR);
   else
     dst.SetFile(path, FileSpec::Style::native);
 
@@ -82,7 +82,8 @@ Status FileSystem::Readlink(const FileSpec &src, FileSpec &dst) {
 }
 
 Status FileSystem::ResolveSymbolicLink(const FileSpec &src, FileSpec &dst) {
-  return Status("ResolveSymbolicLink() isn't implemented on Windows");
+  return Status::FromErrorString(
+      "ResolveSymbolicLink() isn't implemented on Windows");
 }
 
 FILE *FileSystem::Fopen(const char *path, const char *mode) {

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -206,13 +206,14 @@ Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
   if (launch_info.GetFlags().Test(eLaunchFlagShellExpandArguments)) {
     FileSpec expand_tool_spec = HostInfo::GetSupportExeDir();
     if (!expand_tool_spec) {
-      error.SetErrorString("could not find support executable directory for "
-                           "the lldb-argdumper tool");
+      error = Status::FromErrorString(
+          "could not find support executable directory for "
+          "the lldb-argdumper tool");
       return error;
     }
     expand_tool_spec.AppendPathComponent("lldb-argdumper.exe");
     if (!FileSystem::Instance().Exists(expand_tool_spec)) {
-      error.SetErrorString("could not find the lldb-argdumper tool");
+      error = Status::FromErrorString("could not find the lldb-argdumper tool");
       return error;
     }
 
@@ -235,32 +236,32 @@ Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
       return e;
 
     if (status != 0) {
-      error.SetErrorStringWithFormat("lldb-argdumper exited with error %d",
-                                     status);
+      error = Status::FromErrorStringWithFormat(
+          "lldb-argdumper exited with error %d", status);
       return error;
     }
 
     auto data_sp = StructuredData::ParseJSON(output);
     if (!data_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 
     auto dict_sp = data_sp->GetAsDictionary();
     if (!dict_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 
     auto args_sp = dict_sp->GetObjectForDotSeparatedPath("arguments");
     if (!args_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 
     auto args_array_sp = args_sp->GetAsArray();
     if (!args_array_sp) {
-      error.SetErrorString("invalid JSON");
+      error = Status::FromErrorString("invalid JSON");
       return error;
     }
 

--- a/lldb/source/Host/windows/LockFileWindows.cpp
+++ b/lldb/source/Host/windows/LockFileWindows.cpp
@@ -16,7 +16,8 @@ using namespace lldb_private;
 static Status fileLock(HANDLE file_handle, DWORD flags, const uint64_t start,
                        const uint64_t len) {
   if (start != 0)
-    return Status("Non-zero start lock regions are not supported");
+    return Status::FromErrorString(
+        "Non-zero start lock regions are not supported");
 
   OVERLAPPED overlapped = {};
 

--- a/lldb/source/Host/windows/MainLoopWindows.cpp
+++ b/lldb/source/Host/windows/MainLoopWindows.cpp
@@ -65,18 +65,19 @@ MainLoopWindows::ReadHandleUP
 MainLoopWindows::RegisterReadObject(const IOObjectSP &object_sp,
                                     const Callback &callback, Status &error) {
   if (!object_sp || !object_sp->IsValid()) {
-    error.SetErrorString("IO object is not valid.");
+    error = Status::FromErrorString("IO object is not valid.");
     return nullptr;
   }
   if (object_sp->GetFdType() != IOObject::eFDTypeSocket) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "MainLoopWindows: non-socket types unsupported on Windows");
     return nullptr;
   }
 
   WSAEVENT event = WSACreateEvent();
   if (event == WSA_INVALID_EVENT) {
-    error.SetErrorStringWithFormat("Cannot create monitoring event.");
+    error =
+        Status::FromErrorStringWithFormat("Cannot create monitoring event.");
     return nullptr;
   }
 
@@ -86,8 +87,9 @@ MainLoopWindows::RegisterReadObject(const IOObjectSP &object_sp,
           .second;
   if (!inserted) {
     WSACloseEvent(event);
-    error.SetErrorStringWithFormat("File descriptor %d already monitored.",
-                                   object_sp->GetWaitableHandle());
+    error = Status::FromErrorStringWithFormat(
+        "File descriptor %d already monitored.",
+        object_sp->GetWaitableHandle());
     return nullptr;
   }
 

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -961,20 +961,23 @@ CommandObjectMultiword *CommandInterpreter::VerifyUserMultiwordCmdPath(
       [&result](CommandObjectSP cmd_sp,
                            const char *name) -> CommandObjectMultiword * {
     if (!cmd_sp) {
-      result.SetErrorStringWithFormat("Path component: '%s' not found", name);
+      result = Status::FromErrorStringWithFormat(
+          "Path component: '%s' not found", name);
       return nullptr;
     }
     if (!cmd_sp->IsUserCommand()) {
-      result.SetErrorStringWithFormat("Path component: '%s' is not a user "
-                                      "command",
-                                      name);
+      result = Status::FromErrorStringWithFormat(
+          "Path component: '%s' is not a user "
+          "command",
+          name);
       return nullptr;
     }
     CommandObjectMultiword *cmd_as_multi = cmd_sp->GetAsMultiwordCommand();
     if (!cmd_as_multi) {
-      result.SetErrorStringWithFormat("Path component: '%s' is not a container "
-                                      "command",
-                                      name);
+      result = Status::FromErrorStringWithFormat(
+          "Path component: '%s' is not a container "
+          "command",
+          name);
       return nullptr;
     }
     return cmd_as_multi;
@@ -982,7 +985,7 @@ CommandObjectMultiword *CommandInterpreter::VerifyUserMultiwordCmdPath(
 
   size_t num_args = path.GetArgumentCount();
   if (num_args == 0) {
-    result.SetErrorString("empty command path");
+    result = Status::FromErrorString("empty command path");
     return nullptr;
   }
 
@@ -1169,18 +1172,19 @@ Status CommandInterpreter::AddUserCommand(llvm::StringRef name,
     lldbassert((this == &cmd_sp->GetCommandInterpreter()) &&
                "tried to add a CommandObject from a different interpreter");
   if (name.empty()) {
-    result.SetErrorString("can't use the empty string for a command name");
+    result = Status::FromErrorString(
+        "can't use the empty string for a command name");
     return result;
   }
   // do not allow replacement of internal commands
   if (CommandExists(name)) {
-    result.SetErrorString("can't replace builtin command");
+    result = Status::FromErrorString("can't replace builtin command");
     return result;
   }
 
   if (UserCommandExists(name)) {
     if (!can_replace) {
-      result.SetErrorStringWithFormatv(
+      result = Status::FromErrorStringWithFormatv(
           "user command \"{0}\" already exists and force replace was not set "
           "by --overwrite or 'settings set interpreter.require-overwrite "
           "false'",
@@ -1189,13 +1193,14 @@ Status CommandInterpreter::AddUserCommand(llvm::StringRef name,
     }
     if (cmd_sp->IsMultiwordObject()) {
       if (!m_user_mw_dict[std::string(name)]->IsRemovable()) {
-        result.SetErrorString(
+        result = Status::FromErrorString(
             "can't replace explicitly non-removable multi-word command");
         return result;
       }
     } else {
       if (!m_user_dict[std::string(name)]->IsRemovable()) {
-        result.SetErrorString("can't replace explicitly non-removable command");
+        result = Status::FromErrorString(
+            "can't replace explicitly non-removable command");
         return result;
       }
     }
@@ -1835,16 +1840,18 @@ CommandInterpreter::PreprocessToken(std::string &expr_str) {
       if (value_string_size) {
         expr_str = value_strm.GetData();
       } else {
-        error.SetErrorStringWithFormat("expression value didn't result "
-                                       "in a scalar value for the "
-                                       "expression '%s'",
-                                       expr_str.c_str());
+        error =
+            Status::FromErrorStringWithFormat("expression value didn't result "
+                                              "in a scalar value for the "
+                                              "expression '%s'",
+                                              expr_str.c_str());
       }
     } else {
-      error.SetErrorStringWithFormat("expression value didn't result "
-                                     "in a scalar value for the "
-                                     "expression '%s'",
-                                     expr_str.c_str());
+      error =
+          Status::FromErrorStringWithFormat("expression value didn't result "
+                                            "in a scalar value for the "
+                                            "expression '%s'",
+                                            expr_str.c_str());
     }
     return error;
   }
@@ -1857,8 +1864,9 @@ CommandInterpreter::PreprocessToken(std::string &expr_str) {
     error = expr_result_valobj_sp->GetError();
 
   if (error.Success()) {
-    std::string result = lldb_private::toString(expr_result);
-    error.SetErrorString(result + "for the expression '" + expr_str + "'");
+    std::string result = lldb_private::toString(expr_result) +
+                         "for the expression '" + expr_str + "'";
+    error = Status(result);
   }
   return error;
 }

--- a/lldb/source/Interpreter/OptionArgParser.cpp
+++ b/lldb/source/Interpreter/OptionArgParser.cpp
@@ -66,12 +66,12 @@ int64_t OptionArgParser::ToOptionEnum(llvm::StringRef s,
                                       int32_t fail_value, Status &error) {
   error.Clear();
   if (enum_values.empty()) {
-    error.SetErrorString("invalid enumeration argument");
+    error = Status::FromErrorString("invalid enumeration argument");
     return fail_value;
   }
 
   if (s.empty()) {
-    error.SetErrorString("empty enumeration string");
+    error = Status::FromErrorString("empty enumeration string");
     return fail_value;
   }
 
@@ -88,7 +88,7 @@ int64_t OptionArgParser::ToOptionEnum(llvm::StringRef s,
     strm.Printf("%s\"%s\"",
         is_first ? is_first = false,"" : ", ", enum_value.string_value);
   }
-  error.SetErrorString(strm.GetString());
+  error = Status(strm.GetString().str());
   return fail_value;
 }
 
@@ -125,13 +125,14 @@ Status OptionArgParser::ToFormat(const char *s, lldb::Format &format,
       if (byte_size_ptr)
         error_strm.PutCString(
             "An optional byte size can precede the format character.\n");
-      error.SetErrorString(error_strm.GetString());
+      error = Status(error_strm.GetString().str());
     }
 
     if (error.Fail())
       return error;
   } else {
-    error.SetErrorStringWithFormat("%s option string", s ? "empty" : "invalid");
+    error = Status::FromErrorStringWithFormat("%s option string",
+                                              s ? "empty" : "invalid");
   }
   return error;
 }
@@ -185,8 +186,8 @@ OptionArgParser::DoToAddress(const ExecutionContext *exe_ctx, llvm::StringRef s,
                              Status *error_ptr) {
   if (s.empty()) {
     if (error_ptr)
-      error_ptr->SetErrorStringWithFormat("invalid address expression \"%s\"",
-                                          s.str().c_str());
+      *error_ptr = Status::FromErrorStringWithFormat(
+          "invalid address expression \"%s\"", s.str().c_str());
     return {};
   }
 
@@ -210,8 +211,8 @@ OptionArgParser::DoToAddress(const ExecutionContext *exe_ctx, llvm::StringRef s,
   Target *target = nullptr;
   if (!exe_ctx || !(target = exe_ctx->GetTargetPtr())) {
     if (error_ptr)
-      error_ptr->SetErrorStringWithFormat("invalid address expression \"%s\"",
-                                          s.str().c_str());
+      *error_ptr = Status::FromErrorStringWithFormat(
+          "invalid address expression \"%s\"", s.str().c_str());
     return {};
   }
 
@@ -239,7 +240,7 @@ OptionArgParser::DoToAddress(const ExecutionContext *exe_ctx, llvm::StringRef s,
       return addr;
     }
     if (error_ptr)
-      error_ptr->SetErrorStringWithFormat(
+      *error_ptr = Status::FromErrorStringWithFormat(
           "address expression \"%s\" resulted in a value whose type "
           "can't be converted to an address: %s",
           s.str().c_str(), valobj_sp->GetTypeName().GetCString());
@@ -314,7 +315,7 @@ OptionArgParser::DoToAddress(const ExecutionContext *exe_ctx, llvm::StringRef s,
   }
 
   if (error_ptr)
-    error_ptr->SetErrorStringWithFormat(
+    *error_ptr = Status::FromErrorStringWithFormat(
         "address expression \"%s\" evaluation failed", s.str().c_str());
   return {};
 }

--- a/lldb/source/Interpreter/OptionGroupFormat.cpp
+++ b/lldb/source/Interpreter/OptionGroupFormat.cpp
@@ -81,23 +81,23 @@ Status OptionGroupFormat::SetOptionValue(uint32_t option_idx,
 
   case 'c':
     if (m_count.GetDefaultValue() == 0) {
-      error.SetErrorString("--count option is disabled");
+      error = Status::FromErrorString("--count option is disabled");
     } else {
       error = m_count.SetValueFromString(option_arg);
       if (m_count.GetCurrentValue() == 0)
-        error.SetErrorStringWithFormat("invalid --count option value '%s'",
-                                       option_arg.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid --count option value '%s'", option_arg.str().c_str());
     }
     break;
 
   case 's':
     if (m_byte_size.GetDefaultValue() == 0) {
-      error.SetErrorString("--size option is disabled");
+      error = Status::FromErrorString("--size option is disabled");
     } else {
       error = m_byte_size.SetValueFromString(option_arg);
       if (m_byte_size.GetCurrentValue() == 0)
-        error.SetErrorStringWithFormat("invalid --size option value '%s'",
-                                       option_arg.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid --size option value '%s'", option_arg.str().c_str());
     }
     break;
 
@@ -122,8 +122,8 @@ Status OptionGroupFormat::SetOptionValue(uint32_t option_idx,
     if (!gdb_format_str.empty() ||
         (format == eFormatInvalid && byte_size == 0 && count == 0)) {
       // Nothing got set correctly
-      error.SetErrorStringWithFormat("invalid gdb format string '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid gdb format string '%s'", option_arg.str().c_str());
       return error;
     }
 
@@ -144,7 +144,7 @@ Status OptionGroupFormat::SetOptionValue(uint32_t option_idx,
       // Byte size is disabled, make sure it wasn't specified but if this is an
       // address, it's actually necessary to specify one so don't error out
       if (byte_size > 0 && format != lldb::eFormatAddressInfo) {
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "this command doesn't support specifying a byte size");
         return error;
       }
@@ -158,7 +158,8 @@ Status OptionGroupFormat::SetOptionValue(uint32_t option_idx,
     } else {
       // Count is disabled, make sure it wasn't specified
       if (count > 0) {
-        error.SetErrorString("this command doesn't support specifying a count");
+        error = Status::FromErrorString(
+            "this command doesn't support specifying a count");
         return error;
       }
     }

--- a/lldb/source/Interpreter/OptionGroupPlatform.cpp
+++ b/lldb/source/Interpreter/OptionGroupPlatform.cpp
@@ -25,7 +25,7 @@ PlatformSP OptionGroupPlatform::CreatePlatformWithOptions(
   if (!m_platform_name.empty()) {
     platform_sp = platforms.Create(m_platform_name);
     if (!platform_sp) {
-      error.SetErrorStringWithFormatv(
+      error = Status::FromErrorStringWithFormatv(
           "unable to find a plug-in for the platform named \"{0}\"",
           m_platform_name);
     }
@@ -33,9 +33,9 @@ PlatformSP OptionGroupPlatform::CreatePlatformWithOptions(
       if (platform_arch.IsValid() &&
           !platform_sp->IsCompatibleArchitecture(
               arch, {}, ArchSpec::CompatibleMatch, &platform_arch)) {
-        error.SetErrorStringWithFormatv("platform '{0}' doesn't support '{1}'",
-                                        platform_sp->GetPluginName(),
-                                        arch.GetTriple().getTriple());
+        error = Status::FromErrorStringWithFormatv(
+            "platform '{0}' doesn't support '{1}'",
+            platform_sp->GetPluginName(), arch.GetTriple().getTriple());
         platform_sp.reset();
         return platform_sp;
       }
@@ -108,8 +108,8 @@ OptionGroupPlatform::SetOptionValue(uint32_t option_idx,
 
   case 'v':
     if (m_os_version.tryParse(option_arg))
-      error.SetErrorStringWithFormatv("invalid version string '{0}'",
-                                      option_arg);
+      error = Status::FromErrorStringWithFormatv("invalid version string '{0}'",
+                                                 option_arg);
     break;
 
   case 'b':

--- a/lldb/source/Interpreter/OptionGroupPythonClassWithDict.cpp
+++ b/lldb/source/Interpreter/OptionGroupPythonClassWithDict.cpp
@@ -94,9 +94,9 @@ Status OptionGroupPythonClassWithDict::SetOptionValue(
       if (m_current_key.empty())
         m_current_key.assign(std::string(option_arg));
       else
-        error.SetErrorStringWithFormat("Key: \"%s\" missing value.",
-                                        m_current_key.c_str());
-    
+        return Status::FromErrorStringWithFormatv("Key: \"{0}\" missing value.",
+                                                  m_current_key);
+
   } break;
   case 2: {
       if (!m_dict_sp)
@@ -124,8 +124,8 @@ Status OptionGroupPythonClassWithDict::SetOptionValue(
         m_current_key.clear();
       }
       else
-        error.SetErrorStringWithFormat("Value: \"%s\" missing matching key.",
-                                       option_arg.str().c_str());
+        return Status::FromErrorStringWithFormatv(
+            "Value: \"{0}\" missing matching key.", option_arg);
   } break;
   default:
     llvm_unreachable("Unimplemented option");
@@ -149,8 +149,8 @@ Status OptionGroupPythonClassWithDict::OptionParsingFinished(
   // If we get here and there's contents in the m_current_key, somebody must
   // have provided a key but no value.
   if (!m_current_key.empty())
-      error.SetErrorStringWithFormat("Key: \"%s\" missing value.",
-                                     m_current_key.c_str());
+    error = Status::FromErrorStringWithFormat("Key: \"%s\" missing value.",
+                                              m_current_key.c_str());
   return error;
 }
 

--- a/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
+++ b/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
@@ -102,8 +102,8 @@ Status OptionGroupValueObjectDisplay::SetOptionValue(
   case 'D':
     if (option_arg.getAsInteger(0, max_depth)) {
       max_depth = UINT32_MAX;
-      error.SetErrorStringWithFormat("invalid max depth '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid max depth '%s'",
+                                                option_arg.str().c_str());
     } else {
       max_depth_is_default = false;
     }
@@ -112,16 +112,16 @@ Status OptionGroupValueObjectDisplay::SetOptionValue(
   case 'Z':
     if (option_arg.getAsInteger(0, elem_count)) {
       elem_count = UINT32_MAX;
-      error.SetErrorStringWithFormat("invalid element count '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid element count '%s'",
+                                                option_arg.str().c_str());
     }
     break;
 
   case 'P':
     if (option_arg.getAsInteger(0, ptr_depth)) {
       ptr_depth = 0;
-      error.SetErrorStringWithFormat("invalid pointer depth '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid pointer depth '%s'",
+                                                option_arg.str().c_str());
     }
     break;
 
@@ -130,23 +130,23 @@ Status OptionGroupValueObjectDisplay::SetOptionValue(
       no_summary_depth = 1;
     else if (option_arg.getAsInteger(0, no_summary_depth)) {
       no_summary_depth = 0;
-      error.SetErrorStringWithFormat("invalid pointer depth '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid pointer depth '%s'",
+                                                option_arg.str().c_str());
     }
     break;
 
   case 'S':
     use_synth = OptionArgParser::ToBoolean(option_arg, true, &success);
     if (!success)
-      error.SetErrorStringWithFormat("invalid synthetic-type '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid synthetic-type '%s'",
+                                                option_arg.str().c_str());
     break;
 
   case 'V':
     run_validator = OptionArgParser::ToBoolean(option_arg, true, &success);
     if (!success)
-      error.SetErrorStringWithFormat("invalid validate '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid validate '%s'",
+                                                option_arg.str().c_str());
     break;
 
   default:

--- a/lldb/source/Interpreter/OptionGroupVariable.cpp
+++ b/lldb/source/Interpreter/OptionGroupVariable.cpp
@@ -57,17 +57,20 @@ static const auto g_variable_options_noframe =
 
 static Status ValidateNamedSummary(const char *str, void *) {
   if (!str || !str[0])
-    return Status("must specify a valid named summary");
+    return Status::FromErrorStringWithFormat(
+        "must specify a valid named summary");
   TypeSummaryImplSP summary_sp;
   if (!DataVisualization::NamedSummaryFormats::GetSummaryFormat(
           ConstString(str), summary_sp))
-    return Status("must specify a valid named summary");
+    return Status::FromErrorStringWithFormat(
+        "must specify a valid named summary");
   return Status();
 }
 
 static Status ValidateSummaryString(const char *str, void *) {
   if (!str || !str[0])
-    return Status("must specify a non-empty summary string");
+    return Status::FromErrorStringWithFormat(
+        "must specify a non-empty summary string");
   return Status();
 }
 

--- a/lldb/source/Interpreter/OptionGroupWatchpoint.cpp
+++ b/lldb/source/Interpreter/OptionGroupWatchpoint.cpp
@@ -72,7 +72,7 @@ OptionGroupWatchpoint::SetOptionValue(uint32_t option_idx,
                   "supported languages:\n",
                   option_arg.str().c_str());
       Language::PrintSupportedLanguagesForExpressions(sstr, " ", "\n");
-      error.SetErrorString(sstr.GetString());
+      error = Status(sstr.GetString().str());
     }
     break;
   }
@@ -89,8 +89,8 @@ OptionGroupWatchpoint::SetOptionValue(uint32_t option_idx,
   case 's':
     error = watch_size.SetValueFromString(option_arg);
     if (watch_size.GetCurrentValue() == 0)
-      error.SetErrorStringWithFormat("invalid --size option value '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid --size option value '%s'", option_arg.str().c_str());
     break;
 
   default:

--- a/lldb/source/Interpreter/OptionValue.cpp
+++ b/lldb/source/Interpreter/OptionValue.cpp
@@ -37,9 +37,7 @@ OptionValue& OptionValue::operator=(const OptionValue &other) {
 Status OptionValue::SetSubValue(const ExecutionContext *exe_ctx,
                                 VarSetOperationType op, llvm::StringRef name,
                                 llvm::StringRef value) {
-  Status error;
-  error.SetErrorString("SetSubValue is not supported");
-  return error;
+  return Status::FromErrorString("SetSubValue is not supported");
 }
 
 OptionValueBoolean *OptionValue::GetAsBoolean() {
@@ -568,7 +566,7 @@ lldb::OptionValueSP OptionValue::CreateValueFromCStringForTypeMask(
   if (value_sp)
     error = value_sp->SetValueFromString(value_cstr, eVarSetOperationAssign);
   else
-    error.SetErrorString("unsupported type mask");
+    error = Status::FromErrorString("unsupported type mask");
   return value_sp;
 }
 
@@ -604,39 +602,39 @@ Status OptionValue::SetValueFromString(llvm::StringRef value,
   Status error;
   switch (op) {
   case eVarSetOperationReplace:
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%s objects do not support the 'replace' operation",
         GetTypeAsCString());
     break;
   case eVarSetOperationInsertBefore:
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%s objects do not support the 'insert-before' operation",
         GetTypeAsCString());
     break;
   case eVarSetOperationInsertAfter:
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%s objects do not support the 'insert-after' operation",
         GetTypeAsCString());
     break;
   case eVarSetOperationRemove:
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%s objects do not support the 'remove' operation", GetTypeAsCString());
     break;
   case eVarSetOperationAppend:
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%s objects do not support the 'append' operation", GetTypeAsCString());
     break;
   case eVarSetOperationClear:
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%s objects do not support the 'clear' operation", GetTypeAsCString());
     break;
   case eVarSetOperationAssign:
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%s objects do not support the 'assign' operation", GetTypeAsCString());
     break;
   case eVarSetOperationInvalid:
-    error.SetErrorStringWithFormat("invalid operation performed on a %s object",
-                                   GetTypeAsCString());
+    error = Status::FromErrorStringWithFormat(
+        "invalid operation performed on a %s object", GetTypeAsCString());
     break;
   }
   return error;

--- a/lldb/source/Interpreter/OptionValueArch.cpp
+++ b/lldb/source/Interpreter/OptionValueArch.cpp
@@ -49,8 +49,8 @@ Status OptionValueArch::SetValueFromString(llvm::StringRef value,
       m_value_was_set = true;
       NotifyValueChanged();
     } else
-      error.SetErrorStringWithFormat("unsupported architecture '%s'",
-                                     value_str.c_str());
+      error = Status::FromErrorStringWithFormat("unsupported architecture '%s'",
+                                                value_str.c_str());
     break;
   }
   case eVarSetOperationInsertBefore:

--- a/lldb/source/Interpreter/OptionValueArray.cpp
+++ b/lldb/source/Interpreter/OptionValueArray.cpp
@@ -96,10 +96,10 @@ lldb::OptionValueSP
 OptionValueArray::GetSubValue(const ExecutionContext *exe_ctx,
                               llvm::StringRef name, Status &error) const {
   if (name.empty() || name.front() != '[') {
-    error.SetErrorStringWithFormat(
-      "invalid value path '%s', %s values only support '[<index>]' subvalues "
-      "where <index> is a positive or negative array index",
-      name.str().c_str(), GetTypeAsCString());
+    error = Status::FromErrorStringWithFormat(
+        "invalid value path '%s', %s values only support '[<index>]' subvalues "
+        "where <index> is a positive or negative array index",
+        name.str().c_str(), GetTypeAsCString());
     return nullptr;
   }
 
@@ -134,17 +134,18 @@ OptionValueArray::GetSubValue(const ExecutionContext *exe_ctx,
     }
   } else {
     if (array_count == 0)
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "index %i is not valid for an empty array", idx);
     else if (idx > 0)
-      error.SetErrorStringWithFormat(
-          "index %i out of range, valid values are 0 through %" PRIu64,
-          idx, (uint64_t)(array_count - 1));
+      error = Status::FromErrorStringWithFormat(
+          "index %i out of range, valid values are 0 through %" PRIu64, idx,
+          (uint64_t)(array_count - 1));
     else
-      error.SetErrorStringWithFormat("negative index %i out of range, "
-                                      "valid values are -1 through "
-                                      "-%" PRIu64,
-                                      idx, (uint64_t)array_count);
+      error =
+          Status::FromErrorStringWithFormat("negative index %i out of range, "
+                                            "valid values are -1 through "
+                                            "-%" PRIu64,
+                                            idx, (uint64_t)array_count);
   }
   return OptionValueSP();
 }
@@ -166,7 +167,7 @@ Status OptionValueArray::SetArgs(const Args &args, VarSetOperationType op) {
   const size_t argc = args.GetArgumentCount();
   switch (op) {
   case eVarSetOperationInvalid:
-    error.SetErrorString("unsupported operation");
+    error = Status::FromErrorString("unsupported operation");
     break;
 
   case eVarSetOperationInsertBefore:
@@ -175,7 +176,7 @@ Status OptionValueArray::SetArgs(const Args &args, VarSetOperationType op) {
       uint32_t idx;
       const uint32_t count = GetSize();
       if (!llvm::to_integer(args.GetArgumentAtIndex(0), idx) || idx > count) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid insert array index %s, index must be 0 through %u",
             args.GetArgumentAtIndex(0), count);
       } else {
@@ -192,15 +193,16 @@ Status OptionValueArray::SetArgs(const Args &args, VarSetOperationType op) {
             else
               m_values.insert(m_values.begin() + idx, value_sp);
           } else {
-            error.SetErrorString(
+            error = Status::FromErrorString(
                 "array of complex types must subclass OptionValueArray");
             return error;
           }
         }
       }
     } else {
-      error.SetErrorString("insert operation takes an array index followed by "
-                           "one or more values");
+      error = Status::FromErrorString(
+          "insert operation takes an array index followed by "
+          "one or more values");
     }
     break;
 
@@ -237,12 +239,13 @@ Status OptionValueArray::SetArgs(const Args &args, VarSetOperationType op) {
           }
         }
       } else {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid array index '%s', aborting remove operation",
             args.GetArgumentAtIndex(i));
       }
     } else {
-      error.SetErrorString("remove operation takes one or more array indices");
+      error = Status::FromErrorString(
+          "remove operation takes one or more array indices");
     }
     break;
 
@@ -255,7 +258,7 @@ Status OptionValueArray::SetArgs(const Args &args, VarSetOperationType op) {
       uint32_t idx;
       const uint32_t count = GetSize();
       if (!llvm::to_integer(args.GetArgumentAtIndex(0), idx) || idx > count) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid replace array index %s, index must be 0 through %u",
             args.GetArgumentAtIndex(0), count);
       } else {
@@ -270,15 +273,16 @@ Status OptionValueArray::SetArgs(const Args &args, VarSetOperationType op) {
             else
               m_values.push_back(value_sp);
           } else {
-            error.SetErrorString(
+            error = Status::FromErrorString(
                 "array of complex types must subclass OptionValueArray");
             return error;
           }
         }
       }
     } else {
-      error.SetErrorString("replace operation takes an array index followed by "
-                           "one or more values");
+      error = Status::FromErrorString(
+          "replace operation takes an array index followed by "
+          "one or more values");
     }
     break;
 
@@ -296,7 +300,7 @@ Status OptionValueArray::SetArgs(const Args &args, VarSetOperationType op) {
         m_value_was_set = true;
         AppendValue(value_sp);
       } else {
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "array of complex types must subclass OptionValueArray");
       }
     }

--- a/lldb/source/Interpreter/OptionValueBoolean.cpp
+++ b/lldb/source/Interpreter/OptionValueBoolean.cpp
@@ -49,10 +49,10 @@ Status OptionValueBoolean::SetValueFromString(llvm::StringRef value_str,
       NotifyValueChanged();
     } else {
       if (value_str.size() == 0)
-        error.SetErrorString("invalid boolean string value <empty>");
+        error = Status::FromErrorString("invalid boolean string value <empty>");
       else
-        error.SetErrorStringWithFormat("invalid boolean string value: '%s'",
-                                       value_str.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid boolean string value: '%s'", value_str.str().c_str());
     }
   } break;
 

--- a/lldb/source/Interpreter/OptionValueChar.cpp
+++ b/lldb/source/Interpreter/OptionValueChar.cpp
@@ -47,8 +47,8 @@ Status OptionValueChar::SetValueFromString(llvm::StringRef value,
       m_current_value = char_value;
       m_value_was_set = true;
     } else
-      error.SetErrorStringWithFormat("'%s' cannot be longer than 1 character",
-                                     value.str().c_str());
+      return Status::FromErrorStringWithFormatv(
+          "'{0}' cannot be longer than 1 character", value);
   } break;
 
   default:

--- a/lldb/source/Interpreter/OptionValueEnumeration.cpp
+++ b/lldb/source/Interpreter/OptionValueEnumeration.cpp
@@ -66,7 +66,7 @@ Status OptionValueEnumeration::SetValueFromString(llvm::StringRef value,
                             m_enumerations.GetCStringAtIndex(i).GetCString());
         }
       }
-      error.SetErrorString(error_strm.GetString());
+      error = Status(error_strm.GetString().str());
     }
     break;
   }

--- a/lldb/source/Interpreter/OptionValueFileColonLine.cpp
+++ b/lldb/source/Interpreter/OptionValueFileColonLine.cpp
@@ -73,9 +73,10 @@ Status OptionValueFileColonLine::SetValueFromString(llvm::StringRef value,
 
       std::tie(left_of_last_piece, last_piece) = value.rsplit(':');
       if (last_piece.empty()) {
-        error.SetErrorStringWithFormat("Line specifier must include file and "
-                                       "line: '%s'",
-                                       value.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "Line specifier must include file and "
+            "line: '%s'",
+            value.str().c_str());
         return error;
       }
 
@@ -95,18 +96,18 @@ Status OptionValueFileColonLine::SetValueFromString(llvm::StringRef value,
         // name and pull out the line number:
         file_name = left_of_last_piece;
         if (!llvm::to_integer(last_piece, m_line_number)) {
-          error.SetErrorStringWithFormat("Bad line number value '%s' in: '%s'",
-                                         last_piece.str().c_str(),
-                                         value.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "Bad line number value '%s' in: '%s'", last_piece.str().c_str(),
+              value.str().c_str());
           return error;
         }
       } else {
         // There were three pieces, and we've got the line number.  So now
         // we just need to check the column number which was the last peice.
         if (!llvm::to_integer(last_piece, m_column_number)) {
-          error.SetErrorStringWithFormat("Bad column value '%s' in: '%s'",
-                                         last_piece.str().c_str(),
-                                         value.str().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "Bad column value '%s' in: '%s'", last_piece.str().c_str(),
+              value.str().c_str());
           return error;
         }
       }
@@ -115,7 +116,7 @@ Status OptionValueFileColonLine::SetValueFromString(llvm::StringRef value,
       m_file_spec.SetFile(file_name, FileSpec::Style::native);
       NotifyValueChanged();
     } else {
-      error.SetErrorString("invalid value string");
+      error = Status::FromErrorString("invalid value string");
     }
     break;
 

--- a/lldb/source/Interpreter/OptionValueFileSpec.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpec.cpp
@@ -67,7 +67,7 @@ Status OptionValueFileSpec::SetValueFromString(llvm::StringRef value,
       m_data_mod_time = llvm::sys::TimePoint<>();
       NotifyValueChanged();
     } else {
-      error.SetErrorString("invalid value string");
+      error = Status::FromErrorString("invalid value string");
     }
     break;
 

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -59,7 +59,7 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
       uint32_t idx;
       const uint32_t count = m_current_value.GetSize();
       if (!llvm::to_integer(args.GetArgumentAtIndex(0), idx) || idx > count) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid file list index %s, index must be 0 through %u",
             args.GetArgumentAtIndex(0), count);
       } else {
@@ -73,8 +73,9 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
         NotifyValueChanged();
       }
     } else {
-      error.SetErrorString("replace operation takes an array index followed by "
-                           "one or more values");
+      error = Status::FromErrorString(
+          "replace operation takes an array index followed by "
+          "one or more values");
     }
     break;
 
@@ -91,7 +92,7 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
       }
       NotifyValueChanged();
     } else {
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "assign operation takes at least one file path argument");
     }
     break;
@@ -102,7 +103,7 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
       uint32_t idx;
       const uint32_t count = m_current_value.GetSize();
       if (!llvm::to_integer(args.GetArgumentAtIndex(0), idx) || idx > count) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid insert file list index %s, index must be 0 through %u",
             args.GetArgumentAtIndex(0), count);
       } else {
@@ -115,8 +116,9 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
         NotifyValueChanged();
       }
     } else {
-      error.SetErrorString("insert operation takes an array index followed by "
-                           "one or more values");
+      error = Status::FromErrorString(
+          "insert operation takes an array index followed by "
+          "one or more values");
     }
     break;
 
@@ -144,12 +146,13 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
         }
         NotifyValueChanged();
       } else {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid array index '%s', aborting remove operation",
             args.GetArgumentAtIndex(i));
       }
     } else {
-      error.SetErrorString("remove operation takes one or more array index");
+      error = Status::FromErrorString(
+          "remove operation takes one or more array index");
     }
     break;
 

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -89,7 +89,7 @@ Status OptionValueFormatEntity::SetValueFromString(llvm::StringRef value_str,
       if (first_char == '"' || first_char == '\'') {
         const size_t trimmed_len = trimmed_value_str.size();
         if (trimmed_len == 1 || value_str[trimmed_len - 1] != first_char) {
-          error.SetErrorString("mismatched quotes");
+          error = Status::FromErrorString("mismatched quotes");
           return error;
         }
         value_str = trimmed_value_str.substr(1, trimmed_len - 2);

--- a/lldb/source/Interpreter/OptionValueLanguage.cpp
+++ b/lldb/source/Interpreter/OptionValueLanguage.cpp
@@ -57,7 +57,7 @@ Status OptionValueLanguage::SetValueFromString(llvm::StringRef value,
         error_strm.Printf("    %s\n",
                           Language::GetNameForLanguageType(language));
       }
-      error.SetErrorString(error_strm.GetString());
+      error = Status(error_strm.GetString().str());
     }
   } break;
 

--- a/lldb/source/Interpreter/OptionValuePathMappings.cpp
+++ b/lldb/source/Interpreter/OptionValuePathMappings.cpp
@@ -58,7 +58,7 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
       uint32_t idx;
       const uint32_t count = m_path_mappings.GetSize();
       if (!llvm::to_integer(args.GetArgumentAtIndex(0), idx) || idx > count) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid file list index %s, index must be 0 through %u",
             args.GetArgumentAtIndex(0), count);
       } else {
@@ -75,7 +75,7 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
           } else {
             std::string previousError =
                 error.Fail() ? std::string(error.AsCString()) + "\n" : "";
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "%sthe replacement path doesn't exist: \"%s\"",
                 previousError.c_str(), replace_path);
           }
@@ -84,14 +84,16 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
           NotifyValueChanged();
       }
     } else {
-      error.SetErrorString("replace operation takes an array index followed by "
-                           "one or more path pairs");
+      error = Status::FromErrorString(
+          "replace operation takes an array index followed by "
+          "one or more path pairs");
     }
     break;
 
   case eVarSetOperationAssign:
     if (argc < 2 || (argc & 1)) {
-      error.SetErrorString("assign operation takes one or more path pairs");
+      error = Status::FromErrorString(
+          "assign operation takes one or more path pairs");
       break;
     }
     m_path_mappings.Clear(m_notify_changes);
@@ -99,7 +101,8 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
     [[fallthrough]];
   case eVarSetOperationAppend:
     if (argc < 2 || (argc & 1)) {
-      error.SetErrorString("append operation takes one or more path pairs");
+      error = Status::FromErrorString(
+          "append operation takes one or more path pairs");
       break;
     } else {
       bool changed = false;
@@ -113,7 +116,7 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
         } else {
           std::string previousError =
               error.Fail() ? std::string(error.AsCString()) + "\n" : "";
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "%sthe replacement path doesn't exist: \"%s\"",
               previousError.c_str(), replace_path);
         }
@@ -131,7 +134,7 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
       uint32_t idx;
       const uint32_t count = m_path_mappings.GetSize();
       if (!llvm::to_integer(args.GetArgumentAtIndex(0), idx) || idx > count) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid file list index %s, index must be 0 through %u",
             args.GetArgumentAtIndex(0), count);
       } else {
@@ -149,7 +152,7 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
           } else {
             std::string previousError =
                 error.Fail() ? std::string(error.AsCString()) + "\n" : "";
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "%sthe replacement path doesn't exist: \"%s\"",
                 previousError.c_str(), replace_path);
           }
@@ -158,8 +161,9 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
           NotifyValueChanged();
       }
     } else {
-      error.SetErrorString("insert operation takes an array index followed by "
-                           "one or more path pairs");
+      error = Status::FromErrorString(
+          "insert operation takes an array index followed by "
+          "one or more path pairs");
     }
     break;
 
@@ -170,7 +174,7 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
         int idx;
         if (!llvm::to_integer(args.GetArgumentAtIndex(i), idx) || idx < 0 ||
             idx >= (int)m_path_mappings.GetSize()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "invalid array index '%s', aborting remove operation",
               args.GetArgumentAtIndex(i));
           break;
@@ -184,7 +188,8 @@ Status OptionValuePathMappings::SetValueFromString(llvm::StringRef value,
         m_path_mappings.Remove(index, m_notify_changes);
       NotifyValueChanged();
     } else {
-      error.SetErrorString("remove operation takes one or more array index");
+      error = Status::FromErrorString(
+          "remove operation takes one or more array index");
     }
     break;
 

--- a/lldb/source/Interpreter/OptionValueProperties.cpp
+++ b/lldb/source/Interpreter/OptionValueProperties.cpp
@@ -131,8 +131,8 @@ Status OptionValueProperties::SetSubValue(const ExecutionContext *exe_ctx,
     // Don't set an error if the path contained .experimental. - those are
     // allowed to be missing and should silently fail.
     if (!name_contains_experimental && error.AsCString() == nullptr) {
-      error.SetErrorStringWithFormat("invalid value path '%s'",
-                                     name.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid value path '%s'",
+                                                name.str().c_str());
     }
   }
   return error;

--- a/lldb/source/Interpreter/OptionValueRegex.cpp
+++ b/lldb/source/Interpreter/OptionValueRegex.cpp
@@ -51,9 +51,9 @@ Status OptionValueRegex::SetValueFromString(llvm::StringRef value,
       m_value_was_set = true;
       NotifyValueChanged();
     } else if (llvm::Error err = m_regex.GetError()) {
-      error.SetErrorString(llvm::toString(std::move(err)));
+      return Status(std::move(err));
     } else {
-      error.SetErrorString("regex error");
+      return Status::FromErrorString("regex error");
     }
     break;
   }

--- a/lldb/source/Interpreter/OptionValueSInt64.cpp
+++ b/lldb/source/Interpreter/OptionValueSInt64.cpp
@@ -48,13 +48,13 @@ Status OptionValueSInt64::SetValueFromString(llvm::StringRef value_ref,
         m_current_value = value;
         NotifyValueChanged();
       } else
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "%" PRIi64 " is out of range, valid values must be between %" PRIi64
             " and %" PRIi64 ".",
             value, m_min_value, m_max_value);
     } else {
-      error.SetErrorStringWithFormat("invalid int64_t string value: '%s'",
-                                     value_ref.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid int64_t string value: '%s'", value_ref.str().c_str());
     }
   } break;
 

--- a/lldb/source/Interpreter/OptionValueString.cpp
+++ b/lldb/source/Interpreter/OptionValueString.cpp
@@ -52,7 +52,7 @@ Status OptionValueString::SetValueFromString(llvm::StringRef value,
     case '"':
     case '\'': {
       if (value.size() <= 1 || value.back() != value.front()) {
-        error.SetErrorString("mismatched quotes");
+        error = Status::FromErrorString("mismatched quotes");
         return error;
       }
       value = value.drop_front().drop_back();

--- a/lldb/source/Interpreter/OptionValueUInt64.cpp
+++ b/lldb/source/Interpreter/OptionValueUInt64.cpp
@@ -52,14 +52,14 @@ Status OptionValueUInt64::SetValueFromString(llvm::StringRef value_ref,
         m_current_value = value;
         NotifyValueChanged();
       } else {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "%" PRIu64 " is out of range, valid values must be between %" PRIu64
             " and %" PRIu64 ".",
             value, m_min_value, m_max_value);
       }
     } else {
-      error.SetErrorStringWithFormat("invalid uint64_t string value: '%s'",
-                                     value_ref.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid uint64_t string value: '%s'", value_ref.str().c_str());
     }
   } break;
 

--- a/lldb/source/Interpreter/OptionValueUUID.cpp
+++ b/lldb/source/Interpreter/OptionValueUUID.cpp
@@ -39,8 +39,8 @@ Status OptionValueUUID::SetValueFromString(llvm::StringRef value,
   case eVarSetOperationReplace:
   case eVarSetOperationAssign: {
     if (!m_uuid.SetFromStringRef(value))
-      error.SetErrorStringWithFormat("invalid uuid string value '%s'",
-                                     value.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid uuid string value '%s'", value.str().c_str());
     else {
       m_value_was_set = true;
       NotifyValueChanged();

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -811,7 +811,8 @@ Status OptionGroupOptions::SetOptionValue(uint32_t option_idx,
         execution_context);
 
   } else {
-    error.SetErrorString("invalid option index"); // Shouldn't happen...
+    error =
+        Status::FromErrorString("invalid option index"); // Shouldn't happen...
   }
   return error;
 }
@@ -1261,7 +1262,7 @@ llvm::Expected<Args> Options::Parse(const Args &args,
                               &long_options_index);
 
     if (val == ':') {
-      error.SetErrorString("last option requires an argument");
+      error = Status::FromErrorString("last option requires an argument");
       break;
     }
 
@@ -1270,7 +1271,7 @@ llvm::Expected<Args> Options::Parse(const Args &args,
 
     // Did we get an error?
     if (val == '?') {
-      error.SetErrorString("unknown or ambiguous option");
+      error = Status::FromErrorString("unknown or ambiguous option");
       break;
     }
     // The option auto-set itself
@@ -1319,9 +1320,9 @@ llvm::Expected<Args> Options::Parse(const Args &args,
             execution_context ? execution_context : &dummy_context;
         if (validator && !validator->IsValid(*platform_sp, *exe_ctx_p)) {
           validation_failed = true;
-          error.SetErrorStringWithFormat("Option \"%s\" invalid.  %s",
-                                         def->long_option,
-                                         def->validator->LongConditionString());
+          error = Status::FromErrorStringWithFormat(
+              "Option \"%s\" invalid.  %s", def->long_option,
+              def->validator->LongConditionString());
         }
       }
 
@@ -1338,7 +1339,8 @@ llvm::Expected<Args> Options::Parse(const Args &args,
       if (error.Fail())
         break;
     } else {
-      error.SetErrorStringWithFormat("invalid option with value '%i'", val);
+      error = Status::FromErrorStringWithFormat(
+          "invalid option with value '%i'", val);
     }
   }
 

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -53,7 +53,7 @@ bool ScriptInterpreter::LoadScriptingModule(const char *filename,
                                             lldb_private::Status &error,
                                             StructuredData::ObjectSP *module_sp,
                                             FileSpec extra_search_dir) {
-  error.SetErrorString(
+  error = Status::FromErrorString(
       "This script interpreter does not support importing modules.");
   return false;
 }

--- a/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
@@ -240,13 +240,13 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                       lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType return_value_type = new_value_sp->GetCompilerType();
   if (!return_value_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -259,7 +259,7 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     const uint64_t byte_size = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -276,7 +276,7 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
             uint64_t raw_value = data.GetMaxU64(&offset, byte_size);
 
             if (!reg_ctx->WriteRegisterFromUnsigned(x0_info, raw_value))
-              error.SetErrorString("failed to write register x0");
+              error = Status::FromErrorString("failed to write register x0");
           } else {
             uint64_t raw_value = data.GetMaxU64(&offset, 8);
 
@@ -286,17 +286,18 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
               raw_value = data.GetMaxU64(&offset, byte_size - offset);
 
               if (!reg_ctx->WriteRegisterFromUnsigned(x1_info, raw_value))
-                error.SetErrorString("failed to write register x1");
+                error = Status::FromErrorString("failed to write register x1");
             }
           }
         } else {
-          error.SetErrorString("We don't support returning longer than 128 bit "
-                               "integer values at present.");
+          error = Status::FromErrorString(
+              "We don't support returning longer than 128 bit "
+              "integer values at present.");
         }
       } else if (type_flags & eTypeIsFloat) {
         if (type_flags & eTypeIsComplex) {
           // Don't handle complex yet.
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "returning complex float values are not supported");
         } else {
           const RegisterInfo *v0_info = reg_ctx->GetRegisterInfoByName("v0", 0);
@@ -307,13 +308,16 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
               error = reg_value.SetValueFromData(*v0_info, data, 0, true);
               if (error.Success())
                 if (!reg_ctx->WriteRegister(v0_info, reg_value))
-                  error.SetErrorString("failed to write register v0");
+                  error =
+                      Status::FromErrorString("failed to write register v0");
             } else {
-              error.SetErrorString("returning float values longer than 128 "
-                                   "bits are not supported");
+              error = Status::FromErrorString(
+                  "returning float values longer than 128 "
+                  "bits are not supported");
             }
           } else
-            error.SetErrorString("v0 register is not available on this target");
+            error = Status::FromErrorString(
+                "v0 register is not available on this target");
         }
       }
     } else if (type_flags & eTypeIsVector) {
@@ -326,14 +330,14 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
             error = reg_value.SetValueFromData(*v0_info, data, 0, true);
             if (error.Success()) {
               if (!reg_ctx->WriteRegister(v0_info, reg_value))
-                error.SetErrorString("failed to write register v0");
+                error = Status::FromErrorString("failed to write register v0");
             }
           }
         }
       }
     }
   } else {
-    error.SetErrorString("no registers are available");
+    error = Status::FromErrorString("no registers are available");
   }
 
   return error;

--- a/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
@@ -212,13 +212,13 @@ Status ABISysV_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                            lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType return_value_type = new_value_sp->GetCompilerType();
   if (!return_value_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -231,7 +231,7 @@ Status ABISysV_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     const uint64_t byte_size = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -249,7 +249,7 @@ Status ABISysV_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
             uint64_t raw_value = data.GetMaxU64(&offset, byte_size);
 
             if (!reg_ctx->WriteRegisterFromUnsigned(x0_info, raw_value))
-              error.SetErrorString("failed to write register x0");
+              error = Status::FromErrorString("failed to write register x0");
           } else {
             uint64_t raw_value = data.GetMaxU64(&offset, 8);
 
@@ -259,17 +259,18 @@ Status ABISysV_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
               raw_value = data.GetMaxU64(&offset, byte_size - offset);
 
               if (!reg_ctx->WriteRegisterFromUnsigned(x1_info, raw_value))
-                error.SetErrorString("failed to write register x1");
+                error = Status::FromErrorString("failed to write register x1");
             }
           }
         } else {
-          error.SetErrorString("We don't support returning longer than 128 bit "
-                               "integer values at present.");
+          error = Status::FromErrorString(
+              "We don't support returning longer than 128 bit "
+              "integer values at present.");
         }
       } else if (type_flags & eTypeIsFloat) {
         if (type_flags & eTypeIsComplex) {
           // Don't handle complex yet.
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "returning complex float values are not supported");
         } else {
           const RegisterInfo *v0_info = reg_ctx->GetRegisterInfoByName("v0", 0);
@@ -280,13 +281,16 @@ Status ABISysV_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
               error = reg_value.SetValueFromData(*v0_info, data, 0, true);
               if (error.Success())
                 if (!reg_ctx->WriteRegister(v0_info, reg_value))
-                  error.SetErrorString("failed to write register v0");
+                  error =
+                      Status::FromErrorString("failed to write register v0");
             } else {
-              error.SetErrorString("returning float values longer than 128 "
-                                   "bits are not supported");
+              error = Status::FromErrorString(
+                  "returning float values longer than 128 "
+                  "bits are not supported");
             }
           } else
-            error.SetErrorString("v0 register is not available on this target");
+            error = Status::FromErrorString(
+                "v0 register is not available on this target");
         }
       }
     } else if (type_flags & eTypeIsVector) {
@@ -299,14 +303,14 @@ Status ABISysV_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
             error = reg_value.SetValueFromData(*v0_info, data, 0, true);
             if (error.Success()) {
               if (!reg_ctx->WriteRegister(v0_info, reg_value))
-                error.SetErrorString("failed to write register v0");
+                error = Status::FromErrorString("failed to write register v0");
             }
           }
         }
       }
     }
   } else {
-    error.SetErrorString("no registers are available");
+    error = Status::FromErrorString("no registers are available");
   }
 
   return error;

--- a/lldb/source/Plugins/ABI/ARC/ABISysV_arc.cpp
+++ b/lldb/source/Plugins/ABI/ARC/ABISysV_arc.cpp
@@ -312,13 +312,13 @@ Status ABISysV_arc::SetReturnValueObject(StackFrameSP &frame_sp,
                                          ValueObjectSP &new_value_sp) {
   Status result;
   if (!new_value_sp) {
-    result.SetErrorString("Empty value object for return value.");
+    result = Status::FromErrorString("Empty value object for return value.");
     return result;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    result.SetErrorString("Null clang type for return value.");
+    result = Status::FromErrorString("Null clang type for return value.");
     return result;
   }
 
@@ -327,7 +327,8 @@ Status ABISysV_arc::SetReturnValueObject(StackFrameSP &frame_sp,
   bool is_signed = false;
   if (!compiler_type.IsIntegerOrEnumerationType(is_signed) &&
       !compiler_type.IsPointerType()) {
-    result.SetErrorString("We don't support returning other types at present");
+    result = Status::FromErrorString(
+        "We don't support returning other types at present");
     return result;
   }
 
@@ -335,7 +336,7 @@ Status ABISysV_arc::SetReturnValueObject(StackFrameSP &frame_sp,
   size_t num_bytes = new_value_sp->GetData(data, result);
 
   if (result.Fail()) {
-    result.SetErrorStringWithFormat(
+    result = Status::FromErrorStringWithFormat(
         "Couldn't convert return value to raw data: %s", result.AsCString());
     return result;
   }
@@ -347,8 +348,8 @@ Status ABISysV_arc::SetReturnValueObject(StackFrameSP &frame_sp,
     auto reg_info =
         reg_ctx.GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1);
     if (!reg_ctx.WriteRegisterFromUnsigned(reg_info, raw_value)) {
-      result.SetErrorStringWithFormat("Couldn't write value to register %s",
-                                      reg_info->name);
+      result = Status::FromErrorStringWithFormat(
+          "Couldn't write value to register %s", reg_info->name);
       return result;
     }
 
@@ -359,14 +360,14 @@ Status ABISysV_arc::SetReturnValueObject(StackFrameSP &frame_sp,
     reg_info =
         reg_ctx.GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG2);
     if (!reg_ctx.WriteRegisterFromUnsigned(reg_info, raw_value)) {
-      result.SetErrorStringWithFormat("Couldn't write value to register %s",
-                                      reg_info->name);
+      result = Status::FromErrorStringWithFormat(
+          "Couldn't write value to register %s", reg_info->name);
     }
 
     return result;
   }
 
-  result.SetErrorString(
+  result = Status::FromErrorString(
       "We don't support returning large integer values at present.");
   return result;
 }

--- a/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
@@ -1686,13 +1686,13 @@ Status ABIMacOSX_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                            lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -1711,7 +1711,7 @@ Status ABIMacOSX_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -1767,20 +1767,21 @@ Status ABIMacOSX_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         }
       }
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning float values at present");
   }
 
   if (!set_it_simple)
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "We only support setting simple integer return types at present.");
 
   return error;

--- a/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
@@ -1831,13 +1831,13 @@ Status ABISysV_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                          lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -1856,7 +1856,7 @@ Status ABISysV_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -1883,20 +1883,21 @@ Status ABISysV_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         }
       }
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning float values at present");
   }
 
   if (!set_it_simple)
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "We only support setting simple integer return types at present.");
 
   return error;

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
@@ -701,13 +701,13 @@ Status ABISysV_mips::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                           lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -726,7 +726,7 @@ Status ABISysV_mips::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -752,20 +752,21 @@ Status ABISysV_mips::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         }
       }
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning float values at present");
   }
 
   if (!set_it_simple)
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "We only support setting simple integer return types at present.");
 
   return error;

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
@@ -663,13 +663,13 @@ Status ABISysV_mips64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                             lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -678,13 +678,13 @@ Status ABISysV_mips64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
   if (!reg_ctx)
-    error.SetErrorString("no registers are available");
+    error = Status::FromErrorString("no registers are available");
 
   DataExtractor data;
   Status data_error;
   size_t num_bytes = new_value_sp->GetData(data, data_error);
   if (data_error.Fail()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't convert return value to raw data: %s",
         data_error.AsCString());
     return error;
@@ -702,7 +702,7 @@ Status ABISysV_mips64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           uint64_t raw_value = data.GetMaxU64(&offset, num_bytes);
 
           if (!reg_ctx->WriteRegisterFromUnsigned(r2_info, raw_value))
-            error.SetErrorString("failed to write register r2");
+            error = Status::FromErrorString("failed to write register r2");
         } else {
           uint64_t raw_value = data.GetMaxU64(&offset, 8);
           if (reg_ctx->WriteRegisterFromUnsigned(r2_info, raw_value)) {
@@ -711,19 +711,21 @@ Status ABISysV_mips64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
             raw_value = data.GetMaxU64(&offset, num_bytes - offset);
 
             if (!reg_ctx->WriteRegisterFromUnsigned(r3_info, raw_value))
-              error.SetErrorString("failed to write register r3");
+              error = Status::FromErrorString("failed to write register r3");
           } else
-            error.SetErrorString("failed to write register r2");
+            error = Status::FromErrorString("failed to write register r2");
         }
       } else {
-        error.SetErrorString("We don't support returning longer than 128 bit "
-                             "integer values at present.");
+        error = Status::FromErrorString(
+            "We don't support returning longer than 128 bit "
+            "integer values at present.");
       }
     } else if (type_flags & eTypeIsFloat) {
-      error.SetErrorString("TODO: Handle Float Types.");
+      error = Status::FromErrorString("TODO: Handle Float Types.");
     }
   } else if (type_flags & eTypeIsVector) {
-    error.SetErrorString("returning vector values are not supported");
+    error =
+        Status::FromErrorString("returning vector values are not supported");
   }
 
   return error;

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -415,16 +415,12 @@ bool ABISysV_ppc::GetArgumentValues(Thread &thread, ValueList &values) const {
 Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                          lldb::ValueObjectSP &new_value_sp) {
   Status error;
-  if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
-    return error;
-  }
+  if (!new_value_sp)
+    return Status::FromErrorString("Empty value object for return value.");
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
-  if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
-    return error;
-  }
+  if (!compiler_type)
+    return Status::FromErrorString("Null clang type for return value.");
 
   Thread *thread = frame_sp->GetThread().get();
 
@@ -442,12 +438,10 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     DataExtractor data;
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
-    if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+    if (data_error.Fail())
+      return Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
-      return error;
-    }
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
       uint64_t raw_value = data.GetMaxU64(&offset, num_bytes);
@@ -455,18 +449,19 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
           compiler_type.GetBitSize(frame_sp.get());
       if (!bit_width) {
-        error.SetErrorString("can't get type size");
+        error = Status::FromErrorString("can't get type size");
         return error;
       }
       if (*bit_width <= 64) {
@@ -474,7 +469,7 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         Status data_error;
         size_t num_bytes = new_value_sp->GetData(data, data_error);
         if (data_error.Fail()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "Couldn't convert return value to raw data: %s",
               data_error.AsCString());
           return error;
@@ -487,7 +482,7 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         set_it_simple = true;
       } else {
         // FIXME - don't know how to do 80 bit long doubles yet.
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "We don't support returning float values > 64 bits at present");
       }
     }
@@ -497,8 +492,9 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     // Okay we've got a structure or something that doesn't fit in a simple
     // register. We should figure out where it really goes, but we don't
     // support this yet.
-    error.SetErrorString("We only support setting simple integer and float "
-                         "return types at present.");
+    error = Status::FromErrorString(
+        "We only support setting simple integer and float "
+        "return types at present.");
   }
 
   return error;

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
@@ -295,13 +295,13 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                            lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -322,7 +322,7 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -334,18 +334,19 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
           compiler_type.GetBitSize(frame_sp.get());
       if (!bit_width) {
-        error.SetErrorString("can't get size of type");
+        error = Status::FromErrorString("can't get size of type");
         return error;
       }
       if (*bit_width <= 64) {
@@ -353,7 +354,7 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         Status data_error;
         size_t num_bytes = new_value_sp->GetData(data, data_error);
         if (data_error.Fail()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "Couldn't convert return value to raw data: %s",
               data_error.AsCString());
           return error;
@@ -366,7 +367,7 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         set_it_simple = true;
       } else {
         // FIXME - don't know how to do 80 bit long doubles yet.
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "We don't support returning float values > 64 bits at present");
       }
     }
@@ -376,8 +377,9 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     // Okay we've got a structure or something that doesn't fit in a simple
     // register. We should figure out where it really goes, but we don't
     // support this yet.
-    error.SetErrorString("We only support setting simple integer and float "
-                         "return types at present.");
+    error = Status::FromErrorString(
+        "We only support setting simple integer and float "
+        "return types at present.");
   }
 
   return error;

--- a/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
+++ b/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
@@ -291,13 +291,13 @@ Status ABISysV_riscv::SetReturnValueObject(StackFrameSP &frame_sp,
                                            ValueObjectSP &new_value_sp) {
   Status result;
   if (!new_value_sp) {
-    result.SetErrorString("Empty value object for return value.");
+    result = Status::FromErrorString("Empty value object for return value.");
     return result;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    result.SetErrorString("Null clang type for return value.");
+    result = Status::FromErrorString("Null clang type for return value.");
     return result;
   }
 
@@ -306,7 +306,8 @@ Status ABISysV_riscv::SetReturnValueObject(StackFrameSP &frame_sp,
   bool is_signed = false;
   if (!compiler_type.IsIntegerOrEnumerationType(is_signed) &&
       !compiler_type.IsPointerType()) {
-    result.SetErrorString("We don't support returning other types at present");
+    result = Status::FromErrorString(
+        "We don't support returning other types at present");
     return result;
   }
 
@@ -314,7 +315,7 @@ Status ABISysV_riscv::SetReturnValueObject(StackFrameSP &frame_sp,
   size_t num_bytes = new_value_sp->GetData(data, result);
 
   if (result.Fail()) {
-    result.SetErrorStringWithFormat(
+    result = Status::FromErrorStringWithFormat(
         "Couldn't convert return value to raw data: %s", result.AsCString());
     return result;
   }
@@ -327,8 +328,8 @@ Status ABISysV_riscv::SetReturnValueObject(StackFrameSP &frame_sp,
     auto reg_info =
         reg_ctx.GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1);
     if (!reg_ctx.WriteRegisterFromUnsigned(reg_info, raw_value)) {
-      result.SetErrorStringWithFormat("Couldn't write value to register %s",
-                                      reg_info->name);
+      result = Status::FromErrorStringWithFormat(
+          "Couldn't write value to register %s", reg_info->name);
       return result;
     }
 
@@ -344,14 +345,14 @@ Status ABISysV_riscv::SetReturnValueObject(StackFrameSP &frame_sp,
     reg_info =
         reg_ctx.GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG2);
     if (!reg_ctx.WriteRegisterFromUnsigned(reg_info, raw_value)) {
-      result.SetErrorStringWithFormat("Couldn't write value to register %s",
-                                      reg_info->name);
+      result = Status::FromErrorStringWithFormat(
+          "Couldn't write value to register %s", reg_info->name);
     }
 
     return result;
   }
 
-  result.SetErrorString(
+  result = Status::FromErrorString(
       "We don't support returning large integer values at present.");
   return result;
 }

--- a/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
+++ b/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
@@ -379,13 +379,13 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                            lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -406,7 +406,7 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -418,18 +418,19 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
           compiler_type.GetBitSize(frame_sp.get());
       if (!bit_width) {
-        error.SetErrorString("can't get type size");
+        error = Status::FromErrorString("can't get type size");
         return error;
       }
       if (*bit_width <= 64) {
@@ -439,7 +440,7 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         Status data_error;
         size_t num_bytes = new_value_sp->GetData(data, data_error);
         if (data_error.Fail()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "Couldn't convert return value to raw data: %s",
               data_error.AsCString());
           return error;
@@ -454,7 +455,7 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         set_it_simple = true;
       } else {
         // FIXME - don't know how to do long doubles yet.
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "We don't support returning float values > 64 bits at present");
       }
     }
@@ -464,8 +465,9 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     // Okay we've got a structure or something that doesn't fit in a simple
     // register. We should figure out where it really goes, but we don't
     // support this yet.
-    error.SetErrorString("We only support setting simple integer and float "
-                         "return types at present.");
+    error = Status::FromErrorString(
+        "We only support setting simple integer and float "
+        "return types at present.");
   }
 
   return error;

--- a/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
@@ -184,13 +184,13 @@ Status ABIMacOSX_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                             lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -209,7 +209,7 @@ Status ABIMacOSX_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -235,20 +235,21 @@ Status ABIMacOSX_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         }
       }
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning float values at present");
   }
 
   if (!set_it_simple)
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "We only support setting simple integer return types at present.");
 
   return error;

--- a/lldb/source/Plugins/ABI/X86/ABISysV_i386.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_i386.cpp
@@ -201,13 +201,13 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                           lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -220,7 +220,7 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   bool register_write_successful = true;
 
   if (data_error.Fail()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't convert return value to raw data: %s",
         data_error.AsCString());
     return error;
@@ -233,7 +233,8 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   if (type_flags & eTypeIsPointer) // 'Pointer'
   {
     if (num_bytes != sizeof(uint32_t)) {
-      error.SetErrorString("Pointer to be returned is not 4 bytes wide");
+      error =
+          Status::FromErrorString("Pointer to be returned is not 4 bytes wide");
       return error;
     }
     lldb::offset_t offset = 0;
@@ -318,7 +319,8 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         else if (num_bytes == 12)
           value_long_dbl = data.GetLongDouble(&offset);
         else {
-          error.SetErrorString("Invalid number of bytes for this return type");
+          error = Status::FromErrorString(
+              "Invalid number of bytes for this return type");
           return error;
         }
         st0_value.SetLongDouble(value_long_dbl);
@@ -330,22 +332,24 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
             reg_ctx->WriteRegister(ftag_info, ftag_value);
       } else if (num_bytes == 16) // handles __float128
       {
-        error.SetErrorString("Implementation is missing for this clang type.");
+        error = Status::FromErrorString(
+            "Implementation is missing for this clang type.");
       }
     } else {
       // Neither 'Integral' nor 'Floating Point'. If flow reaches here then
       // check type_flags. This type_flags is not a valid type.
-      error.SetErrorString("Invalid clang type");
+      error = Status::FromErrorString("Invalid clang type");
     }
   } else {
     /* 'Complex Floating Point', 'Packed', 'Decimal Floating Point' and
     'Aggregate' data types
     are yet to be implemented */
-    error.SetErrorString("Currently only Integral and Floating Point clang "
-                         "types are supported.");
+    error = Status::FromErrorString(
+        "Currently only Integral and Floating Point clang "
+        "types are supported.");
   }
   if (!register_write_successful)
-    error.SetErrorString("Register writing failed");
+    error = Status::FromErrorString("Register writing failed");
   return error;
 }
 

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -291,13 +291,13 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                             lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -318,7 +318,7 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -330,18 +330,19 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
           compiler_type.GetBitSize(frame_sp.get());
       if (!bit_width) {
-        error.SetErrorString("can't get type size");
+        error = Status::FromErrorString("can't get type size");
         return error;
       }
       if (*bit_width <= 64) {
@@ -352,7 +353,7 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         Status data_error;
         size_t num_bytes = new_value_sp->GetData(data, data_error);
         if (data_error.Fail()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "Couldn't convert return value to raw data: %s",
               data_error.AsCString());
           return error;
@@ -367,7 +368,7 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         set_it_simple = true;
       } else {
         // FIXME - don't know how to do 80 bit long doubles yet.
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "We don't support returning float values > 64 bits at present");
       }
     }
@@ -377,8 +378,9 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     // Okay we've got a structure or something that doesn't fit in a simple
     // register. We should figure out where it really goes, but we don't
     // support this yet.
-    error.SetErrorString("We only support setting simple integer and float "
-                         "return types at present.");
+    error = Status::FromErrorString(
+        "We only support setting simple integer and float "
+        "return types at present.");
   }
 
   return error;

--- a/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
@@ -298,13 +298,13 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
                                             lldb::ValueObjectSP &new_value_sp) {
   Status error;
   if (!new_value_sp) {
-    error.SetErrorString("Empty value object for return value.");
+    error = Status::FromErrorString("Empty value object for return value.");
     return error;
   }
 
   CompilerType compiler_type = new_value_sp->GetCompilerType();
   if (!compiler_type) {
-    error.SetErrorString("Null clang type for return value.");
+    error = Status::FromErrorString("Null clang type for return value.");
     return error;
   }
 
@@ -325,7 +325,7 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     Status data_error;
     size_t num_bytes = new_value_sp->GetData(data, data_error);
     if (data_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
           data_error.AsCString());
       return error;
@@ -337,18 +337,19 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
     } else {
-      error.SetErrorString("We don't support returning longer than 64 bit "
-                           "integer values at present.");
+      error = Status::FromErrorString(
+          "We don't support returning longer than 64 bit "
+          "integer values at present.");
     }
   } else if (compiler_type.IsFloatingPointType(count, is_complex)) {
     if (is_complex)
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
           compiler_type.GetBitSize(frame_sp.get());
       if (!bit_width) {
-        error.SetErrorString("can't get type size");
+        error = Status::FromErrorString("can't get type size");
         return error;
       }
       if (*bit_width <= 64) {
@@ -359,7 +360,7 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         Status data_error;
         size_t num_bytes = new_value_sp->GetData(data, data_error);
         if (data_error.Fail()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "Couldn't convert return value to raw data: %s",
               data_error.AsCString());
           return error;
@@ -374,7 +375,7 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         set_it_simple = true;
       } else {
         // Windows doesn't support 80 bit FP
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "Windows-x86_64 doesn't allow FP larger than 64 bits.");
       }
     }
@@ -387,8 +388,9 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     // 1) smaller that 64 bits and return by value -> RAX
     // 2) bigger than 64 bits, the caller will allocate memory for that struct
     // and pass the struct pointer in RCX then return the pointer in RAX
-    error.SetErrorString("We only support setting simple integer and float "
-                         "return types at present.");
+    error = Status::FromErrorString(
+        "We only support setting simple integer and float "
+        "return types at present.");
   }
 
   return error;

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1605,7 +1605,7 @@ DynamicLoaderDarwinKernel::GetStepThroughTrampolinePlan(Thread &thread,
 
 Status DynamicLoaderDarwinKernel::CanLoadImage() {
   Status error;
-  error.SetErrorString(
+  error = Status::FromErrorString(
       "always unsafe to load or unload shared libraries in the darwin kernel");
   return error;
 }

--- a/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.cpp
@@ -783,6 +783,5 @@ ThreadPlanSP DynamicLoaderFreeBSDKernel::GetStepThroughTrampolinePlan(
 }
 
 Status DynamicLoaderFreeBSDKernel::CanLoadImage() {
-  Status error("shared object cannot be loaded into kernel");
-  return error;
+  return Status::FromErrorString("shared object cannot be loaded into kernel");
 }

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -668,7 +668,8 @@ Status DynamicLoaderMacOS::CanLoadImage() {
       int lock_held =
           m_process->ReadUnsignedIntegerFromMemory(symbol_address, 4, 0, error);
       if (lock_held != 0) {
-        error.SetErrorString("dyld lock held - unsafe to load images.");
+        error =
+            Status::FromErrorString("dyld lock held - unsafe to load images.");
       }
     }
   } else {
@@ -678,8 +679,8 @@ Status DynamicLoaderMacOS::CanLoadImage() {
     // than one module then we are clearly past _dyld_start so in that case
     // we'll default to "it's safe".
     if (target.GetImages().GetSize() <= 1)
-      error.SetErrorString("could not find the dyld library or "
-                           "the dyld lock symbol");
+      error = Status::FromErrorString("could not find the dyld library or "
+                                      "the dyld lock symbol");
   }
   return error;
 }

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
@@ -1060,7 +1060,7 @@ Status DynamicLoaderMacOSXDYLD::CanLoadImage() {
       return error; // Success
   }
 
-  error.SetErrorString("unsafe to load or unload shared libraries");
+  error = Status::FromErrorString("unsafe to load or unload shared libraries");
   return error;
 }
 

--- a/lldb/source/Plugins/DynamicLoader/Static/DynamicLoaderStatic.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Static/DynamicLoaderStatic.cpp
@@ -130,9 +130,8 @@ DynamicLoaderStatic::GetStepThroughTrampolinePlan(Thread &thread,
 }
 
 Status DynamicLoaderStatic::CanLoadImage() {
-  Status error;
-  error.SetErrorString("can't load images on with a static debug session");
-  return error;
+  return Status::FromErrorString(
+      "can't load images on with a static debug session");
 }
 
 void DynamicLoaderStatic::Initialize() {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -161,7 +161,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
                                       "generic context";
 
         if (!variable_list_sp) {
-          err.SetErrorString(thisErrorString);
+          err = Status::FromErrorString(thisErrorString);
           return;
         }
 
@@ -170,7 +170,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
         if (!this_var_sp || !this_var_sp->IsInScope(frame) ||
             !this_var_sp->LocationIsValidForFrame(frame)) {
-          err.SetErrorString(thisErrorString);
+          err = Status::FromErrorString(thisErrorString);
           return;
         }
       }
@@ -191,7 +191,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
                                       "are in a generic context";
 
         if (!variable_list_sp) {
-          err.SetErrorString(selfErrorString);
+          err = Status::FromErrorString(selfErrorString);
           return;
         }
 
@@ -200,7 +200,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
         if (!self_variable_sp || !self_variable_sp->IsInScope(frame) ||
             !self_variable_sp->LocationIsValidForFrame(frame)) {
-          err.SetErrorString(selfErrorString);
+          err = Status::FromErrorString(selfErrorString);
           return;
         }
       }
@@ -235,7 +235,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
                                         "are in a generic context";
 
           if (!variable_list_sp) {
-            err.SetErrorString(thisErrorString);
+            err = Status::FromErrorString(thisErrorString);
             return;
           }
 
@@ -244,7 +244,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           if (!this_var_sp || !this_var_sp->IsInScope(frame) ||
               !this_var_sp->LocationIsValidForFrame(frame)) {
-            err.SetErrorString(thisErrorString);
+            err = Status::FromErrorString(thisErrorString);
             return;
           }
         }
@@ -262,7 +262,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
               "generic context";
 
           if (!variable_list_sp) {
-            err.SetErrorString(selfErrorString);
+            err = Status::FromErrorString(selfErrorString);
             return;
           }
 
@@ -271,21 +271,21 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           if (!self_variable_sp || !self_variable_sp->IsInScope(frame) ||
               !self_variable_sp->LocationIsValidForFrame(frame)) {
-            err.SetErrorString(selfErrorString);
+            err = Status::FromErrorString(selfErrorString);
             return;
           }
 
           Type *self_type = self_variable_sp->GetType();
 
           if (!self_type) {
-            err.SetErrorString(selfErrorString);
+            err = Status::FromErrorString(selfErrorString);
             return;
           }
 
           CompilerType self_clang_type = self_type->GetForwardCompilerType();
 
           if (!self_clang_type) {
-            err.SetErrorString(selfErrorString);
+            err = Status::FromErrorString(selfErrorString);
             return;
           }
 
@@ -296,7 +296,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             m_in_objectivec_method = true;
             m_needs_object_ptr = true;
           } else {
-            err.SetErrorString(selfErrorString);
+            err = Status::FromErrorString(selfErrorString);
             return;
           }
         } else {
@@ -861,7 +861,7 @@ lldb::addr_t ClangUserExpression::GetCppObjectPointer(
   lldb::addr_t ret = valobj_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
 
   if (ret == LLDB_INVALID_ADDRESS) {
-    err.SetErrorStringWithFormatv(
+    err = Status::FromErrorStringWithFormatv(
         "Couldn't load '{0}' because its value couldn't be evaluated",
         object_name);
     return LLDB_INVALID_ADDRESS;
@@ -901,8 +901,8 @@ bool ClangUserExpression::AddArguments(ExecutionContext &exe_ctx,
       object_ptr = m_ctx_obj->GetAddressOf(false, &address_type);
       if (object_ptr == LLDB_INVALID_ADDRESS ||
           address_type != eAddressTypeLoad)
-        object_ptr_error.SetErrorString("Can't get context object's "
-                                        "debuggee address");
+        object_ptr_error = Status::FromErrorString("Can't get context object's "
+                                                   "debuggee address");
     } else {
       if (m_in_cplusplus_method) {
         object_ptr =

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -692,12 +692,12 @@ ExtractRuntimeGlobalSymbol(Process *process, ConstString name,
                            uint64_t default_value = LLDB_INVALID_ADDRESS,
                            SymbolType sym_type = lldb::eSymbolTypeData) {
   if (!process) {
-    error.SetErrorString("no process");
+    error = Status::FromErrorString("no process");
     return default_value;
   }
 
   if (!module_sp) {
-    error.SetErrorString("no module");
+    error = Status::FromErrorString("no module");
     return default_value;
   }
 
@@ -707,14 +707,14 @@ ExtractRuntimeGlobalSymbol(Process *process, ConstString name,
       module_sp->FindFirstSymbolWithNameAndType(name, lldb::eSymbolTypeData);
 
   if (!symbol || !symbol->ValueIsAddress()) {
-    error.SetErrorString("no symbol");
+    error = Status::FromErrorString("no symbol");
     return default_value;
   }
 
   lldb::addr_t symbol_load_addr =
       symbol->GetAddressRef().GetLoadAddress(&process->GetTarget());
   if (symbol_load_addr == LLDB_INVALID_ADDRESS) {
-    error.SetErrorString("symbol address invalid");
+    error = Status::FromErrorString("symbol address invalid");
     return default_value;
   }
 
@@ -869,8 +869,8 @@ public:
         break;
 
       default:
-        error.SetErrorStringWithFormat("unrecognized short option '%c'",
-                                       short_option);
+        error = Status::FromErrorStringWithFormat(
+            "unrecognized short option '%c'", short_option);
         break;
       }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
@@ -418,7 +418,7 @@ Status ObjCLanguageRuntime::ObjCExceptionPrecondition::ConfigurePrecondition(
     Args &args) {
   Status error;
   if (args.GetArgumentCount() > 0)
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "The ObjC Exception breakpoint doesn't support extra options.");
   return error;
 }

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -1068,7 +1068,8 @@ ObjectFileELF::RefineModuleDetailsFromNote(lldb_private::DataExtractor &data,
       // Pull out the min version info.
       uint32_t version_info;
       if (data.GetU32(&offset, &version_info, 1) == nullptr) {
-        error.SetErrorString("failed to read FreeBSD ABI note payload");
+        error =
+            Status::FromErrorString("failed to read FreeBSD ABI note payload");
         return error;
       }
 
@@ -1099,7 +1100,8 @@ ObjectFileELF::RefineModuleDetailsFromNote(lldb_private::DataExtractor &data,
           uint32_t version_info[4];
           if (data.GetU32(&offset, &version_info[0], note.n_descsz / 4) ==
               nullptr) {
-            error.SetErrorString("failed to read GNU ABI note payload");
+            error =
+                Status::FromErrorString("failed to read GNU ABI note payload");
             return error;
           }
 
@@ -1160,7 +1162,8 @@ ObjectFileELF::RefineModuleDetailsFromNote(lldb_private::DataExtractor &data,
               // Save the build id as the UUID for the module.
               uuid = UUID(buf, note.n_descsz);
             } else {
-              error.SetErrorString("failed to read GNU_BUILD_ID note payload");
+              error = Status::FromErrorString(
+                  "failed to read GNU_BUILD_ID note payload");
               return error;
             }
           }
@@ -1180,7 +1183,8 @@ ObjectFileELF::RefineModuleDetailsFromNote(lldb_private::DataExtractor &data,
       // Pull out the version info.
       uint32_t version_info;
       if (data.GetU32(&offset, &version_info, 1) == nullptr) {
-        error.SetErrorString("failed to read NetBSD ABI note payload");
+        error =
+            Status::FromErrorString("failed to read NetBSD ABI note payload");
         return error;
       }
       // Convert the version info into a major/minor/patch number.
@@ -1251,10 +1255,11 @@ ObjectFileELF::RefineModuleDetailsFromNote(lldb_private::DataExtractor &data,
         for (size_t i = 0; i < count; ++i) {
           cstr = data.GetCStr(&offset);
           if (cstr == nullptr) {
-            error.SetErrorStringWithFormat("ObjectFileELF::%s trying to read "
-                                           "at an offset after the end "
-                                           "(GetCStr returned nullptr)",
-                                           __FUNCTION__);
+            error = Status::FromErrorStringWithFormat(
+                "ObjectFileELF::%s trying to read "
+                "at an offset after the end "
+                "(GetCStr returned nullptr)",
+                __FUNCTION__);
             return error;
           }
           llvm::StringRef path(cstr);

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6556,8 +6556,8 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
       make_core = true;
       break;
     default:
-      error.SetErrorStringWithFormat("unsupported core architecture: %s",
-                                     target_triple.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "unsupported core architecture: %s", target_triple.str().c_str());
       break;
     }
 
@@ -6837,9 +6837,10 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
             for (auto &lcnote : lc_notes) {
               if (core_file.get()->SeekFromStart(lcnote->payload_file_offset) ==
                   -1) {
-                error.SetErrorStringWithFormat("Unable to seek to corefile pos "
-                                               "to write '%s' LC_NOTE payload",
-                                               lcnote->name.c_str());
+                error = Status::FromErrorStringWithFormat(
+                    "Unable to seek to corefile pos "
+                    "to write '%s' LC_NOTE payload",
+                    lcnote->name.c_str());
                 return false;
               }
               bytes_written = lcnote->payload.GetSize();
@@ -6852,7 +6853,7 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
             // Now write the file data for all memory segments in the process
             for (const auto &segment : segment_load_commands) {
               if (core_file.get()->SeekFromStart(segment.fileoff) == -1) {
-                error.SetErrorStringWithFormat(
+                error = Status::FromErrorStringWithFormat(
                     "unable to seek to offset 0x%" PRIx64 " in '%s'",
                     segment.fileoff, core_file_path.c_str());
                 break;

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -86,10 +86,10 @@ Status MinidumpFileBuilder::AddHeaderAndCalculateDirectories() {
   Status error;
   offset_t new_offset = m_core_file->SeekFromStart(m_saved_data_size);
   if (new_offset != m_saved_data_size)
-    error.SetErrorStringWithFormat("Failed to fill in header and directory "
-                                   "sections. Written / Expected (%" PRIx64
-                                   " / %" PRIx64 ")",
-                                   new_offset, m_saved_data_size);
+    error = Status::FromErrorStringWithFormat(
+        "Failed to fill in header and directory "
+        "sections. Written / Expected (%" PRIx64 " / %" PRIx64 ")",
+        new_offset, m_saved_data_size);
 
   return error;
 }
@@ -99,14 +99,15 @@ Status MinidumpFileBuilder::AddDirectory(StreamType type,
   // We explicitly cast type, an 32b enum, to uint32_t to avoid warnings.
   Status error;
   if (GetCurrentDataEndOffset() > UINT32_MAX) {
-    error.SetErrorStringWithFormat("Unable to add directory for stream type "
-                                   "%x, offset is greater then 32 bit limit.",
-                                   (uint32_t)type);
+    error = Status::FromErrorStringWithFormat(
+        "Unable to add directory for stream type "
+        "%x, offset is greater then 32 bit limit.",
+        (uint32_t)type);
     return error;
   }
 
   if (m_directories.size() + 1 > m_expected_directories) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "Unable to add directory for stream type %x, exceeded expected number "
         "of directories %zu.",
         (uint32_t)type, m_expected_directories);
@@ -161,8 +162,9 @@ Status MinidumpFileBuilder::AddSystemInfo() {
     arch = ProcessorArchitecture::PPC;
     break;
   default:
-    error.SetErrorStringWithFormat("Architecture %s not supported.",
-                                   target_triple.getArchName().str().c_str());
+    error = Status::FromErrorStringWithFormat(
+        "Architecture %s not supported.",
+        target_triple.getArchName().str().c_str());
     return error;
   };
 
@@ -185,8 +187,8 @@ Status MinidumpFileBuilder::AddSystemInfo() {
     platform_id = OSPlatform::IOS;
     break;
   default:
-    error.SetErrorStringWithFormat("OS %s not supported.",
-                                   target_triple.getOSName().str().c_str());
+    error = Status::FromErrorStringWithFormat(
+        "OS %s not supported.", target_triple.getOSName().str().c_str());
     return error;
   };
 
@@ -203,7 +205,8 @@ Status MinidumpFileBuilder::AddSystemInfo() {
 
   error = WriteString(csd_string, &m_data);
   if (error.Fail()) {
-    error.SetErrorString("Unable to convert the csd string to UTF16.");
+    error =
+        Status::FromErrorString("Unable to convert the csd string to UTF16.");
     return error;
   }
 
@@ -219,7 +222,7 @@ Status WriteString(const std::string &to_write,
 
   bool converted = convertUTF8ToUTF16String(to_write_ref, to_write_utf16);
   if (!converted) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "Unable to convert the string to UTF16. Failed to convert %s",
         to_write.c_str());
     return error;
@@ -322,7 +325,7 @@ Status MinidumpFileBuilder::AddModuleList() {
       llvm::Error mod_size_err = maybe_mod_size.takeError();
       llvm::handleAllErrors(std::move(mod_size_err),
                             [&](const llvm::ErrorInfoBase &E) {
-                              error.SetErrorStringWithFormat(
+                              error = Status::FromErrorStringWithFormat(
                                   "Unable to get the size of module %s: %s.",
                                   module_name.c_str(), E.message().c_str());
                             });
@@ -575,7 +578,7 @@ Status MinidumpFileBuilder::FixThreadStacks() {
     size_t bytes_written = bytes_to_write;
     error = m_core_file->Write(&thread, bytes_written);
     if (error.Fail() || bytes_to_write != bytes_written) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Wrote incorrect number of bytes to minidump file. (written %zd/%zd)",
           bytes_written, bytes_to_write);
       return error;
@@ -614,7 +617,7 @@ Status MinidumpFileBuilder::AddThreadList() {
     RegisterContextSP reg_ctx_sp(thread_sp->GetRegisterContext());
 
     if (!reg_ctx_sp) {
-      error.SetErrorString("Unable to get the register context.");
+      error = Status::FromErrorString("Unable to get the register context.");
       return error;
     }
     RegisterContext *reg_ctx = reg_ctx_sp.get();
@@ -622,7 +625,7 @@ Status MinidumpFileBuilder::AddThreadList() {
     const ArchSpec &arch = target.GetArchitecture();
     ArchThreadContexts thread_context(arch.GetMachine());
     if (!thread_context.prepareRegisterContext(reg_ctx)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "architecture %s not supported.",
           arch.GetTriple().getArchName().str().c_str());
       return error;
@@ -855,9 +858,10 @@ Status MinidumpFileBuilder::AddMemoryList() {
   }
 
   if (total_size >= UINT32_MAX) {
-    error.SetErrorStringWithFormat("Unable to write minidump. Stack memory "
-                                   "exceeds 32b limit. (Num Stacks %zu)",
-                                   ranges_32.size());
+    error = Status::FromErrorStringWithFormat(
+        "Unable to write minidump. Stack memory "
+        "exceeds 32b limit. (Num Stacks %zu)",
+        ranges_32.size());
     return error;
   }
 
@@ -924,7 +928,7 @@ Status MinidumpFileBuilder::DumpHeader() const {
   error = m_core_file->Write(&header, bytes_written);
   if (error.Fail() || bytes_written != HEADER_SIZE) {
     if (bytes_written != HEADER_SIZE)
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Unable to write the minidump header (written %zd/%zd)",
           bytes_written, HEADER_SIZE);
     return error;
@@ -945,7 +949,7 @@ Status MinidumpFileBuilder::DumpDirectories() const {
     error = m_core_file->Write(&dir, bytes_written);
     if (error.Fail() || bytes_written != DIRECTORY_SIZE) {
       if (bytes_written != DIRECTORY_SIZE)
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "unable to write the directory (written %zd/%zd)", bytes_written,
             DIRECTORY_SIZE);
       return error;
@@ -1137,7 +1141,7 @@ Status MinidumpFileBuilder::AddMemoryList_64(
     error = m_core_file->Write(descriptors.data(), bytes_written);
     if (error.Fail() ||
         bytes_written != sizeof(MemoryDescriptor_64) * descriptors.size()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "unable to write the memory descriptors (written %zd/%zd)",
           bytes_written, sizeof(MemoryDescriptor_64) * descriptors.size());
     }
@@ -1174,7 +1178,7 @@ Status MinidumpFileBuilder::FlushBufferToDisk() {
     // so just decrement the remaining bytes.
     error = m_core_file->Write(m_data.GetBytes() + offset, bytes_written);
     if (error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Wrote incorrect number of bytes to minidump file. (written %" PRIx64
           "/%" PRIx64 ")",
           starting_size - remaining_bytes, starting_size);

--- a/lldb/source/Plugins/ObjectFile/PECOFF/WindowsMiniDump.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/WindowsMiniDump.cpp
@@ -36,7 +36,7 @@ bool SaveMiniDump(const lldb::ProcessSP &process_sp,
   const llvm::UTF8 *error_ptr = nullptr;
   if (!llvm::ConvertUTF8toWide(sizeof(wchar_t), file_name, result_ptr,
                                error_ptr)) {
-    error.SetErrorString("cannot convert file name");
+    error = Status::FromErrorString("cannot convert file name");
     return false;
   }
   HANDLE file_handle =

--- a/lldb/source/Plugins/Platform/Android/AdbClient.cpp
+++ b/lldb/source/Plugins/Platform/Android/AdbClient.cpp
@@ -82,7 +82,7 @@ static Status ReadAllBytes(Connection &conn, void *buffer, size_t size) {
     now = steady_clock::now();
   }
   if (total_read_bytes < size)
-    error = Status(
+    error = Status::FromErrorStringWithFormat(
         "Unable to read requested number of bytes. Connection status: %d.",
         status);
   return error;
@@ -104,9 +104,10 @@ Status AdbClient::CreateByDeviceID(const std::string &device_id,
       return error;
 
     if (connected_devices.size() != 1)
-      return Status("Expected a single connected device, got instead %zu - try "
-                    "setting 'ANDROID_SERIAL'",
-                    connected_devices.size());
+      return Status::FromErrorStringWithFormat(
+          "Expected a single connected device, got instead %zu - try "
+          "setting 'ANDROID_SERIAL'",
+          connected_devices.size());
     adb.SetDeviceID(connected_devices.front());
   } else {
     adb.SetDeviceID(android_serial);
@@ -270,7 +271,7 @@ Status AdbClient::ReadMessageStream(std::vector<char> &message,
     auto end = steady_clock::now();
     auto elapsed = end - start;
     if (elapsed >= timeout)
-      return Status("Timed out");
+      return Status::FromErrorString("Timed out");
 
     size_t n = m_conn->Read(buffer, sizeof(buffer),
                             duration_cast<microseconds>(timeout - elapsed),
@@ -299,15 +300,14 @@ Status AdbClient::ReadResponseStatus() {
 
 Status AdbClient::GetResponseError(const char *response_id) {
   if (strcmp(response_id, kFAIL) != 0)
-    return Status("Got unexpected response id from adb: \"%s\"", response_id);
+    return Status::FromErrorStringWithFormat(
+        "Got unexpected response id from adb: \"%s\"", response_id);
 
   std::vector<char> error_message;
   auto error = ReadMessage(error_message);
-  if (error.Success())
-    error.SetErrorString(
-        std::string(&error_message[0], error_message.size()).c_str());
-
-  return error;
+  if (!error.Success())
+    return error;
+  return Status(std::string(&error_message[0], error_message.size()));
 }
 
 Status AdbClient::SwitchDeviceTransport() {
@@ -324,12 +324,13 @@ Status AdbClient::SwitchDeviceTransport() {
 Status AdbClient::StartSync() {
   auto error = SwitchDeviceTransport();
   if (error.Fail())
-    return Status("Failed to switch to device transport: %s",
-                  error.AsCString());
+    return Status::FromErrorStringWithFormat(
+        "Failed to switch to device transport: %s", error.AsCString());
 
   error = Sync();
   if (error.Fail())
-    return Status("Sync failed: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Sync failed: %s",
+                                             error.AsCString());
 
   return error;
 }
@@ -352,8 +353,8 @@ Status AdbClient::internalShell(const char *command, milliseconds timeout,
 
   auto error = SwitchDeviceTransport();
   if (error.Fail())
-    return Status("Failed to switch to device transport: %s",
-                  error.AsCString());
+    return Status::FromErrorStringWithFormat(
+        "Failed to switch to device transport: %s", error.AsCString());
 
   StreamString adb_command;
   adb_command.Printf("shell:%s", command);
@@ -374,8 +375,9 @@ Status AdbClient::internalShell(const char *command, milliseconds timeout,
   static const char *kShellPrefix = "/system/bin/sh:";
   if (output_buf.size() > strlen(kShellPrefix)) {
     if (!memcmp(&output_buf[0], kShellPrefix, strlen(kShellPrefix)))
-      return Status("Shell command %s failed: %s", command,
-                    std::string(output_buf.begin(), output_buf.end()).c_str());
+      return Status::FromErrorStringWithFormat(
+          "Shell command %s failed: %s", command,
+          std::string(output_buf.begin(), output_buf.end()).c_str());
   }
 
   return Status();
@@ -404,12 +406,14 @@ Status AdbClient::ShellToFile(const char *command, milliseconds timeout,
   std::error_code EC;
   llvm::raw_fd_ostream dst(output_filename, EC, llvm::sys::fs::OF_None);
   if (EC)
-    return Status("Unable to open local file %s", output_filename.c_str());
+    return Status::FromErrorStringWithFormat("Unable to open local file %s",
+                                             output_filename.c_str());
 
   dst.write(&output_buffer[0], output_buffer.size());
   dst.close();
   if (dst.has_error())
-    return Status("Failed to write file %s", output_filename.c_str());
+    return Status::FromErrorStringWithFormat("Failed to write file %s",
+                                             output_filename.c_str());
   return Status();
 }
 
@@ -431,7 +435,8 @@ Status AdbClient::SyncService::internalPullFile(const FileSpec &remote_file,
   std::error_code EC;
   llvm::raw_fd_ostream dst(local_file_path, EC, llvm::sys::fs::OF_None);
   if (EC)
-    return Status("Unable to open local file %s", local_file_path.c_str());
+    return Status::FromErrorStringWithFormat("Unable to open local file %s",
+                                             local_file_path.c_str());
 
   const auto remote_file_path = remote_file.GetPath(false);
   auto error = SendSyncRequest(kRECV, remote_file_path.length(),
@@ -450,7 +455,8 @@ Status AdbClient::SyncService::internalPullFile(const FileSpec &remote_file,
   }
   dst.close();
   if (dst.has_error())
-    return Status("Failed to write file %s", local_file_path.c_str());
+    return Status::FromErrorStringWithFormat("Failed to write file %s",
+                                             local_file_path.c_str());
 
   local_file_remover.releaseFile();
   return error;
@@ -461,7 +467,8 @@ Status AdbClient::SyncService::internalPushFile(const FileSpec &local_file,
   const auto local_file_path(local_file.GetPath());
   std::ifstream src(local_file_path.c_str(), std::ios::in | std::ios::binary);
   if (!src.is_open())
-    return Status("Unable to open local file %s", local_file_path.c_str());
+    return Status::FromErrorStringWithFormat("Unable to open local file %s",
+                                             local_file_path.c_str());
 
   std::stringstream file_description;
   file_description << remote_file.GetPath(false).c_str() << "," << kDefaultMode;
@@ -476,7 +483,8 @@ Status AdbClient::SyncService::internalPushFile(const FileSpec &local_file,
     size_t chunk_size = src.gcount();
     error = SendSyncRequest(kDATA, chunk_size, chunk);
     if (error.Fail())
-      return Status("Failed to send file chunk: %s", error.AsCString());
+      return Status::FromErrorStringWithFormat("Failed to send file chunk: %s",
+                                               error.AsCString());
   }
   error = SendSyncRequest(
       kDONE, llvm::sys::toTimeT(FileSystem::Instance().GetModificationTime(local_file)),
@@ -488,20 +496,25 @@ Status AdbClient::SyncService::internalPushFile(const FileSpec &local_file,
   uint32_t data_len;
   error = ReadSyncHeader(response_id, data_len);
   if (error.Fail())
-    return Status("Failed to read DONE response: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to read DONE response: %s",
+                                             error.AsCString());
   if (response_id == kFAIL) {
     std::string error_message(data_len, 0);
     error = ReadAllBytes(&error_message[0], data_len);
     if (error.Fail())
-      return Status("Failed to read DONE error message: %s", error.AsCString());
-    return Status("Failed to push file: %s", error_message.c_str());
+      return Status::FromErrorStringWithFormat(
+          "Failed to read DONE error message: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to push file: %s",
+                                             error_message.c_str());
   } else if (response_id != kOKAY)
-    return Status("Got unexpected DONE response: %s", response_id.c_str());
+    return Status::FromErrorStringWithFormat("Got unexpected DONE response: %s",
+                                             response_id.c_str());
 
   // If there was an error reading the source file, finish the adb file
   // transfer first so that adb isn't expecting any more data.
   if (src.bad())
-    return Status("Failed read on %s", local_file_path.c_str());
+    return Status::FromErrorStringWithFormat("Failed read on %s",
+                                             local_file_path.c_str());
   return error;
 }
 
@@ -512,7 +525,8 @@ Status AdbClient::SyncService::internalStat(const FileSpec &remote_file,
   auto error = SendSyncRequest(kSTAT, remote_file_path.length(),
                                remote_file_path.c_str());
   if (error.Fail())
-    return Status("Failed to send request: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to send request: %s",
+                                             error.AsCString());
 
   static const size_t stat_len = strlen(kSTAT);
   static const size_t response_len = stat_len + (sizeof(uint32_t) * 3);
@@ -520,7 +534,8 @@ Status AdbClient::SyncService::internalStat(const FileSpec &remote_file,
   std::vector<char> buffer(response_len);
   error = ReadAllBytes(&buffer[0], buffer.size());
   if (error.Fail())
-    return Status("Failed to read response: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to read response: %s",
+                                             error.AsCString());
 
   DataExtractor extractor(&buffer[0], buffer.size(), eByteOrderLittle,
                           sizeof(void *));
@@ -528,10 +543,11 @@ Status AdbClient::SyncService::internalStat(const FileSpec &remote_file,
 
   const void *command = extractor.GetData(&offset, stat_len);
   if (!command)
-    return Status("Failed to get response command");
+    return Status::FromErrorStringWithFormat("Failed to get response command");
   const char *command_str = static_cast<const char *>(command);
   if (strncmp(command_str, kSTAT, stat_len))
-    return Status("Got invalid stat command: %s", command_str);
+    return Status::FromErrorStringWithFormat("Got invalid stat command: %s",
+                                             command_str);
 
   mode = extractor.GetU32(&offset);
   size = extractor.GetU32(&offset);
@@ -570,7 +586,7 @@ AdbClient::SyncService::SyncService(std::unique_ptr<Connection> &&conn)
 Status
 AdbClient::SyncService::executeCommand(const std::function<Status()> &cmd) {
   if (!m_conn)
-    return Status("SyncService is disconnected");
+    return Status::FromErrorString("SyncService is disconnected");
 
   const auto error = cmd();
   if (error.Fail())
@@ -635,10 +651,13 @@ Status AdbClient::SyncService::PullFileChunk(std::vector<char> &buffer,
     std::string error_message(data_len, 0);
     error = ReadAllBytes(&error_message[0], data_len);
     if (error.Fail())
-      return Status("Failed to read pull error message: %s", error.AsCString());
-    return Status("Failed to pull file: %s", error_message.c_str());
+      return Status::FromErrorStringWithFormat(
+          "Failed to read pull error message: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to pull file: %s",
+                                             error_message.c_str());
   } else
-    return Status("Pull failed with unknown response: %s", response_id.c_str());
+    return Status::FromErrorStringWithFormat(
+        "Pull failed with unknown response: %s", response_id.c_str());
 
   return Status();
 }

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -177,17 +177,18 @@ Status PlatformAndroid::ConnectRemote(Args &args) {
   m_device_id.clear();
 
   if (IsHost())
-    return Status("can't connect to the host platform, always connected");
+    return Status::FromErrorString(
+        "can't connect to the host platform, always connected");
 
   if (!m_remote_platform_sp)
     m_remote_platform_sp = PlatformSP(new PlatformAndroidRemoteGDBServer());
 
   const char *url = args.GetArgumentAtIndex(0);
   if (!url)
-    return Status("URL is null.");
+    return Status::FromErrorString("URL is null.");
   std::optional<URI> parsed_url = URI::Parse(url);
   if (!parsed_url)
-    return Status("Invalid URL: %s", url);
+    return Status::FromErrorStringWithFormat("Invalid URL: %s", url);
   if (parsed_url->hostname != "localhost")
     m_device_id = parsed_url->hostname.str();
 
@@ -233,7 +234,8 @@ Status PlatformAndroid::GetFile(const FileSpec &source,
             source_file.c_str());
 
   if (strchr(source_file.c_str(), '\'') != nullptr)
-    return Status("Doesn't support single-quotes in filenames");
+    return Status::FromErrorString(
+        "Doesn't support single-quotes in filenames");
 
   // mode == 0 can signify that adbd cannot access the file due security
   // constraints - try "cat ..." as a fallback.
@@ -280,7 +282,8 @@ Status PlatformAndroid::DownloadModuleSlice(const FileSpec &src_file_spec,
 
   std::string source_file = src_file_spec.GetPath(false);
   if (source_file.find('\'') != std::string::npos)
-    return Status("Doesn't support single-quotes in filenames");
+    return Status::FromErrorString(
+        "Doesn't support single-quotes in filenames");
 
   // For zip .so file, src_file_spec will be "zip_path!/so_path".
   // Extract "zip_path" from the source_file.
@@ -350,21 +353,22 @@ Status PlatformAndroid::DownloadSymbolFile(const lldb::ModuleSP &module_sp,
   // For oat file we can try to fetch additional debug info from the device
   llvm::StringRef extension = module_sp->GetFileSpec().GetFileNameExtension();
   if (extension != ".oat" && extension != ".odex")
-    return Status(
+    return Status::FromErrorString(
         "Symbol file downloading only supported for oat and odex files");
 
   // If we have no information about the platform file we can't execute oatdump
   if (!module_sp->GetPlatformFileSpec())
-    return Status("No platform file specified");
+    return Status::FromErrorString("No platform file specified");
 
   // Symbolizer isn't available before SDK version 23
   if (GetSdkVersion() < 23)
-    return Status("Symbol file generation only supported on SDK 23+");
+    return Status::FromErrorString(
+        "Symbol file generation only supported on SDK 23+");
 
   // If we already have symtab then we don't have to try and generate one
   if (module_sp->GetSectionList()->FindSectionByName(ConstString(".symtab")) !=
       nullptr)
-    return Status("Symtab already available in the module");
+    return Status::FromErrorString("Symtab already available in the module");
 
   Status error;
   AdbClientUP adb(GetAdbClient(error));
@@ -374,8 +378,9 @@ Status PlatformAndroid::DownloadSymbolFile(const lldb::ModuleSP &module_sp,
   error = adb->Shell("mktemp --directory --tmpdir /data/local/tmp", seconds(5),
                      &tmpdir);
   if (error.Fail() || tmpdir.empty())
-    return Status("Failed to generate temporary directory on the device (%s)",
-                  error.AsCString());
+    return Status::FromErrorStringWithFormat(
+        "Failed to generate temporary directory on the device (%s)",
+        error.AsCString());
   tmpdir = llvm::StringRef(tmpdir).trim().str();
 
   // Create file remover for the temporary directory created on the device
@@ -401,7 +406,8 @@ Status PlatformAndroid::DownloadSymbolFile(const lldb::ModuleSP &module_sp,
                  symfile_platform_filespec.GetPath(false).c_str());
   error = adb->Shell(command.GetData(), minutes(1), nullptr);
   if (error.Fail())
-    return Status("Oatdump failed: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Oatdump failed: %s",
+                                             error.AsCString());
 
   // Download the symbolfile from the remote device
   return GetFile(symfile_platform_filespec, dst_file_spec);
@@ -443,7 +449,7 @@ PlatformAndroid::AdbClientUP PlatformAndroid::GetAdbClient(Status &error) {
   if (adb)
     error.Clear();
   else
-    error = Status("Failed to create AdbClient");
+    error = Status::FromErrorString("Failed to create AdbClient");
   return adb;
 }
 

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroidRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroidRemoteGDBServer.cpp
@@ -50,7 +50,7 @@ static Status ForwardPortWithAdb(
             remote_socket_name.str().c_str(), local_port);
 
   if (!socket_namespace)
-    return Status("Invalid socket namespace");
+    return Status::FromErrorString("Invalid socket namespace");
 
   return adb.SetPortForwarding(local_port, remote_socket_name,
                                *socket_namespace);
@@ -114,15 +114,15 @@ Status PlatformAndroidRemoteGDBServer::ConnectRemote(Args &args) {
   m_device_id.clear();
 
   if (args.GetArgumentCount() != 1)
-    return Status(
+    return Status::FromErrorString(
         "\"platform connect\" takes a single argument: <connect-url>");
 
   const char *url = args.GetArgumentAtIndex(0);
   if (!url)
-    return Status("URL is null.");
+    return Status::FromErrorString("URL is null.");
   std::optional<URI> parsed_url = URI::Parse(url);
   if (!parsed_url)
-    return Status("Invalid URL: %s", url);
+    return Status::FromErrorStringWithFormat("Invalid URL: %s", url);
   if (parsed_url->hostname != "localhost")
     m_device_id = parsed_url->hostname.str();
 
@@ -231,8 +231,7 @@ lldb::ProcessSP PlatformAndroidRemoteGDBServer::ConnectProcess(
 
   std::optional<URI> parsed_url = URI::Parse(connect_url);
   if (!parsed_url) {
-    error.SetErrorStringWithFormat("Invalid URL: %s",
-                                   connect_url.str().c_str());
+    error = Status::FromErrorStringWithFormatv("Invalid URL: {0}", connect_url);
     return nullptr;
   }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -79,7 +79,7 @@ lldb_private::Status PlatformAppleSimulator::LaunchProcess(
     return spawned.GetError();
 #else
   Status err;
-  err.SetErrorString(UNSUPPORTED_ERROR);
+  err = Status::FromErrorString(UNSUPPORTED_ERROR);
   return err;
 #endif
 }
@@ -157,17 +157,18 @@ Status PlatformAppleSimulator::ConnectRemote(Args &args) {
             }
           });
       if (!m_device)
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "no device with UDID or name '%s' was found", arg_cstr);
     }
   } else {
-    error.SetErrorString("this command take a single UDID argument of the "
-                         "device you want to connect to.");
+    error = Status::FromErrorString(
+        "this command take a single UDID argument of the "
+        "device you want to connect to.");
   }
   return error;
 #else
   Status err;
-  err.SetErrorString(UNSUPPORTED_ERROR);
+  err = Status::FromErrorString(UNSUPPORTED_ERROR);
   return err;
 #endif
 }
@@ -178,7 +179,7 @@ Status PlatformAppleSimulator::DisconnectRemote() {
   return Status();
 #else
   Status err;
-  err.SetErrorString(UNSUPPORTED_ERROR);
+  err = Status::FromErrorString(UNSUPPORTED_ERROR);
   return err;
 #endif
 }
@@ -408,11 +409,11 @@ Status PlatformAppleSimulator::GetSymbolFile(const FileSpec &platform_file,
       if (FileSystem::Instance().Exists(local_file))
         return error;
     }
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "unable to locate a platform file for '{0}' in platform '{1}'",
         platform_file_path, GetPluginName());
   } else {
-    error.SetErrorString("invalid platform file argument");
+    error = Status::FromErrorString("invalid platform file argument");
   }
   return error;
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -65,8 +65,8 @@ static Status ExceptionMaskValidator(const char *string, void *unused) {
           || candidate == "EXC_RESOURCE"
           || candidate == "EXC_GUARD"
           || candidate == "EXC_SYSCALL")) {
-      error.SetErrorStringWithFormat("invalid exception type: '%s'",
-          candidate.str().c_str());
+      error = Status::FromErrorStringWithFormat("invalid exception type: '%s'",
+                                                candidate.str().c_str());
       return error;
     }
   }
@@ -713,7 +713,8 @@ lldb::ProcessSP PlatformDarwin::DebugProcess(ProcessLaunchInfo &launch_info,
       process_sp = m_remote_platform_sp->DebugProcess(launch_info, debugger,
                                                       target, error);
     else
-      error.SetErrorString("the platform is not currently connected");
+      error =
+          Status::FromErrorString("the platform is not currently connected");
   }
   return process_sp;
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -462,9 +462,9 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
         module_sp->SetPlatformFileSpec(module_spec.GetFileSpec());
         return Status();
       } else
-        return Status("unable to obtain valid module file");
+        return Status::FromErrorString("unable to obtain valid module file");
     } else
-      return Status("no cache path");
+      return Status::FromErrorString("no cache path");
   } else
-    return Status("unable to resolve module");
+    return Status::FromErrorString("unable to resolve module");
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -147,11 +147,11 @@ Status PlatformRemoteDarwinDevice::GetSymbolFile(const FileSpec &platform_file,
     if (FileSystem::Instance().Exists(local_file))
       return error;
 
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "unable to locate a platform file for '{0}' in platform '{1}'",
         platform_file_path, GetPluginName());
   } else {
-    error.SetErrorString("invalid platform file argument");
+    error = Status::FromErrorString("invalid platform file argument");
   }
   return error;
 }

--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -101,30 +101,31 @@ PlatformPOSIX::PutFile(const lldb_private::FileSpec &source,
     // chown uid:gid dst
     std::string src_path(source.GetPath());
     if (src_path.empty())
-      return Status("unable to get file path for source");
+      return Status::FromErrorString("unable to get file path for source");
     std::string dst_path(destination.GetPath());
     if (dst_path.empty())
-      return Status("unable to get file path for destination");
+      return Status::FromErrorString("unable to get file path for destination");
     StreamString command;
     command.Printf("cp %s %s", src_path.c_str(), dst_path.c_str());
     int status;
     RunShellCommand(command.GetData(), FileSpec(), &status, nullptr, nullptr,
                     std::chrono::seconds(10));
     if (status != 0)
-      return Status("unable to perform copy");
+      return Status::FromErrorString("unable to perform copy");
     if (uid == UINT32_MAX && gid == UINT32_MAX)
       return Status();
     if (chown_file(this, dst_path.c_str(), uid, gid) != 0)
-      return Status("unable to perform chown");
+      return Status::FromErrorString("unable to perform chown");
     return Status();
   } else if (m_remote_platform_sp) {
     if (GetSupportsRSync()) {
       std::string src_path(source.GetPath());
       if (src_path.empty())
-        return Status("unable to get file path for source");
+        return Status::FromErrorString("unable to get file path for source");
       std::string dst_path(destination.GetPath());
       if (dst_path.empty())
-        return Status("unable to get file path for destination");
+        return Status::FromErrorString(
+            "unable to get file path for destination");
       StreamString command;
       if (GetIgnoresRemoteHostname()) {
         if (!GetRSyncPrefix())
@@ -143,7 +144,8 @@ PlatformPOSIX::PutFile(const lldb_private::FileSpec &source,
       if (retcode == 0) {
         // Don't chown a local file for a remote system
         //                if (chown_file(this,dst_path.c_str(),uid,gid) != 0)
-        //                    return Status("unable to perform chown");
+        //                    return Status::FromErrorString("unable to perform
+        //                    chown");
         return Status();
       }
       // if we are still here rsync has failed - let's try the slow way before
@@ -162,14 +164,15 @@ lldb_private::Status PlatformPOSIX::GetFile(
   // Check the args, first.
   std::string src_path(source.GetPath());
   if (src_path.empty())
-    return Status("unable to get file path for source");
+    return Status::FromErrorString("unable to get file path for source");
   std::string dst_path(destination.GetPath());
   if (dst_path.empty())
-    return Status("unable to get file path for destination");
+    return Status::FromErrorString("unable to get file path for destination");
   if (IsHost()) {
     if (source == destination)
-      return Status("local scenario->source and destination are the same file "
-                    "path: no operation performed");
+      return Status::FromErrorString(
+          "local scenario->source and destination are the same file "
+          "path: no operation performed");
     // cp src dst
     StreamString cp_command;
     cp_command.Printf("cp %s %s", src_path.c_str(), dst_path.c_str());
@@ -177,7 +180,7 @@ lldb_private::Status PlatformPOSIX::GetFile(
     RunShellCommand(cp_command.GetData(), FileSpec(), &status, nullptr, nullptr,
                     std::chrono::seconds(10));
     if (status != 0)
-      return Status("unable to perform copy");
+      return Status::FromErrorString("unable to perform copy");
     return Status();
   } else if (m_remote_platform_sp) {
     if (GetSupportsRSync()) {
@@ -212,7 +215,7 @@ lldb_private::Status PlatformPOSIX::GetFile(
                                 lldb::eFilePermissionsFileDefault, error);
 
     if (fd_src == UINT64_MAX)
-      return Status("unable to open source file");
+      return Status::FromErrorString("unable to open source file");
 
     uint32_t permissions = 0;
     error = GetFilePermissions(source, permissions);
@@ -227,7 +230,7 @@ lldb_private::Status PlatformPOSIX::GetFile(
 
     if (fd_dst == UINT64_MAX) {
       if (error.Success())
-        error.SetErrorString("unable to open destination file");
+        error = Status::FromErrorString("unable to open destination file");
     }
 
     if (error.Success()) {
@@ -245,7 +248,8 @@ lldb_private::Status PlatformPOSIX::GetFile(
                                                buffer_sp->GetBytes(), n_read,
                                                error) != n_read) {
           if (!error.Fail())
-            error.SetErrorString("unable to write to destination file");
+            error =
+                Status::FromErrorString("unable to write to destination file");
           break;
         }
         offset += n_read;
@@ -258,7 +262,7 @@ lldb_private::Status PlatformPOSIX::GetFile(
     if (fd_dst != UINT64_MAX &&
         !FileCache::GetInstance().CloseFile(fd_dst, error)) {
       if (!error.Fail())
-        error.SetErrorString("unable to close destination file");
+        error = Status::FromErrorString("unable to close destination file");
     }
     return error;
   }
@@ -303,7 +307,7 @@ const lldb::UnixSignalsSP &PlatformPOSIX::GetRemoteUnixSignals() {
 Status PlatformPOSIX::ConnectRemote(Args &args) {
   Status error;
   if (IsHost()) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "can't connect to the host platform '{0}', always connected",
         GetPluginName());
   } else {
@@ -315,7 +319,8 @@ Status PlatformPOSIX::ConnectRemote(Args &args) {
     if (m_remote_platform_sp && error.Success())
       error = m_remote_platform_sp->ConnectRemote(args);
     else
-      error.SetErrorString("failed to create a 'remote-gdb-server' platform");
+      error = Status::FromErrorString(
+          "failed to create a 'remote-gdb-server' platform");
 
     if (error.Fail())
       m_remote_platform_sp.reset();
@@ -348,14 +353,15 @@ Status PlatformPOSIX::DisconnectRemote() {
   Status error;
 
   if (IsHost()) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "can't disconnect from the host platform '{0}', always connected",
         GetPluginName());
   } else {
     if (m_remote_platform_sp)
       error = m_remote_platform_sp->DisconnectRemote();
     else
-      error.SetErrorString("the platform is not currently connected");
+      error =
+          Status::FromErrorString("the platform is not currently connected");
   }
   return error;
 }
@@ -410,7 +416,8 @@ lldb::ProcessSP PlatformPOSIX::Attach(ProcessAttachInfo &attach_info,
       process_sp =
           m_remote_platform_sp->Attach(attach_info, debugger, target, error);
     else
-      error.SetErrorString("the platform is not currently connected");
+      error =
+          Status::FromErrorString("the platform is not currently connected");
   }
   return process_sp;
 }
@@ -428,7 +435,8 @@ lldb::ProcessSP PlatformPOSIX::DebugProcess(ProcessLaunchInfo &launch_info,
       process_sp = m_remote_platform_sp->DebugProcess(launch_info, debugger,
                                                       target, error);
     else
-      error.SetErrorString("the platform is not currently connected");
+      error =
+          Status::FromErrorString("the platform is not currently connected");
     return process_sp;
   }
 
@@ -451,7 +459,8 @@ lldb::ProcessSP PlatformPOSIX::DebugProcess(ProcessLaunchInfo &launch_info,
                                     nullptr, true);
 
   if (!process_sp) {
-    error.SetErrorString("CreateProcess() failed for gdb-remote process");
+    error = Status::FromErrorString(
+        "CreateProcess() failed for gdb-remote process");
     LLDB_LOG(log, "error: {0}", error);
     return process_sp;
   }
@@ -510,11 +519,11 @@ Status PlatformPOSIX::EvaluateLibdlExpression(
 
   ThreadSP thread_sp(process->GetThreadList().GetExpressionExecutionThread());
   if (!thread_sp)
-    return Status("Selected thread isn't valid");
+    return Status::FromErrorString("Selected thread isn't valid");
 
   StackFrameSP frame_sp(thread_sp->GetStackFrameAtIndex(0));
   if (!frame_sp)
-    return Status("Frame 0 isn't valid");
+    return Status::FromErrorString("Frame 0 isn't valid");
 
   ExecutionContext exe_ctx;
   frame_sp->CalculateExecutionContext(exe_ctx);
@@ -616,7 +625,7 @@ PlatformPOSIX::MakeLoadImageUtilityFunction(ExecutionContext &exe_ctx,
       std::move(expr), dlopen_wrapper_name, eLanguageTypeC_plus_plus, exe_ctx);
   if (!utility_fn_or_error) {
     std::string error_str = llvm::toString(utility_fn_or_error.takeError());
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not create utility function: %s",
         error_str.c_str());
     return nullptr;
@@ -653,7 +662,7 @@ PlatformPOSIX::MakeLoadImageUtilityFunction(ExecutionContext &exe_ctx,
   do_dlopen_function = dlopen_utility_func_up->MakeFunctionCaller(
       clang_void_pointer_type, arguments, exe_ctx.GetThreadSP(), utility_error);
   if (utility_error.Fail()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not make function caller: %s",
         utility_error.AsCString());
     return nullptr;
@@ -661,7 +670,8 @@ PlatformPOSIX::MakeLoadImageUtilityFunction(ExecutionContext &exe_ctx,
   
   do_dlopen_function = dlopen_utility_func_up->GetFunctionCaller();
   if (!do_dlopen_function) {
-    error.SetErrorString("dlopen error: could not get function caller.");
+    error =
+        Status::FromErrorString("dlopen error: could not get function caller.");
     return nullptr;
   }
   
@@ -682,7 +692,8 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
 
   ThreadSP thread_sp = process->GetThreadList().GetExpressionExecutionThread();
   if (!thread_sp) {
-    error.SetErrorString("dlopen error: no thread available to call dlopen.");
+    error = Status::FromErrorString(
+        "dlopen error: no thread available to call dlopen.");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
   
@@ -708,7 +719,8 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
     
   do_dlopen_function = dlopen_utility_func->GetFunctionCaller();
   if (!do_dlopen_function) {
-    error.SetErrorString("dlopen error: could not get function caller.");
+    error =
+        Status::FromErrorString("dlopen error: could not get function caller.");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
   arguments = do_dlopen_function->GetArgumentValues();
@@ -721,7 +733,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                                    permissions,
                                                    utility_error);
   if (path_addr == LLDB_INVALID_ADDRESS) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not allocate memory for path: %s",
         utility_error.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
@@ -735,7 +747,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
 
   process->WriteMemory(path_addr, path.c_str(), path_len, utility_error);
   if (utility_error.Fail()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not write path string: %s",
         utility_error.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
@@ -748,7 +760,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                                       permissions,
                                                       utility_error);
   if (utility_error.Fail()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not allocate memory for path: %s",
         utility_error.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
@@ -797,7 +809,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                               permissions,
                                               utility_error);
     if (path_array_addr == LLDB_INVALID_ADDRESS) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "dlopen error: could not allocate memory for path array: %s",
           utility_error.AsCString());
       return LLDB_INVALID_IMAGE_TOKEN;
@@ -813,7 +825,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                          path_array.size(), utility_error);
 
     if (utility_error.Fail()) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "dlopen error: could not write path array: %s",
           utility_error.AsCString());
       return LLDB_INVALID_IMAGE_TOKEN;
@@ -826,7 +838,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                           permissions,
                                           utility_error);
     if (buffer_addr == LLDB_INVALID_ADDRESS) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "dlopen error: could not allocate memory for buffer: %s",
           utility_error.AsCString());
       return LLDB_INVALID_IMAGE_TOKEN;
@@ -851,7 +863,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                                  func_args_addr,
                                                  arguments,
                                                  diagnostics)) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not write function arguments: %s",
         diagnostics.GetString().c_str());
     return LLDB_INVALID_IMAGE_TOKEN;
@@ -881,7 +893,8 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   TypeSystemClangSP scratch_ts_sp =
       ScratchTypeSystemClang::GetForTarget(process->GetTarget());
   if (!scratch_ts_sp) {
-    error.SetErrorString("dlopen error: Unable to get TypeSystemClang");
+    error =
+        Status::FromErrorString("dlopen error: Unable to get TypeSystemClang");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -893,7 +906,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   ExpressionResults results = do_dlopen_function->ExecuteFunction(
       exe_ctx, &func_args_addr, options, diagnostics, return_value);
   if (results != eExpressionCompleted) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: failed executing dlopen wrapper function: %s",
         diagnostics.GetString().c_str());
     return LLDB_INVALID_IMAGE_TOKEN;
@@ -903,7 +916,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   lldb::addr_t token = process->ReadPointerFromMemory(return_addr, 
                                                       utility_error);
   if (utility_error.Fail()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not read the return struct: %s",
         utility_error.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
@@ -928,7 +941,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   lldb::addr_t error_addr 
     = process->ReadPointerFromMemory(return_addr + addr_size, utility_error);
   if (utility_error.Fail()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "dlopen error: could not read error string: %s",
         utility_error.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
@@ -938,10 +951,11 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                                     dlopen_error_str, 
                                                     utility_error);
   if (utility_error.Success() && num_chars > 0)
-    error.SetErrorStringWithFormat("dlopen error: %s",
-                                   dlopen_error_str.c_str());
+    error = Status::FromErrorStringWithFormat("dlopen error: %s",
+                                              dlopen_error_str.c_str());
   else
-    error.SetErrorStringWithFormat("dlopen failed for unknown reasons.");
+    error =
+        Status::FromErrorStringWithFormat("dlopen failed for unknown reasons.");
 
   return LLDB_INVALID_IMAGE_TOKEN;
 }
@@ -950,7 +964,7 @@ Status PlatformPOSIX::UnloadImage(lldb_private::Process *process,
                                   uint32_t image_token) {
   const addr_t image_addr = process->GetImagePtrFromToken(image_token);
   if (image_addr == LLDB_INVALID_IMAGE_TOKEN)
-    return Status("Invalid image token");
+    return Status::FromErrorString("Invalid image token");
 
   StreamString expr;
   expr.Printf("dlclose((void *)0x%" PRIx64 ")", image_addr);
@@ -967,7 +981,8 @@ Status PlatformPOSIX::UnloadImage(lldb_private::Process *process,
   Scalar scalar;
   if (result_valobj_sp->ResolveValue(scalar)) {
     if (scalar.UInt(1))
-      return Status("expression failed: \"%s\"", expr.GetData());
+      return Status::FromErrorStringWithFormat("expression failed: \"%s\"",
+                                               expr.GetData());
     process->ResetImageToken(image_token);
   }
   return Status();

--- a/lldb/source/Plugins/Platform/QemuUser/PlatformQemuUser.cpp
+++ b/lldb/source/Plugins/Platform/QemuUser/PlatformQemuUser.cpp
@@ -225,7 +225,7 @@ lldb::ProcessSP PlatformQemuUser::DebugProcess(ProcessLaunchInfo &launch_info,
       process_gdb_remote::ProcessGDBRemote::GetPluginNameStatic(), nullptr,
       true);
   if (!process_sp) {
-    error.SetErrorString("Failed to create GDB process");
+    error = Status::FromErrorString("Failed to create GDB process");
     return nullptr;
   }
 

--- a/lldb/source/Plugins/Platform/QemuUser/PlatformQemuUser.h
+++ b/lldb/source/Plugins/Platform/QemuUser/PlatformQemuUser.h
@@ -41,7 +41,7 @@ public:
 
   lldb::ProcessSP Attach(ProcessAttachInfo &attach_info, Debugger &debugger,
                          Target *target, Status &status) override {
-    status.SetErrorString("Not supported");
+    status = Status::FromErrorString("Not supported");
     return nullptr;
   }
 

--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -133,7 +133,7 @@ PlatformWindows::PlatformWindows(bool is_host) : RemoteAwarePlatform(is_host) {
 Status PlatformWindows::ConnectRemote(Args &args) {
   Status error;
   if (IsHost()) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "can't connect to the host platform '{0}', always connected",
         GetPluginName());
   } else {
@@ -147,12 +147,13 @@ Status PlatformWindows::ConnectRemote(Args &args) {
         if (m_remote_platform_sp) {
           error = m_remote_platform_sp->ConnectRemote(args);
         } else {
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "\"platform connect\" takes a single argument: <connect-url>");
         }
       }
     } else
-      error.SetErrorString("failed to create a 'remote-gdb-server' platform");
+      error = Status::FromErrorString(
+          "failed to create a 'remote-gdb-server' platform");
 
     if (error.Fail())
       m_remote_platform_sp.reset();
@@ -172,7 +173,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
 
   ThreadSP thread = process->GetThreadList().GetExpressionExecutionThread();
   if (!thread) {
-    error.SetErrorString("LoadLibrary error: no thread available to invoke LoadLibrary");
+    error = Status::FromErrorString(
+        "LoadLibrary error: no thread available to invoke LoadLibrary");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -189,14 +191,16 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
 
   FunctionCaller *invocation = loader->GetFunctionCaller();
   if (!invocation) {
-    error.SetErrorString("LoadLibrary error: could not get function caller");
+    error = Status::FromErrorString(
+        "LoadLibrary error: could not get function caller");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
   /* Convert name */
   llvm::SmallVector<llvm::UTF16, 261> name;
   if (!llvm::convertUTF8ToUTF16String(remote_file.GetPath(), name)) {
-    error.SetErrorString("LoadLibrary error: could not convert path to UCS2");
+    error = Status::FromErrorString(
+        "LoadLibrary error: could not convert path to UCS2");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
   name.emplace_back(L'\0');
@@ -207,8 +211,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
                               ePermissionsReadable | ePermissionsWritable,
                               status);
   if (injected_name == LLDB_INVALID_ADDRESS) {
-    error.SetErrorStringWithFormat("LoadLibrary error: unable to allocate memory for name: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: unable to allocate memory for name: %s",
+        status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -219,8 +224,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   process->WriteMemory(injected_name, name.data(),
                        name.size() * sizeof(llvm::UTF16), status);
   if (status.Fail()) {
-    error.SetErrorStringWithFormat("LoadLibrary error: unable to write name: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: unable to write name: %s", status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -248,8 +253,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
                                 ePermissionsReadable | ePermissionsWritable,
                                 status);
     if (injected_paths == LLDB_INVALID_ADDRESS) {
-      error.SetErrorStringWithFormat("LoadLibrary error: unable to allocate memory for paths: %s",
-                                     status.AsCString());
+      error = Status::FromErrorStringWithFormat(
+          "LoadLibrary error: unable to allocate memory for paths: %s",
+          status.AsCString());
       return LLDB_INVALID_IMAGE_TOKEN;
     }
 
@@ -260,8 +266,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
     process->WriteMemory(injected_paths, search_paths.data(),
                          search_paths.size() * sizeof(llvm::UTF16), status);
     if (status.Fail()) {
-      error.SetErrorStringWithFormat("LoadLibrary error: unable to write paths: %s",
-                                     status.AsCString());
+      error = Status::FromErrorStringWithFormat(
+          "LoadLibrary error: unable to write paths: %s", status.AsCString());
       return LLDB_INVALID_IMAGE_TOKEN;
     }
   }
@@ -277,8 +283,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
                               ePermissionsReadable | ePermissionsWritable,
                               status);
   if (injected_module_path == LLDB_INVALID_ADDRESS) {
-    error.SetErrorStringWithFormat("LoadLibrary error: unable to allocate memory for module location: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: unable to allocate memory for module location: %s",
+        status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -294,8 +301,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
                               ePermissionsReadable | ePermissionsWritable,
                               status);
   if (status.Fail()) {
-    error.SetErrorStringWithFormat("LoadLibrary error: could not allocate memory for result: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: could not allocate memory for result: %s",
+        status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -306,8 +314,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   process->WritePointerToMemory(injected_result + word_size,
                                 injected_module_path, status);
   if (status.Fail()) {
-    error.SetErrorStringWithFormat("LoadLibrary error: could not initialize result: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: could not initialize result: %s",
+        status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -316,8 +325,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
                                Scalar{injected_length}, sizeof(unsigned),
                                status);
   if (status.Fail()) {
-    error.SetErrorStringWithFormat("LoadLibrary error: could not initialize result: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: could not initialize result: %s",
+        status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -331,8 +341,9 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   diagnostics.Clear();
   if (!invocation->WriteFunctionArguments(context, injected_parameters,
                                           parameters, diagnostics)) {
-    error.SetErrorStringWithFormat("LoadLibrary error: unable to write function parameters: %s",
-                                   diagnostics.GetString().c_str());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: unable to write function parameters: %s",
+        diagnostics.GetString().c_str());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -344,7 +355,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   TypeSystemClangSP scratch_ts_sp =
       ScratchTypeSystemClang::GetForTarget(process->GetTarget());
   if (!scratch_ts_sp) {
-    error.SetErrorString("LoadLibrary error: unable to get (clang) type system");
+    error = Status::FromErrorString(
+        "LoadLibrary error: unable to get (clang) type system");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -372,16 +384,17 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
       invocation->ExecuteFunction(context, &injected_parameters, options,
                                   diagnostics, value);
   if (result != eExpressionCompleted) {
-    error.SetErrorStringWithFormat("LoadLibrary error: failed to execute LoadLibrary helper: %s",
-                                   diagnostics.GetString().c_str());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: failed to execute LoadLibrary helper: %s",
+        diagnostics.GetString().c_str());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
   /* Read result */
   lldb::addr_t token = process->ReadPointerFromMemory(injected_result, status);
   if (status.Fail()) {
-    error.SetErrorStringWithFormat("LoadLibrary error: could not read the result: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: could not read the result: %s", status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -391,20 +404,23 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
         process->ReadUnsignedIntegerFromMemory(injected_result + 2 * word_size + sizeof(unsigned),
                                                word_size, 0, status);
     if (status.Fail()) {
-      error.SetErrorStringWithFormat("LoadLibrary error: could not read error status: %s",
-                                     status.AsCString());
+      error = Status::FromErrorStringWithFormat(
+          "LoadLibrary error: could not read error status: %s",
+          status.AsCString());
       return LLDB_INVALID_IMAGE_TOKEN;
     }
 
-    error.SetErrorStringWithFormat("LoadLibrary Error: %" PRIu64, error_code);
+    error = Status::FromErrorStringWithFormat("LoadLibrary Error: %" PRIu64,
+                                              error_code);
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
   std::string module_path;
   process->ReadCStringFromMemory(injected_module_path, module_path, status);
   if (status.Fail()) {
-    error.SetErrorStringWithFormat("LoadLibrary error: could not read module path: %s",
-                                   status.AsCString());
+    error = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: could not read module path: %s",
+        status.AsCString());
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
@@ -416,7 +432,7 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
 Status PlatformWindows::UnloadImage(Process *process, uint32_t image_token) {
   const addr_t address = process->GetImagePtrFromToken(image_token);
   if (address == LLDB_INVALID_IMAGE_TOKEN)
-    return Status("invalid image token");
+    return Status::FromErrorString("invalid image token");
 
   StreamString expression;
   expression.Printf("FreeLibrary((HMODULE)0x%" PRIx64 ")", address);
@@ -433,7 +449,8 @@ Status PlatformWindows::UnloadImage(Process *process, uint32_t image_token) {
   Scalar scalar;
   if (value->ResolveValue(scalar)) {
     if (scalar.UInt(1))
-      return Status("expression failed: \"%s\"", expression.GetData());
+      return Status::FromErrorStringWithFormat("expression failed: \"%s\"",
+                                               expression.GetData());
     process->ResetImageToken(image_token);
   }
 
@@ -444,14 +461,15 @@ Status PlatformWindows::DisconnectRemote() {
   Status error;
 
   if (IsHost()) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "can't disconnect from the host platform '{0}', always connected",
         GetPluginName());
   } else {
     if (m_remote_platform_sp)
       error = m_remote_platform_sp->DisconnectRemote();
     else
-      error.SetErrorString("the platform is not currently connected");
+      error =
+          Status::FromErrorString("the platform is not currently connected");
   }
   return error;
 }
@@ -483,7 +501,8 @@ ProcessSP PlatformWindows::DebugProcess(ProcessLaunchInfo &launch_info,
       return m_remote_platform_sp->DebugProcess(launch_info, debugger, target,
                                                 error);
     else
-      error.SetErrorString("the platform is not currently connected");
+      error =
+          Status::FromErrorString("the platform is not currently connected");
   }
 
   if (launch_info.GetProcessID() != LLDB_INVALID_PROCESS_ID) {
@@ -516,7 +535,8 @@ lldb::ProcessSP PlatformWindows::Attach(ProcessAttachInfo &attach_info,
       process_sp =
           m_remote_platform_sp->Attach(attach_info, debugger, target, error);
     else
-      error.SetErrorString("the platform is not currently connected");
+      error =
+          Status::FromErrorString("the platform is not currently connected");
     return process_sp;
   }
 
@@ -680,8 +700,9 @@ void * __lldb_LoadLibraryHelper(const wchar_t *name, const wchar_t *paths,
                                                context);
   if (!function) {
     std::string error = llvm::toString(function.takeError());
-    status.SetErrorStringWithFormat("LoadLibrary error: could not create utility function: %s",
-                                    error.c_str());
+    status = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: could not create utility function: %s",
+        error.c_str());
     return nullptr;
   }
 
@@ -712,13 +733,15 @@ void * __lldb_LoadLibraryHelper(const wchar_t *name, const wchar_t *paths,
   utility->MakeFunctionCaller(VoidPtrTy, parameters, context.GetThreadSP(),
                               error);
   if (error.Fail()) {
-    status.SetErrorStringWithFormat("LoadLibrary error: could not create function caller: %s",
-                                    error.AsCString());
+    status = Status::FromErrorStringWithFormat(
+        "LoadLibrary error: could not create function caller: %s",
+        error.AsCString());
     return nullptr;
   }
 
   if (!utility->GetFunctionCaller()) {
-    status.SetErrorString("LoadLibrary error: could not get function caller");
+    status = Status::FromErrorString(
+        "LoadLibrary error: could not get function caller");
     return nullptr;
   }
 
@@ -755,11 +778,11 @@ extern "C" {
 
   ThreadSP thread = process->GetThreadList().GetExpressionExecutionThread();
   if (!thread)
-    return Status("selected thread is invalid");
+    return Status::FromErrorString("selected thread is invalid");
 
   StackFrameSP frame = thread->GetStackFrameAtIndex(0);
   if (!frame)
-    return Status("frame 0 is invalid");
+    return Status::FromErrorString("frame 0 is invalid");
 
   ExecutionContext context;
   frame->CalculateExecutionContext(context);

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -215,27 +215,24 @@ bool PlatformRemoteGDBServer::IsConnected() const {
 
 Status PlatformRemoteGDBServer::ConnectRemote(Args &args) {
   Status error;
-  if (IsConnected()) {
-    error.SetErrorStringWithFormat("the platform is already connected to '%s', "
-                                   "execute 'platform disconnect' to close the "
-                                   "current connection",
-                                   GetHostname());
-    return error;
-  }
+  if (IsConnected())
+    return Status::FromErrorStringWithFormat(
+        "the platform is already connected to '%s', "
+        "execute 'platform disconnect' to close the "
+        "current connection",
+        GetHostname());
 
-  if (args.GetArgumentCount() != 1) {
-    error.SetErrorString(
+  if (args.GetArgumentCount() != 1)
+    return Status::FromErrorString(
         "\"platform connect\" takes a single argument: <connect-url>");
-    return error;
-  }
 
   const char *url = args.GetArgumentAtIndex(0);
   if (!url)
-    return Status("URL is null.");
+    return Status::FromErrorString("URL is null.");
 
   std::optional<URI> parsed_url = URI::Parse(url);
   if (!parsed_url)
-    return Status("Invalid URL: %s", url);
+    return Status::FromErrorStringWithFormat("Invalid URL: %s", url);
 
   // We're going to reuse the hostname when we connect to the debugserver.
   m_platform_scheme = parsed_url->scheme.str();
@@ -270,7 +267,7 @@ Status PlatformRemoteGDBServer::ConnectRemote(Args &args) {
   } else {
     client_up->Disconnect();
     if (error.Success())
-      error.SetErrorString("handshake failed");
+      error = Status::FromErrorString("handshake failed");
   }
   return error;
 }
@@ -328,7 +325,7 @@ Status PlatformRemoteGDBServer::LaunchProcess(ProcessLaunchInfo &launch_info) {
   LLDB_LOGF(log, "PlatformRemoteGDBServer::%s() called", __FUNCTION__);
 
   if (!IsConnected())
-    return Status("Not connected.");
+    return Status::FromErrorStringWithFormat("Not connected.");
   auto num_file_actions = launch_info.GetNumFileActions();
   for (decltype(num_file_actions) i = 0; i < num_file_actions; ++i) {
     const auto file_action = launch_info.GetFileActionAtIndex(i);
@@ -379,9 +376,9 @@ Status PlatformRemoteGDBServer::LaunchProcess(ProcessLaunchInfo &launch_info) {
     if (FileSpec exe_file = launch_info.GetExecutableFile())
       args.ReplaceArgumentAtIndex(0, exe_file.GetPath(false));
     if (llvm::Error err = m_gdb_client_up->LaunchProcess(args)) {
-      error.SetErrorStringWithFormatv("Cannot launch '{0}': {1}",
-                                      args.GetArgumentAtIndex(0),
-                                      llvm::fmt_consume(std::move(err)));
+      error = Status::FromErrorStringWithFormatv(
+          "Cannot launch '{0}': {1}", args.GetArgumentAtIndex(0),
+          llvm::fmt_consume(std::move(err)));
       return error;
     }
   }
@@ -398,14 +395,15 @@ Status PlatformRemoteGDBServer::LaunchProcess(ProcessLaunchInfo &launch_info) {
               "PlatformRemoteGDBServer::%s() launch succeeded but we "
               "didn't get a valid process id back!",
               __FUNCTION__);
-    error.SetErrorString("failed to get PID");
+    error = Status::FromErrorString("failed to get PID");
   }
   return error;
 }
 
 Status PlatformRemoteGDBServer::KillProcess(const lldb::pid_t pid) {
   if (!KillSpawnedProcess(pid))
-    return Status("failed to kill remote spawned process");
+    return Status::FromErrorStringWithFormat(
+        "failed to kill remote spawned process");
   return Status();
 }
 
@@ -419,8 +417,8 @@ PlatformRemoteGDBServer::DebugProcess(ProcessLaunchInfo &launch_info,
       lldb::pid_t debugserver_pid = LLDB_INVALID_PROCESS_ID;
       std::string connect_url;
       if (!LaunchGDBServer(debugserver_pid, connect_url)) {
-        error.SetErrorStringWithFormat("unable to launch a GDB server on '%s'",
-                                       GetHostname());
+        error = Status::FromErrorStringWithFormat(
+            "unable to launch a GDB server on '%s'", GetHostname());
       } else {
         // The darwin always currently uses the GDB remote debugger plug-in
         // so even when debugging locally we are debugging remotely!
@@ -444,7 +442,7 @@ PlatformRemoteGDBServer::DebugProcess(ProcessLaunchInfo &launch_info,
         }
       }
     } else {
-      error.SetErrorString("not connected to remote gdb server");
+      error = Status::FromErrorString("not connected to remote gdb server");
     }
   }
   return process_sp;
@@ -498,8 +496,8 @@ lldb::ProcessSP PlatformRemoteGDBServer::Attach(
       lldb::pid_t debugserver_pid = LLDB_INVALID_PROCESS_ID;
       std::string connect_url;
       if (!LaunchGDBServer(debugserver_pid, connect_url)) {
-        error.SetErrorStringWithFormat("unable to launch a GDB server on '%s'",
-                                       GetHostname());
+        error = Status::FromErrorStringWithFormat(
+            "unable to launch a GDB server on '%s'", GetHostname());
       } else {
         if (target == nullptr) {
           TargetSP new_target_sp;
@@ -533,7 +531,7 @@ lldb::ProcessSP PlatformRemoteGDBServer::Attach(
         }
       }
     } else {
-      error.SetErrorString("not connected to remote gdb server");
+      error = Status::FromErrorString("not connected to remote gdb server");
     }
   }
   return process_sp;
@@ -542,7 +540,7 @@ lldb::ProcessSP PlatformRemoteGDBServer::Attach(
 Status PlatformRemoteGDBServer::MakeDirectory(const FileSpec &file_spec,
                                               uint32_t mode) {
   if (!IsConnected())
-    return Status("Not connected.");
+    return Status::FromErrorStringWithFormat("Not connected.");
   Status error = m_gdb_client_up->MakeDirectory(file_spec, mode);
   Log *log = GetLog(LLDBLog::Platform);
   LLDB_LOGF(log,
@@ -556,7 +554,7 @@ Status PlatformRemoteGDBServer::MakeDirectory(const FileSpec &file_spec,
 Status PlatformRemoteGDBServer::GetFilePermissions(const FileSpec &file_spec,
                                                    uint32_t &file_permissions) {
   if (!IsConnected())
-    return Status("Not connected.");
+    return Status::FromErrorStringWithFormat("Not connected.");
   Status error =
       m_gdb_client_up->GetFilePermissions(file_spec, file_permissions);
   Log *log = GetLog(LLDBLog::Platform);
@@ -571,7 +569,7 @@ Status PlatformRemoteGDBServer::GetFilePermissions(const FileSpec &file_spec,
 Status PlatformRemoteGDBServer::SetFilePermissions(const FileSpec &file_spec,
                                                    uint32_t file_permissions) {
   if (!IsConnected())
-    return Status("Not connected.");
+    return Status::FromErrorStringWithFormat("Not connected.");
   Status error =
       m_gdb_client_up->SetFilePermissions(file_spec, file_permissions);
   Log *log = GetLog(LLDBLog::Platform);
@@ -595,7 +593,7 @@ lldb::user_id_t PlatformRemoteGDBServer::OpenFile(const FileSpec &file_spec,
 bool PlatformRemoteGDBServer::CloseFile(lldb::user_id_t fd, Status &error) {
   if (IsConnected())
     return m_gdb_client_up->CloseFile(fd, error);
-  error = Status("Not connected.");
+  error = Status::FromErrorStringWithFormat("Not connected.");
   return false;
 }
 
@@ -617,7 +615,7 @@ uint64_t PlatformRemoteGDBServer::ReadFile(lldb::user_id_t fd, uint64_t offset,
                                            Status &error) {
   if (IsConnected())
     return m_gdb_client_up->ReadFile(fd, offset, dst, dst_len, error);
-  error = Status("Not connected.");
+  error = Status::FromErrorStringWithFormat("Not connected.");
   return 0;
 }
 
@@ -626,7 +624,7 @@ uint64_t PlatformRemoteGDBServer::WriteFile(lldb::user_id_t fd, uint64_t offset,
                                             Status &error) {
   if (IsConnected())
     return m_gdb_client_up->WriteFile(fd, offset, src, src_len, error);
-  error = Status("Not connected.");
+  error = Status::FromErrorStringWithFormat("Not connected.");
   return 0;
 }
 
@@ -641,7 +639,7 @@ Status PlatformRemoteGDBServer::CreateSymlink(
     const FileSpec &dst) // The symlink points to dst
 {
   if (!IsConnected())
-    return Status("Not connected.");
+    return Status::FromErrorStringWithFormat("Not connected.");
   Status error = m_gdb_client_up->CreateSymlink(src, dst);
   Log *log = GetLog(LLDBLog::Platform);
   LLDB_LOGF(log,
@@ -654,7 +652,7 @@ Status PlatformRemoteGDBServer::CreateSymlink(
 
 Status PlatformRemoteGDBServer::Unlink(const FileSpec &file_spec) {
   if (!IsConnected())
-    return Status("Not connected.");
+    return Status::FromErrorStringWithFormat("Not connected.");
   Status error = m_gdb_client_up->Unlink(file_spec);
   Log *log = GetLog(LLDBLog::Platform);
   LLDB_LOGF(log, "PlatformRemoteGDBServer::Unlink(path='%s') error = %u (%s)",
@@ -679,7 +677,7 @@ Status PlatformRemoteGDBServer::RunShellCommand(
         *command_output, // Pass NULL if you don't want the command output
     const Timeout<std::micro> &timeout) {
   if (!IsConnected())
-    return Status("Not connected.");
+    return Status::FromErrorStringWithFormat("Not connected.");
   return m_gdb_client_up->RunShellCommand(command, working_dir, status_ptr,
                                           signo_ptr, command_output, timeout);
 }

--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -54,10 +54,11 @@ static Status CanTrace() {
   ret = ::sysctlbyname("security.bsd.unprivileged_proc_debug", &proc_debug,
                        &len, nullptr, 0);
   if (ret != 0)
-    return Status("sysctlbyname() security.bsd.unprivileged_proc_debug failed");
+    return Status::FromErrorString(
+        "sysctlbyname() security.bsd.unprivileged_proc_debug failed");
 
   if (proc_debug < 1)
-    return Status(
+    return Status::FromErrorString(
         "process debug disabled by security.bsd.unprivileged_proc_debug oid");
 
   return {};
@@ -488,13 +489,14 @@ Status NativeProcessFreeBSD::Resume(const ResumeActionList &resume_actions) {
     case eStateSuspended:
     case eStateStopped:
       if (action->signal != LLDB_INVALID_SIGNAL_NUMBER)
-        return Status("Passing signal to suspended thread unsupported");
+        return Status::FromErrorString(
+            "Passing signal to suspended thread unsupported");
 
       ret = thread.Suspend();
       break;
 
     default:
-      return Status(
+      return Status::FromErrorStringWithFormat(
           "NativeProcessFreeBSD::%s (): unexpected state %s specified "
           "for pid %" PRIu64 ", tid %" PRIu64,
           __FUNCTION__, StateAsCString(action->state), GetID(), thread.GetID());
@@ -585,7 +587,7 @@ Status NativeProcessFreeBSD::GetMemoryRegionInfo(lldb::addr_t load_addr,
 
   if (m_supports_mem_region == LazyBool::eLazyBoolNo) {
     // We're done.
-    return Status("unsupported");
+    return Status::FromErrorString("unsupported");
   }
 
   Status error = PopulateMemoryRegionCache();
@@ -653,7 +655,7 @@ Status NativeProcessFreeBSD::PopulateMemoryRegionCache() {
   ret = ::sysctl(mib, 4, nullptr, &len, nullptr, 0);
   if (ret != 0) {
     m_supports_mem_region = LazyBool::eLazyBoolNo;
-    return Status("sysctl() for KERN_PROC_VMMAP failed");
+    return Status::FromErrorString("sysctl() for KERN_PROC_VMMAP failed");
   }
 
   std::unique_ptr<WritableMemoryBuffer> buf =
@@ -661,7 +663,7 @@ Status NativeProcessFreeBSD::PopulateMemoryRegionCache() {
   ret = ::sysctl(mib, 4, buf->getBufferStart(), &len, nullptr, 0);
   if (ret != 0) {
     m_supports_mem_region = LazyBool::eLazyBoolNo;
-    return Status("sysctl() for KERN_PROC_VMMAP failed");
+    return Status::FromErrorString("sysctl() for KERN_PROC_VMMAP failed");
   }
 
   char *bp = buf->getBufferStart();
@@ -706,7 +708,7 @@ Status NativeProcessFreeBSD::PopulateMemoryRegionCache() {
     LLDB_LOG(log, "failed to find any vmmap entries, assuming no support "
                   "for memory region metadata retrieval");
     m_supports_mem_region = LazyBool::eLazyBoolNo;
-    return Status("not supported");
+    return Status::FromErrorString("not supported");
   }
   LLDB_LOG(log, "read {0} memory region entries from process {1}",
            m_mem_region_cache.size(), GetID());
@@ -745,8 +747,9 @@ Status NativeProcessFreeBSD::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status("Module file (%s) not found in process' memory map!",
-                module_file_spec.GetFilename().AsCString());
+  return Status::FromErrorStringWithFormat(
+      "Module file (%s) not found in process' memory map!",
+      module_file_spec.GetFilename().AsCString());
 }
 
 Status
@@ -768,7 +771,8 @@ NativeProcessFreeBSD::GetFileLoadAddress(const llvm::StringRef &file_name,
       return Status();
     }
   }
-  return Status("No load address found for file %s.", file_name.str().c_str());
+  return Status::FromErrorStringWithFormat("No load address found for file %s.",
+                                           file_name.str().c_str());
 }
 
 void NativeProcessFreeBSD::SigchldHandler() {

--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_arm.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_arm.cpp
@@ -91,16 +91,16 @@ NativeRegisterContextFreeBSD_arm::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   uint32_t set = GetRegisterInfo().GetRegisterSetFromRegisterIndex(reg);
   error = ReadRegisterSet(set);
@@ -118,14 +118,14 @@ Status NativeRegisterContextFreeBSD_arm::WriteRegister(
   Status error;
 
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   uint32_t set = GetRegisterInfo().GetRegisterSetFromRegisterIndex(reg);
   error = ReadRegisterSet(set);
@@ -163,14 +163,14 @@ Status NativeRegisterContextFreeBSD_arm::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_arm::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != m_reg_data.size()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_arm::%s data_sp contained mismatched "
         "data size, expected %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, m_reg_data.size(), data_sp->GetByteSize());
@@ -179,10 +179,11 @@ Status NativeRegisterContextFreeBSD_arm::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextFreeBSD_arm::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextFreeBSD_arm::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(m_reg_data.data(), src, m_reg_data.size());

--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_arm64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_arm64.cpp
@@ -120,7 +120,7 @@ NativeRegisterContextFreeBSD_arm64::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -192,14 +192,14 @@ Status NativeRegisterContextFreeBSD_arm64::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_arm64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != m_reg_data.size()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_arm64::%s data_sp contained mismatched "
         "data size, expected %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, m_reg_data.size(), data_sp->GetByteSize());
@@ -208,10 +208,11 @@ Status NativeRegisterContextFreeBSD_arm64::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextFreeBSD_arm64::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextFreeBSD_arm64::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(m_reg_data.data(), src, m_reg_data.size());

--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_mips64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_mips64.cpp
@@ -110,7 +110,7 @@ NativeRegisterContextFreeBSD_mips64::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -125,8 +125,8 @@ NativeRegisterContextFreeBSD_mips64::ReadRegister(const RegisterInfo *reg_info,
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -159,8 +159,8 @@ Status NativeRegisterContextFreeBSD_mips64::WriteRegister(
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -200,14 +200,14 @@ Status NativeRegisterContextFreeBSD_mips64::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_mips64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != m_reg_data.size()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_mips64::%s data_sp contained mismatched "
         "data size, expected %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, m_reg_data.size(), data_sp->GetByteSize());
@@ -216,10 +216,11 @@ Status NativeRegisterContextFreeBSD_mips64::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextFreeBSD_mips64::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextFreeBSD_mips64::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(m_reg_data.data(), src, m_reg_data.size());

--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_powerpc.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_powerpc.cpp
@@ -161,23 +161,23 @@ NativeRegisterContextFreeBSD_powerpc::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   std::optional<RegSetKind> opt_set = GetSetForNativeRegNum(reg);
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -197,21 +197,21 @@ Status NativeRegisterContextFreeBSD_powerpc::WriteRegister(
   Status error;
 
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   std::optional<RegSetKind> opt_set = GetSetForNativeRegNum(reg);
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -251,14 +251,14 @@ Status NativeRegisterContextFreeBSD_powerpc::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_powerpc::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != m_reg_data.size()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_powerpc::%s data_sp contained mismatched "
         "data size, expected %zu, actual %" PRIu64,
         __FUNCTION__, m_reg_data.size(), data_sp->GetByteSize());
@@ -267,10 +267,11 @@ Status NativeRegisterContextFreeBSD_powerpc::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextFreeBSD_powerpc::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextFreeBSD_powerpc::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(m_reg_data.data(), src, m_reg_data.size());

--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_x86_64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_x86_64.cpp
@@ -412,7 +412,7 @@ NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -420,9 +420,10 @@ NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -430,8 +431,8 @@ NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -456,7 +457,7 @@ NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   case YMMRegSet: {
     std::optional<YMMSplitPtr> ymm_reg = GetYMMSplitReg(reg);
     if (!ymm_reg) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "register \"%s\" not supported by CPU/kernel", reg_info->name);
     } else {
       YMMReg ymm = XStateToYMM(ymm_reg->xmm, ymm_reg->ymm_hi);
@@ -478,7 +479,7 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -486,9 +487,10 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -496,8 +498,8 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -521,7 +523,7 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
   case YMMRegSet: {
     std::optional<YMMSplitPtr> ymm_reg = GetYMMSplitReg(reg);
     if (!ymm_reg) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "register \"%s\" not supported by CPU/kernel", reg_info->name);
     } else {
       YMMReg ymm;
@@ -558,14 +560,14 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_x86_64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextFreeBSD_x86_64::%s data_sp contained mismatched "
         "data size, expected %zu, actual %" PRIu64,
         __FUNCTION__, REG_CONTEXT_SIZE, data_sp->GetByteSize());
@@ -574,10 +576,11 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextFreeBSD_x86_64::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextFreeBSD_x86_64::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(m_gpr.data(), src, GetRegisterInfoInterface().GetGPRSize());

--- a/lldb/source/Plugins/Process/FreeBSD/NativeThreadFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeThreadFreeBSD.cpp
@@ -252,14 +252,14 @@ Status NativeThreadFreeBSD::SetWatchpoint(lldb::addr_t addr, size_t size,
                                           uint32_t watch_flags, bool hardware) {
   assert(m_state == eStateStopped);
   if (!hardware)
-    return Status("not implemented");
+    return Status::FromErrorString("not implemented");
   Status error = RemoveWatchpoint(addr);
   if (error.Fail())
     return error;
   uint32_t wp_index =
       GetRegisterContext().SetHardwareWatchpoint(addr, size, watch_flags);
   if (wp_index == LLDB_INVALID_INDEX32)
-    return Status("Setting hardware watchpoint failed.");
+    return Status::FromErrorString("Setting hardware watchpoint failed.");
   m_watchpoint_index_map.insert({addr, wp_index});
   return Status();
 }
@@ -272,7 +272,7 @@ Status NativeThreadFreeBSD::RemoveWatchpoint(lldb::addr_t addr) {
   m_watchpoint_index_map.erase(wp);
   if (GetRegisterContext().ClearHardwareWatchpoint(wp_index))
     return Status();
-  return Status("Clearing hardware watchpoint failed.");
+  return Status::FromErrorString("Clearing hardware watchpoint failed.");
 }
 
 Status NativeThreadFreeBSD::SetHardwareBreakpoint(lldb::addr_t addr,
@@ -285,7 +285,7 @@ Status NativeThreadFreeBSD::SetHardwareBreakpoint(lldb::addr_t addr,
   uint32_t bp_index = GetRegisterContext().SetHardwareBreakpoint(addr, size);
 
   if (bp_index == LLDB_INVALID_INDEX32)
-    return Status("Setting hardware breakpoint failed.");
+    return Status::FromErrorString("Setting hardware breakpoint failed.");
 
   m_hw_break_index_map.insert({addr, bp_index});
   return Status();
@@ -302,7 +302,7 @@ Status NativeThreadFreeBSD::RemoveHardwareBreakpoint(lldb::addr_t addr) {
     return Status();
   }
 
-  return Status("Clearing hardware breakpoint failed.");
+  return Status::FromErrorString("Clearing hardware breakpoint failed.");
 }
 
 llvm::Error

--- a/lldb/source/Plugins/Process/FreeBSDKernel/ProcessFreeBSDKernel.cpp
+++ b/lldb/source/Plugins/Process/FreeBSDKernel/ProcessFreeBSDKernel.cpp
@@ -291,7 +291,8 @@ size_t ProcessFreeBSDKernelFVC::DoReadMemory(lldb::addr_t addr, void *buf,
   ssize_t rd = 0;
   rd = fvc_read(m_fvc, addr, buf, size);
   if (rd < 0 || static_cast<size_t>(rd) != size) {
-    error.SetErrorStringWithFormat("Reading memory failed: %s", GetError());
+    error = Status::FromErrorStringWithFormat("Reading memory failed: %s",
+                                              GetError());
     return rd > 0 ? rd : 0;
   }
   return rd;
@@ -319,7 +320,8 @@ size_t ProcessFreeBSDKernelKVM::DoReadMemory(lldb::addr_t addr, void *buf,
   ssize_t rd = 0;
   rd = kvm_read2(m_kvm, addr, buf, size);
   if (rd < 0 || static_cast<size_t>(rd) != size) {
-    error.SetErrorStringWithFormat("Reading memory failed: %s", GetError());
+    error = Status::FromErrorStringWithFormat("Reading memory failed: %s",
+                                              GetError());
     return rd > 0 ? rd : 0;
   }
   return rd;

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -1050,10 +1050,10 @@ Status NativeProcessLinux::Resume(const ResumeActionList &resume_actions) {
       Status error = ResumeThread(static_cast<NativeThreadLinux &>(*thread),
                                   action->state, signo);
       if (error.Fail())
-        return Status("NativeProcessLinux::%s: failed to resume thread "
-                      "for pid %" PRIu64 ", tid %" PRIu64 ", error = %s",
-                      __FUNCTION__, GetID(), thread->GetID(),
-                      error.AsCString());
+        return Status::FromErrorStringWithFormat(
+            "NativeProcessLinux::%s: failed to resume thread "
+            "for pid %" PRIu64 ", tid %" PRIu64 ", error = %s",
+            __FUNCTION__, GetID(), thread->GetID(), error.AsCString());
 
       break;
     }
@@ -1063,10 +1063,11 @@ Status NativeProcessLinux::Resume(const ResumeActionList &resume_actions) {
       break;
 
     default:
-      return Status("NativeProcessLinux::%s (): unexpected state %s specified "
-                    "for pid %" PRIu64 ", tid %" PRIu64,
-                    __FUNCTION__, StateAsCString(action->state), GetID(),
-                    thread->GetID());
+      return Status::FromErrorStringWithFormat(
+          "NativeProcessLinux::%s (): unexpected state %s specified "
+          "for pid %" PRIu64 ", tid %" PRIu64,
+          __FUNCTION__, StateAsCString(action->state), GetID(),
+          thread->GetID());
     }
   }
 
@@ -1209,7 +1210,7 @@ Status NativeProcessLinux::GetMemoryRegionInfo(lldb::addr_t load_addr,
 
   if (m_supports_mem_region == LazyBool::eLazyBoolNo) {
     // We're done.
-    return Status("unsupported");
+    return Status::FromErrorString("unsupported");
   }
 
   Status error = PopulateMemoryRegionCache();
@@ -1318,7 +1319,7 @@ Status NativeProcessLinux::PopulateMemoryRegionCache() {
     LLDB_LOG(log,
              "failed to find any procfs maps entries, assuming no support "
              "for memory region metadata retrieval");
-    return Status("not supported");
+    return Status::FromErrorString("not supported");
   }
 
   LLDB_LOG(log, "read {0} memory region entries from /proc/{1}/maps",
@@ -1853,8 +1854,9 @@ Status NativeProcessLinux::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status("Module file (%s) not found in /proc/%" PRIu64 "/maps file!",
-                module_file_spec.GetFilename().AsCString(), GetID());
+  return Status::FromErrorStringWithFormat(
+      "Module file (%s) not found in /proc/%" PRIu64 "/maps file!",
+      module_file_spec.GetFilename().AsCString(), GetID());
 }
 
 Status NativeProcessLinux::GetFileLoadAddress(const llvm::StringRef &file_name,
@@ -1871,7 +1873,7 @@ Status NativeProcessLinux::GetFileLoadAddress(const llvm::StringRef &file_name,
       return Status();
     }
   }
-  return Status("No load address found for specified file.");
+  return Status::FromErrorString("No load address found for specified file.");
 }
 
 NativeThreadLinux *NativeProcessLinux::GetThreadByID(lldb::tid_t tid) {

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.cpp
@@ -28,7 +28,8 @@ Status NativeRegisterContextLinux::ReadRegisterRaw(uint32_t reg_index,
                                                    RegisterValue &reg_value) {
   const RegisterInfo *const reg_info = GetRegisterInfoAtIndex(reg_index);
   if (!reg_info)
-    return Status("register %" PRIu32 " not found", reg_index);
+    return Status::FromErrorStringWithFormat("register %" PRIu32 " not found",
+                                             reg_index);
 
   return DoReadRegisterValue(GetPtraceOffset(reg_index), reg_info->name,
                              reg_info->byte_size, reg_value);
@@ -88,9 +89,10 @@ NativeRegisterContextLinux::WriteRegisterRaw(uint32_t reg_index,
   assert(register_to_write_info_p &&
          "register to write does not have valid RegisterInfo");
   if (!register_to_write_info_p)
-    return Status("NativeRegisterContextLinux::%s failed to get RegisterInfo "
-                  "for write register index %" PRIu32,
-                  __FUNCTION__, reg_to_write);
+    return Status::FromErrorStringWithFormat(
+        "NativeRegisterContextLinux::%s failed to get RegisterInfo "
+        "for write register index %" PRIu32,
+        __FUNCTION__, reg_to_write);
 
   return DoWriteRegisterValue(GetPtraceOffset(reg_index), reg_info->name,
                               reg_value);

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
@@ -104,7 +104,7 @@ NativeRegisterContextLinux_arm::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -160,8 +160,8 @@ NativeRegisterContextLinux_arm::ReadRegister(const RegisterInfo *reg_info,
     break;
   default:
     assert(false && "Unhandled data size.");
-    error.SetErrorStringWithFormat("unhandled byte size: %" PRIu32,
-                                   reg_info->byte_size);
+    error = Status::FromErrorStringWithFormat("unhandled byte size: %" PRIu32,
+                                              reg_info->byte_size);
     break;
   }
 
@@ -172,13 +172,13 @@ Status
 NativeRegisterContextLinux_arm::WriteRegister(const RegisterInfo *reg_info,
                                               const RegisterValue &reg_value) {
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg_index = reg_info->kinds[lldb::eRegisterKindLLDB];
   if (reg_index == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   if (IsGPR(reg_index))
     return WriteRegisterRaw(reg_index, reg_value);
@@ -193,8 +193,9 @@ NativeRegisterContextLinux_arm::WriteRegister(const RegisterInfo *reg_info,
     return WriteFPR();
   }
 
-  return Status("failed - register wasn't recognized to be a GPR or an FPR, "
-                "write strategy unknown");
+  return Status::FromErrorString(
+      "failed - register wasn't recognized to be a GPR or an FPR, "
+      "write strategy unknown");
 }
 
 Status NativeRegisterContextLinux_arm::ReadAllRegisterValues(
@@ -223,14 +224,14 @@ Status NativeRegisterContextLinux_arm::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_arm::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_arm::%s data_sp contained mismatched "
         "data size, expected %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, (uint64_t)REG_CONTEXT_SIZE, data_sp->GetByteSize());
@@ -239,10 +240,11 @@ Status NativeRegisterContextLinux_arm::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextLinux_arm::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextLinux_arm::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(&m_gpr_arm, src, GetRegisterInfoInterface().GetGPRSize());
@@ -796,7 +798,8 @@ Status NativeRegisterContextLinux_arm::DoReadRegisterValue(
   // processing time in lldb-server.
   assert(offset % 4 == 0 && "Try to write a register with unaligned offset");
   if (offset + sizeof(uint32_t) > sizeof(m_gpr_arm))
-    return Status("Register isn't fit into the size of the GPR area");
+    return Status::FromErrorString(
+        "Register isn't fit into the size of the GPR area");
 
   Status error = ReadGPR();
   if (error.Fail())
@@ -815,7 +818,8 @@ Status NativeRegisterContextLinux_arm::DoWriteRegisterValue(
   // overhead is negligible in comparison to processing time in lldb-server.
   assert(offset % 4 == 0 && "Try to write a register with unaligned offset");
   if (offset + sizeof(uint32_t) > sizeof(m_gpr_arm))
-    return Status("Register isn't fit into the size of the GPR area");
+    return Status::FromErrorString(
+        "Register isn't fit into the size of the GPR area");
 
   Status error = ReadGPR();
   if (error.Fail())

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -239,16 +239,16 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   uint8_t *src;
   uint32_t offset = LLDB_INVALID_INDEX32;
@@ -320,7 +320,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
     src = (uint8_t *)GetTLSBuffer() + offset;
   } else if (IsSVE(reg)) {
     if (m_sve_state == SVEState::Disabled || m_sve_state == SVEState::Unknown)
-      return Status("SVE disabled or not supported");
+      return Status::FromErrorString("SVE disabled or not supported");
 
     if (GetRegisterInfo().IsSVERegVG(reg)) {
       sve_vg = GetSVERegVG();
@@ -414,8 +414,9 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
       src = (uint8_t *)GetSMEPseudoBuffer() + offset;
     }
   } else
-    return Status("failed - register wasn't recognized to be a GPR or an FPR, "
-                  "write strategy unknown");
+    return Status::FromErrorString(
+        "failed - register wasn't recognized to be a GPR or an FPR, "
+        "write strategy unknown");
 
   reg_value.SetFromMemoryData(*reg_info, src, reg_info->byte_size,
                               eByteOrderLittle, error);
@@ -428,14 +429,14 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
   Status error;
 
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   uint8_t *dst;
   uint32_t offset = LLDB_INVALID_INDEX32;
@@ -502,7 +503,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
     }
   } else if (IsSVE(reg)) {
     if (m_sve_state == SVEState::Disabled || m_sve_state == SVEState::Unknown)
-      return Status("SVE disabled or not supported");
+      return Status::FromErrorString("SVE disabled or not supported");
     else {
       // Target has SVE enabled, we will read and cache SVE ptrace data
       error = ReadAllSVE();
@@ -530,7 +531,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
             return error;
         }
 
-        return Status("SVE vector length update failed.");
+        return Status::FromErrorString("SVE vector length update failed.");
       }
 
       // If target supports SVE but currently in FPSIMD mode.
@@ -566,7 +567,8 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
 
           return WriteAllSVE();
         } else
-          return Status("SVE state change operation not supported");
+          return Status::FromErrorString(
+              "SVE state change operation not supported");
       } else {
         offset = CalculateSVEOffset(reg_info);
         assert(offset < GetSVEBufferSize());
@@ -622,10 +624,11 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
 
       return WriteZT();
     } else
-      return Status("Writing to SVG or SVCR is not supported.");
+      return Status::FromErrorString(
+          "Writing to SVG or SVCR is not supported.");
   }
 
-  return Status("Failed to write register value");
+  return Status::FromErrorString("Failed to write register value");
 }
 
 enum RegisterSetType : uint32_t {
@@ -849,7 +852,7 @@ Status NativeRegisterContextLinux_arm64::WriteAllRegisterValues(
 
   Status error;
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_arm64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
@@ -857,17 +860,18 @@ Status NativeRegisterContextLinux_arm64::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextLinux_arm64::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextLinux_arm64::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
 
   uint64_t reg_data_min_size =
       GetGPRBufferSize() + GetFPRSize() + 2 * (sizeof(RegisterSetType));
   if (data_sp->GetByteSize() < reg_data_min_size) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_arm64::%s data_sp contained insufficient "
         "register data bytes, expected at least %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, reg_data_min_size, data_sp->GetByteSize());
@@ -896,9 +900,10 @@ Status NativeRegisterContextLinux_arm64::WriteAllRegisterValues(
       ::memcpy(GetSVEHeader(), src, GetSVEHeaderSize());
       if (!sve::vl_valid(m_sve_header.vl)) {
         m_sve_header_is_valid = false;
-        error.SetErrorStringWithFormat("NativeRegisterContextLinux_arm64::%s "
-                                       "Invalid SVE header in data_sp",
-                                       __FUNCTION__);
+        error = Status::FromErrorStringWithFormat(
+            "NativeRegisterContextLinux_arm64::%s "
+            "Invalid SVE header in data_sp",
+            __FUNCTION__);
         return error;
       }
       m_sve_header_is_valid = true;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
@@ -93,16 +93,16 @@ Status NativeRegisterContextLinux_loongarch64::ReadRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   uint8_t *src = nullptr;
   uint32_t offset = LLDB_INVALID_INDEX32;
@@ -125,8 +125,9 @@ Status NativeRegisterContextLinux_loongarch64::ReadRegister(
     assert(offset < GetFPRSize());
     src = (uint8_t *)GetFPRBuffer() + offset;
   } else
-    return Status("failed - register wasn't recognized to be a GPR or an FPR, "
-                  "write strategy unknown");
+    return Status::FromErrorString(
+        "failed - register wasn't recognized to be a GPR or an FPR, "
+        "write strategy unknown");
 
   reg_value.SetFromMemoryData(*reg_info, src, reg_info->byte_size,
                               eByteOrderLittle, error);
@@ -139,14 +140,14 @@ Status NativeRegisterContextLinux_loongarch64::WriteRegister(
   Status error;
 
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
 
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info->name != nullptr
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info->name != nullptr ? reg_info->name : "<unknown register>");
 
   uint8_t *dst = nullptr;
   uint32_t offset = LLDB_INVALID_INDEX32;
@@ -174,7 +175,7 @@ Status NativeRegisterContextLinux_loongarch64::WriteRegister(
     return WriteFPR();
   }
 
-  return Status("Failed to write register value");
+  return Status::FromErrorString("Failed to write register value");
 }
 
 Status NativeRegisterContextLinux_loongarch64::ReadAllRegisterValues(
@@ -204,14 +205,14 @@ Status NativeRegisterContextLinux_loongarch64::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_loongarch64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_loongarch64::%s data_sp contained "
         "mismatched data size, expected %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, REG_CONTEXT_SIZE, data_sp->GetByteSize());
@@ -220,10 +221,11 @@ Status NativeRegisterContextLinux_loongarch64::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextLinux_loongarch64::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextLinux_loongarch64::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(GetGPRBuffer(), src, GetRegisterInfoInterface().GetGPRSize());

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_ppc64le.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_ppc64le.cpp
@@ -169,7 +169,7 @@ Status NativeRegisterContextLinux_ppc64le::ReadRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -240,8 +240,9 @@ Status NativeRegisterContextLinux_ppc64le::ReadRegister(
     reg_value.SetFromMemoryData(*reg_info, src, reg_info->byte_size,
                                 eByteOrderLittle, error);
   } else {
-    return Status("failed - register wasn't recognized to be a GPR, FPR, VSX "
-                  "or VMX, read strategy unknown");
+    return Status::FromErrorString(
+        "failed - register wasn't recognized to be a GPR, FPR, VSX "
+        "or VMX, read strategy unknown");
   }
 
   return error;
@@ -251,13 +252,13 @@ Status NativeRegisterContextLinux_ppc64le::WriteRegister(
     const RegisterInfo *reg_info, const RegisterValue &reg_value) {
   Status error;
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg_index = reg_info->kinds[lldb::eRegisterKindLLDB];
   if (reg_index == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   if (IsGPR(reg_index)) {
     error = ReadGPR();
@@ -350,8 +351,9 @@ Status NativeRegisterContextLinux_ppc64le::WriteRegister(
     return Status();
   }
 
-  return Status("failed - register wasn't recognized to be a GPR, FPR, VSX "
-                "or VMX, write strategy unknown");
+  return Status::FromErrorString(
+      "failed - register wasn't recognized to be a GPR, FPR, VSX "
+      "or VMX, write strategy unknown");
 }
 
 Status NativeRegisterContextLinux_ppc64le::ReadAllRegisterValues(
@@ -392,14 +394,14 @@ Status NativeRegisterContextLinux_ppc64le::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_ppc64le::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_ppc64le::%s data_sp contained mismatched "
         "data size, expected %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, REG_CONTEXT_SIZE, data_sp->GetByteSize());
@@ -408,10 +410,11 @@ Status NativeRegisterContextLinux_ppc64le::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextLinux_ppc64le::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextLinux_ppc64le::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
 

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_s390x.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_s390x.cpp
@@ -190,13 +190,14 @@ Status
 NativeRegisterContextLinux_s390x::ReadRegister(const RegisterInfo *reg_info,
                                                RegisterValue &reg_value) {
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("register \"%s\" is an internal-only lldb register, cannot "
-                  "read directly",
-                  reg_info->name);
+    return Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb register, cannot "
+        "read directly",
+        reg_info->name);
 
   if (IsGPR(reg)) {
     Status error = ReadGPR();
@@ -214,7 +215,8 @@ NativeRegisterContextLinux_s390x::ReadRegister(const RegisterInfo *reg_info,
       break;
     default:
       assert(false && "Unhandled data size.");
-      return Status("unhandled byte size: %" PRIu32, reg_info->byte_size);
+      return Status::FromErrorStringWithFormat("unhandled byte size: %" PRIu32,
+                                               reg_info->byte_size);
     }
     return Status();
   }
@@ -236,7 +238,8 @@ NativeRegisterContextLinux_s390x::ReadRegister(const RegisterInfo *reg_info,
       break;
     default:
       assert(false && "Unhandled data size.");
-      return Status("unhandled byte size: %" PRIu32, reg_info->byte_size);
+      return Status::FromErrorStringWithFormat("unhandled byte size: %" PRIu32,
+                                               reg_info->byte_size);
     }
     return Status();
   }
@@ -261,19 +264,20 @@ NativeRegisterContextLinux_s390x::ReadRegister(const RegisterInfo *reg_info,
     return Status();
   }
 
-  return Status("failed - register wasn't recognized");
+  return Status::FromErrorString("failed - register wasn't recognized");
 }
 
 Status NativeRegisterContextLinux_s390x::WriteRegister(
     const RegisterInfo *reg_info, const RegisterValue &reg_value) {
   if (!reg_info)
-    return Status("reg_info NULL");
+    return Status::FromErrorString("reg_info NULL");
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
   if (reg == LLDB_INVALID_REGNUM)
-    return Status("register \"%s\" is an internal-only lldb register, cannot "
-                  "write directly",
-                  reg_info->name);
+    return Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb register, cannot "
+        "write directly",
+        reg_info->name);
 
   if (IsGPR(reg)) {
     Status error = ReadGPR();
@@ -291,7 +295,8 @@ Status NativeRegisterContextLinux_s390x::WriteRegister(
       break;
     default:
       assert(false && "Unhandled data size.");
-      return Status("unhandled byte size: %" PRIu32, reg_info->byte_size);
+      return Status::FromErrorStringWithFormat("unhandled byte size: %" PRIu32,
+                                               reg_info->byte_size);
     }
     return WriteGPR();
   }
@@ -313,13 +318,14 @@ Status NativeRegisterContextLinux_s390x::WriteRegister(
       break;
     default:
       assert(false && "Unhandled data size.");
-      return Status("unhandled byte size: %" PRIu32, reg_info->byte_size);
+      return Status::FromErrorStringWithFormat("unhandled byte size: %" PRIu32,
+                                               reg_info->byte_size);
     }
     return WriteFPR();
   }
 
   if (reg == lldb_last_break_s390x) {
-    return Status("The last break address is read-only");
+    return Status::FromErrorString("The last break address is read-only");
   }
 
   if (reg == lldb_system_call_s390x) {
@@ -327,7 +333,7 @@ Status NativeRegisterContextLinux_s390x::WriteRegister(
     return DoWriteRegisterSet(NT_S390_SYSTEM_CALL, &system_call, 4);
   }
 
-  return Status("failed - register wasn't recognized");
+  return Status::FromErrorString("failed - register wasn't recognized");
 }
 
 Status NativeRegisterContextLinux_s390x::ReadAllRegisterValues(
@@ -367,14 +373,14 @@ Status NativeRegisterContextLinux_s390x::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_s390x::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_s390x::%s data_sp contained mismatched "
         "data size, expected %" PRIu64 ", actual %" PRIu64,
         __FUNCTION__, REG_CONTEXT_SIZE, data_sp->GetByteSize());
@@ -383,10 +389,11 @@ Status NativeRegisterContextLinux_s390x::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextLinux_s390x::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextLinux_s390x::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
 
@@ -412,12 +419,12 @@ Status NativeRegisterContextLinux_s390x::WriteAllRegisterValues(
 Status NativeRegisterContextLinux_s390x::DoReadRegisterValue(
     uint32_t offset, const char *reg_name, uint32_t size,
     RegisterValue &value) {
-  return Status("DoReadRegisterValue unsupported");
+  return Status::FromErrorString("DoReadRegisterValue unsupported");
 }
 
 Status NativeRegisterContextLinux_s390x::DoWriteRegisterValue(
     uint32_t offset, const char *reg_name, const RegisterValue &value) {
-  return Status("DoWriteRegisterValue unsupported");
+  return Status::FromErrorString("DoWriteRegisterValue unsupported");
 }
 
 Status NativeRegisterContextLinux_s390x::PeekUserArea(uint32_t offset,
@@ -489,7 +496,7 @@ Status NativeRegisterContextLinux_s390x::IsWatchpointHit(uint32_t wp_index,
   per_lowcore_bits per_lowcore;
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   if (m_watchpoint_addr == LLDB_INVALID_ADDRESS) {
     is_hit = false;
@@ -536,7 +543,7 @@ Status NativeRegisterContextLinux_s390x::GetWatchpointHitIndex(
 Status NativeRegisterContextLinux_s390x::IsWatchpointVacant(uint32_t wp_index,
                                                             bool &is_vacant) {
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   is_vacant = m_watchpoint_addr == LLDB_INVALID_ADDRESS;
 
@@ -572,7 +579,7 @@ bool NativeRegisterContextLinux_s390x::ClearHardwareWatchpoint(
 Status NativeRegisterContextLinux_s390x::ClearAllHardwareWatchpoints() {
   if (ClearHardwareWatchpoint(0))
     return Status();
-  return Status("Clearing all hardware watchpoints failed.");
+  return Status::FromErrorString("Clearing all hardware watchpoints failed.");
 }
 
 uint32_t NativeRegisterContextLinux_s390x::SetHardwareWatchpoint(

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_x86_64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_x86_64.cpp
@@ -419,7 +419,7 @@ NativeRegisterContextLinux_x86_64::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -427,9 +427,10 @@ NativeRegisterContextLinux_x86_64::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -487,7 +488,7 @@ NativeRegisterContextLinux_x86_64::ReadRegister(const RegisterInfo *reg_info,
           reg_value.SetBytes(m_ymm_set.ymm[reg - m_reg_info.first_ymm].bytes,
                              reg_info->byte_size, byte_order);
         else {
-          error.SetErrorString("failed to copy ymm register value");
+          error = Status::FromErrorString("failed to copy ymm register value");
           return error;
         }
       }
@@ -496,7 +497,7 @@ NativeRegisterContextLinux_x86_64::ReadRegister(const RegisterInfo *reg_info,
           reg_value.SetBytes(m_mpx_set.mpxr[reg - m_reg_info.first_mpxr].bytes,
                              reg_info->byte_size, byte_order);
         else {
-          error.SetErrorString("failed to copy mpx register value");
+          error = Status::FromErrorString("failed to copy mpx register value");
           return error;
         }
       }
@@ -505,19 +506,19 @@ NativeRegisterContextLinux_x86_64::ReadRegister(const RegisterInfo *reg_info,
           reg_value.SetBytes(m_mpx_set.mpxc[reg - m_reg_info.first_mpxc].bytes,
                              reg_info->byte_size, byte_order);
         else {
-          error.SetErrorString("failed to copy mpx register value");
+          error = Status::FromErrorString("failed to copy mpx register value");
           return error;
         }
       }
 
       if (reg_value.GetType() != RegisterValue::eTypeBytes)
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "write failed - type was expected to be RegisterValue::eTypeBytes");
 
       return error;
     }
 
-    error.SetErrorString("byte order is invalid");
+    error = Status::FromErrorString("byte order is invalid");
     return error;
   }
 
@@ -557,8 +558,8 @@ NativeRegisterContextLinux_x86_64::ReadRegister(const RegisterInfo *reg_info,
     break;
   default:
     assert(false && "Unhandled data size.");
-    error.SetErrorStringWithFormat("unhandled byte size: %" PRIu32,
-                                   reg_info->byte_size);
+    error = Status::FromErrorStringWithFormat("unhandled byte size: %" PRIu32,
+                                              reg_info->byte_size);
     break;
   }
 
@@ -587,9 +588,9 @@ Status NativeRegisterContextLinux_x86_64::WriteRegister(
 
   const uint32_t reg_index = reg_info->kinds[lldb::eRegisterKindLLDB];
   if (reg_index == LLDB_INVALID_REGNUM)
-    return Status("no lldb regnum for %s", reg_info && reg_info->name
-                                               ? reg_info->name
-                                               : "<unknown register>");
+    return Status::FromErrorStringWithFormat(
+        "no lldb regnum for %s",
+        reg_info && reg_info->name ? reg_info->name : "<unknown register>");
 
   UpdateXSTATEforWrite(reg_index);
 
@@ -617,7 +618,7 @@ Status NativeRegisterContextLinux_x86_64::WriteRegister(
         ::memcpy(m_ymm_set.ymm[reg_index - m_reg_info.first_ymm].bytes,
                  reg_value.GetBytes(), reg_value.GetByteSize());
         if (!CopyYMMtoXSTATE(reg_index, GetByteOrder()))
-          return Status("CopyYMMtoXSTATE() failed");
+          return Status::FromErrorString("CopyYMMtoXSTATE() failed");
       }
 
       if (reg_index >= m_reg_info.first_mpxr &&
@@ -625,7 +626,7 @@ Status NativeRegisterContextLinux_x86_64::WriteRegister(
         ::memcpy(m_mpx_set.mpxr[reg_index - m_reg_info.first_mpxr].bytes,
                  reg_value.GetBytes(), reg_value.GetByteSize());
         if (!CopyMPXtoXSTATE(reg_index))
-          return Status("CopyMPXtoXSTATE() failed");
+          return Status::FromErrorString("CopyMPXtoXSTATE() failed");
       }
 
       if (reg_index >= m_reg_info.first_mpxc &&
@@ -633,7 +634,7 @@ Status NativeRegisterContextLinux_x86_64::WriteRegister(
         ::memcpy(m_mpx_set.mpxc[reg_index - m_reg_info.first_mpxc].bytes,
                  reg_value.GetBytes(), reg_value.GetByteSize());
         if (!CopyMPXtoXSTATE(reg_index))
-          return Status("CopyMPXtoXSTATE() failed");
+          return Status::FromErrorString("CopyMPXtoXSTATE() failed");
       }
     } else {
       // Get pointer to m_xstate->fxsave variable and set the data to it.
@@ -670,8 +671,8 @@ Status NativeRegisterContextLinux_x86_64::WriteRegister(
           break;
         default:
           assert(false && "Unhandled data size.");
-          return Status("unhandled register data size %" PRIu32,
-                        reg_info->byte_size);
+          return Status::FromErrorStringWithFormat(
+              "unhandled register data size %" PRIu32, reg_info->byte_size);
         }
       }
     }
@@ -682,17 +683,18 @@ Status NativeRegisterContextLinux_x86_64::WriteRegister(
 
     if (IsAVX(reg_index)) {
       if (!CopyYMMtoXSTATE(reg_index, GetByteOrder()))
-        return Status("CopyYMMtoXSTATE() failed");
+        return Status::FromErrorString("CopyYMMtoXSTATE() failed");
     }
 
     if (IsMPX(reg_index)) {
       if (!CopyMPXtoXSTATE(reg_index))
-        return Status("CopyMPXtoXSTATE() failed");
+        return Status::FromErrorString("CopyMPXtoXSTATE() failed");
     }
     return Status();
   }
-  return Status("failed - register wasn't recognized to be a GPR or an FPR, "
-                "write strategy unknown");
+  return Status::FromErrorString(
+      "failed - register wasn't recognized to be a GPR or an FPR, "
+      "write strategy unknown");
 }
 
 Status NativeRegisterContextLinux_x86_64::ReadAllRegisterValues(
@@ -721,7 +723,7 @@ Status NativeRegisterContextLinux_x86_64::ReadAllRegisterValues(
       for (uint32_t reg = m_reg_info.first_ymm; reg <= m_reg_info.last_ymm;
            ++reg) {
         if (!CopyXSTATEtoYMM(reg, byte_order)) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "NativeRegisterContextLinux_x86_64::%s "
               "CopyXSTATEtoYMM() failed for reg num "
               "%" PRIu32,
@@ -735,7 +737,7 @@ Status NativeRegisterContextLinux_x86_64::ReadAllRegisterValues(
       for (uint32_t reg = m_reg_info.first_mpxr; reg <= m_reg_info.last_mpxc;
            ++reg) {
         if (!CopyXSTATEtoMPX(reg)) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "NativeRegisterContextLinux_x86_64::%s "
               "CopyXSTATEtoMPX() failed for reg num "
               "%" PRIu32,
@@ -748,7 +750,8 @@ Status NativeRegisterContextLinux_x86_64::ReadAllRegisterValues(
     ::memcpy(dst, m_xstate.get(), sizeof(FPR));
   } else {
     assert(false && "how do we save the floating point registers?");
-    error.SetErrorString("unsure how to save the floating point registers");
+    error = Status::FromErrorString(
+        "unsure how to save the floating point registers");
   }
   /** The following code is specific to Linux x86 based architectures,
    *  where the register orig_eax (32 bit)/orig_rax (64 bit) is set to
@@ -769,14 +772,14 @@ Status NativeRegisterContextLinux_x86_64::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextLinux_x86_64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
         REG_CONTEXT_SIZE, data_sp->GetByteSize());
     return error;
@@ -784,10 +787,11 @@ Status NativeRegisterContextLinux_x86_64::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextLinux_x86_64::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextLinux_x86_64::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(&m_gpr_x86_64, src, GetRegisterInfoInterface().GetGPRSize());
@@ -814,7 +818,7 @@ Status NativeRegisterContextLinux_x86_64::WriteAllRegisterValues(
       for (uint32_t reg = m_reg_info.first_ymm; reg <= m_reg_info.last_ymm;
            ++reg) {
         if (!CopyYMMtoXSTATE(reg, byte_order)) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "NativeRegisterContextLinux_x86_64::%s "
               "CopyYMMtoXSTATE() failed for reg num "
               "%" PRIu32,
@@ -828,7 +832,7 @@ Status NativeRegisterContextLinux_x86_64::WriteAllRegisterValues(
       for (uint32_t reg = m_reg_info.first_mpxr; reg <= m_reg_info.last_mpxc;
            ++reg) {
         if (!CopyMPXtoXSTATE(reg)) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "NativeRegisterContextLinux_x86_64::%s "
               "CopyMPXtoXSTATE() failed for reg num "
               "%" PRIu32,
@@ -906,7 +910,7 @@ Status NativeRegisterContextLinux_x86_64::WriteFPR() {
   case XStateType::XSAVE:
     return WriteRegisterSet(&m_iovec, sizeof(m_xstate->xsave), NT_X86_XSTATE);
   default:
-    return Status("Unrecognized FPR type.");
+    return Status::FromErrorString("Unrecognized FPR type.");
   }
 }
 
@@ -989,7 +993,7 @@ Status NativeRegisterContextLinux_x86_64::ReadFPR() {
     m_xstate_type = XStateType::FXSAVE;
     return error;
   }
-  return Status("Unrecognized FPR type.");
+  return Status::FromErrorString("Unrecognized FPR type.");
 }
 
 bool NativeRegisterContextLinux_x86_64::IsMPX(uint32_t reg_index) const {

--- a/lldb/source/Plugins/Process/Linux/NativeThreadLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeThreadLinux.cpp
@@ -151,7 +151,7 @@ bool NativeThreadLinux::GetStopReason(ThreadStopInfo &stop_info,
 Status NativeThreadLinux::SetWatchpoint(lldb::addr_t addr, size_t size,
                                         uint32_t watch_flags, bool hardware) {
   if (!hardware)
-    return Status("not implemented");
+    return Status::FromErrorString("not implemented");
   if (m_state == eStateLaunching)
     return Status();
   Status error = RemoveWatchpoint(addr);
@@ -160,7 +160,7 @@ Status NativeThreadLinux::SetWatchpoint(lldb::addr_t addr, size_t size,
   uint32_t wp_index =
       m_reg_context_up->SetHardwareWatchpoint(addr, size, watch_flags);
   if (wp_index == LLDB_INVALID_INDEX32)
-    return Status("Setting hardware watchpoint failed.");
+    return Status::FromErrorString("Setting hardware watchpoint failed.");
   m_watchpoint_index_map.insert({addr, wp_index});
   return Status();
 }
@@ -173,7 +173,7 @@ Status NativeThreadLinux::RemoveWatchpoint(lldb::addr_t addr) {
   m_watchpoint_index_map.erase(wp);
   if (m_reg_context_up->ClearHardwareWatchpoint(wp_index))
     return Status();
-  return Status("Clearing hardware watchpoint failed.");
+  return Status::FromErrorString("Clearing hardware watchpoint failed.");
 }
 
 Status NativeThreadLinux::SetHardwareBreakpoint(lldb::addr_t addr,
@@ -188,7 +188,7 @@ Status NativeThreadLinux::SetHardwareBreakpoint(lldb::addr_t addr,
   uint32_t bp_index = m_reg_context_up->SetHardwareBreakpoint(addr, size);
 
   if (bp_index == LLDB_INVALID_INDEX32)
-    return Status("Setting hardware breakpoint failed.");
+    return Status::FromErrorString("Setting hardware breakpoint failed.");
 
   m_hw_break_index_map.insert({addr, bp_index});
   return Status();
@@ -205,7 +205,7 @@ Status NativeThreadLinux::RemoveHardwareBreakpoint(lldb::addr_t addr) {
     return Status();
   }
 
-  return Status("Clearing hardware breakpoint failed.");
+  return Status::FromErrorString("Clearing hardware breakpoint failed.");
 }
 
 Status NativeThreadLinux::Resume(uint32_t signo) {

--- a/lldb/source/Plugins/Process/MacOSX-Kernel/CommunicationKDP.cpp
+++ b/lldb/source/Plugins/Process/MacOSX-Kernel/CommunicationKDP.cpp
@@ -571,12 +571,12 @@ uint32_t CommunicationKDP::SendRequestReadMemory(lldb::addr_t addr, void *dst,
       }
     }
     if (kdp_error)
-      error.SetErrorStringWithFormat("kdp read memory failed (error %u)",
-                                     kdp_error);
+      error = Status::FromErrorStringWithFormat(
+          "kdp read memory failed (error %u)", kdp_error);
     else
-      error.SetErrorString("kdp read memory failed");
+      error = Status::FromErrorString("kdp read memory failed");
   } else {
-    error.SetErrorString("failed to send packet");
+    error = Status::FromErrorString("failed to send packet");
   }
   return 0;
 }
@@ -602,14 +602,14 @@ uint32_t CommunicationKDP::SendRequestWriteMemory(lldb::addr_t addr,
     lldb::offset_t offset = 8;
     uint32_t kdp_error = reply_packet.GetU32(&offset);
     if (kdp_error)
-      error.SetErrorStringWithFormat("kdp write memory failed (error %u)",
-                                     kdp_error);
+      error = Status::FromErrorStringWithFormat(
+          "kdp write memory failed (error %u)", kdp_error);
     else {
       error.Clear();
       return src_len;
     }
   } else {
-    error.SetErrorString("failed to send packet");
+    error = Status::FromErrorString("failed to send packet");
   }
   return 0;
 }
@@ -631,14 +631,14 @@ bool CommunicationKDP::SendRawRequest(
     lldb::offset_t offset = 8;
     uint32_t kdp_error = reply_packet.GetU32(&offset);
     if (kdp_error && (command_byte != KDP_DUMPINFO))
-      error.SetErrorStringWithFormat("request packet 0x%8.8x failed (error %u)",
-                                     command_byte, kdp_error);
+      error = Status::FromErrorStringWithFormat(
+          "request packet 0x%8.8x failed (error %u)", command_byte, kdp_error);
     else {
       error.Clear();
       return true;
     }
   } else {
-    error.SetErrorString("failed to send packet");
+    error = Status::FromErrorString("failed to send packet");
   }
   return false;
 }
@@ -1194,14 +1194,14 @@ uint32_t CommunicationKDP::SendRequestReadRegisters(uint32_t cpu,
       }
     }
     if (kdp_error)
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "failed to read kdp registers for cpu %u flavor %u (error %u)", cpu,
           flavor, kdp_error);
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "failed to read kdp registers for cpu %u flavor %u", cpu, flavor);
   } else {
-    error.SetErrorString("failed to send packet");
+    error = Status::FromErrorString("failed to send packet");
   }
   return 0;
 }
@@ -1226,11 +1226,11 @@ uint32_t CommunicationKDP::SendRequestWriteRegisters(uint32_t cpu,
     uint32_t kdp_error = reply_packet.GetU32(&offset);
     if (kdp_error == 0)
       return src_len;
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "failed to read kdp registers for cpu %u flavor %u (error %u)", cpu,
         flavor, kdp_error);
   } else {
-    error.SetErrorString("failed to send packet");
+    error = Status::FromErrorString("failed to send packet");
   }
   return 0;
 }

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
@@ -447,8 +447,9 @@ static llvm::Expected<ptrace_siginfo_t> ComputeSignalInfo(
         signaled_threads++;
         if (action->signal != signal) {
           if (signal != LLDB_INVALID_SIGNAL_NUMBER)
-            return Status("NetBSD does not support passing multiple signals "
-                          "simultaneously")
+            return Status::FromErrorString(
+                       "NetBSD does not support passing multiple signals "
+                       "simultaneously")
                 .ToError();
           signal = action->signal;
           signaled_lwp = thread->GetID();
@@ -464,7 +465,8 @@ static llvm::Expected<ptrace_siginfo_t> ComputeSignalInfo(
   }
 
   if (signaled_threads > 1 && signaled_threads < threads.size())
-    return Status("NetBSD does not support passing signal to 1<i<all threads")
+    return Status::FromErrorString(
+               "NetBSD does not support passing signal to 1<i<all threads")
         .ToError();
 
   ptrace_siginfo_t siginfo;
@@ -522,16 +524,17 @@ Status NativeProcessNetBSD::Resume(const ResumeActionList &resume_actions) {
     case eStateSuspended:
     case eStateStopped:
       if (action->signal != LLDB_INVALID_SIGNAL_NUMBER)
-        return Status("Passing signal to suspended thread unsupported");
+        return Status::FromErrorString(
+            "Passing signal to suspended thread unsupported");
 
       ret = thread.Suspend();
       break;
 
     default:
-      return Status("NativeProcessNetBSD::%s (): unexpected state %s specified "
-                    "for pid %" PRIu64 ", tid %" PRIu64,
-                    __FUNCTION__, StateAsCString(action->state), GetID(),
-                    thread.GetID());
+      return Status::FromErrorStringWithFormat(
+          "NativeProcessNetBSD::%s (): unexpected state %s specified "
+          "for pid %" PRIu64 ", tid %" PRIu64,
+          __FUNCTION__, StateAsCString(action->state), GetID(), thread.GetID());
     }
 
     if (!ret.Success())
@@ -621,7 +624,7 @@ Status NativeProcessNetBSD::GetMemoryRegionInfo(lldb::addr_t load_addr,
 
   if (m_supports_mem_region == LazyBool::eLazyBoolNo) {
     // We're done.
-    return Status("unsupported");
+    return Status::FromErrorString("unsupported");
   }
 
   Status error = PopulateMemoryRegionCache();
@@ -688,7 +691,7 @@ Status NativeProcessNetBSD::PopulateMemoryRegionCache() {
   if (vm == NULL) {
     m_supports_mem_region = LazyBool::eLazyBoolNo;
     Status error;
-    error.SetErrorString("not supported");
+    error = Status::FromErrorString("not supported");
     return error;
   }
   for (i = 0; i < count; i++) {
@@ -728,7 +731,7 @@ Status NativeProcessNetBSD::PopulateMemoryRegionCache() {
                   "for memory region metadata retrieval");
     m_supports_mem_region = LazyBool::eLazyBoolNo;
     Status error;
-    error.SetErrorString("not supported");
+    error = Status::FromErrorString("not supported");
     return error;
   }
   LLDB_LOG(log, "read {0} memory region entries from process {1}",
@@ -748,7 +751,8 @@ size_t NativeProcessNetBSD::UpdateThreads() { return m_threads.size(); }
 Status NativeProcessNetBSD::SetBreakpoint(lldb::addr_t addr, uint32_t size,
                                           bool hardware) {
   if (hardware)
-    return Status("NativeProcessNetBSD does not support hardware breakpoints");
+    return Status::FromErrorString(
+        "NativeProcessNetBSD does not support hardware breakpoints");
   else
     return SetSoftwareBreakpoint(addr, size);
 }
@@ -769,8 +773,9 @@ Status NativeProcessNetBSD::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status("Module file (%s) not found in process' memory map!",
-                module_file_spec.GetFilename().AsCString());
+  return Status::FromErrorStringWithFormat(
+      "Module file (%s) not found in process' memory map!",
+      module_file_spec.GetFilename().AsCString());
 }
 
 Status NativeProcessNetBSD::GetFileLoadAddress(const llvm::StringRef &file_name,
@@ -787,7 +792,8 @@ Status NativeProcessNetBSD::GetFileLoadAddress(const llvm::StringRef &file_name,
       return Status();
     }
   }
-  return Status("No load address found for file %s.", file_name.str().c_str());
+  return Status::FromErrorStringWithFormat("No load address found for file %s.",
+                                           file_name.str().c_str());
 }
 
 void NativeProcessNetBSD::SigchldHandler() {

--- a/lldb/source/Plugins/Process/NetBSD/NativeRegisterContextNetBSD_x86_64.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeRegisterContextNetBSD_x86_64.cpp
@@ -386,7 +386,7 @@ NativeRegisterContextNetBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -394,9 +394,10 @@ NativeRegisterContextNetBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -404,8 +405,8 @@ NativeRegisterContextNetBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -431,7 +432,7 @@ NativeRegisterContextNetBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   case YMMRegSet: {
     std::optional<YMMSplitPtr> ymm_reg = GetYMMSplitReg(reg);
     if (!ymm_reg) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "register \"%s\" not supported by CPU/kernel", reg_info->name);
     } else {
       YMMReg ymm = XStateToYMM(ymm_reg->xmm, ymm_reg->ymm_hi);
@@ -453,7 +454,7 @@ Status NativeRegisterContextNetBSD_x86_64::WriteRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -461,9 +462,10 @@ Status NativeRegisterContextNetBSD_x86_64::WriteRegister(
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -471,8 +473,8 @@ Status NativeRegisterContextNetBSD_x86_64::WriteRegister(
   if (!opt_set) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is in unrecognized set",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is in unrecognized set", reg_info->name);
     return error;
   }
 
@@ -508,7 +510,7 @@ Status NativeRegisterContextNetBSD_x86_64::WriteRegister(
   case YMMRegSet: {
     std::optional<YMMSplitPtr> ymm_reg = GetYMMSplitReg(reg);
     if (!ymm_reg) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "register \"%s\" not supported by CPU/kernel", reg_info->name);
     } else {
       YMMReg ymm;
@@ -548,14 +550,14 @@ Status NativeRegisterContextNetBSD_x86_64::WriteAllRegisterValues(
   Status error;
 
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextNetBSD_x86_64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextNetBSD_x86_64::%s data_sp contained mismatched "
         "data size, expected %zu, actual %" PRIu64,
         __FUNCTION__, REG_CONTEXT_SIZE, data_sp->GetByteSize());
@@ -564,10 +566,11 @@ Status NativeRegisterContextNetBSD_x86_64::WriteAllRegisterValues(
 
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
-    error.SetErrorStringWithFormat("NativeRegisterContextNetBSD_x86_64::%s "
-                                   "DataBuffer::GetBytes() returned a null "
-                                   "pointer",
-                                   __FUNCTION__);
+    error = Status::FromErrorStringWithFormat(
+        "NativeRegisterContextNetBSD_x86_64::%s "
+        "DataBuffer::GetBytes() returned a null "
+        "pointer",
+        __FUNCTION__);
     return error;
   }
   ::memcpy(m_gpr.data(), src, GetRegisterInfoInterface().GetGPRSize());

--- a/lldb/source/Plugins/Process/NetBSD/NativeThreadNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeThreadNetBSD.cpp
@@ -264,14 +264,14 @@ Status NativeThreadNetBSD::SetWatchpoint(lldb::addr_t addr, size_t size,
                                          uint32_t watch_flags, bool hardware) {
   assert(m_state == eStateStopped);
   if (!hardware)
-    return Status("not implemented");
+    return Status::FromErrorString("not implemented");
   Status error = RemoveWatchpoint(addr);
   if (error.Fail())
     return error;
   uint32_t wp_index =
       GetRegisterContext().SetHardwareWatchpoint(addr, size, watch_flags);
   if (wp_index == LLDB_INVALID_INDEX32)
-    return Status("Setting hardware watchpoint failed.");
+    return Status::FromErrorString("Setting hardware watchpoint failed.");
   m_watchpoint_index_map.insert({addr, wp_index});
   return Status();
 }
@@ -284,7 +284,7 @@ Status NativeThreadNetBSD::RemoveWatchpoint(lldb::addr_t addr) {
   m_watchpoint_index_map.erase(wp);
   if (GetRegisterContext().ClearHardwareWatchpoint(wp_index))
     return Status();
-  return Status("Clearing hardware watchpoint failed.");
+  return Status::FromErrorString("Clearing hardware watchpoint failed.");
 }
 
 Status NativeThreadNetBSD::SetHardwareBreakpoint(lldb::addr_t addr,
@@ -297,7 +297,7 @@ Status NativeThreadNetBSD::SetHardwareBreakpoint(lldb::addr_t addr,
   uint32_t bp_index = GetRegisterContext().SetHardwareBreakpoint(addr, size);
 
   if (bp_index == LLDB_INVALID_INDEX32)
-    return Status("Setting hardware breakpoint failed.");
+    return Status::FromErrorString("Setting hardware breakpoint failed.");
 
   m_hw_break_index_map.insert({addr, bp_index});
   return Status();
@@ -314,7 +314,7 @@ Status NativeThreadNetBSD::RemoveHardwareBreakpoint(lldb::addr_t addr) {
     return Status();
   }
 
-  return Status("Clearing hardware breakpoint failed.");
+  return Status::FromErrorString("Clearing hardware breakpoint failed.");
 }
 
 llvm::Error

--- a/lldb/source/Plugins/Process/Utility/NativeProcessSoftwareSingleStep.cpp
+++ b/lldb/source/Plugins/Process/Utility/NativeProcessSoftwareSingleStep.cpp
@@ -138,7 +138,7 @@ Status NativeProcessSoftwareSingleStep::SetupSoftwareSingleStepping(
                                      nullptr));
 
   if (emulator_up == nullptr)
-    return Status("Instruction emulator not found!");
+    return Status::FromErrorString("Instruction emulator not found!");
 
   EmulatorBaton baton(process, register_context);
   emulator_up->SetBaton(&baton);
@@ -151,13 +151,13 @@ Status NativeProcessSoftwareSingleStep::SetupSoftwareSingleStepping(
     // try to get at least the size of next instruction to set breakpoint.
     auto instr_size = emulator_up->GetLastInstrSize();
     if (!instr_size)
-      return Status("Read instruction failed!");
+      return Status::FromErrorString("Read instruction failed!");
     bool success = false;
     auto pc = emulator_up->ReadRegisterUnsigned(eRegisterKindGeneric,
                                                 LLDB_REGNUM_GENERIC_PC,
                                                 LLDB_INVALID_ADDRESS, &success);
     if (!success)
-      return Status("Reading pc failed!");
+      return Status::FromErrorString("Reading pc failed!");
     lldb::addr_t next_pc = pc + *instr_size;
     auto result =
         SetSoftwareBreakpointOnPC(arch, next_pc, /* next_flags */ 0x0, process);
@@ -202,7 +202,8 @@ Status NativeProcessSoftwareSingleStep::SetupSoftwareSingleStepping(
     // The instruction emulation failed after it modified the PC. It is an
     // unknown error where we can't continue because the next instruction is
     // modifying the PC but we don't  know how.
-    return Status("Instruction emulation failed unexpectedly.");
+    return Status::FromErrorString(
+        "Instruction emulation failed unexpectedly.");
   }
   auto result = SetSoftwareBreakpointOnPC(arch, next_pc, next_flags, process);
   m_threads_stepping_with_breakpoint.insert({thread.GetID(), next_pc});

--- a/lldb/source/Plugins/Process/Utility/NativeRegisterContextDBReg_x86.cpp
+++ b/lldb/source/Plugins/Process/Utility/NativeRegisterContextDBReg_x86.cpp
@@ -95,7 +95,7 @@ const RegisterInfo *NativeRegisterContextDBReg_x86::GetDR(int num) const {
 Status NativeRegisterContextDBReg_x86::IsWatchpointHit(uint32_t wp_index,
                                                        bool &is_hit) {
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   RegisterValue dr6;
   Status error = ReadRegister(GetDR(6), dr6);
@@ -128,7 +128,7 @@ NativeRegisterContextDBReg_x86::GetWatchpointHitIndex(uint32_t &wp_index,
 Status NativeRegisterContextDBReg_x86::IsWatchpointVacant(uint32_t wp_index,
                                                           bool &is_vacant) {
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   RegisterValue dr7;
   Status error = ReadRegister(GetDR(7), dr7);
@@ -144,7 +144,7 @@ Status NativeRegisterContextDBReg_x86::SetHardwareWatchpointWithIndex(
     lldb::addr_t addr, size_t size, uint32_t watch_flags, uint32_t wp_index) {
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   // Read only watchpoints aren't supported on x86_64. Fall back to read/write
   // waitchpoints instead.
@@ -154,16 +154,16 @@ Status NativeRegisterContextDBReg_x86::SetHardwareWatchpointWithIndex(
     watch_flags = 3;
 
   if (watch_flags != 1 && watch_flags != 3)
-    return Status("Invalid read/write bits for watchpoint");
+    return Status::FromErrorString("Invalid read/write bits for watchpoint");
   if (size != 1 && size != 2 && size != 4 && size != 8)
-    return Status("Invalid size for watchpoint");
+    return Status::FromErrorString("Invalid size for watchpoint");
 
   bool is_vacant;
   Status error = IsWatchpointVacant(wp_index, is_vacant);
   if (error.Fail())
     return error;
   if (!is_vacant)
-    return Status("Watchpoint index not vacant");
+    return Status::FromErrorString("Watchpoint index not vacant");
 
   RegisterValue dr7, drN;
   error = ReadRegister(GetDR(7), dr7);
@@ -219,7 +219,7 @@ bool NativeRegisterContextDBReg_x86::ClearHardwareWatchpoint(
 
 Status NativeRegisterContextDBReg_x86::ClearWatchpointHit(uint32_t wp_index) {
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   RegisterValue dr6;
   Status error = ReadRegister(GetDR(6), dr6);

--- a/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
@@ -198,9 +198,7 @@ Status RegisterContextThreadMemory::ReadRegisterValueFromMemory(
   if (m_reg_ctx_sp)
     return m_reg_ctx_sp->ReadRegisterValueFromMemory(reg_info, src_addr,
                                                      src_len, reg_value);
-  Status error;
-  error.SetErrorString("invalid register context");
-  return error;
+  return Status::FromErrorString("invalid register context");
 }
 
 Status RegisterContextThreadMemory::WriteRegisterValueToMemory(
@@ -210,7 +208,5 @@ Status RegisterContextThreadMemory::WriteRegisterValueToMemory(
   if (m_reg_ctx_sp)
     return m_reg_ctx_sp->WriteRegisterValueToMemory(reg_info, dst_addr, dst_len,
                                                     reg_value);
-  Status error;
-  error.SetErrorString("invalid register context");
-  return error;
+  return Status::FromErrorString("invalid register context");
 }

--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -129,7 +129,7 @@ Status NativeProcessWindows::Resume(const ResumeActionList &resume_actions) {
     }
 
     if (failed) {
-      error.SetErrorString("NativeProcessWindows::DoResume failed");
+      error = Status::FromErrorString("NativeProcessWindows::DoResume failed");
     } else {
       SetState(eStateRunning);
     }
@@ -177,9 +177,10 @@ Status NativeProcessWindows::Detach() {
     else
       LLDB_LOG(log, "Detaching process error: {0}", error);
   } else {
-    error.SetErrorStringWithFormatv("error: process {0} in state = {1}, but "
-                                    "cannot detach it in this state.",
-                                    GetID(), state);
+    error = Status::FromErrorStringWithFormatv(
+        "error: process {0} in state = {1}, but "
+        "cannot detach it in this state.",
+        GetID(), state);
     LLDB_LOG(log, "error: {0}", error);
   }
   return error;
@@ -187,7 +188,8 @@ Status NativeProcessWindows::Detach() {
 
 Status NativeProcessWindows::Signal(int signo) {
   Status error;
-  error.SetErrorString("Windows does not support sending signals to processes");
+  error = Status::FromErrorString(
+      "Windows does not support sending signals to processes");
   return error;
 }
 
@@ -377,8 +379,9 @@ Status NativeProcessWindows::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status("Module (%s) not found in process %" PRIu64 "!",
-                module_file_spec.GetPath().c_str(), GetID());
+  return Status::FromErrorStringWithFormat(
+      "Module (%s) not found in process %" PRIu64 "!",
+      module_file_spec.GetPath().c_str(), GetID());
 }
 
 Status
@@ -397,8 +400,9 @@ NativeProcessWindows::GetFileLoadAddress(const llvm::StringRef &file_name,
       return Status();
     }
   }
-  return Status("Can't get loaded address of file (%s) in process %" PRIu64 "!",
-                file_spec.GetPath().c_str(), GetID());
+  return Status::FromErrorStringWithFormat(
+      "Can't get loaded address of file (%s) in process %" PRIu64 "!",
+      file_spec.GetPath().c_str(), GetID());
 }
 
 void NativeProcessWindows::OnExitProcess(uint32_t exit_code) {

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_WoW64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_WoW64.cpp
@@ -257,9 +257,9 @@ Status NativeRegisterContextWindows_WoW64::DRRead(const uint32_t reg,
     reg_value.SetUInt32(tls_context.Dr3);
     break;
   case lldb_dr4_i386:
-    return Status("register DR4 is obsolete");
+    return Status::FromErrorString("register DR4 is obsolete");
   case lldb_dr5_i386:
-    return Status("register DR5 is obsolete");
+    return Status::FromErrorString("register DR5 is obsolete");
   case lldb_dr6_i386:
     reg_value.SetUInt32(tls_context.Dr6);
     break;
@@ -296,9 +296,9 @@ NativeRegisterContextWindows_WoW64::DRWrite(const uint32_t reg,
     tls_context.Dr3 = reg_value.GetAsUInt32();
     break;
   case lldb_dr4_i386:
-    return Status("register DR4 is obsolete");
+    return Status::FromErrorString("register DR4 is obsolete");
   case lldb_dr5_i386:
-    return Status("register DR5 is obsolete");
+    return Status::FromErrorString("register DR5 is obsolete");
   case lldb_dr6_i386:
     tls_context.Dr6 = reg_value.GetAsUInt32();
     break;
@@ -315,7 +315,7 @@ NativeRegisterContextWindows_WoW64::ReadRegister(const RegisterInfo *reg_info,
                                                  RegisterValue &reg_value) {
   Status error;
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -323,9 +323,10 @@ NativeRegisterContextWindows_WoW64::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -335,7 +336,7 @@ NativeRegisterContextWindows_WoW64::ReadRegister(const RegisterInfo *reg_info,
   if (IsDR(reg))
     return DRRead(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_WoW64::WriteRegister(
@@ -343,7 +344,7 @@ Status NativeRegisterContextWindows_WoW64::WriteRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -351,9 +352,10 @@ Status NativeRegisterContextWindows_WoW64::WriteRegister(
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly written.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot write directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot write directly",
+        reg_info->name);
     return error;
   }
 
@@ -363,7 +365,7 @@ Status NativeRegisterContextWindows_WoW64::WriteRegister(
   if (IsDR(reg))
     return DRWrite(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_WoW64::ReadAllRegisterValues(
@@ -385,14 +387,14 @@ Status NativeRegisterContextWindows_WoW64::WriteAllRegisterValues(
   Status error;
   const size_t data_size = REG_CONTEXT_SIZE;
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextWindows_WoW64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != data_size) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
         data_size, data_sp->GetByteSize());
     return error;
@@ -408,7 +410,7 @@ Status NativeRegisterContextWindows_WoW64::IsWatchpointHit(uint32_t wp_index,
   is_hit = false;
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("watchpoint index out of range");
+    return Status::FromErrorString("watchpoint index out of range");
 
   RegisterValue reg_value;
   Status error = DRRead(lldb_dr6_i386, reg_value);
@@ -444,7 +446,7 @@ Status NativeRegisterContextWindows_WoW64::IsWatchpointVacant(uint32_t wp_index,
   is_vacant = false;
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   RegisterValue reg_value;
   Status error = DRRead(lldb_dr7_i386, reg_value);

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm.cpp
@@ -508,7 +508,7 @@ NativeRegisterContextWindows_arm::ReadRegister(const RegisterInfo *reg_info,
                                                RegisterValue &reg_value) {
   Status error;
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -516,9 +516,10 @@ NativeRegisterContextWindows_arm::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -528,7 +529,7 @@ NativeRegisterContextWindows_arm::ReadRegister(const RegisterInfo *reg_info,
   if (IsFPR(reg))
     return FPRRead(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm::WriteRegister(
@@ -536,7 +537,7 @@ Status NativeRegisterContextWindows_arm::WriteRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -544,9 +545,10 @@ Status NativeRegisterContextWindows_arm::WriteRegister(
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly written.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot write directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot write directly",
+        reg_info->name);
     return error;
   }
 
@@ -556,7 +558,7 @@ Status NativeRegisterContextWindows_arm::WriteRegister(
   if (IsFPR(reg))
     return FPRWrite(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm::ReadAllRegisterValues(
@@ -579,14 +581,14 @@ Status NativeRegisterContextWindows_arm::WriteAllRegisterValues(
   Status error;
   const size_t data_size = REG_CONTEXT_SIZE;
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextWindows_arm::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != data_size) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
         data_size, data_sp->GetByteSize());
     return error;
@@ -599,22 +601,22 @@ Status NativeRegisterContextWindows_arm::WriteAllRegisterValues(
 
 Status NativeRegisterContextWindows_arm::IsWatchpointHit(uint32_t wp_index,
                                                          bool &is_hit) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm::GetWatchpointHitIndex(
     uint32_t &wp_index, lldb::addr_t trap_addr) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm::IsWatchpointVacant(uint32_t wp_index,
                                                             bool &is_vacant) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm::SetHardwareWatchpointWithIndex(
     lldb::addr_t addr, size_t size, uint32_t watch_flags, uint32_t wp_index) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 bool NativeRegisterContextWindows_arm::ClearHardwareWatchpoint(
@@ -623,7 +625,7 @@ bool NativeRegisterContextWindows_arm::ClearHardwareWatchpoint(
 }
 
 Status NativeRegisterContextWindows_arm::ClearAllHardwareWatchpoints() {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 uint32_t NativeRegisterContextWindows_arm::SetHardwareWatchpoint(

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
@@ -618,7 +618,7 @@ NativeRegisterContextWindows_arm64::ReadRegister(const RegisterInfo *reg_info,
                                                  RegisterValue &reg_value) {
   Status error;
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -626,9 +626,10 @@ NativeRegisterContextWindows_arm64::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -638,7 +639,7 @@ NativeRegisterContextWindows_arm64::ReadRegister(const RegisterInfo *reg_info,
   if (IsFPR(reg))
     return FPRRead(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm64::WriteRegister(
@@ -646,7 +647,7 @@ Status NativeRegisterContextWindows_arm64::WriteRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -654,9 +655,10 @@ Status NativeRegisterContextWindows_arm64::WriteRegister(
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly written.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot write directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot write directly",
+        reg_info->name);
     return error;
   }
 
@@ -666,7 +668,7 @@ Status NativeRegisterContextWindows_arm64::WriteRegister(
   if (IsFPR(reg))
     return FPRWrite(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm64::ReadAllRegisterValues(
@@ -689,14 +691,14 @@ Status NativeRegisterContextWindows_arm64::WriteAllRegisterValues(
   Status error;
   const size_t data_size = REG_CONTEXT_SIZE;
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextWindows_arm64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != data_size) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
         data_size, data_sp->GetByteSize());
     return error;
@@ -709,22 +711,22 @@ Status NativeRegisterContextWindows_arm64::WriteAllRegisterValues(
 
 Status NativeRegisterContextWindows_arm64::IsWatchpointHit(uint32_t wp_index,
                                                            bool &is_hit) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm64::GetWatchpointHitIndex(
     uint32_t &wp_index, lldb::addr_t trap_addr) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm64::IsWatchpointVacant(uint32_t wp_index,
                                                               bool &is_vacant) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_arm64::SetHardwareWatchpointWithIndex(
     lldb::addr_t addr, size_t size, uint32_t watch_flags, uint32_t wp_index) {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 bool NativeRegisterContextWindows_arm64::ClearHardwareWatchpoint(
@@ -733,7 +735,7 @@ bool NativeRegisterContextWindows_arm64::ClearHardwareWatchpoint(
 }
 
 Status NativeRegisterContextWindows_arm64::ClearAllHardwareWatchpoints() {
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 uint32_t NativeRegisterContextWindows_arm64::SetHardwareWatchpoint(

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_i386.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_i386.cpp
@@ -265,9 +265,9 @@ Status NativeRegisterContextWindows_i386::DRRead(const uint32_t reg,
     reg_value.SetUInt32(tls_context.Dr3);
     break;
   case lldb_dr4_i386:
-    return Status("register DR4 is obsolete");
+    return Status::FromErrorString("register DR4 is obsolete");
   case lldb_dr5_i386:
-    return Status("register DR5 is obsolete");
+    return Status::FromErrorString("register DR5 is obsolete");
   case lldb_dr6_i386:
     reg_value.SetUInt32(tls_context.Dr6);
     break;
@@ -304,9 +304,9 @@ NativeRegisterContextWindows_i386::DRWrite(const uint32_t reg,
     tls_context.Dr3 = reg_value.GetAsUInt32();
     break;
   case lldb_dr4_i386:
-    return Status("register DR4 is obsolete");
+    return Status::FromErrorString("register DR4 is obsolete");
   case lldb_dr5_i386:
-    return Status("register DR5 is obsolete");
+    return Status::FromErrorString("register DR5 is obsolete");
   case lldb_dr6_i386:
     tls_context.Dr6 = reg_value.GetAsUInt32();
     break;
@@ -324,7 +324,7 @@ NativeRegisterContextWindows_i386::ReadRegister(const RegisterInfo *reg_info,
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -332,9 +332,10 @@ NativeRegisterContextWindows_i386::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -344,7 +345,7 @@ NativeRegisterContextWindows_i386::ReadRegister(const RegisterInfo *reg_info,
   if (IsDR(reg))
     return DRRead(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_i386::WriteRegister(
@@ -352,7 +353,7 @@ Status NativeRegisterContextWindows_i386::WriteRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -360,9 +361,10 @@ Status NativeRegisterContextWindows_i386::WriteRegister(
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly written.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot write directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot write directly",
+        reg_info->name);
     return error;
   }
 
@@ -372,7 +374,7 @@ Status NativeRegisterContextWindows_i386::WriteRegister(
   if (IsDR(reg))
     return DRWrite(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_i386::ReadAllRegisterValues(
@@ -395,14 +397,14 @@ Status NativeRegisterContextWindows_i386::WriteAllRegisterValues(
   Status error;
   const size_t data_size = REG_CONTEXT_SIZE;
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextWindows_i386::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != data_size) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
         data_size, data_sp->GetByteSize());
     return error;
@@ -418,7 +420,7 @@ Status NativeRegisterContextWindows_i386::IsWatchpointHit(uint32_t wp_index,
   is_hit = false;
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("watchpoint index out of range");
+    return Status::FromErrorString("watchpoint index out of range");
 
   RegisterValue reg_value;
   Status error = DRRead(lldb_dr6_i386, reg_value);
@@ -454,7 +456,7 @@ Status NativeRegisterContextWindows_i386::IsWatchpointVacant(uint32_t wp_index,
   is_vacant = false;
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   RegisterValue reg_value;
   Status error = DRRead(lldb_dr7_i386, reg_value);

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_x86_64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_x86_64.cpp
@@ -463,9 +463,9 @@ Status NativeRegisterContextWindows_x86_64::DRRead(const uint32_t reg,
     reg_value.SetUInt64(tls_context.Dr3);
     break;
   case lldb_dr4_x86_64:
-    return Status("register DR4 is obsolete");
+    return Status::FromErrorString("register DR4 is obsolete");
   case lldb_dr5_x86_64:
-    return Status("register DR5 is obsolete");
+    return Status::FromErrorString("register DR5 is obsolete");
   case lldb_dr6_x86_64:
     reg_value.SetUInt64(tls_context.Dr6);
     break;
@@ -502,9 +502,9 @@ NativeRegisterContextWindows_x86_64::DRWrite(const uint32_t reg,
     tls_context.Dr3 = reg_value.GetAsUInt64();
     break;
   case lldb_dr4_x86_64:
-    return Status("register DR4 is obsolete");
+    return Status::FromErrorString("register DR4 is obsolete");
   case lldb_dr5_x86_64:
-    return Status("register DR5 is obsolete");
+    return Status::FromErrorString("register DR5 is obsolete");
   case lldb_dr6_x86_64:
     tls_context.Dr6 = reg_value.GetAsUInt64();
     break;
@@ -521,7 +521,7 @@ NativeRegisterContextWindows_x86_64::ReadRegister(const RegisterInfo *reg_info,
                                                   RegisterValue &reg_value) {
   Status error;
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -529,9 +529,10 @@ NativeRegisterContextWindows_x86_64::ReadRegister(const RegisterInfo *reg_info,
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly queried.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot read directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot read directly",
+        reg_info->name);
     return error;
   }
 
@@ -544,7 +545,7 @@ NativeRegisterContextWindows_x86_64::ReadRegister(const RegisterInfo *reg_info,
   if (IsDR(reg))
     return DRRead(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_x86_64::WriteRegister(
@@ -552,7 +553,7 @@ Status NativeRegisterContextWindows_x86_64::WriteRegister(
   Status error;
 
   if (!reg_info) {
-    error.SetErrorString("reg_info NULL");
+    error = Status::FromErrorString("reg_info NULL");
     return error;
   }
 
@@ -560,9 +561,10 @@ Status NativeRegisterContextWindows_x86_64::WriteRegister(
   if (reg == LLDB_INVALID_REGNUM) {
     // This is likely an internal register for lldb use only and should not be
     // directly written.
-    error.SetErrorStringWithFormat("register \"%s\" is an internal-only lldb "
-                                   "register, cannot write directly",
-                                   reg_info->name);
+    error = Status::FromErrorStringWithFormat(
+        "register \"%s\" is an internal-only lldb "
+        "register, cannot write directly",
+        reg_info->name);
     return error;
   }
 
@@ -575,7 +577,7 @@ Status NativeRegisterContextWindows_x86_64::WriteRegister(
   if (IsDR(reg))
     return DRWrite(reg, reg_value);
 
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 Status NativeRegisterContextWindows_x86_64::ReadAllRegisterValues(
@@ -598,14 +600,14 @@ Status NativeRegisterContextWindows_x86_64::WriteAllRegisterValues(
   Status error;
   const size_t data_size = REG_CONTEXT_SIZE;
   if (!data_sp) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NativeRegisterContextWindows_x86_64::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != data_size) {
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
         data_size, data_sp->GetByteSize());
     return error;
@@ -621,7 +623,7 @@ Status NativeRegisterContextWindows_x86_64::IsWatchpointHit(uint32_t wp_index,
   is_hit = false;
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("watchpoint index out of range");
+    return Status::FromErrorString("watchpoint index out of range");
 
   RegisterValue reg_value;
   Status error = DRRead(lldb_dr6_x86_64, reg_value);
@@ -658,7 +660,7 @@ NativeRegisterContextWindows_x86_64::IsWatchpointVacant(uint32_t wp_index,
   is_vacant = false;
 
   if (wp_index >= NumSupportedHardwareWatchpoints())
-    return Status("Watchpoint index out of range");
+    return Status::FromErrorString("Watchpoint index out of range");
 
   RegisterValue reg_value;
   Status error = DRRead(lldb_dr7_x86_64, reg_value);

--- a/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
@@ -151,7 +151,7 @@ bool NativeThreadWindows::GetStopReason(ThreadStopInfo &stop_info,
 Status NativeThreadWindows::SetWatchpoint(lldb::addr_t addr, size_t size,
                                           uint32_t watch_flags, bool hardware) {
   if (!hardware)
-    return Status("not implemented");
+    return Status::FromErrorString("not implemented");
   if (m_state == eStateLaunching)
     return Status();
   Status error = RemoveWatchpoint(addr);
@@ -160,7 +160,7 @@ Status NativeThreadWindows::SetWatchpoint(lldb::addr_t addr, size_t size,
   uint32_t wp_index =
       m_reg_context_up->SetHardwareWatchpoint(addr, size, watch_flags);
   if (wp_index == LLDB_INVALID_INDEX32)
-    return Status("Setting hardware watchpoint failed.");
+    return Status::FromErrorString("Setting hardware watchpoint failed.");
   m_watchpoint_index_map.insert({addr, wp_index});
   return Status();
 }
@@ -173,14 +173,14 @@ Status NativeThreadWindows::RemoveWatchpoint(lldb::addr_t addr) {
   m_watchpoint_index_map.erase(wp);
   if (m_reg_context_up->ClearHardwareWatchpoint(wp_index))
     return Status();
-  return Status("Clearing hardware watchpoint failed.");
+  return Status::FromErrorString("Clearing hardware watchpoint failed.");
 }
 
 Status NativeThreadWindows::SetHardwareBreakpoint(lldb::addr_t addr,
                                                   size_t size) {
-  return Status("unimplemented.");
+  return Status::FromErrorString("unimplemented.");
 }
 
 Status NativeThreadWindows::RemoveHardwareBreakpoint(lldb::addr_t addr) {
-  return Status("unimplemented.");
+  return Status::FromErrorString("unimplemented.");
 }

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
@@ -116,8 +116,8 @@ Status ProcessDebugger::LaunchProcess(ProcessLaunchInfo &launch_info,
   if (working_dir) {
     FileSystem::Instance().Resolve(working_dir);
     if (!FileSystem::Instance().IsDirectory(working_dir)) {
-      result.SetErrorStringWithFormat("No such file or directory: %s",
-                                      working_dir.GetPath().c_str());
+      result = Status::FromErrorStringWithFormat(
+          "No such file or directory: %s", working_dir.GetPath().c_str());
       return result;
     }
   }
@@ -128,7 +128,7 @@ Status ProcessDebugger::LaunchProcess(ProcessLaunchInfo &launch_info,
                   "only be used for debug launches.",
                   launch_info.GetExecutableFile().GetPath().c_str());
     std::string message = stream.GetString().str();
-    result.SetErrorString(message.c_str());
+    result = Status::FromErrorString(message.c_str());
 
     LLDB_LOG(log, "error: {0}", message);
     return result;
@@ -267,7 +267,7 @@ Status ProcessDebugger::ReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
   llvm::sys::ScopedLock lock(m_mutex);
 
   if (!m_session_data) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "cannot read, there is no active debugger connection.");
     LLDB_LOG(log, "error: {0}", error);
     return error;
@@ -299,7 +299,7 @@ Status ProcessDebugger::WriteMemory(lldb::addr_t vm_addr, const void *buf,
            vm_addr);
 
   if (!m_session_data) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "cannot write, there is no active debugger connection.");
     LLDB_LOG(log, "error: {0}", error);
     return error;
@@ -329,7 +329,7 @@ Status ProcessDebugger::AllocateMemory(size_t size, uint32_t permissions,
            permissions);
 
   if (!m_session_data) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "cannot allocate, there is no active debugger connection");
     LLDB_LOG(log, "error: {0}", error);
     return error;
@@ -356,7 +356,7 @@ Status ProcessDebugger::DeallocateMemory(lldb::addr_t vm_addr) {
   LLDB_LOG(log, "attempting to deallocate bytes at address {0}", vm_addr);
 
   if (!m_session_data) {
-    result.SetErrorString(
+    result = Status::FromErrorString(
         "cannot deallocate, there is no active debugger connection");
     LLDB_LOG(log, "error: {0}", result);
     return result;
@@ -381,7 +381,7 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
   info.Clear();
 
   if (!m_session_data) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "GetMemoryRegionInfo called with no debugging session.");
     LLDB_LOG(log, "error: {0}", error);
     return error;
@@ -389,7 +389,7 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
   HostProcess process = m_session_data->m_debugger->GetProcess();
   lldb::process_t handle = process.GetNativeProcess().GetSystemHandle();
   if (handle == nullptr || handle == LLDB_INVALID_PROCESS) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "GetMemoryRegionInfo called with an invalid target process.");
     LLDB_LOG(log, "error: {0}", error);
     return error;

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -123,24 +123,24 @@ ProcessWindows::ProcessWindows(lldb::TargetSP target_sp,
 ProcessWindows::~ProcessWindows() {}
 
 size_t ProcessWindows::GetSTDOUT(char *buf, size_t buf_size, Status &error) {
-  error.SetErrorString("GetSTDOUT unsupported on Windows");
+  error = Status::FromErrorString("GetSTDOUT unsupported on Windows");
   return 0;
 }
 
 size_t ProcessWindows::GetSTDERR(char *buf, size_t buf_size, Status &error) {
-  error.SetErrorString("GetSTDERR unsupported on Windows");
+  error = Status::FromErrorString("GetSTDERR unsupported on Windows");
   return 0;
 }
 
 size_t ProcessWindows::PutSTDIN(const char *buf, size_t buf_size,
                                 Status &error) {
-  error.SetErrorString("PutSTDIN unsupported on Windows");
+  error = Status::FromErrorString("PutSTDIN unsupported on Windows");
   return 0;
 }
 
 Status ProcessWindows::EnableBreakpointSite(BreakpointSite *bp_site) {
   if (bp_site->HardwareRequired())
-    return Status("Hardware breakpoints are not supported.");
+    return Status::FromErrorString("Hardware breakpoints are not supported.");
 
   Log *log = GetLog(WindowsLog::Breakpoints);
   LLDB_LOG(log, "bp_site = {0:x}, id={1}, addr={2:x}", bp_site,
@@ -175,9 +175,10 @@ Status ProcessWindows::DoDetach(bool keep_stopped) {
     else
       LLDB_LOG(log, "Detaching process error: {0}", error);
   } else {
-    error.SetErrorStringWithFormatv("error: process {0} in state = {1}, but "
-                                    "cannot detach it in this state.",
-                                    GetID(), private_state);
+    error = Status::FromErrorStringWithFormatv(
+        "error: process {0} in state = {1}, but "
+        "cannot detach it in this state.",
+        GetID(), private_state);
     LLDB_LOG(log, "error: {0}", error);
   }
   return error;
@@ -231,7 +232,7 @@ Status ProcessWindows::DoResume() {
     }
 
     if (failed) {
-      error.SetErrorString("ProcessWindows::DoResume failed");
+      error = Status::FromErrorString("ProcessWindows::DoResume failed");
     } else {
       SetPrivateState(eStateRunning);
     }
@@ -849,8 +850,8 @@ Status ProcessWindows::EnableWatchpoint(WatchpointSP wp_sp, bool notify) {
     if (m_watchpoint_ids[info.slot_id] == LLDB_INVALID_BREAK_ID)
       break;
   if (info.slot_id == RegisterContextWindows::GetNumHardwareBreakpointSlots()) {
-    error.SetErrorStringWithFormat("Can't find free slot for watchpoint %i",
-                                   wp_sp->GetID());
+    error = Status::FromErrorStringWithFormat(
+        "Can't find free slot for watchpoint %i", wp_sp->GetID());
     return error;
   }
   info.address = wp_sp->GetLoadAddress();
@@ -864,7 +865,7 @@ Status ProcessWindows::EnableWatchpoint(WatchpointSP wp_sp, bool notify) {
         thread->GetRegisterContext().get());
     if (!reg_ctx->AddHardwareBreakpoint(info.slot_id, info.address, info.size,
                                         info.read, info.write)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Can't enable watchpoint %i on thread 0x%llx", wp_sp->GetID(),
           thread->GetID());
       break;
@@ -898,8 +899,8 @@ Status ProcessWindows::DisableWatchpoint(WatchpointSP wp_sp, bool notify) {
 
   auto it = m_watchpoints.find(wp_sp->GetID());
   if (it == m_watchpoints.end()) {
-    error.SetErrorStringWithFormat("Info about watchpoint %i is not found",
-                                   wp_sp->GetID());
+    error = Status::FromErrorStringWithFormat(
+        "Info about watchpoint %i is not found", wp_sp->GetID());
     return error;
   }
 
@@ -908,7 +909,7 @@ Status ProcessWindows::DisableWatchpoint(WatchpointSP wp_sp, bool notify) {
     auto *reg_ctx = static_cast<RegisterContextWindows *>(
         thread->GetRegisterContext().get());
     if (!reg_ctx->RemoveHardwareBreakpoint(it->second.slot_id)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Can't disable watchpoint %i on thread 0x%llx", wp_sp->GetID(),
           thread->GetID());
       break;

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -160,19 +160,19 @@ lldb::addr_t ProcessElfCore::AddAddressRangeFromMemoryTagSegment(
 Status ProcessElfCore::DoLoadCore() {
   Status error;
   if (!m_core_module_sp) {
-    error.SetErrorString("invalid core module");
+    error = Status::FromErrorString("invalid core module");
     return error;
   }
 
   ObjectFileELF *core = (ObjectFileELF *)(m_core_module_sp->GetObjectFile());
   if (core == nullptr) {
-    error.SetErrorString("invalid core object file");
+    error = Status::FromErrorString("invalid core object file");
     return error;
   }
 
   llvm::ArrayRef<elf::ELFProgramHeader> segments = core->ProgramHeaders();
   if (segments.size() == 0) {
-    error.SetErrorString("core file has no segments");
+    error = Status::FromErrorString("core file has no segments");
     return error;
   }
 
@@ -383,8 +383,8 @@ size_t ProcessElfCore::DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
   const VMRangeToFileOffset::Entry *address_range =
       m_core_aranges.FindEntryThatContains(addr);
   if (address_range == nullptr || address_range->GetRangeEnd() < addr) {
-    error.SetErrorStringWithFormat("core file does not contain 0x%" PRIx64,
-                                   addr);
+    error = Status::FromErrorStringWithFormat(
+        "core file does not contain 0x%" PRIx64, addr);
     return 0;
   }
 

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
@@ -67,10 +67,8 @@ public:
   void RefreshStateAfterStop() override;
 
   lldb_private::Status WillResume() override {
-    lldb_private::Status error;
-    error.SetErrorStringWithFormatv(
+    return lldb_private::Status::FromErrorStringWithFormatv(
         "error: {0} does not support resuming processes", GetPluginName());
-    return error;
   }
 
   // Process Queries

--- a/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
@@ -280,7 +280,7 @@ Status ELFLinuxPrStatus::Parse(const DataExtractor &data,
                                const ArchSpec &arch) {
   Status error;
   if (GetSize(arch) > data.GetByteSize()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NT_PRSTATUS size should be %zu, but the remaining bytes are: %" PRIu64,
         GetSize(arch), data.GetByteSize());
     return error;
@@ -376,7 +376,7 @@ Status ELFLinuxPrPsInfo::Parse(const DataExtractor &data,
   Status error;
   ByteOrder byteorder = data.GetByteOrder();
   if (GetSize(arch) > data.GetByteSize()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NT_PRPSINFO size should be %zu, but the remaining bytes are: %" PRIu64,
         GetSize(arch), data.GetByteSize());
     return error;
@@ -544,7 +544,7 @@ size_t ELFLinuxSigInfo::GetSize(const lldb_private::ArchSpec &arch) {
 Status ELFLinuxSigInfo::Parse(const DataExtractor &data, const ArchSpec &arch) {
   Status error;
   if (GetSize(arch) > data.GetByteSize()) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "NT_SIGINFO size should be %zu, but the remaining bytes are: %" PRIu64,
         GetSize(arch), data.GetByteSize());
     return error;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -835,7 +835,7 @@ GDBRemoteCommunication::CheckForPacket(const uint8_t *src, size_t src_len,
 Status GDBRemoteCommunication::StartListenThread(const char *hostname,
                                                  uint16_t port) {
   if (m_listen_thread.IsJoinable())
-    return Status("listen thread already running");
+    return Status::FromErrorString("listen thread already running");
 
   char listen_url[512];
   if (hostname && hostname[0])
@@ -1052,10 +1052,10 @@ Status GDBRemoteCommunication::StartDebugserverProcess(
           if (port)
             *port = port_;
         } else {
-          error.SetErrorString("failed to bind to port 0 on 127.0.0.1");
           LLDB_LOGF(log, "GDBRemoteCommunication::%s() failed: %s",
                     __FUNCTION__, error.AsCString());
-          return error;
+          return Status::FromErrorString(
+              "failed to bind to port 0 on 127.0.0.1");
         }
       }
     }
@@ -1191,7 +1191,7 @@ Status GDBRemoteCommunication::StartDebugserverProcess(
       JoinListenThread();
     }
   } else {
-    error.SetErrorStringWithFormat("unable to locate " DEBUGSERVER_BASENAME);
+    error = Status::FromErrorString("unable to locate " DEBUGSERVER_BASENAME);
   }
 
   if (error.Fail()) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -104,11 +104,12 @@ bool GDBRemoteCommunicationClient::HandshakeWithServer(Status *error_ptr) {
               .count();
       if (error_ptr) {
         if (!IsConnected())
-          error_ptr->SetErrorString("Connection shut down by remote side "
-                                    "while waiting for reply to initial "
-                                    "handshake packet");
+          *error_ptr =
+              Status::FromErrorString("Connection shut down by remote side "
+                                      "while waiting for reply to initial "
+                                      "handshake packet");
         else
-          error_ptr->SetErrorStringWithFormat(
+          *error_ptr = Status::FromErrorStringWithFormat(
               "failed to get reply to handshake packet within timeout of "
               "%.1f seconds",
               handshake_timeout);
@@ -116,7 +117,7 @@ bool GDBRemoteCommunicationClient::HandshakeWithServer(Status *error_ptr) {
     }
   } else {
     if (error_ptr)
-      error_ptr->SetErrorString("failed to send the handshake ack");
+      *error_ptr = Status::FromErrorString("failed to send the handshake ack");
   }
   return false;
 }
@@ -708,7 +709,7 @@ Status GDBRemoteCommunicationClient::WriteMemoryTags(
   if (SendPacketAndWaitForResponse(packet.GetString(), response) !=
           PacketResult::Success ||
       !response.IsOKResponse()) {
-    status.SetErrorString("QMemTags packet failed");
+    status = Status::FromErrorString("QMemTags packet failed");
   }
   return status;
 }
@@ -1522,7 +1523,8 @@ Status GDBRemoteCommunicationClient::Detach(bool keep_stopped,
     }
 
     if (m_supports_detach_stay_stopped == eLazyBoolNo) {
-      error.SetErrorString("Stays stopped not supported by this target.");
+      error = Status::FromErrorString(
+          "Stays stopped not supported by this target.");
       return error;
     } else {
       packet.PutChar('1');
@@ -1537,7 +1539,8 @@ Status GDBRemoteCommunicationClient::Detach(bool keep_stopped,
     packet.PutChar(';');
     packet.PutHex64(pid);
   } else if (pid != LLDB_INVALID_PROCESS_ID) {
-    error.SetErrorString("Multiprocess extension not supported by the server.");
+    error = Status::FromErrorString(
+        "Multiprocess extension not supported by the server.");
     return error;
   }
 
@@ -1545,7 +1548,7 @@ Status GDBRemoteCommunicationClient::Detach(bool keep_stopped,
   PacketResult packet_result =
       SendPacketAndWaitForResponse(packet.GetString(), response);
   if (packet_result != PacketResult::Success)
-    error.SetErrorString("Sending isconnect packet failed.");
+    error = Status::FromErrorString("Sending isconnect packet failed.");
   return error;
 }
 
@@ -1641,7 +1644,7 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
           std::string error_string;
           // Now convert the HEX bytes into a string value
           error_extractor.GetHexByteString(error_string);
-          error.SetErrorString(error_string.c_str());
+          error = Status::FromErrorString(error_string.c_str());
         } else if (name == "dirty-pages") {
           std::vector<addr_t> dirty_page_list;
           for (llvm::StringRef x : llvm::split(value, ',')) {
@@ -1668,7 +1671,7 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
         }
       } else {
         // We got an invalid address range back
-        error.SetErrorString("Server returned invalid range");
+        error = Status::FromErrorString("Server returned invalid range");
       }
     } else {
       m_supports_memory_region_info = eLazyBoolNo;
@@ -1676,7 +1679,7 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
   }
 
   if (m_supports_memory_region_info == eLazyBoolNo) {
-    error.SetErrorString("qMemoryRegionInfo is not supported");
+    error = Status::FromErrorString("qMemoryRegionInfo is not supported");
   }
 
   // Try qXfer:memory-map:read to get region information not included in
@@ -1716,7 +1719,7 @@ Status GDBRemoteCommunicationClient::GetQXferMemoryMapRegionInfo(
       return error;
     }
   }
-  error.SetErrorString("Region not found");
+  error = Status::FromErrorString("Region not found");
   return error;
 }
 
@@ -1729,12 +1732,12 @@ Status GDBRemoteCommunicationClient::LoadQXferMemoryMap() {
     return error;
 
   if (!XMLDocument::XMLEnabled()) {
-    error.SetErrorString("XML is not supported");
+    error = Status::FromErrorString("XML is not supported");
     return error;
   }
 
   if (!GetQXferMemoryMapReadSupported()) {
-    error.SetErrorString("Memory map is not supported");
+    error = Status::FromErrorString("Memory map is not supported");
     return error;
   }
 
@@ -1745,13 +1748,13 @@ Status GDBRemoteCommunicationClient::LoadQXferMemoryMap() {
   XMLDocument xml_document;
 
   if (!xml_document.ParseMemory(xml->c_str(), xml->size())) {
-    error.SetErrorString("Failed to parse memory map xml");
+    error = Status::FromErrorString("Failed to parse memory map xml");
     return error;
   }
 
   XMLNode map_node = xml_document.GetRootElement("memory-map");
   if (!map_node) {
-    error.SetErrorString("Invalid root node in memory map xml");
+    error = Status::FromErrorString("Invalid root node in memory map xml");
     return error;
   }
 
@@ -2979,28 +2982,28 @@ lldb_private::Status GDBRemoteCommunicationClient::RunShellCommand(
   if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F')
-      return Status("malformed reply");
+      return Status::FromErrorString("malformed reply");
     if (response.GetChar() != ',')
-      return Status("malformed reply");
+      return Status::FromErrorString("malformed reply");
     uint32_t exitcode = response.GetHexMaxU32(false, UINT32_MAX);
     if (exitcode == UINT32_MAX)
-      return Status("unable to run remote process");
+      return Status::FromErrorString("unable to run remote process");
     else if (status_ptr)
       *status_ptr = exitcode;
     if (response.GetChar() != ',')
-      return Status("malformed reply");
+      return Status::FromErrorString("malformed reply");
     uint32_t signo = response.GetHexMaxU32(false, UINT32_MAX);
     if (signo_ptr)
       *signo_ptr = signo;
     if (response.GetChar() != ',')
-      return Status("malformed reply");
+      return Status::FromErrorString("malformed reply");
     std::string output;
     response.GetEscapedBinaryData(output);
     if (command_output)
       command_output->assign(output);
     return Status();
   }
-  return Status("unable to send packet");
+  return Status::FromErrorString("unable to send packet");
 }
 
 Status GDBRemoteCommunicationClient::MakeDirectory(const FileSpec &file_spec,
@@ -3015,10 +3018,12 @@ Status GDBRemoteCommunicationClient::MakeDirectory(const FileSpec &file_spec,
   StringExtractorGDBRemote response;
 
   if (SendPacketAndWaitForResponse(packet, response) != PacketResult::Success)
-    return Status("failed to send '%s' packet", packet.str().c_str());
+    return Status::FromErrorStringWithFormat("failed to send '%s' packet",
+                                             packet.str().c_str());
 
   if (response.GetChar() != 'F')
-    return Status("invalid response to '%s' packet", packet.str().c_str());
+    return Status::FromErrorStringWithFormat("invalid response to '%s' packet",
+                                             packet.str().c_str());
 
   return Status(response.GetHexMaxU32(false, UINT32_MAX), eErrorTypePOSIX);
 }
@@ -3036,10 +3041,12 @@ GDBRemoteCommunicationClient::SetFilePermissions(const FileSpec &file_spec,
   StringExtractorGDBRemote response;
 
   if (SendPacketAndWaitForResponse(packet, response) != PacketResult::Success)
-    return Status("failed to send '%s' packet", stream.GetData());
+    return Status::FromErrorStringWithFormat("failed to send '%s' packet",
+                                             stream.GetData());
 
   if (response.GetChar() != 'F')
-    return Status("invalid response to '%s' packet", stream.GetData());
+    return Status::FromErrorStringWithFormat("invalid response to '%s' packet",
+                                             stream.GetData());
 
   return Status(response.GetHexMaxU32(false, UINT32_MAX), eErrorTypePOSIX);
 }
@@ -3066,9 +3073,9 @@ static uint64_t ParseHostIOPacketResponse(StringExtractorGDBRemote &response,
   if (response.GetChar() == ',') {
     int result_errno = gdb_errno_to_system(response.GetS32(-1, 16));
     if (result_errno != -1)
-      error.SetError(result_errno, eErrorTypePOSIX);
+      error = Status(result_errno, eErrorTypePOSIX);
     else
-      error.SetError(-1, eErrorTypeGeneric);
+      error = Status(-1, eErrorTypeGeneric);
   } else
     error.Clear();
   return result;
@@ -3206,25 +3213,25 @@ GDBRemoteCommunicationClient::GetFilePermissions(const FileSpec &file_spec,
     StringExtractorGDBRemote response;
     if (SendPacketAndWaitForResponse(stream.GetString(), response) !=
         PacketResult::Success) {
-      error.SetErrorStringWithFormat("failed to send '%s' packet",
-                                     stream.GetData());
+      error = Status::FromErrorStringWithFormat("failed to send '%s' packet",
+                                                stream.GetData());
       return error;
     }
     if (!response.IsUnsupportedResponse()) {
       if (response.GetChar() != 'F') {
-        error.SetErrorStringWithFormat("invalid response to '%s' packet",
-                                       stream.GetData());
+        error = Status::FromErrorStringWithFormat(
+            "invalid response to '%s' packet", stream.GetData());
       } else {
         const uint32_t mode = response.GetS32(-1, 16);
         if (static_cast<int32_t>(mode) == -1) {
           if (response.GetChar() == ',') {
             int response_errno = gdb_errno_to_system(response.GetS32(-1, 16));
             if (response_errno > 0)
-              error.SetError(response_errno, lldb::eErrorTypePOSIX);
+              error = Status(response_errno, lldb::eErrorTypePOSIX);
             else
-              error.SetErrorToGenericError();
+              error = Status::FromErrorString("unknown error");
           } else
-            error.SetErrorToGenericError();
+            error = Status::FromErrorString("unknown error");
         } else {
           file_permissions = mode & (S_IRWXU | S_IRWXG | S_IRWXO);
         }
@@ -3240,7 +3247,7 @@ GDBRemoteCommunicationClient::GetFilePermissions(const FileSpec &file_spec,
     file_permissions = st->gdb_st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
     return Status();
   }
-  return Status("fstat failed");
+  return Status::FromErrorString("fstat failed");
 }
 
 uint64_t GDBRemoteCommunicationClient::ReadFile(lldb::user_id_t fd,
@@ -3257,11 +3264,11 @@ uint64_t GDBRemoteCommunicationClient::ReadFile(lldb::user_id_t fd,
       return 0;
     int64_t retcode = response.GetS64(-1, 16);
     if (retcode == -1) {
-      error.SetErrorToGenericError();
+      error = Status::FromErrorString("unknown error");
       if (response.GetChar() == ',') {
         int response_errno = gdb_errno_to_system(response.GetS32(-1, 16));
         if (response_errno > 0)
-          error.SetError(response_errno, lldb::eErrorTypePOSIX);
+          error = Status(response_errno, lldb::eErrorTypePOSIX);
       }
       return -1;
     }
@@ -3295,22 +3302,22 @@ uint64_t GDBRemoteCommunicationClient::WriteFile(lldb::user_id_t fd,
   if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F') {
-      error.SetErrorStringWithFormat("write file failed");
+      error = Status::FromErrorStringWithFormat("write file failed");
       return 0;
     }
     int64_t bytes_written = response.GetS64(-1, 16);
     if (bytes_written == -1) {
-      error.SetErrorToGenericError();
+      error = Status::FromErrorString("unknown error");
       if (response.GetChar() == ',') {
         int response_errno = gdb_errno_to_system(response.GetS32(-1, 16));
         if (response_errno > 0)
-          error.SetError(response_errno, lldb::eErrorTypePOSIX);
+          error = Status(response_errno, lldb::eErrorTypePOSIX);
       }
       return -1;
     }
     return bytes_written;
   } else {
-    error.SetErrorString("failed to send vFile:pwrite packet");
+    error = Status::FromErrorString("failed to send vFile:pwrite packet");
   }
   return 0;
 }
@@ -3332,19 +3339,19 @@ Status GDBRemoteCommunicationClient::CreateSymlink(const FileSpec &src,
     if (response.GetChar() == 'F') {
       uint32_t result = response.GetHexMaxU32(false, UINT32_MAX);
       if (result != 0) {
-        error.SetErrorToGenericError();
+        error = Status::FromErrorString("unknown error");
         if (response.GetChar() == ',') {
           int response_errno = gdb_errno_to_system(response.GetS32(-1, 16));
           if (response_errno > 0)
-            error.SetError(response_errno, lldb::eErrorTypePOSIX);
+            error = Status(response_errno, lldb::eErrorTypePOSIX);
         }
       }
     } else {
       // Should have returned with 'F<result>[,<errno>]'
-      error.SetErrorStringWithFormat("symlink failed");
+      error = Status::FromErrorStringWithFormat("symlink failed");
     }
   } else {
-    error.SetErrorString("failed to send vFile:symlink packet");
+    error = Status::FromErrorString("failed to send vFile:symlink packet");
   }
   return error;
 }
@@ -3363,19 +3370,19 @@ Status GDBRemoteCommunicationClient::Unlink(const FileSpec &file_spec) {
     if (response.GetChar() == 'F') {
       uint32_t result = response.GetHexMaxU32(false, UINT32_MAX);
       if (result != 0) {
-        error.SetErrorToGenericError();
+        error = Status::FromErrorString("unknown error");
         if (response.GetChar() == ',') {
           int response_errno = gdb_errno_to_system(response.GetS32(-1, 16));
           if (response_errno > 0)
-            error.SetError(response_errno, lldb::eErrorTypePOSIX);
+            error = Status(response_errno, lldb::eErrorTypePOSIX);
         }
       }
     } else {
       // Should have returned with 'F<result>[,<errno>]'
-      error.SetErrorStringWithFormat("unlink failed");
+      error = Status::FromErrorStringWithFormat("unlink failed");
     }
   } else {
-    error.SetErrorString("failed to send vFile:unlink packet");
+    error = Status::FromErrorString("failed to send vFile:unlink packet");
   }
   return error;
 }
@@ -4255,12 +4262,13 @@ Status GDBRemoteCommunicationClient::SendSignalsToIgnore(
   auto send_status = SendPacketAndWaitForResponse(packet, response);
 
   if (send_status != GDBRemoteCommunication::PacketResult::Success)
-    return Status("Sending QPassSignals packet failed");
+    return Status::FromErrorString("Sending QPassSignals packet failed");
 
   if (response.IsOKResponse()) {
     return Status();
   } else {
-    return Status("Unknown error happened during sending QPassSignals packet.");
+    return Status::FromErrorString(
+        "Unknown error happened during sending QPassSignals packet.");
   }
 }
 
@@ -4269,7 +4277,7 @@ Status GDBRemoteCommunicationClient::ConfigureRemoteStructuredData(
   Status error;
 
   if (type_name.empty()) {
-    error.SetErrorString("invalid type_name argument");
+    error = Status::FromErrorString("invalid type_name argument");
     return error;
   }
 
@@ -4299,13 +4307,13 @@ Status GDBRemoteCommunicationClient::ConfigureRemoteStructuredData(
       // Okay!
       error.Clear();
     } else {
-      error.SetErrorStringWithFormatv(
+      error = Status::FromErrorStringWithFormatv(
           "configuring StructuredData feature {0} failed with error {1}",
           type_name, response.GetStringRef());
     }
   } else {
     // Can we get more data here on the failure?
-    error.SetErrorStringWithFormatv(
+    error = Status::FromErrorStringWithFormatv(
         "configuring StructuredData feature {0} failed when sending packet: "
         "PacketResult={1}",
         type_name, (int)result);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServer.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServer.cpp
@@ -55,7 +55,7 @@ GDBRemoteCommunicationServer::GetPacketAndSendResponse(
       break;
 
     case StringExtractorGDBRemote::eServerPacketType_invalid:
-      error.SetErrorString("invalid packet");
+      error = Status::FromErrorString("invalid packet");
       quit = true;
       break;
 
@@ -73,10 +73,10 @@ GDBRemoteCommunicationServer::GetPacketAndSendResponse(
     }
   } else {
     if (!IsConnected()) {
-      error.SetErrorString("lost connection");
+      error = Status::FromErrorString("lost connection");
       quit = true;
     } else {
-      error.SetErrorString("timeout");
+      error = Status::FromErrorString("timeout");
     }
   }
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -261,8 +261,8 @@ Status GDBRemoteCommunicationServerLLGS::LaunchProcess() {
   Log *log = GetLog(LLDBLog::Process);
 
   if (!m_process_launch_info.GetArguments().GetArgumentCount())
-    return Status("%s: no process command line specified to launch",
-                  __FUNCTION__);
+    return Status::FromErrorStringWithFormat(
+        "%s: no process command line specified to launch", __FUNCTION__);
 
   const bool should_forward_stdio =
       m_process_launch_info.GetFileActionForFD(STDIN_FILENO) == nullptr ||
@@ -348,10 +348,10 @@ Status GDBRemoteCommunicationServerLLGS::AttachToProcess(lldb::pid_t pid) {
   // Before we try to attach, make sure we aren't already monitoring something
   // else.
   if (!m_debugged_processes.empty())
-    return Status("cannot attach to process %" PRIu64
-                  " when another process with pid %" PRIu64
-                  " is being debugged.",
-                  pid, m_current_process->GetID());
+    return Status::FromErrorStringWithFormat(
+        "cannot attach to process %" PRIu64
+        " when another process with pid %" PRIu64 " is being debugged.",
+        pid, m_current_process->GetID());
 
   // Try to attach.
   auto process_or = m_process_manager.Attach(pid, *this);
@@ -447,7 +447,7 @@ Status GDBRemoteCommunicationServerLLGS::AttachWaitProcess(
         error_stream.Format("{0}.", loop_process_list.back().GetProcessID());
 
         Status error;
-        error.SetErrorString(error_stream.GetString());
+        error = Status(error_stream.GetString().str());
         return error;
       }
     }
@@ -1212,14 +1212,15 @@ Status GDBRemoteCommunicationServerLLGS::SetSTDIOFileDescriptor(int fd) {
   std::unique_ptr<ConnectionFileDescriptor> conn_up(
       new ConnectionFileDescriptor(fd, true));
   if (!conn_up) {
-    error.SetErrorString("failed to create ConnectionFileDescriptor");
+    error =
+        Status::FromErrorString("failed to create ConnectionFileDescriptor");
     return error;
   }
 
   m_stdio_communication.SetCloseOnEOF(false);
   m_stdio_communication.SetConnection(std::move(conn_up));
   if (!m_stdio_communication.IsConnected()) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "failed to set connection for inferior I/O communication");
     return error;
   }
@@ -1288,7 +1289,7 @@ GDBRemoteCommunicationServerLLGS::Handle_jLLDBTraceSupported(
   // Fail if we don't have a current process.
   if (!m_current_process ||
       (m_current_process->GetID() == LLDB_INVALID_PROCESS_ID))
-    return SendErrorResponse(Status("Process not running."));
+    return SendErrorResponse(Status::FromErrorString("Process not running."));
 
   return SendJSONResponse(m_current_process->TraceSupported());
 }
@@ -1299,7 +1300,7 @@ GDBRemoteCommunicationServerLLGS::Handle_jLLDBTraceStop(
   // Fail if we don't have a current process.
   if (!m_current_process ||
       (m_current_process->GetID() == LLDB_INVALID_PROCESS_ID))
-    return SendErrorResponse(Status("Process not running."));
+    return SendErrorResponse(Status::FromErrorString("Process not running."));
 
   packet.ConsumeFront("jLLDBTraceStop:");
   Expected<TraceStopRequest> stop_request =
@@ -1320,7 +1321,7 @@ GDBRemoteCommunicationServerLLGS::Handle_jLLDBTraceStart(
   // Fail if we don't have a current process.
   if (!m_current_process ||
       (m_current_process->GetID() == LLDB_INVALID_PROCESS_ID))
-    return SendErrorResponse(Status("Process not running."));
+    return SendErrorResponse(Status::FromErrorString("Process not running."));
 
   packet.ConsumeFront("jLLDBTraceStart:");
   Expected<TraceStartRequest> request =
@@ -1341,7 +1342,7 @@ GDBRemoteCommunicationServerLLGS::Handle_jLLDBTraceGetState(
   // Fail if we don't have a current process.
   if (!m_current_process ||
       (m_current_process->GetID() == LLDB_INVALID_PROCESS_ID))
-    return SendErrorResponse(Status("Process not running."));
+    return SendErrorResponse(Status::FromErrorString("Process not running."));
 
   packet.ConsumeFront("jLLDBTraceGetState:");
   Expected<TraceGetStateRequest> request =
@@ -1359,7 +1360,7 @@ GDBRemoteCommunicationServerLLGS::Handle_jLLDBTraceGetBinaryData(
   // Fail if we don't have a current process.
   if (!m_current_process ||
       (m_current_process->GetID() == LLDB_INVALID_PROCESS_ID))
-    return SendErrorResponse(Status("Process not running."));
+    return SendErrorResponse(Status::FromErrorString("Process not running."));
 
   packet.ConsumeFront("jLLDBTraceGetBinaryData:");
   llvm::Expected<TraceGetBinaryDataRequest> request =
@@ -3539,7 +3540,7 @@ GDBRemoteCommunicationServerLLGS::Handle_vRun(
   }
 
   if (argv.empty())
-    return SendErrorResponse(Status("No arguments"));
+    return SendErrorResponse(Status::FromErrorString("No arguments"));
   m_process_launch_info.GetExecutableFile().SetFile(
       m_process_launch_info.GetArguments()[0].ref(), FileSpec::Style::native);
   m_process_launch_error = LaunchProcess();
@@ -3599,7 +3600,8 @@ GDBRemoteCommunicationServerLLGS::Handle_D(StringExtractorGDBRemote &packet) {
   if (detach_error)
     return SendErrorResponse(std::move(detach_error));
   if (!detached)
-    return SendErrorResponse(Status("PID %" PRIu64 " not traced", pid));
+    return SendErrorResponse(
+        Status::FromErrorStringWithFormat("PID %" PRIu64 " not traced", pid));
   return SendOKResponse();
 }
 
@@ -3920,7 +3922,7 @@ GDBRemoteCommunicationServerLLGS::Handle_qSaveCore(
   // Fail if we don't have a current process.
   if (!m_current_process ||
       (m_current_process->GetID() == LLDB_INVALID_PROCESS_ID))
-    return SendErrorResponse(Status("Process not running."));
+    return SendErrorResponse(Status::FromErrorString("Process not running."));
 
   std::string path_hint;
 
@@ -3931,7 +3933,8 @@ GDBRemoteCommunicationServerLLGS::Handle_qSaveCore(
       if (x.consume_front("path-hint:"))
         StringExtractor(x).GetHexByteString(path_hint);
       else
-        return SendErrorResponse(Status("Unsupported qSaveCore option"));
+        return SendErrorResponse(
+            Status::FromErrorString("Unsupported qSaveCore option"));
     }
   }
 
@@ -3982,7 +3985,8 @@ GDBRemoteCommunicationServerLLGS::Handle_QNonStop(
       StartSTDIOForwarding();
     m_non_stop = true;
   } else
-    return SendErrorResponse(Status("Invalid QNonStop packet"));
+    return SendErrorResponse(
+        Status::FromErrorString("Invalid QNonStop packet"));
   return SendOKResponse();
 }
 
@@ -3995,7 +3999,8 @@ GDBRemoteCommunicationServerLLGS::HandleNotificationAck(
   // the last message in the queue is ACK-ed, in which case the packet sends
   // an OK response.
   if (queue.empty())
-    return SendErrorResponse(Status("No pending notification to ack"));
+    return SendErrorResponse(
+        Status::FromErrorString("No pending notification to ack"));
   queue.pop_front();
   if (!queue.empty())
     return SendPacketNoLock(queue.front());
@@ -4025,7 +4030,8 @@ GDBRemoteCommunication::PacketResult
 GDBRemoteCommunicationServerLLGS::Handle_vCtrlC(
     StringExtractorGDBRemote &packet) {
   if (!m_non_stop)
-    return SendErrorResponse(Status("vCtrl is only valid in non-stop mode"));
+    return SendErrorResponse(
+        Status::FromErrorString("vCtrl is only valid in non-stop mode"));
 
   PacketResult interrupt_res = Handle_interrupt(packet);
   // If interrupting the process failed, pass the result through.

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
@@ -149,7 +149,7 @@ GDBRemoteCommunicationServerPlatform::GDBRemoteCommunicationServerPlatform(
   RegisterPacketHandler(StringExtractorGDBRemote::eServerPacketType_interrupt,
                         [](StringExtractorGDBRemote packet, Status &error,
                            bool &interrupt, bool &quit) {
-                          error.SetErrorString("interrupt received");
+                          error = Status::FromErrorString("interrupt received");
                           interrupt = true;
                           return PacketResult::Success;
                         });
@@ -527,8 +527,8 @@ void GDBRemoteCommunicationServerPlatform::DebugserverProcessReaped(
 
 Status GDBRemoteCommunicationServerPlatform::LaunchProcess() {
   if (!m_process_launch_info.GetArguments().GetArgumentCount())
-    return Status("%s: no process command line specified to launch",
-                  __FUNCTION__);
+    return Status::FromErrorStringWithFormat(
+        "%s: no process command line specified to launch", __FUNCTION__);
 
   // specify the process monitor if not already set.  This should generally be
   // what happens since we need to reap started processes.

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -565,15 +565,15 @@ Status ProcessGDBRemote::DoConnectRemote(llvm::StringRef remote_url) {
       if (state != eStateInvalid) {
         SetPrivateState(state);
       } else
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "Process %" PRIu64 " was reported after connecting to "
             "'%s', but state was not stopped: %s",
             pid, remote_url.str().c_str(), StateAsCString(state));
     } else
-      error.SetErrorStringWithFormat("Process %" PRIu64
-                                     " was reported after connecting to '%s', "
-                                     "but no stop reply packet was received",
-                                     pid, remote_url.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "Process %" PRIu64 " was reported after connecting to '%s', "
+          "but no stop reply packet was received",
+          pid, remote_url.str().c_str());
   }
 
   LLDB_LOGF(log,
@@ -761,9 +761,9 @@ Status ProcessGDBRemote::DoLaunch(lldb_private::Module *exe_module,
       if (FileSpec exe_file = launch_info.GetExecutableFile())
         args.ReplaceArgumentAtIndex(0, exe_file.GetPath(false));
       if (llvm::Error err = m_gdb_comm.LaunchProcess(args)) {
-        error.SetErrorStringWithFormatv("Cannot launch '{0}': {1}",
-                                        args.GetArgumentAtIndex(0),
-                                        llvm::fmt_consume(std::move(err)));
+        error = Status::FromErrorStringWithFormatv(
+            "Cannot launch '{0}': {1}", args.GetArgumentAtIndex(0),
+            llvm::fmt_consume(std::move(err)));
       } else {
         SetID(m_gdb_comm.GetCurrentProcessID());
       }
@@ -834,7 +834,7 @@ Status ProcessGDBRemote::ConnectToDebugserver(llvm::StringRef connect_url) {
 
   if (!m_gdb_comm.IsConnected()) {
     if (error.Success())
-      error.SetErrorString("not connected to remote gdb server");
+      error = Status::FromErrorString("not connected to remote gdb server");
     return error;
   }
 
@@ -845,7 +845,7 @@ Status ProcessGDBRemote::ConnectToDebugserver(llvm::StringRef connect_url) {
   if (!m_gdb_comm.HandshakeWithServer(&error)) {
     m_gdb_comm.Disconnect();
     if (error.Success())
-      error.SetErrorString("not connected to remote gdb server");
+      error = Status::FromErrorString("not connected to remote gdb server");
     return error;
   }
 
@@ -1364,11 +1364,13 @@ Status ProcessGDBRemote::DoResume() {
     }
 
     if (continue_packet_error) {
-      error.SetErrorString("can't make continue packet for this resume");
+      error =
+          Status::FromErrorString("can't make continue packet for this resume");
     } else {
       EventSP event_sp;
       if (!m_async_thread.IsJoinable()) {
-        error.SetErrorString("Trying to resume but the async thread is dead.");
+        error = Status::FromErrorString(
+            "Trying to resume but the async thread is dead.");
         LLDB_LOGF(log, "ProcessGDBRemote::DoResume: Trying to resume but the "
                        "async thread is dead.");
         return error;
@@ -1379,11 +1381,12 @@ Status ProcessGDBRemote::DoResume() {
       m_async_broadcaster.BroadcastEvent(eBroadcastBitAsyncContinue, data_sp);
 
       if (!listener_sp->GetEvent(event_sp, std::chrono::seconds(5))) {
-        error.SetErrorString("Resume timed out.");
+        error = Status::FromErrorString("Resume timed out.");
         LLDB_LOGF(log, "ProcessGDBRemote::DoResume: Resume timed out.");
       } else if (event_sp->BroadcasterIs(&m_async_broadcaster)) {
-        error.SetErrorString("Broadcast continue, but the async thread was "
-                             "killed before we got an ack back.");
+        error = Status::FromErrorString(
+            "Broadcast continue, but the async thread was "
+            "killed before we got an ack back.");
         LLDB_LOGF(log,
                   "ProcessGDBRemote::DoResume: Broadcast continue, but the "
                   "async thread was killed before we got an ack back.");
@@ -2648,16 +2651,18 @@ size_t ProcessGDBRemote::DoReadMemory(addr_t addr, void *buf, size_t size,
             llvm::MutableArrayRef<uint8_t>((uint8_t *)buf, size), '\xdd');
       }
     } else if (response.IsErrorResponse())
-      error.SetErrorStringWithFormat("memory read failed for 0x%" PRIx64, addr);
+      error = Status::FromErrorStringWithFormat(
+          "memory read failed for 0x%" PRIx64, addr);
     else if (response.IsUnsupportedResponse())
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "GDB server does not support reading memory");
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "unexpected response to GDB server memory read packet '%s': '%s'",
           packet, response.GetStringRef().data());
   } else {
-    error.SetErrorStringWithFormat("failed to send packet: '%s'", packet);
+    error = Status::FromErrorStringWithFormat("failed to send packet: '%s'",
+                                              packet);
   }
   return 0;
 }
@@ -2738,13 +2743,15 @@ Status ProcessGDBRemote::FlashErase(lldb::addr_t addr, size_t size) {
   // about only one region's block size.  DoMemoryWrite is this function's
   // primary user, and it can easily keep writes within a single memory region
   if (addr + size > region.GetRange().GetRangeEnd()) {
-    status.SetErrorString("Unable to erase flash in multiple regions");
+    status =
+        Status::FromErrorString("Unable to erase flash in multiple regions");
     return status;
   }
 
   uint64_t blocksize = region.GetBlocksize();
   if (blocksize == 0) {
-    status.SetErrorString("Unable to erase flash because blocksize is 0");
+    status =
+        Status::FromErrorString("Unable to erase flash because blocksize is 0");
     return status;
   }
 
@@ -2789,18 +2796,19 @@ Status ProcessGDBRemote::FlashErase(lldb::addr_t addr, size_t size) {
       m_erased_flash_ranges.Insert(range, true);
     } else {
       if (response.IsErrorResponse())
-        status.SetErrorStringWithFormat("flash erase failed for 0x%" PRIx64,
-                                        addr);
+        status = Status::FromErrorStringWithFormat(
+            "flash erase failed for 0x%" PRIx64, addr);
       else if (response.IsUnsupportedResponse())
-        status.SetErrorStringWithFormat("GDB server does not support flashing");
+        status = Status::FromErrorStringWithFormat(
+            "GDB server does not support flashing");
       else
-        status.SetErrorStringWithFormat(
+        status = Status::FromErrorStringWithFormat(
             "unexpected response to GDB server flash erase packet '%s': '%s'",
             packet.GetData(), response.GetStringRef().data());
     }
   } else {
-    status.SetErrorStringWithFormat("failed to send packet: '%s'",
-                                    packet.GetData());
+    status = Status::FromErrorStringWithFormat("failed to send packet: '%s'",
+                                               packet.GetData());
   }
   return status;
 }
@@ -2819,16 +2827,18 @@ Status ProcessGDBRemote::FlashDone() {
       m_erased_flash_ranges.Clear();
     } else {
       if (response.IsErrorResponse())
-        status.SetErrorStringWithFormat("flash done failed");
+        status = Status::FromErrorStringWithFormat("flash done failed");
       else if (response.IsUnsupportedResponse())
-        status.SetErrorStringWithFormat("GDB server does not support flashing");
+        status = Status::FromErrorStringWithFormat(
+            "GDB server does not support flashing");
       else
-        status.SetErrorStringWithFormat(
+        status = Status::FromErrorStringWithFormat(
             "unexpected response to GDB server flash done packet: '%s'",
             response.GetStringRef().data());
     }
   } else {
-    status.SetErrorStringWithFormat("failed to send flash done packet");
+    status =
+        Status::FromErrorStringWithFormat("failed to send flash done packet");
   }
   return status;
 }
@@ -2855,7 +2865,7 @@ size_t ProcessGDBRemote::DoWriteMemory(addr_t addr, const void *buf,
 
   if (is_flash) {
     if (!m_allow_flash_writes) {
-      error.SetErrorString("Writing to flash memory is not allowed");
+      error = Status::FromErrorString("Writing to flash memory is not allowed");
       return 0;
     }
     // Keep the write within a flash memory region
@@ -2880,18 +2890,18 @@ size_t ProcessGDBRemote::DoWriteMemory(addr_t addr, const void *buf,
       error.Clear();
       return size;
     } else if (response.IsErrorResponse())
-      error.SetErrorStringWithFormat("memory write failed for 0x%" PRIx64,
-                                     addr);
+      error = Status::FromErrorStringWithFormat(
+          "memory write failed for 0x%" PRIx64, addr);
     else if (response.IsUnsupportedResponse())
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "GDB server does not support writing memory");
     else
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "unexpected response to GDB server memory write packet '%s': '%s'",
           packet.GetData(), response.GetStringRef().data());
   } else {
-    error.SetErrorStringWithFormat("failed to send packet: '%s'",
-                                   packet.GetData());
+    error = Status::FromErrorStringWithFormat("failed to send packet: '%s'",
+                                              packet.GetData());
   }
   return 0;
 }
@@ -2933,7 +2943,7 @@ lldb::addr_t ProcessGDBRemote::DoAllocateMemory(size_t size,
   }
 
   if (allocated_addr == LLDB_INVALID_ADDRESS)
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "unable to allocate %" PRIu64 " bytes of memory with permissions %s",
         (uint64_t)size, GetPermissionsAsCString(permissions));
   else
@@ -2964,13 +2974,13 @@ Status ProcessGDBRemote::DoDeallocateMemory(lldb::addr_t addr) {
   case eLazyBoolCalculate:
     // We should never be deallocating memory without allocating memory first
     // so we should never get eLazyBoolCalculate
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "tried to deallocate memory without ever allocating memory");
     break;
 
   case eLazyBoolYes:
     if (!m_gdb_comm.DeallocateMemory(addr))
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "unable to deallocate memory at 0x%" PRIx64, addr);
     break;
 
@@ -2982,7 +2992,7 @@ Status ProcessGDBRemote::DoDeallocateMemory(lldb::addr_t addr) {
           InferiorCallMunmap(this, addr, pos->second))
         m_addr_to_mmap_size.erase(pos);
       else
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "unable to deallocate memory at 0x%" PRIx64, addr);
     }
     break;
@@ -3063,10 +3073,10 @@ Status ProcessGDBRemote::EnableBreakpointSite(BreakpointSite *bp_site) {
     // fall through and try another form of breakpoint.
     if (m_gdb_comm.SupportsGDBStoppointPacket(eBreakpointSoftware)) {
       if (error_no != UINT8_MAX)
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "error: %d sending the breakpoint request", error_no);
       else
-        error.SetErrorString("error sending the breakpoint request");
+        error = Status::FromErrorString("error sending the breakpoint request");
       return error;
     }
 
@@ -3098,14 +3108,15 @@ Status ProcessGDBRemote::EnableBreakpointSite(BreakpointSite *bp_site) {
     if (m_gdb_comm.SupportsGDBStoppointPacket(eBreakpointHardware)) {
       // Unable to set this hardware breakpoint
       if (error_no != UINT8_MAX)
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "error: %d sending the hardware breakpoint request "
             "(hardware breakpoint resources might be exhausted or unavailable)",
             error_no);
       else
-        error.SetErrorString("error sending the hardware breakpoint request "
-                             "(hardware breakpoint resources "
-                             "might be exhausted or unavailable)");
+        error = Status::FromErrorString(
+            "error sending the hardware breakpoint request "
+            "(hardware breakpoint resources "
+            "might be exhausted or unavailable)");
       return error;
     }
 
@@ -3118,7 +3129,7 @@ Status ProcessGDBRemote::EnableBreakpointSite(BreakpointSite *bp_site) {
 
   // Don't fall through when hardware breakpoints were specifically requested
   if (bp_site->HardwareRequired()) {
-    error.SetErrorString("hardware breakpoints are not supported");
+    error = Status::FromErrorString("hardware breakpoints are not supported");
     return error;
   }
 
@@ -3151,14 +3162,14 @@ Status ProcessGDBRemote::DisableBreakpointSite(BreakpointSite *bp_site) {
       if (m_gdb_comm.SendGDBStoppointTypePacket(eBreakpointHardware, false,
                                                 addr, bp_op_size,
                                                 GetInterruptTimeout()))
-        error.SetErrorToGenericError();
+        error = Status::FromErrorString("unknown error");
       break;
 
     case BreakpointSite::eExternal: {
       if (m_gdb_comm.SendGDBStoppointTypePacket(eBreakpointSoftware, false,
                                                 addr, bp_op_size,
                                                 GetInterruptTimeout()))
-        error.SetErrorToGenericError();
+        error = Status::FromErrorString("unknown error");
     } break;
     }
     if (error.Success())
@@ -3172,7 +3183,7 @@ Status ProcessGDBRemote::DisableBreakpointSite(BreakpointSite *bp_site) {
   }
 
   if (error.Success())
-    error.SetErrorToGenericError();
+    error = Status::FromErrorString("unknown error");
   return error;
 }
 
@@ -3196,7 +3207,7 @@ GetGDBStoppointType(const WatchpointResourceSP &wp_res_sp) {
 Status ProcessGDBRemote::EnableWatchpoint(WatchpointSP wp_sp, bool notify) {
   Status error;
   if (!wp_sp) {
-    error.SetErrorString("No watchpoint specified");
+    error = Status::FromErrorString("No watchpoint specified");
     return error;
   }
   user_id_t watchID = wp_sp->GetID();
@@ -3282,7 +3293,8 @@ Status ProcessGDBRemote::EnableWatchpoint(WatchpointSP wp_sp, bool notify) {
       m_gdb_comm.SendGDBStoppointTypePacket(type, false, addr, size,
                                             GetInterruptTimeout());
     }
-    error.SetErrorString("Setting one of the watchpoint resources failed");
+    error = Status::FromErrorString(
+        "Setting one of the watchpoint resources failed");
   }
   return error;
 }
@@ -3290,7 +3302,7 @@ Status ProcessGDBRemote::EnableWatchpoint(WatchpointSP wp_sp, bool notify) {
 Status ProcessGDBRemote::DisableWatchpoint(WatchpointSP wp_sp, bool notify) {
   Status error;
   if (!wp_sp) {
-    error.SetErrorString("Watchpoint argument was NULL.");
+    error = Status::FromErrorString("Watchpoint argument was NULL.");
     return error;
   }
 
@@ -3341,7 +3353,8 @@ Status ProcessGDBRemote::DisableWatchpoint(WatchpointSP wp_sp, bool notify) {
 
     wp_sp->SetEnabled(false, notify);
     if (!disabled_all)
-      error.SetErrorString("Failure disabling one of the watchpoint locations");
+      error = Status::FromErrorString(
+          "Failure disabling one of the watchpoint locations");
   }
   return error;
 }
@@ -3357,7 +3370,8 @@ Status ProcessGDBRemote::DoSignal(int signo) {
   LLDB_LOGF(log, "ProcessGDBRemote::DoSignal (signal = %d)", signo);
 
   if (!m_gdb_comm.SendAsyncSignal(signo, GetInterruptTimeout()))
-    error.SetErrorStringWithFormat("failed to send signal %i", signo);
+    error =
+        Status::FromErrorStringWithFormat("failed to send signal %i", signo);
   return error;
 }
 
@@ -3369,7 +3383,7 @@ ProcessGDBRemote::EstablishConnectionIfNeeded(const ProcessInfo &process_info) {
 
   PlatformSP platform_sp(GetTarget().GetPlatform());
   if (platform_sp && !platform_sp->IsHost())
-    return Status("Lost debug server connection");
+    return Status::FromErrorString("Lost debug server connection");
 
   auto error = LaunchAndConnectToDebugserver(process_info);
   if (error.Fail()) {
@@ -3439,7 +3453,7 @@ Status ProcessGDBRemote::LaunchAndConnectToDebugserver(
     // reasons.
     int sockets[2]; /* the pair of socket descriptors */
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == -1) {
-      error.SetErrorToErrno();
+      error = Status::FromErrno();
       return error;
     }
 
@@ -3486,7 +3500,7 @@ Status ProcessGDBRemote::LaunchAndConnectToDebugserver(
       // connecting (send NULL URL)
       error = ConnectToDebugserver("");
     } else {
-      error.SetErrorString("connection failed");
+      error = Status::FromErrorString("connection failed");
     }
   }
   return error;
@@ -3895,10 +3909,11 @@ Status ProcessGDBRemote::SendEventData(const char *data) {
   return_value = m_gdb_comm.SendLaunchEventDataPacket(data, &was_supported);
   if (return_value != 0) {
     if (!was_supported)
-      error.SetErrorString("Sending events is not supported for this process.");
+      error = Status::FromErrorString(
+          "Sending events is not supported for this process.");
     else
-      error.SetErrorStringWithFormat("Error sending event data: %d.",
-                                     return_value);
+      error = Status::FromErrorStringWithFormat("Error sending event data: %d.",
+                                                return_value);
   }
   return error;
 }
@@ -5195,7 +5210,7 @@ Status ProcessGDBRemote::GetFileLoadAddress(const FileSpec &file,
 
   std::string file_path = file.GetPath(false);
   if (file_path.empty())
-    return Status("Empty file name specified");
+    return Status::FromErrorString("Empty file name specified");
 
   StreamString packet;
   packet.PutCString("qFileLoadAddress:");
@@ -5204,7 +5219,7 @@ Status ProcessGDBRemote::GetFileLoadAddress(const FileSpec &file,
   StringExtractorGDBRemote response;
   if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response) !=
       GDBRemoteCommunication::PacketResult::Success)
-    return Status("Sending qFileLoadAddress packet failed");
+    return Status::FromErrorString("Sending qFileLoadAddress packet failed");
 
   if (response.IsErrorResponse()) {
     if (response.GetError() == 1) {
@@ -5214,7 +5229,7 @@ Status ProcessGDBRemote::GetFileLoadAddress(const FileSpec &file,
       return Status();
     }
 
-    return Status(
+    return Status::FromErrorString(
         "Fetching file load address from remote server returned an error");
   }
 
@@ -5224,7 +5239,7 @@ Status ProcessGDBRemote::GetFileLoadAddress(const FileSpec &file,
     return Status();
   }
 
-  return Status(
+  return Status::FromErrorString(
       "Unknown error happened during sending the load address packet");
 }
 

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -550,13 +550,13 @@ void ProcessMachCore::CleanupMemoryRegionPermissions() {
 Status ProcessMachCore::DoLoadCore() {
   Status error;
   if (!m_core_module_sp) {
-    error.SetErrorString("invalid core module");
+    error = Status::FromErrorString("invalid core module");
     return error;
   }
 
   ObjectFile *core_objfile = m_core_module_sp->GetObjectFile();
   if (core_objfile == nullptr) {
-    error.SetErrorString("invalid core object file");
+    error = Status::FromErrorString("invalid core object file");
     return error;
   }
 
@@ -701,7 +701,7 @@ size_t ProcessMachCore::DoReadMemory(addr_t addr, void *buf, size_t size,
       } else {
         // Only set the error if we didn't read any bytes
         if (bytes_read == 0)
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "core file does not contain 0x%" PRIx64, curr_addr);
         break;
       }

--- a/lldb/source/Plugins/Process/minidump/MinidumpTypes.h
+++ b/lldb/source/Plugins/Process/minidump/MinidumpTypes.h
@@ -48,15 +48,12 @@ enum class MinidumpMiscInfoFlags : uint32_t {
 
 template <typename T>
 Status consumeObject(llvm::ArrayRef<uint8_t> &Buffer, const T *&Object) {
-  Status error;
-  if (Buffer.size() < sizeof(T)) {
-    error.SetErrorString("Insufficient buffer!");
-    return error;
-  }
+  if (Buffer.size() < sizeof(T))
+    return Status::FromErrorString("Insufficient buffer!");
 
   Object = reinterpret_cast<const T *>(Buffer.data());
   Buffer = Buffer.drop_front(sizeof(T));
-  return error;
+  return Status();
 }
 
 struct MinidumpMemoryDescriptor64 {

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -202,8 +202,8 @@ Status ProcessMinidump::DoLoadCore() {
     // ThreadMinidump::CreateRegisterContextForFrame().
     break;
   default:
-    error.SetErrorStringWithFormat("unsupported minidump architecture: %s",
-                                   arch.GetArchitectureName());
+    error = Status::FromErrorStringWithFormat(
+        "unsupported minidump architecture: %s", arch.GetArchitectureName());
     return error;
   }
   GetTarget().SetArchitecture(arch, true /*set_platform*/);
@@ -304,7 +304,7 @@ size_t ProcessMinidump::DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
 
   llvm::ArrayRef<uint8_t> mem = m_minidump_parser->GetMemory(addr, size);
   if (mem.empty()) {
-    error.SetErrorString("could not parse memory info");
+    error = Status::FromErrorString("could not parse memory info");
     return 0;
   }
 

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
@@ -81,10 +81,8 @@ public:
   bool GetProcessInfo(ProcessInstanceInfo &info) override;
 
   Status WillResume() override {
-    Status error;
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "error: {0} does not support resuming processes", GetPluginName());
-    return error;
   }
 
   std::optional<MinidumpParser> m_minidump_parser;

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -81,8 +81,8 @@ ScriptedProcess::ScriptedProcess(lldb::TargetSP target_sp,
     : Process(target_sp, listener_sp), m_scripted_metadata(scripted_metadata) {
 
   if (!target_sp) {
-    error.SetErrorStringWithFormat("ScriptedProcess::%s () - ERROR: %s",
-                                   __FUNCTION__, "Invalid target");
+    error = Status::FromErrorStringWithFormat(
+        "ScriptedProcess::%s () - ERROR: %s", __FUNCTION__, "Invalid target");
     return;
   }
 
@@ -90,16 +90,16 @@ ScriptedProcess::ScriptedProcess(lldb::TargetSP target_sp,
       target_sp->GetDebugger().GetScriptInterpreter();
 
   if (!interpreter) {
-    error.SetErrorStringWithFormat("ScriptedProcess::%s () - ERROR: %s",
-                                   __FUNCTION__,
-                                   "Debugger has no Script Interpreter");
+    error = Status::FromErrorStringWithFormat(
+        "ScriptedProcess::%s () - ERROR: %s", __FUNCTION__,
+        "Debugger has no Script Interpreter");
     return;
   }
 
   // Create process instance interface
   m_interface_up = interpreter->CreateScriptedProcessInterface();
   if (!m_interface_up) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "ScriptedProcess::%s () - ERROR: %s", __FUNCTION__,
         "Script interpreter couldn't create Scripted Process Interface");
     return;
@@ -114,16 +114,16 @@ ScriptedProcess::ScriptedProcess(lldb::TargetSP target_sp,
 
   if (!obj_or_err) {
     llvm::consumeError(obj_or_err.takeError());
-    error.SetErrorString("Failed to create script object.");
+    error = Status::FromErrorString("Failed to create script object.");
     return;
   }
 
   StructuredData::GenericSP object_sp = *obj_or_err;
 
   if (!object_sp || !object_sp->IsValid()) {
-    error.SetErrorStringWithFormat("ScriptedProcess::%s () - ERROR: %s",
-                                   __FUNCTION__,
-                                   "Failed to create valid script object");
+    error = Status::FromErrorStringWithFormat(
+        "ScriptedProcess::%s () - ERROR: %s", __FUNCTION__,
+        "Failed to create valid script object");
     return;
   }
 }
@@ -270,7 +270,8 @@ Status ScriptedProcess::EnableBreakpointSite(BreakpointSite *bp_site) {
   }
 
   if (bp_site->HardwareRequired()) {
-    return Status("Scripted Processes don't support hardware breakpoints");
+    return Status::FromErrorString(
+        "Scripted Processes don't support hardware breakpoints");
   }
 
   Status error;

--- a/lldb/source/Plugins/REPL/Clang/ClangREPL.cpp
+++ b/lldb/source/Plugins/REPL/Clang/ClangREPL.cpp
@@ -51,7 +51,7 @@ lldb::REPLSP ClangREPL::CreateInstance(Status &error,
                                        const char *repl_options) {
   // Creating a dummy target if only a debugger is given isn't implemented yet.
   if (!target) {
-    error.SetErrorString("must have a target to create a REPL");
+    error = Status::FromErrorString("must have a target to create a REPL");
     return nullptr;
   }
   lldb::REPLSP result = std::make_shared<ClangREPL>(language, *target);

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
@@ -219,8 +219,9 @@ bool ScriptInterpreterLua::LoadScriptingModule(
     FileSpec extra_search_dir) {
 
   if (llvm::Error e = m_lua->LoadModule(filename)) {
-    error.SetErrorStringWithFormatv("lua failed to import '{0}': {1}\n",
-                                    filename, llvm::toString(std::move(e)));
+    error = Status::FromErrorStringWithFormatv(
+        "lua failed to import '{0}': {1}\n", filename,
+        llvm::toString(std::move(e)));
     return false;
   }
   return true;

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
@@ -48,7 +48,8 @@ Status ScriptedPythonInterface::ExtractValueFromPythonObject<Status>(
   if (lldb::SBError *sb_error = reinterpret_cast<lldb::SBError *>(
           python::LLDBSWIGPython_CastPyObjectToSBError(p.get())))
     return m_interpreter.GetStatusFromSBError(*sb_error);
-  error.SetErrorString("Couldn't cast lldb::SBError to lldb::Status.");
+  error =
+      Status::FromErrorString("Couldn't cast lldb::SBError to lldb::Status.");
 
   return {};
 }
@@ -59,7 +60,8 @@ Event *ScriptedPythonInterface::ExtractValueFromPythonObject<Event *>(
   if (lldb::SBEvent *sb_event = reinterpret_cast<lldb::SBEvent *>(
           python::LLDBSWIGPython_CastPyObjectToSBEvent(p.get())))
     return m_interpreter.GetOpaqueTypeFromSBEvent(*sb_event);
-  error.SetErrorString("Couldn't cast lldb::SBEvent to lldb_private::Event.");
+  error = Status::FromErrorString(
+      "Couldn't cast lldb::SBEvent to lldb_private::Event.");
 
   return nullptr;
 }
@@ -71,7 +73,8 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::StreamSP>(
   if (lldb::SBStream *sb_stream = reinterpret_cast<lldb::SBStream *>(
           python::LLDBSWIGPython_CastPyObjectToSBStream(p.get())))
     return m_interpreter.GetOpaqueTypeFromSBStream(*sb_stream);
-  error.SetErrorString("Couldn't cast lldb::SBStream to lldb_private::Stream.");
+  error = Status::FromErrorString(
+      "Couldn't cast lldb::SBStream to lldb_private::Stream.");
 
   return nullptr;
 }
@@ -84,7 +87,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::DataExtractorSP>(
       python::LLDBSWIGPython_CastPyObjectToSBData(p.get()));
 
   if (!sb_data) {
-    error.SetErrorString(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't cast lldb::SBData to lldb::DataExtractorSP.");
     return nullptr;
   }
@@ -100,7 +103,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::BreakpointSP>(
       python::LLDBSWIGPython_CastPyObjectToSBBreakpoint(p.get()));
 
   if (!sb_breakpoint) {
-    error.SetErrorString(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't cast lldb::SBBreakpoint to lldb::BreakpointSP.");
     return nullptr;
   }
@@ -115,7 +118,7 @@ lldb::ProcessAttachInfoSP ScriptedPythonInterface::ExtractValueFromPythonObject<
       python::LLDBSWIGPython_CastPyObjectToSBAttachInfo(p.get()));
 
   if (!sb_attach_info) {
-    error.SetErrorString(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't cast lldb::SBAttachInfo to lldb::ProcessAttachInfoSP.");
     return nullptr;
   }
@@ -130,7 +133,7 @@ lldb::ProcessLaunchInfoSP ScriptedPythonInterface::ExtractValueFromPythonObject<
       python::LLDBSWIGPython_CastPyObjectToSBLaunchInfo(p.get()));
 
   if (!sb_launch_info) {
-    error.SetErrorString(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't cast lldb::SBLaunchInfo to lldb::ProcessLaunchInfoSP.");
     return nullptr;
   }
@@ -148,7 +151,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<
           python::LLDBSWIGPython_CastPyObjectToSBMemoryRegionInfo(p.get()));
 
   if (!sb_mem_reg_info) {
-    error.SetErrorString(
+    error = Status::FromErrorStringWithFormat(
         "Couldn't cast lldb::SBMemoryRegionInfo to lldb::MemoryRegionInfoSP.");
     return {};
   }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -269,7 +269,7 @@ protected:
         transformed_args);
 
     if (llvm::Error e = expected_return_object.takeError()) {
-      error.SetErrorString(llvm::toString(std::move(e)).c_str());
+      error = Status(std::move(e));
       return ErrorWithMessage<T>(caller_signature,
                                  "Python method could not be called.", error);
     }
@@ -368,9 +368,8 @@ protected:
     if (boolean_arg.IsValid())
       original_arg = boolean_arg.GetValue();
     else
-      error.SetErrorString(
-          llvm::formatv("{}: Invalid boolean argument.", LLVM_PRETTY_FUNCTION)
-              .str());
+      error = Status::FromErrorStringWithFormatv(
+          "{}: Invalid boolean argument.", LLVM_PRETTY_FUNCTION);
   }
 
   template <std::size_t... I, typename... Args>

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -1247,7 +1247,8 @@ public:
     if (!bytes_written)
       return Status(bytes_written.takeError());
     if (bytes_written.get() < 0)
-      return Status(".write() method returned a negative number!");
+      return Status::FromErrorString(
+          ".write() method returned a negative number!");
     static_assert(sizeof(long long) >= sizeof(size_t), "overflow");
     num_bytes = bytes_written.get();
     return Status();
@@ -1301,7 +1302,8 @@ public:
     if (!bytes_written)
       return Status(bytes_written.takeError());
     if (bytes_written.get() < 0)
-      return Status(".write() method returned a negative number!");
+      return Status::FromErrorString(
+          ".write() method returned a negative number!");
     static_assert(sizeof(long long) >= sizeof(size_t), "overflow");
     num_bytes = bytes_written.get();
     return Status();
@@ -1313,7 +1315,8 @@ public:
     size_t orig_num_bytes = num_bytes;
     num_bytes = 0;
     if (orig_num_bytes < 6) {
-      return Status("can't read less than 6 bytes from a utf8 text stream");
+      return Status::FromErrorString(
+          "can't read less than 6 bytes from a utf8 text stream");
     }
     auto pystring = As<PythonString>(
         m_py_obj.CallMethod("read", (unsigned long long)num_chars));

--- a/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
+++ b/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
@@ -197,8 +197,8 @@ public:
     auto map = GetCreationFuncMap();
     auto find_it = map.find(operation);
     if (find_it == map.end()) {
-      error.SetErrorStringWithFormatv("unknown filter operation \"{0}\"",
-                                      operation);
+      error = Status::FromErrorStringWithFormatv(
+          "unknown filter operation \"{0}\"", operation);
       return FilterRuleSP();
     }
 
@@ -281,15 +281,15 @@ private:
                                       Status &error) {
     // We treat the op_arg as a regex.  Validate it.
     if (op_arg.empty()) {
-      error.SetErrorString("regex filter type requires a regex "
-                           "argument");
+      error = Status::FromErrorString("regex filter type requires a regex "
+                                      "argument");
       return FilterRuleSP();
     }
 
     // Instantiate the regex so we can report any errors.
     auto regex = RegularExpression(op_arg);
     if (llvm::Error err = regex.GetError()) {
-      error.SetErrorString(llvm::toString(std::move(err)));
+      error = Status(std::move(err));
       return FilterRuleSP();
     }
 
@@ -332,9 +332,9 @@ private:
                                       const std::string &op_arg,
                                       Status &error) {
     if (op_arg.empty()) {
-      error.SetErrorString("exact match filter type requires an "
-                           "argument containing the text that must "
-                           "match the specified message attribute.");
+      error = Status::FromErrorString("exact match filter type requires an "
+                                      "argument containing the text that must "
+                                      "match the specified message attribute.");
       return FilterRuleSP();
     }
 
@@ -553,7 +553,8 @@ public:
       break;
 
     default:
-      error.SetErrorStringWithFormat("unsupported option '%c'", short_option);
+      error = Status::FromErrorStringWithFormat("unsupported option '%c'",
+                                                short_option);
     }
     return error;
   }
@@ -635,7 +636,7 @@ private:
     Status error;
 
     if (rule_text.empty()) {
-      error.SetErrorString("invalid rule_text");
+      error = Status::FromErrorString("invalid rule_text");
       return error;
     }
 
@@ -662,9 +663,9 @@ private:
     // Parse action.
     auto action_end_pos = rule_text.find(' ');
     if (action_end_pos == std::string::npos) {
-      error.SetErrorStringWithFormat("could not parse filter rule "
-                                     "action from \"%s\"",
-                                     rule_text.str().c_str());
+      error = Status::FromErrorStringWithFormat("could not parse filter rule "
+                                                "action from \"%s\"",
+                                                rule_text.str().c_str());
       return error;
     }
     auto action = rule_text.substr(0, action_end_pos);
@@ -674,25 +675,27 @@ private:
     else if (action == "reject")
       accept = false;
     else {
-      error.SetErrorString("filter action must be \"accept\" or \"deny\"");
+      error = Status::FromErrorString(
+          "filter action must be \"accept\" or \"deny\"");
       return error;
     }
 
     // parse attribute
     auto attribute_end_pos = rule_text.find(" ", action_end_pos + 1);
     if (attribute_end_pos == std::string::npos) {
-      error.SetErrorStringWithFormat("could not parse filter rule "
-                                     "attribute from \"%s\"",
-                                     rule_text.str().c_str());
+      error = Status::FromErrorStringWithFormat("could not parse filter rule "
+                                                "attribute from \"%s\"",
+                                                rule_text.str().c_str());
       return error;
     }
     auto attribute = rule_text.substr(action_end_pos + 1,
                                       attribute_end_pos - (action_end_pos + 1));
     auto attribute_index = MatchAttributeIndex(attribute);
     if (attribute_index < 0) {
-      error.SetErrorStringWithFormat("filter rule attribute unknown: "
-                                     "%s",
-                                     attribute.str().c_str());
+      error =
+          Status::FromErrorStringWithFormat("filter rule attribute unknown: "
+                                            "%s",
+                                            attribute.str().c_str());
       return error;
     }
 
@@ -983,8 +986,8 @@ EnableOptionsSP ParseAutoEnableOptions(Status &error, Debugger &debugger) {
   if (!error.Success())
     return EnableOptionsSP();
   if (!options_property_sp) {
-    error.SetErrorString("failed to find option setting for "
-                         "plugin.structured-data.darwin-log.");
+    error = Status::FromErrorString("failed to find option setting for "
+                                    "plugin.structured-data.darwin-log.");
     return EnableOptionsSP();
   }
 
@@ -1111,7 +1114,7 @@ void StructuredDataDarwinLog::HandleArrivalOfStructuredData(
 static void SetErrorWithJSON(Status &error, const char *message,
                              StructuredData::Object &object) {
   if (!message) {
-    error.SetErrorString("Internal error: message not set.");
+    error = Status::FromErrorString("Internal error: message not set.");
     return;
   }
 
@@ -1119,7 +1122,8 @@ static void SetErrorWithJSON(Status &error, const char *message,
   object.Dump(object_stream);
   object_stream.Flush();
 
-  error.SetErrorStringWithFormat("%s: %s", message, object_stream.GetData());
+  error = Status::FromErrorStringWithFormat("%s: %s", message,
+                                            object_stream.GetData());
 }
 
 Status StructuredDataDarwinLog::GetDescription(
@@ -1127,7 +1131,7 @@ Status StructuredDataDarwinLog::GetDescription(
   Status error;
 
   if (!object_sp) {
-    error.SetErrorString("No structured data.");
+    error = Status::FromErrorString("No structured data.");
     return error;
   }
 
@@ -1406,7 +1410,8 @@ Status StructuredDataDarwinLog::FilterLaunchInfo(ProcessLaunchInfo &launch_info,
     // We really can't do this without a target.  We need to be able to get to
     // the debugger to get the proper options to do this right.
     // TODO log.
-    error.SetErrorString("requires a target to auto-enable DarwinLog.");
+    error =
+        Status::FromErrorString("requires a target to auto-enable DarwinLog.");
     return error;
   }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -90,18 +90,18 @@ void DWARFUnit::ExtractUnitDIEIfNeeded() {
   DWARFUnit *dwo_cu = dwo_symbol_file->GetDWOCompileUnitForHash(*m_dwo_id);
 
   if (!dwo_cu) {
-    SetDwoError(Status::createWithFormat(
+    SetDwoError(Status::FromErrorStringWithFormatv(
         "unable to load .dwo file from \"{0}\" due to ID ({1:x16}) mismatch "
         "for skeleton DIE at {2:x8}",
-        dwo_symbol_file->GetObjectFile()->GetFileSpec().GetPath().c_str(),
-        *m_dwo_id, m_first_die.GetOffset()));
+        dwo_symbol_file->GetObjectFile()->GetFileSpec().GetPath(), *m_dwo_id,
+        m_first_die.GetOffset()));
     return; // Can't fetch the compile unit from the dwo file.
   }
 
   // Link the DWO unit to this object, if it hasn't been linked already (this
   // can happen when we have an index, and the DWO unit is parsed first).
   if (!dwo_cu->LinkToSkeletonUnit(*this)) {
-    SetDwoError(Status::createWithFormat(
+    SetDwoError(Status::FromErrorStringWithFormatv(
         "multiple compile units with Dwo ID {0:x16}", *m_dwo_id));
     return;
   }
@@ -109,7 +109,7 @@ void DWARFUnit::ExtractUnitDIEIfNeeded() {
   DWARFBaseDIE dwo_cu_die = dwo_cu->GetUnitDIEOnly();
   if (!dwo_cu_die.IsValid()) {
     // Can't fetch the compile unit DIE from the dwo file.
-    SetDwoError(Status::createWithFormat(
+    SetDwoError(Status::FromErrorStringWithFormatv(
         "unable to extract compile unit DIE from .dwo file for skeleton "
         "DIE at {0:x16}",
         m_first_die.GetOffset()));

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1843,7 +1843,7 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
 
   const char *dwo_name = GetDWOName(*dwarf_cu, cu_die);
   if (!dwo_name) {
-    unit.SetDwoError(Status::createWithFormat(
+    unit.SetDwoError(Status::FromErrorStringWithFormatv(
         "missing DWO name in skeleton DIE {0:x16}", cu_die.GetOffset()));
     return nullptr;
   }
@@ -1970,7 +1970,7 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
       error_dwo_path.PrependPathComponent(comp_dir);
       FileSystem::Instance().Resolve(error_dwo_path);
     }
-    unit.SetDwoError(Status::createWithFormat(
+    unit.SetDwoError(Status::FromErrorStringWithFormatv(
         "unable to locate .dwo debug file \"{0}\" for skeleton DIE "
         "{1:x16}",
         error_dwo_path.GetPath().c_str(), cu_die.GetOffset()));
@@ -1991,7 +1991,7 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
       FileSystem::Instance().GetByteSize(dwo_file), dwo_file_data_sp,
       dwo_file_data_offset);
   if (dwo_obj_file == nullptr) {
-    unit.SetDwoError(Status::createWithFormat(
+    unit.SetDwoError(Status::FromErrorStringWithFormatv(
         "unable to load object file for .dwo debug file \"{0}\" for "
         "unit DIE {1:x16}",
         dwo_name, cu_die.GetOffset()));
@@ -4492,8 +4492,9 @@ Status SymbolFileDWARF::CalculateFrameVariableError(StackFrame &frame) {
   if (dwarf_cu->HasAny({DW_TAG_variable, DW_TAG_formal_parameter}))
     return Status();
 
-  return Status("no variable information is available in debug info for this "
-                "compile unit");
+  return Status::FromErrorString(
+      "no variable information is available in debug info for this "
+      "compile unit");
 }
 
 void SymbolFileDWARF::GetCompileOptions(

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -426,10 +426,11 @@ Module *SymbolFileDWARFDebugMap::GetModuleByCompUnitInfo(
         // modification timestamp, since it will never match.
         if (comp_unit_info->oso_mod_time != llvm::sys::TimePoint<>() &&
             oso_mod_time != comp_unit_info->oso_mod_time) {
-          comp_unit_info->oso_load_error.SetErrorStringWithFormat(
+          comp_unit_info->oso_load_error = Status::FromErrorStringWithFormat(
               "debug map object file \"%s\" changed (actual: 0x%8.8x, debug "
               "map: 0x%8.8x) since this executable was linked, debug info "
-              "will not be loaded", oso_file.GetPath().c_str(),
+              "will not be loaded",
+              oso_file.GetPath().c_str(),
               (uint32_t)llvm::sys::toTimeT(oso_mod_time),
               (uint32_t)llvm::sys::toTimeT(comp_unit_info->oso_mod_time));
           obj_file->GetModule()->ReportError(
@@ -442,7 +443,7 @@ Module *SymbolFileDWARFDebugMap::GetModuleByCompUnitInfo(
 
         if (!ObjectFile::SplitArchivePathWithObject(oso_path, oso_file,
                                                     oso_object, must_exist)) {
-          comp_unit_info->oso_load_error.SetErrorStringWithFormat(
+          comp_unit_info->oso_load_error = Status::FromErrorStringWithFormat(
               "debug map object file \"%s\" containing debug info does not "
               "exist, debug info will not be loaded",
               comp_unit_info->oso_path.GetCString());
@@ -474,7 +475,7 @@ Module *SymbolFileDWARFDebugMap::GetModuleByCompUnitInfo(
         // If we are loading a .o file from a .a file the "oso_object" will
         // have a valid value name and if the .a file exists, either the .o
         // file didn't exist in the .a file or the mod time didn't match.
-        comp_unit_info->oso_load_error.SetErrorStringWithFormat(
+        comp_unit_info->oso_load_error = Status::FromErrorStringWithFormat(
             "\"%s\" object from the \"%s\" archive: "
             "either the .o file doesn't exist in the archive or the "
             "modification time (0x%8.8x) of the .o file doesn't match",
@@ -1575,9 +1576,10 @@ Status SymbolFileDWARFDebugMap::CalculateFrameVariableError(StackFrame &frame) {
             if (comp_unit_info->oso_load_error.Fail())
               return comp_unit_info->oso_load_error;
             else
-              return Status("unable to load debug map object file \"%s\" "
-                            "exist, debug info will not be loaded",
-                            comp_unit_info->oso_path.GetCString());
+              return Status::FromErrorStringWithFormat(
+                  "unable to load debug map object file \"%s\" "
+                  "exist, debug info will not be loaded",
+                  comp_unit_info->oso_path.GetCString());
           }
         }
       }

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -812,7 +812,7 @@ static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,
         std::string errorstr = command;
         errorstr += ":\n";
         errorstr += str;
-        error.SetErrorString(errorstr);
+        error = Status(errorstr);
       }
     }
 

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
@@ -234,7 +234,8 @@ AppleGetItemInfoHandler::GetItemInfo(Thread &thread, uint64_t item,
   if (!thread.SafeToCallFunctions()) {
     LLDB_LOGF(log, "Not safe to call functions on thread 0x%" PRIx64,
               thread.GetID());
-    error.SetErrorString("Not safe to call functions on this thread.");
+    error =
+        Status::FromErrorString("Not safe to call functions on this thread.");
     return return_value;
   }
 
@@ -336,8 +337,9 @@ AppleGetItemInfoHandler::GetItemInfo(Thread &thread, uint64_t item,
   thread.CalculateExecutionContext(exe_ctx);
 
   if (!m_get_item_info_impl_code) {
-    error.SetErrorString("Unable to compile function to call "
-                         "__introspection_dispatch_queue_item_get_info");
+    error =
+        Status::FromErrorString("Unable to compile function to call "
+                                "__introspection_dispatch_queue_item_get_info");
     return return_value;
   }
 
@@ -347,8 +349,9 @@ AppleGetItemInfoHandler::GetItemInfo(Thread &thread, uint64_t item,
   if (!func_caller) {
     LLDB_LOGF(log, "Could not retrieve function caller for "
                    "__introspection_dispatch_queue_item_get_info.");
-    error.SetErrorString("Could not retrieve function caller for "
-                         "__introspection_dispatch_queue_item_get_info.");
+    error = Status::FromErrorString(
+        "Could not retrieve function caller for "
+        "__introspection_dispatch_queue_item_get_info.");
     return return_value;
   }
 
@@ -360,9 +363,10 @@ AppleGetItemInfoHandler::GetItemInfo(Thread &thread, uint64_t item,
               "__introspection_dispatch_queue_item_get_info(), got "
               "ExpressionResults %d, error contains %s",
               func_call_ret, error.AsCString(""));
-    error.SetErrorString("Unable to call "
-                         "__introspection_dispatch_queue_get_item_info() for "
-                         "list of queues");
+    error = Status::FromErrorString(
+        "Unable to call "
+        "__introspection_dispatch_queue_get_item_info() for "
+        "list of queues");
     return return_value;
   }
 

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetPendingItemsHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetPendingItemsHandler.cpp
@@ -230,7 +230,8 @@ AppleGetPendingItemsHandler::GetPendingItems(Thread &thread, addr_t queue,
   if (!thread.SafeToCallFunctions()) {
     LLDB_LOGF(log, "Not safe to call functions on thread 0x%" PRIx64,
               thread.GetID());
-    error.SetErrorString("Not safe to call functions on this thread.");
+    error =
+        Status::FromErrorString("Not safe to call functions on this thread.");
     return return_value;
   }
 
@@ -337,8 +338,9 @@ AppleGetPendingItemsHandler::GetPendingItems(Thread &thread, addr_t queue,
   thread.CalculateExecutionContext(exe_ctx);
 
   if (get_pending_items_caller == nullptr) {
-    error.SetErrorString("Unable to compile function to call "
-                         "__introspection_dispatch_queue_get_pending_items");
+    error = Status::FromErrorString(
+        "Unable to compile function to call "
+        "__introspection_dispatch_queue_get_pending_items");
     return return_value;
   }
 
@@ -352,9 +354,10 @@ AppleGetPendingItemsHandler::GetPendingItems(Thread &thread, addr_t queue,
               "__introspection_dispatch_queue_get_pending_items(), got "
               "ExpressionResults %d, error contains %s",
               func_call_ret, error.AsCString(""));
-    error.SetErrorString("Unable to call "
-                         "__introspection_dispatch_queue_get_pending_items() "
-                         "for list of queues");
+    error = Status::FromErrorString(
+        "Unable to call "
+        "__introspection_dispatch_queue_get_pending_items() "
+        "for list of queues");
     return return_value;
   }
 

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetQueuesHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetQueuesHandler.cpp
@@ -235,7 +235,8 @@ AppleGetQueuesHandler::GetCurrentQueues(Thread &thread, addr_t page_to_free,
   if (!thread.SafeToCallFunctions()) {
     LLDB_LOGF(log, "Not safe to call functions on thread 0x%" PRIx64,
               thread.GetID());
-    error.SetErrorString("Not safe to call functions on this thread.");
+    error =
+        Status::FromErrorString("Not safe to call functions on this thread.");
     return return_value;
   }
 
@@ -315,7 +316,7 @@ AppleGetQueuesHandler::GetCurrentQueues(Thread &thread, addr_t page_to_free,
   addr_t args_addr = SetupGetQueuesFunction(thread, argument_values);
 
   if (!m_get_queues_impl_code_up) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "Unable to compile __introspection_dispatch_get_queues.");
     return return_value;
   }
@@ -324,7 +325,7 @@ AppleGetQueuesHandler::GetCurrentQueues(Thread &thread, addr_t page_to_free,
       m_get_queues_impl_code_up->GetFunctionCaller();
 
   if (get_queues_caller == nullptr) {
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "Unable to get caller for call __introspection_dispatch_get_queues");
     return return_value;
   }
@@ -353,8 +354,9 @@ AppleGetQueuesHandler::GetCurrentQueues(Thread &thread, addr_t page_to_free,
               "Unable to call introspection_get_dispatch_queues(), got "
               "ExpressionResults %d, error contains %s",
               func_call_ret, error.AsCString(""));
-    error.SetErrorString("Unable to call introspection_get_dispatch_queues() "
-                         "for list of queues");
+    error = Status::FromErrorString(
+        "Unable to call introspection_get_dispatch_queues() "
+        "for list of queues");
     return return_value;
   }
 

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetThreadItemInfoHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetThreadItemInfoHandler.cpp
@@ -236,7 +236,8 @@ AppleGetThreadItemInfoHandler::GetThreadItemInfo(Thread &thread,
   if (!thread.SafeToCallFunctions()) {
     LLDB_LOGF(log, "Not safe to call functions on thread 0x%" PRIx64,
               thread.GetID());
-    error.SetErrorString("Not safe to call functions on this thread.");
+    error =
+        Status::FromErrorString("Not safe to call functions on this thread.");
     return return_value;
   }
 
@@ -338,8 +339,9 @@ AppleGetThreadItemInfoHandler::GetThreadItemInfo(Thread &thread,
   thread.CalculateExecutionContext(exe_ctx);
 
   if (!m_get_thread_item_info_impl_code) {
-    error.SetErrorString("Unable to compile function to call "
-                         "__introspection_dispatch_thread_get_item_info");
+    error = Status::FromErrorString(
+        "Unable to compile function to call "
+        "__introspection_dispatch_thread_get_item_info");
     return return_value;
   }
 
@@ -347,8 +349,9 @@ AppleGetThreadItemInfoHandler::GetThreadItemInfo(Thread &thread,
       m_get_thread_item_info_impl_code->GetFunctionCaller();
 
   if (!get_thread_item_info_caller) {
-    error.SetErrorString("Unable to compile function caller for "
-                         "__introspection_dispatch_thread_get_item_info");
+    error = Status::FromErrorString(
+        "Unable to compile function caller for "
+        "__introspection_dispatch_thread_get_item_info");
     return return_value;
   }
 
@@ -362,9 +365,10 @@ AppleGetThreadItemInfoHandler::GetThreadItemInfo(Thread &thread,
               "__introspection_dispatch_thread_get_item_info(), got "
               "ExpressionResults %d, error contains %s",
               func_call_ret, error.AsCString(""));
-    error.SetErrorString("Unable to call "
-                         "__introspection_dispatch_thread_get_item_info() for "
-                         "list of queues");
+    error = Status::FromErrorString(
+        "Unable to call "
+        "__introspection_dispatch_thread_get_item_info() for "
+        "list of queues");
     return return_value;
   }
 

--- a/lldb/source/Plugins/Trace/intel-pt/CommandObjectTraceStartIntelPT.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/CommandObjectTraceStartIntelPT.cpp
@@ -37,8 +37,8 @@ Status CommandObjectThreadTraceStartIntelPT::CommandOptions::SetOptionValue(
             ParsingUtils::ParseUserFriendlySizeExpression(option_arg))
       m_ipt_trace_size = *bytes;
     else
-      error.SetErrorStringWithFormat("invalid bytes expression for '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid bytes expression for '%s'", option_arg.str().c_str());
     break;
   }
   case 't': {
@@ -49,8 +49,8 @@ Status CommandObjectThreadTraceStartIntelPT::CommandOptions::SetOptionValue(
     int64_t psb_period;
     if (option_arg.empty() || option_arg.getAsInteger(0, psb_period) ||
         psb_period < 0)
-      error.SetErrorStringWithFormat("invalid integer value for option '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid integer value for option '%s'", option_arg.str().c_str());
     else
       m_psb_period = psb_period;
     break;
@@ -102,8 +102,8 @@ Status CommandObjectProcessTraceStartIntelPT::CommandOptions::SetOptionValue(
             ParsingUtils::ParseUserFriendlySizeExpression(option_arg))
       m_ipt_trace_size = *bytes;
     else
-      error.SetErrorStringWithFormat("invalid bytes expression for '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid bytes expression for '%s'", option_arg.str().c_str());
     break;
   }
   case 'l': {
@@ -111,8 +111,8 @@ Status CommandObjectProcessTraceStartIntelPT::CommandOptions::SetOptionValue(
             ParsingUtils::ParseUserFriendlySizeExpression(option_arg))
       m_process_buffer_size_limit = *bytes;
     else
-      error.SetErrorStringWithFormat("invalid bytes expression for '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid bytes expression for '%s'", option_arg.str().c_str());
     break;
   }
   case 't': {
@@ -131,8 +131,8 @@ Status CommandObjectProcessTraceStartIntelPT::CommandOptions::SetOptionValue(
     int64_t psb_period;
     if (option_arg.empty() || option_arg.getAsInteger(0, psb_period) ||
         psb_period < 0)
-      error.SetErrorStringWithFormat("invalid integer value for option '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "invalid integer value for option '%s'", option_arg.str().c_str());
     else
       m_psb_period = psb_period;
     break;

--- a/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.cpp
+++ b/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.cpp
@@ -39,8 +39,8 @@ Status CommandObjectThreadTraceExportCTF::CommandOptions::SetOptionValue(
     int64_t thread_index;
     if (option_arg.empty() || option_arg.getAsInteger(0, thread_index) ||
         thread_index < 0)
-      error.SetErrorStringWithFormat("invalid integer value for option '%s'",
-                                     option_arg.str().c_str());
+      error = Status::FromErrorStringWithFormatv(
+          "invalid integer value for option '{0}'", option_arg);
     else
       m_thread_index = thread_index;
     break;

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -22,7 +22,7 @@ Status SaveCoreOptions::SetPluginName(const char *name) {
   }
 
   if (!PluginManager::IsRegisteredObjectFilePluginName(name)) {
-    error.SetErrorStringWithFormat(
+    return Status::FromErrorStringWithFormat(
         "plugin name '%s' is not a valid ObjectFile plugin name", name);
     return error;
   }
@@ -57,7 +57,7 @@ Status SaveCoreOptions::SetProcess(lldb::ProcessSP process_sp) {
   }
 
   if (!process_sp->IsValid()) {
-    error.SetErrorString("Cannot assign an invalid process.");
+    error = Status::FromErrorString("Cannot assign an invalid process.");
     return error;
   }
 
@@ -73,13 +73,14 @@ Status SaveCoreOptions::SetProcess(lldb::ProcessSP process_sp) {
 Status SaveCoreOptions::AddThread(lldb::ThreadSP thread_sp) {
   Status error;
   if (!thread_sp) {
-    error.SetErrorString("invalid thread");
+    error = Status::FromErrorString("invalid thread");
     return error;
   }
 
   if (m_process_sp) {
     if (m_process_sp != thread_sp->GetProcess()) {
-      error.SetErrorString("Cannot add a thread from a different process.");
+      error = Status::FromErrorString(
+          "Cannot add a thread from a different process.");
       return error;
     }
   } else {
@@ -126,7 +127,7 @@ Status SaveCoreOptions::EnsureValidConfiguration(
                  "Options were constructed targeting a different process. \n";
 
   if (!error_str.empty())
-    error.SetErrorString(error_str);
+    error = Status(error_str);
 
   return error;
 }

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -710,13 +710,13 @@ bool SymbolContext::GetAddressRangeFromHereToEndLine(uint32_t end_line,
                                                      AddressRange &range,
                                                      Status &error) {
   if (!line_entry.IsValid()) {
-    error.SetErrorString("Symbol context has no line table.");
+    error = Status::FromErrorString("Symbol context has no line table.");
     return false;
   }
 
   range = line_entry.range;
   if (line_entry.line > end_line) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "end line option %d must be after the current line: %d", end_line,
         line_entry.line);
     return false;
@@ -740,7 +740,7 @@ bool SymbolContext::GetAddressRangeFromHereToEndLine(uint32_t end_line,
   if (!found) {
     // Can't find the index of the SymbolContext's line entry in the
     // SymbolContext's CompUnit.
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "Can't find the current line entry in the CompUnit - can't process "
         "the end-line option");
     return false;
@@ -749,7 +749,7 @@ bool SymbolContext::GetAddressRangeFromHereToEndLine(uint32_t end_line,
   line_index = comp_unit->FindLineEntry(line_index, end_line, nullptr, false,
                                         &end_entry);
   if (line_index == UINT32_MAX) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "could not find a line table entry corresponding "
         "to end line number %d",
         end_line);
@@ -759,7 +759,7 @@ bool SymbolContext::GetAddressRangeFromHereToEndLine(uint32_t end_line,
   Block *func_block = GetFunctionBlock();
   if (func_block && func_block->GetRangeIndexContainingAddress(
                         end_entry.range.GetBaseAddress()) == UINT32_MAX) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "end line number %d is not contained within the current function.",
         end_line);
     return false;
@@ -875,7 +875,7 @@ const Symbol *SymbolContext::FindBestGlobalDataSymbol(ConstString name,
         symbol->GetDescription(&ss, eDescriptionLevelFull, &target);
       }
       ss.PutChar('\n');
-      error.SetErrorString(ss.GetData());
+      error = Status::FromErrorString(ss.GetData());
       return nullptr;
     } else if (external_symbols.size()) {
       return external_symbols[0];
@@ -886,7 +886,7 @@ const Symbol *SymbolContext::FindBestGlobalDataSymbol(ConstString name,
         symbol->GetDescription(&ss, eDescriptionLevelVerbose, &target);
         ss.PutChar('\n');
       }
-      error.SetErrorString(ss.GetData());
+      error = Status::FromErrorString(ss.GetData());
       return nullptr;
     } else if (internal_symbols.size()) {
       return internal_symbols[0];

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -328,7 +328,7 @@ Status Variable::GetValuesForVariableExpressionPath(
     ValueObjectList &valobj_list) {
   Status error;
   if (!callback || variable_expr_path.empty()) {
-    error.SetErrorString("unknown error");
+    error = Status::FromErrorString("unknown error");
     return error;
   }
 
@@ -338,7 +338,7 @@ Status Variable::GetValuesForVariableExpressionPath(
         variable_expr_path.drop_front(), scope, callback, baton, variable_list,
         valobj_list);
     if (error.Fail()) {
-      error.SetErrorString("unknown error");
+      error = Status::FromErrorString("unknown error");
       return error;
     }
     for (uint32_t i = 0; i < valobj_list.GetSize();) {
@@ -372,7 +372,7 @@ Status Variable::GetValuesForVariableExpressionPath(
         }
       }
     } else {
-      error.SetErrorString("unknown error");
+      error = Status::FromErrorString("unknown error");
     }
     return error;
   } break;
@@ -383,13 +383,13 @@ Status Variable::GetValuesForVariableExpressionPath(
     llvm::SmallVector<llvm::StringRef, 2> matches;
     variable_list.Clear();
     if (!g_regex.Execute(variable_expr_path, &matches)) {
-      error.SetErrorStringWithFormatv(
+      error = Status::FromErrorStringWithFormatv(
           "unable to extract a variable name from '{0}'", variable_expr_path);
       return error;
     }
     std::string variable_name = matches[1].str();
     if (!callback(baton, variable_name.c_str(), variable_list)) {
-      error.SetErrorString("unknown error");
+      error = Status::FromErrorString("unknown error");
       return error;
     }
     uint32_t i = 0;
@@ -413,7 +413,7 @@ Status Variable::GetValuesForVariableExpressionPath(
         valobj_sp = variable_valobj_sp->GetValueForExpressionPath(
             variable_sub_expr_path);
         if (!valobj_sp) {
-          error.SetErrorStringWithFormatv(
+          error = Status::FromErrorStringWithFormatv(
               "invalid expression path '{0}' for variable '{1}'",
               variable_sub_expr_path, var_sp->GetName().GetCString());
           variable_list.RemoveVariableAtIndex(i);
@@ -434,7 +434,7 @@ Status Variable::GetValuesForVariableExpressionPath(
     }
   } break;
   }
-  error.SetErrorString("unknown error");
+  error = Status::FromErrorString("unknown error");
   return error;
 }
 

--- a/lldb/source/Target/Memory.cpp
+++ b/lldb/source/Target/Memory.cpp
@@ -164,7 +164,8 @@ size_t MemoryCache::Read(addr_t addr, void *dst, size_t dst_len,
   // by an existing invalid range. It cannot check if the argument contains
   // invalid ranges and cannot check for overlaps.
   if (m_invalid_ranges.FindEntryThatContains(addr)) {
-    error.SetErrorStringWithFormat("memory read failed for 0x%" PRIx64, addr);
+    error = Status::FromErrorStringWithFormat(
+        "memory read failed for 0x%" PRIx64, addr);
     return 0;
   }
 
@@ -240,8 +241,8 @@ size_t MemoryCache::Read(addr_t addr, void *dst, size_t dst_len,
     // will have to check the second line to see if it is in an invalid range as
     // well. See the check near the beginning of the function for more details.
     if (m_invalid_ranges.FindEntryThatContains(cache_line_base_addr)) {
-      error.SetErrorStringWithFormat("memory read failed for 0x%" PRIx64,
-                                     cache_line_base_addr);
+      error = Status::FromErrorStringWithFormat(
+          "memory read failed for 0x%" PRIx64, cache_line_base_addr);
       return dst_len - bytes_left;
     }
 

--- a/lldb/source/Target/ModuleCache.cpp
+++ b/lldb/source/Target/ModuleCache.cpp
@@ -173,8 +173,8 @@ ModuleLock::ModuleLock(const FileSpec &root_dir_spec, const UUID &uuid,
   m_lock = std::make_unique<lldb_private::LockFile>(m_file_up->GetDescriptor());
   error = m_lock->WriteLock(0, 1);
   if (error.Fail())
-    error.SetErrorStringWithFormat("Failed to lock file: %s",
-                                   error.AsCString());
+    error =
+        Status::FromErrorStringWithFormatv("Failed to lock file: {0}", error);
 }
 
 void ModuleLock::Delete() {
@@ -200,15 +200,16 @@ Status ModuleCache::Put(const FileSpec &root_dir_spec, const char *hostname,
   const auto err_code =
       llvm::sys::fs::rename(tmp_file_path, module_file_path.GetPath());
   if (err_code)
-    return Status("Failed to rename file %s to %s: %s", tmp_file_path.c_str(),
-                  module_file_path.GetPath().c_str(),
-                  err_code.message().c_str());
+    return Status::FromErrorStringWithFormat(
+        "Failed to rename file %s to %s: %s", tmp_file_path.c_str(),
+        module_file_path.GetPath().c_str(), err_code.message().c_str());
 
   const auto error = CreateHostSysRootModuleLink(
       root_dir_spec, hostname, target_file, module_file_path, true);
   if (error.Fail())
-    return Status("Failed to create link to %s: %s",
-                  module_file_path.GetPath().c_str(), error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to create link to %s: %s",
+                                             module_file_path.GetPath().c_str(),
+                                             error.AsCString());
   return Status();
 }
 
@@ -230,11 +231,12 @@ Status ModuleCache::Get(const FileSpec &root_dir_spec, const char *hostname,
       module_spec_dir, module_spec.GetFileSpec().GetFilename().AsCString());
 
   if (!FileSystem::Instance().Exists(module_file_path))
-    return Status("Module %s not found", module_file_path.GetPath().c_str());
+    return Status::FromErrorStringWithFormat(
+        "Module %s not found", module_file_path.GetPath().c_str());
   if (FileSystem::Instance().GetByteSize(module_file_path) !=
       module_spec.GetObjectSize())
-    return Status("Module %s has invalid file size",
-                  module_file_path.GetPath().c_str());
+    return Status::FromErrorStringWithFormat(
+        "Module %s has invalid file size", module_file_path.GetPath().c_str());
 
   // We may have already cached module but downloaded from an another host - in
   // this case let's create a link to it.
@@ -242,8 +244,9 @@ Status ModuleCache::Get(const FileSpec &root_dir_spec, const char *hostname,
                                            module_spec.GetFileSpec(),
                                            module_file_path, false);
   if (error.Fail())
-    return Status("Failed to create link to %s: %s",
-                  module_file_path.GetPath().c_str(), error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to create link to %s: %s",
+                                             module_file_path.GetPath().c_str(),
+                                             error.AsCString());
 
   auto cached_module_spec(module_spec);
   cached_module_spec.GetUUID().Clear(); // Clear UUID since it may contain md5
@@ -281,9 +284,9 @@ Status ModuleCache::GetAndPut(const FileSpec &root_dir_spec,
 
   ModuleLock lock(root_dir_spec, module_spec.GetUUID(), error);
   if (error.Fail())
-    return Status("Failed to lock module %s: %s",
-                  module_spec.GetUUID().GetAsString().c_str(),
-                  error.AsCString());
+    return Status::FromErrorStringWithFormat(
+        "Failed to lock module %s: %s",
+        module_spec.GetUUID().GetAsString().c_str(), error.AsCString());
 
   const auto escaped_hostname(GetEscapedHostname(hostname));
   // Check local cache for a module.
@@ -296,13 +299,15 @@ Status ModuleCache::GetAndPut(const FileSpec &root_dir_spec,
   error = module_downloader(module_spec, tmp_download_file_spec);
   llvm::FileRemover tmp_file_remover(tmp_download_file_spec.GetPath());
   if (error.Fail())
-    return Status("Failed to download module: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat("Failed to download module: %s",
+                                             error.AsCString());
 
   // Put downloaded file into local module cache.
   error = Put(root_dir_spec, escaped_hostname.c_str(), module_spec,
               tmp_download_file_spec, module_spec.GetFileSpec());
   if (error.Fail())
-    return Status("Failed to put module into cache: %s", error.AsCString());
+    return Status::FromErrorStringWithFormat(
+        "Failed to put module into cache: %s", error.AsCString());
 
   tmp_file_remover.releaseFile();
   error = Get(root_dir_spec, escaped_hostname.c_str(), module_spec,
@@ -325,8 +330,8 @@ Status ModuleCache::GetAndPut(const FileSpec &root_dir_spec,
               tmp_download_sym_file_spec,
               GetSymbolFileSpec(module_spec.GetFileSpec()));
   if (error.Fail())
-    return Status("Failed to put symbol file into cache: %s",
-                  error.AsCString());
+    return Status::FromErrorStringWithFormat(
+        "Failed to put symbol file into cache: %s", error.AsCString());
 
   tmp_symfile_remover.releaseFile();
 

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -401,9 +401,8 @@ RecurseCopy_Callback(void *baton, llvm::sys::fs::file_type ft,
     Status error = rc_baton->platform_ptr->MakeDirectory(
         dst_dir, lldb::eFilePermissionsDirectoryDefault);
     if (error.Fail()) {
-      rc_baton->error.SetErrorStringWithFormat(
-          "unable to setup directory %s on remote end",
-          dst_dir.GetPath().c_str());
+      rc_baton->error = Status::FromErrorStringWithFormatv(
+          "unable to setup directory {0} on remote end", dst_dir.GetPath());
       return FileSystem::eEnumerateDirectoryResultQuit; // got an error, bail out
     }
 
@@ -419,7 +418,7 @@ RecurseCopy_Callback(void *baton, llvm::sys::fs::file_type ft,
     FileSystem::Instance().EnumerateDirectory(src_dir_path, true, true, true,
                                               RecurseCopy_Callback, &rc_baton2);
     if (rc_baton2.error.Fail()) {
-      rc_baton->error.SetErrorString(rc_baton2.error.AsCString());
+      rc_baton->error = Status::FromErrorString(rc_baton2.error.AsCString());
       return FileSystem::eEnumerateDirectoryResultQuit; // got an error, bail out
     }
     return FileSystem::eEnumerateDirectoryResultNext;
@@ -454,14 +453,14 @@ RecurseCopy_Callback(void *baton, llvm::sys::fs::file_type ft,
       dst_file.SetFilename(src.GetFilename());
     Status err = rc_baton->platform_ptr->PutFile(src, dst_file);
     if (err.Fail()) {
-      rc_baton->error.SetErrorString(err.AsCString());
+      rc_baton->error = Status::FromErrorString(err.AsCString());
       return FileSystem::eEnumerateDirectoryResultQuit; // got an error, bail out
     }
     return FileSystem::eEnumerateDirectoryResultNext;
   } break;
 
   default:
-    rc_baton->error.SetErrorStringWithFormat(
+    rc_baton->error = Status::FromErrorStringWithFormat(
         "invalid file detected during copy: %s", src.GetPath().c_str());
     return FileSystem::eEnumerateDirectoryResultQuit; // got an error, bail out
     break;
@@ -499,7 +498,7 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
           relative_spec.AppendPathComponent(dst.GetPath());
           fixed_dst.SetDirectory(relative_spec.GetDirectory());
         } else {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "platform working directory must be valid for relative path '%s'",
               dst.GetPath().c_str());
           return error;
@@ -509,7 +508,7 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
       if (working_dir) {
         fixed_dst.SetDirectory(working_dir.GetPathAsConstString());
       } else {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "platform working directory must be valid for relative path '%s'",
             dst.GetPath().c_str());
         return error;
@@ -519,8 +518,9 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
     if (working_dir) {
       fixed_dst.SetDirectory(working_dir.GetPathAsConstString());
     } else {
-      error.SetErrorStringWithFormat("platform working directory must be valid "
-                                     "when destination directory is empty");
+      error =
+          Status::FromErrorString("platform working directory must be valid "
+                                  "when destination directory is empty");
       return error;
     }
   }
@@ -566,13 +566,14 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
         error = CreateSymlink(dst, src_resolved);
     } break;
     case fs::file_type::fifo_file:
-      error.SetErrorString("platform install doesn't handle pipes");
+      error = Status::FromErrorString("platform install doesn't handle pipes");
       break;
     case fs::file_type::socket_file:
-      error.SetErrorString("platform install doesn't handle sockets");
+      error =
+          Status::FromErrorString("platform install doesn't handle sockets");
       break;
     default:
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "platform install doesn't handle non file or directory items");
       break;
     }
@@ -601,8 +602,9 @@ Status Platform::MakeDirectory(const FileSpec &file_spec,
     return llvm::sys::fs::create_directory(file_spec.GetPath(), permissions);
   else {
     Status error;
-    error.SetErrorStringWithFormatv("remote platform {0} doesn't support {1}",
-                                    GetPluginName(), LLVM_PRETTY_FUNCTION);
+    return Status::FromErrorStringWithFormatv(
+        "remote platform {0} doesn't support {1}", GetPluginName(),
+        LLVM_PRETTY_FUNCTION);
     return error;
   }
 }
@@ -616,8 +618,9 @@ Status Platform::GetFilePermissions(const FileSpec &file_spec,
     return Status(Value.getError());
   } else {
     Status error;
-    error.SetErrorStringWithFormatv("remote platform {0} doesn't support {1}",
-                                    GetPluginName(), LLVM_PRETTY_FUNCTION);
+    return Status::FromErrorStringWithFormatv(
+        "remote platform {0} doesn't support {1}", GetPluginName(),
+        LLVM_PRETTY_FUNCTION);
     return error;
   }
 }
@@ -629,8 +632,9 @@ Status Platform::SetFilePermissions(const FileSpec &file_spec,
     return llvm::sys::fs::setPermissions(file_spec.GetPath(), Perms);
   } else {
     Status error;
-    error.SetErrorStringWithFormatv("remote platform {0} doesn't support {1}",
-                                    GetPluginName(), LLVM_PRETTY_FUNCTION);
+    return Status::FromErrorStringWithFormatv(
+        "remote platform {0} doesn't support {1}", GetPluginName(),
+        LLVM_PRETTY_FUNCTION);
     return error;
   }
 }
@@ -663,7 +667,7 @@ uint64_t Platform::ReadFile(lldb::user_id_t fd, uint64_t offset, void *dst,
                             uint64_t dst_len, Status &error) {
   if (IsHost())
     return FileCache::GetInstance().ReadFile(fd, offset, dst, dst_len, error);
-  error.SetErrorStringWithFormatv(
+  error = Status::FromErrorStringWithFormatv(
       "Platform::ReadFile() is not supported in the {0} platform",
       GetPluginName());
   return -1;
@@ -673,7 +677,7 @@ uint64_t Platform::WriteFile(lldb::user_id_t fd, uint64_t offset,
                              const void *src, uint64_t src_len, Status &error) {
   if (IsHost())
     return FileCache::GetInstance().WriteFile(fd, offset, src, src_len, error);
-  error.SetErrorStringWithFormatv(
+  error = Status::FromErrorStringWithFormatv(
       "Platform::WriteFile() is not supported in the {0} platform",
       GetPluginName());
   return -1;
@@ -742,8 +746,8 @@ Platform::ResolveExecutable(const ModuleSpec &module_spec,
 
   if (!FileSystem::Instance().Exists(resolved_module_spec.GetFileSpec()) &&
       !module_spec.GetUUID().IsValid())
-    return Status::createWithFormat("'{0}' does not exist",
-                                    resolved_module_spec.GetFileSpec());
+    return Status::FromErrorStringWithFormatv(
+        "'{0}' does not exist", resolved_module_spec.GetFileSpec());
 
   if (resolved_module_spec.GetArchitecture().IsValid() ||
       resolved_module_spec.GetUUID().IsValid()) {
@@ -770,7 +774,7 @@ Platform::ResolveExecutable(const ModuleSpec &module_spec,
     if (error.Success()) {
       if (exe_module_sp && exe_module_sp->GetObjectFile())
         break;
-      error.SetErrorToGenericError();
+      error = Status::FromErrorString("no exe object file");
     }
 
     arch_names << LS << arch.GetArchitectureName();
@@ -780,14 +784,14 @@ Platform::ResolveExecutable(const ModuleSpec &module_spec,
     return {};
 
   if (!FileSystem::Instance().Readable(resolved_module_spec.GetFileSpec()))
-    return Status::createWithFormat("'{0}' is not readable",
-                                    resolved_module_spec.GetFileSpec());
+    return Status::FromErrorStringWithFormatv(
+        "'{0}' is not readable", resolved_module_spec.GetFileSpec());
 
   if (!ObjectFile::IsObjectFile(resolved_module_spec.GetFileSpec()))
-    return Status::createWithFormat("'{0}' is not a valid executable",
-                                    resolved_module_spec.GetFileSpec());
+    return Status::FromErrorStringWithFormatv(
+        "'{0}' is not a valid executable", resolved_module_spec.GetFileSpec());
 
-  return Status::createWithFormat(
+  return Status::FromErrorStringWithFormatv(
       "'{0}' doesn't contain any '{1}' platform architectures: {2}",
       resolved_module_spec.GetFileSpec(), GetPluginName(),
       arch_names.GetData());
@@ -799,7 +803,7 @@ Status Platform::ResolveSymbolFile(Target &target, const ModuleSpec &sym_spec,
   if (FileSystem::Instance().Exists(sym_spec.GetSymbolFileSpec()))
     sym_file = sym_spec.GetSymbolFileSpec();
   else
-    error.SetErrorString("unable to resolve symbol file");
+    error = Status::FromErrorString("unable to resolve symbol file");
   return error;
 }
 
@@ -876,12 +880,12 @@ ArchSpec Platform::GetAugmentedArchSpec(llvm::StringRef triple) {
 Status Platform::ConnectRemote(Args &args) {
   Status error;
   if (IsHost())
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "The currently selected platform ({0}) is "
         "the host platform and is always connected.",
         GetPluginName());
   else
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "Platform::ConnectRemote() is not supported by {0}", GetPluginName());
   return error;
 }
@@ -889,12 +893,12 @@ Status Platform::ConnectRemote(Args &args) {
 Status Platform::DisconnectRemote() {
   Status error;
   if (IsHost())
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "The currently selected platform ({0}) is "
         "the host platform and is always connected.",
         GetPluginName());
   else
-    error.SetErrorStringWithFormatv(
+    return Status::FromErrorStringWithFormatv(
         "Platform::DisconnectRemote() is not supported by {0}",
         GetPluginName());
   return error;
@@ -957,10 +961,11 @@ Status Platform::LaunchProcess(ProcessLaunchInfo &launch_info) {
     } else if (launch_info.GetFlags().Test(eLaunchFlagShellExpandArguments)) {
       error = ShellExpandArguments(launch_info);
       if (error.Fail()) {
-        error.SetErrorStringWithFormat("shell expansion failed (reason: %s). "
-                                       "consider launching with 'process "
-                                       "launch'.",
-                                       error.AsCString("unknown"));
+        error = Status::FromErrorStringWithFormat(
+            "shell expansion failed (reason: %s). "
+            "consider launching with 'process "
+            "launch'.",
+            error.AsCString("unknown"));
         return error;
       }
     }
@@ -970,7 +975,7 @@ Status Platform::LaunchProcess(ProcessLaunchInfo &launch_info) {
 
     error = Host::LaunchProcess(launch_info);
   } else
-    error.SetErrorString(
+    error = Status::FromErrorString(
         "base lldb_private::Platform class can't launch remote processes");
   return error;
 }
@@ -978,7 +983,8 @@ Status Platform::LaunchProcess(ProcessLaunchInfo &launch_info) {
 Status Platform::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
   if (IsHost())
     return Host::ShellExpandArguments(launch_info);
-  return Status("base lldb_private::Platform class can't expand arguments");
+  return Status::FromErrorString(
+      "base lldb_private::Platform class can't expand arguments");
 }
 
 Status Platform::KillProcess(const lldb::pid_t pid) {
@@ -986,7 +992,7 @@ Status Platform::KillProcess(const lldb::pid_t pid) {
   LLDB_LOGF(log, "Platform::%s, pid %" PRIu64, __FUNCTION__, pid);
 
   if (!IsHost()) {
-    return Status(
+    return Status::FromErrorString(
         "base lldb_private::Platform class can't kill remote processes");
   }
   Host::Kill(pid, SIGKILL);
@@ -1166,7 +1172,7 @@ Status Platform::PutFile(const FileSpec &source, const FileSpec &destination,
   if (error.Fail())
     return error;
   if (dest_file == UINT64_MAX)
-    return Status("unable to open target file");
+    return Status::FromErrorString("unable to open target file");
   lldb::WritableDataBufferSP buffer_sp(new DataBufferHeap(1024 * 16, 0));
   uint64_t offset = 0;
   for (;;) {
@@ -1198,8 +1204,7 @@ Status Platform::PutFile(const FileSpec &source, const FileSpec &destination,
 }
 
 Status Platform::GetFile(const FileSpec &source, const FileSpec &destination) {
-  Status error("unimplemented");
-  return error;
+  return Status::FromErrorString("unimplemented");
 }
 
 Status
@@ -1208,7 +1213,7 @@ Platform::CreateSymlink(const FileSpec &src, // The name of the link is in src
 {
   if (IsHost())
     return FileSystem::Instance().Symlink(src, dst);
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 bool Platform::GetFileExists(const lldb_private::FileSpec &file_spec) {
@@ -1220,7 +1225,7 @@ bool Platform::GetFileExists(const lldb_private::FileSpec &file_spec) {
 Status Platform::Unlink(const FileSpec &path) {
   if (IsHost())
     return llvm::sys::fs::remove(path.GetPath());
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 MmapArgList Platform::GetMmapArgumentList(const ArchSpec &arch, addr_t addr,
@@ -1266,7 +1271,8 @@ lldb_private::Status Platform::RunShellCommand(
   if (IsHost())
     return Host::RunShellCommand(shell, command, working_dir, status_ptr,
                                  signo_ptr, command_output, timeout);
-  return Status("unable to run a remote command without a platform");
+  return Status::FromErrorString(
+      "unable to run a remote command without a platform");
 }
 
 llvm::ErrorOr<llvm::MD5::MD5Result>
@@ -1349,7 +1355,8 @@ OptionGroupPlatformRSync::SetOptionValue(uint32_t option_idx,
     break;
 
   default:
-    error.SetErrorStringWithFormat("unrecognized option '%c'", short_option);
+    error = Status::FromErrorStringWithFormat("unrecognized option '%c'",
+                                              short_option);
     break;
   }
 
@@ -1387,7 +1394,8 @@ OptionGroupPlatformSSH::SetOptionValue(uint32_t option_idx,
     break;
 
   default:
-    error.SetErrorStringWithFormat("unrecognized option '%c'", short_option);
+    error = Status::FromErrorStringWithFormat("unrecognized option '%c'",
+                                              short_option);
     break;
   }
 
@@ -1414,7 +1422,8 @@ lldb_private::Status OptionGroupPlatformCaching::SetOptionValue(
     break;
 
   default:
-    error.SetErrorStringWithFormat("unrecognized option '%c'", short_option);
+    error = Status::FromErrorStringWithFormat("unrecognized option '%c'",
+                                              short_option);
     break;
   }
 
@@ -1577,7 +1586,8 @@ Status Platform::GetRemoteSharedModule(const ModuleSpec &module_spec,
     return Status();
   }
 
-  return Status("Failed to call GetCachedSharedModule");
+  return Status::FromErrorStringWithFormat(
+      "Failed to call GetCachedSharedModule");
 }
 
 void Platform::CallLocateModuleCallbackIfSet(const ModuleSpec &module_spec,
@@ -1728,8 +1738,8 @@ Status Platform::DownloadModuleSlice(const FileSpec &src_file_spec,
   std::error_code EC;
   llvm::raw_fd_ostream dst(dst_file_spec.GetPath(), EC, llvm::sys::fs::OF_None);
   if (EC) {
-    error.SetErrorStringWithFormat("unable to open destination file: %s",
-                                   dst_file_spec.GetPath().c_str());
+    error = Status::FromErrorStringWithFormat(
+        "unable to open destination file: %s", dst_file_spec.GetPath().c_str());
     return error;
   }
 
@@ -1737,8 +1747,8 @@ Status Platform::DownloadModuleSlice(const FileSpec &src_file_spec,
                          lldb::eFilePermissionsFileDefault, error);
 
   if (error.Fail()) {
-    error.SetErrorStringWithFormat("unable to open source file: %s",
-                                   error.AsCString());
+    error = Status::FromErrorStringWithFormat("unable to open source file: %s",
+                                              error.AsCString());
     return error;
   }
 
@@ -1753,7 +1763,7 @@ Status Platform::DownloadModuleSlice(const FileSpec &src_file_spec,
     if (error.Fail())
       break;
     if (n_read == 0) {
-      error.SetErrorString("read 0 bytes");
+      error = Status::FromErrorString("read 0 bytes");
       break;
     }
     offset += n_read;
@@ -1769,7 +1779,7 @@ Status Platform::DownloadModuleSlice(const FileSpec &src_file_spec,
 
 Status Platform::DownloadSymbolFile(const lldb::ModuleSP &module_sp,
                                     const FileSpec &dst_file_spec) {
-  return Status(
+  return Status::FromErrorString(
       "Symbol file downloading not supported by the default platform.");
 }
 
@@ -1825,7 +1835,8 @@ uint32_t Platform::LoadImage(lldb_private::Process *process,
     return DoLoadImage(process, remote_file, nullptr, error);
   }
 
-  error.SetErrorString("Neither local nor remote file was specified");
+  error =
+      Status::FromErrorString("Neither local nor remote file was specified");
   return LLDB_INVALID_IMAGE_TOKEN;
 }
 
@@ -1834,7 +1845,8 @@ uint32_t Platform::DoLoadImage(lldb_private::Process *process,
                                const std::vector<std::string> *paths,
                                lldb_private::Status &error,
                                lldb_private::FileSpec *loaded_image) {
-  error.SetErrorString("LoadImage is not supported on the current platform");
+  error = Status::FromErrorString(
+      "LoadImage is not supported on the current platform");
   return LLDB_INVALID_IMAGE_TOKEN;
 }
 
@@ -1857,7 +1869,8 @@ uint32_t Platform::LoadImageUsingPaths(lldb_private::Process *process,
 
 Status Platform::UnloadImage(lldb_private::Process *process,
                              uint32_t image_token) {
-  return Status("UnloadImage is not supported on the current platform");
+  return Status::FromErrorString(
+      "UnloadImage is not supported on the current platform");
 }
 
 lldb::ProcessSP Platform::ConnectProcess(llvm::StringRef connect_url,

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1383,10 +1383,10 @@ Status Process::Resume() {
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
   LLDB_LOGF(log, "(plugin = %s) -- locking run lock", GetPluginName().data());
   if (!m_public_run_lock.TrySetRunning()) {
-    Status error("Resume request failed - process still running.");
     LLDB_LOGF(log, "(plugin = %s) -- TrySetRunning failed, not resuming.",
              GetPluginName().data());
-    return error;
+    return Status::FromErrorString(
+        "Resume request failed - process still running.");
   }
   Status error = PrivateResume();
   if (!error.Success()) {
@@ -1400,9 +1400,9 @@ Status Process::ResumeSynchronous(Stream *stream) {
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
   LLDB_LOGF(log, "Process::ResumeSynchronous -- locking run lock");
   if (!m_public_run_lock.TrySetRunning()) {
-    Status error("Resume request failed - process still running.");
     LLDB_LOGF(log, "Process::Resume: -- TrySetRunning failed, not resuming.");
-    return error;
+    return Status::FromErrorString(
+        "Resume request failed - process still running.");
   }
 
   ListenerSP listener_sp(
@@ -1417,7 +1417,7 @@ Status Process::ResumeSynchronous(Stream *stream) {
     const bool must_be_alive =
         false; // eStateExited is ok, so this must be false
     if (!StateIsStoppedState(state, must_be_alive))
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "process not in stopped state after synchronous resume: %s",
           StateAsCString(state));
   } else {
@@ -1639,8 +1639,8 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
     if (bp_site_sp->IsEnabled())
       error = DisableBreakpointSite(bp_site_sp.get());
   } else {
-    error.SetErrorStringWithFormat("invalid breakpoint site ID: %" PRIu64,
-                                   break_id);
+    error = Status::FromErrorStringWithFormat(
+        "invalid breakpoint site ID: %" PRIu64, break_id);
   }
 
   return error;
@@ -1653,8 +1653,8 @@ Status Process::EnableBreakpointSiteByID(lldb::user_id_t break_id) {
     if (!bp_site_sp->IsEnabled())
       error = EnableBreakpointSite(bp_site_sp.get());
   } else {
-    error.SetErrorStringWithFormat("invalid breakpoint site ID: %" PRIu64,
-                                   break_id);
+    error = Status::FromErrorStringWithFormat(
+        "invalid breakpoint site ID: %" PRIu64, break_id);
   }
   return error;
 }
@@ -1818,7 +1818,8 @@ Status Process::EnableSoftwareBreakpoint(BreakpointSite *bp_site) {
   }
 
   if (bp_addr == LLDB_INVALID_ADDRESS) {
-    error.SetErrorString("BreakpointSite contains an invalid load address.");
+    error = Status::FromErrorString(
+        "BreakpointSite contains an invalid load address.");
     return error;
   }
   // Ask the lldb::Process subclass to fill in the correct software breakpoint
@@ -1826,15 +1827,16 @@ Status Process::EnableSoftwareBreakpoint(BreakpointSite *bp_site) {
   const size_t bp_opcode_size = GetSoftwareBreakpointTrapOpcode(bp_site);
 
   if (bp_opcode_size == 0) {
-    error.SetErrorStringWithFormat("Process::GetSoftwareBreakpointTrapOpcode() "
-                                   "returned zero, unable to get breakpoint "
-                                   "trap for address 0x%" PRIx64,
-                                   bp_addr);
+    error = Status::FromErrorStringWithFormat(
+        "Process::GetSoftwareBreakpointTrapOpcode() "
+        "returned zero, unable to get breakpoint "
+        "trap for address 0x%" PRIx64,
+        bp_addr);
   } else {
     const uint8_t *const bp_opcode_bytes = bp_site->GetTrapOpcodeBytes();
 
     if (bp_opcode_bytes == nullptr) {
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "BreakpointSite doesn't contain a valid breakpoint trap opcode.");
       return error;
     }
@@ -1857,15 +1859,17 @@ Status Process::EnableSoftwareBreakpoint(BreakpointSite *bp_site) {
                       "addr = 0x%" PRIx64 " -- SUCCESS",
                       bp_site->GetID(), (uint64_t)bp_addr);
           } else
-            error.SetErrorString(
+            error = Status::FromErrorString(
                 "failed to verify the breakpoint trap in memory.");
         } else
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "Unable to read memory to verify breakpoint trap.");
       } else
-        error.SetErrorString("Unable to write breakpoint trap to memory.");
+        error = Status::FromErrorString(
+            "Unable to write breakpoint trap to memory.");
     } else
-      error.SetErrorString("Unable to read memory at breakpoint address.");
+      error = Status::FromErrorString(
+          "Unable to read memory at breakpoint address.");
   }
   if (log && error.Fail())
     LLDB_LOGF(
@@ -1888,7 +1892,8 @@ Status Process::DisableSoftwareBreakpoint(BreakpointSite *bp_site) {
             breakID, (uint64_t)bp_addr);
 
   if (bp_site->IsHardware()) {
-    error.SetErrorString("Breakpoint site is a hardware breakpoint.");
+    error =
+        Status::FromErrorString("Breakpoint site is a hardware breakpoint.");
   } else if (bp_site->IsEnabled()) {
     const size_t break_op_size = bp_site->GetByteSize();
     const uint8_t *const break_op = bp_site->GetTrapOpcodeBytes();
@@ -1911,10 +1916,10 @@ Status Process::DisableSoftwareBreakpoint(BreakpointSite *bp_site) {
                             break_op_size, error) == break_op_size) {
             verify = true;
           } else
-            error.SetErrorString(
+            error = Status::FromErrorString(
                 "Memory write failed when restoring original opcode.");
         } else {
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "Original breakpoint trap is no longer in memory.");
           // Set verify to true and so we can check if the original opcode has
           // already been restored
@@ -1939,14 +1944,16 @@ Status Process::DisableSoftwareBreakpoint(BreakpointSite *bp_site) {
               return error;
             } else {
               if (break_op_found)
-                error.SetErrorString("Failed to restore original opcode.");
+                error = Status::FromErrorString(
+                    "Failed to restore original opcode.");
             }
           } else
-            error.SetErrorString("Failed to read memory to verify that "
-                                 "breakpoint trap was restored.");
+            error =
+                Status::FromErrorString("Failed to read memory to verify that "
+                                        "breakpoint trap was restored.");
         }
       } else
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "Unable to read memory that should contain the breakpoint trap.");
     }
   } else {
@@ -2051,23 +2058,23 @@ AddressRanges Process::FindRangesInMemory(const uint8_t *buf, uint64_t size,
                                           Status &error) {
   AddressRanges matches;
   if (buf == nullptr) {
-    error.SetErrorString("buffer is null");
+    error = Status::FromErrorString("buffer is null");
     return matches;
   }
   if (size == 0) {
-    error.SetErrorString("buffer size is zero");
+    error = Status::FromErrorString("buffer size is zero");
     return matches;
   }
   if (ranges.empty()) {
-    error.SetErrorString("empty ranges");
+    error = Status::FromErrorString("empty ranges");
     return matches;
   }
   if (alignment == 0) {
-    error.SetErrorString("alignment must be greater than zero");
+    error = Status::FromErrorString("alignment must be greater than zero");
     return matches;
   }
   if (max_matches == 0) {
-    error.SetErrorString("max_matches must be greater than zero");
+    error = Status::FromErrorString("max_matches must be greater than zero");
     return matches;
   }
 
@@ -2094,7 +2101,7 @@ AddressRanges Process::FindRangesInMemory(const uint8_t *buf, uint64_t size,
   if (resolved_ranges > 0)
     error.Clear();
   else
-    error.SetErrorString("unable to resolve any ranges");
+    error = Status::FromErrorString("unable to resolve any ranges");
 
   return matches;
 }
@@ -2103,19 +2110,19 @@ lldb::addr_t Process::FindInMemory(const uint8_t *buf, uint64_t size,
                                    const AddressRange &range, size_t alignment,
                                    Status &error) {
   if (buf == nullptr) {
-    error.SetErrorString("buffer is null");
+    error = Status::FromErrorString("buffer is null");
     return LLDB_INVALID_ADDRESS;
   }
   if (size == 0) {
-    error.SetErrorString("buffer size is zero");
+    error = Status::FromErrorString("buffer size is zero");
     return LLDB_INVALID_ADDRESS;
   }
   if (!range.IsValid()) {
-    error.SetErrorString("range is invalid");
+    error = Status::FromErrorString("range is invalid");
     return LLDB_INVALID_ADDRESS;
   }
   if (alignment == 0) {
-    error.SetErrorString("alignment must be greater than zero");
+    error = Status::FromErrorString("alignment must be greater than zero");
     return LLDB_INVALID_ADDRESS;
   }
 
@@ -2123,7 +2130,7 @@ lldb::addr_t Process::FindInMemory(const uint8_t *buf, uint64_t size,
   const lldb::addr_t start_addr =
       range.GetBaseAddress().GetLoadAddress(&target);
   if (start_addr == LLDB_INVALID_ADDRESS) {
-    error.SetErrorString("range load address is invalid");
+    error = Status::FromErrorString("range load address is invalid");
     return LLDB_INVALID_ADDRESS;
   }
   const lldb::addr_t end_addr = start_addr + range.GetByteSize();
@@ -2198,7 +2205,7 @@ size_t Process::ReadCStringFromMemory(addr_t addr, char *dst,
     }
   } else {
     if (dst == nullptr)
-      result_error.SetErrorString("invalid arguments");
+      result_error = Status::FromErrorString("invalid arguments");
     else
       result_error.Clear();
   }
@@ -2355,7 +2362,7 @@ size_t Process::WriteMemory(addr_t addr, const void *buf, size_t size,
         // done looping and will return the number of bytes that we have
         // written so far.
         if (error.Success())
-          error.SetErrorToGenericError();
+          error = Status::FromErrorString("could not write all bytes");
       }
     }
     // Now write any bytes that would cover up any software breakpoints
@@ -2385,9 +2392,9 @@ size_t Process::WriteScalarToMemory(addr_t addr, const Scalar &scalar,
     if (mem_size > 0)
       return WriteMemory(addr, buf, mem_size, error);
     else
-      error.SetErrorString("failed to get scalar as memory data");
+      error = Status::FromErrorString("failed to get scalar as memory data");
   } else {
-    error.SetErrorString("invalid scalar value");
+    error = Status::FromErrorString("invalid scalar value");
   }
   return 0;
 }
@@ -2397,10 +2404,10 @@ size_t Process::ReadScalarIntegerFromMemory(addr_t addr, uint32_t byte_size,
                                             Status &error) {
   uint64_t uval = 0;
   if (byte_size == 0) {
-    error.SetErrorString("byte size is zero");
+    error = Status::FromErrorString("byte size is zero");
   } else if (byte_size & (byte_size - 1)) {
-    error.SetErrorStringWithFormat("byte size %u is not a power of 2",
-                                   byte_size);
+    error = Status::FromErrorStringWithFormat(
+        "byte size %u is not a power of 2", byte_size);
   } else if (byte_size <= sizeof(uval)) {
     const size_t bytes_read = ReadMemory(addr, &uval, byte_size, error);
     if (bytes_read == byte_size) {
@@ -2416,7 +2423,7 @@ size_t Process::ReadScalarIntegerFromMemory(addr_t addr, uint32_t byte_size,
       return bytes_read;
     }
   } else {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "byte size of %u is too large for integer scalar type", byte_size);
   }
   return 0;
@@ -2437,7 +2444,8 @@ Status Process::WriteObjectFile(std::vector<ObjectFile::LoadableData> entries) {
 addr_t Process::AllocateMemory(size_t size, uint32_t permissions,
                                Status &error) {
   if (GetPrivateState() != eStateStopped) {
-    error.SetErrorToGenericError();
+    error = Status::FromErrorString(
+        "cannot allocate memory while process is running");
     return LLDB_INVALID_ADDRESS;
   }
 
@@ -2509,7 +2517,7 @@ Status Process::DeallocateMemory(addr_t ptr) {
   Status error;
 #if defined(USE_ALLOCATE_MEMORY_CACHE)
   if (!m_allocated_memory_cache.DeallocateMemory(ptr)) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "deallocation of memory at 0x%" PRIx64 " failed.", (uint64_t)ptr);
   }
 #else
@@ -2588,13 +2596,13 @@ bool Process::GetLoadAddressPermissions(lldb::addr_t load_addr,
 
 Status Process::EnableWatchpoint(WatchpointSP wp_sp, bool notify) {
   Status error;
-  error.SetErrorString("watchpoints are not supported");
+  error = Status::FromErrorString("watchpoints are not supported");
   return error;
 }
 
 Status Process::DisableWatchpoint(WatchpointSP wp_sp, bool notify) {
   Status error;
-  error.SetErrorString("watchpoints are not supported");
+  error = Status::FromErrorString("watchpoints are not supported");
   return error;
 }
 
@@ -2687,7 +2695,7 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
   FileSpec exe_spec_to_use;
   if (!exe_module) {
     if (!launch_info.GetExecutableFile() && !launch_info.IsScriptedProcess()) {
-      error.SetErrorString("executable module does not exist");
+      error = Status::FromErrorString("executable module does not exist");
       return error;
     }
     exe_spec_to_use = launch_info.GetExecutableFile();
@@ -2714,7 +2722,8 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
   error = WillLaunch(exe_module);
   if (error.Fail()) {
     std::string local_exec_file_path = exe_spec_to_use.GetPath();
-    return Status("file doesn't exist: '%s'", local_exec_file_path.c_str());
+    return Status::FromErrorStringWithFormat("file doesn't exist: '%s'",
+                                             local_exec_file_path.c_str());
   }
 
   const bool restarted = false;
@@ -2726,7 +2735,7 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
     error = DoLaunch(exe_module, launch_info);
   } else {
     // This shouldn't happen
-    error.SetErrorString("failed to acquire process run lock");
+    error = Status::FromErrorString("failed to acquire process run lock");
   }
 
   if (error.Fail()) {
@@ -2747,7 +2756,7 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
   if (state == eStateInvalid || !event_sp) {
     // We were able to launch the process, but we failed to catch the
     // initial stop.
-    error.SetErrorString("failed to catch stop after launch");
+    error = Status::FromErrorString("failed to catch stop after launch");
     SetExitStatus(0, error.AsCString());
     Destroy(false);
     return error;
@@ -2789,11 +2798,12 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
     return Status();
   }
 
-  return Status("Unexpected process state after the launch: %s, expected %s, "
-                "%s, %s or %s",
-                StateAsCString(state), StateAsCString(eStateInvalid),
-                StateAsCString(eStateExited), StateAsCString(eStateStopped),
-                StateAsCString(eStateCrashed));
+  return Status::FromErrorStringWithFormat(
+      "Unexpected process state after the launch: %s, expected %s, "
+      "%s, %s or %s",
+      StateAsCString(state), StateAsCString(eStateInvalid),
+      StateAsCString(eStateExited), StateAsCString(eStateStopped),
+      StateAsCString(eStateCrashed));
 }
 
 Status Process::LoadCore() {
@@ -2835,7 +2845,7 @@ Status Process::LoadCore() {
       Log *log = GetLog(LLDBLog::Process);
       LLDB_LOGF(log, "Process::Halt() failed to stop, state is: %s",
                 StateAsCString(state));
-      error.SetErrorString(
+      error = Status::FromErrorString(
           "Did not get stopped event after loading the core file.");
     }
     RestoreProcessEvents();
@@ -3000,14 +3010,15 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
             error = DoAttachToProcessWithName(process_name, attach_info);
           } else {
             // This shouldn't happen
-            error.SetErrorString("failed to acquire process run lock");
+            error =
+                Status::FromErrorString("failed to acquire process run lock");
           }
 
           if (error.Fail()) {
             if (GetID() != LLDB_INVALID_PROCESS_ID) {
               SetID(LLDB_INVALID_PROCESS_ID);
               if (error.AsCString() == nullptr)
-                error.SetErrorString("attach failed");
+                error = Status::FromErrorString("attach failed");
 
               SetExitStatus(-1, error.AsCString());
             }
@@ -3041,21 +3052,21 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
                 process_infos[i].DumpAsTableRow(
                     s, platform_sp->GetUserIDResolver(), true, false);
               }
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "more than one process named %s:\n%s", process_name,
                   s.GetData());
             } else
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "could not find a process named %s", process_name);
           }
         } else {
-          error.SetErrorString(
+          error = Status::FromErrorString(
               "invalid platform, can't find processes by name");
           return error;
         }
       }
     } else {
-      error.SetErrorString("invalid process name");
+      error = Status::FromErrorString("invalid process name");
     }
   }
 
@@ -3071,7 +3082,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
         error = DoAttachToProcessWithID(attach_pid, attach_info);
       } else {
         // This shouldn't happen
-        error.SetErrorString("failed to acquire process run lock");
+        error = Status::FromErrorString("failed to acquire process run lock");
       }
 
       if (error.Success()) {
@@ -3284,7 +3295,7 @@ Status Process::PrivateResume() {
     if (m_thread_list.WillResume()) {
       // Last thing, do the PreResumeActions.
       if (!RunPreResumeActions()) {
-        error.SetErrorString(
+        error = Status::FromErrorString(
             "Process::PrivateResume PreResumeActions failed, not resuming.");
       } else {
         m_mod_id.BumpResumeID();
@@ -3317,7 +3328,7 @@ Status Process::PrivateResume() {
 
 Status Process::Halt(bool clear_thread_plans, bool use_run_lock) {
   if (!StateIsRunningState(m_public_state.GetValue()))
-    return Status("Process is not running.");
+    return Status::FromErrorString("Process is not running.");
 
   // Don't clear the m_clear_thread_plans_on_stop, only set it to true if in
   // case it was already set and some thread plan logic calls halt on its own.
@@ -3352,7 +3363,8 @@ Status Process::Halt(bool clear_thread_plans, bool use_run_lock) {
 
   if (state == eStateInvalid || !event_sp) {
     // We timed out and didn't get a stop event...
-    return Status("Halt timed out. State = %s", StateAsCString(GetState()));
+    return Status::FromErrorStringWithFormat("Halt timed out. State = %s",
+                                             StateAsCString(GetState()));
   }
 
   BroadcastEvent(event_sp);
@@ -3430,7 +3442,7 @@ Status Process::StopForDestroyOrDetach(lldb::EventSP &exit_event_sp) {
       // really are stopped, then continue on.
       StateType private_state = m_private_state.GetValue();
       if (private_state != eStateStopped) {
-        return Status(
+        return Status::FromErrorStringWithFormat(
             "Attempt to stop the target in order to detach timed out. "
             "State = %s",
             StateAsCString(GetState()));
@@ -6005,7 +6017,7 @@ void Process::DidExec() {
 
 addr_t Process::ResolveIndirectFunction(const Address *address, Status &error) {
   if (address == nullptr) {
-    error.SetErrorString("Invalid address argument");
+    error = Status::FromErrorString("Invalid address argument");
     return LLDB_INVALID_ADDRESS;
   }
 
@@ -6019,7 +6031,7 @@ addr_t Process::ResolveIndirectFunction(const Address *address, Status &error) {
   } else {
     if (!CallVoidArgVoidPtrReturn(address, function_addr)) {
       Symbol *symbol = address->CalculateSymbolContextSymbol();
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "Unable to call resolver for indirect function %s",
           symbol ? symbol->GetName().AsCString() : "<UNKNOWN>");
       function_addr = LLDB_INVALID_ADDRESS;
@@ -6249,7 +6261,7 @@ Process::ConfigureStructuredData(llvm::StringRef type_name,
   // If you get this, the Process-derived class needs to implement a method to
   // enable an already-reported asynchronous structured data feature. See
   // ProcessGDBRemote for an example implementation over gdb-remote.
-  return Status("unimplemented");
+  return Status::FromErrorString("unimplemented");
 }
 
 void Process::MapSupportedStructuredDataPlugins(
@@ -6687,8 +6699,9 @@ FinalizeCoreFileSaveRanges(Process::CoreFileMemoryRanges &ranges) {
       next_region->SetRangeBase(base);
       next_region->SetByteSize(byte_size);
       if (!ranges.Erase(i, i + 1)) {
-        error.SetErrorString("Core file memory ranges mutated outside of "
-                             "CalculateCoreFileSaveRanges");
+        error = Status::FromErrorString(
+            "Core file memory ranges mutated outside of "
+            "CalculateCoreFileSaveRanges");
         return error;
       }
     }
@@ -6704,10 +6717,12 @@ Status Process::CalculateCoreFileSaveRanges(const SaveCoreOptions &options,
   if (err.Fail())
     return err;
   if (regions.empty())
-    return Status("failed to get any valid memory regions from the process");
+    return Status::FromErrorString(
+        "failed to get any valid memory regions from the process");
   if (core_style == eSaveCoreUnspecified)
-    return Status("callers must set the core_style to something other than "
-                  "eSaveCoreUnspecified");
+    return Status::FromErrorString(
+        "callers must set the core_style to something other than "
+        "eSaveCoreUnspecified");
 
   GetUserSpecifiedCoreFileSaveRanges(*this, regions, options, ranges);
 
@@ -6740,7 +6755,8 @@ Status Process::CalculateCoreFileSaveRanges(const SaveCoreOptions &options,
     return err;
 
   if (ranges.IsEmpty())
-    return Status("no valid address ranges found for core style");
+    return Status::FromErrorString(
+        "no valid address ranges found for core style");
 
   return FinalizeCoreFileSaveRanges(ranges);
 }

--- a/lldb/source/Target/RegisterContext.cpp
+++ b/lldb/source/Target/RegisterContext.cpp
@@ -305,10 +305,8 @@ Status RegisterContext::ReadRegisterValueFromMemory(
     const RegisterInfo *reg_info, lldb::addr_t src_addr, uint32_t src_len,
     RegisterValue &reg_value) {
   Status error;
-  if (reg_info == nullptr) {
-    error.SetErrorString("invalid register info argument.");
-    return error;
-  }
+  if (!reg_info)
+    return Status::FromErrorString("invalid register info argument.");
 
   // Moving from addr into a register
   //
@@ -329,7 +327,7 @@ Status RegisterContext::ReadRegisterValueFromMemory(
   const uint32_t dst_len = reg_info->byte_size;
 
   if (src_len > dst_len) {
-    error.SetErrorStringWithFormat(
+    return Status::FromErrorStringWithFormat(
         "%u bytes is too big to store in register %s (%u bytes)", src_len,
         reg_info->name, dst_len);
     return error;
@@ -347,8 +345,8 @@ Status RegisterContext::ReadRegisterValueFromMemory(
     if (bytes_read != src_len) {
       if (error.Success()) {
         // This might happen if we read _some_ bytes but not all
-        error.SetErrorStringWithFormat("read %u of %u bytes", bytes_read,
-                                       src_len);
+        return Status::FromErrorStringWithFormat("read %u of %u bytes",
+                                                 bytes_read, src_len);
       }
       return error;
     }
@@ -361,7 +359,7 @@ Status RegisterContext::ReadRegisterValueFromMemory(
     reg_value.SetFromMemoryData(*reg_info, src.data(), src_len,
                                 process_sp->GetByteOrder(), error);
   } else
-    error.SetErrorString("invalid process");
+    return Status::FromErrorString("invalid process");
 
   return error;
 }
@@ -373,12 +371,12 @@ Status RegisterContext::WriteRegisterValueToMemory(
   ProcessSP process_sp(m_thread.GetProcess());
 
   if (!process_sp) {
-    error.SetErrorString("invalid process");
+    return Status::FromErrorString("invalid process");
     return error;
   }
 
   if (reg_info == nullptr) {
-    error.SetErrorString("Invalid register info argument.");
+    return Status::FromErrorString("Invalid register info argument.");
     return error;
   }
 
@@ -391,15 +389,15 @@ Status RegisterContext::WriteRegisterValueToMemory(
 
   if (error.Success()) {
     if (bytes_copied == 0) {
-      error.SetErrorString("byte copy failed.");
+      return Status::FromErrorString("byte copy failed.");
     } else {
       const uint32_t bytes_written =
           process_sp->WriteMemory(dst_addr, dst.data(), bytes_copied, error);
       if (bytes_written != bytes_copied) {
         if (error.Success()) {
           // This might happen if we read _some_ bytes but not all
-          error.SetErrorStringWithFormat("only wrote %u of %u bytes",
-                                         bytes_written, bytes_copied);
+          return Status::FromErrorStringWithFormat("only wrote %u of %u bytes",
+                                                   bytes_written, bytes_copied);
         }
       }
     }

--- a/lldb/source/Target/ScriptedThreadPlan.cpp
+++ b/lldb/source/Target/ScriptedThreadPlan.cpp
@@ -35,7 +35,7 @@ ScriptedThreadPlan::ScriptedThreadPlan(Thread &thread, const char *class_name,
   if (!interpreter) {
     SetPlanComplete(false);
     // FIXME: error handling
-    // error.SetErrorStringWithFormat(
+    // error = Status::FromErrorStringWithFormat(
     //     "ScriptedThreadPlan::%s () - ERROR: %s", __FUNCTION__,
     //     "Couldn't get script interpreter");
     return;
@@ -45,7 +45,7 @@ ScriptedThreadPlan::ScriptedThreadPlan(Thread &thread, const char *class_name,
   if (!m_interface) {
     SetPlanComplete(false);
     // FIXME: error handling
-    // error.SetErrorStringWithFormat(
+    // error = Status::FromErrorStringWithFormat(
     //     "ScriptedThreadPlan::%s () - ERROR: %s", __FUNCTION__,
     //     "Script interpreter couldn't create Scripted Thread Plan Interface");
     return;

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -514,8 +514,8 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
     return ValueObjectSP();
 
   if (var_expr.empty()) {
-    error.SetErrorStringWithFormat("invalid variable path '%s'",
-                                   var_expr.str().c_str());
+    error = Status::FromErrorStringWithFormatv("invalid variable path '{0}'",
+                                               var_expr);
     return ValueObjectSP();
   }
 
@@ -616,8 +616,8 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
       return valobj_sp;
   }
   if (!valobj_sp) {
-    error.SetErrorStringWithFormat("no variable named '%s' found in this frame",
-                                   name_const_string.GetCString());
+    error = Status::FromErrorStringWithFormatv(
+        "no variable named '{0}' found in this frame", name_const_string);
     return ValueObjectSP();
   }
 
@@ -653,21 +653,22 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
         if (valobj_sp->GetCompilerType().IsReferenceType()) {
           valobj_sp = valobj_sp->GetSyntheticValue()->Dereference(deref_error);
           if (!valobj_sp || deref_error.Fail()) {
-            error.SetErrorStringWithFormatv(
-                "Failed to dereference reference type: %s", deref_error);
+            error = Status::FromErrorStringWithFormatv(
+                "Failed to dereference reference type: {0}", deref_error);
             return ValueObjectSP();
           }
         }
 
         valobj_sp = valobj_sp->Dereference(deref_error);
         if (!valobj_sp || deref_error.Fail()) {
-          error.SetErrorStringWithFormatv(
+          error = Status::FromErrorStringWithFormatv(
               "Failed to dereference sythetic value: {0}", deref_error);
           return ValueObjectSP();
         }
         // Some synthetic plug-ins fail to set the error in Dereference
         if (!valobj_sp) {
-          error.SetErrorString("Failed to dereference sythetic value");
+          error =
+              Status::FromErrorString("Failed to dereference sythetic value");
           return ValueObjectSP();
         }
         expr_is_ptr = false;
@@ -691,13 +692,13 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
           // class/union/struct instance or reference.
           valobj_sp->GetExpressionPath(var_expr_path_strm);
           if (actual_is_ptr)
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "\"%s\" is a pointer and . was used to attempt to access "
                 "\"%s\". Did you mean \"%s->%s\"?",
                 var_expr_path_strm.GetData(), child_name.GetCString(),
                 var_expr_path_strm.GetData(), var_expr.str().c_str());
           else
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "\"%s\" is not a pointer and -> was used to attempt to "
                 "access \"%s\". Did you mean \"%s.%s\"?",
                 var_expr_path_strm.GetData(), child_name.GetCString(),
@@ -720,20 +721,20 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
             // We added a "this->" or "self->" to the beginning of the
             // expression and this is the first pointer ivar access, so just
             // return the normal error
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "no variable or instance variable named '%s' found in "
                 "this frame",
                 name_const_string.GetCString());
           } else {
             valobj_sp->GetExpressionPath(var_expr_path_strm);
             if (child_name) {
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "\"%s\" is not a member of \"(%s) %s\"",
                   child_name.GetCString(),
                   valobj_sp->GetTypeName().AsCString("<invalid type>"),
                   var_expr_path_strm.GetData());
             } else {
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "incomplete expression path after \"%s\" in \"%s\"",
                   var_expr_path_strm.GetData(),
                   original_var_expr.str().c_str());
@@ -757,7 +758,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
       // Array member access, or treating pointer as an array Need at least two
       // brackets and a number
       if (var_expr.size() <= 2) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "invalid square bracket encountered after \"%s\" in \"%s\"",
             var_expr_path_strm.GetData(), var_expr.str().c_str());
         return ValueObjectSP();
@@ -770,7 +771,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
       // If there's no closing brace, this is an invalid expression.
       size_t end_pos = var_expr.find_first_of(']');
       if (end_pos == llvm::StringRef::npos) {
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "missing closing square bracket in expression \"%s\"",
             var_expr_path_strm.GetData());
         return ValueObjectSP();
@@ -783,8 +784,8 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
       if (index_expr.consumeInteger(0, child_index)) {
         // If there was no integer anywhere in the index expression, this is
         // erroneous expression.
-        error.SetErrorStringWithFormat("invalid index expression \"%s\"",
-                                       index_expr.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid index expression \"%s\"", index_expr.str().c_str());
         return ValueObjectSP();
       }
 
@@ -799,7 +800,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
           ValueObjectSP temp(valobj_sp->Dereference(deref_error));
           if (!temp || deref_error.Fail()) {
             valobj_sp->GetExpressionPath(var_expr_path_strm);
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "could not dereference \"(%s) %s\"",
                 valobj_sp->GetTypeName().AsCString("<invalid type>"),
                 var_expr_path_strm.GetData());
@@ -816,7 +817,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
           ValueObjectSP temp(valobj_sp->GetChildAtIndex(0));
           if (!temp) {
             valobj_sp->GetExpressionPath(var_expr_path_strm);
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "could not get item 0 for \"(%s) %s\"",
                 valobj_sp->GetTypeName().AsCString("<invalid type>"),
                 var_expr_path_strm.GetData());
@@ -837,7 +838,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
             is_objc_pointer = false;
 
           if (no_synth_child && is_objc_pointer) {
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "\"(%s) %s\" is an Objective-C pointer, and cannot be "
                 "subscripted",
                 valobj_sp->GetTypeName().AsCString("<invalid type>"),
@@ -853,7 +854,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
                                               the original object */
             {
               valobj_sp->GetExpressionPath(var_expr_path_strm);
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "\"(%s) %s\" is not an array type",
                   valobj_sp->GetTypeName().AsCString("<invalid type>"),
                   var_expr_path_strm.GetData());
@@ -863,7 +864,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
                                                                 not have that
                                                                 many values */) {
               valobj_sp->GetExpressionPath(var_expr_path_strm);
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "array index %ld is not valid for \"(%s) %s\"", child_index,
                   valobj_sp->GetTypeName().AsCString("<invalid type>"),
                   var_expr_path_strm.GetData());
@@ -871,7 +872,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
               child_valobj_sp = synthetic->GetChildAtIndex(child_index);
               if (!child_valobj_sp) {
                 valobj_sp->GetExpressionPath(var_expr_path_strm);
-                error.SetErrorStringWithFormat(
+                error = Status::FromErrorStringWithFormat(
                     "array index %ld is not valid for \"(%s) %s\"", child_index,
                     valobj_sp->GetTypeName().AsCString("<invalid type>"),
                     var_expr_path_strm.GetData());
@@ -882,7 +883,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
                 valobj_sp->GetSyntheticArrayMember(child_index, true);
             if (!child_valobj_sp) {
               valobj_sp->GetExpressionPath(var_expr_path_strm);
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "failed to use pointer as array for index %ld for "
                   "\"(%s) %s\"",
                   child_index,
@@ -901,7 +902,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
 
           if (!child_valobj_sp) {
             valobj_sp->GetExpressionPath(var_expr_path_strm);
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "array index %ld is not valid for \"(%s) %s\"", child_index,
                 valobj_sp->GetTypeName().AsCString("<invalid type>"),
                 var_expr_path_strm.GetData());
@@ -912,7 +913,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
               child_index, child_index, true);
           if (!child_valobj_sp) {
             valobj_sp->GetExpressionPath(var_expr_path_strm);
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "bitfield range %ld-%ld is not valid for \"(%s) %s\"",
                 child_index, child_index,
                 valobj_sp->GetTypeName().AsCString("<invalid type>"),
@@ -926,7 +927,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
                                             original object */
           {
             valobj_sp->GetExpressionPath(var_expr_path_strm);
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "\"(%s) %s\" is not an array type",
                 valobj_sp->GetTypeName().AsCString("<invalid type>"),
                 var_expr_path_strm.GetData());
@@ -934,7 +935,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
                      synthetic->GetNumChildrenIgnoringErrors() /* synthetic
                                      does not have that many values */) {
             valobj_sp->GetExpressionPath(var_expr_path_strm);
-            error.SetErrorStringWithFormat(
+            error = Status::FromErrorStringWithFormat(
                 "array index %ld is not valid for \"(%s) %s\"", child_index,
                 valobj_sp->GetTypeName().AsCString("<invalid type>"),
                 var_expr_path_strm.GetData());
@@ -942,7 +943,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
             child_valobj_sp = synthetic->GetChildAtIndex(child_index);
             if (!child_valobj_sp) {
               valobj_sp->GetExpressionPath(var_expr_path_strm);
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "array index %ld is not valid for \"(%s) %s\"", child_index,
                   valobj_sp->GetTypeName().AsCString("<invalid type>"),
                   var_expr_path_strm.GetData());
@@ -968,16 +969,18 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
 
       // this is most probably a BitField, let's take a look
       if (index_expr.front() != '-') {
-        error.SetErrorStringWithFormat("invalid range expression \"'%s'\"",
-                                       original_index_expr.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid range expression \"'%s'\"",
+            original_index_expr.str().c_str());
         return ValueObjectSP();
       }
 
       index_expr = index_expr.drop_front();
       long final_index = 0;
       if (index_expr.getAsInteger(0, final_index)) {
-        error.SetErrorStringWithFormat("invalid range expression \"'%s'\"",
-                                       original_index_expr.str().c_str());
+        error = Status::FromErrorStringWithFormat(
+            "invalid range expression \"'%s'\"",
+            original_index_expr.str().c_str());
         return ValueObjectSP();
       }
 
@@ -997,7 +1000,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
         ValueObjectSP temp(valobj_sp->Dereference(deref_error));
         if (!temp || deref_error.Fail()) {
           valobj_sp->GetExpressionPath(var_expr_path_strm);
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "could not dereference \"(%s) %s\"",
               valobj_sp->GetTypeName().AsCString("<invalid type>"),
               var_expr_path_strm.GetData());
@@ -1013,7 +1016,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
         ValueObjectSP temp(valobj_sp->GetChildAtIndex(0));
         if (!temp) {
           valobj_sp->GetExpressionPath(var_expr_path_strm);
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "could not get item 0 for \"(%s) %s\"",
               valobj_sp->GetTypeName().AsCString("<invalid type>"),
               var_expr_path_strm.GetData());
@@ -1027,7 +1030,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
           valobj_sp->GetSyntheticBitFieldChild(child_index, final_index, true);
       if (!child_valobj_sp) {
         valobj_sp->GetExpressionPath(var_expr_path_strm);
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "bitfield range %ld-%ld is not valid for \"(%s) %s\"", child_index,
             final_index, valobj_sp->GetTypeName().AsCString("<invalid type>"),
             var_expr_path_strm.GetData());
@@ -1052,7 +1055,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
       // Failure...
       {
         valobj_sp->GetExpressionPath(var_expr_path_strm);
-        error.SetErrorStringWithFormat(
+        error = Status::FromErrorStringWithFormat(
             "unexpected char '%c' encountered after \"%s\" in \"%s\"",
             separator_type, var_expr_path_strm.GetData(),
             var_expr.str().c_str());
@@ -1079,7 +1082,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
 bool StackFrame::GetFrameBaseValue(Scalar &frame_base, Status *error_ptr) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (!m_cfa_is_valid) {
-    m_frame_base_error.SetErrorString(
+    m_frame_base_error = Status::FromErrorString(
         "No frame base available for this historical stack frame.");
     return false;
   }
@@ -1105,7 +1108,8 @@ bool StackFrame::GetFrameBaseValue(Scalar &frame_base, Status *error_ptr) {
       else
         m_frame_base = expr_value->ResolveValue(&exe_ctx);
     } else {
-      m_frame_base_error.SetErrorString("No function in symbol context.");
+      m_frame_base_error =
+          Status::FromErrorString("No function in symbol context.");
     }
   }
 
@@ -1120,7 +1124,7 @@ bool StackFrame::GetFrameBaseValue(Scalar &frame_base, Status *error_ptr) {
 DWARFExpressionList *StackFrame::GetFrameBaseExpression(Status *error_ptr) {
   if (!m_sc.function) {
     if (error_ptr) {
-      error_ptr->SetErrorString("No function in symbol context.");
+      *error_ptr = Status::FromErrorString("No function in symbol context.");
     }
     return nullptr;
   }

--- a/lldb/source/Target/TargetList.cpp
+++ b/lldb/source/Target/TargetList.cpp
@@ -88,8 +88,8 @@ Status TargetList::CreateTargetInternal(
   // determine the architecture.
   const ArchSpec arch(triple_str);
   if (!triple_str.empty() && !arch.IsValid()) {
-    error.SetErrorStringWithFormat("invalid triple '%s'",
-                                   triple_str.str().c_str());
+    error = Status::FromErrorStringWithFormat("invalid triple '%s'",
+                                              triple_str.str().c_str());
     return error;
   }
 
@@ -158,7 +158,7 @@ Status TargetList::CreateTargetInternal(
               platform_arch.DumpTriple(platform_arch_strm.AsRawOstream());
               matching_module_spec.GetArchitecture().DumpTriple(
                   module_arch_strm.AsRawOstream());
-              error.SetErrorStringWithFormat(
+              error = Status::FromErrorStringWithFormat(
                   "the specified architecture '%s' is not compatible with '%s' "
                   "in '%s'",
                   platform_arch_strm.GetData(), module_arch_strm.GetData(),
@@ -188,7 +188,8 @@ Status TargetList::CreateTargetInternal(
                 platform_list.GetOrCreate(archs, {}, candidates)) {
           platform_sp = platform_for_archs_sp;
         } else if (candidates.empty()) {
-          error.SetErrorString("no matching platforms found for this file");
+          error = Status::FromErrorString(
+              "no matching platforms found for this file");
           return error;
         } else {
           // More than one platform claims to support this file.
@@ -206,7 +207,7 @@ Status TargetList::CreateTargetInternal(
             platform_set.insert(platform_name);
           }
           error_strm.Printf("), specify an architecture to disambiguate");
-          error.SetErrorString(error_strm.GetString());
+          error = Status(error_strm.GetString().str());
           return error;
         }
       }
@@ -315,12 +316,12 @@ Status TargetList::CreateTargetInternal(Debugger &debugger,
     if (error.Success() && exe_module_sp) {
       if (exe_module_sp->GetObjectFile() == nullptr) {
         if (arch.IsValid()) {
-          error.SetErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormat(
               "\"%s\" doesn't contain architecture %s", file.GetPath().c_str(),
               arch.GetArchitectureName());
         } else {
-          error.SetErrorStringWithFormat("unsupported file type \"%s\"",
-                                         file.GetPath().c_str());
+          error = Status::FromErrorStringWithFormat(
+              "unsupported file type \"%s\"", file.GetPath().c_str());
         }
         return error;
       }

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1171,8 +1171,7 @@ Status Thread::QueueThreadPlan(ThreadPlanSP &thread_plan_sp,
   if (!thread_plan_sp->ValidatePlan(&s)) {
     DiscardThreadPlansUpToPlan(thread_plan_sp);
     thread_plan_sp.reset();
-    status.SetErrorString(s.GetString());
-    return status;
+    return Status(s.GetString().str());
   }
 
   if (abort_other_plans)
@@ -1187,8 +1186,7 @@ Status Thread::QueueThreadPlan(ThreadPlanSP &thread_plan_sp,
   if (!thread_plan_sp->ValidatePlan(&s)) {
     DiscardThreadPlansUpToPlan(thread_plan_sp);
     thread_plan_sp.reset();
-    status.SetErrorString(s.GetString());
-    return status;
+    return Status(s.GetString().str());
   }
 
   return status;
@@ -1239,7 +1237,8 @@ Status Thread::UnwindInnermostExpression() {
   Status error;
   ThreadPlan *innermost_expr_plan = GetPlans().GetInnermostExpression();
   if (!innermost_expr_plan) {
-    error.SetErrorString("No expressions currently active on this thread");
+    error = Status::FromErrorString(
+        "No expressions currently active on this thread");
     return error;
   }
   DiscardThreadPlansUpToPlan(innermost_expr_plan);
@@ -1461,7 +1460,7 @@ Status Thread::ReturnFromFrameWithIndex(uint32_t frame_idx,
   Status return_error;
 
   if (!frame_sp) {
-    return_error.SetErrorStringWithFormat(
+    return_error = Status::FromErrorStringWithFormat(
         "Could not find frame with index %d in thread 0x%" PRIx64 ".",
         frame_idx, GetID());
   }
@@ -1475,7 +1474,7 @@ Status Thread::ReturnFromFrame(lldb::StackFrameSP frame_sp,
   Status return_error;
 
   if (!frame_sp) {
-    return_error.SetErrorString("Can't return to a null frame.");
+    return_error = Status::FromErrorString("Can't return to a null frame.");
     return return_error;
   }
 
@@ -1483,14 +1482,15 @@ Status Thread::ReturnFromFrame(lldb::StackFrameSP frame_sp,
   uint32_t older_frame_idx = frame_sp->GetFrameIndex() + 1;
   StackFrameSP older_frame_sp = thread->GetStackFrameAtIndex(older_frame_idx);
   if (!older_frame_sp) {
-    return_error.SetErrorString("No older frame to return to.");
+    return_error = Status::FromErrorString("No older frame to return to.");
     return return_error;
   }
 
   if (return_value_sp) {
     lldb::ABISP abi = thread->GetProcess()->GetABI();
     if (!abi) {
-      return_error.SetErrorString("Could not find ABI to set return value.");
+      return_error =
+          Status::FromErrorString("Could not find ABI to set return value.");
       return return_error;
     }
     SymbolContext sc = frame_sp->GetSymbolContext(eSymbolContextFunction);
@@ -1538,13 +1538,14 @@ Status Thread::ReturnFromFrame(lldb::StackFrameSP frame_sp,
           BroadcastEvent(eBroadcastBitStackChanged, data_sp);
         }
       } else {
-        return_error.SetErrorString("Could not reset register values.");
+        return_error =
+            Status::FromErrorString("Could not reset register values.");
       }
     } else {
-      return_error.SetErrorString("Frame has no register context.");
+      return_error = Status::FromErrorString("Frame has no register context.");
     }
   } else {
-    return_error.SetErrorString("Returned past top frame.");
+    return_error = Status::FromErrorString("Returned past top frame.");
   }
   return return_error;
 }
@@ -1586,16 +1587,19 @@ Status Thread::JumpToLine(const FileSpec &file, uint32_t line,
   // Check if we got anything.
   if (candidates.empty()) {
     if (outside_function.empty()) {
-      return Status("Cannot locate an address for %s:%i.",
-                    file.GetFilename().AsCString(), line);
+      return Status::FromErrorStringWithFormat(
+          "Cannot locate an address for %s:%i.", file.GetFilename().AsCString(),
+          line);
     } else if (outside_function.size() == 1) {
-      return Status("%s:%i is outside the current function.",
-                    file.GetFilename().AsCString(), line);
+      return Status::FromErrorStringWithFormat(
+          "%s:%i is outside the current function.",
+          file.GetFilename().AsCString(), line);
     } else {
       StreamString sstr;
       DumpAddressList(sstr, outside_function, target);
-      return Status("%s:%i has multiple candidate locations:\n%s",
-                    file.GetFilename().AsCString(), line, sstr.GetData());
+      return Status::FromErrorStringWithFormat(
+          "%s:%i has multiple candidate locations:\n%s",
+          file.GetFilename().AsCString(), line, sstr.GetData());
     }
   }
 
@@ -1611,7 +1615,7 @@ Status Thread::JumpToLine(const FileSpec &file, uint32_t line,
   }
 
   if (!reg_ctx->SetPC(dest))
-    return Status("Cannot change PC to target address.");
+    return Status::FromErrorString("Cannot change PC to target address.");
 
   return Status();
 }
@@ -1963,7 +1967,7 @@ Status Thread::StepIn(bool source_step,
     process->GetThreadList().SetSelectedThreadByID(GetID());
     error = process->Resume();
   } else {
-    error.SetErrorString("process not stopped");
+    error = Status::FromErrorString("process not stopped");
   }
   return error;
 }
@@ -1996,7 +2000,7 @@ Status Thread::StepOver(bool source_step,
     process->GetThreadList().SetSelectedThreadByID(GetID());
     error = process->Resume();
   } else {
-    error.SetErrorString("process not stopped");
+    error = Status::FromErrorString("process not stopped");
   }
   return error;
 }
@@ -2020,7 +2024,7 @@ Status Thread::StepOut(uint32_t frame_idx) {
     process->GetThreadList().SetSelectedThreadByID(GetID());
     error = process->Resume();
   } else {
-    error.SetErrorString("process not stopped");
+    error = Status::FromErrorString("process not stopped");
   }
   return error;
 }
@@ -2066,7 +2070,8 @@ lldb::ValueObjectSP Thread::GetSiginfoValue() {
 
   CompilerType type = platform_sp->GetSiginfoType(arch.GetTriple());
   if (!type.IsValid())
-    return ValueObjectConstResult::Create(&target, Status("no siginfo_t for the platform"));
+    return ValueObjectConstResult::Create(
+        &target, Status::FromErrorString("no siginfo_t for the platform"));
 
   std::optional<uint64_t> type_size = type.GetByteSize(nullptr);
   assert(type_size);

--- a/lldb/source/Utility/RegisterValue.cpp
+++ b/lldb/source/Utility/RegisterValue.cpp
@@ -43,8 +43,8 @@ uint32_t RegisterValue::GetAsMemoryData(const RegisterInfo &reg_info, void *dst,
   // calling this.
   if (GetType() == eTypeInvalid) {
     // No value has been read into this object...
-    error.SetErrorStringWithFormat(
-        "invalid register value type for register %s", reg_info.name);
+    error = Status::FromErrorStringWithFormatv(
+        "invalid register value type for register {0}", reg_info.name);
     return 0;
   }
 
@@ -53,7 +53,7 @@ uint32_t RegisterValue::GetAsMemoryData(const RegisterInfo &reg_info, void *dst,
   // Extract the register data into a data extractor
   DataExtractor reg_data;
   if (!GetData(reg_data)) {
-    error.SetErrorString("invalid register value to copy into");
+    error = Status::FromErrorString("invalid register value to copy into");
     return 0;
   }
 
@@ -65,7 +65,7 @@ uint32_t RegisterValue::GetAsMemoryData(const RegisterInfo &reg_info, void *dst,
                                    dst_len,         // dst length
                                    dst_byte_order); // dst byte order
   if (bytes_copied == 0)
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "failed to copy data for register write of %s", reg_info.name);
 
   return bytes_copied;
@@ -94,7 +94,7 @@ uint32_t RegisterValue::SetFromMemoryData(const RegisterInfo &reg_info,
   const uint32_t dst_len = reg_info.byte_size;
 
   if (src_len > dst_len) {
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "%u bytes is too big to store in register %s (%u bytes)", src_len,
         reg_info.name, dst_len);
     return 0;
@@ -159,19 +159,19 @@ Status RegisterValue::SetValueFromData(const RegisterInfo &reg_info,
   Status error;
 
   if (src.GetByteSize() == 0) {
-    error.SetErrorString("empty data.");
+    error = Status::FromErrorString("empty data.");
     return error;
   }
 
   if (reg_info.byte_size == 0) {
-    error.SetErrorString("invalid register info.");
+    error = Status::FromErrorString("invalid register info.");
     return error;
   }
 
   uint32_t src_len = src.GetByteSize() - src_offset;
 
   if (!partial_data_ok && (src_len < reg_info.byte_size)) {
-    error.SetErrorString("not enough data.");
+    error = Status::FromErrorString("not enough data.");
     return error;
   }
 
@@ -229,7 +229,7 @@ Status RegisterValue::SetValueFromData(const RegisterInfo &reg_info,
             buffer.bytes.size(), // dst length
             buffer.byte_order) == 0) // dst byte order
     {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "failed to copy data for register write of %s", reg_info.name);
       return error;
     }
@@ -237,7 +237,7 @@ Status RegisterValue::SetValueFromData(const RegisterInfo &reg_info,
   }
 
   if (m_type == eTypeInvalid)
-    error.SetErrorStringWithFormat(
+    error = Status::FromErrorStringWithFormat(
         "invalid register value type for register %s", reg_info.name);
   return error;
 }
@@ -314,13 +314,13 @@ Status RegisterValue::SetValueFromString(const RegisterInfo *reg_info,
                                          llvm::StringRef value_str) {
   Status error;
   if (reg_info == nullptr) {
-    error.SetErrorString("Invalid register info argument.");
+    error = Status::FromErrorString("Invalid register info argument.");
     return error;
   }
 
   m_type = eTypeInvalid;
   if (value_str.empty()) {
-    error.SetErrorString("Invalid c-string value string.");
+    error = Status::FromErrorString("Invalid c-string value string.");
     return error;
   }
   const uint32_t byte_size = reg_info->byte_size;
@@ -332,23 +332,23 @@ Status RegisterValue::SetValueFromString(const RegisterInfo *reg_info,
   long double ldbl_val;
   switch (reg_info->encoding) {
   case eEncodingInvalid:
-    error.SetErrorString("Invalid encoding.");
+    error = Status::FromErrorString("Invalid encoding.");
     break;
 
   case eEncodingUint:
     if (byte_size > sizeof(uint64_t)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "unsupported unsigned integer byte size: %u", byte_size);
       break;
     }
     if (value_str.getAsInteger(0, uval64)) {
-      error.SetErrorStringWithFormatv(
+      error = Status::FromErrorStringWithFormatv(
           "'{0}' is not a valid unsigned integer string value", value_str);
       break;
     }
 
     if (!UInt64ValueIsValidForByteSize(uval64, byte_size)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "value 0x%" PRIx64
           " is too large to fit in a %u byte unsigned integer value",
           uval64, byte_size);
@@ -356,7 +356,7 @@ Status RegisterValue::SetValueFromString(const RegisterInfo *reg_info,
     }
 
     if (!SetUInt(uval64, reg_info->byte_size)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "unsupported unsigned integer byte size: %u", byte_size);
       break;
     }
@@ -364,19 +364,19 @@ Status RegisterValue::SetValueFromString(const RegisterInfo *reg_info,
 
   case eEncodingSint:
     if (byte_size > sizeof(long long)) {
-      error.SetErrorStringWithFormat("unsupported signed integer byte size: %u",
-                                     byte_size);
+      error = Status::FromErrorStringWithFormat(
+          "unsupported signed integer byte size: %u", byte_size);
       break;
     }
 
     if (value_str.getAsInteger(0, ival64)) {
-      error.SetErrorStringWithFormatv(
+      error = Status::FromErrorStringWithFormatv(
           "'{0}' is not a valid signed integer string value", value_str);
       break;
     }
 
     if (!SInt64ValueIsValidForByteSize(ival64, byte_size)) {
-      error.SetErrorStringWithFormat(
+      error = Status::FromErrorStringWithFormat(
           "value 0x%" PRIx64
           " is too large to fit in a %u byte signed integer value",
           ival64, byte_size);
@@ -384,8 +384,8 @@ Status RegisterValue::SetValueFromString(const RegisterInfo *reg_info,
     }
 
     if (!SetUInt(ival64, reg_info->byte_size)) {
-      error.SetErrorStringWithFormat("unsupported signed integer byte size: %u",
-                                     byte_size);
+      error = Status::FromErrorStringWithFormat(
+          "unsupported signed integer byte size: %u", byte_size);
       break;
     }
     break;
@@ -394,38 +394,39 @@ Status RegisterValue::SetValueFromString(const RegisterInfo *reg_info,
     std::string value_string = std::string(value_str);
     if (byte_size == sizeof(float)) {
       if (::sscanf(value_string.c_str(), "%f", &flt_val) != 1) {
-        error.SetErrorStringWithFormat("'%s' is not a valid float string value",
-                                       value_string.c_str());
+        error = Status::FromErrorStringWithFormat(
+            "'%s' is not a valid float string value", value_string.c_str());
         break;
       }
       m_scalar = flt_val;
       m_type = eTypeFloat;
     } else if (byte_size == sizeof(double)) {
       if (::sscanf(value_string.c_str(), "%lf", &dbl_val) != 1) {
-        error.SetErrorStringWithFormat("'%s' is not a valid float string value",
-                                       value_string.c_str());
+        error = Status::FromErrorStringWithFormat(
+            "'%s' is not a valid float string value", value_string.c_str());
         break;
       }
       m_scalar = dbl_val;
       m_type = eTypeDouble;
     } else if (byte_size == sizeof(long double)) {
       if (::sscanf(value_string.c_str(), "%Lf", &ldbl_val) != 1) {
-        error.SetErrorStringWithFormat("'%s' is not a valid float string value",
-                                       value_string.c_str());
+        error = Status::FromErrorStringWithFormat(
+            "'%s' is not a valid float string value", value_string.c_str());
         break;
       }
       m_scalar = ldbl_val;
       m_type = eTypeLongDouble;
     } else {
-      error.SetErrorStringWithFormat("unsupported float byte size: %u",
-                                     byte_size);
+      error = Status::FromErrorStringWithFormat(
+          "unsupported float byte size: %u", byte_size);
       return error;
     }
     break;
   }
   case eEncodingVector:
     if (!ParseVectorEncoding(reg_info, value_str, byte_size, this))
-      error.SetErrorString("unrecognized vector encoding string value.");
+      error =
+          Status::FromErrorString("unrecognized vector encoding string value.");
     break;
   }
 

--- a/lldb/source/Utility/SelectHelper.cpp
+++ b/lldb/source/Utility/SelectHelper.cpp
@@ -97,7 +97,8 @@ lldb_private::Status SelectHelper::Select() {
   // numeric value.
   lldbassert(m_fd_map.size() <= FD_SETSIZE);
   if (m_fd_map.size() > FD_SETSIZE)
-    return lldb_private::Status("Too many file descriptors for select()");
+    return lldb_private::Status::FromErrorString(
+        "Too many file descriptors for select()");
 #endif
 
   std::optional<lldb::socket_t> max_read_fd;
@@ -110,7 +111,8 @@ lldb_private::Status SelectHelper::Select() {
 #if !defined(__APPLE__) && !defined(_WIN32)
     lldbassert(fd < static_cast<int>(FD_SETSIZE));
     if (fd >= static_cast<int>(FD_SETSIZE)) {
-      error.SetErrorStringWithFormat("%i is too large for select()", fd);
+      error =
+          Status::FromErrorStringWithFormat("%i is too large for select()", fd);
       return error;
     }
 #endif
@@ -124,8 +126,7 @@ lldb_private::Status SelectHelper::Select() {
   }
 
   if (!max_fd) {
-    error.SetErrorString("no valid file descriptors");
-    return error;
+    return lldb_private::Status::FromErrorString("no valid file descriptors");
   }
 
   const unsigned nfds = static_cast<unsigned>(*max_fd) + 1;
@@ -215,7 +216,7 @@ lldb_private::Status SelectHelper::Select() {
                                      error_fdset_ptr, tv_ptr);
     if (num_set_fds < 0) {
       // We got an error
-      error.SetErrorToErrno();
+      error = lldb_private::Status::FromErrno();
       if (error.GetError() == EINTR) {
         error.Clear();
         continue; // Keep calling select if we get EINTR
@@ -223,9 +224,8 @@ lldb_private::Status SelectHelper::Select() {
         return error;
     } else if (num_set_fds == 0) {
       // Timeout
-      error.SetError(ETIMEDOUT, lldb::eErrorTypePOSIX);
-      error.SetErrorString("timed out");
-      return error;
+      return lldb_private::Status(ETIMEDOUT, lldb::eErrorTypePOSIX,
+                                  "timed out");
     } else {
       // One or more descriptors were set, update the FDInfo::select_is_set
       // mask so users can ask the SelectHelper class so clients can call one

--- a/lldb/source/Utility/Status.cpp
+++ b/lldb/source/Utility/Status.cpp
@@ -37,10 +37,10 @@ class raw_ostream;
 using namespace lldb;
 using namespace lldb_private;
 
-Status::Status() : m_string() {}
+Status::Status() {}
 
-Status::Status(ValueType err, ErrorType type)
-    : m_code(err), m_type(type), m_string() {}
+Status::Status(ValueType err, ErrorType type, std::string msg)
+    : m_code(err), m_type(type), m_string(std::move(msg)) {}
 
 // This logic is confusing because c++ calls the traditional (posix) errno codes
 // "generic errors", while we use the term "generic" to mean completely
@@ -51,13 +51,9 @@ Status::Status(std::error_code EC)
                                                       : eErrorTypeGeneric),
       m_string(EC.message()) {}
 
-Status::Status(const char *format, ...) : m_string() {
-  va_list args;
-  va_start(args, format);
-  SetErrorToGenericError();
-  SetErrorStringWithVarArg(format, args);
-  va_end(args);
-}
+Status::Status(std::string err_str)
+    : m_code(LLDB_GENERIC_ERROR), m_type(eErrorTypeGeneric),
+      m_string(std::move(err_str)) {}
 
 const Status &Status::operator=(llvm::Error error) {
   if (!error) {
@@ -79,11 +75,25 @@ const Status &Status::operator=(llvm::Error error) {
 
   // Otherwise, just preserve the message
   if (error) {
-    SetErrorToGenericError();
-    SetErrorString(llvm::toString(std::move(error)));
+    m_code = LLDB_GENERIC_ERROR;
+    m_type = eErrorTypeGeneric;
+    m_string = llvm::toString(std::move(error));
   }
 
   return *this;
+}
+
+Status Status::FromErrorStringWithFormat(const char *format, ...) {
+  std::string string;
+  va_list args;
+  va_start(args, format);
+  if (format != nullptr && format[0]) {
+    llvm::SmallString<1024> buf;
+    VASprintf(buf, format, args);
+    string = std::string(buf.str());
+  }
+  va_end(args);
+  return Status(string);
 }
 
 llvm::Error Status::ToError() const {
@@ -179,98 +189,9 @@ ErrorType Status::GetType() const { return m_type; }
 // otherwise non-success result.
 bool Status::Fail() const { return m_code != 0; }
 
-void Status::SetExpressionError(lldb::ExpressionResults result,
-                                const char *mssg) {
-  m_code = result;
-  m_type = eErrorTypeExpression;
-  m_string = mssg;
-}
-
-int Status::SetExpressionErrorWithFormat(lldb::ExpressionResults result,
-                                         const char *format, ...) {
-  int length = 0;
-
-  if (format != nullptr && format[0]) {
-    va_list args;
-    va_start(args, format);
-    length = SetErrorStringWithVarArg(format, args);
-    va_end(args);
-  } else {
-    m_string.clear();
-  }
-  m_code = result;
-  m_type = eErrorTypeExpression;
-  return length;
-}
-
-// Set accessor for the error value and type.
-void Status::SetError(ValueType err, ErrorType type) {
-  m_code = err;
-  m_type = type;
-  m_string.clear();
-}
-
-// Update the error value to be "errno" and update the type to be "POSIX".
-void Status::SetErrorToErrno() {
-  m_code = errno;
-  m_type = eErrorTypePOSIX;
-  m_string.clear();
-}
-
-// Update the error value to be LLDB_GENERIC_ERROR and update the type to be
-// "Generic".
-void Status::SetErrorToGenericError() {
-  m_code = LLDB_GENERIC_ERROR;
-  m_type = eErrorTypeGeneric;
-  m_string.clear();
-}
-
-// Set accessor for the error string value for a specific error. This allows
-// any string to be supplied as an error explanation. The error string value
-// will remain until the error value is cleared or a new error value/type is
-// assigned.
-void Status::SetErrorString(llvm::StringRef err_str) {
-  if (!err_str.empty()) {
-    // If we have an error string, we should always at least have an error set
-    // to a generic value.
-    if (Success())
-      SetErrorToGenericError();
-  }
-  m_string = std::string(err_str);
-}
-
-/// Set the current error string to a formatted error string.
-///
-/// \param format
-///     A printf style format string
-int Status::SetErrorStringWithFormat(const char *format, ...) {
-  if (format != nullptr && format[0]) {
-    va_list args;
-    va_start(args, format);
-    int length = SetErrorStringWithVarArg(format, args);
-    va_end(args);
-    return length;
-  } else {
-    m_string.clear();
-  }
-  return 0;
-}
-
-int Status::SetErrorStringWithVarArg(const char *format, va_list args) {
-  if (format != nullptr && format[0]) {
-    // If we have an error string, we should always at least have an error set
-    // to a generic value.
-    if (Success())
-      SetErrorToGenericError();
-
-    llvm::SmallString<1024> buf;
-    VASprintf(buf, format, args);
-    m_string = std::string(buf.str());
-    return buf.size();
-  } else {
-    m_string.clear();
-  }
-  return 0;
+Status Status::FromErrno() {
+  // Update the error value to be "errno" and update the type to be "POSIX".
+  return Status(errno, eErrorTypePOSIX);
 }
 
 // Returns true if the error code in this object is considered a successful

--- a/lldb/source/Utility/StringExtractorGDBRemote.cpp
+++ b/lldb/source/Utility/StringExtractorGDBRemote.cpp
@@ -500,13 +500,11 @@ lldb_private::Status StringExtractorGDBRemote::GetStatus() {
   if (GetResponseType() == eError) {
     SetFilePos(1);
     uint8_t errc = GetHexU8(255);
-    error.SetError(errc, lldb::eErrorTypeGeneric);
-
-    error.SetErrorStringWithFormat("Error %u", errc);
+    error = lldb_private::Status::FromErrorStringWithFormat("Error %u", errc);
     std::string error_messg;
     if (GetChar() == ';') {
       GetHexByteString(error_messg);
-      error.SetErrorString(error_messg);
+      error = lldb_private::Status(error_messg);
     }
   }
   return error;

--- a/lldb/source/Utility/StructuredData.cpp
+++ b/lldb/source/Utility/StructuredData.cpp
@@ -37,16 +37,16 @@ StructuredData::ParseJSONFromFile(const FileSpec &input_spec, Status &error) {
 
   auto buffer_or_error = llvm::MemoryBuffer::getFile(input_spec.GetPath());
   if (!buffer_or_error) {
-    error.SetErrorStringWithFormatv("could not open input file: {0} - {1}.",
-                                    input_spec.GetPath(),
-                                    buffer_or_error.getError().message());
+    error = Status::FromErrorStringWithFormatv(
+        "could not open input file: {0} - {1}.", input_spec.GetPath(),
+        buffer_or_error.getError().message());
     return return_sp;
   }
   llvm::Expected<json::Value> value =
       json::parse(buffer_or_error.get()->getBuffer().str());
   if (value)
     return ParseJSONValue(*value);
-  error.SetErrorString(toString(value.takeError()));
+  error = Status(value.takeError());
   return StructuredData::ObjectSP();
 }
 

--- a/lldb/test/API/functionalities/postmortem/FreeBSDKernel/tools/lldb-minimize-processes.patch
+++ b/lldb/test/API/functionalities/postmortem/FreeBSDKernel/tools/lldb-minimize-processes.patch
@@ -74,7 +74,7 @@ index e3707365a9c3..c4a9c82f3c63 100644
 +  rd = fvc_write(m_fvc, vm_addr, buf, size);
 +  printf("fvc_write(%p, %p, %d) -> %d\n", vm_addr, buf, size, rd);
 +  if (rd < 0 || static_cast<size_t>(rd) != size) {
-+    error.SetErrorStringWithFormat("Writing memory failed: %s", GetError());
++    error = Status::FromErrorStringWithFormat("Writing memory failed: %s", GetError());
 +    return rd > 0 ? rd : 0;
 +  }
 +  return rd;

--- a/lldb/tools/lldb-server/Acceptor.cpp
+++ b/lldb/tools/lldb-server/Acceptor.cpp
@@ -55,8 +55,8 @@ std::unique_ptr<Acceptor> Acceptor::Create(StringRef name,
   if (std::optional<URI> res = URI::Parse(name)) {
     if (!Socket::FindProtocolByScheme(res->scheme.str().c_str(),
                                       socket_protocol))
-      error.SetErrorStringWithFormat("Unknown protocol scheme \"%s\"",
-                                     res->scheme.str().c_str());
+      error = Status::FromErrorStringWithFormat(
+          "Unknown protocol scheme \"%s\"", res->scheme.str().c_str());
     else
       name = name.drop_front(res->scheme.size() + strlen("://"));
   } else {

--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -103,8 +103,9 @@ static Status save_socket_id_to_file(const std::string &socket_id,
   FileSpec temp_file_spec(file_spec.GetDirectory().GetStringRef());
   Status error(llvm::sys::fs::create_directory(temp_file_spec.GetPath()));
   if (error.Fail())
-    return Status("Failed to create directory %s: %s",
-                  temp_file_spec.GetPath().c_str(), error.AsCString());
+    return Status::FromErrorStringWithFormat(
+        "Failed to create directory %s: %s", temp_file_spec.GetPath().c_str(),
+        error.AsCString());
 
   Status status;
   if (auto Err = llvm::writeToOutput(file_spec.GetPath(),
@@ -112,9 +113,9 @@ static Status save_socket_id_to_file(const std::string &socket_id,
                                        OS << socket_id;
                                        return llvm::Error::success();
                                      }))
-    return Status("Failed to atomically write file %s: %s",
-                  file_spec.GetPath().c_str(),
-                  llvm::toString(std::move(Err)).c_str());
+    return Status::FromErrorStringWithFormat(
+        "Failed to atomically write file %s: %s", file_spec.GetPath().c_str(),
+        llvm::toString(std::move(Err)).c_str());
   return status;
 }
 
@@ -223,7 +224,7 @@ static Status spawn_process(const char *progname, const Socket *conn_socket,
 
   lldb::pid_t child_pid = launch_info.GetProcessID();
   if (child_pid == LLDB_INVALID_PROCESS_ID)
-    return Status("invalid pid");
+    return Status::FromErrorString("invalid pid");
 
   LLDB_LOG(GetLog(LLDBLog::Platform), "lldb-platform launched '{0}', pid={1}",
            cmd, child_pid);

--- a/lldb/unittests/Platform/Android/PlatformAndroidTest.cpp
+++ b/lldb/unittests/Platform/Android/PlatformAndroidTest.cpp
@@ -58,7 +58,8 @@ TEST_F(PlatformAndroidTest, DownloadModuleSliceWithAdbClientError) {
   EXPECT_CALL(*this, GetAdbClient(_))
       .Times(1)
       .WillOnce(DoAll(WithArg<0>([](auto &arg) {
-                        arg = Status("Failed to create AdbClient");
+                        arg = Status::FromErrorString(
+                            "Failed to create AdbClient");
                       }),
                       Return(ByMove(AdbClientUP()))));
 

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationServerTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationServerTest.cpp
@@ -25,10 +25,7 @@ TEST(GDBRemoteCommunicationServerTest, SendErrorResponse_ErrorNumber) {
 
 TEST(GDBRemoteCommunicationServerTest, SendErrorResponse_Status) {
   MockServerWithMockConnection server;
-  Status status;
-
-  status.SetError(0x42, lldb::eErrorTypeGeneric);
-  status.SetErrorString("Test error message");
+  Status status(0x42, lldb::eErrorTypeGeneric, "Test error message");
   server.SendErrorResponse(status);
 
   EXPECT_THAT(

--- a/lldb/unittests/Target/LocateModuleCallbackTest.cpp
+++ b/lldb/unittests/Target/LocateModuleCallbackTest.cpp
@@ -358,7 +358,7 @@ TEST_F(LocateModuleCallbackTest, GetOrCreateModuleCallbackFailureNoCache) {
                                    FileSpec &symbol_file_spec) {
         CheckCallbackArgsWithUUID(module_spec, module_file_spec,
                                   symbol_file_spec, ++callback_call_count);
-        return Status("The locate module callback failed");
+        return Status::FromErrorString("The locate module callback failed");
       });
 
   m_module_sp = m_target_sp->GetOrCreateModule(m_module_spec, /*notify=*/false);
@@ -379,7 +379,7 @@ TEST_F(LocateModuleCallbackTest, GetOrCreateModuleCallbackFailureCached) {
                                    FileSpec &symbol_file_spec) {
         CheckCallbackArgsWithUUID(module_spec, module_file_spec,
                                   symbol_file_spec, ++callback_call_count);
-        return Status("The locate module callback failed");
+        return Status::FromErrorString("The locate module callback failed");
       });
 
   m_module_sp = m_target_sp->GetOrCreateModule(m_module_spec, /*notify=*/false);
@@ -755,7 +755,7 @@ TEST_F(LocateModuleCallbackTest,
           // The module_spec does not have UUID on the first call.
           CheckCallbackArgsWithoutUUID(module_spec, module_file_spec,
                                        symbol_file_spec, callback_call_count);
-          return Status("Ignored empty UUID");
+          return Status::FromErrorString("Ignored empty UUID");
         } else {
           // The module_spec has UUID on the second call.
           CheckCallbackArgsWithUUID(module_spec, module_file_spec,
@@ -793,7 +793,7 @@ TEST_F(LocateModuleCallbackTest,
           // The module_spec does not have UUID on the first call.
           CheckCallbackArgsWithoutUUID(module_spec, module_file_spec,
                                        symbol_file_spec, callback_call_count);
-          return Status("Ignored empty UUID");
+          return Status::FromErrorString("Ignored empty UUID");
         } else {
           // The module_spec has UUID on the second call.
           CheckCallbackArgsWithUUID(module_spec, module_file_spec,
@@ -833,7 +833,7 @@ TEST_F(LocateModuleCallbackTest,
           // The module_spec does not have UUID on the first call.
           CheckCallbackArgsWithoutUUID(module_spec, module_file_spec,
                                        symbol_file_spec, callback_call_count);
-          return Status("Ignored empty UUID");
+          return Status::FromErrorString("Ignored empty UUID");
         } else {
           // The module_spec has UUID on the second call.
           CheckCallbackArgsWithUUID(module_spec, module_file_spec,
@@ -876,7 +876,7 @@ TEST_F(LocateModuleCallbackTest,
           // The module_spec does not have UUID on the first call.
           CheckCallbackArgsWithoutUUID(module_spec, module_file_spec,
                                        symbol_file_spec, callback_call_count);
-          return Status("Ignored empty UUID");
+          return Status::FromErrorString("Ignored empty UUID");
         } else {
           // The module_spec has UUID on the second call.
           CheckCallbackArgsWithUUID(module_spec, module_file_spec,

--- a/lldb/unittests/Target/ModuleCacheTest.cpp
+++ b/lldb/unittests/Target/ModuleCacheTest.cpp
@@ -105,7 +105,7 @@ void ModuleCacheTest::TryGetAndPut(const FileSpec &cache_dir,
         return Status();
       },
       [](const ModuleSP &module_sp, const FileSpec &tmp_download_file_spec) {
-        return Status("Not supported.");
+        return Status::FromErrorString("Not supported.");
       },
       module_sp, &did_create);
   EXPECT_EQ(expect_download, download_called);

--- a/lldb/unittests/Utility/StatusTest.cpp
+++ b/lldb/unittests/Utility/StatusTest.cpp
@@ -18,8 +18,12 @@ using namespace lldb;
 
 TEST(StatusTest, Formatv) {
   EXPECT_EQ("", llvm::formatv("{0}", Status()).str());
-  EXPECT_EQ("Hello Status", llvm::formatv("{0}", Status("Hello Status")).str());
-  EXPECT_EQ("Hello", llvm::formatv("{0:5}", Status("Hello Error")).str());
+  EXPECT_EQ(
+      "Hello Status",
+      llvm::formatv("{0}", Status::FromErrorString("Hello Status")).str());
+  EXPECT_EQ(
+      "Hello",
+      llvm::formatv("{0:5}", Status::FromErrorString("Hello Error")).str());
 }
 
 TEST(StatusTest, ErrorConstructor) {
@@ -59,7 +63,7 @@ TEST(StatusTest, ErrorConversion) {
   EXPECT_EQ(EAGAIN, ec.value());
   EXPECT_EQ(std::generic_category(), ec.category());
 
-  llvm::Error foo = Status("foo").ToError();
+  llvm::Error foo = Status::FromErrorString("foo").ToError();
   EXPECT_TRUE(bool(foo));
   EXPECT_EQ("foo", llvm::toString(std::move(foo)));
 }


### PR DESCRIPTION
This patch removes all of the Set.* methods from Status.

This cleanup is part of a series of patches that make it harder use the anti-pattern of keeping a long-lives Status object around and updating it while dropping any errors it contains on the floor.

This patch is largely NFC, the more interesting next steps this enables is to:
1. remove Status.Clear()
2. assert that Status::operator=() never overwrites an error
3. remove Status::operator=()

Note that step (2) will bring 90% of the benefits for users, and step (3) will dramatically clean up the error handling code in various places. In the end my goal is to convert all APIs that are of the form

`    ResultTy DoFoo(Status& error)
`
to

`    llvm::Expected<ResultTy> DoFoo()
`
How to read this patch?

The interesting changes are in Status.h and Status.cpp, all other changes are mostly

`     perl -pi -e 's/\.SetErrorString/ = Status::FromErrorString/g' $(git grep -l SetErrorString lldb/source)
`
plus the occasional manual cleanup.