### PR TITLE
Try to parse template args in C-Style casts.

### DIFF
--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -3343,7 +3343,7 @@ AbstractManglingParser<Derived, Alloc>::parseOperatorName(NameState *State) {
   if (const auto *Op = parseOperatorEncoding()) {
     if (Op->getKind() == OperatorInfo::CCast) {
       //              ::= cv <type>    # (cast)
-      ScopedOverride<bool> SaveTemplate(TryToParseTemplateArgs, false);
+      ScopedOverride<bool> SaveTemplate(TryToParseTemplateArgs, true);
       // If we're parsing an encoding, State != nullptr and the conversion
       // operators' <type> could have a <template-param> that refers to some
       // <template-arg>s further ahead in the mangled name.


### PR DESCRIPTION
C++ABI permits to use template arguments in "cv" names representing operator of C-Style cast. 

For example `foo::operator std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>()` translates by clang mangler into `_ZN3foocvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEv` which contains template args.

Related to issue #109130 