### PR TITLE
[ARM] Fix -mno-omit-leaf-frame-pointer flag doesn't  works on 32-bit ARM 

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -599,6 +599,11 @@ X86 Support
 Arm and AArch64 Support
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+- In the ARM Target, the frame pointer (FP) of a leaf function can be retained
+  by using the ``-fno-omit-frame-pointer`` option. If you want to eliminate the FP
+  in leaf functions after enabling ``-fno-omit-frame-pointer``, you can do so by adding
+  the ``-momit-leaf-frame-pointer`` option.
+
 Android Support
 ^^^^^^^^^^^^^^^
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -125,6 +125,12 @@ Changes to the ARM Backend
   the required alignment space with a sequence of `0x0` bytes (the requested
   fill value) rather than NOPs.
 
+* The default behavior for frame pointers in leaf functions has been updated.
+  When the `-fno-omit-frame-pointer` option is specified, `FPKeepKindStr` is
+  set to `-mframe-pointer=all`, meaning the frame pointer (FP) is now retained
+  in leaf functions by default. To eliminate the frame pointer in leaf functions,
+  you must explicitly use the `-momit-leaf-frame-pointer` option.
+
 Changes to the AVR Backend
 --------------------------
 

--- a/llvm/include/llvm/CodeGen/TargetFrameLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetFrameLowering.h
@@ -277,12 +277,6 @@ public:
     return false;
   }
 
-  /// Return true if the target wants to keep the frame pointer regardless of
-  /// the function attribute "frame-pointer".
-  virtual bool keepFramePointer(const MachineFunction &MF) const {
-    return false;
-  }
-
   /// hasFP - Return true if the specified function should have a dedicated
   /// frame pointer register. For most targets this is true only if the function
   /// has variable sized allocas or if frame pointer elimination is disabled.

--- a/llvm/lib/CodeGen/TargetOptionsImpl.cpp
+++ b/llvm/lib/CodeGen/TargetOptionsImpl.cpp
@@ -22,10 +22,6 @@ using namespace llvm;
 /// DisableFramePointerElim - This returns true if frame pointer elimination
 /// optimization should be disabled for the given machine function.
 bool TargetOptions::DisableFramePointerElim(const MachineFunction &MF) const {
-  // Check to see if the target want to forcibly keep frame pointer.
-  if (MF.getSubtarget().getFrameLowering()->keepFramePointer(MF))
-    return true;
-
   const Function &F = MF.getFunction();
 
   if (!F.hasFnAttribute("frame-pointer"))
@@ -41,10 +37,6 @@ bool TargetOptions::DisableFramePointerElim(const MachineFunction &MF) const {
 }
 
 bool TargetOptions::FramePointerIsReserved(const MachineFunction &MF) const {
-  // Check to see if the target want to forcibly keep frame pointer.
-  if (MF.getSubtarget().getFrameLowering()->keepFramePointer(MF))
-    return true;
-
   const Function &F = MF.getFunction();
 
   if (!F.hasFnAttribute("frame-pointer"))

--- a/llvm/lib/Target/ARM/ARMFrameLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMFrameLowering.cpp
@@ -324,6 +324,10 @@ bool ARMFrameLowering::hasFP(const MachineFunction &MF) const {
   const TargetRegisterInfo *RegInfo = MF.getSubtarget().getRegisterInfo();
   const MachineFrameInfo &MFI = MF.getFrameInfo();
 
+  // Check to see if the target want to forcibly keep frame pointer.
+  if (keepFramePointer(MF))
+    return true;
+
   // ABI-required frame pointer.
   if (MF.getTarget().Options.DisableFramePointerElim(MF))
     return true;
@@ -2365,7 +2369,8 @@ void ARMFrameLowering::determineCalleeSaves(MachineFunction &MF,
   // to take advantage the eliminateFrameIndex machinery. This also ensures it
   // is spilled in the order specified by getCalleeSavedRegs() to make it easier
   // to combine multiple loads / stores.
-  bool CanEliminateFrame = !(requiresAAPCSFrameRecord(MF) && hasFP(MF));
+  bool CanEliminateFrame = !(requiresAAPCSFrameRecord(MF) && hasFP(MF)) &&
+                           !MF.getTarget().Options.DisableFramePointerElim(MF);
   bool CS1Spilled = false;
   bool LRSpilled = false;
   unsigned NumGPRSpills = 0;

--- a/llvm/lib/Target/ARM/ARMFrameLowering.h
+++ b/llvm/lib/Target/ARM/ARMFrameLowering.h
@@ -41,7 +41,7 @@ public:
                               MutableArrayRef<CalleeSavedInfo> CSI,
                               const TargetRegisterInfo *TRI) const override;
 
-  bool keepFramePointer(const MachineFunction &MF) const override;
+  bool keepFramePointer(const MachineFunction &MF) const;
 
   bool enableCalleeSaveSkip(const MachineFunction &MF) const override;
 

--- a/llvm/test/CodeGen/ARM/2011-03-15-LdStMultipleBug.ll
+++ b/llvm/test/CodeGen/ARM/2011-03-15-LdStMultipleBug.ll
@@ -9,7 +9,7 @@
 
 @oStruct = external global %struct.Outer, align 4
 
-define void @main(i8 %val8) nounwind {
+define void @main(i8 %val8) nounwind "frame-pointer"="none" {
 ; CHECK-LABEL: main:
 ; CHECK:       @ %bb.0: @ %for.body.lr.ph
 ; CHECK-NEXT:    movw r0, :lower16:(L_oStruct$non_lazy_ptr-(LPC0_0+4))

--- a/llvm/test/CodeGen/ARM/2011-12-19-sjlj-clobber.ll
+++ b/llvm/test/CodeGen/ARM/2011-12-19-sjlj-clobber.ll
@@ -3,7 +3,7 @@
 ; Radar 10567930: Make sure that all the caller-saved registers are saved and
 ; restored in a function with setjmp/longjmp EH.  In particular, r6 was not
 ; being saved here.
-; CHECK: push {r4, r5, r6, r7, lr}
+; CHECK: push.w {r4, r5, r6, r7, r8, r10, r11, lr}
 
 %0 = type opaque
 %struct.NSConstantString = type { ptr, i32, ptr, i32 }

--- a/llvm/test/CodeGen/ARM/arm-shrink-wrapping.ll
+++ b/llvm/test/CodeGen/ARM/arm-shrink-wrapping.ll
@@ -1732,7 +1732,7 @@ if.end:
 ; Another infinite loop test this time with two nested infinite loop.
 ; infiniteloop3
 ; bx lr
-define void @infiniteloop3() "frame-pointer"="all" {
+define void @infiniteloop3() "frame-pointer"="none" {
 ; ARM-LABEL: infiniteloop3:
 ; ARM:       @ %bb.0: @ %entry
 ; ARM-NEXT:    mov r0, #0

--- a/llvm/test/CodeGen/ARM/atomic-load-store.ll
+++ b/llvm/test/CodeGen/ARM/atomic-load-store.ll
@@ -324,18 +324,17 @@ define void @test_old_store_64bit(ptr %p, i64 %v) {
 ;
 ; ARMOPTNONE-LABEL: test_old_store_64bit:
 ; ARMOPTNONE:       @ %bb.0:
-; ARMOPTNONE-NEXT:    push {r4, r5, r7, lr}
-; ARMOPTNONE-NEXT:    add r7, sp, #8
-; ARMOPTNONE-NEXT:    push {r8, r10, r11}
-; ARMOPTNONE-NEXT:    sub sp, sp, #24
-; ARMOPTNONE-NEXT:    str r0, [sp, #4] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    str r1, [sp, #12] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    dmb ish
-; ARMOPTNONE-NEXT:    ldr r1, [r0]
-; ARMOPTNONE-NEXT:    ldr r0, [r0, #4]
-; ARMOPTNONE-NEXT:    str r1, [sp, #16] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    str r0, [sp, #20] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    push	{r4, r5, r7, r8, r10, r11, lr}
+; ARMOPTNONE-NEXT:    add	r7, sp, #20
+; ARMOPTNONE-NEXT:    sub	sp, sp, #24
+; ARMOPTNONE-NEXT:    str	r0, [sp, #4] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    str	r2, [sp, #8] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    str	r1, [sp, #12] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    dmb	ish
+; ARMOPTNONE-NEXT:    ldr	r1, [r0]
+; ARMOPTNONE-NEXT:    ldr	r0, [r0, #4]
+; ARMOPTNONE-NEXT:    str	r1, [sp, #16] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    str	r0, [sp, #20] @ 4-byte Spill
 ; ARMOPTNONE-NEXT:    b LBB5_1
 ; ARMOPTNONE-NEXT:  LBB5_1: @ %atomicrmw.start
 ; ARMOPTNONE-NEXT:    @ =>This Loop Header: Depth=1
@@ -382,8 +381,7 @@ define void @test_old_store_64bit(ptr %p, i64 %v) {
 ; ARMOPTNONE-NEXT:  LBB5_5: @ %atomicrmw.end
 ; ARMOPTNONE-NEXT:    dmb ish
 ; ARMOPTNONE-NEXT:    sub sp, r7, #20
-; ARMOPTNONE-NEXT:    pop {r8, r10, r11}
-; ARMOPTNONE-NEXT:    pop {r4, r5, r7, pc}
+; ARMOPTNONE-NEXT:    pop	{r4, r5, r7, r8, r10, r11, pc}
 ;
 ; THUMBTWO-LABEL: test_old_store_64bit:
 ; THUMBTWO:       @ %bb.0:
@@ -864,20 +862,19 @@ define void @store_atomic_f64__seq_cst(ptr %ptr, double %val1) {
 ;
 ; ARMOPTNONE-LABEL: store_atomic_f64__seq_cst:
 ; ARMOPTNONE:       @ %bb.0:
-; ARMOPTNONE-NEXT:    push {r4, r5, r7, lr}
-; ARMOPTNONE-NEXT:    add r7, sp, #8
-; ARMOPTNONE-NEXT:    push {r8, r10, r11}
-; ARMOPTNONE-NEXT:    sub sp, sp, #24
-; ARMOPTNONE-NEXT:    str r0, [sp, #4] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    vmov d16, r1, r2
-; ARMOPTNONE-NEXT:    vmov r1, r2, d16
-; ARMOPTNONE-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    str r1, [sp, #12] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    dmb ish
-; ARMOPTNONE-NEXT:    ldr r1, [r0]
-; ARMOPTNONE-NEXT:    ldr r0, [r0, #4]
-; ARMOPTNONE-NEXT:    str r1, [sp, #16] @ 4-byte Spill
-; ARMOPTNONE-NEXT:    str r0, [sp, #20] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    push	{r4, r5, r7, r8, r10, r11, lr}
+; ARMOPTNONE-NEXT:    add	r7, sp, #20
+; ARMOPTNONE-NEXT:    sub	sp, sp, #24
+; ARMOPTNONE-NEXT:    str	r0, [sp, #4] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    vmov	d16, r1, r2
+; ARMOPTNONE-NEXT:    vmov	r1, r2, d16
+; ARMOPTNONE-NEXT:    str	r2, [sp, #8] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    str	r1, [sp, #12] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    dmb	ish
+; ARMOPTNONE-NEXT:    ldr	r1, [r0]
+; ARMOPTNONE-NEXT:    ldr	r0, [r0, #4]
+; ARMOPTNONE-NEXT:    str	r1, [sp, #16] @ 4-byte Spill
+; ARMOPTNONE-NEXT:    str	r0, [sp, #20] @ 4-byte Spill
 ; ARMOPTNONE-NEXT:    b LBB13_1
 ; ARMOPTNONE-NEXT:  LBB13_1: @ %atomicrmw.start
 ; ARMOPTNONE-NEXT:    @ =>This Loop Header: Depth=1
@@ -924,8 +921,7 @@ define void @store_atomic_f64__seq_cst(ptr %ptr, double %val1) {
 ; ARMOPTNONE-NEXT:  LBB13_5: @ %atomicrmw.end
 ; ARMOPTNONE-NEXT:    dmb ish
 ; ARMOPTNONE-NEXT:    sub sp, r7, #20
-; ARMOPTNONE-NEXT:    pop {r8, r10, r11}
-; ARMOPTNONE-NEXT:    pop {r4, r5, r7, pc}
+; ARMOPTNONE-NEXT:    pop	{r4, r5, r7, r8, r10, r11, pc}
 ;
 ; THUMBTWO-LABEL: store_atomic_f64__seq_cst:
 ; THUMBTWO:       @ %bb.0:

--- a/llvm/test/CodeGen/ARM/call-tc.ll
+++ b/llvm/test/CodeGen/ARM/call-tc.ll
@@ -17,7 +17,7 @@ define void @t1() "frame-pointer"="all" {
         ret void
 }
 
-define void @t2() "frame-pointer"="all" {
+define void @t2() "frame-pointer"="none" {
 ; CHECKV6-LABEL: t2:
 ; CHECKV6: bx r0
 ; CHECKT2D-LABEL: t2:
@@ -102,7 +102,7 @@ bb:
 
 ; Make sure codegenprep is duplicating ret instructions to enable tail calls.
 ; rdar://11140249
-define i32 @t8(i32 %x) nounwind ssp "frame-pointer"="all" {
+define i32 @t8(i32 %x) nounwind ssp "frame-pointer"="none" {
 entry:
 ; CHECKT2D-LABEL: t8:
 ; CHECKT2D-NOT: push

--- a/llvm/test/CodeGen/ARM/debug-frame.ll
+++ b/llvm/test/CodeGen/ARM/debug-frame.ll
@@ -526,7 +526,7 @@ entry:
 ; Test 4
 ;-------------------------------------------------------------------------------
 
-define void @test4() nounwind {
+define void @test4() nounwind "frame-pointer"="none" {
 entry:
   ret void
 }

--- a/llvm/test/CodeGen/ARM/ehabi.ll
+++ b/llvm/test/CodeGen/ARM/ehabi.ll
@@ -575,7 +575,7 @@ entry:
 ; Test 4
 ;-------------------------------------------------------------------------------
 
-define void @test4() nounwind {
+define void @test4() nounwind "frame-pointer"="none" {
 entry:
   ret void
 }

--- a/llvm/test/CodeGen/ARM/fast-isel-frameaddr.ll
+++ b/llvm/test/CodeGen/ARM/fast-isel-frameaddr.ll
@@ -16,7 +16,7 @@ entry:
 ; DARWIN-THUMB2: mov r0, r7
 
 ; LINUX-ARM-LABEL: frameaddr_index0:
-; LINUX-ARM: push {r11, lr}
+; LINUX-ARM: push {r11}
 ; LINUX-ARM: mov r11, sp
 ; LINUX-ARM: mov r0, r11
 
@@ -42,7 +42,7 @@ entry:
 ; DARWIN-THUMB2: ldr r0, [r7]
 
 ; LINUX-ARM-LABEL: frameaddr_index1:
-; LINUX-ARM: push {r11, lr}
+; LINUX-ARM: push {r11}
 ; LINUX-ARM: mov r11, sp
 ; LINUX-ARM: ldr r0, [r11]
 
@@ -73,7 +73,7 @@ entry:
 ; DARWIN-THUMB2: ldr r0, [r0]
 
 ; LINUX-ARM-LABEL: frameaddr_index3:
-; LINUX-ARM: push {r11, lr}
+; LINUX-ARM: push {r11}
 ; LINUX-ARM: mov r11, sp
 ; LINUX-ARM: ldr r0, [r11]
 ; LINUX-ARM: ldr r0, [r0]

--- a/llvm/test/CodeGen/ARM/frame-chain.ll
+++ b/llvm/test/CodeGen/ARM/frame-chain.ll
@@ -10,11 +10,14 @@
 define dso_local noundef i32 @leaf(i32 noundef %0) {
 ; LEAF-FP-LABEL: leaf:
 ; LEAF-FP:       @ %bb.0:
-; LEAF-FP-NEXT:    .pad #4
-; LEAF-FP-NEXT:    sub sp, sp, #4
-; LEAF-FP-NEXT:    str r0, [sp]
+; LEAF-FP-NEXT:    .save {r11, lr}
+; LEAF-FP-NEXT:    push {r11, lr}
+; LEAF-FP-NEXT:    .setfp r11, sp
+; LEAF-FP-NEXT:    mov r11, sp
+; LEAF-FP-NEXT:    push {r0}
 ; LEAF-FP-NEXT:    add r0, r0, #4
-; LEAF-FP-NEXT:    add sp, sp, #4
+; LEAF-FP-NEXT:    mov sp, r11
+; LEAF-FP-NEXT:    pop {r11, lr}
 ; LEAF-FP-NEXT:    mov pc, lr
 ;
 ; LEAF-FP-AAPCS-LABEL: leaf:

--- a/llvm/test/CodeGen/ARM/ifcvt5.ll
+++ b/llvm/test/CodeGen/ARM/ifcvt5.ll
@@ -5,7 +5,7 @@
 
 @x = external global ptr		; <ptr> [#uses=1]
 
-define void @foo(i32 %a) "frame-pointer"="all" {
+define void @foo(i32 %a) "frame-pointer"="none" {
 ; A8-LABEL: foo:
 ; A8:       @ %bb.0: @ %entry
 ; A8-NEXT:    movw r1, :lower16:(L_x$non_lazy_ptr-(LPC0_0+8))

--- a/llvm/test/CodeGen/ARM/ldrd.ll
+++ b/llvm/test/CodeGen/ARM/ldrd.ll
@@ -168,7 +168,7 @@ define void @ldrd_postupdate_inc(ptr %p0) "frame-pointer"="all" {
 ; NORMAL: strd r1, r2, [r0], #-8
 ; CONSERVATIVE-NOT: strd
 ; CHECK: bx lr
-define ptr @strd_postupdate_dec(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="all" {
+define ptr @strd_postupdate_dec(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="none" {
   %p0.1 = getelementptr i32, ptr %p0, i32 1
   store i32 %v0, ptr %p0
   store i32 %v1, ptr %p0.1
@@ -180,7 +180,7 @@ define ptr @strd_postupdate_dec(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="all"
 ; NORMAL: strd r1, r2, [r0], #8
 ; CONSERVATIVE-NOT: strd
 ; CHECK: bx lr
-define ptr @strd_postupdate_inc(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="all" {
+define ptr @strd_postupdate_inc(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="none" {
   %p0.1 = getelementptr i32, ptr %p0, i32 1
   store i32 %v0, ptr %p0
   store i32 %v1, ptr %p0.1

--- a/llvm/test/CodeGen/ARM/stack-frame-layout-remarks.ll
+++ b/llvm/test/CodeGen/ARM/stack-frame-layout-remarks.ll
@@ -51,7 +51,7 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 ; BOTH:  [SP-8]{{.+}}8{{.+}}4
 ; DEBUG: a @ dot.c:13
 ; STRIPPED-NOT: a @ dot.c:13
-define void @cleanup_array(ptr %0) #1 {
+define void @cleanup_array(ptr %0) #3 {
   %2 = alloca ptr, align 8
   store ptr %0, ptr %2, align 8
   call void @llvm.dbg.declare(metadata ptr %2, metadata !41, metadata !DIExpression()), !dbg !46
@@ -62,7 +62,7 @@ define void @cleanup_array(ptr %0) #1 {
 ; BOTH:  [SP-8]{{.+}}8{{.+}}4
 ; DEBUG: res @ dot.c:21
 ; STRIPPED-NOT: res @ dot.c:21
-define void @cleanup_result(ptr %0) #1 {
+define void @cleanup_result(ptr %0) #3 {
   %2 = alloca ptr, align 8
   store ptr %0, ptr %2, align 8
   call void @llvm.dbg.declare(metadata ptr %2, metadata !47, metadata !DIExpression()), !dbg !51
@@ -92,7 +92,7 @@ define void @cleanup_result(ptr %0) #1 {
 ; BOTH:  [SP-40]{{.+}}4{{.+}}4
 ; DEBUG: i @ dot.c:55
 ; STRIPPED-NOT: i @ dot.c:55
-define i32 @do_work(ptr %0, ptr %1, ptr %2) #1 {
+define i32 @do_work(ptr %0, ptr %1, ptr %2) #3 {
   %4 = alloca i32, align 4
   %5 = alloca ptr, align 8
   %6 = alloca ptr, align 8
@@ -144,7 +144,7 @@ define i32 @do_work(ptr %0, ptr %1, ptr %2) #1 {
 ; BOTH:  [SP-20]{{.+}}4{{.*}}4
 ; DEBUG: i @ dot.c:69
 ; STRIPPED-NOT: i @ dot.c:69
-define ptr @gen_array(i32 %0) #1 {
+define ptr @gen_array(i32 %0) #3 {
   %2 = alloca ptr, align 8
   %3 = alloca i32, align 4
   %4 = alloca ptr, align 8
@@ -227,6 +227,7 @@ uselistorder ptr @llvm.dbg.declare, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 
 attributes #0 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
 attributes #1 = { "frame-pointer"="all" }
 attributes #2 = { ssp "stack-protector-buffer-size"="5" "frame-pointer"="all" }
+attributes #3 = { "frame-pointer"="none" }
 
 !llvm.dbg.cu = !{!0, !2}
 !llvm.module.flags = !{!18, !19, !20, !21, !22, !23, !24}

--- a/llvm/test/CodeGen/ARM/stack-size-section.ll
+++ b/llvm/test/CodeGen/ARM/stack-size-section.ll
@@ -29,4 +29,4 @@ define void @dynalloc(i32 %N) #0 {
   ret void
 }
 
-attributes #0 = { "frame-pointer"="all" }
+attributes #0 = { "frame-pointer"="none" }

--- a/llvm/test/CodeGen/ARM/swifterror.ll
+++ b/llvm/test/CodeGen/ARM/swifterror.ll
@@ -79,18 +79,17 @@ define float @caller(ptr %error_ref) {
 ;
 ; CHECK-O0-LABEL: caller:
 ; CHECK-O0:       @ %bb.0: @ %entry
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #12
+; CHECK-O0-NEXT:    push	{r7, r8, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
+; CHECK-O0-NEXT:    sub	sp, sp, #12
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
-; CHECK-O0-NEXT:    str r0, [sp] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r8, #0
-; CHECK-O0-NEXT:    bl _foo
-; CHECK-O0-NEXT:    str r8, [sp, #4] @ 4-byte Spill
-; CHECK-O0-NEXT:    movw r0, #0
-; CHECK-O0-NEXT:    cmp r8, r0
-; CHECK-O0-NEXT:    bne LBB1_2
+; CHECK-O0-NEXT:    str	r0, [sp]                        @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r8, #0
+; CHECK-O0-NEXT:    bl	_foo
+; CHECK-O0-NEXT:    str	r8, [sp, #4]                    @ 4-byte Spill
+; CHECK-O0-NEXT:    movw	r0, #0
+; CHECK-O0-NEXT:    cmp	r8, r0
+; CHECK-O0-NEXT:    bne	LBB1_2
 ; CHECK-O0-NEXT:  @ %bb.1: @ %cont
 ; CHECK-O0-NEXT:    ldr r1, [sp] @ 4-byte Reload
 ; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
@@ -101,8 +100,7 @@ define float @caller(ptr %error_ref) {
 ; CHECK-O0-NEXT:    bl _free
 ; CHECK-O0-NEXT:    mov r0, #1065353216
 ; CHECK-O0-NEXT:    sub sp, r7, #4
-; CHECK-O0-NEXT:    pop {r8}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    pop	{r7, r8, pc}
 ;
 ; CHECK-ANDROID-LABEL: caller:
 ; CHECK-ANDROID:       @ %bb.0: @ %entry
@@ -176,12 +174,11 @@ define float @caller2(ptr %error_ref) {
 ;
 ; CHECK-O0-LABEL: caller2:
 ; CHECK-O0:       @ %bb.0: @ %entry
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #16
+; CHECK-O0-NEXT:    push	{r7, r8, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
+; CHECK-O0-NEXT:    sub	sp, sp, #16
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
-; CHECK-O0-NEXT:    str r0, [sp, #8] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r0, [sp, #8] @ 4-byte Spill
 ; CHECK-O0-NEXT:  LBB2_1: @ %bb_loop
 ; CHECK-O0-NEXT:    @ =>This Inner Loop Header: Depth=1
 ; CHECK-O0-NEXT:    mov r8, #0
@@ -209,8 +206,7 @@ define float @caller2(ptr %error_ref) {
 ; CHECK-O0-NEXT:    bl _free
 ; CHECK-O0-NEXT:    mov r0, #1065353216
 ; CHECK-O0-NEXT:    sub sp, r7, #4
-; CHECK-O0-NEXT:    pop {r8}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    pop	{r7, r8, pc}
 ;
 ; CHECK-ANDROID-LABEL: caller2:
 ; CHECK-ANDROID:       @ %bb.0: @ %entry
@@ -585,21 +581,20 @@ define float @caller3(ptr %error_ref) {
 ;
 ; CHECK-O0-LABEL: caller3:
 ; CHECK-O0:       @ %bb.0: @ %entry
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #44
-; CHECK-O0-NEXT:    bfc sp, #0, #3
+; CHECK-O0-NEXT:    push	{r7, r8, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
+; CHECK-O0-NEXT:    sub	sp, sp, #44
+; CHECK-O0-NEXT:    bfc	sp, #0, #3
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
-; CHECK-O0-NEXT:    str r0, [sp, #4] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r8, #0
-; CHECK-O0-NEXT:    add r0, sp, #16
-; CHECK-O0-NEXT:    mov r1, #1
-; CHECK-O0-NEXT:    bl _foo_sret
-; CHECK-O0-NEXT:    str r8, [sp, #8] @ 4-byte Spill
-; CHECK-O0-NEXT:    movw r0, #0
-; CHECK-O0-NEXT:    cmp r8, r0
-; CHECK-O0-NEXT:    bne LBB6_2
+; CHECK-O0-NEXT:    str	r0, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r8, #0
+; CHECK-O0-NEXT:    add	r0, sp, #16
+; CHECK-O0-NEXT:    mov	r1, #1
+; CHECK-O0-NEXT:    bl	_foo_sret
+; CHECK-O0-NEXT:    str	r8, [sp, #8] @ 4-byte Spill
+; CHECK-O0-NEXT:    movw	r0, #0
+; CHECK-O0-NEXT:    cmp	r8, r0
+; CHECK-O0-NEXT:    bne	LBB6_2
 ; CHECK-O0-NEXT:  @ %bb.1: @ %cont
 ; CHECK-O0-NEXT:    ldr r1, [sp, #4] @ 4-byte Reload
 ; CHECK-O0-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
@@ -610,8 +605,7 @@ define float @caller3(ptr %error_ref) {
 ; CHECK-O0-NEXT:    bl _free
 ; CHECK-O0-NEXT:    mov r0, #1065353216
 ; CHECK-O0-NEXT:    sub sp, r7, #4
-; CHECK-O0-NEXT:    pop {r8}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    pop	{r7, r8, pc}
 ;
 ; CHECK-ANDROID-LABEL: caller3:
 ; CHECK-ANDROID:       @ %bb.0: @ %entry
@@ -809,27 +803,26 @@ define float @caller4(ptr %error_ref) {
 ;
 ; CHECK-O0-LABEL: caller4:
 ; CHECK-O0:       @ %bb.0: @ %entry
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #24
+; CHECK-O0-NEXT:    push	{r7, r8, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
+; CHECK-O0-NEXT:    sub	sp, sp, #24
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
-; CHECK-O0-NEXT:    str r0, [sp] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r8, #0
-; CHECK-O0-NEXT:    mov r0, #10
-; CHECK-O0-NEXT:    str r0, [r7, #-12]
-; CHECK-O0-NEXT:    mov r0, #11
-; CHECK-O0-NEXT:    str r0, [sp, #12]
-; CHECK-O0-NEXT:    mov r0, #12
-; CHECK-O0-NEXT:    str r0, [sp, #8]
-; CHECK-O0-NEXT:    ldr r0, [r7, #-12]
-; CHECK-O0-NEXT:    ldr r1, [sp, #12]
-; CHECK-O0-NEXT:    ldr r2, [sp, #8]
-; CHECK-O0-NEXT:    bl _foo_vararg
-; CHECK-O0-NEXT:    str r8, [sp, #4] @ 4-byte Spill
-; CHECK-O0-NEXT:    movw r0, #0
-; CHECK-O0-NEXT:    cmp r8, r0
-; CHECK-O0-NEXT:    bne LBB8_2
+; CHECK-O0-NEXT:    str	r0, [sp] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r8, #0
+; CHECK-O0-NEXT:    mov	r0, #10
+; CHECK-O0-NEXT:    str	r0, [r7, #-12]
+; CHECK-O0-NEXT:    mov	r0, #11
+; CHECK-O0-NEXT:    str	r0, [sp, #12]
+; CHECK-O0-NEXT:    mov	r0, #12
+; CHECK-O0-NEXT:    str	r0, [sp, #8]
+; CHECK-O0-NEXT:    ldr	r0, [r7, #-12]
+; CHECK-O0-NEXT:    ldr	r1, [sp, #12]
+; CHECK-O0-NEXT:    ldr	r2, [sp, #8]
+; CHECK-O0-NEXT:    bl	_foo_vararg
+; CHECK-O0-NEXT:    str	r8, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    movw	r0, #0
+; CHECK-O0-NEXT:    cmp	r8, r0
+; CHECK-O0-NEXT:    bne	LBB8_2
 ; CHECK-O0-NEXT:  @ %bb.1: @ %cont
 ; CHECK-O0-NEXT:    ldr r1, [sp] @ 4-byte Reload
 ; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
@@ -840,8 +833,7 @@ define float @caller4(ptr %error_ref) {
 ; CHECK-O0-NEXT:    bl _free
 ; CHECK-O0-NEXT:    mov r0, #1065353216
 ; CHECK-O0-NEXT:    sub sp, r7, #4
-; CHECK-O0-NEXT:    pop {r8}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    pop	{r7, r8, pc}
 ;
 ; CHECK-ANDROID-LABEL: caller4:
 ; CHECK-ANDROID:       @ %bb.0: @ %entry
@@ -995,14 +987,12 @@ define swiftcc void @swifterror_reg_clobber(ptr nocapture %err) {
 ;
 ; CHECK-O0-LABEL: swifterror_reg_clobber:
 ; CHECK-O0:       @ %bb.0:
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r8}
+; CHECK-O0-NEXT:    push	{r7, r8, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
 ; CHECK-O0-NEXT:    @ InlineAsm Start
 ; CHECK-O0-NEXT:    nop
 ; CHECK-O0-NEXT:    @ InlineAsm End
-; CHECK-O0-NEXT:    pop {r8}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    pop	{r7, r8, pc}
 ;
 ; CHECK-ANDROID-LABEL: swifterror_reg_clobber:
 ; CHECK-ANDROID:       @ %bb.0:
@@ -1048,36 +1038,34 @@ define swiftcc void @params_in_reg(i32, i32, i32, i32, ptr swiftself, ptr nocapt
 ;
 ; CHECK-O0-LABEL: params_in_reg:
 ; CHECK-O0:       @ %bb.0:
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r10}
-; CHECK-O0-NEXT:    sub sp, sp, #28
-; CHECK-O0-NEXT:    bfc sp, #0, #3
-; CHECK-O0-NEXT:    str r8, [sp, #20] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r10, [sp] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r3, [sp, #16] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r2, [sp, #12] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r1, [sp, #8] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r0, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    push	{r7, r10, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
+; CHECK-O0-NEXT:    sub	sp, sp, #28
+; CHECK-O0-NEXT:    bfc	sp, #0, #3
+; CHECK-O0-NEXT:    str	r8, [sp, #20] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r10, [sp] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r3, [sp, #16] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r2, [sp, #12] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r1, [sp, #8] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r0, [sp, #4] @ 4-byte Spill
 ; CHECK-O0-NEXT:    @ implicit-def: $r0
-; CHECK-O0-NEXT:    mov r8, #0
-; CHECK-O0-NEXT:    mov r0, #1
-; CHECK-O0-NEXT:    mov r1, #2
-; CHECK-O0-NEXT:    mov r2, #3
-; CHECK-O0-NEXT:    mov r3, #4
-; CHECK-O0-NEXT:    mov r10, r8
-; CHECK-O0-NEXT:    bl _params_in_reg2
-; CHECK-O0-NEXT:    ldr r10, [sp] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r1, [sp, #8] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r2, [sp, #12] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r3, [sp, #16] @ 4-byte Reload
-; CHECK-O0-NEXT:    mov r9, r8
-; CHECK-O0-NEXT:    ldr r8, [sp, #20] @ 4-byte Reload
-; CHECK-O0-NEXT:    bl _params_in_reg2
-; CHECK-O0-NEXT:    sub sp, r7, #4
-; CHECK-O0-NEXT:    pop {r10}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    mov	r8, #0
+; CHECK-O0-NEXT:    mov	r0, #1
+; CHECK-O0-NEXT:    mov	r1, #2
+; CHECK-O0-NEXT:    mov	r2, #3
+; CHECK-O0-NEXT:    mov	r3, #4
+; CHECK-O0-NEXT:    mov	r10, r8
+; CHECK-O0-NEXT:    bl	_params_in_reg2
+; CHECK-O0-NEXT:    ldr	r10, [sp] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r0, [sp, #4] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r1, [sp, #8] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r2, [sp, #12] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r3, [sp, #16] @ 4-byte Reload
+; CHECK-O0-NEXT:    mov	r9, r8
+; CHECK-O0-NEXT:    ldr	r8, [sp, #20] @ 4-byte Reload
+; CHECK-O0-NEXT:    bl	_params_in_reg2
+; CHECK-O0-NEXT:    sub	sp, r7, #4
+; CHECK-O0-NEXT:    pop	{r7, r10, pc}
 ;
 ; CHECK-ANDROID-LABEL: params_in_reg:
 ; CHECK-ANDROID:       @ %bb.0:
@@ -1165,65 +1153,63 @@ define swiftcc { i32, i32, i32, i32} @params_and_return_in_reg(i32, i32, i32, i3
 ;
 ; CHECK-O0-LABEL: params_and_return_in_reg:
 ; CHECK-O0:       @ %bb.0:
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r10}
-; CHECK-O0-NEXT:    sub sp, sp, #76
-; CHECK-O0-NEXT:    bfc sp, #0, #3
-; CHECK-O0-NEXT:    str r8, [sp, #24] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r10, [sp, #4] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r3, [sp, #20] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r2, [sp, #16] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r1, [sp, #12] @ 4-byte Spill
-; CHECK-O0-NEXT:    str r0, [sp, #8] @ 4-byte Spill
+; CHECK-O0-NEXT:    push	{r7, r10, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
+; CHECK-O0-NEXT:    sub	sp, sp, #76
+; CHECK-O0-NEXT:    bfc	sp, #0, #3
+; CHECK-O0-NEXT:    str	r8, [sp, #24] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r10, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r3, [sp, #20] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r2, [sp, #16] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r1, [sp, #12] @ 4-byte Spill
+; CHECK-O0-NEXT:    str	r0, [sp, #8] @ 4-byte Spill
 ; CHECK-O0-NEXT:    @ implicit-def: $r0
-; CHECK-O0-NEXT:    mov r8, #0
-; CHECK-O0-NEXT:    str r8, [sp, #28] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r0, #1
-; CHECK-O0-NEXT:    str r0, [sp, #32] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r1, #2
-; CHECK-O0-NEXT:    str r1, [sp, #36] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r2, #3
-; CHECK-O0-NEXT:    str r2, [sp, #40] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r3, #4
-; CHECK-O0-NEXT:    str r3, [sp, #44] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r10, r8
-; CHECK-O0-NEXT:    bl _params_in_reg2
-; CHECK-O0-NEXT:    ldr r10, [sp, #4] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r2, [sp, #16] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r3, [sp, #20] @ 4-byte Reload
-; CHECK-O0-NEXT:    mov r9, r8
-; CHECK-O0-NEXT:    ldr r8, [sp, #24] @ 4-byte Reload
-; CHECK-O0-NEXT:    str r9, [sp, #48] @ 4-byte Spill
-; CHECK-O0-NEXT:    bl _params_and_return_in_reg2
-; CHECK-O0-NEXT:    ldr r10, [sp, #28] @ 4-byte Reload
-; CHECK-O0-NEXT:    mov r9, r0
-; CHECK-O0-NEXT:    ldr r0, [sp, #32] @ 4-byte Reload
-; CHECK-O0-NEXT:    str r9, [sp, #52] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r9, r1
-; CHECK-O0-NEXT:    ldr r1, [sp, #36] @ 4-byte Reload
-; CHECK-O0-NEXT:    str r9, [sp, #56] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r9, r2
-; CHECK-O0-NEXT:    ldr r2, [sp, #40] @ 4-byte Reload
-; CHECK-O0-NEXT:    str r9, [sp, #60] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r9, r3
-; CHECK-O0-NEXT:    ldr r3, [sp, #44] @ 4-byte Reload
-; CHECK-O0-NEXT:    str r9, [sp, #64] @ 4-byte Spill
-; CHECK-O0-NEXT:    mov r9, r8
-; CHECK-O0-NEXT:    ldr r8, [sp, #48] @ 4-byte Reload
-; CHECK-O0-NEXT:    str r9, [sp, #68] @ 4-byte Spill
-; CHECK-O0-NEXT:    bl _params_in_reg2
-; CHECK-O0-NEXT:    ldr r0, [sp, #52] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r1, [sp, #56] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r2, [sp, #60] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r3, [sp, #64] @ 4-byte Reload
-; CHECK-O0-NEXT:    mov r9, r8
-; CHECK-O0-NEXT:    ldr r8, [sp, #68] @ 4-byte Reload
-; CHECK-O0-NEXT:    sub sp, r7, #4
-; CHECK-O0-NEXT:    pop {r10}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    mov	r8, #0
+; CHECK-O0-NEXT:    str	r8, [sp, #28] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r0, #1
+; CHECK-O0-NEXT:    str	r0, [sp, #32] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r1, #2
+; CHECK-O0-NEXT:    str	r1, [sp, #36] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r2, #3
+; CHECK-O0-NEXT:    str	r2, [sp, #40] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r3, #4
+; CHECK-O0-NEXT:    str	r3, [sp, #44] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r10, r8
+; CHECK-O0-NEXT:    bl	_params_in_reg2
+; CHECK-O0-NEXT:    ldr	r10, [sp, #4] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r0, [sp, #8] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r1, [sp, #12] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r2, [sp, #16] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r3, [sp, #20] @ 4-byte Reload
+; CHECK-O0-NEXT:    mov	r9, r8
+; CHECK-O0-NEXT:    ldr	r8, [sp, #24] @ 4-byte Reload
+; CHECK-O0-NEXT:    str	r9, [sp, #48] @ 4-byte Spill
+; CHECK-O0-NEXT:    bl	_params_and_return_in_reg2
+; CHECK-O0-NEXT:    ldr	r10, [sp, #28] @ 4-byte Reload
+; CHECK-O0-NEXT:    mov	r9, r0
+; CHECK-O0-NEXT:    ldr	r0, [sp, #32] @ 4-byte Reload
+; CHECK-O0-NEXT:    str	r9, [sp, #52] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r9, r1
+; CHECK-O0-NEXT:    ldr	r1, [sp, #36] @ 4-byte Reload
+; CHECK-O0-NEXT:    str	r9, [sp, #56] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r9, r2
+; CHECK-O0-NEXT:    ldr	r2, [sp, #40] @ 4-byte Reload
+; CHECK-O0-NEXT:    str	r9, [sp, #60] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r9, r3
+; CHECK-O0-NEXT:    ldr	r3, [sp, #44] @ 4-byte Reload
+; CHECK-O0-NEXT:    str	r9, [sp, #64] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r9, r8
+; CHECK-O0-NEXT:    ldr	r8, [sp, #48] @ 4-byte Reload
+; CHECK-O0-NEXT:    str	r9, [sp, #68] @ 4-byte Spill
+; CHECK-O0-NEXT:    bl	_params_in_reg2
+; CHECK-O0-NEXT:    ldr	r0, [sp, #52] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r1, [sp, #56] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r2, [sp, #60] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr	r3, [sp, #64] @ 4-byte Reload
+; CHECK-O0-NEXT:    mov	r9, r8
+; CHECK-O0-NEXT:    ldr	r8, [sp, #68] @ 4-byte Reload
+; CHECK-O0-NEXT:    sub	sp, r7, #4
+; CHECK-O0-NEXT:    pop	{r7, r10, pc}
 ;
 ; CHECK-ANDROID-LABEL: params_and_return_in_reg:
 ; CHECK-ANDROID:       @ %bb.0:
@@ -1339,19 +1325,17 @@ define swiftcc ptr @testAssign(ptr %error_ref) {
 ;
 ; CHECK-O0-LABEL: testAssign:
 ; CHECK-O0:       @ %bb.0: @ %entry
-; CHECK-O0-NEXT:    push {r7, lr}
-; CHECK-O0-NEXT:    mov r7, sp
-; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #8
+; CHECK-O0-NEXT:    push	{r7, r8, lr}
+; CHECK-O0-NEXT:    add	r7, sp, #4
+; CHECK-O0-NEXT:    sub	sp, sp, #8
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
-; CHECK-O0-NEXT:    mov r8, #0
-; CHECK-O0-NEXT:    bl _foo2
-; CHECK-O0-NEXT:    str r8, [sp] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov	r8, #0
+; CHECK-O0-NEXT:    bl	_foo2
+; CHECK-O0-NEXT:    str	r8, [sp] @ 4-byte Spill
 ; CHECK-O0-NEXT:  @ %bb.1: @ %a
 ; CHECK-O0-NEXT:    ldr r0, [sp] @ 4-byte Reload
 ; CHECK-O0-NEXT:    sub sp, r7, #4
-; CHECK-O0-NEXT:    pop {r8}
-; CHECK-O0-NEXT:    pop {r7, pc}
+; CHECK-O0-NEXT:    pop	{r7, r8, pc}
 ;
 ; CHECK-ANDROID-LABEL: testAssign:
 ; CHECK-ANDROID:       @ %bb.0: @ %entry

--- a/llvm/test/CodeGen/ARM/v7k-abi-align.ll
+++ b/llvm/test/CodeGen/ARM/v7k-abi-align.ll
@@ -117,7 +117,7 @@ define void @test_dpr_unwind_align_no_dprs() "frame-pointer"="all" {
 
 ; 128-bit vectors should use 128-bit (i.e. correctly aligned) slots on
 ; the stack.
-define <4 x float> @test_v128_stack_pass([8 x double], float, <4 x float> %in) "frame-pointer"="all" {
+define <4 x float> @test_v128_stack_pass([8 x double], float, <4 x float> %in) "frame-pointer"="none" {
 ; CHECK-LABEL: test_v128_stack_pass:
 ; CHECK: add r[[ADDR:[0-9]+]], sp, #16
 ; CHECK: vld1.64 {d0, d1}, [r[[ADDR]]:128]
@@ -140,7 +140,7 @@ define void @test_v128_stack_pass_varargs(<4 x float> %in) "frame-pointer"="all"
 
 ; To be compatible with AAPCS's va_start model (store r0-r3 at incoming SP, give
 ; a single pointer), 64-bit quantities must be pass
-define i64 @test_64bit_gpr_align(i32, i64 %r2_r3, i32 %sp) "frame-pointer"="all" {
+define i64 @test_64bit_gpr_align(i32, i64 %r2_r3, i32 %sp) "frame-pointer"="none" {
 ; CHECK-LABEL: test_64bit_gpr_align:
 ; CHECK: ldr [[RHS:r[0-9]+]], [sp]
 ; CHECK: adds r0, [[RHS]], r2

--- a/llvm/test/CodeGen/Thumb/frame-chain.ll
+++ b/llvm/test/CodeGen/Thumb/frame-chain.ll
@@ -8,12 +8,16 @@
 define dso_local noundef i32 @leaf(i32 noundef %0) {
 ; LEAF-FP-LABEL: leaf:
 ; LEAF-FP:       @ %bb.0:
-; LEAF-FP-NEXT:    .pad #4
-; LEAF-FP-NEXT:    sub sp, #4
-; LEAF-FP-NEXT:    str r0, [sp]
-; LEAF-FP-NEXT:    adds r0, r0, #4
-; LEAF-FP-NEXT:    add sp, #4
-; LEAF-FP-NEXT:    bx lr
+; LEAF-FP-NEXT:    .save	{r7, lr}
+; LEAF-FP-NEXT:    push	{r7, lr}
+; LEAF-FP-NEXT:	   .setfp	r7, sp
+; LEAF-FP-NEXT:	   add	r7, sp, #0
+; LEAF-FP-NEXT:	   .pad	#4
+; LEAF-FP-NEXT:	   sub	sp, #4
+; LEAF-FP-NEXT:	   str	r0, [sp]
+; LEAF-FP-NEXT:	   adds	r0, r0, #4
+; LEAF-FP-NEXT:	   add	sp, #4
+; LEAF-FP-NEXT:	   pop	{r7, pc}
 ;
 ; LEAF-FP-AAPCS-LABEL: leaf:
 ; LEAF-FP-AAPCS:       @ %bb.0:

--- a/llvm/test/CodeGen/Thumb2/frame-pointer.ll
+++ b/llvm/test/CodeGen/Thumb2/frame-pointer.ll
@@ -14,7 +14,7 @@ define void @leaf() {
 
 ; Leaf function, frame pointer is requested but we don't need any stack frame,
 ; so don't create a frame pointer.
-define void @leaf_nofpelim() "frame-pointer"="all" {
+define void @leaf_nofpelim() "frame-pointer"="none" {
 ; CHECK-LABEL: leaf_nofpelim:
 ; CHECK-NOT: push
 ; CHECK-NOT: sp

--- a/llvm/test/CodeGen/Thumb2/frameless.ll
+++ b/llvm/test/CodeGen/Thumb2/frameless.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mtriple=thumbv7-apple-darwin -frame-pointer=all | not grep mov
-; RUN: llc < %s -mtriple=thumbv7-linux -frame-pointer=all | not grep mov
+; RUN: llc < %s -mtriple=thumbv7-apple-darwin -frame-pointer=none | not grep mov
+; RUN: llc < %s -mtriple=thumbv7-linux -frame-pointer=none | not grep mov
 
 define void @t() nounwind readnone {
   ret void

--- a/llvm/test/CodeGen/Thumb2/frameless2.ll
+++ b/llvm/test/CodeGen/Thumb2/frameless2.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s -mtriple=thumbv7-apple-darwin -frame-pointer=all | not grep r7
+; RUN: llc < %s -mtriple=thumbv7-apple-darwin -frame-pointer=none | not grep r7
 
 %struct.noise3 = type { [3 x [17 x i32]] }
 %struct.noiseguard = type { i32, i32, i32 }

--- a/llvm/test/CodeGen/Thumb2/machine-licm.ll
+++ b/llvm/test/CodeGen/Thumb2/machine-licm.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mtriple=thumbv7-apple-darwin -mcpu=cortex-a8 -relocation-model=dynamic-no-pic -frame-pointer=all | FileCheck %s
-; RUN: llc < %s -mtriple=thumbv7-apple-darwin -mcpu=cortex-a8 -relocation-model=pic -frame-pointer=all | FileCheck %s --check-prefix=PIC
+; RUN: llc < %s -mtriple=thumbv7-apple-darwin -mcpu=cortex-a8 -relocation-model=dynamic-no-pic -frame-pointer=none | FileCheck %s
+; RUN: llc < %s -mtriple=thumbv7-apple-darwin -mcpu=cortex-a8 -relocation-model=pic -frame-pointer=none | FileCheck %s --check-prefix=PIC
 ; rdar://7353541
 ; rdar://7354376
 

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll
@@ -60,4 +60,4 @@ define dso_local i32 @main() #0 {
   ret i32 0
 }
 
-attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
+attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="none" }

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.generated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.generated.expected
@@ -61,7 +61,7 @@ define dso_local i32 @main() #0 {
   ret i32 0
 }
 
-attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
+attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="none" }
 ; CHECK-LABEL: check_boundaries:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #20

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.nogenerated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.nogenerated.expected
@@ -121,4 +121,4 @@ define dso_local i32 @main() #0 {
   ret i32 0
 }
 
-attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
+attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="none" }


### PR DESCRIPTION
The -mno-omit-leaf-frame-pointer flag works on 32-bit ARM architectures and addresses the bug reported in #108019