### PR TITLE
Add missing extendhfxf2 in compiler rt

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -104,6 +104,7 @@ set(GENERIC_SOURCES
   divti3.c
   extendsfdf2.c
   extendhfsf2.c
+  extendhfxf2.c
   ffsdi2.c
   ffssi2.c
   ffsti2.c

--- a/compiler-rt/lib/builtins/extendhfxf2.c
+++ b/compiler-rt/lib/builtins/extendhfxf2.c
@@ -1,0 +1,18 @@
+//===-- lib/extendhfxf2.c - half -> long double conversion -------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_HALF
+#define DST_DOUBLE
+#include "fp_extend_impl.inc"
+
+// Use a forwarding definition and noinline to implement a poor man's alias,
+// as there isn't a good cross-platform way of defining one.
+// Long double are expected to be as precise as double.
+COMPILER_RT_ABI NOINLINE long double __extendhfxf2(src_t a) {
+  return (long double)__extendXfYf2__(a);
+}

--- a/compiler-rt/lib/builtins/extendhfxf2.c
+++ b/compiler-rt/lib/builtins/extendhfxf2.c
@@ -1,4 +1,4 @@
-//===-- lib/extendhfxf2.c - half -> long double conversion -------------*- C -*-===//
+//===-- lib/extendhfxf2.c - half -> long double conversion --------*- C -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler-rt/lib/builtins/macho_embedded/common.txt
+++ b/compiler-rt/lib/builtins/macho_embedded/common.txt
@@ -60,6 +60,7 @@ divsf3
 divsi3
 extendsfdf2
 extendhfsf2
+extendhfxf2
 ffssi2
 fixdfsi
 fixsfsi

--- a/compiler-rt/test/builtins/Unit/extendhfxf2_test.c
+++ b/compiler-rt/test/builtins/Unit/extendhfxf2_test.c
@@ -1,0 +1,61 @@
+// RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_extendhfxf2
+
+#include <limits.h>
+#include <math.h> // for isnan, isinf
+#include <stdio.h>
+
+long double __extendhfxf2(_Float16 f);
+
+int test_extendhfxf2(_Float16 a, long double expected) {
+  long double x = __extendhfxf2(a);
+  __uint16_t *b = (void *)&a;
+  int ret = !(x == expected || (isnan(x) && isnan(expected)) ||
+              (isinf(x) && isinf(expected) && x == expected));
+  if (ret) {
+    printf("error in test__extendhfsf2(%#.4x) = %.20Lf, "
+           "expected %.20Lf\n",
+           *b, x, expected);
+  }
+  return ret;
+}
+
+char assumption_1[sizeof(_Float16) * CHAR_BIT == 16] = {0};
+
+int main() {
+  // Small positive value
+  if (test_extendhfxf2(0.09997558593750000000f, 0.09997558593750000000L))
+    return 1;
+
+  // Small negative value
+  if (test_extendhfxf2(-0.09997558593750000000f, -0.09997558593750000000L))
+    return 1;
+
+  // Zero
+  if (test_extendhfxf2(0.0f, 0.0L))
+    return 1;
+
+  // Smallest positive non-zero value
+  if (test_extendhfxf2(0x1p-16f, 0x1p-16L))
+    return 1;
+
+  // Smallest negative non-zero value
+  if (test_extendhfxf2(-0x1p-16f, -0x1p-16L))
+    return 1;
+
+  // Positive infinity
+  if (test_extendhfxf2(__builtin_huge_valf16(), __builtin_huge_valf64x()))
+    return 1;
+
+  // Negative infinity
+  if (test_extendhfxf2(-__builtin_huge_valf16(),
+                       (long double)-__builtin_huge_valf64x()))
+    return 1;
+
+  // NaN
+  if (test_extendhfxf2(__builtin_nanf16(""),
+                       (long double)__builtin_nanf64x("")))
+    return 1;
+
+  return 0;
+}

--- a/llvm/utils/gn/secondary/compiler-rt/lib/builtins/BUILD.gn
+++ b/llvm/utils/gn/secondary/compiler-rt/lib/builtins/BUILD.gn
@@ -126,6 +126,7 @@ static_library("builtins") {
     "divsi3.c",
     "divti3.c",
     "extendhfsf2.c",
+    "extendhfxf2.c"
     "extendsfdf2.c",
     "ffsdi2.c",
     "ffssi2.c",


### PR DESCRIPTION
Issue: #105181
extendhfxf2 calls extendhfXfy to convert _Float16 to double, then type casts this converted value to long double. 
__uint128_t may not be available on all architectures. Thus I din't use extendhfXfy to widen precision to 128 bits.
