### PR TITLE
[clang][RISCV] Remove `experimental` for vector crypto intrinsics

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -2688,7 +2688,7 @@ multiclass RVVSignedWidenBinBuiltinSetVwsll
 
 let UnMaskedPolicyScheme = HasPassthruOperand in {
   // zvkb
-  let RequiredFeatures = ["Zvkb", "Experimental"] in {
+  let RequiredFeatures = ["Zvkb"] in {
     defm vandn   : RVVUnsignedBinBuiltinSet;
     defm vbrev8  : RVVOutBuiltinSetZvbb;
     defm vrev8   : RVVOutBuiltinSetZvbb;
@@ -2697,7 +2697,7 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
   }
 
   // zvbb
-  let RequiredFeatures = ["Zvbb", "Experimental"] in {
+  let RequiredFeatures = ["Zvbb"] in {
     defm vbrev   : RVVOutBuiltinSetZvbb;
     defm vclz    : RVVOutBuiltinSetZvbb;
     defm vctz    : RVVOutBuiltinSetZvbb;
@@ -2708,7 +2708,7 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
   }
 
   // zvbc
-  let RequiredFeatures = ["Zvbc", "Experimental"] in {
+  let RequiredFeatures = ["Zvbc"] in {
     defm vclmul  : RVVInt64BinBuiltinSet;
     defm vclmulh : RVVInt64BinBuiltinSet;
   }
@@ -2716,13 +2716,13 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
 
 let UnMaskedPolicyScheme = HasPolicyOperand, HasMasked = false in {
   // zvkg
-  let RequiredFeatures = ["Zvkg", "Experimental"] in {
+  let RequiredFeatures = ["Zvkg"] in {
     defm vghsh   : RVVOutOp2BuiltinSetVVZvk;
     defm vgmul   : RVVOutBuiltinSetZvk<HasVV=1, HasVS=0>;
   }
 
   // zvkned
-  let RequiredFeatures = ["Zvkned", "Experimental"] in {
+  let RequiredFeatures = ["Zvkned"] in {
     defm vaesdf  : RVVOutBuiltinSetZvk;
     defm vaesdm  : RVVOutBuiltinSetZvk;
     defm vaesef  : RVVOutBuiltinSetZvk;
@@ -2734,28 +2734,28 @@ let UnMaskedPolicyScheme = HasPolicyOperand, HasMasked = false in {
   }
 
   // zvknha
-  let RequiredFeatures = ["Zvknha", "Experimental"] in {
+  let RequiredFeatures = ["Zvknha"] in {
     defm vsha2ch : RVVOutOp2BuiltinSetVVZvk<"i">;
     defm vsha2cl : RVVOutOp2BuiltinSetVVZvk<"i">;
     defm vsha2ms : RVVOutOp2BuiltinSetVVZvk<"i">;
   }
 
   // zvknhb
-  let RequiredFeatures = ["Zvknhb", "Experimental"] in {
+  let RequiredFeatures = ["Zvknhb"] in {
     defm vsha2ch : RVVOutOp2BuiltinSetVVZvk<"il">;
     defm vsha2cl : RVVOutOp2BuiltinSetVVZvk<"il">;
     defm vsha2ms : RVVOutOp2BuiltinSetVVZvk<"il">;
   }
 
   // zvksed
-  let RequiredFeatures = ["Zvksed", "Experimental"] in {
+  let RequiredFeatures = ["Zvksed"] in {
     let UnMaskedPolicyScheme = HasPassthruOperand in
     defm vsm4k   : RVVOutOp1BuiltinSet<"vsm4k", "i", [["vi", "Uv", "UvUvKz"]]>;
     defm vsm4r   : RVVOutBuiltinSetZvk;
   }
 
   // zvksh
-  let RequiredFeatures = ["Zvksh", "Experimental"] in {
+  let RequiredFeatures = ["Zvksh"] in {
     defm vsm3c   : RVVOutOp2BuiltinSetVIZvk;
     let UnMaskedPolicyScheme = HasPassthruOperand in
     defm vsm3me  : RVVOutOp1BuiltinSet<"vsm3me", "i", [["vv", "Uv", "UvUvUv"]]>;

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesdf.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesdf.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesdm.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesdm.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesef.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesef.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesem.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesem.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaeskf1.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaeskf1.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaeskf2.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaeskf2.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vaesz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vandn.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vandn.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vbrev.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vbrev.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vbrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vbrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vclmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vclmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vclmulh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vclmulh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vclz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vclz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vcpopv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vcpopv.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vctz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vctz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vghsh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vghsh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vgmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vgmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vrol.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vrol.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vror.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vror.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsha2ch.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsha2ch.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsha2cl.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsha2cl.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsha2ms.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsha2ms.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm3c.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm3c.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm3me.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm3me.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm4k.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm4k.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm4r.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsm4r.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vwsll.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vwsll.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesdf.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesdf.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesdm.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesdm.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesef.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesef.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesem.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesem.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaeskf1.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaeskf1.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaeskf2.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaeskf2.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vaesz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vandn.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vandn.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vbrev.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vbrev.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vbrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vbrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vclmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vclmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vclmulh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vclmulh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vclz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vclz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vcpopv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vcpopv.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vctz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vctz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vghsh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vghsh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vgmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vgmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vrol.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vrol.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vror.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vror.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsha2ch.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsha2ch.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsha2cl.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsha2cl.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsha2ms.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsha2ms.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm3c.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm3c.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm3me.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm3me.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm4k.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm4k.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm4r.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vsm4r.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vwsll.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/overloaded/vwsll.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesdf.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesdf.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesdm.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesdm.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesef.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesef.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesem.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesem.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaeskf1.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaeskf1.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaeskf2.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaeskf2.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vaesz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vandn.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vandn.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vbrev.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vbrev.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vbrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vbrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vclmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vclmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vclmulh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vclmulh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vclz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vclz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vcpopv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vcpopv.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vctz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vctz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vghsh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vghsh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vgmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vgmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vrol.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vrol.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vror.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vror.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsha2ch.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsha2ch.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsha2cl.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsha2cl.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsha2ms.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsha2ms.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm3c.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm3c.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm3me.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm3me.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm4k.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm4k.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm4r.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsm4r.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vwsll.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vwsll.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesdf.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesdf.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesdm.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesdm.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesef.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesef.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesem.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesem.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaeskf1.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaeskf1.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaeskf2.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaeskf2.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vaesz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vandn.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vandn.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vbrev.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vbrev.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vbrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vbrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vclmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vclmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vclmulh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vclmulh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vclz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vclz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vcpopv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vcpopv.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vctz.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vctz.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vghsh.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vghsh.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vgmul.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vgmul.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vrev8.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vrev8.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vrol.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vrol.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vror.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vror.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsha2ch.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsha2ch.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsha2cl.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsha2cl.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsha2ms.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsha2ms.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm3c.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm3c.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm3me.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm3me.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm4k.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm4k.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm4r.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vsm4r.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vwsll.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/overloaded/vwsll.c
@@ -9,7 +9,6 @@
 // RUN:   -target-feature +zvknhb \
 // RUN:   -target-feature +zvksed \
 // RUN:   -target-feature +zvksh \
-// RUN:   -target-feature +experimental \
 // RUN:   -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s


### PR DESCRIPTION
The C intrinsic spec is ratified: https://github.com/riscv-non-isa/rvv-intrinsic-doc/pull/234.
