### PR TITLE
[ADT] Deprecate DenseMap::getOrInsertDefault

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1123,13 +1123,11 @@ class DiagnoseHLSLAvailability
 
   // Helper methods for dealing with shader stage bitmap
   void AddToScannedFunctions(const FunctionDecl *FD) {
-    unsigned &ScannedStages = ScannedDecls.getOrInsertDefault(FD);
+    unsigned &ScannedStages = ScannedDecls[FD];
     ScannedStages |= CurrentShaderStageBit;
   }
 
-  unsigned GetScannedStages(const FunctionDecl *FD) {
-    return ScannedDecls.getOrInsertDefault(FD);
-  }
+  unsigned GetScannedStages(const FunctionDecl *FD) { return ScannedDecls[FD]; }
 
   bool WasAlreadyScannedInCurrentStage(const FunctionDecl *FD) {
     return WasAlreadyScannedInCurrentStage(GetScannedStages(FD));

--- a/flang/lib/Optimizer/Transforms/AddAliasTags.cpp
+++ b/flang/lib/Optimizer/Transforms/AddAliasTags.cpp
@@ -103,8 +103,8 @@ void PassState::processFunctionScopes(mlir::func::FuncOp func) {
   if (scopeNames.contains(func))
     return;
 
-  auto &scopeMap = scopeNames.getOrInsertDefault(func);
-  auto &scopeOps = sortedScopeOperations.getOrInsertDefault(func);
+  auto &scopeMap = scopeNames[func];
+  auto &scopeOps = sortedScopeOperations[func];
   func.walk([&](fir::DummyScopeOp op) { scopeOps.push_back(op); });
   llvm::stable_sort(scopeOps, [&](const fir::DummyScopeOp &op1,
                                   const fir::DummyScopeOp &op2) {

--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -322,6 +322,7 @@ public:
   /// Returns the value associated to the key in the map if it exists. If it
   /// does not exist, emplace a default value for the key and returns a
   /// reference to the newly created value.
+  LLVM_DEPRECATED("Use operator[] instead", "[Key]")
   ValueT &getOrInsertDefault(KeyT &&Key) {
     return try_emplace(Key).first->second;
   }
@@ -329,6 +330,7 @@ public:
   /// Returns the value associated to the key in the map if it exists. If it
   /// does not exist, emplace a default value for the key and returns a
   /// reference to the newly created value.
+  LLVM_DEPRECATED("Use operator[] instead", "[Key]")
   ValueT &getOrInsertDefault(const KeyT &Key) {
     return try_emplace(Key).first->second;
   }

--- a/mlir/lib/Transforms/SROA.cpp
+++ b/mlir/lib/Transforms/SROA.cpp
@@ -57,7 +57,7 @@ computeDestructuringInfo(DestructurableMemorySlot &slot,
 
   auto scheduleAsBlockingUse = [&](OpOperand &use) {
     SmallPtrSetImpl<OpOperand *> &blockingUses =
-        info.userToBlockingUses.getOrInsertDefault(use.getOwner());
+        info.userToBlockingUses[use.getOwner()];
     blockingUses.insert(&use);
   };
 
@@ -122,7 +122,7 @@ computeDestructuringInfo(DestructurableMemorySlot &slot,
       assert(llvm::is_contained(user->getResults(), blockingUse->get()));
 
       SmallPtrSetImpl<OpOperand *> &newUserBlockingUseSet =
-          info.userToBlockingUses.getOrInsertDefault(blockingUse->getOwner());
+          info.userToBlockingUses[blockingUse->getOwner()];
       newUserBlockingUseSet.insert(blockingUse);
     }
   }


### PR DESCRIPTION
This patch deprecates DenseMap::getOrInsertDefault in favor of
DenseMap::operator[], which does the same thing, has been around
longer, and is also a household name as part of std::map and
std::unordered_map.

Note that DenseMap provides several equivalent ways to insert or
default-construct a key-value pair:

- operator[Key]
- try_emplace(Key).first->second
- getOrInsertDefault(Key)
- FindAndConstruct(Key).second
