### PR TITLE
[cmake] Add symbolic links for MSVC libraries

### DIFF
--- a/llvm/cmake/platforms/WinMsvc.cmake
+++ b/llvm/cmake/platforms/WinMsvc.cmake
@@ -95,6 +95,7 @@ list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
   LLVM_WINSYSROOT
   MSVC_VER
   WINSDK_VER
+  msvc_lib_symlinks_dir
   winsdk_lib_symlinks_dir
   winsdk_vfs_overlay_path
   )
@@ -152,6 +153,24 @@ function(generate_winsdk_lib_symlinks winsdk_um_lib_dir output_dir)
                               -E create_symlink
                               "${winsdk_um_lib_dir}/${library}"
                               "${output_dir}/${lowercase_ext_symlink_name}")
+    endif()
+  endforeach()
+endfunction()
+
+function(generate_msvc_lib_symlinks msvc_lib_dir output_dir)
+  execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${output_dir}")
+  file(GLOB libraries RELATIVE "${msvc_lib_dir}" "${msvc_lib_dir}/*.lib")
+  foreach(library ${libraries})
+    get_filename_component(name_wle "${library}" NAME_WLE)
+    get_filename_component(ext "${library}" LAST_EXT)
+    string(TOLOWER "${ext}" lowercase_ext)
+    string(TOUPPER "${name_wle}" all_uppercase_symlink_name_wle)
+    set(uppercase_symlink_name "${all_uppercase_symlink_name_wle}${lowercase_ext}")
+    if(NOT library STREQUAL uppercase_symlink_name)
+      execute_process(COMMAND "${CMAKE_COMMAND}"
+                              -E create_symlink
+                              "${msvc_lib_dir}/${library}"
+                              "${output_dir}/${uppercase_symlink_name}")
     endif()
   endforeach()
 endfunction()
@@ -297,6 +316,12 @@ if(case_sensitive_filesystem)
   endif()
   list(APPEND LINK_FLAGS
        -libpath:"${winsdk_lib_symlinks_dir}")
+  if(NOT msvc_lib_symlinks_dir)
+    set(msvc_lib_symlinks_dir "${CMAKE_BINARY_DIR}/msvc_lib_symlinks")
+    generate_msvc_lib_symlinks("${MSVC_LIB}/${WINSDK_ARCH}" "${msvc_lib_symlinks_dir}")
+  endif()
+  list(APPEND LINK_FLAGS
+       -libpath:"${msvc_lib_symlinks_dir}")
 endif()
 
 string(REPLACE ";" " " LINK_FLAGS "${LINK_FLAGS}")


### PR DESCRIPTION
When cross-compiling a Windows clang with `-DLLVM_BUILD_INSTRUMENTED`, the profiling compiler-rt is linked to binaries, as one would expect, but the profiling compiler-rt contains objects with `/DEFAULTLIB:LIBCMT` and `/DEFAULTLIB:OLDNAMES` directives, which makes the build expect `LIBCMT.lib` and `OLDNAMES.lib`, but they are nowhere to be found because they are in lowercase. While the WinMsvc.cmake helper recreates symbolic links to work around such case sensitivity issues for the Windows SDK libs, it doesn't do so for the MSVC libs, which we add here.