### PR TITLE
[bazel][libc][NFC] Add missing layering deps

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
@@ -4,7 +4,6 @@
 
 # Tests for LLVM libc math.h functions.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
 load("//libc/test/src/math:libc_math_test_rules.bzl", "math_mpfr_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -53,6 +52,9 @@ math_mpfr_test(name = "cos")
 math_mpfr_test(
     name = "cosf",
     hdrs = ["sdcomp26094.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(
@@ -65,6 +67,9 @@ math_mpfr_test(
 math_mpfr_test(
     name = "cospif",
     hdrs = ["sdcomp26094.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(
@@ -107,7 +112,7 @@ math_mpfr_test(
     name = "exp2m1f",
     deps = [
         "//libc:__support_cpp_array",
-    ]
+    ],
 )
 
 math_mpfr_test(name = "expm1")
@@ -211,8 +216,8 @@ math_mpfr_test(
 math_mpfr_test(
     name = "hypotf",
     hdrs = [
-        "hypotf_hard_to_round.h",
         "HypotTest.h",
+        "hypotf_hard_to_round.h",
     ],
 )
 
@@ -297,16 +302,25 @@ math_mpfr_test(
 math_mpfr_test(
     name = "nearbyint",
     hdrs = ["NearbyIntTest.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(
     name = "nearbyintf",
     hdrs = ["NearbyIntTest.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(
     name = "nearbyintl",
     hdrs = ["NearbyIntTest.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(name = "pow")
@@ -378,6 +392,9 @@ math_mpfr_test(name = "sin")
 math_mpfr_test(
     name = "sinf",
     hdrs = ["sdcomp26094.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(name = "sincos")
@@ -385,18 +402,24 @@ math_mpfr_test(name = "sincos")
 math_mpfr_test(
     name = "sincosf",
     hdrs = ["sdcomp26094.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(
     name = "sinhf",
     deps = [
         "//libc:__support_cpp_array",
-    ]
+    ],
 )
 
 math_mpfr_test(
     name = "sinpif",
     hdrs = ["sdcomp26094.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(
@@ -419,6 +442,9 @@ math_mpfr_test(name = "tan")
 math_mpfr_test(
     name = "tanf",
     hdrs = ["sdcomp26094.h"],
+    deps = [
+        "//libc:__support_cpp_array",
+    ],
 )
 
 math_mpfr_test(name = "tanhf")

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/libc_math_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/libc_math_test_rules.bzl
@@ -25,8 +25,9 @@ def math_test(name, hdrs = [], deps = [], **kwargs):
         srcs = [test_name + ".cpp"] + hdrs,
         libc_function_deps = ["//libc:func_name".replace("func_name", name)],
         deps = [
-            "//libc/test/UnitTest:fp_test_helpers",
             "//libc:__support_cpp_algorithm",
+            "//libc:__support_cpp_bit",
+            "//libc:__support_cpp_limits",
             "//libc:__support_fputil_basic_operations",
             "//libc:__support_fputil_fenv_impl",
             "//libc:__support_fputil_fp_bits",
@@ -36,7 +37,10 @@ def math_test(name, hdrs = [], deps = [], **kwargs):
             "//libc:__support_macros_properties_architectures",
             "//libc:__support_math_extras",
             "//libc:__support_uint128",
+            "//libc:hdr_errno_macros",
+            "//libc:hdr_fenv_macros",
             "//libc:hdr_math_macros",
+            "//libc/test/UnitTest:fp_test_helpers",
         ] + deps,
         **kwargs
     )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -4,7 +4,6 @@
 
 # Smoke tests for LLVM libc math.h functions.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
 load("//libc/test/src/math:libc_math_test_rules.bzl", "math_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -951,12 +950,7 @@ math_test(
     hdrs = ["NextUpTest.h"],
 )
 
-math_test(
-    name = "pow",
-    deps = [
-        "//libc:hdr_fenv_macros",
-    ],
-)
+math_test(name = "pow")
 
 math_test(name = "powf")
 
@@ -1156,7 +1150,7 @@ math_test(
     name = "sinhf",
     deps = [
         "//libc:__support_cpp_array",
-    ]
+    ],
 )
 
 math_test(name = "sinpif")


### PR DESCRIPTION
After 277371943fa48f2550df02870951f5e5a77efef5

e.g.

```
external/llvm-project/libc/test/src/math/smoke/NextTowardTest.h:12:10: error: module llvm-project//libc/test/src/math/smoke:nexttowardf_test does not depend on a module exporting 'src/__support/CPP/bit.h'
```