### PR TITLE
[Bolt] Explicitly request PIE in tests

### DIFF
--- a/bolt/test/lit.local.cfg
+++ b/bolt/test/lit.local.cfg
@@ -1,6 +1,6 @@
 host_linux_triple = config.target_triple.split("-")[0] + "-unknown-linux-gnu"
-common_linker_flags = "-fuse-ld=lld -Wl,--unresolved-symbols=ignore-all"
-flags = f"--target={host_linux_triple} {common_linker_flags}"
+common_linker_flags = "-fuse-ld=lld -Wl,--unresolved-symbols=ignore-all -pie"
+flags = f"--target={host_linux_triple} -fPIE {common_linker_flags}"
 
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))


### PR DESCRIPTION
When clang is built with `-DCLANG_DEFAULT_PIE_ON_LINUX=OFF`, a number of bolt tests fail:

    BOLT :: AArch64/build_id.c
    BOLT :: AArch64/plt-call.test
    BOLT :: X86/dwarf5-dwarf4-types-backward-forward-cross-reference.test
    BOLT :: X86/dwarf5-locexpr-referrence.test
    BOLT :: X86/internal-call-instrument.s
    BOLT :: X86/linux-static-keys.s
    BOLT :: X86/plt-call.test

Avoid this by explicitly adding `-fPIE` and `-pie` to the default flags in tests, so we don't depend on the clang-side default.