### PR TITLE
[libc] Add stubs for 'langinfo.h'

### DIFF
--- a/libc/config/gpu/headers.txt
+++ b/libc/config/gpu/headers.txt
@@ -17,6 +17,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.uchar
     libc.include.features
     libc.include.locale
+    libc.include.langinfo
 
     # Header for RPC extensions
     libc.include.gpu_rpc

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -732,6 +732,17 @@ add_header_macro(
     .llvm-libc-types.struct_lconv
 )
 
+add_header_macro(
+  langinfo
+  ../libc/newhdrgen/yaml/langinfo.yaml
+  langinfo.h.def
+  langinfo.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.langinfo_macros
+    .llvm-libc-types.nl_item
+)
+
 if(LIBC_TARGET_OS_IS_GPU)
   file(MAKE_DIRECTORY ${LIBC_INCLUDE_DIR}/gpu)
 

--- a/libc/include/langinfo.h.def
+++ b/libc/include/langinfo.h.def
@@ -1,0 +1,20 @@
+//===-- C standard library header langinfo.h --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_LANGINFO_H
+#define LLVM_LIBC_LANGINFO_H
+
+#include "__llvm-libc-common.h"
+
+#include "llvm-libc-types/locale_t.h"
+#include "llvm-libc-macros/langinfo-macros.h"
+
+%%public_api()
+
+#endif // LLVM_LIBC_LANGINFO_H
+

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -301,3 +301,9 @@ add_macro_header(
   HDR
     locale-macros.h
 )
+
+add_macro_header(
+  langinfo_macros
+  HDR
+    langinfo-macros.h
+)

--- a/libc/include/llvm-libc-macros/langinfo-macros.h
+++ b/libc/include/llvm-libc-macros/langinfo-macros.h
@@ -1,0 +1,81 @@
+//===-- Definition of macros from langinfo.h ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_LANGINFO_MACROS_H
+#define LLVM_LIBC_MACROS_LANGINFO_MACROS_H
+
+// TODO: Define these for the C locale.
+#define CODESET 0
+
+#define D_T_FMT 0
+#define D_FMT 0
+#define T_FMT 0
+#define T_FMT_AMPM 0
+
+#define AM_STR 0
+#define PM_STR 0
+
+#define DAY_1 0
+#define DAY_2 0
+#define DAY_3 0
+#define DAY_4 0
+#define DAY_5 0
+#define DAY_6 0
+#define DAY_7 0
+
+#define ABDAY_1 0
+#define ABDAY_2 0
+#define ABDAY_3 0
+#define ABDAY_4 0
+#define ABDAY_5 0
+#define ABDAY_6 0
+#define ABDAY_7 0
+
+#define MON_1 0
+#define MON_2 0
+#define MON_3 0
+#define MON_4 0
+#define MON_5 0
+#define MON_6 0
+#define MON_7 0
+#define MON_8 0
+#define MON_9 0
+#define MON_10 0
+#define MON_11 0
+#define MON_12 0
+
+#define ABMON_1 0
+#define ABMON_2 0
+#define ABMON_3 0
+#define ABMON_4 0
+#define ABMON_5 0
+#define ABMON_6 0
+#define ABMON_7 0
+#define ABMON_8 0
+#define ABMON_9 0
+#define ABMON_10 0
+#define ABMON_11 0
+#define ABMON_12 0
+
+#define ERA 0
+#define ERA_D_FMT 0
+#define ERA_D_T_FMT 0
+#define ERA_T_FMT 0
+
+#define ALT_DIGITS 0
+
+#define RADIXCHAR 0
+
+#define THOUSEP 0
+
+#define YESEXPR 0
+#define NOEXPR 0
+
+#define CRNCYSTR 0
+
+#endif // LLVM_LIBC_MACROS_LANGINFO_MACROS_H

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -144,3 +144,4 @@ DEPENDS
 )
 add_header(locale_t HDR locale_t.h)
 add_header(struct_lconv HDR struct_lconv.h)
+add_header(nl_item HDR nl_item.h)

--- a/libc/include/llvm-libc-types/nl_item.h
+++ b/libc/include/llvm-libc-types/nl_item.h
@@ -1,0 +1,14 @@
+//===-- Definition of type nl_item ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_NL_ITEM_H
+#define LLVM_LIBC_TYPES_NL_ITEM_H
+
+typedef int nl_item;
+
+#endif // LLVM_LIBC_TYPES_NL_ITEM_H

--- a/libc/newhdrgen/yaml/langinfo.yaml
+++ b/libc/newhdrgen/yaml/langinfo.yaml
@@ -1,0 +1,19 @@
+header: langinfo.h
+macros: []
+types: []
+enums: []
+objects: []
+functions:
+  - name: nl_langinfo
+    standards:
+      - POSIX
+    return_type: char *
+    arguments:
+        - type: nl_item
+  - name: nl_langinfo_l
+    standards:
+      - POSIX
+    return_type: char *
+    arguments:
+        - type: nl_item
+        - type: locale_t

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -5,6 +5,7 @@ def StdC : StandardSpec<"stdc"> {
   PtrType TimeTTypePtr = PtrType<TimeTType>;
   NamedType ClockT = NamedType<"clock_t">;
   NamedType LocaleT = NamedType<"locale_t">;
+  NamedType NLItem = NamedType<"nl_item">;
 
   NamedType DivTType = NamedType<"div_t">;
   NamedType LDivTType = NamedType<"ldiv_t">;
@@ -1754,6 +1755,30 @@ def StdC : StandardSpec<"stdc"> {
       ]  // Functions
   >;
 
+  HeaderSpec LangInfo = HeaderSpec<
+      "langinfo.h",
+      [],
+      [], // Types
+      [], // Enumerations
+      [
+        FunctionSpec<
+          "nl_langinfo",
+          RetValSpec<CharPtr>,
+          [
+            ArgSpec<NLItem>
+          ]
+        >,
+        FunctionSpec<
+          "nl_langinfo",
+          RetValSpec<CharPtr>,
+          [
+            ArgSpec<NLItem>,
+            ArgSpec<LocaleT>
+          ]
+        >
+      ] // Functions
+  >;
+
   let Headers = [
     Assert,
     CType,
@@ -1776,5 +1801,6 @@ def StdC : StandardSpec<"stdc"> {
     UChar,
     WChar,
     Locale,
+    LangInfo,
   ];
 }

--- a/libc/src/langinfo/CMakeLists.txt
+++ b/libc/src/langinfo/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_object_library(
+  nl_langinfo
+  SRCS
+    nl_langinfo.cpp
+  HDRS
+    nl_langinfo.h
+  DEPENDS
+    libc.include.langinfo
+    libc.include.locale
+)
+
+add_object_library(
+  nl_langinfo_l
+  SRCS
+    nl_langinfo_l.cpp
+  HDRS
+    nl_langinfo_l.h
+  DEPENDS
+    libc.include.locale
+)

--- a/libc/src/langinfo/nl_langinfo.cpp
+++ b/libc/src/langinfo/nl_langinfo.cpp
@@ -1,0 +1,20 @@
+//===-- Implementation of nl_langinfo -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/langinfo/nl_langinfo.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, nl_langinfo, (nl_item)) {
+  static char EMPTY[] = "";
+  return EMPTY;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/langinfo/nl_langinfo.h
+++ b/libc/src/langinfo/nl_langinfo.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for nl_langinfo -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_LANGINFO_NL_LANGINFO_H
+#define LLVM_LIBC_SRC_LANGINFO_NL_LANGINFO_H
+
+#include "include/llvm-libc-types/nl_item.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *nl_langinfo(nl_item);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_LANGINFO_NL_LANGINFO_H

--- a/libc/src/langinfo/nl_langinfo_l.cpp
+++ b/libc/src/langinfo/nl_langinfo_l.cpp
@@ -1,0 +1,20 @@
+//===-- Implementation of nl_langinfo_l -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/langinfo/nl_langinfo_l.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, nl_langinfo_l, (nl_item, locale_t locale)) {
+  static char EMPTY[] = "";
+  return EMPTY;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/langinfo/nl_langinfo_l.h
+++ b/libc/src/langinfo/nl_langinfo_l.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for nl_langinfo_l -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_LANGINFO_NL_LANGINFO_L_H
+#define LLVM_LIBC_SRC_LANGINFO_NL_LANGINFO_L_H
+
+#include "include/llvm-libc-types/locale_t.h"
+#include "include/llvm-libc-types/nl_item.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *nl_langinfo_l(nl_item, locale_t locale);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_LANGINFO_NL_LANGINFO_L_H


### PR DESCRIPTION
Summary:
This patch adds the stubs for the `langinfo.h` POSIX header. These are
currently all set to zero and won't do anything if used. A future patch
should hard-code all of these to the "C" locale.
