### PR TITLE
[rtsan] Add basic test for c compilation

### DIFF
--- a/compiler-rt/test/rtsan/basic.cpp
+++ b/compiler-rt/test/rtsan/basic.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
+// RUN: %clang -fsanitize=realtime %s -o %t
 // RUN: not %run %t 2>&1 | FileCheck %s
 // UNSUPPORTED: ios
 


### PR DESCRIPTION
I was reminded of https://github.com/realtime-sanitizer/radsan/issues/25, where we were including C++ code that was never linked in C.

Adding this test to ensure that we don't break this functionality in the future