### PR TITLE
[ADT] Relax iterator constraints on all_equal

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2062,7 +2062,7 @@ bool equal(L &&LRange, R &&RRange, BinaryPredicate P) {
 template <typename R> bool all_equal(R &&Range) {
   auto Begin = adl_begin(Range);
   auto End = adl_end(Range);
-  return Begin == End || std::equal(Begin + 1, End, Begin);
+  return Begin == End || std::equal(std::next(Begin), End, Begin);
 }
 
 /// Returns true if all Values in the initializer lists are equal or the list

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -836,8 +836,8 @@ TEST(STLExtrasTest, AllEqual) {
 // model the random access iterator concept.
 TEST(STLExtrasTest, AllEqualNonRandomAccess) {
   std::list<int> V;
-  static_assert(!std::is_convertible<std::iterator_traits<decltype(V)::iterator>::iterator_category,
-                                     std::random_access_iterator_tag >::value);
+  static_assert(!std::is_convertible_v<std::iterator_traits<decltype(V)::iterator>::iterator_category,
+                                     std::random_access_iterator_tag >);
   
   EXPECT_TRUE(all_equal(V));
 

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -832,12 +832,13 @@ TEST(STLExtrasTest, AllEqual) {
   EXPECT_FALSE(all_equal(V));
 }
 
-// Test to verify that all_equal works with a container that does not 
+// Test to verify that all_equal works with a container that does not
 // model the random access iterator concept.
 TEST(STLExtrasTest, AllEqualNonRandomAccess) {
   std::list<int> V;
-  static_assert(!std::is_convertible_v<std::iterator_traits<decltype(V)::iterator>::iterator_category,
-                                     std::random_access_iterator_tag >);
+  static_assert(!std::is_convertible_v<
+                std::iterator_traits<decltype(V)::iterator>::iterator_category,
+                std::random_access_iterator_tag>);
   
   EXPECT_TRUE(all_equal(V));
 
@@ -851,7 +852,7 @@ TEST(STLExtrasTest, AllEqualNonRandomAccess) {
   V.push_back(2);
   EXPECT_FALSE(all_equal(V));
 }
-                                
+
 TEST(STLExtrasTest, AllEqualInitializerList) {
   EXPECT_TRUE(all_equal({1}));
   EXPECT_TRUE(all_equal({1, 1}));

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -839,7 +839,6 @@ TEST(STLExtrasTest, AllEqualNonRandomAccess) {
   static_assert(!std::is_convertible_v<
                 std::iterator_traits<decltype(V)::iterator>::iterator_category,
                 std::random_access_iterator_tag>);
-  
   EXPECT_TRUE(all_equal(V));
 
   V.push_back(1);

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -15,6 +15,7 @@
 #include <climits>
 #include <cstddef>
 #include <initializer_list>
+#include <iterator>
 #include <list>
 #include <tuple>
 #include <type_traits>
@@ -831,6 +832,26 @@ TEST(STLExtrasTest, AllEqual) {
   EXPECT_FALSE(all_equal(V));
 }
 
+// Test to verify that all_equal works with a container that does not 
+// model the random access iterator concept.
+TEST(STLExtrasTest, AllEqualNonRandomAccess) {
+  std::list<int> V;
+  static_assert(!std::is_convertible<std::iterator_traits<decltype(V)::iterator>::iterator_category,
+                                     std::random_access_iterator_tag >::value);
+  
+  EXPECT_TRUE(all_equal(V));
+
+  V.push_back(1);
+  EXPECT_TRUE(all_equal(V));
+
+  V.push_back(1);
+  V.push_back(1);
+  EXPECT_TRUE(all_equal(V));
+
+  V.push_back(2);
+  EXPECT_FALSE(all_equal(V));
+}
+                                
 TEST(STLExtrasTest, AllEqualInitializerList) {
   EXPECT_TRUE(all_equal({1}));
   EXPECT_TRUE(all_equal({1, 1}));


### PR DESCRIPTION
The previous `all_equal` implementation contained `Begin + 1`, which implicitly requires `Begin` to model the [random_access_iterator](https://en.cppreference.com/w/cpp/iterator/random_access_iterator) concept due to the usage of the `+` operator. By swapping this out with `std::next`, this method can be used with weaker iterator concepts, such as [forward_iterator](https://en.cppreference.com/w/cpp/iterator/forward_iterator).