### PR TITLE
[JITLink] Add support for R_X86_64_PC16 relocation type.

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELF_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_x86_64.cpp
@@ -156,6 +156,9 @@ private:
     case ELF::R_X86_64_PC8:
       Kind = x86_64::Delta8;
       break;
+    case ELF::R_X86_64_PC16:
+      Kind = x86_64::Delta16;
+      break;
     case ELF::R_X86_64_PC32:
     case ELF::R_X86_64_GOTPC32:
       Kind = x86_64::Delta32;

--- a/llvm/lib/ExecutionEngine/JITLink/x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/x86_64.cpp
@@ -34,6 +34,8 @@ const char *getEdgeKindName(Edge::Kind K) {
     return "Delta64";
   case Delta32:
     return "Delta32";
+  case Delta16:
+    return "Delta16";
   case Delta8:
     return "Delta8";
   case NegDelta64:

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_PC.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_PC.s
@@ -2,7 +2,7 @@
 # RUN:     -filetype=obj -o %t.o %s
 # RUN: llvm-jitlink -noexec %t.o
 #
-# Check R_X86_64_PC8 handling.
+# Check R_X86_64_PC* handling.
 
 	.text
 	.globl	main
@@ -14,3 +14,6 @@ main:
 
 	.rodata
 	.byte	main-. # Generate R_X86_64_PC8 relocation.
+	.short	main-. # Generate R_X86_64_PC16 relocation.
+	.long	main-. # Generate R_X86_64_PC32 relocation.
+	.quad	main-. # Generate R_X86_64_PC64 relocation.


### PR DESCRIPTION
This patch adds support for R_X86_64_PC16 relocation type and x86_64::Delta16 edge kind. This patch also adds missing test cases for R_X86_64_PC32, R_X86_64_PC64 relocation types.