### PR TITLE
[libc][wchar] Move wchar's types to proxy headers.

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -161,4 +161,13 @@ add_proxy_header_library(
     libc.include.sys_auxv
 )
 
+add_proxy_header_library(
+  wchar_macros
+  HDRS
+    wchar_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-macros.wchar_macros
+    libc.include.wchar
+)
+
 add_subdirectory(types)

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -161,10 +161,14 @@ add_proxy_header_library(
     libc.include.sys_auxv
 )
 
+add_header_library(wchar_overlay HDRS wchar_overlay.h)
+
 add_proxy_header_library(
   wchar_macros
   HDRS
     wchar_macros.h
+  DEPENDS
+    .wchar_overlay
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.wchar_macros
     libc.include.wchar

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -230,6 +230,8 @@ add_proxy_header_library(
   wchar_t
   HDRS
     wchar_t.h
+  DEPENDS
+    libc.hdr.wchar_overlay
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.wchar_t
     libc.include.wchar
@@ -239,6 +241,8 @@ add_proxy_header_library(
   wint_t
   HDRS
     wint_t.h
+  DEPENDS
+    libc.hdr.wchar_overlay
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.wint_t
     libc.include.wchar

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -199,7 +199,6 @@ add_proxy_header_library(
     libc.include.setjmp
 )
 
-
 add_proxy_header_library(
   struct_msghdr
   HDRS
@@ -225,4 +224,22 @@ add_proxy_header_library(
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.socklen_t
     libc.include.sys_socket
+)
+
+add_proxy_header_library(
+  wchar_t
+  HDRS
+    wchar_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.wchar_t
+    libc.include.wchar
+)
+
+add_proxy_header_library(
+  wint_t
+  HDRS
+    wint_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.wint_t
+    libc.include.wchar
 )

--- a/libc/hdr/types/wchar_t.h
+++ b/libc/hdr/types/wchar_t.h
@@ -1,0 +1,50 @@
+//===-- Definition of wchar_t.h -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_WCHAR_T_H
+#define LLVM_LIBC_HDR_TYPES_WCHAR_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/wchar_t.h"
+
+#else // overlay mode
+
+// glibc <wchar.h header might provide extern inline definitions for few
+// functions, causing external alias errors.  They are guarded by
+// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
+// macro by defining `__NO_INLINE__` before including <wchar.h>.
+// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
+// with `_FORTIFY_SOURCE`.
+
+#ifdef _FORTIFY_SOURCE
+#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
+#undef _FORTIFY_SOURCE
+#endif
+
+#ifndef __NO_INLINE__
+#define __NO_INLINE__ 1
+#define LIBC_SET_NO_INLINE
+#endif
+
+#include <wchar.h>
+
+#ifdef LIBC_OLD_FORTIFY_SOURCE
+#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
+#undef LIBC_OLD_FORTIFY_SOURCE
+#endif
+
+#ifdef LIBC_SET_NO_INLINE
+#undef __NO_INLINE__
+#undef LIBC_SET_NO_INLINE
+#endif
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_WCHAR_T_H

--- a/libc/hdr/types/wchar_t.h
+++ b/libc/hdr/types/wchar_t.h
@@ -16,34 +16,7 @@
 
 #else // overlay mode
 
-// glibc <wchar.h header might provide extern inline definitions for few
-// functions, causing external alias errors.  They are guarded by
-// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
-// macro by defining `__NO_INLINE__` before including <wchar.h>.
-// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
-// with `_FORTIFY_SOURCE`.
-
-#ifdef _FORTIFY_SOURCE
-#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
-#undef _FORTIFY_SOURCE
-#endif
-
-#ifndef __NO_INLINE__
-#define __NO_INLINE__ 1
-#define LIBC_SET_NO_INLINE
-#endif
-
-#include <wchar.h>
-
-#ifdef LIBC_OLD_FORTIFY_SOURCE
-#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
-#undef LIBC_OLD_FORTIFY_SOURCE
-#endif
-
-#ifdef LIBC_SET_NO_INLINE
-#undef __NO_INLINE__
-#undef LIBC_SET_NO_INLINE
-#endif
+#include "hdr/wchar_overlay.h"
 
 #endif // LLVM_LIBC_FULL_BUILD
 

--- a/libc/hdr/types/wint_t.h
+++ b/libc/hdr/types/wint_t.h
@@ -16,34 +16,7 @@
 
 #else // overlay mode
 
-// glibc <wchar.h header might provide extern inline definitions for few
-// functions, causing external alias errors.  They are guarded by
-// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
-// macro by defining `__NO_INLINE__` before including <wchar.h>.
-// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
-// with `_FORTIFY_SOURCE`.
-
-#ifdef _FORTIFY_SOURCE
-#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
-#undef _FORTIFY_SOURCE
-#endif
-
-#ifndef __NO_INLINE__
-#define __NO_INLINE__ 1
-#define LIBC_SET_NO_INLINE
-#endif
-
-#include <wchar.h>
-
-#ifdef LIBC_OLD_FORTIFY_SOURCE
-#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
-#undef LIBC_OLD_FORTIFY_SOURCE
-#endif
-
-#ifdef LIBC_SET_NO_INLINE
-#undef __NO_INLINE__
-#undef LIBC_SET_NO_INLINE
-#endif
+#include "hdr/wchar_overlay.h"
 
 #endif // LLVM_LIBC_FULL_BUILD
 

--- a/libc/hdr/types/wint_t.h
+++ b/libc/hdr/types/wint_t.h
@@ -1,0 +1,50 @@
+//===-- Definition of wint_t.h --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_WINT_T_H
+#define LLVM_LIBC_HDR_TYPES_WINT_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/wint_t.h"
+
+#else // overlay mode
+
+// glibc <wchar.h header might provide extern inline definitions for few
+// functions, causing external alias errors.  They are guarded by
+// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
+// macro by defining `__NO_INLINE__` before including <wchar.h>.
+// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
+// with `_FORTIFY_SOURCE`.
+
+#ifdef _FORTIFY_SOURCE
+#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
+#undef _FORTIFY_SOURCE
+#endif
+
+#ifndef __NO_INLINE__
+#define __NO_INLINE__ 1
+#define LIBC_SET_NO_INLINE
+#endif
+
+#include <wchar.h>
+
+#ifdef LIBC_OLD_FORTIFY_SOURCE
+#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
+#undef LIBC_OLD_FORTIFY_SOURCE
+#endif
+
+#ifdef LIBC_SET_NO_INLINE
+#undef __NO_INLINE__
+#undef LIBC_SET_NO_INLINE
+#endif
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_WINT_T_H

--- a/libc/hdr/wchar_macros.h
+++ b/libc/hdr/wchar_macros.h
@@ -15,34 +15,7 @@
 
 #else // Overlay mode
 
-// glibc <wchar.h header might provide extern inline definitions for few
-// functions, causing external alias errors.  They are guarded by
-// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
-// macro by defining `__NO_INLINE__` before including <wchar.h>.
-// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
-// with `_FORTIFY_SOURCE`.
-
-#ifdef _FORTIFY_SOURCE
-#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
-#undef _FORTIFY_SOURCE
-#endif
-
-#ifndef __NO_INLINE__
-#define __NO_INLINE__ 1
-#define LIBC_SET_NO_INLINE
-#endif
-
-#include <wchar.h>
-
-#ifdef LIBC_OLD_FORTIFY_SOURCE
-#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
-#undef LIBC_OLD_FORTIFY_SOURCE
-#endif
-
-#ifdef LIBC_SET_NO_INLINE
-#undef __NO_INLINE__
-#undef LIBC_SET_NO_INLINE
-#endif
+#include "hdr/wchar_overlay.h"
 
 #endif // LLVM_LIBC_FULL_BUILD
 

--- a/libc/hdr/wchar_macros.h
+++ b/libc/hdr/wchar_macros.h
@@ -1,0 +1,49 @@
+//===-- Definition of macros from wchar.h ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_WCHAR_MACROS_H
+#define LLVM_LIBC_HDR_WCHAR_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/wchar-macros.h"
+
+#else // Overlay mode
+
+// glibc <wchar.h header might provide extern inline definitions for few
+// functions, causing external alias errors.  They are guarded by
+// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
+// macro by defining `__NO_INLINE__` before including <wchar.h>.
+// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
+// with `_FORTIFY_SOURCE`.
+
+#ifdef _FORTIFY_SOURCE
+#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
+#undef _FORTIFY_SOURCE
+#endif
+
+#ifndef __NO_INLINE__
+#define __NO_INLINE__ 1
+#define LIBC_SET_NO_INLINE
+#endif
+
+#include <wchar.h>
+
+#ifdef LIBC_OLD_FORTIFY_SOURCE
+#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
+#undef LIBC_OLD_FORTIFY_SOURCE
+#endif
+
+#ifdef LIBC_SET_NO_INLINE
+#undef __NO_INLINE__
+#undef LIBC_SET_NO_INLINE
+#endif
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_WCHAR_MACROS_H

--- a/libc/hdr/wchar_overlay.h
+++ b/libc/hdr/wchar_overlay.h
@@ -1,0 +1,47 @@
+//===-- Including wchar.h in overlay mode ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_WCHAR_OVERLAY_H
+#define LLVM_LIBC_HDR_WCHAR_OVERLAY_H
+
+#ifdef LIBC_FULL_BUILD
+#error "This header should only be included in overlay mode"
+#endif
+
+// Overlay mode
+
+// glibc <wchar.h header might provide extern inline definitions for few
+// functions, causing external alias errors.  They are guarded by
+// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
+// macro by defining `__NO_INLINE__` before including <wchar.h>.
+// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
+// with `_FORTIFY_SOURCE`.
+
+#ifdef _FORTIFY_SOURCE
+#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
+#undef _FORTIFY_SOURCE
+#endif
+
+#ifndef __NO_INLINE__
+#define __NO_INLINE__ 1
+#define LIBC_SET_NO_INLINE
+#endif
+
+#include <wchar.h>
+
+#ifdef LIBC_OLD_FORTIFY_SOURCE
+#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
+#undef LIBC_OLD_FORTIFY_SOURCE
+#endif
+
+#ifdef LIBC_SET_NO_INLINE
+#undef __NO_INLINE__
+#undef LIBC_SET_NO_INLINE
+#endif
+
+#endif // LLVM_LIBC_HDR_WCHAR_OVERLAY_H

--- a/libc/include/llvm-libc-types/wchar_t.h
+++ b/libc/include/llvm-libc-types/wchar_t.h
@@ -9,11 +9,6 @@
 #ifndef LLVM_LIBC_TYPES_WCHAR_T_H
 #define LLVM_LIBC_TYPES_WCHAR_T_H
 
-// Since __need_wchar_t is defined, we get the definition of wchar_t from the
-// standalone C header stddef.h. Also, because __need_wchar_t is defined,
-// including stddef.h will pull only the type wchar_t and nothing else.
-#define __need_wchar_t
-#include <stddef.h>
-#undef __need_wchar_t
+typedef __WCHAR_TYPE__ wchar_t;
 
 #endif // LLVM_LIBC_TYPES_WCHAR_T_H

--- a/libc/include/llvm-libc-types/wint_t.h
+++ b/libc/include/llvm-libc-types/wint_t.h
@@ -9,11 +9,6 @@
 #ifndef LLVM_LIBC_TYPES_WINT_T_H
 #define LLVM_LIBC_TYPES_WINT_T_H
 
-// Since __need_wint_t is defined, we get the definition of wint_t from the
-// standalone C header stddef.h. Also, because __need_wint_t is defined,
-// including stddef.h will pull only the type wint_t and nothing else.
-#define __need_wint_t
-#include <stddef.h>
-#undef __need_wint_t
+typedef __WINT_TYPE__ wint_t;
 
 #endif // LLVM_LIBC_TYPES_WINT_T_H

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -117,6 +117,8 @@ add_header_library(
   wctype_utils
   HDRS
     wctype_utils.h
+  DEPENDS
+    libc.hdr.types.wint_t
 )
 
 add_header_library(

--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -9,13 +9,10 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_WCTYPE_UTILS_H
 #define LLVM_LIBC_SRC___SUPPORT_WCTYPE_UTILS_H
 
+#include "hdr/types/wint_t.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/config.h"
-
-#define __need_wint_t
-#define __need_wchar_t
-#include <stddef.h> // needed for wint_t and wchar_t
 
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -6,7 +6,6 @@ add_entrypoint_object(
   HDRS
     wctob.h
   DEPENDS
-    libc.include.stdio
-    libc.include.wchar
+    libc.hdr.types.wint_t
     libc.src.__support.wctype_utils
 )

--- a/libc/src/wchar/btowc.cpp
+++ b/libc/src/wchar/btowc.cpp
@@ -12,6 +12,7 @@
 #include "src/__support/wctype_utils.h"
 
 #include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/wint_t.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/wchar/btowc.h
+++ b/libc/src/wchar/btowc.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_WCHAR_BTOWC_H
 #define LLVM_LIBC_SRC_WCHAR_BTOWC_H
 
+#include "hdr/types/wint_t.h"
 #include "src/__support/macros/config.h"
-#include <wchar.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/wchar/wctob.cpp
+++ b/libc/src/wchar/wctob.cpp
@@ -12,6 +12,7 @@
 #include "src/__support/wctype_utils.h"
 
 #include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/wint_t.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/wchar/wctob.h
+++ b/libc/src/wchar/wctob.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_WCHAR_WCTOB_H
 #define LLVM_LIBC_SRC_WCHAR_WCTOB_H
 
+#include "hdr/types/wint_t.h"
 #include "src/__support/macros/config.h"
-#include <wchar.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/src/wchar/btowc_test.cpp
+++ b/libc/test/src/wchar/btowc_test.cpp
@@ -6,10 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <wchar.h> //for WEOF
-
+#include "hdr/wchar_macros.h" // for WEOF
 #include "src/wchar/btowc.h"
-
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcBtowc, DefaultLocale) {


### PR DESCRIPTION
Also protect against extern inline function definitions added when building with gcc: https://github.com/llvm/llvm-project/issues/60481.