### PR TITLE
[NFC][TableGen] Replace DefInit::get() with Record::getDefInit()

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1323,13 +1323,9 @@ public:
     return I->getKind() == IK_DefInit;
   }
 
-  static DefInit *get(Record*);
-
   Init *convertInitializerTo(RecTy *Ty) const override;
 
   Record *getDef() const { return Def; }
-
-  //virtual Init *convertInitializerBitRange(ArrayRef<unsigned> Bits);
 
   RecTy *getFieldType(StringInit *FieldName) const override;
 

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -3334,7 +3334,7 @@ void CodeGenDAGPatterns::ParseDefaultOperands() {
 
   // Find some SDNode.
   assert(!SDNodes.empty() && "No SDNodes parsed?");
-  Init *SomeSDNode = DefInit::get(SDNodes.begin()->first);
+  Init *SomeSDNode = SDNodes.begin()->first->getDefInit();
 
   for (unsigned i = 0, e = DefaultOps.size(); i != e; ++i) {
     DagInit *DefaultInfo = DefaultOps[i]->getValueAsDag("DefaultOps");

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -664,7 +664,7 @@ struct TupleExpander : SetTheory::Expander {
         if (i)
           Name += '_';
         Name += Reg->getName();
-        Tuple.push_back(DefInit::get(Reg));
+        Tuple.push_back(Reg->getDefInit());
       }
 
       // Take the cost list of the first register in the tuple.


### PR DESCRIPTION
Eliminate DefInit::get() as its a duplicate of Record::getDefInit(). 
Use early return in `VarDefInit::instantiate`.