### PR TITLE
[libc++][modules] Don't error when including <wchar.h> or <wctype.h> without wide character support

### DIFF
--- a/libcxx/include/__std_clang_module
+++ b/libcxx/include/__std_clang_module
@@ -73,12 +73,8 @@
 #include <ctime>
 #include <ctype.h>
 #include <cuchar>
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <cwchar>
-#endif
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <cwctype>
-#endif
+#include <cwchar>
+#include <cwctype>
 #include <deque>
 #include <errno.h>
 #include <exception>
@@ -193,9 +189,5 @@
 #include <variant>
 #include <vector>
 #include <version>
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <wchar.h>
-#endif
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <wctype.h>
-#endif
+#include <wchar.h>
+#include <wctype.h>

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -108,11 +108,6 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #  include <__config>
 #  include <stddef.h>
 
-#  if defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#    error                                                                                                             \
-        "The <wchar.h> header is not supported since libc++ has been configured with LIBCXX_ENABLE_WIDE_CHARACTERS disabled"
-#  endif
-
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #    pragma GCC system_header
 #  endif
@@ -142,7 +137,8 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #    endif
 #  endif
 
-#  if defined(__cplusplus) && !defined(_LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#    if defined(__cplusplus) && !defined(_LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
 extern "C++" {
 inline _LIBCPP_HIDE_FROM_ABI wchar_t* __libcpp_wcschr(const wchar_t* __s, wchar_t __c) {
   return (wchar_t*)wcschr(__s, __c);
@@ -197,15 +193,16 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD wchar_t* wmemchr(wchar_t
   return __libcpp_wmemchr(__s, __c, __n);
 }
 }
-#  endif
+#    endif
 
-#  if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
+#    if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
 extern "C" {
 size_t mbsnrtowcs(
     wchar_t* __restrict __dst, const char** __restrict __src, size_t __nmc, size_t __len, mbstate_t* __restrict __ps);
 size_t wcsnrtombs(
     char* __restrict __dst, const wchar_t** __restrict __src, size_t __nwc, size_t __len, mbstate_t* __restrict __ps);
 } // extern "C"
-#  endif // __cplusplus && (_LIBCPP_MSVCRT || __MVS__)
+#    endif // __cplusplus && (_LIBCPP_MSVCRT || __MVS__)
+#  endif   // !_LIBCPP_HAS_NO_WIDE_CHARACTERS
 
 #endif // _LIBCPP_WCHAR_H

--- a/libcxx/include/wctype.h
+++ b/libcxx/include/wctype.h
@@ -46,11 +46,6 @@ wctrans_t wctrans(const char* property);
 
 #include <__config>
 
-#if defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  error                                                                                                               \
-      "The <wctype.h> header is not supported since libc++ has been configured with LIBCXX_ENABLE_WIDE_CHARACTERS disabled"
-#endif
-
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif

--- a/libcxx/modules/std.compat.cppm.in
+++ b/libcxx/modules/std.compat.cppm.in
@@ -38,12 +38,8 @@ module;
 #include <cstring>
 #include <ctime>
 #include <cuchar>
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <cwchar>
-#endif
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <cwctype>
-#endif
+#include <cwchar>
+#include <cwctype>
 
 // *** Headers not yet available ***
 //

--- a/libcxx/modules/std.cppm.in
+++ b/libcxx/modules/std.cppm.in
@@ -57,12 +57,8 @@ module;
 #include <cstring>
 #include <ctime>
 #include <cuchar>
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <cwchar>
-#endif
-#if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
-#  include <cwctype>
-#endif
+#include <cwchar>
+#include <cwctype>
 #include <deque>
 #include <exception>
 #include <execution>

--- a/libcxx/test/std/depr/depr.c.headers/wchar_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/wchar_h.compile.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: no-wide-characters
+// UNSUPPORTED: no-wide-characters
 
 // <wchar.h>
 

--- a/libcxx/test/std/depr/depr.c.headers/wctype_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/wctype_h.compile.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: no-wide-characters
+// UNSUPPORTED: no-wide-characters
 
 // <wctype.h>
 

--- a/libcxx/test/std/strings/c.strings/cwchar.pass.cpp
+++ b/libcxx/test/std/strings/c.strings/cwchar.pass.cpp
@@ -8,7 +8,7 @@
 
 // <cwchar>
 
-// XFAIL: no-wide-characters
+// UNSUPPORTED: no-wide-characters
 
 #include <cwchar>
 #include <ctime>

--- a/libcxx/test/std/strings/c.strings/cwchar_include_order1.compile.verify.cpp
+++ b/libcxx/test/std/strings/c.strings/cwchar_include_order1.compile.verify.cpp
@@ -8,7 +8,7 @@
 
 // <cwchar>
 
-// XFAIL: no-wide-characters
+// UNSUPPORTED: no-wide-characters
 
 // Tests that include ordering does not affect the definition of wcsstr.
 // See: https://llvm.org/PR62638

--- a/libcxx/test/std/strings/c.strings/cwchar_include_order2.compile.verify.cpp
+++ b/libcxx/test/std/strings/c.strings/cwchar_include_order2.compile.verify.cpp
@@ -8,7 +8,7 @@
 
 // <cwchar>
 
-// XFAIL: no-wide-characters
+// UNSUPPORTED: no-wide-characters
 
 // Tests that include ordering does not affect the definition of wcsstr.
 // See: https://llvm.org/PR62638

--- a/libcxx/test/std/strings/c.strings/cwctype.pass.cpp
+++ b/libcxx/test/std/strings/c.strings/cwctype.pass.cpp
@@ -8,7 +8,7 @@
 
 // <cwctype>
 
-// XFAIL: no-wide-characters
+// UNSUPPORTED: no-wide-characters
 
 #include <cwctype>
 #include <type_traits>

--- a/libcxx/utils/libcxx/header_information.py
+++ b/libcxx/utils/libcxx/header_information.py
@@ -30,13 +30,6 @@ header_restrictions = {
     "streambuf": "!defined(_LIBCPP_HAS_NO_LOCALIZATION)",
     "strstream": "!defined(_LIBCPP_HAS_NO_LOCALIZATION)",
     "syncstream": "!defined(_LIBCPP_HAS_NO_LOCALIZATION)",
-
-    # headers with #error directives
-    "wchar.h": "!defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)",
-    "wctype.h": "!defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)",
-    # transitive includers of the above headers
-    "cwchar": "!defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)",
-    "cwctype": "!defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)",
 }
 
 lit_header_restrictions = {


### PR DESCRIPTION
Instead, make the headers empty like we do for all the other carve-outs.