### PR TITLE
[TableGen] Print memory stats in detailed record emitter

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1757,7 +1757,7 @@ public:
   ArrayRef<AssertionInfo> getAssertions() const { return Assertions; }
   ArrayRef<DumpInfo> getDumps() const { return Dumps; }
 
-  ArrayRef<std::pair<Record *, SMRange>>  getSuperClasses() const {
+  ArrayRef<std::pair<Record *, SMRange>> getSuperClasses() const {
     return SuperClasses;
   }
 
@@ -2072,6 +2072,8 @@ public:
   getAllDerivedDefinitionsIfDefined(StringRef ClassName) const;
 
   void dump() const;
+
+  void dumpAllocationStats(raw_ostream &OS) const;
 
 private:
   RecordKeeper(RecordKeeper &&) = delete;

--- a/llvm/lib/TableGen/DetailedRecordsBackend.cpp
+++ b/llvm/lib/TableGen/DetailedRecordsBackend.cpp
@@ -41,6 +41,7 @@ public:
   void printVariables(raw_ostream &OS);
   void printClasses(raw_ostream &OS);
   void printRecords(raw_ostream &OS);
+  void printAllocationStats(raw_ostream &OS);
   void printDefms(const Record &Rec, raw_ostream &OS);
   void printTemplateArgs(const Record &Rec, raw_ostream &OS);
   void printSuperclasses(const Record &Rec, raw_ostream &OS);
@@ -55,6 +56,7 @@ void DetailedRecordsEmitter::run(raw_ostream &OS) {
   printVariables(OS);
   printClasses(OS);
   printRecords(OS);
+  printAllocationStats(OS);
 }
 
 // Print the report heading, including the source file name.
@@ -62,8 +64,7 @@ void DetailedRecordsEmitter::printReportHeading(raw_ostream &OS) {
   OS << formatv("DETAILED RECORDS for file {0}\n", Records.getInputFilename());
 }
 
-// Print a section heading with the name of the section and
-// the item count.
+// Print a section heading with the name of the section and the item count.
 void DetailedRecordsEmitter::printSectionHeading(StringRef Title, int Count,
                                                  raw_ostream &OS) {
   OS << formatv("\n{0} {1} ({2}) {0}\n", "--------------------", Title, Count);
@@ -79,8 +80,7 @@ void DetailedRecordsEmitter::printVariables(raw_ostream &OS) {
     OS << Var.first << " = " << Var.second->getAsString() << '\n';
 }
 
-// Print the classes, including the template arguments, superclasses,
-// and fields.
+// Print classes, including the template arguments, superclasses, and fields.
 void DetailedRecordsEmitter::printClasses(raw_ostream &OS) {
   const auto &ClassList = Records.getClasses();
   printSectionHeading("Classes", ClassList.size(), OS);
@@ -94,8 +94,7 @@ void DetailedRecordsEmitter::printClasses(raw_ostream &OS) {
   }
 }
 
-// Print the records, including the defm sequences, supercasses,
-// and fields.
+// Print the records, including the defm sequences, supercasses, and fields.
 void DetailedRecordsEmitter::printRecords(raw_ostream &OS) {
   const auto &RecordList = Records.getDefs();
   printSectionHeading("Records", RecordList.size(), OS);
@@ -108,6 +107,12 @@ void DetailedRecordsEmitter::printRecords(raw_ostream &OS) {
     printSuperclasses(*Rec, OS);
     printFields(*Rec, OS);
   }
+}
+
+// Print memory allocation related stats.
+void DetailedRecordsEmitter::printAllocationStats(raw_ostream &OS) {
+  OS << formatv("\n{0} Memory Allocation Stats {0}\n", "--------------------");
+  Records.dumpAllocationStats(OS);
 }
 
 // Print the record's defm source locations, if any. Note that they

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -92,9 +92,38 @@ struct RecordKeeperImpl {
 
   unsigned AnonCounter;
   unsigned LastRecordID;
+
+  void dumpAllocationStats(raw_ostream &OS) const;
 };
 } // namespace detail
 } // namespace llvm
+
+void detail::RecordKeeperImpl::dumpAllocationStats(raw_ostream &OS) const {
+  // Dump memory allocation related stats.
+  OS << "TheArgumentInitPool size = " << TheArgumentInitPool.size() << '\n';
+  OS << "TheBitsInitPool size = " << TheBitsInitPool.size() << '\n';
+  OS << "TheIntInitPool size = " << TheIntInitPool.size() << '\n';
+  OS << "TheBitsInitPool size = " << TheBitsInitPool.size() << '\n';
+  OS << "TheListInitPool size = " << TheListInitPool.size() << '\n';
+  OS << "TheUnOpInitPool size = " << TheUnOpInitPool.size() << '\n';
+  OS << "TheBinOpInitPool size = " << TheBinOpInitPool.size() << '\n';
+  OS << "TheTernOpInitPool size = " << TheTernOpInitPool.size() << '\n';
+  OS << "TheFoldOpInitPool size = " << TheFoldOpInitPool.size() << '\n';
+  OS << "TheIsAOpInitPool size = " << TheIsAOpInitPool.size() << '\n';
+  OS << "TheExistsOpInitPool size = " << TheExistsOpInitPool.size() << '\n';
+  OS << "TheCondOpInitPool size = " << TheCondOpInitPool.size() << '\n';
+  OS << "TheDagInitPool size = " << TheDagInitPool.size() << '\n';
+  OS << "RecordTypePool size = " << RecordTypePool.size() << '\n';
+  OS << "TheVarInitPool size = " << TheVarInitPool.size() << '\n';
+  OS << "TheVarBitInitPool size = " << TheVarBitInitPool.size() << '\n';
+  OS << "TheVarDefInitPool size = " << TheVarDefInitPool.size() << '\n';
+  OS << "TheFieldInitPool size = " << TheFieldInitPool.size() << '\n';
+  OS << "Bytes allocated = " << Allocator.getBytesAllocated() << '\n';
+  OS << "Total allocator memory = " << Allocator.getTotalMemory() << "\n\n";
+
+  OS << "Number of records instantiated = " << LastRecordID << '\n';
+  OS << "Number of anonymous records = " << AnonCounter << '\n';
+}
 
 //===----------------------------------------------------------------------===//
 //    Type implementations
@@ -3259,6 +3288,10 @@ std::vector<Record *>
 RecordKeeper::getAllDerivedDefinitionsIfDefined(StringRef ClassName) const {
   return getClass(ClassName) ? getAllDerivedDefinitions(ClassName)
                              : std::vector<Record *>();
+}
+
+void RecordKeeper::dumpAllocationStats(raw_ostream &OS) const {
+  Impl->dumpAllocationStats(OS);
 }
 
 Init *MapResolver::resolve(Init *VarName) {


### PR DESCRIPTION
Print memory allocation and related statistics when dumping detailed record information.