### PR TITLE
[libc] Add 'strings.h' header on the GPU

### DIFF
--- a/libc/config/gpu/headers.txt
+++ b/libc/config/gpu/headers.txt
@@ -2,6 +2,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.assert
     libc.include.ctype
     libc.include.string
+    libc.include.strings
     libc.include.signal
     libc.include.float
     libc.include.stdint

--- a/libc/docs/gpu/support.rst
+++ b/libc/docs/gpu/support.rst
@@ -47,7 +47,6 @@ Function Name  Available  RPC Required
 bcmp           |check|
 bcopy          |check|
 bzero          |check|
-index          |check|
 memccpy        |check|
 memchr         |check|
 memcmp         |check|
@@ -57,11 +56,8 @@ memmove        |check|
 mempcpy        |check|
 memrchr        |check|
 memset         |check|
-rindex         |check|
 stpcpy         |check|
 stpncpy        |check|
-strcasecmp     |check|
-strcasestr     |check|
 strcat         |check|
 strchr         |check|
 strchrnul      |check|
@@ -74,7 +70,6 @@ strerror       |check|
 strlcat        |check|
 strlcpy        |check|
 strlen         |check|
-strncasecmp    |check|
 strncat        |check|
 strncmp        |check|
 strncpy        |check|
@@ -88,6 +83,21 @@ strstr         |check|
 strtok         |check|
 strtok_r       |check|
 strxfrm        |check|
+=============  =========  ============
+
+strings.h
+---------
+
+=============  =========  ============
+Function Name  Available  RPC Required
+=============  =========  ============
+bcmp           |check|
+bcopy          |check|
+bzero          |check|
+strcasecmp     |check|
+strcasestr     |check|
+index          |check|
+rindex         |check|
 =============  =========  ============
 
 stdbit.h
@@ -239,8 +249,8 @@ snprintf       |check|
 vsprintf       |check|
 vsnprintf      |check|
 sscanf         |check|
-scanf          |check|
-fscanf         |check|
+scanf          |check|    |check|
+fscanf         |check|    |check|
 putchar        |check|    |check|
 fclose         |check|    |check|
 fopen          |check|    |check|


### PR DESCRIPTION
Summary:
These are GNU extensions but still show up, the entrypoints were enabled
but we weren't emitting the header so they couldn't be used.
