### PR TITLE
[mlir][linalg][NFC] Drop redundant rankReductionStrategy

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
@@ -526,12 +526,11 @@ linalg::dropUnitDims(RewriterBase &rewriter, GenericOp genericOp,
   rewriter.inlineRegionBefore(genericOp.getRegion(), replacementOp.getRegion(),
                               replacementOp.getRegion().begin());
   // 5a. Replace `linalg.index` operations that refer to the dropped unit
-  // dimensions.
+  //     dimensions.
   replaceUnitDimIndexOps(replacementOp, unitDims, rewriter);
 
   // 6. If any result type changes, insert a reshape/slice to convert from the
-  // original
-  //    type to the new type.
+  //    original type to the new type.
   SmallVector<Value> resultReplacements;
   for (auto [index, result] : llvm::enumerate(replacementOp.getResults())) {
     unsigned opOperandIndex = index + replacementOp.getNumDpsInputs();
@@ -789,8 +788,6 @@ static void
 populateFoldUnitExtentDimsViaSlicesPatterns(RewritePatternSet &patterns,
                                             ControlDropUnitDims &options) {
   auto *context = patterns.getContext();
-  options.rankReductionStrategy =
-      ControlDropUnitDims::RankReductionStrategy::ExtractInsertSlice;
   patterns.add<DropUnitDims>(context, options);
   patterns.add<DropPadUnitDims>(context, options);
   // TODO: Patterns unrelated to unit dim folding should be factored out.


### PR DESCRIPTION
This patch drop redundant rankReductionStrategy in `populateFoldUnitExtentDimsViaSlicesPatterns` and fixes comment typos.