### PR TITLE
[Clang] Prevent Copying of LateParsedClass Instances

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1355,6 +1355,10 @@ private:
     void ParseLexedAttributes() override;
     void ParseLexedPragmas() override;
 
+    // Delete copy constructor and copy assignment operator.
+    LateParsedClass(const LateParsedClass&) = delete;
+    LateParsedClass& operator=(const LateParsedClass&) = delete;
+
   private:
     Parser *Self;
     ParsingClass *Class;

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1356,8 +1356,8 @@ private:
     void ParseLexedPragmas() override;
 
     // Delete copy constructor and copy assignment operator.
-    LateParsedClass(const LateParsedClass&) = delete;
-    LateParsedClass& operator=(const LateParsedClass&) = delete;
+    LateParsedClass(const LateParsedClass &) = delete;
+    LateParsedClass &operator=(const LateParsedClass &) = delete;
 
   private:
     Parser *Self;


### PR DESCRIPTION
Class clang::Parser::LateParsedClass owns resources that are freed in its destructor but has no user-written assignment operator.
This commit explicitly deletes the copy constructor and copy assignment operator for the LateParsedClass. 
