### PR TITLE
Revert "[flang] Warn when F128 is unsupported"

### DIFF
--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -11,7 +11,6 @@
 
 #include "flang/Evaluate/target.h"
 #include "llvm/Target/TargetMachine.h"
-#include <cfloat>
 
 namespace Fortran::tools {
 
@@ -22,25 +21,9 @@ namespace Fortran::tools {
 
   const llvm::Triple &targetTriple{targetMachine.getTargetTriple()};
   // FIXME: Handle real(3) ?
-  if (targetTriple.getArch() != llvm::Triple::ArchType::x86_64) {
+  if (targetTriple.getArch() != llvm::Triple::ArchType::x86_64)
     targetCharacteristics.DisableType(
         Fortran::common::TypeCategory::Real, /*kind=*/10);
-  }
-
-  // Figure out if we can support F128: see
-  // flang/runtime/Float128Math/math-entries.h
-#ifdef FLANG_RUNTIME_F128_MATH_LIB
-  // we can use libquadmath wrappers
-  constexpr bool f128Support = true;
-#elif LDBL_MANT_DIG == 113
-  // we can use libm wrappers
-  constexpr bool f128Support = true;
-#else
-  constexpr bool f128Support = false;
-#endif
-
-  if constexpr (!f128Support)
-    targetCharacteristics.DisableType(Fortran::common::TypeCategory::Real, 16);
 
   targetCharacteristics.set_compilerOptionsString(compilerOptions)
       .set_compilerVersionString(compilerVersion);

--- a/flang/module/ieee_arithmetic.f90
+++ b/flang/module/ieee_arithmetic.f90
@@ -161,8 +161,6 @@ module ieee_arithmetic
   G(1) G(2) G(4) G(8) G(16)
 #define SPECIFICS_L(G) \
   G(1) G(2) G(4) G(8)
-
-#if FLANG_SUPPORT_R16
 #if __x86_64__
 #define SPECIFICS_R(G) \
   G(2) G(3) G(4) G(8) G(10) G(16)
@@ -170,24 +168,12 @@ module ieee_arithmetic
 #define SPECIFICS_R(G) \
   G(2) G(3) G(4) G(8) G(16)
 #endif
-#else
-#if __x86_64__
-#define SPECIFICS_R(G) \
-  G(2) G(3) G(4) G(8) G(10)
-#else
-#define SPECIFICS_R(G) \
-  G(2) G(3) G(4) G(8)
-#endif
-#endif
-
 #define SPECIFICS_II(G) \
   G(1,1) G(1,2) G(1,4) G(1,8) G(1,16) \
   G(2,1) G(2,2) G(2,4) G(2,8) G(2,16) \
   G(4,1) G(4,2) G(4,4) G(4,8) G(4,16) \
   G(8,1) G(8,2) G(8,4) G(8,8) G(8,16) \
   G(16,1) G(16,2) G(16,4) G(16,8) G(16,16)
-
-#if FLANG_SUPPORT_R16
 #if __x86_64__
 #define SPECIFICS_RI(G) \
   G(2,1) G(2,2) G(2,4) G(2,8) G(2,16) \
@@ -204,24 +190,7 @@ module ieee_arithmetic
   G(8,1) G(8,2) G(8,4) G(8,8) G(8,16) \
   G(16,1) G(16,2) G(16,4) G(16,8) G(16,16)
 #endif
-#else
-#if __x86_64__
-#define SPECIFICS_RI(G) \
-  G(2,1) G(2,2) G(2,4) G(2,8) \
-  G(3,1) G(3,2) G(3,4) G(3,8) \
-  G(4,1) G(4,2) G(4,4) G(4,8) \
-  G(8,1) G(8,2) G(8,4) G(8,8) \
-  G(10,1) G(10,2) G(10,4) G(10,8)
-#else
-#define SPECIFICS_RI(G) \
-  G(2,1) G(2,2) G(2,4) G(2,8) \
-  G(3,1) G(3,2) G(3,4) G(3,8) \
-  G(4,1) G(4,2) G(4,4) G(4,8) \
-  G(8,1) G(8,2) G(8,4) G(8,8)
-#endif
-#endif
 
-#if FLANG_SUPPORT_R16
 #if __x86_64__
 #define SPECIFICS_RR(G) \
   G(2,2) G(2,3) G(2,4) G(2,8) G(2,10) G(2,16) \
@@ -237,22 +206,6 @@ module ieee_arithmetic
   G(4,2) G(4,3) G(4,4) G(4,8) G(4,16) \
   G(8,2) G(8,3) G(8,4) G(8,8) G(8,16) \
   G(16,2) G(16,3) G(16,4) G(16,8) G(16,16)
-#endif
-#else
-#if __x86_64__
-#define SPECIFICS_RR(G) \
-  G(2,2) G(2,3) G(2,4) G(2,8) G(2,10) \
-  G(3,2) G(3,3) G(3,4) G(3,8) G(3,10) \
-  G(4,2) G(4,3) G(4,4) G(4,8) G(4,10) \
-  G(8,2) G(8,3) G(8,4) G(8,8) G(8,10) \
-  G(10,2) G(10,3) G(10,4) G(10,8) G(10,10)
-#else
-#define SPECIFICS_RR(G) \
-  G(2,2) G(2,3) G(2,4) G(2,8) \
-  G(3,2) G(3,3) G(3,4) G(3,8) \
-  G(4,2) G(4,3) G(4,4) G(4,8) \
-  G(8,2) G(8,3) G(8,4) G(8,8)
-#endif
 #endif
 
 #define IEEE_CLASS_R(XKIND) \
@@ -509,10 +462,8 @@ module ieee_arithmetic
   interface ieee_real
     SPECIFICS_I(IEEE_REAL_I)
     SPECIFICS_R(IEEE_REAL_R)
-#if FLANG_SUPPORT_R16
     SPECIFICS_II(IEEE_REAL_II)
     SPECIFICS_RI(IEEE_REAL_RI)
-#endif
   end interface ieee_real
   public :: ieee_real
 #undef IEEE_REAL_I

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -11,16 +11,6 @@ llvm_canonicalize_cmake_booleans(
 
 set(FLANG_TOOLS_DIR ${FLANG_BINARY_DIR}/bin)
 
-# Check if 128-bit float computations can be done via long double
-check_cxx_source_compiles(
-  "#include <cfloat>
-   #if LDBL_MANT_DIG != 113
-   #error LDBL_MANT_DIG != 113
-   #endif
-   int main() { return 0; }
-  "
-  HAVE_LDBL_MANT_DIG_113)
-
 # FIXME In out-of-tree builds, "SHLIBDIR" is undefined and passing it to
 # `configure_lit_site_cfg` leads to a configuration error. This is currently
 # only required by plugins/examples, which are not supported in out-of-tree

--- a/flang/test/Evaluate/fold-out_of_range.f90
+++ b/flang/test/Evaluate/fold-out_of_range.f90
@@ -1,7 +1,6 @@
 ! RUN: %python %S/test_folding.py %s %flang_fc1 -pedantic -triple x86_64-unknown-linux-gnu
 ! UNSUPPORTED: system-windows
 ! REQUIRES: target=x86_64{{.*}}
-! REQUIRES: flang-supports-f128-math
 ! Tests folding of OUT_OF_RANGE().
 module m
   integer(1),  parameter :: i1v(*)  = [ -huge(1_1)  - 1_1,  huge(1_1) ]

--- a/flang/test/Evaluate/folding07.f90
+++ b/flang/test/Evaluate/folding07.f90
@@ -1,4 +1,3 @@
-! REQUIRES: flang-supports-f128-math
 ! RUN: %python %S/test_folding.py %s %flang_fc1
 ! Test numeric model inquiry intrinsics
 

--- a/flang/test/Lower/Intrinsics/ieee_class_queries.f90
+++ b/flang/test/Lower/Intrinsics/ieee_class_queries.f90
@@ -1,4 +1,3 @@
-! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir -o - %s | FileCheck %s
 
   ! CHECK-LABEL: func @_QQmain

--- a/flang/test/Lower/Intrinsics/ieee_unordered.f90
+++ b/flang/test/Lower/Intrinsics/ieee_unordered.f90
@@ -1,4 +1,3 @@
-! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir -hlfir=false -o - %s | FileCheck %s
 
 ! CHECK-LABEL: func @_QQmain

--- a/flang/test/Lower/common-block.f90
+++ b/flang/test/Lower/common-block.f90
@@ -1,4 +1,3 @@
-! REQUIRES: flang-supports-f128-math
 ! RUN: bbc %s -o - | tco | FileCheck %s
 ! RUN: %flang -emit-llvm -S -mmlir -disable-external-name-interop %s -o - | FileCheck %s
 
@@ -79,3 +78,4 @@ subroutine s7()
   real(16) r16
   common /co1/ r16
 end subroutine
+

--- a/flang/test/Semantics/kinds03.f90
+++ b/flang/test/Semantics/kinds03.f90
@@ -1,4 +1,3 @@
-! REQUIRES: flang-supports-f128-math
 ! RUN: %python %S/test_symbols.py %s %flang_fc1
  !DEF: /MainProgram1/ipdt DerivedType
  !DEF: /MainProgram1/ipdt/k TypeParam INTEGER(4)

--- a/flang/test/Semantics/modfile26.f90
+++ b/flang/test/Semantics/modfile26.f90
@@ -1,4 +1,3 @@
-! REQUIRES: flang-supports-f128-math
 ! RUN: %python %S/test_modfile.py %s %flang_fc1
 ! Intrinsics SELECTED_INT_KIND, SELECTED_REAL_KIND, PRECISION, RANGE,
 ! RADIX, DIGITS

--- a/flang/test/Semantics/realkinds-aarch64-01.f90
+++ b/flang/test/Semantics/realkinds-aarch64-01.f90
@@ -1,5 +1,4 @@
 ! REQUIRES: aarch64-registered-target
-! REQUIRES: flang-supports-f128-math
 ! RUN: %python %S/test_modfile.py %s %flang_fc1 -triple aarch64-unknown-linux-gnu
 
 module m1

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -216,9 +216,8 @@ if config.have_openmp_rtl:
 # Add features and substitutions to test F128 math support.
 # %f128-lib substitution may be used to generate check prefixes
 # for LIT tests checking for F128 library support.
-if config.flang_runtime_f128_math_lib or config.have_ldbl_mant_dig_113:
-    config.available_features.add("flang-supports-f128-math")
 if config.flang_runtime_f128_math_lib:
+    config.available_features.add("flang-supports-f128-math")
     config.available_features.add(
         "flang-f128-math-lib-" + config.flang_runtime_f128_math_lib
     )

--- a/flang/test/lit.site.cfg.py.in
+++ b/flang/test/lit.site.cfg.py.in
@@ -31,7 +31,6 @@ if "openmp" in "@LLVM_ENABLE_RUNTIMES@".lower().split(";"):
 else:
     config.openmp_module_dir = None
 config.flang_runtime_f128_math_lib = "@FLANG_RUNTIME_F128_MATH_LIB@"
-config.have_ldbl_mant_dig_113 = "@HAVE_LDBL_MANT_DIG_113@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -31,25 +31,6 @@ set(MODULES_WITHOUT_IMPLEMENTATION
 
 set(MODULES ${MODULES_WITH_IMPLEMENTATION} ${MODULES_WITHOUT_IMPLEMENTATION})
 
-# Check if 128-bit float computations can be done via long double.
-check_cxx_source_compiles(
-  "#include <cfloat>
-   #if LDBL_MANT_DIG != 113
-   #error LDBL_MANT_DIG != 113
-   #endif
-   int main() { return 0; }
-  "
-  HAVE_LDBL_MANT_DIG_113)
-
-# Figure out whether we can support REAL(KIND=16)
-if (FLANG_RUNTIME_F128_MATH_LIB)
-  set(FLANG_SUPPORT_R16 "1")
-elseif (HAVE_LDBL_MANT_DIG_113)
-  set(FLANG_SUPPORT_R16 "1")
-else()
-  set(FLANG_SUPPORT_R16 "0")
-endif()
-
 # Init variable to hold extra object files coming from the Fortran modules;
 # these module files will be contributed from the CMakeLists in flang/tools/f18.
 set(module_objects "")
@@ -95,10 +76,6 @@ if (NOT CMAKE_CROSSCOMPILING)
       endif()
     endif()
 
-    set(decls "")
-    if (FLANG_SUPPORT_R16)
-      set(decls "-DFLANG_SUPPORT_R16")
-    endif()
 
     # Some modules have an implementation part that needs to be added to the
     # FortranRuntime library.
@@ -115,7 +92,7 @@ if (NOT CMAKE_CROSSCOMPILING)
     # TODO: We may need to flag this with conditional, in case Flang is built w/o OpenMP support
     add_custom_command(OUTPUT ${base}.mod ${object_output}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${FLANG_INTRINSIC_MODULES_DIR}
-      COMMAND flang-new ${opts} ${decls} -cpp ${compile_with} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
+      COMMAND flang-new ${opts} -cpp ${compile_with} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
         ${FLANG_SOURCE_DIR}/module/${filename}.f90
       DEPENDS flang-new ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${FLANG_SOURCE_DIR}/module/__fortran_builtins.f90 ${depends}
     )


### PR DESCRIPTION
Reverts llvm/llvm-project#102147

It seems some systems which should support F128 are wrongly detected as not supporting.

This might be due to checking `LDBL_MANT_DIG` instead of `__LDBL_MANT_DIG__`. I will investigate.