### PR TITLE
[DebugInfo][AIX] XFAIL debug-ranges-duplication.ll

### DIFF
--- a/llvm/test/DebugInfo/Generic/debug-ranges-duplication.ll
+++ b/llvm/test/DebugInfo/Generic/debug-ranges-duplication.ll
@@ -1,3 +1,6 @@
+; AIX doesn't currently support DWARF 5 section .debug_rnglists
+; XFAIL: target={{.*}}-aix{{.*}}
+
 ; RUN: %llc_dwarf -O0 -filetype=obj < %s | llvm-dwarfdump -debug-info - | FileCheck %s
 ;
 ; Generated from the following C++ source with:


### PR DESCRIPTION
The test fails with `Assertion failed: Section && "Cannot switch to a null section!"` because of unsupported DWARF 5 section.