### PR TITLE
[LLVM][TableGen] Change CodeGenTarget to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -636,7 +636,7 @@ void AsmWriterEmitter::EmitGetRegisterName(raw_ostream &O) {
   Record *AsmWriter = Target.getAsmWriter();
   StringRef ClassName = AsmWriter->getValueAsString("AsmWriterClassName");
   const auto &Registers = Target.getRegBank().getRegisters();
-  const std::vector<Record *> &AltNameIndices = Target.getRegAltNameIndices();
+  ArrayRef<const Record *> AltNameIndices = Target.getRegAltNameIndices();
   bool hasAltNames = AltNameIndices.size() > 1;
   StringRef Namespace = Registers.front().TheDef->getValueAsString("Namespace");
 

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -56,19 +56,18 @@ std::string getQualifiedName(const Record *R);
 /// CodeGenTarget - This class corresponds to the Target class in the .td files.
 ///
 class CodeGenTarget {
-  RecordKeeper &Records;
-  Record *TargetRec;
+  const RecordKeeper &Records;
+  const Record *TargetRec;
 
   mutable DenseMap<const Record *, std::unique_ptr<CodeGenInstruction>>
       Instructions;
   mutable std::unique_ptr<CodeGenRegBank> RegBank;
-  mutable std::vector<Record *> RegAltNameIndices;
+  mutable ArrayRef<const Record *> RegAltNameIndices;
   mutable SmallVector<ValueTypeByHwMode, 8> LegalValueTypes;
   CodeGenHwModes CGH;
-  std::vector<Record *> MacroFusions;
+  ArrayRef<const Record *> MacroFusions;
   mutable bool HasVariableLengthEncodings = false;
 
-  void ReadRegAltNameIndices() const;
   void ReadInstructions() const;
   void ReadLegalValueTypes() const;
 
@@ -81,10 +80,10 @@ class CodeGenTarget {
   mutable unsigned NumPseudoInstructions = 0;
 
 public:
-  CodeGenTarget(RecordKeeper &Records);
+  CodeGenTarget(const RecordKeeper &Records);
   ~CodeGenTarget();
 
-  Record *getTargetRecord() const { return TargetRec; }
+  const Record *getTargetRecord() const { return TargetRec; }
   StringRef getName() const;
 
   /// getInstNamespace - Return the target-specific instruction namespace.
@@ -135,9 +134,9 @@ public:
   /// return it.
   const CodeGenRegister *getRegisterByName(StringRef Name) const;
 
-  const std::vector<Record *> &getRegAltNameIndices() const {
+  ArrayRef<const Record *> getRegAltNameIndices() const {
     if (RegAltNameIndices.empty())
-      ReadRegAltNameIndices();
+      RegAltNameIndices = Records.getAllDerivedDefinitions("RegAltNameIndex");
     return RegAltNameIndices;
   }
 
@@ -159,7 +158,7 @@ public:
 
   bool hasMacroFusion() const { return !MacroFusions.empty(); }
 
-  const std::vector<Record *> getMacroFusions() const { return MacroFusions; }
+  ArrayRef<const Record *> getMacroFusions() const { return MacroFusions; }
 
 private:
   DenseMap<const Record *, std::unique_ptr<CodeGenInstruction>> &

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -152,8 +152,7 @@ void RegisterInfoEmitter::runEnums(raw_ostream &OS, CodeGenTarget &Target,
       OS << "} // end namespace " << Namespace << "\n\n";
   }
 
-  const std::vector<Record *> &RegAltNameIndices =
-      Target.getRegAltNameIndices();
+  ArrayRef<const Record *> RegAltNameIndices = Target.getRegAltNameIndices();
   // If the only definition is the default NoRegAltName, we don't need to
   // emit anything.
   if (RegAltNameIndices.size() > 1) {


### PR DESCRIPTION
 Change CodeGenTarget to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089
