### PR TITLE
[llvm] [Demangle] Fix MSVC demangling for placeholder return types

### DIFF
--- a/llvm/include/llvm/Demangle/MicrosoftDemangle.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangle.h
@@ -173,6 +173,7 @@ private:
   TypeNode *demangleType(std::string_view &MangledName,
                          QualifierMangleMode QMM);
   PrimitiveTypeNode *demanglePrimitiveType(std::string_view &MangledName);
+  PlaceholderTypeNode *demanglePlaceholderType(std::string_view &MangledName);
   CustomTypeNode *demangleCustomType(std::string_view &MangledName);
   TagTypeNode *demangleClassType(std::string_view &MangledName);
   PointerTypeNode *demanglePointerType(std::string_view &MangledName);

--- a/llvm/include/llvm/Demangle/MicrosoftDemangle.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangle.h
@@ -173,7 +173,6 @@ private:
   TypeNode *demangleType(std::string_view &MangledName,
                          QualifierMangleMode QMM);
   PrimitiveTypeNode *demanglePrimitiveType(std::string_view &MangledName);
-  PlaceholderTypeNode *demanglePlaceholderType(std::string_view &MangledName);
   CustomTypeNode *demangleCustomType(std::string_view &MangledName);
   TagTypeNode *demangleClassType(std::string_view &MangledName);
   PointerTypeNode *demanglePointerType(std::string_view &MangledName);

--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
@@ -104,6 +104,8 @@ enum class PrimitiveKind {
   Double,
   Ldouble,
   Nullptr,
+  Auto,
+  DecltypeAuto,
 };
 
 enum class CharKind {

--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
@@ -106,6 +106,11 @@ enum class PrimitiveKind {
   Nullptr,
 };
 
+enum class PlaceholderKind {
+  Auto,
+  DecltypeAuto,
+};
+
 enum class CharKind {
   Char,
   Char16,
@@ -251,7 +256,8 @@ enum class NodeKind {
   LocalStaticGuardVariable,
   FunctionSymbol,
   VariableSymbol,
-  SpecialTableSymbol
+  SpecialTableSymbol,
+  PlaceholderType,
 };
 
 struct Node {
@@ -270,6 +276,7 @@ private:
 
 struct TypeNode;
 struct PrimitiveTypeNode;
+struct PlaceholderTypeNode;
 struct FunctionSignatureNode;
 struct IdentifierNode;
 struct NamedIdentifierNode;
@@ -316,6 +323,16 @@ struct PrimitiveTypeNode : public TypeNode {
   void outputPost(OutputBuffer &OB, OutputFlags Flags) const override {}
 
   PrimitiveKind PrimKind;
+};
+
+struct PlaceholderTypeNode : public TypeNode {
+  explicit PlaceholderTypeNode(PlaceholderKind K)
+      : TypeNode(NodeKind::PlaceholderType), PlaceholderKind(K) {}
+
+  void outputPre(OutputBuffer &OB, OutputFlags Flags) const override;
+  void outputPost(OutputBuffer &OB, OutputFlags Flags) const override {}
+
+  PlaceholderKind PlaceholderKind;
 };
 
 struct FunctionSignatureNode : public TypeNode {

--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
@@ -106,11 +106,6 @@ enum class PrimitiveKind {
   Nullptr,
 };
 
-enum class PlaceholderKind {
-  Auto,
-  DecltypeAuto,
-};
-
 enum class CharKind {
   Char,
   Char16,
@@ -256,8 +251,7 @@ enum class NodeKind {
   LocalStaticGuardVariable,
   FunctionSymbol,
   VariableSymbol,
-  SpecialTableSymbol,
-  PlaceholderType,
+  SpecialTableSymbol
 };
 
 struct Node {
@@ -276,7 +270,6 @@ private:
 
 struct TypeNode;
 struct PrimitiveTypeNode;
-struct PlaceholderTypeNode;
 struct FunctionSignatureNode;
 struct IdentifierNode;
 struct NamedIdentifierNode;
@@ -323,16 +316,6 @@ struct PrimitiveTypeNode : public TypeNode {
   void outputPost(OutputBuffer &OB, OutputFlags Flags) const override {}
 
   PrimitiveKind PrimKind;
-};
-
-struct PlaceholderTypeNode : public TypeNode {
-  explicit PlaceholderTypeNode(PlaceholderKind K)
-      : TypeNode(NodeKind::PlaceholderType), PlaceholderKind(K) {}
-
-  void outputPre(OutputBuffer &OB, OutputFlags Flags) const override;
-  void outputPost(OutputBuffer &OB, OutputFlags Flags) const override {}
-
-  PlaceholderKind PlaceholderKind;
 };
 
 struct FunctionSignatureNode : public TypeNode {

--- a/llvm/lib/Demangle/MicrosoftDemangle.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangle.cpp
@@ -2035,6 +2035,10 @@ Demangler::demanglePrimitiveType(std::string_view &MangledName) {
       return Arena.alloc<PrimitiveTypeNode>(PrimitiveKind::Char16);
     case 'U':
       return Arena.alloc<PrimitiveTypeNode>(PrimitiveKind::Char32);
+    case 'P':
+      return Arena.alloc<PrimitiveTypeNode>(PrimitiveKind::Auto);
+    case 'T':
+      return Arena.alloc<PrimitiveTypeNode>(PrimitiveKind::DecltypeAuto);
     }
     break;
   }

--- a/llvm/lib/Demangle/MicrosoftDemangle.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangle.cpp
@@ -241,11 +241,6 @@ static bool isFunctionType(std::string_view S) {
          llvm::itanium_demangle::starts_with(S, "$$A6");
 }
 
-static bool isPlaceholderType(std::string_view S) {
-  return llvm::itanium_demangle::starts_with(S, "_P") ||
-         llvm::itanium_demangle::starts_with(S, "_T");
-}
-
 static FunctionRefQualifier
 demangleFunctionRefQualifier(std::string_view &MangledName) {
   if (consumeFront(MangledName, 'G'))
@@ -1870,8 +1865,6 @@ TypeNode *Demangler::demangleType(std::string_view &MangledName,
     }
   } else if (isCustomType(MangledName)) {
     Ty = demangleCustomType(MangledName);
-  } else if (isPlaceholderType(MangledName)) {
-    Ty = demanglePlaceholderType(MangledName);
   } else {
     Ty = demanglePrimitiveType(MangledName);
   }
@@ -1983,23 +1976,6 @@ CustomTypeNode *Demangler::demangleCustomType(std::string_view &MangledName) {
   if (Error)
     return nullptr;
   return CTN;
-}
-
-PlaceholderTypeNode *
-Demangler::demanglePlaceholderType(std::string_view &MangledName) {
-  assert(MangledName.front() == '_');
-
-  MangledName.remove_prefix(1);
-  const char F = MangledName.front();
-  MangledName.remove_prefix(1);
-  switch (F) {
-  case 'P':
-    return Arena.alloc<PlaceholderTypeNode>(PlaceholderKind::Auto);
-  case 'T':
-    return Arena.alloc<PlaceholderTypeNode>(PlaceholderKind::DecltypeAuto);
-  }
-  Error = true;
-  return nullptr;
 }
 
 // Reads a primitive type.

--- a/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
@@ -149,6 +149,8 @@ void PrimitiveTypeNode::outputPre(OutputBuffer &OB, OutputFlags Flags) const {
     OUTPUT_ENUM_CLASS_VALUE(PrimitiveKind, Double, "double");
     OUTPUT_ENUM_CLASS_VALUE(PrimitiveKind, Ldouble, "long double");
     OUTPUT_ENUM_CLASS_VALUE(PrimitiveKind, Nullptr, "std::nullptr_t");
+    OUTPUT_ENUM_CLASS_VALUE(PrimitiveKind, Auto, "auto");
+    OUTPUT_ENUM_CLASS_VALUE(PrimitiveKind, DecltypeAuto, "decltype(auto)");
   }
   outputQualifiers(OB, Quals, true, false);
 }

--- a/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
@@ -153,6 +153,14 @@ void PrimitiveTypeNode::outputPre(OutputBuffer &OB, OutputFlags Flags) const {
   outputQualifiers(OB, Quals, true, false);
 }
 
+void PlaceholderTypeNode::outputPre(OutputBuffer &OB, OutputFlags Flags) const {
+  switch (PlaceholderKind) {
+    OUTPUT_ENUM_CLASS_VALUE(PlaceholderKind, Auto, "auto");
+    OUTPUT_ENUM_CLASS_VALUE(PlaceholderKind, DecltypeAuto, "decltype(auto)");
+  };
+  outputQualifiers(OB, Quals, true, false);
+}
+
 void NodeArrayNode::output(OutputBuffer &OB, OutputFlags Flags) const {
   output(OB, Flags, ", ");
 }

--- a/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
@@ -153,14 +153,6 @@ void PrimitiveTypeNode::outputPre(OutputBuffer &OB, OutputFlags Flags) const {
   outputQualifiers(OB, Quals, true, false);
 }
 
-void PlaceholderTypeNode::outputPre(OutputBuffer &OB, OutputFlags Flags) const {
-  switch (PlaceholderKind) {
-    OUTPUT_ENUM_CLASS_VALUE(PlaceholderKind, Auto, "auto");
-    OUTPUT_ENUM_CLASS_VALUE(PlaceholderKind, DecltypeAuto, "decltype(auto)");
-  };
-  outputQualifiers(OB, Quals, true, false);
-}
-
 void NodeArrayNode::output(OutputBuffer &OB, OutputFlags Flags) const {
   output(OB, Flags, ", ");
 }

--- a/llvm/test/Demangle/ms-placeholder-return-type.test
+++ b/llvm/test/Demangle/ms-placeholder-return-type.test
@@ -1,0 +1,18 @@
+; RUN: llvm-undname < %s | FileCheck %s
+
+; CHECK-NOT: Invalid mangled name
+
+?TestNonTemplateAuto@@YA@XZ
+; CHECK: __cdecl TestNonTemplateAuto(void)
+
+??$AutoT@X@@YA?A_PXZ
+; CHECK: auto __cdecl AutoT<void>(void)
+
+??$AutoT@X@@YA?B_PXZ
+; CHECK: auto const __cdecl AutoT<void>(void)
+
+??$AutoT@X@@YA?A_TXZ
+; CHECK: decltype(auto) __cdecl AutoT<void>(void)
+
+??$AutoT@X@@YA?B_TXZ
+; CHECK: decltype(auto) const __cdecl AutoT<void>(void)


### PR DESCRIPTION
Properly demangle `_T` and `_P` return type manglings for MSVC 1920+.
Also added a unit test for `@` return type that is used when mangling non-template auto placeholder return type function.

Tested the output against the undname shipped with MSVC 19.40.