### PR TITLE
[clang] Don't emit bogus dangling diagnostics when `[[gsl::Owner]]` and `[[clang::lifetimebound]]` are used together.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -305,6 +305,8 @@ Improvements to Clang's diagnostics
 
 - Clang now diagnose when importing module implementation partition units in module interface units.
 
+- Don't emit bogus dangling diagnostics when ``[[gsl::Owner]]`` and `[[clang::lifetimebound]]` are used together (#GH108272).
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -269,7 +269,8 @@ static bool isInStlNamespace(const Decl *D) {
 
 static bool shouldTrackImplicitObjectArg(const CXXMethodDecl *Callee) {
   if (auto *Conv = dyn_cast_or_null<CXXConversionDecl>(Callee))
-    if (isRecordWithAttr<PointerAttr>(Conv->getConversionType()))
+    if (isRecordWithAttr<PointerAttr>(Conv->getConversionType()) &&
+        Callee->getParent()->hasAttr<OwnerAttr>())
       return true;
   if (!isInStlNamespace(Callee->getParent()))
     return false;

--- a/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
+++ b/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
@@ -553,3 +553,37 @@ void test() {
   std::string_view svjkk1 = ReturnStringView(StrCat("bar", "x")); // expected-warning {{object backing the pointer will be destroyed at the end of the full-expression}}
 }
 } // namespace GH100549
+
+namespace GH108272 {
+template <typename T>
+struct [[gsl::Owner]] StatusOr {
+  const T &value() [[clang::lifetimebound]];
+};
+
+template <typename V>
+class Wrapper1 {
+ public:
+  operator V() const;
+  V value;
+};
+std::string_view test1() {
+  StatusOr<Wrapper1<std::string_view>> k;
+  // Be conservative in this case, as there is not enough information available
+  // to infer the lifetime relationship for the Wrapper1 type.
+  std::string_view good = StatusOr<Wrapper1<std::string_view>>().value();
+  return k.value();
+}
+
+template <typename V>
+class Wrapper2 {
+ public:
+  operator V() const [[clang::lifetimebound]];
+  V value;
+};
+std::string_view test2() {
+  StatusOr<Wrapper2<std::string_view>> k;
+  // We expect dangling issues as the conversion operator is lifetimebound。
+  std::string_view bad = StatusOr<Wrapper2<std::string_view>>().value(); // expected-warning {{temporary whose address is used as value of}}
+  return k.value(); // expected-warning {{address of stack memory associated}}
+}
+} // namespace GH108272


### PR DESCRIPTION
In the GSL analysis, we don't track the `this` object if the conversion is not from gsl::owner to gsl pointer, we want to be conservative here to avoid triggering false positives.

Fixes #108272 