### PR TITLE
[clang][bytecode] Create dummy pointers for ObjCStringLiterals

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2134,7 +2134,9 @@ bool Compiler<Emitter>::VisitStringLiteral(const StringLiteral *E) {
 
 template <class Emitter>
 bool Compiler<Emitter>::VisitObjCStringLiteral(const ObjCStringLiteral *E) {
-  return this->delegate(E->getString());
+  if (std::optional<unsigned> I = P.getOrCreateDummy(E))
+    return this->emitGetPtrGlobal(*I, E);
+  return false;
 }
 
 template <class Emitter>

--- a/clang/test/AST/ByteCode/codegen.m
+++ b/clang/test/AST/ByteCode/codegen.m
@@ -1,0 +1,12 @@
+// REQUIRES: x86-registered-target
+
+/// See test/CodeGenObjC/constant-strings.m
+/// Test that we let the APValue we create for ObjCStringLiterals point to the right expression.
+
+// RUN: %clang_cc1 -triple x86_64-macho -emit-llvm -o %t %s -fexperimental-new-constant-interpreter
+// RUN: FileCheck --check-prefix=CHECK-NEXT < %t %s
+
+// Check that we set alignment 1 on the string.
+//
+// CHECK-NEXT: @.str = {{.*}}constant [13 x i8] c"Hello World!\00", section "__TEXT,__cstring,cstring_literals", align 1
+id a = @"Hello World!";


### PR DESCRIPTION
We need to have the final APValue point to the ObjCStringLiteral expression, not the StringLiteral itself.