### PR TITLE
[clang] Fix FnInfoOpts::operator&= and FnInfoOpts::operator|= not updating assigned operands

### DIFF
--- a/clang/lib/CodeGen/CGCall.h
+++ b/clang/lib/CodeGen/CGCall.h
@@ -450,12 +450,12 @@ inline FnInfoOpts operator&(FnInfoOpts A, FnInfoOpts B) {
                                  llvm::to_underlying(B));
 }
 
-inline FnInfoOpts operator|=(FnInfoOpts A, FnInfoOpts B) {
+inline FnInfoOpts &operator|=(FnInfoOpts &A, FnInfoOpts B) {
   A = A | B;
   return A;
 }
 
-inline FnInfoOpts operator&=(FnInfoOpts A, FnInfoOpts B) {
+inline FnInfoOpts &operator&=(FnInfoOpts &A, FnInfoOpts B) {
   A = A & B;
   return A;
 }


### PR DESCRIPTION
Hi, this is my first time sending a PR to the LLVM repo.
I ran into this bug when implementing a feature in my private repo, and I think maybe I can take this small patch as a chance to practice contributing to LLVM, so here I publish the fix to this small but certain bug :)