### PR TITLE
[LLVM][TableGen] Change CodeGenMapTable to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/CodeGenMapTable.cpp
+++ b/llvm/utils/TableGen/CodeGenMapTable.cpp
@@ -77,12 +77,15 @@
 
 #include "Common/CodeGenInstruction.h"
 #include "Common/CodeGenTarget.h"
+#include "TableGenBackends.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
-using namespace llvm;
-typedef std::map<std::string, std::vector<Record *>> InstrRelMapTy;
 
-typedef std::map<std::vector<Init *>, std::vector<Record *>> RowInstrMapTy;
+using namespace llvm;
+typedef std::map<std::string, std::vector<const Record *>> InstrRelMapTy;
+typedef std::map<std::vector<const Init *>, std::vector<const Record *>>
+    RowInstrMapTy;
 
 namespace {
 
@@ -92,13 +95,13 @@ class InstrMap {
 private:
   std::string Name;
   std::string FilterClass;
-  ListInit *RowFields;
-  ListInit *ColFields;
-  ListInit *KeyCol;
-  std::vector<ListInit *> ValueCols;
+  const ListInit *RowFields;
+  const ListInit *ColFields;
+  const ListInit *KeyCol;
+  std::vector<const ListInit *> ValueCols;
 
 public:
-  InstrMap(Record *MapRec) {
+  InstrMap(const Record *MapRec) {
     Name = std::string(MapRec->getName());
 
     // FilterClass - It's used to reduce the search space only to the
@@ -133,8 +136,8 @@ public:
                                             MapRec->getName() + "' has empty " +
                                             "`ValueCols' field!");
 
-    for (Init *I : ColValList->getValues()) {
-      auto *ColI = cast<ListInit>(I);
+    for (const Init *I : ColValList->getValues()) {
+      const auto *ColI = cast<ListInit>(I);
 
       // Make sure that all the sub-lists in 'ValueCols' have same number of
       // elements as the fields in 'ColFields'.
@@ -148,18 +151,12 @@ public:
   }
 
   const std::string &getName() const { return Name; }
-
   const std::string &getFilterClass() const { return FilterClass; }
-
-  ListInit *getRowFields() const { return RowFields; }
-
-  ListInit *getColFields() const { return ColFields; }
-
-  ListInit *getKeyCol() const { return KeyCol; }
-
-  const std::vector<ListInit *> &getValueCols() const { return ValueCols; }
+  const ListInit *getRowFields() const { return RowFields; }
+  const ListInit *getColFields() const { return ColFields; }
+  const ListInit *getKeyCol() const { return KeyCol; }
+  ArrayRef<const ListInit *> getValueCols() const { return ValueCols; }
 };
-} // end anonymous namespace
 
 //===----------------------------------------------------------------------===//
 // class MapTableEmitter : It builds the instruction relation maps using
@@ -167,7 +164,6 @@ public:
 // relationship maps as tables into XXXGenInstrInfo.inc file along with the
 // functions to query them.
 
-namespace {
 class MapTableEmitter {
 private:
   //  std::string TargetName;
@@ -177,18 +173,19 @@ private:
 
   // InstrDefs - list of instructions filtered using FilterClass defined
   // in InstrMapDesc.
-  std::vector<Record *> InstrDefs;
+  ArrayRef<const Record *> InstrDefs;
 
   // RowInstrMap - maps RowFields values to the instructions. It's keyed by the
   // values of the row fields and contains vector of records as values.
   RowInstrMapTy RowInstrMap;
 
   // KeyInstrVec - list of key instructions.
-  std::vector<Record *> KeyInstrVec;
-  DenseMap<const Record *, std::vector<Record *>> MapTable;
+  std::vector<const Record *> KeyInstrVec;
+  DenseMap<const Record *, std::vector<const Record *>> MapTable;
 
 public:
-  MapTableEmitter(CodeGenTarget &Target, RecordKeeper &Records, Record *IMRec)
+  MapTableEmitter(const CodeGenTarget &Target, const RecordKeeper &Records,
+                  const Record *IMRec)
       : Target(Target), InstrMapDesc(IMRec) {
     const std::string &FilterClass = InstrMapDesc.getFilterClass();
     InstrDefs = Records.getAllDerivedDefinitions(FilterClass);
@@ -198,11 +195,12 @@ public:
 
   // Returns true if an instruction is a key instruction, i.e., its ColFields
   // have same values as KeyCol.
-  bool isKeyColInstr(Record *CurInstr);
+  bool isKeyColInstr(const Record *CurInstr);
 
   // Find column instruction corresponding to a key instruction based on the
   // constraints for that column.
-  Record *getInstrForColumn(Record *KeyInstr, ListInit *CurValueCol);
+  const Record *getInstrForColumn(const Record *KeyInstr,
+                                  const ListInit *CurValueCol);
 
   // Find column instructions for each key instruction based
   // on ValueCols and store them into MapTable.
@@ -226,17 +224,17 @@ public:
 //===----------------------------------------------------------------------===//
 
 void MapTableEmitter::buildRowInstrMap() {
-  for (Record *CurInstr : InstrDefs) {
-    std::vector<Init *> KeyValue;
-    ListInit *RowFields = InstrMapDesc.getRowFields();
-    for (Init *RowField : RowFields->getValues()) {
-      RecordVal *RecVal = CurInstr->getValue(RowField);
+  for (const Record *CurInstr : InstrDefs) {
+    std::vector<const Init *> KeyValue;
+    const ListInit *RowFields = InstrMapDesc.getRowFields();
+    for (const Init *RowField : RowFields->getValues()) {
+      const RecordVal *RecVal = CurInstr->getValue(RowField);
       if (RecVal == nullptr)
         PrintFatalError(CurInstr->getLoc(),
                         "No value " + RowField->getAsString() + " found in \"" +
                             CurInstr->getName() +
                             "\" instruction description.");
-      Init *CurInstrVal = RecVal->getValue();
+      const Init *CurInstrVal = RecVal->getValue();
       KeyValue.push_back(CurInstrVal);
     }
 
@@ -254,18 +252,19 @@ void MapTableEmitter::buildRowInstrMap() {
 // Return true if an instruction is a KeyCol instruction.
 //===----------------------------------------------------------------------===//
 
-bool MapTableEmitter::isKeyColInstr(Record *CurInstr) {
-  ListInit *ColFields = InstrMapDesc.getColFields();
-  ListInit *KeyCol = InstrMapDesc.getKeyCol();
+bool MapTableEmitter::isKeyColInstr(const Record *CurInstr) {
+  const ListInit *ColFields = InstrMapDesc.getColFields();
+  const ListInit *KeyCol = InstrMapDesc.getKeyCol();
 
   // Check if the instruction is a KeyCol instruction.
   bool MatchFound = true;
   for (unsigned j = 0, endCF = ColFields->size(); (j < endCF) && MatchFound;
        j++) {
-    RecordVal *ColFieldName = CurInstr->getValue(ColFields->getElement(j));
+    const RecordVal *ColFieldName =
+        CurInstr->getValue(ColFields->getElement(j));
     std::string CurInstrVal = ColFieldName->getValue()->getAsUnquotedString();
     std::string KeyColValue = KeyCol->getElement(j)->getAsUnquotedString();
-    MatchFound = (CurInstrVal == KeyColValue);
+    MatchFound = CurInstrVal == KeyColValue;
   }
   return MatchFound;
 }
@@ -278,15 +277,15 @@ bool MapTableEmitter::isKeyColInstr(Record *CurInstr) {
 void MapTableEmitter::buildMapTable() {
   // Find column instructions for a given key based on the ColField
   // constraints.
-  const std::vector<ListInit *> &ValueCols = InstrMapDesc.getValueCols();
+  ArrayRef<const ListInit *> ValueCols = InstrMapDesc.getValueCols();
   unsigned NumOfCols = ValueCols.size();
-  for (Record *CurKeyInstr : KeyInstrVec) {
-    std::vector<Record *> ColInstrVec(NumOfCols);
+  for (const Record *CurKeyInstr : KeyInstrVec) {
+    std::vector<const Record *> ColInstrVec(NumOfCols);
 
     // Find the column instruction based on the constraints for the column.
     for (unsigned ColIdx = 0; ColIdx < NumOfCols; ColIdx++) {
-      ListInit *CurValueCol = ValueCols[ColIdx];
-      Record *ColInstr = getInstrForColumn(CurKeyInstr, CurValueCol);
+      const ListInit *CurValueCol = ValueCols[ColIdx];
+      const Record *ColInstr = getInstrForColumn(CurKeyInstr, CurValueCol);
       ColInstrVec[ColIdx] = ColInstr;
     }
     MapTable[CurKeyInstr] = ColInstrVec;
@@ -297,14 +296,14 @@ void MapTableEmitter::buildMapTable() {
 // Find column instruction based on the constraints for that column.
 //===----------------------------------------------------------------------===//
 
-Record *MapTableEmitter::getInstrForColumn(Record *KeyInstr,
-                                           ListInit *CurValueCol) {
-  ListInit *RowFields = InstrMapDesc.getRowFields();
-  std::vector<Init *> KeyValue;
+const Record *MapTableEmitter::getInstrForColumn(const Record *KeyInstr,
+                                                 const ListInit *CurValueCol) {
+  const ListInit *RowFields = InstrMapDesc.getRowFields();
+  std::vector<const Init *> KeyValue;
 
   // Construct KeyValue using KeyInstr's values for RowFields.
-  for (Init *RowField : RowFields->getValues()) {
-    Init *KeyInstrVal = KeyInstr->getValue(RowField)->getValue();
+  for (const Init *RowField : RowFields->getValues()) {
+    const Init *KeyInstrVal = KeyInstr->getValue(RowField)->getValue();
     KeyValue.push_back(KeyInstrVal);
   }
 
@@ -312,20 +311,20 @@ Record *MapTableEmitter::getInstrForColumn(Record *KeyInstr,
   // in RowInstrMap. We search through these instructions to find a match
   // for the current column, i.e., the instruction which has the same values
   // as CurValueCol for all the fields in ColFields.
-  const std::vector<Record *> &RelatedInstrVec = RowInstrMap[KeyValue];
+  ArrayRef<const Record *> RelatedInstrVec = RowInstrMap[KeyValue];
 
-  ListInit *ColFields = InstrMapDesc.getColFields();
-  Record *MatchInstr = nullptr;
+  const ListInit *ColFields = InstrMapDesc.getColFields();
+  const Record *MatchInstr = nullptr;
 
-  for (llvm::Record *CurInstr : RelatedInstrVec) {
+  for (const Record *CurInstr : RelatedInstrVec) {
     bool MatchFound = true;
     for (unsigned j = 0, endCF = ColFields->size(); (j < endCF) && MatchFound;
          j++) {
-      Init *ColFieldJ = ColFields->getElement(j);
-      Init *CurInstrInit = CurInstr->getValue(ColFieldJ)->getValue();
+      const Init *ColFieldJ = ColFields->getElement(j);
+      const Init *CurInstrInit = CurInstr->getValue(ColFieldJ)->getValue();
       std::string CurInstrVal = CurInstrInit->getAsUnquotedString();
-      Init *ColFieldJVallue = CurValueCol->getElement(j);
-      MatchFound = (CurInstrVal == ColFieldJVallue->getAsUnquotedString());
+      const Init *ColFieldJVallue = CurValueCol->getElement(j);
+      MatchFound = CurInstrVal == ColFieldJVallue->getAsUnquotedString();
     }
 
     if (MatchFound) {
@@ -333,7 +332,7 @@ Record *MapTableEmitter::getInstrForColumn(Record *KeyInstr,
         // Already had a match
         // Error if multiple matches are found for a column.
         std::string KeyValueStr;
-        for (Init *Value : KeyValue) {
+        for (const Init *Value : KeyValue) {
           if (!KeyValueStr.empty())
             KeyValueStr += ", ";
           KeyValueStr += Value->getAsString();
@@ -357,11 +356,10 @@ Record *MapTableEmitter::getInstrForColumn(Record *KeyInstr,
 //===----------------------------------------------------------------------===//
 
 unsigned MapTableEmitter::emitBinSearchTable(raw_ostream &OS) {
-
   ArrayRef<const CodeGenInstruction *> NumberedInstructions =
       Target.getInstructionsByEnumValue();
   StringRef Namespace = Target.getInstNamespace();
-  const std::vector<ListInit *> &ValueCols = InstrMapDesc.getValueCols();
+  ArrayRef<const ListInit *> ValueCols = InstrMapDesc.getValueCols();
   unsigned NumCol = ValueCols.size();
   unsigned TotalNumInstr = NumberedInstructions.size();
   unsigned TableSize = 0;
@@ -372,7 +370,7 @@ unsigned MapTableEmitter::emitBinSearchTable(raw_ostream &OS) {
   OS << "Table[][" << NumCol + 1 << "] = {\n";
   for (unsigned i = 0; i < TotalNumInstr; i++) {
     const Record *CurInstr = NumberedInstructions[i]->TheDef;
-    std::vector<Record *> ColInstrs = MapTable[CurInstr];
+    ArrayRef<const Record *> ColInstrs = MapTable[CurInstr];
     std::string OutStr;
     unsigned RelExists = 0;
     if (!ColInstrs.empty()) {
@@ -434,8 +432,8 @@ void MapTableEmitter::emitBinSearch(raw_ostream &OS, unsigned TableSize) {
 
 void MapTableEmitter::emitMapFuncBody(raw_ostream &OS, unsigned TableSize) {
 
-  ListInit *ColFields = InstrMapDesc.getColFields();
-  const std::vector<ListInit *> &ValueCols = InstrMapDesc.getValueCols();
+  const ListInit *ColFields = InstrMapDesc.getColFields();
+  ArrayRef<const ListInit *> ValueCols = InstrMapDesc.getValueCols();
 
   // Emit binary search algorithm to locate instructions in the
   // relation table. If found, return opcode value from the appropriate column
@@ -444,7 +442,7 @@ void MapTableEmitter::emitMapFuncBody(raw_ostream &OS, unsigned TableSize) {
 
   if (ValueCols.size() > 1) {
     for (unsigned i = 0, e = ValueCols.size(); i < e; i++) {
-      ListInit *ColumnI = ValueCols[i];
+      const ListInit *ColumnI = ValueCols[i];
       OS << "  if (";
       for (unsigned j = 0, ColSize = ColumnI->size(); j < ColSize; ++j) {
         std::string ColName = ColFields->getElement(j)->getAsUnquotedString();
@@ -476,8 +474,8 @@ void MapTableEmitter::emitTablesWithFunc(raw_ostream &OS) {
   // since first column is used for the key instructions), then we also need
   // to pass another input to indicate the column to be selected.
 
-  ListInit *ColFields = InstrMapDesc.getColFields();
-  const std::vector<ListInit *> &ValueCols = InstrMapDesc.getValueCols();
+  const ListInit *ColFields = InstrMapDesc.getColFields();
+  ArrayRef<const ListInit *> ValueCols = InstrMapDesc.getValueCols();
   OS << "// " << InstrMapDesc.getName() << "\nLLVM_READONLY\n";
   OS << "int " << InstrMapDesc.getName() << "(uint16_t Opcode";
   if (ValueCols.size() > 1) {
@@ -499,23 +497,20 @@ void MapTableEmitter::emitTablesWithFunc(raw_ostream &OS) {
 // Emit enums for the column fields across all the instruction maps.
 //===----------------------------------------------------------------------===//
 
-static void emitEnums(raw_ostream &OS, RecordKeeper &Records) {
-
-  std::vector<Record *> InstrMapVec;
-  InstrMapVec = Records.getAllDerivedDefinitions("InstrMapping");
-  std::map<std::string, std::vector<Init *>> ColFieldValueMap;
+static void emitEnums(raw_ostream &OS, const RecordKeeper &Records) {
+  std::map<std::string, std::vector<const Init *>> ColFieldValueMap;
 
   // Iterate over all InstrMapping records and create a map between column
   // fields and their possible values across all records.
-  for (Record *CurMap : InstrMapVec) {
-    ListInit *ColFields;
-    ColFields = CurMap->getValueAsListInit("ColFields");
-    ListInit *List = CurMap->getValueAsListInit("ValueCols");
-    std::vector<ListInit *> ValueCols;
+  for (const Record *CurMap :
+       Records.getAllDerivedDefinitions("InstrMapping")) {
+    const ListInit *ColFields = CurMap->getValueAsListInit("ColFields");
+    const ListInit *List = CurMap->getValueAsListInit("ValueCols");
+    std::vector<const ListInit *> ValueCols;
     unsigned ListSize = List->size();
 
     for (unsigned j = 0; j < ListSize; j++) {
-      auto *ListJ = cast<ListInit>(List->getElement(j));
+      const auto *ListJ = cast<ListInit>(List->getElement(j));
 
       if (ListJ->size() != ColFields->size())
         PrintFatalError("Record `" + CurMap->getName() +
@@ -533,12 +528,10 @@ static void emitEnums(raw_ostream &OS, RecordKeeper &Records) {
     }
   }
 
-  for (auto &Entry : ColFieldValueMap) {
-    std::vector<Init *> FieldValues = Entry.second;
-
+  for (auto &[EnumName, FieldValues] : ColFieldValueMap) {
     // Delete duplicate entries from ColFieldValueMap
     for (unsigned i = 0; i < FieldValues.size() - 1; i++) {
-      Init *CurVal = FieldValues[i];
+      const Init *CurVal = FieldValues[i];
       for (unsigned j = i + 1; j < FieldValues.size(); j++) {
         if (CurVal == FieldValues[j]) {
           FieldValues.erase(FieldValues.begin() + j);
@@ -548,28 +541,24 @@ static void emitEnums(raw_ostream &OS, RecordKeeper &Records) {
     }
 
     // Emit enumerated values for the column fields.
-    OS << "enum " << Entry.first << " {\n";
-    for (unsigned i = 0, endFV = FieldValues.size(); i < endFV; i++) {
-      OS << "\t" << Entry.first << "_" << FieldValues[i]->getAsUnquotedString();
-      if (i != endFV - 1)
-        OS << ",\n";
-      else
-        OS << "\n};\n\n";
-    }
+    OS << "enum " << EnumName << " {\n";
+    ListSeparator LS(",\n");
+    for (const Init *Field : FieldValues)
+      OS << LS << "\t" << EnumName << "_" << Field->getAsUnquotedString();
+    OS << "\n};\n\n";
   }
 }
 
-namespace llvm {
 //===----------------------------------------------------------------------===//
 // Parse 'InstrMapping' records and use the information to form relationship
 // between instructions. These relations are emitted as a tables along with the
 // functions to query them.
 //===----------------------------------------------------------------------===//
-void EmitMapTable(RecordKeeper &Records, raw_ostream &OS) {
+void llvm::EmitMapTable(const RecordKeeper &Records, raw_ostream &OS) {
   CodeGenTarget Target(Records);
   StringRef NameSpace = Target.getInstNamespace();
-  std::vector<Record *> InstrMapVec;
-  InstrMapVec = Records.getAllDerivedDefinitions("InstrMapping");
+  ArrayRef<const Record *> InstrMapVec =
+      Records.getAllDerivedDefinitions("InstrMapping");
 
   if (InstrMapVec.empty())
     return;
@@ -585,7 +574,7 @@ void EmitMapTable(RecordKeeper &Records, raw_ostream &OS) {
   // Iterate over all instruction mapping records and construct relationship
   // maps based on the information specified there.
   //
-  for (Record *CurMap : InstrMapVec) {
+  for (const Record *CurMap : InstrMapVec) {
     MapTableEmitter IMap(Target, Records, CurMap);
 
     // Build RowInstrMap to group instructions based on their values for
@@ -604,5 +593,3 @@ void EmitMapTable(RecordKeeper &Records, raw_ostream &OS) {
   OS << "} // end namespace llvm\n";
   OS << "#endif // GET_INSTRMAP_INFO\n\n";
 }
-
-} // namespace llvm

--- a/llvm/utils/TableGen/TableGenBackends.h
+++ b/llvm/utils/TableGen/TableGenBackends.h
@@ -61,7 +61,7 @@ namespace llvm {
 class raw_ostream;
 class RecordKeeper;
 
-void EmitMapTable(RecordKeeper &RK, raw_ostream &OS);
+void EmitMapTable(const RecordKeeper &RK, raw_ostream &OS);
 
 // Defined in DecoderEmitter.cpp
 void EmitDecoder(RecordKeeper &RK, raw_ostream &OS,


### PR DESCRIPTION
Change CodeGenMapTable to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089