### PR TITLE
[llvm][cmake] Error when a runtime is in LLVM_ENABLE_PROJECTS and LLVM_ENABLE_RUNTIMES

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -161,6 +161,12 @@ foreach(proj IN LISTS LLVM_ENABLE_RUNTIMES)
   endif()
 endforeach()
 
+foreach(proj IN LISTS LLVM_ENABLE_RUNTIMES)
+  if ("${proj}" IN_LIST LLVM_ENABLE_PROJECTS)
+    message(FATAL_ERROR "Runtime project \"${proj}\" found in LLVM_ENABLE_PROJECTS and LLVM_ENABLE_RUNTIMES. It must only appear in one of them and that one should almost always be LLVM_ENABLE_RUNTIMES.")
+  endif()
+endforeach()
+
 # Set a shorthand option to enable the GPU build of the 'libc' project.
 option(LIBC_GPU_BUILD "Enable the 'libc' project targeting the GPU" OFF)
 if(LIBC_GPU_BUILD)


### PR DESCRIPTION
The documentation tells you not to do this:
https://llvm.org/docs/CMake.html#llvm-related-variables

But until now we did not enforce it.

```
$ cmake ../llvm-project/llvm/ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="pstl" -DLLVM_ENABLE_RUNTIMES="libcxx;pstl"
```
```
CMake Error at CMakeLists.txt:166 (message):
  Runtime project "pstl" found in LLVM_ENABLE_PROJECTS and
  LLVM_ENABLE_RUNTIMES.  It must only appear in one of them and that one
  should almost always be LLVM_ENABLE_RUNTIMES.
```