### PR TITLE
[mlir][mesh] Introduce `DialectInlinerInterface` for Mesh dialect

### DIFF
--- a/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
+++ b/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
@@ -24,6 +24,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
@@ -75,6 +76,26 @@ static DimensionSize operator*(DimensionSize lhs, DimensionSize rhs) {
 }
 
 //===----------------------------------------------------------------------===//
+// Inliner
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct MeshInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+  // Currently no restrictions are encoded for inlining.
+  bool isLegalToInline(Operation *, Operation *, bool) const final {
+    return true;
+  }
+  bool isLegalToInline(Region *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // Mesh dialect
 //===----------------------------------------------------------------------===//
 
@@ -91,6 +112,7 @@ void MeshDialect::initialize() {
 #define GET_TYPEDEF_LIST
 #include "mlir/Dialect/Mesh/IR/MeshTypes.cpp.inc"
       >();
+  addInterface<MeshInlinerInterface>();
 }
 
 Operation *MeshDialect::materializeConstant(OpBuilder &builder, Attribute value,

--- a/mlir/test/Dialect/Mesh/inlining.mlir
+++ b/mlir/test/Dialect/Mesh/inlining.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt -inline %s | FileCheck %s
+
+mesh.mesh @mesh0(shape = 4x?x2)
+
+func.func private @mesh_to_inline() -> (index, index) {
+  %0:2 = mesh.mesh_shape @mesh0 axes = [2, 1] : index, index
+  return %0#0, %0#1 : index, index
+}
+// CHECK-LABEL: func.func @main
+func.func @main() -> (index, index) {
+  // CHECK-NEXT: %[[AXIS_SIZE:.*]]:2 = mesh.mesh_shape @mesh0 axes = [2, 1] : index
+  %0:2 = func.call @mesh_to_inline() : () -> (index, index)
+  // CHECK-NEXT: return %[[AXIS_SIZE]]#0, %[[AXIS_SIZE]]#1
+  return %0#0, %0#1 : index, index
+}


### PR DESCRIPTION
The inliner interface does not implement any restrictions for inlining.