### PR TITLE
[clang-tidy] fix false positive when member initialization depends on structured binging variable in cppcoreguidelines-prefer-member-initializer

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
@@ -83,7 +83,7 @@ static void updateAssignmentLevel(
       memberExpr(hasObjectExpression(cxxThisExpr()),
                  member(fieldDecl(indexNotLessThan(Field->getFieldIndex()))));
   auto DeclMatcher = declRefExpr(
-      to(varDecl(unless(parmVarDecl()), hasDeclContext(equalsNode(Ctor)))));
+      to(valueDecl(unless(parmVarDecl()), hasDeclContext(equalsNode(Ctor)))));
   const bool HasDependence = !match(expr(anyOf(MemberMatcher, DeclMatcher,
                                                hasDescendant(MemberMatcher),
                                                hasDescendant(DeclMatcher))),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -111,6 +111,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/casting-through-void>` check to suggest replacing
   the offending code with ``reinterpret_cast``, to more clearly express intent.
 
+- Improved :doc:`cppcoreguidelines-prefer-member-initializer
+  <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>` check to avoid
+  false positive when member initialization depends on structured binging variable.
+
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check to support replacing
   member function calls too.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -113,7 +113,8 @@ Changes in existing checks
 
 - Improved :doc:`cppcoreguidelines-prefer-member-initializer
   <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>` check to avoid
-  false positive when member initialization depends on structured binging variable.
+  false positive when member initialization depends on a structured binging
+  variable.
 
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check to support replacing

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -639,3 +639,14 @@ struct S3 {
   T M;
 };
 }
+
+namespace GH82970 {
+struct InitFromBingingDecl {
+  int m;
+  InitFromBingingDecl() {
+    struct { int i; } a;
+    auto [n] = a;
+    m = n;
+  }
+};
+} // namespace GH82970


### PR DESCRIPTION
Fixes: #82970

Detecting dependiences with `varDecl` is too strict. It will ignore the `bingingDecl`.
This patch wants to use `valueDecl` to match more cases including `bingingDecl`.
