### PR TITLE
[libc][bazel] Enable epoll_pwait2 on bazel

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4126,25 +4126,23 @@ libc_function(
     ],
 )
 
-#TODO: Enable once epoll_pwait2 availablilty can be checked first.
-# https://github.com/llvm/llvm-project/issues/80060
-# libc_function(
-#     name = "epoll_pwait2",
-#     srcs = ["src/sys/epoll/linux/epoll_pwait2.cpp"],
-#     hdrs = ["src/sys/epoll/epoll_pwait2.h"],
-#     target_compatible_with = select({
-#         "@platforms//os:linux": [],
-#         "//conditions:default": ["@platforms//:incompatible"],
-#     }),
-#     weak = True,
-#     deps = [
-#         ":__support_macros_sanitizer",
-#         ":__support_osutil_syscall",
-#         ":errno",
-#         ":hdr_signal_macros",
-#         ":hdr_sys_epoll_macros",
-#         ":types_sigset_t",
-#         ":types_struct_epoll_event",
-#         ":types_struct_timespec",
-#     ],
-# )
+libc_function(
+    name = "epoll_pwait2",
+    srcs = ["src/sys/epoll/linux/epoll_pwait2.cpp"],
+    hdrs = ["src/sys/epoll/epoll_pwait2.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    weak = True,
+    deps = [
+        ":__support_macros_sanitizer",
+        ":__support_osutil_syscall",
+        ":errno",
+        ":hdr_signal_macros",
+        ":hdr_sys_epoll_macros",
+        ":types_sigset_t",
+        ":types_struct_epoll_event",
+        ":types_struct_timespec",
+    ],
+)

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
@@ -78,21 +78,19 @@ libc_test(
     ],
 )
 
-#TODO: Enable once epoll_pwait2 availablilty can be checked first.
-# https://github.com/llvm/llvm-project/issues/80060
-# libc_test(
-#     name = "epoll_pwait2_test",
-#     srcs = ["linux/epoll_pwait2_test.cpp"],
-#     libc_function_deps = [
-#         "//libc:epoll_pwait2",
-#         "//libc:epoll_create1",
-#         "//libc:epoll_ctl",
-#         "//libc:pipe",
-#         "//libc:close",
-#     ],
-#     deps = [
-#         "//libc:hdr_sys_epoll_macros",
-#         "//libc:types_struct_epoll_event",
-#         "//libc:types_struct_timespec",
-#     ],
-# )
+libc_test(
+    name = "epoll_pwait2_test",
+    srcs = ["linux/epoll_pwait2_test.cpp"],
+    libc_function_deps = [
+        "//libc:epoll_pwait2",
+        "//libc:epoll_create1",
+        "//libc:epoll_ctl",
+        "//libc:pipe",
+        "//libc:close",
+    ],
+    deps = [
+        "//libc:hdr_sys_epoll_macros",
+        "//libc:types_struct_epoll_event",
+        "//libc:types_struct_timespec",
+    ],
+)


### PR DESCRIPTION
The wrapper for epoll_pwait2 has been difficult to enable since it
requires a very new version of the linux kernel (5.11). On cmake we
still need to create a mechanism to check if we can build it, but our
current bazel users are all on a new enough kernel version we can just
enable it.
