### PR TITLE
[clang] Update C++ DR page

### DIFF
--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -6,7 +6,7 @@
 // RUN: %clang_cc1 -std=c++23 -pedantic-errors -verify=expected %s
 // RUN: %clang_cc1 -std=c++2c -pedantic-errors -verify=expected %s
 
-namespace cwg2917 { // cwg2917: 20 open 2024-07-30
+namespace cwg2917 { // cwg2917: 20 review 2024-07-30
 template <typename>
 class Foo;
 
@@ -33,7 +33,7 @@ void *operator new(std::size_t, void *p) { return p; }
 void* operator new[] (std::size_t, void* p) {return p;}
 
 
-namespace cwg2922 { // cwg2922: 20 open 2024-07-10
+namespace cwg2922 { // cwg2922: 20 tentatively ready 2024-07-10
 union U { int a, b; };
 constexpr U nondeterministic(bool i) {
   if(i) {

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -17208,7 +17208,7 @@ objects</td>
   </tr>
   <tr class="open" id="2899">
     <td><a href="https://cplusplus.github.io/CWG/issues/2899.html">2899</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Bad value representations should cause undefined behavior</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17220,7 +17220,7 @@ objects</td>
   </tr>
   <tr class="open" id="2901">
     <td><a href="https://cplusplus.github.io/CWG/issues/2901.html">2901</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Unclear semantics for near-match aliased access</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17262,7 +17262,7 @@ objects</td>
   </tr>
   <tr class="open" id="2908">
     <td><a href="https://cplusplus.github.io/CWG/issues/2908.html">2908</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Counting physical source lines for <TT>__LINE__</TT></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17292,43 +17292,43 @@ objects</td>
   </tr>
   <tr class="open" id="2913">
     <td><a href="https://cplusplus.github.io/CWG/issues/2913.html">2913</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Grammar for <I>deduction-guide</I> has <I>requires-clause</I> in the wrong position</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2914">
     <td><a href="https://cplusplus.github.io/CWG/issues/2914.html">2914</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Unclear order of initialization of static and thread-local variables</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2915">
     <td><a href="https://cplusplus.github.io/CWG/issues/2915.html">2915</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Explicit object parameters of type <TT>void</TT></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2916">
     <td><a href="https://cplusplus.github.io/CWG/issues/2916.html">2916</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Variable template partial specializations should not be declared <TT>static</TT></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2917">
     <td><a href="https://cplusplus.github.io/CWG/issues/2917.html">2917</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Disallow multiple <I>friend-type-specifier</I>s for a friend template</td>
     <td title="Clang 20 implements 2024-07-30 resolution" align="center">Not Resolved*</td>
   </tr>
   <tr class="open" id="2918">
     <td><a href="https://cplusplus.github.io/CWG/issues/2918.html">2918</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Consideration of constraints for address of overloaded function</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2919">
     <td><a href="https://cplusplus.github.io/CWG/issues/2919.html">2919</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Conversion function candidates for initialization of const lvalue reference</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17340,15 +17340,45 @@ objects</td>
   </tr>
   <tr class="open" id="2921">
     <td><a href="https://cplusplus.github.io/CWG/issues/2921.html">2921</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Exporting redeclarations of entities not attached to a named module</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2922">
     <td><a href="https://cplusplus.github.io/CWG/issues/2922.html">2922</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>constexpr placement-new is too permissive</td>
     <td title="Clang 20 implements 2024-07-10 resolution" align="center">Not Resolved*</td>
+  </tr>
+  <tr class="open" id="2923">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2923.html">2923</a></td>
+    <td>open</td>
+    <td>Note about infinite loops and execution steps</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2924">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2924.html">2924</a></td>
+    <td>open</td>
+    <td>Undefined behavior during constant evaluation</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2925">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2925.html">2925</a></td>
+    <td>open</td>
+    <td>Deleting a pointer to an incomplete enumeration type</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2926">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2926.html">2926</a></td>
+    <td>open</td>
+    <td>Lookup context for dependent qualified names</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2927">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2927.html">2927</a></td>
+    <td>open</td>
+    <td>Unclear status of translation unit with <TT>module</TT> keyword</td>
+    <td align="center">Not resolved</td>
   </tr></table>
 
 </div>


### PR DESCRIPTION
[CWG2917](https://cplusplus.github.io/CWG/issues/2917.html) got a new proposed resolution that is different from the one the test has been written against.

[CWG2922](https://cplusplus.github.io/CWG/issues/2922.html) apparently the initial "possible resolution" was approved without changes.