### PR TITLE
[bazel][NFC] Use globs to make `Vectorize` less brittle

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1485,15 +1485,11 @@ cc_library(
 cc_library(
     name = "Vectorize",
     srcs = glob([
-        "lib/Transforms/Vectorize/*.cpp",
-        "lib/Transforms/Vectorize/*.h",
-        "lib/Transforms/Vectorize/SandboxVectorizer/*.cpp",
-        "lib/Transforms/Vectorize/SandboxVectorizer/Passes/*.cpp",
+        "lib/Transforms/Vectorize/**/*.cpp",
+        "lib/Transforms/Vectorize/**/*.h",
     ]),
     hdrs = glob([
-        "include/llvm/Transforms/Vectorize/*.h",
-        "include/llvm/Transforms/Vectorize/SandboxVectorizer/*.h",
-        "include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/*.h"
+        "include/llvm/Transforms/Vectorize/**/*.h",
     ]),
     copts = llvm_copts,
     deps = [


### PR DESCRIPTION
This avoids needing to update the rule every time there's a new directory, e.g. SandboxVectorizer packages.