### PR TITLE
[lldb][test] Use tools from llvm instead of compiler tools

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -110,6 +110,10 @@ class Builder:
         if not cc:
             return []
 
+        exe_ext = ""
+        if lldbplatformutil.getHostPlatform() == "windows":
+            exe_ext = ".exe"
+
         cc = cc.strip()
         cc_path = pathlib.Path(cc)
 
@@ -149,9 +153,9 @@ class Builder:
         cc_dir = cc_path.parent
 
         def getToolchainUtil(util_name):
-            return cc_dir / (cc_prefix + util_name + cc_ext)
+            return os.path.join(configuration.llvm_tools_dir, util_name + exe_ext)
 
-        cxx = getToolchainUtil(cxx_type)
+        cxx = cc_dir / (cc_prefix + cxx_type + cc_ext)
 
         util_names = {
             "OBJCOPY": "objcopy",
@@ -160,6 +164,11 @@ class Builder:
             "DWP": "dwp",
         }
         utils = []
+
+        # Required by API TestBSDArchives.py tests.
+        # TODO don't forget to fix the test's Makefile when porting to mainline
+        if not os.getenv("LLVM_AR"):
+            utils.extend(["LLVM_AR=%s" % getToolchainUtil("llvm-ar")])
 
         if not lldbplatformutil.platformIsDarwin():
             if cc_type in ["clang", "cc", "gcc"]:

--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -166,7 +166,6 @@ class Builder:
         utils = []
 
         # Required by API TestBSDArchives.py tests.
-        # TODO don't forget to fix the test's Makefile when porting to mainline
         if not os.getenv("LLVM_AR"):
             utils.extend(["LLVM_AR=%s" % getToolchainUtil("llvm-ar")])
 

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -118,6 +118,9 @@ test_result = None
 # same base name.
 all_tests = set()
 
+# Path to LLVM tools to be used by tests.
+llvm_tools_dir = None
+
 # LLDB library directory.
 lldb_libs_dir = None
 lldb_obj_root = None

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -280,6 +280,7 @@ def parseOptionsAndInitTestdirs():
             "xcrun -find -toolchain default dsymutil"
         )
     if args.llvm_tools_dir:
+        configuration.llvm_tools_dir = args.llvm_tools_dir
         configuration.filecheck = shutil.which("FileCheck", path=args.llvm_tools_dir)
         configuration.yaml2obj = shutil.which("yaml2obj", path=args.llvm_tools_dir)
 

--- a/lldb/test/API/functionalities/archives/Makefile
+++ b/lldb/test/API/functionalities/archives/Makefile
@@ -12,12 +12,10 @@ libfoo.a: a.o b.o
 
 # This tests whether lldb can load a thin archive
 libbar.a: c.o
-	$(eval LLVM_AR := $(LLVM_TOOLS_DIR)/llvm-ar)
 	$(eval LLVM_ARFLAGS := -rcsDT)
 	$(LLVM_AR) $(LLVM_ARFLAGS) $@ $^
 
 libfoo-thin.a: a.o b.o
-	$(eval LLVM_AR := $(LLVM_TOOLS_DIR)/llvm-ar)
 	$(eval LLVM_ARFLAGS := -rcsUT)
 	$(LLVM_AR) $(LLVM_ARFLAGS) $@ $^
 

--- a/lldb/test/API/functionalities/archives/TestBSDArchives.py
+++ b/lldb/test/API/functionalities/archives/TestBSDArchives.py
@@ -25,7 +25,6 @@ class BSDArchivesTestCase(TestBase):
         oslist=["windows"],
         bugnumber="llvm.org/pr24527.  Makefile.rules doesn't know how to build static libs on Windows",
     )
-    @expectedFailureAll(remote=True)
     def test(self):
         """Break inside a() and b() defined within libfoo.a."""
         self.build()

--- a/lldb/test/API/functionalities/archives/TestBSDArchives.py
+++ b/lldb/test/API/functionalities/archives/TestBSDArchives.py
@@ -25,6 +25,7 @@ class BSDArchivesTestCase(TestBase):
         oslist=["windows"],
         bugnumber="llvm.org/pr24527.  Makefile.rules doesn't know how to build static libs on Windows",
     )
+    @expectedFailureAll(remote=True)
     def test(self):
         """Break inside a() and b() defined within libfoo.a."""
         self.build()


### PR DESCRIPTION
In #102185, toolchain detection for API tests has been rewritten in Python. Tools paths for tests there are determined from compiler path.

Here tools are taken from `--llvm-tools-dir` dotest.py argument, which by default refers to the LLVM build directory, unless they are explicitly redefined in environment variables. It helps to minimize external dependencies and to maximize the reproducibility of the build.