### PR TITLE
[libc++][modularization] Get rid of <cstddef> dependency in __datasizeof

### DIFF
--- a/libcxx/include/__type_traits/datasizeof.h
+++ b/libcxx/include/__type_traits/datasizeof.h
@@ -10,9 +10,9 @@
 #define _LIBCPP___TYPE_TRAITS_DATASIZEOF_H
 
 #include <__config>
+#include <__cstddef/size_t.h>
 #include <__type_traits/is_class.h>
 #include <__type_traits/is_final.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -37,15 +37,15 @@ struct _FirstPaddingByte {
   char __first_padding_byte_;
 };
 
-// _FirstPaddingByte<> is sometimes non-standard layout. Using `offsetof` is UB in that case, but GCC and Clang allow
-// the use as an extension.
+// _FirstPaddingByte<> is sometimes non-standard layout.
+// It is conditionally-supported to use __builtin_offsetof in that case, but GCC and Clang allow it.
 _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-offsetof")
 _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Winvalid-offsetof")
 template <class _Tp>
-inline const size_t __datasizeof_v = offsetof(_FirstPaddingByte<_Tp>, __first_padding_byte_);
+inline const size_t __datasizeof_v = __builtin_offsetof(_FirstPaddingByte<_Tp>, __first_padding_byte_);
 _LIBCPP_DIAGNOSTIC_POP
-#endif   // __has_extension(datasizeof)
+#endif // __has_extension(datasizeof)
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
All the compilers we support also provide __builtin_offsetof, so avoid using this macro and use the builtin directly instead. This allows removing a dependency on `<cstddef>`, which is heavier than we need.