### PR TITLE
[sanitizer_common][test] Disable sanitizer_coverage_trace_pc_guard.cp…

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard-dso.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard-dso.cpp
@@ -1,7 +1,8 @@
 // Tests trace pc guard coverage collection.
 
 // REQUIRES: has_sancovcc
-// UNSUPPORTED: ubsan,target={{(powerpc64|s390x|thumb).*}}
+// Doesn't work on big-endian targets.
+// UNSUPPORTED: ubsan,target={{(powerpc64|s390x|sparc|thumb).*}}
 // XFAIL: tsan,darwin
 // XFAIL: android && asan
 

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
@@ -1,7 +1,7 @@
 // Tests trace pc guard coverage collection.
 
 // REQUIRES: has_sancovcc
-// UNSUPPORTED: ubsan,i386-darwin,target={{(powerpc64|s390x|thumb).*}}
+// UNSUPPORTED: ubsan,i386-darwin,target={{(powerpc64|s390x|sparc|thumb).*}}
 // This test is failing for lsan on darwin on x86_64h.
 // UNSUPPORTED: x86_64h-darwin && lsan
 // XFAIL: tsan


### PR DESCRIPTION
…p etc. on SPARC

When enabling ASan testing on SPARC as per PR #107405, two tests `FAIL`:
```
  SanitizerCommon-asan-sparc-SunOS :: sanitizer_coverage_trace_pc_guard-dso.cpp
  SanitizerCommon-asan-sparc-SunOS :: sanitizer_coverage_trace_pc_guard.cpp

```
The issue is the same in both cases:
```
WARNING: No coverage file for projects/compiler-rt/test/sanitizer_common/asan-sparc-SunOS/Output/sanitizer_coverage_trace_pc_guard.cpp.tmp
WARNING: No coverage file for sanitizer_coverage_trace_pc_guard.cpp.tmp.22766.sancov
ERROR: No valid coverage files given.

```
Checking the file with `sancov -print` reveals `Wrong magic: 4294967090`. There seems to be an endianess bug somewhere, since the tests are already disabled on other big-endian targets.

This patch matches this.

Tested on `sparcv9-sun-solaris2.11`.