### PR TITLE
[LLVM][TableGen] Change PrintEnums to use const RecordKeeper

### DIFF
--- a/llvm/utils/TableGen/TableGen.cpp
+++ b/llvm/utils/TableGen/TableGen.cpp
@@ -43,8 +43,8 @@ static void PrintRecords(const RecordKeeper &Records, raw_ostream &OS) {
   OS << Records; // No argument, dump all contents
 }
 
-static void PrintEnums(RecordKeeper &Records, raw_ostream &OS) {
-  for (Record *Rec : Records.getAllDerivedDefinitions(Class))
+static void PrintEnums(const RecordKeeper &Records, raw_ostream &OS) {
+  for (const Record *Rec : Records.getAllDerivedDefinitions(Class))
     OS << Rec->getName() << ", ";
   OS << "\n";
 }


### PR DESCRIPTION
Change PrintEnums to use const RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089