### PR TITLE
[flang] Accept KIND(x) when x is assumed-rank

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -587,7 +587,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"izext", {{"i", AnyInt}}, TypePattern{IntType, KindCode::exactKind, 2}},
     {"jzext", {{"i", AnyInt}}, DefaultInt},
     {"kind",
-        {{"x", AnyIntrinsic, Rank::elemental, Optionality::required,
+        {{"x", AnyIntrinsic, Rank::anyOrAssumedRank, Optionality::required,
             common::Intent::In, {ArgFlag::canBeMoldNull}}},
         DefaultInt, Rank::elemental, IntrinsicClass::inquiryFunction},
     {"lbound",

--- a/flang/test/Evaluate/fold-assumed-rank-kind.f90
+++ b/flang/test/Evaluate/fold-assumed-rank-kind.f90
@@ -1,0 +1,6 @@
+! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+subroutine subr(ar)
+  real(8) :: ar(..)
+!CHECK:  PRINT *, 8_4
+  print *, kind(ar)
+end


### PR DESCRIPTION
Don't emit a bogus error about being unable to forward an assumed-rank dummy argument as an actual argument in the case of the KIND intrinsic function.

Fixes https://github.com/llvm/llvm-project/issues/107782.