### PR TITLE
[libc++][NFC] Remove some boilerplate from <vector> after #76756

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -544,7 +544,7 @@ private:
       if (__vec_.__begin_ != nullptr) {
         __vec_.__clear();
         __vec_.__annotate_delete();
-        __alloc_traits::deallocate(__vec_.__alloc(), __vec_.__begin_, __vec_.capacity());
+        __alloc_traits::deallocate(__vec_.__alloc_, __vec_.__begin_, __vec_.capacity());
       }
     }
 
@@ -618,7 +618,7 @@ public:
 #endif
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT {
-    return this->__alloc();
+    return __alloc_;
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI iterator begin() _NOEXCEPT;
@@ -650,7 +650,7 @@ public:
     return static_cast<size_type>(this->__end_ - this->__begin_);
   }
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI size_type capacity() const _NOEXCEPT {
-    return static_cast<size_type>(__end_cap() - this->__begin_);
+    return static_cast<size_type>(__cap_ - __begin_);
   }
   [[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool empty() const _NOEXCEPT {
     return this->__begin_ == this->__end_;
@@ -785,17 +785,17 @@ private:
   //  Allocate space for __n objects
   //  throws length_error if __n > max_size()
   //  throws (probably bad_alloc) if memory run out
-  //  Precondition:  __begin_ == __end_ == __end_cap() == 0
+  //  Precondition:  __begin_ == __end_ == __cap_ == 0
   //  Precondition:  __n > 0
   //  Postcondition:  capacity() >= __n
   //  Postcondition:  size() == 0
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __vallocate(size_type __n) {
     if (__n > max_size())
       __throw_length_error();
-    auto __allocation = std::__allocate_at_least(__alloc(), __n);
+    auto __allocation = std::__allocate_at_least(__alloc_, __n);
     __begin_          = __allocation.ptr;
     __end_            = __allocation.ptr;
-    __end_cap()       = __begin_ + __allocation.count;
+    __cap_            = __begin_ + __allocation.count;
     __annotate_new(0);
   }
 
@@ -862,9 +862,7 @@ private:
     // don't have a way to update existing valid iterators when the container is resized and thus have to go with
     // a laxer approach.
     return std::__make_bounded_iter(
-        std::__wrap_iter<pointer>(__p),
-        std::__wrap_iter<pointer>(this->__begin_),
-        std::__wrap_iter<pointer>(this->__end_cap()));
+        std::__wrap_iter<pointer>(__p), std::__wrap_iter<pointer>(__begin_), std::__wrap_iter<pointer>(__cap_));
 #else
     return iterator(__p);
 #endif // _LIBCPP_ABI_BOUNDED_ITERATORS_IN_VECTOR
@@ -875,8 +873,8 @@ private:
     // Bound the iterator according to the capacity, rather than the size.
     return std::__make_bounded_iter(
         std::__wrap_iter<const_pointer>(__p),
-        std::__wrap_iter<const_pointer>(this->__begin_),
-        std::__wrap_iter<const_pointer>(this->__end_cap()));
+        std::__wrap_iter<const_pointer>(__begin_),
+        std::__wrap_iter<const_pointer>(__cap_));
 #else
     return const_iterator(__p);
 #endif // _LIBCPP_ABI_BOUNDED_ITERATORS_IN_VECTOR
@@ -972,18 +970,8 @@ private:
   template <class... _Args>
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __construct_one_at_end(_Args&&... __args) {
     _ConstructTransaction __tx(*this, 1);
-    __alloc_traits::construct(this->__alloc(), std::__to_address(__tx.__pos_), std::forward<_Args>(__args)...);
+    __alloc_traits::construct(__alloc_, std::__to_address(__tx.__pos_), std::forward<_Args>(__args)...);
     ++__tx.__pos_;
-  }
-
-  // TODO: Remove these now redundant accessors
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI allocator_type& __alloc() _NOEXCEPT { return this->__alloc_; }
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI const allocator_type& __alloc() const _NOEXCEPT {
-    return this->__alloc_;
-  }
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI pointer& __end_cap() _NOEXCEPT { return this->__cap_; }
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI const pointer& __end_cap() const _NOEXCEPT {
-    return this->__cap_;
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __clear() _NOEXCEPT {
@@ -993,7 +981,7 @@ private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __base_destruct_at_end(pointer __new_last) _NOEXCEPT {
     pointer __soon_to_be_end = this->__end_;
     while (__new_last != __soon_to_be_end)
-      __alloc_traits::destroy(__alloc(), std::__to_address(--__soon_to_be_end));
+      __alloc_traits::destroy(__alloc_, std::__to_address(--__soon_to_be_end));
     this->__end_ = __new_last;
   }
 
@@ -1012,20 +1000,20 @@ private:
   [[__noreturn__]] _LIBCPP_HIDE_FROM_ABI void __throw_out_of_range() const { std::__throw_out_of_range("vector"); }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __copy_assign_alloc(const vector& __c, true_type) {
-    if (__alloc() != __c.__alloc()) {
+    if (__alloc_ != __c.__alloc_) {
       __clear();
       __annotate_delete();
-      __alloc_traits::deallocate(__alloc(), this->__begin_, capacity());
-      this->__begin_ = this->__end_ = __end_cap() = nullptr;
+      __alloc_traits::deallocate(__alloc_, this->__begin_, capacity());
+      __begin_ = __end_ = __cap_ = nullptr;
     }
-    __alloc() = __c.__alloc();
+    __alloc_ = __c.__alloc_;
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __copy_assign_alloc(const vector&, false_type) {}
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __move_assign_alloc(vector& __c, true_type)
       _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value) {
-    __alloc() = std::move(__c.__alloc());
+    __alloc_ = std::move(__c.__alloc_);
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __move_assign_alloc(vector&, false_type) _NOEXCEPT {}
@@ -1061,12 +1049,12 @@ vector<_Tp, _Allocator>::__swap_out_circular_buffer(__split_buffer<value_type, a
   __annotate_delete();
   auto __new_begin = __v.__begin_ - (__end_ - __begin_);
   std::__uninitialized_allocator_relocate(
-      __alloc(), std::__to_address(__begin_), std::__to_address(__end_), std::__to_address(__new_begin));
+      __alloc_, std::__to_address(__begin_), std::__to_address(__end_), std::__to_address(__new_begin));
   __v.__begin_ = __new_begin;
   __end_       = __begin_; // All the objects have been destroyed by relocating them.
   std::swap(this->__begin_, __v.__begin_);
   std::swap(this->__end_, __v.__end_);
-  std::swap(this->__end_cap(), __v.__end_cap());
+  std::swap(__cap_, __v.__end_cap_);
   __v.__first_ = __v.__begin_;
   __annotate_new(size());
 }
@@ -1084,19 +1072,19 @@ vector<_Tp, _Allocator>::__swap_out_circular_buffer(__split_buffer<value_type, a
   // Relocate [__p, __end_) first to avoid having a hole in [__begin_, __end_)
   // in case something in [__begin_, __p) throws.
   std::__uninitialized_allocator_relocate(
-      __alloc(), std::__to_address(__p), std::__to_address(__end_), std::__to_address(__v.__end_));
+      __alloc_, std::__to_address(__p), std::__to_address(__end_), std::__to_address(__v.__end_));
   __v.__end_ += (__end_ - __p);
   __end_           = __p; // The objects in [__p, __end_) have been destroyed by relocating them.
   auto __new_begin = __v.__begin_ - (__p - __begin_);
 
   std::__uninitialized_allocator_relocate(
-      __alloc(), std::__to_address(__begin_), std::__to_address(__p), std::__to_address(__new_begin));
+      __alloc_, std::__to_address(__begin_), std::__to_address(__p), std::__to_address(__new_begin));
   __v.__begin_ = __new_begin;
   __end_       = __begin_; // All the objects have been destroyed by relocating them.
 
   std::swap(this->__begin_, __v.__begin_);
   std::swap(this->__end_, __v.__end_);
-  std::swap(this->__end_cap(), __v.__end_cap());
+  std::swap(__cap_, __v.__end_cap_);
   __v.__first_ = __v.__begin_;
   __annotate_new(size());
   return __ret;
@@ -1107,15 +1095,15 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__vdeallocate() _NOE
   if (this->__begin_ != nullptr) {
     clear();
     __annotate_delete();
-    __alloc_traits::deallocate(this->__alloc(), this->__begin_, capacity());
-    this->__begin_ = this->__end_ = this->__end_cap() = nullptr;
+    __alloc_traits::deallocate(__alloc_, this->__begin_, capacity());
+    __begin_ = __end_ = __cap_ = nullptr;
   }
 }
 
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<_Tp, _Allocator>::size_type
 vector<_Tp, _Allocator>::max_size() const _NOEXCEPT {
-  return std::min<size_type>(__alloc_traits::max_size(this->__alloc()), numeric_limits<difference_type>::max());
+  return std::min<size_type>(__alloc_traits::max_size(__alloc_), numeric_limits<difference_type>::max());
 }
 
 //  Precondition:  __new_size > capacity()
@@ -1141,7 +1129,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__construct_at_end(s
   _ConstructTransaction __tx(*this, __n);
   const_pointer __new_end = __tx.__new_end_;
   for (pointer __pos = __tx.__pos_; __pos != __new_end; __tx.__pos_ = ++__pos) {
-    __alloc_traits::construct(this->__alloc(), std::__to_address(__pos));
+    __alloc_traits::construct(__alloc_, std::__to_address(__pos));
   }
 }
 
@@ -1157,7 +1145,7 @@ vector<_Tp, _Allocator>::__construct_at_end(size_type __n, const_reference __x) 
   _ConstructTransaction __tx(*this, __n);
   const_pointer __new_end = __tx.__new_end_;
   for (pointer __pos = __tx.__pos_; __pos != __new_end; __tx.__pos_ = ++__pos) {
-    __alloc_traits::construct(this->__alloc(), std::__to_address(__pos), __x);
+    __alloc_traits::construct(__alloc_, std::__to_address(__pos), __x);
   }
 }
 
@@ -1166,7 +1154,7 @@ template <class _InputIterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 vector<_Tp, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel __last, size_type __n) {
   _ConstructTransaction __tx(*this, __n);
-  __tx.__pos_ = std::__uninitialized_allocator_copy(__alloc(), __first, __last, __tx.__pos_);
+  __tx.__pos_ = std::__uninitialized_allocator_copy(__alloc_, __first, __last, __tx.__pos_);
 }
 
 //  Default constructs __n objects starting at __end_
@@ -1175,11 +1163,10 @@ vector<_Tp, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel __
 //  Exception safety: strong.
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__append(size_type __n) {
-  if (static_cast<size_type>(this->__end_cap() - this->__end_) >= __n)
+  if (static_cast<size_type>(__cap_ - __end_) >= __n)
     this->__construct_at_end(__n);
   else {
-    allocator_type& __a = this->__alloc();
-    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), size(), __a);
+    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), size(), __alloc_);
     __v.__construct_at_end(__n);
     __swap_out_circular_buffer(__v);
   }
@@ -1191,11 +1178,10 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__append(size_type _
 //  Exception safety: strong.
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__append(size_type __n, const_reference __x) {
-  if (static_cast<size_type>(this->__end_cap() - this->__end_) >= __n)
+  if (static_cast<size_type>(__cap_ - __end_) >= __n)
     this->__construct_at_end(__n, __x);
   else {
-    allocator_type& __a = this->__alloc();
-    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), size(), __a);
+    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), size(), __alloc_);
     __v.__construct_at_end(__n, __x);
     __swap_out_circular_buffer(__v);
   }
@@ -1245,7 +1231,7 @@ vector<_Tp, _Allocator>::vector(_ForwardIterator __first, _ForwardIterator __las
 
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 vector<_Tp, _Allocator>::vector(const vector& __x)
-    : __alloc_(__alloc_traits::select_on_container_copy_construction(__x.__alloc())) {
+    : __alloc_(__alloc_traits::select_on_container_copy_construction(__x.__alloc_)) {
   __init_with_size(__x.__begin_, __x.__end_, __x.size());
 }
 
@@ -1263,22 +1249,22 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 inline _LIBCPP_HIDE_FROM_ABI vector<_Tp, _Allocato
 #else
     _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
 #endif
-    : __alloc_(std::move(__x.__alloc())) {
-  this->__begin_    = __x.__begin_;
-  this->__end_      = __x.__end_;
-  this->__end_cap() = __x.__end_cap();
-  __x.__begin_ = __x.__end_ = __x.__end_cap() = nullptr;
+    : __alloc_(std::move(__x.__alloc_)) {
+  __begin_     = __x.__begin_;
+  __end_       = __x.__end_;
+  __cap_       = __x.__cap_;
+  __x.__begin_ = __x.__end_ = __x.__cap_ = nullptr;
 }
 
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 inline _LIBCPP_HIDE_FROM_ABI
 vector<_Tp, _Allocator>::vector(vector&& __x, const __type_identity_t<allocator_type>& __a)
     : __alloc_(__a) {
-  if (__a == __x.__alloc()) {
-    this->__begin_    = __x.__begin_;
-    this->__end_      = __x.__end_;
-    this->__end_cap() = __x.__end_cap();
-    __x.__begin_ = __x.__end_ = __x.__end_cap() = nullptr;
+  if (__a == __x.__alloc_) {
+    __begin_     = __x.__begin_;
+    __end_       = __x.__end_;
+    __cap_       = __x.__cap_;
+    __x.__begin_ = __x.__end_ = __x.__cap_ = nullptr;
   } else {
     typedef move_iterator<iterator> _Ip;
     auto __guard = std::__make_exception_guard(__destroy_vector(*this));
@@ -1325,7 +1311,7 @@ vector<_Tp, _Allocator>::operator=(vector&& __x)
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__move_assign(vector& __c, false_type)
     _NOEXCEPT_(__alloc_traits::is_always_equal::value) {
-  if (__alloc() != __c.__alloc()) {
+  if (__alloc_ != __c.__alloc_) {
     typedef move_iterator<iterator> _Ip;
     assign(_Ip(__c.begin()), _Ip(__c.end()));
   } else
@@ -1337,10 +1323,10 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::__move_assign(vector
     _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value) {
   __vdeallocate();
   __move_assign_alloc(__c); // this can throw
-  this->__begin_    = __c.__begin_;
-  this->__end_      = __c.__end_;
-  this->__end_cap() = __c.__end_cap();
-  __c.__begin_ = __c.__end_ = __c.__end_cap() = nullptr;
+  __begin_     = __c.__begin_;
+  __end_       = __c.__end_;
+  __cap_       = __c.__cap_;
+  __c.__begin_ = __c.__end_ = __c.__cap_ = nullptr;
 }
 
 template <class _Tp, class _Allocator>
@@ -1475,8 +1461,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::reserve(size_type __
   if (__n > capacity()) {
     if (__n > max_size())
       this->__throw_length_error();
-    allocator_type& __a = this->__alloc();
-    __split_buffer<value_type, allocator_type&> __v(__n, size(), __a);
+    __split_buffer<value_type, allocator_type&> __v(__n, size(), __alloc_);
     __swap_out_circular_buffer(__v);
   }
 }
@@ -1487,8 +1472,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::shrink_to_fit() _NOE
 #if _LIBCPP_HAS_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_EXCEPTIONS
-      allocator_type& __a = this->__alloc();
-      __split_buffer<value_type, allocator_type&> __v(size(), size(), __a);
+      __split_buffer<value_type, allocator_type&> __v(size(), size(), __alloc_);
       // The Standard mandates shrink_to_fit() does not increase the capacity.
       // With equal capacity keep the existing buffer. This avoids extra work
       // due to swapping the elements.
@@ -1505,10 +1489,9 @@ template <class _Tp, class _Allocator>
 template <class _Up>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<_Tp, _Allocator>::pointer
 vector<_Tp, _Allocator>::__push_back_slow_path(_Up&& __x) {
-  allocator_type& __a = this->__alloc();
-  __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), size(), __a);
+  __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), size(), __alloc_);
   // __v.push_back(std::forward<_Up>(__x));
-  __alloc_traits::construct(__a, std::__to_address(__v.__end_), std::forward<_Up>(__x));
+  __alloc_traits::construct(__alloc_, std::__to_address(__v.__end_), std::forward<_Up>(__x));
   __v.__end_++;
   __swap_out_circular_buffer(__v);
   return this->__end_;
@@ -1518,7 +1501,7 @@ template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 inline _LIBCPP_HIDE_FROM_ABI void
 vector<_Tp, _Allocator>::push_back(const_reference __x) {
   pointer __end = this->__end_;
-  if (__end < this->__end_cap()) {
+  if (__end < __cap_) {
     __construct_one_at_end(__x);
     ++__end;
   } else {
@@ -1530,7 +1513,7 @@ vector<_Tp, _Allocator>::push_back(const_reference __x) {
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 inline _LIBCPP_HIDE_FROM_ABI void vector<_Tp, _Allocator>::push_back(value_type&& __x) {
   pointer __end = this->__end_;
-  if (__end < this->__end_cap()) {
+  if (__end < __cap_) {
     __construct_one_at_end(std::move(__x));
     ++__end;
   } else {
@@ -1543,10 +1526,9 @@ template <class _Tp, class _Allocator>
 template <class... _Args>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<_Tp, _Allocator>::pointer
 vector<_Tp, _Allocator>::__emplace_back_slow_path(_Args&&... __args) {
-  allocator_type& __a = this->__alloc();
-  __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), size(), __a);
+  __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), size(), __alloc_);
   //    __v.emplace_back(std::forward<_Args>(__args)...);
-  __alloc_traits::construct(__a, std::__to_address(__v.__end_), std::forward<_Args>(__args)...);
+  __alloc_traits::construct(__alloc_, std::__to_address(__v.__end_), std::forward<_Args>(__args)...);
   __v.__end_++;
   __swap_out_circular_buffer(__v);
   return this->__end_;
@@ -1562,7 +1544,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 inline
 #endif
     vector<_Tp, _Allocator>::emplace_back(_Args&&... __args) {
   pointer __end = this->__end_;
-  if (__end < this->__end_cap()) {
+  if (__end < __cap_) {
     __construct_one_at_end(std::forward<_Args>(__args)...);
     ++__end;
   } else {
@@ -1611,7 +1593,7 @@ vector<_Tp, _Allocator>::__move_range(pointer __from_s, pointer __from_e, pointe
     pointer __i = __from_s + __n;
     _ConstructTransaction __tx(*this, __from_e - __i);
     for (pointer __pos = __tx.__pos_; __i < __from_e; ++__i, (void)++__pos, __tx.__pos_ = __pos) {
-      __alloc_traits::construct(this->__alloc(), std::__to_address(__pos), std::move(*__i));
+      __alloc_traits::construct(__alloc_, std::__to_address(__pos), std::move(*__i));
     }
   }
   std::move_backward(__from_s, __from_s + __n, __old_last);
@@ -1621,7 +1603,7 @@ template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<_Tp, _Allocator>::iterator
 vector<_Tp, _Allocator>::insert(const_iterator __position, const_reference __x) {
   pointer __p = this->__begin_ + (__position - begin());
-  if (this->__end_ < this->__end_cap()) {
+  if (__end_ < __cap_) {
     if (__p == this->__end_) {
       __construct_one_at_end(__x);
     } else {
@@ -1632,8 +1614,7 @@ vector<_Tp, _Allocator>::insert(const_iterator __position, const_reference __x) 
       *__p = *__xr;
     }
   } else {
-    allocator_type& __a = this->__alloc();
-    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), __p - this->__begin_, __a);
+    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), __p - this->__begin_, __alloc_);
     __v.push_back(__x);
     __p = __swap_out_circular_buffer(__v, __p);
   }
@@ -1644,7 +1625,7 @@ template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<_Tp, _Allocator>::iterator
 vector<_Tp, _Allocator>::insert(const_iterator __position, value_type&& __x) {
   pointer __p = this->__begin_ + (__position - begin());
-  if (this->__end_ < this->__end_cap()) {
+  if (__end_ < __cap_) {
     if (__p == this->__end_) {
       __construct_one_at_end(std::move(__x));
     } else {
@@ -1652,8 +1633,7 @@ vector<_Tp, _Allocator>::insert(const_iterator __position, value_type&& __x) {
       *__p = std::move(__x);
     }
   } else {
-    allocator_type& __a = this->__alloc();
-    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), __p - this->__begin_, __a);
+    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), __p - this->__begin_, __alloc_);
     __v.push_back(std::move(__x));
     __p = __swap_out_circular_buffer(__v, __p);
   }
@@ -1665,17 +1645,16 @@ template <class... _Args>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<_Tp, _Allocator>::iterator
 vector<_Tp, _Allocator>::emplace(const_iterator __position, _Args&&... __args) {
   pointer __p = this->__begin_ + (__position - begin());
-  if (this->__end_ < this->__end_cap()) {
+  if (__end_ < __cap_) {
     if (__p == this->__end_) {
       __construct_one_at_end(std::forward<_Args>(__args)...);
     } else {
-      __temp_value<value_type, _Allocator> __tmp(this->__alloc(), std::forward<_Args>(__args)...);
+      __temp_value<value_type, _Allocator> __tmp(__alloc_, std::forward<_Args>(__args)...);
       __move_range(__p, this->__end_, __p + 1);
       *__p = std::move(__tmp.get());
     }
   } else {
-    allocator_type& __a = this->__alloc();
-    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), __p - this->__begin_, __a);
+    __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), __p - this->__begin_, __alloc_);
     __v.emplace_back(std::forward<_Args>(__args)...);
     __p = __swap_out_circular_buffer(__v, __p);
   }
@@ -1688,7 +1667,7 @@ vector<_Tp, _Allocator>::insert(const_iterator __position, size_type __n, const_
   pointer __p = this->__begin_ + (__position - begin());
   if (__n > 0) {
     // We can't compare unrelated pointers inside constant expressions
-    if (!__libcpp_is_constant_evaluated() && __n <= static_cast<size_type>(this->__end_cap() - this->__end_)) {
+    if (!__libcpp_is_constant_evaluated() && __n <= static_cast<size_type>(__cap_ - __end_)) {
       size_type __old_n  = __n;
       pointer __old_last = this->__end_;
       if (__n > static_cast<size_type>(this->__end_ - __p)) {
@@ -1704,8 +1683,7 @@ vector<_Tp, _Allocator>::insert(const_iterator __position, size_type __n, const_
         std::fill_n(__p, __n, *__xr);
       }
     } else {
-      allocator_type& __a = this->__alloc();
-      __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), __p - this->__begin_, __a);
+      __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), __p - this->__begin_, __alloc_);
       __v.__construct_at_end(__n, __x);
       __p = __swap_out_circular_buffer(__v, __p);
     }
@@ -1728,12 +1706,11 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI typename vector<_Tp, _Alloca
 vector<_Tp, _Allocator>::__insert_with_sentinel(const_iterator __position, _InputIterator __first, _Sentinel __last) {
   difference_type __off = __position - begin();
   pointer __p           = this->__begin_ + __off;
-  allocator_type& __a   = this->__alloc();
   pointer __old_last    = this->__end_;
-  for (; this->__end_ != this->__end_cap() && __first != __last; ++__first) {
+  for (; __end_ != __cap_ && __first != __last; ++__first) {
     __construct_one_at_end(*__first);
   }
-  __split_buffer<value_type, allocator_type&> __v(__a);
+  __split_buffer<value_type, allocator_type&> __v(__alloc_);
   if (__first != __last) {
 #if _LIBCPP_HAS_EXCEPTIONS
     try {
@@ -1774,7 +1751,7 @@ vector<_Tp, _Allocator>::__insert_with_size(
   auto __insertion_size = __n;
   pointer __p           = this->__begin_ + (__position - begin());
   if (__n > 0) {
-    if (__n <= this->__end_cap() - this->__end_) {
+    if (__n <= __cap_ - __end_) {
       size_type __old_n    = __n;
       pointer __old_last   = this->__end_;
       _Iterator __m        = std::next(__first, __n);
@@ -1791,8 +1768,7 @@ vector<_Tp, _Allocator>::__insert_with_size(
         std::copy(__first, __m, __p);
       }
     } else {
-      allocator_type& __a = this->__alloc();
-      __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), __p - this->__begin_, __a);
+      __split_buffer<value_type, allocator_type&> __v(__recommend(size() + __n), __p - this->__begin_, __alloc_);
       __v.__construct_at_end_with_size(__first, __insertion_size);
       __p = __swap_out_circular_buffer(__v, __p);
     }
@@ -1827,26 +1803,26 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::swap(vector& __x)
 #endif
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(
-      __alloc_traits::propagate_on_container_swap::value || this->__alloc() == __x.__alloc(),
+      __alloc_traits::propagate_on_container_swap::value || __alloc_ == __x.__alloc_,
       "vector::swap: Either propagate_on_container_swap must be true"
       " or the allocators must compare equal");
   std::swap(this->__begin_, __x.__begin_);
   std::swap(this->__end_, __x.__end_);
-  std::swap(this->__end_cap(), __x.__end_cap());
-  std::__swap_allocator(this->__alloc(), __x.__alloc());
+  std::swap(__cap_, __x.__cap_);
+  std::__swap_allocator(__alloc_, __x.__alloc_);
 }
 
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 bool vector<_Tp, _Allocator>::__invariants() const {
   if (this->__begin_ == nullptr) {
-    if (this->__end_ != nullptr || this->__end_cap() != nullptr)
+    if (__end_ != nullptr || __cap_ != nullptr)
       return false;
   } else {
     if (this->__begin_ > this->__end_)
       return false;
-    if (this->__begin_ == this->__end_cap())
+    if (__begin_ == __cap_)
       return false;
-    if (this->__end_ > this->__end_cap())
+    if (__end_ > __cap_)
       return false;
   }
   return true;
@@ -1901,14 +1877,6 @@ public:
 #endif
 
 private:
-  // TODO: Remove these now redundant accessors
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type& __cap() _NOEXCEPT { return __cap_; }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const size_type& __cap() const _NOEXCEPT { return __cap_; }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __storage_allocator& __alloc() _NOEXCEPT { return __alloc_; }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const __storage_allocator& __alloc() const _NOEXCEPT {
-    return __alloc_;
-  }
-
   static const unsigned __bits_per_word = static_cast<unsigned>(sizeof(__storage_type) * CHAR_BIT);
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static size_type
@@ -1938,7 +1906,7 @@ private:
 
     _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void operator()() {
       if (__vec_.__begin_ != nullptr)
-        __storage_traits::deallocate(__vec_.__alloc(), __vec_.__begin_, __vec_.__cap());
+        __storage_traits::deallocate(__vec_.__alloc_, __vec_.__begin_, __vec_.__cap_);
     }
 
   private:
@@ -2034,12 +2002,12 @@ public:
 #endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 allocator_type get_allocator() const _NOEXCEPT {
-    return allocator_type(this->__alloc());
+    return __alloc_;
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type max_size() const _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type capacity() const _NOEXCEPT {
-    return __internal_cap_to_external(__cap());
+    return __internal_cap_to_external(__cap_);
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type size() const _NOEXCEPT { return __size_; }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool empty() const _NOEXCEPT {
@@ -2200,7 +2168,7 @@ private:
 #if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       if (__begin_ != nullptr)
-        __storage_traits::deallocate(__alloc(), __begin_, __cap());
+        __storage_traits::deallocate(__alloc_, __begin_, __cap_);
       throw;
     }
 #endif // _LIBCPP_HAS_EXCEPTIONS
@@ -2224,19 +2192,19 @@ private:
   //  Allocate space for __n objects
   //  throws length_error if __n > max_size()
   //  throws (probably bad_alloc) if memory run out
-  //  Precondition:  __begin_ == __end_ == __cap() == 0
+  //  Precondition:  __begin_ == __end_ == __cap_ == 0
   //  Precondition:  __n > 0
   //  Postcondition:  capacity() >= __n
   //  Postcondition:  size() == 0
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __vallocate(size_type __n) {
     if (__n > max_size())
       __throw_length_error();
-    auto __allocation = std::__allocate_at_least(__alloc(), __external_cap_to_internal(__n));
+    auto __allocation = std::__allocate_at_least(__alloc_, __external_cap_to_internal(__n));
     __begin_          = __allocation.ptr;
     __size_           = 0;
-    __cap()           = __allocation.count;
+    __cap_            = __allocation.count;
     if (__libcpp_is_constant_evaluated()) {
-      for (size_type __i = 0; __i != __cap(); ++__i)
+      for (size_type __i = 0; __i != __cap_; ++__i)
         std::__construct_at(std::__to_address(__begin_) + __i);
     }
   }
@@ -2273,9 +2241,9 @@ private:
         __v, integral_constant<bool, __storage_traits::propagate_on_container_copy_assignment::value>());
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __copy_assign_alloc(const vector& __c, true_type) {
-    if (__alloc() != __c.__alloc())
+    if (__alloc_ != __c.__alloc_)
       __vdeallocate();
-    __alloc() = __c.__alloc();
+    __alloc_ = __c.__alloc_;
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __copy_assign_alloc(const vector&, false_type) {}
@@ -2291,7 +2259,7 @@ private:
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __move_assign_alloc(vector& __c, true_type)
       _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value) {
-    __alloc() = std::move(__c.__alloc());
+    __alloc_ = std::move(__c.__alloc_);
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __move_assign_alloc(vector&, false_type) _NOEXCEPT {}
@@ -2309,16 +2277,16 @@ private:
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::__vdeallocate() _NOEXCEPT {
   if (this->__begin_ != nullptr) {
-    __storage_traits::deallocate(this->__alloc(), this->__begin_, __cap());
+    __storage_traits::deallocate(__alloc_, this->__begin_, __cap_);
     this->__begin_ = nullptr;
-    this->__size_ = this->__cap() = 0;
+    __size_ = __cap_ = 0;
   }
 }
 
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<bool, _Allocator>::size_type
 vector<bool, _Allocator>::max_size() const _NOEXCEPT {
-  size_type __amax = __storage_traits::max_size(__alloc());
+  size_type __amax = __storage_traits::max_size(__alloc_);
   size_type __nmax = numeric_limits<size_type>::max() / 2; // end() >= begin(), always
   if (__nmax / __bits_per_word <= __amax)
     return __nmax;
@@ -2487,7 +2455,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 vector<bool, _Allocator>::vector(const vector& __v
     : __begin_(nullptr),
       __size_(0),
       __cap_(0),
-      __alloc_(__storage_traits::select_on_container_copy_construction(__v.__alloc())) {
+      __alloc_(__storage_traits::select_on_container_copy_construction(__v.__alloc_)) {
   if (__v.size() > 0) {
     __vallocate(__v.size());
     __construct_at_end(__v.begin(), __v.end(), __v.size());
@@ -2532,19 +2500,19 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 vector<bool, _Allocat
       __alloc_(std::move(__v.__alloc_)) {
   __v.__begin_ = nullptr;
   __v.__size_  = 0;
-  __v.__cap()  = 0;
+  __v.__cap_   = 0;
 }
 
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20
 vector<bool, _Allocator>::vector(vector&& __v, const __type_identity_t<allocator_type>& __a)
     : __begin_(nullptr), __size_(0), __cap_(0), __alloc_(__a) {
-  if (__a == allocator_type(__v.__alloc())) {
+  if (__a == allocator_type(__v.__alloc_)) {
     this->__begin_ = __v.__begin_;
     this->__size_  = __v.__size_;
-    this->__cap()  = __v.__cap();
+    __cap_         = __v.__cap_;
     __v.__begin_   = nullptr;
-    __v.__cap() = __v.__size_ = 0;
+    __v.__cap_ = __v.__size_ = 0;
   } else if (__v.size() > 0) {
     __vallocate(__v.size());
     __construct_at_end(__v.begin(), __v.end(), __v.size());
@@ -2561,7 +2529,7 @@ vector<bool, _Allocator>::operator=(vector&& __v)
 
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::__move_assign(vector& __c, false_type) {
-  if (__alloc() != __c.__alloc())
+  if (__alloc_ != __c.__alloc_)
     assign(__c.begin(), __c.end());
   else
     __move_assign(__c, true_type());
@@ -2574,9 +2542,9 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::__move_assign(vecto
   __move_assign_alloc(__c);
   this->__begin_ = __c.__begin_;
   this->__size_  = __c.__size_;
-  this->__cap()  = __c.__cap();
+  __cap_         = __c.__cap_;
   __c.__begin_   = nullptr;
-  __c.__cap() = __c.__size_ = 0;
+  __c.__cap_ = __c.__size_ = 0;
 }
 
 template <class _Allocator>
@@ -2649,11 +2617,11 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::reserve(size_type _
 
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::shrink_to_fit() _NOEXCEPT {
-  if (__external_cap_to_internal(size()) > __cap()) {
+  if (__external_cap_to_internal(size()) > __cap_) {
 #if _LIBCPP_HAS_EXCEPTIONS
     try {
 #endif // _LIBCPP_HAS_EXCEPTIONS
-      vector(*this, allocator_type(__alloc())).swap(*this);
+      vector(*this, __alloc_).swap(*this);
 #if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
     }
@@ -2829,8 +2797,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::swap(vector& __x)
 {
   std::swap(this->__begin_, __x.__begin_);
   std::swap(this->__size_, __x.__size_);
-  std::swap(this->__cap(), __x.__cap());
-  std::__swap_allocator(this->__alloc(), __x.__alloc());
+  std::swap(__cap_, __x.__cap_);
+  std::__swap_allocator(__alloc_, __x.__alloc_);
 }
 
 template <class _Allocator>
@@ -2874,10 +2842,10 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::flip() _NOEXCEPT {
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 bool vector<bool, _Allocator>::__invariants() const {
   if (this->__begin_ == nullptr) {
-    if (this->__size_ != 0 || this->__cap() != 0)
+    if (this->__size_ != 0 || __cap_ != 0)
       return false;
   } else {
-    if (this->__cap() == 0)
+    if (__cap_ == 0)
       return false;
     if (this->__size_ > this->capacity())
       return false;


### PR DESCRIPTION
A few functions are now unnecessary, since we can access the members directly instread now.
