### PR TITLE
[libc++][modules] Modularize <cstddef>

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -324,6 +324,11 @@ set(files
   __coroutine/coroutine_traits.h
   __coroutine/noop_coroutine_handle.h
   __coroutine/trivial_awaitables.h
+  __cstddef/byte.h
+  __cstddef/max_align_t.h
+  __cstddef/nullptr_t.h
+  __cstddef/ptrdiff_t.h
+  __cstddef/size_t.h
   __debug_utils/randomize_range.h
   __debug_utils/sanitizers.h
   __debug_utils/strict_weak_ordering_check.h

--- a/libcxx/include/__algorithm/ranges_minmax.h
+++ b/libcxx/include/__algorithm/ranges_minmax.h
@@ -24,6 +24,7 @@
 #include <__ranges/access.h>
 #include <__ranges/concepts.h>
 #include <__type_traits/desugars_to.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_reference.h>
 #include <__type_traits/is_trivially_copyable.h>
 #include <__type_traits/remove_cvref.h>

--- a/libcxx/include/__atomic/atomic.h
+++ b/libcxx/include/__atomic/atomic.h
@@ -16,8 +16,10 @@
 #include <__config>
 #include <__functional/operations.h>
 #include <__memory/addressof.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_floating_point.h>
 #include <__type_traits/is_function.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/remove_const.h>
 #include <__type_traits/remove_pointer.h>

--- a/libcxx/include/__charconv/to_chars_integral.h
+++ b/libcxx/include/__charconv/to_chars_integral.h
@@ -21,6 +21,7 @@
 #include <__system_error/errc.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/integral_constant.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/make_32_64_or_128_bit.h>
 #include <__type_traits/make_unsigned.h>

--- a/libcxx/include/__cstddef/byte.h
+++ b/libcxx/include/__cstddef/byte.h
@@ -1,0 +1,84 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___CSTDDEF_BYTE_H
+#define _LIBCPP___CSTDDEF_BYTE_H
+
+#include <__config>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/is_integral.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_STD_VER >= 17
+namespace std { // purposefully not versioned
+
+enum class byte : unsigned char {};
+
+_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator|(byte __lhs, byte __rhs) noexcept {
+  return static_cast<byte>(
+      static_cast<unsigned char>(static_cast<unsigned int>(__lhs) | static_cast<unsigned int>(__rhs)));
+}
+
+_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator|=(byte& __lhs, byte __rhs) noexcept {
+  return __lhs = __lhs | __rhs;
+}
+
+_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator&(byte __lhs, byte __rhs) noexcept {
+  return static_cast<byte>(
+      static_cast<unsigned char>(static_cast<unsigned int>(__lhs) & static_cast<unsigned int>(__rhs)));
+}
+
+_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator&=(byte& __lhs, byte __rhs) noexcept {
+  return __lhs = __lhs & __rhs;
+}
+
+_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator^(byte __lhs, byte __rhs) noexcept {
+  return static_cast<byte>(
+      static_cast<unsigned char>(static_cast<unsigned int>(__lhs) ^ static_cast<unsigned int>(__rhs)));
+}
+
+_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator^=(byte& __lhs, byte __rhs) noexcept {
+  return __lhs = __lhs ^ __rhs;
+}
+
+_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator~(byte __b) noexcept {
+  return static_cast<byte>(static_cast<unsigned char>(~static_cast<unsigned int>(__b)));
+}
+
+template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI constexpr byte& operator<<=(byte& __lhs, _Integer __shift) noexcept {
+  return __lhs = __lhs << __shift;
+}
+
+template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI constexpr byte operator<<(byte __lhs, _Integer __shift) noexcept {
+  return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) << __shift));
+}
+
+template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI constexpr byte& operator>>=(byte& __lhs, _Integer __shift) noexcept {
+  return __lhs = __lhs >> __shift;
+}
+
+template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI constexpr byte operator>>(byte __lhs, _Integer __shift) noexcept {
+  return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) >> __shift));
+}
+
+template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Integer to_integer(byte __b) noexcept {
+  return static_cast<_Integer>(__b);
+}
+
+} // namespace std
+#endif // _LIBCPP_STD_VER >= 17
+
+#endif // _LIBCPP___CSTDDEF_BYTE_H

--- a/libcxx/include/__cstddef/max_align_t.h
+++ b/libcxx/include/__cstddef/max_align_t.h
@@ -1,4 +1,3 @@
-// -*- C++ -*-
 //===---------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -7,32 +6,22 @@
 //
 //===---------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___FWD_SPAN_H
-#define _LIBCPP___FWD_SPAN_H
+#ifndef _LIBCPP___CSTDDEF_MAX_ALIGN_T_H
+#define _LIBCPP___CSTDDEF_MAX_ALIGN_T_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
-#include <limits>
+#include <stddef.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
 
-_LIBCPP_PUSH_MACROS
-#include <__undef_macros>
-
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 20
-
-inline constexpr size_t dynamic_extent = numeric_limits<size_t>::max();
-template <typename _Tp, size_t _Extent = dynamic_extent>
-class span;
-
+#if !defined(_LIBCPP_CXX03_LANG)
+using ::max_align_t _LIBCPP_USING_IF_EXISTS;
 #endif
 
 _LIBCPP_END_NAMESPACE_STD
 
-_LIBCPP_POP_MACROS
-
-#endif // _LIBCPP___FWD_SPAN_H
+#endif // _LIBCPP___CSTDDEF_MAX_ALIGN_T_H

--- a/libcxx/include/__cstddef/nullptr_t.h
+++ b/libcxx/include/__cstddef/nullptr_t.h
@@ -1,4 +1,3 @@
-// -*- C++ -*-
 //===---------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -7,32 +6,20 @@
 //
 //===---------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___FWD_SPAN_H
-#define _LIBCPP___FWD_SPAN_H
+#ifndef _LIBCPP___CSTDDEF_NULLPTR_T_H
+#define _LIBCPP___CSTDDEF_NULLPTR_T_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
-#include <limits>
+#include <stddef.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
 
-_LIBCPP_PUSH_MACROS
-#include <__undef_macros>
-
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 20
-
-inline constexpr size_t dynamic_extent = numeric_limits<size_t>::max();
-template <typename _Tp, size_t _Extent = dynamic_extent>
-class span;
-
-#endif
+using ::nullptr_t;
 
 _LIBCPP_END_NAMESPACE_STD
 
-_LIBCPP_POP_MACROS
-
-#endif // _LIBCPP___FWD_SPAN_H
+#endif // _LIBCPP___CSTDDEF_NULLPTR_T_H

--- a/libcxx/include/__cstddef/ptrdiff_t.h
+++ b/libcxx/include/__cstddef/ptrdiff_t.h
@@ -1,4 +1,3 @@
-// -*- C++ -*-
 //===---------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -7,32 +6,20 @@
 //
 //===---------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___FWD_SPAN_H
-#define _LIBCPP___FWD_SPAN_H
+#ifndef _LIBCPP___CSTDDEF_PTRDIFF_T_H
+#define _LIBCPP___CSTDDEF_PTRDIFF_T_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
-#include <limits>
+#include <stddef.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
 
-_LIBCPP_PUSH_MACROS
-#include <__undef_macros>
-
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 20
-
-inline constexpr size_t dynamic_extent = numeric_limits<size_t>::max();
-template <typename _Tp, size_t _Extent = dynamic_extent>
-class span;
-
-#endif
+using ::ptrdiff_t _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
 
-_LIBCPP_POP_MACROS
-
-#endif // _LIBCPP___FWD_SPAN_H
+#endif // _LIBCPP___CSTDDEF_PTRDIFF_T_H

--- a/libcxx/include/__cstddef/size_t.h
+++ b/libcxx/include/__cstddef/size_t.h
@@ -1,4 +1,3 @@
-// -*- C++ -*-
 //===---------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -7,32 +6,20 @@
 //
 //===---------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___FWD_SPAN_H
-#define _LIBCPP___FWD_SPAN_H
+#ifndef _LIBCPP___CSTDDEF_SIZE_T_H
+#define _LIBCPP___CSTDDEF_SIZE_T_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
-#include <limits>
+#include <stddef.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
 
-_LIBCPP_PUSH_MACROS
-#include <__undef_macros>
-
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 20
-
-inline constexpr size_t dynamic_extent = numeric_limits<size_t>::max();
-template <typename _Tp, size_t _Extent = dynamic_extent>
-class span;
-
-#endif
+using ::size_t _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
 
-_LIBCPP_POP_MACROS
-
-#endif // _LIBCPP___FWD_SPAN_H
+#endif // _LIBCPP___CSTDDEF_SIZE_T_H

--- a/libcxx/include/__exception/nested_exception.h
+++ b/libcxx/include/__exception/nested_exception.h
@@ -13,6 +13,8 @@
 #include <__exception/exception_ptr.h>
 #include <__memory/addressof.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_base_of.h>
 #include <__type_traits/is_class.h>
 #include <__type_traits/is_constructible.h>

--- a/libcxx/include/__fwd/array.h
+++ b/libcxx/include/__fwd/array.h
@@ -10,7 +10,8 @@
 #define _LIBCPP___FWD_ARRAY_H
 
 #include <__config>
-#include <cstddef>
+#include <__cstddef/size_t.h>
+#include <__type_traits/integral_constant.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__fwd/complex.h
+++ b/libcxx/include/__fwd/complex.h
@@ -10,7 +10,7 @@
 #define _LIBCPP___FWD_COMPLEX_H
 
 #include <__config>
-#include <cstddef>
+#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__fwd/pair.h
+++ b/libcxx/include/__fwd/pair.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___FWD_PAIR_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__fwd/tuple.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__fwd/subrange.h
+++ b/libcxx/include/__fwd/subrange.h
@@ -11,8 +11,8 @@
 
 #include <__concepts/copyable.h>
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__iterator/concepts.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__fwd/tuple.h
+++ b/libcxx/include/__fwd/tuple.h
@@ -10,7 +10,7 @@
 #define _LIBCPP___FWD_TUPLE_H
 
 #include <__config>
-#include <cstddef>
+#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/concepts.h
+++ b/libcxx/include/__iterator/concepts.h
@@ -34,6 +34,7 @@
 #include <__memory/pointer_traits.h>
 #include <__type_traits/add_pointer.h>
 #include <__type_traits/common_reference.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/is_primary_template.h>
 #include <__type_traits/is_reference.h>

--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -24,6 +24,8 @@
 #include <__type_traits/common_reference.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/disjunction.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_object.h>
 #include <__type_traits/is_primary_template.h>

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -17,6 +17,7 @@
 #include <__memory/addressof.h>
 #include <__memory/pointer_traits.h>
 #include <__type_traits/enable_if.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_convertible.h>
 #include <cstddef>
 

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -25,6 +25,7 @@
 #include <__type_traits/common_type.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__type_traits/is_same.h>
 #include <__utility/as_const.h>

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -15,6 +15,7 @@
 #include <__type_traits/conditional.h>
 #include <__type_traits/conjunction.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_class.h>
 #include <__type_traits/is_function.h>
 #include <__type_traits/is_void.h>

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -34,6 +34,8 @@
 #include <__type_traits/conditional.h>
 #include <__type_traits/conjunction.h>
 #include <__type_traits/disjunction.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_array.h>
 #include <__type_traits/is_bounded_array.h>
 #include <__type_traits/is_constructible.h>

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -23,6 +23,7 @@
 #include <__type_traits/common_type.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/dependent_type.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_array.h>
 #include <__type_traits/is_assignable.h>

--- a/libcxx/include/__memory/uses_allocator.h
+++ b/libcxx/include/__memory/uses_allocator.h
@@ -11,6 +11,7 @@
 #define _LIBCPP___MEMORY_USES_ALLOCATOR_H
 
 #include <__config>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_convertible.h>
 #include <cstddef>
 

--- a/libcxx/include/__random/mersenne_twister_engine.h
+++ b/libcxx/include/__random/mersenne_twister_engine.h
@@ -13,6 +13,7 @@
 #include <__algorithm/min.h>
 #include <__config>
 #include <__random/is_seed_sequence.h>
+#include <__type_traits/enable_if.h>
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>

--- a/libcxx/include/__random/seed_seq.h
+++ b/libcxx/include/__random/seed_seq.h
@@ -14,6 +14,8 @@
 #include <__algorithm/max.h>
 #include <__config>
 #include <__iterator/iterator_traits.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_unsigned.h>
 #include <cstdint>
 #include <initializer_list>

--- a/libcxx/include/__random/subtract_with_carry_engine.h
+++ b/libcxx/include/__random/subtract_with_carry_engine.h
@@ -14,6 +14,7 @@
 #include <__config>
 #include <__random/is_seed_sequence.h>
 #include <__random/linear_congruential_engine.h>
+#include <__type_traits/enable_if.h>
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -33,6 +33,7 @@
 #include <__tuple/tuple_size.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/is_reference.h>
 #include <__type_traits/make_unsigned.h>

--- a/libcxx/include/__string/constexpr_c_functions.h
+++ b/libcxx/include/__string/constexpr_c_functions.h
@@ -13,11 +13,13 @@
 #include <__memory/addressof.h>
 #include <__memory/construct_at.h>
 #include <__type_traits/datasizeof.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_always_bitcastable.h>
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_equality_comparable.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_trivially_copyable.h>
 #include <__type_traits/is_trivially_lexicographically_comparable.h>

--- a/libcxx/include/__tuple/tuple_size.h
+++ b/libcxx/include/__tuple/tuple_size.h
@@ -12,6 +12,8 @@
 #include <__config>
 #include <__fwd/tuple.h>
 #include <__tuple/tuple_types.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_const.h>
 #include <__type_traits/is_volatile.h>
 #include <cstddef>

--- a/libcxx/include/__type_traits/aligned_storage.h
+++ b/libcxx/include/__type_traits/aligned_storage.h
@@ -10,11 +10,11 @@
 #define _LIBCPP___TYPE_TRAITS_ALIGNED_STORAGE_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/nat.h>
 #include <__type_traits/type_list.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/aligned_union.h
+++ b/libcxx/include/__type_traits/aligned_union.h
@@ -10,9 +10,9 @@
 #define _LIBCPP___TYPE_TRAITS_ALIGNED_UNION_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/aligned_storage.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/alignment_of.h
+++ b/libcxx/include/__type_traits/alignment_of.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___TYPE_TRAITS_ALIGNMENT_OF_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/extent.h
+++ b/libcxx/include/__type_traits/extent.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___TYPE_TRAITS_EXTENT_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_allocator.h
+++ b/libcxx/include/__type_traits/is_allocator.h
@@ -10,10 +10,10 @@
 #define _LIBCPP___TYPE_IS_ALLOCATOR_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_array.h
+++ b/libcxx/include/__type_traits/is_array.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___TYPE_TRAITS_IS_ARRAY_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_bounded_array.h
+++ b/libcxx/include/__type_traits/is_bounded_array.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___TYPE_TRAITS_IS_BOUNDED_ARRAY_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_nothrow_destructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_destructible.h
@@ -10,10 +10,10 @@
 #define _LIBCPP___TYPE_TRAITS_IS_NOTHROW_DESTRUCTIBLE_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_destructible.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_null_pointer.h
+++ b/libcxx/include/__type_traits/is_null_pointer.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___TYPE_TRAITS_IS_NULL_POINTER_H
 
 #include <__config>
+#include <__cstddef/nullptr_t.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_swappable.h
+++ b/libcxx/include/__type_traits/is_swappable.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___TYPE_TRAITS_IS_SWAPPABLE_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/add_lvalue_reference.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_assignable.h>
@@ -18,7 +19,6 @@
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/rank.h
+++ b/libcxx/include/__type_traits/rank.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___TYPE_TRAITS_RANK_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/remove_all_extents.h
+++ b/libcxx/include/__type_traits/remove_all_extents.h
@@ -10,7 +10,7 @@
 #define _LIBCPP___TYPE_TRAITS_REMOVE_ALL_EXTENTS_H
 
 #include <__config>
-#include <cstddef>
+#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/remove_extent.h
+++ b/libcxx/include/__type_traits/remove_extent.h
@@ -10,7 +10,7 @@
 #define _LIBCPP___TYPE_TRAITS_REMOVE_EXTENT_H
 
 #include <__config>
-#include <cstddef>
+#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/type_list.h
+++ b/libcxx/include/__type_traits/type_list.h
@@ -10,7 +10,7 @@
 #define _LIBCPP___TYPE_TRAITS_TYPE_LIST_H
 
 #include <__config>
-#include <cstddef>
+#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__utility/in_place.h
+++ b/libcxx/include/__utility/in_place.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___UTILITY_IN_PLACE_H
 
 #include <__config>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/remove_cvref.h>
 #include <cstddef>
 

--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -25,6 +25,7 @@
 #include <__type_traits/common_type.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_constructible.h>

--- a/libcxx/include/__utility/swap.h
+++ b/libcxx/include/__utility/swap.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___UTILITY_SWAP_H
 
 #include <__config>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_nothrow_assignable.h>

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -90,6 +90,7 @@ namespace std {
 #include <__type_traits/aligned_storage.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_function.h>
 #include <__type_traits/is_nothrow_constructible.h>

--- a/libcxx/include/cstddef
+++ b/libcxx/include/cstddef
@@ -34,9 +34,6 @@ Types:
 */
 
 #include <__config>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/integral_constant.h>
-#include <__type_traits/is_integral.h>
 #include <version>
 
 #include <stddef.h>
@@ -53,80 +50,10 @@ Types:
 #  pragma GCC system_header
 #endif
 
-_LIBCPP_BEGIN_NAMESPACE_STD
-
-using ::nullptr_t;
-using ::ptrdiff_t _LIBCPP_USING_IF_EXISTS;
-using ::size_t _LIBCPP_USING_IF_EXISTS;
-
-#if !defined(_LIBCPP_CXX03_LANG)
-using ::max_align_t _LIBCPP_USING_IF_EXISTS;
-#endif
-
-_LIBCPP_END_NAMESPACE_STD
-
-#if _LIBCPP_STD_VER >= 17
-namespace std { // purposefully not versioned
-
-enum class byte : unsigned char {};
-
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator|(byte __lhs, byte __rhs) noexcept {
-  return static_cast<byte>(
-      static_cast<unsigned char>(static_cast<unsigned int>(__lhs) | static_cast<unsigned int>(__rhs)));
-}
-
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator|=(byte& __lhs, byte __rhs) noexcept {
-  return __lhs = __lhs | __rhs;
-}
-
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator&(byte __lhs, byte __rhs) noexcept {
-  return static_cast<byte>(
-      static_cast<unsigned char>(static_cast<unsigned int>(__lhs) & static_cast<unsigned int>(__rhs)));
-}
-
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator&=(byte& __lhs, byte __rhs) noexcept {
-  return __lhs = __lhs & __rhs;
-}
-
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator^(byte __lhs, byte __rhs) noexcept {
-  return static_cast<byte>(
-      static_cast<unsigned char>(static_cast<unsigned int>(__lhs) ^ static_cast<unsigned int>(__rhs)));
-}
-
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator^=(byte& __lhs, byte __rhs) noexcept {
-  return __lhs = __lhs ^ __rhs;
-}
-
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator~(byte __b) noexcept {
-  return static_cast<byte>(static_cast<unsigned char>(~static_cast<unsigned int>(__b)));
-}
-
-template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte& operator<<=(byte& __lhs, _Integer __shift) noexcept {
-  return __lhs = __lhs << __shift;
-}
-
-template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte operator<<(byte __lhs, _Integer __shift) noexcept {
-  return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) << __shift));
-}
-
-template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte& operator>>=(byte& __lhs, _Integer __shift) noexcept {
-  return __lhs = __lhs >> __shift;
-}
-
-template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte operator>>(byte __lhs, _Integer __shift) noexcept {
-  return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) >> __shift));
-}
-
-template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Integer to_integer(byte __b) noexcept {
-  return static_cast<_Integer>(__b);
-}
-
-} // namespace std
-#endif // _LIBCPP_STD_VER >= 17
+#include <__cstddef/byte.h>
+#include <__cstddef/max_align_t.h>
+#include <__cstddef/nullptr_t.h>
+#include <__cstddef/ptrdiff_t.h>
+#include <__cstddef/size_t.h>
 
 #endif // _LIBCPP_CSTDDEF

--- a/libcxx/include/cstdio
+++ b/libcxx/include/cstdio
@@ -96,6 +96,7 @@ void perror(const char* s);
 */
 
 #include <__config>
+#include <__cstddef/size_t.h>
 
 #include <stdio.h>
 
@@ -115,7 +116,6 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 using ::FILE _LIBCPP_USING_IF_EXISTS;
 using ::fpos_t _LIBCPP_USING_IF_EXISTS;
-using ::size_t _LIBCPP_USING_IF_EXISTS;
 
 using ::fclose _LIBCPP_USING_IF_EXISTS;
 using ::fflush _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/include/cstdlib
+++ b/libcxx/include/cstdlib
@@ -82,6 +82,7 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 */
 
 #include <__config>
+#include <__cstddef/size_t.h>
 
 #include <stdlib.h>
 
@@ -99,7 +100,6 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::size_t _LIBCPP_USING_IF_EXISTS;
 using ::div_t _LIBCPP_USING_IF_EXISTS;
 using ::ldiv_t _LIBCPP_USING_IF_EXISTS;
 using ::lldiv_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/include/cstring
+++ b/libcxx/include/cstring
@@ -57,6 +57,7 @@ size_t strlen(const char* s);
 */
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/is_constant_evaluated.h>
 
 #include <string.h>
@@ -75,7 +76,6 @@ size_t strlen(const char* s);
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::size_t _LIBCPP_USING_IF_EXISTS;
 using ::memcpy _LIBCPP_USING_IF_EXISTS;
 using ::memmove _LIBCPP_USING_IF_EXISTS;
 using ::strcpy _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/include/ctime
+++ b/libcxx/include/ctime
@@ -46,6 +46,7 @@ int timespec_get( struct timespec *ts, int base); // C++17
 */
 
 #include <__config>
+#include <__cstddef/size_t.h>
 
 // <time.h> is not provided by libc++
 #if __has_include(<time.h>)
@@ -62,7 +63,6 @@ int timespec_get( struct timespec *ts, int base); // C++17
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 using ::clock_t _LIBCPP_USING_IF_EXISTS;
-using ::size_t _LIBCPP_USING_IF_EXISTS;
 using ::time_t _LIBCPP_USING_IF_EXISTS;
 using ::tm _LIBCPP_USING_IF_EXISTS;
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/cuchar
+++ b/libcxx/include/cuchar
@@ -37,6 +37,7 @@ size_t c32rtomb(char* s, char32_t c32, mbstate_t* ps);
 */
 
 #include <__config>
+#include <__cstddef/size_t.h>
 
 #include <uchar.h>
 
@@ -57,7 +58,6 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if !defined(_LIBCPP_CXX03_LANG)
 
 using ::mbstate_t _LIBCPP_USING_IF_EXISTS;
-using ::size_t _LIBCPP_USING_IF_EXISTS;
 
 #  if !defined(_LIBCPP_HAS_NO_C8RTOMB_MBRTOC8)
 using ::mbrtoc8 _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/include/cwchar
+++ b/libcxx/include/cwchar
@@ -103,6 +103,7 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 */
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/copy_cv.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_equality_comparable.h>
@@ -127,7 +128,6 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 using ::mbstate_t _LIBCPP_USING_IF_EXISTS;
-using ::size_t _LIBCPP_USING_IF_EXISTS;
 using ::tm _LIBCPP_USING_IF_EXISTS;
 using ::wint_t _LIBCPP_USING_IF_EXISTS;
 using ::FILE _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/include/experimental/__simd/reference.h
+++ b/libcxx/include/experimental/__simd/reference.h
@@ -10,6 +10,7 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_REFERENCE_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_REFERENCE_H
 
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_same.h>
 #include <__utility/declval.h>

--- a/libcxx/include/experimental/__simd/scalar.h
+++ b/libcxx/include/experimental/__simd/scalar.h
@@ -11,6 +11,7 @@
 #define _LIBCPP_EXPERIMENTAL___SIMD_SCALAR_H
 
 #include <__assert>
+#include <__type_traits/integral_constant.h>
 #include <cstddef>
 #include <experimental/__config>
 #include <experimental/__simd/declaration.h>

--- a/libcxx/include/experimental/__simd/simd.h
+++ b/libcxx/include/experimental/__simd/simd.h
@@ -10,6 +10,7 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_SIMD_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_SIMD_H
 
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/remove_cvref.h>
 #include <__utility/forward.h>

--- a/libcxx/include/experimental/__simd/simd_mask.h
+++ b/libcxx/include/experimental/__simd/simd_mask.h
@@ -10,6 +10,7 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_SIMD_MASK_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_SIMD_MASK_H
 
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_same.h>
 #include <cstddef>
 #include <experimental/__config>

--- a/libcxx/include/experimental/__simd/vec_ext.h
+++ b/libcxx/include/experimental/__simd/vec_ext.h
@@ -12,6 +12,7 @@
 
 #include <__assert>
 #include <__bit/bit_ceil.h>
+#include <__type_traits/integral_constant.h>
 #include <__utility/forward.h>
 #include <__utility/integer_sequence.h>
 #include <cstddef>

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -440,6 +440,11 @@ module std_cstdbool [system] {
 }
 module std_cstddef [system] {
   header "cstddef"
+  module byte         { header "__cstddef/byte.h" }
+  module max_align_t  { header "__cstddef/max_align_t.h" }
+  module nullptr_t    { header "__cstddef/nullptr_t.h" }
+  module ptrdiff_t    { header "__cstddef/ptrdiff_t.h" }
+  module size_t       { header "__cstddef/size_t.h" }
   export *
 }
 module std_cstdint [system] {
@@ -1418,6 +1423,7 @@ module std_private_iterator_iterator                [system] { header "__iterato
 module std_private_iterator_iterator_traits         [system] {
   header "__iterator/iterator_traits.h"
   export std_private_type_traits_is_primary_template
+  export std_private_type_traits_integral_constant
 }
 module std_private_iterator_iterator_with_data      [system] { header "__iterator/iterator_with_data.h" }
 module std_private_iterator_mergeable               [system] {
@@ -1814,7 +1820,10 @@ module std_private_tuple_tuple_like             [system] {
   export *
 }
 module std_private_tuple_tuple_like_ext         [system] { header "__tuple/tuple_like_ext.h" }
-module std_private_tuple_tuple_size             [system] { header "__tuple/tuple_size.h" }
+module std_private_tuple_tuple_size             [system] {
+  header "__tuple/tuple_size.h"
+  export std_private_type_traits_integral_constant
+}
 module std_private_tuple_tuple_types            [system] { header "__tuple/tuple_types.h" }
 
 module std_private_type_traits_add_const                                 [system] { header "__type_traits/add_const.h" }
@@ -1926,7 +1935,10 @@ module std_private_type_traits_is_implicitly_default_constructible       [system
   header "__type_traits/is_implicitly_default_constructible.h"
   export std_private_type_traits_integral_constant
 }
-module std_private_type_traits_is_integral                               [system] { header "__type_traits/is_integral.h" }
+module std_private_type_traits_is_integral                               [system] {
+  header "__type_traits/is_integral.h"
+  export std_private_type_traits_integral_constant
+}
 module std_private_type_traits_is_literal_type                           [system] { header "__type_traits/is_literal_type.h" }
 module std_private_type_traits_is_member_pointer                         [system] { header "__type_traits/is_member_pointer.h" }
 module std_private_type_traits_is_nothrow_assignable                     [system] { header "__type_traits/is_nothrow_assignable.h" }
@@ -1954,7 +1966,10 @@ module std_private_type_traits_is_primary_template                       [system
   header "__type_traits/is_primary_template.h"
   export std_private_type_traits_enable_if
 }
-module std_private_type_traits_is_reference                              [system] { header "__type_traits/is_reference.h" }
+module std_private_type_traits_is_reference                              [system] {
+  header "__type_traits/is_reference.h"
+  export std_private_type_traits_integral_constant
+}
 module std_private_type_traits_is_reference_wrapper                      [system] { header "__type_traits/is_reference_wrapper.h" }
 module std_private_type_traits_is_referenceable                          [system] { header "__type_traits/is_referenceable.h" }
 module std_private_type_traits_is_same                                   [system] {
@@ -1976,7 +1991,10 @@ module std_private_type_traits_is_swappable                              [system
 module std_private_type_traits_is_trivial                                [system] { header "__type_traits/is_trivial.h" }
 module std_private_type_traits_is_trivially_assignable                   [system] { header "__type_traits/is_trivially_assignable.h" }
 module std_private_type_traits_is_trivially_constructible                [system] { header "__type_traits/is_trivially_constructible.h" }
-module std_private_type_traits_is_trivially_copyable                     [system] { header "__type_traits/is_trivially_copyable.h" }
+module std_private_type_traits_is_trivially_copyable                     [system] {
+  header "__type_traits/is_trivially_copyable.h"
+  export std_private_type_traits_integral_constant
+}
 module std_private_type_traits_is_trivially_destructible                 [system] { header "__type_traits/is_trivially_destructible.h" }
 module std_private_type_traits_is_trivially_lexicographically_comparable [system] { header "__type_traits/is_trivially_lexicographically_comparable.h" }
 module std_private_type_traits_is_trivially_relocatable                  [system] { header "__type_traits/is_trivially_relocatable.h" }
@@ -2044,7 +2062,10 @@ module std_private_utility_exception_guard        [system] { header "__utility/e
 module std_private_utility_exchange               [system] { header "__utility/exchange.h" }
 module std_private_utility_forward                [system] { header "__utility/forward.h" }
 module std_private_utility_forward_like           [system] { header "__utility/forward_like.h" }
-module std_private_utility_in_place               [system] { header "__utility/in_place.h" }
+module std_private_utility_in_place               [system] {
+  header "__utility/in_place.h"
+  export std_private_type_traits_integral_constant
+}
 module std_private_utility_integer_sequence       [system] { header "__utility/integer_sequence.h" }
 module std_private_utility_is_pointer_in_range    [system] { header "__utility/is_pointer_in_range.h" }
 module std_private_utility_is_valid_range         [system] { header "__utility/is_valid_range.h" }

--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -58,6 +58,7 @@ public:
 
 #include <__config>
 #include <__exception/exception.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__verbose_abort>
 #include <cstddef>

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -600,7 +600,9 @@ template <class Key, class T, class Hash, class Pred, class Alloc>
 #include <__ranges/concepts.h>
 #include <__ranges/container_compatible_range.h>
 #include <__ranges/from_range.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_allocator.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/type_identity.h>
 #include <__utility/forward.h>
 #include <stdexcept>

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -548,7 +548,9 @@ template <class Value, class Hash, class Pred, class Alloc>
 #include <__ranges/concepts.h>
 #include <__ranges/container_compatible_range.h>
 #include <__ranges/from_range.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_allocator.h>
+#include <__type_traits/is_integral.h>
 #include <__utility/forward.h>
 #include <version>
 

--- a/libcxx/test/libcxx/transitive_includes/cxx03.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx03.csv
@@ -231,7 +231,6 @@ expected cstddef
 expected initializer_list
 expected new
 expected version
-experimental/iterator cstddef
 experimental/iterator iosfwd
 experimental/iterator iterator
 experimental/iterator type_traits
@@ -918,7 +917,6 @@ tuple type_traits
 tuple typeinfo
 tuple utility
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare

--- a/libcxx/test/libcxx/transitive_includes/cxx11.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx11.csv
@@ -232,7 +232,6 @@ expected cstddef
 expected initializer_list
 expected new
 expected version
-experimental/iterator cstddef
 experimental/iterator iosfwd
 experimental/iterator iterator
 experimental/iterator type_traits
@@ -925,7 +924,6 @@ tuple type_traits
 tuple typeinfo
 tuple utility
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare

--- a/libcxx/test/libcxx/transitive_includes/cxx14.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx14.csv
@@ -233,7 +233,6 @@ expected cstddef
 expected initializer_list
 expected new
 expected version
-experimental/iterator cstddef
 experimental/iterator iosfwd
 experimental/iterator iterator
 experimental/iterator type_traits
@@ -928,7 +927,6 @@ tuple type_traits
 tuple typeinfo
 tuple utility
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare

--- a/libcxx/test/libcxx/transitive_includes/cxx17.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx17.csv
@@ -233,7 +233,6 @@ expected cstddef
 expected initializer_list
 expected new
 expected version
-experimental/iterator cstddef
 experimental/iterator iosfwd
 experimental/iterator iterator
 experimental/iterator type_traits
@@ -929,7 +928,6 @@ tuple type_traits
 tuple typeinfo
 tuple utility
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare

--- a/libcxx/test/libcxx/transitive_includes/cxx20.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx20.csv
@@ -241,7 +241,6 @@ expected cstddef
 expected initializer_list
 expected new
 expected version
-experimental/iterator cstddef
 experimental/iterator iosfwd
 experimental/iterator iterator
 experimental/iterator type_traits
@@ -936,7 +935,6 @@ tuple type_traits
 tuple typeinfo
 tuple utility
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare

--- a/libcxx/test/libcxx/transitive_includes/cxx23.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx23.csv
@@ -155,7 +155,6 @@ expected cstdint
 expected initializer_list
 expected new
 expected version
-experimental/iterator cstddef
 experimental/iterator iterator
 experimental/memory cstddef
 experimental/memory cstdint
@@ -647,7 +646,6 @@ tuple compare
 tuple cstddef
 tuple cstdint
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -155,7 +155,6 @@ expected cstdint
 expected initializer_list
 expected new
 expected version
-experimental/iterator cstddef
 experimental/iterator iterator
 experimental/memory cstddef
 experimental/memory cstdint
@@ -647,7 +646,6 @@ tuple compare
 tuple cstddef
 tuple cstdint
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare

--- a/libcxx/test/std/numerics/bit/bit.pow.two/bit_ceil.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bit.pow.two/bit_ceil.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 

--- a/libcxx/test/std/numerics/bit/bit.pow.two/bit_floor.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bit.pow.two/bit_floor.pass.cpp
@@ -16,6 +16,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bit.pow.two/bit_width.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bit.pow.two/bit_width.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bit.pow.two/has_single_bit.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bit.pow.two/has_single_bit.pass.cpp
@@ -15,6 +15,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bitops.count/countl_one.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.count/countl_one.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bitops.count/countl_zero.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.count/countl_zero.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bitops.count/countr_one.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.count/countr_one.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bitops.count/countr_zero.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.count/countr_zero.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bitops.count/popcount.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.count/popcount.pass.cpp
@@ -16,6 +16,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bitops.rot/rotl.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.rot/rotl.pass.cpp
@@ -15,6 +15,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/std/numerics/bit/bitops.rot/rotr.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.rot/rotr.pass.cpp
@@ -15,6 +15,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -122,7 +122,9 @@ void header_exportable_declarations::registerMatchers(clang::ast_matchers::Match
     [[fallthrough]];
   case FileType::ModulePartition:
   case FileType::CompatModulePartition:
-    finder->addMatcher(namedDecl(isExpansionInFileMatching(filename_)).bind("header_exportable_declarations"), this);
+    finder->addMatcher(namedDecl(anyOf(isExpansionInFileMatching(filename_), isExpansionInFileMatching(extra_header_)))
+                           .bind("header_exportable_declarations"),
+                       this);
     break;
   case FileType::Module:
   case FileType::CompatModule:

--- a/libcxx/utils/libcxx/test/modules.py
+++ b/libcxx/utils/libcxx/test/modules.py
@@ -99,6 +99,10 @@ ExtraHeader["ranges"] = "v1/__fwd/subrange.h$"
 # same definition.
 ExtraHeader["functional"] = "v1/__compare/compare_three_way.h$"
 
+# Some C compatibility headers define std::size_t, which is in <__cstddef/size_t.h>
+for header in ("cstdio", "cstdlib", "cstring", "ctime", "cuchar", "cwchar"):
+    ExtraHeader[header] = "v1/__cstddef/size_t.h$"
+
 
 # newline needs to be escaped for the module partition output.
 nl = "\\\\n"


### PR DESCRIPTION
Many headers include `<cstddef>` just for size_t, and pulling in additional content (e.g. the traits used for std::byte) is unnecessary. To solve this problem, this patch splits up `<cstddef>` into subcomponents so that headers can include only the parts that they actually require.

This has the added benefit of making the modules build a lot stricter with respect to IWYU, and also providing a canonical location where we define `std::size_t` and friends (which were previously defined in multiple headers like `<cstddef>` and `<ctime>`).

After this patch, there's still many places in the codebase where we include `<cstddef>` when `<__cstddef/size_t.h>` would be sufficient. This patch focuses on removing `<cstddef>` includes from __type_traits to make these headers non-circular with `<cstddef>`. Additional refactorings can be tackled separately.