### PR TITLE
[IR][Attribute] Add support for intersecting AttributeLists; NFC

### DIFF
--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -117,6 +117,10 @@ public:
   static bool canUseAsParamAttr(AttrKind Kind);
   static bool canUseAsRetAttr(AttrKind Kind);
 
+  static bool intersectWithAnd(AttrKind Kind);
+  static bool intersectWithMin(AttrKind Kind);
+  static bool intersectWithCustom(AttrKind Kind);
+
 private:
   AttributeImpl *pImpl = nullptr;
 
@@ -208,8 +212,15 @@ public:
   /// Return true if the target-dependent attribute is present.
   bool hasAttribute(StringRef Val) const;
 
+  /// Returns true if the attribute's kind can be represented as an enum (Enum,
+  /// Integer, Type, ConstantRange, or ConstantRangeList attribute).
+  bool hasKindAsEnum() const {
+    return isEnumAttribute() || isIntAttribute() || isTypeAttribute() ||
+           isConstantRangeAttribute() || isConstantRangeListAttribute();
+  }
+
   /// Return the attribute's kind as an enum (Attribute::AttrKind). This
-  /// requires the attribute to be an enum, integer, or type attribute.
+  /// requires the attribute be representable as an enum (see: `hasKindAsEnum`).
   Attribute::AttrKind getKindAsEnum() const;
 
   /// Return the attribute's value as an integer. This requires that the
@@ -382,6 +393,12 @@ public:
   /// attribute sets are immutable.
   [[nodiscard]] AttributeSet
   removeAttributes(LLVMContext &C, const AttributeMask &AttrsToRemove) const;
+
+  /// Try to intersect this AttributeSet with Other. Returns std::nullopt if
+  /// the two lists are inherently incompatible (imply different behavior, not
+  /// just analysis).
+  [[nodiscard]] std::optional<AttributeSet>
+  intersectWith(LLVMContext &C, AttributeSet Other) const;
 
   /// Return the number of attributes in this set.
   unsigned getNumAttributes() const;
@@ -774,6 +791,12 @@ public:
   [[nodiscard]] AttributeList
   addAllocSizeParamAttr(LLVMContext &C, unsigned ArgNo, unsigned ElemSizeArg,
                         const std::optional<unsigned> &NumElemsArg);
+
+  /// Try to intersect this AttributeList with Other. Returns std::nullopt if
+  /// the two lists are inherently incompatible (imply different behavior, not
+  /// just analysis).
+  [[nodiscard]] std::optional<AttributeList>
+  intersectAttributes(LLVMContext &C, AttributeList Other) const;
 
   //===--------------------------------------------------------------------===//
   // AttributeList Accessors

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -117,6 +117,7 @@ public:
   static bool canUseAsParamAttr(AttrKind Kind);
   static bool canUseAsRetAttr(AttrKind Kind);
 
+  static bool intersectMustPreserve(AttrKind Kind);
   static bool intersectWithAnd(AttrKind Kind);
   static bool intersectWithMin(AttrKind Kind);
   static bool intersectWithCustom(AttrKind Kind);
@@ -214,10 +215,7 @@ public:
 
   /// Returns true if the attribute's kind can be represented as an enum (Enum,
   /// Integer, Type, ConstantRange, or ConstantRangeList attribute).
-  bool hasKindAsEnum() const {
-    return isEnumAttribute() || isIntAttribute() || isTypeAttribute() ||
-           isConstantRangeAttribute() || isConstantRangeListAttribute();
-  }
+  bool hasKindAsEnum() const { return !isStringAttribute(); }
 
   /// Return the attribute's kind as an enum (Attribute::AttrKind). This
   /// requires the attribute be representable as an enum (see: `hasKindAsEnum`).
@@ -305,6 +303,9 @@ public:
   /// Equality and non-equality operators.
   bool operator==(Attribute A) const { return pImpl == A.pImpl; }
   bool operator!=(Attribute A) const { return pImpl != A.pImpl; }
+
+  /// Used to sort attribute by kind.
+  int cmpKind(Attribute A) const;
 
   /// Less-than operator. Useful for sorting the attributes list.
   bool operator<(Attribute A) const;

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -797,7 +797,7 @@ public:
   /// the two lists are inherently incompatible (imply different behavior, not
   /// just analysis).
   [[nodiscard]] std::optional<AttributeList>
-  intersectAttributes(LLVMContext &C, AttributeList Other) const;
+  intersectWith(LLVMContext &C, AttributeList Other) const;
 
   //===--------------------------------------------------------------------===//
   // AttributeList Accessors

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -22,6 +22,37 @@ def ParamAttr : AttrProperty;
 /// Can be used as return attribute.
 def RetAttr : AttrProperty;
 
+
+
+/// Intersection rules. Used for example in sinking/hoisting two
+/// callbases to find a set of attributes that apply to both.
+/// If no rule is specified, the assumed rule is that the attrs
+/// must be equal, otherwise the intersection will fail. Having
+/// any rule implies that it is legal to drop the attribute.
+/// Note, there are some attributes we can (probably) legally drop
+/// but are intentionally excluded as of now. Those include:
+///     - initializes
+///     - allockind
+///     - allocsize
+///     - minsize
+///     - optsize
+///     - optnone
+///     - optdebug
+///     - optforfuzzing    
+///
+/// When intersecting take the AND of the two attrs.
+/// Invalid for Int/ConstantRange/ConstantRangeList attrs.
+def IntersectAnd : AttrProperty;
+
+/// When intersecting take the min value of the two attrs.
+/// Only valid for Int attrs.
+def IntersectMin : AttrProperty;
+
+/// When intersecting rely on some user defined code.
+def IntersectCustom : AttrProperty;
+
+    
+
 /// Attribute base class.
 class Attr<string S, list<AttrProperty> P> {
   // String representation of this attribute in the IR.
@@ -54,17 +85,17 @@ class ConstantRangeListAttr<string S, list<AttrProperty> P> : Attr<S, P>;
 
 /// Alignment of parameter (5 bits) stored as log2 of alignment with +1 bias.
 /// 0 means unaligned (different from align(1)).
-def Alignment : IntAttr<"align", [ParamAttr, RetAttr]>;
+def Alignment : IntAttr<"align", [ParamAttr, RetAttr, IntersectCustom]>;
 
 /// Parameter of a function that tells us the alignment of an allocation, as in
 /// aligned_alloc and aligned ::operator::new.
-def AllocAlign: EnumAttr<"allocalign", [ParamAttr]>;
+def AllocAlign: EnumAttr<"allocalign", [ParamAttr, IntersectAnd]>;
 
 /// Describes behavior of an allocator function in terms of known properties.
 def AllocKind: IntAttr<"allockind", [FnAttr]>;
 
 /// Parameter is the pointer to be manipulated by the allocator function.
-def AllocatedPointer : EnumAttr<"allocptr", [ParamAttr]>;
+def AllocatedPointer : EnumAttr<"allocptr", [ParamAttr, IntersectAnd]>;
 
 /// The result of the function is guaranteed to point to a number of bytes that
 /// we can determine if we know the value of the function's arguments.
@@ -84,23 +115,23 @@ def ByVal : TypeAttr<"byval", [ParamAttr]>;
 def ByRef : TypeAttr<"byref", [ParamAttr]>;
 
 /// Parameter or return value may not contain uninitialized or poison bits.
-def NoUndef : EnumAttr<"noundef", [ParamAttr, RetAttr]>;
+def NoUndef : EnumAttr<"noundef", [ParamAttr, RetAttr, IntersectAnd]>;
 
 /// Marks function as being in a cold path.
-def Cold : EnumAttr<"cold", [FnAttr]>;
+def Cold : EnumAttr<"cold", [FnAttr, IntersectAnd]>;
 
 /// Can only be moved to control-equivalent blocks.
-def Convergent : EnumAttr<"convergent", [FnAttr]>;
+def Convergent : EnumAttr<"convergent", [FnAttr, IntersectAnd]>;
 
 /// Marks function as being in a hot path and frequently called.
-def Hot: EnumAttr<"hot", [FnAttr]>;
+def Hot: EnumAttr<"hot", [FnAttr, IntersectAnd]>;
 
 /// Pointer is known to be dereferenceable.
-def Dereferenceable : IntAttr<"dereferenceable", [ParamAttr, RetAttr]>;
+def Dereferenceable : IntAttr<"dereferenceable", [ParamAttr, RetAttr, IntersectMin]>;
 
 /// Pointer is either null or dereferenceable.
 def DereferenceableOrNull : IntAttr<"dereferenceable_or_null",
-                                    [ParamAttr, RetAttr]>;
+                                    [ParamAttr, RetAttr, IntersectMin]>;
 
 /// Do not instrument function with sanitizers.
 def DisableSanitizerInstrumentation: EnumAttr<"disable_sanitizer_instrumentation", [FnAttr]>;
@@ -122,7 +153,7 @@ def InAlloca : TypeAttr<"inalloca", [ParamAttr]>;
 def Initializes : ConstantRangeListAttr<"initializes", [ParamAttr]>;
 
 /// Source said inlining was desirable.
-def InlineHint : EnumAttr<"inlinehint", [FnAttr]>;
+def InlineHint : EnumAttr<"inlinehint", [FnAttr, IntersectAnd]>;
 
 /// Force argument to be passed in register.
 def InReg : EnumAttr<"inreg", [ParamAttr, RetAttr]>;
@@ -131,10 +162,10 @@ def InReg : EnumAttr<"inreg", [ParamAttr, RetAttr]>;
 def JumpTable : EnumAttr<"jumptable", [FnAttr]>;
 
 /// Memory effects of the function.
-def Memory : IntAttr<"memory", [FnAttr]>;
+def Memory : IntAttr<"memory", [FnAttr, IntersectCustom]>;
 
 /// Forbidden floating-point classes.
-def NoFPClass : IntAttr<"nofpclass", [ParamAttr, RetAttr]>;
+def NoFPClass : IntAttr<"nofpclass", [ParamAttr, RetAttr, IntersectCustom]>;
 
 /// Function must be optimized for size first.
 def MinSize : EnumAttr<"minsize", [FnAttr]>;
@@ -146,16 +177,16 @@ def Naked : EnumAttr<"naked", [FnAttr]>;
 def Nest : EnumAttr<"nest", [ParamAttr]>;
 
 /// Considered to not alias after call.
-def NoAlias : EnumAttr<"noalias", [ParamAttr, RetAttr]>;
+def NoAlias : EnumAttr<"noalias", [ParamAttr, RetAttr, IntersectAnd]>;
 
 /// Callee isn't recognized as a builtin.
 def NoBuiltin : EnumAttr<"nobuiltin", [FnAttr]>;
 
 /// Function cannot enter into caller's translation unit.
-def NoCallback : EnumAttr<"nocallback", [FnAttr]>;
+def NoCallback : EnumAttr<"nocallback", [FnAttr, IntersectAnd]>;
 
 /// Function creates no aliases of pointer.
-def NoCapture : EnumAttr<"nocapture", [ParamAttr]>;
+def NoCapture : EnumAttr<"nocapture", [ParamAttr, IntersectAnd]>;
 
 /// Call cannot be duplicated.
 def NoDuplicate : EnumAttr<"noduplicate", [FnAttr]>;
@@ -164,10 +195,10 @@ def NoDuplicate : EnumAttr<"noduplicate", [FnAttr]>;
 def NoExt : EnumAttr<"noext", [ParamAttr, RetAttr]>;
 
 /// Function does not deallocate memory.
-def NoFree : EnumAttr<"nofree", [FnAttr, ParamAttr]>;
+def NoFree : EnumAttr<"nofree", [FnAttr, ParamAttr, IntersectAnd]>;
 
 /// Argument is dead if the call unwinds.
-def DeadOnUnwind : EnumAttr<"dead_on_unwind", [ParamAttr]>;
+def DeadOnUnwind : EnumAttr<"dead_on_unwind", [ParamAttr, IntersectAnd]>;
 
 /// Disable implicit floating point insts.
 def NoImplicitFloat : EnumAttr<"noimplicitfloat", [FnAttr]>;
@@ -182,19 +213,19 @@ def NonLazyBind : EnumAttr<"nonlazybind", [FnAttr]>;
 def NoMerge : EnumAttr<"nomerge", [FnAttr]>;
 
 /// Pointer is known to be not null.
-def NonNull : EnumAttr<"nonnull", [ParamAttr, RetAttr]>;
+def NonNull : EnumAttr<"nonnull", [ParamAttr, RetAttr, IntersectAnd]>;
 
 /// The function does not recurse.
-def NoRecurse : EnumAttr<"norecurse", [FnAttr]>;
+def NoRecurse : EnumAttr<"norecurse", [FnAttr, IntersectAnd]>;
 
 /// Disable redzone.
 def NoRedZone : EnumAttr<"noredzone", [FnAttr]>;
 
 /// Mark the function as not returning.
-def NoReturn : EnumAttr<"noreturn", [FnAttr]>;
+def NoReturn : EnumAttr<"noreturn", [FnAttr, IntersectAnd]>;
 
 /// Function does not synchronize.
-def NoSync : EnumAttr<"nosync", [FnAttr]>;
+def NoSync : EnumAttr<"nosync", [FnAttr, IntersectAnd]>;
 
 /// Disable Indirect Branch Tracking.
 def NoCfCheck : EnumAttr<"nocf_check", [FnAttr]>;
@@ -207,7 +238,7 @@ def NoProfile : EnumAttr<"noprofile", [FnAttr]>;
 def SkipProfile : EnumAttr<"skipprofile", [FnAttr]>;
 
 /// Function doesn't unwind stack.
-def NoUnwind : EnumAttr<"nounwind", [FnAttr]>;
+def NoUnwind : EnumAttr<"nounwind", [FnAttr, IntersectAnd]>;
 
 /// No SanitizeBounds instrumentation.
 def NoSanitizeBounds : EnumAttr<"nosanitize_bounds", [FnAttr]>;
@@ -234,16 +265,16 @@ def OptimizeNone : EnumAttr<"optnone", [FnAttr]>;
 def Preallocated : TypeAttr<"preallocated", [FnAttr, ParamAttr]>;
 
 /// Parameter or return value is within the specified range.
-def Range : ConstantRangeAttr<"range", [ParamAttr, RetAttr]>;
+def Range : ConstantRangeAttr<"range", [ParamAttr, RetAttr, IntersectCustom]>;
 
 /// Function does not access memory.
-def ReadNone : EnumAttr<"readnone", [ParamAttr]>;
+def ReadNone : EnumAttr<"readnone", [ParamAttr, IntersectAnd]>;
 
 /// Function only reads from memory.
-def ReadOnly : EnumAttr<"readonly", [ParamAttr]>;
+def ReadOnly : EnumAttr<"readonly", [ParamAttr, IntersectAnd]>;
 
 /// Return value is always equal to this argument.
-def Returned : EnumAttr<"returned", [ParamAttr]>;
+def Returned : EnumAttr<"returned", [ParamAttr, IntersectAnd]>;
 
 /// Parameter is required to be a trivial constant.
 def ImmArg : EnumAttr<"immarg", [ParamAttr]>;
@@ -265,7 +296,7 @@ def SExt : EnumAttr<"signext", [ParamAttr, RetAttr]>;
 def StackAlignment : IntAttr<"alignstack", [FnAttr, ParamAttr]>;
 
 /// Function can be speculated.
-def Speculatable : EnumAttr<"speculatable", [FnAttr]>;
+def Speculatable : EnumAttr<"speculatable", [FnAttr, IntersectAnd]>;
 
 /// Stack protection.
 def StackProtect : EnumAttr<"ssp", [FnAttr]>;
@@ -332,19 +363,19 @@ def UWTable : IntAttr<"uwtable", [FnAttr]>;
 def VScaleRange : IntAttr<"vscale_range", [FnAttr]>;
 
 /// Function always comes back to callsite.
-def WillReturn : EnumAttr<"willreturn", [FnAttr]>;
+def WillReturn : EnumAttr<"willreturn", [FnAttr, IntersectAnd]>;
 
 /// Pointer argument is writable.
-def Writable : EnumAttr<"writable", [ParamAttr]>;
+def Writable : EnumAttr<"writable", [ParamAttr, IntersectAnd]>;
 
 /// Function only writes to memory.
-def WriteOnly : EnumAttr<"writeonly", [ParamAttr]>;
+def WriteOnly : EnumAttr<"writeonly", [ParamAttr, IntersectAnd]>;
 
 /// Zero extended before/after call.
 def ZExt : EnumAttr<"zeroext", [ParamAttr, RetAttr]>;
 
 /// Function is required to make Forward Progress.
-def MustProgress : EnumAttr<"mustprogress", [FnAttr]>;
+def MustProgress : EnumAttr<"mustprogress", [FnAttr, IntersectAnd]>;
 
 /// Function is a presplit coroutine.
 def PresplitCoroutine : EnumAttr<"presplitcoroutine", [FnAttr]>;

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -26,9 +26,6 @@ def RetAttr : AttrProperty;
 
 /// Intersection rules. Used for example in sinking/hoisting two
 /// callbases to find a set of attributes that apply to both.
-/// If no rule is specified, the assumed rule is that the attrs
-/// must be equal, otherwise the intersection will fail. Having
-/// any rule implies that it is legal to drop the attribute.
 /// Note, there are some attributes we can (probably) legally drop
 /// but are intentionally excluded as of now. Those include:
 ///     - initializes
@@ -38,305 +35,310 @@ def RetAttr : AttrProperty;
 ///     - optsize
 ///     - optnone
 ///     - optdebug
-///     - optforfuzzing    
+///     - optforfuzzing
 ///
+/// When intersecting the attributes must both present and equal.
+/// Use this for attributes you are not certain it is safe to drop
+/// at any time. I.e `byval(Ty)` on a parameter.
+def IntersectPreserve : AttrProperty;
+
 /// When intersecting take the AND of the two attrs.
-/// Invalid for Int/ConstantRange/ConstantRangeList attrs.
+/// Only valid for Enum attrs.
 def IntersectAnd : AttrProperty;
 
 /// When intersecting take the min value of the two attrs.
 /// Only valid for Int attrs.
 def IntersectMin : AttrProperty;
 
-/// When intersecting rely on some user defined code.
+/// When intersecting rely on some specially defined code.
 def IntersectCustom : AttrProperty;
 
-    
+
 
 /// Attribute base class.
-class Attr<string S, list<AttrProperty> P> {
+class Attr<string S, AttrProperty I, list<AttrProperty> P> {
   // String representation of this attribute in the IR.
   string AttrString = S;
-  list<AttrProperty> Properties = P;
+  list<AttrProperty> Properties = P # [I];
 }
 
 /// Enum attribute.
-class EnumAttr<string S, list<AttrProperty> P> : Attr<S, P>;
+class EnumAttr<string S, AttrProperty I, list<AttrProperty> P> : Attr<S, I, P>;
 
 /// Int attribute.
-class IntAttr<string S, list<AttrProperty> P> : Attr<S, P>;
+class IntAttr<string S, AttrProperty I, list<AttrProperty> P> : Attr<S, I, P>;
 
 /// Type attribute.
-class TypeAttr<string S, list<AttrProperty> P> : Attr<S, P>;
+class TypeAttr<string S, AttrProperty I, list<AttrProperty> P> : Attr<S, I, P>;
 
 /// StringBool attribute.
-class StrBoolAttr<string S> : Attr<S, []>;
+class StrBoolAttr<string S> : Attr<S, IntersectPreserve, []>;
 
 /// Arbitrary string attribute.
-class ComplexStrAttr<string S, list<AttrProperty> P> : Attr<S, P>;
+class ComplexStrAttr<string S, list<AttrProperty> P> : Attr<S, IntersectPreserve, P>;
 
 /// ConstantRange attribute.
-class ConstantRangeAttr<string S, list<AttrProperty> P> : Attr<S, P>;
+class ConstantRangeAttr<string S, AttrProperty I, list<AttrProperty> P> : Attr<S, I, P>;
 
 /// ConstantRangeList attribute.
-class ConstantRangeListAttr<string S, list<AttrProperty> P> : Attr<S, P>;
+class ConstantRangeListAttr<string S, AttrProperty I, list<AttrProperty> P> : Attr<S, I, P>;
 
 /// Target-independent enum attributes.
 
 /// Alignment of parameter (5 bits) stored as log2 of alignment with +1 bias.
 /// 0 means unaligned (different from align(1)).
-def Alignment : IntAttr<"align", [ParamAttr, RetAttr, IntersectCustom]>;
+def Alignment : IntAttr<"align", IntersectCustom, [ParamAttr, RetAttr]>;
 
 /// Parameter of a function that tells us the alignment of an allocation, as in
 /// aligned_alloc and aligned ::operator::new.
-def AllocAlign: EnumAttr<"allocalign", [ParamAttr, IntersectAnd]>;
+def AllocAlign: EnumAttr<"allocalign", IntersectAnd, [ParamAttr]>;
 
 /// Describes behavior of an allocator function in terms of known properties.
-def AllocKind: IntAttr<"allockind", [FnAttr]>;
+def AllocKind: IntAttr<"allockind", IntersectPreserve, [FnAttr]>;
 
 /// Parameter is the pointer to be manipulated by the allocator function.
-def AllocatedPointer : EnumAttr<"allocptr", [ParamAttr, IntersectAnd]>;
+def AllocatedPointer : EnumAttr<"allocptr", IntersectAnd, [ParamAttr]>;
 
 /// The result of the function is guaranteed to point to a number of bytes that
 /// we can determine if we know the value of the function's arguments.
-def AllocSize : IntAttr<"allocsize", [FnAttr]>;
+def AllocSize : IntAttr<"allocsize", IntersectPreserve, [FnAttr]>;
 
 /// inline=always.
-def AlwaysInline : EnumAttr<"alwaysinline", [FnAttr]>;
+def AlwaysInline : EnumAttr<"alwaysinline", IntersectPreserve, [FnAttr]>;
 
 /// Callee is recognized as a builtin, despite nobuiltin attribute on its
 /// declaration.
-def Builtin : EnumAttr<"builtin", [FnAttr]>;
+def Builtin : EnumAttr<"builtin", IntersectPreserve, [FnAttr]>;
 
 /// Pass structure by value.
-def ByVal : TypeAttr<"byval", [ParamAttr]>;
+def ByVal : TypeAttr<"byval", IntersectPreserve, [ParamAttr]>;
 
 /// Mark in-memory ABI type.
-def ByRef : TypeAttr<"byref", [ParamAttr]>;
+def ByRef : TypeAttr<"byref", IntersectPreserve, [ParamAttr]>;
 
 /// Parameter or return value may not contain uninitialized or poison bits.
-def NoUndef : EnumAttr<"noundef", [ParamAttr, RetAttr, IntersectAnd]>;
+def NoUndef : EnumAttr<"noundef", IntersectAnd, [ParamAttr, RetAttr]>;
 
 /// Marks function as being in a cold path.
-def Cold : EnumAttr<"cold", [FnAttr, IntersectAnd]>;
+def Cold : EnumAttr<"cold", IntersectAnd, [FnAttr]>;
 
 /// Can only be moved to control-equivalent blocks.
-def Convergent : EnumAttr<"convergent", [FnAttr, IntersectAnd]>;
+def Convergent : EnumAttr<"convergent", IntersectAnd, [FnAttr]>;
 
 /// Marks function as being in a hot path and frequently called.
-def Hot: EnumAttr<"hot", [FnAttr, IntersectAnd]>;
+def Hot: EnumAttr<"hot", IntersectAnd, [FnAttr]>;
 
 /// Pointer is known to be dereferenceable.
-def Dereferenceable : IntAttr<"dereferenceable", [ParamAttr, RetAttr, IntersectMin]>;
+def Dereferenceable : IntAttr<"dereferenceable", IntersectMin, [ParamAttr, RetAttr]>;
 
 /// Pointer is either null or dereferenceable.
-def DereferenceableOrNull : IntAttr<"dereferenceable_or_null",
-                                    [ParamAttr, RetAttr, IntersectMin]>;
+def DereferenceableOrNull : IntAttr<"dereferenceable_or_null", IntersectMin,
+                                    [ParamAttr, RetAttr]>;
 
 /// Do not instrument function with sanitizers.
-def DisableSanitizerInstrumentation: EnumAttr<"disable_sanitizer_instrumentation", [FnAttr]>;
+def DisableSanitizerInstrumentation: EnumAttr<"disable_sanitizer_instrumentation", IntersectPreserve, [FnAttr]>;
 
 /// Provide pointer element type to intrinsic.
-def ElementType : TypeAttr<"elementtype", [ParamAttr]>;
+def ElementType : TypeAttr<"elementtype", IntersectPreserve, [ParamAttr]>;
 
 /// Whether to keep return instructions, or replace with a jump to an external
 /// symbol.
-def FnRetThunkExtern : EnumAttr<"fn_ret_thunk_extern", [FnAttr]>;
+def FnRetThunkExtern : EnumAttr<"fn_ret_thunk_extern", IntersectPreserve, [FnAttr]>;
 
 /// Function has a hybrid patchable thunk.
-def HybridPatchable : EnumAttr<"hybrid_patchable", [FnAttr]>;
+def HybridPatchable : EnumAttr<"hybrid_patchable", IntersectPreserve, [FnAttr]>;
 
 /// Pass structure in an alloca.
-def InAlloca : TypeAttr<"inalloca", [ParamAttr]>;
+def InAlloca : TypeAttr<"inalloca", IntersectPreserve, [ParamAttr]>;
 
 /// Pointer argument memory is initialized.
-def Initializes : ConstantRangeListAttr<"initializes", [ParamAttr]>;
+def Initializes : ConstantRangeListAttr<"initializes", IntersectPreserve, [ParamAttr]>;
 
 /// Source said inlining was desirable.
-def InlineHint : EnumAttr<"inlinehint", [FnAttr, IntersectAnd]>;
+def InlineHint : EnumAttr<"inlinehint", IntersectAnd, [FnAttr]>;
 
 /// Force argument to be passed in register.
-def InReg : EnumAttr<"inreg", [ParamAttr, RetAttr]>;
+def InReg : EnumAttr<"inreg", IntersectPreserve, [ParamAttr, RetAttr]>;
 
 /// Build jump-instruction tables and replace refs.
-def JumpTable : EnumAttr<"jumptable", [FnAttr]>;
+def JumpTable : EnumAttr<"jumptable", IntersectPreserve, [FnAttr]>;
 
 /// Memory effects of the function.
-def Memory : IntAttr<"memory", [FnAttr, IntersectCustom]>;
+def Memory : IntAttr<"memory", IntersectCustom, [FnAttr]>;
 
 /// Forbidden floating-point classes.
-def NoFPClass : IntAttr<"nofpclass", [ParamAttr, RetAttr, IntersectCustom]>;
+def NoFPClass : IntAttr<"nofpclass", IntersectCustom, [ParamAttr, RetAttr]>;
 
 /// Function must be optimized for size first.
-def MinSize : EnumAttr<"minsize", [FnAttr]>;
+def MinSize : EnumAttr<"minsize", IntersectPreserve, [FnAttr]>;
 
 /// Naked function.
-def Naked : EnumAttr<"naked", [FnAttr]>;
+def Naked : EnumAttr<"naked", IntersectPreserve, [FnAttr]>;
 
 /// Nested function static chain.
-def Nest : EnumAttr<"nest", [ParamAttr]>;
+def Nest : EnumAttr<"nest", IntersectPreserve, [ParamAttr]>;
 
 /// Considered to not alias after call.
-def NoAlias : EnumAttr<"noalias", [ParamAttr, RetAttr, IntersectAnd]>;
+def NoAlias : EnumAttr<"noalias", IntersectAnd, [ParamAttr, RetAttr]>;
 
 /// Callee isn't recognized as a builtin.
-def NoBuiltin : EnumAttr<"nobuiltin", [FnAttr]>;
+def NoBuiltin : EnumAttr<"nobuiltin", IntersectPreserve, [FnAttr]>;
 
 /// Function cannot enter into caller's translation unit.
-def NoCallback : EnumAttr<"nocallback", [FnAttr, IntersectAnd]>;
+def NoCallback : EnumAttr<"nocallback", IntersectAnd, [FnAttr]>;
 
 /// Function creates no aliases of pointer.
-def NoCapture : EnumAttr<"nocapture", [ParamAttr, IntersectAnd]>;
+def NoCapture : EnumAttr<"nocapture", IntersectAnd, [ParamAttr]>;
 
 /// Call cannot be duplicated.
-def NoDuplicate : EnumAttr<"noduplicate", [FnAttr]>;
+def NoDuplicate : EnumAttr<"noduplicate", IntersectPreserve, [FnAttr]>;
 
 /// No extension needed before/after call (high bits are undefined).
-def NoExt : EnumAttr<"noext", [ParamAttr, RetAttr]>;
+def NoExt : EnumAttr<"noext", IntersectPreserve, [ParamAttr, RetAttr]>;
 
 /// Function does not deallocate memory.
-def NoFree : EnumAttr<"nofree", [FnAttr, ParamAttr, IntersectAnd]>;
+def NoFree : EnumAttr<"nofree", IntersectAnd, [FnAttr, ParamAttr]>;
 
 /// Argument is dead if the call unwinds.
-def DeadOnUnwind : EnumAttr<"dead_on_unwind", [ParamAttr, IntersectAnd]>;
+def DeadOnUnwind : EnumAttr<"dead_on_unwind", IntersectAnd, [ParamAttr]>;
 
 /// Disable implicit floating point insts.
-def NoImplicitFloat : EnumAttr<"noimplicitfloat", [FnAttr]>;
+def NoImplicitFloat : EnumAttr<"noimplicitfloat", IntersectPreserve, [FnAttr]>;
 
 /// inline=never.
-def NoInline : EnumAttr<"noinline", [FnAttr]>;
+def NoInline : EnumAttr<"noinline", IntersectPreserve, [FnAttr]>;
 
 /// Function is called early and/or often, so lazy binding isn't worthwhile.
-def NonLazyBind : EnumAttr<"nonlazybind", [FnAttr]>;
+def NonLazyBind : EnumAttr<"nonlazybind", IntersectPreserve, [FnAttr]>;
 
 /// Disable merging for specified functions or call sites.
-def NoMerge : EnumAttr<"nomerge", [FnAttr]>;
+def NoMerge : EnumAttr<"nomerge", IntersectPreserve, [FnAttr]>;
 
 /// Pointer is known to be not null.
-def NonNull : EnumAttr<"nonnull", [ParamAttr, RetAttr, IntersectAnd]>;
+def NonNull : EnumAttr<"nonnull", IntersectAnd, [ParamAttr, RetAttr]>;
 
 /// The function does not recurse.
-def NoRecurse : EnumAttr<"norecurse", [FnAttr, IntersectAnd]>;
+def NoRecurse : EnumAttr<"norecurse", IntersectAnd, [FnAttr]>;
 
 /// Disable redzone.
-def NoRedZone : EnumAttr<"noredzone", [FnAttr]>;
+def NoRedZone : EnumAttr<"noredzone", IntersectPreserve, [FnAttr]>;
 
 /// Mark the function as not returning.
-def NoReturn : EnumAttr<"noreturn", [FnAttr, IntersectAnd]>;
+def NoReturn : EnumAttr<"noreturn", IntersectAnd, [FnAttr]>;
 
 /// Function does not synchronize.
-def NoSync : EnumAttr<"nosync", [FnAttr, IntersectAnd]>;
+def NoSync : EnumAttr<"nosync", IntersectAnd, [FnAttr]>;
 
 /// Disable Indirect Branch Tracking.
-def NoCfCheck : EnumAttr<"nocf_check", [FnAttr]>;
+def NoCfCheck : EnumAttr<"nocf_check", IntersectPreserve, [FnAttr]>;
 
 /// Function should not be instrumented.
-def NoProfile : EnumAttr<"noprofile", [FnAttr]>;
+def NoProfile : EnumAttr<"noprofile", IntersectPreserve, [FnAttr]>;
 
 /// This function should not be instrumented but it is ok to inline profiled
 // functions into it.
-def SkipProfile : EnumAttr<"skipprofile", [FnAttr]>;
+def SkipProfile : EnumAttr<"skipprofile", IntersectPreserve, [FnAttr]>;
 
 /// Function doesn't unwind stack.
-def NoUnwind : EnumAttr<"nounwind", [FnAttr, IntersectAnd]>;
+def NoUnwind : EnumAttr<"nounwind", IntersectAnd, [FnAttr]>;
 
 /// No SanitizeBounds instrumentation.
-def NoSanitizeBounds : EnumAttr<"nosanitize_bounds", [FnAttr]>;
+def NoSanitizeBounds : EnumAttr<"nosanitize_bounds", IntersectPreserve, [FnAttr]>;
 
 /// No SanitizeCoverage instrumentation.
-def NoSanitizeCoverage : EnumAttr<"nosanitize_coverage", [FnAttr]>;
+def NoSanitizeCoverage : EnumAttr<"nosanitize_coverage", IntersectPreserve, [FnAttr]>;
 
 /// Null pointer in address space zero is valid.
-def NullPointerIsValid : EnumAttr<"null_pointer_is_valid", [FnAttr]>;
+def NullPointerIsValid : EnumAttr<"null_pointer_is_valid", IntersectPreserve, [FnAttr]>;
 
 /// Select optimizations that give decent debug info.
-def OptimizeForDebugging : EnumAttr<"optdebug", [FnAttr]>;
+def OptimizeForDebugging : EnumAttr<"optdebug", IntersectPreserve, [FnAttr]>;
 
 /// Select optimizations for best fuzzing signal.
-def OptForFuzzing : EnumAttr<"optforfuzzing", [FnAttr]>;
+def OptForFuzzing : EnumAttr<"optforfuzzing", IntersectPreserve, [FnAttr]>;
 
 /// opt_size.
-def OptimizeForSize : EnumAttr<"optsize", [FnAttr]>;
+def OptimizeForSize : EnumAttr<"optsize", IntersectPreserve, [FnAttr]>;
 
 /// Function must not be optimized.
-def OptimizeNone : EnumAttr<"optnone", [FnAttr]>;
+def OptimizeNone : EnumAttr<"optnone", IntersectPreserve, [FnAttr]>;
 
 /// Similar to byval but without a copy.
-def Preallocated : TypeAttr<"preallocated", [FnAttr, ParamAttr]>;
+def Preallocated : TypeAttr<"preallocated", IntersectPreserve, [FnAttr, ParamAttr]>;
 
 /// Parameter or return value is within the specified range.
-def Range : ConstantRangeAttr<"range", [ParamAttr, RetAttr, IntersectCustom]>;
+def Range : ConstantRangeAttr<"range", IntersectCustom, [ParamAttr, RetAttr]>;
 
 /// Function does not access memory.
-def ReadNone : EnumAttr<"readnone", [ParamAttr, IntersectAnd]>;
+def ReadNone : EnumAttr<"readnone", IntersectAnd, [ParamAttr]>;
 
 /// Function only reads from memory.
-def ReadOnly : EnumAttr<"readonly", [ParamAttr, IntersectAnd]>;
+def ReadOnly : EnumAttr<"readonly", IntersectAnd, [ParamAttr]>;
 
 /// Return value is always equal to this argument.
-def Returned : EnumAttr<"returned", [ParamAttr, IntersectAnd]>;
+def Returned : EnumAttr<"returned", IntersectAnd, [ParamAttr]>;
 
 /// Parameter is required to be a trivial constant.
-def ImmArg : EnumAttr<"immarg", [ParamAttr]>;
+def ImmArg : EnumAttr<"immarg", IntersectPreserve, [ParamAttr]>;
 
 /// Function can return twice.
-def ReturnsTwice : EnumAttr<"returns_twice", [FnAttr]>;
+def ReturnsTwice : EnumAttr<"returns_twice", IntersectPreserve, [FnAttr]>;
 
 /// Safe Stack protection.
-def SafeStack : EnumAttr<"safestack", [FnAttr]>;
+def SafeStack : EnumAttr<"safestack", IntersectPreserve, [FnAttr]>;
 
 /// Shadow Call Stack protection.
-def ShadowCallStack : EnumAttr<"shadowcallstack", [FnAttr]>;
+def ShadowCallStack : EnumAttr<"shadowcallstack", IntersectPreserve, [FnAttr]>;
 
 /// Sign extended before/after call.
-def SExt : EnumAttr<"signext", [ParamAttr, RetAttr]>;
+def SExt : EnumAttr<"signext", IntersectPreserve, [ParamAttr, RetAttr]>;
 
 /// Alignment of stack for function (3 bits)  stored as log2 of alignment with
 /// +1 bias 0 means unaligned (different from alignstack=(1)).
-def StackAlignment : IntAttr<"alignstack", [FnAttr, ParamAttr]>;
+def StackAlignment : IntAttr<"alignstack", IntersectPreserve, [FnAttr, ParamAttr]>;
 
 /// Function can be speculated.
-def Speculatable : EnumAttr<"speculatable", [FnAttr, IntersectAnd]>;
+def Speculatable : EnumAttr<"speculatable", IntersectAnd, [FnAttr]>;
 
 /// Stack protection.
-def StackProtect : EnumAttr<"ssp", [FnAttr]>;
+def StackProtect : EnumAttr<"ssp", IntersectPreserve, [FnAttr]>;
 
 /// Stack protection required.
-def StackProtectReq : EnumAttr<"sspreq", [FnAttr]>;
+def StackProtectReq : EnumAttr<"sspreq", IntersectPreserve, [FnAttr]>;
 
 /// Strong Stack protection.
-def StackProtectStrong : EnumAttr<"sspstrong", [FnAttr]>;
+def StackProtectStrong : EnumAttr<"sspstrong", IntersectPreserve, [FnAttr]>;
 
 /// Function was called in a scope requiring strict floating point semantics.
-def StrictFP : EnumAttr<"strictfp", [FnAttr]>;
+def StrictFP : EnumAttr<"strictfp", IntersectPreserve, [FnAttr]>;
 
 /// Hidden pointer to structure to return.
-def StructRet : TypeAttr<"sret", [ParamAttr]>;
+def StructRet : TypeAttr<"sret", IntersectPreserve, [ParamAttr]>;
 
 /// AddressSanitizer is on.
-def SanitizeAddress : EnumAttr<"sanitize_address", [FnAttr]>;
+def SanitizeAddress : EnumAttr<"sanitize_address", IntersectPreserve, [FnAttr]>;
 
 /// ThreadSanitizer is on.
-def SanitizeThread : EnumAttr<"sanitize_thread", [FnAttr]>;
+def SanitizeThread : EnumAttr<"sanitize_thread", IntersectPreserve, [FnAttr]>;
 
 /// MemorySanitizer is on.
-def SanitizeMemory : EnumAttr<"sanitize_memory", [FnAttr]>;
+def SanitizeMemory : EnumAttr<"sanitize_memory", IntersectPreserve, [FnAttr]>;
 
 /// HWAddressSanitizer is on.
-def SanitizeHWAddress : EnumAttr<"sanitize_hwaddress", [FnAttr]>;
+def SanitizeHWAddress : EnumAttr<"sanitize_hwaddress", IntersectPreserve, [FnAttr]>;
 
 /// MemTagSanitizer is on.
-def SanitizeMemTag : EnumAttr<"sanitize_memtag", [FnAttr]>;
+def SanitizeMemTag : EnumAttr<"sanitize_memtag", IntersectPreserve, [FnAttr]>;
 
 /// NumericalStabilitySanitizer is on.
-def SanitizeNumericalStability : EnumAttr<"sanitize_numerical_stability", [FnAttr]>;
+def SanitizeNumericalStability : EnumAttr<"sanitize_numerical_stability", IntersectPreserve, [FnAttr]>;
 
 /// RealtimeSanitizer is on.
-def SanitizeRealtime : EnumAttr<"sanitize_realtime", [FnAttr]>;
+def SanitizeRealtime : EnumAttr<"sanitize_realtime", IntersectPreserve, [FnAttr]>;
 
 /// RealtimeSanitizer should error if a real-time unsafe function is invoked
 /// during a real-time sanitized function (see `sanitize_realtime`).
-def SanitizeRealtimeUnsafe : EnumAttr<"sanitize_realtime_unsafe", [FnAttr]>;
+def SanitizeRealtimeUnsafe : EnumAttr<"sanitize_realtime_unsafe", IntersectPreserve, [FnAttr]>;
 
 /// Speculative Load Hardening is enabled.
 ///
@@ -345,47 +347,48 @@ def SanitizeRealtimeUnsafe : EnumAttr<"sanitize_realtime_unsafe", [FnAttr]>;
 /// body will add the attribute to the caller. This ensures that code carrying
 /// this attribute will always be lowered with hardening enabled.
 def SpeculativeLoadHardening : EnumAttr<"speculative_load_hardening",
+                                        IntersectPreserve,
                                         [FnAttr]>;
 
 /// Argument is swift error.
-def SwiftError : EnumAttr<"swifterror", [ParamAttr]>;
+def SwiftError : EnumAttr<"swifterror", IntersectPreserve, [ParamAttr]>;
 
 /// Argument is swift self/context.
-def SwiftSelf : EnumAttr<"swiftself", [ParamAttr]>;
+def SwiftSelf : EnumAttr<"swiftself", IntersectPreserve, [ParamAttr]>;
 
 /// Argument is swift async context.
-def SwiftAsync : EnumAttr<"swiftasync", [ParamAttr]>;
+def SwiftAsync : EnumAttr<"swiftasync", IntersectPreserve, [ParamAttr]>;
 
 /// Function must be in a unwind table.
-def UWTable : IntAttr<"uwtable", [FnAttr]>;
+def UWTable : IntAttr<"uwtable", IntersectPreserve, [FnAttr]>;
 
 /// Minimum/Maximum vscale value for function.
-def VScaleRange : IntAttr<"vscale_range", [FnAttr]>;
+def VScaleRange : IntAttr<"vscale_range", IntersectPreserve, [FnAttr]>;
 
 /// Function always comes back to callsite.
-def WillReturn : EnumAttr<"willreturn", [FnAttr, IntersectAnd]>;
+def WillReturn : EnumAttr<"willreturn", IntersectAnd, [FnAttr]>;
 
 /// Pointer argument is writable.
-def Writable : EnumAttr<"writable", [ParamAttr, IntersectAnd]>;
+def Writable : EnumAttr<"writable", IntersectAnd, [ParamAttr]>;
 
 /// Function only writes to memory.
-def WriteOnly : EnumAttr<"writeonly", [ParamAttr, IntersectAnd]>;
+def WriteOnly : EnumAttr<"writeonly", IntersectAnd, [ParamAttr]>;
 
 /// Zero extended before/after call.
-def ZExt : EnumAttr<"zeroext", [ParamAttr, RetAttr]>;
+def ZExt : EnumAttr<"zeroext", IntersectPreserve, [ParamAttr, RetAttr]>;
 
 /// Function is required to make Forward Progress.
-def MustProgress : EnumAttr<"mustprogress", [FnAttr, IntersectAnd]>;
+def MustProgress : EnumAttr<"mustprogress", IntersectAnd, [FnAttr]>;
 
 /// Function is a presplit coroutine.
-def PresplitCoroutine : EnumAttr<"presplitcoroutine", [FnAttr]>;
+def PresplitCoroutine : EnumAttr<"presplitcoroutine", IntersectPreserve, [FnAttr]>;
 
 /// The coroutine would only be destroyed when it is complete.
-def CoroDestroyOnlyWhenComplete : EnumAttr<"coro_only_destroy_when_complete", [FnAttr]>;
+def CoroDestroyOnlyWhenComplete : EnumAttr<"coro_only_destroy_when_complete", IntersectPreserve, [FnAttr]>;
 
 /// The coroutine call meets the elide requirement. Hint the optimization
 /// pipeline to perform elide on the call or invoke instruction.
-def CoroElideSafe : EnumAttr<"coro_elide_safe", [FnAttr]>;
+def CoroElideSafe : EnumAttr<"coro_elide_safe", IntersectPreserve, [FnAttr]>;
 
 /// Target-independent string attributes.
 def LessPreciseFPMAD : StrBoolAttr<"less-precise-fpmad">;

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -115,6 +115,7 @@ def NoUndef : EnumAttr<"noundef", IntersectAnd, [ParamAttr, RetAttr]>;
 def Cold : EnumAttr<"cold", IntersectAnd, [FnAttr]>;
 
 /// Can only be moved to control-equivalent blocks.
+/// NB: Could be IntersectCustom with "or" handling.
 def Convergent : EnumAttr<"convergent", IntersectPreserve, [FnAttr]>;
 
 /// Marks function as being in a hot path and frequently called.

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -27,19 +27,11 @@ def RetAttr : AttrProperty;
 /// Intersection rules. Used for example in sinking/hoisting two
 /// callbases to find a set of attributes that apply to both.
 /// Note, there are some attributes we can (probably) legally drop
-/// but are intentionally excluded as of now. Those include:
-///     - initializes
-///     - allockind
-///     - allocsize
-///     - minsize
-///     - optsize
-///     - optnone
-///     - optdebug
-///     - optforfuzzing
+/// but are intentionally excluded as of now.
 ///
-/// When intersecting the attributes must both present and equal.
-/// Use this for attributes you are not certain it is safe to drop
-/// at any time. I.e `byval(Ty)` on a parameter.
+/// When intersecting the attributes both must be present and equal.
+/// Use this for attributes it is not safe to drop at any time. E.g.
+/// `byval(Ty)` on a parameter.
 def IntersectPreserve : AttrProperty;
 
 /// When intersecting take the AND of the two attrs.
@@ -123,7 +115,7 @@ def NoUndef : EnumAttr<"noundef", IntersectAnd, [ParamAttr, RetAttr]>;
 def Cold : EnumAttr<"cold", IntersectAnd, [FnAttr]>;
 
 /// Can only be moved to control-equivalent blocks.
-def Convergent : EnumAttr<"convergent", IntersectAnd, [FnAttr]>;
+def Convergent : EnumAttr<"convergent", IntersectPreserve, [FnAttr]>;
 
 /// Marks function as being in a hot path and frequently called.
 def Hot: EnumAttr<"hot", IntersectAnd, [FnAttr]>;

--- a/llvm/lib/IR/AttributeImpl.h
+++ b/llvm/lib/IR/AttributeImpl.h
@@ -86,6 +86,9 @@ public:
 
   ArrayRef<ConstantRange> getValueAsConstantRangeList() const;
 
+  /// Used to sort attributes. KindOnly controls if the sort includes the
+  /// attributes' values or just the kind.
+  int cmp(const AttributeImpl &AI, bool KindOnly) const;
   /// Used when sorting the attributes.
   bool operator<(const AttributeImpl &AI) const;
 

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -1039,6 +1039,8 @@ AttributeSet::intersectWith(LLVMContext &C, AttributeSet Other) const {
     if (Attribute::intersectWithCustom(Kind)) {
       switch (Kind) {
       case Attribute::Alignment:
+        // If `byval` is present, alignment become must-preserve. This is
+        // handled below if we have `byval`.
         Intersected.addAlignmentAttr(
             std::min(Attr0.getAlignment().valueOrOne(),
                      Attr1.getAlignment().valueOrOne()));

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -1804,7 +1804,6 @@ AttributeList::intersectWith(LLVMContext &C, AttributeList Other) const {
     return std::nullopt;
 
   SmallVector<std::pair<unsigned, AttributeSet>> IntersectedAttrs;
-  //  AttributeList IntersectedAttrs{};
   for (unsigned Idx : indexes()) {
     auto IntersectedAS =
         getAttributes(Idx).intersectWith(C, Other.getAttributes(Idx));

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -958,11 +958,10 @@ AttributeSet AttributeSet::removeAttributes(LLVMContext &C,
 
 std::optional<AttributeSet>
 AttributeSet::intersectWith(LLVMContext &C, AttributeSet Other) const {
-	//  return std::nullopt;
   if (*this == Other)
     return *this;
-  AttrBuilder Intersected(C);
 
+  AttrBuilder Intersected(C);
   // Iterate over both attr sets at once.
   auto ItBegin0 = begin();
   auto ItEnd0 = end();

--- a/llvm/unittests/IR/AttributesTest.cpp
+++ b/llvm/unittests/IR/AttributesTest.cpp
@@ -48,6 +48,8 @@ TEST(Attributes, Ordering) {
   EXPECT_TRUE(Align4 < Deref4);
   EXPECT_TRUE(Align4 < Deref5);
   EXPECT_TRUE(Align5 < Deref4);
+  EXPECT_EQ(Deref5.cmpKind(Deref4), 0);
+  EXPECT_EQ(Align4.cmpKind(Align5), 0);
 
   Attribute ByVal = Attribute::get(C, Attribute::ByVal, Type::getInt32Ty(C));
   EXPECT_FALSE(ByVal < Attribute::get(C, Attribute::ZExt));

--- a/llvm/utils/TableGen/Attributes.cpp
+++ b/llvm/utils/TableGen/Attributes.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
 #include "llvm/TableGen/TableGenBackend.h"
-#include "llvm/TableGen/Error.h"
 #include <vector>
 using namespace llvm;
 

--- a/llvm/utils/TableGen/Attributes.cpp
+++ b/llvm/utils/TableGen/Attributes.cpp
@@ -126,7 +126,7 @@ void Attributes::emitAttributeProperties(raw_ostream &OS) {
         if (!AllowIntersectAnd &&
             cast<DefInit>(P)->getDef()->getName() == "IntersectAnd")
           PrintFatalError(
-              "'IntersectAnd' only compatible with 'EnumAttr' or 'TypeAttr'");
+              "'IntersectAnd' only compatible with 'EnumAttr'");
         if (!AllowIntersectMin &&
             cast<DefInit>(P)->getDef()->getName() == "IntersectMin")
           PrintFatalError("'IntersectMin' only compatible with 'IntAttr'");

--- a/llvm/utils/TableGen/Attributes.cpp
+++ b/llvm/utils/TableGen/Attributes.cpp
@@ -125,8 +125,7 @@ void Attributes::emitAttributeProperties(raw_ostream &OS) {
       for (Init *P : *A->getValueAsListInit("Properties")) {
         if (!AllowIntersectAnd &&
             cast<DefInit>(P)->getDef()->getName() == "IntersectAnd")
-          PrintFatalError(
-              "'IntersectAnd' only compatible with 'EnumAttr'");
+          PrintFatalError("'IntersectAnd' only compatible with 'EnumAttr'");
         if (!AllowIntersectMin &&
             cast<DefInit>(P)->getDef()->getName() == "IntersectMin")
           PrintFatalError("'IntersectMin' only compatible with 'IntAttr'");


### PR DESCRIPTION
Add support for taking the intersection of two AttributeLists s.t the
result list contains attributes that are valid in the context of both
inputs.

i.e if we have `nonnull align(32) noundef` intersected with `nonnull
align(16) dereferenceable(10)`, the result is `nonnull align(16)`.

Further it handles attributes that are not-droppable. For example
dropping `byval` can change the nature of a callsite/function so its
impossible to correct a correct intersection if its dropped from the
result. i.e `nonnull byval(i64)` intersected with `nonnull` is
invalid.

The motivation for the infrastructure is to enable sinking/hoisting
callsites with differing attributes.
