### PR TITLE
[ASan][test] Skip Linux/odr_c_test.c on SPARC

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/odr_c_test.c
+++ b/compiler-rt/test/asan/TestCases/Linux/odr_c_test.c
@@ -10,6 +10,9 @@
 // RUN: %clang_asan -fcommon %s -fPIC -shared -mllvm -asan-use-private-alias=1 -o %dynamiclib2  -DFILE2
 // RUN: %run %t 2>&1 | count 0
 
+// Unaligned accesses don't work on strict-alignment targets like SPARC.
+// UNSUPPORTED: sparc-target-arch
+
 // CHECK: The following global variable is not properly aligned.
 // CHECK: ERROR: AddressSanitizer: odr-violation
 #if defined(FILE1)


### PR DESCRIPTION
When ASan testing is enabled on SPARC as per PR #107405, the
```
  AddressSanitizer-sparc-linux :: TestCases/Linux/odr_c_test.c

```
test `FAIL`s on Linux/sparc64:
```
+ projects/compiler-rt/test/asan/SPARCLinuxConfig/TestCases/Linux/Output/odr_c_test.c.tmp
+ count 0
Expected 0 lines, got 13.

AddressSanitizer:DEADLYSIGNAL
=================================================================
==4165420==ERROR: AddressSanitizer: BUS on unknown address (pc 0x7012d5b4 bp 0xffa3b938 sp 0xffa3b8d0 T0)
==4165420==The signal is caused by a READ memory access.
==4165420==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
```
The test relies on an unaligned access, which cannot work on a strict-alignment target like SPARC.

Thus this patch skips the test.

Tested on `sparc64-unknown-linux-gnu`.