### PR TITLE
[ASan][test] Fix Posix/coverage-fork.cpp on Solaris

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/coverage-fork.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage-fork.cpp
@@ -26,11 +26,14 @@ void baz() { printf("baz\n"); }
 
 int main(int argc, char **argv) {
   pid_t child_pid = fork();
+  char buf[100];
   if (child_pid == 0) {
-    fprintf(stderr, "Child PID: %d\n", getpid());
+    snprintf(buf, sizeof(buf), "Child PID: %ld\n", (long)getpid());
+    write(2, buf, strlen(buf));
     baz();
   } else {
-    fprintf(stderr, "Parent PID: %d\n", getpid());
+    snprintf(buf, sizeof(buf), "Parent PID: %ld\n", (long)getpid());
+    write(2, buf, strlen(buf));
     foo();
     bar();
 


### PR DESCRIPTION
With ASan testing enabled on SPARC as per PR #107405, the
```
  AddressSanitizer-sparc-sunos-dynamic :: TestCases/Posix/coverage-fork.cpp
```
test occasionally `FAIL`s on Solaris/sparcv9:
```
compiler-rt/test/asan/TestCases/Posix/coverage-fork.cpp:46:15: error: CHECK-DAG: expected string not found in input
// CHECK-DAG: Parent PID: [[ParentPID:[0-9]+]]
              ^
```
It turns out that the output for parent and child processes is interleaved like
```
Parent PID: Child PID: 27426
27425
```
Checking with `truss` shows that the `fprintf`s are implemented as 3 separate `write`s:
```
28489:  write(2, " P a r e n t   P I D :  ", 12)        = 12
28489:  write(2, " 2 8 4 8 9", 5)                       = 5
28489:  write(2, "\n", 1)                               = 1
```

To avoid this, this patch switches the test to use `snprintf`/`write` to guarantee the output is atomic.

Tested on `sparcv9-sun-solaris2.11`, `amd64-pc-solaris2.11`, and `x86_64-pc-linux-gnu`.