### PR TITLE
[libcxx][test] Add macro for when long double is just double

### DIFF
--- a/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
+++ b/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
@@ -8,21 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// The following platforms have sizeof(long double) == sizeof(double), so this test doesn't apply to them.
-// This test does apply to aarch64 where Arm's AAPCS64 is followed. There they are different sizes.
-// XFAIL: target={{arm64|arm64e|armv(7|8)(l|m)?|powerpc|powerpc64}}-{{.+}}
-
-// MSVC configurations have long double equal to regular double on all
-// architectures.
-// XFAIL: target={{.+}}-pc-windows-msvc
-
-// ARM/AArch64 MinGW also has got long double equal to regular double, just
-// like MSVC (thus match both MinGW and MSVC here, for those architectures).
-// XFAIL: target={{aarch64|armv7}}-{{.*}}-windows-{{.+}}
-
-// Android's 32-bit x86 target has long double equal to regular double.
-// XFAIL: target=i686-{{.+}}-android{{.*}}
-
 // <compare>
 
 // template<class T> constexpr strong_ordering strong_order(const T& a, const T& b);
@@ -37,5 +22,9 @@
 
 void f() {
     long double ld = 3.14;
+#ifdef TEST_LONG_DOUBLE_IS_DOUBLE
+    (void)ld; // expected-no-diagnostics
+#else
     (void)std::strong_order(ld, ld);  // expected-error@*:* {{std::strong_order is unimplemented for this floating-point type}}
+#endif
 }

--- a/libcxx/test/std/numerics/bit/bit.cast/bit_cast.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bit.cast/bit_cast.pass.cpp
@@ -229,7 +229,7 @@ bool tests() {
         test_roundtrip_through_nested_T<false>(i);
         test_roundtrip_through_buffer<false>(i);
 
-#if __SIZEOF_LONG_DOUBLE__ == __SIZEOF_DOUBLE__
+#ifdef TEST_LONG_DOUBLE_IS_DOUBLE
         test_roundtrip_through<double, false>(i);
 #endif
 #if defined(__SIZEOF_INT128__) && __SIZEOF_LONG_DOUBLE__ == __SIZEOF_INT128__ &&                                       \

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -511,4 +511,8 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 #  define TEST_CONSTEXPR_OPERATOR_NEW
 #endif
 
+#if __SIZEOF_LONG_DOUBLE__ == __SIZEOF_DOUBLE__
+#  define TEST_LONG_DOUBLE_IS_DOUBLE
+#endif
+
 #endif // SUPPORT_TEST_MACROS_HPP


### PR DESCRIPTION
This removes the need for the long list of platforms in strong_order_long_double_verify.