### PR TITLE
[Transforms] Vectorizing Mem2Reg Pass

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -409,10 +409,11 @@ public:
     return getNode(BB);
   }
 
-  /// getNode using direct index access when it is available.
+  /// getNode - Access a node directly when its node number is known.
   DomTreeNodeBase<NodeT> *getNode(unsigned Idx) const {
-    if (Idx < DomTreeNodes.size())
-      return DomTreeNodes[Idx].get();
+    // DT is 1-indexed.
+    if (Idx + 1 < DomTreeNodes.size())
+      return DomTreeNodes[Idx + 1].get();
     return nullptr;
   }
 

--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -409,6 +409,13 @@ public:
     return getNode(BB);
   }
 
+  /// getNode using direct index access when it is available.
+  DomTreeNodeBase<NodeT> *getNode(unsigned Idx) const {
+    if (Idx < DomTreeNodes.size())
+      return DomTreeNodes[Idx].get();
+    return nullptr;
+  }
+
   /// getRootNode - This returns the entry node for the CFG of the function.  If
   /// this tree represents the post-dominance relations for a function, however,
   /// this root may be a node with the block == NULL.  This is the case when

--- a/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
+++ b/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
@@ -56,8 +56,6 @@
 #include <utility>
 #include <vector>
 
-#include <sstream>
-
 using namespace llvm;
 
 #define DEBUG_TYPE "mem2reg"
@@ -679,38 +677,6 @@ public:
     return llvm::map_range(PHIBlocks[AllocaIndex], [this](BBNumberTy BB) {
       return BBList[BB];
     });
-  }
-
-  std::string dump() {
-    std::vector<std::string> AllocaNames;
-    for (AllocaInst *A: Allocas) {
-      AllocaNames.push_back(A->getNameOrAsOperand());
-    }
-
-    auto AllocaStateToString = [&](AllocaState A) {
-      std::stringstream r;
-      auto V =  A.to_ullong();
-      while (V) {
-        int idx = llvm::countr_zero(V);
-        r << AllocaNames[idx] << ' ';
-        V ^= (1u << idx);
-      }
-      return r.str();
-    };
-
-    std::stringstream result;
-    for (size_t I = 0; I < BBList.size(); ++I) {
-      AllocaState Def = BlockStates.get<DEF_STATE>(I);
-      AllocaState Live = BlockStates.get<LIVEIN_STATE>(I);
-      AllocaState Update = BlockStates.get<UPDATE_STATE>(I);
-      AllocaState IDF = BlockStates.get<IDF_STATE>(I);
-
-      result << "BB" << I << "{ DEF[" << AllocaStateToString(Def)
-             << "] LIVE[" << AllocaStateToString(Live)
-             << "] UPDATE[" << AllocaStateToString(Update)
-             << "] IDF[" << AllocaStateToString(IDF) <<"]} \n";
-    }
-    return result.str();
   }
 };
 

--- a/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
+++ b/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
@@ -1534,7 +1534,7 @@ void VectorizedMem2Reg::Calculate() {
 
   // Order inserted PHI nodes in a deterministic way.
   for (size_t I = 0; I < Allocas.size(); ++I)
-    std::sort(PHIBlocks[I].begin(), PHIBlocks[I].end());
+    llvm::sort(PHIBlocks[I]);
 }
 
 /// Queue a phi-node to be added to a basic-block for a specific Alloca.


### PR DESCRIPTION
This patch adds a vectorized graph traversal algorithm for Mem2Reg pass that can speed it up many times (best case upper bound: 64, or max bit width of a register, worst case guaranteed not to be slower).


Background:
Internal profiling results show certain source files is bogging down in SROA pass where almost all the time is spent on Mem2Reg (this pass replaces allocas with registers, and inserts PHI as needed). This is caused by repeated CFG traversal for every alloca in liveness analysis and dominance frontier (DF) computation, where enumerating the predecessors and successors of basic blocks is very costly. The symptom typically happens on source files that generated very complex CFG (such as having many nested branches and loops, or using goto statements), such as parser projects. Mem2Reg is obviously needed for any -O builds, so there is a need to speed it up in this case.

There is an opportunity to optimize it here, that several (N) allocas can be processed at once, and if their liveness ranges and dominance frontiers overlap by a large portion, we will reduce CFG traversal by N-1 times. Furthermore, since now BBs have assigned number, we can operate the algorithm on a vector indexed by BB number, instead of enumerating the actual BB nodes in CFG. 

This patch applies these two changes, as they seems to be highly coupled (only doing one would hurt compilation performance), because there is not an efficient way to map BB (pointers) to a custom state. First it materializes BB's predecessors and successors and stores their numbers, and uses bit vector to represent a batch of allocas to be processed. Now the algorithm computing liveness and DF operates on a vector (size == #BBs) of bit-vector (size == #allocas per batch) states instead, and some changes need to be applied to the scalar algorithm. In particular, when the scalar algorithm checks whether a BB is in "visited" set, the vectorized algorithm should check whether the BB's existing state OR the new state (values that expand into this BB) would set new bits or not, and repeat the traversal until reaching a fixed point. The fixed point provides the worst case guarantee, since each time at least 1 bit is set, the overall complexity is strictly less than the sum of scalar algorithm traversals. 


The current commit enables this new algorithm by default, which is not intended when this patch is eventually merged. The rest of the change is ready for review, and the option to use this new algorithm will be set to false once reviewed. Doing this just to let build bots to test the new algorithm to make sure there's no bug. I am looking for a thorough review of the algorithm. 


Some timing results for the original file leading to this patch

Before 

```
===-------------------------------------------------------------------------===
                          Pass execution timing report
===-------------------------------------------------------------------------===
  Total Execution Time: 67.4580 seconds (67.5015 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
  31.0238 ( 46.6%)   0.3432 ( 38.4%)  31.3670 ( 46.5%)  31.3867 ( 46.5%)  SROAPass
  14.3334 ( 21.5%)   0.1414 ( 15.8%)  14.4748 ( 21.5%)  14.4879 ( 21.5%)  SampleProfileLoaderPass
   6.6684 ( 10.0%)   0.0174 (  2.0%)   6.6859 (  9.9%)   6.6892 (  9.9%)  GVNPass
   3.4279 (  5.1%)   0.0027 (  0.3%)   3.4306 (  5.1%)   3.4332 (  5.1%)  MemCpyOptPass
   2.9816 (  4.5%)   0.0054 (  0.6%)   2.9870 (  4.4%)   2.9893 (  4.4%)  LoopSimplifyPass
   2.5414 (  3.8%)   0.1240 ( 13.9%)   2.6653 (  4.0%)   2.6658 (  3.9%)  InstCombinePass
   1.0237 (  1.5%)   0.0282 (  3.2%)   1.0519 (  1.6%)   1.0524 (  1.6%)  SimplifyCFGPass
   0.6650 (  1.0%)   0.0131 (  1.5%)   0.6781 (  1.0%)   0.6781 (  1.0%)  JumpThreadingPass
```

After 

```
===-------------------------------------------------------------------------===
                          Pass execution timing report
===-------------------------------------------------------------------------===
  Total Execution Time: 49.1570 seconds (49.1920 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
  15.7304 ( 33.9%)   0.7636 ( 28.1%)  16.4940 ( 33.6%)  16.5181 ( 33.6%)  SampleProfileLoaderPass
  10.9576 ( 23.6%)   0.1350 (  5.0%)  11.0926 ( 22.6%)  11.0964 ( 22.6%)  GVNPass
   2.9374 (  6.3%)   1.2438 ( 45.7%)   4.1812 (  8.5%)   4.1827 (  8.5%)  SROAPass
   4.0594 (  8.7%)   0.0189 (  0.7%)   4.0783 (  8.3%)   4.0798 (  8.3%)  MemCpyOptPass
   3.2248 (  6.9%)   0.0082 (  0.3%)   3.2330 (  6.6%)   3.2351 (  6.6%)  LoopSimplifyPass
   2.9886 (  6.4%)   0.1647 (  6.1%)   3.1532 (  6.4%)   3.1541 (  6.4%)  InstCombinePass
   1.1956 (  2.6%)   0.0237 (  0.9%)   1.2194 (  2.5%)   1.2199 (  2.5%)  SimplifyCFGPass
   0.6961 (  1.5%)   0.0538 (  2.0%)   0.7500 (  1.5%)   0.7503 (  1.5%)  JumpThreadingPass
```
