### PR TITLE
[libc++][CI] Upgrade LLVM HEAD version in Docker image

### DIFF
--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 x-versions: &compiler_versions
   GCC_LATEST_VERSION: 14
-  LLVM_HEAD_VERSION: 19
+  LLVM_HEAD_VERSION: 20
 
 services:
   buildkite-builder:


### PR DESCRIPTION
Before changing the compiler version in https://github.com/llvm/llvm-project/pull/108761, we first of all need to upgrade the HEAD version to `Clang-20` in the Docker files and push new builder images to the CI.