### PR TITLE
libcxx: [NFC] relax error expectation for clang diagnostics

### DIFF
--- a/libcxx/test/libcxx/type_traits/is_specialization.verify.cpp
+++ b/libcxx/test/libcxx/type_traits/is_specialization.verify.cpp
@@ -17,5 +17,5 @@
 #include <array>
 #include <utility>
 
-// expected-error@+1 {{template template argument has different template parameters than its corresponding template template parameter}}
+// expected-error-re@*:* {{{{could not match _Size against 'type-parameter-0-0'|different template parameters}}}}
 static_assert(!std::__is_specialization_v<std::pair<int, std::size_t>, std::array>);


### PR DESCRIPTION
This is a split-off from #96023, where this change has already been reviewed by libcxx maintainers.

This will prevent that PR from triggering libcxx-ci from now on.