### PR TITLE
[mlir] [bufferize] Inplace the operands that must be inplaced.

### DIFF
--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -600,8 +600,12 @@ bool AnalysisState::canOmitTensorCopy(OpOperand &opOperand) const {
 }
 
 bool AnalysisState::isInPlace(OpOperand &opOperand) const {
-  // ToMemrefOps are always in-place.
-  if (isa<ToMemrefOp>(opOperand.getOwner()))
+  // We should always inplace operands that must be inplaced.
+  auto bufferizableOp =
+      getOptions().dynCastBufferizableOp(opOperand.getOwner());
+  if ((bufferizableOp &&
+       bufferizableOp.mustBufferizeInPlace(opOperand, *this)) ||
+      isa<ToMemrefOp>(opOperand.getOwner()))
     return true;
 
   // In the absence of analysis information, OpOperands that bufferize to a


### PR DESCRIPTION
Return true when an op operand marked as "must inplace" in a bufferizable interface, and the operand is the same as the argument of the isInplace function in AnalysisState.

Some operations (e.g., atomic operations) have write effect on certain operands and require in-place bufferization. In such cases, we need to ensure the in-place semantics during the bufferization process.