### PR TITLE
[ConstantFPRange] Suppress unused result warnings. NFC.

### DIFF
--- a/llvm/unittests/IR/ConstantFPRangeTest.cpp
+++ b/llvm/unittests/IR/ConstantFPRangeTest.cpp
@@ -414,18 +414,21 @@ TEST_F(ConstantFPRangeTest, Print) {
 #ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
 TEST_F(ConstantFPRangeTest, NonCanonicalEmptySet) {
-  EXPECT_DEATH(ConstantFPRange::getNonNaN(APFloat(1.0), APFloat(0.0)),
+  EXPECT_DEATH((void)(ConstantFPRange::getNonNaN(APFloat(1.0), APFloat(0.0))),
                "Non-canonical form");
 }
 TEST_F(ConstantFPRangeTest, MismatchedSemantics) {
-  EXPECT_DEATH(ConstantFPRange::getNonNaN(APFloat(0.0), APFloat(1.0f)),
+  EXPECT_DEATH((void)(ConstantFPRange::getNonNaN(APFloat(0.0), APFloat(1.0f))),
                "Should only use the same semantics");
-  EXPECT_DEATH(One.contains(APFloat(1.0f)),
+  EXPECT_DEATH((void)(One.contains(APFloat(1.0f))),
                "Should only use the same semantics");
   ConstantFPRange OneF32 = ConstantFPRange(APFloat(1.0f));
-  EXPECT_DEATH(One.contains(OneF32), "Should only use the same semantics");
-  EXPECT_DEATH(One.intersectWith(OneF32), "Should only use the same semantics");
-  EXPECT_DEATH(One.unionWith(OneF32), "Should only use the same semantics");
+  EXPECT_DEATH((void)(One.contains(OneF32)),
+               "Should only use the same semantics");
+  EXPECT_DEATH((void)(One.intersectWith(OneF32)),
+               "Should only use the same semantics");
+  EXPECT_DEATH((void)(One.unionWith(OneF32)),
+               "Should only use the same semantics");
 }
 #endif
 #endif


### PR DESCRIPTION
Fixes warnings `error: ignoring return value of function declared with 'nodiscard' attribute [-Werror,-Wunused-result]`.
