### PR TITLE
[flang][preprocessor] Extend handling of line continuation replacements

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -712,12 +712,16 @@ bool Prescanner::NextToken(TokenSequence &tokens) {
       // Subtlety: When an identifier is split across three or more continuation
       // lines (or two continuation lines, immediately preceded or followed
       // by '&' free form continuation line markers, its parts are kept as
-      // distinct pp-tokens so that macro operates on them independently.
-      // This trick accommodates the historic practice of using line
-      // continuation for token pasting after replacement.
+      // distinct pp-tokens so that macro replacement operates on them
+      // independently.  This trick accommodates the historic practice of
+      // using line continuation for token pasting after replacement.
     } else if (parts == 2) {
+      if (afterLast && afterLast < limit_) {
+        afterLast = SkipWhiteSpace(afterLast);
+      }
       if ((start > start_ && start[-1] == '&') ||
-          (afterLast < limit_ && (*afterLast == '&' || *afterLast == '\n'))) {
+          (afterLast && afterLast < limit_ &&
+              (*afterLast == '&' || *afterLast == '\n'))) {
         // call &                call foo&        call foo&
         //   &MACRO&      OR       &MACRO&   OR     &MACRO
         //   &foo(...)             &(...)

--- a/flang/test/Preprocessing/pp134.F90
+++ b/flang/test/Preprocessing/pp134.F90
@@ -1,7 +1,8 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
 ! CHECK: print *, ADC, 1
-! CHECK: print *, AD, 1
-! CHECK: print *, DC, 1
+! CHECK: print *, AD, 2
+! CHECK: print *, DC, 3
+! CHECK: print *, AD(1), 4
 ! CHECK: print *, AD
 ! CHECK: print *, AB
 #define B D
@@ -12,10 +13,13 @@ print *, A&
   &C, 1
 print *, A&
   &B&
-  &, 1
+  &, 2
 print *, &
   &B&
-  &C, 1
+  &C, 3
+print *, A&
+  &B &
+  &(1), 4
 print *, A&
   &B
 print *, A&


### PR DESCRIPTION
Codes using traditional C preprocessors will sometimes put a keyword macro name in a free form continuation line in order to get macro replacement of part of an identifier, as in

  call subr_&
    &N&
    &(1.)

where N is a keyword macro.  f18 already handles this case, but not when there is white space between the macro name and the following continuation marker character '&'.  Allow white space to appear.

Fixes https://github.com/llvm/llvm-project/issues/106931.