### PR TITLE
[NFCI][BitcodeReader]Read real GUID from VI as opposed to storing it in map

### DIFF
--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -943,10 +943,8 @@ class ModuleSummaryIndexBitcodeReader : public BitcodeReaderBase {
   // they are recorded in the summary index being built.
   // We save a GUID which refers to the same global as the ValueInfo, but
   // ignoring the linkage, i.e. for values other than local linkage they are
-  // identical (this is the second tuple member).
-  // The third tuple member is the real GUID of the ValueInfo.
-  DenseMap<unsigned,
-           std::tuple<ValueInfo, GlobalValue::GUID, GlobalValue::GUID>>
+  // identical (this is the second tuple member). ValueInfo has the real GUID.
+  DenseMap<unsigned, std::pair<ValueInfo, GlobalValue::GUID>>
       ValueIdToValueInfoMap;
 
   /// Map populated during module path string table parsing, from the
@@ -999,7 +997,7 @@ private:
   parseParamAccesses(ArrayRef<uint64_t> Record);
 
   template <bool AllowNullValueInfo = false>
-  std::tuple<ValueInfo, GlobalValue::GUID, GlobalValue::GUID>
+  std::pair<ValueInfo, GlobalValue::GUID>
   getValueInfoFromValueId(unsigned ValueId);
 
   void addThisModule();
@@ -7101,7 +7099,7 @@ ModuleSummaryIndexBitcodeReader::getThisModule() {
 }
 
 template <bool AllowNullValueInfo>
-std::tuple<ValueInfo, GlobalValue::GUID, GlobalValue::GUID>
+std::pair<ValueInfo, GlobalValue::GUID>
 ModuleSummaryIndexBitcodeReader::getValueInfoFromValueId(unsigned ValueId) {
   auto VGI = ValueIdToValueInfoMap[ValueId];
   // We can have a null value info for memprof callsite info records in
@@ -7128,10 +7126,10 @@ void ModuleSummaryIndexBitcodeReader::setValueGUID(
   // UseStrtab is false for legacy summary formats and value names are
   // created on stack. In that case we save the name in a string saver in
   // the index so that the value name can be recorded.
-  ValueIdToValueInfoMap[ValueID] = std::make_tuple(
+  ValueIdToValueInfoMap[ValueID] = std::make_pair(
       TheIndex.getOrInsertValueInfo(
           ValueGUID, UseStrtab ? ValueName : TheIndex.saveString(ValueName)),
-      OriginalNameID, ValueGUID);
+      OriginalNameID);
 }
 
 // Specialized value symbol table parser used when reading module index
@@ -7219,8 +7217,8 @@ Error ModuleSummaryIndexBitcodeReader::parseValueSymbolTable(
       GlobalValue::GUID RefGUID = Record[1];
       // The "original name", which is the second value of the pair will be
       // overriden later by a FS_COMBINED_ORIGINAL_NAME in the combined index.
-      ValueIdToValueInfoMap[ValueID] = std::make_tuple(
-          TheIndex.getOrInsertValueInfo(RefGUID), RefGUID, RefGUID);
+      ValueIdToValueInfoMap[ValueID] =
+          std::make_pair(TheIndex.getOrInsertValueInfo(RefGUID), RefGUID);
       break;
     }
     }
@@ -7620,8 +7618,8 @@ Error ModuleSummaryIndexBitcodeReader::parseEntireSummary(unsigned ID) {
       } else {
         RefGUID = Record[1];
       }
-      ValueIdToValueInfoMap[ValueID] = std::make_tuple(
-          TheIndex.getOrInsertValueInfo(RefGUID), RefGUID, RefGUID);
+      ValueIdToValueInfoMap[ValueID] =
+          std::make_pair(TheIndex.getOrInsertValueInfo(RefGUID), RefGUID);
       break;
     }
     // FS_PERMODULE is legacy and does not have support for the tail call flag.
@@ -7679,9 +7677,8 @@ Error ModuleSummaryIndexBitcodeReader::parseEntireSummary(unsigned ID) {
       // the prevailing copy of a symbol. The linker doesn't resolve local
       // linkage values so don't check whether those are prevailing.
       auto LT = (GlobalValue::LinkageTypes)Flags.Linkage;
-      if (IsPrevailing &&
-          !GlobalValue::isLocalLinkage(LT) &&
-          !IsPrevailing(std::get<2>(VIAndOriginalGUID))) {
+      if (IsPrevailing && !GlobalValue::isLocalLinkage(LT) &&
+          !IsPrevailing(VIAndOriginalGUID.first.getGUID())) {
         PendingCallsites.clear();
         PendingAllocs.clear();
       }

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -943,7 +943,7 @@ class ModuleSummaryIndexBitcodeReader : public BitcodeReaderBase {
   // they are recorded in the summary index being built.
   // We save a GUID which refers to the same global as the ValueInfo, but
   // ignoring the linkage, i.e. for values other than local linkage they are
-  // identical (this is the second tuple member). ValueInfo has the real GUID.
+  // identical (this is the second member). ValueInfo has the real GUID.
   DenseMap<unsigned, std::pair<ValueInfo, GlobalValue::GUID>>
       ValueIdToValueInfoMap;
 


### PR DESCRIPTION
Currently, `ValueIdToValueInfoMap` [1] stores `std::tuple<ValueInfo, GlobalValue::GUID /* original GUID */, GlobalValue::GUID /* real GUID*/ >`. This change updates the stored value type to `std::pair<ValueInfo, GlobalValue::GUID /* original GUID */>`, and reads real GUID from ValueInfo.

When an entry is inserted into `ValueIdToValueInfoMap`, ValueInfo is created or inserted using real GUID [2]. ValueInfo keeps a pointer to GlobalValueMap [3], using either `GUID` or `{GUID, Name}` [4] when reading per-module summaries to create a combined summary.

[1] owned by per module-summary bitcode reader https://github.com/llvm/llvm-project/blob/caebb4562ce634a22f7b13480b19cffc2a6a6730/llvm/lib/Bitcode/Reader/BitcodeReader.cpp#L947-L950
[2] [first](https://github.com/llvm/llvm-project/blob/caebb4562ce634a22f7b13480b19cffc2a6a6730/llvm/lib/Bitcode/Reader/BitcodeReader.cpp#L7130-L7133), [second](https://github.com/llvm/llvm-project/blob/caebb4562ce634a22f7b13480b19cffc2a6a6730/llvm/lib/Bitcode/Reader/BitcodeReader.cpp#L7221-L7222), [third](https://github.com/llvm/llvm-project/blob/caebb4562ce634a22f7b13480b19cffc2a6a6730/llvm/lib/Bitcode/Reader/BitcodeReader.cpp#L7622-L7623)
[3] https://github.com/llvm/llvm-project/blob/caebb4562ce634a22f7b13480b19cffc2a6a6730/llvm/include/llvm/IR/ModuleSummaryIndex.h#L1427-L1431
[4] https://github.com/llvm/llvm-project/blob/caebb4562ce634a22f7b13480b19cffc2a6a6730/llvm/include/llvm/IR/ModuleSummaryIndex.h#L1631
and https://github.com/llvm/llvm-project/blob/caebb4562ce634a22f7b13480b19cffc2a6a6730/llvm/include/llvm/IR/ModuleSummaryIndex.h#L1621