### PR TITLE
[NFC][clang] Fix clang version in the test for the implementation of cwg1815

### DIFF
--- a/clang/test/CXX/drs/cwg18xx.cpp
+++ b/clang/test/CXX/drs/cwg18xx.cpp
@@ -206,7 +206,7 @@ namespace cwg1814 { // cwg1814: yes
 #endif
 }
 
-namespace cwg1815 { // cwg1815: 19
+namespace cwg1815 { // cwg1815: 20
 #if __cplusplus >= 201402L
   struct A { int &&r = 0; };
   A a = {};


### PR DESCRIPTION
This PR fix the clang version in https://github.com/llvm/llvm-project/pull/97308 .