### PR TITLE
[libc][bazel] Remove specializations from libc_math_function.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1825,26 +1825,11 @@ libc_math_function(
     ],
 )
 
-libc_math_function(
-    name = "ceil",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "ceil")
 
-libc_math_function(
-    name = "ceilf",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "ceilf")
 
-libc_math_function(
-    name = "ceill",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "ceill")
 
 libc_math_function(name = "ceilf128")
 
@@ -2126,19 +2111,9 @@ libc_math_function(
     ],
 )
 
-libc_math_function(
-    name = "floor",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "floor")
 
-libc_math_function(
-    name = "floorf",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "floorf")
 
 libc_math_function(name = "floorl")
 
@@ -2639,19 +2614,9 @@ libc_math_function(name = "rintl")
 
 libc_math_function(name = "rintf128")
 
-libc_math_function(
-    name = "round",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "round")
 
-libc_math_function(
-    name = "roundf",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "roundf")
 
 libc_math_function(name = "roundl")
 
@@ -2850,19 +2815,9 @@ libc_math_function(name = "totalordermagl")
 
 libc_math_function(name = "totalordermagf128")
 
-libc_math_function(
-    name = "trunc",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "trunc")
 
-libc_math_function(
-    name = "truncf",
-    specializations = [
-        "generic",
-    ],
-)
+libc_math_function(name = "truncf")
 
 libc_math_function(name = "truncl")
 

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -129,7 +129,6 @@ def libc_function(
 
 def libc_math_function(
         name,
-        specializations = None,
         additional_deps = None):
     """Add a target for a math function.
 
@@ -142,14 +141,6 @@ def libc_math_function(
                        math function.
     """
     additional_deps = additional_deps or []
-    specializations = specializations or ["generic"]
-    select_map = {}
-    if "generic" in specializations:
-        select_map["//conditions:default"] = ["src/math/generic/" + name + ".cpp"]
-    if "aarch64" in specializations:
-        select_map[PLATFORM_CPU_ARM64] = ["src/math/aarch64/" + name + ".cpp"]
-    if "x86_64" in specializations:
-        select_map[PLATFORM_CPU_X86_64] = ["src/math/x86_64/" + name + ".cpp"]
 
     #TODO(michaelrj): Fix the floating point dependencies
     OLD_FPUTIL_DEPS = [
@@ -166,7 +157,7 @@ def libc_math_function(
     ]
     libc_function(
         name = name,
-        srcs = selects.with_or(select_map),
+        srcs = ["src/math/generic/" + name + ".cpp"],
         hdrs = ["src/math/" + name + ".h"],
         deps = [":__support_common"] + OLD_FPUTIL_DEPS + additional_deps,
     )


### PR DESCRIPTION
There are no more specializations `libc/src/math/x86_64` or `libc/src/math/aarch64` anymore.  All implementations are going through the generic implementation.