### PR TITLE
[libc++] Avoid redefining _LIBCPP_DISABLE_DEPRECATION_WARNINGS if already defined.

### DIFF
--- a/libcxx/src/exception.cpp
+++ b/libcxx/src/exception.cpp
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #define _LIBCPP_ENABLE_CXX20_REMOVED_UNCAUGHT_EXCEPTION
+
+#ifndef _LIBCPP_DISABLE_DEPRECATION_WARNINGS
 #define _LIBCPP_DISABLE_DEPRECATION_WARNINGS
+#endif
 
 #include <exception>
 #include <new>


### PR DESCRIPTION
The following commit defines LIBCPP_DISABLE_DEPRECATION_WARNINGS to libcxx/src/exception.cpp
https://github.com/llvm/llvm-project/commit/1e9c654671d32bdeed867d16889f6451135cdbdb

However, Edge builds already built with LIBCPP_DISABLE_DEPRECATION_WARNINGS as we work towards removing some deprecated functions usage. This results in macro redefinition errors. This PR checks that the macro isn't defined already to avoid redefinition.

Fixes #107316