### PR TITLE
[TableGen] Change CGIOperandList::OperandInfo::Rec to const pointer

### DIFF
--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -764,10 +764,10 @@ public:
   std::map<Record *, SubtargetFeatureInfo, LessRecordByID> SubtargetFeatures;
 
   /// Map of AsmOperandClass records to their class information.
-  std::map<Record *, ClassInfo *> AsmOperandClasses;
+  std::map<const Record *, ClassInfo *> AsmOperandClasses;
 
   /// Map of RegisterClass records to their class information.
-  std::map<Record *, ClassInfo *> RegisterClassClasses;
+  std::map<const Record *, ClassInfo *> RegisterClassClasses;
 
 private:
   /// Map of token to class information which has already been constructed.
@@ -780,7 +780,7 @@ private:
   /// getOperandClass - Lookup or create the class for the given operand.
   ClassInfo *getOperandClass(const CGIOperandList::OperandInfo &OI,
                              int SubOpIdx);
-  ClassInfo *getOperandClass(Record *Rec, int SubOpIdx);
+  ClassInfo *getOperandClass(const Record *Rec, int SubOpIdx);
 
   /// buildRegisterClasses - Build the ClassInfo* instances for register
   /// classes.
@@ -1191,13 +1191,13 @@ ClassInfo *AsmMatcherInfo::getTokenClass(StringRef Token) {
 ClassInfo *
 AsmMatcherInfo::getOperandClass(const CGIOperandList::OperandInfo &OI,
                                 int SubOpIdx) {
-  Record *Rec = OI.Rec;
+  const Record *Rec = OI.Rec;
   if (SubOpIdx != -1)
     Rec = cast<DefInit>(OI.MIOperandInfo->getArg(SubOpIdx))->getDef();
   return getOperandClass(Rec, SubOpIdx);
 }
 
-ClassInfo *AsmMatcherInfo::getOperandClass(Record *Rec, int SubOpIdx) {
+ClassInfo *AsmMatcherInfo::getOperandClass(const Record *Rec, int SubOpIdx) {
   if (Rec->isSubClassOf("RegisterOperand")) {
     // RegisterOperand may have an associated ParserMatchClass. If it does,
     // use it, else just fall back to the underlying register class.
@@ -1208,7 +1208,7 @@ ClassInfo *AsmMatcherInfo::getOperandClass(Record *Rec, int SubOpIdx) {
                           "' does not have a ParserMatchClass!\n");
 
     if (DefInit *DI = dyn_cast<DefInit>(R->getValue())) {
-      Record *MatchClass = DI->getDef();
+      const Record *MatchClass = DI->getDef();
       if (ClassInfo *CI = AsmOperandClasses[MatchClass])
         return CI;
     }
@@ -1724,9 +1724,9 @@ void AsmMatcherInfo::buildInstructionOperandReference(MatchableInfo *II,
   // match class for the asm operand is still the default "ImmAsmOperand",
   // then handle each suboperand separately.
   if (Op->SubOpIdx == -1 && Operands[Idx].MINumOperands > 1) {
-    Record *Rec = Operands[Idx].Rec;
+    const Record *Rec = Operands[Idx].Rec;
     assert(Rec->isSubClassOf("Operand") && "Unexpected operand!");
-    Record *MatchClass = Rec->getValueAsDef("ParserMatchClass");
+    const Record *MatchClass = Rec->getValueAsDef("ParserMatchClass");
     if (MatchClass && MatchClass->getValueAsString("Name") == "Imm") {
       // Insert remaining suboperands after AsmOpIdx in II->AsmOperands.
       StringRef Token = Op->Token; // save this in case Op gets moved

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -1721,7 +1721,8 @@ bool SDTypeConstraint::ApplyTypeConstraint(TreePatternNode &N,
 // Update the node type to match an instruction operand or result as specified
 // in the ins or outs lists on the instruction definition. Return true if the
 // type was actually changed.
-bool TreePatternNode::UpdateNodeTypeFromInst(unsigned ResNo, Record *Operand,
+bool TreePatternNode::UpdateNodeTypeFromInst(unsigned ResNo,
+                                             const Record *Operand,
                                              TreePattern &TP) {
   // The 'unknown' operand indicates that types should be inferred from the
   // context.
@@ -1741,7 +1742,7 @@ bool TreePatternNode::UpdateNodeTypeFromInst(unsigned ResNo, Record *Operand,
 
   // Both RegisterClass and RegisterOperand operands derive their types from a
   // register class def.
-  Record *RC = nullptr;
+  const Record *RC = nullptr;
   if (Operand->isSubClassOf("RegisterClass"))
     RC = Operand;
   else if (Operand->isSubClassOf("RegisterOperand"))
@@ -1891,7 +1892,7 @@ static unsigned GetNumNodeResults(Record *Operator, CodeGenDAGPatterns &CDP) {
 
     // Subtract any defaulted outputs.
     for (unsigned i = 0; i != InstInfo.Operands.NumDefs; ++i) {
-      Record *OperandNode = InstInfo.Operands[i].Rec;
+      const Record *OperandNode = InstInfo.Operands[i].Rec;
 
       if (OperandNode->isSubClassOf("OperandWithDefaultOps") &&
           !CDP.getDefaultOperand(OperandNode).DefaultOps.empty())
@@ -2627,7 +2628,7 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
     unsigned ChildNo = 0;
     assert(NumResults <= NumFixedOperands);
     for (unsigned i = NumResults, e = NumFixedOperands; i != e; ++i) {
-      Record *OperandNode = InstInfo.Operands[i].Rec;
+      const Record *OperandNode = InstInfo.Operands[i].Rec;
 
       // If the operand has a default value, do we use it? We must use the
       // default if we've run out of children of the pattern DAG to consume,
@@ -3807,7 +3808,7 @@ void CodeGenDAGPatterns::parseInstructionPattern(CodeGenInstruction &CGI,
   assert(I.getArgList().empty() && "Args list should still be empty here!");
 
   // Check that all of the results occur first in the list.
-  std::vector<Record *> Results;
+  std::vector<const Record *> Results;
   std::vector<unsigned> ResultIndices;
   SmallVector<TreePatternNodePtr, 2> ResNodes;
   for (unsigned i = 0; i != NumResults; ++i) {
@@ -3853,7 +3854,7 @@ void CodeGenDAGPatterns::parseInstructionPattern(CodeGenInstruction &CGI,
 
   // Loop over the inputs next.
   std::vector<TreePatternNodePtr> ResultNodeOperands;
-  std::vector<Record *> Operands;
+  std::vector<const Record *> Operands;
   for (unsigned i = NumResults, e = CGI.Operands.size(); i != e; ++i) {
     CGIOperandList::OperandInfo &Op = CGI.Operands[i];
     const std::string &OpName = Op.Name;
@@ -3961,8 +3962,8 @@ void CodeGenDAGPatterns::ParseInstructions() {
     // is from a multiclass expansion w/ a SDPatternOperator passed in as
     // null_frag.
     if (!LI || LI->empty() || hasNullFragReference(LI)) {
-      std::vector<Record *> Results;
-      std::vector<Record *> Operands;
+      std::vector<const Record *> Results;
+      std::vector<const Record *> Operands;
 
       CodeGenInstruction &InstInfo = Target.getInstruction(Instr);
 

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -846,7 +846,8 @@ public: // Higher level manipulation routines.
   // Update node type with types inferred from an instruction operand or result
   // def from the ins/outs lists.
   // Return true if the type changed.
-  bool UpdateNodeTypeFromInst(unsigned ResNo, Record *Operand, TreePattern &TP);
+  bool UpdateNodeTypeFromInst(unsigned ResNo, const Record *Operand,
+                              TreePattern &TP);
 
   /// ContainsUnresolvedType - Return true if this tree contains any
   /// unresolved types.
@@ -1010,15 +1011,15 @@ struct DAGDefaultOperand {
 };
 
 class DAGInstruction {
-  std::vector<Record *> Results;
-  std::vector<Record *> Operands;
+  std::vector<const Record *> Results;
+  std::vector<const Record *> Operands;
   std::vector<Record *> ImpResults;
   TreePatternNodePtr SrcPattern;
   TreePatternNodePtr ResultPattern;
 
 public:
-  DAGInstruction(std::vector<Record *> &&results,
-                 std::vector<Record *> &&operands,
+  DAGInstruction(std::vector<const Record *> &&results,
+                 std::vector<const Record *> &&operands,
                  std::vector<Record *> &&impresults,
                  TreePatternNodePtr srcpattern = nullptr,
                  TreePatternNodePtr resultpattern = nullptr)
@@ -1031,12 +1032,12 @@ public:
   unsigned getNumImpResults() const { return ImpResults.size(); }
   const std::vector<Record *> &getImpResults() const { return ImpResults; }
 
-  Record *getResult(unsigned RN) const {
+  const Record *getResult(unsigned RN) const {
     assert(RN < Results.size());
     return Results[RN];
   }
 
-  Record *getOperand(unsigned ON) const {
+  const Record *getOperand(unsigned ON) const {
     assert(ON < Operands.size());
     return Operands[ON];
   }
@@ -1104,7 +1105,7 @@ class CodeGenDAGPatterns {
   std::map<Record *, ComplexPattern, LessRecordByID> ComplexPatterns;
   std::map<Record *, std::unique_ptr<TreePattern>, LessRecordByID>
       PatternFragments;
-  std::map<Record *, DAGDefaultOperand, LessRecordByID> DefaultOperands;
+  std::map<const Record *, DAGDefaultOperand, LessRecordByID> DefaultOperands;
   std::map<Record *, DAGInstruction, LessRecordByID> Instructions;
 
   // Specific SDNode definitions:
@@ -1173,7 +1174,7 @@ public:
     llvm_unreachable("Unknown intrinsic!");
   }
 
-  const DAGDefaultOperand &getDefaultOperand(Record *R) const {
+  const DAGDefaultOperand &getDefaultOperand(const Record *R) const {
     auto F = DefaultOperands.find(R);
     assert(F != DefaultOperands.end() && "Isn't an analyzed default operand!");
     return F->second;
@@ -1225,7 +1226,7 @@ public:
 
   unsigned allocateScope() { return ++NumScopes; }
 
-  bool operandHasDefault(Record *Op) const {
+  bool operandHasDefault(const Record *Op) const {
     return Op->isSubClassOf("OperandWithDefaultOps") &&
            !getDefaultOperand(Op).DefaultOps.empty();
   }

--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
@@ -25,7 +25,7 @@ using namespace llvm;
 /// the corresponding operand of the instruction.  It returns true on a
 /// successful match, with ResOp set to the result operand to be used.
 bool CodeGenInstAlias::tryAliasOpMatch(DagInit *Result, unsigned AliasOpNo,
-                                       Record *InstOpRec, bool hasSubOps,
+                                       const Record *InstOpRec, bool hasSubOps,
                                        ArrayRef<SMLoc> Loc, CodeGenTarget &T,
                                        ResultOperand &ResOp) {
   Init *Arg = Result->getArg(AliasOpNo);
@@ -216,7 +216,7 @@ CodeGenInstAlias::CodeGenInstAlias(Record *R, CodeGenTarget &T) : TheDef(R) {
     if (AliasOpNo >= Result->getNumArgs())
       PrintFatalError(R->getLoc(), "not enough arguments for instruction!");
 
-    Record *InstOpRec = ResultInst->Operands[i].Rec;
+    const Record *InstOpRec = ResultInst->Operands[i].Rec;
     unsigned NumSubOps = ResultInst->Operands[i].MINumOperands;
     ResultOperand ResOp(static_cast<int64_t>(0));
     if (tryAliasOpMatch(Result, AliasOpNo, InstOpRec, (NumSubOps > 1),

--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.h
@@ -95,8 +95,9 @@ public:
 
   CodeGenInstAlias(Record *R, CodeGenTarget &T);
 
-  bool tryAliasOpMatch(DagInit *Result, unsigned AliasOpNo, Record *InstOpRec,
-                       bool hasSubOps, ArrayRef<SMLoc> Loc, CodeGenTarget &T,
+  bool tryAliasOpMatch(DagInit *Result, unsigned AliasOpNo,
+                       const Record *InstOpRec, bool hasSubOps,
+                       ArrayRef<SMLoc> Loc, CodeGenTarget &T,
                        ResultOperand &ResOp);
 };
 

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
@@ -22,7 +22,7 @@ using namespace llvm;
 // CGIOperandList Implementation
 //===----------------------------------------------------------------------===//
 
-CGIOperandList::CGIOperandList(Record *R) : TheDef(R) {
+CGIOperandList::CGIOperandList(const Record *R) : TheDef(R) {
   isPredicable = false;
   hasOptionalDef = false;
   isVariadic = false;
@@ -75,7 +75,7 @@ CGIOperandList::CGIOperandList(Record *R) : TheDef(R) {
       PrintFatalError(R->getLoc(), "Illegal operand for the '" + R->getName() +
                                        "' instruction!");
 
-    Record *Rec = Arg->getDef();
+    const Record *Rec = Arg->getDef();
     std::string PrintMethod = "printOperand";
     std::string EncoderMethod;
     std::string OperandType = "OPERAND_UNKNOWN";

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.h
@@ -73,7 +73,7 @@ public:
   struct OperandInfo {
     /// Rec - The definition this operand is declared as.
     ///
-    Record *Rec;
+    const Record *Rec;
 
     /// Name - If this operand was assigned a symbolic name, this is it,
     /// otherwise, it's empty.
@@ -116,7 +116,7 @@ public:
     /// track constraint info for each.
     std::vector<ConstraintInfo> Constraints;
 
-    OperandInfo(Record *R, const std::string &N, const std::string &PMN,
+    OperandInfo(const Record *R, const std::string &N, const std::string &PMN,
                 const std::string &OT, unsigned MION, unsigned MINO,
                 DagInit *MIOI)
         : Rec(R), Name(N), SubOpNames(MINO), PrinterMethodName(PMN),
@@ -136,9 +136,9 @@ public:
     }
   };
 
-  CGIOperandList(Record *D);
+  CGIOperandList(const Record *D);
 
-  Record *TheDef; // The actual record containing this OperandList.
+  const Record *TheDef; // The actual record containing this OperandList.
 
   /// NumDefs - Number of def operands declared, this is the number of
   /// elements in the instruction's (outs) list.

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -1352,7 +1352,7 @@ CodeGenRegister *CodeGenRegBank::getReg(Record *Def) {
 }
 
 void CodeGenRegBank::addToMaps(CodeGenRegisterClass *RC) {
-  if (Record *Def = RC->getDef())
+  if (const Record *Def = RC->getDef())
     Def2RC.insert(std::pair(Def, RC));
 
   // Duplicate classes are rejected by insert().

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.h
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.h
@@ -604,7 +604,7 @@ class CodeGenRegBank {
 
   // Register classes.
   std::list<CodeGenRegisterClass> RegClasses;
-  DenseMap<Record *, CodeGenRegisterClass *> Def2RC;
+  DenseMap<const Record *, CodeGenRegisterClass *> Def2RC;
   typedef std::map<CodeGenRegisterClass::Key, CodeGenRegisterClass *> RCKeyMap;
   RCKeyMap Key2RC;
 

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -234,7 +234,8 @@ const CodeGenRegister *CodeGenTarget::getRegisterByName(StringRef Name) const {
   return getRegBank().getRegistersByName().lookup(Name);
 }
 
-const CodeGenRegisterClass &CodeGenTarget::getRegisterClass(Record *R) const {
+const CodeGenRegisterClass &
+CodeGenTarget::getRegisterClass(const Record *R) const {
   return *getRegBank().getRegClass(R);
 }
 

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -141,7 +141,7 @@ public:
     return RegAltNameIndices;
   }
 
-  const CodeGenRegisterClass &getRegisterClass(Record *R) const;
+  const CodeGenRegisterClass &getRegisterClass(const Record *R) const;
 
   /// getRegisterVTs - Find the union of all possible SimpleValueTypes for the
   /// specified physical register.

--- a/llvm/utils/TableGen/CompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/CompressInstEmitter.cpp
@@ -127,8 +127,9 @@ class CompressInstEmitter {
                             IndexedMap<OpData> &OperandMap, bool IsSourceInst);
   void evaluateCompressPat(Record *Compress);
   void emitCompressInstEmitter(raw_ostream &OS, EmitterType EType);
-  bool validateTypes(Record *SubType, Record *Type, bool IsSourceInst);
-  bool validateRegister(Record *Reg, Record *RegClass);
+  bool validateTypes(const Record *DagOpType, const Record *InstOpType,
+                     bool IsSourceInst);
+  bool validateRegister(const Record *Reg, const Record *RegClass);
   void createDagOperandMapping(Record *Rec, StringMap<unsigned> &SourceOperands,
                                StringMap<unsigned> &DestOperands,
                                DagInit *SourceDag, DagInit *DestDag,
@@ -148,7 +149,8 @@ public:
 };
 } // End anonymous namespace.
 
-bool CompressInstEmitter::validateRegister(Record *Reg, Record *RegClass) {
+bool CompressInstEmitter::validateRegister(const Record *Reg,
+                                           const Record *RegClass) {
   assert(Reg->isSubClassOf("Register") && "Reg record should be a Register");
   assert(RegClass->isSubClassOf("RegisterClass") &&
          "RegClass record should be a RegisterClass");
@@ -158,7 +160,8 @@ bool CompressInstEmitter::validateRegister(Record *Reg, Record *RegClass) {
   return RC.contains(R);
 }
 
-bool CompressInstEmitter::validateTypes(Record *DagOpType, Record *InstOpType,
+bool CompressInstEmitter::validateTypes(const Record *DagOpType,
+                                        const Record *InstOpType,
                                         bool IsSourceInst) {
   if (DagOpType == InstOpType)
     return true;
@@ -522,7 +525,7 @@ getReqFeatures(std::set<std::pair<bool, StringRef>> &FeaturesSet,
 
 static unsigned getPredicates(DenseMap<const Record *, unsigned> &PredicateMap,
                               std::vector<const Record *> &Predicates,
-                              Record *Rec, StringRef Name) {
+                              const Record *Rec, StringRef Name) {
   unsigned &Entry = PredicateMap[Rec];
   if (Entry)
     return Entry;

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -824,7 +824,7 @@ void MatcherGen::EmitResultInstructionAsOperand(
   for (unsigned InstOpNo = NumResults, e = NumFixedOperands; InstOpNo != e;
        ++InstOpNo) {
     // Determine what to emit for this operand.
-    Record *OperandNode = II.Operands[InstOpNo].Rec;
+    const Record *OperandNode = II.Operands[InstOpNo].Rec;
     if (CGP.operandHasDefault(OperandNode) &&
         (InstOpNo < NonOverridableOperands || ChildNo >= N.getNumChildren())) {
       // This is a predicate or optional def operand which the pattern has not

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -1864,10 +1864,10 @@ void FilterChooser::emitTableEntries(DecoderTableInfo &TableInfo) const {
   }
 }
 
-static std::string findOperandDecoderMethod(Record *Record) {
+static std::string findOperandDecoderMethod(const Record *Record) {
   std::string Decoder;
 
-  RecordVal *DecoderString = Record->getValue("DecoderMethod");
+  const RecordVal *DecoderString = Record->getValue("DecoderMethod");
   StringInit *String =
       DecoderString ? dyn_cast<StringInit>(DecoderString->getValue()) : nullptr;
   if (String) {
@@ -1890,10 +1890,11 @@ static std::string findOperandDecoderMethod(Record *Record) {
   return Decoder;
 }
 
-OperandInfo getOpInfo(Record *TypeRecord) {
+OperandInfo getOpInfo(const Record *TypeRecord) {
   std::string Decoder = findOperandDecoderMethod(TypeRecord);
 
-  RecordVal *HasCompleteDecoderVal = TypeRecord->getValue("hasCompleteDecoder");
+  const RecordVal *HasCompleteDecoderVal =
+      TypeRecord->getValue("hasCompleteDecoder");
   BitInit *HasCompleteDecoderBit =
       HasCompleteDecoderVal
           ? dyn_cast<BitInit>(HasCompleteDecoderVal->getValue())
@@ -1904,9 +1905,9 @@ OperandInfo getOpInfo(Record *TypeRecord) {
   return OperandInfo(Decoder, HasCompleteDecoder);
 }
 
-void parseVarLenInstOperand(const Record &Def,
-                            std::vector<OperandInfo> &Operands,
-                            const CodeGenInstruction &CGI) {
+static void parseVarLenInstOperand(const Record &Def,
+                                   std::vector<OperandInfo> &Operands,
+                                   const CodeGenInstruction &CGI) {
 
   const RecordVal *RV = Def.getValue("Inst");
   VarLenInst VLI(cast<DagInit>(RV->getValue()), RV);

--- a/llvm/utils/TableGen/FastISelEmitter.cpp
+++ b/llvm/utils/TableGen/FastISelEmitter.cpp
@@ -494,7 +494,7 @@ void FastISelMap::collectPatterns(CodeGenDAGPatterns &CGP) {
     const CodeGenRegisterClass *DstRC = nullptr;
     std::string SubRegNo;
     if (Op->getName() != "EXTRACT_SUBREG") {
-      Record *Op0Rec = II.Operands[0].Rec;
+      const Record *Op0Rec = II.Operands[0].Rec;
       if (Op0Rec->isSubClassOf("RegisterOperand"))
         Op0Rec = Op0Rec->getValueAsDef("RegClass");
       if (!Op0Rec->isSubClassOf("RegisterClass"))

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -151,7 +151,7 @@ InstrInfoEmitter::GetOperandInfo(const CodeGenInstruction &Inst) {
     }
 
     for (unsigned j = 0, e = OperandList.size(); j != e; ++j) {
-      Record *OpR = OperandList[j].Rec;
+      const Record *OpR = OperandList[j].Rec;
       std::string Res;
 
       if (OpR->isSubClassOf("RegisterOperand"))
@@ -398,7 +398,7 @@ void InstrInfoEmitter::emitOperandTypeMappings(
   // TODO: Factor out duplicate operand lists to compress the tables.
   if (!NumberedInstructions.empty()) {
     std::vector<int> OperandOffsets;
-    std::vector<Record *> OperandRecords;
+    std::vector<const Record *> OperandRecords;
     int CurrentOffset = 0;
     for (const CodeGenInstruction *Inst : NumberedInstructions) {
       OperandOffsets.push_back(CurrentOffset);
@@ -447,7 +447,7 @@ void InstrInfoEmitter::emitOperandTypeMappings(
         while (OperandOffsets[++CurOffset] == I)
           OS << "/* " << getInstrName(CurOffset) << " */\n    ";
       }
-      Record *OpR = OperandRecords[I];
+      const Record *OpR = OperandRecords[I];
       if ((OpR->isSubClassOf("Operand") ||
            OpR->isSubClassOf("RegisterOperand") ||
            OpR->isSubClassOf("RegisterClass")) &&

--- a/llvm/utils/TableGen/X86FoldTablesEmitter.cpp
+++ b/llvm/utils/TableGen/X86FoldTablesEmitter.cpp
@@ -404,8 +404,8 @@ public:
 
     bool FoundFoldedOp = false;
     for (unsigned I = 0, E = MemInst->Operands.size(); I != E; I++) {
-      Record *MemOpRec = MemInst->Operands[I].Rec;
-      Record *RegOpRec = RegInst->Operands[I + RegStartIdx].Rec;
+      const Record *MemOpRec = MemInst->Operands[I].Rec;
+      const Record *RegOpRec = RegInst->Operands[I + RegStartIdx].Rec;
 
       if (MemOpRec == RegOpRec)
         continue;
@@ -457,8 +457,8 @@ void X86FoldTablesEmitter::addEntryWithFlags(FoldTable &Table,
     return;
   }
 
-  Record *RegOpRec = RegInst->Operands[FoldedIdx].Rec;
-  Record *MemOpRec = MemInst->Operands[FoldedIdx].Rec;
+  const Record *RegOpRec = RegInst->Operands[FoldedIdx].Rec;
+  const Record *MemOpRec = MemInst->Operands[FoldedIdx].Rec;
 
   // Unfolding code generates a load/store instruction according to the size of
   // the register in the register form instruction.
@@ -563,8 +563,8 @@ void X86FoldTablesEmitter::updateTables(const CodeGenInstruction *RegInst,
     // If the i'th register form operand is a register and the i'th memory form
     // operand is a memory operand, add instructions to Table#i.
     for (unsigned I = RegOutSize, E = RegInst->Operands.size(); I < E; I++) {
-      Record *RegOpRec = RegInst->Operands[I].Rec;
-      Record *MemOpRec = MemInst->Operands[I].Rec;
+      const Record *RegOpRec = RegInst->Operands[I].Rec;
+      const Record *MemOpRec = MemInst->Operands[I].Rec;
       // PointerLikeRegClass: For instructions like TAILJMPr, TAILJMPr64,
       // TAILJMPr64_REX
       if ((isRegisterOperand(RegOpRec) ||
@@ -607,8 +607,8 @@ void X86FoldTablesEmitter::updateTables(const CodeGenInstruction *RegInst,
     // For example:
     //   MOVAPSrr => (outs VR128:$dst), (ins VR128:$src)
     //   MOVAPSmr => (outs), (ins f128mem:$dst, VR128:$src)
-    Record *RegOpRec = RegInst->Operands[RegOutSize - 1].Rec;
-    Record *MemOpRec = MemInst->Operands[RegOutSize - 1].Rec;
+    const Record *RegOpRec = RegInst->Operands[RegOutSize - 1].Rec;
+    const Record *MemOpRec = MemInst->Operands[RegOutSize - 1].Rec;
     if (isRegisterOperand(RegOpRec) && isMemoryOperand(MemOpRec) &&
         getRegOperandSize(RegOpRec) == getMemOperandSize(MemOpRec)) {
       assert(!IsBroadcast && "Store can not be broadcast");

--- a/llvm/utils/TableGen/X86InstrMappingEmitter.cpp
+++ b/llvm/utils/TableGen/X86InstrMappingEmitter.cpp
@@ -138,8 +138,8 @@ public:
       return false;
 
     for (unsigned I = 0, E = OldInst->Operands.size(); I < E; ++I) {
-      Record *OldOpRec = OldInst->Operands[I].Rec;
-      Record *NewOpRec = NewInst->Operands[I].Rec;
+      const Record *OldOpRec = OldInst->Operands[I].Rec;
+      const Record *NewOpRec = NewInst->Operands[I].Rec;
 
       if (OldOpRec == NewOpRec)
         continue;


### PR DESCRIPTION
Change CGIOperandList::OperandInfo::Rec and CGIOperandList::TheDef to const pointer.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089
