### PR TITLE
[VirtRegMap] Remove unused MAX_STACK_SLOT. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -34,7 +34,6 @@ class TargetInstrInfo;
   public:
     enum {
       NO_STACK_SLOT = (1L << 30)-1,
-      MAX_STACK_SLOT = (1L << 18)-1
     };
 
   private:


### PR DESCRIPTION
I think this has been unuesd since 92255f27f1c1884585cbcb3fcbd72bd4b0b533f7 in 2011.