### PR TITLE
[SystemZ][z/OS] z/OS does not support nanosleep, use usleep instead

### DIFF
--- a/llvm/unittests/Support/TimerTest.cpp
+++ b/llvm/unittests/Support/TimerTest.cpp
@@ -27,7 +27,12 @@ void SleepMS() {
   struct timespec Interval;
   Interval.tv_sec = 0;
   Interval.tv_nsec = 1000000;
+#if defined(__MVS__)
+  long Microseconds = (Interval.tv_nsec + 999) / 1000;
+  usleep(Microseconds);
+#else
   nanosleep(&Interval, nullptr);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Use usleep instead of nanosleep to resolve a build error on z/OS because there is no support for nanosleep.