### PR TITLE
[analyzer] Fix nullptr dereference for symbols from pointer invalidation

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -308,7 +308,10 @@ static const MemSpaceRegion *getStackOrGlobalSpaceRegion(const MemRegion *R) {
 const MemRegion *getOriginBaseRegion(const MemRegion *Reg) {
   Reg = Reg->getBaseRegion();
   while (const auto *SymReg = dyn_cast<SymbolicRegion>(Reg)) {
-    Reg = SymReg->getSymbol()->getOriginRegion()->getBaseRegion();
+    const auto* OriginReg = SymReg->getSymbol()->getOriginRegion();
+    if (!OriginReg)
+      break;
+    Reg = OriginReg->getBaseRegion();
   }
   return Reg;
 }

--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -308,7 +308,7 @@ static const MemSpaceRegion *getStackOrGlobalSpaceRegion(const MemRegion *R) {
 const MemRegion *getOriginBaseRegion(const MemRegion *Reg) {
   Reg = Reg->getBaseRegion();
   while (const auto *SymReg = dyn_cast<SymbolicRegion>(Reg)) {
-    const auto* OriginReg = SymReg->getSymbol()->getOriginRegion();
+    const auto *OriginReg = SymReg->getSymbol()->getOriginRegion();
     if (!OriginReg)
       break;
     Reg = OriginReg->getBaseRegion();

--- a/clang/test/Analysis/stack-addr-ps.c
+++ b/clang/test/Analysis/stack-addr-ps.c
@@ -130,7 +130,6 @@ void caller_for_nested_leaking() {
 // This used to crash StackAddrEscapeChecker because
 // it features a symbol conj_$1{struct c *, LC1, S763, #1}
 // that has no origin region.
-// bbi-98571
 struct a {
   int member;
 };
@@ -138,10 +137,10 @@ struct a {
 struct c {
   struct a *nested_ptr;
 };
-long global_var;
 void opaque(struct c*);
-void bbi_98571_no_crash() {
-  struct c *ptr = (struct c *)global_var;
+struct c* get_c(void);
+void no_crash_for_symbol_without_origin_region(void) {
+  struct c *ptr = get_c();
   opaque(ptr);
   ptr->nested_ptr->member++;
 }

--- a/clang/test/Analysis/stack-addr-ps.c
+++ b/clang/test/Analysis/stack-addr-ps.c
@@ -143,4 +143,4 @@ void no_crash_for_symbol_without_origin_region(void) {
   struct c *ptr = get_c();
   opaque(ptr);
   ptr->nested_ptr->member++;
-}
+} // No crash at the end of the function

--- a/clang/test/Analysis/stack-addr-ps.c
+++ b/clang/test/Analysis/stack-addr-ps.c
@@ -126,3 +126,22 @@ void caller_for_nested_leaking() {
   int *ptr = 0;
   caller_mid_for_nested_leaking(&ptr);
 }
+
+// This used to crash StackAddrEscapeChecker because
+// it features a symbol conj_$1{struct c *, LC1, S763, #1}
+// that has no origin region.
+// bbi-98571
+struct a {
+  int member;
+};
+
+struct c {
+  struct a *nested_ptr;
+};
+long global_var;
+void opaque(struct c*);
+void bbi_98571_no_crash() {
+  struct c *ptr = (struct c *)global_var;
+  opaque(ptr);
+  ptr->nested_ptr->member++;
+}


### PR DESCRIPTION
As reported in https://github.com/llvm/llvm-project/pull/105648#issuecomment-2317144635 commit 08ad8dc7154bf3ab79f750e6d5fb7df597c7601a
introduced a nullptr dereference in the case when store contains a binding to a symbol that has no origin region associated with it, such as the symbol generated when a pointer is passed to an opaque function.