### PR TITLE
[clang][Frontend] Fix Sema::PerformImplicitConversion for atomic expressions

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4393,6 +4393,10 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
     ToType = ToAtomic->getValueType();
   }
 
+  // Save the initial `atomicity` information of the From-expression for later check
+  // before it's potentially removed in the StandardConversionSequence steps 1-3.
+  const AtomicType* StartingFromAtomic = From->getType()->getAs<AtomicType>();
+
   QualType InitialFromType = FromType;
   // Perform the first implicit conversion.
   switch (SCS.First) {
@@ -4918,7 +4922,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
 
   // If this conversion sequence involved a scalar -> atomic conversion, perform
   // that conversion now.
-  if (!ToAtomicType.isNull()) {
+  if (!StartingFromAtomic && !ToAtomicType.isNull()) {
     assert(Context.hasSameType(
         ToAtomicType->castAs<AtomicType>()->getValueType(), From->getType()));
     From = ImpCastExprToType(From, ToAtomicType, CK_NonAtomicToAtomic,

--- a/clang/test/Sema/atomic-expr-rvalue.c
+++ b/clang/test/Sema/atomic-expr-rvalue.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -fsyntax-only %s -verify
+// expected-no-diagnostics
+
+typedef _Atomic char atomic_char;
+atomic_char counter;
+
+// Check correct implicit conversions of r-value atomic expressions.
+// Bugfix: https://github.com/llvm/llvm-project/issues/106576
+char load_plus_one_stmtexpr() {
+  return ({counter;}) + 1;
+}
+
+char load_stmtexpr() {
+  return ({counter;});
+}
+
+char load_cast_plus_one() {
+  return (atomic_char)('x') + 1;
+}
+
+char load_cast() {
+  return (atomic_char)('x');
+}


### PR DESCRIPTION
Fixes #106576 

In `Sema::PerformImplicitConversion` for standard conversion sequence the NonAtomicToAtomic conversion is not reverted back after 3.rd conversion step if not starting from scalar initially.

This solves this issue and also other issues  like e.g. returning r-value atomic expressions where AtomicToNonAtomic conversion should also normally occur.

Basically this means that atomicity is stripped after lvalue to rvalue conversoin of an atomic expression.

