### PR TITLE
[clang-format] Add support for BasedOnStyle referencing an arbitrary file

### DIFF
--- a/clang-tools-extra/clang-apply-replacements/tool/ClangApplyReplacementsMain.cpp
+++ b/clang-tools-extra/clang-apply-replacements/tool/ClangApplyReplacementsMain.cpp
@@ -69,6 +69,24 @@ static cl::opt<std::string>
     FormatStyleOpt("style", cl::desc(format::StyleOptionHelpDescription),
                    cl::init("LLVM"), cl::cat(FormattingCategory));
 
+static cl::list<std::string>
+StyleSearchPaths(
+    "style-search-path",
+    cl::desc("Directory to search for BasedOnStyle files, when the value of the\n"
+             "BasedOnStyle directive is not one of the predefined styles, nor\n"
+             "InheritFromParent. Multiple style search paths may be specified,\n"
+             "and will be searched in order, stopping at the first file found."),
+    cl::value_desc("directory"),
+    cl::cat(FormattingCategory));
+
+static cl::alias
+StyleSearchPathShort(
+    "S",
+    cl::desc("Alias for --style-search-path"),
+    cl::cat(FormattingCategory),
+    cl::aliasopt(StyleSearchPaths),
+    cl::NotHidden);
+
 namespace {
 // Helper object to remove the TUReplacement and TUDiagnostic (triggered by
 // "remove-change-desc-files" command line option) when exiting current scope.
@@ -102,6 +120,7 @@ int main(int argc, char **argv) {
 
   // Determine a formatting style from options.
   auto FormatStyleOrError = format::getStyle(FormatStyleOpt, FormatStyleConfig,
+                                             StyleSearchPaths,
                                              format::DefaultFallbackStyle);
   if (!FormatStyleOrError) {
     llvm::errs() << llvm::toString(FormatStyleOrError.takeError()) << "\n";

--- a/clang-tools-extra/clang-change-namespace/ChangeNamespace.cpp
+++ b/clang-tools-extra/clang-change-namespace/ChangeNamespace.cpp
@@ -339,8 +339,9 @@ ChangeNamespaceTool::ChangeNamespaceTool(
     llvm::StringRef OldNs, llvm::StringRef NewNs, llvm::StringRef FilePattern,
     llvm::ArrayRef<std::string> AllowedSymbolPatterns,
     std::map<std::string, tooling::Replacements> *FileToReplacements,
-    llvm::StringRef FallbackStyle)
-    : FallbackStyle(FallbackStyle), FileToReplacements(*FileToReplacements),
+    llvm::StringRef FallbackStyle, const std::vector<std::string>& StyleSearchPaths)
+    : FallbackStyle(FallbackStyle), StyleSearchPaths(StyleSearchPaths),
+      FileToReplacements(*FileToReplacements),
       OldNamespace(OldNs.ltrim(':')), NewNamespace(NewNs.ltrim(':')),
       FilePattern(FilePattern), FilePatternRE(FilePattern) {
   FileToReplacements->clear();
@@ -1004,7 +1005,7 @@ void ChangeNamespaceTool::onEndOfTranslationUnit() {
     // which refers to the original code.
     Replaces = Replaces.merge(NewReplacements);
     auto Style =
-        format::getStyle(format::DefaultFormatStyle, FilePath, FallbackStyle);
+        format::getStyle(format::DefaultFormatStyle, FilePath, StyleSearchPaths, FallbackStyle);
     if (!Style) {
       llvm::errs() << llvm::toString(Style.takeError()) << "\n";
       continue;

--- a/clang-tools-extra/clang-change-namespace/ChangeNamespace.h
+++ b/clang-tools-extra/clang-change-namespace/ChangeNamespace.h
@@ -51,7 +51,8 @@ public:
       llvm::StringRef OldNs, llvm::StringRef NewNs, llvm::StringRef FilePattern,
       llvm::ArrayRef<std::string> AllowedSymbolPatterns,
       std::map<std::string, tooling::Replacements> *FileToReplacements,
-      llvm::StringRef FallbackStyle = "LLVM");
+      llvm::StringRef FallbackStyle = "LLVM",
+      const std::vector<std::string>& StyleSearchPaths = {});
 
   void registerMatchers(ast_matchers::MatchFinder *Finder);
 
@@ -109,6 +110,9 @@ private:
   };
 
   std::string FallbackStyle;
+  // Specifies the list of paths to be searched when FormatStyle or a BasedOnStyle
+  // in a .clang-format file specifies an arbitrary file to include
+  std::vector<std::string> StyleSearchPaths;
   // In match callbacks, this contains replacements for replacing `typeLoc`s in
   // and deleting forward declarations in the moved namespace blocks.
   // In `onEndOfTranslationUnit` callback, the previous added replacements are

--- a/clang-tools-extra/clang-change-namespace/tool/ClangChangeNamespace.cpp
+++ b/clang-tools-extra/clang-change-namespace/tool/ClangChangeNamespace.cpp
@@ -72,6 +72,22 @@ cl::opt<std::string> Style("style",
                            cl::desc("The style name used for reformatting."),
                            cl::init("LLVM"), cl::cat(ChangeNamespaceCategory));
 
+cl::list<std::string> StyleSearchPaths(
+    "style-search-path",
+    cl::desc("Directory to search for BasedOnStyle files, when the value of the\n"
+             "BasedOnStyle directive is not one of the predefined styles, nor\n"
+             "InheritFromParent. Multiple style search paths may be specified,\n"
+             "and will be searched in order, stopping at the first file found."),
+    cl::value_desc("directory"),
+    cl::cat(ChangeNamespaceCategory));
+
+cl::alias StyleSearchPathShort(
+    "S",
+    cl::desc("Alias for --style-search-path"),
+    cl::cat(ChangeNamespaceCategory),
+    cl::aliasopt(StyleSearchPaths),
+    cl::NotHidden);
+
 cl::opt<std::string> AllowedFile(
     "allowed_file",
     cl::desc("A file containing regexes of symbol names that are not expected "
@@ -135,7 +151,7 @@ int main(int argc, const char **argv) {
   SourceManager Sources(Diagnostics, FileMgr);
   Rewriter Rewrite(Sources, DefaultLangOptions);
 
-  if (!formatAndApplyAllReplacements(Tool.getReplacements(), Rewrite, Style)) {
+  if (!formatAndApplyAllReplacements(Tool.getReplacements(), Rewrite, Style, StyleSearchPaths)) {
     llvm::errs() << "Failed applying all replacements.\n";
     return 1;
   }

--- a/clang-tools-extra/clang-move/Move.cpp
+++ b/clang-tools-extra/clang-move/Move.cpp
@@ -781,6 +781,7 @@ void ClangMoveTool::removeDeclsInOldFiles() {
     if (SI == FilePathToFileID.end()) continue;
     llvm::StringRef Code = SM.getBufferData(SI->second);
     auto Style = format::getStyle(format::DefaultFormatStyle, FilePath,
+                                  Context->StyleSearchPaths,
                                   Context->FallbackStyle);
     if (!Style) {
       llvm::errs() << llvm::toString(Style.takeError()) << "\n";

--- a/clang-tools-extra/clang-move/Move.h
+++ b/clang-tools-extra/clang-move/Move.h
@@ -89,6 +89,9 @@ struct ClangMoveContext {
   // directory when analyzing the source file. We save the original working
   // directory in order to get the absolute file path for the fields in Spec.
   std::string OriginalRunningDirectory;
+  // Specifies the list of paths to be searched when BasedOnStyle
+  // in a .clang-format file specifies an arbitrary file to include
+  std::vector<std::string> StyleSearchPaths;
   // The name of a predefined code style.
   std::string FallbackStyle;
   // Whether dump all declarations in old header.

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -209,7 +209,8 @@ public:
         }
         StringRef Code = Buffer.get()->getBuffer();
         auto Style = format::getStyle(
-            *Context.getOptionsForFile(File).FormatStyle, File, "none");
+            *Context.getOptionsForFile(File).FormatStyle, File,
+            Context.getGlobalOptions().StyleSearchPaths, "none");
         if (!Style) {
           llvm::errs() << llvm::toString(Style.takeError()) << "\n";
           continue;

--- a/clang-tools-extra/clang-tidy/ClangTidyOptions.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyOptions.h
@@ -42,6 +42,10 @@ struct ClangTidyGlobalOptions {
   /// Output warnings from certain line ranges of certain files only.
   /// If empty, no warnings will be filtered.
   std::vector<FileFilter> LineFilter;
+
+  /// Specifies the list of paths to be searched when BasedOnStyle
+  /// in a .clang-format file specifies an arbitrary file to include
+  std::vector<std::string> StyleSearchPaths;
 };
 
 /// Contains options for clang-tidy. These options may be read from

--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
@@ -60,7 +60,8 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
       IgnoreHeaders(utils::options::parseStringList(
           Options.getLocalOrGlobal("IgnoreHeaders", ""))),
       DeduplicateFindings(
-          Options.getLocalOrGlobal("DeduplicateFindings", true)) {
+          Options.getLocalOrGlobal("DeduplicateFindings", true)),
+      StyleSearchPaths(Context->getGlobalOptions().StyleSearchPaths) {
   for (const auto &Header : IgnoreHeaders) {
     if (!llvm::Regex{Header}.isValid())
       configurationDiag("Invalid ignore headers regex '%0'") << Header;
@@ -196,7 +197,7 @@ void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
   llvm::StringRef Code = SM->getBufferData(SM->getMainFileID());
   auto FileStyle =
       format::getStyle(format::DefaultFormatStyle, getCurrentMainFile(),
-                       format::DefaultFallbackStyle, Code,
+                       StyleSearchPaths, format::DefaultFallbackStyle, Code,
                        &SM->getFileManager().getVirtualFileSystem());
   if (!FileStyle)
     FileStyle = format::getLLVMStyle();

--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
@@ -47,6 +47,7 @@ private:
   std::vector<StringRef> IgnoreHeaders;
   // Whether emit only one finding per usage of a symbol.
   const bool DeduplicateFindings;
+  std::vector<std::string> StyleSearchPaths;
   llvm::SmallVector<llvm::Regex> IgnoreHeadersRegex;
   bool shouldIgnore(const include_cleaner::Header &H);
 };

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -208,6 +208,20 @@ This option overrides the 'FormatStyle` option in
                                         cl::init("none"),
                                         cl::cat(ClangTidyCategory));
 
+static cl::list<std::string> StyleSearchPaths("style-search-path", desc(R"(
+Directory to search for BasedOnStyle files, when the value of the
+BasedOnStyle directive is not one of the predefined styles, nor
+InheritFromParent. Multiple style search paths may be specified,
+and will be searched in order, stopping at the first file found.
+)"),
+                                              cl::value_desc("directory"),
+                                              cl::cat(ClangTidyCategory));
+
+static cl::alias StyleSearchPathShort("S", cl::desc("Alias for --style-search-path"),
+                                      cl::cat(ClangTidyCategory),
+                                      cl::aliasopt(StyleSearchPaths),
+                                      cl::NotHidden);
+
 static cl::opt<bool> ListChecks("list-checks", desc(R"(
 List all enabled checks and exit. Use with
 -checks=* to list all available checks.
@@ -366,6 +380,7 @@ static void printStats(const ClangTidyStats &Stats) {
 static std::unique_ptr<ClangTidyOptionsProvider> createOptionsProvider(
    llvm::IntrusiveRefCntPtr<vfs::FileSystem> FS) {
   ClangTidyGlobalOptions GlobalOptions;
+  GlobalOptions.StyleSearchPaths = StyleSearchPaths;
   if (std::error_code Err = parseLineFilter(LineFilter, GlobalOptions)) {
     llvm::errs() << "Invalid LineFilter: " << Err.message() << "\n\nUsage:\n";
     llvm::cl::PrintHelpMessage(/*Hidden=*/false, /*Categorized=*/true);

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1650,7 +1650,7 @@ ClangdLSPServer::ClangdLSPServer(Transport &Transp, const ThreadsafeFS &TFS,
     assert(!Opts.ContextProvider &&
            "Only one of ConfigProvider and ContextProvider allowed!");
     this->Opts.ContextProvider = ClangdServer::createConfiguredContextProvider(
-        Opts.ConfigProvider, this);
+        Opts.ConfigProvider, this, Opts.StyleSearchPaths);
   }
   LSPBinder Bind(this->Handlers, *this);
   Bind.method("initialize", this, &ClangdLSPServer::onInitialize);

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -96,7 +96,8 @@ public:
   /// (This is typically used as ClangdServer::Options::ContextProvider).
   static std::function<Context(PathRef)>
   createConfiguredContextProvider(const config::Provider *Provider,
-                                  ClangdServer::Callbacks *);
+                                  ClangdServer::Callbacks *,
+                                  const std::vector<std::string> &StyleSearchPaths);
 
   struct Options {
     /// To process requests asynchronously, ClangdServer spawns worker threads.
@@ -141,6 +142,10 @@ public:
     /// The Options provider to use when running clang-tidy. If null, clang-tidy
     /// checks will be disabled.
     TidyProviderRef ClangTidyProvider;
+
+    /// Specifies the list of paths to be searched when BasedOnStyle
+    /// in a .clang-format file specifies an arbitrary file to include
+    std::vector<std::string> StyleSearchPaths;
 
     /// Clangd's workspace root. Relevant for "workspace" operations not bound
     /// to a particular file.
@@ -486,6 +491,10 @@ private:
 
   // When set, provides clang-tidy options for a specific file.
   TidyProviderRef ClangTidyProvider;
+
+  // Specifies the list of paths to be searched when BasedOnStyle
+  // in a .clang-format file specifies an arbitrary file to include
+  std::vector<std::string> StyleSearchPaths;
 
   bool UseDirtyHeaders = false;
 

--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -124,6 +124,10 @@ struct Config {
     // declarations, always spell out the whole name (with or without leading
     // ::). All nested namespaces are affected as well.
     std::vector<std::string> FullyQualifiedNamespaces;
+
+    // Specifies the list of paths to be searched when BasedOnStyle
+    // in a .clang-format file specifies an arbitrary file to include
+    std::vector<std::string> StyleSearchPaths;
   } Style;
 
   /// Configures code completion feature.

--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "IncludeCleaner.h"
+#include "Config.h"
 #include "Diagnostics.h"
 #include "Headers.h"
 #include "ParsedAST.h"

--- a/clang-tools-extra/clangd/SourceCode.cpp
+++ b/clang-tools-extra/clangd/SourceCode.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include "SourceCode.h"
 
+#include "Config.h"
 #include "FuzzyMatch.h"
 #include "Preamble.h"
 #include "Protocol.h"
@@ -597,7 +598,9 @@ format::FormatStyle getFormatStyleForFile(llvm::StringRef File,
   // language is detected.
   if (!FormatFile)
     Content = {};
+  auto &Cfg = Config::current();
   auto Style = format::getStyle(format::DefaultFormatStyle, File,
+                                Cfg.Style.StyleSearchPaths,
                                 format::DefaultFallbackStyle, Content,
                                 TFS.view(/*CWD=*/std::nullopt).get());
   if (!Style) {

--- a/clang-tools-extra/clangd/tool/Check.cpp
+++ b/clang-tools-extra/clangd/tool/Check.cpp
@@ -512,7 +512,7 @@ bool check(llvm::StringRef File, const ThreadsafeFS &TFS,
       config::Provider::combine({Opts.ConfigProvider, &OverrideConfig});
 
   auto ContextProvider = ClangdServer::createConfiguredContextProvider(
-      ConfigProvider.get(), nullptr);
+      ConfigProvider.get(), nullptr, Opts.StyleSearchPaths);
   WithContext Ctx(ContextProvider(
       FakeFile.empty()
           ? File

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -69,16 +69,20 @@ bool check(const llvm::StringRef File, const ThreadsafeFS &TFS,
 
 namespace {
 
+using llvm::cl::alias;
+using llvm::cl::aliasopt;
 using llvm::cl::cat;
 using llvm::cl::CommaSeparated;
 using llvm::cl::desc;
 using llvm::cl::Hidden;
 using llvm::cl::init;
 using llvm::cl::list;
+using llvm::cl::NotHidden;
 using llvm::cl::opt;
 using llvm::cl::OptionCategory;
 using llvm::cl::ValueOptional;
 using llvm::cl::values;
+using llvm::cl::value_desc;
 
 // All flags must be placed in a category, or they will be shown neither in
 // --help, nor --help-hidden!
@@ -240,6 +244,24 @@ opt<std::string> FallbackStyle{
     desc("clang-format style to apply by default when "
          "no .clang-format file is found"),
     init(clang::format::DefaultFallbackStyle),
+};
+
+list<std::string> StyleSearchPaths{
+    "style-search-path",
+    desc("Directory to search for BasedOnStyle files, when the value of the "
+         "BasedOnStyle directive is not one of the predefined styles, nor "
+         "InheritFromParent. Multiple style search paths may be specified, "
+         "and will be searched in order, stopping at the first file found."),
+    value_desc("directory"),
+    cat(Features)
+};
+
+alias StyleSearchPathShort{
+    "S",
+    desc("Alias for --style-search-path"),
+    cat(Features),
+    aliasopt(StyleSearchPaths),
+    NotHidden
 };
 
 opt<bool> EnableFunctionArgSnippets{
@@ -957,6 +979,7 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
     ClangTidyOptProvider = combine(std::move(Providers));
     Opts.ClangTidyProvider = ClangTidyOptProvider;
   }
+  Opts.StyleSearchPaths = StyleSearchPaths;
   Opts.UseDirtyHeaders = UseDirtyHeaders;
   Opts.PreambleParseForwardingFunctions = PreambleParseForwardingFunctions;
   Opts.ImportInsertions = ImportInsertions;

--- a/clang-tools-extra/clangd/unittests/ClangdTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ClangdTests.cpp
@@ -348,7 +348,7 @@ TEST(ClangdServerTest, RespectsConfig) {
 
   auto Opts = ClangdServer::optsForTest();
   Opts.ContextProvider =
-      ClangdServer::createConfiguredContextProvider(&CfgProvider, nullptr);
+      ClangdServer::createConfiguredContextProvider(&CfgProvider, nullptr, Opts.StyleSearchPaths);
   OverlayCDB CDB(/*Base=*/nullptr, /*FallbackFlags=*/{},
                  CommandMangler::forTests());
   MockFS FS;

--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -104,10 +104,23 @@ cl::opt<bool> Remove{
     cl::cat(IncludeCleaner),
 };
 
+static cl::list<std::string> StyleSearchPaths("style-search-path", cl::desc(R"(
+Directory to search for BasedOnStyle files, when the value of the
+BasedOnStyle directive is not one of the predefined styles, nor
+InheritFromParent. Multiple style search paths may be specified,
+and will be searched in order, stopping at the first file found.
+)"),
+                                              cl::value_desc("directory"),
+                                              cl::cat(IncludeCleaner));
+
+static cl::alias StyleSearchPathShort("S", cl::desc("Alias for --style-search-path"),
+                                      cl::cat(IncludeCleaner), cl::aliasopt(StyleSearchPaths),
+                                      cl::NotHidden);
+
 std::atomic<unsigned> Errors = ATOMIC_VAR_INIT(0);
 
 format::FormatStyle getStyle(llvm::StringRef Filename) {
-  auto S = format::getStyle(format::DefaultFormatStyle, Filename,
+  auto S = format::getStyle(format::DefaultFormatStyle, Filename, StyleSearchPaths,
                             format::DefaultFallbackStyle);
   if (!S || !S->isCpp()) {
     consumeError(S.takeError());

--- a/clang-tools-extra/unittests/clang-change-namespace/ChangeNamespaceTests.cpp
+++ b/clang-tools-extra/unittests/clang-change-namespace/ChangeNamespaceTests.cpp
@@ -46,7 +46,7 @@ public:
     if (!tooling::runToolOnCodeWithArgs(Factory->create(), Code, {"-std=c++11"},
                                         FileName))
       return "";
-    formatAndApplyAllReplacements(FileToReplacements, Context.Rewrite);
+    formatAndApplyAllReplacements(FileToReplacements, Context.Rewrite, "file", {} /*StyleSearchPatsh*/);
     return format(Context.getRewrittenText(ID));
   }
 

--- a/clang-tools-extra/unittests/clang-move/ClangMoveTests.cpp
+++ b/clang-tools-extra/unittests/clang-move/ClangMoveTests.cpp
@@ -226,7 +226,7 @@ runClangMoveOnCode(const move::MoveDefinitionSpec &Spec,
   CreateFiles(TestCCName, CC);
 
   std::map<std::string, tooling::Replacements> FileToReplacements;
-  ClangMoveContext MoveContext = {Spec, FileToReplacements, Dir.c_str(), "LLVM",
+  ClangMoveContext MoveContext = {Spec, FileToReplacements, Dir.c_str(), /*StyleSearchPaths*/{}, "LLVM",
                                   Reporter != nullptr};
 
   auto Factory = std::make_unique<clang::move::ClangMoveActionFactory>(
@@ -236,7 +236,7 @@ runClangMoveOnCode(const move::MoveDefinitionSpec &Spec,
       Factory->create(), CC, Context.InMemoryFileSystem,
       {"-std=c++11", "-fparse-all-comments", "-I."}, TestCCName, "clang-move",
       std::make_shared<PCHContainerOperations>());
-  formatAndApplyAllReplacements(FileToReplacements, Context.Rewrite, "llvm");
+  formatAndApplyAllReplacements(FileToReplacements, Context.Rewrite, "llvm", /*StyleSearchPaths*/{});
   // The Key is file name, value is the new code after moving the class.
   std::map<std::string, std::string> Results;
   for (const auto &It : FileToReplacements) {

--- a/clang/include/clang/Tooling/Refactoring.h
+++ b/clang/include/clang/Tooling/Refactoring.h
@@ -87,11 +87,13 @@ private:
 /// \param[in] Rewrite The `Rewritter` to apply replacements on.
 /// \param[in] Style The style name used for reformatting. See ```getStyle``` in
 /// "include/clang/Format/Format.h" for all possible style forms.
+/// \param[in] StyleSearchPaths A list of directories to search for clang-format
+/// files referenced in the BasedOnStyle directive.
 ///
 /// \returns true if all replacements applied and formatted. false otherwise.
 bool formatAndApplyAllReplacements(
     const std::map<std::string, Replacements> &FileToReplaces,
-    Rewriter &Rewrite, StringRef Style = "file");
+    Rewriter &Rewrite, StringRef Style, const std::vector<std::string>& StyleSearchPaths);
 
 } // end namespace tooling
 } // end namespace clang

--- a/clang/lib/Tooling/Refactoring.cpp
+++ b/clang/lib/Tooling/Refactoring.cpp
@@ -68,7 +68,7 @@ int RefactoringTool::saveRewrittenFiles(Rewriter &Rewrite) {
 
 bool formatAndApplyAllReplacements(
     const std::map<std::string, Replacements> &FileToReplaces,
-    Rewriter &Rewrite, StringRef Style) {
+    Rewriter &Rewrite, StringRef Style, const std::vector<std::string>& StyleSearchPaths) {
   SourceManager &SM = Rewrite.getSourceMgr();
   FileManager &Files = SM.getFileManager();
 
@@ -82,7 +82,7 @@ bool formatAndApplyAllReplacements(
     FileID ID = SM.getOrCreateFileID(Entry, SrcMgr::C_User);
     StringRef Code = SM.getBufferData(ID);
 
-    auto CurStyle = format::getStyle(Style, FilePath, "LLVM");
+    auto CurStyle = format::getStyle(Style, FilePath, StyleSearchPaths, "LLVM");
     if (!CurStyle) {
       llvm::errs() << llvm::toString(CurStyle.takeError()) << "\n";
       return false;

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -172,6 +172,24 @@ static cl::opt<bool>
                      cl::desc("If set, changes formatting warnings to errors"),
                      cl::cat(ClangFormatCategory));
 
+static cl::list<std::string>
+    StyleSearchPaths(
+    "style-search-path",
+    cl::desc("Directory to search for BasedOnStyle files, when the value of the\n"
+             "BasedOnStyle directive is not one of the predefined styles, nor\n"
+             "InheritFromParent. Multiple style search paths may be specified,\n"
+             "and will be searched in order, stopping at the first file found."),
+    cl::value_desc("directory"),
+    cl::cat(ClangFormatCategory));
+
+static cl::alias
+    StyleSearchPathShort(
+    "S",
+    cl::desc("Alias for --style-search-path"),
+    cl::cat(ClangFormatCategory),
+    cl::aliasopt(StyleSearchPaths),
+    cl::NotHidden);
+
 namespace {
 enum class WNoError { Unknown };
 }
@@ -452,7 +470,7 @@ static bool format(StringRef FileName, bool ErrorOnIncompleteFormat = false) {
   }
 
   Expected<FormatStyle> FormatStyle =
-      getStyle(Style, AssumedFileName, FallbackStyle, Code->getBuffer(),
+      getStyle(Style, AssumedFileName, StyleSearchPaths, FallbackStyle, Code->getBuffer(),
                nullptr, WNoErrorList.isSet(WNoError::Unknown));
   if (!FormatStyle) {
     llvm::errs() << toString(FormatStyle.takeError()) << "\n";
@@ -573,6 +591,7 @@ static int dumpConfig() {
   Expected<clang::format::FormatStyle> FormatStyle = clang::format::getStyle(
       Style,
       FileNames.empty() || FileNames[0] == "-" ? AssumeFileName : FileNames[0],
+      StyleSearchPaths,
       FallbackStyle, Code ? Code->getBuffer() : "");
   if (!FormatStyle) {
     llvm::errs() << toString(FormatStyle.takeError()) << "\n";

--- a/clang/unittests/Format/FormatTestObjC.cpp
+++ b/clang/unittests/Format/FormatTestObjC.cpp
@@ -32,7 +32,7 @@ protected:
 #define verifyFormat(...) _verifyFormat(__FILE__, __LINE__, __VA_ARGS__)
 
 TEST(FormatTestObjCStyle, DetectsObjCInStdin) {
-  auto Style = getStyle("LLVM", "<stdin>", "none",
+  auto Style = getStyle("LLVM", "<stdin>", /*StyleSearchPaths*/{}, "none",
                         "@interface\n"
                         "- (id)init;");
   ASSERT_TRUE((bool)Style);
@@ -40,67 +40,67 @@ TEST(FormatTestObjCStyle, DetectsObjCInStdin) {
 }
 
 TEST(FormatTestObjCStyle, DetectsObjCInHeaders) {
-  auto Style = getStyle("LLVM", "a.h", "none",
+  auto Style = getStyle("LLVM", "a.h", /*StyleSearchPaths*/{}, "none",
                         "@interface\n"
                         "- (id)init;");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("LLVM", "a.h", "none",
+  Style = getStyle("LLVM", "a.h", /*StyleSearchPaths*/{}, "none",
                    "@interface\n"
                    "+ (id)init;");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("LLVM", "a.h", "none",
+  Style = getStyle("LLVM", "a.h", /*StyleSearchPaths*/{}, "none",
                    "@interface\n"
                    "@end\n"
                    "//comment");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("LLVM", "a.h", "none",
+  Style = getStyle("LLVM", "a.h", /*StyleSearchPaths*/{}, "none",
                    "@interface\n"
                    "@end //comment");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
   // No recognizable ObjC.
-  Style = getStyle("LLVM", "a.h", "none", "void f() {}");
+  Style = getStyle("LLVM", "a.h", /*StyleSearchPaths*/{}, "none", "void f() {}");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_Cpp, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "@interface Foo\n@end");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "@interface Foo\n@end");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none",
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none",
                    "const int interface = 1;\nconst int end = 2;");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_Cpp, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "@protocol Foo\n@end");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "@protocol Foo\n@end");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none",
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none",
                    "const int protocol = 1;\nconst int end = 2;");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_Cpp, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "typedef NS_ENUM(int, Foo) {};");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "typedef NS_ENUM(int, Foo) {};");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "typedef NS_CLOSED_ENUM(int, Foo) {};");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "typedef NS_CLOSED_ENUM(int, Foo) {};");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "typedef NS_ERROR_ENUM(int, Foo) {};");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "typedef NS_ERROR_ENUM(int, Foo) {};");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", R"objc(
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", R"objc(
 NS_ASSUME_NONNULL_BEGIN
 extern int i;
 NS_ASSUME_NONNULL_END
@@ -108,71 +108,71 @@ NS_ASSUME_NONNULL_END
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", R"objc(
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", R"objc(
 FOUNDATION_EXTERN void DoStuff(void);
 )objc");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", R"objc(
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", R"objc(
 FOUNDATION_EXPORT void DoStuff(void);
 )objc");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "enum Foo {};");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "enum Foo {};");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_Cpp, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "inline void Foo() { Log(@\"Foo\"); }");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "inline void Foo() { Log(@\"Foo\"); }");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "inline void Foo() { Log(\"Foo\"); }");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "inline void Foo() { Log(\"Foo\"); }");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_Cpp, Style->Language);
 
   Style =
-      getStyle("{}", "a.h", "none", "inline void Foo() { id = @[1, 2, 3]; }");
+      getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "inline void Foo() { id = @[1, 2, 3]; }");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none",
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none",
                    "inline void Foo() { id foo = @{1: 2, 3: 4, 5: 6}; }");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none",
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none",
                    "inline void Foo() { int foo[] = {1, 2, 3}; }");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_Cpp, Style->Language);
 
   // ObjC characteristic types.
-  Style = getStyle("{}", "a.h", "none", "extern NSString *kFoo;");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "extern NSString *kFoo;");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "extern NSInteger Foo();");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "extern NSInteger Foo();");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "NSObject *Foo();");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "NSObject *Foo();");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 
-  Style = getStyle("{}", "a.h", "none", "NSSet *Foo();");
+  Style = getStyle("{}", "a.h", /*StyleSearchPaths*/{}, "none", "NSSet *Foo();");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_ObjC, Style->Language);
 }
 
 TEST(FormatTestObjCStyle, AvoidDetectingDesignatedInitializersAsObjCInHeaders) {
-  auto Style = getStyle("LLVM", "a.h", "none",
+  auto Style = getStyle("LLVM", "a.h", /*StyleSearchPaths*/{}, "none",
                         "static const char *names[] = {[0] = \"foo\",\n"
                         "[kBar] = \"bar\"};");
   ASSERT_TRUE((bool)Style);
   EXPECT_EQ(FormatStyle::LK_Cpp, Style->Language);
 
-  Style = getStyle("LLVM", "a.h", "none",
+  Style = getStyle("LLVM", "a.h", /*StyleSearchPaths*/{}, "none",
                    "static const char *names[] = {[0] EQ \"foo\",\n"
                    "[kBar] EQ \"bar\"};");
   ASSERT_TRUE((bool)Style);

--- a/clang/unittests/Format/FormatTestRawStrings.cpp
+++ b/clang/unittests/Format/FormatTestRawStrings.cpp
@@ -136,7 +136,7 @@ TEST_F(FormatTestRawStrings, UsesConfigurationOverBaseStyle) {
   EXPECT_EQ(0, parseConfiguration("---\n"
                                   "Language: Cpp\n"
                                   "BasedOnStyle: Google",
-                                  &Style)
+                                  &Style, /*StyleSearchPaths*/{})
                    .value());
   Style.RawStringFormats = {{
       FormatStyle::LK_Cpp,

--- a/clang/unittests/Format/ObjCPropertyAttributeOrderFixerTest.cpp
+++ b/clang/unittests/Format/ObjCPropertyAttributeOrderFixerTest.cpp
@@ -19,11 +19,13 @@ namespace {
 
 #define CHECK_PARSE(TEXT, FIELD, VALUE)                                        \
   EXPECT_NE(VALUE, Style.FIELD) << "Initial value already the same!";          \
-  EXPECT_EQ(0, parseConfiguration(TEXT, &Style).value());                      \
+  EXPECT_EQ(0, parseConfiguration(TEXT, &Style, /*StyleSearchPaths*/{})        \
+               .value());                                                      \
   EXPECT_EQ(VALUE, Style.FIELD) << "Unexpected value after parsing!"
 
 #define FAIL_PARSE(TEXT, FIELD, VALUE)                                         \
-  EXPECT_NE(0, parseConfiguration(TEXT, &Style).value());                      \
+  EXPECT_NE(0, parseConfiguration(TEXT, &Style, /*StyleSearchPaths*/{})        \
+               .value());                                                      \
   EXPECT_EQ(VALUE, Style.FIELD) << "Unexpected value after parsing!"
 
 class ObjCPropertyAttributeOrderFixerTest : public FormatTestBase {

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -19,11 +19,13 @@ namespace {
 
 #define CHECK_PARSE(TEXT, FIELD, VALUE)                                        \
   EXPECT_NE(VALUE, Style.FIELD) << "Initial value already the same!";          \
-  EXPECT_EQ(0, parseConfiguration(TEXT, &Style).value());                      \
+  EXPECT_EQ(0, parseConfiguration(TEXT, &Style, /*StyleSearchPaths*/{})        \
+               .value());                                                      \
   EXPECT_EQ(VALUE, Style.FIELD) << "Unexpected value after parsing!"
 
 #define FAIL_PARSE(TEXT, FIELD, VALUE)                                         \
-  EXPECT_NE(0, parseConfiguration(TEXT, &Style).value());                      \
+  EXPECT_NE(0, parseConfiguration(TEXT, &Style, /*StyleSearchPaths*/{})        \
+               .value());                                                      \
   EXPECT_EQ(VALUE, Style.FIELD) << "Unexpected value after parsing!"
 
 class QualifierFixerTest : public FormatTestBase {

--- a/clang/unittests/Rename/ClangRenameTest.h
+++ b/clang/unittests/Rename/ClangRenameTest.h
@@ -81,7 +81,7 @@ protected:
             FileContents))
       return "";
 
-    formatAndApplyAllReplacements(FileToReplacements, Context.Rewrite, "llvm");
+    formatAndApplyAllReplacements(FileToReplacements, Context.Rewrite, "llvm", /*StyleSearchPaths*/{});
     return Context.getRewrittenText(InputFileID);
   }
 

--- a/clang/unittests/Tooling/RefactoringTest.cpp
+++ b/clang/unittests/Tooling/RefactoringTest.cpp
@@ -541,7 +541,8 @@ TEST_F(ReplacementTest, MultipleFilesReplaceAndFormat) {
                             "10")});
   EXPECT_TRUE(
       formatAndApplyAllReplacements(FileToReplaces, Context.Rewrite,
-                                    "{BasedOnStyle: LLVM, ColumnLimit: 20}"));
+                                    "{BasedOnStyle: LLVM, ColumnLimit: 20}",
+                                    /*StyleSearchPaths*/{}));
   EXPECT_EQ(Expected1, Context.getRewrittenText(ID1));
   EXPECT_EQ(Expected2, Context.getRewrittenText(ID2));
 }

--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -779,6 +779,8 @@ public:
   IO(void *Ctxt = nullptr);
   virtual ~IO();
 
+  virtual SourceMgr& getSourceMgr();
+
   virtual bool outputting() const = 0;
 
   virtual unsigned beginSequence() = 0;
@@ -819,6 +821,7 @@ public:
 
   virtual void setError(const Twine &) = 0;
   virtual void setAllowUnknownKeys(bool Allow);
+  virtual bool allowUnknownKeys() const;
 
   template <typename T>
   void enumCase(T &Val, const char* Str, const T ConstVal) {
@@ -1449,6 +1452,8 @@ public:
   // Check if there was an syntax or semantic error during parsing.
   std::error_code error();
 
+  SourceMgr& getSourceMgr() override;
+
 private:
   bool outputting() const override;
   bool mapTag(StringRef, bool) override;
@@ -1567,6 +1572,7 @@ public:
   const Node *getCurrentNode() const;
 
   void setAllowUnknownKeys(bool Allow) override;
+  bool allowUnknownKeys() const override;
 
 private:
   SourceMgr                           SrcMgr; // must be before Strm

--- a/llvm/lib/Support/YAMLTraits.cpp
+++ b/llvm/lib/Support/YAMLTraits.cpp
@@ -39,6 +39,10 @@ IO::IO(void *Context) : Ctxt(Context) {}
 
 IO::~IO() = default;
 
+SourceMgr& IO::getSourceMgr() {
+  llvm_unreachable("Only supported for Input");
+}
+
 void *IO::getContext() const {
   return Ctxt;
 }
@@ -48,6 +52,10 @@ void IO::setContext(void *Context) {
 }
 
 void IO::setAllowUnknownKeys(bool Allow) {
+  llvm_unreachable("Only supported for Input");
+}
+
+bool IO::allowUnknownKeys() const {
   llvm_unreachable("Only supported for Input");
 }
 
@@ -74,6 +82,8 @@ Input::Input(MemoryBufferRef Input, void *Ctxt,
 Input::~Input() = default;
 
 std::error_code Input::error() { return EC; }
+
+SourceMgr& Input::getSourceMgr() { return SrcMgr; }
 
 bool Input::outputting() const {
   return false;
@@ -472,6 +482,8 @@ void Input::setError(const Twine &Message) {
 }
 
 void Input::setAllowUnknownKeys(bool Allow) { AllowUnknownKeys = Allow; }
+
+bool Input::allowUnknownKeys() const { return AllowUnknownKeys; }
 
 bool Input::canElideEmptySequence() {
   return false;


### PR DESCRIPTION
At present, the ```BasedOnStyle``` directive can reference a predefined style name, or ```InheritFromParent```, instructing clang-format to search upward in the directory hierarchy for a .clang-format file. This works fine when variations in codebase formatting align with the directory hierarchy, but becomes problematic when it is desired to share formatting across portions of a repository with no common parent directory. For example, consider the case of a large, multi-team repository containing many projects as sub-directories of the repository root, where each of the various engineering teams owns multiple of these projects, and wants a common coding style across all of its owned projects.

In this PR, I'm extending ```BasedOnStyle``` to allow referencing an arbitrary file. While this could be an absolute path, that's not typically useful across machines. In typical usage, this will be a relative path (e.g., ```BasedOnStyle: format/team1.clang-format```).  For resolving relative paths, I've mimicked the "include path" model of C/C++ (and, in fact, I'm able to leverage ```SourceMgr```'s "include paths" mechanism to implement this). The list of style search paths is specified on the command-line via one or more ```--style-search-path <path>``` parameters.

The interesting stuff is in Format.cpp...most of the rest of this change is plumbing to get the StyleSearchPaths from the command-line to the call to ```getStyle()```.

Unfinished aspects of this change:
* No unit tests. I am happy to write some, but I'm unsure how to do this in a harmonious way, seeing as my change inherently relies on external files on the filesystem. Most of the unit tests I've seen in Clang rely on in-code strings.
* ```--style-search-path .``` does not seem to work for specifying the current directory as a search path. Evidently the ```SourceMgr``` include paths mechanism does not handle this natively. Can someone point me to the proper "Clang" way to resolve paths like . or .. into paths that ```SourceMgr``` can handle?