### PR TITLE
[Clang] Emit error for duplicate mangled names within a lambda

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4638,8 +4638,8 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
   // Lookup the entry, lazily creating it if necessary.
   llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
   if (Entry) {
+    const FunctionDecl *FD = cast_or_null<FunctionDecl>(D);
     if (WeakRefReferences.erase(Entry)) {
-      const FunctionDecl *FD = cast_or_null<FunctionDecl>(D);
       if (FD && !FD->hasAttr<WeakAttr>())
         Entry->setLinkage(llvm::Function::ExternalLinkage);
     }
@@ -4652,18 +4652,35 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
 
     // If there are two attempts to define the same mangled name, issue an
     // error.
-    if (IsForDefinition && !Entry->isDeclaration()) {
-      GlobalDecl OtherGD;
-      // Check that GD is not yet in DiagnosedConflictingDefinitions is required
-      // to make sure that we issue an error only once.
-      if (lookupRepresentativeDecl(MangledName, OtherGD) &&
-          (GD.getCanonicalDecl().getDecl() !=
-           OtherGD.getCanonicalDecl().getDecl()) &&
-          DiagnosedConflictingDefinitions.insert(GD).second) {
+    GlobalDecl OtherGD;
+    // Check that GD is not yet in DiagnosedConflictingDefinitions is required
+    // to make sure that we issue an error only once.
+    if (GD && lookupRepresentativeDecl(MangledName, OtherGD) &&
+        (GD.getCanonicalDecl().getDecl() !=
+         OtherGD.getCanonicalDecl().getDecl()) &&
+        DiagnosedConflictingDefinitions.insert(GD).second) {
+      if (IsForDefinition && !Entry->isDeclaration()) {
         getDiags().Report(D->getLocation(), diag::err_duplicate_mangled_name)
             << MangledName;
         getDiags().Report(OtherGD.getDecl()->getLocation(),
                           diag::note_previous_definition);
+      } else {
+        // For lambdas, it's possible to create the same mangled name from
+        // different function prototypes. For example, two FPTs may have
+        // identical types but incompatible function attributes which we should
+        // not allow.
+        auto *MD = dyn_cast<CXXMethodDecl>(D);
+        if (MD && MD->getParent()->isLambda()) {
+          const FunctionDecl *OtherFD =
+              cast_or_null<FunctionDecl>(OtherGD.getDecl());
+          if (FD && FD->hasPrototype() && OtherFD && OtherFD->hasPrototype()) {
+            if (FD->getType()->getAs<FunctionProtoType>() !=
+                OtherFD->getType()->getAs<FunctionProtoType>())
+              getDiags().Report(D->getLocation(),
+                                diag::err_duplicate_mangled_name)
+                  << MangledName;
+          }
+        }
       }
     }
 

--- a/clang/test/CodeGenCXX/aarch64-sme-lambda-attributes.cpp
+++ b/clang/test/CodeGenCXX/aarch64-sme-lambda-attributes.cpp
@@ -1,30 +1,31 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang_cc1 -triple aarch64 -target-feature +sme -target-feature +sme2 -emit-llvm -o - %s -verify -DTEST1
+// RUN: %clang_cc1 -triple aarch64 -emit-llvm -o - %s -verify -DTEST1
 // RUN: %clang_cc1 -triple aarch64 -target-feature +sme -target-feature +sme2 -emit-llvm -o - %s -verify -DTEST2
 
 int normal_fn(int);
 int streaming_fn(int) __arm_streaming;
-int streaming_compatible_fn(int) __arm_streaming_compatible;
+int vector_pcs_fn(int) __attribute__((aarch64_vector_pcs));
 
 #ifdef TEST1
 
-// expected-error@+3 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
-// expected-note@+2 {{previous definition is here}}
-int function_params_normal_streaming() {
+// expected-error@+4 {{definition with same mangled name '_ZZ23function_pcs_attributesvENK3$_0clIFiiEEEDaRT_' as another definition}}
+// expected-note@+3 {{previous definition is here}}
+__attribute__((aarch64_vector_pcs))
+int function_pcs_attributes() {
   auto a = [](auto &fn) { return fn(42); };
-  return a(normal_fn) + a(streaming_fn);
+  return a(normal_fn) + a(vector_pcs_fn);
 }
 
 #endif
 
 #ifdef TEST2
 
-// expected-error@+3 {{definition with same mangled name '_ZZ36function_params_streaming_compatiblevENK3$_0clIFiiEEEDaRT_' as another definition}}
+// expected-error@+3 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
 // expected-note@+2 {{previous definition is here}}
-int function_params_streaming_compatible() {
+int function_params_normal_streaming() {
   auto a = [](auto &fn) { return fn(42); };
-  return a(streaming_fn) + a(streaming_compatible_fn);
+  return a(normal_fn) + a(streaming_fn);
 }
 
 #endif

--- a/clang/test/CodeGenCXX/aarch64-sme-lambda-attributes.cpp
+++ b/clang/test/CodeGenCXX/aarch64-sme-lambda-attributes.cpp
@@ -9,7 +9,8 @@ int streaming_compatible_fn(int) __arm_streaming_compatible;
 
 #ifdef TEST1
 
-// expected-error@+2 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
+// expected-error@+3 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
+// expected-note@+2 {{previous definition is here}}
 int function_params_normal_streaming() {
   auto a = [](auto &fn) { return fn(42); };
   return a(normal_fn) + a(streaming_fn);
@@ -19,7 +20,8 @@ int function_params_normal_streaming() {
 
 #ifdef TEST2
 
-// expected-error@+2 {{definition with same mangled name '_ZZ36function_params_streaming_compatiblevENK3$_0clIFiiEEEDaRT_' as another definition}}
+// expected-error@+3 {{definition with same mangled name '_ZZ36function_params_streaming_compatiblevENK3$_0clIFiiEEEDaRT_' as another definition}}
+// expected-note@+2 {{previous definition is here}}
 int function_params_streaming_compatible() {
   auto a = [](auto &fn) { return fn(42); };
   return a(streaming_fn) + a(streaming_compatible_fn);

--- a/clang/test/CodeGenCXX/aarch64-sme-lambda-attributes.cpp
+++ b/clang/test/CodeGenCXX/aarch64-sme-lambda-attributes.cpp
@@ -1,0 +1,28 @@
+// REQUIRES: aarch64-registered-target
+
+// RUN: %clang_cc1 -triple aarch64 -target-feature +sme -target-feature +sme2 -emit-llvm -o - %s -verify -DTEST1
+// RUN: %clang_cc1 -triple aarch64 -target-feature +sme -target-feature +sme2 -emit-llvm -o - %s -verify -DTEST2
+
+int normal_fn(int);
+int streaming_fn(int) __arm_streaming;
+int streaming_compatible_fn(int) __arm_streaming_compatible;
+
+#ifdef TEST1
+
+// expected-error@+2 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
+int function_params_normal_streaming() {
+  auto a = [](auto &fn) { return fn(42); };
+  return a(normal_fn) + a(streaming_fn);
+}
+
+#endif
+
+#ifdef TEST2
+
+// expected-error@+2 {{definition with same mangled name '_ZZ36function_params_streaming_compatiblevENK3$_0clIFiiEEEDaRT_' as another definition}}
+int function_params_streaming_compatible() {
+  auto a = [](auto &fn) { return fn(42); };
+  return a(streaming_fn) + a(streaming_compatible_fn);
+}
+
+#endif

--- a/clang/test/CodeGenCXX/duplicate-mangled-name.cpp
+++ b/clang/test/CodeGenCXX/duplicate-mangled-name.cpp
@@ -2,6 +2,7 @@
 // RUN: %clang_cc1 -triple %itanium_abi_triple-only %s -verify -DTEST2 -emit-llvm -o - | FileCheck %s
 // RUN: %clang_cc1 -triple %itanium_abi_triple -emit-llvm-only %s -verify -DTEST3
 // RUN: %clang_cc1 -triple %itanium_abi_triple -emit-llvm-only %s -verify -DTEST4
+// RUN: %clang_cc1 -triple %itanium_abi_triple -emit-llvm-only %s -verify -DTEST5
 
 #ifdef TEST1
 
@@ -69,6 +70,13 @@ namespace nm {
 float foo() {
   return _ZN2nm3abcE + nm::abc;
 }
+
+#elif TEST5
+
+inline void f(int) asm("foo");
+inline void f(int) {}
+inline void f() asm("foo");
+inline void f(){} // expected-error {{definition with same mangled name 'foo' as another definition}}
 
 #else
 

--- a/clang/test/CodeGenCXX/lambda-instantiation-mangling-conflicts.cpp
+++ b/clang/test/CodeGenCXX/lambda-instantiation-mangling-conflicts.cpp
@@ -11,8 +11,7 @@
 int normal_fn(int);
 int vector_pcs_fn(int) __attribute__((aarch64_vector_pcs));
 
-// expected-error@+4 {{definition with same mangled name '_ZZ23function_pcs_attributesvENK3$_0clIFiiEEEDaRT_' as another definition}}
-// expected-note@+3 {{previous definition is here}}
+// expected-error@+3 {{definition with same mangled name '_ZZ23function_pcs_attributesvENK3$_0clIFiiEEEDaRT_' as another definition}}
 __attribute__((aarch64_vector_pcs))
 int function_pcs_attributes() {
   auto a = [](auto &fn) { return fn(42); };
@@ -24,8 +23,7 @@ int function_pcs_attributes() {
 int normal_fn(int);
 int streaming_fn(int) __arm_streaming;
 
-// expected-error@+3 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
-// expected-note@+2 {{previous definition is here}}
+// expected-error@+2 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
 int function_params_normal_streaming() {
   auto a = [](auto &fn) { return fn(42); };
   return a(normal_fn) + a(streaming_fn);

--- a/clang/test/CodeGenCXX/lambda-instantiation-mangling-conflicts.cpp
+++ b/clang/test/CodeGenCXX/lambda-instantiation-mangling-conflicts.cpp
@@ -1,13 +1,15 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang_cc1 -triple aarch64 -emit-llvm -o - %s -verify -DTEST1
-// RUN: %clang_cc1 -triple aarch64 -target-feature +sme -target-feature +sme2 -emit-llvm -o - %s -verify -DTEST2
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -triple aarch64 -target-feature +sme -target-feature +sme2 -emit-llvm -o - %t/a.cpp -verify
+// RUN: %clang_cc1 -triple aarch64 -target-feature +sme -target-feature +sme2 -emit-llvm -o - %t/b.cpp -verify
+
+;--- a.cpp
 
 int normal_fn(int);
-int streaming_fn(int) __arm_streaming;
 int vector_pcs_fn(int) __attribute__((aarch64_vector_pcs));
-
-#ifdef TEST1
 
 // expected-error@+4 {{definition with same mangled name '_ZZ23function_pcs_attributesvENK3$_0clIFiiEEEDaRT_' as another definition}}
 // expected-note@+3 {{previous definition is here}}
@@ -17,9 +19,10 @@ int function_pcs_attributes() {
   return a(normal_fn) + a(vector_pcs_fn);
 }
 
-#endif
+;--- b.cpp
 
-#ifdef TEST2
+int normal_fn(int);
+int streaming_fn(int) __arm_streaming;
 
 // expected-error@+3 {{definition with same mangled name '_ZZ32function_params_normal_streamingvENK3$_0clIFiiEEEDaRT_' as another definition}}
 // expected-note@+2 {{previous definition is here}}
@@ -27,5 +30,3 @@ int function_params_normal_streaming() {
   auto a = [](auto &fn) { return fn(42); };
   return a(normal_fn) + a(streaming_fn);
 }
-
-#endif

--- a/clang/test/CodeGenCXX/mangle-lambdas-gh88906.cpp
+++ b/clang/test/CodeGenCXX/mangle-lambdas-gh88906.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-linux-gnu %s -emit-llvm -mconstructor-aliases -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fclang-abi-compat=18 %s -emit-llvm -mconstructor-aliases  -o - | FileCheck --check-prefix=CLANG18 %s
+// RUN: not %clang_cc1 -triple x86_64-linux-gnu -fclang-abi-compat=18 %s -emit-llvm -mconstructor-aliases 2>&1 | FileCheck --check-prefix=CLANG18 %s
 // RUN: %clang_cc1 -triple i386-pc-win32 %s -emit-llvm -mconstructor-aliases -o - | FileCheck --check-prefix=MSABI %s
 
 
@@ -29,12 +29,7 @@ void GH88906(){
 // CHECK-LABEL: define internal void @_ZN4funcC2IN7GH889064Test1bMUlvE_EEET_
 // CHECK-LABEL: define internal void @_ZN4funcC2IN7GH889064Test1cMUlvE_EEET_
 
-// CLANG18-LABEL: define internal void @_ZZ7GH88906vEN4TestC2Ev
-// CLANG18: call void @_ZN4funcC2IZ7GH88906vEN4TestUlvE_EZ7GH88906vENS1_UlvE0_EEET_T0_
-// CLANG18: call void @_ZN4funcC2IZ7GH88906vEN4TestUlvE_EEET_
-// CLANG18: call void @_ZN4funcC2IZ7GH88906vEN4TestUlvE_EEET_
-
-
+// CLANG18: error: definition with same mangled name '_ZN4funcC1IZ7GH88906vEN4TestUlvE_EEET_' as another definition
 
 // MSABI-LABEL: define internal x86_thiscallcc noundef ptr @"??0Test@?1??GH88906@@YAXXZ@QAE@XZ"
 // MSABI: call x86_thiscallcc noundef ptr @"??$?0V<lambda_1>@a@Test@?1??GH88906@@YAXXZ@V<lambda_2>@12?1??3@YAXXZ@@func@@QAE@V<lambda_1>@a@Test@?1??GH88906@@YAXXZ@V<lambda_2>@23?1??4@YAXXZ@@Z"


### PR DESCRIPTION
When functions are passed as arguments to a lambda, it's possible for
the mangled names of these functions to be the same despite the prototypes
being different. For example:

```
  int non_streaming_fn(int);
  int streaming_fn(int) __arm_streaming;

  auto lambda_fn = [](const auto &f) { return f(); };
  return lambda_fn(non_streaming_fn) + lambda_fn(streaming_fn);
```

Only one function will be generated for the lambda above and the __arm_streaming
attribute from streaming_fn will be incorrectly applied to the non_streaming_fn call.
With this change, an error will be emitted when a duplicate mangled name is found
but the function prototypes do not match.