### PR TITLE
[clang-tidy] only diagnose definitions in readability-enum-initial-value

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/EnumInitialValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/EnumInitialValueCheck.cpp
@@ -161,7 +161,7 @@ void EnumInitialValueCheck::check(const MatchFinder::MatchResult &Result) {
   if (const auto *Enum = Result.Nodes.getNodeAs<EnumDecl>("inconsistent")) {
     DiagnosticBuilder Diag =
         diag(Enum->getBeginLoc(),
-             "inital values in enum %0 are not consistent, consider explicit "
+             "initial values in enum %0 are not consistent, consider explicit "
              "initialization of all, none or only the first enumerator")
         << Enum;
     for (const EnumConstantDecl *ECD : Enum->enumerators())

--- a/clang-tools-extra/clang-tidy/readability/EnumInitialValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/EnumInitialValueCheck.cpp
@@ -141,16 +141,18 @@ void EnumInitialValueCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 }
 
 void EnumInitialValueCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(
-      enumDecl(unless(isMacro()), unless(hasConsistentInitialValues()))
-          .bind("inconsistent"),
-      this);
+  Finder->addMatcher(enumDecl(isDefinition(), unless(isMacro()),
+                              unless(hasConsistentInitialValues()))
+                         .bind("inconsistent"),
+                     this);
   if (!AllowExplicitZeroFirstInitialValue)
     Finder->addMatcher(
-        enumDecl(hasZeroInitialValueForFirstEnumerator()).bind("zero_first"),
+        enumDecl(isDefinition(), hasZeroInitialValueForFirstEnumerator())
+            .bind("zero_first"),
         this);
   if (!AllowExplicitSequentialInitialValues)
-    Finder->addMatcher(enumDecl(unless(isMacro()), hasSequentialInitialValues())
+    Finder->addMatcher(enumDecl(isDefinition(), unless(isMacro()),
+                                hasSequentialInitialValues())
                            .bind("sequential"),
                        this);
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -133,8 +133,9 @@ Changes in existing checks
   member function calls too.
 
 - Improved :doc:`readability-enum-initial-value
-  <clang-tidy/checks/readability-enum-initial-value>` check to only issue
-  diagnostics for the definition of an ``enum``.
+  <clang-tidy/checks/readability/enum-initial-value>` check by only issuing
+  diagnostics for the definition of an ``enum``, and by fixing a typo in the
+  diagnostic.
 
 - Improved :doc:`performance-avoid-endl
   <clang-tidy/checks/performance/avoid-endl>` check to use ``std::endl`` as

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -132,6 +132,10 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-std-print>` check to support replacing
   member function calls too.
 
+- Improved :doc:`readability-enum-initial-value
+  <clang-tidy/checks/readability-enum-initial-value>` check to only issue
+  diagnostics for the definition of an ``enum``.
+
 - Improved :doc:`performance-avoid-endl
   <clang-tidy/checks/performance/avoid-endl>` check to use ``std::endl`` as
   placeholder when lexer cannot get source text.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/enum-initial-value.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/enum-initial-value.c
@@ -78,3 +78,17 @@ enum EnumSequentialInitialValue {
   EnumSequentialInitialValue_2 = 4,
   // CHECK-FIXES-ENABLE: EnumSequentialInitialValue_2 ,
 };
+
+// gh107590
+enum WithFwdDecl : int;
+
+enum WithFwdDecl : int {
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: inital values in enum 'WithFwdDecl' are not consistent
+  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: inital values in enum 'WithFwdDecl' are not consistent
+  E0,
+  // CHECK-FIXES: E0 = 0,
+  E1 = 1,
+  E2,
+  // CHECK-FIXES: E2 = 2,
+};
+

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/enum-initial-value.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/enum-initial-value.c
@@ -6,8 +6,8 @@
 // RUN:     }}'
 
 enum EError {
-  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: inital values in enum 'EError' are not consistent
-  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: inital values in enum 'EError' are not consistent
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: initial values in enum 'EError' are not consistent
+  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: initial values in enum 'EError' are not consistent
   EError_a = 1,
   EError_b,
   // CHECK-FIXES: EError_b = 2,
@@ -34,8 +34,8 @@ enum EAll {
 
 #define ENUMERATOR_1 EMacro1_b
 enum EMacro1 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: inital values in enum 'EMacro1' are not consistent
-  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: inital values in enum 'EMacro1' are not consistent
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: initial values in enum 'EMacro1' are not consistent
+  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: initial values in enum 'EMacro1' are not consistent
   EMacro1_a = 1,
   ENUMERATOR_1,
   // CHECK-FIXES: ENUMERATOR_1 = 2,
@@ -45,8 +45,8 @@ enum EMacro1 {
 
 #define ENUMERATOR_2 EMacro2_b = 2
 enum EMacro2 {
-  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: inital values in enum 'EMacro2' are not consistent
-  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: inital values in enum 'EMacro2' are not consistent
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: initial values in enum 'EMacro2' are not consistent
+  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: initial values in enum 'EMacro2' are not consistent
   EMacro2_a = 1,
   ENUMERATOR_2,
   EMacro2_c,
@@ -80,15 +80,38 @@ enum EnumSequentialInitialValue {
 };
 
 // gh107590
-enum WithFwdDecl : int;
+enum WithFwdDeclInconsistent : int;
 
-enum WithFwdDecl : int {
-  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: inital values in enum 'WithFwdDecl' are not consistent
-  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: inital values in enum 'WithFwdDecl' are not consistent
-  E0,
-  // CHECK-FIXES: E0 = 0,
-  E1 = 1,
-  E2,
-  // CHECK-FIXES: E2 = 2,
+enum WithFwdDeclInconsistent : int {
+  // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: initial values in enum 'WithFwdDeclInconsistent' are not consistent
+  // CHECK-MESSAGES-ENABLE: :[[@LINE-2]]:1: warning: initial values in enum 'WithFwdDeclInconsistent' are not consistent
+  EFI0,
+  // CHECK-FIXES: EFI0 = 0,
+  EFI1 = 1,
+  EFI2,
+  // CHECK-FIXES: EFI2 = 2,
+};
+
+enum WithFwdDeclZeroFirst : int;
+
+enum WithFwdDeclZeroFirst : int {
+  // CHECK-MESSAGES-ENABLE: :[[@LINE+1]]:3: warning: zero initial value for the first enumerator in 'WithFwdDeclZeroFirst' can be disregarded
+  EFZ0 = 0,
+  // CHECK-FIXES-ENABLE: EFZ0 ,
+  EFZ1,
+  EFZ2,
+};
+
+
+enum WithFwdDeclSequential : int;
+
+enum WithFwdDeclSequential : int {
+  // CHECK-MESSAGES-ENABLE: :[[@LINE-1]]:1: warning: sequential initial value in 'WithFwdDeclSequential' can be ignored
+  EFS0 = 2,
+  // CHECK-FIXES-ENABLE: EFS0 = 2,
+  EFS1 = 3,
+  // CHECK-FIXES-ENABLE: EFS1 ,
+  EFS2 = 4,
+  // CHECK-FIXES-ENABLE: EFS2 ,
 };
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/enum-initial-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/enum-initial-value.cpp
@@ -1,7 +1,7 @@
 // RUN: %check_clang_tidy %s readability-enum-initial-value %t
 
 enum class EError {
-  // CHECK-MESSAGES: :[[@LINE-1]]:1:  warning: inital values in enum 'EError' are not consistent
+  // CHECK-MESSAGES: :[[@LINE-1]]:1:  warning: initial values in enum 'EError' are not consistent
   EError_a = 1,
   EError_b,
   // CHECK-FIXES: EError_b = 2,


### PR DESCRIPTION
With the `isDefinition` matcher, the analysis and diagnostics will be
constrained to definitions only. Previously forward declarations were
diagnosed as well.

Fixes #107590
