### PR TITLE
[Object][NFC] Add extern template declarations needed by llvm-objdump

### DIFF
--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -21,6 +21,7 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Object/ELFTypes.h"
 #include "llvm/Object/Error.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Error.h"
 #include <cassert>
@@ -1366,6 +1367,11 @@ inline uint32_t hashGnu(StringRef Name) {
     H = (H << 5) + H + C;
   return H;
 }
+
+extern template class LLVM_TEMPLATE_ABI llvm::object::ELFFile<ELF32LE>;
+extern template class LLVM_TEMPLATE_ABI llvm::object::ELFFile<ELF32BE>;
+extern template class LLVM_TEMPLATE_ABI llvm::object::ELFFile<ELF64LE>;
+extern template class LLVM_TEMPLATE_ABI llvm::object::ELFFile<ELF64BE>;
 
 } // end namespace object
 } // end namespace llvm

--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/XCOFF.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include <limits>
 
@@ -774,6 +775,13 @@ struct XCOFFSymbolEntry64 {
   XCOFF::StorageClass StorageClass;
   uint8_t NumberOfAuxEntries;
 };
+
+extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<XCOFFRelocation32>>
+XCOFFObjectFile::relocations<XCOFFSectionHeader32, XCOFFRelocation32>(
+    const XCOFFSectionHeader32 &Sec) const;
+extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<XCOFFRelocation64>>
+XCOFFObjectFile::relocations<XCOFFSectionHeader64, XCOFFRelocation64>(
+    const XCOFFSectionHeader64 &Sec) const;
 
 class XCOFFSymbolRef : public SymbolRef {
 public:

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -9,6 +9,7 @@
 #include "llvm/Object/ELF.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 
 using namespace llvm;
@@ -980,7 +981,7 @@ ELFFile<ELFT>::getSectionAndRelocations(
   return SecToRelocMap;
 }
 
-template class llvm::object::ELFFile<ELF32LE>;
-template class llvm::object::ELFFile<ELF32BE>;
-template class llvm::object::ELFFile<ELF64LE>;
-template class llvm::object::ELFFile<ELF64BE>;
+template class LLVM_EXPORT_TEMPLATE llvm::object::ELFFile<ELF32LE>;
+template class LLVM_EXPORT_TEMPLATE llvm::object::ELFFile<ELF32BE>;
+template class LLVM_EXPORT_TEMPLATE llvm::object::ELFFile<ELF64LE>;
+template class LLVM_EXPORT_TEMPLATE llvm::object::ELFFile<ELF64BE>;

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/Object/XCOFFObjectFile.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/TargetParser/SubtargetFeature.h"
 #include <cstddef>
@@ -1060,9 +1061,9 @@ Expected<ArrayRef<ExceptEnt>> XCOFFObjectFile::getExceptionEntries() const {
       ExceptEntStart, ExceptEntStart + getSectionSize(DRI) / sizeof(ExceptEnt));
 }
 
-template Expected<ArrayRef<ExceptionSectionEntry32>>
+template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<ExceptionSectionEntry32>>
 XCOFFObjectFile::getExceptionEntries() const;
-template Expected<ArrayRef<ExceptionSectionEntry64>>
+template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<ExceptionSectionEntry64>>
 XCOFFObjectFile::getExceptionEntries() const;
 
 Expected<XCOFFStringTable>
@@ -1376,14 +1377,16 @@ template struct XCOFFSectionHeader<XCOFFSectionHeader64>;
 template struct XCOFFRelocation<llvm::support::ubig32_t>;
 template struct XCOFFRelocation<llvm::support::ubig64_t>;
 
-template llvm::Expected<llvm::ArrayRef<llvm::object::XCOFFRelocation64>>
-llvm::object::XCOFFObjectFile::relocations<llvm::object::XCOFFSectionHeader64,
-                                           llvm::object::XCOFFRelocation64>(
-    llvm::object::XCOFFSectionHeader64 const &) const;
-template llvm::Expected<llvm::ArrayRef<llvm::object::XCOFFRelocation32>>
-llvm::object::XCOFFObjectFile::relocations<llvm::object::XCOFFSectionHeader32,
-                                           llvm::object::XCOFFRelocation32>(
-    llvm::object::XCOFFSectionHeader32 const &) const;
+template LLVM_EXPORT_TEMPLATE
+    llvm::Expected<llvm::ArrayRef<llvm::object::XCOFFRelocation64>>
+    llvm::object::XCOFFObjectFile::relocations<
+        llvm::object::XCOFFSectionHeader64, llvm::object::XCOFFRelocation64>(
+        llvm::object::XCOFFSectionHeader64 const &) const;
+template LLVM_EXPORT_TEMPLATE
+    llvm::Expected<llvm::ArrayRef<llvm::object::XCOFFRelocation32>>
+    llvm::object::XCOFFObjectFile::relocations<
+        llvm::object::XCOFFSectionHeader32, llvm::object::XCOFFRelocation32>(
+        llvm::object::XCOFFSectionHeader32 const &) const;
 
 bool doesXCOFFTracebackTableBegin(ArrayRef<uint8_t> Bytes) {
   if (Bytes.size() < 4)


### PR DESCRIPTION
These symbols are implicitly imported from the LLVM shared library by llvm-objdump on ELF like platforms, but for windows they need to be explicitly exported when LLVM is built as shared library.
I also add visibility macros for XCOFFObjectFile::getExceptionEntries that can't automatically be added by clang tooling since it doesn't store the source locations for explicit function template instantiations.