### PR TITLE
[ThinLTO] Use DenseMap for OidGuidMap

### DIFF
--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -1343,7 +1343,7 @@ private:
 
   /// Mapping from original ID to GUID. If original ID can map to multiple
   /// GUIDs, it will be mapped to 0.
-  std::map<GlobalValue::GUID, GlobalValue::GUID> OidGuidMap;
+  DenseMap<GlobalValue::GUID, GlobalValue::GUID> OidGuidMap;
 
   /// Indicates that summary-based GlobalValue GC has run, and values with
   /// GVFlags::Live==false are really dead. Otherwise, all values must be


### PR DESCRIPTION
We use OidGuidMap only to map an old GUID to a new one.  We don't use
std::set's strengths like iterators staying valid or the ability to
traverse in a sorted order.

As a data point, during the ThinLTO indexing step of a large
application of ours, we create 440,000 mappings.  Our memory profiler
reports reduction of 127MB in the peak memory usage (out of 4.991GB),
which is bigger than expected savings most likely due to some noise.
The savings should be about 8MB at the max load factor of DenseMap.
