### PR TITLE
[NFC] Rename variables to conform to LLVM coding standards

### DIFF
--- a/llvm/utils/TableGen/Common/DAGISelMatcher.cpp
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.cpp
@@ -17,12 +17,12 @@ using namespace llvm;
 
 void Matcher::anchor() {}
 
-void Matcher::dump() const { print(errs(), 0); }
+void Matcher::dump() const { print(errs()); }
 
-void Matcher::print(raw_ostream &OS, unsigned indent) const {
-  printImpl(OS, indent);
+void Matcher::print(raw_ostream &OS, unsigned Indent) const {
+  printImpl(OS, Indent);
   if (Next)
-    return Next->print(OS, indent);
+    return Next->print(OS, Indent);
 }
 
 void Matcher::printOne(raw_ostream &OS) const { printImpl(OS, 0); }
@@ -111,156 +111,156 @@ unsigned CheckPredicateMatcher::getOperandNo(unsigned i) const {
 
 // printImpl methods.
 
-void ScopeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "Scope\n";
+void ScopeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "Scope\n";
   for (const Matcher *C : Children) {
     if (!C)
-      OS.indent(indent + 1) << "NULL POINTER\n";
+      OS.indent(Indent + 1) << "NULL POINTER\n";
     else
-      C->print(OS, indent + 2);
+      C->print(OS, Indent + 2);
   }
 }
 
-void RecordMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "Record\n";
+void RecordMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "Record\n";
 }
 
-void RecordChildMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "RecordChild: " << ChildNo << '\n';
+void RecordChildMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "RecordChild: " << ChildNo << '\n';
 }
 
-void RecordMemRefMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "RecordMemRef\n";
+void RecordMemRefMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "RecordMemRef\n";
 }
 
 void CaptureGlueInputMatcher::printImpl(raw_ostream &OS,
-                                        unsigned indent) const {
-  OS.indent(indent) << "CaptureGlueInput\n";
+                                        unsigned Indent) const {
+  OS.indent(Indent) << "CaptureGlueInput\n";
 }
 
-void MoveChildMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "MoveChild " << ChildNo << '\n';
+void MoveChildMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "MoveChild " << ChildNo << '\n';
 }
 
 void MoveSiblingMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
   OS.indent(Indent) << "MoveSibling " << SiblingNo << '\n';
 }
 
-void MoveParentMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "MoveParent\n";
+void MoveParentMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "MoveParent\n";
 }
 
-void CheckSameMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckSame " << MatchNumber << '\n';
+void CheckSameMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckSame " << MatchNumber << '\n';
 }
 
-void CheckChildSameMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckChild" << ChildNo << "Same\n";
+void CheckChildSameMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckChild" << ChildNo << "Same\n";
 }
 
 void CheckPatternPredicateMatcher::printImpl(raw_ostream &OS,
-                                             unsigned indent) const {
-  OS.indent(indent) << "CheckPatternPredicate " << Predicate << '\n';
+                                             unsigned Indent) const {
+  OS.indent(Indent) << "CheckPatternPredicate " << Predicate << '\n';
 }
 
-void CheckPredicateMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckPredicate " << getPredicate().getFnName() << '\n';
+void CheckPredicateMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckPredicate " << getPredicate().getFnName() << '\n';
 }
 
-void CheckOpcodeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckOpcode " << Opcode.getEnumName() << '\n';
+void CheckOpcodeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckOpcode " << Opcode.getEnumName() << '\n';
 }
 
-void SwitchOpcodeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "SwitchOpcode: {\n";
+void SwitchOpcodeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "SwitchOpcode: {\n";
   for (const auto &C : Cases) {
-    OS.indent(indent) << "case " << C.first->getEnumName() << ":\n";
-    C.second->print(OS, indent + 2);
+    OS.indent(Indent) << "case " << C.first->getEnumName() << ":\n";
+    C.second->print(OS, Indent + 2);
   }
-  OS.indent(indent) << "}\n";
+  OS.indent(Indent) << "}\n";
 }
 
-void CheckTypeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckType " << getEnumName(Type) << ", ResNo=" << ResNo
+void CheckTypeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckType " << getEnumName(Type) << ", ResNo=" << ResNo
                     << '\n';
 }
 
-void SwitchTypeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "SwitchType: {\n";
+void SwitchTypeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "SwitchType: {\n";
   for (const auto &C : Cases) {
-    OS.indent(indent) << "case " << getEnumName(C.first) << ":\n";
-    C.second->print(OS, indent + 2);
+    OS.indent(Indent) << "case " << getEnumName(C.first) << ":\n";
+    C.second->print(OS, Indent + 2);
   }
-  OS.indent(indent) << "}\n";
+  OS.indent(Indent) << "}\n";
 }
 
-void CheckChildTypeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckChildType " << ChildNo << " " << getEnumName(Type)
+void CheckChildTypeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckChildType " << ChildNo << " " << getEnumName(Type)
                     << '\n';
 }
 
-void CheckIntegerMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckInteger " << Value << '\n';
+void CheckIntegerMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckInteger " << Value << '\n';
 }
 
 void CheckChildIntegerMatcher::printImpl(raw_ostream &OS,
-                                         unsigned indent) const {
-  OS.indent(indent) << "CheckChildInteger " << ChildNo << " " << Value << '\n';
+                                         unsigned Indent) const {
+  OS.indent(Indent) << "CheckChildInteger " << ChildNo << " " << Value << '\n';
 }
 
-void CheckCondCodeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckCondCode ISD::" << CondCodeName << '\n';
+void CheckCondCodeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckCondCode ISD::" << CondCodeName << '\n';
 }
 
 void CheckChild2CondCodeMatcher::printImpl(raw_ostream &OS,
-                                           unsigned indent) const {
-  OS.indent(indent) << "CheckChild2CondCode ISD::" << CondCodeName << '\n';
+                                           unsigned Indent) const {
+  OS.indent(Indent) << "CheckChild2CondCode ISD::" << CondCodeName << '\n';
 }
 
-void CheckValueTypeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckValueType " << getEnumName(VT) << '\n';
+void CheckValueTypeMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckValueType " << getEnumName(VT) << '\n';
 }
 
-void CheckComplexPatMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckComplexPat " << Pattern.getSelectFunc() << '\n';
+void CheckComplexPatMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckComplexPat " << Pattern.getSelectFunc() << '\n';
 }
 
-void CheckAndImmMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckAndImm " << Value << '\n';
+void CheckAndImmMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckAndImm " << Value << '\n';
 }
 
-void CheckOrImmMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckOrImm " << Value << '\n';
+void CheckOrImmMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CheckOrImm " << Value << '\n';
 }
 
 void CheckFoldableChainNodeMatcher::printImpl(raw_ostream &OS,
-                                              unsigned indent) const {
-  OS.indent(indent) << "CheckFoldableChainNode\n";
+                                              unsigned Indent) const {
+  OS.indent(Indent) << "CheckFoldableChainNode\n";
 }
 
 void CheckImmAllOnesVMatcher::printImpl(raw_ostream &OS,
-                                        unsigned indent) const {
-  OS.indent(indent) << "CheckAllOnesV\n";
+                                        unsigned Indent) const {
+  OS.indent(Indent) << "CheckAllOnesV\n";
 }
 
 void CheckImmAllZerosVMatcher::printImpl(raw_ostream &OS,
-                                         unsigned indent) const {
-  OS.indent(indent) << "CheckAllZerosV\n";
+                                         unsigned Indent) const {
+  OS.indent(Indent) << "CheckAllZerosV\n";
 }
 
-void EmitIntegerMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "EmitInteger " << Val << " VT=" << getEnumName(VT)
+void EmitIntegerMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "EmitInteger " << Val << " VT=" << getEnumName(VT)
                     << '\n';
 }
 
 void EmitStringIntegerMatcher::printImpl(raw_ostream &OS,
-                                         unsigned indent) const {
-  OS.indent(indent) << "EmitStringInteger " << Val << " VT=" << getEnumName(VT)
+                                         unsigned Indent) const {
+  OS.indent(Indent) << "EmitStringInteger " << Val << " VT=" << getEnumName(VT)
                     << '\n';
 }
 
-void EmitRegisterMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "EmitRegister ";
+void EmitRegisterMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "EmitRegister ";
   if (Reg)
     OS << Reg->getName();
   else
@@ -269,26 +269,26 @@ void EmitRegisterMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
 }
 
 void EmitConvertToTargetMatcher::printImpl(raw_ostream &OS,
-                                           unsigned indent) const {
-  OS.indent(indent) << "EmitConvertToTarget " << Slot << '\n';
+                                           unsigned Indent) const {
+  OS.indent(Indent) << "EmitConvertToTarget " << Slot << '\n';
 }
 
 void EmitMergeInputChainsMatcher::printImpl(raw_ostream &OS,
-                                            unsigned indent) const {
-  OS.indent(indent) << "EmitMergeInputChains <todo: args>\n";
+                                            unsigned Indent) const {
+  OS.indent(Indent) << "EmitMergeInputChains <todo: args>\n";
 }
 
-void EmitCopyToRegMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "EmitCopyToReg <todo: args>\n";
+void EmitCopyToRegMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "EmitCopyToReg <todo: args>\n";
 }
 
-void EmitNodeXFormMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "EmitNodeXForm " << NodeXForm->getName()
+void EmitNodeXFormMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "EmitNodeXForm " << NodeXForm->getName()
                     << " Slot=" << Slot << '\n';
 }
 
-void EmitNodeMatcherCommon::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent);
+void EmitNodeMatcherCommon::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent);
   OS << (isa<MorphNodeToMatcher>(this) ? "MorphNodeTo: " : "EmitNode: ")
      << CGI.Namespace << "::" << CGI.TheDef->getName() << ": <todo flags> ";
 
@@ -300,10 +300,10 @@ void EmitNodeMatcherCommon::printImpl(raw_ostream &OS, unsigned indent) const {
   OS << ")\n";
 }
 
-void CompleteMatchMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CompleteMatch <todo args>\n";
-  OS.indent(indent) << "Src = " << Pattern.getSrcPattern() << "\n";
-  OS.indent(indent) << "Dst = " << Pattern.getDstPattern() << "\n";
+void CompleteMatchMatcher::printImpl(raw_ostream &OS, unsigned Indent) const {
+  OS.indent(Indent) << "CompleteMatch <todo args>\n";
+  OS.indent(Indent) << "Src = " << Pattern.getSrcPattern() << "\n";
+  OS.indent(Indent) << "Dst = " << Pattern.getDstPattern() << "\n";
 }
 
 bool CheckOpcodeMatcher::isEqualImpl(const Matcher *M) const {

--- a/llvm/utils/TableGen/Common/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.h
@@ -370,7 +370,7 @@ public:
   static bool classof(const Matcher *N) { return N->getKind() == MoveParent; }
 
 private:
-  void printImpl(raw_ostream &OS, unsigned indent) const override;
+  void printImpl(raw_ostream &OS, unsigned Indent) const override;
   bool isEqualImpl(const Matcher *M) const override { return true; }
 };
 
@@ -389,7 +389,7 @@ public:
   static bool classof(const Matcher *N) { return N->getKind() == CheckSame; }
 
 private:
-  void printImpl(raw_ostream &OS, unsigned indent) const override;
+  void printImpl(raw_ostream &OS, unsigned Indent) const override;
   bool isEqualImpl(const Matcher *M) const override {
     return cast<CheckSameMatcher>(M)->getMatchNumber() == getMatchNumber();
   }
@@ -414,7 +414,7 @@ public:
   }
 
 private:
-  void printImpl(raw_ostream &OS, unsigned indent) const override;
+  void printImpl(raw_ostream &OS, unsigned Indent) const override;
   bool isEqualImpl(const Matcher *M) const override {
     return cast<CheckChildSameMatcher>(M)->ChildNo == ChildNo &&
            cast<CheckChildSameMatcher>(M)->MatchNumber == MatchNumber;


### PR DESCRIPTION
Rename `indent` to `Indent` and `o` to `OS`.
Rename `Indentation` to `Indent`.
Remove unused argument from `emitPredicateMatch`.
Change `Indent` argument to `emitBinaryParser` to by value.
