### PR TITLE
[lldb] Support partial memory reads on windows

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
@@ -276,16 +276,29 @@ Status ProcessDebugger::ReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
   LLDB_LOG(log, "attempting to read {0} bytes from address {1:x}", size,
            vm_addr);
 
-  HostProcess process = m_session_data->m_debugger->GetProcess();
+  lldb::process_t handle = m_session_data->m_debugger->GetProcess()
+                               .GetNativeProcess()
+                               .GetSystemHandle();
   void *addr = reinterpret_cast<void *>(vm_addr);
   SIZE_T num_of_bytes_read = 0;
-  if (!::ReadProcessMemory(process.GetNativeProcess().GetSystemHandle(), addr,
-                           buf, size, &num_of_bytes_read)) {
-    error = Status(GetLastError(), eErrorTypeWin32);
-    LLDB_LOG(log, "reading failed with error: {0}", error);
-  } else {
+  if (::ReadProcessMemory(handle, addr, buf, size, &num_of_bytes_read)) {
     bytes_read = num_of_bytes_read;
+    return Status();
   }
+  error = Status(GetLastError(), eErrorTypeWin32);
+  MemoryRegionInfo info;
+  if (GetMemoryRegionInfo(vm_addr, info).Fail() ||
+      info.GetMapped() != MemoryRegionInfo::OptionalBool::eYes)
+    return error;
+  size = info.GetRange().GetRangeEnd() - vm_addr;
+  LLDB_LOG(log, "retrying the read with size {0:x}", size);
+  if (::ReadProcessMemory(handle, addr, buf, size, &num_of_bytes_read)) {
+    LLDB_LOG(log, "success: read {0:x} bytes", num_of_bytes_read);
+    bytes_read = num_of_bytes_read;
+    return Status();
+  }
+  error = Status(GetLastError(), eErrorTypeWin32);
+  LLDB_LOG(log, "error: {0}", error);
   return error;
 }
 

--- a/lldb/test/API/functionalities/memory/holes/TestMemoryHoles.py
+++ b/lldb/test/API/functionalities/memory/holes/TestMemoryHoles.py
@@ -50,7 +50,6 @@ class MemoryHolesTestCase(TestBase):
         ]
         self.assertEqual(len(self.positions), 5)
 
-    @expectedFailureWindows
     def test_memory_read(self):
         self._prepare_inferior()
 


### PR DESCRIPTION
ReadProcessMemory will not perform the read if part of the memory is unreadable (and even though the API has a `number_of_bytes_read` argument). To make this work, I explicitly inspect the memory region being read and only read the accessible part.