### PR TITLE
Don't emit int TBAA metadata on more complex FP math libcalls.

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -689,12 +689,11 @@ static Value *EmitSignBit(CodeGenFunction &CGF, Value *V) {
 static bool hasPointerArgsOrPointerReturnType(Value *V) {
   if (V) {
     if (const CallBase *CB = dyn_cast<CallBase>(V)) {
-      for (const Value *A : CB->args()) {
-        if (A->getType()->isPointerTy())
+      if (llvm::any_of(CB->args(), [](const Value *A) {
+            return A->getType()->isPointerTy();
+          }))
+        if (CB->getFunctionType()->getReturnType()->isPointerTy())
           return true;
-      }
-      if (CB->getFunctionType()->getReturnType()->isPointerTy())
-        return true;
     }
   }
   return false;

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -686,6 +686,20 @@ static Value *EmitSignBit(CodeGenFunction &CGF, Value *V) {
   return CGF.Builder.CreateICmpSLT(V, Zero);
 }
 
+static bool hasPointerArgsOrPointerReturnType(const Value *V) {
+  if (const CallBase *CB = dyn_cast<CallBase>(V)) {
+    for (const Value *A : CB->args()) {
+      if (A->getType()->isPointerTy()) {
+        return true;
+      }
+    }
+    if (CB->getFunctionType()->getReturnType()->isPointerTy()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 static RValue emitLibraryCall(CodeGenFunction &CGF, const FunctionDecl *FD,
                               const CallExpr *E, llvm::Constant *calleeValue) {
   CodeGenFunction::CGFPOptionsRAII FPOptsRAII(CGF, E);
@@ -699,17 +713,8 @@ static RValue emitLibraryCall(CodeGenFunction &CGF, const FunctionDecl *FD,
     bool ConstWithoutErrnoAndExceptions =
         Context.BuiltinInfo.isConstWithoutErrnoAndExceptions(BuiltinID);
     // Restrict to target with errno, for example, MacOS doesn't set errno.
-    bool CallWithPointerArgsOrPointerReturnType = false;
-    if (Call.isScalar() && Call.getScalarVal()) {
-      if (CallBase *CB = dyn_cast<CallBase>(Call.getScalarVal())) {
-        for (Value *A : CB->args())
-          if (A->getType()->isPointerTy())
-            CallWithPointerArgsOrPointerReturnType = true;
-        CallWithPointerArgsOrPointerReturnType =
-            CallWithPointerArgsOrPointerReturnType ||
-            CB->getFunctionType()->getReturnType()->isPointerTy();
-      }
-    }
+    bool CallWithPointerArgsOrPointerReturnType =
+        hasPointerArgsOrPointerReturnType(Call.getScalarVal());
     if (ConstWithoutErrnoAndExceptions && CGF.CGM.getLangOpts().MathErrno &&
         !CGF.Builder.getIsFPConstrained() && Call.isScalar() &&
         !CallWithPointerArgsOrPointerReturnType) {

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -714,6 +714,7 @@ static RValue emitLibraryCall(CodeGenFunction &CGF, const FunctionDecl *FD,
         Context.BuiltinInfo.isConstWithoutErrnoAndExceptions(BuiltinID);
     // Restrict to target with errno, for example, MacOS doesn't set errno.
     bool CallWithPointerArgsOrPointerReturnType =
+        Call.isScalar() && Call.getScalarVal() &&
         hasPointerArgsOrPointerReturnType(Call.getScalarVal());
     if (ConstWithoutErrnoAndExceptions && CGF.CGM.getLangOpts().MathErrno &&
         !CGF.Builder.getIsFPConstrained() && Call.isScalar() &&

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -706,8 +706,8 @@ static RValue emitLibraryCall(CodeGenFunction &CGF, const FunctionDecl *FD,
           if (A->getType()->isPointerTy())
             CallWithPointerArgsOrPointerReturnType = true;
         CallWithPointerArgsOrPointerReturnType =
-          CallWithPointerArgsOrPointerReturnType ||
-          CB->getFunctionType()->getReturnType()->isPointerTy();
+            CallWithPointerArgsOrPointerReturnType ||
+            CB->getFunctionType()->getReturnType()->isPointerTy();
       }
     }
     if (ConstWithoutErrnoAndExceptions && CGF.CGM.getLangOpts().MathErrno &&

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -700,7 +700,7 @@ static RValue emitLibraryCall(CodeGenFunction &CGF, const FunctionDecl *FD,
         Context.BuiltinInfo.isConstWithoutErrnoAndExceptions(BuiltinID);
     // Restrict to target with errno, for example, MacOS doesn't set errno.
     bool CallWithPointerArgsOrPointerReturnType = false;
-    if (Call.isScalar()) {
+    if (Call.isScalar() && Call.getScalarVal()) {
       if (CallBase *CB = dyn_cast<CallBase>(Call.getScalarVal())) {
         for (Value *A : CB->args())
           if (A->getType()->isPointerTy())

--- a/clang/test/CodeGen/complex-math-libcalls-tbaa.c
+++ b/clang/test/CodeGen/complex-math-libcalls-tbaa.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 %s -O3  -fmath-errno -emit-llvm -triple x86_64-unknown-unknown -o - %s | FileCheck %s -check-prefixes=CHECK
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple x86_64-pc-win64 -o - %s | FileCheck %s -check-prefixes=CHECK
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple i686-unknown-unknown -o - %s | FileCheck %s -check-prefixes=CHECK
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple powerpc-unknown-unknown -o - %s | FileCheck %s -check-prefixes=CHECK-PPC
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple armv7-none-linux-gnueabi -o - %s | FileCheck %s -check-prefixes=CHECK-TBAA,TBAA
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple armv7-none-linux-gnueabihf -o - %s | FileCheck %s -check-prefixes=CHECK-ARM,TBAA
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple thumbv7k-apple-watchos2.0 -o - -target-abi aapcs16 %s | FileCheck %s -check-prefixes=CHECK-THUMB,TBAA
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple aarch64-unknown-unknown -o - %s | FileCheck %s -check-prefixes=CHECK-AARCH,TBAA
+// RUN: %clang_cc1 %s -O3 -fmath-errno -emit-llvm -triple spir -o - %s | FileCheck %s -check-prefixes=CHECK-SPIR
+
+_Complex long double foo() {
+  _Complex long double cld;
+  long double v2 = __builtin_cargl(cld);
+  _Complex long double tmp = v2 * cld;
+  return tmp;
+}
+// CHECK: tail call x86_fp80 @cargl(ptr noundef nonnull byval({ {{.*}}, {{.*}} })
+// CHECK-PPC: tail call ppc_fp128 @cargl(ptr noundef nonnull byval({ ppc_fp128, ppc_fp128 })
+// CHECK-TBAA: tail call double @cargl([2 x i64] noundef undef) #[[ATTR1:[0-9]+]], !tbaa [[TBAA3:![0-9]+]]
+
+// CHECK-ARM: tail call double @cargl({ double, double } noundef undef) #[[ATTR1:[0-9]+]], !tbaa [[TBAA3:![0-9]+]]
+
+// CHECK-THUMB: tail call double @cargl([2 x double] noundef undef) #[[ATTR1:[0-9]+]], !tbaa [[TBAA3:![0-9]+]]
+
+// CHECK-AARCH: tail call fp128 @cargl([2 x fp128] noundef alignstack(16) undef) #[[ATTR1:[0-9]+]], !tbaa [[TBAA3:![0-9]+]]
+
+// CHECK-SPIR: tail call spir_func double @cargl(ptr noundef nonnull byval({ {{.*}}, {{.*}} })
+
+// TBAA: [[TBAA3]] = !{[[META4:![0-9]+]], [[META4]], i64 0}
+// TBAA: [[META4]] = !{!"int", [[META5:![0-9]+]], i64 0}
+// TBAA: [[META5]] = !{!"omnipotent char", [[META6:![0-9]+]], i64 0}


### PR DESCRIPTION
In  https://github.com/llvm/llvm-project/pull/100302, `int` TBAA information was added to math function calls to indicate the type of non-argument memory a function might modify. The purpose of this change was to avoid that some math functions (math functions modify errno) be a barrier to various code motion. 
Complex functions have pointer arguments. The `int` TBAA attached to the function is interpreted as describing those arguments instead of the type that arguments are pointing to.

This small example:
```
double b;
void a() { __builtin_cargl(b); }

```
compiled with `-fmath-errno -O3` will generate this call:

`%call = tail call x86_fp80 @cargl(ptr noundef nonnull byval({ x86_fp80, x86_fp80 }) align 16 %byval-temp) #3, !tbaa !9
`
```
9 = !{!10, !10, i64 0}
!10 = !{!"int", !7, i64 0}
```

The TBBA attached to the argument of `__builtin_cargl` is `int`, but that’s not correct.
This patch fixes this issue: calls of functions that have pointer arguments or calls functions that return a pointer are restricted from the TBBA information.