### PR TITLE
[rtsan][compiler-rt] Add 64 bit file interceptors, test for _FILE_OFFSET_BITS

### DIFF
--- a/compiler-rt/lib/rtsan/tests/CMakeLists.txt
+++ b/compiler-rt/lib/rtsan/tests/CMakeLists.txt
@@ -76,6 +76,18 @@ foreach(arch ${RTSAN_TEST_ARCH})
     CFLAGS ${RTSAN_UNITTEST_CFLAGS} -fsanitize=realtime
     LINK_FLAGS ${RTSAN_UNITTEST_LINK_FLAGS} -fsanitize=realtime)
 
+  check_symbol_exists(__GLIBC__ stdio.h RTSAN_USING_GLIBC)
+  if (RTSAN_USING_GLIBC)
+    set(RtsanTestObjects_FileOffset64)
+    generate_compiler_rt_tests(RtsanTestObjects_FileOffset64
+      RtsanUnitTests "Rtsan-${arch}-FileOffset64-Test" ${arch}
+      COMPILE_DEPS ${RTSAN_UNITTEST_HEADERS}
+      SOURCES ${RTSAN_INST_TEST_SOURCES} ${COMPILER_RT_GOOGLETEST_SOURCES}
+      DEPS rtsan
+      CFLAGS ${RTSAN_UNITTEST_CFLAGS} -D_FILE_OFFSET_BITS=64 -fsanitize=realtime
+      LINK_FLAGS ${RTSAN_UNITTEST_LINK_FLAGS} -fsanitize=realtime)
+  endif()
+
   set(RTSAN_TEST_RUNTIME RTRtsanTest.${arch})
   if(APPLE)
     set(RTSAN_TEST_RUNTIME_OBJECTS


### PR DESCRIPTION
From #107988 

We were not intercepting the 64 bit versions of these calls, leading to tests failing when _FILE_OFFSET_BITS = 64.

Add the appropriate interceptors, and add tests for them