### PR TITLE
[lldb-dap] Add feature to remember last non-empty expression.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -64,6 +64,8 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         # Empty expression should equate to the previous expression.
         if context == "repl":
             self.assertEvaluate("", "20")
+        else:
+            self.assertEvaluateFailure("")
         self.assertEvaluate("var2", "21")
         if context == "repl":
             self.assertEvaluate("", "21")

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -63,11 +63,11 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         self.assertEvaluate("var1", "20")
         # Empty expression should equate to the previous expression.
         if context == "repl":
-          self.assertEvaluate("", "20")
+            self.assertEvaluate("", "20")
         self.assertEvaluate("var2", "21")
         if context == "repl":
-          self.assertEvaluate("", "21")
-          self.assertEvaluate("", "21")
+            self.assertEvaluate("", "21")
+            self.assertEvaluate("", "21")
         self.assertEvaluate("static_int", "42")
         self.assertEvaluate("non_static_int", "43")
         self.assertEvaluate("struct1.foo", "15")
@@ -200,12 +200,12 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
 
         # Test memory read, especially with 'empty' repeat commands.
         if context == "repl":
-          self.continue_to_next_stop()
-          self.assertEvaluate("memory read -c 1 &my_ints", ".* 05 .*\n")
-          self.assertEvaluate("", ".* 0a .*\n")
-          self.assertEvaluate("", ".* 0f .*\n")
-          self.assertEvaluate("", ".* 14 .*\n")
-          self.assertEvaluate("", ".* 19 .*\n")
+            self.continue_to_next_stop()
+            self.assertEvaluate("memory read -c 1 &my_ints", ".* 05 .*\n")
+            self.assertEvaluate("", ".* 0a .*\n")
+            self.assertEvaluate("", ".* 0f .*\n")
+            self.assertEvaluate("", ".* 14 .*\n")
+            self.assertEvaluate("", ".* 19 .*\n")
 
     @skipIfWindows
     def test_generic_evaluate_expressions(self):

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -201,10 +201,11 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         # Test memory read, especially with 'empty' repeat commands.
         if context == "repl":
           self.continue_to_next_stop()
-          self.assertEvaluate("memory read &my_ints",
-                              ".*00 00 00 00 02 00 00 00 04 00 00 00 06 00 00 00.*\n.*08 00 00 00 0a 00 00 00 0c 00 00 00 0e 00 00 00.*\n")
-          self.assertEvaluate("",
-                              ".*10 00 00 00 12 00 00 00 14 00 00 00 16 00 00 00.*\n.*18 00 00 00 1a 00 00 00 1c 00 00 00.*\n")
+          self.assertEvaluate("memory read -c 1 &my_ints", ".* 05 .*\n")
+          self.assertEvaluate("", ".* 0a .*\n")
+          self.assertEvaluate("", ".* 0f .*\n")
+          self.assertEvaluate("", ".* 14 .*\n")
+          self.assertEvaluate("", ".* 19 .*\n")
 
     @skipIfWindows
     def test_generic_evaluate_expressions(self):

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -62,10 +62,10 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         # Expressions at breakpoint 1, which is in main
         self.assertEvaluate("var1", "20")
         # Empty expression should equate to the previous expression.
-        if context == "variable":
+        if context == "repl":
           self.assertEvaluate("", "20")
         self.assertEvaluate("var2", "21")
-        if context == "variable":
+        if context == "repl":
           self.assertEvaluate("", "21")
           self.assertEvaluate("", "21")
         self.assertEvaluate("static_int", "42")

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -54,6 +54,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
                 line_number(source, "// breakpoint 5"),
                 line_number(source, "// breakpoint 6"),
                 line_number(source, "// breakpoint 7"),
+                line_number(source, "// breakpoint 8"),
             ],
         )
         self.continue_to_next_stop()
@@ -61,9 +62,12 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         # Expressions at breakpoint 1, which is in main
         self.assertEvaluate("var1", "20")
         # Empty expression should equate to the previous expression.
-        self.assertEvaluate("", "20")
+        if context == "variable":
+          self.assertEvaluate("", "20")
         self.assertEvaluate("var2", "21")
-        self.assertEvaluate("", "21")
+        if context == "variable":
+          self.assertEvaluate("", "21")
+          self.assertEvaluate("", "21")
         self.assertEvaluate("static_int", "42")
         self.assertEvaluate("non_static_int", "43")
         self.assertEvaluate("struct1.foo", "15")
@@ -193,6 +197,14 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         self.assertEvaluate("my_bool_vec", "size=1")
         self.continue_to_next_stop()
         self.assertEvaluate("my_bool_vec", "size=2")
+
+        # Test memory read, especially with 'empty' repeat commands.
+        if context == "repl":
+          self.continue_to_next_stop()
+          self.assertEvaluate("memory read &my_ints",
+                              ".*00 00 00 00 02 00 00 00 04 00 00 00 06 00 00 00.*\n.*08 00 00 00 0a 00 00 00 0c 00 00 00 0e 00 00 00.*\n")
+          self.assertEvaluate("",
+                              ".*10 00 00 00 12 00 00 00 14 00 00 00 16 00 00 00.*\n.*18 00 00 00 1a 00 00 00 1c 00 00 00.*\n")
 
     @skipIfWindows
     def test_generic_evaluate_expressions(self):

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -60,7 +60,10 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
 
         # Expressions at breakpoint 1, which is in main
         self.assertEvaluate("var1", "20")
+        # Empty expression should equate to the previous expression.
+        self.assertEvaluate("", "20")
         self.assertEvaluate("var2", "21")
+        self.assertEvaluate("", "21")
         self.assertEvaluate("static_int", "42")
         self.assertEvaluate("non_static_int", "43")
         self.assertEvaluate("struct1.foo", "15")

--- a/lldb/test/API/tools/lldb-dap/evaluate/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/evaluate/main.cpp
@@ -45,5 +45,6 @@ int main(int argc, char const *argv[]) {
   my_bool_vec.push_back(false); // breakpoint 6
   my_bool_vec.push_back(true);  // breakpoint 7
 
-  return 0;
+  int my_ints[] = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28};
+  return my_ints[0]; // breakpoint 8
 }

--- a/lldb/test/API/tools/lldb-dap/evaluate/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/evaluate/main.cpp
@@ -1,5 +1,6 @@
 #include "foo.h"
 
+#include <cstdint>
 #include <map>
 #include <vector>
 
@@ -45,6 +46,6 @@ int main(int argc, char const *argv[]) {
   my_bool_vec.push_back(false); // breakpoint 6
   my_bool_vec.push_back(true);  // breakpoint 7
 
-  int my_ints[] = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28};
-  return my_ints[0]; // breakpoint 8
+  uint8_t my_ints[] = {5, 10, 15, 20, 25, 30};
+  return 0; // breakpoint 8
 }

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -205,7 +205,18 @@ struct DAP {
   std::string command_escape_prefix = "`";
   lldb::SBFormat frame_format;
   lldb::SBFormat thread_format;
-  std::string last_nonempty_expression;
+  // The next two fields are for allowing empty expressions (user just hits
+  // 'return') to repeat the last non-empty expression. last_expression_context
+  // indicates whether the last non-empty expression was for a variable or for
+  // a command, as we treat the two cases differently: empty commands get
+  // passed to the CommandInterpreter, to handle in the usual manner; empty
+  // variable expressions are replaced by the last nonempty expression, which
+  // was a variable expression (last_expression_context says so).
+  // last_nonempty_var_expression is either empty, if the last expression was
+  // a command; or it contains the last nonempty expression, which was for a
+  // variable evaulation.
+  ExpressionContext last_expression_context;
+  std::string last_nonempty_var_expression;
 
   DAP();
   ~DAP();

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -205,17 +205,11 @@ struct DAP {
   std::string command_escape_prefix = "`";
   lldb::SBFormat frame_format;
   lldb::SBFormat thread_format;
-  // The next two fields are for allowing empty expressions (user just hits
-  // 'return') to repeat the last non-empty expression. last_expression_context
-  // indicates whether the last non-empty expression was for a variable or for
-  // a command, as we treat the two cases differently: empty commands get
-  // passed to the CommandInterpreter, to handle in the usual manner; empty
-  // variable expressions are replaced by the last nonempty expression, which
-  // was a variable expression (last_expression_context says so).
-  // last_nonempty_var_expression is either empty, if the last expression was
-  // a command; or it contains the last nonempty expression, which was for a
-  // variable evaulation.
-  ExpressionContext last_expression_context;
+  // This is used to allow request_evaluate to handle empty expressions
+  // (ie the user pressed 'return' and expects the previous expression to
+  // repeat). If the previous expression was a command, this string will be
+  // empty; if the previous expression was a variable expression, this string
+  // will contain that expression.
   std::string last_nonempty_var_expression;
 
   DAP();

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -205,6 +205,7 @@ struct DAP {
   std::string command_escape_prefix = "`";
   lldb::SBFormat frame_format;
   lldb::SBFormat thread_format;
+  std::string last_nonempty_expression;
 
   DAP();
   ~DAP();

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -45,7 +45,8 @@ bool RunLLDBCommands(llvm::StringRef prefix,
       // RunTerminateCommands.
       static std::mutex handle_command_mutex;
       std::lock_guard<std::mutex> locker(handle_command_mutex);
-      interp.HandleCommand(command.str().c_str(), result);
+      interp.HandleCommand(command.str().c_str(), result,
+                           /* add_to_history */ true);
     }
 
     const bool got_error = !result.Succeeded();

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -46,7 +46,7 @@ bool RunLLDBCommands(llvm::StringRef prefix,
       static std::mutex handle_command_mutex;
       std::lock_guard<std::mutex> locker(handle_command_mutex);
       interp.HandleCommand(command.str().c_str(), result,
-                           /*add_to_history=*/ true);
+                           /*add_to_history=*/true);
     }
 
     const bool got_error = !result.Succeeded();

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -46,7 +46,7 @@ bool RunLLDBCommands(llvm::StringRef prefix,
       static std::mutex handle_command_mutex;
       std::lock_guard<std::mutex> locker(handle_command_mutex);
       interp.HandleCommand(command.str().c_str(), result,
-                           /* add_to_history */ true);
+                           /*add_to_history=*/ true);
     }
 
     const bool got_error = !result.Succeeded();

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1363,12 +1363,14 @@ void request_evaluate(const llvm::json::Object &request) {
   lldb::SBFrame frame = g_dap.GetLLDBFrame(*arguments);
   std::string expression = GetString(arguments, "expression").str();
   llvm::StringRef context = GetString(arguments, "context");
+  bool repeat_last_command = expression.empty() &&
+                             g_dap.last_nonempty_var_expression.empty();
 
   if (context == "repl" &&
-      (expression.empty() ?
-       g_dap.last_nonempty_var_expression.empty() :
-       g_dap.DetectExpressionContext(frame, expression) ==
-       ExpressionContext::Command)) {
+      (repeat_last_command ||
+       (!expression.empty() &&
+        g_dap.DetectExpressionContext(frame, expression) ==
+        ExpressionContext::Command))) {
     // Since the current expression is not for a variable, clear the
     // last_nonempty_var_expression field.
     g_dap.last_nonempty_var_expression.clear();

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1371,7 +1371,7 @@ void request_evaluate(const llvm::json::Object &request) {
        (expression.empty() &&
         g_dap.last_expression_context == ExpressionContext::Command))) {
     // If the current expression is empty, and the last expression context was
-    // for a  command, pass the empty expression along to the
+    // for a command, pass the empty expression along to the
     // CommandInterpreter, to repeat the previous command. Also set the
     // expression context properly for the next (possibly empty) expression.
     g_dap.last_expression_context = ExpressionContext::Command;

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1368,14 +1368,8 @@ void request_evaluate(const llvm::json::Object &request) {
       ((!expression.empty() &&
        g_dap.DetectExpressionContext(frame, expression) ==
        ExpressionContext::Command) ||
-       (expression.empty() &&
-        g_dap.last_expression_context == ExpressionContext::Command))) {
-    // If the current expression is empty, and the last expression context was
-    // for a command, pass the empty expression along to the
-    // CommandInterpreter, to repeat the previous command. Also set the
-    // expression context properly for the next (possibly empty) expression.
-    g_dap.last_expression_context = ExpressionContext::Command;
-    // Since the current expression context is not for a variable, clear the
+       (expression.empty() && g_dap.last_nonempty_var_expression.empty()))) {
+    // Since the current expression is not for a variable, clear the
     // last_nonempty_var_expression field.
     g_dap.last_nonempty_var_expression.clear();
     // If we're evaluating a command relative to the current frame, set the
@@ -1389,12 +1383,10 @@ void request_evaluate(const llvm::json::Object &request) {
     body.try_emplace("variablesReference", (int64_t)0);
   } else {
     if (context != "hover") {
-      // If the expression is empty and the last expression context was for a
+      // If the expression is empty and the last expression was for a
       // variable, set the expression to the previous expression (repeat the
       // evaluation); otherwise save the current non-empty expression for the
-      // next (possibly empty) variable expression. Also set the expression
-      // context for the next (possibly empty) expression.
-      g_dap.last_expression_context = ExpressionContext::Variable;
+      // next (possibly empty) variable expression.
       if (expression.empty())
         expression = g_dap.last_nonempty_var_expression;
       else

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1363,14 +1363,13 @@ void request_evaluate(const llvm::json::Object &request) {
   lldb::SBFrame frame = g_dap.GetLLDBFrame(*arguments);
   std::string expression = GetString(arguments, "expression").str();
   llvm::StringRef context = GetString(arguments, "context");
-  bool repeat_last_command = expression.empty() &&
-                             g_dap.last_nonempty_var_expression.empty();
+  bool repeat_last_command =
+      expression.empty() && g_dap.last_nonempty_var_expression.empty();
 
-  if (context == "repl" &&
-      (repeat_last_command ||
-       (!expression.empty() &&
-        g_dap.DetectExpressionContext(frame, expression) ==
-        ExpressionContext::Command))) {
+  if (context == "repl" && (repeat_last_command ||
+                            (!expression.empty() &&
+                             g_dap.DetectExpressionContext(frame, expression) ==
+                                 ExpressionContext::Command))) {
     // Since the current expression is not for a variable, clear the
     // last_nonempty_var_expression field.
     g_dap.last_nonempty_var_expression.clear();

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1365,10 +1365,10 @@ void request_evaluate(const llvm::json::Object &request) {
   llvm::StringRef context = GetString(arguments, "context");
 
   if (context == "repl" &&
-      ((!expression.empty() &&
+      (expression.empty() ?
+       g_dap.last_nonempty_var_expression.empty() :
        g_dap.DetectExpressionContext(frame, expression) ==
-       ExpressionContext::Command) ||
-       (expression.empty() && g_dap.last_nonempty_var_expression.empty()))) {
+       ExpressionContext::Command)) {
     // Since the current expression is not for a variable, clear the
     // last_nonempty_var_expression field.
     g_dap.last_nonempty_var_expression.clear();
@@ -1382,7 +1382,7 @@ void request_evaluate(const llvm::json::Object &request) {
     EmplaceSafeString(body, "result", result);
     body.try_emplace("variablesReference", (int64_t)0);
   } else {
-    if (context != "hover") {
+    if (context == "repl") {
       // If the expression is empty and the last expression was for a
       // variable, set the expression to the previous expression (repeat the
       // evaluation); otherwise save the current non-empty expression for the

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1363,14 +1363,13 @@ void request_evaluate(const llvm::json::Object &request) {
   lldb::SBFrame frame = g_dap.GetLLDBFrame(*arguments);
   std::string expression = GetString(arguments, "expression").str();
   llvm::StringRef context = GetString(arguments, "context");
-  static std::string last_nonempty_expression;
 
   // Remember the last non-empty expression from the user, and use that if
   // the current expression is empty (i.e. the user hit plain 'return').
   if (!expression.empty())
-    last_nonempty_expression = expression;
+    g_dap.last_nonempty_expression = expression;
   else
-    expression = last_nonempty_expression;
+    expression = g_dap.last_nonempty_expression;
 
   if (context == "repl" && g_dap.DetectExpressionContext(frame, expression) ==
                                ExpressionContext::Command) {

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1363,6 +1363,14 @@ void request_evaluate(const llvm::json::Object &request) {
   lldb::SBFrame frame = g_dap.GetLLDBFrame(*arguments);
   std::string expression = GetString(arguments, "expression").str();
   llvm::StringRef context = GetString(arguments, "context");
+  static std::string last_nonempty_expression;
+
+  // Remember the last non-empty expression from the user, and use that if
+  // the current expression is empty (i.e. the user hit plain 'return').
+  if (!expression.empty())
+    last_nonempty_expression = expression;
+  else
+    expression = last_nonempty_expression;
 
   if (context == "repl" && g_dap.DetectExpressionContext(frame, expression) ==
                                ExpressionContext::Command) {


### PR DESCRIPTION
Update lldb-dap so if the user just presses return, which sends an empty expression, it re-evaluates the most recent non-empty expression/command. Also udpated test to test this case.