### PR TITLE
[CodeGen] Fix documentation for ISD::ATOMIC_STORE. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -1304,7 +1304,7 @@ enum NodeType {
   /// This corresponds to "load atomic" instruction.
   ATOMIC_LOAD,
 
-  /// OUTCHAIN = ATOMIC_STORE(INCHAIN, ptr, val)
+  /// OUTCHAIN = ATOMIC_STORE(INCHAIN, val, ptr)
   /// This corresponds to "store atomic" instruction.
   ATOMIC_STORE,
 


### PR DESCRIPTION
Update ISDOpcodes.h documentation according to commit ad9d13d
("SelectionDAG: Swap operands of atomic_store") for less confusion.