### PR TITLE
[libc] Use `yaml.safe_load` rather than `yaml.load`

### DIFF
--- a/libc/newhdrgen/yaml_functions_sorted.py
+++ b/libc/newhdrgen/yaml_functions_sorted.py
@@ -6,7 +6,7 @@ import os
 
 def sort_yaml_functions(yaml_file):
     with open(yaml_file, "r") as f:
-        yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+        yaml_data = yaml.safe_load(f)
 
     if "functions" in yaml_data:
         yaml_data["functions"].sort(key=lambda x: x["name"])


### PR DESCRIPTION
`yaml.load` is considered unsafe, use `yaml.safe_load`.