### PR TITLE
[HLSL] Add HLSL 202y language mode

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1535,8 +1535,10 @@ def PedanticMacros : DiagGroup<"pedantic-macros",
 def BranchProtection : DiagGroup<"branch-protection">;
 
 // HLSL diagnostic groups
+def HLSL202y : DiagGroup<"hlsl-202y-extensions">;
+
 // Warnings for HLSL Clang extensions
-def HLSLExtension : DiagGroup<"hlsl-extensions">;
+def HLSLExtension : DiagGroup<"hlsl-extensions", [HLSL202y]>;
 
 // Warning for mix packoffset and non-packoffset.
 def HLSLMixPackOffset : DiagGroup<"mix-packoffset">;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1073,7 +1073,10 @@ def err_expected_lambda_body : Error<"expected body of lambda expression">;
 def warn_cxx98_compat_lambda : Warning<
   "lambda expressions are incompatible with C++98">,
   InGroup<CXX98Compat>, DefaultIgnore;
-def ext_lambda : ExtWarn<"lambdas are a C++11 extension">, InGroup<CXX11>;
+def ext_lambda : ExtWarn<"lambdas are a %select{C++11|clang HLSL}0 extension">,
+  InGroup<CXX11>;
+def ext_hlsl_lambda : ExtWarn<ext_lambda.Summary>,
+  InGroup<HLSLExtension>;
 def err_lambda_decl_specifier_repeated : Error<
   "%select{'mutable'|'static'|'constexpr'|'consteval'}0 cannot "
   "appear multiple times in a lambda declarator">;
@@ -1790,7 +1793,5 @@ def ext_hlsl_access_specifiers : ExtWarn<
   InGroup<HLSLExtension>;
 def err_hlsl_unsupported_component : Error<"invalid component '%0' used; expected 'x', 'y', 'z', or 'w'">;
 def err_hlsl_packoffset_invalid_reg : Error<"invalid resource class specifier '%0' for packoffset, expected 'c'">;
-def ext_hlsl_lambda : ExtWarn<"lambdas are a clang HLSL extension">,
-  InGroup<HLSLExtension>;
 
 } // end of Parser diagnostics

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1790,5 +1790,7 @@ def ext_hlsl_access_specifiers : ExtWarn<
   InGroup<HLSLExtension>;
 def err_hlsl_unsupported_component : Error<"invalid component '%0' used; expected 'x', 'y', 'z', or 'w'">;
 def err_hlsl_packoffset_invalid_reg : Error<"invalid resource class specifier '%0' for packoffset, expected 'c'">;
+def ext_hlsl_lambda : ExtWarn<"lambdas are a clang HLSL extension">,
+  InGroup<HLSLExtension>;
 
 } // end of Parser diagnostics

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -267,7 +267,10 @@ def err_invalid_width_spec : Error<
 def err_invalid_complex_spec : Error<"'_Complex %0' is invalid">;
 
 def ext_auto_type_specifier : ExtWarn<
-  "'auto' type specifier is a C++11 extension">, InGroup<CXX11>;
+  "'auto' type specifier is a %select{C++11|HLSL 202y}0 extension">,
+  InGroup<CXX11>;
+def ext_hlsl_auto_type_specifier : ExtWarn<
+  ext_auto_type_specifier.Summary>, InGroup<HLSL202y>;
 def warn_auto_storage_class : Warning<
   "'auto' storage class specifier is redundant and incompatible with C++11">,
   InGroup<CXX11Compat>, DefaultIgnore;
@@ -12396,9 +12399,6 @@ def warn_attr_min_eq_max:  Warning<
 
 def err_hlsl_attribute_number_arguments_insufficient_shader_model: Error<
   "attribute %0 with %1 arguments requires shader model %2 or greater">;
-
-def ext_hlsl_auto_type_specifier : ExtWarn<
-  "'auto' type specifier is a HLSL 202y extension">, InGroup<HLSL202y>;
 
 // Layout randomization diagnostics.
 def err_non_designated_init_used : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12397,6 +12397,9 @@ def warn_attr_min_eq_max:  Warning<
 def err_hlsl_attribute_number_arguments_insufficient_shader_model: Error<
   "attribute %0 with %1 arguments requires shader model %2 or greater">;
 
+def ext_hlsl_auto_type_specifier : ExtWarn<
+  "'auto' type specifier is a HLSL 202y extension">, InGroup<HLSL202y>;
+
 // Layout randomization diagnostics.
 def err_non_designated_init_used : Error<
   "a randomized struct can only be initialized with a designated initializer">;

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -160,7 +160,8 @@ public:
     HLSL_2017 = 2017,
     HLSL_2018 = 2018,
     HLSL_2021 = 2021,
-    HLSL_202x = 2029,
+    HLSL_202x = 2028,
+    HLSL_202y = 2029,
   };
 
   /// Clang versions with different platform ABI conformance.

--- a/clang/include/clang/Basic/LangStandards.def
+++ b/clang/include/clang/Basic/LangStandards.def
@@ -256,6 +256,10 @@ LANGSTANDARD(hlsl202x, "hlsl202x",
              HLSL, "High Level Shader Language 202x",
              LineComment | HLSL | CPlusPlus | CPlusPlus11)
 
+LANGSTANDARD(hlsl202y, "hlsl202y",
+             HLSL, "High Level Shader Language 202y",
+             LineComment | HLSL | CPlusPlus | CPlusPlus11)
+
 
 #undef LANGSTANDARD
 #undef LANGSTANDARD_ALIAS

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8914,7 +8914,7 @@ def dxc_hlsl_version : Option<["/", "-"], "HV", KIND_JOINED_OR_SEPARATE>,
                      Group<dxc_Group>,
                      Visibility<[DXCOption]>,
                      HelpText<"HLSL Version">,
-                     Values<"2016, 2017, 2018, 2021, 202x">;
+                     Values<"2016, 2017, 2018, 2021, 202x, 202y">;
 def dxc_validator_path_EQ : Joined<["--"], "dxv-path=">, Group<dxc_Group>,
   HelpText<"DXIL validator installation path">;
 def dxc_disable_validation : DXCFlag<"Vd">,

--- a/clang/lib/Basic/LangOptions.cpp
+++ b/clang/lib/Basic/LangOptions.cpp
@@ -159,6 +159,8 @@ void LangOptions::setLangDefaults(LangOptions &Opts, Language Lang,
     Opts.HLSLVersion = (unsigned)LangOptions::HLSL_2021;
   else if (LangStd == LangStandard::lang_hlsl202x)
     Opts.HLSLVersion = (unsigned)LangOptions::HLSL_202x;
+  else if (LangStd == LangStandard::lang_hlsl202y)
+    Opts.HLSLVersion = (unsigned)LangOptions::HLSL_202y;
 
   // OpenCL has some additional defaults.
   if (Opts.OpenCL) {

--- a/clang/lib/Basic/LangStandards.cpp
+++ b/clang/lib/Basic/LangStandards.cpp
@@ -78,6 +78,7 @@ LangStandard::Kind LangStandard::getHLSLLangKind(StringRef Name) {
       .Case("2018", LangStandard::lang_hlsl2018)
       .Case("2021", LangStandard::lang_hlsl2021)
       .Case("202x", LangStandard::lang_hlsl202x)
+      .Case("202y", LangStandard::lang_hlsl202y)
       .Default(LangStandard::lang_unspecified);
 }
 

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1344,11 +1344,13 @@ static void DiagnoseStaticSpecifierRestrictions(Parser &P,
 ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
                      LambdaIntroducer &Intro) {
   SourceLocation LambdaBeginLoc = Intro.Range.getBegin();
-  Diag(LambdaBeginLoc, getLangOpts().CPlusPlus11
-                           ? diag::warn_cxx98_compat_lambda
-                           : diag::ext_lambda);
   if (getLangOpts().HLSL)
-    Diag(LambdaBeginLoc, diag::ext_hlsl_lambda);
+    Diag(LambdaBeginLoc, diag::ext_hlsl_lambda) << /*HLSL*/ 1;
+  else
+    Diag(LambdaBeginLoc, getLangOpts().CPlusPlus11
+                             ? diag::warn_cxx98_compat_lambda
+                             : diag::ext_lambda)
+        << /*C++*/ 0;
 
   PrettyStackTraceLoc CrashInfo(PP.getSourceManager(), LambdaBeginLoc,
                                 "lambda expression parsing");

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1347,6 +1347,8 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
   Diag(LambdaBeginLoc, getLangOpts().CPlusPlus11
                            ? diag::warn_cxx98_compat_lambda
                            : diag::ext_lambda);
+  if (getLangOpts().HLSL)
+    Diag(LambdaBeginLoc, diag::ext_hlsl_lambda);
 
   PrettyStackTraceLoc CrashInfo(PP.getSourceManager(), LambdaBeginLoc,
                                 "lambda expression parsing");

--- a/clang/lib/Sema/DeclSpec.cpp
+++ b/clang/lib/Sema/DeclSpec.cpp
@@ -1418,11 +1418,11 @@ void DeclSpec::Finish(Sema &S, const PrintingPolicy &Policy) {
   // specifier in a pre-C++11 dialect of C++ or in a pre-C23 dialect of C.
   if (!S.getLangOpts().CPlusPlus11 && !S.getLangOpts().C23 &&
       TypeSpecType == TST_auto)
-    S.Diag(TSTLoc, diag::ext_auto_type_specifier);
+    S.Diag(TSTLoc, diag::ext_auto_type_specifier) << /*C++*/ 0;
   if (S.getLangOpts().HLSL &&
       S.getLangOpts().getHLSLVersion() < LangOptions::HLSL_202y &&
       TypeSpecType == TST_auto)
-    S.Diag(TSTLoc, diag::ext_hlsl_auto_type_specifier);
+    S.Diag(TSTLoc, diag::ext_hlsl_auto_type_specifier) << /*HLSL*/ 1;
   if (S.getLangOpts().CPlusPlus && !S.getLangOpts().CPlusPlus11 &&
       StorageClassSpec == SCS_auto)
     S.Diag(StorageClassSpecLoc, diag::warn_auto_storage_class)

--- a/clang/lib/Sema/DeclSpec.cpp
+++ b/clang/lib/Sema/DeclSpec.cpp
@@ -1419,6 +1419,10 @@ void DeclSpec::Finish(Sema &S, const PrintingPolicy &Policy) {
   if (!S.getLangOpts().CPlusPlus11 && !S.getLangOpts().C23 &&
       TypeSpecType == TST_auto)
     S.Diag(TSTLoc, diag::ext_auto_type_specifier);
+  if (S.getLangOpts().HLSL &&
+      S.getLangOpts().getHLSLVersion() < LangOptions::HLSL_202y &&
+      TypeSpecType == TST_auto)
+    S.Diag(TSTLoc, diag::ext_hlsl_auto_type_specifier);
   if (S.getLangOpts().CPlusPlus && !S.getLangOpts().CPlusPlus11 &&
       StorageClassSpec == SCS_auto)
     S.Diag(StorageClassSpecLoc, diag::warn_auto_storage_class)

--- a/clang/test/ParserHLSL/group_shared.hlsl
+++ b/clang/test/ParserHLSL/group_shared.hlsl
@@ -1,12 +1,12 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - -fsyntax-only %s -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -std=hlsl202x -o - -fsyntax-only %s -verify
 extern groupshared float f;
 extern float groupshared f; // Ok, redeclaration?
 
 
-// expected-warning@+3 {{lambdas are a C++11 extension}}
-// expected-error@+2   {{expected body of lambda expression}}
-// expected-warning@+1 {{'auto' type specifier is a C++11 extension}}
-auto l = []() groupshared  {};
+// expected-warning@#gs_lambda {{lambdas are a clang HLSL extension}}
+// expected-error@#gs_lambda {{expected body of lambda expression}}
+// expected-warning@#gs_lambda {{'auto' type specifier is a HLSL 202y extension}}
+auto l = []() groupshared  {}; // #gs_lambda
 
 float groupshared [[]] i = 12;
 

--- a/clang/test/ParserHLSL/group_shared_202x.hlsl
+++ b/clang/test/ParserHLSL/group_shared_202x.hlsl
@@ -2,10 +2,14 @@
 extern groupshared float f;
 extern float groupshared f; // Ok, redeclaration?
 
-// expected-error@+1 {{return type cannot be qualified with address space}}
-auto l = []() -> groupshared void {};
-// expected-error@+1 {{expected a type}}
-auto l2 = []() -> groupshared {};
+// expected-error@#l {{return type cannot be qualified with address space}}
+// expected-warning@#l {{lambdas are a clang HLSL extension}}
+// expected-warning@#l{{'auto' type specifier is a HLSL 202y extension}}
+auto l = []() -> groupshared void {}; // #l
+// expected-error@#l2 {{expected a type}}
+// expected-warning@#l2 {{lambdas are a clang HLSL extension}}
+// expected-warning@#l2{{'auto' type specifier is a HLSL 202y extension}}
+auto l2 = []() -> groupshared {}; // #l2
 
 float groupshared [[]] i = 12;
 
@@ -17,13 +21,19 @@ void foo() {
 
 extern groupshared float f;
 const float cf = f;
-// expected-error@+1 {{'auto' return without trailing return type; deduced return types are a C++14 extension}}
-auto func() {
+// expected-error@#func{{'auto' return without trailing return type; deduced return types are a C++14 extension}}
+// expected-warning@#func{{'auto' type specifier is a HLSL 202y extension}}
+auto func() { // #func
   return f;
 }
 
 void other() {
-  // NOTE: groupshared and const are stripped off thanks to lvalue to rvalue conversions and we deduce float for the return type.
-  auto l = [&]() { return f; };
-  auto l2 = [&]() { return cf; };
+  // NOTE: groupshared and const are stripped off thanks to lvalue to rvalue
+  // conversions and we deduce float for the return type.
+  // expected-warning@#local{{lambdas are a clang HLSL extension}}
+  // expected-warning@#local{{'auto' type specifier is a HLSL 202y extension}}
+  auto l = [&]() { return f; }; // #local
+  // expected-warning@#local2{{lambdas are a clang HLSL extension}}
+  // expected-warning@#local2{{'auto' type specifier is a HLSL 202y extension}}
+  auto l2 = [&]() { return cf; }; // #local2
 }

--- a/clang/test/ParserHLSL/invalid_inside_cb.hlsl
+++ b/clang/test/ParserHLSL/invalid_inside_cb.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - -fsyntax-only %s -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -std=hlsl202x -o - -fsyntax-only %s -verify
 
 // template not allowed inside cbuffer.
 cbuffer A {
@@ -15,7 +15,6 @@ cbuffer A {
 
 // typealias not allowed inside cbuffer.
 cbuffer A {
-    // expected-error@+2 {{invalid declaration inside cbuffer}}
-    // expected-warning@+1 {{alias declarations are a C++11 extension}}
+    // expected-error@+1 {{invalid declaration inside cbuffer}}
     using F32 = float;
 }

--- a/clang/test/Preprocessor/predefined-macros-hlsl.hlsl
+++ b/clang/test/Preprocessor/predefined-macros-hlsl.hlsl
@@ -50,4 +50,7 @@
 // STD2021: #define __HLSL_VERSION 2021
 
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl202x | FileCheck -match-full-lines %s --check-prefixes=STD202x
-// STD202x: #define __HLSL_VERSION 2029
+// STD202x: #define __HLSL_VERSION 2028
+
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl202y | FileCheck -match-full-lines %s --check-prefixes=STD202y
+// STD202y: #define __HLSL_VERSION 2029

--- a/clang/test/SemaHLSL/group_shared.hlsl
+++ b/clang/test/SemaHLSL/group_shared.hlsl
@@ -72,9 +72,10 @@ groupshared void (*fp)();
 // expected-error@+1 {{parameter may not be qualified with an address space}}
 void (*fp2)(groupshared float);
 // NOTE: HLSL not support trailing return types.
-// expected-warning@+2 {{'auto' type specifier is a C++11 extension}}
-// expected-error@+1 {{expected function body after function declarator}}
-auto func() -> groupshared void;
+// expected-warning@#func{{'auto' type specifier is a HLSL 202y extension}}
+// expected-warning@#func {{'auto' type specifier is a C++11 extension}}
+// expected-error@#func {{expected function body after function declarator}}
+auto func() -> groupshared void; // #func
 // expected-warning@+2 {{'groupshared' attribute only applies to variables}}
 // expected-error@+1 {{return type cannot be qualified with address space}}
 void groupshared f();

--- a/clang/test/SemaHLSL/group_shared_202x.hlsl
+++ b/clang/test/SemaHLSL/group_shared_202x.hlsl
@@ -1,16 +1,27 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -std=hlsl202x  -o - -fsyntax-only %s -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -std=hlsl202y  -o - -fsyntax-only %s -verify
 
-// expected-error@+1 {{return type cannot be qualified with address space}}
-auto func() -> groupshared void;
+#if __HLSL_VERSION < 2029
+// expected-warning@#func{{'auto' type specifier is a HLSL 202y extension}}
+// expected-warning@#func_gs{{'auto' type specifier is a HLSL 202y extension}}
+// expected-warning@#l{{'auto' type specifier is a HLSL 202y extension}}
+// expected-warning@#l2{{'auto' type specifier is a HLSL 202y extension}}
+#endif
 
-// expected-error@+1 {{parameter may not be qualified with an address space}}
-auto func(float groupshared) -> void;
+// expected-error@#func {{return type cannot be qualified with address space}}
+auto func() -> groupshared void; // #func
 
-// expected-error@+1 {{parameter may not be qualified with an address space}}
-auto l = [](groupshared float ) {};
+// expected-error@#func_gs {{parameter may not be qualified with an address space}}
+auto func(float groupshared) -> void; // #func_gs
 
-// expected-error@+1 {{return type cannot be qualified with address space}}
-auto l2 = []() -> groupshared void {};
+
+// expected-error@#l {{parameter may not be qualified with an address space}}
+// expected-warning@#l {{lambdas are a clang HLSL extension}}
+auto l = [](groupshared float ) {}; // #l
+
+// expected-error@#l2 {{return type cannot be qualified with address space}}
+// expected-warning@#l2 {{lambdas are a clang HLSL extension}}
+auto l2 = []() -> groupshared void {}; // #l2
 
 struct S {
 // expected-error@+1 {{return type cannot be qualified with address space}}


### PR DESCRIPTION
This change adds a new HLSL 202y language mode. Currently HLSL 202y is planned to add `auto` and `constexpr`.

This change updates extension diagnostics to state that lambadas are a "clang HLSL" extension (since we have no planned release yet to include them), and that `auto` is a HLSL 202y extension when used in earlier language modes.

Note: This PR does temporarily work around some differences between HLSL 2021 and 202x in Clang by changing test cases to explicitly specify 202x. A subsequent PR will update 2021's language flags to match 202x.