### PR TITLE
[clang] Output location info in separate fields for -ftime-trace

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -136,6 +136,9 @@ Improvements to Clang's diagnostics
 Improvements to Clang's time-trace
 ----------------------------------
 
+- Clang now adds file and line information for -ftime-trace profile as separate fields
+  (as ``event["args"]["file"]`` and ``event["args"]["line"]`` respectively).
+
 Improvements to Coverage Mapping
 --------------------------------
 

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -50,6 +50,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/TimeProfiler.h"
 #include <cassert>
 #include <cstddef>
 #include <map>
@@ -905,6 +906,10 @@ public:
 
   /// Get the file ID for the precompiled preamble if there is one.
   FileID getPreambleFileID() const { return PreambleFileID; }
+
+  /// Set Location information for Time trace events.
+  void setLocationForTimeTrace(SourceLocation Loc,
+                               llvm::TimeTraceMetadata &M) const;
 
   //===--------------------------------------------------------------------===//
   // Methods to create new FileID's and macro expansions.

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -52,6 +52,7 @@
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/DiagnosticSema.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/APFixedPoint.h"
 #include "llvm/ADT/SmallBitVector.h"
@@ -672,12 +673,14 @@ namespace {
   };
 
   // A shorthand time trace scope struct, prints source range, for example
-  // {"name":"EvaluateAsRValue","args":{"detail":"<test.cc:8:21, col:25>"}}}
+  // {"name":"EvaluateAsRValue","args":{"detail":"test.cc", "line":8, "col":21"}}}
   class ExprTimeTraceScope {
   public:
     ExprTimeTraceScope(const Expr *E, const ASTContext &Ctx, StringRef Name)
         : TimeScope(Name, [E, &Ctx] {
-            return E->getSourceRange().printToString(Ctx.getSourceManager());
+            llvm::TimeTraceMetadata M;
+            Ctx.getSourceManager().setLocationForTimeTrace(E->getBeginLoc(), M);
+            return M;
           }) {}
 
   private:

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -1064,6 +1064,14 @@ bool SourceManager::isAtStartOfImmediateMacroExpansion(SourceLocation Loc,
   return true;
 }
 
+void SourceManager::setLocationForTimeTrace(SourceLocation Loc,
+                                            llvm::TimeTraceMetadata &M) const {
+  Loc = getExpansionLoc(Loc);
+  M.File = getFilename(Loc);
+  M.Line = getExpansionLineNumber(Loc);
+  M.Col = getExpansionColumnNumber(Loc);
+}
+
 bool SourceManager::isAtEndOfImmediateMacroExpansion(SourceLocation Loc,
                                                SourceLocation *MacroEnd) const {
   assert(Loc.isValid() && Loc.isMacroID() && "Expected a valid macro loc");

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -16,6 +16,7 @@
 #include "clang/AST/ASTLambda.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Parse/ParseDiagnostic.h"
 #include "clang/Parse/RAIIObjectsForParser.h"
 #include "clang/Sema/DeclSpec.h"
@@ -1255,8 +1256,12 @@ Parser::DeclGroupPtrTy Parser::ParseDeclarationOrFunctionDefinition(
   // Add an enclosing time trace scope for a bunch of small scopes with
   // "EvaluateAsConstExpr".
   llvm::TimeTraceScope TimeScope("ParseDeclarationOrFunctionDefinition", [&]() {
-    return Tok.getLocation().printToString(
-        Actions.getASTContext().getSourceManager());
+    llvm::TimeTraceMetadata M;
+    const SourceManager &SM = Actions.getASTContext().getSourceManager();
+    auto Loc = SM.getExpansionLoc(Tok.getLocation());
+    M.File = SM.getFilename(Loc);
+    M.Line = SM.getExpansionLineNumber(Loc);
+    return M;
   });
 
   if (DS) {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1257,6 +1257,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclarationOrFunctionDefinition(
   // "EvaluateAsConstExpr".
   llvm::TimeTraceScope TimeScope("ParseDeclarationOrFunctionDefinition", [&]() {
     llvm::TimeTraceMetadata M;
+    // Parsing events are not as common as instantiations. Add location for them
+    // without verbose mode check.
     Actions.getASTContext().getSourceManager().setLocationForTimeTrace(
         Tok.getLocation(), M);
     return M;

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1257,10 +1257,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclarationOrFunctionDefinition(
   // "EvaluateAsConstExpr".
   llvm::TimeTraceScope TimeScope("ParseDeclarationOrFunctionDefinition", [&]() {
     llvm::TimeTraceMetadata M;
-    const SourceManager &SM = Actions.getASTContext().getSourceManager();
-    auto Loc = SM.getExpansionLoc(Tok.getLocation());
-    M.File = SM.getFilename(Loc);
-    M.Line = SM.getExpansionLineNumber(Loc);
+    Actions.getASTContext().getSourceManager().setLocationForTimeTrace(
+        Tok.getLocation(), M);
     return M;
   });
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3423,11 +3423,8 @@ Sema::InstantiateClass(SourceLocation PointOfInstantiation,
     llvm::raw_string_ostream OS(M.Detail);
     Instantiation->getNameForDiagnostic(OS, getPrintingPolicy(),
                                         /*Qualified=*/true);
-    if (llvm::isTimeTraceVerbose()) {
-      auto Loc = SourceMgr.getExpansionLoc(Instantiation->getLocation());
-      M.File = SourceMgr.getFilename(Loc);
-      M.Line = SourceMgr.getExpansionLineNumber(Loc);
-    }
+    if (llvm::isTimeTraceVerbose())
+      SourceMgr.setLocationForTimeTrace(Instantiation->getLocation(), M);
     return M;
   });
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -4970,11 +4970,8 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
     llvm::raw_string_ostream OS(M.Detail);
     Function->getNameForDiagnostic(OS, getPrintingPolicy(),
                                    /*Qualified=*/true);
-    if (llvm::isTimeTraceVerbose()) {
-      auto Loc = SourceMgr.getExpansionLoc(Function->getLocation());
-      M.File = SourceMgr.getFilename(Loc);
-      M.Line = SourceMgr.getExpansionLineNumber(Loc);
-    }
+    if (llvm::isTimeTraceVerbose())
+      SourceMgr.setLocationForTimeTrace(Function->getLocation(), M);
     return M;
   });
 

--- a/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
+++ b/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
@@ -4,7 +4,8 @@
 // RUN:   | FileCheck %s
 
 // CHECK-DAG: "name": "ParseDeclarationOrFunctionDefinition"
-// CHECK-DAG: "detail": "{{.*}}check-time-trace-ParseDeclarationOrFunctionDefinition.cpp:15:1"
+// CHECK-DAG: "file": "{{.*}}check-time-trace-ParseDeclarationOrFunctionDefinition.cpp"
+// CHECK-DAG: "line": 16
 // CHECK-DAG: "name": "ParseFunctionDefinition"
 // CHECK-DAG: "detail": "foo"
 // CHECK-DAG: "name": "ParseFunctionDefinition"

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -210,8 +210,8 @@ constexpr int slow_init_list[] = {1, 1, 2, 3, 5, 8, 13, 21}; // 25th line
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
 Frontend (test.cc)
-| ParseDeclarationOrFunctionDefinition (test.cc:2:1)
-| ParseDeclarationOrFunctionDefinition (test.cc:6:1)
+| ParseDeclarationOrFunctionDefinition (test.cc:2)
+| ParseDeclarationOrFunctionDefinition (test.cc:6)
 | | ParseFunctionDefinition (slow_func)
 | | | EvaluateAsRValue (<test.cc:8:21>)
 | | | EvaluateForOverflow (<test.cc:8:21, col:25>)
@@ -223,15 +223,15 @@ Frontend (test.cc)
 | | | | EvaluateAsRValue (<test.cc:8:21, col:25>)
 | | | EvaluateAsBooleanCondition (<test.cc:8:21, col:25>)
 | | | | EvaluateAsRValue (<test.cc:8:21, col:25>)
-| ParseDeclarationOrFunctionDefinition (test.cc:16:1)
+| ParseDeclarationOrFunctionDefinition (test.cc:16)
 | | ParseFunctionDefinition (slow_test)
 | | | EvaluateAsInitializer (slow_value)
 | | | EvaluateAsConstantExpr (<test.cc:17:33, col:59>)
 | | | EvaluateAsConstantExpr (<test.cc:18:11, col:37>)
-| ParseDeclarationOrFunctionDefinition (test.cc:22:1)
+| ParseDeclarationOrFunctionDefinition (test.cc:22)
 | | EvaluateAsConstantExpr (<test.cc:23:31, col:57>)
 | | EvaluateAsRValue (<test.cc:22:14, line:23:58>)
-| ParseDeclarationOrFunctionDefinition (test.cc:25:1)
+| ParseDeclarationOrFunctionDefinition (test.cc:25)
 | | EvaluateAsInitializer (slow_init_list)
 | PerformPendingInstantiations
 )",
@@ -270,7 +270,7 @@ Frontend (test.cc)
 | ParseFunctionDefinition (fooB)
 | ParseFunctionDefinition (fooMTA)
 | ParseFunctionDefinition (fooA)
-| ParseDeclarationOrFunctionDefinition (test.cc:3:5)
+| ParseDeclarationOrFunctionDefinition (test.cc:3)
 | | ParseFunctionDefinition (user)
 | PerformPendingInstantiations
 | | InstantiateFunction (fooA<int>, a.h:7)
@@ -292,7 +292,7 @@ struct {
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
 Frontend (test.c)
-| ParseDeclarationOrFunctionDefinition (test.c:2:1)
+| ParseDeclarationOrFunctionDefinition (test.c:2)
 | | isIntegerConstantExpr (<test.c:3:18>)
 | | EvaluateKnownConstIntCheckOverflow (<test.c:3:18>)
 | PerformPendingInstantiations

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Frontend/CompilerInstance.h"
-#include "clang/Frontend/FrontendActions.h"
 #include "clang/Lex/PreprocessorOptions.h"
 
 #include "llvm/ADT/StringMap.h"
@@ -18,7 +17,6 @@
 #include <stack>
 
 #include "gtest/gtest.h"
-#include <tuple>
 
 using namespace clang;
 using namespace llvm;
@@ -86,6 +84,8 @@ std::string GetMetadata(json::Object *Event) {
       OS << (M.empty() ? "" : ", ") << llvm::sys::path::filename(*File);
     if (auto Line = Args->getInteger("line"))
       OS << ":" << *Line;
+    if (auto Col = Args->getInteger("col"))
+      OS << ":" << *Col;
   }
   return M;
 }
@@ -210,28 +210,28 @@ constexpr int slow_init_list[] = {1, 1, 2, 3, 5, 8, 13, 21}; // 25th line
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
 Frontend (test.cc)
-| ParseDeclarationOrFunctionDefinition (test.cc:2)
-| ParseDeclarationOrFunctionDefinition (test.cc:6)
+| ParseDeclarationOrFunctionDefinition (test.cc:2:1)
+| ParseDeclarationOrFunctionDefinition (test.cc:6:1)
 | | ParseFunctionDefinition (slow_func)
-| | | EvaluateAsRValue (<test.cc:8:21>)
-| | | EvaluateForOverflow (<test.cc:8:21, col:25>)
-| | | EvaluateForOverflow (<test.cc:8:30, col:32>)
-| | | EvaluateAsRValue (<test.cc:9:14>)
-| | | EvaluateForOverflow (<test.cc:9:9, col:14>)
+| | | EvaluateAsRValue (test.cc:8:21)
+| | | EvaluateForOverflow (test.cc:8:21)
+| | | EvaluateForOverflow (test.cc:8:30)
+| | | EvaluateAsRValue (test.cc:9:14)
+| | | EvaluateForOverflow (test.cc:9:9)
 | | | isPotentialConstantExpr (slow_namespace::slow_func)
-| | | EvaluateAsBooleanCondition (<test.cc:8:21, col:25>)
-| | | | EvaluateAsRValue (<test.cc:8:21, col:25>)
-| | | EvaluateAsBooleanCondition (<test.cc:8:21, col:25>)
-| | | | EvaluateAsRValue (<test.cc:8:21, col:25>)
-| ParseDeclarationOrFunctionDefinition (test.cc:16)
+| | | EvaluateAsBooleanCondition (test.cc:8:21)
+| | | | EvaluateAsRValue (test.cc:8:21)
+| | | EvaluateAsBooleanCondition (test.cc:8:21)
+| | | | EvaluateAsRValue (test.cc:8:21)
+| ParseDeclarationOrFunctionDefinition (test.cc:16:1)
 | | ParseFunctionDefinition (slow_test)
 | | | EvaluateAsInitializer (slow_value)
-| | | EvaluateAsConstantExpr (<test.cc:17:33, col:59>)
-| | | EvaluateAsConstantExpr (<test.cc:18:11, col:37>)
-| ParseDeclarationOrFunctionDefinition (test.cc:22)
-| | EvaluateAsConstantExpr (<test.cc:23:31, col:57>)
-| | EvaluateAsRValue (<test.cc:22:14, line:23:58>)
-| ParseDeclarationOrFunctionDefinition (test.cc:25)
+| | | EvaluateAsConstantExpr (test.cc:17:33)
+| | | EvaluateAsConstantExpr (test.cc:18:11)
+| ParseDeclarationOrFunctionDefinition (test.cc:22:1)
+| | EvaluateAsConstantExpr (test.cc:23:31)
+| | EvaluateAsRValue (test.cc:22:14)
+| ParseDeclarationOrFunctionDefinition (test.cc:25:1)
 | | EvaluateAsInitializer (slow_init_list)
 | PerformPendingInstantiations
 )",
@@ -270,12 +270,12 @@ Frontend (test.cc)
 | ParseFunctionDefinition (fooB)
 | ParseFunctionDefinition (fooMTA)
 | ParseFunctionDefinition (fooA)
-| ParseDeclarationOrFunctionDefinition (test.cc:3)
+| ParseDeclarationOrFunctionDefinition (test.cc:3:5)
 | | ParseFunctionDefinition (user)
 | PerformPendingInstantiations
-| | InstantiateFunction (fooA<int>, a.h:7)
-| | | InstantiateFunction (fooB<int>, b.h:3)
-| | | InstantiateFunction (fooMTA<int>, a.h:4)
+| | InstantiateFunction (fooA<int>, a.h:7:10)
+| | | InstantiateFunction (fooB<int>, b.h:3:7)
+| | | InstantiateFunction (fooMTA<int>, a.h:4:5)
 )",
             buildTraceGraph(Json));
 }
@@ -292,9 +292,9 @@ struct {
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
 Frontend (test.c)
-| ParseDeclarationOrFunctionDefinition (test.c:2)
-| | isIntegerConstantExpr (<test.c:3:18>)
-| | EvaluateKnownConstIntCheckOverflow (<test.c:3:18>)
+| ParseDeclarationOrFunctionDefinition (test.c:2:1)
+| | isIntegerConstantExpr (test.c:3:18)
+| | EvaluateKnownConstIntCheckOverflow (test.c:3:18)
 | PerformPendingInstantiations
 )",
             buildTraceGraph(Json));


### PR DESCRIPTION
Uniformly use file and line metadata information in `-ftime-trace` profiles. This makes postprocessing simpler and not fragile.

This removes the column information. This can be added later if the need be as a separate field.