### PR TITLE
[clang] Use canonical type for substitution which might be incomplete

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -5505,8 +5505,11 @@ static TemplateDeductionResult CheckDeductionConsistency(
   Sema::ArgumentPackSubstitutionIndexRAII PackIndex(
       S, ArgIdx != -1 ? ::getPackIndexForParam(S, FTD, MLTAL, ArgIdx) : -1);
   bool IsIncompleteSubstitution = false;
-  QualType InstP = S.SubstType(P, MLTAL, FTD->getLocation(), FTD->getDeclName(),
-                               &IsIncompleteSubstitution);
+  // FIXME: A substitution can be incomplete on a non-structural part of the
+  // type. Use the canonical type for now, until the TemplateInstantiator can
+  // deal with that.
+  QualType InstP = S.SubstType(P.getCanonicalType(), MLTAL, FTD->getLocation(),
+                               FTD->getDeclName(), &IsIncompleteSubstitution);
   if (InstP.isNull() && !IsIncompleteSubstitution)
     return TemplateDeductionResult::SubstitutionFailure;
   if (!CheckConsistency)

--- a/clang/test/SemaTemplate/GH18291.cpp
+++ b/clang/test/SemaTemplate/GH18291.cpp
@@ -112,3 +112,12 @@ namespace static_vs_nonstatic {
     }
   } // namespace explicit_obj_param
 } // namespace static_vs_nonstatic
+
+namespace incomplete_on_sugar {
+  template <unsigned P, class T> void f(T[P]) = delete;
+  template <unsigned P> void f(int[][P]);
+  void test() {
+    int array[1][8];
+    f<8>(array);
+  }
+} // namespace incomplete_on_sugar


### PR DESCRIPTION
When checking deduction consistency, a substitution can be incomplete such that only sugar parts refer to non-deduced template parameters.

This would not otherwise lead to an inconsistent deduction, so this patch makes it so we canonicalize the types before substitution in order to avoid that possibility, for now.

When we are able to produce substitution failure diagnostics for partial ordering, we might want to improve the TemplateInstantiator so that it does not fail in that case.

This fixes a regression on top of #100692, which was reported on the PR. This was never released, so there are no release notes.