### PR TITLE
[Flang][Driver][Offload] Support -Xoffload-linker argument in Flang

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1055,6 +1055,7 @@ def Xlinker : Separate<["-"], "Xlinker">, Flags<[LinkerInput, RenderAsInput]>,
   HelpText<"Pass <arg> to the linker">, MetaVarName<"<arg>">,
   Group<Link_Group>;
 def Xoffload_linker : JoinedAndSeparate<["-"], "Xoffload-linker">,
+  Visibility<[ClangOption, CLOption, FlangOption, DXCOption]>,
   HelpText<"Pass <arg> to the offload linkers or the ones identified by -<triple>">,
   MetaVarName<"<triple> <arg>">, Group<Link_Group>;
 def Xpreprocessor : Separate<["-"], "Xpreprocessor">, Group<Preprocessor_Group>,

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -1,0 +1,7 @@
+! Test the -Xoffload-linker flag that forwards link commands to the clang-linker-wrapper used
+! to help link offloading device libraries
+
+! RUN:   %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a \
+! RUN:      -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER
+
+! CHECK-XLINKER: -device-linker=a{{.*}}--

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -1,9 +1,10 @@
-! RUN %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefixes=CHECK-XLINKER
+! Test the -Xoffload-linker flag that forwards link commands to the clang-linker-wrapper used
+! to help link offloading device libraries
 
-! CHECK-XLINKER {{.*}}--device-linker=a{{.*}}
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefixes=CHECK-XLINKER
+
+! CHECK-XLINKER: -device-linker=a{{.*}}-
 
 ! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b %s 2>&1 | FileCheck %s --check-prefixes=CHECK-XLINKER-AMDGCN
 
-! CHECK-XLINKER-AMDGCN: {{.*}}"--device-linker=a"{{.*}}"--device-linker=amdgcn-amd-amdhsa=b"{{.*}}
-
-end program
+! CHECK-XLINKER-AMDGCN: -device-linker=a{{.*}}-device-linker=amdgcn-amd-amdhsa=b{{.*}}--

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -1,13 +1,12 @@
 ! Test the -Xoffload-linker flag that forwards link commands to the clang-linker-wrapper used
 ! to help link offloading device libraries
 
-! RUN:   %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a \
-! RUN:      -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER
 
-! CHECK-XLINKER: {{.*}}-device-linker=a{{.*}}
+! CHECK-XLINKER: {{.*}}--device-linker=a{{.*}}
 
-! RUN:   %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a \
-! RUN:      -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b \
-! RUN:      %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER-AMDGCN
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER-AMDGCN
 
-! CHECK-XLINKER-AMDGCN: {{.*}}-device-linker=a{{.*}}-device-linker=amdgcn-amd-amdhsa=b{{.*}}
+! CHECK-XLINKER-AMDGCN: {{.*}}"--device-linker=a"{{.*}}"--device-linker=amdgcn-amd-amdhsa=b"{{.*}}
+
+end program

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -1,11 +1,8 @@
-! Test the -Xoffload-linker flag that forwards link commands to the clang-linker-wrapper used
-! to help link offloading device libraries
+! RUN %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefixes=CHECK-XLINKER
 
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER
+! CHECK-XLINKER {{.*}}--device-linker=a{{.*}}
 
-! CHECK-XLINKER: {{.*}}--device-linker=a{{.*}}
-
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER-AMDGCN
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b %s 2>&1 | FileCheck %s --check-prefixes=CHECK-XLINKER-AMDGCN
 
 ! CHECK-XLINKER-AMDGCN: {{.*}}"--device-linker=a"{{.*}}"--device-linker=amdgcn-amd-amdhsa=b"{{.*}}
 

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -1,10 +1,21 @@
-! Test the -Xoffload-linker flag that forwards link commands to the clang-linker-wrapper used
-! to help link offloading device libraries
+! RUN: %flang -### --target=ppc64le-linux-gnu -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=aarch64-apple-darwin -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=sparc-sun-solaris2.11 -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=x86_64-unknown-freebsd -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=x86_64-unknown-netbsd -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=x86_64-unknown-openbsd -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=x86_64-unknown-dragonfly -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=x86_64-unknown-haiku %s -Xlinker -rpath -Xlinker /not/a/real/path 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=x86_64-windows-gnu -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
+! RUN: %flang -### --target=aarch64-windows-msvc -Xlinker -rpath -Xlinker /not/a/real/path -o obscure.exe %s 2>&1 | FileCheck %s --check-prefixes=MSVC
 
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefixes=CHECK-XLINKER
+! UNIX-LABEL: "{{.*}}ld{{(\.exe)?}}"
+! UNIX-SAME: "-rpath" "/not/a/real/path"
 
-! CHECK-XLINKER: -device-linker=a{{.*}}-
+! The name of this file contains the word "link" which results in a match on
+! the compiler line as well. Instead look for the final name of the executable
+! to be created since that will only appear in the linker line.
+! MSVC: -out:obscure.exe
+! MSVC-SAME: "-rpath" "/not/a/real/path"
 
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b %s 2>&1 | FileCheck %s --check-prefixes=CHECK-XLINKER-AMDGCN
-
-! CHECK-XLINKER-AMDGCN: -device-linker=a{{.*}}-device-linker=amdgcn-amd-amdhsa=b{{.*}}--
+end program

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -1,10 +1,10 @@
 ! Test the -Xoffload-linker flag that forwards link commands to the clang-linker-wrapper used
 ! to help link offloading device libraries
 
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck --check-prefixes=CHECK-XLINKER %s
+! RUN: %flang -### %s -o %t 2>&1 -fopenmp --offload-arch=gfx90a --target=aarch64-unknown-linux-gnu -nogpulib -Xoffload-linker a | FileCheck %s --check-prefix=CHECK-XLINKER
 
-! CHECK-XLINKER: -device-linker=a{{.*}}-
+! CHECK-XLINKER: "{{[^"]*}}clang-linker-wrapper{{.*}}"{{.*}}"--device-linker=a"{{.*}}
 
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b %s 2>&1 | FileCheck --check-prefixes=CHECK-XLINKER-AMDGCN %s
+! RUN: %flang -### %s -o %t 2>&1 -fopenmp --offload-arch=gfx90a --target=aarch64-unknown-linux-gnu -nogpulib -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b | FileCheck %s --check-prefix=CHECK-XLINKER-AMDGCN
 
-! CHECK-XLINKER-AMDGCN: -device-linker=a{{.*}}-device-linker=amdgcn-amd-amdhsa=b{{.*}}--
+! CHECK-XLINKER-AMDGCN: "{{[^"]*}}clang-linker-wrapper{{.*}}"{{.*}}"--device-linker=a"{{.*}}"--device-linker=amdgcn-amd-amdhsa=b"{{.*}}

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -1,21 +1,10 @@
-! RUN: %flang -### --target=ppc64le-linux-gnu -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=aarch64-apple-darwin -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=sparc-sun-solaris2.11 -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=x86_64-unknown-freebsd -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=x86_64-unknown-netbsd -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=x86_64-unknown-openbsd -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=x86_64-unknown-dragonfly -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=x86_64-unknown-haiku %s -Xlinker -rpath -Xlinker /not/a/real/path 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=x86_64-windows-gnu -Xlinker -rpath -Xlinker /not/a/real/path %s 2>&1 | FileCheck %s --check-prefixes=UNIX
-! RUN: %flang -### --target=aarch64-windows-msvc -Xlinker -rpath -Xlinker /not/a/real/path -o obscure.exe %s 2>&1 | FileCheck %s --check-prefixes=MSVC
+! Test the -Xoffload-linker flag that forwards link commands to the clang-linker-wrapper used
+! to help link offloading device libraries
 
-! UNIX-LABEL: "{{.*}}ld{{(\.exe)?}}"
-! UNIX-SAME: "-rpath" "/not/a/real/path"
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a %s 2>&1 | FileCheck --check-prefixes=CHECK-XLINKER %s
 
-! The name of this file contains the word "link" which results in a match on
-! the compiler line as well. Instead look for the final name of the executable
-! to be created since that will only appear in the linker line.
-! MSVC: -out:obscure.exe
-! MSVC-SAME: "-rpath" "/not/a/real/path"
+! CHECK-XLINKER: -device-linker=a{{.*}}-
 
-end program
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b %s 2>&1 | FileCheck --check-prefixes=CHECK-XLINKER-AMDGCN %s
+
+! CHECK-XLINKER-AMDGCN: -device-linker=a{{.*}}-device-linker=amdgcn-amd-amdhsa=b{{.*}}--

--- a/flang/test/Driver/xoffload-linker.f90
+++ b/flang/test/Driver/xoffload-linker.f90
@@ -4,4 +4,10 @@
 ! RUN:   %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a \
 ! RUN:      -Xoffload-linker a %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER
 
-! CHECK-XLINKER: -device-linker=a{{.*}}--
+! CHECK-XLINKER: {{.*}}-device-linker=a{{.*}}
+
+! RUN:   %flang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a \
+! RUN:      -Xoffload-linker a -Xoffload-linker-amdgcn-amd-amdhsa b \
+! RUN:      %s 2>&1 | FileCheck %s --check-prefix=CHECK-XLINKER-AMDGCN
+
+! CHECK-XLINKER-AMDGCN: {{.*}}-device-linker=a{{.*}}-device-linker=amdgcn-amd-amdhsa=b{{.*}}


### PR DESCRIPTION
The -Xoffload-linker command allows forwarding of linker commands to the clang-linker-wrapper used for linking offload libraries into the resulting offload binaries amongst other tasks. This is a rather useful command to have to support the offloading programming models flang-new currently aims to support (OpenMP/OpenACC).

Currently this flag is utilised in the check-offload tests after a recent addition and is used in conjunction with the Fortran OpenMP test suite there, which fails at the moment due to flang-new not recognizing the command, this fixes the issue. The alternative to this would of course be to setup the test config to avoid using this flag with Fortran, but I believe adding support of the flag to flang-new has more merit as having the same compatability/communication capabilities as Clang to the clang-linker-wrapper is important as it's a critical component of the offload pipeline, and the command will likely see more use in the near future.