### PR TITLE
[NVPTX][AA] Traverse use-def chain to find non-generic addrspace

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
@@ -15,10 +15,16 @@
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
 
 #define DEBUG_TYPE "NVPTX-aa"
+
+static cl::opt<unsigned> TraverseAddressSpacesLimit(
+    "nvptx-traverse-address-aliasing-limit", cl::Hidden,
+    cl::desc("Depth limit for finding address space through traversal"),
+    cl::init(6));
 
 AnalysisKey NVPTXAA::Key;
 
@@ -47,6 +53,28 @@ void NVPTXAAWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
 }
 
+static unsigned getAddressSpace(const Value *V, unsigned MaxLookup) {
+  // Find the first non-generic address space traversing the UD chain.
+  // It is undefined behaviour if a pointer belongs to more than one
+  // non-overlapping address spaces along a valid execution path.
+  for (unsigned Count = 0; MaxLookup == 0 || Count < MaxLookup; ++Count) {
+    const auto *PTy = dyn_cast<PointerType>(V->getType());
+    if (!PTy)
+      return AddressSpace::ADDRESS_SPACE_GENERIC;
+
+    const unsigned AS = PTy->getAddressSpace();
+    if (AS != AddressSpace::ADDRESS_SPACE_GENERIC)
+      return AS;
+
+    // Continue traversing if address space is generic
+    const Value *VNext = getUnderlyingObject(V, 1);
+    if (VNext == V)
+      return AddressSpace::ADDRESS_SPACE_GENERIC;
+    V = VNext;
+  }
+  return AddressSpace::ADDRESS_SPACE_GENERIC;
+}
+
 static AliasResult::Kind getAliasResult(unsigned AS1, unsigned AS2) {
   if ((AS1 == ADDRESS_SPACE_GENERIC) || (AS2 == ADDRESS_SPACE_GENERIC))
     return AliasResult::MayAlias;
@@ -70,8 +98,8 @@ static AliasResult::Kind getAliasResult(unsigned AS1, unsigned AS2) {
 AliasResult NVPTXAAResult::alias(const MemoryLocation &Loc1,
                                  const MemoryLocation &Loc2, AAQueryInfo &AAQI,
                                  const Instruction *) {
-  unsigned AS1 = Loc1.Ptr->getType()->getPointerAddressSpace();
-  unsigned AS2 = Loc2.Ptr->getType()->getPointerAddressSpace();
+  unsigned AS1 = getAddressSpace(Loc1.Ptr, TraverseAddressSpacesLimit);
+  unsigned AS2 = getAddressSpace(Loc2.Ptr, TraverseAddressSpacesLimit);
 
   return getAliasResult(AS1, AS2);
 }
@@ -87,11 +115,7 @@ static bool isConstOrParam(unsigned AS) {
 ModRefInfo NVPTXAAResult::getModRefInfoMask(const MemoryLocation &Loc,
                                             AAQueryInfo &AAQI,
                                             bool IgnoreLocals) {
-  if (isConstOrParam(Loc.Ptr->getType()->getPointerAddressSpace()))
-    return ModRefInfo::NoModRef;
-
-  const Value *Base = getUnderlyingObject(Loc.Ptr);
-  if (isConstOrParam(Base->getType()->getPointerAddressSpace()))
+  if (isConstOrParam(getAddressSpace(Loc.Ptr, TraverseAddressSpacesLimit)))
     return ModRefInfo::NoModRef;
 
   return ModRefInfo::ModRef;

--- a/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
@@ -57,18 +57,18 @@ static unsigned getAddressSpace(const Value *V, unsigned MaxLookup) {
   // Find the first non-generic address space traversing the UD chain.
   // It is undefined behaviour if a pointer belongs to more than one
   // non-overlapping address spaces along a valid execution path.
-  auto GetAs = [](const Value *V) -> unsigned {
+  auto GetAS = [](const Value *V) -> unsigned {
     if (const auto *PTy = dyn_cast<PointerType>(V->getType()))
       return PTy->getAddressSpace();
     return ADDRESS_SPACE_GENERIC;
   };
-  while (MaxLookup-- && GetAs(V) == ADDRESS_SPACE_GENERIC) {
+  while (MaxLookup-- && GetAS(V) == ADDRESS_SPACE_GENERIC) {
     const Value *NewV = getUnderlyingObject(V, 1);
     if (NewV == V)
       break;
     V = NewV;
   }
-  return GetAs(V);
+  return GetAS(V);
 }
 
 static AliasResult::Kind getAliasResult(unsigned AS1, unsigned AS2) {

--- a/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
@@ -72,6 +72,9 @@ static unsigned getAddressSpace(const Value *V, unsigned MaxLookup) {
       return AddressSpace::ADDRESS_SPACE_GENERIC;
     V = VNext;
   }
+  // If V's AS is not generic it should be returned above
+  assert(V->getType()->getPointerAddressSpace() ==
+         AddressSpace::ADDRESS_SPACE_GENERIC);
   return AddressSpace::ADDRESS_SPACE_GENERIC;
 }
 

--- a/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAliasAnalysis.cpp
@@ -57,13 +57,13 @@ static unsigned getAddressSpace(const Value *V, unsigned MaxLookup) {
   // Find the first non-generic address space traversing the UD chain.
   // It is undefined behaviour if a pointer belongs to more than one
   // non-overlapping address spaces along a valid execution path.
-  for (unsigned Count = 0; MaxLookup == 0 || Count < MaxLookup; ++Count) {
+  for (unsigned Count = 0;; ++Count) {
     const auto *PTy = dyn_cast<PointerType>(V->getType());
     if (!PTy)
       return AddressSpace::ADDRESS_SPACE_GENERIC;
 
     const unsigned AS = PTy->getAddressSpace();
-    if (AS != AddressSpace::ADDRESS_SPACE_GENERIC)
+    if (AS != AddressSpace::ADDRESS_SPACE_GENERIC || Count >= MaxLookup)
       return AS;
 
     // Continue traversing if address space is generic
@@ -72,10 +72,6 @@ static unsigned getAddressSpace(const Value *V, unsigned MaxLookup) {
       return AddressSpace::ADDRESS_SPACE_GENERIC;
     V = VNext;
   }
-  // If V's AS is not generic it should be returned above
-  assert(V->getType()->getPointerAddressSpace() ==
-         AddressSpace::ADDRESS_SPACE_GENERIC);
-  return AddressSpace::ADDRESS_SPACE_GENERIC;
 }
 
 static AliasResult::Kind getAliasResult(unsigned AS1, unsigned AS2) {


### PR DESCRIPTION
Address space information may be encoded anywhere along the use-def chain. take advantage of this by traversing the chain until we find a non-generic addrspace.