### PR TITLE
[lldb] Fix assert frame recognizer for Ubuntu 22.04

### DIFF
--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -36,6 +36,7 @@ bool GetAbortLocation(llvm::Triple::OSType os, SymbolLocation &location) {
     location.symbols.push_back(ConstString("__GI_raise"));
     location.symbols.push_back(ConstString("gsignal"));
     location.symbols.push_back(ConstString("pthread_kill"));
+    location.symbols.push_back(ConstString("__pthread_kill_implementation"));
     location.symbols_are_regex = true;
     break;
   default:
@@ -130,7 +131,7 @@ AssertFrameRecognizer::RecognizeFrame(lldb::StackFrameSP frame_sp) {
   if (!GetAssertLocation(os, location))
     return RecognizedStackFrameSP();
 
-  const uint32_t frames_to_fetch = 6;
+  const uint32_t frames_to_fetch = 8;
   const uint32_t last_frame_index = frames_to_fetch - 1;
   StackFrameSP prev_frame_sp = nullptr;
 


### PR DESCRIPTION
On Ubuntu 22.04, the top-most stack frame is the function `__pthread_kill_implementation`. Add it to the list of detected functions.

```
(lldb) bt
* thread #1, name = 'a.out', stop reason = signal SIGABRT
  * frame #0: 0x00007ffff7bc29fc libc.so.6`__GI___pthread_kill [inlined] __pthread_kill_implementation(no_tid=0, signo=6, threadid=140737349064512) at pthread_kill.c:44:76
    frame #1: 0x00007ffff7bc29b0 libc.so.6`__GI___pthread_kill [inlined] __pthread_kill_internal(signo=6, threadid=140737349064512) at pthread_kill.c:78:10
    frame #2: 0x00007ffff7bc29b0 libc.so.6`__GI___pthread_kill(threadid=140737349064512, signo=6) at pthread_kill.c:89:10
    frame #3: 0x00007ffff7b6e476 libc.so.6`__GI_raise(sig=6) at raise.c:26:13
    frame #4: 0x00007ffff7b547f3 libc.so.6`__GI_abort at abort.c:79:7
    frame #5: 0x00007ffff7b5471b libc.so.6`__assert_fail_base(fmt="%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion="false", file="test-func-ptr.cpp", line=27, function="int main()") at assert.c:92:3
    frame #6: 0x00007ffff7b65e96 libc.so.6`__GI___assert_fail(assertion="false", file="test-func-ptr.cpp", line=27, function="int main()") at assert.c:101:3
    frame #7: 0x0000555555556359 a.out`main at test-func-ptr.cpp:27:5
```

I did not add a testcase because it would require a specific glibc.