### PR TITLE
[libcxx] Do not include `langinfo.h` when using the LLVM C library

### DIFF
--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -34,7 +34,7 @@
 #  define _CTYPE_DISABLE_MACROS
 #endif
 
-#if !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__) && !defined(__BIONIC__) && !defined(__NuttX__)
+#if __has_include("<langinfo.h>")
 #  include <langinfo.h>
 #endif
 


### PR DESCRIPTION
Summary:
The `langinfo.h` header is a POSIX extension, so ideally we would be
able to build the C++ library without it. Currently the LLVM C library
doesn't support / provide it. This allows us to build the C++ library
with locales enabled. We can either disable it here, or just provide
stubs that do nothing as in https://github.com/llvm/llvm-project/pull/106620.
