### PR TITLE
[TableGen] Resolve arguments with fields in records

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -2289,9 +2289,12 @@ class RecordResolver final : public Resolver {
   DenseMap<Init *, Init *> Cache;
   SmallVector<Init *, 4> Stack;
   Init *Name = nullptr;
+  // Cache is for fields, ArgumentResolver is for arguments.
+  MapResolver *ArgumentResolver;
 
 public:
-  explicit RecordResolver(Record &R) : Resolver(&R) {}
+  explicit RecordResolver(Record &R, MapResolver *ArgumentResolver = nullptr)
+      : Resolver(&R), ArgumentResolver(ArgumentResolver) {}
 
   void setName(Init *NewName) { Name = NewName; }
 

--- a/llvm/test/TableGen/record-recursion.td
+++ b/llvm/test/TableGen/record-recursion.td
@@ -1,0 +1,11 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+
+class SumTillN<int n> {
+    int v = !add(n, 0);
+    int ret = !if(!gt(v, 0), !add(v, SumTillN<!sub(n, 1)>.ret), v);
+}
+
+// CHECK: def SumTill4
+// CHECK-NEXT:  int v = 3;
+// CHECK-NEXT:  int ret = 6;
+def SumTill4 : SumTillN<3>;


### PR DESCRIPTION
Previously, instantiating an anonymous record happened in two steps: 
1. Resolve the arguments with a `MapResolver`
2. Resolve the fields with a `RecordResolver`.

In 1, the `MapResolver` cannot resolve references to fields and in 2 the `RecordResolver` cannot resolve references to arguments. This was leading to incomplete resolution in `llvm/test/TableGen/record-recursion.td` (simplified test-case from #91050 ) like so:

1. `MapResolver` fails to resolve the `if` condition since it references the field `v`.
2. Resolving `SumTillN<!sub(n, 1)>.ret)` fails as it references the argument `n` and the `RecordResolver` doesn't know about it.

This patch merges the two steps into one where arguments and fields are resolved by the `RecordResolver` itself. 