### PR TITLE
[lldb][NFC] New names for the two RegisterLocation classes

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -54,7 +54,7 @@ class UnwindPlan {
 public:
   class Row {
   public:
-    class RegisterLocation {
+    class AbstractRegisterLocation {
     public:
       enum RestoreType {
         unspecified,       // not specified, we may be able to assume this
@@ -72,11 +72,11 @@ public:
         isConstant         // reg = constant
       };
 
-      RegisterLocation() : m_location() {}
+      AbstractRegisterLocation() : m_location() {}
 
-      bool operator==(const RegisterLocation &rhs) const;
+      bool operator==(const AbstractRegisterLocation &rhs) const;
 
-      bool operator!=(const RegisterLocation &rhs) const {
+      bool operator!=(const AbstractRegisterLocation &rhs) const {
         return !(*this == rhs);
       }
 
@@ -337,10 +337,10 @@ public:
     bool operator==(const Row &rhs) const;
 
     bool GetRegisterInfo(uint32_t reg_num,
-                         RegisterLocation &register_location) const;
+                         AbstractRegisterLocation &register_location) const;
 
     void SetRegisterInfo(uint32_t reg_num,
-                         const RegisterLocation register_location);
+                         const AbstractRegisterLocation register_location);
 
     void RemoveRegisterInfo(uint32_t reg_num);
 
@@ -398,7 +398,7 @@ public:
               lldb::addr_t base_addr) const;
 
   protected:
-    typedef std::map<uint32_t, RegisterLocation> collection;
+    typedef std::map<uint32_t, AbstractRegisterLocation> collection;
     lldb::addr_t m_offset = 0; // Offset into the function for this row
 
     FAValue m_cfa_value;

--- a/lldb/include/lldb/Target/ABI.h
+++ b/lldb/include/lldb/Target/ABI.h
@@ -102,9 +102,9 @@ public:
 
   virtual bool RegisterIsVolatile(const RegisterInfo *reg_info) = 0;
 
-  virtual bool
-  GetFallbackRegisterLocation(const RegisterInfo *reg_info,
-                              UnwindPlan::Row::RegisterLocation &unwind_regloc);
+  virtual bool GetFallbackRegisterLocation(
+      const RegisterInfo *reg_info,
+      UnwindPlan::Row::AbstractRegisterLocation &unwind_regloc);
 
   // Should take a look at a call frame address (CFA) which is just the stack
   // pointer value upon entry to a function. ABIs usually impose alignment

--- a/lldb/include/lldb/Target/RegisterContextUnwind.h
+++ b/lldb/include/lldb/Target/RegisterContextUnwind.h
@@ -84,7 +84,7 @@ private:
                     // past the top (end) of the stack
   };
 
-  // UnwindLLDB needs to pass around references to RegisterLocations
+  // UnwindLLDB needs to pass around references to ConcreteRegisterLocations
   friend class UnwindLLDB;
 
   // Returns true if we have an unwind loop -- the same stack frame unwinding
@@ -135,29 +135,28 @@ private:
   // preserved a register that this
   // function didn't modify/use.
   //
-  // The RegisterLocation type may be set to eRegisterNotAvailable -- this will
-  // happen for a volatile register
-  // being queried mid-stack.  Instead of floating frame 0's contents of that
-  // register up the stack (which may
-  // or may not be the value of that reg when the function was executing), we
-  // won't return any value.
+  // The ConcreteRegisterLocation type may be set to eRegisterNotAvailable --
+  // this will happen for a volatile register being queried mid-stack.  Instead
+  // of floating frame 0's contents of that register up the stack (which may or
+  // may not be the value of that reg when the function was executing), we won't
+  // return any value.
   //
   // If a non-volatile register (a "preserved" register) is requested mid-stack
   // and no frames "below" the requested
   // stack have saved the register anywhere, it is safe to assume that frame 0's
   // register values are still the same
   // as the requesting frame's.
-  lldb_private::UnwindLLDB::RegisterSearchResult
-  SavedLocationForRegister(uint32_t lldb_regnum,
-                           lldb_private::UnwindLLDB::RegisterLocation &regloc);
+  lldb_private::UnwindLLDB::RegisterSearchResult SavedLocationForRegister(
+      uint32_t lldb_regnum,
+      lldb_private::UnwindLLDB::ConcreteRegisterLocation &regloc);
 
   bool ReadRegisterValueFromRegisterLocation(
-      lldb_private::UnwindLLDB::RegisterLocation regloc,
+      lldb_private::UnwindLLDB::ConcreteRegisterLocation regloc,
       const lldb_private::RegisterInfo *reg_info,
       lldb_private::RegisterValue &value);
 
   bool WriteRegisterValueToRegisterLocation(
-      lldb_private::UnwindLLDB::RegisterLocation regloc,
+      lldb_private::UnwindLLDB::ConcreteRegisterLocation regloc,
       const lldb_private::RegisterInfo *reg_info,
       const lldb_private::RegisterValue &value);
 
@@ -249,7 +248,7 @@ private:
 
   uint32_t m_frame_number; // What stack frame this RegisterContext is
 
-  std::map<uint32_t, lldb_private::UnwindLLDB::RegisterLocation>
+  std::map<uint32_t, lldb_private::UnwindLLDB::ConcreteRegisterLocation>
       m_registers; // where to find reg values for this frame
 
   lldb_private::UnwindLLDB &m_parent_unwind; // The UnwindLLDB that is creating

--- a/lldb/include/lldb/Target/UnwindLLDB.h
+++ b/lldb/include/lldb/Target/UnwindLLDB.h
@@ -38,7 +38,10 @@ public:
 protected:
   friend class lldb_private::RegisterContextUnwind;
 
-  struct RegisterLocation {
+  /// An UnwindPlan::Row::AbstractRegisterLocation, combined with the register
+  /// context and memory for a specific stop point, is used to create a
+  /// ConcreteRegisterLocation.
+  struct ConcreteRegisterLocation {
     enum RegisterLocationTypes {
       eRegisterNotSaved = 0, // register was not preserved by callee.  If
                              // volatile reg, is unavailable
@@ -90,7 +93,8 @@ protected:
   // Iterate over the RegisterContextUnwind's in our m_frames vector, look for
   // the first one that has a saved location for this reg.
   bool SearchForSavedLocationForRegister(
-      uint32_t lldb_regnum, lldb_private::UnwindLLDB::RegisterLocation &regloc,
+      uint32_t lldb_regnum,
+      lldb_private::UnwindLLDB::ConcreteRegisterLocation &regloc,
       uint32_t starting_frame_num, bool pc_register);
 
   /// Provide the list of user-specified trap handler functions

--- a/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
+++ b/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
@@ -644,7 +644,7 @@ bool ABISysV_s390x::CreateDefaultUnwindPlan(UnwindPlan &unwind_plan) {
 
 bool ABISysV_s390x::GetFallbackRegisterLocation(
     const RegisterInfo *reg_info,
-    UnwindPlan::Row::RegisterLocation &unwind_regloc) {
+    UnwindPlan::Row::AbstractRegisterLocation &unwind_regloc) {
   // If a volatile register is being requested, we don't want to forward the
   // next frame's register contents up the stack -- the register is not
   // retrievable at this frame.

--- a/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.h
+++ b/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.h
@@ -43,7 +43,8 @@ public:
 
   bool GetFallbackRegisterLocation(
       const lldb_private::RegisterInfo *reg_info,
-      lldb_private::UnwindPlan::Row::RegisterLocation &unwind_regloc) override;
+      lldb_private::UnwindPlan::Row::AbstractRegisterLocation &unwind_regloc)
+      override;
 
   bool CallFrameAddressIsValid(lldb::addr_t cfa) override {
     // Make sure the stack call frame addresses are 8 byte aligned

--- a/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
+++ b/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
@@ -614,7 +614,7 @@ bool SymbolFileBreakpad::ParseCFIUnwindRow(llvm::StringRef unwind_rules,
       row.GetCFAValue().SetIsDWARFExpression(saved.data(), saved.size());
     } else if (const RegisterInfo *info =
                    ResolveRegisterOrRA(triple, resolver, lhs)) {
-      UnwindPlan::Row::RegisterLocation loc;
+      UnwindPlan::Row::AbstractRegisterLocation loc;
       loc.SetIsDWARFExpression(saved.data(), saved.size());
       row.SetRegisterInfo(info->kinds[eRegisterKindLLDB], loc);
     } else
@@ -766,7 +766,7 @@ SymbolFileBreakpad::ParseWinUnwindPlan(const Bookmark &bookmark,
     }
 
     llvm::ArrayRef<uint8_t> saved = SaveAsDWARF(*it->second);
-    UnwindPlan::Row::RegisterLocation loc;
+    UnwindPlan::Row::AbstractRegisterLocation loc;
     loc.SetIsDWARFExpression(saved.data(), saved.size());
     row_sp->SetRegisterInfo(info->kinds[eRegisterKindLLDB], loc);
   }

--- a/lldb/source/Plugins/UnwindAssembly/x86/UnwindAssembly-x86.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/x86/UnwindAssembly-x86.cpp
@@ -97,7 +97,7 @@ bool UnwindAssembly_x86::AugmentUnwindPlanFromCallSite(
       first_row->GetCFAValue().GetOffset() != wordsize) {
     return false;
   }
-  UnwindPlan::Row::RegisterLocation first_row_pc_loc;
+  UnwindPlan::Row::AbstractRegisterLocation first_row_pc_loc;
   if (!first_row->GetRegisterInfo(
           pc_regnum.GetAsKind(unwind_plan.GetRegisterKind()),
           first_row_pc_loc) ||
@@ -126,7 +126,7 @@ bool UnwindAssembly_x86::AugmentUnwindPlanFromCallSite(
       // Get the register locations for eip/rip from the first & last rows. Are
       // they both CFA plus an offset?  Is it the same offset?
 
-      UnwindPlan::Row::RegisterLocation last_row_pc_loc;
+      UnwindPlan::Row::AbstractRegisterLocation last_row_pc_loc;
       if (last_row->GetRegisterInfo(
               pc_regnum.GetAsKind(unwind_plan.GetRegisterKind()),
               last_row_pc_loc)) {

--- a/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
@@ -915,7 +915,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
   addr_t current_func_text_offset = 0;
   int current_sp_bytes_offset_from_fa = 0;
   bool is_aligned = false;
-  UnwindPlan::Row::RegisterLocation initial_regloc;
+  UnwindPlan::Row::AbstractRegisterLocation initial_regloc;
   UnwindPlan::RowSP row(new UnwindPlan::Row);
 
   unwind_plan.SetPlanValidAddressRange(func_range);
@@ -1051,7 +1051,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
       if (nonvolatile_reg_p(machine_regno) &&
           machine_regno_to_lldb_regno(machine_regno, lldb_regno) &&
           !saved_registers[machine_regno]) {
-        UnwindPlan::Row::RegisterLocation regloc;
+        UnwindPlan::Row::AbstractRegisterLocation regloc;
         if (is_aligned)
             regloc.SetAtAFAPlusOffset(-current_sp_bytes_offset_from_fa);
         else
@@ -1142,7 +1142,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
              !saved_registers[machine_regno]) {
       saved_registers[machine_regno] = true;
 
-      UnwindPlan::Row::RegisterLocation regloc;
+      UnwindPlan::Row::AbstractRegisterLocation regloc;
 
       // stack_offset for 'movq %r15, -80(%rbp)' will be 80. In the Row, we
       // want to express this as the offset from the FA.  If the frame base is
@@ -1234,7 +1234,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
       // determine the effcts of.  Verify that the stack frame state 
       // has been unwound to the same as it was at function entry to avoid 
       // mis-identifying a JMP instruction as an epilogue.
-      UnwindPlan::Row::RegisterLocation sp, pc;
+      UnwindPlan::Row::AbstractRegisterLocation sp, pc;
       if (row->GetRegisterInfo(m_lldb_sp_regnum, sp) &&
           row->GetRegisterInfo(m_lldb_ip_regnum, pc)) {
         // Any ret instruction variant is definitely indicative of an

--- a/lldb/source/Symbol/ArmUnwindInfo.cpp
+++ b/lldb/source/Symbol/ArmUnwindInfo.cpp
@@ -333,7 +333,7 @@ bool ArmUnwindInfo::GetUnwindPlan(Target &target, const Address &addr,
   }
 
   if (!have_location_for_pc) {
-    UnwindPlan::Row::RegisterLocation lr_location;
+    UnwindPlan::Row::AbstractRegisterLocation lr_location;
     if (row->GetRegisterInfo(dwarf_lr, lr_location))
       row->SetRegisterInfo(dwarf_pc, lr_location);
     else

--- a/lldb/source/Symbol/DWARFCallFrameInfo.cpp
+++ b/lldb/source/Symbol/DWARFCallFrameInfo.cpp
@@ -633,7 +633,7 @@ bool DWARFCallFrameInfo::FDEToUnwindPlan(dw_offset_t dwarf_offset,
 
   std::vector<UnwindPlan::RowSP> stack;
 
-  UnwindPlan::Row::RegisterLocation reg_location;
+  UnwindPlan::Row::AbstractRegisterLocation reg_location;
   while (m_cfi_data.ValidOffset(offset) && offset < end_offset) {
     uint8_t inst = m_cfi_data.GetU8(&offset);
     uint8_t primary_opcode = inst & 0xC0;
@@ -822,7 +822,7 @@ bool DWARFCallFrameInfo::HandleCommonDwarfOpcode(uint8_t primary_opcode,
                                                  int32_t data_align,
                                                  lldb::offset_t &offset,
                                                  UnwindPlan::Row &row) {
-  UnwindPlan::Row::RegisterLocation reg_location;
+  UnwindPlan::Row::AbstractRegisterLocation reg_location;
 
   if (primary_opcode) {
     switch (primary_opcode) {
@@ -852,7 +852,7 @@ bool DWARFCallFrameInfo::HandleCommonDwarfOpcode(uint8_t primary_opcode,
       // except for the encoding and size of the register argument.
       uint32_t reg_num = (uint32_t)m_cfi_data.GetULEB128(&offset);
       int32_t op_offset = (int32_t)m_cfi_data.GetULEB128(&offset) * data_align;
-      UnwindPlan::Row::RegisterLocation reg_location;
+      UnwindPlan::Row::AbstractRegisterLocation reg_location;
       reg_location.SetAtCFAPlusOffset(op_offset);
       row.SetRegisterInfo(reg_num, reg_location);
       return true;
@@ -864,7 +864,7 @@ bool DWARFCallFrameInfo::HandleCommonDwarfOpcode(uint8_t primary_opcode,
       // number. The required action is to set the rule for the specified
       // register to undefined.
       uint32_t reg_num = (uint32_t)m_cfi_data.GetULEB128(&offset);
-      UnwindPlan::Row::RegisterLocation reg_location;
+      UnwindPlan::Row::AbstractRegisterLocation reg_location;
       reg_location.SetUndefined();
       row.SetRegisterInfo(reg_num, reg_location);
       return true;
@@ -876,7 +876,7 @@ bool DWARFCallFrameInfo::HandleCommonDwarfOpcode(uint8_t primary_opcode,
       // number. The required action is to set the rule for the specified
       // register to same value.
       uint32_t reg_num = (uint32_t)m_cfi_data.GetULEB128(&offset);
-      UnwindPlan::Row::RegisterLocation reg_location;
+      UnwindPlan::Row::AbstractRegisterLocation reg_location;
       reg_location.SetSame();
       row.SetRegisterInfo(reg_num, reg_location);
       return true;
@@ -889,7 +889,7 @@ bool DWARFCallFrameInfo::HandleCommonDwarfOpcode(uint8_t primary_opcode,
       // second register.
       uint32_t reg_num = (uint32_t)m_cfi_data.GetULEB128(&offset);
       uint32_t other_reg_num = (uint32_t)m_cfi_data.GetULEB128(&offset);
-      UnwindPlan::Row::RegisterLocation reg_location;
+      UnwindPlan::Row::AbstractRegisterLocation reg_location;
       reg_location.SetInRegister(other_reg_num);
       row.SetRegisterInfo(reg_num, reg_location);
       return true;
@@ -950,7 +950,7 @@ bool DWARFCallFrameInfo::HandleCommonDwarfOpcode(uint8_t primary_opcode,
       uint32_t block_len = (uint32_t)m_cfi_data.GetULEB128(&offset);
       const uint8_t *block_data =
           static_cast<const uint8_t *>(m_cfi_data.GetData(&offset, block_len));
-      UnwindPlan::Row::RegisterLocation reg_location;
+      UnwindPlan::Row::AbstractRegisterLocation reg_location;
       reg_location.SetAtDWARFExpression(block_data, block_len);
       row.SetRegisterInfo(reg_num, reg_location);
       return true;
@@ -964,7 +964,7 @@ bool DWARFCallFrameInfo::HandleCommonDwarfOpcode(uint8_t primary_opcode,
       // signed and factored.
       uint32_t reg_num = (uint32_t)m_cfi_data.GetULEB128(&offset);
       int32_t op_offset = (int32_t)m_cfi_data.GetSLEB128(&offset) * data_align;
-      UnwindPlan::Row::RegisterLocation reg_location;
+      UnwindPlan::Row::AbstractRegisterLocation reg_location;
       reg_location.SetAtCFAPlusOffset(op_offset);
       row.SetRegisterInfo(reg_num, reg_location);
       return true;

--- a/lldb/source/Symbol/FuncUnwinders.cpp
+++ b/lldb/source/Symbol/FuncUnwinders.cpp
@@ -371,8 +371,8 @@ LazyBool FuncUnwinders::CompareUnwindPlansForIdenticalInitialPCLocation(
     UnwindPlan::RowSP b_first_row = b->GetRowAtIndex(0);
 
     if (a_first_row.get() && b_first_row.get()) {
-      UnwindPlan::Row::RegisterLocation a_pc_regloc;
-      UnwindPlan::Row::RegisterLocation b_pc_regloc;
+      UnwindPlan::Row::AbstractRegisterLocation a_pc_regloc;
+      UnwindPlan::Row::AbstractRegisterLocation b_pc_regloc;
 
       a_first_row->GetRegisterInfo(pc_reg_lldb_regnum, a_pc_regloc);
       b_first_row->GetRegisterInfo(pc_reg_lldb_regnum, b_pc_regloc);

--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -210,7 +210,7 @@ bool ABI::PrepareTrivialCall(Thread &thread, lldb::addr_t sp,
 
 bool ABI::GetFallbackRegisterLocation(
     const RegisterInfo *reg_info,
-    UnwindPlan::Row::RegisterLocation &unwind_regloc) {
+    UnwindPlan::Row::AbstractRegisterLocation &unwind_regloc) {
   // Did the UnwindPlan fail to give us the caller's stack pointer? The stack
   // pointer is defined to be the same as THIS frame's CFA, so return the CFA
   // value as the caller's stack pointer.  This is true on x86-32/x86-64 at

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -1108,14 +1108,14 @@ uint32_t RegisterContextUnwind::ConvertRegisterKindToRegisterNumber(
 }
 
 bool RegisterContextUnwind::ReadRegisterValueFromRegisterLocation(
-    lldb_private::UnwindLLDB::RegisterLocation regloc,
+    lldb_private::UnwindLLDB::ConcreteRegisterLocation regloc,
     const RegisterInfo *reg_info, RegisterValue &value) {
   if (!IsValid())
     return false;
   bool success = false;
 
   switch (regloc.type) {
-  case UnwindLLDB::RegisterLocation::eRegisterInLiveRegisterContext: {
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterInLiveRegisterContext: {
     const RegisterInfo *other_reg_info =
         GetRegisterInfoAtIndex(regloc.location.register_number);
 
@@ -1125,7 +1125,7 @@ bool RegisterContextUnwind::ReadRegisterValueFromRegisterLocation(
     success =
         m_thread.GetRegisterContext()->ReadRegister(other_reg_info, value);
   } break;
-  case UnwindLLDB::RegisterLocation::eRegisterInRegister: {
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterInRegister: {
     const RegisterInfo *other_reg_info =
         GetRegisterInfoAtIndex(regloc.location.register_number);
 
@@ -1139,29 +1139,29 @@ bool RegisterContextUnwind::ReadRegisterValueFromRegisterLocation(
       success = GetNextFrame()->ReadRegister(other_reg_info, value);
     }
   } break;
-  case UnwindLLDB::RegisterLocation::eRegisterValueInferred:
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred:
     success =
         value.SetUInt(regloc.location.inferred_value, reg_info->byte_size);
     break;
 
-  case UnwindLLDB::RegisterLocation::eRegisterNotSaved:
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterNotSaved:
     break;
-  case UnwindLLDB::RegisterLocation::eRegisterSavedAtHostMemoryLocation:
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterSavedAtHostMemoryLocation:
     llvm_unreachable("FIXME debugger inferior function call unwind");
-  case UnwindLLDB::RegisterLocation::eRegisterSavedAtMemoryLocation: {
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterSavedAtMemoryLocation: {
     Status error(ReadRegisterValueFromMemory(
         reg_info, regloc.location.target_memory_location, reg_info->byte_size,
         value));
     success = error.Success();
   } break;
   default:
-    llvm_unreachable("Unknown RegisterLocation type.");
+    llvm_unreachable("Unknown ConcreteRegisterLocation type.");
   }
   return success;
 }
 
 bool RegisterContextUnwind::WriteRegisterValueToRegisterLocation(
-    lldb_private::UnwindLLDB::RegisterLocation regloc,
+    lldb_private::UnwindLLDB::ConcreteRegisterLocation regloc,
     const RegisterInfo *reg_info, const RegisterValue &value) {
   if (!IsValid())
     return false;
@@ -1169,13 +1169,13 @@ bool RegisterContextUnwind::WriteRegisterValueToRegisterLocation(
   bool success = false;
 
   switch (regloc.type) {
-  case UnwindLLDB::RegisterLocation::eRegisterInLiveRegisterContext: {
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterInLiveRegisterContext: {
     const RegisterInfo *other_reg_info =
         GetRegisterInfoAtIndex(regloc.location.register_number);
     success =
         m_thread.GetRegisterContext()->WriteRegister(other_reg_info, value);
   } break;
-  case UnwindLLDB::RegisterLocation::eRegisterInRegister: {
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterInRegister: {
     const RegisterInfo *other_reg_info =
         GetRegisterInfoAtIndex(regloc.location.register_number);
     if (IsFrameZero()) {
@@ -1185,19 +1185,19 @@ bool RegisterContextUnwind::WriteRegisterValueToRegisterLocation(
       success = GetNextFrame()->WriteRegister(other_reg_info, value);
     }
   } break;
-  case UnwindLLDB::RegisterLocation::eRegisterValueInferred:
-  case UnwindLLDB::RegisterLocation::eRegisterNotSaved:
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred:
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterNotSaved:
     break;
-  case UnwindLLDB::RegisterLocation::eRegisterSavedAtHostMemoryLocation:
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterSavedAtHostMemoryLocation:
     llvm_unreachable("FIXME debugger inferior function call unwind");
-  case UnwindLLDB::RegisterLocation::eRegisterSavedAtMemoryLocation: {
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterSavedAtMemoryLocation: {
     Status error(WriteRegisterValueToMemory(
         reg_info, regloc.location.target_memory_location, reg_info->byte_size,
         value));
     success = error.Success();
   } break;
   default:
-    llvm_unreachable("Unknown RegisterLocation type.");
+    llvm_unreachable("Unknown ConcreteRegisterLocation type.");
   }
   return success;
 }
@@ -1259,14 +1259,15 @@ bool RegisterContextUnwind::IsTrapHandlerSymbol(
 
 enum UnwindLLDB::RegisterSearchResult
 RegisterContextUnwind::SavedLocationForRegister(
-    uint32_t lldb_regnum, lldb_private::UnwindLLDB::RegisterLocation &regloc) {
+    uint32_t lldb_regnum,
+    lldb_private::UnwindLLDB::ConcreteRegisterLocation &regloc) {
   RegisterNumber regnum(m_thread, eRegisterKindLLDB, lldb_regnum);
   Log *log = GetLog(LLDBLog::Unwind);
 
   // Have we already found this register location?
   if (!m_registers.empty()) {
     std::map<uint32_t,
-             lldb_private::UnwindLLDB::RegisterLocation>::const_iterator
+             lldb_private::UnwindLLDB::ConcreteRegisterLocation>::const_iterator
         iterator;
     iterator = m_registers.find(regnum.GetAsKind(eRegisterKindLLDB));
     if (iterator != m_registers.end()) {
@@ -1279,7 +1280,7 @@ RegisterContextUnwind::SavedLocationForRegister(
 
   // Look through the available UnwindPlans for the register location.
 
-  UnwindPlan::Row::RegisterLocation unwindplan_regloc;
+  UnwindPlan::Row::AbstractRegisterLocation unwindplan_regloc;
   bool have_unwindplan_regloc = false;
   RegisterKind unwindplan_registerkind = kNumRegisterKinds;
 
@@ -1353,7 +1354,7 @@ RegisterContextUnwind::SavedLocationForRegister(
         // signal was received, we should fetch the actual saved $pc
         // value instead of the Return Address register.
         // If $pc is not available, fall back to the RA reg.
-        UnwindPlan::Row::RegisterLocation scratch;
+        UnwindPlan::Row::AbstractRegisterLocation scratch;
         if (m_frame_type == eTrapHandlerFrame &&
             active_row->GetRegisterInfo
               (pc_regnum.GetAsKind (unwindplan_registerkind), scratch)) {
@@ -1404,9 +1405,9 @@ RegisterContextUnwind::SavedLocationForRegister(
           BehavesLikeZerothFrame()) {
         if (return_address_reg.GetAsKind(eRegisterKindLLDB) !=
             LLDB_INVALID_REGNUM) {
-          lldb_private::UnwindLLDB::RegisterLocation new_regloc;
-          new_regloc.type =
-              UnwindLLDB::RegisterLocation::eRegisterInLiveRegisterContext;
+          lldb_private::UnwindLLDB::ConcreteRegisterLocation new_regloc;
+          new_regloc.type = UnwindLLDB::ConcreteRegisterLocation::
+              eRegisterInLiveRegisterContext;
           new_regloc.location.register_number =
               return_address_reg.GetAsKind(eRegisterKindLLDB);
           m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = new_regloc;
@@ -1513,9 +1514,9 @@ RegisterContextUnwind::SavedLocationForRegister(
     if (IsFrameZero()) {
       // This is frame 0 - we should return the actual live register context
       // value
-      lldb_private::UnwindLLDB::RegisterLocation new_regloc;
+      lldb_private::UnwindLLDB::ConcreteRegisterLocation new_regloc;
       new_regloc.type =
-          UnwindLLDB::RegisterLocation::eRegisterInLiveRegisterContext;
+          UnwindLLDB::ConcreteRegisterLocation::eRegisterInLiveRegisterContext;
       new_regloc.location.register_number = regnum.GetAsKind(eRegisterKindLLDB);
       m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = new_regloc;
       regloc = new_regloc;
@@ -1539,8 +1540,8 @@ RegisterContextUnwind::SavedLocationForRegister(
 
   // unwindplan_regloc has valid contents about where to retrieve the register
   if (unwindplan_regloc.IsUnspecified()) {
-    lldb_private::UnwindLLDB::RegisterLocation new_regloc = {};
-    new_regloc.type = UnwindLLDB::RegisterLocation::eRegisterNotSaved;
+    lldb_private::UnwindLLDB::ConcreteRegisterLocation new_regloc = {};
+    new_regloc.type = UnwindLLDB::ConcreteRegisterLocation::eRegisterNotSaved;
     m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = new_regloc;
     UnwindLogMsg("save location for %s (%d) is unspecified, continue searching",
                  regnum.GetName(), regnum.GetAsKind(eRegisterKindLLDB));
@@ -1564,7 +1565,7 @@ RegisterContextUnwind::SavedLocationForRegister(
                    regnum.GetName(), regnum.GetAsKind(eRegisterKindLLDB));
       return UnwindLLDB::RegisterSearchResult::eRegisterNotFound;
     } else {
-      regloc.type = UnwindLLDB::RegisterLocation::eRegisterInRegister;
+      regloc.type = UnwindLLDB::ConcreteRegisterLocation::eRegisterInRegister;
       regloc.location.register_number = regnum.GetAsKind(eRegisterKindLLDB);
       m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
       UnwindLogMsg(
@@ -1577,7 +1578,7 @@ RegisterContextUnwind::SavedLocationForRegister(
 
   if (unwindplan_regloc.IsCFAPlusOffset()) {
     int offset = unwindplan_regloc.GetOffset();
-    regloc.type = UnwindLLDB::RegisterLocation::eRegisterValueInferred;
+    regloc.type = UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred;
     regloc.location.inferred_value = m_cfa + offset;
     m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
     UnwindLogMsg("supplying caller's register %s (%d), value is CFA plus "
@@ -1589,7 +1590,8 @@ RegisterContextUnwind::SavedLocationForRegister(
 
   if (unwindplan_regloc.IsAtCFAPlusOffset()) {
     int offset = unwindplan_regloc.GetOffset();
-    regloc.type = UnwindLLDB::RegisterLocation::eRegisterSavedAtMemoryLocation;
+    regloc.type =
+        UnwindLLDB::ConcreteRegisterLocation::eRegisterSavedAtMemoryLocation;
     regloc.location.target_memory_location = m_cfa + offset;
     m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
     UnwindLogMsg("supplying caller's register %s (%d) from the stack, saved at "
@@ -1604,7 +1606,7 @@ RegisterContextUnwind::SavedLocationForRegister(
         return UnwindLLDB::RegisterSearchResult::eRegisterNotFound;
 
     int offset = unwindplan_regloc.GetOffset();
-    regloc.type = UnwindLLDB::RegisterLocation::eRegisterValueInferred;
+    regloc.type = UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred;
     regloc.location.inferred_value = m_afa + offset;
     m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
     UnwindLogMsg("supplying caller's register %s (%d), value is AFA plus "
@@ -1619,7 +1621,8 @@ RegisterContextUnwind::SavedLocationForRegister(
         return UnwindLLDB::RegisterSearchResult::eRegisterNotFound;
 
     int offset = unwindplan_regloc.GetOffset();
-    regloc.type = UnwindLLDB::RegisterLocation::eRegisterSavedAtMemoryLocation;
+    regloc.type =
+        UnwindLLDB::ConcreteRegisterLocation::eRegisterSavedAtMemoryLocation;
     regloc.location.target_memory_location = m_afa + offset;
     m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
     UnwindLogMsg("supplying caller's register %s (%d) from the stack, saved at "
@@ -1639,7 +1642,7 @@ RegisterContextUnwind::SavedLocationForRegister(
                    regnum.GetName(), regnum.GetAsKind(eRegisterKindLLDB));
       return UnwindLLDB::RegisterSearchResult::eRegisterNotFound;
     }
-    regloc.type = UnwindLLDB::RegisterLocation::eRegisterInRegister;
+    regloc.type = UnwindLLDB::ConcreteRegisterLocation::eRegisterInRegister;
     regloc.location.register_number = row_regnum.GetAsKind(eRegisterKindLLDB);
     m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
     UnwindLogMsg(
@@ -1670,7 +1673,8 @@ RegisterContextUnwind::SavedLocationForRegister(
       addr_t val;
       val = result->GetScalar().ULongLong();
       if (unwindplan_regloc.IsDWARFExpression()) {
-        regloc.type = UnwindLLDB::RegisterLocation::eRegisterValueInferred;
+        regloc.type =
+            UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred;
         regloc.location.inferred_value = val;
         m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
         UnwindLogMsg("supplying caller's register %s (%d) via DWARF expression "
@@ -1678,8 +1682,8 @@ RegisterContextUnwind::SavedLocationForRegister(
                      regnum.GetName(), regnum.GetAsKind(eRegisterKindLLDB));
         return UnwindLLDB::RegisterSearchResult::eRegisterFound;
       } else {
-        regloc.type =
-            UnwindLLDB::RegisterLocation::eRegisterSavedAtMemoryLocation;
+        regloc.type = UnwindLLDB::ConcreteRegisterLocation::
+            eRegisterSavedAtMemoryLocation;
         regloc.location.target_memory_location = val;
         m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
         UnwindLogMsg("supplying caller's register %s (%d) via DWARF expression "
@@ -1695,7 +1699,7 @@ RegisterContextUnwind::SavedLocationForRegister(
   }
 
   if (unwindplan_regloc.IsConstant()) {
-    regloc.type = UnwindLLDB::RegisterLocation::eRegisterValueInferred;
+    regloc.type = UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred;
     regloc.location.inferred_value = unwindplan_regloc.GetConstant();
     m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
     UnwindLogMsg("supplying caller's register %s (%d) via constant value",
@@ -1756,7 +1760,7 @@ bool RegisterContextUnwind::TryFallbackUnwindPlan() {
 
   addr_t old_caller_pc_value = LLDB_INVALID_ADDRESS;
   addr_t new_caller_pc_value = LLDB_INVALID_ADDRESS;
-  UnwindLLDB::RegisterLocation regloc = {};
+  UnwindLLDB::ConcreteRegisterLocation regloc = {};
   if (SavedLocationForRegister(pc_regnum.GetAsKind(eRegisterKindLLDB),
                                regloc) ==
       UnwindLLDB::RegisterSearchResult::eRegisterFound) {
@@ -2188,7 +2192,7 @@ bool RegisterContextUnwind::ReadGPRValue(lldb::RegisterKind register_kind,
        generic_regnum == LLDB_REGNUM_GENERIC_RA))
     pc_register = true;
 
-  lldb_private::UnwindLLDB::RegisterLocation regloc;
+  lldb_private::UnwindLLDB::ConcreteRegisterLocation regloc;
   if (!m_parent_unwind.SearchForSavedLocationForRegister(
           lldb_regnum, regloc, m_frame_number - 1, pc_register)) {
     return false;
@@ -2235,7 +2239,7 @@ bool RegisterContextUnwind::ReadRegister(const RegisterInfo *reg_info,
     is_pc_regnum = true;
   }
 
-  lldb_private::UnwindLLDB::RegisterLocation regloc;
+  lldb_private::UnwindLLDB::ConcreteRegisterLocation regloc;
   // Find out where the NEXT frame saved THIS frame's register contents
   if (!m_parent_unwind.SearchForSavedLocationForRegister(
           lldb_regnum, regloc, m_frame_number - 1, is_pc_regnum))
@@ -2270,7 +2274,7 @@ bool RegisterContextUnwind::WriteRegister(const RegisterInfo *reg_info,
     return m_thread.GetRegisterContext()->WriteRegister(reg_info, value);
   }
 
-  lldb_private::UnwindLLDB::RegisterLocation regloc;
+  lldb_private::UnwindLLDB::ConcreteRegisterLocation regloc;
   // Find out where the NEXT frame saved THIS frame's register contents
   if (!m_parent_unwind.SearchForSavedLocationForRegister(
           lldb_regnum, regloc, m_frame_number - 1, false))

--- a/lldb/source/Target/UnwindLLDB.cpp
+++ b/lldb/source/Target/UnwindLLDB.cpp
@@ -474,7 +474,8 @@ UnwindLLDB::GetRegisterContextForFrameNum(uint32_t frame_num) {
 }
 
 bool UnwindLLDB::SearchForSavedLocationForRegister(
-    uint32_t lldb_regnum, lldb_private::UnwindLLDB::RegisterLocation &regloc,
+    uint32_t lldb_regnum,
+    lldb_private::UnwindLLDB::ConcreteRegisterLocation &regloc,
     uint32_t starting_frame_num, bool pc_reg) {
   int64_t frame_num = starting_frame_num;
   if (static_cast<size_t>(frame_num) >= m_frames.size())
@@ -497,8 +498,8 @@ bool UnwindLLDB::SearchForSavedLocationForRegister(
     // We descended down to the live register context aka stack frame 0 and are
     // reading the value out of a live register.
     if (result == UnwindLLDB::RegisterSearchResult::eRegisterFound &&
-        regloc.type ==
-            UnwindLLDB::RegisterLocation::eRegisterInLiveRegisterContext) {
+        regloc.type == UnwindLLDB::ConcreteRegisterLocation::
+                           eRegisterInLiveRegisterContext) {
       return true;
     }
 
@@ -509,7 +510,8 @@ bool UnwindLLDB::SearchForSavedLocationForRegister(
     // down the stack, or an actual value from a live RegisterContext at frame
     // 0.
     if (result == UnwindLLDB::RegisterSearchResult::eRegisterFound &&
-        regloc.type == UnwindLLDB::RegisterLocation::eRegisterInRegister &&
+        regloc.type ==
+            UnwindLLDB::ConcreteRegisterLocation::eRegisterInRegister &&
         frame_num > 0) {
       result = UnwindLLDB::RegisterSearchResult::eRegisterNotFound;
       lldb_regnum = regloc.location.register_number;

--- a/lldb/unittests/UnwindAssembly/ARM64/TestArm64InstEmulation.cpp
+++ b/lldb/unittests/UnwindAssembly/ARM64/TestArm64InstEmulation.cpp
@@ -62,7 +62,7 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // 'int main() { }' compiled for arm64-apple-ios with clang
   uint8_t data[] = {
@@ -170,7 +170,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // disassembly of -[NSPlaceholderString initWithBytes:length:encoding:]
   // from Foundation for iOS.
@@ -332,7 +332,7 @@ TEST_F(TestArm64InstEmulation, TestFramelessThreeEpilogueFunction) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // disassembly of JSC::ARM64LogicalImmediate::findBitRange<16u>
   // from JavaScriptcore for iOS.
@@ -431,7 +431,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterSavedTwice) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // disassembly of mach_msg_sever_once from libsystem_kernel.dylib for iOS.
   uint8_t data[] = {
@@ -533,7 +533,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterDoubleSpills) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // this file built with clang for iOS arch arm64 optimization -Os
   // #include <stdio.h>
@@ -705,7 +705,7 @@ TEST_F(TestArm64InstEmulation, TestCFARegisterTrackedAcrossJumps) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   uint8_t data[] = {
       // prologue
@@ -804,7 +804,7 @@ TEST_F(TestArm64InstEmulation, TestCFAResetToSP) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // The called_from_nodebug() from TestStepNoDebug.py
   // Most of the previous unit tests have $sp being set as

--- a/lldb/unittests/UnwindAssembly/PPC64/TestPPC64InstEmulation.cpp
+++ b/lldb/unittests/UnwindAssembly/PPC64/TestPPC64InstEmulation.cpp
@@ -61,7 +61,7 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // prologue and epilogue of:
   // int main() {
@@ -180,7 +180,7 @@ TEST_F(TestPPC64InstEmulation, TestMediumFunction) {
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // prologue and epilogue of main() (call-func.c),
   // with several calls and stack variables.

--- a/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
+++ b/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
@@ -168,7 +168,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple64bitFrameFunction) {
               eLazyBoolYes);
   EXPECT_TRUE(unwind_plan.GetSourcedFromCompiler() == eLazyBoolNo);
 
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // 0: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(0);
@@ -244,7 +244,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple32bitFrameFunction) {
               eLazyBoolYes);
   EXPECT_TRUE(unwind_plan.GetSourcedFromCompiler() == eLazyBoolNo);
 
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // offset 0 -- pushl %ebp
   UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(0);
@@ -381,7 +381,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessBigStackFrame) {
   // 33: CFA=rsp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   // 34: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
 
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // grab the Row for when the prologue has finished executing:
   // 17: CFA=rsp+14496 => rbx=[CFA-56] rbp=[CFA-16] rsp=CFA+0 r12=[CFA-48]
@@ -650,7 +650,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
   //  48: CFA=esp+14480 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   //  esp=CFA+0 eip=[CFA-4]
 
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   // Check that we get the CFA correct for the pic base setup sequence
@@ -802,7 +802,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessSmallStackFrame) {
   //     1: CFA=rsp+16 => rsp=CFA+0 rip=[CFA-8]
   //    22: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
 
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // grab the Row for when the prologue has finished executing:
   //     1: CFA=rsp+16 => rsp=CFA+0 rip=[CFA-8]
@@ -911,7 +911,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessSmallStackFrame) {
   // row[3]:    9: CFA=esp+16 => esp=CFA+0 eip=[CFA-4]
   // row[4]:   34: CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
 
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // Check unwind state before we set up the picbase register
   //      3: CFA=esp+16 => esp=CFA+0 eip=[CFA-4]
@@ -962,7 +962,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessSmallStackFrame) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushRBP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1005,7 +1005,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushImm) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1054,7 +1054,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushImm) {
 // in the first function called in a new thread and it needs to
 // put a 0 as the saved pc.  We pretend it didn't change the CFA.
 TEST_F(Testx86AssemblyInspectionEngine, TestPush0) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1085,7 +1085,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPush0) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushExtended) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1133,7 +1133,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushExtended) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR15) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1161,7 +1161,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR15) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR14) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1189,7 +1189,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR14) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR13) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1217,7 +1217,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR13) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR12) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1245,7 +1245,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR12) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushRBX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1276,7 +1276,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBX) {
 // eax, ecx, edx are all considered volatile and push/pops of them are
 // not tracked (except to keep track of stack pointer movement)
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEAX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1305,7 +1305,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEAX) {
 // eax, ecx, edx are all considered volatile and push/pops of them are
 // not tracked (except to keep track of stack pointer movement)
 TEST_F(Testx86AssemblyInspectionEngine, TestPushECX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1334,7 +1334,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushECX) {
 // eax, ecx, edx are all considered volatile and push/pops of them are
 // not tracked (except to keep track of stack pointer movement)
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEDX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1360,7 +1360,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEDX) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEBX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1388,7 +1388,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEBX) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEBP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1416,7 +1416,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEBP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushRBPWithREX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data[] = {
@@ -1444,7 +1444,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBPWithREX) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushESI) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1472,7 +1472,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushESI) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEDI) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1500,7 +1500,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEDI) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
 
   uint8_t data64_1[] = {
@@ -1572,7 +1572,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSubRSP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1612,7 +1612,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubRSP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSubESP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1652,7 +1652,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubESP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestAddRSP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1692,7 +1692,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddRSP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestAddESP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1732,7 +1732,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddESP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestLEA_RSP_Pattern) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1756,7 +1756,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEA_RSP_Pattern) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopRBX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1782,7 +1782,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBX) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopRBP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1808,7 +1808,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR12) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1834,7 +1834,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR12) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR13) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1860,7 +1860,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR13) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR14) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1886,7 +1886,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR14) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR15) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1912,7 +1912,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR15) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopEBX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1938,7 +1938,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEBX) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopEBP) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1964,7 +1964,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEBP) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopRBPWithREX) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -1990,7 +1990,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBPWithREX) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopESI) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2016,7 +2016,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopESI) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopEDI) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2044,7 +2044,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEDI) {
 // We don't track these registers, but make sure the CFA address is updated
 // if we're defining the CFA in term of esp.
 TEST_F(Testx86AssemblyInspectionEngine, Testi386IgnoredRegisters) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2082,7 +2082,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Testi386IgnoredRegisters) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestLEAVE) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2123,7 +2123,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEAVE) {
 // pushes the addr of the next insn on the stack, and then pop that value
 // into a register (the "pic base" register).
 TEST_F(Testx86AssemblyInspectionEngine, TestCALLNextInsn) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2148,7 +2148,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestCALLNextInsn) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVx86_64) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2187,7 +2187,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVx86_64) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVi386) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2221,7 +2221,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVi386) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSpArithx86_64Augmented) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2312,7 +2312,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpArithx86_64Augmented) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2390,7 +2390,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2472,7 +2472,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
 // stops
 // disassembling at that point (long-mode).
 TEST_F(Testx86AssemblyInspectionEngine, Test32BitOnlyInstruction) {
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
@@ -2634,7 +2634,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestStackRealignMSVC_i386) {
   EXPECT_EQ(esp_minus_4, plan.GetRowForFunctionOffset(30)->GetAFAValue());
 
   // Test saved register
-  UnwindPlan::Row::RegisterLocation reg_loc;
+  UnwindPlan::Row::AbstractRegisterLocation reg_loc;
   EXPECT_TRUE(
       plan.GetRowForFunctionOffset(27)->GetRegisterInfo(k_edi, reg_loc));
   EXPECT_TRUE(reg_loc.IsAtAFAPlusOffset());
@@ -2712,7 +2712,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
               eLazyBoolYes);
   EXPECT_TRUE(unwind_plan.GetSourcedFromCompiler() == eLazyBoolNo);
 
-  UnwindPlan::Row::RegisterLocation regloc;
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   //  0: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(0);


### PR DESCRIPTION
lldb has two RegisterLocation classes that do slightly different things.

UnwindPlan::Row::RegisterLocation (new: AbstractRegisterLocation) has a description of how to find a register's value or location, not specific to a particular stopping point.  It may say that at a given offset into a function, the caller's register has been spilled to stack memory at CFA minus an offset.  Or it may say that the caller's register is at a DWARF exprssion.

UnwindLLDB::RegisterLocation (new: ConcreteRegisterLocation) is a specific address where the register is currently stored, or the register it has been copied into, or its value at this point in the current function execution.

When lldb stops in a function, it interprets the
AbstractRegisterLocation's instructions using the register context and stack memory, to create the ConcreteRegisterLocation at this point in time for this stack frame.

I'm not thrilled with AbstractRegisterLocation and ConcreteRegisterLocation, but it's better than the same name and it will be easier to update them if someone suggests a better pair.