### PR TITLE
[Fuzzer] Passthrough zlib CMake paths into the test

### DIFF
--- a/compiler-rt/test/fuzzer/compressed.test
+++ b/compiler-rt/test/fuzzer/compressed.test
@@ -4,7 +4,7 @@ REQUIRES: zlib
 # unsupported by this test.
 UNSUPPORTED: i386, target=arm{{.*}}
 # Custom mutator should find this bug, w/o custom -- no chance.
-RUN: %cpp_compiler %S/CompressedTest.cpp -o %t-CompressedTestCustom -DCUSTOM_MUTATOR -lz
-RUN: %cpp_compiler %S/CompressedTest.cpp -o %t-CompressedTestPlain -lz
+RUN: %cpp_compiler %S/CompressedTest.cpp -o %t-CompressedTestCustom -DCUSTOM_MUTATOR -I%zlib_include_dir %zlib_library
+RUN: %cpp_compiler %S/CompressedTest.cpp -o %t-CompressedTestPlain -I%zlib_include_dir %zlib_library
 RUN: not %run %t-CompressedTestCustom -seed=1 -runs=1000000
 RUN:     %run %t-CompressedTestPlain  -seed=1 -runs=1000000

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -312,6 +312,8 @@ config.available_features.add("host-byteorder-" + sys.byteorder + "-endian")
 
 if config.have_zlib:
     config.available_features.add("zlib")
+    config.substitutions.append(("%zlib_include_dir", config.zlib_include_dir))
+    config.substitutions.append(("%zlib_library", config.zlib_library))
 
 if config.have_internal_symbolizer:
     config.available_features.add("internal_symbolizer")

--- a/compiler-rt/test/lit.common.configured.in
+++ b/compiler-rt/test/lit.common.configured.in
@@ -71,6 +71,8 @@ else:
 
 set_default("have_internal_symbolizer", @COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER_PYBOOL@)
 set_default("have_zlib", @ZLIB_FOUND_PYBOOL@)
+set_default("zlib_include_dir", "@ZLIB_INCLUDE_DIR@")
+set_default("zlib_library", "@ZLIB_LIBRARY@")
 set_default("libcxx_used", "@LLVM_LIBCXX_USED@")
 
 # LLVM tools dir can be passed in lit parameters, so try to


### PR DESCRIPTION
We shouldn't assume that we're using system zlib installation.