### PR TITLE
[flang] Fix edge case regression

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -1626,8 +1626,8 @@ void SubprogramSymbolCollector::Collect() {
         // &/or derived type that it shadows may be needed.
         const Symbol *spec{generic->specific()};
         const Symbol *dt{generic->derivedType()};
-        needed = needed || (spec && useSet_.count(*spec) > 0) ||
-            (dt && useSet_.count(*dt) > 0);
+        needed = needed || (spec && useSet_.count(spec->GetUltimate()) > 0) ||
+            (dt && useSet_.count(dt->GetUltimate()) > 0);
       } else if (const auto *subp{ultimate.detailsIf<SubprogramDetails>()}) {
         const Symbol *interface { subp->moduleInterface() };
         needed = needed || (interface && useSet_.count(*interface) > 0);

--- a/flang/test/Semantics/modfile69.f90
+++ b/flang/test/Semantics/modfile69.f90
@@ -1,0 +1,44 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+module m1
+  type foo
+  end type
+  interface foo
+  end interface
+end
+
+!Expect: m1.mod
+!module m1
+!type::foo
+!end type
+!interface foo
+!end interface
+!end
+
+module m2
+  use m1, only: bar => foo
+end
+
+!Expect: m2.mod
+!module m2
+!use m1,only:bar=>foo
+!use m1,only:bar=>foo
+!interface bar
+!end interface
+!end
+
+module m3
+ contains
+  subroutine sub(x)
+    use m2
+    type(bar) x
+  end
+end
+
+!Expect: m3.mod
+!module m3
+!contains
+!subroutine sub(x)
+!use m2,only:bar
+!type(bar)::x
+!end
+!end


### PR DESCRIPTION
A recent fix to the emission of derived type names to module files exposed a regression in the case of a derived type that (1) has the same name as a generic procedure interface and (2) has undergone renaming through USE association before (3) being used in a declaration significant to a module procedure interface.  Fix.