### PR TITLE
[Clang] Include the clang-shlib CMake project when building for MSVC

### DIFF
--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -22,7 +22,7 @@ add_clang_subdirectory(c-index-test)
 add_clang_subdirectory(clang-refactor)
 # For MinGW we only enable shared library if LLVM_LINK_LLVM_DYLIB=ON.
 # Without that option resulting library is too close to 2^16 DLL exports limit.
-if(UNIX OR (MINGW AND LLVM_LINK_LLVM_DYLIB))
+if(UNIX OR (MSVC AND LLVM_BUILD_LLVM_DYLIB_VIS) OR (MINGW AND LLVM_LINK_LLVM_DYLIB))
   add_clang_subdirectory(clang-shlib)
 endif()
 


### PR DESCRIPTION
Enable building clang-cpp shared library for windows when building with explicit visibility macros enabled and LLVM is built as a shared library(LLVM_BUILD_LLVM_DYLIB_VIS).
This is part of the effort to support for enabling plugins on windows by adding better support for building LLVM and Clang as a DLL.