### PR TITLE
[llvm-lit] Add redirection handling for `env` command without args and write a lit test to check behavior with lit internal shell

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -746,11 +746,25 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
                     env_str = "\n".join(
                         f"{key}={value}" for key, value in sorted(cmd_shenv.env.items())
                     )
-                    results.append(
-                        ShellCommandResult(
-                            j, env_str, "", 0, timeoutHelper.timeoutReached(), []
-                        )
+                    # Process redirections.
+                    stdin, stdout, stderr = processRedirects(
+                        j, default_stdin, cmd_shenv, opened_files
                     )
+                    if stdout != default_stdin:
+                        # Write directly to the redirected file (stdout).
+                        stdout.write(env_str)
+                        results.append(
+                            ShellCommandResult(
+                                j, "", "", 0, timeoutHelper.timeoutReached(), []
+                            )
+                        )
+                    else:
+                        # Capture the output for cases without redirection.
+                        results.append(
+                            ShellCommandResult(
+                                j, env_str, "", 0, timeoutHelper.timeoutReached(), []
+                            )
+                        )
                     return 0
             elif args[0] == "not":
                 not_args.append(args.pop(0))

--- a/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-temp-redirect.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-temp-redirect.txt
@@ -1,0 +1,7 @@
+## Test the env command with output redirection to a file.
+# RUN: rm -f %t
+# RUN: env > %t
+# RUN: FileCheck %s < %t
+
+# CHECK: BAR=2
+# CHECK: FOO=1

--- a/llvm/utils/lit/tests/shtest-env-positive.py
+++ b/llvm/utils/lit/tests/shtest-env-positive.py
@@ -7,7 +7,7 @@
 
 ## Test the env command's successful executions.
 
-# CHECK: -- Testing: 9 tests{{.*}}
+# CHECK: -- Testing: 10 tests{{.*}}
 
 # CHECK: PASS: shtest-env :: env-args-last-is-assign.txt ({{[^)]*}})
 # CHECK: env FOO=1
@@ -47,6 +47,12 @@
 # CHECK-NOT: # error:
 # CHECK: --
 
+# CHECK: PASS: shtest-env :: env-temp-redirect.txt ({{[^)]*}})
+# CHECK: env {{.*}}/env-temp-redirect.txt.tmp
+# CHECK: # executed command: env
+# CHECK-NOT: # error:
+# CHECK: --
+
 # CHECK: PASS: shtest-env :: env-u.txt ({{[^)]*}})
 # CHECK: env -u FOO | {{.*}}
 # CHECK: # executed command: env -u FOO
@@ -65,6 +71,6 @@
 # CHECK-NOT: # error:
 # CHECK: --
 
-# CHECK: Total Discovered Tests: 9
-# CHECK: Passed: 9 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Total Discovered Tests: 10
+# CHECK: Passed: 10 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}


### PR DESCRIPTION
The current implementation of the `env` command in lit's internal shell lacks support for redirection to a temporary file when the command is executed without arguments. This limitation means that when users attempt to redirect the output of the `env` command to a temporary file, it fails to find the file, leading to unexpected behavior. 

This patch enhances the `TestRunner.py` to correctly handle cases where the `env` command is executed without arguments and with redirection. Previously, the `env` command did not support redirection to a temporary file when no arguments were provided, leading to unexpected behavior where environment variables were not written to the specified file.

The patch introduces a check for when the `env` command is run without arguments. It now calls the `processRedirects` function, which returns the file descriptors (stdin (0), stdout (1) , stderr (2) ). If a redirection is specified (i.e., `stdout` is not the default `stdin`), the environment variables are directly written to the redirected file using the `stdout.write(env_str)` command. Otherwise, the output is captured for scenarios without redirection.

Additionally, this patch adds a corresponding test in the lit's internal shell to verify the correct behavior of the `env` command with output redirection. The test ensures that when the `env` command is redirected to a temp file and checks if the environment variables are correctly outputted.


This change is relevant for [[RFC] Enabling the Lit Internal Shell by Default](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179/3)  
fixes: #106627