### PR TITLE
[libc++][modules] Add a header to forward-declare std::get

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -424,6 +424,7 @@ set(files
   __fwd/format.h
   __fwd/fstream.h
   __fwd/functional.h
+  __fwd/get.h
   __fwd/ios.h
   __fwd/istream.h
   __fwd/mdspan.h
@@ -440,6 +441,7 @@ set(files
   __fwd/string_view.h
   __fwd/subrange.h
   __fwd/tuple.h
+  __fwd/variant.h
   __fwd/vector.h
   __hash_table
   __ios/fpos.h

--- a/libcxx/include/__fwd/get.h
+++ b/libcxx/include/__fwd/get.h
@@ -1,0 +1,24 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___FWD_GET_H
+#define _LIBCPP___FWD_GET_H
+
+#include <__config>
+#include <__fwd/array.h>
+#include <__fwd/complex.h>
+#include <__fwd/pair.h>
+#include <__fwd/subrange.h>
+#include <__fwd/tuple.h>
+#include <__fwd/variant.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#endif // _LIBCPP___FWD_GET_H

--- a/libcxx/include/__fwd/variant.h
+++ b/libcxx/include/__fwd/variant.h
@@ -1,0 +1,73 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___FWD_VARIANT_H
+#define _LIBCPP___FWD_VARIANT_H
+
+#include <__config>
+#include <__cstddef/size_t.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <class... _Types>
+class _LIBCPP_TEMPLATE_VIS variant;
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_size;
+
+template <class _Tp>
+inline constexpr size_t variant_size_v = variant_size<_Tp>::value;
+
+template <size_t _Ip, class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_alternative;
+
+template <size_t _Ip, class _Tp>
+using variant_alternative_t = typename variant_alternative<_Ip, _Tp>::type;
+
+inline constexpr size_t variant_npos = static_cast<size_t>(-1);
+
+template <size_t _Ip, class... _Types>
+_LIBCPP_HIDE_FROM_ABI
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr variant_alternative_t<_Ip, variant<_Types...>>&
+get(variant<_Types...>&);
+
+template <size_t _Ip, class... _Types>
+_LIBCPP_HIDE_FROM_ABI
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr variant_alternative_t<_Ip, variant<_Types...>>&&
+get(variant<_Types...>&&);
+
+template <size_t _Ip, class... _Types>
+_LIBCPP_HIDE_FROM_ABI
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const variant_alternative_t<_Ip, variant<_Types...>>&
+get(const variant<_Types...>&);
+
+template <size_t _Ip, class... _Types>
+_LIBCPP_HIDE_FROM_ABI
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const variant_alternative_t<_Ip, variant<_Types...>>&&
+get(const variant<_Types...>&&);
+
+template <class _Tp, class... _Types>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr _Tp& get(variant<_Types...>&);
+
+template <class _Tp, class... _Types>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr _Tp&& get(variant<_Types...>&&);
+
+template <class _Tp, class... _Types>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const _Tp& get(const variant<_Types...>&);
+
+template <class _Tp, class... _Types>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const _Tp&&
+get(const variant<_Types...>&&);
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___FWD_VARIANT_H

--- a/libcxx/include/__fwd/variant.h
+++ b/libcxx/include/__fwd/variant.h
@@ -18,6 +18,8 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
+#if _LIBCPP_STD_VER >= 17
+
 template <class... _Types>
 class _LIBCPP_TEMPLATE_VIS variant;
 
@@ -67,6 +69,8 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr co
 template <class _Tp, class... _Types>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const _Tp&&
 get(const variant<_Types...>&&);
+
+#endif // _LIBCPP_STD_VER >= 17
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__ranges/elements_view.h
+++ b/libcxx/include/__ranges/elements_view.h
@@ -16,7 +16,7 @@
 #include <__concepts/derived_from.h>
 #include <__concepts/equality_comparable.h>
 #include <__config>
-#include <__fwd/complex.h>
+#include <__fwd/get.h>
 #include <__iterator/concepts.h>
 #include <__iterator/iterator_traits.h>
 #include <__ranges/access.h>

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1813,7 +1813,15 @@ module std_private_tuple_tuple_like_no_subrange [system] {
 module std_private_tuple_sfinae_helpers         [system] { header "__tuple/sfinae_helpers.h" }
 module std_private_tuple_tuple_element          [system] { header "__tuple/tuple_element.h" }
 module std_private_tuple_tuple_fwd              [system] { header "__fwd/tuple.h" }
-module std_private_get_fwd                      [system] { header "__fwd/get.h" }
+module std_private_get_fwd                      [system] {
+  header "__fwd/get.h"
+  export std_private_array_array_fwd
+  export std_private_complex_complex_fwd
+  export std_private_ranges_subrange_fwd
+  export std_private_tuple_tuple_fwd
+  export std_private_utility_pair_fwd
+  export std_private_variant_fwd
+}
 module std_private_tuple_tuple_indices          [system] { header "__tuple/tuple_indices.h" }
 module std_private_tuple_tuple_like             [system] {
   header "__tuple/tuple_like.h"

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1813,6 +1813,7 @@ module std_private_tuple_tuple_like_no_subrange [system] {
 module std_private_tuple_sfinae_helpers         [system] { header "__tuple/sfinae_helpers.h" }
 module std_private_tuple_tuple_element          [system] { header "__tuple/tuple_element.h" }
 module std_private_tuple_tuple_fwd              [system] { header "__fwd/tuple.h" }
+module std_private_get_fwd                      [system] { header "__fwd/get.h" }
 module std_private_tuple_tuple_indices          [system] { header "__tuple/tuple_indices.h" }
 module std_private_tuple_tuple_like             [system] {
   header "__tuple/tuple_like.h"
@@ -2103,5 +2104,6 @@ module std_private_utility_to_underlying           [system] { header "__utility/
 module std_private_utility_unreachable             [system] { header "__utility/unreachable.h" }
 
 module std_private_variant_monostate               [system] { header "__variant/monostate.h" }
+module std_private_variant_fwd                     [system] { header "__fwd/variant.h" }
 
 module std_private_vector_fwd                      [system] { header "__fwd/vector.h" }

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -221,6 +221,7 @@ namespace std {
 #include <__functional/invoke.h>
 #include <__functional/operations.h>
 #include <__functional/unary_function.h>
+#include <__fwd/variant.h>
 #include <__memory/addressof.h>
 #include <__memory/construct_at.h>
 #include <__tuple/find_index.h>
@@ -307,15 +308,7 @@ __throw_bad_variant_access() {
 #  endif
 }
 
-template <class... _Types>
-class _LIBCPP_TEMPLATE_VIS variant;
-
-template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_size;
-
-template <class _Tp>
-inline constexpr size_t variant_size_v = variant_size<_Tp>::value;
-
+// variant_size
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS variant_size<const _Tp> : variant_size<_Tp> {};
 
@@ -328,12 +321,7 @@ struct _LIBCPP_TEMPLATE_VIS variant_size<const volatile _Tp> : variant_size<_Tp>
 template <class... _Types>
 struct _LIBCPP_TEMPLATE_VIS variant_size<variant<_Types...>> : integral_constant<size_t, sizeof...(_Types)> {};
 
-template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_alternative;
-
-template <size_t _Ip, class _Tp>
-using variant_alternative_t = typename variant_alternative<_Ip, _Tp>::type;
-
+// variant_alternative
 template <size_t _Ip, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, const _Tp> : add_const<variant_alternative_t<_Ip, _Tp>> {};
 
@@ -348,8 +336,6 @@ struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, variant<_Types...>> {
   static_assert(_Ip < sizeof...(_Types), "Index out of bounds in std::variant_alternative<>");
   using type = __type_pack_element<_Ip, _Types...>;
 };
-
-inline constexpr size_t variant_npos = static_cast<size_t>(-1);
 
 template <size_t _NumAlternatives>
 _LIBCPP_HIDE_FROM_ABI constexpr auto __choose_index_type() {
@@ -368,9 +354,6 @@ using __variant_index_t = decltype(std::__choose_index_type<_NumAlts>());
 
 template <class _IndexType>
 constexpr _IndexType __variant_npos = static_cast<_IndexType>(-1);
-
-template <class... _Types>
-class _LIBCPP_TEMPLATE_VIS variant;
 
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI constexpr variant<_Types...>& __as_variant(variant<_Types...>& __vs) noexcept {


### PR DESCRIPTION
This is necessary because e.g. ranges::elements_view uses std::get but it needs to have in scope the declaration of all the versions of std::get that exist in the library. This need is what had originally led to elements_view.h gaining an include of __fwd/complex.h, but in reality it is a more general issue that requires a canonical declration point for all the std::get variations.