### PR TITLE
[lld][WebAssembly] Don't report relocation error when linking with -r/--relocatable

### DIFF
--- a/lld/test/wasm/unsupported-pic-relocations.s
+++ b/lld/test/wasm/unsupported-pic-relocations.s
@@ -15,6 +15,10 @@
 # RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
 # RUN:   FileCheck %s
 
+## These errors should not be reported under -r/--relocation (i.e. when
+## generating an object file)
+# RUN: wasm-ld --experimental-pic -r %t.o -o /dev/null
+
 .functype external_func () -> ()
 
 use_undefined_function:
@@ -23,7 +27,7 @@ use_undefined_function:
     # CHECK: error: {{.*}}.o: relocation R_WASM_TABLE_INDEX_REL_SLEB is not supported against an undefined symbol `external_func`
     drop
     end_function
-    
+
 use_undefined_data:
     .functype use_undefined_data () -> ()
     i32.const external_data@MBREL

--- a/lld/test/wasm/unsupported-pic-relocations64.s
+++ b/lld/test/wasm/unsupported-pic-relocations64.s
@@ -15,6 +15,10 @@
 # RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
 # RUN:   FileCheck %s
 
+## These errors should not be reported under -r/--relocation (i.e. when
+## generating an object file)
+# RUN: wasm-ld -mwasm64 --experimental-pic -r %t.o -o /dev/null
+
 .functype external_func () -> ()
 
 use_undefined_function:
@@ -23,7 +27,7 @@ use_undefined_function:
     # CHECK: error: {{.*}}.o: relocation R_WASM_TABLE_INDEX_REL_SLEB64 is not supported against an undefined symbol `external_func`
     drop
     end_function
-    
+
 use_undefined_data:
     .functype use_undefined_data () -> ()
     i64.const external_data@MBREL

--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -173,7 +173,7 @@ void scanRelocations(InputChunk *chunk) {
       }
     }
 
-    if (sym->isUndefined()) {
+    if (!config->relocatable && sym->isUndefined()) {
       switch (reloc.Type) {
       case R_WASM_TABLE_INDEX_REL_SLEB:
       case R_WASM_TABLE_INDEX_REL_SLEB64:
@@ -187,11 +187,11 @@ void scanRelocations(InputChunk *chunk) {
               toString(*sym) + "`");
         break;
       }
-    }
 
-    if (sym->isUndefined() && !config->relocatable && !sym->isWeak()) {
-      // Report undefined symbols
-      reportUndefined(file, sym);
+      if (!sym->isWeak()) {
+        // Report undefined symbols
+        reportUndefined(file, sym);
+      }
     }
   }
 }


### PR DESCRIPTION
Followup to #104926.

We ran into issues on the emscripten waterfall where relocation against `__dso_handle` were being reported as errors even though `-r/--relocatable` was being used to generate object file output rather than executable output.