### PR TITLE
[HLSL] Implement TransformHLSLAttributedResourceType

### DIFF
--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -951,12 +951,18 @@ class HLSLAttributedResourceTypeLoc
                              HLSLAttributedResourceLocInfo> {
 public:
   TypeLoc getWrappedLoc() const { return getInnerTypeLoc(); }
+
+  TypeLoc getContainedLoc() const { 
+    return TypeLoc(getTypePtr()->getContainedType(), getNonLocalData());
+  }
+
   void setSourceRange(const SourceRange &R) { getLocalData()->Range = R; }
   SourceRange getLocalSourceRange() const { return getLocalData()->Range; }
   void initializeLocal(ASTContext &Context, SourceLocation loc) {
     setSourceRange(SourceRange());
   }
   QualType getInnerType() const { return getTypePtr()->getWrappedType(); }
+  unsigned getLocalDataSize() const { return sizeof(HLSLAttributedResourceLocInfo); }
 };
 
 struct ObjCObjectTypeLocInfo {

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -952,7 +952,7 @@ class HLSLAttributedResourceTypeLoc
 public:
   TypeLoc getWrappedLoc() const { return getInnerTypeLoc(); }
 
-  TypeLoc getContainedLoc() const { 
+  TypeLoc getContainedLoc() const {
     return TypeLoc(getTypePtr()->getContainedType(), getNonLocalData());
   }
 
@@ -962,7 +962,9 @@ public:
     setSourceRange(SourceRange());
   }
   QualType getInnerType() const { return getTypePtr()->getWrappedType(); }
-  unsigned getLocalDataSize() const { return sizeof(HLSLAttributedResourceLocInfo); }
+  unsigned getLocalDataSize() const {
+    return sizeof(HLSLAttributedResourceLocInfo);
+  }
 };
 
 struct ObjCObjectTypeLocInfo {

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7474,8 +7474,7 @@ QualType TreeTransform<Derived>::TransformHLSLAttributedResourceType(
     ContainedTy = getDerived().TransformType(TLB, TL.getContainedLoc());
 
   QualType Result = TL.getType();
-  if (getDerived().AlwaysRebuild() ||
-      WrappedTy != oldType->getWrappedType() || 
+  if (getDerived().AlwaysRebuild() || WrappedTy != oldType->getWrappedType() ||
       ContainedTy != oldType->getContainedType()) {
     Result = SemaRef.Context.getHLSLAttributedResourceType(
         WrappedTy, ContainedTy, oldType->getAttrs());

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7462,8 +7462,27 @@ QualType TreeTransform<Derived>::TransformBTFTagAttributedType(
 template <typename Derived>
 QualType TreeTransform<Derived>::TransformHLSLAttributedResourceType(
     TypeLocBuilder &TLB, HLSLAttributedResourceTypeLoc TL) {
-  llvm_unreachable(
-      "Unexpected TreeTransform for HLSLAttributedResourceTypeLoc");
+
+  const HLSLAttributedResourceType *oldType = TL.getTypePtr();
+
+  QualType WrappedTy = getDerived().TransformType(TLB, TL.getWrappedLoc());
+  if (WrappedTy.isNull())
+    return QualType();
+
+  QualType ContainedTy = QualType();
+  if (!oldType->getContainedType().isNull())
+    ContainedTy = getDerived().TransformType(TLB, TL.getContainedLoc());
+
+  QualType Result = TL.getType();
+  if (getDerived().AlwaysRebuild() ||
+      WrappedTy != oldType->getWrappedType() || 
+      ContainedTy != oldType->getContainedType()) {
+    Result = SemaRef.Context.getHLSLAttributedResourceType(
+        WrappedTy, ContainedTy, oldType->getAttrs());
+  }
+
+  TLB.push<HLSLAttributedResourceTypeLoc>(Result);
+  return Result;
 }
 
 template<typename Derived>


### PR DESCRIPTION
Implements `TreeTransform<Derived>::TransformHLSLAttributedResourceType` which will enable use of attributed resource types inside templates.

Follow up from llvm/llvm-project#106181

Related to llvm/llvm-project#104861