### PR TITLE
[mlir][tosa] Add missing check for mutiples of `tosa.tile`

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -930,6 +930,10 @@ LogicalResult tosa::TileOp::verify() {
     return emitOpError("expect 'multiples' array to have length ")
            << outputType.getRank() << " but got " << multiples.size() << ".";
 
+  if (llvm::any_of(multiples, [](int64_t v) { return v <= 0 && v != -1; }))
+    return emitOpError(
+        "expect element of 'multiples' to be positive integer or -1.");
+
   return success();
 }
 

--- a/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/mlir/test/Dialect/Tosa/invalid.mlir
@@ -424,6 +424,24 @@ func.func @test_tile_invalid_multiples() {
 
 // -----
 
+func.func @test_tile_invalid_multiples_value() {
+  %0 = tensor.empty() : tensor<4x31xf32>
+  // expected-error@+1 {{'tosa.tile' op expect element of 'multiples' to be positive integer or -1.}}
+  %1 = tosa.tile %0 {multiples = array<i64: 2, -2>} : (tensor<4x31xf32>) -> tensor<4x31xf32>
+  return
+}
+
+// -----
+
+func.func @test_tile_io_rank_mismatch() {
+  %0 = tensor.empty() : tensor<4x31xf32>
+  // expected-error@+1 {{'tosa.tile' op expect same input and output tensor rank.}}
+  %1 = tosa.tile %0 {multiples = array<i64: 2, 2>} : (tensor<4x31xf32>) -> tensor<4x31x31xf32>
+  return
+}
+
+// -----
+
 // CHECK-LABEL: @test_invalid_constant_permutation
 func.func @test_invalid_constant_permutation() {
   // expected-error@+3 {{permutation must be within input bounds}}


### PR DESCRIPTION
This patch adds check for mutiples of `tosa.tile`. The `multiples` in `tosa.tile` indicates how many times the tensor should be replicated along each dimension. Zero and negative values are invalid, except for -1, which represents a dynamic value. Therefore, each element of `mutiples` should be positive integer or -1. Fix #106167.