### PR TITLE
[llvm-debuginfod-find] Enable multicall driver

### DIFF
--- a/llvm/tools/llvm-debuginfod-find/CMakeLists.txt
+++ b/llvm/tools/llvm-debuginfod-find/CMakeLists.txt
@@ -1,11 +1,21 @@
 set(LLVM_LINK_COMPONENTS
+  Option
   Object
   Support
   )
+set(LLVM_TARGET_DEFINITIONS Opts.td)
+tablegen(LLVM Opts.inc -gen-opt-parser-defs)
+add_public_tablegen_target(DebugInfodFindOptsTableGen)
+
 add_llvm_tool(llvm-debuginfod-find
   llvm-debuginfod-find.cpp
+  DEPENDS
+  DebugInfodFindOptsTableGen
+  GENERATE_DRIVER
   )
-target_link_libraries(llvm-debuginfod-find PRIVATE LLVMDebuginfod)
+if(NOT LLVM_TOOL_LLVM_DRIVER_BUILD)
+  target_link_libraries(llvm-debuginfod-find PRIVATE LLVMDebuginfod)
+endif()
 if(LLVM_INSTALL_BINUTILS_SYMLINKS)
   add_llvm_tool_symlink(debuginfod-find llvm-debuginfod-find)
 endif()

--- a/llvm/tools/llvm-debuginfod-find/Opts.td
+++ b/llvm/tools/llvm-debuginfod-find/Opts.td
@@ -1,0 +1,17 @@
+include "llvm/Option/OptParser.td"
+
+class F<string name, string help> : Flag<["-"], name>, HelpText<help>;
+class FF<string name, string help>: Flag<["--"], name>, HelpText<help>;
+class S<string name, string meta, string help>: Separate<["--"], name>, HelpText<help>, MetaVarName<meta>;
+
+def help : FF<"help", "Display available options">;
+def : F<"h", "Alias for --help">, Alias<help>;
+
+def fetch_executable : FF<"executable", "If set, fetch a binary file associated with this build id, containing the executable sections.">;
+def fetch_debuginfo : FF<"debuginfo", "If set, fetch a binary file associated with this build id, containing the debuginfo sections.">;
+def fetch_source : S<"source", "<string>", "Fetch a source file associated with this build id, which is at this relative path relative to the compilation directory.">;
+def dump_to_stdout : FF<"dump", "If set, dumps the contents of the fetched artifact "
+                          "to standard output. Otherwise, dumps the absolute "
+                          "path to the cached artifact on disk.">;
+def debug_file_directory : S<"debug-file-directory", "<string>", "Path to directory where to look for debug files.">;
+

--- a/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
+++ b/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
@@ -16,14 +16,89 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Debuginfod/BuildIDFetcher.h"
 #include "llvm/Debuginfod/Debuginfod.h"
 #include "llvm/Debuginfod/HTTPClient.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/Option.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/LLVMDriver.h"
 
 using namespace llvm;
 
+// Command-line option boilerplate.
+namespace {
+enum ID {
+  OPT_INVALID = 0, // This is not an option ID.
+#define OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__),
+#include "Opts.inc"
+#undef OPTION
+};
+
+#define PREFIX(NAME, VALUE)                                                    \
+  static constexpr StringLiteral NAME##_init[] = VALUE;                        \
+  static constexpr ArrayRef<StringLiteral> NAME(NAME##_init,                   \
+                                                std::size(NAME##_init) - 1);
+#include "Opts.inc"
+#undef PREFIX
+
+using namespace llvm::opt;
+static constexpr opt::OptTable::Info InfoTable[] = {
+#define OPTION(...) LLVM_CONSTRUCT_OPT_INFO(__VA_ARGS__),
+#include "Opts.inc"
+#undef OPTION
+};
+
+class DebuginfodFindOptTable : public opt::GenericOptTable {
+public:
+  DebuginfodFindOptTable() : GenericOptTable(InfoTable) {}
+};
+
+} // end anonymous namespace
+
+static std::string InputBuildID;
+static bool FetchExecutable;
+static bool FetchDebuginfo;
+static std::string FetchSource;
+static bool DumpToStdout;
+static std::vector<std::string> DebugFileDirectory;
+
+static void parseArgs(int argc, char **argv) {
+  DebuginfodFindOptTable Tbl;
+  llvm::StringRef ToolName = argv[0];
+  llvm::BumpPtrAllocator A;
+  llvm::StringSaver Saver{A};
+  opt::InputArgList Args =
+      Tbl.parseArgs(argc, argv, OPT_UNKNOWN, Saver, [&](StringRef Msg) {
+        llvm::errs() << Msg << '\n';
+        std::exit(1);
+      });
+
+  if (Args.hasArg(OPT_help)) {
+    Tbl.printHelp(llvm::outs(),
+                  "llvm-debuginfod-find [options] <input build_id>",
+                  ToolName.str().c_str());
+    std::exit(0);
+  }
+
+  InputBuildID = Args.getLastArgValue(OPT_INPUT);
+
+  FetchExecutable = Args.hasArg(OPT_fetch_executable);
+  FetchDebuginfo = Args.hasArg(OPT_fetch_debuginfo);
+  DumpToStdout = Args.hasArg(OPT_dump_to_stdout);
+  FetchSource = Args.getLastArgValue(OPT_fetch_source, "");
+  DebugFileDirectory = Args.getAllArgValues(OPT_debug_file_directory);
+}
+
+[[noreturn]] static void helpExit() {
+  errs() << "Must specify exactly one of --executable, "
+            "--source=/path/to/file, or --debuginfo.\n";
+  exit(1);
+}
+
+/*
 cl::OptionCategory DebuginfodFindCategory("llvm-debuginfod-find Options");
 
 cl::opt<std::string> InputBuildID(cl::Positional, cl::Required,
@@ -60,30 +135,17 @@ static cl::list<std::string> DebugFileDirectory(
     cl::desc("Path to directory where to look for debug files."),
     cl::cat(DebuginfodFindCategory));
 
-[[noreturn]] static void helpExit() {
-  errs() << "Must specify exactly one of --executable, "
-            "--source=/path/to/file, or --debuginfo.";
-  exit(1);
-}
+*/
 
-ExitOnError ExitOnErr;
+ExitOnError ExitOnDebuginfodFindError;
 
 static std::string fetchDebugInfo(object::BuildIDRef BuildID);
 
-int main(int argc, char **argv) {
-  InitLLVM X(argc, argv);
+int llvm_debuginfod_find_main(int argc, char **argv,
+                              const llvm::ToolContext &) {
+  // InitLLVM X(argc, argv);
   HTTPClient::initialize();
-
-  cl::HideUnrelatedOptions({&DebuginfodFindCategory});
-  cl::ParseCommandLineOptions(
-      argc, argv,
-      "llvm-debuginfod-find: Fetch debuginfod artifacts\n\n"
-      "This program is a frontend to the debuginfod client library. The cache "
-      "directory, request timeout (in seconds), and debuginfod server urls are "
-      "set by these environment variables:\n"
-      "DEBUGINFOD_CACHE_PATH (default set by sys::path::cache_directory)\n"
-      "DEBUGINFOD_TIMEOUT (defaults to 90s)\n"
-      "DEBUGINFOD_URLS=[comma separated URLs] (defaults to empty)\n");
+  parseArgs(argc, argv);
 
   if (FetchExecutable + FetchDebuginfo + (FetchSource != "") != 1)
     helpExit();
@@ -97,9 +159,10 @@ int main(int argc, char **argv) {
 
   std::string Path;
   if (FetchSource != "")
-    Path = ExitOnErr(getCachedOrDownloadSource(ID, FetchSource));
+    Path =
+        ExitOnDebuginfodFindError(getCachedOrDownloadSource(ID, FetchSource));
   else if (FetchExecutable)
-    Path = ExitOnErr(getCachedOrDownloadExecutable(ID));
+    Path = ExitOnDebuginfodFindError(getCachedOrDownloadExecutable(ID));
   else if (FetchDebuginfo)
     Path = fetchDebugInfo(ID);
   else
@@ -110,11 +173,13 @@ int main(int argc, char **argv) {
     // Print the contents of the artifact.
     ErrorOr<std::unique_ptr<MemoryBuffer>> Buf = MemoryBuffer::getFile(
         Path, /*IsText=*/false, /*RequiresNullTerminator=*/false);
-    ExitOnErr(errorCodeToError(Buf.getError()));
+    ExitOnDebuginfodFindError(errorCodeToError(Buf.getError()));
     outs() << Buf.get()->getBuffer();
   } else
     // Print the path to the cached artifact file.
     outs() << Path << "\n";
+
+  return 0;
 }
 
 // Find a debug file in local build ID directories and via debuginfod.


### PR DESCRIPTION
Migrate llvm-debuginfod-find tool to use GenericOptTable. 
Enable multicall driver.