### PR TITLE
[LLVM][TableGen] Add error check for duplicate intrinsic names

### DIFF
--- a/llvm/test/TableGen/intrinsic-duplicate-name.td
+++ b/llvm/test/TableGen/intrinsic-duplicate-name.td
@@ -1,0 +1,9 @@
+// RUN: not llvm-tblgen -gen-intrinsic-impl -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS 2>&1 | FileCheck %s -DFILE=%s
+
+include "llvm/IR/Intrinsics.td"
+
+def int_foo0 : Intrinsic<[llvm_anyint_ty], [], [], "llvm.foo">;
+
+// CHECK: [[FILE]]:[[@LINE+2]]:5: error: Intrinsic `llvm.foo` is already defined
+// CHECK: [[FILE]]:[[@LINE-3]]:5: note: Previous definition here
+def int_foo1 : Intrinsic<[llvm_anyint_ty], [], [], "llvm.foo">;

--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
@@ -189,6 +189,9 @@ public:
   const CodeGenIntrinsic &operator[](size_t Pos) const {
     return Intrinsics[Pos];
   }
+
+private:
+  void CheckDuplicateIntrinsics() const;
 };
 
 // This class builds `CodeGenIntrinsic` on demand for a given Def.


### PR DESCRIPTION
Check for duplicate intrinsic names in the intrinsic emitter backend and issue a fatal error if we find one.