### PR TITLE
[SystemZ][z/OS] fix ppc-xmmintrin.c on z/OS

### DIFF
--- a/clang/test/CodeGen/PowerPC/ppc-xmmintrin.c
+++ b/clang/test/CodeGen/PowerPC/ppc-xmmintrin.c
@@ -23,7 +23,7 @@
 
 // RUN: %clang -S -emit-llvm -target powerpc64-ibm-aix -mcpu=pwr8 -ffreestanding -DNO_WARN_X86_INTRINSICS %s \
 // RUN:   -ffp-contract=off -fno-discard-value-names -mllvm -disable-llvm-optzns -o - | llvm-cxxfilt -n | FileCheck %s --check-prefixes=CHECK,CHECK-BE
-// RUN: %clang -x c++ -fsyntax-only -target powerpc64-ibm-aix -mcpu=pwr8 -ffreestanding -DNO_WARN_X86_INTRINSICS %s \
+// RUN: %clang -x c++ -fsyntax-only -target powerpc64-ibm-aix -mcpu=pwr8 -ffreestanding -nostdlibinc -DNO_WARN_X86_INTRINSICS %s \
 // RUN:   -fno-discard-value-names -mllvm -disable-llvm-optzns
 // RUN: %clang -S -emit-llvm -target powerpc64-ibm-aix -mcpu=pwr10 -ffreestanding -DNO_WARN_X86_INTRINSICS %s \
 // RUN:   -ffp-contract=off -fno-discard-value-names -mllvm -disable-llvm-optzns -o - | llvm-cxxfilt -n | FileCheck %s --check-prefixes=CHECK,CHECK-P10-BE


### PR DESCRIPTION
This will fix the following failure seeing on z/OS:

```
In file included from clang/test/CodeGen/PowerPC/ppc-xmmintrin.c:31:
In file included from build/lib/clang/20/include/ppc_wrappers/xmmintrin.h:44:
In file included from build/lib/clang/20/include/altivec.h:48:
In file included from build/bin/../include/c++/v1/stddef.h:27:
In file included from build/bin/../include/c++/v1/__config:14:
In file included from build/bin/../include/c++/v1/__configuration/abi.h:15:
In file included from build/bin/../include/c++/v1/__configuration/platform.h:35:
/usr/include/features.h:1:20: error: expected unqualified-id
    1 |                    ??=if                       ??/
      |                    ^
/usr/include/features.h:2140:20: error: expected unqualified-id
 2140 |                    ??=endif /* __features_h */
      |                    ^
```
Adding `-nostdlibinc` will not use standard system include path and it will prevent above errors. 