### PR TITLE
[CodeView] Flatten cmd args in frontend for LF_BUILDINFO

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/Program.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/ToolOutputFile.h"
@@ -322,6 +323,40 @@ static bool actionRequiresCodeGen(BackendAction Action) {
          Action != Backend_EmitLL;
 }
 
+static std::string flattenClangCommandLine(ArrayRef<std::string> Args,
+                                           StringRef MainFilename) {
+  if (Args.empty())
+    return std::string{};
+
+  std::string FlatCmdLine;
+  raw_string_ostream OS(FlatCmdLine);
+  bool PrintedOneArg = false;
+  if (!StringRef(Args[0]).contains("-cc1")) {
+    llvm::sys::printArg(OS, "-cc1", /*Quote=*/true);
+    PrintedOneArg = true;
+  }
+  for (unsigned i = 0; i < Args.size(); i++) {
+    StringRef Arg = Args[i];
+    if (Arg.empty())
+      continue;
+    if (Arg == "-main-file-name" || Arg == "-o") {
+      i++; // Skip this argument and next one.
+      continue;
+    }
+    if (Arg.starts_with("-object-file-name") || Arg == MainFilename)
+      continue;
+    // Skip fmessage-length for reproducibility.
+    if (Arg.starts_with("-fmessage-length"))
+      continue;
+    if (PrintedOneArg)
+      OS << " ";
+    llvm::sys::printArg(OS, Arg, /*Quote=*/true);
+    PrintedOneArg = true;
+  }
+  OS.flush();
+  return FlatCmdLine;
+}
+
 static bool initTargetOptions(DiagnosticsEngine &Diags,
                               llvm::TargetOptions &Options,
                               const CodeGenOptions &CodeGenOpts,
@@ -484,8 +519,10 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
          Entry.Group == frontend::IncludeDirGroup::System))
       Options.MCOptions.IASSearchPaths.push_back(
           Entry.IgnoreSysRoot ? Entry.Path : HSOpts.Sysroot + Entry.Path);
-  Options.MCOptions.Argv0 = CodeGenOpts.Argv0;
-  Options.MCOptions.CommandLineArgs = CodeGenOpts.CommandLineArgs;
+  Options.MCOptions.Argv0 =
+      CodeGenOpts.Argv0 != nullptr ? CodeGenOpts.Argv0 : "";
+  Options.MCOptions.CommandlineArgs = flattenClangCommandLine(
+      CodeGenOpts.CommandLineArgs, CodeGenOpts.MainFileName);
   Options.MCOptions.AsSecureLogFile = CodeGenOpts.AsSecureLogFile;
   Options.MCOptions.PPCUseFullRegisterNames =
       CodeGenOpts.PPCUseFullRegisterNames;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -519,8 +519,7 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
          Entry.Group == frontend::IncludeDirGroup::System))
       Options.MCOptions.IASSearchPaths.push_back(
           Entry.IgnoreSysRoot ? Entry.Path : HSOpts.Sysroot + Entry.Path);
-  Options.MCOptions.Argv0 =
-      CodeGenOpts.Argv0 != nullptr ? CodeGenOpts.Argv0 : "";
+  Options.MCOptions.Argv0 = CodeGenOpts.Argv0 ? CodeGenOpts.Argv0 : "";
   Options.MCOptions.CommandlineArgs = flattenClangCommandLine(
       CodeGenOpts.CommandLineArgs, CodeGenOpts.MainFileName);
   Options.MCOptions.AsSecureLogFile = CodeGenOpts.AsSecureLogFile;

--- a/clang/test/CodeGen/debug-info-codeview-buildinfo.c
+++ b/clang/test/CodeGen/debug-info-codeview-buildinfo.c
@@ -36,10 +36,10 @@ int main(void) { return 42; }
 // DISABLE-NOT: "-cc1"
 // DISABLE: 0x{{.+}} | LF_BUILDINFO [size = {{.+}}]
 // DISABLE-NEXT:          0x{{.+}}: `{{.*}}`
-// DISABLE-NEXT:          <no type>: ``
+// DISABLE-NEXT:          0x{{.+}}: `{{.*}}`
 // DISABLE-NEXT:          0x{{.+}}: `{{.*}}`
 // DISABLE-NEXT:          0x{{.+}}: ``
-// DISABLE-NEXT:          <no type>: ``
+// DISABLE-NEXT:          0x{{.+}}: `{{.*}}`
 
 // MESSAGELEN:                       Types (.debug$T)
 // MESSAGELEN: ============================================================

--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -95,8 +95,9 @@ public:
   std::string SplitDwarfFile;
   std::string AsSecureLogFile;
 
-  const char *Argv0 = nullptr;
-  ArrayRef<std::string> CommandLineArgs;
+  // Used for codeview debug info. These will be set as compiler path and commandline arguments in LF_BUILDINFO
+  std::string Argv0;
+  std::string CommandlineArgs;
 
   /// Additional paths to search for `.include` directives when using the
   /// integrated assembler.

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -893,37 +893,6 @@ static TypeIndex getStringIdTypeIdx(GlobalTypeTableBuilder &TypeTable,
   return TypeTable.writeLeafType(SIR);
 }
 
-static std::string flattenCommandLine(ArrayRef<std::string> Args,
-                                      StringRef MainFilename) {
-  std::string FlatCmdLine;
-  raw_string_ostream OS(FlatCmdLine);
-  bool PrintedOneArg = false;
-  if (!StringRef(Args[0]).contains("-cc1")) {
-    llvm::sys::printArg(OS, "-cc1", /*Quote=*/true);
-    PrintedOneArg = true;
-  }
-  for (unsigned i = 0; i < Args.size(); i++) {
-    StringRef Arg = Args[i];
-    if (Arg.empty())
-      continue;
-    if (Arg == "-main-file-name" || Arg == "-o") {
-      i++; // Skip this argument and next one.
-      continue;
-    }
-    if (Arg.starts_with("-object-file-name") || Arg == MainFilename)
-      continue;
-    // Skip fmessage-length for reproduciability.
-    if (Arg.starts_with("-fmessage-length"))
-      continue;
-    if (PrintedOneArg)
-      OS << " ";
-    llvm::sys::printArg(OS, Arg, /*Quote=*/true);
-    PrintedOneArg = true;
-  }
-  OS.flush();
-  return FlatCmdLine;
-}
-
 void CodeViewDebug::emitBuildInfo() {
   // First, make LF_BUILDINFO. It's a sequence of strings with various bits of
   // build info. The known prefix is:
@@ -947,13 +916,11 @@ void CodeViewDebug::emitBuildInfo() {
   // FIXME: PDB is intentionally blank unless we implement /Zi type servers.
   BuildInfoArgs[BuildInfoRecord::TypeServerPDB] =
       getStringIdTypeIdx(TypeTable, "");
-  if (Asm->TM.Options.MCOptions.Argv0 != nullptr) {
-    BuildInfoArgs[BuildInfoRecord::BuildTool] =
-        getStringIdTypeIdx(TypeTable, Asm->TM.Options.MCOptions.Argv0);
-    BuildInfoArgs[BuildInfoRecord::CommandLine] = getStringIdTypeIdx(
-        TypeTable, flattenCommandLine(Asm->TM.Options.MCOptions.CommandLineArgs,
-                                      MainSourceFile->getFilename()));
-  }
+  BuildInfoArgs[BuildInfoRecord::BuildTool] =
+      getStringIdTypeIdx(TypeTable, Asm->TM.Options.MCOptions.Argv0);
+  BuildInfoArgs[BuildInfoRecord::CommandLine] = getStringIdTypeIdx(
+      TypeTable, Asm->TM.Options.MCOptions.CommandlineArgs);
+
   BuildInfoRecord BIR(BuildInfoArgs);
   TypeIndex BuildInfoIndex = TypeTable.writeLeafType(BIR);
 

--- a/llvm/test/DebugInfo/COFF/build-info.ll
+++ b/llvm/test/DebugInfo/COFF/build-info.ll
@@ -3,10 +3,10 @@
 
 ; CHECK: [[INFO_IDX:0x[^ ]*]] | LF_BUILDINFO
 ; CHECK-NEXT:          0x{{.*}}: `D:\src\scopes\clang`
-; CHECK-NEXT:          <no type>: ``
+; CHECK-NEXT:          0x{{.*}}: ``
 ; CHECK-NEXT:          0x{{.*}}: `D:\src\scopes\foo.cpp`
 ; CHECK-NEXT:          0x{{.*}}: ``
-; CHECK-NEXT:          <no type>: ``
+; CHECK-NEXT:          0x{{.*}}: ``
 
 ; CHECK: {{.*}} | S_BUILDINFO [size = 8] BuildId = `[[INFO_IDX]]`
 

--- a/llvm/test/DebugInfo/COFF/global-type-hashes.ll
+++ b/llvm/test/DebugInfo/COFF/global-type-hashes.ll
@@ -300,7 +300,7 @@ attributes #3 = { mustprogress noinline nounwind optnone "frame-pointer"="none" 
 ; YAML:           String:          ''
 ; YAML:       - Kind:            LF_BUILDINFO
 ; YAML:         BuildInfo:
-; YAML:           ArgIndices:      [ 4113, 0, 4114, 4115, 0 ]
+; YAML:           ArgIndices:      [ 4113, 4115, 4114, 4115, 4115 ]
 ; YAML:   - Name:            '.debug$H'
 ; YAML:     Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_DISCARDABLE, IMAGE_SCN_MEM_READ ]
 ; YAML:     Alignment:       4
@@ -328,7 +328,7 @@ attributes #3 = { mustprogress noinline nounwind optnone "frame-pointer"="none" 
 ; YAML:         - 174CF4A3F5448049
 ; YAML:         - 5349856AF14E2246
 ; YAML:         - 55A48E0466FDCDA6
-; YAML:         - 886A1B73D31E9877
+; YAML:         - EE6329A02D9F4959
 
 ; ASM:      .section        .debug$H,"dr"
 ; ASM-NEXT: .p2align        2

--- a/llvm/test/DebugInfo/COFF/types-basic.ll
+++ b/llvm/test/DebugInfo/COFF/types-basic.ll
@@ -525,10 +525,10 @@
 ; ASM: .short	0x1603                  # Record kind: LF_BUILDINFO
 ; ASM: .short	0x5                     # NumArgs
 ; ASM: .long	0x1013                  # Argument: D:\src\llvm\build
-; ASM: .long	0x0                     # Argument
+; ASM: .long	0x1015                  # Argument
 ; ASM: .long	0x1014                  # Argument: t.cpp
 ; ASM: .long	0x1015                  # Argument
-; ASM: .long	0x0                     # Argument
+; ASM: .long	0x1015                  # Argument
 ; ASM: .byte	242
 ; ASM: .byte	241
 

--- a/llvm/test/DebugInfo/COFF/types-data-members.ll
+++ b/llvm/test/DebugInfo/COFF/types-data-members.ll
@@ -740,10 +740,10 @@
 ; ASM: .short	0x1603                  # Record kind: LF_BUILDINFO
 ; ASM: .short	0x5                     # NumArgs
 ; ASM: .long	0x1020                  # Argument: D:\src\llvm\build
-; ASM: .long	0x0                     # Argument
+; ASM: .long	0x1022                  # Argument
 ; ASM: .long	0x1021                  # Argument: t.cpp
 ; ASM: .long	0x1022                  # Argument
-; ASM: .long	0x0                     # Argument
+; ASM: .long	0x1022                  # Argument
 ; ASM: .byte	242
 ; ASM: .byte	241
 


### PR DESCRIPTION
This change moves the flattening of commandline arguments for LF_BUILDINFO into the compiler frontend. This way other compiler frontends that use LLVM can do that flattening in a way that makes sense for them. E.g. clang wants to ensure a "-cc1" argument exists, while other frontends (e.g. rustc) don't.




