### PR TITLE
[LLDB][Minidump] Have Minidumps save off and properly read TLS data

### DIFF
--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -18,6 +18,7 @@
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
+#include "lldb/Target/CoreFileMemoryRanges.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -336,6 +337,13 @@ public:
   virtual std::optional<lldb_private::Address> GetStartAddress() {
     return std::nullopt;
   }
+
+  /// Returns a list of memory ranges that should be saved in the core file, 
+  /// specific for this dßynamic loader.
+  ///
+  /// By default, this returns an empty list, but for POSIX/ELF it will return
+  /// the link map, and the TLS data.
+  virtual void CalculateDynamicSaveCoreRanges(lldb_private::Process &process, std::vector<lldb_private::MemoryRegionInfo> &ranges, std::function<bool(const lldb_private::Thread&)> save_thread_predicate) {};
 
 protected:
   // Utility methods for derived classes

--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -11,6 +11,7 @@
 
 #include "lldb/Core/Address.h"
 #include "lldb/Core/PluginInterface.h"
+#include "lldb/Target/CoreFileMemoryRanges.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/UUID.h"
@@ -18,7 +19,6 @@
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
-#include "lldb/Target/CoreFileMemoryRanges.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -338,12 +338,16 @@ public:
     return std::nullopt;
   }
 
-  /// Returns a list of memory ranges that should be saved in the core file, 
+  /// Returns a list of memory ranges that should be saved in the core file,
   /// specific for this dßynamic loader.
   ///
   /// By default, this returns an empty list, but for POSIX/ELF it will return
   /// the link map, and the TLS data.
-  virtual void CalculateDynamicSaveCoreRanges(lldb_private::Process &process, std::vector<lldb_private::MemoryRegionInfo> &ranges, std::function<bool(const lldb_private::Thread&)> save_thread_predicate) {};
+  virtual void CalculateDynamicSaveCoreRanges(
+      lldb_private::Process &process,
+      std::vector<lldb_private::MemoryRegionInfo> &ranges,
+      std::function<bool(const lldb_private::Thread &)> save_thread_predicate) {
+  };
 
 protected:
   // Utility methods for derived classes

--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -346,8 +346,8 @@ public:
   virtual void CalculateDynamicSaveCoreRanges(
       lldb_private::Process &process,
       std::vector<lldb_private::MemoryRegionInfo> &ranges,
-      llvm::function_ref<bool(const lldb_private::Thread &)> save_thread_predicate) {
-  };
+      llvm::function_ref<bool(const lldb_private::Thread &)>
+          save_thread_predicate) {};
 
 protected:
   // Utility methods for derived classes

--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -339,14 +339,14 @@ public:
   }
 
   /// Returns a list of memory ranges that should be saved in the core file,
-  /// specific for this dßynamic loader.
+  /// specific for this dynamic loader.
   ///
-  /// By default, this returns an empty list, but for POSIX/ELF it will return
-  /// the link map, and the TLS data.
+  /// For example, an implementation of this function can save the thread
+  /// local data of a given thread.
   virtual void CalculateDynamicSaveCoreRanges(
       lldb_private::Process &process,
       std::vector<lldb_private::MemoryRegionInfo> &ranges,
-      std::function<bool(const lldb_private::Thread &)> save_thread_predicate) {
+      llvm::function_ref<bool(const lldb_private::Thread &)> save_thread_predicate) {
   };
 
 protected:

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -83,7 +83,7 @@ ModuleSP DynamicLoader::GetTargetExecutable() {
       ModuleSpec module_spec(executable->GetFileSpec(),
                              executable->GetArchitecture());
       auto module_sp = std::make_shared<Module>(module_spec);
-      // If we're a coredump and we already have a main executable, we don't 
+      // If we're a coredump and we already have a main executable, we don't
       // need to reload the module list that target already has
       if (!m_process->IsLiveDebugSession()) {
         return executable;

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -83,7 +83,11 @@ ModuleSP DynamicLoader::GetTargetExecutable() {
       ModuleSpec module_spec(executable->GetFileSpec(),
                              executable->GetArchitecture());
       auto module_sp = std::make_shared<Module>(module_spec);
-
+      // If we're a coredump and we already have a main executable, we don't 
+      // need to reload the module list that target already has
+      if (!m_process->IsLiveDebugSession()) {
+        return executable;
+      }
       // Check if the executable has changed and set it to the target
       // executable if they differ.
       if (module_sp && module_sp->GetUUID().IsValid() &&
@@ -369,4 +373,3 @@ void DynamicLoader::LoadOperatingSystemPlugin(bool flush)
     if (m_process)
         m_process->LoadOperatingSystemPlugin(flush);
 }
-

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -355,7 +355,7 @@ int64_t DynamicLoader::ReadUnsignedIntWithSizeInBytes(addr_t addr,
     return (int64_t)value;
 }
 
-addr_t DynamicLoader::  ReadPointer(addr_t addr) {
+addr_t DynamicLoader::ReadPointer(addr_t addr) {
   Status error;
   addr_t value = m_process->ReadPointerFromMemory(addr, error);
   if (error.Fail())
@@ -369,3 +369,4 @@ void DynamicLoader::LoadOperatingSystemPlugin(bool flush)
     if (m_process)
         m_process->LoadOperatingSystemPlugin(flush);
 }
+

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -355,7 +355,7 @@ int64_t DynamicLoader::ReadUnsignedIntWithSizeInBytes(addr_t addr,
     return (int64_t)value;
 }
 
-addr_t DynamicLoader::ReadPointer(addr_t addr) {
+addr_t DynamicLoader::  ReadPointer(addr_t addr) {
   Status error;
   addr_t value = m_process->ReadPointerFromMemory(addr, error);
   if (error.Fail())
@@ -369,4 +369,3 @@ void DynamicLoader::LoadOperatingSystemPlugin(bool flush)
     if (m_process)
         m_process->LoadOperatingSystemPlugin(flush);
 }
-

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -2166,6 +2166,8 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // pushes it on the stack.
     case DW_OP_form_tls_address:
     case DW_OP_GNU_push_tls_address: {
+      bool debug = true;
+      while (debug) {}
       if (stack.size() < 1) {
         if (op == DW_OP_form_tls_address)
           return llvm::createStringError(

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -2166,8 +2166,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // pushes it on the stack.
     case DW_OP_form_tls_address:
     case DW_OP_GNU_push_tls_address: {
-      bool debug = true;
-      while (debug) {}
       if (stack.size() < 1) {
         if (op == DW_OP_form_tls_address)
           return llvm::createStringError(

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -118,9 +118,8 @@ void DynamicLoaderPOSIXDYLD::DidAttach() {
       Target &target = m_process->GetTarget();
       Address addr = obj->GetImageInfoAddress(&target);
       addr_t load_addr = addr.GetLoadAddress(&target);
-      if (load_addr != LLDB_INVALID_ADDRESS) {
+      if (load_addr != LLDB_INVALID_ADDRESS)
         rebase_exec = false;
-      } 
     }
   } else {
     // no executable, nothing to re-base

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -108,25 +108,6 @@ void DynamicLoaderPOSIXDYLD::DidAttach() {
   // if we dont have a load address we cant re-base
   bool rebase_exec = load_offset != LLDB_INVALID_ADDRESS;
 
-<<<<<<< HEAD
-=======
-  // if we have a valid executable
-  if (executable_sp.get()) {
-    lldb_private::ObjectFile *obj = executable_sp->GetObjectFile();
-    if (obj) {
-      // don't rebase if the module already has a load address
-      Target &target = m_process->GetTarget();
-      Address addr = obj->GetImageInfoAddress(&target);
-      addr_t load_addr = addr.GetLoadAddress(&target);
-      if (load_addr != LLDB_INVALID_ADDRESS)
-        rebase_exec = false;
-    }
-  } else {
-    // no executable, nothing to re-base
-    rebase_exec = false;
-  }
-
->>>>>>> 7aae643a0970 (Get TLS variables to work for minidump, add a test that the value is accessable correctly)
   // if the target executable should be re-based
   if (rebase_exec || IsCoreFile()) {
     ModuleList module_list;

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -109,7 +109,7 @@ void DynamicLoaderPOSIXDYLD::DidAttach() {
   bool rebase_exec = load_offset != LLDB_INVALID_ADDRESS;
 
   // if the target executable should be re-based
-  if (rebase_exec || IsCoreFile()) {
+  if (rebase_exec) {
     ModuleList module_list;
 
     module_list.Append(executable_sp);

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -901,7 +901,8 @@ static void AddSegmentRegisterSections(Process &process, ThreadSP &thread_sp,
 }
 
 // Save off the link map for core files.
-static void AddLinkMapSections(Process &process, std::vector<MemoryRegionInfo> &ranges) {
+static void AddLinkMapSections(Process &process,
+                               std::vector<MemoryRegionInfo> &ranges) {
   ModuleList &module_list = process.GetTarget().GetImages();
   Target *target = &process.GetTarget();
   for (size_t idx = 0; idx < module_list.GetSize(); idx++) {
@@ -926,7 +927,10 @@ static void AddLinkMapSections(Process &process, std::vector<MemoryRegionInfo> &
   }
 }
 
-void DynamicLoaderPOSIXDYLD::CalculateDynamicSaveCoreRanges(lldb_private::Process &process, std::vector<lldb_private::MemoryRegionInfo> &ranges, std::function<bool(const lldb_private::Thread&)> save_thread_predicate) {
+void DynamicLoaderPOSIXDYLD::CalculateDynamicSaveCoreRanges(
+    lldb_private::Process &process,
+    std::vector<lldb_private::MemoryRegionInfo> &ranges,
+    std::function<bool(const lldb_private::Thread &)> save_thread_predicate) {
   ThreadList &thread_list = process.GetThreadList();
   for (size_t idx = 0; idx < thread_list.GetSize(); idx++) {
     ThreadSP thread_sp = thread_list.GetThreadAtIndex(idx);

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -298,6 +298,7 @@ bool DynamicLoaderPOSIXDYLD::SetRendezvousBreakpoint() {
              "Rendezvous breakpoint breakpoint id {0} for pid {1}"
              "is already set.",
              m_dyld_bid,
+             m_process ? m_process->GetID() : LLDB_INVALID_PROCESS_ID);
     return true;
   }
 

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -298,7 +298,6 @@ bool DynamicLoaderPOSIXDYLD::SetRendezvousBreakpoint() {
              "Rendezvous breakpoint breakpoint id {0} for pid {1}"
              "is already set.",
              m_dyld_bid,
-             m_process ? m_process->GetID() : LLDB_INVALID_PROCESS_ID);
     return true;
   }
 

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -108,8 +108,28 @@ void DynamicLoaderPOSIXDYLD::DidAttach() {
   // if we dont have a load address we cant re-base
   bool rebase_exec = load_offset != LLDB_INVALID_ADDRESS;
 
+<<<<<<< HEAD
+=======
+  // if we have a valid executable
+  if (executable_sp.get()) {
+    lldb_private::ObjectFile *obj = executable_sp->GetObjectFile();
+    if (obj) {
+      // don't rebase if the module already has a load address
+      Target &target = m_process->GetTarget();
+      Address addr = obj->GetImageInfoAddress(&target);
+      addr_t load_addr = addr.GetLoadAddress(&target);
+      if (load_addr != LLDB_INVALID_ADDRESS) {
+        rebase_exec = false;
+      } 
+    }
+  } else {
+    // no executable, nothing to re-base
+    rebase_exec = false;
+  }
+
+>>>>>>> 7aae643a0970 (Get TLS variables to work for minidump, add a test that the value is accessable correctly)
   // if the target executable should be re-based
-  if (rebase_exec) {
+  if (rebase_exec || IsCoreFile()) {
     ModuleList module_list;
 
     module_list.Append(executable_sp);

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -870,7 +870,7 @@ bool DynamicLoaderPOSIXDYLD::IsCoreFile() const {
 
 // For our ELF/POSIX builds save off the fs_base/gs_base regions
 static void AddThreadLocalMemoryRegions(Process &process, ThreadSP &thread_sp,
-                                       std::vector<MemoryRegionInfo> &ranges) {
+                                        std::vector<MemoryRegionInfo> &ranges) {
   lldb::RegisterContextSP reg_ctx = thread_sp->GetRegisterContext();
   if (!reg_ctx)
     return;
@@ -930,7 +930,8 @@ static void AddLinkMapSections(Process &process,
 void DynamicLoaderPOSIXDYLD::CalculateDynamicSaveCoreRanges(
     lldb_private::Process &process,
     std::vector<lldb_private::MemoryRegionInfo> &ranges,
-    llvm::function_ref<bool(const lldb_private::Thread &)> save_thread_predicate) {
+    llvm::function_ref<bool(const lldb_private::Thread &)>
+        save_thread_predicate) {
   ThreadList &thread_list = process.GetThreadList();
   for (size_t idx = 0; idx < thread_list.GetSize(); idx++) {
     ThreadSP thread_sp = thread_list.GetThreadAtIndex(idx);

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
@@ -60,6 +60,8 @@ public:
                                      lldb::addr_t base_addr,
                                      bool base_addr_is_offset) override;
 
+   void CalculateDynamicSaveCoreRanges(lldb_private::Process &process, std::vector<lldb_private::MemoryRegionInfo> &ranges, std::function<bool(const lldb_private::Thread&)> save_thread_predicate) override; 
+
 protected:
   /// Runtime linker rendezvous structure.
   DYLDRendezvous m_rendezvous;

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
@@ -60,7 +60,11 @@ public:
                                      lldb::addr_t base_addr,
                                      bool base_addr_is_offset) override;
 
-   void CalculateDynamicSaveCoreRanges(lldb_private::Process &process, std::vector<lldb_private::MemoryRegionInfo> &ranges, std::function<bool(const lldb_private::Thread&)> save_thread_predicate) override; 
+  void CalculateDynamicSaveCoreRanges(
+      lldb_private::Process &process,
+      std::vector<lldb_private::MemoryRegionInfo> &ranges,
+      std::function<bool(const lldb_private::Thread &)> save_thread_predicate)
+      override;
 
 protected:
   /// Runtime linker rendezvous structure.

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
@@ -63,7 +63,7 @@ public:
   void CalculateDynamicSaveCoreRanges(
       lldb_private::Process &process,
       std::vector<lldb_private::MemoryRegionInfo> &ranges,
-      std::function<bool(const lldb_private::Thread &)> save_thread_predicate)
+      llvm::function_ref<bool(const lldb_private::Thread &)> save_thread_predicate)
       override;
 
 protected:

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h
@@ -63,8 +63,8 @@ public:
   void CalculateDynamicSaveCoreRanges(
       lldb_private::Process &process,
       std::vector<lldb_private::MemoryRegionInfo> &ranges,
-      llvm::function_ref<bool(const lldb_private::Thread &)> save_thread_predicate)
-      override;
+      llvm::function_ref<bool(const lldb_private::Thread &)>
+          save_thread_predicate) override;
 
 protected:
   /// Runtime linker rendezvous structure.

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -336,7 +336,8 @@ ArchSpec ProcessMinidump::GetArchitecture() {
 }
 
 DynamicLoader *ProcessMinidump::GetDynamicLoader() {
-  if (m_dyld_up.get() == nullptr)
+  if (m_dyld_up.get() == nullptr 
+    && GetArchitecture().GetTriple().isOSLinux())
     m_dyld_up.reset(DynamicLoader::FindPlugin(
         this, DynamicLoaderPOSIXDYLD::GetPluginNameStatic()));
   return m_dyld_up.get();

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -35,8 +35,8 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Threading.h"
 
-#include "Plugins/ObjectFile/Placeholder/ObjectFilePlaceholder.h"
 #include "Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h"
+#include "Plugins/ObjectFile/Placeholder/ObjectFilePlaceholder.h"
 #include "Plugins/Process/Utility/StopInfoMachException.h"
 
 #include <memory>
@@ -335,7 +335,7 @@ ArchSpec ProcessMinidump::GetArchitecture() {
   return ArchSpec(triple);
 }
 
-DynamicLoader* ProcessMinidump::GetDynamicLoader() {
+DynamicLoader *ProcessMinidump::GetDynamicLoader() {
   if (m_dyld_up.get() == nullptr)
     m_dyld_up.reset(DynamicLoader::FindPlugin(
         this, DynamicLoaderPOSIXDYLD::GetPluginNameStatic()));
@@ -343,11 +343,13 @@ DynamicLoader* ProcessMinidump::GetDynamicLoader() {
 }
 
 DataExtractor ProcessMinidump::GetAuxvData() {
-  std::optional<llvm::ArrayRef<uint8_t>> auxv = m_minidump_parser->GetStream(StreamType::LinuxAuxv);
+  std::optional<llvm::ArrayRef<uint8_t>> auxv =
+      m_minidump_parser->GetStream(StreamType::LinuxAuxv);
   if (!auxv)
     return DataExtractor();
 
-  return DataExtractor(auxv->data(), auxv->size(), ByteOrder::eByteOrderLittle, GetAddressByteSize(), GetAddressByteSize()); 
+  return DataExtractor(auxv->data(), auxv->size(), ByteOrder::eByteOrderLittle,
+                       GetAddressByteSize(), GetAddressByteSize());
 }
 
 void ProcessMinidump::BuildMemoryRegions() {

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -545,12 +545,12 @@ void ProcessMinidump::ReadModuleList() {
                name);
       module_sp = Module::CreateModuleFromObjectFile<ObjectFilePlaceholder>(
           module_spec, load_addr, load_size);
-    // If we haven't loaded a main executable yet, set the first module to be 
-    // main executable
-    if (!GetTarget().GetExecutableModule())
-      GetTarget().SetExecutableModule(module_sp);
-    else
-      GetTarget().GetImages().Append(module_sp, true /* notify */);
+      // If we haven't loaded a main executable yet, set the first module to be
+      // main executable
+      if (!GetTarget().GetExecutableModule())
+        GetTarget().SetExecutableModule(module_sp);
+      else
+        GetTarget().GetImages().Append(module_sp, true /* notify */);
     }
 
     bool load_addr_changed = false;

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -342,7 +342,7 @@ DataExtractor ProcessMinidump::GetAuxvData() {
   if (!auxv)
     return DataExtractor();
 
-  return DataExtractor(auxv->data(), auxv->size(), ByteOrder::eByteOrderLittle,
+  return DataExtractor(auxv->data(), auxv->size(), GetByteOrder(),
                        GetAddressByteSize(), GetAddressByteSize());
 }
 
@@ -475,6 +475,7 @@ ModuleSP ProcessMinidump::GetOrCreateModule(UUID minidump_uuid,
 void ProcessMinidump::ReadModuleList() {
   std::vector<const minidump::Module *> filtered_modules =
       m_minidump_parser->GetFilteredModuleList();
+
   Log *log = GetLog(LLDBLog::DynamicLoader);
 
   for (auto module : filtered_modules) {
@@ -543,6 +544,7 @@ void ProcessMinidump::ReadModuleList() {
                "Unable to locate the matching object file, creating a "
                "placeholder module for: {0}",
                name);
+
       module_sp = Module::CreateModuleFromObjectFile<ObjectFilePlaceholder>(
           module_spec, load_addr, load_size);
       // If we haven't loaded a main executable yet, set the first module to be

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
@@ -56,8 +56,6 @@ public:
   // Returns AUXV structure found in the core file
   lldb_private::DataExtractor GetAuxvData() override;
 
-  DynamicLoader *GetDynamicLoader() override;
-
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
   Status DoDestroy() override;

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
@@ -54,11 +54,12 @@ public:
 
   Status DoLoadCore() override;
 
+  // Returns AUXV structure found in the core file
+  lldb_private::DataExtractor GetAuxvData() override;
+
   DynamicLoader *GetDynamicLoader() override;
 
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
-
-  SystemRuntime *GetSystemRuntime() override { return nullptr; }
 
   Status DoDestroy() override;
 

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
@@ -50,7 +50,6 @@ public:
                 bool plugin_specified_by_name) override;
 
   CommandObject *GetPluginCommandObject() override;
-  
 
   Status DoLoadCore() override;
 

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
@@ -50,10 +50,11 @@ public:
                 bool plugin_specified_by_name) override;
 
   CommandObject *GetPluginCommandObject() override;
+  
 
   Status DoLoadCore() override;
 
-  DynamicLoader *GetDynamicLoader() override { return nullptr; }
+  DynamicLoader *GetDynamicLoader() override;
 
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 

--- a/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
+++ b/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
@@ -46,7 +46,7 @@ static void writeRegister(const void *reg_src, uint8_t *context,
 
 // TODO: Fix the registers in this file!
 // writeRegister checks x86_64 registers without base registers. This causes
-// an overlap in the register enum values. So we were truncating fs_base. 
+// an overlap in the register enum values. So we were truncating fs_base.
 // We should standardize to the x86_64_with_base registers.
 static void writeBaseRegister(const void *reg_src, uint8_t *context,
                               const RegisterInfo &reg) {
@@ -119,9 +119,9 @@ lldb::DataBufferSP lldb_private::minidump::ConvertMinidumpContext_x86_64(
   // See comment on base regsiter
   if ((context_flags & LLDBSpecificFlag) == LLDBSpecificFlag) {
     writeBaseRegister(&context->fs_base, result_base,
-                  reg_info[x86_64_with_base::lldb_fs_base]);
+                      reg_info[x86_64_with_base::lldb_fs_base]);
     writeBaseRegister(&context->gs_base, result_base,
-                  reg_info[x86_64_with_base::lldb_gs_base]);
+                      reg_info[x86_64_with_base::lldb_gs_base]);
   }
 
   // TODO parse the floating point registers

--- a/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
+++ b/lldb/source/Plugins/Process/minidump/RegisterContextMinidump_x86_64.cpp
@@ -44,6 +44,17 @@ static void writeRegister(const void *reg_src, uint8_t *context,
   memcpy(reg_dest.data(), reg_src, reg_dest.size());
 }
 
+// TODO: Fix the registers in this file!
+// writeRegister checks x86_64 registers without base registers. This causes
+// an overlap in the register enum values. So we were truncating fs_base. 
+// We should standardize to the x86_64_with_base registers.
+static void writeBaseRegister(const void *reg_src, uint8_t *context,
+                              const RegisterInfo &reg) {
+  auto bytes = reg.mutable_data(context);
+  llvm::MutableArrayRef<uint8_t> reg_dest = bytes.take_front(8);
+  memcpy(reg_dest.data(), reg_src, reg_dest.size());
+}
+
 lldb::DataBufferSP lldb_private::minidump::ConvertMinidumpContext_x86_64(
     llvm::ArrayRef<uint8_t> source_data,
     RegisterInfoInterface *target_reg_interface) {
@@ -105,10 +116,11 @@ lldb::DataBufferSP lldb_private::minidump::ConvertMinidumpContext_x86_64(
     writeRegister(&context->r15, result_base, reg_info[lldb_r15_x86_64]);
   }
 
+  // See comment on base regsiter
   if ((context_flags & LLDBSpecificFlag) == LLDBSpecificFlag) {
-    writeRegister(&context->fs_base, result_base,
+    writeBaseRegister(&context->fs_base, result_base,
                   reg_info[x86_64_with_base::lldb_fs_base]);
-    writeRegister(&context->gs_base, result_base,
+    writeBaseRegister(&context->gs_base, result_base,
                   reg_info[x86_64_with_base::lldb_gs_base]);
   }
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -6539,16 +6539,24 @@ static void AddRegion(const MemoryRegionInfo &region, bool try_dirty_pages,
                 CreateCoreFileMemoryRange(region));
 }
 
-static void SaveDynamicLoaderSections(Process &process, const SaveCoreOptions &options, CoreFileMemoryRanges &ranges, std::set<addr_t> &stack_ends) {
+static void SaveDynamicLoaderSections(Process &process,
+                                      const SaveCoreOptions &options,
+                                      CoreFileMemoryRanges &ranges,
+                                      std::set<addr_t> &stack_ends) {
   DynamicLoader *dyld = process.GetDynamicLoader();
   if (!dyld)
     return;
 
   std::vector<MemoryRegionInfo> dynamic_loader_mem_regions;
-  std::function<bool(const lldb_private::Thread&)> save_thread_predicate = [&](const lldb_private::Thread &t) -> bool { return options.ShouldThreadBeSaved(t.GetID()); };
-  dyld->CalculateDynamicSaveCoreRanges(process, dynamic_loader_mem_regions, save_thread_predicate);
+  std::function<bool(const lldb_private::Thread &)> save_thread_predicate =
+      [&](const lldb_private::Thread &t) -> bool {
+    return options.ShouldThreadBeSaved(t.GetID());
+  };
+  dyld->CalculateDynamicSaveCoreRanges(process, dynamic_loader_mem_regions,
+                                       save_thread_predicate);
   for (const auto &region : dynamic_loader_mem_regions) {
-    // The Dynamic Loader can give us regions that could include a truncated stack
+    // The Dynamic Loader can give us regions that could include a truncated
+    // stack
     if (stack_ends.count(region.GetRange().GetRangeEnd()) == 0)
       AddRegion(region, true, ranges);
   }
@@ -6704,8 +6712,8 @@ Status Process::CalculateCoreFileSaveRanges(const SaveCoreOptions &options,
       options.HasSpecifiedThreads()) {
     SaveOffRegionsWithStackPointers(*this, options, regions, ranges,
                                     stack_ends);
-    // Save off the dynamic loader sections, so if we are on an architecture that supports
-    // Thread Locals, that we include those as well.
+    // Save off the dynamic loader sections, so if we are on an architecture
+    // that supports Thread Locals, that we include those as well.
     SaveDynamicLoaderSections(*this, options, ranges, stack_ends);
   }
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -6540,8 +6540,8 @@ static void AddRegion(const MemoryRegionInfo &region, bool try_dirty_pages,
 }
 
 static void AddSegmentRegisterSections(Process &process, ThreadSP &thread_sp,
-                                CoreFileMemoryRanges &ranges,
-                                lldb::addr_t range_end) {
+                                       CoreFileMemoryRanges &ranges,
+                                       lldb::addr_t range_end) {
   lldb::RegisterContextSP reg_ctx = thread_sp->GetRegisterContext();
   if (!reg_ctx)
     return;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -6551,30 +6551,30 @@ static void AddSegmentRegisterSections(Process &process, ThreadSP &thread_sp,
   if (!reg_info)
     return;
 
-  lldb_private::RegisterValue reg_value;
-  bool success = reg_ctx->ReadRegister(reg_info, reg_value);
+  lldb_private::RegisterValue thread_local_register_value;
+  bool success = reg_ctx->ReadRegister(reg_info, thread_local_register_value);
   if (!success)
     return;
 
   const uint64_t fail_value = UINT64_MAX;
   bool readSuccess = false;
   const lldb::addr_t reg_value_addr =
-      reg_value.GetAsUInt64(fail_value, &readSuccess);
+      thread_local_register_value.GetAsUInt64(fail_value, &readSuccess);
   if (!readSuccess || reg_value_addr == fail_value)
     return;
 
-  MemoryRegionInfo register_region;
-  Status err = process.GetMemoryRegionInfo(reg_value_addr, register_region);
+  MemoryRegionInfo thread_local_region;
+  Status err = process.GetMemoryRegionInfo(reg_value_addr, thread_local_region);
   if (err.Fail())
     return;
 
   // We already saved off this truncated stack range.
-  if (register_region.GetRange().GetRangeEnd() == range_end)
+  if (thread_local_region.GetRange().GetRangeEnd() == range_end)
     return;
 
   // We don't need to worry about duplication because the CoreFileMemoryRanges
   // will unique them
-  AddRegion(register_region, true, ranges);
+  AddRegion(thread_local_region, true, ranges);
 }
 
 static void AddLinkMapSections(Process &process, CoreFileMemoryRanges &ranges) {
@@ -6593,12 +6593,12 @@ static void AddLinkMapSections(Process &process, CoreFileMemoryRanges &ranges) {
     if (load_addr == LLDB_INVALID_ADDRESS)
       continue;
 
-    MemoryRegionInfo tls_storage_region;
-    Status err = process.GetMemoryRegionInfo(load_addr, tls_storage_region);
+    MemoryRegionInfo link_map_section;
+    Status err = process.GetMemoryRegionInfo(load_addr, link_map_section);
     if (err.Fail())
       continue;
 
-    AddRegion(tls_storage_region, true, ranges);
+    AddRegion(link_map_section, true, ranges);
   }
 }
 

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -557,9 +557,9 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
             live_region_list.GetMemoryRegionForAddress(fs_base, live_region)
             core_region = lldb.SBMemoryRegionInfo()
             error = core_region_list.GetMemoryRegionForAddress(fs_base, core_region)
-            self.assertTrue(error.Success())    
+            self.assertTrue(error.Success())
             self.assertEqual(live_region, core_region)
-            
+
         finally:
             self.assertTrue(self.dbg.DeleteTarget(target))
             self.assertTrue(self.dbg.DeleteTarget(core_target))
@@ -623,7 +623,7 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
             core_target = self.dbg.CreateTarget(None)
             core_proc = core_target.LoadCore(tls_file)
             frame = core_proc.GetThreadAtIndex(0).GetFrameAtIndex(0)
-            tls_val = frame.FindValue('lf')
+            tls_val = frame.FindValue("lf")
             self.assertEqual(tls_val.GetValueAsUnsigned(), 42)
 
         except:

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -567,7 +567,14 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
                 os.unlink(custom_file)
 
     def minidump_deterministic_difference(self):
-            """Test that verifies that two minidumps produced are identical."""
+        """Test that verifies that two minidumps produced are identical."""
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        try:
+            target = self.dbg.CreateTarget(exe)
+            process = target.LaunchSimple(
+                None, None, self.get_process_working_directory()
+            )
 
             core_styles = [
                 lldb.eSaveCoreStackOnly,
@@ -596,7 +603,6 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
                 self.assertEqual(file_one, file_two)
                 self.assertTrue(os.unlink(spec_one.GetFileName()))
                 self.assertTrue(os.unlink(spec_two.GetFileName()))
-
         finally:
             self.assertTrue(self.dbg.DeleteTarget(target))
 

--- a/lldb/test/API/functionalities/process_save_core_minidump/main.cpp
+++ b/lldb/test/API/functionalities/process_save_core_minidump/main.cpp
@@ -17,7 +17,6 @@ size_t h() {
   return sum;
 }
 
-
 int main() {
   std::thread t1(f);
 

--- a/lldb/test/API/functionalities/process_save_core_minidump/main.cpp
+++ b/lldb/test/API/functionalities/process_save_core_minidump/main.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <iostream>
 #include <thread>
+thread_local size_t lf = 42;
 
 void g() { assert(false); }
 
@@ -15,6 +16,7 @@ size_t h() {
       }
   return sum;
 }
+
 
 int main() {
   std::thread t1(f);


### PR DESCRIPTION
This patch adds the support to `Process.cpp` to automatically save off TLS sections, either via loading the memory region for the module, or via reading `fs_base` via generic register. Then when Minidumps are loaded, we now specify we want the dynamic loader to be the `POSIXDYLD` so we can leverage the same TLS accessor code as `ProcessELFCore`. Being able to access TLS Data is an important step for LLDB generated minidumps to have feature parity with ELF Core dumps.