### PR TITLE
fix update-verify-tests test suite for AIX

### DIFF
--- a/clang/test/utils/update-verify-tests/lit.local.cfg
+++ b/clang/test/utils/update-verify-tests/lit.local.cfg
@@ -23,3 +23,6 @@ else:
             "%s %s" % (python, shell_quote(script_path)),
         )
     )
+    # AIX 'diff' command doesn't support --strip-trailing-cr, but the internal
+    # python implementation does, so use that for cross platform compatibility
+    config.test_format = lit.formats.ShTest()


### PR DESCRIPTION
The diff command on AIX doesn't support the --strip-trailing-cr flag. The internal python implementation does, so execute the tests in the update-verify-tests test suite using the internal shell for compatibility.