### PR TITLE
[Analysis] Guard logf128 cst folding

### DIFF
--- a/llvm/lib/Analysis/CMakeLists.txt
+++ b/llvm/lib/Analysis/CMakeLists.txt
@@ -163,8 +163,6 @@ add_llvm_component_library(LLVMAnalysis
   TargetParser
   )
 
-include(CheckCXXSymbolExists)
-check_cxx_symbol_exists(logf128 math.h HAS_LOGF128)
-if(HAS_LOGF128)
- target_compile_definitions(LLVMAnalysis PRIVATE HAS_LOGF128)
+if(LLVM_HAS_LOGF128)
+  target_compile_definitions(LLVMAnalysis PRIVATE HAS_LOGF128)
 endif()


### PR DESCRIPTION
LLVM has a CMake variable to control whether to consider logf128
constant folding which libAnalysis ignores. This patch changes the
logf128 check to rely on the global LLVM_HAS_LOGF128 setting made in
config-ix.cmake.
