### PR TITLE
[lld] select a default eflags for hexagon

### DIFF
--- a/lld/ELF/Arch/Hexagon.cpp
+++ b/lld/ELF/Arch/Hexagon.cpp
@@ -60,17 +60,15 @@ Hexagon::Hexagon() {
 }
 
 uint32_t Hexagon::calcEFlags() const {
-  assert(!ctx.objectFiles.empty());
-
   // The architecture revision must always be equal to or greater than
   // greatest revision in the list of inputs.
-  uint32_t ret = 0;
+  std::optional<uint32_t> ret;
   for (InputFile *f : ctx.objectFiles) {
     uint32_t eflags = cast<ObjFile<ELF32LE>>(f)->getObj().getHeader().e_flags;
-    if (eflags > ret)
+    if (!ret || eflags > *ret)
       ret = eflags;
   }
-  return ret;
+  return ret.value_or(/* Default Arch Rev: */ 0x60);
 }
 
 static uint32_t applyMask(uint32_t mask, uint32_t data) {

--- a/lld/test/ELF/hexagon-eflag.s
+++ b/lld/test/ELF/hexagon-eflag.s
@@ -5,3 +5,8 @@
 # RUN: llvm-readelf -h  %t3 | FileCheck %s
 # Verify that the largest arch in the input list is selected.
 # CHECK: Flags: 0x62
+
+# RUN: llvm-ar rcsD %t4
+# RUN: ld.lld -m hexagonelf %t4 -o %t5
+# RUN: llvm-readelf -h  %t5 | FileCheck --check-prefix=CHECK-EMPTYARCHIVE %s
+# CHECK-EMPTYARCHIVE: Flags: 0x60


### PR DESCRIPTION
Empty archives are apparently routine in linux kernel builds, so instead of asserting, we should handle this case with a sane default value.