### PR TITLE
[LLVM][TableGen] Change X86MnemonicTables to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/X86MnemonicTables.cpp
+++ b/llvm/utils/TableGen/X86MnemonicTables.cpp
@@ -22,10 +22,10 @@ using namespace llvm;
 namespace {
 
 class X86MnemonicTablesEmitter {
-  CodeGenTarget Target;
+  const CodeGenTarget Target;
 
 public:
-  X86MnemonicTablesEmitter(RecordKeeper &R) : Target(R) {}
+  X86MnemonicTablesEmitter(const RecordKeeper &R) : Target(R) {}
 
   // Output X86 mnemonic tables.
   void run(raw_ostream &OS);
@@ -34,15 +34,13 @@ public:
 void X86MnemonicTablesEmitter::run(raw_ostream &OS) {
   emitSourceFileHeader("X86 Mnemonic tables", OS);
   OS << "namespace llvm {\nnamespace X86 {\n\n";
-  Record *AsmWriter = Target.getAsmWriter();
+  const Record *AsmWriter = Target.getAsmWriter();
   unsigned Variant = AsmWriter->getValueAsInt("Variant");
 
   // Hold all instructions grouped by mnemonic
   StringMap<SmallVector<const CodeGenInstruction *, 0>> MnemonicToCGInstrMap;
 
-  ArrayRef<const CodeGenInstruction *> NumberedInstructions =
-      Target.getInstructionsByEnumValue();
-  for (const CodeGenInstruction *I : NumberedInstructions) {
+  for (const CodeGenInstruction *I : Target.getInstructionsByEnumValue()) {
     const Record *Def = I->TheDef;
     // Filter non-X86 instructions.
     if (!Def->isSubClassOf("X86Inst"))


### PR DESCRIPTION
Change X86MnemonicTables to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089
