### PR TITLE
[LLVM]Fix symbol visibility macros not being define for AIX

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -189,7 +189,7 @@
 #define LLVM_TEMPLATE_ABI __declspec(dllimport)
 #define LLVM_EXPORT_TEMPLATE
 #endif
-#elif defined(__ELF__) || defined(__MINGW32__)
+#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX)
 #define LLVM_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define LLVM_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define LLVM_EXPORT_TEMPLATE


### PR DESCRIPTION
This is to try and fix buildbot failure on [clang-ppc64-aix](https://lab.llvm.org/buildbot/#/builders/64/builds/881) from my changes in #96630.  I don't really know much about AIX so it would be good to have someone more knowledgeable to say if visibility macros on extern templates is needed on AIX similar to ELF.  @compnerd @tstellar 