### PR TITLE
[flang] Catch whole assumed-size array passed to elemental

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1363,6 +1363,14 @@ static bool CheckElementalConformance(parser::ContextualMessages &messages,
     const auto &dummy{proc.dummyArguments.at(index++)};
     if (arg) {
       if (const auto *expr{arg->UnwrapExpr()}) {
+        if (const auto *wholeSymbol{evaluate::UnwrapWholeSymbolDataRef(arg)}) {
+          wholeSymbol = &ResolveAssociations(*wholeSymbol);
+          if (IsAssumedSizeArray(*wholeSymbol)) {
+            evaluate::SayWithDeclaration(messages, *wholeSymbol,
+                "Whole assumed-size array '%s' may not be used as an argument to an elemental procedure"_err_en_US,
+                wholeSymbol->name());
+          }
+        }
         if (auto argShape{evaluate::GetShape(context, *expr)}) {
           if (GetRank(*argShape) > 0) {
             std::string argName{"actual argument ("s + expr->AsFortran() +

--- a/flang/test/Semantics/elemental02.f90
+++ b/flang/test/Semantics/elemental02.f90
@@ -1,0 +1,13 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+subroutine s(a)
+  real a(*)
+  interface
+    elemental function ef(efarg)
+      real, intent(in) :: efarg
+    end
+  end interface
+!ERROR: Whole assumed-size array 'a' may not be used as an argument to an elemental procedure
+  print *, sqrt(a)
+!ERROR: Whole assumed-size array 'a' may not be used as an argument to an elemental procedure
+  print *, ef(a)
+end


### PR DESCRIPTION
A whole assumed-size array is not a valid argument to an elemental procedure (intrinsic or otherwise).