### PR TITLE
[ASan][test] XFAIL stack overflow tests on Linux/sparc64

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/stack-overflow-recovery-mode.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/stack-overflow-recovery-mode.cpp
@@ -3,6 +3,9 @@
 // RUN: %clang_asan -O0 -fsanitize-recover=address %s -o %t
 // RUN: %env_asan_opts=halt_on_error=false not %run %t 2>&1 | FileCheck %s
 
+// Issue #109771
+// XFAIL: target={{sparc.*-.*-linux.*}}
+
 #include <assert.h>
 #include <unistd.h>
 #include <sys/mman.h>

--- a/compiler-rt/test/asan/TestCases/Linux/stack-overflow-sigbus.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/stack-overflow-sigbus.cpp
@@ -2,6 +2,9 @@
 
 // RUN: %clangxx_asan -O0 %s -o %t && %env_asan_opts=use_sigaltstack=1 not %run %t 2>&1 | FileCheck %s
 
+// Issue #109771
+// XFAIL: target={{sparc.*-.*-linux.*}}
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/asan/TestCases/Posix/stack-overflow.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/stack-overflow.cpp
@@ -16,6 +16,9 @@
 // RUN: not %run %t 2>&1 | FileCheck %s
 // REQUIRES: stable-runtime
 
+// Issue #109771
+// XFAIL: target={{sparc.*-.*-linux.*}}
+
 // UNSUPPORTED: ios
 
 #include <assert.h>


### PR DESCRIPTION
When enabling ASan SPARC testing as per PR #107405, 3 stack overflow tests `FAIL` on Linux/sparc64:
```
  AddressSanitizer-sparc-linux :: TestCases/Linux/stack-overflow-recovery-mode.cpp
  AddressSanitizer-sparc-linux :: TestCases/Linux/stack-overflow-sigbus.cpp
  AddressSanitizer-sparc-linux :: TestCases/Posix/stack-overflow.cpp
  AddressSanitizer-sparc-linux-dynamic :: TestCases/Linux/stack-overflow-recovery-mode.cpp
  AddressSanitizer-sparc-linux-dynamic :: TestCases/Linux/stack-overflow-sigbus.cpp
  AddressSanitizer-sparc-linux-dynamic :: TestCases/Posix/stack-overflow.cpp
```
However, as detailed in Issue #109771, even a Linux equivalent of the Solaris/sparcv9 fix (PR #109101) doesn't improve the situation.

Therefore this patch `XFAIL`s the tests until the root cause can be figured out.

Tested on `sparc64-unknown-linux-gnu`, `sparcv9-sun-solaris2.11`, and `x86_64-pc-linux-gnu`.