### PR TITLE
[SPIRV] Fix compilation error 'use of parameter from containing function' when building PR #106429 with gcc

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -259,9 +259,12 @@ SPIRV::Scope::Scope getMemScope(LLVMContext &Ctx, SyncScope::ID Id) {
   // We don't need aliases for Invocation and CrossDevice, as we already have
   // them covered by "singlethread" and "" strings respectively (see
   // implementation of LLVMContext::LLVMContext()).
-  llvm::SyncScope::ID SubGroup = Ctx.getOrInsertSyncScopeID("subgroup");
-  llvm::SyncScope::ID WorkGroup = Ctx.getOrInsertSyncScopeID("workgroup");
-  llvm::SyncScope::ID Device = Ctx.getOrInsertSyncScopeID("device");
+  static const llvm::SyncScope::ID SubGroup =
+      Ctx.getOrInsertSyncScopeID("subgroup");
+  static const llvm::SyncScope::ID WorkGroup =
+      Ctx.getOrInsertSyncScopeID("workgroup");
+  static const llvm::SyncScope::ID Device =
+      Ctx.getOrInsertSyncScopeID("device");
 
   if (Id == llvm::SyncScope::SingleThread)
     return SPIRV::Scope::Invocation;

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -254,26 +254,24 @@ SPIRV::MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering Ord) {
 }
 
 SPIRV::Scope::Scope getMemScope(LLVMContext &Ctx, SyncScope::ID Id) {
-  static const struct {
-    // Named by
-    // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_scope_id.
-    // We don't need aliases for Invocation and CrossDevice, as we already have
-    // them covered by "singlethread" and "" strings respectively (see
-    // implementation of LLVMContext::LLVMContext()).
-    llvm::SyncScope::ID SubGroup = Ctx.getOrInsertSyncScopeID("subgroup");
-    llvm::SyncScope::ID WorkGroup = Ctx.getOrInsertSyncScopeID("workgroup");
-    llvm::SyncScope::ID Device = Ctx.getOrInsertSyncScopeID("device");
-  } SSIDs{};
+  // Named by
+  // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_scope_id.
+  // We don't need aliases for Invocation and CrossDevice, as we already have
+  // them covered by "singlethread" and "" strings respectively (see
+  // implementation of LLVMContext::LLVMContext()).
+  llvm::SyncScope::ID SubGroup = Ctx.getOrInsertSyncScopeID("subgroup");
+  llvm::SyncScope::ID WorkGroup = Ctx.getOrInsertSyncScopeID("workgroup");
+  llvm::SyncScope::ID Device = Ctx.getOrInsertSyncScopeID("device");
 
   if (Id == llvm::SyncScope::SingleThread)
     return SPIRV::Scope::Invocation;
   else if (Id == llvm::SyncScope::System)
     return SPIRV::Scope::CrossDevice;
-  else if (Id == SSIDs.SubGroup)
+  else if (Id == SubGroup)
     return SPIRV::Scope::Subgroup;
-  else if (Id == SSIDs.WorkGroup)
+  else if (Id == WorkGroup)
     return SPIRV::Scope::Workgroup;
-  else if (Id == SSIDs.Device)
+  else if (Id == Device)
     return SPIRV::Scope::Device;
   return SPIRV::Scope::CrossDevice;
 }


### PR DESCRIPTION
It appears that PR https://github.com/llvm/llvm-project/pull/106429 introduced an issue for builds with SPIRV Backend target when building with gcc, e.g.:
```
/llvm-project/llvm/lib/Target/SPIRV/SPIRVUtils.cpp:263:36: error: use of parameter from containing function
  263 |     llvm::SyncScope::ID SubGroup = Ctx.getOrInsertSyncScopeID("subgroup");
      |                                    ^~~
/llvm-project/llvm/lib/Target/SPIRV/SPIRVUtils.cpp:256:46: note: ‘llvm::LLVMContext& Ctx’ declared here
  256 | SPIRV::Scope::Scope getMemScope(LLVMContext &Ctx, SyncScope::ID Id) {
```
This PR fixes this by removing struct and using static const variables instead.

