### PR TITLE
[Support] Add scaling support in `indent`

### DIFF
--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -774,18 +774,33 @@ public:
 // you can use
 // OS << indent(6) << "more stuff";
 // which has better ergonomics (and clang-formats better as well).
+//
+// If indentation is always in increments of a fixed value, you can use Scale
+// to set that value once. So indent(1, 2) will add 2 spaces and
+// indent(1,2) + 1 will add 4 spaces.
 struct indent {
-  unsigned NumSpaces;
+  // Indentation is represented as `NumIndents` steps of size `Scale` each.
+  unsigned NumIndents;
+  unsigned Scale;
 
-  explicit indent(unsigned NumSpaces) : NumSpaces(NumSpaces) {}
-  void operator+=(unsigned N) { NumSpaces += N; }
-  void operator-=(unsigned N) { NumSpaces -= N; }
-  indent operator+(unsigned N) const { return indent(NumSpaces + N); }
-  indent operator-(unsigned N) const { return indent(NumSpaces - N); }
+  explicit indent(unsigned NumIndents, unsigned Scale = 1)
+      : NumIndents(NumIndents), Scale(Scale) {}
+
+  // These arithmeric operators preserve scale.
+  void operator+=(unsigned N) { NumIndents += N; }
+  void operator-=(unsigned N) {
+    assert(NumIndents >= N && "Indentation underflow");
+    NumIndents -= N;
+  }
+  indent operator+(unsigned N) const { return indent(NumIndents + N, Scale); }
+  indent operator-(unsigned N) const {
+    assert(NumIndents >= N && "Indentation undeflow");
+    return indent(NumIndents - N, Scale);
+  }
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const indent &Indent) {
-  return OS.indent(Indent.NumSpaces);
+  return OS.indent(Indent.NumIndents * Indent.Scale);
 }
 
 class Error;

--- a/llvm/unittests/Support/raw_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_ostream_test.cpp
@@ -188,6 +188,16 @@ TEST(raw_ostreamTest, Indent) {
   EXPECT_EQ(Spaces(5), printToString(Indent));
   Indent -= 1;
   EXPECT_EQ(Spaces(4), printToString(Indent));
+
+  // Scaled indent.
+  indent Scaled(4, 2);
+  EXPECT_EQ(Spaces(8), printToString(Scaled));
+  EXPECT_EQ(Spaces(10), printToString(Scaled + 1));
+  EXPECT_EQ(Spaces(6), printToString(Scaled - 1));
+  Scaled += 1;
+  EXPECT_EQ(Spaces(10), printToString(Scaled));
+  Scaled -= 1;
+  EXPECT_EQ(Spaces(8), printToString(Scaled));
 }
 
 TEST(raw_ostreamTest, FormatHex) {  


### PR DESCRIPTION
Scaled indent is useful when indentation is always in steps of a fixed number (the Scale) and still allow using the +/- operators to adjust indentation.