### PR TITLE
[MLIR][Python] Fix detached operation coming from `IfOp` constructor

### DIFF
--- a/mlir/python/mlir/dialects/scf.py
+++ b/mlir/python/mlir/dialects/scf.py
@@ -87,7 +87,7 @@ class IfOp(IfOp):
         operands.append(cond)
         results = []
         results.extend(results_)
-        super().__init__(results, cond)
+        super().__init__(results, cond, loc=loc, ip=ip)
         self.regions[0].blocks.append(*[])
         if hasElse:
             self.regions[1].blocks.append(*[])

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -277,6 +277,7 @@ def testIfWithoutElse():
 # CHECK:   %[[ADD:.*]] = arith.addi %[[ONE]], %[[ONE]]
 # CHECK: return
 
+
 @constructAndPrintInModule
 def testNestedIf():
     bool = IntegerType.get_signless(1)

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -279,20 +279,20 @@ def testIfWithoutElse():
 
 @constructAndPrintInModule
 def testNestedIf():
-  bool = IntegerType.get_signless(1)
-  i32 = IntegerType.get_signless(32)
+    bool = IntegerType.get_signless(1)
+    i32 = IntegerType.get_signless(32)
 
-  @func.FuncOp.from_py_func(bool, bool)
-  def nested_if(b, c):
-    if_op = scf.IfOp(b)
-    with InsertionPoint(if_op.then_block) as ip:
-      if_op = scf.IfOp(c, ip=ip)
-      with InsertionPoint(if_op.then_block):
-        one = arith.ConstantOp(i32, 1)
-        add = arith.AddIOp(one, one)
-        scf.YieldOp([])
-      scf.YieldOp([])
-    return
+    @func.FuncOp.from_py_func(bool, bool)
+    def nested_if(b, c):
+        if_op = scf.IfOp(b)
+        with InsertionPoint(if_op.then_block) as ip:
+            if_op = scf.IfOp(c, ip=ip)
+            with InsertionPoint(if_op.then_block):
+                one = arith.ConstantOp(i32, 1)
+                add = arith.AddIOp(one, one)
+                scf.YieldOp([])
+            scf.YieldOp([])
+        return
 
 
 # CHECK: func @nested_if(%[[ARG0:.*]]: i1, %[[ARG1:.*]]: i1)

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -277,6 +277,30 @@ def testIfWithoutElse():
 # CHECK:   %[[ADD:.*]] = arith.addi %[[ONE]], %[[ONE]]
 # CHECK: return
 
+@constructAndPrintInModule
+def testNestedIf():
+  bool = IntegerType.get_signless(1)
+  i32 = IntegerType.get_signless(32)
+
+  @func.FuncOp.from_py_func(bool, bool)
+  def nested_if(b, c):
+    if_op = scf.IfOp(b)
+    with InsertionPoint(if_op.then_block) as ip:
+      if_op = scf.IfOp(c, ip=ip)
+      with InsertionPoint(if_op.then_block):
+        one = arith.ConstantOp(i32, 1)
+        add = arith.AddIOp(one, one)
+        scf.YieldOp([])
+      scf.YieldOp([])
+    return
+
+
+# CHECK: func @nested_if(%[[ARG0:.*]]: i1, %[[ARG1:.*]]: i1)
+# CHECK: scf.if %[[ARG0:.*]]
+# CHECK:   scf.if %[[ARG1:.*]]
+# CHECK:     %[[ONE:.*]] = arith.constant 1
+# CHECK:     %[[ADD:.*]] = arith.addi %[[ONE]], %[[ONE]]
+# CHECK: return
 
 @constructAndPrintInModule
 def testIfWithElse():

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -303,6 +303,7 @@ def testNestedIf():
 # CHECK:     %[[ADD:.*]] = arith.addi %[[ONE]], %[[ONE]]
 # CHECK: return
 
+
 @constructAndPrintInModule
 def testIfWithElse():
     bool = IntegerType.get_signless(1)


### PR DESCRIPTION
Without this fix, `scf.if` operations would be created without a parent. Since `scf.if` operations often have no results, this caused silent bugs where the generated code was straight-up missing the operation.