### PR TITLE
[X86] Add missing pass initialization function for X86DynAllocaExpander.

### DIFF
--- a/llvm/lib/Target/X86/X86.h
+++ b/llvm/lib/Target/X86/X86.h
@@ -184,6 +184,7 @@ void initializeX86CallFrameOptimizationPass(PassRegistry &);
 void initializeX86CmovConverterPassPass(PassRegistry &);
 void initializeX86DAGToDAGISelLegacyPass(PassRegistry &);
 void initializeX86DomainReassignmentPass(PassRegistry &);
+void initializeX86DynAllocaExpanderPass(PassRegistry &);
 void initializeX86ExecutionDomainFixPass(PassRegistry &);
 void initializeX86ExpandPseudoPass(PassRegistry &);
 void initializeX86FastPreTileConfigPass(PassRegistry &);

--- a/llvm/lib/Target/X86/X86DynAllocaExpander.cpp
+++ b/llvm/lib/Target/X86/X86DynAllocaExpander.cpp
@@ -65,12 +65,17 @@ private:
   bool NoStackArgProbe = false;
 
   StringRef getPassName() const override { return "X86 DynAlloca Expander"; }
+
+public:
   static char ID;
 };
 
 char X86DynAllocaExpander::ID = 0;
 
 } // end anonymous namespace
+
+INITIALIZE_PASS(X86DynAllocaExpander, "x86-dyn-alloca-expander",
+                "X86 DynAlloca Expander", false, false)
 
 FunctionPass *llvm::createX86DynAllocaExpander() {
   return new X86DynAllocaExpander();

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -106,6 +106,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeX86Target() {
   initializeX86ArgumentStackSlotPassPass(PR);
   initializeX86FixupInstTuningPassPass(PR);
   initializeX86FixupVectorConstantsPassPass(PR);
+  initializeX86DynAllocaExpanderPass(PR);
 }
 
 static std::unique_ptr<TargetLoweringObjectFile> createTLOF(const Triple &TT) {


### PR DESCRIPTION
This allows it to show up in -print-before/after-all