### PR TITLE
[libc++][NFC] Remove some boilerplate from <string> after #76756

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -941,7 +941,7 @@ private:
       __set_short_size(__size);
     } else {
       auto __capacity   = __recommend(__size) + 1;
-      auto __allocation = __alloc_traits::allocate(__alloc(), __capacity);
+      auto __allocation = __alloc_traits::allocate(__alloc_, __capacity);
       __begin_lifetime(__allocation, __capacity);
       __set_long_cap(__capacity);
       __set_long_pointer(__allocation);
@@ -1006,7 +1006,7 @@ public:
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS basic_string(const basic_string& __str)
-      : __alloc_(__alloc_traits::select_on_container_copy_construction(__str.__alloc())) {
+      : __alloc_(__alloc_traits::select_on_container_copy_construction(__str.__alloc_)) {
     if (!__str.__is_long()) {
       __rep_ = __str.__rep_;
       __annotate_new(__get_short_size());
@@ -1048,7 +1048,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(basic_string&& __str, const allocator_type& __a)
       : __alloc_(__a) {
-    if (__str.__is_long() && __a != __str.__alloc()) // copy, not move
+    if (__str.__is_long() && __a != __str.__alloc_) // copy, not move
       __init(std::__to_address(__str.__get_long_pointer()), __str.__get_long_size());
     else {
       if (__libcpp_is_constant_evaluated())
@@ -1107,7 +1107,7 @@ public:
       __throw_out_of_range();
 
     auto __len = std::min<size_type>(__n, __str.size() - __pos);
-    if (__alloc_traits::is_always_equal::value || __alloc == __str.__alloc()) {
+    if (__alloc_traits::is_always_equal::value || __alloc == __str.__alloc_) {
       __move_assign(std::move(__str), __pos, __len);
     } else {
       // Perform a copy because the allocators are not compatible.
@@ -1212,7 +1212,7 @@ public:
   inline _LIBCPP_CONSTEXPR_SINCE_CXX20 ~basic_string() {
     __annotate_delete();
     if (__is_long())
-      __alloc_traits::deallocate(__alloc(), __get_long_pointer(), __get_long_cap());
+      __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 operator __self_view() const _NOEXCEPT {
@@ -1289,7 +1289,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type length() const _NOEXCEPT { return size(); }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type max_size() const _NOEXCEPT {
-    size_type __m = __alloc_traits::max_size(__alloc());
+    size_type __m = __alloc_traits::max_size(__alloc_);
     if (__m <= std::numeric_limits<size_type>::max() / 2) {
       return __m - __alignment;
     } else {
@@ -1409,7 +1409,7 @@ public:
   template <class _InputIterator, __enable_if_t<__has_exactly_input_iterator_category<_InputIterator>::value, int> = 0>
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   append(_InputIterator __first, _InputIterator __last) {
-    const basic_string __temp(__first, __last, __alloc());
+    const basic_string __temp(__first, __last, __alloc_);
     append(__temp.data(), __temp.size());
     return *this;
   }
@@ -1465,7 +1465,7 @@ public:
 #if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI constexpr void __move_assign(basic_string&& __str, size_type __pos, size_type __len) {
     // Pilfer the allocation from __str.
-    _LIBCPP_ASSERT_INTERNAL(__alloc() == __str.__alloc(), "__move_assign called with wrong allocator");
+    _LIBCPP_ASSERT_INTERNAL(__alloc_ == __str.__alloc_, "__move_assign called with wrong allocator");
     size_type __old_sz = __str.size();
     if (!__str.__is_long())
       __str.__annotate_delete();
@@ -1571,7 +1571,7 @@ public:
       return __insert_with_size(__position, ranges::begin(__range), ranges::end(__range), __n);
 
     } else {
-      basic_string __temp(from_range, std::forward<_Range>(__range), __alloc());
+      basic_string __temp(from_range, std::forward<_Range>(__range), __alloc_);
       return insert(__position, __temp.data(), __temp.data() + __temp.size());
     }
   }
@@ -1666,7 +1666,7 @@ public:
   template <_ContainerCompatibleRange<_CharT> _Range>
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string&
   replace_with_range(const_iterator __i1, const_iterator __i2, _Range&& __range) {
-    basic_string __temp(from_range, std::forward<_Range>(__range), __alloc());
+    basic_string __temp(from_range, std::forward<_Range>(__range), __alloc_);
     return replace(__i1, __i2, __temp);
   }
 #endif
@@ -1713,7 +1713,7 @@ public:
 #endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 allocator_type get_allocator() const _NOEXCEPT {
-    return __alloc();
+    return __alloc_;
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type
@@ -1949,9 +1949,6 @@ private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator
   __insert_with_size(const_iterator __pos, _Iterator __first, _Sentinel __last, size_type __n);
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 allocator_type& __alloc() _NOEXCEPT { return __alloc_; }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR const allocator_type& __alloc() const _NOEXCEPT { return __alloc_; }
-
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS void
   __set_short_size(size_type __s) _NOEXCEPT {
     _LIBCPP_ASSERT_INTERNAL(__s < __min_cap, "__s should never be greater than or equal to the short string capacity");
@@ -2152,20 +2149,20 @@ private:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __copy_assign_alloc(const basic_string& __str, true_type) {
-    if (__alloc() == __str.__alloc())
-      __alloc() = __str.__alloc();
+    if (__alloc_ == __str.__alloc_)
+      __alloc_ = __str.__alloc_;
     else {
       if (!__str.__is_long()) {
         __clear_and_shrink();
-        __alloc() = __str.__alloc();
+        __alloc_ = __str.__alloc_;
       } else {
         __annotate_delete();
-        allocator_type __a = __str.__alloc();
+        allocator_type __a = __str.__alloc_;
         auto __allocation  = std::__allocate_at_least(__a, __str.__get_long_cap());
         __begin_lifetime(__allocation.ptr, __allocation.count);
         if (__is_long())
-          __alloc_traits::deallocate(__alloc(), __get_long_pointer(), __get_long_cap());
-        __alloc() = std::move(__a);
+          __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
+        __alloc_ = std::move(__a);
         __set_long_pointer(__allocation.ptr);
         __set_long_cap(__allocation.count);
         __set_long_size(__str.size());
@@ -2198,7 +2195,7 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __move_assign_alloc(basic_string& __c, true_type)
       _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value) {
-    __alloc() = std::move(__c.__alloc());
+    __alloc_ = std::move(__c.__alloc_);
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __move_assign_alloc(basic_string&, false_type) _NOEXCEPT {}
@@ -2321,7 +2318,7 @@ basic_string<_CharT, _Traits, _Allocator>::__init(const value_type* __s, size_ty
     __set_short_size(__sz);
     __p = __get_short_pointer();
   } else {
-    auto __allocation = std::__allocate_at_least(__alloc(), __recommend(__reserve) + 1);
+    auto __allocation = std::__allocate_at_least(__alloc_, __recommend(__reserve) + 1);
     __p               = __allocation.ptr;
     __begin_lifetime(__p, __allocation.count);
     __set_long_pointer(__p);
@@ -2345,7 +2342,7 @@ basic_string<_CharT, _Traits, _Allocator>::__init(const value_type* __s, size_ty
     __set_short_size(__sz);
     __p = __get_short_pointer();
   } else {
-    auto __allocation = std::__allocate_at_least(__alloc(), __recommend(__sz) + 1);
+    auto __allocation = std::__allocate_at_least(__alloc_, __recommend(__sz) + 1);
     __p               = __allocation.ptr;
     __begin_lifetime(__p, __allocation.count);
     __set_long_pointer(__p);
@@ -2370,7 +2367,7 @@ basic_string<_CharT, _Traits, _Allocator>::__init_copy_ctor_external(const value
   } else {
     if (__sz > max_size())
       __throw_length_error();
-    auto __allocation = std::__allocate_at_least(__alloc(), __recommend(__sz) + 1);
+    auto __allocation = std::__allocate_at_least(__alloc_, __recommend(__sz) + 1);
     __p               = __allocation.ptr;
     __begin_lifetime(__p, __allocation.count);
     __set_long_pointer(__p);
@@ -2393,7 +2390,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::__
     __set_short_size(__n);
     __p = __get_short_pointer();
   } else {
-    auto __allocation = std::__allocate_at_least(__alloc(), __recommend(__n) + 1);
+    auto __allocation = std::__allocate_at_least(__alloc_, __recommend(__n) + 1);
     __p               = __allocation.ptr;
     __begin_lifetime(__p, __allocation.count);
     __set_long_pointer(__p);
@@ -2428,7 +2425,7 @@ basic_string<_CharT, _Traits, _Allocator>::__init_with_sentinel(_InputIterator _
   } catch (...) {
     __annotate_delete();
     if (__is_long())
-      __alloc_traits::deallocate(__alloc(), __get_long_pointer(), __get_long_cap());
+      __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
     throw;
   }
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
@@ -2458,7 +2455,7 @@ basic_string<_CharT, _Traits, _Allocator>::__init_with_size(_InputIterator __fir
     __p = __get_short_pointer();
 
   } else {
-    auto __allocation = std::__allocate_at_least(__alloc(), __recommend(__sz) + 1);
+    auto __allocation = std::__allocate_at_least(__alloc_, __recommend(__sz) + 1);
     __p               = __allocation.ptr;
     __begin_lifetime(__p, __allocation.count);
     __set_long_pointer(__p);
@@ -2474,7 +2471,7 @@ basic_string<_CharT, _Traits, _Allocator>::__init_with_size(_InputIterator __fir
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     if (__is_long())
-      __alloc_traits::deallocate(__alloc(), __get_long_pointer(), __get_long_cap());
+      __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
     throw;
   }
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
@@ -2497,7 +2494,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::__
   size_type __cap =
       __old_cap < __ms / 2 - __alignment ? __recommend(std::max(__old_cap + __delta_cap, 2 * __old_cap)) : __ms - 1;
   __annotate_delete();
-  auto __allocation = std::__allocate_at_least(__alloc(), __cap + 1);
+  auto __allocation = std::__allocate_at_least(__alloc_, __cap + 1);
   pointer __p       = __allocation.ptr;
   __begin_lifetime(__p, __allocation.count);
   if (__n_copy != 0)
@@ -2509,7 +2506,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::__
     traits_type::copy(
         std::__to_address(__p) + __n_copy + __n_add, std::__to_address(__old_p) + __n_copy + __n_del, __sec_cp_sz);
   if (__old_cap + 1 != __min_cap)
-    __alloc_traits::deallocate(__alloc(), __old_p, __old_cap + 1);
+    __alloc_traits::deallocate(__alloc_, __old_p, __old_cap + 1);
   __set_long_pointer(__p);
   __set_long_cap(__allocation.count);
   __old_sz = __n_copy + __n_add + __sec_cp_sz;
@@ -2540,7 +2537,7 @@ _LIBCPP_DEPRECATED_("use __grow_by_without_replace") basic_string<_CharT, _Trait
   size_type __cap =
       __old_cap < __ms / 2 - __alignment ? __recommend(std::max(__old_cap + __delta_cap, 2 * __old_cap)) : __ms - 1;
   __annotate_delete();
-  auto __allocation = std::__allocate_at_least(__alloc(), __cap + 1);
+  auto __allocation = std::__allocate_at_least(__alloc_, __cap + 1);
   pointer __p       = __allocation.ptr;
   __begin_lifetime(__p, __allocation.count);
   if (__n_copy != 0)
@@ -2550,7 +2547,7 @@ _LIBCPP_DEPRECATED_("use __grow_by_without_replace") basic_string<_CharT, _Trait
     traits_type::copy(
         std::__to_address(__p) + __n_copy + __n_add, std::__to_address(__old_p) + __n_copy + __n_del, __sec_cp_sz);
   if (__old_cap + 1 != __min_cap)
-    __alloc_traits::deallocate(__alloc(), __old_p, __old_cap + 1);
+    __alloc_traits::deallocate(__alloc_, __old_p, __old_cap + 1);
   __set_long_pointer(__p);
   __set_long_cap(__allocation.count);
 }
@@ -2685,7 +2682,7 @@ basic_string<_CharT, _Traits, _Allocator>::operator=(const basic_string& __str) 
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::__move_assign(
     basic_string& __str, false_type) noexcept(__alloc_traits::is_always_equal::value) {
-  if (__alloc() != __str.__alloc())
+  if (__alloc_ != __str.__alloc_)
     assign(__str);
   else
     __move_assign(__str, true_type());
@@ -2702,7 +2699,7 @@ basic_string<_CharT, _Traits, _Allocator>::__move_assign(basic_string& __str, tr
 {
   __annotate_delete();
   if (__is_long()) {
-    __alloc_traits::deallocate(__alloc(), __get_long_pointer(), __get_long_cap());
+    __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
 #  if _LIBCPP_STD_VER <= 14
     if (!is_nothrow_move_assignable<allocator_type>::value) {
       __set_short_size(0);
@@ -2752,7 +2749,7 @@ template <class _CharT, class _Traits, class _Allocator>
 template <class _InputIterator, class _Sentinel>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 basic_string<_CharT, _Traits, _Allocator>::__assign_with_sentinel(_InputIterator __first, _Sentinel __last) {
-  const basic_string __temp(__init_with_sentinel_tag(), std::move(__first), std::move(__last), __alloc());
+  const basic_string __temp(__init_with_sentinel_tag(), std::move(__first), std::move(__last), __alloc_);
   assign(__temp.data(), __temp.size());
 }
 
@@ -2940,7 +2937,7 @@ basic_string<_CharT, _Traits, _Allocator>::append(_ForwardIterator __first, _For
       traits_type::assign(*__end, value_type());
       __set_size(__sz + __n);
     } else {
-      const basic_string __temp(__first, __last, __alloc());
+      const basic_string __temp(__first, __last, __alloc_);
       append(__temp.data(), __temp.size());
     }
   }
@@ -3038,7 +3035,7 @@ template <class _CharT, class _Traits, class _Allocator>
 template <class _InputIterator, __enable_if_t<__has_exactly_input_iterator_category<_InputIterator>::value, int> >
 _LIBCPP_CONSTEXPR_SINCE_CXX20 typename basic_string<_CharT, _Traits, _Allocator>::iterator
 basic_string<_CharT, _Traits, _Allocator>::insert(const_iterator __pos, _InputIterator __first, _InputIterator __last) {
-  const basic_string __temp(__first, __last, __alloc());
+  const basic_string __temp(__first, __last, __alloc_);
   return insert(__pos, __temp.data(), __temp.data() + __temp.size());
 }
 
@@ -3063,7 +3060,7 @@ basic_string<_CharT, _Traits, _Allocator>::__insert_with_size(
   if (__string_is_trivial_iterator<_Iterator>::value && !__addr_in_range(*__first)) {
     return __insert_from_safe_copy(__n, __ip, __first, __last);
   } else {
-    const basic_string __temp(__init_with_sentinel_tag(), __first, __last, __alloc());
+    const basic_string __temp(__init_with_sentinel_tag(), __first, __last, __alloc_);
     return __insert_from_safe_copy(__n, __ip, __temp.begin(), __temp.end());
   }
 }
@@ -3200,7 +3197,7 @@ template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_Inp
 _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::replace(
     const_iterator __i1, const_iterator __i2, _InputIterator __j1, _InputIterator __j2) {
-  const basic_string __temp(__j1, __j2, __alloc());
+  const basic_string __temp(__j1, __j2, __alloc_);
   return replace(__i1, __i2, __temp);
 }
 
@@ -3372,7 +3369,7 @@ basic_string<_CharT, _Traits, _Allocator>::__shrink_or_extend(size_type __target
     if (__target_capacity > __cap) {
       // Extend
       // - called from reserve should propagate the exception thrown.
-      auto __allocation = std::__allocate_at_least(__alloc(), __target_capacity + 1);
+      auto __allocation = std::__allocate_at_least(__alloc_, __target_capacity + 1);
       __new_data        = __allocation.ptr;
       __target_capacity = __allocation.count - 1;
     } else {
@@ -3382,13 +3379,13 @@ basic_string<_CharT, _Traits, _Allocator>::__shrink_or_extend(size_type __target
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
       try {
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
-        auto __allocation = std::__allocate_at_least(__alloc(), __target_capacity + 1);
+        auto __allocation = std::__allocate_at_least(__alloc_, __target_capacity + 1);
 
         // The Standard mandates shrink_to_fit() does not increase the capacity.
         // With equal capacity keep the existing buffer. This avoids extra work
         // due to swapping the elements.
         if (__allocation.count - 1 > __target_capacity) {
-          __alloc_traits::deallocate(__alloc(), __allocation.ptr, __allocation.count);
+          __alloc_traits::deallocate(__alloc_, __allocation.ptr, __allocation.count);
           __annotate_new(__sz); // Undoes the __annotate_delete()
           return;
         }
@@ -3407,7 +3404,7 @@ basic_string<_CharT, _Traits, _Allocator>::__shrink_or_extend(size_type __target
   }
   traits_type::copy(std::__to_address(__new_data), std::__to_address(__p), size() + 1);
   if (__was_long)
-    __alloc_traits::deallocate(__alloc(), __p, __cap + 1);
+    __alloc_traits::deallocate(__alloc_, __p, __cap + 1);
   if (__now_long) {
     __set_long_cap(__target_capacity + 1);
     __set_long_size(__sz);
@@ -3454,14 +3451,14 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocat
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(
       __alloc_traits::propagate_on_container_swap::value || __alloc_traits::is_always_equal::value ||
-          __alloc() == __str.__alloc(),
+          __alloc_ == __str.__alloc_,
       "swapping non-equal allocators");
   if (!__is_long())
     __annotate_delete();
   if (this != std::addressof(__str) && !__str.__is_long())
     __str.__annotate_delete();
   std::swap(__rep_, __str.__rep_);
-  std::__swap_allocator(__alloc(), __str.__alloc());
+  std::__swap_allocator(__alloc_, __str.__alloc_);
   if (!__is_long())
     __annotate_new(__get_short_size());
   if (this != std::addressof(__str) && !__str.__is_long())
@@ -3814,7 +3811,7 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocat
   clear();
   if (__is_long()) {
     __annotate_delete();
-    __alloc_traits::deallocate(__alloc(), __get_long_pointer(), capacity() + 1);
+    __alloc_traits::deallocate(__alloc_, __get_long_pointer(), capacity() + 1);
     __rep_ = __rep();
   }
 }


### PR DESCRIPTION
A few functions are now unnecessary, since we can access the members directly instread now.
