### PR TITLE
Changing `auto` to `const auto&` to avoid unnecessary copies

### DIFF
--- a/llvm/lib/CodeGen/WindowScheduler.cpp
+++ b/llvm/lib/CodeGen/WindowScheduler.cpp
@@ -318,7 +318,7 @@ void WindowScheduler::generateTripleMBB() {
       auto *NewMI = MF->CloneMachineInstr(MI);
       DenseMap<Register, Register> NewDefs;
       // New defines are updated.
-      for (auto MO : NewMI->all_defs())
+      for (const auto &MO : NewMI->all_defs())
         if (MO.isReg() && MO.getReg().isVirtual()) {
           Register NewDef =
               MRI->createVirtualRegister(MRI->getRegClass(MO.getReg()));
@@ -699,7 +699,7 @@ unsigned WindowScheduler::getOriStage(MachineInstr *OriMI, unsigned Offset) {
 Register WindowScheduler::getAntiRegister(MachineInstr *Phi) {
   assert(Phi->isPHI() && "Expecting PHI!");
   Register AntiReg;
-  for (auto MO : Phi->uses()) {
+  for (const auto &MO : Phi->uses()) {
     if (MO.isReg())
       AntiReg = MO.getReg();
     else if (MO.isMBB() && MO.getMBB() == MBB)


### PR DESCRIPTION
Changing `auto` to `const auto&` to avoid unnecessary copies