### PR TITLE
[analyzer] Fix StreamChecker crash in fread modeling

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
@@ -1129,7 +1129,7 @@ tryToInvalidateFReadBufferByElements(ProgramStateRef State, CheckerContext &C,
   if (!ElemTy.isNull() && CountVal && Size && StartIndexVal) {
     int64_t NumBytesRead = Size.value() * CountVal.value();
     int64_t ElemSizeInChars = Ctx.getTypeSizeInChars(ElemTy).getQuantity();
-    if (ElemSizeInChars == 0)
+    if (ElemSizeInChars == 0 || NumBytesRead < 0)
       return nullptr;
 
     bool IncompleteLastElement = (NumBytesRead % ElemSizeInChars) != 0;

--- a/clang/test/Analysis/fread.c
+++ b/clang/test/Analysis/fread.c
@@ -443,3 +443,33 @@ void test_unaligned_start_read(void) {
     fclose(fp);
   }
 }
+
+void no_crash_if_count_is_negative(long s, unsigned char *buffer) {
+  FILE *fp = fopen("path", "r");
+  if (fp) {
+    if (s * s == -1) {
+      fread(buffer, 1, s * s, fp); // no-crash
+    }
+    fclose(fp);
+  }
+}
+
+void no_crash_if_size_is_negative(long s, unsigned char *buffer) {
+  FILE *fp = fopen("path", "r");
+  if (fp) {
+    if (s * s == -1) {
+      fread(buffer, s * s, 1, fp); // no-crash
+    }
+    fclose(fp);
+  }
+}
+
+void no_crash_if_size_and_count_are_negative(long s, unsigned char *buffer) {
+  FILE *fp = fopen("path", "r");
+  if (fp) {
+    if (s * s == -1) {
+      fread(buffer, s * s, s * s, fp); // no-crash
+    }
+    fclose(fp);
+  }
+}

--- a/clang/test/Analysis/fread.c
+++ b/clang/test/Analysis/fread.c
@@ -444,31 +444,31 @@ void test_unaligned_start_read(void) {
   }
 }
 
-void no_crash_if_count_is_negative(long s, unsigned char *buffer) {
+void no_crash_if_count_is_negative(long l, long r, unsigned char *buffer) {
   FILE *fp = fopen("path", "r");
   if (fp) {
-    if (s * s == -1) {
-      fread(buffer, 1, s * s, fp); // no-crash
+    if (l * r == -1) {
+      fread(buffer, 1, l * r, fp); // no-crash
     }
     fclose(fp);
   }
 }
 
-void no_crash_if_size_is_negative(long s, unsigned char *buffer) {
+void no_crash_if_size_is_negative(long l, long r, unsigned char *buffer) {
   FILE *fp = fopen("path", "r");
   if (fp) {
-    if (s * s == -1) {
-      fread(buffer, s * s, 1, fp); // no-crash
+    if (l * r == -1) {
+      fread(buffer, l * r, 1, fp); // no-crash
     }
     fclose(fp);
   }
 }
 
-void no_crash_if_size_and_count_are_negative(long s, unsigned char *buffer) {
+void no_crash_if_size_and_count_are_negative(long l, long r, unsigned char *buffer) {
   FILE *fp = fopen("path", "r");
   if (fp) {
-    if (s * s == -1) {
-      fread(buffer, s * s, s * s, fp); // no-crash
+    if (l * r == -1) {
+      fread(buffer, l * r, l * r, fp); // no-crash
     }
     fclose(fp);
   }


### PR DESCRIPTION
In #93408 https://github.com/llvm/llvm-project/commit/69bc159142c6e4ed168e32a6168392d396f891de
I refined how invalidation is done for `fread`. It can crash, if the "size" or "count" parameters of "fread" is a perfectly constrained negative value. In such cases, when it will try to allocate a SmallVector with a negative size, which will cause a crash.

To mitigate this issue, let's just guard against negative values.

CPP-3247