### PR TITLE
[clang-tools-extra] Fix add_clang_library usage

### DIFF
--- a/clang-tools-extra/clang-apply-replacements/CMakeLists.txt
+++ b/clang-tools-extra/clang-apply-replacements/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangApplyReplacements
+add_clang_library(clangApplyReplacements STATIC
   lib/Tooling/ApplyReplacements.cpp
 
   DEPENDS

--- a/clang-tools-extra/clang-change-namespace/CMakeLists.txt
+++ b/clang-tools-extra/clang-change-namespace/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangChangeNamespace
+add_clang_library(clangChangeNamespace STATIC
   ChangeNamespace.cpp
 
   DEPENDS

--- a/clang-tools-extra/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/CMakeLists.txt
@@ -4,7 +4,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangDoc
+add_clang_library(clangDoc STATIC
   BitcodeReader.cpp
   BitcodeWriter.cpp
   ClangDoc.cpp

--- a/clang-tools-extra/clang-include-fixer/CMakeLists.txt
+++ b/clang-tools-extra/clang-include-fixer/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LLVM_LINK_COMPONENTS
   support
   )
 
-add_clang_library(clangIncludeFixer
+add_clang_library(clangIncludeFixer STATIC
   IncludeFixer.cpp
   IncludeFixerContext.cpp
   InMemorySymbolIndex.cpp

--- a/clang-tools-extra/clang-include-fixer/find-all-symbols/CMakeLists.txt
+++ b/clang-tools-extra/clang-include-fixer/find-all-symbols/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(findAllSymbols
+add_clang_library(findAllSymbols STATIC
   FindAllSymbols.cpp
   FindAllSymbolsAction.cpp
   FindAllMacros.cpp

--- a/clang-tools-extra/clang-include-fixer/plugin/CMakeLists.txt
+++ b/clang-tools-extra/clang-include-fixer/plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_clang_library(clangIncludeFixerPlugin
+add_clang_library(clangIncludeFixerPlugin STATIC
   IncludeFixerPlugin.cpp
 
   LINK_LIBS

--- a/clang-tools-extra/clang-move/CMakeLists.txt
+++ b/clang-tools-extra/clang-move/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangMove
+add_clang_library(clangMove STATIC
   Move.cpp
   HelperDeclRefGraph.cpp
 

--- a/clang-tools-extra/clang-query/CMakeLists.txt
+++ b/clang-tools-extra/clang-query/CMakeLists.txt
@@ -4,7 +4,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangQuery
+add_clang_library(clangQuery STATIC
   Query.cpp
   QueryParser.cpp
 

--- a/clang-tools-extra/clang-reorder-fields/CMakeLists.txt
+++ b/clang-tools-extra/clang-reorder-fields/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   support
 )
 
-add_clang_library(clangReorderFields
+add_clang_library(clangReorderFields STATIC
   ReorderFieldsAction.cpp
 
   DEPENDS

--- a/clang-tools-extra/clang-tidy/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/CMakeLists.txt
@@ -8,7 +8,7 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/clang-tidy-config.h)
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
-add_clang_library(clangTidy
+add_clang_library(clangTidy STATIC
   ClangTidy.cpp
   ClangTidyCheck.cpp
   ClangTidyModule.cpp

--- a/clang-tools-extra/clang-tidy/abseil/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/abseil/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangTidyAbseilModule
+add_clang_library(clangTidyAbseilModule STATIC
   AbseilTidyModule.cpp
   CleanupCtadCheck.cpp
   DurationAdditionCheck.cpp

--- a/clang-tools-extra/clang-tidy/altera/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/altera/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   support
   )
 
-add_clang_library(clangTidyAlteraModule
+add_clang_library(clangTidyAlteraModule STATIC
   AlteraTidyModule.cpp
   IdDependentBackwardBranchCheck.cpp
   KernelNameRestrictionCheck.cpp

--- a/clang-tools-extra/clang-tidy/android/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/android/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangTidyAndroidModule
+add_clang_library(clangTidyAndroidModule STATIC
   AndroidTidyModule.cpp
   CloexecAccept4Check.cpp
   CloexecAcceptCheck.cpp

--- a/clang-tools-extra/clang-tidy/boost/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/boost/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangTidyBoostModule
+add_clang_library(clangTidyBoostModule STATIC
   BoostTidyModule.cpp
   UseRangesCheck.cpp
   UseToStringCheck.cpp

--- a/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangTidyBugproneModule
+add_clang_library(clangTidyBugproneModule STATIC
   ArgumentCommentCheck.cpp
   AssertSideEffectCheck.cpp
   AssignmentInIfConditionCheck.cpp

--- a/clang-tools-extra/clang-tidy/cert/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/cert/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   FrontendOpenMP
   )
 
-add_clang_library(clangTidyCERTModule
+add_clang_library(clangTidyCERTModule STATIC
   CERTTidyModule.cpp
   CommandProcessorCheck.cpp
   DefaultOperatorNewAlignmentCheck.cpp

--- a/clang-tools-extra/clang-tidy/concurrency/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/concurrency/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyConcurrencyModule
+add_clang_library(clangTidyConcurrencyModule STATIC
   ConcurrencyTidyModule.cpp
   MtUnsafeCheck.cpp
   ThreadCanceltypeAsynchronousCheck.cpp

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyCppCoreGuidelinesModule
+add_clang_library(clangTidyCppCoreGuidelinesModule STATIC
   AvoidCapturingLambdaCoroutinesCheck.cpp
   AvoidConstOrRefDataMembersCheck.cpp
   AvoidDoWhileCheck.cpp

--- a/clang-tools-extra/clang-tidy/darwin/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/darwin/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyDarwinModule
+add_clang_library(clangTidyDarwinModule STATIC
   AvoidSpinlockCheck.cpp
   DarwinTidyModule.cpp
   DispatchOnceNonstaticCheck.cpp

--- a/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyFuchsiaModule
+add_clang_library(clangTidyFuchsiaModule STATIC
   DefaultArgumentsCallsCheck.cpp
   DefaultArgumentsDeclarationsCheck.cpp
   FuchsiaTidyModule.cpp

--- a/clang-tools-extra/clang-tidy/google/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/google/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyGoogleModule
+add_clang_library(clangTidyGoogleModule STATIC
   AvoidCStyleCastsCheck.cpp
   AvoidNSObjectNewCheck.cpp
   AvoidThrowingObjCExceptionCheck.cpp

--- a/clang-tools-extra/clang-tidy/hicpp/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/hicpp/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyHICPPModule
+add_clang_library(clangTidyHICPPModule STATIC
   ExceptionBaseclassCheck.cpp
   HICPPTidyModule.cpp
   IgnoredRemoveResultCheck.cpp

--- a/clang-tools-extra/clang-tidy/linuxkernel/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/linuxkernel/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyLinuxKernelModule
+add_clang_library(clangTidyLinuxKernelModule STATIC
   LinuxKernelTidyModule.cpp
   MustCheckErrsCheck.cpp
 

--- a/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyLLVMModule
+add_clang_library(clangTidyLLVMModule STATIC
   HeaderGuardCheck.cpp
   IncludeOrderCheck.cpp
   LLVMTidyModule.cpp

--- a/clang-tools-extra/clang-tidy/llvmlibc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/llvmlibc/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyLLVMLibcModule
+add_clang_library(clangTidyLLVMLibcModule STATIC
   CalleeNamespaceCheck.cpp
   ImplementationInNamespaceCheck.cpp
   InlineFunctionDeclCheck.cpp

--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -17,7 +17,7 @@ add_custom_command(
 add_custom_target(genconfusable DEPENDS Confusables.inc)
 set_target_properties(genconfusable PROPERTIES FOLDER "Clang Tools Extra/Sourcegenning")
 
-add_clang_library(clangTidyMiscModule
+add_clang_library(clangTidyMiscModule STATIC
   ConstCorrectnessCheck.cpp
   CoroutineHostileRAIICheck.cpp
   DefinitionsInHeadersCheck.cpp

--- a/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyModernizeModule
+add_clang_library(clangTidyModernizeModule STATIC
   AvoidBindCheck.cpp
   AvoidCArraysCheck.cpp
   ConcatNestedNamespacesCheck.cpp

--- a/clang-tools-extra/clang-tidy/mpi/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/mpi/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyMPIModule
+add_clang_library(clangTidyMPIModule STATIC
   BufferDerefCheck.cpp
   MPITidyModule.cpp
   TypeMismatchCheck.cpp

--- a/clang-tools-extra/clang-tidy/objc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/objc/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyObjCModule
+add_clang_library(clangTidyObjCModule STATIC
   AssertEquals.cpp
   AvoidNSErrorInitCheck.cpp
   DeallocInCategoryCheck.cpp

--- a/clang-tools-extra/clang-tidy/openmp/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/openmp/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyOpenMPModule
+add_clang_library(clangTidyOpenMPModule STATIC
   ExceptionEscapeCheck.cpp
   OpenMPTidyModule.cpp
   UseDefaultNoneCheck.cpp

--- a/clang-tools-extra/clang-tidy/performance/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/performance/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyPerformanceModule
+add_clang_library(clangTidyPerformanceModule STATIC
   AvoidEndlCheck.cpp
   EnumSizeCheck.cpp
   FasterStringFindCheck.cpp

--- a/clang-tools-extra/clang-tidy/plugin/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_clang_library(clangTidyPlugin
+add_clang_library(clangTidyPlugin STATIC
   ClangTidyPlugin.cpp
 
   LINK_LIBS

--- a/clang-tools-extra/clang-tidy/portability/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/portability/CMakeLists.txt
@@ -4,7 +4,7 @@ set(LLVM_LINK_COMPONENTS
   TargetParser
   )
 
-add_clang_library(clangTidyPortabilityModule
+add_clang_library(clangTidyPortabilityModule STATIC
   PortabilityTidyModule.cpp
   RestrictSystemIncludesCheck.cpp
   SIMDIntrinsicsCheck.cpp

--- a/clang-tools-extra/clang-tidy/readability/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/readability/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyReadabilityModule
+add_clang_library(clangTidyReadabilityModule STATIC
   AvoidConstParamsInDecls.cpp
   AvoidNestedConditionalOperatorCheck.cpp
   AvoidReturnWithVoidValueCheck.cpp

--- a/clang-tools-extra/clang-tidy/tool/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/tool/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LLVM_LINK_COMPONENTS
 # Needed by LLVM's CMake checks because this file defines multiple targets.
 set(LLVM_OPTIONAL_SOURCES ClangTidyMain.cpp ClangTidyToolMain.cpp)
 
-add_clang_library(clangTidyMain
+add_clang_library(clangTidyMain STATIC
   ClangTidyMain.cpp
 
   LINK_LIBS

--- a/clang-tools-extra/clang-tidy/utils/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/utils/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyUtils
+add_clang_library(clangTidyUtils STATIC
   Aliasing.cpp
   ASTUtils.cpp
   BracesAroundStatement.cpp

--- a/clang-tools-extra/clang-tidy/zircon/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/zircon/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_library(clangTidyZirconModule
+add_clang_library(clangTidyZirconModule STATIC
   TemporaryObjectsCheck.cpp
   ZirconTidyModule.cpp
 

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 include_directories(BEFORE "${CMAKE_CURRENT_BINARY_DIR}/../clang-tidy")
 include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/../include-cleaner/include")
 
-add_clang_library(clangDaemon
+add_clang_library(clangDaemon STATIC
   AST.cpp
   ASTSignals.cpp
   ClangdLSPServer.cpp

--- a/clang-tools-extra/clangd/index/remote/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/CMakeLists.txt
@@ -19,7 +19,7 @@ if (CLANGD_ENABLE_REMOTE)
   # target-local?
   add_definitions(-DGOOGLE_PROTOBUF_NO_RTTI=1)
 
-  add_clang_library(clangdRemoteIndex
+  add_clang_library(clangdRemoteIndex STATIC
     Client.cpp
 
     LINK_LIBS

--- a/clang-tools-extra/clangd/index/remote/marshalling/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/marshalling/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_clang_library(clangdRemoteMarshalling
+add_clang_library(clangdRemoteMarshalling STATIC
   Marshalling.cpp
 
   LINK_LIBS

--- a/clang-tools-extra/clangd/index/remote/unimplemented/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/unimplemented/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 # When compiled without Remote Index support, the real implementation index
 # client is not present. Users will get a notification about this when trying
 # to connect to remote index server instance.
-add_clang_library(clangdRemoteIndex
+add_clang_library(clangdRemoteIndex STATIC
   UnimplementedClient.cpp
 
   LINK_LIBS

--- a/clang-tools-extra/clangd/support/CMakeLists.txt
+++ b/clang-tools-extra/clangd/support/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB OR NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
   list(APPEND CLANGD_ATOMIC_LIB "atomic")
 endif()
 
-add_clang_library(clangdSupport
+add_clang_library(clangdSupport STATIC
   Bracket.cpp
   Cancellation.cpp
   Context.cpp

--- a/clang-tools-extra/clangd/tool/CMakeLists.txt
+++ b/clang-tools-extra/clangd/tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Needed by LLVM's CMake checks because this file defines multiple targets.
 set(LLVM_OPTIONAL_SOURCES ClangdToolMain.cpp)
 
-add_clang_library(clangdMain
+add_clang_library(clangdMain STATIC
   ClangdMain.cpp
   Check.cpp
   )

--- a/clang-tools-extra/clangd/xpc/CMakeLists.txt
+++ b/clang-tools-extra/clangd/xpc/CMakeLists.txt
@@ -14,12 +14,12 @@ set(LLVM_LINK_COMPONENTS
 # Needed by LLVM's CMake checks because this file defines multiple targets.
 set(LLVM_OPTIONAL_SOURCES Conversion.cpp XPCTransport.cpp)
 
-add_clang_library(clangdXpcJsonConversions
+add_clang_library(clangdXpcJsonConversions STATIC
   Conversion.cpp
   LINK_LIBS clangDaemon clangdSupport
   )
 
-add_clang_library(clangdXpcTransport
+add_clang_library(clangdXpcTransport STATIC
   XPCTransport.cpp
   LINK_LIBS clangDaemon clangdSupport clangdXpcJsonConversions
   DEPENDS ClangDriverOptions

--- a/clang-tools-extra/include-cleaner/lib/CMakeLists.txt
+++ b/clang-tools-extra/include-cleaner/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(LLVM_LINK_COMPONENTS Support)
 
-add_clang_library(clangIncludeCleaner
+add_clang_library(clangIncludeCleaner STATIC
   Analysis.cpp
   IncludeSpeller.cpp
   FindHeaders.cpp


### PR DESCRIPTION
If a add_clang_library call doesn't specify building as static or shared library they are implicitly added to the list static libraries that is linked in to clang-cpp shared library here.
https://github.com/llvm/llvm-project/blob/315ba7740663208f8bc45a7e4f145dc1df79500c/clang/cmake/modules/AddClang.cmake#L107
Because the clang-tools-extra libraries targets were declared after clang-cpp they by luck never got linked to clang-cpp.
This change is required for clang symbol visibility macros on windows to work correctly for clang tools since we need to distinguish if a target being built will be importing or exporting clang symbols from the clang-cpp DLL.