### PR TITLE
[include-cleaner] Suppress all clang warnings

### DIFF
--- a/clang-tools-extra/include-cleaner/test/tool-ignores-warnings.cpp
+++ b/clang-tools-extra/include-cleaner/test/tool-ignores-warnings.cpp
@@ -1,0 +1,5 @@
+// RUN: clang-include-cleaner %s -- -Wunused 2>&1 | FileCheck --allow-empty %s
+static void foo() {}
+
+// Make sure that we don't get an unused warning
+// CHECK-NOT: unused function

--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -139,7 +139,17 @@ private:
   }
 
   void ExecuteAction() override {
-    auto &P = getCompilerInstance().getPreprocessor();
+    const auto &CI = getCompilerInstance();
+
+    // Disable all warnings when running include-cleaner, as we are only
+    // interested in include-cleaner related findings. This makes the tool both
+    // more resilient around in-development code, and possibly faster as we
+    // skip some extra analysis.
+    auto &Diags = CI.getDiagnostics();
+    Diags.setEnableAllWarnings(false);
+    Diags.setSeverityForAll(clang::diag::Flavor::WarningOrError,
+                            clang::diag::Severity::Ignored);
+    auto &P = CI.getPreprocessor();
     P.addPPCallbacks(PP.record(P));
     PI.record(getCompilerInstance());
     ASTFrontendAction::ExecuteAction();


### PR DESCRIPTION
This patch disables all clang warnings when running include-cleaner, as
users aren't interested in other findings and in-development code might
have them temporarily. This ensures tool can keep working even in
presence of such issues.
