### PR TITLE
[ThinLTO] Add lookup to ImportListsTy

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -270,11 +270,18 @@ public:
   // A map from destination modules to lists of imports.
   class ImportListsTy {
   public:
-    ImportListsTy() = default;
-    ImportListsTy(size_t Size) : ListsImpl(Size) {}
+    ImportListsTy() : EmptyList(ImportIDs) {}
+    ImportListsTy(size_t Size) : EmptyList(ImportIDs), ListsImpl(Size) {}
 
     ImportMapTy &operator[](StringRef DestMod) {
       return ListsImpl.try_emplace(DestMod, ImportIDs).first->second;
+    }
+
+    const ImportMapTy &lookup(StringRef DestMod) const {
+      auto It = ListsImpl.find(DestMod);
+      if (It != ListsImpl.end())
+        return It->second;
+      return EmptyList;
     }
 
     size_t size() const { return ListsImpl.size(); }
@@ -284,6 +291,7 @@ public:
     const_iterator end() const { return ListsImpl.end(); }
 
   private:
+    ImportMapTy EmptyList;
     DenseMap<StringRef, ImportMapTy> ListsImpl;
     ImportIDTable ImportIDs;
   };


### PR DESCRIPTION
This is primarily to unblock Rust, which could potentially use
ImportListsTy::operator[] on a module that's not in ListsImpl and
cause concurrency problems.

This patch fixes a regression in the sense that it restores
ImportListsTy::lookup, which was available when ImportListsTy was just
a plain DenseMap.
