### PR TITLE
[compiler-rt][rtsan] Use Die instead of exit, define cf.exitcode

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_context.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_context.cpp
@@ -62,7 +62,7 @@ static __rtsan::Context &GetContextForThisThreadImpl() {
     Until then, and to keep the first PRs small, only the exit mode
     is available.
 */
-static void InvokeViolationDetectedAction() { exit(EXIT_FAILURE); }
+static void InvokeViolationDetectedAction() { Die(); }
 
 __rtsan::Context::Context() = default;
 

--- a/compiler-rt/lib/rtsan/rtsan_flags.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_flags.cpp
@@ -35,6 +35,7 @@ void __rtsan::InitializeFlags() {
   {
     CommonFlags cf;
     cf.CopyFrom(*common_flags());
+    cf.exitcode = 43; // (TR-)808 % 255 = 43
     cf.external_symbolizer_path = GetEnv("RTSAN_SYMBOLIZER_PATH");
     OverrideCommonFlags(cf);
   }

--- a/compiler-rt/lib/rtsan/rtsan_flags.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_flags.cpp
@@ -35,7 +35,7 @@ void __rtsan::InitializeFlags() {
   {
     CommonFlags cf;
     cf.CopyFrom(*common_flags());
-    cf.exitcode = 43; // (TR-)808 % 255 = 43
+    cf.exitcode = 43;
     cf.external_symbolizer_path = GetEnv("RTSAN_SYMBOLIZER_PATH");
     OverrideCommonFlags(cf);
   }

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_main.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_main.cpp
@@ -8,7 +8,24 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "sanitizer_common/sanitizer_platform.h"
 #include "sanitizer_test_utils.h"
+
+// Default RTSAN_OPTIONS for the unit tests.
+extern "C" const char *__rtsan_default_options() {
+#if SANITIZER_APPLE
+  // On Darwin, we default to `abort_on_error=1`, which would make tests run
+  // much slower. Let's override this and run lit tests with 'abort_on_error=0'
+  // and make sure we do not overwhelm the syslog while testing. Also, let's
+  // turn symbolization off to speed up testing, especially when not running
+  // with llvm-symbolizer but with atos.
+  return "symbolize=false:abort_on_error=0:log_to_syslog=0";
+#else
+  // Let's turn symbolization off to speed up testing (more than 3 times speedup
+  // observed).
+  return "symbolize=false";
+#endif
+}
 
 int main(int argc, char **argv) {
   testing::GTEST_FLAG(death_test_style) = "threadsafe";

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_utilities.h
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_utilities.h
@@ -37,8 +37,8 @@ void ExpectRealtimeDeath(Function &&Func,
                : "";
   };
 
-  EXPECT_EXIT(RealtimeInvoke(std::forward<Function>(Func)),
-              ExitedWithCode(EXIT_FAILURE), GetExpectedErrorSubstring());
+  EXPECT_EXIT(RealtimeInvoke(std::forward<Function>(Func)), ExitedWithCode(43),
+              GetExpectedErrorSubstring());
 }
 
 template <typename Function> void ExpectNonRealtimeSurvival(Function &&Func) {

--- a/compiler-rt/test/rtsan/lit.cfg.py
+++ b/compiler-rt/test/rtsan/lit.cfg.py
@@ -3,6 +3,22 @@ import os
 # Setup config name.
 config.name = "RTSAN" + config.name_suffix
 
+
+default_rtsan_opts = "atexit_sleep_ms=0"
+
+if config.host_os == "Darwin":
+    # On Darwin, we default to `abort_on_error=1`, which would make tests run
+    # much slower. Let's override this and run lit tests with 'abort_on_error=0'.
+    default_rtsan_opts += ":abort_on_error=0"
+
+if default_rtsan_opts:
+    config.environment["RTSAN_OPTIONS"] = default_rtsan_opts
+    default_rtsan_opts += ":"
+
+config.substitutions.append(
+    ("%env_rtsan_opts=", "env RTSAN_OPTIONS=" + default_rtsan_opts)
+)
+
 # Setup source root.
 config.test_source_root = os.path.dirname(__file__)
 


### PR DESCRIPTION
This is typical sanitizer behavior.

Specifically, what die does is aborts on mac by default, and exits on other platforms. This gives the ability to collect very nice stack traces (see info here https://discourse.llvm.org/t/why-do-sanitizers-abort-on-error-by-default-on-mac-and-android/80807)

With this, we need to do a few things:
* Turn off abort_on_error on our unit tests, both lit and unit. I grabbed code from asan that does this, along with helpful comments as to why it is being done.
* Set an error code that is unique to rtsan. 

A note on the error code. It must be < 255 on mac at least, I chose the 808 drum machine as a little nod to audio tech. Happy to change this if you have another favorite number.