### PR TITLE
[RISCV] Rename `vcix_state` register to `sf_vcix_state`. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
@@ -308,7 +308,7 @@ class VPseudoVC_V_XVV<Operand OpClass, VReg RDClass, VReg RS2Class,
 multiclass VPseudoVC_X<LMULInfo m, DAGOperand RS1Class,
                        Operand OpClass = payload2> {
   let VLMul = m.value in {
-    let Defs = [VCIX_STATE], Uses = [VCIX_STATE] in {
+    let Defs = [SF_VCIX_STATE], Uses = [SF_VCIX_STATE] in {
       def "PseudoVC_" # NAME # "_SE_" # m.MX
         : VPseudoVC_X<OpClass, RS1Class>,
           Sched<[!cast<SchedWrite>("WriteVC_" # NAME # "_" # m.MX)]>;
@@ -325,7 +325,7 @@ multiclass VPseudoVC_X<LMULInfo m, DAGOperand RS1Class,
 multiclass VPseudoVC_XV<LMULInfo m, DAGOperand RS1Class,
                         Operand OpClass = payload2> {
   let VLMul = m.value in {
-    let Defs = [VCIX_STATE], Uses = [VCIX_STATE] in {
+    let Defs = [SF_VCIX_STATE], Uses = [SF_VCIX_STATE] in {
       def "PseudoVC_" # NAME # "_SE_" # m.MX
         : VPseudoVC_XV<OpClass, m.vrclass, RS1Class>,
           Sched<[!cast<SchedWrite>("WriteVC_" # NAME # "_" # m.MX)]>;
@@ -342,7 +342,7 @@ multiclass VPseudoVC_XV<LMULInfo m, DAGOperand RS1Class,
 multiclass VPseudoVC_XVV<LMULInfo m, DAGOperand RS1Class,
                          Operand OpClass = payload2> {
   let VLMul = m.value in {
-    let Defs = [VCIX_STATE], Uses = [VCIX_STATE] in {
+    let Defs = [SF_VCIX_STATE], Uses = [SF_VCIX_STATE] in {
       def "PseudoVC_" # NAME # "_SE_" # m.MX
         : VPseudoVC_XVV<OpClass, m.vrclass, m.vrclass, RS1Class>,
           Sched<[!cast<SchedWrite>("WriteVC_" # NAME # "_" # m.MX)]>;
@@ -359,12 +359,12 @@ multiclass VPseudoVC_XVV<LMULInfo m, DAGOperand RS1Class,
 multiclass VPseudoVC_XVW<LMULInfo m, DAGOperand RS1Class,
                          Operand OpClass = payload2> {
   let VLMul = m.value in {
-    let Defs = [VCIX_STATE], Uses = [VCIX_STATE] in
+    let Defs = [SF_VCIX_STATE], Uses = [SF_VCIX_STATE] in
     def "PseudoVC_" # NAME # "_SE_" # m.MX
       : VPseudoVC_XVV<OpClass, m.wvrclass, m.vrclass, RS1Class>,
         Sched<[!cast<SchedWrite>("WriteVC_" # NAME # "_" # m.MX)]>;
     let Constraints = "@earlyclobber $rd, $rd = $rs3" in {
-      let Defs = [VCIX_STATE], Uses = [VCIX_STATE] in
+      let Defs = [SF_VCIX_STATE], Uses = [SF_VCIX_STATE] in
       def "PseudoVC_V_" # NAME # "_SE_" # m.MX
         : VPseudoVC_V_XVV<OpClass, m.wvrclass, m.vrclass, RS1Class>,
           Sched<[!cast<SchedWrite>("WriteVC_V_" # NAME # "_" # m.MX)]>;

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -145,7 +145,7 @@ BitVector RISCVRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   markSuperRegs(Reserved, RISCV::FFLAGS);
 
   // SiFive VCIX state registers.
-  markSuperRegs(Reserved, RISCV::VCIX_STATE);
+  markSuperRegs(Reserved, RISCV::SF_VCIX_STATE);
 
   if (MF.getFunction().getCallingConv() == CallingConv::GRAAL) {
     if (Subtarget.hasStdExtE())

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -664,5 +664,5 @@ def FRM    : RISCVReg<0, "frm">;
 // Shadow Stack register
 def SSP    : RISCVReg<0, "ssp">;
 
-// Dummy VCIX state register
-def VCIX_STATE : RISCVReg<0, "vcix_state">;
+// Dummy SiFive VCIX state register
+def SF_VCIX_STATE : RISCVReg<0, "sf_vcix_state">;

--- a/llvm/test/CodeGen/RISCV/rvv/copyprop.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/copyprop.mir
@@ -47,7 +47,7 @@ body:             |
     %22:vr = PseudoVMSNE_VI_M1 %3, 0, 1, 6 /* e64 */
     $v0 = COPY %22
     %25:vrnov0 = PseudoVMERGE_VIM_M1 undef $noreg, %17, -1, $v0, 1, 6 /* e64 */
-    %29:vr = PseudoVC_V_X_SE_M1 3, 31, %2, 1, 6 /* e64 */, implicit-def dead $vcix_state, implicit $vcix_state
+    %29:vr = PseudoVC_V_X_SE_M1 3, 31, %2, 1, 6 /* e64 */, implicit-def dead $sf_vcix_state, implicit $sf_vcix_state
     %30:vr = PseudoVMV_V_I_M1 undef $noreg, 0, 1, 6 /* e64 */, 0
     BGEU %1, $x0, %bb.2
 


### PR DESCRIPTION
Since it's SiFive VCIX specific register, it's better to have a prefix
so that it's more understandable.
