### PR TITLE
[clang][bytecode] Use field descriptor in IntPointer::atOffset

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -665,7 +665,7 @@ IntPointer IntPointer::atOffset(const ASTContext &ASTCtx,
   uint64_t FieldOffset =
       ASTCtx.toCharUnitsFromBits(Layout.getFieldOffset(FieldIndex))
           .getQuantity();
-  return IntPointer{this->Desc, this->Value + FieldOffset};
+  return IntPointer{F->Desc, this->Value + FieldOffset};
 }
 
 IntPointer IntPointer::baseCast(const ASTContext &ASTCtx,

--- a/clang/test/AST/ByteCode/codegen.c
+++ b/clang/test/AST/ByteCode/codegen.c
@@ -17,3 +17,10 @@ struct B {
 };
 const int A = (char *)(&( (struct B *)(16) )->b[0]) - (char *)(16);
 // CHECK: @A = constant i32 1
+
+struct X { int a[2]; };
+int test(void) {
+  static int i23 = (int) &(((struct X *)0)->a[1]);
+  return i23;
+}
+// CHECK: @test.i23 = internal global i32 4, align 4


### PR DESCRIPTION
We're otherwise still pointing to the old type, but with the new offset.