### PR TITLE
[WebAssembly] Fix br type checking

### DIFF
--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
@@ -143,9 +143,10 @@ bool WebAssemblyAsmTypeCheck::checkBr(SMLoc ErrorLoc, size_t Level) {
       BrStack[BrStack.size() - Level - 1];
   if (Expected.size() > Stack.size())
     return typeError(ErrorLoc, "br: insufficient values on the type stack");
-  auto IsStackTopInvalid = checkStackTop(Expected, Stack);
-  if (IsStackTopInvalid)
-    return typeError(ErrorLoc, "br " + IsStackTopInvalid.value());
+  for (auto VT : llvm::reverse(Expected)) {
+    if (popType(ErrorLoc, VT))
+      return true;
+  }
   return false;
 }
 

--- a/llvm/test/MC/WebAssembly/basic-assembly.s
+++ b/llvm/test/MC/WebAssembly/basic-assembly.s
@@ -82,11 +82,13 @@ test0:
     i32.const   3
     end_block            # "switch" exit.
     if                   # void
+    i32.const   0
     if          i32
-    end_if
-    else
+    i32.const   5
     end_if
     drop
+    else
+    end_if
     block       void
     i32.const   2
     return

--- a/llvm/test/MC/WebAssembly/eh-assembly.s
+++ b/llvm/test/MC/WebAssembly/eh-assembly.s
@@ -4,10 +4,10 @@
 
   .tagtype  __cpp_exception i32
   .tagtype  __c_longjmp i32
-  .functype  eh_legacy_test () -> ()
   .functype  foo () -> ()
 
 eh_legacy_test:
+  .functype  eh_legacy_test () -> ()
   # try-catch with catch, catch_all, throw, and rethrow
   try
     i32.const 3

--- a/llvm/test/MC/WebAssembly/eh-assembly.s
+++ b/llvm/test/MC/WebAssembly/eh-assembly.s
@@ -8,6 +8,7 @@
 
 eh_legacy_test:
   .functype  eh_legacy_test () -> ()
+
   # try-catch with catch, catch_all, throw, and rethrow
   try
     i32.const 3


### PR DESCRIPTION
Currently the type checker does not pop values from the stack when a `br` takes a value to the end of a typed `block`. For example:
```wat
block i32
  ...
  block
    i32.const 3
    br 1
  end_block
  ;; At this point, 'i32.const 3' is still on the stack, because 'br'
  ;; did not pop 'i32.const 3'
  ...
end_block
```

`checkStackTop` only checks the top of the stack and does not actually pop them. This makes `br` actually pop the stack.

Test changes in the `if` part were necessary because those `if`s were not valid but somehow did not error out due to the (incorrectly) remaining values from above. Also the checker does not correctly handle block input values, but that's a separate bug.

A couple more lines of test changes were just drive-by fixes to make `-filetype=obj` work. Currently the produced `.o` files are not valid without them.