### PR TITLE
[LLVM][AArch64] Refactor sve-b16b16 instruction definitions.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -63,7 +63,8 @@ def SVE2p1Unsupported : AArch64Unsupported;
 
 def SVE2Unsupported : AArch64Unsupported {
   let F = !listconcat([HasSVE2, HasSVE2orSME, HasSVE2orSME2, HasSSVE_FP8FMA, HasSMEF8F16,
-                       HasSMEF8F32, HasSVE2AES, HasSVE2SHA3, HasSVE2SM4, HasSVE2BitPerm],
+                       HasSMEF8F32, HasSVE2AES, HasSVE2SHA3, HasSVE2SM4, HasSVE2BitPerm,
+                       HasSVEB16B16],
                        SVE2p1Unsupported.F);
 }
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -143,7 +143,7 @@ def HasFuseAES       : Predicate<"Subtarget->hasFuseAES()">,
                                  "fuse-aes">;
 def HasSVE           : Predicate<"Subtarget->isSVEAvailable()">,
                                  AssemblerPredicateWithAll<(all_of FeatureSVE), "sve">;
-def HasSVEB16B16     : Predicate<"Subtarget->hasSVEB16B16()">,
+def HasSVEB16B16     : Predicate<"Subtarget->isSVEorStreamingSVEAvailable() && Subtarget->hasSVEB16B16()">,
                                  AssemblerPredicateWithAll<(all_of FeatureSVEB16B16), "sve-b16b16">;
 def HasSVE2          : Predicate<"Subtarget->isSVEAvailable() && Subtarget->hasSVE2()">,
                                  AssemblerPredicateWithAll<(all_of FeatureSVE2), "sve2">;

--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -3892,7 +3892,7 @@ defm PSEL_PPPRI : sve2_int_perm_sel_p<"psel", int_aarch64_sve_psel>;
 //===----------------------------------------------------------------------===//
 
 let Predicates = [HasSVE2p1_or_HasSME2] in {
-defm FCLAMP_ZZZ : sve2p1_fclamp<"fclamp", AArch64fclamp>;
+defm FCLAMP_ZZZ : sve_fp_clamp<"fclamp", AArch64fclamp>;
 
 defm FDOT_ZZZ_S  : sve_float_dot<0b0, 0b0, ZPR32, ZPR16, "fdot", nxv8f16, int_aarch64_sve_fdot_x2>;
 defm FDOT_ZZZI_S : sve_float_dot_indexed<0b0, 0b00, ZPR16, ZPR3b16, "fdot", nxv8f16, int_aarch64_sve_fdot_lane_x2>;
@@ -4075,57 +4075,50 @@ def : InstAlias<"pfalse\t$Pd", (PFALSE PPRorPNR8:$Pd), 0>;
 // Non-widening BFloat16 to BFloat16 instructions
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasSVE2orSME2, HasSVEB16B16, UseExperimentalZeroingPseudos] in {
-defm BFADD_ZPZZ : sve2p1_bf_2op_p_zds_zeroing<int_aarch64_sve_fadd>;
-defm BFSUB_ZPZZ : sve2p1_bf_2op_p_zds_zeroing<int_aarch64_sve_fsub>;
-defm BFMUL_ZPZZ : sve2p1_bf_2op_p_zds_zeroing<int_aarch64_sve_fmul>;
-defm BFMAXNM_ZPZZ : sve2p1_bf_2op_p_zds_zeroing<int_aarch64_sve_fmaxnm>;
-defm BFMINNM_ZPZZ : sve2p1_bf_2op_p_zds_zeroing<int_aarch64_sve_fminnm>;
-defm BFMIN_ZPZZ : sve2p1_bf_2op_p_zds_zeroing<int_aarch64_sve_fmin>;
-defm BFMAX_ZPZZ : sve2p1_bf_2op_p_zds_zeroing<int_aarch64_sve_fmax>;
-} // HasSVE2orSME2, HasSVEB16B16, UseExperimentalZeroingPseudos
+let Predicates = [HasSVEB16B16] in {
+defm BFADD_ZZZ : sve_fp_3op_u_zd_bfloat<0b000, "bfadd", AArch64fadd>;
+defm BFSUB_ZZZ : sve_fp_3op_u_zd_bfloat<0b001, "bfsub", AArch64fsub>;
+defm BFMUL_ZZZ : sve_fp_3op_u_zd_bfloat<0b010, "bfmul", AArch64fmul>;
 
-let Predicates = [HasSVE2orSME2, HasSVEB16B16] in {
+defm BFADD_ZPmZZ   : sve_fp_2op_p_zds_bfloat<0b0000, "bfadd", "BFADD_ZPZZ", AArch64fadd_m1, DestructiveBinaryComm>;
+defm BFSUB_ZPmZZ   : sve_fp_2op_p_zds_bfloat<0b0001, "bfsub", "BFSUB_ZPZZ", AArch64fsub_m1, DestructiveBinaryComm>;
+defm BFMUL_ZPmZZ   : sve_fp_2op_p_zds_bfloat<0b0010, "bfmul", "BFMUL_ZPZZ", AArch64fmul_m1, DestructiveBinaryComm>;
+defm BFMAXNM_ZPmZZ : sve_fp_2op_p_zds_bfloat<0b0100, "bfmaxnm", "BFMAXNM_ZPZZ", int_aarch64_sve_fmaxnm, DestructiveBinaryComm>;
+defm BFMINNM_ZPmZZ : sve_fp_2op_p_zds_bfloat<0b0101, "bfminnm", "BFMINNM_ZPZZ", int_aarch64_sve_fminnm, DestructiveBinaryComm>;
+defm BFMAX_ZPmZZ   : sve_fp_2op_p_zds_bfloat<0b0110, "bfmax", "BFMAX_ZPZZ", int_aarch64_sve_fmax, DestructiveBinaryComm>;
+defm BFMIN_ZPmZZ   : sve_fp_2op_p_zds_bfloat<0b0111, "bfmin", "BFMIN_ZPZZ", int_aarch64_sve_fmin, DestructiveBinaryComm>;
 
-defm BFMLA_ZPmZZ : sve_fp_3op_p_zds_a_bf<0b00, "bfmla", "BFMLA_ZPZZZ", AArch64fmla_m1>;
-defm BFMLS_ZPmZZ : sve_fp_3op_p_zds_a_bf<0b01, "bfmls", "BFMLS_ZPZZZ", AArch64fmls_m1>;
+defm BFADD_ZPZZ   : sve_fp_bin_pred_bfloat<AArch64fadd_p>;
+defm BFSUB_ZPZZ   : sve_fp_bin_pred_bfloat<AArch64fsub_p>;
+defm BFMUL_ZPZZ   : sve_fp_bin_pred_bfloat<AArch64fmul_p>;
+defm BFMAXNM_ZPZZ : sve_fp_bin_pred_bfloat<AArch64fmaxnm_p>;
+defm BFMINNM_ZPZZ : sve_fp_bin_pred_bfloat<AArch64fminnm_p>;
+defm BFMAX_ZPZZ   : sve_fp_bin_pred_bfloat<AArch64fmax_p>;
+defm BFMIN_ZPZZ   : sve_fp_bin_pred_bfloat<AArch64fmin_p>;
 
-defm BFMLA_ZPZZZ : sve_fp_3op_pred_bf<AArch64fmla_p>;
-defm BFMLS_ZPZZZ : sve_fp_3op_pred_bf<AArch64fmls_p>;
+defm BFMLA_ZPmZZ : sve_fp_3op_p_zds_a_bfloat<0b00, "bfmla", "BFMLA_ZPZZZ", AArch64fmla_m1>;
+defm BFMLS_ZPmZZ : sve_fp_3op_p_zds_a_bfloat<0b01, "bfmls", "BFMLS_ZPZZZ", AArch64fmls_m1>;
 
-defm BFMLA_ZZZI : sve2p1_fp_bfma_by_indexed_elem<"bfmla", 0b10, int_aarch64_sve_fmla_lane>;
-defm BFMLS_ZZZI : sve2p1_fp_bfma_by_indexed_elem<"bfmls", 0b11, int_aarch64_sve_fmls_lane>;
+defm BFMLA_ZPZZZ : sve_fp_3op_pred_bfloat<AArch64fmla_p>;
+defm BFMLS_ZPZZZ : sve_fp_3op_pred_bfloat<AArch64fmls_p>;
 
-defm BFADD_ZPmZZ : sve2p1_bf_2op_p_zds<0b0000, "bfadd", "BFADD_ZPZZ", AArch64fadd_m1, DestructiveBinaryComm>;
-defm BFSUB_ZPmZZ : sve2p1_bf_2op_p_zds<0b0001, "bfsub", "BFSUB_ZPZZ", AArch64fsub_m1, DestructiveBinaryComm>;
-defm BFMUL_ZPmZZ : sve2p1_bf_2op_p_zds<0b0010, "bfmul", "BFMUL_ZPZZ", AArch64fmul_m1, DestructiveBinaryComm>;
+defm BFMLA_ZZZI : sve_fp_fma_by_indexed_elem_bfloat<"bfmla", 0b10, int_aarch64_sve_fmla_lane>;
+defm BFMLS_ZZZI : sve_fp_fma_by_indexed_elem_bfloat<"bfmls", 0b11, int_aarch64_sve_fmls_lane>;
 
-defm BFADD_ZZZ : sve2p1_bf_3op_u_zd<0b000, "bfadd", AArch64fadd>;
-defm BFSUB_ZZZ : sve2p1_bf_3op_u_zd<0b001, "bfsub", AArch64fsub>;
-defm BFMUL_ZZZ : sve2p1_bf_3op_u_zd<0b010, "bfmul", AArch64fmul>;
+defm BFMUL_ZZZI : sve_fp_fmul_by_indexed_elem_bfloat<"bfmul", int_aarch64_sve_fmul_lane>;
 
-defm BFADD_ZPZZ : sve2p1_bf_bin_pred_zds<AArch64fadd_p>;
-defm BFSUB_ZPZZ : sve2p1_bf_bin_pred_zds<AArch64fsub_p>;
-defm BFMUL_ZPZZ : sve2p1_bf_bin_pred_zds<AArch64fmul_p>;
+defm BFCLAMP_ZZZ : sve_fp_clamp_bfloat<"bfclamp", AArch64fclamp>;
+} // End HasSVEB16B16
 
-
-defm BFMAX_ZPmZZ : sve2p1_bf_2op_p_zds<0b0110, "bfmax", "BFMAX_ZPZZ", int_aarch64_sve_fmax, DestructiveBinaryComm>;
-defm BFMIN_ZPmZZ : sve2p1_bf_2op_p_zds<0b0111, "bfmin", "BFMIN_ZPZZ", int_aarch64_sve_fmin, DestructiveBinaryComm>;
-
-defm BFMAX_ZPZZ : sve2p1_bf_bin_pred_zds<AArch64fmax_p>;
-defm BFMIN_ZPZZ : sve2p1_bf_bin_pred_zds<AArch64fmin_p>;
-
-
-defm BFMAXNM_ZPmZZ : sve2p1_bf_2op_p_zds<0b0100, "bfmaxnm", "BFMAXNM_ZPZZ", int_aarch64_sve_fmaxnm, DestructiveBinaryComm>;
-defm BFMINNM_ZPmZZ : sve2p1_bf_2op_p_zds<0b0101, "bfminnm", "BFMINNM_ZPZZ", int_aarch64_sve_fminnm, DestructiveBinaryComm>;
-
-defm BFMAXNM_ZPZZ : sve2p1_bf_bin_pred_zds<AArch64fmaxnm_p>;
-defm BFMINNM_ZPZZ : sve2p1_bf_bin_pred_zds<AArch64fminnm_p>;
-
-defm BFMUL_ZZZI : sve2p1_fp_bfmul_by_indexed_elem<"bfmul", int_aarch64_sve_fmul_lane>;
-
-defm BFCLAMP_ZZZ : sve2p1_bfclamp<"bfclamp", AArch64fclamp>;
-} // End HasSVE2orSME2, HasSVEB16B16
+let Predicates = [HasSVEB16B16, UseExperimentalZeroingPseudos] in {
+defm BFADD_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fadd>;
+defm BFSUB_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fsub>;
+defm BFMUL_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fmul>;
+defm BFMAXNM_ZPZZ : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fmaxnm>;
+defm BFMINNM_ZPZZ : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fminnm>;
+defm BFMIN_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fmin>;
+defm BFMAX_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fmax>;
+} // HasSVEB16B16, UseExperimentalZeroingPseudos
 
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseN2.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseN2.td
@@ -19,7 +19,7 @@ def NeoverseN2Model : SchedMachineModel {
   let CompleteModel         =   1;
 
   list<Predicate> UnsupportedFeatures = !listconcat(SMEUnsupported.F,
-    [HasSVE2p1, HasPAuthLR, HasCPA, HasCSSC]);
+    [HasSVE2p1, HasSVEB16B16, HasPAuthLR, HasCPA, HasCSSC]);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV2.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV2.td
@@ -22,8 +22,8 @@ def NeoverseV2Model : SchedMachineModel {
   let CompleteModel         =   1;
 
   list<Predicate> UnsupportedFeatures = !listconcat(SMEUnsupported.F,
-                                                    [HasSVE2p1, HasCPA,
-                                                    HasCSSC]);
+                                                    [HasSVE2p1, HasSVEB16B16,
+                                                     HasCPA, HasCSSC]);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -2134,29 +2134,6 @@ class sve_fp_2op_p_zds<bits<2> sz, bits<4> opc, string asm,
   let mayRaiseFPException = 1;
 }
 
-multiclass sve2p1_bf_2op_p_zds<bits<4> opc, string asm, string Ps,
-                            SDPatternOperator op, DestructiveInstTypeEnum flags,
-                            string revname="", bit isReverseInstr=0> {
-let DestructiveInstType = flags in {
-  def NAME : sve_fp_2op_p_zds<0b00, opc, asm, ZPR16>,
-           SVEPseudo2Instr<Ps, 1>, SVEInstr2Rev<NAME , revname , isReverseInstr>;
-  }
-
-  def : SVE_3_Op_Pat<nxv8bf16, op, nxv8i1, nxv8bf16, nxv8bf16, !cast<Instruction>(NAME)>;
-}
-
-multiclass sve2p1_bf_bin_pred_zds<SDPatternOperator op> {
-  def _UNDEF : PredTwoOpPseudo<NAME, ZPR16, FalseLanesUndef>;
-
-  def : SVE_3_Op_Pat<nxv8bf16, op, nxv8i1,  nxv8bf16, nxv8bf16, !cast<Pseudo>(NAME # _UNDEF)>;
-}
-
-multiclass sve2p1_bf_2op_p_zds_zeroing<SDPatternOperator op> {
-  def _ZERO : PredTwoOpPseudo<NAME, ZPR16, FalseLanesZero>;
-
-  def : SVE_3_Op_Pat_SelZero<nxv8bf16, op, nxv8i1, nxv8bf16, nxv8bf16, !cast<Pseudo>(NAME # _ZERO)>;
-}
-
 multiclass sve_fp_2op_p_zds<bits<4> opc, string asm, string Ps,
                             SDPatternOperator op, DestructiveInstTypeEnum flags,
                             string revname="", bit isReverseInstr=0> {
@@ -2185,6 +2162,18 @@ multiclass sve_fp_2op_p_zds_fscale<bits<4> opc, string asm,
   def : SVE_3_Op_Pat<nxv2f64, op, nxv2i1, nxv2f64, nxv2i64, !cast<Instruction>(NAME # _D)>;
 }
 
+multiclass sve_fp_2op_p_zds_bfloat<bits<4> opc, string asm, string Ps,
+                                   SDPatternOperator op,
+                                   DestructiveInstTypeEnum flags,
+                                   string revname="", bit isReverseInstr=0> {
+  let DestructiveInstType = flags in {
+  def NAME : sve_fp_2op_p_zds<0b00, opc, asm, ZPR16>,
+             SVEPseudo2Instr<Ps, 1>, SVEInstr2Rev<NAME , revname , isReverseInstr>;
+  }
+
+  def : SVE_3_Op_Pat<nxv8bf16, op, nxv8i1, nxv8bf16, nxv8bf16, !cast<Instruction>(NAME)>;
+}
+
 multiclass sve_fp_2op_p_zds_zeroing_hsd<SDPatternOperator op> {
   def _H_ZERO : PredTwoOpPseudo<NAME # _H, ZPR16, FalseLanesZero>;
   def _S_ZERO : PredTwoOpPseudo<NAME # _S, ZPR32, FalseLanesZero>;
@@ -2193,6 +2182,12 @@ multiclass sve_fp_2op_p_zds_zeroing_hsd<SDPatternOperator op> {
   def : SVE_3_Op_Pat_SelZero<nxv8f16, op, nxv8i1, nxv8f16, nxv8f16, !cast<Pseudo>(NAME # _H_ZERO)>;
   def : SVE_3_Op_Pat_SelZero<nxv4f32, op, nxv4i1, nxv4f32, nxv4f32, !cast<Pseudo>(NAME # _S_ZERO)>;
   def : SVE_3_Op_Pat_SelZero<nxv2f64, op, nxv2i1, nxv2f64, nxv2f64, !cast<Pseudo>(NAME # _D_ZERO)>;
+}
+
+multiclass sve_fp_2op_p_zds_zeroing_bfloat<SDPatternOperator op> {
+  def _ZERO : PredTwoOpPseudo<NAME, ZPR16, FalseLanesZero>;
+
+  def : SVE_3_Op_Pat_SelZero<nxv8bf16, op, nxv8i1, nxv8bf16, nxv8bf16, !cast<Pseudo>(NAME # _ZERO)>;
 }
 
 class sve_fp_ftmad<bits<2> sz, string asm, ZPRRegOp zprty>
@@ -2300,7 +2295,7 @@ multiclass sve_fp_3op_u_zd<bits<3> opc, string asm, SDPatternOperator op> {
   def : SVE_2_Op_Pat<nxv2f64, op, nxv2f64, nxv2f64, !cast<Instruction>(NAME # _D)>;
 }
 
-multiclass sve2p1_bf_3op_u_zd<bits<3> opc, string asm, SDPatternOperator op> {
+multiclass sve_fp_3op_u_zd_bfloat<bits<3> opc, string asm, SDPatternOperator op> {
   def NAME : sve_fp_3op_u_zd<0b00, opc, asm, ZPR16>;
 
   def : SVE_2_Op_Pat<nxv8bf16, op, nxv8bf16, nxv8bf16, !cast<Instruction>(NAME)>;
@@ -2364,8 +2359,8 @@ multiclass sve_fp_3op_p_zds_a<bits<2> opc, string asm, string Ps,
   def : SVE_4_Op_Pat<nxv2f64, op, nxv2i1, nxv2f64, nxv2f64, nxv2f64, !cast<Instruction>(NAME # _D)>;
 }
 
-multiclass sve_fp_3op_p_zds_a_bf<bits<2> opc, string asm, string Ps,
-                              SDPatternOperator op> {
+multiclass sve_fp_3op_p_zds_a_bfloat<bits<2> opc, string asm, string Ps,
+                                     SDPatternOperator op> {
   def NAME : sve_fp_3op_p_zds_a<0b00, opc, asm, ZPR16>,
            SVEPseudo2Instr<Ps, 1>, SVEInstr2Rev<NAME, "", 0>;
 
@@ -2439,19 +2434,6 @@ class sve_fp_fma_by_indexed_elem<bits<2> sz, bits<2> opc, string asm,
   let mayRaiseFPException = 1;
 }
 
-multiclass sve2p1_fp_bfma_by_indexed_elem<string asm, bits<2> opc, SDPatternOperator op> {
-  def NAME : sve_fp_fma_by_indexed_elem<{0, ?}, opc, asm, ZPR16, ZPR3b16,
-                                         VectorIndexH32b> {
-    bits<3> Zm;
-    bits<3> iop;
-    let Inst{22} = iop{2};
-    let Inst{20-19} = iop{1-0};
-    let Inst{18-16} = Zm;
-  }
-  def : Pat<(nxv8bf16 (op nxv8bf16:$op1, nxv8bf16:$op2, nxv8bf16:$op3, (i32 VectorIndexH32b_timm:$idx))),
-            (!cast<Instruction>(NAME) $op1, $op2, $op3, VectorIndexH32b_timm:$idx)>;
-}
-
 multiclass sve_fp_fma_by_indexed_elem<bits<2> opc, string asm,
                                       SDPatternOperator op> {
   def _H : sve_fp_fma_by_indexed_elem<{0, ?}, opc, asm, ZPR16, ZPR3b16, VectorIndexH32b> {
@@ -2482,6 +2464,19 @@ multiclass sve_fp_fma_by_indexed_elem<bits<2> opc, string asm,
             (!cast<Instruction>(NAME # _D) $Op1, $Op2, $Op3, VectorIndexD32b_timm:$idx)>;
 }
 
+multiclass sve_fp_fma_by_indexed_elem_bfloat<string asm, bits<2> opc,
+                                             SDPatternOperator op> {
+  def NAME : sve_fp_fma_by_indexed_elem<{0, ?}, opc, asm, ZPR16, ZPR3b16, VectorIndexH32b> {
+    bits<3> Zm;
+    bits<3> iop;
+    let Inst{22} = iop{2};
+    let Inst{20-19} = iop{1-0};
+    let Inst{18-16} = Zm;
+  }
+
+  def : Pat<(nxv8bf16 (op nxv8bf16:$op1, nxv8bf16:$op2, nxv8bf16:$op3, (i32 VectorIndexH32b_timm:$idx))),
+            (!cast<Instruction>(NAME) $op1, $op2, $op3, VectorIndexH32b_timm:$idx)>;
+}
 
 //===----------------------------------------------------------------------===//
 // SVE Floating Point Multiply - Indexed Group
@@ -2504,18 +2499,6 @@ class sve_fp_fmul_by_indexed_elem<bits<2> sz, bit o2, string asm, ZPRRegOp zprty
 
   let hasSideEffects = 0;
   let mayRaiseFPException = 1;
-}
-
-multiclass sve2p1_fp_bfmul_by_indexed_elem<string asm, SDPatternOperator ir_intrinsic> {
-  def NAME : sve_fp_fmul_by_indexed_elem<{0, ?}, 0b1, asm, ZPR16, ZPR3b16, VectorIndexH32b> {
-    bits<3> Zm;
-    bits<3> iop;
-    let Inst{22} = iop{2};
-    let Inst{20-19} = iop{1-0};
-    let Inst{18-16} = Zm;
-  }
-  def : Pat <(nxv8bf16 (ir_intrinsic nxv8bf16:$Op1, nxv8bf16:$Op2, (i32 VectorIndexH32b_timm:$idx))),
-             (!cast<Instruction>(NAME) $Op1, $Op2, VectorIndexH32b_timm:$idx)>;
 }
 
 multiclass sve_fp_fmul_by_indexed_elem<string asm, SDPatternOperator op> {
@@ -2545,6 +2528,19 @@ multiclass sve_fp_fmul_by_indexed_elem<string asm, SDPatternOperator op> {
             (!cast<Instruction>(NAME # _S) $Op1, $Op2, VectorIndexS32b_timm:$idx)>;
   def : Pat<(nxv2f64 (op nxv2f64:$Op1, nxv2f64:$Op2, (i32 VectorIndexD32b_timm:$idx))),
             (!cast<Instruction>(NAME # _D) $Op1, $Op2, VectorIndexD32b_timm:$idx)>;
+}
+
+multiclass sve_fp_fmul_by_indexed_elem_bfloat<string asm,
+                                              SDPatternOperator op> {
+  def NAME : sve_fp_fmul_by_indexed_elem<{0, ?}, 0b1, asm, ZPR16, ZPR3b16, VectorIndexH32b> {
+    bits<3> Zm;
+    bits<3> iop;
+    let Inst{22} = iop{2};
+    let Inst{20-19} = iop{1-0};
+    let Inst{18-16} = Zm;
+  }
+  def : Pat <(nxv8bf16 (op nxv8bf16:$Op1, nxv8bf16:$Op2, (i32 VectorIndexH32b_timm:$idx))),
+             (!cast<Instruction>(NAME) $Op1, $Op2, VectorIndexH32b_timm:$idx)>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -9073,6 +9069,13 @@ multiclass sve_fp_bin_pred_hfd<SDPatternOperator op> {
   def : SVE_3_Op_Pat<nxv2f64, op, nxv2i1, nxv2f64, nxv2f64, !cast<Pseudo>(NAME # _D_UNDEF)>;
 }
 
+// Predicated pseudo floating point (BFloat) two operand instructions.
+multiclass sve_fp_bin_pred_bfloat<SDPatternOperator op> {
+  def _UNDEF : PredTwoOpPseudo<NAME, ZPR16, FalseLanesUndef>;
+
+  def : SVE_3_Op_Pat<nxv8bf16, op, nxv8i1,  nxv8bf16, nxv8bf16, !cast<Pseudo>(NAME # _UNDEF)>;
+}
+
 // Predicated pseudo floating point three operand instructions.
 multiclass sve_fp_3op_pred_hfd<SDPatternOperator op> {
   def _H_UNDEF : PredThreeOpPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
@@ -9087,7 +9090,8 @@ multiclass sve_fp_3op_pred_hfd<SDPatternOperator op> {
   def : SVE_4_Op_Pat<nxv2f64, op, nxv2i1, nxv2f64, nxv2f64, nxv2f64, !cast<Instruction>(NAME # _D_UNDEF)>;
 }
 
-multiclass sve_fp_3op_pred_bf<SDPatternOperator op> {
+// Predicated pseudo floating point (BFloat) three operand instructions.
+multiclass sve_fp_3op_pred_bfloat<SDPatternOperator op> {
   def _UNDEF : PredThreeOpPseudo<NAME, ZPR16, FalseLanesUndef>;
 
   def : SVE_4_Op_Pat<nxv8bf16, op, nxv8i1, nxv8bf16, nxv8bf16, nxv8bf16, !cast<Instruction>(NAME # _UNDEF)>;
@@ -9147,7 +9151,7 @@ multiclass sve_int_bin_pred_all_active_bhsd<SDPatternOperator op> {
 // SME2 or SVE2.1 Instructions
 //===----------------------------------------------------------------------===//
 
-class sve2p1_fclamp<string asm, bits<2> sz, ZPRRegOp zpr_ty>
+class sve_fp_clamp<string asm, bits<2> sz, ZPRRegOp zpr_ty>
     : I<(outs zpr_ty:$Zd), (ins zpr_ty:$_Zd, zpr_ty:$Zn, zpr_ty:$Zm),
         asm, "\t$Zd, $Zn, $Zm", "", []>,
       Sched<[]> {
@@ -9168,18 +9172,19 @@ class sve2p1_fclamp<string asm, bits<2> sz, ZPRRegOp zpr_ty>
   let hasSideEffects = 0;
 }
 
-multiclass sve2p1_fclamp<string asm, SDPatternOperator op> {
-  def _H : sve2p1_fclamp<asm, 0b01, ZPR16>;
-  def _S : sve2p1_fclamp<asm, 0b10, ZPR32>;
-  def _D : sve2p1_fclamp<asm, 0b11, ZPR64>;
+multiclass sve_fp_clamp<string asm, SDPatternOperator op> {
+  def _H : sve_fp_clamp<asm, 0b01, ZPR16>;
+  def _S : sve_fp_clamp<asm, 0b10, ZPR32>;
+  def _D : sve_fp_clamp<asm, 0b11, ZPR64>;
 
   def : SVE_3_Op_Pat<nxv8f16, op, nxv8f16, nxv8f16, nxv8f16, !cast<Instruction>(NAME # _H)>;
   def : SVE_3_Op_Pat<nxv4f32, op, nxv4f32, nxv4f32, nxv4f32, !cast<Instruction>(NAME # _S)>;
   def : SVE_3_Op_Pat<nxv2f64, op, nxv2f64, nxv2f64, nxv2f64, !cast<Instruction>(NAME # _D)>;
 }
 
-multiclass sve2p1_bfclamp<string asm, SDPatternOperator op> {
-  def NAME : sve2p1_fclamp<asm, 0b00, ZPR16>;
+multiclass sve_fp_clamp_bfloat<string asm, SDPatternOperator op> {
+  def NAME : sve_fp_clamp<asm, 0b00, ZPR16>;
+
   def : SVE_3_Op_Pat<nxv8bf16, op, nxv8bf16, nxv8bf16, nxv8bf16, !cast<Instruction>(NAME)>;
 }
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfadd.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfadd.s
@@ -27,7 +27,7 @@ bfadd   z23.h, p3/m, z23.h, z13.h  // 01100101-00000000-10001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfadd   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65008db7 <unknown>
 
 movprfx z23, z31
@@ -35,53 +35,53 @@ bfadd   z23.h, p3/m, z23.h, z13.h  // 01100101-00000000-10001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfadd   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65008db7 <unknown>
 
 bfadd   z0.h, p0/m, z0.h, z0.h  // 01100101-00000000-10000000-00000000
 // CHECK-INST: bfadd   z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x80,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65008000 <unknown>
 
 bfadd   z21.h, p5/m, z21.h, z10.h  // 01100101-00000000-10010101-01010101
 // CHECK-INST: bfadd   z21.h, p5/m, z21.h, z10.h
 // CHECK-ENCODING: [0x55,0x95,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65009555 <unknown>
 
 bfadd   z23.h, p3/m, z23.h, z13.h  // 01100101-00000000-10001101-10110111
 // CHECK-INST: bfadd   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65008db7 <unknown>
 
 bfadd   z31.h, p7/m, z31.h, z31.h  // 01100101-00000000-10011111-11111111
 // CHECK-INST: bfadd   z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x9f,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65009fff <unknown>
 
 bfadd   z0.h, z0.h, z0.h  // 01100101-00000000-00000000-00000000
 // CHECK-INST: bfadd   z0.h, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x00,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65000000 <unknown>
 
 bfadd   z21.h, z10.h, z21.h  // 01100101-00010101-00000001-01010101
 // CHECK-INST: bfadd   z21.h, z10.h, z21.h
 // CHECK-ENCODING: [0x55,0x01,0x15,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65150155 <unknown>
 
 bfadd   z23.h, z13.h, z8.h  // 01100101-00001000-00000001-10110111
 // CHECK-INST: bfadd   z23.h, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x01,0x08,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 650801b7 <unknown>
 
 bfadd   z31.h, z31.h, z31.h  // 01100101-00011111-00000011-11111111
 // CHECK-INST: bfadd   z31.h, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x03,0x1f,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 651f03ff <unknown>

--- a/llvm/test/MC/AArch64/SVE2p1/bfclamp.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfclamp.s
@@ -27,30 +27,30 @@ bfclamp z23.h, z13.h, z8.h  // 01100100-00101000-00100101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfclamp z23.h, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x25,0x28,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 642825b7 <unknown>
 
 bfclamp z0.h, z0.h, z0.h  // 01100100-00100000-00100100-00000000
 // CHECK-INST: bfclamp z0.h, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x24,0x20,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64202400 <unknown>
 
 bfclamp z21.h, z10.h, z21.h  // 01100100-00110101-00100101-01010101
 // CHECK-INST: bfclamp z21.h, z10.h, z21.h
 // CHECK-ENCODING: [0x55,0x25,0x35,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64352555 <unknown>
 
 bfclamp z23.h, z13.h, z8.h  // 01100100-00101000-00100101-10110111
 // CHECK-INST: bfclamp z23.h, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x25,0x28,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 642825b7 <unknown>
 
 bfclamp z31.h, z31.h, z31.h  // 01100100-00111111-00100111-11111111
 // CHECK-INST: bfclamp z31.h, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x27,0x3f,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 643f27ff <unknown>
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfmax.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfmax.s
@@ -27,7 +27,7 @@ bfmax   z23.h, p3/m, z23.h, z13.h  // 01100101-00000110-10001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfmax   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x06,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65068db7 <unknown>
 
 movprfx z23, z31
@@ -35,29 +35,29 @@ bfmax   z23.h, p3/m, z23.h, z13.h  // 01100101-00000110-10001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmax   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x06,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65068db7 <unknown>
 
 bfmax   z0.h, p0/m, z0.h, z0.h  // 01100101-00000110-10000000-00000000
 // CHECK-INST: bfmax   z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x80,0x06,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65068000 <unknown>
 
 bfmax   z21.h, p5/m, z21.h, z10.h  // 01100101-00000110-10010101-01010101
 // CHECK-INST: bfmax   z21.h, p5/m, z21.h, z10.h
 // CHECK-ENCODING: [0x55,0x95,0x06,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65069555 <unknown>
 
 bfmax   z23.h, p3/m, z23.h, z13.h  // 01100101-00000110-10001101-10110111
 // CHECK-INST: bfmax   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x06,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65068db7 <unknown>
 
 bfmax   z31.h, p7/m, z31.h, z31.h  // 01100101-00000110-10011111-11111111
 // CHECK-INST: bfmax   z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x9f,0x06,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65069fff <unknown>

--- a/llvm/test/MC/AArch64/SVE2p1/bfmaxnm.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfmaxnm.s
@@ -27,7 +27,7 @@ bfmaxnm z23.h, p3/m, z23.h, z13.h  // 01100101-00000100-10001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfmaxnm z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x04,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65048db7 <unknown>
 
 movprfx z23, z31
@@ -35,30 +35,30 @@ bfmaxnm z23.h, p3/m, z23.h, z13.h  // 01100101-00000100-10001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmaxnm z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x04,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65048db7 <unknown>
 
 bfmaxnm z0.h, p0/m, z0.h, z0.h  // 01100101-00000100-10000000-00000000
 // CHECK-INST: bfmaxnm z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x80,0x04,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65048000 <unknown>
 
 bfmaxnm z21.h, p5/m, z21.h, z10.h  // 01100101-00000100-10010101-01010101
 // CHECK-INST: bfmaxnm z21.h, p5/m, z21.h, z10.h
 // CHECK-ENCODING: [0x55,0x95,0x04,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65049555 <unknown>
 
 bfmaxnm z23.h, p3/m, z23.h, z13.h  // 01100101-00000100-10001101-10110111
 // CHECK-INST: bfmaxnm z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x04,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65048db7 <unknown>
 
 bfmaxnm z31.h, p7/m, z31.h, z31.h  // 01100101-00000100-10011111-11111111
 // CHECK-INST: bfmaxnm z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x9f,0x04,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65049fff <unknown>
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfmin.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfmin.s
@@ -27,7 +27,7 @@ bfmin   z23.h, p3/m, z23.h, z13.h  // 01100101-00000111-10001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfmin   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x07,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65078db7 <unknown>
 
 movprfx z23, z31
@@ -35,30 +35,30 @@ bfmin   z23.h, p3/m, z23.h, z13.h  // 01100101-00000111-10001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmin   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x07,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65078db7 <unknown>
 
 bfmin   z0.h, p0/m, z0.h, z0.h  // 01100101-00000111-10000000-00000000
 // CHECK-INST: bfmin   z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x80,0x07,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65078000 <unknown>
 
 bfmin   z21.h, p5/m, z21.h, z10.h  // 01100101-00000111-10010101-01010101
 // CHECK-INST: bfmin   z21.h, p5/m, z21.h, z10.h
 // CHECK-ENCODING: [0x55,0x95,0x07,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65079555 <unknown>
 
 bfmin   z23.h, p3/m, z23.h, z13.h  // 01100101-00000111-10001101-10110111
 // CHECK-INST: bfmin   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x07,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65078db7 <unknown>
 
 bfmin   z31.h, p7/m, z31.h, z31.h  // 01100101-00000111-10011111-11111111
 // CHECK-INST: bfmin   z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x9f,0x07,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65079fff <unknown>
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfminnm.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfminnm.s
@@ -27,7 +27,7 @@ bfminnm z23.h, p3/m, z23.h, z13.h  // 01100101-00000101-10001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfminnm z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x05,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65058db7 <unknown>
 
 movprfx z23, z31
@@ -35,30 +35,30 @@ bfminnm z23.h, p3/m, z23.h, z13.h  // 01100101-00000101-10001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfminnm z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x05,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65058db7 <unknown>
 
 bfminnm z0.h, p0/m, z0.h, z0.h  // 01100101-00000101-10000000-00000000
 // CHECK-INST: bfminnm z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x80,0x05,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65058000 <unknown>
 
 bfminnm z21.h, p5/m, z21.h, z10.h  // 01100101-00000101-10010101-01010101
 // CHECK-INST: bfminnm z21.h, p5/m, z21.h, z10.h
 // CHECK-ENCODING: [0x55,0x95,0x05,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65059555 <unknown>
 
 bfminnm z23.h, p3/m, z23.h, z13.h  // 01100101-00000101-10001101-10110111
 // CHECK-INST: bfminnm z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x05,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65058db7 <unknown>
 
 bfminnm z31.h, p7/m, z31.h, z31.h  // 01100101-00000101-10011111-11111111
 // CHECK-INST: bfminnm z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x9f,0x05,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65059fff <unknown>
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfmla.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfmla.s
@@ -27,31 +27,31 @@ bfmla   z23.h, z13.h, z0.h[5]  // 01100100-01101000-00001001-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmla   z23.h, z13.h, z0.h[5]
 // CHECK-ENCODING: [0xb7,0x09,0x68,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 646809b7 <unknown>
 
 bfmla   z0.h, z0.h, z0.h[0]  // 01100100-00100000-00001000-00000000
 // CHECK-INST: bfmla   z0.h, z0.h, z0.h[0]
 // CHECK-ENCODING: [0x00,0x08,0x20,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64200800 <unknown>
 
 bfmla   z21.h, z10.h, z5.h[6]  // 01100100-01110101-00001001-01010101
 // CHECK-INST: bfmla   z21.h, z10.h, z5.h[6]
 // CHECK-ENCODING: [0x55,0x09,0x75,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64750955 <unknown>
 
 bfmla   z23.h, z13.h, z0.h[5]  // 01100100-01101000-00001001-10110111
 // CHECK-INST: bfmla   z23.h, z13.h, z0.h[5]
 // CHECK-ENCODING: [0xb7,0x09,0x68,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 646809b7 <unknown>
 
 bfmla   z31.h, z31.h, z7.h[7]  // 01100100-01111111-00001011-11111111
 // CHECK-INST: bfmla   z31.h, z31.h, z7.h[7]
 // CHECK-ENCODING: [0xff,0x0b,0x7f,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 647f0bff <unknown>
 
 
@@ -60,7 +60,7 @@ bfmla   z23.h, p3/m, z13.h, z8.h  // 01100101-00101000-00001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfmla   z23.h, p3/m, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x0d,0x28,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65280db7 <unknown>
 
 movprfx z23, z31
@@ -68,30 +68,30 @@ bfmla   z23.h, p3/m, z13.h, z8.h  // 01100101-00101000-00001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmla   z23.h, p3/m, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x0d,0x28,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65280db7 <unknown>
 
 bfmla   z0.h, p0/m, z0.h, z0.h  // 01100101-00100000-00000000-00000000
 // CHECK-INST: bfmla   z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x00,0x20,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65200000 <unknown>
 
 bfmla   z21.h, p5/m, z10.h, z21.h  // 01100101-00110101-00010101-01010101
 // CHECK-INST: bfmla   z21.h, p5/m, z10.h, z21.h
 // CHECK-ENCODING: [0x55,0x15,0x35,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65351555 <unknown>
 
 bfmla   z23.h, p3/m, z13.h, z8.h  // 01100101-00101000-00001101-10110111
 // CHECK-INST: bfmla   z23.h, p3/m, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x0d,0x28,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65280db7 <unknown>
 
 bfmla   z31.h, p7/m, z31.h, z31.h  // 01100101-00111111-00011111-11111111
 // CHECK-INST: bfmla   z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x1f,0x3f,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 653f1fff <unknown>
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfmls.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfmls.s
@@ -28,31 +28,31 @@ bfmls   z23.h, z13.h, z0.h[5]  // 01100100-01101000-00001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmls   z23.h, z13.h, z0.h[5]
 // CHECK-ENCODING: [0xb7,0x0d,0x68,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64680db7 <unknown>
 
 bfmls   z0.h, z0.h, z0.h[0]  // 01100100-00100000-00001100-00000000
 // CHECK-INST: bfmls   z0.h, z0.h, z0.h[0]
 // CHECK-ENCODING: [0x00,0x0c,0x20,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64200c00 <unknown>
 
 bfmls   z21.h, z10.h, z5.h[6]  // 01100100-01110101-00001101-01010101
 // CHECK-INST: bfmls   z21.h, z10.h, z5.h[6]
 // CHECK-ENCODING: [0x55,0x0d,0x75,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64750d55 <unknown>
 
 bfmls   z23.h, z13.h, z0.h[5]  // 01100100-01101000-00001101-10110111
 // CHECK-INST: bfmls   z23.h, z13.h, z0.h[5]
 // CHECK-ENCODING: [0xb7,0x0d,0x68,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64680db7 <unknown>
 
 bfmls   z31.h, z31.h, z7.h[7]  // 01100100-01111111-00001111-11111111
 // CHECK-INST: bfmls   z31.h, z31.h, z7.h[7]
 // CHECK-ENCODING: [0xff,0x0f,0x7f,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 647f0fff <unknown>
 
 
@@ -61,7 +61,7 @@ bfmls   z23.h, p3/m, z13.h, z8.h  // 01100101-00101000-00101101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfmls   z23.h, p3/m, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x2d,0x28,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65282db7 <unknown>
 
 movprfx z23, z31
@@ -69,30 +69,30 @@ bfmls   z23.h, p3/m, z13.h, z8.h  // 01100101-00101000-00101101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmls   z23.h, p3/m, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x2d,0x28,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65282db7 <unknown>
 
 bfmls   z0.h, p0/m, z0.h, z0.h  // 01100101-00100000-00100000-00000000
 // CHECK-INST: bfmls   z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x20,0x20,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65202000 <unknown>
 
 bfmls   z21.h, p5/m, z10.h, z21.h  // 01100101-00110101-00110101-01010101
 // CHECK-INST: bfmls   z21.h, p5/m, z10.h, z21.h
 // CHECK-ENCODING: [0x55,0x35,0x35,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65353555 <unknown>
 
 bfmls   z23.h, p3/m, z13.h, z8.h  // 01100101-00101000-00101101-10110111
 // CHECK-INST: bfmls   z23.h, p3/m, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x2d,0x28,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65282db7 <unknown>
 
 bfmls   z31.h, p7/m, z31.h, z31.h  // 01100101-00111111-00111111-11111111
 // CHECK-INST: bfmls   z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x3f,0x3f,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16 
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 653f3fff <unknown>
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfmul.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfmul.s
@@ -25,25 +25,25 @@
 bfmul   z0.h, z0.h, z0.h[0]  // 01100100-00100000-00101000-00000000
 // CHECK-INST: bfmul   z0.h, z0.h, z0.h[0]
 // CHECK-ENCODING: [0x00,0x28,0x20,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64202800 <unknown>
 
 bfmul   z21.h, z10.h, z5.h[6]  // 01100100-01110101-00101001-01010101
 // CHECK-INST: bfmul   z21.h, z10.h, z5.h[6]
 // CHECK-ENCODING: [0x55,0x29,0x75,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 64752955 <unknown>
 
 bfmul   z23.h, z13.h, z0.h[5]  // 01100100-01101000-00101001-10110111
 // CHECK-INST: bfmul   z23.h, z13.h, z0.h[5]
 // CHECK-ENCODING: [0xb7,0x29,0x68,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 646829b7 <unknown>
 
 bfmul   z31.h, z31.h, z7.h[7]  // 01100100-01111111-00101011-11111111
 // CHECK-INST: bfmul   z31.h, z31.h, z7.h[7]
 // CHECK-ENCODING: [0xff,0x2b,0x7f,0x64]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 647f2bff <unknown>
 
 movprfx  z23.h, p3/m, z31.h
@@ -51,7 +51,7 @@ bfmul   z23.h, p3/m, z23.h, z13.h  // 01100101-00000010-10001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfmul   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x02,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65028db7 <unknown>
 
 movprfx z23, z31
@@ -59,54 +59,54 @@ bfmul   z23.h, p3/m, z23.h, z13.h  // 01100101-00000010-10001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfmul   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x02,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65028db7 <unknown>
 
 bfmul   z0.h, p0/m, z0.h, z0.h  // 01100101-00000010-10000000-00000000
 // CHECK-INST: bfmul   z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x80,0x02,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65028000 <unknown>
 
 bfmul   z21.h, p5/m, z21.h, z10.h  // 01100101-00000010-10010101-01010101
 // CHECK-INST: bfmul   z21.h, p5/m, z21.h, z10.h
 // CHECK-ENCODING: [0x55,0x95,0x02,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65029555 <unknown>
 
 bfmul   z23.h, p3/m, z23.h, z13.h  // 01100101-00000010-10001101-10110111
 // CHECK-INST: bfmul   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x02,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65028db7 <unknown>
 
 bfmul   z31.h, p7/m, z31.h, z31.h  // 01100101-00000010-10011111-11111111
 // CHECK-INST: bfmul   z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x9f,0x02,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65029fff <unknown>
 
 bfmul   z0.h, z0.h, z0.h  // 01100101-00000000-00001000-00000000
 // CHECK-INST: bfmul   z0.h, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x08,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65000800 <unknown>
 
 bfmul   z21.h, z10.h, z21.h  // 01100101-00010101-00001001-01010101
 // CHECK-INST: bfmul   z21.h, z10.h, z21.h
 // CHECK-ENCODING: [0x55,0x09,0x15,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65150955 <unknown>
 
 bfmul   z23.h, z13.h, z8.h  // 01100101-00001000-00001001-10110111
 // CHECK-INST: bfmul   z23.h, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x09,0x08,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 650809b7 <unknown>
 
 bfmul   z31.h, z31.h, z31.h  // 01100101-00011111-00001011-11111111
 // CHECK-INST: bfmul   z31.h, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x0b,0x1f,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 651f0bff <unknown>
 

--- a/llvm/test/MC/AArch64/SVE2p1/bfsub.s
+++ b/llvm/test/MC/AArch64/SVE2p1/bfsub.s
@@ -27,7 +27,7 @@ bfsub   z23.h, p3/m, z23.h, z13.h  // 01100101-00000001-10001101-10110111
 // CHECK-INST:  movprfx  z23.h, p3/m, z31.h
 // CHECK-INST: bfsub   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x01,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65018db7 <unknown>
 
 movprfx z23, z31
@@ -35,53 +35,53 @@ bfsub   z23.h, p3/m, z23.h, z13.h  // 01100101-00000001-10001101-10110111
 // CHECK-INST:  movprfx z23, z31
 // CHECK-INST: bfsub   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x01,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65018db7 <unknown>
 
 bfsub   z0.h, p0/m, z0.h, z0.h  // 01100101-00000001-10000000-00000000
 // CHECK-INST: bfsub   z0.h, p0/m, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x80,0x01,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65018000 <unknown>
 
 bfsub   z21.h, p5/m, z21.h, z10.h  // 01100101-00000001-10010101-01010101
 // CHECK-INST: bfsub   z21.h, p5/m, z21.h, z10.h
 // CHECK-ENCODING: [0x55,0x95,0x01,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65019555 <unknown>
 
 bfsub   z23.h, p3/m, z23.h, z13.h  // 01100101-00000001-10001101-10110111
 // CHECK-INST: bfsub   z23.h, p3/m, z23.h, z13.h
 // CHECK-ENCODING: [0xb7,0x8d,0x01,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65018db7 <unknown>
 
 bfsub   z31.h, p7/m, z31.h, z31.h  // 01100101-00000001-10011111-11111111
 // CHECK-INST: bfsub   z31.h, p7/m, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x9f,0x01,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65019fff <unknown>
 
 bfsub   z0.h, z0.h, z0.h  // 01100101-00000000-00000100-00000000
 // CHECK-INST: bfsub   z0.h, z0.h, z0.h
 // CHECK-ENCODING: [0x00,0x04,0x00,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65000400 <unknown>
 
 bfsub   z21.h, z10.h, z21.h  // 01100101-00010101-00000101-01010101
 // CHECK-INST: bfsub   z21.h, z10.h, z21.h
 // CHECK-ENCODING: [0x55,0x05,0x15,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 65150555 <unknown>
 
 bfsub   z23.h, z13.h, z8.h  // 01100101-00001000-00000101-10110111
 // CHECK-INST: bfsub   z23.h, z13.h, z8.h
 // CHECK-ENCODING: [0xb7,0x05,0x08,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 650805b7 <unknown>
 
 bfsub   z31.h, z31.h, z31.h  // 01100101-00011111-00000111-11111111
 // CHECK-INST: bfsub   z31.h, z31.h, z31.h
 // CHECK-ENCODING: [0xff,0x07,0x1f,0x65]
-// CHECK-ERROR: instruction requires: sve2 or sme2 sve-b16b16
+// CHECK-ERROR: instruction requires: sve-b16b16
 // CHECK-UNKNOWN: 651f07ff <unknown>


### PR DESCRIPTION
Update the predicate protecting bfloat instructions to only reference FEAT_SVE_B16B16, which matches the specification.

Rename and move instruction classes to match the names of the encoding groups the bfloat arithmetic instructions belong.