### PR TITLE
[NFC] Fix an inaccurate comment about typo-correction.

### DIFF
--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -228,7 +228,7 @@ Retry:
         return StmtError();
       }
 
-      // If the identifier was typo-corrected, try again.
+      // If the identifier was annotated, try again.
       if (Tok.isNot(tok::identifier))
         goto Retry;
     }


### PR DESCRIPTION
The comment describes "If the identifier was typo-corrected", but it doesn't need to have been typo-corrected, just being annotated is enough to retry.