### PR TITLE
[libcxx] Do not warn on missing `ELAST` definition on LLVM libc

### DIFF
--- a/libcxx/src/include/config_elast.h
+++ b/libcxx/src/include/config_elast.h
@@ -31,6 +31,8 @@
 // No _LIBCPP_ELAST needed on WASI
 #elif defined(__EMSCRIPTEN__)
 // No _LIBCPP_ELAST needed on Emscripten
+#elif defined(__LLVM_LIBC__)
+// No _LIBCPP_ELAST needed on LLVM's libc.
 #elif defined(__linux__) || defined(_LIBCPP_HAS_MUSL_LIBC)
 #  define _LIBCPP_ELAST 4095
 #elif defined(__APPLE__)


### PR DESCRIPTION
Summary:
The LLVM C library shouldn't need this `ELAST` definition because our
implementation should handle out-of-range error values gracefully.
