### PR TITLE
[github][Security] Add the llvm-security-group team as code owner for Security.rst

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,3 +150,6 @@
 
 # libclang/Python bindings
 /clang/bindings/python @DeinAlptraum
+
+# LLVM Security Group documentation
+/llvm/docs/Security.rst @llvm/llvm-security-group


### PR DESCRIPTION
This will help to notify all the LLVM Security Group when pull requests to the documentation are created.