### PR TITLE
[flang][Semantics][OpenMP] Don't privatise associate names

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -718,7 +718,7 @@ private:
   void CheckDataCopyingClause(
       const parser::Name &, const Symbol &, Symbol::Flag);
   void CheckAssocLoopLevel(std::int64_t level, const parser::OmpClause *clause);
-  void CheckObjectInNamelist(
+  void CheckObjectInNamelistOrAssociate(
       const parser::Name &, const Symbol &, Symbol::Flag);
   void CheckSourceLabel(const parser::Label &);
   void CheckLabelContext(const parser::CharBlock, const parser::CharBlock,
@@ -2357,7 +2357,7 @@ void OmpAttributeVisitor::ResolveOmpObject(
                     CheckMultipleAppearances(*name, *symbol, ompFlag);
                   }
                   if (privateDataSharingAttributeFlags.test(ompFlag)) {
-                    CheckObjectInNamelist(*name, *symbol, ompFlag);
+                    CheckObjectInNamelistOrAssociate(*name, *symbol, ompFlag);
                   }
 
                   if (ompFlag == Symbol::Flag::OmpAllocate) {
@@ -2714,7 +2714,7 @@ void OmpAttributeVisitor::CheckDataCopyingClause(
   }
 }
 
-void OmpAttributeVisitor::CheckObjectInNamelist(
+void OmpAttributeVisitor::CheckObjectInNamelistOrAssociate(
     const parser::Name &name, const Symbol &symbol, Symbol::Flag ompFlag) {
   const auto &ultimateSymbol{symbol.GetUltimate()};
   llvm::StringRef clauseName{"PRIVATE"};

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -19,6 +19,7 @@
 #include "flang/Parser/parse-tree.h"
 #include "flang/Parser/tools.h"
 #include "flang/Semantics/expression.h"
+#include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
 #include <list>
 #include <map>
@@ -2726,6 +2727,12 @@ void OmpAttributeVisitor::CheckObjectInNamelist(
   if (ultimateSymbol.test(Symbol::Flag::InNamelist)) {
     context_.Say(name.source,
         "Variable '%s' in NAMELIST cannot be in a %s clause"_err_en_US,
+        name.ToString(), clauseName.str());
+  }
+
+  if (ultimateSymbol.has<AssocEntityDetails>()) {
+    context_.Say(name.source,
+        "Variable '%s' in ASSOCIATE cannot be in a %s clause"_err_en_US,
         name.ToString(), clauseName.str());
   }
 }

--- a/flang/test/Semantics/OpenMP/private-assoc.f90
+++ b/flang/test/Semantics/OpenMP/private-assoc.f90
@@ -1,0 +1,32 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+
+! The ASSOCIATE name preserves the association with the selector established
+! in the associate statement. Therefore it is incorrect to change the
+! data-sharing attribute of the name.
+
+subroutine assoc_private(x)
+  integer :: x
+  associate(z => x)
+  !ERROR: Variable 'z' in ASSOCIATE cannot be in a PRIVATE clause
+  !$omp parallel private(z)
+  !$omp end parallel
+  end associate
+end subroutine
+
+subroutine assoc_firstprivate(x)
+  integer :: x
+  associate(z => x)
+  !ERROR: Variable 'z' in ASSOCIATE cannot be in a FIRSTPRIVATE clause
+  !$omp parallel firstprivate(z)
+  !$omp end parallel
+  end associate
+end subroutine
+
+subroutine assoc_lastprivate(x)
+  integer :: x
+  associate(z => x)
+  !ERROR: Variable 'z' in ASSOCIATE cannot be in a LASTPRIVATE clause
+  !$omp parallel sections lastprivate(z)
+  !$omp end parallel sections
+  end associate
+end subroutine


### PR DESCRIPTION
The associate name preserves the association with the selector established in the associate statement. Therefore it is incorrect to change the data-sharing attribute of the name.

Closes #58041