### PR TITLE
[libc] Add MSAN unpoison annotations to recv funcs

### DIFF
--- a/libc/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/src/sys/socket/linux/CMakeLists.txt
@@ -33,6 +33,7 @@ add_entrypoint_object(
   DEPENDS
     libc.include.sys_syscall
     libc.include.sys_socket
+    libc.src.__support.macros.sanitizer
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -87,6 +88,7 @@ add_entrypoint_object(
     libc.include.sys_syscall
     libc.hdr.types.struct_sockaddr
     libc.hdr.types.socklen_t
+    libc.src.__support.macros.sanitizer
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -101,6 +103,7 @@ add_entrypoint_object(
     libc.include.sys_syscall
     libc.hdr.types.struct_sockaddr
     libc.hdr.types.socklen_t
+    libc.src.__support.macros.sanitizer
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -114,6 +117,7 @@ add_entrypoint_object(
   DEPENDS
     libc.include.sys_syscall
     libc.hdr.types.struct_msghdr
+    libc.src.__support.macros.sanitizer
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )

--- a/libc/src/sys/socket/linux/recv.cpp
+++ b/libc/src/sys/socket/linux/recv.cpp
@@ -13,6 +13,7 @@
 #include "hdr/types/struct_sockaddr.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
+#include "src/__support/macros/sanitizer.h"
 #include "src/errno/libc_errno.h"
 #include <linux/net.h>   // For SYS_SOCKET socketcall number.
 #include <sys/syscall.h> // For syscall numbers.
@@ -41,6 +42,9 @@ LLVM_LIBC_FUNCTION(ssize_t, recv,
     libc_errno = static_cast<int>(-ret);
     return -1;
   }
+
+  MSAN_UNPOISON(buf, ret);
+
   return ret;
 }
 

--- a/libc/src/sys/socket/linux/recvfrom.cpp
+++ b/libc/src/sys/socket/linux/recvfrom.cpp
@@ -13,6 +13,7 @@
 #include "hdr/types/struct_sockaddr.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
+#include "src/__support/macros/sanitizer.h"
 #include "src/errno/libc_errno.h"
 #include <linux/net.h>   // For SYS_SOCKET socketcall number.
 #include <sys/syscall.h> // For syscall numbers.
@@ -43,6 +44,9 @@ LLVM_LIBC_FUNCTION(ssize_t, recvfrom,
     libc_errno = static_cast<int>(-ret);
     return -1;
   }
+
+  MSAN_UNPOISON(buf, ret);
+
   return ret;
 }
 

--- a/libc/src/sys/socket/linux/socketpair.cpp
+++ b/libc/src/sys/socket/linux/socketpair.cpp
@@ -10,10 +10,9 @@
 
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/sanitizer.h"
 #include "src/errno/libc_errno.h"
-
 #include <linux/net.h>   // For SYS_SOCKET socketcall number.
 #include <sys/syscall.h> // For syscall numbers.
 
@@ -37,6 +36,9 @@ LLVM_LIBC_FUNCTION(int, socketpair,
     libc_errno = -ret;
     return -1;
   }
+
+  MSAN_UNPOISON(sv, sizeof(int) * 2);
+
   return ret;
 }
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
@@ -2,7 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Tests for LLVM libc string.h functions.
+# Tests for LLVM libc socket.h functions.
 
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 


### PR DESCRIPTION
Anywhere a struct is returned from the kernel, we need to explicitly
unpoison it for MSAN. This patch does that for the recv, recvfrom,
recvmsg, and socketpair functions.
