### PR TITLE
[RecursiveASTVisitor] Do not inline TraverseStmt (NFC)

### DIFF
--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -652,9 +652,11 @@ bool RecursiveASTVisitor<Derived>::PostVisitStmt(Stmt *S) {
 
 #undef DISPATCH_STMT
 
+// Inlining this method can lead to large code size and compile-time increases
+// without any benefit to runtime performance.
 template <typename Derived>
-bool RecursiveASTVisitor<Derived>::TraverseStmt(Stmt *S,
-                                                DataRecursionQueue *Queue) {
+LLVM_ATTRIBUTE_NOINLINE bool
+RecursiveASTVisitor<Derived>::TraverseStmt(Stmt *S, DataRecursionQueue *Queue) {
   if (!S)
     return true;
 


### PR DESCRIPTION
As things are now, this reduces size of clang bootstrapped with ThinLTO by 0.3% and reduces thin link time by 0.3%. More importantly, it avoids a large regression once https://github.com/llvm/llvm-project/pull/107114 is merged. Without this change, there would be a 0.4% regression in code size and 4% (!) regression in thin link time. There is no impact on run-time performance.