### PR TITLE
[clang-tidy] Fix performance-unnecessary-value-param

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-crash.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-crash.cpp
@@ -1,0 +1,23 @@
+// RUN: %check_clang_tidy  -std=c++14-or-later %s performance-unnecessary-value-param %t
+
+// The test case used to crash clang-tidy.
+// https://github.com/llvm/llvm-project/issues/108963
+
+struct A
+{
+  template<typename T> A(T&&) {}
+};
+
+struct B
+{
+  ~B();
+};
+
+struct C
+{
+  A a;
+  C(B, int i) : a(i) {}
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: the parameter #1 is copied for each invocation but only used as a const reference; consider making it a const reference
+};
+
+C c(B(), 0);

--- a/clang/include/clang/Analysis/Analyses/ExprMutationAnalyzer.h
+++ b/clang/include/clang/Analysis/Analyses/ExprMutationAnalyzer.h
@@ -119,18 +119,18 @@ public:
   getFunctionParmMutationAnalyzer(const FunctionDecl &Func, ASTContext &Context,
                                   ExprMutationAnalyzer::Memoized &Memorized) {
     auto it = Memorized.FuncParmAnalyzer.find(&Func);
-    if (it == Memorized.FuncParmAnalyzer.end())
-      // We call try_emplace here, repeating a hash lookup on the same key. Note
-      // that creating a new instance of FunctionParmMutationAnalyzer below may
-      // add additional elements to FuncParmAnalyzer and invalidate iterators.
-      // That means that we cannot call try_emplace above and update the value
-      // portion (i.e. it->second) here.
+    if (it == Memorized.FuncParmAnalyzer.end()) {
+      // Creating a new instance of FunctionParmMutationAnalyzer below may add
+      // additional elements to FuncParmAnalyzer. If we did try_emplace before
+      // creating a new instance, the returned iterator of try_emplace could be
+      // invalidated.
       it =
           Memorized.FuncParmAnalyzer
               .try_emplace(&Func, std::unique_ptr<FunctionParmMutationAnalyzer>(
                                       new FunctionParmMutationAnalyzer(
                                           Func, Context, Memorized)))
               .first;
+    }
     return it->getSecond().get();
   }
 


### PR DESCRIPTION
This patch essentially reverts #108674 while adding a testcase that
triggers a crash in clang-tidy.

Fixes #108963.
