### PR TITLE
[ValueTracking] Add CharWidth argument to getConstantStringInfo (NFC)

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/AMDGPU.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/AMDGPU.cpp
@@ -399,7 +399,7 @@ void CodeGenFunction::ProcessOrderScopeAMDGCN(Value *Order, Value *Scope,
 
   // Some of the atomic builtins take the scope as a string name.
   StringRef scp;
-  if (llvm::getConstantStringInfo(Scope, scp)) {
+  if (llvm::getConstantStringInfo(Scope, scp, /*CharWidth=*/8)) {
     if (getTarget().getTriple().isSPIRV())
       scp = mapScopeToSPIRV(scp);
     SSID = getLLVMContext().getOrInsertSyncScopeID(scp);
@@ -445,7 +445,7 @@ void CodeGenFunction::AddAMDGPUFenceAddressSpaceMMRA(llvm::Instruction *Inst,
   for (unsigned K = 2; K < E->getNumArgs(); ++K) {
     llvm::Value *V = EmitScalarExpr(E->getArg(K));
     StringRef AS;
-    if (llvm::getConstantStringInfo(V, AS)) {
+    if (llvm::getConstantStringInfo(V, AS, /*CharWidth=*/8)) {
       MMRAs.push_back({Tag, AS});
       // TODO: Delete the resulting unused constant?
       continue;

--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -415,7 +415,7 @@ LLVM_ABI bool getConstantDataArrayInfo(const Value *V,
 /// trailing null characters as well as any other characters that come after
 /// it.
 LLVM_ABI bool getConstantStringInfo(const Value *V, StringRef &Str,
-                                    bool TrimAtNul = true);
+                                    unsigned CharWidth, bool TrimAtNul = true);
 
 /// If we can compute the length of the string pointed to by the specified
 /// pointer, return 'len+1'.  If we can't, return 0.

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6746,9 +6746,12 @@ bool llvm::getConstantDataArrayInfo(const Value *V,
 /// return true.  When TrimAtNul is set, Str will contain only the bytes up
 /// to but not including the first nul.  Return false on failure.
 bool llvm::getConstantStringInfo(const Value *V, StringRef &Str,
-                                 bool TrimAtNul) {
+                                 unsigned CharWidth, bool TrimAtNul) {
+  if (CharWidth != CHAR_BIT)
+    return false;
+
   ConstantDataArraySlice Slice;
-  if (!getConstantDataArrayInfo(V, Slice, 8))
+  if (!getConstantDataArrayInfo(V, Slice, CharWidth))
     return false;
 
   if (Slice.Array == nullptr) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
@@ -121,7 +121,7 @@ static_assert(NonLiteralStr.size() == 3);
 
 static StringRef getAsConstantStr(Value *V) {
   StringRef S;
-  if (!getConstantStringInfo(V, S))
+  if (!getConstantStringInfo(V, S, /*CharWidth=*/8))
     S = NonLiteralStr;
 
   return S;
@@ -154,7 +154,7 @@ bool AMDGPUPrintfRuntimeBindingImpl::lowerPrintfForGpu(Module &M) {
     Value *Op = CI->getArgOperand(0);
 
     StringRef FormatStr;
-    if (!getConstantStringInfo(Op, FormatStr)) {
+    if (!getConstantStringInfo(Op, FormatStr, /*CharWidth=*/8)) {
       Value *Stripped = Op->stripPointerCasts();
       if (!isa<UndefValue>(Stripped) && !isa<ConstantPointerNull>(Stripped))
         diagnoseInvalidFormatString(CI);

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -734,7 +734,7 @@ void SPIRVAsmPrinter::outputAnnotations(const Module &M) {
 
       StringRef AnnotationString;
       [[maybe_unused]] bool Success =
-          getConstantStringInfo(GV, AnnotationString);
+          getConstantStringInfo(GV, AnnotationString, /*CharWidth=*/8);
       assert(Success && "Failed to get annotation string");
       MCInst Inst;
       Inst.setOpcode(SPIRV::OpDecorate);

--- a/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
@@ -182,7 +182,7 @@ static std::string getAnnotation(Value *AnnoVal, Value *OptAnnoVal) {
   std::string Anno;
   if (auto *C = dyn_cast_or_null<Constant>(AnnoVal)) {
     StringRef Str;
-    if (getConstantStringInfo(C, Str))
+    if (getConstantStringInfo(C, Str, /*CharWidth=*/8))
       Anno = Str;
   }
   // handle optional annotation parameter in a way that Khronos Translator do

--- a/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
@@ -578,7 +578,7 @@ void WebAssemblyAsmPrinter::EmitFunctionAttributes(Module &M) {
     // The second field is a pointer to a global annotation string.
     auto *GV = cast<GlobalVariable>(CS->getOperand(1)->stripPointerCasts());
     StringRef AnnotationString;
-    getConstantStringInfo(GV, AnnotationString);
+    getConstantStringInfo(GV, AnnotationString, /*CharWidth=*/8);
     auto *Sym = static_cast<MCSymbolWasm *>(getSymbol(F));
     CustomSections[AnnotationString].push_back(Sym);
   }

--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -1681,6 +1681,8 @@ private:
 /// handled by the instcombine pass.
 ///
 bool StrNCmpInliner::optimizeStrNCmp() {
+  unsigned CharWidth = DL.getByteWidth();
+
   if (StrNCmpInlineThreshold < 2)
     return false;
 
@@ -1694,8 +1696,10 @@ bool StrNCmpInliner::optimizeStrNCmp() {
     return false;
 
   StringRef Str1, Str2;
-  bool HasStr1 = getConstantStringInfo(Str1P, Str1, /*TrimAtNul=*/false);
-  bool HasStr2 = getConstantStringInfo(Str2P, Str2, /*TrimAtNul=*/false);
+  bool HasStr1 =
+      getConstantStringInfo(Str1P, Str1, CharWidth, /*TrimAtNul=*/false);
+  bool HasStr2 =
+      getConstantStringInfo(Str2P, Str2, CharWidth, /*TrimAtNul=*/false);
   if (HasStr1 == HasStr2)
     return false;
 
@@ -1833,12 +1837,14 @@ void StrNCmpInliner::inlineCompare(Value *LHS, StringRef RHS, uint64_t N,
 /// Convert memchr with a small constant string into a switch
 static bool foldMemChr(CallInst *Call, DomTreeUpdater *DTU,
                        const DataLayout &DL) {
+  unsigned CharWidth = DL.getByteWidth();
+
   if (isa<Constant>(Call->getArgOperand(1)))
     return false;
 
   StringRef Str;
   Value *Base = Call->getArgOperand(0);
-  if (!getConstantStringInfo(Base, Str, /*TrimAtNul=*/false))
+  if (!getConstantStringInfo(Base, Str, CharWidth, /*TrimAtNul=*/false))
     return false;
 
   uint64_t N = Str.size();

--- a/llvm/lib/Transforms/Utils/AMDGPUEmitPrintf.cpp
+++ b/llvm/lib/Transforms/Utils/AMDGPUEmitPrintf.cpp
@@ -249,7 +249,7 @@ static Value *callBufferedPrintfStart(
   for (size_t i = 1; i < Args.size(); i++) {
     if (SpecIsCString.test(i)) {
       StringRef ArgStr;
-      if (getConstantStringInfo(Args[i], ArgStr)) {
+      if (getConstantStringInfo(Args[i], ArgStr, /*CharWidth=*/8)) {
         auto alignedLen = alignTo(ArgStr.size() + 1, 8);
         StringContents.push_back(StringData(
             ArgStr,
@@ -431,7 +431,7 @@ Value *llvm::emitAMDGPUPrintfCall(IRBuilder<> &Builder, ArrayRef<Value *> Args,
   SparseBitVector<8> SpecIsCString;
   StringRef FmtStr;
 
-  if (getConstantStringInfo(Fmt, FmtStr))
+  if (getConstantStringInfo(Fmt, FmtStr, /*CharWidth=*/8))
     locateCStrings(SpecIsCString, FmtStr);
 
   if (IsBuffered) {

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -485,6 +485,7 @@ static Value* memChrToCharCompare(CallInst *CI, Value *NBytes,
 }
 
 Value *LibCallSimplifier::optimizeStrChr(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
   Value *SrcStr = CI->getArgOperand(0);
   Value *CharVal = CI->getArgOperand(1);
   annotateNonNullNoUndefBasedOnAccess(CI, 0);
@@ -527,7 +528,7 @@ Value *LibCallSimplifier::optimizeStrChr(CallInst *CI, IRBuilderBase &B) {
   // Otherwise, the character is a constant, see if the first argument is
   // a string literal.  If so, we can constant fold.
   StringRef Str;
-  if (!getConstantStringInfo(SrcStr, Str)) {
+  if (!getConstantStringInfo(SrcStr, Str, CharWidth)) {
     if (CharC->isZero()) // strchr(p, 0) -> p + strlen(p)
       if (Value *StrLen = emitStrLen(SrcStr, B, DL, TLI))
         return B.CreateInBoundsGEP(B.getInt8Ty(), SrcStr, StrLen, "strchr");
@@ -547,13 +548,14 @@ Value *LibCallSimplifier::optimizeStrChr(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeStrRChr(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
   Value *SrcStr = CI->getArgOperand(0);
   Value *CharVal = CI->getArgOperand(1);
   ConstantInt *CharC = dyn_cast<ConstantInt>(CharVal);
   annotateNonNullNoUndefBasedOnAccess(CI, 0);
 
   StringRef Str;
-  if (!getConstantStringInfo(SrcStr, Str)) {
+  if (!getConstantStringInfo(SrcStr, Str, CharWidth)) {
     // strrchr(s, 0) -> strchr(s, 0)
     if (CharC && CharC->isZero())
       return copyFlags(*CI, emitStrChr(SrcStr, '\0', B, TLI));
@@ -571,13 +573,15 @@ Value *LibCallSimplifier::optimizeStrRChr(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeStrCmp(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   Value *Str1P = CI->getArgOperand(0), *Str2P = CI->getArgOperand(1);
   if (Str1P == Str2P) // strcmp(x,x)  -> 0
     return ConstantInt::get(CI->getType(), 0);
 
   StringRef Str1, Str2;
-  bool HasStr1 = getConstantStringInfo(Str1P, Str1);
-  bool HasStr2 = getConstantStringInfo(Str2P, Str2);
+  bool HasStr1 = getConstantStringInfo(Str1P, Str1, CharWidth);
+  bool HasStr2 = getConstantStringInfo(Str2P, Str2, CharWidth);
 
   // strcmp(x, y)  -> cnst  (if both x and y are constant strings)
   if (HasStr1 && HasStr2)
@@ -631,6 +635,7 @@ static Value *optimizeMemCmpVarSize(CallInst *CI, Value *LHS, Value *RHS,
                                     IRBuilderBase &B, const DataLayout &DL);
 
 Value *LibCallSimplifier::optimizeStrNCmp(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
   Value *Str1P = CI->getArgOperand(0);
   Value *Str2P = CI->getArgOperand(1);
   Value *Size = CI->getArgOperand(2);
@@ -653,8 +658,8 @@ Value *LibCallSimplifier::optimizeStrNCmp(CallInst *CI, IRBuilderBase &B) {
     return copyFlags(*CI, emitMemCmp(Str1P, Str2P, Size, B, DL, TLI));
 
   StringRef Str1, Str2;
-  bool HasStr1 = getConstantStringInfo(Str1P, Str1);
-  bool HasStr2 = getConstantStringInfo(Str2P, Str2);
+  bool HasStr1 = getConstantStringInfo(Str1P, Str1, CharWidth);
+  bool HasStr2 = getConstantStringInfo(Str2P, Str2, CharWidth);
 
   // strncmp(x, y)  -> cnst  (if both x and y are constant strings)
   if (HasStr1 && HasStr2) {
@@ -765,6 +770,8 @@ Value *LibCallSimplifier::optimizeStpCpy(CallInst *CI, IRBuilderBase &B) {
 // Optimize a call to size_t strlcpy(char*, const char*, size_t).
 
 Value *LibCallSimplifier::optimizeStrLCpy(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   Value *Size = CI->getArgOperand(2);
   if (isKnownNonZero(Size, DL))
     // Like snprintf, the function stores into the destination only when
@@ -795,7 +802,7 @@ Value *LibCallSimplifier::optimizeStrLCpy(CallInst *CI, IRBuilderBase &B) {
   // when it's not nul-terminated (as it's required to be) to avoid
   // reading past its end.
   StringRef Str;
-  if (!getConstantStringInfo(Src, Str, /*TrimAtNul=*/false))
+  if (!getConstantStringInfo(Src, Str, CharWidth, /*TrimAtNul=*/false))
     return nullptr;
 
   uint64_t SrcLen = Str.find('\0');
@@ -843,6 +850,7 @@ Value *LibCallSimplifier::optimizeStrLCpy(CallInst *CI, IRBuilderBase &B) {
 // otherwise.
 Value *LibCallSimplifier::optimizeStringNCpy(CallInst *CI, bool RetEnd,
                                              IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
   Value *Dst = CI->getArgOperand(0);
   Value *Src = CI->getArgOperand(1);
   Value *Size = CI->getArgOperand(2);
@@ -909,7 +917,7 @@ Value *LibCallSimplifier::optimizeStringNCpy(CallInst *CI, bool RetEnd,
 
     // st{p,r}ncpy(D, "a", N) -> memcpy(D, "a\0\0\0", N) for N <= 128.
     StringRef Str;
-    if (!getConstantStringInfo(Src, Str))
+    if (!getConstantStringInfo(Src, Str, CharWidth))
       return nullptr;
     std::string SrcStr = Str.str();
     // Create a bigger, nul-padded array with the same length, SrcLen,
@@ -1081,9 +1089,11 @@ Value *LibCallSimplifier::optimizeWcslen(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeStrPBrk(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   StringRef S1, S2;
-  bool HasS1 = getConstantStringInfo(CI->getArgOperand(0), S1);
-  bool HasS2 = getConstantStringInfo(CI->getArgOperand(1), S2);
+  bool HasS1 = getConstantStringInfo(CI->getArgOperand(0), S1, CharWidth);
+  bool HasS2 = getConstantStringInfo(CI->getArgOperand(1), S2, CharWidth);
 
   // strpbrk(s, "") -> nullptr
   // strpbrk("", s) -> nullptr
@@ -1120,9 +1130,11 @@ Value *LibCallSimplifier::optimizeStrTo(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeStrSpn(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   StringRef S1, S2;
-  bool HasS1 = getConstantStringInfo(CI->getArgOperand(0), S1);
-  bool HasS2 = getConstantStringInfo(CI->getArgOperand(1), S2);
+  bool HasS1 = getConstantStringInfo(CI->getArgOperand(0), S1, CharWidth);
+  bool HasS2 = getConstantStringInfo(CI->getArgOperand(1), S2, CharWidth);
 
   // strspn(s, "") -> 0
   // strspn("", s) -> 0
@@ -1141,9 +1153,11 @@ Value *LibCallSimplifier::optimizeStrSpn(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeStrCSpn(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   StringRef S1, S2;
-  bool HasS1 = getConstantStringInfo(CI->getArgOperand(0), S1);
-  bool HasS2 = getConstantStringInfo(CI->getArgOperand(1), S2);
+  bool HasS1 = getConstantStringInfo(CI->getArgOperand(0), S1, CharWidth);
+  bool HasS2 = getConstantStringInfo(CI->getArgOperand(1), S2, CharWidth);
 
   // strcspn("", s) -> 0
   if (HasS1 && S1.empty())
@@ -1165,6 +1179,8 @@ Value *LibCallSimplifier::optimizeStrCSpn(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeStrStr(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   // fold strstr(x, x) -> x.
   if (CI->getArgOperand(0) == CI->getArgOperand(1))
     return CI->getArgOperand(0);
@@ -1190,8 +1206,10 @@ Value *LibCallSimplifier::optimizeStrStr(CallInst *CI, IRBuilderBase &B) {
 
   // See if either input string is a constant string.
   StringRef SearchStr, ToFindStr;
-  bool HasStr1 = getConstantStringInfo(CI->getArgOperand(0), SearchStr);
-  bool HasStr2 = getConstantStringInfo(CI->getArgOperand(1), ToFindStr);
+  bool HasStr1 =
+      getConstantStringInfo(CI->getArgOperand(0), SearchStr, CharWidth);
+  bool HasStr2 =
+      getConstantStringInfo(CI->getArgOperand(1), ToFindStr, CharWidth);
 
   // fold strstr(x, "") -> x.
   if (HasStr2 && ToFindStr.empty())
@@ -1219,6 +1237,8 @@ Value *LibCallSimplifier::optimizeStrStr(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeMemRChr(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   Value *SrcStr = CI->getArgOperand(0);
   Value *Size = CI->getArgOperand(2);
   annotateNonNullAndDereferenceable(CI, 0, Size, DL);
@@ -1243,7 +1263,7 @@ Value *LibCallSimplifier::optimizeMemRChr(CallInst *CI, IRBuilderBase &B) {
   }
 
   StringRef Str;
-  if (!getConstantStringInfo(SrcStr, Str, /*TrimAtNul=*/false))
+  if (!getConstantStringInfo(SrcStr, Str, CharWidth, /*TrimAtNul=*/false))
     return nullptr;
 
   if (Str.size() == 0)
@@ -1307,6 +1327,7 @@ Value *LibCallSimplifier::optimizeMemRChr(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeMemChr(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
   Value *SrcStr = CI->getArgOperand(0);
   Value *Size = CI->getArgOperand(2);
 
@@ -1338,7 +1359,7 @@ Value *LibCallSimplifier::optimizeMemChr(CallInst *CI, IRBuilderBase &B) {
   }
 
   StringRef Str;
-  if (!getConstantStringInfo(SrcStr, Str, /*TrimAtNul=*/false))
+  if (!getConstantStringInfo(SrcStr, Str, CharWidth, /*TrimAtNul=*/false))
     return nullptr;
 
   if (CharC) {
@@ -1504,12 +1525,14 @@ Value *LibCallSimplifier::optimizeMemChr(CallInst *CI, IRBuilderBase &B) {
 static Value *optimizeMemCmpVarSize(CallInst *CI, Value *LHS, Value *RHS,
                                     Value *Size, bool StrNCmp,
                                     IRBuilderBase &B, const DataLayout &DL) {
+  unsigned CharWidth = DL.getByteWidth();
+
   if (LHS == RHS) // memcmp(s,s,x) -> 0
     return Constant::getNullValue(CI->getType());
 
   StringRef LStr, RStr;
-  if (!getConstantStringInfo(LHS, LStr, /*TrimAtNul=*/false) ||
-      !getConstantStringInfo(RHS, RStr, /*TrimAtNul=*/false))
+  if (!getConstantStringInfo(LHS, LStr, CharWidth, /*TrimAtNul=*/false) ||
+      !getConstantStringInfo(RHS, RStr, CharWidth, /*TrimAtNul=*/false))
     return nullptr;
 
   // If the contents of both constant arrays are known, fold a call to
@@ -1645,6 +1668,7 @@ Value *LibCallSimplifier::optimizeMemCpy(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizeMemCCpy(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
   Value *Dst = CI->getArgOperand(0);
   Value *Src = CI->getArgOperand(1);
   ConstantInt *StopChar = dyn_cast<ConstantInt>(CI->getArgOperand(2));
@@ -1656,7 +1680,7 @@ Value *LibCallSimplifier::optimizeMemCCpy(CallInst *CI, IRBuilderBase &B) {
   if (N) {
     if (N->isNullValue())
       return Constant::getNullValue(CI->getType());
-    if (!getConstantStringInfo(Src, SrcStr, /*TrimAtNul=*/false) ||
+    if (!getConstantStringInfo(Src, SrcStr, CharWidth, /*TrimAtNul=*/false) ||
         // TODO: Handle zeroinitializer.
         !StopChar)
       return nullptr;
@@ -3267,8 +3291,10 @@ Value *LibCallSimplifier::optimizeToAscii(CallInst *CI, IRBuilderBase &B) {
 
 // Fold calls to atoi, atol, and atoll.
 Value *LibCallSimplifier::optimizeAtoi(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   StringRef Str;
-  if (!getConstantStringInfo(CI->getArgOperand(0), Str))
+  if (!getConstantStringInfo(CI->getArgOperand(0), Str, CharWidth))
     return nullptr;
 
   return convertStrToInt(CI, Str, nullptr, 10, /*AsSigned=*/true, B);
@@ -3277,6 +3303,8 @@ Value *LibCallSimplifier::optimizeAtoi(CallInst *CI, IRBuilderBase &B) {
 // Fold calls to strtol, strtoll, strtoul, and strtoull.
 Value *LibCallSimplifier::optimizeStrToInt(CallInst *CI, IRBuilderBase &B,
                                            bool AsSigned) {
+  unsigned CharWidth = DL.getByteWidth();
+
   Value *EndPtr = CI->getArgOperand(1);
   if (isa<ConstantPointerNull>(EndPtr)) {
     // With a null EndPtr, this function won't capture the main argument.
@@ -3288,7 +3316,7 @@ Value *LibCallSimplifier::optimizeStrToInt(CallInst *CI, IRBuilderBase &B,
     return nullptr;
 
   StringRef Str;
-  if (!getConstantStringInfo(CI->getArgOperand(0), Str))
+  if (!getConstantStringInfo(CI->getArgOperand(0), Str, CharWidth))
     return nullptr;
 
   if (ConstantInt *CInt = dyn_cast<ConstantInt>(CI->getArgOperand(2))) {
@@ -3345,9 +3373,11 @@ static bool isReportingError(Function *Callee, CallInst *CI, int StreamArg) {
 }
 
 Value *LibCallSimplifier::optimizePrintFString(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   // Check for a fixed format string.
   StringRef FormatStr;
-  if (!getConstantStringInfo(CI->getArgOperand(0), FormatStr))
+  if (!getConstantStringInfo(CI->getArgOperand(0), FormatStr, CharWidth))
     return nullptr;
 
   // Empty format string -> noop.
@@ -3373,7 +3403,7 @@ Value *LibCallSimplifier::optimizePrintFString(CallInst *CI, IRBuilderBase &B) {
   // Try to remove call or emit putchar/puts.
   if (FormatStr == "%s" && CI->arg_size() > 1) {
     StringRef OperandStr;
-    if (!getConstantStringInfo(CI->getOperand(1), OperandStr))
+    if (!getConstantStringInfo(CI->getOperand(1), OperandStr, CharWidth))
       return nullptr;
     // printf("%s", "") --> NOP
     if (OperandStr.empty())
@@ -3466,9 +3496,11 @@ Value *LibCallSimplifier::optimizePrintF(CallInst *CI, IRBuilderBase &B) {
 
 Value *LibCallSimplifier::optimizeSPrintFString(CallInst *CI,
                                                 IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   // Check for a fixed format string.
   StringRef FormatStr;
-  if (!getConstantStringInfo(CI->getArgOperand(1), FormatStr))
+  if (!getConstantStringInfo(CI->getArgOperand(1), FormatStr, CharWidth))
     return nullptr;
 
   // If we just have a format string (nothing else crazy) transform it.
@@ -3634,6 +3666,8 @@ Value *LibCallSimplifier::emitSnPrintfMemCpy(CallInst *CI, Value *StrArg,
 
 Value *LibCallSimplifier::optimizeSnPrintFString(CallInst *CI,
                                                  IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   // Check for size
   ConstantInt *Size = dyn_cast<ConstantInt>(CI->getArgOperand(1));
   if (!Size)
@@ -3651,7 +3685,7 @@ Value *LibCallSimplifier::optimizeSnPrintFString(CallInst *CI,
 
   // Check for a fixed format string.
   StringRef FormatStr;
-  if (!getConstantStringInfo(FmtArg, FormatStr))
+  if (!getConstantStringInfo(FmtArg, FormatStr, CharWidth))
     return nullptr;
 
   // If we just have a format string (nothing else crazy) transform it.
@@ -3696,7 +3730,7 @@ Value *LibCallSimplifier::optimizeSnPrintFString(CallInst *CI,
   Value *StrArg = CI->getArgOperand(3);
   // snprintf(dest, size, "%s", str) to llvm.memcpy(dest, str, len+1, 1)
   StringRef Str;
-  if (!getConstantStringInfo(StrArg, Str))
+  if (!getConstantStringInfo(StrArg, Str, CharWidth))
     return nullptr;
 
   return emitSnPrintfMemCpy(CI, StrArg, Str, N, B);
@@ -3714,11 +3748,13 @@ Value *LibCallSimplifier::optimizeSnPrintF(CallInst *CI, IRBuilderBase &B) {
 
 Value *LibCallSimplifier::optimizeFPrintFString(CallInst *CI,
                                                 IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   optimizeErrorReporting(CI, B, 0);
 
   // All the optimizations depend on the format string.
   StringRef FormatStr;
-  if (!getConstantStringInfo(CI->getArgOperand(1), FormatStr))
+  if (!getConstantStringInfo(CI->getArgOperand(1), FormatStr, CharWidth))
     return nullptr;
 
   // Do not do any of the following transformations if the fprintf return
@@ -3857,6 +3893,8 @@ Value *LibCallSimplifier::optimizeFPuts(CallInst *CI, IRBuilderBase &B) {
 }
 
 Value *LibCallSimplifier::optimizePuts(CallInst *CI, IRBuilderBase &B) {
+  unsigned CharWidth = DL.getByteWidth();
+
   annotateNonNullNoUndefBasedOnAccess(CI, 0);
   if (!CI->use_empty())
     return nullptr;
@@ -3864,7 +3902,8 @@ Value *LibCallSimplifier::optimizePuts(CallInst *CI, IRBuilderBase &B) {
   // Check for a constant string.
   // puts("") -> putchar('\n')
   StringRef Str;
-  if (getConstantStringInfo(CI->getArgOperand(0), Str) && Str.empty()) {
+  if (getConstantStringInfo(CI->getArgOperand(0), Str, CharWidth) &&
+      Str.empty()) {
     // putchar takes an argument of the same type as puts returns, i.e.,
     // int, which need not be 32 bits wide.
     Type *IntTy = CI->getType();
@@ -4010,8 +4049,10 @@ Value *LibCallSimplifier::optimizeStringMemoryLibCall(CallInst *CI,
 
 /// Constant folding nan/nanf/nanl.
 static Value *optimizeNaN(CallInst *CI) {
+  unsigned CharWidth = CI->getDataLayout().getByteWidth();
+
   StringRef CharSeq;
-  if (!getConstantStringInfo(CI->getArgOperand(0), CharSeq))
+  if (!getConstantStringInfo(CI->getArgOperand(0), CharSeq, CharWidth))
     return nullptr;
 
   APInt Fill;


### PR DESCRIPTION
The method assumes that host chars and target chars have the same width.
Add a CharWidth argument so that it can bail out if the requested char
width differs from the host char width.

Alternatively, the check could be done at call sites, but this is more
error-prone.

In the future, this method will be replaced with a different one that
allows host/target chars to have different widths. The prototype will
be the same except that StringRef is replaced with something that is
byte width agnostic. Adding CharWidth argument now reduces the future
diff.