### PR TITLE
[SDAG] Handle range attribute for call instructions.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -4499,6 +4499,17 @@ static const MDNode *getRangeMetadata(const Instruction &I) {
   // transforms that are known not to be poison-safe, such as folding logical
   // and/or to bitwise and/or. For now, only transfer !range if !noundef is
   // also present.
+  if (const auto *CB = dyn_cast<CallBase>(&I))
+    if (CB->hasRetAttr(Attribute::NoUndef))
+      if (std::optional<ConstantRange> CR = CB->getRange()) {
+        Metadata *Range[] = {ConstantAsMetadata::get(ConstantInt::get(
+                                 I.getContext(), CR->getLower())),
+                             ConstantAsMetadata::get(ConstantInt::get(
+                                 I.getContext(), CR->getUpper()))};
+
+        return MDNode::get(I.getContext(), Range);
+      }
+
   if (!I.hasMetadata(LLVMContext::MD_noundef))
     return nullptr;
   return I.getMetadata(LLVMContext::MD_range);


### PR DESCRIPTION
Possible way to handle range attribute on Intrinsic in SDAG by creating a MDNode when needed instead of adding a constRange to MachineMemOperand to save memory.

There is no test that have ranges on the Intrinsic where getRangeMetadata is called and I can not find that the range is used for any of the Intrinsics so alternative is to not handle range attribute on them until there is a usage.