### PR TITLE
[libc++][test] Add default member initializers to `TestCaseMapSet`

### DIFF
--- a/libcxx/test/std/containers/insert_range_maps_sets.h
+++ b/libcxx/test/std/containers/insert_range_maps_sets.h
@@ -70,10 +70,10 @@ constexpr bool test_map_constraints_insert_range() {
 
 template <class T>
 struct TestCaseMapSet {
-  Buffer<T> initial;
-  Buffer<T> input;
-  Buffer<T> expected;
-  Buffer<T> expected_multi;
+  Buffer<T> initial{};
+  Buffer<T> input{};
+  Buffer<T> expected{};
+  Buffer<T> expected_multi{};
 };
 
 // Empty container.


### PR DESCRIPTION
These do-nothing initializers (`Buffer<T>` is fully initialized, so value-init and default-init are equivalent) silence Clang 18 `-Wmissing-field-initializers` warnings when the functions in the same header use designated initializers for `TestCaseMapSet`. (Clang 19+ doesn't emit this warning for designated initializers.)