### PR TITLE
[clang] Fix incorrect partial ordering context setting

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -3411,7 +3411,7 @@ DeduceTemplateArguments(Sema &S, T *Partial,
   if (TemplateDeductionResult Result = ::DeduceTemplateArguments(
           S, Partial->getTemplateParameters(),
           Partial->getTemplateArgs().asArray(), TemplateArgs, Info, Deduced,
-          /*NumberOfArgumentsMustMatch=*/false, /*PartialOrdering=*/true,
+          /*NumberOfArgumentsMustMatch=*/false, /*PartialOrdering=*/false,
           PackFold::ParameterToArgument,
           /*HasDeducedAnyParam=*/nullptr);
       Result != TemplateDeductionResult::Success)

--- a/clang/test/SemaTemplate/cwg2398.cpp
+++ b/clang/test/SemaTemplate/cwg2398.cpp
@@ -379,3 +379,13 @@ namespace regression1 {
     bar(input);
   }
 } // namespace regression1
+
+namespace regression2 {
+  template <class> struct D {};
+
+  template <class ET, template <class> class VT>
+  struct D<VT<ET>>;
+
+  template <typename, int> struct Matrix;
+  template struct D<Matrix<double, 3>>;
+} // namespace regression2


### PR DESCRIPTION
Fixes regression introduced in #94981, reported on the pull-request.

Since this fixes a commit which was never released, there are no release notes.