### PR TITLE
[flang][driver] Make the -J option less restrictive so we would not have to struggle with autoconf

### DIFF
--- a/flang/test/Driver/use-module-error.f90
+++ b/flang/test/Driver/use-module-error.f90
@@ -3,6 +3,11 @@
 !--------------------------
 ! FLANG DRIVER (flang-new)
 !--------------------------
+! RUN: %flang -fsyntax-only -J %S/Inputs/ %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
+! RUN: %flang -fsyntax-only -J %S/Inputs/ -J %S/Inputs/ %s  2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
+! RUN: %flang -fsyntax-only -module-dir %S/Inputs/module-dir %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
+! RUN: %flang -fsyntax-only -module-dir %S/Inputs/module-dir -module-dir %S/Inputs/module-dir %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
+! RUN: %flang -fsyntax-only -module-dir %S/Inputs/module-dir -J%S/Inputs/module-dir %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
 ! RUN: not %flang -fsyntax-only -J %S/Inputs/module-dir -J %S/Inputs/ %s  2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 ! RUN: not %flang -fsyntax-only -J %S/Inputs/module-dir -module-dir %S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 ! RUN: not %flang -fsyntax-only -module-dir %S/Inputs/module-dir -J%S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
@@ -10,11 +15,17 @@
 !-----------------------------------------
 ! FRONTEND FLANG DRIVER (flang-new -fc1)
 !-----------------------------------------
+! RUN: %flang_fc1 -fsyntax-only -J %S/Inputs/ %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
+! RUN: %flang_fc1 -fsyntax-only -J %S/Inputs/ -J %S/Inputs/ %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
+! RUN: %flang_fc1 -fsyntax-only -module-dir %S/Inputs/module-dir %s 2>&1 | FileCheck %s --allow-empty  --check-prefix=SINGLEINCLUDE
+! RUN: %flang_fc1 -fsyntax-only -module-dir %S/Inputs/module-dir -module-dir %S/Inputs/module-dir %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
+! RUN: %flang_fc1 -fsyntax-only -module-dir %S/Inputs/module-dir -J%S/Inputs/module-dir %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
 ! RUN: not %flang_fc1 -fsyntax-only -J %S/Inputs/module-dir -J %S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 ! RUN: not %flang_fc1 -fsyntax-only -J %S/Inputs/module-dir -module-dir %S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 ! RUN: not %flang_fc1 -fsyntax-only -module-dir %S/Inputs/module-dir -J%S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 
-! DOUBLEINCLUDE:error: Only one '-module-dir/-J' option allowed
+! DOUBLEINCLUDE:error: Only one '-module-dir/-J' directory allowed
+! SINGLEINCLUDE-NOT:error: Only one '-module-dir/-J' directory allowed
 
 program too_many_module_dirs
 end


### PR DESCRIPTION
There are autoconf-configured projects for which the generated Makefile is invoking flang with more than one -J option, each one specifying the same directory. Although only one module directory should be specified (by either -J or -module-dir), it should not really matter how many times this same directory has been specified.

Apparently, other compilers understand it that way, hence autoconf's configure script may generate a Makefile with the repetitive -J's.

For example, when trying to build the ABINIT [1] project (which can be configured by either CMake or the configure script) when configured by autoconf, it fails to build as such:

```
make[3]: Entering directory 'src/98_main'
mpifort -DHAVE_CONFIG_H -I. -I../../../src/98_main -I../..  -I../../src/incs -I../../../src/incs -Ifallbacks/exports/include  -Jbuild/mods  -Jbuild/mods -c -o abinit-abinit.o `test -f 'abinit.F90' || echo '../../../src/98_main/'`abinit.F90
error: Only one '-module-dir/-J' option allowed
make[3]: *** [Makefile:3961: abinit-abinit.o] Error 1
```

This patch solves the problem.

[1] https://github.com/abinit/abinit.git
