### PR TITLE
[lldb][test] Handle failure to get /proc/cpuinfo from a remote Linux platform

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1317,7 +1317,18 @@ class Base(unittest.TestCase):
         # Need to do something different for non-Linux/Android targets
         cpuinfo_path = self.getBuildArtifact("cpuinfo")
         if configuration.lldb_platform_name:
-            self.runCmd('platform get-file "/proc/cpuinfo" ' + cpuinfo_path)
+            self.runCmd(
+                'platform get-file "/proc/cpuinfo" ' + cpuinfo_path, check=False
+            )
+            if not self.res.Succeeded():
+                if self.TraceOn():
+                    print(
+                        'Failed to get /proc/cpuinfo from remote: "{}"'.format(
+                            self.res.GetOutput().strip()
+                        )
+                    )
+                    print("All cpuinfo feature checks will fail.")
+                return ""
         else:
             cpuinfo_path = "/proc/cpuinfo"
 


### PR DESCRIPTION
I've been testing against qemu-aarch64 using the qemu-user platform, which doesn't support get-file:
```
AssertionError: False is not true : Command 'platform get-file "/proc/cpuinfo" <...>/TestAArch64LinuxMTEMemoryRegion.test_mte_regions/cpuinfo
Command output:
get-file failed: unimplemented
' did not return successfully
```

QEMU itself does support overriding cpuinfo for the emulated process (https://gitlab.com/qemu-project/qemu/-/commit/a55b9e72267085957cadb0af0a8811cfbd7c61a9) however we'd need to be able to read the cpuinfo before the process starts, so I'm not attempting to use this feature.

Instead if the get-file fails, assume empty cpuinfo so we can at least carry on testing. I've logged the failure and the reason to the trace so developers can find it.

```
runCmd: platform get-file "/proc/cpuinfo" <...>/TestAArch64LinuxMTEMemoryRegion.test_mte_regions/cpuinfo
check of return status not required

runCmd failed!

Failed to get /proc/cpuinfo from remote: "get-file failed: unimplemented"
All cpuinfo feature checks will fail.
```

For now this only helps AArch64 but I suspect that RISC-V, being even more mix and match when it comes to extensions, may need this in future. And I know we have some folks testing against qemu-riscv at the moment.