### PR TITLE
[NFC][Support] Refactor FormatVariadic code.

### DIFF
--- a/llvm/include/llvm/Support/FormatCommon.h
+++ b/llvm/include/llvm/Support/FormatCommon.h
@@ -16,15 +16,17 @@
 namespace llvm {
 enum class AlignStyle { Left, Center, Right };
 
+/// Helper class to format to a \p Width wide field, with alignment \p Where
+/// within that field.
 struct FmtAlign {
   support::detail::format_adapter &Adapter;
   AlignStyle Where;
-  size_t Amount;
+  unsigned Width;
   char Fill;
 
   FmtAlign(support::detail::format_adapter &Adapter, AlignStyle Where,
-           size_t Amount, char Fill = ' ')
-      : Adapter(Adapter), Where(Where), Amount(Amount), Fill(Fill) {}
+           unsigned Width, char Fill = ' ')
+      : Adapter(Adapter), Where(Where), Width(Width), Fill(Fill) {}
 
   void format(raw_ostream &S, StringRef Options) {
     // If we don't need to align, we can format straight into the underlying
@@ -32,7 +34,7 @@ struct FmtAlign {
     // in order to calculate how long the output is so we can align it.
     // TODO: Make the format method return the number of bytes written, that
     // way we can also skip the intermediate stream for left-aligned output.
-    if (Amount == 0) {
+    if (Width == 0) {
       Adapter.format(S, Options);
       return;
     }
@@ -40,19 +42,19 @@ struct FmtAlign {
     raw_svector_ostream Stream(Item);
 
     Adapter.format(Stream, Options);
-    if (Amount <= Item.size()) {
+    if (Width <= Item.size()) {
       S << Item;
       return;
     }
 
-    size_t PadAmount = Amount - Item.size();
+    unsigned PadAmount = Width - static_cast<unsigned>(Item.size());
     switch (Where) {
     case AlignStyle::Left:
       S << Item;
       fill(S, PadAmount);
       break;
     case AlignStyle::Center: {
-      size_t X = PadAmount / 2;
+      unsigned X = PadAmount / 2;
       fill(S, X);
       S << Item;
       fill(S, PadAmount - X);
@@ -66,8 +68,8 @@ struct FmtAlign {
   }
 
 private:
-  void fill(llvm::raw_ostream &S, size_t Count) {
-    for (size_t I = 0; I < Count; ++I)
+  void fill(llvm::raw_ostream &S, unsigned Count) {
+    for (unsigned I = 0; I < Count; ++I)
       S << Fill;
   }
 };

--- a/llvm/include/llvm/Support/FormatVariadic.h
+++ b/llvm/include/llvm/Support/FormatVariadic.h
@@ -43,21 +43,20 @@
 
 namespace llvm {
 
-enum class ReplacementType { Empty, Format, Literal };
+enum class ReplacementType { Format, Literal };
 
 struct ReplacementItem {
-  ReplacementItem() = default;
   explicit ReplacementItem(StringRef Literal)
       : Type(ReplacementType::Literal), Spec(Literal) {}
-  ReplacementItem(StringRef Spec, size_t Index, size_t Align, AlignStyle Where,
-                  char Pad, StringRef Options)
-      : Type(ReplacementType::Format), Spec(Spec), Index(Index), Align(Align),
+  ReplacementItem(StringRef Spec, unsigned Index, unsigned Width,
+                  AlignStyle Where, char Pad, StringRef Options)
+      : Type(ReplacementType::Format), Spec(Spec), Index(Index), Width(Width),
         Where(Where), Pad(Pad), Options(Options) {}
 
-  ReplacementType Type = ReplacementType::Empty;
+  ReplacementType Type;
   StringRef Spec;
-  size_t Index = 0;
-  size_t Align = 0;
+  unsigned Index = 0;
+  unsigned Width = 0;
   AlignStyle Where = AlignStyle::Right;
   char Pad = 0;
   StringRef Options;
@@ -81,8 +80,6 @@ public:
   void format(raw_ostream &S) const {
     const auto Replacements = parseFormatString(Fmt, Adapters.size(), Validate);
     for (const auto &R : Replacements) {
-      if (R.Type == ReplacementType::Empty)
-        continue;
       if (R.Type == ReplacementType::Literal) {
         S << R.Spec;
         continue;
@@ -94,7 +91,7 @@ public:
 
       auto *W = Adapters[R.Index];
 
-      FmtAlign Align(*W, R.Where, R.Align, R.Pad);
+      FmtAlign Align(*W, R.Where, R.Width, R.Pad);
       Align.format(S, R.Options);
     }
   }
@@ -248,14 +245,10 @@ public:
 
 // formatv() with validation enable/disable controlled by the first argument.
 template <typename... Ts>
-inline auto formatv(bool Validate, const char *Fmt, Ts &&...Vals)
-    -> formatv_object<decltype(std::make_tuple(
-        support::detail::build_format_adapter(std::forward<Ts>(Vals))...))> {
-  using ParamTuple = decltype(std::make_tuple(
-      support::detail::build_format_adapter(std::forward<Ts>(Vals))...));
+inline auto formatv(bool Validate, const char *Fmt, Ts &&...Vals) {
   auto Params = std::make_tuple(
       support::detail::build_format_adapter(std::forward<Ts>(Vals))...);
-  return formatv_object<ParamTuple>(Fmt, std::move(Params), Validate);
+  return formatv_object<decltype(Params)>(Fmt, std::move(Params), Validate);
 }
 
 // formatv() with validation enabled.

--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -87,14 +87,14 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(0u, Replacements[0].Align);
+  EXPECT_EQ(0u, Replacements[0].Width);
   EXPECT_EQ("", Replacements[0].Options);
 
   Replacements = parseFormatString("{1}");
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(1u, Replacements[0].Index);
-  EXPECT_EQ(0u, Replacements[0].Align);
+  EXPECT_EQ(0u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ("", Replacements[0].Options);
 
@@ -103,7 +103,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(3u, Replacements[0].Align);
+  EXPECT_EQ(3u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ("", Replacements[0].Options);
 
@@ -112,7 +112,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(3u, Replacements[0].Align);
+  EXPECT_EQ(3u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Left, Replacements[0].Where);
   EXPECT_EQ("", Replacements[0].Options);
 
@@ -121,7 +121,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(3u, Replacements[0].Align);
+  EXPECT_EQ(3u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Center, Replacements[0].Where);
   EXPECT_EQ("", Replacements[0].Options);
 
@@ -130,7 +130,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(0u, Replacements[0].Align);
+  EXPECT_EQ(0u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ("foo", Replacements[0].Options);
 
@@ -139,7 +139,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(3u, Replacements[0].Align);
+  EXPECT_EQ(3u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Left, Replacements[0].Where);
   EXPECT_EQ("foo", Replacements[0].Options);
 
@@ -148,7 +148,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(3u, Replacements[0].Align);
+  EXPECT_EQ(3u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Left, Replacements[0].Where);
   EXPECT_EQ("foo", Replacements[0].Options);
 
@@ -159,7 +159,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   EXPECT_EQ("0:0:1", Replacements[0].Spec);
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(0u, Replacements[0].Align);
+  EXPECT_EQ(0u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ("0:1", Replacements[0].Options);
 
@@ -169,7 +169,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   EXPECT_EQ("0,p+4:foo", Replacements[0].Spec);
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(4u, Replacements[0].Align);
+  EXPECT_EQ(4u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ('p', Replacements[0].Pad);
   EXPECT_EQ("foo", Replacements[0].Options);
@@ -180,7 +180,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   EXPECT_EQ("0,-+4:foo", Replacements[0].Spec);
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(4u, Replacements[0].Align);
+  EXPECT_EQ(4u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ('-', Replacements[0].Pad);
   EXPECT_EQ("foo", Replacements[0].Options);
@@ -190,7 +190,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   EXPECT_EQ("0,+-4:foo", Replacements[0].Spec);
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(4u, Replacements[0].Align);
+  EXPECT_EQ(4u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Left, Replacements[0].Where);
   EXPECT_EQ('+', Replacements[0].Pad);
   EXPECT_EQ("foo", Replacements[0].Options);
@@ -200,7 +200,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   EXPECT_EQ("0,==4:foo", Replacements[0].Spec);
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(4u, Replacements[0].Align);
+  EXPECT_EQ(4u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Center, Replacements[0].Where);
   EXPECT_EQ('=', Replacements[0].Pad);
   EXPECT_EQ("foo", Replacements[0].Options);
@@ -210,7 +210,7 @@ TEST(FormatVariadicTest, ValidReplacementSequence) {
   EXPECT_EQ("0,:=4:foo", Replacements[0].Spec);
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(4u, Replacements[0].Align);
+  EXPECT_EQ(4u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Center, Replacements[0].Where);
   EXPECT_EQ(':', Replacements[0].Pad);
   EXPECT_EQ("foo", Replacements[0].Options);
@@ -222,7 +222,7 @@ TEST(FormatVariadicTest, DefaultReplacementValues) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(3u, Replacements[0].Align);
+  EXPECT_EQ(3u, Replacements[0].Width);
   EXPECT_EQ("", Replacements[0].Options);
 
   // Including if the colon is present but contains no text.
@@ -230,7 +230,7 @@ TEST(FormatVariadicTest, DefaultReplacementValues) {
   ASSERT_EQ(1u, Replacements.size());
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(3u, Replacements[0].Align);
+  EXPECT_EQ(3u, Replacements[0].Width);
   EXPECT_EQ("", Replacements[0].Options);
 
   // 3. If alignment is missing, it defaults to 0, right, space
@@ -240,7 +240,7 @@ TEST(FormatVariadicTest, DefaultReplacementValues) {
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ(' ', Replacements[0].Pad);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(0u, Replacements[0].Align);
+  EXPECT_EQ(0u, Replacements[0].Width);
   EXPECT_EQ("foo", Replacements[0].Options);
 }
 
@@ -250,7 +250,7 @@ TEST(FormatVariadicTest, MultipleReplacements) {
   // {0}
   EXPECT_EQ(ReplacementType::Format, Replacements[0].Type);
   EXPECT_EQ(0u, Replacements[0].Index);
-  EXPECT_EQ(0u, Replacements[0].Align);
+  EXPECT_EQ(0u, Replacements[0].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[0].Where);
   EXPECT_EQ("", Replacements[0].Options);
 
@@ -261,7 +261,7 @@ TEST(FormatVariadicTest, MultipleReplacements) {
   // {1:foo} - Options=foo
   EXPECT_EQ(ReplacementType::Format, Replacements[2].Type);
   EXPECT_EQ(1u, Replacements[2].Index);
-  EXPECT_EQ(0u, Replacements[2].Align);
+  EXPECT_EQ(0u, Replacements[2].Width);
   EXPECT_EQ(AlignStyle::Right, Replacements[2].Where);
   EXPECT_EQ("foo", Replacements[2].Options);
 
@@ -272,7 +272,7 @@ TEST(FormatVariadicTest, MultipleReplacements) {
   // {2:bar,-3} - Options=bar, Align=-3
   EXPECT_EQ(ReplacementType::Format, Replacements[4].Type);
   EXPECT_EQ(2u, Replacements[4].Index);
-  EXPECT_EQ(3u, Replacements[4].Align);
+  EXPECT_EQ(3u, Replacements[4].Width);
   EXPECT_EQ(AlignStyle::Left, Replacements[4].Where);
   EXPECT_EQ("bar", Replacements[4].Options);
 }


### PR DESCRIPTION
- Rename `Align` field in ReplacementItem/FmtAlign to `Width` to 
  accurately reflect its use.
- Change both `Width` and `Index` in ReplacementItem to 32-bit int 
  instead of size_t (as 64-bits seems excessive in this context).
- Eliminate the use of `Empty` ReplacementType, and use the
  existing std::optional<> instead to indicate that.
- Eliminate some boilerplate type code in formatv().
- Eliminate the loop in `splitLiteralAndReplacement`. The existing
  code will never loop back.
- Directly use constructor instead of std::make_pair.