### PR TITLE
[ctx_prof] Simplify ingestContext (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
@@ -68,8 +68,7 @@ public:
   CallsiteMapTy &callsites() { return Callsites; }
 
   void ingestContext(uint32_t CSId, PGOCtxProfContext &&Other) {
-    auto [Iter, _] = callsites().try_emplace(CSId, CallTargetMapTy());
-    Iter->second.emplace(Other.guid(), std::move(Other));
+    callsites()[CSId].emplace(Other.guid(), std::move(Other));
   }
 
   void ingestAllContexts(uint32_t CSId, CallTargetMapTy &&Other) {


### PR DESCRIPTION
try_emplace can default-construct the value, so:

  try_emplace(CSId, CallTargetMapTy())
  try_emplace(CSId)

are equivalent to each other.  We can further simplify the function
using the fact that Map.try_emplace(Key).first->second is the same as
Map[Key].
