### PR TITLE
[Github] Cancel previous in-progress code formatting jobs

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -13,6 +13,9 @@ jobs:
   code_formatter:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources


### PR DESCRIPTION
If the user pushes multiple times in relatively rapid succession, we might end up with multiple code formatting jobs in flight at the same time for different revisions of the same PR. It makes no sense to keep jobs running on outdated versions of the PR.

Additionally, if my hypothesis proves correct, this might end up fixing