### PR TITLE
[Clang] Change Attribute plugin to link clang-cpp like other examples

### DIFF
--- a/clang/examples/Attribute/CMakeLists.txt
+++ b/clang/examples/Attribute/CMakeLists.txt
@@ -1,11 +1,13 @@
 add_llvm_library(Attribute MODULE Attribute.cpp PLUGIN_TOOL clang)
 
 if(WIN32 OR CYGWIN)
-  target_link_libraries(Attribute PRIVATE
+  set(LLVM_LINK_COMPONENTS
+    Support
+  )
+  clang_target_link_libraries(Attribute PRIVATE
     clangAST
     clangBasic
     clangFrontend
     clangLex
-    LLVMSupport
     )
 endif()


### PR DESCRIPTION
Change the Attribute example plugin to use clang_target_link_libraries instead of target_link_libraries so libclang-cpp is linked when the CLANG_LINK_CLANG_DYLIB CMake option is used. 
This change will allow building the plugin on windows when building llvm and clang as a shared library with explicit visibility macros enabled.