### PR TITLE
[RISCV] Bump hwprobe support to Linux 6.11

### DIFF
--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1988,7 +1988,8 @@ struct RISCVHwProbe {
 };
 const StringMap<bool> sys::getHostCPUFeatures() {
   RISCVHwProbe Query[]{{/*RISCV_HWPROBE_KEY_BASE_BEHAVIOR=*/3, 0},
-                       {/*RISCV_HWPROBE_KEY_IMA_EXT_0=*/4, 0}};
+                       {/*RISCV_HWPROBE_KEY_IMA_EXT_0=*/4, 0},
+                       {/*RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF=*/9, 0}};
   int Ret = syscall(/*__NR_riscv_hwprobe=*/258, /*pairs=*/Query,
                     /*pair_count=*/std::size(Query), /*cpu_count=*/0,
                     /*cpus=*/0, /*flags=*/0);
@@ -2044,9 +2045,26 @@ const StringMap<bool> sys::getHostCPUFeatures() {
   Features["zicond"] = ExtMask & (1ULL << 35);  // RISCV_HWPROBE_EXT_ZICOND
   Features["zihintpause"] =
       ExtMask & (1ULL << 36); // RISCV_HWPROBE_EXT_ZIHINTPAUSE
+  Features["zve32x"] = ExtMask & (1ULL << 37); // RISCV_HWPROBE_EXT_ZVE32X
+  Features["zve32f"] = ExtMask & (1ULL << 38); // RISCV_HWPROBE_EXT_ZVE32F
+  Features["zve64x"] = ExtMask & (1ULL << 39); // RISCV_HWPROBE_EXT_ZVE64X
+  Features["zve64f"] = ExtMask & (1ULL << 40); // RISCV_HWPROBE_EXT_ZVE64F
+  Features["zve64d"] = ExtMask & (1ULL << 41); // RISCV_HWPROBE_EXT_ZVE64D
+  Features["zimop"] = ExtMask & (1ULL << 42);  // RISCV_HWPROBE_EXT_ZIMOP
+  Features["zca"] = ExtMask & (1ULL << 43);    // RISCV_HWPROBE_EXT_ZCA
+  Features["zcb"] = ExtMask & (1ULL << 44);    // RISCV_HWPROBE_EXT_ZCB
+  Features["zcd"] = ExtMask & (1ULL << 45);    // RISCV_HWPROBE_EXT_ZCD
+  Features["zcf"] = ExtMask & (1ULL << 46);    // RISCV_HWPROBE_EXT_ZCF
+  Features["zcmop"] = ExtMask & (1ULL << 47);  // RISCV_HWPROBE_EXT_ZCMOP
+  Features["zawrs"] = ExtMask & (1ULL << 48);  // RISCV_HWPROBE_EXT_ZAWRS
 
-  // TODO: set unaligned-scalar-mem if RISCV_HWPROBE_KEY_MISALIGNED_PERF returns
-  // RISCV_HWPROBE_MISALIGNED_FAST.
+  // Check whether the processor supports fast misaligned scalar memory access.
+  // NOTE: RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF is only available on
+  // Linux 6.11 or later. If it is not recognized, the key field will be cleared
+  // to -1.
+  if (Query[2].Key != -1 &&
+      Query[2].Value == /*RISCV_HWPROBE_MISALIGNED_SCALAR_FAST=*/3)
+    Features["unaligned-scalar-mem"] = true;
 
   return Features;
 }


### PR DESCRIPTION
This patch is the follow-up of https://github.com/llvm/llvm-project/pull/94352 with some updates:
1. Add support for more extensions for `zve*`, `zimop`, `zc*`, `zcmop` and `zawrs`.
2. Use `RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF` to check whether the processor supports fast misaligned scalar memory access. https://github.com/llvm/llvm-project/pull/108551 reminds me that the patch https://lore.kernel.org/all/20240809214444.3257596-1-evan@rivosinc.com/T/ has been merged. Address comment https://github.com/llvm/llvm-project/pull/94352#discussion_r1626056015.

References:
1. constants: https://github.com/torvalds/linux/blame/v6.11-rc7/arch/riscv/include/uapi/asm/hwprobe.h
2. https://docs.kernel.org/arch/riscv/hwprobe.html
3. Related commits:
    1. `zve*` support: https://github.com/torvalds/linux/commit/de8f8282a969d0b7342702f355886aab3b14043d
    2. `zimop` support: https://github.com/torvalds/linux/commit/36f8960de887a5e2811c5d1c0517cfa6f419c1c4
    3. `zc*` support: https://github.com/torvalds/linux/commit/0ad70db5eb21e50ed693fa274bea0346de453e29
    4. `zcmop` support: https://github.com/torvalds/linux/commit/fc078ea317cc856c1e82997da7e8fd4d6da7aa29
    5. `zawrs` support: https://github.com/torvalds/linux/commit/244c18fbf64a33d152645766a033b2935ab0acb5
    6. scalar misaligned perf: https://github.com/torvalds/linux/commit/c42e2f076769c9c1bc5f3f0aa1c2032558e76647 and https://github.com/torvalds/linux/commit/1f5288874de776412041022607513ffac74ae1a6
