### PR TITLE
[compiler-rt] Remove duplicates of sanitizer_common functions

### DIFF
--- a/compiler-rt/lib/interception/interception_win.cpp
+++ b/compiler-rt/lib/interception/interception_win.cpp
@@ -234,7 +234,7 @@ static bool FunctionHasPadding(uptr address, uptr size) {
 }
 
 static void WritePadding(uptr from, uptr size) {
-  internal_memset((void*)from, 0xCC, (size_t)size);
+  internal_memset((void *)from, 0xCC, (size_t)size);
 }
 
 static void WriteJumpInstruction(uptr from, uptr target) {
@@ -706,7 +706,7 @@ static bool CopyInstructions(uptr to, uptr from, size_t size) {
     if (!instruction_size)
       return false;
     internal_memcpy((void *)(to + cursor), (void *)(from + cursor),
-            (size_t)instruction_size);
+                    (size_t)instruction_size);
     if (rel_offset) {
 #  if SANITIZER_WINDOWS64
       // we want to make sure that the new relative offset still fits in 32-bits
@@ -1013,7 +1013,7 @@ uptr InternalGetProcAddress(void *module, const char *func_name) {
 
         internal_memcpy(function_name, func, funtion_name_length);
         function_name[funtion_name_length] = '\0';
-        char* separator = internal_strchr(function_name, '.');
+        char *separator = internal_strchr(function_name, '.');
         if (!separator)
           InterceptionFailed();
         *separator = '\0';

--- a/compiler-rt/lib/interception/interception_win.cpp
+++ b/compiler-rt/lib/interception/interception_win.cpp
@@ -127,9 +127,11 @@
 #include "interception.h"
 
 #if SANITIZER_WINDOWS
-#include "sanitizer_common/sanitizer_platform.h"
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#  include "sanitizer_common/sanitizer_common.h"
+#  include "sanitizer_common/sanitizer_libc.h"
+#  include "sanitizer_common/sanitizer_platform.h"
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
 
 namespace __interception {
 
@@ -186,40 +188,6 @@ static uptr GetMmapGranularity() {
   return si.dwAllocationGranularity;
 }
 
-UNUSED static uptr RoundUpTo(uptr size, uptr boundary) {
-  return (size + boundary - 1) & ~(boundary - 1);
-}
-
-// FIXME: internal_str* and internal_mem* functions should be moved from the
-// ASan sources into interception/.
-
-static size_t _strlen(const char *str) {
-  const char* p = str;
-  while (*p != '\0') ++p;
-  return p - str;
-}
-
-static char* _strchr(char* str, char c) {
-  while (*str) {
-    if (*str == c)
-      return str;
-    ++str;
-  }
-  return nullptr;
-}
-
-static void _memset(void *p, int value, size_t sz) {
-  for (size_t i = 0; i < sz; ++i)
-    ((char*)p)[i] = (char)value;
-}
-
-static void _memcpy(void *dst, void *src, size_t sz) {
-  char *dst_c = (char*)dst,
-       *src_c = (char*)src;
-  for (size_t i = 0; i < sz; ++i)
-    dst_c[i] = src_c[i];
-}
-
 static bool ChangeMemoryProtection(
     uptr address, uptr size, DWORD *old_protection) {
   return ::VirtualProtect((void*)address, size,
@@ -266,7 +234,7 @@ static bool FunctionHasPadding(uptr address, uptr size) {
 }
 
 static void WritePadding(uptr from, uptr size) {
-  _memset((void*)from, 0xCC, (size_t)size);
+  internal_memset((void*)from, 0xCC, (size_t)size);
 }
 
 static void WriteJumpInstruction(uptr from, uptr target) {
@@ -737,7 +705,7 @@ static bool CopyInstructions(uptr to, uptr from, size_t size) {
     size_t instruction_size = GetInstructionSize(from + cursor, &rel_offset);
     if (!instruction_size)
       return false;
-    _memcpy((void *)(to + cursor), (void *)(from + cursor),
+    internal_memcpy((void *)(to + cursor), (void *)(from + cursor),
             (size_t)instruction_size);
     if (rel_offset) {
 #  if SANITIZER_WINDOWS64
@@ -1027,7 +995,7 @@ uptr InternalGetProcAddress(void *module, const char *func_name) {
 
   for (DWORD i = 0; i < exports->NumberOfNames; i++) {
     RVAPtr<char> name(module, names[i]);
-    if (!strcmp(func_name, name)) {
+    if (!internal_strcmp(func_name, name)) {
       DWORD index = ordinals[i];
       RVAPtr<char> func(module, functions[index]);
 
@@ -1039,13 +1007,13 @@ uptr InternalGetProcAddress(void *module, const char *func_name) {
         // format: "<module> . <function_name>" that is stored into the
         // exported directory.
         char function_name[256];
-        size_t funtion_name_length = _strlen(func);
+        size_t funtion_name_length = internal_strlen(func);
         if (funtion_name_length >= sizeof(function_name) - 1)
           InterceptionFailed();
 
-        _memcpy(function_name, func, funtion_name_length);
+        internal_memcpy(function_name, func, funtion_name_length);
         function_name[funtion_name_length] = '\0';
-        char* separator = _strchr(function_name, '.');
+        char* separator = internal_strchr(function_name, '.');
         if (!separator)
           InterceptionFailed();
         *separator = '\0';


### PR DESCRIPTION
These functions in interception_win.cpp already exist in
sanitizer_common. Use those instead.
