### PR TITLE
[NFC][TableGen] Adopt scaled indent in PredicateExpander

### DIFF
--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -797,6 +797,30 @@ struct indent {
     assert(NumIndents >= N && "Indentation undeflow");
     return indent(NumIndents - N, Scale);
   }
+  indent &operator++() { // Prefix ++.
+    ++NumIndents;
+    return *this;
+  }
+  indent operator++(int) { // Postfix ++.
+    indent Old = *this;
+    ++NumIndents;
+    return Old;
+  }
+  indent &operator--() { // Prefix --.
+    assert(NumIndents >= 1);
+    --NumIndents;
+    return *this;
+  }
+  indent operator--(int) { // Postfix --.
+    indent Old = *this;
+    assert(NumIndents >= 1);
+    --NumIndents;
+    return Old;
+  }
+  indent &operator=(unsigned N) {
+    NumIndents = N;
+    return *this;
+  }
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const indent &Indent) {

--- a/llvm/unittests/Support/raw_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_ostream_test.cpp
@@ -198,6 +198,26 @@ TEST(raw_ostreamTest, Indent) {
   EXPECT_EQ(Spaces(10), printToString(Scaled));
   Scaled -= 1;
   EXPECT_EQ(Spaces(8), printToString(Scaled));
+
+  // Operators.
+  Indent = 10;
+  EXPECT_EQ(Spaces(10), printToString(Indent));
+
+  indent Temp = Indent++;
+  EXPECT_EQ(Spaces(11), printToString(Indent));
+  EXPECT_EQ(Spaces(10), printToString(Temp));
+
+  Temp = Indent--;
+  EXPECT_EQ(Spaces(10), printToString(Indent));
+  EXPECT_EQ(Spaces(11), printToString(Temp));
+
+  Temp = ++Indent;
+  EXPECT_EQ(Spaces(11), printToString(Indent));
+  EXPECT_EQ(Spaces(11), printToString(Temp));
+
+  Temp = --Indent;
+  EXPECT_EQ(Spaces(10), printToString(Indent));
+  EXPECT_EQ(Spaces(10), printToString(Temp));
 }
 
 TEST(raw_ostreamTest, FormatHex) {  

--- a/llvm/utils/TableGen/Common/PredicateExpander.h
+++ b/llvm/utils/TableGen/Common/PredicateExpander.h
@@ -18,39 +18,38 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
 
-class raw_ostream;
 class Record;
 
 class PredicateExpander {
   bool EmitCallsByRef;
   bool NegatePredicate;
   bool ExpandForMC;
-  unsigned IndentLevel;
   StringRef TargetName;
 
   PredicateExpander(const PredicateExpander &) = delete;
   PredicateExpander &operator=(const PredicateExpander &) = delete;
 
+protected:
+  indent Indent;
+
 public:
-  PredicateExpander(StringRef Target)
+  explicit PredicateExpander(StringRef Target, unsigned Indent = 1)
       : EmitCallsByRef(true), NegatePredicate(false), ExpandForMC(false),
-        IndentLevel(1U), TargetName(Target) {}
+        TargetName(Target), Indent(Indent, 2) {}
   bool isByRef() const { return EmitCallsByRef; }
   bool shouldNegate() const { return NegatePredicate; }
   bool shouldExpandForMC() const { return ExpandForMC; }
-  unsigned getIndentLevel() const { return IndentLevel; }
+  indent &getIndent() { return Indent; }
   StringRef getTargetName() const { return TargetName; }
 
   void setByRef(bool Value) { EmitCallsByRef = Value; }
   void flipNegatePredicate() { NegatePredicate = !NegatePredicate; }
   void setNegatePredicate(bool Value) { NegatePredicate = Value; }
   void setExpandForMC(bool Value) { ExpandForMC = Value; }
-  void setIndentLevel(unsigned Level) { IndentLevel = Level; }
-  void increaseIndentLevel() { ++IndentLevel; }
-  void decreaseIndentLevel() { --IndentLevel; }
 
   void expandTrue(raw_ostream &OS);
   void expandFalse(raw_ostream &OS);
@@ -116,8 +115,8 @@ class STIPredicateExpander : public PredicateExpander {
   void expandEpilogue(raw_ostream &OS, const STIPredicateFunction &Fn);
 
 public:
-  STIPredicateExpander(StringRef Target)
-      : PredicateExpander(Target), ExpandDefinition(false) {}
+  explicit STIPredicateExpander(StringRef Target, unsigned Indent = 1)
+      : PredicateExpander(Target, Indent), ExpandDefinition(false) {}
 
   bool shouldExpandDefinition() const { return ExpandDefinition; }
   StringRef getClassPrefix() const { return ClassPrefix; }

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -711,7 +711,7 @@ void InstrInfoEmitter::emitMCIIHelperMethods(raw_ostream &OS,
     OS << "bool " << Rec->getValueAsString("FunctionName");
     OS << "(const MCInst &MI) {\n";
 
-    OS.indent(PE.getIndentLevel() * 2);
+    OS << PE.getIndent();
     PE.expandStatement(OS, Rec->getValueAsDef("Body"));
     OS << "\n}\n\n";
   }
@@ -914,7 +914,7 @@ void InstrInfoEmitter::emitTIIHelperMethods(raw_ostream &OS,
     }
 
     OS << " {\n";
-    OS.indent(PE.getIndentLevel() * 2);
+    OS << PE.getIndent();
     PE.expandStatement(OS, Rec->getValueAsDef("Body"));
     OS << "\n}\n\n";
   }

--- a/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
+++ b/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
@@ -160,7 +160,7 @@ void MacroFusionPredicatorEmitter::emitFirstPredicate(const Record *Predicate,
     OS.indent(4) << "const MachineInstr *MI = FirstMI;\n";
     OS.indent(4) << "if (";
     PE.setNegatePredicate(true);
-    PE.setIndentLevel(3);
+    PE.getIndent() = 3;
     PE.expandPredicate(OS, Predicate->getValueAsDef("Predicate"));
     OS << ")\n";
     OS.indent(4) << "  return false;\n";
@@ -181,7 +181,7 @@ void MacroFusionPredicatorEmitter::emitSecondPredicate(const Record *Predicate,
     OS.indent(4) << "const MachineInstr *MI = &SecondMI;\n";
     OS.indent(4) << "if (";
     PE.setNegatePredicate(true);
-    PE.setIndentLevel(3);
+    PE.getIndent() = 3;
     PE.expandPredicate(OS, Predicate->getValueAsDef("Predicate"));
     OS << ")\n";
     OS.indent(4) << "  return false;\n";

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1576,13 +1576,13 @@ static void emitPredicates(const CodeGenSchedTransition &T,
   unsigned NumNonTruePreds =
       T.PredTerm.size() - count_if(T.PredTerm, isTruePredicate);
 
-  SS.indent(PE.getIndentLevel() * 2);
+  SS << PE.getIndent();
 
   if (NumNonTruePreds) {
     bool FirstNonTruePredicate = true;
     SS << "if (";
 
-    PE.setIndentLevel(PE.getIndentLevel() + 2);
+    PE.getIndent() += 2;
 
     for (const Record *Rec : T.PredTerm) {
       // Skip predicates that evaluate to "true".
@@ -1593,7 +1593,7 @@ static void emitPredicates(const CodeGenSchedTransition &T,
         FirstNonTruePredicate = false;
       } else {
         SS << "\n";
-        SS.indent(PE.getIndentLevel() * 2);
+        SS << PE.getIndent();
         SS << "&& ";
       }
 
@@ -1610,9 +1610,9 @@ static void emitPredicates(const CodeGenSchedTransition &T,
     }
 
     SS << ")\n"; // end of if-stmt
-    PE.decreaseIndentLevel();
-    SS.indent(PE.getIndentLevel() * 2);
-    PE.decreaseIndentLevel();
+    --PE.getIndent();
+    SS << PE.getIndent();
+    --PE.getIndent();
   }
 
   SS << "return " << T.ToClassIdx << "; // " << SC.Name << '\n';
@@ -1736,7 +1736,7 @@ void SubtargetEmitter::emitSchedModelHelpersImpl(
           FinalT = &T;
           continue;
         }
-        PE.setIndentLevel(3);
+        PE.getIndent() = 3;
         emitPredicates(T, SchedModels.getSchedClass(T.ToClassIdx), PE, OS);
       }
       if (FinalT)
@@ -1780,11 +1780,10 @@ void SubtargetEmitter::EmitSchedModelHelpers(const std::string &ClassName,
      << "::resolveVariantSchedClassImpl(SchedClass, MI, MCII, CPUID);\n"
      << "} // " << ClassName << "::resolveVariantSchedClass\n\n";
 
-  STIPredicateExpander PE(Target);
+  STIPredicateExpander PE(Target, /*Indent=*/0);
   PE.setClassPrefix(ClassName);
   PE.setExpandDefinition(true);
   PE.setByRef(false);
-  PE.setIndentLevel(0);
 
   for (const STIPredicateFunction &Fn : SchedModels.getSTIPredicates())
     PE.expandSTIPredicate(OS, Fn);
@@ -1962,7 +1961,7 @@ void SubtargetEmitter::EmitMCInstrAnalysisPredicateFunctions(raw_ostream &OS) {
   OS << "\n#ifdef GET_STIPREDICATE_DECLS_FOR_MC_ANALYSIS\n";
   OS << "#undef GET_STIPREDICATE_DECLS_FOR_MC_ANALYSIS\n\n";
 
-  STIPredicateExpander PE(Target);
+  STIPredicateExpander PE(Target, /*Indent=*/0);
   PE.setExpandForMC(true);
   PE.setByRef(true);
   for (const STIPredicateFunction &Fn : SchedModels.getSTIPredicates())
@@ -1976,7 +1975,6 @@ void SubtargetEmitter::EmitMCInstrAnalysisPredicateFunctions(raw_ostream &OS) {
   std::string ClassPrefix = Target + "MCInstrAnalysis";
   PE.setExpandDefinition(true);
   PE.setClassPrefix(ClassPrefix);
-  PE.setIndentLevel(0);
   for (const STIPredicateFunction &Fn : SchedModels.getSTIPredicates())
     PE.expandSTIPredicate(OS, Fn);
 


### PR DESCRIPTION
Adopt scaled indent in PredicateExpander.
Added pre/post inc/dec operators to `indent` and related unit tests.
Verified by comparing *.inc files generated by LLVM build with/without the change.