### PR TITLE
[compiler-rt][rtsan] NFC: Refactor context helper functions

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -69,8 +69,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_enable() {
 SANITIZER_INTERFACE_ATTRIBUTE void
 __rtsan_expect_not_realtime(const char *intercepted_function_name) {
   __rtsan_ensure_initialized();
-  __rtsan::GetContextForThisThread().ExpectNotRealtime(
-      intercepted_function_name);
+  ExpectNotRealtime(GetContextForThisThread(), intercepted_function_name);
 }
 
 } // extern "C"

--- a/compiler-rt/lib/rtsan/rtsan_context.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_context.cpp
@@ -71,13 +71,13 @@ void __rtsan::Context::BypassPush() { bypass_depth++; }
 
 void __rtsan::Context::BypassPop() { bypass_depth--; }
 
-void __rtsan::Context::ExpectNotRealtime(
-    const char *intercepted_function_name) {
-  if (InRealtimeContext() && !IsBypassed()) {
-    BypassPush();
+void __rtsan::ExpectNotRealtime(Context &context,
+                                const char *intercepted_function_name) {
+  if (context.InRealtimeContext() && !context.IsBypassed()) {
+    context.BypassPush();
     PrintDiagnostics(intercepted_function_name);
     InvokeViolationDetectedAction();
-    BypassPop();
+    context.BypassPop();
   }
 }
 
@@ -85,7 +85,7 @@ bool __rtsan::Context::InRealtimeContext() const { return realtime_depth > 0; }
 
 bool __rtsan::Context::IsBypassed() const { return bypass_depth > 0; }
 
-void __rtsan::Context::PrintDiagnostics(const char *intercepted_function_name) {
+void __rtsan::PrintDiagnostics(const char *intercepted_function_name) {
   fprintf(stderr,
           "Real-time violation: intercepted call to real-time unsafe function "
           "`%s` in real-time context! Stack trace:\n",

--- a/compiler-rt/lib/rtsan/rtsan_context.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_context.cpp
@@ -63,13 +63,13 @@ static void InvokeViolationDetectedAction() { exit(EXIT_FAILURE); }
 
 __rtsan::Context::Context() = default;
 
-void __rtsan::Context::RealtimePush() { realtime_depth++; }
+void __rtsan::Context::RealtimePush() { realtime_depth_++; }
 
-void __rtsan::Context::RealtimePop() { realtime_depth--; }
+void __rtsan::Context::RealtimePop() { realtime_depth_--; }
 
-void __rtsan::Context::BypassPush() { bypass_depth++; }
+void __rtsan::Context::BypassPush() { bypass_depth_++; }
 
-void __rtsan::Context::BypassPop() { bypass_depth--; }
+void __rtsan::Context::BypassPop() { bypass_depth_--; }
 
 void __rtsan::ExpectNotRealtime(Context &context,
                                 const char *intercepted_function_name) {
@@ -81,9 +81,9 @@ void __rtsan::ExpectNotRealtime(Context &context,
   }
 }
 
-bool __rtsan::Context::InRealtimeContext() const { return realtime_depth > 0; }
+bool __rtsan::Context::InRealtimeContext() const { return realtime_depth_ > 0; }
 
-bool __rtsan::Context::IsBypassed() const { return bypass_depth > 0; }
+bool __rtsan::Context::IsBypassed() const { return bypass_depth_ > 0; }
 
 void __rtsan::PrintDiagnostics(const char *intercepted_function_name) {
   fprintf(stderr,

--- a/compiler-rt/lib/rtsan/rtsan_context.h
+++ b/compiler-rt/lib/rtsan/rtsan_context.h
@@ -22,17 +22,22 @@ public:
   void BypassPush();
   void BypassPop();
 
-  void ExpectNotRealtime(const char *intercepted_function_name);
-
-private:
   bool InRealtimeContext() const;
   bool IsBypassed() const;
-  void PrintDiagnostics(const char *intercepted_function_name);
 
+  Context(const Context &) = delete;
+  Context(Context &&) = delete;
+  Context &operator=(const Context &) = delete;
+  Context &operator=(Context &&) = delete;
+
+private:
   int realtime_depth{0};
   int bypass_depth{0};
 };
 
 Context &GetContextForThisThread();
+
+void ExpectNotRealtime(Context &context, const char *intercepted_function_name);
+void PrintDiagnostics(const char *intercepted_function_name);
 
 } // namespace __rtsan

--- a/compiler-rt/lib/rtsan/rtsan_context.h
+++ b/compiler-rt/lib/rtsan/rtsan_context.h
@@ -31,8 +31,8 @@ public:
   Context &operator=(Context &&) = delete;
 
 private:
-  int realtime_depth{0};
-  int bypass_depth{0};
+  int realtime_depth_{0};
+  int bypass_depth_{0};
 };
 
 Context &GetContextForThisThread();

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_context.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_context.cpp
@@ -16,21 +16,21 @@ TEST(TestRtsanContext, CanCreateContext) { __rtsan::Context context{}; }
 
 TEST(TestRtsanContext, ExpectNotRealtimeDoesNotDieBeforeRealtimePush) {
   __rtsan::Context context{};
-  context.ExpectNotRealtime("do_some_stuff");
+  ExpectNotRealtime(context, "do_some_stuff");
 }
 
 TEST(TestRtsanContext, ExpectNotRealtimeDoesNotDieAfterPushAndPop) {
   __rtsan::Context context{};
   context.RealtimePush();
   context.RealtimePop();
-  context.ExpectNotRealtime("do_some_stuff");
+  ExpectNotRealtime(context, "do_some_stuff");
 }
 
 TEST(TestRtsanContext, ExpectNotRealtimeDiesAfterRealtimePush) {
   __rtsan::Context context{};
 
   context.RealtimePush();
-  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
+  EXPECT_DEATH(ExpectNotRealtime(context, "do_some_stuff"), "");
 }
 
 TEST(TestRtsanContext,
@@ -42,7 +42,7 @@ TEST(TestRtsanContext,
   context.RealtimePush();
   context.RealtimePop();
   context.RealtimePop();
-  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
+  EXPECT_DEATH(ExpectNotRealtime(context, "do_some_stuff"), "");
 }
 
 TEST(TestRtsanContext, ExpectNotRealtimeDoesNotDieAfterBypassPush) {
@@ -50,7 +50,7 @@ TEST(TestRtsanContext, ExpectNotRealtimeDoesNotDieAfterBypassPush) {
 
   context.RealtimePush();
   context.BypassPush();
-  context.ExpectNotRealtime("do_some_stuff");
+  ExpectNotRealtime(context, "do_some_stuff");
 }
 
 TEST(TestRtsanContext,
@@ -63,7 +63,7 @@ TEST(TestRtsanContext,
   context.BypassPush();
   context.BypassPop();
   context.BypassPop();
-  context.ExpectNotRealtime("do_some_stuff");
+  ExpectNotRealtime(context, "do_some_stuff");
   context.BypassPop();
-  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
+  EXPECT_DEATH(ExpectNotRealtime(context, "do_some_stuff"), "");
 }


### PR DESCRIPTION
Pull `ExpectNotRealtime` and `PrintDiagnostics` into their own functions, away from Context.

Why?
- Currently PrintDiagnostics does not depend on any private method of Context
- We want to change soon to allow for detection of infinite loops and user defined blocking functions
    - These changes will affect these two functions, but shouldn't affect Context.
    - We will need to add an argument, or otherwise change these methods to say "why" we expect not realtime in this situation.

Overall, I think this refactor decreases coupling, and increases our flexibility going forward.