### PR TITLE
[IPSCCP] Infer nonnull return attribute

### DIFF
--- a/llvm/lib/Transforms/IPO/SCCP.cpp
+++ b/llvm/lib/Transforms/IPO/SCCP.cpp
@@ -296,6 +296,14 @@ static bool runIPSCCP(
       F->addRangeRetAttr(CR);
       continue;
     }
+    // Infer nonnull return attribute.
+    if (F->getReturnType()->isPointerTy() && ReturnValue.isNotConstant() &&
+        ReturnValue.getNotConstant()->isNullValue() &&
+        !F->hasRetAttribute(Attribute::NonNull) &&
+        !F->hasRetAttribute(Attribute::Dereferenceable)) {
+      F->addRetAttr(Attribute::NonNull);
+      continue;
+    }
     if (F->getReturnType()->isVoidTy())
       continue;
     if (SCCPSolver::isConstant(ReturnValue) || ReturnValue.isUnknownOrUndef())

--- a/llvm/lib/Transforms/IPO/SCCP.cpp
+++ b/llvm/lib/Transforms/IPO/SCCP.cpp
@@ -299,8 +299,7 @@ static bool runIPSCCP(
     // Infer nonnull return attribute.
     if (F->getReturnType()->isPointerTy() && ReturnValue.isNotConstant() &&
         ReturnValue.getNotConstant()->isNullValue() &&
-        !F->hasRetAttribute(Attribute::NonNull) &&
-        !F->hasRetAttribute(Attribute::Dereferenceable)) {
+        !F->hasRetAttribute(Attribute::NonNull)) {
       F->addRetAttr(Attribute::NonNull);
       continue;
     }

--- a/llvm/test/Transforms/PGOProfile/memprof.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof.ll
@@ -81,7 +81,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress noinline optnone uwtable
-; ALL-LABEL: define dso_local noundef ptr @_Z3foov()
+; ALL-LABEL: define dso_local noundef{{.*}}ptr @_Z3foov()
 ; There should be some PGO metadata
 ; PGO: !prof
 define dso_local noundef ptr @_Z3foov() #0 !dbg !10 {
@@ -96,7 +96,7 @@ entry:
 declare noundef nonnull ptr @_Znam(i64 noundef) #1
 
 ; Function Attrs: mustprogress noinline optnone uwtable
-; ALL-LABEL: define dso_local noundef ptr @_Z4foo2v()
+; ALL-LABEL: define dso_local noundef{{.*}}ptr @_Z4foo2v()
 define dso_local noundef ptr @_Z4foo2v() #0 !dbg !15 {
 entry:
   ; MEMPROF: call {{.*}} @_Z3foov{{.*}} !callsite ![[C2:[0-9]+]]

--- a/llvm/test/Transforms/SCCP/pointer-nonnull.ll
+++ b/llvm/test/Transforms/SCCP/pointer-nonnull.ll
@@ -232,9 +232,13 @@ define i1 @ip_test_nonnull_caller(ptr %p) {
 }
 
 define ptr @ret_nonnull_pointer(ptr nonnull %p) {
-; CHECK-LABEL: define ptr @ret_nonnull_pointer(
-; CHECK-SAME: ptr nonnull [[P:%.*]]) {
-; CHECK-NEXT:    ret ptr [[P]]
+; SCCP-LABEL: define ptr @ret_nonnull_pointer(
+; SCCP-SAME: ptr nonnull [[P:%.*]]) {
+; SCCP-NEXT:    ret ptr [[P]]
+;
+; IPSCCP-LABEL: define nonnull ptr @ret_nonnull_pointer(
+; IPSCCP-SAME: ptr nonnull [[P:%.*]]) {
+; IPSCCP-NEXT:    ret ptr [[P]]
 ;
   ret ptr %p
 }


### PR DESCRIPTION
Similarly to the existing range attribute inference, also infer the nonnull attribute on function return values.

I think in practice FunctionAttrs will handle nearly all cases, the main one I think it doesn't is cases involving branch conditions. But as we already have the information here, we may as well materialize it.