### PR TITLE
[llvm][llvm-lit] Enabled lit internal shell for llvm test suite

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -23,7 +23,7 @@ config.name = "LLVM"
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-    use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -18,7 +18,18 @@ from lit.llvm.subst import ToolSubst
 config.name = "LLVM"
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# We prefer the lit internal shell which provides a better user experience on failures
+# unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+
+config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
+
+# FIXME: Tests that REQUIRES: shell are unsupported by the lit internal shell
+if use_lit_shell:
+    config.available_features.discard("shell")
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.


### PR DESCRIPTION
This patch sets lit's internal shell to be the default shell when running llvm tests. Tests that `REQUIRES: shell` are not currently supported by the internal shell, so those tests are skipped with this implementation.

Resolves https://github.com/llvm/llvm-project/issues/102697. 