### PR TITLE
[TSan] fix the module map of main executable on darwin platforms

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
@@ -433,7 +433,9 @@ void MemoryMappingLayout::DumpListOfModules(
   MemoryMappedSegmentData data;
   segment.data_ = &data;
   while (Next(&segment)) {
-    if (segment.filename[0] == '\0') continue;
+    // skip the __PAGEZERO segment, its vmsize is 0
+    if (segment.filename[0] == '\0' || (segment.start == segment.end))
+      continue;
     LoadedModule *cur_module = nullptr;
     if (!modules->empty() &&
         0 == internal_strcmp(segment.filename, modules->back().full_name())) {


### PR DESCRIPTION
In the executable image on Darwin platforms, there is a `__PAGEZERO` segment with a size of 0. When calculating the module map, this segment must be skipped to avoid errors. The previous implementation inaccurately calculated the executable image's range, starting the address at `0 + slide`.