### PR TITLE
[clang][bytecode] Fix zero-init of first union member

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1235,12 +1235,6 @@ bool Compiler<Emitter>::VisitImplicitValueInitExpr(
     assert(RD);
     if (RD->isInvalidDecl())
       return false;
-    if (RD->isUnion()) {
-      // C++11 [dcl.init]p5: If T is a (possibly cv-qualified) union type, the
-      // object's first non-static named data member is zero-initialized
-      // FIXME
-      return false;
-    }
 
     if (const auto *CXXRD = dyn_cast<CXXRecordDecl>(RD);
         CXXRD && CXXRD->getNumVBases() > 0) {
@@ -3434,6 +3428,8 @@ bool Compiler<Emitter>::visitZeroRecordInitializer(const Record *R,
     if (!this->emitFinishInitPop(E))
       return false;
 
+    // C++11 [dcl.init]p5: If T is a (possibly cv-qualified) union type, the
+    // object's first non-static named data member is zero-initialized
     if (R->isUnion())
       break;
   }

--- a/clang/test/SemaObjC/non-trivial-c-union.m
+++ b/clang/test/SemaObjC/non-trivial-c-union.m
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -fblocks -fobjc-arc -fobjc-runtime-has-weak -I %S/Inputs -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fblocks -fobjc-arc -fobjc-runtime-has-weak -I %S/Inputs -verify -fexperimental-new-constant-interpreter %s
 
 #include "non-trivial-c-union.h"
 


### PR DESCRIPTION
... if done via a ImplicitValueInitExpr.
We were already doing this later in visitZeroRecordInitializer().