### PR TITLE
[libc++][modules] Introduce a forward-declaration for std::byte

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -418,6 +418,7 @@ set(files
   __functional/weak_result_type.h
   __fwd/array.h
   __fwd/bit_reference.h
+  __fwd/byte.h
   __fwd/complex.h
   __fwd/deque.h
   __fwd/format.h

--- a/libcxx/include/__cstddef/byte.h
+++ b/libcxx/include/__cstddef/byte.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___CSTDDEF_BYTE_H
 
 #include <__config>
+#include <__fwd/byte.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_integral.h>
 

--- a/libcxx/include/__fwd/byte.h
+++ b/libcxx/include/__fwd/byte.h
@@ -1,0 +1,26 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___FWD_BYTE_H
+#define _LIBCPP___FWD_BYTE_H
+
+#include <__config>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_STD_VER >= 17
+namespace std { // purposefully not versioned
+
+enum class byte : unsigned char;
+
+} // namespace std
+#endif // _LIBCPP_STD_VER >= 17
+
+#endif // _LIBCPP___FWD_BYTE_H

--- a/libcxx/include/__type_traits/is_trivially_lexicographically_comparable.h
+++ b/libcxx/include/__type_traits/is_trivially_lexicographically_comparable.h
@@ -10,13 +10,13 @@
 #define _LIBCPP___TYPE_TRAITS_IS_TRIVIALLY_LEXICOGRAPHICALLY_COMPARABLE_H
 
 #include <__config>
+#include <__fwd/byte.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_unsigned.h>
 #include <__type_traits/remove_cv.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -636,6 +636,9 @@ module std_private_bit_reference     [system] {
 module std_private_fwd_bit_reference [system] {
   header "__fwd/bit_reference.h"
 }
+module std_private_fwd_byte [system] {
+  header "__fwd/byte.h"
+}
 module std_private_config            [system] {
   textual header "__config"
   textual header "__configuration/abi.h"

--- a/libcxx/utils/generate_iwyu_mapping.py
+++ b/libcxx/utils/generate_iwyu_mapping.py
@@ -40,6 +40,8 @@ def IWYU_mapping(header: str) -> typing.Optional[typing.List[str]]:
         return ["atomic", "mutex", "semaphore", "thread"]
     elif header == "__tree":
         return ["map", "set"]
+    elif header == "__fwd/byte.h":
+        return ["cstddef"]
     elif header == "__fwd/pair.h":
         return ["utility"]
     elif header == "__fwd/subrange.h":


### PR DESCRIPTION
We need a forward-declaration so that we can know about std::byte from some type traits without having to include std::byte's definition, which (circularly) depends back on type traits.