### PR TITLE
[libcxxabi] Rename abort_message to __abort_message

### DIFF
--- a/libcxxabi/src/abort_message.cpp
+++ b/libcxxabi/src/abort_message.cpp
@@ -26,7 +26,7 @@
 #   define _LIBCXXABI_USE_CRASHREPORTER_CLIENT
 #endif
 
-void abort_message(const char* format, ...)
+void __abort_message(const char* format, ...)
 {
     // Write message to stderr. We do this before formatting into a
     // variable-size buffer so that we still get some information if
@@ -61,7 +61,7 @@ void abort_message(const char* format, ...)
 
 #   if __ANDROID_API__ >= 21
     // Show error in tombstone.
-    android_set_abort_message(buffer);
+    android_set___abort_message(buffer);
 
     // Show error in logcat.
     openlog("libc++abi", 0, 0);

--- a/libcxxabi/src/abort_message.h
+++ b/libcxxabi/src/abort_message.h
@@ -12,14 +12,14 @@
 #include "cxxabi.h"
 
 extern "C" _LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN void
-abort_message(const char *format, ...) __attribute__((format(printf, 1, 2)));
+__abort_message(const char *format, ...) __attribute__((format(printf, 1, 2)));
 
 #ifndef _LIBCXXABI_ASSERT
 #  define _LIBCXXABI_ASSERT(expr, msg)                                                                                 \
     do {                                                                                                               \
       if (!(expr)) {                                                                                                   \
         char const* __msg = (msg);                                                                                     \
-        ::abort_message("%s:%d: %s", __FILE__, __LINE__, __msg);                                                       \
+        ::__abort_message("%s:%d: %s", __FILE__, __LINE__, __msg);                                                     \
       }                                                                                                                \
     } while (false)
 

--- a/libcxxabi/src/cxa_default_handlers.cpp
+++ b/libcxxabi/src/cxa_default_handlers.cpp
@@ -30,18 +30,18 @@ static void demangling_terminate_handler()
 
     // If there is no uncaught exception, just note that we're terminating
     if (!globals)
-        abort_message("terminating");
+        __abort_message("terminating");
 
     __cxa_exception* exception_header = globals->caughtExceptions;
     if (!exception_header)
-        abort_message("terminating");
+        __abort_message("terminating");
 
     _Unwind_Exception* unwind_exception =
         reinterpret_cast<_Unwind_Exception*>(exception_header + 1) - 1;
 
     // If we're terminating due to a foreign exception
     if (!__isOurExceptionClass(unwind_exception))
-        abort_message("terminating due to %s foreign exception", cause);
+        __abort_message("terminating due to %s foreign exception", cause);
 
     void* thrown_object =
         __getExceptionClass(unwind_exception) == kOurDependentExceptionClass ?
@@ -67,19 +67,19 @@ static void demangling_terminate_handler()
     {
         // Include the what() message from the exception
         const std::exception* e = static_cast<const std::exception*>(thrown_object);
-        abort_message("terminating due to %s exception of type %s: %s", cause, name, e->what());
+        __abort_message("terminating due to %s exception of type %s: %s", cause, name, e->what());
     }
     else
     {
         // Else just note that we're terminating due to an exception
-        abort_message("terminating due to %s exception of type %s", cause, name);
+        __abort_message("terminating due to %s exception of type %s", cause, name);
     }
 }
 #else // !_LIBCXXABI_NO_EXCEPTIONS
 __attribute__((noreturn))
 static void demangling_terminate_handler()
 {
-    abort_message("terminating");
+    __abort_message("terminating");
 }
 #endif // !_LIBCXXABI_NO_EXCEPTIONS
 

--- a/libcxxabi/src/cxa_exception_storage.cpp
+++ b/libcxxabi/src/cxa_exception_storage.cpp
@@ -61,12 +61,12 @@ namespace {
     void _LIBCPP_TLS_DESTRUCTOR_CC destruct_(void *p) {
         __free_with_fallback(p);
         if (0 != std::__libcpp_tls_set(key_, NULL))
-            abort_message("cannot zero out thread value for __cxa_get_globals()");
+            __abort_message("cannot zero out thread value for __cxa_get_globals()");
     }
 
     void construct_() {
         if (0 != std::__libcpp_tls_create(&key_, destruct_))
-            abort_message("cannot create thread specific key for __cxa_get_globals()");
+            __abort_message("cannot create thread specific key for __cxa_get_globals()");
     }
 } // namespace
 
@@ -80,9 +80,9 @@ extern "C" {
             retVal = static_cast<__cxa_eh_globals*>(
                 __calloc_with_fallback(1, sizeof(__cxa_eh_globals)));
             if (NULL == retVal)
-                abort_message("cannot allocate __cxa_eh_globals");
+                __abort_message("cannot allocate __cxa_eh_globals");
             if (0 != std::__libcpp_tls_set(key_, retVal))
-               abort_message("std::__libcpp_tls_set failure in __cxa_get_globals()");
+               __abort_message("std::__libcpp_tls_set failure in __cxa_get_globals()");
         }
         return retVal;
     }
@@ -94,7 +94,7 @@ extern "C" {
     __cxa_eh_globals *__cxa_get_globals_fast() {
         // First time through, create the key.
         if (0 != std::__libcpp_execute_once(&flag_, construct_))
-            abort_message("execute once failure in __cxa_get_globals_fast()");
+            __abort_message("execute once failure in __cxa_get_globals_fast()");
         return static_cast<__cxa_eh_globals*>(std::__libcpp_tls_get(key_));
     }
 } // extern "C"

--- a/libcxxabi/src/cxa_guard_impl.h
+++ b/libcxxabi/src/cxa_guard_impl.h
@@ -91,7 +91,7 @@
 // the former.
 #ifdef BUILDING_CXA_GUARD
 #  include "abort_message.h"
-#  define ABORT_WITH_MESSAGE(...) ::abort_message(__VA_ARGS__)
+#  define ABORT_WITH_MESSAGE(...) ::__abort_message(__VA_ARGS__)
 #elif defined(TESTING_CXA_GUARD)
 #  define ABORT_WITH_MESSAGE(...) ::abort()
 #else

--- a/libcxxabi/src/cxa_handlers.cpp
+++ b/libcxxabi/src/cxa_handlers.cpp
@@ -33,7 +33,7 @@ __unexpected(unexpected_handler func)
 {
     func();
     // unexpected handler should not return
-    abort_message("unexpected_handler unexpectedly returned");
+    __abort_message("unexpected_handler unexpectedly returned");
 }
 
 __attribute__((noreturn))
@@ -58,13 +58,13 @@ __terminate(terminate_handler func) noexcept
 #endif // _LIBCXXABI_NO_EXCEPTIONS
         func();
         // handler should not return
-        abort_message("terminate_handler unexpectedly returned");
+        __abort_message("terminate_handler unexpectedly returned");
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
     }
     catch (...)
     {
         // handler should not throw exception
-        abort_message("terminate_handler unexpectedly threw an exception");
+        __abort_message("terminate_handler unexpectedly threw an exception");
     }
 #endif // _LIBCXXABI_NO_EXCEPTIONS
 }

--- a/libcxxabi/src/cxa_thread_atexit.cpp
+++ b/libcxxabi/src/cxa_thread_atexit.cpp
@@ -89,7 +89,7 @@ namespace {
       // __cxa_thread_atexit() may be called arbitrarily late (for example, from
       // global destructors or atexit() handlers).
       if (std::__libcpp_tls_create(&dtors_key, run_dtors) != 0) {
-        abort_message("std::__libcpp_tls_create() failed in __cxa_thread_atexit()");
+        __abort_message("std::__libcpp_tls_create() failed in __cxa_thread_atexit()");
       }
     }
 

--- a/libcxxabi/src/cxa_vector.cpp
+++ b/libcxxabi/src/cxa_vector.cpp
@@ -121,7 +121,7 @@ void throw_bad_array_new_length() {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
   throw std::bad_array_new_length();
 #else
-  abort_message("__cxa_vec_new failed to allocate memory");
+  __abort_message("__cxa_vec_new failed to allocate memory");
 #endif
 }
 

--- a/libcxxabi/src/cxa_virtual.cpp
+++ b/libcxxabi/src/cxa_virtual.cpp
@@ -13,12 +13,12 @@ namespace __cxxabiv1 {
 extern "C" {
 _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN
 void __cxa_pure_virtual(void) {
-  abort_message("Pure virtual function called!");
+  __abort_message("Pure virtual function called!");
 }
 
 _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN
 void __cxa_deleted_virtual(void) {
-  abort_message("Deleted virtual function called!");
+  __abort_message("Deleted virtual function called!");
 }
 } // extern "C"
 } // abi

--- a/libcxxabi/src/demangle/DemangleConfig.h
+++ b/libcxxabi/src/demangle/DemangleConfig.h
@@ -15,7 +15,7 @@
 // build systems to override this value.
 // https://libcxx.llvm.org/UsingLibcxx.html#enabling-the-safe-libc-mode
 #ifndef _LIBCPP_VERBOSE_ABORT
-#define _LIBCPP_VERBOSE_ABORT(...) abort_message(__VA_ARGS__)
+#define _LIBCPP_VERBOSE_ABORT(...) __abort_message(__VA_ARGS__)
 #include "../abort_message.h"
 #endif
 

--- a/libcxxabi/src/stdlib_new_delete.cpp
+++ b/libcxxabi/src/stdlib_new_delete.cpp
@@ -32,14 +32,14 @@ inline void __throw_bad_alloc_shim() {
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   throw std::bad_alloc();
 #else
-  abort_message("bad_alloc was thrown in -fno-exceptions mode");
+  __abort_message("bad_alloc was thrown in -fno-exceptions mode");
 #endif
 }
 
 #define _LIBCPP_ASSERT_SHIM(expr, str)                                                                                 \
   do {                                                                                                                 \
     if (!expr)                                                                                                         \
-      abort_message(str);                                                                                              \
+      __abort_message(str);                                                                                            \
   } while (false)
 
 // ------------------ BEGIN COPY ------------------


### PR DESCRIPTION
This is an internal API and the name should reflect that.