### PR TITLE
[asan][windows][tests] support MSVC compiler-id in asan tests

### DIFF
--- a/compiler-rt/test/asan/lit.cfg.py
+++ b/compiler-rt/test/asan/lit.cfg.py
@@ -154,11 +154,11 @@ if platform.system() == "Windows":
     # MSVC-specific tests might also use the clang-cl.exe driver.
     if target_is_msvc:
         clang_cl_cxxflags = [
-            "-Wno-deprecated-declarations",
             "-WX",
             "-D_HAS_EXCEPTIONS=0",
-            "-Zi",
-        ] + target_cflags
+        ] + config.debug_info_flags + target_cflags
+        if config.compiler_id != "MSVC":
+            clang_cl_cxxflags = ["-Wno-deprecated-declarations"] + clang_cl_cxxflags
         clang_cl_asan_cxxflags = ["-fsanitize=address"] + clang_cl_cxxflags
         if config.asan_dynamic:
             clang_cl_asan_cxxflags.append("-MD")
@@ -284,6 +284,12 @@ if (
 if config.host_os == "Windows":
     os.environ["PATH"] = os.path.pathsep.join(
         [config.compiler_rt_libdir, os.environ.get("PATH", "")]
+    )
+
+# msvc needs to be instructed where the compiler-rt libraries are
+if config.compiler_id == "MSVC":
+    config.environment["LIB"] = os.path.pathsep.join(
+        [config.compiler_rt_libdir, config.environment.get("LIB", "")]
     )
 
 # Default test suffixes.

--- a/compiler-rt/test/asan/lit.cfg.py
+++ b/compiler-rt/test/asan/lit.cfg.py
@@ -153,10 +153,14 @@ if config.asan_dynamic:
 if platform.system() == "Windows":
     # MSVC-specific tests might also use the clang-cl.exe driver.
     if target_is_msvc:
-        clang_cl_cxxflags = [
-            "-WX",
-            "-D_HAS_EXCEPTIONS=0",
-        ] + config.debug_info_flags + target_cflags
+        clang_cl_cxxflags = (
+            [
+                "-WX",
+                "-D_HAS_EXCEPTIONS=0",
+            ]
+            + config.debug_info_flags
+            + target_cflags
+        )
         if config.compiler_id != "MSVC":
             clang_cl_cxxflags = ["-Wno-deprecated-declarations"] + clang_cl_cxxflags
         clang_cl_asan_cxxflags = ["-fsanitize=address"] + clang_cl_cxxflags


### PR DESCRIPTION
This follows up on https://github.com/llvm/llvm-project/pull/108255 to allow actually running the test suite with MSVC. Note, however, that MSVC can't yet build compiler-rt, most tests don't yet pass with msvc, and building and testing with different compilers is ill-supported. Follow ups will fix the first two issues, the third is future work.

Note that `/Zi` is removed from the clang-cl command line, but lit as a whole adds `-gcodeview`, so there should still be debug info.