### PR TITLE
[MIR] Allow overriding isSSA, noPhis, noVRegs in MIR input

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -730,6 +730,11 @@ struct MachineFunction {
   bool TracksRegLiveness = false;
   bool HasWinCFI = false;
 
+  // Computed properties that should be overridable
+  bool NoPHIs = false;
+  bool IsSSA = false;
+  bool NoVRegs = false;
+
   bool CallsEHReturn = false;
   bool CallsUnwindInit = false;
   bool HasEHCatchret = false;
@@ -769,6 +774,12 @@ template <> struct MappingTraits<MachineFunction> {
     YamlIO.mapOptional("failedISel", MF.FailedISel, false);
     YamlIO.mapOptional("tracksRegLiveness", MF.TracksRegLiveness, false);
     YamlIO.mapOptional("hasWinCFI", MF.HasWinCFI, false);
+
+    // PHIs must be not be capitalized, since it will clash with the MIR opcode
+    // leading to false-positive FileCheck hits with CHECK-NOT
+    YamlIO.mapOptional("noPhis", MF.NoPHIs, true);
+    YamlIO.mapOptional("isSSA", MF.IsSSA, true);
+    YamlIO.mapOptional("noVRegs", MF.NoVRegs, true);
 
     YamlIO.mapOptional("callsEHReturn", MF.CallsEHReturn, false);
     YamlIO.mapOptional("callsUnwindInit", MF.CallsUnwindInit, false);

--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -731,9 +731,9 @@ struct MachineFunction {
   bool HasWinCFI = false;
 
   // Computed properties that should be overridable
-  bool NoPHIs = false;
-  bool IsSSA = false;
-  bool NoVRegs = false;
+  std::optional<bool> NoPHIs;
+  std::optional<bool> IsSSA;
+  std::optional<bool> NoVRegs;
 
   bool CallsEHReturn = false;
   bool CallsUnwindInit = false;
@@ -777,9 +777,9 @@ template <> struct MappingTraits<MachineFunction> {
 
     // PHIs must be not be capitalized, since it will clash with the MIR opcode
     // leading to false-positive FileCheck hits with CHECK-NOT
-    YamlIO.mapOptional("noPhis", MF.NoPHIs, true);
-    YamlIO.mapOptional("isSSA", MF.IsSSA, true);
-    YamlIO.mapOptional("noVRegs", MF.NoVRegs, true);
+    YamlIO.mapOptional("noPhis", MF.NoPHIs, std::optional<bool>());
+    YamlIO.mapOptional("isSSA", MF.IsSSA, std::optional<bool>());
+    YamlIO.mapOptional("noVRegs", MF.NoVRegs, std::optional<bool>());
 
     YamlIO.mapOptional("callsEHReturn", MF.CallsEHReturn, false);
     YamlIO.mapOptional("callsUnwindInit", MF.CallsUnwindInit, false);

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -406,11 +406,13 @@ bool MIRParserImpl::computeFunctionProperties(
   auto ComputedPropertyHelper =
       [&Properties](std::optional<bool> ExplicitProp, bool ComputedProp,
                     MachineFunctionProperties::Property P) -> bool {
+    // Prefer explicitly given values over the computed properties
     if (ExplicitProp.value_or(ComputedProp))
       Properties.set(P);
     else
       Properties.reset(P);
-    
+
+    // Check for conflict between the explicit values and the computed ones
     return ExplicitProp && *ExplicitProp && !ComputedProp;
   };
 

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -406,27 +406,12 @@ bool MIRParserImpl::computeFunctionProperties(
   auto ComputedPropertyHelper =
       [&Properties](std::optional<bool> ExplicitProp, bool ComputedProp,
                     MachineFunctionProperties::Property P) -> bool {
-    // Prefer whatever is set explicitly by the input MIR
-    if (ExplicitProp.has_value()) {
-      if (*ExplicitProp) {
-        // Check for conflicts with the computed value
-        if (!ComputedProp)
-          return true;
-
-        Properties.set(P);
-      } else
-        Properties.reset(P);
-
-      return false;
-    }
-
-    // No explicit value given, so use computed value
-    if (ComputedProp)
+    if (ExplicitProp.value_or(ComputedProp))
       Properties.set(P);
     else
       Properties.reset(P);
-
-    return false;
+    
+    return ExplicitProp && *ExplicitProp && !ComputedProp;
   };
 
   if (ComputedPropertyHelper(YamlMF.NoPHIs, !HasPHI,

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -223,6 +223,13 @@ void MIRPrinter::print(const MachineFunction &MF) {
   YamlMF.TracksDebugUserValues = MF.getProperties().hasProperty(
       MachineFunctionProperties::Property::TracksDebugUserValues);
 
+  YamlMF.NoPHIs = MF.getProperties().hasProperty(
+      MachineFunctionProperties::Property::NoPHIs);
+  YamlMF.IsSSA = MF.getProperties().hasProperty(
+      MachineFunctionProperties::Property::IsSSA);
+  YamlMF.NoVRegs = MF.getProperties().hasProperty(
+      MachineFunctionProperties::Property::NoVRegs);
+
   convert(YamlMF, MF.getRegInfo(), MF.getSubtarget().getRegisterInfo());
   MachineModuleSlotTracker MST(MMI, &MF);
   MST.incorporateFunction(MF.getFunction());

--- a/llvm/test/CodeGen/AArch64/mlicm-stack-write-check.mir
+++ b/llvm/test/CodeGen/AArch64/mlicm-stack-write-check.mir
@@ -3,6 +3,7 @@
 ---
 name: test
 tracksRegLiveness: true
+isSSA: false
 registers:
   - { id: 0, class: gpr64 }
 stack:
@@ -30,11 +31,11 @@ body: |
   bb.2:
     liveins: $x0
     %0 = COPY $x0
-    %0 = COPY $x0  ; Force isSSA = false.
 ...
 ---
 name: test2
 tracksRegLiveness: true
+isSSA: false
 registers:
   - { id: 0, class: gpr64 }
 stack:
@@ -62,5 +63,4 @@ body: |
   bb.2:
     liveins: $x0
     %0 = COPY $x0
-    %0 = COPY $x0  ; Force isSSA = false.
 ...

--- a/llvm/test/CodeGen/AMDGPU/early-tailduplicator-nophis.mir
+++ b/llvm/test/CodeGen/AMDGPU/early-tailduplicator-nophis.mir
@@ -2,13 +2,11 @@
 # RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=early-tailduplication -verify-machineinstrs -o - %s | FileCheck %s
 
  # There are no phis in this testcase. Early tail duplication introduces them,
- # so the NoPHIs property needs to be set explicitly to false to avoid verifier
- # errors
+ # so the NoPHIs property needs to be cleared to avoid verifier errors
 
 ---
 name:           tail_duplicate_nophis
 tracksRegLiveness: true
-noPhis: false
 body:             |
   ; CHECK-LABEL: name: tail_duplicate_nophis
   ; CHECK: bb.0:

--- a/llvm/test/CodeGen/AMDGPU/early-tailduplicator-nophis.mir
+++ b/llvm/test/CodeGen/AMDGPU/early-tailduplicator-nophis.mir
@@ -2,11 +2,13 @@
 # RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=early-tailduplication -verify-machineinstrs -o - %s | FileCheck %s
 
  # There are no phis in this testcase. Early tail duplication introduces them,
- # so the NoPHIs property needs to be cleared to avoid verifier errors
+ # so the NoPHIs property needs to be set explicitly to false to avoid verifier
+ # errors
 
 ---
 name:           tail_duplicate_nophis
 tracksRegLiveness: true
+noPhis: false
 body:             |
   ; CHECK-LABEL: name: tail_duplicate_nophis
   ; CHECK: bb.0:

--- a/llvm/test/CodeGen/Hexagon/expand-condsets-impuse2.mir
+++ b/llvm/test/CodeGen/Hexagon/expand-condsets-impuse2.mir
@@ -6,12 +6,12 @@
 
 name: f0
 tracksRegLiveness: true
+isSSA: false
 body: |
   bb.0:
     successors: %bb.1
     liveins: $r0, $r1
     %0:intregs = COPY $r0
-    %0:intregs = COPY $r0       ; defeat IsSSA detection
     %1:intregs = COPY $r1
     %2:intregs = COPY $r0
     %3:intregs = M2_mpyi %2, %1

--- a/llvm/test/CodeGen/Hexagon/expand-condsets-phys-reg.mir
+++ b/llvm/test/CodeGen/Hexagon/expand-condsets-phys-reg.mir
@@ -9,12 +9,12 @@
 
 name: fred
 tracksRegLiveness: true
+isSSA: false
 body: |
   bb.0:
     successors: %bb.1, %bb.2
     liveins: $r0
 
-    %0:intregs = A2_tfrsi 0           ;; Multiple defs to ensure IsSSA = false
     %0:intregs = L2_loadri_io $r0, 0
     %1:predregs = C2_cmpgti %0, 10
     %2:intregs = C2_mux %1, $r31, %0

--- a/llvm/test/CodeGen/Hexagon/expand-condsets-rm-reg.mir
+++ b/llvm/test/CodeGen/Hexagon/expand-condsets-rm-reg.mir
@@ -20,6 +20,7 @@
 
 name: fred
 tracksRegLiveness: true
+isSSA: false
 registers:
   - { id: 0, class: intregs }
   - { id: 1, class: intregs }
@@ -35,7 +36,6 @@ body: |
   bb.0:
     liveins: $r0, $r1, $p0
         %0 = COPY $r0
-        %0 = COPY $r0  ; Force isSSA = false.
         %1 = COPY $r1
         %2 = COPY $p0
         ; Check that %3 was coalesced into %4.

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties-conflict.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties-conflict.mir
@@ -4,35 +4,32 @@
 # properties
 
 ---
-# CHECK-LABEL: TestNoPhisOverrideConflict
-# CHECK-SAME: has explicit property NoPhi, but contains at least one PHI
+# CHECK: error: {{.*}}: TestNoPhisOverrideConflict has explicit property NoPhi, but contains at least one PHI
 name:            TestNoPhisOverrideConflict
 noPhis: true
 tracksRegLiveness: true
 body: |
   bb.0:
-    %0:_(s32) = IMPLICIT_DEF
+    %0:_(s32) = G_IMPLICIT_DEF
 
   bb.1:
     %1:_(s32) = PHI %0, %bb.0, %1, %bb.1
     G_BR %bb.1
 ...
 ---
-# CHECK-LABEL: TestIsSSAOverrideConflict
-# CHECK-SAME: has explicit property IsSSA, but is not valid SSA
+# CHECK: error: {{.*}}: TestIsSSAOverrideConflict has explicit property IsSSA, but is not valid SSA
 name:            TestIsSSAOverrideConflict
 isSSA: true
 body: |
   bb.0:
-    %0:_(s32) = IMPLICIT_DEF
-    %0:_(s32) = IMPLICIT_DEF
+    %0:_(s32) = G_IMPLICIT_DEF
+    %0:_(s32) = G_IMPLICIT_DEF
 ...
 ---
-# CHECK-LABEL: TestNoVRegsOverrideConflict
-# CHECK-SAME: has explicit property NoVRegs, but contains virtual registers
+# CHECK: error: {{.*}}: TestNoVRegsOverrideConflict has explicit property NoVRegs, but contains virtual registers
 name:            TestNoVRegsOverrideConflict
 noVRegs: true
 body: |
   bb.0:
-    %0:_(s32) = IMPLICIT_DEF
+    %0:_(s32) = G_IMPLICIT_DEF
 ...

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties-conflict.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties-conflict.mir
@@ -1,0 +1,38 @@
+# RUN: not llc -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+
+# Test that computed properties are not conflicting with explicitly set
+# properties
+
+---
+# CHECK-LABEL: TestNoPhisOverrideConflict
+# CHECK-SAME: has explicit property NoPhi, but contains at least one PHI
+name:            TestNoPhisOverrideConflict
+noPhis: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    %0:_(s32) = IMPLICIT_DEF
+
+  bb.1:
+    %1:_(s32) = PHI %0, %bb.0, %1, %bb.1
+    G_BR %bb.1
+...
+---
+# CHECK-LABEL: TestIsSSAOverrideConflict
+# CHECK-SAME: has explicit property IsSSA, but is not valid SSA
+name:            TestIsSSAOverrideConflict
+isSSA: true
+body: |
+  bb.0:
+    %0:_(s32) = IMPLICIT_DEF
+    %0:_(s32) = IMPLICIT_DEF
+...
+---
+# CHECK-LABEL: TestNoVRegsOverrideConflict
+# CHECK-SAME: has explicit property NoVRegs, but contains virtual registers
+name:            TestNoVRegsOverrideConflict
+noVRegs: true
+body: |
+  bb.0:
+    %0:_(s32) = IMPLICIT_DEF
+...

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties.mir
@@ -1,9 +1,6 @@
 # RUN: llc -run-pass none -o - %s | FileCheck %s
-# Test that we can disable certain properties that are normally computed. This
-# override is a soft-override (only allows overriding when it relaxes the
-# property). Therefore, a conflicting override (e.g. setting noPhis to true in
-# the presence of PHI nodes) should not result in an error, but instead should
-# use the computed property instead (noPhis = false in the mentioned example).
+
+# Test that we can disable certain properties that are normally computed
 
 ---
 # CHECK-LABEL: name: TestNoPhis
@@ -26,21 +23,6 @@ name:            TestNoPhisOverrideTrue
 noPhis: true
 ...
 ---
-# CHECK-LABEL: name: TestNoPhisOverrideConflict
-# CHECK: noPhis: false
-# CHECK: ...
-name:            TestNoPhisOverrideConflict
-noPhis: true
-tracksRegLiveness: true
-body: |
-  bb.0:
-    %0:_(s32) = IMPLICIT_DEF
-
-  bb.1:
-    %1:_(s32) = PHI %0, %bb.0, %0, %bb.1
-    G_BR %bb.1
-...
----
 # CHECK-LABEL: name: TestIsSSA
 # CHECK: isSSA: true
 # CHECK: ...
@@ -61,17 +43,6 @@ name:            TestIsSSAOverrideTrue
 isSSA: true
 ...
 ---
-# CHECK-LABEL: name: TestIsSSAOverrideConflict
-# CHECK: isSSA: false
-# CHECK: ...
-name:            TestIsSSAOverrideConflict
-isSSA: true
-body: |
-  bb.0:
-    %0:_(s32) = IMPLICIT_DEF
-    %0:_(s32) = IMPLICIT_DEF
-...
----
 # CHECK-LABEL: name: TestNoVRegs
 # CHECK: noVRegs: true
 # CHECK: ...
@@ -90,14 +61,4 @@ noVRegs: false
 # CHECK: ...
 name:            TestNoVRegsOverrideTrue
 noVRegs: true
-...
----
-# CHECK-LABEL: name: TestNoVRegsOverrideConflict
-# CHECK: noVRegs: false
-# CHECK: ...
-name:            TestNoVRegsOverrideConflict
-noVRegs: true
-body: |
-  bb.0:
-    %0:_(s32) = IMPLICIT_DEF
 ...

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties.mir
@@ -1,5 +1,9 @@
 # RUN: llc -run-pass none -o - %s | FileCheck %s
-# Test that we can disable certain properties that are normally computed
+# Test that we can disable certain properties that are normally computed. This
+# override is a soft-override (only allows overriding when it relaxes the
+# property). Therefore, a conflicting override (e.g. setting noPhis to true in
+# the presence of PHI nodes) should not result in an error, but instead should
+# use the computed property instead (noPhis = false in the mentioned example).
 
 ---
 # CHECK-LABEL: name: TestNoPhis
@@ -15,6 +19,28 @@ name:            TestNoPhisOverride
 noPhis: false
 ...
 ---
+# CHECK-LABEL: name: TestNoPhisOverrideTrue
+# CHECK: noPhis: true
+# CHECK: ...
+name:            TestNoPhisOverrideTrue
+noPhis: true
+...
+---
+# CHECK-LABEL: name: TestNoPhisOverrideConflict
+# CHECK: noPhis: false
+# CHECK: ...
+name:            TestNoPhisOverrideConflict
+noPhis: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    %0:_(s32) = IMPLICIT_DEF
+
+  bb.1:
+    %1:_(s32) = PHI %0, %bb.0, %0, %bb.1
+    G_BR %bb.1
+...
+---
 # CHECK-LABEL: name: TestIsSSA
 # CHECK: isSSA: true
 # CHECK: ...
@@ -28,6 +54,24 @@ name:            TestIsSSAOverride
 isSSA: false
 ...
 ---
+# CHECK-LABEL: name: TestIsSSAOverrideTrue
+# CHECK: isSSA: true
+# CHECK: ...
+name:            TestIsSSAOverrideTrue
+isSSA: true
+...
+---
+# CHECK-LABEL: name: TestIsSSAOverrideConflict
+# CHECK: isSSA: false
+# CHECK: ...
+name:            TestIsSSAOverrideConflict
+isSSA: true
+body: |
+  bb.0:
+    %0:_(s32) = IMPLICIT_DEF
+    %0:_(s32) = IMPLICIT_DEF
+...
+---
 # CHECK-LABEL: name: TestNoVRegs
 # CHECK: noVRegs: true
 # CHECK: ...
@@ -39,4 +83,21 @@ name:            TestNoVRegs
 # CHECK: ...
 name:            TestNoVRegsOverride
 noVRegs: false
+...
+---
+# CHECK-LABEL: name: TestNoVRegsOverrideTrue
+# CHECK: noVRegs: true
+# CHECK: ...
+name:            TestNoVRegsOverrideTrue
+noVRegs: true
+...
+---
+# CHECK-LABEL: name: TestNoVRegsOverrideConflict
+# CHECK: noVRegs: false
+# CHECK: ...
+name:            TestNoVRegsOverrideConflict
+noVRegs: true
+body: |
+  bb.0:
+    %0:_(s32) = IMPLICIT_DEF
 ...

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-optionally-computed-properties.mir
@@ -1,0 +1,42 @@
+# RUN: llc -run-pass none -o - %s | FileCheck %s
+# Test that we can disable certain properties that are normally computed
+
+---
+# CHECK-LABEL: name: TestNoPhis
+# CHECK: noPhis: true
+# CHECK: ...
+name:            TestNoPhis
+...
+---
+# CHECK-LABEL: name: TestNoPhisOverride
+# CHECK: noPhis: false
+# CHECK: ...
+name:            TestNoPhisOverride
+noPhis: false
+...
+---
+# CHECK-LABEL: name: TestIsSSA
+# CHECK: isSSA: true
+# CHECK: ...
+name:            TestIsSSA
+...
+---
+# CHECK-LABEL: name: TestIsSSAOverride
+# CHECK: isSSA: false
+# CHECK: ...
+name:            TestIsSSAOverride
+isSSA: false
+...
+---
+# CHECK-LABEL: name: TestNoVRegs
+# CHECK: noVRegs: true
+# CHECK: ...
+name:            TestNoVRegs
+...
+---
+# CHECK-LABEL: name: TestNoVRegsOverride
+# CHECK: noVRegs: false
+# CHECK: ...
+name:            TestNoVRegsOverride
+noVRegs: false
+...

--- a/llvm/test/CodeGen/X86/sjlj-shadow-stack-liveness.mir
+++ b/llvm/test/CodeGen/X86/sjlj-shadow-stack-liveness.mir
@@ -14,6 +14,7 @@ name:            bar
 # CHECK-LABEL: name: bar
 alignment:       16
 tracksRegLiveness: true
+noPhis: false
 body:             |
   bb.0:
     %0:gr64 = IMPLICIT_DEF
@@ -29,8 +30,6 @@ body:             |
     ; CHECK-NOT: MOV64rm killed %0
     ; CHECK-NEXT: MOV64rm killed %0
 
-  ; FIXME: Dummy PHI to set the property NoPHIs to false. PR38439.
   bb.2:
-    %1:gr64 = PHI undef %1, %bb.2, undef %1, %bb.2
     JMP_1 %bb.2
 ...

--- a/llvm/test/tools/llvm-reduce/mir/preserve-func-info.mir
+++ b/llvm/test/tools/llvm-reduce/mir/preserve-func-info.mir
@@ -14,6 +14,9 @@
 # RESULT-NEXT: failedISel:      true
 # RESULT-NEXT: tracksRegLiveness: true
 # RESULT-NEXT: hasWinCFI:       true
+# RESULT-NEXT: noPhis:          false
+# RESULT-NEXT: isSSA:           false
+# RESULT-NEXT: noVRegs:         false
 # RESULT-NEXT: callsEHReturn: true
 # RESULT-NEXT: callsUnwindInit: true
 # RESULT-NEXT: hasEHCatchret: true
@@ -41,6 +44,9 @@ selected:        true
 failedISel:      true
 tracksRegLiveness: true
 hasWinCFI:       true
+noPhis:          false
+isSSA:           false
+noVRegs:         false
 failsVerification: true
 tracksDebugUserValues: true
 callsEHReturn: true


### PR DESCRIPTION
Allow setting the computed properties IsSSA, NoPHIs, NoVRegs for MIR functions in MIR input. The default value is still the computed value. If the property is set to false, the computed result is ignored. This allows for tests where a pass is for example inserting PHI nodes into a function that didn't have any previously.

Closes #37787