### PR TITLE
Add missing deps edge: CodeGenAction.cpp.o -> GenVT.inc

### DIFF
--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -144,6 +144,7 @@ add_clang_library(clangCodeGen
   VarBypassDetector.cpp
 
   DEPENDS
+  vt_gen
   intrinsics_gen
   ClangDriverOptions
   # These generated headers are included transitively.


### PR DESCRIPTION
CodeGenAction.cpp.o depends on generating GenVT.inc before trying to compile it through the following header chain:

```
GenVT.inc
MachineValueType.h
LowLevelType.h
MachineMemOperand.h
MachineInstr.h
MachineBasicBlock.h
MachineFunctionPass.h
MachineOptimizationRemarkEmitter.h
CodeGenAction.cpp
```

There is a dependency edge through LLVMCodeGenTypes, but that edge is applied to the clangCodeGen link step, not the compile step of the files that make up clangCodeGen. Usually the compile and link are close enough in the build that GenVT.inc is scheduled early enough that it exists by the time we're compiling CodeGenAction.cpp.o, but on machines with high core counts, it seems to be more prevalent that the scheduling works out just right to expose the missing edge. I've only been able to reproduce this on machines with at least 64 cores (but even then it was not reliable).

Additionally, llvm-tblgen depends on GenVT.inc, so to see the missing dependency edge, one must be using a pre-built tablegen binary.

Adding the missing dependency edge to ensure that GenVT.inc is generated before trying to compile CodeGenAction.cpp.o.

Found by inspecting the dependency graph generated from Ninja with:

```sh
cmake -G 'Ninja' \
  ...
  -DLLVM_TABLEGEN=<path to native tblegen> \
  -DCLANG_TABLEGEN=<path to native clang tblgen> \
  -DLLVM_ENABLE_PROJECTS=clang \
  ...

ninja -t graph \
  tools/clang/lib/CodeGen/CMakeFiles/obj.clangCodeGen.dir/CodeGenAction.cpp.o | dot -Tpdf > CodeGenAction.pdf
```