### PR TITLE
[TableGen] Migrate CodeGenHWModes to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/CodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/CodeEmitterGen.cpp
@@ -58,7 +58,7 @@ private:
   int getVariableBit(const std::string &VarName, BitsInit *BI, int bit);
   std::pair<std::string, std::string>
   getInstructionCases(Record *R, CodeGenTarget &Target);
-  void addInstructionCasesForEncoding(Record *R, Record *EncodingDef,
+  void addInstructionCasesForEncoding(Record *R, const Record *EncodingDef,
                                       CodeGenTarget &Target, std::string &Case,
                                       std::string &BitOffsetCase);
   bool addCodeToMergeInOperand(Record *R, BitsInit *BI,
@@ -342,8 +342,8 @@ CodeEmitterGen::getInstructionCases(Record *R, CodeGenTarget &Target) {
 }
 
 void CodeEmitterGen::addInstructionCasesForEncoding(
-    Record *R, Record *EncodingDef, CodeGenTarget &Target, std::string &Case,
-    std::string &BitOffsetCase) {
+    Record *R, const Record *EncodingDef, CodeGenTarget &Target,
+    std::string &Case, std::string &BitOffsetCase) {
   BitsInit *BI = EncodingDef->getValueAsBitsInit("Inst");
 
   // Loop over all of the fields in the instruction, determining which are the
@@ -413,7 +413,7 @@ void CodeEmitterGen::emitInstructionBaseValues(
       continue;
     }
 
-    Record *EncodingDef = R;
+    const Record *EncodingDef = R;
     if (const RecordVal *RV = R->getValue("EncodingInfos")) {
       if (auto *DI = dyn_cast_or_null<DefInit>(RV->getValue())) {
         EncodingInfoByHwMode EBM(DI->getDef(), HWM);

--- a/llvm/utils/TableGen/Common/CodeGenHwModes.h
+++ b/llvm/utils/TableGen/Common/CodeGenHwModes.h
@@ -28,7 +28,7 @@ class RecordKeeper;
 struct CodeGenHwModes;
 
 struct HwMode {
-  HwMode(Record *R);
+  HwMode(const Record *R);
   StringRef Name;
   std::string Features;
   std::string Predicates;
@@ -36,8 +36,8 @@ struct HwMode {
 };
 
 struct HwModeSelect {
-  HwModeSelect(Record *R, CodeGenHwModes &CGH);
-  typedef std::pair<unsigned, Record *> PairType;
+  HwModeSelect(const Record *R, CodeGenHwModes &CGH);
+  typedef std::pair<unsigned, const Record *> PairType;
   std::vector<PairType> Items;
   void dump() const;
 };
@@ -46,8 +46,8 @@ struct CodeGenHwModes {
   enum : unsigned { DefaultMode = 0 };
   static StringRef DefaultModeName;
 
-  CodeGenHwModes(RecordKeeper &R);
-  unsigned getHwModeId(Record *R) const;
+  CodeGenHwModes(const RecordKeeper &R);
+  unsigned getHwModeId(const Record *R) const;
   const HwMode &getMode(unsigned Id) const {
     assert(Id != 0 && "Mode id of 0 is reserved for the default mode");
     return Modes[Id - 1];
@@ -57,18 +57,18 @@ struct CodeGenHwModes {
       return DefaultModeName;
     return getMode(Id).Name;
   }
-  const HwModeSelect &getHwModeSelect(Record *R) const;
-  const std::map<Record *, HwModeSelect> &getHwModeSelects() const {
+  const HwModeSelect &getHwModeSelect(const Record *R) const;
+  const std::map<const Record *, HwModeSelect> &getHwModeSelects() const {
     return ModeSelects;
   }
   unsigned getNumModeIds() const { return Modes.size() + 1; }
   void dump() const;
 
 private:
-  RecordKeeper &Records;
-  DenseMap<Record *, unsigned> ModeIds; // HwMode Record -> HwModeId
+  const RecordKeeper &Records;
+  DenseMap<const Record *, unsigned> ModeIds; // HwMode Record -> HwModeId
   std::vector<HwMode> Modes;
-  std::map<Record *, HwModeSelect> ModeSelects;
+  std::map<const Record *, HwModeSelect> ModeSelects;
 };
 } // namespace llvm
 

--- a/llvm/utils/TableGen/Common/InfoByHwMode.cpp
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.cpp
@@ -115,7 +115,7 @@ ValueTypeByHwMode llvm::getValueTypeByHwMode(Record *Rec,
   return ValueTypeByHwMode(Rec, llvm::getValueType(Rec));
 }
 
-RegSizeInfo::RegSizeInfo(Record *R) {
+RegSizeInfo::RegSizeInfo(const Record *R) {
   RegSize = R->getValueAsInt("RegSize");
   SpillSize = R->getValueAsInt("SpillSize");
   SpillAlignment = R->getValueAsInt("SpillAlignment");
@@ -136,7 +136,8 @@ void RegSizeInfo::writeToStream(raw_ostream &OS) const {
      << ']';
 }
 
-RegSizeInfoByHwMode::RegSizeInfoByHwMode(Record *R, const CodeGenHwModes &CGH) {
+RegSizeInfoByHwMode::RegSizeInfoByHwMode(const Record *R,
+                                         const CodeGenHwModes &CGH) {
   const HwModeSelect &MS = CGH.getHwModeSelect(R);
   for (const HwModeSelect::PairType &P : MS.Items) {
     auto I = Map.insert({P.first, RegSizeInfo(P.second)});
@@ -183,12 +184,13 @@ void RegSizeInfoByHwMode::writeToStream(raw_ostream &OS) const {
   OS << '}';
 }
 
-SubRegRange::SubRegRange(Record *R) {
+SubRegRange::SubRegRange(const Record *R) {
   Size = R->getValueAsInt("Size");
   Offset = R->getValueAsInt("Offset");
 }
 
-SubRegRangeByHwMode::SubRegRangeByHwMode(Record *R, const CodeGenHwModes &CGH) {
+SubRegRangeByHwMode::SubRegRangeByHwMode(const Record *R,
+                                         const CodeGenHwModes &CGH) {
   const HwModeSelect &MS = CGH.getHwModeSelect(R);
   for (const HwModeSelect::PairType &P : MS.Items) {
     auto I = Map.insert({P.first, SubRegRange(P.second)});
@@ -197,7 +199,7 @@ SubRegRangeByHwMode::SubRegRangeByHwMode(Record *R, const CodeGenHwModes &CGH) {
   }
 }
 
-EncodingInfoByHwMode::EncodingInfoByHwMode(Record *R,
+EncodingInfoByHwMode::EncodingInfoByHwMode(const Record *R,
                                            const CodeGenHwModes &CGH) {
   const HwModeSelect &MS = CGH.getHwModeSelect(R);
   for (const HwModeSelect::PairType &P : MS.Items) {

--- a/llvm/utils/TableGen/Common/InfoByHwMode.h
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.h
@@ -183,7 +183,7 @@ struct RegSizeInfo {
   unsigned SpillSize;
   unsigned SpillAlignment;
 
-  RegSizeInfo(Record *R);
+  RegSizeInfo(const Record *R);
   RegSizeInfo() = default;
   bool operator<(const RegSizeInfo &I) const;
   bool operator==(const RegSizeInfo &I) const {
@@ -197,7 +197,7 @@ struct RegSizeInfo {
 };
 
 struct RegSizeInfoByHwMode : public InfoByHwMode<RegSizeInfo> {
-  RegSizeInfoByHwMode(Record *R, const CodeGenHwModes &CGH);
+  RegSizeInfoByHwMode(const Record *R, const CodeGenHwModes &CGH);
   RegSizeInfoByHwMode() = default;
   bool operator<(const RegSizeInfoByHwMode &VI) const;
   bool operator==(const RegSizeInfoByHwMode &VI) const;
@@ -222,12 +222,12 @@ struct SubRegRange {
   uint16_t Size;
   uint16_t Offset;
 
-  SubRegRange(Record *R);
+  SubRegRange(const Record *R);
   SubRegRange(uint16_t Size, uint16_t Offset) : Size(Size), Offset(Offset) {}
 };
 
 struct SubRegRangeByHwMode : public InfoByHwMode<SubRegRange> {
-  SubRegRangeByHwMode(Record *R, const CodeGenHwModes &CGH);
+  SubRegRangeByHwMode(const Record *R, const CodeGenHwModes &CGH);
   SubRegRangeByHwMode(SubRegRange Range) { Map.insert({DefaultMode, Range}); }
   SubRegRangeByHwMode() = default;
 
@@ -236,8 +236,8 @@ struct SubRegRangeByHwMode : public InfoByHwMode<SubRegRange> {
   }
 };
 
-struct EncodingInfoByHwMode : public InfoByHwMode<Record *> {
-  EncodingInfoByHwMode(Record *R, const CodeGenHwModes &CGH);
+struct EncodingInfoByHwMode : public InfoByHwMode<const Record *> {
+  EncodingInfoByHwMode(const Record *R, const CodeGenHwModes &CGH);
   EncodingInfoByHwMode() = default;
 };
 

--- a/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.cpp
@@ -241,8 +241,8 @@ void VarLenCodeEmitterGen::run(raw_ostream &OS) {
         for (auto &KV : EBM) {
           AltEncodingTy Mode = KV.first;
           Modes.insert({Mode, "_" + HWM.getMode(Mode).Name.str()});
-          Record *EncodingDef = KV.second;
-          RecordVal *RV = EncodingDef->getValue("Inst");
+          const Record *EncodingDef = KV.second;
+          const RecordVal *RV = EncodingDef->getValue("Inst");
           DagInit *DI = cast<DagInit>(RV->getValue());
           VarLenInsts[R].insert({Mode, VarLenInst(DI, RV)});
         }


### PR DESCRIPTION
Migrate CodeGenHWModes to use const RecordKeeper and const Record pointers.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089