### PR TITLE
[SPIR-V] Fix incorrect emission of G_SPLAT_VECTOR for fixed vectors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -496,7 +496,7 @@ Register SPIRVGlobalRegistry::getOrCreateIntCompositeOrNull(
     assignSPIRVTypeToVReg(SpvType, SpvVecConst, *CurMF);
     DT.add(CA, CurMF, SpvVecConst);
     if (EmitIR) {
-      MIRBuilder.buildSplatVector(SpvVecConst, SpvScalConst);
+      MIRBuilder.buildSplatBuildVector(SpvVecConst, SpvScalConst);
     } else {
       if (Val) {
         auto MIB = MIRBuilder.buildInstr(SPIRV::OpConstantComposite)


### PR DESCRIPTION
This PR replaces MIRBuilder.buildSplatVector() by MIRBuilder.buildSplatBuildVector(), so that we emit G_BUILD_VECTOR instead of G_SPLAT_VECTOR: the latter is incorrect for fixed vectors and is limited to scalable vectors only.