### PR TITLE
Allow disabling of types from the command line

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6761,6 +6761,12 @@ def fdefault_integer_8 : Flag<["-"],"fdefault-integer-8">, Group<f_Group>,
   HelpText<"Set the default integer and logical kind to an 8 byte wide type">;
 def fdefault_real_8 : Flag<["-"],"fdefault-real-8">, Group<f_Group>,
   HelpText<"Set the default real kind to an 8 byte wide type">;
+def fdisable_real_3 : Flag<["-"],"fdisable-real-3">, Group<f_Group>,
+  Flags<[HelpHidden]>;
+def fdisable_real_10 : Flag<["-"],"fdisable-real-10">, Group<f_Group>,
+  Flags<[HelpHidden]>;
+def fdisable_integer_16 : Flag<["-"],"fdisable-integer-16">, Group<f_Group>,
+  Flags<[HelpHidden]>;
 def flarge_sizes : Flag<["-"],"flarge-sizes">, Group<f_Group>,
   HelpText<"Use INTEGER(KIND=8) for the result type in size-related intrinsics">;
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6762,11 +6762,13 @@ def fdefault_integer_8 : Flag<["-"],"fdefault-integer-8">, Group<f_Group>,
 def fdefault_real_8 : Flag<["-"],"fdefault-real-8">, Group<f_Group>,
   HelpText<"Set the default real kind to an 8 byte wide type">;
 def fdisable_real_3 : Flag<["-"],"fdisable-real-3">, Group<f_Group>,
-  Flags<[HelpHidden]>;
+   HelpText<"Disable real(KIND=3) from TargetCharacteristics">, Flags<[HelpHidden]>;
 def fdisable_real_10 : Flag<["-"],"fdisable-real-10">, Group<f_Group>,
-  Flags<[HelpHidden]>;
+  HelpText<"Disable real(KIND=10) from TargetCharacteristics">, Flags<[HelpHidden]>;
+def fdisable_integer_2 : Flag<["-"],"fdisable-integer-2">, Group<f_Group>,
+  HelpText<"Disable integer(KIND=2) from TargetCharacteristics">, Flags<[HelpHidden]>;
 def fdisable_integer_16 : Flag<["-"],"fdisable-integer-16">, Group<f_Group>,
-  Flags<[HelpHidden]>;
+  HelpText<"Disable integer(KIND=16) from TargetCharacteristics">, Flags<[HelpHidden]>;
 def flarge_sizes : Flag<["-"],"flarge-sizes">, Group<f_Group>,
   HelpText<"Use INTEGER(KIND=8) for the result type in size-related intrinsics">;
 

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -41,7 +41,7 @@ public:
 
   /// The real KINDs disabled for this target
   std::vector<int> disabledRealKinds;
-  
+
   /// The integer KINDs disabled for this target
   std::vector<int> disabledIntegerKinds;
 };

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -38,6 +38,12 @@ public:
   /// The list of target specific features to enable or disable, as written on
   /// the command line.
   std::vector<std::string> featuresAsWritten;
+
+  /// The real KINDs disabled for this target
+  std::vector<int> disabledRealKinds;
+  
+  /// The integer KINDs disabled for this target
+  std::vector<int> disabledIntegerKinds;
 };
 
 } // end namespace Fortran::frontend

--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -26,12 +26,13 @@ namespace Fortran::tools {
   if (targetTriple.getArch() != llvm::Triple::ArchType::x86_64)
     targetCharacteristics.DisableType(
         Fortran::common::TypeCategory::Real, /*kind=*/10);
-  for (auto realKind : targetOptions.disabledRealKinds) {
+        
+  for (auto realKind : targetOptions.disabledRealKinds)
     targetCharacteristics.DisableType(common::TypeCategory::Real, realKind);
-  }
-  for (auto intKind : targetOptions.disabledIntegerKinds) {
+
+  for (auto intKind : targetOptions.disabledIntegerKinds)
     targetCharacteristics.DisableType(common::TypeCategory::Integer, intKind);
-  }
+
   targetCharacteristics.set_compilerOptionsString(compilerOptions)
       .set_compilerVersionString(compilerVersion);
 

--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -26,7 +26,7 @@ namespace Fortran::tools {
   if (targetTriple.getArch() != llvm::Triple::ArchType::x86_64)
     targetCharacteristics.DisableType(
         Fortran::common::TypeCategory::Real, /*kind=*/10);
-        
+
   for (auto realKind : targetOptions.disabledRealKinds)
     targetCharacteristics.DisableType(common::TypeCategory::Real, realKind);
 

--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -27,12 +27,10 @@ namespace Fortran::tools {
     targetCharacteristics.DisableType(
         Fortran::common::TypeCategory::Real, /*kind=*/10);
   for (auto realKind : targetOptions.disabledRealKinds) {
-    targetCharacteristics.DisableType(
-        common::TypeCategory::Real, realKind);
+    targetCharacteristics.DisableType(common::TypeCategory::Real, realKind);
   }
   for (auto intKind : targetOptions.disabledIntegerKinds) {
-    targetCharacteristics.DisableType(
-        common::TypeCategory::Integer, intKind);
+    targetCharacteristics.DisableType(common::TypeCategory::Integer, intKind);
   }
   targetCharacteristics.set_compilerOptionsString(compilerOptions)
       .set_compilerVersionString(compilerVersion);

--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -10,6 +10,7 @@
 #define FORTRAN_TOOLS_TARGET_SETUP_H
 
 #include "flang/Evaluate/target.h"
+#include "flang/Frontend/TargetOptions.h"
 #include "llvm/Target/TargetMachine.h"
 
 namespace Fortran::tools {
@@ -17,6 +18,7 @@ namespace Fortran::tools {
 [[maybe_unused]] inline static void setUpTargetCharacteristics(
     Fortran::evaluate::TargetCharacteristics &targetCharacteristics,
     const llvm::TargetMachine &targetMachine,
+    const Fortran::frontend::TargetOptions &targetOptions,
     const std::string &compilerVersion, const std::string &compilerOptions) {
 
   const llvm::Triple &targetTriple{targetMachine.getTargetTriple()};
@@ -24,7 +26,14 @@ namespace Fortran::tools {
   if (targetTriple.getArch() != llvm::Triple::ArchType::x86_64)
     targetCharacteristics.DisableType(
         Fortran::common::TypeCategory::Real, /*kind=*/10);
-
+  for (auto realKind : targetOptions.disabledRealKinds) {
+    targetCharacteristics.DisableType(
+        common::TypeCategory::Real, realKind);
+  }
+  for (auto intKind : targetOptions.disabledIntegerKinds) {
+    targetCharacteristics.DisableType(
+        common::TypeCategory::Integer, intKind);
+  }
   targetCharacteristics.set_compilerOptionsString(compilerOptions)
       .set_compilerVersionString(compilerVersion);
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -439,17 +439,17 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
        args.filtered(clang::driver::options::OPT_target_feature))
     opts.featuresAsWritten.emplace_back(currentArg->getValue());
 
-  if (args.hasArg(clang::driver::options::OPT_fdisable_real_10)) {
+  if (args.hasArg(clang::driver::options::OPT_fdisable_real_10))
     opts.disabledRealKinds.push_back(10);
-  }
 
-  if (args.hasArg(clang::driver::options::OPT_fdisable_real_3)) {
+  if (args.hasArg(clang::driver::options::OPT_fdisable_real_3)) 
     opts.disabledRealKinds.push_back(3);
-  }
 
-  if (args.hasArg(clang::driver::options::OPT_fdisable_integer_16)) {
+  if (args.hasArg(clang::driver::options::OPT_fdisable_integer_2))
+    opts.disabledIntegerKinds.push_back(2);
+
+  if (args.hasArg(clang::driver::options::OPT_fdisable_integer_16))
     opts.disabledIntegerKinds.push_back(16);
-  }
 }
 // Tweak the frontend configuration based on the frontend action
 static void setUpFrontendBasedOnAction(FrontendOptions &opts) {

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -442,11 +442,11 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
   if (args.hasArg(clang::driver::options::OPT_fdisable_real_10)) {
     opts.disabledRealKinds.push_back(10);
   }
-  
+
   if (args.hasArg(clang::driver::options::OPT_fdisable_real_3)) {
     opts.disabledRealKinds.push_back(3);
   }
-  
+
   if (args.hasArg(clang::driver::options::OPT_fdisable_integer_16)) {
     opts.disabledIntegerKinds.push_back(16);
   }

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -438,8 +438,19 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
   for (const llvm::opt::Arg *currentArg :
        args.filtered(clang::driver::options::OPT_target_feature))
     opts.featuresAsWritten.emplace_back(currentArg->getValue());
-}
 
+  if (args.hasArg(clang::driver::options::OPT_fdisable_real_10)) {
+    opts.disabledRealKinds.push_back(10);
+  }
+  
+  if (args.hasArg(clang::driver::options::OPT_fdisable_real_3)) {
+    opts.disabledRealKinds.push_back(3);
+  }
+  
+  if (args.hasArg(clang::driver::options::OPT_fdisable_integer_16)) {
+    opts.disabledIntegerKinds.push_back(16);
+  }
+}
 // Tweak the frontend configuration based on the frontend action
 static void setUpFrontendBasedOnAction(FrontendOptions &opts) {
   if (opts.programAction == DebugDumpParsingLog)
@@ -1529,8 +1540,8 @@ CompilerInvocation::getSemanticsCtx(
 
   std::string compilerVersion = Fortran::common::getFlangFullVersion();
   Fortran::tools::setUpTargetCharacteristics(
-      semanticsContext->targetCharacteristics(), targetMachine, compilerVersion,
-      allCompilerInvocOpts);
+      semanticsContext->targetCharacteristics(), targetMachine, getTargetOpts(),
+      compilerVersion, allCompilerInvocOpts);
   return semanticsContext;
 }
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -442,7 +442,7 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
   if (args.hasArg(clang::driver::options::OPT_fdisable_real_10))
     opts.disabledRealKinds.push_back(10);
 
-  if (args.hasArg(clang::driver::options::OPT_fdisable_real_3)) 
+  if (args.hasArg(clang::driver::options::OPT_fdisable_real_3))
     opts.disabledRealKinds.push_back(3);
 
   if (args.hasArg(clang::driver::options::OPT_fdisable_integer_2))

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -18,6 +18,7 @@
 #include "flang/Common/OpenMP-features.h"
 #include "flang/Common/Version.h"
 #include "flang/Common/default-kinds.h"
+#include "flang/Frontend/TargetOptions.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/Support/Verifier.h"
@@ -556,8 +557,8 @@ int main(int argc, char **argv) {
   std::string compilerVersion = Fortran::common::getFlangToolFullVersion("bbc");
   std::string compilerOptions = "";
   Fortran::tools::setUpTargetCharacteristics(
-      semanticsContext.targetCharacteristics(), *targetMachine, compilerVersion,
-      compilerOptions);
+      semanticsContext.targetCharacteristics(), *targetMachine,
+      {}, compilerVersion, compilerOptions);
 
   return mlir::failed(
       convertFortranSourceToMLIR(inputFilename, options, programPrefix,

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -557,8 +557,8 @@ int main(int argc, char **argv) {
   std::string compilerVersion = Fortran::common::getFlangToolFullVersion("bbc");
   std::string compilerOptions = "";
   Fortran::tools::setUpTargetCharacteristics(
-      semanticsContext.targetCharacteristics(), *targetMachine,
-      {}, compilerVersion, compilerOptions);
+      semanticsContext.targetCharacteristics(), *targetMachine, {},
+      compilerVersion, compilerOptions);
 
   return mlir::failed(
       convertFortranSourceToMLIR(inputFilename, options, programPrefix,


### PR DESCRIPTION
I would to add hidden options to disable types through the `TargetCharacteristics`. I am seeing issues when I do this programmatically and would like, for anyone, to have the ability to reproduce them for development and testing purposes. 

I am planning to file a couple of issues following this patch.
