### PR TITLE
Guard an include of `<ostream>` in `<chrono>` with availability macro

### DIFF
--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -1015,8 +1015,8 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 #  include <charconv>
 #  if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 #    include <locale>
+#    include <ostream>
 #  endif
-#  include <ostream>
 #endif
 
 #endif // _LIBCPP_CHRONO


### PR DESCRIPTION
This fixes a regression introduced in
https://github.com/llvm/llvm-project/pull/96035.
