### PR TITLE
[Target] Use templated MachineFunction::getSubtarget in *CallingConv.td. NFC

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCallingConv.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCallingConv.td
@@ -214,13 +214,11 @@ def RetCC_AMDGPU_Func : CallingConv<[
 ]>;
 
 def CC_AMDGPU : CallingConv<[
-   CCIf<"static_cast<const GCNSubtarget&>"
-         "(State.getMachineFunction().getSubtarget()).getGeneration() >= "
-           "AMDGPUSubtarget::SOUTHERN_ISLANDS",
+   CCIf<"State.getMachineFunction().getSubtarget<GCNSubtarget>().getGeneration() >= "
+          "AMDGPUSubtarget::SOUTHERN_ISLANDS",
         CCDelegateTo<CC_SI_SHADER>>,
-   CCIf<"static_cast<const GCNSubtarget&>"
-         "(State.getMachineFunction().getSubtarget()).getGeneration() >= "
-           "AMDGPUSubtarget::SOUTHERN_ISLANDS && State.getCallingConv() == CallingConv::C",
+   CCIf<"State.getMachineFunction().getSubtarget<GCNSubtarget>().getGeneration() >= "
+          "AMDGPUSubtarget::SOUTHERN_ISLANDS && State.getCallingConv() == CallingConv::C",
         CCDelegateTo<CC_AMDGPU_Func>>
 ]>;
 

--- a/llvm/lib/Target/M68k/M68kCallingConv.td
+++ b/llvm/lib/Target/M68k/M68kCallingConv.td
@@ -15,8 +15,8 @@
 // TODO Verify C convention follows SysV M68K ABI
 
 class CCIfSubtarget<string F, CCAction A>
-    : CCIf<!strconcat("static_cast<const M68kSubtarget &>"
-                      "(State.getMachineFunction().getSubtarget()).", F), A>;
+    : CCIf<!strconcat("State.getMachineFunction()."
+                      "getSubtarget<M68kSubtarget>().", F), A>;
 
 //===----------------------------------------------------------------------===//
 // Return Value Calling Conventions

--- a/llvm/lib/Target/Mips/MipsCallingConv.td
+++ b/llvm/lib/Target/Mips/MipsCallingConv.td
@@ -11,8 +11,7 @@
 /// CCIfSubtarget - Match if the current subtarget has a feature F.
 class CCIfSubtarget<string F, CCAction A, string Invert = "">
     : CCIf<!strconcat(Invert,
-                      "static_cast<const MipsSubtarget&>"
-			"(State.getMachineFunction().getSubtarget()).",
+                      "State.getMachineFunction().getSubtarget<MipsSubtarget>().",
                       F),
            A>;
 

--- a/llvm/lib/Target/PowerPC/PPCCallingConv.td
+++ b/llvm/lib/Target/PowerPC/PPCCallingConv.td
@@ -13,13 +13,11 @@
 
 /// CCIfSubtarget - Match if the current subtarget has a feature F.
 class CCIfSubtarget<string F, CCAction A>
-    : CCIf<!strconcat("static_cast<const PPCSubtarget&>"
-                       "(State.getMachineFunction().getSubtarget()).",
+    : CCIf<!strconcat("State.getMachineFunction().getSubtarget<PPCSubtarget>().",
                      F),
           A>;
 class CCIfNotSubtarget<string F, CCAction A>
-    : CCIf<!strconcat("!static_cast<const PPCSubtarget&>"
-                       "(State.getMachineFunction().getSubtarget()).",
+    : CCIf<!strconcat("!State.getMachineFunction().getSubtarget<PPCSubtarget>().",
                      F),
           A>;
 class CCIfOrigArgWasNotPPCF128<CCAction A>

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.td
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.td
@@ -12,8 +12,8 @@ class CCIfExtend<CCAction A>
   : CCIf<"ArgFlags.isSExt() || ArgFlags.isZExt()", A>;
 
 class CCIfSubtarget<string F, CCAction A>
-  : CCIf<!strconcat("static_cast<const SystemZSubtarget&>"
-                    "(State.getMachineFunction().getSubtarget()).", F),
+  : CCIf<!strconcat("State.getMachineFunction()."
+                    "getSubtarget<SystemZSubtarget>().", F),
          A>;
 
 // Match if this specific argument is a fixed (i.e. named) argument.

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -13,14 +13,14 @@
 
 /// CCIfSubtarget - Match if the current subtarget has a feature F.
 class CCIfSubtarget<string F, CCAction A>
-    : CCIf<!strconcat("static_cast<const X86Subtarget&>"
-                       "(State.getMachineFunction().getSubtarget()).", F),
+    : CCIf<!strconcat("State.getMachineFunction()."
+                      "getSubtarget<X86Subtarget>().", F),
            A>;
 
 /// CCIfNotSubtarget - Match if the current subtarget doesn't has a feature F.
 class CCIfNotSubtarget<string F, CCAction A>
-    : CCIf<!strconcat("!static_cast<const X86Subtarget&>"
-                       "(State.getMachineFunction().getSubtarget()).", F),
+    : CCIf<!strconcat("!State.getMachineFunction()."
+                      "getSubtarget<X86Subtarget>().", F),
            A>;
 
 /// CCIfRegCallv4 - Match if RegCall ABIv4 is respected.


### PR DESCRIPTION
This hides away the static_cast to get the target specific Subtarget object.