### PR TITLE
[flang][cuda] Avoid generating data transfer when calling size intrinsic

### DIFF
--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -1011,6 +1011,9 @@ struct CollectCudaSymbolsHelper : public SetTraverse<CollectCudaSymbolsHelper,
   }
   // Overload some of the operator() to filter out the symbols that are not
   // of interest for CUDA data transfer logic.
+  semantics::UnorderedSymbolSet operator()(const DescriptorInquiry &) const {
+    return {};
+  }
   semantics::UnorderedSymbolSet operator()(const Subscript &) const {
     return {};
   }

--- a/flang/test/Lower/CUDA/cuda-data-transfer.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer.cuf
@@ -353,3 +353,13 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPsub17()
 ! CHECK: cuf.kernel<<<*, *>>>
 ! CHECK-NOT: cuf.data_transfer
+
+subroutine sub18()
+  integer, device, allocatable :: a(:)
+  integer :: isz
+
+  isz = size(a)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsub18()
+! CHECK-NOT: cuf.data_transfer


### PR DESCRIPTION
cuf.data_transfer was wrongly generated when calling the `size` intrinsic on a device allocatable variable. Since the descriptor is available on the host, there is no transfer needed. 

Add `DescriptorInquiry` in the `CollectCudaSymbolsHelper` to filter out symbols that are not needed for the transfer decision to be made. 