### PR TITLE
LCA: migrate from DA to LAA; fix cost computation

### DIFF
--- a/llvm/include/llvm/Analysis/LoopAccessAnalysis.h
+++ b/llvm/include/llvm/Analysis/LoopAccessAnalysis.h
@@ -270,6 +270,8 @@ public:
     return PointerBounds;
   }
 
+  uint64_t getMinDepDist() const { return MinDepDistBytes; }
+
 private:
   /// A wrapper around ScalarEvolution, used to add runtime SCEV checks, and
   /// applies dynamic knowledge to simplify SCEV expressions and convert them

--- a/llvm/include/llvm/Analysis/LoopCacheAnalysis.h
+++ b/llvm/include/llvm/Analysis/LoopCacheAnalysis.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_ANALYSIS_LOOPCACHEANALYSIS_H
 #define LLVM_ANALYSIS_LOOPCACHEANALYSIS_H
 
+#include "llvm/Analysis/LoopAccessAnalysis.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/IR/PassManager.h"
 #include <optional>
@@ -82,7 +83,8 @@ public:
   /// MaxDistance and std::nullopt if unsure.
   std::optional<bool> hasTemporalReuse(const IndexedReference &Other,
                                        unsigned MaxDistance, const Loop &L,
-                                       DependenceInfo &DI, AAResults &AA) const;
+                                       const LoopAccessInfo &LAI,
+                                       AAResults &AA) const;
 
   /// Compute the cost of the reference w.r.t. the given loop \p L when it is
   /// considered in the innermost position in the loop nest.
@@ -199,7 +201,8 @@ public:
   /// between array elements accessed in a loop so that the elements are
   /// classified to have temporal reuse.
   CacheCost(const LoopVectorTy &Loops, const LoopInfo &LI, ScalarEvolution &SE,
-            TargetTransformInfo &TTI, AAResults &AA, DependenceInfo &DI,
+            TargetTransformInfo &TTI, AAResults &AA,
+            LoopAccessInfoManager &LAIs,
             std::optional<unsigned> TRT = std::nullopt);
 
   /// Create a CacheCost for the loop nest rooted by \p Root.
@@ -207,7 +210,8 @@ public:
   /// between array elements accessed in a loop so that the elements are
   /// classified to have temporal reuse.
   static std::unique_ptr<CacheCost>
-  getCacheCost(Loop &Root, LoopStandardAnalysisResults &AR, DependenceInfo &DI,
+  getCacheCost(Loop &Root, LoopStandardAnalysisResults &AR,
+               LoopAccessInfoManager &LAIs,
                std::optional<unsigned> TRT = std::nullopt);
 
   /// Return the estimated cost of loop \p L if the given loop is part of the
@@ -276,7 +280,7 @@ private:
   ScalarEvolution &SE;
   TargetTransformInfo &TTI;
   AAResults &AA;
-  DependenceInfo &DI;
+  LoopAccessInfoManager &LAIs;
 };
 
 raw_ostream &operator<<(raw_ostream &OS, const IndexedReference &R);

--- a/llvm/lib/Analysis/LoopCacheAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopCacheAnalysis.cpp
@@ -724,7 +724,7 @@ CacheCostTy CacheCost::computeRefGroupCacheCost(const ReferenceGroupTy &RG,
 PreservedAnalyses LoopCachePrinterPass::run(Loop &L, LoopAnalysisManager &AM,
                                             LoopStandardAnalysisResults &AR,
                                             LPMUpdater &U) {
-  LoopAccessInfoManager LAIs(AR.SE, AR.AA, AR.DT, AR.LI, &AR.TTI, nullptr);
+  LoopAccessInfoManager LAIs(AR.SE, AR.AA, AR.DT, AR.LI, &AR.TTI, &AR.TLI);
   if (auto CC = CacheCost::getCacheCost(L, AR, LAIs))
     OS << *CC;
 

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1714,7 +1714,7 @@ PreservedAnalyses LoopInterchangePass::run(LoopNest &LN,
                                            LPMUpdater &U) {
   Function &F = *LN.getParent();
 
-  LoopAccessInfoManager LAIs(AR.SE, AR.AA, AR.DT, AR.LI, &AR.TTI, nullptr);
+  LoopAccessInfoManager LAIs(AR.SE, AR.AA, AR.DT, AR.LI, &AR.TTI, &AR.TLI);
   std::unique_ptr<CacheCost> CC =
       CacheCost::getCacheCost(LN.getOutermostLoop(), AR, LAIs);
   OptimizationRemarkEmitter ORE(&F);

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1714,10 +1714,11 @@ PreservedAnalyses LoopInterchangePass::run(LoopNest &LN,
                                            LPMUpdater &U) {
   Function &F = *LN.getParent();
 
-  DependenceInfo DI(&F, &AR.AA, &AR.SE, &AR.LI);
+  LoopAccessInfoManager LAIs(AR.SE, AR.AA, AR.DT, AR.LI, &AR.TTI, nullptr);
   std::unique_ptr<CacheCost> CC =
-      CacheCost::getCacheCost(LN.getOutermostLoop(), AR, DI);
+      CacheCost::getCacheCost(LN.getOutermostLoop(), AR, LAIs);
   OptimizationRemarkEmitter ORE(&F);
+  DependenceInfo DI(&F, &AR.AA, &AR.SE, &AR.LI);
   if (!LoopInterchange(&AR.SE, &AR.LI, &DI, &AR.DT, CC, &ORE).run(LN))
     return PreservedAnalyses::all();
   U.markLoopNestChanged(true);

--- a/llvm/test/Analysis/LoopCacheAnalysis/PowerPC/compute-cost.ll
+++ b/llvm/test/Analysis/LoopCacheAnalysis/PowerPC/compute-cost.ll
@@ -114,11 +114,7 @@ for.neg.end:                                          ; preds = %for.neg.cond
 ;   for (int i = 40960; i > 0; i--)
 ;     B[i] = B[40960 - i];
 
-; FIXME: Currently negative access functions are treated the same as positive
-; access functions. When this is fixed this testcase should have a cost
-; approximately 2x higher.
-
-; CHECK: Loop 'for.cond2' has cost = 2561
+; CHECK: Loop 'for.cond2' has cost = 5122
 define void @Test2(ptr %B) {
 entry:
   br label %for.cond2

--- a/llvm/test/Analysis/LoopCacheAnalysis/compute-cost.ll
+++ b/llvm/test/Analysis/LoopCacheAnalysis/compute-cost.ll
@@ -121,12 +121,8 @@ for.neg.end:                                          ; preds = %for.neg.cond
 ;   for (int i = 40960; i > 0; i--)
 ;     B[i] = B[40960 - i];
 
-; FIXME: Currently negative access functions are treated the same as positive
-; access functions. When this is fixed this testcase should have a cost
-; approximately 2x higher.
-
-; SMALLER-CACHELINE: Loop 'for.cond2' has cost = 10241
-; LARGER-CACHELINE: Loop 'for.cond2' has cost = 1281
+; SMALLER-CACHELINE: Loop 'for.cond2' has cost = 20482
+; LARGER-CACHELINE: Loop 'for.cond2' has cost = 2562
 define void @Test2(ptr %B) {
 entry:
   br label %for.cond2


### PR DESCRIPTION
LoopCacheAnalysis currently uses DependenceAnalysis, which hasn't been worked on for years. Migrate it to use the newer and actively-maintaiend LoopAccessAnalysis, fixing a long-standing cost-computation issue, due to an underlying bug in DependenceAnalysis.