### PR TITLE
[Clang] Introduce FunctionParmPackDecl for expanded lambda captures

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -344,7 +344,7 @@ Bug Fixes to C++ Support
   module imports in those situations. (#GH60336)
 - Fix init-capture packs having a size of one before being instantiated. (#GH63677)
 - Clang now preserves the unexpanded flag in a lambda transform used for pack expansion. (#GH56852), (#GH85667),
-  (#GH99877).
+  (#GH99877), (#GH18873).
 - Fixed a bug when diagnosing ambiguous explicit specializations of constrained member functions.
 - Fixed an assertion failure when selecting a function from an overload set that includes a
   specialization of a conversion function template.

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -3220,6 +3220,43 @@ public:
   friend class ASTDeclReader;
 };
 
+class FunctionParmPackDecl final
+    : public Decl,
+      private llvm::TrailingObjects<FunctionParmPackDecl, VarDecl *> {
+  friend TrailingObjects;
+  friend class ASTDeclReader;
+
+  /// The function parameter pack which was referenced.
+  NamedDecl *Pattern;
+
+  unsigned NumExpansions;
+
+  FunctionParmPackDecl(DeclContext *DC, SourceLocation StartLoc,
+                       NamedDecl *Pattern, ArrayRef<VarDecl *> ExpandedParams);
+
+  void setExpandedParams(ArrayRef<VarDecl *> ExpandedParams);
+
+public:
+  static FunctionParmPackDecl *Create(ASTContext &C, DeclContext *DC,
+                                      SourceLocation StartLoc,
+                                      NamedDecl *Pattern,
+                                      ArrayRef<VarDecl *> ExpandedParams);
+
+  static FunctionParmPackDecl *
+  CreateDeserialized(ASTContext &C, GlobalDeclID ID, unsigned NumExpansions);
+
+  ArrayRef<VarDecl *> getExpandedParams() const {
+    return ArrayRef<VarDecl *>(getTrailingObjects<VarDecl *>(), NumExpansions);
+  }
+
+  unsigned getNumExpansions() const { return NumExpansions; }
+
+  NamedDecl *getPattern() const { return Pattern; }
+
+  static bool classofKind(Kind K) { return K == FunctionParmPack; }
+  static bool classof(const Decl *D) { return classofKind(D->getKind()); }
+};
+
 /// A template parameter object.
 ///
 /// Template parameter objects represent values of class type used as template

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2353,6 +2353,8 @@ DEF_TRAVERSE_DECL(ImplicitConceptSpecializationDecl, {
   TRY_TO(TraverseTemplateArguments(D->getTemplateArguments()));
 })
 
+DEF_TRAVERSE_DECL(FunctionParmPackDecl, {})
+
 #undef DEF_TRAVERSE_DECL
 
 // ----------------- Stmt traversal -----------------

--- a/clang/include/clang/Basic/DeclNodes.td
+++ b/clang/include/clang/Basic/DeclNodes.td
@@ -91,6 +91,7 @@ def Named : DeclNode<Decl, "named declarations", 1>;
   def ObjCProperty : DeclNode<Named, "Objective-C properties">;
   def ObjCCompatibleAlias : DeclNode<Named>;
 def ImplicitConceptSpecialization : DeclNode<Decl>;
+def FunctionParmPack : DeclNode<Decl>;
 def LinkageSpec : DeclNode<Decl>, DeclContext;
 def Export : DeclNode<Decl>, DeclContext;
 def ObjCPropertyImpl : DeclNode<Decl>;

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -515,6 +515,9 @@ enum class TemplateSubstitutionKind : char {
     llvm::PointerUnion<Decl *, DeclArgumentPack *> *
     findInstantiationOf(const Decl *D);
 
+    llvm::PointerUnion<Decl *, DeclArgumentPack *> *
+    findInstantiationUnsafe(const Decl *D);
+
     void InstantiatedLocal(const Decl *D, Decl *Inst);
     void InstantiatedLocalPackArg(const Decl *D, VarDecl *Inst);
     void MakeInstantiatedLocalArgPack(const Decl *D);

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1493,7 +1493,10 @@ enum DeclCode {
   /// An ImplicitConceptSpecializationDecl record.
   DECL_IMPLICIT_CONCEPT_SPECIALIZATION,
 
-  DECL_LAST = DECL_IMPLICIT_CONCEPT_SPECIALIZATION
+  /// A FunctionParmPackDecl record.
+  DECL_FUNCTION_PARM_PACK,
+
+  DECL_LAST = DECL_FUNCTION_PARM_PACK
 };
 
 /// Record codes for each kind of statement or expression.

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -986,6 +986,7 @@ unsigned Decl::getIdentifierNamespaceForKind(Kind DeclKind) {
     case LifetimeExtendedTemporary:
     case RequiresExprBody:
     case ImplicitConceptSpecialization:
+    case FunctionParmPack:
       // Never looked up by name.
       return 0;
   }

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1133,6 +1133,43 @@ void ImplicitConceptSpecializationDecl::setTemplateArguments(
 }
 
 //===----------------------------------------------------------------------===//
+// FunctionParmPackDecl Implementation
+//===----------------------------------------------------------------------===//
+FunctionParmPackDecl::FunctionParmPackDecl(DeclContext *DC,
+                                           SourceLocation StartLoc,
+                                           NamedDecl *Pattern,
+                                           ArrayRef<VarDecl *> ExpandedParams)
+    : Decl(FunctionParmPack, DC, StartLoc), Pattern(Pattern),
+      NumExpansions(ExpandedParams.size()) {
+  std::uninitialized_copy(ExpandedParams.begin(), ExpandedParams.end(),
+                          getTrailingObjects<VarDecl *>());
+}
+
+FunctionParmPackDecl *
+FunctionParmPackDecl::Create(ASTContext &C, DeclContext *DC,
+                             SourceLocation StartLoc, NamedDecl *Pattern,
+                             ArrayRef<VarDecl *> ExpandedParams) {
+  return new (C, DC, additionalSizeToAlloc<VarDecl *>(ExpandedParams.size()))
+      FunctionParmPackDecl(DC, StartLoc, Pattern, ExpandedParams);
+}
+
+FunctionParmPackDecl *
+FunctionParmPackDecl::CreateDeserialized(ASTContext &C, GlobalDeclID ID,
+                                         unsigned NumExpansions) {
+  return new (C, ID, additionalSizeToAlloc<VarDecl *>(NumExpansions))
+      FunctionParmPackDecl(/*DC=*/nullptr, SourceLocation(),
+                           /*Pattern=*/nullptr,
+                           SmallVector<VarDecl *>(NumExpansions, nullptr));
+}
+
+void FunctionParmPackDecl::setExpandedParams(
+    ArrayRef<VarDecl *> ExpandedParams) {
+  assert(ExpandedParams.size() == NumExpansions);
+  std::uninitialized_copy(ExpandedParams.begin(), ExpandedParams.end(),
+                          getTrailingObjects<VarDecl *>());
+}
+
+//===----------------------------------------------------------------------===//
 // ClassTemplatePartialSpecializationDecl Implementation
 //===----------------------------------------------------------------------===//
 void ClassTemplatePartialSpecializationDecl::anchor() {}

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -134,6 +134,7 @@ void CodeGenFunction::EmitDecl(const Decl &D) {
   case Decl::ImplicitConceptSpecialization:
   case Decl::LifetimeExtendedTemporary:
   case Decl::RequiresExprBody:
+  case Decl::FunctionParmPack:
     // None of these decls require codegen support.
     return;
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1855,6 +1855,21 @@ Decl *TemplateInstantiator::TransformDecl(SourceLocation Loc, Decl *D) {
     // template parameter.
   }
 
+  if (ParmVarDecl *PVD = dyn_cast<ParmVarDecl>(D);
+      PVD && SemaRef.ArgumentPackSubstitutionIndex == -1) {
+    if (auto *Found =
+            SemaRef.CurrentInstantiationScope->findInstantiationUnsafe(D)) {
+      using DeclArgumentPack = LocalInstantiationScope::DeclArgumentPack;
+      if (auto *Pack = Found->dyn_cast<DeclArgumentPack *>()) {
+        assert(SemaRef.getCurLambda() &&
+               "Only lambdas can hold off an expanded pack expansion");
+        return FunctionParmPackDecl::Create(SemaRef.getASTContext(),
+                                            PVD->getDeclContext(),
+                                            PVD->getLocation(), PVD, *Pack);
+      }
+    }
+  }
+
   return SemaRef.FindInstantiatedDecl(Loc, cast<NamedDecl>(D), TemplateArgs);
 }
 
@@ -4369,9 +4384,8 @@ static const Decl *getCanonicalParmVarDecl(const Decl *D) {
   return D;
 }
 
-
 llvm::PointerUnion<Decl *, LocalInstantiationScope::DeclArgumentPack *> *
-LocalInstantiationScope::findInstantiationOf(const Decl *D) {
+LocalInstantiationScope::findInstantiationUnsafe(const Decl *D) {
   D = getCanonicalParmVarDecl(D);
   for (LocalInstantiationScope *Current = this; Current;
        Current = Current->Outer) {
@@ -4395,6 +4409,13 @@ LocalInstantiationScope::findInstantiationOf(const Decl *D) {
     if (!Current->CombineWithOuterScope)
       break;
   }
+  return nullptr;
+}
+
+llvm::PointerUnion<Decl *, LocalInstantiationScope::DeclArgumentPack *> *
+LocalInstantiationScope::findInstantiationOf(const Decl *D) {
+  if (auto *Result = findInstantiationUnsafe(D))
+    return Result;
 
   // If we're performing a partial substitution during template argument
   // deduction, we may not have values for template parameters yet.

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1856,7 +1856,8 @@ Decl *TemplateInstantiator::TransformDecl(SourceLocation Loc, Decl *D) {
   }
 
   if (ParmVarDecl *PVD = dyn_cast<ParmVarDecl>(D);
-      PVD && SemaRef.ArgumentPackSubstitutionIndex == -1) {
+      PVD && SemaRef.CurrentInstantiationScope &&
+      SemaRef.ArgumentPackSubstitutionIndex == -1) {
     if (auto *Found =
             SemaRef.CurrentInstantiationScope->findInstantiationUnsafe(D)) {
       using DeclArgumentPack = LocalInstantiationScope::DeclArgumentPack;

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -4120,6 +4120,11 @@ Decl *TemplateDeclInstantiator::VisitImplicitConceptSpecializationDecl(
 }
 
 Decl *
+TemplateDeclInstantiator::VisitFunctionParmPackDecl(FunctionParmPackDecl *D) {
+  llvm_unreachable("Function param packs cannot reside inside a template");
+}
+
+Decl *
 TemplateDeclInstantiator::VisitRequiresExprBodyDecl(RequiresExprBodyDecl *D) {
   return RequiresExprBodyDecl::Create(SemaRef.Context, D->getDeclContext(),
                                       D->getBeginLoc());

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -14722,12 +14722,20 @@ TreeTransform<Derived>::TransformLambdaExpr(LambdaExpr *E) {
     }
 
     // Transform the captured variable.
-    auto *CapturedVar = cast_or_null<ValueDecl>(
-        getDerived().TransformDecl(C->getLocation(), C->getCapturedVar()));
-    if (!CapturedVar || CapturedVar->isInvalidDecl()) {
+    Decl *NewCapturedDecl =
+        getDerived().TransformDecl(C->getLocation(), C->getCapturedVar());
+    if (!NewCapturedDecl || NewCapturedDecl->isInvalidDecl()) {
       Invalid = true;
       continue;
     }
+    if (auto *FPPD = dyn_cast<FunctionParmPackDecl>(NewCapturedDecl)) {
+      LSI->ContainsUnexpandedParameterPack = true;
+      for (VarDecl *Expanded : FPPD->getExpandedParams())
+        getSema().tryCaptureVariable(Expanded, C->getLocation(), Kind,
+                                     EllipsisLoc);
+      continue;
+    }
+    auto *CapturedVar = cast<ValueDecl>(NewCapturedDecl);
 
     // This is not an init-capture; however it contains an unexpanded pack e.g.
     //  ([Pack] {}(), ...)

--- a/clang/lib/Serialization/ASTCommon.cpp
+++ b/clang/lib/Serialization/ASTCommon.cpp
@@ -453,6 +453,7 @@ bool serialization::isRedeclarableDeclKind(unsigned Kind) {
   case Decl::RequiresExprBody:
   case Decl::UnresolvedUsingIfExists:
   case Decl::HLSLBuffer:
+  case Decl::FunctionParmPack:
     return false;
 
   // These indirectly derive from Redeclarable<T> but are not actually

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -389,6 +389,7 @@ public:
   void VisitUnresolvedUsingValueDecl(UnresolvedUsingValueDecl *D);
   void VisitDeclaratorDecl(DeclaratorDecl *DD);
   void VisitFunctionDecl(FunctionDecl *FD);
+  void VisitFunctionParmPackDecl(FunctionParmPackDecl *D);
   void VisitCXXDeductionGuideDecl(CXXDeductionGuideDecl *GD);
   void VisitCXXMethodDecl(CXXMethodDecl *D);
   void VisitCXXConstructorDecl(CXXConstructorDecl *D);
@@ -2406,6 +2407,13 @@ void ASTDeclReader::VisitImplicitConceptSpecializationDecl(
   D->setTemplateArguments(Args);
 }
 
+void ASTDeclReader::VisitFunctionParmPackDecl(FunctionParmPackDecl *D) {
+  SmallVector<VarDecl *, 4> Expanded;
+  for (unsigned I = 0; I < D->getNumExpansions(); ++I)
+    Expanded.push_back(cast<VarDecl>(Record.readDeclRef()));
+  D->setExpandedParams(Expanded);
+}
+
 void ASTDeclReader::VisitRequiresExprBodyDecl(RequiresExprBodyDecl *D) {
 }
 
@@ -4157,6 +4165,9 @@ Decl *ASTReader::ReadDeclRecord(GlobalDeclID ID) {
   case DECL_IMPLICIT_CONCEPT_SPECIALIZATION:
     D = ImplicitConceptSpecializationDecl::CreateDeserialized(Context, ID,
                                                               Record.readInt());
+    break;
+  case DECL_FUNCTION_PARM_PACK:
+    D = FunctionParmPackDecl::CreateDeserialized(Context, ID, Record.readInt());
     break;
   }
 

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -90,6 +90,7 @@ namespace clang {
     void VisitUnresolvedUsingValueDecl(UnresolvedUsingValueDecl *D);
     void VisitDeclaratorDecl(DeclaratorDecl *D);
     void VisitFunctionDecl(FunctionDecl *D);
+    void VisitFunctionParmPackDecl(FunctionParmPackDecl *D);
     void VisitCXXDeductionGuideDecl(CXXDeductionGuideDecl *D);
     void VisitCXXMethodDecl(CXXMethodDecl *D);
     void VisitCXXConstructorDecl(CXXConstructorDecl *D);
@@ -1698,6 +1699,15 @@ void ASTDeclWriter::VisitImplicitConceptSpecializationDecl(
   for (const TemplateArgument &Arg : D->getTemplateArguments())
     Record.AddTemplateArgument(Arg);
   Code = serialization::DECL_IMPLICIT_CONCEPT_SPECIALIZATION;
+}
+
+void ASTDeclWriter::VisitFunctionParmPackDecl(FunctionParmPackDecl *D) {
+  Record.push_back(D->getNumExpansions());
+  VisitDecl(D);
+  Record.AddDeclRef(D->getPattern());
+  for (VarDecl *VD : D->getExpandedParams())
+    Record.AddDeclRef(VD);
+  Code = serialization::DECL_FUNCTION_PARM_PACK;
 }
 
 void ASTDeclWriter::VisitRequiresExprBodyDecl(RequiresExprBodyDecl *D) {

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -7068,6 +7068,7 @@ CXCursor clang_getCursorDefinition(CXCursor C) {
   case Decl::LifetimeExtendedTemporary:
   case Decl::RequiresExprBody:
   case Decl::UnresolvedUsingIfExists:
+  case Decl::FunctionParmPack:
     return C;
 
   // Declaration kinds that don't make any sense here, but are


### PR DESCRIPTION
This patch continues the effort of #86265, fixing another issue involving expanded captures that were not able to held off in the process of the inner lambda's transformation.

Similar to FunctionParmPackExpr, FunctionParmPackDecl is introduced to model expanded parameters (particularly, lambda parameters) in the situation where the expansion shouldn't occur in the subsequent transformation. This node acts as an intermediate Decl and thus should not show up in the eventual AST.

Fixes #18873
