### PR TITLE
[clang][flang] Support -time in both clang and flang

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5896,6 +5896,7 @@ def print_enabled_extensions : Flag<["-", "--"], "print-enabled-extensions">,
 def : Flag<["-"], "mcpu=help">, Alias<print_supported_cpus>;
 def : Flag<["-"], "mtune=help">, Alias<print_supported_cpus>;
 def time : Flag<["-"], "time">,
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   HelpText<"Time individual commands">;
 def traditional_cpp : Flag<["-", "--"], "traditional-cpp">,
   Visibility<[ClangOption, CC1Option]>,

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -21,6 +21,9 @@
 #include "llvm/Option/OptSpecifier.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cassert>
@@ -194,11 +197,29 @@ int Compilation::ExecuteCommand(const Command &C,
   if (LogOnly)
     return 0;
 
+  // We don't use any timers or llvm::TimeGroup's because those are tied into
+  // the global static timer list which, in principle, could be cleared without
+  // us knowing about it.
+  llvm::TimeRecord StartTime;
+  if (getArgs().hasArg(options::OPT_time)) {
+    StartTime = llvm::TimeRecord::getCurrentTime(true);
+  }
+
   std::string Error;
   bool ExecutionFailed;
   int Res = C.Execute(Redirects, &Error, &ExecutionFailed);
   if (PostCallback)
     PostCallback(C, Res);
+
+  if (getArgs().hasArg(options::OPT_time)) {
+    llvm::TimeRecord Time = llvm::TimeRecord::getCurrentTime(false);
+    Time -= StartTime;
+    llvm::StringRef Name = llvm::sys::path::filename(C.getExecutable());
+    llvm::errs() << "# " << Name << " "
+                 << llvm::format("%0.5f", Time.getUserTime()) << " "
+                 << llvm::format("%0.5f", Time.getSystemTime()) << "\n";
+  }
+
   if (!Error.empty()) {
     assert(Res && "Error string set with 0 result code!");
     getDriver().Diag(diag::err_drv_command_failure) << Error;

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -202,7 +202,7 @@ int Compilation::ExecuteCommand(const Command &C,
   // us knowing about it.
   llvm::TimeRecord StartTime;
   if (getArgs().hasArg(options::OPT_time)) {
-    StartTime = llvm::TimeRecord::getCurrentTime(true);
+    StartTime = llvm::TimeRecord::getCurrentTime(/*Start=*/true);
   }
 
   std::string Error;
@@ -212,7 +212,7 @@ int Compilation::ExecuteCommand(const Command &C,
     PostCallback(C, Res);
 
   if (getArgs().hasArg(options::OPT_time)) {
-    llvm::TimeRecord Time = llvm::TimeRecord::getCurrentTime(false);
+    llvm::TimeRecord Time = llvm::TimeRecord::getCurrentTime(/*Start=*/false);
     Time -= StartTime;
     llvm::StringRef Name = llvm::sys::path::filename(C.getExecutable());
     llvm::errs() << "# " << Name << " "

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -201,9 +201,8 @@ int Compilation::ExecuteCommand(const Command &C,
   // the global static timer list which, in principle, could be cleared without
   // us knowing about it.
   llvm::TimeRecord StartTime;
-  if (getArgs().hasArg(options::OPT_time)) {
+  if (getArgs().hasArg(options::OPT_time))
     StartTime = llvm::TimeRecord::getCurrentTime(/*Start=*/true);
-  }
 
   std::string Error;
   bool ExecutionFailed;
@@ -216,8 +215,8 @@ int Compilation::ExecuteCommand(const Command &C,
     Time -= StartTime;
     llvm::StringRef Name = llvm::sys::path::filename(C.getExecutable());
     llvm::errs() << "# " << Name << " "
-                 << llvm::format("%0.5f", Time.getUserTime()) << " "
-                 << llvm::format("%0.5f", Time.getSystemTime()) << "\n";
+                 << llvm::format("%0.2f", Time.getUserTime()) << " "
+                 << llvm::format("%0.2f", Time.getSystemTime()) << "\n";
   }
 
   if (!Error.empty()) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1315,6 +1315,9 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   // Ignore -pipe.
   Args.ClaimAllArgs(options::OPT_pipe);
 
+  // Ignore -time.
+  Args.ClaimAllArgs(options::OPT_time);
+
   // Extract -ccc args.
   //
   // FIXME: We need to figure out where this behavior should live. Most of it

--- a/clang/test/Driver/time.c
+++ b/clang/test/Driver/time.c
@@ -5,13 +5,21 @@
 // could be something different, just check that whatever is printed to stderr
 // looks like timing information.
 
-// RUN: %clang -time -c -o /dev/null %s 2>&1 \
+// Ideally, this should be tested on various platforms, but that requires the
+// the full toolchain, including a linker to be present. The initial author of
+// the test only had access to Linux on x86 which is why this is only enabled
+// there. More platforms ought to be added if possible.
+
+// REQUIRES: x86-registered-target
+// REQUIRES: x86_64-linux
+
+// RUN: %clang --target=x86_64-pc-linux -time -c -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-// RUN: %clang -time -S -emit-llvm -o /dev/null %s 2>&1 \
+// RUN: %clang --target=x86_64-pc-linux -time -S -emit-llvm -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-// RUN: %clang -time -S -o /dev/null %s 2>&1 \
+// RUN: %clang --target=x86_64-pc-linux -time -S -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-// RUN: %clang -time -o /dev/null %s 2>&1 \
+// RUN: %clang --target=x86_64-pc-linux -time -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-AND-LINK
 
 // COMPILE-ONLY: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}

--- a/clang/test/Driver/time.c
+++ b/clang/test/Driver/time.c
@@ -1,0 +1,24 @@
+// The -time option prints timing information for the various subcommands in a
+// format similar to that used by gcc. When compiling and linking, this will
+// include the time to call clang-${LLVM_VERSION_MAJOR} and the linker. Since
+// the name of the linker could vary across platforms, and name of the compiler
+// could be something different, just check that whatever is printed to stderr
+// looks like timing information.
+
+// RUN: %clang -time -c -O3 -o /dev/null %s 2>&1 \
+// RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
+// RUN: %clang -time -S -emit-llvm -O3 -o /dev/null %s 2>&1 \
+// RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
+// RUN: %clang -time -S -O3 -o /dev/null %s 2>&1 \
+// RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
+// RUN: %clang -time -O3 -o /dev/null %s 2>&1 \
+// RUN:     | FileCheck %s --check-prefix=COMPILE-AND-LINK
+
+// COMPILE-ONLY: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+
+// COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+// COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+
+int main() {
+  return 0;
+}

--- a/clang/test/Driver/time.c
+++ b/clang/test/Driver/time.c
@@ -5,16 +5,17 @@
 // could be something different, just check that whatever is printed to stderr
 // looks like timing information.
 
-// RUN: %clang -time -c -O3 -o /dev/null %s 2>&1 \
+// RUN: %clang -time -c -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-// RUN: %clang -time -S -emit-llvm -O3 -o /dev/null %s 2>&1 \
+// RUN: %clang -time -S -emit-llvm -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-// RUN: %clang -time -S -O3 -o /dev/null %s 2>&1 \
+// RUN: %clang -time -S -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-// RUN: %clang -time -O3 -o /dev/null %s 2>&1 \
+// RUN: %clang -time -o /dev/null %s 2>&1 \
 // RUN:     | FileCheck %s --check-prefix=COMPILE-AND-LINK
 
 // COMPILE-ONLY: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+// COMPILE-ONLY-NOT: {{.}}
 
 // COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
 // COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}

--- a/flang/test/Driver/time.f90
+++ b/flang/test/Driver/time.f90
@@ -1,0 +1,22 @@
+! The -time option prints timing information for the various subcommands in a
+! format similar to that used by gfortran. When compiling and linking, this will
+! include the time to call flang-${LLVM_VERSION_MAJOR} and the linker. Since the
+! name of the linker could vary across platforms, and the flang name could also
+! potentially be something different, just check that whatever is printed to
+! stderr looks like timing information.
+
+! RUN: %flang -time -c -O3 -o /dev/null %s 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
+! RUN: %flang -time -S -emit-llvm -O3 -o /dev/null %s 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
+! RUN: %flang -time -S -O3 -o /dev/null %s 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
+! RUN: %flang -time -O3 -o /dev/null %s 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=COMPILE-AND-LINK
+
+! COMPILE-ONLY: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+
+! COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+! COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+
+end program

--- a/flang/test/Driver/time.f90
+++ b/flang/test/Driver/time.f90
@@ -11,16 +11,17 @@
 ! potentially be something different, just check that whatever is printed to
 ! stderr looks like timing information.
 
-! RUN: %flang -time -c -O3 -o /dev/null %s 2>&1 \
+! RUN: %flang -time -c -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
 ! RUN: %flang -time -S -emit-llvm -O3 -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-! RUN: %flang -time -S -O3 -o /dev/null %s 2>&1 \
+! RUN: %flang -time -S -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-! RUN: %flang -time -O3 -o /dev/null %s 2>&1 \
+! RUN: %flang -time -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-AND-LINK
 
 ! COMPILE-ONLY: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
+! COMPILE-ONLY-NOT: {{.}}
 
 ! COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}
 ! COMPILE-AND-LINK: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}

--- a/flang/test/Driver/time.f90
+++ b/flang/test/Driver/time.f90
@@ -1,3 +1,9 @@
+! TODO: For some reason, on Windows, nothing is printed to stderr which causes
+! the checks to fail. It is not clear why this is, so disable this on Windows
+! until the root cause can be determined.
+!
+! UNSUPPORTED: system-windows
+
 ! The -time option prints timing information for the various subcommands in a
 ! format similar to that used by gfortran. When compiling and linking, this will
 ! include the time to call flang-${LLVM_VERSION_MAJOR} and the linker. Since the

--- a/flang/test/Driver/time.f90
+++ b/flang/test/Driver/time.f90
@@ -11,13 +11,20 @@
 ! potentially be something different, just check that whatever is printed to
 ! stderr looks like timing information.
 
-! RUN: %flang -time -c -o /dev/null %s 2>&1 \
+! Ideally, this should be tested on various platforms, but that requires the
+! the full toolchain, including a linker to be present. The initial author of
+! the test only had access to Linux on x86 which is why this is only enabled
+! there. More platforms ought to be added if possible.
+
+! REQUIRES: x86_64-linux
+
+! RUN: %flang --target=x86_64-linux -time -c -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-! RUN: %flang -time -S -emit-llvm -O3 -o /dev/null %s 2>&1 \
+! RUN: %flang --target=x86_64-linux -time -S -emit-llvm -O3 -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-! RUN: %flang -time -S -o /dev/null %s 2>&1 \
+! RUN: %flang --target=x86_64-linux -time -S -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-ONLY
-! RUN: %flang -time -o /dev/null %s 2>&1 \
+! RUN: %flang --target=x86_64-linux -time -o /dev/null %s 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=COMPILE-AND-LINK
 
 ! COMPILE-ONLY: # {{.+}} {{[0-9]+(.[0-9]+)?}} {{[0-9]+(.[0-9]+)?}}


### PR DESCRIPTION
The -time option prints timing information for the subcommands (compiler, linker) in a format similar to that used by gcc/gfortran (we use more digits of precision).

This partially addresses requests from #89888