### PR TITLE
[SDAG] Simplify divergence verification. NFC.

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -87,6 +87,7 @@ class TargetLibraryInfo;
 class TargetLowering;
 class TargetMachine;
 class TargetSubtargetInfo;
+class TargetTransformInfo;
 class Value;
 
 template <typename T> class GenericSSAContext;
@@ -584,8 +585,10 @@ public:
     return Root;
   }
 
-#ifndef NDEBUG
-  void VerifyDAGDivergence();
+#ifdef NDEBUG
+  void VerifyDAGDivergence(TargetTransformInfo *TTI) {}
+#else
+  void VerifyDAGDivergence(TargetTransformInfo *TTI);
 #endif
 
   /// This iterates over the nodes in the SelectionDAG, folding

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -25,6 +25,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/MemoryLocation.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Analysis/VectorUtils.h"
 #include "llvm/BinaryFormat/Dwarf.h"
@@ -11713,7 +11714,10 @@ void SelectionDAG::CreateTopologicalOrder(std::vector<SDNode *> &Order) {
 }
 
 #ifndef NDEBUG
-void SelectionDAG::VerifyDAGDivergence() {
+void SelectionDAG::VerifyDAGDivergence(TargetTransformInfo *TTI) {
+  if (TTI && !TTI->hasBranchDivergence())
+    return;
+
   std::vector<SDNode *> TopoOrder;
   CreateTopologicalOrder(TopoOrder);
   for (auto *N : TopoOrder) {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -940,10 +940,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                    << "'\n";
             CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-  if (TTI->hasBranchDivergence())
-    CurDAG->VerifyDAGDivergence();
-#endif
+  CurDAG->VerifyDAGDivergence(TTI);
 
   if (ViewDAGCombine1 && MatchFilterBB)
     CurDAG->viewGraph("dag-combine1 input for " + BlockName);
@@ -960,10 +957,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                    << "'\n";
             CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-  if (TTI->hasBranchDivergence())
-    CurDAG->VerifyDAGDivergence();
-#endif
+  CurDAG->VerifyDAGDivergence(TTI);
 
   // Second step, hack on the DAG until it only uses operations and types that
   // the target supports.
@@ -982,10 +976,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                    << "'\n";
             CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-  if (TTI->hasBranchDivergence())
-    CurDAG->VerifyDAGDivergence();
-#endif
+  CurDAG->VerifyDAGDivergence(TTI);
 
   // Only allow creation of legal node types.
   CurDAG->NewNodesMustHaveLegalTypes = true;
@@ -1006,10 +997,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                      << "'\n";
               CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-    if (TTI->hasBranchDivergence())
-      CurDAG->VerifyDAGDivergence();
-#endif
+    CurDAG->VerifyDAGDivergence(TTI);
   }
 
   {
@@ -1024,10 +1012,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                      << "'\n";
               CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-    if (TTI->hasBranchDivergence())
-      CurDAG->VerifyDAGDivergence();
-#endif
+    CurDAG->VerifyDAGDivergence(TTI);
 
     {
       NamedRegionTimer T("legalize_types2", "Type Legalization 2", GroupName,
@@ -1040,10 +1025,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                      << "'\n";
               CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-    if (TTI->hasBranchDivergence())
-      CurDAG->VerifyDAGDivergence();
-#endif
+    CurDAG->VerifyDAGDivergence(TTI);
 
     if (ViewDAGCombineLT && MatchFilterBB)
       CurDAG->viewGraph("dag-combine-lv input for " + BlockName);
@@ -1060,10 +1042,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                      << "'\n";
               CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-    if (TTI->hasBranchDivergence())
-      CurDAG->VerifyDAGDivergence();
-#endif
+    CurDAG->VerifyDAGDivergence(TTI);
   }
 
   if (ViewLegalizeDAGs && MatchFilterBB)
@@ -1080,10 +1059,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                    << "'\n";
             CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-  if (TTI->hasBranchDivergence())
-    CurDAG->VerifyDAGDivergence();
-#endif
+  CurDAG->VerifyDAGDivergence(TTI);
 
   if (ViewDAGCombine2 && MatchFilterBB)
     CurDAG->viewGraph("dag-combine2 input for " + BlockName);
@@ -1100,10 +1076,7 @@ void SelectionDAGISel::CodeGenAndEmitDAG() {
                    << "'\n";
             CurDAG->dump());
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-  if (TTI->hasBranchDivergence())
-    CurDAG->VerifyDAGDivergence();
-#endif
+  CurDAG->VerifyDAGDivergence(TTI);
 
   if (OptLevel != CodeGenOptLevel::None)
     ComputeLiveOutVRegInfo();


### PR DESCRIPTION
Simplify VerifyDAGDivergence call sites by pushing the
hasBranchDivergence check into it. Also verify when TTI is not available
by skipping the hasBranchDivergence shortcut.
