### PR TITLE
[DLCov 2/5] Implement DebugLoc coverage tracking

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -961,6 +961,22 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       Debugify.setOrigDIVerifyBugsReportFilePath(
           CodeGenOpts.DIBugsReportFilePath);
     Debugify.registerCallbacks(PIC, MAM);
+
+#if ENABLE_DEBUGLOC_COVERAGE_TRACKING
+    // If we're using debug location coverage tracking, mark all the
+    // instructions coming out of the frontend without a DebugLoc as being
+    // compiler-generated, to prevent both those instructions and new
+    // instructions that inherit their location from being treated as
+    // incorrectly empty locations.
+    for (Function &F : *TheModule) {
+      if (!F.getSubprogram())
+        continue;
+      for (BasicBlock &BB : F)
+        for (Instruction &I : BB)
+          if (!I.getDebugLoc())
+            I.setDebugLoc(DebugLoc::getCompilerGenerated());
+    }
+#endif
   }
   // Attempt to load pass plugins and register their callbacks with PB.
   for (auto &PluginFN : CodeGenOpts.PassPlugins) {

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -175,9 +175,9 @@ Setting locations for new instructions
 --------------------------------------
 
 Whenever a new instruction is created and there is no suitable location for that
-instruction, that location should be annotated accordingly. There are a set of
-special ``DebugLoc`` values that can be used to indicate the reason that a new
-instruction does not have a valid location. These are as follows:
+instruction, that instruction should be annotated accordingly. There are a set
+of special ``DebugLoc`` values that can be set on an instruction to annotate the
+reason that it does not have a valid location. These are as follows:
 
 * ``DebugLoc::getCompilerGenerated()``: This indicates that the instruction is a
   compiler-generated instruction, i.e. it is not associated with any user source
@@ -185,28 +185,30 @@ instruction does not have a valid location. These are as follows:
 
 * ``DebugLoc::getDropped()``: This indicates that the instruction has
   intentionally had its source location removed, according to the rules for
-  dropping locations; this is set automatically by
+  :ref:`dropping locations<WhenToDropLocation>`; this is set automatically by
   ``Instruction::dropLocation()``.
 
 * ``DebugLoc::getUnknown()``: This indicates that the instruction does not have
-  a known or currently knowable source location, e.g. the attribution is ambiguous
-  in a way that can't currently be represented in LLVM, or that it is otherwise
-  infeasible to determine or track the correct source location.
+  a known or currently knowable source location, e.g. that it is infeasible to
+  determine the correct source location, or that the source location is
+  ambiguous in a way that LLVM cannot currently represent.
 
 * ``DebugLoc::getTemporary()``: This is used for instructions that we don't
-  expect to be emitted (e.g. ``UnreachableInst``), and so should not need a valid
-  location; if we ever try to emit a temporary location into an object file, this
-  indicates that something has gone wrong.
+  expect to be emitted (e.g. ``UnreachableInst``), and so should not need a
+  valid location; if we ever try to emit a temporary location into an object/asm
+  file, this indicates that something has gone wrong.
 
 Where applicable, these should be used instead of leaving an instruction without
 an assigned location or explicitly setting the location as ``DebugLoc()``.
-Ordinarily these special locations are ignored by the compiler, but some testing
-builds will track their use in order to detect missing locations; for this
-reason, the most important rule is to *not* apply any of these if it isn't clear
-which, if any, is appropriate - an absent location can be detected and fixed,
-while an incorrectly annotated instruction is much harder to detect. On the
-other hand, if any of these clearly apply, then they should be used to prevent
-false positives from being flagged up.
+Ordinarily these special locations are identical to an absent location, but LLVM
+built with coverage-tracking
+(``-DLLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING="COVERAGE"``) will keep track of
+these special locations in order to detect unintentionally-missing locations;
+for this reason, the most important rule is to *not* apply any of these if it
+isn't clear which, if any, is appropriate - an absent location can be detected
+and fixed, while an incorrectly annotated instruction is much harder to detect.
+On the other hand, if any of these clearly apply, then they should be used to
+prevent false positives from being flagged up.
 
 Rules for updating debug values
 ===============================

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -172,7 +172,7 @@ dropping locations applies.
 .. _NewInstLocations:
 
 Setting locations for new instructions
-------------------------------------
+--------------------------------------
 
 Whenever a new instruction is created and there is no suitable location for that
 instruction, that location should be annotated accordingly. There are a set of

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -179,21 +179,24 @@ instruction, that location should be annotated accordingly. There are a set of
 special ``DebugLoc`` values that can be used to indicate the reason that a new
 instruction does not have a valid location. These are as follows:
 
-- ``DebugLoc::getCompilerGenerated()``: This indicates that the instruction is a
-compiler-generated instruction, i.e. it is not associated with any user source
-code.
-- ``DebugLoc::getDropped()``: This indicates that the instruction has
-intentionally had its source location removed, according to the rules for
-dropping locations; this is set automatically by
-``Instruction::dropLocation()``.
-- ``DebugLoc::getUnknown()``: This indicates that the instruction does not have
-a known or currently knowable source location, e.g. the attribution is ambiguous
-in a way that can't currently be represented in LLVM, or that it is otherwise
-infeasible to determine or track the correct source location.
-- ``DebugLoc::getTemporary()``: This is used for instructions that we don't
-expect to be emitted (e.g. ``UnreachableInst``), and so should not need a valid
-location; if we ever try to emit a temporary location into an object file, this
-indicates that something has gone wrong.
+* ``DebugLoc::getCompilerGenerated()``: This indicates that the instruction is a
+  compiler-generated instruction, i.e. it is not associated with any user source
+  code.
+
+* ``DebugLoc::getDropped()``: This indicates that the instruction has
+  intentionally had its source location removed, according to the rules for
+  dropping locations; this is set automatically by
+  ``Instruction::dropLocation()``.
+
+* ``DebugLoc::getUnknown()``: This indicates that the instruction does not have
+  a known or currently knowable source location, e.g. the attribution is ambiguous
+  in a way that can't currently be represented in LLVM, or that it is otherwise
+  infeasible to determine or track the correct source location.
+
+* ``DebugLoc::getTemporary()``: This is used for instructions that we don't
+  expect to be emitted (e.g. ``UnreachableInst``), and so should not need a valid
+  location; if we ever try to emit a temporary location into an object file, this
+  indicates that something has gone wrong.
 
 Where applicable, these should be used instead of leaving an instruction without
 an assigned location or explicitly setting the location as ``DebugLoc()``.

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -169,6 +169,42 @@ See the discussion in the section about
 :ref:`merging locations<WhenToMergeLocation>` for examples of when the rule for
 dropping locations applies.
 
+.. _NewInstLocations:
+
+Setting locations for new instructions
+------------------------------------
+
+Whenever a new instruction is created and there is no suitable location for that
+instruction, that location should be annotated accordingly. There are a set of
+special ``DebugLoc`` values that can be used to indicate the reason that a new
+instruction does not have a valid location. These are as follows:
+
+- ``DebugLoc::getCompilerGenerated()``: This indicates that the instruction is a
+compiler-generated instruction, i.e. it is not associated with any user source
+code.
+- ``DebugLoc::getDropped()``: This indicates that the instruction has
+intentionally had its source location removed, according to the rules for
+dropping locations; this is set automatically by
+``Instruction::dropLocation()``.
+- ``DebugLoc::getUnknown()``: This indicates that the instruction does not have
+a known or currently knowable source location, e.g. the attribution is ambiguous
+in a way that can't currently be represented in LLVM, or that it is otherwise
+infeasible to determine or track the correct source location.
+- ``DebugLoc::getTemporary()``: This is used for instructions that we don't
+expect to be emitted (e.g. ``UnreachableInst``), and so should not need a valid
+location; if we ever try to emit a temporary location into an object file, this
+indicates that something has gone wrong.
+
+Where applicable, these should be used instead of leaving an instruction without
+an assigned location or explicitly setting the location as ``DebugLoc()``.
+Ordinarily these special locations are ignored by the compiler, but some testing
+builds will track their use in order to detect missing locations; for this
+reason, the most important rule is to *not* apply any of these if it isn't clear
+which, if any, is appropriate - an absent location can be detected and fixed,
+while an incorrectly annotated instruction is much harder to detect. On the
+other hand, if any of these clearly apply, then they should be used to prevent
+false positives from being flagged up.
+
 Rules for updating debug values
 ===============================
 

--- a/llvm/include/llvm/IR/DebugLoc.h
+++ b/llvm/include/llvm/IR/DebugLoc.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_IR_DEBUGLOC_H
 #define LLVM_IR_DEBUGLOC_H
 
+#include "llvm/Config/config.h"
 #include "llvm/IR/TrackingMDRef.h"
 #include "llvm/Support/DataTypes.h"
 
@@ -22,6 +23,73 @@ namespace llvm {
   class LLVMContext;
   class raw_ostream;
   class DILocation;
+  class Function;
+
+#if ENABLE_DEBUGLOC_COVERAGE_TRACKING
+  // Used to represent different "kinds" of DebugLoc, expressing that the
+  // instruction it is part of is either normal and should contain a valid
+  // DILocation, or otherwise describing the reason why the instruction does
+  // not contain a valid DILocation.
+  enum class DebugLocKind : uint8_t {
+    // The instruction is expected to contain a valid DILocation.
+    Normal,
+    // The instruction is compiler-generated, i.e. it is not associated with any
+    // line in the original source.
+    CompilerGenerated,
+    // The instruction has intentionally had its source location removed,
+    // typically because it was moved outside of its original control-flow and
+    // presenting the prior source location would be misleading for debuggers
+    // or profilers.
+    Dropped,
+    // The instruction does not have a known or currently knowable source
+    // location, e.g. the attribution is ambiguous in a way that can't be
+    // represented, or determining the correct location is complicated and
+    // requires future developer effort.
+    Unknown,
+    // DebugLoc is attached to an instruction that we don't expect to be
+    // emitted, and so can omit a valid DILocation; we don't expect to ever try
+    // and emit these into the line table, and trying to do so is a sign that
+    // something has gone wrong (most likely a DebugLoc leaking from a transient
+    // compiler-generated instruction).
+    Temporary
+  };
+
+  // Extends TrackingMDNodeRef to also store a DebugLocKind, allowing Debugify
+  // to ignore intentionally-empty DebugLocs.
+  class DILocAndCoverageTracking : public TrackingMDNodeRef {
+  public:
+    DebugLocKind Kind;
+    // Default constructor for empty DebugLocs.
+    DILocAndCoverageTracking()
+        : TrackingMDNodeRef(nullptr), Kind(DebugLocKind::Normal) {}
+    // Valid or nullptr MDNode*, normal DebugLocKind.
+    DILocAndCoverageTracking(const MDNode *Loc)
+        : TrackingMDNodeRef(const_cast<MDNode *>(Loc)),
+          Kind(DebugLocKind::Normal) {}
+    DILocAndCoverageTracking(const DILocation *Loc);
+    // Explicit DebugLocKind, which always means a nullptr MDNode*.
+    DILocAndCoverageTracking(DebugLocKind Kind)
+        : TrackingMDNodeRef(nullptr), Kind(Kind) {}
+  };
+  template <> struct simplify_type<DILocAndCoverageTracking> {
+    using SimpleType = MDNode *;
+
+    static MDNode *getSimplifiedValue(DILocAndCoverageTracking &MD) {
+      return MD.get();
+    }
+  };
+  template <> struct simplify_type<const DILocAndCoverageTracking> {
+    using SimpleType = MDNode *;
+
+    static MDNode *getSimplifiedValue(const DILocAndCoverageTracking &MD) {
+      return MD.get();
+    }
+  };
+
+  using DebugLocTrackingRef = DILocAndCoverageTracking;
+#else
+  using DebugLocTrackingRef = TrackingMDNodeRef;
+#endif // ENABLE_DEBUGLOC_COVERAGE_TRACKING
 
   /// A debug info location.
   ///
@@ -31,7 +99,8 @@ namespace llvm {
   /// To avoid extra includes, \a DebugLoc doubles the \a DILocation API with a
   /// one based on relatively opaque \a MDNode pointers.
   class DebugLoc {
-    TrackingMDNodeRef Loc;
+
+    DebugLocTrackingRef Loc;
 
   public:
     DebugLoc() = default;
@@ -46,6 +115,23 @@ namespace llvm {
     /// supported in order to handle forward references when reading textual
     /// IR.
     explicit DebugLoc(const MDNode *N);
+
+#if ENABLE_DEBUGLOC_COVERAGE_TRACKING
+    DebugLoc(DebugLocKind Kind) : Loc(Kind) {}
+    DebugLocKind getKind() const { return Loc.Kind; }
+#endif
+
+#if ENABLE_DEBUGLOC_COVERAGE_TRACKING
+    static inline DebugLoc getTemporary() { return DebugLoc(DebugLocKind::Temporary); }
+    static inline DebugLoc getUnknown() { return DebugLoc(DebugLocKind::Unknown); }
+    static inline DebugLoc getCompilerGenerated() { return DebugLoc(DebugLocKind::CompilerGenerated); }
+    static inline DebugLoc getDropped() { return DebugLoc(DebugLocKind::Dropped); }
+#else
+    static inline DebugLoc getTemporary() { return DebugLoc(); }
+    static inline DebugLoc getUnknown() { return DebugLoc(); }
+    static inline DebugLoc getCompilerGenerated() { return DebugLoc(); }
+    static inline DebugLoc getDropped() { return DebugLoc(); }
+#endif // ENABLE_DEBUGLOC_COVERAGE_TRACKING
 
     /// Get the underlying \a DILocation.
     ///

--- a/llvm/include/llvm/IR/DebugLoc.h
+++ b/llvm/include/llvm/IR/DebugLoc.h
@@ -122,10 +122,18 @@ namespace llvm {
 #endif
 
 #if ENABLE_DEBUGLOC_COVERAGE_TRACKING
-    static inline DebugLoc getTemporary() { return DebugLoc(DebugLocKind::Temporary); }
-    static inline DebugLoc getUnknown() { return DebugLoc(DebugLocKind::Unknown); }
-    static inline DebugLoc getCompilerGenerated() { return DebugLoc(DebugLocKind::CompilerGenerated); }
-    static inline DebugLoc getDropped() { return DebugLoc(DebugLocKind::Dropped); }
+    static inline DebugLoc getTemporary() {
+      return DebugLoc(DebugLocKind::Temporary);
+    }
+    static inline DebugLoc getUnknown() {
+      return DebugLoc(DebugLocKind::Unknown);
+    }
+    static inline DebugLoc getCompilerGenerated() {
+      return DebugLoc(DebugLocKind::CompilerGenerated);
+    }
+    static inline DebugLoc getDropped() {
+      return DebugLoc(DebugLocKind::Dropped);
+    }
 #else
     static inline DebugLoc getTemporary() { return DebugLoc(); }
     static inline DebugLoc getUnknown() { return DebugLoc(); }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -31,7 +31,6 @@
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
-#include "llvm/Config/config.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/DebugInfo/DWARF/DWARFExpression.h"
 #include "llvm/IR/Constants.h"

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -31,6 +31,7 @@
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/Config/config.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/DebugInfo/DWARF/DWARFExpression.h"
 #include "llvm/IR/Constants.h"
@@ -2097,6 +2098,10 @@ void DwarfDebug::beginInstruction(const MachineInstr *MI) {
   }
 
   if (!DL) {
+    // FIXME: We could assert that `DL.getKind() != DebugLocKind::Temporary`
+    // here, or otherwise record any temporary DebugLocs seen to ensure that
+    // transient compiler-generated instructions aren't leaking their DLs to
+    // other instructions.
     // We have an unspecified location, which might want to be line 0.
     // If we have already emitted a line-0 record, don't repeat it.
     if (LastAsmLine == 0)

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -987,8 +987,10 @@ void Instruction::updateLocationAfterHoist() { dropLocation(); }
 
 void Instruction::dropLocation() {
   const DebugLoc &DL = getDebugLoc();
-  if (!DL)
+  if (!DL) {
+    setDebugLoc(DebugLoc::getDropped());
     return;
+  }
 
   // If this isn't a call, drop the location to allow a location from a
   // preceding instruction to propagate.
@@ -1000,7 +1002,7 @@ void Instruction::dropLocation() {
   }
 
   if (!MayLowerToCall) {
-    setDebugLoc(DebugLoc());
+    setDebugLoc(DebugLoc::getDropped());
     return;
   }
 
@@ -1019,7 +1021,7 @@ void Instruction::dropLocation() {
     //
     // One alternative is to set a line 0 location with the existing scope and
     // inlinedAt info. The location might be sensitive to when inlining occurs.
-    setDebugLoc(DebugLoc());
+    setDebugLoc(DebugLoc::getDropped());
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -11,6 +11,12 @@
 #include "llvm/IR/DebugInfo.h"
 using namespace llvm;
 
+#if ENABLE_DEBUGLOC_COVERAGE_TRACKING
+DILocAndCoverageTracking::DILocAndCoverageTracking(const DILocation *L)
+    : TrackingMDNodeRef(const_cast<DILocation *>(L)),
+      Kind(DebugLocKind::Normal) {}
+#endif // ENABLE_DEBUGLOC_COVERAGE_TRACKING
+
 //===----------------------------------------------------------------------===//
 // DebugLoc Implementation
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Transforms/Utils/Debugify.cpp
+++ b/llvm/lib/Transforms/Utils/Debugify.cpp
@@ -290,6 +290,16 @@ bool llvm::stripDebugifyMetadata(Module &M) {
   return Changed;
 }
 
+bool hasLoc(const Instruction &I) {
+  const DILocation *Loc = I.getDebugLoc().get();
+#if ENABLE_DEBUGLOC_COVERAGE_TRACKING
+  DebugLocKind Kind = I.getDebugLoc().getKind();
+  return Loc || Kind != DebugLocKind::Normal;
+#else
+  return Loc;
+#endif
+}
+
 bool llvm::collectDebugInfoMetadata(Module &M,
                                     iterator_range<Module::iterator> Functions,
                                     DebugInfoPerPass &DebugInfoBeforePass,
@@ -362,9 +372,7 @@ bool llvm::collectDebugInfoMetadata(Module &M,
         LLVM_DEBUG(dbgs() << "  Collecting info for inst: " << I << '\n');
         DebugInfoBeforePass.InstToDelete.insert({&I, &I});
 
-        const DILocation *Loc = I.getDebugLoc().get();
-        bool HasLoc = Loc != nullptr;
-        DebugInfoBeforePass.DILocations.insert({&I, HasLoc});
+        DebugInfoBeforePass.DILocations.insert({&I, hasLoc(I)});
       }
     }
   }
@@ -607,10 +615,7 @@ bool llvm::checkDebugInfoMetadata(Module &M,
 
         LLVM_DEBUG(dbgs() << "  Collecting info for inst: " << I << '\n');
 
-        const DILocation *Loc = I.getDebugLoc().get();
-        bool HasLoc = Loc != nullptr;
-
-        DebugInfoAfterPass.DILocations.insert({&I, HasLoc});
+        DebugInfoAfterPass.DILocations.insert({&I, hasLoc(I)});
       }
     }
   }


### PR DESCRIPTION
This is part of a series of patches that tries to improve DILocation bug detection in Debugify; see below for more details. This is the patch that adds the main feature, adding a set of `DebugLoc::get<Kind>` functions that can be used for instructions with intentionally empty DebugLocs to prevent Debugify from treating them as bugs, removing the currently-pervasive false positives and allowing us to use Debugify (in its original DI preservation mode) to reliably detect existing bugs and regressions. This patch does not add uses of these functions, except for once in Clang before optimizations, and in `Instruction::dropLocation()`, since that is an obvious case that immediately removes a set of false positives.

--------------------

This series of patches adds a "DebugLoc coverage tracking" feature, that inserts conditionally-compiled tracking information into DebugLocs (and by extension, to Instructions), which is used by Debugify to provide more accurate and detailed coverage reports. When enabled, this features tracks whether and why we have intentionally dropped a DebugLoc, allowing Debugify to ignore false positives. An optional additional feature allows also storing a stack trace of the point where a DebugLoc was unintentionally dropped/not generated, which is used to make fixing detected errors significantly easier. The goal of these features is to provide useful tools for developers to fix existing DebugLoc errors and allow reliable detection of regressions by either manual inspection or an automated script. 

Previous: https://github.com/llvm/llvm-project/pull/107278
Next: https://github.com/llvm/llvm-project/pull/107369