### PR TITLE
[gn build] Bump macOS target to 12 and make it configurable

### DIFF
--- a/llvm/utils/gn/build/BUILD.gn
+++ b/llvm/utils/gn/build/BUILD.gn
@@ -72,9 +72,9 @@ config("compiler_defaults") {
     ldflags += [ "-miphoneos-version-min=8.0" ]
   }
   if (current_os == "mac") {
-    asmflags += [ "-mmacos-version-min=10.10" ]
-    cflags += [ "-mmacos-version-min=10.10" ]
-    ldflags += [ "-mmacos-version-min=10.10" ]
+    asmflags += [ "-mmacos-version-min=$mac_deployment_target" ]
+    cflags += [ "-mmacos-version-min=$mac_deployment_target" ]
+    ldflags += [ "-mmacos-version-min=$mac_deployment_target" ]
   }
 
   assert(symbol_level == 0 || symbol_level == 1 || symbol_level == 2,

--- a/llvm/utils/gn/build/mac_sdk.gni
+++ b/llvm/utils/gn/build/mac_sdk.gni
@@ -2,6 +2,10 @@ import("//llvm/utils/gn/build/sysroot.gni")
 
 have_ios_sdks = true
 
+declare_args() {
+  mac_deployment_target = "12"
+}
+
 if (sysroot == "") {
   declare_args() {
     # Set to true if you don't have Xcode installed, but do have the commandline

--- a/llvm/utils/gn/build/toolchain/target_flags.gni
+++ b/llvm/utils/gn/build/toolchain/target_flags.gni
@@ -47,7 +47,7 @@ if (current_os == "android") {
       rebase_path(mac_sdk_path, root_build_dir),
       # TODO(lgrey): We should be getting this from `compiler_defaults`. Why
       # aren't we?
-    "-mmacos-version-min=10.10",
+    "-mmacos-version-min=$mac_deployment_target",
     ]
   }
 } else if (current_os == "baremetal") {


### PR DESCRIPTION
Bumping the deployment target from macOS 10.10 to 12 enables chained fixups and DWARF 4 debug information for the LLVM binaries and libraries.
    
Like in Chromium, a GN arg (`mac_deployment_target`) is added to allow overriding the default.