### PR TITLE
[HLSL] update StructuredBuffer subscript test for alwaysinline

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/StructuredBuffer-subscript.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/StructuredBuffer-subscript.hlsl
@@ -11,6 +11,7 @@ void main(unsigned GI : SV_GroupIndex) {
 // Even at -O0 the subscript operators get inlined. The -O0 IR is a bit messy
 // and confusing to follow so the match here is pretty weak.
 
-// CHECK: define internal void @"?main@@YAXI@Z"
-// CHECK-NOT: call
+// CHECK: define void @main()
+// Verify inlining leaves only calls to "llvm." intrinsics
+// CHECK-NOT:   call {{[^@]*}} @{{[^l][^l][^v][^m][^\.]}}
 // CHECK: ret void


### PR DESCRIPTION
The Alwaysinline change made the mangled form of entry points get removed. The StructuredBuffer-subscript.hlsl test was introduced in the meantime depending on that version of the entry point. This revises it in the same way as RWBuffer-subscript

Follow up to #89282