### PR TITLE
[Support] Delete FormatVariadicTest Validate sub-test

### DIFF
--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -710,16 +710,6 @@ TEST(FormatVariadicTest, FormatFilterRange) {
   EXPECT_EQ("1, 2, 3", formatv("{0}", Range).str());
 }
 
-#ifdef NDEBUG // Disable the test in debug builds where it will assert.
-TEST(FormatVariadicTest, Validate) {
-  std::string Str = formatv("{0}", 1, 2).str();
-  EXPECT_THAT(Str, HasSubstr("Unexpected number of arguments"));
-
-  Str = formatv("{0} {2}", 1, 2, 3).str();
-  EXPECT_THAT(Str, HasSubstr("eplacement indices have holes"));
-}
-#endif // NDEBUG
-
 namespace {
 
 enum class Base { First };


### PR DESCRIPTION
- The subtest, if enabled correctly, will fail with assert in Debug builds and validation is disabled in Release builds.
- Hence deleting the test to fix test failures in CI.