### PR TITLE
[compiler-rt] Hardcode uptr/sptr typedefs on Linux Arm

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -139,14 +139,14 @@
 namespace __sanitizer {
 
 #if defined(__UINTPTR_TYPE__)
-#if defined(__arm__) && defined(__linux__)
+#  if defined(__arm__) && defined(__linux__)
 // Linux Arm headers redefine __UINTPTR_TYPE__ and disagree with clang/gcc.
 typedef unsigned int uptr;
 typedef int sptr;
-#else
+#  else
 typedef __UINTPTR_TYPE__ uptr;
 typedef __INTPTR_TYPE__ sptr;
-#endif
+#  endif
 #elif defined(_WIN64)
 // 64-bit Windows uses LLP64 data model.
 typedef unsigned long long uptr;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -139,8 +139,14 @@
 namespace __sanitizer {
 
 #if defined(__UINTPTR_TYPE__)
+#if defined(__arm__) && defined(__linux__)
+// Linux Arm headers redefine __UINTPTR_TYPE__ and disagree with clang/gcc.
+typedef unsigned int uptr;
+typedef int sptr;
+#else
 typedef __UINTPTR_TYPE__ uptr;
 typedef __INTPTR_TYPE__ sptr;
+#endif
 #elif defined(_WIN64)
 // 64-bit Windows uses LLP64 data model.
 typedef unsigned long long uptr;


### PR DESCRIPTION
After #106155, Android arm32 asan builds stopped working with missing definition linker errors. This is due to inconsistent definitions of `uptr` of either `unsigned long` or `unsigned int` even between TUs in compiler-rt. This is caused by Linux arm32 headers redefining `__UINTPTR_TYPE__` (see `arch/arm/include/uapi/asm/types.h` in the Linux kernel repo), meaning include order/whether or not the Linux header is included changes compiler-rt symbol mangling.

As a workaround, this hardcodes `uptr`/`sptr` in compiler-rt to `unsigned int`/`int` on Linux arm32, matching clang/gcc.