### PR TITLE
[Github] Set code formatting job timeout to 30 minutes

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   code_formatter:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources


### PR DESCRIPTION
This patch sets the timeout of the code formatting job to 30 minutes. The job is currently failing in specific circumstances and needs to be reworked, but as a temp hack, change the timeout to 30 minutes so that we can catch these jobs before they hit the Github Actions timeout limit of six hours.

Somewhat (hackily) alleviates #79661 slightly.