### PR TITLE
[SSAUpdater] Use DenseMap::operator[] (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/SSAUpdaterImpl.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdaterImpl.h
@@ -139,17 +139,16 @@ public:
       for (unsigned p = 0; p != Info->NumPreds; ++p) {
         BlkT *Pred = Preds[p];
         // Check if BBMap already has a BBInfo for the predecessor block.
-        typename BBMapTy::value_type &BBMapBucket =
-          BBMap.FindAndConstruct(Pred);
-        if (BBMapBucket.second) {
-          Info->Preds[p] = BBMapBucket.second;
+        BBInfo *&BBMapBucket = BBMap[Pred];
+        if (BBMapBucket) {
+          Info->Preds[p] = BBMapBucket;
           continue;
         }
 
         // Create a new BBInfo for the predecessor.
         ValT PredVal = AvailableVals->lookup(Pred);
         BBInfo *PredInfo = new (Allocator) BBInfo(Pred, PredVal);
-        BBMapBucket.second = PredInfo;
+        BBMapBucket = PredInfo;
         Info->Preds[p] = PredInfo;
 
         if (PredInfo->AvailableVal) {


### PR DESCRIPTION
I'm planning to deprecate DenseMap::FindAndConstruct in favor of
DenseMap::operator[].  I thought about renaming the variable to
PredInfo, but the name is taken, so I am leaving the name as is.
