### PR TITLE
[TableGen] Add `CodeGenIntrinsicsMap` for on-demand intrinsic creation

### DIFF
--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
@@ -15,6 +15,7 @@
 
 #include "SDNodeProperties.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ModRef.h"
 #include <string>
@@ -24,6 +25,12 @@
 namespace llvm {
 class Record;
 class RecordKeeper;
+
+// Global information needed to build intrinsics.
+struct CodeGenIntrinsicContext {
+  explicit CodeGenIntrinsicContext(const RecordKeeper &RC);
+  std::vector<const Record *> DefaultProperties;
+};
 
 struct CodeGenIntrinsic {
   const Record *TheDef; // The actual record defining this intrinsic.
@@ -155,8 +162,7 @@ struct CodeGenIntrinsic {
 
   bool isParamImmArg(unsigned ParamIdx) const;
 
-  CodeGenIntrinsic(const Record *R,
-                   ArrayRef<const Record *> DefaultProperties = {});
+  CodeGenIntrinsic(const Record *R, const CodeGenIntrinsicContext &Ctx);
 };
 
 class CodeGenIntrinsicTable {
@@ -171,7 +177,6 @@ public:
   std::vector<TargetSet> Targets;
 
   explicit CodeGenIntrinsicTable(const RecordKeeper &RC);
-  CodeGenIntrinsicTable() = default;
 
   bool empty() const { return Intrinsics.empty(); }
   size_t size() const { return Intrinsics.size(); }
@@ -182,6 +187,17 @@ public:
     return Intrinsics[Pos];
   }
 };
+
+// This class builds `CodeGenIntrinsic` on demand for a given Def.
+class CodeGenIntrinsicMap {
+  DenseMap<const Record *, std::unique_ptr<CodeGenIntrinsic>> Map;
+  const CodeGenIntrinsicContext Ctx;
+
+public:
+  explicit CodeGenIntrinsicMap(const RecordKeeper &RC) : Ctx(RC) {}
+  CodeGenIntrinsic &operator[](const Record *Def);
+};
+
 } // namespace llvm
 
 #endif // LLVM_UTILS_TABLEGEN_BASIC_CODEGENINTRINSICS_H

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -3160,10 +3160,8 @@ void TreePattern::dump() const { print(errs()); }
 
 CodeGenDAGPatterns::CodeGenDAGPatterns(RecordKeeper &R,
                                        PatternRewriterFn PatternRewriter)
-    : Records(R), Target(R), LegalVTS(Target.getLegalValueTypes()),
-      PatternRewriter(PatternRewriter) {
-
-  Intrinsics = CodeGenIntrinsicTable(Records);
+    : Records(R), Target(R), Intrinsics(R),
+      LegalVTS(Target.getLegalValueTypes()), PatternRewriter(PatternRewriter) {
   ParseNodeInfo();
   ParseNodeTransforms();
   ParseComplexPatterns();

--- a/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
@@ -107,13 +107,10 @@ getInstrForIntrinsic(const CodeGenTarget &CGT, const CodeGenIntrinsic *I) {
 static const CodeGenIntrinsic *getCodeGenIntrinsic(Record *R) {
   // Intrinsics need to have a static lifetime because the match table keeps
   // references to CodeGenIntrinsic objects.
-  static DenseMap<const Record *, std::unique_ptr<CodeGenIntrinsic>>
-      AllIntrinsics;
-
-  auto &Ptr = AllIntrinsics[R];
-  if (!Ptr)
-    Ptr = std::make_unique<CodeGenIntrinsic>(R);
-  return Ptr.get();
+  static CodeGenIntrinsicMap *AllIntrinsics;
+  if (!AllIntrinsics)
+    AllIntrinsics = new CodeGenIntrinsicMap(R->getRecords());
+  return &(*AllIntrinsics)[R];
 }
 
 std::unique_ptr<Pattern>


### PR DESCRIPTION
- Add class `CodeGenIntrinsicMap` for on-demand creation of  
  `CodeGenIntrinsic`.
- Add class `CodeGenIntrinsicContext` to capture global information
  required to build `CodeGenIntrinsic` objects.
- Adopt GlobalISel PatternParser and SearchableTableEmitter to use it.