### PR TITLE
Discourage vectorisation of small loops with gathers and scatters

### DIFF
--- a/llvm/lib/Target/ARM/ARMFeatures.td
+++ b/llvm/lib/Target/ARM/ARMFeatures.td
@@ -254,6 +254,12 @@ def FeatureSlowVDUP32     : SubtargetFeature<"slow-vdup32", "HasSlowVDUP32",
                                              "true",
                                              "Has slow VDUP32 - prefer VMOV">;
 
+// For some MVE-enabled processors, scalar loops are preferred when they are small enough
+// that the overhead of gathers and scatters is detrimental to performance.
+// In these cases, prefer to not use gathers and scatters, or avoid vectorising entirely.
+def FeaturePreferScalarToGatherScatter : SubtargetFeature<"prefer-scalar-to-gatscat", "PreferScalarToGatherScatter",
+                                             "true", "Disable gather and scatter instructions">;
+
 // Some targets (e.g. Cortex-A9) prefer VMOVSR to VMOVDRR even when using NEON
 // for scalar FP, as this allows more effective execution domain optimization.
 // True if VMOVSR will be favored over VMOVDRR.

--- a/llvm/lib/Target/ARM/ARMProcessors.td
+++ b/llvm/lib/Target/ARM/ARMProcessors.td
@@ -386,6 +386,7 @@ def : ProcessorModel<"cortex-m85", CortexM85Model,      [ARMv81mMainline,
                                                          FeatureFPARMv8_D16,
                                                          FeaturePACBTI,
                                                          FeatureUseMISched,
+                                                         FeaturePreferScalarToGatherScatter,
                                                          HasMVEFloatOps]>;
 
 def : ProcessorModel<"cortex-m52", CortexM55Model,      [ARMv81mMainline,


### PR DESCRIPTION
On Cortex-M85, our benchmarks are faster with scalar loops than vectorised loops with gathers and scatters on. This patch disables gathers and scatters for Cortex-M85, as an initial approach, and discourages vectorisation of the loop to encourage scalarisation. This increases performance in several benchmarks.

Additionally, don't allow tail predication with strided accesses if gather scatter is disabled