### PR TITLE
[lld][ELF] Add `-plugin-opt=time-trace=` as an alias of `--time-trace=`

### DIFF
--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -729,6 +729,7 @@ def: J<"plugin-opt=sample-profile=">,
 def: F<"plugin-opt=save-temps">, Alias<save_temps>, HelpText<"Alias for --save-temps">;
 def plugin_opt_stats_file: J<"plugin-opt=stats-file=">,
   HelpText<"Filename to write LTO statistics to">;
+def: J<"plugin-opt=time-trace=">, Alias<time_trace_eq>, HelpText<"Alias for --time-trace=">;
 def: F<"plugin-opt=thinlto-emit-imports-files">,
   Alias<thinlto_emit_imports_files>,
   HelpText<"Alias for --thinlto-emit-imports-files">;

--- a/lld/test/ELF/lto/time-trace.ll
+++ b/lld/test/ELF/lto/time-trace.ll
@@ -1,9 +1,8 @@
 ; REQUIRES: x86
 ; RUN: llvm-as %s -o %t.o
-; Print to a specific file
 ; RUN: ld.lld -m elf_x86_64 -shared %t.o -o %t.so --plugin-opt=time-trace=%t.trace.json
 ; RUN: FileCheck --input-file=%t.trace.json %s
-; Print to stdout
+;; Print to stdout
 ; RUN: ld.lld -m elf_x86_64 -shared %t.o -o %t.so --plugin-opt=time-trace=- | \
 ; RUN: FileCheck %s
 
@@ -18,4 +17,3 @@ target triple = "x86_64-unknown-linux-gnu"
 define void @foo() {
   ret void
 }
-

--- a/lld/test/ELF/lto/time-trace.ll
+++ b/lld/test/ELF/lto/time-trace.ll
@@ -1,0 +1,21 @@
+; REQUIRES: x86
+; RUN: llvm-as %s -o %t.o
+; Print to a specific file
+; RUN: ld.lld -m elf_x86_64 -shared %t.o -o %t.so --plugin-opt=time-trace=%t.trace.json
+; RUN: FileCheck --input-file=%t.trace.json %s
+; Print to stdout
+; RUN: ld.lld -m elf_x86_64 -shared %t.o -o %t.so --plugin-opt=time-trace=- | \
+; RUN: FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Make sure the content is correct
+; CHECK: "traceEvents"
+; Make sure LTO events are recorded
+; CHECK-SAME: "name":"LTO"
+
+define void @foo() {
+  ret void
+}
+


### PR DESCRIPTION
Time trace profiler support was added into LLVMgold in cd3255abede5e3687c1538f2d3857deb2c51af1b. This patch adds its `-plugin-opt` counterpart, which is just an alias to `--time-trace=`, into LLD for compatibility.