### PR TITLE
[hwasan] Allow stack traces even when fixed shadow is used

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1901,7 +1901,7 @@ void HWAddressSanitizer::ShadowMapping::init(Triple &TargetTriple,
   } else if (ClEnableKhwasan || InstrumentWithCalls) {
     InGlobal = false;
     InTls = false;
-    Offset = optOr(ClMappingOffset, (unsigned long)0);
+    Offset = optOr(ClMappingOffset, 0UL);
     WithFrameRecord = false;
   } else if (ClMappingOffset.getNumOccurrences() > 0) {
     InGlobal = false;

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1340,7 +1340,8 @@ Value *HWAddressSanitizer::getFrameRecordInfo(IRBuilder<> &IRB) {
 }
 
 void HWAddressSanitizer::emitPrologue(IRBuilder<> &IRB, bool WithFrameRecord) {
-  if (!Mapping.InTls || (Mapping.Offset != 0 && Mapping.Offset != kDynamicShadowSentinel))
+  if (!Mapping.InTls ||
+      (Mapping.Offset != 0 && Mapping.Offset != kDynamicShadowSentinel))
     ShadowBase = getShadowNonTls(IRB);
   else if (!WithFrameRecord && TargetTriple.isAndroid())
     ShadowBase = getDynamicShadowIfunc(IRB);

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1925,4 +1925,3 @@ void HWAddressSanitizer::ShadowMapping::init(Triple &TargetTriple,
     WithFrameRecord = false;
   }
 }
-

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1901,7 +1901,7 @@ void HWAddressSanitizer::ShadowMapping::init(Triple &TargetTriple,
   } else if (ClEnableKhwasan || InstrumentWithCalls) {
     InGlobal = false;
     InTls = false;
-    Offset = optOr(ClMappingOffset, 0UL);
+    Offset = optOr<uint64_t>(ClMappingOffset, (uint64_t)0);
     WithFrameRecord = false;
   } else if (ClMappingOffset.getNumOccurrences() > 0) {
     InGlobal = false;

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1901,10 +1901,7 @@ void HWAddressSanitizer::ShadowMapping::init(Triple &TargetTriple,
   } else if (ClEnableKhwasan || InstrumentWithCalls) {
     InGlobal = false;
     InTls = false;
-    if (ClMappingOffset.getNumOccurrences() > 0)
-      Offset = ClMappingOffset;
-    else
-      Offset = 0;
+    Offset = optOr(ClMappingOffset, (unsigned long)0);
     WithFrameRecord = false;
   } else if (ClMappingOffset.getNumOccurrences() > 0) {
     InGlobal = false;
@@ -1928,3 +1925,4 @@ void HWAddressSanitizer::ShadowMapping::init(Triple &TargetTriple,
     WithFrameRecord = false;
   }
 }
+


### PR DESCRIPTION
Previously, fixed shadow implied !InTls, and !InTls implied no stack traces, but InTls implied it would not use a fixed shadow. This patch changes fixed shadow to be compatible with stack traces.

It maintains the legacy behavior for KHWAsan || InstrumentWithCalls.