### PR TITLE
[TableGen] Add PrintError family overload that take a print function

### DIFF
--- a/llvm/include/llvm/TableGen/Error.h
+++ b/llvm/include/llvm/TableGen/Error.h
@@ -14,12 +14,16 @@
 #ifndef LLVM_TABLEGEN_ERROR_H
 #define LLVM_TABLEGEN_ERROR_H
 
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/TableGen/Record.h"
 
 namespace llvm {
+class Record;
+class RecordVal;
+class Init;
 
 void PrintNote(const Twine &Msg);
+void PrintNote(function_ref<void(raw_ostream &OS)> PrintMsg);
 void PrintNote(ArrayRef<SMLoc> NoteLoc, const Twine &Msg);
 
 [[noreturn]] void PrintFatalNote(const Twine &Msg);
@@ -32,6 +36,7 @@ void PrintWarning(ArrayRef<SMLoc> WarningLoc, const Twine &Msg);
 void PrintWarning(const char *Loc, const Twine &Msg);
 
 void PrintError(const Twine &Msg);
+void PrintError(function_ref<void(raw_ostream &OS)> PrintMsg);
 void PrintError(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg);
 void PrintError(const char *Loc, const Twine &Msg);
 void PrintError(const Record *Rec, const Twine &Msg);
@@ -41,6 +46,7 @@ void PrintError(const RecordVal *RecVal, const Twine &Msg);
 [[noreturn]] void PrintFatalError(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg);
 [[noreturn]] void PrintFatalError(const Record *Rec, const Twine &Msg);
 [[noreturn]] void PrintFatalError(const RecordVal *RecVal, const Twine &Msg);
+[[noreturn]] void PrintFatalError(function_ref<void(raw_ostream &OS)> PrintMsg);
 
 void CheckAssert(SMLoc Loc, Init *Condition, Init *Message);
 void dumpMessage(SMLoc Loc, Init *Message);

--- a/llvm/lib/TableGen/Error.cpp
+++ b/llvm/lib/TableGen/Error.cpp
@@ -40,10 +40,21 @@ static void PrintMessage(ArrayRef<SMLoc> Loc, SourceMgr::DiagKind Kind,
                         "instantiated from multiclass");
 }
 
+// Run file cleanup handlers and then exit fatally (with non-zero exit code).
+[[noreturn]] inline static void fatal_exit() {
+  // The following call runs the file cleanup handlers.
+  sys::RunInterruptHandlers();
+  std::exit(1);
+}
+
 // Functions to print notes.
 
 void PrintNote(const Twine &Msg) {
   WithColor::note() << Msg << "\n";
+}
+
+void PrintNote(function_ref<void(raw_ostream &OS)> PrintMsg) {
+  PrintMsg(WithColor::note());
 }
 
 void PrintNote(ArrayRef<SMLoc> NoteLoc, const Twine &Msg) {
@@ -54,34 +65,26 @@ void PrintNote(ArrayRef<SMLoc> NoteLoc, const Twine &Msg) {
 
 void PrintFatalNote(const Twine &Msg) {
   PrintNote(Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
 }
 
 void PrintFatalNote(ArrayRef<SMLoc> NoteLoc, const Twine &Msg) {
   PrintNote(NoteLoc, Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
 }
 
 // This method takes a Record and uses the source location
 // stored in it.
 void PrintFatalNote(const Record *Rec, const Twine &Msg) {
   PrintNote(Rec->getLoc(), Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
 }
 
 // This method takes a RecordVal and uses the source location
 // stored in it.
 void PrintFatalNote(const RecordVal *RecVal, const Twine &Msg) {
   PrintNote(RecVal->getLoc(), Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
 }
 
 // Functions to print warnings.
@@ -99,6 +102,10 @@ void PrintWarning(const char *Loc, const Twine &Msg) {
 // Functions to print errors.
 
 void PrintError(const Twine &Msg) { WithColor::error() << Msg << "\n"; }
+
+void PrintError(function_ref<void(raw_ostream &OS)> PrintMsg) {
+  PrintMsg(WithColor::error());
+}
 
 void PrintError(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg) {
   PrintMessage(ErrorLoc, SourceMgr::DK_Error, Msg);
@@ -124,34 +131,31 @@ void PrintError(const RecordVal *RecVal, const Twine &Msg) {
 
 void PrintFatalError(const Twine &Msg) {
   PrintError(Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
+}
+
+void PrintFatalError(function_ref<void(raw_ostream &OS)> PrintMsg) {
+  PrintError(PrintMsg);
+  fatal_exit();
 }
 
 void PrintFatalError(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg) {
   PrintError(ErrorLoc, Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
 }
 
 // This method takes a Record and uses the source location
 // stored in it.
 void PrintFatalError(const Record *Rec, const Twine &Msg) {
   PrintError(Rec->getLoc(), Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
 }
 
 // This method takes a RecordVal and uses the source location
 // stored in it.
 void PrintFatalError(const RecordVal *RecVal, const Twine &Msg) {
   PrintError(RecVal->getLoc(), Msg);
-  // The following call runs the file cleanup handlers.
-  sys::RunInterruptHandlers();
-  std::exit(1);
+  fatal_exit();
 }
 
 // Check an assertion: Obtain the condition value and be sure it is true.

--- a/llvm/test/TableGen/intrinsic-prefix-error.td
+++ b/llvm/test/TableGen/intrinsic-prefix-error.td
@@ -1,0 +1,14 @@
+// RUN: not llvm-tblgen -gen-intrinsic-enums --intrinsic-prefix=gen3 -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS 2>&1 | FileCheck %s
+
+include "llvm/IR/Intrinsics.td"
+
+// CHECK: error: tried to generate intrinsics for unknown target gen3
+// CHECK-NEXT: Known targets are: gen1, gen2
+
+let TargetPrefix = "gen1" in {
+  def int_gen1_int0 : Intrinsic<[llvm_i32_ty]>;
+}
+
+let TargetPrefix = "gen2" in {
+  def int_gen2_int0 : Intrinsic<[llvm_i32_ty]>;
+}

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -1603,14 +1603,11 @@ static TreePatternNode &getOperandNum(unsigned OpNo, TreePatternNode &N,
   OpNo -= NumResults;
 
   if (OpNo >= N.getNumChildren()) {
-    std::string S;
-    raw_string_ostream OS(S);
-    OS << "Invalid operand number in type constraint " << (OpNo + NumResults)
-       << " ";
-    N.print(OS);
-    PrintFatalError(S);
+    PrintFatalError([&N, OpNo, NumResults](raw_ostream &OS) {
+      OS << "Invalid operand number in type constraint " << (OpNo + NumResults);
+      N.print(OS);
+    });
   }
-
   return N.getChild(OpNo);
 }
 

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -1961,12 +1961,11 @@ void parseVarLenInstOperand(const Record &Def,
 }
 
 static void debugDumpRecord(const Record &Rec) {
-  // Dump the record, so we can see what's going on...
-  std::string E;
-  raw_string_ostream S(E);
-  S << "Dumping record for previous error:\n";
-  S << Rec;
-  PrintNote(E);
+  // Dump the record, so we can see what's going on.
+  PrintNote([&Rec](raw_ostream &OS) {
+    OS << "Dumping record for previous error:\n";
+    OS << Rec;
+  });
 }
 
 /// For an operand field named OpName: populate OpInfo.InitValue with the


### PR DESCRIPTION
Add PrintError and family overload that accepts a print function. This avoids constructing potentially long strings for passing into these print functions.