### PR TITLE
[MLIR][LLVM][NFC] Remove dead interface and add namespace qualifiers

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -25,7 +25,7 @@ def FastmathFlagsInterface : OpInterface<"FastmathFlagsInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/        "Returns a FastmathFlagsAttr attribute for the operation",
-      /*returnType=*/  "FastmathFlagsAttr",
+      /*returnType=*/  "::mlir::LLVM::FastmathFlagsAttr",
       /*methodName=*/  "getFastmathAttr",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -37,7 +37,7 @@ def FastmathFlagsInterface : OpInterface<"FastmathFlagsInterface"> {
     StaticInterfaceMethod<
       /*desc=*/        [{Returns the name of the FastmathFlagsAttr attribute
                          for the operation}],
-      /*returnType=*/  "StringRef",
+      /*returnType=*/  "::llvm::StringRef",
       /*methodName=*/  "getFastmathAttrName",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -100,7 +100,7 @@ def BranchWeightOpInterface : OpInterface<"BranchWeightOpInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/        "Returns the branch weights attribute or nullptr",
-      /*returnType=*/  "DenseI32ArrayAttr",
+      /*returnType=*/  "::mlir::DenseI32ArrayAttr",
       /*methodName=*/  "getBranchWeightsOrNull",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -113,7 +113,7 @@ def BranchWeightOpInterface : OpInterface<"BranchWeightOpInterface"> {
       /*desc=*/        "Sets the branch weights attribute",
       /*returnType=*/  "void",
       /*methodName=*/  "setBranchWeights",
-      /*args=*/        (ins "DenseI32ArrayAttr":$attr),
+      /*args=*/        (ins "::mlir::DenseI32ArrayAttr":$attr),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
@@ -137,7 +137,7 @@ def AccessGroupOpInterface : OpInterface<"AccessGroupOpInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/        "Returns the access groups attribute or nullptr",
-      /*returnType=*/  "ArrayAttr",
+      /*returnType=*/  "::mlir::ArrayAttr",
       /*methodName=*/  "getAccessGroupsOrNull",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -150,7 +150,7 @@ def AccessGroupOpInterface : OpInterface<"AccessGroupOpInterface"> {
       /*desc=*/        "Sets the access groups attribute",
       /*returnType=*/  "void",
       /*methodName=*/  "setAccessGroups",
-      /*args=*/        (ins "const ArrayAttr":$attr),
+      /*args=*/        (ins "const ::mlir::ArrayAttr":$attr),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
@@ -175,7 +175,7 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/        "Returns the alias scopes attribute or nullptr",
-      /*returnType=*/  "ArrayAttr",
+      /*returnType=*/  "::mlir::ArrayAttr",
       /*methodName=*/  "getAliasScopesOrNull",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -188,7 +188,7 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
       /*desc=*/        "Sets the alias scopes attribute",
       /*returnType=*/  "void",
       /*methodName=*/  "setAliasScopes",
-      /*args=*/        (ins "const ArrayAttr":$attr),
+      /*args=*/        (ins "const ::mlir::ArrayAttr":$attr),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
@@ -197,7 +197,7 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
       >,
     InterfaceMethod<
       /*desc=*/        "Returns the noalias scopes attribute or nullptr",
-      /*returnType=*/  "ArrayAttr",
+      /*returnType=*/  "::mlir::ArrayAttr",
       /*methodName=*/  "getNoAliasScopesOrNull",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -210,7 +210,7 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
       /*desc=*/        "Sets the noalias scopes attribute",
       /*returnType=*/  "void",
       /*methodName=*/  "setNoAliasScopes",
-      /*args=*/        (ins "const ArrayAttr":$attr),
+      /*args=*/        (ins "const ::mlir::ArrayAttr":$attr),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
@@ -219,7 +219,7 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
       >,
     InterfaceMethod<
       /*desc=*/        "Returns the tbaa attribute or nullptr",
-      /*returnType=*/  "ArrayAttr",
+      /*returnType=*/  "::mlir::ArrayAttr",
       /*methodName=*/  "getTBAATagsOrNull",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -232,7 +232,7 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
       /*desc=*/        "Sets the tbaa attribute",
       /*returnType=*/  "void",
       /*methodName=*/  "setTBAATags",
-      /*args=*/        (ins "const ArrayAttr":$attr),
+      /*args=*/        (ins "const ::mlir::ArrayAttr":$attr),
       /*methodBody=*/  [{}],
       /*defaultImpl=*/ [{
         auto op = cast<ConcreteOp>(this->getOperation());
@@ -249,29 +249,6 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
   ];
 }
 
-def GetResultPtrElementType : OpInterface<"GetResultPtrElementType"> {
-  let description = [{
-    An interface for operations that yield an LLVMPointer. Allows the
-    operation to provide the type of the element an LLVMPointer points to,
-    if known. This is only a hint as to how to interpret a given pointer,
-    translating how the current operation understands it.
-  }];
-
-  let cppNamespace = "::mlir::LLVM";
-
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/        [{Returns the the element type hint of the result
-                         LLVMPointer, if known. Returns nullptr if the
-                         requested result is not an LLVMPointer or if the
-                         element type is unknown.}],
-      /*returnType=*/  "Type",
-      /*methodName=*/  "getResultPtrElementType",
-      /*args=*/        (ins)
-      >
-  ];
-}
-
 def FPExceptionBehaviorOpInterface : OpInterface<"FPExceptionBehaviorOpInterface"> {
   let description = [{
     An interface for operations receiving an exception behavior attribute
@@ -283,7 +260,7 @@ def FPExceptionBehaviorOpInterface : OpInterface<"FPExceptionBehaviorOpInterface
   let methods = [
     InterfaceMethod<
       /*desc=*/        "Returns a FPExceptionBehavior attribute for the operation",
-      /*returnType=*/  "FPExceptionBehaviorAttr",
+      /*returnType=*/  "::mlir::LLVM::FPExceptionBehaviorAttr",
       /*methodName=*/  "getFPExceptionBehaviorAttr",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -295,7 +272,7 @@ def FPExceptionBehaviorOpInterface : OpInterface<"FPExceptionBehaviorOpInterface
     StaticInterfaceMethod<
       /*desc=*/        [{Returns the name of the FPExceptionBehaviorAttr
                         attribute for the operation}],
-      /*returnType=*/  "StringRef",
+      /*returnType=*/  "::llvm::StringRef",
       /*methodName=*/  "getFPExceptionBehaviorAttrName",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -317,7 +294,7 @@ def RoundingModeOpInterface : OpInterface<"RoundingModeOpInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/        "Returns a RoundingMode attribute for the operation",
-      /*returnType=*/  "RoundingModeAttr",
+      /*returnType=*/  "::mlir::LLVM::RoundingModeAttr",
       /*methodName=*/  "getRoundingModeAttr",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -329,7 +306,7 @@ def RoundingModeOpInterface : OpInterface<"RoundingModeOpInterface"> {
     StaticInterfaceMethod<
       /*desc=*/        [{Returns the name of the RoundingModeAttr attribute
                          for the operation}],
-      /*returnType=*/  "StringRef",
+      /*returnType=*/  "::llvm::StringRef",
       /*methodName=*/  "getRoundingModeAttrName",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
@@ -359,7 +336,7 @@ def LLVM_PointerElementTypeInterface
       /*description=*/"Returns the size of the type in bytes.",
       /*retTy=*/"unsigned",
       /*methodName=*/"getSizeInBytes",
-      /*args=*/(ins "const DataLayout &":$dataLayout),
+      /*args=*/(ins "const ::mlir::DataLayout &":$dataLayout),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return dataLayout.getTypeSize($_type);

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -201,8 +201,7 @@ def LLVM_FNegOp : LLVM_UnaryFloatArithmeticOp<
 // Memory-related operations.
 def LLVM_AllocaOp : LLVM_Op<"alloca",
     [DeclareOpInterfaceMethods<PromotableAllocationOpInterface>,
-     DeclareOpInterfaceMethods<DestructurableAllocationOpInterface>,
-     DeclareOpInterfaceMethods<GetResultPtrElementType>]>,
+     DeclareOpInterfaceMethods<DestructurableAllocationOpInterface>]>,
   LLVM_MemOpPatterns {
   let arguments = (ins AnySignlessInteger:$arraySize,
                    OptionalAttr<I64Attr>:$alignment,
@@ -247,8 +246,7 @@ def LLVM_AllocaOp : LLVM_Op<"alloca",
 def LLVM_GEPOp : LLVM_Op<"getelementptr", [Pure,
     DeclareOpInterfaceMethods<PromotableOpInterface>,
     DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
-    DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
-    DeclareOpInterfaceMethods<GetResultPtrElementType>]> {
+    DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>]> {
   let arguments = (ins LLVM_ScalarOrVectorOf<LLVM_AnyPointer>:$base,
                    Variadic<LLVM_ScalarOrVectorOf<AnySignlessInteger>>:$dynamicIndices,
                    DenseI32ArrayAttr:$rawConstantIndices,

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -413,8 +413,6 @@ LogicalResult AllocaOp::verify() {
   return success();
 }
 
-Type AllocaOp::getResultPtrElementType() { return getElemType(); }
-
 //===----------------------------------------------------------------------===//
 // LLVM::BrOp
 //===----------------------------------------------------------------------===//
@@ -790,35 +788,6 @@ LogicalResult LLVM::GEPOp::verify() {
 
   return verifyStructIndices(getElemType(), getIndices(),
                              [&] { return emitOpError(); });
-}
-
-Type GEPOp::getResultPtrElementType() {
-  // Set the initial type currently being used for indexing. This will be
-  // updated as the indices get walked over.
-  Type selectedType = getElemType();
-
-  // Follow the indexed elements in the gep.
-  auto indices = getIndices();
-  for (GEPIndicesAdaptor<ValueRange>::value_type index :
-       llvm::drop_begin(indices)) {
-    // GEPs can only index into aggregates which can be structs or arrays.
-
-    // The resulting type if indexing into an array type is always the element
-    // type, regardless of index.
-    if (auto arrayType = dyn_cast<LLVMArrayType>(selectedType)) {
-      selectedType = arrayType.getElementType();
-      continue;
-    }
-
-    // The GEP verifier ensures that any index into structs are static and
-    // that they refer to a field within the struct.
-    selectedType = cast<DestructurableTypeInterface>(selectedType)
-                       .getTypeAtIndex(cast<IntegerAttr>(index));
-  }
-
-  // When there are no more indices, the type currently being used for indexing
-  // is the type of the value pointed at by the returned indexed pointer.
-  return selectedType;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The `GetResultPtrElementType` interface is dead now that MLIR has fully moved to opaque pointers, and can be removed.

Add namespace qualifiers to all argument types and return types of interface methods for when they're used outside of LLVM dialect.