### PR TITLE
[OpenMP][Docs] Update OpenMP release notes with 'omp scope'

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -637,6 +637,7 @@ Python Binding Changes
 OpenMP Support
 --------------
 - Added support for 'omp assume' directive.
+- Added support for 'omp scope' directive.
 
 Improvements
 ^^^^^^^^^^^^


### PR DESCRIPTION
Release notes: added 'omp scope' directive to "OpenMP Support" section of "What's New in Clang"