### PR TITLE
[RISCV] Added new register class GPRNoGPRS defined as substraction of GPRC sequences from GPR

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -180,6 +180,9 @@ def GPRJALRNonX7 : GPRRegisterClass<(sub GPRJALR, X7)>;
 def GPRC : GPRRegisterClass<(add (sequence "X%u", 10, 15),
                                  (sequence "X%u", 8, 9))>;
 
+// The list of GPR registers not using with compressed instructions
+def GPRNoGPRC : GPRRegisterClass<(sub GPR, GPRC)>;
+
 // For indirect tail calls, we can't use callee-saved registers, as they are
 // restored to the saved value before the tail call, which would clobber a call
 // address. We shouldn't use x5 since that is a hint for to pop the return


### PR DESCRIPTION
This patch adds new register class allowed to select general purpose registers that can not be used as operands of compressed instructions. It can be useful for some compiler routine and llvm-based RISC-V tools. 