### PR TITLE
[libc++] Guard ..._REMOVED_UNCAUGHT_EXCEPTION behind ifndef

### DIFF
--- a/libcxx/src/exception.cpp
+++ b/libcxx/src/exception.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #ifndef _LIBCPP_ENABLE_CXX20_REMOVED_UNCAUGHT_EXCEPTION
-#define _LIBCPP_ENABLE_CXX20_REMOVED_UNCAUGHT_EXCEPTION
+#  define _LIBCPP_ENABLE_CXX20_REMOVED_UNCAUGHT_EXCEPTION
 #endif
 #define _LIBCPP_DISABLE_DEPRECATION_WARNINGS
 

--- a/libcxx/src/exception.cpp
+++ b/libcxx/src/exception.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef _LIBCPP_ENABLE_CXX20_REMOVED_UNCAUGHT_EXCEPTION
 #define _LIBCPP_ENABLE_CXX20_REMOVED_UNCAUGHT_EXCEPTION
+#endif
 #define _LIBCPP_DISABLE_DEPRECATION_WARNINGS
 
 #include <exception>


### PR DESCRIPTION
Resolves "macro redefined" error when _LIBCPP_ENABLE_CXX20_REMOVED_UNCAUGHT_EXCEPTION is also set on command line by a build system.