### PR TITLE
[flang] Better error recovery for REAL(x, [KIND=]bad)

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -2264,7 +2264,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         messages.Say("'kind=' argument must be a constant scalar integer "
                      "whose value is a supported kind for the "
                      "intrinsic result type"_err_en_US);
-        return std::nullopt;
+        // use default kind below for error recovery
       } else if (kindDummyArg->flags.test(ArgFlag::defaultsToSameKind)) {
         CHECK(sameArg);
         resultType = *sameArg->GetType();
@@ -2274,6 +2274,8 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
             DynamicType{TypeCategory::Integer, defaults.sizeIntegerKind()};
       } else {
         CHECK(kindDummyArg->flags.test(ArgFlag::defaultsToDefaultForResult));
+      }
+      if (!resultType) {
         int kind{defaults.GetDefaultKind(*category)};
         if (*category == TypeCategory::Character) { // ACHAR & CHAR
           resultType = DynamicType{kind, 1};

--- a/flang/test/Semantics/kinds06.f90
+++ b/flang/test/Semantics/kinds06.f90
@@ -1,0 +1,4 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+!ERROR: 'kind=' argument must be a constant scalar integer whose value is a supported kind for the intrinsic result type
+print *, real(1.,666)
+end


### PR DESCRIPTION
There's two entries in the intrinsic table for REAL; the first handles the REAL(z) case of a COMPLEX argument, and the second handles the data type/kind conversion case.

In the case of REAL(x,bad) with a bad or unsupported kind of REAL, neither table entry was matching.  In the event of an unrecognized intrinsic function, the compiler emits the first error message that resulted, which was confusing here because it was a complaint about having too many arguments.

Reversing the order of the intrinsic table entries would fix the error message, but would also have broken REAL(z) with a complex argument, since it would then be treated as REAL(z,KIND=KIND(0.)) rather than REAL(z,KIND=KIND(z)).

The fix is to let the second entry "hit" with improved error recovery.