### PR TITLE
[rtsan][NFC] Standardize lambda function case, fix autos

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_context.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_context.cpp
@@ -26,11 +26,11 @@ static pthread_once_t key_once = PTHREAD_ONCE_INIT;
 static void InternalFreeWrapper(void *ptr) { __sanitizer::InternalFree(ptr); }
 
 static __rtsan::Context &GetContextForThisThreadImpl() {
-  auto make_thread_local_context_key = []() {
+  auto MakeThreadLocalContextKey = []() {
     CHECK_EQ(pthread_key_create(&context_key, InternalFreeWrapper), 0);
   };
 
-  pthread_once(&key_once, make_thread_local_context_key);
+  pthread_once(&key_once, MakeThreadLocalContextKey);
   __rtsan::Context *current_thread_context =
       static_cast<__rtsan::Context *>(pthread_getspecific(context_key));
   if (current_thread_context == nullptr) {

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_context.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_context.cpp
@@ -43,24 +43,24 @@ TEST_F(TestRtsanContext, IsNotRealtimeAfterRealtimePushAndPop) {
 
 TEST_F(TestRtsanContext, RealtimeContextStateIsStatefullyTracked) {
   __rtsan::Context context{};
-  auto const expect_rt = [&context](bool is_rt) {
+  auto const ExpectRealtime = [&context](bool is_rt) {
     EXPECT_THAT(context.InRealtimeContext(), Eq(is_rt));
   };
-  expect_rt(false);
+  ExpectRealtime(false);
   context.RealtimePush(); // depth 1
-  expect_rt(true);
+  ExpectRealtime(true);
   context.RealtimePush(); // depth 2
-  expect_rt(true);
+  ExpectRealtime(true);
   context.RealtimePop(); // depth 1
-  expect_rt(true);
+  ExpectRealtime(true);
   context.RealtimePush(); // depth 2
-  expect_rt(true);
+  ExpectRealtime(true);
   context.RealtimePop(); // depth 1
-  expect_rt(true);
+  ExpectRealtime(true);
   context.RealtimePop(); // depth 0
-  expect_rt(false);
+  ExpectRealtime(false);
   context.RealtimePush(); // depth 1
-  expect_rt(true);
+  ExpectRealtime(true);
 }
 
 TEST_F(TestRtsanContext, IsNotBypassedAfterDefaultConstruction) {
@@ -76,22 +76,22 @@ TEST_F(TestRtsanContext, IsBypassedAfterBypassPush) {
 
 TEST_F(TestRtsanContext, BypassedStateIsStatefullyTracked) {
   __rtsan::Context context{};
-  auto const expect_bypassed = [&context](bool is_bypassed) {
+  auto const ExpectBypassed = [&context](bool is_bypassed) {
     EXPECT_THAT(context.IsBypassed(), Eq(is_bypassed));
   };
-  expect_bypassed(false);
+  ExpectBypassed(false);
   context.BypassPush(); // depth 1
-  expect_bypassed(true);
+  ExpectBypassed(true);
   context.BypassPush(); // depth 2
-  expect_bypassed(true);
+  ExpectBypassed(true);
   context.BypassPop(); // depth 1
-  expect_bypassed(true);
+  ExpectBypassed(true);
   context.BypassPush(); // depth 2
-  expect_bypassed(true);
+  ExpectBypassed(true);
   context.BypassPop(); // depth 1
-  expect_bypassed(true);
+  ExpectBypassed(true);
   context.BypassPop(); // depth 0
-  expect_bypassed(false);
+  ExpectBypassed(false);
   context.BypassPush(); // depth 1
-  expect_bypassed(true);
+  ExpectBypassed(true);
 }

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
@@ -142,13 +142,13 @@ void InvokeStdFunction(std::function<void()> &&function) { function(); }
 
 TEST(TestRtsan, CopyingALambdaWithLargeCaptureDiesWhenRealtime) {
   std::array<float, 16> lots_of_data;
-  auto lambda = [lots_of_data]() mutable {
+  auto LargeLambda = [lots_of_data]() mutable {
     // Stop everything getting optimised out
     lots_of_data[3] = 0.25f;
     EXPECT_EQ(16u, lots_of_data.size());
     EXPECT_EQ(0.25f, lots_of_data[3]);
   };
-  auto Func = [&]() { InvokeStdFunction(lambda); };
+  auto Func = [&]() { InvokeStdFunction(LargeLambda); };
   ExpectRealtimeDeath(Func);
   ExpectNonRealtimeSurvival(Func);
 }

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
@@ -200,15 +200,15 @@ TEST(TestRtsanInterceptors, NanosleepDiesWhenRealtime) {
 */
 
 TEST_F(RtsanFileTest, OpenDiesWhenRealtime) {
-  auto func = [this]() { open(GetTemporaryFilePath(), O_RDONLY); };
-  ExpectRealtimeDeath(func, kOpenFunctionName);
-  ExpectNonRealtimeSurvival(func);
+  auto Func = [this]() { open(GetTemporaryFilePath(), O_RDONLY); };
+  ExpectRealtimeDeath(Func, kOpenFunctionName);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanFileTest, OpenatDiesWhenRealtime) {
-  auto func = [this]() { openat(0, GetTemporaryFilePath(), O_RDONLY); };
-  ExpectRealtimeDeath(func, kOpenAtFunctionName);
-  ExpectNonRealtimeSurvival(func);
+  auto Func = [this]() { openat(0, GetTemporaryFilePath(), O_RDONLY); };
+  ExpectRealtimeDeath(Func, kOpenAtFunctionName);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanFileTest, OpenCreatesFileWithProperMode) {
@@ -231,22 +231,22 @@ TEST_F(RtsanFileTest, OpenCreatesFileWithProperMode) {
 }
 
 TEST_F(RtsanFileTest, CreatDiesWhenRealtime) {
-  auto func = [this]() { creat(GetTemporaryFilePath(), S_IWOTH | S_IROTH); };
-  ExpectRealtimeDeath(func, kCreatFunctionName);
-  ExpectNonRealtimeSurvival(func);
+  auto Func = [this]() { creat(GetTemporaryFilePath(), S_IWOTH | S_IROTH); };
+  ExpectRealtimeDeath(Func, kCreatFunctionName);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST(TestRtsanInterceptors, FcntlDiesWhenRealtime) {
-  auto func = []() { fcntl(0, F_GETFL); };
-  ExpectRealtimeDeath(func, kFcntlFunctionName);
-  ExpectNonRealtimeSurvival(func);
+  auto Func = []() { fcntl(0, F_GETFL); };
+  ExpectRealtimeDeath(Func, kFcntlFunctionName);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanFileTest, FcntlFlockDiesWhenRealtime) {
   int fd = creat(GetTemporaryFilePath(), S_IRUSR | S_IWUSR);
   ASSERT_THAT(fd, Ne(-1));
 
-  auto func = [fd]() {
+  auto Func = [fd]() {
     struct flock lock {};
     lock.l_type = F_RDLCK;
     lock.l_whence = SEEK_SET;
@@ -257,8 +257,8 @@ TEST_F(RtsanFileTest, FcntlFlockDiesWhenRealtime) {
     ASSERT_THAT(fcntl(fd, F_GETLK, &lock), Eq(0));
     ASSERT_THAT(lock.l_type, F_UNLCK);
   };
-  ExpectRealtimeDeath(func, kFcntlFunctionName);
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, kFcntlFunctionName);
+  ExpectNonRealtimeSurvival(Func);
 
   close(fd);
 }
@@ -267,7 +267,7 @@ TEST_F(RtsanFileTest, FcntlSetFdDiesWhenRealtime) {
   int fd = creat(GetTemporaryFilePath(), S_IRUSR | S_IWUSR);
   ASSERT_THAT(fd, Ne(-1));
 
-  auto func = [fd]() {
+  auto Func = [fd]() {
     int old_flags = fcntl(fd, F_GETFD);
     ASSERT_THAT(fcntl(fd, F_SETFD, FD_CLOEXEC), Eq(0));
 
@@ -279,26 +279,26 @@ TEST_F(RtsanFileTest, FcntlSetFdDiesWhenRealtime) {
     ASSERT_THAT(fcntl(fd, F_GETFD), Eq(old_flags));
   };
 
-  ExpectRealtimeDeath(func, kFcntlFunctionName);
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, kFcntlFunctionName);
+  ExpectNonRealtimeSurvival(Func);
 
   close(fd);
 }
 
 TEST(TestRtsanInterceptors, CloseDiesWhenRealtime) {
-  auto func = []() { close(0); };
-  ExpectRealtimeDeath(func, "close");
-  ExpectNonRealtimeSurvival(func);
+  auto Func = []() { close(0); };
+  ExpectRealtimeDeath(Func, "close");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanFileTest, FopenDiesWhenRealtime) {
-  auto func = [this]() {
-    auto fd = fopen(GetTemporaryFilePath(), "w");
-    EXPECT_THAT(fd, Ne(nullptr));
+  auto Func = [this]() {
+    FILE *f = fopen(GetTemporaryFilePath(), "w");
+    EXPECT_THAT(f, Ne(nullptr));
   };
 
-  ExpectRealtimeDeath(func, kFopenFunctionName);
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, kFopenFunctionName);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 class RtsanOpenedFileTest : public RtsanFileTest {
@@ -327,39 +327,39 @@ private:
 };
 
 TEST_F(RtsanOpenedFileTest, FreadDiesWhenRealtime) {
-  auto func = [this]() {
+  auto Func = [this]() {
     char c{};
     fread(&c, 1, 1, GetOpenFile());
   };
-  ExpectRealtimeDeath(func, "fread");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "fread");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanOpenedFileTest, FwriteDiesWhenRealtime) {
   const char *message = "Hello, world!";
-  auto func = [&]() { fwrite(&message, 1, 4, GetOpenFile()); };
-  ExpectRealtimeDeath(func, "fwrite");
-  ExpectNonRealtimeSurvival(func);
+  auto Func = [&]() { fwrite(&message, 1, 4, GetOpenFile()); };
+  ExpectRealtimeDeath(Func, "fwrite");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanFileTest, FcloseDiesWhenRealtime) {
-  auto fd = fopen(GetTemporaryFilePath(), "w");
-  EXPECT_THAT(fd, Ne(nullptr));
-  auto func = [fd]() { fclose(fd); };
-  ExpectRealtimeDeath(func, "fclose");
-  ExpectNonRealtimeSurvival(func);
+  FILE *f = fopen(GetTemporaryFilePath(), "w");
+  EXPECT_THAT(f, Ne(nullptr));
+  auto Func = [f]() { fclose(f); };
+  ExpectRealtimeDeath(Func, "fclose");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST(TestRtsanInterceptors, PutsDiesWhenRealtime) {
-  auto func = []() { puts("Hello, world!\n"); };
-  ExpectRealtimeDeath(func);
-  ExpectNonRealtimeSurvival(func);
+  auto Func = []() { puts("Hello, world!\n"); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanOpenedFileTest, FputsDiesWhenRealtime) {
-  auto func = [this]() { fputs("Hello, world!\n", GetOpenFile()); };
-  ExpectRealtimeDeath(func);
-  ExpectNonRealtimeSurvival(func);
+  auto Func = [this]() { fputs("Hello, world!\n", GetOpenFile()); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 TEST_F(RtsanOpenedFileTest, ReadDiesWhenRealtime) {


### PR DESCRIPTION
Move to PascalCase for anonymous functions, because it is more consistent to the rest of our tests and compiler-rt.

Fix a few outstanding cases of auto being used