### PR TITLE
[libc++][modules] Use inline variable instead of true_type

### DIFF
--- a/libcxx/include/__fwd/array.h
+++ b/libcxx/include/__fwd/array.h
@@ -35,11 +35,11 @@ template <size_t _Ip, class _Tp, size_t _Size>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&& get(const array<_Tp, _Size>&&) _NOEXCEPT;
 #endif
 
-template <class>
-struct __is_std_array : false_type {};
+template <class _Tp>
+inline const bool __is_std_array_v = false;
 
 template <class _Tp, size_t _Size>
-struct __is_std_array<array<_Tp, _Size> > : true_type {};
+inline const bool __is_std_array_v<array<_Tp, _Size> > = true;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -210,7 +210,7 @@ concept __span_compatible_range =
     ranges::contiguous_range<_Range> &&                             //
     ranges::sized_range<_Range> &&                                  //
     (ranges::borrowed_range<_Range> || is_const_v<_ElementType>) && //
-    !__is_std_array<remove_cvref_t<_Range>>::value &&               //
+    !__is_std_array_v<remove_cvref_t<_Range>> &&                    //
     !is_array_v<remove_cvref_t<_Range>> &&                          //
     is_convertible_v<remove_reference_t<ranges::range_reference_t<_Range>> (*)[], _ElementType (*)[]>;
 


### PR DESCRIPTION
This allows breaking up a dependency from __fwd/array.h onto __type_traits, which is a circular dependency once __type_traits becomes a module of its own. This is also a small consistency improvement since we've been using inline variables for traits like this elsewhere in the library.