### PR TITLE
[compiler-rt] [docs] Mention Windows as one of the supported OSes

### DIFF
--- a/compiler-rt/www/index.html
+++ b/compiler-rt/www/index.html
@@ -77,7 +77,7 @@
    <p><b>builtins</b> is known to work on the following platforms:</p>
    <ul>
    <li>Machine Architectures: i386, X86-64, SPARC64, ARM, PowerPC, PowerPC 64.</li>
-   <li>OS: DragonFlyBSD, FreeBSD, NetBSD, OpenBSD, Linux, Darwin.</li>
+   <li>OS: DragonFlyBSD, FreeBSD, NetBSD, OpenBSD, Linux, Darwin, Windows.</li>
    </ul>
 
    <p>Most sanitizer runtimes are supported only on Linux x86-64. See tool-specific


### PR DESCRIPTION
Compiler-rt can be built for Windows, and most parts of it work. Some parts only really work on x86/x86_64 (like address sanitizers), but the OS overall is supported.