### PR TITLE
[lldb] Include checksum in source cache dump

### DIFF
--- a/lldb/include/lldb/Core/SourceManager.h
+++ b/lldb/include/lldb/Core/SourceManager.h
@@ -43,7 +43,6 @@ public:
 
     bool ModificationTimeIsStale() const;
     bool PathRemappingIsStale() const;
-    bool ChecksumIsStale() const;
 
     size_t DisplaySourceLines(uint32_t line, std::optional<size_t> column,
                               uint32_t context_before, uint32_t context_after,
@@ -75,8 +74,6 @@ public:
 
     const Checksum &GetChecksum() const { return m_checksum; }
 
-    llvm::once_flag &GetChecksumOnceFlag() { return m_checksum_once_flag; }
-
   protected:
     /// Set file and update modification time.
     void SetSupportFile(lldb::SupportFileSP support_file_sp);
@@ -89,9 +86,6 @@ public:
 
     /// Keep track of the on-disk checksum.
     Checksum m_checksum;
-
-    /// Only warn once of checksum mismatch.
-    llvm::once_flag m_checksum_once_flag;
 
     // Keep the modification time that this file data is valid for
     llvm::sys::TimePoint<> m_mod_time;

--- a/lldb/include/lldb/Core/SourceManager.h
+++ b/lldb/include/lldb/Core/SourceManager.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_CORE_SOURCEMANAGER_H
 #define LLDB_CORE_SOURCEMANAGER_H
 
+#include "lldb/Utility/Checksum.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-forward.h"
@@ -42,6 +43,7 @@ public:
 
     bool ModificationTimeIsStale() const;
     bool PathRemappingIsStale() const;
+    bool ChecksumIsStale() const;
 
     size_t DisplaySourceLines(uint32_t line, std::optional<size_t> column,
                               uint32_t context_before, uint32_t context_after,
@@ -71,6 +73,10 @@ public:
 
     llvm::sys::TimePoint<> GetTimestamp() const { return m_mod_time; }
 
+    const Checksum &GetChecksum() const { return m_checksum; }
+
+    llvm::once_flag &GetChecksumOnceFlag() { return m_checksum_once_flag; }
+
   protected:
     /// Set file and update modification time.
     void SetSupportFile(lldb::SupportFileSP support_file_sp);
@@ -80,6 +86,12 @@ public:
     /// The support file. If the target has source mappings, this might be
     /// different from the original support file passed to the constructor.
     lldb::SupportFileSP m_support_file_sp;
+
+    /// Keep track of the on-disk checksum.
+    Checksum m_checksum;
+
+    /// Only warn once of checksum mismatch.
+    llvm::once_flag m_checksum_once_flag;
 
     // Keep the modification time that this file data is valid for
     llvm::sys::TimePoint<> m_mod_time;


### PR DESCRIPTION
This patch updates the source cache dump command to print both the actual (on-disk) checksum and the expected (line table) checksum. To achieve that we now read and store the on-disk checksum in the cached object. The same information will be used in a future path to print a warning when the checksums differ.