### PR TITLE
[Minidump] Support multiple exceptions in a minidump

### DIFF
--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -83,14 +83,24 @@ public:
     return getListStream<minidump::Thread>(minidump::StreamType::ThreadList);
   }
 
-  /// Returns the contents of the Exception stream.  An error is returned if the
-  /// file does not contain this stream, or the stream is smaller than the size
-  /// of the ExceptionStream structure.  The internal consistency of the stream
-  /// is not checked in any way.
-  Expected<const minidump::ExceptionStream &> getExceptionStream() const {
-    return getStream<minidump::ExceptionStream>(
-        minidump::StreamType::Exception);
+  /// Returns the contents of the Exception stream. An error is returned if the
+  /// associated stream is smaller than the size of the ExceptionStream
+  /// structure. Or the directory supplied is not of kind exception stream.
+  Expected<const minidump::ExceptionStream &>
+  getExceptionStream(minidump::Directory Directory) const {
+    if (Directory.Type != minidump::StreamType::Exception) {
+      return createError("Not an exception stream");
+    }
+
+    return getStreamFromDirectory<minidump::ExceptionStream>(Directory);
   }
+
+  /// Returns the contents of the Exception streams.  An error is returned if
+  /// any of the streams are smaller than the size of the ExceptionStream
+  /// structure. The internal consistency of the stream is not checked in any
+  /// way.
+  Expected<std::vector<const minidump::ExceptionStream *>>
+  getExceptionStreams() const;
 
   /// Returns the list of descriptors embedded in the MemoryList stream. The
   /// descriptors provide the content of interesting regions of memory at the
@@ -267,6 +277,12 @@ private:
   /// Return the stream of the given type, cast to the appropriate type. Checks
   /// that the stream is large enough to hold an object of this type.
   template <typename T>
+  Expected<const T &>
+  getStreamFromDirectory(minidump::Directory Directory) const;
+
+  /// Return the stream of the given type, cast to the appropriate type. Checks
+  /// that the stream is large enough to hold an object of this type.
+  template <typename T>
   Expected<const T &> getStream(minidump::StreamType Stream) const;
 
   /// Return the contents of a stream which contains a list of fixed-size items,
@@ -278,6 +294,15 @@ private:
   ArrayRef<minidump::Directory> Streams;
   DenseMap<minidump::StreamType, std::size_t> StreamMap;
 };
+
+template <typename T>
+Expected<const T &>
+MinidumpFile::getStreamFromDirectory(minidump::Directory Directory) const {
+  ArrayRef<uint8_t> Stream = getRawStream(Directory);
+  if (Stream.size() >= sizeof(T))
+    return *reinterpret_cast<const T *>(Stream.data());
+  return createEOFError();
+}
 
 template <typename T>
 Expected<const T &> MinidumpFile::getStream(minidump::StreamType Type) const {

--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -236,12 +236,12 @@ class ExceptionStreamsIterator {
 
     bool operator!=(const ExceptionStreamsIterator &R) const { return !(*this == R); }
 
-    const Expected<const minidump::ExceptionStream &>
+    Expected<const minidump::ExceptionStream &>
     operator*() {
       return ReadCurrent();
     }
 
-    const Expected<const minidump::ExceptionStream &>
+    Expected<const minidump::ExceptionStream &>
     operator->() {
       return ReadCurrent();
     }

--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -95,6 +95,17 @@ public:
     return getStreamFromDirectory<minidump::ExceptionStream>(Directory);
   }
 
+  /// Returns the first exception stream in the file. An error is returned if
+  /// the associated stream is smaller than the size of the ExceptionStream
+  /// structure. Or the directory supplied is not of kind exception stream.
+  Expected<const minidump::ExceptionStream &>
+  getExceptionStream() const {
+    auto it = getExceptionStreams();
+    if (it.begin() == it.end())
+      return createError("No exception streams");
+    return *it.begin();
+  }
+
   /// Returns the list of descriptors embedded in the MemoryList stream. The
   /// descriptors provide the content of interesting regions of memory at the
   /// time the minidump was taken. An error is returned if the file does not

--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -98,8 +98,7 @@ public:
   /// Returns the first exception stream in the file. An error is returned if
   /// the associated stream is smaller than the size of the ExceptionStream
   /// structure. Or the directory supplied is not of kind exception stream.
-  Expected<const minidump::ExceptionStream &>
-  getExceptionStream() const {
+  Expected<const minidump::ExceptionStream &> getExceptionStream() const {
     auto it = getExceptionStreams();
     if (it.begin() == it.end())
       return createError("No exception streams");
@@ -233,8 +232,8 @@ public:
   class ExceptionStreamsIterator {
   public:
     ExceptionStreamsIterator(ArrayRef<minidump::Directory> Streams,
-                            const MinidumpFile *File)
-      : Streams(Streams), File(File) {}
+                             const MinidumpFile *File)
+        : Streams(Streams), File(File) {}
 
     bool operator==(const ExceptionStreamsIterator &R) const {
       return Streams.size() == R.Streams.size();

--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -219,70 +219,67 @@ public:
     bool IsEnd;
   };
 
-class ExceptionStreamsIterator {
+  class ExceptionStreamsIterator {
   public:
-
-    static ExceptionStreamsIterator begin(ArrayRef<minidump::Directory> Streams, const MinidumpFile *File) {
+    static ExceptionStreamsIterator begin(ArrayRef<minidump::Directory> Streams,
+                                          const MinidumpFile *File) {
       return ExceptionStreamsIterator(Streams, File);
     }
 
-    static ExceptionStreamsIterator end() {
-      return ExceptionStreamsIterator();
-    }
+    static ExceptionStreamsIterator end() { return ExceptionStreamsIterator(); }
 
     bool operator==(const ExceptionStreamsIterator &R) const {
       return Streams.empty() && R.Streams.empty();
     }
 
-    bool operator!=(const ExceptionStreamsIterator &R) const { return !(*this == R); }
+    bool operator!=(const ExceptionStreamsIterator &R) const {
+      return !(*this == R);
+    }
 
-    Expected<const minidump::ExceptionStream &>
-    operator*() {
+    Expected<const minidump::ExceptionStream &> operator*() {
       return ReadCurrent();
     }
 
-    Expected<const minidump::ExceptionStream &>
-    operator->() {
+    Expected<const minidump::ExceptionStream &> operator->() {
       return ReadCurrent();
     }
 
-    ExceptionStreamsIterator &
-    operator++ () {
+    ExceptionStreamsIterator &operator++() {
       if (!Streams.empty())
         Streams = Streams.drop_front();
-
 
       return *this;
     }
 
   private:
-    ExceptionStreamsIterator(ArrayRef<minidump::Directory> Streams, const MinidumpFile *File)
-      : Streams(Streams), File(File) {}
+    ExceptionStreamsIterator(ArrayRef<minidump::Directory> Streams,
+                             const MinidumpFile *File)
+        : Streams(Streams), File(File) {}
 
-    ExceptionStreamsIterator() : Streams(ArrayRef<minidump::Directory>()), File(nullptr) {}
+    ExceptionStreamsIterator()
+        : Streams(ArrayRef<minidump::Directory>()), File(nullptr) {}
 
     ArrayRef<minidump::Directory> Streams;
     const MinidumpFile *File;
 
-    Expected<const minidump::ExceptionStream&> ReadCurrent() {
+    Expected<const minidump::ExceptionStream &> ReadCurrent() {
       assert(!Streams.empty());
       Expected<const minidump::ExceptionStream &> ExceptionStream =
           File->getExceptionStream(Streams.front());
       if (!ExceptionStream)
         return ExceptionStream.takeError();
-      
+
       return ExceptionStream;
     }
   };
 
   using FallibleMemory64Iterator = llvm::fallible_iterator<Memory64Iterator>;
 
-  /// Returns an iterator that reads each exception stream independently. The 
-  /// contents of the exception strema are not validated before being read, an 
+  /// Returns an iterator that reads each exception stream independently. The
+  /// contents of the exception strema are not validated before being read, an
   /// error will be returned if the stream is not large enough to contain an
   /// exception stream, or if the stream points beyond the end of the file.
-  iterator_range<ExceptionStreamsIterator>
-  getExceptionStreams() const;
+  iterator_range<ExceptionStreamsIterator> getExceptionStreams() const;
 
   /// Returns an iterator that pairs each descriptor with it's respective
   /// content from the Memory64List stream. An error is returned if the file
@@ -325,7 +322,8 @@ private:
                DenseMap<minidump::StreamType, std::size_t> StreamMap,
                std::vector<minidump::Directory> ExceptionStreams)
       : Binary(ID_Minidump, Source), Header(Header), Streams(Streams),
-        StreamMap(std::move(StreamMap)), ExceptionStreams(std::move(ExceptionStreams)) {}
+        StreamMap(std::move(StreamMap)),
+        ExceptionStreams(std::move(ExceptionStreams)) {}
 
   ArrayRef<uint8_t> getData() const {
     return arrayRefFromStringRef(Data.getBuffer());

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -166,8 +166,9 @@ MinidumpFile::create(MemoryBufferRef Source) {
       return createError("Duplicate stream type");
   }
 
-  return std::unique_ptr<MinidumpFile>(new MinidumpFile(
-      Source, Hdr, *ExpectedStreams, std::move(StreamMap), std::move(ExceptionStreams)));
+  return std::unique_ptr<MinidumpFile>(
+      new MinidumpFile(Source, Hdr, *ExpectedStreams, std::move(StreamMap),
+                       std::move(ExceptionStreams)));
 }
 
 iterator_range<MinidumpFile::FallibleMemory64Iterator>

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -166,8 +166,8 @@ MinidumpFile::create(MemoryBufferRef Source) {
       return createError("Duplicate stream type");
   }
 
-  return std::unique_ptr<MinidumpFile>(
-      new MinidumpFile(Source, Hdr, *ExpectedStreams, std::move(StreamMap), ExceptionStreams));
+  return std::unique_ptr<MinidumpFile>(new MinidumpFile(
+      Source, Hdr, *ExpectedStreams, std::move(StreamMap), ExceptionStreams));
 }
 
 iterator_range<MinidumpFile::FallibleMemory64Iterator>

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -150,13 +150,11 @@ MinidumpFile::create(MemoryBufferRef Source) {
       continue;
     }
 
-    // We treat exceptions differently here because the LLDB minidump
-    // makes some assumptions about uniqueness, all the streams other than
-    // exceptions are lists. But exceptions are not a list, they are single
-    // streams that point back to their thread So we will omit them here, and
-    // will find them when needed in the MinidumpFile.
+    // Exceptions can be treated as a special case of streams. Other streams
+    // represent a list of entities, but exceptions are unique per stream.
     if (Type == StreamType::Exception) {
       ExceptionStreams.push_back(StreamDescriptor.value());
+      continue;
     }
 
     if (Type == DenseMapInfo<StreamType>::getEmptyKey() ||

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -53,6 +53,27 @@ Expected<std::string> MinidumpFile::getString(size_t Offset) const {
   return Result;
 }
 
+Expected<std::vector<const minidump::ExceptionStream *>>
+MinidumpFile::getExceptionStreams() const {
+
+  std::vector<const minidump::ExceptionStream *> exceptionStreamList;
+  for (const auto &directory : Streams) {
+    if (directory.Type == StreamType::Exception) {
+      llvm::Expected<minidump::ExceptionStream *> ExpectedStream =
+          getStreamFromDirectory<minidump::ExceptionStream *>(directory);
+      if (!ExpectedStream)
+        return ExpectedStream.takeError();
+
+      exceptionStreamList.push_back(ExpectedStream.get());
+    }
+  }
+
+  if (exceptionStreamList.empty())
+    return createError("No exception streams found");
+
+  return exceptionStreamList;
+}
+
 Expected<iterator_range<MinidumpFile::MemoryInfoIterator>>
 MinidumpFile::getMemoryInfoList() const {
   std::optional<ArrayRef<uint8_t>> Stream =
@@ -128,6 +149,7 @@ MinidumpFile::create(MemoryBufferRef Source) {
     return ExpectedStreams.takeError();
 
   DenseMap<StreamType, std::size_t> StreamMap;
+  std::vector<std::size_t> ExceptionStreams;
   for (const auto &StreamDescriptor : llvm::enumerate(*ExpectedStreams)) {
     StreamType Type = StreamDescriptor.value().Type;
     const LocationDescriptor &Loc = StreamDescriptor.value().Location;
@@ -140,6 +162,15 @@ MinidumpFile::create(MemoryBufferRef Source) {
     if (Type == StreamType::Unused && Loc.DataSize == 0) {
       // Ignore dummy streams. This is technically ill-formed, but a number of
       // existing minidumps seem to contain such streams.
+      continue;
+    }
+
+    // We treat exceptions differently here because the LLDB minidump
+    // makes some assumptions about uniqueness, all the streams other than
+    // exceptions are lists. But exceptions are not a list, they are single
+    // streams that point back to their thread So we will omit them here, and
+    // will find them when needed in the MinidumpFile.
+    if (Type == StreamType::Exception) {
       continue;
     }
 

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -55,8 +55,8 @@ Expected<std::string> MinidumpFile::getString(size_t Offset) const {
 
 iterator_range<llvm::object::MinidumpFile::ExceptionStreamsIterator>
 MinidumpFile::getExceptionStreams() const {
-  return make_range(ExceptionStreamsIterator::begin(ExceptionStreams, this),
-                    ExceptionStreamsIterator::end());
+  return make_range(ExceptionStreamsIterator(ExceptionStreams, this),
+                    ExceptionStreamsIterator({}, this));
 }
 
 Expected<iterator_range<MinidumpFile::MemoryInfoIterator>>
@@ -167,7 +167,7 @@ MinidumpFile::create(MemoryBufferRef Source) {
   }
 
   return std::unique_ptr<MinidumpFile>(new MinidumpFile(
-      Source, Hdr, *ExpectedStreams, std::move(StreamMap), ExceptionStreams));
+      Source, Hdr, *ExpectedStreams, std::move(StreamMap), std::move(ExceptionStreams)));
 }
 
 iterator_range<MinidumpFile::FallibleMemory64Iterator>

--- a/llvm/lib/ObjectYAML/MinidumpYAML.cpp
+++ b/llvm/lib/ObjectYAML/MinidumpYAML.cpp
@@ -499,7 +499,7 @@ Stream::create(const Directory &StreamDesc, const object::MinidumpFile &File) {
   switch (Kind) {
   case StreamKind::Exception: {
     Expected<const minidump::ExceptionStream &> ExpectedExceptionStream =
-        File.getExceptionStream();
+        File.getExceptionStream(StreamDesc);
     if (!ExpectedExceptionStream)
       return ExpectedExceptionStream.takeError();
     Expected<ArrayRef<uint8_t>> ExpectedThreadContext =

--- a/llvm/unittests/Object/MinidumpTest.cpp
+++ b/llvm/unittests/Object/MinidumpTest.cpp
@@ -711,7 +711,7 @@ TEST(MinidumpFile, getMemoryInfoList) {
                                    0x0001000908000000u));
 }
 
-TEST(MinidumpFile, getExceptionStream) {
+TEST(MinidumpFile, getExceptionStreams) {
   std::vector<uint8_t> Data{
       // Header
       'M', 'D', 'M', 'P', 0x93, 0xa7, 0, 0, // Signature, Version
@@ -751,8 +751,10 @@ TEST(MinidumpFile, getExceptionStream) {
   auto ExpectedFile = create(Data);
   ASSERT_THAT_EXPECTED(ExpectedFile, Succeeded());
   const MinidumpFile &File = **ExpectedFile;
-  auto ExceptionIterator = File.getExceptionStreams().begin();
-
+  
+  auto ExceptionStreams = File.getExceptionStreams();
+  ASSERT_NE(ExceptionStreams.begin(), ExceptionStreams.end());
+  auto ExceptionIterator = ExceptionStreams.begin();
   Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());
   EXPECT_EQ(0x04030201u, ExpectedStream->ThreadId);
@@ -768,4 +770,6 @@ TEST(MinidumpFile, getExceptionStream) {
   }
   EXPECT_EQ(0x84838281, ExpectedStream->ThreadContext.DataSize);
   EXPECT_EQ(0x88878685, ExpectedStream->ThreadContext.RVA);
+  ++ExceptionIterator;
+  ASSERT_EQ(ExceptionIterator, ExceptionStreams.end());
 }

--- a/llvm/unittests/Object/MinidumpTest.cpp
+++ b/llvm/unittests/Object/MinidumpTest.cpp
@@ -751,8 +751,10 @@ TEST(MinidumpFile, getExceptionStream) {
   auto ExpectedFile = create(Data);
   ASSERT_THAT_EXPECTED(ExpectedFile, Succeeded());
   const MinidumpFile &File = **ExpectedFile;
-  Expected<const minidump::ExceptionStream &> ExpectedStream =
-      File.getExceptionStream();
+  auto ExceptionIterator =
+      File.getExceptionStreams().begin();
+
+  Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());
   EXPECT_EQ(0x04030201u, ExpectedStream->ThreadId);
   const minidump::Exception &Exception = ExpectedStream->ExceptionRecord;

--- a/llvm/unittests/Object/MinidumpTest.cpp
+++ b/llvm/unittests/Object/MinidumpTest.cpp
@@ -751,8 +751,7 @@ TEST(MinidumpFile, getExceptionStream) {
   auto ExpectedFile = create(Data);
   ASSERT_THAT_EXPECTED(ExpectedFile, Succeeded());
   const MinidumpFile &File = **ExpectedFile;
-  auto ExceptionIterator =
-      File.getExceptionStreams().begin();
+  auto ExceptionIterator = File.getExceptionStreams().begin();
 
   Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());

--- a/llvm/unittests/Object/MinidumpTest.cpp
+++ b/llvm/unittests/Object/MinidumpTest.cpp
@@ -751,7 +751,7 @@ TEST(MinidumpFile, getExceptionStreams) {
   auto ExpectedFile = create(Data);
   ASSERT_THAT_EXPECTED(ExpectedFile, Succeeded());
   const MinidumpFile &File = **ExpectedFile;
-  
+
   auto ExceptionStreams = File.getExceptionStreams();
   ASSERT_NE(ExceptionStreams.begin(), ExceptionStreams.end());
   auto ExceptionIterator = ExceptionStreams.begin();

--- a/llvm/unittests/ObjectYAML/MinidumpYAMLTest.cpp
+++ b/llvm/unittests/ObjectYAML/MinidumpYAMLTest.cpp
@@ -162,8 +162,10 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  Expected<const minidump::ExceptionStream &> ExpectedStream =
-      File.getExceptionStream();
+  auto ExceptionIterator =
+      File.getExceptionStreams().begin();
+
+  Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
 
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());
 
@@ -205,9 +207,10 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  Expected<const minidump::ExceptionStream &> ExpectedStream =
-      File.getExceptionStream();
+  auto ExceptionIterator =
+      File.getExceptionStreams().begin();
 
+  Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());
 
   const minidump::ExceptionStream &Stream = *ExpectedStream;
@@ -261,8 +264,10 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  Expected<const minidump::ExceptionStream &> ExpectedStream =
-      File.getExceptionStream();
+  auto ExceptionIterator =
+      File.getExceptionStreams().begin();
+
+  Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
 
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());
 
@@ -312,8 +317,10 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  Expected<const minidump::ExceptionStream &> ExpectedStream =
-      File.getExceptionStream();
+  auto ExceptionIterator =
+      File.getExceptionStreams().begin();
+
+  Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
 
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());
 
@@ -398,4 +405,47 @@ Streams:
   ASSERT_THAT(*DescTwoExpectedContentSlice, arrayRefFromStringRef("world"));
 
   ASSERT_EQ(Iterator, MemoryList.end());
+
+}
+
+// Test that we can parse multiple exception streams.
+TEST(MinidumpYAML, ExceptionStream_MultipleExceptions) {
+  SmallString<0> Storage;
+  auto ExpectedFile = toBinary(Storage, R"(
+--- !minidump
+Streams:
+  - Type:            Exception
+    Thread ID:  0x7
+    Exception Record:
+      Exception Code:  0x23
+      Exception Flags: 0x5
+      Exception Record: 0x0102030405060708
+      Exception Address: 0x0a0b0c0d0e0f1011
+      Number of Parameters: 2
+      Parameter 0: 0x99
+      Parameter 1: 0x23
+      Parameter 2: 0x42
+    Thread Context:  3DeadBeefDefacedABadCafe
+  - Type:            Exception
+    Thread ID:  0x5
+    Exception Record:
+      Exception Code:  0x23
+      Exception Flags: 0x5
+      Exception Record: 0x0102030405060708
+      Exception Address: 0x0a0b0c0d0e0f1011
+    Thread Context:  3DeadBeefDefacedABadCafe)");
+  
+  ASSERT_THAT_EXPECTED(ExpectedFile, Succeeded());
+  object::MinidumpFile &File = **ExpectedFile;
+
+  ASSERT_EQ(2u, File.streams().size());
+
+  size_t count = 0;
+  for (auto exception_stream : File.getExceptionStreams()) {
+    count++;
+    ASSERT_THAT_EXPECTED(exception_stream, Succeeded());
+    ASSERT_THAT(0x23u, exception_stream->ExceptionRecord.ExceptionCode);
+  }
+
+  ASSERT_THAT(2u, count);
 }

--- a/llvm/unittests/ObjectYAML/MinidumpYAMLTest.cpp
+++ b/llvm/unittests/ObjectYAML/MinidumpYAMLTest.cpp
@@ -162,8 +162,7 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  auto ExceptionIterator =
-      File.getExceptionStreams().begin();
+  auto ExceptionIterator = File.getExceptionStreams().begin();
 
   Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
 
@@ -207,8 +206,7 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  auto ExceptionIterator =
-      File.getExceptionStreams().begin();
+  auto ExceptionIterator = File.getExceptionStreams().begin();
 
   Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
   ASSERT_THAT_EXPECTED(ExpectedStream, Succeeded());
@@ -264,8 +262,7 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  auto ExceptionIterator =
-      File.getExceptionStreams().begin();
+  auto ExceptionIterator = File.getExceptionStreams().begin();
 
   Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
 
@@ -317,8 +314,7 @@ Streams:
 
   ASSERT_EQ(1u, File.streams().size());
 
-  auto ExceptionIterator =
-      File.getExceptionStreams().begin();
+  auto ExceptionIterator = File.getExceptionStreams().begin();
 
   Expected<const ExceptionStream &> ExpectedStream = *ExceptionIterator;
 
@@ -405,7 +401,6 @@ Streams:
   ASSERT_THAT(*DescTwoExpectedContentSlice, arrayRefFromStringRef("world"));
 
   ASSERT_EQ(Iterator, MemoryList.end());
-
 }
 
 // Test that we can parse multiple exception streams.
@@ -434,7 +429,7 @@ Streams:
       Exception Record: 0x0102030405060708
       Exception Address: 0x0a0b0c0d0e0f1011
     Thread Context:  3DeadBeefDefacedABadCafe)");
-  
+
   ASSERT_THAT_EXPECTED(ExpectedFile, Succeeded());
   object::MinidumpFile &File = **ExpectedFile;
 


### PR DESCRIPTION
A fork of #97470, splitting off the LLVM changes from the LLDB specific changes. This patch enables a minidump file to have multiple exceptions, exposed via an iterator of Expected streams.