### PR TITLE
[LLVM][TableGen] Check name conflicts between target dep and independent intrinsics 

### DIFF
--- a/llvm/test/TableGen/intrinsic-target-prefix-for-target-independent.td
+++ b/llvm/test/TableGen/intrinsic-target-prefix-for-target-independent.td
@@ -1,0 +1,9 @@
+// RUN: not llvm-tblgen -gen-intrinsic-enums -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s
+
+include "llvm/IR/Intrinsics.td"
+
+// Check that target independent intrinsics with a prefix that matches a target
+// name are flagged.
+// CHECK: [[FILE]]:[[@LINE+1]]:5: error: target independent intrinsic `llvm.aarch64.foo' has prefix `llvm.aarch64` that conflicts with intrinsics for target `aarch64`
+def int_aarch64_foo : Intrinsic<[],[]>;
+

--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
@@ -192,6 +192,7 @@ public:
 
 private:
   void CheckDuplicateIntrinsics() const;
+  void CheckTargetIndependentIntrinsics() const;
 };
 
 // This class builds `CodeGenIntrinsic` on demand for a given Def.


### PR DESCRIPTION
Validate that for target independent intrinsics the second dotted component of their name (after the `llvm.`) does not match any existing target names (for which atleast one intrinsic has been defined). Doing so is invalid as LLVM will search for that intrinsic in that target's intrinsic table and not find it, and conclude that its an unknown intrinsic.