### PR TITLE
[AVR] Reformat MC tests

### DIFF
--- a/llvm/test/MC/AVR/hex-immediates.s
+++ b/llvm/test/MC/AVR/hex-immediates.s
@@ -1,6 +1,6 @@
 ; RUN: llvm-mc -filetype=obj -triple=avr %s -o %t
 ; RUN: llvm-objdump --no-print-imm-hex -d %t | FileCheck %s --check-prefix=DEC
-; RUN: llvm-objdump -d --print-imm-hex %t | FileCheck %s --check-prefix=HEX
+; RUN: llvm-objdump -dr --print-imm-hex %t | FileCheck %s --check-prefix=HEX
 
 ; DEC: ldi r24, 66
 ; HEX: ldi r24, 0x42

--- a/llvm/test/MC/AVR/inst-adc.s
+++ b/llvm/test/MC/AVR/inst-adc.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   adc r0,  r15
   adc r15, r0
   adc r16, r31

--- a/llvm/test/MC/AVR/inst-add.s
+++ b/llvm/test/MC/AVR/inst-add.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   add r0,  r15
   add r15, r0
   add r16, r31

--- a/llvm/test/MC/AVR/inst-adiw.s
+++ b/llvm/test/MC/AVR/inst-adiw.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=addsubiw -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=addsubiw < %s | llvm-objdump --no-print-imm-hex -dr --mattr=addsubiw - | FileCheck --check-prefix=CHECK-INST %s
 
-
 foo:
-
   adiw r26,  12
   adiw r26,  63
 

--- a/llvm/test/MC/AVR/inst-and.s
+++ b/llvm/test/MC/AVR/inst-and.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   and r0,  r15
   and r15, r0
   and r16, r31

--- a/llvm/test/MC/AVR/inst-andi.s
+++ b/llvm/test/MC/AVR/inst-andi.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   andi r16, 255
   andi r29, 190
   andi r22, 172

--- a/llvm/test/MC/AVR/inst-asr.s
+++ b/llvm/test/MC/AVR/inst-asr.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   asr r31
   asr r25
   asr r5

--- a/llvm/test/MC/AVR/inst-bld.s
+++ b/llvm/test/MC/AVR/inst-bld.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   bld r3, 5
   bld r1, 1
   bld r0, 0

--- a/llvm/test/MC/AVR/inst-brbc.s
+++ b/llvm/test/MC/AVR/inst-brbc.s
@@ -1,6 +1,6 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - | FileCheck --check-prefix=INST %s
+; RUN:     | llvm-objdump -dr - | FileCheck --check-prefix=INST %s
 
 foo:
   brbc 3, .+8

--- a/llvm/test/MC/AVR/inst-brbs.s
+++ b/llvm/test/MC/AVR/inst-brbs.s
@@ -1,6 +1,6 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - | FileCheck --check-prefix=INST %s
+; RUN:     | llvm-objdump -dr - | FileCheck --check-prefix=INST %s
 
 foo:
   brbs 3, .+8

--- a/llvm/test/MC/AVR/inst-brcc.s
+++ b/llvm/test/MC/AVR/inst-brcc.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brcs.s
+++ b/llvm/test/MC/AVR/inst-brcs.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-break.s
+++ b/llvm/test/MC/AVR/inst-break.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=break -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=break < %s | llvm-objdump -d --mattr=break - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=break < %s | llvm-objdump -dr --mattr=break - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   break
 
 ; CHECK: break                  ; encoding: [0x98,0x95]

--- a/llvm/test/MC/AVR/inst-breq.s
+++ b/llvm/test/MC/AVR/inst-breq.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brge.s
+++ b/llvm/test/MC/AVR/inst-brge.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brhc.s
+++ b/llvm/test/MC/AVR/inst-brhc.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brhs.s
+++ b/llvm/test/MC/AVR/inst-brhs.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brid.s
+++ b/llvm/test/MC/AVR/inst-brid.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brie.s
+++ b/llvm/test/MC/AVR/inst-brie.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brlo.s
+++ b/llvm/test/MC/AVR/inst-brlo.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brlt.s
+++ b/llvm/test/MC/AVR/inst-brlt.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brmi.s
+++ b/llvm/test/MC/AVR/inst-brmi.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brne.s
+++ b/llvm/test/MC/AVR/inst-brne.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brpl.s
+++ b/llvm/test/MC/AVR/inst-brpl.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brsh.s
+++ b/llvm/test/MC/AVR/inst-brsh.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brtc.s
+++ b/llvm/test/MC/AVR/inst-brtc.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brts.s
+++ b/llvm/test/MC/AVR/inst-brts.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brvc.s
+++ b/llvm/test/MC/AVR/inst-brvc.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-brvs.s
+++ b/llvm/test/MC/AVR/inst-brvs.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-bst.s
+++ b/llvm/test/MC/AVR/inst-bst.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   bst r3, 5
   bst r1, 1
   bst r0, 0

--- a/llvm/test/MC/AVR/inst-call.s
+++ b/llvm/test/MC/AVR/inst-call.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=jmpcall -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=jmpcall < %s | llvm-objdump --no-print-imm-hex -dr --mattr=jmpcall - | FileCheck -check-prefix=CHECK-INST %s
 
-
 foo:
-
   call  4096
   call  -124
   call   -12

--- a/llvm/test/MC/AVR/inst-cbi.s
+++ b/llvm/test/MC/AVR/inst-cbi.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   cbi 3, 5
   cbi 1, 1
   cbi 7, 2

--- a/llvm/test/MC/AVR/inst-cbr.s
+++ b/llvm/test/MC/AVR/inst-cbr.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   cbr r17, 208
   cbr r24, 190
   cbr r20, 173

--- a/llvm/test/MC/AVR/inst-clr.s
+++ b/llvm/test/MC/AVR/inst-clr.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   clr r2
   clr r12
   clr r5

--- a/llvm/test/MC/AVR/inst-com.s
+++ b/llvm/test/MC/AVR/inst-com.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   com r30
   com r17
   com r4

--- a/llvm/test/MC/AVR/inst-cp.s
+++ b/llvm/test/MC/AVR/inst-cp.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   cp r12, r2
   cp r19, r0
   cp r15, r31

--- a/llvm/test/MC/AVR/inst-cpc.s
+++ b/llvm/test/MC/AVR/inst-cpc.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   cp r13, r12
   cp r20, r0
   cp r10, r31

--- a/llvm/test/MC/AVR/inst-cpi.s
+++ b/llvm/test/MC/AVR/inst-cpi.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   cpi r16, 241
   cpi r29, 190
   cpi r22, 172

--- a/llvm/test/MC/AVR/inst-cpse.s
+++ b/llvm/test/MC/AVR/inst-cpse.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   cpse r2, r13
   cpse r9, r0
   cpse r5, r31

--- a/llvm/test/MC/AVR/inst-dec.s
+++ b/llvm/test/MC/AVR/inst-dec.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   dec r26
   dec r3
   dec r24

--- a/llvm/test/MC/AVR/inst-des.s
+++ b/llvm/test/MC/AVR/inst-des.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=des -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=des < %s | llvm-objdump --no-print-imm-hex -d --mattr=des - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=des < %s | llvm-objdump --no-print-imm-hex -dr --mattr=des - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   des 0
   des 6
   des 1

--- a/llvm/test/MC/AVR/inst-eicall.s
+++ b/llvm/test/MC/AVR/inst-eicall.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=eijmpcall -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=eijmpcall < %s | llvm-objdump -d --mattr=eijmpcall - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=eijmpcall < %s | llvm-objdump -dr --mattr=eijmpcall - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   eicall
 
 ; CHECK: eicall                  ; encoding: [0x19,0x95]

--- a/llvm/test/MC/AVR/inst-eijmp.s
+++ b/llvm/test/MC/AVR/inst-eijmp.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=eijmpcall -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=eijmpcall < %s | llvm-objdump -d --mattr=eijmpcall - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=eijmpcall < %s | llvm-objdump -dr --mattr=eijmpcall - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   eijmp
 
 ; CHECK: eijmp                  ; encoding: [0x19,0x94]

--- a/llvm/test/MC/AVR/inst-elpm.s
+++ b/llvm/test/MC/AVR/inst-elpm.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=elpm,elpmx -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=elpm,elpmx < %s | llvm-objdump -d --mattr=elpm,elpmx - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=elpm,elpmx < %s | llvm-objdump -dr --mattr=elpm,elpmx - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   elpm
 
   elpm r3,  Z

--- a/llvm/test/MC/AVR/inst-eor.s
+++ b/llvm/test/MC/AVR/inst-eor.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   eor r0,  r15
   eor r15, r0
   eor r16, r31

--- a/llvm/test/MC/AVR/inst-family-set-clr-flag.s
+++ b/llvm/test/MC/AVR/inst-family-set-clr-flag.s
@@ -1,5 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
 

--- a/llvm/test/MC/AVR/inst-fmul.s
+++ b/llvm/test/MC/AVR/inst-fmul.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=mul -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -d --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -dr --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   fmul r22, r16
   fmul r19, r17
   fmul r21, r23

--- a/llvm/test/MC/AVR/inst-fmuls.s
+++ b/llvm/test/MC/AVR/inst-fmuls.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=mul -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -d --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -dr --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   fmuls r22, r16
   fmuls r19, r17
   fmuls r21, r23

--- a/llvm/test/MC/AVR/inst-fmulsu.s
+++ b/llvm/test/MC/AVR/inst-fmulsu.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=mul -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -d --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -dr --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   fmulsu r22, r16
   fmulsu r19, r17
   fmulsu r21, r23

--- a/llvm/test/MC/AVR/inst-icall.s
+++ b/llvm/test/MC/AVR/inst-icall.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=ijmpcall -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=ijmpcall < %s | llvm-objdump -d --mattr=ijmpcall - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=ijmpcall < %s | llvm-objdump -dr --mattr=ijmpcall - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   icall
 
 ; CHECK: icall                  ; encoding: [0x09,0x95]

--- a/llvm/test/MC/AVR/inst-ijmp.s
+++ b/llvm/test/MC/AVR/inst-ijmp.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=ijmpcall -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=ijmpcall < %s | llvm-objdump -d --mattr=ijmpcall - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=ijmpcall < %s | llvm-objdump -dr --mattr=ijmpcall - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   ijmp
 
 ; CHECK: ijmp                  ; encoding: [0x09,0x94]

--- a/llvm/test/MC/AVR/inst-in.s
+++ b/llvm/test/MC/AVR/inst-in.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   in r2, 4
   in r9, 6
   in r5, 32

--- a/llvm/test/MC/AVR/inst-inc.s
+++ b/llvm/test/MC/AVR/inst-inc.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   inc r12
   inc r29
   inc r6

--- a/llvm/test/MC/AVR/inst-jmp.s
+++ b/llvm/test/MC/AVR/inst-jmp.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=jmpcall -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=jmpcall < %s | llvm-objdump --no-print-imm-hex -dr --mattr=jmpcall - | FileCheck -check-prefix=CHECK-INST %s
 
-
 foo:
-
   jmp   200
   jmp  -12
   jmp   80

--- a/llvm/test/MC/AVR/inst-lac.s
+++ b/llvm/test/MC/AVR/inst-lac.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=rmw -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -d --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -dr --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   lac Z, r13
   lac Z, r0
   lac Z, r31

--- a/llvm/test/MC/AVR/inst-las.s
+++ b/llvm/test/MC/AVR/inst-las.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=rmw -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -d --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -dr --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   las Z, r13
   las Z, r0
   las Z, r31

--- a/llvm/test/MC/AVR/inst-lat.s
+++ b/llvm/test/MC/AVR/inst-lat.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=rmw -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -d --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -dr --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   lat Z, r13
   lat Z, r0
   lat Z, r31

--- a/llvm/test/MC/AVR/inst-ld.s
+++ b/llvm/test/MC/AVR/inst-ld.s
@@ -1,10 +1,8 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s \
-; RUN:     | llvm-objdump -d --mattr=sram - | FileCheck --check-prefix=INST %s
-
+; RUN:     | llvm-objdump -dr --mattr=sram - | FileCheck --check-prefix=INST %s
 
 foo:
-
   ; Normal
 
   ld r10, X

--- a/llvm/test/MC/AVR/inst-ldd.s
+++ b/llvm/test/MC/AVR/inst-ldd.s
@@ -1,6 +1,6 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s \
-; RUN:     | llvm-objdump -d --mattr=sram - | FileCheck --check-prefix=INST %s
+; RUN:     | llvm-objdump -dr --mattr=sram - | FileCheck --check-prefix=INST %s
 
 foo:
   ldd r2, Y+2

--- a/llvm/test/MC/AVR/inst-ldi.s
+++ b/llvm/test/MC/AVR/inst-ldi.s
@@ -1,6 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump --no-print-imm-hex -d --mattr=sram - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump --no-print-imm-hex -dr --mattr=sram - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
   ldi r16, 241

--- a/llvm/test/MC/AVR/inst-lds.s
+++ b/llvm/test/MC/AVR/inst-lds.s
@@ -1,7 +1,6 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump --no-print-imm-hex -dr --mattr=sram - | FileCheck -check-prefix=CHECK-INST %s
 
-
 foo:
   lds r16, 241
   lds r29, 190

--- a/llvm/test/MC/AVR/inst-lpm.s
+++ b/llvm/test/MC/AVR/inst-lpm.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=lpm,lpmx -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=lpm,lpmx < %s | llvm-objdump -d --mattr=lpm,lpmx - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=lpm,lpmx < %s | llvm-objdump -dr --mattr=lpm,lpmx - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   lpm
 
   lpm r3,  Z

--- a/llvm/test/MC/AVR/inst-lsl.s
+++ b/llvm/test/MC/AVR/inst-lsl.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   lsl r31
   lsl r25
   lsl r5

--- a/llvm/test/MC/AVR/inst-lsr.s
+++ b/llvm/test/MC/AVR/inst-lsr.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   lsr r31
   lsr r25
   lsr r5

--- a/llvm/test/MC/AVR/inst-mov.s
+++ b/llvm/test/MC/AVR/inst-mov.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   mov r2, r13
   mov r9, r0
   mov r5, r31

--- a/llvm/test/MC/AVR/inst-movw.s
+++ b/llvm/test/MC/AVR/inst-movw.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=movw -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=movw < %s | llvm-objdump -d --mattr=movw - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=movw < %s | llvm-objdump -dr --mattr=movw - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   movw r10, r8
   movw r12, r16
   movw r20, r22

--- a/llvm/test/MC/AVR/inst-mul.s
+++ b/llvm/test/MC/AVR/inst-mul.s
@@ -1,7 +1,6 @@
 ; RUN: llvm-mc -triple avr -mattr=mul -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s \
-; RUN:     | llvm-objdump -d --mattr=mul - | FileCheck --check-prefix=INST %s
-
+; RUN:     | llvm-objdump -dr --mattr=mul - | FileCheck --check-prefix=INST %s
 
 foo:
   mul r0,  r15

--- a/llvm/test/MC/AVR/inst-muls.s
+++ b/llvm/test/MC/AVR/inst-muls.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=mul -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -d --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -dr --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   muls r22, r16
   muls r19, r17
   muls r28, r31

--- a/llvm/test/MC/AVR/inst-mulsu.s
+++ b/llvm/test/MC/AVR/inst-mulsu.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=mul -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -d --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=mul < %s | llvm-objdump -dr --mattr=mul - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   mulsu r22, r16
   mulsu r19, r17
   mulsu r21, r23

--- a/llvm/test/MC/AVR/inst-neg.s
+++ b/llvm/test/MC/AVR/inst-neg.s
@@ -1,5 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
   neg r15

--- a/llvm/test/MC/AVR/inst-nop.s
+++ b/llvm/test/MC/AVR/inst-nop.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   nop
 
 ; CHECK: nop                  ; encoding: [0x00,0x00]

--- a/llvm/test/MC/AVR/inst-or.s
+++ b/llvm/test/MC/AVR/inst-or.s
@@ -1,6 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
   or r0,  r15

--- a/llvm/test/MC/AVR/inst-ori.s
+++ b/llvm/test/MC/AVR/inst-ori.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   ori r17, 208
   ori r24, 190
   ori r20, 173

--- a/llvm/test/MC/AVR/inst-out.s
+++ b/llvm/test/MC/AVR/inst-out.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   out 4,  r2
   out 6,  r9
   out 32, r5

--- a/llvm/test/MC/AVR/inst-pop.s
+++ b/llvm/test/MC/AVR/inst-pop.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump -d --mattr=sram - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump -dr --mattr=sram - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   pop r31
   pop r25
   pop r5

--- a/llvm/test/MC/AVR/inst-push.s
+++ b/llvm/test/MC/AVR/inst-push.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump -d --mattr=sram - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump -dr --mattr=sram - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   push r31
   push r25
   push r5

--- a/llvm/test/MC/AVR/inst-rcall.s
+++ b/llvm/test/MC/AVR/inst-rcall.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-ret.s
+++ b/llvm/test/MC/AVR/inst-ret.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   ret
 
 ; CHECK: ret                  ; encoding: [0x08,0x95]

--- a/llvm/test/MC/AVR/inst-reti.s
+++ b/llvm/test/MC/AVR/inst-reti.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   reti
 
 ; CHECK: reti                  ; encoding: [0x18,0x95]

--- a/llvm/test/MC/AVR/inst-rjmp.s
+++ b/llvm/test/MC/AVR/inst-rjmp.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ;
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump -d - \
+; RUN:     | llvm-objdump -dr - \
 ; RUN:     | FileCheck --check-prefix=INST %s
 
 foo:

--- a/llvm/test/MC/AVR/inst-rol.s
+++ b/llvm/test/MC/AVR/inst-rol.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   rol r31
   rol r25
   rol r5

--- a/llvm/test/MC/AVR/inst-ror.s
+++ b/llvm/test/MC/AVR/inst-ror.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   ror r31
   ror r25
   ror r5

--- a/llvm/test/MC/AVR/inst-sbc.s
+++ b/llvm/test/MC/AVR/inst-sbc.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   sbc r0,  r15
   sbc r15, r0
   sbc r16, r31

--- a/llvm/test/MC/AVR/inst-sbci.s
+++ b/llvm/test/MC/AVR/inst-sbci.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   sbci r17, 21
   sbci r23, 196
   sbci r30, 244

--- a/llvm/test/MC/AVR/inst-sbi.s
+++ b/llvm/test/MC/AVR/inst-sbi.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   sbi 3, 5
   sbi 1, 1
   sbi 7, 2

--- a/llvm/test/MC/AVR/inst-sbic.s
+++ b/llvm/test/MC/AVR/inst-sbic.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   sbic 4,  3
   sbic 6,  2
   sbic 16, 5

--- a/llvm/test/MC/AVR/inst-sbis.s
+++ b/llvm/test/MC/AVR/inst-sbis.s
@@ -1,6 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
   sbis 4,  3

--- a/llvm/test/MC/AVR/inst-sbiw.s
+++ b/llvm/test/MC/AVR/inst-sbiw.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=addsubiw -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=addsubiw < %s | llvm-objdump --no-print-imm-hex -dr --mattr=addsubiw - | FileCheck --check-prefix=CHECK-INST %s
 
-
 foo:
-
   sbiw r26, 54
   sbiw X,   63
 

--- a/llvm/test/MC/AVR/inst-sbr.s
+++ b/llvm/test/MC/AVR/inst-sbr.s
@@ -1,6 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
   sbr r17, 208

--- a/llvm/test/MC/AVR/inst-sbrc.s
+++ b/llvm/test/MC/AVR/inst-sbrc.s
@@ -1,10 +1,8 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=INST %s
-
+; RUN:     | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=INST %s
 
 foo:
-
   sbrc r2, 3
   sbrc r0, 7
 

--- a/llvm/test/MC/AVR/inst-sbrs.s
+++ b/llvm/test/MC/AVR/inst-sbrs.s
@@ -1,10 +1,8 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr < %s \
-; RUN:     | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=INST %s
-
+; RUN:     | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=INST %s
 
 foo:
-
   sbrs r2, 3
   sbrs r0, 7
 

--- a/llvm/test/MC/AVR/inst-ser.s
+++ b/llvm/test/MC/AVR/inst-ser.s
@@ -1,6 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
   ser r16

--- a/llvm/test/MC/AVR/inst-sleep.s
+++ b/llvm/test/MC/AVR/inst-sleep.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   sleep
 
 ; CHECK: sleep                  ; encoding: [0x88,0x95]

--- a/llvm/test/MC/AVR/inst-spm.s
+++ b/llvm/test/MC/AVR/inst-spm.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=spm,spmx -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=spm,spmx < %s | llvm-objdump -d --mattr=spm,spmx - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=spm,spmx < %s | llvm-objdump -dr --mattr=spm,spmx - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   spm
   spm Z+
 

--- a/llvm/test/MC/AVR/inst-st.s
+++ b/llvm/test/MC/AVR/inst-st.s
@@ -1,7 +1,6 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s \
-; RUN:     | llvm-objdump -d --mattr=sram - | FileCheck --check-prefix=INST %s
-
+; RUN:     | llvm-objdump -dr --mattr=sram - | FileCheck --check-prefix=INST %s
 
 foo:
   ; Normal

--- a/llvm/test/MC/AVR/inst-std.s
+++ b/llvm/test/MC/AVR/inst-std.s
@@ -1,9 +1,8 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s \
-; RUN:     | llvm-objdump -d --mattr=sram - | FileCheck --check-prefix=INST %s
+; RUN:     | llvm-objdump -dr --mattr=sram - | FileCheck --check-prefix=INST %s
 
 foo:
-
   std Y+2, r2
   std Y+0, r0
 

--- a/llvm/test/MC/AVR/inst-sts.s
+++ b/llvm/test/MC/AVR/inst-sts.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=sram -show-encoding < %s | FileCheck %s
 ; RUN: llvm-mc -filetype=obj -triple avr -mattr=sram < %s | llvm-objdump --no-print-imm-hex -dr --mattr=sram - | FileCheck -check-prefix=CHECK-INST %s
 
-
 foo:
-
   sts 3,        r5
   sts 255,      r7
   sts SYMBOL+1, r25

--- a/llvm/test/MC/AVR/inst-sub.s
+++ b/llvm/test/MC/AVR/inst-sub.s
@@ -1,6 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
   sub r0,  r15

--- a/llvm/test/MC/AVR/inst-subi.s
+++ b/llvm/test/MC/AVR/inst-subi.s
@@ -1,6 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump --no-print-imm-hex -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
   subi r22, 82

--- a/llvm/test/MC/AVR/inst-swap.s
+++ b/llvm/test/MC/AVR/inst-swap.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   swap r31
   swap r25
   swap r5

--- a/llvm/test/MC/AVR/inst-tst.s
+++ b/llvm/test/MC/AVR/inst-tst.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   tst r3
   tst r14
   tst r24

--- a/llvm/test/MC/AVR/inst-wdr.s
+++ b/llvm/test/MC/AVR/inst-wdr.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK-INST %s
 
 foo:
-
   wdr
 
 ; CHECK: wdr                  ; encoding: [0xa8,0x95]

--- a/llvm/test/MC/AVR/inst-xch.s
+++ b/llvm/test/MC/AVR/inst-xch.s
@@ -1,9 +1,7 @@
 ; RUN: llvm-mc -triple avr -mattr=rmw -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -d --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
-
+; RUN: llvm-mc -filetype=obj -triple avr -mattr=rmw < %s | llvm-objdump -dr --mattr=rmw - | FileCheck -check-prefix=CHECK-INST %s
 
 foo:
-
   xch Z, r13
   xch Z, r0
   xch Z, r31

--- a/llvm/test/MC/AVR/modifiers.s
+++ b/llvm/test/MC/AVR/modifiers.s
@@ -4,7 +4,6 @@
 ; FIXME: most of these tests use values (i.e. 0x0815) that are out of bounds.
 
 foo:
-
     ldi r24, lo8(0x42)
     ldi r24, lo8(0x2342)
 
@@ -17,9 +16,7 @@ foo:
 ; CHECK: ldi  r24, lo8(35)          ; encoding: [0x83,0xe2]
 ; CHECK: ldi  r24, hi8(9026)        ; encoding: [0x83,0xe2]
 
-
 bar:
-
     ldi r24, lo8(bar)
     ldi r24, hi8(bar)
 
@@ -29,7 +26,6 @@ bar:
 ; CHECK:                            ; fixup A - offset: 0, value: hi8(bar), kind: fixup_hi8_ldi
 
 lo8:
-
     ldi r24, lo8(0x0815)
     ldi r24, lo8(foo)
     ldi r24, lo8(bar + 5)
@@ -41,7 +37,6 @@ lo8:
 ; CHECK:                            ; fixup A - offset: 0, value: lo8(bar+5), kind: fixup_lo8_ldi
 
 lo8_neg:
-
     ldi r24, lo8(-(123456))
     ldi r24, lo8(-(foo))
 
@@ -50,7 +45,6 @@ lo8_neg:
 ; CHECK:                            ; fixup A - offset: 0, value: lo8(-(foo)), kind: fixup_lo8_ldi_neg
 
 hi8:
-
     ldi r24, hi8(0x0815)
     ldi r24, hi8(foo)
     ldi r24, hi8(bar + 5)
@@ -62,7 +56,6 @@ hi8:
 ; CHECK:                            ; fixup A - offset: 0, value: hi8(bar+5), kind: fixup_hi8_ldi
 
 hi8_neg:
-
     ldi r24, hi8(-(123456))
     ldi r24, hi8(-(foo))
 
@@ -71,7 +64,6 @@ hi8_neg:
 ; CHECK:                            ; fixup A - offset: 0, value: hi8(-(foo)), kind: fixup_hi8_ldi_neg
 
 hh8:
-
     ldi r24, hh8(0x0815)
     ldi r24, hh8(foo)
     ldi r24, hh8(bar + 5)
@@ -83,7 +75,6 @@ hh8:
 ; CHECK:                            ; fixup A - offset: 0, value: hh8(bar+5), kind: fixup_hh8_ldi
 
 hh8_neg:
-
     ldi r24, hh8(-(123456))
     ldi r24, hh8(-(foo))
 
@@ -92,7 +83,6 @@ hh8_neg:
 ; CHECK:                            ; fixup A - offset: 0, value: hh8(-(foo)), kind: fixup_hh8_ldi_neg
 
 hlo8: ; synonym with hh8() above, hence the... odd results
-
     ldi r24, hlo8(0x0815)
     ldi r24, hlo8(foo)
     ldi r24, hlo8(bar + 5)
@@ -104,17 +94,14 @@ hlo8: ; synonym with hh8() above, hence the... odd results
 ; CHECK:                            ; fixup A - offset: 0, value: hh8(bar+5), kind: fixup_hh8_ldi
 
 hlo8_neg:
-
     ldi r24, hlo8(-(123456))
     ldi r24, hlo8(-(foo))
-
 
 ; CHECK: ldi  r24, hh8(-(123456))  ; encoding: [0x8e,0xef]
 ; CHECK: ldi  r24, hh8(-(foo))     ; encoding: [0x80'A',0xe0]
 ; CHECK:                           ; fixup A - offset: 0, value: hh8(-(foo)), kind: fixup_hh8_ldi_neg
 
 hhi8:
-
     ldi r24, hhi8(0x0815)
     ldi r24, hhi8(foo)
     ldi r24, hhi8(bar + 5)
@@ -166,7 +153,6 @@ pm_hh8:
 ; CHECK:                            ; fixup A - offset: 0, value: pm_hh8(foo), kind: fixup_hh8_ldi_pm
 ; CHECK: ldi  r24, pm_hh8(bar+5)    ; encoding: [0x80'A',0xe0]
 ; CHECK:                            ; fixup A - offset: 0, value: pm_hh8(bar+5), kind: fixup_hh8_ldi_pm
-
 
 pm_lo8_neg:
     ldi r24, pm_lo8(-(0x0815))

--- a/llvm/test/MC/AVR/registers.s
+++ b/llvm/test/MC/AVR/registers.s
@@ -1,5 +1,5 @@
 ; RUN: llvm-mc -triple avr -show-encoding < %s | FileCheck %s
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck -check-prefix=CHECK-INST %s
 
 ; Test register aliases: the upper 6 registers have aliases that can be used in
 ; assembly.

--- a/llvm/test/MC/AVR/relocations-abs.s
+++ b/llvm/test/MC/AVR/relocations-abs.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -filetype=obj -triple=avr %s | llvm-objdump -d -r - | FileCheck %s
+; RUN: llvm-mc -filetype=obj -triple=avr %s | llvm-objdump -dr -r - | FileCheck %s
 
 ; CHECK: <bar>:
 ; CHECK-NEXT: 00 00 nop

--- a/llvm/test/MC/AVR/relocations.s
+++ b/llvm/test/MC/AVR/relocations.s
@@ -3,6 +3,7 @@
 ; CHECK: RELOCATION RECORDS FOR
 
 .global bar
+
 bar:
   jmp bar
 

--- a/llvm/test/MC/AVR/separator.s
+++ b/llvm/test/MC/AVR/separator.s
@@ -1,7 +1,6 @@
-; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -d - | FileCheck %s
+; RUN: llvm-mc -filetype=obj -triple avr < %s | llvm-objdump -dr - | FileCheck %s
 
 foo:
-
   ; The $ symbol is a separator (like a newline).
   mov r0, r1 $ mov r1, r2 $ mov r2, r3 $ mov r3, r4
 

--- a/llvm/test/MC/AVR/syntax-reg-int-literal.s
+++ b/llvm/test/MC/AVR/syntax-reg-int-literal.s
@@ -7,7 +7,6 @@ foo:
   add r16, r31
   add 31,  r16
 
-
 ; CHECK: add r0,  r15               ; encoding: [0x0f,0x0c]
 ; CHECK: add r15, r0                ; encoding: [0xf0,0x0c]
 ; CHECK: add r16, r31               ; encoding: [0x0f,0x0f]

--- a/llvm/test/MC/AVR/syntax-reg-pair.s
+++ b/llvm/test/MC/AVR/syntax-reg-pair.s
@@ -1,7 +1,6 @@
 ; RUN: llvm-mc -triple avr -mattr=addsubiw -show-encoding < %s | FileCheck %s
 
 foo:
-
   sbiw r24,     1
   sbiw r25:r24, 2
   sbiw r24,     2


### PR DESCRIPTION
This is just a small refactoring extracted from https://github.com/llvm/llvm-project/pull/102936 - it's mostly adjusting the tests to common format, but we're also changing invocations of `llvm-objdump` from `-d` to `-dr`, so that we know when we generate relocations.

(i.e. relative jumps don't generate relocations at the moment, but will start soon™️ and we'll have those tests as proofs)

cc @benshi001 