### PR TITLE
[clang] Add tests for CWG issues about language linkage

### DIFF
--- a/clang/test/CXX/drs/cwg1818.cpp
+++ b/clang/test/CXX/drs/cwg1818.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++20 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++23 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++2c %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+
+// expected-no-diagnostics
+
+namespace cwg1818 { // cwg1818: 3.4
+extern "C" void f() {
+  // This declaration binds name 'g' in the scope of function 'f',
+  // but its target scope corresponds to namespace 'cwg1818' (_N4988_.[dcl.meaning]/3.5).
+  // Linkage specification of 'f' applies to 'g' per _N4988_.[dcl.link]/5.
+  void g();
+}
+// Target scope of this declaration is naturally the one
+// that corresponds to namespace 'cwg1818',
+// which makes it declare the same entity
+// as the previous declaration per _N4988_.[basic.link]/8,
+// turning it into a redeclaration per _N4988_.[basic.def]/1.
+// Then _N4988_.[dcl.link]/6 applies, making it inherit
+// the (С) language linkage of the previous declaration.
+void g();
+} // namespace cwg1818
+
+// Check that the former 'g' has C language linkage,
+// then that the latter 'g' is considered to be a redeclaration of it,
+// which would make the latter 'g' inherit C language linkage from the former 'g'.
+
+// CHECK: LinkageSpecDecl [[LINKAGE_DECL:0x[0-9a-f]+]] {{.*}} C
+// CHECK: FunctionDecl [[FIRST_DECL:0x[0-9a-f]+]] parent [[LINKAGE_DECL]] {{.*}} g 'void ()'
+// CHECK: FunctionDecl {{.*}} prev [[FIRST_DECL]] {{.*}} g 'void ()'

--- a/clang/test/CXX/drs/cwg18xx.cpp
+++ b/clang/test/CXX/drs/cwg18xx.cpp
@@ -222,6 +222,8 @@ namespace cwg1815 { // cwg1815: no
 #endif
 }
 
+// cwg1818 is in cwg1818.cpp
+
 namespace cwg1820 { // cwg1820: 3.5
 typedef int A;
 typedef int cwg1820::A;

--- a/clang/test/CXX/drs/cwg563.cpp
+++ b/clang/test/CXX/drs/cwg563.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -std=c++98 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++11 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++14 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++17 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++20 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++23 %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -std=c++2c %s -verify=expected -fexceptions -fcxx-exceptions -pedantic-errors -ast-dump | FileCheck %s
+
+// expected-no-diagnostics
+
+namespace cwg563 { // cwg563: 3.3
+extern "C" int a;
+} // namespace cwg563
+
+// CHECK:      LinkageSpecDecl {{.*}} C
+// CHECK-NEXT: `-VarDecl {{.*}} a 'int'

--- a/clang/test/CXX/drs/cwg5xx.cpp
+++ b/clang/test/CXX/drs/cwg5xx.cpp
@@ -799,6 +799,7 @@ namespace cwg561 { // cwg561: yes
 }
 
 // cwg562: na
+// cwg563 is in cwg563.cpp
 
 namespace cwg564 { // cwg564: yes
   extern "C++" void f(int);

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -3431,7 +3431,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/563.html">563</a></td>
     <td>CD6</td>
     <td>Linkage specification for objects</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.3</td>
   </tr>
   <tr id="564">
     <td><a href="https://cplusplus.github.io/CWG/issues/564.html">564</a></td>
@@ -10735,7 +10735,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1818.html">1818</a></td>
     <td>CD6</td>
     <td>Visibility and inherited language linkage</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.4</td>
   </tr>
   <tr id="1819">
     <td><a href="https://cplusplus.github.io/CWG/issues/1819.html">1819</a></td>


### PR DESCRIPTION
This patch covers Core issues about language linkage during declaration matching resolved in [P1787R6](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1787r6.html), namely [CWG563](https://cplusplus.github.io/CWG/issues/563.html) and [CWG1818](https://cplusplus.github.io/CWG/issues/1818.html).

[CWG563](https://cplusplus.github.io/CWG/issues/563.html) "Linkage specification for objects"
-----------
[P1787R6](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1787r6.html):
> [CWG563](https://cplusplus.github.io/CWG/issues/563.html) is resolved by simplifications that follow its suggestions.

Wording ([[dcl.link]/5](https://eel.is/c++draft/dcl.link#5)):
> In a [linkage-specification](https://eel.is/c++draft/dcl.link#nt:linkage-specification), the specified language linkage applies to the function types of all function declarators and to all functions and variables whose names have external linkage[.](https://eel.is/c++draft/dcl.link#5.sentence-5)

Now the wording clearly says that linkage-specification applies to variables with external linkage.

[CWG1818](https://cplusplus.github.io/CWG/issues/1818.html) "Visibility and inherited language linkage"
------------
[P1787R6](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1787r6.html):
> [CWG386](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#386), [CWG1839](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#1839), [CWG1818](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#1818), [CWG2058](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#2058), [CWG1900](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#1900), and Richard’s observation in [“are non-type names ignored in a class-head-name or enum-head-name?”](http://lists.isocpp.org/core/2017/01/1604.php) are resolved by describing the limited lookup that occurs for a declarator-id, including the changes in Richard’s [proposed resolution for CWG1839](http://wiki.edg.com/pub/Wg21cologne2019/CoreWorkingGroup/cwg1839.html) (which also resolves CWG1818 and what of CWG2058 was not resolved along with CWG2059) and rejecting the example from [CWG1477](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1477).

Wording ([[dcl.link]/6](https://eel.is/c++draft/dcl.link#6)):
> A redeclaration of an entity without a linkage specification inherits the language linkage of the entity and (if applicable) its type[.](https://eel.is/c++draft/dcl.link#6.sentence-2).

Answer to the question in the example is `extern "C"`, and not linkage mismatch. Further analysis of the example is provided as inline comments in the test itself. Note that https://eel.is/c++draft/dcl.link#7 does NOT apply in this example, as it's focused squarely at declarations that are already known to have C language linkage, and declarations of variables in the global scope.