### PR TITLE
[GISel] Use Function::getFunctionType() instead of getType() in some remarks.

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -3943,7 +3943,8 @@ bool IRTranslator::runOnMachineFunction(MachineFunction &CurMF) {
   if (CLI->fallBackToDAGISel(*MF)) {
     OptimizationRemarkMissed R("gisel-irtranslator", "GISelFailure",
                                F.getSubprogram(), &F.getEntryBlock());
-    R << "unable to lower function: " << ore::NV("Prototype", F.getType());
+    R << "unable to lower function: "
+      << ore::NV("Prototype", F.getFunctionType());
     reportTranslationError(*MF, *TPC, *ORE, R);
     return false;
   }
@@ -3965,7 +3966,8 @@ bool IRTranslator::runOnMachineFunction(MachineFunction &CurMF) {
   if (!CLI->lowerFormalArguments(*EntryBuilder, F, VRegArgs, FuncInfo)) {
     OptimizationRemarkMissed R("gisel-irtranslator", "GISelFailure",
                                F.getSubprogram(), &F.getEntryBlock());
-    R << "unable to lower arguments: " << ore::NV("Prototype", F.getType());
+    R << "unable to lower arguments: "
+      << ore::NV("Prototype", F.getFunctionType());
     reportTranslationError(*MF, *TPC, *ORE, R);
     return false;
   }

--- a/llvm/test/CodeGen/ARM/GlobalISel/arm-unsupported.ll
+++ b/llvm/test/CodeGen/ARM/GlobalISel/arm-unsupported.ll
@@ -8,41 +8,41 @@
 ; be unsupported on the ARM target. It should progressively shrink in size.
 
 define <4 x i32> @test_int_vectors(<4 x i32> %a, <4 x i32> %b) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: <4 x i32> (<4 x i32>, <4 x i32>)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_int_vectors
   %res = add <4 x i32> %a, %b
   ret <4 x i32> %res
 }
 
 define <4 x float> @test_float_vectors(<4 x float> %a, <4 x float> %b) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: <4 x float> (<4 x float>, <4 x float>)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_float_vectors
   %res = fadd <4 x float> %a, %b
   ret <4 x float> %res
 }
 
 define i64 @test_i64(i64 %a, i64 %b) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: i64 (i64, i64)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_i64
   %res = add i64 %a, %b
   ret i64 %res
 }
 
 define void @test_i64_arr([1 x i64] %a) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: void ([1 x i64])
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_i64_arr
   ret void
 }
 
 define i128 @test_i128(i128 %a, i128 %b) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: i128 (i128, i128)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_i128
   %res = add i128 %a, %b
   ret i128 %res
 }
 
 define i17 @test_funny_ints(i17 %a, i17 %b) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: i17 (i17, i17)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_funny_ints
   %res = add i17 %a, %b
   ret i17 %res
@@ -78,7 +78,7 @@ define %large.struct @test_large_struct_return() {
 %mixed.struct = type {ptr, float, i32}
 
 define %mixed.struct @test_mixed_struct(%mixed.struct %x) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: %mixed.struct (%mixed.struct)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_mixed_struct
   ret %mixed.struct %x
 }
@@ -86,19 +86,19 @@ define %mixed.struct @test_mixed_struct(%mixed.struct %x) {
 %bad.element.type = type {i24, i24}
 
 define void @test_bad_element_struct(%bad.element.type %x) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: void (%bad.element.type)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_bad_element_struct
   ret void
 }
 
 define void @test_vararg_definition(i32 %a, ...) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: void (i32, ...)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_vararg_definition
   ret void
 }
 
 define i32 @test_thumb(i32 %a) #0 {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: i32 (i32)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_thumb
   ret i32 %a
 }
@@ -123,7 +123,7 @@ define i32 @test_thread_local_global() {
 %byval.class = type { i32 }
 
 define void @test_byval_arg(ptr byval(%byval.class) %x) {
-; CHECK: remark: {{.*}} unable to lower arguments: ptr
+; CHECK: remark: {{.*}} unable to lower arguments: void (ptr)
 ; CHECK-LABEL: warning: Instruction selection used fallback path for test_byval
   ret void
 }

--- a/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-args-bf16-err.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-args-bf16-err.ll
@@ -11,6 +11,6 @@ entry:
   ret void
 }
 
-; CHECK: LLVM ERROR: unable to lower arguments: ptr (in function: test_args_nxv1bf16)
+; CHECK: LLVM ERROR: unable to lower arguments: void (<vscale x 1 x bfloat>) (in function: test_args_nxv1bf16)
 
 

--- a/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-args-f16-err.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/vec-args-f16-err.ll
@@ -11,6 +11,6 @@ entry:
   ret void
 }
 
-; CHECK: LLVM ERROR: unable to lower arguments: ptr (in function: test_args_nxv1f16)
+; CHECK: LLVM ERROR: unable to lower arguments: void (<vscale x 1 x half>) (in function: test_args_nxv1f16)
 
 


### PR DESCRIPTION
getType() on a Function is always 'ptr'. We should use getFunctionType() so we get the function signature.