### PR TITLE
[Coverage] Skip empty profile name section

### DIFF
--- a/llvm/lib/ProfileData/Coverage/CoverageMappingReader.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMappingReader.cpp
@@ -1061,9 +1061,11 @@ lookupSections(ObjectFile &OF, InstrProfSectKind IPSK) {
     if (!NameOrErr)
       return NameOrErr.takeError();
     if (stripSuffix(*NameOrErr) == Name) {
+      // Skip empty profile name section.
       // COFF profile name section contains two null bytes indicating the
       // start/end of the section. If its size is 2 bytes, it's empty.
-      if (IsCOFF && IPSK == IPSK_name && Section.getSize() == 2)
+      if (IPSK == IPSK_name &&
+          (Section.getSize() == 0 || (IsCOFF && Section.getSize() == 2)))
         continue;
       Sections.push_back(Section);
     }


### PR DESCRIPTION
llvm-cov reads __llvm_prf_names section in an object file to find the profile names, and it instead reads __llvm_covnames section in binary profile correlation mode when __llvm_prf_names section is omitted. This patch ensures that it still reads __llvm_covnames section when there is an empty __llvm_prf_names section.