### PR TITLE
[llvm-size] Avoid unneeded uses of 'raw_string_ostream::str' (NFC)

### DIFF
--- a/llvm/tools/llvm-size/llvm-size.cpp
+++ b/llvm/tools/llvm-size/llvm-size.cpp
@@ -214,7 +214,7 @@ static void printDarwinSectionSizes(MachOObjectFile *MachO) {
     if (Load.C.cmd == MachO::LC_SEGMENT_64) {
       MachO::segment_command_64 Seg = MachO->getSegment64LoadCommand(Load);
       outs() << "Segment " << Seg.segname << ": "
-             << format(fmt.str().c_str(), Seg.vmsize);
+             << format(fmtbuf.c_str(), Seg.vmsize);
       if (DarwinLongFormat)
         outs() << " (vmaddr 0x" << format("%" PRIx64, Seg.vmaddr) << " fileoff "
                << Seg.fileoff << ")";
@@ -228,7 +228,7 @@ static void printDarwinSectionSizes(MachOObjectFile *MachO) {
                  << format("%.16s", &Sec.sectname) << "): ";
         else
           outs() << "\tSection " << format("%.16s", &Sec.sectname) << ": ";
-        outs() << format(fmt.str().c_str(), Sec.size);
+        outs() << format(fmtbuf.c_str(), Sec.size);
         if (DarwinLongFormat)
           outs() << " (addr 0x" << format("%" PRIx64, Sec.addr) << " offset "
                  << Sec.offset << ")";
@@ -236,12 +236,12 @@ static void printDarwinSectionSizes(MachOObjectFile *MachO) {
         sec_total += Sec.size;
       }
       if (Seg.nsects != 0)
-        outs() << "\ttotal " << format(fmt.str().c_str(), sec_total) << "\n";
+        outs() << "\ttotal " << format(fmtbuf.c_str(), sec_total) << "\n";
     } else if (Load.C.cmd == MachO::LC_SEGMENT) {
       MachO::segment_command Seg = MachO->getSegmentLoadCommand(Load);
       uint64_t Seg_vmsize = Seg.vmsize;
       outs() << "Segment " << Seg.segname << ": "
-             << format(fmt.str().c_str(), Seg_vmsize);
+             << format(fmtbuf.c_str(), Seg_vmsize);
       if (DarwinLongFormat)
         outs() << " (vmaddr 0x" << format("%" PRIx32, Seg.vmaddr) << " fileoff "
                << Seg.fileoff << ")";
@@ -256,7 +256,7 @@ static void printDarwinSectionSizes(MachOObjectFile *MachO) {
         else
           outs() << "\tSection " << format("%.16s", &Sec.sectname) << ": ";
         uint64_t Sec_size = Sec.size;
-        outs() << format(fmt.str().c_str(), Sec_size);
+        outs() << format(fmtbuf.c_str(), Sec_size);
         if (DarwinLongFormat)
           outs() << " (addr 0x" << format("%" PRIx32, Sec.addr) << " offset "
                  << Sec.offset << ")";
@@ -264,10 +264,10 @@ static void printDarwinSectionSizes(MachOObjectFile *MachO) {
         sec_total += Sec.size;
       }
       if (Seg.nsects != 0)
-        outs() << "\ttotal " << format(fmt.str().c_str(), sec_total) << "\n";
+        outs() << "\ttotal " << format(fmtbuf.c_str(), sec_total) << "\n";
     }
   }
-  outs() << "total " << format(fmt.str().c_str(), total) << "\n";
+  outs() << "total " << format(fmtbuf.c_str(), total) << "\n";
 }
 
 /// Print the summary sizes of the standard Mach-O segments in @p MachO.
@@ -399,7 +399,7 @@ static void printObjectSectionSizes(ObjectFile *Obj) {
         << "%" << max_addr_len << "s\n";
 
     // Print header
-    outs() << format(fmt.str().c_str(), static_cast<const char *>("section"),
+    outs() << format(fmtbuf.c_str(), static_cast<const char *>("section"),
                      static_cast<const char *>("size"),
                      static_cast<const char *>("addr"));
     fmtbuf.clear();
@@ -422,13 +422,13 @@ static void printObjectSectionSizes(ObjectFile *Obj) {
 
       uint64_t size = Section.getSize();
       uint64_t addr = Section.getAddress();
-      outs() << format(fmt.str().c_str(), name_or_err->str().c_str(), size, addr);
+      outs() << format(fmtbuf.c_str(), name_or_err->str().c_str(), size, addr);
     }
 
     if (ELFCommons) {
       if (Expected<uint64_t> CommonSizeOrErr = getCommonSize(Obj)) {
         total += *CommonSizeOrErr;
-        outs() << format(fmt.str().c_str(), std::string("*COM*").c_str(),
+        outs() << format(fmtbuf.c_str(), std::string("*COM*").c_str(),
                          *CommonSizeOrErr, static_cast<uint64_t>(0));
       } else {
         error(CommonSizeOrErr.takeError(), Obj->getFileName());
@@ -440,8 +440,7 @@ static void printObjectSectionSizes(ObjectFile *Obj) {
     fmtbuf.clear();
     fmt << "%-" << max_name_len << "s "
         << "%#" << max_size_len << radix_fmt << "\n";
-    outs() << format(fmt.str().c_str(), static_cast<const char *>("Total"),
-                     total)
+    outs() << format(fmtbuf.c_str(), static_cast<const char *>("Total"), total)
            << "\n\n";
   } else {
     // The Berkeley format does not display individual section sizes. It
@@ -498,11 +497,11 @@ static void printObjectSectionSizes(ObjectFile *Obj) {
     fmt << "%#7" << radix_fmt << "\t"
         << "%#7" << radix_fmt << "\t"
         << "%#7" << radix_fmt << "\t";
-    outs() << format(fmt.str().c_str(), total_text, total_data, total_bss);
+    outs() << format(fmtbuf.c_str(), total_text, total_data, total_bss);
     fmtbuf.clear();
     fmt << "%7" << (Radix == octal ? PRIo64 : PRIu64) << "\t"
         << "%7" PRIx64 "\t";
-    outs() << format(fmt.str().c_str(), total, total);
+    outs() << format(fmtbuf.c_str(), total, total);
   }
 }
 
@@ -852,12 +851,12 @@ static void printBerkeleyTotals() {
   fmt << "%#7" << radix_fmt << "\t"
       << "%#7" << radix_fmt << "\t"
       << "%#7" << radix_fmt << "\t";
-  outs() << format(fmt.str().c_str(), TotalObjectText, TotalObjectData,
+  outs() << format(fmtbuf.c_str(), TotalObjectText, TotalObjectData,
                    TotalObjectBss);
   fmtbuf.clear();
   fmt << "%7" << (Radix == octal ? PRIo64 : PRIu64) << "\t"
       << "%7" PRIx64 "\t";
-  outs() << format(fmt.str().c_str(), TotalObjectTotal, TotalObjectTotal)
+  outs() << format(fmtbuf.c_str(), TotalObjectTotal, TotalObjectTotal)
          << "(TOTALS)\n";
 }
 


### PR DESCRIPTION
Remove unnecessary layer of indirection.