### PR TITLE
[libc] Add proxy header for the jmp_buf type

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -190,3 +190,12 @@ add_proxy_header_library(
     libc.include.signal
 )
 
+add_proxy_header_library(
+  jmp_buf
+  HDRS
+    jmp_buf.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.jmp_buf
+    libc.include.setjmp
+)
+

--- a/libc/hdr/types/jmp_buf.h
+++ b/libc/hdr/types/jmp_buf.h
@@ -1,0 +1,22 @@
+//===-- Definition of jmp_buf.h ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apahce License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_JMP_BUF_H
+#define LLVM_LIBC_HDR_JMP_BUF_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/jmp_buf.h"
+
+#else // overlay mode
+
+#include <setjmp.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_JMP_BUF_H

--- a/libc/hdr/types/stack_t.h
+++ b/libc/hdr/types/stack_t.h
@@ -1,7 +1,7 @@
 //===-- Definition of stack_t.h -------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https:llvm.or/LICENSE.txt for license information.
+// See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //

--- a/libc/src/setjmp/aarch64/CMakeLists.txt
+++ b/libc/src/setjmp/aarch64/CMakeLists.txt
@@ -12,7 +12,7 @@ add_entrypoint_object(
   HDRS
     ../setjmp_impl.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
   ${setjmp_config_options}
 )
 
@@ -23,6 +23,6 @@ add_entrypoint_object(
   HDRS
     ../longjmp.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
   ${setjmp_config_options}
 )

--- a/libc/src/setjmp/aarch64/longjmp.cpp
+++ b/libc/src/setjmp/aarch64/longjmp.cpp
@@ -23,7 +23,7 @@ namespace LIBC_NAMESPACE_DECL {
 // them.)
 
 [[gnu::naked]] LLVM_LIBC_FUNCTION(void, longjmp,
-                                  ([[maybe_unused]] __jmp_buf * buf,
+                                  ([[maybe_unused]] jmp_buf buf,
                                    [[maybe_unused]] int val)) {
   // If BTI branch protection is in use, the compiler will automatically insert
   // a BTI here, so we don't need to make any extra effort to do so.

--- a/libc/src/setjmp/aarch64/setjmp.cpp
+++ b/libc/src/setjmp/aarch64/setjmp.cpp
@@ -12,8 +12,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-[[gnu::naked]] LLVM_LIBC_FUNCTION(int, setjmp,
-                                  ([[maybe_unused]] jmp_buf buf)) {
+[[gnu::naked]] LLVM_LIBC_FUNCTION(int, setjmp, ([[maybe_unused]] jmp_buf buf)) {
   // If BTI branch protection is in use, the compiler will automatically insert
   // a BTI here, so we don't need to make any extra effort to do so.
 

--- a/libc/src/setjmp/aarch64/setjmp.cpp
+++ b/libc/src/setjmp/aarch64/setjmp.cpp
@@ -13,7 +13,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 [[gnu::naked]] LLVM_LIBC_FUNCTION(int, setjmp,
-                                  ([[maybe_unused]] __jmp_buf * buf)) {
+                                  ([[maybe_unused]] jmp_buf buf)) {
   // If BTI branch protection is in use, the compiler will automatically insert
   // a BTI here, so we don't need to make any extra effort to do so.
 

--- a/libc/src/setjmp/arm/CMakeLists.txt
+++ b/libc/src/setjmp/arm/CMakeLists.txt
@@ -5,7 +5,7 @@ add_entrypoint_object(
   HDRS
     ../setjmp_impl.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
 )
 
 add_entrypoint_object(
@@ -15,5 +15,5 @@ add_entrypoint_object(
   HDRS
     ../longjmp.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
 )

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -16,7 +16,7 @@ namespace LIBC_NAMESPACE_DECL {
 #if defined(__thumb__) && __ARM_ARCH_ISA_THUMB == 1
 
 [[gnu::naked, gnu::target("thumb")]]
-LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
+LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
   asm(R"(
       # Reload r4, r5, r6, r7.
       ldmia r0!, {r4-r7}
@@ -54,7 +54,7 @@ LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
 // (d0-d16)
 // TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
 [[gnu::naked]]
-LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
+LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
   asm(R"(
       # While sp may appear in a register list for ARM mode, it may not for
       # Thumb2 mode. Just load the previous value of sp into r12 then move it

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -15,8 +15,9 @@ namespace LIBC_NAMESPACE_DECL {
 
 #if defined(__thumb__) && __ARM_ARCH_ISA_THUMB == 1
 
-[[gnu::naked, gnu::target("thumb")]]
-LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
+[[gnu::naked, gnu::target("thumb")]] LLVM_LIBC_FUNCTION(void, longjmp,
+                                                        (jmp_buf buf,
+                                                         int val)) {
   asm(R"(
       # Reload r4, r5, r6, r7.
       ldmia r0!, {r4-r7}
@@ -53,8 +54,7 @@ LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
 // TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers
 // (d0-d16)
 // TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
-[[gnu::naked]]
-LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
+[[gnu::naked]] LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
   asm(R"(
       # While sp may appear in a register list for ARM mode, it may not for
       # Thumb2 mode. Just load the previous value of sp into r12 then move it

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -15,7 +15,7 @@ namespace LIBC_NAMESPACE_DECL {
 #if defined(__thumb__) && __ARM_ARCH_ISA_THUMB == 1
 
 [[gnu::naked, gnu::target("thumb")]]
-LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
   asm(R"(
       # Store r4, r5, r6, and r7 into buf.
       stmia r0!, {r4-r7}
@@ -45,7 +45,7 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
 // (d0-d16)
 // TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
 [[gnu::naked]]
-LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
   asm(R"(
       # While sp may appear in a register list for ARM mode, it may not for
       # Thumb2 mode. Just move it into r12 then stm that, so that this code

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -14,8 +14,8 @@ namespace LIBC_NAMESPACE_DECL {
 
 #if defined(__thumb__) && __ARM_ARCH_ISA_THUMB == 1
 
-[[gnu::naked, gnu::target("thumb")]]
-LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
+[[gnu::naked, gnu::target("thumb")]] LLVM_LIBC_FUNCTION(int, setjmp,
+                                                        (jmp_buf buf)) {
   asm(R"(
       # Store r4, r5, r6, and r7 into buf.
       stmia r0!, {r4-r7}
@@ -44,8 +44,7 @@ LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
 // TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers
 // (d0-d16)
 // TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
-[[gnu::naked]]
-LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
+[[gnu::naked]] LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
   asm(R"(
       # While sp may appear in a register list for ARM mode, it may not for
       # Thumb2 mode. Just move it into r12 then stm that, so that this code

--- a/libc/src/setjmp/longjmp.h
+++ b/libc/src/setjmp/longjmp.h
@@ -10,11 +10,11 @@
 #define LLVM_LIBC_SRC_SETJMP_LONGJMP_H
 
 #include "src/__support/macros/config.h"
-#include <setjmp.h>
+#include "hdr/types/jmp_buf.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-void longjmp(__jmp_buf *buf, int val);
+void longjmp(jmp_buf buf, int val);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/setjmp/longjmp.h
+++ b/libc/src/setjmp/longjmp.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SETJMP_LONGJMP_H
 #define LLVM_LIBC_SRC_SETJMP_LONGJMP_H
 
-#include "src/__support/macros/config.h"
 #include "hdr/types/jmp_buf.h"
+#include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/setjmp/riscv/CMakeLists.txt
+++ b/libc/src/setjmp/riscv/CMakeLists.txt
@@ -5,7 +5,7 @@ add_entrypoint_object(
   HDRS
     ../setjmp_impl.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
   COMPILE_OPTIONS
     -O3
     -fomit-frame-pointer
@@ -18,7 +18,7 @@ add_entrypoint_object(
   HDRS
     ../longjmp.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
   COMPILE_OPTIONS
     -O3
     -fomit-frame-pointer

--- a/libc/src/setjmp/riscv/longjmp.cpp
+++ b/libc/src/setjmp/riscv/longjmp.cpp
@@ -11,8 +11,6 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
 
-#include <setjmp.h>
-
 #if !defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
 #error "Invalid file include"
 #endif
@@ -30,7 +28,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
+LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
   LOAD(ra, buf->__pc);
   LOAD(s0, buf->__regs[0]);
   LOAD(s1, buf->__regs[1]);

--- a/libc/src/setjmp/riscv/setjmp.cpp
+++ b/libc/src/setjmp/riscv/setjmp.cpp
@@ -10,8 +10,6 @@
 #include "src/__support/macros/config.h"
 #include "src/setjmp/setjmp_impl.h"
 
-#include <setjmp.h>
-
 #if !defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
 #error "Invalid file include"
 #endif
@@ -29,7 +27,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
   STORE(ra, buf->__pc);
   STORE(s0, buf->__regs[0]);
   STORE(s1, buf->__regs[1]);

--- a/libc/src/setjmp/setjmp_impl.h
+++ b/libc/src/setjmp/setjmp_impl.h
@@ -11,8 +11,8 @@
 
 // This header has the _impl prefix in its name to avoid conflict with the
 // public header setjmp.h which is also included. here.
-#include "src/__support/macros/config.h"
 #include "hdr/types/jmp_buf.h"
+#include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/setjmp/setjmp_impl.h
+++ b/libc/src/setjmp/setjmp_impl.h
@@ -12,11 +12,11 @@
 // This header has the _impl prefix in its name to avoid conflict with the
 // public header setjmp.h which is also included. here.
 #include "src/__support/macros/config.h"
-#include <setjmp.h>
+#include "hdr/types/jmp_buf.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-int setjmp(__jmp_buf *buf);
+int setjmp(jmp_buf buf);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/setjmp/x86_64/CMakeLists.txt
+++ b/libc/src/setjmp/x86_64/CMakeLists.txt
@@ -5,7 +5,7 @@ add_entrypoint_object(
   HDRS
     ../setjmp_impl.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
   COMPILE_OPTIONS
     -O3
     -fno-omit-frame-pointer
@@ -23,7 +23,7 @@ add_entrypoint_object(
   HDRS
     ../longjmp.h
   DEPENDS
-    libc.include.setjmp
+    libc.hdr.types.jmp_buf
   COMPILE_OPTIONS
     -O3
     -fomit-frame-pointer

--- a/libc/src/setjmp/x86_64/longjmp.cpp
+++ b/libc/src/setjmp/x86_64/longjmp.cpp
@@ -16,7 +16,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
+LLVM_LIBC_FUNCTION(void, longjmp, (jmp_buf buf, int val)) {
   register __UINT64_TYPE__ rbx __asm__("rbx");
   register __UINT64_TYPE__ rbp __asm__("rbp");
   register __UINT64_TYPE__ r12 __asm__("r12");

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -16,7 +16,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
   register __UINT64_TYPE__ rbx __asm__("rbx");
   register __UINT64_TYPE__ r12 __asm__("r12");
   register __UINT64_TYPE__ r13 __asm__("r13");

--- a/libc/test/src/setjmp/CMakeLists.txt
+++ b/libc/test/src/setjmp/CMakeLists.txt
@@ -12,7 +12,6 @@ add_libc_unittest(
   SRCS
     setjmp_test.cpp
   DEPENDS
-    libc.include.setjmp
     libc.src.setjmp.longjmp
     libc.src.setjmp.setjmp
 )


### PR DESCRIPTION
Added proxy header for the jmp_buf type and changed all use instances from __jmp_buf * to the typedef alias jmp_buf , fixed the link to LLVM in stack_t.h description