### PR TITLE
[NFC][clang-tidy] fix tests of deleted functions for missing-std-forward

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
@@ -187,14 +187,14 @@ void lambda_value_reference_auxiliary_var(T&& t) {
 namespace deleted_functions {
 
 template <typename T>
-void f(T &&) = delete;
+void f(T &&t) = delete;
 
 struct S {
     template <typename T>
-    S(T &&) = delete;
+    S(T &&t) = delete;
 
     template <typename T>
-    void operator&(T &&) = delete;
+    void operator&(T &&t) = delete;
 };
 
 } // namespace deleted_functions


### PR DESCRIPTION
Since #87832, unnamed identifiers are excluded from being diagnosed. As
a result, the tests that were supposed to test that deleted functions
are correctly ignored, are ignored because of the unnamed identifiers
instead of the deleted function. This change simply introduces names for
the parameters of the deleted functions.
