### PR TITLE
[mlir][GPU] Fix docs modified by #94910

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td
@@ -43,7 +43,7 @@ def GPUTargetAttrInterface : AttrInterface<"TargetAttrInterface"> {
     InterfaceMethod<[{
         Creates a GPU object attribute from a binary string.
 
-        The `module` parameter must be a GPU Module Op and can be used to
+        The `module` parameter must be a `GPUModuleOp` and can be used to
         retrieve additional information like the list of kernels in the binary.
         The `object` parameter is a binary string. The `options` parameter is
         meant to be used for passing additional options that are not in the

--- a/mlir/include/mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td
@@ -43,6 +43,8 @@ def GPUTargetAttrInterface : AttrInterface<"TargetAttrInterface"> {
     InterfaceMethod<[{
         Creates a GPU object attribute from a binary string.
 
+        The `module` parameter must be a GPU Module Op and can be used to
+        retrieve additional information like the list of kernels in the binary.
         The `object` parameter is a binary string. The `options` parameter is
         meant to be used for passing additional options that are not in the
         attribute.

--- a/mlir/unittests/Target/LLVM/SerializeToLLVMBitcode.cpp
+++ b/mlir/unittests/Target/LLVM/SerializeToLLVMBitcode.cpp
@@ -102,6 +102,7 @@ TEST_F(MLIRTargetLLVM, SKIP_WITHOUT_NATIVE(SerializeToLLVMBitcode)) {
 std::optional<SmallVector<char, 0>>
 TargetAttrImpl::serializeToObject(Attribute attribute, Operation *module,
                                   const gpu::TargetOptions &options) const {
+  // Set a dummy attr to be retrieved by `createObject`.
   module->setAttr("serialize_attr", UnitAttr::get(module->getContext()));
   std::string targetTriple = llvm::sys::getProcessTriple();
   LLVM::ModuleToObject serializer(*module, targetTriple, "", "");
@@ -112,6 +113,8 @@ Attribute
 TargetAttrImpl::createObject(Attribute attribute, Operation *module,
                              const SmallVector<char, 0> &object,
                              const gpu::TargetOptions &options) const {
+  // Create a GPU object with the GPU module dictionary as the object
+  // properties.
   return gpu::ObjectAttr::get(
       module->getContext(), attribute, gpu::CompilationTarget::Offload,
       StringAttr::get(module->getContext(),
@@ -119,6 +122,9 @@ TargetAttrImpl::createObject(Attribute attribute, Operation *module,
       module->getAttrDictionary());
 }
 
+// This test checks the correct functioning of `TargetAttrInterface` as an API.
+// In particular, it shows how `TargetAttrInterface::createObject` can leverage
+// the `module` operation argument to retrieve information from the module.
 TEST_F(MLIRTargetLLVM, SKIP_WITHOUT_NATIVE(TargetAttrAPI)) {
   MLIRContext context(registry);
   context.loadAllAvailableDialects();


### PR DESCRIPTION
Fix docs modified by #94910 by adding information about the `module` argument in `gpu::TargetAttrInterface::createObject`.