### PR TITLE
[Vectorize] Update comment of getSubdividedVectorType

### DIFF
--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -492,9 +492,9 @@ public:
     return VectorType::get(EltTy, VTy->getElementCount());
   }
 
-  // This static method returns a VectorType with a smaller number of elements
-  // of a larger type than the input element type. For example, a <16 x i8>
-  // subdivided twice would return <4 x i32>
+  // This static method returns a VectorType with a larger number of elements
+  // of a smaller type than the input element type. For example, a <16 x i8>
+  // subdivided twice would return <64 x i2>
   static VectorType *getSubdividedVectorType(VectorType *VTy, int NumSubdivs) {
     for (int i = 0; i < NumSubdivs; ++i) {
       VTy = VectorType::getDoubleElementsVectorType(VTy);

--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -493,8 +493,8 @@ public:
   }
 
   // This static method returns a VectorType with a larger number of elements
-  // of a smaller type than the input element type. For example, a <16 x i8>
-  // subdivided twice would return <64 x i2>
+  // of a smaller type than the input element type. For example, a <4 x i64>
+  // subdivided twice would return <16 x i16>
   static VectorType *getSubdividedVectorType(VectorType *VTy, int NumSubdivs) {
     for (int i = 0; i < NumSubdivs; ++i) {
       VTy = VectorType::getDoubleElementsVectorType(VTy);

--- a/llvm/unittests/IR/VectorTypesTest.cpp
+++ b/llvm/unittests/IR/VectorTypesTest.cpp
@@ -125,6 +125,10 @@ TEST(VectorTypesTest, FixedLength) {
   EltCnt = V8Int64Ty->getElementCount();
   EXPECT_EQ(EltCnt.getKnownMinValue(), 8U);
   ASSERT_FALSE(EltCnt.isScalable());
+
+  auto *SubTy = VectorType::getSubdividedVectorType(V16Int8Ty, 2);
+  EXPECT_EQ(SubTy->getElementCount(), ElementCount::getFixed(64));
+  EXPECT_TRUE(SubTy->getElementType()->isIntegerTy(2));
 }
 
 TEST(VectorTypesTest, Scalable) {

--- a/llvm/unittests/IR/VectorTypesTest.cpp
+++ b/llvm/unittests/IR/VectorTypesTest.cpp
@@ -126,9 +126,9 @@ TEST(VectorTypesTest, FixedLength) {
   EXPECT_EQ(EltCnt.getKnownMinValue(), 8U);
   ASSERT_FALSE(EltCnt.isScalable());
 
-  auto *SubTy = VectorType::getSubdividedVectorType(V16Int8Ty, 2);
-  EXPECT_EQ(SubTy->getElementCount(), ElementCount::getFixed(64));
-  EXPECT_TRUE(SubTy->getElementType()->isIntegerTy(2));
+  auto *SubTy = VectorType::getSubdividedVectorType(V4Int64Ty, 2);
+  EXPECT_EQ(SubTy->getElementCount(), ElementCount::getFixed(16));
+  EXPECT_TRUE(SubTy->getElementType()->isIntegerTy(16));
 }
 
 TEST(VectorTypesTest, Scalable) {


### PR DESCRIPTION
The original comment here is wrong, as demonstrated by the included test.

Update the comment to reflect what getSubdividedVectorType actually does.