### PR TITLE
[flang][cuda] Add c_devptr and bypass output semantic check

### DIFF
--- a/flang/lib/Semantics/check-io.cpp
+++ b/flang/lib/Semantics/check-io.cpp
@@ -1171,6 +1171,11 @@ parser::Message *IoChecker::CheckForBadIoType(const evaluate::DynamicType &type,
             "Derived type '%s' in I/O may not be polymorphic unless using defined I/O"_err_en_US,
             derived.name());
       }
+      if (IsBuiltinDerivedType(&derived, "c_ptr") ||
+          IsBuiltinDerivedType(&derived, "c_devptr")) {
+        // Bypass the check below for c_ptr and c_devptr.
+        return nullptr;
+      }
       if (const Symbol *
           bad{FindInaccessibleComponent(which, derived, scope)}) {
         return &context_.Say(where,

--- a/flang/module/__fortran_builtins.f90
+++ b/flang/module/__fortran_builtins.f90
@@ -102,6 +102,10 @@ module __fortran_builtins
     __builtin_threadIdx, __builtin_blockDim, __builtin_blockIdx, &
     __builtin_gridDim
   integer, parameter, public :: __builtin_warpsize = 32
+  
+  type, public, bind(c) :: __builtin_c_devptr
+    type(__builtin_c_ptr) :: cptr
+  end type
 
   intrinsic :: __builtin_fma
   intrinsic :: __builtin_ieee_is_nan, __builtin_ieee_is_negative, &

--- a/flang/test/Lower/CUDA/cuda-devptr.cuf
+++ b/flang/test/Lower/CUDA/cuda-devptr.cuf
@@ -1,0 +1,16 @@
+! RUN: bbc -emit-hlfir -fcuda %s -o - | FileCheck %s
+
+! Test CUDA Fortran specific type
+
+subroutine sub1()
+  use iso_c_binding
+  use __fortran_builtins, only : c_devptr => __builtin_c_devptr
+
+  type(c_ptr) :: ptr
+  type(c_devptr) :: dptr
+  print*,ptr
+  print*,dptr
+end
+
+! CHECK-LABEL: func.func @_QPsub1()
+! CHECK-COUNT-2: %{{.*}} = fir.call @_FortranAioOutputDerivedType


### PR DESCRIPTION
Add a builtin type for c_devptr since it will need some special handling for some function like c_f_pointer. 
`c_ptr` is defined as a builtin type and was raising a semantic error if you try to use it in a I/O statement. This patch add a check for c_ptr and c_devptr to bypass the semantic check and allow the variables of these types to be used in I/O.