### PR TITLE
[LLVM][TableGen] Change CodeGenSchedule to use const RecordKeeper

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1912,6 +1912,9 @@ public:
   /// vector of records, throwing an exception if the field does not exist or
   /// if the value is not the right type.
   std::vector<Record*> getValueAsListOfDefs(StringRef FieldName) const;
+  // Temporary function to help staged migration to const Record pointers.
+  std::vector<const Record *>
+  getValueAsListOfConstDefs(StringRef FieldName) const;
 
   /// This method looks up the specified field and returns its value as a
   /// vector of integers, throwing an exception if the field does not exist or

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -3027,6 +3027,21 @@ Record::getValueAsListOfDefs(StringRef FieldName) const {
   return Defs;
 }
 
+std::vector<const Record *>
+Record::getValueAsListOfConstDefs(StringRef FieldName) const {
+  ListInit *List = getValueAsListInit(FieldName);
+  std::vector<const Record *> Defs;
+  for (const Init *I : List->getValues()) {
+    if (const DefInit *DI = dyn_cast<DefInit>(I))
+      Defs.push_back(DI->getDef());
+    else
+      PrintFatalError(getLoc(), "Record `" + getName() + "', field `" +
+                                    FieldName +
+                                    "' list is not entirely DefInit!");
+  }
+  return Defs;
+}
+
 int64_t Record::getValueAsInt(StringRef FieldName) const {
   const RecordVal *R = getValue(FieldName);
   if (!R || !R->getValue())

--- a/llvm/utils/TableGen/Common/Utils.cpp
+++ b/llvm/utils/TableGen/Common/Utils.cpp
@@ -27,7 +27,7 @@ struct LessRecordFieldNameAndID {
 
 /// Sort an array of Records on the "Name" field, and check for records with
 /// duplicate "Name" field. If duplicates are found, report a fatal error.
-void llvm::sortAndReportDuplicates(MutableArrayRef<Record *> Records,
+void llvm::sortAndReportDuplicates(MutableArrayRef<const Record *> Records,
                                    StringRef ObjectName) {
   llvm::sort(Records, LessRecordFieldNameAndID());
 

--- a/llvm/utils/TableGen/Common/Utils.h
+++ b/llvm/utils/TableGen/Common/Utils.h
@@ -17,7 +17,7 @@ class Record;
 
 /// Sort an array of Records on the "Name" field, and check for records with
 /// duplicate "Name" field. If duplicates are found, report a fatal error.
-void sortAndReportDuplicates(MutableArrayRef<Record *> Records,
+void sortAndReportDuplicates(MutableArrayRef<const Record *> Records,
                              StringRef ObjectName);
 
 } // namespace llvm

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -100,13 +100,13 @@ int DFAPacketizerEmitter::collectAllFuncUnits(
   LLVM_DEBUG(dbgs() << "collectAllFuncUnits");
   LLVM_DEBUG(dbgs() << " (" << ProcModels.size() << " itineraries)\n");
 
-  std::set<Record *> ProcItinList;
+  std::set<const Record *> ProcItinList;
   for (const CodeGenProcModel *Model : ProcModels)
     ProcItinList.insert(Model->ItinsDef);
 
   int totalFUs = 0;
   // Parse functional units for all the itineraries.
-  for (Record *Proc : ProcItinList) {
+  for (const Record *Proc : ProcItinList) {
     std::vector<Record *> FUs = Proc->getValueAsListOfDefs("FU");
 
     LLVM_DEBUG(dbgs() << "    FU:"


### PR DESCRIPTION
Change CodeGenSchedule to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089