### PR TITLE
Fix CLANG_BOOTSTRAP_TARGETS in Release.cmake

### DIFF
--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -55,14 +55,22 @@ set(STAGE1_RUNTIMES "compiler-rt")
 
 if (LLVM_RELEASE_ENABLE_PGO)
   list(APPEND STAGE1_PROJECTS "lld")
-  set(CLANG_BOOTSTRAP_TARGETS
+  set(tmp_targets
     generate-profdata
     stage2-package
     stage2-clang
+    stage2
     stage2-install
     stage2-check-all
     stage2-check-llvm
-    stage2-check-clang CACHE STRING "")
+    stage2-check-clang)
+
+  foreach(X IN LISTS LLVM_RELEASE_FINAL_STAGE_TARGETS)
+    list(APPEND tmp_targets "stage2-${X}")
+  endforeach()
+  list(REMOVE_DUPLICATES tmp_targets)
+
+  set(CLANG_BOOTSTRAP_TARGETS "${tmp_targets}" CACHE STRING "")
 
   # Configuration for stage2-instrumented
   set(BOOTSTRAP_CLANG_ENABLE_BOOTSTRAP ON CACHE STRING "")


### PR DESCRIPTION
# Problem

Before this patch you could not build the `stage2-LLVM` for example because you first had to manually add it to `CLANG_BOOTSTRAP_TARGETS` in the `Release.cmake` and also add it to `LLVM_RELEASE_FINAL_STAGE_TARGETS` in the cmake configure run. Now you can just use `-DLLVM_RELEASE_FINAL_STAGE_TARGETS="LLVM;clang"` on the cmake CLI and be able to build the targets `stage2-LLVM` and `stage2-clang` without further changes to the cache file.  

# Solution

Take all `LLVM_RELEASE_FINAL_STAGE_TARGETS` elements and append them prefixed with `stage2-` to `CLANG_BOOTSTRAP_TARGETS`. Afterwards all duplicates are removed.