### PR TITLE
Fix compiler errors in GVN.h for clang versions older than 15

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -131,13 +131,22 @@
 #if (!(defined(_WIN32) || defined(__CYGWIN__)) ||                              \
      (defined(__MINGW32__) && defined(__clang__)))
 #define LLVM_LIBRARY_VISIBILITY LLVM_ATTRIBUTE_VISIBILITY_HIDDEN
+// Clang compilers older then 15 do not support gnu style attributes on
+// namespaces.
+#if defined(__clang__) && __clang_major__ < 15
+#define LLVM_LIBRARY_VISIBILITY_NAMESPACE [[gnu::visibility("hidden")]]
+#else
+#define LLVM_LIBRARY_VISIBILITY_NAMESPACE LLVM_ATTRIBUTE_VISIBILITY_HIDDEN
+#endif
 #define LLVM_ALWAYS_EXPORT LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #elif defined(_WIN32)
 #define LLVM_ALWAYS_EXPORT __declspec(dllexport)
 #define LLVM_LIBRARY_VISIBILITY
+#define LLVM_LIBRARY_VISIBILITY_NAMESPACE
 #else
 #define LLVM_LIBRARY_VISIBILITY
 #define LLVM_ALWAYS_EXPORT
+#define LLVM_LIBRARY_VISIBILITY_NAMESPACE
 #endif
 
 /// LLVM_ABI is the main export/visibility macro to mark something as explicitly

--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -56,7 +56,7 @@ class TargetLibraryInfo;
 class Value;
 /// A private "module" namespace for types and utilities used by GVN. These
 /// are implementation details and should not be used by clients.
-namespace LLVM_LIBRARY_VISIBILITY gvn {
+namespace LLVM_LIBRARY_VISIBILITY_NAMESPACE gvn {
 
 struct AvailableValue;
 struct AvailableValueInBlock;


### PR DESCRIPTION
Fix compiler errors in GVN.h from clang versions older than 15 that don't support gnu style attribute on namespaces. @tstellar, @compnerd.