### PR TITLE
[llvm][Docs] Update guide to include ``pip install lit``

### DIFF
--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -12,7 +12,7 @@ Quickstart
    lit 20.0.0dev
    ```
 
-   An alternative is installing it as a Python package in a python virtual
+   An alternative is installing it as a Python package in a Python virtual
    environment:
 
    ```bash
@@ -24,8 +24,9 @@ Quickstart
    ```
 
    Installing the official Python release of lit in a Python virtual
-   environment would also work. This will install the most recent 
+   environment could also work. This will install the most recent 
    release of lit:
+
    ```bash
    % python3 -m venv .venv
    % . .venv/bin/activate
@@ -33,6 +34,9 @@ Quickstart
    % lit --version
    lit 18.1.8
    ```
+
+   Please note that recent tests may rely on features not in the latest released lit. 
+   If in doubt, try one of the previous methods.
 
 2. Check out the `test-suite` module with:
 

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -24,7 +24,8 @@ Quickstart
    ```
 
    Installing the official Python release of lit in a Python virtual
-   environment would also work.
+   environment would also work. This will install the most recent 
+   release of lit:
    ```bash
    % python3 -m venv .venv
    % . .venv/bin/activate

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -9,10 +9,10 @@ Quickstart
 
    ```bash
    % <path to llvm build>/bin/llvm-lit --version
-   lit 0.8.0dev
+   lit 20.0.0dev
    ```
 
-   An alternative is installing it as a python package in a python virtual
+   An alternative is installing it as a Python package in a python virtual
    environment:
 
    ```bash
@@ -20,7 +20,17 @@ Quickstart
    % . .venv/bin/activate
    % pip install git+https://github.com/llvm/llvm-project.git#subdirectory=llvm/utils/lit
    % lit --version
-   lit 0.8.0dev
+   lit 20.0.0dev
+   ```
+
+   Installing the official Python release of lit in a Python virtual
+   environment would also work.
+   ```bash
+   % python3 -m venv .venv
+   % . .venv/bin/activate
+   % pip install lit
+   % lit --version
+   lit 18.1.8
    ```
 
 2. Check out the `test-suite` module with:


### PR DESCRIPTION
Also updates and clarifies which version would be installed.

As per https://discourse.llvm.org/t/information-on-lit-is-outdated/76498/10?u=mch_dj7.