### PR TITLE
[libc++][test] fix redefinition of _LIBCPP_HARDENING_MODE

### DIFF
--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -392,6 +392,7 @@ DEFAULT_PARAMETERS = [
         actions=lambda hardening_mode: filter(
             None,
             [
+                AddCompileFlag("-U_LIBCPP_HARDENING_MODE")                                  if hardening_mode != "undefined" else None,
                 AddCompileFlag("-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE")      if hardening_mode == "none" else None,
                 AddCompileFlag("-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST")      if hardening_mode == "fast" else None,
                 AddCompileFlag("-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE") if hardening_mode == "extensive" else None,


### PR DESCRIPTION
-D_LIBCPP_HARDENING_MODE may be set in clang config files or through CXXFLAGS

This was the case for us on Gentoo.