### PR TITLE
[BPF] Fix dst/val mismatch in class ATOMIC_NOFETCH

### DIFF
--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -790,7 +790,7 @@ let Predicates = [BPFNoALU32] in {
 class ATOMIC_NOFETCH<BPFWidthModifer SizeOp, string OpType, RegisterClass RegTp,
                      BPFArithOp Opc, string Opstr>
     : TYPE_LD_ST<BPF_ATOMIC.Value, SizeOp.Value,
-                 (outs GPR:$dst),
+                 (outs RegTp:$dst),
                  (ins MEMri:$addr, RegTp:$val),
                  "lock *(" #OpType# " *)($addr) " #Opstr# "= $val",
                  []> {


### PR DESCRIPTION
All ATOMIC_NOFETCH insns have "$dst = $val" constraints. So let us enforce "$dst = $val" having the same register type in ATOMIC_NOFETCH as well.

Currently, things work since ATOMIC_NOFETCH does not have source code pattern matching. I am experimenting to introduce memory ordering to BPFInstrInfo.td file and pattern matching will be needed. Eventually, for atomic_fetch_*() insns locked insns could be generated if memory ordering is memory_order_relaxed.

  [1] https://lore.kernel.org/bpf/7b941f53-2a05-48ec-9032-8f106face3a3@linux.dev/