### PR TITLE
Add docs and an example use of the scripted command get_flags API.

### DIFF
--- a/lldb/docs/use/python-reference.rst
+++ b/lldb/docs/use/python-reference.rst
@@ -562,6 +562,12 @@ which should implement the following interface:
           this call should return the short help text for this command[1]
       def get_long_help(self):
           this call should return the long help text for this command[1]
+      def get_flags(self):
+          this will be called when the command is added to the command interpreter,
+          and should return a flag field made from or-ing together the appropriate
+          elements of the lldb.CommandFlags enum to specify the requirements of this command.
+          The CommandInterpreter will make sure all these requirements are met, and will
+          return the standard lldb error if they are not.[1]
       def get_repeat_command(self, command):
           The auto-repeat command is what will get executed when the user types just
           a return at the next prompt after this command is run.  Even if your command

--- a/lldb/examples/python/cmdtemplate.py
+++ b/lldb/examples/python/cmdtemplate.py
@@ -25,6 +25,9 @@ class FrameStatCommand(ParsedCommand):
             '--help" for detailed help.'.format(cls.program)
         )
 
+    def get_flags(self):
+        return lldb.eCommandRequiresFrame | lldb.eCommandProcessMustBePaused
+
     def setup_command_definition(self):
 
         self.ov_parser.add_option(


### PR DESCRIPTION
The API is present, and we even have a test for it, but it isn't documented so no one probably knows you can set requirements for your scripted commands.  This just adds docs and uses it appropriately in the `framestats` example command.