### PR TITLE
[clang] Add "debug_transparent" attribute

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -293,6 +293,10 @@ Attribute Changes in Clang
 
 - Fix a bug where clang doesn't automatically apply the ``[[gsl::Owner]]`` or
   ``[[gsl::Pointer]]`` to STL explicit template specialization decls. (#GH109442)
+- Introduced a new function attribute ``__attribute__((debug_transparent))``
+  which is intended as a hint to debuggers that they should not stop at the annotated
+  function, but instead step through it when stepping in, and continuing directly to 
+  its caller when stepping out.
 
 Improvements to Clang's diagnostics
 -----------------------------------

--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -467,4 +467,6 @@ def warn_try_not_valid_on_target : Warning<
   "target '%0' does not support exception handling;"
   " 'catch' block is ignored">,
   InGroup<OpenMPTargetException>;
+def warn_debug_transparent_ignored : Warning<
+  "'debug_transparent' attribute is ignored since it is only supported by DWARF">;
 }

--- a/clang/test/CodeGen/attr-debug-transparent-method-warning.cpp
+++ b/clang/test/CodeGen/attr-debug-transparent-method-warning.cpp
@@ -1,0 +1,14 @@
+// Pipe stderr to FileCheck since we're checking for a warning
+// RUN: %clang -gcodeview -g -emit-llvm -S %s -o - 2>&1 | FileCheck %s
+
+
+struct S {
+[[clang::debug_transparent]] 
+void foo(void) {}
+};
+
+int main() {
+  S s;
+  s.foo();
+}
+// CHECK: warning: 'debug_transparent' attribute is ignored since it is only supported by DWARF

--- a/clang/test/CodeGen/attr-debug-transparent-method.cpp
+++ b/clang/test/CodeGen/attr-debug-transparent-method.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang -gdwarf -emit-llvm -S %s -o - | FileCheck %s
+
+void bar(void) {}
+
+struct A {
+[[clang::debug_transparent()]]
+void foo(void) {
+  bar();
+}
+};
+
+int main() {
+  A().foo();
+}
+
+// CHECK: DISubprogram(name: "foo"{{.*}} DISPFlagIsDebugTransparent

--- a/clang/test/CodeGen/attr-debug-transparent-no-warning.c
+++ b/clang/test/CodeGen/attr-debug-transparent-no-warning.c
@@ -1,0 +1,10 @@
+// Pipe stderr to FileCheck since we're checking for a warning
+// RUN: %clang -gcodeview -emit-llvm -S %s -o - 2>&1 | FileCheck %s
+
+
+__attribute__((debug_transparent)) 
+void foo(void) {}
+
+// Check that the warning is NOT printed when compiling without debug information.
+// CHECK-NOT: warning: 'debug_transparent' attribute is ignored since it is only supported by DWARF
+

--- a/clang/test/CodeGen/attr-debug-transparent-objc-warning.m
+++ b/clang/test/CodeGen/attr-debug-transparent-objc-warning.m
@@ -1,0 +1,12 @@
+// Pipe stderr to FileCheck since we're checking for a warning
+// RUN: %clang -gcodeview -g -emit-llvm -S %s -o - 2>&1 | FileCheck %s
+
+@interface ObjCClass
+- (void)foo __attribute__((debug_transparent));
+@end
+
+@implementation ObjCClass
+- (void)foo {}
+@end
+
+// CHECK: warning: 'debug_transparent' attribute is ignored since it is only supported by DWARF

--- a/clang/test/CodeGen/attr-debug-transparent-objc.m
+++ b/clang/test/CodeGen/attr-debug-transparent-objc.m
@@ -1,0 +1,13 @@
+// RUN: %clang -gdwarf -emit-llvm -S %s -o - | FileCheck %s
+
+
+@interface ObjCClass
+- (void)foo __attribute__((debug_transparent));
+@end
+
+@implementation ObjCClass
+- (void)foo {}
+@end
+
+
+// CHECK: DISubprogram(name: "-[ObjCClass foo]"{{.*}} DISPFlagIsDebugTransparent

--- a/clang/test/CodeGen/attr-debug-transparent-warning.c
+++ b/clang/test/CodeGen/attr-debug-transparent-warning.c
@@ -1,0 +1,9 @@
+// Pipe stderr to FileCheck since we're checking for a warning
+// RUN: %clang -gcodeview -g -emit-llvm -S %s -o - 2>&1 | FileCheck %s
+
+
+__attribute__((debug_transparent)) 
+void foo(void) {}
+
+// CHECK: warning: 'debug_transparent' attribute is ignored since it is only supported by DWARF
+

--- a/clang/test/CodeGen/attr-debug-transparent.c
+++ b/clang/test/CodeGen/attr-debug-transparent.c
@@ -1,0 +1,10 @@
+// RUN: %clang -gdwarf -emit-llvm -S %s -o - | FileCheck %s
+
+void bar(void) {}
+
+__attribute__((debug_transparent))
+void foo(void) {
+  bar();
+}
+
+// CHECK: DISubprogram(name: "foo"{{.*}} DISPFlagIsDebugTransparent

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1260,6 +1260,9 @@ bool DwarfUnit::applySubprogramDefinitionAttributes(const DISubprogram *SP,
       (DD->useAllLinkageNames() || DU->getAbstractScopeDIEs().lookup(SP)))
     addLinkageName(SPDie, LinkageName);
 
+  if (SP->isDebugTransparent())
+    addFlag(SPDie, dwarf::DW_AT_trampoline);
+
   if (!DeclDie)
     return false;
 
@@ -1378,6 +1381,8 @@ void DwarfUnit::applySubprogramAttributes(const DISubprogram *SP, DIE &SPDie,
 
   if (!SP->getTargetFuncName().empty())
     addString(SPDie, dwarf::DW_AT_trampoline, SP->getTargetFuncName());
+  else if (SP->isDebugTransparent())
+    addFlag(SPDie, dwarf::DW_AT_trampoline);
 
   if (DD->getDwarfVersion() >= 5 && SP->isDeleted())
     addFlag(SPDie, dwarf::DW_AT_deleted);


### PR DESCRIPTION
The `debug_transparent` attribute is intended as a hint for debuggers that this function itself is not interesting, but it calls a function that might be.  So, when stepping in arrives at a function with this attribute, debuggers should transparently step-in through it into the functions called by the annotated function (but not by subsequent calls made by those functions), stopping at the first one its normal rules for whether to stop says to stop at - or stepping out again if none qualify. Also, when stepping out arrives at a function with this attribute, the debugger should continue stepping out to its caller.