### PR TITLE
[libc] Correct the entrypoints list for ARM/darwin

### DIFF
--- a/libc/config/darwin/arm/entrypoints.txt
+++ b/libc/config/darwin/arm/entrypoints.txt
@@ -94,16 +94,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.calloc
     libc.src.stdlib.realloc
     libc.src.stdlib.free
-
-    # stdio.h external entrypoints
-    libc.src.stdio.snprintf
-    libc.src.stdio.sprintf
-    libc.src.stdio.asprintf
-    libc.src.stdio.asprintf
-    libc.src.stdio.vprintf
-    libc.src.stdio.vsnprintf
-    libc.src.stdio.vsprintf
-    libc.src.stdio.vasprintf
 )
 
 set(TARGET_LIBM_ENTRYPOINTS
@@ -148,9 +138,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.cospif
     libc.src.math.dfmal
     libc.src.math.dsqrtl
-    libc.src.math.daddl
     libc.src.math.ddivl
-    libc.src.math.dsubl
     libc.src.math.erff
     libc.src.math.exp
     libc.src.math.expf


### PR DESCRIPTION
These entrypoints were added to every target without testing. They don't
work on ARM macs.
