### PR TITLE
[CMake] Remove requirement of NumPy header files

### DIFF
--- a/mlir/cmake/modules/MLIRDetectPythonEnv.cmake
+++ b/mlir/cmake/modules/MLIRDetectPythonEnv.cmake
@@ -19,7 +19,7 @@ macro(mlir_configure_python_dev_packages)
   set(_python_development_component Development.Module)
 
   find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION}
-    COMPONENTS Interpreter ${_python_development_component} NumPy REQUIRED)
+    COMPONENTS Interpreter ${_python_development_component} REQUIRED)
   unset(_python_development_component)
   message(STATUS "Found python include dirs: ${Python3_INCLUDE_DIRS}")
   message(STATUS "Found python libraries: ${Python3_LIBRARIES}")


### PR DESCRIPTION
NumPy header files were required for building MLIR, however the NumPy C-API is never used. In other words, NumPy is not a build time dependency. `numpy`, the python package, is required at runtime for the python bindings tests. In particular the file `mlir/python/mlir/runtime/np_to_memref.py` and all tests which may use it. This commit removes the build time dependency, but the runtime dependency remains through the `requirements.txt` file.