### PR TITLE
[flang] Extension intrinsics INT8 and INT2

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1169,6 +1169,12 @@ static const SpecificIntrinsicInterface specificIntrinsicFunction[]{
     // procedure pointer target.
     {{"index", {{"string", DefaultChar}, {"substring", DefaultChar}},
         DefaultInt}},
+    {{"int2", {{"a", AnyNumeric, Rank::elementalOrBOZ}},
+         TypePattern{IntType, KindCode::exactKind, 2}},
+        "int"},
+    {{"int8", {{"a", AnyNumeric, Rank::elementalOrBOZ}},
+         TypePattern{IntType, KindCode::exactKind, 8}},
+        "int"},
     {{"isign", {{"a", DefaultInt}, {"b", DefaultInt}}, DefaultInt}, "sign"},
     {{"jiabs", {{"a", TypePattern{IntType, KindCode::exactKind, 4}}},
          TypePattern{IntType, KindCode::exactKind, 4}},

--- a/flang/test/Evaluate/int8.f90
+++ b/flang/test/Evaluate/int8.f90
@@ -1,0 +1,5 @@
+! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+!CHECK: warning: REAL(4) to INTEGER(2) conversion overflowed
+!CHECK: PRINT *, 32767_2, 4000000000_8
+print *, int2(4.e9), int8(4.e9)
+end


### PR DESCRIPTION
These are legacy conversion intrinsic functions supported by nearly all Fortran compilers (esp. INT8).
They are equivalent to INT(..., KIND=8 or 2), respectively.