### PR TITLE
[libcxx] Use `lgamma` rather than `lgamma_r` with LLVM libc

### DIFF
--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -103,7 +103,7 @@ extern "C" double lgamma_r(double, int*);
 #endif
 
 inline _LIBCPP_HIDE_FROM_ABI double __libcpp_lgamma(double __d) {
-#if defined(_LIBCPP_MSVCRT_LIKE)
+#if defined(_LIBCPP_MSVCRT_LIKE) || defined(__LLVM_LIBC__)
   return lgamma(__d);
 #else
   int __sign;


### PR DESCRIPTION
`lgamma_r` is currently only available on GPU targets.