### PR TITLE
[PS4,PS5][Driver] Pass `-L<...>/target/lib -L.` to linker

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -186,6 +186,9 @@ void tools::PS4cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs))
     TC.addSanitizerArgs(Args, CmdArgs, "-l", "");
 
+  // Other drivers typically add library search paths (`-L`) here via
+  // TC.AddFilePathLibArgs(). We don't do that on PS4 as the PS4 linker
+  // searches those locations by default.
   Args.addAllArgs(CmdArgs, {options::OPT_L, options::OPT_T_Group,
                             options::OPT_s, options::OPT_t});
 
@@ -290,6 +293,7 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs))
     TC.addSanitizerArgs(Args, CmdArgs, "-l", "");
 
+  TC.AddFilePathLibArgs(Args, CmdArgs);
   Args.addAllArgs(CmdArgs, {options::OPT_L, options::OPT_T_Group,
                             options::OPT_s, options::OPT_t});
 
@@ -382,6 +386,8 @@ toolchains::PS4PS5Base::PS4PS5Base(const Driver &D, const llvm::Triple &Triple,
     llvm::sys::path::append(Dir, "target/include");
     CheckSDKPartExists(Dir, "system headers");
   }
+
+  getFilePaths().push_back(".");
 }
 
 void toolchains::PS4PS5Base::AddClangSystemIncludeArgs(

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -58,14 +58,15 @@
 // Test that <sdk-root>/target/lib is added to library search paths, if it
 // exists and no --sysroot is specified.
 
-// RUN: rm -rf %t.dir && mkdir -p %t.dir/target/lib
+// RUN: rm -rf %t.dir && mkdir %t.dir
+// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
+// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### --sysroot=%t.dir 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
+
+// CHECK-NO-TARGETLIB: {{ld(\.exe)?}}"
+// CHECK-NO-TARGETLIB-NOT: "-L{{.*[/\\]}}target/lib"
+
+// RUN: mkdir -p %t.dir/target/lib
 // RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
 
 // CHECK-TARGETLIB: {{ld(\.exe)?}}"
 // CHECK-TARGETLIB-SAME: "-L{{.*[/\\]}}target/lib"
-
-// RUN: env SCE_PROSPERO_SDK_DIR=missing %clang --target=x64_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
-// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### --sysroot=missing 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
-
-// CHECK-NO-TARGETLIB: {{ld(\.exe)?}}"
-// CHECK-NO-TARGETLIB-NOT: "-L{{.*[/\\]}}target/lib"

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -46,3 +46,26 @@
 
 // CHECK-SYSROOT: {{ld(\.exe)?}}"
 // CHECK-SYSROOT-SAME: "--sysroot=mysdk"
+
+// Test that "." is always added to library search paths. This is long-standing
+// behavior, unique to PlayStation toolchains.
+
+// RUN: %clang --target=x64_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-LDOT %s
+
+// CHECK-LDOT: {{ld(\.exe)?}}"
+// CHECK-LDOT-SAME: "-L."
+
+// Test that <sdk-root>/target/lib is added to library search paths, if it
+// exists and no --sysroot is specified.
+
+// RUN: rm -rf %t.dir && mkdir -p %t.dir/target/lib
+// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
+
+// CHECK-TARGETLIB: {{ld(\.exe)?}}"
+// CHECK-TARGETLIB-SAME: "-L{{.*[/\\]}}target/lib"
+
+// RUN: env SCE_PROSPERO_SDK_DIR=missing %clang --target=x64_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
+// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### --sysroot=missing 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
+
+// CHECK-NO-TARGETLIB: {{ld(\.exe)?}}"
+// CHECK-NO-TARGETLIB-NOT: "-L{{.*[/\\]}}target/lib"


### PR DESCRIPTION
The proprietary PS4 linker implicitly adds `=/target/lib` and `.` as library search paths. This behaviour was added to the PS5 linker via a downstream patch in LLD. This really belongs in the driver, instead. This change adds the driver behaviour to allow removal of the downstream patch in LLD.

There are no plans to update the PS4 linker behaviour in the analogous way, so do not pass the same search paths to the PS4 linker.

SIE tracker: TOOLCHAIN-16704