### PR TITLE
[LTO][ELF][lld] Use unique string saver in ELF bitcode symbol parsing

### DIFF
--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -9,6 +9,8 @@
 #ifndef LLD_ELF_INPUT_FILES_H
 #define LLD_ELF_INPUT_FILES_H
 
+#include <string>
+
 #include "Config.h"
 #include "Symbols.h"
 #include "lld/Common/ErrorHandler.h"
@@ -23,6 +25,8 @@
 namespace llvm {
 struct DILineInfo;
 class TarWriter;
+class StringRef;
+class Twine;
 namespace lto {
 class InputFile;
 }
@@ -335,6 +339,12 @@ public:
   void postParse();
   std::unique_ptr<llvm::lto::InputFile> obj;
   std::vector<bool> keptComdats;
+
+private:
+  StringRef saved_symbol(const char *S);
+  StringRef saved_symbol(StringRef S);
+  StringRef saved_symbol(const Twine &S);
+  StringRef saved_symbol(const std::string &S);
 };
 
 // .so file.

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -9,8 +9,6 @@
 #ifndef LLD_ELF_INPUT_FILES_H
 #define LLD_ELF_INPUT_FILES_H
 
-#include <string>
-
 #include "Config.h"
 #include "Symbols.h"
 #include "lld/Common/ErrorHandler.h"
@@ -25,8 +23,6 @@
 namespace llvm {
 struct DILineInfo;
 class TarWriter;
-class StringRef;
-class Twine;
 namespace lto {
 class InputFile;
 }
@@ -339,12 +335,6 @@ public:
   void postParse();
   std::unique_ptr<llvm::lto::InputFile> obj;
   std::vector<bool> keptComdats;
-
-private:
-  StringRef saved_symbol(const char *S);
-  StringRef saved_symbol(StringRef S);
-  StringRef saved_symbol(const Twine &S);
-  StringRef saved_symbol(const std::string &S);
 };
 
 // .so file.

--- a/lld/include/lld/Common/CommonLinkerContext.h
+++ b/lld/include/lld/Common/CommonLinkerContext.h
@@ -55,10 +55,11 @@ template <typename T = CommonLinkerContext> T &context() {
 
 bool hasContext();
 
-inline llvm::StringSaver &saver() { return context().saver; }
 inline llvm::BumpPtrAllocator &bAlloc() { return context().bAlloc; }
-
+inline llvm::StringSaver &saver() { return context().saver; }
 inline llvm::UniqueStringSaver &unique_saver() {
+  // FIXME: Look into other places where duplications are common in saved
+  // strings and unique saver make sense.
   return context().unique_saver;
 }
 } // namespace lld

--- a/lld/include/lld/Common/CommonLinkerContext.h
+++ b/lld/include/lld/Common/CommonLinkerContext.h
@@ -38,6 +38,7 @@ public:
 
   llvm::BumpPtrAllocator bAlloc;
   llvm::StringSaver saver{bAlloc};
+  llvm::UniqueStringSaver unique_saver{bAlloc};
   llvm::DenseMap<void *, SpecificAllocBase *> instances;
 
   ErrorHandler e;
@@ -56,6 +57,10 @@ bool hasContext();
 
 inline llvm::StringSaver &saver() { return context().saver; }
 inline llvm::BumpPtrAllocator &bAlloc() { return context().bAlloc; }
+
+inline llvm::UniqueStringSaver &unique_saver() {
+  return context().unique_saver;
+}
 } // namespace lld
 
 #endif


### PR DESCRIPTION
 lld ELF [BitcodeFile](https://github.com/llvm/llvm-project/blob/a527248a3c2d638b0c92a06992f3f1c1f80842ad/lld/ELF/InputFiles.h#L328) uses [string saver](https://github.com/llvm/llvm-project/blob/a527248a3c2d638b0c92a06992f3f1c1f80842ad/lld/include/lld/Common/CommonLinkerContext.h#L57) to keep copies of bitcode symbols. Symbol duplication is very common when compiling application binaries.

This change proposes to introduce a UniqueStringSaver in lld context and use it for bitcode symbol parsing. The implementation covers ELF only. Similar opportunities should exist on other (COFF, MachO, wasm) formats.

For an internal production binary where lto indexing takes ~10GiB originally, this changes optimizes away ~800MiB (~7.8%), measured by https://github.com/google/pprof. Flame graph breaks down memory by usage call stacks and agrees with this measurement.