### PR TITLE
[Offload] Fix disabling of cuda target on unsupported platforms

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -159,8 +159,8 @@ if(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(ppc64le)|(aarch64)$"
                    "Linux x86_64, ppc64le, or aarch64 hosts")
     list(REMOVE_ITEM LIBOMPTARGET_PLUGINS_TO_BUILD "amdgpu")
   endif()
-  if("nvptx" IN_LIST LIBOMPTARGET_PLUGINS_TO_BUILD)
-    message(STATUS "Not building CUDA plugin: only support AMDGPU in "
+  if("cuda" IN_LIST LIBOMPTARGET_PLUGINS_TO_BUILD)
+    message(STATUS "Not building CUDA plugin: only support CUDA in "
                    "Linux x86_64, ppc64le, or aarch64 hosts")
     list(REMOVE_ITEM LIBOMPTARGET_PLUGINS_TO_BUILD "cuda")
   endif()


### PR DESCRIPTION
The target name and the message are wrong -- both should say "cuda" for the filtering to work.

Fixes commit 300e5b911442 (#93186).