### PR TITLE
Let memref.collapse_shape implement ReifyRankedShapedTypeOpInterface.

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -1670,7 +1670,7 @@ def MemRef_ExpandShapeOp : MemRef_ReassociativeReshapeOp<"expand_shape", [
     }]>,
 
     // Builder that infers the result layout map. The result shape must be
-    // specified. Otherwise, the op may be ambiguous. The output shape for 
+    // specified. Otherwise, the op may be ambiguous. The output shape for
     // the op will be inferred using the inferOutputShape() method.
     OpBuilder<(ins "ArrayRef<int64_t>":$resultShape, "Value":$src,
                "ArrayRef<ReassociationIndices>":$reassociation)>,
@@ -1699,7 +1699,9 @@ def MemRef_ExpandShapeOp : MemRef_ReassociativeReshapeOp<"expand_shape", [
 }
 
 def MemRef_CollapseShapeOp : MemRef_ReassociativeReshapeOp<"collapse_shape", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>]>
+{
   let summary = "operation to produce a memref with a smaller rank.";
   let description = [{
     The `memref.collapse_shape` op produces a new view with a smaller rank

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -2497,6 +2497,42 @@ MemRefType CollapseShapeOp::computeCollapsedType(
                          srcType.getMemorySpace());
 }
 
+static bool isDynamicInGroup(ReassociationIndices group,
+                             ArrayRef<int64_t> sourceShape) {
+  return llvm::any_of(group, [sourceShape](int64_t dim) {
+    return ShapedType::isDynamic(sourceShape[dim]);
+  });
+}
+
+// This method supports following cases only:
+// - There is dynamic dimension in reassociation groups with single element.
+LogicalResult CollapseShapeOp::reifyResultShapes(
+    OpBuilder &builder, ReifiedRankedShapedTypeDims &reifiedResultShapes) {
+  SmallVector<ReassociationIndices, 4> reassociationArray =
+      getReassociationIndices();
+  Value source = getSrc();
+  auto sourceShape = cast<MemRefType>(source.getType()).getShape();
+  if (!ShapedType::isDynamicShape(sourceShape))
+    return failure();
+  for (auto group : enumerate(reassociationArray)) {
+    bool isDynInGroup = isDynamicInGroup(group.value(), sourceShape);
+    if (isDynInGroup && group.value().size() > 1)
+      return failure();
+  }
+  auto resultShape = cast<ShapedType>(getResultType()).getShape();
+
+  SmallVector<Value> dynamicValues;
+  for (int64_t i = 0; i < resultShape.size(); ++i) {
+    if (ShapedType::isDynamic(resultShape[i]))
+      dynamicValues.push_back(builder.create<DimOp>(
+          source.getLoc(), source,
+          builder.create<arith::ConstantIndexOp>(source.getLoc(), i)));
+  }
+  reifiedResultShapes = {getMixedValues(resultShape, dynamicValues, builder)};
+
+  return success();
+}
+
 void CollapseShapeOp::build(OpBuilder &b, OperationState &result, Value src,
                             ArrayRef<ReassociationIndices> reassociation,
                             ArrayRef<NamedAttribute> attrs) {


### PR DESCRIPTION
This MR lets memref.collapse_shape implement ReifyRankedShapedTypeOpInterface.
To be on the safe side it adds support for following case only:
 - There is dynamic dimension in reassociation groups with single element.