### PR TITLE
[SPIR-V] Fix minor build warnings

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVRegularizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVRegularizer.cpp
@@ -127,7 +127,8 @@ void SPIRVRegularizer::runLowerConstExpr(Function &F) {
             ReplList.push_back(Inst);
           Repl = InsertElementInst::Create(
               (Repl ? Repl : PoisonValue::get(Vec->getType())), V,
-              ConstantInt::get(Type::getInt32Ty(Ctx), Idx++), "", InsPoint->getIterator());
+              ConstantInt::get(Type::getInt32Ty(Ctx), Idx++), "",
+              InsPoint->getIterator());
         }
         WorkList.splice(WorkList.begin(), ReplList);
         return Repl;
@@ -234,11 +235,12 @@ void SPIRVRegularizer::visitCallScalToVec(CallInst *CI, StringRef MangledName,
   // %call = OpExtInst %v2uint %1 s_min %14 %11
   auto ConstInt = ConstantInt::get(IntegerType::get(CI->getContext(), 32), 0);
   PoisonValue *PVal = PoisonValue::get(Arg0Ty);
-  Instruction *Inst =
-      InsertElementInst::Create(PVal, CI->getOperand(1), ConstInt, "", CI->getIterator());
+  Instruction *Inst = InsertElementInst::Create(
+      PVal, CI->getOperand(1), ConstInt, "", CI->getIterator());
   ElementCount VecElemCount = cast<VectorType>(Arg0Ty)->getElementCount();
   Constant *ConstVec = ConstantVector::getSplat(VecElemCount, ConstInt);
-  Value *NewVec = new ShuffleVectorInst(Inst, PVal, ConstVec, "", CI->getIterator());
+  Value *NewVec =
+      new ShuffleVectorInst(Inst, PVal, ConstVec, "", CI->getIterator());
   CI->setOperand(1, NewVec);
   CI->replaceUsesOfWith(OldF, NewF);
   CI->mutateFunctionType(NewF->getFunctionType());

--- a/llvm/lib/Target/SPIRV/SPIRVRegularizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVRegularizer.cpp
@@ -127,7 +127,7 @@ void SPIRVRegularizer::runLowerConstExpr(Function &F) {
             ReplList.push_back(Inst);
           Repl = InsertElementInst::Create(
               (Repl ? Repl : PoisonValue::get(Vec->getType())), V,
-              ConstantInt::get(Type::getInt32Ty(Ctx), Idx++), "", InsPoint);
+              ConstantInt::get(Type::getInt32Ty(Ctx), Idx++), "", InsPoint->getIterator());
         }
         WorkList.splice(WorkList.begin(), ReplList);
         return Repl;
@@ -235,10 +235,10 @@ void SPIRVRegularizer::visitCallScalToVec(CallInst *CI, StringRef MangledName,
   auto ConstInt = ConstantInt::get(IntegerType::get(CI->getContext(), 32), 0);
   PoisonValue *PVal = PoisonValue::get(Arg0Ty);
   Instruction *Inst =
-      InsertElementInst::Create(PVal, CI->getOperand(1), ConstInt, "", CI);
+      InsertElementInst::Create(PVal, CI->getOperand(1), ConstInt, "", CI->getIterator());
   ElementCount VecElemCount = cast<VectorType>(Arg0Ty)->getElementCount();
   Constant *ConstVec = ConstantVector::getSplat(VecElemCount, ConstInt);
-  Value *NewVec = new ShuffleVectorInst(Inst, PVal, ConstVec, "", CI);
+  Value *NewVec = new ShuffleVectorInst(Inst, PVal, ConstVec, "", CI->getIterator());
   CI->setOperand(1, NewVec);
   CI->replaceUsesOfWith(OldF, NewF);
   CI->mutateFunctionType(NewF->getFunctionType());

--- a/llvm/lib/Target/SPIRV/SPIRVStripConvergentIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStripConvergentIntrinsics.cpp
@@ -62,7 +62,7 @@ public:
         return;
 
       auto *NewCall = CallBase::removeOperandBundle(
-          CI, LLVMContext::OB_convergencectrl, CI);
+          CI, LLVMContext::OB_convergencectrl, CI->getIterator());
       NewCall->copyMetadata(*CI);
       CI->replaceAllUsesWith(NewCall);
       ToRemove.insert(CI);


### PR DESCRIPTION
`warning: 'InsertPosition' is deprecated: Use BasicBlock::iterators for insertion instead [-Wdeprecated-declarations]`

Calling `Instruction->getIterator()` removes the warning.