### PR TITLE
[libc++] Switch to the current XCode beta on macOS builders

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 'latest-stable'
+          xcode-version: 'latest'
       - uses: seanmiddleditch/gha-setup-ninja@master
       - name: Build and test
         run: |


### PR DESCRIPTION
This unblocks a ton of work including #76756 as it updates to a newer version of AppleClang.