### PR TITLE
[clang][bytecode] Diagnose array-to-pointer decays of dummy pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2535,7 +2535,7 @@ inline bool ArrayDecay(InterpState &S, CodePtr OpPC) {
   if (!CheckRange(S, OpPC, Ptr, CSK_ArrayToPointer))
     return false;
 
-  if (Ptr.isRoot() || !Ptr.isUnknownSizeArray() || Ptr.isDummy()) {
+  if (Ptr.isRoot() || !Ptr.isUnknownSizeArray()) {
     S.Stk.push<Pointer>(Ptr.atIndex(0));
     return true;
   }

--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -436,6 +436,15 @@ namespace Incomplete {
   constexpr int C = *F.a; // both-error {{must be initialized by a constant expression}} \
                           // both-note {{array-to-pointer decay of array member without known bound}}
 
+  struct X {
+    int a;
+    int b[];
+  };
+  extern X x;
+  constexpr int *xb = x.b; // both-error {{must be initialized by a constant expression}} \
+                           // both-note {{array-to-pointer decay of array member without known bound}}
+
+
   /// These are from test/SemaCXX/constant-expression-cxx11.cpp
   extern int arr[];
   constexpr int *c = &arr[1]; // both-error  {{must be initialized by a constant expression}} \


### PR DESCRIPTION
We have type information for them now, so we can do this.