### PR TITLE
[analyzer] Add missing include <unordered_map> to llvm/lib/Support/Z3Solver.cpp

### DIFF
--- a/llvm/lib/Support/Z3Solver.cpp
+++ b/llvm/lib/Support/Z3Solver.cpp
@@ -19,6 +19,7 @@ using namespace llvm;
 #include "llvm/ADT/Twine.h"
 
 #include <set>
+#include <unordered_map>
 
 #include <z3.h>
 


### PR DESCRIPTION
Resolves #106361. Adding #include <unordered_map> to llvm/lib/Support/Z3Solver.cpp fixes compilation errors for homebrew build on macOS with Xcode 14.  https://github.com/Homebrew/homebrew-core/actions/runs/10604291631/job/29390993615?pr=181351 shows that this is resolved when the include is patched in (Linux CI failure is due to unrelated timeout).