### PR TITLE
Add clang-tidy external examples

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -17,7 +17,7 @@ pull-request on `LLVM Github`_ to have it added here. Since the primary purpose 
 this page is to provide examples that can help developers, the listed projects should
 have code available.
 
-As :program:`clang-tidy` shares C++ AST Matchers with Clang diagnostics, 
+As :program:`clang-tidy` is using, for example, the AST Matchers and diagnostics of Clang,
 `External Clang Examples`_ may also be useful to look at for such examples.
 
 .. _LLVM Github: https://github.com/llvm/llvm-project

--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -7,7 +7,7 @@ Introduction
 
 This page provides examples of what people have done with :program:`clang-tidy` that 
 might serve as useful guides (or starting points) to develop your own checks. 
-They may be helpful for necessary things such as how to write CMakeLists.txt 
+They may be helpful for necessary things such as how to write the `CMakeLists.txt`` 
 for an out-of-tree plugin of :program:`clang-tidy` checks.
 
 If you know of (or wrote!) a tool or project using :program:`clang-tidy`, please share it 
@@ -29,4 +29,4 @@ List of projects and tools
 ==========================
 
 `<https://github.com/coveooss/clang-tidy-plugin-examples/tree/main>`_
-    "This folder contains clang-tidy plugins."
+    "This folder contains :program:`clang-tidy` plugins."

--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -23,10 +23,8 @@ As :program:`clang-tidy` shares C++ AST Matchers with Clang diagnostics,
 .. _LLVM Github: https://github.com/llvm/llvm-project
 .. _External Clang Examples: https://clang.llvm.org/docs/ExternalClangExamples.html
 
-https://clang.llvm.org/docs/ExternalClangExamples.html
-
 List of projects and tools
 ==========================
 
-`<https://github.com/coveooss/clang-tidy-plugin-examples/tree/main>`_
+`<https://github.com/coveooss/clang-tidy-plugin-examples>`_
     "This folder contains :program:`clang-tidy` plugins."

--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -1,24 +1,24 @@
-=======================
+============================
 External Clang-Tidy Examples
-=======================
+============================
 
 Introduction
 ============
 
-This page provides examples of what people have done with `clang-tidy` that 
+This page provides examples of what people have done with :program:`clang-tidy` that 
 might serve as useful guides (or starting points) to develop your own checks. 
 They may be helpful for necessary things such as how to write CMakeLists.txt 
-for an out-of-tree plugin of `clang-tidy` checks.
+for an out-of-tree plugin of :program:`clang-tidy` checks.
 
-If you know of (or wrote!) a tool or project using clang-tidy, please share it 
+If you know of (or wrote!) a tool or project using :program:`clang-tidy`, please share it 
 on `the Discourse forums (Clang Frontend category)
 <https://discourse.llvm.org/c/clang/6>`_ for wider visibility and open a 
 pull-request on `LLVM Github`_ to have it added here. Since the primary purpose of 
 this page is to provide examples that can help developers, the listed projects should
 have code available.
 
-As `clang-tidy` shares C++ AST Matchers with Clang diagnostics, `External Clang Examples`_ 
-may also be useful to look at for examples.
+As :program:`clang-tidy` shares C++ AST Matchers with Clang diagnostics, 
+`External Clang Examples`_ may also be useful to look at for such examples.
 
 .. _LLVM Github: https://github.com/llvm/llvm-project
 .. _External Clang Examples: https://clang.llvm.org/docs/ExternalClangExamples.html

--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -5,7 +5,7 @@ External Clang-Tidy Examples
 Introduction
 ============
 
-This page provides examples of what people have done with `clang-tidy`` that 
+This page provides examples of what people have done with `clang-tidy` that 
 might serve as useful guides (or starting points) to develop your own checks. 
 They may be helpful for necessary things such as how to write CMakeLists.txt 
 for an out-of-tree plugin of `clang-tidy` checks.
@@ -14,8 +14,8 @@ If you know of (or wrote!) a tool or project using clang-tidy, please share it
 on `the Discourse forums (Clang Frontend category)
 <https://discourse.llvm.org/c/clang/6>`_ for wider visibility and open a 
 pull-request on `LLVM Github`_ to have it added here. Since the primary purpose of 
-this page is to provide examples that can help developers, generally they must have 
-code available.
+this page is to provide examples that can help developers, the listed projects should
+have code available.
 
 As `clang-tidy` shares C++ AST Matchers with Clang diagnostics, `External Clang Examples`_ 
 may also be useful to look at for examples.

--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -5,21 +5,22 @@ External Clang-Tidy Examples
 Introduction
 ============
 
-This page provides examples of what people have done with clang-tidy that 
+This page provides examples of what people have done with `clang-tidy`` that 
 might serve as useful guides (or starting points) to develop your own checks. 
-They may be helpful even for necessary things such as how to write CMakeLists.txt 
-for an out-of-tree plugin of clang-tidy checks.
+They may be helpful for necessary things such as how to write CMakeLists.txt 
+for an out-of-tree plugin of `clang-tidy` checks.
 
-If you know of (or wrote!) a tool or project using clang-tidy, please post on
-`the Discourse forums (Clang Frontend category)
-<https://discourse.llvm.org/c/clang/6>`_ to have it added.
-(or if you are already a clang-tidy contributor, feel free to directly commit
-additions). Since the primary purpose of this page is to provide examples
-that can help developers, generally they must have code available.
+If you know of (or wrote!) a tool or project using clang-tidy, please share it 
+on `the Discourse forums (Clang Frontend category)
+<https://discourse.llvm.org/c/clang/6>`_ for wider visibility and open a 
+pull-request on `LLVM Github`_ to have it added here. Since the primary purpose of 
+this page is to provide examples that can help developers, generally they must have 
+code available.
 
-As clang-tidy shares C++ AST Matchers with Clang diagnostics, `External Clang Examples`_ 
-may also be useful to look at.
+As `clang-tidy` shares C++ AST Matchers with Clang diagnostics, `External Clang Examples`_ 
+may also be useful to look at for examples.
 
+.. _LLVM Github: https://github.com/llvm/llvm-project
 .. _External Clang Examples: https://clang.llvm.org/docs/ExternalClangExamples.html
 
 https://clang.llvm.org/docs/ExternalClangExamples.html

--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -7,7 +7,7 @@ Introduction
 
 This page provides examples of what people have done with :program:`clang-tidy` that 
 might serve as useful guides (or starting points) to develop your own checks. 
-They may be helpful for necessary things such as how to write the `CMakeLists.txt`` 
+They may be helpful for necessary things such as how to write the `CMakeLists.txt`
 for an out-of-tree plugin of :program:`clang-tidy` checks.
 
 If you know of (or wrote!) a tool or project using :program:`clang-tidy`, please share it 

--- a/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
+++ b/clang-tools-extra/docs/clang-tidy/ExternalClang-TidyExamples.rst
@@ -1,0 +1,31 @@
+=======================
+External Clang-Tidy Examples
+=======================
+
+Introduction
+============
+
+This page provides examples of what people have done with clang-tidy that 
+might serve as useful guides (or starting points) to develop your own checks. 
+They may be helpful even for necessary things such as how to write CMakeLists.txt 
+for an out-of-tree plugin of clang-tidy checks.
+
+If you know of (or wrote!) a tool or project using clang-tidy, please post on
+`the Discourse forums (Clang Frontend category)
+<https://discourse.llvm.org/c/clang/6>`_ to have it added.
+(or if you are already a clang-tidy contributor, feel free to directly commit
+additions). Since the primary purpose of this page is to provide examples
+that can help developers, generally they must have code available.
+
+As clang-tidy shares C++ AST Matchers with Clang diagnostics, `External Clang Examples`_ 
+may also be useful to look at.
+
+.. _External Clang Examples: https://clang.llvm.org/docs/ExternalClangExamples.html
+
+https://clang.llvm.org/docs/ExternalClangExamples.html
+
+List of projects and tools
+==========================
+
+`<https://github.com/coveooss/clang-tidy-plugin-examples/tree/main>`_
+    "This folder contains clang-tidy plugins."

--- a/clang-tools-extra/docs/clang-tidy/index.rst
+++ b/clang-tools-extra/docs/clang-tidy/index.rst
@@ -12,6 +12,7 @@ See also:
    The list of clang-tidy checks <checks/list>
    Clang-tidy IDE/Editor Integrations <Integrations>
    Getting Involved <Contributing>
+   External Clang-Tidy Examples <ExternalClang-TidyExamples>
 
 :program:`clang-tidy` is a clang-based C++ "linter" tool. Its purpose is to
 provide an extensible framework for diagnosing and fixing typical programming


### PR DESCRIPTION
Motivation: Clang has a page where they list out external examples: https://clang.llvm.org/docs/ExternalClangExamples.html. While I was writing an out-of-tree clang-tidy plugin, I wanted such a page to exist also as it would have helped development. The example repo listed in the proposed page has been useful for me.