### PR TITLE
[flang][runtime] long double isn't always f80

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -341,7 +341,18 @@ constexpr TypeBuilderFunc getModel<const double *>() {
 template <>
 constexpr TypeBuilderFunc getModel<long double>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::FloatType::getF80(context);
+    // See TODO at the top of the file. This is configuring for the host system
+    // - it might be incorrect when cross-compiling!
+    constexpr size_t size = sizeof(long double);
+    static_assert(size == 16 || size == 10 || size == 8,
+                  "unsupported long double size");
+    if constexpr (size == 16)
+      return mlir::FloatType::getF128(context);
+    if constexpr (size == 10)
+      return mlir::FloatType::getF80(context);
+    if constexpr (size == 8)
+      return mlir::FloatType::getF64(context);
+    llvm_unreachable("failed static assert");
   };
 }
 template <>


### PR DESCRIPTION
f80 is only a thing on x86, and even then the size of long double can be changed with compiler flags. Instead set the size according to the host system (this is what is already done for integer types).

---

I spotted this while reading some code and thought it looked like a bug. Please let me know if I misunderstood.