### PR TITLE
[ThinLTO] Avoid repeated std::map lookups (NFC)

### DIFF
--- a/llvm/include/llvm/IR/ModuleSummaryIndexYAML.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndexYAML.h
@@ -214,15 +214,13 @@ template <> struct CustomMappingTraits<GlobalValueSummaryMapTy> {
       io.setError("key not an integer");
       return;
     }
-    if (!V.count(KeyInt))
-      V.emplace(KeyInt, /*IsAnalysis=*/false);
-    auto &Elem = V.find(KeyInt)->second;
+    auto &Elem = V.try_emplace(KeyInt, /*IsAnalysis=*/false).first->second;
     for (auto &FSum : FSums) {
       std::vector<ValueInfo> Refs;
+      Refs.reserve(FSum.Refs.size());
       for (auto &RefGUID : FSum.Refs) {
-        if (!V.count(RefGUID))
-          V.emplace(RefGUID, /*IsAnalysis=*/false);
-        Refs.push_back(ValueInfo(/*IsAnalysis=*/false, &*V.find(RefGUID)));
+        auto It = V.try_emplace(RefGUID, /*IsAnalysis=*/false).first;
+        Refs.push_back(ValueInfo(/*IsAnalysis=*/false, &*It));
       }
       Elem.SummaryList.push_back(std::make_unique<FunctionSummary>(
           GlobalValueSummary::GVFlags(
@@ -247,6 +245,7 @@ template <> struct CustomMappingTraits<GlobalValueSummaryMapTy> {
       for (auto &Sum : P.second.SummaryList) {
         if (auto *FSum = dyn_cast<FunctionSummary>(Sum.get())) {
           std::vector<uint64_t> Refs;
+          Refs.reserve(FSum->refs().size());
           for (auto &VI : FSum->refs())
             Refs.push_back(VI.getGUID());
           FSums.push_back(FunctionSummaryYaml{


### PR DESCRIPTION
This patch avoids repeated std::map lookups with try_emplace.

While I am at it, this patch adds a couple of calls to
std::vector::reserve.
