### PR TITLE
[Flang][OpenMP] Fixed semantic error when list item with a private da…

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1542,8 +1542,15 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPBlockConstruct &x) {
   }
   if (beginDir.v == llvm::omp::Directive::OMPD_master)
     IssueNonConformanceWarning(beginDir.v, beginDir.source);
-  ClearDataSharingAttributeObjects();
-  ClearPrivateDataSharingAttributeObjects();
+
+  // The omp_taskgroup directive doesn't have its own data-sharing clauses.
+  // It inherits data-sharing attributes from the surrounding context.
+  // Therefore, don't clear the data-sharing attributes if it's an omp taskgroup
+  if (beginDir.v != llvm::omp::Directive::OMPD_taskgroup) {
+    ClearDataSharingAttributeObjects();
+    ClearPrivateDataSharingAttributeObjects();
+  }
+
   ClearAllocateNames();
   return true;
 }

--- a/flang/test/Semantics/OpenMP/omp_taskgroup_allocate.f90
+++ b/flang/test/Semantics/OpenMP/omp_taskgroup_allocate.f90
@@ -1,0 +1,12 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=50 -fsyntax-only %s
+
+! Verify that a list item with a private data-sharing clause used in the 'allocate' clause of 'taskgroup'
+! causes no semantic errors.
+
+subroutine omp_allocate_taskgroup
+   integer :: x
+   !$omp parallel private(x)
+   !$omp taskgroup allocate(x)
+   !$omp end taskgroup
+   !$omp end parallel
+end subroutine


### PR DESCRIPTION
…ta-sharing clause used in 'allocate' clause of 'taskgroup' construct.

Issue: A list item with a private data-sharing clause used in 'allocate' clause of 'taskgroup' construct throws an error "The ALLOCATE clause requires that 'x' must be listed in a private data-sharing attribute clause on the same directive"

Fix: As omp_taskgroup doesn't accept data sharing clauses, the list item in the allocate clause should accept the data sharing clause of list items from the enclosing directive.