### PR TITLE
[SandboxIR] Implement ConstantAggregate

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIRValues.def
+++ b/llvm/include/llvm/SandboxIR/SandboxIRValues.def
@@ -27,6 +27,9 @@ DEF_VALUE(Block, BasicBlock)
 DEF_CONST(Constant, Constant)
 DEF_CONST(ConstantInt, ConstantInt)
 DEF_CONST(ConstantFP, ConstantFP)
+DEF_CONST(ConstantArray, ConstantArray)
+DEF_CONST(ConstantStruct, ConstantStruct)
+DEF_CONST(ConstantVector, ConstantVector)
 
 #ifndef DEF_INSTR
 #define DEF_INSTR(ID, OPCODE, CLASS)

--- a/llvm/include/llvm/SandboxIR/Type.h
+++ b/llvm/include/llvm/SandboxIR/Type.h
@@ -27,6 +27,8 @@ class PointerType;
 class VectorType;
 class IntegerType;
 class FunctionType;
+class ArrayType;
+class StructType;
 #define DEF_INSTR(ID, OPCODE, CLASS) class CLASS;
 #define DEF_CONST(ID, CLASS) class CLASS;
 #include "llvm/SandboxIR/SandboxIRValues.def"
@@ -36,13 +38,19 @@ class FunctionType;
 class Type {
 protected:
   llvm::Type *LLVMTy;
-  friend class VectorType;   // For LLVMTy.
-  friend class PointerType;  // For LLVMTy.
-  friend class FunctionType; // For LLVMTy.
-  friend class IntegerType;  // For LLVMTy.
-  friend class Function;     // For LLVMTy.
-  friend class CallBase;     // For LLVMTy.
-  friend class ConstantInt;  // For LLVMTy.
+  friend class ArrayType;      // For LLVMTy.
+  friend class StructType;     // For LLVMTy.
+  friend class VectorType;     // For LLVMTy.
+  friend class PointerType;    // For LLVMTy.
+  friend class FunctionType;   // For LLVMTy.
+  friend class IntegerType;    // For LLVMTy.
+  friend class Function;       // For LLVMTy.
+  friend class CallBase;       // For LLVMTy.
+  friend class ConstantInt;    // For LLVMTy.
+  friend class ConstantArray;  // For LLVMTy.
+  friend class ConstantStruct; // For LLVMTy.
+  friend class ConstantVector; // For LLVMTy.
+
   // Friend all instruction classes because `create()` functions use LLVMTy.
 #define DEF_INSTR(ID, OPCODE, CLASS) friend class CLASS;
 #define DEF_CONST(ID, CLASS) friend class CLASS;
@@ -281,8 +289,31 @@ public:
   }
 };
 
+class ArrayType : public Type {
+public:
+  // TODO: add missing functions
+  static bool classof(const Type *From) {
+    return isa<llvm::ArrayType>(From->LLVMTy);
+  }
+};
+
+class StructType : public Type {
+public:
+  /// This static method is the primary way to create a literal StructType.
+  static StructType *get(Context &Ctx, ArrayRef<Type *> Elements,
+                         bool IsPacked = false);
+
+  bool isPacked() const { return cast<llvm::StructType>(LLVMTy)->isPacked(); }
+
+  // TODO: add missing functions
+  static bool classof(const Type *From) {
+    return isa<llvm::StructType>(From->LLVMTy);
+  }
+};
+
 class VectorType : public Type {
 public:
+  static VectorType *get(Type *ElementType, ElementCount EC);
   // TODO: add missing functions
   static bool classof(const Type *From) {
     return isa<llvm::VectorType>(From->LLVMTy);

--- a/llvm/lib/SandboxIR/Type.cpp
+++ b/llvm/lib/SandboxIR/Type.cpp
@@ -47,6 +47,21 @@ PointerType *PointerType::get(Context &Ctx, unsigned AddressSpace) {
       Ctx.getType(llvm::PointerType::get(Ctx.LLVMCtx, AddressSpace)));
 }
 
+StructType *StructType::get(Context &Ctx, ArrayRef<Type *> Elements,
+                            bool IsPacked) {
+  SmallVector<llvm::Type *> LLVMElements;
+  LLVMElements.reserve(Elements.size());
+  for (Type *Elm : Elements)
+    LLVMElements.push_back(Elm->LLVMTy);
+  return cast<StructType>(
+      Ctx.getType(llvm::StructType::get(Ctx.LLVMCtx, LLVMElements, IsPacked)));
+}
+
+VectorType *VectorType::get(Type *ElementType, ElementCount EC) {
+  return cast<VectorType>(ElementType->getContext().getType(
+      llvm::VectorType::get(ElementType->LLVMTy, EC)));
+}
+
 IntegerType *IntegerType::get(Context &Ctx, unsigned NumBits) {
   return cast<IntegerType>(
       Ctx.getType(llvm::IntegerType::get(Ctx.LLVMCtx, NumBits)));

--- a/llvm/unittests/SandboxIR/TypesTest.cpp
+++ b/llvm/unittests/SandboxIR/TypesTest.cpp
@@ -224,6 +224,44 @@ define void @foo(ptr %ptr) {
   EXPECT_EQ(NewPtrTy2, PtrTy);
 }
 
+TEST_F(SandboxTypeTest, ArrayType) {
+  parseIR(C, R"IR(
+define void @foo([2 x i8] %v0) {
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  // Check classof(), creation.
+  [[maybe_unused]] auto *ArrayTy =
+      cast<sandboxir::ArrayType>(F->getArg(0)->getType());
+}
+
+TEST_F(SandboxTypeTest, StructType) {
+  parseIR(C, R"IR(
+define void @foo({i32, i8} %v0) {
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *Int32Ty = sandboxir::Type::getInt32Ty(Ctx);
+  auto *Int8Ty = sandboxir::Type::getInt8Ty(Ctx);
+  // Check classof(), creation.
+  [[maybe_unused]] auto *StructTy =
+      cast<sandboxir::StructType>(F->getArg(0)->getType());
+  // Check get().
+  auto *NewStructTy = sandboxir::StructType::get(Ctx, {Int32Ty, Int8Ty});
+  EXPECT_EQ(NewStructTy, StructTy);
+  // Check get(Packed).
+  auto *NewStructTyPacked =
+      sandboxir::StructType::get(Ctx, {Int32Ty, Int8Ty}, /*Packed=*/true);
+  EXPECT_NE(NewStructTyPacked, StructTy);
+  EXPECT_TRUE(NewStructTyPacked->isPacked());
+}
+
 TEST_F(SandboxTypeTest, VectorType) {
   parseIR(C, R"IR(
 define void @foo(<2 x i8> %v0) {


### PR DESCRIPTION
This patch implements sandboxir:: ConstantAggregate, ConstantStruct, ConstantArray and ConstantVector, mirroring LLVM IR.