### PR TITLE
[Clang] Reject `this void` explicit object parameters (CWG2915)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -170,6 +170,9 @@ Resolutions to C++ Defect Reports
   in constant expressions. These comparisons always worked in non-constant expressions.
   (`CWG2749: Treatment of "pointer to void" for relational comparisons <https://cplusplus.github.io/CWG/issues/2749.html>`_).
 
+- Reject explicit object parameters with type ``void`` (``this void``).
+  (`CWG2915: Explicit object parameters of type void <https://cplusplus.github.io/CWG/issues/2915.html>`_).
+
 C Language Changes
 ------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4687,6 +4687,8 @@ def err_void_only_param : Error<
   "'void' must be the first and only parameter if specified">;
 def err_void_param_qualified : Error<
   "'void' as parameter must not have type qualifiers">;
+def err_void_explicit_object_param : Error<
+  "explicit object parameter cannot have 'void' type">;
 def err_ident_list_in_fn_declaration : Error<
   "a parameter list without types is only allowed in a function definition">;
 def ext_param_not_declared : ExtWarn<

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5166,6 +5166,14 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
               if (ParamTy.hasQualifiers())
                 S.Diag(DeclType.Loc, diag::err_void_param_qualified);
 
+              // Reject, but continue to parse 'float(this void)' as
+              // 'float(void)'.
+              if (Param->isExplicitObjectParameter()) {
+                S.Diag(Param->getLocation(),
+                       diag::err_void_explicit_object_param);
+                Param->setExplicitObjectParameterLoc(SourceLocation());
+              }
+
               // Do not add 'void' to the list.
               break;
             }

--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -6,6 +6,14 @@
 // RUN: %clang_cc1 -std=c++23 -pedantic-errors -verify=expected %s
 // RUN: %clang_cc1 -std=c++2c -pedantic-errors -verify=expected %s
 
+namespace cwg2915 { // cwg2915: 20 tentatively ready 2024-08-16
+#if __cplusplus >= 202302L
+struct A {
+  void f(this void); // expected-error {{explicit object parameter cannot have 'void' type}}
+};
+#endif
+}
+
 namespace cwg2917 { // cwg2917: 20 review 2024-07-30
 template <typename>
 class Foo;

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -11809,11 +11809,11 @@ and <I>POD class</I></td>
     <td>Reference list-initialization ignores conversion functions</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr id="1997">
+  <tr class="open" id="1997">
     <td><a href="https://cplusplus.github.io/CWG/issues/1997.html">1997</a></td>
-    <td>DRWP</td>
+    <td>drafting</td>
     <td>Placement new and previous initialization</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td align="center">Not resolved</td>
   </tr>
   <tr id="1998">
     <td><a href="https://cplusplus.github.io/CWG/issues/1998.html">1998</a></td>
@@ -17354,7 +17354,7 @@ objects</td>
   </tr>
   <tr class="open" id="2916">
     <td><a href="https://cplusplus.github.io/CWG/issues/2916.html">2916</a></td>
-    <td>review</td>
+    <td>tentatively ready</td>
     <td>Variable template partial specializations should not be declared <TT>static</TT></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17430,60 +17430,6 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2927.html">2927</a></td>
     <td>open</td>
     <td>Unclear status of translation unit with <TT>module</TT> keyword</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2928">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2928.html">2928</a></td>
-    <td>open</td>
-    <td>No ordering for initializing thread-local variables</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2929">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2929.html">2929</a></td>
-    <td>open</td>
-    <td>Lifetime of trivially-destructible static or thread-local objects</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2930">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2930.html">2930</a></td>
-    <td>open</td>
-    <td>Unclear term "copy/move operation" in specification of copy elision</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2931">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2931.html">2931</a></td>
-    <td>open</td>
-    <td>Restrictions on operator functions that are explicit object member functions</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2932">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2932.html">2932</a></td>
-    <td>open</td>
-    <td>Value range of empty enumeration</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2933">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2933.html">2933</a></td>
-    <td>open</td>
-    <td>Dangling references</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2934">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2934.html">2934</a></td>
-    <td>open</td>
-    <td>Unclear semantics of exception escaping from <TT>unhandled_exception</TT></td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2935">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2935.html">2935</a></td>
-    <td>open</td>
-    <td>Destroying the coroutine state when initial-await-resume-called is false</td>
-    <td align="center">Not resolved</td>
-  </tr>
-  <tr class="open" id="2936">
-    <td><a href="https://cplusplus.github.io/CWG/issues/2936.html">2936</a></td>
-    <td>open</td>
-    <td>Local classes of templated functions should be part of the current instantiation</td>
     <td align="center">Not resolved</td>
   </tr></table>
 

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -11809,11 +11809,11 @@ and <I>POD class</I></td>
     <td>Reference list-initialization ignores conversion functions</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="1997">
+  <tr id="1997">
     <td><a href="https://cplusplus.github.io/CWG/issues/1997.html">1997</a></td>
-    <td>drafting</td>
+    <td>DRWP</td>
     <td>Placement new and previous initialization</td>
-    <td align="center">Not resolved</td>
+    <td class="unknown" align="center">Unknown</td>
   </tr>
   <tr id="1998">
     <td><a href="https://cplusplus.github.io/CWG/issues/1998.html">1998</a></td>
@@ -17346,11 +17346,15 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2915.html">2915</a></td>
     <td>tentatively ready</td>
     <td>Explicit object parameters of type <TT>void</TT></td>
-    <td align="center">Not resolved</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 20 implements 2024-08-16 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2916">
     <td><a href="https://cplusplus.github.io/CWG/issues/2916.html">2916</a></td>
-    <td>tentatively ready</td>
+    <td>review</td>
     <td>Variable template partial specializations should not be declared <TT>static</TT></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17426,6 +17430,60 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2927.html">2927</a></td>
     <td>open</td>
     <td>Unclear status of translation unit with <TT>module</TT> keyword</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2928">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2928.html">2928</a></td>
+    <td>open</td>
+    <td>No ordering for initializing thread-local variables</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2929">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2929.html">2929</a></td>
+    <td>open</td>
+    <td>Lifetime of trivially-destructible static or thread-local objects</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2930">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2930.html">2930</a></td>
+    <td>open</td>
+    <td>Unclear term "copy/move operation" in specification of copy elision</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2931">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2931.html">2931</a></td>
+    <td>open</td>
+    <td>Restrictions on operator functions that are explicit object member functions</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2932">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2932.html">2932</a></td>
+    <td>open</td>
+    <td>Value range of empty enumeration</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2933">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2933.html">2933</a></td>
+    <td>open</td>
+    <td>Dangling references</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2934">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2934.html">2934</a></td>
+    <td>open</td>
+    <td>Unclear semantics of exception escaping from <TT>unhandled_exception</TT></td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2935">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2935.html">2935</a></td>
+    <td>open</td>
+    <td>Destroying the coroutine state when initial-await-resume-called is false</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2936">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2936.html">2936</a></td>
+    <td>open</td>
+    <td>Local classes of templated functions should be part of the current instantiation</td>
     <td align="center">Not resolved</td>
   </tr></table>
 


### PR DESCRIPTION
https://cplusplus.github.io/CWG/issues/2915.html

Previously, `struct A { void f(this void); };` was accepted with `A::f` being a member function with no non-object arguments, but it was still a little wonky because it was still considered an explicit object member function. Now, this is rejected immediately.

This applies to any language mode with explicit object parameters as this is a DR (C++23 and C++26)