### PR TITLE
[libc] improve error handling and compiler hints

### DIFF
--- a/libc/src/__support/CPP/string.h
+++ b/libc/src/__support/CPP/string.h
@@ -11,6 +11,7 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/integer_to_string.h" // IntegerToString
+#include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
 #include "src/string/memory_utils/inline_memcpy.h"
 #include "src/string/memory_utils/inline_memset.h"
@@ -133,9 +134,8 @@ public:
                               new_capacity)) {
       buffer_ = static_cast<char *>(Ptr);
       capacity_ = new_capacity;
-    } else {
-      __builtin_unreachable(); // out of memory
-    }
+    } else
+      LIBC_CHECK_UNREACHABLE();
   }
 
   LIBC_INLINE void resize(size_t size) {

--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -22,6 +22,7 @@ add_object_library(
     libc.hdr.types.struct_flock64
     libc.hdr.types.struct_f_owner_ex
     libc.hdr.types.off_t
+    libc.hdr.errno_macros
 )
 
 add_header_library(

--- a/libc/src/__support/OSUtil/linux/io.h
+++ b/libc/src/__support/OSUtil/linux/io.h
@@ -9,17 +9,68 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_LINUX_IO_H
 #define LLVM_LIBC_SRC___SUPPORT_OSUTIL_LINUX_IO_H
 
+#include "hdr/errno_macros.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/macros/config.h"
-#include "syscall.h" // For internal syscall function.
-
+#include "syscall.h"     // For internal syscall function.
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LIBC_INLINE void write_to_stderr(cpp::string_view msg) {
-  LIBC_NAMESPACE::syscall_impl<long>(SYS_write, 2 /* stderr */, msg.data(),
-                                     msg.size());
+  size_t written = 0;
+  const char *msg_data = msg.data();
+  while (written != msg.size()) {
+    auto delta = LIBC_NAMESPACE::syscall_impl<long>(SYS_write, 2 /* stderr */,
+                                                    msg_data, msg.size());
+    // If the write syscall was interrupted, try again. Otherwise, this is an
+    // error routine, we do not handle further errors.
+    if (delta == -EINTR)
+      continue;
+    if (delta < 0)
+      return;
+    written += delta;
+    msg_data += delta;
+  }
+}
+
+template <size_t N>
+LIBC_INLINE void write_all_to_stderr(const cpp::string_view (&msgs)[N]) {
+  struct IOVec {
+    const char *base;
+    size_t len;
+  } iovs[N];
+
+  size_t total_len = 0;
+  for (size_t i = 0; i < N; ++i) {
+    iovs[i].base = msgs[i].data();
+    iovs[i].len = msgs[i].size();
+    total_len += msgs[i].size();
+  }
+
+  size_t written = 0;
+  while (written != total_len) {
+    auto delta =
+        LIBC_NAMESPACE::syscall_impl<long>(SYS_writev, 2 /* stderr */, iovs, N);
+
+    // If the write syscall was interrupted, try again. Otherwise, this is an
+    // error routine, we do not handle further errors.
+    if (delta == -EINTR)
+      continue;
+    if (delta < 0)
+      return;
+
+    size_t udelta = delta;
+    written += udelta;
+    for (size_t i = 0; i < N; ++i) {
+      if (udelta == 0)
+        break;
+      auto change = udelta < iovs[i].len ? udelta : iovs[i].len;
+      udelta -= change;
+      iovs[i].base += change;
+      iovs[i].len -= change;
+    }
+  }
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/OSUtil/linux/io.h
+++ b/libc/src/__support/OSUtil/linux/io.h
@@ -49,7 +49,7 @@ LIBC_INLINE void write_all_to_stderr(const cpp::string_view (&msgs)[N]) {
   }
 
   size_t written = 0;
-  while (written != total_len) {
+  for (;;) {
     auto delta =
         LIBC_NAMESPACE::syscall_impl<long>(SYS_writev, 2 /* stderr */, iovs, N);
 
@@ -62,6 +62,10 @@ LIBC_INLINE void write_all_to_stderr(const cpp::string_view (&msgs)[N]) {
 
     auto udelta = static_cast<size_t>(delta);
     written += udelta;
+
+    if (written == total_len)
+      break;
+
     for (size_t i = 0; i < N; ++i) {
       if (udelta == 0)
         break;

--- a/libc/src/__support/OSUtil/linux/io.h
+++ b/libc/src/__support/OSUtil/linux/io.h
@@ -60,7 +60,7 @@ LIBC_INLINE void write_all_to_stderr(const cpp::string_view (&msgs)[N]) {
     if (delta < 0)
       return;
 
-    size_t udelta = delta;
+    auto udelta = static_cast<size_t>(delta);
     written += udelta;
     for (size_t i = 0; i < N; ++i) {
       if (udelta == 0)


### PR DESCRIPTION
Macros:
- `LIBC_ASSERT(COND)`: similar to `assert(COND)` but may use libc's internal
  implementation.
- `LIBC_CHECK(COND)`: similar to `LIBC_ASSERT(COND)` but will not be disabled in
  release builds.
- `LIBC_ASSUME(COND)`: `LIBC_CHECK` in debug builds, `__builtin_assume` in release.
- `LIBC_UNREACHABLE()`: similar to `__builtin_unreachable()` but checks in
  debug mode.
- `LIBC_CHECK_UNREACHABLE()`: checks in both debug and release builds.