### PR TITLE
[LLD] Improve linker script handing in LLD 

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -136,10 +136,9 @@ std::function<ExprValue()> ScriptExpr::getExpr() const {
   // reinterpret_cast<uintptr_t>(this) << "\n";
   switch (kind_) {
   case ExprKind::Constant:
-    return static_cast<const ConstantExpr *>(this)->getExpr();
+    return static_cast<const ConstantExpr *>(this)->getConstantExpr();
   case ExprKind::Dynamic: {
     auto expr = static_cast<const DynamicExpr *>(this);
-    // llvm::errs() << "expr = " <<
     return expr->getImpl();
   }
   default:
@@ -148,9 +147,11 @@ std::function<ExprValue()> ScriptExpr::getExpr() const {
 }
 
 ExprValue ScriptExpr::getExprValue() const {
+  // llvm::errs() << "getExprValue: " << static_cast<int>(kind_) << ", " <<
+  // reinterpret_cast<uintptr_t>(this) << "\n";
   switch (kind_) {
   case ExprKind::Constant:
-    return static_cast<const ConstantExpr *>(this)->getExprValue();
+    return static_cast<const ConstantExpr *>(this)->getConstantExprValue();
   case ExprKind::Dynamic:
     return static_cast<const DynamicExpr *>(this)->getImpl()();
   default:

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -131,6 +131,17 @@ uint64_t ExprValue::getSectionOffset() const {
   return getValue() - getSecAddr();
 }
 
+std::function<ExprValue()> ScriptExpr::getExpr() const {
+  switch (kind_) {
+  case ExprKind::Constant:
+    return static_cast<const ConstantExpr *>(this)->getVal();
+  case ExprKind::Dynamic:
+    return static_cast<const DynamicExpr *>(this)->getImpl();
+  default:
+    return [] { return ExprValue(0); };
+  };
+}
+
 OutputDesc *LinkerScript::createOutputSection(StringRef name,
                                               StringRef location) {
   OutputDesc *&secRef = nameToOutputSection[CachedHashStringRef(name)];

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -132,11 +132,16 @@ uint64_t ExprValue::getSectionOffset() const {
 }
 
 std::function<ExprValue()> ScriptExpr::getExpr() const {
+  // llvm::errs() << "getExpr: " << static_cast<int>(kind_) << ", " <<
+  // reinterpret_cast<uintptr_t>(this) << "\n";
   switch (kind_) {
   case ExprKind::Constant:
     return static_cast<const ConstantExpr *>(this)->getVal();
-  case ExprKind::Dynamic:
-    return static_cast<const DynamicExpr *>(this)->getImpl();
+  case ExprKind::Dynamic: {
+    auto expr = static_cast<const DynamicExpr *>(this);
+    // llvm::errs() << "expr = " <<
+    return expr->getImpl();
+  }
   default:
     return [] { return ExprValue(0); };
   };

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -160,7 +160,7 @@ uint64_t ScriptExpr::getExprValueAlignValue() const {
   return e.getValue();
 }
 
-uint64_t BinaryExpr::evaluateSymbolAssignment() {
+ExprValue BinaryExpr::evaluateSymbolAssignment() {
   switch (op_[0]) {
   case '*':
     return LHS.getValue() * RHS.getValue();
@@ -169,7 +169,22 @@ uint64_t BinaryExpr::evaluateSymbolAssignment() {
       return LHS.getValue() / rv;
     error(loc_ + ": division by zero");
     return 0;
-    // case '+':
+  case '+':
+    return add(LHS, RHS);
+  case '-':
+    return sub(LHS, RHS);
+  case '<':
+    return LHS.getValue() << RHS.getValue() % 64;
+  case '>':
+    return LHS.getValue() >> RHS.getValue() % 64;
+  case '&':
+    return LHS.getValue() & RHS.getValue();
+  case '^':
+    return LHS.getValue() ^ RHS.getValue();
+  case '|':
+    return LHS.getValue() | RHS.getValue();
+  default:
+    llvm_unreachable("");
   }
   return 0;
 }

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -239,8 +239,7 @@ ExprValue BinaryExpr::evaluateBinaryOperands() const {
   case Op::OrAssign:
     return LHS->getExprValue().getValue() | RHS->getExprValue().getValue();
   case Op::Invalid:
-  default:
-    llvm_unreachable("invalid operator");
+    error(loc_ + ": invalid operator");
   }
 }
 

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -140,8 +140,21 @@ ExprValue ScriptExpr::getExprValue() const {
     return static_cast<const DynamicExpr *>(this)->getExprValue();
   case ExprKind::Binary:
     return static_cast<const BinaryExpr *>(this)->getExprValue();
+  case ExprKind::Unary:
+    return static_cast<const UnaryExpr *>(this)->getExprValue();
   default:
     return ExprValue(0);
+  }
+}
+
+ExprValue UnaryExpr::getExprValue() const {
+  switch (op_[0]) {
+  case '~':
+    return ExprValue(~operand_->getExprValue().getValue());
+  case '!':
+    return ExprValue(!operand_->getExprValue().getValue());
+  case '-':
+    return ExprValue(-operand_->getExprValue().getValue());
   }
 }
 

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -132,7 +132,7 @@ uint64_t ExprValue::getSectionOffset() const {
   return getValue() - getSecAddr();
 }
 
-ExprValue ScriptExpr::getExprValue() const {
+ExprValue Expr::getExprValue() const {
   switch (kind_) {
   case ExprKind::Constant:
     return static_cast<const ConstantExpr *>(this)->getExprValue();
@@ -333,7 +333,7 @@ void LinkerScript::expandOutputSection(uint64_t size) {
   expandMemoryRegions(size);
 }
 
-void LinkerScript::setDot(ScriptExpr *e, const Twine &loc, bool inSec) {
+void LinkerScript::setDot(Expr *e, const Twine &loc, bool inSec) {
   uint64_t val = e->getExprValue().getValue();
   // If val is smaller and we are in an output section, record the error and
   // report it if this is the last assignAddresses iteration. dot may be smaller

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -24,6 +24,7 @@
 #include "lld/Common/Strings.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Endian.h"
@@ -145,22 +146,35 @@ ExprValue ScriptExpr::getExprValue() const {
 }
 
 BinaryExpr::Op BinaryExpr::stringToOp(const StringRef op) {
-  static const std::unordered_map<llvm::StringRef, Op> opMap = {
-      {"+", Op::Add},        {"-", Op::Sub},         {"*", Op::Mul},
-      {"/", Op::Div},        {"%", Op::Mod},         {"<<", Op::Shl},
-      {">>", Op::Shr},       {"&", Op::And},         {"|", Op::Or},
-      {"^", Op::Xor},        {"&&", Op::LAnd},       {"||", Op::LOr},
-      {"==", Op::Eq},        {"!=", Op::Neq},        {"<", Op::Lt},
-      {">", Op::Gt},         {"<=", Op::Leq},        {">=", Op::Geq},
-      {"+=", Op::AddAssign}, {"-=", Op::SubAssign},  {"*=", Op::MulAssign},
-      {"/=", Op::DivAssign}, {"<<=", Op::ShlAssign}, {">>=", Op::ShrAssign},
-      {"&=", Op::AndAssign}, {"|=", Op::OrAssign},   {"^=", Op::XorAssign}};
-
-  auto it = opMap.find(op);
-  if (it != opMap.end()) {
-    return it->second;
-  }
-  return Op::Invalid;
+  return llvm::StringSwitch<Op>(op)
+      .Case("+", Op::Add)
+      .Case("-", Op::Sub)
+      .Case("*", Op::Mul)
+      .Case("/", Op::Div)
+      .Case("%", Op::Mod)
+      .Case("<<", Op::Shl)
+      .Case(">>", Op::Shr)
+      .Case("&", Op::And)
+      .Case("|", Op::Or)
+      .Case("^", Op::Xor)
+      .Case("&&", Op::LAnd)
+      .Case("||", Op::LOr)
+      .Case("==", Op::Eq)
+      .Case("!=", Op::Neq)
+      .Case("<", Op::Lt)
+      .Case(">", Op::Gt)
+      .Case("<=", Op::Leq)
+      .Case(">=", Op::Geq)
+      .Case("+=", Op::AddAssign)
+      .Case("-=", Op::SubAssign)
+      .Case("*=", Op::MulAssign)
+      .Case("/=", Op::DivAssign)
+      .Case("<<=", Op::ShlAssign)
+      .Case(">>=", Op::ShrAssign)
+      .Case("&=", Op::AndAssign)
+      .Case("|=", Op::OrAssign)
+      .Case("^=", Op::XorAssign)
+      .Default(Op::Invalid);
 }
 
 ExprValue BinaryExpr::getExprValue() const {

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -131,31 +131,14 @@ uint64_t ExprValue::getSectionOffset() const {
   return getValue() - getSecAddr();
 }
 
-std::function<ExprValue()> ScriptExpr::getExpr() const {
-  switch (kind_) {
-  case ExprKind::Constant:
-    return static_cast<const ConstantExpr *>(this)->getConstantExpr();
-  case ExprKind::Dynamic: {
-    auto expr = static_cast<const DynamicExpr *>(this);
-    return expr->getImpl();
-  }
-  case ExprKind::Binary: {
-    auto expr = static_cast<const BinaryExpr *>(this);
-    return [=] { return expr->evaluateBinaryOperands(); };
-  }
-  default:
-    return [] { return ExprValue(0); };
-  };
-}
-
 ExprValue ScriptExpr::getExprValue() const {
   switch (kind_) {
   case ExprKind::Constant:
-    return static_cast<const ConstantExpr *>(this)->getConstantExprValue();
+    return static_cast<const ConstantExpr *>(this)->getExprValue();
   case ExprKind::Dynamic:
-    return static_cast<const DynamicExpr *>(this)->getImpl()();
+    return static_cast<const DynamicExpr *>(this)->getExprValue();
   case ExprKind::Binary:
-    return static_cast<const BinaryExpr *>(this)->evaluateBinaryOperands();
+    return static_cast<const BinaryExpr *>(this)->getExprValue();
   default:
     return ExprValue(0);
   }
@@ -180,7 +163,7 @@ BinaryExpr::Op BinaryExpr::stringToOp(const StringRef op) {
   return Op::Invalid;
 }
 
-ExprValue BinaryExpr::evaluateBinaryOperands() const {
+ExprValue BinaryExpr::getExprValue() const {
   switch (opcode) {
   case Op::Add:
   case Op::AddAssign:

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -136,8 +136,8 @@ ExprValue Expr::getExprValue() const {
   switch (kind_) {
   case ExprKind::Constant:
     return static_cast<const ConstantExpr *>(this)->getExprValue();
-  case ExprKind::Dynamic:
-    return static_cast<const DynamicExpr *>(this)->getExprValue();
+  case ExprKind::Fallback:
+    return static_cast<const FallbackExpr *>(this)->getExprValue();
   case ExprKind::Binary:
     return static_cast<const BinaryExpr *>(this)->getExprValue();
   case ExprKind::Unary:

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -134,7 +134,7 @@ public:
              const std::string loc)
       : ScriptExpr(ExprKind::Binary), op_(op), LHS(LHS), RHS(RHS), loc_(loc) {}
 
-  uint64_t evaluateSymbolAssignment();
+  ExprValue evaluateSymbolAssignment();
   // Some operations only support one non absolute value. Move the
   // absolute one to the right hand side for convenience.
   static void moveAbsRight(ExprValue &a, ExprValue &b);

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -129,12 +129,10 @@ private:
 
 class BinaryExpr : public ScriptExpr {
 public:
-  enum class Opcode { LNot, Minus, Not, Plus };
-  BinaryExpr(StringRef op, const ExprValue LHS, const ExprValue RHS,
+  BinaryExpr(StringRef op, ScriptExpr *LHS, ScriptExpr *RHS,
              const std::string loc)
       : ScriptExpr(ExprKind::Binary), op_(op), LHS(LHS), RHS(RHS), loc_(loc) {}
-
-  ExprValue evaluateSymbolAssignment();
+  ExprValue evaluateBinaryOperands() const;
   // Some operations only support one non absolute value. Move the
   // absolute one to the right hand side for convenience.
   static void moveAbsRight(ExprValue &a, ExprValue &b);
@@ -146,7 +144,8 @@ public:
 
 private:
   StringRef op_;
-  const ExprValue LHS, RHS;
+  // const ExprValue LHS, RHS;
+  const ScriptExpr *LHS, *RHS;
   std::string loc_;
 };
 

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -86,14 +86,17 @@ protected:
 
 public:
   ExprKind getKind() const { return kind_; }
+  std::function<ExprValue()> getExpr() const;
 };
 
 class ConstantExpr : public ScriptExpr {
 public:
   ConstantExpr(ExprValue val) : ScriptExpr(ExprKind::Constant), val_(val) {}
-  ConstantExpr(uint64_t val)
-      : ScriptExpr(ExprKind::Constant), val_(ExprValue(val)) {}
-  ExprValue getVal() const { return val_; }
+  // ConstantExpr(uint64_t val)
+  //     : ScriptExpr(ExprKind::Constant), val_(val) {}
+  std::function<ExprValue()> getVal() const {
+    return [=] { return val_; };
+  }
 
 private:
   ExprValue val_;
@@ -122,6 +125,7 @@ private:
 
 class BinaryExpr : public ScriptExpr {
 public:
+  enum class Opcode { LNot, Minus, Not, Plus };
   static const BinaryExpr *create();
 
 private:

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -130,13 +130,24 @@ private:
 class BinaryExpr : public ScriptExpr {
 public:
   enum class Opcode { LNot, Minus, Not, Plus };
-  static const BinaryExpr *create();
+  BinaryExpr(StringRef op, const ExprValue LHS, const ExprValue RHS,
+             const std::string loc)
+      : ScriptExpr(ExprKind::Binary), op_(op), LHS(LHS), RHS(RHS), loc_(loc) {}
+
+  uint64_t evaluateSymbolAssignment();
+  // Some operations only support one non absolute value. Move the
+  // absolute one to the right hand side for convenience.
+  static void moveAbsRight(ExprValue &a, ExprValue &b);
+  static ExprValue add(ExprValue a, ExprValue b);
+  static ExprValue sub(ExprValue a, ExprValue b);
+  static ExprValue bitAnd(ExprValue a, ExprValue b);
+  static ExprValue bitXor(ExprValue a, ExprValue b);
+  static ExprValue bitOr(ExprValue a, ExprValue b);
 
 private:
-  BinaryExpr(const ExprValue *LHS, const ExprValue *RHS)
-      : ScriptExpr(ExprKind::Binary), LHS(LHS), RHS(RHS) {}
-
-  const ExprValue *LHS, *RHS;
+  StringRef op_;
+  const ExprValue LHS, RHS;
+  std::string loc_;
 };
 
 // This enum is used to implement linker script SECTIONS command.

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -13,6 +13,7 @@
 #include "InputSection.h"
 #include "Writer.h"
 #include "lld/Common/LLVM.h"
+#include "lld/Common/Memory.h"
 #include "lld/Common/Strings.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -91,9 +92,8 @@ public:
 
 class ConstantExpr : public ScriptExpr {
 public:
-  ConstantExpr(ExprValue val) : ScriptExpr(ExprKind::Constant), val_(val) {}
-  // ConstantExpr(uint64_t val)
-  //     : ScriptExpr(ExprKind::Constant), val_(val) {}
+  // ConstantExpr(ExprValue val) : ScriptExpr(ExprKind::Constant), val_(val) {}
+  ConstantExpr(uint64_t val) : ScriptExpr(ExprKind::Constant), val_(val) {}
   std::function<ExprValue()> getVal() const {
     return [=] { return val_; };
   }
@@ -104,14 +104,14 @@ private:
 
 class DynamicExpr : public ScriptExpr {
 public:
-  static DynamicExpr create(std::function<ExprValue()> impl) {
-    return DynamicExpr(impl);
-  }
+  // static DynamicExpr create(std::function<ExprValue()> impl) {
+  //   return DynamicExpr(impl);
+  // }
   std::function<ExprValue()> getImpl() const { return impl_; }
-
-private:
   DynamicExpr(std::function<ExprValue()> impl)
       : ScriptExpr(ExprKind::Dynamic), impl_(impl) {}
+
+private:
   std::function<ExprValue()> impl_;
 };
 

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -96,13 +96,14 @@ class ConstantExpr : public ScriptExpr {
 public:
   // ConstantExpr(ExprValue val) : ScriptExpr(ExprKind::Constant), val_(val) {}
   ConstantExpr(uint64_t val) : ScriptExpr(ExprKind::Constant), val_(val) {}
-  std::function<ExprValue()> getExpr() const {
+  std::function<ExprValue()> getConstantExpr() const {
     return [=] { return val_; };
   }
-  ExprValue getExprValue() const { return val_; }
+  ExprValue getConstantExprValue() const { return ExprValue(val_); }
 
 private:
-  ExprValue val_;
+  // ExprValue val_;
+  uint64_t val_;
 };
 
 class DynamicExpr : public ScriptExpr {
@@ -321,7 +322,7 @@ struct ByteCommand : SectionCommand {
   // Keeps string representing the command. Used for -Map" is perhaps better.
   std::string commandString;
 
-  ScriptExpr *expression;
+  ScriptExpr *expression = nullptr;
 
   // This is just an offset of this assignment command in the output section.
   unsigned offset;

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -129,9 +129,42 @@ private:
 
 class BinaryExpr : public ScriptExpr {
 public:
+  enum class Op {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Shl,
+    Shr,
+    And,
+    Or,
+    Xor,
+    LAnd,
+    LOr,
+    Eq,
+    Neq,
+    Lt,
+    Gt,
+    Leq,
+    Geq,
+    AddAssign,
+    SubAssign,
+    MulAssign,
+    DivAssign,
+    ModAssign,
+    ShlAssign,
+    ShrAssign,
+    AndAssign,
+    OrAssign,
+    XorAssign,
+    Invalid
+  };
   BinaryExpr(StringRef op, ScriptExpr *LHS, ScriptExpr *RHS,
              const std::string loc)
-      : ScriptExpr(ExprKind::Binary), op_(op), LHS(LHS), RHS(RHS), loc_(loc) {}
+      : ScriptExpr(ExprKind::Binary), LHS(LHS), RHS(RHS), loc_(loc) {
+    opcode = stringToOp(op);
+  }
   ExprValue evaluateBinaryOperands() const;
   // Some operations only support one non absolute value. Move the
   // absolute one to the right hand side for convenience.
@@ -143,10 +176,10 @@ public:
   static ExprValue bitOr(ExprValue a, ExprValue b);
 
 private:
-  StringRef op_;
-  // const ExprValue LHS, RHS;
+  Op opcode;
   const ScriptExpr *LHS, *RHS;
   std::string loc_;
+  static Op stringToOp(const StringRef op);
 };
 
 // This enum is used to implement linker script SECTIONS command.

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -151,7 +151,6 @@ public:
     SubAssign,
     MulAssign,
     DivAssign,
-    ModAssign,
     ShlAssign,
     ShrAssign,
     AndAssign,

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -153,9 +153,8 @@ public:
     Invalid
   };
   BinaryExpr(StringRef op, Expr *LHS, Expr *RHS, const std::string loc)
-      : Expr(ExprKind::Binary), LHS(LHS), RHS(RHS), loc_(loc) {
-    opcode = stringToOp(op);
-  }
+      : Expr(ExprKind::Binary), opcode(stringToOp(op)), LHS(LHS), RHS(RHS),
+        loc_(loc) {}
   ExprValue getExprValue() const;
   // Some operations only support one non absolute value. Move the
   // absolute one to the right hand side for convenience.
@@ -261,10 +260,12 @@ struct MemoryRegion {
   uint64_t curPos = 0;
 
   uint64_t getOrigin() const {
-    return origin ? origin->getExprValue().getValue() : 0;
+    assert(origin != nullptr);
+    return origin->getExprValue().getValue();
   }
   uint64_t getLength() const {
-    return length ? length->getExprValue().getValue() : 0;
+    assert(length != nullptr);
+    return length->getExprValue().getValue();
   }
 
   bool compatibleWith(uint32_t secFlags) const {

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -112,11 +112,11 @@ private:
 
 class UnaryExpr : public ScriptExpr {
 public:
-  static const UnaryExpr *create();
-
-private:
   UnaryExpr(StringRef op, ScriptExpr *operand)
       : ScriptExpr(ExprKind::Unary), op_(op), operand_(operand) {}
+  ExprValue getExprValue() const;
+
+private:
   StringRef op_;
   const ScriptExpr *operand_;
 };

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -89,7 +89,6 @@ public:
   ExprKind getKind() const { return kind_; }
   std::function<ExprValue()> getExpr() const;
   ExprValue getExprValue() const;
-  uint64_t getExprValueAlignValue() const;
 };
 
 class ConstantExpr : public ScriptExpr {
@@ -272,10 +271,10 @@ struct MemoryRegion {
   uint64_t curPos = 0;
 
   uint64_t getOrigin() const {
-    return origin ? origin->getExprValueAlignValue() : 0;
+    return origin ? origin->getExprValue().getValue() : 0;
   }
   uint64_t getLength() const {
-    return length ? length->getExprValueAlignValue() : 0;
+    return length ? length->getExprValue().getValue() : 0;
   }
 
   bool compatibleWith(uint32_t secFlags) const {

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -97,13 +97,11 @@ public:
   ExprValue getExprValue() const { return ExprValue(val_); }
 
 private:
-  // ExprValue val_;
   uint64_t val_;
 };
 
 class DynamicExpr : public ScriptExpr {
 public:
-  // std::function<ExprValue()> getImpl() const { return impl_; }
   DynamicExpr(std::function<ExprValue()> impl)
       : ScriptExpr(ExprKind::Dynamic), impl_(impl) {}
   ExprValue getExprValue() const { return impl_(); }

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -72,11 +72,11 @@ struct ExprValue {
 
 // This represents an expression in the linker script.
 // ScriptParser::readExpr reads an expression and returns an Expr.
-// Later, we evaluate the expression by calling the function.
-
+// Later, we evaluate the expression by calling the function if the
+// expression type is FallbackExpr.
 class Expr {
 public:
-  enum class ExprKind : uint8_t { Constant, Dynamic, Unary, Binary };
+  enum class ExprKind : uint8_t { Constant, Fallback, Unary, Binary };
 
 private:
   ExprKind kind_;
@@ -99,10 +99,10 @@ private:
   uint64_t val_;
 };
 
-class DynamicExpr : public Expr {
+class FallbackExpr : public Expr {
 public:
-  DynamicExpr(std::function<ExprValue()> impl)
-      : Expr(ExprKind::Dynamic), impl_(impl) {}
+  FallbackExpr(std::function<ExprValue()> impl)
+      : Expr(ExprKind::Fallback), impl_(impl) {}
   ExprValue getExprValue() const { return impl_(); }
 
 private:

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -93,12 +93,8 @@ public:
 
 class ConstantExpr : public ScriptExpr {
 public:
-  // ConstantExpr(ExprValue val) : ScriptExpr(ExprKind::Constant), val_(val) {}
   ConstantExpr(uint64_t val) : ScriptExpr(ExprKind::Constant), val_(val) {}
-  std::function<ExprValue()> getConstantExpr() const {
-    return [=] { return val_; };
-  }
-  ExprValue getConstantExprValue() const { return ExprValue(val_); }
+  ExprValue getExprValue() const { return ExprValue(val_); }
 
 private:
   // ExprValue val_;
@@ -107,12 +103,10 @@ private:
 
 class DynamicExpr : public ScriptExpr {
 public:
-  // static DynamicExpr create(std::function<ExprValue()> impl) {
-  //   return DynamicExpr(impl);
-  // }
-  std::function<ExprValue()> getImpl() const { return impl_; }
+  // std::function<ExprValue()> getImpl() const { return impl_; }
   DynamicExpr(std::function<ExprValue()> impl)
       : ScriptExpr(ExprKind::Dynamic), impl_(impl) {}
+  ExprValue getExprValue() const { return impl_(); }
 
 private:
   std::function<ExprValue()> impl_;
@@ -123,7 +117,10 @@ public:
   static const UnaryExpr *create();
 
 private:
-  UnaryExpr() : ScriptExpr(ExprKind::Unary) {}
+  UnaryExpr(StringRef op, ScriptExpr *operand)
+      : ScriptExpr(ExprKind::Unary), op_(op), operand_(operand) {}
+  StringRef op_;
+  const ScriptExpr *operand_;
 };
 
 class BinaryExpr : public ScriptExpr {
@@ -163,7 +160,7 @@ public:
       : ScriptExpr(ExprKind::Binary), LHS(LHS), RHS(RHS), loc_(loc) {
     opcode = stringToOp(op);
   }
-  ExprValue evaluateBinaryOperands() const;
+  ExprValue getExprValue() const;
   // Some operations only support one non absolute value. Move the
   // absolute one to the right hand side for convenience.
   static void moveAbsRight(ExprValue &a, ExprValue &b);

--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -558,7 +558,8 @@ void OutputSection::writeTo(uint8_t *buf, parallel::TaskGroup &tg) {
     if (auto *data = dyn_cast<ByteCommand>(cmd)) {
       if (!std::exchange(written, true))
         fn(0, numSections);
-      writeInt(buf + data->offset, data->expression().getValue(), data->size);
+      writeInt(buf + data->offset, data->expression->getExprValueAlignValue(),
+               data->size);
     }
   if (written || !numSections)
     return;

--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -558,7 +558,7 @@ void OutputSection::writeTo(uint8_t *buf, parallel::TaskGroup &tg) {
     if (auto *data = dyn_cast<ByteCommand>(cmd)) {
       if (!std::exchange(written, true))
         fn(0, numSections);
-      writeInt(buf + data->offset, data->expression->getExprValueAlignValue(),
+      writeInt(buf + data->offset, data->expression->getExprValue().getValue(),
                data->size);
     }
   if (written || !numSections)

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -80,10 +80,10 @@ public:
   // The following members are normally only used in linker scripts.
   MemoryRegion *memRegion = nullptr;
   MemoryRegion *lmaRegion = nullptr;
-  Expr addrExpr;
-  Expr alignExpr;
-  Expr lmaExpr;
-  Expr subalignExpr;
+  ScriptExpr *addrExpr;
+  ScriptExpr *alignExpr;
+  ScriptExpr *lmaExpr;
+  ScriptExpr *subalignExpr;
 
   // Used by non-alloc SHT_CREL to hold the header and content byte stream.
   uint64_t crelHeader = 0;

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -80,10 +80,10 @@ public:
   // The following members are normally only used in linker scripts.
   MemoryRegion *memRegion = nullptr;
   MemoryRegion *lmaRegion = nullptr;
-  ScriptExpr *addrExpr;
-  ScriptExpr *alignExpr;
-  ScriptExpr *lmaExpr;
-  ScriptExpr *subalignExpr;
+  ScriptExpr *addrExpr = nullptr;
+  ScriptExpr *alignExpr = nullptr;
+  ScriptExpr *lmaExpr = nullptr;
+  ScriptExpr *subalignExpr = nullptr;
 
   // Used by non-alloc SHT_CREL to hold the header and content byte stream.
   uint64_t crelHeader = 0;

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -80,10 +80,10 @@ public:
   // The following members are normally only used in linker scripts.
   MemoryRegion *memRegion = nullptr;
   MemoryRegion *lmaRegion = nullptr;
-  ScriptExpr *addrExpr = nullptr;
-  ScriptExpr *alignExpr = nullptr;
-  ScriptExpr *lmaExpr = nullptr;
-  ScriptExpr *subalignExpr = nullptr;
+  Expr *addrExpr = nullptr;
+  Expr *alignExpr = nullptr;
+  Expr *lmaExpr = nullptr;
+  Expr *subalignExpr = nullptr;
 
   // Used by non-alloc SHT_CREL to hold the header and content byte stream.
   uint64_t crelHeader = 0;

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -104,7 +104,7 @@ private:
   SymbolAssignment *readAssignment(StringRef tok);
   void readSort();
   Expr readAssert();
-  DynamicExpr readConstant();
+  ScriptExpr readConstant();
   DynamicExpr getPageSize();
 
   Expr readMemoryAssignment(StringRef, StringRef, StringRef);
@@ -1332,13 +1332,14 @@ DynamicExpr ScriptParser::getPageSize() {
   });
 }
 
-DynamicExpr ScriptParser::readConstant() {
+ScriptExpr ScriptParser::readConstant() {
   StringRef s = readParenName();
   if (s == "COMMONPAGESIZE")
     return getPageSize();
   if (s == "MAXPAGESIZE")
     return DynamicExpr::create([] { return config->maxPageSize; });
   setError("unknown constant: " + s);
+  // return ConstantExpr(ExprValue(0));
   return DynamicExpr::create([] { return 0; });
 }
 
@@ -1537,7 +1538,7 @@ Expr ScriptParser::readPrimary() {
   if (tok == "ASSERT")
     return readAssert();
   if (tok == "CONSTANT")
-    return readConstant().getImpl();
+    return readConstant().getExpr();
   if (tok == "DATA_SEGMENT_ALIGN") {
     expect("(");
     Expr e = readExpr();

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -1164,31 +1164,7 @@ SymbolAssignment *ScriptParser::readSymbolAssignment(StringRef name) {
     e = make<DynamicExpr>([=, c = op[0]]() -> ExprValue {
       ExprValue lhs = script->getSymbolValue(name, loc);
       BinaryExpr *expr = make<BinaryExpr>(op, lhs, e->getExprValue(), loc);
-      switch (c) {
-      case '*':
-        return lhs.getValue() * e->getExprValueAlignValue();
-      case '/':
-        if (uint64_t rv = e->getExprValueAlignValue())
-          return lhs.getValue() / rv;
-        error(loc + ": division by zero");
-        return 0;
-      case '+':
-        return BinaryExpr::add(lhs, e->getExprValue());
-      case '-':
-        return BinaryExpr::sub(lhs, e->getExprValue());
-      case '<':
-        return lhs.getValue() << e->getExprValueAlignValue() % 64;
-      case '>':
-        return lhs.getValue() >> e->getExprValueAlignValue() % 64;
-      case '&':
-        return lhs.getValue() & e->getExprValueAlignValue();
-      case '^':
-        return lhs.getValue() ^ e->getExprValueAlignValue();
-      case '|':
-        return lhs.getValue() | e->getExprValueAlignValue();
-      default:
-        llvm_unreachable("");
-      }
+      return expr->evaluateSymbolAssignment();
     });
   }
   return make<SymbolAssignment>(name, e, ctx.scriptSymOrderCounter++,

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -1360,20 +1360,10 @@ ScriptExpr *ScriptParser::readPrimary() {
   if (peek() == "(")
     return readParenExpr();
 
-  if (consume("~")) {
-    ScriptExpr *e = readPrimary();
-    return make<DynamicExpr>([=] { return ~e->getExprValue().getValue(); });
-  }
-  if (consume("!")) {
-    ScriptExpr *e = readPrimary();
-    return make<DynamicExpr>([=] { return !e->getExprValue().getValue(); });
-  }
-  if (consume("-")) {
-    ScriptExpr *e = readPrimary();
-    return make<DynamicExpr>([=] { return -e->getExprValue().getValue(); });
-  }
-
   StringRef tok = next();
+  if (tok == "~" || tok == "!" || tok == "-")
+    return make<UnaryExpr>(tok, readPrimary());
+
   std::string location = getCurrentLocation();
 
   // Built-in functions are parsed here.

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -1362,7 +1362,6 @@ ScriptExpr *ScriptParser::readPrimary() {
 
   if (consume("~")) {
     ScriptExpr *e = readPrimary();
-    // return [=] { return ~e().getValue(); };
     return make<DynamicExpr>([=] { return ~e->getExprValue().getValue(); });
   }
   if (consume("!")) {
@@ -1472,10 +1471,8 @@ ScriptExpr *ScriptParser::readPrimary() {
     StringRef name = readParenName();
     if (script->memoryRegions.count(name) == 0) {
       setError("memory region not defined: " + name);
-      // return [] { return 0; };
       return make<ConstantExpr>(0);
     }
-    // TODO
     return script->memoryRegions[name]->length;
   }
   if (tok == "LOADADDR") {
@@ -1519,7 +1516,6 @@ ScriptExpr *ScriptParser::readPrimary() {
       setError("memory region not defined: " + name);
       return make<ConstantExpr>(0);
     }
-    // TODO
     return script->memoryRegions[name]->origin;
   }
   if (tok == "SEGMENT_START") {
@@ -1528,7 +1524,7 @@ ScriptExpr *ScriptParser::readPrimary() {
     expect(",");
     ScriptExpr *e = readExpr();
     expect(")");
-    return make<DynamicExpr>([=] { return e->getExprValue(); });
+    return e;
   }
   if (tok == "SIZEOF") {
     StringRef name = readParenName();

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -1160,12 +1160,9 @@ SymbolAssignment *ScriptParser::readSymbolAssignment(StringRef name) {
   ScriptExpr *e = readExpr();
   if (op != "=") {
     std::string loc = getCurrentLocation();
-    e = make<DynamicExpr>([=, c = op[0]]() -> ExprValue {
-      ExprValue lhs = script->getSymbolValue(name, loc);
-      BinaryExpr *expr =
-          make<BinaryExpr>(op, make<DynamicExpr>([=] { return lhs; }), e, loc);
-      return expr->evaluateBinaryOperands();
-    });
+    DynamicExpr *lhs =
+        make<DynamicExpr>([=] { return script->getSymbolValue(name, loc); });
+    e = make<BinaryExpr>(op, lhs, e, loc);
   }
   return make<SymbolAssignment>(name, e, ctx.scriptSymOrderCounter++,
                                 getCurrentLocation());

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -1544,7 +1544,7 @@ ScriptExpr *ScriptParser::readPrimary() {
 
   // Tok is a literal number.
   if (std::optional<uint64_t> val = parseInt(tok))
-    return make<DynamicExpr>([=] { return *val; });
+    return make<ConstantExpr>(*val);
 
   // Tok is a symbol name.
   if (tok.starts_with("\""))

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -2406,7 +2406,7 @@ template <class ELFT> void Writer<ELFT>::fixSectionAlignments() {
           (config->zSeparate == SeparateSegmentKind::Code && prev &&
            (prev->p_flags & PF_X) != (p->p_flags & PF_X)) ||
           cmd->type == SHT_LLVM_PART_EHDR)
-        cmd->addrExpr = make<DynamicExpr>([] {
+        cmd->addrExpr = make<FallbackExpr>([] {
           return alignToPowerOf2(script->getDot(), config->maxPageSize);
         });
       // PT_TLS is at the start of the first RW PT_LOAD. If `p` includes PT_TLS,
@@ -2423,13 +2423,13 @@ template <class ELFT> void Writer<ELFT>::fixSectionAlignments() {
       // bug, musl (TLS Variant 1 architectures) before 1.1.23 handled TLS
       // blocks correctly. We need to keep the workaround for a while.
       else if (ctx.tlsPhdr && ctx.tlsPhdr->firstSec == p->firstSec)
-        cmd->addrExpr = make<DynamicExpr>([] {
+        cmd->addrExpr = make<FallbackExpr>([] {
           return alignToPowerOf2(script->getDot(), config->maxPageSize) +
                  alignToPowerOf2(script->getDot() % config->maxPageSize,
                                  ctx.tlsPhdr->p_align);
         });
       else
-        cmd->addrExpr = make<DynamicExpr>([] {
+        cmd->addrExpr = make<FallbackExpr>([] {
           return alignToPowerOf2(script->getDot(), config->maxPageSize) +
                  script->getDot() % config->maxPageSize;
         });

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1911,7 +1911,7 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
   for (OutputSection *sec : ctx.outputSections) {
     auto i = config->sectionStartMap.find(sec->name);
     if (i != config->sectionStartMap.end())
-      sec->addrExpr = make<DynamicExpr>([=] { return i->second; });
+      sec->addrExpr = make<ConstantExpr>(i->second);
   }
 
   // With the ctx.outputSections available check for GDPLT relocations
@@ -2387,8 +2387,7 @@ template <class ELFT> void Writer<ELFT>::fixSectionAlignments() {
     OutputSection *cmd = p->firstSec;
     if (!cmd)
       return;
-    cmd->alignExpr =
-        make<DynamicExpr>([align = cmd->addralign]() { return align; });
+    cmd->alignExpr = make<ConstantExpr>(cmd->addralign);
     if (!cmd->addrExpr) {
       // Prefer advancing to align(dot, maxPageSize) + dot%maxPageSize to avoid
       // padding in the file contents.


### PR DESCRIPTION
The current implementation of linker scripts in LLD faces challenges due to inadequate support and tooling, particularly for tasks such as writing and debugging. To address these issues, especially in embedded development, improvements to the lexer and parser in LLD are proposed, including better diagnostics, support for LTO code generation, and potentially creating an intermediate representation for linker scripts within LLD.

One key proposal is to replace the use of lambda functions (`Expr`) with new, well-defined expression types called `ScriptExpr`. Currently, expressions in linker scripts are represented as lambdas, which, while practical, hinder the separation of expression evaluation from the parser and make managing state opaque and challenging. The proposed `ScriptExpr` types aim to make this state systematically accessible through a well-defined context, improving code organization, maintainability, and extensibility.

The benefits of this transition include improved debuggability, better performance through efficient memory allocation, and more flexible and efficient expression handling. The new types—`ConstantExpr`, `FallbackExpr`, `UnaryExpr`, and `BinaryExpr`—are inspired by the `MCExpr` in LLVM and provide a clearer structure for linker script expressions.

For more details, please check our RFC: https://discourse.llvm.org/t/rfc-improve-linker-script-handing-in-lld/80866
