### PR TITLE
[AMDGPU] Remove dead code in SIISelLowering (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -16207,9 +16207,6 @@ SITargetLowering::shouldExpandAtomicRMWInIR(AtomicRMWInst *RMW) const {
     return isAtomicRMWLegalXChgTy(RMW)
                ? TargetLowering::AtomicExpansionKind::None
                : TargetLowering::AtomicExpansionKind::CmpXChg;
-
-    // PCIe supports add and xchg for system atomics.
-    return atomicSupportedIfLegalIntType(RMW);
   }
   case AtomicRMWInst::Add:
   case AtomicRMWInst::And:


### PR DESCRIPTION
This return is dead code as the return just above will always be taken.