### PR TITLE
[lldb][intel-pt] Fix build error on conversion from llvm::Error to Status::FromError

### DIFF
--- a/lldb/source/Plugins/Trace/intel-pt/CommandObjectTraceStartIntelPT.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/CommandObjectTraceStartIntelPT.cpp
@@ -78,7 +78,7 @@ bool CommandObjectThreadTraceStartIntelPT::DoExecuteOnThreads(
     llvm::ArrayRef<lldb::tid_t> tids) {
   if (Error err = m_trace.Start(tids, m_options.m_ipt_trace_size,
                                 m_options.m_enable_tsc, m_options.m_psb_period))
-    result.SetError(Status(std::move(err)));
+    result.SetError(std::move(err));
   else
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
@@ -164,7 +164,7 @@ void CommandObjectProcessTraceStartIntelPT::DoExecute(
           m_options.m_ipt_trace_size, m_options.m_process_buffer_size_limit,
           m_options.m_enable_tsc, m_options.m_psb_period,
           m_options.m_per_cpu_tracing, m_options.m_disable_cgroup_filtering))
-    result.SetError(Status(std::move(err)));
+    result.SetError(std::move(err));
   else
     result.SetStatus(eReturnStatusSuccessFinishResult);
 }


### PR DESCRIPTION
Summary: This introduced from upstream [#107163](https://github.com/llvm/llvm-project/pull/107163)

Test Plan: I can build

Closes: #107580