### PR TITLE
[WebAssembly] Create separate file for EH assembly tests

### DIFF
--- a/llvm/test/MC/WebAssembly/basic-assembly.s
+++ b/llvm/test/MC/WebAssembly/basic-assembly.s
@@ -1,6 +1,6 @@
-# RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+tail-call,+reference-types,atomics,+simd128,+nontrapping-fptoint,+exception-handling < %s | FileCheck %s
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+tail-call,+reference-types,atomics,+simd128,+nontrapping-fptoint < %s | FileCheck %s
 # Check that it converts to .o without errors, but don't check any output:
-# RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj -mattr=+tail-call,+reference-types,+atomics,+simd128,+nontrapping-fptoint,+exception-handling -o %t.o < %s
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj -mattr=+tail-call,+reference-types,+atomics,+simd128,+nontrapping-fptoint -o %t.o < %s
 
 .functype   something1 () -> ()
 .functype   something2 (i64) -> (i32, f64)
@@ -107,19 +107,14 @@ test0:
     #i32x4.trunc_sat_f32x4_s
     f32.const   1.0
     i32.trunc_f32_s
-    try
     i32.atomic.load 0
     i32.const   0
     memory.atomic.notify 0
     drop
 .LBB0_3:
-    catch       __cpp_exception
-    local.set   0
-    end_try
     i32.const   .L.str
     i32.load8_u .L.str+2
     i32.load16_u .L.str:p2align=0
-    throw 0
 .LBB0_4:
     #i32.trunc_sat_f32_s
     global.get  __stack_pointer
@@ -249,19 +244,14 @@ empty_exnref_table:
 # CHECK-NEXT:      drop
 # CHECK-NEXT:      f32.const   0x1p0
 # CHECK-NEXT:      i32.trunc_f32_s
-# CHECK-NEXT:      try
 # CHECK-NEXT:      i32.atomic.load 0
 # CHECK-NEXT:      i32.const   0
 # CHECK-NEXT:      memory.atomic.notify 0
 # CHECK-NEXT:      drop
 # CHECK-NEXT:  .LBB0_3:
-# CHECK-NEXT:      catch       __cpp_exception
-# CHECK-NEXT:      local.set   0
-# CHECK-NEXT:      end_try
 # CHECK-NEXT:      i32.const   .L.str
 # CHECK-NEXT:      i32.load8_u .L.str+2
 # CHECK-NEXT:      i32.load16_u .L.str:p2align=0
-# CHECK-NEXT:      throw       0
 # CHECK-NEXT:  .LBB0_4:
 # CHECK-NEXT:      global.get  __stack_pointer
 # CHECK-NEXT:      global.set  __stack_pointer

--- a/llvm/test/MC/WebAssembly/eh-assembly.s
+++ b/llvm/test/MC/WebAssembly/eh-assembly.s
@@ -1,0 +1,65 @@
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+exception-handling < %s | FileCheck %s
+# Check that it converts to .o without errors, but don't check any output:
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj -mattr=+exception-handling -o %t.o < %s
+
+  .tagtype  __cpp_exception i32
+  .tagtype  __c_longjmp i32
+  .functype  eh_legacy_test () -> ()
+  .functype  foo () -> ()
+
+eh_legacy_test:
+  # try-catch with catch, catch_all, throw, and rethrow
+  try
+    throw     __cpp_exception
+  catch       __cpp_exception
+    drop
+    rethrow 0
+  catch       __c_longjmp
+    drop
+  catch_all
+    rethrow 0
+  end_try
+
+  # try-catch with a return value
+  try i32
+    i32.const 0
+  catch       __cpp_exception
+  end_try
+  drop
+
+  # Nested try-catch with a rethrow
+  try
+    call  foo
+  catch_all
+    try
+    catch_all
+      rethrow 1
+    end_try
+  end_try
+  end_function
+
+# CHECK-LABEL: eh_legacy_test:
+# CHECK-NEXT:    try
+# CHECK-NEXT:    throw           __cpp_exception
+# CHECK-NEXT:    catch           __cpp_exception
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    rethrow         0
+# CHECK-NEXT:    catch           __c_longjmp
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    catch_all
+# CHECK-NEXT:    rethrow         0
+# CHECK-NEXT:    end_try
+# CHECK:         try             i32
+# CHECK-NEXT:    i32.const       0
+# CHECK-NEXT:    catch           __cpp_exception
+# CHECK-NEXT:    end_try
+# CHECK-NEXT:    drop
+# CHECK:         try
+# CHECK-NEXT:    call    foo
+# CHECK-NEXT:    catch_all
+# CHECK-NEXT:    try
+# CHECK-NEXT:    catch_all
+# CHECK-NEXT:    rethrow         1
+# CHECK-NEXT:    end_try
+# CHECK-NEXT:    end_try
+# CHECK-NEXT:    end_function

--- a/llvm/test/MC/WebAssembly/eh-assembly.s
+++ b/llvm/test/MC/WebAssembly/eh-assembly.s
@@ -20,13 +20,6 @@ eh_legacy_test:
     rethrow 0
   end_try
 
-  # try-catch with a return value
-  try i32
-    i32.const 0
-  catch       __cpp_exception
-  end_try
-  drop
-
   # Nested try-catch with a rethrow
   try
     call  foo
@@ -36,6 +29,13 @@ eh_legacy_test:
       rethrow 1
     end_try
   end_try
+
+  # try-catch with a single return value
+  try i32
+    i32.const 0
+  catch       __cpp_exception
+  end_try
+  drop
   end_function
 
 # CHECK-LABEL: eh_legacy_test:
@@ -49,11 +49,7 @@ eh_legacy_test:
 # CHECK-NEXT:    catch_all
 # CHECK-NEXT:    rethrow         0
 # CHECK-NEXT:    end_try
-# CHECK:         try             i32
-# CHECK-NEXT:    i32.const       0
-# CHECK-NEXT:    catch           __cpp_exception
-# CHECK-NEXT:    end_try
-# CHECK-NEXT:    drop
+
 # CHECK:         try
 # CHECK-NEXT:    call    foo
 # CHECK-NEXT:    catch_all
@@ -62,4 +58,10 @@ eh_legacy_test:
 # CHECK-NEXT:    rethrow         1
 # CHECK-NEXT:    end_try
 # CHECK-NEXT:    end_try
+
+# CHECK:         try             i32
+# CHECK-NEXT:    i32.const       0
+# CHECK-NEXT:    catch           __cpp_exception
+# CHECK-NEXT:    end_try
+# CHECK-NEXT:    drop
 # CHECK-NEXT:    end_function


### PR DESCRIPTION
Create `eh-assembly.s` that contains EH tests and remove EH tests from `basic-assembly.s`, given that it's easier to manage. (We can have many different tests, including the legacy EH and the new exnref, and with nesting for readability)