### PR TITLE
ValueTracking/test: cover known-high-bits of rem

### DIFF
--- a/llvm/test/Analysis/ValueTracking/knownbits-rem.ll
+++ b/llvm/test/Analysis/ValueTracking/knownbits-rem.ll
@@ -12,6 +12,17 @@ define i8 @urem_low_bits_know(i8 %xx, i8 %yy) {
   ret i8 %r
 }
 
+define i8 @urem_high_bits_know(i8 %xx, i8 %yy) {
+; CHECK-LABEL: @urem_high_bits_know(
+; CHECK-NEXT:    ret i8 0
+;
+  %x = and i8 %xx, 2
+  %y = and i8 %yy, -4
+  %rem = urem i8 %x, %y
+  %r = and i8 %rem, 8
+  ret i8 %r
+}
+
 define i8 @urem_low_bits_know2(i8 %xx, i8 %yy) {
 ; CHECK-LABEL: @urem_low_bits_know2(
 ; CHECK-NEXT:    ret i8 2
@@ -88,6 +99,74 @@ define i8 @srem_low_bits_know2(i8 %xx, i8 %yy) {
   %y = and i8 %yy, -2
   %rem = srem i8 %x, %y
   %r = and i8 %rem, 1
+  ret i8 %r
+}
+
+define i8 @srem_high_bits_know(i8 %xx, i8 %yy) {
+; CHECK-LABEL: @srem_high_bits_know(
+; CHECK-NEXT:    [[X:%.*]] = or i8 [[XX:%.*]], -2
+; CHECK-NEXT:    [[Y:%.*]] = and i8 [[YY:%.*]], -4
+; CHECK-NEXT:    [[REM:%.*]] = srem i8 [[X]], [[Y]]
+; CHECK-NEXT:    [[R:%.*]] = and i8 [[REM]], -2
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %x = or i8 %xx, -2
+  %y = and i8 %yy, -4
+  %rem = srem i8 %x, %y
+  %r = and i8 %rem, -2
+  ret i8 %r
+}
+
+define i8 @srem_high_bits_know2(i8 %xx, i8 %yy) {
+; CHECK-LABEL: @srem_high_bits_know2(
+; CHECK-NEXT:    [[X:%.*]] = and i8 [[XX:%.*]], 13
+; CHECK-NEXT:    [[Y:%.*]] = or i8 [[YY:%.*]], -4
+; CHECK-NEXT:    [[REM:%.*]] = srem i8 [[X]], [[Y]]
+; CHECK-NEXT:    [[R:%.*]] = and i8 [[REM]], 8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %x = and i8 %xx, 13
+  %y = or i8 %yy, -4
+  %rem = srem i8 %x, %y
+  %r = and i8 %rem, 8
+  ret i8 %r
+}
+
+define i8 @srem_high_bits_know3(i8 %xx, i8 %yy) {
+; CHECK-LABEL: @srem_high_bits_know3(
+; CHECK-NEXT:    [[X:%.*]] = or i8 [[XX:%.*]], -13
+; CHECK-NEXT:    [[Y:%.*]] = and i8 [[YY:%.*]], 4
+; CHECK-NEXT:    [[REM:%.*]] = srem i8 [[X]], [[Y]]
+; CHECK-NEXT:    [[R:%.*]] = and i8 [[REM]], 8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %x = or i8 %xx, -13
+  %y = and i8 %yy, 4
+  %rem = srem i8 %x, %y
+  %r = and i8 %rem, 8
+  ret i8 %r
+}
+
+define i8 @srem_high_bits_know4(i8 %xx, i8 %yy) {
+; CHECK-LABEL: @srem_high_bits_know4(
+; CHECK-NEXT:    ret i8 0
+;
+  %x = and i8 %xx, 4
+  %y = or i8 %yy, -13
+  %rem = srem i8 %x, %y
+  %r = and i8 %rem, 8
+  ret i8 %r
+}
+
+define i8 @srem_high_bits_know5(i8 %xx, i8 %yy) {
+; CHECK-LABEL: @srem_high_bits_know5(
+; CHECK-NEXT:    [[X:%.*]] = and i8 [[XX:%.*]], 2
+; CHECK-NEXT:    ret i8 [[X]]
+;
+  %x = and i8 %xx, 2
+  %y = and i8 %yy, 4
+  %rem = srem i8 %x, %y
+  %r = and i8 %rem, 2
   ret i8 %r
 }
 


### PR DESCRIPTION
There is an underlying bug in KnownBits, and we should theoretically be able to determine the high-bits of an srem as shown in the test, just like urem. In preparation to fix this bug, add pre-commit tests testing high-bits of srem and urem.