### PR TITLE
[VPlan] Add ExplicitVectorLength to isSingleScalar

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -680,7 +680,8 @@ bool VPInstruction::isVectorToScalar() const {
 }
 
 bool VPInstruction::isSingleScalar() const {
-  return getOpcode() == VPInstruction::ResumePhi;
+  return getOpcode() == VPInstruction::ResumePhi ||
+         getOpcode() == VPInstruction::ExplicitVectorLength;
 }
 
 #if !defined(NDEBUG)


### PR DESCRIPTION
The docstring of this function:

> Returns true if this VPInstruction's operands are single scalars and the
> result is also a single scalar.

ExplicitVectorLength fits this description. I don't have a test for it now, but it is needed by #106560.