### PR TITLE
Fix for llvm/test/CodeGen/RISCV/O3-pipeline.ll

### DIFF
--- a/llvm/test/CodeGen/RISCV/O3-pipeline.ll
+++ b/llvm/test/CodeGen/RISCV/O3-pipeline.ll
@@ -20,7 +20,6 @@
 ; CHECK-NEXT: Machine Branch Probability Analysis
 ; CHECK-NEXT: Default Regalloc Eviction Advisor
 ; CHECK-NEXT: Default Regalloc Priority Advisor
-; CHECK-NEXT: Module summary info
 ; CHECK-NEXT:   ModulePass Manager
 ; CHECK-NEXT:     Pre-ISel Intrinsic Lowering
 ; CHECK-NEXT:     FunctionPass Manager


### PR DESCRIPTION
The previous `Fix for Attempt to fix [CGData][MachineOutliner] Global Outlining (#90074) #108037 (#108047)`  somehow dropped this file.