### PR TITLE
[libc++][test] LWG2593: Moved-from state of Allocators

### DIFF
--- a/libcxx/docs/Status/Cxx20Issues.csv
+++ b/libcxx/docs/Status/Cxx20Issues.csv
@@ -1,7 +1,7 @@
 "Issue #","Issue Name","Meeting","Status","First released version","Notes"
 "`LWG2070 <https://wg21.link/LWG2070>`__","``allocate_shared``\  should use ``allocator_traits<A>::construct``\ ","2017-07 (Toronto)","|Nothing To Do|","","Resolved by `P0674R1 <https://wg21.link/P0674R1>`__"
 "`LWG2444 <https://wg21.link/LWG2444>`__","Inconsistent complexity for ``std::sort_heap``\ ","2017-07 (Toronto)","|Nothing To Do|","",""
-"`LWG2593 <https://wg21.link/LWG2593>`__","Moved-from state of Allocators","2017-07 (Toronto)","","",""
+"`LWG2593 <https://wg21.link/LWG2593>`__","Moved-from state of Allocators","2017-07 (Toronto)","|Nothing To Do|","",""
 "`LWG2597 <https://wg21.link/LWG2597>`__","``std::log``\  misspecified for complex numbers","2017-07 (Toronto)","","",""
 "`LWG2783 <https://wg21.link/LWG2783>`__","``stack::emplace()``\  and ``queue::emplace()``\  should return ``decltype(auto)``\ ","2017-07 (Toronto)","|Complete|","",""
 "`LWG2932 <https://wg21.link/LWG2932>`__","Constraints on parallel algorithm implementations are underspecified","2017-07 (Toronto)","","",""

--- a/libcxx/test/std/containers/associative/map/map.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.cons/move.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**)
         assert(m.size() == 0);
         assert(std::distance(m.begin(), m.end()) == 0);
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -65,7 +65,7 @@ int main(int, char**)
         assert(*std::next(m.begin()) == V(2, 1));
         assert(*std::next(m.begin(), 2) == V(3, 1));
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/associative/multimap/multimap.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.cons/move.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**)
         assert(m.size() == 0);
         assert(std::distance(m.begin(), m.end()) == 0);
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -71,7 +71,7 @@ int main(int, char**)
         assert(*std::next(m.begin(), 7) == V(3, 1.5));
         assert(*std::next(m.begin(), 8) == V(3, 2));
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/associative/multiset/multiset.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/multiset/multiset.cons/move.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**)
         assert(m.size() == 0);
         assert(std::distance(m.begin(), m.end()) == 0);
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -72,7 +72,7 @@ int main(int, char**)
         assert(*std::next(m.begin(), 7) == 3);
         assert(*std::next(m.begin(), 8) == 3);
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/associative/set/set.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/set.cons/move.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**)
         assert(m.size() == 0);
         assert(std::distance(m.begin(), m.end()) == 0);
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -66,7 +66,7 @@ int main(int, char**)
         assert(*std::next(m.begin()) == 2);
         assert(*std::next(m.begin(), 2) == 3);
 
-        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.get_allocator() == A(7));
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/container.requirements/container.requirements.general/allocator_move.pass.cpp
+++ b/libcxx/test/std/containers/container.requirements/container.requirements.general/allocator_move.pass.cpp
@@ -50,14 +50,15 @@ void test(int expected_num_allocs = 1) {
     assert(alloc_stats.copied == 0);
     assert(alloc_stats.moved == num_stored_allocs);
     {
-      const AllocT& a = v.get_allocator();
-      assert(a.get_id() == test_alloc_base::moved_value);
-      assert(a.get_data() == test_alloc_base::moved_value);
-    }
-    {
-      const AllocT& a = v2.get_allocator();
-      assert(a.get_id() == 101);
-      assert(a.get_data() == 42);
+      const AllocT& a1 = v.get_allocator();
+      assert(a1.get_id() == test_alloc_base::moved_value);
+      assert(a1.get_data() == 42);
+
+      const AllocT& a2 = v2.get_allocator();
+      assert(a2.get_id() == 101);
+      assert(a2.get_data() == 42);
+
+      assert(a1 == a2);
     }
   }
 }

--- a/libcxx/test/std/containers/sequences/deque/deque.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.cons/move.pass.cpp
@@ -38,7 +38,7 @@ int main(int, char**)
         assert(c2 == c3);
         assert(c1.size() == 0);
         assert(c3.get_allocator() == old_a);
-        assert(c1.get_allocator() == A(test_alloc_base::moved_value));
+        assert(c1.get_allocator() == A(1));
         LIBCPP_ASSERT(is_double_ended_contiguous_container_asan_correct(c1));
         LIBCPP_ASSERT(is_double_ended_contiguous_container_asan_correct(c2));
         LIBCPP_ASSERT(is_double_ended_contiguous_container_asan_correct(c3));

--- a/libcxx/test/std/containers/sequences/vector.bool/move.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/move.pass.cpp
@@ -80,14 +80,15 @@ TEST_CONSTEXPR_CXX20 bool tests()
       assert(alloc_stats.copied == 0);
       assert(alloc_stats.moved == 1);
       {
-        const AllocT& a = v.get_allocator();
-        assert(a.get_id() == test_alloc_base::moved_value);
-        assert(a.get_data() == test_alloc_base::moved_value);
-      }
-      {
-        const AllocT& a = v2.get_allocator();
-        assert(a.get_id() == 101);
-        assert(a.get_data() == 42);
+        const AllocT& a1 = v.get_allocator();
+        assert(a1.get_id() == test_alloc_base::moved_value);
+        assert(a1.get_data() == 42);
+
+        const AllocT& a2 = v2.get_allocator();
+        assert(a2.get_id() == 101);
+        assert(a2.get_data() == 42);
+
+        assert(a1 == a2);
       }
     }
 

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/move.pass.cpp
@@ -148,14 +148,15 @@ TEST_CONSTEXPR_CXX20 bool tests()
       assert(alloc_stats.copied == 0);
       assert(alloc_stats.moved == 1);
       {
-        const test_allocator<int>& a = v.get_allocator();
-        assert(a.get_id() == test_alloc_base::moved_value);
-        assert(a.get_data() == test_alloc_base::moved_value);
-      }
-      {
-        const test_allocator<int>& a = v2.get_allocator();
-        assert(a.get_id() == 101);
-        assert(a.get_data() == 42);
+        const test_allocator<int>& a1 = v.get_allocator();
+        assert(a1.get_id() == test_alloc_base::moved_value);
+        assert(a1.get_data() == 42);
+
+        const test_allocator<int>& a2 = v2.get_allocator();
+        assert(a2.get_id() == 101);
+        assert(a2.get_data() == 42);
+
+        assert(a1 == a2);
       }
     }
 

--- a/libcxx/test/support/test_allocator.h
+++ b/libcxx/test/support/test_allocator.h
@@ -125,7 +125,6 @@ public:
     }
     assert(a.data_ != test_alloc_base::destructed_value && a.id_ != test_alloc_base::destructed_value &&
            "moving from destroyed allocator");
-    a.data_ = test_alloc_base::moved_value;
     a.id_ = test_alloc_base::moved_value;
   }
 


### PR DESCRIPTION
The resolution of LWG2593 didn't require the standard library implementation to change. It merely strengthened requirements on user-defined allocator types and allowed the implementation to make stronger assumptions. The status is tentatively set to Nothing To Do.

However, `test_allocator` in libc++'s test suit needs to be fixed to conform to the strengthened requirements.

Closes #100220.