### PR TITLE
[Docs][clang-query] disclose Windows linetab bug on clang-query tab auto-complete

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/Contributing.rst
+++ b/clang-tools-extra/docs/clang-tidy/Contributing.rst
@@ -346,13 +346,13 @@ matching expressions to simplify your matcher.
 
 Alternatively, pressing the tab key after a previous matcher's open parentheses would also 
 show which matchers can be chained with the previous matcher, though some matchers that work 
-may not be listed.
+may not be listed. Note that this suggestion feature currently does not work on Windows.
 
 Just like breaking up a huge function into smaller chunks with intention-revealing names 
 can help you understand a complex algorithm, breaking up a matcher into smaller matchers 
 with intention-revealing names can help you understand a complicated matcher.  
 
-Once you have a working clang-query matcher, the C++ API matchers will be the same or similar 
+Once you have a working :program:`clang-query` matcher, the C++ API matchers will be the same or similar 
 to your interactively constructed matcher (there can be cases where they differ slightly). 
 You can use local variables to preserve your intention-revealing names that you applied 
 to nested matchers.

--- a/clang-tools-extra/docs/clang-tidy/Contributing.rst
+++ b/clang-tools-extra/docs/clang-tidy/Contributing.rst
@@ -344,18 +344,20 @@ matching expressions to simplify your matcher.
   clang-query> let c1 cxxRecordDecl()
   clang-query> match c1
 
-Alternatively, pressing the tab key after a previous matcher's open parentheses would also 
-show which matchers can be chained with the previous matcher, though some matchers that work 
-may not be listed. Note that this suggestion feature currently does not work on Windows.
+Alternatively, pressing the tab key after a previous matcher's open parentheses 
+would also show which matchers can be chained with the previous matcher, 
+though some matchers that work may not be listed. Note that tab completion 
+does not currently work on Windows.
 
-Just like breaking up a huge function into smaller chunks with intention-revealing names 
-can help you understand a complex algorithm, breaking up a matcher into smaller matchers 
-with intention-revealing names can help you understand a complicated matcher.  
+Just like breaking up a huge function into smaller chunks with 
+intention-revealing names can help you understand a complex algorithm, breaking 
+up a matcher into smaller matchers with intention-revealing names can help 
+you understand a complicated matcher.  
 
-Once you have a working :program:`clang-query` matcher, the C++ API matchers will be the same or similar 
-to your interactively constructed matcher (there can be cases where they differ slightly). 
-You can use local variables to preserve your intention-revealing names that you applied 
-to nested matchers.
+Once you have a working :program:`clang-query` matcher, the C++ API matchers 
+will be the same or similar to your interactively constructed matcher (there 
+can be cases where they differ slightly). You can use local variables to preserve 
+your intention-revealing names that you applied to nested matchers.
 
 Creating private matchers
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
As per https://github.com/llvm/llvm-project/pull/106672/#issuecomment-2325577815 and https://github.com/llvm/llvm-project/issues/107377, the documentation should be updated to note that the current bug on Windows involving ``LineEditor`` causing Tab key related features to not work.