### PR TITLE
[flang][Semantics] set scope even for module subroutines outside modules

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4344,15 +4344,18 @@ bool SubprogramVisitor::BeginSubprogram(const parser::Name &name,
     Symbol::Flag subpFlag, bool hasModulePrefix,
     const parser::LanguageBindingSpec *bindingSpec,
     const ProgramTree::EntryStmtList *entryStmts) {
+  bool isValid{true};
   if (hasModulePrefix && !currScope().IsModule() &&
       !currScope().IsSubmodule()) { // C1547
     Say(name,
         "'%s' is a MODULE procedure which must be declared within a "
         "MODULE or SUBMODULE"_err_en_US);
-    return false;
+    // Don't return here because it can be useful to have the scope set for
+    // other semantic checks run before we print the errors
+    isValid = false;
   }
   Symbol *moduleInterface{nullptr};
-  if (hasModulePrefix && !inInterfaceBlock()) {
+  if (isValid && hasModulePrefix && !inInterfaceBlock()) {
     moduleInterface = FindSeparateModuleProcedureInterface(name);
     if (moduleInterface && &moduleInterface->owner() == &currScope()) {
       // Subprogram is MODULE FUNCTION or MODULE SUBROUTINE with an interface

--- a/flang/test/Semantics/OpenMP/bad_module_subroutine.f90
+++ b/flang/test/Semantics/OpenMP/bad_module_subroutine.f90
@@ -1,0 +1,6 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+! Test that we don't crash on this code inside of openmp semantics checks
+
+!ERROR: 'e' is a MODULE procedure which must be declared within a MODULE or SUBMODULE
+impure elemental module subroutine e()
+end subroutine


### PR DESCRIPTION
The missing scope information led to a crash in OpenMP semantic checks run before printing the error that was already discovered in the code.

The following block has to be skipped for this invalid code so that we don't emit a second spurious error.

Fixes #82913