### PR TITLE
[lld-macho] Fix `Defined` size increase with `-mms-bitfields`

### DIFF
--- a/lld/MachO/Symbols.h
+++ b/lld/MachO/Symbols.h
@@ -14,6 +14,7 @@
 #include "Target.h"
 
 #include "llvm/Object/Archive.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 
 namespace lld {
@@ -152,7 +153,8 @@ public:
   // Whether this symbol should appear in the output symbol table.
   bool includeInSymtab : 1;
   // The ICF folding kind of this symbol: None / Body / Thunk.
-  ICFFoldKind identicalCodeFoldingKind : 2;
+  LLVM_PREFERRED_TYPE(ICFFoldKind)
+  uint8_t identicalCodeFoldingKind : 2;
   // Symbols marked referencedDynamically won't be removed from the output's
   // symbol table by tools like strip. In theory, this could be set on arbitrary
   // symbols in input object files. In practice, it's used solely for the


### PR DESCRIPTION
Under the Microsoft ABI, only those bit fields can be merged whose underlying types have the same size.

d175616 (`[lld-macho][arm64] Enhance safe ICF with thunk-based deduplication`) added an enum field (`identicalCodeFoldingKind`) next to booleans in the `Defined` class, which increased the size under the MS ABI. On MinGW targets, this triggered the `static_assert` which checks the size of `Defined` (for MSVC targets, the check is disabled due to another problem). Let's store it as a `uint8_t` to allow merging to take place.

Fixes #107511