### PR TITLE
[libc++] Add basic constant folding for std::format

### DIFF
--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -11,6 +11,8 @@
 #define _LIBCPP___FORMAT_FORMAT_FUNCTIONS
 
 #include <__algorithm/clamp.h>
+#include <__algorithm/ranges_find_first_of.h>
+#include <__chrono/statically_widen.h>
 #include <__concepts/convertible_to.h>
 #include <__concepts/same_as.h>
 #include <__config>
@@ -36,6 +38,7 @@
 #include <__iterator/iterator_traits.h> // iter_value_t
 #include <__variant/monostate.h>
 #include <array>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -447,10 +450,47 @@ format_to(_OutIt __out_it, wformat_string<_Args...> __fmt, _Args&&... __args) {
 }
 #  endif
 
+// Try constant folding the format string instead of going through the whole formatting machinery. If there is no
+// constant folding no extra code should be emitted (with optimizations enabled) and the function returns nullopt. When
+// constant folding is successful, the formatting is performed and the resulting string is returned.
+namespace __format {
+template <class _CharT>
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<basic_string<_CharT>> __try_constant_folding(
+    basic_string_view<_CharT> __fmt,
+    basic_format_args<basic_format_context<back_insert_iterator<__format::__output_buffer<_CharT>>, _CharT>> __args) {
+  // Fold strings not containing '{' or '}' to just return the string
+  if (bool __is_identity = [&] [[__gnu__::__pure__]] // Make sure the compiler knows this call can be eliminated
+      { return std::ranges::find_first_of(__fmt, array{'{', '}'}) == __fmt.end(); }();
+      __builtin_constant_p(__is_identity) && __is_identity)
+    return basic_string<_CharT>{__fmt};
+
+  // Fold '{}' to the appropriate conversion function
+  if (auto __only_first_arg = __fmt == _LIBCPP_STATICALLY_WIDEN(_CharT, "{}");
+      __builtin_constant_p(__only_first_arg) && __only_first_arg) {
+    if (auto __arg = __args.get(0); __builtin_constant_p(__arg.__type_)) {
+      return std::__visit_format_arg(
+          []<class _Tp>(_Tp&& __argument) -> optional<basic_string<_CharT>> {
+            if constexpr (is_same_v<remove_cvref_t<_Tp>, basic_string_view<_CharT>>) {
+              return basic_string<_CharT>{__argument};
+            } else {
+              return nullopt;
+            }
+          },
+          __arg);
+    }
+  }
+
+  return nullopt;
+}
+} // namespace __format
+
 // TODO FMT This needs to be a template or std::to_chars(floating-point) availability markup
 // fires too eagerly, see http://llvm.org/PR61563.
 template <class = void>
 [[nodiscard]] _LIBCPP_ALWAYS_INLINE inline _LIBCPP_HIDE_FROM_ABI string vformat(string_view __fmt, format_args __args) {
+  auto __result = __format::__try_constant_folding(__fmt, __args);
+  if (__result.has_value())
+    return *std::move(__result);
   __format::__allocating_buffer<char> __buffer;
   std::vformat_to(__buffer.__make_output_iterator(), __fmt, __args);
   return string{__buffer.__view()};
@@ -462,6 +502,9 @@ template <class = void>
 template <class = void>
 [[nodiscard]] _LIBCPP_ALWAYS_INLINE inline _LIBCPP_HIDE_FROM_ABI wstring
 vformat(wstring_view __fmt, wformat_args __args) {
+  auto __result = __format::__try_constant_folding(__fmt, __args);
+  if (__result.has_value())
+    return *std::move(__result);
   __format::__allocating_buffer<wchar_t> __buffer;
   std::vformat_to(__buffer.__make_output_iterator(), __fmt, __args);
   return wstring{__buffer.__view()};

--- a/libcxx/test/benchmarks/format/format.bench.cpp
+++ b/libcxx/test/benchmarks/format/format.bench.cpp
@@ -35,4 +35,15 @@ BENCHMARK(BM_format_string<char>)->RangeMultiplier(2)->Range(1, 1 << 20);
 BENCHMARK(BM_format_string<wchar_t>)->RangeMultiplier(2)->Range(1, 1 << 20);
 #endif
 
+template <class CharT>
+static void BM_string_without_formatting(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(std::format(CSTR("Hello, World!")));
+  }
+}
+BENCHMARK(BM_string_without_formatting<char>);
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
+BENCHMARK(BM_string_without_formatting<wchar_t>);
+#endif
+
 BENCHMARK_MAIN();


### PR DESCRIPTION
```
-------------------------------------------------------------------
Benchmark                                        old            new
-------------------------------------------------------------------
BM_format_string<char>/1                     42.1 ns        7.67 ns
BM_format_string<char>/2                     22.3 ns        3.84 ns
BM_format_string<char>/4                     10.6 ns        1.92 ns
BM_format_string<char>/8                     5.31 ns       0.815 ns
BM_format_string<char>/16                    2.79 ns       0.480 ns
BM_format_string<char>/32                    1.63 ns       0.550 ns
BM_format_string<char>/64                   0.782 ns       0.276 ns
BM_format_string<char>/128                  0.397 ns       0.145 ns
BM_format_string<char>/256                  0.211 ns       0.066 ns
BM_format_string<char>/512                  0.154 ns       0.035 ns
BM_format_string<char>/1024                 0.146 ns       0.021 ns
BM_format_string<char>/2048                 0.125 ns       0.033 ns
BM_format_string<char>/4096                 0.097 ns       0.016 ns
BM_format_string<char>/8192                 0.077 ns       0.012 ns
BM_format_string<char>/16384                0.066 ns       0.010 ns
BM_format_string<char>/32768                0.062 ns       0.016 ns
BM_format_string<char>/65536                0.062 ns       0.016 ns
BM_format_string<char>/131072               0.443 ns       0.015 ns
BM_format_string<char>/262144               0.629 ns       0.017 ns
BM_format_string<char>/524288               0.715 ns       0.020 ns
BM_format_string<char>/1048576              0.757 ns       0.020 ns
BM_format_string<wchar_t>/1                  38.8 ns        34.0 ns
BM_format_string<wchar_t>/2                  19.4 ns        16.9 ns
BM_format_string<wchar_t>/4                  9.88 ns        8.45 ns
BM_format_string<wchar_t>/8                  6.30 ns        6.47 ns
BM_format_string<wchar_t>/16                 3.11 ns        3.21 ns
BM_format_string<wchar_t>/32                 1.60 ns        1.63 ns
BM_format_string<wchar_t>/64                0.899 ns       0.925 ns
BM_format_string<wchar_t>/128               0.676 ns       0.693 ns
BM_format_string<wchar_t>/256               0.658 ns       0.685 ns
BM_format_string<wchar_t>/512               0.556 ns       0.531 ns
BM_format_string<wchar_t>/1024              0.428 ns       0.402 ns
BM_format_string<wchar_t>/2048              0.328 ns       0.319 ns
BM_format_string<wchar_t>/4096              0.276 ns       0.274 ns
BM_format_string<wchar_t>/8192              0.252 ns       0.251 ns
BM_format_string<wchar_t>/16384             0.248 ns       0.246 ns
BM_format_string<wchar_t>/32768             0.229 ns       0.232 ns
BM_format_string<wchar_t>/65536             0.248 ns       0.246 ns
BM_format_string<wchar_t>/131072            0.250 ns       0.240 ns
BM_format_string<wchar_t>/262144             3.03 ns        3.03 ns
BM_format_string<wchar_t>/524288             3.14 ns        3.15 ns
BM_format_string<wchar_t>/1048576            3.60 ns        3.61 ns
BM_string_without_formatting<char>           32.2 ns       0.470 ns
BM_string_without_formatting<wchar_t>        38.8 ns        10.2 ns
```

