### PR TITLE
[OpenMP] LIBOMPTARGET_DEVICE_ARCHITECTURES requires semicolons

### DIFF
--- a/openmp/docs/SupportAndFAQ.rst
+++ b/openmp/docs/SupportAndFAQ.rst
@@ -81,9 +81,9 @@ The Cuda SDK is required on the machine that will execute the openmp application
 If your build machine is not the target machine or automatic detection of the
 available GPUs failed, you should also set:
 
-- ``LIBOMPTARGET_DEVICE_ARCHITECTURES=sm_<xy>,...`` where ``<xy>`` is the numeric 
+- ``LIBOMPTARGET_DEVICE_ARCHITECTURES='sm_<xy>;...'`` where ``<xy>`` is the numeric
   compute capability of your GPU. For instance, set 
-  ``LIBOMPTARGET_DEVICE_ARCHITECTURES=sm_70,sm_80`` to target the Nvidia Volta 
+  ``LIBOMPTARGET_DEVICE_ARCHITECTURES='sm_70;sm_80'`` to target the Nvidia Volta
   and Ampere architectures. 
 
 
@@ -141,9 +141,9 @@ With those libraries installed, then LLVM build and installed, try:
 If your build machine is not the target machine or automatic detection of the
 available GPUs failed, you should also set:
 
-- ``LIBOMPTARGET_DEVICE_ARCHITECTURES=gfx<xyz>,...`` where ``<xyz>`` is the 
+- ``LIBOMPTARGET_DEVICE_ARCHITECTURES='gfx<xyz>;...'`` where ``<xyz>`` is the
   shader core instruction set architecture. For instance, set 
-  ``LIBOMPTARGET_DEVICE_ARCHITECTURES=gfx906,gfx90a`` to target AMD GCN5 
+  ``LIBOMPTARGET_DEVICE_ARCHITECTURES='gfx906;gfx90a'`` to target AMD GCN5
   and CDNA2 devices. 
 
 Q: What are the known limitations of OpenMP AMDGPU offload?


### PR DESCRIPTION
If I use commas to delimit architectures in `LIBOMPTARGET_DEVICE_ARCHITECTURES`, cmake for the runtimes complains:

```
Unknown GPU architecture 'sm_70,sm_80,sm_90'
```

Semicolons are required instead.