### PR TITLE
[libc] Add stubs for 'strftime' function

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -254,6 +254,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.clock
     libc.src.time.clock_gettime
     libc.src.time.nanosleep
+    libc.src.time.strftime
+    libc.src.time.strftime_l
 
     # wchar.h entrypoints
     libc.src.wchar.wctob

--- a/libc/newhdrgen/yaml/time.yaml
+++ b/libc/newhdrgen/yaml/time.yaml
@@ -8,6 +8,7 @@ types:
   - type_name: time_t
   - type_name: clock_t
   - type_name: size_t
+  - type_name: locale_t
 enums: []
 objects: []
 functions:
@@ -83,3 +84,22 @@ functions:
     return_type: time_t
     arguments:
       - type: time_t *
+  - name: strftime
+    standard:
+      - stdc
+    return_type: size_t
+    arguments:
+      - type: char *__restrict
+      - type: size_t
+      - type: const char *__restrict
+      - type: const struct tm *__restrict
+  - name: strftime_l
+    standard:
+      - stdc
+    return_type: size_t
+    arguments:
+      - type: char *__restrict
+      - type: size_t
+      - type: const char *__restrict
+      - type: const struct tm *__restrict
+      - type: locale_t

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -1584,6 +1584,7 @@ def StdC : StandardSpec<"stdc"> {
          StructTimeSpec,
          TimeTType,
          SizeTType,
+         LocaleT,
       ],
       [], // Enumerations
       [
@@ -1635,6 +1636,26 @@ def StdC : StandardSpec<"stdc"> {
               "time",
               RetValSpec<TimeTType>,
               [ArgSpec<TimeTTypePtr>]
+          >,
+          FunctionSpec<
+              "strftime",
+              RetValSpec<SizeTType>,
+              [
+                  ArgSpec<CharRestrictedPtr>,
+                  ArgSpec<SizeTType>,
+                  ArgSpec<ConstCharRestrictedPtr>,
+                  ArgSpec<StructTmPtr>
+              ]
+          FunctionSpec<
+              "strftime_l",
+              RetValSpec<SizeTType>,
+              [
+                  ArgSpec<CharRestrictedPtr>,
+                  ArgSpec<SizeTType>,
+                  ArgSpec<ConstCharRestrictedPtr>,
+                  ArgSpec<StructTmPtr>,
+                  ArgSpec<LocaleT>
+              ]
           >,
       ]
   >;

--- a/libc/src/time/CMakeLists.txt
+++ b/libc/src/time/CMakeLists.txt
@@ -75,9 +75,30 @@ add_entrypoint_object(
   HDRS
     mktime.h
   DEPENDS
-    .time_utils
     libc.include.time
     libc.src.errno.errno
+)
+
+
+add_entrypoint_object(
+  strftime
+  SRCS
+    strftime.cpp
+  HDRS
+    strftime.h
+  DEPENDS
+    libc.include.time
+)
+
+add_entrypoint_object(
+  strftime_l
+  SRCS
+    strftime_l.cpp
+  HDRS
+    strftime_l.h
+  DEPENDS
+    libc.include.time
+    libc.include.locale
 )
 
 add_entrypoint_object(

--- a/libc/src/time/strftime.cpp
+++ b/libc/src/time/strftime.cpp
@@ -1,0 +1,25 @@
+//===-- Implementation of strftime function -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/time/strftime.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/time/time_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+using LIBC_NAMESPACE::time_utils::TimeConstants;
+
+LLVM_LIBC_FUNCTION(size_t, strftime,
+                   (char *__restrict, size_t, const char *__restrict,
+                    const struct tm *)) {
+  // TODO: Implement this for the default locale.
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/time/strftime.cpp
+++ b/libc/src/time/strftime.cpp
@@ -9,6 +9,7 @@
 #include "src/time/strftime.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
+#include "src/errno/libc_errno.h"
 #include "src/time/time_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -19,7 +20,7 @@ LLVM_LIBC_FUNCTION(size_t, strftime,
                    (char *__restrict, size_t, const char *__restrict,
                     const struct tm *)) {
   // TODO: Implement this for the default locale.
-  return 0;
+  return -1;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/time/strftime.h
+++ b/libc/src/time/strftime.h
@@ -1,0 +1,23 @@
+//===-- Implementation header of strftime -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_TIME_STRFTIME_H
+#define LLVM_LIBC_SRC_TIME_STRFTIME_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+#include <time.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strftime(char *__restrict, size_t max, const char *__restrict format,
+                const struct tm *timeptr);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_TIME_STRFTIME_H

--- a/libc/src/time/strftime_l.cpp
+++ b/libc/src/time/strftime_l.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of strftime_l function -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/time/strftime_l.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/time/time_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, strftime_l,
+                   (char *__restrict, size_t, const char *__restrict,
+                    const struct tm *, locale_t)) {
+  // TODO: Implement this for the default locale.
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/time/strftime_l.cpp
+++ b/libc/src/time/strftime_l.cpp
@@ -9,6 +9,7 @@
 #include "src/time/strftime_l.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
+#include "src/errno/libc_errno.h"
 #include "src/time/time_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -17,7 +18,7 @@ LLVM_LIBC_FUNCTION(size_t, strftime_l,
                    (char *__restrict, size_t, const char *__restrict,
                     const struct tm *, locale_t)) {
   // TODO: Implement this for the default locale.
-  return 0;
+  return -1;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/time/strftime_l.h
+++ b/libc/src/time/strftime_l.h
@@ -1,0 +1,24 @@
+//===-- Implementation header of strftime_l ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_TIME_STRFTIME_L_H
+#define LLVM_LIBC_SRC_TIME_STRFTIME_L_H
+
+#include "include/llvm-libc-types/locale_t.h"
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+#include <time.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strftime_l(char *__restrict, size_t max, const char *__restrict format,
+                  const struct tm *timeptr, locale_t locale);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_TIME_STRFTIME_L_H

--- a/libc/src/time/strftime_l.h
+++ b/libc/src/time/strftime_l.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_TIME_STRFTIME_L_H
 #define LLVM_LIBC_SRC_TIME_STRFTIME_L_H
 
-#include "include/llvm-libc-types/locale_t.h"
+#include "hdr/types/locale_t.h"
 #include "src/__support/macros/config.h"
 #include <stddef.h>
 #include <time.h>


### PR DESCRIPTION
Summary:
This patch does not actually implement the function, but provides the
interface. This partially resovles
https://github.com/llvm/llvm-project/issues/106630 as it will allow us
to build libc++ with locale support (so long as you don't use it).
