### PR TITLE
[ConstantFPRange] Remove `ConstantFPRange::toKnownFPClass`

### DIFF
--- a/llvm/include/llvm/IR/ConstantFPRange.h
+++ b/llvm/include/llvm/IR/ConstantFPRange.h
@@ -175,9 +175,6 @@ public:
   /// Return the FPClassTest which will return true for the value.
   FPClassTest classify() const;
 
-  /// Return known floating-point classes for values in this range.
-  KnownFPClass toKnownFPClass() const;
-
   /// Print out the bounds to a stream.
   void print(raw_ostream &OS) const;
 

--- a/llvm/lib/IR/ConstantFPRange.cpp
+++ b/llvm/lib/IR/ConstantFPRange.cpp
@@ -196,13 +196,6 @@ FPClassTest ConstantFPRange::classify() const {
   return static_cast<FPClassTest>(Mask);
 }
 
-KnownFPClass ConstantFPRange::toKnownFPClass() const {
-  KnownFPClass Result;
-  Result.KnownFPClasses = classify();
-  Result.SignBit = getSignBit();
-  return Result;
-}
-
 void ConstantFPRange::print(raw_ostream &OS) const {
   if (isFullSet())
     OS << "full-set";

--- a/llvm/lib/IR/ConstantFPRange.cpp
+++ b/llvm/lib/IR/ConstantFPRange.cpp
@@ -8,7 +8,6 @@
 
 #include "llvm/IR/ConstantFPRange.h"
 #include "llvm/ADT/APFloat.h"
-#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>

--- a/llvm/unittests/IR/ConstantFPRangeTest.cpp
+++ b/llvm/unittests/IR/ConstantFPRangeTest.cpp
@@ -363,14 +363,11 @@ TEST_F(ConstantFPRangeTest, FPClassify) {
   EXPECT_EQ(SomeNeg.classify(), fcNegFinite);
   EXPECT_EQ(PosInf.classify(), fcPosInf);
   EXPECT_EQ(NegInf.classify(), fcNegInf);
-  EXPECT_TRUE(SomePos.toKnownFPClass().cannotBeOrderedLessThanZero());
   EXPECT_EQ(Finite.getSignBit(), std::nullopt);
   EXPECT_EQ(PosZero.getSignBit(), false);
   EXPECT_EQ(NegZero.getSignBit(), true);
   EXPECT_EQ(SomePos.getSignBit(), false);
   EXPECT_EQ(SomeNeg.getSignBit(), true);
-  EXPECT_EQ(SomePos.toKnownFPClass().SignBit, false);
-  EXPECT_EQ(SomeNeg.toKnownFPClass().SignBit, true);
 
   EnumerateConstantFPRanges(
       [](const ConstantFPRange &CR) {

--- a/llvm/unittests/IR/ConstantFPRangeTest.cpp
+++ b/llvm/unittests/IR/ConstantFPRangeTest.cpp
@@ -7,12 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/IR/ConstantFPRange.h"
-#include "llvm/ADT/BitVector.h"
-#include "llvm/ADT/Sequence.h"
-#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
-#include "llvm/Support/KnownBits.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;

--- a/llvm/unittests/IR/ConstantFPRangeTest.cpp
+++ b/llvm/unittests/IR/ConstantFPRangeTest.cpp
@@ -10,7 +10,6 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallBitVector.h"
-#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/Support/KnownBits.h"


### PR DESCRIPTION
Addresses comment https://github.com/llvm/llvm-project/pull/86483#pullrequestreview-2327710679.
