### PR TITLE
Attempt to fix: Sporadic Test Failure in thread.condition.condvarany/notify_one.pass.cpp

### DIFF
--- a/draft_PR.txt
+++ b/draft_PR.txt
@@ -1,0 +1,1 @@
+Aim to fix sporadic failure of notify_one.pass.cpp


### PR DESCRIPTION
Hello, I am creating this draft PR to address the sporadic test failure in `thread.condition.condvarany/notify_one.pass.cpp`
 within the LLVM `libcxx` test suite. The issue stems from timing assumptions that cause the test to fail intermittently in both internal and external CI environments.
 
 I have previously worked in Microsoft STL's repository to unskip some of these sporadic tests.
 
Context: 

The proposed fix adapts the approach used in the `notify_all test` (Issue #95944 and PR #97622 ) to enhance reliability by ensuring synchronization without relying on specific timing. This change should reduce or eliminate the occurrence of sporadic failures in this test.

I was not able to find any issue raised for `notify_one.pass` issue similar to `notify_all.pass` issue, should I raise one to bind with this PR as well?

I am seeking advice on this so adding a few people here
Please suggest @EugeneZelenko @lattner @topperc @shiltian @nikic @tbaederr  please suggest.