### PR TITLE
[flang][runtime] Allow OPEN(,RECL=) on open unit with no RECL=

### DIFF
--- a/flang/runtime/io-api.cpp
+++ b/flang/runtime/io-api.cpp
@@ -952,7 +952,7 @@ bool IODEF(SetRecl)(Cookie cookie, std::size_t n) {
     io.GetIoErrorHandler().SignalError("RECL= must be greater than zero");
     return false;
   } else if (open->wasExtant() &&
-      open->unit().openRecl.value_or(0) != static_cast<std::int64_t>(n)) {
+      open->unit().openRecl.value_or(n) != static_cast<std::int64_t>(n)) {
     open->SignalError("RECL= may not be changed for an open unit");
     return false;
   } else {


### PR DESCRIPTION
Most Fortran implementations allow an OPEN(,RECL=n) statement to impose a record length on an already-opened unit that was opened with no RECL=, typically OPEN(6,RECL=<big number>) to avoid automatic line-wrapping of output.  We emit an unconditional error if the unit was already open, as must be the case for preconnected unit 6. Make the error conditional on RECL= simply not having been already set.