### PR TITLE
[libc++] use copy_file_range for fs::copy

### DIFF
--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <iterator>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 #include <vector>
 
@@ -321,6 +322,7 @@ bool copy_file_impl(FileDescriptor& read_fd, FileDescriptor& write_fd, error_cod
   return copy_file_impl_fstream(read_fd, write_fd, ec);
 #  else
   // since iostreams are unavailable in the no-locale build, just fail after a failed sendfile
+  ec.assign(EINVAL, std::system_category());
   return false;
 #  endif
 }

--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -261,10 +261,14 @@ bool copy_file_impl_sendfile(FileDescriptor& read_fd, FileDescriptor& write_fd, 
   size_t count = read_fd.get_stat().st_size;
   // a zero-length file is either empty, or not copyable by this syscall
   // return early to avoid the syscall cost
+  // however, we can't afford this luxury in the no-locale build,
+  // as we can't utilize the fstream impl to copy empty files
+#  if _LIBCPP_HAS_LOCALIZATION
   if (count == 0) {
     ec = {EINVAL, generic_category()};
     return false;
   }
+#  endif
   do {
     ssize_t res;
     if ((res = ::sendfile(write_fd.fd, read_fd.fd, nullptr, count)) == -1) {

--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -278,9 +278,8 @@ bool copy_file_impl_sendfile(FileDescriptor& read_fd, FileDescriptor& write_fd, 
 }
 #endif
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(_LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE)
 bool copy_file_impl(FileDescriptor& read_fd, FileDescriptor& write_fd, error_code& ec) {
-#  if defined(_LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE)
   if (copy_file_impl_copy_file_range(read_fd, write_fd, ec)) {
     return true;
   }
@@ -301,9 +300,10 @@ bool copy_file_impl(FileDescriptor& read_fd, FileDescriptor& write_fd, error_cod
     return false;
   }
   ec.clear();
-#  endif
-
-#  if defined(_LIBCPP_FILESYSTEM_USE_SENDFILE)
+  return copy_file_impl_fstream(read_fd, write_fd, ec);
+}
+#elif defined(_LIBCPP_FILESYSTEM_USE_SENDFILE)
+bool copy_file_impl(FileDescriptor& read_fd, FileDescriptor& write_fd, error_code& ec) {
   if (copy_file_impl_sendfile(read_fd, write_fd, ec)) {
     return true;
   }
@@ -312,8 +312,6 @@ bool copy_file_impl(FileDescriptor& read_fd, FileDescriptor& write_fd, error_cod
     return false;
   }
   ec.clear();
-#  endif
-
   return copy_file_impl_fstream(read_fd, write_fd, ec);
 }
 #elif defined(_LIBCPP_FILESYSTEM_USE_COPYFILE)

--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -41,8 +41,7 @@
 // since Linux 4.5 and FreeBSD 13
 #if defined(__linux__) || defined(__FreeBSD__)
 #  define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
-#endif
-#if __has_include(<sys/sendfile.h>)
+#elif __has_include(<sys/sendfile.h>)
 #  include <sys/sendfile.h>
 #  define _LIBCPP_FILESYSTEM_USE_SENDFILE
 #elif defined(__APPLE__) || __has_include(<copyfile.h>)

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file_procfs.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file_procfs.pass.cpp
@@ -9,6 +9,7 @@
 // UNSUPPORTED: c++03, c++11, c++14
 // REQUIRES: linux
 // UNSUPPORTED: no-filesystem
+// XFAIL: no-localization
 // UNSUPPORTED: availability-filesystem-missing
 
 // <filesystem>

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file_procfs.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file_procfs.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+// REQUIRES: linux
+// UNSUPPORTED: no-filesystem
+// UNSUPPORTED: availability-filesystem-missing
+
+// <filesystem>
+
+// bool copy_file(const path& from, const path& to);
+// bool copy_file(const path& from, const path& to, error_code& ec) noexcept;
+// bool copy_file(const path& from, const path& to, copy_options options);
+// bool copy_file(const path& from, const path& to, copy_options options,
+//           error_code& ec) noexcept;
+
+#include <cassert>
+#include <filesystem>
+#include <system_error>
+
+#include "test_macros.h"
+#include "filesystem_test_helper.h"
+
+namespace fs = std::filesystem;
+
+// Linux has various virtual filesystems such as /proc and /sys
+// where files may have no length (st_size == 0), but still contain data.
+// This is because the to-be-read data is usually generated ad-hoc by the reading syscall
+// These files can not be copied with kernel-side copies like copy_file_range or sendfile,
+// and must instead be copied via a traditional userspace read + write loop.
+int main(int, char** argv) {
+  const fs::path procfile{"/proc/self/comm"};
+  assert(file_size(procfile) == 0);
+
+  scoped_test_env env;
+  std::error_code ec = GetTestEC();
+
+  const fs::path dest = env.make_env_path("dest");
+
+  assert(copy_file(procfile, dest, ec));
+  assert(!ec);
+
+  // /proc/self/comm contains the filename of the executable, plus a null terminator
+  assert(file_size(dest) == fs::path(argv[0]).filename().string().size() + 1);
+
+  return 0;
+}


### PR DESCRIPTION
Hi,

this optimizes `std::filesystem::copy_file` to use the `copy_file_range` syscall (Linux and FreeBSD) when available. It allows for reflinks on filesystems such as btrfs, zfs and xfs, and server-side copy for network filesystems such as NFS.

This behaviour is in line with Boost.Filesystem and libstdc++ (where [I implemented this](https://github.com/gcc-mirror/gcc/commit/d87caacf8e2df563afda85f3a5b7b852e08b6b2c) some time ago). It's also the default behaviour of the standard file copy operations in .NET Core, Java, and (hopefully) soon python, and in the `cp` program from GNU coreutils.

I don't have the opportunity to test this on FreeBSD, but I think the FreeBSD folks will want a look at this. Sadly I don't know any by name, perhaps someone could CC the relevant person(s).

As for the `LIBCXX_USE_COPY_FILE_RANGE` cmake check, I was unsure where to put it, and this is probably not the desired location.

Lastly I am not sure if the largefile handling (see usage of `off_t`) is correct.