### PR TITLE
[analyzer] fix crash on binding to symbolic region with `void *` type

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -2380,15 +2380,11 @@ RegionStoreManager::bind(RegionBindingsConstRef B, Loc L, SVal V) {
 
   // Binding directly to a symbolic region should be treated as binding
   // to element 0.
-  if (const SymbolicRegion *SR = dyn_cast<SymbolicRegion>(R)) {
-    // Symbolic region with void * type may appear as input for inline asm
-    // block. In such case CSA cannot reason about region content and just
-    // assumes it has UnknownVal()
-    QualType PT = SR->getPointeeStaticType();
-    if (PT->isVoidType())
-      PT = StateMgr.getContext().CharTy;
-
-    R = GetElementZeroRegion(SR, PT);
+  if (const auto *SymReg = dyn_cast<SymbolicRegion>(R)) {
+    QualType Ty = SymReg->getPointeeStaticType();
+    if (Ty->isVoidType())
+      Ty = StateMgr.getContext().CharTy;
+    R = GetElementZeroRegion(SymReg, Ty);
   }
 
   assert((!isa<CXXThisRegion>(R) || !B.lookup(R)) &&

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -3,6 +3,9 @@
 
 int clang_analyzer_eval(int);
 
+void clang_analyzer_dump(int);
+void clang_analyzer_dump_ptr(void *);
+
 int global;
 void testRValueOutput() {
   int &ref = global;

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -2,7 +2,6 @@
 // RUN:      -analyzer-checker debug.ExprInspection,core -Wno-error=invalid-gnu-asm-cast -w %s -verify
 
 int clang_analyzer_eval(int);
-
 void clang_analyzer_dump(int);
 void clang_analyzer_dump_ptr(void *);
 

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -41,11 +41,12 @@ void testInlineAsmMemcpyUninit(void)
     c = a[0]; // expected-warning{{Assigned value is garbage or undefined}}
 }
 
-void *globalPtr;
-
-void testNoCrash()
+void testAsmWithVoidPtrArgument()
 {
-  // Use global pointer to make it symbolic. Then engine will try to bind
-  // value to first element of type void * and should not crash.
-  asm ("" : : "a"(globalPtr)); // no crash
+  extern void *globalVoidPtr;
+  clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning-re {{reg_${{[0-9]+}}<int Element{SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>},0 S64b,int}>}}
+  clang_analyzer_dump_ptr(globalVoidPtr); // expected-warning-re {{&SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>}}}
+  asm ("" : : "a"(globalVoidPtr)); // no crash
+  clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning {{Unknown}}
+  clang_analyzer_dump_ptr(globalVoidPtr); // expected-warning-re {{&SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>}}}
 }

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -40,3 +40,12 @@ void testInlineAsmMemcpyUninit(void)
     MyMemcpy(&a[1], &b[1], sizeof(b) - sizeof(b[1]));
     c = a[0]; // expected-warning{{Assigned value is garbage or undefined}}
 }
+
+void *globalPtr;
+
+void testNoCrash()
+{
+  // Use global pointer to make it symbolic. Then engine will try to bind
+  // value to first element of type void * and should not crash.
+  asm ("" : : "a"(globalPtr)); // no crash
+}


### PR DESCRIPTION
As reported in https://github.com/llvm/llvm-project/pull/103714#issuecomment-2295769193. CSA crashes on trying to bind value to symbolic region with `void *`. This happens when such region gets passed as inline asm input and engine tries to bind `UnknownVal` to that region.

Fix it by changing type from void to char before calling `GetElementZeroRegion`