### PR TITLE
[clang][bytecode] Allow right-shift of negative values

### DIFF
--- a/clang/test/AST/ByteCode/shifts.cpp
+++ b/clang/test/AST/ByteCode/shifts.cpp
@@ -5,6 +5,7 @@
 
 #define INT_MIN (~__INT_MAX__)
 
+constexpr int a = -1 >> 3;
 
 namespace shifts {
   constexpr void test() { // ref-error {{constexpr function never produces a constant expression}} \


### PR DESCRIPTION
We used to incorrectly diagnose this as a "left shift of negative value".