### PR TITLE
LICM: hoist BO assoc when (C1 op LV) op C2

### DIFF
--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2804,10 +2804,6 @@ static bool hoistMulAddAssociation(Instruction &I, Loop &L,
 /// Reassociate associative binary expressions of the form
 ///
 /// 1. "(LV op C1) op C2" ==> "LV op (C1 op C2)" if op is an associative BinOp
-///
-/// where LV is a loop variant, and C1 and C2 are loop invariants that we want
-/// to hoist.
-///
 /// 2. "(C1 op LV) op C2" ==> "LV op (C1 op C2)" if op is a commutative BinOp
 ///
 /// where LV is a loop variant, and C1 and C2 are loop invariants that we want
@@ -2839,8 +2835,7 @@ static bool hoistBOAssociation(Instruction &I, Loop &L,
   Value *C2 = BO->getOperand(1);
 
   if (L.isLoopInvariant(LV) && !L.isLoopInvariant(C1)) {
-    assert(BO->isCommutative() && BO0->isCommutative() &&
-           "Associativity implies commutativity");
+    assert(BO0->isCommutative() && "Associativity implies commutativity");
     std::swap(LV, C1);
   }
   if (L.isLoopInvariant(LV) || !L.isLoopInvariant(C1) || !L.isLoopInvariant(C2))

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2803,15 +2803,19 @@ static bool hoistMulAddAssociation(Instruction &I, Loop &L,
 
 /// Reassociate associative binary expressions of the form
 ///
-/// 1. "(LV op C1) op C2" ==> "LV op (C1 op C2)"
+/// 1. "(LV op C1) op C2" ==> "LV op (C1 op C2)" if op is an associative BinOp
 ///
-/// where op is an associative binary op, LV is a loop variant, and C1 and C2
-/// are loop invariants that we want to hoist.
+/// where LV is a loop variant, and C1 and C2 are loop invariants that we want
+/// to hoist.
+///
+/// 2. "(C1 op LV) op C2" ==> "LV op (C1 op C2)" if op is a commutative BinOp
+///
+/// where LV is a loop variant, and C1 and C2 are loop invariants that we want
+/// to hoist.
 ///
 /// TODO: This can be extended to more cases such as
-/// 2. "C1 op (C2 op LV)" ==> "(C1 op C2) op LV"
-/// 3. "(C1 op LV) op C2" ==> "LV op (C1 op C2)" if op is commutative
-/// 4. "C1 op (LV op C2)" ==> "(C1 op C2) op LV" if op is commutative
+/// 1. "C1 op (C2 op LV)" ==> "(C1 op C2) op LV" if op an associative BinOp
+/// 2. "C1 op (LV op C2)" ==> "(C1 op C2) op LV" if op is a commutative BinOp
 static bool hoistBOAssociation(Instruction &I, Loop &L,
                                ICFLoopSafetyInfo &SafetyInfo,
                                MemorySSAUpdater &MSSAU, AssumptionCache *AC,
@@ -2830,11 +2834,15 @@ static bool hoistBOAssociation(Instruction &I, Loop &L,
       BO0->hasNUsesOrMore(3))
     return false;
 
-  // Transform: "(LV op C1) op C2" ==> "LV op (C1 op C2)"
   Value *LV = BO0->getOperand(0);
   Value *C1 = BO0->getOperand(1);
   Value *C2 = BO->getOperand(1);
 
+  if (L.isLoopInvariant(LV) && !L.isLoopInvariant(C1)) {
+    assert(BO->isCommutative() && BO0->isCommutative() &&
+           "Associativity implies commutativity");
+    std::swap(LV, C1);
+  }
   if (L.isLoopInvariant(LV) || !L.isLoopInvariant(C1) || !L.isLoopInvariant(C2))
     return false;
 

--- a/llvm/test/Transforms/LICM/hoist-binop.ll
+++ b/llvm/test/Transforms/LICM/hoist-binop.ll
@@ -22,27 +22,6 @@ loop:
   br label %loop
 }
 
-; Hoist ADD and remove old op if unused. Commutative version.
-define void @add_one_use_comm(i64 %c1, i64 %c2) {
-; CHECK-LABEL: @add_one_use_comm(
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i64 [[C1:%.*]], [[C2:%.*]]
-; CHECK-NEXT:    br label [[LOOP:%.*]]
-; CHECK:       loop:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
-; CHECK-NEXT:    br label [[LOOP]]
-;
-entry:
-  br label %loop
-
-loop:
-  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
-  %step.add = add i64 %c1, %index
-  %index.next = add i64 %step.add, %c2
-  br label %loop
-}
-
 ; Hoist MUL and remove old op if unused.
 define void @mul_one_use(i64 %c1, i64 %c2) {
 ; CHECK-LABEL: @mul_one_use(
@@ -63,28 +42,6 @@ loop:
   %index.next = mul i64 %step.add, %c2
   br label %loop
 }
-
-; Hoist MUL and remove old op if unused. Commutative version.
-define void @mul_one_use_comm(i64 %c1, i64 %c2) {
-; CHECK-LABEL: @mul_one_use_comm(
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[FACTOR_OP_MUL:%.*]] = mul i64 [[C1:%.*]], [[C2:%.*]]
-; CHECK-NEXT:    br label [[LOOP:%.*]]
-; CHECK:       loop:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[STEP_ADD_REASS:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[STEP_ADD_REASS]] = mul i64 [[FACTOR_OP_MUL]], [[INDEX]]
-; CHECK-NEXT:    br label [[LOOP]]
-;
-entry:
-  br label %loop
-
-loop:
-  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
-  %step.add = mul i64 %c1, %index
-  %index.next = mul i64 %step.add, %c2
-  br label %loop
-}
-
 
 ; Hoist ADD and copy NUW if both ops have it.
 define void @add_nuw(i64 %c1, i64 %c2) {
@@ -111,7 +68,7 @@ loop:
 }
 
 
-; Hoist ADD and copy NUW even if both ops have it. Commutative version.
+; Hoist ADD and copy NUW if both ops have it. Commutative version.
 define void @add_nuw_comm(i64 %c1, i64 %c2) {
 ; CHECK-LABEL: @add_nuw_comm(
 ; CHECK-NEXT:  entry:
@@ -207,30 +164,6 @@ loop:
   br label %loop
 }
 
-; Hoist ADD but don't copy NUW if only one op has it. Commutative version.
-define void @add_no_nuw_comm(i64 %c1, i64 %c2) {
-; CHECK-LABEL: @add_no_nuw_comm(
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i64 [[C1:%.*]], [[C2:%.*]]
-; CHECK-NEXT:    br label [[LOOP:%.*]]
-; CHECK:       loop:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[STEP_ADD:%.*]] = add i64 [[C1]], [[INDEX]]
-; CHECK-NEXT:    call void @use(i64 [[STEP_ADD]])
-; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
-; CHECK-NEXT:    br label [[LOOP]]
-;
-entry:
-  br label %loop
-
-loop:
-  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
-  %step.add = add i64 %c1, %index
-  call void @use(i64 %step.add)
-  %index.next = add nuw i64 %step.add, %c2
-  br label %loop
-}
-
 ; Hoist ADD but don't copy NSW if one op has it.
 define void @add_no_nsw(i64 %c1, i64 %c2) {
 ; CHECK-LABEL: @add_no_nsw(
@@ -250,30 +183,6 @@ entry:
 loop:
   %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
   %step.add = add i64 %index, %c1
-  call void @use(i64 %step.add)
-  %index.next = add nsw i64 %step.add, %c2
-  br label %loop
-}
-
-; Hoist ADD but don't copy NSW if one op has it. Commutative version.
-define void @add_no_nsw_comm(i64 %c1, i64 %c2) {
-; CHECK-LABEL: @add_no_nsw_comm(
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i64 [[C1:%.*]], [[C2:%.*]]
-; CHECK-NEXT:    br label [[LOOP:%.*]]
-; CHECK:       loop:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[STEP_ADD:%.*]] = add i64 [[C1]], [[INDEX]]
-; CHECK-NEXT:    call void @use(i64 [[STEP_ADD]])
-; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
-; CHECK-NEXT:    br label [[LOOP]]
-;
-entry:
-  br label %loop
-
-loop:
-  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
-  %step.add = add i64 %c1, %index
   call void @use(i64 %step.add)
   %index.next = add nsw i64 %step.add, %c2
   br label %loop
@@ -303,31 +212,6 @@ loop:
   br label %loop
 }
 
-; Hoist ADD but don't copy NSW even if both ops have it. Commutative version.
-define void @add_no_nsw_2_comm(i64 %c1, i64 %c2) {
-; CHECK-LABEL: @add_no_nsw_2_comm(
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i64 [[C1:%.*]], [[C2:%.*]]
-; CHECK-NEXT:    br label [[LOOP:%.*]]
-; CHECK:       loop:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[STEP_ADD:%.*]] = add nsw i64 [[C1]], [[INDEX]]
-; CHECK-NEXT:    call void @use(i64 [[STEP_ADD]])
-; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
-; CHECK-NEXT:    br label [[LOOP]]
-;
-entry:
-  br label %loop
-
-loop:
-  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
-  %step.add = add nsw i64 %c1, %index
-  call void @use(i64 %step.add)
-  %index.next = add nsw i64 %step.add, %c2
-  br label %loop
-}
-
-
 ; Hoist MUL and drop NSW even if both ops have it.
 define void @mul_no_nsw_2(i64 %c1, i64 %c2) {
 ; CHECK-LABEL: @mul_no_nsw_2(
@@ -347,30 +231,6 @@ entry:
 loop:
   %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
   %step.add = mul nsw i64 %index, %c1
-  call void @use(i64 %step.add)
-  %index.next = mul nsw i64 %step.add, %c2
-  br label %loop
-}
-
-; Hoist MUL and drop NSW even if both ops have it. Commutative version.
-define void @mul_no_nsw_2_comm(i64 %c1, i64 %c2) {
-; CHECK-LABEL: @mul_no_nsw_2_comm(
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = mul i64 [[C1:%.*]], [[C2:%.*]]
-; CHECK-NEXT:    br label [[LOOP:%.*]]
-; CHECK:       loop:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[STEP_ADD:%.*]] = mul nsw i64 [[C1]], [[INDEX]]
-; CHECK-NEXT:    call void @use(i64 [[STEP_ADD]])
-; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = mul i64 [[INDEX]], [[INVARIANT_OP]]
-; CHECK-NEXT:    br label [[LOOP]]
-;
-entry:
-  br label %loop
-
-loop:
-  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
-  %step.add = mul nsw i64 %c1, %index
   call void @use(i64 %step.add)
   %index.next = mul nsw i64 %step.add, %c2
   br label %loop


### PR DESCRIPTION
Extend hoistBOAssociation to handle the "(C1 op LV) op C2" case, when op is a commutative operand.