### PR TITLE
[Test][JITLink] Correctly generate the R_X86_64_PC8 relocation.

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_PC8.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_PC8.s
@@ -12,8 +12,5 @@ main:
 	retq
 	.size	main, .-main
 
-	.type	P,@object
-	.globl	P
-P:
-	.byte main-. # Generate R_X86_64_PC8 relocation.
-  .size P, .-P
+	.rodata
+	.byte	main-. # Generate R_X86_64_PC8 relocation.


### PR DESCRIPTION
Previously, ELF_R_X86_64_PC8.s doesn't produce the R_X86_64_PC8 relocation. This patch helps fix it.

Before:

```
llvm-mc -triple=x86_64-unknown-linux -position-independent -filetype=obj -o - ELF_R_X86_64_PC8.s | llvm-readobj -r -

File: <stdin>
Format: elf64-x86-64
Arch: x86_64
AddressSize: 64bit
LoadName: <Not found>
Relocations [
]
```

After:

```
llvm-mc -triple=x86_64-unknown-linux -position-independent -filetype=obj -o - ELF_R_X86_64_PC8.s | llvm-readobj -r -

File: <stdin>
Format: elf64-x86-64
Arch: x86_64
AddressSize: 64bit
LoadName: <Not found>
Relocations [
  Section (3) .rela.text {
    0x4 R_X86_64_PC8 main 0xFFFFFFFFFFFFFFFF
  }
]
```