### PR TITLE
Revert "[libc++][string] Remove potential non-trailing 0-length array"

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -749,14 +749,6 @@ struct __can_be_converted_to_string_view
 struct __uninitialized_size_tag {};
 struct __init_with_sentinel_tag {};
 
-template <size_t _PaddingSize>
-struct __padding {
-  char __padding_[_PaddingSize];
-};
-
-template <>
-struct __padding<0> {};
-
 template <class _CharT, class _Traits, class _Allocator>
 class basic_string {
 private:
@@ -861,7 +853,7 @@ private:
 
   struct __short {
     value_type __data_[__min_cap];
-    _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(value_type) - 1> __padding_;
+    unsigned char __padding_[sizeof(value_type) - 1];
     unsigned char __size_    : 7;
     unsigned char __is_long_ : 1;
   };
@@ -913,7 +905,7 @@ private:
       unsigned char __is_long_ : 1;
       unsigned char __size_    : 7;
     };
-    _LIBCPP_NO_UNIQUE_ADDRESS __padding<sizeof(value_type) - 1> __padding_;
+    char __padding_[sizeof(value_type) - 1];
     value_type __data_[__min_cap];
   };
 


### PR DESCRIPTION
Reverts llvm/llvm-project#105865

This breaks a pair of LLDB tests in CI.