### PR TITLE
[RISCV] Set the isMoveReg flag for FMV_X_W

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
@@ -388,11 +388,11 @@ foreach Ext = FExts in {
 } // foreach Ext = FExts
 
 let Predicates = [HasStdExtF], mayRaiseFPException = 0,
-    IsSignExtendingOpW = 1 in
+    IsSignExtendingOpW = 1, isMoveReg = 1 in
 def FMV_X_W : FPUnaryOp_r<0b1110000, 0b00000, 0b000, GPR, FPR32, "fmv.x.w">,
               Sched<[WriteFMovF32ToI32, ReadFMovF32ToI32]>;
 
-let Predicates = [HasStdExtF], mayRaiseFPException = 0 in
+let Predicates = [HasStdExtF], mayRaiseFPException = 0, isMoveReg = 1 in
 def FMV_W_X : FPUnaryOp_r<0b1111000, 0b00000, 0b000, FPR32, GPR, "fmv.w.x">,
               Sched<[WriteFMovI32ToF32, ReadFMovI32ToF32]>;
 

--- a/llvm/test/CodeGen/RISCV/select-const.ll
+++ b/llvm/test/CodeGen/RISCV/select-const.ll
@@ -102,8 +102,6 @@ define float @select_const_fp(i1 zeroext %a) nounwind {
 ; RV32IF-NEXT:  .LBB4_2:
 ; RV32IF-NEXT:    lui a0, 263168
 ; RV32IF-NEXT:  .LBB4_3:
-; RV32IF-NEXT:    fmv.w.x fa5, a0
-; RV32IF-NEXT:    fmv.x.w a0, fa5
 ; RV32IF-NEXT:    ret
 ;
 ; RV64I-LABEL: select_const_fp:
@@ -125,8 +123,6 @@ define float @select_const_fp(i1 zeroext %a) nounwind {
 ; RV64IFD-NEXT:  .LBB4_2:
 ; RV64IFD-NEXT:    lui a0, 263168
 ; RV64IFD-NEXT:  .LBB4_3:
-; RV64IFD-NEXT:    fmv.w.x fa5, a0
-; RV64IFD-NEXT:    fmv.x.w a0, fa5
 ; RV64IFD-NEXT:    ret
   %1 = select i1 %a, float 3.0, float 4.0
   ret float %1


### PR DESCRIPTION
It seems that other `mv` instructions should do this, but llvm's tests have not changed.