### PR TITLE
[LLVM][TableGen] Change GISelCombinerEmitter to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -80,10 +80,10 @@ void emitEncodingMacrosUndef(raw_ostream &OS) {
      << "#undef " << EncodeMacroName << "8\n";
 }
 
-std::string getNameForFeatureBitset(const std::vector<Record *> &FeatureBitset,
+std::string getNameForFeatureBitset(ArrayRef<const Record *> FeatureBitset,
                                     int HwModeIdx) {
   std::string Name = "GIFBS";
-  for (const auto &Feature : FeatureBitset)
+  for (const Record *Feature : FeatureBitset)
     Name += ("_" + Feature->getName()).str();
   if (HwModeIdx >= 0)
     Name += ("_HwMode" + std::to_string(HwModeIdx));
@@ -859,14 +859,6 @@ void RuleMatcher::addRequiredSimplePredicate(StringRef PredName) {
 
 const std::vector<std::string> &RuleMatcher::getRequiredSimplePredicates() {
   return RequiredSimplePredicates;
-}
-
-void RuleMatcher::addRequiredFeature(Record *Feature) {
-  RequiredFeatures.push_back(Feature);
-}
-
-const std::vector<Record *> &RuleMatcher::getRequiredFeatures() const {
-  return RequiredFeatures;
 }
 
 unsigned RuleMatcher::implicitlyDefineInsnVar(InstructionMatcher &Matcher) {

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -62,7 +62,7 @@ using GISelFlags = std::uint16_t;
 void emitEncodingMacrosDef(raw_ostream &OS);
 void emitEncodingMacrosUndef(raw_ostream &OS);
 
-std::string getNameForFeatureBitset(const std::vector<Record *> &FeatureBitset,
+std::string getNameForFeatureBitset(ArrayRef<const Record *> FeatureBitset,
                                     int HwModeIdx);
 
 /// Takes a sequence of \p Rules and group them based on the predicates
@@ -516,7 +516,7 @@ protected:
   GISelFlags Flags = 0;
 
   std::vector<std::string> RequiredSimplePredicates;
-  std::vector<Record *> RequiredFeatures;
+  std::vector<const Record *> RequiredFeatures;
   std::vector<std::unique_ptr<PredicateMatcher>> EpilogueMatchers;
 
   DenseSet<unsigned> ErasedInsnIDs;
@@ -553,8 +553,12 @@ public:
   uint64_t getRuleID() const { return RuleID; }
 
   InstructionMatcher &addInstructionMatcher(StringRef SymbolicName);
-  void addRequiredFeature(Record *Feature);
-  const std::vector<Record *> &getRequiredFeatures() const;
+  void addRequiredFeature(const Record *Feature) {
+    RequiredFeatures.push_back(Feature);
+  }
+  ArrayRef<const Record *> getRequiredFeatures() const {
+    return RequiredFeatures;
+  }
 
   void addHwModeIdx(unsigned Idx) { HwModeIdx = Idx; }
   int getHwModeIdx() const { return HwModeIdx; }

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTableExecutorEmitter.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTableExecutorEmitter.cpp
@@ -49,14 +49,14 @@ void GlobalISelMatchTableExecutorEmitter::emitSubtargetFeatureBitsetImpl(
 
   // Emit a table containing the PredicateBitsets objects needed by the matcher
   // and an enum for the matcher to reference them with.
-  std::vector<std::pair<std::vector<Record *>, int>> FeatureBitsets;
+  std::vector<std::pair<std::vector<const Record *>, int>> FeatureBitsets;
   FeatureBitsets.reserve(Rules.size());
   for (auto &Rule : Rules)
     FeatureBitsets.emplace_back(Rule.getRequiredFeatures(),
                                 Rule.getHwModeIdx());
   llvm::sort(FeatureBitsets,
-             [&](const std::pair<std::vector<Record *>, int> &A,
-                 const std::pair<std::vector<Record *>, int> &B) {
+             [&](const std::pair<std::vector<const Record *>, int> &A,
+                 const std::pair<std::vector<const Record *>, int> &B) {
                if (A.first.size() < B.first.size())
                  return true;
                if (A.first.size() > B.first.size())


### PR DESCRIPTION
Change GISelCombinerEmitter to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089