### PR TITLE
[libc++][math] Provide overloads for cv-unqualified floating point types for `std::signbit`

### DIFF
--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -12,7 +12,6 @@
 #include <__config>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_arithmetic.h>
-#include <__type_traits/is_floating_point.h>
 #include <__type_traits/is_integral.h>
 #include <__type_traits/is_signed.h>
 #include <__type_traits/promote.h>

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -34,27 +34,21 @@ namespace __math {
 #  define _LIBCPP_SIGNBIT_CONSTEXPR
 #endif
 
-// The universal C runtime (UCRT) in the WinSDK provides overloads for all floating point types
-// for std::signbit(). We need to work around it as the compilation would otherwise error out
-// due to duplicated definitions for clang-cl builds.
-#if defined(_LIBCPP_MSVCRT) && defined(_LIBCPP_PREFERRED_OVERLOAD)
-#  define LIBCPP_SIGNBIT_OVERLOAD _LIBCPP_PREFERRED_OVERLOAD
-#else
-#  define LIBCPP_SIGNBIT_OVERLOAD
-#endif
-
-_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI LIBCPP_SIGNBIT_OVERLOAD bool
-signbit(float __x) _NOEXCEPT {
+// The universal C runtime (UCRT) in the WinSDK provides floating point overloads
+// for std::signbit(). By defining our overloads as templates, we can work around
+// this issue as templates are less preferred than non-template functions.
+template <class = void>
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool signbit(float __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
 
-_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI LIBCPP_SIGNBIT_OVERLOAD bool
-signbit(double __x) _NOEXCEPT {
+template <class = void>
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool signbit(double __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
 
-_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI LIBCPP_SIGNBIT_OVERLOAD bool
-signbit(long double __x) _NOEXCEPT {
+template <class = void>
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool signbit(long double __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
 

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -34,30 +34,27 @@ namespace __math {
 #  define _LIBCPP_SIGNBIT_CONSTEXPR
 #endif
 
-_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
-#ifdef _LIBCPP_PREFERRED_OVERLOAD
-_LIBCPP_PREFERRED_OVERLOAD
+// The universal C runtime (UCRT) in the WinSDK provides overloads for all floating point types
+// for std::signbit(). We need to work around it as the compilation would otherwise error out
+// due to duplicated definitions for clang-cl builds.
+#if defined(_LIBCPP_MSVCRT) && defined(_LIBCPP_PREFERRED_OVERLOAD)
+#  define LIBCPP_SIGNBIT_OVERLOAD _LIBCPP_PREFERRED_OVERLOAD
+#else
+#  define LIBCPP_SIGNBIT_OVERLOAD
 #endif
-    bool
-    signbit(float __x) _NOEXCEPT {
+
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI LIBCPP_SIGNBIT_OVERLOAD bool
+signbit(float __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
 
-_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
-#ifdef _LIBCPP_PREFERRED_OVERLOAD
-_LIBCPP_PREFERRED_OVERLOAD
-#endif
-    bool
-    signbit(double __x) _NOEXCEPT {
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI LIBCPP_SIGNBIT_OVERLOAD bool
+signbit(double __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
 
-_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
-#ifdef _LIBCPP_PREFERRED_OVERLOAD
-_LIBCPP_PREFERRED_OVERLOAD
-#endif
-    bool
-    signbit(long double __x) _NOEXCEPT {
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI LIBCPP_SIGNBIT_OVERLOAD bool
+signbit(long double __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
 

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -34,8 +34,30 @@ namespace __math {
 #  define _LIBCPP_SIGNBIT_CONSTEXPR
 #endif
 
-template <class _A1, __enable_if_t<is_floating_point<_A1>::value, int> = 0>
-_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool signbit(_A1 __x) _NOEXCEPT {
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
+#ifdef _LIBCPP_PREFERRED_OVERLOAD
+_LIBCPP_PREFERRED_OVERLOAD
+#endif
+    bool
+    signbit(float __x) _NOEXCEPT {
+  return __builtin_signbit(__x);
+}
+
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
+#ifdef _LIBCPP_PREFERRED_OVERLOAD
+_LIBCPP_PREFERRED_OVERLOAD
+#endif
+    bool
+    signbit(double __x) _NOEXCEPT {
+  return __builtin_signbit(__x);
+}
+
+_LIBCPP_NODISCARD inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
+#ifdef _LIBCPP_PREFERRED_OVERLOAD
+_LIBCPP_PREFERRED_OVERLOAD
+#endif
+    bool
+    signbit(long double __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
 

--- a/libcxx/test/std/numerics/c.math/signbit.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/signbit.pass.cpp
@@ -70,9 +70,22 @@ struct TestInt {
   }
 };
 
+template <typename T>
+struct ConvertibleTo {
+  operator T() const { return T(); }
+};
+
 int main(int, char**) {
   types::for_each(types::floating_point_types(), TestFloat());
   types::for_each(types::integral_types(), TestInt());
 
+  // Make sure we can call `std::signbit` with convertible types. This checks
+  // whether overloads for all cv-unqualified floating-point types are working
+  // as expected.
+  {
+    assert(!std::signbit(ConvertibleTo<float>()));
+    assert(!std::signbit(ConvertibleTo<double>()));
+    assert(!std::signbit(ConvertibleTo<long double>()));
+  }
   return 0;
 }


### PR DESCRIPTION
## Why
Following up on https://github.com/llvm/llvm-project/pull/105946, this patch provides the floating point overloads for `std::signbit` as defined by [P0533R9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf).

## What
* Test and add overloads for cv-unqualified floating point types
* Remove constrained overload as it is not needed anymore
* Make use of `template<class = void>` as the universal C runtime (UCRT) needed for Clang-Cl comes with overloads for all cv-unqualified floating point types (float, double, long double) for `std::signbit()` by itself [in the WinSDK](https://github.com/microsoft/win32metadata/blob/e012b29924c53aa941fc010850b68331b0c3ea80/generation/WinSDK/RecompiledIdlHeaders/ucrt/corecrt_math.h#L309-L322). In a certain way, this can be seen as a deviation from the C standard. We need to work around it as the compilation would otherwise error out due to duplicated definitions.