### PR TITLE
[LTO] Don't make unnecessary copies of ImportIDTable

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -115,8 +115,8 @@ public:
 
     ImportIDTable() = default;
 
-    // Three is something wrong with the application logic if we need to make a
-    // copy of this and potentially make a fork.
+    // Something is wrong with the application logic if we need to make a copy
+    // of this and potentially make a fork.
     ImportIDTable(const ImportIDTable &) = delete;
     ImportIDTable &operator=(const ImportIDTable &) = delete;
 

--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -113,6 +113,13 @@ public:
   public:
     using ImportIDTy = uint32_t;
 
+    ImportIDTable() = default;
+
+    // Three is something wrong with the application logic if we need to make a
+    // copy of this and potentially make a fork.
+    ImportIDTable(const ImportIDTable &) = delete;
+    ImportIDTable &operator=(const ImportIDTable &) = delete;
+
     // Create a pair of import IDs [Def, Decl] for a given pair of FromModule
     // and GUID.
     std::pair<ImportIDTy, ImportIDTy> createImportIDs(StringRef FromModule,
@@ -218,9 +225,10 @@ public:
     getImportType(StringRef FromModule, GlobalValue::GUID GUID) const;
 
     // Iterate over the import list.  The caller gets tuples of FromModule,
-    // GUID, and ImportKind instead of import IDs.
-    auto begin() const { return map_iterator(Imports.begin(), IDs); }
-    auto end() const { return map_iterator(Imports.end(), IDs); }
+    // GUID, and ImportKind instead of import IDs.  std::cref below prevents
+    // map_iterator from deep-copying IDs.
+    auto begin() const { return map_iterator(Imports.begin(), std::cref(IDs)); }
+    auto end() const { return map_iterator(Imports.end(), std::cref(IDs)); }
 
     friend class SortedImportList;
 
@@ -251,9 +259,10 @@ public:
     }
 
     // Iterate over the import list.  The caller gets tuples of FromModule,
-    // GUID, and ImportKind instead of import IDs.
-    auto begin() const { return map_iterator(Imports.begin(), IDs); }
-    auto end() const { return map_iterator(Imports.end(), IDs); }
+    // GUID, and ImportKind instead of import IDs.  std::cref below prevents
+    // map_iterator from deep-copying IDs.
+    auto begin() const { return map_iterator(Imports.begin(), std::cref(IDs)); }
+    auto end() const { return map_iterator(Imports.end(), std::cref(IDs)); }
 
   private:
     const ImportIDTable &IDs;


### PR DESCRIPTION
Without this patch, {ImportMapTy,SortedImportList}::{begin,end} make
unnecessary copies of ImportIDTable via:

  map_iterator(Imports.begin(), IDs);

The second parameter, IDs, is passed by value, so we make a copy of
MapVector inside ImportIDTable every time we call begin and end.
These begin and end show up as time-consuming functions in the
performance profile.

This patch fixes the problem by passing IDs by reference with
std::cref.

While we are at it, this patch deletes the copy constructor and
assignment operator.  I cannot think of any legitimate need reason to
make a copy of the deduplication table.
