### PR TITLE
[libc++][modules] Consolidate leaf modules into their own top-level modules

### DIFF
--- a/libcxx/include/__filesystem/directory_entry.h
+++ b/libcxx/include/__filesystem/directory_entry.h
@@ -20,6 +20,7 @@
 #include <__filesystem/operations.h>
 #include <__filesystem/path.h>
 #include <__filesystem/perms.h>
+#include <__fwd/ostream.h>
 #include <__system_error/errc.h>
 #include <__system_error/error_code.h>
 #include <__utility/move.h>

--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -21,6 +21,7 @@
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/remove_const.h>
 #include <__type_traits/remove_pointer.h>
+#include <__utility/move.h>
 #include <cstddef>
 #include <string>
 #include <string_view>

--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -21,6 +21,7 @@
 #include <__config>
 #include <__fwd/mdspan.h>
 #include <__mdspan/extents.h>
+#include <__type_traits/common_type.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_nothrow_constructible.h>

--- a/libcxx/include/__mdspan/layout_right.h
+++ b/libcxx/include/__mdspan/layout_right.h
@@ -21,6 +21,7 @@
 #include <__config>
 #include <__fwd/mdspan.h>
 #include <__mdspan/extents.h>
+#include <__type_traits/common_type.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_nothrow_constructible.h>

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -18,12 +18,15 @@
 #define _LIBCPP___MDSPAN_LAYOUT_STRIDE_H
 
 #include <__assert>
+#include <__concepts/same_as.h>
 #include <__config>
 #include <__fwd/mdspan.h>
 #include <__mdspan/extents.h>
+#include <__type_traits/common_type.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_nothrow_constructible.h>
+#include <__type_traits/is_same.h>
 #include <__utility/as_const.h>
 #include <__utility/integer_sequence.h>
 #include <__utility/swap.h>
@@ -31,6 +34,7 @@
 #include <cinttypes>
 #include <cstddef>
 #include <limits>
+#include <span>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -29,6 +29,16 @@ module std_bitset [system] {
 }
 module std_charconv [system] {
   header "charconv"
+  module chars_format            { header "__charconv/chars_format.h" }
+  module from_chars_integral     { header "__charconv/from_chars_integral.h" }
+  module from_chars_result       { header "__charconv/from_chars_result.h" }
+  module tables                  { header "__charconv/tables.h" }
+  module to_chars                { header "__charconv/to_chars.h" }
+  module to_chars_base_10        { header "__charconv/to_chars_base_10.h" }
+  module to_chars_floating_point { header "__charconv/to_chars_floating_point.h" }
+  module to_chars_integral       { header "__charconv/to_chars_integral.h" }
+  module to_chars_result         { header "__charconv/to_chars_result.h" }
+  module traits                  { header "__charconv/traits.h" }
   export *
 }
 module std_chrono [system] {
@@ -53,10 +63,15 @@ module std_concepts [system] {
 }
 module std_condition_variable [system] {
   header "condition_variable"
+  module condition_variable { header "__condition_variable/condition_variable.h" }
   export *
 }
 module std_coroutine [system] {
   header "coroutine"
+  module coroutine_handle      { header "__coroutine/coroutine_handle.h" }
+  module coroutine_traits      { header "__coroutine/coroutine_traits.h" }
+  module noop_coroutine_handle { header "__coroutine/noop_coroutine_handle.h" }
+  module trivial_awaitables    { header "__coroutine/trivial_awaitables.h" }
   export *
 }
 module std_deque [system] {
@@ -77,6 +92,28 @@ module std_expected [system] {
 }
 module std_filesystem [system] {
   header "filesystem"
+  module copy_options                 { header "__filesystem/copy_options.h" }
+  module directory_entry              { header "__filesystem/directory_entry.h" }
+  module directory_iterator           { header "__filesystem/directory_iterator.h" }
+  module directory_options            { header "__filesystem/directory_options.h" }
+  module file_status                  { header "__filesystem/file_status.h" }
+  module file_time_type               { header "__filesystem/file_time_type.h" }
+  module file_type                    { header "__filesystem/file_type.h" }
+  module filesystem_error             {
+    header "__filesystem/filesystem_error.h"
+    export std_private_memory_shared_ptr
+  }
+  module operations                   { header "__filesystem/operations.h" }
+  module path                         {
+    header "__filesystem/path.h"
+    export std_string // returned by various methods
+  }
+  module path_iterator                { header "__filesystem/path_iterator.h" }
+  module perm_options                 { header "__filesystem/perm_options.h" }
+  module perms                        { header "__filesystem/perms.h" }
+  module recursive_directory_iterator { header "__filesystem/recursive_directory_iterator.h" }
+  module space_info                   { header "__filesystem/space_info.h" }
+  module u8path                       { header "__filesystem/u8path.h" }
   export *
 }
 module std_format [system] {
@@ -149,6 +186,16 @@ module std_map [system] {
 }
 module std_mdspan [system] {
   header "mdspan"
+  module default_accessor { header "__mdspan/default_accessor.h" }
+  module extents          { header "__mdspan/extents.h" }
+  module fwd              { header "__fwd/mdspan.h" }
+  module layout_left      { header "__mdspan/layout_left.h" }
+  module layout_right     { header "__mdspan/layout_right.h" }
+  module layout_stride    { header "__mdspan/layout_stride.h" }
+  module mdspan           {
+    header "__mdspan/mdspan.h"
+    export std_array // for strides()
+  }
   export *
 }
 module std_memory [system] {
@@ -1082,23 +1129,6 @@ module std_private_bit_invert_if      [system] { header "__bit/invert_if.h" }
 module std_private_bit_popcount       [system] { header "__bit/popcount.h" }
 module std_private_bit_rotate         [system] { header "__bit/rotate.h" }
 
-module std_private_charconv_chars_format            [system] { header "__charconv/chars_format.h" }
-module std_private_charconv_from_chars_integral     [system] { header "__charconv/from_chars_integral.h" }
-module std_private_charconv_from_chars_result       [system] { header "__charconv/from_chars_result.h" }
-module std_private_charconv_tables                  [system] { header "__charconv/tables.h" }
-module std_private_charconv_to_chars                [system] { header "__charconv/to_chars.h" }
-module std_private_charconv_to_chars_base_10        [system] { header "__charconv/to_chars_base_10.h" }
-module std_private_charconv_to_chars_floating_point [system] { header "__charconv/to_chars_floating_point.h" }
-module std_private_charconv_to_chars_integral       [system] {
-  header "__charconv/to_chars_integral.h"
-  export std_private_charconv_traits
-}
-module std_private_charconv_to_chars_result         [system] {
-  header "__charconv/to_chars_result.h"
-  export *
-}
-module std_private_charconv_traits                  [system] { header "__charconv/traits.h" }
-
 module std_private_chrono_calendar               [system] { header "__chrono/calendar.h" }
 module std_private_chrono_concepts               [system] { header "__chrono/concepts.h" }
 module std_private_chrono_convert_to_timespec    [system] { header "__chrono/convert_to_timespec.h" }
@@ -1223,16 +1253,6 @@ module std_private_concepts_semiregular           [system] { header "__concepts/
 module std_private_concepts_swappable             [system] { header "__concepts/swappable.h" }
 module std_private_concepts_totally_ordered       [system] { header "__concepts/totally_ordered.h" }
 
-module std_private_condition_variable_condition_variable [system] {
-  header "__condition_variable/condition_variable.h"
-  export *
-}
-
-module std_private_coroutine_coroutine_handle      [system] { header "__coroutine/coroutine_handle.h" }
-module std_private_coroutine_coroutine_traits      [system] { header "__coroutine/coroutine_traits.h" }
-module std_private_coroutine_noop_coroutine_handle [system] { header "__coroutine/noop_coroutine_handle.h" }
-module std_private_coroutine_trivial_awaitables    [system] { header "__coroutine/trivial_awaitables.h" }
-
 module std_private_debug_utils_randomize_range            [system] { header "__debug_utils/randomize_range.h" }
 module std_private_debug_utils_sanitizers                 [system] { header "__debug_utils/sanitizers.h" }
 module std_private_debug_utils_strict_weak_ordering_check [system] {
@@ -1255,38 +1275,6 @@ module std_private_expected_bad_expected_access [system] { header "__expected/ba
 module std_private_expected_expected            [system] { header "__expected/expected.h" }
 module std_private_expected_unexpect            [system] { header "__expected/unexpect.h" }
 module std_private_expected_unexpected          [system] { header "__expected/unexpected.h" }
-
-module std_private_filesystem_copy_options                 [system] { header "__filesystem/copy_options.h" }
-module std_private_filesystem_directory_entry              [system] {
-  header "__filesystem/directory_entry.h"
-  export *
-}
-module std_private_filesystem_directory_iterator           [system] {
-  header "__filesystem/directory_iterator.h"
-  export *
-}
-module std_private_filesystem_directory_options            [system] { header "__filesystem/directory_options.h" }
-module std_private_filesystem_file_status                  [system] { header "__filesystem/file_status.h" }
-module std_private_filesystem_file_time_type               [system] { header "__filesystem/file_time_type.h" }
-module std_private_filesystem_file_type                    [system] { header "__filesystem/file_type.h" }
-module std_private_filesystem_filesystem_error             [system] {
-  header "__filesystem/filesystem_error.h"
-  export *
-}
-module std_private_filesystem_operations                   [system] { header "__filesystem/operations.h" }
-module std_private_filesystem_path                         [system] {
-  header "__filesystem/path.h"
-  export *
-}
-module std_private_filesystem_path_iterator                [system] { header "__filesystem/path_iterator.h" }
-module std_private_filesystem_perm_options                 [system] { header "__filesystem/perm_options.h" }
-module std_private_filesystem_perms                        [system] { header "__filesystem/perms.h" }
-module std_private_filesystem_recursive_directory_iterator [system] {
-  header "__filesystem/recursive_directory_iterator.h"
-  export *
-}
-module std_private_filesystem_space_info                   [system] { header "__filesystem/space_info.h" }
-module std_private_filesystem_u8path                       [system] { header "__filesystem/u8path.h" }
 
 module std_private_format_buffer                          [system] { header "__format/buffer.h" }
 module std_private_format_concepts                        [system] { header "__format/concepts.h" }
@@ -1495,17 +1483,6 @@ module std_private_math_rounding_functions              [system] { header "__mat
 module std_private_math_special_functions               [system] { header "__math/special_functions.h" }
 module std_private_math_traits                          [system] { header "__math/traits.h" }
 module std_private_math_trigonometric_functions         [system] { header "__math/trigonometric_functions.h" }
-
-module std_private_mdspan_default_accessor [system] { header "__mdspan/default_accessor.h" }
-module std_private_mdspan_extents          [system] {
-  header "__mdspan/extents.h"
-  export *
-}
-module std_private_mdspan_layout_left      [system] { header "__mdspan/layout_left.h" }
-module std_private_mdspan_layout_right     [system] { header "__mdspan/layout_right.h" }
-module std_private_mdspan_layout_stride    [system] { header "__mdspan/layout_stride.h" }
-module std_private_mdspan_mdspan           [system] { header "__mdspan/mdspan.h" }
-module std_private_mdspan_mdspan_fwd       [system] { header "__fwd/mdspan.h" }
 
 module std_private_memory_addressof                       [system] { header "__memory/addressof.h" }
 module std_private_memory_align                           [system] { header "__memory/align.h" }

--- a/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
+++ b/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <limits>
 #include <mdspan>
+#include <span> // dynamic_extent
 #include <type_traits>
 #include <utility>
 

--- a/libcxx/test/std/containers/views/mdspan/extents/comparison.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/comparison.pass.cpp
@@ -18,9 +18,10 @@
 //
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/extents/conversion.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/conversion.pass.cpp
@@ -29,10 +29,11 @@
 //          (numeric_limits<index_type>::max() < numeric_limits<OtherIndexType>::max())
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
@@ -18,6 +18,7 @@
 
 #include <mdspan>
 #include <cassert>
+#include <span> // dynamic_extent
 #include <type_traits>
 
 #include "../ConvertibleToIntegral.h"

--- a/libcxx/test/std/containers/views/mdspan/extents/dextents.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/dextents.pass.cpp
@@ -18,6 +18,7 @@
 
 #include <mdspan>
 #include <cstddef>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/extents/dims.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/dims.pass.cpp
@@ -18,6 +18,7 @@
 
 #include <mdspan>
 #include <cstddef>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/extents/index_type.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/index_type.verify.cpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <climits>
 #include <mdspan>
+#include <span> // dynamic_extent
 
 void invalid_index_types() {
   // expected-error@*:* {{static assertion failed: extents::index_type must be a signed or unsigned integer type}}

--- a/libcxx/test/std/containers/views/mdspan/extents/obs_static.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/obs_static.pass.cpp
@@ -28,6 +28,7 @@
 
 #include <mdspan>
 #include <cassert>
+#include <span> // dynamic_extent
 #include <utility>
 
 #include "test_macros.h"

--- a/libcxx/test/std/containers/views/mdspan/extents/types.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/types.pass.cpp
@@ -23,9 +23,10 @@
 //  }
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/comparison.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/comparison.pass.cpp
@@ -16,9 +16,10 @@
 // Constraints: extents_type::rank() == OtherExtents::rank() is true.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.default.pass.cpp
@@ -17,6 +17,7 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.extents.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.extents.pass.cpp
@@ -20,6 +20,7 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_right.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_right.pass.cpp
@@ -21,9 +21,10 @@
 // Preconditions: other.required_span_size() is representable as a value of type index_type
 
 #include <mdspan>
-#include <type_traits>
 #include <cassert>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.layout_stride.pass.cpp
@@ -24,9 +24,11 @@
 // Effects: Direct-non-list-initializes extents_ with other.extents().
 
 #include <mdspan>
-#include <type_traits>
+#include <array>
 #include <cassert>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/ctor.mapping.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/ctor.mapping.pass.cpp
@@ -19,9 +19,10 @@
 // Preconditions: other.required_span_size() is representable as a value of type index_type
 
 #include <mdspan>
-#include <type_traits>
 #include <cassert>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
@@ -24,8 +24,10 @@
 //   * extents_type::index-cast(i) is a multidimensional index in extents_.
 
 #include <mdspan>
+#include <type_traits>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/properties.pass.cpp
@@ -27,9 +27,10 @@
 // }
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/required_span_size.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/required_span_size.pass.cpp
@@ -14,10 +14,10 @@
 //
 // Returns: extents().fwd-prod-of-extents(extents_type::rank()).
 
-
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
@@ -77,9 +77,11 @@
 //    Returns: true only if m.is_strided() is true for all possible objects m of type M.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/stride.pass.cpp
@@ -19,10 +19,12 @@
 //   Returns: extents().rev-prod-of-extents(i).
 
 #include <mdspan>
-#include <cassert>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <span> // dynamic_extent
+
 #include "test_macros.h"
 
 template <class E, class... Args>

--- a/libcxx/test/std/containers/views/mdspan/layout_right/comparison.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/comparison.pass.cpp
@@ -16,9 +16,10 @@
 // Constraints: extents_type::rank() == OtherExtents::rank() is true.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.default.pass.cpp
@@ -17,6 +17,7 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.extents.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.extents.pass.cpp
@@ -20,6 +20,7 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_left.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_left.pass.cpp
@@ -21,9 +21,10 @@
 // Preconditions: other.required_span_size() is representable as a value of type index_type
 
 #include <mdspan>
-#include <type_traits>
 #include <cassert>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.layout_stride.pass.cpp
@@ -24,9 +24,11 @@
 // Effects: Direct-non-list-initializes extents_ with other.extents().
 
 #include <mdspan>
-#include <type_traits>
+#include <array>
 #include <cassert>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/ctor.mapping.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/ctor.mapping.pass.cpp
@@ -19,9 +19,10 @@
 // Preconditions: other.required_span_size() is representable as a value of type index_type
 
 #include <mdspan>
-#include <type_traits>
 #include <cassert>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
@@ -26,6 +26,8 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/properties.pass.cpp
@@ -27,9 +27,10 @@
 // }
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/required_span_size.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/required_span_size.pass.cpp
@@ -18,6 +18,7 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
@@ -77,9 +77,11 @@
 //    Returns: true only if m.is_strided() is true for all possible objects m of type M.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_right/stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/stride.pass.cpp
@@ -19,10 +19,12 @@
 //   Returns: extents().rev-prod-of-extents(i).
 
 #include <mdspan>
-#include <cassert>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <span> // dynamic_extent
+
 #include "test_macros.h"
 
 template <class E, class... Args>

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/comparison.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/comparison.pass.cpp
@@ -23,9 +23,10 @@
 // Returns: true if x.extents() == y.extents() is true, OFFSET(y) == 0 is true, and each of x.stride(r) == y.stride(r) is true for r in the range [0, x.extents().rank()). Otherwise, false.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.default.pass.cpp
@@ -23,6 +23,7 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.extents_array.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.extents_array.pass.cpp
@@ -28,8 +28,11 @@
 //         direct-non-list-initializes strides_[d] with as_const(s[d]).
 
 #include <mdspan>
+#include <array>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 #include "../ConvertibleToIntegral.h"

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.extents_span.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.extents_span.pass.cpp
@@ -28,8 +28,11 @@
 //         direct-non-list-initializes strides_[d] with as_const(s[d]).
 
 #include <mdspan>
+#include <array>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 #include "../ConvertibleToIntegral.h"

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp
@@ -36,9 +36,10 @@
 //        is-mapping-of<layout_stride, LayoutStrideMapping>))
 
 #include <mdspan>
-#include <type_traits>
 #include <cassert>
 #include <limits>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
@@ -11,9 +11,11 @@
 // <mdspan>
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
+#include <array>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
@@ -14,6 +14,7 @@
 #include <array>
 #include <cassert>
 #include <concepts>
+#include <cstdint>
 #include <span> // dynamic_extent
 #include <type_traits>
 
@@ -35,7 +36,7 @@ constexpr bool test() {
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int, D>(), std::array<char, 1>{1})),
                    std::layout_stride::mapping<std::extents<int, D>>);
   ASSERT_SAME_TYPE(
-      decltype(std::layout_stride::mapping(std::extents<unsigned, D, 3>(), std::array<int64_t, 2>{3, 100})),
+      decltype(std::layout_stride::mapping(std::extents<unsigned, D, 3>(), std::array<std::int64_t, 2>{3, 100})),
       std::layout_stride::mapping<std::extents<unsigned, D, 3>>);
 
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int>(), std::span<unsigned, 0>())),
@@ -45,7 +46,7 @@ constexpr bool test() {
   ASSERT_SAME_TYPE(decltype(std::layout_stride::mapping(std::extents<int, D>(), std::declval<std::span<char, 1>>())),
                    std::layout_stride::mapping<std::extents<int, D>>);
   ASSERT_SAME_TYPE(
-      decltype(std::layout_stride::mapping(std::extents<unsigned, D, 3>(), std::declval<std::span<int64_t, 2>>())),
+      decltype(std::layout_stride::mapping(std::extents<unsigned, D, 3>(), std::declval<std::span<std::int64_t, 2>>())),
       std::layout_stride::mapping<std::extents<unsigned, D, 3>>);
   return true;
 }

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
@@ -24,8 +24,11 @@
 //   * extents_type::index-cast(i) is a multidimensional index in extents_.
 
 #include <mdspan>
+#include <array>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/is_exhaustive_corner_case.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/is_exhaustive_corner_case.pass.cpp
@@ -20,9 +20,11 @@
 //   - Otherwise, false.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
+#include <array>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/properties.pass.cpp
@@ -39,9 +39,11 @@
 //   - Otherwise, false.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
+#include <array>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/required_span_size.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/required_span_size.pass.cpp
@@ -20,8 +20,10 @@
 //   Returns: REQUIRED-SPAN-SIZE(extents(), strides_).
 
 #include <mdspan>
+#include <array>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
@@ -77,9 +77,11 @@
 //    Returns: true only if m.is_strided() is true for all possible objects m of type M.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/stride.pass.cpp
@@ -19,10 +19,12 @@
 //   Returns: extents().rev-prod-of-extents(i).
 
 #include <mdspan>
-#include <cassert>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <span> // dynamic_extent
+
 #include "test_macros.h"
 
 template <class E, class... Args>

--- a/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -12,9 +12,10 @@
 // constexpr mdspan& operator=(const mdspan& rhs) = default;
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
@@ -39,9 +39,10 @@
 //   || !is_convertible_v<const OtherAccessor&, accessor_type>
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -14,9 +14,10 @@
 // A specialization of mdspan is a trivially copyable type if its accessor_type, mapping_type, and data_handle_type are trivially copyable types.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
@@ -22,9 +22,10 @@
 // Effects: Value-initializes ptr_, map_, and acc_.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
@@ -29,9 +29,10 @@
 //   - value-initializes acc_.
 
 #include <array>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 #include <mdspan>
+#include <span> // dynamic_extent
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
@@ -24,9 +24,10 @@
 //   - value-initializes acc_.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
@@ -30,9 +30,10 @@
 //   - value-initializes acc_.
 
 #include <array>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 #include <mdspan>
+#include <span> // dynamic_extent
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
@@ -22,9 +22,10 @@
 //   - value-initializes acc_.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
@@ -19,9 +19,10 @@
 //   - direct-non-list-initializes acc_ with a.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
@@ -29,9 +29,10 @@
 //   - value-initializes acc_.
 
 #include <array>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 #include <mdspan>
+#include <span> // dynamic_extent
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -14,9 +14,10 @@
 // A specialization of mdspan is a trivially copyable type if its accessor_type, mapping_type, and data_handle_type are trivially copyable types.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/deduction.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/deduction.pass.cpp
@@ -52,9 +52,10 @@
 //                typename MappingType::layout_type, AccessorType>;
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -32,6 +32,7 @@
 #include <mdspan>
 #include <cassert>
 #include <cstdint>
+#include <span> // dynamic_extent
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -14,9 +14,10 @@
 // A specialization of mdspan is a trivially copyable type if its accessor_type, mapping_type, and data_handle_type are trivially copyable types.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/properties.pass.cpp
@@ -52,9 +52,10 @@
 // A specialization of mdspan is a trivially copyable type if its accessor_type, mapping_type, and data_handle_type are trivially copyable types.
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/swap.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/swap.pass.cpp
@@ -17,9 +17,10 @@
 //   swap(x.acc_, y.acc_);
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/types.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/types.pass.cpp
@@ -28,9 +28,10 @@
 //  };
 
 #include <mdspan>
-#include <type_traits>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <span> // dynamic_extent
+#include <type_traits>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/test_offset_time_zone.h
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/test_offset_time_zone.h
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <format>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 
 enum class offset_time_zone_flags {

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view.pass.cpp
@@ -20,7 +20,9 @@
 // explicit zoned_time(string_view name);
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
+#include <string_view>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_local_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_local_time.pass.cpp
@@ -20,7 +20,9 @@
 // zoned_time(string_view name, const local_time<Duration>& st);
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
+#include <string_view>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_local_time_choose.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_local_time_choose.pass.cpp
@@ -20,8 +20,8 @@
 // zoned_time(string_view name, const local_time<Duration>& st, choose c);
 
 #include <chrono>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_sys_time.pass.cpp
@@ -20,7 +20,9 @@
 // zoned_time(string_view name, const sys_time<Duration>& st);
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
+#include <string_view>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_zoned_time_duration2_time_zone_ptr2.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_zoned_time_duration2_time_zone_ptr2.pass.cpp
@@ -21,8 +21,8 @@
 // zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& y);
 
 #include <chrono>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_zoned_time_duration2_time_zone_ptr2_choose.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view_zoned_time_duration2_time_zone_ptr2_choose.pass.cpp
@@ -21,8 +21,8 @@
 // zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& y, choose c);
 
 #include <chrono>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/sys_time.pass.cpp
@@ -20,6 +20,7 @@
 // zoned_time(const sys_time<Duration>& st);
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
 #include <type_traits>
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer.pass.cpp
@@ -20,6 +20,7 @@
 // explicit zoned_time(TimeZonePtr z);
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
 
 #include "../test_offset_time_zone.h"

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer_local_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer_local_time.pass.cpp
@@ -20,8 +20,8 @@
 // zoned_time(TimeZonePtr z, const local_time<Duration>& st);
 
 #include <chrono>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer_local_time_choose.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer_local_time_choose.pass.cpp
@@ -20,8 +20,8 @@
 // zoned_time(TimeZonePtr z, const local_time<Duration>& st, choose c);
 
 #include <chrono>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer_sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer_sys_time.pass.cpp
@@ -20,8 +20,8 @@
 // zoned_time(TimeZonePtr z, const sys_time<Duration>& st);
 
 #include <chrono>
-#include <concepts>
 #include <cassert>
+#include <concepts>
 
 #include "../test_offset_time_zone.h"
 

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_local_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_local_time.pass.cpp
@@ -20,6 +20,7 @@
 // local_time<duration> get_local_time() const;
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
 
 #include "../test_offset_time_zone.h"

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_sys_time.pass.cpp
@@ -20,6 +20,7 @@
 // sys_time<duration> get_sys_time() const;
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
 
 #include "../test_offset_time_zone.h"

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_time_zone.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_time_zone.pass.cpp
@@ -20,6 +20,7 @@
 // TimeZonePtr get_time_zone() const;
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
 
 #include "../test_offset_time_zone.h"

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/operator_local_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/operator_local_time.pass.cpp
@@ -20,6 +20,7 @@
 // explicit operator local_time<duration>() const;
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
 
 #include "../test_offset_time_zone.h"

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/operator_sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/operator_sys_time.pass.cpp
@@ -20,6 +20,7 @@
 // operator sys_time<duration>() const;
 
 #include <chrono>
+#include <cassert>
 #include <concepts>
 
 #include "../test_offset_time_zone.h"

--- a/libcxx/test/std/utilities/charconv/charconv.from.chars/integral.pass.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.from.chars/integral.pass.cpp
@@ -14,6 +14,8 @@
 //                                        Integral& value, int base = 10)
 
 #include <charconv>
+#include <system_error>
+
 #include "test_macros.h"
 #include "charconv_test_helpers.h"
 

--- a/libcxx/test/std/utilities/charconv/charconv.from.chars/integral.roundtrip.pass.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.from.chars/integral.roundtrip.pass.cpp
@@ -16,6 +16,8 @@
 //                                        Integral& value, int base = 10)
 
 #include <charconv>
+#include <system_error>
+
 #include "test_macros.h"
 #include "charconv_test_helpers.h"
 

--- a/libcxx/test/std/utilities/charconv/charconv.syn/from_chars_result.operator_bool.pass.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.syn/from_chars_result.operator_bool.pass.cpp
@@ -16,6 +16,7 @@
 #include <charconv>
 
 #include <cassert>
+#include <system_error>
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/test/std/utilities/charconv/charconv.syn/from_chars_result.pass.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.syn/from_chars_result.pass.cpp
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <compare>
 #include <concepts>
+#include <system_error>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/utilities/charconv/charconv.syn/to_chars_result.operator_bool.pass.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.syn/to_chars_result.operator_bool.pass.cpp
@@ -16,6 +16,7 @@
 #include <charconv>
 
 #include <cassert>
+#include <system_error>
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/test/std/utilities/charconv/charconv.syn/to_chars_result.pass.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.syn/to_chars_result.pass.cpp
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <compare>
 #include <concepts>
+#include <system_error>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/utilities/charconv/charconv.to.chars/integral.pass.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.to.chars/integral.pass.cpp
@@ -19,6 +19,7 @@
 
 #include <charconv>
 #include <cstdint>
+#include <system_error>
 
 #include "test_macros.h"
 #include "charconv_test_helpers.h"


### PR DESCRIPTION
Some modules are leaf modules in the sense that they are not used by any other part of the headers. These leaf modules are easy to consolidate since there is no risk to create a cycle. As a result of regrouping these modules, several missing includes were found and fixed in this patch.