### PR TITLE
[llvm-profdata] Default to MemProf version 3

### DIFF
--- a/llvm/test/tools/llvm-profdata/memprof-merge-versions.test
+++ b/llvm/test/tools/llvm-profdata/memprof-merge-versions.test
@@ -25,6 +25,10 @@ RUN: llvm-profdata show %t.prof.v3 | FileCheck %s
 RUN: llvm-profdata merge %t.proftext %p/Inputs/basic.memprofraw --memprof-version=3 --memprof-full-schema --profiled-binary %p/Inputs/basic.memprofexe -o %t.prof.v3
 RUN: llvm-profdata show %t.prof.v3 | FileCheck %s
 
+Check to see if llvm-profdata produces V3 by default.
+RUN: llvm-profdata merge %t.proftext %p/Inputs/basic.memprofraw --memprof-full-schema --profiled-binary %p/Inputs/basic.memprofexe -o %t.prof.default
+RUN: cmp %t.prof.default %t.prof.v3
+
 For now we only check the validity of the instrumented profile since we don't
 have a way to display the contents of the memprof indexed format yet.
 

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -332,7 +332,7 @@ cl::opt<bool> DoWritePrevVersion(
 cl::opt<memprof::IndexedVersion> MemProfVersionRequested(
     "memprof-version", cl::Hidden, cl::sub(MergeSubcommand),
     cl::desc("Specify the version of the memprof format to use"),
-    cl::init(memprof::Version0),
+    cl::init(memprof::Version3),
     cl::values(clEnumValN(memprof::Version0, "0", "version 0"),
                clEnumValN(memprof::Version1, "1", "version 1"),
                clEnumValN(memprof::Version2, "2", "version 2"),


### PR DESCRIPTION
It's very confusing to have support for Verion 3 but not default to
it.  This patch teaches llvm-profdata to use MemProf version 3 by
default.
