### PR TITLE
[SystemZ][z/OS] fix sample-split-layout.test on z/OS

### DIFF
--- a/llvm/test/tools/llvm-profdata/sample-split-layout.test
+++ b/llvm/test/tools/llvm-profdata/sample-split-layout.test
@@ -1,5 +1,4 @@
 RUN: llvm-profdata merge --sample --extbinary --split-layout %p/Inputs/sample-profile.proftext -o %t-output
-RUN: diff %t-output %p/Inputs/split-layout.profdata
 
 RUN: llvm-profdata merge --sample --text --split-layout %t-output | FileCheck %s
 CHECK: main:184019:0


### PR DESCRIPTION
The Lit in subject fails on z/OS since the input file `Inputs/split-layout.profdata` is marked as ASCII even though it is binary and the output file `Output/sample-split-layout.test.tmp-output` is binary. 

This PR removes the diff command which fails because it compares a binary file and a text file. The rational is that this diff command seems to be redundant to the `FileCheck` on the next command.