### PR TITLE
[Flang][Lower] Handle mangling of a generic name with a homonym specific procedure

### DIFF
--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -165,6 +165,16 @@ std::string Fortran::lower::mangle::mangleName(
             return mangleName(procBinding.symbol(), scopeBlockIdMap,
                               keepExternalInScope, underscoring);
           },
+          [&](const Fortran::semantics::GenericDetails &generic)
+              -> std::string {
+            if (generic.specific())
+              return mangleName(*generic.specific(), scopeBlockIdMap,
+                                keepExternalInScope, underscoring);
+            else
+              llvm::report_fatal_error(
+                  "attempt to mangle a generic name but "
+                  "it has no specific procedure of the same name");
+          },
           [&](const Fortran::semantics::DerivedTypeDetails &) -> std::string {
             // Derived type mangling must use mangleName(DerivedTypeSpec) so
             // that kind type parameter values can be mangled.

--- a/flang/test/Lower/module-generic-with-specific-mangling.f90
+++ b/flang/test/Lower/module-generic-with-specific-mangling.f90
@@ -1,0 +1,60 @@
+! RUN: split-file %s %t
+! RUN: bbc -emit-fir %t/mangling_mod_a.f90 -o - | FileCheck %s --check-prefix=FIR
+! RUN: bbc -emit-fir %t/mangling_mod_b.f90 -o - | FileCheck %s --check-prefix=MANGLE
+! RUN: bbc -emit-fir %t/mangling_mod_c.f90 -o - | FileCheck %s --check-prefix=MANGLE
+! RUN: bbc -emit-fir %t/mangling_mod_d.f90 -o - | FileCheck %s --check-prefix=MANGLE
+
+! FIR: module
+! MANGLE: func.func private @_QPmy_sub(!fir.ref<i32>)
+
+!--- mangling_mod_a.f90
+module mangling_mod_a
+  interface
+    subroutine my_sub(a)
+      integer :: a
+    end subroutine my_sub
+  end interface
+
+  ! Generic interface
+  interface my_sub
+      procedure :: my_sub
+  end interface
+  contains
+end module mangling_mod_a
+
+!--- mangling_mod_b.f90
+module mangling_mod_b
+  use mangling_mod_a
+
+  contains
+    subroutine my_sub2(a)
+      integer :: a
+      call my_sub(a)
+    end subroutine my_sub2
+
+end module mangling_mod_b
+
+!--- mangling_mod_c.f90
+module mangling_mod_c
+  use mangling_mod_b
+
+  contains
+    subroutine my_sub3(a)
+      integer :: a
+
+      call my_sub(a)
+    end subroutine my_sub3
+end module mangling_mod_c
+
+!--- mangling_mod_d.f90
+module mangling_mod_d
+  use mangling_mod_b
+  use mangling_mod_c
+
+  contains
+    subroutine my_sub4(a)
+      integer :: a
+
+      call my_sub(a)
+    end subroutine my_sub4
+end module mangling_mod_d


### PR DESCRIPTION
This may happen when using modules.

Fixes #93707