### PR TITLE
[ASAN] Do not consider alignment during object size calculations

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -3057,9 +3057,7 @@ bool AddressSanitizer::instrumentFunction(Function &F,
                    OperandsToInstrument.size() + IntrinToInstrument.size() >
                        (unsigned)InstrumentationWithCallsThreshold);
   const DataLayout &DL = F.getDataLayout();
-  ObjectSizeOpts ObjSizeOpts;
-  ObjSizeOpts.RoundToAlign = true;
-  ObjectSizeOffsetVisitor ObjSizeVis(DL, TLI, F.getContext(), ObjSizeOpts);
+  ObjectSizeOffsetVisitor ObjSizeVis(DL, TLI, F.getContext());
 
   // Instrument.
   int NumInstrumented = 0;

--- a/llvm/test/Instrumentation/AddressSanitizer/instrument_global.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/instrument_global.ll
@@ -16,6 +16,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; indexed with constants in-bounds. But instrument all other cases.
 
 @GlobSt = global [10 x i32] zeroinitializer, align 16  ; static initializer
+@GlobStAlignInBounds = global [10 x i8] zeroinitializer, align 16  ; static initializer
 @GlobDy = global [10 x i32] zeroinitializer, align 16, sanitize_address_dyninit  ; dynamic initializer
 @GlobEx = external global [10 x i32] , align 16        ; extern initializer
 
@@ -47,6 +48,26 @@ entry:
 ; CHECK-LABEL: define i32 @AccessGlobSt_1_2
 ; CHECK: __asan_report
 ; CHECK: ret i32
+}
+
+; GlobStAlignInBount is accessed with out of bounds index, but in bounds of allocated area (because of alignemnt)
+define i8 @AccessGlobStAlignInBounds_0_11() sanitize_address {
+entry:
+    %0 = load i8, ptr getelementptr inbounds ([10 x i8], ptr @GlobStAlignInBounds, i64 0, i64 11), align 1
+    ret i8 %0
+; CHECK-LABEL: define i8 @AccessGlobStAlignInBounds_0_11
+; CHECK: __asan_report
+; CHECK: ret i8
+}
+
+; GlobStAlignInBount is accessed with in-bound index
+define i8 @AccessGlobStAlignInBounds_0_9() sanitize_address {
+entry:
+    %0 = load i8, ptr getelementptr inbounds ([10 x i8], ptr @GlobStAlignInBounds, i64 0, i64 9), align 1
+    ret i8 %0
+; CHECK-LABEL: define i8 @AccessGlobStAlignInBounds_0_9
+; CHECK-NOT: __asan_report
+; CHECK: ret i8
 }
 
 ; GlobDy is declared with dynamic initializer -- can't optimize.


### PR DESCRIPTION
It was found that ASAN logic optimizes away out-of-bound access instrumentation for over-aligned arrays. See #108287 for complete code examples.

Fix it by not considering alignment during object size calculation, since out-of-bounds access for over-aligned object is still UB and should be reported by ASAN.

Closes: #108287 