### PR TITLE
[ADT] Declare replaceAllocation in SmallVector.cpp (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -74,19 +74,6 @@ protected:
   /// This function will report a fatal error if it cannot increase capacity.
   void grow_pod(void *FirstEl, size_t MinSize, size_t TSize);
 
-  /// If vector was first created with capacity 0, getFirstEl() points to the
-  /// memory right after, an area unallocated. If a subsequent allocation,
-  /// that grows the vector, happens to return the same pointer as getFirstEl(),
-  /// get a new allocation, otherwise isSmall() will falsely return that no
-  /// allocation was done (true) and the memory will not be freed in the
-  /// destructor. If a VSize is given (vector size), also copy that many
-  /// elements to the new allocation - used if realloca fails to increase
-  /// space, and happens to allocate precisely at BeginX.
-  /// This is unlikely to be called often, but resolves a memory leak when the
-  /// situation does occur.
-  void *replaceAllocation(void *NewElts, size_t TSize, size_t NewCapacity,
-                          size_t VSize = 0);
-
 public:
   size_t size() const { return Size; }
   size_t capacity() const { return Capacity; }


### PR DESCRIPTION
This patch changes replaceAllocation to a static function while moving
the declaration to SmallVector.cpp.  Note that:

- replaceAllocation is used only within SmallVector.cpp.
- replaceAllocation doesn't access any class members.
