### PR TITLE
Adjust modulemap to mark mm3dnow as textual header.

### DIFF
--- a/clang/lib/Headers/module.modulemap
+++ b/clang/lib/Headers/module.modulemap
@@ -66,6 +66,8 @@ module _Builtin_intrinsics [system] [extern_c] {
     textual header "__wmmintrin_aes.h"
     textual header "__wmmintrin_pclmul.h"
 
+    textual header "mm3dnow.h"
+
     explicit module mm_malloc {
       requires !freestanding
       header "mm_malloc.h"
@@ -120,10 +122,6 @@ module _Builtin_intrinsics [system] [extern_c] {
 
     explicit module popcnt {
       header "popcntintrin.h"
-    }
-
-    explicit module mm3dnow {
-      header "mm3dnow.h"
     }
 
     explicit module aes_pclmul {


### PR DESCRIPTION
This avoids issuing the deprecation diagnostic when building the module.

Not building it into a module shouldn't cause any negative impacts, since it no longer has any declarations other than the header guard. It's also very rarely included by anything.

Addresses https://github.com/llvm/llvm-project/pull/96246#issuecomment-2322453809