### PR TITLE
[libc++] Add `_LIBCPP_NO_CFI` to `__allocate_unique_temporary_buffer`

### DIFF
--- a/libcxx/include/__memory/unique_temporary_buffer.h
+++ b/libcxx/include/__memory/unique_temporary_buffer.h
@@ -47,7 +47,7 @@ template <class _Tp>
 using __unique_temporary_buffer = unique_ptr<_Tp, __temporary_buffer_deleter<_Tp> >;
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 __unique_temporary_buffer<_Tp>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI _LIBCPP_CONSTEXPR_SINCE_CXX23 __unique_temporary_buffer<_Tp>
 __allocate_unique_temporary_buffer(ptrdiff_t __count) {
   using __deleter_type       = __temporary_buffer_deleter<_Tp>;
   using __unique_buffer_type = __unique_temporary_buffer<_Tp>;


### PR DESCRIPTION
Follows up #100914. Addresses the issue revealed in https://github.com/llvm/llvm-project/pull/100914#discussion_r1771647801.