### PR TITLE
[flang] Catch attempts to subscribe empty arrays

### DIFF
--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -331,7 +331,7 @@ private:
       const semantics::Scope &, bool C919bAlreadyEnforced = false);
   MaybeExpr CompleteSubscripts(ArrayRef &&);
   MaybeExpr ApplySubscripts(DataRef &&, std::vector<Subscript> &&);
-  void CheckConstantSubscripts(ArrayRef &);
+  void CheckSubscripts(ArrayRef &);
   bool CheckRanks(const DataRef &); // Return false if error exists.
   bool CheckPolymorphic(const DataRef &); // ditto
   bool CheckDataRef(const DataRef &); // ditto

--- a/flang/test/Semantics/expr-errors06.f90
+++ b/flang/test/Semantics/expr-errors06.f90
@@ -1,7 +1,7 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror
 ! Check out-of-range subscripts
 subroutine subr(da)
-  real a(10), da(2,1)
+  real a(10), da(2,1), empty(1:0,1)
   integer, parameter :: n(2) = [1, 2]
   integer unknown
   !ERROR: DATA statement designator 'a(0_8)' is out of range
@@ -39,4 +39,10 @@ subroutine subr(da)
   print *, da(1,0)
   !WARNING: Subscript 2 is greater than upper bound 1 for dimension 2 of array
   print *, da(1,2)
+  print *, empty([(j,j=1,0)],1) ! ok
+  print *, empty(1:0,1) ! ok
+  print *, empty(:,1) ! ok
+  print *, empty(i:j,k) ! ok
+  !ERROR: Empty array dimension 1 cannot be subscripted as an element or non-empty array section
+  print *, empty(i,1)
 end


### PR DESCRIPTION
An array that has one or more empty dimensions cannot have subscripts unless there's a possibility that they constitute an empty array section.

We previously only checked that constant subscripts are in bounds.