### PR TITLE
[SandboxIR] Add test that checks if classof is missing.

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -2744,6 +2744,10 @@ public:
          AtomicOrdering SuccessOrdering, AtomicOrdering FailureOrdering,
          BasicBlock *InsertAtEnd, Context &Ctx,
          SyncScope::ID SSID = SyncScope::System, const Twine &Name = "");
+
+  static bool classof(const Value *From) {
+    return From->getSubclassID() == ClassID::AtomicCmpXchg;
+  }
 };
 
 class AllocaInst final : public UnaryInstruction {

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -4317,3 +4317,10 @@ define void @foo() {
   EXPECT_EQ(NewUIEnd->getParent(), BB);
   EXPECT_EQ(NewUIEnd->getNextNode(), nullptr);
 }
+
+/// Makes sure that all Instruction sub-classes have a classof().
+TEST_F(SandboxIRTest, CheckClassof) {
+#define DEF_INSTR(ID, OPC, CLASS)                                              \
+  EXPECT_NE(&sandboxir::CLASS::classof, &sandboxir::Instruction::classof);
+#include "llvm/SandboxIR/SandboxIRValues.def"
+}


### PR DESCRIPTION
Forgetting to implement an `<Instruction Subclass>::classof()` function does not cause any failures because it falls back to Instruction::classof(). This patch adds an explicit check for all instruction classes to confirm that they have a classof implementation.