### PR TITLE
[unittests] Use {} instead of std::nullopt to initialize empty ArrayRef

### DIFF
--- a/llvm/unittests/CodeGen/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/CodeGen/AArch64SelectionDAGTest.cpp
@@ -709,7 +709,7 @@ TEST_F(AArch64SelectionDAGTest, ReplaceAllUsesWith) {
   EXPECT_FALSE(DAG->getHeapAllocSite(N2.getNode()));
   EXPECT_FALSE(DAG->getNoMergeSiteInfo(N2.getNode()));
   EXPECT_FALSE(DAG->getPCSections(N2.getNode()));
-  MDNode *MD = MDNode::get(Context, std::nullopt);
+  MDNode *MD = MDNode::get(Context, {});
   DAG->addHeapAllocSite(N2.getNode(), MD);
   DAG->addNoMergeSiteInfo(N2.getNode(), true);
   DAG->addPCSections(N2.getNode(), MD);

--- a/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
+++ b/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
@@ -102,8 +102,7 @@ public:
     OurFile = DIB.createFile("xyzzy.c", "/cave");
     OurCU =
         DIB.createCompileUnit(dwarf::DW_LANG_C99, OurFile, "nou", false, "", 0);
-    auto OurSubT =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
+    auto OurSubT = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     OurFunc =
         DIB.createFunction(OurCU, "bees", "", OurFile, 1, OurSubT, 1,
                            DINode::FlagZero, DISubprogram::SPFlagDefinition);

--- a/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
+++ b/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
@@ -103,7 +103,7 @@ public:
     OurCU =
         DIB.createCompileUnit(dwarf::DW_LANG_C99, OurFile, "nou", false, "", 0);
     auto OurSubT =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     OurFunc =
         DIB.createFunction(OurCU, "bees", "", OurFile, 1, OurSubT, 1,
                            DINode::FlagZero, DISubprogram::SPFlagDefinition);

--- a/llvm/unittests/CodeGen/LexicalScopesTest.cpp
+++ b/llvm/unittests/CodeGen/LexicalScopesTest.cpp
@@ -104,7 +104,7 @@ public:
     OurCU =
         DIB.createCompileUnit(dwarf::DW_LANG_C99, OurFile, "nou", false, "", 0);
     auto OurSubT =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     OurFunc =
         DIB.createFunction(OurCU, "bees", "", OurFile, 1, OurSubT, 1,
                            DINode::FlagZero, DISubprogram::SPFlagDefinition);

--- a/llvm/unittests/CodeGen/LexicalScopesTest.cpp
+++ b/llvm/unittests/CodeGen/LexicalScopesTest.cpp
@@ -103,8 +103,7 @@ public:
     OurFile = DIB.createFile("xyzzy.c", "/cave");
     OurCU =
         DIB.createCompileUnit(dwarf::DW_LANG_C99, OurFile, "nou", false, "", 0);
-    auto OurSubT =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
+    auto OurSubT = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     OurFunc =
         DIB.createFunction(OurCU, "bees", "", OurFile, 1, OurSubT, 1,
                            DINode::FlagZero, DISubprogram::SPFlagDefinition);

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -33,8 +33,8 @@ public:
   getCalleeSavedRegs(const MachineFunction *MF) const override {
     return nullptr;
   }
-  ArrayRef<const uint32_t *> getRegMasks() const override { return std::nullopt; }
-  ArrayRef<const char *> getRegMaskNames() const override { return std::nullopt; }
+  ArrayRef<const uint32_t *> getRegMasks() const override { return {}; }
+  ArrayRef<const char *> getRegMaskNames() const override { return {}; }
   BitVector getReservedRegs(const MachineFunction &MF) const override {
     return BitVector();
   }

--- a/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
+++ b/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
@@ -43,7 +43,7 @@ TEST(FindDebugLocTest, DifferentIterators) {
   DICompileUnit *OurCU =
       DIB.createCompileUnit(dwarf::DW_LANG_C99, OurFile, "", false, "", 0);
   auto OurSubT =
-      DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+      DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
   DISubprogram *OurFunc =
       DIB.createFunction(OurCU, "bees", "", OurFile, 1, OurSubT, 1,
                          DINode::FlagZero, DISubprogram::SPFlagDefinition);

--- a/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
+++ b/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
@@ -42,8 +42,7 @@ TEST(FindDebugLocTest, DifferentIterators) {
   DIFile *OurFile = DIB.createFile("foo.c", "/bar");
   DICompileUnit *OurCU =
       DIB.createCompileUnit(dwarf::DW_LANG_C99, OurFile, "", false, "", 0);
-  auto OurSubT =
-      DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
+  auto OurSubT = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
   DISubprogram *OurFunc =
       DIB.createFunction(OurCU, "bees", "", OurFile, 1, OurSubT, 1,
                          DINode::FlagZero, DISubprogram::SPFlagDefinition);

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -276,8 +276,8 @@ TEST(MachineInstrExtraInfo, AddExtraInfo) {
   MMOs.push_back(MMO);
   MCSymbol *Sym1 = MC->createTempSymbol("pre_label", false);
   MCSymbol *Sym2 = MC->createTempSymbol("post_label", false);
-  MDNode *HAM = MDNode::getDistinct(Ctx, std::nullopt);
-  MDNode *PCS = MDNode::getDistinct(Ctx, std::nullopt);
+  MDNode *HAM = MDNode::getDistinct(Ctx, {});
+  MDNode *PCS = MDNode::getDistinct(Ctx, {});
   MDNode *MMRA = MMRAMetadata::getTagMD(Ctx, "foo", "bar");
 
   ASSERT_TRUE(MI->memoperands_empty());
@@ -357,8 +357,8 @@ TEST(MachineInstrExtraInfo, ChangeExtraInfo) {
   MMOs.push_back(MMO);
   MCSymbol *Sym1 = MC->createTempSymbol("pre_label", false);
   MCSymbol *Sym2 = MC->createTempSymbol("post_label", false);
-  MDNode *HAM = MDNode::getDistinct(Ctx, std::nullopt);
-  MDNode *PCS = MDNode::getDistinct(Ctx, std::nullopt);
+  MDNode *HAM = MDNode::getDistinct(Ctx, {});
+  MDNode *PCS = MDNode::getDistinct(Ctx, {});
 
   MDNode *MMRA1 = MMRAMetadata::getTagMD(Ctx, "foo", "bar");
   MDNode *MMRA2 = MMRAMetadata::getTagMD(Ctx, "bar", "bux");
@@ -413,8 +413,8 @@ TEST(MachineInstrExtraInfo, RemoveExtraInfo) {
   MMOs.push_back(MMO);
   MCSymbol *Sym1 = MC->createTempSymbol("pre_label", false);
   MCSymbol *Sym2 = MC->createTempSymbol("post_label", false);
-  MDNode *HAM = MDNode::getDistinct(Ctx, std::nullopt);
-  MDNode *PCS = MDNode::getDistinct(Ctx, std::nullopt);
+  MDNode *HAM = MDNode::getDistinct(Ctx, {});
+  MDNode *PCS = MDNode::getDistinct(Ctx, {});
 
   MDNode *MMRA = MDTuple::get(Ctx, {});
 
@@ -506,8 +506,8 @@ MATCHER_P(HasMIMetadata, MIMD, "") {
 
 TEST(MachineInstrBuilder, BuildMI) {
   LLVMContext Ctx;
-  MDNode *PCS = MDNode::getDistinct(Ctx, std::nullopt);
-  MDNode *DI = MDNode::getDistinct(Ctx, std::nullopt);
+  MDNode *PCS = MDNode::getDistinct(Ctx, {});
+  MDNode *DI = MDNode::getDistinct(Ctx, {});
   DebugLoc DL(DI);
   MIMetadata MIMD(DL, PCS);
   EXPECT_EQ(MIMD.getDL(), DL);

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -176,7 +176,7 @@ protected:
     auto CU =
         DIB.createCompileUnit(dwarf::DW_LANG_C, File, "llvm-C", true, "", 0);
     auto Type =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     auto SP = DIB.createFunction(
         CU, "foo", "", File, 1, Type, 1, DINode::FlagZero,
         DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized);

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -175,8 +175,7 @@ protected:
                                std::optional<StringRef>("/src/test.dbg"));
     auto CU =
         DIB.createCompileUnit(dwarf::DW_LANG_C, File, "llvm-C", true, "", 0);
-    auto Type =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
+    auto Type = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     auto SP = DIB.createFunction(
         CU, "foo", "", File, 1, Type, 1, DINode::FlagZero,
         DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized);

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -896,8 +896,7 @@ TEST_F(IRBuilderTest, DIBuilder) {
     auto CU = DIB.createCompileUnit(dwarf::DW_LANG_Cobol74,
                                     DIB.createFile("F.CBL", "/"),
                                     "llvm-cobol74", true, "", 0);
-    auto Type =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
+    auto Type = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     auto SP = DIB.createFunction(
         CU, "foo", "", File, 1, Type, 1, DINode::FlagZero,
         DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized);
@@ -1168,8 +1167,7 @@ TEST_F(IRBuilderTest, DebugLoc) {
   auto CU = DIB.createCompileUnit(dwarf::DW_LANG_C_plus_plus_11,
                                   DIB.createFile("tmp.cpp", "/"), "", true, "",
                                   0);
-  auto SPType =
-      DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
+  auto SPType = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
   auto SP =
       DIB.createFunction(CU, "foo", "foo", File, 1, SPType, 1, DINode::FlagZero,
                          DISubprogram::SPFlagDefinition);

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -438,7 +438,7 @@ TEST_F(IRBuilderTest, ConstrainedFPFunctionCall) {
   // Now call the empty constrained FP function.
   Builder.setIsFPConstrained(true);
   Builder.setConstrainedFPFunctionAttr();
-  CallInst *FCall = Builder.CreateCall(Callee, std::nullopt);
+  CallInst *FCall = Builder.CreateCall(Callee, {});
 
   // Check the attributes to verify the strictfp attribute is on the call.
   EXPECT_TRUE(
@@ -697,24 +697,24 @@ TEST_F(IRBuilderTest, FastMathFlags) {
   auto Callee =
       Function::Create(CalleeTy, Function::ExternalLinkage, "", M.get());
 
-  FCall = Builder.CreateCall(Callee, std::nullopt);
+  FCall = Builder.CreateCall(Callee, {});
   EXPECT_FALSE(FCall->hasNoNaNs());
 
   Function *V =
       Function::Create(CalleeTy, Function::ExternalLinkage, "", M.get());
-  FCall = Builder.CreateCall(V, std::nullopt);
+  FCall = Builder.CreateCall(V, {});
   EXPECT_FALSE(FCall->hasNoNaNs());
 
   FMF.clear();
   FMF.setNoNaNs();
   Builder.setFastMathFlags(FMF);
 
-  FCall = Builder.CreateCall(Callee, std::nullopt);
+  FCall = Builder.CreateCall(Callee, {});
   EXPECT_TRUE(Builder.getFastMathFlags().any());
   EXPECT_TRUE(Builder.getFastMathFlags().NoNaNs);
   EXPECT_TRUE(FCall->hasNoNaNs());
 
-  FCall = Builder.CreateCall(V, std::nullopt);
+  FCall = Builder.CreateCall(V, {});
   EXPECT_TRUE(Builder.getFastMathFlags().any());
   EXPECT_TRUE(Builder.getFastMathFlags().NoNaNs);
   EXPECT_TRUE(FCall->hasNoNaNs());
@@ -856,7 +856,7 @@ TEST_F(IRBuilderTest, createFunction) {
   auto File = DIB.createFile("error.swift", "/");
   auto CU =
       DIB.createCompileUnit(dwarf::DW_LANG_Swift, File, "swiftc", true, "", 0);
-  auto Type = DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+  auto Type = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
   auto NoErr = DIB.createFunction(
       CU, "noerr", "", File, 1, Type, 1, DINode::FlagZero,
       DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized);
@@ -897,7 +897,7 @@ TEST_F(IRBuilderTest, DIBuilder) {
                                     DIB.createFile("F.CBL", "/"),
                                     "llvm-cobol74", true, "", 0);
     auto Type =
-        DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+        DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
     auto SP = DIB.createFunction(
         CU, "foo", "", File, 1, Type, 1, DINode::FlagZero,
         DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized);
@@ -1014,7 +1014,7 @@ TEST_F(IRBuilderTest, createArtificialSubprogram) {
   auto CU = DIB.createCompileUnit(dwarf::DW_LANG_C, File, "clang",
                                   /*isOptimized=*/true, /*Flags=*/"",
                                   /*Runtime Version=*/0);
-  auto Type = DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+  auto Type = DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
   auto SP = DIB.createFunction(
       CU, "foo", /*LinkageName=*/"", File,
       /*LineNo=*/1, Type, /*ScopeLine=*/2, DINode::FlagZero,
@@ -1169,7 +1169,7 @@ TEST_F(IRBuilderTest, DebugLoc) {
                                   DIB.createFile("tmp.cpp", "/"), "", true, "",
                                   0);
   auto SPType =
-      DIB.createSubroutineType(DIB.getOrCreateTypeArray(std::nullopt));
+      DIB.createSubroutineType(DIB.getOrCreateTypeArray({}));
   auto SP =
       DIB.createFunction(CU, "foo", "foo", File, 1, SPType, 1, DINode::FlagZero,
                          DISubprogram::SPFlagDefinition);
@@ -1183,13 +1183,13 @@ TEST_F(IRBuilderTest, DebugLoc) {
   IRBuilder<> Builder(Ctx);
   Builder.SetInsertPoint(Br);
   EXPECT_EQ(DL1, Builder.getCurrentDebugLocation());
-  auto Call1 = Builder.CreateCall(Callee, std::nullopt);
+  auto Call1 = Builder.CreateCall(Callee, {});
   EXPECT_EQ(DL1, Call1->getDebugLoc());
 
   Call1->setDebugLoc(DL2);
   Builder.SetInsertPoint(Call1->getParent(), Call1->getIterator());
   EXPECT_EQ(DL2, Builder.getCurrentDebugLocation());
-  auto Call2 = Builder.CreateCall(Callee, std::nullopt);
+  auto Call2 = Builder.CreateCall(Callee, {});
   EXPECT_EQ(DL2, Call2->getDebugLoc());
 
   DIB.finalize();
@@ -1202,7 +1202,7 @@ TEST_F(IRBuilderTest, DIImportedEntity) {
   auto CU = DIB.createCompileUnit(dwarf::DW_LANG_Cobol74,
                                   F, "llvm-cobol74",
                                   true, "", 0);
-  MDTuple *Elements = MDTuple::getDistinct(Ctx, std::nullopt);
+  MDTuple *Elements = MDTuple::getDistinct(Ctx, {});
 
   DIB.createImportedDeclaration(CU, nullptr, F, 1);
   DIB.createImportedDeclaration(CU, nullptr, F, 1);

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -756,7 +756,7 @@ TEST(InstructionsTest, AlterCallBundles) {
   AttrBuilder AB(C);
   AB.addAttribute(Attribute::Cold);
   Call->setAttributes(AttributeList::get(C, AttributeList::FunctionIndex, AB));
-  Call->setDebugLoc(DebugLoc(MDNode::get(C, std::nullopt)));
+  Call->setDebugLoc(DebugLoc(MDNode::get(C, {})));
 
   OperandBundleDef NewBundle("after", ConstantInt::get(Int32Ty, 7));
   std::unique_ptr<CallInst> Clone(CallInst::Create(Call.get(), NewBundle));
@@ -786,7 +786,7 @@ TEST(InstructionsTest, AlterInvokeBundles) {
   AB.addAttribute(Attribute::Cold);
   Invoke->setAttributes(
       AttributeList::get(C, AttributeList::FunctionIndex, AB));
-  Invoke->setDebugLoc(DebugLoc(MDNode::get(C, std::nullopt)));
+  Invoke->setDebugLoc(DebugLoc(MDNode::get(C, {})));
 
   OperandBundleDef NewBundle("after", ConstantInt::get(Int32Ty, 7));
   std::unique_ptr<InvokeInst> Clone(

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -73,14 +73,14 @@ protected:
   Module M;
   int Counter;
 
-  MDNode *getNode() { return MDNode::get(Context, std::nullopt); }
+  MDNode *getNode() { return MDNode::get(Context, {}); }
   MDNode *getNode(Metadata *MD) { return MDNode::get(Context, MD); }
   MDNode *getNode(Metadata *MD1, Metadata *MD2) {
     Metadata *MDs[] = {MD1, MD2};
     return MDNode::get(Context, MDs);
   }
 
-  MDTuple *getTuple() { return MDTuple::getDistinct(Context, std::nullopt); }
+  MDTuple *getTuple() { return MDTuple::getDistinct(Context, {}); }
   DISubroutineType *getSubroutineType() {
     return DISubroutineType::getDistinct(Context, DINode::FlagZero, 0,
                                          getNode(nullptr));
@@ -121,7 +121,7 @@ protected:
   }
   Function *getFunction(StringRef Name) {
     return Function::Create(
-        FunctionType::get(Type::getVoidTy(Context), std::nullopt, false),
+        FunctionType::get(Type::getVoidTy(Context), {}, false),
         Function::ExternalLinkage, Name, M);
   }
 };
@@ -227,7 +227,7 @@ TEST_F(MDNodeTest, SelfReference) {
   // !0 = !{!0}
   // !1 = !{!0}
   {
-    auto Temp = MDNode::getTemporary(Context, std::nullopt);
+    auto Temp = MDNode::getTemporary(Context, {});
     Metadata *Args[] = {Temp.get()};
     MDNode *Self = MDNode::get(Context, Args);
     Self->replaceOperandWith(0, Self);
@@ -245,8 +245,8 @@ TEST_F(MDNodeTest, SelfReference) {
   // !0 = !{!0, !{}}
   // !1 = !{!0, !{}}
   {
-    auto Temp = MDNode::getTemporary(Context, std::nullopt);
-    Metadata *Args[] = {Temp.get(), MDNode::get(Context, std::nullopt)};
+    auto Temp = MDNode::getTemporary(Context, {});
+    Metadata *Args[] = {Temp.get(), MDNode::get(Context, {})};
     MDNode *Self = MDNode::get(Context, Args);
     Self->replaceOperandWith(0, Self);
     ASSERT_EQ(Self, Self->getOperand(0));
@@ -354,8 +354,8 @@ TEST_F(MDNodeTest, PrintFromFunction) {
   auto *BB1 = BasicBlock::Create(Context, "entry", F1);
   auto *R0 = ReturnInst::Create(Context, BB0);
   auto *R1 = ReturnInst::Create(Context, BB1);
-  auto *N0 = MDNode::getDistinct(Context, std::nullopt);
-  auto *N1 = MDNode::getDistinct(Context, std::nullopt);
+  auto *N0 = MDNode::getDistinct(Context, {});
+  auto *N1 = MDNode::getDistinct(Context, {});
   R0->setMetadata("md", N0);
   R1->setMetadata("md", N1);
 
@@ -380,8 +380,8 @@ TEST_F(MDNodeTest, PrintFromMetadataAsValue) {
   auto *F1 = Function::Create(FTy, GlobalValue::ExternalLinkage, "F1", &M);
   auto *BB0 = BasicBlock::Create(Context, "entry", F0);
   auto *BB1 = BasicBlock::Create(Context, "entry", F1);
-  auto *N0 = MDNode::getDistinct(Context, std::nullopt);
-  auto *N1 = MDNode::getDistinct(Context, std::nullopt);
+  auto *N0 = MDNode::getDistinct(Context, {});
+  auto *N1 = MDNode::getDistinct(Context, {});
   auto *MAV0 = MetadataAsValue::get(Context, N0);
   auto *MAV1 = MetadataAsValue::get(Context, N1);
   CallInst::Create(Intrinsic, MAV0, "", BB0);
@@ -415,7 +415,7 @@ TEST_F(MDNodeTest, PrintWithDroppedCallOperand) {
   CI0->dropAllReferences();
 
   auto *R0 = ReturnInst::Create(Context, BB0);
-  auto *N0 = MDNode::getDistinct(Context, std::nullopt);
+  auto *N0 = MDNode::getDistinct(Context, {});
   R0->setMetadata("md", N0);
 
   // Printing the metadata node would previously result in a failed assertion
@@ -488,7 +488,7 @@ TEST_F(MDNodeTest, PrintTree) {
 
 TEST_F(MDNodeTest, NullOperand) {
   // metadata !{}
-  MDNode *Empty = MDNode::get(Context, std::nullopt);
+  MDNode *Empty = MDNode::get(Context, {});
 
   // metadata !{metadata !{}}
   Metadata *Ops[] = {Empty};
@@ -508,7 +508,7 @@ TEST_F(MDNodeTest, NullOperand) {
 
 TEST_F(MDNodeTest, DistinctOnUniquingCollision) {
   // !{}
-  MDNode *Empty = MDNode::get(Context, std::nullopt);
+  MDNode *Empty = MDNode::get(Context, {});
   ASSERT_TRUE(Empty->isResolved());
   EXPECT_FALSE(Empty->isDistinct());
 
@@ -535,7 +535,7 @@ TEST_F(MDNodeTest, DistinctOnUniquingCollision) {
 
 TEST_F(MDNodeTest, UniquedOnDeletedOperand) {
   // temp !{}
-  TempMDTuple T = MDTuple::getTemporary(Context, std::nullopt);
+  TempMDTuple T = MDTuple::getTemporary(Context, {});
 
   // !{temp !{}}
   Metadata *Ops[] = {T.get()};
@@ -569,14 +569,14 @@ TEST_F(MDNodeTest, DistinctOnDeletedValueOperand) {
 
 TEST_F(MDNodeTest, getDistinct) {
   // !{}
-  MDNode *Empty = MDNode::get(Context, std::nullopt);
+  MDNode *Empty = MDNode::get(Context, {});
   ASSERT_TRUE(Empty->isResolved());
   ASSERT_FALSE(Empty->isDistinct());
-  ASSERT_EQ(Empty, MDNode::get(Context, std::nullopt));
+  ASSERT_EQ(Empty, MDNode::get(Context, {}));
 
   // distinct !{}
-  MDNode *Distinct1 = MDNode::getDistinct(Context, std::nullopt);
-  MDNode *Distinct2 = MDNode::getDistinct(Context, std::nullopt);
+  MDNode *Distinct1 = MDNode::getDistinct(Context, {});
+  MDNode *Distinct2 = MDNode::getDistinct(Context, {});
   EXPECT_TRUE(Distinct1->isResolved());
   EXPECT_TRUE(Distinct2->isDistinct());
   EXPECT_NE(Empty, Distinct1);
@@ -584,31 +584,31 @@ TEST_F(MDNodeTest, getDistinct) {
   EXPECT_NE(Distinct1, Distinct2);
 
   // !{}
-  ASSERT_EQ(Empty, MDNode::get(Context, std::nullopt));
+  ASSERT_EQ(Empty, MDNode::get(Context, {}));
 }
 
 TEST_F(MDNodeTest, isUniqued) {
-  MDNode *U = MDTuple::get(Context, std::nullopt);
-  MDNode *D = MDTuple::getDistinct(Context, std::nullopt);
-  auto T = MDTuple::getTemporary(Context, std::nullopt);
+  MDNode *U = MDTuple::get(Context, {});
+  MDNode *D = MDTuple::getDistinct(Context, {});
+  auto T = MDTuple::getTemporary(Context, {});
   EXPECT_TRUE(U->isUniqued());
   EXPECT_FALSE(D->isUniqued());
   EXPECT_FALSE(T->isUniqued());
 }
 
 TEST_F(MDNodeTest, isDistinct) {
-  MDNode *U = MDTuple::get(Context, std::nullopt);
-  MDNode *D = MDTuple::getDistinct(Context, std::nullopt);
-  auto T = MDTuple::getTemporary(Context, std::nullopt);
+  MDNode *U = MDTuple::get(Context, {});
+  MDNode *D = MDTuple::getDistinct(Context, {});
+  auto T = MDTuple::getTemporary(Context, {});
   EXPECT_FALSE(U->isDistinct());
   EXPECT_TRUE(D->isDistinct());
   EXPECT_FALSE(T->isDistinct());
 }
 
 TEST_F(MDNodeTest, isTemporary) {
-  MDNode *U = MDTuple::get(Context, std::nullopt);
-  MDNode *D = MDTuple::getDistinct(Context, std::nullopt);
-  auto T = MDTuple::getTemporary(Context, std::nullopt);
+  MDNode *U = MDTuple::get(Context, {});
+  MDNode *D = MDTuple::getDistinct(Context, {});
+  auto T = MDTuple::getTemporary(Context, {});
   EXPECT_FALSE(U->isTemporary());
   EXPECT_FALSE(D->isTemporary());
   EXPECT_TRUE(T->isTemporary());
@@ -616,7 +616,7 @@ TEST_F(MDNodeTest, isTemporary) {
 
 TEST_F(MDNodeTest, getDistinctWithUnresolvedOperands) {
   // temporary !{}
-  auto Temp = MDTuple::getTemporary(Context, std::nullopt);
+  auto Temp = MDTuple::getTemporary(Context, {});
   ASSERT_FALSE(Temp->isResolved());
 
   // distinct !{temporary !{}}
@@ -626,17 +626,17 @@ TEST_F(MDNodeTest, getDistinctWithUnresolvedOperands) {
   EXPECT_EQ(Temp.get(), Distinct->getOperand(0));
 
   // temporary !{} => !{}
-  MDNode *Empty = MDNode::get(Context, std::nullopt);
+  MDNode *Empty = MDNode::get(Context, {});
   Temp->replaceAllUsesWith(Empty);
   EXPECT_EQ(Empty, Distinct->getOperand(0));
 }
 
 TEST_F(MDNodeTest, handleChangedOperandRecursion) {
   // !0 = !{}
-  MDNode *N0 = MDNode::get(Context, std::nullopt);
+  MDNode *N0 = MDNode::get(Context, {});
 
   // !1 = !{!3, null}
-  auto Temp3 = MDTuple::getTemporary(Context, std::nullopt);
+  auto Temp3 = MDTuple::getTemporary(Context, {});
   Metadata *Ops1[] = {Temp3.get(), nullptr};
   MDNode *N1 = MDNode::get(Context, Ops1);
 
@@ -700,7 +700,7 @@ TEST_F(MDNodeTest, replaceResolvedOperand) {
   // a global value that gets RAUW'ed.
   //
   // Use a temporary node to keep N from being resolved.
-  auto Temp = MDTuple::getTemporary(Context, std::nullopt);
+  auto Temp = MDTuple::getTemporary(Context, {});
   Metadata *Ops[] = {nullptr, Temp.get()};
 
   MDNode *Empty = MDTuple::get(Context, ArrayRef<Metadata *>());
@@ -721,7 +721,7 @@ TEST_F(MDNodeTest, replaceResolvedOperand) {
 }
 
 TEST_F(MDNodeTest, replaceWithUniqued) {
-  auto *Empty = MDTuple::get(Context, std::nullopt);
+  auto *Empty = MDTuple::get(Context, {});
   MDTuple *FirstUniqued;
   {
     Metadata *Ops[] = {Empty};
@@ -747,7 +747,7 @@ TEST_F(MDNodeTest, replaceWithUniqued) {
     EXPECT_EQ(FirstUniqued, Uniqued);
   }
   {
-    auto Unresolved = MDTuple::getTemporary(Context, std::nullopt);
+    auto Unresolved = MDTuple::getTemporary(Context, {});
     Metadata *Ops[] = {Unresolved.get()};
     auto Temp = MDTuple::getTemporary(Context, Ops);
     EXPECT_TRUE(Temp->isTemporary());
@@ -769,7 +769,7 @@ TEST_F(MDNodeTest, replaceWithUniqued) {
 
 TEST_F(MDNodeTest, replaceWithUniquedResolvingOperand) {
   // temp !{}
-  MDTuple *Op = MDTuple::getTemporary(Context, std::nullopt).release();
+  MDTuple *Op = MDTuple::getTemporary(Context, {}).release();
   EXPECT_FALSE(Op->isResolved());
 
   // temp !{temp !{}}
@@ -836,7 +836,7 @@ TEST_F(MDNodeTest, replaceWithUniquedChangedOperand) {
 
 TEST_F(MDNodeTest, replaceWithDistinct) {
   {
-    auto *Empty = MDTuple::get(Context, std::nullopt);
+    auto *Empty = MDTuple::get(Context, {});
     Metadata *Ops[] = {Empty};
     auto Temp = MDTuple::getTemporary(Context, Ops);
     EXPECT_TRUE(Temp->isTemporary());
@@ -849,7 +849,7 @@ TEST_F(MDNodeTest, replaceWithDistinct) {
     EXPECT_EQ(Current, Distinct);
   }
   {
-    auto Unresolved = MDTuple::getTemporary(Context, std::nullopt);
+    auto Unresolved = MDTuple::getTemporary(Context, {});
     Metadata *Ops[] = {Unresolved.get()};
     auto Temp = MDTuple::getTemporary(Context, Ops);
     EXPECT_TRUE(Temp->isTemporary());
@@ -908,7 +908,7 @@ TEST_F(MDNodeTest, deleteTemporaryWithTrackingRef) {
   TrackingMDRef Ref;
   EXPECT_EQ(nullptr, Ref.get());
   {
-    auto Temp = MDTuple::getTemporary(Context, std::nullopt);
+    auto Temp = MDTuple::getTemporary(Context, {});
     Ref.reset(Temp.get());
     EXPECT_EQ(Temp.get(), Ref.get());
   }
@@ -1253,14 +1253,14 @@ TEST_F(DILocationTest, getDistinct) {
 }
 
 TEST_F(DILocationTest, getTemporary) {
-  MDNode *N = MDNode::get(Context, std::nullopt);
+  MDNode *N = MDNode::get(Context, {});
   auto L = DILocation::getTemporary(Context, 2, 7, N);
   EXPECT_TRUE(L->isTemporary());
   EXPECT_FALSE(L->isResolved());
 }
 
 TEST_F(DILocationTest, cloneTemporary) {
-  MDNode *N = MDNode::get(Context, std::nullopt);
+  MDNode *N = MDNode::get(Context, {});
   auto L = DILocation::getTemporary(Context, 2, 7, N);
   EXPECT_TRUE(L->isTemporary());
   auto L2 = L->clone();
@@ -1370,7 +1370,7 @@ typedef MetadataTest GenericDINodeTest;
 
 TEST_F(GenericDINodeTest, get) {
   StringRef Header = "header";
-  auto *Empty = MDNode::get(Context, std::nullopt);
+  auto *Empty = MDNode::get(Context, {});
   Metadata *Ops1[] = {Empty};
   auto *N = GenericDINode::get(Context, 15, Header, Ops1);
   EXPECT_EQ(15u, N->getTag());
@@ -1406,7 +1406,7 @@ TEST_F(GenericDINodeTest, get) {
 
 TEST_F(GenericDINodeTest, getEmptyHeader) {
   // Canonicalize !"" to null.
-  auto *N = GenericDINode::get(Context, 15, StringRef(), std::nullopt);
+  auto *N = GenericDINode::get(Context, 15, StringRef(), {});
   EXPECT_EQ(StringRef(), N->getHeader());
   EXPECT_EQ(nullptr, N->getOperand(0));
 }
@@ -2145,7 +2145,7 @@ TEST_F(DICompositeTypeTest, replaceOperands) {
       Context, Tag, Name, File, Line, Scope, BaseType, SizeInBits, AlignInBits,
       OffsetInBits, Flags, nullptr, RuntimeLang, nullptr, nullptr, Identifier);
 
-  auto *Elements = MDTuple::getDistinct(Context, std::nullopt);
+  auto *Elements = MDTuple::getDistinct(Context, {});
   EXPECT_EQ(nullptr, N->getElements().get());
   N->replaceElements(Elements);
   EXPECT_EQ(Elements, N->getElements().get());
@@ -2164,7 +2164,7 @@ TEST_F(DICompositeTypeTest, replaceOperands) {
   N->replaceVTableHolder(nullptr);
   EXPECT_EQ(nullptr, N->getVTableHolder());
 
-  auto *TemplateParams = MDTuple::getDistinct(Context, std::nullopt);
+  auto *TemplateParams = MDTuple::getDistinct(Context, {});
   EXPECT_EQ(nullptr, N->getTemplateParams().get());
   N->replaceTemplateParams(TemplateParams);
   EXPECT_EQ(TemplateParams, N->getTemplateParams().get());
@@ -2496,9 +2496,9 @@ TEST_F(DICompileUnitTest, replaceArrays) {
   unsigned RuntimeVersion = 2;
   StringRef SplitDebugFilename = "another/file";
   auto EmissionKind = DICompileUnit::FullDebug;
-  MDTuple *EnumTypes = MDTuple::getDistinct(Context, std::nullopt);
-  MDTuple *RetainedTypes = MDTuple::getDistinct(Context, std::nullopt);
-  MDTuple *ImportedEntities = MDTuple::getDistinct(Context, std::nullopt);
+  MDTuple *EnumTypes = MDTuple::getDistinct(Context, {});
+  MDTuple *RetainedTypes = MDTuple::getDistinct(Context, {});
+  MDTuple *ImportedEntities = MDTuple::getDistinct(Context, {});
   uint64_t DWOId = 0xc0ffee;
   StringRef SysRoot = "/";
   StringRef SDK = "MacOSX.sdk";
@@ -2508,14 +2508,14 @@ TEST_F(DICompileUnitTest, replaceArrays) {
       RetainedTypes, nullptr, ImportedEntities, nullptr, DWOId, true, false,
       DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK);
 
-  auto *GlobalVariables = MDTuple::getDistinct(Context, std::nullopt);
+  auto *GlobalVariables = MDTuple::getDistinct(Context, {});
   EXPECT_EQ(nullptr, N->getGlobalVariables().get());
   N->replaceGlobalVariables(GlobalVariables);
   EXPECT_EQ(GlobalVariables, N->getGlobalVariables().get());
   N->replaceGlobalVariables(nullptr);
   EXPECT_EQ(nullptr, N->getGlobalVariables().get());
 
-  auto *Macros = MDTuple::getDistinct(Context, std::nullopt);
+  auto *Macros = MDTuple::getDistinct(Context, {});
   EXPECT_EQ(nullptr, N->getMacros().get());
   N->replaceMacros(Macros);
   EXPECT_EQ(Macros, N->getMacros().get());
@@ -3760,7 +3760,7 @@ TEST_F(DIExpressionTest, isValid) {
   } while (false)
 
   // Empty expression should be valid.
-  EXPECT_TRUE(DIExpression::get(Context, std::nullopt)->isValid());
+  EXPECT_TRUE(DIExpression::get(Context, {})->isValid());
 
   // Valid constructions.
   EXPECT_VALID(dwarf::DW_OP_plus_uconst, 6);
@@ -4394,7 +4394,7 @@ TEST_F(DIImportedEntityTest, get) {
 typedef MetadataTest MetadataAsValueTest;
 
 TEST_F(MetadataAsValueTest, MDNode) {
-  MDNode *N = MDNode::get(Context, std::nullopt);
+  MDNode *N = MDNode::get(Context, {});
   auto *V = MetadataAsValue::get(Context, N);
   EXPECT_TRUE(V->getType()->isMetadataTy());
   EXPECT_EQ(N, V->getMetadata());
@@ -4404,7 +4404,7 @@ TEST_F(MetadataAsValueTest, MDNode) {
 }
 
 TEST_F(MetadataAsValueTest, MDNodeMDNode) {
-  MDNode *N = MDNode::get(Context, std::nullopt);
+  MDNode *N = MDNode::get(Context, {});
   Metadata *Ops[] = {N};
   MDNode *N2 = MDNode::get(Context, Ops);
   auto *V = MetadataAsValue::get(Context, N2);
@@ -4475,7 +4475,7 @@ TEST_F(ValueAsMetadataTest, TempTempReplacement) {
   ConstantAsMetadata *CI =
       ConstantAsMetadata::get(ConstantInt::get(Context, APInt(8, 0)));
 
-  auto Temp1 = MDTuple::getTemporary(Context, std::nullopt);
+  auto Temp1 = MDTuple::getTemporary(Context, {});
   auto Temp2 = MDTuple::getTemporary(Context, {CI});
   auto *N = MDTuple::get(Context, {Temp1.get()});
 
@@ -4493,7 +4493,7 @@ TEST_F(ValueAsMetadataTest, CollidingDoubleUpdates) {
       ConstantAsMetadata::get(ConstantInt::get(Context, APInt(8, 0)));
 
   // Create a temporary to prevent nodes from resolving.
-  auto Temp = MDTuple::getTemporary(Context, std::nullopt);
+  auto Temp = MDTuple::getTemporary(Context, {});
 
   // When the first operand of N1 gets reset to nullptr, it'll collide with N2.
   Metadata *Ops1[] = {CI, CI, Temp.get()};
@@ -4758,7 +4758,7 @@ TEST_F(DistinctMDOperandPlaceholderTest, replaceUseWith) {
   ASSERT_EQ(&PH2, D->getOperand(2));
 
   // Replace them.
-  auto *N0 = MDTuple::get(Context, std::nullopt);
+  auto *N0 = MDTuple::get(Context, {});
   auto *N1 = MDTuple::get(Context, N0);
   PH0.replaceUseWith(N0);
   PH1.replaceUseWith(N1);
@@ -4771,7 +4771,7 @@ TEST_F(DistinctMDOperandPlaceholderTest, replaceUseWith) {
 TEST_F(DistinctMDOperandPlaceholderTest, replaceUseWithNoUser) {
   // There is no user, but we can still call replace.
   DistinctMDOperandPlaceholder(7).replaceUseWith(
-      MDTuple::get(Context, std::nullopt));
+      MDTuple::get(Context, {}));
 }
 
 // Test various assertions in metadata tracking. Don't run these tests if gtest
@@ -4937,7 +4937,7 @@ TEST_F(MDTupleAllocationTest, Resize) {
   EXPECT_EQ(B->getOperand(3), Value5);
 
   // Check that we can resize temporary nodes as well.
-  auto Temp1 = MDTuple::getTemporary(Context, std::nullopt);
+  auto Temp1 = MDTuple::getTemporary(Context, {});
   EXPECT_EQ(Temp1->getNumOperands(), 0u);
 
   Temp1->push_back(Value1);

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -4770,8 +4770,7 @@ TEST_F(DistinctMDOperandPlaceholderTest, replaceUseWith) {
 
 TEST_F(DistinctMDOperandPlaceholderTest, replaceUseWithNoUser) {
   // There is no user, but we can still call replace.
-  DistinctMDOperandPlaceholder(7).replaceUseWith(
-      MDTuple::get(Context, {}));
+  DistinctMDOperandPlaceholder(7).replaceUseWith(MDTuple::get(Context, {}));
 }
 
 // Test various assertions in metadata tracking. Don't run these tests if gtest

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -271,7 +271,7 @@ TEST(VerifierTest, DetectInvalidDebugInfo) {
 
 TEST(VerifierTest, MDNodeWrongContext) {
   LLVMContext C1, C2;
-  auto *Node = MDNode::get(C1, std::nullopt);
+  auto *Node = MDNode::get(C1, {});
 
   Module M("M", C2);
   auto *NamedNode = M.getOrInsertNamedMetadata("test");

--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -809,7 +809,7 @@ TEST_P(InstrProfReaderWriterTest, icall_and_vtable_data_read_write) {
         {(uint64_t)callee1, 1}, {(uint64_t)callee2, 2}, {(uint64_t)callee3, 3}};
     Record1.addValueData(IPVK_IndirectCallTarget, 0, VD0, nullptr);
     // No value profile data at the second site.
-    Record1.addValueData(IPVK_IndirectCallTarget, 1, std::nullopt, nullptr);
+    Record1.addValueData(IPVK_IndirectCallTarget, 1, {}, nullptr);
     InstrProfValueData VD2[] = {{(uint64_t)callee1, 1}, {(uint64_t)callee2, 2}};
     Record1.addValueData(IPVK_IndirectCallTarget, 2, VD2, nullptr);
     InstrProfValueData VD3[] = {{(uint64_t)callee7, 1}, {(uint64_t)callee8, 2}};
@@ -1013,7 +1013,7 @@ TEST_P(MaybeSparseInstrProfTest, icall_and_vtable_data_merge) {
     Record11.addValueData(IPVK_IndirectCallTarget, 0, VD0, nullptr);
 
     // No value profile data at the second site.
-    Record11.addValueData(IPVK_IndirectCallTarget, 1, std::nullopt, nullptr);
+    Record11.addValueData(IPVK_IndirectCallTarget, 1, {}, nullptr);
 
     InstrProfValueData VD2[] = {
         {uint64_t(callee1), 1}, {uint64_t(callee2), 2}, {uint64_t(callee3), 3}};
@@ -1052,13 +1052,13 @@ TEST_P(MaybeSparseInstrProfTest, icall_and_vtable_data_merge) {
   Record12.addValueData(IPVK_IndirectCallTarget, 0, VD02, nullptr);
 
   // No value profile data at the second site.
-  Record12.addValueData(IPVK_IndirectCallTarget, 1, std::nullopt, nullptr);
+  Record12.addValueData(IPVK_IndirectCallTarget, 1, {}, nullptr);
 
   InstrProfValueData VD22[] = {
       {uint64_t(callee2), 1}, {uint64_t(callee3), 3}, {uint64_t(callee4), 4}};
   Record12.addValueData(IPVK_IndirectCallTarget, 2, VD22, nullptr);
 
-  Record12.addValueData(IPVK_IndirectCallTarget, 3, std::nullopt, nullptr);
+  Record12.addValueData(IPVK_IndirectCallTarget, 3, {}, nullptr);
 
   InstrProfValueData VD42[] = {
       {uint64_t(callee1), 1}, {uint64_t(callee2), 2}, {uint64_t(callee3), 3}};
@@ -1269,7 +1269,7 @@ TEST_P(ValueProfileMergeEdgeCaseTest, value_profile_data_merge_site_trunc) {
   }
 
   Record11.addValueData(ValueKind, 0, VD0, nullptr);
-  Record11.addValueData(ValueKind, 1, std::nullopt, nullptr);
+  Record11.addValueData(ValueKind, 1, {}, nullptr);
 
   Record12.reserveSites(ValueKind, 2);
   InstrProfValueData VD1[255];
@@ -1279,7 +1279,7 @@ TEST_P(ValueProfileMergeEdgeCaseTest, value_profile_data_merge_site_trunc) {
   }
 
   Record12.addValueData(ValueKind, 0, VD1, nullptr);
-  Record12.addValueData(ValueKind, 1, std::nullopt, nullptr);
+  Record12.addValueData(ValueKind, 1, {}, nullptr);
 
   Writer.addRecord(std::move(Record11), Err);
   // Merge profile data.
@@ -1329,7 +1329,7 @@ static void addValueProfData(InstrProfRecord &Record) {
     InstrProfValueData VD3[] = {{uint64_t(callee2), 1800},
                                 {uint64_t(callee3), 2000}};
     Record.addValueData(IPVK_IndirectCallTarget, 3, VD3, nullptr);
-    Record.addValueData(IPVK_IndirectCallTarget, 4, std::nullopt, nullptr);
+    Record.addValueData(IPVK_IndirectCallTarget, 4, {}, nullptr);
     InstrProfValueData VD5[] = {{uint64_t(callee7), 1234},
                                 {uint64_t(callee8), 5678}};
     Record.addValueData(IPVK_IndirectCallTarget, 5, VD5, nullptr);

--- a/llvm/unittests/Support/ConvertUTFTest.cpp
+++ b/llvm/unittests/Support/ConvertUTFTest.cpp
@@ -82,7 +82,7 @@ TEST(ConvertUTFTest, OddLengthInput) {
 TEST(ConvertUTFTest, Empty) {
   std::string Result;
   bool Success =
-      convertUTF16ToUTF8String(llvm::ArrayRef<char>(std::nullopt), Result);
+      convertUTF16ToUTF8String(llvm::ArrayRef<char>(), Result);
   EXPECT_TRUE(Success);
   EXPECT_TRUE(Result.empty());
 }
@@ -97,7 +97,7 @@ TEST(ConvertUTFTest, HasUTF16BOM) {
   HasBOM = hasUTF16ByteOrderMark(ArrayRef("\xfe\xff\x00asdf", 6));
   EXPECT_TRUE(HasBOM);
 
-  HasBOM = hasUTF16ByteOrderMark(std::nullopt);
+  HasBOM = hasUTF16ByteOrderMark({});
   EXPECT_FALSE(HasBOM);
   HasBOM = hasUTF16ByteOrderMark(ArrayRef("\xfe", 1));
   EXPECT_FALSE(HasBOM);

--- a/llvm/unittests/Support/ConvertUTFTest.cpp
+++ b/llvm/unittests/Support/ConvertUTFTest.cpp
@@ -81,8 +81,7 @@ TEST(ConvertUTFTest, OddLengthInput) {
 
 TEST(ConvertUTFTest, Empty) {
   std::string Result;
-  bool Success =
-      convertUTF16ToUTF8String(llvm::ArrayRef<char>(), Result);
+  bool Success = convertUTF16ToUTF8String(llvm::ArrayRef<char>(), Result);
   EXPECT_TRUE(Success);
   EXPECT_TRUE(Result.empty());
 }

--- a/llvm/unittests/Support/SourceMgrTest.cpp
+++ b/llvm/unittests/Support/SourceMgrTest.cpp
@@ -48,8 +48,7 @@ public:
 
 TEST_F(SourceMgrTest, BasicError) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"
@@ -59,8 +58,7 @@ TEST_F(SourceMgrTest, BasicError) {
 
 TEST_F(SourceMgrTest, BasicWarning) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Warning, "message", {},
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Warning, "message", {}, {});
 
   EXPECT_EQ("file.in:1:5: warning: message\n"
             "aaa bbb\n"
@@ -70,8 +68,7 @@ TEST_F(SourceMgrTest, BasicWarning) {
 
 TEST_F(SourceMgrTest, BasicRemark) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Remark, "message", {},
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Remark, "message", {}, {});
 
   EXPECT_EQ("file.in:1:5: remark: message\n"
             "aaa bbb\n"
@@ -81,8 +78,7 @@ TEST_F(SourceMgrTest, BasicRemark) {
 
 TEST_F(SourceMgrTest, BasicNote) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Note, "message", {},
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Note, "message", {}, {});
 
   EXPECT_EQ("file.in:1:5: note: message\n"
             "aaa bbb\n"
@@ -92,8 +88,7 @@ TEST_F(SourceMgrTest, BasicNote) {
 
 TEST_F(SourceMgrTest, LocationAtEndOfLine) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(6), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(6), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:7: error: message\n"
             "aaa bbb\n"
@@ -103,8 +98,7 @@ TEST_F(SourceMgrTest, LocationAtEndOfLine) {
 
 TEST_F(SourceMgrTest, LocationAtNewline) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(7), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(7), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:8: error: message\n"
             "aaa bbb\n"
@@ -114,8 +108,7 @@ TEST_F(SourceMgrTest, LocationAtNewline) {
 
 TEST_F(SourceMgrTest, LocationAtEmptyBuffer) {
   setMainBuffer("", "file.in");
-  printMessage(getLoc(0), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(0), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:1: error: message\n"
             "\n"
@@ -125,8 +118,7 @@ TEST_F(SourceMgrTest, LocationAtEmptyBuffer) {
 
 TEST_F(SourceMgrTest, LocationJustOnSoleNewline) {
   setMainBuffer("\n", "file.in");
-  printMessage(getLoc(0), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(0), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:1: error: message\n"
             "\n"
@@ -136,8 +128,7 @@ TEST_F(SourceMgrTest, LocationJustOnSoleNewline) {
 
 TEST_F(SourceMgrTest, LocationJustAfterSoleNewline) {
   setMainBuffer("\n", "file.in");
-  printMessage(getLoc(1), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(1), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:2:1: error: message\n"
             "\n"
@@ -147,8 +138,7 @@ TEST_F(SourceMgrTest, LocationJustAfterSoleNewline) {
 
 TEST_F(SourceMgrTest, LocationJustAfterNonNewline) {
   setMainBuffer("123", "file.in");
-  printMessage(getLoc(3), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(3), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:4: error: message\n"
             "123\n"
@@ -158,8 +148,7 @@ TEST_F(SourceMgrTest, LocationJustAfterNonNewline) {
 
 TEST_F(SourceMgrTest, LocationOnFirstLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(3), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(3), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:4: error: message\n"
             "1234\n"
@@ -169,8 +158,7 @@ TEST_F(SourceMgrTest, LocationOnFirstLineOfMultiline) {
 
 TEST_F(SourceMgrTest, LocationOnEOLOfFirstLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "1234\n"
@@ -180,8 +168,7 @@ TEST_F(SourceMgrTest, LocationOnEOLOfFirstLineOfMultiline) {
 
 TEST_F(SourceMgrTest, LocationOnSecondLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(5), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(5), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:2:1: error: message\n"
             "6789\n"
@@ -191,8 +178,7 @@ TEST_F(SourceMgrTest, LocationOnSecondLineOfMultiline) {
 
 TEST_F(SourceMgrTest, LocationOnSecondLineOfMultilineNoSecondEOL) {
   setMainBuffer("1234\n6789", "file.in");
-  printMessage(getLoc(5), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(5), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:2:1: error: message\n"
             "6789\n"
@@ -202,8 +188,7 @@ TEST_F(SourceMgrTest, LocationOnSecondLineOfMultilineNoSecondEOL) {
 
 TEST_F(SourceMgrTest, LocationOnEOLOfSecondSecondLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(9), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(9), SourceMgr::DK_Error, "message", {}, {});
 
   EXPECT_EQ("file.in:2:5: error: message\n"
             "6789\n"
@@ -233,8 +218,7 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf255ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12"                       // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(253), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(253), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:1: error: message\n"
             "12\n"
             "^\n",
@@ -245,8 +229,7 @@ TEST_F(SourceMgrTest, LocationAtEndOf255ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12"                       // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "12\n"
             " ^\n",
@@ -257,8 +240,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf255ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12"                       // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "12\n"
             "  ^\n",
@@ -269,8 +251,7 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf255ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1\n"                      // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(253), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(253), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:1: error: message\n"
             "1\n"
             "^\n",
@@ -281,8 +262,7 @@ TEST_F(SourceMgrTest, LocationAtEndOf255ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1\n"                      // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "1\n"
             " ^\n",
@@ -293,8 +273,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf255ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1\n"                      // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:25:1: error: message\n"
             "\n"
             "^\n",
@@ -309,8 +288,7 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf256ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123"                      // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "123\n"
             " ^\n",
@@ -321,8 +299,7 @@ TEST_F(SourceMgrTest, LocationAtEndOf256ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123"                      // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "123\n"
             "  ^\n",
@@ -333,8 +310,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf256ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123"                      // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:4: error: message\n"
             "123\n"
             "   ^\n",
@@ -345,8 +321,7 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf256ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12\n"                     // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "12\n"
             " ^\n",
@@ -357,8 +332,7 @@ TEST_F(SourceMgrTest, LocationAtEndOf256ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12\n"                     // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "12\n"
             "  ^\n",
@@ -369,8 +343,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf256ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12\n"                     // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:25:1: error: message\n"
             "\n"
             "^\n",
@@ -385,8 +358,7 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf257ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1234"                     // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "1234\n"
             "  ^\n",
@@ -397,8 +369,7 @@ TEST_F(SourceMgrTest, LocationAtEndOf257ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1234"                     // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:4: error: message\n"
             "1234\n"
             "   ^\n",
@@ -409,8 +380,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf257ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1234"                     // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(257), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(257), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:5: error: message\n"
             "1234\n"
             "    ^\n",
@@ -421,8 +391,7 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf257ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123\n"                    // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "123\n"
             "  ^\n",
@@ -433,8 +402,7 @@ TEST_F(SourceMgrTest, LocationAtEndOf257ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123\n"                    // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:24:4: error: message\n"
             "123\n"
             "   ^\n",
@@ -445,8 +413,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf257ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123\n"                    // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(257), SourceMgr::DK_Error, "message", {},
-               {});
+  printMessage(getLoc(257), SourceMgr::DK_Error, "message", {}, {});
   EXPECT_EQ("file.in:25:1: error: message\n"
             "\n"
             "^\n",
@@ -455,8 +422,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf257ByteBufferEndingInNewline) {
 
 TEST_F(SourceMgrTest, BasicRange) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(4, 3),
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(4, 3), {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"
@@ -466,8 +432,7 @@ TEST_F(SourceMgrTest, BasicRange) {
 
 TEST_F(SourceMgrTest, RangeWithTab) {
   setMainBuffer("aaa\tbbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(3, 3),
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(3, 3), {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa     bbb\n"
@@ -477,8 +442,7 @@ TEST_F(SourceMgrTest, RangeWithTab) {
 
 TEST_F(SourceMgrTest, MultiLineRange) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(4, 7),
-               {});
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(4, 7), {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"

--- a/llvm/unittests/Support/SourceMgrTest.cpp
+++ b/llvm/unittests/Support/SourceMgrTest.cpp
@@ -48,8 +48,8 @@ public:
 
 TEST_F(SourceMgrTest, BasicError) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"
@@ -59,8 +59,8 @@ TEST_F(SourceMgrTest, BasicError) {
 
 TEST_F(SourceMgrTest, BasicWarning) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Warning, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(4), SourceMgr::DK_Warning, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:5: warning: message\n"
             "aaa bbb\n"
@@ -70,8 +70,8 @@ TEST_F(SourceMgrTest, BasicWarning) {
 
 TEST_F(SourceMgrTest, BasicRemark) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Remark, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(4), SourceMgr::DK_Remark, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:5: remark: message\n"
             "aaa bbb\n"
@@ -81,8 +81,8 @@ TEST_F(SourceMgrTest, BasicRemark) {
 
 TEST_F(SourceMgrTest, BasicNote) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Note, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(4), SourceMgr::DK_Note, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:5: note: message\n"
             "aaa bbb\n"
@@ -92,8 +92,8 @@ TEST_F(SourceMgrTest, BasicNote) {
 
 TEST_F(SourceMgrTest, LocationAtEndOfLine) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(6), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(6), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:7: error: message\n"
             "aaa bbb\n"
@@ -103,8 +103,8 @@ TEST_F(SourceMgrTest, LocationAtEndOfLine) {
 
 TEST_F(SourceMgrTest, LocationAtNewline) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(7), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(7), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:8: error: message\n"
             "aaa bbb\n"
@@ -114,8 +114,8 @@ TEST_F(SourceMgrTest, LocationAtNewline) {
 
 TEST_F(SourceMgrTest, LocationAtEmptyBuffer) {
   setMainBuffer("", "file.in");
-  printMessage(getLoc(0), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(0), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:1: error: message\n"
             "\n"
@@ -125,8 +125,8 @@ TEST_F(SourceMgrTest, LocationAtEmptyBuffer) {
 
 TEST_F(SourceMgrTest, LocationJustOnSoleNewline) {
   setMainBuffer("\n", "file.in");
-  printMessage(getLoc(0), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(0), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:1: error: message\n"
             "\n"
@@ -136,8 +136,8 @@ TEST_F(SourceMgrTest, LocationJustOnSoleNewline) {
 
 TEST_F(SourceMgrTest, LocationJustAfterSoleNewline) {
   setMainBuffer("\n", "file.in");
-  printMessage(getLoc(1), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(1), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:2:1: error: message\n"
             "\n"
@@ -147,8 +147,8 @@ TEST_F(SourceMgrTest, LocationJustAfterSoleNewline) {
 
 TEST_F(SourceMgrTest, LocationJustAfterNonNewline) {
   setMainBuffer("123", "file.in");
-  printMessage(getLoc(3), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(3), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:4: error: message\n"
             "123\n"
@@ -158,8 +158,8 @@ TEST_F(SourceMgrTest, LocationJustAfterNonNewline) {
 
 TEST_F(SourceMgrTest, LocationOnFirstLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(3), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(3), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:4: error: message\n"
             "1234\n"
@@ -169,8 +169,8 @@ TEST_F(SourceMgrTest, LocationOnFirstLineOfMultiline) {
 
 TEST_F(SourceMgrTest, LocationOnEOLOfFirstLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "1234\n"
@@ -180,8 +180,8 @@ TEST_F(SourceMgrTest, LocationOnEOLOfFirstLineOfMultiline) {
 
 TEST_F(SourceMgrTest, LocationOnSecondLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(5), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(5), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:2:1: error: message\n"
             "6789\n"
@@ -191,8 +191,8 @@ TEST_F(SourceMgrTest, LocationOnSecondLineOfMultiline) {
 
 TEST_F(SourceMgrTest, LocationOnSecondLineOfMultilineNoSecondEOL) {
   setMainBuffer("1234\n6789", "file.in");
-  printMessage(getLoc(5), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(5), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:2:1: error: message\n"
             "6789\n"
@@ -202,8 +202,8 @@ TEST_F(SourceMgrTest, LocationOnSecondLineOfMultilineNoSecondEOL) {
 
 TEST_F(SourceMgrTest, LocationOnEOLOfSecondSecondLineOfMultiline) {
   setMainBuffer("1234\n6789\n", "file.in");
-  printMessage(getLoc(9), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(9), SourceMgr::DK_Error, "message", {},
+               {});
 
   EXPECT_EQ("file.in:2:5: error: message\n"
             "6789\n"
@@ -233,8 +233,8 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf255ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12"                       // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(253), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(253), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:1: error: message\n"
             "12\n"
             "^\n",
@@ -245,8 +245,8 @@ TEST_F(SourceMgrTest, LocationAtEndOf255ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12"                       // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "12\n"
             " ^\n",
@@ -257,8 +257,8 @@ TEST_F(SourceMgrTest, LocationPastEndOf255ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12"                       // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "12\n"
             "  ^\n",
@@ -269,8 +269,8 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf255ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1\n"                      // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(253), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(253), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:1: error: message\n"
             "1\n"
             "^\n",
@@ -281,8 +281,8 @@ TEST_F(SourceMgrTest, LocationAtEndOf255ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1\n"                      // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "1\n"
             " ^\n",
@@ -293,8 +293,8 @@ TEST_F(SourceMgrTest, LocationPastEndOf255ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1\n"                      // + 2 = 255 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:25:1: error: message\n"
             "\n"
             "^\n",
@@ -309,8 +309,8 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf256ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123"                      // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "123\n"
             " ^\n",
@@ -321,8 +321,8 @@ TEST_F(SourceMgrTest, LocationAtEndOf256ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123"                      // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "123\n"
             "  ^\n",
@@ -333,8 +333,8 @@ TEST_F(SourceMgrTest, LocationPastEndOf256ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123"                      // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:4: error: message\n"
             "123\n"
             "   ^\n",
@@ -345,8 +345,8 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf256ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12\n"                     // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(254), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(254), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:2: error: message\n"
             "12\n"
             " ^\n",
@@ -357,8 +357,8 @@ TEST_F(SourceMgrTest, LocationAtEndOf256ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12\n"                     // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "12\n"
             "  ^\n",
@@ -369,8 +369,8 @@ TEST_F(SourceMgrTest, LocationPastEndOf256ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "12\n"                     // + 3 = 256 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:25:1: error: message\n"
             "\n"
             "^\n",
@@ -385,8 +385,8 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf257ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1234"                     // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "1234\n"
             "  ^\n",
@@ -397,8 +397,8 @@ TEST_F(SourceMgrTest, LocationAtEndOf257ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1234"                     // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:4: error: message\n"
             "1234\n"
             "   ^\n",
@@ -409,8 +409,8 @@ TEST_F(SourceMgrTest, LocationPastEndOf257ByteBuffer) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "1234"                     // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(257), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(257), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:5: error: message\n"
             "1234\n"
             "    ^\n",
@@ -421,8 +421,8 @@ TEST_F(SourceMgrTest, LocationBeforeEndOf257ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123\n"                    // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(255), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(255), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:3: error: message\n"
             "123\n"
             "  ^\n",
@@ -433,8 +433,8 @@ TEST_F(SourceMgrTest, LocationAtEndOf257ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123\n"                    // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(256), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(256), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:24:4: error: message\n"
             "123\n"
             "   ^\n",
@@ -445,8 +445,8 @@ TEST_F(SourceMgrTest, LocationPastEndOf257ByteBufferEndingInNewline) {
   setMainBuffer(STRING_LITERAL_253_BYTES   // first 253 bytes
                 "123\n"                    // + 4 = 257 bytes
                 , "file.in");
-  printMessage(getLoc(257), SourceMgr::DK_Error, "message", std::nullopt,
-               std::nullopt);
+  printMessage(getLoc(257), SourceMgr::DK_Error, "message", {},
+               {});
   EXPECT_EQ("file.in:25:1: error: message\n"
             "\n"
             "^\n",
@@ -456,7 +456,7 @@ TEST_F(SourceMgrTest, LocationPastEndOf257ByteBufferEndingInNewline) {
 TEST_F(SourceMgrTest, BasicRange) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
   printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(4, 3),
-               std::nullopt);
+               {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"
@@ -467,7 +467,7 @@ TEST_F(SourceMgrTest, BasicRange) {
 TEST_F(SourceMgrTest, RangeWithTab) {
   setMainBuffer("aaa\tbbb\nccc ddd\n", "file.in");
   printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(3, 3),
-               std::nullopt);
+               {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa     bbb\n"
@@ -478,7 +478,7 @@ TEST_F(SourceMgrTest, RangeWithTab) {
 TEST_F(SourceMgrTest, MultiLineRange) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
   printMessage(getLoc(4), SourceMgr::DK_Error, "message", getRange(4, 7),
-               std::nullopt);
+               {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"
@@ -489,7 +489,7 @@ TEST_F(SourceMgrTest, MultiLineRange) {
 TEST_F(SourceMgrTest, MultipleRanges) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
   SMRange Ranges[] = { getRange(0, 3), getRange(4, 3) };
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", Ranges, std::nullopt);
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", Ranges, {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"
@@ -500,7 +500,7 @@ TEST_F(SourceMgrTest, MultipleRanges) {
 TEST_F(SourceMgrTest, OverlappingRanges) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
   SMRange Ranges[] = { getRange(0, 3), getRange(2, 4) };
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", Ranges, std::nullopt);
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", Ranges, {});
 
   EXPECT_EQ("file.in:1:5: error: message\n"
             "aaa bbb\n"
@@ -510,7 +510,7 @@ TEST_F(SourceMgrTest, OverlappingRanges) {
 
 TEST_F(SourceMgrTest, BasicFixit) {
   setMainBuffer("aaa bbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(4), SourceMgr::DK_Error, "message", std::nullopt,
+  printMessage(getLoc(4), SourceMgr::DK_Error, "message", {},
                ArrayRef(SMFixIt(getRange(4, 3), "zzz")));
 
   EXPECT_EQ("file.in:1:5: error: message\n"
@@ -522,7 +522,7 @@ TEST_F(SourceMgrTest, BasicFixit) {
 
 TEST_F(SourceMgrTest, FixitForTab) {
   setMainBuffer("aaa\tbbb\nccc ddd\n", "file.in");
-  printMessage(getLoc(3), SourceMgr::DK_Error, "message", std::nullopt,
+  printMessage(getLoc(3), SourceMgr::DK_Error, "message", {},
                ArrayRef(SMFixIt(getRange(3, 1), "zzz")));
 
   EXPECT_EQ("file.in:1:4: error: message\n"

--- a/llvm/unittests/Transforms/Utils/CloningTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CloningTest.cpp
@@ -475,7 +475,7 @@ protected:
 
     // Function DI
     auto *File = DBuilder.createFile("filename.c", "/file/dir/");
-    DITypeRefArray ParamTypes = DBuilder.getOrCreateTypeArray(std::nullopt);
+    DITypeRefArray ParamTypes = DBuilder.getOrCreateTypeArray({});
     DISubroutineType *FuncType =
         DBuilder.createSubroutineType(ParamTypes);
     auto *CU = DBuilder.createCompileUnit(dwarf::DW_LANG_C99,
@@ -965,7 +965,7 @@ protected:
 
     // Create debug info
     auto *File = DBuilder.createFile("filename.c", "/file/dir/");
-    DITypeRefArray ParamTypes = DBuilder.getOrCreateTypeArray(std::nullopt);
+    DITypeRefArray ParamTypes = DBuilder.getOrCreateTypeArray({});
     DISubroutineType *DFuncType = DBuilder.createSubroutineType(ParamTypes);
     auto *CU = DBuilder.createCompileUnit(dwarf::DW_LANG_C99,
                                           DBuilder.createFile("filename.c",

--- a/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
+++ b/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
@@ -21,7 +21,7 @@ namespace {
 
 TEST(ValueMapperTest, mapMDNode) {
   LLVMContext Context;
-  auto *U = MDTuple::get(Context, std::nullopt);
+  auto *U = MDTuple::get(Context, {});
 
   // The node should be unchanged.
   ValueToValueMapTy VM;
@@ -107,7 +107,7 @@ TEST(ValueMapperTest, mapMDNodeDuplicatedCycle) {
 
 TEST(ValueMapperTest, mapMDNodeUnresolved) {
   LLVMContext Context;
-  TempMDTuple T = MDTuple::getTemporary(Context, std::nullopt);
+  TempMDTuple T = MDTuple::getTemporary(Context, {});
 
   ValueToValueMapTy VM;
   EXPECT_EQ(T.get(), ValueMapper(VM, RF_NoModuleLevelChanges).mapMDNode(*T));
@@ -115,7 +115,7 @@ TEST(ValueMapperTest, mapMDNodeUnresolved) {
 
 TEST(ValueMapperTest, mapMDNodeDistinct) {
   LLVMContext Context;
-  auto *D = MDTuple::getDistinct(Context, std::nullopt);
+  auto *D = MDTuple::getDistinct(Context, {});
 
   {
     // The node should be cloned.
@@ -131,11 +131,11 @@ TEST(ValueMapperTest, mapMDNodeDistinct) {
 
 TEST(ValueMapperTest, mapMDNodeDistinctOperands) {
   LLVMContext Context;
-  Metadata *Old = MDTuple::getDistinct(Context, std::nullopt);
+  Metadata *Old = MDTuple::getDistinct(Context, {});
   auto *D = MDTuple::getDistinct(Context, Old);
   ASSERT_EQ(Old, D->getOperand(0));
 
-  Metadata *New = MDTuple::getDistinct(Context, std::nullopt);
+  Metadata *New = MDTuple::getDistinct(Context, {});
   ValueToValueMapTy VM;
   VM.MD()[Old].reset(New);
 
@@ -146,7 +146,7 @@ TEST(ValueMapperTest, mapMDNodeDistinctOperands) {
 
 TEST(ValueMapperTest, mapMDNodeSeeded) {
   LLVMContext Context;
-  auto *D = MDTuple::getDistinct(Context, std::nullopt);
+  auto *D = MDTuple::getDistinct(Context, {});
 
   // The node should be moved.
   ValueToValueMapTy VM;
@@ -159,7 +159,7 @@ TEST(ValueMapperTest, mapMDNodeSeeded) {
 
 TEST(ValueMapperTest, mapMDNodeSeededWithNull) {
   LLVMContext Context;
-  auto *D = MDTuple::getDistinct(Context, std::nullopt);
+  auto *D = MDTuple::getDistinct(Context, {});
 
   // The node should be moved.
   ValueToValueMapTy VM;
@@ -199,7 +199,7 @@ TEST(ValueMapperTest, mapMetadataMDString) {
 
 TEST(ValueMapperTest, mapMetadataGetMappedMD) {
   LLVMContext C;
-  auto *N0 = MDTuple::get(C, std::nullopt);
+  auto *N0 = MDTuple::get(C, {});
   auto *N1 = MDTuple::get(C, N0);
 
   // Make sure hasMD and getMappedMD work correctly.
@@ -216,7 +216,7 @@ TEST(ValueMapperTest, mapMetadataGetMappedMD) {
 
 TEST(ValueMapperTest, mapMetadataNoModuleLevelChanges) {
   LLVMContext C;
-  auto *N0 = MDTuple::get(C, std::nullopt);
+  auto *N0 = MDTuple::get(C, {});
   auto *N1 = MDTuple::get(C, N0);
 
   // Nothing should be memoized when RF_NoModuleLevelChanges.
@@ -246,7 +246,7 @@ TEST(ValueMapperTest, mapMetadataConstantAsMetadata) {
     EXPECT_FALSE(VM.MD().count(CAM));
 
     // But it should respect a mapping that gets seeded.
-    auto *N = MDTuple::get(C, std::nullopt);
+    auto *N = MDTuple::get(C, {});
     VM.MD()[CAM].reset(N);
     EXPECT_EQ(N, ValueMapper(VM).mapMetadata(*CAM));
     EXPECT_EQ(N, ValueMapper(VM, RF_IgnoreMissingLocals).mapMetadata(*CAM));
@@ -303,7 +303,7 @@ TEST(ValueMapperTest, mapValueLocalAsMetadata) {
   // property.  To keep RemapInstruction from crashing we need a non-null
   // return here, but we also shouldn't reference the unmapped local.  Use
   // "metadata !{}".
-  auto *N0 = MDTuple::get(C, std::nullopt);
+  auto *N0 = MDTuple::get(C, {});
   auto *N0AV = MetadataAsValue::get(C, N0);
   ValueToValueMapTy VM;
   EXPECT_EQ(N0AV, ValueMapper(VM).mapValue(*MAV));


### PR DESCRIPTION
Follow up to #109133.
