### PR TITLE
[flang] Adjust execute_command_line intrinsic return values for AIX (NFC)

### DIFF
--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -348,8 +348,12 @@ TEST_F(ZeroArguments, ECLGeneralErrorCommandErrorSync) {
 
   RTNAME(ExecuteCommandLine)
   (*command.get(), wait, exitStat.get(), cmdStat.get(), cmdMsg.get());
-#ifdef _WIN32
+#if defined(_WIN32)
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 1);
+  CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 6);
+  CheckDescriptorEqStr(cmdMsg.get(), "Invalid command lineXXXXXXXXX");
+#elif defined(_AIX)
+  CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 2);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 6);
   CheckDescriptorEqStr(cmdMsg.get(), "Invalid command lineXXXXXXXXX");
 #else


### PR DESCRIPTION
AIX's std::system returns different values for command failure.