### PR TITLE
[docs][clang-tidy] Correct StrictMode example in modernize-use-std-print

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-format.rst
@@ -43,7 +43,7 @@ Options
     extern std::string strprintf(const char *format, ...);
     int i = -42;
     unsigned int u = 0xffffffff;
-    return strprintf("%d %u\n", i, u);
+    return strprintf("%u %d\n", i, u);
 
   would be converted to
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -109,7 +109,7 @@ Options
 
   .. code-block:: c++
 
-    std::print("{} {}\n", static_cast<unsigned int>(i), static_cast<int>(u));
+    std::print("{} {}\n", static_cast<int>(u), static_cast<unsigned int>(i));
 
   to ensure that the output will continue to be the unsigned representation
   of `-42` and the signed representation of `0xffffffff` (often

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-print.rst
@@ -103,13 +103,13 @@ Options
 
     int i = -42;
     unsigned int u = 0xffffffff;
-    printf("%d %u\n", i, u);
+    printf("%u %d\n", i, u);
 
   would be converted to:
 
   .. code-block:: c++
 
-    std::print("{} {}\n", static_cast<int>(u), static_cast<unsigned int>(i));
+    std::print("{} {}\n", static_cast<unsigned int>(i), static_cast<int>(u));
 
   to ensure that the output will continue to be the unsigned representation
   of `-42` and the signed representation of `0xffffffff` (often


### PR DESCRIPTION
Updated the example in the `StrictMode` section of the clang-tidy check `modernize-use-std-print`.

The previous example incorrectly swapped the cast of signed and unsigned integers. Specifically:
- The signed integer `i` was being cast to `unsigned int`, and
- The unsigned integer `u` was being cast to `int`.

This correction ensures that the behavior of `std::print` with `StrictMode` enabled matches that of `printf`, by reversing the casts to maintain the correct signedness. 

Issue Refference
It solves #101397