### PR TITLE
[docs] Replace mailing list with Discourse

### DIFF
--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -89,7 +89,8 @@ When Is an RFC Required?
 Some changes are too significant for just a code review. Changes that should
 change the LLVM Language Reference (e.g., adding new target-independent
 intrinsics), adding language extensions in Clang, and so on, require an RFC
-(Request for Comment) email on the project's ``*-dev`` mailing list first. For
+(Request for Comment) topic on the `LLVM Discourse forums
+<https://discourse.llvm.org>`_ first. For
 changes that promise significant impact on users and/or downstream code bases,
 reviewers can request an RFC achieving consensus before proceeding with code
 review. That having been said, posting initial patches can help with


### PR DESCRIPTION
RFCs are now expected to be sent to the LLVM Discourse forums.