### PR TITLE
Revert "[MLIR] Make `OneShotModuleBufferize` use `OpInterface`"

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
@@ -11,7 +11,6 @@
 
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/DenseMapInfoVariant.h"
 #include "llvm/ADT/SetVector.h"
@@ -261,9 +260,9 @@ struct BufferizationOptions {
   using AnalysisStateInitFn = std::function<void(AnalysisState &)>;
   /// Tensor -> MemRef type converter.
   /// Parameters: Value, memory space, func op, bufferization options
-  using FunctionArgTypeConverterFn = std::function<BaseMemRefType(
-      TensorType, Attribute memorySpace, FunctionOpInterface,
-      const BufferizationOptions &)>;
+  using FunctionArgTypeConverterFn =
+      std::function<BaseMemRefType(TensorType, Attribute memorySpace,
+                                   func::FuncOp, const BufferizationOptions &)>;
   /// Tensor -> MemRef type converter.
   /// Parameters: Value, memory space, bufferization options
   using UnknownTypeConverterFn = std::function<BaseMemRefType(

--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h
@@ -50,24 +50,24 @@ struct FuncAnalysisState : public OneShotAnalysisState::Extension {
 
   /// A mapping of ReturnOp OpOperand indices to equivalent FuncOp BBArg
   /// indices.
-  DenseMap<FunctionOpInterface, IndexMapping> equivalentFuncArgs;
+  DenseMap<FuncOp, IndexMapping> equivalentFuncArgs;
 
   /// A mapping of FuncOp BBArg indices to aliasing ReturnOp OpOperand indices.
-  DenseMap<FunctionOpInterface, IndexToIndexListMapping> aliasingReturnVals;
+  DenseMap<FuncOp, IndexToIndexListMapping> aliasingReturnVals;
 
   /// A set of all read BlockArguments of FuncOps.
-  DenseMap<FunctionOpInterface, BbArgIndexSet> readBbArgs;
+  DenseMap<FuncOp, BbArgIndexSet> readBbArgs;
 
   /// A set of all written-to BlockArguments of FuncOps.
-  DenseMap<FunctionOpInterface, BbArgIndexSet> writtenBbArgs;
+  DenseMap<FuncOp, BbArgIndexSet> writtenBbArgs;
 
   /// Keep track of which FuncOps are fully analyzed or currently being
   /// analyzed.
-  DenseMap<FunctionOpInterface, FuncOpAnalysisState> analyzedFuncOps;
+  DenseMap<FuncOp, FuncOpAnalysisState> analyzedFuncOps;
 
   /// This function is called right before analyzing the given FuncOp. It
   /// initializes the data structures for the FuncOp in this state object.
-  void startFunctionAnalysis(FunctionOpInterface funcOp);
+  void startFunctionAnalysis(FuncOp funcOp);
 };
 
 void registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry);

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -18,7 +18,6 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/Debug.h"
 
@@ -315,7 +314,7 @@ namespace {
 /// Default function arg type converter: Use a fully dynamic layout map.
 BaseMemRefType
 defaultFunctionArgTypeConverter(TensorType type, Attribute memorySpace,
-                                FunctionOpInterface funcOp,
+                                func::FuncOp funcOp,
                                 const BufferizationOptions &options) {
   return getMemRefTypeWithFullyDynamicLayout(type, memorySpace);
 }
@@ -362,7 +361,7 @@ BufferizationOptions::dynCastBufferizableOp(Value value) const {
 void BufferizationOptions::setFunctionBoundaryTypeConversion(
     LayoutMapOption layoutMapOption) {
   functionArgTypeConverterFn = [=](TensorType tensorType, Attribute memorySpace,
-                                   FunctionOpInterface funcOp,
+                                   func::FuncOp funcOp,
                                    const BufferizationOptions &options) {
     if (layoutMapOption == LayoutMapOption::IdentityLayoutMap)
       return bufferization::getMemRefTypeWithStaticIdentityLayout(tensorType,

--- a/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
@@ -22,7 +22,7 @@ namespace mlir {
 namespace bufferization {
 namespace func_ext {
 
-void FuncAnalysisState::startFunctionAnalysis(FunctionOpInterface funcOp) {
+void FuncAnalysisState::startFunctionAnalysis(FuncOp funcOp) {
   analyzedFuncOps[funcOp] = FuncOpAnalysisState::InProgress;
   auto createdEquiv = equivalentFuncArgs.try_emplace(funcOp, IndexMapping());
   auto createdAliasingResults =

--- a/mlir/test/Dialect/Bufferization/Transforms/transform-ops.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/transform-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --transform-interpreter="debug-payload-root-tag=payload" %s -split-input-file -verify-diagnostics | FileCheck %s
+// RUN: mlir-opt --transform-interpreter %s -split-input-file -verify-diagnostics | FileCheck %s
 
 // Test One-Shot Bufferize.
 
@@ -12,21 +12,19 @@ module attributes {transform.with_named_sequence} {
 
 // CHECK-LABEL: func @test_function(
 //  CHECK-SAME:     %[[A:.*]]: tensor<?xf32>
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @test_function(%A : tensor<?xf32>, %v : vector<4xf32>) -> (tensor<?xf32>) {
-    %c0 = arith.constant 0 : index
+func.func @test_function(%A : tensor<?xf32>, %v : vector<4xf32>) -> (tensor<?xf32>) {
+  %c0 = arith.constant 0 : index
 
-    // CHECK: %[[A_memref:.*]] = bufferization.to_memref %[[A]]
-    // CHECK: %[[dim:.*]] = memref.dim %[[A_memref]]
-    // CHECK: %[[alloc:.*]] = memref.alloc(%[[dim]])
-    // CHECK: memref.copy %[[A_memref]], %[[alloc]]
-    // CHECK: vector.transfer_write %{{.*}}, %[[alloc]]
-    // CHECK: %[[res_tensor:.*]] = bufferization.to_tensor %[[alloc]]
-    %0 = vector.transfer_write %v, %A[%c0] : vector<4xf32>, tensor<?xf32>
+  // CHECK: %[[A_memref:.*]] = bufferization.to_memref %[[A]]
+  // CHECK: %[[dim:.*]] = memref.dim %[[A_memref]]
+  // CHECK: %[[alloc:.*]] = memref.alloc(%[[dim]])
+  // CHECK: memref.copy %[[A_memref]], %[[alloc]]
+  // CHECK: vector.transfer_write %{{.*}}, %[[alloc]]
+  // CHECK: %[[res_tensor:.*]] = bufferization.to_tensor %[[alloc]]
+  %0 = vector.transfer_write %v, %A[%c0] : vector<4xf32>, tensor<?xf32>
 
-    // CHECK: return %[[res_tensor]]
-    return %0 : tensor<?xf32>
-  }
+  // CHECK: return %[[res_tensor]]
+  return %0 : tensor<?xf32>
 }
 
 // -----
@@ -44,21 +42,19 @@ module attributes {transform.with_named_sequence} {
 // CHECK-LABEL: func @test_function(
 //  CHECK-SAME:     %[[A:.*]]: tensor<?xf32>
 //   CHECK-NOT:   memref.copy
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @test_function(%A : tensor<?xf32>, %v : vector<4xf32>) -> (tensor<?xf32>) {
-    %c0 = arith.constant 0 : index
+func.func @test_function(%A : tensor<?xf32>, %v : vector<4xf32>) -> (tensor<?xf32>) {
+  %c0 = arith.constant 0 : index
 
-    // CHECK: %[[A_memref:.*]] = bufferization.to_memref %[[A]]
-    // CHECK: %[[dim:.*]] = memref.dim %[[A_memref]]
-    // CHECK: %[[alloc:.*]] = memref.alloc(%[[dim]])
-    // CHECK: linalg.copy ins(%[[A_memref]] : memref<{{.*}}>) outs(%[[alloc]]
-    // CHECK: vector.transfer_write %{{.*}}, %[[alloc]]
-    // CHECK: %[[res_tensor:.*]] = bufferization.to_tensor %[[alloc]]
-    %0 = vector.transfer_write %v, %A[%c0] : vector<4xf32>, tensor<?xf32>
+  // CHECK: %[[A_memref:.*]] = bufferization.to_memref %[[A]]
+  // CHECK: %[[dim:.*]] = memref.dim %[[A_memref]]
+  // CHECK: %[[alloc:.*]] = memref.alloc(%[[dim]])
+  // CHECK: linalg.copy ins(%[[A_memref]] : memref<{{.*}}>) outs(%[[alloc]]
+  // CHECK: vector.transfer_write %{{.*}}, %[[alloc]]
+  // CHECK: %[[res_tensor:.*]] = bufferization.to_tensor %[[alloc]]
+  %0 = vector.transfer_write %v, %A[%c0] : vector<4xf32>, tensor<?xf32>
 
-    // CHECK: return %[[res_tensor]]
-    return %0 : tensor<?xf32>
-  }
+  // CHECK: return %[[res_tensor]]
+  return %0 : tensor<?xf32>
 }
 
 // -----
@@ -76,15 +72,13 @@ module attributes {transform.with_named_sequence} {
 
 // CHECK-LABEL: func @test_function_analysis(
 //  CHECK-SAME:     %[[A:.*]]: tensor<?xf32>
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @test_function_analysis(%A : tensor<?xf32>, %v : vector<4xf32>) -> (tensor<?xf32>) {
-    %c0 = arith.constant 0 : index
-    // CHECK: vector.transfer_write
-    // CHECK-SAME: {__inplace_operands_attr__ = ["none", "false", "none"]}
-    // CHECK-SAME: tensor<?xf32>
-    %0 = vector.transfer_write %v, %A[%c0] : vector<4xf32>, tensor<?xf32>
-    return %0 : tensor<?xf32>
-  }
+func.func @test_function_analysis(%A : tensor<?xf32>, %v : vector<4xf32>) -> (tensor<?xf32>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.transfer_write
+  // CHECK-SAME: {__inplace_operands_attr__ = ["none", "false", "none"]}
+  // CHECK-SAME: tensor<?xf32>
+  %0 = vector.transfer_write %v, %A[%c0] : vector<4xf32>, tensor<?xf32>
+  return %0 : tensor<?xf32>
 }
 
 // -----
@@ -101,12 +95,10 @@ module attributes {transform.with_named_sequence} {
   }
 }
 
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @test_unknown_op_failure() -> (tensor<?xf32>) {
-    // expected-error @+1 {{op was not bufferized}}
-    %0 = "test.dummy_op"() : () -> (tensor<?xf32>)
-    return %0 : tensor<?xf32>
-  }
+func.func @test_unknown_op_failure() -> (tensor<?xf32>) {
+  // expected-error @+1 {{op was not bufferized}}
+  %0 = "test.dummy_op"() : () -> (tensor<?xf32>)
+  return %0 : tensor<?xf32>
 }
 
 // -----
@@ -119,7 +111,7 @@ module attributes {transform.with_named_sequence} {
   }
 }
 
-module @payload attributes { transform.target_tag = "payload" } {
+module {
   // CHECK-LABEL: func @test_function(
   //  CHECK-SAME:     %[[A:.*]]: tensor<?xf32>
   func.func @test_function(%A : tensor<?xf32>, %v : vector<4xf32>) -> (tensor<?xf32>) {
@@ -154,13 +146,11 @@ module attributes {transform.with_named_sequence} {
 // CHECK-SAME:  %[[A:.*]]: memref<12x9xf32>,
 // CHECK-SAME:  %[[B:.*]]: memref<9x6xf32>,
 // CHECK-SAME:  %[[C:.*]]: memref<12x6xf32>) -> memref<12x6xf32> {
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @matmul(%A: tensor<12x9xf32>, %B: tensor<9x6xf32>, %C: tensor<12x6xf32>) -> tensor<12x6xf32> {
-    // CHECK: linalg.matmul ins(%[[A]], %[[B]] : memref<12x9xf32>, memref<9x6xf32>) outs(%[[C]] : memref<12x6xf32>)
-    %D = linalg.matmul ins(%A, %B: tensor<12x9xf32>, tensor<9x6xf32>) outs(%C: tensor<12x6xf32>) -> tensor<12x6xf32>
-    // CHECK: return %[[C]] : memref<12x6xf32>
-    return %D : tensor<12x6xf32>
-  }
+func.func @matmul(%A: tensor<12x9xf32>, %B: tensor<9x6xf32>, %C: tensor<12x6xf32>) -> tensor<12x6xf32> {
+  // CHECK: linalg.matmul ins(%[[A]], %[[B]] : memref<12x9xf32>, memref<9x6xf32>) outs(%[[C]] : memref<12x6xf32>)
+  %D = linalg.matmul ins(%A, %B: tensor<12x9xf32>, tensor<9x6xf32>) outs(%C: tensor<12x6xf32>) -> tensor<12x6xf32>
+  // CHECK: return %[[C]] : memref<12x6xf32>
+  return %D : tensor<12x6xf32>
 }
 
 // -----
@@ -175,12 +165,10 @@ module attributes {transform.with_named_sequence} {
 }
 
 // Expect `bufferization.empty_tensor_to_alloc_tensor` to replace the tensor.empty.
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @empty_to_tensor_alloc() -> tensor<2x2xf32> {
-    // CHECK: bufferization.alloc_tensor
-    %0 = tensor.empty() : tensor<2x2xf32>
-    return %0 : tensor<2x2xf32>
-  }
+func.func @empty_to_tensor_alloc() -> tensor<2x2xf32> {
+  // CHECK: bufferization.alloc_tensor
+  %0 = tensor.empty() : tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
 }
 
 // -----
@@ -197,15 +185,13 @@ module attributes {transform.with_named_sequence} {
 //       CHECK:   tensor.extract_slice
 //       CHECK:   linalg.fill
 //       CHECK:   tensor.insert_slice
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @empty_tensor_elimination(
-      %t: tensor<10xf32>, %f: f32) -> tensor<10xf32> {
-    %0 = tensor.empty() : tensor<5xf32>
-    %1 = linalg.fill ins(%f : f32) outs(%0 : tensor<5xf32>) -> tensor<5xf32>
-    %2 = tensor.insert_slice %1 into %t [1][5][1]
-        : tensor<5xf32> into tensor<10xf32>
-    return %2 : tensor<10xf32>
-  }
+func.func @empty_tensor_elimination(
+    %t: tensor<10xf32>, %f: f32) -> tensor<10xf32> {
+  %0 = tensor.empty() : tensor<5xf32>
+  %1 = linalg.fill ins(%f : f32) outs(%0 : tensor<5xf32>) -> tensor<5xf32>
+  %2 = tensor.insert_slice %1 into %t [1][5][1]
+      : tensor<5xf32> into tensor<10xf32>
+  return %2 : tensor<10xf32>
 }
 
 // -----
@@ -222,14 +208,12 @@ module attributes {transform.with_named_sequence} {
 //       CHECK:   memref.alloca
 //       CHECK:   scf.for
 //       CHECK:     memref.store
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @buffer_loop_hoisting(%lb: index, %ub: index, %step: index, %f: f32, %pos: index) {
-    scf.for %iv = %lb to %ub step %step {
-      %0 = memref.alloca() : memref<5xf32>
-      memref.store %f, %0[%pos] : memref<5xf32>
-    }
-    return
+func.func @buffer_loop_hoisting(%lb: index, %ub: index, %step: index, %f: f32, %pos: index) {
+  scf.for %iv = %lb to %ub step %step {
+    %0 = memref.alloca() : memref<5xf32>
+    memref.store %f, %0[%pos] : memref<5xf32>
   }
+  return
 }
 
 // -----
@@ -247,12 +231,10 @@ module attributes {transform.with_named_sequence} {
 
 // Expect `bufferization.bufferize_to_allocation` to create an alloc.
 //  CHECK-LABEL: func.func @empty_to_tensor_alloc()
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @empty_to_tensor_alloc() -> tensor<2x2xf32> {
-    // CHECK-NEXT: %[[alloca:.*]] = memref.alloca() : memref<2x2xf32>
-    // CHECK-NEXT: %[[tensor:.*]] = bufferization.to_tensor %[[alloca]] restrict writable : memref<2x2xf32>
-    // CHECK-NEXT: return %[[tensor]] : tensor<2x2xf32>
-    %0 = bufferization.alloc_tensor() : tensor<2x2xf32>
-    return %0 : tensor<2x2xf32>
-  }
+func.func @empty_to_tensor_alloc() -> tensor<2x2xf32> {
+  // CHECK-NEXT: %[[alloca:.*]] = memref.alloca() : memref<2x2xf32>
+  // CHECK-NEXT: %[[tensor:.*]] = bufferization.to_tensor %[[alloca]] restrict writable : memref<2x2xf32>
+  // CHECK-NEXT: return %[[tensor]] : tensor<2x2xf32>
+  %0 = bufferization.alloc_tensor() : tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
 }

--- a/mlir/test/Dialect/LLVM/transform-e2e.mlir
+++ b/mlir/test/Dialect/LLVM/transform-e2e.mlir
@@ -1,17 +1,15 @@
-// RUN: mlir-opt %s --transform-interpreter="debug-payload-root-tag=payload" -test-transform-dialect-erase-schedule --test-lower-to-llvm --split-input-file | FileCheck %s
+// RUN: mlir-opt %s --transform-interpreter -test-transform-dialect-erase-schedule --test-lower-to-llvm --split-input-file | FileCheck %s
 
 // CHECK-LABEL: llvm.func @matmul_tensors
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @matmul_tensors(
-    %arg0: tensor<2x4xf32>, %arg1: tensor<4x6xf32>, %arg2: tensor<2x6xf32>)
-      -> tensor<2x6xf32> {
-  // CHECK-NOT: linalg
-  // CHECK: llvm.intr.fmuladd{{.*}}
-    %0 = linalg.matmul  ins(%arg0, %arg1: tensor<2x4xf32>, tensor<4x6xf32>)
-                       outs(%arg2: tensor<2x6xf32>)
-      -> tensor<2x6xf32>
-    return %0 : tensor<2x6xf32>
-  }
+func.func @matmul_tensors(
+  %arg0: tensor<2x4xf32>, %arg1: tensor<4x6xf32>, %arg2: tensor<2x6xf32>)
+    -> tensor<2x6xf32> {
+// CHECK-NOT: linalg
+// CHECK: llvm.intr.fmuladd{{.*}}
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<2x4xf32>, tensor<4x6xf32>)
+                     outs(%arg2: tensor<2x6xf32>)
+    -> tensor<2x6xf32>
+  return %0 : tensor<2x6xf32>
 }
 
 module attributes {transform.with_named_sequence} {

--- a/mlir/test/Dialect/Linalg/matmul-shared-memory-padding.mlir
+++ b/mlir/test/Dialect/Linalg/matmul-shared-memory-padding.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --split-input-file --transform-interpreter="debug-payload-root-tag=payload" %s | FileCheck %s
+// RUN: mlir-opt --split-input-file --transform-interpreter %s | FileCheck %s
 
 // CHECK-LABEL: func @matmul_divisible
 //       CHECK:   scf.forall
@@ -24,21 +24,19 @@
 //       CHECK:       scf.forall
 //       CHECK:         vector.transfer_read
 //       CHECK:         vector.transfer_write
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @matmul_divisible(%A: tensor<1024x1024xf32>,
-                              %B: tensor<1024x1024xf32>,
-                              %C: tensor<1024x1024xf32>)
+func.func @matmul_divisible(%A: tensor<1024x1024xf32>,
+                            %B: tensor<1024x1024xf32>,
+                            %C: tensor<1024x1024xf32>)
+    -> tensor<1024x1024xf32>
+{
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = linalg.fill ins(%cst : f32)
+                   outs(%C : tensor<1024x1024xf32>)
       -> tensor<1024x1024xf32>
-  {
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = linalg.fill ins(%cst : f32)
-                     outs(%C : tensor<1024x1024xf32>)
-        -> tensor<1024x1024xf32>
-    %1 = linalg.matmul ins(%A, %B : tensor<1024x1024xf32>, tensor<1024x1024xf32>)
-                       outs(%0 : tensor<1024x1024xf32>)
-        -> tensor<1024x1024xf32>
-    return %1 : tensor<1024x1024xf32>
-  }
+  %1 = linalg.matmul ins(%A, %B : tensor<1024x1024xf32>, tensor<1024x1024xf32>)
+                     outs(%0 : tensor<1024x1024xf32>)
+      -> tensor<1024x1024xf32>
+  return %1 : tensor<1024x1024xf32>
 }
 
 module attributes {transform.with_named_sequence} {
@@ -145,21 +143,19 @@ module attributes {transform.with_named_sequence} {
 //       CHECK:       linalg.matmul
 //       CHECK:       vector.transfer_read
 //       CHECK:       vector.transfer_write
-module @payload attributes { transform.target_tag = "payload" } {
 func.func @matmul_not_divisible(%A: tensor<1023x1023xf32>,
-                                  %B: tensor<1023x1023xf32>,
-                                  %C: tensor<1023x1023xf32>)
+                                %B: tensor<1023x1023xf32>,
+                                %C: tensor<1023x1023xf32>)
+    -> tensor<1023x1023xf32>
+{
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = linalg.fill ins(%cst : f32)
+                   outs(%C : tensor<1023x1023xf32>)
       -> tensor<1023x1023xf32>
-  {
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = linalg.fill ins(%cst : f32)
-                     outs(%C : tensor<1023x1023xf32>)
-        -> tensor<1023x1023xf32>
-    %1 = linalg.matmul ins(%A, %B : tensor<1023x1023xf32>, tensor<1023x1023xf32>)
-                       outs(%0 : tensor<1023x1023xf32>)
-        -> tensor<1023x1023xf32>
-    return %1 : tensor<1023x1023xf32>
-  }
+  %1 = linalg.matmul ins(%A, %B : tensor<1023x1023xf32>, tensor<1023x1023xf32>)
+                     outs(%0 : tensor<1023x1023xf32>)
+      -> tensor<1023x1023xf32>
+  return %1 : tensor<1023x1023xf32>
 }
 
 module attributes {transform.with_named_sequence} {

--- a/mlir/test/Dialect/Linalg/pad-to-specific-memory-space.mlir
+++ b/mlir/test/Dialect/Linalg/pad-to-specific-memory-space.mlir
@@ -1,5 +1,5 @@
 
-// RUN: mlir-opt --transform-interpreter="debug-payload-root-tag=payload" -cse -canonicalize -split-input-file -verify-diagnostics %s | FileCheck %s
+// RUN: mlir-opt --transform-interpreter -cse -canonicalize -split-input-file -verify-diagnostics %s | FileCheck %s
 
 #map = affine_map<()[s0] -> (-s0 + 12, 7)>
 
@@ -7,45 +7,43 @@
 //  CHECK-SAME:     %[[arg0:.*]]: memref<24x12xf32, strided<[?, ?], offset: ?>>,
 //  CHECK-SAME:     %[[arg1:.*]]: memref<12x25xf32, strided<[?, ?], offset: ?>>,
 //  CHECK-SAME:     %[[arg2:.*]]: memref<24x25xf32, strided<[?, ?], offset: ?>>,
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @pad_to_memory_space(%arg0: tensor<24x12xf32>,
-                                 %arg1: tensor<12x25xf32>,
-                                 %arg2: tensor<24x25xf32>,
-                                 %iv0 : index, %iv1 : index,
-                                 %iv2 : index) -> tensor<24x25xf32> {
-    %0 = affine.min #map()[%iv2]
+func.func @pad_to_memory_space(%arg0: tensor<24x12xf32>,
+                               %arg1: tensor<12x25xf32>,
+                               %arg2: tensor<24x25xf32>,
+                               %iv0 : index, %iv1 : index,
+                               %iv2 : index) -> tensor<24x25xf32> {
+  %0 = affine.min #map()[%iv2]
 
-    // CHECK: %[[s0:.*]] = memref.subview %[[arg0]]
-    %1 = tensor.extract_slice %arg0[%iv0, %iv2] [4, %0] [1, 1] : tensor<24x12xf32> to tensor<4x?xf32>
-    // CHECK: %[[s1:.*]] = memref.subview %[[arg1]]
-    %2 = tensor.extract_slice %arg1[%iv2, %iv1] [%0, 5] [1, 1] : tensor<12x25xf32> to tensor<?x5xf32>
-    // CHECK: %[[s2:.*]] = memref.subview %[[arg2]]
-    %3 = tensor.extract_slice %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<24x25xf32> to tensor<4x5xf32>
+  // CHECK: %[[s0:.*]] = memref.subview %[[arg0]]
+  %1 = tensor.extract_slice %arg0[%iv0, %iv2] [4, %0] [1, 1] : tensor<24x12xf32> to tensor<4x?xf32>
+  // CHECK: %[[s1:.*]] = memref.subview %[[arg1]]
+  %2 = tensor.extract_slice %arg1[%iv2, %iv1] [%0, 5] [1, 1] : tensor<12x25xf32> to tensor<?x5xf32>
+  // CHECK: %[[s2:.*]] = memref.subview %[[arg2]]
+  %3 = tensor.extract_slice %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<24x25xf32> to tensor<4x5xf32>
 
-    // CHECK: %[[alloc0:.*]] = memref.alloc() : memref<4x7xf32, 3>
-    // CHECK: linalg.fill {{.*}} outs(%[[alloc0]]
-    // CHECK: %[[alloc0_view:.*]] = memref.subview %[[alloc0]][0, 0] [4, %{{.*}}] [1, 1]
-    // CHECK: memref.copy %[[s0]], %[[alloc0_view]]
+  // CHECK: %[[alloc0:.*]] = memref.alloc() : memref<4x7xf32, 3>
+  // CHECK: linalg.fill {{.*}} outs(%[[alloc0]]
+  // CHECK: %[[alloc0_view:.*]] = memref.subview %[[alloc0]][0, 0] [4, %{{.*}}] [1, 1]
+  // CHECK: memref.copy %[[s0]], %[[alloc0_view]]
 
-    // CHECK: %[[alloc1:.*]] = memref.alloc() : memref<7x5xf32, 3>
-    // CHECK: linalg.fill {{.*}} outs(%[[alloc1]]
-    // CHECK: %[[alloc1_view:.*]] = memref.subview %[[alloc1]][0, 0] [%{{.*}}, 5] [1, 1]
-    // CHECK: memref.copy %[[s1]], %[[alloc1_view]]
+  // CHECK: %[[alloc1:.*]] = memref.alloc() : memref<7x5xf32, 3>
+  // CHECK: linalg.fill {{.*}} outs(%[[alloc1]]
+  // CHECK: %[[alloc1_view:.*]] = memref.subview %[[alloc1]][0, 0] [%{{.*}}, 5] [1, 1]
+  // CHECK: memref.copy %[[s1]], %[[alloc1_view]]
 
-    // CHECK: %[[alloc2:.*]] = memref.alloc() : memref<4x5xf32, 3>
-    // CHECK-NOT: linalg.fill {{.*}} outs(%[[alloc2]]
-    // No subview because there is 0 padding
-    // CHECK: memref.copy %[[s2]], %[[alloc2]]
+  // CHECK: %[[alloc2:.*]] = memref.alloc() : memref<4x5xf32, 3>
+  // CHECK-NOT: linalg.fill {{.*}} outs(%[[alloc2]]
+  // No subview because there is 0 padding
+  // CHECK: memref.copy %[[s2]], %[[alloc2]]
 
-    // CHECK: linalg.matmul ins(%[[alloc0]], %[[alloc1]] : {{.*}}) outs(%[[alloc2]] : {{.*}})
-    // Copy back result.
-    // CHECK: memref.copy %[[alloc2]], %[[s2]]
-    %4 = linalg.matmul ins(%1, %2 : tensor<4x?xf32>, tensor<?x5xf32>) outs(%3 : tensor<4x5xf32>) -> tensor<4x5xf32>
+  // CHECK: linalg.matmul ins(%[[alloc0]], %[[alloc1]] : {{.*}}) outs(%[[alloc2]] : {{.*}})
+  // Copy back result.
+  // CHECK: memref.copy %[[alloc2]], %[[s2]]
+  %4 = linalg.matmul ins(%1, %2 : tensor<4x?xf32>, tensor<?x5xf32>) outs(%3 : tensor<4x5xf32>) -> tensor<4x5xf32>
 
-    // insert_slice bufferizes to a no-op.
-    %5 = tensor.insert_slice %4 into %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<4x5xf32> into tensor<24x25xf32>
-    func.return %5 : tensor<24x25xf32>
-  }
+  // insert_slice bufferizes to a no-op.
+  %5 = tensor.insert_slice %4 into %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<4x5xf32> into tensor<24x25xf32>
+  func.return %5 : tensor<24x25xf32>
 }
 
 module attributes {transform.with_named_sequence} {
@@ -71,42 +69,40 @@ module attributes {transform.with_named_sequence} {
 //  CHECK-SAME:     %[[arg0:.*]]: memref<24x12xf32, strided<[?, ?], offset: ?>>,
 //  CHECK-SAME:     %[[arg1:.*]]: memref<12x25xf32, strided<[?, ?], offset: ?>>,
 //  CHECK-SAME:     %[[arg2:.*]]: memref<24x25xf32, strided<[?, ?], offset: ?>>,
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @vectorize_and_bufferize_pad(%arg0: tensor<24x12xf32>,
-                                         %arg1: tensor<12x25xf32>,
-                                         %arg2: tensor<24x25xf32>,
-                                         %iv0 : index, %iv1 : index,
-                                         %iv2 : index) -> tensor<24x25xf32> {
-    %0 = affine.min #map()[%iv2]
+func.func @vectorize_and_bufferize_pad(%arg0: tensor<24x12xf32>,
+                                       %arg1: tensor<12x25xf32>,
+                                       %arg2: tensor<24x25xf32>,
+                                       %iv0 : index, %iv1 : index,
+                                       %iv2 : index) -> tensor<24x25xf32> {
+  %0 = affine.min #map()[%iv2]
 
-    // CHECK: %[[s0:.*]] = memref.subview %[[arg0]]
-    %1 = tensor.extract_slice %arg0[%iv0, %iv2] [4, %0] [1, 1] : tensor<24x12xf32> to tensor<4x?xf32>
-    // CHECK: %[[s1:.*]] = memref.subview %[[arg1]]
-    %2 = tensor.extract_slice %arg1[%iv2, %iv1] [%0, 5] [1, 1] : tensor<12x25xf32> to tensor<?x5xf32>
-    // CHECK: %[[s2:.*]] = memref.subview %[[arg2]]
-    %3 = tensor.extract_slice %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<24x25xf32> to tensor<4x5xf32>
+  // CHECK: %[[s0:.*]] = memref.subview %[[arg0]]
+  %1 = tensor.extract_slice %arg0[%iv0, %iv2] [4, %0] [1, 1] : tensor<24x12xf32> to tensor<4x?xf32>
+  // CHECK: %[[s1:.*]] = memref.subview %[[arg1]]
+  %2 = tensor.extract_slice %arg1[%iv2, %iv1] [%0, 5] [1, 1] : tensor<12x25xf32> to tensor<?x5xf32>
+  // CHECK: %[[s2:.*]] = memref.subview %[[arg2]]
+  %3 = tensor.extract_slice %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<24x25xf32> to tensor<4x5xf32>
 
-    // CHECK: %[[v0:.*]] = vector.mask {{.*}} { vector.transfer_read %[[s0]]
-    // CHECK: %[[alloc0:.*]] = memref.alloc() : memref<4x7xf32, 3>
-    // CHECK: vector.mask {{.*}} { vector.transfer_write %[[v0]], %[[alloc0]]
+  // CHECK: %[[v0:.*]] = vector.mask {{.*}} { vector.transfer_read %[[s0]]
+  // CHECK: %[[alloc0:.*]] = memref.alloc() : memref<4x7xf32, 3>
+  // CHECK: vector.mask {{.*}} { vector.transfer_write %[[v0]], %[[alloc0]]
 
-    // CHECK: %[[v1:.*]] = vector.mask {{.*}} { vector.transfer_read %[[s1]]
-    // CHECK: %[[alloc1:.*]] = memref.alloc() : memref<7x5xf32, 3>
-    // CHECK: vector.mask {{.*}} { vector.transfer_write %[[v1]], %[[alloc1]]
+  // CHECK: %[[v1:.*]] = vector.mask {{.*}} { vector.transfer_read %[[s1]]
+  // CHECK: %[[alloc1:.*]] = memref.alloc() : memref<7x5xf32, 3>
+  // CHECK: vector.mask {{.*}} { vector.transfer_write %[[v1]], %[[alloc1]]
 
-    // CHECK: %[[v2:.*]] = vector.mask {{.*}} { vector.transfer_read %[[s2]]
-    // CHECK: %[[alloc2:.*]] = memref.alloc() : memref<4x5xf32, 3>
-    // CHECK: vector.mask {{.*}} { vector.transfer_write %[[v2]], %[[alloc0]]
+  // CHECK: %[[v2:.*]] = vector.mask {{.*}} { vector.transfer_read %[[s2]]
+  // CHECK: %[[alloc2:.*]] = memref.alloc() : memref<4x5xf32, 3>
+  // CHECK: vector.mask {{.*}} { vector.transfer_write %[[v2]], %[[alloc0]]
 
-    // CHECK: linalg.matmul ins(%[[alloc0]], %[[alloc1]] : {{.*}}) outs(%[[alloc2]] : {{.*}})
-    // Copy back result.
-    // CHECK: memref.copy %[[alloc2]], %[[s2]]
-    %4 = linalg.matmul ins(%1, %2 : tensor<4x?xf32>, tensor<?x5xf32>) outs(%3 : tensor<4x5xf32>) -> tensor<4x5xf32>
+  // CHECK: linalg.matmul ins(%[[alloc0]], %[[alloc1]] : {{.*}}) outs(%[[alloc2]] : {{.*}})
+  // Copy back result.
+  // CHECK: memref.copy %[[alloc2]], %[[s2]]
+  %4 = linalg.matmul ins(%1, %2 : tensor<4x?xf32>, tensor<?x5xf32>) outs(%3 : tensor<4x5xf32>) -> tensor<4x5xf32>
 
-    // insert_slice bufferizes to a no-op.
-    %5 = tensor.insert_slice %4 into %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<4x5xf32> into tensor<24x25xf32>
-    func.return %5 : tensor<24x25xf32>
-  }
+  // insert_slice bufferizes to a no-op.
+  %5 = tensor.insert_slice %4 into %arg2[%iv0, %iv1] [4, 5] [1, 1] : tensor<4x5xf32> into tensor<24x25xf32>
+  func.return %5 : tensor<24x25xf32>
 }
 
 module attributes {transform.with_named_sequence} {

--- a/mlir/test/Dialect/Vector/transform-vector.mlir
+++ b/mlir/test/Dialect/Vector/transform-vector.mlir
@@ -1,18 +1,16 @@
-// RUN: mlir-opt --transform-interpreter="debug-payload-root-tag=payload" %s --split-input-file | FileCheck %s
+// RUN: mlir-opt %s --transform-interpreter --split-input-file | FileCheck %s
 
 // CHECK-LABEL: func @matmul_tensors
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @matmul_tensors(
-    %arg0: tensor<8x16xf32>, %arg1: tensor<16x32xf32>, %arg2: tensor<8x32xf32>)
-      -> tensor<8x32xf32> {
-  // CHECK-NOT: linalg
-  // CHECK: vector.extract {{.*}} : vector<4xf32> from vector<8x4xf32>
-  // CHECK: vector.store {{.*}} : memref<8x32xf32>, vector<4xf32>
-    %0 = linalg.matmul  ins(%arg0, %arg1: tensor<8x16xf32>, tensor<16x32xf32>)
-                       outs(%arg2: tensor<8x32xf32>)
-      -> tensor<8x32xf32>
-    return %0 : tensor<8x32xf32>
-  }
+func.func @matmul_tensors(
+  %arg0: tensor<8x16xf32>, %arg1: tensor<16x32xf32>, %arg2: tensor<8x32xf32>)
+    -> tensor<8x32xf32> {
+// CHECK-NOT: linalg
+// CHECK: vector.extract {{.*}} : vector<4xf32> from vector<8x4xf32>
+// CHECK: vector.store {{.*}} : memref<8x32xf32>, vector<4xf32>
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<8x16xf32>, tensor<16x32xf32>)
+                     outs(%arg2: tensor<8x32xf32>)
+    -> tensor<8x32xf32>
+  return %0 : tensor<8x32xf32>
 }
 
 module attributes {transform.with_named_sequence} {
@@ -78,13 +76,11 @@ module attributes {transform.with_named_sequence} {
 //  CHECK-SAME:   iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
 //  CHECK-SAME:   %[[ARG0]], %[[ARG1]], %[[ARG2]] : vector<64x64xf16>, vector<64x64xf16> into vector<64x64xf32>
 //  CHECK-NEXT:   return %[[R]] : vector<64x64xf32>
-module @payload attributes { transform.target_tag = "payload" } {
-  func.func @fold_arith_extf_into_contract(%arg0: vector<64x64xf16>, %arg1: vector<64x64xf16>, %arg2: vector<64x64xf32>) -> vector<64x64xf32> {
-      %lhs_f32 = arith.extf %arg0 : vector<64x64xf16> to vector<64x64xf32>
-      %rhs_f32 = arith.extf %arg1 : vector<64x64xf16> to vector<64x64xf32>
-      %result = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %lhs_f32, %rhs_f32, %arg2 : vector<64x64xf32>, vector<64x64xf32> into vector<64x64xf32>
-      return %result : vector<64x64xf32>
-  }
+func.func @fold_arith_extf_into_contract(%arg0: vector<64x64xf16>, %arg1: vector<64x64xf16>, %arg2: vector<64x64xf32>) -> vector<64x64xf32> {
+    %lhs_f32 = arith.extf %arg0 : vector<64x64xf16> to vector<64x64xf32>
+    %rhs_f32 = arith.extf %arg1 : vector<64x64xf16> to vector<64x64xf32>
+    %result = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %lhs_f32, %rhs_f32, %arg2 : vector<64x64xf32>, vector<64x64xf32> into vector<64x64xf32>
+    return %result : vector<64x64xf32>
 }
 
 module attributes {transform.with_named_sequence} {
@@ -99,32 +95,30 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-module @payload attributes { transform.target_tag = "payload" } {
-  // CHECK-LABEL: func.func @arith_to_outerproduct_scalable_i32
-  //  CHECK-SAME:   %[[LHS:.*]]: vector<[4]xi32>,
-  //  CHECK-SAME:   %[[RHS:.*]]: vector<[4]xi32>) -> vector<[4]x[4]xi32> {
-  //       CHECK:     %[[RES:.*]] = vector.outerproduct %[[LHS]], %[[RHS]] : vector<[4]xi32>, vector<[4]xi32>
-  //       CHECK:     return %[[RES]] : vector<[4]x[4]xi32>
-  func.func @arith_to_outerproduct_scalable_i32(%lhs: vector<[4]xi32>, %rhs: vector<[4]xi32>) -> vector<[4]x[4]xi32> {
-    %lhsBcast = vector.broadcast %lhs : vector<[4]xi32> to vector<[4]x[4]xi32>
-    %lhsT = vector.transpose %lhsBcast, [1, 0] : vector<[4]x[4]xi32> to vector<[4]x[4]xi32>
-    %rhsBcast = vector.broadcast %rhs : vector<[4]xi32> to vector<[4]x[4]xi32>
-    %mul = arith.muli %lhsT, %rhsBcast : vector<[4]x[4]xi32>
-    return %mul: vector<[4]x[4]xi32>
-  }
+// CHECK-LABEL: func.func @arith_to_outerproduct_scalable_i32
+//  CHECK-SAME:   %[[LHS:.*]]: vector<[4]xi32>,
+//  CHECK-SAME:   %[[RHS:.*]]: vector<[4]xi32>) -> vector<[4]x[4]xi32> {
+//       CHECK:     %[[RES:.*]] = vector.outerproduct %[[LHS]], %[[RHS]] : vector<[4]xi32>, vector<[4]xi32>
+//       CHECK:     return %[[RES]] : vector<[4]x[4]xi32>
+func.func @arith_to_outerproduct_scalable_i32(%lhs: vector<[4]xi32>, %rhs: vector<[4]xi32>) -> vector<[4]x[4]xi32> {
+  %lhsBcast = vector.broadcast %lhs : vector<[4]xi32> to vector<[4]x[4]xi32>
+  %lhsT = vector.transpose %lhsBcast, [1, 0] : vector<[4]x[4]xi32> to vector<[4]x[4]xi32>
+  %rhsBcast = vector.broadcast %rhs : vector<[4]xi32> to vector<[4]x[4]xi32>
+  %mul = arith.muli %lhsT, %rhsBcast : vector<[4]x[4]xi32>
+  return %mul: vector<[4]x[4]xi32>
+}
 
-  // CHECK-LABEL: func.func @arith_to_outerproduct_trans_rhs_f32
-  //  CHECK-SAME:   %[[LHS:.*]]: vector<16xf32>,
-  //  CHECK-SAME:   %[[RHS:.*]]: vector<8xf32>) -> vector<8x16xf32> {
-  //       CHECK:     %[[RES:.*]] = vector.outerproduct %[[RHS]], %[[LHS]] : vector<8xf32>, vector<16xf32>
-  //       CHECK:     return %[[RES]] : vector<8x16xf32>
-  func.func @arith_to_outerproduct_trans_rhs_f32(%lhs: vector<16xf32>, %rhs: vector<8xf32>) -> vector<8x16xf32> {
-    %rhsBcast = vector.broadcast %rhs : vector<8xf32> to vector<16x8xf32>
-    %rhsT = vector.transpose %rhsBcast, [1, 0] : vector<16x8xf32> to vector<8x16xf32>
-    %lhsBcast = vector.broadcast %lhs : vector<16xf32> to vector<8x16xf32>
-    %mul = arith.mulf %lhsBcast, %rhsT : vector<8x16xf32>
-    return %mul: vector<8x16xf32>
-  }
+// CHECK-LABEL: func.func @arith_to_outerproduct_trans_rhs_f32
+//  CHECK-SAME:   %[[LHS:.*]]: vector<16xf32>,
+//  CHECK-SAME:   %[[RHS:.*]]: vector<8xf32>) -> vector<8x16xf32> {
+//       CHECK:     %[[RES:.*]] = vector.outerproduct %[[RHS]], %[[LHS]] : vector<8xf32>, vector<16xf32>
+//       CHECK:     return %[[RES]] : vector<8x16xf32>
+func.func @arith_to_outerproduct_trans_rhs_f32(%lhs: vector<16xf32>, %rhs: vector<8xf32>) -> vector<8x16xf32> {
+  %rhsBcast = vector.broadcast %rhs : vector<8xf32> to vector<16x8xf32>
+  %rhsT = vector.transpose %rhsBcast, [1, 0] : vector<16x8xf32> to vector<8x16xf32>
+  %lhsBcast = vector.broadcast %lhs : vector<16xf32> to vector<8x16xf32>
+  %mul = arith.mulf %lhsBcast, %rhsT : vector<8x16xf32>
+  return %mul: vector<8x16xf32>
 }
 
 module attributes {transform.with_named_sequence} {

--- a/mlir/test/Examples/transform/ChH/full.mlir
+++ b/mlir/test/Examples/transform/ChH/full.mlir
@@ -1,6 +1,8 @@
-// RUN: mlir-opt %s --transform-interpreter="debug-payload-root-tag=payload" \
-// RUN:             --test-transform-dialect-erase-schedule |\
-// RUN: mlir-opt -pass-pipeline='builtin.module(builtin.module(math-uplift-to-fma,convert-bufferization-to-memref,test-lower-to-llvm))' - |\
+// RUN: mlir-opt %s --transform-interpreter \
+// RUN:             --test-transform-dialect-erase-schedule \
+// RUN:             --math-uplift-to-fma \
+// RUN:             --convert-bufferization-to-memref \
+// RUN:             --test-lower-to-llvm |\
 // RUN: FileCheck %s
 
 // Fixed-size tensor types to be used in convolution.
@@ -17,7 +19,6 @@
 // tensors annotated with attributes from the `bufferization` dialect. These
 // attributes hint the bufferization pass to assume buffers can be directly
 // used for these tensors without reshaping.
-module @payload attributes { transform.target_tag = "payload" } {
 func.func @conv(
     %input: !tinput {bufferization.writable = false,
                      bufferization.access = "read",
@@ -83,7 +84,7 @@ func.func @conv(
 
   return %relued : !toutput
 }
-}
+
 // Module containing the transformation script to be applied. The attribute
 // is required to correctly verify the use of named (macro-like) sequences.
 module attributes { transform.with_named_sequence } {


### PR DESCRIPTION
Reverts llvm/llvm-project#107295

This commit breaks an integration test:
```
build/bin/mlir-opt mlir/test/Integration/Dialect/Complex/CPU/correctness.mlir  -one-shot-bufferize="bufferize-function-boundaries"
```
