### PR TITLE
[clang] fix range of empty enumeration without fixed underlying type

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -10284,7 +10284,6 @@ static bool AnalyzeBitFieldAssignment(Sema &S, FieldDecl *Bitfield, Expr *Init,
     // inconsistency by storing this as a signed type.
     if (S.getLangOpts().CPlusPlus11 &&
         !BitfieldEnumDecl->getIntegerTypeSourceInfo() &&
-        BitfieldEnumDecl->getNumPositiveBits() > 0 &&
         BitfieldEnumDecl->getNumNegativeBits() == 0) {
       S.Diag(InitLoc, diag::warn_no_underlying_type_specified_for_enum_bitfield)
           << BitfieldEnumDecl;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -19903,22 +19903,13 @@ void Sema::ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
 
     // Keep track of the size of positive and negative values.
     if (InitVal.isUnsigned() || InitVal.isNonNegative()) {
-      // If the enumerator is zero that should still be counted as a positive
-      // bit since we need a bit to store the value zero.
       unsigned ActiveBits = InitVal.getActiveBits();
-      NumPositiveBits = std::max({NumPositiveBits, ActiveBits, 1u});
+      NumPositiveBits = std::max(NumPositiveBits, ActiveBits);
     } else {
       NumNegativeBits =
           std::max(NumNegativeBits, (unsigned)InitVal.getSignificantBits());
     }
   }
-
-  // If we have an empty set of enumerators we still need one bit.
-  // From [dcl.enum]p8
-  // If the enumerator-list is empty, the values of the enumeration are as if
-  // the enumeration had a single enumerator with value 0
-  if (!NumPositiveBits && !NumNegativeBits)
-    NumPositiveBits = 1;
 
   // Figure out the type that should be used for this enum.
   QualType BestType;

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -115,15 +115,19 @@ void testValueInRangeOfEnumerationValues() {
 
   constexpr E4 x11 = static_cast<E4>(0);
   constexpr E4 x12 = static_cast<E4>(1);
+  // both-error@-1 {{constexpr variable 'x12' must be initialized by a constant expression}}
+  // both-note@-2 {{integer value 1 is outside the valid range of values [0, 0] for the enumeration type 'E4'}}
   constexpr E4 x13 = static_cast<E4>(2);
   // both-error@-1 {{constexpr variable 'x13' must be initialized by a constant expression}}
-  // both-note@-2 {{integer value 2 is outside the valid range of values [0, 1] for the enumeration type 'E4'}}
+  // both-note@-2 {{integer value 2 is outside the valid range of values [0, 0] for the enumeration type 'E4'}}
 
   constexpr EEmpty x14 = static_cast<EEmpty>(0);
   constexpr EEmpty x15 = static_cast<EEmpty>(1);
+  // both-error@-1 {{constexpr variable 'x15' must be initialized by a constant expression}}
+  // both-note@-2 {{integer value 1 is outside the valid range of values [0, 0] for the enumeration type 'EEmpty'}}
   constexpr EEmpty x16 = static_cast<EEmpty>(2);
   // both-error@-1 {{constexpr variable 'x16' must be initialized by a constant expression}}
-  // both-note@-2 {{integer value 2 is outside the valid range of values [0, 1] for the enumeration type 'EEmpty'}}
+  // both-note@-2 {{integer value 2 is outside the valid range of values [0, 0] for the enumeration type 'EEmpty'}}
 
   constexpr EFixed x17 = static_cast<EFixed>(100);
   constexpr EScoped x18 = static_cast<EScoped>(100);

--- a/clang/test/CodeGenCXX/pr12251.cpp
+++ b/clang/test/CodeGenCXX/pr12251.cpp
@@ -18,14 +18,14 @@ e1 g1(e1 *x) {
   return *x;
 }
 // CHECK-LABEL: define{{.*}} i32 @_Z2g1P2e1
-// CHECK: ret i32 %0
+// CHECK: ret i32 0
 
 enum e2 { e2_a = 0 };
 e2 g2(e2 *x) {
   return *x;
 }
 // CHECK-LABEL: define{{.*}} i32 @_Z2g2P2e2
-// CHECK: ret i32 %0
+// CHECK: ret i32 0
 
 enum e3 { e3_a = 16 };
 e3 g3(e3 *x) {

--- a/clang/test/SemaCXX/constant-expression-cxx11.cpp
+++ b/clang/test/SemaCXX/constant-expression-cxx11.cpp
@@ -2485,15 +2485,19 @@ void testValueInRangeOfEnumerationValues() {
 
   constexpr E4 x11 = static_cast<E4>(0);
   constexpr E4 x12 = static_cast<E4>(1);
+  // expected-error@-1 {{constexpr variable 'x12' must be initialized by a constant expression}}
+  // expected-note@-2 {{integer value 1 is outside the valid range of values [0, 0] for the enumeration type 'E4'}}
   constexpr E4 x13 = static_cast<E4>(2);
   // expected-error@-1 {{constexpr variable 'x13' must be initialized by a constant expression}}
-  // expected-note@-2 {{integer value 2 is outside the valid range of values [0, 1] for the enumeration type 'E4'}}
+  // expected-note@-2 {{integer value 2 is outside the valid range of values [0, 0] for the enumeration type 'E4'}}
 
   constexpr EEmpty x14 = static_cast<EEmpty>(0);
   constexpr EEmpty x15 = static_cast<EEmpty>(1);
+  // expected-error@-1 {{constexpr variable 'x15' must be initialized by a constant expression}}
+  // expected-note@-2 {{integer value 1 is outside the valid range of values [0, 0] for the enumeration type 'EEmpty'}}
   constexpr EEmpty x16 = static_cast<EEmpty>(2);
   // expected-error@-1 {{constexpr variable 'x16' must be initialized by a constant expression}}
-  // expected-note@-2 {{integer value 2 is outside the valid range of values [0, 1] for the enumeration type 'EEmpty'}}
+  // expected-note@-2 {{integer value 2 is outside the valid range of values [0, 0] for the enumeration type 'EEmpty'}}
 
   constexpr EFixed x17 = static_cast<EFixed>(100);
   constexpr EScoped x18 = static_cast<EScoped>(100);


### PR DESCRIPTION
In C++ enumerations without fixed underlying type which have either no enumerator or only enumerators with value 0 have a value set containing only 0, instead of 0 and 1. See [decl.enum]/8.

This PR affects casts in C++ constant expressions, where casting a value of 1 to such an enumeration type is now no longer permitted. It also affects code generation in C++ mode with `-fstrict-enums` which may now assume that loading from such enumeration types will always produce 0. It also affects the `-fsanitize=enum` behavior, which will now diagnose a load of a value of `1` from such an enumeration type.

Fixes #106815