### PR TITLE
[libc++][type_traits][modules] Added missing `std::is_virtual_base_of` to `type_traits.inc`

### DIFF
--- a/libcxx/modules/std/type_traits.inc
+++ b/libcxx/modules/std/type_traits.inc
@@ -114,6 +114,9 @@ export namespace std {
 
   // [meta.rel], type relations
   using std::is_base_of;
+#if _LIBCPP_STD_VER >= 26 && __has_builtin(__builtin_is_virtual_base_of)
+  using std::is_virtual_base_of;
+#endif
   using std::is_convertible;
   // using std::is_layout_compatible;
   using std::is_nothrow_convertible;
@@ -287,6 +290,9 @@ export namespace std {
 
   // [meta.rel], type relations
   using std::is_base_of_v;
+#if _LIBCPP_STD_VER >= 26 && __has_builtin(__builtin_is_virtual_base_of)
+  using std::is_virtual_base_of_v;
+#endif
   using std::is_convertible_v;
   using std::is_invocable_r_v;
   using std::is_invocable_v;


### PR DESCRIPTION
`std::is_virtual_base_of` was implemented in https://github.com/llvm/llvm-project/pull/105847