### PR TITLE
[ROCDL] Pass `amd_code_object_version` when serializing ROCDL gpu module

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -693,7 +693,7 @@ def ROCDL_CvtSrFp8F32Op :
 // ROCDL target attribute.
 //===----------------------------------------------------------------------===//
 
-def ROCDL_TargettAttr :
+def ROCDL_TargetAttr :
     ROCDL_Attr<"ROCDLTarget", "target"> {
   let description = [{
     ROCDL target attribute for controlling compilation of AMDGPU targets. All

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -71,14 +71,17 @@ public:
   virtual std::optional<SmallVector<std::unique_ptr<llvm::Module>>>
   loadBitcodeFiles(llvm::Module &module) override;
 
-  /// Adds `oclc` control variables to the LLVM module.
+  /// Determines required Device Libraries and adds `oclc` control variables to
+  /// the LLVM Module if needed. Also sets
+  /// `amdhsa_code_object_version` module flag
   void handleModulePreLink(llvm::Module &module) override;
 
   /// Removes unnecessary metadata from the loaded bitcode files.
   LogicalResult handleBitcodeFile(llvm::Module &module) override;
 
 protected:
-  /// Adds `oclc` control variables to the LLVM module.
+  /// Adds `oclc` control variables to the LLVM Module if needed and sets
+  /// `amdhsa_code_object_version` module flag
   void addControlVariables(llvm::Module &module, AMDGCNLibraries libs,
                            bool wave64, bool daz, bool finiteOnly,
                            bool unsafeMath, bool fastMath, bool correctSqrt,

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -81,7 +81,8 @@ public:
 
 protected:
   /// Adds `oclc` control variables to the LLVM Module if needed. It also sets
-  /// `amdhsa_code_object_version` module flag which is equal to ABI version.
+  /// `amdhsa_code_object_version` module flag which is equal to ABI version and
+  /// it uses "llvm::Module::Error" to set that flag.
   void addControlVariables(llvm::Module &module, AMDGCNLibraries libs,
                            bool wave64, bool daz, bool finiteOnly,
                            bool unsafeMath, bool fastMath, bool correctSqrt,

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -80,8 +80,8 @@ public:
   LogicalResult handleBitcodeFile(llvm::Module &module) override;
 
 protected:
-  /// Adds `oclc` control variables to the LLVM Module if needed and sets
-  /// `amdhsa_code_object_version` module flag.
+  /// Adds `oclc` control variables to the LLVM Module if needed. It also sets
+  /// `amdhsa_code_object_version` module flag which is equal to ABI version.
   void addControlVariables(llvm::Module &module, AMDGCNLibraries libs,
                            bool wave64, bool daz, bool finiteOnly,
                            bool unsafeMath, bool fastMath, bool correctSqrt,

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -81,7 +81,7 @@ public:
 
 protected:
   /// Adds `oclc` control variables to the LLVM Module if needed and sets
-  /// `amdhsa_code_object_version` module flag
+  /// `amdhsa_code_object_version` module flag.
   void addControlVariables(llvm::Module &module, AMDGCNLibraries libs,
                            bool wave64, bool daz, bool finiteOnly,
                            bool unsafeMath, bool fastMath, bool correctSqrt,

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -73,7 +73,7 @@ public:
 
   /// Determines required Device Libraries and adds `oclc` control variables to
   /// the LLVM Module if needed. Also sets
-  /// `amdhsa_code_object_version` module flag
+  /// `amdhsa_code_object_version` module flag.
   void handleModulePreLink(llvm::Module &module) override;
 
   /// Removes unnecessary metadata from the loaded bitcode files.

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -231,9 +231,6 @@ void SerializeGPUModuleBase::addControlVariables(
     llvm::Module &module, AMDGCNLibraries libs, bool wave64, bool daz,
     bool finiteOnly, bool unsafeMath, bool fastMath, bool correctSqrt,
     StringRef abiVer) {
-  // Return if no device libraries are required.
-  if (libs == AMDGCNLibraries::None)
-    return;
   // Helper function for adding control variables.
   auto addControlVariable = [&module](StringRef name, uint32_t value,
                                       uint32_t bitwidth) {
@@ -252,6 +249,13 @@ void SerializeGPUModuleBase::addControlVariables(
     controlVariable->setAlignment(llvm::MaybeAlign(bitwidth / 8));
     controlVariable->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Local);
   };
+
+  int abi = 500;
+  abiVer.getAsInteger(0, abi);
+  module.addModuleFlag(llvm::Module::Error, "amdhsa_code_object_version", abi);
+  // Return if no device libraries are required.
+  if (libs == AMDGCNLibraries::None)
+    return;
   // Add ocml related control variables.
   if (any(libs & AMDGCNLibraries::Ocml)) {
     addControlVariable("__oclc_finite_only_opt", finiteOnly || fastMath, 8);
@@ -263,7 +267,6 @@ void SerializeGPUModuleBase::addControlVariables(
   // Add ocml or ockl related control variables.
   if (any(libs & (AMDGCNLibraries::Ocml | AMDGCNLibraries::Ockl))) {
     addControlVariable("__oclc_wavefrontsize64", wave64, 8);
-
     // Get the ISA version.
     llvm::AMDGPU::IsaVersion isaVersion = llvm::AMDGPU::getIsaVersion(chip);
     // Add the ISA control variable.
@@ -271,8 +274,6 @@ void SerializeGPUModuleBase::addControlVariables(
                        isaVersion.Minor + 100 * isaVersion.Stepping +
                            1000 * isaVersion.Major,
                        32);
-    int abi = 500;
-    abiVer.getAsInteger(0, abi);
     addControlVariable("__oclc_ABI_version", abi, 32);
   }
 }

--- a/mlir/unittests/Target/LLVM/SerializeROCDLTarget.cpp
+++ b/mlir/unittests/Target/LLVM/SerializeROCDLTarget.cpp
@@ -70,7 +70,7 @@ protected:
 };
 
 // Test ROCDL serialization to LLVM.
-TEST_F(MLIRTargetLLVMROCDL, SKIP_WITHOUT_AMDGPU(SerializeROCDLMToLLVM)) {
+TEST_F(MLIRTargetLLVMROCDL, SKIP_WITHOUT_AMDGPU(SerializeROCDLToLLVM)) {
   MLIRContext context(registry);
 
   OwningOpRef<ModuleOp> module =
@@ -102,6 +102,60 @@ TEST_F(MLIRTargetLLVMROCDL, SKIP_WITHOUT_AMDGPU(SerializeROCDLMToLLVM)) {
 
     // Check that it has a function named `foo`.
     ASSERT_TRUE((*llvmModule)->getFunction("rocdl_kernel") != nullptr);
+  }
+}
+// Test ROCDL serialization to ISA with default code object version.
+TEST_F(MLIRTargetLLVMROCDL,
+       SKIP_WITHOUT_AMDGPU(SerializeROCDLToISAWithDefaultCOV)) {
+  MLIRContext context(registry);
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(moduleStr, &context);
+  ASSERT_TRUE(!!module);
+
+  // Create a ROCDL target.
+  ROCDL::ROCDLTargetAttr target = ROCDL::ROCDLTargetAttr::get(&context);
+
+  // Serialize the module.
+  auto serializer = dyn_cast<gpu::TargetAttrInterface>(target);
+  ASSERT_TRUE(!!serializer);
+  gpu::TargetOptions options("", {}, "", gpu::CompilationTarget::Assembly);
+  for (auto gpuModule : (*module).getBody()->getOps<gpu::GPUModuleOp>()) {
+    std::optional<SmallVector<char, 0>> object =
+        serializer.serializeToObject(gpuModule, options);
+    // Check that the serializer was successful.
+    ASSERT_TRUE(object != std::nullopt);
+    ASSERT_TRUE(!object->empty());
+    ASSERT_TRUE(StringRef(object->data(), object->size())
+                    .contains(".amdhsa_code_object_version 5"));
+  }
+}
+
+// Test ROCDL serialization to ISA with non-default code object version.
+TEST_F(MLIRTargetLLVMROCDL,
+       SKIP_WITHOUT_AMDGPU(SerializeROCDLToISAWithNonDefaultCOV)) {
+  MLIRContext context(registry);
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(moduleStr, &context);
+  ASSERT_TRUE(!!module);
+
+  // Create a ROCDL target.
+  ROCDL::ROCDLTargetAttr target = ROCDL::ROCDLTargetAttr::get(
+      &context, 2, "amdgcn-amd-amdhsa", "gfx900", "", "400");
+
+  // Serialize the module.
+  auto serializer = dyn_cast<gpu::TargetAttrInterface>(target);
+  ASSERT_TRUE(!!serializer);
+  gpu::TargetOptions options("", {}, "", gpu::CompilationTarget::Assembly);
+  for (auto gpuModule : (*module).getBody()->getOps<gpu::GPUModuleOp>()) {
+    std::optional<SmallVector<char, 0>> object =
+        serializer.serializeToObject(gpuModule, options);
+    // Check that the serializer was successful.
+    ASSERT_TRUE(object != std::nullopt);
+    ASSERT_TRUE(!object->empty());
+    ASSERT_TRUE(StringRef(object->data(), object->size())
+                    .contains(".amdhsa_code_object_version 4"));
   }
 }
 

--- a/mlir/unittests/Target/LLVM/SerializeROCDLTarget.cpp
+++ b/mlir/unittests/Target/LLVM/SerializeROCDLTarget.cpp
@@ -124,9 +124,7 @@ TEST_F(MLIRTargetLLVMROCDL,
     std::optional<SmallVector<char, 0>> object =
         serializer.serializeToObject(gpuModule, options);
     // Check that the serializer was successful.
-    ASSERT_TRUE(object != std::nullopt);
-    ASSERT_TRUE(!object->empty());
-    ASSERT_TRUE(StringRef(object->data(), object->size())
+    EXPECT_TRUE(StringRef(object->data(), object->size())
                     .contains(".amdhsa_code_object_version 5"));
   }
 }
@@ -152,9 +150,7 @@ TEST_F(MLIRTargetLLVMROCDL,
     std::optional<SmallVector<char, 0>> object =
         serializer.serializeToObject(gpuModule, options);
     // Check that the serializer was successful.
-    ASSERT_TRUE(object != std::nullopt);
-    ASSERT_TRUE(!object->empty());
-    ASSERT_TRUE(StringRef(object->data(), object->size())
+    EXPECT_TRUE(StringRef(object->data(), object->size())
                     .contains(".amdhsa_code_object_version 4"));
   }
 }


### PR DESCRIPTION
This PR adds ability to pass non-default value to  `.amdhsa_code_object_version` metadata when serializing ROCDL GPU modules. 

It also fixes typos in two places.

CC: @krzysz00 