### PR TITLE
[clang-scan-deps] Don't inspect Args[0] as an option

### DIFF
--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -837,7 +837,12 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
 
           // Reverse scan, starting at the end or at the element before "--".
           auto R = std::make_reverse_iterator(FlagsEnd);
-          for (auto I = R, E = Args.rend(); I != E; ++I) {
+          auto E = Args.rend();
+          // Don't include Args[0] in the iteration; that's the executable, not
+          // an option.
+          if (E != R)
+            E--;
+          for (auto I = R; I != E; ++I) {
             StringRef Arg = *I;
             if (ClangCLMode) {
               // Ignore arguments that are preceded by "-Xclang".


### PR DESCRIPTION
Since a26ec542371652e1d774696e90016fd5b0b1c191, we expand the executable name to an absolute path, if it isn't already one, if found in path.

This broke a couple tests in some environments; when the clang workdir resides in a path under e.g. /opt. Tests that only use a tool name like "clang-cl" would get expanded to the absolute path in the build tree. The loop for finding the last "-o" like option for clang-cl command lines would inspect all arguments, including Args[0] which is the executable name itself. As an /opt path matches Arg.starts_with("/o"), this would get detected as an object file output name in cases where there was no other explicit output argument.

Thus, this fixes those tests in workdirs under e.g. /opt.