### PR TITLE
[libc] Remove -ffreestanding when building MPFR wrapper.

### DIFF
--- a/libc/utils/MPFRWrapper/CMakeLists.txt
+++ b/libc/utils/MPFRWrapper/CMakeLists.txt
@@ -5,6 +5,8 @@ if(LIBC_TESTS_CAN_USE_MPFR)
     mpfr_inc.h
   )
   _get_common_test_compile_options(compile_options "" "")
+  # mpfr/gmp headers do not work with -ffreestanding flag.
+  list(REMOVE_ITEM compile_options "-ffreestanding")
   target_compile_options(libcMPFRWrapper PRIVATE -O3 ${compile_options})
   add_dependencies(
     libcMPFRWrapper


### PR DESCRIPTION
MPFR/GMP headers do not work with -ffreestanding flags.