### PR TITLE
[mlir][EmitC] Remove restrictions on include op

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -730,7 +730,7 @@ def EmitC_ReturnOp : EmitC_Op<"return", [Pure, HasParent<"FuncOp">,
 }
 
 def EmitC_IncludeOp
-    : EmitC_Op<"include", [HasParent<"ModuleOp">]> {
+    : EmitC_Op<"include", []> {
   let summary = "Include operation";
   let description = [{
     The `emitc.include` operation allows to define a source file inclusion via the

--- a/mlir/test/Target/Cpp/common-cpp.mlir
+++ b/mlir/test/Target/Cpp/common-cpp.mlir
@@ -5,6 +5,13 @@ emitc.include "myheader.h"
 // CHECK: #include <myheader.h>
 emitc.include <"myheader.h">
 
+// CHECK: void test_include() {
+func.func @test_include() {
+  // CHECK: #include "myheader.h"
+  emitc.include "myheader.h"
+  return
+}
+
 // CHECK: void test_foo_print() {
 func.func @test_foo_print() {
   // CHECK: [[V1:[^ ]*]] = foo::constant({0, 1});


### PR DESCRIPTION
An `emitc.include` should be usable even though the parent is not a ModuleOp. This requirement is therefore removed.