### PR TITLE
[libc++] Fix constant initialization of unique_ptr in C++17 and prior

### DIFF
--- a/libcxx/include/__memory/compressed_pair.h
+++ b/libcxx/include/__memory/compressed_pair.h
@@ -56,7 +56,7 @@ template <class _ToPad,
           bool _Empty = ((is_empty<_ToPad>::value && !__libcpp_is_final<_ToPad>::value) ||
                          is_reference<_ToPad>::value || sizeof(_ToPad) == __datasizeof_v<_ToPad>)>
 class __compressed_pair_padding {
-  char __padding_[sizeof(_ToPad) - __datasizeof_v<_ToPad>];
+  char __padding_[sizeof(_ToPad) - __datasizeof_v<_ToPad>] = {};
 };
 
 template <class _ToPad>

--- a/libcxx/test/std/utilities/any/any.class/any.cons/default.pass.cpp
+++ b/libcxx/test/std/utilities/any/any.class/any.cons/default.pass.cpp
@@ -32,7 +32,7 @@ int main(int, char**)
         struct TestConstexpr : public std::any {
           constexpr TestConstexpr() : std::any() {}
         };
-        static TEST_CONSTINIT std::any a;
+        TEST_CONSTINIT static std::any a;
         (void)a;
     }
     {

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -221,9 +221,11 @@
 #endif
 
 #if TEST_STD_VER > 17
-#define TEST_CONSTINIT constinit
+#  define TEST_CONSTINIT constinit
+#elif __has_cpp_attribute(clang::require_constant_initialization)
+#  define TEST_CONSTINIT [[clang::require_constant_initialization]]
 #else
-#define TEST_CONSTINIT
+#  define TEST_CONSTINIT
 #endif
 
 #if TEST_STD_VER < 11


### PR DESCRIPTION
This is already tested in `std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp` except that `TEST_CONSTINIT` doesn't do anything before C++20 without this patch.