### PR TITLE
[lld][llvm-lit] Enabled lit internal shell for lld test suite

### DIFF
--- a/lld/test/lit.cfg.py
+++ b/lld/test/lit.cfg.py
@@ -19,7 +19,18 @@ config.name = "lld"
 # testFormat: The test format to use to interpret tests.
 #
 # For now we require '&&' between commands, until they get globally killed and the test runner updated.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# We prefer the lit internal shell which provides a better user experience on failures
+# unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+
+config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
+
+# TODO: Tests that REQUIRES: shell are unsupported by the lit internal shell
+if use_lit_shell:
+    config.available_features.discard("shell")
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".ll", ".s", ".test", ".yaml", ".objtxt"]


### PR DESCRIPTION
This patch sets lit's internal shell to be the default shell when running lld tests. Tests that `REQUIRES: shell` are not currently supported by the internal shell, so those tests are skipped with this implementation.

Resolves https://github.com/llvm/llvm-project/issues/102700.