### PR TITLE
[Instrumentation] Mark instrumented calls as implicit

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
+++ b/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
@@ -949,7 +949,7 @@ void ModuleSanitizerCoverage::InjectCoverageAtBlock(Function &F, BasicBlock &BB,
   DebugLoc EntryLoc;
   if (IsEntryBB) {
     if (auto SP = F.getSubprogram())
-      EntryLoc = DILocation::get(SP->getContext(), SP->getScopeLine(), 0, SP);
+      EntryLoc = DILocation::get(SP->getContext(), 0, 0, SP);
     // Keep static allocas and llvm.localescape calls in the entry block.  Even
     // if we aren't splitting the block, it's nice for allocas to be before
     // calls.

--- a/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
+++ b/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
@@ -949,6 +949,7 @@ void ModuleSanitizerCoverage::InjectCoverageAtBlock(Function &F, BasicBlock &BB,
   DebugLoc EntryLoc;
   if (IsEntryBB) {
     if (auto SP = F.getSubprogram())
+      // Use a compile-generated source-location for all coverage calls.
       EntryLoc = DILocation::get(SP->getContext(), 0, 0, SP);
     // Keep static allocas and llvm.localescape calls in the entry block.  Even
     // if we aren't splitting the block, it's nice for allocas to be before

--- a/llvm/test/Instrumentation/SanitizerCoverage/coverage-dbg.ll
+++ b/llvm/test/Instrumentation/SanitizerCoverage/coverage-dbg.ll
@@ -16,7 +16,7 @@
 
 ; Test that __sanitizer_cov_trace_pc_guard call has !dbg pointing to the opening { of A::f().
 ; CHECK: call void @__sanitizer_cov_trace_pc_guard(ptr{{.*}}) #{{.*}}, !dbg [[A:!.*]]
-; CHECK: [[A]] = !DILocation(line: 6, scope: !{{.*}})
+; CHECK: [[A]] = !DILocation(line: 0, scope: !{{.*}})
 
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/llvm/test/Instrumentation/SanitizerCoverage/coverage-dbg.ll
+++ b/llvm/test/Instrumentation/SanitizerCoverage/coverage-dbg.ll
@@ -14,9 +14,11 @@
 ; clang++ ../1.cc -O3 -g -S -emit-llvm  -fno-strict-aliasing
 ; and add sanitize_address to @_ZN1A1fEv
 
-; Test that __sanitizer_cov_trace_pc_guard call has !dbg pointing to the opening { of A::f().
+; Test that __sanitizer_cov_trace_pc_guard call has !dbg pointing at a
+; compiler-generated instruction.
+
 ; CHECK: call void @__sanitizer_cov_trace_pc_guard(ptr{{.*}}) #{{.*}}, !dbg [[A:!.*]]
-; CHECK: [[A]] = !DILocation(line: 0, scope: !{{.*}})
+; CHECK: [[A]] = !DILocation(line: 1, scope: !{{.*}})
 
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/llvm/test/Instrumentation/SanitizerCoverage/coverage2-dbg.ll
+++ b/llvm/test/Instrumentation/SanitizerCoverage/coverage2-dbg.ll
@@ -20,7 +20,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; CHECK: call void @__sanitizer_cov{{.*}}(ptr{{.*}}) #{{.*}}, !dbg [[A:!.*]]
 ; CHECK: call void @__sanitizer_cov{{.*}}(ptr{{.*}}) #{{.*}}, !dbg [[B:!.*]]
 ; CHECK: ret void
-; CHECK: [[A]] = !DILocation(line: 1, scope: !{{.*}})
+; CHECK: [[A]] = !DILocation(line: 0, scope: !{{.*}})
 ; CHECK: [[B]] = !DILocation(line: 3, column: 5, scope: !{{.*}})
 
 define void @_Z3fooPi(ptr %a) #0 !dbg !4 {

--- a/llvm/test/Instrumentation/SanitizerCoverage/crit-edge-sancov.ll
+++ b/llvm/test/Instrumentation/SanitizerCoverage/crit-edge-sancov.ll
@@ -18,12 +18,11 @@ define void @update_shadow(i1 %c) !dbg !3 {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @__sanitizer_cov_trace_pc() #[[ATTR0:[0-9]+]], !dbg [[DBG6:![0-9]+]]
 ; CHECK:       entry.for.inc.i_crit_edge:
-; CHECK-NEXT:    call void @__sanitizer_cov_trace_pc() #[[ATTR0]], !dbg [[DBG7:![0-9]+]]
+; CHECK-NEXT:    call void @__sanitizer_cov_trace_pc() #[[ATTR0]], !dbg [[DBG6]]
 ; CHECK:       if.end22.i:
-; CHECK-NEXT:    call void @__sanitizer_cov_trace_pc() #[[ATTR0]], !dbg [[DBG8:![0-9]+]]
-; CHECK:       [[DBG6]] = !DILocation(line: 192, scope: !3)
-; CHECK:       [[DBG7]] = !DILocation(line: 0, scope: !3)
-; CHECK:       [[DBG8]] = !DILocation(line: 129, column: 2, scope: !3)
+; CHECK-NEXT:    call void @__sanitizer_cov_trace_pc() #[[ATTR0]], !dbg [[DBG7:![0-9]+]]
+; CHECK:       [[DBG6]] = !DILocation(line: 0, scope: !3)
+; CHECK:       [[DBG7]] = !DILocation(line: 129, column: 2, scope: !3)
 entry:
   br i1 %c, label %for.inc.i, label %if.end22.i
 

--- a/llvm/test/Instrumentation/SanitizerCoverage/missing_dbg.ll
+++ b/llvm/test/Instrumentation/SanitizerCoverage/missing_dbg.ll
@@ -16,7 +16,7 @@ entry:
 ; CHECK-LABEL: @with_dbg
 ; CHECK-NEXT:  entry:
 ; CHECK:       call void @__sanitizer_cov_trace_pc_guard(ptr @__sancov_gen_) #1, !dbg [[DBG1:![0-9]+]]
-; CHECK:       call void @__sanitizer_cov_trace_pc_guard(ptr inttoptr (i64 add (i64 ptrtoint (ptr @__sancov_gen_ to i64), i64 4) to ptr)) #1, !dbg [[DBG2:![0-9]+]]
+; CHECK:       call void @__sanitizer_cov_trace_pc_guard(ptr inttoptr (i64 add (i64 ptrtoint (ptr @__sancov_gen_ to i64), i64 4) to ptr)) #1, !dbg [[DBG1]]
 
 define i32 @without_dbg(ptr %a, ptr %b) {
 entry:
@@ -46,5 +46,4 @@ entry:
 !6 = !DILocation(line: 192, scope: !3)
 !7 = !DILocation(line: 0, scope: !3)
 
-; CHECK:       [[DBG1]] = !DILocation(line: 192, scope: !3)
-; CHECK:       [[DBG2]] = !DILocation(line: 0, scope: !3)
+; CHECK:       [[DBG1]] = !DILocation(line: 0, scope: !3)


### PR DESCRIPTION
Make sure that instrumentation code doesn't interferes with with prologue endpoint computation when generating debug information.

Fix #54873