### PR TITLE
[clang] Minor updates to C++ DR page design

### DIFF
--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -2879,7 +2879,11 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/472.html">472</a></td>
     <td>drafting</td>
     <td>Casting across protected inheritance</td>
-    <td title="Clang does not implement 2011-04 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang does not implement 2011-04 resolution
+      </details></td>
   </tr>
   <tr id="473">
     <td><a href="https://cplusplus.github.io/CWG/issues/473.html">473</a></td>
@@ -7153,7 +7157,11 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1223.html">1223</a></td>
     <td>drafting</td>
     <td>Syntactic disambiguation and <I>trailing-return-type</I>s</td>
-    <td title="Clang 17 implements 2023-05-12 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 17 implements 2023-05-12 resolution
+      </details></td>
   </tr>
   <tr id="1224">
     <td><a href="https://cplusplus.github.io/CWG/issues/1224.html">1224</a></td>
@@ -9319,7 +9327,11 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1584.html">1584</a></td>
     <td>drafting</td>
     <td>Deducing function types from cv-qualified types</td>
-    <td title="Clang 7 implements 2015-05 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 7 implements 2015-05 resolution
+      </details></td>
   </tr>
   <tr id="1585">
     <td><a href="https://cplusplus.github.io/CWG/issues/1585.html">1585</a></td>
@@ -11155,7 +11167,11 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1890.html">1890</a></td>
     <td>drafting</td>
     <td>Member type depending on definition of member function</td>
-    <td title="Clang does not implement 2018-06-04 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang does not implement 2018-06-04 resolution
+      </details></td>
   </tr>
   <tr id="1891">
     <td><a href="https://cplusplus.github.io/CWG/issues/1891.html">1891</a></td>
@@ -13825,7 +13841,11 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2335.html">2335</a></td>
     <td>drafting</td>
     <td>Deduced return types vs member types</td>
-    <td title="Clang does not implement 2018-06 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang does not implement 2018-06 resolution
+      </details></td>
   </tr>
   <tr id="2336">
     <td><a href="https://cplusplus.github.io/CWG/issues/2336.html">2336</a></td>
@@ -15133,13 +15153,21 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2553.html">2553</a></td>
     <td>review</td>
     <td>Restrictions on explicit object member functions</td>
-    <td title="Clang 18 implements 2023-07-14 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 18 implements 2023-07-14 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2554">
     <td><a href="https://cplusplus.github.io/CWG/issues/2554.html">2554</a></td>
     <td>review</td>
     <td>Overriding virtual functions, also with explicit object parameters</td>
-    <td title="Clang 18 implements 2021-12-10 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 18 implements 2021-12-10 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2555">
     <td><a href="https://cplusplus.github.io/CWG/issues/2555.html">2555</a></td>
@@ -15205,7 +15233,11 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2565.html">2565</a></td>
     <td>open</td>
     <td>Invalid types in the <I>parameter-declaration-clause</I> of a <I>requires-expression</I></td>
-    <td title="Clang 16 implements 2023-06-07 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 16 implements 2023-06-07 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2566">
     <td><a href="https://cplusplus.github.io/CWG/issues/2566.html">2566</a></td>
@@ -16898,7 +16930,11 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2847.html">2847</a></td>
     <td>review</td>
     <td>Constrained explicit specializations of function templates at class scope</td>
-    <td title="Clang 19 implements 2024-03-01 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 19 implements 2024-03-01 resolution
+      </details></td>
   </tr>
   <tr id="2848">
     <td><a href="https://cplusplus.github.io/CWG/issues/2848.html">2848</a></td>
@@ -17126,7 +17162,11 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2885.html">2885</a></td>
     <td>review</td>
     <td>Non-eligible trivial default constructors</td>
-    <td title="Clang 16 implements 2024-05-31 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 16 implements 2024-05-31 resolution
+      </details></td>
   </tr>
   <tr id="2886">
     <td><a href="https://cplusplus.github.io/CWG/issues/2886.html">2886</a></td>
@@ -17318,7 +17358,11 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2917.html">2917</a></td>
     <td>review</td>
     <td>Disallow multiple <I>friend-type-specifier</I>s for a friend template</td>
-    <td title="Clang 20 implements 2024-07-30 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 20 implements 2024-07-30 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2918">
     <td><a href="https://cplusplus.github.io/CWG/issues/2918.html">2918</a></td>
@@ -17348,7 +17392,11 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2922.html">2922</a></td>
     <td>tentatively ready</td>
     <td>constexpr placement-new is too permissive</td>
-    <td title="Clang 20 implements 2024-07-10 resolution" align="center">Not Resolved*</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 20 implements 2024-07-10 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2923">
     <td><a href="https://cplusplus.github.io/CWG/issues/2923.html">2923</a></td>

--- a/clang/www/make_cxx_dr_status
+++ b/clang/www/make_cxx_dr_status
@@ -156,7 +156,7 @@ def availability(issue):
 
   avail_suffix = ''
   avail_style = ''
-  tooltip = ''
+  details = ''
   if status.endswith(' c++11'):
     status = status[:-6]
     avail_suffix = ' (C++11 onwards)'
@@ -180,29 +180,29 @@ def availability(issue):
       else:
         avail_style = 'full'
     else: 
-      avail = 'Not Resolved*'
-      tooltip = f' title="Clang {status} implements {proposed_resolution} resolution"'
+      avail = 'Not resolved'
+      details = f'Clang {status} implements {proposed_resolution} resolution'
   elif status == 'yes':
     if not proposed_resolution:
       avail = 'Yes'
       avail_style = 'full'
     else:
-      avail = 'Not Resolved*'
-      tooltip = f' title="Clang implements {proposed_resolution} resolution"'
+      avail = 'Not resolved'
+      details = f'Clang implements {proposed_resolution} resolution'
   elif status == 'partial':
     if not proposed_resolution:
       avail = 'Partial'
       avail_style = 'partial'
     else:
-      avail = 'Not Resolved*'
-      tooltip = f' title="Clang partially implements {proposed_resolution} resolution"'
+      avail = 'Not resolved'
+      details = f'Clang partially implements {proposed_resolution} resolution'
   elif status == 'no':
     if not proposed_resolution:
       avail = 'No'
       avail_style = 'none'
     else:
-      avail = 'Not Resolved*'
-      tooltip = f' title="Clang does not implement {proposed_resolution} resolution"'
+      avail = 'Not resolved'
+      details = f'Clang does not implement {proposed_resolution} resolution'
   elif status == 'na':
     avail = 'N/A'
     avail_style = 'na'
@@ -231,7 +231,7 @@ def availability(issue):
     _, avail_style, _, _ = availability(dup)
   else:
     raise AvailabilityError('Unknown status %s for issue %s' % (status, dr.issue))
-  return (avail + avail_suffix, avail_style, unresolved_status, tooltip)
+  return (avail + avail_suffix, avail_style, unresolved_status, details)
 
 count = {}
 for dr in drs:
@@ -248,7 +248,7 @@ for dr in drs:
   elif dr.status in ('open', 'drafting', 'review', 'tentatively ready', 'ready'):
     row_style = ' class="open"'
     try:
-      avail, avail_style, unresolved_status, tooltip = availability(dr.issue)
+      avail, avail_style, unresolved_status, details = availability(dr.issue)
     except AvailabilityError as e:
       availability_error_occurred = True
       print(e.args[0])
@@ -266,7 +266,7 @@ for dr in drs:
   else:
     row_style = ''
     try:
-      avail, avail_style, unresolved_status, tooltip = availability(dr.issue)
+      avail, avail_style, unresolved_status, details = availability(dr.issue)
     except AvailabilityError as e:
       availability_error_occurred = True
       print(e.args[0])
@@ -283,13 +283,20 @@ for dr in drs:
 
   if avail_style != '':
     avail_style = ' class="{}"'.format(avail_style)
-  out_file.write('''
-  <tr%s id="%s">
-    <td><a href="https://cplusplus.github.io/CWG/issues/%s.html">%s</a></td>
-    <td>%s</td>
-    <td>%s</td>
-    <td%s%s align="center">%s</td>
-  </tr>''' % (row_style, dr.issue, dr.issue, dr.issue, dr.status, dr.title, avail_style, tooltip, avail))
+
+  if details != '':
+    avail = f'''
+      <details>
+        <summary>{avail}</summary>
+        {details}
+      </details>'''
+  out_file.write(f'''
+  <tr{row_style} id="{dr.issue}">
+    <td><a href="https://cplusplus.github.io/CWG/issues/{dr.issue}.html">{dr.issue}</a></td>
+    <td>{dr.status}</td>
+    <td>{dr.title}</td>
+    <td{avail_style} align="center">{avail}</td>
+  </tr>''')
 
 if availability_error_occurred:
   exit(1)


### PR DESCRIPTION
This patch updates `make_cxx_dr_status` script to use the same spoiler-like way to hide additional details that `cxx_status.html` uses. This gives implemented yet unresolved DRs new but very familiar look:
![s9EpO0E](https://github.com/user-attachments/assets/54852d7b-5fdd-4595-8dca-20628797f952)

I also took an opportunity to fix spelling inconsistency pointed out by @zygoloid in https://github.com/llvm/llvm-project/pull/106299#discussion_r1733592539.

I got tired of counting `%s`s when we substitute data into HTML template, so I replaced them with an f-string (available since Python 3.6), because I had to touch this code anyway.