### PR TITLE
[Flang][OpenMP] Add Semantic Checks for Atomic Capture Construct

### DIFF
--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -736,5 +736,32 @@ std::string GetCommonBlockObjectName(const Symbol &, bool underscoring);
 // Check for ambiguous USE associations
 bool HadUseError(SemanticsContext &, SourceName at, const Symbol *);
 
+/// Checks if the assignment statement has a single variable on the RHS.
+inline bool checkForSingleVariableOnRHS(
+    const Fortran::parser::AssignmentStmt &assignmentStmt) {
+  const Fortran::parser::Expr &expr{
+      std::get<Fortran::parser::Expr>(assignmentStmt.t)};
+  const Fortran::common::Indirection<Fortran::parser::Designator> *designator =
+      std::get_if<Fortran::common::Indirection<Fortran::parser::Designator>>(
+          &expr.u);
+  return designator != nullptr;
+}
+
+/// Checks if the symbol on the LHS of the assignment statement is present in
+/// the RHS expression.
+inline bool checkForSymbolMatch(
+    const Fortran::parser::AssignmentStmt &assignmentStmt) {
+  const auto &var{std::get<Fortran::parser::Variable>(assignmentStmt.t)};
+  const auto &expr{std::get<Fortran::parser::Expr>(assignmentStmt.t)};
+  const auto *e{Fortran::semantics::GetExpr(expr)};
+  const auto *v{Fortran::semantics::GetExpr(var)};
+  auto varSyms{Fortran::evaluate::GetSymbolVector(*v)};
+  const Fortran::semantics::Symbol &varSymbol{*varSyms.front()};
+  for (const Fortran::semantics::Symbol &symbol :
+      Fortran::evaluate::GetSymbolVector(*e))
+    if (varSymbol == symbol)
+      return true;
+  return false;
+}
 } // namespace Fortran::semantics
 #endif // FORTRAN_SEMANTICS_TOOLS_H_

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -758,9 +758,11 @@ inline bool checkForSymbolMatch(
   auto varSyms{Fortran::evaluate::GetSymbolVector(*v)};
   const Fortran::semantics::Symbol &varSymbol{*varSyms.front()};
   for (const Fortran::semantics::Symbol &symbol :
-      Fortran::evaluate::GetSymbolVector(*e))
-    if (varSymbol == symbol)
+      Fortran::evaluate::GetSymbolVector(*e)) {
+    if (varSymbol == symbol) {
       return true;
+    }
+  }
   return false;
 }
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1997,24 +1997,22 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
   if (Fortran::semantics::checkForSingleVariableOnRHS(stmt1)) {
     CheckAtomicCaptureStmt(stmt1);
     if (Fortran::semantics::checkForSymbolMatch(stmt2)) {
-      // Atomic capture construct is of the form [capture-stmt, update-stmt]
+      // ATOMIC CAPTURE construct is of the form [capture-stmt, update-stmt]
       CheckAtomicUpdateStmt(stmt2);
     } else {
-      // Atomic capture construct is of the form [capture-stmt, write-stmt]
+      // ATOMIC CAPTURE construct is of the form [capture-stmt, write-stmt]
       CheckAtomicWriteStmt(stmt2);
     }
     auto *v{stmt2Var.typedExpr.get()};
     auto *e{stmt1Expr.typedExpr.get()};
     if (v && e && !(v->v == e->v)) {
       context_.Say(stmt1Expr.source,
-          "Captured variable %s "
-          "expected to be assigned in the second statement of "
-          "atomic capture construct"_err_en_US,
+          "Captured variable/array element/derived-type component %s expected to be assigned in the second statement of ATOMIC CAPTURE construct"_err_en_US,
           stmt1Expr.source);
     }
   } else if (Fortran::semantics::checkForSymbolMatch(stmt1) &&
       Fortran::semantics::checkForSingleVariableOnRHS(stmt2)) {
-    // Atomic capture construct is of the form [update-stmt, capture-stmt]
+    // ATOMIC CAPTURE construct is of the form [update-stmt, capture-stmt]
     CheckAtomicUpdateStmt(stmt1);
     CheckAtomicCaptureStmt(stmt2);
     // Variable updated in stmt1 should be captured in stmt2
@@ -2022,16 +2020,12 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
     auto *e{stmt2Expr.typedExpr.get()};
     if (v && e && !(v->v == e->v)) {
       context_.Say(stmt1Var.GetSource(),
-          "Updated variable %s "
-          "expected to be captured in the second statement of "
-          "atomic capture construct"_err_en_US,
+          "Updated variable/array element/derived-type component %s expected to be captured in the second statement of ATOMIC CAPTURE construct"_err_en_US,
           stmt1Var.GetSource());
     }
   } else {
     context_.Say(stmt1Expr.source,
-        "Invalid atomic capture construct statements. "
-        "Expected one of [update-stmt, capture-stmt], "
-        "[capture-stmt, update-stmt], or [capture-stmt, write-stmt]"_err_en_US);
+        "Invalid ATOMIC CAPTURE construct statements. Expected one of [update-stmt, capture-stmt], [capture-stmt, update-stmt], or [capture-stmt, write-stmt]"_err_en_US);
   }
 }
 

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2014,7 +2014,7 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
             "Captured variable %s "
             "expected to be assigned in the second statement of "
             "atomic capture construct"_err_en_US,
-            stmt1ExprSymbol.name().ToString());
+            stmt1ExprSymbol.name());
       }
     }
   } else if (Fortran::semantics::checkForSymbolMatch(stmt1) &&
@@ -2033,7 +2033,7 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
             "Updated variable %s "
             "expected to be captured in the second statement of "
             "atomic capture construct"_err_en_US,
-            stmt1Var.GetSource().ToString());
+            stmt1Var.GetSource());
     }
   } else {
     context_.Say(stmt1Expr.source,

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2009,12 +2009,13 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
     if (e && v) {
       const Symbol &stmt2VarSymbol = evaluate::GetSymbolVector(*v).front();
       const Symbol &stmt1ExprSymbol = evaluate::GetSymbolVector(*e).front();
-      if (stmt2VarSymbol != stmt1ExprSymbol)
+      if (stmt2VarSymbol != stmt1ExprSymbol) {
         context_.Say(stmt1Expr.source,
             "Captured variable %s "
             "expected to be assigned in the second statement of "
             "atomic capture construct"_err_en_US,
             stmt1ExprSymbol.name().ToString());
+      }
     }
   } else if (Fortran::semantics::checkForSymbolMatch(stmt1) &&
       Fortran::semantics::checkForSingleVariableOnRHS(stmt2)) {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2003,19 +2003,14 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
       // Atomic capture construct is of the form [capture-stmt, write-stmt]
       CheckAtomicWriteStmt(stmt2);
     }
-    // Variable captured in stmt1 should be assigned in stmt2
-    const auto *e{GetExpr(context_, stmt1Expr)};
-    const auto *v{GetExpr(context_, stmt2Var)};
-    if (e && v) {
-      const Symbol &stmt2VarSymbol = evaluate::GetSymbolVector(*v).front();
-      const Symbol &stmt1ExprSymbol = evaluate::GetSymbolVector(*e).front();
-      if (stmt2VarSymbol != stmt1ExprSymbol) {
-        context_.Say(stmt1Expr.source,
-            "Captured variable %s "
-            "expected to be assigned in the second statement of "
-            "atomic capture construct"_err_en_US,
-            stmt1ExprSymbol.name());
-      }
+    auto *v{stmt2Var.typedExpr.get()};
+    auto *e{stmt1Expr.typedExpr.get()};
+    if (v && e && !(v->v == e->v)) {
+      context_.Say(stmt1Expr.source,
+          "Captured variable %s "
+          "expected to be assigned in the second statement of "
+          "atomic capture construct"_err_en_US,
+          stmt1Expr.source);
     }
   } else if (Fortran::semantics::checkForSymbolMatch(stmt1) &&
       Fortran::semantics::checkForSingleVariableOnRHS(stmt2)) {
@@ -2023,17 +2018,14 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
     CheckAtomicUpdateStmt(stmt1);
     CheckAtomicCaptureStmt(stmt2);
     // Variable updated in stmt1 should be captured in stmt2
-    const auto *e{GetExpr(context_, stmt2Expr)};
-    const auto *v{GetExpr(context_, stmt1Var)};
-    if (e && v) {
-      const Symbol &stmt1VarSymbol = evaluate::GetSymbolVector(*v).front();
-      const Symbol &stmt2ExprSymbol = evaluate::GetSymbolVector(*e).front();
-      if (stmt1VarSymbol != stmt2ExprSymbol)
-        context_.Say(stmt1Var.GetSource(),
-            "Updated variable %s "
-            "expected to be captured in the second statement of "
-            "atomic capture construct"_err_en_US,
-            stmt1Var.GetSource());
+    auto *v{stmt1Var.typedExpr.get()};
+    auto *e{stmt2Expr.typedExpr.get()};
+    if (v && e && !(v->v == e->v)) {
+      context_.Say(stmt1Var.GetSource(),
+          "Updated variable %s "
+          "expected to be captured in the second statement of "
+          "atomic capture construct"_err_en_US,
+          stmt1Var.GetSource());
     }
   } else {
     context_.Say(stmt1Expr.source,

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1977,6 +1977,7 @@ void OmpStructureChecker::CheckAtomicUpdateStmt(
   ErrIfAllocatableVariable(var);
 }
 
+// TODO: Allow cond-update-stmt once compare clause is supported.
 void OmpStructureChecker::CheckAtomicCaptureConstruct(
     const parser::OmpAtomicCapture &atomicCaptureConstruct) {
   const Fortran::parser::AssignmentStmt &stmt1 =

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2012,7 +2012,7 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
       if (stmt2VarSymbol != stmt1ExprSymbol)
         context_.Say(stmt1Expr.source,
             "Captured variable %s "
-            "expected to be assigned in statement 2 of "
+            "expected to be assigned in the second statement of "
             "atomic capture construct"_err_en_US,
             stmt1ExprSymbol.name().ToString());
     }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2030,7 +2030,7 @@ void OmpStructureChecker::CheckAtomicCaptureConstruct(
       if (stmt1VarSymbol != stmt2ExprSymbol)
         context_.Say(stmt1Var.GetSource(),
             "Updated variable %s "
-            "expected to be captured in statement 2 of "
+            "expected to be captured in the second statement of "
             "atomic capture construct"_err_en_US,
             stmt1Var.GetSource().ToString());
     }

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -193,6 +193,7 @@ private:
   void CheckAtomicUpdateStmt(const parser::AssignmentStmt &);
   void CheckAtomicCaptureStmt(const parser::AssignmentStmt &);
   void CheckAtomicWriteStmt(const parser::AssignmentStmt &);
+  void CheckAtomicCaptureConstruct(const parser::OmpAtomicCapture &);
   void CheckAtomicConstructStructure(const parser::OpenMPAtomicConstruct &);
   void CheckDistLinear(const parser::OpenMPLoopConstruct &x);
   void CheckSIMDNest(const parser::OpenMPConstruct &x);

--- a/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
+++ b/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
@@ -102,49 +102,49 @@ program sample
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Captured variable x expected to be assigned in the second statement of atomic capture construct
+    !ERROR: Captured variable/array element/derived-type component x expected to be assigned in the second statement of ATOMIC CAPTURE construct
         v = x
         b = b + 1
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Captured variable x expected to be assigned in the second statement of atomic capture construct
+    !ERROR: Captured variable/array element/derived-type component x expected to be assigned in the second statement of ATOMIC CAPTURE construct
         v = x
         b = 10
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Updated variable x expected to be captured in the second statement of atomic capture construct
+    !ERROR: Updated variable/array element/derived-type component x expected to be captured in the second statement of ATOMIC CAPTURE construct
         x = x + 10
         v = b
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Invalid atomic capture construct statements. Expected one of [update-stmt, capture-stmt], [capture-stmt, update-stmt], or [capture-stmt, write-stmt]
+    !ERROR: Invalid ATOMIC CAPTURE construct statements. Expected one of [update-stmt, capture-stmt], [capture-stmt, update-stmt], or [capture-stmt, write-stmt]
         v = 1
         x = 4
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Captured variable z%y expected to be assigned in the second statement of atomic capture construct
+    !ERROR: Captured variable/array element/derived-type component z%y expected to be assigned in the second statement of ATOMIC CAPTURE construct
         x = z%y
         z%m = z%m + 1.0
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Updated variable z%m expected to be captured in the second statement of atomic capture construct
+    !ERROR: Updated variable/array element/derived-type component z%m expected to be captured in the second statement of ATOMIC CAPTURE construct
         z%m = z%m + 1.0
         x = z%y
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Captured variable y(2) expected to be assigned in the second statement of atomic capture construct
+    !ERROR: Captured variable/array element/derived-type component y(2) expected to be assigned in the second statement of ATOMIC CAPTURE construct
         x = y(2)
         y(1) = y(1) + 1
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Updated variable y(1) expected to be captured in the second statement of atomic capture construct
+    !ERROR: Updated variable/array element/derived-type component y(1) expected to be captured in the second statement of ATOMIC CAPTURE construct
         y(1) = y(1) + 1
         x = y(2)
     !$omp end atomic

--- a/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
+++ b/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
@@ -124,4 +124,28 @@ program sample
         v = 1
         x = 4
     !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Captured variable z%y expected to be assigned in the second statement of atomic capture construct
+        x = z%y
+        z%m = z%m + 1.0
+    !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Updated variable z%m expected to be captured in the second statement of atomic capture construct
+        z%m = z%m + 1.0
+        x = z%y
+    !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Captured variable y(2) expected to be assigned in the second statement of atomic capture construct
+        x = y(2)
+        y(1) = y(1) + 1
+    !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Updated variable y(1) expected to be captured in the second statement of atomic capture construct
+        y(1) = y(1) + 1
+        x = y(2)
+    !$omp end atomic
 end program

--- a/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
+++ b/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
@@ -84,4 +84,44 @@ program sample
     !$omp atomic write
     !ERROR: Expected scalar variable on the LHS of atomic assignment statement
         a = x
+
+    !$omp atomic capture
+        v = x
+        x = x + 1
+    !$omp end atomic
+
+    !$omp atomic release capture
+        v = x
+    !ERROR: Atomic update statement should be of form `x = x operator expr` OR `x = expr operator x`
+        x = b + (x*1)
+    !$omp end atomic
+
+    !$omp atomic capture hint(0)
+        v = x
+        x = 1
+    !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Captured variable x expected to be assigned in statement 2 of atomic capture construct
+        v = x
+        b = b + 1
+    !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Captured variable x expected to be assigned in statement 2 of atomic capture construct
+        v = x
+        b = 10
+    !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Updated variable x expected to be captured in statement 2 of atomic capture construct
+        x = x + 10
+        v = b
+    !$omp end atomic
+
+    !$omp atomic capture
+    !ERROR: Invalid atomic capture construct statements. Expected one of [update-stmt, capture-stmt], [capture-stmt, update-stmt], or [capture-stmt, write-stmt]
+        v = 1
+        x = 4
+    !$omp end atomic
 end program

--- a/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
+++ b/flang/test/Semantics/OpenMP/omp-atomic-assignment-stmt.f90
@@ -102,19 +102,19 @@ program sample
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Captured variable x expected to be assigned in statement 2 of atomic capture construct
+    !ERROR: Captured variable x expected to be assigned in the second statement of atomic capture construct
         v = x
         b = b + 1
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Captured variable x expected to be assigned in statement 2 of atomic capture construct
+    !ERROR: Captured variable x expected to be assigned in the second statement of atomic capture construct
         v = x
         b = 10
     !$omp end atomic
 
     !$omp atomic capture
-    !ERROR: Updated variable x expected to be captured in statement 2 of atomic capture construct
+    !ERROR: Updated variable x expected to be captured in the second statement of atomic capture construct
         x = x + 10
         v = b
     !$omp end atomic

--- a/flang/test/Semantics/OpenMP/requires-atomic01.f90
+++ b/flang/test/Semantics/OpenMP/requires-atomic01.f90
@@ -88,7 +88,7 @@ program requires
   ! CHECK: OmpMemoryOrderClause -> OmpClause -> SeqCst
   !$omp atomic capture
   i = j
-  i = j
+  j = j + 1
   !$omp end atomic
 
   ! CHECK-LABEL: OpenMPAtomicConstruct -> OmpAtomicCapture
@@ -96,7 +96,7 @@ program requires
   ! CHECK: OmpMemoryOrderClause -> OmpClause -> Relaxed
   !$omp atomic relaxed capture
   i = j
-  i = j
+  j = j + 1
   !$omp end atomic
 
   ! CHECK-LABEL: OpenMPAtomicConstruct -> OmpAtomicCapture
@@ -104,6 +104,6 @@ program requires
   ! CHECK: OmpMemoryOrderClause -> OmpClause -> Relaxed
   !$omp atomic capture relaxed
   i = j
-  i = j
+  j = j + 1
   !$omp end atomic
 end program requires

--- a/flang/test/Semantics/OpenMP/requires-atomic02.f90
+++ b/flang/test/Semantics/OpenMP/requires-atomic02.f90
@@ -88,7 +88,7 @@ program requires
   ! CHECK: OmpMemoryOrderClause -> OmpClause -> AcqRel
   !$omp atomic capture
   i = j
-  i = j
+  j = j + 1
   !$omp end atomic
 
   ! CHECK-LABEL: OpenMPAtomicConstruct -> OmpAtomicCapture
@@ -96,7 +96,7 @@ program requires
   ! CHECK: OmpMemoryOrderClause -> OmpClause -> Relaxed
   !$omp atomic relaxed capture
   i = j
-  i = j
+  j = j + 1
   !$omp end atomic
 
   ! CHECK-LABEL: OpenMPAtomicConstruct -> OmpAtomicCapture
@@ -104,6 +104,6 @@ program requires
   ! CHECK: OmpMemoryOrderClause -> OmpClause -> Relaxed
   !$omp atomic capture relaxed
   i = j
-  i = j
+  j = j + 1
   !$omp end atomic
 end program requires


### PR DESCRIPTION
This PR adds semantic checks to ensure the atomic capture construct conforms to one of the valid forms:
[capture-stmt, update-stmt], [capture-stmt, write-stmt] or [update-stmt, capture-stmt].

Functions checkForSymbolMatch and checkForSingleVariableOnRHS are moved from flang/lib/Lower/DirectivesCommon.h to flang/Semantics/tools.h for reuse.