### PR TITLE
[lld][WebAssembly] Fix non-pie dynamic-linking executable

### DIFF
--- a/lld/test/wasm/Inputs/lib.s
+++ b/lld/test/wasm/Inputs/lib.s
@@ -1,0 +1,6 @@
+	.functype	f () -> ()
+	.globl	f
+	.type	f,@function
+f:
+	.functype	f () -> ()
+	end_function

--- a/lld/test/wasm/Inputs/lib.s
+++ b/lld/test/wasm/Inputs/lib.s
@@ -1,6 +1,0 @@
-	.functype	f () -> ()
-	.globl	f
-	.type	f,@function
-f:
-	.functype	f () -> ()
-	end_function

--- a/lld/test/wasm/dylink-non-pie.s
+++ b/lld/test/wasm/dylink-non-pie.s
@@ -6,9 +6,7 @@
 # RUN: llvm-objdump -d --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --check-prefixes DIS
 
 	.functype	ret32 (f32) -> (i32)
-	.functype	_start () -> ()
 	.globl	_start
-	.type	_start,@function
 _start:
 	.functype	_start () -> ()
 	i32.const   f_p
@@ -16,7 +14,6 @@ _start:
 	end_function
 
 	.section	.data.f_p,"",@
-	.globl	f_p
 f_p:
 	.int32	ret32
 	.size	f_p, 4

--- a/lld/test/wasm/dylink-non-pie.s
+++ b/lld/test/wasm/dylink-non-pie.s
@@ -25,6 +25,10 @@ f_p:
 # CHECK-NEXT:   - Type:            CUSTOM
 # CHECK-NEXT:     Name:            dylink.0
 
+# non-pie executable doesn't import __memory_base
+# CHECK:   - Type:            IMPORT
+# CHECK-NOT: Field:           __memory_base
+
 # CHECK:   - Type:            EXPORT
 # CHECK:       - Name:            __wasm_apply_data_relocs
 # CHECK-NEXT:         Kind:            FUNCTION

--- a/lld/test/wasm/dylink-non-pie.s
+++ b/lld/test/wasm/dylink-non-pie.s
@@ -3,6 +3,7 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
 # RUN: wasm-ld -m wasm32 -Bdynamic %t.o %t.lib.so -o %t.wasm
 # RUN: obj2yaml %t.wasm | FileCheck %s
+# RUN: llvm-objdump -d --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --check-prefixes DIS
 
 	.functype	ret32 (f32) -> (i32)
 	.functype	_start () -> ()
@@ -27,3 +28,10 @@ f_p:
 # CHECK:   - Type:            EXPORT
 # CHECK:       - Name:            __wasm_apply_data_relocs
 # CHECK-NEXT:         Kind:            FUNCTION
+
+# DIS:    <__wasm_apply_data_relocs>:
+# DIS-EMPTY:
+# DIS-NEXT:    i32.const       1024
+# DIS-NEXT:    global.get      0
+# DIS-NEXT:    i32.store       0
+# DIS-NEXT:    end

--- a/lld/test/wasm/dylink-non-pie.s
+++ b/lld/test/wasm/dylink-non-pie.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.lib.o %p/Inputs/lib.s
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.lib.o %p/Inputs/ret32.s
 # RUN: wasm-ld -m wasm32 --experimental-pic -shared --no-entry %t.lib.o -o %t.lib.so
 # RUN: llvm-mc -filetype=obj -mattr=+reference-types -triple=wasm32-unknown-unknown -o %t.o %s
 # RUN: wasm-ld -m wasm32 --features=mutable-globals -Bdynamic --export-table --growable-table --export-memory --export=__stack_pointer --export=__heap_base --export=__heap_end --entry=_start %t.o %t.lib.so -o %t.wasm
@@ -7,23 +7,25 @@
 	.tabletype	__indirect_function_table, funcref
 	.globaltype	__memory_base, i32, immutable
 
-	.functype	f () -> ()
+	.functype	ret32 (f32) -> (i32)
 	.functype	_start () -> ()
 	.globl	_start
 	.type	_start,@function
 _start:
 	.functype	_start () -> ()
+	f32.const   0.0
 	global.get	__memory_base
 	i32.const	f_p@MBREL
 	i32.add
 	i32.load	0
-	call_indirect	 __indirect_function_table, () -> ()
+	call_indirect	 __indirect_function_table, (f32) -> (i32)
+	drop
 	end_function
 
 	.section	.data.f_p,"",@
 	.globl	f_p
 f_p:
-	.int32	f
+	.int32	ret32
 	.size	f_p, 4
 
 # CHECK:      Sections:

--- a/lld/test/wasm/dylink-non-pie.s
+++ b/lld/test/wasm/dylink-non-pie.s
@@ -1,11 +1,8 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.lib.o %p/Inputs/ret32.s
 # RUN: wasm-ld -m wasm32 --experimental-pic -shared --no-entry %t.lib.o -o %t.lib.so
-# RUN: llvm-mc -filetype=obj -mattr=+reference-types -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld -m wasm32 --features=mutable-globals -Bdynamic --export-table --growable-table --export-memory --export=__stack_pointer --export=__heap_base --export=__heap_end --entry=_start %t.o %t.lib.so -o %t.wasm
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
+# RUN: wasm-ld -m wasm32 -Bdynamic %t.o %t.lib.so -o %t.wasm
 # RUN: obj2yaml %t.wasm | FileCheck %s
-
-	.tabletype	__indirect_function_table, funcref
-	.globaltype	__memory_base, i32, immutable
 
 	.functype	ret32 (f32) -> (i32)
 	.functype	_start () -> ()
@@ -13,12 +10,7 @@
 	.type	_start,@function
 _start:
 	.functype	_start () -> ()
-	f32.const   0.0
-	global.get	__memory_base
-	i32.const	f_p@MBREL
-	i32.add
-	i32.load	0
-	call_indirect	 __indirect_function_table, (f32) -> (i32)
+	i32.const   f_p
 	drop
 	end_function
 

--- a/lld/test/wasm/dylink-non-pie.s
+++ b/lld/test/wasm/dylink-non-pie.s
@@ -1,0 +1,35 @@
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.lib.o %p/Inputs/lib.s
+# RUN: wasm-ld -m wasm32 --experimental-pic -shared --no-entry %t.lib.o -o %t.lib.so
+# RUN: llvm-mc -filetype=obj -mattr=+reference-types -triple=wasm32-unknown-unknown -o %t.o %s
+# RUN: wasm-ld -m wasm32 --features=mutable-globals -Bdynamic --export-table --growable-table --export-memory --export=__stack_pointer --export=__heap_base --export=__heap_end --entry=_start %t.o %t.lib.so -o %t.wasm
+# RUN: obj2yaml %t.wasm | FileCheck %s
+
+	.tabletype	__indirect_function_table, funcref
+	.globaltype	__memory_base, i32, immutable
+
+	.functype	f () -> ()
+	.functype	_start () -> ()
+	.globl	_start
+	.type	_start,@function
+_start:
+	.functype	_start () -> ()
+	global.get	__memory_base
+	i32.const	f_p@MBREL
+	i32.add
+	i32.load	0
+	call_indirect	 __indirect_function_table, () -> ()
+	end_function
+
+	.section	.data.f_p,"",@
+	.globl	f_p
+f_p:
+	.int32	f
+	.size	f_p, 4
+
+# CHECK:      Sections:
+# CHECK-NEXT:   - Type:            CUSTOM
+# CHECK-NEXT:     Name:            dylink.0
+
+# CHECK:   - Type:            EXPORT
+# CHECK:       - Name:            __wasm_apply_data_relocs
+# CHECK-NEXT:         Kind:            FUNCTION

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -146,7 +146,8 @@ void scanRelocations(InputChunk *chunk) {
 
     if (ctx.isPic ||
         (sym->isUndefined() &&
-         config->unresolvedSymbols == UnresolvedPolicy::ImportDynamic)) {
+         config->unresolvedSymbols == UnresolvedPolicy::ImportDynamic) ||
+        sym->isShared()) {
       switch (reloc.Type) {
       case R_WASM_TABLE_INDEX_SLEB:
       case R_WASM_TABLE_INDEX_SLEB64:

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -144,10 +144,9 @@ void scanRelocations(InputChunk *chunk) {
       break;
     }
 
-    if (ctx.isPic ||
+    if (ctx.isPic || sym->isShared() ||
         (sym->isUndefined() &&
-         config->unresolvedSymbols == UnresolvedPolicy::ImportDynamic) ||
-        sym->isShared()) {
+         config->unresolvedSymbols == UnresolvedPolicy::ImportDynamic)) {
       switch (reloc.Type) {
       case R_WASM_TABLE_INDEX_SLEB:
       case R_WASM_TABLE_INDEX_SLEB64:


### PR DESCRIPTION
The commit 22b7b84860d39da71964c9b329937f2ee1d875ba
made the symbols provided by shared libraries "defined",
and thus effectively made it impossible to generate non-pie
dynamically linked executables using --unresolved-symbols=import-dynamic.

This commit, based on https://github.com/llvm/llvm-project/pull/109249,
fixes it by checking sym->isShared() explictly.
(as a bonus, you don't need to rely on --unresolved-symbols=import-dynamic
anymore.)

Fixes https://github.com/llvm/llvm-project/issues/107387