### PR TITLE
[NFC] Reserve the number of operands before push_back

### DIFF
--- a/llvm/lib/IR/ConstantsContext.h
+++ b/llvm/lib/IR/ConstantsContext.h
@@ -292,6 +292,7 @@ template <class ConstantClass> struct ConstantAggrKeyType {
   ConstantAggrKeyType(const ConstantClass *C,
                       SmallVectorImpl<Constant *> &Storage) {
     assert(Storage.empty() && "Expected empty storage");
+    Storage.reserve(C->getNumOperands());
     for (unsigned I = 0, E = C->getNumOperands(); I != E; ++I)
       Storage.push_back(C->getOperand(I));
     Operands = Storage;


### PR DESCRIPTION
This reduces the number of allocations inside the loop.

Partially addresses #105836