### PR TITLE
[MIPS] Fix -msingle-float doesn't work with double on O32

### DIFF
--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
@@ -1244,6 +1244,11 @@ SDValue MipsSETargetLowering::lowerBITCAST(SDValue Op,
 
   // Bitcast double to i64.
   if (Src == MVT::f64 && Dest == MVT::i64) {
+    // Skip lower bitcast when operand0 has converted float results to integer
+    // which was done by function SoftenFloatResult.
+    if (getTypeAction(*DAG.getContext(), Op.getOperand(0).getValueType()) ==
+        TargetLowering::TypeSoftenFloat)
+      return SDValue();
     SDValue Lo =
         DAG.getNode(MipsISD::ExtractElementF64, DL, MVT::i32, Op.getOperand(0),
                     DAG.getConstant(0, DL, MVT::i32));

--- a/llvm/test/CodeGen/Mips/2008-07-06-fadd64.ll
+++ b/llvm/test/CodeGen/Mips/2008-07-06-fadd64.ll
@@ -1,8 +1,18 @@
-; RUN: llc -march=mips -mattr=single-float  < %s | FileCheck %s
+; RUN: llc -mtriple=mipsel-linux-gnu -mcpu=mips32 -mattr=+single-float < %s | FileCheck %s
+; RUN: llc -mtriple=mipsel-linux-gnu -mcpu=mips32r2 -mattr=+single-float < %s | FileCheck %s
 
 define double @dofloat(double %a, double %b) nounwind {
+; CHECK-LABEL: dofloat:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    addiu $sp, $sp, -24
+; CHECK-NEXT:    sw    $ra, 20($sp)
+; CHECK-NEXT:    jal   __adddf3
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    lw    $ra, 20($sp)
+; CHECK-NEXT:    jr    $ra
+; CHECK-NEXT:    addiu $sp, $sp, 24
+
 entry:
-; CHECK: __adddf3
-	fadd double %a, %b		; <double>:0 [#uses=1]
-	ret double %0
+  fadd double %a, %b ; <double>:0 [#uses=1]
+  ret double %0
 }


### PR DESCRIPTION
Skip the following function 'CustomLowerNode' when the operand had done `SoftenFloatResult`.

Fix #93052