### PR TITLE
[MLIR][OpenMP][Docs] NFC: Document op naming conventions

### DIFF
--- a/mlir/docs/Dialects/OpenMPDialect/_index.md
+++ b/mlir/docs/Dialects/OpenMPDialect/_index.md
@@ -14,3 +14,30 @@ other definitions in this dialect, refer to the automatically-generated
 [ODS Documentation](ODS.md).
 
 [TOC]
+
+## Operation Naming Conventions
+
+This section aims to standardize how dialect operation names are chosen, to
+ensure a level of consistency. There are two categories of names: tablegen names
+and assembly names. The former also corresponds to the C++ class that is
+generated for the operation, whereas the latter is used to represent it in MLIR
+text form.
+
+Tablegen names are CamelCase, with the first letter capitalized and an "Op"
+suffix, whereas assembly names are snake_case, with all lowercase letters and
+words separated by underscores.
+
+If the operation corresponds to a directive, clause or other kind of definition
+in the OpenMP specification, it must use the same name split into words in the
+same way. For example, the `target data` directive would become `TargetDataOp` /
+`omp.target_data`, whereas `taskloop` would become `TaskloopOp` /
+`omp.taskloop`.
+
+Operations intended to carry extra information for another particular operation
+or clause must be named after that other operation or clause, followed by the
+name of the additional information. The assembly name must use a period to
+separate both parts. For example, the operation used to define some extra
+mapping information is named `MapInfoOp` / `omp.map.info`. The same rules are
+followed if multiple operations are created for different variants of the same
+directive, e.g. `atomic` becomes `Atomic{Read,Write,Update,Capture}Op` /
+`omp.atomic.{read,write,update,capture}`.


### PR DESCRIPTION
This patch documents op naming conventions discussed in [this RFC](https://discourse.llvm.org/t/rfc-uniformize-openmp-dialect-operation-names/77715).