### PR TITLE
[lldb] Deflake TestDAP_attach

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -116,9 +116,6 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
 
     @skipIfDarwin
     @skipIfNetBSD  # Hangs on NetBSD as well
-    @skipIf(
-        archs=["arm", "aarch64"]
-    )  # Example of a flaky run http://lab.llvm.org:8011/builders/lldb-aarch64-ubuntu/builds/5527/steps/test/logs/stdio
     def test_commands(self):
         """
         Tests the "initCommands", "preRunCommands", "stopCommands",
@@ -152,7 +149,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         initCommands = ["target list", "platform list"]
         preRunCommands = ["image list a.out", "image dump sections a.out"]
         postRunCommands = ["help trace", "help process trace"]
-        stopCommands = ["frame variable", "bt"]
+        stopCommands = ["frame variable", "thread backtrace"]
         exitCommands = ["expr 2+3", "expr 3+4"]
         terminateCommands = ["expr 4+2"]
         self.attach(
@@ -179,7 +176,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         breakpoint_ids = self.set_function_breakpoints(functions)
         self.assertEqual(len(breakpoint_ids), len(functions), "expect one breakpoint")
         self.continue_to_breakpoints(breakpoint_ids)
-        output = self.get_console(timeout=1.0)
+        output = self.collect_console(timeout_secs=10, pattern=stopCommands[-1])
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue after launch and hit the "pause()" call and stop the target.
@@ -189,7 +186,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         time.sleep(0.5)
         self.dap_server.request_pause()
         self.dap_server.wait_for_stopped()
-        output = self.get_console(timeout=1.0)
+        output = self.collect_console(timeout_secs=10, pattern=stopCommands[-1])
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue until the program exits
@@ -198,7 +195,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         # "exitCommands" that were run after the second breakpoint was hit
         # and the "terminateCommands" due to the debugging session ending
         output = self.collect_console(
-            timeout_secs=1.0,
+            timeout_secs=10.0,
             pattern=terminateCommands[0],
         )
         self.verify_commands("exitCommands", output, exitCommands)


### PR DESCRIPTION
The test failed in
<https://lab.llvm.org/buildbot/#/builders/162/builds/5785> due to frame variable not being in stop commands, even though the DAP log shows the command being present there. I'm pretty sure this is a race in the test the collection of the test log. I fix that by making sure we wait for the expected output, and also by increasing the timeout (1s is cutting it very close).

The arm failure link is no longer functional, but I'm fairly certain that this was the cause of those flakes as well.