### PR TITLE
[LLVM][TableGen] Use const record pointers in TableGen/Common files

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -910,22 +910,16 @@ bool TreePredicateFn::hasPredCode() const {
 std::string TreePredicateFn::getPredCode() const {
   std::string Code;
 
-  if (!isLoad() && !isStore() && !isAtomic()) {
-    Record *MemoryVT = getMemoryVT();
-
-    if (MemoryVT)
-      PrintFatalError(getOrigPatFragRecord()->getRecord()->getLoc(),
-                      "MemoryVT requires IsLoad or IsStore");
-  }
+  if (!isLoad() && !isStore() && !isAtomic() && getMemoryVT())
+    PrintFatalError(getOrigPatFragRecord()->getRecord()->getLoc(),
+                    "MemoryVT requires IsLoad or IsStore");
 
   if (!isLoad() && !isStore()) {
     if (isUnindexed())
       PrintFatalError(getOrigPatFragRecord()->getRecord()->getLoc(),
                       "IsUnindexed requires IsLoad or IsStore");
 
-    Record *ScalarMemoryVT = getScalarMemoryVT();
-
-    if (ScalarMemoryVT)
+    if (getScalarMemoryVT())
       PrintFatalError(getOrigPatFragRecord()->getRecord()->getLoc(),
                       "ScalarMemoryVT requires IsLoad or IsStore");
   }
@@ -1016,15 +1010,15 @@ std::string TreePredicateFn::getPredCode() const {
   }
 
   if (isLoad() || isStore() || isAtomic()) {
-    if (ListInit *AddressSpaces = getAddressSpaces()) {
+    if (const ListInit *AddressSpaces = getAddressSpaces()) {
       Code += "unsigned AddrSpace = cast<MemSDNode>(N)->getAddressSpace();\n"
               " if (";
 
       ListSeparator LS(" && ");
-      for (Init *Val : AddressSpaces->getValues()) {
+      for (const Init *Val : AddressSpaces->getValues()) {
         Code += LS;
 
-        IntInit *IntVal = dyn_cast<IntInit>(Val);
+        const IntInit *IntVal = dyn_cast<IntInit>(Val);
         if (!IntVal) {
           PrintFatalError(getOrigPatFragRecord()->getRecord()->getLoc(),
                           "AddressSpaces element must be integer");
@@ -1043,9 +1037,7 @@ std::string TreePredicateFn::getPredCode() const {
       Code += "))\nreturn false;\n";
     }
 
-    Record *MemoryVT = getMemoryVT();
-
-    if (MemoryVT)
+    if (const Record *MemoryVT = getMemoryVT())
       Code += ("if (cast<MemSDNode>(N)->getMemoryVT() != MVT::" +
                MemoryVT->getName() + ") return false;\n")
                   .str();
@@ -1129,9 +1121,7 @@ std::string TreePredicateFn::getPredCode() const {
             " if (!cast<StoreSDNode>(N)->isTruncatingStore()) return false;\n";
     }
 
-    Record *ScalarMemoryVT = getScalarMemoryVT();
-
-    if (ScalarMemoryVT)
+    if (const Record *ScalarMemoryVT = getScalarMemoryVT())
       Code += ("if (cast<" + SDNodeName +
                ">(N)->getMemoryVT().getScalarType() != MVT::" +
                ScalarMemoryVT->getName() + ") return false;\n")
@@ -1254,14 +1244,14 @@ bool TreePredicateFn::isAtomicOrderingWeakerThanRelease() const {
   return isPredefinedPredicateEqualTo("IsAtomicOrderingReleaseOrStronger",
                                       false);
 }
-Record *TreePredicateFn::getMemoryVT() const {
+const Record *TreePredicateFn::getMemoryVT() const {
   const Record *R = getOrigPatFragRecord()->getRecord();
   if (R->isValueUnset("MemoryVT"))
     return nullptr;
   return R->getValueAsDef("MemoryVT");
 }
 
-ListInit *TreePredicateFn::getAddressSpaces() const {
+const ListInit *TreePredicateFn::getAddressSpaces() const {
   const Record *R = getOrigPatFragRecord()->getRecord();
   if (R->isValueUnset("AddressSpaces"))
     return nullptr;
@@ -1275,7 +1265,7 @@ int64_t TreePredicateFn::getMinAlignment() const {
   return R->getValueAsInt("MinAlignment");
 }
 
-Record *TreePredicateFn::getScalarMemoryVT() const {
+const Record *TreePredicateFn::getScalarMemoryVT() const {
   const Record *R = getOrigPatFragRecord()->getRecord();
   if (R->isValueUnset("ScalarMemoryVT"))
     return nullptr;
@@ -1419,11 +1409,11 @@ std::string TreePredicateFn::getCodeToRunOnSDNode() const {
 static bool isImmAllOnesAllZerosMatch(const TreePatternNode &P) {
   if (!P.isLeaf())
     return false;
-  DefInit *DI = dyn_cast<DefInit>(P.getLeafValue());
+  const DefInit *DI = dyn_cast<DefInit>(P.getLeafValue());
   if (!DI)
     return false;
 
-  Record *R = DI->getDef();
+  const Record *R = DI->getDef();
   return R->getName() == "immAllOnesV" || R->getName() == "immAllZerosV";
 }
 
@@ -1483,10 +1473,10 @@ int PatternToMatch::getPatternComplexity(const CodeGenDAGPatterns &CGP) const {
 }
 
 void PatternToMatch::getPredicateRecords(
-    SmallVectorImpl<Record *> &PredicateRecs) const {
-  for (Init *I : Predicates->getValues()) {
-    if (DefInit *Pred = dyn_cast<DefInit>(I)) {
-      Record *Def = Pred->getDef();
+    SmallVectorImpl<const Record *> &PredicateRecs) const {
+  for (const Init *I : Predicates->getValues()) {
+    if (const DefInit *Pred = dyn_cast<DefInit>(I)) {
+      const Record *Def = Pred->getDef();
       if (!Def->isSubClassOf("Predicate")) {
 #ifndef NDEBUG
         Def->dump();
@@ -1506,13 +1496,13 @@ void PatternToMatch::getPredicateRecords(
 /// pattern's predicates concatenated with "&&" operators.
 ///
 std::string PatternToMatch::getPredicateCheck() const {
-  SmallVector<Record *, 4> PredicateRecs;
+  SmallVector<const Record *, 4> PredicateRecs;
   getPredicateRecords(PredicateRecs);
 
   SmallString<128> PredicateCheck;
   raw_svector_ostream OS(PredicateCheck);
   ListSeparator LS(" && ");
-  for (Record *Pred : PredicateRecs) {
+  for (const Record *Pred : PredicateRecs) {
     StringRef CondString = Pred->getValueAsString("CondString");
     if (CondString.empty())
       continue;
@@ -1659,7 +1649,7 @@ bool SDTypeConstraint::ApplyTypeConstraint(TreePatternNode &N,
       TP.error(N.getOperator()->getName() + " expects a VT operand!");
       return false;
     }
-    DefInit *DI = cast<DefInit>(NodeToApply.getLeafValue());
+    const DefInit *DI = cast<DefInit>(NodeToApply.getLeafValue());
     const CodeGenTarget &T = TP.getDAGPatterns().getTargetInfo();
     auto VVT = getValueTypeByHwMode(DI->getDef(), T.getHwModes());
     TypeSetByHwMode TypeListTmp(VVT);
@@ -1731,7 +1721,7 @@ bool TreePatternNode::UpdateNodeTypeFromInst(unsigned ResNo,
 
   // The Operand class specifies a type directly.
   if (Operand->isSubClassOf("Operand")) {
-    Record *R = Operand->getValueAsDef("Type");
+    const Record *R = Operand->getValueAsDef("Type");
     const CodeGenTarget &T = TP.getDAGPatterns().getTargetInfo();
     return UpdateNodeType(ResNo, getValueTypeByHwMode(R, T.getHwModes()), TP);
   }
@@ -1802,7 +1792,7 @@ bool TreePatternNode::setDefaultMode(unsigned Mode) {
 SDNodeInfo::SDNodeInfo(const Record *R, const CodeGenHwModes &CGH) : Def(R) {
   EnumName = R->getValueAsString("Opcode");
   SDClassName = R->getValueAsString("SDClass");
-  Record *TypeProfile = R->getValueAsDef("TypeProfile");
+  const Record *TypeProfile = R->getValueAsDef("TypeProfile");
   NumResults = TypeProfile->getValueAsInt("NumResults");
   NumOperands = TypeProfile->getValueAsInt("NumOperands");
 
@@ -1810,9 +1800,7 @@ SDNodeInfo::SDNodeInfo(const Record *R, const CodeGenHwModes &CGH) : Def(R) {
   Properties = parseSDPatternOperatorProperties(R);
 
   // Parse the type constraints.
-  std::vector<Record *> ConstraintList =
-      TypeProfile->getValueAsListOfDefs("Constraints");
-  for (Record *R : ConstraintList)
+  for (const Record *R : TypeProfile->getValueAsListOfDefs("Constraints"))
     TypeConstraints.emplace_back(R, CGH);
 }
 
@@ -1872,13 +1860,13 @@ static unsigned GetNumNodeResults(const Record *Operator,
       return NumResults;
     }
 
-    ListInit *LI = Operator->getValueAsListInit("Fragments");
+    const ListInit *LI = Operator->getValueAsListInit("Fragments");
     assert(LI && "Invalid Fragment");
     unsigned NumResults = 0;
-    for (Init *I : LI->getValues()) {
-      Record *Op = nullptr;
-      if (DagInit *Dag = dyn_cast<DagInit>(I))
-        if (DefInit *DI = dyn_cast<DefInit>(Dag->getOperator()))
+    for (const Init *I : LI->getValues()) {
+      const Record *Op = nullptr;
+      if (const DagInit *Dag = dyn_cast<DagInit>(I))
+        if (const DefInit *DI = dyn_cast<DefInit>(Dag->getOperator()))
           Op = DI->getDef();
       assert(Op && "Invalid Fragment");
       NumResults = std::max(NumResults, GetNumNodeResults(Op, CDP));
@@ -1986,8 +1974,8 @@ bool TreePatternNode::isIsomorphicTo(const TreePatternNode &N,
     return false;
 
   if (isLeaf()) {
-    if (DefInit *DI = dyn_cast<DefInit>(getLeafValue())) {
-      if (DefInit *NDI = dyn_cast<DefInit>(N.getLeafValue())) {
+    if (const DefInit *DI = dyn_cast<DefInit>(getLeafValue())) {
+      if (const DefInit *NDI = dyn_cast<DefInit>(N.getLeafValue())) {
         return ((DI->getDef() == NDI->getDef()) &&
                 (!DepVars.contains(getName()) || getName() == N.getName()));
       }
@@ -2044,7 +2032,7 @@ void TreePatternNode::SubstituteFormalArguments(
   for (unsigned i = 0, e = getNumChildren(); i != e; ++i) {
     TreePatternNode &Child = getChild(i);
     if (Child.isLeaf()) {
-      Init *Val = Child.getLeafValue();
+      const Init *Val = Child.getLeafValue();
       // Note that, when substituting into an output pattern, Val might be an
       // UnsetInit.
       if (isa<UnsetInit>(Val) ||
@@ -2217,7 +2205,7 @@ void TreePatternNode::InlinePatternFragments(
 /// When Unnamed is false, return the type of a named DAG operand such as the
 /// GPR:$src operand above.
 ///
-static TypeSetByHwMode getImplicitType(Record *R, unsigned ResNo,
+static TypeSetByHwMode getImplicitType(const Record *R, unsigned ResNo,
                                        bool NotRegisters, bool Unnamed,
                                        TreePattern &TP) {
   CodeGenDAGPatterns &CDP = TP.getDAGPatterns();
@@ -2227,7 +2215,7 @@ static TypeSetByHwMode getImplicitType(Record *R, unsigned ResNo,
     assert(ResNo == 0 && "Regoperand ref only has one result!");
     if (NotRegisters)
       return TypeSetByHwMode(); // Unknown.
-    Record *RegClass = R->getValueAsDef("RegClass");
+    const Record *RegClass = R->getValueAsDef("RegClass");
     const CodeGenTarget &T = TP.getDAGPatterns().getTargetInfo();
     return TypeSetByHwMode(T.getRegisterClass(RegClass).getValueTypes());
   }
@@ -2316,7 +2304,7 @@ static TypeSetByHwMode getImplicitType(Record *R, unsigned ResNo,
 
   if (R->isSubClassOf("Operand")) {
     const CodeGenHwModes &CGH = CDP.getTargetInfo().getHwModes();
-    Record *T = R->getValueAsDef("Type");
+    const Record *T = R->getValueAsDef("Type");
     return TypeSetByHwMode(getValueTypeByHwMode(T, CGH));
   }
 
@@ -2343,7 +2331,7 @@ const ComplexPattern *
 TreePatternNode::getComplexPatternInfo(const CodeGenDAGPatterns &CGP) const {
   const Record *Rec;
   if (isLeaf()) {
-    DefInit *DI = dyn_cast<DefInit>(getLeafValue());
+    const DefInit *DI = dyn_cast<DefInit>(getLeafValue());
     if (!DI)
       return nullptr;
     Rec = DI->getDef();
@@ -2362,9 +2350,9 @@ unsigned TreePatternNode::getNumMIResults(const CodeGenDAGPatterns &CGP) const {
 
   // If MIOperandInfo is specified, that gives the count.
   if (isLeaf()) {
-    DefInit *DI = dyn_cast<DefInit>(getLeafValue());
+    const DefInit *DI = dyn_cast<DefInit>(getLeafValue());
     if (DI && DI->getDef()->isSubClassOf("Operand")) {
-      DagInit *MIOps = DI->getDef()->getValueAsDag("MIOperandInfo");
+      const DagInit *MIOps = DI->getDef()->getValueAsDag("MIOperandInfo");
       if (MIOps->getNumArgs())
         return MIOps->getNumArgs();
     }
@@ -2423,7 +2411,7 @@ static bool isOperandClass(const TreePatternNode &N, StringRef Class) {
   if (!N.isLeaf())
     return N.getOperator()->isSubClassOf(Class);
 
-  DefInit *DI = dyn_cast<DefInit>(N.getLeafValue());
+  const DefInit *DI = dyn_cast<DefInit>(N.getLeafValue());
   if (DI && DI->getDef()->isSubClassOf(Class))
     return true;
 
@@ -2451,7 +2439,7 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
 
   CodeGenDAGPatterns &CDP = TP.getDAGPatterns();
   if (isLeaf()) {
-    if (DefInit *DI = dyn_cast<DefInit>(getLeafValue())) {
+    if (const DefInit *DI = dyn_cast<DefInit>(getLeafValue())) {
       // If it's a regclass or something else known, include the type.
       bool MadeChange = false;
       for (unsigned i = 0, e = Types.size(); i != e; ++i)
@@ -2461,7 +2449,7 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
       return MadeChange;
     }
 
-    if (IntInit *II = dyn_cast<IntInit>(getLeafValue())) {
+    if (const IntInit *II = dyn_cast<IntInit>(getLeafValue())) {
       assert(Types.size() == 1 && "Invalid IntInit");
 
       // Int inits are always integers. :)
@@ -2658,7 +2646,7 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
 
           if (Child->getNumMIResults(CDP) < NumArgs) {
             // Match first sub-operand against the child we already have.
-            Record *SubRec = cast<DefInit>(MIOpInfo->getArg(0))->getDef();
+            const Record *SubRec = cast<DefInit>(MIOpInfo->getArg(0))->getDef();
             MadeChange |= Child->UpdateNodeTypeFromInst(ChildResNo, SubRec, TP);
 
             // And the remaining sub-operands against subsequent children.
@@ -2794,8 +2782,8 @@ bool TreePatternNode::canPatternMatch(std::string &Reason,
 // TreePattern implementation
 //
 
-TreePattern::TreePattern(const Record *TheRec, ListInit *RawPat, bool isInput,
-                         CodeGenDAGPatterns &cdp)
+TreePattern::TreePattern(const Record *TheRec, const ListInit *RawPat,
+                         bool isInput, CodeGenDAGPatterns &cdp)
     : TheRecord(TheRec), CDP(cdp), isInputPattern(isInput), HasError(false),
       Infer(*this) {
   for (Init *I : RawPat->getValues())
@@ -2840,8 +2828,10 @@ void TreePattern::ComputeNamedNodes(TreePatternNode &N) {
 TreePatternNodePtr TreePattern::ParseTreePattern(Init *TheInit,
                                                  StringRef OpName) {
   RecordKeeper &RK = TheInit->getRecordKeeper();
+  // Here, we are creating new records (BitsInit->InitInit), so const_cast
+  // TheInit back to non-const pointer.
   if (DefInit *DI = dyn_cast<DefInit>(TheInit)) {
-    Record *R = DI->getDef();
+    const Record *R = DI->getDef();
 
     // Direct reference to a leaf DagNode or PatFrag?  Turn it into a
     // TreePatternNode of its own.  For example:
@@ -2901,7 +2891,7 @@ TreePatternNodePtr TreePattern::ParseTreePattern(Init *TheInit,
     error("Pattern has unexpected operator type!");
     return nullptr;
   }
-  Record *Operator = OpDef->getDef();
+  const Record *Operator = OpDef->getDef();
 
   if (Operator->isSubClassOf("ValueType")) {
     // If the operator is a ValueType, then this must be "type cast" of a leaf
@@ -2996,7 +2986,7 @@ TreePatternNodePtr TreePattern::ParseTreePattern(Init *TheInit,
       // Check that the ComplexPattern uses are consistent: "(MY_PAT $a, $b)"
       // and "(MY_PAT $b, $a)" should not be allowed in the same pattern;
       // neither should "(MY_PAT_1 $a, $b)" and "(MY_PAT_2 $a, $b)".
-      auto OperandId = std::pair(Operator, i);
+      auto OperandId = std::make_pair(Operator, i);
       auto PrevOp = ComplexPatternOperands.find(Child->getName());
       if (PrevOp != ComplexPatternOperands.end()) {
         if (PrevOp->getValue() != OperandId)
@@ -3094,7 +3084,7 @@ bool TreePattern::InferAllTypes(
           // us to match things like:
           //  def : Pat<(v1i64 (bitconvert(v2i32 DPR:$src))), (v1i64 DPR:$src)>;
           if (Node == Trees[0].get() && Node->isLeaf()) {
-            DefInit *DI = dyn_cast<DefInit>(Node->getLeafValue());
+            const DefInit *DI = dyn_cast<DefInit>(Node->getLeafValue());
             if (DI && (DI->getDef()->isSubClassOf("RegisterClass") ||
                        DI->getDef()->isSubClassOf("RegisterOperand")))
               continue;
@@ -3188,11 +3178,10 @@ CodeGenDAGPatterns::CodeGenDAGPatterns(const RecordKeeper &R,
   VerifyInstructionFlags();
 }
 
-Record *CodeGenDAGPatterns::getSDNodeNamed(StringRef Name) const {
-  Record *N = Records.getDef(Name);
+const Record *CodeGenDAGPatterns::getSDNodeNamed(StringRef Name) const {
+  const Record *N = Records.getDef(Name);
   if (!N || !N->isSubClassOf("SDNode"))
     PrintFatalError("Error getting SDNode '" + Name + "'!");
-
   return N;
 }
 
@@ -3286,7 +3275,7 @@ void CodeGenDAGPatterns::ParsePatternFragments(bool OutFrags) {
 
     // If there is a node transformation corresponding to this, keep track of
     // it.
-    Record *Transform = Frag->getValueAsDef("OperandTransform");
+    const Record *Transform = Frag->getValueAsDef("OperandTransform");
     if (!getSDNodeTransform(Transform).second.empty()) // not noop xform?
       for (const auto &T : P->getTrees())
         T->setTransformFn(Transform);
@@ -3369,7 +3358,7 @@ static bool HandleUse(TreePattern &I, TreePatternNodePtr Pat,
   // No name -> not interesting.
   if (Pat->getName().empty()) {
     if (Pat->isLeaf()) {
-      DefInit *DI = dyn_cast<DefInit>(Pat->getLeafValue());
+      const DefInit *DI = dyn_cast<DefInit>(Pat->getLeafValue());
       if (DI && (DI->getDef()->isSubClassOf("RegisterClass") ||
                  DI->getDef()->isSubClassOf("RegisterOperand")))
         I.error("Input " + DI->getDef()->getName() + " must be named!");
@@ -3379,7 +3368,7 @@ static bool HandleUse(TreePattern &I, TreePatternNodePtr Pat,
 
   const Record *Rec;
   if (Pat->isLeaf()) {
-    DefInit *DI = dyn_cast<DefInit>(Pat->getLeafValue());
+    const DefInit *DI = dyn_cast<DefInit>(Pat->getLeafValue());
     if (!DI)
       I.error("Input $" + Pat->getName() + " must be an identifier!");
     Rec = DI->getDef();
@@ -3423,8 +3412,7 @@ void CodeGenDAGPatterns::FindPatternInputsAndOutputs(
     std::map<std::string, TreePatternNodePtr> &InstInputs,
     MapVector<std::string, TreePatternNodePtr, std::map<std::string, unsigned>>
         &InstResults,
-    std::vector<Record *> &InstImpResults) {
-
+    std::vector<const Record *> &InstImpResults) {
   // The instruction pattern still has unresolved fragments.  For *named*
   // nodes we must resolve those here.  This may not result in multiple
   // alternatives.
@@ -3448,7 +3436,7 @@ void CodeGenDAGPatterns::FindPatternInputsAndOutputs(
       if (!Dest.isLeaf())
         I.error("implicitly defined value should be a register!");
 
-      DefInit *Val = dyn_cast<DefInit>(Dest.getLeafValue());
+      const DefInit *Val = dyn_cast<DefInit>(Dest.getLeafValue());
       if (!Val || !Val->getDef()->isSubClassOf("Register"))
         I.error("implicitly defined value should be a register!");
       if (Val)
@@ -3496,7 +3484,7 @@ void CodeGenDAGPatterns::FindPatternInputsAndOutputs(
     if (!Dest->isLeaf())
       I.error("set destination should be a register!");
 
-    DefInit *Val = dyn_cast<DefInit>(Dest->getLeafValue());
+    const DefInit *Val = dyn_cast<DefInit>(Dest->getLeafValue());
     if (!Val) {
       I.error("set destination should be a register!");
       continue;
@@ -3571,8 +3559,8 @@ private:
 public:
   void AnalyzeNode(const TreePatternNode &N) {
     if (N.isLeaf()) {
-      if (DefInit *DI = dyn_cast<DefInit>(N.getLeafValue())) {
-        Record *LeafRec = DI->getDef();
+      if (const DefInit *DI = dyn_cast<DefInit>(N.getLeafValue())) {
+        const Record *LeafRec = DI->getDef();
         // Handle ComplexPattern leaves.
         if (LeafRec->isSubClassOf("ComplexPattern")) {
           const ComplexPattern &CP = CDP.getComplexPattern(LeafRec);
@@ -3729,7 +3717,8 @@ static void getInstructionsInTree(TreePatternNode &Tree,
 
 /// Check the class of a pattern leaf node against the instruction operand it
 /// represents.
-static bool checkOperandClass(CGIOperandList::OperandInfo &OI, Record *Leaf) {
+static bool checkOperandClass(CGIOperandList::OperandInfo &OI,
+                              const Record *Leaf) {
   if (OI.Rec == Leaf)
     return true;
 
@@ -3746,7 +3735,7 @@ static bool checkOperandClass(CGIOperandList::OperandInfo &OI, Record *Leaf) {
 }
 
 void CodeGenDAGPatterns::parseInstructionPattern(CodeGenInstruction &CGI,
-                                                 ListInit *Pat,
+                                                 const ListInit *Pat,
                                                  DAGInstMap &DAGInsts) {
 
   assert(!DAGInsts.count(CGI.TheDef) && "Instruction already parsed!");
@@ -3763,7 +3752,7 @@ void CodeGenDAGPatterns::parseInstructionPattern(CodeGenInstruction &CGI,
   MapVector<std::string, TreePatternNodePtr, std::map<std::string, unsigned>>
       InstResults;
 
-  std::vector<Record *> InstImpResults;
+  std::vector<const Record *> InstImpResults;
 
   // Verify that the top-level forms in the instruction are of void type, and
   // fill in the InstResults map.
@@ -3821,7 +3810,7 @@ void CodeGenDAGPatterns::parseInstructionPattern(CodeGenInstruction &CGI,
       I.error("Operand $" + OpName + " does not exist in operand list!");
 
     TreePatternNodePtr RNode = InstResultIter->second;
-    Record *R = cast<DefInit>(RNode->getLeafValue())->getDef();
+    const Record *R = cast<DefInit>(RNode->getLeafValue())->getDef();
     ResNodes.push_back(std::move(RNode));
     if (!R)
       I.error("Operand $" + OpName +
@@ -3869,7 +3858,7 @@ void CodeGenDAGPatterns::parseInstructionPattern(CodeGenInstruction &CGI,
     InstInputs.erase(OpName); // It occurred, remove from map.
 
     if (InVal->isLeaf() && isa<DefInit>(InVal->getLeafValue())) {
-      Record *InRec = cast<DefInit>(InVal->getLeafValue())->getDef();
+      const Record *InRec = cast<DefInit>(InVal->getLeafValue())->getDef();
       if (!checkOperandClass(Op, InRec)) {
         I.error("Operand $" + OpName +
                 "'s register class disagrees"
@@ -3886,7 +3875,7 @@ void CodeGenDAGPatterns::parseInstructionPattern(CodeGenInstruction &CGI,
     OpNode->clearPredicateCalls();
 
     // Promote the xform function to be an explicit node if set.
-    if (Record *Xform = OpNode->getTransformFn()) {
+    if (const Record *Xform = OpNode->getTransformFn()) {
       OpNode->setTransformFn(nullptr);
       std::vector<TreePatternNodePtr> Children;
       Children.push_back(OpNode);
@@ -3965,7 +3954,7 @@ void CodeGenDAGPatterns::ParseInstructions() {
 
       // Create and insert the instruction.
       Instructions.try_emplace(Instr, std::move(Results), std::move(Operands),
-                               std::vector<Record *>());
+                               std::vector<const Record *>());
       continue; // no pattern.
     }
 
@@ -4211,7 +4200,7 @@ static bool ForceArbitraryInstResultType(TreePatternNode &N, TreePattern &TP) {
 
 // Promote xform function to be an explicit node wherever set.
 static TreePatternNodePtr PromoteXForms(TreePatternNodePtr N) {
-  if (Record *Xform = N->getTransformFn()) {
+  if (const Record *Xform = N->getTransformFn()) {
     N->setTransformFn(nullptr);
     std::vector<TreePatternNodePtr> Children;
     Children.push_back(PromoteXForms(N));
@@ -4229,8 +4218,7 @@ static TreePatternNodePtr PromoteXForms(TreePatternNodePtr N) {
 
 void CodeGenDAGPatterns::ParseOnePattern(
     const Record *TheDef, TreePattern &Pattern, TreePattern &Result,
-    const std::vector<Record *> &InstImpResults, bool ShouldIgnore) {
-
+    ArrayRef<const Record *> InstImpResults, bool ShouldIgnore) {
   // Inline pattern fragments and expand multiple alternatives.
   Pattern.InlinePatternFragments();
   Result.InlinePatternFragments();
@@ -4354,7 +4342,7 @@ void CodeGenDAGPatterns::ParsePatterns() {
     std::map<std::string, TreePatternNodePtr> InstInputs;
     MapVector<std::string, TreePatternNodePtr, std::map<std::string, unsigned>>
         InstResults;
-    std::vector<Record *> InstImpResults;
+    std::vector<const Record *> InstImpResults;
     for (unsigned j = 0, ee = Pattern.getNumTrees(); j != ee; ++j)
       FindPatternInputsAndOutputs(Pattern, Pattern.getTree(j), InstInputs,
                                   InstResults, InstImpResults);
@@ -4682,8 +4670,8 @@ static void GenerateVariantsOf(TreePatternNodePtr N,
     for (; i != e; ++i) {
       TreePatternNode &Child = N->getChild(i);
       if (Child.isLeaf())
-        if (DefInit *DI = dyn_cast<DefInit>(Child.getLeafValue())) {
-          Record *RR = DI->getDef();
+        if (const DefInit *DI = dyn_cast<DefInit>(Child.getLeafValue())) {
+          const Record *RR = DI->getDef();
           if (RR->isSubClassOf("Register"))
             NoRegisters = false;
         }

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -582,13 +582,13 @@ public:
   /// If non-null, indicates that this predicate is a predefined memory VT
   /// predicate for a load/store and returns the ValueType record for the memory
   /// VT.
-  Record *getMemoryVT() const;
+  const Record *getMemoryVT() const;
   /// If non-null, indicates that this predicate is a predefined memory VT
   /// predicate (checking only the scalar type) for load/store and returns the
   /// ValueType record for the memory VT.
-  Record *getScalarMemoryVT() const;
+  const Record *getScalarMemoryVT() const;
 
-  ListInit *getAddressSpaces() const;
+  const ListInit *getAddressSpaces() const;
   int64_t getMinAlignment() const;
 
   // If true, indicates that GlobalISel-based C++ code was supplied.
@@ -634,7 +634,7 @@ class TreePatternNode : public RefCountedBase<TreePatternNode> {
   /// OperatorOrVal - The Record for the operator if this is an interior node
   /// (not a leaf) or the init value (e.g. the "GPRC" record, or "7") for a
   /// leaf.
-  PointerUnion<const Record *, Init *> OperatorOrVal;
+  PointerUnion<const Record *, const Init *> OperatorOrVal;
 
   /// Name - The name given to this node with the :$foo notation.
   ///
@@ -648,7 +648,7 @@ class TreePatternNode : public RefCountedBase<TreePatternNode> {
 
   /// TransformFn - The transformation function to execute on this node before
   /// it can be substituted into the resulting instruction on a pattern match.
-  Record *TransformFn;
+  const Record *TransformFn;
 
   std::vector<TreePatternNodePtr> Children;
 
@@ -664,7 +664,7 @@ public:
     ResultPerm.resize(NumResults);
     std::iota(ResultPerm.begin(), ResultPerm.end(), 0);
   }
-  TreePatternNode(Init *val, unsigned NumResults) // leaf ctor
+  TreePatternNode(const Init *val, unsigned NumResults) // leaf ctor
       : OperatorOrVal(val), TransformFn(nullptr) {
     Types.resize(NumResults);
     ResultPerm.resize(NumResults);
@@ -685,7 +685,7 @@ public:
     NamesAsPredicateArg.push_back(N);
   }
 
-  bool isLeaf() const { return isa<Init *>(OperatorOrVal); }
+  bool isLeaf() const { return isa<const Init *>(OperatorOrVal); }
 
   // Type accessors.
   unsigned getNumTypes() const { return Types.size(); }
@@ -713,9 +713,9 @@ public:
   unsigned getResultIndex(unsigned ResNo) const { return ResultPerm[ResNo]; }
   void setResultIndex(unsigned ResNo, unsigned RI) { ResultPerm[ResNo] = RI; }
 
-  Init *getLeafValue() const {
+  const Init *getLeafValue() const {
     assert(isLeaf());
-    return cast<Init *>(OperatorOrVal);
+    return cast<const Init *>(OperatorOrVal);
   }
   const Record *getOperator() const {
     assert(!isLeaf());
@@ -766,8 +766,8 @@ public:
     addPredicateCall(TreePredicateCall(Fn, Scope));
   }
 
-  Record *getTransformFn() const { return TransformFn; }
-  void setTransformFn(Record *Fn) { TransformFn = Fn; }
+  const Record *getTransformFn() const { return TransformFn; }
+  void setTransformFn(const Record *Fn) { TransformFn = Fn; }
 
   /// getIntrinsicInfo - If this node corresponds to an intrinsic, return the
   /// CodeGenIntrinsic information for it, otherwise return a null pointer.
@@ -901,14 +901,14 @@ class TreePattern {
   /// ComplexPattern. This records the ComplexPattern instance and the operand
   /// number for each operand encountered in a ComplexPattern to aid in that
   /// check.
-  StringMap<std::pair<Record *, unsigned>> ComplexPatternOperands;
+  StringMap<std::pair<const Record *, unsigned>> ComplexPatternOperands;
 
   TypeInfer Infer;
 
 public:
   /// TreePattern constructor - Parse the specified DagInits into the
   /// current record.
-  TreePattern(const Record *TheRec, ListInit *RawPat, bool isInput,
+  TreePattern(const Record *TheRec, const ListInit *RawPat, bool isInput,
               CodeGenDAGPatterns &ise);
   TreePattern(const Record *TheRec, DagInit *Pat, bool isInput,
               CodeGenDAGPatterns &ise);
@@ -1013,24 +1013,24 @@ struct DAGDefaultOperand {
 class DAGInstruction {
   std::vector<const Record *> Results;
   std::vector<const Record *> Operands;
-  std::vector<Record *> ImpResults;
+  std::vector<const Record *> ImpResults;
   TreePatternNodePtr SrcPattern;
   TreePatternNodePtr ResultPattern;
 
 public:
-  DAGInstruction(std::vector<const Record *> &&results,
-                 std::vector<const Record *> &&operands,
-                 std::vector<Record *> &&impresults,
-                 TreePatternNodePtr srcpattern = nullptr,
-                 TreePatternNodePtr resultpattern = nullptr)
-      : Results(std::move(results)), Operands(std::move(operands)),
-        ImpResults(std::move(impresults)), SrcPattern(srcpattern),
-        ResultPattern(resultpattern) {}
+  DAGInstruction(std::vector<const Record *> &&Results,
+                 std::vector<const Record *> &&Operands,
+                 std::vector<const Record *> &&ImpResults,
+                 TreePatternNodePtr SrcPattern = nullptr,
+                 TreePatternNodePtr ResultPattern = nullptr)
+      : Results(std::move(Results)), Operands(std::move(Operands)),
+        ImpResults(std::move(ImpResults)), SrcPattern(SrcPattern),
+        ResultPattern(ResultPattern) {}
 
   unsigned getNumResults() const { return Results.size(); }
   unsigned getNumOperands() const { return Operands.size(); }
   unsigned getNumImpResults() const { return ImpResults.size(); }
-  const std::vector<Record *> &getImpResults() const { return ImpResults; }
+  ArrayRef<const Record *> getImpResults() const { return ImpResults; }
 
   const Record *getResult(unsigned RN) const {
     assert(RN < Results.size());
@@ -1042,7 +1042,7 @@ public:
     return Operands[ON];
   }
 
-  Record *getImpResult(unsigned RN) const {
+  const Record *getImpResult(unsigned RN) const {
     assert(RN < ImpResults.size());
     return ImpResults[RN];
   }
@@ -1058,7 +1058,7 @@ class PatternToMatch {
   ListInit *Predicates;          // Top level predicate conditions to match.
   TreePatternNodePtr SrcPattern; // Source pattern to match.
   TreePatternNodePtr DstPattern; // Resulting pattern.
-  std::vector<Record *> Dstregs; // Physical register defs being matched.
+  std::vector<const Record *> Dstregs; // Physical register defs being matched.
   std::string HwModeFeatures;
   int AddedComplexity;    // Add to matching pattern complexity.
   bool GISelShouldIgnore; // Should GlobalISel ignore importing this pattern.
@@ -1067,12 +1067,11 @@ class PatternToMatch {
 public:
   PatternToMatch(const Record *srcrecord, ListInit *preds,
                  TreePatternNodePtr src, TreePatternNodePtr dst,
-                 std::vector<Record *> dstregs, int complexity, unsigned uid,
+                 ArrayRef<const Record *> dstregs, int complexity, unsigned uid,
                  bool ignore, const Twine &hwmodefeatures = "")
       : SrcRecord(srcrecord), Predicates(preds), SrcPattern(src),
-        DstPattern(dst), Dstregs(std::move(dstregs)),
-        HwModeFeatures(hwmodefeatures.str()), AddedComplexity(complexity),
-        GISelShouldIgnore(ignore), ID(uid) {}
+        DstPattern(dst), Dstregs(dstregs), HwModeFeatures(hwmodefeatures.str()),
+        AddedComplexity(complexity), GISelShouldIgnore(ignore), ID(uid) {}
 
   const Record *getSrcRecord() const { return SrcRecord; }
   ListInit *getPredicates() const { return Predicates; }
@@ -1080,14 +1079,15 @@ public:
   TreePatternNodePtr getSrcPatternShared() const { return SrcPattern; }
   TreePatternNode &getDstPattern() const { return *DstPattern; }
   TreePatternNodePtr getDstPatternShared() const { return DstPattern; }
-  const std::vector<Record *> &getDstRegs() const { return Dstregs; }
+  ArrayRef<const Record *> getDstRegs() const { return Dstregs; }
   StringRef getHwModeFeatures() const { return HwModeFeatures; }
   int getAddedComplexity() const { return AddedComplexity; }
   bool getGISelShouldIgnore() const { return GISelShouldIgnore; }
   unsigned getID() const { return ID; }
 
   std::string getPredicateCheck() const;
-  void getPredicateRecords(SmallVectorImpl<Record *> &PredicateRecs) const;
+  void
+  getPredicateRecords(SmallVectorImpl<const Record *> &PredicateRecs) const;
 
   /// Compute the complexity metric for the input pattern.  This roughly
   /// corresponds to the number of nodes that are covered.
@@ -1113,8 +1113,8 @@ private:
   std::map<const Record *, DAGInstruction, LessRecordByID> Instructions;
 
   // Specific SDNode definitions:
-  Record *intrinsic_void_sdnode;
-  Record *intrinsic_w_chain_sdnode, *intrinsic_wo_chain_sdnode;
+  const Record *intrinsic_void_sdnode;
+  const Record *intrinsic_w_chain_sdnode, *intrinsic_wo_chain_sdnode;
 
   /// PatternsToMatch - All of the things we are matching on the DAG.  The first
   /// value is the pattern to match, the second pattern is the result to
@@ -1136,7 +1136,7 @@ public:
   const CodeGenTarget &getTargetInfo() const { return Target; }
   const TypeSetByHwMode &getLegalTypes() const { return LegalVTS; }
 
-  Record *getSDNodeNamed(StringRef Name) const;
+  const Record *getSDNodeNamed(StringRef Name) const;
 
   const SDNodeInfo &getSDNodeInfo(const Record *R) const {
     auto F = SDNodes.find(R);
@@ -1170,7 +1170,7 @@ public:
     llvm_unreachable("Bad intrinsic ID!");
   }
 
-  unsigned getIntrinsicID(Record *R) const {
+  unsigned getIntrinsicID(const Record *R) const {
     for (unsigned i = 0, e = Intrinsics.size(); i != e; ++i)
       if (Intrinsics[i].TheDef == R)
         return i;
@@ -1209,7 +1209,7 @@ public:
 
   /// Parse the Pattern for an instruction, and insert the result in DAGInsts.
   typedef std::map<const Record *, DAGInstruction, LessRecordByID> DAGInstMap;
-  void parseInstructionPattern(CodeGenInstruction &CGI, ListInit *Pattern,
+  void parseInstructionPattern(CodeGenInstruction &CGI, const ListInit *Pattern,
                                DAGInstMap &DAGInsts);
 
   const DAGInstruction &getInstruction(const Record *R) const {
@@ -1218,11 +1218,13 @@ public:
     return F->second;
   }
 
-  Record *get_intrinsic_void_sdnode() const { return intrinsic_void_sdnode; }
-  Record *get_intrinsic_w_chain_sdnode() const {
+  const Record *get_intrinsic_void_sdnode() const {
+    return intrinsic_void_sdnode;
+  }
+  const Record *get_intrinsic_w_chain_sdnode() const {
     return intrinsic_w_chain_sdnode;
   }
-  Record *get_intrinsic_wo_chain_sdnode() const {
+  const Record *get_intrinsic_wo_chain_sdnode() const {
     return intrinsic_wo_chain_sdnode;
   }
 
@@ -1248,7 +1250,7 @@ private:
 
   void ParseOnePattern(const Record *TheDef, TreePattern &Pattern,
                        TreePattern &Result,
-                       const std::vector<Record *> &InstImpResults,
+                       ArrayRef<const Record *> InstImpResults,
                        bool ShouldIgnore = false);
   void AddPatternToMatch(TreePattern *Pattern, PatternToMatch &&PTM);
   void FindPatternInputsAndOutputs(
@@ -1256,7 +1258,7 @@ private:
       std::map<std::string, TreePatternNodePtr> &InstInputs,
       MapVector<std::string, TreePatternNodePtr,
                 std::map<std::string, unsigned>> &InstResults,
-      std::vector<Record *> &InstImpResults);
+      std::vector<const Record *> &InstImpResults);
   unsigned getNewUID();
 };
 

--- a/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
@@ -39,8 +39,8 @@ LLVM_DUMP_METHOD
 void HwMode::dump() const { dbgs() << Name << ": " << Features << '\n'; }
 
 HwModeSelect::HwModeSelect(const Record *R, CodeGenHwModes &CGH) {
-  std::vector<Record *> Modes = R->getValueAsListOfDefs("Modes");
-  std::vector<Record *> Objects = R->getValueAsListOfDefs("Objects");
+  std::vector<const Record *> Modes = R->getValueAsListOfConstDefs("Modes");
+  std::vector<const Record *> Objects = R->getValueAsListOfConstDefs("Objects");
   if (Modes.size() != Objects.size()) {
     PrintError(
         R->getLoc(),
@@ -49,9 +49,9 @@ HwModeSelect::HwModeSelect(const Record *R, CodeGenHwModes &CGH) {
             "have the same size");
     report_fatal_error("error in target description.");
   }
-  for (unsigned i = 0, e = Modes.size(); i != e; ++i) {
-    unsigned ModeId = CGH.getHwModeId(Modes[i]);
-    Items.push_back(std::pair(ModeId, Objects[i]));
+  for (auto [Mode, Object] : zip_equal(Modes, Objects)) {
+    unsigned ModeId = CGH.getHwModeId(Mode);
+    Items.push_back(std::pair(ModeId, Object));
   }
 }
 

--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.h
@@ -57,7 +57,7 @@ public:
     ResultOperand(std::string N, const Record *R)
         : Name(std::move(N)), R(R), Kind(K_Record) {}
     ResultOperand(int64_t I) : Imm(I), Kind(K_Imm) {}
-    ResultOperand(Record *R) : R(R), Kind(K_Reg) {}
+    ResultOperand(const Record *R) : R(R), Kind(K_Reg) {}
 
     bool isRecord() const { return Kind == K_Record; }
     bool isImm() const { return Kind == K_Imm; }

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -79,7 +79,8 @@ void CodeGenSubRegIndex::updateComponents(CodeGenRegBank &RegBank) {
   if (!TheDef)
     return;
 
-  std::vector<Record *> Comps = TheDef->getValueAsListOfDefs("ComposedOf");
+  std::vector<const Record *> Comps =
+      TheDef->getValueAsListOfConstDefs("ComposedOf");
   if (!Comps.empty()) {
     if (Comps.size() != 2)
       PrintFatalError(TheDef->getLoc(),
@@ -91,8 +92,8 @@ void CodeGenSubRegIndex::updateComponents(CodeGenRegBank &RegBank) {
       PrintFatalError(TheDef->getLoc(), "Ambiguous ComposedOf entries");
   }
 
-  std::vector<Record *> Parts =
-      TheDef->getValueAsListOfDefs("CoveringSubRegIndices");
+  std::vector<const Record *> Parts =
+      TheDef->getValueAsListOfConstDefs("CoveringSubRegIndices");
   if (!Parts.empty()) {
     if (Parts.size() < 2)
       PrintFatalError(TheDef->getLoc(),
@@ -167,8 +168,10 @@ CodeGenRegister::CodeGenRegister(const Record *R, unsigned Enum)
 }
 
 void CodeGenRegister::buildObjectGraph(CodeGenRegBank &RegBank) {
-  std::vector<Record *> SRIs = TheDef->getValueAsListOfDefs("SubRegIndices");
-  std::vector<Record *> SRs = TheDef->getValueAsListOfDefs("SubRegs");
+  std::vector<const Record *> SRIs =
+      TheDef->getValueAsListOfConstDefs("SubRegIndices");
+  std::vector<const Record *> SRs =
+      TheDef->getValueAsListOfConstDefs("SubRegs");
 
   if (SRIs.size() != SRs.size())
     PrintFatalError(TheDef->getLoc(),
@@ -625,7 +628,8 @@ struct TupleExpander : SetTheory::Expander {
 
   void expand(SetTheory &ST, const Record *Def,
               SetTheory::RecSet &Elts) override {
-    std::vector<Record *> Indices = Def->getValueAsListOfDefs("SubRegIndices");
+    std::vector<const Record *> Indices =
+        Def->getValueAsListOfConstDefs("SubRegIndices");
     unsigned Dim = Indices.size();
     ListInit *SubRegs = Def->getValueAsListInit("SubRegs");
     if (Dim != SubRegs->size())
@@ -760,7 +764,8 @@ CodeGenRegisterClass::CodeGenRegisterClass(CodeGenRegBank &RegBank,
     : TheDef(R), Name(std::string(R->getName())),
       TopoSigs(RegBank.getNumTopoSigs()), EnumValue(-1), TSFlags(0) {
   GeneratePressureSet = R->getValueAsBit("GeneratePressureSet");
-  std::vector<Record *> TypeList = R->getValueAsListOfDefs("RegTypes");
+  std::vector<const Record *> TypeList =
+      R->getValueAsListOfConstDefs("RegTypes");
   if (TypeList.empty())
     PrintFatalError(R->getLoc(), "RegTypes list must not be empty!");
   for (unsigned i = 0, e = TypeList.size(); i != e; ++i) {

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -121,7 +121,7 @@ StringRef CodeGenTarget::getRegNamespace() const {
   return RegClasses.size() > 0 ? RegClasses.front().Namespace : "";
 }
 
-Record *CodeGenTarget::getInstructionSet() const {
+const Record *CodeGenTarget::getInstructionSet() const {
   return TargetRec->getValueAsDef("InstructionSet");
 }
 
@@ -131,8 +131,9 @@ bool CodeGenTarget::getAllowRegisterRenaming() const {
 
 /// getAsmParser - Return the AssemblyParser definition for this target.
 ///
-Record *CodeGenTarget::getAsmParser() const {
-  std::vector<Record *> LI = TargetRec->getValueAsListOfDefs("AssemblyParsers");
+const Record *CodeGenTarget::getAsmParser() const {
+  std::vector<const Record *> LI =
+      TargetRec->getValueAsListOfConstDefs("AssemblyParsers");
   if (AsmParserNum >= LI.size())
     PrintFatalError("Target does not have an AsmParser #" +
                     Twine(AsmParserNum) + "!");
@@ -142,28 +143,27 @@ Record *CodeGenTarget::getAsmParser() const {
 /// getAsmParserVariant - Return the AssemblyParserVariant definition for
 /// this target.
 ///
-Record *CodeGenTarget::getAsmParserVariant(unsigned i) const {
-  std::vector<Record *> LI =
-      TargetRec->getValueAsListOfDefs("AssemblyParserVariants");
-  if (i >= LI.size())
-    PrintFatalError("Target does not have an AsmParserVariant #" + Twine(i) +
+const Record *CodeGenTarget::getAsmParserVariant(unsigned Idx) const {
+  std::vector<const Record *> LI =
+      TargetRec->getValueAsListOfConstDefs("AssemblyParserVariants");
+  if (Idx >= LI.size())
+    PrintFatalError("Target does not have an AsmParserVariant #" + Twine(Idx) +
                     "!");
-  return LI[i];
+  return LI[Idx];
 }
 
 /// getAsmParserVariantCount - Return the AssemblyParserVariant definition
 /// available for this target.
 ///
 unsigned CodeGenTarget::getAsmParserVariantCount() const {
-  std::vector<Record *> LI =
-      TargetRec->getValueAsListOfDefs("AssemblyParserVariants");
-  return LI.size();
+  return TargetRec->getValueAsListOfDefs("AssemblyParserVariants").size();
 }
 
 /// getAsmWriter - Return the AssemblyWriter definition for this target.
 ///
-Record *CodeGenTarget::getAsmWriter() const {
-  std::vector<Record *> LI = TargetRec->getValueAsListOfDefs("AssemblyWriters");
+const Record *CodeGenTarget::getAsmWriter() const {
+  std::vector<const Record *> LI =
+      TargetRec->getValueAsListOfConstDefs("AssemblyWriters");
   if (AsmWriterNum >= LI.size())
     PrintFatalError("Target does not have an AsmWriter #" +
                     Twine(AsmWriterNum) + "!");
@@ -422,30 +422,29 @@ ComplexPattern::ComplexPattern(const Record *R) {
   // FIXME: Why is this different from parseSDPatternOperatorProperties?
   // Parse the properties.
   Properties = 0;
-  std::vector<Record *> PropList = R->getValueAsListOfDefs("Properties");
-  for (unsigned i = 0, e = PropList.size(); i != e; ++i)
-    if (PropList[i]->getName() == "SDNPHasChain") {
+  for (const Record *Prop : R->getValueAsListOfDefs("Properties")) {
+    if (Prop->getName() == "SDNPHasChain") {
       Properties |= 1 << SDNPHasChain;
-    } else if (PropList[i]->getName() == "SDNPOptInGlue") {
+    } else if (Prop->getName() == "SDNPOptInGlue") {
       Properties |= 1 << SDNPOptInGlue;
-    } else if (PropList[i]->getName() == "SDNPMayStore") {
+    } else if (Prop->getName() == "SDNPMayStore") {
       Properties |= 1 << SDNPMayStore;
-    } else if (PropList[i]->getName() == "SDNPMayLoad") {
+    } else if (Prop->getName() == "SDNPMayLoad") {
       Properties |= 1 << SDNPMayLoad;
-    } else if (PropList[i]->getName() == "SDNPSideEffect") {
+    } else if (Prop->getName() == "SDNPSideEffect") {
       Properties |= 1 << SDNPSideEffect;
-    } else if (PropList[i]->getName() == "SDNPMemOperand") {
+    } else if (Prop->getName() == "SDNPMemOperand") {
       Properties |= 1 << SDNPMemOperand;
-    } else if (PropList[i]->getName() == "SDNPVariadic") {
+    } else if (Prop->getName() == "SDNPVariadic") {
       Properties |= 1 << SDNPVariadic;
-    } else if (PropList[i]->getName() == "SDNPWantRoot") {
+    } else if (Prop->getName() == "SDNPWantRoot") {
       Properties |= 1 << SDNPWantRoot;
-    } else if (PropList[i]->getName() == "SDNPWantParent") {
+    } else if (Prop->getName() == "SDNPWantParent") {
       Properties |= 1 << SDNPWantParent;
     } else {
-      PrintFatalError(R->getLoc(), "Unsupported SD Node property '" +
-                                       PropList[i]->getName() +
-                                       "' on ComplexPattern '" + R->getName() +
-                                       "'!");
+      PrintFatalError(R->getLoc(),
+                      "Unsupported SD Node property '" + Prop->getName() +
+                          "' on ComplexPattern '" + R->getName() + "'!");
     }
+  }
 }

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -95,7 +95,7 @@ public:
 
   /// getInstructionSet - Return the InstructionSet object.
   ///
-  Record *getInstructionSet() const;
+  const Record *getInstructionSet() const;
 
   /// getAllowRegisterRenaming - Return the AllowRegisterRenaming flag value for
   /// this target.
@@ -104,12 +104,12 @@ public:
 
   /// getAsmParser - Return the AssemblyParser definition for this target.
   ///
-  Record *getAsmParser() const;
+  const Record *getAsmParser() const;
 
   /// getAsmParserVariant - Return the AssemblyParserVariant definition for
   /// this target.
   ///
-  Record *getAsmParserVariant(unsigned i) const;
+  const Record *getAsmParserVariant(unsigned i) const;
 
   /// getAsmParserVariantCount - Return the AssemblyParserVariant definition
   /// available for this target.
@@ -118,7 +118,7 @@ public:
 
   /// getAsmWriter - Return the AssemblyWriter definition for this target.
   ///
-  Record *getAsmWriter() const;
+  const Record *getAsmWriter() const;
 
   /// getRegBank - Return the register bank description.
   CodeGenRegBank &getRegBank() const;

--- a/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
@@ -117,7 +117,7 @@ PatternParser::parseInstructionPattern(const Init &Arg, StringRef Name) {
         std::make_unique<CodeGenInstructionPattern>(Instr, insertStrRef(Name));
   } else if (const DagInit *IP =
                  getDagWithOperatorOfSubClass(Arg, "Intrinsic")) {
-    Record *TheDef = IP->getOperatorAsDef(DiagLoc);
+    const Record *TheDef = IP->getOperatorAsDef(DiagLoc);
     const CodeGenIntrinsic *Intrin = &CGT.getIntrinsic(TheDef);
     const CodeGenInstruction &Instr = getInstrForIntrinsic(CGT, Intrin);
     Pat =
@@ -169,7 +169,7 @@ PatternParser::parseWipMatchOpcodeMatcher(const Init &Arg, StringRef Name) {
   // Each argument is an opcode that can match.
   auto Result = std::make_unique<AnyOpcodePattern>(insertStrRef(Name));
   for (const auto &Arg : Matcher->getArgs()) {
-    Record *OpcodeDef = getDefOfSubClass(*Arg, "Instruction");
+    const Record *OpcodeDef = getDefOfSubClass(*Arg, "Instruction");
     if (OpcodeDef) {
       Result->addOpcode(&CGT.getInstruction(OpcodeDef));
       continue;

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -202,7 +202,7 @@ void MatcherGen::EmitLeafMatchCode(const TreePatternNode &N) {
   assert(N.isLeaf() && "Not a leaf?");
 
   // Direct match against an integer constant.
-  if (IntInit *II = dyn_cast<IntInit>(N.getLeafValue())) {
+  if (const IntInit *II = dyn_cast<IntInit>(N.getLeafValue())) {
     // If this is the root of the dag we're matching, we emit a redundant opcode
     // check to ensure that this gets folded into the normal top-level
     // OpcodeSwitch.
@@ -336,7 +336,7 @@ void MatcherGen::EmitOperatorMatchCode(const TreePatternNode &N,
        N.getOperator()->getName() == "or") &&
       N.getChild(1).isLeaf() && N.getChild(1).getPredicateCalls().empty() &&
       N.getPredicateCalls().empty()) {
-    if (IntInit *II = dyn_cast<IntInit>(N.getChild(1).getLeafValue())) {
+    if (const IntInit *II = dyn_cast<IntInit>(N.getChild(1).getLeafValue())) {
       if (!llvm::has_single_bit<uint32_t>(
               II->getValue())) { // Don't bother with single bits.
         // If this is at the root of the pattern, we emit a redundant
@@ -665,14 +665,14 @@ void MatcherGen::EmitResultLeafAsOperand(const TreePatternNode &N,
                                          SmallVectorImpl<unsigned> &ResultOps) {
   assert(N.isLeaf() && "Must be a leaf");
 
-  if (IntInit *II = dyn_cast<IntInit>(N.getLeafValue())) {
+  if (const IntInit *II = dyn_cast<IntInit>(N.getLeafValue())) {
     AddMatcher(new EmitIntegerMatcher(II->getValue(), N.getSimpleType(0)));
     ResultOps.push_back(NextRecordedOperandNo++);
     return;
   }
 
   // If this is an explicit register reference, handle it.
-  if (DefInit *DI = dyn_cast<DefInit>(N.getLeafValue())) {
+  if (const DefInit *DI = dyn_cast<DefInit>(N.getLeafValue())) {
     const Record *Def = DI->getDef();
     if (Def->isSubClassOf("Register")) {
       const CodeGenRegister *Reg = CGP.getTargetInfo().getRegBank().getReg(Def);

--- a/llvm/utils/TableGen/FastISelEmitter.cpp
+++ b/llvm/utils/TableGen/FastISelEmitter.cpp
@@ -269,7 +269,7 @@ struct OperandsSignature {
       if (Op.getSimpleType(0) != VT)
         return false;
 
-      DefInit *OpDI = dyn_cast<DefInit>(Op.getLeafValue());
+      const DefInit *OpDI = dyn_cast<DefInit>(Op.getLeafValue());
       if (!OpDI)
         return false;
       const Record *OpLeafRec = OpDI->getDef();
@@ -509,7 +509,7 @@ void FastISelMap::collectPatterns(const CodeGenDAGPatterns &CGP) {
       if (!Dst.getChild(1).isLeaf())
         continue;
 
-      DefInit *SR = dyn_cast<DefInit>(Dst.getChild(1).getLeafValue());
+      const DefInit *SR = dyn_cast<DefInit>(Dst.getChild(1).getLeafValue());
       if (SR)
         SubRegNo = getQualifiedName(SR->getDef());
       else


### PR DESCRIPTION
Use const record pointers in TableGen/Common files.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089