### PR TITLE
Revert "[RuntimeDyld][Windows] Allocate space for dllimport things."

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
@@ -690,12 +690,9 @@ unsigned RuntimeDyldImpl::computeSectionStubBufSize(const ObjectFile &Obj,
     if (!(RelSecI == Section))
       continue;
 
-    for (const RelocationRef &Reloc : SI->relocations()) {
+    for (const RelocationRef &Reloc : SI->relocations())
       if (relocationNeedsStub(Reloc))
         StubBufSize += StubSize;
-      if (relocationNeedsDLLImportStub(Reloc))
-        StubBufSize = sizeAfterAddingDLLImportStub(StubBufSize);
-    }
   }
 
   // Get section data size and alignment

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
@@ -119,14 +119,4 @@ bool RuntimeDyldCOFF::isCompatibleFile(const object::ObjectFile &Obj) const {
   return Obj.isCOFF();
 }
 
-bool RuntimeDyldCOFF::relocationNeedsDLLImportStub(
-    const RelocationRef &R) const {
-  object::symbol_iterator Symbol = R.getSymbol();
-  Expected<StringRef> TargetNameOrErr = Symbol->getName();
-  if (!TargetNameOrErr)
-    return false;
-
-  return TargetNameOrErr->starts_with(getImportSymbolPrefix());
-}
-
 } // namespace llvm

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
@@ -14,7 +14,6 @@
 #define LLVM_RUNTIME_DYLD_COFF_H
 
 #include "RuntimeDyldImpl.h"
-#include "llvm/Support/MathExtras.h"
 
 namespace llvm {
 
@@ -45,12 +44,6 @@ protected:
                               StringRef Name, bool SetSectionIDMinus1 = false);
 
   static constexpr StringRef getImportSymbolPrefix() { return "__imp_"; }
-
-  bool relocationNeedsDLLImportStub(const RelocationRef &R) const;
-
-  unsigned sizeAfterAddingDLLImportStub(unsigned Size) const {
-    return alignTo(Size, PointerSize) + PointerSize;
-  }
 
 private:
   unsigned PointerSize;

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
@@ -455,16 +455,6 @@ protected:
     return true;    // Conservative answer
   }
 
-  // Return true if the relocation R may require allocating a DLL import stub.
-  virtual bool relocationNeedsDLLImportStub(const RelocationRef &R) const {
-    return false;
-  }
-
-  // Add the size of a DLL import stub to the buffer size
-  virtual unsigned sizeAfterAddingDLLImportStub(unsigned Size) const {
-    return Size;
-  }
-
 public:
   RuntimeDyldImpl(RuntimeDyld::MemoryManager &MemMgr,
                   JITSymbolResolver &Resolver)


### PR DESCRIPTION
Looks like I missed an `override` (maybe that warning was enabled recently?). Will revert and fix.

Reverts llvm/llvm-project#102586
