### PR TITLE
[lld][WebAssembly] Fix use of uninitialized stack data with --wasm64

### DIFF
--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -587,8 +587,7 @@ void ElemSection::writeBody() {
     initExpr.Inst.Value.Global = WasmSym::tableBase->getGlobalIndex();
   } else {
     bool is64 = config->is64.value_or(false);
-    initExpr.Inst.Opcode = is64 ? WASM_OPCODE_I64_CONST : WASM_OPCODE_I32_CONST;
-    initExpr.Inst.Value.Int32 = config->tableBase;
+    initExpr = intConst(config->tableBase, is64);
   }
   writeInitExpr(os, initExpr);
 


### PR DESCRIPTION
In the case of `-wasm64` we were setting the type of the init expression to be 64-bit but were only setting the low 32-bits of the value (by assigning to Int32).

Fixes: https://github.com/emscripten-core/emscripten/issues/22538