### PR TITLE
[lldb-dap][test] Fix: Typo in unresolved test

### DIFF
--- a/lldb/test/API/tools/lldb-dap/instruction-breakpoint/TestDAP_instruction_breakpoint.py
+++ b/lldb/test/API/tools/lldb-dap/instruction-breakpoint/TestDAP_instruction_breakpoint.py
@@ -35,7 +35,7 @@ class TestDAP_InstructionBreakpointTestCase(lldbdap_testcase.DAPTestCaseBase):
         # Set source breakpoint 1
         response = self.dap_server.request_setBreakpoints(self.main_path, [main_line])
         breakpoints = response["body"]["breakpoints"]
-        self.assertEquals(len(breakpoints), 1)
+        self.assertEqual(len(breakpoints), 1)
         breakpoint = breakpoints[0]
         self.assertEqual(
             breakpoint["line"], main_line, "incorrect breakpoint source line"


### PR DESCRIPTION
There is a typo in an assertion that causes the  instruction break-point test to be unresolved 