### PR TITLE
[flang][OpenMP] don't privatise loop index marked shared

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1317,7 +1317,8 @@ private:
                                      bool isUnordered) {
     if (isUnordered || sym.has<Fortran::semantics::HostAssocDetails>() ||
         sym.has<Fortran::semantics::UseDetails>()) {
-      if (!shallowLookupSymbol(sym)) {
+      if (!shallowLookupSymbol(sym) &&
+          !sym.test(Fortran::semantics::Symbol::Flag::OmpShared)) {
         // Do concurrent loop variables are not mapped yet since they are local
         // to the Do concurrent scope (same for OpenMP loops).
         mlir::OpBuilder::InsertPoint insPt = builder->saveInsertionPoint();

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2121,15 +2121,18 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
       }
       return lastDeclSymbol;
     };
-    auto makeSharedSymbol = [&]() {
+    auto makeSharedSymbol = [&](bool setFlag) {
       const Symbol *hostSymbol =
           lastDeclSymbol ? lastDeclSymbol : &symbol->GetUltimate();
-      MakeAssocSymbol(symbol->name(), *hostSymbol,
+      Symbol &assocSymbol = MakeAssocSymbol(symbol->name(), *hostSymbol,
           context_.FindScope(dirContext.directiveSource));
+      if (setFlag) {
+        assocSymbol.set(Symbol::Flag::OmpShared);
+      }
     };
-    auto useLastDeclSymbol = [&]() {
+    auto useLastDeclSymbol = [&](bool setFlag) {
       if (lastDeclSymbol) {
-        makeSharedSymbol();
+        makeSharedSymbol(setFlag);
       }
     };
 
@@ -2140,8 +2143,9 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
 
     if (dsa.has_value()) {
       if (dsa.value() == Symbol::Flag::OmpShared &&
-          (parallelDir || taskGenDir || teamsDir))
-        makeSharedSymbol();
+          (parallelDir || taskGenDir || teamsDir)) {
+        makeSharedSymbol(/*setFlag=*/true);
+      }
       // Private symbols will have been declared already.
       prevDSA = dsa;
       continue;
@@ -2155,18 +2159,19 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
       if (!parallelDir && !taskGenDir && !teamsDir) {
         return;
       }
-      if (dirContext.defaultDSA != Symbol::Flag::OmpShared)
+      if (dirContext.defaultDSA != Symbol::Flag::OmpShared) {
         makePrivateSymbol(dirContext.defaultDSA);
-      else
-        makeSharedSymbol();
+      } else {
+        makeSharedSymbol(/*setFlag=*/true);
+      }
       dsa = dirContext.defaultDSA;
     } else if (parallelDir) {
       // 2) parallel -> shared
-      makeSharedSymbol();
+      makeSharedSymbol(/*setFlag=*/false);
       dsa = Symbol::Flag::OmpShared;
     } else if (!taskGenDir && !targetDir) {
       // 3) enclosing context
-      useLastDeclSymbol();
+      useLastDeclSymbol(/*setFlag=*/false);
       dsa = prevDSA;
     } else if (targetDir) {
       // TODO 4) not mapped target variable -> firstprivate
@@ -2175,7 +2180,7 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
       // TODO 5) dummy arg in orphaned taskgen construct -> firstprivate
       if (prevDSA == Symbol::Flag::OmpShared) {
         // 6) shared in enclosing context -> shared
-        makeSharedSymbol();
+        makeSharedSymbol(/*setFlag=*/false);
         dsa = Symbol::Flag::OmpShared;
       } else {
         // 7) firstprivate

--- a/flang/test/Lower/OpenMP/shared-loop.f90
+++ b/flang/test/Lower/OpenMP/shared-loop.f90
@@ -9,7 +9,9 @@
 ! CHECK:        omp.section {
 ! CHECK:          %[[RES:.*]]:2 = fir.do_loop {{.*}} iter_args(%[[ARG:.*]] =
 ! CHECK:            fir.store %[[ARG]] to %[[DECL_I]]#1
-! CHECK:            fir.result
+! CHECK:            %[[LOAD_I:.*]] = fir.load %[[DECL_I]]#1
+! CHECK:            %[[RES_I:.*]] = arith.addi %[[LOAD_I]], %{{.*}}
+! CHECK:            fir.result {{.*}}, %[[RES_I]]
 ! CHECK:          }
 ! CHECK:          fir.store %[[RES]]#1 to %[[DECL_I]]#1
 ! CHECK:          omp.terminator

--- a/flang/test/Lower/OpenMP/shared-loop.f90
+++ b/flang/test/Lower/OpenMP/shared-loop.f90
@@ -3,7 +3,7 @@
 
 ! --- Check that with shared(i) the variable outside the parallel section
 ! --- is updated. 
-! CHECK:  func.func @_QPomploop()
+! CHECK-LABEL:  func.func @_QPomploop()
 ! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomploopEi"}
 ! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFomploopEi"} :
 ! CHECK:    omp.parallel {
@@ -39,7 +39,7 @@ end subroutine
 
 ! --- Check that with default(shared) the variable outside the parallel section
 ! --- is NOT updated (i is private to the omp.parallel code)
-! CHECK:  func.func @_QPomploop2()
+! CHECK-LABEL:  func.func @_QPomploop2()
 ! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomploop2Ei"}
 ! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFomploop2Ei"} :
 ! CHECK:    omp.parallel {
@@ -79,7 +79,7 @@ end subroutine
 
 ! --- Check that with no data-sharing the variable outside the parallel section
 ! --- is NOT updated (i is private to the omp.parallel code)
-! CHECK:  func.func @_QPomploop3()
+! CHECK-LABEL:  func.func @_QPomploop3()
 ! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomploop3Ei"}
 ! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFomploop3Ei"} :
 ! CHECK:    omp.parallel {

--- a/flang/test/Lower/OpenMP/shared-loop.f90
+++ b/flang/test/Lower/OpenMP/shared-loop.f90
@@ -1,0 +1,33 @@
+! RUN: bbc -emit-hlfir -fopenmp %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+! CHECK:  func.func @_QQmain() attributes
+! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
+! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFEi"} :
+! CHECK:    omp.parallel {
+! CHECK:      omp.sections {
+! CHECK:        omp.section {
+! CHECK:          %[[RES:.*]]:2 = fir.do_loop {{.*}} iter_args(%[[ARG:.*]] =
+! CHECK:            fir.store %[[ARG]] to %[[DECL_I]]#1
+! CHECK:            fir.result
+! CHECK:          }
+! CHECK:          fir.store %[[RES]]#1 to %[[DECL_I]]#1
+! CHECK:          omp.terminator
+! CHECK:        }
+! CHECK:        omp.terminator
+! CHECK:      }
+! CHECK:      return
+! CHECK:    }
+program omploop
+  implicit none
+  integer :: i, j
+  i = 1
+  j = 0
+  !$omp parallel shared(i)
+    !$omp sections
+      do i=1,10
+         j = j + i
+      end do
+    !$omp end sections
+  !$omp end parallel
+end program

--- a/flang/test/Lower/OpenMP/shared-loop.f90
+++ b/flang/test/Lower/OpenMP/shared-loop.f90
@@ -7,11 +7,12 @@
 ! CHECK:    omp.parallel {
 ! CHECK:      omp.sections {
 ! CHECK:        omp.section {
-! CHECK:          %[[RES:.*]]:2 = fir.do_loop {{.*}} iter_args(%[[ARG:.*]] =
-! CHECK:            fir.store %[[ARG]] to %[[DECL_I]]#1
+! CHECK:          %[[RES:.*]]:2 = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] = 
+! CHECK:            fir.store %[[ARG1]] to %[[DECL_I]]#1
+! CHECK:            %[[UPDATE_ITER:.*]] = arith.addi %[[ARG0]], %{{.*}}
 ! CHECK:            %[[LOAD_I:.*]] = fir.load %[[DECL_I]]#1
 ! CHECK:            %[[RES_I:.*]] = arith.addi %[[LOAD_I]], %{{.*}}
-! CHECK:            fir.result {{.*}}, %[[RES_I]]
+! CHECK:            fir.result %[[UPDATE_ITER]], %[[RES_I]]
 ! CHECK:          }
 ! CHECK:          fir.store %[[RES]]#1 to %[[DECL_I]]#1
 ! CHECK:          omp.terminator

--- a/flang/test/Lower/OpenMP/shared-loop.f90
+++ b/flang/test/Lower/OpenMP/shared-loop.f90
@@ -1,9 +1,11 @@
 ! RUN: bbc -emit-hlfir -fopenmp %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
 
-! CHECK:  func.func @_QQmain() attributes
-! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
-! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFEi"} :
+! --- Check that with shared(i) the variable outside the parallel section
+! --- is updated. 
+! CHECK:  func.func @_QPomploop()
+! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomploopEi"}
+! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFomploopEi"} :
 ! CHECK:    omp.parallel {
 ! CHECK:      omp.sections {
 ! CHECK:        omp.section {
@@ -21,7 +23,7 @@
 ! CHECK:      }
 ! CHECK:      return
 ! CHECK:    }
-program omploop
+subroutine omploop
   implicit none
   integer :: i, j
   i = 1
@@ -33,4 +35,86 @@ program omploop
       end do
     !$omp end sections
   !$omp end parallel
-end program
+end subroutine
+
+! --- Check that with default(shared) the variable outside the parallel section
+! --- is NOT updated (i is private to the omp.parallel code)
+! CHECK:  func.func @_QPomploop2()
+! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomploop2Ei"}
+! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFomploop2Ei"} :
+! CHECK:    omp.parallel {
+! CHECK:      %[[ALLOC_PRIV_I:.*]] = fir.alloca i32 {bindc_name = "i", pinned}
+! CHECK:      %[[DECL_PRIV_I:.*]]:2 = hlfir.declare %[[ALLOC_PRIV_I]]
+! CHECK:      omp.sections {
+! CHECK:        omp.section {
+! CHECK:          %[[RES:.*]]:2 = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] = 
+! CHECK-NOT:            fir.store %[[ARG1]] to %[[DECL_I]]#1
+! CHECK:            fir.store %[[ARG1]] to %[[DECL_PRIV_I]]#1
+! CHECK:            %[[UPDATE_ITER:.*]] = arith.addi %[[ARG0]], %{{.*}}
+! CHECK:            %[[LOAD_I:.*]] = fir.load %[[DECL_PRIV_I]]#1
+! CHECK:            %[[RES_I:.*]] = arith.addi %[[LOAD_I]], %{{.*}}
+! CHECK:            fir.result %[[UPDATE_ITER]], %[[RES_I]]
+! CHECK:          }
+! CHECK:          fir.store %[[RES]]#1 to %[[DECL_PRIV_I]]#1
+! CHECK:          omp.terminator
+! CHECK:        }
+! CHECK:        omp.terminator
+! CHECK:      }
+! CHECK:      return
+! CHECK:    }
+subroutine omploop2
+  implicit none
+  integer :: i, j
+  i = 1
+  j = 0
+  !$omp parallel default(shared)
+    !$omp sections
+      do i=1,10
+         j = j + i
+      end do
+    !$omp end sections
+  !$omp end parallel
+end subroutine
+
+
+! --- Check that with no data-sharing the variable outside the parallel section
+! --- is NOT updated (i is private to the omp.parallel code)
+! CHECK:  func.func @_QPomploop3()
+! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomploop3Ei"}
+! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFomploop3Ei"} :
+! CHECK:    omp.parallel {
+! CHECK:      %[[ALLOC_PRIV_I:.*]] = fir.alloca i32 {bindc_name = "i", pinned}
+! CHECK:      %[[DECL_PRIV_I:.*]]:2 = hlfir.declare %[[ALLOC_PRIV_I]]
+! CHECK:      omp.sections {
+! CHECK:        omp.section {
+! CHECK:          %[[RES:.*]]:2 = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] = 
+! CHECK-NOT:            fir.store %[[ARG1]] to %[[DECL_I]]#1
+! CHECK:            fir.store %[[ARG1]] to %[[DECL_PRIV_I]]#1
+! CHECK:            %[[UPDATE_ITER:.*]] = arith.addi %[[ARG0]], %{{.*}}
+! CHECK:            %[[LOAD_I:.*]] = fir.load %[[DECL_PRIV_I]]#1
+! CHECK:            %[[RES_I:.*]] = arith.addi %[[LOAD_I]], %{{.*}}
+! CHECK:            fir.result %[[UPDATE_ITER]], %[[RES_I]]
+! CHECK:          }
+! CHECK:          fir.store %[[RES]]#1 to %[[DECL_PRIV_I]]#1
+! CHECK:          omp.terminator
+! CHECK:        }
+! CHECK:        omp.terminator
+! CHECK:      }
+! CHECK:      return
+! CHECK:    }
+subroutine omploop3
+  implicit none
+  integer :: i, j
+  i = 1
+  j = 0
+  !$omp parallel
+    !$omp sections
+      do i=1,10
+         j = j + i
+      end do
+    !$omp end sections
+  !$omp end parallel
+end subroutine
+
+
+ 

--- a/flang/test/Semantics/OpenMP/do05-positivecase.f90
+++ b/flang/test/Semantics/OpenMP/do05-positivecase.f90
@@ -20,7 +20,7 @@ program omp_do
   !$omp parallel  default(shared)
   !$omp do
   !DEF: /omp_do/OtherConstruct2/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
-  !DEF: /omp_do/OtherConstruct2/n HostAssoc INTEGER(4)
+  !DEF: /omp_do/OtherConstruct2/n (OmpShared) HostAssoc INTEGER(4)
   do i=1,n
     !$omp parallel
     !$omp single

--- a/flang/test/Semantics/OpenMP/do05-positivecase.f90
+++ b/flang/test/Semantics/OpenMP/do05-positivecase.f90
@@ -20,7 +20,7 @@ program omp_do
   !$omp parallel  default(shared)
   !$omp do
   !DEF: /omp_do/OtherConstruct2/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
-  !DEF: /omp_do/OtherConstruct2/n (OmpShared) HostAssoc INTEGER(4)
+  !DEF: /omp_do/OtherConstruct2/n HostAssoc INTEGER(4)
   do i=1,n
     !$omp parallel
     !$omp single

--- a/flang/test/Semantics/OpenMP/do20.f90
+++ b/flang/test/Semantics/OpenMP/do20.f90
@@ -10,7 +10,7 @@ subroutine shared_iv
 
   !$omp parallel shared(i)
     !$omp single
-      !DEF: /shared_iv/OtherConstruct1/i HostAssoc INTEGER(4)
+      !DEF: /shared_iv/OtherConstruct1/i (OmpShared) HostAssoc INTEGER(4)
       do i = 0, 1
       end do
     !$omp end single

--- a/flang/test/Semantics/OpenMP/implicit-dsa.f90
+++ b/flang/test/Semantics/OpenMP/implicit-dsa.f90
@@ -15,14 +15,14 @@ subroutine implicit_dsa_test1
   !$omp task private(y) shared(z)
     !DEF: /implicit_dsa_test1/OtherConstruct1/x (OmpFirstPrivate, OmpImplicit) HostAssoc INTEGER(4)
     !DEF: /implicit_dsa_test1/OtherConstruct1/y (OmpPrivate) HostAssoc INTEGER(4)
-    !DEF: /implicit_dsa_test1/OtherConstruct1/z HostAssoc INTEGER(4)
+    !DEF: /implicit_dsa_test1/OtherConstruct1/z (OmpShared) HostAssoc INTEGER(4)
     x = y + z
   !$omp end task
 
   !$omp task default(shared)
-    !DEF: /implicit_dsa_test1/OtherConstruct2/x HostAssoc INTEGER(4)
-    !DEF: /implicit_dsa_test1/OtherConstruct2/y HostAssoc INTEGER(4)
-    !DEF: /implicit_dsa_test1/OtherConstruct2/z HostAssoc INTEGER(4)
+    !DEF: /implicit_dsa_test1/OtherConstruct2/x (OmpShared) HostAssoc INTEGER(4)
+    !DEF: /implicit_dsa_test1/OtherConstruct2/y (OmpShared) HostAssoc INTEGER(4)
+    !DEF: /implicit_dsa_test1/OtherConstruct2/z (OmpShared) HostAssoc INTEGER(4)
     x = y + z
   !$omp end task
 
@@ -133,7 +133,7 @@ subroutine implicit_dsa_test6
     !$omp end parallel
 
     !$omp parallel default(firstprivate) shared(y)
-      !DEF: /implicit_dsa_test6/OtherConstruct1/OtherConstruct2/y HostAssoc INTEGER(4)
+      !DEF: /implicit_dsa_test6/OtherConstruct1/OtherConstruct2/y (OmpShared) HostAssoc INTEGER(4)
       !DEF: /implicit_dsa_test6/OtherConstruct1/OtherConstruct2/x (OmpFirstPrivate) HostAssocINTEGER(4)
       !DEF: /implicit_dsa_test6/OtherConstruct1/OtherConstruct2/z (OmpFirstPrivate) HostAssocINTEGER(4)
       y = x + z

--- a/flang/test/Semantics/OpenMP/implicit-dsa.f90
+++ b/flang/test/Semantics/OpenMP/implicit-dsa.f90
@@ -20,9 +20,9 @@ subroutine implicit_dsa_test1
   !$omp end task
 
   !$omp task default(shared)
-    !DEF: /implicit_dsa_test1/OtherConstruct2/x (OmpShared) HostAssoc INTEGER(4)
-    !DEF: /implicit_dsa_test1/OtherConstruct2/y (OmpShared) HostAssoc INTEGER(4)
-    !DEF: /implicit_dsa_test1/OtherConstruct2/z (OmpShared) HostAssoc INTEGER(4)
+    !DEF: /implicit_dsa_test1/OtherConstruct2/x HostAssoc INTEGER(4)
+    !DEF: /implicit_dsa_test1/OtherConstruct2/y HostAssoc INTEGER(4)
+    !DEF: /implicit_dsa_test1/OtherConstruct2/z HostAssoc INTEGER(4)
     x = y + z
   !$omp end task
 

--- a/flang/test/Semantics/OpenMP/symbol01.f90
+++ b/flang/test/Semantics/OpenMP/symbol01.f90
@@ -62,7 +62,7 @@ program mm
   !REF: /mm/OtherConstruct1/i
   !REF: /mm/OtherConstruct1/y
   x = a+i+y
-  !DEF: /mm/OtherConstruct1/c HostAssoc REAL(4)
+  !DEF: /mm/OtherConstruct1/c (OmpShared) HostAssoc REAL(4)
   c = 3.0
  end do
 end program

--- a/flang/test/Semantics/OpenMP/symbol02.f90
+++ b/flang/test/Semantics/OpenMP/symbol02.f90
@@ -15,9 +15,9 @@
   a = 3.
   !DEF: /MainProgram1/OtherConstruct1/b (OmpPrivate) HostAssoc REAL(4)
   b = 4
-  !DEF: /MainProgram1/OtherConstruct1/c HostAssoc REAL(4)
+  !DEF: /MainProgram1/OtherConstruct1/c (OmpShared) HostAssoc REAL(4)
   c = 5
-  !DEF: /MainProgram1/OtherConstruct1/d HostAssoc REAL(4)
+  !DEF: /MainProgram1/OtherConstruct1/d (OmpShared) HostAssoc REAL(4)
   d = 6
   !$omp end parallel
   !DEF: /MainProgram1/a (Implicit) ObjectEntity REAL(4)

--- a/flang/test/Semantics/OpenMP/symbol03.f90
+++ b/flang/test/Semantics/OpenMP/symbol03.f90
@@ -9,10 +9,10 @@
   !$omp parallel  private(a) shared(b)
   !DEF: /MainProgram1/OtherConstruct1/a (OmpPrivate) HostAssoc REAL(4)
   a = 3.
-  !DEF: /MainProgram1/OtherConstruct1/b HostAssoc REAL(4)
+  !DEF: /MainProgram1/OtherConstruct1/b (OmpShared) HostAssoc REAL(4)
   b = 4
   !$omp parallel  private(b) shared(a)
-  !DEF: /MainProgram1/OtherConstruct1/OtherConstruct1/a HostAssoc REAL(4)
+  !DEF: /MainProgram1/OtherConstruct1/OtherConstruct1/a (OmpShared) HostAssoc REAL(4)
   a = 5.
   !DEF: /MainProgram1/OtherConstruct1/OtherConstruct1/b (OmpPrivate) HostAssoc REAL(4)
   b = 6

--- a/flang/test/Semantics/OpenMP/symbol07.f90
+++ b/flang/test/Semantics/OpenMP/symbol07.f90
@@ -23,7 +23,7 @@ subroutine function_call_in_region
   !$omp parallel  default(none) private(a) shared(b)
   !DEF: /function_call_in_region/OtherConstruct1/a (OmpPrivate) HostAssoc REAL(4)
   !REF: /function_call_in_region/foo
-  !DEF: /function_call_in_region/OtherConstruct1/b HostAssoc REAL(4)
+  !DEF: /function_call_in_region/OtherConstruct1/b (OmpShared) HostAssoc REAL(4)
   a = foo(b)
   !$omp end parallel
   !REF: /function_call_in_region/a

--- a/flang/test/Semantics/OpenMP/symbol09.f90
+++ b/flang/test/Semantics/OpenMP/symbol09.f90
@@ -23,7 +23,7 @@ subroutine function_call_in_region
   !$omp parallel  default(none) private(a) shared(b)
   !DEF: /function_call_in_region/OtherConstruct1/a (OmpPrivate) HostAssoc REAL(4)
   !REF: /function_call_in_region/foo
-  !DEF: /function_call_in_region/OtherConstruct1/b HostAssoc REAL(4)
+  !DEF: /function_call_in_region/OtherConstruct1/b (OmpShared) HostAssoc REAL(4)
   a = foo(b)
   !$omp end parallel
   !REF: /function_call_in_region/a


### PR DESCRIPTION
Mark the symbol with OmpShared, and then check that later in lowering to avoid making a local loop index.

Tests updated to match the extra OmpShared attribute.

Add regression test for lowering to hlfir.

Closes #102961