### PR TITLE
[Clang] - Add libclangSerialization to clang driver unittests

### DIFF
--- a/clang/unittests/Driver/CMakeLists.txt
+++ b/clang/unittests/Driver/CMakeLists.txt
@@ -22,4 +22,5 @@ clang_target_link_libraries(ClangDriverTests
   clangDriver
   clangBasic
   clangFrontend # For TextDiagnosticPrinter.
+  clangSerialization
   )


### PR DESCRIPTION
This PR is a fix for issue [#109328](https://github.com/llvm/llvm-project/issues/109328). libclangSerializaton.so is needed for building clang driver unittests after
https://github.com/llvm/llvm-project/pull/76838 was merged. Needed for builds with `BUILD_SHARED_LIBS=ON`