### PR TITLE
[TableGen] Migrate Option Emitters to const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/Common/OptEmitter.h
+++ b/llvm/utils/TableGen/Common/OptEmitter.h
@@ -1,4 +1,4 @@
-//===- OptEmitter.h - Helper for emitting options. --------------*- C++ -*-===//
+//===- OptEmitter.h - Helper for emitting options ---------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,7 +11,7 @@
 
 namespace llvm {
 class Record;
-int CompareOptionRecords(Record *const *Av, Record *const *Bv);
+bool CompareOptionRecords(const Record *A, const Record *B);
 } // namespace llvm
 
 #endif // LLVM_UTILS_TABLEGEN_COMMON_OPTEMITTER_H

--- a/llvm/utils/TableGen/ExegesisEmitter.cpp
+++ b/llvm/utils/TableGen/ExegesisEmitter.cpp
@@ -30,7 +30,7 @@ namespace {
 
 class ExegesisEmitter {
 public:
-  ExegesisEmitter(RecordKeeper &RK);
+  ExegesisEmitter(const RecordKeeper &RK);
 
   void run(raw_ostream &OS) const;
 
@@ -51,7 +51,7 @@ private:
 
   void emitPfmCountersLookupTable(raw_ostream &OS) const;
 
-  RecordKeeper &Records;
+  const RecordKeeper &Records;
   std::string Target;
 
   // Table of counter name -> counter index.
@@ -59,7 +59,7 @@ private:
 };
 
 static std::map<llvm::StringRef, unsigned>
-collectPfmCounters(RecordKeeper &Records) {
+collectPfmCounters(const RecordKeeper &Records) {
   std::map<llvm::StringRef, unsigned> PfmCounterNameTable;
   const auto AddPfmCounterName = [&PfmCounterNameTable](
                                      const Record *PfmCounterDef) {
@@ -67,7 +67,8 @@ collectPfmCounters(RecordKeeper &Records) {
     if (!Counter.empty())
       PfmCounterNameTable.emplace(Counter, 0);
   };
-  for (Record *Def : Records.getAllDerivedDefinitions("ProcPfmCounters")) {
+  for (const Record *Def :
+       Records.getAllDerivedDefinitions("ProcPfmCounters")) {
     // Check that ResourceNames are unique.
     llvm::SmallSet<llvm::StringRef, 16> Seen;
     for (const Record *IssueCounter :
@@ -95,9 +96,9 @@ collectPfmCounters(RecordKeeper &Records) {
   return PfmCounterNameTable;
 }
 
-ExegesisEmitter::ExegesisEmitter(RecordKeeper &RK)
+ExegesisEmitter::ExegesisEmitter(const RecordKeeper &RK)
     : Records(RK), PfmCounterNameTable(collectPfmCounters(RK)) {
-  std::vector<Record *> Targets = Records.getAllDerivedDefinitions("Target");
+  ArrayRef<const Record *> Targets = Records.getAllDerivedDefinitions("Target");
   if (Targets.size() == 0)
     PrintFatalError("No 'Target' subclasses defined!");
   if (Targets.size() != 1)
@@ -223,7 +224,7 @@ void ExegesisEmitter::emitPfmCounters(raw_ostream &OS) const {
 } // namespace
 
 void ExegesisEmitter::emitPfmCountersLookupTable(raw_ostream &OS) const {
-  std::vector<Record *> Bindings =
+  std::vector<const Record *> Bindings =
       Records.getAllDerivedDefinitions("PfmCountersBinding");
   assert(!Bindings.empty() && "there must be at least one binding");
   llvm::sort(Bindings, [](const Record *L, const Record *R) {
@@ -232,7 +233,7 @@ void ExegesisEmitter::emitPfmCountersLookupTable(raw_ostream &OS) const {
 
   OS << "// Sorted (by CpuName) array of pfm counters.\n"
      << "static const CpuAndPfmCounters " << Target << "CpuPfmCounters[] = {\n";
-  for (Record *Binding : Bindings) {
+  for (const Record *Binding : Bindings) {
     // Emit as { "cpu", procinit },
     OS << "  { \""                                                        //
        << Binding->getValueAsString("CpuName") << "\","                   //

--- a/llvm/utils/TableGen/OptParserEmitter.cpp
+++ b/llvm/utils/TableGen/OptParserEmitter.cpp
@@ -250,15 +250,15 @@ static void EmitHelpTextsForVariants(
 /// OptParserEmitter - This tablegen backend takes an input .td file
 /// describing a list of options and emits a data structure for parsing and
 /// working with those options when given an input command line.
-static void EmitOptParser(RecordKeeper &Records, raw_ostream &OS) {
+static void EmitOptParser(const RecordKeeper &Records, raw_ostream &OS) {
   // Get the option groups and options.
-  const std::vector<Record *> &Groups =
+  ArrayRef<const Record *> Groups =
       Records.getAllDerivedDefinitions("OptionGroup");
-  std::vector<Record *> Opts = Records.getAllDerivedDefinitions("Option");
+  std::vector<const Record *> Opts = Records.getAllDerivedDefinitions("Option");
 
   emitSourceFileHeader("Option Parsing Definitions", OS);
 
-  array_pod_sort(Opts.begin(), Opts.end(), CompareOptionRecords);
+  llvm::sort(Opts, CompareOptionRecords);
   // Generate prefix groups.
   typedef SmallVector<SmallString<2>, 2> PrefixKeyT;
   typedef std::map<PrefixKeyT, std::string> PrefixesT;


### PR DESCRIPTION
 Migrate Opt/OptRST Emitters to const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089