### PR TITLE
[libc++] Remove unused pair.h include from hypot.h

### DIFF
--- a/libcxx/include/__math/hypot.h
+++ b/libcxx/include/__math/hypot.h
@@ -18,7 +18,6 @@
 #include <__type_traits/is_arithmetic.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/promote.h>
-#include <__utility/pair.h>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/test/libcxx/transitive_includes/cxx03.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx03.csv
@@ -132,7 +132,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath cstdint
 cmath initializer_list
 cmath limits
 cmath type_traits

--- a/libcxx/test/libcxx/transitive_includes/cxx11.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx11.csv
@@ -132,7 +132,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath cstdint
 cmath initializer_list
 cmath limits
 cmath type_traits

--- a/libcxx/test/libcxx/transitive_includes/cxx14.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx14.csv
@@ -133,7 +133,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath cstdint
 cmath initializer_list
 cmath limits
 cmath type_traits

--- a/libcxx/test/libcxx/transitive_includes/cxx17.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx17.csv
@@ -133,7 +133,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath cstdint
 cmath initializer_list
 cmath limits
 cmath type_traits

--- a/libcxx/test/libcxx/transitive_includes/cxx20.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx20.csv
@@ -138,7 +138,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath cstdint
 cmath initializer_list
 cmath limits
 cmath type_traits

--- a/libcxx/test/libcxx/transitive_includes/cxx23.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx23.csv
@@ -85,7 +85,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath cstdint
 cmath initializer_list
 cmath limits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -85,7 +85,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath cstdint
 cmath initializer_list
 cmath limits
 cmath version


### PR DESCRIPTION
This was added in #100820 by mistake since the final version of that PR didn't depend on std::pair anymore.