### PR TITLE
[SandboxVec] Boilerplate for vectorization passes

### DIFF
--- a/llvm/include/llvm/SandboxIR/Pass.h
+++ b/llvm/include/llvm/SandboxIR/Pass.h
@@ -40,6 +40,8 @@ public:
   virtual void print(raw_ostream &OS) const { OS << Name; }
   LLVM_DUMP_METHOD virtual void dump() const;
 #endif
+  /// Similar to print() but adds a newline. Used for testing.
+  void printPipeline(raw_ostream &OS) const { OS << Name << "\n"; }
 };
 
 /// A pass that runs on a sandbox::Function.

--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -49,6 +49,7 @@ public:
   void print(raw_ostream &OS) const override {
     OS << this->getName();
     OS << "(";
+    // TODO: This should call Pass->print(OS) because Pass may be a PM.
     interleave(Passes, OS, [&OS](auto *Pass) { OS << Pass->getName(); }, ",");
     OS << ")";
   }
@@ -57,6 +58,12 @@ public:
     dbgs() << "\n";
   }
 #endif
+  /// Similar to print() but prints one pass per line. Used for testing.
+  void printPipeline(raw_ostream &OS) const {
+    OS << this->getName() << "\n";
+    for (const auto &PassPtr : Passes)
+      PassPtr->printPipeline(OS);
+  }
 };
 
 class FunctionPassManager final

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -1,0 +1,28 @@
+//===- BottomUpVec.h --------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A Bottom-Up Vectorizer pass.
+//
+
+#ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_BOTTOMUPVEC_H
+#define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_BOTTOMUPVEC_H
+
+#include "llvm/SandboxIR/Pass.h"
+
+namespace llvm::sandboxir {
+
+class BottomUpVec final : public FunctionPass {
+
+public:
+  BottomUpVec() : FunctionPass("bottom-up-vec") {}
+  bool runOnFunction(Function &F) final;
+};
+
+} // namespace llvm::sandboxir
+
+#endif // LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_BOTTOMUPVEC_H

--- a/llvm/lib/Transforms/Vectorize/CMakeLists.txt
+++ b/llvm/lib/Transforms/Vectorize/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_component_library(LLVMVectorize
   LoopIdiomVectorize.cpp
   LoopVectorizationLegality.cpp
   LoopVectorize.cpp
+  SandboxVectorizer/Passes/BottomUpVec.cpp
   SandboxVectorizer/SandboxVectorizer.cpp
   SLPVectorizer.cpp
   Vectorize.cpp

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -1,0 +1,13 @@
+//===- BottomUpVec.cpp - A bottom-up vectorizer pass ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h"
+
+using namespace llvm::sandboxir;
+
+bool BottomUpVec::runOnFunction(Function &F) { return false; }

--- a/llvm/test/Transforms/SandboxVectorizer/default_pass_pipeline.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/default_pass_pipeline.ll
@@ -1,0 +1,11 @@
+; RUN: opt -passes=sandbox-vectorizer -sbvec-print-pass-pipeline %s -disable-output | FileCheck %s
+
+; !!!WARNING!!! This won't get updated by update_test_checks.py !
+
+; This checks the default pass pipeline for the sandbox vectorizer.
+define void @pipeline() {
+; CHECK: pm
+; CHECK: bottom-up-vec
+; CHECK-EMPTY:
+  ret void
+}


### PR DESCRIPTION
This patch implements a new empty pass for the Bottom-up vectorizer and creates a pass pipeline that includes it.
The SandboxVectorizer LLVM pass runs the Sandbox IR pass pipeline.