### PR TITLE
[flang] Downgrade error message to warning

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -1587,8 +1587,11 @@ void CheckHelper::CheckExternal(const Symbol &symbol) {
             } else if (!globalChars->CanBeCalledViaImplicitInterface() &&
                 context_.ShouldWarn(
                     common::UsageWarning::ExternalInterfaceMismatch)) {
-              msg = messages_.Say(
-                  "The global subprogram '%s' may not be referenced via the implicit interface '%s'"_err_en_US,
+              // TODO: This should be a hard error if the procedure has
+              // actually been called (as opposed to just being used as a
+              // procedure pointer target or passed as an actual argument).
+              msg = WarnIfNotInModuleFile(
+                  "The global subprogram '%s' should not be referenced via the implicit interface '%s'"_warn_en_US,
                   global->name(), symbol.name());
             }
           }

--- a/flang/test/Semantics/local-vs-global.f90
+++ b/flang/test/Semantics/local-vs-global.f90
@@ -50,20 +50,20 @@ program test
   external module_before_1
   !WARNING: The global entity 'block_data_before_1' corresponding to the local procedure 'block_data_before_1' is not a callable subprogram
   external block_data_before_1
-  !ERROR: The global subprogram 'explicit_before_1' may not be referenced via the implicit interface 'explicit_before_1'
+  !WARNING: The global subprogram 'explicit_before_1' should not be referenced via the implicit interface 'explicit_before_1'
   external explicit_before_1
   external implicit_before_1
-  !ERROR: The global subprogram 'explicit_func_before_1' may not be referenced via the implicit interface 'explicit_func_before_1'
+  !WARNING: The global subprogram 'explicit_func_before_1' should not be referenced via the implicit interface 'explicit_func_before_1'
   external explicit_func_before_1
   external implicit_func_before_1
   !WARNING: The global entity 'module_after_1' corresponding to the local procedure 'module_after_1' is not a callable subprogram
   external module_after_1
   !WARNING: The global entity 'block_data_after_1' corresponding to the local procedure 'block_data_after_1' is not a callable subprogram
   external block_data_after_1
-  !ERROR: The global subprogram 'explicit_after_1' may not be referenced via the implicit interface 'explicit_after_1'
+  !WARNING: The global subprogram 'explicit_after_1' should not be referenced via the implicit interface 'explicit_after_1'
   external explicit_after_1
   external implicit_after_1
-  !ERROR: The global subprogram 'explicit_func_after_1' may not be referenced via the implicit interface 'explicit_func_after_1'
+  !WARNING: The global subprogram 'explicit_func_after_1' should not be referenced via the implicit interface 'explicit_func_after_1'
   external explicit_func_after_1
   external implicit_func_after_1
   call module_before_1


### PR DESCRIPTION
It is a non-mandatory error to reference an external procedure via an implicit interface declaration (EXTERNAL or PROCEDURE()) when the external procedure has an interface that requires the presence of an explicit interface to be called.

Until now, the compiler has issued a fatal error message from semantics for this situation.  But (1) there are situations, such as passing such an EXTERNAL as an actual argument, or as the target of a procedure pointer assignment, where little or no harm is done, (2) other compilers don't/can't detect this error, even when the procedure's definition is in the same source file, and (3) it shows up in some real applications.

So downgrade this error to a stern warning.  Perhaps in the future the compiler could resume emission of a hard error in the cases where the EXTERNAL procedure is actually known to be called via its implicit interface.