### PR TITLE
[MLIR] Reuse the path to runner_utils libraries

### DIFF
--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -168,6 +168,7 @@ tools.extend(
         ToolSubst("transform-opt-ch3", unresolved="ignore"),
         ToolSubst("transform-opt-ch4", unresolved="ignore"),
         ToolSubst("mlir-transform-opt", unresolved="ignore"),
+        ToolSubst("%llvm_shlib_dir", config.llvm_shlib_dir, unresolved="ignore"),
         ToolSubst("%mlir_lib_dir", config.mlir_lib_dir, unresolved="ignore"),
         ToolSubst("%mlir_src_dir", config.mlir_src_root, unresolved="ignore"),
     ]

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -168,7 +168,6 @@ tools.extend(
         ToolSubst("transform-opt-ch3", unresolved="ignore"),
         ToolSubst("transform-opt-ch4", unresolved="ignore"),
         ToolSubst("mlir-transform-opt", unresolved="ignore"),
-        ToolSubst("%llvm_shlib_dir", config.llvm_shlib_dir, unresolved="ignore"),
         ToolSubst("%mlir_lib_dir", config.mlir_lib_dir, unresolved="ignore"),
         ToolSubst("%mlir_src_dir", config.mlir_src_root, unresolved="ignore"),
     ]

--- a/mlir/test/python/execution_engine.py
+++ b/mlir/test/python/execution_engine.py
@@ -7,8 +7,12 @@ from mlir.execution_engine import *
 from mlir.runtime import *
 from ml_dtypes import bfloat16, float8_e5m2
 
-MLIR_RUNNER_UTILS = os.getenv("MLIR_RUNNER_UTILS", "../../../../lib/libmlir_runner_utils.so")
-MLIR_C_RUNNER_UTILS = os.getenv("MLIR_C_RUNNER_UTILS", "../../../../lib/libmlir_c_runner_utils.so")
+MLIR_RUNNER_UTILS = os.getenv(
+    "MLIR_RUNNER_UTILS", "../../../../lib/libmlir_runner_utils.so"
+)
+MLIR_C_RUNNER_UTILS = os.getenv(
+    "MLIR_C_RUNNER_UTILS", "../../../../lib/libmlir_c_runner_utils.so"
+)
 
 # Log everything to stderr and flush so that we have a unified stream to match
 # errors/info emitted by MLIR to stderr.

--- a/mlir/test/python/execution_engine.py
+++ b/mlir/test/python/execution_engine.py
@@ -1,4 +1,4 @@
-# RUN: %PYTHON %s 2>&1 | FileCheck %s
+# RUN: env LLVM_SHLIB_DIR=%llvm_shlib_dir %PYTHON %s 2>&1 | FileCheck %s
 # REQUIRES: host-supports-jit
 import gc, sys, os, tempfile
 from mlir.ir import *
@@ -7,6 +7,8 @@ from mlir.execution_engine import *
 from mlir.runtime import *
 from ml_dtypes import bfloat16, float8_e5m2
 
+_DEFAULT_LIB_DIR = "../../../../lib"
+LIB_DIR = os.getenv("LLVM_SHLIB_DIR", _DEFAULT_LIB_DIR)
 
 # Log everything to stderr and flush so that we have a unified stream to match
 # errors/info emitted by MLIR to stderr.
@@ -700,8 +702,8 @@ def testSharedLibLoad():
             ]
         else:
             shared_libs = [
-                "../../../../lib/libmlir_runner_utils.so",
-                "../../../../lib/libmlir_c_runner_utils.so",
+                LIB_DIR + "/libmlir_runner_utils.so",
+                LIB_DIR + "/libmlir_c_runner_utils.so",
             ]
 
         execution_engine = ExecutionEngine(
@@ -743,8 +745,8 @@ def testNanoTime():
             ]
         else:
             shared_libs = [
-                "../../../../lib/libmlir_runner_utils.so",
-                "../../../../lib/libmlir_c_runner_utils.so",
+                LIB_DIR + "/libmlir_runner_utils.so",
+                LIB_DIR + "/libmlir_c_runner_utils.so",
             ]
 
         execution_engine = ExecutionEngine(

--- a/mlir/test/python/execution_engine.py
+++ b/mlir/test/python/execution_engine.py
@@ -749,8 +749,8 @@ def testNanoTime():
             ]
         else:
             shared_libs = [
-                LIB_DIR + "/libmlir_runner_utils.so",
-                LIB_DIR + "/libmlir_c_runner_utils.so",
+                MLIR_RUNNER_UTILS,
+                MLIR_C_RUNNER_UTILS,
             ]
 
         execution_engine = ExecutionEngine(

--- a/mlir/test/python/execution_engine.py
+++ b/mlir/test/python/execution_engine.py
@@ -1,4 +1,4 @@
-# RUN: env LLVM_SHLIB_DIR=%llvm_shlib_dir %PYTHON %s 2>&1 | FileCheck %s
+# RUN: env MLIR_RUNNER_UTILS=%mlir_runner_utils MLIR_C_RUNNER_UTILS=%mlir_c_runner_utils %PYTHON %s 2>&1 | FileCheck %s
 # REQUIRES: host-supports-jit
 import gc, sys, os, tempfile
 from mlir.ir import *
@@ -7,8 +7,8 @@ from mlir.execution_engine import *
 from mlir.runtime import *
 from ml_dtypes import bfloat16, float8_e5m2
 
-_DEFAULT_LIB_DIR = "../../../../lib"
-LIB_DIR = os.getenv("LLVM_SHLIB_DIR", _DEFAULT_LIB_DIR)
+MLIR_RUNNER_UTILS = os.getenv("MLIR_RUNNER_UTILS", "../../../../lib/libmlir_runner_utils.so")
+MLIR_C_RUNNER_UTILS = os.getenv("MLIR_C_RUNNER_UTILS", "../../../../lib/libmlir_c_runner_utils.so")
 
 # Log everything to stderr and flush so that we have a unified stream to match
 # errors/info emitted by MLIR to stderr.
@@ -702,8 +702,8 @@ def testSharedLibLoad():
             ]
         else:
             shared_libs = [
-                LIB_DIR + "/libmlir_runner_utils.so",
-                LIB_DIR + "/libmlir_c_runner_utils.so",
+                MLIR_RUNNER_UTILS,
+                MLIR_C_RUNNER_UTILS,
             ]
 
         execution_engine = ExecutionEngine(


### PR DESCRIPTION
Prefer to get the path to libmlir_runner_utils and libmlir_c_runner_utils via %mlir_runner_utils and %mlir_c_runner_utils. Fallback to the previous paths only if they aren't defined.

This ensures the test will pass regardless of the build configuration used downstream.