### PR TITLE
[RISCV] Rename XCValu cv.slet(u) to cv.sle(u).

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -203,9 +203,9 @@ let Predicates = [HasVendorXCValu, IsRV32],
   // General ALU Operations
   def CV_ABS    : CVInstAluR<0b0101000, 0b011, "cv.abs">,
                   Sched<[]>;
-  def CV_SLET   : CVInstAluRR<0b0101001, 0b011, "cv.slet">,
+  def CV_SLE    : CVInstAluRR<0b0101001, 0b011, "cv.sle">,
                   Sched<[]>;
-  def CV_SLETU  : CVInstAluRR<0b0101010, 0b011, "cv.sletu">,
+  def CV_SLEU   : CVInstAluRR<0b0101010, 0b011, "cv.sleu">,
                   Sched<[]>;
   def CV_MIN    : CVInstAluRR<0b0101011, 0b011, "cv.min">,
                   Sched<[]>;
@@ -276,6 +276,10 @@ let Predicates = [HasVendorXCValu, IsRV32],
   //   hasSideEffects = 0, mayLoad = 0, mayStore = 0,
   //   Constraints = "$rd = $rd_wb"
 
+let Predicates = [HasVendorXCValu, IsRV32] in {
+  def : MnemonicAlias<"cv.slet", "cv.sle">;
+  def : MnemonicAlias<"cv.sletu", "cv.sleu">;
+}
 
 class CVInstSIMDRR<bits<5> funct5, bit F, bit funct1, bits<3> funct3,
                    RISCVOpcode opcode, dag outs,
@@ -778,8 +782,8 @@ multiclass PatCoreVAluGprGprImm<Intrinsic intr> {
 
 let Predicates = [HasVendorXCValu, IsRV32], AddedComplexity = 1 in {
   def : PatGpr<abs, CV_ABS>;
-  def : PatGprGpr<setle, CV_SLET>;
-  def : PatGprGpr<setule, CV_SLETU>;
+  def : PatGprGpr<setle, CV_SLE>;
+  def : PatGprGpr<setule, CV_SLEU>;
   def : PatGprGpr<smin, CV_MIN>;
   def : PatGprGpr<umin, CV_MINU>;
   def : PatGprGpr<smax, CV_MAX>;

--- a/llvm/test/CodeGen/RISCV/xcvalu.ll
+++ b/llvm/test/CodeGen/RISCV/xcvalu.ll
@@ -20,7 +20,7 @@ define i32 @abs(i32 %a) {
 define i1 @slet(i32 %a, i32 %b) {
 ; CHECK-LABEL: slet:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.slet a0, a0, a1
+; CHECK-NEXT:    cv.sle a0, a0, a1
 ; CHECK-NEXT:    ret
   %1 = icmp sle i32 %a, %b
   ret i1 %1
@@ -29,7 +29,7 @@ define i1 @slet(i32 %a, i32 %b) {
 define i1 @sletu(i32 %a, i32 %b) {
 ; CHECK-LABEL: sletu:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    cv.sletu a0, a0, a1
+; CHECK-NEXT:    cv.sleu a0, a0, a1
 ; CHECK-NEXT:    ret
   %1 = icmp ule i32 %a, %b
   ret i1 %1

--- a/llvm/test/MC/RISCV/corev/XCValu-valid.s
+++ b/llvm/test/MC/RISCV/corev/XCValu-valid.s
@@ -36,15 +36,25 @@ cv.subrnr a0, a1, a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x8c]
 # CHECK-NO-EXT: instruction requires the following: 'XCValu' (CORE-V ALU Operations){{$}}
 
-cv.slet t0, t1, t2
-# CHECK-INSTR: cv.slet t0, t1, t2
+cv.sle t0, t1, t2
+# CHECK-INSTR: cv.sle t0, t1, t2
 # CHECK-ENCODING: [0xab,0x32,0x73,0x52]
 # CHECK-NO-EXT: instruction requires the following: 'XCValu' (CORE-V ALU Operations){{$}}
 
-cv.slet a0, a1, a2
-# CHECK-INSTR: cv.slet a0, a1, a2
+cv.slet t0, t1, t2
+# CHECK-INSTR: cv.sle t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x52]
+# CHECK-NO-EXT: unrecognized instruction mnemonic
+
+cv.sle a0, a1, a2
+# CHECK-INSTR: cv.sle a0, a1, a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x52]
 # CHECK-NO-EXT: instruction requires the following: 'XCValu' (CORE-V ALU Operations){{$}}
+
+cv.slet a0, a1, a2
+# CHECK-INSTR: cv.sle a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x52]
+# CHECK-NO-EXT: unrecognized instruction mnemonic
 
 cv.subrn t0, t1, t2, 0
 # CHECK-INSTR: cv.subrn t0, t1, t2, 0
@@ -261,15 +271,25 @@ cv.extbs a0, a1
 # CHECK-ENCODING: [0x2b,0xb5,0x05,0x64]
 # CHECK-NO-EXT: instruction requires the following: 'XCValu' (CORE-V ALU Operations){{$}}
 
-cv.sletu t0, t1, t2
-# CHECK-INSTR: cv.sletu t0, t1, t2
+cv.sleu t0, t1, t2
+# CHECK-INSTR: cv.sleu t0, t1, t2
 # CHECK-ENCODING: [0xab,0x32,0x73,0x54]
 # CHECK-NO-EXT: instruction requires the following: 'XCValu' (CORE-V ALU Operations){{$}}
 
-cv.sletu a0, a1, a2
-# CHECK-INSTR: cv.sletu a0, a1, a2
+cv.sletu t0, t1, t2
+# CHECK-INSTR: cv.sleu t0, t1, t2
+# CHECK-ENCODING: [0xab,0x32,0x73,0x54]
+# CHECK-NO-EXT: unrecognized instruction mnemonic
+
+cv.sleu a0, a1, a2
+# CHECK-INSTR: cv.sleu a0, a1, a2
 # CHECK-ENCODING: [0x2b,0xb5,0xc5,0x54]
 # CHECK-NO-EXT: instruction requires the following: 'XCValu' (CORE-V ALU Operations){{$}}
+
+cv.sletu a0, a1, a2
+# CHECK-INSTR: cv.sleu a0, a1, a2
+# CHECK-ENCODING: [0x2b,0xb5,0xc5,0x54]
+# CHECK-NO-EXT: unrecognized instruction mnemonic
 
 cv.min t0, t1, t2
 # CHECK-INSTR: cv.min t0, t1, t2


### PR DESCRIPTION
According to https://github.com/openhwgroup/cv32e40p/issues/833 this instruction was renamed last year to remove the 't'.

I used MnemonicAlias to support the old name. Unfortunately, this gives a generic error if XCValu is not enabled. Since its an old name I hope this isn't too big of an issue.

CC: @jeremybennett