### PR TITLE
Revert "[clang] Silence GCC warnings about control reaching end of non void function"

### DIFF
--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -18,7 +18,6 @@
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/ErrorHandling.h"
 #include <optional>
 #include <vector>
 
@@ -311,7 +310,6 @@ public:
         return {diag::Severity::Fatal, std::string(Message), CLASS_ERROR,
                 /*ShowInSystemHeader*/ true};
       }
-      llvm_unreachable("Fully covered switch above!");
     }());
   }
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7331,7 +7331,6 @@ static bool diagnoseDiagnoseIfAttrsWith(Sema &S, const NamedDecl *ND,
     case DiagnoseIfAttr::DS_error:
       return diag::Severity::Error;
     }
-    llvm_unreachable("Fully covered switch above!");
   };
 
   for (const auto *DIA : llvm::make_range(WarningBegin, Attrs.end()))


### PR DESCRIPTION
This reverts commit 90a2e0bb423629b7e70f4b91adb44851199dd5ea.

Reverting parent of this change in #108645, 
