### PR TITLE
[git-clang-format] Fix: make the tool backward compatible

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -402,6 +402,8 @@ def filter_symlinks(dictionary):
 
 def filter_ignored_files(dictionary, binary):
   """Delete every key in `dictionary` that is ignored by clang-format."""
+  if not os.path.exists('.clang-format-ignore'):
+    return
   ignored_files = run(binary, '-list-ignored', *dictionary.keys())
   if not ignored_files:
     return


### PR DESCRIPTION
## Summary

Currently it's not backward compatible, because the flag -list-ignored doesn't exists on older version of clang-format.

To make this tool still backward compatible, we can first check if the .clang-format-ignore file exists before we run clang-format with the -list-ignored flag.

Maybe better would be to check the version of the installed `clang-format` and if it's not 19 than skip this functionality ?

Related issues:

https://github.com/llvm/llvm-project/pull/102629
https://github.com/llvm/llvm-project/issues/108337