### PR TITLE
[llvm][Support] Enable pass timing in StandardInstrumentations constr…

### DIFF
--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -602,8 +602,8 @@ public:
   StandardInstrumentations(LLVMContext &Context, bool DebugLogging,
                            bool VerifyEach = false,
                            PrintPassOptions PrintPassOpts = PrintPassOptions(),
-                           std::optional<bool> TimePasses = std::nullopt,
-                           std::optional<bool> TimePassesPerRun = std::nullopt);
+                           bool EnableTimePasses = false,
+                           bool EnableTimePassesPerRun = false);
 
   // Register all the standard instrumentation callbacks. If \p FAM is nullptr
   // then PreservedCFGChecker is not enabled.

--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -601,7 +601,9 @@ class StandardInstrumentations {
 public:
   StandardInstrumentations(LLVMContext &Context, bool DebugLogging,
                            bool VerifyEach = false,
-                           PrintPassOptions PrintPassOpts = PrintPassOptions());
+                           PrintPassOptions PrintPassOpts = PrintPassOptions(),
+                           std::optional<bool> TimePasses = std::nullopt,
+                           std::optional<bool> TimePassesPerRun = std::nullopt);
 
   // Register all the standard instrumentation callbacks. If \p FAM is nullptr
   // then PreservedCFGChecker is not enabled.

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -2442,8 +2442,11 @@ void DotCfgChangeReporter::registerCallbacks(
 
 StandardInstrumentations::StandardInstrumentations(
     LLVMContext &Context, bool DebugLogging, bool VerifyEach,
-    PrintPassOptions PrintPassOpts)
+    PrintPassOptions PrintPassOpts, std::optional<bool> EnableTimePasses,
+    std::optional<bool> EnablePerRunTiming)
     : PrintPass(DebugLogging, PrintPassOpts),
+      TimePasses(EnableTimePasses ? *EnableTimePasses : TimePassesIsEnabled,
+                 EnablePerRunTiming ? *EnablePerRunTiming : TimePassesPerRun),
       OptNone(DebugLogging),
       OptPassGate(Context),
       PrintChangedIR(PrintChanged == ChangePrinter::Verbose),

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -2447,8 +2447,7 @@ StandardInstrumentations::StandardInstrumentations(
     : PrintPass(DebugLogging, PrintPassOpts),
       TimePasses(EnableTimePasses ? *EnableTimePasses : TimePassesIsEnabled,
                  EnablePerRunTiming ? *EnablePerRunTiming : TimePassesPerRun),
-      OptNone(DebugLogging),
-      OptPassGate(Context),
+      OptNone(DebugLogging), OptPassGate(Context),
       PrintChangedIR(PrintChanged == ChangePrinter::Verbose),
       PrintChangedDiff(PrintChanged == ChangePrinter::DiffVerbose ||
                            PrintChanged == ChangePrinter::ColourDiffVerbose,

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -2442,11 +2442,11 @@ void DotCfgChangeReporter::registerCallbacks(
 
 StandardInstrumentations::StandardInstrumentations(
     LLVMContext &Context, bool DebugLogging, bool VerifyEach,
-    PrintPassOptions PrintPassOpts, std::optional<bool> EnableTimePasses,
-    std::optional<bool> EnablePerRunTiming)
+    PrintPassOptions PrintPassOpts, bool EnableTimePasses,
+    bool EnableTimePassesPerRun)
     : PrintPass(DebugLogging, PrintPassOpts),
-      TimePasses(EnableTimePasses ? *EnableTimePasses : TimePassesIsEnabled,
-                 EnablePerRunTiming ? *EnablePerRunTiming : TimePassesPerRun),
+      TimePasses(TimePassesIsEnabled ? TimePassesIsEnabled : EnableTimePasses,
+                 TimePassesPerRun ? TimePassesPerRun : EnableTimePassesPerRun),
       OptNone(DebugLogging), OptPassGate(Context),
       PrintChangedIR(PrintChanged == ChangePrinter::Verbose),
       PrintChangedDiff(PrintChanged == ChangePrinter::DiffVerbose ||


### PR DESCRIPTION
…uctor

Add two optional arguments to the llvm::StandardInstrumentations constructor that enables pass timings and pass timings per run. If the optional arguments are not provided, the TimePassesIsEnabled and TimePassesPerRun global variables will be read when constructing the TimePassesHandler object which will preserve the current behavior.

------------------

Notes for reviewers: This was motivated by #107270 which could be simplified if timing of passes could be enabled without having to set `llvm::TimePassesIsEnabled` and `llvm::TimePassesPerRun` directly.