### PR TITLE
[analyzer][NFC] Remove a non-actionable dump

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -326,7 +326,6 @@ std::optional<std::string> printReferrer(const MemRegion *Referrer) {
       // warn_init_ptr_member_to_parameter_addr
       return std::nullopt;
     } else {
-      Referrer->dump();
       assert(false && "Unexpected referrer region type.");
       return std::nullopt;
     }


### PR DESCRIPTION
This dump, if it is ever executed, is not actionable by the user and might produce unwanted noise in the stderr.

The original intention behind this dump, to provide maximum information in an unexpected situation, does not outweigh the potential annoyance caused to users who might not even realize that they witnessed an unexpected situation.