### PR TITLE
[LLVM][TableGen] Change SubtargetEmitter to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -489,7 +489,7 @@ public:
     return ModelDef;
   }
 
-  const CodeGenProcModel &getModelForProc(Record *ProcDef) const {
+  const CodeGenProcModel &getModelForProc(const Record *ProcDef) const {
     const Record *ModelDef = getModelOrItinDef(ProcDef);
     ProcModelMapTy::const_iterator I = ProcModelMap.find(ModelDef);
     assert(I != ProcModelMap.end() && "missing machine model");


### PR DESCRIPTION
 Change SubtargetEmitter to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089