### PR TITLE
[LLVM][TableGen] Change VarLenCodeEmitterGen to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.h
+++ b/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.h
@@ -53,7 +53,7 @@ public:
   bool isFixedValueOnly() const { return !HasDynamicSegment; }
 };
 
-void emitVarLenCodeEmitter(RecordKeeper &R, raw_ostream &OS);
+void emitVarLenCodeEmitter(const RecordKeeper &R, raw_ostream &OS);
 
 } // end namespace llvm
 


### PR DESCRIPTION
Change VarLenCodeEmitterGen to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089