### PR TITLE
[flang][Driver] Support -fdiagnostics-color

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1975,10 +1975,15 @@ def fno_color_diagnostics : Flag<["-"], "fno-color-diagnostics">, Group<f_Group>
   Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   HelpText<"Disable colors in diagnostics">;
 def : Flag<["-"], "fdiagnostics-color">, Group<f_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption]>, Alias<fcolor_diagnostics>;
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+  Alias<fcolor_diagnostics>;
 def : Flag<["-"], "fno-diagnostics-color">, Group<f_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption]>, Alias<fno_color_diagnostics>;
-def fdiagnostics_color_EQ : Joined<["-"], "fdiagnostics-color=">, Group<f_Group>;
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+  Alias<fno_color_diagnostics>;
+def fdiagnostics_color_EQ : Joined<["-"], "fdiagnostics-color=">, Group<f_Group>,
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+  Values<"auto,always,never">,
+  HelpText<"When to use colors in diagnostics">;
 def fansi_escape_codes : Flag<["-"], "fansi-escape-codes">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>,
   HelpText<"Use ANSI escape codes for diagnostics">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4421,21 +4421,7 @@ static void RenderDiagnosticsOptions(const Driver &D, const ArgList &Args,
       CmdArgs.push_back("-fno-diagnostics-show-note-include-stack");
   }
 
-  // Color diagnostics are parsed by the driver directly from argv and later
-  // re-parsed to construct this job; claim any possible color diagnostic here
-  // to avoid warn_drv_unused_argument and diagnose bad
-  // OPT_fdiagnostics_color_EQ values.
-  Args.getLastArg(options::OPT_fcolor_diagnostics,
-                  options::OPT_fno_color_diagnostics);
-  if (const Arg *A = Args.getLastArg(options::OPT_fdiagnostics_color_EQ)) {
-    StringRef Value(A->getValue());
-    if (Value != "always" && Value != "never" && Value != "auto")
-      D.Diag(diag::err_drv_invalid_argument_to_option)
-          << Value << A->getOption().getName();
-  }
-
-  if (D.getDiags().getDiagnosticOptions().ShowColors)
-    CmdArgs.push_back("-fcolor-diagnostics");
+  handleColorDiagnosticsArgs(D, Args, CmdArgs);
 
   if (Args.hasArg(options::OPT_fansi_escape_codes))
     CmdArgs.push_back("-fansi-escape-codes");

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2976,3 +2976,22 @@ void tools::addMCModel(const Driver &D, const llvm::opt::ArgList &Args,
     }
   }
 }
+
+void tools::handleColorDiagnosticsArgs(const Driver &D, const ArgList &Args,
+                                       ArgStringList &CmdArgs) {
+  // Color diagnostics are parsed by the driver directly from argv and later
+  // re-parsed to construct this job; claim any possible color diagnostic here
+  // to avoid warn_drv_unused_argument and diagnose bad
+  // OPT_fdiagnostics_color_EQ values.
+  Args.getLastArg(options::OPT_fcolor_diagnostics,
+                  options::OPT_fno_color_diagnostics);
+  if (const Arg *A = Args.getLastArg(options::OPT_fdiagnostics_color_EQ)) {
+    StringRef Value(A->getValue());
+    if (Value != "always" && Value != "never" && Value != "auto")
+      D.Diag(diag::err_drv_invalid_argument_to_option)
+          << Value << A->getOption().getName();
+  }
+
+  if (D.getDiags().getDiagnosticOptions().ShowColors)
+    CmdArgs.push_back("-fcolor-diagnostics");
+}

--- a/clang/lib/Driver/ToolChains/CommonArgs.h
+++ b/clang/lib/Driver/ToolChains/CommonArgs.h
@@ -236,6 +236,10 @@ void addMCModel(const Driver &D, const llvm::opt::ArgList &Args,
                 const llvm::Reloc::Model &RelocationModel,
                 llvm::opt::ArgStringList &CmdArgs);
 
+/// Handle the -f{no}-color-diagnostics and -f{no}-diagnostics-colors options.
+void handleColorDiagnosticsArgs(const Driver &D, const llvm::opt::ArgList &Args,
+                                llvm::opt::ArgStringList &CmdArgs);
+
 } // end namespace tools
 } // end namespace driver
 } // end namespace clang

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -732,6 +732,12 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
   // to avoid warn_drv_unused_argument.
   Args.getLastArg(options::OPT_fcolor_diagnostics,
                   options::OPT_fno_color_diagnostics);
+  if (const Arg *A = Args.getLastArg(options::OPT_fdiagnostics_color_EQ)) {
+    StringRef Value(A->getValue());
+    if (Value != "always" && Value != "never" && Value != "auto")
+      D.Diag(diag::err_drv_invalid_argument_to_option)
+          << Value << A->getOption().getName();
+  }
   if (Diags.getDiagnosticOptions().ShowColors)
     CmdArgs.push_back("-fcolor-diagnostics");
 

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -727,19 +727,7 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   addFortranDialectOptions(Args, CmdArgs);
 
-  // Color diagnostics are parsed by the driver directly from argv and later
-  // re-parsed to construct this job; claim any possible color diagnostic here
-  // to avoid warn_drv_unused_argument.
-  Args.getLastArg(options::OPT_fcolor_diagnostics,
-                  options::OPT_fno_color_diagnostics);
-  if (const Arg *A = Args.getLastArg(options::OPT_fdiagnostics_color_EQ)) {
-    StringRef Value(A->getValue());
-    if (Value != "always" && Value != "never" && Value != "auto")
-      D.Diag(diag::err_drv_invalid_argument_to_option)
-          << Value << A->getOption().getName();
-  }
-  if (Diags.getDiagnosticOptions().ShowColors)
-    CmdArgs.push_back("-fcolor-diagnostics");
+  handleColorDiagnosticsArgs(D, Args, CmdArgs);
 
   // LTO mode is parsed by the Clang driver library.
   LTOKind LTOMode = D.getLTOMode();

--- a/flang/test/Driver/color-diagnostics-forwarding.f90
+++ b/flang/test/Driver/color-diagnostics-forwarding.f90
@@ -1,11 +1,19 @@
-! Test that flang-new forwards -f{no-}color-diagnostics options to
-! flang-new -fc1 as expected.
+! Test that flang-new forwards -f{no-}color-diagnostics and
+! -f{no-}diagnostics-color options to flang-new -fc1 as expected.
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 -fcolor-diagnostics \
+! RUN:   | FileCheck %s --check-prefix=CHECK-CD
+! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 -fdiagnostics-color \
+! RUN:   | FileCheck %s --check-prefix=CHECK-CD
+! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 -fdiagnostics-color=always \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-CD
 ! CHECK-CD: "-fc1"{{.*}} "-fcolor-diagnostics"
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 -fno-color-diagnostics \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NCD
+! RUN: %flang -fsyntax-only -### %s -o %t -fno-diagnostics-color 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NCD
+! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 -fdiagnostics-color=never \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-NCD
 ! CHECK-NCD-NOT: "-fc1"{{.*}} "-fcolor-diagnostics"
 
@@ -13,9 +21,33 @@
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 \
 ! RUN:     -fno-color-diagnostics -fcolor-diagnostics \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-NCD_CD_S
+! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 \
+! RUN:     -fno-diagnostics-color -fdiagnostics-color \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NCD_CD_S
+! RUN: %flang -fsyntax-only -### %s -o %t \
+! RUN:     -fno-color-diagnostics -fdiagnostics-color=always 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NCD_CD_S
+! RUN: %flang -fsyntax-only -### %s -o %t \
+! RUN:     -fdiagnostics-color=never -fdiagnostics-color=always 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NCD_CD_S
+! RUN: %flang -fsyntax-only -### %s -o %t \
+! RUN:     -fdiagnostics-color=never -fcolor-diagnostics 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NCD_CD_S
 ! CHECK-NCD_CD_S: "-fc1"{{.*}} "-fcolor-diagnostics"
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 \
 ! RUN:     -fcolor-diagnostics -fno-color-diagnostics \
+! RUN:   | FileCheck %s --check-prefix=CHECK-CD_NCD_S
+! RUN: %flang -fsyntax-only -### %s -o %t \
+! RUN:     -fdiagnostics-color -fno-diagnostics-color  2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-CD_NCD_S
+! RUN: %flang -fsyntax-only -### %s -o %t \
+! RUN:     -fdiagnostics-color=always -fno-color-diagnostics 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-CD_NCD_S
+! RUN: %flang -fsyntax-only -### %s -o %t \
+! RUN:     -fdiagnostics-color=always -fdiagnostics-color=never 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-CD_NCD_S
+! RUN: %flang -fsyntax-only -### %s -o %t \
+! RUN:     -fcolor-diagnostics -fdiagnostics-color=never 2>&1 \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-CD_NCD_S
 ! CHECK-CD_NCD_S-NOT: "-fc1"{{.*}} "-fcolor-diagnostics"

--- a/flang/test/Driver/color-diagnostics-parse.f90
+++ b/flang/test/Driver/color-diagnostics-parse.f90
@@ -1,12 +1,22 @@
-! Test the behaviors of -f{no-}color-diagnostics when emitting parsing
-! diagnostics.
+! Test the behaviors of -f{no-}color-diagnostics and -f{no-}diagnostics-color
+! when emitting parsing diagnostics.
 ! Windows command prompt doesn't support ANSI escape sequences.
 ! REQUIRES: shell
 
 ! RUN: not %flang %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -fdiagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -fdiagnostics-color=always 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+
 ! RUN: not %flang %s -fno-color-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+! RUN: not %flang %s -fno-diagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+! RUN: not %flang %s -fdiagnostics-color=never 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+
 ! RUN: not %flang_fc1 %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD
 ! RUN: not %flang_fc1 %s 2>&1 | FileCheck %s --check-prefix=CHECK_NCD

--- a/flang/test/Driver/color-diagnostics-scan.f
+++ b/flang/test/Driver/color-diagnostics-scan.f
@@ -1,5 +1,5 @@
-! Test the behaviors of -f{no-}color-diagnostics when emitting scanning
-! diagnostics.
+! Test the behaviors of -f{no-}color-diagnostics and -f{no}-diagnostic-colors
+! when emitting scanning diagnostics.
 ! Windows command prompt doesn't support ANSI escape sequences.
 ! REQUIRES: shell
 
@@ -9,6 +9,17 @@
 ! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
 ! RUN: not %flang_fc1 -E -Werror %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+
+! RUN: not %flang %s -E -Werror -fdiagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -E -Werror -fno-diagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+
+! RUN: not %flang %s -E -Werror -fdiagnostics-color=always 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -E -Werror -fdiagnostics-color=never 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+
 ! RUN: not %flang_fc1 -E -Werror %s 2>&1 | FileCheck %s --check-prefix=CHECK_NCD
 
 ! CHECK_CD: {{.*}}[0;1;35mwarning: {{.*}}[0mCharacter in fixed-form label field must be a digit

--- a/flang/test/Driver/color-diagnostics-sema.f90
+++ b/flang/test/Driver/color-diagnostics-sema.f90
@@ -1,5 +1,5 @@
-! Test the behaviors of -f{no-}color-diagnostics when emitting semantic
-! diagnostics.
+! Test the behaviors of -f{no-}color-diagnostics and -f{no}diagnostics-color
+! when emitting semantic diagnostics.
 ! Windows command prompt doesn't support ANSI escape sequences.
 ! REQUIRES: shell
 
@@ -9,6 +9,17 @@
 ! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
 ! RUN: not %flang_fc1 %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+
+! RUN: not %flang %s -fdiagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -fno-diagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+
+! RUN: not %flang %s -fdiagnostics-color=always 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -fdiagnostics-color=never 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+
 ! RUN: not %flang_fc1 %s 2>&1 | FileCheck %s --check-prefix=CHECK_NCD
 
 ! CHECK_CD: {{.*}}[0;1;31merror: {{.*}}[0mMust be a constant value

--- a/flang/test/Driver/color-diagnostics.f90
+++ b/flang/test/Driver/color-diagnostics.f90
@@ -1,4 +1,4 @@
-! Test the behaviors of -f{no-}color-diagnostics.
+! Test the behaviors of -f{no-}color-diagnostics and -f{no}-diagnostics-color.
 ! Windows command prompt doesn't support ANSI escape sequences.
 ! REQUIRES: shell
 
@@ -9,14 +9,36 @@
 ! RUN: not %flang_fc1 %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD
 ! RUN: not %flang_fc1 %s -fno-color-diagnostics 2>&1 \
-! RUN:     | FileCheck %s --check-prefix=UNSUPPORTED_OPTION
+! RUN:     | FileCheck %s --check-prefix=UNSUPPORTED_COLOR_DIAGS
+
+! RUN: not %flang %s -fdiagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -fno-diagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+! RUN: not %flang_fc1 %s -fdiagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=UNSUPPORTED_DIAGS_COLOR
+! RUN: not %flang_fc1 %s -fno-diagnostics-color 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=UNSUPPORTED_NO_DIAGS_COLOR
+
+! RUN: not %flang %s -fdiagnostics-color=always 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_CD
+! RUN: not %flang %s -fdiagnostics-color=never 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=CHECK_NCD
+
 ! RUN: not %flang_fc1 %s 2>&1 | FileCheck %s --check-prefix=CHECK_NCD
 
 ! CHECK_CD: {{.*}}[0;1;31merror: {{.*}}[0m{{.*}}[1mSemantic errors in {{.*}}color-diagnostics.f90{{.*}}[0m
 
 ! CHECK_NCD: Semantic errors in {{.*}}color-diagnostics.f90
 
-! UNSUPPORTED_OPTION: error: unknown argument: '-fno-color-diagnostics'
+! UNSUPPORTED_COLOR_DIAGS: error: unknown argument: '-fno-color-diagnostics'
+! UNSUPPORTED_DIAGS_COLOR: error: unknown argument: '-fdiagnostics-color'
+! UNSUPPORTED_NO_DIAGS_COLOR: error: unknown argument: '-fno-diagnostics-color'
+
+! Check that invalid values of -fdiagnostics-color= are disallowed.
+! RUN: not %flang %s -fdiagnostics-color=sometimes 2>&1 \
+! RUN:     | FileCheck %s --check-prefix=DCEQ_BAD
+! DCEQ_BAD: error: invalid argument 'sometimes' to -fdiagnostics-color=
 
 program m
   integer :: i = k


### PR DESCRIPTION
Add support for -fdiagnostics-color and -fdiagnostics-color=. Add documentation for -fdiagnostics-color= which should also be visible in clang.

Partially addresses requests in #89888