### PR TITLE
[sanitizer_common] Provide dummy ThreadDescriptorSize on Solaris

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -226,7 +226,7 @@ static void GetGLibcVersion(int *major, int *minor, int *patch) {
 // sizeof(struct pthread) from glibc.
 static uptr thread_descriptor_size;
 
-// FIXME: Implementation is very GLIBC specific, but it's used by FREEBSD.
+// FIXME: Implementation is very GLIBC specific, but it's used by FreeBSD.
 static uptr ThreadDescriptorSizeFallback() {
 #    if defined(__x86_64__) || defined(__i386__) || defined(__arm__) || \
         SANITIZER_RISCV64
@@ -364,6 +364,7 @@ static uptr TlsPreTcbSize() {
 #    endif
 #  else   // (SANITIZER_FREEBSD || SANITIZER_GLIBC) && !SANITIZER_GO
 void InitTlsSize() {}
+uptr ThreadDescriptorSize() { return 0; }
 #  endif  // (SANITIZER_FREEBSD || SANITIZER_GLIBC) && !SANITIZER_GO
 
 #  if (SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_SOLARIS) && \


### PR DESCRIPTION
Since 2c69a09bee94acca859a1adf5b04d01dc13f7295, the Solaris build is broken like
```
Undefined			first referenced
 symbol  			    in file
_ZN11__sanitizer20ThreadDescriptorSizeEv projects/compiler-rt/lib/sanitizer_common/CMakeFiles/RTSanitizerCommonLibc.i386.dir/sanitizer_linux_libcdep.cpp.o
```
The `ThreadDescriptorSize` reference is from `sanitizer_linux_libcdep.cpp` (`GetTls`), l.590.  This isn't actually needed on non-glibc targets AFAICS, so this patch provides a dummy to restore the build.

Tested on `sparcv9-sun-solaris2.11`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.