### PR TITLE
[HLSL] Warn about incomplete language support

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -382,4 +382,8 @@ def err_ast_action_on_llvm_ir : Error<
 def err_os_unsupport_riscv_fmv : Error<
   "function multiversioning is currently only supported on Linux">;
 
+def warn_hlsl_langstd_minimal :
+  Warning<"support for HLSL language version %0 is incomplete, "
+          "recommend using %1 instead">,
+  InGroup<HLSLDXCCompat>;
 }

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1549,6 +1549,9 @@ def DXILValidation : DiagGroup<"dxil-validation">;
 // Warning for HLSL API availability
 def HLSLAvailability : DiagGroup<"hlsl-availability">;
 
+// Warnings specifically for DXC incompatabilities.
+def HLSLDXCCompat : DiagGroup<"hlsl-dxc-compatability">;
+
 // Warnings for legacy binding behavior
 def LegacyConstantRegisterBinding : DiagGroup<"legacy-constant-register-binding">;
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4486,6 +4486,15 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
       }
     } else
       Diags.Report(diag::err_drv_hlsl_unsupported_target) << T.str();
+
+    if (Opts.LangStd < LangStandard::lang_hlsl202x) {
+      const LangStandard &Requested =
+          LangStandard::getLangStandardForKind(Opts.LangStd);
+      const LangStandard &Recommended =
+          LangStandard::getLangStandardForKind(LangStandard::lang_hlsl202x);
+      Diags.Report(diag::warn_hlsl_langstd_minimal)
+          << Requested.getName() << Recommended.getName();
+    }
   }
 
   return Diags.getNumErrors() == NumErrorsBefore;

--- a/clang/lib/Headers/hlsl.h
+++ b/clang/lib/Headers/hlsl.h
@@ -9,7 +9,18 @@
 #ifndef _HLSL_H_
 #define _HLSL_H_
 
+#if defined(__clang__)
+// Don't warn about any of the DXC compatibility warnings in the clang-only
+// headers since these will never be used with DXC anyways.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Whlsl-dxc-compatability"
+#endif
+
 #include "hlsl/hlsl_basic_types.h"
 #include "hlsl/hlsl_intrinsics.h"
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif //_HLSL_H_

--- a/clang/test/Preprocessor/predefined-macros-hlsl.hlsl
+++ b/clang/test/Preprocessor/predefined-macros-hlsl.hlsl
@@ -34,23 +34,30 @@
 // PIXEL: #define __SHADER_TARGET_STAGE 0
 // VERTEX: #define __SHADER_TARGET_STAGE 1
 
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl2015 | FileCheck -match-full-lines %s --check-prefixes=STD2015
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -E -dM -o - -x hlsl -std=hlsl2015 2>&1 | FileCheck -match-full-lines %s --check-prefixes=STD2015
+// STD2015: warning: support for HLSL language version hlsl2015 is incomplete, recommend using hlsl202x instead
 // STD2015: #define __HLSL_VERSION 2015
 
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl2016 | FileCheck -match-full-lines %s --check-prefixes=STD2016
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -E -dM -o - -x hlsl -std=hlsl2016 2>&1 | FileCheck -match-full-lines %s --check-prefixes=STD2016
+// STD2016: warning: support for HLSL language version hlsl2016 is incomplete, recommend using hlsl202x instead
 // STD2016: #define __HLSL_VERSION 2016
 
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl2017 | FileCheck -match-full-lines %s --check-prefixes=STD2017
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -E -dM -o - -x hlsl -std=hlsl2017 2>&1 | FileCheck -match-full-lines %s --check-prefixes=STD2017
+// STD2017: warning: support for HLSL language version hlsl2017 is incomplete, recommend using hlsl202x instead
 // STD2017: #define __HLSL_VERSION 2017
 
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl2018 | FileCheck -match-full-lines %s --check-prefixes=STD2018
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -E -dM -o - -x hlsl -std=hlsl2018 2>&1 | FileCheck -match-full-lines %s --check-prefixes=STD2018
+// STD2018: warning: support for HLSL language version hlsl2018 is incomplete, recommend using hlsl202x instead
 // STD2018: #define __HLSL_VERSION 2018
 
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl2021 | FileCheck -match-full-lines %s --check-prefixes=STD2021
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -E -dM -o - -x hlsl -std=hlsl2021 2>&1 | FileCheck -match-full-lines %s --check-prefixes=STD2021
+// STD2021: warning: support for HLSL language version hlsl2021 is incomplete, recommend using hlsl202x instead
 // STD2021: #define __HLSL_VERSION 2021
 
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl202x | FileCheck -match-full-lines %s --check-prefixes=STD202x
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -E -dM -o - -x hlsl -std=hlsl202x | FileCheck -match-full-lines %s --check-prefixes=STD202x
+// STD202x-NOT: warning
 // STD202x: #define __HLSL_VERSION 2028
 
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library %s -E -dM -o - -x hlsl -std=hlsl202y | FileCheck -match-full-lines %s --check-prefixes=STD202y
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -E -dM -o - -x hlsl -std=hlsl202y | FileCheck -match-full-lines %s --check-prefixes=STD202y
+// STD202y-NOT: warning
 // STD202y: #define __HLSL_VERSION 2029


### PR DESCRIPTION
This adds a warning about incomplete language mode support before HLSL 202x. This is the last change in the sequence to fix and make HLSL 202x the default mode for Clang (#108044).


Fixes #108044