### PR TITLE
workflows/release-binaries: Use static ZSTD on macOS

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -126,7 +126,7 @@ jobs:
         # add extra CMake args to disable them.
         # See https://github.com/llvm/llvm-project/issues/99767
         if [ "${{ runner.os }}" = "macOS" ]; then
-          target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_COMPILER_RT_ENABLE_IOS=OFF"
+          target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_COMPILER_RT_ENABLE_IOS=OFF -DLLVM_USE_STATIC_ZSTD=ON"
           if [ "${{ runner.arch }}" = "ARM64" ]; then
             arches=arm64
           else

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -126,7 +126,7 @@ jobs:
         # add extra CMake args to disable them.
         # See https://github.com/llvm/llvm-project/issues/99767
         if [ "${{ runner.os }}" = "macOS" ]; then
-          target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_COMPILER_RT_ENABLE_IOS=OFF -DLLVM_USE_STATIC_ZSTD=ON"
+          target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_COMPILER_RT_ENABLE_IOS=OFF"
           if [ "${{ runner.arch }}" = "ARM64" ]; then
             arches=arm64
           else

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -123,7 +123,7 @@ jobs:
         echo "enable-pgo=false" >> $GITHUB_OUTPUT
         target_cmake_flags="-DLLVM_RELEASE_ENABLE_PGO=OFF"
         # The macOS builds try to cross compile some libraries so we need to
-        # add extra CMake args to disable them. TODO Remove this comment
+        # add extra CMake args to disable them.
         # See https://github.com/llvm/llvm-project/issues/99767
         if [ "${{ runner.os }}" = "macOS" ]; then
           target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_COMPILER_RT_ENABLE_IOS=OFF"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -123,7 +123,7 @@ jobs:
         echo "enable-pgo=false" >> $GITHUB_OUTPUT
         target_cmake_flags="-DLLVM_RELEASE_ENABLE_PGO=OFF"
         # The macOS builds try to cross compile some libraries so we need to
-        # add extra CMake args to disable them.
+        # add extra CMake args to disable them. TODO Remove this comment
         # See https://github.com/llvm/llvm-project/issues/99767
         if [ "${{ runner.os }}" = "macOS" ]; then
           target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_COMPILER_RT_ENABLE_IOS=OFF"

--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -109,3 +109,6 @@ set_final_stage_var(LLVM_ENABLE_PROJECTS "${LLVM_RELEASE_ENABLE_PROJECTS}" STRIN
 set_final_stage_var(CPACK_GENERATOR "TXZ" STRING)
 set_final_stage_var(CPACK_ARCHIVE_THREADS "0" STRING)
 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set_final_stage_var(LLVM_USE_STATIC_ZSTD "ON" BOOL)
+endif()

--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -109,6 +109,6 @@ set_final_stage_var(LLVM_ENABLE_PROJECTS "${LLVM_RELEASE_ENABLE_PROJECTS}" STRIN
 set_final_stage_var(CPACK_GENERATOR "TXZ" STRING)
 set_final_stage_var(CPACK_ARCHIVE_THREADS "0" STRING)
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
   set_final_stage_var(LLVM_USE_STATIC_ZSTD "ON" BOOL)
 endif()


### PR DESCRIPTION
On macOS the shared zstd library points to a homebrew install that isn't
very stable for users.
