### PR TITLE
[Flang][OpenMP] Process motion clauses in a single call (NFC)

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1223,12 +1223,10 @@ static void genTargetEnterExitUpdateDataClauses(
   cp.processDevice(stmtCtx, clauseOps);
   cp.processIf(directive, clauseOps);
 
-  if (directive == llvm::omp::Directive::OMPD_target_update) {
-    cp.processMotionClauses<clause::To>(stmtCtx, clauseOps);
-    cp.processMotionClauses<clause::From>(stmtCtx, clauseOps);
-  } else {
+  if (directive == llvm::omp::Directive::OMPD_target_update)
+    cp.processMotionClauses(stmtCtx, clauseOps);
+  else
     cp.processMap(loc, stmtCtx, clauseOps);
-  }
 
   cp.processNowait(clauseOps);
 }


### PR DESCRIPTION
This patch removes the template parameter of the
`ClauseProcessor::processMotionClauses()` method and instead processes both `TO` and `FROM` as part of a single call. This also enables moving the implementation out of the header and makes it simpler for a follow-up patch to potentially refactor `processMap()`, `processMotionClauses()`, `processUseDeviceAddr()` and `processUseDevicePtr()`, and minimize code duplication among these.