### PR TITLE
[clang] fix the unexpected control flow in ParseTentative.cpp

### DIFF
--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1973,7 +1973,7 @@ Parser::TPResult Parser::TryParseTypeofSpecifier() {
 Parser::TPResult Parser::TryParseProtocolQualifiers() {
   assert(Tok.is(tok::less) && "Expected '<' for qualifier list");
   ConsumeToken();
-  do {
+  while (true) {
     if (Tok.isNot(tok::identifier))
       return TPResult::Error;
     ConsumeToken();
@@ -1987,9 +1987,9 @@ Parser::TPResult Parser::TryParseProtocolQualifiers() {
       ConsumeToken();
       return TPResult::Ambiguous;
     }
-  } while (false);
 
-  return TPResult::Error;
+    return TPResult::Error;
+  }
 }
 
 /// isCXXFunctionDeclarator - Disambiguates between a function declarator or


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/95895.

It appears that there was a logic error in the code of Parser::TryParseProtocolQualifiers related to parsing the identifier list. This pull request fixed the issue.