### PR TITLE
[lldb][test] TestDataFormatterLibcxxStringSimulator.py: fix padding for current layout

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -22,6 +22,9 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
         self.expect_var_path("shortstring", summary='"short"')
         self.expect_var_path("longstring", summary='"I am a very long string"')
 
+        self.expect_expr("shortstring", result_summary='"short"')
+        self.expect_expr("longstring", result_summary='"I am a very long string"')
+
 
 for v in [None, "ALTERNATE_LAYOUT"]:
     for r in range(5):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -83,7 +83,8 @@ public:
 #else // !BITMASKS
     unsigned char __size_ : 7;
     unsigned char __is_long_ : 1;
-#endif
+#endif // BITMASKS
+#endif // SUBCLASS_PADDING
   };
 
 #ifdef BITMASKS

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -71,15 +71,15 @@ public:
 
   struct __short {
     value_type __data_[__min_cap];
-#ifdef BITMASKS
 #ifdef SUBCLASS_PADDING
     struct : __padding<value_type> {
       unsigned char __size_;
     };
-#else
+#else // !SUBCLASS_PADDING
+
     unsigned char __padding[sizeof(value_type) - 1];
+#ifdef BITMASKS
     unsigned char __size_;
-#endif
 #else // !BITMASKS
     unsigned char __size_ : 7;
     unsigned char __is_long_ : 1;


### PR DESCRIPTION
IIUC, the history of `std::string`'s `__short` structure in the alternate ABI layout (as recorded by the simulator test) looks as follows:
* First layout ( `SUBCLASS_PADDING` is defined):
```
     struct __short                                          
     {                                                       
         value_type __data_[__min_cap];                      
        struct                                              
            : __padding<value_type>                         
        {                                                   
            unsigned char __size_;                          
        };
     };                                      
```
* Then:
```
     struct __short                                         
     {                                                      
        value_type __data_[__min_cap];                                                               
        unsigned char __padding[sizeof(value_type) - 1];   
        unsigned char __size_;                             
     };
```
* Then, post-`BITMASKS`:
```
     struct __short                                         
     {                                                      
        value_type __data_[__min_cap];                                                               
        unsigned char __padding[sizeof(value_type) - 1];   
        unsigned char __size_ : 7;
        unsigned char __is_long_ : 1;                             
     };
```

Which is the one that's [on top-of-tree](https://github.com/llvm/llvm-project/blob/89c10e27d8b4d5f44998aad9abd2590d9f96c5df/libcxx/include/string#L854-L859).

But for `REVISION > 1`, `BITMASKS` is never set, so for those tests we lose the `__padding` member.

This patch fixes this by splitting out the `SUBCLASS_PADDING` out of the ifdef.

Drive-by:
* Also run expression evaluator on the string to provide is with some extra coverage.