### PR TITLE
[libc++][modules] Remove dependency on __algorithm/max from hypot.h

### DIFF
--- a/libcxx/include/__math/hypot.h
+++ b/libcxx/include/__math/hypot.h
@@ -12,6 +12,7 @@
 #include <__config>
 #include <__math/abs.h>
 #include <__math/exponential_functions.h>
+#include <__math/min_max.h>
 #include <__math/roots.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_arithmetic.h>
@@ -61,7 +62,7 @@ _LIBCPP_HIDE_FROM_ABI _Real __hypot(_Real __x, _Real __y, _Real __z) {
   const _Real __overflow_scale     = __math::ldexp(_Real(1), -(__exp + 20));
 
   // Scale arguments depending on their size
-  const _Real __max_abs = __builtin_fmax(__math::fabs(__x), __builtin_fmax(__math::fabs(__y), __math::fabs(__z)));
+  const _Real __max_abs = __math::fmax(__math::fabs(__x), __math::fmax(__math::fabs(__y), __math::fabs(__z)));
   _Real __scale;
   if (__max_abs > __overflow_threshold) { // x*x + y*y + z*z might overflow
     __scale = __overflow_scale;

--- a/libcxx/include/__math/hypot.h
+++ b/libcxx/include/__math/hypot.h
@@ -9,7 +9,6 @@
 #ifndef _LIBCPP___MATH_HYPOT_H
 #define _LIBCPP___MATH_HYPOT_H
 
-#include <__algorithm/max.h>
 #include <__config>
 #include <__math/abs.h>
 #include <__math/exponential_functions.h>
@@ -62,7 +61,7 @@ _LIBCPP_HIDE_FROM_ABI _Real __hypot(_Real __x, _Real __y, _Real __z) {
   const _Real __overflow_scale     = __math::ldexp(_Real(1), -(__exp + 20));
 
   // Scale arguments depending on their size
-  const _Real __max_abs = std::max(__math::fabs(__x), std::max(__math::fabs(__y), __math::fabs(__z)));
+  const _Real __max_abs = __builtin_fmax(__math::fabs(__x), __builtin_fmax(__math::fabs(__y), __math::fabs(__z)));
   _Real __scale;
   if (__max_abs > __overflow_threshold) { // x*x + y*y + z*z might overflow
     __scale = __overflow_scale;

--- a/libcxx/test/libcxx/transitive_includes/cxx03.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx03.csv
@@ -132,7 +132,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath initializer_list
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx03.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx03.csv
@@ -131,7 +131,6 @@ chrono type_traits
 chrono vector
 chrono version
 cinttypes cstdint
-cmath cstddef
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx11.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx11.csv
@@ -132,7 +132,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath initializer_list
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx11.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx11.csv
@@ -131,7 +131,6 @@ chrono type_traits
 chrono vector
 chrono version
 cinttypes cstdint
-cmath cstddef
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx14.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx14.csv
@@ -132,7 +132,6 @@ chrono type_traits
 chrono vector
 chrono version
 cinttypes cstdint
-cmath cstddef
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx14.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx14.csv
@@ -133,7 +133,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath initializer_list
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx17.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx17.csv
@@ -132,7 +132,6 @@ chrono type_traits
 chrono vector
 chrono version
 cinttypes cstdint
-cmath cstddef
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx17.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx17.csv
@@ -133,7 +133,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath initializer_list
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx20.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx20.csv
@@ -137,7 +137,6 @@ chrono type_traits
 chrono vector
 chrono version
 cinttypes cstdint
-cmath cstddef
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx20.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx20.csv
@@ -138,7 +138,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath initializer_list
 cmath limits
 cmath type_traits
 cmath version

--- a/libcxx/test/libcxx/transitive_includes/cxx23.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx23.csv
@@ -84,7 +84,6 @@ chrono string_view
 chrono vector
 chrono version
 cinttypes cstdint
-cmath cstddef
 cmath limits
 cmath version
 codecvt cctype

--- a/libcxx/test/libcxx/transitive_includes/cxx23.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx23.csv
@@ -85,7 +85,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath initializer_list
 cmath limits
 cmath version
 codecvt cctype

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -84,7 +84,6 @@ chrono string_view
 chrono vector
 chrono version
 cinttypes cstdint
-cmath cstddef
 cmath limits
 cmath version
 codecvt cctype

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -85,7 +85,6 @@ chrono vector
 chrono version
 cinttypes cstdint
 cmath cstddef
-cmath initializer_list
 cmath limits
 cmath version
 codecvt cctype


### PR DESCRIPTION
That dependency was added recently when we made improvements to std::hypot, but that resulted in `__math` depending on `__algorithm`, which is a very heavyweight module. This patch uses `__math::fmax` instead.