### PR TITLE
[rtsan][NFC] Make Uninitialzed state explicit

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -31,7 +31,8 @@ enum class InitializationState : u8 {
 } // namespace
 
 static StaticSpinMutex rtsan_inited_mutex;
-static atomic_uint8_t rtsan_initialized = {0};
+static atomic_uint8_t rtsan_initialized = {
+    static_cast<u8>(InitializationState::Uninitialized)};
 
 static void SetInitializationState(InitializationState state) {
   atomic_store(&rtsan_initialized, static_cast<u8>(state),


### PR DESCRIPTION
Follow on to #109830 

There should be no functional change, as enums start at 0 anyway. This just makes the code more readable and prevents any future bugs.