### PR TITLE
use EXPENSIVE_CHECKS macro to enable  MF.verify from PPCMIPeephole pass

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -177,6 +177,11 @@ public:
     if (skipFunction(MF.getFunction()))
       return false;
     bool Changed = simplifyCode();
+#ifdef EXPENSIVE_CHECKS
+    if (Changed)
+      MF.verify(this, "Error in PowerPC MI Peephole optimization, compile with "
+                      "-mllvm -disable-ppc-peephole");
+#endif
     return Changed;
   }
 };

--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -177,11 +177,6 @@ public:
     if (skipFunction(MF.getFunction()))
       return false;
     bool Changed = simplifyCode();
-#ifndef NDEBUG
-    if (Changed)
-      MF.verify(this, "Error in PowerPC MI Peephole optimization, compile with "
-                      "-mllvm -disable-ppc-peephole");
-#endif
     return Changed;
   }
 };


### PR DESCRIPTION
verifying the machine instructions of the functions in the PPCMIPeephole pass will cause a huge compile time increase in some cases. use EXPENSIVE_CHECKS macro to enable  MF.verify from PPCMIPeephole pass.