### PR TITLE
[clang][docs] Add clang-tutor to ExternalClangExamples.

### DIFF
--- a/clang/docs/ExternalClangExamples.rst
+++ b/clang/docs/ExternalClangExamples.rst
@@ -98,3 +98,6 @@ List of projects and tools
    uses of reserved identifiers to ensuring that code adheres to lifecycle
    protocols for certain LibreOffice-specific classes.  They may serve as
    examples for writing RecursiveASTVisitor-based plugins."
+
+`<https://github.com/banach-space/clang-tutor>`_
+   "A collection of out-of-tree Clang plugins for teaching and learning"

--- a/clang/docs/ExternalClangExamples.rst
+++ b/clang/docs/ExternalClangExamples.rst
@@ -34,7 +34,7 @@ List of projects and tools
    etc."
 
 `<https://rprichard.github.io/CxxCodeBrowser/>`_
-   "A C/C++ source code indexer and navigator"
+   "A C/C++ source code indexer and navigator."
 
 `<https://github.com/etaoins/qconnectlint>`_
    "qconnectlint is a Clang tool for statically verifying the consistency
@@ -100,4 +100,4 @@ List of projects and tools
    examples for writing RecursiveASTVisitor-based plugins."
 
 `<https://github.com/banach-space/clang-tutor>`_
-   "A collection of out-of-tree Clang plugins for teaching and learning"
+   "A collection of out-of-tree Clang plugins for teaching and learning."


### PR DESCRIPTION
Closes #107584.