### PR TITLE
[rtsan] Fix RTTI issue, make a better c test

### DIFF
--- a/compiler-rt/lib/rtsan/CMakeLists.txt
+++ b/compiler-rt/lib/rtsan/CMakeLists.txt
@@ -29,6 +29,8 @@ set(RTSAN_LINK_LIBS
   ${COMPILER_RT_UNWINDER_LINK_LIBS}
   ${COMPILER_RT_CXX_LINK_LIBS})
 
+append_rtti_flag(OFF RTSAN_CFLAGS)
+
 if(APPLE)
   add_compiler_rt_object_libraries(RTRtsan
     OS ${SANITIZER_COMMON_SUPPORTED_OS}

--- a/compiler-rt/test/rtsan/basic.cpp
+++ b/compiler-rt/test/rtsan/basic.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
-// RUN: %clang -fsanitize=realtime %s -o %t
 // RUN: not %run %t 2>&1 | FileCheck %s
 // UNSUPPORTED: ios
 

--- a/compiler-rt/test/rtsan/sanity_check_pure_c.c
+++ b/compiler-rt/test/rtsan/sanity_check_pure_c.c
@@ -1,0 +1,28 @@
+// RUN: %clang -fsanitize=realtime %s -o %t
+// RUN: not %run %t 2>&1 | FileCheck %s
+// RUN: %clang %s -o %t
+// RUN: %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NO-SANITIZE
+#ifdef __cplusplus
+#  error "This test must be built in C mode"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// Check that we can build and run C code.
+
+void nonblocking_function(void) __attribute__((nonblocking));
+
+void nonblocking_function(void) __attribute__((nonblocking)) {
+  void *ptr = malloc(2);
+  printf("ptr: %p\n", ptr); // ensure we don't optimize out the malloc
+}
+
+int main() {
+  nonblocking_function();
+  printf("Done\n");
+  return 0;
+}
+
+// CHECK: ==ERROR: RealtimeSanitizer
+// CHECK-NO-SANITIZE: Done


### PR DESCRIPTION
Later in a development branch, our c tests were failing, this was due to the lack of RTTI.

This follows very similar patterns found in the other sanitizers:
https://github.com/llvm/llvm-project/blob/a205a854e06d36c1d0def3e3bc3743defdb6abc1/compiler-rt/lib/asan/CMakeLists.txt#L113
https://github.com/llvm/llvm-project/blob/a205a854e06d36c1d0def3e3bc3743defdb6abc1/compiler-rt/lib/tsan/CMakeLists.txt#L10
https://github.com/llvm/llvm-project/blob/a205a854e06d36c1d0def3e3bc3743defdb6abc1/compiler-rt/lib/ubsan/CMakeLists.txt#L45

Adding a more fully fledged c test that ensures we will catch these issues in the future.