### PR TITLE
[DirectX] Fix crash in DXILOpBuilder for vector types

### DIFF
--- a/llvm/lib/Target/DirectX/DXILOpBuilder.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpBuilder.cpp
@@ -123,8 +123,7 @@ static OverloadKind getOverloadKind(Type *Ty) {
   case Type::StructTyID:
     return OverloadKind::ObjectType;
   default:
-    llvm_unreachable("invalid overload type");
-    return OverloadKind::VOID;
+    return OverloadKind::UNDEFINED;
   }
 }
 

--- a/llvm/test/CodeGen/DirectX/sin_vector_error.ll
+++ b/llvm/test/CodeGen/DirectX/sin_vector_error.ll
@@ -1,0 +1,11 @@
+; RUN: not opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.0-library %s 2>&1 | FileCheck %s
+; The sin intrinsic needs to be scalarized before op lowering
+
+; CHECK: error:
+; CHECK-SAME: in function sin_vector
+; CHECK-SAME: Cannot create Sin operation: Invalid overload type
+
+define <4 x float> @sin_vector(<4 x float> %a) {
+  %x = call <4 x float> @llvm.sin.v4f32(<4 x float> %a)
+  ret <4 x float> %x
+}


### PR DESCRIPTION
This function needs to return the "undefined" sigil for unknown types so that the actual error handling triggers instead of a crash.