### PR TITLE
[clang][bytecode] Print Pointers via APValue

### DIFF
--- a/clang/test/AST/ByteCode/constexpr-frame-describe.cpp
+++ b/clang/test/AST/ByteCode/constexpr-frame-describe.cpp
@@ -84,7 +84,6 @@ static_assert(bar.fail3(3, 4UL, bar, &bar)); // both-error {{constant expression
 
 
 
-/// FIXME: Bound member pointer printing doesn't work right, see the last parameter to MemPtr().
 struct MemPtrTest {
   int n;
   void f();
@@ -94,5 +93,4 @@ constexpr int MemPtr(int (MemPtrTest::*a), void (MemPtrTest::*b)(), int &c) {
   return c; // both-note {{read of non-constexpr variable 'mpt'}}
 }
 static_assert(MemPtr(&MemPtrTest::n, &MemPtrTest::f, mpt.*&MemPtrTest::n), ""); // both-error {{constant expression}} \
-                                                                                // expected-note {{in call to 'MemPtr(&MemPtrTest::n, &MemPtrTest::f, mpt)'}} \
-                                                                                // ref-note {{in call to 'MemPtr(&MemPtrTest::n, &MemPtrTest::f, mpt.n)'}}
+                                                                                // both-note {{in call to 'MemPtr(&MemPtrTest::n, &MemPtrTest::f, mpt.n)'}}


### PR DESCRIPTION
Instead of doing this ourselves, just rely on printing the APValue.