### PR TITLE
[libomp][AIX] Ensure only libomp.a is published on AIX

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -426,7 +426,11 @@ if(WIN32)
   endforeach()
 else()
 
-  install(TARGETS omp ${export_to_llvmexports} ${LIBOMP_INSTALL_KIND} DESTINATION "${OPENMP_INSTALL_LIBDIR}")
+  if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+    install(FILES ${LIBOMP_LIBRARY_DIR}/libomp.a DESTINATION "${OPENMP_INSTALL_LIBDIR}" COMPONENT runtime)
+  else()
+    install(TARGETS omp ${export_to_llvmexports} ${LIBOMP_INSTALL_KIND} DESTINATION "${OPENMP_INSTALL_LIBDIR}")
+  endif()
 
   if(${LIBOMP_INSTALL_ALIASES})
     # Create aliases (symlinks) of the library for backwards compatibility


### PR DESCRIPTION
For `libomp` on AIX, we build shared object `libomp.so` first and then archive it into `libomp.a`. Due to a CMake for AIX problem, the install step also tries to publish `libomp.so`. While we use a script to build `libomp.a` out-of-tree for Clang and avoided the problem, this chokes the in-tree build for Flang. The issue will be reported to CMake but before a fixed CMake is available, this patch ensures only `libomp.a` is published.