### PR TITLE
[libc++][NFC] Mark P1424R1 as partially implemented

### DIFF
--- a/libcxx/docs/Status/Cxx20Papers.csv
+++ b/libcxx/docs/Status/Cxx20Papers.csv
@@ -118,7 +118,7 @@
 "`P1361R2 <https://wg21.link/P1361R2>`__","Integration of chrono with text formatting","2019-07 (Cologne)","|Partial|","",""
 "`P1423R3 <https://wg21.link/P1423R3>`__","char8_t backward compatibility remediation","2019-07 (Cologne)","|Complete|","15.0",""
 "`P1424R1 <https://wg21.link/P1424R1>`__","'constexpr' feature macro concerns","2019-07 (Cologne)","|Nothing To Do|","","Superseded by `P1902 <https://wg21.link/P1902>`__"
-"`P1466R3 <https://wg21.link/P1466R3>`__","Miscellaneous minor fixes for chrono","2019-07 (Cologne)","","",""
+"`P1466R3 <https://wg21.link/P1466R3>`__","Miscellaneous minor fixes for chrono","2019-07 (Cologne)","|Partial|","",""
 "`P1474R1 <https://wg21.link/P1474R1>`__","Helpful pointers for ContiguousIterator","2019-07 (Cologne)","|Complete|","15.0",""
 "`P1502R1 <https://wg21.link/P1502R1>`__","Standard library header units for C++20","2019-07 (Cologne)","","",""
 "`P1522R1 <https://wg21.link/P1522R1>`__","Iterator Difference Type and Integer Overflow","2019-07 (Cologne)","|Complete|","15.0",""


### PR DESCRIPTION
`hh_mm_ss` and related functions from https://wg21.link/P1466R3 was partially implemented in LLVM 10 https://github.com/llvm/llvm-project/commit/fde236b1f719b3a366af4cd5810e847cdb18e480

```C++
// 27.9, class template time_of_dayhh_mm_ss
template <class Duration> hh_mm_ss;

// 27.10, 12/24 hour functions
constexpr bool is_am(const hours& h) noexcept;
constexpr bool is_pm(const hours& h) noexcept;
constexpr hours make12(const hours& h) noexcept;
constexpr hours make24(const hours& h, bool is_pm) noexcept;
```

Accessors added in https://github.com/llvm/llvm-project/commit/db99d3a2a238f532ee8369b5599ee134db753247 (operator << is not implemented)

```C++
Modify 27.8.6.2 [time.cal.wd.members] as indicated:

constexpr explicit weekday(unsigned wd) noexcept;
Effects: Constructs an object of type weekday by initializing wd_ with wd == 7 ? 0 : wd. The value held is unspecified if wd is not in the range [0, 255].

constexpr explicit operator unsigned() const noexcept;
Returns: wd_.

constexpr unsigned c_encoding() const noexcept;
Returns: wd_.

constexpr unsigned iso_encoding() const noexcept;
Returns: wd_ == 0u ? 7u : wd_.

Modify 27.8.6.3 [time.cal.wd.nonmembers] as indicated:

constexpr bool operator==(const weekday& x, const weekday& y) noexcept;
Returns: unsigned{x} == unsigned{y} x.wd_ == y.wd_.

constexpr weekday operator+(const weekday& x, const days& y) noexcept;
Returns: weekday{modulo(static_cast<long long>(unsigned{x.wd_}) + y.count(), 7)}.

template<class charT, class traits>
  basic_ostream<charT, traits>&
    operator<<(basic_ostream<charT, traits>& os, const weekday& wd);
Effects: If wd.ok() == true inserts format(os.getloc(), fmt, wd) where fmt is "%a" widened to charT. Otherwise inserts unsigned{wd.wd_} << " is not a valid weekday".


```

Reference: 

- GitHub issue: https://github.com/llvm/llvm-project/issues/100015
- Phabricator review: https://reviews.llvm.org/D65365

