### PR TITLE
[X86][APX] Do not emit {evex} prefix for memory variant

### DIFF
--- a/llvm/lib/Target/X86/X86InstrAVX512.td
+++ b/llvm/lib/Target/X86/X86InstrAVX512.td
@@ -2617,20 +2617,19 @@ defm VFPCLASS : avx512_fp_fpclass_all<"vfpclass", 0x66, 0x67, SchedWriteFCmp>, E
 multiclass avx512_mask_mov<bits<8> opc_kk, bits<8> opc_km, bits<8> opc_mk,
                           string OpcodeStr, RegisterClass KRC, ValueType vvt,
                           X86MemOperand x86memop, string Suffix = ""> {
-  let explicitOpPrefix = !if(!eq(Suffix, ""), NoExplicitOpPrefix, ExplicitEVEX) in {
-    let isMoveReg = 1, hasSideEffects = 0, SchedRW = [WriteMove] in
-    def kk#Suffix : I<opc_kk, MRMSrcReg, (outs KRC:$dst), (ins KRC:$src),
-                      !strconcat(OpcodeStr, "\t{$src, $dst|$dst, $src}"), []>,
-                    Sched<[WriteMove]>;
-    def km#Suffix : I<opc_km, MRMSrcMem, (outs KRC:$dst), (ins x86memop:$src),
-                      !strconcat(OpcodeStr, "\t{$src, $dst|$dst, $src}"),
-                      [(set KRC:$dst, (vvt (load addr:$src)))]>,
-                    Sched<[WriteLoad]>, NoCD8;
-    def mk#Suffix : I<opc_mk, MRMDestMem, (outs), (ins x86memop:$dst, KRC:$src),
-                      !strconcat(OpcodeStr, "\t{$src, $dst|$dst, $src}"),
-                      [(store KRC:$src, addr:$dst)]>,
-                    Sched<[WriteStore]>, NoCD8;
-  }
+  let isMoveReg = 1, hasSideEffects = 0, SchedRW = [WriteMove],
+      explicitOpPrefix = !if(!eq(Suffix, ""), NoExplicitOpPrefix, ExplicitEVEX) in
+  def kk#Suffix : I<opc_kk, MRMSrcReg, (outs KRC:$dst), (ins KRC:$src),
+                    !strconcat(OpcodeStr, "\t{$src, $dst|$dst, $src}"), []>,
+                  Sched<[WriteMove]>;
+  def km#Suffix : I<opc_km, MRMSrcMem, (outs KRC:$dst), (ins x86memop:$src),
+                    !strconcat(OpcodeStr, "\t{$src, $dst|$dst, $src}"),
+                    [(set KRC:$dst, (vvt (load addr:$src)))]>,
+                  Sched<[WriteLoad]>, NoCD8;
+  def mk#Suffix : I<opc_mk, MRMDestMem, (outs), (ins x86memop:$dst, KRC:$src),
+                    !strconcat(OpcodeStr, "\t{$src, $dst|$dst, $src}"),
+                    [(store KRC:$src, addr:$dst)]>,
+                  Sched<[WriteStore]>, NoCD8;
 }
 
 multiclass avx512_mask_mov_gpr<bits<8> opc_kr, bits<8> opc_rk,

--- a/llvm/test/MC/Disassembler/X86/apx/kmov.txt
+++ b/llvm/test/MC/Disassembler/X86/apx/kmov.txt
@@ -17,20 +17,20 @@
 # INTEL: {evex} kmovq	k2, k1
 0x62,0xf1,0xfc,0x08,0x90,0xd1
 
-# ATT:   {evex} kmovb   -16(%rax), %k0
-# INTEL: {evex} kmovb   k0, byte ptr [rax - 16]
+# ATT:   kmovb	-16(%rax), %k0
+# INTEL: kmovb	k0, byte ptr [rax - 16]
 0x62,0xf1,0x7d,0x08,0x90,0x40,0xf0
 
-# ATT:   {evex} kmovw   -16(%rax), %k0
-# INTEL: {evex} kmovw   k0, word ptr [rax - 16]
+# ATT:   kmovw	-16(%rax), %k0
+# INTEL: kmovw	k0, word ptr [rax - 16]
 0x62,0xf1,0x7c,0x08,0x90,0x40,0xf0
 
-# ATT:   {evex} kmovd   -16(%rax), %k0
-# INTEL: {evex} kmovd   k0, dword ptr [rax - 16]
+# ATT:   kmovd	-16(%rax), %k0
+# INTEL: kmovd	k0, dword ptr [rax - 16]
 0x62,0xf1,0xfd,0x08,0x90,0x40,0xf0
 
-# ATT:   {evex} kmovq   -16(%rax), %k0
-# INTEL: {evex} kmovq   k0, qword ptr [rax - 16]
+# ATT:   kmovq	-16(%rax), %k0
+# INTEL: kmovq	k0, qword ptr [rax - 16]
 0x62,0xf1,0xfc,0x08,0x90,0x40,0xf0
 
 # ATT-NOT: {evex}


### PR DESCRIPTION
This was mistakely changed by #109579, which doesn't match with other EVEX decoding.