### PR TITLE
[lldb][test] Add test for no_unique_address when mixed with bitfields

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
@@ -2,8 +2,6 @@
 // into the AST when an overlapping no_unique_address
 // field precedes a bitfield.
 
-// XFAIL: *
-
 // RUN: %clangxx_host -c -gdwarf -o %t %s
 // RUN: %lldb %t \
 // RUN:   -o "target var global" \
@@ -11,12 +9,12 @@
 // RUN:   -o exit | FileCheck %s
 
 // CHECK:      (lldb) image dump ast
-// CHECK-NEXT: CXXRecordDecl {{.*}} struct Foo definition
+// CHECK:      CXXRecordDecl {{.*}} struct Foo definition
 // CHECK:      |-FieldDecl {{.*}} data 'char[5]'
 // CHECK-NEXT: |-FieldDecl {{.*}} padding 'Empty'
 // CHECK-NEXT: |-FieldDecl {{.*}} 'int'
 // CHECK-NEXT: | `-IntegerLiteral {{.*}} 'int' 8
-// CHECK-NEXT: `-FieldDecl {{.*}} sloc> mem 'unsigned long'
+// CHECK-NEXT: `-FieldDecl {{.*}} sloc> flag 'unsigned long'
 // CHECK-NEXT:   `-IntegerLiteral {{.*}} 'int' 1
 
 struct Empty {};

--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
@@ -2,7 +2,7 @@
 // into the AST when an overlapping no_unique_address
 // field precedes a bitfield.
 
-// RUN: %clangxx_host -c -gdwarf -o %t %s
+// RUN: %clang --target=x86_64-apple-macosx -c -gdwarf -o %t %s
 // RUN: %lldb %t \
 // RUN:   -o "target var global" \
 // RUN:   -o "image dump ast" \

--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
@@ -1,0 +1,30 @@
+// LLDB currently erroneously adds an unnamed bitfield
+// into the AST when a overlapping no_unique_address
+// field precedes a bitfield.
+
+// XFAIL: *
+
+// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %lldb %t \
+// RUN:   -o "target var global" \
+// RUN:   -o "image dump ast" \
+// RUN:   -o exit | FileCheck %s
+
+// CHECK:      (lldb) image dump ast
+// CHECK-NEXT: CXXRecordDecl {{.*}} struct Foo definition
+// CHECK:      |-FieldDecl {{.*}} data 'char[5]'
+// CHECK-NEXT: |-FieldDecl {{.*}} padding 'Empty'
+// CHECK-NEXT: |-FieldDecl {{.*}} 'int'
+// CHECK-NEXT: | `-IntegerLiteral {{.*}} 'int' 8
+// CHECK-NEXT: `-FieldDecl {{.*}} sloc> mem 'unsigned long'
+// CHECK-NEXT:   `-IntegerLiteral {{.*}} 'int' 1
+
+struct Empty {};
+
+struct Foo {
+  char data[5];
+  [[no_unique_address]] Empty padding;
+  unsigned long flag : 1;
+};
+
+Foo global;

--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-with-bitfields.cpp
@@ -1,10 +1,10 @@
 // LLDB currently erroneously adds an unnamed bitfield
-// into the AST when a overlapping no_unique_address
+// into the AST when an overlapping no_unique_address
 // field precedes a bitfield.
 
 // XFAIL: *
 
-// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %clangxx_host -c -gdwarf -o %t %s
 // RUN: %lldb %t \
 // RUN:   -o "target var global" \
 // RUN:   -o "image dump ast" \


### PR DESCRIPTION
This is the root-cause for the LLDB failures that started occurring after https://github.com/llvm/llvm-project/pull/105865.

The DWARFASTParserClang has logic to try derive unnamed bitfields from DWARF offsets. In this case we treat `padding` as a 1-byte size field that would overlap with `flag`, and decide we need to introduce an unnamed bitfield into the AST, which is incorrect.