### PR TITLE
[mlir][SME] Update E2E test to show potential optimisation (NFC)

### DIFF
--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
@@ -85,7 +85,7 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.canonicalization
     } : !transform.any_op
 
-    // Step 5 (optionnal): Hoist accumulator load/store.
+    // Step 5 (optional optimization): Hoist accumulator load/store.
     %func_h = transform.structured.hoist_redundant_vector_transfers %func
         : (!transform.any_op) -> !transform.any_op
     %all_loops = transform.structured.match interface{LoopLikeInterface} in %module

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
@@ -85,7 +85,7 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.canonicalization
     } : !transform.any_op
 
-    // Step 5: Hoist load of accumulator.
+    // Step 5 (optionnal): Hoist accumulator load/store.
     %func_h = transform.structured.hoist_redundant_vector_transfers %func
         : (!transform.any_op) -> !transform.any_op
     %all_loops = transform.structured.match interface{LoopLikeInterface} in %module

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
@@ -82,8 +82,16 @@ module attributes {transform.with_named_sequence} {
     transform.apply_patterns to %func {
       transform.apply_patterns.vector.lower_contraction lowering_strategy = "outerproduct"
       transform.apply_patterns.vector.lower_masks
+      transform.apply_patterns.canonicalization
     } : !transform.any_op
 
+    // Step 5: Hoist load of accumulator.
+    %func_h = transform.structured.hoist_redundant_vector_transfers %func
+        : (!transform.any_op) -> !transform.any_op
+    %all_loops = transform.structured.match interface{LoopLikeInterface} in %module
+      : (!transform.any_op) -> !transform.any_op
+    transform.apply_licm to %all_loops : !transform.any_op
+    transform.loop.hoist_loop_invariant_subsets %all_loops : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
@@ -91,7 +91,7 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.canonicalization
     } : !transform.any_op
 
-    // Step 6 (optionnal): Hoist accumulator load/store.
+    // Step 6 (optional optimization): Hoist accumulator load/store.
     %func_h = transform.structured.hoist_redundant_vector_transfers %func
         : (!transform.any_op) -> !transform.any_op
     %all_loops = transform.structured.match interface{LoopLikeInterface} in %bufferize

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
@@ -91,7 +91,7 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.canonicalization
     } : !transform.any_op
 
-    // Step 6: Hoist load of accumulator.
+    // Step 6 (optionnal): Hoist accumulator load/store.
     %func_h = transform.structured.hoist_redundant_vector_transfers %func
         : (!transform.any_op) -> !transform.any_op
     %all_loops = transform.structured.match interface{LoopLikeInterface} in %bufferize

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
@@ -88,8 +88,16 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.vector.lower_contraction lowering_strategy = "outerproduct"
       transform.apply_patterns.vector.lower_masks
       transform.apply_patterns.vector.rank_reducing_subview_patterns
+      transform.apply_patterns.canonicalization
     } : !transform.any_op
 
+    // Step 6: Hoist load of accumulator.
+    %func_h = transform.structured.hoist_redundant_vector_transfers %func
+        : (!transform.any_op) -> !transform.any_op
+    %all_loops = transform.structured.match interface{LoopLikeInterface} in %bufferize
+      : (!transform.any_op) -> !transform.any_op
+    transform.apply_licm to %all_loops : !transform.any_op
+    transform.loop.hoist_loop_invariant_subsets %all_loops : !transform.any_op
     transform.yield
   }
 }


### PR DESCRIPTION
Introduces loop hoisting to ARM SME E2E tests to allow the hoisting of the tile load offering very important speedup.

Discussed here : https://discourse.llvm.org/t/mlir-for-arm-sme-reducing-tile-data-transfers/80065/2