### PR TITLE
[flang] Fix code that deletes unit from bad OPEN

### DIFF
--- a/flang/runtime/io-api.cpp
+++ b/flang/runtime/io-api.cpp
@@ -948,7 +948,7 @@ bool IODEF(SetRecl)(Cookie cookie, std::size_t n) {
     io.GetIoErrorHandler().Crash(
         "SetRecl() called after GetNewUnit() for an OPEN statement");
   }
-  if (n <= 0) {
+  if (static_cast<std::int64_t>(n) <= 0) {
     io.GetIoErrorHandler().SignalError("RECL= must be greater than zero");
     return false;
   } else if (open->wasExtant() &&

--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -329,8 +329,11 @@ void OpenStatementState::CompleteOperation() {
   }
   if (!wasExtant_ && InError()) {
     // Release the new unit on failure
-    unit().CloseUnit(CloseStatus::Delete, *this);
-    unit().DestroyClosed();
+    if (ExternalFileUnit *
+        toClose{unit().LookUpForClose(unit().unitNumber())}) {
+      toClose->Close(CloseStatus::Delete, *this);
+      toClose->DestroyClosed();
+    }
   }
   IoStatementBase::CompleteOperation();
 }


### PR DESCRIPTION
When an OPEN statement fails, a unit that was created for the OPEN needs to be removed from the unit map.  The code that tried to do this was incorrect -- it needs to re-acquire the unit via LookUpForClose as a CLOSE statement does.  (The failure to do this completely was leaving a zombie unit active that could break a later OPEN on the same unit number.)