### PR TITLE
[RISCV] Custom legalize f16/bf16 FNEG/FABS with Zfhmin/Zbfmin.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -459,8 +459,8 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::BR_CC, MVT::bf16, Expand);
     setOperationAction(ZfhminZfbfminPromoteOps, MVT::bf16, Promote);
     setOperationAction(ISD::FREM, MVT::bf16, Promote);
-    setOperationAction(ISD::FABS, MVT::bf16, Expand);
-    setOperationAction(ISD::FNEG, MVT::bf16, Expand);
+    setOperationAction(ISD::FABS, MVT::bf16, Custom);
+    setOperationAction(ISD::FNEG, MVT::bf16, Custom);
     setOperationAction(ISD::FCOPYSIGN, MVT::bf16, Expand);
   }
 
@@ -476,8 +476,8 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
       setOperationAction({ISD::STRICT_LRINT, ISD::STRICT_LLRINT,
                           ISD::STRICT_LROUND, ISD::STRICT_LLROUND},
                          MVT::f16, Legal);
-      setOperationAction(ISD::FABS, MVT::f16, Expand);
-      setOperationAction(ISD::FNEG, MVT::f16, Expand);
+      setOperationAction(ISD::FABS, MVT::f16, Custom);
+      setOperationAction(ISD::FNEG, MVT::f16, Custom);
       setOperationAction(ISD::FCOPYSIGN, MVT::f16, Expand);
     }
 
@@ -5942,6 +5942,29 @@ static SDValue lowerFMAXIMUM_FMINIMUM(SDValue Op, SelectionDAG &DAG,
   return Res;
 }
 
+static SDValue lowerFABSorFNEG(SDValue Op, SelectionDAG &DAG,
+                               const RISCVSubtarget &Subtarget) {
+  bool IsFABS = Op.getOpcode() == ISD::FABS;
+  assert((IsFABS || Op.getOpcode() == ISD::FNEG) &&
+         "Wrong opcode for lowering FABS or FNEG.");
+
+  MVT XLenVT = Subtarget.getXLenVT();
+  MVT VT = Op.getSimpleValueType();
+  assert((VT == MVT::f16 || VT == MVT::bf16) && "Unexpected type");
+
+  SDLoc DL(Op);
+  SDValue Fmv =
+      DAG.getNode(RISCVISD::FMV_X_ANYEXTH, DL, XLenVT, Op.getOperand(0));
+
+  APInt Mask = IsFABS ? APInt::getSignedMaxValue(16) : APInt::getSignMask(16);
+  Mask = Mask.sext(Subtarget.getXLen());
+
+  unsigned LogicOpc = IsFABS ? ISD::AND : ISD::XOR;
+  SDValue Logic =
+      DAG.getNode(LogicOpc, DL, XLenVT, Fmv, DAG.getConstant(Mask, DL, XLenVT));
+  return DAG.getNode(RISCVISD::FMV_H_X, DL, VT, Logic);
+}
+
 /// Get a RISC-V target specified VL op for a given SDNode.
 static unsigned getRISCVVLOp(SDValue Op) {
 #define OP_CASE(NODE)                                                          \
@@ -7071,12 +7094,15 @@ SDValue RISCVTargetLowering::LowerOperation(SDValue Op,
     assert(Op.getOperand(1).getValueType() == MVT::i32 && Subtarget.is64Bit() &&
            "Unexpected custom legalisation");
     return SDValue();
+  case ISD::FABS:
+  case ISD::FNEG:
+    if (Op.getValueType() == MVT::f16 || Op.getValueType() == MVT::bf16)
+      return lowerFABSorFNEG(Op, DAG, Subtarget);
+    [[fallthrough]];
   case ISD::FADD:
   case ISD::FSUB:
   case ISD::FMUL:
   case ISD::FDIV:
-  case ISD::FNEG:
-  case ISD::FABS:
   case ISD::FSQRT:
   case ISD::FMA:
   case ISD::FMINNUM:

--- a/llvm/test/CodeGen/RISCV/bfloat-arith.ll
+++ b/llvm/test/CodeGen/RISCV/bfloat-arith.ll
@@ -75,14 +75,19 @@ define bfloat @fsgnj_s(bfloat %a, bfloat %b) nounwind {
 ; RV32IZFBFMIN:       # %bb.0:
 ; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
 ; RV32IZFBFMIN-NEXT:    fsh fa1, 12(sp)
-; RV32IZFBFMIN-NEXT:    fsh fa0, 8(sp)
 ; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    lbu a1, 9(sp)
-; RV32IZFBFMIN-NEXT:    andi a0, a0, 128
-; RV32IZFBFMIN-NEXT:    andi a1, a1, 127
-; RV32IZFBFMIN-NEXT:    or a0, a1, a0
-; RV32IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFBFMIN-NEXT:    flh fa0, 8(sp)
+; RV32IZFBFMIN-NEXT:    fmv.x.h a1, fa0
+; RV32IZFBFMIN-NEXT:    slli a1, a1, 17
+; RV32IZFBFMIN-NEXT:    andi a2, a0, 128
+; RV32IZFBFMIN-NEXT:    srli a0, a1, 17
+; RV32IZFBFMIN-NEXT:    beqz a2, .LBB5_2
+; RV32IZFBFMIN-NEXT:  # %bb.1:
+; RV32IZFBFMIN-NEXT:    lui a1, 1048568
+; RV32IZFBFMIN-NEXT:    or a0, a0, a1
+; RV32IZFBFMIN-NEXT:  .LBB5_2:
+; RV32IZFBFMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
+; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
 ; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFBFMIN-NEXT:    ret
 ;
@@ -90,14 +95,19 @@ define bfloat @fsgnj_s(bfloat %a, bfloat %b) nounwind {
 ; RV64IZFBFMIN:       # %bb.0:
 ; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
 ; RV64IZFBFMIN-NEXT:    fsh fa1, 8(sp)
-; RV64IZFBFMIN-NEXT:    fsh fa0, 0(sp)
 ; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    lbu a1, 1(sp)
-; RV64IZFBFMIN-NEXT:    andi a0, a0, 128
-; RV64IZFBFMIN-NEXT:    andi a1, a1, 127
-; RV64IZFBFMIN-NEXT:    or a0, a1, a0
-; RV64IZFBFMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFBFMIN-NEXT:    flh fa0, 0(sp)
+; RV64IZFBFMIN-NEXT:    fmv.x.h a1, fa0
+; RV64IZFBFMIN-NEXT:    slli a1, a1, 49
+; RV64IZFBFMIN-NEXT:    andi a2, a0, 128
+; RV64IZFBFMIN-NEXT:    srli a0, a1, 49
+; RV64IZFBFMIN-NEXT:    beqz a2, .LBB5_2
+; RV64IZFBFMIN-NEXT:  # %bb.1:
+; RV64IZFBFMIN-NEXT:    lui a1, 1048568
+; RV64IZFBFMIN-NEXT:    or a0, a0, a1
+; RV64IZFBFMIN-NEXT:  .LBB5_2:
+; RV64IZFBFMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
+; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
 ; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFBFMIN-NEXT:    ret
   %1 = call bfloat @llvm.copysign.bf16(bfloat %a, bfloat %b)
@@ -105,39 +115,19 @@ define bfloat @fsgnj_s(bfloat %a, bfloat %b) nounwind {
 }
 
 define i32 @fneg_s(bfloat %a, bfloat %b) nounwind {
-; RV32IZFBFMIN-LABEL: fneg_s:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa4, 12(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
-; RV32IZFBFMIN-NEXT:    feq.s a0, fa5, fa4
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fneg_s:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa4, 8(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
-; RV64IZFBFMIN-NEXT:    feq.s a0, fa5, fa4
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fneg_s:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa0
+; CHECK-NEXT:    fadd.s fa5, fa5, fa5
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa4, a0
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa4
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    feq.s a0, fa5, fa4
+; CHECK-NEXT:    ret
   %1 = fadd bfloat %a, %a
   %2 = fneg bfloat %1
   %3 = fcmp oeq bfloat %1, %2
@@ -153,45 +143,57 @@ define bfloat @fsgnjn_s(bfloat %a, bfloat %b) nounwind {
 ; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa0
 ; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 4(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 5(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 5(sp)
-; RV32IZFBFMIN-NEXT:    flh fa5, 4(sp)
-; RV32IZFBFMIN-NEXT:    fsh fa0, 8(sp)
+; RV32IZFBFMIN-NEXT:    fmv.x.h a1, fa5
+; RV32IZFBFMIN-NEXT:    lui a0, 1048568
+; RV32IZFBFMIN-NEXT:    xor a1, a1, a0
+; RV32IZFBFMIN-NEXT:    fmv.h.x fa5, a1
 ; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 9(sp)
 ; RV32IZFBFMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZFBFMIN-NEXT:    andi a0, a0, 127
-; RV32IZFBFMIN-NEXT:    andi a1, a1, 128
-; RV32IZFBFMIN-NEXT:    or a0, a0, a1
-; RV32IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFBFMIN-NEXT:    flh fa0, 8(sp)
+; RV32IZFBFMIN-NEXT:    fmv.x.h a2, fa0
+; RV32IZFBFMIN-NEXT:    slli a2, a2, 17
+; RV32IZFBFMIN-NEXT:    andi a3, a1, 128
+; RV32IZFBFMIN-NEXT:    srli a1, a2, 17
+; RV32IZFBFMIN-NEXT:    bnez a3, .LBB7_2
+; RV32IZFBFMIN-NEXT:  # %bb.1:
+; RV32IZFBFMIN-NEXT:    fmv.h.x fa5, a1
+; RV32IZFBFMIN-NEXT:    j .LBB7_3
+; RV32IZFBFMIN-NEXT:  .LBB7_2:
+; RV32IZFBFMIN-NEXT:    or a0, a1, a0
+; RV32IZFBFMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IZFBFMIN-NEXT:  .LBB7_3:
+; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
+; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
 ; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFBFMIN-NEXT:    ret
 ;
 ; RV64IZFBFMIN-LABEL: fsgnjn_s:
 ; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -32
+; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
 ; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa1
 ; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa0
 ; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
+; RV64IZFBFMIN-NEXT:    fmv.x.h a1, fa5
+; RV64IZFBFMIN-NEXT:    lui a0, 1048568
+; RV64IZFBFMIN-NEXT:    xor a1, a1, a0
+; RV64IZFBFMIN-NEXT:    fmv.h.x fa5, a1
 ; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    fsh fa0, 16(sp)
-; RV64IZFBFMIN-NEXT:    fsh fa5, 24(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 17(sp)
-; RV64IZFBFMIN-NEXT:    lbu a1, 25(sp)
-; RV64IZFBFMIN-NEXT:    andi a0, a0, 127
-; RV64IZFBFMIN-NEXT:    andi a1, a1, 128
-; RV64IZFBFMIN-NEXT:    or a0, a0, a1
-; RV64IZFBFMIN-NEXT:    sb a0, 17(sp)
-; RV64IZFBFMIN-NEXT:    flh fa0, 16(sp)
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 32
+; RV64IZFBFMIN-NEXT:    lbu a1, 9(sp)
+; RV64IZFBFMIN-NEXT:    fmv.x.h a2, fa0
+; RV64IZFBFMIN-NEXT:    slli a2, a2, 49
+; RV64IZFBFMIN-NEXT:    andi a3, a1, 128
+; RV64IZFBFMIN-NEXT:    srli a1, a2, 49
+; RV64IZFBFMIN-NEXT:    bnez a3, .LBB7_2
+; RV64IZFBFMIN-NEXT:  # %bb.1:
+; RV64IZFBFMIN-NEXT:    fmv.h.x fa5, a1
+; RV64IZFBFMIN-NEXT:    j .LBB7_3
+; RV64IZFBFMIN-NEXT:  .LBB7_2:
+; RV64IZFBFMIN-NEXT:    or a0, a1, a0
+; RV64IZFBFMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IZFBFMIN-NEXT:  .LBB7_3:
+; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
+; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
+; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFBFMIN-NEXT:    ret
   %1 = fadd bfloat %a, %b
   %2 = fneg bfloat %1
@@ -204,40 +206,34 @@ declare bfloat @llvm.fabs.bf16(bfloat)
 define bfloat @fabs_s(bfloat %a, bfloat %b) nounwind {
 ; RV32IZFBFMIN-LABEL: fabs_s:
 ; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
 ; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa1
 ; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa0
 ; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    andi a0, a0, 127
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa4, 12(sp)
+; RV32IZFBFMIN-NEXT:    fmv.x.h a0, fa5
+; RV32IZFBFMIN-NEXT:    slli a0, a0, 17
+; RV32IZFBFMIN-NEXT:    srli a0, a0, 17
+; RV32IZFBFMIN-NEXT:    fmv.h.x fa4, a0
 ; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
 ; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
 ; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFBFMIN-NEXT:    ret
 ;
 ; RV64IZFBFMIN-LABEL: fabs_s:
 ; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
 ; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa1
 ; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa0
 ; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    andi a0, a0, 127
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa4, 8(sp)
+; RV64IZFBFMIN-NEXT:    fmv.x.h a0, fa5
+; RV64IZFBFMIN-NEXT:    slli a0, a0, 49
+; RV64IZFBFMIN-NEXT:    srli a0, a0, 49
+; RV64IZFBFMIN-NEXT:    fmv.h.x fa4, a0
 ; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
 ; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
 ; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFBFMIN-NEXT:    ret
   %1 = fadd bfloat %a, %b
   %2 = call bfloat @llvm.fabs.bf16(bfloat %1)
@@ -289,45 +285,22 @@ define bfloat @fmadd_s(bfloat %a, bfloat %b, bfloat %c) nounwind {
 }
 
 define bfloat @fmsub_s(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fmsub_s:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV32IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa1
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fmsub_s:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV64IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa1
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fmsub_s:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa2
+; CHECK-NEXT:    fmv.w.x fa4, zero
+; CHECK-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa5, a0
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa1
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa0
+; CHECK-NEXT:    fmadd.s fa5, fa3, fa4, fa5
+; CHECK-NEXT:    fcvt.bf16.s fa0, fa5
+; CHECK-NEXT:    ret
   %c_ = fadd bfloat 0.0, %c ; avoid negation using xor
   %negc = fsub bfloat -0.0, %c_
   %1 = call bfloat @llvm.fma.bf16(bfloat %a, bfloat %b, bfloat %negc)
@@ -335,61 +308,28 @@ define bfloat @fmsub_s(bfloat %a, bfloat %b, bfloat %c) nounwind {
 }
 
 define bfloat @fnmadd_s(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fnmadd_s:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV32IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFBFMIN-NEXT:    flh fa4, 8(sp)
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa1
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
-; RV32IZFBFMIN-NEXT:    fmadd.s fa5, fa4, fa3, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fnmadd_s:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV64IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 0(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 1(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFBFMIN-NEXT:    flh fa4, 0(sp)
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa1
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
-; RV64IZFBFMIN-NEXT:    fmadd.s fa5, fa4, fa3, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fnmadd_s:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa0
+; CHECK-NEXT:    fmv.w.x fa4, zero
+; CHECK-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa2
+; CHECK-NEXT:    fadd.s fa4, fa3, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa4, fa4
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa5, a0
+; CHECK-NEXT:    fmv.x.h a0, fa4
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa4, a0
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa4
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa1
+; CHECK-NEXT:    fmadd.s fa5, fa5, fa3, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa0, fa5
+; CHECK-NEXT:    ret
   %a_ = fadd bfloat 0.0, %a
   %c_ = fadd bfloat 0.0, %c
   %nega = fsub bfloat -0.0, %a_
@@ -399,61 +339,28 @@ define bfloat @fnmadd_s(bfloat %a, bfloat %b, bfloat %c) nounwind {
 }
 
 define bfloat @fnmadd_s_2(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fnmadd_s_2:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa1
-; RV32IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFBFMIN-NEXT:    flh fa4, 8(sp)
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
-; RV32IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fnmadd_s_2:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa1
-; RV64IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 0(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 1(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFBFMIN-NEXT:    flh fa4, 0(sp)
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa4
-; RV64IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fnmadd_s_2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa1
+; CHECK-NEXT:    fmv.w.x fa4, zero
+; CHECK-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa2
+; CHECK-NEXT:    fadd.s fa4, fa3, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa4, fa4
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa5, a0
+; CHECK-NEXT:    fmv.x.h a0, fa4
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa4, a0
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa4
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa0
+; CHECK-NEXT:    fmadd.s fa5, fa3, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa0, fa5
+; CHECK-NEXT:    ret
   %b_ = fadd bfloat 0.0, %b
   %c_ = fadd bfloat 0.0, %c
   %negb = fsub bfloat -0.0, %b_
@@ -463,37 +370,18 @@ define bfloat @fnmadd_s_2(bfloat %a, bfloat %b, bfloat %c) nounwind {
 }
 
 define bfloat @fnmadd_s_3(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fnmadd_s_3:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa1
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV32IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa0, 12(sp)
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fnmadd_s_3:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa1
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV64IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa0, 8(sp)
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fnmadd_s_3:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa2
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa1
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa0
+; CHECK-NEXT:    fmadd.s fa5, fa3, fa4, fa5
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa0, a0
+; CHECK-NEXT:    ret
   %1 = call bfloat @llvm.fma.bf16(bfloat %a, bfloat %b, bfloat %c)
   %neg = fneg bfloat %1
   ret bfloat %neg
@@ -501,82 +389,40 @@ define bfloat @fnmadd_s_3(bfloat %a, bfloat %b, bfloat %c) nounwind {
 
 
 define bfloat @fnmadd_nsz(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fnmadd_nsz:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa1
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV32IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa0, 12(sp)
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fnmadd_nsz:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa1
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV64IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa0, 8(sp)
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fnmadd_nsz:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa2
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa1
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa0
+; CHECK-NEXT:    fmadd.s fa5, fa3, fa4, fa5
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa0, a0
+; CHECK-NEXT:    ret
   %1 = call nsz bfloat @llvm.fma.bf16(bfloat %a, bfloat %b, bfloat %c)
   %neg = fneg nsz bfloat %1
   ret bfloat %neg
 }
 
 define bfloat @fnmsub_s(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fnmsub_s:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV32IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa2
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa1
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fnmsub_s:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV64IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa2
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa1
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fnmsub_s:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa0
+; CHECK-NEXT:    fmv.w.x fa4, zero
+; CHECK-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa5, a0
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa2
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa1
+; CHECK-NEXT:    fmadd.s fa5, fa5, fa3, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa0, fa5
+; CHECK-NEXT:    ret
   %a_ = fadd bfloat 0.0, %a
   %nega = fsub bfloat -0.0, %a_
   %1 = call bfloat @llvm.fma.bf16(bfloat %nega, bfloat %b, bfloat %c)
@@ -584,45 +430,22 @@ define bfloat @fnmsub_s(bfloat %a, bfloat %b, bfloat %c) nounwind {
 }
 
 define bfloat @fnmsub_s_2(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fnmsub_s_2:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa1
-; RV32IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa2
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fnmsub_s_2:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa1
-; RV64IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa2
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa0
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fnmsub_s_2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa1
+; CHECK-NEXT:    fmv.w.x fa4, zero
+; CHECK-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa5, a0
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa2
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa0
+; CHECK-NEXT:    fmadd.s fa5, fa3, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa0, fa5
+; CHECK-NEXT:    ret
   %b_ = fadd bfloat 0.0, %b
   %negb = fsub bfloat -0.0, %b_
   %1 = call bfloat @llvm.fma.bf16(bfloat %a, bfloat %negb, bfloat %c)
@@ -669,63 +492,31 @@ define bfloat @fmsub_s_contract(bfloat %a, bfloat %b, bfloat %c) nounwind {
 }
 
 define bfloat @fnmadd_s_contract(bfloat %a, bfloat %b, bfloat %c) nounwind {
-; RV32IZFBFMIN-LABEL: fnmadd_s_contract:
-; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV32IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa1
-; RV32IZFBFMIN-NEXT:    fadd.s fa3, fa3, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa3, fa3
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa3
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fmul.s fa5, fa5, fa3
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFBFMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV32IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV32IZFBFMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFBFMIN-NEXT:    flh fa3, 12(sp)
-; RV32IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa3
-; RV32IZFBFMIN-NEXT:    fsub.s fa5, fa4, fa5
-; RV32IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV32IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV32IZFBFMIN-NEXT:    ret
-;
-; RV64IZFBFMIN-LABEL: fnmadd_s_contract:
-; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    addi sp, sp, -16
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa0
-; RV64IZFBFMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa1
-; RV64IZFBFMIN-NEXT:    fadd.s fa3, fa3, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa3, fa3
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa3, fa3
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fmul.s fa5, fa5, fa3
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFBFMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa2
-; RV64IZFBFMIN-NEXT:    xori a0, a0, 128
-; RV64IZFBFMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFBFMIN-NEXT:    flh fa3, 8(sp)
-; RV64IZFBFMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa5, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa5, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.s.bf16 fa4, fa3
-; RV64IZFBFMIN-NEXT:    fsub.s fa5, fa4, fa5
-; RV64IZFBFMIN-NEXT:    fcvt.bf16.s fa0, fa5
-; RV64IZFBFMIN-NEXT:    addi sp, sp, 16
-; RV64IZFBFMIN-NEXT:    ret
+; CHECK-LABEL: fnmadd_s_contract:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa0
+; CHECK-NEXT:    fmv.w.x fa4, zero
+; CHECK-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa1
+; CHECK-NEXT:    fadd.s fa3, fa3, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa3, fa3
+; CHECK-NEXT:    fcvt.s.bf16 fa2, fa2
+; CHECK-NEXT:    fadd.s fa4, fa2, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa4, fa4
+; CHECK-NEXT:    fcvt.s.bf16 fa3, fa3
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    fmul.s fa5, fa5, fa3
+; CHECK-NEXT:    fcvt.bf16.s fa5, fa5
+; CHECK-NEXT:    fmv.x.h a0, fa5
+; CHECK-NEXT:    lui a1, 1048568
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    fmv.h.x fa5, a0
+; CHECK-NEXT:    fcvt.s.bf16 fa5, fa5
+; CHECK-NEXT:    fcvt.s.bf16 fa4, fa4
+; CHECK-NEXT:    fsub.s fa5, fa5, fa4
+; CHECK-NEXT:    fcvt.bf16.s fa0, fa5
+; CHECK-NEXT:    ret
   %a_ = fadd bfloat 0.0, %a ; avoid negation using xor
   %b_ = fadd bfloat 0.0, %b ; avoid negation using xor
   %c_ = fadd bfloat 0.0, %c ; avoid negation using xor

--- a/llvm/test/CodeGen/RISCV/copysign-casts.ll
+++ b/llvm/test/CodeGen/RISCV/copysign-casts.ll
@@ -503,48 +503,53 @@ define half @fold_demote_h_s(half %a, float %b) nounwind {
 ;
 ; RV32IFZFHMIN-LABEL: fold_demote_h_s:
 ; RV32IFZFHMIN:       # %bb.0:
-; RV32IFZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IFZFHMIN-NEXT:    fsh fa0, 12(sp)
-; RV32IFZFHMIN-NEXT:    fmv.x.w a0, fa1
-; RV32IFZFHMIN-NEXT:    lbu a1, 13(sp)
-; RV32IFZFHMIN-NEXT:    lui a2, 524288
-; RV32IFZFHMIN-NEXT:    and a0, a0, a2
-; RV32IFZFHMIN-NEXT:    srli a0, a0, 24
-; RV32IFZFHMIN-NEXT:    andi a1, a1, 127
-; RV32IFZFHMIN-NEXT:    or a0, a1, a0
-; RV32IFZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IFZFHMIN-NEXT:    flh fa0, 12(sp)
-; RV32IFZFHMIN-NEXT:    addi sp, sp, 16
+; RV32IFZFHMIN-NEXT:    fmv.x.h a0, fa0
+; RV32IFZFHMIN-NEXT:    slli a0, a0, 17
+; RV32IFZFHMIN-NEXT:    fmv.x.w a1, fa1
+; RV32IFZFHMIN-NEXT:    srli a0, a0, 17
+; RV32IFZFHMIN-NEXT:    bgez a1, .LBB4_2
+; RV32IFZFHMIN-NEXT:  # %bb.1:
+; RV32IFZFHMIN-NEXT:    lui a1, 1048568
+; RV32IFZFHMIN-NEXT:    or a0, a0, a1
+; RV32IFZFHMIN-NEXT:  .LBB4_2:
+; RV32IFZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IFZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IFZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IFZFHMIN-NEXT:    ret
 ;
 ; RV32IFDZFHMIN-LABEL: fold_demote_h_s:
 ; RV32IFDZFHMIN:       # %bb.0:
-; RV32IFDZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IFDZFHMIN-NEXT:    fsh fa0, 12(sp)
-; RV32IFDZFHMIN-NEXT:    fmv.x.w a0, fa1
-; RV32IFDZFHMIN-NEXT:    lbu a1, 13(sp)
-; RV32IFDZFHMIN-NEXT:    lui a2, 524288
-; RV32IFDZFHMIN-NEXT:    and a0, a0, a2
-; RV32IFDZFHMIN-NEXT:    srli a0, a0, 24
-; RV32IFDZFHMIN-NEXT:    andi a1, a1, 127
-; RV32IFDZFHMIN-NEXT:    or a0, a1, a0
-; RV32IFDZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IFDZFHMIN-NEXT:    flh fa0, 12(sp)
-; RV32IFDZFHMIN-NEXT:    addi sp, sp, 16
+; RV32IFDZFHMIN-NEXT:    fmv.x.h a0, fa0
+; RV32IFDZFHMIN-NEXT:    slli a0, a0, 17
+; RV32IFDZFHMIN-NEXT:    fmv.x.w a1, fa1
+; RV32IFDZFHMIN-NEXT:    srli a0, a0, 17
+; RV32IFDZFHMIN-NEXT:    bgez a1, .LBB4_2
+; RV32IFDZFHMIN-NEXT:  # %bb.1:
+; RV32IFDZFHMIN-NEXT:    lui a1, 1048568
+; RV32IFDZFHMIN-NEXT:    or a0, a0, a1
+; RV32IFDZFHMIN-NEXT:  .LBB4_2:
+; RV32IFDZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IFDZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IFDZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IFDZFHMIN-NEXT:    ret
 ;
 ; RV64IFDZFHMIN-LABEL: fold_demote_h_s:
 ; RV64IFDZFHMIN:       # %bb.0:
 ; RV64IFDZFHMIN-NEXT:    addi sp, sp, -16
 ; RV64IFDZFHMIN-NEXT:    fsw fa1, 8(sp)
-; RV64IFDZFHMIN-NEXT:    fsh fa0, 0(sp)
 ; RV64IFDZFHMIN-NEXT:    lbu a0, 11(sp)
-; RV64IFDZFHMIN-NEXT:    lbu a1, 1(sp)
-; RV64IFDZFHMIN-NEXT:    andi a0, a0, 128
-; RV64IFDZFHMIN-NEXT:    andi a1, a1, 127
-; RV64IFDZFHMIN-NEXT:    or a0, a1, a0
-; RV64IFDZFHMIN-NEXT:    sb a0, 1(sp)
-; RV64IFDZFHMIN-NEXT:    flh fa0, 0(sp)
+; RV64IFDZFHMIN-NEXT:    fmv.x.h a1, fa0
+; RV64IFDZFHMIN-NEXT:    slli a1, a1, 49
+; RV64IFDZFHMIN-NEXT:    andi a2, a0, 128
+; RV64IFDZFHMIN-NEXT:    srli a0, a1, 49
+; RV64IFDZFHMIN-NEXT:    beqz a2, .LBB4_2
+; RV64IFDZFHMIN-NEXT:  # %bb.1:
+; RV64IFDZFHMIN-NEXT:    lui a1, 1048568
+; RV64IFDZFHMIN-NEXT:    or a0, a0, a1
+; RV64IFDZFHMIN-NEXT:  .LBB4_2:
+; RV64IFDZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IFDZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IFDZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV64IFDZFHMIN-NEXT:    addi sp, sp, 16
 ; RV64IFDZFHMIN-NEXT:    ret
   %c = fptrunc float %b to half
@@ -642,17 +647,22 @@ define half @fold_demote_h_d(half %a, double %b) nounwind {
 ; RV32IFZFHMIN-LABEL: fold_demote_h_d:
 ; RV32IFZFHMIN:       # %bb.0:
 ; RV32IFZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IFZFHMIN-NEXT:    fsh fa0, 8(sp)
 ; RV32IFZFHMIN-NEXT:    srli a1, a1, 16
 ; RV32IFZFHMIN-NEXT:    fmv.h.x fa5, a1
 ; RV32IFZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IFZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV32IFZFHMIN-NEXT:    lbu a1, 13(sp)
-; RV32IFZFHMIN-NEXT:    andi a0, a0, 127
-; RV32IFZFHMIN-NEXT:    andi a1, a1, 128
+; RV32IFZFHMIN-NEXT:    lbu a0, 13(sp)
+; RV32IFZFHMIN-NEXT:    fmv.x.h a1, fa0
+; RV32IFZFHMIN-NEXT:    slli a1, a1, 17
+; RV32IFZFHMIN-NEXT:    andi a2, a0, 128
+; RV32IFZFHMIN-NEXT:    srli a0, a1, 17
+; RV32IFZFHMIN-NEXT:    beqz a2, .LBB5_2
+; RV32IFZFHMIN-NEXT:  # %bb.1:
+; RV32IFZFHMIN-NEXT:    lui a1, 1048568
 ; RV32IFZFHMIN-NEXT:    or a0, a0, a1
-; RV32IFZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IFZFHMIN-NEXT:    flh fa0, 8(sp)
+; RV32IFZFHMIN-NEXT:  .LBB5_2:
+; RV32IFZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IFZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IFZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IFZFHMIN-NEXT:    addi sp, sp, 16
 ; RV32IFZFHMIN-NEXT:    ret
 ;
@@ -660,31 +670,36 @@ define half @fold_demote_h_d(half %a, double %b) nounwind {
 ; RV32IFDZFHMIN:       # %bb.0:
 ; RV32IFDZFHMIN-NEXT:    addi sp, sp, -16
 ; RV32IFDZFHMIN-NEXT:    fsd fa1, 8(sp)
-; RV32IFDZFHMIN-NEXT:    fsh fa0, 4(sp)
 ; RV32IFDZFHMIN-NEXT:    lbu a0, 15(sp)
-; RV32IFDZFHMIN-NEXT:    lbu a1, 5(sp)
-; RV32IFDZFHMIN-NEXT:    andi a0, a0, 128
-; RV32IFDZFHMIN-NEXT:    andi a1, a1, 127
-; RV32IFDZFHMIN-NEXT:    or a0, a1, a0
-; RV32IFDZFHMIN-NEXT:    sb a0, 5(sp)
-; RV32IFDZFHMIN-NEXT:    flh fa0, 4(sp)
+; RV32IFDZFHMIN-NEXT:    fmv.x.h a1, fa0
+; RV32IFDZFHMIN-NEXT:    slli a1, a1, 17
+; RV32IFDZFHMIN-NEXT:    andi a2, a0, 128
+; RV32IFDZFHMIN-NEXT:    srli a0, a1, 17
+; RV32IFDZFHMIN-NEXT:    beqz a2, .LBB5_2
+; RV32IFDZFHMIN-NEXT:  # %bb.1:
+; RV32IFDZFHMIN-NEXT:    lui a1, 1048568
+; RV32IFDZFHMIN-NEXT:    or a0, a0, a1
+; RV32IFDZFHMIN-NEXT:  .LBB5_2:
+; RV32IFDZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IFDZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IFDZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IFDZFHMIN-NEXT:    addi sp, sp, 16
 ; RV32IFDZFHMIN-NEXT:    ret
 ;
 ; RV64IFDZFHMIN-LABEL: fold_demote_h_d:
 ; RV64IFDZFHMIN:       # %bb.0:
-; RV64IFDZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IFDZFHMIN-NEXT:    fsh fa0, 8(sp)
-; RV64IFDZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IFDZFHMIN-NEXT:    andi a0, a0, 127
+; RV64IFDZFHMIN-NEXT:    fmv.x.h a0, fa0
+; RV64IFDZFHMIN-NEXT:    slli a0, a0, 49
 ; RV64IFDZFHMIN-NEXT:    fmv.x.d a1, fa1
-; RV64IFDZFHMIN-NEXT:    srli a1, a1, 63
-; RV64IFDZFHMIN-NEXT:    slli a1, a1, 63
-; RV64IFDZFHMIN-NEXT:    srli a1, a1, 56
+; RV64IFDZFHMIN-NEXT:    srli a0, a0, 49
+; RV64IFDZFHMIN-NEXT:    bgez a1, .LBB5_2
+; RV64IFDZFHMIN-NEXT:  # %bb.1:
+; RV64IFDZFHMIN-NEXT:    lui a1, 1048568
 ; RV64IFDZFHMIN-NEXT:    or a0, a0, a1
-; RV64IFDZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IFDZFHMIN-NEXT:    flh fa0, 8(sp)
-; RV64IFDZFHMIN-NEXT:    addi sp, sp, 16
+; RV64IFDZFHMIN-NEXT:  .LBB5_2:
+; RV64IFDZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IFDZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IFDZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV64IFDZFHMIN-NEXT:    ret
   %c = fptrunc double %b to half
   %t = call half @llvm.copysign.f16(half %a, half %c)

--- a/llvm/test/CodeGen/RISCV/half-arith-strict.ll
+++ b/llvm/test/CodeGen/RISCV/half-arith-strict.ll
@@ -239,83 +239,36 @@ define half @fmsub_h(half %a, half %b, half %c) nounwind strictfp {
 ; CHECK-ZHINX-NEXT:    fmsub.h a0, a0, a1, a2
 ; CHECK-ZHINX-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV32-LABEL: fmsub_h:
-; CHECK-ZFHMIN-RV32:       # %bb.0:
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa2
-; CHECK-ZFHMIN-RV32-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV32-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fsh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    lbu a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV32-NEXT:    sb a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    flh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa4, fa1
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa3, fa0
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV32-NEXT:    ret
+; CHECK-ZFHMIN-LABEL: fmsub_h:
+; CHECK-ZFHMIN:       # %bb.0:
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa2
+; CHECK-ZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECK-ZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECK-ZFHMIN-NEXT:    lui a1, 1048568
+; CHECK-ZFHMIN-NEXT:    xor a0, a0, a1
+; CHECK-ZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa4, fa1
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECK-ZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECK-ZFHMIN-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV64-LABEL: fmsub_h:
-; CHECK-ZFHMIN-RV64:       # %bb.0:
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa2
-; CHECK-ZFHMIN-RV64-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV64-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fsh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    lbu a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV64-NEXT:    sb a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    flh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa4, fa1
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa3, fa0
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV64-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV32-LABEL: fmsub_h:
-; CHECK-ZHINXMIN-RV32:       # %bb.0:
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fadd.s a2, a2, zero
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    sh a2, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lbu a2, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    xori a2, a2, 128
-; CHECK-ZHINXMIN-RV32-NEXT:    sb a2, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lh a2, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV32-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV64-LABEL: fmsub_h:
-; CHECK-ZHINXMIN-RV64:       # %bb.0:
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fadd.s a2, a2, zero
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    sh a2, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lbu a2, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    xori a2, a2, 128
-; CHECK-ZHINXMIN-RV64-NEXT:    sb a2, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lh a2, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV64-NEXT:    ret
+; CHECK-ZHINXMIN-LABEL: fmsub_h:
+; CHECK-ZHINXMIN:       # %bb.0:
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fadd.s a2, a2, zero
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a2, a2
+; CHECK-ZHINXMIN-NEXT:    lui a3, 1048568
+; CHECK-ZHINXMIN-NEXT:    xor a2, a2, a3
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECK-ZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECK-ZHINXMIN-NEXT:    ret
   %c_ = fadd half 0.0, %c ; avoid negation using xor
   %negc = fneg half %c_
   %1 = call half @llvm.experimental.constrained.fma.f16(half %a, half %b, half %negc, metadata !"round.dynamic", metadata !"fpexcept.strict") strictfp
@@ -338,115 +291,46 @@ define half @fnmadd_h(half %a, half %b, half %c) nounwind strictfp {
 ; CHECK-ZHINX-NEXT:    fnmadd.h a0, a0, a1, a2
 ; CHECK-ZHINX-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV32-LABEL: fnmadd_h:
-; CHECK-ZFHMIN-RV32:       # %bb.0:
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa0
-; CHECK-ZFHMIN-RV32-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV32-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fsh fa5, 8(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    lbu a0, 9(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa2
-; CHECK-ZFHMIN-RV32-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV32-NEXT:    sb a0, 9(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    flh fa4, 8(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fsh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    lbu a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV32-NEXT:    sb a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    flh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa3, fa1
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa4, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fmadd.s fa5, fa4, fa3, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV32-NEXT:    ret
+; CHECK-ZFHMIN-LABEL: fnmadd_h:
+; CHECK-ZFHMIN:       # %bb.0:
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa0
+; CHECK-ZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECK-ZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa3, fa2
+; CHECK-ZFHMIN-NEXT:    fadd.s fa4, fa3, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa4, fa4
+; CHECK-ZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECK-ZFHMIN-NEXT:    lui a1, 1048568
+; CHECK-ZFHMIN-NEXT:    xor a0, a0, a1
+; CHECK-ZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECK-ZFHMIN-NEXT:    fmv.x.h a0, fa4
+; CHECK-ZFHMIN-NEXT:    xor a0, a0, a1
+; CHECK-ZFHMIN-NEXT:    fmv.h.x fa4, a0
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa4, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa3, fa1
+; CHECK-ZFHMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECK-ZFHMIN-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV64-LABEL: fnmadd_h:
-; CHECK-ZFHMIN-RV64:       # %bb.0:
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa0
-; CHECK-ZFHMIN-RV64-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV64-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fsh fa5, 0(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    lbu a0, 1(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa2
-; CHECK-ZFHMIN-RV64-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV64-NEXT:    sb a0, 1(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    flh fa4, 0(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fsh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    lbu a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV64-NEXT:    sb a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    flh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa3, fa1
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa4, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fmadd.s fa5, fa4, fa3, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV64-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV32-LABEL: fnmadd_h:
-; CHECK-ZHINXMIN-RV32:       # %bb.0:
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    fadd.s a0, a0, zero
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    sh a0, 8(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lbu a0, 9(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fadd.s a2, a2, zero
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZHINXMIN-RV32-NEXT:    sb a0, 9(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lh a0, 8(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    sh a2, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lbu a2, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    xori a2, a2, 128
-; CHECK-ZHINXMIN-RV32-NEXT:    sb a2, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lh a2, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV32-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV64-LABEL: fnmadd_h:
-; CHECK-ZHINXMIN-RV64:       # %bb.0:
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    fadd.s a0, a0, zero
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    sh a0, 0(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lbu a0, 1(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fadd.s a2, a2, zero
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZHINXMIN-RV64-NEXT:    sb a0, 1(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lh a0, 0(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    sh a2, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lbu a2, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    xori a2, a2, 128
-; CHECK-ZHINXMIN-RV64-NEXT:    sb a2, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lh a2, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV64-NEXT:    ret
+; CHECK-ZHINXMIN-LABEL: fnmadd_h:
+; CHECK-ZHINXMIN:       # %bb.0:
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECK-ZHINXMIN-NEXT:    fadd.s a0, a0, zero
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fadd.s a2, a2, zero
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a2, a2
+; CHECK-ZHINXMIN-NEXT:    lui a3, 1048568
+; CHECK-ZHINXMIN-NEXT:    xor a0, a0, a3
+; CHECK-ZHINXMIN-NEXT:    xor a2, a2, a3
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECK-ZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECK-ZHINXMIN-NEXT:    ret
   %a_ = fadd half 0.0, %a
   %c_ = fadd half 0.0, %c
   %nega = fneg half %a_
@@ -471,115 +355,46 @@ define half @fnmadd_h_2(half %a, half %b, half %c) nounwind strictfp {
 ; CHECK-ZHINX-NEXT:    fnmadd.h a0, a1, a0, a2
 ; CHECK-ZHINX-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV32-LABEL: fnmadd_h_2:
-; CHECK-ZFHMIN-RV32:       # %bb.0:
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa1
-; CHECK-ZFHMIN-RV32-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV32-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fsh fa5, 8(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    lbu a0, 9(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa2
-; CHECK-ZFHMIN-RV32-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV32-NEXT:    sb a0, 9(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    flh fa4, 8(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fsh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    lbu a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV32-NEXT:    sb a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    flh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa3, fa0
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa4, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV32-NEXT:    ret
+; CHECK-ZFHMIN-LABEL: fnmadd_h_2:
+; CHECK-ZFHMIN:       # %bb.0:
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa1
+; CHECK-ZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECK-ZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa3, fa2
+; CHECK-ZFHMIN-NEXT:    fadd.s fa4, fa3, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa4, fa4
+; CHECK-ZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECK-ZFHMIN-NEXT:    lui a1, 1048568
+; CHECK-ZFHMIN-NEXT:    xor a0, a0, a1
+; CHECK-ZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECK-ZFHMIN-NEXT:    fmv.x.h a0, fa4
+; CHECK-ZFHMIN-NEXT:    xor a0, a0, a1
+; CHECK-ZFHMIN-NEXT:    fmv.h.x fa4, a0
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa4, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECK-ZFHMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECK-ZFHMIN-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV64-LABEL: fnmadd_h_2:
-; CHECK-ZFHMIN-RV64:       # %bb.0:
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa1
-; CHECK-ZFHMIN-RV64-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV64-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fsh fa5, 0(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    lbu a0, 1(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa2
-; CHECK-ZFHMIN-RV64-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV64-NEXT:    sb a0, 1(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    flh fa4, 0(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fsh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    lbu a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV64-NEXT:    sb a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    flh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa3, fa0
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa4, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV64-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV32-LABEL: fnmadd_h_2:
-; CHECK-ZHINXMIN-RV32:       # %bb.0:
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    fadd.s a1, a1, zero
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    sh a1, 8(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lbu a1, 9(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fadd.s a2, a2, zero
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    xori a1, a1, 128
-; CHECK-ZHINXMIN-RV32-NEXT:    sb a1, 9(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lh a1, 8(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    sh a2, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lbu a2, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    xori a2, a2, 128
-; CHECK-ZHINXMIN-RV32-NEXT:    sb a2, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lh a2, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV32-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV64-LABEL: fnmadd_h_2:
-; CHECK-ZHINXMIN-RV64:       # %bb.0:
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    fadd.s a1, a1, zero
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    sh a1, 0(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lbu a1, 1(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fadd.s a2, a2, zero
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    xori a1, a1, 128
-; CHECK-ZHINXMIN-RV64-NEXT:    sb a1, 1(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lh a1, 0(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    sh a2, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lbu a2, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    xori a2, a2, 128
-; CHECK-ZHINXMIN-RV64-NEXT:    sb a2, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lh a2, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV64-NEXT:    ret
+; CHECK-ZHINXMIN-LABEL: fnmadd_h_2:
+; CHECK-ZHINXMIN:       # %bb.0:
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECK-ZHINXMIN-NEXT:    fadd.s a1, a1, zero
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a1, a1
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fadd.s a2, a2, zero
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a2, a2
+; CHECK-ZHINXMIN-NEXT:    lui a3, 1048568
+; CHECK-ZHINXMIN-NEXT:    xor a1, a1, a3
+; CHECK-ZHINXMIN-NEXT:    xor a2, a2, a3
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECK-ZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECK-ZHINXMIN-NEXT:    ret
   %b_ = fadd half 0.0, %b
   %c_ = fadd half 0.0, %c
   %negb = fneg half %b_
@@ -602,83 +417,36 @@ define half @fnmsub_h(half %a, half %b, half %c) nounwind strictfp {
 ; CHECK-ZHINX-NEXT:    fnmsub.h a0, a0, a1, a2
 ; CHECK-ZHINX-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV32-LABEL: fnmsub_h:
-; CHECK-ZFHMIN-RV32:       # %bb.0:
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa0
-; CHECK-ZFHMIN-RV32-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV32-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fsh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    lbu a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV32-NEXT:    sb a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    flh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa4, fa2
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa3, fa1
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fmadd.s fa5, fa5, fa3, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV32-NEXT:    ret
+; CHECK-ZFHMIN-LABEL: fnmsub_h:
+; CHECK-ZFHMIN:       # %bb.0:
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa0
+; CHECK-ZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECK-ZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECK-ZFHMIN-NEXT:    lui a1, 1048568
+; CHECK-ZFHMIN-NEXT:    xor a0, a0, a1
+; CHECK-ZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa4, fa2
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa3, fa1
+; CHECK-ZFHMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECK-ZFHMIN-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV64-LABEL: fnmsub_h:
-; CHECK-ZFHMIN-RV64:       # %bb.0:
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa0
-; CHECK-ZFHMIN-RV64-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV64-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fsh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    lbu a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV64-NEXT:    sb a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    flh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa4, fa2
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa3, fa1
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fmadd.s fa5, fa5, fa3, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV64-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV32-LABEL: fnmsub_h:
-; CHECK-ZHINXMIN-RV32:       # %bb.0:
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    fadd.s a0, a0, zero
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    sh a0, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lbu a0, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZHINXMIN-RV32-NEXT:    sb a0, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lh a0, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV32-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV64-LABEL: fnmsub_h:
-; CHECK-ZHINXMIN-RV64:       # %bb.0:
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    fadd.s a0, a0, zero
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    sh a0, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lbu a0, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZHINXMIN-RV64-NEXT:    sb a0, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lh a0, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV64-NEXT:    ret
+; CHECK-ZHINXMIN-LABEL: fnmsub_h:
+; CHECK-ZHINXMIN:       # %bb.0:
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECK-ZHINXMIN-NEXT:    fadd.s a0, a0, zero
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECK-ZHINXMIN-NEXT:    lui a3, 1048568
+; CHECK-ZHINXMIN-NEXT:    xor a0, a0, a3
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECK-ZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECK-ZHINXMIN-NEXT:    ret
   %a_ = fadd half 0.0, %a
   %nega = fneg half %a_
   %1 = call half @llvm.experimental.constrained.fma.f16(half %nega, half %b, half %c, metadata !"round.dynamic", metadata !"fpexcept.strict") strictfp
@@ -699,85 +467,43 @@ define half @fnmsub_h_2(half %a, half %b, half %c) nounwind strictfp {
 ; CHECK-ZHINX-NEXT:    fnmsub.h a0, a1, a0, a2
 ; CHECK-ZHINX-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV32-LABEL: fnmsub_h_2:
-; CHECK-ZFHMIN-RV32:       # %bb.0:
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa1
-; CHECK-ZFHMIN-RV32-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV32-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fsh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    lbu a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV32-NEXT:    sb a0, 13(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    flh fa5, 12(sp)
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa4, fa2
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa3, fa0
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    fmadd.s fa5, fa3, fa5, fa4
-; CHECK-ZFHMIN-RV32-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV32-NEXT:    ret
+; CHECK-ZFHMIN-LABEL: fnmsub_h_2:
+; CHECK-ZFHMIN:       # %bb.0:
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa1
+; CHECK-ZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECK-ZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECK-ZFHMIN-NEXT:    lui a1, 1048568
+; CHECK-ZFHMIN-NEXT:    xor a0, a0, a1
+; CHECK-ZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa4, fa2
+; CHECK-ZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECK-ZFHMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
+; CHECK-ZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECK-ZFHMIN-NEXT:    ret
 ;
-; CHECK-ZFHMIN-RV64-LABEL: fnmsub_h_2:
-; CHECK-ZFHMIN-RV64:       # %bb.0:
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa1
-; CHECK-ZFHMIN-RV64-NEXT:    fmv.w.x fa4, zero
-; CHECK-ZFHMIN-RV64-NEXT:    fadd.s fa5, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fsh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    lbu a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    xori a0, a0, 128
-; CHECK-ZFHMIN-RV64-NEXT:    sb a0, 9(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    flh fa5, 8(sp)
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa4, fa2
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa3, fa0
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.s.h fa5, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    fmadd.s fa5, fa3, fa5, fa4
-; CHECK-ZFHMIN-RV64-NEXT:    fcvt.h.s fa0, fa5
-; CHECK-ZFHMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZFHMIN-RV64-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV32-LABEL: fnmsub_h_2:
-; CHECK-ZHINXMIN-RV32:       # %bb.0:
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    fadd.s a1, a1, zero
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    sh a1, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lbu a1, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    xori a1, a1, 128
-; CHECK-ZHINXMIN-RV32-NEXT:    sb a1, 13(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    lh a1, 12(sp)
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV32-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV32-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV32-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV32-NEXT:    ret
-;
-; CHECK-ZHINXMIN-RV64-LABEL: fnmsub_h_2:
-; CHECK-ZHINXMIN-RV64:       # %bb.0:
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, -16
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    fadd.s a1, a1, zero
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    sh a1, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lbu a1, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    xori a1, a1, 128
-; CHECK-ZHINXMIN-RV64-NEXT:    sb a1, 9(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    lh a1, 8(sp)
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a2, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.s.h a1, a1
-; CHECK-ZHINXMIN-RV64-NEXT:    fmadd.s a0, a0, a1, a2
-; CHECK-ZHINXMIN-RV64-NEXT:    fcvt.h.s a0, a0
-; CHECK-ZHINXMIN-RV64-NEXT:    addi sp, sp, 16
-; CHECK-ZHINXMIN-RV64-NEXT:    ret
+; CHECK-ZHINXMIN-LABEL: fnmsub_h_2:
+; CHECK-ZHINXMIN:       # %bb.0:
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECK-ZHINXMIN-NEXT:    fadd.s a1, a1, zero
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a1, a1
+; CHECK-ZHINXMIN-NEXT:    lui a3, 1048568
+; CHECK-ZHINXMIN-NEXT:    xor a1, a1, a3
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECK-ZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECK-ZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECK-ZHINXMIN-NEXT:    ret
   %b_ = fadd half 0.0, %b
   %negb = fneg half %b_
   %1 = call half @llvm.experimental.constrained.fma.f16(half %a, half %negb, half %c, metadata !"round.dynamic", metadata !"fpexcept.strict") strictfp
   ret half %1
 }
+;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
+; CHECK-ZFHMIN-RV32: {{.*}}
+; CHECK-ZFHMIN-RV64: {{.*}}
+; CHECK-ZHINXMIN-RV32: {{.*}}
+; CHECK-ZHINXMIN-RV64: {{.*}}

--- a/llvm/test/CodeGen/RISCV/half-arith.ll
+++ b/llvm/test/CodeGen/RISCV/half-arith.ll
@@ -444,14 +444,19 @@ define half @fsgnj_s(half %a, half %b) nounwind {
 ; RV32IZFHMIN:       # %bb.0:
 ; RV32IZFHMIN-NEXT:    addi sp, sp, -16
 ; RV32IZFHMIN-NEXT:    fsh fa1, 12(sp)
-; RV32IZFHMIN-NEXT:    fsh fa0, 8(sp)
 ; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    lbu a1, 9(sp)
-; RV32IZFHMIN-NEXT:    andi a0, a0, 128
-; RV32IZFHMIN-NEXT:    andi a1, a1, 127
-; RV32IZFHMIN-NEXT:    or a0, a1, a0
-; RV32IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFHMIN-NEXT:    flh fa0, 8(sp)
+; RV32IZFHMIN-NEXT:    fmv.x.h a1, fa0
+; RV32IZFHMIN-NEXT:    slli a1, a1, 17
+; RV32IZFHMIN-NEXT:    andi a2, a0, 128
+; RV32IZFHMIN-NEXT:    srli a0, a1, 17
+; RV32IZFHMIN-NEXT:    beqz a2, .LBB5_2
+; RV32IZFHMIN-NEXT:  # %bb.1:
+; RV32IZFHMIN-NEXT:    lui a1, 1048568
+; RV32IZFHMIN-NEXT:    or a0, a0, a1
+; RV32IZFHMIN-NEXT:  .LBB5_2:
+; RV32IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFHMIN-NEXT:    ret
 ;
@@ -459,14 +464,19 @@ define half @fsgnj_s(half %a, half %b) nounwind {
 ; RV64IZFHMIN:       # %bb.0:
 ; RV64IZFHMIN-NEXT:    addi sp, sp, -16
 ; RV64IZFHMIN-NEXT:    fsh fa1, 8(sp)
-; RV64IZFHMIN-NEXT:    fsh fa0, 0(sp)
 ; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    lbu a1, 1(sp)
-; RV64IZFHMIN-NEXT:    andi a0, a0, 128
-; RV64IZFHMIN-NEXT:    andi a1, a1, 127
-; RV64IZFHMIN-NEXT:    or a0, a1, a0
-; RV64IZFHMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFHMIN-NEXT:    flh fa0, 0(sp)
+; RV64IZFHMIN-NEXT:    fmv.x.h a1, fa0
+; RV64IZFHMIN-NEXT:    slli a1, a1, 49
+; RV64IZFHMIN-NEXT:    andi a2, a0, 128
+; RV64IZFHMIN-NEXT:    srli a0, a1, 49
+; RV64IZFHMIN-NEXT:    beqz a2, .LBB5_2
+; RV64IZFHMIN-NEXT:  # %bb.1:
+; RV64IZFHMIN-NEXT:    lui a1, 1048568
+; RV64IZFHMIN-NEXT:    or a0, a0, a1
+; RV64IZFHMIN-NEXT:  .LBB5_2:
+; RV64IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV64IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFHMIN-NEXT:    ret
 ;
@@ -474,14 +484,17 @@ define half @fsgnj_s(half %a, half %b) nounwind {
 ; RV32IZHINXMIN:       # %bb.0:
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
 ; RV32IZHINXMIN-NEXT:    sh a1, 12(sp)
-; RV32IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV32IZHINXMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV32IZHINXMIN-NEXT:    andi a0, a0, 128
-; RV32IZHINXMIN-NEXT:    andi a1, a1, 127
-; RV32IZHINXMIN-NEXT:    or a0, a1, a0
-; RV32IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 8(sp)
+; RV32IZHINXMIN-NEXT:    lbu a1, 13(sp)
+; RV32IZHINXMIN-NEXT:    slli a0, a0, 17
+; RV32IZHINXMIN-NEXT:    andi a1, a1, 128
+; RV32IZHINXMIN-NEXT:    srli a0, a0, 17
+; RV32IZHINXMIN-NEXT:    beqz a1, .LBB5_2
+; RV32IZHINXMIN-NEXT:  # %bb.1:
+; RV32IZHINXMIN-NEXT:    lui a1, 1048568
+; RV32IZHINXMIN-NEXT:    or a0, a0, a1
+; RV32IZHINXMIN-NEXT:  .LBB5_2:
+; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV32IZHINXMIN-NEXT:    ret
 ;
@@ -489,14 +502,17 @@ define half @fsgnj_s(half %a, half %b) nounwind {
 ; RV64IZHINXMIN:       # %bb.0:
 ; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
 ; RV64IZHINXMIN-NEXT:    sh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    sh a0, 0(sp)
-; RV64IZHINXMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 1(sp)
-; RV64IZHINXMIN-NEXT:    andi a0, a0, 128
-; RV64IZHINXMIN-NEXT:    andi a1, a1, 127
-; RV64IZHINXMIN-NEXT:    or a0, a1, a0
-; RV64IZHINXMIN-NEXT:    sb a0, 1(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 0(sp)
+; RV64IZHINXMIN-NEXT:    lbu a1, 9(sp)
+; RV64IZHINXMIN-NEXT:    slli a0, a0, 49
+; RV64IZHINXMIN-NEXT:    andi a1, a1, 128
+; RV64IZHINXMIN-NEXT:    srli a0, a0, 49
+; RV64IZHINXMIN-NEXT:    beqz a1, .LBB5_2
+; RV64IZHINXMIN-NEXT:  # %bb.1:
+; RV64IZHINXMIN-NEXT:    lui a1, 1048568
+; RV64IZHINXMIN-NEXT:    or a0, a0, a1
+; RV64IZHINXMIN-NEXT:  .LBB5_2:
+; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV64IZHINXMIN-NEXT:    ret
   %1 = call half @llvm.copysign.f16(half %a, half %b)
@@ -582,73 +598,31 @@ define i32 @fneg_s(half %a, half %b) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 32
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fneg_s:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa5
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa4, 12(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
-; RV32IZFHMIN-NEXT:    feq.s a0, fa5, fa4
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fneg_s:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa0
+; CHECKIZFHMIN-NEXT:    fadd.s fa5, fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa4, a0
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    feq.s a0, fa5, fa4
+; CHECKIZFHMIN-NEXT:    ret
 ;
-; RV64IZFHMIN-LABEL: fneg_s:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa5
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa4, 8(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
-; RV64IZFHMIN-NEXT:    feq.s a0, fa5, fa4
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
-;
-; RV32IZHINXMIN-LABEL: fneg_s:
-; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fadd.s a0, a0, a0
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    sh a0, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV32IZHINXMIN-NEXT:    sb a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a1, 12(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    feq.s a0, a0, a1
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV32IZHINXMIN-NEXT:    ret
-;
-; RV64IZHINXMIN-LABEL: fneg_s:
-; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fadd.s a0, a0, a0
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV64IZHINXMIN-NEXT:    sb a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    feq.s a0, a0, a1
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV64IZHINXMIN-NEXT:    ret
+; CHECKIZHINXMIN-LABEL: fneg_s:
+; CHECKIZHINXMIN:       # %bb.0:
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fadd.s a0, a0, a0
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    lui a1, 1048568
+; CHECKIZHINXMIN-NEXT:    xor a1, a0, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    feq.s a0, a0, a1
+; CHECKIZHINXMIN-NEXT:    ret
   %1 = fadd half %a, %a
   %2 = fneg half %1
   %3 = fcmp oeq half %1, %2
@@ -756,45 +730,57 @@ define half @fsgnjn_s(half %a, half %b) nounwind {
 ; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa0
 ; RV32IZFHMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 4(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 5(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 5(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 4(sp)
-; RV32IZFHMIN-NEXT:    fsh fa0, 8(sp)
+; RV32IZFHMIN-NEXT:    fmv.x.h a1, fa5
+; RV32IZFHMIN-NEXT:    lui a0, 1048568
+; RV32IZFHMIN-NEXT:    xor a1, a1, a0
+; RV32IZFHMIN-NEXT:    fmv.h.x fa5, a1
 ; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 9(sp)
 ; RV32IZFHMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZFHMIN-NEXT:    andi a0, a0, 127
-; RV32IZFHMIN-NEXT:    andi a1, a1, 128
-; RV32IZFHMIN-NEXT:    or a0, a0, a1
-; RV32IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFHMIN-NEXT:    flh fa0, 8(sp)
+; RV32IZFHMIN-NEXT:    fmv.x.h a2, fa0
+; RV32IZFHMIN-NEXT:    slli a2, a2, 17
+; RV32IZFHMIN-NEXT:    andi a3, a1, 128
+; RV32IZFHMIN-NEXT:    srli a1, a2, 17
+; RV32IZFHMIN-NEXT:    bnez a3, .LBB7_2
+; RV32IZFHMIN-NEXT:  # %bb.1:
+; RV32IZFHMIN-NEXT:    fmv.h.x fa5, a1
+; RV32IZFHMIN-NEXT:    j .LBB7_3
+; RV32IZFHMIN-NEXT:  .LBB7_2:
+; RV32IZFHMIN-NEXT:    or a0, a1, a0
+; RV32IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IZFHMIN-NEXT:  .LBB7_3:
+; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFHMIN-NEXT:    ret
 ;
 ; RV64IZFHMIN-LABEL: fsgnjn_s:
 ; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -32
+; RV64IZFHMIN-NEXT:    addi sp, sp, -16
 ; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa1
 ; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa0
 ; RV64IZFHMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; RV64IZFHMIN-NEXT:    fmv.x.h a1, fa5
+; RV64IZFHMIN-NEXT:    lui a0, 1048568
+; RV64IZFHMIN-NEXT:    xor a1, a1, a0
+; RV64IZFHMIN-NEXT:    fmv.h.x fa5, a1
 ; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    fsh fa0, 16(sp)
-; RV64IZFHMIN-NEXT:    fsh fa5, 24(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 17(sp)
-; RV64IZFHMIN-NEXT:    lbu a1, 25(sp)
-; RV64IZFHMIN-NEXT:    andi a0, a0, 127
-; RV64IZFHMIN-NEXT:    andi a1, a1, 128
-; RV64IZFHMIN-NEXT:    or a0, a0, a1
-; RV64IZFHMIN-NEXT:    sb a0, 17(sp)
-; RV64IZFHMIN-NEXT:    flh fa0, 16(sp)
-; RV64IZFHMIN-NEXT:    addi sp, sp, 32
+; RV64IZFHMIN-NEXT:    lbu a1, 9(sp)
+; RV64IZFHMIN-NEXT:    fmv.x.h a2, fa0
+; RV64IZFHMIN-NEXT:    slli a2, a2, 49
+; RV64IZFHMIN-NEXT:    andi a3, a1, 128
+; RV64IZFHMIN-NEXT:    srli a1, a2, 49
+; RV64IZFHMIN-NEXT:    bnez a3, .LBB7_2
+; RV64IZFHMIN-NEXT:  # %bb.1:
+; RV64IZFHMIN-NEXT:    fmv.h.x fa5, a1
+; RV64IZFHMIN-NEXT:    j .LBB7_3
+; RV64IZFHMIN-NEXT:  .LBB7_2:
+; RV64IZFHMIN-NEXT:    or a0, a1, a0
+; RV64IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IZFHMIN-NEXT:  .LBB7_3:
+; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; RV64IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFHMIN-NEXT:    ret
 ;
 ; RV32IZHINXMIN-LABEL: fsgnjn_s:
@@ -803,46 +789,44 @@ define half @fsgnjn_s(half %a, half %b) nounwind {
 ; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a0
 ; RV32IZHINXMIN-NEXT:    fadd.s a1, a2, a1
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV32IZHINXMIN-NEXT:    sh a1, 4(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 5(sp)
-; RV32IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV32IZHINXMIN-NEXT:    sb a1, 5(sp)
-; RV32IZHINXMIN-NEXT:    lh a1, 4(sp)
-; RV32IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV32IZHINXMIN-NEXT:    sh a1, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    andi a0, a0, 127
-; RV32IZHINXMIN-NEXT:    andi a1, a1, 128
+; RV32IZHINXMIN-NEXT:    fcvt.h.s a2, a1
+; RV32IZHINXMIN-NEXT:    lui a1, 1048568
+; RV32IZHINXMIN-NEXT:    xor a2, a2, a1
+; RV32IZHINXMIN-NEXT:    sh a2, 12(sp)
+; RV32IZHINXMIN-NEXT:    lbu a2, 13(sp)
+; RV32IZHINXMIN-NEXT:    slli a0, a0, 17
+; RV32IZHINXMIN-NEXT:    andi a2, a2, 128
+; RV32IZHINXMIN-NEXT:    srli a0, a0, 17
+; RV32IZHINXMIN-NEXT:    beqz a2, .LBB7_2
+; RV32IZHINXMIN-NEXT:  # %bb.1:
 ; RV32IZHINXMIN-NEXT:    or a0, a0, a1
-; RV32IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 8(sp)
+; RV32IZHINXMIN-NEXT:  .LBB7_2:
+; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV32IZHINXMIN-NEXT:    ret
 ;
 ; RV64IZHINXMIN-LABEL: fsgnjn_s:
 ; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -32
+; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
 ; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a0
 ; RV64IZHINXMIN-NEXT:    fadd.s a1, a2, a1
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV64IZHINXMIN-NEXT:    sh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV64IZHINXMIN-NEXT:    sb a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    sh a0, 16(sp)
-; RV64IZHINXMIN-NEXT:    sh a1, 24(sp)
-; RV64IZHINXMIN-NEXT:    lbu a0, 17(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 25(sp)
-; RV64IZHINXMIN-NEXT:    andi a0, a0, 127
-; RV64IZHINXMIN-NEXT:    andi a1, a1, 128
+; RV64IZHINXMIN-NEXT:    fcvt.h.s a2, a1
+; RV64IZHINXMIN-NEXT:    lui a1, 1048568
+; RV64IZHINXMIN-NEXT:    xor a2, a2, a1
+; RV64IZHINXMIN-NEXT:    sh a2, 8(sp)
+; RV64IZHINXMIN-NEXT:    lbu a2, 9(sp)
+; RV64IZHINXMIN-NEXT:    slli a0, a0, 49
+; RV64IZHINXMIN-NEXT:    andi a2, a2, 128
+; RV64IZHINXMIN-NEXT:    srli a0, a0, 49
+; RV64IZHINXMIN-NEXT:    beqz a2, .LBB7_2
+; RV64IZHINXMIN-NEXT:  # %bb.1:
 ; RV64IZHINXMIN-NEXT:    or a0, a0, a1
-; RV64IZHINXMIN-NEXT:    sb a0, 17(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 16(sp)
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 32
+; RV64IZHINXMIN-NEXT:  .LBB7_2:
+; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV64IZHINXMIN-NEXT:    ret
   %1 = fadd half %a, %b
   %2 = fneg half %1
@@ -945,78 +929,62 @@ define half @fabs_s(half %a, half %b) nounwind {
 ;
 ; RV32IZFHMIN-LABEL: fabs_s:
 ; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
 ; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa1
 ; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa0
 ; RV32IZFHMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    andi a0, a0, 127
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa4, 12(sp)
+; RV32IZFHMIN-NEXT:    fmv.x.h a0, fa5
+; RV32IZFHMIN-NEXT:    slli a0, a0, 17
+; RV32IZFHMIN-NEXT:    srli a0, a0, 17
+; RV32IZFHMIN-NEXT:    fmv.h.x fa4, a0
 ; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
 ; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
 ; RV32IZFHMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFHMIN-NEXT:    ret
 ;
 ; RV64IZFHMIN-LABEL: fabs_s:
 ; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
 ; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa1
 ; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa0
 ; RV64IZFHMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    andi a0, a0, 127
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa4, 8(sp)
+; RV64IZFHMIN-NEXT:    fmv.x.h a0, fa5
+; RV64IZFHMIN-NEXT:    slli a0, a0, 49
+; RV64IZFHMIN-NEXT:    srli a0, a0, 49
+; RV64IZFHMIN-NEXT:    fmv.h.x fa4, a0
 ; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
 ; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
 ; RV64IZFHMIN-NEXT:    fadd.s fa5, fa4, fa5
 ; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFHMIN-NEXT:    ret
 ;
 ; RV32IZHINXMIN-LABEL: fabs_s:
 ; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
 ; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
 ; RV32IZHINXMIN-NEXT:    fadd.s a0, a0, a1
 ; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    sh a0, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    andi a1, a1, 127
-; RV32IZHINXMIN-NEXT:    sb a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a1, 12(sp)
+; RV32IZHINXMIN-NEXT:    slli a1, a0, 17
+; RV32IZHINXMIN-NEXT:    srli a1, a1, 17
 ; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
 ; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV32IZHINXMIN-NEXT:    fadd.s a0, a1, a0
 ; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV32IZHINXMIN-NEXT:    ret
 ;
 ; RV64IZHINXMIN-LABEL: fabs_s:
 ; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
 ; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
 ; RV64IZHINXMIN-NEXT:    fadd.s a0, a0, a1
 ; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    andi a1, a1, 127
-; RV64IZHINXMIN-NEXT:    sb a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a1, 8(sp)
+; RV64IZHINXMIN-NEXT:    slli a1, a0, 49
+; RV64IZHINXMIN-NEXT:    srli a1, a1, 49
 ; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
 ; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV64IZHINXMIN-NEXT:    fadd.s a0, a1, a0
 ; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV64IZHINXMIN-NEXT:    ret
   %1 = fadd half %a, %b
   %2 = call half @llvm.fabs.f16(half %1)
@@ -1394,83 +1362,36 @@ define half @fmsub_s(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fmsub_s:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV32IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fmsub_s:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa2
+; CHECKIZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECKIZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa1
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECKIZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECKIZFHMIN-NEXT:    ret
 ;
-; RV64IZFHMIN-LABEL: fmsub_s:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV64IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
-;
-; RV32IZHINXMIN-LABEL: fmsub_s:
-; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fadd.s a2, a2, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a2, a2
-; RV32IZHINXMIN-NEXT:    sh a2, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a2, 13(sp)
-; RV32IZHINXMIN-NEXT:    xori a2, a2, 128
-; RV32IZHINXMIN-NEXT:    sb a2, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a2, 12(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV32IZHINXMIN-NEXT:    ret
-;
-; RV64IZHINXMIN-LABEL: fmsub_s:
-; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fadd.s a2, a2, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a2, a2
-; RV64IZHINXMIN-NEXT:    sh a2, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a2, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a2, a2, 128
-; RV64IZHINXMIN-NEXT:    sb a2, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a2, 8(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV64IZHINXMIN-NEXT:    ret
+; CHECKIZHINXMIN-LABEL: fmsub_s:
+; CHECKIZHINXMIN:       # %bb.0:
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fadd.s a2, a2, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a2, a2
+; CHECKIZHINXMIN-NEXT:    lui a3, 1048568
+; CHECKIZHINXMIN-NEXT:    xor a2, a2, a3
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    ret
   %c_ = fadd half 0.0, %c ; avoid negation using xor
   %negc = fsub half -0.0, %c_
   %1 = call half @llvm.fma.f16(half %a, half %b, half %negc)
@@ -1609,115 +1530,46 @@ define half @fnmadd_s(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fnmadd_s:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV32IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFHMIN-NEXT:    flh fa4, 8(sp)
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa1
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
-; RV32IZFHMIN-NEXT:    fmadd.s fa5, fa4, fa3, fa5
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fnmadd_s:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa0
+; CHECKIZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECKIZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa2
+; CHECKIZFHMIN-NEXT:    fadd.s fa4, fa3, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa4, fa4
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa4
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa4, a0
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa1
+; CHECKIZFHMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECKIZFHMIN-NEXT:    ret
 ;
-; RV64IZFHMIN-LABEL: fnmadd_s:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV64IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 0(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 1(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFHMIN-NEXT:    flh fa4, 0(sp)
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa1
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
-; RV64IZFHMIN-NEXT:    fmadd.s fa5, fa4, fa3, fa5
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
-;
-; RV32IZHINXMIN-LABEL: fnmadd_s:
-; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fadd.s a0, a0, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV32IZHINXMIN-NEXT:    lbu a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fadd.s a2, a2, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a2, a2
-; RV32IZHINXMIN-NEXT:    xori a0, a0, 128
-; RV32IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 8(sp)
-; RV32IZHINXMIN-NEXT:    sh a2, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a2, 13(sp)
-; RV32IZHINXMIN-NEXT:    xori a2, a2, 128
-; RV32IZHINXMIN-NEXT:    sb a2, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a2, 12(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV32IZHINXMIN-NEXT:    ret
-;
-; RV64IZHINXMIN-LABEL: fnmadd_s:
-; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fadd.s a0, a0, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    sh a0, 0(sp)
-; RV64IZHINXMIN-NEXT:    lbu a0, 1(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fadd.s a2, a2, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a2, a2
-; RV64IZHINXMIN-NEXT:    xori a0, a0, 128
-; RV64IZHINXMIN-NEXT:    sb a0, 1(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 0(sp)
-; RV64IZHINXMIN-NEXT:    sh a2, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a2, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a2, a2, 128
-; RV64IZHINXMIN-NEXT:    sb a2, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a2, 8(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV64IZHINXMIN-NEXT:    ret
+; CHECKIZHINXMIN-LABEL: fnmadd_s:
+; CHECKIZHINXMIN:       # %bb.0:
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fadd.s a0, a0, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fadd.s a2, a2, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a2, a2
+; CHECKIZHINXMIN-NEXT:    lui a3, 1048568
+; CHECKIZHINXMIN-NEXT:    xor a0, a0, a3
+; CHECKIZHINXMIN-NEXT:    xor a2, a2, a3
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    ret
   %a_ = fadd half 0.0, %a
   %c_ = fadd half 0.0, %c
   %nega = fsub half -0.0, %a_
@@ -1858,115 +1710,46 @@ define half @fnmadd_s_2(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fnmadd_s_2:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa1
-; RV32IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFHMIN-NEXT:    flh fa4, 8(sp)
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
-; RV32IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fnmadd_s_2:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa1
+; CHECKIZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECKIZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa2
+; CHECKIZFHMIN-NEXT:    fadd.s fa4, fa3, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa4, fa4
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa4
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa4, a0
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECKIZFHMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECKIZFHMIN-NEXT:    ret
 ;
-; RV64IZFHMIN-LABEL: fnmadd_s_2:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa1
-; RV64IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 0(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 1(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFHMIN-NEXT:    flh fa4, 0(sp)
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa4
-; RV64IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
-;
-; RV32IZHINXMIN-LABEL: fnmadd_s_2:
-; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV32IZHINXMIN-NEXT:    sh a1, 8(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fadd.s a2, a2, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a2, a2
-; RV32IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV32IZHINXMIN-NEXT:    sb a1, 9(sp)
-; RV32IZHINXMIN-NEXT:    lh a1, 8(sp)
-; RV32IZHINXMIN-NEXT:    sh a2, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a2, 13(sp)
-; RV32IZHINXMIN-NEXT:    xori a2, a2, 128
-; RV32IZHINXMIN-NEXT:    sb a2, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a2, 12(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV32IZHINXMIN-NEXT:    ret
-;
-; RV64IZHINXMIN-LABEL: fnmadd_s_2:
-; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV64IZHINXMIN-NEXT:    sh a1, 0(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 1(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fadd.s a2, a2, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a2, a2
-; RV64IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV64IZHINXMIN-NEXT:    sb a1, 1(sp)
-; RV64IZHINXMIN-NEXT:    lh a1, 0(sp)
-; RV64IZHINXMIN-NEXT:    sh a2, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a2, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a2, a2, 128
-; RV64IZHINXMIN-NEXT:    sb a2, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a2, 8(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV64IZHINXMIN-NEXT:    ret
+; CHECKIZHINXMIN-LABEL: fnmadd_s_2:
+; CHECKIZHINXMIN:       # %bb.0:
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fadd.s a1, a1, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a1, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fadd.s a2, a2, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a2, a2
+; CHECKIZHINXMIN-NEXT:    lui a3, 1048568
+; CHECKIZHINXMIN-NEXT:    xor a1, a1, a3
+; CHECKIZHINXMIN-NEXT:    xor a2, a2, a3
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    ret
   %b_ = fadd half 0.0, %b
   %c_ = fadd half 0.0, %c
   %negb = fsub half -0.0, %b_
@@ -2071,37 +1854,18 @@ define half @fnmadd_s_3(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fnmadd_s_3:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV32IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa0, 12(sp)
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
-;
-; RV64IZFHMIN-LABEL: fnmadd_s_3:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV64IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa0, 8(sp)
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fnmadd_s_3:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa2
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa1
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECKIZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa0, a0
+; CHECKIZFHMIN-NEXT:    ret
 ;
 ; CHECKIZHINXMIN-LABEL: fnmadd_s_3:
 ; CHECKIZHINXMIN:       # %bb.0:
@@ -2212,37 +1976,18 @@ define half @fnmadd_nsz(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fnmadd_nsz:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV32IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa0, 12(sp)
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
-;
-; RV64IZFHMIN-LABEL: fnmadd_nsz:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV64IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa0, 8(sp)
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fnmadd_nsz:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa2
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa1
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECKIZFHMIN-NEXT:    fmadd.s fa5, fa3, fa4, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa0, a0
+; CHECKIZFHMIN-NEXT:    ret
 ;
 ; CHECKIZHINXMIN-LABEL: fnmadd_nsz:
 ; CHECKIZHINXMIN:       # %bb.0:
@@ -2359,83 +2104,36 @@ define half @fnmsub_s(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fnmsub_s:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV32IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa2
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa1
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fnmsub_s:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa0
+; CHECKIZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECKIZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa2
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa1
+; CHECKIZFHMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECKIZFHMIN-NEXT:    ret
 ;
-; RV64IZFHMIN-LABEL: fnmsub_s:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV64IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa2
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa1
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fmadd.s fa5, fa5, fa3, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
-;
-; RV32IZHINXMIN-LABEL: fnmsub_s:
-; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fadd.s a0, a0, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    sh a0, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZHINXMIN-NEXT:    xori a0, a0, 128
-; RV32IZHINXMIN-NEXT:    sb a0, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 12(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV32IZHINXMIN-NEXT:    ret
-;
-; RV64IZHINXMIN-LABEL: fnmsub_s:
-; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fadd.s a0, a0, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a0, a0, 128
-; RV64IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 8(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV64IZHINXMIN-NEXT:    ret
+; CHECKIZHINXMIN-LABEL: fnmsub_s:
+; CHECKIZHINXMIN:       # %bb.0:
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fadd.s a0, a0, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    lui a3, 1048568
+; CHECKIZHINXMIN-NEXT:    xor a0, a0, a3
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    ret
   %a_ = fadd half 0.0, %a
   %nega = fsub half -0.0, %a_
   %1 = call half @llvm.fma.f16(half %nega, half %b, half %c)
@@ -2544,83 +2242,36 @@ define half @fnmsub_s_2(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fnmsub_s_2:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa1
-; RV32IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa2
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fnmsub_s_2:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa1
+; CHECKIZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECKIZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa2
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa0
+; CHECKIZFHMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECKIZFHMIN-NEXT:    ret
 ;
-; RV64IZFHMIN-LABEL: fnmsub_s_2:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa1
-; RV64IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa2
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa0
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fmadd.s fa5, fa3, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
-;
-; RV32IZHINXMIN-LABEL: fnmsub_s_2:
-; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV32IZHINXMIN-NEXT:    sh a1, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV32IZHINXMIN-NEXT:    sb a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a1, 12(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV32IZHINXMIN-NEXT:    ret
-;
-; RV64IZHINXMIN-LABEL: fnmsub_s_2:
-; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV64IZHINXMIN-NEXT:    sh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV64IZHINXMIN-NEXT:    sb a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a2, a2
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV64IZHINXMIN-NEXT:    ret
+; CHECKIZHINXMIN-LABEL: fnmsub_s_2:
+; CHECKIZHINXMIN:       # %bb.0:
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fadd.s a1, a1, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a1, a1
+; CHECKIZHINXMIN-NEXT:    lui a3, 1048568
+; CHECKIZHINXMIN-NEXT:    xor a1, a1, a3
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fmadd.s a0, a0, a1, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    ret
   %b_ = fadd half 0.0, %b
   %negb = fsub half -0.0, %b_
   %1 = call half @llvm.fma.f16(half %a, half %negb, half %c)
@@ -3020,119 +2671,54 @@ define half @fnmadd_s_contract(half %a, half %b, half %c) nounwind {
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
 ;
-; RV32IZFHMIN-LABEL: fnmadd_s_contract:
-; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV32IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa1
-; RV32IZFHMIN-NEXT:    fadd.s fa3, fa3, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa3, fa3
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa3, fa3
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fmul.s fa5, fa5, fa3
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV32IZFHMIN-NEXT:    xori a0, a0, 128
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa3, 12(sp)
-; RV32IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa3
-; RV32IZFHMIN-NEXT:    fsub.s fa5, fa4, fa5
-; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
-; RV32IZFHMIN-NEXT:    ret
+; CHECKIZFHMIN-LABEL: fnmadd_s_contract:
+; CHECKIZFHMIN:       # %bb.0:
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa0
+; CHECKIZFHMIN-NEXT:    fmv.w.x fa4, zero
+; CHECKIZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa1
+; CHECKIZFHMIN-NEXT:    fadd.s fa3, fa3, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa3, fa3
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa2, fa2
+; CHECKIZFHMIN-NEXT:    fadd.s fa4, fa2, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa4, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa3, fa3
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmul.s fa5, fa5, fa3
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; CHECKIZFHMIN-NEXT:    fmv.x.h a0, fa5
+; CHECKIZFHMIN-NEXT:    lui a1, 1048568
+; CHECKIZFHMIN-NEXT:    xor a0, a0, a1
+; CHECKIZFHMIN-NEXT:    fmv.h.x fa5, a0
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; CHECKIZFHMIN-NEXT:    fcvt.s.h fa4, fa4
+; CHECKIZFHMIN-NEXT:    fsub.s fa5, fa5, fa4
+; CHECKIZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; CHECKIZFHMIN-NEXT:    ret
 ;
-; RV64IZFHMIN-LABEL: fnmadd_s_contract:
-; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa0
-; RV64IZFHMIN-NEXT:    fmv.w.x fa4, zero
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa1
-; RV64IZFHMIN-NEXT:    fadd.s fa3, fa3, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa3, fa3
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa3, fa3
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fmul.s fa5, fa5, fa3
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa2
-; RV64IZFHMIN-NEXT:    xori a0, a0, 128
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa3, 8(sp)
-; RV64IZFHMIN-NEXT:    fadd.s fa5, fa5, fa4
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa3
-; RV64IZFHMIN-NEXT:    fsub.s fa5, fa4, fa5
-; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
-; RV64IZFHMIN-NEXT:    ret
-;
-; RV32IZHINXMIN-LABEL: fnmadd_s_contract:
-; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fadd.s a0, a0, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fmul.s a0, a0, a1
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    sh a0, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a2
-; RV32IZHINXMIN-NEXT:    xori a0, a0, 128
-; RV32IZHINXMIN-NEXT:    sb a0, 13(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 12(sp)
-; RV32IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV32IZHINXMIN-NEXT:    fsub.s a0, a0, a1
-; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV32IZHINXMIN-NEXT:    ret
-;
-; RV64IZHINXMIN-LABEL: fnmadd_s_contract:
-; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fadd.s a0, a0, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fmul.s a0, a0, a1
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV64IZHINXMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a2
-; RV64IZHINXMIN-NEXT:    xori a0, a0, 128
-; RV64IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 8(sp)
-; RV64IZHINXMIN-NEXT:    fadd.s a1, a1, zero
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a1, a1
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
-; RV64IZHINXMIN-NEXT:    fsub.s a0, a0, a1
-; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
-; RV64IZHINXMIN-NEXT:    ret
+; CHECKIZHINXMIN-LABEL: fnmadd_s_contract:
+; CHECKIZHINXMIN:       # %bb.0:
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fadd.s a0, a0, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fadd.s a1, a1, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a1, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a2, a2
+; CHECKIZHINXMIN-NEXT:    fadd.s a2, a2, zero
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a2, a2
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fmul.s a0, a0, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    lui a1, 1048568
+; CHECKIZHINXMIN-NEXT:    xor a0, a0, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; CHECKIZHINXMIN-NEXT:    fcvt.s.h a1, a2
+; CHECKIZHINXMIN-NEXT:    fsub.s a0, a0, a1
+; CHECKIZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; CHECKIZHINXMIN-NEXT:    ret
   %a_ = fadd half 0.0, %a ; avoid negation using xor
   %b_ = fadd half 0.0, %b ; avoid negation using xor
   %c_ = fadd half 0.0, %c ; avoid negation using xor
@@ -3369,19 +2955,22 @@ define half @fsgnjx_f16(half %x, half %y) nounwind {
 ; RV32IZFHMIN-LABEL: fsgnjx_f16:
 ; RV32IZFHMIN:       # %bb.0:
 ; RV32IZFHMIN-NEXT:    addi sp, sp, -16
+; RV32IZFHMIN-NEXT:    fsh fa0, 12(sp)
+; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
+; RV32IZFHMIN-NEXT:    andi a0, a0, 128
+; RV32IZFHMIN-NEXT:    bnez a0, .LBB23_2
+; RV32IZFHMIN-NEXT:  # %bb.1:
 ; RV32IZFHMIN-NEXT:    lui a0, %hi(.LCPI23_0)
 ; RV32IZFHMIN-NEXT:    flh fa5, %lo(.LCPI23_0)(a0)
-; RV32IZFHMIN-NEXT:    fsh fa0, 12(sp)
-; RV32IZFHMIN-NEXT:    fsh fa5, 8(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    lbu a1, 9(sp)
-; RV32IZFHMIN-NEXT:    andi a0, a0, 128
-; RV32IZFHMIN-NEXT:    andi a1, a1, 127
-; RV32IZFHMIN-NEXT:    or a0, a1, a0
-; RV32IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
 ; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IZFHMIN-NEXT:    j .LBB23_3
+; RV32IZFHMIN-NEXT:  .LBB23_2:
+; RV32IZFHMIN-NEXT:    lui a0, 784384
+; RV32IZFHMIN-NEXT:    fmv.w.x fa5, a0
+; RV32IZFHMIN-NEXT:  .LBB23_3:
+; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
 ; RV32IZFHMIN-NEXT:    fmul.s fa5, fa5, fa4
 ; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IZFHMIN-NEXT:    addi sp, sp, 16
@@ -3390,19 +2979,22 @@ define half @fsgnjx_f16(half %x, half %y) nounwind {
 ; RV64IZFHMIN-LABEL: fsgnjx_f16:
 ; RV64IZFHMIN:       # %bb.0:
 ; RV64IZFHMIN-NEXT:    addi sp, sp, -16
+; RV64IZFHMIN-NEXT:    fsh fa0, 8(sp)
+; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
+; RV64IZFHMIN-NEXT:    andi a0, a0, 128
+; RV64IZFHMIN-NEXT:    bnez a0, .LBB23_2
+; RV64IZFHMIN-NEXT:  # %bb.1:
 ; RV64IZFHMIN-NEXT:    lui a0, %hi(.LCPI23_0)
 ; RV64IZFHMIN-NEXT:    flh fa5, %lo(.LCPI23_0)(a0)
-; RV64IZFHMIN-NEXT:    fsh fa0, 8(sp)
-; RV64IZFHMIN-NEXT:    fsh fa5, 0(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    lbu a1, 1(sp)
-; RV64IZFHMIN-NEXT:    andi a0, a0, 128
-; RV64IZFHMIN-NEXT:    andi a1, a1, 127
-; RV64IZFHMIN-NEXT:    or a0, a1, a0
-; RV64IZFHMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 0(sp)
-; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
 ; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IZFHMIN-NEXT:    j .LBB23_3
+; RV64IZFHMIN-NEXT:  .LBB23_2:
+; RV64IZFHMIN-NEXT:    lui a0, 784384
+; RV64IZFHMIN-NEXT:    fmv.w.x fa5, a0
+; RV64IZFHMIN-NEXT:  .LBB23_3:
+; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
+; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IZFHMIN-NEXT:    fcvt.s.h fa4, fa1
 ; RV64IZFHMIN-NEXT:    fmul.s fa5, fa5, fa4
 ; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV64IZFHMIN-NEXT:    addi sp, sp, 16
@@ -3411,19 +3003,21 @@ define half @fsgnjx_f16(half %x, half %y) nounwind {
 ; RV32IZHINXMIN-LABEL: fsgnjx_f16:
 ; RV32IZHINXMIN:       # %bb.0:
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    lui a2, %hi(.LCPI23_0)
-; RV32IZHINXMIN-NEXT:    lh a2, %lo(.LCPI23_0)(a2)
 ; RV32IZHINXMIN-NEXT:    sh a0, 12(sp)
-; RV32IZHINXMIN-NEXT:    sh a2, 8(sp)
 ; RV32IZHINXMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZHINXMIN-NEXT:    lbu a2, 9(sp)
 ; RV32IZHINXMIN-NEXT:    andi a0, a0, 128
-; RV32IZHINXMIN-NEXT:    andi a2, a2, 127
-; RV32IZHINXMIN-NEXT:    or a0, a2, a0
-; RV32IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 8(sp)
-; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; RV32IZHINXMIN-NEXT:    bnez a0, .LBB23_2
+; RV32IZHINXMIN-NEXT:  # %bb.1:
+; RV32IZHINXMIN-NEXT:    lui a0, %hi(.LCPI23_0)
+; RV32IZHINXMIN-NEXT:    lh a0, %lo(.LCPI23_0)(a0)
 ; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV32IZHINXMIN-NEXT:    j .LBB23_3
+; RV32IZHINXMIN-NEXT:  .LBB23_2:
+; RV32IZHINXMIN-NEXT:    lui a0, 784384
+; RV32IZHINXMIN-NEXT:  .LBB23_3:
+; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV32IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV32IZHINXMIN-NEXT:    fmul.s a0, a0, a1
 ; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
@@ -3432,19 +3026,21 @@ define half @fsgnjx_f16(half %x, half %y) nounwind {
 ; RV64IZHINXMIN-LABEL: fsgnjx_f16:
 ; RV64IZHINXMIN:       # %bb.0:
 ; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV64IZHINXMIN-NEXT:    lui a2, %hi(.LCPI23_0)
-; RV64IZHINXMIN-NEXT:    lh a2, %lo(.LCPI23_0)(a2)
 ; RV64IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV64IZHINXMIN-NEXT:    sh a2, 0(sp)
 ; RV64IZHINXMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZHINXMIN-NEXT:    lbu a2, 1(sp)
 ; RV64IZHINXMIN-NEXT:    andi a0, a0, 128
-; RV64IZHINXMIN-NEXT:    andi a2, a2, 127
-; RV64IZHINXMIN-NEXT:    or a0, a2, a0
-; RV64IZHINXMIN-NEXT:    sb a0, 1(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 0(sp)
-; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
+; RV64IZHINXMIN-NEXT:    bnez a0, .LBB23_2
+; RV64IZHINXMIN-NEXT:  # %bb.1:
+; RV64IZHINXMIN-NEXT:    lui a0, %hi(.LCPI23_0)
+; RV64IZHINXMIN-NEXT:    lh a0, %lo(.LCPI23_0)(a0)
 ; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV64IZHINXMIN-NEXT:    j .LBB23_3
+; RV64IZHINXMIN-NEXT:  .LBB23_2:
+; RV64IZHINXMIN-NEXT:    lui a0, 784384
+; RV64IZHINXMIN-NEXT:  .LBB23_3:
+; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV64IZHINXMIN-NEXT:    fcvt.s.h a1, a1
 ; RV64IZHINXMIN-NEXT:    fmul.s a0, a0, a1
 ; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV64IZHINXMIN-NEXT:    addi sp, sp, 16

--- a/llvm/test/CodeGen/RISCV/half-bitmanip-dagcombines.ll
+++ b/llvm/test/CodeGen/RISCV/half-bitmanip-dagcombines.ll
@@ -208,87 +208,83 @@ define half @fcopysign_fneg(half %a, half %b) nounwind {
 ; RV32IZFHMIN-LABEL: fcopysign_fneg:
 ; RV32IZFHMIN:       # %bb.0:
 ; RV32IZFHMIN-NEXT:    addi sp, sp, -16
+; RV32IZFHMIN-NEXT:    lui a2, 1048568
+; RV32IZFHMIN-NEXT:    xor a1, a1, a2
 ; RV32IZFHMIN-NEXT:    fmv.h.x fa5, a1
-; RV32IZFHMIN-NEXT:    fsh fa5, 4(sp)
-; RV32IZFHMIN-NEXT:    lbu a1, 5(sp)
-; RV32IZFHMIN-NEXT:    xori a1, a1, 128
-; RV32IZFHMIN-NEXT:    sb a1, 5(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 4(sp)
-; RV32IZFHMIN-NEXT:    fmv.h.x fa4, a0
-; RV32IZFHMIN-NEXT:    fsh fa4, 8(sp)
 ; RV32IZFHMIN-NEXT:    fsh fa5, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 9(sp)
 ; RV32IZFHMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZFHMIN-NEXT:    andi a0, a0, 127
+; RV32IZFHMIN-NEXT:    slli a0, a0, 17
 ; RV32IZFHMIN-NEXT:    andi a1, a1, 128
-; RV32IZFHMIN-NEXT:    or a0, a0, a1
-; RV32IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFHMIN-NEXT:    flh fa5, 8(sp)
+; RV32IZFHMIN-NEXT:    srli a0, a0, 17
+; RV32IZFHMIN-NEXT:    beqz a1, .LBB2_2
+; RV32IZFHMIN-NEXT:  # %bb.1:
+; RV32IZFHMIN-NEXT:    or a0, a0, a2
+; RV32IZFHMIN-NEXT:  .LBB2_2:
+; RV32IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
 ; RV32IZFHMIN-NEXT:    fmv.x.h a0, fa5
 ; RV32IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFHMIN-NEXT:    ret
 ;
 ; RV64IZFHMIN-LABEL: fcopysign_fneg:
 ; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -32
+; RV64IZFHMIN-NEXT:    addi sp, sp, -16
+; RV64IZFHMIN-NEXT:    lui a2, 1048568
+; RV64IZFHMIN-NEXT:    xor a1, a1, a2
 ; RV64IZFHMIN-NEXT:    fmv.h.x fa5, a1
 ; RV64IZFHMIN-NEXT:    fsh fa5, 8(sp)
 ; RV64IZFHMIN-NEXT:    lbu a1, 9(sp)
-; RV64IZFHMIN-NEXT:    xori a1, a1, 128
-; RV64IZFHMIN-NEXT:    sb a1, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 8(sp)
-; RV64IZFHMIN-NEXT:    fmv.h.x fa4, a0
-; RV64IZFHMIN-NEXT:    fsh fa4, 16(sp)
-; RV64IZFHMIN-NEXT:    fsh fa5, 24(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 17(sp)
-; RV64IZFHMIN-NEXT:    lbu a1, 25(sp)
-; RV64IZFHMIN-NEXT:    andi a0, a0, 127
+; RV64IZFHMIN-NEXT:    slli a0, a0, 49
 ; RV64IZFHMIN-NEXT:    andi a1, a1, 128
-; RV64IZFHMIN-NEXT:    or a0, a0, a1
-; RV64IZFHMIN-NEXT:    sb a0, 17(sp)
-; RV64IZFHMIN-NEXT:    flh fa5, 16(sp)
+; RV64IZFHMIN-NEXT:    srli a0, a0, 49
+; RV64IZFHMIN-NEXT:    beqz a1, .LBB2_2
+; RV64IZFHMIN-NEXT:  # %bb.1:
+; RV64IZFHMIN-NEXT:    or a0, a0, a2
+; RV64IZFHMIN-NEXT:  .LBB2_2:
+; RV64IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IZFHMIN-NEXT:    fcvt.h.s fa5, fa5
 ; RV64IZFHMIN-NEXT:    fmv.x.h a0, fa5
-; RV64IZFHMIN-NEXT:    addi sp, sp, 32
+; RV64IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFHMIN-NEXT:    ret
 ;
 ; RV32IZHINXMIN-LABEL: fcopysign_fneg:
 ; RV32IZHINXMIN:       # %bb.0:
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
-; RV32IZHINXMIN-NEXT:    sh a1, 4(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 5(sp)
-; RV32IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV32IZHINXMIN-NEXT:    sb a1, 5(sp)
-; RV32IZHINXMIN-NEXT:    lh a1, 4(sp)
-; RV32IZHINXMIN-NEXT:    sh a0, 8(sp)
+; RV32IZHINXMIN-NEXT:    lui a2, 1048568
+; RV32IZHINXMIN-NEXT:    xor a1, a1, a2
 ; RV32IZHINXMIN-NEXT:    sh a1, 12(sp)
-; RV32IZHINXMIN-NEXT:    lbu a0, 9(sp)
 ; RV32IZHINXMIN-NEXT:    lbu a1, 13(sp)
-; RV32IZHINXMIN-NEXT:    andi a0, a0, 127
+; RV32IZHINXMIN-NEXT:    slli a0, a0, 17
 ; RV32IZHINXMIN-NEXT:    andi a1, a1, 128
-; RV32IZHINXMIN-NEXT:    or a0, a0, a1
-; RV32IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 8(sp)
+; RV32IZHINXMIN-NEXT:    srli a0, a0, 17
+; RV32IZHINXMIN-NEXT:    beqz a1, .LBB2_2
+; RV32IZHINXMIN-NEXT:  # %bb.1:
+; RV32IZHINXMIN-NEXT:    or a0, a0, a2
+; RV32IZHINXMIN-NEXT:  .LBB2_2:
+; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV32IZHINXMIN-NEXT:    ret
 ;
 ; RV64IZHINXMIN-LABEL: fcopysign_fneg:
 ; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    addi sp, sp, -32
+; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
+; RV64IZHINXMIN-NEXT:    lui a2, 1048568
+; RV64IZHINXMIN-NEXT:    xor a1, a1, a2
 ; RV64IZHINXMIN-NEXT:    sh a1, 8(sp)
 ; RV64IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    xori a1, a1, 128
-; RV64IZHINXMIN-NEXT:    sb a1, 9(sp)
-; RV64IZHINXMIN-NEXT:    lh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    sh a0, 16(sp)
-; RV64IZHINXMIN-NEXT:    sh a1, 24(sp)
-; RV64IZHINXMIN-NEXT:    lbu a0, 17(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 25(sp)
-; RV64IZHINXMIN-NEXT:    andi a0, a0, 127
+; RV64IZHINXMIN-NEXT:    slli a0, a0, 49
 ; RV64IZHINXMIN-NEXT:    andi a1, a1, 128
-; RV64IZHINXMIN-NEXT:    or a0, a0, a1
-; RV64IZHINXMIN-NEXT:    sb a0, 17(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 16(sp)
-; RV64IZHINXMIN-NEXT:    addi sp, sp, 32
+; RV64IZHINXMIN-NEXT:    srli a0, a0, 49
+; RV64IZHINXMIN-NEXT:    beqz a1, .LBB2_2
+; RV64IZHINXMIN-NEXT:  # %bb.1:
+; RV64IZHINXMIN-NEXT:    or a0, a0, a2
+; RV64IZHINXMIN-NEXT:  .LBB2_2:
+; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
+; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV64IZHINXMIN-NEXT:    ret
   %1 = fneg half %b
   %2 = call half @llvm.copysign.f16(half %a, half %1)

--- a/llvm/test/CodeGen/RISCV/half-intrinsics.ll
+++ b/llvm/test/CodeGen/RISCV/half-intrinsics.ll
@@ -1823,24 +1823,18 @@ define half @fabs_f16(half %a) nounwind {
 ;
 ; RV32IZFHMIN-LABEL: fabs_f16:
 ; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    addi sp, sp, -16
-; RV32IZFHMIN-NEXT:    fsh fa0, 12(sp)
-; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    andi a0, a0, 127
-; RV32IZFHMIN-NEXT:    sb a0, 13(sp)
-; RV32IZFHMIN-NEXT:    flh fa0, 12(sp)
-; RV32IZFHMIN-NEXT:    addi sp, sp, 16
+; RV32IZFHMIN-NEXT:    fmv.x.h a0, fa0
+; RV32IZFHMIN-NEXT:    slli a0, a0, 17
+; RV32IZFHMIN-NEXT:    srli a0, a0, 17
+; RV32IZFHMIN-NEXT:    fmv.h.x fa0, a0
 ; RV32IZFHMIN-NEXT:    ret
 ;
 ; RV64IZFHMIN-LABEL: fabs_f16:
 ; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    addi sp, sp, -16
-; RV64IZFHMIN-NEXT:    fsh fa0, 8(sp)
-; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    andi a0, a0, 127
-; RV64IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV64IZFHMIN-NEXT:    flh fa0, 8(sp)
-; RV64IZFHMIN-NEXT:    addi sp, sp, 16
+; RV64IZFHMIN-NEXT:    fmv.x.h a0, fa0
+; RV64IZFHMIN-NEXT:    slli a0, a0, 49
+; RV64IZFHMIN-NEXT:    srli a0, a0, 49
+; RV64IZFHMIN-NEXT:    fmv.h.x fa0, a0
 ; RV64IZFHMIN-NEXT:    ret
 ;
 ; RV32IZHINXMIN-LABEL: fabs_f16:
@@ -2078,14 +2072,19 @@ define half @copysign_f16(half %a, half %b) nounwind {
 ; RV32IZFHMIN:       # %bb.0:
 ; RV32IZFHMIN-NEXT:    addi sp, sp, -16
 ; RV32IZFHMIN-NEXT:    fsh fa1, 12(sp)
-; RV32IZFHMIN-NEXT:    fsh fa0, 8(sp)
 ; RV32IZFHMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZFHMIN-NEXT:    lbu a1, 9(sp)
-; RV32IZFHMIN-NEXT:    andi a0, a0, 128
-; RV32IZFHMIN-NEXT:    andi a1, a1, 127
-; RV32IZFHMIN-NEXT:    or a0, a1, a0
-; RV32IZFHMIN-NEXT:    sb a0, 9(sp)
-; RV32IZFHMIN-NEXT:    flh fa0, 8(sp)
+; RV32IZFHMIN-NEXT:    fmv.x.h a1, fa0
+; RV32IZFHMIN-NEXT:    slli a1, a1, 17
+; RV32IZFHMIN-NEXT:    andi a2, a0, 128
+; RV32IZFHMIN-NEXT:    srli a0, a1, 17
+; RV32IZFHMIN-NEXT:    beqz a2, .LBB16_2
+; RV32IZFHMIN-NEXT:  # %bb.1:
+; RV32IZFHMIN-NEXT:    lui a1, 1048568
+; RV32IZFHMIN-NEXT:    or a0, a0, a1
+; RV32IZFHMIN-NEXT:  .LBB16_2:
+; RV32IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV32IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV32IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV32IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV32IZFHMIN-NEXT:    ret
 ;
@@ -2093,14 +2092,19 @@ define half @copysign_f16(half %a, half %b) nounwind {
 ; RV64IZFHMIN:       # %bb.0:
 ; RV64IZFHMIN-NEXT:    addi sp, sp, -16
 ; RV64IZFHMIN-NEXT:    fsh fa1, 8(sp)
-; RV64IZFHMIN-NEXT:    fsh fa0, 0(sp)
 ; RV64IZFHMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZFHMIN-NEXT:    lbu a1, 1(sp)
-; RV64IZFHMIN-NEXT:    andi a0, a0, 128
-; RV64IZFHMIN-NEXT:    andi a1, a1, 127
-; RV64IZFHMIN-NEXT:    or a0, a1, a0
-; RV64IZFHMIN-NEXT:    sb a0, 1(sp)
-; RV64IZFHMIN-NEXT:    flh fa0, 0(sp)
+; RV64IZFHMIN-NEXT:    fmv.x.h a1, fa0
+; RV64IZFHMIN-NEXT:    slli a1, a1, 49
+; RV64IZFHMIN-NEXT:    andi a2, a0, 128
+; RV64IZFHMIN-NEXT:    srli a0, a1, 49
+; RV64IZFHMIN-NEXT:    beqz a2, .LBB16_2
+; RV64IZFHMIN-NEXT:  # %bb.1:
+; RV64IZFHMIN-NEXT:    lui a1, 1048568
+; RV64IZFHMIN-NEXT:    or a0, a0, a1
+; RV64IZFHMIN-NEXT:  .LBB16_2:
+; RV64IZFHMIN-NEXT:    fmv.h.x fa5, a0
+; RV64IZFHMIN-NEXT:    fcvt.s.h fa5, fa5
+; RV64IZFHMIN-NEXT:    fcvt.h.s fa0, fa5
 ; RV64IZFHMIN-NEXT:    addi sp, sp, 16
 ; RV64IZFHMIN-NEXT:    ret
 ;
@@ -2108,14 +2112,17 @@ define half @copysign_f16(half %a, half %b) nounwind {
 ; RV32IZHINXMIN:       # %bb.0:
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, -16
 ; RV32IZHINXMIN-NEXT:    sh a1, 12(sp)
-; RV32IZHINXMIN-NEXT:    sh a0, 8(sp)
-; RV32IZHINXMIN-NEXT:    lbu a0, 13(sp)
-; RV32IZHINXMIN-NEXT:    lbu a1, 9(sp)
-; RV32IZHINXMIN-NEXT:    andi a0, a0, 128
-; RV32IZHINXMIN-NEXT:    andi a1, a1, 127
-; RV32IZHINXMIN-NEXT:    or a0, a1, a0
-; RV32IZHINXMIN-NEXT:    sb a0, 9(sp)
-; RV32IZHINXMIN-NEXT:    lh a0, 8(sp)
+; RV32IZHINXMIN-NEXT:    lbu a1, 13(sp)
+; RV32IZHINXMIN-NEXT:    slli a0, a0, 17
+; RV32IZHINXMIN-NEXT:    andi a1, a1, 128
+; RV32IZHINXMIN-NEXT:    srli a0, a0, 17
+; RV32IZHINXMIN-NEXT:    beqz a1, .LBB16_2
+; RV32IZHINXMIN-NEXT:  # %bb.1:
+; RV32IZHINXMIN-NEXT:    lui a1, 1048568
+; RV32IZHINXMIN-NEXT:    or a0, a0, a1
+; RV32IZHINXMIN-NEXT:  .LBB16_2:
+; RV32IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV32IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV32IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV32IZHINXMIN-NEXT:    ret
 ;
@@ -2123,14 +2130,17 @@ define half @copysign_f16(half %a, half %b) nounwind {
 ; RV64IZHINXMIN:       # %bb.0:
 ; RV64IZHINXMIN-NEXT:    addi sp, sp, -16
 ; RV64IZHINXMIN-NEXT:    sh a1, 8(sp)
-; RV64IZHINXMIN-NEXT:    sh a0, 0(sp)
-; RV64IZHINXMIN-NEXT:    lbu a0, 9(sp)
-; RV64IZHINXMIN-NEXT:    lbu a1, 1(sp)
-; RV64IZHINXMIN-NEXT:    andi a0, a0, 128
-; RV64IZHINXMIN-NEXT:    andi a1, a1, 127
-; RV64IZHINXMIN-NEXT:    or a0, a1, a0
-; RV64IZHINXMIN-NEXT:    sb a0, 1(sp)
-; RV64IZHINXMIN-NEXT:    lh a0, 0(sp)
+; RV64IZHINXMIN-NEXT:    lbu a1, 9(sp)
+; RV64IZHINXMIN-NEXT:    slli a0, a0, 49
+; RV64IZHINXMIN-NEXT:    andi a1, a1, 128
+; RV64IZHINXMIN-NEXT:    srli a0, a0, 49
+; RV64IZHINXMIN-NEXT:    beqz a1, .LBB16_2
+; RV64IZHINXMIN-NEXT:  # %bb.1:
+; RV64IZHINXMIN-NEXT:    lui a1, 1048568
+; RV64IZHINXMIN-NEXT:    or a0, a0, a1
+; RV64IZHINXMIN-NEXT:  .LBB16_2:
+; RV64IZHINXMIN-NEXT:    fcvt.s.h a0, a0
+; RV64IZHINXMIN-NEXT:    fcvt.h.s a0, a0
 ; RV64IZHINXMIN-NEXT:    addi sp, sp, 16
 ; RV64IZHINXMIN-NEXT:    ret
   %1 = call half @llvm.copysign.f16(half %a, half %b)

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fp.ll
@@ -650,165 +650,38 @@ define void @fabs_v6f16(ptr %x) {
 ; ZVFH-NEXT:    vse16.v v8, (a0)
 ; ZVFH-NEXT:    ret
 ;
-; ZVFHMIN-ZFH-RV32-LABEL: fabs_v6f16:
-; ZVFHMIN-ZFH-RV32:       # %bb.0:
-; ZVFHMIN-ZFH-RV32-NEXT:    vsetivli zero, 8, e16, mf2, ta, ma
-; ZVFHMIN-ZFH-RV32-NEXT:    vle16.v v8, (a0)
-; ZVFHMIN-ZFH-RV32-NEXT:    vfwcvt.f.f.v v9, v8
-; ZVFHMIN-ZFH-RV32-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; ZVFHMIN-ZFH-RV32-NEXT:    vfabs.v v8, v9
-; ZVFHMIN-ZFH-RV32-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
-; ZVFHMIN-ZFH-RV32-NEXT:    vfncvt.f.f.w v9, v8
-; ZVFHMIN-ZFH-RV32-NEXT:    addi a1, a0, 8
-; ZVFHMIN-ZFH-RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVFHMIN-ZFH-RV32-NEXT:    vslidedown.vi v8, v9, 2
-; ZVFHMIN-ZFH-RV32-NEXT:    vse32.v v8, (a1)
-; ZVFHMIN-ZFH-RV32-NEXT:    vsetivli zero, 4, e16, mf4, ta, ma
-; ZVFHMIN-ZFH-RV32-NEXT:    vse16.v v9, (a0)
-; ZVFHMIN-ZFH-RV32-NEXT:    ret
+; ZVFHMIN-RV32-LABEL: fabs_v6f16:
+; ZVFHMIN-RV32:       # %bb.0:
+; ZVFHMIN-RV32-NEXT:    vsetivli zero, 8, e16, mf2, ta, ma
+; ZVFHMIN-RV32-NEXT:    vle16.v v8, (a0)
+; ZVFHMIN-RV32-NEXT:    vfwcvt.f.f.v v9, v8
+; ZVFHMIN-RV32-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
+; ZVFHMIN-RV32-NEXT:    vfabs.v v8, v9
+; ZVFHMIN-RV32-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
+; ZVFHMIN-RV32-NEXT:    vfncvt.f.f.w v9, v8
+; ZVFHMIN-RV32-NEXT:    addi a1, a0, 8
+; ZVFHMIN-RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVFHMIN-RV32-NEXT:    vslidedown.vi v8, v9, 2
+; ZVFHMIN-RV32-NEXT:    vse32.v v8, (a1)
+; ZVFHMIN-RV32-NEXT:    vsetivli zero, 4, e16, mf4, ta, ma
+; ZVFHMIN-RV32-NEXT:    vse16.v v9, (a0)
+; ZVFHMIN-RV32-NEXT:    ret
 ;
-; ZVFHMIN-ZFH-RV64-LABEL: fabs_v6f16:
-; ZVFHMIN-ZFH-RV64:       # %bb.0:
-; ZVFHMIN-ZFH-RV64-NEXT:    vsetivli zero, 8, e16, mf2, ta, ma
-; ZVFHMIN-ZFH-RV64-NEXT:    vle16.v v8, (a0)
-; ZVFHMIN-ZFH-RV64-NEXT:    vfwcvt.f.f.v v9, v8
-; ZVFHMIN-ZFH-RV64-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; ZVFHMIN-ZFH-RV64-NEXT:    vfabs.v v8, v9
-; ZVFHMIN-ZFH-RV64-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
-; ZVFHMIN-ZFH-RV64-NEXT:    vfncvt.f.f.w v9, v8
-; ZVFHMIN-ZFH-RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVFHMIN-ZFH-RV64-NEXT:    vse64.v v9, (a0)
-; ZVFHMIN-ZFH-RV64-NEXT:    addi a0, a0, 8
-; ZVFHMIN-ZFH-RV64-NEXT:    vslidedown.vi v8, v9, 2
-; ZVFHMIN-ZFH-RV64-NEXT:    vse32.v v8, (a0)
-; ZVFHMIN-ZFH-RV64-NEXT:    ret
-;
-; ZVFHMIN-ZFHIN-RV32-LABEL: fabs_v6f16:
-; ZVFHMIN-ZFHIN-RV32:       # %bb.0:
-; ZVFHMIN-ZFHIN-RV32-NEXT:    addi sp, sp, -64
-; ZVFHMIN-ZFHIN-RV32-NEXT:    .cfi_def_cfa_offset 64
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vsetivli zero, 8, e16, mf2, ta, ma
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vle16.v v8, (a0)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    mv a1, sp
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vse16.v v8, (a1)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 10(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 36(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 8(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 32(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 6(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 28(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 4(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 24(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 2(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 20(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 0(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 16(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    lbu a1, 37(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV32-NEXT:    sb a1, 37(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    lbu a1, 33(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV32-NEXT:    sb a1, 33(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    lbu a1, 29(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV32-NEXT:    sb a1, 29(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    lbu a1, 25(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV32-NEXT:    sb a1, 25(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    lbu a1, 21(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV32-NEXT:    sb a1, 21(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    lbu a1, 17(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV32-NEXT:    sb a1, 17(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 36(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 58(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 32(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 56(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa5, 28(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 54(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa4, 24(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa4, 52(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa3, 20(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa3, 50(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    flh fa2, 16(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa2, 48(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    addi a1, sp, 48
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vle16.v v8, (a1)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa5, 46(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa4, 44(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa3, 42(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    fsh fa2, 40(sp)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    addi a1, sp, 40
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vsetivli zero, 4, e32, mf2, ta, ma
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vle16.v v9, (a1)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vse16.v v9, (a0)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    addi a0, a0, 8
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vslidedown.vi v8, v8, 2
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVFHMIN-ZFHIN-RV32-NEXT:    vse32.v v8, (a0)
-; ZVFHMIN-ZFHIN-RV32-NEXT:    addi sp, sp, 64
-; ZVFHMIN-ZFHIN-RV32-NEXT:    ret
-;
-; ZVFHMIN-ZFHIN-RV64-LABEL: fabs_v6f16:
-; ZVFHMIN-ZFHIN-RV64:       # %bb.0:
-; ZVFHMIN-ZFHIN-RV64-NEXT:    addi sp, sp, -80
-; ZVFHMIN-ZFHIN-RV64-NEXT:    .cfi_def_cfa_offset 80
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vsetivli zero, 8, e16, mf2, ta, ma
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vle16.v v8, (a0)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    mv a1, sp
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vse16.v v8, (a1)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 10(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 56(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 8(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 48(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 6(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 40(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 4(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 32(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 2(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 24(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 0(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 16(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    lbu a1, 57(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV64-NEXT:    sb a1, 57(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    lbu a1, 49(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV64-NEXT:    sb a1, 49(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    lbu a1, 41(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV64-NEXT:    sb a1, 41(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    lbu a1, 33(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV64-NEXT:    sb a1, 33(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    lbu a1, 25(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV64-NEXT:    sb a1, 25(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    lbu a1, 17(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    andi a1, a1, 127
-; ZVFHMIN-ZFHIN-RV64-NEXT:    sb a1, 17(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 56(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 74(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 48(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 72(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 40(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 70(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 32(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 68(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 24(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 66(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    flh fa5, 16(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    fsh fa5, 64(sp)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    addi a1, sp, 64
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vle16.v v8, (a1)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vse64.v v8, (a0)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    addi a0, a0, 8
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vslidedown.vi v8, v8, 2
-; ZVFHMIN-ZFHIN-RV64-NEXT:    vse32.v v8, (a0)
-; ZVFHMIN-ZFHIN-RV64-NEXT:    addi sp, sp, 80
-; ZVFHMIN-ZFHIN-RV64-NEXT:    ret
+; ZVFHMIN-RV64-LABEL: fabs_v6f16:
+; ZVFHMIN-RV64:       # %bb.0:
+; ZVFHMIN-RV64-NEXT:    vsetivli zero, 8, e16, mf2, ta, ma
+; ZVFHMIN-RV64-NEXT:    vle16.v v8, (a0)
+; ZVFHMIN-RV64-NEXT:    vfwcvt.f.f.v v9, v8
+; ZVFHMIN-RV64-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
+; ZVFHMIN-RV64-NEXT:    vfabs.v v8, v9
+; ZVFHMIN-RV64-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
+; ZVFHMIN-RV64-NEXT:    vfncvt.f.f.w v9, v8
+; ZVFHMIN-RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVFHMIN-RV64-NEXT:    vse64.v v9, (a0)
+; ZVFHMIN-RV64-NEXT:    addi a0, a0, 8
+; ZVFHMIN-RV64-NEXT:    vslidedown.vi v8, v9, 2
+; ZVFHMIN-RV64-NEXT:    vse32.v v8, (a0)
+; ZVFHMIN-RV64-NEXT:    ret
   %a = load <6 x half>, ptr %x
   %b = call <6 x half> @llvm.fabs.v6f16(<6 x half> %a)
   store <6 x half> %b, ptr %x


### PR DESCRIPTION
The LegalizeDAG expansion will go through memory since i16 isn't a legal type. Avoid this by using FMV nodes.