### PR TITLE
[clang-format] Fix regression with BlockIndent of Braced Initializers

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -348,8 +348,8 @@ bool ContinuationIndenter::canBreak(const LineState &State) {
     }
   }
 
-  // Don't allow breaking before a closing right brace of a block-indented
-  // braced list initializer if there was not already a break.
+  // Don't allow breaking before a closing brace of a block-indented braced list
+  // initializer if there isn't already a break.
   if (Current.is(tok::r_brace) && Current.MatchingParen &&
       Current.isBlockIndentedInitRBrace(Style)) {
     return CurrentState.BreakBeforeClosingBrace;

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -348,6 +348,13 @@ bool ContinuationIndenter::canBreak(const LineState &State) {
     }
   }
 
+  // Don't allow breaking before a closing right brace of a block-indented
+  // braced list initializer if there was not already a break.
+  if (Current.is(tok::r_brace) && Current.MatchingParen &&
+      Current.isBlockIndentedInitRBrace(Style)) {
+    return CurrentState.BreakBeforeClosingBrace;
+  }
+
   // If binary operators are moved to the next line (including commas for some
   // styles of constructor initializers), that's always ok.
   if (!Current.isOneOf(TT_BinaryOperator, tok::comma) &&

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -9336,9 +9336,6 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
                "    ccccccc(aaaaaaaaaaaaaaaaa,         //\n"
                "        b));",
                Style);
-  verifyFormat("aaaaaaa<bbbbbbbb> const aaaaaaaaaa{\n"
-               "    aaaaaaaaaaaaa(aaaaaaaaaaa, aaaaaaaaaaaaaaaa)};",
-               Style);
 
   Style.ColumnLimit = 30;
   verifyFormat("for (int foo = 0; foo < FOO;\n"
@@ -9398,9 +9395,6 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
       "fooooooooooo(new FOO::BARRRR(\n"
       "    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXZZZZZZZZZZZZZZZZZZZZZZZZZ()));",
       Style);
-  verifyFormat("aaaaaaa<bbbbbbbb> const aaaaaaaaaa{\n"
-               "    aaaaaaaaaaaaa(aaaaaaaaaaa, aaaaaaaaaaaaaaaa)};",
-               Style);
 
   Style.AlignAfterOpenBracket = FormatStyle::BAS_BlockIndent;
   Style.BinPackArguments = false;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -9336,6 +9336,9 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
                "    ccccccc(aaaaaaaaaaaaaaaaa,         //\n"
                "        b));",
                Style);
+  verifyFormat("aaaaaaa<bbbbbbbb> const aaaaaaaaaa{\n"
+               "    aaaaaaaaaaaaa(aaaaaaaaaaa, aaaaaaaaaaaaaaaa)};",
+               Style);
 
   Style.ColumnLimit = 30;
   verifyFormat("for (int foo = 0; foo < FOO;\n"
@@ -9395,6 +9398,9 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
       "fooooooooooo(new FOO::BARRRR(\n"
       "    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXZZZZZZZZZZZZZZZZZZZZZZZZZ()));",
       Style);
+  verifyFormat("aaaaaaa<bbbbbbbb> const aaaaaaaaaa{\n"
+               "    aaaaaaaaaaaaa(aaaaaaaaaaa, aaaaaaaaaaaaaaaa)};",
+               Style);
 
   Style.AlignAfterOpenBracket = FormatStyle::BAS_BlockIndent;
   Style.BinPackArguments = false;
@@ -9441,6 +9447,11 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
       "    aaaaaaaaaaaaaaaa\n"
       ");",
       Style);
+  verifyFormat("aaaaaaa<bbbbbbbb> const aaaaaaaaaa{\n"
+               "    aaaaaaaaaaaaa(aaaaaaaaaaa, aaaaaaaaaaaaaaaa)\n"
+               "};",
+               Style);
+
   verifyFormat("bool aaaaaaaaaaaaaaaaaaaaaaaaaaa(\n"
                "    const bool &aaaaaaaaa, const void *aaaaaaaaaa\n"
                ") const {\n"


### PR DESCRIPTION
Fixes #73584.