### PR TITLE
[compiler-rt][test] Added `env` command to fix NSAN_OPTIONS command not found error

### DIFF
--- a/compiler-rt/test/nsan/vec_sqrt.cpp
+++ b/compiler-rt/test/nsan/vec_sqrt.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx_nsan -O0 -g -mavx %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
 // RUN: %clangxx_nsan -O3 -g -mavx %s -o %t
-// RUN: NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
+// RUN: env NSAN_OPTIONS=check_nan=true,halt_on_error=0 %run %t 2>&1 | FileCheck %s
 
 #include <cmath>
 #include <immintrin.h>


### PR DESCRIPTION
Resolved the issue where `'NSAN_OPTIONS=check_nan=true,halt_on_error=0'` was not recognized as a command. Changed the test command to set the environment variable correctly using `env`. 
fixes: #106598