### PR TITLE
[libc++][test] Confirm that P0508R0 has been implemented

### DIFF
--- a/libcxx/docs/Status/Cxx17Papers.csv
+++ b/libcxx/docs/Status/Cxx17Papers.csv
@@ -81,7 +81,7 @@
 "`P0503R0 <https://wg21.link/P0503R0>`__","Correcting library usage of ""literal type""","2016-11 (Issaquah)","|Complete|","4.0",""
 "`P0504R0 <https://wg21.link/P0504R0>`__","Revisiting in-place tag types for any/optional/variant","2016-11 (Issaquah)","|Complete|","4.0",""
 "`P0505R0 <https://wg21.link/P0505R0>`__","Wording for GB 50 - constexpr for chrono","2016-11 (Issaquah)","|Complete|","4.0",""
-"`P0508R0 <https://wg21.link/P0508R0>`__","Wording for GB 58 - structured bindings for node_handles","2016-11 (Issaquah)","","",""
+"`P0508R0 <https://wg21.link/P0508R0>`__","Wording for GB 58 - structured bindings for node_handles","2016-11 (Issaquah)","|Complete|","7.0",""
 "`P0509R1 <https://wg21.link/P0509R1>`__","Updating ""Restrictions on exception handling""","2016-11 (Issaquah)","|Nothing To Do|","n/a",""
 "`P0510R0 <https://wg21.link/P0510R0>`__","Disallowing references, incomplete types, arrays, and empty variants","2016-11 (Issaquah)","|Complete|","4.0",""
 "`P0513R0 <https://wg21.link/P0513R0>`__","Poisoning the Hash","2016-11 (Issaquah)","|Complete|","5.0",""

--- a/libcxx/test/std/containers/associative/map/map.modifiers/insert_node_type.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.modifiers/insert_node_type.pass.cpp
@@ -15,9 +15,31 @@
 // insert_return_type insert(node_type&&);
 
 #include <map>
+#include <memory>
 #include <type_traits>
 #include "test_macros.h"
 #include "min_allocator.h"
+
+template <class Container, class T>
+void verify_insert_return_type(T&& t) {
+  using verified_type = std::remove_cv_t<std::remove_reference_t<T>>;
+  static_assert(std::is_aggregate_v<verified_type>);
+  static_assert(std::is_same_v<verified_type, typename Container::insert_return_type>);
+
+  auto& [pos, ins, nod] = t;
+
+  static_assert(std::is_same_v<decltype(pos), typename Container::iterator>);
+  static_assert(std::is_same_v<decltype(t.position), typename Container::iterator>);
+  assert(std::addressof(pos) == std::addressof(t.position));
+
+  static_assert(std::is_same_v<decltype(ins), bool>);
+  static_assert(std::is_same_v<decltype(t.inserted), bool>);
+  assert(&ins == &t.inserted);
+
+  static_assert(std::is_same_v<decltype(nod), typename Container::node_type>);
+  static_assert(std::is_same_v<decltype(t.node), typename Container::node_type>);
+  assert(std::addressof(nod) == std::addressof(t.node));
+}
 
 template <class Container>
 typename Container::node_type
@@ -44,6 +66,7 @@ void test(Container& c)
         assert(irt.inserted);
         assert(irt.node.empty());
         assert(irt.position->first == i && irt.position->second == i + 1);
+        verify_insert_return_type<Container>(irt);
     }
 
     assert(c.size() == 10);
@@ -55,6 +78,7 @@ void test(Container& c)
         assert(!irt.inserted);
         assert(irt.node.empty());
         assert(irt.position == c.end());
+        verify_insert_return_type<Container>(irt);
     }
 
     { // Insert duplicate node.
@@ -65,6 +89,7 @@ void test(Container& c)
         assert(!irt.node.empty());
         assert(irt.position == c.find(0));
         assert(irt.node.key() == 0 && irt.node.mapped() == 42);
+        verify_insert_return_type<Container>(irt);
     }
 
     assert(c.size() == 10);

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.modifiers/insert_node_type.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.modifiers/insert_node_type.pass.cpp
@@ -14,9 +14,31 @@
 
 // insert_return_type insert(node_type&&);
 
+#include <memory>
 #include <unordered_map>
 #include "test_macros.h"
 #include "min_allocator.h"
+
+template <class Container, class T>
+void verify_insert_return_type(T&& t) {
+  using verified_type = std::remove_cv_t<std::remove_reference_t<T>>;
+  static_assert(std::is_aggregate_v<verified_type>);
+  static_assert(std::is_same_v<verified_type, typename Container::insert_return_type>);
+
+  auto& [pos, ins, nod] = t;
+
+  static_assert(std::is_same_v<decltype(pos), typename Container::iterator>);
+  static_assert(std::is_same_v<decltype(t.position), typename Container::iterator>);
+  assert(std::addressof(pos) == std::addressof(t.position));
+
+  static_assert(std::is_same_v<decltype(ins), bool>);
+  static_assert(std::is_same_v<decltype(t.inserted), bool>);
+  assert(&ins == &t.inserted);
+
+  static_assert(std::is_same_v<decltype(nod), typename Container::node_type>);
+  static_assert(std::is_same_v<decltype(t.node), typename Container::node_type>);
+  assert(std::addressof(nod) == std::addressof(t.node));
+}
 
 template <class Container>
 typename Container::node_type
@@ -43,6 +65,7 @@ void test(Container& c)
         assert(irt.inserted);
         assert(irt.node.empty());
         assert(irt.position->first == i && irt.position->second == i + 1);
+        verify_insert_return_type<Container>(irt);
     }
 
     assert(c.size() == 10);
@@ -54,6 +77,7 @@ void test(Container& c)
         assert(!irt.inserted);
         assert(irt.node.empty());
         assert(irt.position == c.end());
+        verify_insert_return_type<Container>(irt);
     }
 
     { // Insert duplicate node.
@@ -64,6 +88,7 @@ void test(Container& c)
         assert(!irt.node.empty());
         assert(irt.position == c.find(0));
         assert(irt.node.key() == 0 && irt.node.mapped() == 42);
+        verify_insert_return_type<Container>(irt);
     }
 
     assert(c.size() == 10);

--- a/libcxx/test/std/containers/unord/unord.set/insert_node_type.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/insert_node_type.pass.cpp
@@ -14,10 +14,32 @@
 
 // insert_return_type insert(node_type&&);
 
+#include <memory>
 #include <unordered_set>
 #include <type_traits>
 #include "test_macros.h"
 #include "min_allocator.h"
+
+template <class Container, class T>
+void verify_insert_return_type(T&& t) {
+  using verified_type = std::remove_cv_t<std::remove_reference_t<T>>;
+  static_assert(std::is_aggregate_v<verified_type>);
+  static_assert(std::is_same_v<verified_type, typename Container::insert_return_type>);
+
+  auto& [pos, ins, nod] = t;
+
+  static_assert(std::is_same_v<decltype(pos), typename Container::iterator>);
+  static_assert(std::is_same_v<decltype(t.position), typename Container::iterator>);
+  assert(std::addressof(pos) == std::addressof(t.position));
+
+  static_assert(std::is_same_v<decltype(ins), bool>);
+  static_assert(std::is_same_v<decltype(t.inserted), bool>);
+  assert(&ins == &t.inserted);
+
+  static_assert(std::is_same_v<decltype(nod), typename Container::node_type>);
+  static_assert(std::is_same_v<decltype(t.node), typename Container::node_type>);
+  assert(std::addressof(nod) == std::addressof(t.node));
+}
 
 template <class Container>
 typename Container::node_type
@@ -43,6 +65,7 @@ void test(Container& c)
         assert(irt.inserted);
         assert(irt.node.empty());
         assert(*irt.position == i);
+        verify_insert_return_type<Container>(irt);
     }
 
     assert(c.size() == 10);
@@ -54,6 +77,7 @@ void test(Container& c)
         assert(!irt.inserted);
         assert(irt.node.empty());
         assert(irt.position == c.end());
+        verify_insert_return_type<Container>(irt);
     }
 
     { // Insert duplicate node.
@@ -64,6 +88,7 @@ void test(Container& c)
         assert(!irt.node.empty());
         assert(irt.position == c.find(0));
         assert(irt.node.value() == 0);
+        verify_insert_return_type<Container>(irt);
     }
 
     assert(c.size() == 10);


### PR DESCRIPTION
I believe the paper was implemented by commit b0386a515b60c2f43eaaef986bd5b1cdc4448244 (https://reviews.llvm.org/D46845) in LLVM 7.0. But it would be nice to have test coverage for desired properties of `insert_return_type`.

Closes #99944.