### PR TITLE
[Coverage] Ignore unused functions if the count is 0.

### DIFF
--- a/compiler-rt/test/profile/instrprof-merging-2.cpp
+++ b/compiler-rt/test/profile/instrprof-merging-2.cpp
@@ -1,5 +1,6 @@
 // UNSUPPORTED: target={{.*windows.*}}
 
+// clang-format off
 // RUN: split-file %s %t
 // RUN: %clangxx_profgen -fcoverage-mapping %t/test1.cpp -o %t/test1.exe
 // RUN: %clangxx_profgen -fcoverage-mapping %t/test2.cpp -o %t/test2.exe

--- a/compiler-rt/test/profile/instrprof-merging-2.cpp
+++ b/compiler-rt/test/profile/instrprof-merging-2.cpp
@@ -1,0 +1,54 @@
+// UNSUPPORTED: target={{.*windows.*}}
+
+// RUN: split-file %s %t
+// RUN: %clangxx_profgen -fcoverage-mapping %t/test1.cpp -o %t/test1.exe
+// RUN: %clangxx_profgen -fcoverage-mapping %t/test2.cpp -o %t/test2.exe
+// RUN: env LLVM_PROFILE_FILE=%t/test1.profraw %run %t/test1.exe
+// RUN: env LLVM_PROFILE_FILE=%t/test2.profraw %run %t/test2.exe
+// RUN: llvm-profdata merge %t/test1.profraw %t/test2.profraw -o %t/merged.profdata
+// RUN: llvm-cov show -instr-profile=%t/merged.profdata -object %t/test1.exe %t/test2.exe | FileCheck %s
+// RUN: llvm-cov show -instr-profile=%t/merged.profdata -object %t/test2.exe %t/test1.exe | FileCheck %s
+
+// CHECK:       |struct Test {
+// CHECK-NEXT: 1|  int getToTest() {
+// CHECK-NEXT: 2|    for (int i = 0; i < 1; i++) {
+// CHECK-NEXT: 1|      if (false) {
+// CHECK-NEXT: 0|        return 1;
+// CHECK-NEXT: 0|      }
+// CHECK-NEXT: 1|    }
+// CHECK-NEXT: 1|    if (true) {
+// CHECK-NEXT: 1|      return 1;
+// CHECK-NEXT: 1|    }
+// CHECK-NEXT: 0|    return 1;
+// CHECK-NEXT: 1|  }
+// CHECK-NEXT:  |};
+// CHECK-NEXT:  |
+
+#--- test.h
+struct Test {
+  int getToTest() {
+    for (int i = 0; i < 1; i++) {
+      if (false) {
+        return 1;
+      }
+    }
+    if (true) {
+      return 1;
+    }
+    return 1;
+  }
+};
+
+#--- test1.cpp
+#include "test.h"
+int main() {
+  Test t;
+  t.getToTest();
+  return 0;
+}
+
+#--- test2.cpp
+#include "test.h"
+int main() {
+  return 0;
+}

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -851,7 +851,7 @@ Error CoverageMapping::loadFunctionRecord(
   // won't (in which case we don't unintuitively report functions as uncovered
   // when they have non-zero counts in the profile).
   if (Record.MappingRegions.size() == 1 &&
-      Record.MappingRegions[0].Count.isZero() && Counts[0] > 0)
+      Record.MappingRegions[0].Count.isZero())
     return Error::success();
 
   MCDCDecisionRecorder MCDCDecisions;


### PR DESCRIPTION
Relax the condition to ignore the case when count is 0. 

This fixes a bug on https://github.com/llvm/llvm-project/commit/381e9d2386facea7f2acc0f8c16a6d0731267f80. This was reported at https://discourse.llvm.org/t/coverage-from-multiple-test-executables/81024/.

