### PR TITLE
[AsmPrinter] Do not emit label instructions after the function body if the target is SPIR-V

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1973,7 +1973,8 @@ void AsmPrinter::emitFunctionBody() {
 
   // SPIR-V supports label instructions only inside a block, not after the
   // function body.
-  if (!TT.isSPIRV() && (EmitFunctionSize || needFuncLabels(*MF, *this))) {
+  if (TT.getObjectFormat() != Triple::SPIRV &&
+      (EmitFunctionSize || needFuncLabels(*MF, *this))) {
     // Create a symbol for the end of function.
     CurrentFnEnd = createTempSymbol("func_end");
     OutStreamer->emitLabel(CurrentFnEnd);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1971,7 +1971,9 @@ void AsmPrinter::emitFunctionBody() {
   // are automatically sized.
   bool EmitFunctionSize = MAI->hasDotTypeDotSizeDirective() && !TT.isWasm();
 
-  if (EmitFunctionSize || needFuncLabels(*MF, *this)) {
+  // SPIR-V supports label instructions only inside a block, not after the
+  // function body.
+  if (!TT.isSPIRV() && (EmitFunctionSize || needFuncLabels(*MF, *this))) {
     // Create a symbol for the end of function.
     CurrentFnEnd = createTempSymbol("func_end");
     OutStreamer->emitLabel(CurrentFnEnd);

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-compilation-unit.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-compilation-unit.ll
@@ -29,11 +29,13 @@ define spir_func void @foo() {
 entry:
   ret void
 }
+; CHECK-SPIRV-NOT: Lfunc_end0:
 
 define spir_func void @bar() {
 entry:
   ret void
 }
+; CHECK-SPIRV-NOT: Lfunc_end1:
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5}


### PR DESCRIPTION
AsmPrinter always creates a symbol for the end of function if valid debug info is present. However, this breaks SPIR-V target's output, because SPIR-V specification allows label instructions only inside a block, not after the function body (see https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpLabel). This PR proposes to disable emission of label instructions after the function body if the target is SPIR-V.

This PR is a fix of the https://github.com/llvm/llvm-project/issues/102732 issue.