### PR TITLE
[analyzer] use `invalidateRegions()` in `VisitGCCAsmStmt`

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3810,7 +3810,9 @@ void ExprEngine::VisitGCCAsmStmt(const GCCAsmStmt *A, ExplodedNode *Pred,
     assert(!isa<NonLoc>(X)); // Should be an Lval, or unknown, undef.
 
     if (std::optional<Loc> LV = X.getAs<Loc>())
-      state = state->bindLoc(*LV, UnknownVal(), Pred->getLocationContext());
+      state = state->invalidateRegions(*LV, A, currBldrCtx->blockCount(),
+                                       Pred->getLocationContext(),
+                                       /*CausedByPointerEscape=*/true);
   }
 
   // Do not reason about locations passed inside inline assembly.
@@ -3818,7 +3820,9 @@ void ExprEngine::VisitGCCAsmStmt(const GCCAsmStmt *A, ExplodedNode *Pred,
     SVal X = state->getSVal(I, Pred->getLocationContext());
 
     if (std::optional<Loc> LV = X.getAs<Loc>())
-      state = state->bindLoc(*LV, UnknownVal(), Pred->getLocationContext());
+      state = state->invalidateRegions(*LV, A, currBldrCtx->blockCount(),
+                                       Pred->getLocationContext(),
+                                       /*CausedByPointerEscape=*/true);
   }
 
   Bldr.generateNode(A, Pred, state);

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -51,7 +51,7 @@ void testInlineAsmMemcpyUninitLoop(const void *src, unsigned long len)
     int a[10], c;
     unsigned long toCopy = sizeof(a) < len ? sizeof(a) : len;
 
-    MyMemcpy(&a, src, toCopy);
+    MyMemcpy(a, src, toCopy);
 
     for (unsigned long i = 0; i < toCopy; ++i)
       c = a[i]; // no-warning
@@ -63,6 +63,6 @@ void testAsmWithVoidPtrArgument()
   clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning-re {{reg_${{[0-9]+}}<int Element{SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>},0 S64b,int}>}}
   clang_analyzer_dump_ptr(globalVoidPtr); // expected-warning-re {{&SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>}}}
   asm ("" : : "a"(globalVoidPtr)); // no crash
-  clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning {{derived_$3{conj_$2{int, LC1, S2385, #1},Element{SymRegion{reg_$0<void * globalVoidPtr>},0 S64b,int}}}}
+  clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning-re {{derived_$3{conj_$2{int, LC1, S{{[0-9]+}}, #1},Element{SymRegion{reg_$0<void * globalVoidPtr>},0 S64b,int}}}}
   clang_analyzer_dump_ptr(globalVoidPtr); // expected-warning-re {{&SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>}}}
 }

--- a/clang/test/Analysis/asm.cpp
+++ b/clang/test/Analysis/asm.cpp
@@ -10,8 +10,10 @@ void testRValueOutput() {
   int &ref = global;
   ref = 1;
   __asm__("" : "=r"(((int)(global))));  // don't crash on rvalue output operand
-  clang_analyzer_eval(global == 1); // expected-warning{{UNKNOWN}}
-  clang_analyzer_eval(ref == 1);    // expected-warning{{UNKNOWN}}
+  clang_analyzer_eval(global == 1); // expected-warning{{FALSE}}
+                                    // expected-warning@-1{{TRUE}}
+  clang_analyzer_eval(ref == 1);    // expected-warning{{FALSE}}
+                                    // expected-warning@-1{{TRUE}}
 }
 
 void *MyMemcpy(void *d, const void *s, const int n) {
@@ -40,7 +42,19 @@ void testInlineAsmMemcpyUninit(void)
 {
     int a[10], b[10] = {}, c;
     MyMemcpy(&a[1], &b[1], sizeof(b) - sizeof(b[1]));
-    c = a[0]; // expected-warning{{Assigned value is garbage or undefined}}
+    c = a[0]; // FIXME: should be warning about uninitialized value, but invalidateRegions() also
+              // invalidates super region.
+}
+
+void testInlineAsmMemcpyUninitLoop(const void *src, unsigned long len)
+{
+    int a[10], c;
+    unsigned long toCopy = sizeof(a) < len ? sizeof(a) : len;
+
+    MyMemcpy(&a, src, toCopy);
+
+    for (unsigned long i = 0; i < toCopy; ++i)
+      c = a[i]; // no-warning
 }
 
 void testAsmWithVoidPtrArgument()
@@ -49,6 +63,6 @@ void testAsmWithVoidPtrArgument()
   clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning-re {{reg_${{[0-9]+}}<int Element{SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>},0 S64b,int}>}}
   clang_analyzer_dump_ptr(globalVoidPtr); // expected-warning-re {{&SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>}}}
   asm ("" : : "a"(globalVoidPtr)); // no crash
-  clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning {{Unknown}}
+  clang_analyzer_dump(*(int *)globalVoidPtr); // expected-warning {{derived_$3{conj_$2{int, LC1, S2385, #1},Element{SymRegion{reg_$0<void * globalVoidPtr>},0 S64b,int}}}}
   clang_analyzer_dump_ptr(globalVoidPtr); // expected-warning-re {{&SymRegion{reg_${{[0-9]+}}<void * globalVoidPtr>}}}
 }


### PR DESCRIPTION
Since b1e4656e8ee3289dc5f3139fc8eb33152f96bfe6 it's possible to pass `Stmt` into `invalidateRegions`(). Use it in `VisitGCCAsmStmt` to invalidate regions passed as in and out arguments for inline assembly. 

This also fixes #109836 issue with FP uninitialized read, since `invalidateRegions()` invalidates super region as well, so there won't be problems with binding only to first element of the array.

Closes #109836 