### PR TITLE
[sanitizer] Disable new test on powerpc64le

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_get_addr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_get_addr.c
@@ -10,6 +10,9 @@
 // These don't intercept __tls_get_addr.
 // XFAIL: lsan,hwasan,ubsan
 
+// FIXME: Fails for unknown reasons.
+// UNSUPPORTED: powerpc64le-target-arch
+
 #ifndef BUILD_SO
 #  include <assert.h>
 #  include <dlfcn.h>


### PR DESCRIPTION
The reason is not clear
https://lab.llvm.org/buildbot/#/builders/72/builds/3260

The test was introduced in #108349.
