### PR TITLE
[mlir][polly][llvm-lit] Fixed logic for turning on external shell in lit

### DIFF
--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -23,7 +23,7 @@ config.name = "MLIR"
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-  use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+  use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -18,6 +18,9 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = "MLIR"
 
+# TODO: Consolidate the logic for turning on the internal shell by default for all LLVM test suites.
+# See https://github.com/llvm/llvm-project/issues/106636 for more details.
+#
 # We prefer the lit internal shell which provides a better user experience on failures
 # unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
 use_lit_shell = True

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -23,7 +23,7 @@ config.name = "MLIR"
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-  use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 

--- a/polly/test/UnitIsl/lit.cfg
+++ b/polly/test/UnitIsl/lit.cfg
@@ -22,7 +22,7 @@ config.name = 'Polly - isl unit tests'
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-  use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+	use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 

--- a/polly/test/UnitIsl/lit.cfg
+++ b/polly/test/UnitIsl/lit.cfg
@@ -22,7 +22,7 @@ config.name = 'Polly - isl unit tests'
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-  use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+  use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 

--- a/polly/test/UnitIsl/lit.cfg
+++ b/polly/test/UnitIsl/lit.cfg
@@ -17,6 +17,9 @@ config.name = 'Polly - isl unit tests'
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
 #
+# TODO: Consolidate the logic for turning on the internal shell by default for all LLVM test suites.
+# See https://github.com/llvm/llvm-project/issues/106636 for more details.
+#
 # We prefer the lit internal shell which provides a better user experience on failures
 # unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
 use_lit_shell = True

--- a/polly/test/lit.cfg
+++ b/polly/test/lit.cfg
@@ -20,6 +20,9 @@ config.name = 'Polly'
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
 #
+# TODO: Consolidate the logic for turning on the internal shell by default for all LLVM test suites.
+# See https://github.com/llvm/llvm-project/issues/106636 for more details.
+#
 # We prefer the lit internal shell which provides a better user experience on failures
 # unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
 use_lit_shell = True

--- a/polly/test/lit.cfg
+++ b/polly/test/lit.cfg
@@ -25,7 +25,7 @@ config.name = 'Polly'
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-  use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 

--- a/polly/test/lit.cfg
+++ b/polly/test/lit.cfg
@@ -25,7 +25,7 @@ config.name = 'Polly'
 use_lit_shell = True
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
-  use_lit_shell = not lit.util.pythonize_bool(lit_shell_env)
+  use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 


### PR DESCRIPTION
For both mlir and polly, the lit internal shell is the default shell for running lit tests. However, if the user wanted to switch back to the external shell by setting `LIT_USE_INTERNAL_SHELL=0`, the `not` used in the body of the `if` conditional changes `use_lit_shell` to be True instead of the intended False. Removing `not` allows for this lit config to work as intended.

Fixes https://github.com/llvm/llvm-project/issues/106459.