### PR TITLE
Revert "[mlir] Nits on uses of llvm::raw_string_ostream (NFC)"

### DIFF
--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -708,7 +708,7 @@ public:
         llvm::raw_string_ostream os(message);
         os << "Expected a static ShapedType for the shaped_type parameter: "
            << py::repr(py::cast(*explicitType));
-        throw py::value_error(message);
+        throw py::value_error(os.str());
       }
       shapedType = *explicitType;
     } else {
@@ -732,7 +732,7 @@ public:
         os << "All attributes must be of the same type and match "
            << "the type parameter: expected=" << py::repr(py::cast(shapedType))
            << ", but got=" << py::repr(py::cast(attrType));
-        throw py::value_error(message);
+        throw py::value_error(os.str());
       }
     }
 

--- a/mlir/lib/TableGen/CodeGenHelpers.cpp
+++ b/mlir/lib/TableGen/CodeGenHelpers.cpp
@@ -315,5 +315,5 @@ std::string mlir::tblgen::escapeString(StringRef value) {
   std::string ret;
   llvm::raw_string_ostream os(ret);
   os.write_escaped(value);
-  return ret;
+  return os.str();
 }

--- a/mlir/lib/TableGen/Predicate.cpp
+++ b/mlir/lib/TableGen/Predicate.cpp
@@ -301,7 +301,7 @@ static std::string combineBinary(ArrayRef<std::string> children,
   for (unsigned i = 1; i < size; ++i) {
     os << ' ' << combiner << " (" << children[i] << ')';
   }
-  return str;
+  return os.str();
 }
 
 // Prepend negation to the only condition in the predicate expression list.

--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -182,7 +182,7 @@ ModuleToObject::translateToISA(llvm::Module &llvmModule,
 
     codegenPasses.run(llvmModule);
   }
-  return targetISA;
+  return stream.str();
 }
 
 void ModuleToObject::setDataLayoutAndTriple(llvm::Module &module) {

--- a/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
+++ b/mlir/lib/Target/LLVMIR/ConvertFromLLVMIR.cpp
@@ -50,7 +50,7 @@ void registerFromLLVMIRTranslation() {
           std::string errStr;
           llvm::raw_string_ostream errStream(errStr);
           err.print(/*ProgName=*/"", errStream);
-          emitError(UnknownLoc::get(context)) << errStr;
+          emitError(UnknownLoc::get(context)) << errStream.str();
           return {};
         }
         if (llvm::verifyModule(*llvmModule, &llvm::errs()))

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -62,7 +62,7 @@ static std::string diagStr(const llvm::Type *type) {
   std::string str;
   llvm::raw_string_ostream os(str);
   type->print(os);
-  return str;
+  return os.str();
 }
 
 /// Get the declaration of an overloaded llvm intrinsic. First we get the

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMPCommon.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMPCommon.cpp
@@ -25,7 +25,7 @@ mlir::LLVM::createSourceLocStrFromLocation(Location loc,
   std::string locStr;
   llvm::raw_string_ostream locOS(locStr);
   locOS << loc;
-  return builder.getOrCreateSrcLocStr(locStr, strLen);
+  return builder.getOrCreateSrcLocStr(locOS.str(), strLen);
 }
 
 llvm::Constant *

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -55,7 +55,7 @@ static std::string diag(const llvm::Value &value) {
   std::string str;
   llvm::raw_string_ostream os(str);
   os << value;
-  return str;
+  return os.str();
 }
 
 // Utility to print an LLVM metadata node as a string for passing
@@ -66,7 +66,7 @@ static std::string diagMD(const llvm::Metadata *node,
   std::string str;
   llvm::raw_string_ostream os(str);
   node->print(os, module, /*IsForDebug=*/true);
-  return str;
+  return os.str();
 }
 
 /// Returns the name of the global_ctors global variables.

--- a/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
+++ b/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
@@ -137,7 +137,7 @@ Serializer::processSpecConstantOperationOp(spirv::SpecConstantOperationOp op) {
   std::string enclosedOpName;
   llvm::raw_string_ostream rss(enclosedOpName);
   rss << "Op" << enclosedOp.getName().stripDialect();
-  auto enclosedOpcode = spirv::symbolizeOpcode(enclosedOpName);
+  auto enclosedOpcode = spirv::symbolizeOpcode(rss.str());
 
   if (!enclosedOpcode) {
     op.emitError("Couldn't find op code for op ")

--- a/mlir/lib/Target/SPIRV/Serialization/Serializer.cpp
+++ b/mlir/lib/Target/SPIRV/Serialization/Serializer.cpp
@@ -915,7 +915,7 @@ uint32_t Serializer::prepareConstantInt(Location loc, IntegerAttr intAttr,
     value.print(rss, /*isSigned=*/false);
 
     emitError(loc, "cannot serialize ")
-        << bitwidth << "-bit integer literal: " << valueStr;
+        << bitwidth << "-bit integer literal: " << rss.str();
     return 0;
   }
   }
@@ -968,7 +968,7 @@ uint32_t Serializer::prepareConstantFp(Location loc, FloatAttr floatAttr,
     value.print(rss);
 
     emitError(loc, "cannot serialize ")
-        << floatAttr.getType() << "-typed float literal: " << valueStr;
+        << floatAttr.getType() << "-typed float literal: " << rss.str();
     return 0;
   }
 

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -148,8 +148,9 @@ private:
     std::string docStr;
     {
       llvm::raw_string_ostream docOS(docStr);
+      std::string tmpDocStr = doc.str();
       raw_indented_ostream(docOS).printReindented(
-          StringRef(docStr).rtrim(" \t"));
+          StringRef(tmpDocStr).rtrim(" \t"));
     }
     return docStr;
   }

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -312,7 +312,8 @@ static LogicalResult doVerifyRoundTrip(Operation *op,
     FallbackAsmResourceMap fallbackResourceMap;
     ParserConfig parseConfig(&roundtripContext, /*verifyAfterParse=*/true,
                              &fallbackResourceMap);
-    roundtripModule = parseSourceString<Operation *>(buffer, parseConfig);
+    roundtripModule =
+        parseSourceString<Operation *>(ostream.str(), parseConfig);
     if (!roundtripModule) {
       op->emitOpError() << "failed to parse " << testType
                         << " content back, cannot verify round-trip.\n";

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -46,7 +46,7 @@ static std::string strFromOs(function_ref<void(raw_ostream &)> func) {
   std::string buf;
   llvm::raw_string_ostream os(buf);
   func(os);
-  return buf;
+  return os.str();
 }
 
 /// Escape special characters such as '\n' and quotation marks.
@@ -199,7 +199,7 @@ private:
     std::string buf;
     llvm::raw_string_ostream ss(buf);
     attr.print(ss);
-    os << truncateString(buf);
+    os << truncateString(ss.str());
   }
 
   /// Append an edge to the list of edges.
@@ -262,7 +262,7 @@ private:
         std::string buf;
         llvm::raw_string_ostream ss(buf);
         interleaveComma(op->getResultTypes(), ss);
-        os << truncateString(buf) << ")";
+        os << truncateString(ss.str()) << ")";
       }
 
       // Print attributes.


### PR DESCRIPTION
https://lab.llvm.org/buildbot/#/builders/169

This reverts commit 5a6e52d6ef96d2bcab6dc50bdb369662ff17d2a0.
