### PR TITLE
[SLP] Extract isIdentityOrder to common routine [probably NFC]

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -1369,7 +1369,7 @@ public:
   /// decide if we can canonicalize a computed order.  Undef elements
   /// (represented as size) are ignored.
   bool isIdentityOrder(ArrayRef<unsigned> Order) const {
-    assert(!Order.empty() && "expected non-empty mask");
+    assert(!Order.empty() && "expected non-empty order");
     const unsigned Sz = Order.size();
     return all_of(enumerate(Order), [&](const auto &P) {
       return P.value() == P.index() || P.value() == Sz;


### PR DESCRIPTION
This isn't quite just code motion as the four different versions we had of this routine differed in whether they ignored the "size" marker used to represent undef.  I doubt this matters in practice, but it is a functional change.