### PR TITLE
[MLGO] Fix logging verbosity in scripts

### DIFF
--- a/llvm/utils/mlgo-utils/mlgo/corpus/combine_training_corpus.py
+++ b/llvm/utils/mlgo-utils/mlgo/corpus/combine_training_corpus.py
@@ -36,6 +36,7 @@ def parse_args_and_run():
     parser.add_argument(
         "--root_dir", type=str, help="The root dir of module paths to combine."
     )
+    # TODO(#107898): Refactor this into a common location.
     parser.add_argument(
         "--verbosity",
         type=str,

--- a/llvm/utils/mlgo-utils/mlgo/corpus/combine_training_corpus.py
+++ b/llvm/utils/mlgo-utils/mlgo/corpus/combine_training_corpus.py
@@ -24,6 +24,7 @@ and corpus2 are combined into combinedcorpus.
 """
 
 import argparse
+import logging
 
 from mlgo.corpus import combine_training_corpus_lib
 
@@ -35,11 +36,20 @@ def parse_args_and_run():
     parser.add_argument(
         "--root_dir", type=str, help="The root dir of module paths to combine."
     )
+    parser.add_argument(
+        "--verbosity",
+        type=int,
+        help="The verbosity level to use for logging",
+        default=0,
+        nargs="?",
+    )
     args = parser.parse_args()
     main(args)
 
 
 def main(args):
+    logging.basicConfig(level=args.verbosity)
+
     combine_training_corpus_lib.combine_corpus(args.root_dir)
 
 

--- a/llvm/utils/mlgo-utils/mlgo/corpus/combine_training_corpus.py
+++ b/llvm/utils/mlgo-utils/mlgo/corpus/combine_training_corpus.py
@@ -38,10 +38,11 @@ def parse_args_and_run():
     )
     parser.add_argument(
         "--verbosity",
-        type=int,
+        type=str,
         help="The verbosity level to use for logging",
-        default=0,
+        default="INFO",
         nargs="?",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
     args = parser.parse_args()
     main(args)

--- a/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir.py
+++ b/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir.py
@@ -20,8 +20,8 @@ specifying -Wl,--save-temps=import -Wl,--thinlto-emit-index-files
 
 To change the logging verbosity, pass an integer representing the desired
 verbosity to the --verbosity flag. Use 0 for all logs, status information,
-and detailed debug information, -1 for solely warnings, and -2 to not produce
-any output.
+and detailed debug information, 30 for solely warnings, and 50 or higher to
+not produce any output.
 """
 
 import argparse
@@ -113,11 +113,20 @@ def parse_args_and_run():
         default=".llvmbc",
         nargs="?",
     )
+    parser.add_argument(
+        "--verbosity",
+        type=int,
+        help="The verbosity level to use for logging",
+        default=0,
+        nargs="?",
+    )
     args = parser.parse_args()
     main(args)
 
 
 def main(args):
+    logging.basicConfig(level=args.verbosity)
+
     objs = []
     if args.input is not None and args.thinlto_build == "local":
         raise ValueError("--thinlto_build=local cannot be run with --input")

--- a/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir.py
+++ b/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir.py
@@ -18,10 +18,9 @@ specifying -mllvm -lto-embed-bitcode=post-merge-pre-opt.
 In a local ThinLTO case, the compilation is assumedto have been performed
 specifying -Wl,--save-temps=import -Wl,--thinlto-emit-index-files
 
-To change the logging verbosity, pass an integer representing the desired
-verbosity to the --verbosity flag. Use 0 for all logs, status information,
-and detailed debug information, 30 for solely warnings, and 50 or higher to
-not produce any output.
+To change the logging verbosity, set the --verbosity flag to the desired level.
+Setting it to a specific level will enable all messages at that level and
+higher. Exact values can be found by invoking the script with --help.
 """
 
 import argparse
@@ -115,10 +114,11 @@ def parse_args_and_run():
     )
     parser.add_argument(
         "--verbosity",
-        type=int,
+        type=str,
         help="The verbosity level to use for logging",
-        default=0,
+        default="INFO",
         nargs="?",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
     args = parser.parse_args()
     main(args)

--- a/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir.py
+++ b/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir.py
@@ -112,6 +112,7 @@ def parse_args_and_run():
         default=".llvmbc",
         nargs="?",
     )
+    # TODO(#107898): Refactor this into a common location.
     parser.add_argument(
         "--verbosity",
         type=str,


### PR DESCRIPTION
This patch fixes issues related to logging verbosity in the MLGO python scripts. This was an oversight when converting from absl.logging to the python logging API as absl natively supports a --verbosity flag to set the desired logging level. This patch adds a flag to support similar functionality in Python's logging library and additionally updates docstrings where relevant to point to the new values.