### PR TITLE
[lldb/Interpreter] Propagate `script` output back to command return object

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -884,9 +884,12 @@ bool ScriptInterpreterPythonImpl::ExecuteOneLine(
                   PyRefType::Owned,
                   PyObject_CallObject(m_run_one_line_function.get(),
                                       pargs.get()));
-              if (return_value.IsValid())
+              if (return_value.IsValid()) {
                 success = true;
-              else if (options.GetMaskoutErrors() && PyErr_Occurred()) {
+                PythonString repr = return_value.Repr();
+                if (repr && repr.GetSize())
+                  result->AppendMessage(repr.GetString());
+              } else if (options.GetMaskoutErrors() && PyErr_Occurred()) {
                 PyErr_Print();
                 PyErr_Clear();
               }


### PR DESCRIPTION
When running a oneliner script expression, if the script interpreter returned a value, that value would be printed to the debugger standard output straight from the interpreter instead of being propagated back to the command return object, which would then forward it to its output stream.

This implies that when evaluating a oneliner script expression (with `SBCommandInterpreter::HandleCommand`), the return value would get printed to stdout, but we would not be able to fetch it from the command return object.

This patch solves this issue by extending the default Python `InteractiveConsole` class to keep track of the return value, before include it to the command return object.

rdar://132420488