### PR TITLE
[SystemZ][z/OS] Query if a file is text and set the text flag accordingly

### DIFF
--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -52,6 +52,12 @@ std::error_code restorezOSStdHandleAutoConversion(int FD);
 /// \brief Set the tag information for a file descriptor.
 std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
 
+// Get the the tag ccsid for a file name or a file descriptor.
+ErrorOr<__ccsid_t> getzOSFileTag(const char *FileName, const int FD = -1);
+
+// Query the file tag to determine if the file is a text file.
+ErrorOr<bool> iszOSTextFile(const char *Filename, const int FD = -1);
+
 } // namespace llvm
 #endif // __cplusplus
 

--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -52,11 +52,8 @@ std::error_code restorezOSStdHandleAutoConversion(int FD);
 /// \brief Set the tag information for a file descriptor.
 std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
 
-// Get the the tag ccsid for a file name or a file descriptor.
-ErrorOr<__ccsid_t> getzOSFileTag(const char *FileName, const int FD = -1);
-
 // Query the file tag to determine if the file is a text file.
-ErrorOr<bool> iszOSTextFile(const char *Filename, const int FD = -1);
+bool iszOSTextFile(const char *Filename, const int FD = -1);
 
 } // namespace llvm
 #endif // __cplusplus

--- a/llvm/lib/Support/AutoConvert.cpp
+++ b/llvm/lib/Support/AutoConvert.cpp
@@ -116,4 +116,30 @@ std::error_code llvm::setzOSFileTag(int FD, int CCSID, bool Text) {
   return std::error_code();
 }
 
+ErrorOr<__ccsid_t> llvm::getzOSFileTag(const char *FileName, const int FD) {
+  // If we have a file descriptor, use it to find out file tagging. Otherwise we
+  // need to use stat() with the file path.
+  if (FD != -1) {
+    struct f_cnvrt Query = {
+        QUERYCVT, // cvtcmd
+        0,        // pccsid
+        0,        // fccsid
+    };
+    if (fcntl(FD, F_CONTROL_CVT, &Query) == -1)
+      return std::error_code(errno, std::generic_category());
+    return Query.fccsid;
+  }
+  struct stat Attr;
+  if (stat(FileName, &Attr) == -1)
+    return std::error_code(errno, std::generic_category());
+  return Attr.st_tag.ft_ccsid;
+}
+
+ErrorOr<bool> llvm::iszOSTextFile(const char *Filename, const int FD) {
+  ErrorOr<__ccsid_t> Ccsid = getzOSFileTag(Filename, FD);
+  if (std::error_code EC = Ccsid.getError())
+    return EC;
+  return *Ccsid != FT_BINARY;
+}
+
 #endif // __MVS__

--- a/llvm/lib/Support/AutoConvert.cpp
+++ b/llvm/lib/Support/AutoConvert.cpp
@@ -116,7 +116,7 @@ std::error_code llvm::setzOSFileTag(int FD, int CCSID, bool Text) {
   return std::error_code();
 }
 
-ErrorOr<__ccsid_t> llvm::getzOSFileTag(const char *FileName, const int FD) {
+ErrorOr<__ccsid_t> getzOSFileTag(const char *FileName, const int FD) {
   // If we have a file descriptor, use it to find out file tagging. Otherwise we
   // need to use stat() with the file path.
   if (FD != -1) {
@@ -135,10 +135,10 @@ ErrorOr<__ccsid_t> llvm::getzOSFileTag(const char *FileName, const int FD) {
   return Attr.st_tag.ft_ccsid;
 }
 
-ErrorOr<bool> llvm::iszOSTextFile(const char *Filename, const int FD) {
+bool llvm::iszOSTextFile(const char *Filename, const int FD) {
   ErrorOr<__ccsid_t> Ccsid = getzOSFileTag(Filename, FD);
   if (std::error_code EC = Ccsid.getError())
-    return EC;
+    return false;
   return *Ccsid != FT_BINARY;
 }
 

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -328,8 +328,7 @@ RealFileSystem::openFileForRead(const Twine &Name) {
   auto OpenFlags = sys::fs::OF_None;
 #ifdef __MVS__
   // If the file is tagged with a text ccsid, it may require autoconversion.
-  llvm::ErrorOr<bool> IsFileText = llvm::iszOSTextFile(Name.str().c_str());
-  if (IsFileText && *IsFileText)
+  if (llvm::iszOSTextFile(Name.str().c_str()))
     OpenFlags |= sys::fs::OF_Text;
 #endif
   Expected<file_t> FDOrErr = sys::fs::openNativeFileForRead(


### PR DESCRIPTION
This patch sets the text flag correctly when opening files by querying the file tag on z/OS. For other platforms, there will be no change in behaviour.