### PR TITLE
Revert "[AArch64][AsmParser] Directives should clear transitively implied features"

### DIFF
--- a/llvm/test/MC/AArch64/SVE/directive-arch-negative.s
+++ b/llvm/test/MC/AArch64/SVE/directive-arch-negative.s
@@ -1,8 +1,0 @@
-// RUN: not llvm-mc -triple aarch64 -filetype asm -o - %s 2>&1 | FileCheck %s
-
-// Check that setting +nosve implies +nosve2
-.arch armv9-a+nosve
-
-adclb z0.s, z1.s, z31.s
-// CHECK: error: instruction requires: sve2
-// CHECK-NEXT: adclb z0.s, z1.s, z31.s

--- a/llvm/test/MC/AArch64/SVE/directive-arch_extension-negative.s
+++ b/llvm/test/MC/AArch64/SVE/directive-arch_extension-negative.s
@@ -1,12 +1,7 @@
 // RUN: not llvm-mc -triple aarch64 -filetype asm -o - %s 2>&1 | FileCheck %s
 
-.arch_extension sve2+nosve
+.arch_extension nosve
 
 ptrue   p0.b, pow2
 // CHECK: error: instruction requires: sve or sme
 // CHECK-NEXT: ptrue   p0.b, pow2
-
-// Check that setting +nosve implies +nosve2
-adclb z0.s, z1.s, z31.s
-// CHECK: error: instruction requires: sve2
-// CHECK-NEXT: adclb z0.s, z1.s, z31.s

--- a/llvm/test/MC/AArch64/SVE/directive-cpu-negative.s
+++ b/llvm/test/MC/AArch64/SVE/directive-cpu-negative.s
@@ -1,11 +1,6 @@
 // RUN: not llvm-mc -triple aarch64 -filetype asm -o - %s 2>&1 | FileCheck %s
 
-.cpu generic+sve2+nosve
+.cpu generic+sve+nosve
 ptrue   p0.b, pow2
 // CHECK: error: instruction requires: sve or sme
 // CHECK-NEXT: ptrue   p0.b, pow2
-
-// Check that setting +nosve implies +nosve2
-adclb z0.s, z1.s, z31.s
-// CHECK: error: instruction requires: sve2
-// CHECK-NEXT: adclb z0.s, z1.s, z31.s

--- a/llvm/test/MC/AArch64/directive-arch-negative.s
+++ b/llvm/test/MC/AArch64/directive-arch-negative.s
@@ -12,12 +12,9 @@
 # CHECK-NEXT: 	aese v0.8h, v1.8h
 # CHECK-NEXT:	^
 
+// We silently ignore invalid features.
 	.arch armv8+foo
 	aese v0.8h, v1.8h
-
-# CHECK: error: unsupported architectural extension: foo
-# CHECK-NEXT:   .arch armv8+foo
-# CHECK-NEXT:               ^
 
 # CHECK: error: invalid operand for instruction
 # CHECK-NEXT:	aese v0.8h, v1.8h

--- a/llvm/test/MC/AArch64/directive-arch_extension-negative.s
+++ b/llvm/test/MC/AArch64/directive-arch_extension-negative.s
@@ -4,7 +4,7 @@
 // RUN: -filetype asm -o - %s 2>&1 | FileCheck %s
 
 .arch_extension axp64
-// CHECK: error: unsupported architectural extension: axp64
+// CHECK: error: unknown architectural extension: axp64
 // CHECK-NEXT: .arch_extension axp64
 
 crc32cx w0, w1, x3
@@ -49,8 +49,6 @@ fminnm d0, d0, d1
 // CHECK: [[@LINE-1]]:1: error: instruction requires: fp
 // CHECK-NEXT: fminnm d0, d0, d1
 
-// nofp implied nosimd, so reinstate it
-.arch_extension simd
 addp v0.4s, v0.4s, v0.4s
 // CHECK-NOT: [[@LINE-1]]:1: error: instruction requires: neon
 .arch_extension nosimd
@@ -72,8 +70,6 @@ casa w5, w7, [x20]
 // CHECK: [[@LINE-1]]:1: error: instruction requires: lse
 // CHECK-NEXT: casa w5, w7, [x20]
 
-// nolse implied nolse128, so reinstate it
-.arch_extension lse128
 swpp x0, x2, [x3]
 // CHECK-NOT: [[@LINE-1]]:1: error: instruction requires: lse128
 .arch_extension nolse128
@@ -88,8 +84,6 @@ cfp rctx, x0
 // CHECK: [[@LINE-1]]:5: error: CFPRCTX requires: predres
 // CHECK-NEXT: cfp rctx, x0
 
-// nopredres implied nopredres2, so reinstate it
-.arch_extension predres2
 cosp rctx, x0
 // CHECK-NOT: [[@LINE-1]]:6: error: COSP requires: predres2
 .arch_extension nopredres2
@@ -139,8 +133,6 @@ ldapr x0, [x1]
 // CHECK: [[@LINE-1]]:1: error: instruction requires: rcpc
 // CHECK-NEXT: ldapr x0, [x1]
 
-// norcpc implied norcpc3, so reinstate it
-.arch_extension rcpc3
 stilp w24, w0, [x16, #-8]!
 // CHECK-NOT: [[@LINE-1]]:1: error: instruction requires: rcpc3
 .arch_extension norcpc3
@@ -177,8 +169,6 @@ cpyfp [x0]!, [x1]!, x2!
 // CHECK: [[@LINE-1]]:1: error: instruction requires: mops
 // CHECK-NEXT: cpyfp [x0]!, [x1]!, x2!
 
-// nolse128 implied nod128, so reinstate it
-.arch_extension d128
 // This needs to come before `.arch_extension nothe` as it uses an instruction
 // that requires both the and d128
 sysp #0, c2, c0, #0, x0, x1
@@ -214,8 +204,6 @@ umax x0, x1, x2
 // CHECK: [[@LINE-1]]:1: error: instruction requires: cssc
 // CHECK-NEXT: umax x0, x1, x2
 
-// noras implied norasv2, so reinstate it
-.arch_extension rasv2
 mrs x0, ERXGSR_EL1
 // CHECK-NOT: [[@LINE-1]]:9: error: expected readable system register
 .arch_extension norasv2


### PR DESCRIPTION
Reverts llvm/llvm-project#106625

Introduces buffer overflow
https://lab.llvm.org/buildbot/#/builders/169/builds/2677/steps/9/logs/stdio