### PR TITLE
[include-cleaner] Mark RecordDecls referenced in UsingDecls as explicit

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -203,7 +203,12 @@ public:
   bool VisitUsingDecl(UsingDecl *UD) {
     for (const auto *Shadow : UD->shadows()) {
       auto *TD = Shadow->getTargetDecl();
-      auto IsUsed = TD->isUsed() || TD->isReferenced();
+      // For function-decls, we might have overloads brought in due to
+      // transitive dependencies. Hence we only want to report explicit
+      // references for those if they're used.
+      // But for record decls, spelling of the type always refers to primary
+      // decl non-ambiguously. Hence spelling is already a use.
+      auto IsUsed = TD->isUsed() || TD->isReferenced() || !TD->getAsFunction();
       report(UD->getLocation(), TD,
              IsUsed ? RefType::Explicit : RefType::Ambiguous);
 

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -255,7 +255,7 @@ TEST(WalkAST, TemplateSpecializationsFromUsingDecl) {
   // Class templates
   testWalk(R"cpp(
 namespace ns {
-template<class T> class $ambiguous^Z {};      // primary template
+template<class T> class $explicit^Z {};      // primary template
 template<class T> class $ambiguous^Z<T*> {};  // partial specialization
 template<> class $ambiguous^Z<int> {};        // full specialization
 }
@@ -265,7 +265,7 @@ template<> class $ambiguous^Z<int> {};        // full specialization
   // Var templates
   testWalk(R"cpp(
 namespace ns {
-template<class T> T $ambiguous^foo;      // primary template
+template<class T> T $explicit^foo;      // primary template
 template<class T> T $ambiguous^foo<T*>;  // partial specialization
 template<> int* $ambiguous^foo<int>;     // full specialization
 }
@@ -335,7 +335,12 @@ TEST(WalkAST, Using) {
   testWalk(R"cpp(
     namespace ns {
       template<class T>
-      class $ambiguous^Y {};
+      class $explicit^Y {};
+    })cpp",
+           "using ns::^Y;");
+  testWalk(R"cpp(
+    namespace ns {
+      class $explicit^Y {};
     })cpp",
            "using ns::^Y;");
   testWalk(R"cpp(


### PR DESCRIPTION
We were reporting ambigious references from using declarations as user
can be depending on different overloads of a function just because they
are visible in the TU.
This doesn't apply to records, or primary templates as declaration being
referenced in such cases is unambigious, the ambiguity applies to
specializations though.

Hence this patch returns an explicit reference to record decls and
primary templates of those.
