### PR TITLE
[gn] Add "/Zc:preprocessor" build flag on windows

### DIFF
--- a/llvm/utils/gn/build/BUILD.gn
+++ b/llvm/utils/gn/build/BUILD.gn
@@ -183,11 +183,11 @@ config("compiler_defaults") {
     cflags += [ "/EHs-c-" ]
     cflags_cc += [ "/std:c++17" ]
 
-    # cl.exe doesn't set __cplusplus correctly by default.
-    # clang-cl gets it right by default, so don't needlessly add the flag there.
     if (!is_clang) {
       # expand __VA_ARGS__ in "OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__)"
       cflags += [ "/Zc:preprocessor" ]
+      # cl.exe doesn't set __cplusplus correctly by default.
+      # clang-cl gets it right by default, so don't needlessly add the flag there.
       cflags_cc += [ "/Zc:__cplusplus" ]
     }
 

--- a/llvm/utils/gn/build/BUILD.gn
+++ b/llvm/utils/gn/build/BUILD.gn
@@ -183,6 +183,9 @@ config("compiler_defaults") {
     cflags += [ "/EHs-c-" ]
     cflags_cc += [ "/std:c++17" ]
 
+    # expand __VA_ARGS__ in "OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__)"
+    cflags += [ "/Zc:preprocessor" ]
+
     # cl.exe doesn't set __cplusplus correctly by default.
     # clang-cl gets it right by default, so don't needlessly add the flag there.
     if (!is_clang) {

--- a/llvm/utils/gn/build/BUILD.gn
+++ b/llvm/utils/gn/build/BUILD.gn
@@ -183,12 +183,11 @@ config("compiler_defaults") {
     cflags += [ "/EHs-c-" ]
     cflags_cc += [ "/std:c++17" ]
 
-    # expand __VA_ARGS__ in "OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__)"
-    cflags += [ "/Zc:preprocessor" ]
-
     # cl.exe doesn't set __cplusplus correctly by default.
     # clang-cl gets it right by default, so don't needlessly add the flag there.
     if (!is_clang) {
+      # expand __VA_ARGS__ in "OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__)"
+      cflags += [ "/Zc:preprocessor" ]
       cflags_cc += [ "/Zc:__cplusplus" ]
     }
 


### PR DESCRIPTION
Add ```/Zc:preprocessor``` to fix the ```__VA_ARGS__``` expansion error encountered when building with gn

```
gen\llvm\lib\ToolDrivers\llvm-dlltool\Options.inc(43): warning C4003: not enough arguments for function-like macro invocation 'LLVM_MAKE_OPT_ID'
gen\llvm\lib\ToolDrivers\llvm-dlltool\Options.inc(44): warning C4003: not enough arguments for function-like macro invocation 'LLVM_MAKE_OPT_ID'
gen\llvm\lib\ToolDrivers\llvm-dlltool\Options.inc(44): error C2365: '`anonymous-namespace'::OPT_': redefinition; previous definition was 'enumerator'
gen\llvm\lib\ToolDrivers\llvm-dlltool\Options.inc(43): note: see declaration of '`anonymous-namespace'::OPT_'
gen\llvm\lib\ToolDrivers\llvm-dlltool\Options.inc(45): warning C4003: not enough arguments for function-like macro invocation 'LLVM_MAKE_OPT_ID'
gen\llvm\lib\ToolDrivers\llvm-dlltool\Options.inc(45): error C2365: '`anonymous-namespace'::OPT_': redefinition; previous definition was 'enumerator'
```