### PR TITLE
[MachineVerifier] Improve G_EXTRACT_SUBVECTOR checking

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1769,7 +1769,7 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     if (!SrcTy.isVector()) {
-      report("First source must be a vector", MI);
+      report("Source must be a vector", MI);
       break;
     }
 
@@ -1783,6 +1783,12 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       break;
     }
 
+    if (ElementCount::isKnownGT(DstTy.getElementCount(),
+                                SrcTy.getElementCount())) {
+      report("Destination vector must be smaller than source vector", MI);
+      break;
+    }
+
     uint64_t Idx = IndexOp.getImm();
     uint64_t DstMinLen = DstTy.getElementCount().getKnownMinValue();
     if (Idx % DstMinLen != 0) {
@@ -1793,8 +1799,7 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     uint64_t SrcMinLen = SrcTy.getElementCount().getKnownMinValue();
-    if (SrcTy.isScalable() == DstTy.isScalable() &&
-        (Idx >= SrcMinLen || Idx + DstMinLen > SrcMinLen)) {
+    if ((Idx >= SrcMinLen || Idx + DstMinLen > SrcMinLen)) {
       report("Source type and index must not cause extract to overrun to the "
              "destination type",
              MI);

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1799,9 +1799,9 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     uint64_t SrcMinLen = SrcTy.getElementCount().getKnownMinValue();
-    if ((Idx >= SrcMinLen || Idx + DstMinLen > SrcMinLen)) {
-      report("Source type and index must not cause extract to overrun to the "
-             "destination type",
+    if (Idx >= SrcMinLen || Idx + DstMinLen > SrcMinLen) {
+      report("Destination type and index must not cause extract to overrun the "
+             "source vector",
              MI);
       break;
     }

--- a/llvm/test/MachineVerifier/test_g_extract_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_extract_subvector.mir
@@ -19,7 +19,7 @@ body:             |
     ; CHECK: Destination type must be a vector
     %5:_(s32) = G_EXTRACT_SUBVECTOR %2, 0
 
-    ; CHECK: First source must be a vector
+    ; CHECK: Source must be a vector
     %6:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR %0, 0
 
     %7:_(<vscale x 1 x s16>) = G_IMPLICIT_DEF
@@ -27,10 +27,10 @@ body:             |
     ; CHECK: Element type of vectors must be the same
     %8:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR %7, 0
 
-    ; CHECK: Index must be a multiple of the destination vector's minimum vector length
+    ; CHECK: Destination vector must be smaller than source vector
     %9:_(<vscale x 4 x s32>) = G_EXTRACT_SUBVECTOR  %1, 3
 
-    ; CHECK: Index must be a multiple of the destination vector's minimum vector length
+    ; CHECK: Destination vector must be smaller than source vector
     %10:_(<vscale x 4 x s32>) = G_EXTRACT_SUBVECTOR  %1, 2
 
     ; CHECK: Source type and index must not cause extract to overrun to the destination type
@@ -56,5 +56,7 @@ body:             |
     ; CHECK: Vector types must both be fixed or both be scalable
     %19:_(<2 x s32>) = G_EXTRACT_SUBVECTOR %12, 0
 
+    ; CHECK: Index must be a multiple of the destination vector's minimum vector length
+    %20:_(<2 x s32>) = G_EXTRACT_SUBVECTOR %12, 1
 
 ...

--- a/llvm/test/MachineVerifier/test_g_extract_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_extract_subvector.mir
@@ -10,6 +10,7 @@ body:             |
     %1:_(<vscale x 2 x s32>) = G_IMPLICIT_DEF
     %2:_(<vscale x 1 x s32>) = G_IMPLICIT_DEF
 
+    ; CHECK: generic instruction must use register operands
     ; CHECK: G_EXTRACT_SUBVECTOR first source must be a register
     %3:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR 1, 0
 

--- a/llvm/test/MachineVerifier/test_g_extract_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_extract_subvector.mir
@@ -33,21 +33,21 @@ body:             |
     ; CHECK: Destination vector must be smaller than source vector
     %10:_(<vscale x 4 x s32>) = G_EXTRACT_SUBVECTOR  %1, 2
 
-    ; CHECK: Source type and index must not cause extract to overrun to the destination type
+    ; CHECK: Destination type and index must not cause extract to overrun the source vector
     %11:_(<vscale x 1 x s32>) = G_EXTRACT_SUBVECTOR  %1, 4
 
     %12:_(<vscale x 4 x s32>) = G_IMPLICIT_DEF
 
-    ; CHECK: Source type and index must not cause extract to overrun to the destination type
+    ; CHECK: Destination type and index must not cause extract to overrun the source vector
     %13:_(<vscale x 3 x s32>) = G_EXTRACT_SUBVECTOR  %12, 3
 
     %14:_(<2 x s32>) = G_IMPLICIT_DEF
     %15:_(<4 x s32>) = G_IMPLICIT_DEF
 
-    ; CHECK: Source type and index must not cause extract to overrun to the destination type
+    ; CHECK: Destination type and index must not cause extract to overrun the source vector
     %16:_(<2 x s32>) = G_EXTRACT_SUBVECTOR  %14, 4
 
-    ; CHECK: Source type and index must not cause extract to overrun to the destination type
+    ; CHECK: Destination type and index must not cause extract to overrun the source vector
     %17:_(<3 x s32>) = G_EXTRACT_SUBVECTOR  %15, 3
 
     ; CHECK: Vector types must both be fixed or both be scalable
@@ -57,6 +57,6 @@ body:             |
     %19:_(<2 x s32>) = G_EXTRACT_SUBVECTOR %12, 0
 
     ; CHECK: Index must be a multiple of the destination vector's minimum vector length
-    %20:_(<2 x s32>) = G_EXTRACT_SUBVECTOR %12, 1
+    %20:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR %12, 1
 
 ...


### PR DESCRIPTION
Check that the destination of G_EXTRACT_SUBVECTOR is smaller than the source.
Fix wording of error messages