### PR TITLE
[AMDGPU] Don't realign already allocated LDS. Point fix for 106412

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -1131,6 +1131,11 @@ private:
         continue;
       }
 
+      if (GV.isAbsoluteSymbolRef()) {
+        // If the variable is already allocated, don't change the alignment
+        continue;
+      }
+
       Align Alignment = AMDGPU::getAlign(DL, &GV);
       TypeSize GVSize = DL.getTypeAllocSize(GV.getValueType());
 

--- a/llvm/test/CodeGen/AMDGPU/lds-no-realign-allocated-variables.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-no-realign-allocated-variables.ll
@@ -1,0 +1,15 @@
+; RUN: opt -S -mtriple=amdgcn-- -passes=amdgpu-lower-module-lds < %s | FileCheck %s
+
+; Can't have a second variable without absolute_symbol showing it is realigned as
+; there is a fatal error on mixing absolute and non-absolute symbols
+
+; CHECK: @lds.dont_realign = internal addrspace(3) global i64 poison, align 2, !absolute_symbol !0
+@lds.dont_realign = internal addrspace(3) global i64 poison, align 2, !absolute_symbol !0
+
+; CHECK: void @use_variables
+define amdgpu_kernel void @use_variables(i64 %val) {
+  store i64 %val, ptr addrspace(3) @lds.dont_realign, align 2
+  ret void
+}
+
+!0 = !{i32 2, i32 3}


### PR DESCRIPTION
Fixes 106412. The logic that skips the pass on already-lowered variables doesn't cover the path that increases alignment of variables. If a variable is allocated at 24 and then given 16 byte alignment, the backend notices and fatal-errors on the inconsistency.