### PR TITLE
[CMake] Use old DynamicLibrary symbol behavior on AIX for now

### DIFF
--- a/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
+++ b/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
@@ -15,12 +15,22 @@ set_output_directory(DynamicLibraryLib
   LIBRARY_DIR ${LLVM_LIBRARY_OUTPUT_INTDIR}
   )
 
-add_llvm_unittest(DynamicLibraryTests
-  DynamicLibraryTest.cpp
+# FIXME: Find out why AIX fails with new DynamicLibrary symbols behavior.
+if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  add_llvm_unittest(DynamicLibraryTests
+    DynamicLibraryTest.cpp
+    )
+else()
+  add_llvm_unittest(DynamicLibraryTests
+    DynamicLibraryTest.cpp
 
-  EXPORT_SYMBOLS
-  )
+    EXPORT_SYMBOLS
+    )
+endif()
 target_link_libraries(DynamicLibraryTests PRIVATE DynamicLibraryLib)
+if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  export_executable_symbols(DynamicLibraryTests)
+endif()
 
 function(dynlib_add_module NAME)
   add_library(${NAME} MODULE


### PR DESCRIPTION
New behavior broke the AIX bot, so fall back to the old behavior on AIX for now to give time to investigate