### PR TITLE
[llvm-exegesis] Use MCRegister instead of unsigned to hold registers

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
@@ -154,7 +154,7 @@ private:
   std::string LastError;
   raw_string_ostream ErrorStream;
   const DenseMap<StringRef, unsigned> &OpcodeNameToOpcodeIdx;
-  const DenseMap<StringRef, unsigned> &RegNameToRegNo;
+  const DenseMap<StringRef, MCRegister> &RegNameToRegNo;
 };
 } // namespace
 

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
@@ -111,11 +111,11 @@ LLVMState::createOpcodeNameToOpcodeIdxMapping() const {
   return std::move(Map);
 }
 
-std::unique_ptr<const DenseMap<StringRef, unsigned>>
+std::unique_ptr<const DenseMap<StringRef, MCRegister>>
 LLVMState::createRegNameToRegNoMapping() const {
   const MCRegisterInfo &RegInfo = getRegInfo();
   auto Map =
-      std::make_unique<DenseMap<StringRef, unsigned>>(RegInfo.getNumRegs());
+      std::make_unique<DenseMap<StringRef, MCRegister>>(RegInfo.getNumRegs());
   // Special-case RegNo 0, which would otherwise be spelled as ''.
   (*Map)[kNoRegister] = 0;
   for (unsigned I = 1, E = RegInfo.getNumRegs(); I < E; ++I)

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.h
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.h
@@ -19,6 +19,7 @@
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Target/TargetMachine.h"
@@ -75,7 +76,7 @@ public:
     return *OpcodeNameToOpcodeIdxMapping;
   };
 
-  const DenseMap<StringRef, unsigned> &getRegNameToRegNoMapping() const {
+  const DenseMap<StringRef, MCRegister> &getRegNameToRegNoMapping() const {
     assert(RegNameToRegNoMapping);
     return *RegNameToRegNoMapping;
   }
@@ -84,7 +85,7 @@ private:
   std::unique_ptr<const DenseMap<StringRef, unsigned>>
   createOpcodeNameToOpcodeIdxMapping() const;
 
-  std::unique_ptr<const DenseMap<StringRef, unsigned>>
+  std::unique_ptr<const DenseMap<StringRef, MCRegister>>
   createRegNameToRegNoMapping() const;
 
   LLVMState(std::unique_ptr<const TargetMachine> TM, const ExegesisTarget *ET,
@@ -97,7 +98,7 @@ private:
   const PfmCountersInfo *PfmCounters;
   std::unique_ptr<const DenseMap<StringRef, unsigned>>
       OpcodeNameToOpcodeIdxMapping;
-  std::unique_ptr<const DenseMap<StringRef, unsigned>> RegNameToRegNoMapping;
+  std::unique_ptr<const DenseMap<StringRef, MCRegister>> RegNameToRegNoMapping;
 };
 
 } // namespace exegesis

--- a/llvm/tools/llvm-exegesis/lib/SnippetFile.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetFile.cpp
@@ -36,7 +36,7 @@ namespace {
 class BenchmarkCodeStreamer : public MCStreamer, public AsmCommentConsumer {
 public:
   explicit BenchmarkCodeStreamer(
-      MCContext *Context, const DenseMap<StringRef, unsigned> &RegNameToRegNo,
+      MCContext *Context, const DenseMap<StringRef, MCRegister> &RegNameToRegNo,
       BenchmarkCode *Result)
       : MCStreamer(*Context), RegNameToRegNo(RegNameToRegNo), Result(Result) {}
 
@@ -215,7 +215,7 @@ private:
     return 0;
   }
 
-  const DenseMap<StringRef, unsigned> &RegNameToRegNo;
+  const DenseMap<StringRef, MCRegister> &RegNameToRegNo;
   BenchmarkCode *const Result;
   unsigned InvalidComments = 0;
 };


### PR DESCRIPTION
This patch switches getRegNameToRegNoMapping and downstream users to using MCRegister to hold registers rather than raw unsigned. Other uses within llvm-exegesis are not currently migrated.