### PR TITLE
[libc++] Remove _LIBCPP_USING_IF_EXISTS from fundamental aliases

### DIFF
--- a/libcxx/include/__cstddef/max_align_t.h
+++ b/libcxx/include/__cstddef/max_align_t.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if !defined(_LIBCPP_CXX03_LANG)
-using ::max_align_t _LIBCPP_USING_IF_EXISTS;
+using ::max_align_t;
 #endif
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__cstddef/ptrdiff_t.h
+++ b/libcxx/include/__cstddef/ptrdiff_t.h
@@ -18,7 +18,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::ptrdiff_t _LIBCPP_USING_IF_EXISTS;
+using ::ptrdiff_t;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__cstddef/size_t.h
+++ b/libcxx/include/__cstddef/size_t.h
@@ -18,7 +18,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::size_t _LIBCPP_USING_IF_EXISTS;
+using ::size_t;
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION

There are a few types without which the library is hopelessly broken. Specifically, these are `size_t`, `ptrdiff_t` and the `intX_t` and `uintX_t` types. This results in significantly better diagnostics if they are missing, since they are flagged at the `using` instead of the inevitable first use.

