### PR TITLE
[LLVM][TableGen] Change DisassemblerEmitter to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -159,7 +159,7 @@ class DecoderEmitter {
   std::vector<EncodingAndInst> NumberedEncodings;
 
 public:
-  DecoderEmitter(const RecordKeeper &R, const std::string &PredicateNamespace)
+  DecoderEmitter(const RecordKeeper &R, StringRef PredicateNamespace)
       : RK(R), Target(R), PredicateNamespace(PredicateNamespace) {}
 
   // Emit the decoder state machine table.
@@ -181,7 +181,7 @@ private:
   CodeGenTarget Target;
 
 public:
-  const std::string &PredicateNamespace;
+  StringRef PredicateNamespace;
 };
 
 } // end anonymous namespace
@@ -2651,11 +2651,7 @@ namespace llvm {
   OS << "\n} // end namespace llvm\n";
 }
 
-namespace llvm {
-
-void EmitDecoder(RecordKeeper &RK, raw_ostream &OS,
-                 const std::string &PredicateNamespace) {
+void llvm::EmitDecoder(const RecordKeeper &RK, raw_ostream &OS,
+                       StringRef PredicateNamespace) {
   DecoderEmitter(RK, PredicateNamespace).run(OS);
 }
-
-} // end namespace llvm

--- a/llvm/utils/TableGen/DisassemblerEmitter.cpp
+++ b/llvm/utils/TableGen/DisassemblerEmitter.cpp
@@ -95,19 +95,17 @@ using namespace llvm::X86Disassembler;
 /// X86RecognizableInstr.cpp contains the implementation for a single
 ///   instruction.
 
-static void EmitDisassembler(RecordKeeper &Records, raw_ostream &OS) {
-  CodeGenTarget Target(Records);
+static void EmitDisassembler(const RecordKeeper &Records, raw_ostream &OS) {
+  const CodeGenTarget Target(Records);
   emitSourceFileHeader(" * " + Target.getName().str() + " Disassembler", OS);
 
   // X86 uses a custom disassembler.
   if (Target.getName() == "X86") {
     DisassemblerTables Tables;
 
-    ArrayRef<const CodeGenInstruction *> numberedInstructions =
-        Target.getInstructionsByEnumValue();
-
-    for (unsigned i = 0, e = numberedInstructions.size(); i != e; ++i)
-      RecognizableInstr::processInstr(Tables, *numberedInstructions[i], i);
+    for (const auto &[Idx, NumberedInst] :
+         enumerate(Target.getInstructionsByEnumValue()))
+      RecognizableInstr::processInstr(Tables, *NumberedInst, Idx);
 
     if (Tables.hasConflicts()) {
       PrintError(Target.getTargetRecord()->getLoc(), "Primary decode conflict");
@@ -126,7 +124,7 @@ static void EmitDisassembler(RecordKeeper &Records, raw_ostream &OS) {
     return;
   }
 
-  std::string PredicateNamespace = std::string(Target.getName());
+  StringRef PredicateNamespace = Target.getName();
   if (PredicateNamespace == "Thumb")
     PredicateNamespace = "ARM";
   EmitDecoder(Records, OS, PredicateNamespace);

--- a/llvm/utils/TableGen/TableGenBackends.h
+++ b/llvm/utils/TableGen/TableGenBackends.h
@@ -64,8 +64,8 @@ class RecordKeeper;
 void EmitMapTable(const RecordKeeper &RK, raw_ostream &OS);
 
 // Defined in DecoderEmitter.cpp
-void EmitDecoder(RecordKeeper &RK, raw_ostream &OS,
-                 const std::string &PredicateNamespace);
+void EmitDecoder(const RecordKeeper &RK, raw_ostream &OS,
+                 StringRef PredicateNamespace);
 
 } // namespace llvm
 


### PR DESCRIPTION
Change DisassemblerEmitter to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089