### PR TITLE
[SystemZ][z/OS] Introduce new AsmStreamer for z/OS specific HLASM format output

### DIFF
--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -208,6 +208,10 @@ public:
   using AsmTargetStreamerCtorTy =
       MCTargetStreamer *(*)(MCStreamer &S, formatted_raw_ostream &OS,
                             MCInstPrinter *InstPrint);
+  using AsmStreamerCtorTy =
+      MCStreamer *(*)(MCContext &Ctx, std::unique_ptr<formatted_raw_ostream> OS,
+                      MCInstPrinter *IP, std::unique_ptr<MCCodeEmitter> CE,
+                      std::unique_ptr<MCAsmBackend> TAB);
   using ObjectTargetStreamerCtorTy = MCTargetStreamer *(*)(
       MCStreamer &S, const MCSubtargetInfo &STI);
   using MCRelocationInfoCtorTy = MCRelocationInfo *(*)(const Triple &TT,
@@ -315,6 +319,10 @@ private:
   /// Construction function for this target's asm TargetStreamer, if
   /// registered (default = nullptr).
   AsmTargetStreamerCtorTy AsmTargetStreamerCtorFn = nullptr;
+
+  /// Construction function for this target's AsmStreamer, if
+  /// registered (default = nullptr).
+  AsmStreamerCtorTy AsmStreamerCtorFn = nullptr;
 
   /// Construction function for this target's obj TargetStreamer, if
   /// registered (default = nullptr).
@@ -925,6 +933,10 @@ struct TargetRegistry {
   static void RegisterNullTargetStreamer(Target &T,
                                          Target::NullTargetStreamerCtorTy Fn) {
     T.NullTargetStreamerCtorFn = Fn;
+  }
+
+  static void RegisterAsmStreamer(Target &T, Target::AsmStreamerCtorTy Fn) {
+    T.AsmStreamerCtorFn = Fn;
   }
 
   static void RegisterAsmTargetStreamer(Target &T,

--- a/llvm/lib/MC/TargetRegistry.cpp
+++ b/llvm/lib/MC/TargetRegistry.cpp
@@ -93,8 +93,14 @@ MCStreamer *Target::createAsmStreamer(MCContext &Ctx,
                                       std::unique_ptr<MCCodeEmitter> CE,
                                       std::unique_ptr<MCAsmBackend> TAB) const {
   formatted_raw_ostream &OSRef = *OS;
-  MCStreamer *S = llvm::createAsmStreamer(Ctx, std::move(OS), IP,
-                                          std::move(CE), std::move(TAB));
+  MCStreamer *S;
+  if (AsmStreamerCtorFn)
+    S = AsmStreamerCtorFn(Ctx, std::move(OS), IP, std::move(CE),
+                          std::move(TAB));
+  else
+    S = llvm::createAsmStreamer(Ctx, std::move(OS), IP, std::move(CE),
+                                std::move(TAB));
+
   createAsmTargetStreamer(*S, OSRef, IP);
   return S;
 }

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_component_library(LLVMSystemZDesc
   SystemZELFObjectWriter.cpp
   SystemZGOFFObjectWriter.cpp
+  SystemZHLASMAsmStreamer.cpp
   SystemZInstPrinter.cpp
   SystemZMCAsmBackend.cpp
   SystemZMCAsmInfo.cpp

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
@@ -1,0 +1,24 @@
+//===- SystemZHLASMAsmStreamer.cpp - HLASM Assembly Text Output -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SystemZHLASMAsmStreamer.h"
+
+void SystemZHLASMAsmStreamer::changeSection(MCSection *Section,
+                                            uint32_t Subsection) {
+  MCStreamer::changeSection(Section, Subsection);
+}
+
+void SystemZHLASMAsmStreamer::emitLabel(MCSymbol *Symbol, SMLoc Loc) {
+  MCStreamer::emitLabel(Symbol, Loc);
+
+  Symbol->print(OS, MAI);
+  // TODO: update LabelSuffix in SystemZMCAsmInfoGOFF once tests have been
+  // moved to HLASM syntax.
+  // OS << MAI->getLabelSuffix();
+  OS << '\n';
+}

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
@@ -1,0 +1,93 @@
+//===- SystemZHLASMAsmStreamer.h - HLASM Assembly Text Output ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the SystemZHLASMAsmStreamer class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCAssembler.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Support/FormattedStream.h"
+
+using namespace llvm;
+
+class SystemZHLASMAsmStreamer final : public MCStreamer {
+  std::unique_ptr<formatted_raw_ostream> OSOwner;
+  formatted_raw_ostream &OS;
+  const MCAsmInfo *MAI;
+  std::unique_ptr<MCInstPrinter> InstPrinter;
+  std::unique_ptr<MCAssembler> Assembler;
+  SmallString<128> CommentToEmit;
+  raw_svector_ostream CommentStream;
+  raw_null_ostream NullStream;
+
+  bool IsVerboseAsm = false;
+
+public:
+  SystemZHLASMAsmStreamer(MCContext &Context,
+                          std::unique_ptr<formatted_raw_ostream> os,
+                          MCInstPrinter *printer,
+                          std::unique_ptr<MCCodeEmitter> emitter,
+                          std::unique_ptr<MCAsmBackend> asmbackend)
+      : MCStreamer(Context), OSOwner(std::move(os)), OS(*OSOwner),
+        MAI(Context.getAsmInfo()), InstPrinter(printer),
+        Assembler(std::make_unique<MCAssembler>(
+            Context, std::move(asmbackend), std::move(emitter),
+            (asmbackend) ? asmbackend->createObjectWriter(NullStream)
+                         : nullptr)),
+        CommentStream(CommentToEmit) {
+    assert(InstPrinter);
+    if (Assembler->getBackendPtr())
+      setAllowAutoPadding(Assembler->getBackend().allowAutoPadding());
+
+    Context.setUseNamesOnTempLabels(true);
+    auto *TO = Context.getTargetOptions();
+    if (!TO)
+      return;
+    IsVerboseAsm = TO->AsmVerbose;
+    if (IsVerboseAsm)
+      InstPrinter->setCommentStream(CommentStream);
+  }
+
+  MCAssembler &getAssembler() { return *Assembler; }
+
+  /// Return true if this streamer supports verbose assembly at all.
+  bool isVerboseAsm() const override { return IsVerboseAsm; }
+
+  /// Do we support EmitRawText?
+  bool hasRawTextSupport() const override { return true; }
+
+  /// @name MCStreamer Interface
+  /// @{
+
+  void changeSection(MCSection *Section, uint32_t Subsection) override;
+
+  void emitLabel(MCSymbol *Symbol, SMLoc Loc) override;
+  bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override {
+    return false;
+  }
+
+  void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
+                        Align ByteAlignment) override {}
+
+  void emitZerofill(MCSection *Section, MCSymbol *Symbol = nullptr,
+                    uint64_t Size = 0, Align ByteAlignment = Align(1),
+                    SMLoc Loc = SMLoc()) override {}
+
+  /// @}
+};

--- a/llvm/test/CodeGen/SystemZ/zos-hlasm-out.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-hlasm-out.ll
@@ -1,0 +1,9 @@
+; RUN: llc < %s -emit-gnuas-syntax-on-zos=0 --mtriple=s390x-ibm-zos | FileCheck --match-full-lines %s
+
+; empty function
+; CHECK: foo
+; CHECK-NEXT: L#func_end0
+define void @foo() {
+entry:
+  ret void
+}


### PR DESCRIPTION
Building on top of https://github.com/llvm/llvm-project/pull/107415

Introduce a skeleton implementation of a new SystemZ specific HLASM asm streamer base on current `MCAsmStreamer`. Since this will require some migration for z/OS specific testcases, adding an option to help with the migration process. 