### PR TITLE
[flang][semantics][OpenMP] store DSA using ultimate sym

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2514,14 +2514,14 @@ void OmpAttributeVisitor::CheckMultipleAppearances(
       target = &details->symbol();
     }
   }
-  if (HasDataSharingAttributeObject(*target) &&
+  if (HasDataSharingAttributeObject(target->GetUltimate()) &&
       !WithMultipleAppearancesOmpException(symbol, ompFlag)) {
     context_.Say(name.source,
         "'%s' appears in more than one data-sharing clause "
         "on the same OpenMP directive"_err_en_US,
         name.ToString());
   } else {
-    AddDataSharingAttributeObject(*target);
+    AddDataSharingAttributeObject(target->GetUltimate());
     if (privateDataSharingAttributeFlags.test(ompFlag)) {
       AddPrivateDataSharingAttributeObjects(*target);
     }

--- a/flang/test/Semantics/OpenMP/clause-order.f90
+++ b/flang/test/Semantics/OpenMP/clause-order.f90
@@ -1,0 +1,19 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+! Ensure that checks on more than one data-sharing clause do not depend upon
+! the clause order
+
+PROGRAM main
+  INTEGER:: I, N1, N2
+
+  !ERROR: 'n1' appears in more than one data-sharing clause on the same OpenMP directive
+  !$OMP PARALLEL DO PRIVATE(N1) SHARED(N1)
+  DO I=1, 4
+  ENDDO
+  !$OMP END PARALLEL DO
+
+  !ERROR: 'n2' appears in more than one data-sharing clause on the same OpenMP directive
+  !$OMP PARALLEL DO SHARED(N2) PRIVATE(N2)
+  DO I=1, 4
+  ENDDO
+  !$OMP END PARALLEL DO
+END PROGRAM


### PR DESCRIPTION
Previously we tracked data sharing attributes by the symbol itself not by the ultimate symbol. When the private clause came first, subsequent uses of the symbol found a host-associated version instead of the ultimate symbol and so the check didn't consider them to be the same symbol. Always adding and checking for the ultimate symbol ensures that we have the same behaviour no matter the order of clauses.

Closes #78235