### PR TITLE
[RISCV][TTI] Fix potential crash of using dyn_cast() in getIntrinsicInstrCost() NFC.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1040,7 +1040,7 @@ RISCVTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     Intrinsic::ID IID = ICA.getID();
     std::optional<unsigned> FOp = VPIntrinsic::getFunctionalOpcodeForVP(IID);
     // We can only handle vp_cmp intrinsics with underlying instructions.
-    if(!ICA.getInst())
+    if (!ICA.getInst())
       break;
 
     assert(FOp);

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1039,12 +1039,12 @@ RISCVTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
   case Intrinsic::vp_fcmp: {
     Intrinsic::ID IID = ICA.getID();
     std::optional<unsigned> FOp = VPIntrinsic::getFunctionalOpcodeForVP(IID);
-    auto *UI = dyn_cast<VPCmpIntrinsic>(ICA.getInst());
-
     // We can only handle vp_cmp intrinsics with underlying instructions.
-    if (!UI)
+    if(!ICA.getInst())
       break;
+
     assert(FOp);
+    auto *UI = cast<VPCmpIntrinsic>(ICA.getInst());
     return getCmpSelInstrCost(*FOp, ICA.getArgTypes()[0], ICA.getReturnType(),
                               UI->getPredicate(), CostKind);
   }


### PR DESCRIPTION
This patch fix the potential crash about using dyn_cast in `vp_cmp` which is  same as #109313.

Check if the IntrinsicCostAttrubute contains underlying instruction first and cast to the VPCmpIntrinsic.