### PR TITLE
[CMake][Support] Use /nologo when compiling BLAKE3 assembly sources on Windows

### DIFF
--- a/llvm/lib/Support/BLAKE3/CMakeLists.txt
+++ b/llvm/lib/Support/BLAKE3/CMakeLists.txt
@@ -38,7 +38,7 @@ if (CAN_USE_ASSEMBLER)
       # Supress the copyright message and 'Assembling...' message.
       foreach(LLVM_BLAKE3_ASM_FILE ${LLVM_BLAKE3_ASM_FILES})
         set_source_files_properties(${LLVM_BLAKE3_ASM_FILE}
-          PROPERTIES COMPILE_OPTIONS "/quiet;/nologo")
+          PROPERTIES COMPILE_OPTIONS "/nologo")
       endforeach()
     else()
       disable_blake3_x86_simd()

--- a/llvm/lib/Support/BLAKE3/CMakeLists.txt
+++ b/llvm/lib/Support/BLAKE3/CMakeLists.txt
@@ -35,11 +35,9 @@ if (CAN_USE_ASSEMBLER)
         blake3_avx512_x86-64_windows_msvc.asm
       )
       list(APPEND LLVM_BLAKE3_FILES ${LLVM_BLAKE3_ASM_FILES})
-      # Supress the copyright message and 'Assembling...' message.
-      foreach(LLVM_BLAKE3_ASM_FILE ${LLVM_BLAKE3_ASM_FILES})
-        set_source_files_properties(${LLVM_BLAKE3_ASM_FILE}
-          PROPERTIES COMPILE_OPTIONS "/nologo")
-      endforeach()
+      # Supress the copyright message.
+      set_source_files_properties(${LLVM_BLAKE3_ASM_FILES}
+        PROPERTIES COMPILE_OPTIONS "/nologo")
     else()
       disable_blake3_x86_simd()
     endif()

--- a/llvm/lib/Support/BLAKE3/CMakeLists.txt
+++ b/llvm/lib/Support/BLAKE3/CMakeLists.txt
@@ -28,12 +28,18 @@ if (CAN_USE_ASSEMBLER)
     check_symbol_exists(_M_X64 "" IS_X64)
     if (IS_X64)
       enable_language(ASM_MASM)
-      list(APPEND LLVM_BLAKE3_FILES
+      set(LLVM_BLAKE3_ASM_FILES
         blake3_sse2_x86-64_windows_msvc.asm
         blake3_sse41_x86-64_windows_msvc.asm
         blake3_avx2_x86-64_windows_msvc.asm
         blake3_avx512_x86-64_windows_msvc.asm
       )
+      list(APPEND LLVM_BLAKE3_FILES ${LLVM_BLAKE3_ASM_FILES})
+      # Supress the copyright message and 'Assembling...' message.
+      foreach(LLVM_BLAKE3_ASM_FILE ${LLVM_BLAKE3_ASM_FILES})
+        set_source_files_properties(${LLVM_BLAKE3_ASM_FILE}
+          PROPERTIES COMPILE_OPTIONS "/quiet;/nologo")
+      endforeach()
     else()
       disable_blake3_x86_simd()
     endif()


### PR DESCRIPTION
Suppresses the copyright banner for `ml64` compiling BLAKE3 assembly sources with MSVC and Ninja on Windows:

```
[157/3758] Building ASM_MASM object lib\Support\BLAKE3\CMa...upportBlake3.dir\blake3_avx512_x86-64_windows_msvc.asm.obj
Microsoft (R) Macro Assembler (x64) Version 14.41.34120.0
Copyright (C) Microsoft Corporation.  All rights reserved.

 Assembling: C:\path\to\llvm-project\llvm\lib\Support\BLAKE3\blake3_avx512_x86-64_windows_msvc.asm
```

is now just:

```
 Assembling: C:\path\to\llvm-project\llvm\lib\Support\BLAKE3\blake3_avx512_x86-64_windows_msvc.asm
```

We can suppress that last line with `/quiet` in more recent versions of `ml64` (from MSVC 2022 17.6) but it is not supported by all potential MASM compilers.