### PR TITLE
Revert "[sanitizer] Fix partially initialized static TLS range"

### DIFF
--- a/compiler-rt/lib/asan/asan_posix.cpp
+++ b/compiler-rt/lib/asan/asan_posix.cpp
@@ -59,10 +59,10 @@ bool PlatformUnpoisonStacks() {
 
   // Since we're on the signal alternate stack, we cannot find the DEFAULT
   // stack bottom using a local variable.
-  uptr stack_begin, stack_end, tls_begin, tls_end;
-  GetThreadStackAndTls(/*main=*/false, &stack_begin, &stack_end, &tls_begin,
-                       &tls_end);
-  UnpoisonStack(stack_begin, stack_end, "default");
+  uptr default_bottom, tls_addr, tls_size, stack_size;
+  GetThreadStackAndTls(/*main=*/false, &default_bottom, &stack_size, &tls_addr,
+                       &tls_size);
+  UnpoisonStack(default_bottom, default_bottom + stack_size, "default");
   return true;
 }
 

--- a/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/compiler-rt/lib/asan/asan_rtl.cpp
@@ -580,8 +580,10 @@ static void UnpoisonDefaultStack() {
   } else {
     CHECK(!SANITIZER_FUCHSIA);
     // If we haven't seen this thread, try asking the OS for stack bounds.
-    uptr tls_begin, tls_end;
-    GetThreadStackAndTls(/*main=*/false, &bottom, &top, &tls_begin, &tls_end);
+    uptr tls_addr, tls_size, stack_size;
+    GetThreadStackAndTls(/*main=*/false, &bottom, &stack_size, &tls_addr,
+                         &tls_size);
+    top = bottom + stack_size;
   }
 
   UnpoisonStack(bottom, top, "default");

--- a/compiler-rt/lib/asan/asan_thread.cpp
+++ b/compiler-rt/lib/asan/asan_thread.cpp
@@ -306,10 +306,13 @@ AsanThread *CreateMainThread() {
 // OS-specific implementations that need more information passed through.
 void AsanThread::SetThreadStackAndTls(const InitOptions *options) {
   DCHECK_EQ(options, nullptr);
-  GetThreadStackAndTls(tid() == kMainTid, &stack_bottom_, &stack_top_,
-                       &tls_begin_, &tls_end_);
-  stack_top_ = RoundDownTo(stack_top_, ASAN_SHADOW_GRANULARITY);
+  uptr tls_size = 0;
+  uptr stack_size = 0;
+  GetThreadStackAndTls(tid() == kMainTid, &stack_bottom_, &stack_size,
+                       &tls_begin_, &tls_size);
+  stack_top_ = RoundDownTo(stack_bottom_ + stack_size, ASAN_SHADOW_GRANULARITY);
   stack_bottom_ = RoundDownTo(stack_bottom_, ASAN_SHADOW_GRANULARITY);
+  tls_end_ = tls_begin_ + tls_size;
   dtls_ = DTLS_Get();
 
   if (stack_top_ != stack_bottom_) {

--- a/compiler-rt/lib/dfsan/dfsan_thread.cpp
+++ b/compiler-rt/lib/dfsan/dfsan_thread.cpp
@@ -21,8 +21,13 @@ DFsanThread *DFsanThread::Create(thread_callback_t start_routine, void *arg,
 }
 
 void DFsanThread::SetThreadStackAndTls() {
-  GetThreadStackAndTls(IsMainThread(), &stack_.bottom, &stack_.top, &tls_begin_,
-                       &tls_end_);
+  uptr tls_size = 0;
+  uptr stack_size = 0;
+  GetThreadStackAndTls(IsMainThread(), &stack_.bottom, &stack_size, &tls_begin_,
+                       &tls_size);
+  stack_.top = stack_.bottom + stack_size;
+  tls_end_ = tls_begin_ + tls_size;
+
   int local;
   CHECK(AddrIsInStack((uptr)&local));
 }

--- a/compiler-rt/lib/hwasan/hwasan_linux.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_linux.cpp
@@ -499,8 +499,12 @@ void HwasanOnDeadlySignal(int signo, void *info, void *context) {
 }
 
 void Thread::InitStackAndTls(const InitState *) {
-  GetThreadStackAndTls(IsMainThread(), &stack_bottom_, &stack_top_, &tls_begin_,
-                       &tls_end_);
+  uptr tls_size;
+  uptr stack_size;
+  GetThreadStackAndTls(IsMainThread(), &stack_bottom_, &stack_size, &tls_begin_,
+                       &tls_size);
+  stack_top_ = stack_bottom_ + stack_size;
+  tls_end_ = tls_begin_ + tls_size;
 }
 
 uptr TagMemoryAligned(uptr p, uptr size, tag_t tag) {

--- a/compiler-rt/lib/lsan/lsan_posix.cpp
+++ b/compiler-rt/lib/lsan/lsan_posix.cpp
@@ -50,8 +50,12 @@ void ThreadContext::OnStarted(void *arg) {
 
 void ThreadStart(u32 tid, tid_t os_id, ThreadType thread_type) {
   OnStartedArgs args;
-  GetThreadStackAndTls(tid == kMainTid, &args.stack_begin, &args.stack_end,
-                       &args.tls_begin, &args.tls_end);
+  uptr stack_size = 0;
+  uptr tls_size = 0;
+  GetThreadStackAndTls(tid == kMainTid, &args.stack_begin, &stack_size,
+                       &args.tls_begin, &tls_size);
+  args.stack_end = args.stack_begin + stack_size;
+  args.tls_end = args.tls_begin + tls_size;
   GetAllocatorCacheRange(&args.cache_begin, &args.cache_end);
   args.dtls = DTLS_Get();
   ThreadContextLsanBase::ThreadStart(tid, os_id, thread_type, &args);

--- a/compiler-rt/lib/memprof/memprof_thread.cpp
+++ b/compiler-rt/lib/memprof/memprof_thread.cpp
@@ -168,8 +168,12 @@ MemprofThread *CreateMainThread() {
 // OS-specific implementations that need more information passed through.
 void MemprofThread::SetThreadStackAndTls(const InitOptions *options) {
   DCHECK_EQ(options, nullptr);
-  GetThreadStackAndTls(tid() == kMainTid, &stack_bottom_, &stack_top_,
-                       &tls_begin_, &tls_end_);
+  uptr tls_size = 0;
+  uptr stack_size = 0;
+  GetThreadStackAndTls(tid() == kMainTid, &stack_bottom_, &stack_size,
+                       &tls_begin_, &tls_size);
+  stack_top_ = stack_bottom_ + stack_size;
+  tls_end_ = tls_begin_ + tls_size;
   dtls_ = DTLS_Get();
 
   if (stack_top_ != stack_bottom_) {

--- a/compiler-rt/lib/msan/msan_thread.cpp
+++ b/compiler-rt/lib/msan/msan_thread.cpp
@@ -20,8 +20,13 @@ MsanThread *MsanThread::Create(thread_callback_t start_routine,
 }
 
 void MsanThread::SetThreadStackAndTls() {
-  GetThreadStackAndTls(IsMainThread(), &stack_.bottom, &stack_.top, &tls_begin_,
-                       &tls_end_);
+  uptr tls_size = 0;
+  uptr stack_size = 0;
+  GetThreadStackAndTls(IsMainThread(), &stack_.bottom, &stack_size, &tls_begin_,
+                       &tls_size);
+  stack_.top = stack_.bottom + stack_size;
+  tls_end_ = tls_begin_ + tls_size;
+
   int local;
   CHECK(AddrIsInStack((uptr)&local));
 }

--- a/compiler-rt/lib/nsan/nsan_thread.cpp
+++ b/compiler-rt/lib/nsan/nsan_thread.cpp
@@ -29,8 +29,13 @@ NsanThread *NsanThread::Create(thread_callback_t start_routine, void *arg) {
 }
 
 void NsanThread::SetThreadStackAndTls() {
-  GetThreadStackAndTls(IsMainThread(), &stack_.bottom, &stack_.top, &tls_begin_,
-                       &tls_end_);
+  uptr tls_size = 0;
+  uptr stack_size = 0;
+  GetThreadStackAndTls(IsMainThread(), &stack_.bottom, &stack_size, &tls_begin_,
+                       &tls_size);
+  stack_.top = stack_.bottom + stack_size;
+  tls_end_ = tls_begin_ + tls_size;
+
   int local;
   CHECK(AddrIsInStack((uptr)&local));
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -83,8 +83,8 @@ int TgKill(pid_t pid, tid_t tid, int sig);
 uptr GetThreadSelf();
 void GetThreadStackTopAndBottom(bool at_initialization, uptr *stack_top,
                                 uptr *stack_bottom);
-void GetThreadStackAndTls(bool main, uptr *stk_begin, uptr *stk_end,
-                          uptr *tls_begin, uptr *tls_end);
+void GetThreadStackAndTls(bool main, uptr *stk_addr, uptr *stk_size,
+                          uptr *tls_addr, uptr *tls_size);
 
 // Memory management
 void *MmapOrDie(uptr size, const char *mem_type, bool raw_report = false);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -626,32 +626,25 @@ uptr GetTlsSize() {
 }
 #  endif
 
-void GetThreadStackAndTls(bool main, uptr *stk_begin, uptr *stk_end,
-                          uptr *tls_begin, uptr *tls_end) {
+void GetThreadStackAndTls(bool main, uptr *stk_addr, uptr *stk_size,
+                          uptr *tls_addr, uptr *tls_size) {
 #  if SANITIZER_GO
   // Stub implementation for Go.
-  *stk_begin = 0;
-  *stk_end = 0;
-  *tls_begin = 0;
-  *tls_end = 0;
+  *stk_addr = *stk_size = *tls_addr = *tls_size = 0;
 #  else
-  uptr tls_addr = 0;
-  uptr tls_size = 0;
-  GetTls(&tls_addr, &tls_size);
-  *tls_begin = tls_addr;
-  *tls_end = tls_addr + tls_size;
+  GetTls(tls_addr, tls_size);
 
   uptr stack_top, stack_bottom;
   GetThreadStackTopAndBottom(main, &stack_top, &stack_bottom);
-  *stk_begin = stack_bottom;
-  *stk_end = stack_top;
+  *stk_addr = stack_bottom;
+  *stk_size = stack_top - stack_bottom;
 
   if (!main) {
     // If stack and tls intersect, make them non-intersecting.
-    if (*tls_begin > *stk_begin && *tls_begin < *stk_end) {
-      if (*stk_end < *tls_end)
-        *tls_end = *stk_end;
-      *stk_end = *tls_begin;
+    if (*tls_addr > *stk_addr && *tls_addr < *stk_addr + *stk_size) {
+      if (*stk_addr + *stk_size < *tls_addr + *tls_size)
+        *tls_size = *stk_addr + *stk_size - *tls_addr;
+      *stk_size = *tls_addr - *stk_addr;
     }
   }
 #  endif

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -572,18 +572,21 @@ uptr TlsSize() {
 #endif
 }
 
-void GetThreadStackAndTls(bool main, uptr *stk_begin, uptr *stk_end,
-                          uptr *tls_begin, uptr *tls_end) {
-#  if !SANITIZER_GO
-  GetThreadStackTopAndBottom(main, stk_begin, stk_end);
-  *tls_begin = TlsBaseAddr();
-  *tls_end = *tls_begin + TlsSize();
-#  else
-  *stk_begin = 0;
-  *stk_end = 0;
-  *tls_begin = 0;
-  *tls_end = 0;
-#  endif
+void GetThreadStackAndTls(bool main, uptr *stk_addr, uptr *stk_size,
+                          uptr *tls_addr, uptr *tls_size) {
+#if !SANITIZER_GO
+  uptr stack_top, stack_bottom;
+  GetThreadStackTopAndBottom(main, &stack_top, &stack_bottom);
+  *stk_addr = stack_bottom;
+  *stk_size = stack_top - stack_bottom;
+  *tls_addr = TlsBaseAddr();
+  *tls_size = TlsSize();
+#else
+  *stk_addr = 0;
+  *stk_size = 0;
+  *tls_addr = 0;
+  *tls_size = 0;
+#endif
 }
 
 void ListOfModules::init() {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -876,18 +876,21 @@ uptr GetTlsSize() {
 void InitTlsSize() {
 }
 
-void GetThreadStackAndTls(bool main, uptr *stk_begin, uptr *stk_end,
-                          uptr *tls_begin, uptr *tls_end) {
-#  if SANITIZER_GO
-  *stk_begin = 0;
-  *stk_end = 0;
-  *tls_begin = 0;
-  *tls_end = 0;
-#  else
-  GetThreadStackTopAndBottom(main, stk_begin, stk_end);
-  *tls_begin = 0;
-  *tls_end = 0;
-#  endif
+void GetThreadStackAndTls(bool main, uptr *stk_addr, uptr *stk_size,
+                          uptr *tls_addr, uptr *tls_size) {
+#if SANITIZER_GO
+  *stk_addr = 0;
+  *stk_size = 0;
+  *tls_addr = 0;
+  *tls_size = 0;
+#else
+  uptr stack_top, stack_bottom;
+  GetThreadStackTopAndBottom(main, &stack_top, &stack_bottom);
+  *stk_addr = stack_bottom;
+  *stk_size = stack_top - stack_bottom;
+  *tls_addr = 0;
+  *tls_size = 0;
+#endif
 }
 
 void ReportFile::Write(const char *buffer, uptr length) {

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_common_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_common_test.cpp
@@ -204,29 +204,30 @@ TEST(SanitizerCommon, InternalMmapVectorSwap) {
 }
 
 void TestThreadInfo(bool main) {
-  uptr stk_begin = 0;
-  uptr stk_end = 0;
-  uptr tls_begin = 0;
-  uptr tls_end = 0;
-  GetThreadStackAndTls(main, &stk_begin, &stk_end, &tls_begin, &tls_end);
+  uptr stk_addr = 0;
+  uptr stk_size = 0;
+  uptr tls_addr = 0;
+  uptr tls_size = 0;
+  GetThreadStackAndTls(main, &stk_addr, &stk_size, &tls_addr, &tls_size);
 
   int stack_var;
-  EXPECT_NE(stk_begin, (uptr)0);
-  EXPECT_GT(stk_end, stk_begin);
-  EXPECT_GT((uptr)&stack_var, stk_begin);
-  EXPECT_LT((uptr)&stack_var, stk_end);
+  EXPECT_NE(stk_addr, (uptr)0);
+  EXPECT_NE(stk_size, (uptr)0);
+  EXPECT_GT((uptr)&stack_var, stk_addr);
+  EXPECT_LT((uptr)&stack_var, stk_addr + stk_size);
 
 #if SANITIZER_LINUX && defined(__x86_64__)
   static __thread int thread_var;
-  EXPECT_NE(tls_begin, (uptr)0);
-  EXPECT_GT(tls_end, tls_begin);
-  EXPECT_GT((uptr)&thread_var, tls_begin);
-  EXPECT_LT((uptr)&thread_var, tls_end);
+  EXPECT_NE(tls_addr, (uptr)0);
+  EXPECT_NE(tls_size, (uptr)0);
+  EXPECT_GT((uptr)&thread_var, tls_addr);
+  EXPECT_LT((uptr)&thread_var, tls_addr + tls_size);
 
   // Ensure that tls and stack do not intersect.
-  EXPECT_TRUE(tls_begin < stk_begin || tls_begin >= stk_end);
-  EXPECT_TRUE(tls_end < stk_begin || tls_end >= stk_end);
-  EXPECT_TRUE((tls_begin < stk_begin) == (tls_end < stk_begin));
+  uptr tls_end = tls_addr + tls_size;
+  EXPECT_TRUE(tls_addr < stk_addr || tls_addr >= stk_addr + stk_size);
+  EXPECT_TRUE(tls_end  < stk_addr || tls_end  >=  stk_addr + stk_size);
+  EXPECT_TRUE((tls_addr < stk_addr) == (tls_end  < stk_addr));
 #endif
 }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
@@ -165,16 +165,14 @@ void ThreadStart(ThreadState *thr, Tid tid, tid_t os_id,
 #endif
 
   uptr stk_addr = 0;
-  uptr stk_end = 0;
+  uptr stk_size = 0;
   uptr tls_addr = 0;
-  uptr tls_end = 0;
+  uptr tls_size = 0;
 #if !SANITIZER_GO
   if (thread_type != ThreadType::Fiber)
-    GetThreadStackAndTls(tid == kMainTid, &stk_addr, &stk_end, &tls_addr,
-                         &tls_end);
+    GetThreadStackAndTls(tid == kMainTid, &stk_addr, &stk_size, &tls_addr,
+                         &tls_size);
 #endif
-  uptr stk_size = stk_end - stk_addr;
-  uptr tls_size = tls_end - tls_addr;
   thr->stk_addr = stk_addr;
   thr->stk_size = stk_size;
   thr->tls_addr = tls_addr;

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_malloc_hook.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_malloc_hook.c
@@ -9,6 +9,10 @@
 // No allocator and hooks.
 // XFAIL: ubsan
 
+// FIXME: Crashes on CHECK.
+// XFAIL: asan && !i386-linux
+// XFAIL: msan && !i386-linux
+
 #ifndef BUILD_SO
 #  include <assert.h>
 #  include <dlfcn.h>


### PR DESCRIPTION
Reverts llvm/llvm-project#108685

Breaks Darwin and Windows
https://lab.llvm.org/buildbot/#/builders/107/builds/2930
https://ci.swift.org/view/all/job/llvm.org/view/LLDB/job/as-lldb-cmake/11684/