### PR TITLE
[TableGen] Eliminate static CodeGenIntrinsicMap in PatternParser

### DIFF
--- a/llvm/lib/Target/AMDGPU/InstCombineTables.td
+++ b/llvm/lib/Target/AMDGPU/InstCombineTables.td
@@ -1,5 +1,4 @@
-include "llvm/TableGen/SearchableTable.td"
-include "llvm/IR/Intrinsics.td"
+include "AMDGPU.td"
 
 def AMDGPUImageDMaskIntrinsicTable : GenericTable {
   let FilterClass = "AMDGPUImageDMaskIntrinsic";

--- a/llvm/test/TableGen/searchabletables-intrinsic.td
+++ b/llvm/test/TableGen/searchabletables-intrinsic.td
@@ -2,7 +2,9 @@
 // XFAIL: vg_leak
 
 include "llvm/TableGen/SearchableTable.td"
-include "llvm/IR/Intrinsics.td"
+include "llvm/Target/Target.td"
+
+def DummyTarget : Target;
 
 def int_abc : Intrinsic<[llvm_anyint_ty]>;
 def int_xyz : Intrinsic<[llvm_anyint_ty]>;

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -86,7 +86,7 @@ std::string llvm::getQualifiedName(const Record *R) {
 /// getTarget - Return the current instance of the Target class.
 ///
 CodeGenTarget::CodeGenTarget(RecordKeeper &records)
-    : Records(records), CGH(records) {
+    : Records(records), CGH(records), Intrinsics(records) {
   std::vector<Record *> Targets = Records.getAllDerivedDefinitions("Target");
   if (Targets.size() == 0)
     PrintFatalError("No 'Target' subclasses defined!");

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_UTILS_TABLEGEN_COMMON_CODEGENTARGET_H
 #define LLVM_UTILS_TABLEGEN_COMMON_CODEGENTARGET_H
 
+#include "Basic/CodeGenIntrinsics.h"
 #include "Basic/SDNodeProperties.h"
 #include "CodeGenHwModes.h"
 #include "CodeGenInstruction.h"
@@ -75,6 +76,8 @@ class CodeGenTarget {
 
   mutable StringRef InstNamespace;
   mutable std::vector<const CodeGenInstruction *> InstrsByEnum;
+  mutable CodeGenIntrinsicMap Intrinsics;
+
   mutable unsigned NumPseudoInstructions = 0;
 
 public:
@@ -224,6 +227,10 @@ public:
   /// guessInstructionProperties - should we just guess unset instruction
   /// properties?
   bool guessInstructionProperties() const;
+
+  const CodeGenIntrinsic &getIntrinsic(const Record *Def) const {
+    return Intrinsics[Def];
+  }
 
 private:
   void ComputeInstrsByEnum() const;

--- a/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
@@ -104,15 +104,6 @@ getInstrForIntrinsic(const CodeGenTarget &CGT, const CodeGenIntrinsic *I) {
   return CGT.getInstruction(RK.getDef(Opc));
 }
 
-static const CodeGenIntrinsic *getCodeGenIntrinsic(Record *R) {
-  // Intrinsics need to have a static lifetime because the match table keeps
-  // references to CodeGenIntrinsic objects.
-  static CodeGenIntrinsicMap *AllIntrinsics;
-  if (!AllIntrinsics)
-    AllIntrinsics = new CodeGenIntrinsicMap(R->getRecords());
-  return &(*AllIntrinsics)[R];
-}
-
 std::unique_ptr<Pattern>
 PatternParser::parseInstructionPattern(const Init &Arg, StringRef Name) {
   const DagInit *DagPat = dyn_cast<DagInit>(&Arg);
@@ -127,7 +118,7 @@ PatternParser::parseInstructionPattern(const Init &Arg, StringRef Name) {
   } else if (const DagInit *IP =
                  getDagWithOperatorOfSubClass(Arg, "Intrinsic")) {
     Record *TheDef = IP->getOperatorAsDef(DiagLoc);
-    const CodeGenIntrinsic *Intrin = getCodeGenIntrinsic(TheDef);
+    const CodeGenIntrinsic *Intrin = &CGT.getIntrinsic(TheDef);
     const CodeGenInstruction &Instr = getInstrForIntrinsic(CGT, Intrin);
     Pat =
         std::make_unique<CodeGenInstructionPattern>(Instr, insertStrRef(Name));


### PR DESCRIPTION
Instead, move it to CodeGenTarget class, and use it in both PatternParser and SearchableTableEmitter.