### PR TITLE
[PAC] Make __is_function_overridden pauth-aware on ELF platforms

### DIFF
--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -116,6 +116,11 @@ _LIBCPP_HIDE_FROM_ABI bool __is_function_overridden(_Ret (*__fptr)(_Args...)) no
   uintptr_t __end   = reinterpret_cast<uintptr_t>(&__stop___lcxx_override);
   uintptr_t __ptr   = reinterpret_cast<uintptr_t>(__fptr);
 
+#  if __has_feature(ptrauth_calls)
+  // We must pass a void* to ptrauth_strip since it only accepts a pointer type. See full explanation above.
+  __ptr = reinterpret_cast<uintptr_t>(ptrauth_strip(reinterpret_cast<void*>(__ptr), ptrauth_key_function_pointer));
+#  endif
+
   return __ptr < __start || __ptr > __end;
 }
 _LIBCPP_END_NAMESPACE_STD


### PR DESCRIPTION
Apparently, there are two almost identical implementations: one for MachO and another one for ELF. The ELF bits somehow slipped while https://github.com/llvm/llvm-project/pull/84573 was reviewed.

The particular implementation is identical to MachO case.