### PR TITLE
[ASan][test] XFAIL Linux/preinstalled_signal.cpp on Linux/sparc64

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/preinstalled_signal.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/preinstalled_signal.cpp
@@ -17,6 +17,9 @@
 // This way of setting LD_PRELOAD does not work with Android test runner.
 // REQUIRES: !android
 
+// Issue #109573: Cannot use syscall(__NR_rt_sigaction) on Linux/sparc64.
+// XFAIL: target={{sparc.*-.*-linux.*}}
+
 #include <assert.h>
 #include <signal.h>
 #include <stdio.h>


### PR DESCRIPTION
With ASan testing enabled on SPARC as per PR #107405, the
```
  AddressSanitizer-sparc-linux-dynamic :: TestCases/Linux/preinstalled_signal.cpp
```
test `FAIL`s on Linux/sparc64.  See Issue #109573 for all the details, but the core is that `syscall(__NR_rt_sigaction)` cannot be used because it takes an additional argument that isn't accessible outside of `libc`, while switching to `sigaction` instead changes the order of `AsanInitInternal` and `Init`, breaking the test.

Therefore this patch `XFAIL`s the test.

Tested on `sparc64-unknown-linux-gnu` and `x86_64-pc-linux-gnu`.