### PR TITLE
[clang][transformer] Add `join` stencil.

### DIFF
--- a/clang/include/clang/Tooling/Transformer/Stencil.h
+++ b/clang/include/clang/Tooling/Transformer/Stencil.h
@@ -65,6 +65,15 @@ template <typename... Ts> Stencil cat(Ts &&... Parts) {
   return catVector({detail::makeStencil(std::forward<Ts>(Parts))...});
 }
 
+// Constructs the string representing the concatenation of the given \p
+// Parts, separated using \p Sep.
+Stencil joinVector(StringRef Sep, std::vector<Stencil> Parts);
+
+// Same as `cat(Parts[0], Sep, Parts[1], Sep, ...,)`.
+template <typename... Ts> Stencil join(StringRef Sep, Ts &&...Parts) {
+  return joinVector(Sep, {detail::makeStencil(std::forward<Ts>(Parts))...});
+}
+
 //
 // Functions for conveniently building stencils.
 //

--- a/clang/lib/Tooling/Transformer/Stencil.cpp
+++ b/clang/lib/Tooling/Transformer/Stencil.cpp
@@ -492,3 +492,18 @@ Stencil transformer::catVector(std::vector<Stencil> Parts) {
     return std::move(Parts[0]);
   return std::make_shared<SequenceStencil>(std::move(Parts));
 }
+
+Stencil transformer::joinVector(StringRef Sep, std::vector<Stencil> Parts) {
+  if (Parts.size() == 1)
+    return std::move(Parts[0]);
+
+  Stencil SepStencil = detail::makeStencil(Sep);
+  std::vector<Stencil> SeparatedParts;
+  SeparatedParts.reserve(2 * Parts.size() - 1);
+  SeparatedParts.push_back(std::move(Parts[0]));
+  for (size_t I = 1, E = Parts.size(); I < E; ++I) {
+    SeparatedParts.emplace_back(SepStencil);
+    SeparatedParts.push_back(std::move(Parts[I]));
+  }
+  return std::make_shared<SequenceStencil>(std::move(SeparatedParts));
+}

--- a/clang/unittests/Tooling/StencilTest.cpp
+++ b/clang/unittests/Tooling/StencilTest.cpp
@@ -769,4 +769,9 @@ TEST(StencilToStringTest, SequenceFromVector) {
                        R"repr(ifBound("x", "t", access("e", "f"))))repr";
   EXPECT_EQ(S->toString(), Expected);
 }
+
+TEST(StencilToStringTest, Join) {
+  auto S = join(" sep ", cat("a"), cat("b"), cat("c"));
+  EXPECT_EQ(S->toString(), R"repr(seq("a", " sep ", "b", " sep ", "c"))repr");
+}
 } // namespace


### PR DESCRIPTION
`join(",", a, b, c)` is the same as `cat(a, ",", b, ",", c)`.