### PR TITLE
[clang-tools-extra] Use {} instead of std::nullopt to initialize empty ArrayRef

### DIFF
--- a/clang-tools-extra/clang-query/Query.cpp
+++ b/clang-tools-extra/clang-query/Query.cpp
@@ -146,7 +146,7 @@ bool MatchQuery::run(llvm::raw_ostream &OS, QuerySession &QS) const {
             TD.emitDiagnostic(
                 FullSourceLoc(R.getBegin(), AST->getSourceManager()),
                 DiagnosticsEngine::Note, "\"" + BI->first + "\" binds here",
-                CharSourceRange::getTokenRange(R), std::nullopt);
+                CharSourceRange::getTokenRange(R), {});
           }
         }
         if (QS.PrintOutput) {

--- a/clang-tools-extra/unittests/clang-tidy/ClangTidyTest.h
+++ b/clang-tools-extra/unittests/clang-tidy/ClangTidyTest.h
@@ -86,7 +86,7 @@ template <typename... CheckTypes>
 std::string
 runCheckOnCode(StringRef Code, std::vector<ClangTidyError> *Errors = nullptr,
                const Twine &Filename = "input.cc",
-               ArrayRef<std::string> ExtraArgs = std::nullopt,
+               ArrayRef<std::string> ExtraArgs = {},
                const ClangTidyOptions &ExtraOptions = ClangTidyOptions(),
                std::map<StringRef, StringRef> PathsToContent =
                    std::map<StringRef, StringRef>()) {

--- a/clang-tools-extra/unittests/clang-tidy/IncludeCleanerTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/IncludeCleanerTest.cpp
@@ -103,14 +103,13 @@ int BazResult = baz();
 )";
 
   std::vector<ClangTidyError> Errors;
-  EXPECT_EQ(PostCode,
-            runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
-                {{"bar.h", R"(#pragma once
+  EXPECT_EQ(PostCode, runCheckOnCode<IncludeCleanerCheck>(
+                          PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
+                          {{"bar.h", R"(#pragma once
                               #include "baz.h"
                               int bar();
                            )"},
-                 {"baz.h", R"(#pragma once
+                           {"baz.h", R"(#pragma once
                               int baz();
                            )"}}));
 }
@@ -124,8 +123,8 @@ int BarResult2 = $diag2^bar();)");
 
   {
     std::vector<ClangTidyError> Errors;
-    runCheckOnCode<IncludeCleanerCheck>(Code.code(), &Errors, "file.cpp",
-                                        {}, ClangTidyOptions(),
+    runCheckOnCode<IncludeCleanerCheck>(Code.code(), &Errors, "file.cpp", {},
+                                        ClangTidyOptions(),
                                         {{"baz.h", R"(#pragma once
                               #include "bar.h"
                            )"},
@@ -141,8 +140,8 @@ int BarResult2 = $diag2^bar();)");
     std::vector<ClangTidyError> Errors;
     ClangTidyOptions Opts;
     Opts.CheckOptions.insert({"DeduplicateFindings", "false"});
-    runCheckOnCode<IncludeCleanerCheck>(Code.code(), &Errors, "file.cpp",
-                                        {}, Opts,
+    runCheckOnCode<IncludeCleanerCheck>(Code.code(), &Errors, "file.cpp", {},
+                                        Opts,
                                         {{"baz.h", R"(#pragma once
                               #include "bar.h"
                            )"},
@@ -215,14 +214,13 @@ int BazResult_1 = baz_1();
 )";
 
   std::vector<ClangTidyError> Errors;
-  EXPECT_EQ(PostCode,
-            runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
-                {{"bar.h", R"(#pragma once
+  EXPECT_EQ(PostCode, runCheckOnCode<IncludeCleanerCheck>(
+                          PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
+                          {{"bar.h", R"(#pragma once
                               #include "baz.h"
                               int bar();
                            )"},
-                 {"baz.h", R"(#pragma once
+                           {"baz.h", R"(#pragma once
                               int baz_0();
                               int baz_1();
                            )"}}));
@@ -244,13 +242,12 @@ std::vector Vec;
 )";
 
   std::vector<ClangTidyError> Errors;
-  EXPECT_EQ(PostCode,
-            runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
-                {{"string", R"(#pragma once
+  EXPECT_EQ(PostCode, runCheckOnCode<IncludeCleanerCheck>(
+                          PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
+                          {{"string", R"(#pragma once
                               namespace std { class string {}; }
                             )"},
-                 {"vector", R"(#pragma once
+                           {"vector", R"(#pragma once
                               #include <string>
                               namespace std { class vector {}; }
                             )"}}));
@@ -272,14 +269,13 @@ int FooBarResult = foobar();
 )";
 
   std::vector<ClangTidyError> Errors;
-  EXPECT_EQ(PostCode,
-            runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
-                {{"bar.h", R"(#pragma once
+  EXPECT_EQ(PostCode, runCheckOnCode<IncludeCleanerCheck>(
+                          PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
+                          {{"bar.h", R"(#pragma once
                               #include "private.h"
                               int bar();
                            )"},
-                 {"private.h", R"(#pragma once
+                           {"private.h", R"(#pragma once
                                 // IWYU pragma: private, include "public.h"
                                 int foobar();
                                )"}}));
@@ -295,11 +291,10 @@ DECLARE(myfunc) {
 )";
 
   std::vector<ClangTidyError> Errors;
-  EXPECT_EQ(PreCode,
-            runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
-                {{"foo.h",
-                  R"(#pragma once
+  EXPECT_EQ(PreCode, runCheckOnCode<IncludeCleanerCheck>(
+                         PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
+                         {{"foo.h",
+                           R"(#pragma once
                      #define DECLARE(X) void X()
                   )"}}));
 
@@ -311,11 +306,10 @@ DECLARE {
 }
 )";
 
-  EXPECT_EQ(PreCode,
-            runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
-                {{"foo.h",
-                  R"(#pragma once
+  EXPECT_EQ(PreCode, runCheckOnCode<IncludeCleanerCheck>(
+                         PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
+                         {{"foo.h",
+                           R"(#pragma once
                      #define DECLARE void myfunc()
                   )"}}));
 }

--- a/clang-tools-extra/unittests/clang-tidy/IncludeCleanerTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/IncludeCleanerTest.cpp
@@ -49,7 +49,7 @@ TEST(IncludeCleanerCheckTest, BasicUnusedIncludes) {
   std::vector<ClangTidyError> Errors;
   EXPECT_EQ(PostCode,
             runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", std::nullopt, ClangTidyOptions(),
+                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
                 {{"bar.h", "#pragma once"}, {"vector", "#pragma once"}}));
 }
 
@@ -78,7 +78,7 @@ TEST(IncludeCleanerCheckTest, SuppressUnusedIncludes) {
   EXPECT_EQ(
       PostCode,
       runCheckOnCode<IncludeCleanerCheck>(
-          PreCode, &Errors, "file.cpp", std::nullopt, Opts,
+          PreCode, &Errors, "file.cpp", {}, Opts,
           {{"bar.h", "#pragma once"},
            {"vector", "#pragma once"},
            {"list", "#pragma once"},
@@ -105,7 +105,7 @@ int BazResult = baz();
   std::vector<ClangTidyError> Errors;
   EXPECT_EQ(PostCode,
             runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", std::nullopt, ClangTidyOptions(),
+                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
                 {{"bar.h", R"(#pragma once
                               #include "baz.h"
                               int bar();
@@ -125,7 +125,7 @@ int BarResult2 = $diag2^bar();)");
   {
     std::vector<ClangTidyError> Errors;
     runCheckOnCode<IncludeCleanerCheck>(Code.code(), &Errors, "file.cpp",
-                                        std::nullopt, ClangTidyOptions(),
+                                        {}, ClangTidyOptions(),
                                         {{"baz.h", R"(#pragma once
                               #include "bar.h"
                            )"},
@@ -142,7 +142,7 @@ int BarResult2 = $diag2^bar();)");
     ClangTidyOptions Opts;
     Opts.CheckOptions.insert({"DeduplicateFindings", "false"});
     runCheckOnCode<IncludeCleanerCheck>(Code.code(), &Errors, "file.cpp",
-                                        std::nullopt, Opts,
+                                        {}, Opts,
                                         {{"baz.h", R"(#pragma once
                               #include "bar.h"
                            )"},
@@ -176,7 +176,7 @@ std::vector x;
       llvm::Regex::escape(appendPathFileSystemIndependent({"foo", "qux.h"}))};
   std::vector<ClangTidyError> Errors;
   EXPECT_EQ(PreCode, runCheckOnCode<IncludeCleanerCheck>(
-                         PreCode, &Errors, "file.cpp", std::nullopt, Opts,
+                         PreCode, &Errors, "file.cpp", {}, Opts,
                          {{"bar.h", R"(#pragma once
                               #include "baz.h"
                               #include "foo/qux.h"
@@ -217,7 +217,7 @@ int BazResult_1 = baz_1();
   std::vector<ClangTidyError> Errors;
   EXPECT_EQ(PostCode,
             runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", std::nullopt, ClangTidyOptions(),
+                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
                 {{"bar.h", R"(#pragma once
                               #include "baz.h"
                               int bar();
@@ -246,7 +246,7 @@ std::vector Vec;
   std::vector<ClangTidyError> Errors;
   EXPECT_EQ(PostCode,
             runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", std::nullopt, ClangTidyOptions(),
+                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
                 {{"string", R"(#pragma once
                               namespace std { class string {}; }
                             )"},
@@ -274,7 +274,7 @@ int FooBarResult = foobar();
   std::vector<ClangTidyError> Errors;
   EXPECT_EQ(PostCode,
             runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", std::nullopt, ClangTidyOptions(),
+                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
                 {{"bar.h", R"(#pragma once
                               #include "private.h"
                               int bar();
@@ -297,7 +297,7 @@ DECLARE(myfunc) {
   std::vector<ClangTidyError> Errors;
   EXPECT_EQ(PreCode,
             runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", std::nullopt, ClangTidyOptions(),
+                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
                 {{"foo.h",
                   R"(#pragma once
                      #define DECLARE(X) void X()
@@ -313,7 +313,7 @@ DECLARE {
 
   EXPECT_EQ(PreCode,
             runCheckOnCode<IncludeCleanerCheck>(
-                PreCode, &Errors, "file.cpp", std::nullopt, ClangTidyOptions(),
+                PreCode, &Errors, "file.cpp", {}, ClangTidyOptions(),
                 {{"foo.h",
                   R"(#pragma once
                      #define DECLARE void myfunc()

--- a/clang-tools-extra/unittests/clang-tidy/IncludeInserterTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/IncludeInserterTest.cpp
@@ -167,7 +167,7 @@ public:
 template <typename Check>
 std::string runCheckOnCode(StringRef Code, StringRef Filename) {
   std::vector<ClangTidyError> Errors;
-  return test::runCheckOnCode<Check>(Code, &Errors, Filename, std::nullopt,
+  return test::runCheckOnCode<Check>(Code, &Errors, Filename, {},
                                      ClangTidyOptions(),
                                      {// Main file include
                                       {"clang_tidy/tests/"

--- a/clang-tools-extra/unittests/clang-tidy/NamespaceAliaserTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/NamespaceAliaserTest.cpp
@@ -56,9 +56,8 @@ std::string runChecker(StringRef Code, unsigned ExpectedWarningCount) {
                                                             "}"}};
   std::vector<ClangTidyError> errors;
 
-  std::string result =
-      test::runCheckOnCode<Check>(Code, &errors, "foo.cc", {},
-                                  ClangTidyOptions(), AdditionalFileContents);
+  std::string result = test::runCheckOnCode<Check>(
+      Code, &errors, "foo.cc", {}, ClangTidyOptions(), AdditionalFileContents);
 
   EXPECT_EQ(ExpectedWarningCount, errors.size());
   return result;

--- a/clang-tools-extra/unittests/clang-tidy/NamespaceAliaserTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/NamespaceAliaserTest.cpp
@@ -57,7 +57,7 @@ std::string runChecker(StringRef Code, unsigned ExpectedWarningCount) {
   std::vector<ClangTidyError> errors;
 
   std::string result =
-      test::runCheckOnCode<Check>(Code, &errors, "foo.cc", std::nullopt,
+      test::runCheckOnCode<Check>(Code, &errors, "foo.cc", {},
                                   ClangTidyOptions(), AdditionalFileContents);
 
   EXPECT_EQ(ExpectedWarningCount, errors.size());

--- a/clang-tools-extra/unittests/clang-tidy/ReadabilityModuleTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/ReadabilityModuleTest.cpp
@@ -256,7 +256,7 @@ TEST(BracesAroundStatementsCheckTest, IfElseWithShortStatements) {
                 "  else if (1 == 2) return -2;\n"
                 "  else return -3;\n"
                 "}",
-                nullptr, "input.cc", std::nullopt, Options));
+                nullptr, "input.cc", {}, Options));
 
   // If the last else is an else-if, we also force it.
   EXPECT_EQ("int main() {\n"
@@ -269,7 +269,7 @@ TEST(BracesAroundStatementsCheckTest, IfElseWithShortStatements) {
                 "  if (false) return -1;\n"
                 "  else if (1 == 2) return -2;\n"
                 "}",
-                nullptr, "input.cc", std::nullopt, Options));
+                nullptr, "input.cc", {}, Options));
 }
 
 TEST(BracesAroundStatementsCheckTest, For) {
@@ -485,7 +485,7 @@ TEST(BracesAroundStatementsCheckTest, Macros) {
 
 #define EXPECT_NO_CHANGES_WITH_OPTS(Check, Opts, Code)                         \
   EXPECT_EQ(Code, runCheckOnCode<Check>(Code, nullptr, "input.cc",             \
-                                        std::nullopt, Opts))
+                                        {}, Opts))
 TEST(BracesAroundStatementsCheckTest, ImplicitCastInReturn) {
   ClangTidyOptions Opts;
   Opts.CheckOptions["test-check-0.ShortStatementLines"] = "1";

--- a/clang-tools-extra/unittests/clang-tidy/ReadabilityModuleTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/ReadabilityModuleTest.cpp
@@ -484,8 +484,7 @@ TEST(BracesAroundStatementsCheckTest, Macros) {
 }
 
 #define EXPECT_NO_CHANGES_WITH_OPTS(Check, Opts, Code)                         \
-  EXPECT_EQ(Code, runCheckOnCode<Check>(Code, nullptr, "input.cc",             \
-                                        {}, Opts))
+  EXPECT_EQ(Code, runCheckOnCode<Check>(Code, nullptr, "input.cc", {}, Opts))
 TEST(BracesAroundStatementsCheckTest, ImplicitCastInReturn) {
   ClangTidyOptions Opts;
   Opts.CheckOptions["test-check-0.ShortStatementLines"] = "1";

--- a/clang-tools-extra/unittests/clang-tidy/TransformerClangTidyCheckTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/TransformerClangTidyCheckTest.cpp
@@ -346,20 +346,20 @@ int h(int x) { return 5; })cc";
   ClangTidyOptions Options;
   std::map<StringRef, StringRef> PathsToContent = {{"input.h", "\n"}};
   Options.CheckOptions["test-check-0.IncludeStyle"] = "llvm";
-  EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                       Input, nullptr, "inputTest.cpp",
-                                       {}, Options, PathsToContent));
-  EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                      Input, nullptr, "input_test.cpp",
-                                      {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsLibraryHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "inputTest.cpp", {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsNormalHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "input_test.cpp", {}, Options, PathsToContent));
 
   Options.CheckOptions["test-check-0.IncludeStyle"] = "google";
-  EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                      Input, nullptr, "inputTest.cc",
-                                      {}, Options, PathsToContent));
-  EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                       Input, nullptr, "input_test.cc",
-                                       {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsNormalHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "inputTest.cc", {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsLibraryHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "input_test.cc", {}, Options, PathsToContent));
 }
 
 TEST(TransformerClangTidyCheckTest, AddIncludeObeysSortStyleGlobalOption) {
@@ -378,20 +378,20 @@ int h(int x) { return 5; })cc";
   ClangTidyOptions Options;
   std::map<StringRef, StringRef> PathsToContent = {{"input.h", "\n"}};
   Options.CheckOptions["IncludeStyle"] = "llvm";
-  EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                       Input, nullptr, "inputTest.cpp",
-                                       {}, Options, PathsToContent));
-  EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                      Input, nullptr, "input_test.cpp",
-                                      {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsLibraryHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "inputTest.cpp", {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsNormalHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "input_test.cpp", {}, Options, PathsToContent));
 
   Options.CheckOptions["IncludeStyle"] = "google";
-  EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                      Input, nullptr, "inputTest.cc",
-                                      {}, Options, PathsToContent));
-  EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
-                                       Input, nullptr, "input_test.cc",
-                                       {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsNormalHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "inputTest.cc", {}, Options, PathsToContent));
+  EXPECT_EQ(TreatsAsLibraryHeader,
+            test::runCheckOnCode<IncludeOrderCheck>(
+                Input, nullptr, "input_test.cc", {}, Options, PathsToContent));
 }
 
 } // namespace

--- a/clang-tools-extra/unittests/clang-tidy/TransformerClangTidyCheckTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/TransformerClangTidyCheckTest.cpp
@@ -260,11 +260,11 @@ TEST(TransformerClangTidyCheckTest, DisableByConfig) {
 
   Options.CheckOptions["test-check-0.Skip"] = "true";
   EXPECT_EQ(Input, test::runCheckOnCode<ConfigurableCheck>(
-                       Input, nullptr, "input.cc", std::nullopt, Options));
+                       Input, nullptr, "input.cc", {}, Options));
 
   Options.CheckOptions["test-check-0.Skip"] = "false";
   EXPECT_EQ(Expected, test::runCheckOnCode<ConfigurableCheck>(
-                          Input, nullptr, "input.cc", std::nullopt, Options));
+                          Input, nullptr, "input.cc", {}, Options));
 }
 
 RewriteRuleWith<std::string> replaceCall(IncludeFormat Format) {
@@ -348,18 +348,18 @@ int h(int x) { return 5; })cc";
   Options.CheckOptions["test-check-0.IncludeStyle"] = "llvm";
   EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                        Input, nullptr, "inputTest.cpp",
-                                       std::nullopt, Options, PathsToContent));
+                                       {}, Options, PathsToContent));
   EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                       Input, nullptr, "input_test.cpp",
-                                      std::nullopt, Options, PathsToContent));
+                                      {}, Options, PathsToContent));
 
   Options.CheckOptions["test-check-0.IncludeStyle"] = "google";
   EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                       Input, nullptr, "inputTest.cc",
-                                      std::nullopt, Options, PathsToContent));
+                                      {}, Options, PathsToContent));
   EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                        Input, nullptr, "input_test.cc",
-                                       std::nullopt, Options, PathsToContent));
+                                       {}, Options, PathsToContent));
 }
 
 TEST(TransformerClangTidyCheckTest, AddIncludeObeysSortStyleGlobalOption) {
@@ -380,18 +380,18 @@ int h(int x) { return 5; })cc";
   Options.CheckOptions["IncludeStyle"] = "llvm";
   EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                        Input, nullptr, "inputTest.cpp",
-                                       std::nullopt, Options, PathsToContent));
+                                       {}, Options, PathsToContent));
   EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                       Input, nullptr, "input_test.cpp",
-                                      std::nullopt, Options, PathsToContent));
+                                      {}, Options, PathsToContent));
 
   Options.CheckOptions["IncludeStyle"] = "google";
   EXPECT_EQ(TreatsAsNormalHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                       Input, nullptr, "inputTest.cc",
-                                      std::nullopt, Options, PathsToContent));
+                                      {}, Options, PathsToContent));
   EXPECT_EQ(TreatsAsLibraryHeader, test::runCheckOnCode<IncludeOrderCheck>(
                                        Input, nullptr, "input_test.cc",
-                                       std::nullopt, Options, PathsToContent));
+                                       {}, Options, PathsToContent));
 }
 
 } // namespace

--- a/clang-tools-extra/unittests/clang-tidy/UsingInserterTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/UsingInserterTest.cpp
@@ -60,9 +60,8 @@ std::string runChecker(StringRef Code, unsigned ExpectedWarningCount) {
                                                             "}"}};
   std::vector<ClangTidyError> errors;
 
-  std::string result =
-      test::runCheckOnCode<Check>(Code, &errors, "foo.cc", {},
-                                  ClangTidyOptions(), AdditionalFileContents);
+  std::string result = test::runCheckOnCode<Check>(
+      Code, &errors, "foo.cc", {}, ClangTidyOptions(), AdditionalFileContents);
 
   EXPECT_EQ(ExpectedWarningCount, errors.size());
   return result;

--- a/clang-tools-extra/unittests/clang-tidy/UsingInserterTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/UsingInserterTest.cpp
@@ -61,7 +61,7 @@ std::string runChecker(StringRef Code, unsigned ExpectedWarningCount) {
   std::vector<ClangTidyError> errors;
 
   std::string result =
-      test::runCheckOnCode<Check>(Code, &errors, "foo.cc", std::nullopt,
+      test::runCheckOnCode<Check>(Code, &errors, "foo.cc", {},
                                   ClangTidyOptions(), AdditionalFileContents);
 
   EXPECT_EQ(ExpectedWarningCount, errors.size());


### PR DESCRIPTION
Follow up to #109133.
