### PR TITLE
[SPIR-V] Fix deprecation warnings after #102608

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVStripConvergentIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStripConvergentIntrinsics.cpp
@@ -62,7 +62,7 @@ public:
         return;
 
       auto *NewCall = CallBase::removeOperandBundle(
-          CI, LLVMContext::OB_convergencectrl, CI);
+          CI, LLVMContext::OB_convergencectrl, CI->getIterator());
       NewCall->copyMetadata(*CI);
       CI->replaceAllUsesWith(NewCall);
       ToRemove.insert(CI);


### PR DESCRIPTION
Follow up to fix warnings in the SPIRV backend after 2f50b280dc8e "[DebugInfo] Enable deprecation of iterator-insertion methods (#102608)"