### PR TITLE
[lldb] Fix error reporting in SBTarget::ReadMemory

### DIFF
--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -662,15 +662,14 @@ size_t SBTarget::ReadMemory(const SBAddress addr, void *buf, size_t size,
                             lldb::SBError &error) {
   LLDB_INSTRUMENT_VA(this, addr, buf, size, error);
 
-  SBError sb_error;
   size_t bytes_read = 0;
   TargetSP target_sp(GetSP());
   if (target_sp) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     bytes_read =
-        target_sp->ReadMemory(addr.ref(), buf, size, sb_error.ref(), true);
+        target_sp->ReadMemory(addr.ref(), buf, size, error.ref(), true);
   } else {
-    sb_error.SetErrorString("invalid target");
+    error.SetErrorString("invalid target");
   }
 
   return bytes_read;

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -153,6 +153,11 @@ class TargetAPITestCase(TestBase):
         self.assertSuccess(error, "Make sure memory read succeeded")
         self.assertEqual(len(content), 1)
 
+        # Make sure reading from 0x0 fails
+        sb_addr = lldb.SBAddress(0, target)
+        self.assertIsNone(target.ReadMemory(sb_addr, 1, error))
+        self.assertTrue(error.Fail())
+
     @skipIfWindows  # stdio manipulation unsupported on Windows
     @skipIfRemote  # stdio manipulation unsupported on remote iOS devices<rdar://problem/54581135>
     @skipIf(oslist=["linux"], archs=["arm", "aarch64"])


### PR DESCRIPTION
The function should use the by-ref SBError argument instead of creating a new one. This code has been here since ~forever, and was probably copied from methods which return an SBError result (where one needs to create a local variable).