### PR TITLE
[lsan] Fix free(NULL) interception during initialization

### DIFF
--- a/compiler-rt/lib/lsan/lsan_interceptors.cpp
+++ b/compiler-rt/lib/lsan/lsan_interceptors.cpp
@@ -77,6 +77,8 @@ INTERCEPTOR(void*, malloc, uptr size) {
 }
 
 INTERCEPTOR(void, free, void *p) {
+  if (UNLIKELY(!p))
+    return;
   if (DlsymAlloc::PointerIsMine(p))
     return DlsymAlloc::Free(p);
   ENSURE_LSAN_INITED;

--- a/compiler-rt/test/sanitizer_common/TestCases/dlsym_alloc.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/dlsym_alloc.c
@@ -3,9 +3,6 @@
 // FIXME: TSAN does not use DlsymAlloc.
 // UNSUPPORTED: tsan
 
-// FIXME: https://github.com/llvm/llvm-project/pull/106912
-// XFAIL: lsan
-
 #include <stdlib.h>
 
 const char *test() __attribute__((disable_sanitizer_instrumentation)) {


### PR DESCRIPTION
Previously an attempt to free a null pointer during initialization would fail on ENSURE_LSAN_INITED assertion (since a null pointer is not owned by DlsymAlloc).