### PR TITLE
[profile][test] Build Posix/instrprof-dlopen-norpath.test objects as PIC

### DIFF
--- a/compiler-rt/test/profile/Posix/instrprof-dlopen-norpath.test
+++ b/compiler-rt/test/profile/Posix/instrprof-dlopen-norpath.test
@@ -1,6 +1,6 @@
 RUN: rm -rf %t && split-file %s %t && cd %t
-RUN: %clang_pgogen foo.c -c -Xclang -fprofile-instrument-path="default_foo_%m.profraw"
-RUN: %clang_pgogen foo2.c -c -Xclang -fprofile-instrument-path="default_foo2_%m.profraw"
+RUN: %clang_pgogen -fPIC foo.c -c -Xclang -fprofile-instrument-path="default_foo_%m.profraw"
+RUN: %clang_pgogen -fPIC foo2.c -c -Xclang -fprofile-instrument-path="default_foo2_%m.profraw"
 RUN: %clang_pgogen -shared foo.o -o shr_foo.o %if target={{.*aix.*}} %{ -bcdtors:mbr %}
 RUN: %clang_pgogen -shared foo2.o -o shr_foo2.o
 


### PR DESCRIPTION
`Profile-x86_64 :: Posix/instrprof-dlopen-norpath.test` `FAILs` on Solaris/amd64 and similarly on Solaris/sparcv9:
```
RUN: at line 10: ./a.out 2>&1 | FileCheck compiler-rt/test/profile/Posix/instrprof-dlopen-norpath.test -check-prefix=CHECK-FOO
+ ./a.out
+ FileCheck compiler-rt/test/profile/Posix/instrprof-dlopen-norpath.test -check-prefix=CHECK-FOO
compiler-rt/test/profile/Posix/instrprof-dlopen-norpath.test:24:12: error: CHECK-FOO: expected string not found in input
CHECK-FOO: foo:
           ^
<stdin>:1:1: note: scanning from here
unable to lookup symbol 'foo': ld.so.1: a.out: invalid handle: 0x0
```
The problem turned out to be two-fold: `OPEN_AND_RUN` didn't check the `dlopen` return value and the objects linked into the shared objects to be `dlopen`ed aren't built as PIC.

This patch fixes the latter.

Tested on `amd64-pc-solaris2.11`, `sparcv9-sun-solaris2.11`, and `x86_64-pc-linux-gnu`.