### PR TITLE
[clang][bytecode] Fix diagnosing std::construct_at with wrong type

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.cpp
+++ b/clang/lib/AST/ByteCode/Descriptor.cpp
@@ -389,12 +389,17 @@ Descriptor::Descriptor(const DeclTy &D)
 }
 
 QualType Descriptor::getType() const {
-  if (const auto *E = asExpr())
-    return E->getType();
   if (const auto *D = asValueDecl())
     return D->getType();
-  if (const auto *T = dyn_cast<TypeDecl>(asDecl()))
+  if (const auto *T = dyn_cast_if_present<TypeDecl>(asDecl()))
     return QualType(T->getTypeForDecl(), 0);
+
+  // The Source sometimes has a different type than the once
+  // we really save. Try to consult the Record first.
+  if (isRecord())
+    return QualType(ElemRecord->getDecl()->getTypeForDecl(), 0);
+  if (const auto *E = asExpr())
+    return E->getType();
   llvm_unreachable("Invalid descriptor type");
 }
 

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1296,10 +1296,6 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
   if (!InvalidNewDeleteExpr(S, OpPC, E))
     return false;
 
-  // Assume proper types in std functions.
-  if (S.Current->isStdFunction())
-    return true;
-
   const auto *NewExpr = cast<CXXNewExpr>(E);
   QualType StorageType = Ptr.getType();
 

--- a/clang/test/AST/ByteCode/placement-new.cpp
+++ b/clang/test/AST/ByteCode/placement-new.cpp
@@ -13,7 +13,8 @@ namespace std {
   };
   template<typename T, typename ...Args>
   constexpr void construct_at(void *p, Args &&...args) {
-    new (p) T((Args&&)args...); // both-note {{in call to}}
+    new (p) T((Args&&)args...); // both-note {{in call to}} \
+                                // both-note {{placement new would change type of storage from 'int' to 'float'}}
   }
 }
 
@@ -259,5 +260,14 @@ namespace ConstructAt {
   }
   static_assert(ctorFail()); // both-error {{not an integral constant expression}} \
                              // both-note {{in call to 'ctorFail()'}}
+
+
+  constexpr bool bad_construct_at_type() {
+    int a;
+    std::construct_at<float>(&a, 1.0f); // both-note {{in call to}}
+    return true;
+  }
+  static_assert(bad_construct_at_type()); // both-error {{not an integral constant expression}} \
+                                          // both-note {{in call}}
 
 }


### PR DESCRIPTION
We can't make the assumption that types are always fine in std functions.