### PR TITLE
[LLVM][TableGen] Change CodeGenInstAlias to use const Record pointers

### DIFF
--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -454,7 +454,7 @@ struct MatchableInfo {
       int64_t ImmVal;
 
       /// Register - This is the register record.
-      Record *Register;
+      const Record *Register;
     };
 
     /// MINumOperands - The number of MCInst operands populated by this
@@ -486,7 +486,7 @@ struct MatchableInfo {
       return X;
     }
 
-    static ResOperand getRegOp(Record *Reg) {
+    static ResOperand getRegOp(const Record *Reg) {
       ResOperand X;
       X.Kind = RegOperand;
       X.Register = Reg;
@@ -1946,7 +1946,7 @@ void MatchableInfo::buildAliasResultOperands(bool AliasConstraintsAreChecked) {
         break;
       }
       case CodeGenInstAlias::ResultOperand::K_Reg: {
-        Record *Reg = CGA.ResultOperands[AliasOpNo].getRegister();
+        const Record *Reg = CGA.ResultOperands[AliasOpNo].getRegister();
         ResOperands.push_back(ResOperand::getRegOp(Reg));
         break;
       }

--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -953,7 +953,7 @@ void AsmWriterEmitter::EmitPrintAliasInstruction(raw_ostream &O) {
           if (Rec->isSubClassOf("RegisterClass")) {
             if (!IAP.isOpMapped(ROName)) {
               IAP.addOperand(ROName, MIOpNum, PrintMethodIdx);
-              Record *R = CGA.ResultOperands[i].getRecord();
+              const Record *R = CGA.ResultOperands[i].getRecord();
               if (R->isSubClassOf("RegisterOperand"))
                 R = R->getValueAsDef("RegClass");
               IAP.addCond(std::string(

--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
@@ -24,9 +24,11 @@ using namespace llvm;
 /// constructor.  It checks if an argument in an InstAlias pattern matches
 /// the corresponding operand of the instruction.  It returns true on a
 /// successful match, with ResOp set to the result operand to be used.
-bool CodeGenInstAlias::tryAliasOpMatch(DagInit *Result, unsigned AliasOpNo,
+bool CodeGenInstAlias::tryAliasOpMatch(const DagInit *Result,
+                                       unsigned AliasOpNo,
                                        const Record *InstOpRec, bool hasSubOps,
-                                       ArrayRef<SMLoc> Loc, CodeGenTarget &T,
+                                       ArrayRef<SMLoc> Loc,
+                                       const CodeGenTarget &T,
                                        ResultOperand &ResOp) {
   Init *Arg = Result->getArg(AliasOpNo);
   DefInit *ADI = dyn_cast<DefInit>(Arg);
@@ -152,11 +154,11 @@ unsigned CodeGenInstAlias::ResultOperand::getMINumOperands() const {
   if (!isRecord())
     return 1;
 
-  Record *Rec = getRecord();
+  const Record *Rec = getRecord();
   if (!Rec->isSubClassOf("Operand"))
     return 1;
 
-  DagInit *MIOpInfo = Rec->getValueAsDag("MIOperandInfo");
+  const DagInit *MIOpInfo = Rec->getValueAsDag("MIOperandInfo");
   if (MIOpInfo->getNumArgs() == 0) {
     // Unspecified, so it defaults to 1
     return 1;
@@ -165,7 +167,8 @@ unsigned CodeGenInstAlias::ResultOperand::getMINumOperands() const {
   return MIOpInfo->getNumArgs();
 }
 
-CodeGenInstAlias::CodeGenInstAlias(Record *R, CodeGenTarget &T) : TheDef(R) {
+CodeGenInstAlias::CodeGenInstAlias(const Record *R, const CodeGenTarget &T)
+    : TheDef(R) {
   Result = R->getValueAsDag("ResultInst");
   AsmString = std::string(R->getValueAsString("AsmString"));
 

--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.h
@@ -32,7 +32,7 @@ class Record;
 /// CodeGenInstAlias - This represents an InstAlias definition.
 class CodeGenInstAlias {
 public:
-  Record *TheDef; // The actual record defining this InstAlias.
+  const Record *TheDef; // The actual record defining this InstAlias.
 
   /// AsmString - The format string used to emit a .s file for the
   /// instruction.
@@ -48,16 +48,16 @@ public:
   struct ResultOperand {
   private:
     std::string Name;
-    Record *R = nullptr;
+    const Record *R = nullptr;
     int64_t Imm = 0;
 
   public:
     enum { K_Record, K_Imm, K_Reg } Kind;
 
-    ResultOperand(std::string N, Record *r)
-        : Name(std::move(N)), R(r), Kind(K_Record) {}
+    ResultOperand(std::string N, const Record *R)
+        : Name(std::move(N)), R(R), Kind(K_Record) {}
     ResultOperand(int64_t I) : Imm(I), Kind(K_Imm) {}
-    ResultOperand(Record *r) : R(r), Kind(K_Reg) {}
+    ResultOperand(Record *R) : R(R), Kind(K_Reg) {}
 
     bool isRecord() const { return Kind == K_Record; }
     bool isImm() const { return Kind == K_Imm; }
@@ -67,7 +67,7 @@ public:
       assert(isRecord());
       return Name;
     }
-    Record *getRecord() const {
+    const Record *getRecord() const {
       assert(isRecord());
       return R;
     }
@@ -75,7 +75,7 @@ public:
       assert(isImm());
       return Imm;
     }
-    Record *getRegister() const {
+    const Record *getRegister() const {
       assert(isReg());
       return R;
     }
@@ -93,11 +93,11 @@ public:
   /// of them are matched by the operand, the second value should be -1.
   std::vector<std::pair<unsigned, int>> ResultInstOperandIndex;
 
-  CodeGenInstAlias(Record *R, CodeGenTarget &T);
+  CodeGenInstAlias(const Record *R, const CodeGenTarget &T);
 
-  bool tryAliasOpMatch(DagInit *Result, unsigned AliasOpNo,
+  bool tryAliasOpMatch(const DagInit *Result, unsigned AliasOpNo,
                        const Record *InstOpRec, bool hasSubOps,
-                       ArrayRef<SMLoc> Loc, CodeGenTarget &T,
+                       ArrayRef<SMLoc> Loc, const CodeGenTarget &T,
                        ResultOperand &ResOp);
 };
 


### PR DESCRIPTION
Change CodeGenInstAlias to use const Record pointers.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089