### PR TITLE
[CodeGen] Compute call frame sizes instead of storing them in MachineBBs

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -146,12 +146,13 @@ private:
   int Number;
 
   /// The call frame size on entry to this basic block due to call frame setup
-  /// instructions in a predecessor. This is usually zero, unless basic blocks
-  /// are split in the middle of a call sequence.
+  /// instructions in a predecessor. Usually does not contain a value, unless
+  /// basic blocks are split in the middle of a call sequence. Zero-sized call
+  /// frames are possible.
   ///
   /// This information is only maintained until PrologEpilogInserter eliminates
   /// call frame pseudos.
-  unsigned CallFrameSize = 0;
+  std::optional<unsigned> CallFrameSize;
 
   MachineFunction *xParent;
   Instructions Insts;
@@ -1216,9 +1217,17 @@ public:
   void setNumber(int N) { Number = N; }
 
   /// Return the call frame size on entry to this basic block.
-  unsigned getCallFrameSize() const { return CallFrameSize; }
+  std::optional<unsigned> getCallFrameSize() const { return CallFrameSize; }
+
+  /// Return the call frame size on entry to this basic block if it is part of a
+  /// call sequence and 0 otherwise.
+  unsigned getCallFrameSizeOrZero() const { return CallFrameSize.value_or(0); }
+
   /// Set the call frame size on entry to this basic block.
-  void setCallFrameSize(unsigned N) { CallFrameSize = N; }
+  void setCallFrameSize(std::optional<unsigned> N) { CallFrameSize = N; }
+
+  /// Reset the stored call frame size.
+  void clearCallFrameSize() { CallFrameSize.reset(); }
 
   /// Return the MCSymbol for this basic block.
   MCSymbol *getSymbol() const;

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -145,15 +145,6 @@ private:
   const BasicBlock *BB;
   int Number;
 
-  /// The call frame size on entry to this basic block due to call frame setup
-  /// instructions in a predecessor. Usually does not contain a value, unless
-  /// basic blocks are split in the middle of a call sequence. Zero-sized call
-  /// frames are possible.
-  ///
-  /// This information is only maintained until PrologEpilogInserter eliminates
-  /// call frame pseudos.
-  std::optional<unsigned> CallFrameSize;
-
   MachineFunction *xParent;
   Instructions Insts;
 
@@ -1215,19 +1206,6 @@ public:
   /// they're not in a MachineFunction yet, in which case this will return -1.
   int getNumber() const { return Number; }
   void setNumber(int N) { Number = N; }
-
-  /// Return the call frame size on entry to this basic block.
-  std::optional<unsigned> getCallFrameSize() const { return CallFrameSize; }
-
-  /// Return the call frame size on entry to this basic block if it is part of a
-  /// call sequence and 0 otherwise.
-  unsigned getCallFrameSizeOrZero() const { return CallFrameSize.value_or(0); }
-
-  /// Set the call frame size on entry to this basic block.
-  void setCallFrameSize(std::optional<unsigned> N) { CallFrameSize = N; }
-
-  /// Reset the stored call frame size.
-  void clearCallFrameSize() { CallFrameSize.reset(); }
 
   /// Return the MCSymbol for this basic block.
   MCSymbol *getSymbol() const;

--- a/llvm/include/llvm/CodeGen/MachineFrameInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineFrameInfo.h
@@ -26,7 +26,6 @@ class MachineFunction;
 class MachineBasicBlock;
 class BitVector;
 class AllocaInst;
-class MachineFrameSizeInfo;
 class TargetInstrInfo;
 
 /// The CalleeSavedInfo class tracks the information need to locate where a
@@ -283,10 +282,6 @@ private:
   /// class).  This information is important for frame pointer elimination.
   /// It is only valid during and after prolog/epilog code insertion.
   uint64_t MaxCallFrameSize = ~UINT64_C(0);
-
-  /// Call frame sizes for the MachineFunction's MachineBasicBlocks. This is set
-  /// by the MachineFrameSizeInfo constructor and cleared by its destructor.
-  MachineFrameSizeInfo *SizeInfo = nullptr;
 
   /// The number of bytes of callee saved registers that the target wants to
   /// report for the current function in the CodeView S_FRAMEPROC record.
@@ -681,13 +676,6 @@ public:
   }
   void setMaxCallFrameSize(uint64_t S) { MaxCallFrameSize = S; }
 
-  /// Return an object that can be queried for call frame sizes at specific
-  /// locations in the MachineFunction. Constructing a MachineFrameSizeInfo
-  /// object for the MachineFunction automatically makes it available via this
-  /// field during the object's lifetime.
-  MachineFrameSizeInfo *getSizeInfo() const { return SizeInfo; }
-  void setSizeInfo(MachineFrameSizeInfo *SI) { SizeInfo = SI; }
-
   /// Returns how many bytes of callee-saved registers the target pushed in the
   /// prologue. Only used for debug info.
   unsigned getCVBytesOfCalleeSavedRegisters() const {
@@ -863,11 +851,7 @@ public:
 /// MachineBasicBlocks of a MachineFunction based on call frame setup and
 /// destroy pseudo instructions. Usually, no call frame is open at block
 /// boundaries, except if a call sequence has been split into multiple blocks.
-///
-/// Computing this information is deferred until it is queried. Upon
-/// construction, a MachineFrameSizeInfo object registers itself in the
-/// MachineFunction's MachineFrameInfo (and it unregisters when destructed).
-/// While registered, it can be retrieved via MachineFrameInfo::getSizeInfo().
+/// Computing this information is deferred until it is queried.
 ///
 /// This class assumes that call frame instructions are placed properly, i.e.,
 /// every program path hits a frame destroy of equal size after hitting a frame
@@ -875,12 +859,7 @@ public:
 /// frame sequences are not allowed.
 class MachineFrameSizeInfo {
 public:
-  MachineFrameSizeInfo(MachineFunction &MF) : MF(MF) {
-    assert(MF.getFrameInfo().getSizeInfo() == nullptr);
-    MF.getFrameInfo().setSizeInfo(this);
-  }
-
-  ~MachineFrameSizeInfo() { MF.getFrameInfo().setSizeInfo(nullptr); }
+  MachineFrameSizeInfo(MachineFunction &MF) : MF(MF) {}
 
   /// Get the call frame size just before MI. Contains no value if MI is not in
   /// a call sequence. Zero-sized call frames are possible.

--- a/llvm/include/llvm/CodeGen/MachineFrameInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineFrameInfo.h
@@ -26,6 +26,8 @@ class MachineFunction;
 class MachineBasicBlock;
 class BitVector;
 class AllocaInst;
+class MachineFrameSizeInfo;
+class TargetInstrInfo;
 
 /// The CalleeSavedInfo class tracks the information need to locate where a
 /// callee saved register is in the current frame.
@@ -281,6 +283,10 @@ private:
   /// class).  This information is important for frame pointer elimination.
   /// It is only valid during and after prolog/epilog code insertion.
   uint64_t MaxCallFrameSize = ~UINT64_C(0);
+
+  /// Call frame sizes for the MachineFunction's MachineBasicBlocks. This is set
+  /// by the MachineFrameSizeInfo constructor and cleared by its destructor.
+  MachineFrameSizeInfo *SizeInfo = nullptr;
 
   /// The number of bytes of callee saved registers that the target wants to
   /// report for the current function in the CodeView S_FRAMEPROC record.
@@ -675,6 +681,13 @@ public:
   }
   void setMaxCallFrameSize(uint64_t S) { MaxCallFrameSize = S; }
 
+  /// Return an object that can be queried for call frame sizes at specific
+  /// locations in the MachineFunction. Constructing a MachineFrameSizeInfo
+  /// object for the MachineFunction automatically makes it available via this
+  /// field during the object's lifetime.
+  MachineFrameSizeInfo *getSizeInfo() const { return SizeInfo; }
+  void setSizeInfo(MachineFrameSizeInfo *SI) { SizeInfo = SI; }
+
   /// Returns how many bytes of callee-saved registers the target pushed in the
   /// prologue. Only used for debug info.
   unsigned getCVBytesOfCalleeSavedRegisters() const {
@@ -844,6 +857,73 @@ public:
 
   /// dump - Print the function to stderr.
   void dump(const MachineFunction &MF) const;
+};
+
+/// Computes and stores the call frame sizes at the entries and exits of
+/// MachineBasicBlocks of a MachineFunction based on call frame setup and
+/// destroy pseudo instructions. Usually, no call frame is open at block
+/// boundaries, except if a call sequence has been split into multiple blocks.
+///
+/// Computing this information is deferred until it is queried. Upon
+/// construction, a MachineFrameSizeInfo object registers itself in the
+/// MachineFunction's MachineFrameInfo (and it unregisters when destructed).
+/// While registered, it can be retrieved via MachineFrameInfo::getSizeInfo().
+///
+/// This class assumes that call frame instructions are placed properly, i.e.,
+/// every program path hits a frame destroy of equal size after hitting a frame
+/// setup, and a frame setup of equal size before a frame destroy. Nested call
+/// frame sequences are not allowed.
+class MachineFrameSizeInfo {
+public:
+  MachineFrameSizeInfo(MachineFunction &MF) : MF(MF) {
+    assert(MF.getFrameInfo().getSizeInfo() == nullptr);
+    MF.getFrameInfo().setSizeInfo(this);
+  }
+
+  ~MachineFrameSizeInfo() { MF.getFrameInfo().setSizeInfo(nullptr); }
+
+  /// Get the call frame size just before MI. Contains no value if MI is not in
+  /// a call sequence. Zero-sized call frames are possible.
+  std::optional<unsigned> getCallFrameSizeAt(MachineInstr &MI);
+
+  /// Get the call frame size just before MII. Contains no value if MII is not
+  /// in a call sequence. Zero-sized call frames are possible.
+  std::optional<unsigned> getCallFrameSizeAt(MachineBasicBlock &MBB,
+                                             MachineBasicBlock::iterator MII);
+
+  /// Get the call frame size at the entry of MBB. Contains no value if the
+  /// entry of MBB is not in a call sequence. Zero-sized call frames are
+  /// possible. Prefer this over getCallFrameSizeAt(MBB, MBB.begin()).
+  std::optional<unsigned> getCallFrameSizeAtBegin(MachineBasicBlock &MBB);
+
+  /// Get the call frame size at the exit of MBB. Contains no value if the exit
+  /// of MBB is not in a call sequence. Zero-sized call frames are possible.
+  /// Prefer this over getCallFrameSizeAt(MBB, MBB.end()).
+  std::optional<unsigned> getCallFrameSizeAtEnd(MachineBasicBlock &MBB);
+
+private:
+  /// Stores the call frame sizes at the boundaries of a MachineBasicBlock.
+  struct MachineFrameSizeInfoForBB {
+    MachineFrameSizeInfoForBB() = default;
+    MachineFrameSizeInfoForBB(std::optional<unsigned> EntryVal,
+                              std::optional<unsigned> ExitVal)
+        : Entry(EntryVal), Exit(ExitVal) {}
+
+    std::optional<unsigned> Entry;
+    std::optional<unsigned> Exit;
+  };
+
+  /// Compute call frame sizes at the boundaries of each MachineBasicBlock.
+  void computeSizes();
+
+  MachineFunction &MF;
+  const TargetInstrInfo *TII;
+  unsigned FrameSetupOpcode = ~0u;
+  unsigned FrameDestroyOpcode = ~0u;
+  bool HasFrameOpcodes = false;
+  bool HasNoBrokenUpCallSeqs = false;
+  SmallVector<MachineFrameSizeInfoForBB, 8> State;
+  bool IsComputed = false;
 };
 
 } // End llvm namespace

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2265,16 +2265,6 @@ public:
     return false;
   }
 
-  /// Get the call frame size just before MI. Contains no value if MI is not in
-  /// a call sequence. Zero-sized call frames are possible.
-  std::optional<unsigned> getCallFrameSizeAt(MachineInstr &MI) const;
-
-  /// Get the call frame size just before MII. Contains no value if MII is not
-  /// in a call sequence. Zero-sized call frames are possible.
-  std::optional<unsigned>
-  getCallFrameSizeAt(MachineBasicBlock &MBB,
-                     MachineBasicBlock::iterator MII) const;
-
   /// Fills in the necessary MachineOperands to refer to a frame index.
   /// The best way to understand this is to print `asm(""::"m"(x));` after
   /// finalize-isel. Example:

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2269,6 +2269,12 @@ public:
   /// a call sequence. Zero-sized call frames are possible.
   std::optional<unsigned> getCallFrameSizeAt(MachineInstr &MI) const;
 
+  /// Get the call frame size just before MII. Contains no value if MII is not
+  /// in a call sequence. Zero-sized call frames are possible.
+  std::optional<unsigned>
+  getCallFrameSizeAt(MachineBasicBlock &MBB,
+                     MachineBasicBlock::iterator MII) const;
+
   /// Fills in the necessary MachineOperands to refer to a frame index.
   /// The best way to understand this is to print `asm(""::"m"(x));` after
   /// finalize-isel. Example:

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2265,8 +2265,9 @@ public:
     return false;
   }
 
-  // Get the call frame size just before MI.
-  unsigned getCallFrameSizeAt(MachineInstr &MI) const;
+  /// Get the call frame size just before MI. Contains no value if MI is not in
+  /// a call sequence. Zero-sized call frames are possible.
+  std::optional<unsigned> getCallFrameSizeAt(MachineInstr &MI) const;
 
   /// Fills in the necessary MachineOperands to refer to a frame index.
   /// The best way to understand this is to print `asm(""::"m"(x));` after

--- a/llvm/lib/CodeGen/MIRParser/MILexer.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.cpp
@@ -285,7 +285,6 @@ static MIToken::TokenKind getIdentifierKind(StringRef Identifier) {
       .Case("ir-block-address-taken", MIToken::kw_ir_block_address_taken)
       .Case("machine-block-address-taken",
             MIToken::kw_machine_block_address_taken)
-      .Case("call-frame-size", MIToken::kw_call_frame_size)
       .Case("noconvergent", MIToken::kw_noconvergent)
       .Default(MIToken::Identifier);
 }

--- a/llvm/lib/CodeGen/MIRParser/MILexer.h
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.h
@@ -139,7 +139,6 @@ struct MIToken {
     kw_unknown_address,
     kw_ir_block_address_taken,
     kw_machine_block_address_taken,
-    kw_call_frame_size,
     kw_noconvergent,
 
     // Metadata types.

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -502,7 +502,6 @@ public:
   bool parseAddrspace(unsigned &Addrspace);
   bool parseSectionID(std::optional<MBBSectionID> &SID);
   bool parseBBID(std::optional<UniqueBBID> &BBID);
-  bool parseCallFrameSize(std::optional<unsigned> &CallFrameSize);
   bool parseOperandsOffset(MachineOperand &Op);
   bool parseIRValue(const Value *&V);
   bool parseMemoryOperandFlag(MachineMemOperand::Flags &Flags);
@@ -684,18 +683,6 @@ bool MIParser::parseBBID(std::optional<UniqueBBID> &BBID) {
   return false;
 }
 
-// Parse basic block call frame size.
-bool MIParser::parseCallFrameSize(std::optional<unsigned> &CallFrameSize) {
-  assert(Token.is(MIToken::kw_call_frame_size));
-  lex();
-  unsigned Value = 0;
-  if (getUnsigned(Value))
-    return error("Unknown call frame size");
-  CallFrameSize = Value;
-  lex();
-  return false;
-}
-
 bool MIParser::parseBasicBlockDefinition(
     DenseMap<unsigned, MachineBasicBlock *> &MBBSlots) {
   assert(Token.is(MIToken::MachineBasicBlockLabel));
@@ -713,7 +700,6 @@ bool MIParser::parseBasicBlockDefinition(
   std::optional<MBBSectionID> SectionID;
   uint64_t Alignment = 0;
   std::optional<UniqueBBID> BBID;
-  std::optional<unsigned> CallFrameSize;
   BasicBlock *BB = nullptr;
   if (consumeIfPresent(MIToken::lparen)) {
     do {
@@ -758,10 +744,6 @@ bool MIParser::parseBasicBlockDefinition(
         if (parseBBID(BBID))
           return true;
         break;
-      case MIToken::kw_call_frame_size:
-        if (parseCallFrameSize(CallFrameSize))
-          return true;
-        break;
       default:
         break;
       }
@@ -799,7 +781,6 @@ bool MIParser::parseBasicBlockDefinition(
     MBB->setSectionID(*SectionID);
     MF.setBBSectionsType(BasicBlockSection::List);
   }
-  MBB->setCallFrameSize(CallFrameSize);
   return false;
 }
 

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -502,7 +502,7 @@ public:
   bool parseAddrspace(unsigned &Addrspace);
   bool parseSectionID(std::optional<MBBSectionID> &SID);
   bool parseBBID(std::optional<UniqueBBID> &BBID);
-  bool parseCallFrameSize(unsigned &CallFrameSize);
+  bool parseCallFrameSize(std::optional<unsigned> &CallFrameSize);
   bool parseOperandsOffset(MachineOperand &Op);
   bool parseIRValue(const Value *&V);
   bool parseMemoryOperandFlag(MachineMemOperand::Flags &Flags);
@@ -685,7 +685,7 @@ bool MIParser::parseBBID(std::optional<UniqueBBID> &BBID) {
 }
 
 // Parse basic block call frame size.
-bool MIParser::parseCallFrameSize(unsigned &CallFrameSize) {
+bool MIParser::parseCallFrameSize(std::optional<unsigned> &CallFrameSize) {
   assert(Token.is(MIToken::kw_call_frame_size));
   lex();
   unsigned Value = 0;
@@ -713,7 +713,7 @@ bool MIParser::parseBasicBlockDefinition(
   std::optional<MBBSectionID> SectionID;
   uint64_t Alignment = 0;
   std::optional<UniqueBBID> BBID;
-  unsigned CallFrameSize = 0;
+  std::optional<unsigned> CallFrameSize;
   BasicBlock *BB = nullptr;
   if (consumeIfPresent(MIToken::lparen)) {
     do {

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -578,11 +578,6 @@ void MachineBasicBlock::printName(raw_ostream &os, unsigned printNameFlags,
         os << " " << getBBID()->CloneID;
       hasAttributes = true;
     }
-    if (CallFrameSize.has_value()) {
-      os << (hasAttributes ? ", " : " (");
-      os << "call-frame-size " << CallFrameSize.value();
-      hasAttributes = true;
-    }
   }
 
   if (hasAttributes)
@@ -1155,7 +1150,6 @@ MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
   MachineBasicBlock *PrevFallthrough = getNextNode();
 
   MachineBasicBlock *NMBB = MF->CreateMachineBasicBlock();
-  NMBB->setCallFrameSize(Succ->getCallFrameSize());
 
   // Is there an indirect jump with jump table?
   bool ChangedIndirectJump = false;

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -578,9 +578,9 @@ void MachineBasicBlock::printName(raw_ostream &os, unsigned printNameFlags,
         os << " " << getBBID()->CloneID;
       hasAttributes = true;
     }
-    if (CallFrameSize != 0) {
+    if (CallFrameSize.has_value()) {
       os << (hasAttributes ? ", " : " (");
-      os << "call-frame-size " << CallFrameSize;
+      os << "call-frame-size " << CallFrameSize.value();
       hasAttributes = true;
     }
   }

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -3894,11 +3894,11 @@ void MachineVerifier::verifyStackFrame() {
       BBState.ExitIsSetup = BBState.EntryIsSetup;
     }
 
-    if ((int)MBB->getCallFrameSize() != -BBState.EntryValue) {
+    if ((int)MBB->getCallFrameSizeOrZero() != -BBState.EntryValue) {
       report("Call frame size on entry does not match value computed from "
              "predecessor",
              MBB);
-      OS << "Call frame size on entry " << MBB->getCallFrameSize()
+      OS << "Call frame size on entry " << MBB->getCallFrameSizeOrZero()
          << " does not match value computed from predecessor "
          << -BBState.EntryValue << '\n';
     }

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -3889,15 +3889,6 @@ void MachineVerifier::verifyStackFrame() {
       BBState.Exit = BBState.Entry;
     }
 
-    if (MBB->getCallFrameSize() != BBState.Entry) {
-      report("Call frame size on entry does not match value computed from "
-             "predecessor",
-             MBB);
-      OS << "Call frame size on entry " << MBB->getCallFrameSize()
-         << " does not match value computed from predecessor " << BBState.Entry
-         << '\n';
-    }
-
     // Update stack state by checking contents of MBB.
     for (const auto &I : *MBB) {
       if (I.getOpcode() == FrameSetupOpcode) {

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -3843,21 +3843,17 @@ void MachineVerifier::verifyLiveInterval(const LiveInterval &LI) {
 
 namespace {
 
-  // FrameSetup and FrameDestroy can have zero adjustment, so using a single
-  // integer, we can't tell whether it is a FrameSetup or FrameDestroy if the
-  // value is zero.
-  // We use a bool plus an integer to capture the stack state.
+/// Store for each MachineBasicBlock the call frame size at its entry and its
+/// exit. No value means that no call frame is open, zero means that a
+/// zero-sized call frame is open.
 struct StackStateOfBB {
   StackStateOfBB() = default;
-  StackStateOfBB(int EntryVal, int ExitVal, bool EntrySetup, bool ExitSetup)
-      : EntryValue(EntryVal), ExitValue(ExitVal), EntryIsSetup(EntrySetup),
-        ExitIsSetup(ExitSetup) {}
+  StackStateOfBB(std::optional<unsigned> EntryVal,
+                 std::optional<unsigned> ExitVal)
+      : Entry(EntryVal), Exit(ExitVal) {}
 
-  // Can be negative, which means we are setting up a frame.
-  int EntryValue = 0;
-  int ExitValue = 0;
-  bool EntryIsSetup = false;
-  bool ExitIsSetup = false;
+  std::optional<unsigned> Entry;
+  std::optional<unsigned> Exit;
 };
 
 } // end anonymous namespace
@@ -3866,19 +3862,20 @@ struct StackStateOfBB {
 /// by a FrameDestroy <n>, stack adjustments are identical on all
 /// CFG edges to a merge point, and frame is destroyed at end of a return block.
 void MachineVerifier::verifyStackFrame() {
-  unsigned FrameSetupOpcode   = TII->getCallFrameSetupOpcode();
+  unsigned FrameSetupOpcode = TII->getCallFrameSetupOpcode();
   unsigned FrameDestroyOpcode = TII->getCallFrameDestroyOpcode();
   if (FrameSetupOpcode == ~0u && FrameDestroyOpcode == ~0u)
     return;
 
   SmallVector<StackStateOfBB, 8> SPState;
   SPState.resize(MF->getNumBlockIDs());
-  df_iterator_default_set<const MachineBasicBlock*> Reachable;
+  df_iterator_default_set<const MachineBasicBlock *> Reachable;
 
   // Visit the MBBs in DFS order.
   for (df_ext_iterator<const MachineFunction *,
                        df_iterator_default_set<const MachineBasicBlock *>>
-       DFI = df_ext_begin(MF, Reachable), DFE = df_ext_end(MF, Reachable);
+           DFI = df_ext_begin(MF, Reachable),
+           DFE = df_ext_end(MF, Reachable);
        DFI != DFE; ++DFI) {
     const MachineBasicBlock *MBB = *DFI;
 
@@ -3888,49 +3885,45 @@ void MachineVerifier::verifyStackFrame() {
       const MachineBasicBlock *StackPred = DFI.getPath(DFI.getPathLength() - 2);
       assert(Reachable.count(StackPred) &&
              "DFS stack predecessor is already visited.\n");
-      BBState.EntryValue = SPState[StackPred->getNumber()].ExitValue;
-      BBState.EntryIsSetup = SPState[StackPred->getNumber()].ExitIsSetup;
-      BBState.ExitValue = BBState.EntryValue;
-      BBState.ExitIsSetup = BBState.EntryIsSetup;
+      BBState.Entry = SPState[StackPred->getNumber()].Exit;
+      BBState.Exit = BBState.Entry;
     }
 
-    if ((int)MBB->getCallFrameSizeOrZero() != -BBState.EntryValue) {
+    if (MBB->getCallFrameSize() != BBState.Entry) {
       report("Call frame size on entry does not match value computed from "
              "predecessor",
              MBB);
-      OS << "Call frame size on entry " << MBB->getCallFrameSizeOrZero()
-         << " does not match value computed from predecessor "
-         << -BBState.EntryValue << '\n';
+      OS << "Call frame size on entry " << MBB->getCallFrameSize()
+         << " does not match value computed from predecessor " << BBState.Entry
+         << '\n';
     }
 
     // Update stack state by checking contents of MBB.
     for (const auto &I : *MBB) {
       if (I.getOpcode() == FrameSetupOpcode) {
-        if (BBState.ExitIsSetup)
+        if (BBState.Exit.has_value())
           report("FrameSetup is after another FrameSetup", &I);
         if (!MRI->isSSA() && !MF->getFrameInfo().adjustsStack())
           report("AdjustsStack not set in presence of a frame pseudo "
-                 "instruction.", &I);
-        BBState.ExitValue -= TII->getFrameTotalSize(I);
-        BBState.ExitIsSetup = true;
+                 "instruction.",
+                 &I);
+        BBState.Exit = TII->getFrameTotalSize(I);
       }
 
       if (I.getOpcode() == FrameDestroyOpcode) {
-        int Size = TII->getFrameTotalSize(I);
-        if (!BBState.ExitIsSetup)
+        int64_t Size = TII->getFrameTotalSize(I);
+        if (!BBState.Exit.has_value())
           report("FrameDestroy is not after a FrameSetup", &I);
-        int AbsSPAdj = BBState.ExitValue < 0 ? -BBState.ExitValue :
-                                               BBState.ExitValue;
-        if (BBState.ExitIsSetup && AbsSPAdj != Size) {
+        else if ((int64_t)BBState.Exit.value() != Size) {
           report("FrameDestroy <n> is after FrameSetup <m>", &I);
           OS << "FrameDestroy <" << Size << "> is after FrameSetup <"
-             << AbsSPAdj << ">.\n";
+             << BBState.Exit.value() << ">.\n";
         }
         if (!MRI->isSSA() && !MF->getFrameInfo().adjustsStack())
           report("AdjustsStack not set in presence of a frame pseudo "
-                 "instruction.", &I);
-        BBState.ExitValue += Size;
-        BBState.ExitIsSetup = false;
+                 "instruction.",
+                 &I);
+        BBState.Exit.reset();
       }
     }
     SPState[MBB->getNumber()] = BBState;
@@ -3939,14 +3932,12 @@ void MachineVerifier::verifyStackFrame() {
     // state.
     for (const MachineBasicBlock *Pred : MBB->predecessors()) {
       if (Reachable.count(Pred) &&
-          (SPState[Pred->getNumber()].ExitValue != BBState.EntryValue ||
-           SPState[Pred->getNumber()].ExitIsSetup != BBState.EntryIsSetup)) {
+          SPState[Pred->getNumber()].Exit != BBState.Entry) {
         report("The exit stack state of a predecessor is inconsistent.", MBB);
-        OS << "Predecessor " << printMBBReference(*Pred) << " has exit state ("
-           << SPState[Pred->getNumber()].ExitValue << ", "
-           << SPState[Pred->getNumber()].ExitIsSetup << "), while "
-           << printMBBReference(*MBB) << " has entry state ("
-           << BBState.EntryValue << ", " << BBState.EntryIsSetup << ").\n";
+        OS << "Predecessor " << printMBBReference(*Pred) << " has exit state "
+           << SPState[Pred->getNumber()].Exit << ", while "
+           << printMBBReference(*MBB) << " has entry state " << BBState.Entry
+           << ".\n";
       }
     }
 
@@ -3954,23 +3945,19 @@ void MachineVerifier::verifyStackFrame() {
     // state.
     for (const MachineBasicBlock *Succ : MBB->successors()) {
       if (Reachable.count(Succ) &&
-          (SPState[Succ->getNumber()].EntryValue != BBState.ExitValue ||
-           SPState[Succ->getNumber()].EntryIsSetup != BBState.ExitIsSetup)) {
+          SPState[Succ->getNumber()].Entry != BBState.Exit) {
         report("The entry stack state of a successor is inconsistent.", MBB);
-        OS << "Successor " << printMBBReference(*Succ) << " has entry state ("
-           << SPState[Succ->getNumber()].EntryValue << ", "
-           << SPState[Succ->getNumber()].EntryIsSetup << "), while "
-           << printMBBReference(*MBB) << " has exit state ("
-           << BBState.ExitValue << ", " << BBState.ExitIsSetup << ").\n";
+        OS << "Successor " << printMBBReference(*Succ) << " has entry state "
+           << SPState[Succ->getNumber()].Entry << ", while "
+           << printMBBReference(*MBB) << " has exit state " << BBState.Exit
+           << ".\n";
       }
     }
 
     // Make sure a basic block with return ends with zero stack adjustment.
     if (!MBB->empty() && MBB->back().isReturn()) {
-      if (BBState.ExitIsSetup)
+      if (BBState.Exit.has_value())
         report("A return block ends with a FrameSetup.", MBB);
-      if (BBState.ExitValue)
-        report("A return block ends with a nonzero stack adjustment.", MBB);
     }
   }
 }

--- a/llvm/lib/CodeGen/PrologEpilogInserter.cpp
+++ b/llvm/lib/CodeGen/PrologEpilogInserter.cpp
@@ -390,11 +390,6 @@ void PEI::calculateCallFrameInfo(MachineFunction &MF) {
     // need to track the SP adjustment for frame index elimination.
     for (MachineBasicBlock::iterator I : FrameSDOps)
       TFI->eliminateCallFramePseudoInstr(MF, *I->getParent(), I);
-
-    // We can't track the call frame size after call frame pseudos have been
-    // eliminated. Clear it everywhere to keep MachineVerifier happy.
-    for (MachineBasicBlock &MBB : MF)
-      MBB.clearCallFrameSize();
   }
 }
 
@@ -1343,27 +1338,14 @@ void PEI::insertZeroCallUsedRegs(MachineFunction &MF) {
 /// offsets.
 void PEI::replaceFrameIndicesBackward(MachineFunction &MF) {
   const TargetFrameLowering &TFI = *MF.getSubtarget().getFrameLowering();
+  MachineFrameSizeInfo MFSI(MF);
 
   for (auto &MBB : MF) {
-    int SPAdj = 0;
-    if (!MBB.succ_empty()) {
-      // Get the SP adjustment for the end of MBB from the start of any of its
-      // successors. They should all be the same.
-      assert(all_of(MBB.successors(), [&MBB](const MachineBasicBlock *Succ) {
-        return Succ->getCallFrameSizeOrZero() ==
-               (*MBB.succ_begin())->getCallFrameSizeOrZero();
-      }));
-      const MachineBasicBlock &FirstSucc = **MBB.succ_begin();
-      SPAdj = TFI.alignSPAdjust(FirstSucc.getCallFrameSizeOrZero());
-      if (TFI.getStackGrowthDirection() == TargetFrameLowering::StackGrowsUp)
-        SPAdj = -SPAdj;
-    }
+    int SPAdj = TFI.alignSPAdjust(MFSI.getCallFrameSizeAtEnd(MBB).value_or(0));
+    if (TFI.getStackGrowthDirection() == TargetFrameLowering::StackGrowsUp)
+      SPAdj = -SPAdj;
 
     replaceFrameIndicesBackward(&MBB, MF, SPAdj);
-
-    // We can't track the call frame size after call frame pseudos have been
-    // eliminated. Clear it everywhere to keep MachineVerifier happy.
-    MBB.clearCallFrameSize();
   }
 }
 
@@ -1371,17 +1353,15 @@ void PEI::replaceFrameIndicesBackward(MachineFunction &MF) {
 /// register references and actual offsets.
 void PEI::replaceFrameIndices(MachineFunction &MF) {
   const TargetFrameLowering &TFI = *MF.getSubtarget().getFrameLowering();
+  MachineFrameSizeInfo MFSI(MF);
 
   for (auto &MBB : MF) {
-    int SPAdj = TFI.alignSPAdjust(MBB.getCallFrameSizeOrZero());
+    int SPAdj =
+        TFI.alignSPAdjust(MFSI.getCallFrameSizeAtBegin(MBB).value_or(0));
     if (TFI.getStackGrowthDirection() == TargetFrameLowering::StackGrowsUp)
       SPAdj = -SPAdj;
 
     replaceFrameIndices(&MBB, MF, SPAdj);
-
-    // We can't track the call frame size after call frame pseudos have been
-    // eliminated. Clear it everywhere to keep MachineVerifier happy.
-    MBB.clearCallFrameSize();
   }
 }
 

--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -1624,15 +1624,15 @@ TargetInstrInfo::describeLoadedValue(const MachineInstr &MI,
   return std::nullopt;
 }
 
-// Get the call frame size just before MI.
-unsigned TargetInstrInfo::getCallFrameSizeAt(MachineInstr &MI) const {
+std::optional<unsigned>
+TargetInstrInfo::getCallFrameSizeAt(MachineInstr &MI) const {
   // Search backwards from MI for the most recent call frame instruction.
   MachineBasicBlock *MBB = MI.getParent();
   for (auto &AdjI : reverse(make_range(MBB->instr_begin(), MI.getIterator()))) {
     if (AdjI.getOpcode() == getCallFrameSetupOpcode())
       return getFrameTotalSize(AdjI);
     if (AdjI.getOpcode() == getCallFrameDestroyOpcode())
-      return 0;
+      return std::nullopt;
   }
 
   // If none was found, use the call frame size from the start of the basic

--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -1625,27 +1625,6 @@ TargetInstrInfo::describeLoadedValue(const MachineInstr &MI,
   return std::nullopt;
 }
 
-std::optional<unsigned>
-TargetInstrInfo::getCallFrameSizeAt(MachineInstr &MI) const {
-  return this->getCallFrameSizeAt(*MI.getParent(), MI.getIterator());
-}
-
-std::optional<unsigned>
-TargetInstrInfo::getCallFrameSizeAt(MachineBasicBlock &MBB,
-                                    MachineBasicBlock::iterator MII) const {
-  // Search backwards from MI for the most recent call frame instruction.
-  for (auto &AdjI : reverse(make_range(MBB.begin(), MII))) {
-    if (AdjI.getOpcode() == getCallFrameSetupOpcode())
-      return getFrameTotalSize(AdjI);
-    if (AdjI.getOpcode() == getCallFrameDestroyOpcode())
-      return std::nullopt;
-  }
-
-  // If none was found, use the call frame size from the start of the basic
-  // block.
-  return MBB.getCallFrameSize();
-}
-
 /// Both DefMI and UseMI must be valid.  By default, call directly to the
 /// itinerary. This may be overriden by the target.
 std::optional<unsigned> TargetInstrInfo::getOperandLatency(

--- a/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
@@ -817,14 +817,6 @@ bool AMDGPURegisterBankInfo::executeInWaterfallLoop(
   MachineBasicBlock *RemainderBB = MF->CreateMachineBasicBlock();
   MachineBasicBlock *RestoreExecBB = MF->CreateMachineBasicBlock();
 
-  // Set call-frame sizes in each new BB, in case we are in a call sequence.
-  std::optional<unsigned> CallFrameSizeBefore =
-      TII->getCallFrameSizeAt(MBB, Range.begin());
-  LoopBB->setCallFrameSize(CallFrameSizeBefore);
-  BodyBB->setCallFrameSize(CallFrameSizeBefore);
-  RemainderBB->setCallFrameSize(CallFrameSizeBefore);
-  RestoreExecBB->setCallFrameSize(CallFrameSizeBefore);
-
   MachineFunction::iterator MBBI(MBB);
   ++MBBI;
   MF->insert(MBBI, LoopBB);

--- a/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
@@ -816,6 +816,15 @@ bool AMDGPURegisterBankInfo::executeInWaterfallLoop(
   MachineBasicBlock *BodyBB = MF->CreateMachineBasicBlock();
   MachineBasicBlock *RemainderBB = MF->CreateMachineBasicBlock();
   MachineBasicBlock *RestoreExecBB = MF->CreateMachineBasicBlock();
+
+  // Set call-frame sizes in each new BB, in case we are in a call sequence.
+  std::optional<unsigned> CallFrameSizeBefore =
+      TII->getCallFrameSizeAt(MBB, Range.begin());
+  LoopBB->setCallFrameSize(CallFrameSizeBefore);
+  BodyBB->setCallFrameSize(CallFrameSizeBefore);
+  RemainderBB->setCallFrameSize(CallFrameSizeBefore);
+  RestoreExecBB->setCallFrameSize(CallFrameSizeBefore);
+
   MachineFunction::iterator MBBI(MBB);
   ++MBBI;
   MF->insert(MBBI, LoopBB);

--- a/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
@@ -816,7 +816,6 @@ bool AMDGPURegisterBankInfo::executeInWaterfallLoop(
   MachineBasicBlock *BodyBB = MF->CreateMachineBasicBlock();
   MachineBasicBlock *RemainderBB = MF->CreateMachineBasicBlock();
   MachineBasicBlock *RestoreExecBB = MF->CreateMachineBasicBlock();
-
   MachineFunction::iterator MBBI(MBB);
   ++MBBI;
   MF->insert(MBBI, LoopBB);

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -11581,7 +11581,7 @@ ARMTargetLowering::EmitStructByval(MachineInstr &MI,
   MF->insert(It, exitMBB);
 
   // Set the call frame size on entry to the new basic blocks.
-  unsigned CallFrameSize = TII->getCallFrameSizeAt(MI);
+  std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
   loopMBB->setCallFrameSize(CallFrameSize);
   exitMBB->setCallFrameSize(CallFrameSize);
 
@@ -12182,7 +12182,7 @@ ARMTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     F->insert(It, sinkMBB);
 
     // Set the call frame size on entry to the new basic blocks.
-    unsigned CallFrameSize = TII->getCallFrameSizeAt(MI);
+    std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
     copy0MBB->setCallFrameSize(CallFrameSize);
     sinkMBB->setCallFrameSize(CallFrameSize);
 

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -11580,11 +11580,6 @@ ARMTargetLowering::EmitStructByval(MachineInstr &MI,
   MF->insert(It, loopMBB);
   MF->insert(It, exitMBB);
 
-  // Set the call frame size on entry to the new basic blocks.
-  std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
-  loopMBB->setCallFrameSize(CallFrameSize);
-  exitMBB->setCallFrameSize(CallFrameSize);
-
   // Transfer the remainder of BB and its successor edges to exitMBB.
   exitMBB->splice(exitMBB->begin(), BB,
                   std::next(MachineBasicBlock::iterator(MI)), BB->end());
@@ -12180,11 +12175,6 @@ ARMTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     MachineBasicBlock *sinkMBB  = F->CreateMachineBasicBlock(LLVM_BB);
     F->insert(It, copy0MBB);
     F->insert(It, sinkMBB);
-
-    // Set the call frame size on entry to the new basic blocks.
-    std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
-    copy0MBB->setCallFrameSize(CallFrameSize);
-    sinkMBB->setCallFrameSize(CallFrameSize);
 
     // Check whether CPSR is live past the tMOVCCr_pseudo.
     const TargetRegisterInfo *TRI = Subtarget->getRegisterInfo();

--- a/llvm/lib/Target/AVR/AVRISelLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRISelLowering.cpp
@@ -2424,7 +2424,7 @@ AVRTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   MF->insert(I, falseMBB);
 
   // Set the call frame size on entry to the new basic blocks.
-  unsigned CallFrameSize = TII.getCallFrameSizeAt(MI);
+  std::optional<unsigned> CallFrameSize = TII.getCallFrameSizeAt(MI);
   trueMBB->setCallFrameSize(CallFrameSize);
   falseMBB->setCallFrameSize(CallFrameSize);
 

--- a/llvm/lib/Target/AVR/AVRISelLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRISelLowering.cpp
@@ -2423,11 +2423,6 @@ AVRTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   MF->insert(I, trueMBB);
   MF->insert(I, falseMBB);
 
-  // Set the call frame size on entry to the new basic blocks.
-  std::optional<unsigned> CallFrameSize = TII.getCallFrameSizeAt(MI);
-  trueMBB->setCallFrameSize(CallFrameSize);
-  falseMBB->setCallFrameSize(CallFrameSize);
-
   // Transfer remaining instructions and all successors of the current
   // block to the block which will contain the Phi node for the
   // select.

--- a/llvm/lib/Target/M68k/M68kISelLowering.cpp
+++ b/llvm/lib/Target/M68k/M68kISelLowering.cpp
@@ -3198,11 +3198,6 @@ M68kTargetLowering::EmitLoweredSelect(MachineInstr &MI,
   F->insert(It, Copy0MBB);
   F->insert(It, SinkMBB);
 
-  // Set the call frame size on entry to the new basic blocks.
-  std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
-  Copy0MBB->setCallFrameSize(CallFrameSize);
-  SinkMBB->setCallFrameSize(CallFrameSize);
-
   // If the CCR register isn't dead in the terminator, then claim that it's
   // live into the sink and copy blocks.
   const TargetRegisterInfo *TRI = Subtarget.getRegisterInfo();

--- a/llvm/lib/Target/M68k/M68kISelLowering.cpp
+++ b/llvm/lib/Target/M68k/M68kISelLowering.cpp
@@ -3199,7 +3199,7 @@ M68kTargetLowering::EmitLoweredSelect(MachineInstr &MI,
   F->insert(It, SinkMBB);
 
   // Set the call frame size on entry to the new basic blocks.
-  unsigned CallFrameSize = TII->getCallFrameSizeAt(MI);
+  std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
   Copy0MBB->setCallFrameSize(CallFrameSize);
   SinkMBB->setCallFrameSize(CallFrameSize);
 

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -13149,12 +13149,6 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     F->insert(It, copy0MBB);
     F->insert(It, sinkMBB);
 
-    // Set the call frame size on entry to the new basic blocks.
-    // See https://reviews.llvm.org/D156113.
-    std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
-    copy0MBB->setCallFrameSize(CallFrameSize);
-    sinkMBB->setCallFrameSize(CallFrameSize);
-
     // Transfer the remainder of BB and its successor edges to sinkMBB.
     sinkMBB->splice(sinkMBB->begin(), BB,
                     std::next(MachineBasicBlock::iterator(MI)), BB->end());

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -13151,7 +13151,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 
     // Set the call frame size on entry to the new basic blocks.
     // See https://reviews.llvm.org/D156113.
-    unsigned CallFrameSize = TII->getCallFrameSizeAt(MI);
+    std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
     copy0MBB->setCallFrameSize(CallFrameSize);
     sinkMBB->setCallFrameSize(CallFrameSize);
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -18598,12 +18598,6 @@ static MachineBasicBlock *emitSelectPseudo(MachineInstr &MI,
   F->insert(I, IfFalseMBB);
   F->insert(I, TailMBB);
 
-  // Set the call frame size on entry to the new basic blocks.
-  std::optional<unsigned> CallFrameSize =
-      TII.getCallFrameSizeAt(*LastSelectPseudo);
-  IfFalseMBB->setCallFrameSize(CallFrameSize);
-  TailMBB->setCallFrameSize(CallFrameSize);
-
   // Transfer debug instructions associated with the selects to TailMBB.
   for (MachineInstr *DebugInstr : SelectDebugValues) {
     TailMBB->push_back(DebugInstr->removeFromParent());

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -18599,7 +18599,8 @@ static MachineBasicBlock *emitSelectPseudo(MachineInstr &MI,
   F->insert(I, TailMBB);
 
   // Set the call frame size on entry to the new basic blocks.
-  unsigned CallFrameSize = TII.getCallFrameSizeAt(*LastSelectPseudo);
+  std::optional<unsigned> CallFrameSize =
+      TII.getCallFrameSizeAt(*LastSelectPseudo);
   IfFalseMBB->setCallFrameSize(CallFrameSize);
   TailMBB->setCallFrameSize(CallFrameSize);
 

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -790,12 +790,6 @@ void X86FrameLowering::emitStackProbeInlineGenericLoop(
   MachineBasicBlock *testMBB = MF.CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *tailMBB = MF.CreateMachineBasicBlock(LLVM_BB);
 
-  // Set call-frame sizes in each new BB, in case we are in a call sequence.
-  std::optional<unsigned> CallFrameSizeBefore =
-      TII.getCallFrameSizeAt(MBB, MBBI);
-  testMBB->setCallFrameSize(CallFrameSizeBefore);
-  tailMBB->setCallFrameSize(CallFrameSizeBefore);
-
   MachineFunction::iterator MBBIter = ++MBB.getIterator();
   MF.insert(MBBIter, testMBB);
   MF.insert(MBBIter, tailMBB);
@@ -937,13 +931,6 @@ void X86FrameLowering::emitStackProbeInlineWindowsCoreCLR64(
   MachineBasicBlock *RoundMBB = MF.CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *LoopMBB = MF.CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *ContinueMBB = MF.CreateMachineBasicBlock(LLVM_BB);
-
-  // Set call-frame sizes in each new BB, in case we are in a call sequence.
-  std::optional<unsigned> CallFrameSizeBefore =
-      TII.getCallFrameSizeAt(MBB, MBBI);
-  RoundMBB->setCallFrameSize(CallFrameSizeBefore);
-  LoopMBB->setCallFrameSize(CallFrameSizeBefore);
-  ContinueMBB->setCallFrameSize(CallFrameSizeBefore);
 
   MachineFunction::iterator MBBIter = std::next(MBB.getIterator());
   MF.insert(MBBIter, RoundMBB);
@@ -1298,19 +1285,6 @@ void X86FrameLowering::BuildStackAlignAND(MachineBasicBlock &MBB,
       Register FinalStackProbed = Uses64BitFramePtr ? X86::R11
                                   : Is64Bit         ? X86::R11D
                                                     : X86::EAX;
-
-      std::optional<unsigned> CallFrameSizeBefore =
-          TII.getCallFrameSizeAt(MBB, MBBI);
-      // entryMBB takes the place of MBB, so give it its stored call frame size.
-      entryMBB->setCallFrameSize(MBB.getCallFrameSize());
-      // MBB contains only a tail of its original instructions, so update its
-      // stored call frame size.
-      MBB.setCallFrameSize(CallFrameSizeBefore);
-      // For the other basic blocks, take the state at the insertion point as
-      // well.
-      headMBB->setCallFrameSize(CallFrameSizeBefore);
-      bodyMBB->setCallFrameSize(CallFrameSizeBefore);
-      footMBB->setCallFrameSize(CallFrameSizeBefore);
 
       // Setup entry block
       {

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -790,6 +790,12 @@ void X86FrameLowering::emitStackProbeInlineGenericLoop(
   MachineBasicBlock *testMBB = MF.CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *tailMBB = MF.CreateMachineBasicBlock(LLVM_BB);
 
+  // Set call-frame sizes in each new BB, in case we are in a call sequence.
+  std::optional<unsigned> CallFrameSizeBefore =
+      TII.getCallFrameSizeAt(MBB, MBBI);
+  testMBB->setCallFrameSize(CallFrameSizeBefore);
+  tailMBB->setCallFrameSize(CallFrameSizeBefore);
+
   MachineFunction::iterator MBBIter = ++MBB.getIterator();
   MF.insert(MBBIter, testMBB);
   MF.insert(MBBIter, tailMBB);
@@ -931,6 +937,13 @@ void X86FrameLowering::emitStackProbeInlineWindowsCoreCLR64(
   MachineBasicBlock *RoundMBB = MF.CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *LoopMBB = MF.CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *ContinueMBB = MF.CreateMachineBasicBlock(LLVM_BB);
+
+  // Set call-frame sizes in each new BB, in case we are in a call sequence.
+  std::optional<unsigned> CallFrameSizeBefore =
+      TII.getCallFrameSizeAt(MBB, MBBI);
+  RoundMBB->setCallFrameSize(CallFrameSizeBefore);
+  LoopMBB->setCallFrameSize(CallFrameSizeBefore);
+  ContinueMBB->setCallFrameSize(CallFrameSizeBefore);
 
   MachineFunction::iterator MBBIter = std::next(MBB.getIterator());
   MF.insert(MBBIter, RoundMBB);
@@ -1285,6 +1298,19 @@ void X86FrameLowering::BuildStackAlignAND(MachineBasicBlock &MBB,
       Register FinalStackProbed = Uses64BitFramePtr ? X86::R11
                                   : Is64Bit         ? X86::R11D
                                                     : X86::EAX;
+
+      std::optional<unsigned> CallFrameSizeBefore =
+          TII.getCallFrameSizeAt(MBB, MBBI);
+      // entryMBB takes the place of MBB, so give it its stored call frame size.
+      entryMBB->setCallFrameSize(MBB.getCallFrameSize());
+      // MBB contains only a tail of its original instructions, so update its
+      // stored call frame size.
+      MBB.setCallFrameSize(CallFrameSizeBefore);
+      // For the other basic blocks, take the state at the insertion point as
+      // well.
+      headMBB->setCallFrameSize(CallFrameSizeBefore);
+      bodyMBB->setCallFrameSize(CallFrameSizeBefore);
+      footMBB->setCallFrameSize(CallFrameSizeBefore);
 
       // Setup entry block
       {

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -35646,11 +35646,6 @@ X86TargetLowering::EmitLoweredSelect(MachineInstr &MI,
   F->insert(It, FalseMBB);
   F->insert(It, SinkMBB);
 
-  // Set the call frame size on entry to the new basic blocks.
-  std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
-  FalseMBB->setCallFrameSize(CallFrameSize);
-  SinkMBB->setCallFrameSize(CallFrameSize);
-
   // If the EFLAGS register isn't dead in the terminator, then claim that it's
   // live into the sink and copy blocks.
   const TargetRegisterInfo *TRI = Subtarget.getRegisterInfo();
@@ -35719,16 +35714,6 @@ X86TargetLowering::EmitLoweredProbedAlloca(MachineInstr &MI,
   MachineBasicBlock *testMBB = MF->CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *tailMBB = MF->CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *blockMBB = MF->CreateMachineBasicBlock(LLVM_BB);
-
-  // Set call-frame sizes in each new BB, in case we are in a call sequence.
-  // MBB is split at std::next(MachineBasicBlock::iterator(MI) and these blocks
-  // are inserted in between, so they should all have the call frame size at
-  // the split point.
-  std::optional<unsigned> CallFrameSizeAtSplit =
-      TII->getCallFrameSizeAt(*MBB, std::next(MachineBasicBlock::iterator(MI)));
-  testMBB->setCallFrameSize(CallFrameSizeAtSplit);
-  blockMBB->setCallFrameSize(CallFrameSizeAtSplit);
-  tailMBB->setCallFrameSize(CallFrameSizeAtSplit);
 
   MachineFunction::iterator MBBIter = ++MBB->getIterator();
   MF->insert(MBBIter, testMBB);

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -35720,6 +35720,16 @@ X86TargetLowering::EmitLoweredProbedAlloca(MachineInstr &MI,
   MachineBasicBlock *tailMBB = MF->CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *blockMBB = MF->CreateMachineBasicBlock(LLVM_BB);
 
+  // Set call-frame sizes in each new BB, in case we are in a call sequence.
+  // MBB is split at std::next(MachineBasicBlock::iterator(MI) and these blocks
+  // are inserted in between, so they should all have the call frame size at
+  // the split point.
+  std::optional<unsigned> CallFrameSizeAtSplit =
+      TII->getCallFrameSizeAt(*MBB, std::next(MachineBasicBlock::iterator(MI)));
+  testMBB->setCallFrameSize(CallFrameSizeAtSplit);
+  blockMBB->setCallFrameSize(CallFrameSizeAtSplit);
+  tailMBB->setCallFrameSize(CallFrameSizeAtSplit);
+
   MachineFunction::iterator MBBIter = ++MBB->getIterator();
   MF->insert(MBBIter, testMBB);
   MF->insert(MBBIter, blockMBB);

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -35647,7 +35647,7 @@ X86TargetLowering::EmitLoweredSelect(MachineInstr &MI,
   F->insert(It, SinkMBB);
 
   // Set the call frame size on entry to the new basic blocks.
-  unsigned CallFrameSize = TII->getCallFrameSizeAt(MI);
+  std::optional<unsigned> CallFrameSize = TII->getCallFrameSizeAt(MI);
   FalseMBB->setCallFrameSize(CallFrameSize);
   SinkMBB->setCallFrameSize(CallFrameSize);
 

--- a/llvm/test/CodeGen/ARM/no-register-coalescing-in-returnsTwice.mir
+++ b/llvm/test/CodeGen/ARM/no-register-coalescing-in-returnsTwice.mir
@@ -123,7 +123,7 @@ body:             |
     %61:gpr = COPY killed %29
     %62:gpr = COPY killed %4
     %63:gpr = COPY killed %27
-  bb.2 (call-frame-size 72):
+  bb.2:
     %35:gpr = COPY killed %63
     %33:gpr = COPY killed %62
     %31:gpr = COPY killed %61
@@ -136,7 +136,7 @@ body:             |
     %62:gpr = COPY killed %32
     %63:gpr = COPY killed %34
     Bcc %bb.2, 1, killed $cpsr
-  bb.3 (call-frame-size 72):
+  bb.3:
     successors:
     %28:gpr = ADDri %stack.1.jb1, 0, 14, $noreg, $noreg
     $r0 = COPY killed %28

--- a/llvm/test/CodeGen/MIR/ARM/call-frame-size.mir
+++ b/llvm/test/CodeGen/MIR/ARM/call-frame-size.mir
@@ -11,7 +11,7 @@ body: |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 100, 0, 14 /* CC::al */, $noreg, implicit-def $sp, implicit $sp
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1 (call-frame-size 100):
+  ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   ADJCALLSTACKUP 100, 0, 14 /* CC::al */, $noreg, implicit-def $sp, implicit $sp
@@ -19,7 +19,7 @@ body: |
   ; CHECK-NEXT: bb.2:
   bb.0:
     ADJCALLSTACKDOWN 100, 0, 14, $noreg, implicit-def $sp, implicit $sp
-  bb.1 (call-frame-size 100):
+  bb.1:
     ADJCALLSTACKUP 100, 0, 14, $noreg, implicit-def $sp, implicit $sp
   bb.2:
 ...
@@ -33,7 +33,7 @@ body: |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, 14 /* CC::al */, $noreg, implicit-def $sp, implicit $sp
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.1 (call-frame-size 0):
+  ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, 14 /* CC::al */, $noreg, implicit-def $sp, implicit $sp
@@ -41,7 +41,7 @@ body: |
   ; CHECK-NEXT: bb.2:
   bb.0:
     ADJCALLSTACKDOWN 0, 0, 14, $noreg, implicit-def $sp, implicit $sp
-  bb.1 (call-frame-size 0):
+  bb.1:
     ADJCALLSTACKUP 0, 0, 14, $noreg, implicit-def $sp, implicit $sp
   bb.2:
 ...

--- a/llvm/test/CodeGen/MIR/ARM/call-frame-size.mir
+++ b/llvm/test/CodeGen/MIR/ARM/call-frame-size.mir
@@ -23,3 +23,25 @@ body: |
     ADJCALLSTACKUP 100, 0, 14, $noreg, implicit-def $sp, implicit $sp
   bb.2:
 ...
+
+---
+name: callframesizezero
+body: |
+  ; CHECK-LABEL: name: callframesizezero
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, 14 /* CC::al */, $noreg, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1 (call-frame-size 0):
+  ; CHECK-NEXT:   successors: %bb.2(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, 14 /* CC::al */, $noreg, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  bb.0:
+    ADJCALLSTACKDOWN 0, 0, 14, $noreg, implicit-def $sp, implicit $sp
+  bb.1 (call-frame-size 0):
+    ADJCALLSTACKUP 0, 0, 14, $noreg, implicit-def $sp, implicit $sp
+  bb.2:
+...

--- a/llvm/test/CodeGen/RISCV/pr97304.ll
+++ b/llvm/test/CodeGen/RISCV/pr97304.ll
@@ -22,10 +22,10 @@ define i32 @_ZNK2cv12LMSolverImpl3runERKNS_17_InputOutputArrayE(i1 %cmp436) {
   ; CHECK-NEXT:   [[ADDI1:%[0-9]+]]:gpr = ADDI $x0, 32
   ; CHECK-NEXT:   BNE [[ANDI]], $x0, %bb.3
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.2.for.cond (call-frame-size 8):
+  ; CHECK-NEXT: bb.2.for.cond:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.3.for.cond (call-frame-size 8):
+  ; CHECK-NEXT: bb.3.for.cond:
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI:%[0-9]+]]:gpr = PHI [[ADDI1]], %bb.1, [[ADDI]], %bb.2

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -249,8 +249,6 @@ static std::unique_ptr<MachineFunction> cloneMF(MachineFunction *SrcMF,
         DstMF->CreateMachineBasicBlock(SrcMBB.getBasicBlock());
     Src2DstMBB[&SrcMBB] = DstMBB;
 
-    DstMBB->setCallFrameSize(SrcMBB.getCallFrameSize());
-
     if (SrcMBB.isIRBlockAddressTaken())
       DstMBB->setAddressTakenIRBlock(SrcMBB.getAddressTakenIRBlock());
     if (SrcMBB.isMachineBlockAddressTaken())


### PR DESCRIPTION
Previously, we would need to update stored call frame sizes whenever a MachineBB with a call sequence is split or call frame instructions are moved. By recomputing them instead, this change avoids the need for keeping track of the call frame sizes throughout transformations. It also fixes several cases where updates of call frame sizes were missing.

The overhead according to the compile time tracker is < +0.03% executed instructions on all CT benchmark categories.

This also allows distinguishing a zero-sized call frame from no open call frame, which is helpful to avoid nested CALLSEQs (which are illegal and cause machine verifier errors).

---

Original Description, under the title "[CodeGen] Distinguish zero-sized call frames from no call frame in MachineBB":
Call frames can be zero-sized. Distinguishing between instructions in a
zero-sized call frame and instructions outside of call frames via the
call frame size info stored in the MachineBBs is helpful to avoid nested
CALLSEQs (which are illegal and cause machine verifier errors).

This patch uses std::optional<unsigned> instead of unsigned to represent
call frame sizes. Locations outside of call frames are marked with
std::nullopt whereas locations in zero-sized call-frames are represented
with a std::optional that contains 0.