### PR TITLE
workflows/release-binaries: Remove .git/config file from artifacts

### DIFF
--- a/.github/workflows/release-binaries-save-stage/action.yml
+++ b/.github/workflows/release-binaries-save-stage/action.yml
@@ -21,10 +21,9 @@ runs:
     - name: Package Build and Source Directories
       shell: bash
       run: |
-        # Remove git directory so we avoid leaking secrets stored in .git/config.
+        # Remove .git/config to avoid leaking GITHUB_TOKEN stored there.
         # See https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/
-        # This also helps reduce the size of the archive.
-        rm -Rf .git/
+        rm -Rf .git/config
         # Windows does not support symlinks, so we need to dereference them.
         tar --exclude build/ ${{ (runner.os == 'Windows' && '-h') || '' }} -c . | zstd -T0 -c > ../llvm-project.tar.zst
         mv ../llvm-project.tar.zst .

--- a/.github/workflows/release-binaries-save-stage/action.yml
+++ b/.github/workflows/release-binaries-save-stage/action.yml
@@ -10,6 +10,9 @@ inputs:
     required: true
     type: 'string'
 
+permissions:
+  contents: read
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/release-binaries-save-stage/action.yml
+++ b/.github/workflows/release-binaries-save-stage/action.yml
@@ -18,6 +18,10 @@ runs:
     - name: Package Build and Source Directories
       shell: bash
       run: |
+        # Remove git directory so we avoid leaking secrets stored in .git/config.
+        # See https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/
+        # This also helps reduce the size of the archive.
+        rm -Rf .git/
         # Windows does not support symlinks, so we need to dereference them.
         tar --exclude build/ ${{ (runner.os == 'Windows' && '-h') || '' }} -c . | zstd -T0 -c > ../llvm-project.tar.zst
         mv ../llvm-project.tar.zst .


### PR DESCRIPTION
The .git/config file contains an auth token that can be leaked if the .git directory is included in a workflow artifact.