### PR TITLE
[flang] Relax ETIME(VALUES=) runtime checking

### DIFF
--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -490,16 +490,20 @@ void RTNAME(Etime)(const Descriptor *values, const Descriptor *time,
     auto typeCode{values->type().GetCategoryAndKind()};
     // ETIME values argument must have decimal range == 2.
     RUNTIME_CHECK(terminator,
-        values->rank() == 1 && values->GetDimension(0).Extent() == 2 &&
-            typeCode && typeCode->first == Fortran::common::TypeCategory::Real);
+        values->rank() == 1 && typeCode &&
+            typeCode->first == Fortran::common::TypeCategory::Real);
     // Only accept KIND=4 here.
     int kind{typeCode->second};
     RUNTIME_CHECK(terminator, kind == 4);
-
-    ApplyFloatingPointKind<StoreFloatingPointAt, void>(
-        kind, terminator, *values, /* atIndex = */ 0, usrTime);
-    ApplyFloatingPointKind<StoreFloatingPointAt, void>(
-        kind, terminator, *values, /* atIndex = */ 1, sysTime);
+    auto extent{values->GetDimension(0).Extent()};
+    if (extent >= 1) {
+      ApplyFloatingPointKind<StoreFloatingPointAt, void>(
+          kind, terminator, *values, /* atIndex = */ 0, usrTime);
+    }
+    if (extent >= 2) {
+      ApplyFloatingPointKind<StoreFloatingPointAt, void>(
+          kind, terminator, *values, /* atIndex = */ 1, sysTime);
+    }
   }
 
   if (time) {


### PR DESCRIPTION
Don't require the "VALUES=" argument to the extension intrinsic procedure ETIME to have exactly two elements.  Other compilers that support ETIME do not, and it's easy to adapt the behavior to whatever the dynamic size turns out to be.