### PR TITLE
[SystemZ][z/OS] Enable lit testing for z/OS

### DIFF
--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -844,7 +844,7 @@ size_t raw_fd_ostream::preferred_buffer_size() const {
     return 0;
   return raw_ostream::preferred_buffer_size();
 #elif defined(__MVS__)
-  // The buffer size on zOS is defined with macro BUFSIZ, which can be retrieved
+  // The buffer size on z/OS is defined with macro BUFSIZ, which can be retrieved
   // by invoking function raw_ostream::preferred_buffer_size().
   return raw_ostream::preferred_buffer_size();
 #else

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -844,8 +844,8 @@ size_t raw_fd_ostream::preferred_buffer_size() const {
     return 0;
   return raw_ostream::preferred_buffer_size();
 #elif defined(__MVS__)
-  // The buffer size on z/OS is defined with macro BUFSIZ, which can be retrieved
-  // by invoking function raw_ostream::preferred_buffer_size().
+  // The buffer size on z/OS is defined with macro BUFSIZ, which can be
+  // retrieved by invoking function raw_ostream::preferred_buffer_size().
   return raw_ostream::preferred_buffer_size();
 #else
   assert(FD >= 0 && "File not yet open!");

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -843,6 +843,10 @@ size_t raw_fd_ostream::preferred_buffer_size() const {
   if (IsWindowsConsole)
     return 0;
   return raw_ostream::preferred_buffer_size();
+#elif defined(__MVS__)
+  // The buffer size on zOS is defined with macro BUFSIZ, which can be retrieved
+  // by invoking function raw_ostream::preferred_buffer_size().
+  return raw_ostream::preferred_buffer_size();
 #else
   assert(FD >= 0 && "File not yet open!");
   struct stat statbuf;

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import platform
 import time
 
 import lit.Test
@@ -136,6 +137,6 @@ class Run(object):
                     "Raised process limit from %d to %d" % (soft_limit, desired_limit)
                 )
         except Exception as ex:
-            # Warn, unless this is Windows, in which case this is expected.
-            if os.name != "nt":
+            # Warn, unless this is Windows or z/OS, in which case this is expected.
+            if os.name != "nt" and platform.system() != "OS/390":
                 self.lit_config.warning("Failed to raise process limit: %s" % ex)

--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -502,7 +502,7 @@ def killProcessAndChildrenIsSupported():
         otherwise is contains a string describing why the function is
         not supported.
     """
-    if platform.system() == "AIX":
+    if platform.system() == "AIX" or platform.system() == "OS/390":
         return (True, "")
     try:
         import psutil  # noqa: F401
@@ -528,6 +528,9 @@ def killProcessAndChildren(pid):
     """
     if platform.system() == "AIX":
         subprocess.call("kill -kill $(ps -o pid= -L{})".format(pid), shell=True)
+    elif platform.system() == "OS/390":
+        # FIXME: Only the process is killed.
+        subprocess.call("kill -KILL $(ps -s {} -o pid=)".format(pid), shell=True)
     else:
         import psutil
 


### PR DESCRIPTION
This patch fixes various errors to enable llvm-lit to run on z/OS