### PR TITLE
Mark tests as unsupported when targeting z/OS

### DIFF
--- a/clang/test/Analysis/ctu-on-demand-parsing.c
+++ b/clang/test/Analysis/ctu-on-demand-parsing.c
@@ -24,6 +24,7 @@
 //
 // FIXME: Path handling should work on all platforms.
 // REQUIRES: system-linux
+// UNSUPPORTED: target={{.*}}-zos{{.*}}
 
 void clang_analyzer_eval(int);
 

--- a/clang/test/Analysis/ctu-on-demand-parsing.cpp
+++ b/clang/test/Analysis/ctu-on-demand-parsing.cpp
@@ -35,6 +35,7 @@
 //
 // FIXME: Path handling should work on all platforms.
 // REQUIRES: system-linux
+// UNSUPPORTED: target={{.*}}-zos{{.*}}
 
 #include "ctu-hdr.h"
 

--- a/clang/test/CodeGenCXX/pr59765-modules-global-ctor-dtor.cppm
+++ b/clang/test/CodeGenCXX/pr59765-modules-global-ctor-dtor.cppm
@@ -1,9 +1,10 @@
 // https://github.com/llvm/llvm-project/issues/59765
 // FIXME: Since the signature of the constructors/destructors is
 // different in different targets. The current CHECK can't work
-// well when targeting or running on AIX and z/OS.
+// well when targeting AIX and z/OS.
 // It would be better to add the corresponding test for other test.
-// UNSUPPORTED: system-zos, system-aix
+// UNSUPPORTED: system-aix
+// UNSUPPORTED: target={{.*}}-zos{{.*}}
 //
 // RUN: rm -rf %t
 // RUN: mkdir %t

--- a/clang/test/Driver/hipstdpar.c
+++ b/clang/test/Driver/hipstdpar.c
@@ -1,6 +1,7 @@
 // REQUIRES: x86-registered-target
 // REQUIRES: amdgpu-registered-target
 // REQUIRES: system-linux
+// UNSUPPORTED: target={{.*}}-zos{{.*}}
 // XFAIL: target={{.*}}hexagon{{.*}}
 // XFAIL: target={{.*}}-scei{{.*}}
 // XFAIL: target={{.*}}-sie{{.*}}

--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -1,5 +1,5 @@
 // REQUIRES: lld
-// UNSUPPORTED: target={{.*-(ps4|ps5)}}
+// UNSUPPORTED: target={{.*-(ps4|ps5)}}, target={{.*}}-zos{{.*}}
 
 // RUN: echo "-nostartfiles -nostdlib -fuse-ld=lld -gen-reproducer=error -fcrash-diagnostics-dir=%t" \
 // RUN:   | sed -e 's/\\/\\\\/g' > %t.rsp

--- a/clang/test/OpenMP/lit.local.cfg
+++ b/clang/test/OpenMP/lit.local.cfg
@@ -1,5 +1,9 @@
 # -*- Python -*- vim: set ft=python ts=4 sw=4 expandtab tw=79:
+import re
 from lit.llvm.subst import ToolSubst
 
 fc = ToolSubst("FileCheck", unresolved="fatal")
 config.substitutions.insert(0, (fc.regex, "FileCheck --allow-unused-prefixes"))
+
+if re.match(r".*-zos", config.target_triple):
+    config.unsupported = True


### PR DESCRIPTION
Set up these tests so these are marked as unsupported when targeting z/OS.  Most would already be unsupported if you ran lit on z/OS.  However, they also need to be unsupported if the default triple is z/OS.