### PR TITLE
[LoongArch][sanitizer] Fix SC_ADDRERR_{RD,WR} missing in the musl environment

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2018,17 +2018,17 @@ SignalContext::WriteFlag SignalContext::GetWriteFlag() const {
     return Unknown;
   return esr & ESR_ELx_WNR ? Write : Read;
 #  elif defined(__loongarch__)
-     // In the musl environment, the Linux kernel uapi sigcontext.h is not
-     // included in signal.h. To avoid missing the SC_ADDRERR_{RD,WR} macros,
-     // copy them here. The LoongArch Linux kernel uapi is already stable,
-     // so there's no need to worry about the value changing.
+  // In the musl environment, the Linux kernel uapi sigcontext.h is not
+  // included in signal.h. To avoid missing the SC_ADDRERR_{RD,WR} macros,
+  // copy them here. The LoongArch Linux kernel uapi is already stable,
+  // so there's no need to worry about the value changing.
 #    ifndef SC_ADDRERR_RD
-       // Address error was due to memory load
-#      define SC_ADDRERR_RD		(1 << 30)
+  // Address error was due to memory load
+#      define SC_ADDRERR_RD (1 << 30)
 #    endif
 #    ifndef SC_ADDRERR_WR
-       // Address error was due to memory store
-#      define SC_ADDRERR_WR		(1 << 31)
+  // Address error was due to memory store
+#      define SC_ADDRERR_WR (1 << 31)
 #    endif
   u32 flags = ucontext->uc_mcontext.__flags;
   if (flags & SC_ADDRERR_RD)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2018,6 +2018,18 @@ SignalContext::WriteFlag SignalContext::GetWriteFlag() const {
     return Unknown;
   return esr & ESR_ELx_WNR ? Write : Read;
 #  elif defined(__loongarch__)
+     // In the musl environment, the Linux kernel uapi sigcontext.h is not
+     // included in signal.h. To avoid missing the SC_ADDRERR_{RD,WR} macros,
+     // copy them here. The LoongArch Linux kernel uapi is already stable,
+     // so there's no need to worry about the value changing.
+#    ifndef SC_ADDRERR_RD
+       // Address error was due to memory load
+#      define SC_ADDRERR_RD		(1 << 30)
+#    endif
+#    ifndef SC_ADDRERR_WR
+       // Address error was due to memory store
+#      define SC_ADDRERR_WR		(1 << 31)
+#    endif
   u32 flags = ucontext->uc_mcontext.__flags;
   if (flags & SC_ADDRERR_RD)
     return SignalContext::Read;


### PR DESCRIPTION
Fixes #108550