### PR TITLE
[NFC] [HLSL] Update test for HLSL 202x

### DIFF
--- a/clang/test/CodeGenHLSL/loops/unroll.hlsl
+++ b/clang/test/CodeGenHLSL/loops/unroll.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN: dxil-pc-shadermodel6.3-library -disable-llvm-passes %s -emit-llvm -o - | FileCheck %s
 
 /*** for ***/
@@ -35,8 +35,8 @@ void for_nested_one_unroll_enable()
         for( int j = 0; j < 10; ++j)
             s += i + j;
     }
-// CHECK: br label %{{.*}}, !llvm.loop ![[FOR_NESTED_ENABLE:.*]]
-// CHECK-NOT: br label %{{.*}}, !llvm.loop ![[FOR_NESTED_1_ENABLE:.*]]
+// CHECK: br label %{{.*}}, !llvm.loop ![[FOR_NESTED_ENABLE_INNER:.*]]
+// CHECK: br label %{{.*}}, !llvm.loop ![[FOR_NESTED_ENABLE_OUTER:.*]]
 }
 
 void for_nested_two_unroll_enable()
@@ -111,20 +111,26 @@ void do_enable()
 }
 
 
-// CHECK: ![[FOR_DISTINCT]]     =  distinct !{![[FOR_DISTINCT]],  ![[FOR_COUNT:.*]]}
-// CHECK: ![[FOR_COUNT]]         =  !{!"llvm.loop.unroll.count", i32 8}
-// CHECK: ![[FOR_DISABLE]]   =  distinct !{![[FOR_DISABLE]],  ![[DISABLE:.*]]}
-// CHECK: ![[DISABLE]]       =  !{!"llvm.loop.unroll.disable"}
-// CHECK: ![[FOR_ENABLE]]      =  distinct !{![[FOR_ENABLE]],  ![[ENABLE:.*]]}
-// CHECK: ![[ENABLE]]          =  !{!"llvm.loop.unroll.enable"}
-// CHECK: ![[FOR_NESTED_ENABLE]] =  distinct !{![[FOR_NESTED_ENABLE]], ![[ENABLE]]}
-// CHECK: ![[FOR_NESTED2_ENABLE]] =  distinct !{![[FOR_NESTED2_ENABLE]], ![[ENABLE]]}
-// CHECK: ![[FOR_NESTED2_1_ENABLE]] =  distinct !{![[FOR_NESTED2_1_ENABLE]], ![[ENABLE]]}
-// CHECK: ![[WHILE_DISTINCT]]   =  distinct !{![[WHILE_DISTINCT]],    ![[WHILE_COUNT:.*]]}
-// CHECK: ![[WHILE_COUNT]]         =  !{!"llvm.loop.unroll.count", i32 4}
-// CHECK: ![[WHILE_DISABLE]] =  distinct !{![[WHILE_DISABLE]],  ![[DISABLE]]}
-// CHECK: ![[WHILE_ENABLE]]    =  distinct !{![[WHILE_ENABLE]],     ![[ENABLE]]}
-// CHECK: ![[DO_DISTINCT]]      =  distinct !{![[DO_DISTINCT]],       ![[DO_COUNT:.*]]}
-// CHECK: ![[DO_COUNT]]         =  !{!"llvm.loop.unroll.count", i32 16}
-// CHECK: ![[DO_DISABLE]]    =  distinct !{![[DO_DISABLE]],     ![[DISABLE]]}
-// CHECK: ![[DO_ENABLE]]       =  distinct !{![[DO_ENABLE]],        ![[ENABLE]]}
+// CHECK-DAG: [[MUST_PROGRESS:.*]] = !{!"llvm.loop.mustprogress"}
+// CHECK-DAG: [[DISABLE:.*]] = !{!"llvm.loop.unroll.disable"}
+// CHECK-DAG: [[FOR_COUNT:.*]] =  !{!"llvm.loop.unroll.count", i32 8}
+// CHECK-DAG: [[ENABLE:.*]] = !{!"llvm.loop.unroll.enable"}
+// CHECK-DAG: [[WHILE_COUNT:.*]] = !{!"llvm.loop.unroll.count", i32 4}
+// CHECK-DAG: [[DO_COUNT:.*]] = !{!"llvm.loop.unroll.count", i32 16}
+
+// CHECK-DAG: ![[FOR_DISTINCT]] =  distinct !{![[FOR_DISTINCT]], [[MUST_PROGRESS]], [[FOR_COUNT]]}
+// CHECK-DAG: ![[FOR_DISABLE]] =  distinct !{![[FOR_DISABLE]], [[MUST_PROGRESS]], [[DISABLE]]}
+// CHECK-DAG: ![[FOR_ENABLE]] =  distinct !{![[FOR_ENABLE]], [[MUST_PROGRESS]], [[ENABLE]]}
+
+// CHECK-DAG: ![[FOR_NESTED_ENABLE_INNER]] = distinct !{![[FOR_NESTED_ENABLE_INNER]], [[MUST_PROGRESS]]}
+// CHECK-DAG: ![[FOR_NESTED_ENABLE_OUTER]] = distinct !{![[FOR_NESTED_ENABLE_OUTER]], [[MUST_PROGRESS]], [[ENABLE]]}
+// CHECK-DAG: ![[FOR_NESTED2_ENABLE]] =  distinct !{![[FOR_NESTED2_ENABLE]], [[MUST_PROGRESS]], [[ENABLE]]}
+// CHECK-DAG: ![[FOR_NESTED2_1_ENABLE]] =  distinct !{![[FOR_NESTED2_1_ENABLE]], [[MUST_PROGRESS]], [[ENABLE]]}
+// CHECK-DAG: ![[WHILE_DISTINCT]]   =  distinct !{![[WHILE_DISTINCT]], [[MUST_PROGRESS]], [[WHILE_COUNT]]}
+
+// CHECK-DAG: ![[WHILE_DISABLE]] =  distinct !{![[WHILE_DISABLE]], [[MUST_PROGRESS]], [[DISABLE]]}
+// CHECK-DAG: ![[WHILE_ENABLE]] =  distinct !{![[WHILE_ENABLE]], [[MUST_PROGRESS]], [[ENABLE]]}
+// CHECK-DAG: ![[DO_DISTINCT]]  =  distinct !{![[DO_DISTINCT]], [[MUST_PROGRESS]], [[DO_COUNT]]}
+
+// CHECK-DAG: ![[DO_DISABLE]] =  distinct !{![[DO_DISABLE]], [[MUST_PROGRESS]], [[DISABLE]]}
+// CHECK-DAG: ![[DO_ENABLE]] =  distinct !{![[DO_ENABLE]], [[MUST_PROGRESS]], [[ENABLE]]}


### PR DESCRIPTION
HLSL 202x inherits from C++11, which generates additional loop hint information for loops that must progress. Since HLSL 202x is going to be the default for Clang we want to make sure all our tests pass with it.

Required for https://github.com/llvm/llvm-project/issues/108044