### PR TITLE
[DXIL][test] Fix a few tests now that HLSL functions are internalized

### DIFF
--- a/llvm/test/tools/dxil-dis/BasicIR.ll
+++ b/llvm/test/tools/dxil-dis/BasicIR.ll
@@ -2,7 +2,7 @@
 
 ; RUN: llc --filetype=obj %s --stop-after=dxil-write-bitcode -o %t && llvm-bcanalyzer --dump-blockinfo %t | FileCheck %s  --check-prefix=BLOCK_INFO
 
-; CHECK: define i32 @foo(i32 %X, i32 %Y) {
+; CHECK: define internal i32 @foo(i32 %X, i32 %Y) {
 ; CHECK:   %Z = sub i32 %X, %Y
 ; CHECK:   %Q = add i32 %Z, %Y
 ; CHECK:   ret i32 %Q

--- a/llvm/test/tools/dxil-dis/debug-info.ll
+++ b/llvm/test/tools/dxil-dis/debug-info.ll
@@ -2,7 +2,7 @@
 target triple = "dxil-unknown-shadermodel6.7-library"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 
-; CHECK: define float @fma(float, float, float) unnamed_addr #0 !dbg [[Fn:[!][0-9]+]]
+; CHECK: define internal float @fma(float, float, float) unnamed_addr #0 !dbg [[Fn:[!][0-9]+]]
 ; Function Attrs: norecurse nounwind readnone willreturn
 define dso_local float @fma(float %0, float %1, float %2) local_unnamed_addr #0 !dbg !6 {
 ; CHECK-NEXT: call void @llvm.dbg.value(metadata float %0, metadata [[VarX:[!][0-9]+]], metadata [[Expr:[!][0-9]+]]), !dbg [[Line1:[!][0-9]+]]

--- a/llvm/test/tools/dxil-dis/opaque-gep.ll
+++ b/llvm/test/tools/dxil-dis/opaque-gep.ll
@@ -7,7 +7,7 @@ define i32 @fn(ptr %0)  {
   ret i32 %3
 }
 
-; CHECK:        define i32 @fn(i32*) 
+; CHECK:        define internal i32 @fn(i32*)
 ; CHECK-NEXT:   %2 = getelementptr i32, i32* %0, i32 4
 ; CHECK-NEXT:   %3 = load i32, i32* %2, align 4
 
@@ -17,6 +17,6 @@ define i32 @fn2(ptr addrspace(1) %0)  {
   ret i32 %3
 }
 
-; CHECK:        define i32 @fn2(i32 addrspace(1)*) 
+; CHECK:        define internal i32 @fn2(i32 addrspace(1)*)
 ; CHECK-NEXT:   %2 = getelementptr i32, i32 addrspace(1)* %0, i32 4
 ; CHECK-NEXT:   %3 = load i32, i32 addrspace(1)* %2, align 4

--- a/llvm/test/tools/dxil-dis/opaque-pointers.ll
+++ b/llvm/test/tools/dxil-dis/opaque-pointers.ll
@@ -7,7 +7,7 @@ define i64 @test(ptr %p) {
   ret i64 %v
 }
 
-; CHECK: define i64 @test(i8* %p) {
+; CHECK: define internal i64 @test(i8* %p) {
 ; CHECK-NEXT: %1 = bitcast i8* %p to i32*
 ; CHECK-NEXT: store i32 0, i32* %1, align 4
 ; CHECK-NEXT: %2 = bitcast i8* %p to i64*
@@ -19,7 +19,7 @@ define i64 @test2(ptr %p) {
   ret i64 %v
 }
 
-; CHECK: define i64 @test2(i64* %p) {
+; CHECK: define internal i64 @test2(i64* %p) {
 ; CHECK-NEXT: store i64 0, i64* %p, align 8
 ; CHECK-NEXT: %v = load i64, i64* %p, align 8
 
@@ -29,7 +29,7 @@ define i64 @test3(ptr addrspace(1) %p) {
   ret i64 %v
 }
 
-; CHECK: define i64 @test3(i8 addrspace(1)* %p) {
+; CHECK: define internal i64 @test3(i8 addrspace(1)* %p) {
 ; CHECK-NEXT: %1 = bitcast i8 addrspace(1)* %p to i32 addrspace(1)*
 ; CHECK-NEXT: store i32 0, i32 addrspace(1)* %1, align 4
 ; CHECK-NEXT: %2 = bitcast i8 addrspace(1)* %p to i64 addrspace(1)*
@@ -41,7 +41,7 @@ define i64 @test4(ptr addrspace(1) %p) {
   ret i64 %v
 }
 
-; CHECK: define i64 @test4(i64 addrspace(1)* %p) {
+; CHECK: define internal i64 @test4(i64 addrspace(1)* %p) {
 ; CHECK-NEXT: store i64 0, i64 addrspace(1)* %p, align 8
 ; CHECK-NEXT: %v = load i64, i64 addrspace(1)* %p, align 8
 
@@ -53,7 +53,7 @@ define i64 @test5(ptr %p) {
   ret i64 %v
 }
 
-; CHECK: define i64 @test5(i8* %p) {
+; CHECK: define internal i64 @test5(i8* %p) {
 ; CHECK-NEXT: %casted = addrspacecast i8* %p to i64 addrspace(1)*
 ; CHECK-NEXT: store i64 0, i64 addrspace(1)* %casted, align 8
 ; CHECK-NEXT: %v = load i64, i64 addrspace(1)* %casted, align 8


### PR DESCRIPTION
These tests have been failing since db279c72f2fe "[HLSL] Change default linkage of HLSL functions to internal (#95331)". This presumably went unnoticed because they're not run by default since they rely on an external tool (dxil-dis).