### PR TITLE
[lldb] Fix some tests that fail with system libstdc++

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/Makefile
@@ -1,5 +1,3 @@
-# FIXME: once the expression evaluator can handle std libraries with debug
-# info, change this to USE_LIBCPP=1
-USE_SYSTEM_STDLIB := 1
+USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/Makefile
@@ -1,5 +1,3 @@
-# FIXME: once the expression evaluator can handle std libraries with debug
-# info, change this to USE_LIBCPP=1
-USE_SYSTEM_STDLIB := 1
+USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/Makefile
@@ -1,5 +1,3 @@
-# FIXME: once the expression evaluator can handle std libraries with debug
-# info, change this to USE_LIBCPP=1
-USE_SYSTEM_STDLIB := 1
+USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
 include Makefile.rules


### PR DESCRIPTION
This is a revert of b1fcc1840c312472cb9ccb8c4e5e02ca13b31113.

These tests weren't working on Ubuntu 22.04 or Fedora 37-40.  I'm not sure exactly why, but it seems like they may be incompatible with libstdc++.  Also, despite the fact that the tests were using the system libstdc++, the tests were only run when libcxx was enabled.

I tested this with a RelWithDebInfo build and the tests passed.

Fixes #106475