### PR TITLE
[NFC] Add explicit #include config.h where its macros are used.

### DIFF
--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -29,6 +29,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Config/config.h" // for HAVE_SYS_STAT_H
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/Error.h"

--- a/llvm/lib/Support/Unix/DynamicLibrary.inc
+++ b/llvm/lib/Support/Unix/DynamicLibrary.inc
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Config/config.h" // for HAVE_DLFCN_H, HAVE_DLOPEN
+
 #if defined(HAVE_DLFCN_H) && defined(HAVE_DLOPEN)
 #include <dlfcn.h>
 

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Unix.h"
+#include "llvm/Config/config.h" // for HAVE_DLFCN_H, HAVE_DLADDR, HAVE_FCNTL_H, HAVE_FUTIMENS, HAVE_FUTIMES, HAVE_PREAD, HAVE_SYS_STAT_H, HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC, HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC, HAVE_UNISTD_H
 #include <limits.h>
 #include <stdio.h>
 #if HAVE_SYS_STAT_H

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Config/config.h" // for HAVE_PTHREAD_GETNAME_NP, HAVE_PTHREAD_SETNAME_NP
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/llvm/lib/Support/Windows/explicit_symbols.inc
+++ b/llvm/lib/Support/Windows/explicit_symbols.inc
@@ -1,4 +1,5 @@
 /* in libgcc.a */
+#include "llvm/Config/config.h" // for HAVE__* macros
 
 #ifdef HAVE__ALLOCA
 EXPLICIT_SYMBOL(_alloca)

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Config/config.h" // for LLVM_VERSION_PRINTER_SHOW_HOST_TARGET_INFO
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"

--- a/llvm/tools/llvm-exegesis/lib/Assembler.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "Assembler.h"
-
 #include "SnippetRepetitor.h"
 #include "SubprocessMemory.h"
 #include "Target.h"
@@ -22,6 +21,7 @@
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/Config/config.h" // for HAVE_LIBPFM
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Instructions.h"

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Config/config.h" // for HAVE_LIBPFM, HAVE_BUILTIN_THREAD_POINTER
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/Support/CrashRecoveryContext.h"
 #include "llvm/Support/Error.h"

--- a/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 #include "../Target.h"
-
 #include "../Error.h"
 #include "../MmapUtils.h"
 #include "../ParallelSnippetGenerator.h"
@@ -20,16 +19,17 @@
 #include "X86RegisterInfo.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/Config/config.h" // for HAVE_LIBPFM, LIBPFM_HAS_FIELD_CYCLES
 #include "llvm/MC/MCInstBuilder.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/TargetParser/Host.h"
-
 #include <memory>
 #include <string>
 #include <vector>
+
 #if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 #include <immintrin.h>
 #include <intrin.h>

--- a/llvm/tools/llvm-exegesis/lib/X86/X86Counter.cpp
+++ b/llvm/tools/llvm-exegesis/lib/X86/X86Counter.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "X86Counter.h"
+#include "llvm/Config/config.h" // for HAVE_LIBPFM, LIBPFM_HAS_FIELD_CYCLES
 
 #if defined(__linux__) && defined(HAVE_LIBPFM) &&                              \
     defined(LIBPFM_HAS_FIELD_CYCLES)

--- a/llvm/tools/llvm-exegesis/lib/X86/X86Counter.h
+++ b/llvm/tools/llvm-exegesis/lib/X86/X86Counter.h
@@ -16,6 +16,7 @@
 #define LLVM_TOOLS_LLVM_EXEGESIS_LIB_X86_X86COUNTER_H
 
 #include "../PerfHelper.h"
+#include "llvm/Config/config.h" // for HAVE_LIBPFM, LIBPFM_HAS_FIELD_CYCLES
 #include "llvm/Support/Error.h"
 
 // FIXME: Use appropriate wrappers for poll.h and mman.h

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -28,6 +28,7 @@
 #include "lib/ValidationEvent.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Config/config.h" // for HAVE_LIBPFM
 #include "llvm/MC/MCInstBuilder.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCParser/MCAsmParser.h"

--- a/llvm/unittests/Support/ProcessTest.cpp
+++ b/llvm/unittests/Support/ProcessTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/Process.h"
+#include "llvm/Config/config.h" // for HAVE_SETENV
 #include "llvm/Support/Error.h"
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"


### PR DESCRIPTION
Without these explicit includes, removing other headers, who implicitly include `config.h`, may have non-trivial side effects. For example, `clangd` may report even `config.h` as "no used" in case it defines a macro, that is explicitly used with `#ifdef`. It is actually amplified with different build configs which use different set of macros.