### PR TITLE
[X86][test] Avoid writing to a potentially write-protected dir

### DIFF
--- a/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins-errors.c
+++ b/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins-errors.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -flax-vector-conversions=none -ffreestanding %s -triple=i386-unknown-unknown -target-feature +avx10.2-512 -emit-llvm -Wall -Werror -verify
+// RUN: %clang_cc1 -flax-vector-conversions=none -ffreestanding %s -triple=i386-unknown-unknown -target-feature +avx10.2-512 -Wall -Werror -verify
 
 #include <immintrin.h>
 #include <stddef.h>

--- a/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins-x64-error.c
+++ b/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins-x64-error.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-unknown -target-feature +avx10.2-512 -emit-llvm -Wall -Werror -verify
+// RUN: %clang_cc1 -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-unknown -target-feature +avx10.2-512 -Wall -Werror -verify
 
 #include <immintrin.h>
 #include <stddef.h>


### PR DESCRIPTION
This patch simply remove the -emit-llvm option as this testcase don't care about the outputed llvm IR.
The current directory may be write protected e.g. in a sandboxed environment.