### PR TITLE
[AMDGPU][MC]FMA-mix instructions should not be supported in GFX908 etc.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -1348,8 +1348,7 @@ def FeatureISAVersion9_Generic : FeatureSet<
 
 def FeatureISAVersion9_0_MI_Common : FeatureSet<
   !listconcat(FeatureISAVersion9_0_Common.Features,
-    [FeatureFmaMixInsts,
-     FeatureDLInsts,
+    [FeatureDLInsts,
      FeatureDot1Insts,
      FeatureDot2Insts,
      FeatureDot3Insts,
@@ -1426,7 +1425,6 @@ def FeatureISAVersion9_4_Common : FeatureSet<
   [FeatureGFX9,
    FeatureGFX90AInsts,
    FeatureGFX940Insts,
-   FeatureFmaMixInsts,
    FeatureLDSBankCount32,
    FeatureDLInsts,
    FeatureFmacF64Inst,

--- a/llvm/test/MC/AMDGPU/fma-mix.s
+++ b/llvm/test/MC/AMDGPU/fma-mix.s
@@ -1,6 +1,9 @@
 // RUN: llvm-mc -triple=amdgcn -mcpu=gfx904 -show-encoding %s | FileCheck -check-prefix=GFX9-FMAMIX %s
 // RUN: llvm-mc -triple=amdgcn -mcpu=gfx906 -show-encoding %s | FileCheck -check-prefix=GFX9-FMAMIX %s
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx900 %s 2>&1 | FileCheck -check-prefix=GFX9-MADMIX-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx908 %s 2>&1 | FileCheck -check-prefix=GFX9-MADMIX-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx90a %s 2>&1 | FileCheck -check-prefix=GFX9-MADMIX-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx940 %s 2>&1 | FileCheck -check-prefix=GFX9-MADMIX-ERR --implicit-check-not=error: %s
 
 v_fma_mix_f32 v0, v1, v2, v3
 // GFX9-FMAMIX: v_fma_mix_f32 v0, v1, v2, v3 ; encoding: [0x00,0x00,0xa0,0xd3,0x01,0x05,0x0e,0x04]


### PR DESCRIPTION
FMA-mix instructions, including v_fma_mix_f32, v_fma_mixhi_f16, and v_fma_mixlo_f16 should not be supported in GFX908, GFX90a, and GFX940.