### PR TITLE
[CodeLayout] Size-aware machine block placement

### DIFF
--- a/llvm/test/CodeGen/X86/code_placement_ext_tsp_size.ll
+++ b/llvm/test/CodeGen/X86/code_placement_ext_tsp_size.ll
@@ -1,0 +1,131 @@
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=true  < %s | FileCheck %s
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=false < %s | FileCheck %s -check-prefix=CHECK2
+
+define void @func1() minsize {
+;
+; +-----+
+; | b0  | -+
+; +-----+  |
+;   |      |
+;   | 10   |
+;   v      |
+; +-----+  |
+; | b1  |  | 10000
+; +-----+  |
+;   |      |
+;   | 10   |
+;   v      |
+; +-----+  |
+; | b2  | <+
+; +-----+
+;
+; CHECK-LABEL: func1:
+; CHECK: %b0
+; CHECK: %b1
+; CHECK: %b2
+;
+; CHECK2-LABEL: func1:
+; CHECK2: %b0
+; CHECK2: %b2
+; CHECK2: %b1
+
+b0:
+  %call = call zeroext i1 @a()
+  br i1 %call, label %b1, label %b2, !prof !1
+
+b1:
+  call void @d()
+  call void @d()
+  call void @d()
+  br label %b2
+
+b2:
+  call void @e()
+  ret void
+}
+
+define void @func_loop() minsize !prof !9 {
+; Test that the algorithm can rotate loops in the presence of profile data.
+;
+;                  +--------+
+;                  | entry  |
+;                  +--------+
+;                    |
+;                    | 1
+;                    v
+; +--------+  16   +--------+
+; | if.then| <---- | header | <+
+; +--------+       +--------+  |
+;   |                |         |
+;   |                | 160     |
+;   |                v         |
+;   |              +--------+  |
+;   |              | if.else|  | 175
+;   |              +--------+  |
+;   |                |         |
+;   |                | 160     |
+;   |                v         |
+;   |        16    +--------+  |
+;   +------------> | if.end | -+
+;                  +--------+
+;                    |
+;                    | 1
+;                    v
+;                  +--------+
+;                  |  end   |
+;                  +--------+
+;
+; CHECK-LABEL: func_loop:
+; CHECK: %entry
+; CHECK: %header
+; CHECK: %if.then
+; CHECK: %if.else
+; CHECK: %if.end
+; CHECK: %end
+;
+; CHECK2-LABEL: func_loop:
+; CHECK2: %entry
+; CHECK2: %header
+; CHECK2: %if.else
+; CHECK2: %if.end
+; CHECK2: %if.then
+; CHECK2: %end
+
+entry:
+  br label %header
+
+header:
+  call void @e()
+  %call = call zeroext i1 @a()
+  br i1 %call, label %if.then, label %if.else, !prof !10
+
+if.then:
+  call void @f()
+  br label %if.end
+
+if.else:
+  call void @g()
+  br label %if.end
+
+if.end:
+  call void @h()
+  %call2 = call zeroext i1 @a()
+  br i1 %call2, label %header, label %end
+
+end:
+  ret void
+}
+
+
+declare zeroext i1 @a()
+declare void @b()
+declare void @c()
+declare void @d()
+declare void @e()
+declare void @g()
+declare void @f()
+declare void @h()
+
+!1 = !{!"branch_weights", i32 10, i32 10000}
+!9 = !{!"function_entry_count", i64 1}
+!10 = !{!"branch_weights", i32 16, i32 160}

--- a/llvm/test/CodeGen/X86/code_placement_ext_tsp_size.ll
+++ b/llvm/test/CodeGen/X86/code_placement_ext_tsp_size.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=true  < %s | FileCheck %s
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=false < %s | FileCheck %s -check-prefix=CHECK2
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=true  < %s | FileCheck %s -check-prefix=CHECK-PERF
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=false < %s | FileCheck %s -check-prefix=CHECK-SIZE
 
 define void @func1() minsize {
 ;
@@ -19,15 +19,15 @@ define void @func1() minsize {
 ; | b2  | <+
 ; +-----+
 ;
-; CHECK-LABEL: func1:
-; CHECK: %b0
-; CHECK: %b1
-; CHECK: %b2
+; CHECK-PERF-LABEL: func1:
+; CHECK-PERF: %b0
+; CHECK-PERF: %b1
+; CHECK-PERF: %b2
 ;
-; CHECK2-LABEL: func1:
-; CHECK2: %b0
-; CHECK2: %b2
-; CHECK2: %b1
+; CHECK-SIZE-LABEL: func1:
+; CHECK-SIZE: %b0
+; CHECK-SIZE: %b2
+; CHECK-SIZE: %b1
 
 b0:
   %call = call zeroext i1 @a()
@@ -75,21 +75,21 @@ define void @func_loop() minsize !prof !9 {
 ;                  |  end   |
 ;                  +--------+
 ;
-; CHECK-LABEL: func_loop:
-; CHECK: %entry
-; CHECK: %header
-; CHECK: %if.then
-; CHECK: %if.else
-; CHECK: %if.end
-; CHECK: %end
+; CHECK-PERF-LABEL: func_loop:
+; CHECK-PERF: %entry
+; CHECK-PERF: %header
+; CHECK-PERF: %if.then
+; CHECK-PERF: %if.else
+; CHECK-PERF: %if.end
+; CHECK-PERF: %end
 ;
-; CHECK2-LABEL: func_loop:
-; CHECK2: %entry
-; CHECK2: %header
-; CHECK2: %if.else
-; CHECK2: %if.end
-; CHECK2: %if.then
-; CHECK2: %end
+; CHECK-SIZE-LABEL: func_loop:
+; CHECK-SIZE: %entry
+; CHECK-SIZE: %header
+; CHECK-SIZE: %if.else
+; CHECK-SIZE: %if.end
+; CHECK-SIZE: %if.then
+; CHECK-SIZE: %end
 
 entry:
   br label %header


### PR DESCRIPTION
This is an implementation of a new "size-aware" machine block placement. The 
idea is to reorder blocks so that the number of fall-through jumps is maximized.
Observe that profile data is ignored for the optimization, and it is applied only
for instances with hasOptSize()=true.
This strategy has two benefits:
(i) it eliminates jump instructions, which results in smaller text size; 
(ii) we avoid using profile data while reordering blocks, which yields more 
"uniform" functions, thus helping ICF and machine outliner/merger.

For large (mobile) apps, the size benefits of (i) and (ii) are roughly the same, 
combined providing up to 0.5% uncompressed and up to 1% compressed savings size
on top of the current solution.

The optimization is turned off by default.