### PR TITLE
[RISCV] Rename sf_vcix_state to sf.vcix_state. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -665,4 +665,4 @@ def FRM    : RISCVReg<0, "frm">;
 def SSP    : RISCVReg<0, "ssp">;
 
 // Dummy SiFive VCIX state register
-def SF_VCIX_STATE : RISCVReg<0, "sf_vcix_state">;
+def SF_VCIX_STATE : RISCVReg<0, "sf.vcix_state">;


### PR DESCRIPTION
This PR: https://github.com/llvm/llvm-project/pull/106995 names the
vendor CSR in a wrong way, it should be `sf.` rather than `sf_` for
prefix.
