### PR TITLE
 [RISCV][MachineCombiner] Combine `fadd X, (fneg Y)` to `fsub X, Y`

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -57,6 +57,7 @@ enum RISCVMachineCombinerPattern : unsigned {
   FNMSUB,
   SHXADD_ADD_SLLI_OP1,
   SHXADD_ADD_SLLI_OP2,
+  FADD_NEGRHS,
 };
 
 class RISCVInstrInfo : public RISCVGenInstrInfo {

--- a/llvm/test/CodeGen/RISCV/float-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/float-zfa.ll
@@ -274,8 +274,7 @@ define float @add_negimm(float %x) {
 ; CHECK-LABEL: add_negimm:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    fli.s fa5, 0.5
-; CHECK-NEXT:    fneg.s fa5, fa5
-; CHECK-NEXT:    fadd.s fa0, fa0, fa5
+; CHECK-NEXT:    fsub.s fa0, fa0, fa5
 ; CHECK-NEXT:    ret
 entry:
   %sub = fadd float %x, -5.000000e-01

--- a/llvm/test/CodeGen/RISCV/float-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/float-zfa.ll
@@ -269,3 +269,15 @@ define void @fli_remat() {
   tail call void @foo(float 1.000000e+00, float 1.000000e+00)
   ret void
 }
+
+define float @add_negimm(float %x) {
+; CHECK-LABEL: add_negimm:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    fli.s fa5, 0.5
+; CHECK-NEXT:    fneg.s fa5, fa5
+; CHECK-NEXT:    fadd.s fa0, fa0, fa5
+; CHECK-NEXT:    ret
+entry:
+  %sub = fadd float %x, -5.000000e-01
+  ret float %sub
+}


### PR DESCRIPTION
This patch adds transformation `fadd X, (fneg Y)` to `fsub X, Y` to eliminate unnecessary fneg instructions introduced by materializing fpimm -0.5 with zfa. I don't see the value of combining the commuted version because it should be handled by SDAG.

Closes https://github.com/llvm/llvm-project/issues/107772.
