### PR TITLE
[lldb][NFC] Add a missing setter method for UnwindPlans

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -370,6 +370,13 @@ public:
 
     bool SetRegisterLocationToSame(uint32_t reg_num, bool must_replace);
 
+    /// This method does not make a copy of the \a opcodes memory, it is
+    /// assumed to have the same lifetime as the Module this UnwindPlan will
+    /// be registered in.
+    bool SetRegisterLocationToIsDWARFExpression(uint32_t reg_num,
+                                                const uint8_t *opcodes,
+                                                uint32_t len, bool can_replace);
+
     bool SetRegisterLocationToIsConstant(uint32_t reg_num, uint64_t constant,
                                          bool can_replace);
 


### PR DESCRIPTION
The UnwindPlan class has getter and setter methods for specifying an abstract register location, but it doesn't have a setter for a DWARF Expression register location.  This hasn't been needed for any of the UnwindPlans that we do in mainline lldb yet, but it is used in the Swift language SwiftLanguageRuntime plugin which creates UnwindPlan for async functions.  While it's currently unused on main branch, this is a straightforward setter in the same form as the others, the only caveat being that it doesn't own the dwarf expression bytes, it has a pointer to them.