### PR TITLE
[VirtRegMap] Replace a single value enum with a static constexpr member variable. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -32,7 +32,7 @@ class TargetInstrInfo;
 
   class VirtRegMap : public MachineFunctionPass {
   public:
-    static constexpr unsigned NO_STACK_SLOT = (1u << 30) - 1;
+    static constexpr int NO_STACK_SLOT = (1u << 30) - 1;
 
   private:
     MachineRegisterInfo *MRI = nullptr;

--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -32,9 +32,7 @@ class TargetInstrInfo;
 
   class VirtRegMap : public MachineFunctionPass {
   public:
-    enum {
-      NO_STACK_SLOT = (1L << 30)-1,
-    };
+    static constexpr unsigned NO_STACK_SLOT = (1u << 30) - 1;
 
   private:
     MachineRegisterInfo *MRI = nullptr;

--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -63,7 +63,7 @@ class TargetInstrInfo;
   public:
     static char ID;
 
-    static constexpr int NO_STACK_SLOT = (1u << 30) - 1;
+    static constexpr int NO_STACK_SLOT = INT_MAX;
 
     VirtRegMap() : MachineFunctionPass(ID), Virt2StackSlotMap(NO_STACK_SLOT) {}
     VirtRegMap(const VirtRegMap &) = delete;

--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -31,10 +31,6 @@ class raw_ostream;
 class TargetInstrInfo;
 
   class VirtRegMap : public MachineFunctionPass {
-  public:
-    static constexpr int NO_STACK_SLOT = (1u << 30) - 1;
-
-  private:
     MachineRegisterInfo *MRI = nullptr;
     const TargetInstrInfo *TII = nullptr;
     const TargetRegisterInfo *TRI = nullptr;
@@ -66,6 +62,8 @@ class TargetInstrInfo;
 
   public:
     static char ID;
+
+    static constexpr int NO_STACK_SLOT = (1u << 30) - 1;
 
     VirtRegMap() : MachineFunctionPass(ID), Virt2StackSlotMap(NO_STACK_SLOT) {}
     VirtRegMap(const VirtRegMap &) = delete;


### PR DESCRIPTION
Change the constant to INT_MAX instead of our own large number. Any value larger than a valid frame index should work.

I'm a bit puzzled why it was using a shift of 30. A long time ago when it was first created, the value was INT_MAX. Then it was changed in e2b77d57c0c13 to (~0 >> 1) which I guess was trying to be INT_MAX without using the constant. But ~0 is an `int` so that produced -1.

I'm not sure what the 'l' suffix was for. Unless that was an attempt to avoid undefined behavior had the shift been 31 instead of 30. But 'long' is 32 bits on some targets so that wouldn't have worked for all platforms.

Using INT_MAX is straightforward.