### PR TITLE
[libc++] Split the module_std and module_std_compat tests

### DIFF
--- a/libcxx/test/libcxx/module_std.gen.py
+++ b/libcxx/test/libcxx/module_std.gen.py
@@ -33,6 +33,4 @@ generator = module_test_generator(
     "std",
 )
 
-
-print("//--- module_std.sh.cpp")
 generator.write_test("std")

--- a/libcxx/test/libcxx/module_std_compat.gen.py
+++ b/libcxx/test/libcxx/module_std_compat.gen.py
@@ -34,8 +34,6 @@ generator = module_test_generator(
     "std.compat",
 )
 
-
-print("//--- module_std_compat.sh.cpp")
 generator.write_test(
     "std.compat",
     module_c_headers,

--- a/libcxx/utils/libcxx/test/modules.py
+++ b/libcxx/utils/libcxx/test/modules.py
@@ -283,13 +283,13 @@ class module_test_generator:
         )
 
     def write_test(self, module, c_headers=[]):
-        self.write_lit_configuration()
-
-        # Validate all module parts.
         for header in module_headers:
+            print(f"//--- {header}.sh.cpp")
+            self.write_lit_configuration()
+
             is_c_header = header in c_headers
             include = self.process_module_partition(header, is_c_header)
             self.process_header(header, include, is_c_header)
 
-        self.process_module(module)
-        self.test_module(module)
+            self.process_module(module)
+            self.test_module(module)


### PR DESCRIPTION
The C++20 modules tests were set up such that the top-level gen-py test would generate a single ShTest which would then run tests for all the module parts.

However, gen-py tests were originally intended to generate multiple smaller independent Lit tests that would be executed by Lit directly. Doing so increases test suite parallelism, makes error messages easier to understand and avoids nesting multiple layers of test generation, which is confusing.

This patch modifies the C++20 modules test to generate individual Lit tests instead.