### PR TITLE
fix kcfi doesn't take effect when callee function has no input parameter

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2813,6 +2813,11 @@ void CodeGenFunction::EmitKCFIOperandBundle(
       Callee.getAbstractInfo().getCalleeFunctionProtoType();
   if (FP)
     Bundles.emplace_back("kcfi", CGM.CreateKCFITypeId(FP->desugar()));
+  else {
+    ASTContext &context = this->getContext();
+    QualType voidType = context.VoidTy;
+    Bundles.emplace_back("kcfi", CGM.CreateKCFITypeId(voidType));
+  }
 }
 
 llvm::Value *CodeGenFunction::FormAArch64ResolverCondition(


### PR DESCRIPTION
fix #106344