### PR TITLE
[clang-tidy][NFC] remove autosar link in documents

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
@@ -7,8 +7,7 @@ This check implements detection of local variables which could be declared as
 ``const`` but are not. Declaring variables as ``const`` is required or recommended by many
 coding guidelines, such as:
 `ES.25 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es25-declare-an-object-const-or-constexpr-unless-you-want-to-modify-its-value-later-on>`_
-from the C++ Core Guidelines and `AUTOSAR C++14 Rule A7-1-1 (6.7.1 Specifiers)
-<https://www.autosar.org/fileadmin/standards/R22-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf>`_.
+from the C++ Core Guidelines.
 
 Please note that this check's analysis is type-based only. Variables that are not modified
 but used to create a non-const handle that might escape the scope are not diagnosed

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unconventional-assign-operator.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unconventional-assign-operator.rst
@@ -13,6 +13,3 @@ types and definitions with good return type but wrong ``return`` statements.
     type (e.g. ``int``).
   * Private and deleted operators are ignored.
   * The operator must always return ``*this``.
-
-This check implements `AUTOSAR C++14 Rule A13-2-1
-<https://www.autosar.org/fileadmin/standards/R22-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-nested-conditional-operator.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-nested-conditional-operator.rst
@@ -16,6 +16,3 @@ Examples:
   int NestInConditional = (condition1 ? true1 : false1) ? true2 : false2;
   int NestInTrue = condition1 ? (condition2 ? true1 : false1) : false2;
   int NestInFalse = condition1 ? true1 : condition2 ? true2 : false1;
-
-This check implements part of `AUTOSAR C++14 Rule A5-16-1
-<https://www.autosar.org/fileadmin/standards/R22-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf>`_.


### PR DESCRIPTION
As discussion in https://discourse.llvm.org/t/clang-tidy-rfc-add-autosar-c-14-clang-tidy-module/59223/12. We should not link clang-tidy check with AUTOSAR rules. 