### PR TITLE
[NFC][SystemZ][z/OS] Rename autoconversion-related functions to be less generic

### DIFF
--- a/clang/tools/c-arcmt-test/c-arcmt-test.c
+++ b/clang/tools/c-arcmt-test/c-arcmt-test.c
@@ -109,10 +109,10 @@ static void flush_atexit(void) {
 
 int main(int argc, const char **argv) {
 #ifdef __MVS__
-  if (enableAutoConversion(fileno(stdout)) == -1)
+  if (enablezOSAutoConversion(fileno(stdout)) == -1)
     fprintf(stderr, "Setting conversion on stdout failed\n");
 
-  if (enableAutoConversion(fileno(stderr)) == -1)
+  if (enablezOSAutoConversion(fileno(stderr)) == -1)
     fprintf(stderr, "Setting conversion on stderr failed\n");
 #endif
 

--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -5180,10 +5180,10 @@ int main(int argc, const char **argv) {
   thread_info client_data;
 
 #ifdef __MVS__
-  if (enableAutoConversion(fileno(stdout)) == -1)
+  if (enablezOSAutoConversion(fileno(stdout)) == -1)
     fprintf(stderr, "Setting conversion on stdout failed\n");
 
-  if (enableAutoConversion(fileno(stderr)) == -1)
+  if (enablezOSAutoConversion(fileno(stderr)) == -1)
     fprintf(stderr, "Setting conversion on stderr failed\n");
 #endif
 

--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -27,9 +27,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-int enableAutoConversion(int FD);
-int disableAutoConversion(int FD);
-int restoreStdHandleAutoConversion(int FD);
+int enablezOSAutoConversion(int FD);
+int disablezOSAutoConversion(int FD);
+int restorezOSStdHandleAutoConversion(int FD);
 #ifdef __cplusplus
 }
 #endif // __cplusplus
@@ -39,18 +39,18 @@ namespace llvm {
 
 /// \brief Disable the z/OS enhanced ASCII auto-conversion for the file
 /// descriptor.
-std::error_code disableAutoConversion(int FD);
+std::error_code disablezOSAutoConversion(int FD);
 
 /// \brief Query the z/OS enhanced ASCII auto-conversion status of a file
 /// descriptor and force the conversion if the file is not tagged with a
 /// codepage.
-std::error_code enableAutoConversion(int FD);
+std::error_code enablezOSAutoConversion(int FD);
 
 /// Restore the z/OS enhanced ASCII auto-conversion for the std handle.
-std::error_code restoreStdHandleAutoConversion(int FD);
+std::error_code restorezOSStdHandleAutoConversion(int FD);
 
 /// \brief Set the tag information for a file descriptor.
-std::error_code setFileTag(int FD, int CCSID, bool Text);
+std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
 
 } // namespace llvm
 #endif // __cplusplus

--- a/llvm/lib/Support/AutoConvert.cpp
+++ b/llvm/lib/Support/AutoConvert.cpp
@@ -22,7 +22,7 @@
 
 static int savedStdHandleAutoConversionMode[3] = {-1, -1, -1};
 
-int disableAutoConversion(int FD) {
+int disablezOSAutoConversion(int FD) {
   static const struct f_cnvrt Convert = {
       SETCVTOFF, // cvtcmd
       0,         // pccsid
@@ -32,7 +32,7 @@ int disableAutoConversion(int FD) {
   return fcntl(FD, F_CONTROL_CVT, &Convert);
 }
 
-int restoreStdHandleAutoConversion(int FD) {
+int restorezOSStdHandleAutoConversion(int FD) {
   assert(FD == STDIN_FILENO || FD == STDOUT_FILENO || FD == STDERR_FILENO);
   if (savedStdHandleAutoConversionMode[FD] == -1)
     return 0;
@@ -44,7 +44,7 @@ int restoreStdHandleAutoConversion(int FD) {
   return (fcntl(FD, F_CONTROL_CVT, &Cvt));
 }
 
-int enableAutoConversion(int FD) {
+int enablezOSAutoConversion(int FD) {
   struct f_cnvrt Query = {
       QUERYCVT, // cvtcmd
       0,        // pccsid
@@ -81,28 +81,28 @@ int enableAutoConversion(int FD) {
   return fcntl(FD, F_CONTROL_CVT, &Query);
 }
 
-std::error_code llvm::disableAutoConversion(int FD) {
-  if (::disableAutoConversion(FD) == -1)
+std::error_code llvm::disablezOSAutoConversion(int FD) {
+  if (::disablezOSAutoConversion(FD) == -1)
     return errnoAsErrorCode();
 
   return std::error_code();
 }
 
-std::error_code llvm::enableAutoConversion(int FD) {
-  if (::enableAutoConversion(FD) == -1)
+std::error_code llvm::enablezOSAutoConversion(int FD) {
+  if (::enablezOSAutoConversion(FD) == -1)
     return errnoAsErrorCode();
 
   return std::error_code();
 }
 
-std::error_code llvm::restoreStdHandleAutoConversion(int FD) {
-  if (::restoreStdHandleAutoConversion(FD) == -1)
+std::error_code llvm::restorezOSStdHandleAutoConversion(int FD) {
+  if (::restorezOSStdHandleAutoConversion(FD) == -1)
     return errnoAsErrorCode();
 
   return std::error_code();
 }
 
-std::error_code llvm::setFileTag(int FD, int CCSID, bool Text) {
+std::error_code llvm::setzOSFileTag(int FD, int CCSID, bool Text) {
   assert((!Text || (CCSID != FT_UNTAGGED && CCSID != FT_BINARY)) &&
          "FT_UNTAGGED and FT_BINARY are not allowed for text files");
   struct file_tag Tag;

--- a/llvm/lib/Support/InitLLVM.cpp
+++ b/llvm/lib/Support/InitLLVM.cpp
@@ -27,9 +27,9 @@ void CleanupStdHandles(void *Cookie) {
   llvm::raw_ostream *Outs = &llvm::outs(), *Errs = &llvm::errs();
   Outs->flush();
   Errs->flush();
-  llvm::restoreStdHandleAutoConversion(STDIN_FILENO);
-  llvm::restoreStdHandleAutoConversion(STDOUT_FILENO);
-  llvm::restoreStdHandleAutoConversion(STDERR_FILENO);
+  llvm::restorezOSStdHandleAutoConversion(STDIN_FILENO);
+  llvm::restorezOSStdHandleAutoConversion(STDOUT_FILENO);
+  llvm::restorezOSStdHandleAutoConversion(STDERR_FILENO);
 }
 #endif
 
@@ -70,8 +70,8 @@ InitLLVM::InitLLVM(int &Argc, const char **&Argv,
 
   // If turning on conversion for stderr fails then the error message
   // may be garbled. There is no solution to this problem.
-  ExitOnErr(errorCodeToError(llvm::enableAutoConversion(STDERR_FILENO)));
-  ExitOnErr(errorCodeToError(llvm::enableAutoConversion(STDOUT_FILENO)));
+  ExitOnErr(errorCodeToError(llvm::enablezOSAutoConversion(STDERR_FILENO)));
+  ExitOnErr(errorCodeToError(llvm::enablezOSAutoConversion(STDOUT_FILENO)));
 #endif
 
 #ifdef _WIN32

--- a/llvm/lib/Support/MemoryBuffer.cpp
+++ b/llvm/lib/Support/MemoryBuffer.cpp
@@ -505,7 +505,7 @@ getOpenFileImpl(sys::fs::file_t FD, const Twine &Filename, uint64_t FileSize,
 
 #ifdef __MVS__
   // Set codepage auto-conversion for z/OS.
-  if (auto EC = llvm::enableAutoConversion(FD))
+  if (auto EC = llvm::enablezOSAutoConversion(FD))
     return EC;
 #endif
 

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1096,17 +1096,17 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
                     !Stat.st_tag.ft_txtflag && !Stat.st_tag.ft_ccsid &&
                     Stat.st_size == 0;
     if (Flags & OF_Text) {
-      if (auto EC = llvm::enableAutoConversion(ResultFD))
+      if (auto EC = llvm::enablezOSAutoConversion(ResultFD))
         return EC;
       if (DoSetTag) {
-        if (auto EC = llvm::setFileTag(ResultFD, CCSID_IBM_1047, true))
+        if (auto EC = llvm::setzOSFileTag(ResultFD, CCSID_IBM_1047, true))
           return EC;
       }
     } else {
-      if (auto EC = llvm::disableAutoConversion(ResultFD))
+      if (auto EC = llvm::disablezOSAutoConversion(ResultFD))
         return EC;
       if (DoSetTag) {
-        if (auto EC = llvm::setFileTag(ResultFD, FT_BINARY, false))
+        if (auto EC = llvm::setzOSFileTag(ResultFD, FT_BINARY, false))
           return EC;
       }
     }

--- a/llvm/lib/Support/Unix/Program.inc
+++ b/llvm/lib/Support/Unix/Program.inc
@@ -533,7 +533,7 @@ std::error_code llvm::sys::ChangeStdoutMode(fs::OpenFlags Flags) {
 
 std::error_code llvm::sys::ChangeStdinToBinary() {
 #ifdef __MVS__
-  return disableAutoConversion(STDIN_FILENO);
+  return disablezOSAutoConversion(STDIN_FILENO);
 #else
   // Do nothing, as Unix doesn't differentiate between text and binary.
   return std::error_code();

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -894,7 +894,7 @@ raw_fd_ostream &llvm::outs() {
   // Set buffer settings to model stdout behavior.
   std::error_code EC;
 #ifdef __MVS__
-  EC = enableAutoConversion(STDOUT_FILENO);
+  EC = enablezOSAutoConversion(STDOUT_FILENO);
   assert(!EC);
 #endif
   static raw_fd_ostream S("-", EC, sys::fs::OF_None);
@@ -905,7 +905,7 @@ raw_fd_ostream &llvm::outs() {
 raw_fd_ostream &llvm::errs() {
   // Set standard error to be unbuffered.
 #ifdef __MVS__
-  std::error_code EC = enableAutoConversion(STDERR_FILENO);
+  std::error_code EC = enablezOSAutoConversion(STDERR_FILENO);
   assert(!EC);
 #endif
   static raw_fd_ostream S(STDERR_FILENO, false, true);

--- a/llvm/utils/count/count.c
+++ b/llvm/utils/count/count.c
@@ -12,10 +12,10 @@
 
 int main(int argc, char **argv) {
 #ifdef __MVS__
-  if (enableAutoConversion(fileno(stdin)) == -1)
+  if (enablezOSAutoConversion(fileno(stdin)) == -1)
     fprintf(stderr, "Setting conversion on stdin failed\n");
 
-  if (enableAutoConversion(fileno(stderr)) == -1)
+  if (enablezOSAutoConversion(fileno(stderr)) == -1)
     fprintf(stdout, "Setting conversion on stderr failed\n");
 #endif
   size_t Count, NumLines, NumRead;


### PR DESCRIPTION
This patch renames the functions in AutoConvert.h/cpp to have a less generic name because they are z/OS specific.