### PR TITLE
[clang][bytecode] Fix modify_global diagnostics in C++11

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -883,7 +883,7 @@ bool CheckDummy(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
     return diagnoseUnknownDecl(S, OpPC, D);
 
   assert(AK == AK_Assign);
-  if (S.getLangOpts().CPlusPlus11) {
+  if (S.getLangOpts().CPlusPlus14) {
     const SourceInfo &E = S.Current->getSource(OpPC);
     S.FFDiag(E, diag::note_constexpr_modify_global);
   }

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -169,3 +169,8 @@ namespace FinalLtorDiags {
   A<q> c; // both-error {{non-type template argument of type 'int *' is not a constant expression}} \
           // both-note {{read of non-constexpr variable 'q' is not allowed in a constant expression}}
 }
+
+void lambdas() {
+  int d;
+  int a9[1] = {[d = 0] = 1}; // both-error {{not an integral constant expression}}
+}


### PR DESCRIPTION
We shouldn't emit this until C++14.