### PR TITLE
[libc] Include features.h in baremetal targets

### DIFF
--- a/libc/config/baremetal/arm/headers.txt
+++ b/libc/config/baremetal/arm/headers.txt
@@ -2,6 +2,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.assert
     libc.include.ctype
     libc.include.errno
+    libc.include.features
     libc.include.fenv
     libc.include.float
     libc.include.inttypes

--- a/libc/config/baremetal/riscv/headers.txt
+++ b/libc/config/baremetal/riscv/headers.txt
@@ -1,13 +1,14 @@
 set(TARGET_PUBLIC_HEADERS
     libc.include.assert
     libc.include.ctype
-    libc.include.fenv
     libc.include.errno
+    libc.include.features
+    libc.include.fenv
     libc.include.float
-    libc.include.stdint
     libc.include.inttypes
     libc.include.math
     libc.include.stdfix
+    libc.include.stdint
     libc.include.stdio
     libc.include.stdlib
     libc.include.string


### PR DESCRIPTION
This is used by other libraries like libc++.