### PR TITLE
[flang][runtime] Correct RANDOM_INIT seed generation

### DIFF
--- a/flang/runtime/random.cpp
+++ b/flang/runtime/random.cpp
@@ -42,7 +42,7 @@ void RTNAME(RandomInit)(bool repeatable, bool /*image_distinct*/) {
 #ifdef CLOCK_REALTIME
       timespec ts;
       clock_gettime(CLOCK_REALTIME, &ts);
-      generator.seed(ts.tv_sec & ts.tv_nsec);
+      generator.seed(ts.tv_sec ^ ts.tv_nsec);
 #else
       generator.seed(time(nullptr));
 #endif


### PR DESCRIPTION
The initial seed was generated from a bitwise AND ("&") of two clock-generated values, instead of an XOR or (best) a truncated integer multiplication.  Maybe I mistyped a shift-7 instead of a shift-6 or shift-8 when I wrote that line, but it was most likely just stupidity.

Fixes https://github.com/llvm/llvm-project/issues/106221.