### PR TITLE
[ARM] Honour -mno-movt in stack protector handling

### DIFF
--- a/llvm/lib/Target/ARM/Thumb2InstrInfo.cpp
+++ b/llvm/lib/Target/ARM/Thumb2InstrInfo.cpp
@@ -264,8 +264,11 @@ void Thumb2InstrInfo::expandLoadStackGuard(
   }
 
   const auto *GV = cast<GlobalValue>((*MI->memoperands_begin())->getValue());
-  if (MF.getSubtarget<ARMSubtarget>().isTargetELF() && !GV->isDSOLocal())
+  const ARMSubtarget &Subtarget = MF.getSubtarget<ARMSubtarget>();
+  if (Subtarget.isTargetELF() && !GV->isDSOLocal())
     expandLoadStackGuardBase(MI, ARM::t2LDRLIT_ga_pcrel, ARM::t2LDRi12);
+  else if (!Subtarget.useMovt())
+    expandLoadStackGuardBase(MI, ARM::tLDRLIT_ga_abs, ARM::t2LDRi12);
   else if (MF.getTarget().isPositionIndependent())
     expandLoadStackGuardBase(MI, ARM::t2MOV_ga_pcrel, ARM::t2LDRi12);
   else

--- a/llvm/test/CodeGen/ARM/stack-guard-nomovt.ll
+++ b/llvm/test/CodeGen/ARM/stack-guard-nomovt.ll
@@ -1,0 +1,32 @@
+; RUN: llc -relocation-model=static -mattr=+no-movt < %s | FileCheck %s
+
+target triple = "thumbv7a-linux-gnueabi"
+
+define i32 @test1() #0 {
+; CHECK-LABEL: test1:
+; CHECK:       @ %bb.0:
+; CHECK-NEXT:    push	{r7, lr}
+; CHECK-NEXT:    sub.w	sp, sp, #1032
+; CHECK-NEXT:    ldr	r0, .LCPI0_0
+; CHECK-NEXT:    ldr	r0, [r0]
+; CHECK-NEXT:    str.w	r0, [sp, #1028]
+; CHECK-NEXT:    add	r0, sp, #4
+; CHECK-NEXT:    bl	foo
+; CHECK-NEXT:    ldr.w	r0, [sp, #1028]
+; CHECK-NEXT:    ldr	r1, .LCPI0_0
+; CHECK-NEXT:    ldr	r1, [r1]
+; CHECK-NEXT:    cmp	r1, r0
+; CHECK-NEXT:    ittt	eq
+; CHECK-NEXT:    moveq	r0, #0
+; CHECK-NEXT:    addeq.w	sp, sp, #1032
+; CHECK-NEXT:    popeq	{r7, pc}
+; CHECK-NEXT:  .LBB0_1:
+; CHECK-NEXT:    bl __stack_chk_fail
+  %a1 = alloca [256 x i32], align 4
+  call void @foo(ptr %a1) #3
+  ret i32 0
+}
+
+declare void @foo(ptr)
+
+attributes #0 = { nounwind sspstrong }


### PR DESCRIPTION
When -mno-movt is passed to Clang, the ARM codegen correctly avoids movt/movw pairs to take the address of __stack_chk_guard in the stack protector code emitted into the function pro- and epilogues. However, the Thumb2 codegen fails to do so, and happily emits movw/movt pairs unless it is generating an ELF binary and the symbol might be in a different DSO. Let's incorporate a check for useMovt() in the logic here, so movt/movw are never emitted when -mno-movt is specified.

Suggestions welcome for how/where to add a test case for this.