### PR TITLE
[clang][bytecode] Fix reinterpret casts of two non-primitive types

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2478,8 +2478,15 @@ bool Compiler<Emitter>::VisitCXXReinterpretCastExpr(
     const CXXReinterpretCastExpr *E) {
   const Expr *SubExpr = E->getSubExpr();
 
-  bool TypesMatch = classify(E) == classify(SubExpr);
-  if (!this->emitInvalidCast(CastKind::Reinterpret, /*Fatal=*/!TypesMatch, E))
+  bool Fatal = false;
+  std::optional<PrimType> FromT = classify(SubExpr);
+  std::optional<PrimType> ToT = classify(E);
+  if (!FromT || !ToT)
+    Fatal = true;
+  else
+    Fatal = (ToT != FromT);
+
+  if (!this->emitInvalidCast(CastKind::Reinterpret, Fatal, E))
     return false;
 
   return this->delegate(SubExpr);


### PR DESCRIPTION
We don't want to allow e.g. cast from a record to an array or the other way arround.