### PR TITLE
[bazel] Add CGData targets/deps

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1872,6 +1872,25 @@ cc_library(
 )
 
 cc_library(
+    name = "CGData",
+    srcs = glob(["lib/CGData/**/*.cpp"]),
+    hdrs = glob([
+        "include/llvm/CGData/**/*.h",
+        "include/llvm/CGData/**/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":BitReader",
+        ":BitWriter",
+        ":Core",
+        ":Object",
+        ":ObjectYAML",
+        ":Support",
+        ":TargetParser",
+    ],
+)
+
+cc_library(
     name = "CodeGen",
     srcs = glob(
         [
@@ -1900,6 +1919,7 @@ cc_library(
         ":BitReader",
         ":BitWriter",
         ":CFGuard",
+        ":CGData",
         ":CodeGenTypes",
         ":Core",
         ":DebugInfoCodeView",
@@ -3486,6 +3506,39 @@ cc_binary(
         ":IRReader",
         ":Support",
     ],
+)
+
+gentbl(
+    name = "CGDataOptsTableGen",
+    strip_include_prefix = "tools/llvm-cgdata",
+    tbl_outs = [(
+        "-gen-opt-parser-defs",
+        "tools/llvm-cgdata/Opts.inc",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "tools/llvm-cgdata/Opts.td",
+    td_srcs = ["include/llvm/Option/OptParser.td"],
+)
+
+cc_library(
+    name = "llvm-cgdata-lib",
+    srcs = glob(["tools/llvm-cgdata/*.cpp"]),
+    copts = llvm_copts,
+    deps = [
+        ":CGData",
+        ":CGDataOptsTableGen",
+        ":CodeGen",
+        ":Core",
+        ":Object",
+        ":Option",
+        ":Support",
+    ],
+)
+
+llvm_driver_cc_binary(
+    name = "llvm-cgdata",
+    stamp = 0,
+    deps = [":llvm-cgdata-lib"],
 )
 
 cc_binary(

--- a/utils/bazel/llvm-project-overlay/llvm/driver.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/driver.bzl
@@ -14,6 +14,7 @@ _TOOLS = {
     "dsymutil": "//llvm:dsymutil-lib",
     "lld": "//lld:lld-lib",
     "llvm-ar": "//llvm:llvm-ar-lib",
+    "llvm-cgdata": "//llvm:llvm-cgdata-lib",
     "llvm-cxxfilt": "//llvm:llvm-cxxfilt-lib",
     "llvm-dwp": "//llvm:llvm-dwp-lib",
     "llvm-gsymutil": "//llvm:llvm-gsymutil-lib",

--- a/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
@@ -121,6 +121,24 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "cgdata_tests",
+    size = "small",
+    srcs = glob(
+        ["CGData/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//llvm:CGData",
+        "//llvm:CodeGen",
+        "//llvm:Core",
+        "//llvm:Support",
+        "//third-party/unittest:gmock",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
 cc_library(
     name = "codegen_tests_includes",
     textual_hdrs = glob(


### PR DESCRIPTION
This is newly used as of 0f525452896771cc8c579eb362dc7645e38fd0b9.

The bulk of the targets were added earlier in 9bb555688caf6ae4ba89fee5baa3dc29fec6a9b1.