### PR TITLE
[BPF] make __BPF_FEATURE_MAY_GOTO available for cpuv1

### DIFF
--- a/clang/lib/Basic/Targets/BPF.cpp
+++ b/clang/lib/Basic/Targets/BPF.cpp
@@ -37,6 +37,7 @@ void BPFTargetInfo::getTargetDefines(const LangOptions &Opts,
   }
 
   Builder.defineMacro("__BPF_FEATURE_ADDR_SPACE_CAST");
+  Builder.defineMacro("__BPF_FEATURE_MAY_GOTO");
 
   if (CPU.empty())
     CPU = "v3";
@@ -48,7 +49,6 @@ void BPFTargetInfo::getTargetDefines(const LangOptions &Opts,
 
   std::string CpuVerNumStr = CPU.substr(1);
   Builder.defineMacro("__BPF_CPU_VERSION__", CpuVerNumStr);
-  Builder.defineMacro("__BPF_FEATURE_MAY_GOTO");
 
   int CpuVerNum = std::stoi(CpuVerNumStr);
   if (CpuVerNum >= 2)

--- a/clang/test/Preprocessor/bpf-predefined-macros.c
+++ b/clang/test/Preprocessor/bpf-predefined-macros.c
@@ -64,6 +64,9 @@ int s;
 #ifdef __BPF_FEATURE_ADDR_SPACE_CAST
 int t;
 #endif
+#ifdef __BPF_FEATURE_MAY_GOTO
+int u;
+#endif
 
 // CHECK: int b;
 // CHECK: int c;
@@ -97,6 +100,11 @@ int t;
 // CPU_V2: int t;
 // CPU_V3: int t;
 // CPU_V4: int t;
+
+// CPU_V1: int u;
+// CPU_V2: int u;
+// CPU_V3: int u;
+// CPU_V4: int u;
 
 // CPU_GENERIC: int g;
 


### PR DESCRIPTION
For some reason `__BPF_FEATURE_MAY_GOTO` is available for CPUs v{2,3,4} but is not available for CPU v1. This limitation is arbitrary:
- the instruction is never produced by LLVM backend;
- on Linux Kernel side this instruction is available in kernels that also support CPUv4.

Hence, it is more consistent to either always allow `__BPF_FEATURE_MAY_GOTO` or only allow it for CPUv4.