### PR TITLE
[Sema] Avoid repeated hash lookups (NFC)

### DIFF
--- a/clang/include/clang/Sema/SemaObjC.h
+++ b/clang/include/clang/Sema/SemaObjC.h
@@ -218,6 +218,7 @@ public:
     std::pair<iterator, bool> insert(std::pair<Selector, Lists> &&Val) {
       return Methods.insert(Val);
     }
+    Lists &operator[](Selector Key) { return Methods[Key]; }
     int count(Selector Sel) const { return Methods.count(Sel); }
     bool empty() const { return Methods.empty(); }
 

--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -3441,16 +3441,11 @@ void SemaObjC::AddMethodToGlobalPool(ObjCMethodDecl *Method, bool impl,
   if (SemaRef.ExternalSource)
     ReadMethodPool(Method->getSelector());
 
-  GlobalMethodPool::iterator Pos = MethodPool.find(Method->getSelector());
-  if (Pos == MethodPool.end())
-    Pos = MethodPool
-              .insert(std::make_pair(Method->getSelector(),
-                                     GlobalMethodPool::Lists()))
-              .first;
+  auto &Lists = MethodPool[Method->getSelector()];
 
   Method->setDefined(impl);
 
-  ObjCMethodList &Entry = instance ? Pos->second.first : Pos->second.second;
+  ObjCMethodList &Entry = instance ? Lists.first : Lists.second;
   addMethodToGlobalList(&Entry, Method);
 }
 


### PR DESCRIPTION
GlobalMethodPool, the type of MethodPool, is a type wrapping DenseMap
and exposes only a subset of the DenseMap methods.

This patch adds operator[] to GlobalMethodPool so that we can avoid
repeated hash lookups.  I don't bother using references or rvalue
references in operator[] because Selector, the key type, is small and
trivially copyable.  Note that Selector is a class that wraps a
PointerUnion.
