### PR TITLE
[Clang][TableGen] Support specifying address space in clang builtin prototypes

### DIFF
--- a/clang/include/clang/Basic/BuiltinsBase.td
+++ b/clang/include/clang/Basic/BuiltinsBase.td
@@ -73,6 +73,13 @@ def Constexpr : Attribute<"E">;
 // Builtin is immediate and must be constant evaluated. Implies Constexpr, and will only be supported in C++20 mode.
 def Consteval : Attribute<"EG">;
 
+// Address space attribute, only valid for pointer or reference arguments.
+// ArgIdx - argument to which the attribute refers. value 0 is for return type.
+// AddrSpaceNum - Address space number for the argument.
+class AddressSpace<int ArgIdx, int AddrSpaceNum> : IndexedAttribute<"", ArgIdx> {
+  int SpaceNum = AddrSpaceNum;
+}
+
 // Builtin kinds
 // =============
 

--- a/clang/test/TableGen/target-builtins-prototype-parser.td
+++ b/clang/test/TableGen/target-builtins-prototype-parser.td
@@ -6,6 +6,12 @@
 // RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_B 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_B
 // RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_C 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_C
 // RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_D 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_D
+// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_E 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_E
+// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_F 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_F
+// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_G 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_G
+// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_H 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_H
+// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_I 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_I
+// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_J 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_J
 
 include "clang/Basic/BuiltinsBase.td"
 
@@ -113,3 +119,68 @@ def : Builtin {
 }
 #endif
 
+def : Builtin {
+// CHECK: BUILTIN(__builtin_test_addrspace_attribute_01, "di*3", "")
+  let Prototype = "double( [[addrspace[3]]] int*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_01"];
+}
+
+def : Builtin {
+// CHECK: BUILTIN(__builtin_test_addrspace_attribute_02, "Ii*5i*d", "")
+  let Prototype = "_Constant [[addrspace[5]]] int* (int*, double)";
+  let Spellings = ["__builtin_test_addrspace_attribute_02"];
+}
+
+def : Builtin {
+// CHECK: BUILTIN(__builtin_test_addrspace_attribute_04, "Ii&4id*7", "")
+  let Prototype = "_Constant [[addrspace[4]]] int& (int , [[addrspace[7]]] double*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+}
+
+#ifdef ERROR_EXPECTED_E
+def : Builtin {
+// ERROR_EXPECTED_E: :[[# @LINE + 1]]:7: error: Expected opening bracket '[' after 'addrspace'
+  let Prototype = "_Constant [[addrspace]] int& (int , double*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+}
+#endif
+
+#ifdef ERROR_EXPECTED_F
+def : Builtin {
+// ERROR_EXPECTED_F: :[[# @LINE + 1]]:7: error: Address space attribute can only be specified with a pointer or reference type
+  let Prototype = "_Constant [[addrspace[4]]] int (int , double*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+}
+#endif
+
+#ifdef ERROR_EXPECTED_G
+def : Builtin {
+// ERROR_EXPECTED_G: :[[# @LINE + 1]]:7: error: Expecetd valid integer for 'addrspace' attribute
+  let Prototype = "_Constant [[addrspace[k]]] int* (int , double*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+}
+#endif
+
+#ifdef ERROR_EXPECTED_H
+def : Builtin {
+// ERROR_EXPECTED_H: :[[# @LINE + 1]]:7: error: Expected closing bracket ']' after address space specification
+  let Prototype = "_Constant [[addrspace[6 int* (int , double*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+}
+#endif
+
+#ifdef ERROR_EXPECTED_I
+def : Builtin {
+// ERROR_EXPECTED_I: :[[# @LINE + 1]]:7: error: Expected closing brackets ']]' for attribute list
+  let Prototype = "_Constant [[addrspace[6] int* (int , double*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+}
+#endif
+
+#ifdef ERROR_EXPECTED_J
+def : Builtin {
+// ERROR_EXPECTED_J: :[[# @LINE + 1]]:7: error: Unknown attribute name specified
+  let Prototype = "_Constant [[invalid]] int* (int , double*)";
+  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+}
+#endif

--- a/clang/test/TableGen/target-builtins-prototype-parser.td
+++ b/clang/test/TableGen/target-builtins-prototype-parser.td
@@ -8,10 +8,6 @@
 // RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_D 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_D
 // RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_E 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_E
 // RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_F 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_F
-// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_G 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_G
-// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_H 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_H
-// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_I 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_I
-// RUN: not clang-tblgen -I %p/../../include/ %s --gen-clang-builtins -DERROR_EXPECTED_J 2>&1 | FileCheck %s --check-prefix=ERROR_EXPECTED_J
 
 include "clang/Basic/BuiltinsBase.td"
 
@@ -121,66 +117,39 @@ def : Builtin {
 
 def : Builtin {
 // CHECK: BUILTIN(__builtin_test_addrspace_attribute_01, "di*3", "")
-  let Prototype = "double( [[addrspace[3]]] int*)";
+  let Prototype = "double(int*)";
   let Spellings = ["__builtin_test_addrspace_attribute_01"];
+  let Attributes = [AddressSpace<1, 3>];
 }
 
 def : Builtin {
-// CHECK: BUILTIN(__builtin_test_addrspace_attribute_02, "Ii*5i*d", "")
-  let Prototype = "_Constant [[addrspace[5]]] int* (int*, double)";
+// CHECK: BUILTIN(__builtin_test_addrspace_attribute_02, "Ii*5i*d", "n")
+  let Prototype = "_Constant int* (int*, double)";
   let Spellings = ["__builtin_test_addrspace_attribute_02"];
+  let Attributes = [AddressSpace<0, 5>, NoThrow];
 }
 
 def : Builtin {
-// CHECK: BUILTIN(__builtin_test_addrspace_attribute_04, "Ii&4id*7", "")
-  let Prototype = "_Constant [[addrspace[4]]] int& (int , [[addrspace[7]]] double*)";
+// CHECK: BUILTIN(__builtin_test_addrspace_attribute_04, "Ii&4id*7", "En")
+  let Prototype = "_Constant int& (int , double*)";
   let Spellings = ["__builtin_test_addrspace_attribute_04"];
+  let Attributes = [AddressSpace<0, 4>, Constexpr, AddressSpace<2, 7>, NoThrow];
 }
 
 #ifdef ERROR_EXPECTED_E
 def : Builtin {
-// ERROR_EXPECTED_E: :[[# @LINE + 1]]:7: error: Expected opening bracket '[' after 'addrspace'
-  let Prototype = "_Constant [[addrspace]] int& (int , double*)";
+// ERROR_EXPECTED_E: :[[# @LINE + 1]]:7: error: Address space attribute for argument 2 repeated
+  let Prototype = "_Constant int& (int , double*)";
   let Spellings = ["__builtin_test_addrspace_attribute_04"];
+  let Attributes = [AddressSpace<2, 4>, AddressSpace<2, 7>];
 }
 #endif
 
 #ifdef ERROR_EXPECTED_F
 def : Builtin {
 // ERROR_EXPECTED_F: :[[# @LINE + 1]]:7: error: Address space attribute can only be specified with a pointer or reference type
-  let Prototype = "_Constant [[addrspace[4]]] int (int , double*)";
+  let Prototype = "_Constant int (int , double*)";
   let Spellings = ["__builtin_test_addrspace_attribute_04"];
-}
-#endif
-
-#ifdef ERROR_EXPECTED_G
-def : Builtin {
-// ERROR_EXPECTED_G: :[[# @LINE + 1]]:7: error: Expecetd valid integer for 'addrspace' attribute
-  let Prototype = "_Constant [[addrspace[k]]] int* (int , double*)";
-  let Spellings = ["__builtin_test_addrspace_attribute_04"];
-}
-#endif
-
-#ifdef ERROR_EXPECTED_H
-def : Builtin {
-// ERROR_EXPECTED_H: :[[# @LINE + 1]]:7: error: Expected closing bracket ']' after address space specification
-  let Prototype = "_Constant [[addrspace[6 int* (int , double*)";
-  let Spellings = ["__builtin_test_addrspace_attribute_04"];
-}
-#endif
-
-#ifdef ERROR_EXPECTED_I
-def : Builtin {
-// ERROR_EXPECTED_I: :[[# @LINE + 1]]:7: error: Expected closing brackets ']]' for attribute list
-  let Prototype = "_Constant [[addrspace[6] int* (int , double*)";
-  let Spellings = ["__builtin_test_addrspace_attribute_04"];
-}
-#endif
-
-#ifdef ERROR_EXPECTED_J
-def : Builtin {
-// ERROR_EXPECTED_J: :[[# @LINE + 1]]:7: error: Unknown attribute name specified
-  let Prototype = "_Constant [[invalid]] int* (int , double*)";
-  let Spellings = ["__builtin_test_addrspace_attribute_04"];
+  let Attributes = [AddressSpace<1, 7>];
 }
 #endif


### PR DESCRIPTION
this is a follow up from the discussion in https://github.com/llvm/llvm-project/pull/86801 (apologies for the long delay...). 
This PR proposes a way to specify address spaces in builtin prototypes. The idea is to specify address space numbers using CXX11 attribute list syntax ([[<attr_list>]]) with following limitations,
1. The attribute [[addrspace[n]]] is strictly a "prefix" to the builtin type, i.e something as follows is not accepted,
     int* const [[addrspace[3]]] ;
2. I really wanted the syntax to be like [[addrspace(n)]] but '(' token conflicts with function signature. so current approach is to use "[[addrspace[n]]]"
3. The attribute is only valid with pointer and reference types (as per the restriction imposed by .def files)

I would like some views on this approach and alternate suggestions if any. Also please let me know if there are any parallel efforts towards this which I might not be aware of.