### PR TITLE
[Sanitizer] Call Die() instead of Abort() when failed to reserve shadow memory range

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_libcdep.cpp
@@ -171,7 +171,7 @@ void ReserveShadowMemoryRange(uptr beg, uptr end, const char *name,
         "ReserveShadowMemoryRange failed while trying to map 0x%zx bytes. "
         "Perhaps you're using ulimit -v or ulimit -d\n",
         size);
-    Abort();
+    Die();
   }
   if (madvise_shadow && common_flags()->use_madv_dontdump)
     DontDumpShadowMemory(beg, size);


### PR DESCRIPTION
I grep the code and find that `Abort()` is only called in `Die()` when the flag `abort_on_error` is set.
Thus, if reserving shadow memory range fails, `Die()` rather than `Abort()` should be called. In this case, the flag `abort_on_error` will be respected and the die callbacks will be called.