### PR TITLE
[EdgeBundles] Correct MBB label name in output graph when `-view-edge-bundles`. NFC.

### DIFF
--- a/llvm/lib/CodeGen/EdgeBundles.cpp
+++ b/llvm/lib/CodeGen/EdgeBundles.cpp
@@ -80,7 +80,8 @@ raw_ostream &WriteGraph<>(raw_ostream &O, const EdgeBundles &G,
   O << "digraph {\n";
   for (const auto &MBB : *MF) {
     unsigned BB = MBB.getNumber();
-    O << "\t\"" << printMBBReference(MBB) << "\" [ shape=box ]\n"
+    O << "\t\"" << printMBBReference(MBB) << "\" [ shape=box, label = \""
+      << printMBBReference(MBB) << "\"" << " ]\n"
       << '\t' << G.getBundle(BB, false) << " -> \"" << printMBBReference(MBB)
       << "\"\n"
       << "\t\"" << printMBBReference(MBB) << "\" -> " << G.getBundle(BB, true)

--- a/llvm/lib/CodeGen/EdgeBundles.cpp
+++ b/llvm/lib/CodeGen/EdgeBundles.cpp
@@ -81,7 +81,7 @@ raw_ostream &WriteGraph<>(raw_ostream &O, const EdgeBundles &G,
   for (const auto &MBB : *MF) {
     unsigned BB = MBB.getNumber();
     O << "\t\"" << printMBBReference(MBB) << "\" [ shape=box, label=\""
-      << printMBBReference(MBB) << "\"" << " ]\n"
+      << printMBBReference(MBB) << "\" ]\n"
       << '\t' << G.getBundle(BB, false) << " -> \"" << printMBBReference(MBB)
       << "\"\n"
       << "\t\"" << printMBBReference(MBB) << "\" -> " << G.getBundle(BB, true)

--- a/llvm/lib/CodeGen/EdgeBundles.cpp
+++ b/llvm/lib/CodeGen/EdgeBundles.cpp
@@ -80,7 +80,7 @@ raw_ostream &WriteGraph<>(raw_ostream &O, const EdgeBundles &G,
   O << "digraph {\n";
   for (const auto &MBB : *MF) {
     unsigned BB = MBB.getNumber();
-    O << "\t\"" << printMBBReference(MBB) << "\" [ shape=box, label = \""
+    O << "\t\"" << printMBBReference(MBB) << "\" [ shape=box, label=\""
       << printMBBReference(MBB) << "\"" << " ]\n"
       << '\t' << G.getBundle(BB, false) << " -> \"" << printMBBReference(MBB)
       << "\"\n"


### PR DESCRIPTION
With `-view-edge-bundles`, before the change, the dot file output is kinda like
```dot
digraph {
        "%bb.0" [ shape=box ]
        0 -> "%bb.0"
        "%bb.0" -> 1
        "%bb.0" -> "%bb.1" [ color=lightgray ]
        "%bb.0" -> "%bb.6" [ color=lightgray ]
        "%bb.1" [ shape=box ]
        1 -> "%bb.1"
        "%bb.1" -> 1
        "%bb.1" -> "%bb.2" [ color=lightgray ]
        "%bb.1" -> "%bb.6" [ color=lightgray ]
        "%bb.2" [ shape=box ]
        1 -> "%bb.2"
        "%bb.2" -> 1
        "%bb.2" -> "%bb.3" [ color=lightgray ]
        "%bb.3" [ shape=box ]
        1 -> "%bb.3"
        "%bb.3" -> 2
        "%bb.3" -> "%bb.4" [ color=lightgray ]
        "%bb.4" [ shape=box ]
        2 -> "%bb.4"
        "%bb.4" -> 2
        "%bb.4" -> "%bb.4" [ color=lightgray ]
        "%bb.4" -> "%bb.5" [ color=lightgray ]
        "%bb.5" [ shape=box ]
        2 -> "%bb.5"
        "%bb.5" -> 1
        "%bb.5" -> "%bb.6" [ color=lightgray ]
        "%bb.5" -> "%bb.3" [ color=lightgray ]
        "%bb.6" [ shape=box ]
        1 -> "%bb.6"
        "%bb.6" -> 3
}
```
However, the graph output by graphviz is
![t](https://github.com/user-attachments/assets/24056c0a-3ba9-49c3-a5da-269f3140e619)
The node name corresponding to the MBB is incorrect.
After the change, the node name is consistent with MBB's name.
![s](https://github.com/user-attachments/assets/38c649d1-7222-4de1-971c-56f7721ab64c)
