### PR TITLE
 [llvm-lit] Show test output when combining -v or -a with -q

### DIFF
--- a/llvm/utils/lit/lit/display.py
+++ b/llvm/utils/lit/lit/display.py
@@ -2,7 +2,7 @@ import sys
 
 
 def create_display(opts, tests, total_tests, workers):
-    if opts.quiet:
+    if opts.quiet and not (opts.showOutput or opts.showAllOutput):
         return NopDisplay()
 
     num_tests = len(tests)
@@ -97,6 +97,7 @@ class Display(object):
         show_result = (
             test.isFailure()
             or self.opts.showAllOutput
+            or self.opts.showOutput
             or (not self.opts.quiet and not self.opts.succinct)
         )
         if show_result:

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -3,6 +3,10 @@
 # RUN: not %{lit} -v %{inputs}/shtest-output-printing > %t.out
 # RUN: FileCheck --input-file %t.out --match-full-lines %s
 #
+# Check that -q doesn't override -v
+# RUN: not %{lit} -v -q %{inputs}/shtest-output-printing > %t.out
+# RUN: FileCheck --input-file %t.out --match-full-lines %s
+#
 # END.
 
 #       CHECK: -- Testing: {{.*}}


### PR DESCRIPTION
This allows the user to silence lit's note and warn diagnostics with --quiet/-q, but still get test output with --verbose/-v or --show-all/-a.

Previously -v and -a silently did nothing when combined with -q, regardless of the order they appeared in.

This fixes #106643