### PR TITLE
[rtsan] Ensure pthread is initialized in test

### DIFF
--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
@@ -472,11 +472,12 @@ TEST_F(PthreadMutexLockTest, PthreadMutexUnlockSurvivesWhenNotRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRtsanInterceptors, PthreadMutexJoinDiesWhenRealtime) {
-  auto Func = []() {
-    pthread_t thread{};
-    pthread_join(thread, nullptr);
-  };
+TEST(TestRtsanInterceptors, PthreadJoinDiesWhenRealtime) {
+  pthread_t thread{};
+  ASSERT_EQ(0,
+            pthread_create(&thread, nullptr, &FakeThreadEntryPoint, nullptr));
+
+  auto Func = [&thread]() { pthread_join(thread, nullptr); };
 
   ExpectRealtimeDeath(Func, "pthread_join");
   ExpectNonRealtimeSurvival(Func);


### PR DESCRIPTION
From #107988 One of the reports was:

> 
>     I use Red Hat Enterprise Linux 9.0 (Plow) and Ubuntu 22.04 LTS, and the following code will work fine with Ubuntu and will segment fault for the redhat.
> 
> #include <pthread.h>
> int main() {
>     pthread_t thread{};
>     pthread_join(thread, nullptr);
>     return 0;
> 

I think this could be that we are trying to join a null thread that was never created.
