### PR TITLE
[AMDGPU] Remove unnecessary untieRegOperand

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIWholeQuadMode.cpp
+++ b/llvm/lib/Target/AMDGPU/SIWholeQuadMode.cpp
@@ -1534,7 +1534,6 @@ bool SIWholeQuadMode::lowerCopyInstrs() {
       if (MI->getOperand(2).isReg())
         RecomputeReg = MI->getOperand(2).getReg();
       MI->removeOperand(2);
-      MI->untieRegOperand(1);
     } else {
       assert(MI->getNumExplicitOperands() == 2);
     }


### PR DESCRIPTION
As far as I can tell, V_SET_INACTIVE has never had tied operands.
