### PR TITLE
Reland "[sanitizer] Add CHECKs to validate calculated TLS range"

### DIFF
--- a/compiler-rt/lib/msan/msan_allocator.cpp
+++ b/compiler-rt/lib/msan/msan_allocator.cpp
@@ -232,6 +232,7 @@ static void *MsanAllocate(BufferedStackTrace *stack, uptr size, uptr alignment,
   }
   UnpoisonParam(2);
   RunMallocHooks(allocated, size);
+  Printf("%p %zu\n", allocated, size);
   return allocated;
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
@@ -151,6 +151,10 @@ DTLS::DTV *DTLS_on_tls_get_addr(void *arg_void, void *res,
     // This may happen inside the DTOR of main thread, so just ignore it.
     tls_size = 0;
   }
+  if (tls_size) {
+    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res));
+    CHECK_LT(reinterpret_cast<uptr>(res), tls_beg + tls_size);
+  }
   dtv->beg = tls_beg;
   dtv->size = tls_size;
   return dtv;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
@@ -151,10 +151,10 @@ DTLS::DTV *DTLS_on_tls_get_addr(void *arg_void, void *res,
     // This may happen inside the DTOR of main thread, so just ignore it.
     tls_size = 0;
   }
-  if (tls_size) {
-    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) - kDtvOffset);
-    CHECK_LT(reinterpret_cast<uptr>(res) - kDtvOffset, tls_beg + tls_size);
-  }
+  // if (tls_size) {
+  //   CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) - kDtvOffset);
+  //   CHECK_LT(reinterpret_cast<uptr>(res) - kDtvOffset, tls_beg + tls_size);
+  // }
   dtv->beg = tls_beg;
   dtv->size = tls_size;
   return dtv;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
@@ -152,8 +152,8 @@ DTLS::DTV *DTLS_on_tls_get_addr(void *arg_void, void *res,
     tls_size = 0;
   }
   if (tls_size) {
-    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res));
-    CHECK_LT(reinterpret_cast<uptr>(res), tls_beg + tls_size);
+    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) + kDtvOffset);
+    CHECK_LT(reinterpret_cast<uptr>(res) + kDtvOffset, tls_beg + tls_size);
   }
   dtv->beg = tls_beg;
   dtv->size = tls_size;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
@@ -152,8 +152,8 @@ DTLS::DTV *DTLS_on_tls_get_addr(void *arg_void, void *res,
     tls_size = 0;
   }
   if (tls_size) {
-    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) + kDtvOffset);
-    CHECK_LT(reinterpret_cast<uptr>(res) + kDtvOffset, tls_beg + tls_size);
+    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) - kDtvOffset);
+    CHECK_LT(reinterpret_cast<uptr>(res) - kDtvOffset, tls_beg + tls_size);
   }
   dtv->beg = tls_beg;
   dtv->size = tls_size;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
@@ -151,10 +151,10 @@ DTLS::DTV *DTLS_on_tls_get_addr(void *arg_void, void *res,
     // This may happen inside the DTOR of main thread, so just ignore it.
     tls_size = 0;
   }
-  // if (tls_size) {
-  //   CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) - kDtvOffset);
-  //   CHECK_LT(reinterpret_cast<uptr>(res) - kDtvOffset, tls_beg + tls_size);
-  // }
+  if (tls_size) {
+    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) - kDtvOffset);
+    CHECK_LT(reinterpret_cast<uptr>(res) - kDtvOffset, tls_beg + tls_size);
+  }
   dtv->beg = tls_beg;
   dtv->size = tls_size;
   return dtv;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
@@ -152,8 +152,8 @@ DTLS::DTV *DTLS_on_tls_get_addr(void *arg_void, void *res,
     tls_size = 0;
   }
   if (tls_size) {
-    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res) - kDtvOffset);
-    CHECK_LT(reinterpret_cast<uptr>(res) - kDtvOffset, tls_beg + tls_size);
+    CHECK_LE(tls_beg, reinterpret_cast<uptr>(res));
+    CHECK_LT(reinterpret_cast<uptr>(res), tls_beg + tls_size);
   }
   dtv->beg = tls_beg;
   dtv->size = tls_size;

--- a/compiler-rt/test/asan/TestCases/Linux/stress_dtls.c
+++ b/compiler-rt/test/asan/TestCases/Linux/stress_dtls.c
@@ -11,8 +11,8 @@
 // RUN: %clangxx_asan -x c -DSO_NAME=f1 %s -shared -o %t-f1.so -fPIC
 // RUN: %clangxx_asan -x c -DSO_NAME=f2 %s -shared -o %t-f2.so -fPIC
 // RUN: %clangxx_asan %s -ldl -pthread -o %t
-// RUN: %run %t 0 3
-// RUN: %run %t 2 3
+// RUN: %env_asan_opts=verbosity=2 %run %t 0 3
+// RUN: %env_asan_opts=verbosity=2 %run %t 2 3
 // RUN: %env_asan_opts=verbosity=2 %run %t 10 2 2>&1 | FileCheck %s
 // RUN: %env_asan_opts=verbosity=2:intercept_tls_get_addr=1 %run %t 10 2 2>&1 | FileCheck %s
 // RUN: %env_asan_opts=verbosity=2:intercept_tls_get_addr=0 %run %t 10 2 2>&1 | FileCheck %s --check-prefix=CHECK0

--- a/compiler-rt/test/asan/TestCases/Linux/stress_dtls.c
+++ b/compiler-rt/test/asan/TestCases/Linux/stress_dtls.c
@@ -11,7 +11,7 @@
 // RUN: %clangxx_asan -x c -DSO_NAME=f1 %s -shared -o %t-f1.so -fPIC
 // RUN: %clangxx_asan -x c -DSO_NAME=f2 %s -shared -o %t-f2.so -fPIC
 // RUN: %clangxx_asan %s -ldl -pthread -o %t
-// RUN: %env_asan_opts=verbosity=2 %run %t 0 3
+// RUN: %env_asan_opts=verbosity=2 %run not %t 0 3
 // RUN: %env_asan_opts=verbosity=2 %run %t 2 3
 // RUN: %env_asan_opts=verbosity=2 %run %t 10 2 2>&1 | FileCheck %s
 // RUN: %env_asan_opts=verbosity=2:intercept_tls_get_addr=1 %run %t 10 2 2>&1 | FileCheck %s

--- a/compiler-rt/test/asan/TestCases/Linux/stress_dtls.c
+++ b/compiler-rt/test/asan/TestCases/Linux/stress_dtls.c
@@ -29,6 +29,7 @@
 // CHECK-NOT: num_live_dtls 5
 //
 // CHECK0-NOT: __tls_get_addr
+
 /*
 cc=your-compiler
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/getgrouplist.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/getgrouplist.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -O0 -g %s -o %t && %run %env_tool_opts=verbosity=2 %t
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <grp.h>
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/getgrouplist.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/getgrouplist.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -O0 -g %s -o %t && %run %t
+// RUN: %clangxx -O0 -g %s -o %t && %run %env_tool_opts=verbosity=2 %t
 
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
Reland #107941 taking into account that `res`
can have non-zero kDtvOffset on some platforms.

Reverts llvm/llvm-project#108112