### PR TITLE
[;SystemZ][z/OS] Fix llvm-ctxprof to open input files in text mode

### DIFF
--- a/llvm/tools/llvm-ctxprof-util/llvm-ctxprof-util.cpp
+++ b/llvm/tools/llvm-ctxprof-util/llvm-ctxprof-util.cpp
@@ -48,7 +48,8 @@ static cl::opt<std::string> OutputFilename("output", cl::value_desc("output"),
 
 // Save the bitstream profile from the JSON representation.
 Error convertFromJSON() {
-  auto BufOrError = MemoryBuffer::getFileOrSTDIN(InputFilename);
+  auto BufOrError =
+      MemoryBuffer::getFileOrSTDIN(InputFilename, /*IsText=*/true);
   if (!BufOrError)
     return createFileError(InputFilename, BufOrError.getError());
 


### PR DESCRIPTION
Reading text files on z/OS relies on auto conversion to handle ASCII/EBCDIC correctly. For this to work files need to be opened in text mode is that is the type of the file. This PR fixes `llvm-ctxprof` utility in this regards which in turn fixes the following LIT failure on z/OS:

`FAIL: LLVM :: Analysis/CtxProfAnalysis/flatten-zero-path.ll` 