### PR TITLE
Fix mistake in comment regarding dyn_cast_or_null

### DIFF
--- a/llvm/include/llvm/Support/Casting.h
+++ b/llvm/include/llvm/Support/Casting.h
@@ -755,7 +755,7 @@ template <class X, class Y> auto dyn_cast_if_present(Y *Val) {
 
 // Forwards to dyn_cast_if_present to avoid breaking current users. This is
 // deprecated and will be removed in a future patch, use
-// cast_if_present instead.
+// dyn_cast_if_present instead.
 template <class X, class Y> auto dyn_cast_or_null(const Y &Val) {
   return dyn_cast_if_present<X>(Val);
 }


### PR DESCRIPTION
There was a mistake in a comment regarding dyn_cast_or_null deprication.
It was suggested to use cast_if_present instead of dyn_cast_or_null, but that was probably a copy paste mistake, and dyn_cast_if_present is the function that should be used instead of dyn_cast_or_null.