### PR TITLE
[IR] Make @llvm.memset prototype byte width dependent

### DIFF
--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3163,7 +3163,7 @@ LLVM_C_ABI LLVMValueRef LLVMGetIntrinsicDeclaration(LLVMModuleRef Mod,
  *
  * @see llvm::Intrinsic::getType()
  */
-LLVM_C_ABI LLVMTypeRef LLVMIntrinsicGetType(LLVMContextRef Ctx, unsigned ID,
+LLVM_C_ABI LLVMTypeRef LLVMIntrinsicGetType(LLVMModuleRef Mod, unsigned ID,
                                             LLVMTypeRef *OverloadTypes,
                                             size_t OverloadCount);
 

--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -24,6 +24,7 @@
 
 namespace llvm {
 
+class DataLayout;
 class Type;
 class FunctionType;
 class Function;
@@ -77,7 +78,7 @@ LLVM_ABI std::string getName(ID Id, ArrayRef<Type *> OverloadTys, Module *M,
 LLVM_ABI std::string getNameNoUnnamedTypes(ID Id, ArrayRef<Type *> OverloadTys);
 
 /// Return the function type for an intrinsic.
-LLVM_ABI FunctionType *getType(LLVMContext &Context, ID id,
+LLVM_ABI FunctionType *getType(const Module *M, ID id,
                                ArrayRef<Type *> OverloadTys = {});
 
 /// Returns true if the intrinsic can be overloaded.
@@ -161,6 +162,7 @@ struct IITDescriptor {
   enum IITDescriptorKind {
     // Concrete types. Additional qualifiers listed in comments.
     Void,
+    Byte,
     VarArg,
     MMX,
     Token,
@@ -278,7 +280,8 @@ getIntrinsicInfoTableEntries(ID id, SmallVectorImpl<IITDescriptor> &T);
 /// Returns false if the given ID and function type combination is not a
 /// valid intrinsic call. Also prints the error message to indicate the reason
 /// of the mismatch to \p OS.
-LLVM_ABI bool isSignatureValid(Intrinsic::ID ID, FunctionType *FT,
+LLVM_ABI bool isSignatureValid(const DataLayout &DL, Intrinsic::ID ID,
+                               FunctionType *FT,
                                SmallVectorImpl<Type *> &OverloadTys,
                                raw_ostream &OS = nulls());
 

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -361,6 +361,7 @@ def IIT_V6 : IIT_Vec<6, 50>;
 def IIT_V10 : IIT_Vec<10, 51>;
 def IIT_V2048 : IIT_Vec<2048, 52>;
 def IIT_V4096 : IIT_Vec<4096, 53>;
+def IIT_BYTE : IIT_Base<54>;
 }
 
 defvar IIT_all_FixedTypes = !filter(iit, IIT_all,
@@ -397,6 +398,10 @@ class LLVMType<ValueType vt> {
     !foreach(iit, IIT_Vecs, iit.Number),
     !if(vt.isScalable, [IIT_SCALABLE_VEC.Number], []),
     !foreach(iit, IITs,     iit.Number));
+}
+
+class LLVMByteType : LLVMType<OtherVT> {
+  let Sig = [IIT_BYTE.Number];
 }
 
 class LLVMAnyType<ValueType vt> : LLVMType<vt> {
@@ -548,7 +553,7 @@ class LLVMVectorOfAnyPointersToElt<int oidx>
 
 
 def llvm_void_ty       : LLVMType<isVoid>;
-
+def llvm_byte_ty       : LLVMByteType;
 def llvm_any_ty        : LLVMAnyType<Any>;
 def llvm_anyint_ty     : LLVMAnyType<iAny>;
 def llvm_anyfloat_ty   : LLVMAnyType<fAny>;
@@ -1089,7 +1094,7 @@ def int_memmove : DefaultAttrsIntrinsic<[],
                              WriteOnly<ArgIndex<0>>, ReadOnly<ArgIndex<1>>,
                              ImmArg<ArgIndex<3>>]>;
 def int_memset  : DefaultAttrsIntrinsic<[],
-                            [llvm_anyptr_ty, llvm_i8_ty, llvm_anyint_ty,
+                            [llvm_anyptr_ty, llvm_byte_ty, llvm_anyint_ty,
                              llvm_i1_ty],
                             [IntrWriteMem, IntrArgMemOnly,
                              NoCapture<ArgIndex<0>>, WriteOnly<ArgIndex<0>>,
@@ -1101,7 +1106,7 @@ def int_memset  : DefaultAttrsIntrinsic<[],
 // The third argument (specifying the size) must be a constant.
 def int_memset_inline
     : DefaultAttrsIntrinsic<[],
-      [llvm_anyptr_ty, llvm_i8_ty, llvm_anyint_ty, llvm_i1_ty],
+      [llvm_anyptr_ty, llvm_byte_ty, llvm_anyint_ty, llvm_i1_ty],
       [IntrWriteMem, IntrArgMemOnly,
        NoCapture<ArgIndex<0>>, WriteOnly<ArgIndex<0>>,
        ImmArg<ArgIndex<3>>]>;
@@ -2751,7 +2756,7 @@ def int_memmove_element_unordered_atomic
 
 // @llvm.memset.element.unordered.atomic.*(dest, value, length, elementsize)
 def int_memset_element_unordered_atomic
-    : Intrinsic<[], [llvm_anyptr_ty, llvm_i8_ty, llvm_anyint_ty, llvm_i32_ty],
+    : Intrinsic<[], [llvm_anyptr_ty, llvm_byte_ty, llvm_anyint_ty, llvm_i32_ty],
                 [IntrWriteMem, IntrArgMemOnly, IntrWillReturn, IntrNoSync,
                  NoCapture<ArgIndex<0>>, WriteOnly<ArgIndex<0>>,
                  ImmArg<ArgIndex<3>>]>;

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -346,7 +346,8 @@ bool LLParser::validateEndOfModule(bool UpgradeDebugInfo) {
 
         SmallVector<Type *> OverloadTys;
         if (IID != Intrinsic::not_intrinsic &&
-            Intrinsic::isSignatureValid(IID, CB->getFunctionType(), OverloadTys,
+            Intrinsic::isSignatureValid(M->getDataLayout(), IID,
+                                        CB->getFunctionType(), OverloadTys,
                                         ErrorOS)) {
           U.set(Intrinsic::getOrInsertDeclaration(M, IID, OverloadTys));
         } else {

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1911,7 +1911,8 @@ bool llvm::UpgradeIntrinsicFunction(Function *F, Function *&NewFn,
   if (Intrinsic::ID id = F->getIntrinsicID()) {
     // Only do this if the intrinsic signature is valid.
     SmallVector<Type *> OverloadTys;
-    if (Intrinsic::isSignatureValid(id, F->getFunctionType(), OverloadTys))
+    if (Intrinsic::isSignatureValid(F->getDataLayout(), id,
+                                    F->getFunctionType(), OverloadTys))
       F->setAttributes(
           Intrinsic::getAttributes(F->getContext(), id, F->getFunctionType()));
   }

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -2568,12 +2568,12 @@ const char *LLVMIntrinsicGetName(unsigned ID, size_t *NameLength) {
   return Str.data();
 }
 
-LLVMTypeRef LLVMIntrinsicGetType(LLVMContextRef Ctx, unsigned ID,
+LLVMTypeRef LLVMIntrinsicGetType(LLVMModuleRef Mod, unsigned ID,
                                  LLVMTypeRef *OverloadTypes,
                                  size_t OverloadCount) {
   auto IID = llvm_map_to_intrinsic_id(ID);
   ArrayRef<Type *> OverloadTys(unwrap(OverloadTypes), OverloadCount);
-  return wrap(llvm::Intrinsic::getType(*unwrap(Ctx), IID, OverloadTys));
+  return wrap(llvm::Intrinsic::getType(unwrap(Mod), IID, OverloadTys));
 }
 
 char *LLVMIntrinsicCopyOverloadedName(unsigned ID, LLVMTypeRef *OverloadTypes,

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -508,7 +508,9 @@ Function::Function(FunctionType *Ty, LinkageTypes Linkage, unsigned AddrSpace,
     // Don't set the attributes if the intrinsic signature is invalid. This
     // case will either be auto-upgraded or fail verification.
     SmallVector<Type *> OverloadTys;
-    if (!Intrinsic::isSignatureValid(IntID, Ty, OverloadTys))
+    assert(ParentModule);
+    if (!Intrinsic::isSignatureValid(ParentModule->getDataLayout(), IntID, Ty,
+                                     OverloadTys))
       return;
 
     setAttributes(Intrinsic::getAttributes(getContext(), IntID, Ty));

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -38,7 +38,7 @@
 using namespace llvm;
 
 // Forward declaration of static functions.
-static bool isSignatureValid(FunctionType *FTy,
+static bool isSignatureValid(const DataLayout &DL, FunctionType *FTy,
                              ArrayRef<Intrinsic::IITDescriptor> &Infos,
                              unsigned NumArgs, bool IsVarArg,
                              SmallVectorImpl<Type *> &OverloadTys,
@@ -180,9 +180,9 @@ static std::string getIntrinsicNameImpl(Intrinsic::ID Id,
   if (HasUnnamedType) {
     assert(M && "unnamed types need a module");
     if (!FT)
-      FT = Intrinsic::getType(M->getContext(), Id, OverloadTys);
+      FT = Intrinsic::getType(M, Id, OverloadTys);
     else
-      assert(FT == Intrinsic::getType(M->getContext(), Id, OverloadTys) &&
+      assert(FT == Intrinsic::getType(M, Id, OverloadTys) &&
              "Provided FunctionType must match arguments");
     return M->getUniqueIntrinsicName(Result, Id, FT);
   }
@@ -230,6 +230,9 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
   switch (Info) {
   case IIT_Done:
     OutputTable.push_back(IITDescriptor::get(IITDescriptor::Void, 0));
+    return;
+  case IIT_BYTE:
+    OutputTable.push_back(IITDescriptor::get(IITDescriptor::Byte, 0));
     return;
   case IIT_VARARG:
     OutputTable.push_back(IITDescriptor::get(IITDescriptor::VarArg, 0));
@@ -517,8 +520,8 @@ Intrinsic::getIntrinsicInfoTableEntries(ID id,
 }
 
 static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
-                             ArrayRef<Type *> OverloadTys,
-                             LLVMContext &Context) {
+                             ArrayRef<Type *> OverloadTys, LLVMContext &Context,
+                             const DataLayout &DL) {
   using namespace Intrinsic;
 
   IITDescriptor D = Infos.consume_front();
@@ -526,6 +529,8 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
   switch (D.Kind) {
   case IITDescriptor::Void:
     return Type::getVoidTy(Context);
+  case IITDescriptor::Byte:
+    return Type::getIntNTy(Context, DL.getByteWidth());
   case IITDescriptor::MMX:
     return llvm::FixedVectorType::get(llvm::IntegerType::get(Context, 64), 1);
   case IITDescriptor::AMX:
@@ -552,14 +557,14 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::Integer:
     return IntegerType::get(Context, D.IntegerWidth);
   case IITDescriptor::Vector:
-    return VectorType::get(DecodeFixedType(Infos, OverloadTys, Context),
+    return VectorType::get(DecodeFixedType(Infos, OverloadTys, Context, DL),
                            D.VectorWidth);
   case IITDescriptor::Pointer:
     return PointerType::get(Context, D.PointerAddressSpace);
   case IITDescriptor::Struct: {
     SmallVector<Type *, 8> Elts;
     for (unsigned i = 0, e = D.StructNumElements; i != e; ++i)
-      Elts.push_back(DecodeFixedType(Infos, OverloadTys, Context));
+      Elts.push_back(DecodeFixedType(Infos, OverloadTys, Context, DL));
     return StructType::get(Context, Elts);
   }
   // For any overload kind or partially dependent type, substitute it with the
@@ -584,7 +589,7 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
         cast<VectorType>(OverloadTys[D.getOverloadIndex()]),
         D.getVectorDivisor());
   case IITDescriptor::SameVecWidth: {
-    Type *EltTy = DecodeFixedType(Infos, OverloadTys, Context);
+    Type *EltTy = DecodeFixedType(Infos, OverloadTys, Context, DL);
     Type *Ty = OverloadTys[D.getOverloadIndex()];
     if (auto *VTy = dyn_cast<VectorType>(Ty))
       return VectorType::get(EltTy, VTy->getElementCount());
@@ -610,16 +615,18 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
   llvm_unreachable("unhandled");
 }
 
-FunctionType *Intrinsic::getType(LLVMContext &Context, ID id,
+FunctionType *Intrinsic::getType(const Module *M, ID id,
                                  ArrayRef<Type *> OverloadTys) {
   SmallVector<IITDescriptor, 8> Table;
   auto [TableRef, _, IsVarArg] = getIntrinsicInfoTableEntries(id, Table);
 
-  Type *ResultTy = DecodeFixedType(TableRef, OverloadTys, Context);
+  Type *ResultTy = DecodeFixedType(TableRef, OverloadTys, M->getContext(),
+                                   M->getDataLayout());
 
   SmallVector<Type *, 8> ArgTys;
   while (!TableRef.empty())
-    ArgTys.push_back(DecodeFixedType(TableRef, OverloadTys, Context));
+    ArgTys.push_back(DecodeFixedType(TableRef, OverloadTys, M->getContext(),
+                                     M->getDataLayout()));
   return FunctionType::get(ResultTy, ArgTys, IsVarArg);
 }
 
@@ -779,7 +786,7 @@ Function *Intrinsic::getOrInsertDeclaration(Module *M, ID id,
                                             ArrayRef<Type *> OverloadTys) {
   // There can never be multiple globals with the same name of different types,
   // because intrinsics must be a specific type.
-  FunctionType *FT = getType(M->getContext(), id, OverloadTys);
+  FunctionType *FT = getType(M, id, OverloadTys);
   return getOrInsertIntrinsicDeclarationImpl(M, id, OverloadTys, FT);
 }
 
@@ -796,8 +803,9 @@ Function *Intrinsic::getOrInsertDeclaration(Module *M, ID id, Type *RetTy,
 
   // Automatically determine the overloaded types.
   SmallVector<Type *, 4> OverloadTys;
-  [[maybe_unused]] bool IsValid = ::isSignatureValid(
-      FTy, TableRef, NumArgs, IsVarArg, OverloadTys, nulls());
+  [[maybe_unused]] bool IsValid =
+      ::isSignatureValid(M->getDataLayout(), FTy, TableRef, NumArgs, IsVarArg,
+                         OverloadTys, nulls());
   assert(IsValid && "intrinsic signature mismatch");
   return getOrInsertIntrinsicDeclarationImpl(M, id, OverloadTys, FTy);
 }
@@ -848,7 +856,8 @@ using DeferredIntrinsicMatchPair =
     std::pair<Type *, ArrayRef<Intrinsic::IITDescriptor>>;
 
 static bool
-matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
+matchIntrinsicType(const DataLayout &DL, Type *Ty,
+                   ArrayRef<Intrinsic::IITDescriptor> &Infos,
                    SmallVectorImpl<Type *> &OverloadTys,
                    SmallVectorImpl<DeferredIntrinsicMatchPair> &DeferredChecks,
                    bool IsDeferredCheck) {
@@ -870,6 +879,8 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   switch (D.Kind) {
   case IITDescriptor::Void:
     return !Ty->isVoidTy();
+  case IITDescriptor::Byte:
+    return !Ty->isIntegerTy(DL.getByteWidth());
   case IITDescriptor::MMX: {
     FixedVectorType *VT = dyn_cast<FixedVectorType>(Ty);
     return !VT || VT->getNumElements() != 1 ||
@@ -901,7 +912,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::Vector: {
     VectorType *VT = dyn_cast<VectorType>(Ty);
     return !VT || VT->getElementCount() != D.VectorWidth ||
-           matchIntrinsicType(VT->getElementType(), Infos, OverloadTys,
+           matchIntrinsicType(DL, VT->getElementType(), Infos, OverloadTys,
                               DeferredChecks, IsDeferredCheck);
   }
   case IITDescriptor::Pointer: {
@@ -916,7 +927,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return true;
 
     for (unsigned i = 0, e = D.StructNumElements; i != e; ++i)
-      if (matchIntrinsicType(ST->getElementType(i), Infos, OverloadTys,
+      if (matchIntrinsicType(DL, ST->getElementType(i), Infos, OverloadTys,
                              DeferredChecks, IsDeferredCheck))
         return true;
     return false;
@@ -998,7 +1009,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
         return true;
       EltTy = ThisArgType->getElementType();
     }
-    return matchIntrinsicType(EltTy, Infos, OverloadTys, DeferredChecks,
+    return matchIntrinsicType(DL, EltTy, Infos, OverloadTys, DeferredChecks,
                               IsDeferredCheck);
   }
   case IITDescriptor::VecOfAnyPtrsToElt: {
@@ -1074,13 +1085,13 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
 ///
 /// If the type is not valid, returns false and prints an error message to
 /// \p OS.
-static bool isSignatureValid(FunctionType *FTy,
+static bool isSignatureValid(const DataLayout &DL, FunctionType *FTy,
                              ArrayRef<Intrinsic::IITDescriptor> &Infos,
                              unsigned NumArgs, bool IsVarArg,
                              SmallVectorImpl<Type *> &OverloadTys,
                              raw_ostream &OS) {
   SmallVector<DeferredIntrinsicMatchPair, 2> DeferredChecks;
-  if (matchIntrinsicType(FTy->getReturnType(), Infos, OverloadTys,
+  if (matchIntrinsicType(DL, FTy->getReturnType(), Infos, OverloadTys,
                          DeferredChecks, false)) {
     OS << "intrinsic has incorrect return type!";
     return false;
@@ -1094,7 +1105,7 @@ static bool isSignatureValid(FunctionType *FTy,
   }
 
   for (Type *Ty : FTy->params()) {
-    if (matchIntrinsicType(Ty, Infos, OverloadTys, DeferredChecks, false)) {
+    if (matchIntrinsicType(DL, Ty, Infos, OverloadTys, DeferredChecks, false)) {
       OS << "intrinsic has incorrect argument type!";
       return false;
     }
@@ -1102,7 +1113,7 @@ static bool isSignatureValid(FunctionType *FTy,
 
   for (unsigned I = 0, E = DeferredChecks.size(); I != E; ++I) {
     DeferredIntrinsicMatchPair &Check = DeferredChecks[I];
-    if (!matchIntrinsicType(Check.first, Check.second, OverloadTys,
+    if (!matchIntrinsicType(DL, Check.first, Check.second, OverloadTys,
                             DeferredChecks, true))
       continue;
     if (I < NumDeferredReturnChecks)
@@ -1135,7 +1146,8 @@ bool Intrinsic::hasStructReturnType(ID id) {
   return !Table.empty() && Table[0].Kind == IITDescriptor::Struct;
 }
 
-bool Intrinsic::isSignatureValid(Intrinsic::ID ID, FunctionType *FT,
+bool Intrinsic::isSignatureValid(const DataLayout &DL, Intrinsic::ID ID,
+                                 FunctionType *FT,
                                  SmallVectorImpl<Type *> &OverloadTys,
                                  raw_ostream &OS) {
   if (!ID)
@@ -1144,14 +1156,15 @@ bool Intrinsic::isSignatureValid(Intrinsic::ID ID, FunctionType *FT,
   SmallVector<Intrinsic::IITDescriptor, 8> Table;
   auto [TableRef, NumArgs, IsVarArg] = getIntrinsicInfoTableEntries(ID, Table);
 
-  return ::isSignatureValid(FT, TableRef, NumArgs, IsVarArg, OverloadTys, OS);
+  return ::isSignatureValid(DL, FT, TableRef, NumArgs, IsVarArg, OverloadTys,
+                            OS);
 }
 
 bool Intrinsic::isSignatureValid(Function *F,
                                  SmallVectorImpl<Type *> &OverloadTys,
                                  raw_ostream &OS) {
-  return isSignatureValid(F->getIntrinsicID(), F->getFunctionType(),
-                          OverloadTys, OS);
+  return isSignatureValid(F->getDataLayout(), F->getIntrinsicID(),
+                          F->getFunctionType(), OverloadTys, OS);
 }
 
 std::optional<Function *> Intrinsic::remangleIntrinsicFunction(Function *F) {

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5961,7 +5961,7 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
   std::string ErrMsg;
   raw_string_ostream ErrOS(ErrMsg);
   SmallVector<Type *, 4> OverloadTys;
-  bool IsValid = Intrinsic::isSignatureValid(ID, IFTy, OverloadTys, ErrOS);
+  bool IsValid = Intrinsic::isSignatureValid(DL, ID, IFTy, OverloadTys, ErrOS);
   Check(IsValid, ErrMsg, IF);
 
   // Now that we have the intrinsic ID and the actual argument types (and we

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -19663,8 +19663,9 @@ Align SITargetLowering::computeKnownAlignForTargetInstr(
     // site specifies a lower alignment?
     Intrinsic::ID IID = GI->getIntrinsicID();
     LLVMContext &Ctx = VT.getMachineFunction().getFunction().getContext();
+    const Module *M = VT.getMachineFunction().getFunction().getParent();
     AttributeList Attrs =
-        Intrinsic::getAttributes(Ctx, IID, Intrinsic::getType(Ctx, IID));
+        Intrinsic::getAttributes(Ctx, IID, Intrinsic::getType(M, IID));
     if (MaybeAlign RetAlign = Attrs.getRetAlignment())
       return *RetAlign;
   }

--- a/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
@@ -1580,7 +1580,7 @@ Value *NumericalStabilitySanitizer::maybeHandleKnownCallBase(
   // Check that the widened intrinsic is valid.
   SmallVector<Type *, 4> OverloadTys;
   [[maybe_unused]] bool IsValid =
-      Intrinsic::isSignatureValid(WidenedId, WidenedFnTy, OverloadTys);
+      Intrinsic::isSignatureValid(DL, WidenedId, WidenedFnTy, OverloadTys);
   assert(IsValid && "invalid widened intrinsic");
   // For known intrinsic functions, we create a second call to the same
   // intrinsic with a different type.

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -94,7 +94,8 @@ getOverloadedDeclaration(CallIntrinsicOp op, llvm::Intrinsic::ID id,
   std::string errorMsg;
   llvm::raw_string_ostream errorOS(errorMsg);
   SmallVector<llvm::Type *, 8> overloadedTys;
-  if (!llvm::Intrinsic::isSignatureValid(id, ft, overloadedTys, errorOS)) {
+  if (!llvm::Intrinsic::isSignatureValid(module->getDataLayout(), id, ft,
+                                         overloadedTys, errorOS)) {
     return mlir::emitError(op.getLoc(), "call intrinsic signature ")
            << diagStr(ft) << " to overloaded intrinsic " << op.getIntrinAttr()
            << " does not match any of the overloads: " << errorMsg;


### PR DESCRIPTION
This patch changes the type of the value argument of @llvm.memset and
similar intrinsics from i8 to iN, where N is the byte width specified
in data layout string.
Note that the argument still has fixed type (not overloaded), but type
checker will complain if the type does not match the byte width.

Ideally, the type of the argument would be dependent on the address
space of the pointer argument. It is easy to do this (and I did it
downstream as a PoC), but since data layout string doesn't currently
allow different byte widths for different address spaces, I refrained
from doing it now.