### PR TITLE
[flang][fir] allow fir.convert from and to !llvm.ptr type

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2713,7 +2713,7 @@ def fir_AddrOfOp : fir_OneResultOp<"address_of", [NoMemoryEffect]> {
   let assemblyFormat = "`(` $symbol `)` attr-dict `:` type($resTy)";
 }
 
-def fir_ConvertOp : fir_OneResultOp<"convert", [NoMemoryEffect]> {
+def fir_ConvertOp : fir_SimpleOneResultOp<"convert", [NoMemoryEffect]> {
   let summary = "encapsulates all Fortran entity type conversions";
 
   let description = [{
@@ -2721,6 +2721,9 @@ def fir_ConvertOp : fir_OneResultOp<"convert", [NoMemoryEffect]> {
     Not all pairs of types have conversions. When types T and U are the same
     type, this instruction is a NOP and may be folded away. This also supports
     integer to pointer conversion and pointer to integer conversion.
+
+    This operation also allows limited interaction between FIR and LLVM
+    dialects by allowing conversion between FIR pointer types and llvm.ptr type.
 
     ```
       %v = ... : i64
@@ -2731,6 +2734,7 @@ def fir_ConvertOp : fir_OneResultOp<"convert", [NoMemoryEffect]> {
   }];
 
   let arguments = (ins AnyType:$value);
+  let results = (outs AnyType:$res);
 
   let assemblyFormat = [{
     $value attr-dict `:` functional-type($value, results)

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1387,7 +1387,7 @@ bool fir::ConvertOp::isFloatCompatible(mlir::Type ty) {
 bool fir::ConvertOp::isPointerCompatible(mlir::Type ty) {
   return mlir::isa<fir::ReferenceType, fir::PointerType, fir::HeapType,
                    fir::LLVMPointerType, mlir::MemRefType, mlir::FunctionType,
-                   fir::TypeDescType>(ty);
+                   fir::TypeDescType, mlir::LLVM::LLVMPointerType>(ty);
 }
 
 static std::optional<mlir::Type> getVectorElementType(mlir::Type ty) {

--- a/flang/test/Fir/convert.fir
+++ b/flang/test/Fir/convert.fir
@@ -11,3 +11,19 @@ func.func @c(%x : !fir.complex<4>) -> !fir.complex<8> {
   %1 = fir.convert %x : (!fir.complex<4>) -> !fir.complex<8>
   return %1 : !fir.complex<8>
 }
+
+func.func @convert_to_llvm_pointer(%x : !fir.llvm_ptr<i32>) -> !llvm.ptr {
+  %0 = fir.convert %x : (!fir.llvm_ptr<i32>) -> !llvm.ptr
+  return %0 : !llvm.ptr
+}
+// CHECK-LABEL: convert_to_llvm_pointer(
+// CHECK-SAME: ptr %[[X:.*]])
+// CHECK-NEXT: ret ptr %[[X]]
+
+func.func @convert_from_llvm_pointer(%x : !llvm.ptr) -> !fir.llvm_ptr<i32> {
+  %0 = fir.convert %x : (!llvm.ptr) -> !fir.llvm_ptr<i32>
+  return %0 : !fir.llvm_ptr<i32>
+}
+// CHECK-LABEL: convert_from_llvm_pointer(
+// CHECK-SAME: ptr %[[X:.*]])
+// CHECK-NEXT: ret ptr %[[X]]


### PR DESCRIPTION
Allow some interaction between LLVM and FIR dialect by allowing conversion between FIR memory types and llvm.ptr type.
This is meant to help experimentation where FIR and LLVM dialect coexists, and is useful to deal with cases where LLVM type makes it early into the MLIR produced by flang, like when inserting LLVM stack intrinsic here: https://github.com/llvm/llvm-project/blob/0a00d32c5f88fce89006dcde6e235bc77d7b495e/flang/lib/Optimizer/Transforms/StackReclaim.cpp#L57