### PR TITLE
[DWARF] Don't search scope chain to find DISubprogram for prologues

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2199,11 +2199,10 @@ DebugLoc DwarfDebug::emitInitialLocDirective(const MachineFunction &MF,
 
     // Ensure the compile unit is created if the function is called before
     // beginFunction().
-    (void)getOrCreateDwarfCompileUnit(
-        MF.getFunction().getSubprogram()->getUnit());
+    DISubprogram *SP = MF.getFunction().getSubprogram();
+    (void)getOrCreateDwarfCompileUnit(SP->getUnit());
     // We'd like to list the prologue as "not statements" but GDB behaves
     // poorly if we do that. Revisit this with caution/GDB (7.5+) testing.
-    const DISubprogram *SP = PrologEndLoc->getInlinedAtScope()->getSubprogram();
     ::recordSourceLine(*Asm, SP->getScopeLine(), 0, SP, DWARF2_FLAG_IS_STMT,
                        CUID, getDwarfVersion(), getUnits());
     return PrologEndLoc;


### PR DESCRIPTION
Despite having a DISubprogram to hand, this code calls `getInlinedAtScope` to step through all inlined scopes to the outermost one and retrieve... the same DISubprogram. Seemingly this goes back to fd07a2af23c in 2015 -- I anticipate that back then the metadata layout was radically different, and the code simply hasn't been changed since then as it isn't broken.

Nowadays at least, we can just directly look up the subprogram (and I'd like to refactor this area a little).