### PR TITLE
[mlir][vector][nfc] Clean-up VectorOps.{h|cpp}

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.h
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.h
@@ -166,11 +166,6 @@ SmallVector<int64_t> getAsIntegers(ArrayRef<OpFoldResult> foldResults);
 SmallVector<Value> getAsValues(OpBuilder &builder, Location loc,
                                ArrayRef<OpFoldResult> foldResults);
 
-/// Returns the constant index ops in `values`. `values` are expected to be
-/// constant operations.
-SmallVector<arith::ConstantIndexOp>
-getAsConstantIndexOps(ArrayRef<Value> values);
-
 /// If `value` is a constant multiple of `vector.vscale` (e.g. `%cst *
 /// vector.vscale`), return the multiplier (`%cst`). Otherwise, return
 /// `std::nullopt`.

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -351,6 +351,21 @@ SmallVector<Value> vector::getAsValues(OpBuilder &builder, Location loc,
   return values;
 }
 
+std::optional<int64_t> vector::getConstantVscaleMultiplier(Value value) {
+  if (value.getDefiningOp<vector::VectorScaleOp>())
+    return 1;
+  auto mul = value.getDefiningOp<arith::MulIOp>();
+  if (!mul)
+    return {};
+  auto lhs = mul.getLhs();
+  auto rhs = mul.getRhs();
+  if (lhs.getDefiningOp<vector::VectorScaleOp>())
+    return getConstantIntValue(rhs);
+  if (rhs.getDefiningOp<vector::VectorScaleOp>())
+    return getConstantIntValue(lhs);
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // CombiningKindAttr
 //===----------------------------------------------------------------------===//
@@ -5892,21 +5907,6 @@ LogicalResult CreateMaskOp::verify() {
         "must specify an operand for each result vector dimension");
   }
   return success();
-}
-
-std::optional<int64_t> vector::getConstantVscaleMultiplier(Value value) {
-  if (value.getDefiningOp<vector::VectorScaleOp>())
-    return 1;
-  auto mul = value.getDefiningOp<arith::MulIOp>();
-  if (!mul)
-    return {};
-  auto lhs = mul.getLhs();
-  auto rhs = mul.getRhs();
-  if (lhs.getDefiningOp<vector::VectorScaleOp>())
-    return getConstantIntValue(rhs);
-  if (rhs.getDefiningOp<vector::VectorScaleOp>())
-    return getConstantIntValue(lhs);
-  return {};
 }
 
 namespace {


### PR DESCRIPTION
* Removes the declaration of `getAsConstantIndexOps` - this method is
  neither defined nor used.
* Moves the definition of `getConstantVscaleMultiplier` near other
  helper hooks so that the order of definitions matches the order of
  declarations.
