### PR TITLE
[clang][TableGen] Change ASTProperties Emitter to use const RecordKeeper

### DIFF
--- a/clang/utils/TableGen/ClangASTPropertiesEmitter.cpp
+++ b/clang/utils/TableGen/ClangASTPropertiesEmitter.cpp
@@ -89,13 +89,13 @@ struct CasedTypeInfo {
 
 class ASTPropsEmitter {
   raw_ostream &Out;
-  RecordKeeper &Records;
+  const RecordKeeper &Records;
   std::map<HasProperties, NodeInfo> NodeInfos;
   std::vector<PropertyType> AllPropertyTypes;
   std::map<PropertyType, CasedTypeInfo> CasedTypeInfos;
 
 public:
-  ASTPropsEmitter(RecordKeeper &records, raw_ostream &out)
+  ASTPropsEmitter(const RecordKeeper &records, raw_ostream &out)
       : Out(out), Records(records) {
 
     // Find all the properties.
@@ -587,28 +587,28 @@ void ASTPropsEmitter::emitWriteOfProperty(StringRef writerName,
 /// Emit an .inc file that defines the AbstractFooReader class
 /// for the given AST class hierarchy.
 template <class NodeClass>
-static void emitASTReader(RecordKeeper &records, raw_ostream &out,
+static void emitASTReader(const RecordKeeper &records, raw_ostream &out,
                           StringRef description) {
   emitSourceFileHeader(description, out, records);
 
   ASTPropsEmitter(records, out).emitNodeReaderClass<NodeClass>();
 }
 
-void clang::EmitClangTypeReader(RecordKeeper &records, raw_ostream &out) {
+void clang::EmitClangTypeReader(const RecordKeeper &records, raw_ostream &out) {
   emitASTReader<TypeNode>(records, out, "A CRTP reader for Clang Type nodes");
 }
 
 /// Emit an .inc file that defines the AbstractFooWriter class
 /// for the given AST class hierarchy.
 template <class NodeClass>
-static void emitASTWriter(RecordKeeper &records, raw_ostream &out,
+static void emitASTWriter(const RecordKeeper &records, raw_ostream &out,
                           StringRef description) {
   emitSourceFileHeader(description, out, records);
 
   ASTPropsEmitter(records, out).emitNodeWriterClass<NodeClass>();
 }
 
-void clang::EmitClangTypeWriter(RecordKeeper &records, raw_ostream &out) {
+void clang::EmitClangTypeWriter(const RecordKeeper &records, raw_ostream &out) {
   emitASTWriter<TypeNode>(records, out, "A CRTP writer for Clang Type nodes");
 }
 
@@ -847,7 +847,8 @@ void ASTPropsEmitter::emitBasicReaderWriterFile(const ReaderWriterInfo &info) {
 
 /// Emit an .inc file that defines some helper classes for reading
 /// basic values.
-void clang::EmitClangBasicReader(RecordKeeper &records, raw_ostream &out) {
+void clang::EmitClangBasicReader(const RecordKeeper &records,
+                                 raw_ostream &out) {
   emitSourceFileHeader("Helper classes for BasicReaders", out, records);
 
   // Use any property, we won't be using those properties.
@@ -857,7 +858,8 @@ void clang::EmitClangBasicReader(RecordKeeper &records, raw_ostream &out) {
 
 /// Emit an .inc file that defines some helper classes for writing
 /// basic values.
-void clang::EmitClangBasicWriter(RecordKeeper &records, raw_ostream &out) {
+void clang::EmitClangBasicWriter(const RecordKeeper &records,
+                                 raw_ostream &out) {
   emitSourceFileHeader("Helper classes for BasicWriters", out, records);
 
   // Use any property, we won't be using those properties.

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -35,11 +35,15 @@ void EmitClangDeclContext(const llvm::RecordKeeper &RK, llvm::raw_ostream &OS);
 void EmitClangASTNodes(const llvm::RecordKeeper &RK, llvm::raw_ostream &OS,
                        const std::string &N, const std::string &S,
                        std::string_view PriorizeIfSubclassOf = "");
-void EmitClangBasicReader(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
-void EmitClangBasicWriter(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
+void EmitClangBasicReader(const llvm::RecordKeeper &Records,
+                          llvm::raw_ostream &OS);
+void EmitClangBasicWriter(const llvm::RecordKeeper &Records,
+                          llvm::raw_ostream &OS);
 void EmitClangTypeNodes(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
-void EmitClangTypeReader(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
-void EmitClangTypeWriter(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
+void EmitClangTypeReader(const llvm::RecordKeeper &Records,
+                         llvm::raw_ostream &OS);
+void EmitClangTypeWriter(const llvm::RecordKeeper &Records,
+                         llvm::raw_ostream &OS);
 void EmitClangAttrParserStringSwitches(const llvm::RecordKeeper &Records,
                                        llvm::raw_ostream &OS);
 void EmitClangAttrSubjectMatchRulesParserStringSwitches(


### PR DESCRIPTION
Change ASTProperties Emitter to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089