### PR TITLE
[mlir][vector][nfc] Update vector load/store doc wrt unit strides.

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1655,6 +1655,7 @@ def Vector_LoadOp : Vector_Op<"load"> {
     strides. Only unit strides are allowed along the most minor memref
     dimension. These constraints guarantee that elements read along the first
     dimension of the slice are contiguous in memory.
+    Non-unit strides are allowed when doing 0-rank or 1-element vector load.
 
     The memref element type can be a scalar or a vector type. If the memref
     element type is a scalar, it should match the element type of the result
@@ -1739,6 +1740,7 @@ def Vector_StoreOp : Vector_Op<"store"> {
     strided by the memref strides. Only unit strides are allowed along the most
     minor memref dimension. These constraints guarantee that elements written
     along the first dimension of the slice are contiguous in memory.
+    Non-unit strides are allowed when doing 0-rank or 1-element vector store.
 
     The memref element type can be a scalar or a vector type. If the memref
     element type is a scalar, it should match the element type of the value

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1652,10 +1652,10 @@ def Vector_LoadOp : Vector_Op<"load"> {
     based on the element type of the memref. The shape of the result vector
     type determines the shape of the slice read from the start memory address.
     The elements along each dimension of the slice are strided by the memref
-    strides. Only unit strides are allowed along the most minor memref
-    dimension. These constraints guarantee that elements read along the first
-    dimension of the slice are contiguous in memory.
-    Non-unit strides are allowed when doing 0-rank or 1-element vector load.
+    strides. When loading more than 1 element, only unit strides are allowed
+    along the most minor memref dimension. These constraints guarantee that
+    elements read along the first dimension of the slice are contiguous in
+    memory.
 
     The memref element type can be a scalar or a vector type. If the memref
     element type is a scalar, it should match the element type of the result
@@ -1737,10 +1737,10 @@ def Vector_StoreOp : Vector_Op<"store"> {
     memref dimension based on the element type of the memref. The shape of the
     vector value to store determines the shape of the slice written from the
     start memory address. The elements along each dimension of the slice are
-    strided by the memref strides. Only unit strides are allowed along the most
-    minor memref dimension. These constraints guarantee that elements written
-    along the first dimension of the slice are contiguous in memory.
-    Non-unit strides are allowed when doing 0-rank or 1-element vector store.
+    strided by the memref strides. When storing more than 1 element, only unit
+    strides are allowed along the most minor memref dimension. These constraints
+    guarantee that elements read along the first dimension of the slice are
+    contiguous in memory.
 
     The memref element type can be a scalar or a vector type. If the memref
     element type is a scalar, it should match the element type of the value

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1739,7 +1739,7 @@ def Vector_StoreOp : Vector_Op<"store"> {
     start memory address. The elements along each dimension of the slice are
     strided by the memref strides. When storing more than 1 element, only unit
     strides are allowed along the most minor memref dimension. These constraints
-    guarantee that elements read along the first dimension of the slice are
+    guarantee that elements written along the first dimension of the slice are
     contiguous in memory.
 
     The memref element type can be a scalar or a vector type. If the memref


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/108998.

Non-contiguous strides are allowed now for 1-element vector load/stores.