### PR TITLE
[llvm][docs] Convert LLVM release notes to Markdown

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -213,12 +213,12 @@ Changes to the C API
 * The following functions are added to allow iterating over debug records attached to
   instructions:
 
-  * ``LLVMGetFirstDbgRecord``
-  * ``LLVMGetLastDbgRecord``
-  * ``LLVMGetNextDbgRecord``
-  * ``LLVMGetPreviousDbgRecord``
+  * `LLVMGetFirstDbgRecord`
+  * `LLVMGetLastDbgRecord`
+  * `LLVMGetNextDbgRecord`
+  * `LLVMGetPreviousDbgRecord`
 
-* Added ``LLVMAtomicRMWBinOpUSubCond`` and ``LLVMAtomicRMWBinOpUSubSat`` to ``LLVMAtomicRMWBinOp`` enum for AtomicRMW instructions.
+* Added `LLVMAtomicRMWBinOpUSubCond` and `LLVMAtomicRMWBinOpUSubSat` to `LLVMAtomicRMWBinOp` enum for AtomicRMW instructions.
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -62,12 +62,30 @@ Changes to the LLVM IR
 
 * Added `usub_cond` and `usub_sat` operations to `atomicrmw`.
 
-* Remove the following intrinsics which can be replaced with a ``bitcast``:
+* Remove the following intrinsics which can be replaced with a `bitcast`:
 
-  * ``llvm.nvvm.bitcast.f2i``
-  * ``llvm.nvvm.bitcast.i2f``
-  * ``llvm.nvvm.bitcast.d2ll``
-  * ``llvm.nvvm.bitcast.ll2d``
+  * `llvm.nvvm.bitcast.f2i`
+  * `llvm.nvvm.bitcast.i2f`
+  * `llvm.nvvm.bitcast.d2ll`
+  * `llvm.nvvm.bitcast.ll2d`
+
+* Remove the following intrinsics which can be replaced with a funnel-shift:
+
+  * `llvm.nvvm.rotate.b32`
+  * `llvm.nvvm.rotate.right.b64`
+  * `llvm.nvvm.rotate.b64`
+
+* Remove the following intrinsics which can be replaced with an
+  `addrspacecast`:
+
+  * `llvm.nvvm.ptr.gen.to.global`
+  * `llvm.nvvm.ptr.gen.to.shared`
+  * `llvm.nvvm.ptr.gen.to.constant`
+  * `llvm.nvvm.ptr.gen.to.local`
+  * `llvm.nvvm.ptr.global.to.gen`
+  * `llvm.nvvm.ptr.shared.to.gen`
+  * `llvm.nvvm.ptr.constant.to.gen`
+  * `llvm.nvvm.ptr.local.to.gen`
 
 Changes to LLVM infrastructure
 ------------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -1,60 +1,66 @@
-============================
-LLVM |release| Release Notes
-============================
+<!-- This document is written in Markdown and uses extra directives provided by
+MyST (https://myst-parser.readthedocs.io/en/latest/). -->
 
-.. contents::
-    :local:
+LLVM {{env.config.release}} Release Notes
+=========================================
 
-.. only:: PreRelease
+```{contents}
+```
 
-  .. warning::
-     These are in-progress notes for the upcoming LLVM |version| release.
-     Release notes for previous releases can be found on
-     `the Download Page <https://releases.llvm.org/download.html>`_.
-
+````{only} PreRelease
+```{warning} These are in-progress notes for the upcoming LLVM {{env.config.release}}
+             release. Release notes for previous releases can be found on
+             [the Download Page](https://releases.llvm.org/download.html).
+```
+````
 
 Introduction
 ============
 
 This document contains the release notes for the LLVM Compiler Infrastructure,
-release |release|.  Here we describe the status of LLVM, including major improvements
-from the previous release, improvements in various subprojects of LLVM, and
-some of the current users of the code.  All LLVM releases may be downloaded
-from the `LLVM releases web site <https://llvm.org/releases/>`_.
+release {{env.config.release}}.  Here we describe the status of LLVM, including
+major improvements from the previous release, improvements in various subprojects
+of LLVM, and some of the current users of the code.  All LLVM releases may be
+downloaded from the [LLVM releases web site](https://llvm.org/releases/).
 
 For more information about LLVM, including information about the latest
-release, please check out the `main LLVM web site <https://llvm.org/>`_.  If you
-have questions or comments, the `Discourse forums
-<https://discourse.llvm.org>`_ is a good place to ask
-them.
+release, please check out the [main LLVM web site](https://llvm.org/).  If you
+have questions or comments, the [Discourse forums](https://discourse.llvm.org)
+is a good place to ask them.
 
 Note that if you are reading this file from a Git checkout or the main
 LLVM web page, this document applies to the *next* release, not the current
-one.  To see the release notes for a specific release, please see the `releases
-page <https://llvm.org/releases/>`_.
+one.  To see the release notes for a specific release, please see the
+[releases page](https://llvm.org/releases/).
 
 Non-comprehensive list of changes in this release
 =================================================
-.. NOTE
-   For small 1-3 sentence descriptions, just add an entry at the end of
-   this list. If your description won't fit comfortably in one bullet
-   point (e.g. maybe you would like to give an example of the
-   functionality, or simply have a lot to talk about), see the `NOTE` below
-   for adding a new subsection.
+
+<!-- For small 1-3 sentence descriptions, just add an entry at the end of
+this list. If your description won't fit comfortably in one bullet
+point (e.g. maybe you would like to give an example of the
+functionality, or simply have a lot to talk about), see the comment below
+for adding a new subsection. -->
 
 * ...
 
-Update on required toolchains to build LLVM
--------------------------------------------
+<!-- If you would like to document a larger change, then you can add a
+subsection about it right here. You can copy the following boilerplate:
+
+Special New Feature
+-------------------
+
+Makes programs 10x faster by doing Special New Thing.
+-->
 
 Changes to the LLVM IR
 ----------------------
 
-* The ``x86_mmx`` IR type has been removed. It will be translated to
-  the standard vector type ``<1 x i64>`` in bitcode upgrade.
-* Renamed ``llvm.experimental.stepvector`` intrinsic to ``llvm.stepvector``.
+* The `x86_mmx` IR type has been removed. It will be translated to
+  the standard vector type `<1 x i64>` in bitcode upgrade.
+* Renamed `llvm.experimental.stepvector` intrinsic to `llvm.stepvector`.
 
-* Added ``usub_cond`` and ``usub_sat`` operations to ``atomicrmw``.
+* Added `usub_cond` and `usub_sat` operations to `atomicrmw`.
 
 * Remove the following intrinsics which can be replaced with a ``bitcast``:
 
@@ -85,9 +91,9 @@ Changes to the AArch64 Backend
 Changes to the AMDGPU Backend
 -----------------------------
 
-* Removed ``llvm.amdgcn.flat.atomic.fadd`` and
-  ``llvm.amdgcn.global.atomic.fadd`` intrinsics. Users should use the
-  :ref:`atomicrmw <i_atomicrmw>` instruction with `fadd` and
+* Removed `llvm.amdgcn.flat.atomic.fadd` and
+  `llvm.amdgcn.global.atomic.fadd` intrinsics. Users should use the
+  {ref}`atomicrmw <i_atomicrmw>` instruction with `fadd` and
   addrspace(0) or addrspace(1) instead.
 
 Changes to the ARM Backend
@@ -121,17 +127,17 @@ Changes to the RISC-V Backend
 * `.balign N, 0`, `.p2align N, 0`, `.align N, 0` in code sections will now fill
   the required alignment space with a sequence of `0x0` bytes (the requested
   fill value) rather than NOPs.
-* Added Syntacore SCR4 and SCR5 CPUs: ``-mcpu=syntacore-scr4/5-rv32/64``
-* ``-mcpu=sifive-p470`` was added.
-* Added Hazard3 CPU as taped out for RP2350: ``-mcpu=rp2350-hazard3`` (32-bit
+* Added Syntacore SCR4 and SCR5 CPUs: `-mcpu=syntacore-scr4/5-rv32/64`
+* `-mcpu=sifive-p470` was added.
+* Added Hazard3 CPU as taped out for RP2350: `-mcpu=rp2350-hazard3` (32-bit
   only).
 * Fixed length vector support using RVV instructions now requires VLEN>=64. This
   means Zve32x and Zve32f will also require Zvl64b. The prior support was
   largely untested.
-* The ``Zvbc32e`` and ``Zvkgs`` extensions are now supported experimentally.
-* Added ``Smctr`` and ``Ssctr`` extensions.
-* ``-mcpu=syntacore-scr7`` was added.
-* The ``Zacas`` extension is no longer marked as experimental.
+* The `Zvbc32e` and `Zvkgs` extensions are now supported experimentally.
+* Added `Smctr` and `Ssctr` extensions.
+* `-mcpu=syntacore-scr7` was added.
+* The `Zacas` extension is no longer marked as experimental.
 
 Changes to the WebAssembly Backend
 ----------------------------------
@@ -149,13 +155,13 @@ Changes to the X86 Backend
   encoding. To use optimised NOP filling in a code section, leave off the
   "fillval" argument, i.e. `.balign N`, `.p2align N` or `.align N` respectively.
 
-* Due to the removal of the ``x86_mmx`` IR type, functions with
-  ``x86_mmx`` arguments or return values will use a different,
+* Due to the removal of the `x86_mmx` IR type, functions with
+  `x86_mmx` arguments or return values will use a different,
   incompatible, calling convention ABI. Such functions are not
   generally seen in the wild (Clang never generates them!), so this is
   not expected to result in real-world compatibility problems.
 
-* Support ISA of ``AVX10.2-256`` and ``AVX10.2-512``.
+* Support ISA of `AVX10.2-256` and `AVX10.2-512`.
 
 Changes to the OCaml bindings
 -----------------------------
@@ -166,40 +172,40 @@ Changes to the Python bindings
 Changes to the C API
 --------------------
 
-* The following symbols are deleted due to the removal of the ``x86_mmx`` IR type:
+* The following symbols are deleted due to the removal of the `x86_mmx` IR type:
 
-  * ``LLVMX86_MMXTypeKind``
-  * ``LLVMX86MMXTypeInContext``
-  * ``LLVMX86MMXType``
+  * `LLVMX86_MMXTypeKind`
+  * `LLVMX86MMXTypeInContext`
+  * `LLVMX86MMXType`
 
  * The following functions are added to further support non-null-terminated strings:
 
-  * ``LLVMGetNamedFunctionWithLength``
-  * ``LLVMGetNamedGlobalWithLength``
+  * `LLVMGetNamedFunctionWithLength`
+  * `LLVMGetNamedGlobalWithLength`
 
-* The following functions are added to access the ``LLVMContextRef`` associated
-   with ``LLVMValueRef`` and ``LLVMBuilderRef`` objects:
+* The following functions are added to access the `LLVMContextRef` associated
+   with `LLVMValueRef` and `LLVMBuilderRef` objects:
 
-  * ``LLVMGetValueContext``
-  * ``LLVMGetBuilderContext``
+  * `LLVMGetValueContext`
+  * `LLVMGetBuilderContext`
 
 * The new pass manager can now be invoked with a custom alias analysis pipeline, using
-  the ``LLVMPassBuilderOptionsSetAAPipeline`` function.
+  the `LLVMPassBuilderOptionsSetAAPipeline` function.
 
 * It is now also possible to run the new pass manager on a single function, by calling
-  ``LLVMRunPassesOnFunction`` instead of ``LLVMRunPasses``.
+  `LLVMRunPassesOnFunction` instead of `LLVMRunPasses`.
 
 * Support for creating instructions with custom synchronization scopes has been added:
 
-  * ``LLVMGetSyncScopeID`` to map a synchronization scope name to an ID.
-  * ``LLVMBuildFenceSyncScope``, ``LLVMBuildAtomicRMWSyncScope`` and
-    ``LLVMBuildAtomicCmpXchgSyncScope`` versions of the existing builder functions
+  * `LLVMGetSyncScopeID` to map a synchronization scope name to an ID.
+  * `LLVMBuildFenceSyncScope`, `LLVMBuildAtomicRMWSyncScope` and
+    `LLVMBuildAtomicCmpXchgSyncScope` versions of the existing builder functions
     with an additional synchronization scope ID parameter.
-  * ``LLVMGetAtomicSyncScopeID`` and ``LLVMSetAtomicSyncScopeID`` to get and set the
+  * `LLVMGetAtomicSyncScopeID` and `LLVMSetAtomicSyncScopeID` to get and set the
     synchronization scope of any atomic instruction.
-  * ``LLVMIsAtomic`` to check if an instruction is atomic, for use with the above functions.
-    Because of backwards compatibility, ``LLVMIsAtomicSingleThread`` and
-    ``LLVMSetAtomicSingleThread`` continue to work with any instruction type.
+  * `LLVMIsAtomic` to check if an instruction is atomic, for use with the above functions.
+    Because of backwards compatibility, `LLVMIsAtomicSingleThread` and
+    `LLVMSetAtomicSingleThread` continue to work with any instruction type.
 
 * The `LLVMSetPersonalityFn` and `LLVMSetInitializer` APIs now support clearing the
   personality function and initializer respectively by passing a null pointer.
@@ -238,20 +244,20 @@ Changes to Sanitizers
 Other Changes
 -------------
 
-External Open Source Projects Using LLVM 19
-===========================================
+External Open Source Projects Using LLVM {{env.config.release}}
+===============================================================
 
 * A project...
 
 Additional Information
 ======================
 
-A wide variety of additional information is available on the `LLVM web page
-<https://llvm.org/>`_, in particular in the `documentation
-<https://llvm.org/docs/>`_ section.  The web page also contains versions of the
-API documentation which is up-to-date with the Git version of the source
-code.  You can access versions of these documents specific to this release by
-going into the ``llvm/docs/`` directory in the LLVM tree.
+A wide variety of additional information is available on the
+[LLVM web page](https://llvm.org/), in particular in the
+[documentation](https://llvm.org/docs/) section.  The web page also contains
+versions of the API documentation which is up-to-date with the Git version of
+the source code.  You can access versions of these documents specific to this
+release by going into the `llvm/docs/` directory in the LLVM tree.
 
 If you have any questions or comments about LLVM, please feel free to contact
-us via the `Discourse forums <https://discourse.llvm.org>`_.
+us via the [Discourse forums](https://discourse.llvm.org).

--- a/llvm/docs/conf.py
+++ b/llvm/docs/conf.py
@@ -39,7 +39,7 @@ except ImportError:
     if not tags.has("builder-man"):
         raise
 else:
-    myst_enable_extensions = ['substitution']
+    myst_enable_extensions = ["substitution"]
 
 # Automatic anchors for markdown titles
 myst_heading_anchors = 6

--- a/llvm/docs/conf.py
+++ b/llvm/docs/conf.py
@@ -38,6 +38,8 @@ try:
 except ImportError:
     if not tags.has("builder-man"):
         raise
+else:
+    myst_enable_extensions = ['substitution']
 
 # Automatic anchors for markdown titles
 myst_heading_anchors = 6


### PR DESCRIPTION
* Markdown is the most common format on GitHub and most contributors are more familiar with it than RST.
* This leads to mistakes in the RST syntax and/or folks just using Markdown syntax and assuming it works.
* The release notes have a high number of edits and a high number of views, we should optimise for making the common path easy. That is, adding a bullet point and a link.
* Though GitHub can render RST and Markdown, its support for Markdown is more complete (and neither handle the Sphinx directives well).
* We already have some Markdown docs in the llvm docs.

To keep the original formatting we do need some Sphinx directives still, and those are provided by MyST which is already enabled.

https://myst-parser.readthedocs.io/en/latest/

I did have to enable an extension so we can substitute in the release version.

https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#substitutions-with-jinja2

Needing to use MyST means there is some special knowledge needed if you want to do advanced things, but at least the basics remain Markdown. Even in RST form, you still had to look up Sphinx syntax.

I also make use of a nested directive
https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html#nesting-directives to implement the prerelease warning.

The note about sections referred to another note that got removed in 4c72deb613d9d8838785b431facb3eb480fb2f51. I presume accidentally, so I have restored that.

I also removed the "Update on required toolchains to build LLVM" header because the section is now empty.

The other difference is that the table of contents now has a heading "Contents". This is the default and I could not find a way to remove that name. Otherwise it's the same table as you'd get from the RST document.