### PR TITLE
[clang] [docs] Clarify the issue with compiler-rt on Windows/MSVC

### DIFF
--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -1057,8 +1057,8 @@ conforms by not defining the <code>__STDC_IEC_559_COMPLEX__</code> macro.
           conformance to Annex G.<br />
           <br />
           <code>_Complex</code> support requires an underlying support library
-          such as compiler-rt to provide functions like <code>__divsc3</code>,
-          but compiler-rt is not supported on Windows.
+          such as compiler-rt to provide functions like <code>__divsc3</code>.
+          Compiler-rt isn't linked in automatically in MSVC style environments.
         </details>
       </td>
     </tr>


### PR DESCRIPTION
Compiler-rt does support Windows just fine, even if outdated docs pages didn't list it as one of the supported OSes, this is being rectified in https://github.com/llvm/llvm-project/pull/106874.

MinGW is another environment configuration on Windows, where compiler-rt or libgcc is linked in automatically, so there's no issue with having such builtins functions available.

For MSVC style environments, compiler-rt builtins do work just fine, but Clang doesn't automatically link them in. See e.g. https://discourse.llvm.org/t/improve-autolinking-of-compiler-rt-and-libc-on-windows-with-lld-link/71392 for a discussion on how to improve this situation. But none of that issue is that compiler-rt itself wouldn't support Windows.