### PR TITLE
[llvm-ml] Adds /quiet flag to llvm-ml

### DIFF
--- a/llvm/test/tools/llvm-ml/run.asm
+++ b/llvm/test/tools/llvm-ml/run.asm
@@ -1,3 +1,4 @@
 ; RUN: llvm-ml --help | FileCheck %s
+; RUN: llvm-ml /nologo /quiet
 
 ; CHECK: USAGE: llvm-ml

--- a/llvm/tools/llvm-ml/Opts.td
+++ b/llvm/tools/llvm-ml/Opts.td
@@ -72,6 +72,7 @@ def define : MLJoinedOrSeparate<"D">, MetaVarName<"<macro>=<value>">,
              HelpText<"Define <macro> to <value> (or blank if <value> "
                       "omitted)">;
 def no_logo : MLFlag<"nologo">, HelpText<"">;
+def quiet : MLFlag<"quiet">, HelpText<"">;
 def output_file : MLJoinedOrSeparate<"Fo">, HelpText<"Names the output file">;
 def include_path : MLJoinedOrSeparate<"I">,
                    HelpText<"Sets path for include files">;


### PR DESCRIPTION
In PR #106794, it was noted that `llvm-ml` does not support the `/quiet` flag. The original reason it was added by Microsoft to `ml`/`ml64` was to remove extraneous CMake build output (see [CMake GitLab issue](https://gitlab.kitware.com/cmake/cmake/-/issues/23537)) much like in the linked PR .

If the goal is for `llvm-ml` to be a drop-in replacement for `ml`/`ml64`, then I think it makes sense to support the `/quiet` flag, much like how `/nologo` is supported.