### PR TITLE
[NFC][TableGen] Migrate LLVM RISCVTarget/VT Emitters to const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/VTEmitter.cpp
+++ b/llvm/utils/TableGen/VTEmitter.cpp
@@ -19,10 +19,10 @@ namespace {
 
 class VTEmitter {
 private:
-  RecordKeeper &Records;
+  const RecordKeeper &Records;
 
 public:
-  VTEmitter(RecordKeeper &R) : Records(R) {}
+  VTEmitter(const RecordKeeper &R) : Records(R) {}
 
   void run(raw_ostream &OS);
 };
@@ -91,8 +91,7 @@ void VTEmitter::run(raw_ostream &OS) {
   emitSourceFileHeader("ValueTypes Source Fragment", OS, Records);
 
   std::vector<const Record *> VTsByNumber{512};
-  auto ValueTypes = Records.getAllDerivedDefinitions("ValueType");
-  for (auto *VT : ValueTypes) {
+  for (auto *VT : Records.getAllDerivedDefinitions("ValueType")) {
     auto Number = VT->getValueAsInt("Value");
     assert(0 <= Number && Number < (int)VTsByNumber.size() &&
            "ValueType should be uint16_t");


### PR DESCRIPTION
Migrate LLVM RISCVTarget/VT Emitters to const RecordKeeper.