### PR TITLE
[test][compiler-rt] Mark dlsym_alloc.c as unsupported on macos

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/dlsym_alloc.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/dlsym_alloc.c
@@ -2,6 +2,8 @@
 
 // FIXME: TSAN does not use DlsymAlloc.
 // UNSUPPORTED: tsan
+// FIXME: investigate why this fails on macos
+// UNSUPPORTED: darwin
 
 #include <stdlib.h>
 


### PR DESCRIPTION
With #106912, the test now fails on macos, e.g.

https://green.lab.llvm.org/job/llvm.org/job/clang-stage1-RA/2058/.