### PR TITLE
[llvm] Prefer StringRef::substr to StringRef::slice (NFC)

### DIFF
--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -298,7 +298,7 @@ Pattern::parseVariable(StringRef &Str, const SourceMgr &SM) {
     ++I;
 
   if (I == Str.size())
-    return ErrorDiagnostic::get(SM, Str.slice(I, StringRef::npos),
+    return ErrorDiagnostic::get(SM, Str.substr(I),
                                 StringRef("empty ") +
                                     (IsPseudo ? "pseudo " : "global ") +
                                     "variable name");

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -556,9 +556,9 @@ static Expected<int64_t> parseChangeSectionLMA(StringRef ArgValue,
                                                StringRef OptionName) {
   StringRef StringValue;
   if (ArgValue.starts_with("*+")) {
-    StringValue = ArgValue.slice(2, StringRef::npos);
+    StringValue = ArgValue.substr(2);
   } else if (ArgValue.starts_with("*-")) {
-    StringValue = ArgValue.slice(1, StringRef::npos);
+    StringValue = ArgValue.substr(1);
   } else if (ArgValue.contains("=")) {
     return createStringError(errc::invalid_argument,
                              "bad format for " + OptionName +
@@ -608,7 +608,7 @@ parseChangeSectionAddr(StringRef ArgValue, StringRef OptionName,
           SectionPattern, SectionMatchStyle, ErrorCallback)))
     return std::move(E);
 
-  StringRef Value = ArgValue.slice(LastSymbolIndex + 1, StringRef::npos);
+  StringRef Value = ArgValue.substr(LastSymbolIndex + 1);
   if (Value.empty()) {
     switch (UpdateSymbol) {
     case '+':

--- a/llvm/unittests/Support/VirtualFileSystemTest.cpp
+++ b/llvm/unittests/Support/VirtualFileSystemTest.cpp
@@ -1583,7 +1583,7 @@ public:
       IntrusiveRefCntPtr<vfs::FileSystem> ExternalFS = new DummyFileSystem(),
       StringRef YAMLFilePath = "") {
     std::string VersionPlusContent("{\n  'version':0,\n");
-    VersionPlusContent += Content.slice(Content.find('{') + 1, StringRef::npos);
+    VersionPlusContent += Content.substr(Content.find('{') + 1);
     return getFromYAMLRawString(VersionPlusContent, ExternalFS, YAMLFilePath);
   }
 


### PR DESCRIPTION
S.substr(N) is simpler than S.slice(N, StringRef::npos). Also, substr
is probably better recognizable than slice thanks to
std::string_view::substr.
