### PR TITLE
workflows/release-tasks: Pass required secrets to all called workflows

### DIFF
--- a/.github/workflows/release-doxygen.yml
+++ b/.github/workflows/release-doxygen.yml
@@ -25,6 +25,10 @@ on:
         description: 'Upload documentation'
         required: false
         type: boolean
+    secrets:
+      RELEASE_TASKS_USER_TOKEN:
+        description: "Secret used to check user permissions."
+        required: false
 
 jobs:
   release-doxygen:
@@ -63,5 +67,6 @@ jobs:
         if: env.upload
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
         run: |
-          ./llvm/utils/release/github-upload-release.py --token "$GITHUB_TOKEN" --release "${{ inputs.release-version }}" --user "${{ github.actor }}" upload --files ./*doxygen*.tar.xz
+          ./llvm/utils/release/github-upload-release.py --token "$GITHUB_TOKEN" --release "${{ inputs.release-version }}" --user "${{ github.actor }}" --user-token "$USER_TOKEN" upload --files ./*doxygen*.tar.xz

--- a/.github/workflows/release-lit.yml
+++ b/.github/workflows/release-lit.yml
@@ -17,6 +17,10 @@ on:
         description: 'Release Version'
         required: true
         type: string
+    secrets:
+      RELEASE_TASKS_USER_TOKEN:
+        description: "Secret used to check user permissions."
+        required: false
 
 jobs:
   release-lit:
@@ -36,8 +40,9 @@ jobs:
       - name: Check Permissions
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
         run: |
-          ./llvm/utils/release/./github-upload-release.py --token "$GITHUB_TOKEN" --user ${{ github.actor }} check-permissions
+          ./llvm/utils/release/./github-upload-release.py --token "$GITHUB_TOKEN" --user ${{ github.actor }} --user-token "$USER_TOKEN" check-permissions
 
       - name: Setup Cpp
         uses: aminya/setup-cpp@v1

--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -16,6 +16,10 @@ on:
         description: Release Version
         required: true
         type: string
+    secrets:
+      RELEASE_TASKS_USER_TOKEN:
+        description: "Secret used to check user permissions."
+        required: false
   # Run on pull_requests for testing purposes.
   pull_request:
     paths:

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -66,6 +66,8 @@ jobs:
     with:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
       upload: true
+    secrets:
+      RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
   release-lit:
     name: Release Lit
@@ -73,6 +75,8 @@ jobs:
     uses: ./.github/workflows/release-lit.yml
     with:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
+    secrets:
+      RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
   release-binaries:
     name: Build Release Binaries
@@ -98,9 +102,6 @@ jobs:
       upload: true
       runs-on: ${{ matrix.runs-on }}
     secrets:
-      # This will be empty for pull_request events, but that's fine, because
-      # the release-binaries workflow does not use this secret for the
-      # pull_request event.
       RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
   release-sources:
@@ -114,3 +115,5 @@ jobs:
     uses: ./.github/workflows/release-sources.yml
     with:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
+    secrets:
+      RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -97,6 +97,11 @@ jobs:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
       upload: true
       runs-on: ${{ matrix.runs-on }}
+    secrets:
+      # This will be empty for pull_request events, but that's fine, because
+      # the release-binaries workflow does not use this secret for the
+      # pull_request event.
+      RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
   release-sources:
     name: Package Release Sources

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -66,6 +66,7 @@ jobs:
     with:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
       upload: true
+    # Called workflows don't have access to secrets by default, so we need to explicitly pass secrets that we use.
     secrets:
       RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
@@ -75,6 +76,7 @@ jobs:
     uses: ./.github/workflows/release-lit.yml
     with:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
+    # Called workflows don't have access to secrets by default, so we need to explicitly pass secrets that we use.
     secrets:
       RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
@@ -101,6 +103,7 @@ jobs:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
       upload: true
       runs-on: ${{ matrix.runs-on }}
+    # Called workflows don't have access to secrets by default, so we need to explicitly pass secrets that we use.
     secrets:
       RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
@@ -115,5 +118,6 @@ jobs:
     uses: ./.github/workflows/release-sources.yml
     with:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
+    # Called workflows don't have access to secrets by default, so we need to explicitly pass secrets that we use.
     secrets:
       RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}


### PR DESCRIPTION
Called workflows don't have access to secrets by default, so we need to explicitly pass secrets that we use.