### PR TITLE
[analyzer] Fix false positive for mutexes inheriting mutex_base

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerHelpers.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerHelpers.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  This file defines CheckerVisitor.
+//  This file defines various utilities used by checkers.
 //
 //===----------------------------------------------------------------------===//
 
@@ -113,6 +113,10 @@ OperatorKind operationKindFromOverloadedOperator(OverloadedOperatorKind OOK,
                                                  bool IsBinary);
 
 std::optional<SVal> getPointeeVal(SVal PtrSVal, ProgramStateRef State);
+
+/// Returns true if declaration \p D is in std namespace or any nested namespace
+/// or class scope.
+bool isWithinStdNamespace(const Decl *D);
 
 } // namespace ento
 

--- a/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
@@ -245,8 +245,10 @@ static const MemRegion *getRegion(const CallEvent &Call,
                                   const MutexDescriptor &Descriptor,
                                   bool IsLock) {
   return std::visit(
-      [&Call, IsLock](auto &&Descriptor) {
-        return Descriptor.getRegion(Call, IsLock);
+      [&Call, IsLock](auto &Descr) -> const MemRegion * {
+        if (const MemRegion *Reg = Descr.getRegion(Call, IsLock))
+          return Reg->getBaseRegion();
+        return nullptr;
       },
       Descriptor);
 }

--- a/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
@@ -242,13 +242,12 @@ BlockInCriticalSectionChecker::checkDescriptorMatch(const CallEvent &Call,
 }
 
 static const MemRegion *skipStdBaseClassRegion(const MemRegion *Reg) {
-  do {
-    assert(Reg);
+  while (Reg) {
     const auto *BaseClassRegion = dyn_cast<CXXBaseObjectRegion>(Reg);
     if (!BaseClassRegion || !BaseClassRegion->getDecl()->isInStdNamespace())
       break;
     Reg = BaseClassRegion->getSuperRegion();
-  } while (true);
+  }
   return Reg;
 }
 

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -38,6 +38,7 @@
 #include "clang/CrossTU/CrossTranslationUnit.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerHelpers.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/DynamicType.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/DynamicTypeInfo.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h"
@@ -921,17 +922,6 @@ SVal AnyCXXConstructorCall::getCXXThisVal() const {
   if (Data)
     return loc::MemRegionVal(static_cast<const MemRegion *>(Data));
   return UnknownVal();
-}
-
-static bool isWithinStdNamespace(const Decl *D) {
-  const DeclContext *DC = D->getDeclContext();
-  while (DC) {
-    if (const auto *NS = dyn_cast<NamespaceDecl>(DC);
-        NS && NS->isStdNamespace())
-      return true;
-    DC = DC->getParent();
-  }
-  return false;
 }
 
 void AnyCXXConstructorCall::getExtraInvalidatedValues(ValueList &Values,

--- a/clang/lib/StaticAnalyzer/Core/CheckerHelpers.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerHelpers.cpp
@@ -190,5 +190,16 @@ std::optional<SVal> getPointeeVal(SVal PtrSVal, ProgramStateRef State) {
   return std::nullopt;
 }
 
+bool isWithinStdNamespace(const Decl *D) {
+  const DeclContext *DC = D->getDeclContext();
+  while (DC) {
+    if (const auto *NS = dyn_cast<NamespaceDecl>(DC);
+        NS && NS->isStdNamespace())
+      return true;
+    DC = DC->getParent();
+  }
+  return false;
+}
+
 } // namespace ento
 } // namespace clang

--- a/clang/test/Analysis/block-in-critical-section-inheritance.cpp
+++ b/clang/test/Analysis/block-in-critical-section-inheritance.cpp
@@ -29,3 +29,13 @@ void gh_99628() {
   // expected-note@-2 {{Call to blocking function 'sleep' inside of critical section}}
   m.unlock();
 }
+
+void no_false_positive_gh_104241() {
+  std::mutex m;
+  m.lock();
+  // If inheritance not handled properly, this unlock might not match the lock
+  // above because technically they act on different memory regions:
+  // __mutex_base and mutex.
+  m.unlock();
+  sleep(10); // no-warning
+}

--- a/clang/test/Analysis/block-in-critical-section-inheritance.cpp
+++ b/clang/test/Analysis/block-in-critical-section-inheritance.cpp
@@ -128,3 +128,26 @@ void two_custom_mutex_bases_casts_tn(MyMutex &m) {
   sleep(10);
 }
 
+struct MutexVirtBase1 : virtual std::mutex {
+  void lock1() { lock(); }
+  void unlock1() { unlock(); }
+};
+
+struct MutexVirtBase2 : virtual std::mutex {
+  void lock2() { lock(); }
+  void unlock2() { unlock(); }
+};
+
+struct CombinedVirtMutex : MutexVirtBase1, MutexVirtBase2 {};
+
+void virt_inherited_mutexes_same_base_tn1(CombinedVirtMutex &cvt) {
+  cvt.lock1();
+  cvt.unlock1();
+  sleep(10);
+}
+
+void virt_inherited_mutexes_different_bases_tn(CombinedVirtMutex &cvt) {
+  cvt.lock1();
+  cvt.unlock2(); // Despite a different name, unlock2 acts on the same mutex as lock1
+  sleep(10);
+}

--- a/clang/test/Analysis/block-in-critical-section-inheritance.cpp
+++ b/clang/test/Analysis/block-in-critical-section-inheritance.cpp
@@ -39,3 +39,17 @@ void no_false_positive_gh_104241() {
   m.unlock();
   sleep(10); // no-warning
 }
+
+struct TwoMutexes {
+  std::mutex m1;
+  std::mutex m2;
+};
+
+void two_mutexes_false_negative(TwoMutexes &tm) {
+  tm.m1.lock();
+  tm.m2.unlock();
+  // Critical section is associated with tm now so tm.m1 and tm.m2 are
+  // undistinguishiable
+  sleep(10); // False-negative
+  tm.m1.unlock();
+}

--- a/clang/test/Analysis/block-in-critical-section-inheritance.cpp
+++ b/clang/test/Analysis/block-in-critical-section-inheritance.cpp
@@ -45,11 +45,12 @@ struct TwoMutexes {
   std::mutex m2;
 };
 
-void two_mutexes_false_negative(TwoMutexes &tm) {
+void two_mutexes_no_false_negative(TwoMutexes &tm) {
   tm.m1.lock();
+  // expected-note@-1 {{Entering critical section here}}
   tm.m2.unlock();
-  // Critical section is associated with tm now so tm.m1 and tm.m2 are
-  // undistinguishiable
-  sleep(10); // False-negative
+  sleep(10);
+  // expected-warning@-1 {{Call to blocking function 'sleep' inside of critical section}}
+  // expected-note@-2 {{Call to blocking function 'sleep' inside of critical section}}
   tm.m1.unlock();
 }

--- a/clang/test/Analysis/block-in-critical-section-inheritance.cpp
+++ b/clang/test/Analysis/block-in-critical-section-inheritance.cpp
@@ -54,3 +54,77 @@ void two_mutexes_no_false_negative(TwoMutexes &tm) {
   // expected-note@-2 {{Call to blocking function 'sleep' inside of critical section}}
   tm.m1.unlock();
 }
+
+struct MyMutexBase1 : std::mutex {
+  void lock1() { lock(); }
+  void unlock1() { unlock(); }
+};
+struct MyMutexBase2 : std::mutex {
+  void lock2() { lock(); }
+  void unlock2() { unlock(); }
+};
+struct MyMutex : MyMutexBase1, MyMutexBase2 {};
+// MyMutex has two distinct std::mutex as base classes
+
+void custom_mutex_tp(MyMutexBase1 &mb) {
+  mb.lock();
+  // expected-note@-1 {{Entering critical section here}}
+  sleep(10);
+  // expected-warning@-1 {{Call to blocking function 'sleep' inside of critical section}}
+  // expected-note@-2 {{Call to blocking function 'sleep' inside of critical section}}
+  mb.unlock();
+}
+
+void custom_mutex_tn(MyMutexBase1 &mb) {
+  mb.lock();
+  mb.unlock();
+  sleep(10);
+}
+
+void custom_mutex_cast_tp(MyMutexBase1 &mb) {
+  static_cast<std::mutex&>(mb).lock();
+  // expected-note@-1 {{Entering critical section here}}
+  sleep(10);
+  // expected-warning@-1 {{Call to blocking function 'sleep' inside of critical section}}
+  // expected-note@-2 {{Call to blocking function 'sleep' inside of critical section}}
+  static_cast<std::mutex&>(mb).unlock();
+}
+
+void custom_mutex_cast_tn(MyMutexBase1 &mb) {
+  static_cast<std::mutex&>(mb).lock();
+  static_cast<std::mutex&>(mb).unlock();
+  sleep(10);
+}
+
+void two_custom_mutex_bases_fn(MyMutex &m) {
+  m.lock1();
+  m.unlock2();
+  // The critical section is associated with `m` ignoring the fact that m holds
+  // two mutexes. hense unlock2 is considered to unlock the same mutex as lock1
+  // locks
+  sleep(10); // False negative
+  m.unlock1();
+}
+
+void two_custom_mutex_bases_tn(MyMutex &m) {
+  m.lock1();
+  m.unlock1();
+  sleep(10);
+}
+
+void two_custom_mutex_bases_casts_fn(MyMutex &m) {
+  static_cast<MyMutexBase1&>(m).lock();
+  static_cast<MyMutexBase2&>(m).unlock();
+  // The critical section is associated with `m` ignoring the fact that m holds
+  // two mutexes. hense MyMutexBase2::unlock is considered to unlock the same
+  // mutex as MyMutexBase1::lock locks
+  sleep(10); // False negative
+  static_cast<MyMutexBase1&>(m).unlock();
+}
+
+void two_custom_mutex_bases_casts_tn(MyMutex &m) {
+  static_cast<MyMutexBase1&>(m).lock();
+  static_cast<MyMutexBase1&>(m).unlock();
+  sleep(10);
+}
+

--- a/clang/test/Analysis/block-in-critical-section-nested-namespace.cpp
+++ b/clang/test/Analysis/block-in-critical-section-nested-namespace.cpp
@@ -1,0 +1,42 @@
+
+// RUN: %clang_analyze_cc1 \
+// RUN:   -analyzer-checker=unix.BlockInCriticalSection \
+// RUN:   -std=c++11 \
+// RUN:   -analyzer-output text \
+// RUN:   -verify %s
+
+unsigned int sleep(unsigned int seconds) {return 0;}
+namespace std {
+namespace __detail {
+class __mutex_base {
+public:
+  void lock();
+};
+} // namespace __detail
+
+class mutex : public __detail::__mutex_base{
+public:
+  void unlock();
+  bool try_lock();
+};
+} // namespace std
+
+void gh_99628() {
+  std::mutex m;
+  m.lock();
+  // expected-note@-1 {{Entering critical section here}}
+  sleep(10);
+  // expected-warning@-1 {{Call to blocking function 'sleep' inside of critical section}}
+  // expected-note@-2 {{Call to blocking function 'sleep' inside of critical section}}
+  m.unlock();
+}
+
+void no_false_positive_gh_104241() {
+  std::mutex m;
+  m.lock();
+  // If inheritance not handled properly, this unlock might not match the lock
+  // above because technically they act on different memory regions:
+  // __mutex_base and mutex.
+  m.unlock();
+  sleep(10); // no-warning
+}


### PR DESCRIPTION
If a mutex interface is split in inheritance chain, e.g. struct mutex has `unlock` and inherits `lock` from __mutex_base then calls m.lock() and m.unlock() have different "this" targets: m and the __mutex_base of m, which used to confuse the `ActiveCritSections` list.

Taking base region canonicalizes the region used to identify a critical section and enables search in ActiveCritSections list regardless of which class the callee is the member of.

This possibly fixes #104241

CPP-5541