### PR TITLE
[DebugInfo][z/OS] XFAIL debug-ranges-duplication.ll on z/OS

### DIFF
--- a/llvm/test/DebugInfo/Generic/debug-ranges-duplication.ll
+++ b/llvm/test/DebugInfo/Generic/debug-ranges-duplication.ll
@@ -1,5 +1,5 @@
 ; AIX doesn't currently support DWARF 5 section .debug_rnglists
-; XFAIL: target={{.*}}-aix{{.*}}
+; XFAIL: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
 
 ; RUN: %llc_dwarf -O0 -filetype=obj < %s | llvm-dwarfdump -debug-info - | FileCheck %s
 ;


### PR DESCRIPTION
Same fix was provided for AIX in commit 704da919bafa5b088223f9d77424f24ae754539e.
The issue is unsupported DWARF 5 section with the following assertion:

`Assertion failed: Section && "Cannot switch to a null section!", file: llvm/lib/MC/MCStreamer.cpp, line: 1266 `