### PR TITLE
[flang][OpenMP] Don't abort when default is used on an invalid directive

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2152,7 +2152,9 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
         dirContext.defaultDSA == Symbol::Flag::OmpShared) {
       // 1) default
       // Allowed only with parallel, teams and task generating constructs.
-      assert(parallelDir || taskGenDir || teamsDir);
+      if (!parallelDir && !taskGenDir && !teamsDir) {
+        return;
+      }
       if (dirContext.defaultDSA != Symbol::Flag::OmpShared)
         makePrivateSymbol(dirContext.defaultDSA);
       else

--- a/flang/test/Semantics/OpenMP/default.f90
+++ b/flang/test/Semantics/OpenMP/default.f90
@@ -31,4 +31,13 @@ program omp_default
   end do
   !$omp end teams
 
+  !$omp parallel
+  !ERROR: DEFAULT clause is not allowed on the DO directive
+  !$omp do default(private)
+  do i = 1, 10
+     k = i
+  end do
+  !$omp end do
+  !$omp end parallel
+
 end program omp_default


### PR DESCRIPTION
The previous assert was not considering programs with semantic errors.

Fixes https://github.com/llvm/llvm-project/issues/107495
Fixes https://github.com/llvm/llvm-project/issues/93437