### PR TITLE
[libc++] Only include math implementation headers from `math.h`.

### DIFF
--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -313,7 +313,6 @@ constexpr long double lerp(long double a, long double b, long double t) noexcept
 */
 
 #include <__config>
-#include <__math/hypot.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_arithmetic.h>
 #include <__type_traits/is_constant_evaluated.h>
@@ -324,7 +323,6 @@ constexpr long double lerp(long double a, long double b, long double t) noexcept
 #include <limits>
 #include <version>
 
-#include <__math/special_functions.h>
 #include <math.h>
 
 #ifndef _LIBCPP_MATH_H

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -372,6 +372,7 @@ extern "C++" {
 #    include <__math/remainder.h>
 #    include <__math/roots.h>
 #    include <__math/rounding_functions.h>
+#    include <__math/special_functions.h>
 #    include <__math/traits.h>
 #    include <__math/trigonometric_functions.h>
 #    include <__type_traits/enable_if.h>


### PR DESCRIPTION
`math.h` has logic for undefining macros that might be defined in the
C Standard Library. We need to make sure we do that prelude before
referring to any function names that might potentially be macros;
otherwise, valid user code that includes a macro-prone `<math.h>` from
the C Standard Library before including `<cmath>` (or a header that
transitively includes `<cmath>`) ends up broken.
