### PR TITLE
[Clang] Replace vt_gen with LLVMCodeGenTypes

### DIFF
--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -144,7 +144,6 @@ add_clang_library(clangCodeGen
   VarBypassDetector.cpp
 
   DEPENDS
-  vt_gen
   intrinsics_gen
   ClangDriverOptions
   # These generated headers are included transitively.


### PR DESCRIPTION
Fixes a build failure with Clang being built from standalone sources (environments like Nix).

Exact error:
```
CMake Error at /nix/store/h9yw8mg03z3dz6rgcjr7gbzkjysqc2sj-llvm-20.0.0-unstable-2024-09-22-dev/lib/cmake/llvm/AddLLVM.cmake:587 (add_dependencies):
  The dependency target "vt_gen" of target "obj.clangCodeGen" does not exist.
Call Stack (most recent call first):
  cmake/modules/AddClang.cmake:109 (llvm_add_library)
  lib/CodeGen/CMakeLists.txt:57 (add_clang_library)


CMake Error at /nix/store/h9yw8mg03z3dz6rgcjr7gbzkjysqc2sj-llvm-20.0.0-unstable-2024-09-22-dev/lib/cmake/llvm/AddLLVM.cmake:807 (add_dependencies):
  The dependency target "vt_gen" of target "clangCodeGen" does not exist.
Call Stack (most recent call first):
  cmake/modules/AddClang.cmake:109 (llvm_add_library)
  lib/CodeGen/CMakeLists.txt:57 (add_clang_library)
```

This fix can be reproduced via the following script (just set out to some remote source and monorepoSrc to your LLVM source dir):
```
mkdir -p "$out"
cp -r ${monorepoSrc}/cmake "$out"
cp -r ${monorepoSrc}/${pname} "$out"
cp -r ${monorepoSrc}/clang-tools-extra "$out"

mkdir -p "$out/llvm/include/llvm/CodeGen"
cp -r ${monorepoSrc}/llvm/include/llvm/CodeGen/CMakeLists.txt "$out/llvm/include/llvm/CodeGen/"

mkdir -p "$out/clang/include/llvm"
cp -r ${monorepoSrc}/llvm/include/llvm/CodeGen $out/clang/include/llvm/CodeGen
```