### PR TITLE
[clangd] Improve robustness when clang-tidy check names contain leading spaces.

### DIFF
--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -280,6 +280,8 @@ public:
     llvm::StringRef Check;
     while (!Checks.empty()) {
       std::tie(Check, Checks) = Checks.split(',');
+      Check = Check.trim();
+
       if (Check.empty())
         continue;
 

--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -748,6 +748,10 @@ TEST(DiagnosticTest, ClangTidyEnablesClangWarning) {
   TU.ExtraArgs = {"-Wunused"};
   TU.ClangTidyProvider = addClangArgs({"-Wno-unused"}, {});
   EXPECT_THAT(TU.build().getDiagnostics(), IsEmpty());
+
+  TU.ExtraArgs = {"-Wno-unused"};
+  TU.ClangTidyProvider = addClangArgs({"-Wunused"}, {"-*, clang-diagnostic-*"});
+  EXPECT_THAT(TU.build().getDiagnostics(), SizeIs(1));
 }
 
 TEST(DiagnosticTest, LongFixMessages) {


### PR DESCRIPTION
The current logic assumes that check names do not have leading spaces.

In cases like "-*, clang-diagnostic*", when processing the second check " clang-diagnostics-*" (with a leading space), the check fails on `CDPrefix.starts_with(Check)`, resulting in all diagnostics remaining disabled.