### PR TITLE
[lsp] Fix format string in Reply

### DIFF
--- a/mlir/lib/Tools/lsp-server-support/Transport.cpp
+++ b/mlir/lib/Tools/lsp-server-support/Transport.cpp
@@ -75,7 +75,7 @@ void Reply::operator()(llvm::Expected<llvm::json::Value> reply) {
     transport->reply(std::move(id), std::move(reply));
   } else {
     llvm::Error error = reply.takeError();
-    Logger::info("--> reply:{0}({1})", method, id, error);
+    Logger::info("--> reply:{0}({1}): {2}", method, id, error);
     transport->reply(std::move(id), std::move(error));
   }
 }


### PR DESCRIPTION
PR #105745 requires that `formatv` calls have the correct number of
arguments. This call to `Logger::info` was incorrect.
