### PR TITLE
[Driver][X86] Add flang visibility for -m[no-]evex512

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6352,8 +6352,10 @@ def mcx16 : Flag<["-"], "mcx16">, Group<m_x86_Features_Group>;
 def mno_cx16 : Flag<["-"], "mno-cx16">, Group<m_x86_Features_Group>;
 def menqcmd : Flag<["-"], "menqcmd">, Group<m_x86_Features_Group>;
 def mno_enqcmd : Flag<["-"], "mno-enqcmd">, Group<m_x86_Features_Group>;
-def mevex512 : Flag<["-"], "mevex512">, Group<m_x86_Features_Group>;
-def mno_evex512 : Flag<["-"], "mno-evex512">, Group<m_x86_Features_Group>;
+def mevex512 : Flag<["-"], "mevex512">, Group<m_x86_Features_Group>,
+               Visibility<[ClangOption, CLOption, FlangOption]>;
+def mno_evex512 : Flag<["-"], "mno-evex512">, Group<m_x86_Features_Group>,
+                  Visibility<[ClangOption, CLOption, FlangOption]>;
 def mf16c : Flag<["-"], "mf16c">, Group<m_x86_Features_Group>;
 def mno_f16c : Flag<["-"], "mno-f16c">, Group<m_x86_Features_Group>;
 def mfma : Flag<["-"], "mfma">, Group<m_x86_Features_Group>;

--- a/flang/test/Driver/target-cpu-features.f90
+++ b/flang/test/Driver/target-cpu-features.f90
@@ -23,6 +23,12 @@
 ! RUN: %flang --target=x86_64-linux-gnu -mno-apx-features=ccmp -c %s -### 2>&1 \
 ! RUN: | FileCheck %s -check-prefix=CHECK-NO-APX
 
+! RUN: %flang --target=x86_64-linux-gnu -mevex512 -c %s -### 2>&1 \
+! RUN: | FileCheck %s -check-prefix=CHECK-EVEX512
+
+! RUN: %flang --target=x86_64-linux-gnu -mno-evex512 -c %s -### 2>&1 \
+! RUN: | FileCheck %s -check-prefix=CHECK-NO-EVEX512
+
 ! RUN: %flang --target=x86_64h-linux-gnu -c %s -### 2>&1 \
 ! RUN: | FileCheck %s -check-prefix=CHECK-X86_64H
 
@@ -62,6 +68,12 @@
 
 ! CHECK-NO-APX: "-fc1" "-triple" "x86_64-unknown-linux-gnu"
 ! CHECK-NO-APX-SAME: "-target-feature" "-ccmp"
+
+! CHECK-EVEX512: "-fc1" "-triple" "x86_64-unknown-linux-gnu"
+! CHECK-EVEX512-SAME: "-target-feature" "+evex512"
+
+! CHECK-NO-EVEX512: "-fc1" "-triple" "x86_64-unknown-linux-gnu"
+! CHECK-NO-EVEX512-SAME: "-target-feature" "-evex512"
 
 ! CHECK-X86_64H: "-fc1" "-triple" "x86_64h-unknown-linux-gnu"
 ! CHECK-X86_64H-SAME: "-target-cpu" "x86-64" "-target-feature" "-rdrnd" "-target-feature" "-aes" "-target-feature" "-pclmul" "-target-feature" "-rtm" "-target-feature" "-fsgsbase"


### PR DESCRIPTION
The `-m[no-]evex512` are nontrivial options which are used to control vector size of other AVX512 features. Hence we expose both to flang for Fortran users.