### PR TITLE
[CI] Update OS base image to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -60,7 +60,7 @@ jobs:
         id: vars
         run: |
           tag=`date +%s`
-          container_name="ghcr.io/$GITHUB_REPOSITORY_OWNER/ci-ubuntu-22.04"
+          container_name="ghcr.io/$GITHUB_REPOSITORY_OWNER/ci-ubuntu-24.04"
           echo "container-name=$container_name" >> $GITHUB_OUTPUT
           echo "container-name-tag=$container_name:$tag" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-post-commit-analyzer.yml
+++ b/.github/workflows/ci-post-commit-analyzer.yml
@@ -34,9 +34,9 @@ jobs:
     if: >-
       github.repository_owner == 'llvm' &&
       github.event.action != 'closed'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/llvm/ci-ubuntu-22.04:latest'
+      image: 'ghcr.io/llvm/ci-ubuntu-24.04:latest'
     env:
       LLVM_VERSION: 18
     steps:

--- a/.github/workflows/commit-access-review.yml
+++ b/.github/workflows/commit-access-review.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   commit-access-review:
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4

--- a/.github/workflows/containers/github-action-ci/stage1.Dockerfile
+++ b/.github/workflows/containers/github-action-ci/stage1.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:22.04 as base
+FROM docker.io/library/ubuntu:24.04 as base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base as stage1-toolchain

--- a/.github/workflows/containers/github-action-ci/stage2.Dockerfile
+++ b/.github/workflows/containers/github-action-ci/stage2.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:22.04 as base
+FROM docker.io/library/ubuntu:24.04 as base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM stage1-toolchain AS stage2-toolchain

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   audit:
     name: "Release Asset Audit"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 #v4.1.6

--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -52,7 +52,7 @@ jobs:
   setup-variables:
     if: >-
       (github.event_name != 'pull_request' || github.event.action != 'closed')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       release-version: ${{ steps.vars.outputs.release-version }}
       upload: ${{ steps.vars.outputs.upload }}
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
           - macos-13
           - macos-14

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: choice
         options:
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
           - macos-13
           - macos-14
@@ -413,7 +413,7 @@ jobs:
       always() &&
       github.event_name != 'pull_request' &&
       needs.prepare.outputs.upload == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # For release uploads
       id-token: write     # For artifact attestations

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
           - macos-13
           - macos-14


### PR DESCRIPTION
In Github Actions, `ubuntu-24.04` is released as GA recently. It`s better to switch to new version of Ubuntu.