### PR TITLE
[OpenMP] Fix not linking C libraries when enabled

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -182,7 +182,12 @@ def remove_suffix_if_present(name):
         return name
 
 def add_libraries(source):
-    return source + " " + config.llvm_library_intdir + "/libomptarget.devicertl.a"
+    if config.libomptarget_has_libc:
+        return source + " -Xoffload-linker " + "-lc " + \
+               "-Xoffload-linker " + "-lm " + \
+               config.llvm_library_intdir + "/libomptarget.devicertl.a"
+    else:
+        return source + " " + config.llvm_library_intdir + "/libomptarget.devicertl.a"
 
 # Add platform targets
 host_targets = [


### PR DESCRIPTION
Summary:
We used to do this automatically, add it back in to do it manually.
