### PR TITLE
[lld][WebAssembly] Reject shared libraries when `-static`/`-Bstatic` is used

### DIFF
--- a/lld/test/wasm/static-error.s
+++ b/lld/test/wasm/static-error.s
@@ -1,0 +1,12 @@
+// RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %s -o %t.o
+// RUN: wasm-ld --experimental-pic -shared -o %t.so %t.o
+
+// RUN: wasm-ld --experimental-pic -pie -o /dev/null %t.o %t.so
+// RUN: not wasm-ld -o /dev/null -static %t.o %t.so 2>&1 | FileCheck %s
+
+// CHECK: attempted static link of dynamic object
+
+.global _start
+_start:
+  .functype _start () -> ()
+  end_function

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -333,9 +333,15 @@ void LinkerDriver::addFile(StringRef path) {
     return;
   }
   case file_magic::bitcode:
-  case file_magic::wasm_object:
-    files.push_back(createObjectFile(mbref, "", 0, inLib));
+  case file_magic::wasm_object: {
+    auto obj = createObjectFile(mbref, "", 0, inLib);
+    if (config->isStatic && isa<SharedFile>(obj)) {
+      error("attempted static link of dynamic object " + path);
+      break;
+    }
+    files.push_back(obj);
     break;
+  }
   case file_magic::unknown:
     if (mbref.getBuffer().starts_with("#STUB")) {
       files.push_back(make<StubFile>(mbref));


### PR DESCRIPTION
This matches the behaviour of GNU ld and the ELF version of lld.