### PR TITLE
[libc++] Add a Github action to build libc++'s Docker images

### DIFF
--- a/.github/workflows/libcxx-build-containers.yaml
+++ b/.github/workflows/libcxx-build-containers.yaml
@@ -1,0 +1,51 @@
+# This file defines an action that builds the various Docker images used to run
+# libc++ CI whenever modifications to those Docker files are pushed to `main`.
+#
+# The images are pushed to the LLVM package registry at https://github.com/orgs/llvm/packages
+# and tagged appropriately. The selection of which Docker image version is used by the libc++
+# CI nodes at any given point is controlled by the libc++ maintainers using a mechanism that
+# is not publicly visible for safety purposes.
+
+name: Build Docker images for libc++ CI
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'libcxx/utils/ci/**'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'llvm'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push the Linux builder image
+      working-directory: libcxx/utils/ci
+      run:
+        - docker compose build actions-builder
+        - docker compose push actions-builder
+      env:
+        TAG: libcxx-linux-builder:${{ github.sha }}
+
+    - name: Build and push the Android builder image
+      working-directory: libcxx/utils/ci
+      run:
+        - docker compose build android-buildkite-builder
+        - docker compose push android-buildkite-builder
+      env:
+        TAG: libcxx-android-builder:${{ github.sha }}

--- a/.github/workflows/libcxx-build-containers.yaml
+++ b/.github/workflows/libcxx-build-containers.yaml
@@ -3,8 +3,7 @@
 #
 # The images are pushed to the LLVM package registry at https://github.com/orgs/llvm/packages
 # and tagged appropriately. The selection of which Docker image version is used by the libc++
-# CI nodes at any given point is controlled by the libc++ maintainers using a mechanism that
-# is not publicly visible for safety purposes.
+# CI nodes at any given point is controlled from the workflow files themselves.
 
 name: Build Docker images for libc++ CI
 
@@ -27,6 +26,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build the Linux builder image and the Android builder image
+      working-directory: libcxx/utils/ci
+      run:
+        - docker compose build actions-builder
+        - docker compose build android-buildkite-builder
+
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -34,18 +39,16 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push the Linux builder image
+    - name: Push the Linux builder image
       working-directory: libcxx/utils/ci
       run:
-        - docker compose build actions-builder
         - docker compose push actions-builder
       env:
         TAG: libcxx-linux-builder:${{ github.sha }}
 
-    - name: Build and push the Android builder image
+    - name: Push the Android builder image
       working-directory: libcxx/utils/ci
       run:
-        - docker compose build android-buildkite-builder
         - docker compose push android-buildkite-builder
       env:
         TAG: libcxx-android-builder:${{ github.sha }}

--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -17,6 +17,13 @@ on:
       - main
     paths:
       - 'libcxx/utils/ci/**'
+      - '.github/workflows/libcxx-build-containers.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'libcxx/utils/ci/**'
+      - '.github/workflows/libcxx-build-containers.yml'
 
 jobs:
   build-and-push:
@@ -40,6 +47,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push the Linux builder image
+      if: github.event_name == 'push'
       working-directory: libcxx/utils/ci
       run:
         - docker compose push actions-builder
@@ -47,6 +55,7 @@ jobs:
         TAG: libcxx-linux-builder:${{ github.sha }}
 
     - name: Push the Android builder image
+      if: github.event_name == 'push'
       working-directory: libcxx/utils/ci
       run:
         - docker compose push android-buildkite-builder


### PR DESCRIPTION
This patch adds a Github action that runs whenever changes to the libc++ Docker images are pushed to `main`. The action will rebuild the Docker images and push them to LLVM's container registry so that we can then point to those images from our CI nodes.