### PR TITLE
[libcxx] Use the default rune table when using the LLVM libc

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -888,7 +888,7 @@ typedef __char32_t char32_t;
 #  endif
 
 #  if defined(__BIONIC__) || defined(__NuttX__) || defined(__Fuchsia__) || defined(__wasi__) ||                        \
-      defined(_LIBCPP_HAS_MUSL_LIBC) || defined(__OpenBSD__)
+      defined(_LIBCPP_HAS_MUSL_LIBC) || defined(__OpenBSD__) || defined(__LLVM_LIBC__)
 #    define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
 #  endif
 


### PR DESCRIPTION
Summary:
We currently do not provide a more complicated rune table, so we want the
default.
