### PR TITLE
[ADT] Add more useful methods to SmallSet API

### DIFF
--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -160,7 +160,7 @@ public:
     insert(R.begin(), R.end());
   }
 
-  SmallSet(std::initializer_list<T> L) { this->insert(L.begin(), L.end()); }
+  SmallSet(std::initializer_list<T> L) { insert(L.begin(), L.end()); }
 
   SmallSet &operator=(const SmallSet &) = default;
   SmallSet &operator=(SmallSet &&) = default;

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -152,12 +152,12 @@ public:
   SmallSet(SmallSet &&) = default;
 
   template <typename IterT> SmallSet(IterT Begin, IterT End) {
-    this->insert(Begin, End);
+    insert(Begin, End);
   }
 
   template <typename RangeT>
   explicit SmallSet(const iterator_range<RangeT> &R) {
-    this->insert(R.begin(), R.end());
+    insert(R.begin(), R.end());
   }
 
   SmallSet(std::initializer_list<T> L) { this->insert(L.begin(), L.end()); }

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/iterator.h"
 #include <cstddef>
 #include <functional>
+#include <initializer_list>
 #include <set>
 #include <utility>
 
@@ -147,6 +148,22 @@ public:
   using const_iterator = SmallSetIterator<T, N, C>;
 
   SmallSet() = default;
+  SmallSet(const SmallSet &) = default;
+  SmallSet(SmallSet &&) = default;
+
+  template <typename IterT> SmallSet(IterT Begin, IterT End) {
+    this->insert(Begin, End);
+  }
+
+  template <typename RangeT>
+  explicit SmallSet(const iterator_range<RangeT> &R) {
+    this->insert(R.begin(), R.end());
+  }
+
+  SmallSet(std::initializer_list<T> L) { this->insert(L.begin(), L.end()); }
+
+  SmallSet &operator=(const SmallSet &) = default;
+  SmallSet &operator=(SmallSet &&) = default;
 
   [[nodiscard]] bool empty() const { return Vector.empty() && Set.empty(); }
 

--- a/llvm/unittests/ADT/SmallSetTest.cpp
+++ b/llvm/unittests/ADT/SmallSetTest.cpp
@@ -17,6 +17,66 @@
 
 using namespace llvm;
 
+TEST(SmallSetTest, ConstructorIteratorPair) {
+  auto L = {1, 2, 3, 4, 5};
+  SmallSet<int, 4> S(std::begin(L), std::end(L));
+  for (int Value : L)
+    EXPECT_TRUE(S.contains(Value));
+}
+
+TEST(SmallSet, ConstructorRange) {
+  auto L = {1, 2, 3, 4, 5};
+
+  SmallSet<int, 4> S(llvm::make_range(std::begin(L), std::end(L)));
+  for (int Value : L)
+    EXPECT_TRUE(S.contains(Value));
+}
+
+TEST(SmallSet, ConstructorInitializerList) {
+  auto L = {1, 2, 3, 4, 5};
+  SmallSet<int, 4> S = {1, 2, 3, 4, 5};
+  for (int Value : L)
+    EXPECT_TRUE(S.contains(Value));
+}
+
+TEST(SmallSet, CopyConstructor) {
+  SmallSet<int, 4> S = {1, 2, 3};
+  SmallSet<int, 4> T = S;
+
+  EXPECT_EQ(S, T);
+}
+
+TEST(SmallSet, MoveConstructor) {
+  auto L = {1, 2, 3};
+  SmallSet<int, 4> S = L;
+  SmallSet<int, 4> T = std::move(S);
+
+  EXPECT_TRUE(T.size() == L.size());
+  for (int Value : L) {
+    EXPECT_TRUE(T.contains(Value));
+  }
+}
+
+TEST(SmallSet, CopyAssignment) {
+  SmallSet<int, 4> S = {1, 2, 3};
+  SmallSet<int, 4> T;
+  T = S;
+
+  EXPECT_EQ(S, T);
+}
+
+TEST(SmallSet, MoveAssignment) {
+  auto L = {1, 2, 3};
+  SmallSet<int, 4> S = L;
+  SmallSet<int, 4> T;
+  T = std::move(S);
+
+  EXPECT_TRUE(T.size() == L.size());
+  for (int Value : L) {
+    EXPECT_TRUE(T.contains(Value));
+  }
+}
+
 TEST(SmallSetTest, Insert) {
 
   SmallSet<int, 4> s1;

--- a/llvm/unittests/ADT/SmallSetTest.cpp
+++ b/llvm/unittests/ADT/SmallSetTest.cpp
@@ -12,49 +12,44 @@
 
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <string>
 
 using namespace llvm;
 
 TEST(SmallSetTest, ConstructorIteratorPair) {
-  auto L = {1, 2, 3, 4, 5};
+  std::initializer_list<int> L = {1, 2, 3, 4, 5};
   SmallSet<int, 4> S(std::begin(L), std::end(L));
-  for (int Value : L)
-    EXPECT_TRUE(S.contains(Value));
+  EXPECT_THAT(S, testing::UnorderedElementsAreArray(L));
 }
 
 TEST(SmallSet, ConstructorRange) {
-  auto L = {1, 2, 3, 4, 5};
+  std::initializer_list<int> L = {1, 2, 3, 4, 5};
 
   SmallSet<int, 4> S(llvm::make_range(std::begin(L), std::end(L)));
-  for (int Value : L)
-    EXPECT_TRUE(S.contains(Value));
+  EXPECT_THAT(S, testing::UnorderedElementsAreArray(L));
 }
 
 TEST(SmallSet, ConstructorInitializerList) {
-  auto L = {1, 2, 3, 4, 5};
+  std::initializer_list<int> L = {1, 2, 3, 4, 5};
   SmallSet<int, 4> S = {1, 2, 3, 4, 5};
-  for (int Value : L)
-    EXPECT_TRUE(S.contains(Value));
+  EXPECT_THAT(S, testing::UnorderedElementsAreArray(L));
 }
 
 TEST(SmallSet, CopyConstructor) {
   SmallSet<int, 4> S = {1, 2, 3};
   SmallSet<int, 4> T = S;
 
-  EXPECT_EQ(S, T);
+  EXPECT_THAT(S, testing::ContainerEq(T));
 }
 
 TEST(SmallSet, MoveConstructor) {
-  auto L = {1, 2, 3};
+  std::initializer_list<int> L = {1, 2, 3};
   SmallSet<int, 4> S = L;
   SmallSet<int, 4> T = std::move(S);
 
-  EXPECT_TRUE(T.size() == L.size());
-  for (int Value : L) {
-    EXPECT_TRUE(T.contains(Value));
-  }
+  EXPECT_THAT(T, testing::UnorderedElementsAreArray(L));
 }
 
 TEST(SmallSet, CopyAssignment) {
@@ -62,19 +57,16 @@ TEST(SmallSet, CopyAssignment) {
   SmallSet<int, 4> T;
   T = S;
 
-  EXPECT_EQ(S, T);
+  EXPECT_THAT(S, testing::ContainerEq(T));
 }
 
 TEST(SmallSet, MoveAssignment) {
-  auto L = {1, 2, 3};
+  std::initializer_list<int> L = {1, 2, 3};
   SmallSet<int, 4> S = L;
   SmallSet<int, 4> T;
   T = std::move(S);
 
-  EXPECT_TRUE(T.size() == L.size());
-  for (int Value : L) {
-    EXPECT_TRUE(T.contains(Value));
-  }
+  EXPECT_THAT(T, testing::UnorderedElementsAreArray(L));
 }
 
 TEST(SmallSetTest, Insert) {


### PR DESCRIPTION
This patch adds useful methods to the SmallSet API:

 - Constructor that takes pair of iterators.
 - Constructor that takes a range.
 - Constructor that takes an initializer list.
 - Copy constructor.
 - Move constructor.
 - Copy assignment operator.
 - Move assignment operator.