### PR TITLE
[ASan][test] XFAIL global-overflow.cpp etc. on SPARC

### DIFF
--- a/compiler-rt/test/asan/TestCases/global-overflow.cpp
+++ b/compiler-rt/test/asan/TestCases/global-overflow.cpp
@@ -3,6 +3,9 @@
 // RUN: %clangxx_asan -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s
 // RUN: %clangxx_asan -O3 %s -o %t && not %run %t 2>&1 | FileCheck %s
 
+// Issue #108194: Incomplete .debug_line at -O1 and above.
+// XFAIL: target={{.*sparc.*}}
+
 #include <string.h>
 int main(int argc, char **argv) {
   static char XXX[10];

--- a/compiler-rt/test/asan/TestCases/large_func_test.cpp
+++ b/compiler-rt/test/asan/TestCases/large_func_test.cpp
@@ -4,6 +4,9 @@
 // RUN: %clangxx_asan -O3 %s -o %t && not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-%os --check-prefix=CHECK
 // REQUIRES: stable-runtime
 
+// Issue #108194: Incomplete .debug_line at -O1 and above.
+// XFAIL: target={{.*sparc.*}}
+
 #include <stdlib.h>
 __attribute__((noinline))
 static void LargeFunction(int *x, int zero) {


### PR DESCRIPTION
When enabling ASan testing on SPARC as per PR #107405, two tests `FAIL` in similar ways as detailed in Issue #108194: at `-O1` and above, one line of the stacktrace lacks the line number info, causing the tests to `FAIL`.  I could trace this to `clang` generating incomplete line number info; `g++` gets this right.

To avoid this, this patch `XFAIL`s the affected tests on SPARC.

Tested on `sparcv9-sun-solaris2.11`.