### PR TITLE
[KnownBits] Add KnownBits::makeInclusiveRange to determine the known bits from a pair of unsigned lo/hi bound values

### DIFF
--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -291,6 +291,9 @@ public:
     return KnownBits(~C, C);
   }
 
+  /// Create known bits from a known INCLUSIVE pair of unsigned constants.
+  static KnownBits makeInclusiveRange(const APInt &Lower, const APInt &Upper);
+
   /// Returns KnownBits information that is known to be true for both this and
   /// RHS.
   ///

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -750,6 +750,21 @@ static KnownBits computeForSatAddSub(bool Add, bool Signed,
   return Res;
 }
 
+KnownBits KnownBits::makeInclusiveRange(const APInt &Lower,
+                                        const APInt &Upper) {
+  assert(Lower.getBitWidth() == Upper.getBitWidth() && "Bitwidth mismatch");
+  assert(Lower.ule(Upper) && "Constant range mismatch");
+
+  KnownBits Known = KnownBits::makeConstant(Lower);
+  if (std::optional<unsigned> DifferentBit =
+          APIntOps::GetMostSignificantDifferentBit(Lower, Upper)) {
+    Known.Zero.clearLowBits(*DifferentBit + 1);
+    Known.One.clearLowBits(*DifferentBit + 1);
+  }
+
+  return Known;
+}
+
 KnownBits KnownBits::sadd_sat(const KnownBits &LHS, const KnownBits &RHS) {
   return computeForSatAddSub(/*Add*/ true, /*Signed*/ true, LHS, RHS);
 }

--- a/llvm/unittests/Support/KnownBitsTest.cpp
+++ b/llvm/unittests/Support/KnownBitsTest.cpp
@@ -668,6 +668,23 @@ TEST(KnownBitsTest, ICmpExhaustive) {
   });
 }
 
+TEST(KnownBitsTest, InclusiveRange) {
+  unsigned Bits = 4;
+  unsigned MaxValue = (1U << Bits) - 1;
+  for (unsigned Lo = 0; Lo <= MaxValue; ++Lo) {
+    const APInt LoInt(Bits, Lo);
+    for (unsigned Hi = Lo; Hi <= MaxValue; ++Hi) {
+      KnownBits Ref = KnownBits::makeConstant(LoInt);
+      for (unsigned I = Lo + 1; I <= Hi; ++I)
+        Ref = Ref.intersectWith(KnownBits::makeConstant(APInt(Bits, I)));
+
+      KnownBits Known = KnownBits::makeInclusiveRange(LoInt, APInt(Bits, Hi));
+      EXPECT_EQ(Ref.Zero, Known.Zero);
+      EXPECT_EQ(Ref.One, Known.One);
+    }
+  }
+}
+
 TEST(KnownBitsTest, GetMinMaxVal) {
   unsigned Bits = 4;
   ForeachKnownBits(Bits, [&](const KnownBits &Known) {


### PR DESCRIPTION
If we have the lower/upper bounds for a value, determine the known bits shared by all values within those bounds.

Unlike llvm::ConstantRange, these bounds values are INCLUSIVE (to stop overflow issues in some future use cases).