### PR TITLE
[libc++] Remove obsolete header restrictions for _LIBCPP_HAS_NO_THREADS

### DIFF
--- a/libcxx/include/__std_clang_module
+++ b/libcxx/include/__std_clang_module
@@ -33,9 +33,7 @@
 #if !defined(_LIBCPP_HAS_NO_ATOMIC_HEADER)
 #  include <atomic>
 #endif
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <barrier>
-#endif
+#include <barrier>
 #include <bit>
 #include <bitset>
 #include <cassert>
@@ -101,9 +99,7 @@
 #  include <fstream>
 #endif
 #include <functional>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <future>
-#endif
+#include <future>
 #include <initializer_list>
 #include <inttypes.h>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
@@ -120,9 +116,7 @@
 #  include <istream>
 #endif
 #include <iterator>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <latch>
-#endif
+#include <latch>
 #include <limits>
 #include <list>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
@@ -153,13 +147,9 @@
 #  include <regex>
 #endif
 #include <scoped_allocator>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <semaphore>
-#endif
+#include <semaphore>
 #include <set>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <shared_mutex>
-#endif
+#include <shared_mutex>
 #include <source_location>
 #include <span>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
@@ -175,9 +165,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <stop_token>
-#endif
+#include <stop_token>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 #  include <streambuf>
 #endif
@@ -192,9 +180,7 @@
 #endif
 #include <system_error>
 #include <tgmath.h>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <thread>
-#endif
+#include <thread>
 #include <tuple>
 #include <type_traits>
 #include <typeindex>

--- a/libcxx/modules/std.cppm.in
+++ b/libcxx/modules/std.cppm.in
@@ -23,9 +23,7 @@ module;
 #if !defined(_LIBCPP_HAS_NO_ATOMIC_HEADER)
 #  include <atomic>
 #endif
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <barrier>
-#endif
+#include <barrier>
 #include <bit>
 #include <bitset>
 #include <cassert>
@@ -76,9 +74,7 @@ module;
 #  include <fstream>
 #endif
 #include <functional>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <future>
-#endif
+#include <future>
 #include <initializer_list>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 #  include <iomanip>
@@ -94,9 +90,7 @@ module;
 #  include <istream>
 #endif
 #include <iterator>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <latch>
-#endif
+#include <latch>
 #include <limits>
 #include <list>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
@@ -123,13 +117,9 @@ module;
 #  include <regex>
 #endif
 #include <scoped_allocator>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <semaphore>
-#endif
+#include <semaphore>
 #include <set>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <shared_mutex>
-#endif
+#include <shared_mutex>
 #include <source_location>
 #include <span>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
@@ -137,9 +127,7 @@ module;
 #endif
 #include <stack>
 #include <stdexcept>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <stop_token>
-#endif
+#include <stop_token>
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 #  include <streambuf>
 #endif
@@ -152,9 +140,7 @@ module;
 #  include <syncstream>
 #endif
 #include <system_error>
-#if !defined(_LIBCPP_HAS_NO_THREADS)
-#  include <thread>
-#endif
+#include <thread>
 #include <tuple>
 #include <type_traits>
 #include <typeindex>

--- a/libcxx/utils/libcxx/header_information.py
+++ b/libcxx/utils/libcxx/header_information.py
@@ -32,15 +32,6 @@ header_restrictions = {
     "syncstream": "!defined(_LIBCPP_HAS_NO_LOCALIZATION)",
 
     # headers with #error directives
-    "barrier": "!defined(_LIBCPP_HAS_NO_THREADS)",
-    "future": "!defined(_LIBCPP_HAS_NO_THREADS)",
-    "latch": "!defined(_LIBCPP_HAS_NO_THREADS)",
-    "semaphore": "!defined(_LIBCPP_HAS_NO_THREADS)",
-    "shared_mutex": "!defined(_LIBCPP_HAS_NO_THREADS)",
-    "stop_token": "!defined(_LIBCPP_HAS_NO_THREADS)",
-    "thread": "!defined(_LIBCPP_HAS_NO_THREADS)",
-
-    # headers with #error directives
     "wchar.h": "!defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)",
     "wctype.h": "!defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)",
     # transitive includers of the above headers


### PR DESCRIPTION
The _LIBCPP_HAS_NO_THREADS carve-out does not result in hard errors
anymore, but the patch that changed that forgot to update the header
restrictions we use to auto-generate several files.

We can also remove the restrictions for the no-localization build and
no-wide-characters, but doing it is less straightforward so I'm leaving
it out of this patch.