### PR TITLE
[NFC] Correct the misuse of the API in the Clang test-report script.

### DIFF
--- a/clang/tools/scan-build-py/tests/unit/test_report.py
+++ b/clang/tools/scan-build-py/tests/unit/test_report.py
@@ -538,7 +538,7 @@ class MergeSarifTest(unittest.TestCase):
                         "test message 6-1 [link](sarif:/runs/4/results/0)",
                     ],
                 )
-                self.assertEquals(
+                self.assertEqual(
                     thread_flows,
                     [
                         "test message 1-2 [link](sarif:/runs/1/results/0)",


### PR DESCRIPTION
ref: https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertEqual