### PR TITLE
[DebugInfo] Make a test more robust

### DIFF
--- a/clang/test/CodeGenCXX/debug-info-lambda-this.cpp
+++ b/clang/test/CodeGenCXX/debug-info-lambda-this.cpp
@@ -21,7 +21,8 @@ int main() {
   return 0;
 }
 
-// CHECK: !{![[FOO_THIS:[0-9]+]], ![[FOO_AA:[0-9]+]], ![[FOO_OPERATOR:[0-9]+]]}
+// CHECK: distinct !DICompositeType(tag: DW_TAG_class_type, name: "<lambda_1>", {{.*}}, elements: ![[ELEMENT_TAG:[0-9]+]]
+// CHECK: ![[ELEMENT_TAG]] = !{![[FOO_THIS:[0-9]+]], ![[FOO_AA:[0-9]+]], ![[FOO_OPERATOR:[0-9]+]]}
 // CHECK-NEXT: ![[FOO_THIS]] = !DIDerivedType(tag: DW_TAG_member, name: "__this", scope: ![[#]], file: ![[#]], line: [[#]], baseType: ![[#]], size: [[#]])
 // CHECK-NEXT: ![[FOO_AA]] = !DIDerivedType(tag: DW_TAG_member, name: "aa", scope: ![[#]], file: ![[#]], line: [[#]], baseType: ![[#]], size: [[#]], offset: [[#]])
 // CHECK-NEXT: ![[FOO_OPERATOR]] = !DISubprogram(name: "operator()", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#]], scopeLine: [[#]], flags: DIFlagPublic | DIFlagPrototyped, spFlags: 0)


### PR DESCRIPTION
This was accidentally matching a metadata record that happend to have three elements, but wasn't the record of interest. Add CHECKs to make sure we've found the correct record.