### PR TITLE
[analyzer] [MallocChecker] Fix Store modification in `checkPreCall`

### DIFF
--- a/clang/test/Analysis/NewDelete-intersections.mm
+++ b/clang/test/Analysis/NewDelete-intersections.mm
@@ -17,6 +17,7 @@
 
 #include "Inputs/system-header-simulator-cxx.h"
 #include "Inputs/system-header-simulator-objc.h"
+#include "Inputs/system-header-simulator.h"
 
 typedef __typeof__(sizeof(int)) size_t;
 extern "C" void *malloc(size_t);
@@ -85,4 +86,12 @@ void testStandardPlacementNewAfterDelete() {
   int *p = new int;
   delete p;
   p = new (p) int; // newdelete-warning{{Use of memory after it is freed}}
+}
+
+void testGetLine(FILE *f) {
+  char *buffer = (char *)malloc(10);
+  char *old = buffer;
+  size_t n = 0;
+  getline(&buffer, &n, f);
+  int a = *old; // no-warn
 }


### PR DESCRIPTION
This is small follow-up for #106081

While trying to add sanity check for `Enviroment` and `Store` being consistent during `checkPostCall` and `checkPreCall` I found out that `MallocChecker` still violates that rule. 

The problem lies in `FreeMemAux`, which invalidates freed region while being called from `preGetdelim`. This invalidation was added to prevent "use of uninitialized memory" for malloc and friends while `unix.Malloc` is disabled.

Fix adds another bool flag to `FreeMemAux` to control invalidation from call-site and set it to false in `preGetdelim`

