### PR TITLE
[RISCV][NFC] Reimplementation of target attribute override mechanism

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -255,7 +255,6 @@ bool RISCVTargetInfo::initFeatureMap(
     Features["32bit"] = true;
   }
 
-  // Otherwise, parse the features and add any implied extensions.
   std::vector<std::string> AllFeatures = FeaturesVec;
   auto ParseResult = llvm::RISCVISAInfo::parseFeatures(XLen, FeaturesVec);
   if (!ParseResult) {

--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -255,24 +255,6 @@ bool RISCVTargetInfo::initFeatureMap(
     Features["32bit"] = true;
   }
 
-  // If a target attribute specified a full arch string, override all the ISA
-  // extension target features.
-  const auto I = llvm::find(FeaturesVec, "__RISCV_TargetAttrNeedOverride");
-  if (I != FeaturesVec.end()) {
-    std::vector<std::string> OverrideFeatures(std::next(I), FeaturesVec.end());
-
-    // Add back any non ISA extension features, e.g. +relax.
-    auto IsNonISAExtFeature = [](StringRef Feature) {
-      assert(Feature.size() > 1 && (Feature[0] == '+' || Feature[0] == '-'));
-      StringRef Ext = Feature.substr(1); // drop the +/-
-      return !llvm::RISCVISAInfo::isSupportedExtensionFeature(Ext);
-    };
-    llvm::copy_if(llvm::make_range(FeaturesVec.begin(), I),
-                  std::back_inserter(OverrideFeatures), IsNonISAExtFeature);
-
-    return TargetInfo::initFeatureMap(Features, Diags, CPU, OverrideFeatures);
-  }
-
   // Otherwise, parse the features and add any implied extensions.
   std::vector<std::string> AllFeatures = FeaturesVec;
   auto ParseResult = llvm::RISCVISAInfo::parseFeatures(XLen, FeaturesVec);
@@ -389,9 +371,20 @@ void RISCVTargetInfo::fillValidTuneCPUList(
   llvm::RISCV::fillValidTuneCPUArchList(Values, Is64Bit);
 }
 
+static void populateNegativeRISCVFeatures(std::vector<std::string> &Features) {
+  auto RII = llvm::RISCVISAInfo::parseArchString(
+      "rv64i", /* EnableExperimentalExtension */ true);
+
+  if (llvm::errorToBool(RII.takeError()))
+    llvm_unreachable("unsupport rv64i");
+
+  std::vector<std::string> FeatStrings =
+      (*RII)->toFeatures(/* AddAllExtensions */ true);
+  Features.insert(Features.end(), FeatStrings.begin(), FeatStrings.end());
+}
+
 static void handleFullArchString(StringRef FullArchStr,
                                  std::vector<std::string> &Features) {
-  Features.push_back("__RISCV_TargetAttrNeedOverride");
   auto RII = llvm::RISCVISAInfo::parseArchString(
       FullArchStr, /* EnableExperimentalExtension */ true);
   if (llvm::errorToBool(RII.takeError())) {
@@ -400,6 +393,7 @@ static void handleFullArchString(StringRef FullArchStr,
   } else {
     // Append a full list of features, including any negative extensions so that
     // we override the CPU's features.
+    populateNegativeRISCVFeatures(Features);
     std::vector<std::string> FeatStrings =
         (*RII)->toFeatures(/* AddAllExtensions */ true);
     Features.insert(Features.end(), FeatStrings.begin(), FeatStrings.end());


### PR DESCRIPTION
This patch aims to replace the target attribute override mechanism based on `__RISCV_TargetAttrNeedOverride` with the insertion of several negative target features

When the target attribute uses the full architecture string ("arch=rv64gc") or specifies the CPU ("cpu=rocket-rv64") as the version, it will override the module-level target feature. Currently, this mechanism is implemented by inserting `__RISCV_TargetAttrNeedOverride` as a dummy target feature immediately before the target attribute's feature.

```
module target features + __RISCV_TargetAttrNeedOverride + target attribute's feature
```

The RISCVTargetInfo::initFeatureMap function will remove the "module target features" and use only the "target attribute's features".

This patch changes the process as follows:

```
module target features + negative target feature for all supported extension + target attribute's feature
```

The `module target features` will be disable by `negative target feature for all supported extension` in `TargetInfo::initFeatureMap`