### PR TITLE
[C++20] [Modules] Don't insert class not in named modules to PendingEmittingVTables

### DIFF
--- a/clang/include/clang/Serialization/ASTWriter.h
+++ b/clang/include/clang/Serialization/ASTWriter.h
@@ -500,8 +500,8 @@ private:
   std::vector<SourceRange> NonAffectingRanges;
   std::vector<SourceLocation::UIntTy> NonAffectingOffsetAdjustments;
 
-  /// A list of classes which need to emit the VTable in the corresponding
-  /// object file.
+  /// A list of classes in named modules which need to emit the VTable in
+  /// the corresponding object file.
   llvm::SmallVector<CXXRecordDecl *> PendingEmittingVTables;
 
   /// Computes input files that didn't affect compilation of the current module,

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -3963,6 +3963,9 @@ void ASTWriter::WriteIdentifierTable(Preprocessor &PP,
 }
 
 void ASTWriter::handleVTable(CXXRecordDecl *RD) {
+  if (!RD->isInNamedModule())
+    return;
+
   PendingEmittingVTables.push_back(RD);
 }
 

--- a/clang/test/Modules/pr106483.cppm
+++ b/clang/test/Modules/pr106483.cppm
@@ -1,0 +1,39 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++23 %t/a.cppm -emit-module-interface -o %t/a.pcm
+// RUN: %clang_cc1 -std=c++23 %t/b.cppm -emit-module-interface -o %t/b.pcm \
+// RUN:   -fprebuilt-module-path=%t
+// RUN: %clang_cc1 -std=c++23 -fprebuilt-module-path=%t %t/b.pcm -emit-llvm \
+// RUN:     -disable-llvm-passes -o - | FileCheck %t/b.cppm
+
+//--- a.cppm
+module;
+
+struct base {
+    virtual void f() const;
+};
+
+inline void base::f() const {
+}
+
+export module a;
+export using ::base;
+
+//--- b.cppm
+module;
+
+struct base {
+    virtual void f() const;
+};
+
+inline void base::f() const {
+}
+
+export module b;
+import a;
+export using ::base;
+
+// We only need to check that the IR are successfully emitted instead of crash.
+// CHECK: define

--- a/clang/test/Modules/pr106483.cppm
+++ b/clang/test/Modules/pr106483.cppm
@@ -35,5 +35,7 @@ export module b;
 import a;
 export using ::base;
 
+export extern "C" void func() {}
+
 // We only need to check that the IR are successfully emitted instead of crash.
-// CHECK: define
+// CHECK: func


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/102933

The root cause of the issue is an oversight in
https://github.com/llvm/llvm-project/pull/102287 that I didn't notice that PendingEmittingVTables should only accept classes in named modules.