### PR TITLE
[llvm][NFC] Remove redundant copy parameter

### DIFF
--- a/llvm/include/llvm/Support/Memory.h
+++ b/llvm/include/llvm/Support/Memory.h
@@ -137,7 +137,7 @@ namespace sys {
   class OwningMemoryBlock {
   public:
     OwningMemoryBlock() = default;
-    explicit OwningMemoryBlock(MemoryBlock M) : M(M) {}
+    explicit OwningMemoryBlock(MemoryBlock M) : M(std::move(M)) {}
     OwningMemoryBlock(OwningMemoryBlock &&Other) {
       M = Other.M;
       Other.M = MemoryBlock();


### PR DESCRIPTION
Remove redundant copy parameter and move it

from `explicit OwningMemoryBlock(MemoryBlock M) : M(M) {}`

to `explicit OwningMemoryBlock(MemoryBlock M) : M(std::move(m)) {}`

Fixes: #95640