### PR TITLE
[SystemZ][z/OS] fix libcxx lit when aligned allocation/de. functions are not available

### DIFF
--- a/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp
+++ b/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp
@@ -195,10 +195,12 @@ int main(int, char**) {
   test<TrivialEmptyType, FinalEmptyAlloc>();
   test<TrivialEmptyType, NonTrivialAlloc>();
 
+#if !defined(_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION)
   test<OveralignedEmptyType, TrivialEmptyAlloc>();
   test<OveralignedEmptyType, TrivialNonEmptyAlloc>();
   test<OveralignedEmptyType, FinalEmptyAlloc>();
   test<OveralignedEmptyType, NonTrivialAlloc>();
+#endif
 
   test<TrivialNonEmptyType, TrivialEmptyAlloc>();
   test<TrivialNonEmptyType, TrivialNonEmptyAlloc>();

--- a/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp
+++ b/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp
@@ -195,7 +195,7 @@ int main(int, char**) {
   test<TrivialEmptyType, FinalEmptyAlloc>();
   test<TrivialEmptyType, NonTrivialAlloc>();
 
-#if !defined(_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION)
+#if !defined(TEST_HAS_NO_ALIGNED_ALLOCATION)
   test<OveralignedEmptyType, TrivialEmptyAlloc>();
   test<OveralignedEmptyType, TrivialNonEmptyAlloc>();
   test<OveralignedEmptyType, FinalEmptyAlloc>();


### PR DESCRIPTION
This PR fixes the following lit which was recently updated in [PR 76756](https://github.com/llvm/llvm-project/pull/76756):

`FAIL: ibm-zos-libc++-shared.cfg.in :: libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp
`
Here are some compilation errors

```
# | llvm-project/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp:76:8: error: aligned deallocation function of type 'void (void *, enum std::align_val_t) noexcept' is not available on z/OS
# |    76 | struct OldEmplaceControlBlock : std::__shared_weak_count {
# |       |        ^
# | llvm-project/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp:103:7: note: in implicit destructor for 'OldEmplaceControlBlock<OveralignedEmptyType, TrivialEmptyAlloc<OveralignedEmptyType>>' first required here
# |   103 |   Old old(a);
# |       |       ^
# | llvm-project/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp:200:3: note: in instantiation of function template specialization 'test<OveralignedEmptyType, TrivialEmptyAlloc>' requested here
# |   198 |   test<OveralignedEmptyType, TrivialEmptyAlloc>();
# |       |   ^
# |llvm-project/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_layout.pass.cpp:76:8: note: if you supply your own aligned allocation functions, use -faligned-allocation to silence this diagnostic
# |    76 | struct OldEmplaceControlBlock : std::__shared_weak_count {
# |       |        ^
```