### PR TITLE
[LTO] Turn ImportListsTy into a proper class (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -150,7 +150,24 @@ public:
   };
 
   // A map from destination modules to lists of imports.
-  using ImportListsTy = DenseMap<StringRef, ImportMapTy>;
+  class ImportListsTy {
+  public:
+    ImportListsTy() = default;
+    ImportListsTy(size_t Size) : ListsImpl(Size) {}
+
+    ImportMapTy &operator[](StringRef DestMod) {
+      return ListsImpl.try_emplace(DestMod).first->second;
+    }
+
+    size_t size() const { return ListsImpl.size(); }
+
+    using const_iterator = DenseMap<StringRef, ImportMapTy>::const_iterator;
+    const_iterator begin() const { return ListsImpl.begin(); }
+    const_iterator end() const { return ListsImpl.end(); }
+
+  private:
+    DenseMap<StringRef, ImportMapTy> ListsImpl;
+  };
 
   /// The set contains an entry for every global value that the module exports.
   /// Depending on the user context, this container is allowed to contain


### PR DESCRIPTION
This patch turns ImportListsTy into a class that wraps
DenseMap<StringRef, ImportMapTy>.

Here is the background.  I'm planning to reduce the memory footprint
of ThinLTO indexing.  Specifically, ImportMapTy, the list of imports
for a given destination module, will be a hash set of integer IDs
indexing into a deduplication table of pairs (SourceModule, GUID),
which is a lot like string interning.  I'm planning to put this
deduplication table as part of ImportListsTy and have each instance of
ImportMapTy hold a reference to the deduplication table.

Another reason to wrap the DenseMap is that I need to intercept
operator[]() so that I can construct an instance of ImportMapTy with a
reference to the deduplication table.  Note that the default
implementation of operator[]() would default-construct ImportMapTy,
which I am going to disable.
