### PR TITLE
[flang] Fix warnings from more recent GCCs

### DIFF
--- a/flang/include/flang/Evaluate/integer.h
+++ b/flang/include/flang/Evaluate/integer.h
@@ -828,9 +828,9 @@ public:
           if (Part ypart{y.LEPart(k)}) {
             BigPart xy{xpart};
             xy *= ypart;
-#if defined __GNUC__ && __GNUC__ < 8
-            // && to < (2 * parts) was added to avoid GCC < 8 build failure on
-            // -Werror=array-bounds. This can be removed if -Werror is disable.
+#if defined __GNUC__ && __GNUC__ < 8 || __GNUC__ >= 12
+            // && to < (2 * parts) was added to avoid GCC build failure on
+            // -Werror=array-bounds. This can be removed if -Werror is disabled.
             for (int to{j + k}; xy != 0 && to < (2 * parts); ++to) {
 #else
             for (int to{j + k}; xy != 0; ++to) {

--- a/flang/include/flang/Runtime/descriptor.h
+++ b/flang/include/flang/Runtime/descriptor.h
@@ -438,7 +438,7 @@ public:
   }
   RT_API_ATTRS inline void SetAllocIdx(int pos) {
     raw_.extra &= ~_CFI_ALLOCATOR_IDX_MASK; // Clear the allocator index bits.
-    raw_.extra |= (pos << _CFI_ALLOCATOR_IDX_SHIFT);
+    raw_.extra |= pos << _CFI_ALLOCATOR_IDX_SHIFT;
   }
 
 private:

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -5590,7 +5590,8 @@ private:
     ty = unwrapBoxEleTy(ty);
     mlir::Location loc = getLoc();
     mlir::IndexType idxTy = builder.getIndexType();
-    for (auto extent : mlir::cast<fir::SequenceType>(ty).getShape()) {
+    auto seqType = mlir::cast<fir::SequenceType>(ty);
+    for (auto extent : seqType.getShape()) {
       auto v = extent == fir::SequenceType::getUnknownExtent()
                    ? builder.create<fir::UndefOp>(loc, idxTy).getResult()
                    : builder.createIntegerConstant(loc, idxTy, extent);

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1273,7 +1273,7 @@ struct EmboxCommonConversion : public fir::FIROpConversion<OP> {
     } else {
       // Compute the value of the extra field based on allocator_idx and
       // addendum present using a Descriptor object.
-      Fortran::runtime::StaticDescriptor<0> staticDescriptor;
+      Fortran::runtime::StaticDescriptor staticDescriptor;
       Fortran::runtime::Descriptor &desc{staticDescriptor.descriptor()};
       desc.raw().extra = 0;
       desc.SetAllocIdx(allocatorIdx);

--- a/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
@@ -411,7 +411,8 @@ class DesignateOpConversion
     llvm::SmallVector<mlir::Value> firstElementIndices;
     auto indices = designate.getIndices();
     int i = 0;
-    for (auto isTriplet : designate.getIsTripletAttr().asArrayRef()) {
+    auto attrs = designate.getIsTripletAttr();
+    for (auto isTriplet : attrs.asArrayRef()) {
       // Coordinate of the first element are the index and triplets lower
       // bounds
       firstElementIndices.push_back(indices[i]);

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1796,13 +1796,12 @@ inline void OmpStructureChecker::ErrIfLHSAndRHSSymbolsMatch(
   const auto *e{GetExpr(context_, expr)};
   const auto *v{GetExpr(context_, var)};
   if (e && v) {
-    const Symbol &varSymbol = evaluate::GetSymbolVector(*v).front();
+    auto vSyms{evaluate::GetSymbolVector(*v)};
+    const Symbol &varSymbol = vSyms.front();
     for (const Symbol &symbol : evaluate::GetSymbolVector(*e)) {
       if (varSymbol == symbol) {
         context_.Say(expr.source,
-            "RHS expression "
-            "on atomic assignment statement"
-            " cannot access '%s'"_err_en_US,
+            "RHS expression on atomic assignment statement cannot access '%s'"_err_en_US,
             var.GetSource().ToString());
       }
     }
@@ -1942,12 +1941,14 @@ void OmpStructureChecker::CheckAtomicUpdateStmt(
           "Expected scalar variable "
           "on the LHS of atomic update assignment "
           "statement"_err_en_US);
-    const Symbol &varSymbol = evaluate::GetSymbolVector(*v).front();
+    auto vSyms{evaluate::GetSymbolVector(*v)};
+    const Symbol &varSymbol = vSyms.front();
     int numOfSymbolMatches{0};
-    SymbolVector exprSymbols = evaluate::GetSymbolVector(*e);
+    SymbolVector exprSymbols{evaluate::GetSymbolVector(*e)};
     for (const Symbol &symbol : exprSymbols) {
-      if (varSymbol == symbol)
+      if (varSymbol == symbol) {
         numOfSymbolMatches++;
+      }
     }
     if (isIntrinsicProcedure) {
       std::string varName = var.GetSource().ToString();

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -1354,7 +1354,7 @@ ComponentIterator<componentKind>::const_iterator::BuildResultDesignatorName()
     const {
   std::string designator;
   for (const auto &node : componentPath_) {
-    designator += "%" + DEREF(node.component()).name().ToString();
+    designator += "%"s + DEREF(node.component()).name().ToString();
   }
   return designator;
 }

--- a/flang/unittests/Runtime/Reduction.cpp
+++ b/flang/unittests/Runtime/Reduction.cpp
@@ -42,7 +42,7 @@ TEST(Reductions, DimMaskProductInt4) {
       shape, std::vector<std::int32_t>{1, 2, 3, 4, 5, 6})};
   auto mask{MakeArray<TypeCategory::Logical, 1>(
       shape, std::vector<bool>{true, false, false, true, true, true})};
-  StaticDescriptor<1, true> statDesc;
+  StaticDescriptor<maxRank, true> statDesc;
   Descriptor &prod{statDesc.descriptor()};
   RTNAME(ProductDim)(prod, *array, 1, __FILE__, __LINE__, &*mask);
   EXPECT_EQ(prod.rank(), 1);
@@ -152,7 +152,7 @@ TEST(Reductions, DoubleMaxMinNorm2) {
   // A scalar result occurs when you have a rank 1 array and dim == 1.
   std::vector<int> shape1{24};
   auto array1{MakeArray<TypeCategory::Real, 8>(shape1, rawData)};
-  StaticDescriptor<1, true> statDesc0[1];
+  StaticDescriptor<2, true> statDesc0[1];
   Descriptor &scalarResult{statDesc0[0].descriptor()};
   RTNAME(MaxlocDim)
   (scalarResult, *array1, /*KIND=*/2, /*DIM=*/1, __FILE__, __LINE__,
@@ -655,7 +655,7 @@ TEST(Reductions, ReduceInt4) {
 TEST(Reductions, ReduceInt4Dim) {
   auto intMatrix{MakeArray<TypeCategory::Integer, 4>(
       std::vector<int>{2, 2}, std::vector<std::int32_t>{1, 2, 3, 4})};
-  StaticDescriptor<1, true> statDesc;
+  StaticDescriptor<2, true> statDesc;
   Descriptor &sums{statDesc.descriptor()};
   RTNAME(ReduceInteger4DimRef)(sums, *intMatrix, IAdd, __FILE__, __LINE__, 1);
   EXPECT_EQ(sums.rank(), 1);

--- a/flang/unittests/Runtime/Transformational.cpp
+++ b/flang/unittests/Runtime/Transformational.cpp
@@ -33,7 +33,7 @@ template <int KIND>
 static void testBesselJn(BesselFuncType<KIND> rtFunc, int32_t n1, int32_t n2,
     CppTypeFor<TypeCategory::Real, KIND> x,
     const std::vector<CppTypeFor<TypeCategory::Real, KIND>> &expected) {
-  StaticDescriptor<1> desc;
+  StaticDescriptor desc;
   Descriptor &result{desc.descriptor()};
   unsigned len = expected.size();
 
@@ -60,7 +60,7 @@ static void testBesselJn(BesselFuncType<KIND> rtFunc, int32_t n1, int32_t n2,
 template <int KIND>
 static void testBesselJnX0(
     BesselX0FuncType<KIND> rtFunc, int32_t n1, int32_t n2) {
-  StaticDescriptor<1> desc;
+  StaticDescriptor desc;
   Descriptor &result{desc.descriptor()};
 
   rtFunc(result, n1, n2, __FILE__, __LINE__);
@@ -131,7 +131,7 @@ template <int KIND>
 static void testBesselYn(BesselFuncType<KIND> rtFunc, int32_t n1, int32_t n2,
     CppTypeFor<TypeCategory::Real, KIND> x,
     const std::vector<CppTypeFor<TypeCategory::Real, KIND>> &expected) {
-  StaticDescriptor<1> desc;
+  StaticDescriptor desc;
   Descriptor &result{desc.descriptor()};
   unsigned len = expected.size();
 
@@ -158,7 +158,7 @@ static void testBesselYn(BesselFuncType<KIND> rtFunc, int32_t n1, int32_t n2,
 template <int KIND>
 static void testBesselYnX0(
     BesselX0FuncType<KIND> rtFunc, int32_t n1, int32_t n2) {
-  StaticDescriptor<1> desc;
+  StaticDescriptor<2> desc;
   Descriptor &result{desc.descriptor()};
 
   rtFunc(result, n1, n2, __FILE__, __LINE__);
@@ -383,7 +383,7 @@ TEST(Transformational, Pack) {
       std::vector<std::uint8_t>{false, true, true, false, false, true})};
   mask->GetDimension(0).SetLowerBound(0); // shouldn't matter
   mask->GetDimension(1).SetLowerBound(2);
-  StaticDescriptor<1, true> statDesc;
+  StaticDescriptor<maxRank, true> statDesc;
   Descriptor &result{statDesc.descriptor()};
 
   RTNAME(Pack)(result, *array, *mask, nullptr, __FILE__, __LINE__);


### PR DESCRIPTION
While experimenting with some more recent C++ features, I ran into trouble with warnings from GCC 12.3.0 and 14.2.0. These warnings looked legitimate, so I've tweaked the code to avoid them.