### PR TITLE
[clang][ExprConst] Explicitly reject dependent types without diagnostic

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -16009,6 +16009,8 @@ static bool Evaluate(APValue &Result, EvalInfo &Info, const Expr *E) {
       if (!EvaluateAtomic(E, nullptr, Result, Info))
         return false;
     }
+  } else if (T->isDependentType()) {
+    return false;
   } else if (Info.getLangOpts().CPlusPlus11) {
     Info.FFDiag(E, diag::note_constexpr_nonliteral) << E->getType();
     return false;

--- a/clang/test/SemaCXX/cxx2a-template-lambdas.cpp
+++ b/clang/test/SemaCXX/cxx2a-template-lambdas.cpp
@@ -43,13 +43,11 @@ struct ShadowMe {
 #if __cplusplus >= 201102L
 template<typename T>
 constexpr T outer() {
-  // FIXME: The C++11 error seems wrong
   return []<T x>() { return x; }.template operator()<123>(); // expected-error {{no matching member function}}  \
                                                                 expected-note {{candidate template ignored}}    \
-        cxx11-note {{non-literal type '<dependent type>' cannot be used in a constant expression}} \
         cxx14-note {{non-literal type}}
 }
-static_assert(outer<int>() == 123); // cxx11-cxx14-error {{not an integral constant expression}} cxx11-cxx14-note {{in call}}
+static_assert(outer<int>() == 123); // cxx11-cxx14-error {{not an integral constant expression}} cxx14-note {{in call}}
 template int *outer<int *>(); // expected-note {{in instantiation}}
 #endif
 


### PR DESCRIPTION
This should never happen I believe, but if it does, the `"non-literal type '<dependent type>'"` diagnostic is weird.

That dependent type should never reach this stage I believe.

If we actually try to generate code for this, we hit an assertion in codegen: https://godbolt.org/z/b19P9eqf9