### PR TITLE
[libc++][NFC] Mark P1869R1 as implemented

### DIFF
--- a/libcxx/docs/Status/Cxx20Papers.csv
+++ b/libcxx/docs/Status/Cxx20Papers.csv
@@ -152,7 +152,7 @@
 "`P1855R0 <https://wg21.link/P1855R0>`__","Make ``<compare>``\  freestanding","2019-11 (Belfast)","","",""
 "`P1862R1 <https://wg21.link/P1862R1>`__","Ranges adaptors for non-copyable iterators","2019-11 (Belfast)","|Complete|","16.0",""
 "`P1865R1 <https://wg21.link/P1865R1>`__","Add max() to latch and barrier","2019-11 (Belfast)","|Complete|","11.0",""
-"`P1869R1 <https://wg21.link/P1869R1>`__","Rename 'condition_variable_any' interruptible wait methods","2019-11 (Belfast)","","",""
+"`P1869R1 <https://wg21.link/P1869R1>`__","Rename 'condition_variable_any' interruptible wait methods","2019-11 (Belfast)","|Complete|","18.0","The paper is implemented but the features are experimental and can be enabled via ``-fexperimental-library``."
 "`P1870R1 <https://wg21.link/P1870R1>`__","forwarding-range is too subtle","2019-11 (Belfast)","|Complete|","15.0",""
 "`P1871R1 <https://wg21.link/P1871R1>`__","Concept traits should be named after concepts","2019-11 (Belfast)","|Complete|","14.0",""
 "`P1872R0 <https://wg21.link/P1872R0>`__","span should have size_type, not index_type","2019-11 (Belfast)","|Complete|","10.0",""

--- a/libcxx/docs/Status/Cxx20Papers.csv
+++ b/libcxx/docs/Status/Cxx20Papers.csv
@@ -152,7 +152,7 @@
 "`P1855R0 <https://wg21.link/P1855R0>`__","Make ``<compare>``\  freestanding","2019-11 (Belfast)","","",""
 "`P1862R1 <https://wg21.link/P1862R1>`__","Ranges adaptors for non-copyable iterators","2019-11 (Belfast)","|Complete|","16.0",""
 "`P1865R1 <https://wg21.link/P1865R1>`__","Add max() to latch and barrier","2019-11 (Belfast)","|Complete|","11.0",""
-"`P1869R1 <https://wg21.link/P1869R1>`__","Rename 'condition_variable_any' interruptible wait methods","2019-11 (Belfast)","|Complete|","18.0","The paper is implemented but the features are experimental and can be enabled via ``-fexperimental-library``."
+"`P1869R1 <https://wg21.link/P1869R1>`__","Rename 'condition_variable_any' interruptible wait methods","2019-11 (Belfast)","|Complete|","18.0",""
 "`P1870R1 <https://wg21.link/P1870R1>`__","forwarding-range is too subtle","2019-11 (Belfast)","|Complete|","15.0",""
 "`P1871R1 <https://wg21.link/P1871R1>`__","Concept traits should be named after concepts","2019-11 (Belfast)","|Complete|","14.0",""
 "`P1872R0 <https://wg21.link/P1872R0>`__","span should have size_type, not index_type","2019-11 (Belfast)","|Complete|","10.0",""


### PR DESCRIPTION
https://wg21.link/p1869r1: Rename `condition_variable_any` interruptible wait methods

The paper was implemented as experimental feature in Clang 18 in: https://github.com/llvm/llvm-project/commit/4fa812bb52a5b1eea22750a1b59f94221d0df622

Experimental status removed in: https://github.com/llvm/llvm-project/pull/107900

Closes https://github.com/llvm/llvm-project/issues/100031