### PR TITLE
[DL] Invert `getTypeStoreSize` bytes-bits relationship to avoid `divideCeil` (NFC)

### DIFF
--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -421,8 +421,9 @@ public:
   ///
   /// For example, returns 5 for i36 and 10 for x86_fp80.
   TypeSize getTypeStoreSize(Type *Ty) const {
-    TypeSize BaseSize = getTypeSizeInBits(Ty);
-    return {divideCeil(BaseSize.getKnownMinValue(), 8), BaseSize.isScalable()};
+    TypeSize StoreSizeInBits = getTypeStoreSizeInBits(Ty);
+    return {StoreSizeInBits.getKnownMinValue() / 8,
+            StoreSizeInBits.isScalable()};
   }
 
   /// Returns the maximum number of bits that may be overwritten by
@@ -433,7 +434,10 @@ public:
   ///
   /// For example, returns 40 for i36 and 80 for x86_fp80.
   TypeSize getTypeStoreSizeInBits(Type *Ty) const {
-    return 8 * getTypeStoreSize(Ty);
+    TypeSize BaseSize = getTypeSizeInBits(Ty);
+    uint64_t AlignedSizeInBits =
+        alignToPowerOf2(BaseSize.getKnownMinValue(), 8);
+    return {AlignedSizeInBits, BaseSize.isScalable()};
   }
 
   /// Returns true if no extra padding bits are needed when storing the


### PR DESCRIPTION
Change how `getTypeStoreSize` and `getTypeStoreSizeInBits` interact by first aligning the bit size to the nearest power of 2 boundary and then applying plain division to derive the byte size. This simplifies the calculation by avoiding possible overflow concerns in the first place.