### PR TITLE
[NVPTX] Emit ld.v4.b16 for loading <4 x bfloat>

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -6179,6 +6179,7 @@ static void ReplaceLoadVector(SDNode *N, SelectionDAG &DAG,
   case MVT::v4i16:
   case MVT::v4i32:
   case MVT::v4f16:
+  case MVT::v4bf16:
   case MVT::v4f32:
   case MVT::v8f16:  // <4 x f16x2>
   case MVT::v8bf16: // <4 x bf16x2>

--- a/llvm/test/CodeGen/NVPTX/vector-loads.ll
+++ b/llvm/test/CodeGen/NVPTX/vector-loads.ll
@@ -198,3 +198,12 @@ define void @extv8f16_generic_a4(ptr noalias readonly align 16 %dst, ptr noalias
 
 
 !1 = !{i32 0, i32 64}
+
+; CHECK-LABEL: bf16_v4_align_load_store
+define dso_local void @bf16_v4_align_load_store(ptr noundef %0, ptr noundef %1) #0 {
+  ; CHECK: ld.v4.b16
+  ; CHECK: st.v4.b16
+  %3 = load <4 x bfloat>, ptr %1, align 8
+  store <4 x bfloat> %3, ptr %0, align 8
+  ret void
+}


### PR DESCRIPTION
This PR enables emitting a single load instruction for <4 x bfloat>, otherwise, 2 ld.b32 loads are generated.