### PR TITLE
[ValueTracking] Infer is-power-of-2 from assumptions.

### DIFF
--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -276,3 +276,24 @@ define i32 @cttz_of_power_of_two_wrong_constant_2(i32 %x) {
   %r = call i32 @llvm.cttz.i32(i32 %add, i1 false)
   ret i32 %r
 }
+
+define i16 @cttz_assume(i16 %x) {
+; CHECK-LABEL: @cttz_assume(
+; CHECK-NEXT:    [[ADD:%.*]] = add i16 [[X:%.*]], 1
+; CHECK-NEXT:    [[COND0:%.*]] = icmp ult i16 [[ADD]], 10
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND0]])
+; CHECK-NEXT:    [[COND1:%.*]] = icmp ne i16 [[X]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND1]])
+; CHECK-NEXT:    [[CTTZ:%.*]] = call range(i16 0, 17) i16 @llvm.cttz.i16(i16 [[X]], i1 false)
+; CHECK-NEXT:    ret i16 [[CTTZ]]
+;
+  %add = add i16 %x, 1
+  %cond0 = icmp ult i16 %add, 10
+  call void @llvm.assume(i1 %cond0)
+
+  %cond1 = icmp ne i16 %x, 0
+  call void @llvm.assume(i1 %cond1)
+
+  %cttz = call i16 @llvm.cttz.i16(i16 %x, i1 false)
+  ret i16 %cttz
+}

--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -284,7 +284,7 @@ define i16 @cttz_assume(i16 %x) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND0]])
 ; CHECK-NEXT:    [[COND1:%.*]] = icmp ne i16 [[X]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND1]])
-; CHECK-NEXT:    [[CTTZ:%.*]] = call range(i16 0, 17) i16 @llvm.cttz.i16(i16 [[X]], i1 false)
+; CHECK-NEXT:    [[CTTZ:%.*]] = call range(i16 0, 17) i16 @llvm.cttz.i16(i16 [[X]], i1 true)
 ; CHECK-NEXT:    ret i16 [[CTTZ]]
 ;
   %add = add i16 %x, 1

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -5326,3 +5326,43 @@ define i1 @pr94897(i32 range(i32 -2147483648, 0) %x) {
   %cmp = icmp ugt i32 %shl, -50331648
   ret i1 %cmp
 }
+
+define i1 @icmp_and_inv_pow2_ne_0(i32 %A, i32 %B) {
+; CHECK-LABEL: @icmp_and_inv_pow2_ne_0(
+; CHECK-NEXT:    [[POPCNT:%.*]] = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[A:%.*]])
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq i32 [[POPCNT]], 1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[INV:%.*]] = xor i32 [[B:%.*]], -1
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[A]], [[INV]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[AND]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %popcnt = tail call i32 @llvm.ctpop.i32(i32 %A)
+  %cond = icmp eq i32 %popcnt, 1
+  call void @llvm.assume(i1 %cond)
+
+  %inv = xor i32 %B, -1
+  %and = and i32 %A, %inv
+  %cmp = icmp ne i32 %and, 0
+  ret i1 %cmp
+}
+
+define i1 @icmp_and_inv_pow2_or_zero_ne_0(i32 %A, i32 %B) {
+; CHECK-LABEL: @icmp_and_inv_pow2_or_zero_ne_0(
+; CHECK-NEXT:    [[POPCNT:%.*]] = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[A:%.*]])
+; CHECK-NEXT:    [[COND:%.*]] = icmp ult i32 [[POPCNT]], 2
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[INV:%.*]] = xor i32 [[B:%.*]], -1
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[A]], [[INV]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[AND]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %popcnt = tail call i32 @llvm.ctpop.i32(i32 %A)
+  %cond = icmp ult i32 %popcnt, 2
+  call void @llvm.assume(i1 %cond)
+
+  %inv = xor i32 %B, -1
+  %and = and i32 %A, %inv
+  %cmp = icmp ne i32 %and, 0
+  ret i1 %cmp
+}

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -5332,9 +5332,8 @@ define i1 @icmp_and_inv_pow2_ne_0(i32 %A, i32 %B) {
 ; CHECK-NEXT:    [[POPCNT:%.*]] = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[A:%.*]])
 ; CHECK-NEXT:    [[COND:%.*]] = icmp eq i32 [[POPCNT]], 1
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
-; CHECK-NEXT:    [[INV:%.*]] = xor i32 [[B:%.*]], -1
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[A]], [[INV]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[AND]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[A]], [[B:%.*]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[TMP1]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %popcnt = tail call i32 @llvm.ctpop.i32(i32 %A)

--- a/llvm/test/Transforms/InstCombine/rem.ll
+++ b/llvm/test/Transforms/InstCombine/rem.ll
@@ -1047,7 +1047,8 @@ define i16 @rem_pow2_or_zero(i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[POPCNT:%.*]] = call range(i16 1, 17) i16 @llvm.ctpop.i16(i16 [[Y:%.*]])
 ; CHECK-NEXT:    [[COND:%.*]] = icmp ult i16 [[POPCNT]], 2
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[COND]])
-; CHECK-NEXT:    [[REM:%.*]] = urem i16 [[X:%.*]], [[Y]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i16 [[Y]], -1
+; CHECK-NEXT:    [[REM:%.*]] = and i16 [[X:%.*]], [[TMP1]]
 ; CHECK-NEXT:    ret i16 [[REM]]
 ;
   %popcnt = call i16 @llvm.ctpop.i16(i16 %y)
@@ -1062,7 +1063,8 @@ define i16 @rem_pow2(i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[POPCNT:%.*]] = call range(i16 1, 17) i16 @llvm.ctpop.i16(i16 [[Y:%.*]])
 ; CHECK-NEXT:    [[COND:%.*]] = icmp eq i16 [[POPCNT]], 1
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[COND]])
-; CHECK-NEXT:    [[REM:%.*]] = urem i16 [[X:%.*]], [[Y]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i16 [[Y]], -1
+; CHECK-NEXT:    [[REM:%.*]] = and i16 [[X:%.*]], [[TMP1]]
 ; CHECK-NEXT:    ret i16 [[REM]]
 ;
   %popcnt = call i16 @llvm.ctpop.i16(i16 %y)

--- a/llvm/test/Transforms/InstCombine/rem.ll
+++ b/llvm/test/Transforms/InstCombine/rem.ll
@@ -1041,3 +1041,33 @@ define <2 x i32> @PR62401(<2 x i1> %x, <2 x i32> %y) {
   %r = urem <2 x i32> %y, %sext.i1
   ret <2 x i32> %r
 }
+
+define i16 @rem_pow2_or_zero(i16 %x, i16 %y) {
+; CHECK-LABEL: @rem_pow2_or_zero(
+; CHECK-NEXT:    [[POPCNT:%.*]] = call range(i16 1, 17) i16 @llvm.ctpop.i16(i16 [[Y:%.*]])
+; CHECK-NEXT:    [[COND:%.*]] = icmp ult i16 [[POPCNT]], 2
+; CHECK-NEXT:    tail call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[REM:%.*]] = urem i16 [[X:%.*]], [[Y]]
+; CHECK-NEXT:    ret i16 [[REM]]
+;
+  %popcnt = call i16 @llvm.ctpop.i16(i16 %y)
+  %cond = icmp ult i16 %popcnt, 2
+  tail call void @llvm.assume(i1 %cond)
+  %rem = urem i16 %x, %y
+  ret i16 %rem
+}
+
+define i16 @rem_pow2(i16 %x, i16 %y) {
+; CHECK-LABEL: @rem_pow2(
+; CHECK-NEXT:    [[POPCNT:%.*]] = call range(i16 1, 17) i16 @llvm.ctpop.i16(i16 [[Y:%.*]])
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq i16 [[POPCNT]], 1
+; CHECK-NEXT:    tail call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[REM:%.*]] = urem i16 [[X:%.*]], [[Y]]
+; CHECK-NEXT:    ret i16 [[REM]]
+;
+  %popcnt = call i16 @llvm.ctpop.i16(i16 %y)
+  %cond = icmp eq i16 %popcnt, 1
+  tail call void @llvm.assume(i1 %cond)
+  %rem = urem i16 %x, %y
+  ret i16 %rem
+}


### PR DESCRIPTION
This patch tries to infer is-power-of-2 from assumptions. I don't see that this kind of assumption exists in my dataset.
Related issue: https://github.com/rust-lang/rust/issues/129795

Close https://github.com/llvm/llvm-project/issues/58996.
