### PR TITLE
[clang] Apply the [[gsl::Owner]] or [[gsl::Pointer]] attributes to the STL template specialization declarations.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -273,6 +273,9 @@ Attribute Changes in Clang
   not change the behaviour of the compiler, as this was true for previous
   versions.
 
+- Fix a bug where clang doesn't automatically apply the ``[[gsl::Owner]]`` or
+  ``[[gsl::Pointer]]`` to STL explicit template specialization decls. (#GH109442)
+
 Improvements to Clang's diagnostics
 -----------------------------------
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -8631,6 +8631,7 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     return SkipBody->Previous;
 
   Specialization->setInvalidDecl(Invalid);
+  inferGslOwnerPointerAttribute(Specialization);
   return Specialization;
 }
 

--- a/clang/test/SemaCXX/attr-gsl-owner-pointer-std.cpp
+++ b/clang/test/SemaCXX/attr-gsl-owner-pointer-std.cpp
@@ -27,6 +27,11 @@ public:
 static_assert(sizeof(vector<int>), "");           // Force instantiation.
 static_assert(sizeof(vector<int>::iterator), ""); // Force instantiation.
 
+template <>
+class vector<bool> {};
+// CHECK: ClassTemplateSpecializationDecl {{.*}} vector
+// CHECK: OwnerAttr {{.*}}
+
 // If std::container::iterator is a using declaration, attributes are inferred
 // for the underlying class.
 template <typename T>
@@ -173,6 +178,18 @@ class reference_wrapper;
 class some_unknown_type;
 // CHECK: CXXRecordDecl {{.*}} some_unknown_type
 
+using size_t = unsigned;
+inline constexpr size_t dynamic_extent = -1;
+template <typename _Tp, size_t _Extent = dynamic_extent>
+class span;
+// CHECK: CXXRecordDecl {{.*}} span
+// CHECK: PointerAttr {{.*}}
+
+
+template <typename _Tp>
+struct span<_Tp, dynamic_extent> {};
+// CHECK: ClassTemplatePartialSpecializationDecl {{.*}} span
+// CHECK: PointerAttr {{.*}}
 } // namespace std
 
 namespace user {


### PR DESCRIPTION
Fixes #109442