### PR TITLE
[LLDB][Minidump] Extend the minidump x86_64 registers to include fs_base and gs_base

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -473,7 +473,8 @@ GetThreadContext_x86_64(RegisterContext *reg_ctx) {
       lldb_private::minidump::MinidumpContext_x86_64_Flags::x86_64_Flag |
       lldb_private::minidump::MinidumpContext_x86_64_Flags::Control |
       lldb_private::minidump::MinidumpContext_x86_64_Flags::Segments |
-      lldb_private::minidump::MinidumpContext_x86_64_Flags::Integer);
+      lldb_private::minidump::MinidumpContext_x86_64_Flags::Integer |
+      lldb_private::minidump::MinidumpContext_x86_64_Flags::LLDBSpecific);
   thread_context.rax = read_register_u64(reg_ctx, "rax");
   thread_context.rbx = read_register_u64(reg_ctx, "rbx");
   thread_context.rcx = read_register_u64(reg_ctx, "rcx");
@@ -499,6 +500,8 @@ GetThreadContext_x86_64(RegisterContext *reg_ctx) {
   thread_context.gs = read_register_u64(reg_ctx, "gs");
   thread_context.ss = read_register_u64(reg_ctx, "ss");
   thread_context.ds = read_register_u64(reg_ctx, "ds");
+  thread_context.fs_base = read_register_u64(reg_ctx, "fs_base");
+  thread_context.gs_base = read_register_u64(reg_ctx, "gs_base");
   return thread_context;
 }
 

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86_64.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86_64.cpp
@@ -21,7 +21,7 @@ RegisterContextCorePOSIX_x86_64::RegisterContextCorePOSIX_x86_64(
 
   size = GetGPRSize();
   m_gpregset.reset(new uint8_t[size]);
-  len = 
+  len =
       gpregset.ExtractBytes(0, size, lldb::eByteOrderLittle, m_gpregset.get());
   if (len != size)
     m_gpregset.reset();

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86_64.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86_64.cpp
@@ -21,7 +21,7 @@ RegisterContextCorePOSIX_x86_64::RegisterContextCorePOSIX_x86_64(
 
   size = GetGPRSize();
   m_gpregset.reset(new uint8_t[size]);
-  len =
+  len = 
       gpregset.ExtractBytes(0, size, lldb::eByteOrderLittle, m_gpregset.get());
   if (len != size)
     m_gpregset.reset();

--- a/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
+++ b/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
@@ -67,6 +67,7 @@ lldb::DataBufferSP lldb_private::minidump::ConvertMinidumpContext_x86_64(
   auto ControlFlag = MinidumpContext_x86_64_Flags::Control;
   auto IntegerFlag = MinidumpContext_x86_64_Flags::Integer;
   auto SegmentsFlag = MinidumpContext_x86_64_Flags::Segments;
+  auto LLDBSpecificFlag = MinidumpContext_x86_64_Flags::LLDBSpecific;
 
   if ((context_flags & x86_64_Flag) != x86_64_Flag)
     return nullptr;
@@ -102,6 +103,12 @@ lldb::DataBufferSP lldb_private::minidump::ConvertMinidumpContext_x86_64(
     writeRegister(&context->r13, result_base, reg_info[lldb_r13_x86_64]);
     writeRegister(&context->r14, result_base, reg_info[lldb_r14_x86_64]);
     writeRegister(&context->r15, result_base, reg_info[lldb_r15_x86_64]);
+  }
+
+  if ((context_flags & LLDBSpecificFlag) == LLDBSpecificFlag) {
+    writeRegister(&context->fs_base, result_base, reg_info[x86_64_with_base::lldb_fs_base]);
+    writeRegister(&context->gs_base, result_base,
+                  reg_info[x86_64_with_base::lldb_gs_base]);
   }
 
   // TODO parse the floating point registers

--- a/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
+++ b/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
@@ -106,7 +106,8 @@ lldb::DataBufferSP lldb_private::minidump::ConvertMinidumpContext_x86_64(
   }
 
   if ((context_flags & LLDBSpecificFlag) == LLDBSpecificFlag) {
-    writeRegister(&context->fs_base, result_base, reg_info[x86_64_with_base::lldb_fs_base]);
+    writeRegister(&context->fs_base, result_base,
+                  reg_info[x86_64_with_base::lldb_fs_base]);
     writeRegister(&context->gs_base, result_base,
                   reg_info[x86_64_with_base::lldb_gs_base]);
   }

--- a/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.h
+++ b/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.h
@@ -154,7 +154,8 @@ struct MinidumpContext_x86_64 {
   llvm::support::ulittle64_t last_exception_to_rip;
   llvm::support::ulittle64_t last_exception_from_rip;
 
-  // These registers are LLDB specific.
+  // LLDB can save core files and save extra information that isn't available from
+  // Google breakpad, or similar, minidump files. 
   llvm::support::ulittle64_t fs_base;
   llvm::support::ulittle64_t gs_base;
 };

--- a/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.h
+++ b/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.h
@@ -153,6 +153,10 @@ struct MinidumpContext_x86_64 {
   llvm::support::ulittle64_t last_branch_from_rip;
   llvm::support::ulittle64_t last_exception_to_rip;
   llvm::support::ulittle64_t last_exception_from_rip;
+
+  // These registers are LLDB specific.
+  llvm::support::ulittle64_t fs_base;
+  llvm::support::ulittle64_t gs_base;
 };
 
 // For context_flags. These values indicate the type of
@@ -168,9 +172,10 @@ enum class MinidumpContext_x86_64_Flags : uint32_t {
   FloatingPoint = x86_64_Flag | 0x00000008,
   DebugRegisters = x86_64_Flag | 0x00000010,
   XState = x86_64_Flag | 0x00000040,
+  LLDBSpecific = x86_64_Flag | 0x80000000,
 
   Full = Control | Integer | FloatingPoint,
-  All = Full | Segments | DebugRegisters,
+  All = Full | Segments | DebugRegisters | LLDBSpecific,
 
   LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ All)
 };

--- a/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.h
+++ b/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.h
@@ -154,8 +154,8 @@ struct MinidumpContext_x86_64 {
   llvm::support::ulittle64_t last_exception_to_rip;
   llvm::support::ulittle64_t last_exception_from_rip;
 
-  // LLDB can save core files and save extra information that isn't available from
-  // Google breakpad, or similar, minidump files. 
+  // LLDB can save core files and save extra information that isn't available
+  // from Google breakpad, or similar, minidump files.
   llvm::support::ulittle64_t fs_base;
   llvm::support::ulittle64_t gs_base;
 };

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -72,7 +72,12 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
             for reg in explicit_registers:
                 register = frame_register_list.GetFirstValueByName(reg)
                 self.assertNotEqual(None, register)
-                self.assertEqual(register.GetValueAsUnsigned(), stacks_to_registers_map[thread_id].GetFirstValueByName("fs_base").GetValueAsUnsigned())
+                self.assertEqual(
+                    register.GetValueAsUnsigned(),
+                    stacks_to_registers_map[thread_id]
+                    .GetFirstValueByName("fs_base")
+                    .GetValueAsUnsigned(),
+                )
 
             for x in register_val_list:
                 self.assertEqual(

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -67,6 +67,13 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
             self.assertIn(thread_id, stacks_to_registers_map)
             register_val_list = stacks_to_registers_map[thread_id]
             frame_register_list = frame.GetRegisters()
+            # explicitly verify we collected fs and gs base for x86_64
+            explicit_registers = ["fs_base", "gs_base"]
+            for reg in explicit_registers:
+                register = frame_register_list.GetFirstValueByName(reg)
+                self.assertNotEqual(None, register)
+                self.assertEqual(register.GetValueAsUnsigned(), stacks_to_registers_map[thread_id].GetFirstValueByName("fs_base").GetValueAsUnsigned())
+
             for x in register_val_list:
                 self.assertEqual(
                     x.GetValueAsUnsigned(),


### PR DESCRIPTION
A follow up to #106473 Minidump wasn't collecting fs or gs_base. This patch extends the x86_64 register context and gated reading it behind an lldb specific flag. Additionally these registers are explicitly checked in the tests.