### PR TITLE
[flang] Silence warning in module file

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -4027,7 +4027,8 @@ bool ExpressionAnalyzer::CheckIntrinsicKind(
     return true;
   } else if (foldingContext_.targetCharacteristics().CanSupportType(
                  category, kind)) {
-    if (context_.ShouldWarn(common::UsageWarning::BadTypeForTarget)) {
+    if (context_.ShouldWarn(common::UsageWarning::BadTypeForTarget) &&
+        !context_.IsInModuleFile(GetContextualMessages().at())) {
       Say("%s(KIND=%jd) is not an enabled type for this target"_warn_en_US,
           ToUpperCase(EnumToString(category)), kind);
     }


### PR DESCRIPTION
Most warnings should be silenced when processing the content of a module file, since the warning should have also appeared when the module file was generated.  The case of an intrinsic type kind not being supported for a target wasn't being suppressed; fix.

Fixes https://github.com/llvm/llvm-project/issues/107337.