### PR TITLE
[AMDGPU] Precommit and Modify `phi_moveimm_subreg_input` testcase

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/phi-vgpr-input-moveimm.mir
+++ b/llvm/test/CodeGen/AMDGPU/phi-vgpr-input-moveimm.mir
@@ -63,51 +63,52 @@ body:             |
   ; GCN-LABEL: name: phi_moveimm_subreg_input
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x80000000)
-  ; GCN-NEXT:   liveins: $sgpr0, $sgpr1
+  ; GCN-NEXT:   liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
-  ; GCN-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY $sgpr1
+  ; GCN-NEXT:   [[V_MOV_B64_e32_:%[0-9]+]]:vreg_64 = V_MOV_B64_e32 0, implicit $exec
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_64 = COPY $sgpr0_sgpr1
+  ; GCN-NEXT:   [[COPY1:%[0-9]+]]:sreg_64 = COPY $sgpr2_sgpr3
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.1:
   ; GCN-NEXT:   successors: %bb.2(0x80000000)
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   undef [[S_ADD_U32_:%[0-9]+]].sub0:sreg_64 = S_ADD_U32 [[COPY]], [[COPY1]], implicit-def $scc
+  ; GCN-NEXT:   [[S_ADD_U:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO [[COPY]], [[COPY1]], implicit-def $scc
+  ; GCN-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[S_ADD_U]].sub0, implicit $exec
   ; GCN-NEXT:   S_BRANCH %bb.2
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   successors: %bb.3(0x80000000)
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[PHI:%[0-9]+]]:sreg_64 = PHI %5, %bb.3, [[S_ADD_U32_]], %bb.1
+  ; GCN-NEXT:   [[PHI:%[0-9]+]]:vgpr_32 = PHI [[V_MOV_B64_e32_]].sub0, %bb.3, [[COPY2]], %bb.1
   ; GCN-NEXT:   S_BRANCH %bb.3
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.3:
   ; GCN-NEXT:   successors: %bb.2(0x80000000)
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   undef [[S_MOV_B32_:%[0-9]+]].sub0:sreg_64 = S_MOV_B32 0
+  ; GCN-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; GCN-NEXT:   S_BRANCH %bb.2
   bb.0:
     successors: %bb.1
-    liveins: $sgpr0, $sgpr1
+    liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3
 
-    %0:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    %0:vreg_64 = V_MOV_B64_e32 0, implicit $exec
 
-    %4:sreg_32 = COPY $sgpr0
-    %5:sreg_32 = COPY $sgpr1
+    %4:sreg_64 = COPY $sgpr0_sgpr1
+    %5:sreg_64 = COPY $sgpr2_sgpr3
 
   bb.1:
     successors: %bb.2
-    undef %2.sub0:sreg_64 = S_ADD_U32 %4, %5, implicit-def $scc
+    %2:sreg_64 = S_ADD_U64_PSEUDO %4, %5, implicit-def $scc
     S_BRANCH %bb.2
 
   bb.2:
     successors: %bb.3
-    %3:sreg_64 = PHI %1, %bb.3, %2, %bb.1
+    %3:sreg_32 = PHI %1.sub0:sreg_64, %bb.3, %2.sub0:sreg_64, %bb.1
     S_BRANCH %bb.3
 
   bb.3:
     successors: %bb.2
-    undef %1.sub0:sreg_64 = COPY %0
+    %1:sreg_64 = COPY %0.sub0:vreg_64
     S_BRANCH %bb.2
 ...
 


### PR DESCRIPTION
- Updated `phi_moveimm_subreg_input` test case to introduce sub-registers as PHI input operands.
Currently subreg is making the testcase in non-SSA format, need to fix this by giving subreg as an input operand to PHI instead defining the subreg register. 

This change is relevant for : [[AMDGPU] Add MachineVerifier check to detect illegal copies from vector register to SGPR ](https://github.com/llvm/llvm-project/pull/105494)