### PR TITLE
[libc] Put bind back, fix gcc build

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1042,6 +1042,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sys/socket.h entrypoints
     libc.src.sys.socket.socket
+    libc.src.sys.socket.bind
     libc.src.sys.socket.socketpair
     libc.src.sys.socket.send
     libc.src.sys.socket.sendto

--- a/libc/include/llvm-libc-types/struct_sockaddr.h
+++ b/libc/include/llvm-libc-types/struct_sockaddr.h
@@ -15,7 +15,7 @@ struct sockaddr {
   sa_family_t sa_family;
   // sa_data is a variable length array. It is provided with a length of one
   // here as a placeholder.
-  char sa_data[];
+  char sa_data[1];
 };
 
 #endif // LLVM_LIBC_TYPES_STRUCT_SOCKADDR_H

--- a/libc/src/sys/socket/CMakeLists.txt
+++ b/libc/src/sys/socket/CMakeLists.txt
@@ -10,6 +10,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  bind
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.bind
+)
+
+add_entrypoint_object(
   socketpair
   ALIAS
   DEPENDS

--- a/libc/src/sys/socket/bind.h
+++ b/libc/src/sys/socket/bind.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bind --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SYS_SOCKET_BIND_H
+#define LLVM_LIBC_SRC_SYS_SOCKET_BIND_H
+
+#include "hdr/types/socklen_t.h"
+#include "hdr/types/struct_sockaddr.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int bind(int socket, const struct sockaddr *address, socklen_t address_len);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SYS_SOCKET_BIND_H

--- a/libc/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/src/sys/socket/linux/CMakeLists.txt
@@ -12,6 +12,19 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  bind
+  SRCS
+    bind.cpp
+  HDRS
+    ../bind.h
+  DEPENDS
+    libc.include.sys_syscall
+    libc.include.sys_socket
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
   socketpair
   SRCS
     socketpair.cpp

--- a/libc/src/sys/socket/linux/bind.cpp
+++ b/libc/src/sys/socket/linux/bind.cpp
@@ -1,0 +1,44 @@
+//===-- Linux implementation of bind --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sys/socket/bind.h"
+
+#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/common.h"
+
+#include "src/__support/macros/config.h"
+#include "src/errno/libc_errno.h"
+
+#include <linux/net.h>   // For SYS_SOCKET socketcall number.
+#include <sys/syscall.h> // For syscall numbers.
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, bind,
+                   (int socket, const struct sockaddr *address,
+                    socklen_t address_len)) {
+#ifdef SYS_bind
+  int ret =
+      LIBC_NAMESPACE::syscall_impl<int>(SYS_bind, socket, address, address_len);
+#elif defined(SYS_socketcall)
+  unsigned long sockcall_args[3] = {static_cast<unsigned long>(socket),
+                                    reinterpret_cast<unsigned long>(address),
+                                    static_cast<unsigned long>(address_len)};
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_socketcall, SYS_BIND,
+                                              sockcall_args);
+#else
+#error "socket and socketcall syscalls unavailable for this platform."
+#endif
+  if (ret < 0) {
+    libc_errno = -ret;
+    return -1;
+  }
+  return ret;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -14,6 +14,21 @@ add_libc_unittest(
 )
 
 add_libc_unittest(
+  bind_test
+  SUITE
+    libc_sys_socket_unittests
+  SRCS
+    bind_test.cpp
+  DEPENDS
+    libc.include.sys_socket
+    libc.src.errno.errno
+    libc.src.sys.socket.socket
+    libc.src.sys.socket.bind
+    libc.src.stdio.remove
+    libc.src.unistd.close
+)
+
+add_libc_unittest(
   socketpair_test
   SUITE
     libc_sys_socket_unittests

--- a/libc/test/src/sys/socket/linux/bind_test.cpp
+++ b/libc/test/src/sys/socket/linux/bind_test.cpp
@@ -1,0 +1,54 @@
+//===-- Unittests for bind ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sys/socket/bind.h"
+#include "src/sys/socket/socket.h"
+
+#include "src/stdio/remove.h"
+#include "src/unistd/close.h"
+
+#include "src/errno/libc_errno.h"
+#include "test/UnitTest/Test.h"
+
+#include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM
+
+TEST(LlvmLibcSocketTest, BindLocalSocket) {
+
+  const char *FILENAME = "bind_file.test";
+  auto SOCK_PATH = libc_make_test_file_path(FILENAME);
+
+  int sock = LIBC_NAMESPACE::socket(AF_UNIX, SOCK_DGRAM, 0);
+  ASSERT_GE(sock, 0);
+  ASSERT_ERRNO_SUCCESS();
+
+  struct sockaddr_un my_addr;
+
+  my_addr.sun_family = AF_UNIX;
+  unsigned int i = 0;
+  for (;
+       SOCK_PATH[i] != '\0' && (i < sizeof(sockaddr_un) - sizeof(sa_family_t));
+       ++i)
+    my_addr.sun_path[i] = SOCK_PATH[i];
+  my_addr.sun_path[i] = '\0';
+
+  // It's important that the path fits in the struct, if it doesn't then we
+  // can't try to bind to the file.
+  ASSERT_LT(
+      i, static_cast<unsigned int>(sizeof(sockaddr_un) - sizeof(sa_family_t)));
+
+  int result =
+      LIBC_NAMESPACE::bind(sock, reinterpret_cast<struct sockaddr *>(&my_addr),
+                           sizeof(struct sockaddr_un));
+
+  ASSERT_EQ(result, 0);
+  ASSERT_ERRNO_SUCCESS();
+
+  LIBC_NAMESPACE::close(sock);
+
+  LIBC_NAMESPACE::remove(SOCK_PATH);
+}


### PR DESCRIPTION
Fixes #106467.
Bind was accidentally removed while trying to clean up functions that
didn't end up being needed. The GCC issue was just a warning treated as
an error.
