### PR TITLE
[llvm][Support] Adjust maximum thread name length to the right value for OpenBSD

### DIFF
--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -146,7 +146,7 @@ static constexpr uint32_t get_max_thread_name_length_impl() {
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
   return 16;
 #elif defined(__OpenBSD__)
-  return 32;
+  return 24;
 #else
   return 0;
 #endif


### PR DESCRIPTION
The thread name length is derived from _MAXCOMLEN which is 24.