### PR TITLE
[WebAssembly] Simplify a switch-case in CFGStackify (NFC)

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrControl.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrControl.td
@@ -147,9 +147,9 @@ let isTerminator = 1, hasSideEffects = 1, isBarrier = 1, hasCtrlDep = 1,
 // usage gets low enough.
 
 // Rethrowing an exception: rethrow
-let isTerminator = 1, hasCtrlDep = 1, isBarrier = 1 in {
+let isTerminator = 1, hasCtrlDep = 1, isBarrier = 1 in
 defm RETHROW : NRI<(outs), (ins i32imm:$depth), [], "rethrow \t$depth", 0x09>;
-} // isTerminator = 1, hasCtrlDep = 1, isBarrier = 1
+// isTerminator = 1, hasCtrlDep = 1, isBarrier = 1
 // The depth argument will be computed in CFGStackify. We set it to 0 here for
 // now.
 def : Pat<(int_wasm_rethrow), (RETHROW 0)>;


### PR DESCRIPTION
This merges some `case`s using `[[fallthrough]]`, and make `DELEGATE` as a separate `case`. (Previously the reason we didn't do that was not to duplicate the code in `RewriteOperands`. But now that we've extracted it into a lambda function in #107182 we can do it.