### PR TITLE
[libcxx] Use __libcpp_verbose_abort for error messages

### DIFF
--- a/libcxx/src/support/runtime/exception_fallback.ipp
+++ b/libcxx/src/support/runtime/exception_fallback.ipp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cstdio>
+#include <__verbose_abort>
 
 namespace std {
 
@@ -39,13 +39,11 @@ terminate_handler get_terminate() noexcept { return __libcpp_atomic_load(&__term
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
     (*get_terminate())();
     // handler should not return
-    fprintf(stderr, "terminate_handler unexpectedly returned\n");
-    ::abort();
+    __libcpp_verbose_abort("terminate_handler unexpectedly returned\n");
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     // handler should not throw exception
-    fprintf(stderr, "terminate_handler unexpectedly threw an exception\n");
-    ::abort();
+    __libcpp_verbose_abort("terminate_handler unexpectedly threw an exception\n");
   }
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
@@ -54,8 +52,7 @@ bool uncaught_exception() noexcept { return uncaught_exceptions() > 0; }
 
 int uncaught_exceptions() noexcept {
 #warning uncaught_exception not yet implemented
-  fprintf(stderr, "uncaught_exceptions not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("uncaught_exceptions not yet implemented\n");
 }
 
 exception::~exception() noexcept {}

--- a/libcxx/src/support/runtime/exception_msvc.ipp
+++ b/libcxx/src/support/runtime/exception_msvc.ipp
@@ -11,8 +11,7 @@
 #  error this header can only be used when targeting the MSVC ABI
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <__verbose_abort>
 
 extern "C" {
 typedef void(__cdecl* terminate_handler)();
@@ -48,13 +47,11 @@ terminate_handler get_terminate() noexcept { return ::_get_terminate(); }
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
     (*get_terminate())();
     // handler should not return
-    fprintf(stderr, "terminate_handler unexpectedly returned\n");
-    ::abort();
+    __libcpp_verbose_abort("terminate_handler unexpectedly returned\n");
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     // handler should not throw exception
-    fprintf(stderr, "terminate_handler unexpectedly threw an exception\n");
-    ::abort();
+    __libcpp_verbose_abort("terminate_handler unexpectedly threw an exception\n");
   }
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }

--- a/libcxx/src/support/runtime/exception_pointer_unimplemented.ipp
+++ b/libcxx/src/support/runtime/exception_pointer_unimplemented.ipp
@@ -7,33 +7,28 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <__verbose_abort>
 
 namespace std {
 
 exception_ptr::~exception_ptr() noexcept {
 #warning exception_ptr not yet implemented
-  fprintf(stderr, "exception_ptr not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("exception_ptr not yet implemented\n");
 }
 
 exception_ptr::exception_ptr(const exception_ptr& other) noexcept : __ptr_(other.__ptr_) {
 #warning exception_ptr not yet implemented
-  fprintf(stderr, "exception_ptr not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("exception_ptr not yet implemented\n");
 }
 
 exception_ptr& exception_ptr::operator=(const exception_ptr& other) noexcept {
 #warning exception_ptr not yet implemented
-  fprintf(stderr, "exception_ptr not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("exception_ptr not yet implemented\n");
 }
 
 exception_ptr exception_ptr::__from_native_exception_pointer(void *__e) noexcept {
 #warning exception_ptr not yet implemented
-  fprintf(stderr, "exception_ptr not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("exception_ptr not yet implemented\n");
 }
 
 nested_exception::nested_exception() noexcept : __ptr_(current_exception()) {}
@@ -46,8 +41,7 @@ nested_exception::~nested_exception() noexcept {}
 
 [[noreturn]] void nested_exception::rethrow_nested() const {
 #warning exception_ptr not yet implemented
-  fprintf(stderr, "exception_ptr not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("exception_ptr not yet implemented\n");
 #if 0
   if (__ptr_ == nullptr)
       terminate();
@@ -57,14 +51,12 @@ nested_exception::~nested_exception() noexcept {}
 
 exception_ptr current_exception() noexcept {
 #warning exception_ptr not yet implemented
-  fprintf(stderr, "exception_ptr not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("exception_ptr not yet implemented\n");
 }
 
 [[noreturn]] void rethrow_exception(exception_ptr p) {
 #warning exception_ptr not yet implemented
-  fprintf(stderr, "exception_ptr not yet implemented\n");
-  ::abort();
+  __libcpp_verbose_abort("exception_ptr not yet implemented\n");
 }
 
 } // namespace std


### PR DESCRIPTION
Rather than using the following sequence of calls:

```
fprintf(stderr, "...");
::abort();
```

We should use the following:

```
__libcpp_verbose_abort("...")
```

This simplifies the code and ensures the behavior is consistent across all call sites.