### PR TITLE
[compiler-rt][test] Move tmp dir creation with env to where dir is run

### DIFF
--- a/compiler-rt/test/profile/Linux/instrprof-dir.c
+++ b/compiler-rt/test/profile/Linux/instrprof-dir.c
@@ -1,7 +1,6 @@
 // RUN: %clang_pgogen -o %t %s
-// RUN: env LLVM_PROFILE_FILE="%t.d/%m.profraw"
 // RUN: rm -fr %t.d
-// RUN: %run %t %t.d
+// RUN: env LLVM_PROFILE_FILE="%t.d/%m.profraw" %run %t %t.d
 
 #include <errno.h>
 #include <unistd.h>


### PR DESCRIPTION
The original test used env to set the LLVM_PROFILE_FILE variable, but because it does not have a subcommand, this is only temporary and does not propogate to the following RUN lines.

NOTE: this patch DOES NOT work.