### PR TITLE
[flang] Catch untyped entities in interfaces with IMPLICIT NONE

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -8738,6 +8738,9 @@ void ResolveNamesVisitor::FinishSpecificationPart(
   CheckImports();
   for (auto &pair : currScope()) {
     auto &symbol{*pair.second};
+    if (inInterfaceBlock()) {
+      ConvertToObjectEntity(symbol);
+    }
     if (NeedsExplicitType(symbol)) {
       ApplyImplicitRules(symbol);
     }

--- a/flang/test/Semantics/implicit16.f90
+++ b/flang/test/Semantics/implicit16.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+interface
+!ERROR: No explicit type declared for 'a'
+  subroutine s(a)
+    implicit none
+  end
+!ERROR: No explicit type declared for 'f'
+  function f()
+    implicit none
+  end
+end interface
+end


### PR DESCRIPTION
The order of operations in name resolution wasn't converting named entities to objects by the time that they were subjected to the implicit typing rules in the case of interface blocks. This led to entities remaining untyped without error, leading to a crash in module file generation.

Fixes https://github.com/llvm/llvm-project/issues/108975.