### PR TITLE
[flang][runtime] Accept '\n' as space in internal list-directed input

### DIFF
--- a/flang/runtime/io-stmt.h
+++ b/flang/runtime/io-stmt.h
@@ -194,8 +194,9 @@ public:
       std::size_t &byteCount) {
     auto ch{GetCurrentChar(byteCount)};
     bool inNamelist{mutableModes().inNamelist};
-    while (!ch || *ch == ' ' || *ch == '\t' || (inNamelist && *ch == '!')) {
-      if (ch && (*ch == ' ' || *ch == '\t')) {
+    while (!ch || *ch == ' ' || *ch == '\t' || *ch == '\n' ||
+        (inNamelist && *ch == '!')) {
+      if (ch && (*ch == ' ' || *ch == '\t' || *ch == '\n')) {
         HandleRelativePosition(byteCount);
       } else if (!AdvanceRecord()) {
         return Fortran::common::nullopt;


### PR DESCRIPTION
When scanning ahead for the first character in the next input item in list-directed internal input, allow a newline character to appear and treat it as a space, matching the behavior of nearly all other Fortran compilers.