### PR TITLE
Add warning message to `session save` when transcript isn't saved.

### DIFF
--- a/lldb/source/Commands/CommandObjectSession.cpp
+++ b/lldb/source/Commands/CommandObjectSession.cpp
@@ -19,7 +19,8 @@ public:
       : CommandObjectParsed(interpreter, "session save",
                             "Save the current session transcripts to a file.\n"
                             "If no file if specified, transcripts will be "
-                            "saved to a temporary file.",
+                            "saved to a temporary file.\n"
+                            "Note: transcripts will only be saved if interpreter.save-transcript is true.\n",
                             "session save [file]") {
     AddSimpleArgumentList(eArgTypePath, eArgRepeatOptional);
   }

--- a/lldb/source/Commands/CommandObjectSession.cpp
+++ b/lldb/source/Commands/CommandObjectSession.cpp
@@ -20,7 +20,8 @@ public:
                             "Save the current session transcripts to a file.\n"
                             "If no file if specified, transcripts will be "
                             "saved to a temporary file.\n"
-                            "Note: transcripts will only be saved if interpreter.save-transcript is true.\n",
+                            "Note: transcripts will only be saved if "
+                            "interpreter.save-transcript is true.\n",
                             "session save [file]") {
     AddSimpleArgumentList(eArgTypePath, eArgRepeatOptional);
   }

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3308,6 +3308,8 @@ bool CommandInterpreter::SaveTranscript(
   result.SetStatus(eReturnStatusSuccessFinishNoResult);
   result.AppendMessageWithFormat("Session's transcripts saved to %s\n",
                                  output_file->c_str());
+  if (!GetSaveTranscript())
+    result.AppendError("Note: the setting interpreter.save-transcript is set to false, so the transcript might not have been recorded.");
 
   if (GetOpenTranscriptInEditor() && Host::IsInteractiveGraphicSession()) {
     const FileSpec file_spec;

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3309,7 +3309,9 @@ bool CommandInterpreter::SaveTranscript(
   result.AppendMessageWithFormat("Session's transcripts saved to %s\n",
                                  output_file->c_str());
   if (!GetSaveTranscript())
-    result.AppendError("Note: the setting interpreter.save-transcript is set to false, so the transcript might not have been recorded.");
+    result.AppendError(
+        "Note: the setting interpreter.save-transcript is set to false, so the "
+        "transcript might not have been recorded.");
 
   if (GetOpenTranscriptInEditor() && Host::IsInteractiveGraphicSession()) {
     const FileSpec file_spec;

--- a/lldb/source/Interpreter/InterpreterProperties.td
+++ b/lldb/source/Interpreter/InterpreterProperties.td
@@ -16,7 +16,7 @@ let Definition = "interpreter" in {
   def SaveSessionOnQuit: Property<"save-session-on-quit", "Boolean">,
     Global,
     DefaultFalse,
-    Desc<"If true, LLDB will save the session's transcripts before quitting.">;
+    Desc<"If true, LLDB will save the session's transcripts before quitting. Note: transcripts will only be saved if interpreter.save-transcript is true.">;
   def OpenTranscriptInEditor: Property<"open-transcript-in-editor", "Boolean">,
     Global,
     DefaultTrue,

--- a/lldb/test/API/commands/session/save/TestSessionSave.py
+++ b/lldb/test/API/commands/session/save/TestSessionSave.py
@@ -85,6 +85,8 @@ class SessionSaveTestCase(TestBase):
         interpreter.HandleCommand("session save", res)
         self.assertTrue(res.Succeeded())
         raw += self.raw_transcript_builder(cmd, res)
+        # Also check that we don't print an error message about an empty transcript.
+        self.assertNotIn("interpreter.save-transcript is set to false", res.GetError())
 
         with open(os.path.join(td.name, os.listdir(td.name)[0]), "r") as file:
             content = file.read()
@@ -92,6 +94,33 @@ class SessionSaveTestCase(TestBase):
             lines = raw.splitlines()[:-1]
             for line in lines:
                 self.assertIn(line, content)
+
+    @no_debug_info_test
+    def test_session_save_no_transcript_warning(self):
+        interpreter = self.dbg.GetCommandInterpreter()
+
+        self.runCmd("settings set interpreter.save-transcript false")
+
+        # These commands won't be saved, so are arbitrary.
+        commands = [
+            "p 1",
+            "settings set interpreter.save-session-on-quit true",
+            "fr v",
+            "settings set interpreter.echo-comment-commands true",
+        ]
+
+        for command in commands:
+            res = lldb.SBCommandReturnObject()
+            interpreter.HandleCommand(command, res)
+
+        output_file = self.getBuildArtifact('my-session')
+
+        res = lldb.SBCommandReturnObject()
+        interpreter.HandleCommand("session save " + output_file, res)
+        self.assertTrue(res.Succeeded())
+        # We should warn about the setting being false.
+        self.assertIn("interpreter.save-transcript is set to false", res.GetError())
+        self.assertTrue(os.path.getsize(output_file) == 0, "Output file should be empty since we didn't save the transcript.")
 
     @no_debug_info_test
     def test_session_save_on_quit(self):

--- a/lldb/test/API/commands/session/save/TestSessionSave.py
+++ b/lldb/test/API/commands/session/save/TestSessionSave.py
@@ -113,14 +113,17 @@ class SessionSaveTestCase(TestBase):
             res = lldb.SBCommandReturnObject()
             interpreter.HandleCommand(command, res)
 
-        output_file = self.getBuildArtifact('my-session')
+        output_file = self.getBuildArtifact("my-session")
 
         res = lldb.SBCommandReturnObject()
         interpreter.HandleCommand("session save " + output_file, res)
         self.assertTrue(res.Succeeded())
         # We should warn about the setting being false.
         self.assertIn("interpreter.save-transcript is set to false", res.GetError())
-        self.assertTrue(os.path.getsize(output_file) == 0, "Output file should be empty since we didn't save the transcript.")
+        self.assertTrue(
+            os.path.getsize(output_file) == 0,
+            "Output file should be empty since we didn't save the transcript.",
+        )
 
     @no_debug_info_test
     def test_session_save_on_quit(self):


### PR DESCRIPTION
Somewhat recently, we made the change to hide the behavior to save LLDB session history to the transcript buffer behind the flag `interpreter.save-transcript`. By default, `interpreter.save-transcript` is false. See #90703 for context.

I'm making a small update here to our `session save` messaging and some help docs to clarify for users that aren't aware of this change. Maybe `interpreter.save-transcript` could be true by default as well. Any feedback welcome.

# Tests
```
bin/lldb-dotest -p TestSessionSave
```