### PR TITLE
[HLSL] Fix move assignment of `this`

### DIFF
--- a/clang/test/CodeGenHLSL/this-assignment.hlsl
+++ b/clang/test/CodeGenHLSL/this-assignment.hlsl
@@ -56,7 +56,6 @@ void main() {
 
 // CHECK-LABEL:     define {{.*}}DoSilly
 // CHECK-NEXT:entry:
-
 // CHECK-NEXT: [[ResPtr:%.*]] = alloca ptr
 // CHECK-NEXT: [[ThisPtrAddr:%.*]] = alloca ptr
 // CHECK-NEXT: store ptr [[AggRes:%.*]], ptr [[ResPtr]]

--- a/clang/test/CodeGenHLSL/this-assignment.hlsl
+++ b/clang/test/CodeGenHLSL/this-assignment.hlsl
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -emit-llvm -disable-llvm-passes -o - -hlsl-entry main %s | FileCheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -emit-llvm -disable-llvm-passes -o - -hlsl-entry main %s | FileCheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -std=hlsl202x -emit-llvm -disable-llvm-passes -o - -hlsl-entry main %s | FileCheck %s
 
 struct Pair {
   int First;
@@ -10,9 +11,17 @@ struct Pair {
 	  return this.First;
   }
 
+  // In HLSL 202x, this is a move assignment rather than a copy.
   int getSecond() {
     this = Pair();
     return Second;
+  }
+
+  // In HLSL 202x, this is a copy assignment.
+  Pair DoSilly(Pair Obj) {
+    this = Obj;
+    First += 2;
+    return Obj;
   }
 };
 
@@ -21,10 +30,11 @@ void main() {
   Pair Vals = {1, 2.0};
   Vals.First = Vals.getFirst();
   Vals.Second = Vals.getSecond();
+  (void) Vals.DoSilly(Vals);
 }
 
 // This tests reference like implicit this in HLSL
-// CHECK:     define linkonce_odr noundef i32 @"?getFirst@Pair@@QAAHXZ"(ptr noundef nonnull align 4 dereferenceable(8) %this) #0 align 2 {
+// CHECK-LABEL:     define {{.*}}getFirst
 // CHECK-NEXT:entry:
 // CHECK-NEXT:%this.addr = alloca ptr, align 4
 // CHECK-NEXT:%Another = alloca %struct.Pair, align 4
@@ -34,7 +44,7 @@ void main() {
 // CHECK-NEXT:call void @llvm.memcpy.p0.p0.i32(ptr align 4 %this1, ptr align 4 %Another, i32 8, i1 false)
 // CHECK-NEXT:%First = getelementptr inbounds nuw %struct.Pair, ptr %this1, i32 0, i32 0
 
-// CHECK:     define linkonce_odr noundef i32 @"?getSecond@Pair@@QAAHXZ"(ptr noundef nonnull align 4 dereferenceable(8) %this) #0 align 2 {
+// CHECK-LABEL:     define {{.*}}getSecond
 // CHECK-NEXT:entry:
 // CHECK-NEXT:%this.addr = alloca ptr, align 4
 // CHECK-NEXT:%ref.tmp = alloca %struct.Pair, align 4
@@ -43,3 +53,18 @@ void main() {
 // CHECK-NEXT:call void @llvm.memset.p0.i32(ptr align 4 %ref.tmp, i8 0, i32 8, i1 false)
 // CHECK-NEXT:call void @llvm.memcpy.p0.p0.i32(ptr align 4 %this1, ptr align 4 %ref.tmp, i32 8, i1 false)
 // CHECK-NEXT:%Second = getelementptr inbounds nuw %struct.Pair, ptr %this1, i32 0, i32 1
+
+// CHECK-LABEL:     define {{.*}}DoSilly
+// CHECK-NEXT:entry:
+
+// CHECK-NEXT: [[ResPtr:%.*]] = alloca ptr
+// CHECK-NEXT: [[ThisPtrAddr:%.*]] = alloca ptr
+// CHECK-NEXT: store ptr [[AggRes:%.*]], ptr [[ResPtr]]
+// CHECK-NEXT: store ptr {{.*}}, ptr [[ThisPtrAddr]]
+// CHECK-NEXT: [[ThisPtr:%.*]] = load ptr, ptr [[ThisPtrAddr]]
+// CHECK-NEXT: call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[ThisPtr]], ptr align 4 [[Obj:%.*]], i32 8, i1 false)
+// CHECK-NEXT: [[FirstAddr:%.*]] = getelementptr inbounds nuw %struct.Pair, ptr [[ThisPtr]], i32 0, i32 0
+// CHECK-NEXT: [[First:%.*]] = load i32, ptr [[FirstAddr]]
+// CHECK-NEXT: [[FirstPlusTwo:%.*]] = add nsw i32 [[First]], 2
+// CHECK-NEXT: store i32 [[FirstPlusTwo]], ptr [[FirstAddr]]
+// CHECK-NEXT: call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[AggRes]], ptr align 4 [[Obj]], i32 8, i1 false)


### PR DESCRIPTION
Under HLSL 202x+ move assignment can occur and when targeting `this` move assignment was generating some really odd errors. This corrects the errors by properly generating the `this` object reference for HLSL and always treating it as a reference.

This mirrors the implementation added eariler for copy assignment, and extends the test case to cover both move and copy assignment under HLSL 202x+.