### PR TITLE
[lldb] Recurse through DW_AT_signature when looking for attributes

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -50,7 +50,8 @@ class ElaboratingDIEIterator
     m_worklist.pop_back();
 
     // And add back any items that elaborate it.
-    for (dw_attr_t attr : {DW_AT_specification, DW_AT_abstract_origin}) {
+    for (dw_attr_t attr :
+         {DW_AT_specification, DW_AT_abstract_origin, DW_AT_specification}) {
       if (DWARFDIE d = die.GetReferencedDIE(attr))
         if (m_seen.insert(die.GetDIE()).second)
           m_worklist.push_back(d);
@@ -129,10 +130,10 @@ DWARFDIE
 DWARFDIE::GetAttributeValueAsReferenceDIE(const dw_attr_t attr) const {
   if (IsValid()) {
     DWARFUnit *cu = GetCU();
-    const bool check_specification_or_abstract_origin = true;
+    const bool check_elaborating_dies = true;
     DWARFFormValue form_value;
     if (m_die->GetAttributeValue(cu, attr, form_value, nullptr,
-                                 check_specification_or_abstract_origin))
+                                 check_elaborating_dies))
       return form_value.Reference();
   }
   return DWARFDIE();
@@ -377,11 +378,6 @@ static void GetDeclContextImpl(DWARFDIE die,
       die = spec;
       continue;
     }
-    // To find the name of a type in a type unit, we must follow the signature.
-    if (DWARFDIE spec = die.GetReferencedDIE(DW_AT_signature)) {
-      die = spec;
-      continue;
-    }
 
     // Add this DIE's contribution at the end of the chain.
     auto push_ctx = [&](CompilerContextKind kind, llvm::StringRef name) {
@@ -434,12 +430,6 @@ static void GetTypeLookupContextImpl(DWARFDIE die,
                                      std::vector<CompilerContext> &context) {
   // Stop if we hit a cycle.
   while (die && seen.insert(die.GetID()).second) {
-    // To find the name of a type in a type unit, we must follow the signature.
-    if (DWARFDIE spec = die.GetReferencedDIE(DW_AT_signature)) {
-      die = spec;
-      continue;
-    }
-
     // Add this DIE's contribution at the end of the chain.
     auto push_ctx = [&](CompilerContextKind kind, llvm::StringRef name) {
       context.push_back({kind, ConstString(name)});

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -25,9 +25,9 @@ using namespace lldb_private::plugin::dwarf;
 namespace {
 
 /// Iterate through all DIEs elaborating (i.e. reachable by a chain of
-/// DW_AT_specification and DW_AT_abstract_origin attributes) a given DIE. For
-/// convenience, the starting die is included in the sequence as the first
-/// item.
+/// DW_AT_specification, DW_AT_abstract_origin and/or DW_AT_signature
+/// attributes) a given DIE. For convenience, the starting die is included in
+/// the sequence as the first item.
 class ElaboratingDIEIterator
     : public llvm::iterator_facade_base<
           ElaboratingDIEIterator, std::input_iterator_tag, DWARFDIE,
@@ -51,7 +51,7 @@ class ElaboratingDIEIterator
 
     // And add back any items that elaborate it.
     for (dw_attr_t attr :
-         {DW_AT_specification, DW_AT_abstract_origin, DW_AT_specification}) {
+         {DW_AT_specification, DW_AT_abstract_origin, DW_AT_signature}) {
       if (DWARFDIE d = die.GetReferencedDIE(attr))
         if (m_seen.insert(die.GetDIE()).second)
           m_worklist.push_back(d);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
@@ -60,44 +60,45 @@ public:
     return attrs;
   }
 
-  dw_offset_t
-  GetAttributeValue(const DWARFUnit *cu, const dw_attr_t attr,
-                    DWARFFormValue &formValue,
-                    dw_offset_t *end_attr_offset_ptr = nullptr,
-                    bool check_specification_or_abstract_origin = false) const;
+  dw_offset_t GetAttributeValue(const DWARFUnit *cu, const dw_attr_t attr,
+                                DWARFFormValue &formValue,
+                                dw_offset_t *end_attr_offset_ptr = nullptr,
+                                bool check_elaborating_dies = false) const;
 
-  const char *GetAttributeValueAsString(
-      const DWARFUnit *cu, const dw_attr_t attr, const char *fail_value,
-      bool check_specification_or_abstract_origin = false) const;
+  const char *
+  GetAttributeValueAsString(const DWARFUnit *cu, const dw_attr_t attr,
+                            const char *fail_value,
+                            bool check_elaborating_dies = false) const;
 
-  uint64_t GetAttributeValueAsUnsigned(
-      const DWARFUnit *cu, const dw_attr_t attr, uint64_t fail_value,
-      bool check_specification_or_abstract_origin = false) const;
+  uint64_t
+  GetAttributeValueAsUnsigned(const DWARFUnit *cu, const dw_attr_t attr,
+                              uint64_t fail_value,
+                              bool check_elaborating_dies = false) const;
 
   std::optional<uint64_t> GetAttributeValueAsOptionalUnsigned(
       const DWARFUnit *cu, const dw_attr_t attr,
-      bool check_specification_or_abstract_origin = false) const;
+      bool check_elaborating_dies = false) const;
 
-  DWARFDIE GetAttributeValueAsReference(
-      const DWARFUnit *cu, const dw_attr_t attr,
-      bool check_specification_or_abstract_origin = false) const;
+  DWARFDIE
+  GetAttributeValueAsReference(const DWARFUnit *cu, const dw_attr_t attr,
+                               bool check_elaborating_dies = false) const;
 
-  uint64_t GetAttributeValueAsAddress(
-      const DWARFUnit *cu, const dw_attr_t attr, uint64_t fail_value,
-      bool check_specification_or_abstract_origin = false) const;
+  uint64_t
+  GetAttributeValueAsAddress(const DWARFUnit *cu, const dw_attr_t attr,
+                             uint64_t fail_value,
+                             bool check_elaborating_dies = false) const;
 
-  dw_addr_t
-  GetAttributeHighPC(const DWARFUnit *cu, dw_addr_t lo_pc, uint64_t fail_value,
-                     bool check_specification_or_abstract_origin = false) const;
+  dw_addr_t GetAttributeHighPC(const DWARFUnit *cu, dw_addr_t lo_pc,
+                               uint64_t fail_value,
+                               bool check_elaborating_dies = false) const;
 
-  bool GetAttributeAddressRange(
-      const DWARFUnit *cu, dw_addr_t &lo_pc, dw_addr_t &hi_pc,
-      uint64_t fail_value,
-      bool check_specification_or_abstract_origin = false) const;
+  bool GetAttributeAddressRange(const DWARFUnit *cu, dw_addr_t &lo_pc,
+                                dw_addr_t &hi_pc, uint64_t fail_value,
+                                bool check_elaborating_dies = false) const;
 
-  DWARFRangeList GetAttributeAddressRanges(
-      DWARFUnit *cu, bool check_hi_lo_pc,
-      bool check_specification_or_abstract_origin = false) const;
+  DWARFRangeList
+  GetAttributeAddressRanges(DWARFUnit *cu, bool check_hi_lo_pc,
+                            bool check_elaborating_dies = false) const;
 
   const char *GetName(const DWARFUnit *cu) const;
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/type-unit-same-basename.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/type-unit-same-basename.cpp
@@ -1,0 +1,45 @@
+// Test that we can correctly disambiguate a nested type (where the outer type
+// is in a type unit) from a non-nested type with the same basename. Failure to
+// do so can cause us to think a type is a member of itself, which caused
+// infinite recursion (crash) in the past.
+
+// REQUIRES: lld
+
+// RUN: %clang --target=x86_64-pc-linux -c %s -o %t-a.o -g -fdebug-types-section -flimit-debug-info -DFILE_A
+// RUN: %clang --target=x86_64-pc-linux -c %s -o %t-b.o -g -fdebug-types-section -flimit-debug-info -DFILE_B
+// RUN: ld.lld -z undefs %t-a.o %t-b.o -o %t
+// RUN: %lldb %t -o "target variable x" -o exit | FileCheck %s
+
+// CHECK: (lldb) target variable
+// CHECK-NEXT: (const X) x = {
+// CHECK-NEXT:   NS::Outer::Struct = {
+// CHECK-NEXT:     x = 42
+// CHECK-NEXT:     o = (x = 47)
+// CHECK-NEXT:     y = 24
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+namespace NS {
+struct Struct {
+  int x = 47;
+  virtual void anchor();
+};
+} // namespace NS
+
+#ifdef FILE_A
+namespace NS {
+struct Outer {
+  struct Struct {
+    int x = 42;
+    NS::Struct o;
+    int y = 24;
+  };
+};
+} // namespace NS
+
+struct X : NS::Outer::Struct {};
+extern constexpr X x = {};
+#endif
+#ifdef FILE_B
+void NS::Struct::anchor() {}
+#endif


### PR DESCRIPTION
This allows e.g. DWARFDIE::GetName() to return the name of the type when looking at its declaration (which contains only
DW_AT_declaration+DW_AT_signature). This is similar to how we recurse through DW_AT_specification when looking for a function name. Llvm dwarf parser has obtained the same functionality through #99495.

This fixes a bug where we would confuse a type like NS::Outer::Struct with NS::Struct (because NS::Outer (and its name) was in a type unit).