### PR TITLE
IVDescriptors: clarify getSCEV use in a function (NFC)

### DIFF
--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1479,8 +1479,8 @@ bool InductionDescriptor::isInductionPHI(
     InductionDescriptor &D, const SCEV *Expr,
     SmallVectorImpl<Instruction *> *CastsToIgnore) {
   Type *PhiTy = Phi->getType();
-  // We only handle integer and pointer inductions variables.
-  if (!PhiTy->isIntegerTy() && !PhiTy->isPointerTy())
+  // isSCEVable returns true for integer and pointer types.
+  if (!SE->isSCEVable(PhiTy))
     return false;
 
   // Check that the PHI is consecutive.


### PR DESCRIPTION
getSCEV will assert unless the operand is SCEVable. Replace an instance of the implementation of ScalarEvolution::isSCEVable (which checks that the operand is either integer or pointer type) with a call to the function, to make it clear that the subsequent use of getSCEV will not fail.