### PR TITLE
[offload][ompt] Added lookup function for device callbacks

### DIFF
--- a/offload/include/OpenMP/OMPT/Callback.h
+++ b/offload/include/OpenMP/OMPT/Callback.h
@@ -49,6 +49,8 @@ namespace omp {
 namespace target {
 namespace ompt {
 
+extern ompt_interface_fn_t ompt_device_fn_lookup(const char *s);
+
 #define declareOmptCallback(Name, Type, Code) extern Name##_t Name##_fn;
 FOREACH_OMPT_NOEMI_EVENT(declareOmptCallback)
 FOREACH_OMPT_EMI_EVENT(declareOmptCallback)

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -767,7 +767,7 @@ Error GenericDeviceTy::init(GenericPluginTy &Plugin) {
       performOmptCallback(device_initialize, Plugin.getUserId(DeviceId),
                           /*type=*/getComputeUnitKind().c_str(),
                           /*device=*/reinterpret_cast<ompt_device_t *>(this),
-                          /*lookup=*/ompt::lookupCallbackByName,
+                          /*lookup=*/ompt::ompt_device_fn_lookup,
                           /*documentation=*/nullptr);
   }
 #endif

--- a/offload/src/OpenMP/OMPT/Callback.cpp
+++ b/offload/src/OpenMP/OMPT/Callback.cpp
@@ -27,6 +27,8 @@
 #undef DEBUG_PREFIX
 #define DEBUG_PREFIX "OMPT"
 
+using namespace llvm::omp::target::ompt;
+
 // Define OMPT callback functions (bound to actual callbacks later on)
 #define defineOmptCallback(Name, Type, Code)                                   \
   Name##_t llvm::omp::target::ompt::Name##_fn = nullptr;
@@ -34,7 +36,68 @@ FOREACH_OMPT_NOEMI_EVENT(defineOmptCallback)
 FOREACH_OMPT_EMI_EVENT(defineOmptCallback)
 #undef defineOmptCallback
 
-using namespace llvm::omp::target::ompt;
+int ompt_get_device_num_procs(ompt_device_t *device) { return 0; }
+
+ompt_device_time_t ompt_get_device_time(ompt_device_t *device) { return 0; }
+
+double ompt_translate_time(ompt_device_t *device, ompt_device_time_t time) {
+  return 0;
+}
+
+ompt_set_result_t ompt_set_trace_ompt(ompt_device_t *device,
+                                      unsigned int enable, unsigned int etype) {
+  return ompt_set_error;
+}
+
+ompt_set_result_t ompt_set_trace_native(ompt_device_t *device, int enable,
+                                        int flags) {
+  return ompt_set_error;
+}
+
+int ompt_start_trace(ompt_device_t *device,
+                     ompt_callback_buffer_request_t request,
+                     ompt_callback_buffer_complete_t complete) {
+  return 0;
+}
+
+int ompt_pause_trace(ompt_device_t *device, int begin_pause) { return 0; }
+
+int ompt_flush_trace(ompt_device_t *device) { return 0; }
+
+int ompt_stop_trace(ompt_device_t *device) { return 0; }
+
+int ompt_advance_buffer_cursor(ompt_device_t *device, ompt_buffer_t *buffer,
+                               size_t size, ompt_buffer_cursor_t current,
+                               ompt_buffer_cursor_t *next) {
+  return 0;
+}
+
+ompt_record_t ompt_get_record_type(ompt_buffer_t *buffer,
+                                   ompt_buffer_cursor_t current) {
+  return ompt_record_ompt;
+}
+
+void *ompt_get_record_native(ompt_buffer_t *buffer,
+                             ompt_buffer_cursor_t current,
+                             ompt_id_t *host_op_id) {
+  return NULL;
+}
+
+ompt_record_abstract_t *ompt_get_record_abstract(void *native_record) {
+  return NULL;
+}
+
+ompt_interface_fn_t
+llvm::omp::target::ompt::ompt_device_fn_lookup(const char *s) {
+#define ompt_interface_fn(fn)                                                  \
+  if (strcmp(s, #fn) == 0) {                                                   \
+    fn##_t fn##_f = fn;                                                        \
+    return (ompt_interface_fn_t)fn##_f;                                        \
+  }
+  FOREACH_OMPT_DEVICE_INQUIRY_FN(ompt_interface_fn)
+#undef ompt_interface_fn
+  return NULL;
+}
 
 /// Forward declaration
 class LibomptargetRtlFinalizer;

--- a/openmp/runtime/src/include/omp-tools.h.var
+++ b/openmp/runtime/src/include/omp-tools.h.var
@@ -60,6 +60,23 @@
     macro(ompt_get_target_info)             \
     macro(ompt_get_num_devices)
 
+#define FOREACH_OMPT_DEVICE_INQUIRY_FN(macro) \
+    macro (ompt_get_device_num_procs)         \
+    macro (ompt_get_device_time)              \
+    macro (ompt_translate_time)               \
+    macro (ompt_set_trace_ompt)               \
+    macro (ompt_set_trace_native)             \
+    /* macro (ompt_get_buffer_limits) */      \
+    macro (ompt_start_trace)                  \
+    macro (ompt_pause_trace)                  \
+    macro (ompt_flush_trace)                  \
+    macro (ompt_stop_trace)                   \
+    macro (ompt_advance_buffer_cursor)        \
+    macro (ompt_get_record_type)              \
+    /* macro (ompt_get_record_ompt) */        \
+    macro (ompt_get_record_native)            \
+    macro (ompt_get_record_abstract)
+
 #define FOREACH_OMPT_STATE(macro)                                                                \
                                                                                                 \
     /* first available state */                                                                 \

--- a/openmp/runtime/src/ompt-general.cpp
+++ b/openmp/runtime/src/ompt-general.cpp
@@ -121,6 +121,8 @@ static ompt_start_tool_result_t *libomptarget_ompt_result = NULL;
 
 static ompt_interface_fn_t ompt_fn_lookup(const char *s);
 
+static ompt_interface_fn_t ompt_device_fn_lookup(const char *s);
+
 OMPT_API_ROUTINE ompt_data_t *ompt_get_thread_data(void);
 
 /*****************************************************************************


### PR DESCRIPTION
- replaced generic OMPT lookup function being provided by `ompt_callback_device_initialize` with a device-specific lookup function
- implemented device-specific lookup function
- added callback placeholders for not yet implemented device OMPT functions

An open question is how to go about testing that the lookup function returns pointers to the actual placeholders. Is there an existing test where this can be added, or does a separate one need to be made?