### PR TITLE
[AMDGPU] Fix has_single_bit assertion for Mask in SIInstrInfo

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -9793,7 +9793,7 @@ bool SIInstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
 
     // A valid Mask is required to have a single bit set, hence a non-zero and
     // power-of-two value. This verifies that we will not do 64-bit shift below.
-    assert(llvm::has_single_bit(Mask) && "Invalid mask.");
+    assert(llvm::has_single_bit<uint64_t>(Mask) && "Invalid mask.");
     unsigned BitNo = llvm::countr_zero((uint64_t)Mask);
     if (IsSigned && BitNo == SrcSize - 1)
       return false;


### PR DESCRIPTION
Convert the `int64_t` Mask to `uint64_t` for `llvm::has_single_bit` to compile.