### PR TITLE
[gn build] Add missing llvm-strings dependency to check-lld

### DIFF
--- a/llvm/utils/gn/secondary/lld/test/BUILD.gn
+++ b/llvm/utils/gn/secondary/lld/test/BUILD.gn
@@ -140,6 +140,7 @@ group("test") {
     "//llvm/tools/llvm-pdbutil",
     "//llvm/tools/llvm-profdata",
     "//llvm/tools/llvm-readobj:symlinks",
+    "//llvm/tools/llvm-strings:symlinks",
     "//llvm/tools/llvm-symbolizer:symlinks",
     "//llvm/tools/obj2yaml",
     "//llvm/tools/opt",


### PR DESCRIPTION
This has been required by `lld/test/ELF/zsectionheader.s` since it was added in 5d972c58.