### PR TITLE
[IPO] NFC: avoid recalculating FunctionId hashes during ProfiledCallGraph construction

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
+++ b/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
@@ -57,25 +57,6 @@ struct ProfiledCallGraphNode {
   edges Edges;
 };
 
-class PrehashedFunctionId {
-public:
-  PrehashedFunctionId() = default;
-
-  PrehashedFunctionId(FunctionId FId) : Id(FId), Hash(hash_value(Id)) {}
-
-  uint64_t GetHash() const { return Hash; }
-
-  const FunctionId &GetId() const { return Id; }
-
-private:
-  FunctionId Id;
-  uint64_t Hash;
-};
-
-inline uint64_t hash_value(const PrehashedFunctionId &Obj) {
-  return Obj.GetHash();
-}
-
 class ProfiledCallGraph {
 public:
   using iterator = ProfiledCallGraphNode::iterator;
@@ -157,6 +138,23 @@ public:
   }
 
 private:
+  class PrehashedFunctionId {
+  public:
+    PrehashedFunctionId() = default;
+
+    PrehashedFunctionId(FunctionId FId) : Id(FId), Hash(hash_value(Id)) {}
+
+    const FunctionId &GetId() const { return Id; }
+
+    operator FunctionId() const {
+      return FunctionId{Hash};
+    }
+
+  private:
+    FunctionId Id;
+    uint64_t Hash;
+  };
+
   void addProfiledFunction(const PrehashedFunctionId &Name) {
     if (!ProfiledFunctions.count(Name)) {
       // Link to synthetic root to make sure every node is reachable

--- a/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
+++ b/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
@@ -62,15 +62,14 @@ struct PrehashedFunctionId {
 
   PrehashedFunctionId() = default;
 
-  /* implicit */ PrehashedFunctionId(FunctionId FId) : Id(FId), Hash(hash_value(Id)) {}
+  /* implicit */ PrehashedFunctionId(FunctionId FId)
+      : Id(FId), Hash(hash_value(Id)) {}
 
   FunctionId Id;
   uint64_t Hash;
 };
 
-inline uint64_t hash_value(const PrehashedFunctionId& Obj) {
-  return Obj.Hash;
-}
+inline uint64_t hash_value(const PrehashedFunctionId &Obj) { return Obj.Hash; }
 
 class ProfiledCallGraph {
 public:
@@ -158,15 +157,15 @@ private:
       // Link to synthetic root to make sure every node is reachable
       // from root. This does not affect SCC order.
       // Store the pointer of the node because the map can be rehashed.
-      auto &Node =
-          ProfiledCallGraphNodeList.emplace_back(ProfiledCallGraphNode(Name.Id));
+      auto &Node = ProfiledCallGraphNodeList.emplace_back(
+          ProfiledCallGraphNode(Name.Id));
       ProfiledFunctions[Name] = &Node;
       Root.Edges.emplace(&Root, ProfiledFunctions[Name], 0);
     }
   }
 
-  void addProfiledCall(PrehashedFunctionId CallerName, PrehashedFunctionId CalleeName,
-                       uint64_t Weight = 0) {
+  void addProfiledCall(PrehashedFunctionId CallerName,
+                       PrehashedFunctionId CalleeName, uint64_t Weight = 0) {
     assert(ProfiledFunctions.count(CallerName));
     auto CalleeIt = ProfiledFunctions.find(CalleeName);
     if (CalleeIt == ProfiledFunctions.end())
@@ -226,7 +225,7 @@ private:
   ProfiledCallGraphNode Root;
   // backing buffer for ProfiledCallGraphNodes.
   std::list<ProfiledCallGraphNode> ProfiledCallGraphNodeList;
-  HashKeyMap<llvm::DenseMap, PrehashedFunctionId, ProfiledCallGraphNode*>
+  HashKeyMap<llvm::DenseMap, PrehashedFunctionId, ProfiledCallGraphNode *>
       ProfiledFunctions;
 };
 

--- a/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
+++ b/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
@@ -150,9 +150,7 @@ private:
     // Implicit conversion for hash_value(PrehashedFunctionId) to work.
     // You are not supposed to use it directly, since it converts into
     // hash-represeting FunctionId and thus drops the Name, use `GetId` instead.
-    operator FunctionId() const {
-      return FunctionId{Hash};
-    }
+    operator FunctionId() const { return FunctionId{Hash}; }
 
   private:
     FunctionId Id;

--- a/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
+++ b/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
@@ -50,10 +50,9 @@ struct ProfiledCallGraphNode {
   using edges = std::set<edge, ProfiledCallGraphEdgeComparer>;
   using iterator = edges::iterator;
   using const_iterator = edges::const_iterator;
-  
-  ProfiledCallGraphNode(FunctionId FName = FunctionId()) : Name(FName)
-  {}
-  
+
+  ProfiledCallGraphNode(FunctionId FName = FunctionId()) : Name(FName) {}
+
   FunctionId Name;
   edges Edges;
 };
@@ -62,23 +61,20 @@ class PrehashedFunctionId {
 public:
   PrehashedFunctionId() = default;
 
-  PrehashedFunctionId(FunctionId FId)
-      : Id(FId), Hash(hash_value(Id)) {}
+  PrehashedFunctionId(FunctionId FId) : Id(FId), Hash(hash_value(Id)) {}
 
-  uint64_t GetHash() const {
-    return Hash;
-  }
+  uint64_t GetHash() const { return Hash; }
 
-  const FunctionId& GetId() const {
-    return Id;
-  }
+  const FunctionId &GetId() const { return Id; }
 
 private:
   FunctionId Id;
   uint64_t Hash;
 };
 
-inline uint64_t hash_value(const PrehashedFunctionId &Obj) { return Obj.GetHash(); }
+inline uint64_t hash_value(const PrehashedFunctionId &Obj) {
+  return Obj.GetHash();
+}
 
 class ProfiledCallGraph {
 public:
@@ -155,13 +151,13 @@ public:
   iterator begin() { return Root.Edges.begin(); }
   iterator end() { return Root.Edges.end(); }
   ProfiledCallGraphNode *getEntryNode() { return &Root; }
-  
+
   void addProfiledFunction(FunctionId Name) {
     addProfiledFunction(PrehashedFunctionId{Name});
   }
 
 private:
-  void addProfiledFunction(const PrehashedFunctionId& Name) {
+  void addProfiledFunction(const PrehashedFunctionId &Name) {
     if (!ProfiledFunctions.count(Name)) {
       // Link to synthetic root to make sure every node is reachable
       // from root. This does not affect SCC order.
@@ -173,14 +169,15 @@ private:
     }
   }
 
-  void addProfiledCall(const PrehashedFunctionId& CallerName,
-                       const PrehashedFunctionId& CalleeName, uint64_t Weight = 0) {
+  void addProfiledCall(const PrehashedFunctionId &CallerName,
+                       const PrehashedFunctionId &CalleeName,
+                       uint64_t Weight = 0) {
     assert(ProfiledFunctions.count(CallerName));
     auto CalleeIt = ProfiledFunctions.find(CalleeName);
     if (CalleeIt == ProfiledFunctions.end())
       return;
-    ProfiledCallGraphEdge Edge(ProfiledFunctions[CallerName],
-                               CalleeIt->second, Weight);
+    ProfiledCallGraphEdge Edge(ProfiledFunctions[CallerName], CalleeIt->second,
+                               Weight);
     auto &Edges = Edge.Source->Edges;
     auto [EdgeIt, Inserted] = Edges.insert(Edge);
     if (!Inserted) {

--- a/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
+++ b/llvm/include/llvm/Transforms/IPO/ProfiledCallGraph.h
@@ -138,6 +138,7 @@ public:
   }
 
 private:
+  // A helper to not recalculate FunctionId hash
   class PrehashedFunctionId {
   public:
     PrehashedFunctionId() = default;
@@ -146,6 +147,9 @@ private:
 
     const FunctionId &GetId() const { return Id; }
 
+    // Implicit conversion for hash_value(PrehashedFunctionId) to work.
+    // You are not supposed to use it directly, since it converts into
+    // hash-represeting FunctionId and thus drops the Name, use `GetId` instead.
     operator FunctionId() const {
       return FunctionId{Hash};
     }


### PR DESCRIPTION
This patch aims to reduce amount of time spent in recalculating `FunctionId` hashes (heavy md5) during `ProfiledCallGraph` construction