### PR TITLE
[flang][Driver] Support --no-warnings option

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5978,7 +5978,9 @@ def _no_line_commands : Flag<["--"], "no-line-commands">, Alias<P>;
 def _no_standard_includes : Flag<["--"], "no-standard-includes">, Alias<nostdinc>;
 def _no_standard_libraries : Flag<["--"], "no-standard-libraries">, Alias<nostdlib>;
 def _no_undefined : Flag<["--"], "no-undefined">, Flags<[LinkerInput]>;
-def _no_warnings : Flag<["--"], "no-warnings">, Alias<w>;
+def _no_warnings : Flag<["--"], "no-warnings">,
+  Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
+  Alias<w>;
 def _optimize_EQ : Joined<["--"], "optimize=">, Alias<O>;
 def _optimize : Flag<["--"], "optimize">, Alias<O>;
 def _output_class_directory_EQ : Joined<["--"], "output-class-directory=">, Alias<foutput_class_dir_EQ>;

--- a/flang/test/Driver/w-option.f90
+++ b/flang/test/Driver/w-option.f90
@@ -4,6 +4,9 @@
 ! Test that the warnings are not generated with `-w` option.
 ! RUN: %flang -c -w %s 2>&1 | FileCheck --allow-empty %s -check-prefix=WARNING
 
+! Test that the warnings are not generated with `--no-warnings` option.
+! RUN: %flang -c --no-warnings %s 2>&1 | FileCheck --allow-empty %s -check-prefix=WARNING
+
 ! Test that warnings are portability messages are generated.
 ! RUN: %flang -c -pedantic %s 2>&1 | FileCheck %s -check-prefixes=DEFAULT,PORTABILITY
 


### PR DESCRIPTION
Because of the way visibility is implemented in Options.td, options that are aliases do not inherit the visibility of the option being aliased. Therefore, explicitly set the visibility of the alias to be the same as the aliased option.

This partially addresses https://github.com/llvm/llvm-project/issues/89888