### PR TITLE
[ItaniumDemangle] Add template name to the substitutions list during demangling

### DIFF
--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -4336,6 +4336,7 @@ Node *AbstractManglingParser<Derived, Alloc>::parseType() {
     // parse them, take the second production.
 
     if (TryToParseTemplateArgs && look() == 'I') {
+      Subs.push_back(Result);
       Node *TA = getDerived().parseTemplateArgs();
       if (TA == nullptr)
         return nullptr;

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -4336,6 +4336,7 @@ Node *AbstractManglingParser<Derived, Alloc>::parseType() {
     // parse them, take the second production.
 
     if (TryToParseTemplateArgs && look() == 'I') {
+      Subs.push_back(Result);
       Node *TA = getDerived().parseTemplateArgs();
       if (TA == nullptr)
         return nullptr;


### PR DESCRIPTION
When demangling a template template parameter (`method<bool, Bar>(Bar<bool> b)`), the current demangler version first enters the template argument (`bool`) into the substitutions list, then the whole template specialization (`Bar<bool>`). The template name (`Bar`) never becomes a substitution candidate on its own.

This is different when mangling. Mangling `method<bool, Bar>(Bar<bool> b, Bar<int> i)` substitutes the `Bar` in the second parameter with the substitution for `TemplateTemplateParmDecl`.

This leads to a discrepancy between mangler and demangler, see https://github.com/llvm/llvm-project/issues/108009.