### PR TITLE
[WebAssembly] Change F16x8 extract lane to require constant integer.

### DIFF
--- a/clang/include/clang/Basic/BuiltinsWebAssembly.def
+++ b/clang/include/clang/Basic/BuiltinsWebAssembly.def
@@ -209,8 +209,8 @@ TARGET_BUILTIN(__builtin_wasm_relaxed_dot_bf16x8_add_f32_f32x4, "V4fV8UsV8UsV4f"
 TARGET_BUILTIN(__builtin_wasm_loadf16_f32, "fh*", "nU", "fp16")
 TARGET_BUILTIN(__builtin_wasm_storef16_f32, "vfh*", "n", "fp16")
 TARGET_BUILTIN(__builtin_wasm_splat_f16x8, "V8hf", "nc", "fp16")
-TARGET_BUILTIN(__builtin_wasm_extract_lane_f16x8, "fV8hi", "nc", "fp16")
-TARGET_BUILTIN(__builtin_wasm_replace_lane_f16x8, "V8hV8hif", "nc", "fp16")
+TARGET_BUILTIN(__builtin_wasm_extract_lane_f16x8, "fV8hIi", "nc", "fp16")
+TARGET_BUILTIN(__builtin_wasm_replace_lane_f16x8, "V8hV8hIif", "nc", "fp16")
 
 // Reference Types builtins
 // Some builtins are custom type-checked - see 't' as part of the third argument,

--- a/clang/lib/Headers/wasm_simd128.h
+++ b/clang/lib/Headers/wasm_simd128.h
@@ -1889,6 +1889,8 @@ static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_splat(float __a) {
 }
 
 #ifdef __wasm_fp16__
+// TODO Replace the following macros with regular C functions and use normal
+// target-independent vector code like the other replace/extract instructions.
 
 #define wasm_f16x8_extract_lane(__a, __i)                                      \
   (__builtin_wasm_extract_lane_f16x8((__f16x8)(__a), __i))

--- a/clang/lib/Headers/wasm_simd128.h
+++ b/clang/lib/Headers/wasm_simd128.h
@@ -1888,18 +1888,15 @@ static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_splat(float __a) {
   return (v128_t)__builtin_wasm_splat_f16x8(__a);
 }
 
-static __inline__ float __FP16_FN_ATTRS wasm_f16x8_extract_lane(v128_t __a,
-                                                                int __i)
-    __REQUIRE_CONSTANT(__i) {
-  return __builtin_wasm_extract_lane_f16x8((__f16x8)__a, __i);
-}
+#ifdef __wasm_fp16__
 
-static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_replace_lane(v128_t __a,
-                                                                 int __i,
-                                                                 float __b)
-    __REQUIRE_CONSTANT(__i) {
-  return (v128_t)__builtin_wasm_replace_lane_f16x8((__f16x8)__a, __i, __b);
-}
+#define wasm_f16x8_extract_lane(__a, __i)                                      \
+  (__builtin_wasm_extract_lane_f16x8((__f16x8)(__a), __i))
+
+#define wasm_f16x8_replace_lane(__a, __i, __b)                                 \
+  ((v128_t)__builtin_wasm_replace_lane_f16x8((__f16x8)(__a), __i, __b))
+
+#endif
 
 static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_abs(v128_t __a) {
   return (v128_t)__builtin_wasm_abs_f16x8((__f16x8)__a);

--- a/clang/test/CodeGen/builtins-wasm.c
+++ b/clang/test/CodeGen/builtins-wasm.c
@@ -834,16 +834,16 @@ f16x8 splat_f16x8(float a) {
   return __builtin_wasm_splat_f16x8(a);
 }
 
-float extract_lane_f16x8(f16x8 a, int i) {
-  // WEBASSEMBLY:  %0 = tail call float @llvm.wasm.extract.lane.f16x8(<8 x half> %a, i32 %i)
+float extract_lane_f16x8(f16x8 a) {
+  // WEBASSEMBLY:  %0 = tail call float @llvm.wasm.extract.lane.f16x8(<8 x half> %a, i32 7)
   // WEBASSEMBLY-NEXT: ret float %0
-  return __builtin_wasm_extract_lane_f16x8(a, i);
+  return __builtin_wasm_extract_lane_f16x8(a, 7);
 }
 
-f16x8 replace_lane_f16x8(f16x8 a, int i, float v) {
-  // WEBASSEMBLY:  %0 = tail call <8 x half> @llvm.wasm.replace.lane.f16x8(<8 x half> %a, i32 %i, float %v)
+f16x8 replace_lane_f16x8(f16x8 a, float v) {
+  // WEBASSEMBLY:  %0 = tail call <8 x half> @llvm.wasm.replace.lane.f16x8(<8 x half> %a, i32 7, float %v)
   // WEBASSEMBLY-NEXT: ret <8 x half> %0
-  return __builtin_wasm_replace_lane_f16x8(a, i, v);
+  return __builtin_wasm_replace_lane_f16x8(a, 7, v);
 }
 
 f16x8 min_f16x8(f16x8 a, f16x8 b) {


### PR DESCRIPTION
Building with no optimizations resulted in failures since the lane constant wasn't a constant in LLVM IR.