### PR TITLE
[Flang][OpenMP] NFC: DataSharingProcessor cleanup

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -39,7 +39,7 @@ DataSharingProcessor::DataSharingProcessor(
     const List<Clause> &clauses, lower::pft::Evaluation &eval,
     bool shouldCollectPreDeterminedSymbols, bool useDelayedPrivatization,
     lower::SymMap *symTable)
-    : hasLastPrivateOp(false), converter(converter), semaCtx(semaCtx),
+    : converter(converter), semaCtx(semaCtx),
       firOpBuilder(converter.getFirOpBuilder()), clauses(clauses), eval(eval),
       shouldCollectPreDeterminedSymbols(shouldCollectPreDeterminedSymbols),
       useDelayedPrivatization(useDelayedPrivatization), symTable(symTable),
@@ -64,9 +64,8 @@ void DataSharingProcessor::processStep1(
 void DataSharingProcessor::processStep2(mlir::Operation *op, bool isLoop) {
   // 'sections' lastprivate is handled by genOMP()
   if (!mlir::isa<mlir::omp::SectionsOp>(op)) {
-    insPt = firOpBuilder.saveInsertionPoint();
+    mlir::OpBuilder::InsertionGuard guard(firOpBuilder);
     copyLastPrivatize(op);
-    firOpBuilder.restoreInsertionPoint(insPt);
   }
 
   if (isLoop) {
@@ -202,7 +201,6 @@ void DataSharingProcessor::collectSymbolsForPrivatization() {
                    std::get_if<omp::clause::Lastprivate>(&clause.u)) {
       const ObjectList &objects = std::get<ObjectList>(lastPrivateClause->t);
       collectOmpObjectListSymbol(objects, explicitlyPrivatizedSymbols);
-      hasLastPrivateOp = true;
     }
   }
 

--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.h
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.h
@@ -68,9 +68,7 @@ private:
                           lower::pft::Evaluation &eval) const;
   };
 
-  bool hasLastPrivateOp;
   mlir::OpBuilder::InsertPoint lastPrivIP;
-  mlir::OpBuilder::InsertPoint insPt;
   llvm::SmallVector<mlir::Value> loopIVs;
   // Symbols in private, firstprivate, and/or lastprivate clauses.
   llvm::SetVector<const semantics::Symbol *> explicitlyPrivatizedSymbols;
@@ -106,12 +104,6 @@ private:
   void collectImplicitSymbols();
   void collectPreDeterminedSymbols();
   void privatize(mlir::omp::PrivateClauseOps *clauseOps);
-  void defaultPrivatize(
-      mlir::omp::PrivateClauseOps *clauseOps,
-      llvm::SmallVectorImpl<const semantics::Symbol *> *privateSyms);
-  void implicitPrivatize(
-      mlir::omp::PrivateClauseOps *clauseOps,
-      llvm::SmallVectorImpl<const semantics::Symbol *> *privateSyms);
   void doPrivatize(const semantics::Symbol *sym,
                    mlir::omp::PrivateClauseOps *clauseOps);
   void copyLastPrivatize(mlir::Operation *op);


### PR DESCRIPTION
This patch removes unused and undefined method declarations from `DataSharingProcessor`, as well as the unused `hasLastPrivateOp` class member. The `insPt` class member is replaced by a local `InsertionGuard` in the only place it is set and used.