### PR TITLE
[mlir][AsmParser] Avoid use of moved value

### DIFF
--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2412,13 +2412,14 @@ ParseResult OperationParser::parseOptionalBlockArgList(Block *owner) {
 //===----------------------------------------------------------------------===//
 
 ParseResult OperationParser::codeCompleteSSAUse() {
-  std::string detailData;
-  llvm::raw_string_ostream detailOS(detailData);
   for (IsolatedSSANameScope &scope : isolatedNameScopes) {
     for (auto &it : scope.values) {
       if (it.second.empty())
         continue;
       Value frontValue = it.second.front().value;
+
+      std::string detailData;
+      llvm::raw_string_ostream detailOS(detailData);
 
       // If the value isn't a forward reference, we also add the name of the op
       // to the detail.
@@ -2440,7 +2441,7 @@ ParseResult OperationParser::codeCompleteSSAUse() {
         detailOS << ", ...";
 
       state.codeCompleteContext->appendSSAValueCompletion(
-          it.getKey(), std::move(detailOS.str()));
+          it.getKey(), std::move(detailData));
     }
   }
 


### PR DESCRIPTION
'std::string detailData' is moved in the innermost loop of a 2-layer loop, but is written to throughout the whole duration of the 2-layer loop.

After move, std::string is in an unspecified state (implementation-dependent).

Avoid using a moved value, as it incurs undefined behavior.