### PR TITLE
[TableGen] Fix MacOS failure in Option Emitter.

### DIFF
--- a/llvm/utils/TableGen/Common/OptEmitter.cpp
+++ b/llvm/utils/TableGen/Common/OptEmitter.cpp
@@ -41,6 +41,8 @@ static int StrCmpOptionName(const char *A, const char *B) {
 
 // Returns true if A is ordered before B.
 bool CompareOptionRecords(const Record *A, const Record *B) {
+  if (A == B)
+    return false;
   // Sentinel options precede all others and are only ordered by precedence.
   bool ASent = A->getValueAsDef("Kind")->getValueAsBit("Sentinel");
   bool BSent = B->getValueAsDef("Kind")->getValueAsBit("Sentinel");


### PR DESCRIPTION
Handle the case of same pointer used as both inputs to the `CompareOptionRecords`, to avoid emitting errors for equivalent options.