### PR TITLE
[sanitizer_common] Fix GetArgsAndEnv on Linux/sparc64

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -725,6 +725,11 @@ static void GetArgsAndEnv(char ***argv, char ***envp) {
 #    if !SANITIZER_GO
   if (&__libc_stack_end) {
     uptr *stack_end = (uptr *)__libc_stack_end;
+    // Linux/sparc64 needs an adjustment, cf. glibc
+    // sysdeps/sparc/sparc{32,64}/dl-machine.h (DL_STACK_END).
+#      if SANITIZER_LINUX && defined(__sparc__)
+    stack_end = &stack_end[16];
+#      endif
     // Normally argc can be obtained from *stack_end, however, on ARM glibc's
     // _start clobbers it:
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/arm/start.S;hb=refs/heads/release/2.31/master#l75


### PR DESCRIPTION
When ASan testing is enabled on SPARC as per PR #107405, the
```
  AddressSanitizer-sparc-linux :: TestCases/Posix/print_cmdline.cpp
```
test `FAIL`s.  Either `ASAN_OPTIONS=print_cmdline=true` yielded binary garbage in the `Command:` output or just an empty string.

It turns out one needs to apply an offset to `__libc_stack_end` to get at the actual `argc`/`argv`, as described in `glibc`'s `sysdeps/sparc/sparc{32,64}/dl-machine.h` (`DL_STACK_END`).

This patch does this, fixing the test.

Tested on `sparc64-unknown-linux-gnu`.