### PR TITLE
[compiler-rt][rtsan] Add scoped reporting lock

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_context.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_context.cpp
@@ -91,6 +91,8 @@ bool __rtsan::Context::IsBypassed() const { return bypass_depth_ > 0; }
 
 void __rtsan::PrintDiagnostics(const char *intercepted_function_name, uptr pc,
                                uptr bp) {
+  ScopedErrorReportLock l;
+
   fprintf(stderr,
           "Real-time violation: intercepted call to real-time unsafe function "
           "`%s` in real-time context! Stack trace:\n",


### PR DESCRIPTION
From the `ScopedReportingLock` docstring:

```
// Lock sanitizer error reporting and protects against nested errors.
```

Uses a static lock to ensure multiple threads reporting issues at the same time don't have printing collisions. This isn't so important now, but will be with continue mode in the future.