### PR TITLE
[X86] Don't save/restore fp/bp around terminator

### DIFF
--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -4502,8 +4502,9 @@ void X86FrameLowering::spillFPBP(MachineFunction &MF) const {
     bool InsideEHLabels = false;
     auto MI = MBB.rbegin(), ME = MBB.rend();
     auto TermMI = MBB.getFirstTerminator();
-    if (TermMI != MBB.begin())
-      MI = *(std::prev(TermMI));
+    if (TermMI == MBB.begin())
+      continue;
+    MI = *(std::prev(TermMI));
 
     while (MI != ME) {
       // Skip frame setup/destroy instructions.


### PR DESCRIPTION
In function spillFPBP we already try to skip terminator, but there is a logic error, so when there is only terminator instruction in the MBB, it still tries to save/restore fp/bp around it if the terminator clobbers fp/bp, for example a tail call with ghc calling convention.

Now this patch really skips terminator even if it is the only instruction in the MBB.