### PR TITLE
[clang][bytecode] Fix defining extern variables

### DIFF
--- a/clang/test/AST/ByteCode/extern.cpp
+++ b/clang/test/AST/ByteCode/extern.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify=both,expected %s
+// RUN: %clang_cc1 -verify=both,ref %s
+
+
+// both-no-diagnostics
+
+extern const int E;
+constexpr int getE() {
+  return E;
+}
+const int E = 10;
+static_assert(getE() == 10);
+


### PR DESCRIPTION
At the point of defintion of the variable, a function might already refert to the variable by its index. Replace the index with the new one.