### PR TITLE
[libc++][modules] Include __type_traits/invoke.h from __type_traits/result_of.h

### DIFF
--- a/libcxx/include/__type_traits/result_of.h
+++ b/libcxx/include/__type_traits/result_of.h
@@ -10,7 +10,7 @@
 #define _LIBCPP___TYPE_TRAITS_RESULT_OF_H
 
 #include <__config>
-#include <__functional/invoke.h>
+#include <__type_traits/invoke.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header


### PR DESCRIPTION
The result_of trait requires the __invoke_of implementation detail, but that is defined under __type_traits, not under __functional. Include the right header directly to remove a dependency from __type_traits to __functional.