### PR TITLE
[SPIR-V] Enable `spirv-sim` lit substitution unconditionally

### DIFF
--- a/llvm/test/CodeGen/SPIRV/lit.local.cfg
+++ b/llvm/test/CodeGen/SPIRV/lit.local.cfg
@@ -3,15 +3,16 @@ if not "SPIRV" in config.root.targets:
 
 spirv_sim_root = os.path.join(config.llvm_src_root, "utils", "spirv-sim")
 
+config.substitutions.append(
+    (
+        "spirv-sim",
+        "'%s' %s" % (config.python_executable,
+                     os.path.join(spirv_sim_root, "spirv-sim.py")),
+    )
+)
+
 if config.spirv_tools_tests:
     config.available_features.add("spirv-tools")
     config.substitutions.append(("spirv-dis", os.path.join(config.llvm_tools_dir, "spirv-dis")))
     config.substitutions.append(("spirv-val", os.path.join(config.llvm_tools_dir, "spirv-val")))
     config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
-    config.substitutions.append(
-      (
-        "spirv-sim",
-        "'%s' %s"
-        % (config.python_executable, os.path.join(spirv_sim_root, "spirv-sim.py")),
-      )
-    )


### PR DESCRIPTION
The uses of spirv-sim aren't gated by LLVM_INCLUDE_SPIRV_TOOLS_TESTS, so the substitution shouldn't be gated either. Fixes tests after #107408