### PR TITLE
[rtsan] Introduce halt_on_error flag

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -44,7 +44,7 @@ static InitializationState GetInitializationState() {
       atomic_load(&rtsan_initialized, memory_order_acquire));
 }
 
-static auto DefaultErrorAction(DiagnosticsInfo info) {
+static auto OnViolationAction(DiagnosticsInfo info) {
   return [info]() {
     __rtsan::PrintDiagnostics(info);
     if (flags().halt_on_error)
@@ -107,8 +107,8 @@ __rtsan_notify_intercepted_call(const char *func_name) {
   __rtsan_ensure_initialized();
   GET_CALLER_PC_BP;
   ExpectNotRealtime(GetContextForThisThread(),
-                    DefaultErrorAction({DiagnosticsInfoType::InterceptedCall,
-                                        func_name, pc, bp}));
+                    OnViolationAction({DiagnosticsInfoType::InterceptedCall,
+                                       func_name, pc, bp}));
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE void
@@ -116,8 +116,8 @@ __rtsan_notify_blocking_call(const char *func_name) {
   __rtsan_ensure_initialized();
   GET_CALLER_PC_BP;
   ExpectNotRealtime(GetContextForThisThread(),
-                    DefaultErrorAction({DiagnosticsInfoType::BlockingCall,
-                                        func_name, pc, bp}));
+                    OnViolationAction({DiagnosticsInfoType::BlockingCall,
+                                       func_name, pc, bp}));
 }
 
 } // extern "C"

--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -44,10 +44,11 @@ static InitializationState GetInitializationState() {
       atomic_load(&rtsan_initialized, memory_order_acquire));
 }
 
-static auto PrintDiagnosticsAndDieAction(DiagnosticsInfo info) {
+static auto DefaultErrorAction(DiagnosticsInfo info) {
   return [info]() {
     __rtsan::PrintDiagnostics(info);
-    Die();
+    if (flags().halt_on_error)
+      Die();
   };
 }
 
@@ -105,20 +106,18 @@ __rtsan_notify_intercepted_call(const char *func_name) {
 
   __rtsan_ensure_initialized();
   GET_CALLER_PC_BP;
-  ExpectNotRealtime(
-      GetContextForThisThread(),
-      PrintDiagnosticsAndDieAction(
-          {DiagnosticsInfoType::InterceptedCall, func_name, pc, bp}));
+  ExpectNotRealtime(GetContextForThisThread(),
+                    DefaultErrorAction({DiagnosticsInfoType::InterceptedCall,
+                                        func_name, pc, bp}));
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE void
 __rtsan_notify_blocking_call(const char *func_name) {
   __rtsan_ensure_initialized();
   GET_CALLER_PC_BP;
-  ExpectNotRealtime(
-      GetContextForThisThread(),
-      PrintDiagnosticsAndDieAction(
-          {DiagnosticsInfoType::BlockingCall, func_name, pc, bp}));
+  ExpectNotRealtime(GetContextForThisThread(),
+                    DefaultErrorAction({DiagnosticsInfoType::BlockingCall,
+                                        func_name, pc, bp}));
 }
 
 } // extern "C"

--- a/compiler-rt/lib/rtsan/rtsan_flags.inc
+++ b/compiler-rt/lib/rtsan/rtsan_flags.inc
@@ -16,5 +16,4 @@
 // RTSAN_FLAG(Type, Name, DefaultValue, Description)
 // See COMMON_FLAG in sanitizer_flags.inc for more details.
 
-// Example flag, until we get a real one
-// RTSAN_FLAG(bool, halt_on_error, true, "If true, halt the program on error")
+RTSAN_FLAG(bool, halt_on_error, true, "Exit after first reported error.")

--- a/compiler-rt/test/rtsan/halt_on_error.cpp
+++ b/compiler-rt/test/rtsan/halt_on_error.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
-// RUN: env RTSAN_OPTIONS="halt_on_error=false" %run %t 2>&1 | FileCheck %s
+// RUN: %env_rtsan_opts="halt_on_error=true" not %run %t 2>&1 | FileCheck %s
+// RUN: %env_rtsan_opts="halt_on_error=false" %run %t 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-HALT,CHECK
 // UNSUPPORTED: ios
 
 // Intent: Ensure that halt_on_error does not exit on the first violation.
@@ -20,6 +21,6 @@ int main() {
   return 0;
   // CHECK: ==ERROR: RealtimeSanitizer
   // CHECK-NEXT: {{.*`malloc`.*}}
-  // CHECK: ==ERROR: RealtimeSanitizer
-  // CHECK-NEXT: {{.*`free`.*}}
+  // CHECK-NO-HALT: ==ERROR: RealtimeSanitizer
+  // CHECK-NO-HALT-NEXT: {{.*`free`.*}}
 }

--- a/compiler-rt/test/rtsan/halt_on_error.cpp
+++ b/compiler-rt/test/rtsan/halt_on_error.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx -fsanitize=realtime %s -o %t
+// RUN: env RTSAN_OPTIONS="halt_on_error=false" %run %t 2>&1 | FileCheck %s
+// UNSUPPORTED: ios
+
+// Intent: Ensure that halt_on_error does not exit on the first violation.
+
+#include <stdlib.h>
+
+void *MallocViolation() { return malloc(10); }
+
+void FreeViolation(void *Ptr) { free(Ptr); }
+
+void process() [[clang::nonblocking]] {
+  void *Ptr = MallocViolation();
+  FreeViolation(Ptr);
+}
+
+int main() {
+  process();
+  return 0;
+  // CHECK: ==ERROR: RealtimeSanitizer
+  // CHECK-NEXT: {{.*`malloc`.*}}
+  // CHECK: ==ERROR: RealtimeSanitizer
+  // CHECK-NEXT: {{.*`free`.*}}
+}


### PR DESCRIPTION
This is what we were previously calling "continue mode"

Allow a runtime option to either 

1. Die (halt_on_error=false) -- default behavior
2. Continue

Follow up reviews will allow for de-duplication so users do not drown in info.