### PR TITLE
[llvm][llvm-cat] Fix typo in the Input file name option

### DIFF
--- a/llvm/tools/llvm-cat/llvm-cat.cpp
+++ b/llvm/tools/llvm-cat/llvm-cat.cpp
@@ -44,7 +44,7 @@ static cl::opt<std::string> OutputFilename("o", cl::Required,
                                            cl::cat(CatCategory));
 
 static cl::list<std::string> InputFilenames(cl::Positional,
-                                            cl::desc("<input  files>"),
+                                            cl::desc("<input files>"),
                                             cl::cat(CatCategory));
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Current usage printed by llvm-cat

`USAGE: llvm-cat [options] <input  files>`

Should be changed to 

`USAGE: llvm-cat [options] <input files>`