### PR TITLE
Fix build errors with a `LLVM_ENABLE_MODULES=ON` build

### DIFF
--- a/clang/include/clang/Tooling/Inclusions/StandardLibrary.h
+++ b/clang/include/clang/Tooling/Inclusions/StandardLibrary.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace clang {
 class Decl;

--- a/llvm/include/llvm/Analysis/SyntheticCountsUtils.h
+++ b/llvm/include/llvm/Analysis/SyntheticCountsUtils.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/ScaledNumber.h"
+#include <vector>
 
 namespace llvm {
 

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_TRANSFORMS_INSTCOMBINE_INSTCOMBINER_H
 #define LLVM_TRANSFORMS_INSTCOMBINE_INSTCOMBINER_H
 
+#include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Analysis/DomConditionCache.h"
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/Analysis/TargetFolder.h"


### PR DESCRIPTION
The errors fixed were:
* llvm-project/llvm/include/llvm/Analysis/SyntheticCountsUtils.h:33:22: error: missing '#include <__fwd/vector.h>'; default argument of 'vector' must be defined before it is used
* llvm-project/clang/include/clang/Tooling/Inclusions/StandardLibrary.h:41:15: error: missing '#include <vector>'; 'vector' must be declared before it is used
* llvm-project/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h:83:3: error: missing '#include "llvm/ADT/PostOrderIterator.h"'; 'ReversePostOrderTraversal' must be declared before it is used