### PR TITLE
[SandboxVec] User-defined pass pipeline

### DIFF
--- a/llvm/test/Transforms/SandboxVectorizer/user_pass_pipeline.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/user_pass_pipeline.ll
@@ -1,0 +1,12 @@
+; RUN: opt -passes=sandbox-vectorizer -sbvec-print-pass-pipeline -sbvec-passes=bottom-up-vec,bottom-up-vec %s -disable-output | FileCheck %s
+
+; !!!WARNING!!! This won't get updated by update_test_checks.py !
+
+; This checks the user defined pass pipeline.
+define void @pipeline() {
+; CHECK: pm
+; CHECK: bottom-up-vec
+; CHECK: bottom-up-vec
+; CHECK-EMPTY:
+  ret void
+}


### PR DESCRIPTION
This patch adds support for a user-defined pass-pipeline that overrides the default pipeline of the vectorizer.
This will commonly be used by lit tests.