### PR TITLE
[MC] Introduce ability to add target specific AsmStreamer

### DIFF
--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -208,6 +208,10 @@ public:
   using AsmTargetStreamerCtorTy =
       MCTargetStreamer *(*)(MCStreamer &S, formatted_raw_ostream &OS,
                             MCInstPrinter *InstPrint);
+  using AsmStreamerCtorTy =
+      MCStreamer *(*)(MCContext &Ctx, std::unique_ptr<formatted_raw_ostream> OS,
+                      MCInstPrinter *IP, std::unique_ptr<MCCodeEmitter> CE,
+                      std::unique_ptr<MCAsmBackend> TAB);
   using ObjectTargetStreamerCtorTy = MCTargetStreamer *(*)(
       MCStreamer &S, const MCSubtargetInfo &STI);
   using MCRelocationInfoCtorTy = MCRelocationInfo *(*)(const Triple &TT,
@@ -315,6 +319,10 @@ private:
   /// Construction function for this target's asm TargetStreamer, if
   /// registered (default = nullptr).
   AsmTargetStreamerCtorTy AsmTargetStreamerCtorFn = nullptr;
+
+  /// Construction function for this target's AsmStreamer, if
+  /// registered (default = nullptr).
+  AsmStreamerCtorTy AsmStreamerCtorFn = nullptr;
 
   /// Construction function for this target's obj TargetStreamer, if
   /// registered (default = nullptr).
@@ -925,6 +933,10 @@ struct TargetRegistry {
   static void RegisterNullTargetStreamer(Target &T,
                                          Target::NullTargetStreamerCtorTy Fn) {
     T.NullTargetStreamerCtorFn = Fn;
+  }
+
+  static void RegisterAsmStreamer(Target &T, Target::AsmStreamerCtorTy Fn) {
+    T.AsmStreamerCtorFn = Fn;
   }
 
   static void RegisterAsmTargetStreamer(Target &T,

--- a/llvm/lib/MC/TargetRegistry.cpp
+++ b/llvm/lib/MC/TargetRegistry.cpp
@@ -93,8 +93,14 @@ MCStreamer *Target::createAsmStreamer(MCContext &Ctx,
                                       std::unique_ptr<MCCodeEmitter> CE,
                                       std::unique_ptr<MCAsmBackend> TAB) const {
   formatted_raw_ostream &OSRef = *OS;
-  MCStreamer *S = llvm::createAsmStreamer(Ctx, std::move(OS), IP,
-                                          std::move(CE), std::move(TAB));
+  MCStreamer *S;
+  if (AsmStreamerCtorFn)
+    S = AsmStreamerCtorFn(Ctx, std::move(OS), IP, std::move(CE),
+                          std::move(TAB));
+  else
+    S = llvm::createAsmStreamer(Ctx, std::move(OS), IP, std::move(CE),
+                                std::move(TAB));
+
   createAsmTargetStreamer(*S, OSRef, IP);
   return S;
 }


### PR DESCRIPTION
Currently the AsmStreamer class `MCAsmStreamer.cpp` only outputs GNU assembly syntax. However, we wish to add additional AsmStreamer classes for specific targets that can output alternative assembly syntaxes (the immediate use case is HLASM syntax for z/OS).

This is the first patch to add this ability by utilizing the TargetRegistry functions. 