### PR TITLE
[SandboxVec][InstrInterval] Add ArrayRef constructor

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/InstrInterval.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/InstrInterval.h
@@ -80,6 +80,17 @@ public:
     assert((FromI == ToI || FromI->comesBefore(ToI)) &&
            "FromI should come before TopI!");
   }
+  InstrInterval(ArrayRef<Instruction *> Instrs) {
+    assert(!Instrs.empty() && "Expected non-empty Instrs!");
+    FromI = Instrs[0];
+    ToI = Instrs[0];
+    for (auto *I : drop_begin(Instrs)) {
+      if (I->comesBefore(FromI))
+        FromI = I;
+      else if (ToI->comesBefore(I))
+        ToI = I;
+    }
+  }
   bool empty() const {
     assert(((FromI == nullptr && ToI == nullptr) ||
             (FromI != nullptr && ToI != nullptr)) &&
@@ -92,6 +103,8 @@ public:
     return (FromI == I || FromI->comesBefore(I)) &&
            (I == ToI || I->comesBefore(ToI));
   }
+  Instruction *top() const { return FromI; }
+  Instruction *bottom() const { return ToI; }
 
   using iterator =
       InstrIntervalIterator<sandboxir::Instruction &, InstrInterval>;

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/InstrIntervalTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/InstrIntervalTest.cpp
@@ -50,6 +50,26 @@ define void @foo(i8 %v0) {
 #ifndef NDEBUG
   EXPECT_DEATH(sandboxir::InstrInterval(I1, I0), ".*before.*");
 #endif // NDEBUG
+  // Check InstrInterval(ArrayRef), from(), to().
+  {
+    sandboxir::InstrInterval Interval(
+        SmallVector<sandboxir::Instruction *>({I0, Ret}));
+    EXPECT_EQ(Interval.top(), I0);
+    EXPECT_EQ(Interval.bottom(), Ret);
+  }
+  {
+    sandboxir::InstrInterval Interval(
+        SmallVector<sandboxir::Instruction *>({Ret, I0}));
+    EXPECT_EQ(Interval.top(), I0);
+    EXPECT_EQ(Interval.bottom(), Ret);
+  }
+  {
+    sandboxir::InstrInterval Interval(
+        SmallVector<sandboxir::Instruction *>({I0, I0}));
+    EXPECT_EQ(Interval.top(), I0);
+    EXPECT_EQ(Interval.bottom(), I0);
+  }
+
   // Check empty().
   EXPECT_FALSE(Interval.empty());
   sandboxir::InstrInterval Empty;


### PR DESCRIPTION
The new constructor creates an InstrInterval from an ArrayRef<Instruction *>. This patch also adds top() and bottom() getters.