### PR TITLE
[LLD][COFF][NFC] Use is64Bit in Baserel::getDefaultType.

### DIFF
--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -1000,16 +1000,7 @@ void BaserelChunk::writeTo(uint8_t *buf) const {
 }
 
 uint8_t Baserel::getDefaultType(llvm::COFF::MachineTypes machine) {
-  switch (machine) {
-  case AMD64:
-  case ARM64:
-    return IMAGE_REL_BASED_DIR64;
-  case I386:
-  case ARMNT:
-    return IMAGE_REL_BASED_HIGHLOW;
-  default:
-    llvm_unreachable("unknown machine type");
-  }
+  return is64Bit(machine) ? IMAGE_REL_BASED_DIR64 : IMAGE_REL_BASED_HIGHLOW;
 }
 
 MergeChunk::MergeChunk(uint32_t alignment)

--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -713,7 +713,7 @@ public:
   Baserel(uint32_t v, uint8_t ty) : rva(v), type(ty) {}
   explicit Baserel(uint32_t v, llvm::COFF::MachineTypes machine)
       : Baserel(v, getDefaultType(machine)) {}
-  uint8_t getDefaultType(llvm::COFF::MachineTypes machine);
+  static uint8_t getDefaultType(llvm::COFF::MachineTypes machine);
 
   uint32_t rva;
   uint8_t type;


### PR DESCRIPTION
In preparation for ARM64EC support. Also make it static.