### PR TITLE
[DWARFLinkerTypeUnit] Simplify code around try_emplace (NFC)

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerTypeUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerTypeUnit.cpp
@@ -286,21 +286,18 @@ uint32_t TypeUnit::addFileNameIntoLinetable(StringEntry *Dir,
       DirIdx++;
   }
 
-  uint32_t FileIdx = 0;
-  auto [FileEntry, Inserted] = FileNamesMap.try_emplace({FileName, DirIdx});
+  auto [FileEntry, Inserted] = FileNamesMap.try_emplace(
+      {FileName, DirIdx}, LineTable.Prologue.FileNames.size());
   if (Inserted) {
     // We currently do not support more than UINT32_MAX files.
     assert(LineTable.Prologue.FileNames.size() < UINT32_MAX);
-    FileIdx = LineTable.Prologue.FileNames.size();
-    FileEntry->second = FileIdx;
     LineTable.Prologue.FileNames.push_back(DWARFDebugLine::FileNameEntry());
     LineTable.Prologue.FileNames.back().Name = DWARFFormValue::createFromPValue(
         dwarf::DW_FORM_string, FileName->getKeyData());
     LineTable.Prologue.FileNames.back().DirIdx = DirIdx;
-  } else {
-    FileIdx = FileEntry->second;
   }
 
+  uint32_t FileIdx = FileEntry->second;
   return getVersion() < 5 ? FileIdx + 1 : FileIdx;
 }
 


### PR DESCRIPTION
Without this patch, we first default-construct a value with
try_emplace and then immediately override it with a new value.

This patch inserts the final value with try_emplace and simplies the
code around it.
