### PR TITLE
Full path names are used in several unittests instead of the binary name. Fix up the testcase failures

### DIFF
--- a/clang-tools-extra/clangd/test/log.test
+++ b/clang-tools-extra/clangd/test/log.test
@@ -1,7 +1,7 @@
 # RUN: env CLANGD_FLAGS=-compile-commands-dir=no-such-dir not clangd -lit-test </dev/null 2>&1 >/dev/null | FileCheck %s
 CHECK: I[{{.*}}]{{.*}} clangd version {{.*}}
 CHECK: Working directory: {{.*}}
-CHECK: argv[0]: clangd
+CHECK: argv[0]: {{.*}}clangd
 CHECK: argv[1]: -lit-test
 CHECK: CLANGD_FLAGS: -compile-commands-dir=no-such-dir
 CHECK: E[{{.*}}] Path specified by --compile-commands-dir does not exist.

--- a/clang-tools-extra/test/clang-query/invalid-command-line.cpp
+++ b/clang-tools-extra/test/clang-query/invalid-command-line.cpp
@@ -1,4 +1,4 @@
 // RUN: not clang-query --invalid-arg 2>&1 | FileCheck %s
 
-// CHECK: error: clang-query{{(\.exe)?}}: Unknown command line argument '--invalid-arg'.  Try: 'clang-query{{(\.exe)?}} --help'
+// CHECK: error: clang-query{{(\.exe)?}}: Unknown command line argument '--invalid-arg'.  Try: '{{.*}}clang-query{{(\.exe)?}} --help'
 // CHECK-NEXT: clang-query{{(\.exe)?}}: Did you mean '--extra-arg'?

--- a/clang-tools-extra/test/clang-tidy/infrastructure/invalid-command-line.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/invalid-command-line.cpp
@@ -1,4 +1,4 @@
 // RUN: not clang-tidy --invalid-arg 2>&1 | FileCheck %s
 
-// CHECK: error: clang-tidy{{(\.exe)?}}: Unknown command line argument '--invalid-arg'.  Try: 'clang-tidy{{(\.exe)?}} --help'
+// CHECK: error: clang-tidy{{(\.exe)?}}: Unknown command line argument '--invalid-arg'.  Try: '{{.*}}clang-tidy{{(\.exe)?}} --help'
 // CHECK-NEXT: clang-tidy{{(\.exe)?}}: Did you mean '--extra-arg'?

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -25,7 +25,7 @@
 #  CHECK-NEXT: not not wc missing-file &> [[FILE:.*]] || true
 #  CHECK-NEXT: # executed command: not not wc missing-file
 #  CHECK-NEXT: # .---redirected output from '[[FILE]]'
-#  CHECK-NEXT: # | wc: {{cannot open missing-file|missing-file.* No such file or directory}}
+#  CHECK-NEXT: # | {{.*}}wc: {{cannot open missing-file|missing-file.* No such file or directory}}
 #  CHECK-NEXT: # `-----------------------------
 #  CHECK-NEXT: # note: command had no output on stdout or stderr
 #  CHECK-NEXT: # error: command failed with exit status: 1


### PR DESCRIPTION
Encountered several testcase failures when running `ninja check-all`. It was due to the full path name were shown in the error message instead of the binary name, and therefore causing the check string mismatch.

The machine was running CentOS 9 with binfmt_misc setup that uses qemu-aarch64 (8.1.2). Built and ran the unittest as aarch64 host (through qemu user).