### PR TITLE
[SandboxIR][Bench] Fix build

### DIFF
--- a/llvm/benchmarks/SandboxIRBench.cpp
+++ b/llvm/benchmarks/SandboxIRBench.cpp
@@ -21,6 +21,7 @@
 #include "llvm/SandboxIR/SandboxIR.h"
 #include "llvm/Support/SourceMgr.h"
 #include <memory>
+#include <sstream>
 
 using namespace llvm;
 


### PR DESCRIPTION
Add header files(sstream), so that msvc can be compiled normally.

1>SandboxIRBench.cpp
1>benchmarks\SandboxIRBench.cpp(68,21): error C2079: 'SS' uses undefined class 'std::basic_stringstream<char,std::char_traits<char>,std::allocator<char>>'
1>benchmarks\SandboxIRBench.cpp(69,6): error C2297: '<<': not valid as right operand has type 'const char [38]'
1>benchmarks\SandboxIRBench.cpp(69,6): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(71,8): error C2297: '<<': not valid as right operand has type 'const char [7]'
1>benchmarks\SandboxIRBench.cpp(71,27): error C2297: '<<': not valid as right operand has type 'const char [21]'
1>benchmarks\SandboxIRBench.cpp(71,27): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(72,6): error C2297: '<<': not valid as right operand has type 'const char [9]'
1>benchmarks\SandboxIRBench.cpp(72,6): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(73,6): error C2297: '<<': not valid as right operand has type 'const char [2]'
1>benchmarks\SandboxIRBench.cpp(73,6): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(110,21): error C2079: 'SS' uses undefined class 'std::basic_stringstream<char,std::char_traits<char>,std::allocator<char>>'
1>benchmarks\SandboxIRBench.cpp(111,6): error C2297: '<<': not valid as right operand has type 'const char [38]'
1>benchmarks\SandboxIRBench.cpp(111,6): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(112,6): error C2297: '<<': not valid as right operand has type 'const char [28]'
1>benchmarks\SandboxIRBench.cpp(112,6): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(113,6): error C2297: '<<': not valid as right operand has type 'const char [28]'
1>benchmarks\SandboxIRBench.cpp(113,6): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(115,8): error C2297: '<<': not valid as right operand has type 'const char [7]'
1>benchmarks\SandboxIRBench.cpp(115,27): error C2297: '<<': not valid as right operand has type 'const char [25]'
1>benchmarks\SandboxIRBench.cpp(115,27): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(116,6): error C2297: '<<': not valid as right operand has type 'const char [9]'
1>benchmarks\SandboxIRBench.cpp(116,6): warning C4552: '<<': result of expression not used
1>benchmarks\SandboxIRBench.cpp(117,6): error C2297: '<<': not valid as right operand has type 'const char [2]'
1>benchmarks\SandboxIRBench.cpp(117,6): warning C4552: '<<': result of expression not used