### PR TITLE
[libcxx] No _LIBCPP_ELAST needed for LLVM libc

### DIFF
--- a/libcxx/src/include/config_elast.h
+++ b/libcxx/src/include/config_elast.h
@@ -21,6 +21,8 @@
 // where strerror/strerror_r can't handle out-of-range errno values.
 #if defined(ELAST)
 #  define _LIBCPP_ELAST ELAST
+#elif defined(__LLVM_LIBC__)
+// No _LIBCPP_ELAST needed for LLVM libc
 #elif defined(_NEWLIB_VERSION)
 #  define _LIBCPP_ELAST __ELASTERROR
 #elif defined(__NuttX__)


### PR DESCRIPTION
LLVM libc can handle out-of-range errno values.