### PR TITLE
[NVPTX] fixup incorrect rounding mode for int to float conversion

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXTargetTransformInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetTransformInfo.cpp
@@ -290,15 +290,16 @@ static Instruction *simplifyNvvmIntrinsic(IntrinsicInst *II, InstCombiner &IC) {
     case Intrinsic::nvvm_d2ull_rz:
     case Intrinsic::nvvm_f2ull_rz:
       return {Instruction::FPToUI};
-    case Intrinsic::nvvm_i2d_rz:
-    case Intrinsic::nvvm_i2f_rz:
-    case Intrinsic::nvvm_ll2d_rz:
-    case Intrinsic::nvvm_ll2f_rz:
+    // Integer to floating-point uses RN rounding, not RZ
+    case Intrinsic::nvvm_i2d_rn:
+    case Intrinsic::nvvm_i2f_rn:
+    case Intrinsic::nvvm_ll2d_rn:
+    case Intrinsic::nvvm_ll2f_rn:
       return {Instruction::SIToFP};
-    case Intrinsic::nvvm_ui2d_rz:
-    case Intrinsic::nvvm_ui2f_rz:
-    case Intrinsic::nvvm_ull2d_rz:
-    case Intrinsic::nvvm_ull2f_rz:
+    case Intrinsic::nvvm_ui2d_rn:
+    case Intrinsic::nvvm_ui2f_rn:
+    case Intrinsic::nvvm_ull2d_rn:
+    case Intrinsic::nvvm_ull2f_rn:
       return {Instruction::UIToFP};
 
     // NVVM intrinsics that map to LLVM binary ops.

--- a/llvm/test/Transforms/InstCombine/NVPTX/nvvm-intrins.ll
+++ b/llvm/test/Transforms/InstCombine/NVPTX/nvvm-intrins.ll
@@ -238,49 +238,49 @@ define i64 @test_f2ull(float %a) #0 {
 ; CHECK-LABEL: @test_i2d
 define double @test_i2d(i32 %a) #0 {
 ; CHECK: sitofp i32 %a to double
-  %ret = call double @llvm.nvvm.i2d.rz(i32 %a)
+  %ret = call double @llvm.nvvm.i2d.rn(i32 %a)
   ret double %ret
 }
 ; CHECK-LABEL: @test_i2f
 define float @test_i2f(i32 %a) #0 {
 ; CHECK: sitofp i32 %a to float
-  %ret = call float @llvm.nvvm.i2f.rz(i32 %a)
+  %ret = call float @llvm.nvvm.i2f.rn(i32 %a)
   ret float %ret
 }
 ; CHECK-LABEL: @test_ll2d
 define double @test_ll2d(i64 %a) #0 {
 ; CHECK: sitofp i64 %a to double
-  %ret = call double @llvm.nvvm.ll2d.rz(i64 %a)
+  %ret = call double @llvm.nvvm.ll2d.rn(i64 %a)
   ret double %ret
 }
 ; CHECK-LABEL: @test_ll2f
 define float @test_ll2f(i64 %a) #0 {
 ; CHECK: sitofp i64 %a to float
-  %ret = call float @llvm.nvvm.ll2f.rz(i64 %a)
+  %ret = call float @llvm.nvvm.ll2f.rn(i64 %a)
   ret float %ret
 }
 ; CHECK-LABEL: @test_ui2d
 define double @test_ui2d(i32 %a) #0 {
 ; CHECK: uitofp i32 %a to double
-  %ret = call double @llvm.nvvm.ui2d.rz(i32 %a)
+  %ret = call double @llvm.nvvm.ui2d.rn(i32 %a)
   ret double %ret
 }
 ; CHECK-LABEL: @test_ui2f
 define float @test_ui2f(i32 %a) #0 {
 ; CHECK: uitofp i32 %a to float
-  %ret = call float @llvm.nvvm.ui2f.rz(i32 %a)
+  %ret = call float @llvm.nvvm.ui2f.rn(i32 %a)
   ret float %ret
 }
 ; CHECK-LABEL: @test_ull2d
 define double @test_ull2d(i64 %a) #0 {
 ; CHECK: uitofp i64 %a to double
-  %ret = call double @llvm.nvvm.ull2d.rz(i64 %a)
+  %ret = call double @llvm.nvvm.ull2d.rn(i64 %a)
   ret double %ret
 }
 ; CHECK-LABEL: @test_ull2f
 define float @test_ull2f(i64 %a) #0 {
 ; CHECK: uitofp i64 %a to float
-  %ret = call float @llvm.nvvm.ull2f.rz(i64 %a)
+  %ret = call float @llvm.nvvm.ull2f.rn(i64 %a)
   ret float %ret
 }
 
@@ -428,10 +428,10 @@ declare float @llvm.nvvm.fmax.ftz.f(float, float)
 declare double @llvm.nvvm.fmin.d(double, double)
 declare float @llvm.nvvm.fmin.f(float, float)
 declare float @llvm.nvvm.fmin.ftz.f(float, float)
-declare double @llvm.nvvm.i2d.rz(i32)
-declare float @llvm.nvvm.i2f.rz(i32)
-declare double @llvm.nvvm.ll2d.rz(i64)
-declare float @llvm.nvvm.ll2f.rz(i64)
+declare double @llvm.nvvm.i2d.rn(i32)
+declare float @llvm.nvvm.i2f.rn(i32)
+declare double @llvm.nvvm.ll2d.rn(i64)
+declare float @llvm.nvvm.ll2f.rn(i64)
 declare double @llvm.nvvm.lohi.i2d(i32, i32)
 declare double @llvm.nvvm.mul.rn.d(double, double)
 declare float @llvm.nvvm.mul.rn.f(float, float)
@@ -450,8 +450,7 @@ declare float @llvm.nvvm.sqrt.rn.ftz.f(float)
 declare double @llvm.nvvm.trunc.d(double)
 declare float @llvm.nvvm.trunc.f(float)
 declare float @llvm.nvvm.trunc.ftz.f(float)
-declare double @llvm.nvvm.ui2d.rz(i32)
+declare double @llvm.nvvm.ui2d.rn(i32)
 declare float @llvm.nvvm.ui2f.rn(i32)
-declare float @llvm.nvvm.ui2f.rz(i32)
-declare double @llvm.nvvm.ull2d.rz(i64)
-declare float @llvm.nvvm.ull2f.rz(i64)
+declare double @llvm.nvvm.ull2d.rn(i64)
+declare float @llvm.nvvm.ull2f.rn(i64)


### PR DESCRIPTION
`uitofp` and `sitofp` instructions use the default rounding mode which is defined as round-to-nearest.