### PR TITLE
[compiler-rt][rtsan] Improve error message wording to match ASan style

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_context.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_context.cpp
@@ -95,10 +95,11 @@ void __rtsan::PrintDiagnostics(const char *intercepted_function_name, uptr pc,
                                uptr bp) {
   ScopedErrorReportLock l;
 
-  fprintf(stderr,
-          "Real-time violation: intercepted call to real-time unsafe function "
-          "`%s` in real-time context! Stack trace:\n",
-          intercepted_function_name);
+  Report("ERROR: RealtimeSanitizer: unsafe-library-call\n");
+  Printf("Intercepted call to real-time unsafe function "
+         "`%s` in real-time context!\n",
+         intercepted_function_name);
+
   __rtsan::PrintStackTrace(pc, bp);
 }
 

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_utilities.h
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_utilities.h
@@ -30,9 +30,10 @@ void ExpectRealtimeDeath(Function &&Func,
 
   auto GetExpectedErrorSubstring = [&]() -> std::string {
     return intercepted_method_name != nullptr
-               ? "Real-time violation: intercepted call to real-time unsafe "
-                 "function `" +
-                     std::string(intercepted_method_name) + "`"
+               ? ".*==ERROR: RealtimeSanitizer: unsafe-library-call.*"
+                 "Intercepted call to real-time unsafe function `" +
+                     std::string(intercepted_method_name) +
+                     "` in real-time context!"
                : "";
   };
 

--- a/compiler-rt/test/rtsan/basic.cpp
+++ b/compiler-rt/test/rtsan/basic.cpp
@@ -17,6 +17,7 @@ void violation() [[clang::nonblocking]] {
 int main() {
   violation();
   return 0;
-  // CHECK: Real-time violation: intercepted call to real-time unsafe function `malloc` in real-time context! Stack trace:
+  // CHECK: ==ERROR: RealtimeSanitizer: unsafe-library-call
+  // CHECK-NEXT: Intercepted call to real-time unsafe function `malloc` in real-time context!
   // CHECK-NEXT: {{.*malloc*}}
 }

--- a/compiler-rt/test/rtsan/disabler.cpp
+++ b/compiler-rt/test/rtsan/disabler.cpp
@@ -41,7 +41,7 @@ int main() {
   // CHECK: Allocated pointer {{.*}} in disabled context
   // CHECK: Allocated second pointer {{.*}} in disabled context
   // CHECK: Free'd second pointer in disabled context
-  // CHECK: {{.*Real-time violation.*}}
+  // CHECK: ==ERROR: RealtimeSanitizer: unsafe-library-call
   // CHECK-NOT: {{.*malloc*}}
   // CHECK-NEXT: {{.*free.*}}
 }


### PR DESCRIPTION
New error messages look like:

```
==4866==ERROR: RealtimeSanitizer: unsafe-library-call
Intercepted call to real-time unsafe function `malloc` in real-time context!
    #0 0x000100c838c4 in malloc rtsan_interceptors.cpp:310
    #1 0x000195bd7bd0 in operator new(unsigned long)+0x1c (libc++abi.dylib:arm64+0x16bd0)
    #2 0x5b12800100703f30  (<unknown module>)
    #3 0x000100703f70 in main main.cpp:23
    #4 0x0001958960dc  (<unknown module>)
    #5 0x4669fffffffffffc  (<unknown module>)
```

The main changes:
* We now use `Report` instead of fprintf to kick off the error message. This puts the `==PID==` in the front of the message.
* We are having a first line be "greppable and semi-structured" in that it is: `==PID==ERROR: RealtimeSanitizer: specific-reason-code` - again matching asan.
* The next line is a human readable reason describing the issue `Intercepted call to real-time unsafe function `fname` in real-time context!`
* Then the stack trace (we have removed the words "Stack trace:"


The current version looks like this, for reference:
```
Real-time violation: intercepted call to real-time unsafe function `malloc` in real-time context! Stack trace:
    #0 0x6106dc6253c8 in malloc
...
```
