### PR TITLE
[LineEditor] Flush the output stream after printing the prompt

### DIFF
--- a/llvm/lib/LineEditor/LineEditor.cpp
+++ b/llvm/lib/LineEditor/LineEditor.cpp
@@ -294,6 +294,7 @@ void LineEditor::loadHistory() {}
 
 std::optional<std::string> LineEditor::readLine() const {
   ::fprintf(Data->Out, "%s", Prompt.c_str());
+  ::fflush(Data->Out);
 
   std::string Line;
   do {


### PR DESCRIPTION
Despite that a lot of libc implementations implicitly flush before read operations in interactive environments, this behaviour is not guaranteed. For example, [musl libc](https://musl.libc.org) does not do that, which causes the prompt to either not get printed or get printed at unexpected times.