### PR TITLE
[NFC] Add GIntrinsic::setIntrinsicID

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GenericMachineInstrs.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GenericMachineInstrs.h
@@ -511,6 +511,9 @@ public:
   Intrinsic::ID getIntrinsicID() const {
     return getOperand(getNumExplicitDefs()).getIntrinsicID();
   }
+  void setIntrinsicID(Intrinsic::ID ID) {
+    getOperand(getNumExplicitDefs()).setIntrinsicID(ID);
+  }
 
   bool is(Intrinsic::ID ID) const { return getIntrinsicID() == ID; }
 


### PR DESCRIPTION
Add a function to set the intrinsic ID for GIntrinsic.