### PR TITLE
[flang][driver] rename flang-new to flang

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -328,7 +328,7 @@ jobs:
       run: |
         # Build some of the mlir tools that take a long time to link
         if [ "${{ needs.prepare.outputs.build-flang }}" = "true" ]; then
-          ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/ -j2 flang-new bbc
+          ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/ -j2 flang bbc
         fi
         ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/ \
             mlir-bytecode-parser-fuzzer \

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -147,6 +147,9 @@ def warn_drv_unsupported_option_for_processor : Warning<
 def warn_drv_unsupported_openmp_library : Warning<
   "the library '%0=%1' is not supported, OpenMP will not be enabled">,
   InGroup<OptionIgnored>;
+def warn_openmp_experimental : Warning<
+  "OpenMP support in flang is still experimental">,
+  InGroup<ExperimentalOption>;
 
 def err_drv_invalid_thread_model_for_target : Error<
   "invalid thread model '%0' in '%1' for this target">;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1583,3 +1583,7 @@ def ExtractAPIMisuse : DiagGroup<"extractapi-misuse">;
 // Warnings about using the non-standard extension having an explicit specialization
 // with a storage class specifier.
 def ExplicitSpecializationStorageClass : DiagGroup<"explicit-specialization-storage-class">;
+
+// A warning for options that enable a feature that is not yet complete
+def ExperimentalOption : DiagGroup<"experimental-option">;
+

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6077,7 +6077,7 @@ def _sysroot_EQ : Joined<["--"], "sysroot=">, Visibility<[ClangOption, FlangOpti
 def _sysroot : Separate<["--"], "sysroot">, Alias<_sysroot_EQ>;
 
 //===----------------------------------------------------------------------===//
-// pie/pic options (clang + flang-new)
+// pie/pic options (clang + flang)
 //===----------------------------------------------------------------------===//
 let Visibility = [ClangOption, FlangOption] in {
 
@@ -6093,7 +6093,7 @@ def fno_pie : Flag<["-"], "fno-pie">, Group<f_Group>;
 } // let Vis = [Default, FlangOption]
 
 //===----------------------------------------------------------------------===//
-// Target Options (clang + flang-new)
+// Target Options (clang + flang)
 //===----------------------------------------------------------------------===//
 let Flags = [TargetSpecific] in {
 let Visibility = [ClangOption, FlangOption] in {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2029,7 +2029,7 @@ void Driver::PrintHelp(bool ShowHidden) const {
 
 void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   if (IsFlangMode()) {
-    OS << getClangToolFullVersion("flang-new") << '\n';
+    OS << getClangToolFullVersion("flang") << '\n';
   } else {
     // FIXME: The following handlers should use a callback mechanism, we don't
     // know what the client would like to do.

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -386,6 +386,9 @@ static const DriverSuffix *FindDriverSuffix(StringRef ProgName, size_t &Pos) {
       {"cl", "--driver-mode=cl"},
       {"++", "--driver-mode=g++"},
       {"flang", "--driver-mode=flang"},
+      // For backwards compatibility, we create a symlink for `flang` called
+      // `flang-new`. This will be removed in the future.
+      {"flang-new", "--driver-mode=flang"},
       {"clang-dxc", "--driver-mode=dxc"},
   };
 

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -881,14 +881,12 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   CmdArgs.push_back(Input.getFilename());
 
-  // TODO: Replace flang-new with flang once the new driver replaces the
-  // throwaway driver
-  const char *Exec = Args.MakeArgString(D.GetProgramPath("flang-new", TC));
+  const char *Exec = Args.MakeArgString(D.GetProgramPath("flang", TC));
   C.addCommand(std::make_unique<Command>(JA, *this,
                                          ResponseFileSupport::AtFileUTF8(),
                                          Exec, CmdArgs, Inputs, Output));
 }
 
-Flang::Flang(const ToolChain &TC) : Tool("flang-new", "flang frontend", TC) {}
+Flang::Flang(const ToolChain &TC) : Tool("flang", "flang frontend", TC) {}
 
 Flang::~Flang() {}

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -787,6 +787,9 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
       if (Args.hasArg(options::OPT_fopenmp_force_usm))
         CmdArgs.push_back("-fopenmp-force-usm");
+      // TODO: OpenMP support isn't "done" yet, so for now we warn that it
+      // is experimental.
+      D.Diag(diag::warn_openmp_experimental);
 
       // FIXME: Clang supports a whole bunch more flags here.
       break;

--- a/clang/test/Driver/flang/flang.f90
+++ b/clang/test/Driver/flang/flang.f90
@@ -13,7 +13,7 @@
 ! * (no type specified, resulting in an object file)
 
 ! All invocations should begin with flang -fc1, consume up to here.
-! ALL-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! ALL-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 
 ! Check that f90 files are not treated as "previously preprocessed"
 ! ... in --driver-mode=flang.

--- a/clang/test/Driver/flang/flang_ucase.F90
+++ b/clang/test/Driver/flang/flang_ucase.F90
@@ -13,7 +13,7 @@
 ! * (no type specified, resulting in an object file)
 
 ! All invocations should begin with flang -fc1, consume up to here.
-! ALL-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! ALL-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 
 ! Check that f90 files are not treated as "previously preprocessed"
 ! ... in --driver-mode=flang.

--- a/clang/test/Driver/flang/multiple-inputs-mixed.f90
+++ b/clang/test/Driver/flang/multiple-inputs-mixed.f90
@@ -1,7 +1,7 @@
 ! Check that flang can handle mixed C and fortran inputs.
 
 ! RUN: %clang --driver-mode=flang -### -fsyntax-only %S/Inputs/one.f90 %S/Inputs/other.c 2>&1 | FileCheck --check-prefixes=CHECK-SYNTAX-ONLY %s
-! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/one.f90"
 ! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}clang{{[^"/]*}}" "-cc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/other.c"

--- a/clang/test/Driver/flang/multiple-inputs.f90
+++ b/clang/test/Driver/flang/multiple-inputs.f90
@@ -1,7 +1,7 @@
 ! Check that flang driver can handle multiple inputs at once.
 
 ! RUN: %clang --driver-mode=flang -### -fsyntax-only %S/Inputs/one.f90 %S/Inputs/two.f90 2>&1 | FileCheck --check-prefixes=CHECK-SYNTAX-ONLY %s
-! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/one.f90"
-! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang-new{{[^"/]*}}" "-fc1"
+! CHECK-SYNTAX-ONLY-LABEL: "{{[^"]*}}flang{{[^"/]*}}" "-fc1"
 ! CHECK-SYNTAX-ONLY: "{{[^"]*}}/Inputs/two.f90"

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -15,17 +15,13 @@ local:
 ```
 
 There are two main drivers in Flang:
-* the compiler driver, `flang-new`
-* the frontend driver, `flang-new -fc1`
-
-> **_NOTE:_** The diagrams in this document refer to `flang` as opposed to
-> `flang-new`. Eventually, `flang-new` will be renamed as `flang` and the
-> diagrams reflect the final design that we are still working towards.
+* the compiler driver, `flang`
+* the frontend driver, `flang -fc1`
 
 The **compiler driver** will allow you to control all compilation phases (e.g.
 preprocessing, semantic checks, code-generation, code-optimisation, lowering
 and linking). For frontend specific tasks, the compiler driver creates a
-Fortran compilation job and delegates it to `flang-new -fc1`, the frontend
+Fortran compilation job and delegates it to `flang -fc1`, the frontend
 driver. For linking, it creates a linker job and calls an external linker (e.g.
 LLVM's [`lld`](https://lld.llvm.org/)). It can also call other tools such as
 external assemblers (e.g. [`as`](https://www.gnu.org/software/binutils/)). In
@@ -47,7 +43,7 @@ frontend. It uses MLIR and LLVM for code-generation and can be viewed as a
 driver for Flang, LLVM and MLIR libraries. Contrary to the compiler driver, it
 is not capable of calling any external tools (including linkers).  It is aware
 of all the frontend internals that are "hidden" from the compiler driver. It
-accepts many frontend-specific options not available in `flang-new` and as such
+accepts many frontend-specific options not available in `flang` and as such
 it provides a finer control over the frontend. Note that this tool is mostly
 intended for Flang developers. In particular, there are no guarantees about the
 stability of its interface and compiler developers can use it to experiment
@@ -62,30 +58,30 @@ frontend specific flag from the _compiler_ directly to the _frontend_ driver,
 e.g.:
 
 ```bash
-flang-new -Xflang -fdebug-dump-parse-tree input.f95
+flang -Xflang -fdebug-dump-parse-tree input.f95
 ```
 
-In the invocation above, `-fdebug-dump-parse-tree` is forwarded to `flang-new
+In the invocation above, `-fdebug-dump-parse-tree` is forwarded to `flang
 -fc1`. Without the forwarding flag, `-Xflang`, you would see the following
 warning:
 
 ```bash
-flang-new: warning: argument unused during compilation:
+flang: warning: argument unused during compilation:
 ```
 
-As `-fdebug-dump-parse-tree` is only supported by `flang-new -fc1`, `flang-new`
+As `-fdebug-dump-parse-tree` is only supported by `flang -fc1`, `flang`
 will ignore it when used without `Xflang`.
 
 ## Why Do We Need Two Drivers?
-As hinted above, `flang-new` and `flang-new -fc1` are two separate tools. The
-fact that these tools are accessed through one binary, `flang-new`, is just an
+As hinted above, `flang` and `flang -fc1` are two separate tools. The
+fact that these tools are accessed through one binary, `flang`, is just an
 implementation detail. Each tool has a separate list of options, albeit defined
 in the same file: `clang/include/clang/Driver/Options.td`.
 
 The separation helps us split various tasks and allows us to implement more
-specialised tools. In particular, `flang-new` is not aware of various
+specialised tools. In particular, `flang` is not aware of various
 compilation phases within the frontend (e.g. scanning, parsing or semantic
-checks). It does not have to be. Conversely, the frontend driver, `flang-new
+checks). It does not have to be. Conversely, the frontend driver, `flang
 -fc1`, needs not to be concerned with linkers or other external tools like
 assemblers. Nor does it need to know where to look for various systems
 libraries, which is usually OS and platform specific.
@@ -104,7 +100,7 @@ GCC](https://en.wikibooks.org/wiki/GNU_C_Compiler_Internals/GNU_C_Compiler_Archi
 In fact, Flang needs to adhere to this model in order to be able to re-use
 Clang's driver library. If you are more familiar with the [architecture of
 GFortran](https://gcc.gnu.org/onlinedocs/gcc-4.7.4/gfortran/About-GNU-Fortran.html)
-than Clang, then `flang-new` corresponds to `gfortran` and `flang-new -fc1` to
+than Clang, then `flang` corresponds to `gfortran` and `flang -fc1` to
 `f951`.
 
 ## Compiler Driver
@@ -135,7 +131,7 @@ output from one action is the input for the subsequent one. You can use the
 `-ccc-print-phases` flag to see the sequence of actions that the driver will
 create for your compiler invocation:
 ```bash
-flang-new -ccc-print-phases -E file.f
+flang -ccc-print-phases -E file.f
 +- 0: input, "file.f", f95-cpp-input
 1: preprocessor, {0}, f95
 ```
@@ -143,7 +139,7 @@ As you can see, for `-E` the driver creates only two jobs and stops immediately
 after preprocessing. The first job simply prepares the input. For `-c`, the
 pipeline of the created jobs is more complex:
 ```bash
-flang-new -ccc-print-phases -c file.f
+flang -ccc-print-phases -c file.f
          +- 0: input, "file.f", f95-cpp-input
       +- 1: preprocessor, {0}, f95
    +- 2: compiler, {1}, ir
@@ -158,7 +154,7 @@ command to call the frontend driver is generated (more specifically, an
 instance of `clang::driver::Command`). Every command is bound to an instance of
 `clang::driver::Tool`. For Flang we introduced a specialisation of this class:
 `clang::driver::Flang`. This class implements the logic to either translate or
-forward compiler options to the frontend driver, `flang-new -fc1`.
+forward compiler options to the frontend driver, `flang -fc1`.
 
 You can read more on the design of `clangDriver` in Clang's [Driver Design &
 Internals](https://clang.llvm.org/docs/DriverInternals.html).
@@ -232,12 +228,12 @@ driver, `clang -cc1` and consists of the following classes:
 This list is not exhaustive and only covers the main classes that implement the
 driver. The main entry point for the frontend driver, `fc1_main`, is
 implemented in `flang/tools/flang-driver/driver.cpp`. It can be accessed by
-invoking the compiler driver, `flang-new`, with the `-fc1` flag.
+invoking the compiler driver, `flang`, with the `-fc1` flag.
 
 The frontend driver will only run one action at a time. If you specify multiple
 action flags, only the last one will be taken into account. The default action
 is `ParseSyntaxOnlyAction`, which corresponds to `-fsyntax-only`. In other
-words, `flang-new -fc1 <input-file>` is equivalent to `flang-new -fc1 -fsyntax-only
+words, `flang -fc1 <input-file>` is equivalent to `flang -fc1 -fsyntax-only
 <input-file>`.
 
 ## Adding new Compiler Options
@@ -262,8 +258,8 @@ similar semantics to your new option and start by copying that.
 For every new option, you will also have to define the visibility of the new
 option. This is controlled through the `Visibility` field. You can use the
 following Flang specific visibility flags to control this:
-  * `FlangOption` - this option will be available in the `flang-new` compiler driver,
-  * `FC1Option` - this option will be available in the `flang-new -fc1` frontend driver,
+  * `FlangOption` - this option will be available in the `flang` compiler driver,
+  * `FC1Option` - this option will be available in the `flang -fc1` frontend driver,
 
 Options that are supported by clang should explicitly specify `ClangOption` in
 `Visibility`, and options that are only supported in Flang should not specify
@@ -290,10 +286,10 @@ The parsing will depend on the semantics encoded in the TableGen definition.
 
 When adding a compiler driver option (i.e. an option that contains
 `FlangOption` among in it's `Visibility`) that you also intend to be understood
-by the frontend, make sure that it is either forwarded to `flang-new -fc1` or
+by the frontend, make sure that it is either forwarded to `flang -fc1` or
 translated into some other option that is accepted by the frontend driver. In
 the case of options that contain both `FlangOption` and `FC1Option` among its
-flags, we usually just forward from `flang-new` to `flang-new -fc1`. This is
+flags, we usually just forward from `flang` to `flang -fc1`. This is
 then tested in `flang/test/Driver/frontend-forward.F90`.
 
 What follows is usually very dependant on the meaning of the corresponding
@@ -339,11 +335,11 @@ just added using your new frontend option.
 
 ## CMake Support
 As of [#7246](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7246)
-(and soon to be released CMake 3.24.0), `cmake` can detect `flang-new` as a
+(and soon to be released CMake 3.24.0), `cmake` can detect `flang` as a
 supported Fortran compiler. You can configure your CMake projects to use
-`flang-new` as follows:
+`flang` as follows:
 ```bash
-cmake -DCMAKE_Fortran_COMPILER=<path/to/flang-new> <src/dir>
+cmake -DCMAKE_Fortran_COMPILER=<path/to/flang> <src/dir>
 ```
 You should see the following in the output:
 ```
@@ -353,14 +349,14 @@ where `<version>` corresponds to the LLVM Flang version.
 
 ## Testing
 In LIT, we define two variables that you can use to invoke Flang's drivers:
-* `%flang` is expanded as `flang-new` (i.e. the compiler driver)
-* `%flang_fc1` is expanded as `flang-new -fc1` (i.e. the frontend driver)
+* `%flang` is expanded as `flang` (i.e. the compiler driver)
+* `%flang_fc1` is expanded as `flang -fc1` (i.e. the frontend driver)
 
 For most regression tests for the frontend, you will want to use `%flang_fc1`.
 In some cases, the observable behaviour will be identical regardless of whether
 `%flang` or `%flang_fc1` is used. However, when you are using `%flang` instead
 of `%flang_fc1`, the compiler driver will add extra flags to the frontend
-driver invocation (i.e. `flang-new -fc1 -<extra-flags>`). In some cases that might
+driver invocation (i.e. `flang -fc1 -<extra-flags>`). In some cases that might
 be exactly what you want to test.  In fact, you can check these additional
 flags by using the `-###` compiler driver command line option.
 
@@ -380,7 +376,7 @@ plugins. The process for using plugins includes:
 * [Creating a plugin](#creating-a-plugin)
 * [Loading and running a plugin](#loading-and-running-a-plugin)
 
-Flang plugins are limited to `flang-new -fc1` and are currently only available /
+Flang plugins are limited to `flang -fc1` and are currently only available /
 been tested on Linux.
 
 ### Creating a Plugin
@@ -465,14 +461,14 @@ static FrontendPluginRegistry::Add<PrintFunctionNamesAction> X(
 
 ### Loading and Running a Plugin
 In order to use plugins, there are 2 command line options made available to the
-frontend driver, `flang-new -fc1`:
+frontend driver, `flang -fc1`:
 * [`-load <dsopath>`](#the--load-dsopath-option) for loading the dynamic shared
   object of the plugin
 * [`-plugin <name>`](#the--plugin-name-option) for calling the registered plugin
 
 Invocation of the example plugin is done through:
 ```bash
-flang-new -fc1 -load flangPrintFunctionNames.so -plugin print-fns file.f90
+flang -fc1 -load flangPrintFunctionNames.so -plugin print-fns file.f90
 ```
 
 Both these options are parsed in `flang/lib/Frontend/CompilerInvocation.cpp` and
@@ -493,7 +489,7 @@ reports an error diagnostic and returns `nullptr`.
 
 ### Enabling In-Tree Plugins
 For in-tree plugins, there is the CMake flag `FLANG_PLUGIN_SUPPORT`, enabled by
-default, that controls the exporting of executable symbols from `flang-new`,
+default, that controls the exporting of executable symbols from `flang`,
 which plugins need access to. Additionally, there is the CMake flag
 `LLVM_BUILD_EXAMPLES`, turned off by default, that is used to control if the
 example programs are built. This includes plugins that are in the
@@ -526,7 +522,7 @@ invocations `invokeFIROptEarlyEPCallbacks`, `invokeFIRInlinerCallback`, and
 `invokeFIROptLastEPCallbacks` for Flang drivers to be able to insert additonal
 passes at different points of the default pass pipeline. An example use of these
 extension point callbacks is shown in `registerDefaultInlinerPass` to invoke the
-default inliner pass in `flang-new`.
+default inliner pass in `flang`.
 
 ## LLVM Pass Plugins
 
@@ -539,7 +535,7 @@ documentation for
 [`llvm::PassBuilder`](https://llvm.org/doxygen/classllvm_1_1PassBuilder.html)
 for details.
 
-The framework to enable pass plugins in `flang-new` uses the exact same
+The framework to enable pass plugins in `flang` uses the exact same
 machinery as that used by `clang` and thus has the same capabilities and
 limitations.
 
@@ -547,7 +543,7 @@ In order to use a pass plugin, the pass(es) must be compiled into a dynamic
 shared object which is then loaded using the `-fpass-plugin` option.
 
 ```
-flang-new -fpass-plugin=/path/to/plugin.so <file.f90>
+flang -fpass-plugin=/path/to/plugin.so <file.f90>
 ```
 
 This option is available in both the compiler driver and the frontend driver.
@@ -559,7 +555,7 @@ Pass extensions are similar to plugins, except that they can also be linked
 statically. Setting `-DLLVM_${NAME}_LINK_INTO_TOOLS` to `ON` in the cmake
 command turns the project into a statically linked extension. An example would
 be Polly, e.g., using `-DLLVM_POLLY_LINK_INTO_TOOLS=ON` would link Polly passes
-into `flang-new` as built-in middle-end passes.
+into `flang` as built-in middle-end passes.
 
 See the
 [`WritingAnLLVMNewPMPass`](https://llvm.org/docs/WritingAnLLVMNewPMPass.html#id9)

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -335,7 +335,7 @@ just added using your new frontend option.
 
 ## CMake Support
 As of [#7246](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7246)
-(and soon to be released CMake 3.24.0), `cmake` can detect `flang` as a
+(CMake 3.28.0), `cmake` can detect `flang` as a
 supported Fortran compiler. You can configure your CMake projects to use
 `flang` as follows:
 ```bash

--- a/flang/docs/ImplementingASemanticCheck.md
+++ b/flang/docs/ImplementingASemanticCheck.md
@@ -68,7 +68,7 @@ of the call to `intentOutFunc()`:
 
 I also used this program to produce a parse tree for the program using the command:
 ```bash
-  flang-new -fc1 -fdebug-dump-parse-tree testfun.f90
+  flang -fc1 -fdebug-dump-parse-tree testfun.f90
 ```
 
 Here's the relevant fragment of the parse tree produced by the compiler:
@@ -296,7 +296,7 @@ In `lib/Semantics/check-do.cpp`, I added an (almost empty) implementation:
 I then built the compiler with these changes and ran it on my test program.
 This time, I made sure to invoke semantic checking.  Here's the command I used:
 ```bash
-  flang-new -fc1 -fdebug-unparse-with-symbols testfun.f90
+  flang -fc1 -fdebug-unparse-with-symbols testfun.f90
 ```
 
 This produced the output:

--- a/flang/docs/Overview.md
+++ b/flang/docs/Overview.md
@@ -65,8 +65,8 @@ See [Preprocessing.md](Preprocessing.md).
 **Entry point:** `parser::Parsing::Prescan`
 
 **Commands:** 
- - `flang-new -fc1 -E src.f90` dumps the cooked character stream
- - `flang-new -fc1 -fdebug-dump-provenance src.f90` dumps provenance
+ - `flang -fc1 -E src.f90` dumps the cooked character stream
+ - `flang -fc1 -fdebug-dump-provenance src.f90` dumps provenance
    information
 
 ### Parsing
@@ -80,10 +80,10 @@ representing a syntactically correct program, rooted at the program unit.  See:
 **Entry point:** `parser::Parsing::Parse`
 
 **Commands:**
-  - `flang-new -fc1 -fdebug-dump-parse-tree-no-sema src.f90` dumps the parse tree
-  - `flang-new -fc1 -fdebug-unparse src.f90` converts the parse tree to normalized Fortran
-  - `flang-new -fc1 -fdebug-dump-parsing-log src.f90` runs an instrumented parse and dumps the log
-  - `flang-new -fc1 -fdebug-measure-parse-tree src.f90` measures the parse tree
+  - `flang -fc1 -fdebug-dump-parse-tree-no-sema src.f90` dumps the parse tree
+  - `flang -fc1 -fdebug-unparse src.f90` converts the parse tree to normalized Fortran
+  - `flang -fc1 -fdebug-dump-parsing-log src.f90` runs an instrumented parse and dumps the log
+  - `flang -fc1 -fdebug-measure-parse-tree src.f90` measures the parse tree
 
 ### Semantic processing
 
@@ -121,9 +121,9 @@ In the course of semantic analysis, the compiler:
 At the end of semantic processing, all validation of the user's program is complete.  This is the last detailed phase of analysis processing.
 
 **Commands:**
-  - `flang-new -fc1 -fdebug-dump-parse-tree src.f90` dumps the parse tree after semantic analysis
-  - `flang-new -fc1 -fdebug-dump-symbols src.f90` dumps the symbol table
-  - `flang-new -fc1 -fdebug-dump-all src.f90` dumps both the parse tree and the symbol table
+  - `flang -fc1 -fdebug-dump-parse-tree src.f90` dumps the parse tree after semantic analysis
+  - `flang -fc1 -fdebug-dump-symbols src.f90` dumps the symbol table
+  - `flang -fc1 -fdebug-dump-all src.f90` dumps both the parse tree and the symbol table
 
 ## Lowering
 
@@ -163,8 +163,8 @@ contain a list of evaluations.  All of these contain pointers back into the
 parse tree.  The compiler walks the PFT generating FIR.
 
 **Commands:**
-  - `flang-new -fc1 -fdebug-dump-pft src.f90` dumps the pre-FIR tree
-  - `flang-new -fc1 -emit-mlir src.f90` dumps the FIR to the files src.mlir
+  - `flang -fc1 -fdebug-dump-pft src.f90` dumps the pre-FIR tree
+  - `flang -fc1 -emit-mlir src.f90` dumps the FIR to the files src.mlir
 
 ### Transformation passes
 
@@ -180,8 +180,8 @@ perform various optimizations and transformations.  The final pass creates an
 LLVM IR representation of the program.
 
 **Commands:**
-  - `flang-new -mmlir --mlir-print-ir-after-all -S src.f90` dumps the FIR code after each pass to standard error
-  - `flang-new -fc1 -emit-llvm src.f90` dumps the LLVM IR to src.ll
+  - `flang -mmlir --mlir-print-ir-after-all -S src.f90` dumps the FIR code after each pass to standard error
+  - `flang -fc1 -emit-llvm src.f90` dumps the LLVM IR to src.ll
 
 ## Object code generation and linking
 

--- a/flang/examples/FlangOmpReport/FlangOmpReport.cpp
+++ b/flang/examples/FlangOmpReport/FlangOmpReport.cpp
@@ -9,7 +9,7 @@
 // all the OpenMP constructs and clauses and which line they're located on.
 //
 // The plugin may be invoked as:
-// ./bin/flang-new -fc1 -load lib/flangOmpReport.so -plugin flang-omp-report
+// ./bin/flang -fc1 -load lib/flangOmpReport.so -plugin flang-omp-report
 // -fopenmp
 //
 //===----------------------------------------------------------------------===//

--- a/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
+++ b/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
@@ -67,7 +67,7 @@ struct AliasAnalysis {
   //  end subroutine
   //  -------------------------------------------------
   // 
-  //  flang-new -fc1 -emit-fir test.f90 -o test.fir
+  //  flang -fc1 -emit-fir test.f90 -o test.fir
   //
   //  ------------------- test.fir --------------------
   //  fir.global @_QMtopEa : !fir.box<!fir.ptr<!fir.array<?xf32>>> 

--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // A header file for containing functionallity that is used across Flang tools,
 // such as helper functions which apply or generate information needed accross
-// tools like bbc and flang-new.
+// tools like bbc and flang.
 //===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_TOOLS_CROSS_TOOL_HELPERS_H

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -66,8 +66,8 @@ CompilerInvocationBase::~CompilerInvocationBase() = default;
 static bool parseShowColorsArgs(const llvm::opt::ArgList &args,
                                 bool defaultColor = true) {
   // Color diagnostics default to auto ("on" if terminal supports) in the
-  // compiler driver `flang-new` but default to off in the frontend driver
-  // `flang-new -fc1`, needing an explicit OPT_fdiagnostics_color.
+  // compiler driver `flang` but default to off in the frontend driver
+  // `flang -fc1`, needing an explicit OPT_fdiagnostics_color.
   // Support both clang's -f[no-]color-diagnostics and gcc's
   // -f[no-]diagnostics-colors[=never|always|auto].
   enum {
@@ -900,7 +900,7 @@ static bool parseDiagArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
     }
   }
 
-  // Default to off for `flang-new -fc1`.
+  // Default to off for `flang -fc1`.
   res.getFrontendOpts().showColors =
       parseShowColorsArgs(args, /*defaultDiagColor=*/false);
 

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -233,7 +233,7 @@ bool CodeGenAction::beginSourceFileAction() {
     llvm::SMDiagnostic err;
     llvmModule = llvm::parseIRFile(getCurrentInput().getFile(), err, *llvmCtx);
     if (!llvmModule || llvm::verifyModule(*llvmModule, &llvm::errs())) {
-      err.print("flang-new", llvm::errs());
+      err.print("flang", llvm::errs());
       unsigned diagID = ci.getDiagnostics().getCustomDiagID(
           clang::DiagnosticsEngine::Error, "Could not parse IR");
       ci.getDiagnostics().Report(diagID);

--- a/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -154,8 +154,7 @@ bool executeCompilerInvocation(CompilerInstance *flang) {
   // Honor -help.
   if (flang->getFrontendOpts().showHelp) {
     clang::driver::getDriverOptTable().printHelp(
-        llvm::outs(), "flang-new -fc1 [options] file...",
-        "LLVM 'Flang' Compiler",
+        llvm::outs(), "flang -fc1 [options] file...", "LLVM 'Flang' Compiler",
         /*ShowHidden=*/false, /*ShowAllAliases=*/false,
         llvm::opt::Visibility(clang::driver::options::FC1Option));
     return true;

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -308,12 +308,12 @@ set_target_properties(FortranRuntime PROPERTIES FOLDER "Flang/Runtime Libraries"
 # If FortranRuntime is part of a Flang build (and not a separate build) then
 # add dependency to make sure that Fortran runtime library is being built after
 # we have the Flang compiler available.  This also includes the MODULE files
-# that compile when the 'flang-new' target is built.
+# that compile when the 'flang' target is built.
 #
 # TODO: This is a workaround and should be updated when runtime build procedure
 # is changed to a regular runtime build.  See discussion in PR #95388.
-if (TARGET flang-new AND TARGET module_files)
-  add_dependencies(FortranRuntime flang-new module_files)
+if (TARGET flang AND TARGET module_files)
+  add_dependencies(FortranRuntime flang module_files)
 endif()
 
 if (FLANG_CUF_RUNTIME)

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -58,7 +58,7 @@ set(FLANG_TEST_PARAMS
   flang_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py)
 
 set(FLANG_TEST_DEPENDS
-  flang-new
+  flang
   llvm-config
   FileCheck
   count

--- a/flang/test/Driver/aarch64-outline-atomics.f90
+++ b/flang/test/Driver/aarch64-outline-atomics.f90
@@ -1,4 +1,4 @@
-! Test that flang-new forwards the -moutline-atomics and -mno-outline-atomics.
+! Test that flang forwards the -moutline-atomics and -mno-outline-atomics.
 ! RUN: %flang -moutline-atomics --target=aarch64-none-none -### %s -o %t 2>&1  | FileCheck %s
 ! CHECK: "-target-feature" "+outline-atomics"
 

--- a/flang/test/Driver/color-diagnostics-forwarding.f90
+++ b/flang/test/Driver/color-diagnostics-forwarding.f90
@@ -1,5 +1,5 @@
-! Test that flang-new forwards -f{no-}color-diagnostics and
-! -f{no-}diagnostics-color options to flang-new -fc1 as expected.
+! Test that flang forwards -f{no-}color-diagnostics and
+! -f{no-}diagnostics-color options to flang -fc1 as expected.
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 -fcolor-diagnostics \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-CD

--- a/flang/test/Driver/compiler-options.f90
+++ b/flang/test/Driver/compiler-options.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang -S -emit-llvm -flang-deprecated-no-hlfir -o - %s | FileCheck %s
-! Test communication of COMPILER_OPTIONS from flang-new to flang-new -fc1.
-! CHECK: [[OPTSVAR:@_QQclX[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} {{.*}}-S -emit-llvm -flang-deprecated-no-hlfir -o - {{.*}}compiler-options.f90"
+! Test communication of COMPILER_OPTIONS from flang to flang -fc1.
+! CHECK: [[OPTSVAR:@_QQclX[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang{{(\.exe)?}} {{.*}}-S -emit-llvm -flang-deprecated-no-hlfir -o - {{.*}}compiler-options.f90"
 program main
     use ISO_FORTRAN_ENV, only: compiler_options
     implicit none

--- a/flang/test/Driver/convert.f90
+++ b/flang/test/Driver/convert.f90
@@ -12,7 +12,7 @@
 ! RUN: not %flang -fconvert=foobar %s  2>&1 | FileCheck %s --check-prefix=INVALID
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -emit-mlir -fconvert=unknown %s -o - | FileCheck %s --check-prefix=VALID_FC1
 ! RUN: %flang_fc1 -emit-mlir -fconvert=native %s -o - | FileCheck %s --check-prefix=VALID_FC1

--- a/flang/test/Driver/disable-ext-name-interop.f90
+++ b/flang/test/Driver/disable-ext-name-interop.f90
@@ -1,4 +1,4 @@
-! Test that we can disable the ExternalNameConversion pass in flang-new.
+! Test that we can disable the ExternalNameConversion pass in flang.
 
 ! RUN: %flang_fc1 -S %s -o - 2>&1 | FileCheck %s --check-prefix=EXTNAMES
 ! RUN: %flang_fc1 -S -mmlir -disable-external-name-interop %s -o - 2>&1 | FileCheck %s --check-prefix=INTNAMES

--- a/flang/test/Driver/driver-version.f90
+++ b/flang/test/Driver/driver-version.f90
@@ -4,12 +4,12 @@
 ! RUN: %flang_fc1 -version 2>&1 | FileCheck %s --check-prefix=VERSION-FC1
 ! RUN: not %flang_fc1 --version 2>&1 | FileCheck %s --check-prefix=ERROR-FC1
 
-! VERSION: flang-new version
+! VERSION: flang version
 ! VERSION-NEXT: Target:
 ! VERSION-NEXT: Thread model:
 ! VERSION-NEXT: InstalledDir:
 
-! ERROR: flang-new: error: unknown argument '--versions'; did you mean '--version'?
+! ERROR: flang: error: unknown argument '--versions'; did you mean '--version'?
 
 ! VERSION-FC1: LLVM version
 

--- a/flang/test/Driver/driver-version.f90
+++ b/flang/test/Driver/driver-version.f90
@@ -9,7 +9,7 @@
 ! VERSION-NEXT: Thread model:
 ! VERSION-NEXT: InstalledDir:
 
-! ERROR: flang: error: unknown argument '--versions'; did you mean '--version'?
+! ERROR: flang{{.*}}: error: unknown argument '--versions'; did you mean '--version'?
 
 ! VERSION-FC1: LLVM version
 

--- a/flang/test/Driver/escaped-backslash.f90
+++ b/flang/test/Driver/escaped-backslash.f90
@@ -1,14 +1,14 @@
 ! Ensure argument -fbackslash works as expected.
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang -E %s  2>&1 | FileCheck %s --check-prefix=ESCAPED
 ! RUN: %flang -E -fbackslash -fno-backslash %s  2>&1 | FileCheck %s --check-prefix=ESCAPED
 ! RUN: %flang -E -fbackslash %s  2>&1 | FileCheck %s --check-prefix=UNESCAPED
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -E %s  2>&1 | FileCheck %s --check-prefix=ESCAPED
 ! RUN: %flang_fc1 -E -fbackslash -fno-backslash %s  2>&1 | FileCheck %s --check-prefix=ESCAPED

--- a/flang/test/Driver/fdefault.f90
+++ b/flang/test/Driver/fdefault.f90
@@ -2,25 +2,25 @@
 ! TODO: Add checks when actual codegen is possible for this family
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOOPTION
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=REAL8
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=DOUBLE8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOOPTION
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=REAL8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=DOUBLE8
 ! RUN: not %flang -fsyntax-only -fdefault-double-8 %s  2>&1 | FileCheck %s --check-prefix=ERROR
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOOPTION
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=REAL8
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=DOUBLE8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOOPTION
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -fdefault-real-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=REAL8
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -fdefault-real-8 -fdefault-double-8 -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=DOUBLE8
 ! RUN: not %flang_fc1 -fsyntax-only -fdefault-double-8 %s  2>&1 | FileCheck %s --check-prefix=ERROR
 
 ! NOOPTION: integer(4),parameter::real_kind=4_4

--- a/flang/test/Driver/flarge-sizes.f90
+++ b/flang/test/Driver/flarge-sizes.f90
@@ -2,20 +2,20 @@
 ! TODO: Add checks when actual codegen is possible.
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOLARGE
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang -fsyntax-only -flarge-sizes -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=LARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOLARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang -fsyntax-only -flarge-sizes -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=LARGE
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=NOLARGE
-! RUN: rm -rf %t/dir-flang-new  && mkdir -p %t/dir-flang-new && %flang_fc1 -fsyntax-only -flarge-sizes -module-dir %t/dir-flang-new %s  2>&1
-! RUN: cat %t/dir-flang-new/m.mod | FileCheck %s --check-prefix=LARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=NOLARGE
+! RUN: rm -rf %t/dir-flang  && mkdir -p %t/dir-flang && %flang_fc1 -fsyntax-only -flarge-sizes -module-dir %t/dir-flang %s  2>&1
+! RUN: cat %t/dir-flang/m.mod | FileCheck %s --check-prefix=LARGE
 
 ! NOLARGE: real(4)::z(1_8:10_8)
 ! NOLARGE-NEXT: integer(4),parameter::size_kind=4_4

--- a/flang/test/Driver/fopenmp.f90
+++ b/flang/test/Driver/fopenmp.f90
@@ -73,3 +73,7 @@
 !
 ! CHECK-LD-ANYMD: "{{.*}}ld{{(.exe)?}}"
 ! CHECK-LD-ANYMD: "-l{{(omp|gomp|iomp5md)}}"
+!
+! RUN: %flang -fopenmp -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-EXPERIMENTAL
+!
+! CHECK-EXPERIMENTAL: flang{{.*}}: warning: OpenMP support in flang is still experimental

--- a/flang/test/Driver/frame-pointer-forwarding.f90
+++ b/flang/test/Driver/frame-pointer-forwarding.f90
@@ -1,4 +1,4 @@
-! Test that flang-new forwards -fno-omit-frame-pointer and -fomit-frame-pointer Flang frontend
+! Test that flang forwards -fno-omit-frame-pointer and -fomit-frame-pointer Flang frontend
 ! RUN: %flang --target=aarch64-none-none -fsyntax-only -### %s -o %t 2>&1  | FileCheck %s --check-prefix=CHECK-NOVALUE
 ! CHECK-NOVALUE: "-fc1"{{.*}}"-mframe-pointer=non-leaf"
 

--- a/flang/test/Driver/frontend-forwarding.f90
+++ b/flang/test/Driver/frontend-forwarding.f90
@@ -1,5 +1,5 @@
-! Test that flang-new forwards Flang frontend
-! options to flang-new -fc1 as expected.
+! Test that flang forwards Flang frontend
+! options to flang -fc1 as expected.
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 \
 ! RUN:     -finput-charset=utf-8 \

--- a/flang/test/Driver/hlfir-no-hlfir-error.f90
+++ b/flang/test/Driver/hlfir-no-hlfir-error.f90
@@ -2,12 +2,12 @@
 ! options cannot be both used.
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: not %flang -flang-experimental-hlfir -flang-deprecated-no-hlfir %s 2>&1 | FileCheck %s
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: not %flang_fc1 -emit-llvm -flang-experimental-hlfir -flang-deprecated-no-hlfir %s 2>&1 | FileCheck %s
 

--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -4,7 +4,7 @@
 ! default one, causing a CHECKSUM error.
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -fsyntax-only %s  2>&1 | FileCheck %s --allow-empty --check-prefix=WITHOUT
 ! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/ %s  2>&1 | FileCheck %s --check-prefix=GIVEN

--- a/flang/test/Driver/large-data-threshold.f90
+++ b/flang/test/Driver/large-data-threshold.f90
@@ -7,11 +7,11 @@
 ! RUN: not %flang -### -c --target=aarch64 -mcmodel=small -mlarge-data-threshold=32768 %s 2>&1 | FileCheck %s --check-prefix=NOT-SUPPORTED
   
   
-! CHECK: "{{.*}}flang-new" "-fc1"
+! CHECK: "{{.*}}flang" "-fc1"
 ! CHECK-SAME: "-mlarge-data-threshold=32768"
-! CHECK-59000: "{{.*}}flang-new" "-fc1"
+! CHECK-59000: "{{.*}}flang" "-fc1"
 ! CHECK-59000-SAME: "-mlarge-data-threshold=59000"
-! CHECK-1M: "{{.*}}flang-new" "-fc1"
+! CHECK-1M: "{{.*}}flang" "-fc1"
 ! CHECK-1M-SAME: "-mlarge-data-threshold=1048576"
 ! NO-MCMODEL: 'mlarge-data-threshold=' only applies to medium and large code models
 ! INVALID: error: invalid value 'nonsense' in '-mlarge-data-threshold='

--- a/flang/test/Driver/lto-flags.f90
+++ b/flang/test/Driver/lto-flags.f90
@@ -30,7 +30,7 @@
 ! FULL-LTO: "-fc1"
 ! FULL-LTO-SAME: "-flto=full"
 
-! THIN-LTO-ALL: flang-new: warning: the option '-flto=thin' is a work in progress
+! THIN-LTO-ALL: flang: warning: the option '-flto=thin' is a work in progress
 ! THIN-LTO-ALL: "-fc1"
 ! THIN-LTO-ALL-SAME: "-flto=thin"
 ! THIN-LTO-LINKER-PLUGIN: "-plugin-opt=thinlto"

--- a/flang/test/Driver/lto-flags.f90
+++ b/flang/test/Driver/lto-flags.f90
@@ -30,7 +30,7 @@
 ! FULL-LTO: "-fc1"
 ! FULL-LTO-SAME: "-flto=full"
 
-! THIN-LTO-ALL: flang: warning: the option '-flto=thin' is a work in progress
+! THIN-LTO-ALL: flang{{.*}}: warning: the option '-flto=thin' is a work in progress
 ! THIN-LTO-ALL: "-fc1"
 ! THIN-LTO-ALL-SAME: "-flto=thin"
 ! THIN-LTO-LINKER-PLUGIN: "-plugin-opt=thinlto"

--- a/flang/test/Driver/macro-def-undef.F90
+++ b/flang/test/Driver/macro-def-undef.F90
@@ -1,14 +1,14 @@
 ! Ensure arguments -D and -U work as expected.
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang -E -P %s  2>&1 | FileCheck %s --check-prefix=UNDEFINED
 ! RUN: %flang -E -P -DX=A %s  2>&1 | FileCheck %s --check-prefix=DEFINED
 ! RUN: %flang -E -P -DX=A -UX %s  2>&1 | FileCheck %s --check-prefix=UNDEFINED
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -E -P %s  2>&1 | FileCheck %s --check-prefix=UNDEFINED
 ! RUN: %flang_fc1 -E -P -DX=A %s  2>&1 | FileCheck %s --check-prefix=DEFINED

--- a/flang/test/Driver/missing-input.f90
+++ b/flang/test/Driver/missing-input.f90
@@ -1,26 +1,26 @@
 ! Test the behaviour of the driver when input is missing or is invalid. Note
-! that with the compiler driver (flang-new), the input _has_ to be specified.
+! that with the compiler driver (flang), the input _has_ to be specified.
 ! Indeed, the driver decides what "job/command" to create based on the input
 ! file's extension. No input file means that it doesn't know what to do
-! (compile?  preprocess? link?). The frontend driver (flang-new -fc1) simply
+! (compile?  preprocess? link?). The frontend driver (flang -fc1) simply
 ! assumes that "no explicit input == read from stdin"
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: not %flang  2>&1 | FileCheck %s --check-prefix=FLANG-NO-FILE
 ! RUN: not %flang %t.f90 2>&1 | FileCheck %s --check-prefix=FLANG-NONEXISTENT-FILE
 
 !-----------------------------------------
-! FLANG FRONTEND DRIVER (flang-new -fc1)
+! FLANG FRONTEND DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: not %flang_fc1 %t.f90 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-NONEXISTENT-FILE
 ! RUN: not %flang_fc1 %S 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-DIR
 
-! FLANG-NO-FILE: flang-new: error: no input files
+! FLANG-NO-FILE: flang: error: no input files
 
-! FLANG-NONEXISTENT-FILE: flang-new: error: no such file or directory: {{.*}}
-! FLANG-NONEXISTENT-FILE: flang-new: error: no input files
+! FLANG-NONEXISTENT-FILE: flang: error: no such file or directory: {{.*}}
+! FLANG-NONEXISTENT-FILE: flang: error: no input files
 
 ! FLANG-FC1-NONEXISTENT-FILE: error: {{.*}} does not exist
 ! FLANG-FC1-DIR: error: {{.*}} is not a regular file

--- a/flang/test/Driver/missing-input.f90
+++ b/flang/test/Driver/missing-input.f90
@@ -17,10 +17,10 @@
 ! RUN: not %flang_fc1 %t.f90 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-NONEXISTENT-FILE
 ! RUN: not %flang_fc1 %S 2>&1  | FileCheck %s --check-prefix=FLANG-FC1-DIR
 
-! FLANG-NO-FILE: flang: error: no input files
+! FLANG-NO-FILE: flang{{.*}}: error: no input files
 
-! FLANG-NONEXISTENT-FILE: flang: error: no such file or directory: {{.*}}
-! FLANG-NONEXISTENT-FILE: flang: error: no input files
+! FLANG-NONEXISTENT-FILE: flang{{.*}}: error: no such file or directory: {{.*}}
+! FLANG-NONEXISTENT-FILE: flang{{.*}}: error: no input files
 
 ! FLANG-FC1-NONEXISTENT-FILE: error: {{.*}} does not exist
 ! FLANG-FC1-DIR: error: {{.*}} is not a regular file

--- a/flang/test/Driver/multiple-input-files.f90
+++ b/flang/test/Driver/multiple-input-files.f90
@@ -39,7 +39,7 @@
 ! FLANG-NEXT:end program hello
 
 ! TEST 2: `-o` does not when multiple input files are present
-! ERROR: flang-new: error: cannot specify -o when generating multiple output files
+! ERROR: flang: error: cannot specify -o when generating multiple output files
 
 ! TEST 3: The output file _was not_ specified - `flang_fc1` will process all
 ! input files and generate one output file for every input file.

--- a/flang/test/Driver/multiple-input-files.f90
+++ b/flang/test/Driver/multiple-input-files.f90
@@ -39,7 +39,7 @@
 ! FLANG-NEXT:end program hello
 
 ! TEST 2: `-o` does not when multiple input files are present
-! ERROR: flang: error: cannot specify -o when generating multiple output files
+! ERROR: flang{{.*}}: error: cannot specify -o when generating multiple output files
 
 ! TEST 3: The output file _was not_ specified - `flang_fc1` will process all
 ! input files and generate one output file for every input file.

--- a/flang/test/Driver/omp-driver-offload.f90
+++ b/flang/test/Driver/omp-driver-offload.f90
@@ -1,6 +1,6 @@
-! Test that flang-new OpenMP and OpenMP offload related 
+! Test that flang OpenMP and OpenMP offload related 
 ! commands forward or expand to the appropriate commands 
-! for flang-new -fc1 as expected. Assumes a gfx90a, aarch64,
+! for flang -fc1 as expected. Assumes a gfx90a, aarch64,
 ! and sm_70 architecture, but doesn't require one to be 
 ! installed or compiled for, just testing the appropriate 
 ! generation of jobs are created with the correct 
@@ -8,8 +8,8 @@
 
 ! Test regular -fopenmp with no offload
 ! RUN: %flang -### -fopenmp %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP %s
-! CHECK-OPENMP: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
-! CHECK-OPENMP-NOT: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}}.f90"
+! CHECK-OPENMP-NOT: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Test regular -fopenmp with offload, and invocation filtering options
 ! RUN: %flang -S -### %s -o %t 2>&1 \
@@ -22,47 +22,47 @@
 ! RUN: --target=aarch64-unknown-linux-gnu -nogpulib\
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST-AND-DEVICE
 
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-HOST-AND-DEVICE-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-HOST-AND-DEVICE: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-host-only \
 ! RUN: --target=aarch64-unknown-linux-gnu -nogpulib\
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-HOST
 
-! OFFLOAD-HOST: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 ! OFFLOAD-HOST-NOT: "-triple" "amdgcn-amd-amdhsa"
 ! OFFLOAD-HOST-NOT: "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-HOST-NOT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-HOST-NOT: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! RUN: %flang -S -### %s 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-device-only \
 ! RUN: --target=aarch64-unknown-linux-gnu -nogpulib\
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-DEVICE
 
-! OFFLOAD-DEVICE: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
-! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "nvptx64-nvidia-cuda"
-! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-DEVICE-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! Test regular -fopenmp with offload for basic fopenmp-is-target-device flag addition and correct fopenmp 
 ! RUN: %flang -### -fopenmp --offload-arch=gfx90a -fopenmp-targets=amdgcn-amd-amdhsa -nogpulib %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP-IS-TARGET-DEVICE %s
-! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
+! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Testing appropriate flags are gnerated and appropriately assigned by the driver when offloading
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
 ! RUN: --target=aarch64-unknown-linux-gnu -nogpulib\
 ! RUN:   | FileCheck %s --check-prefix=OPENMP-OFFLOAD-ARGS
-! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}}.f90"
+! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "amdgcn-amd-amdhsa"
 ! OPENMP-OFFLOAD-ARGS-SAME:  "-fopenmp"
 ! OPENMP-OFFLOAD-ARGS-SAME:  "-fopenmp-host-ir-file-path" "{{.*}}.bc" "-fopenmp-is-target-device"
 ! OPENMP-OFFLOAD-ARGS-SAME:  {{.*}}.f90"
 ! OPENMP-OFFLOAD-ARGS: "{{[^"]*}}clang-offload-packager{{.*}}" {{.*}} "--image=file={{.*}}.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=openmp"
-! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 ! OPENMP-OFFLOAD-ARGS-SAME:  "-fopenmp"
 ! OPENMP-OFFLOAD-ARGS-SAME:  "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
 
@@ -77,7 +77,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-threads-oversubscription  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREADS-OVS
-! CHECK-THREADS-OVS: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
+! CHECK-THREADS-OVS: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -89,7 +89,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-teams-oversubscription  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TEAMS-OVS
-! CHECK-TEAMS-OVS: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
+! CHECK-TEAMS-OVS: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -101,7 +101,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-nested-parallelism  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-NEST-PAR
-! CHECK-NEST-PAR: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
+! CHECK-NEST-PAR: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -113,7 +113,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREAD-STATE
-! CHECK-THREAD-STATE: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
+! CHECK-THREAD-STATE: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -125,7 +125,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
+! CHECK-TARGET-DEBUG: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
 
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -137,7 +137,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
-! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
+! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
 
 ! RUN: %flang -S -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a \
@@ -153,7 +153,7 @@
 ! RUN: -fopenmp-assume-teams-oversubscription -fopenmp-assume-no-nested-parallelism \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-RTL-ALL
-! CHECK-RTL-ALL: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
+! CHECK-RTL-ALL: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
 ! CHECK-RTL-ALL: "-fopenmp-assume-threads-oversubscription" "-fopenmp-assume-no-thread-state" "-fopenmp-assume-no-nested-parallelism"
 ! CHECK-RTL-ALL: {{.*}}.f90"
 
@@ -167,7 +167,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-version=45 \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-OPENMP-VERSION
-! CHECK-OPENMP-VERSION: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
+! CHECK-OPENMP-VERSION: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
 
 ! Test diagnostic error when host IR file is non-existent 
 ! RUN: not %flang_fc1 %s -o %t 2>&1 -fopenmp -fopenmp-is-target-device \
@@ -187,7 +187,7 @@
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=FORCE-USM-NO-OFFLOAD
 
-! FORCE-USM-NO-OFFLOAD: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! FORCE-USM-NO-OFFLOAD: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 ! FORCE-USM-NO-OFFLOAD-SAME: "-fopenmp" "-fopenmp-force-usm"
 
 ! Test -fopenmp-force-usm option with offload
@@ -196,16 +196,16 @@
 ! RUN: --target=aarch64-unknown-linux-gnu -nogpulib\
 ! RUN:   | FileCheck %s --check-prefix=FORCE-USM-OFFLOAD
 
-! FORCE-USM-OFFLOAD: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! FORCE-USM-OFFLOAD: "{{[^"]*}}flang" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 ! FORCE-USM-OFFLOAD-SAME: "-fopenmp" "-fopenmp-force-usm"
-! FORCE-USM-OFFLOAD-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! FORCE-USM-OFFLOAD-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "amdgcn-amd-amdhsa"
 ! FORCE-USM-OFFLOAD-SAME: "-fopenmp" "-fopenmp-force-usm"
 
 ! RUN:   %flang -### -v --target=x86_64-unknown-linux-gnu -fopenmp  \
 ! RUN:      --offload-arch=gfx900 \
 ! RUN:      --rocm-path=%S/Inputs/rocm %s 2>&1 \
 ! RUN:   | FileCheck --check-prefix=MLINK-BUILTIN-BITCODE  %s
-! MLINK-BUILTIN-BITCODE:      "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! MLINK-BUILTIN-BITCODE:      "{{[^"]*}}flang" "-fc1" "-triple" "amdgcn-amd-amdhsa"
 ! MLINK-BUILTIN-BITCODE-SAME: "-mlink-builtin-bitcode" {{.*Inputs.*rocm.*amdgcn.*bitcode.*}}oclc_isa_version_900.bc
 
 ! Test that the -fopenmp-targets option is added to host compilation invocations
@@ -219,9 +219,9 @@
 ! RUN: --target=x86_64-unknown-linux-gnu -nogpulib \
 ! RUN: | FileCheck %s --check-prefix=OFFLOAD-TARGETS
 
-! OFFLOAD-TARGETS: "{{[^"]*}}flang-new" "-fc1" "-triple" "x86_64-unknown-linux-gnu"
+! OFFLOAD-TARGETS: "{{[^"]*}}flang" "-fc1" "-triple" "x86_64-unknown-linux-gnu"
 ! OFFLOAD-TARGETS-SAME: "-fopenmp-targets=amdgcn-amd-amdhsa"
-! OFFLOAD-TARGETS-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OFFLOAD-TARGETS-NEXT: "{{[^"]*}}flang" "-fc1" "-triple" "amdgcn-amd-amdhsa"
 ! OFFLOAD-TARGETS-NOT: -fopenmp-targets
-! OFFLOAD-TARGETS: "{{[^"]*}}flang-new" "-fc1" "-triple" "x86_64-unknown-linux-gnu"
+! OFFLOAD-TARGETS: "{{[^"]*}}flang" "-fc1" "-triple" "x86_64-unknown-linux-gnu"
 ! OFFLOAD-TARGETS-SAME: "-fopenmp-targets=amdgcn-amd-amdhsa"

--- a/flang/test/Driver/predefined-macros-compiler-version.F90
+++ b/flang/test/Driver/predefined-macros-compiler-version.F90
@@ -1,12 +1,12 @@
 ! Check that the driver correctly defines macros with the compiler version
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang_fc1 -E %s  2>&1 | FileCheck %s --ignore-case
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -E %s  2>&1 | FileCheck %s --ignore-case
 

--- a/flang/test/Driver/std2018-wrong.f90
+++ b/flang/test/Driver/std2018-wrong.f90
@@ -1,7 +1,7 @@
 ! Ensure argument -std=f2018 works as expected.
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: not %flang_fc1 -std=90 %s  2>&1 | FileCheck %s --check-prefix=WRONG
 

--- a/flang/test/Driver/std2018.f90
+++ b/flang/test/Driver/std2018.f90
@@ -1,7 +1,7 @@
 ! Ensure argument -std=f2018 works as expected.
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -fsyntax-only %s  2>&1 | FileCheck %s --allow-empty --check-prefix=WITHOUT
 ! RUN: %flang_fc1 -fsyntax-only -std=f2018 %s  2>&1 | FileCheck %s --check-prefix=GIVEN

--- a/flang/test/Driver/supported-suffices/f03-suffix.f03
+++ b/flang/test/Driver/supported-suffices/f03-suffix.f03
@@ -1,5 +1,5 @@
 ! RUN: %flang -### %s 2>&1 | FileCheck %s
 
-! CHECK: "{{.*}}flang-new" "-fc1" {{.*}} "-o" "{{.*}}.o"
+! CHECK: "{{.*}}flang" "-fc1" {{.*}} "-o" "{{.*}}.o"
 program f03
 end program f03

--- a/flang/test/Driver/supported-suffices/f08-suffix.f08
+++ b/flang/test/Driver/supported-suffices/f08-suffix.f08
@@ -1,5 +1,5 @@
 ! RUN: %flang -### %s 2>&1 | FileCheck %s
 
-! CHECK: "{{.*}}flang-new" "-fc1" {{.*}} "-o" "{{.*}}.o"
+! CHECK: "{{.*}}flang" "-fc1" {{.*}} "-o" "{{.*}}.o"
 program f08
 end program f08

--- a/flang/test/Driver/use-module-error.f90
+++ b/flang/test/Driver/use-module-error.f90
@@ -1,7 +1,7 @@
 ! Ensure that multiple module directories are not allowed
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang -fsyntax-only -J %S/Inputs/ %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
 ! RUN: %flang -fsyntax-only -J %S/Inputs/ -J %S/Inputs/ %s  2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
@@ -13,7 +13,7 @@
 ! RUN: not %flang -fsyntax-only -module-dir %S/Inputs/module-dir -J%S/Inputs/ %s 2>&1 | FileCheck %s --check-prefix=DOUBLEINCLUDE
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -fsyntax-only -J %S/Inputs/ %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE
 ! RUN: %flang_fc1 -fsyntax-only -J %S/Inputs/ -J %S/Inputs/ %s 2>&1 | FileCheck %s --allow-empty --check-prefix=SINGLEINCLUDE

--- a/flang/test/Driver/use-module.f90
+++ b/flang/test/Driver/use-module.f90
@@ -1,7 +1,7 @@
 ! Checks that module search directories specified with `-J/-module-dir` and `-I` are handled correctly
 
 !--------------------------
-! FLANG DRIVER (flang-new)
+! FLANG DRIVER (flang)
 !--------------------------
 ! RUN: %flang -fsyntax-only -I %S/Inputs -I %S/Inputs/module-dir %s  2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty
 ! RUN: %flang -fsyntax-only -I %S/Inputs -J %S/Inputs/module-dir %s 2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty
@@ -16,7 +16,7 @@
 ! RUN: not %flang -fsyntax-only -module-dir %S/Inputs/module-dir %s  2>&1 | FileCheck %s --check-prefix=SINGLEINCLUDE
 
 !-----------------------------------------
-! FRONTEND FLANG DRIVER (flang-new -fc1)
+! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
 ! RUN: %flang_fc1 -fsyntax-only -I %S/Inputs -I %S/Inputs/module-dir %s  2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty
 ! RUN: %flang_fc1 -fsyntax-only -I %S/Inputs -J %S/Inputs/module-dir %s 2>&1 | FileCheck %s --check-prefix=INCLUDED --allow-empty

--- a/flang/test/Driver/version-loops.f90
+++ b/flang/test/Driver/version-loops.f90
@@ -1,5 +1,5 @@
-! Test that flang-new forwards the -f{no-,}version-loops-for-stride 
-! options correctly to flang-new -fc1 for different variants of optimisation
+! Test that flang forwards the -f{no-,}version-loops-for-stride 
+! options correctly to flang -fc1 for different variants of optimisation
 ! and explicit flags.
 
 ! RUN: %flang -### %s -o %t 2>&1   -O3 \
@@ -23,32 +23,32 @@
 ! RUN: %flang -### %s -o %t 2>&1 -O3 -fno-version-loops-for-stride \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-O3-no
 
-! CHECK: "{{.*}}flang-new" "-fc1"
+! CHECK: "{{.*}}flang" "-fc1"
 ! CHECK-SAME: "-fversion-loops-for-stride"
 ! CHECK-SAME: "-O3"
 
-! CHECK-O2: "{{.*}}flang-new" "-fc1"
+! CHECK-O2: "{{.*}}flang" "-fc1"
 ! CHECK-O2-NOT: "-fversion-loops-for-stride"
 ! CHECK-O2-SAME: "-O2"  
 
-! CHECK-O2-with: "{{.*}}flang-new" "-fc1"
+! CHECK-O2-with: "{{.*}}flang" "-fc1"
 ! CHECK-O2-with-SAME: "-fversion-loops-for-stride"
 ! CHECK-O2-with-SAME: "-O2"  
   
-! CHECK-O4: "{{.*}}flang-new" "-fc1"
+! CHECK-O4: "{{.*}}flang" "-fc1"
 ! CHECK-O4-SAME: "-fversion-loops-for-stride"
 ! CHECK-O4-SAME: "-O3"
 
-! CHECK-Ofast: "{{.*}}flang-new" "-fc1"
+! CHECK-Ofast: "{{.*}}flang" "-fc1"
 ! CHECK-Ofast-SAME: "-ffast-math"
 ! CHECK-Ofast-SAME: "-fversion-loops-for-stride"
 ! CHECK-Ofast-SAME: "-O3"
 
-! CHECK-Ofast-no: "{{.*}}flang-new" "-fc1"
+! CHECK-Ofast-no: "{{.*}}flang" "-fc1"
 ! CHECK-Ofast-no-SAME: "-ffast-math"
 ! CHECK-Ofast-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-Ofast-no-SAME: "-O3"
 
-! CHECK-O3-no: "{{.*}}flang-new" "-fc1"
+! CHECK-O3-no: "{{.*}}flang" "-fc1"
 ! CHECK-O3-no-NOT: "-fversion-loops-for-stride"
 ! CHECK-O3-no-SAME: "-O3"

--- a/flang/test/Driver/wextra-ok.f90
+++ b/flang/test/Driver/wextra-ok.f90
@@ -1,4 +1,4 @@
-! Ensure that supplying -Wextra into flang-new does not raise error
+! Ensure that supplying -Wextra into flang does not raise error
 ! The first check should be changed if -Wextra is implemented
 
 ! RUN: %flang -std=f2018 -Wextra %s -c 2>&1 | FileCheck %s --check-prefix=CHECK-OK

--- a/flang/test/HLFIR/hlfir-flags.f90
+++ b/flang/test/HLFIR/hlfir-flags.f90
@@ -1,4 +1,4 @@
-! Test -flang-deprecated-hlfir, -flang-experimental-hlfir (flang-new), and
+! Test -flang-deprecated-hlfir, -flang-experimental-hlfir (flang), and
 ! -hlfir (bbc), -emit-hlfir, -emit-fir flags
 ! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck --check-prefix HLFIR --check-prefix ALL %s
 ! RUN: bbc -emit-hlfir -o - %s | FileCheck --check-prefix HLFIR --check-prefix ALL %s

--- a/flang/test/Lower/Intrinsics/command_argument_count.f90
+++ b/flang/test/Lower/Intrinsics/command_argument_count.f90
@@ -1,6 +1,6 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! bbc doesn't have a way to set the default kinds so we use flang-new driver
-! RUN: flang-new -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64  %s
+! bbc doesn't have a way to set the default kinds so we use flang driver
+! RUN: flang -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64  %s
 
 ! CHECK-LABEL: argument_count_test
 subroutine argument_count_test()

--- a/flang/test/Lower/Intrinsics/exit.f90
+++ b/flang/test/Lower/Intrinsics/exit.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck --check-prefixes=CHECK,CHECK-32 -DDEFAULT_INTEGER_SIZE=32 %s
-! bbc doesn't have a way to set the default kinds so we use flang-new driver
+! bbc doesn't have a way to set the default kinds so we use flang driver
 ! RUN: %flang_fc1 -fdefault-integer-8 -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64 -DDEFAULT_INTEGER_SIZE=64 %s
 
 ! CHECK-LABEL: func @_QPexit_test1() {

--- a/flang/test/Lower/Intrinsics/ieee_is_normal.f90
+++ b/flang/test/Lower/Intrinsics/ieee_is_normal.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! RUN: flang-new -fc1 -emit-fir %s -o - | FileCheck %s
+! RUN: flang -fc1 -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: ieee_is_normal_f16
 subroutine ieee_is_normal_f16(r)

--- a/flang/test/Lower/Intrinsics/isnan.f90
+++ b/flang/test/Lower/Intrinsics/isnan.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! RUN: flang-new -fc1 -emit-fir %s -o - | FileCheck %s
+! RUN: flang -fc1 -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: isnan_f32
 subroutine isnan_f32(r)

--- a/flang/test/Lower/Intrinsics/modulo.f90
+++ b/flang/test/Lower/Intrinsics/modulo.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s -check-prefixes=HONORINF,ALL
-! RUN: flang-new -fc1 -menable-no-infs -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s -check-prefixes=CHECK,ALL
+! RUN: flang -fc1 -menable-no-infs -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s -check-prefixes=CHECK,ALL
 
 ! ALL-LABEL: func @_QPmodulo_testr(
 ! ALL-SAME: %[[arg0:.*]]: !fir.ref<f64>{{.*}}, %[[arg1:.*]]: !fir.ref<f64>{{.*}}, %[[arg2:.*]]: !fir.ref<f64>{{.*}}) {

--- a/flang/test/Lower/OpenMP/Todo/omp-declarative-allocate.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declarative-allocate.f90
@@ -1,6 +1,6 @@
 ! This test checks lowering of OpenMP allocate Directive.
 
-// RUN: not flang-new -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
+// RUN: not flang -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
 
 program main
   integer :: x, y

--- a/flang/test/Lower/OpenMP/Todo/omp-declare-reduction.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declare-reduction.f90
@@ -1,6 +1,6 @@
 ! This test checks lowering of OpenMP declare reduction Directive.
 
-// RUN: not flang-new -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
+// RUN: not flang -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
 
 subroutine declare_red()
   integer :: my_var

--- a/flang/test/Lower/OpenMP/Todo/omp-declare-simd.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declare-simd.f90
@@ -1,6 +1,6 @@
 ! This test checks lowering of OpenMP declare simd Directive.
 
-// RUN: not flang-new -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
+// RUN: not flang -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
 
 subroutine sub(x, y)
   real, intent(inout) :: x, y

--- a/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
@@ -1,7 +1,7 @@
 ! This test checks lowering of `LASTPRIVATE` clause for scalar types.
 
 ! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
-! RUN: flang-new -fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
+! RUN: flang -fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
 
 !CHECK: func @_QPlastprivate_character(%[[ARG1:.*]]: !fir.boxchar<1>{{.*}}) {
 !CHECK-DAG: %[[ARG1_UNBOX:.*]]:2 = fir.unboxchar

--- a/flang/test/Lower/OpenMP/parallel-wsloop-reduction-byref.f90
+++ b/flang/test/Lower/OpenMP/parallel-wsloop-reduction-byref.f90
@@ -1,7 +1,7 @@
 ! Check that for parallel do, reduction is only processed for the loop
 
 ! RUN: bbc -fopenmp --force-byref-reduction -emit-hlfir %s -o - | FileCheck %s
-! RUN: flang-new -fc1 -fopenmp -mmlir --force-byref-reduction -emit-hlfir %s -o - | FileCheck %s
+! RUN: flang -fc1 -fopenmp -mmlir --force-byref-reduction -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK: omp.parallel {
 ! CHECK: omp.wsloop reduction(byref @add_reduction_byref_i32

--- a/flang/test/Lower/OpenMP/parallel-wsloop-reduction.f90
+++ b/flang/test/Lower/OpenMP/parallel-wsloop-reduction.f90
@@ -1,7 +1,7 @@
 ! Check that for parallel do, reduction is only processed for the loop
 
 ! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
-! RUN: flang-new -fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
+! RUN: flang -fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK: omp.parallel {
 ! CHECK: omp.wsloop reduction(@add_reduction_i32

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -132,13 +132,13 @@ if config.default_sysroot:
 tools = [
     ToolSubst(
         "%flang",
-        command=FindTool("flang-new"),
+        command=FindTool("flang"),
         extra_args=isysroot_flag,
         unresolved="fatal",
     ),
     ToolSubst(
         "%flang_fc1",
-        command=FindTool("flang-new"),
+        command=FindTool("flang"),
         extra_args=["-fc1"],
         unresolved="fatal",
     ),

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 set(module_objects "")
 
 # Create module files directly from the top-level module source directory.
-# If CMAKE_CROSSCOMPILING, then the newly built flang-new executable was
+# If CMAKE_CROSSCOMPILING, then the newly built flang executable was
 # cross compiled, and thus can't be executed on the build system and thus
 # can't be used for generating module files.
 if (NOT CMAKE_CROSSCOMPILING)
@@ -115,9 +115,9 @@ if (NOT CMAKE_CROSSCOMPILING)
     # TODO: We may need to flag this with conditional, in case Flang is built w/o OpenMP support
     add_custom_command(OUTPUT ${base}.mod ${object_output}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${FLANG_INTRINSIC_MODULES_DIR}
-      COMMAND flang-new ${opts} ${decls} -cpp ${compile_with} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
+      COMMAND flang ${opts} ${decls} -cpp ${compile_with} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
         ${FLANG_SOURCE_DIR}/module/${filename}.f90
-      DEPENDS flang-new ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${FLANG_SOURCE_DIR}/module/__fortran_builtins.f90 ${depends}
+      DEPENDS flang ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${FLANG_SOURCE_DIR}/module/__fortran_builtins.f90 ${depends}
     )
     list(APPEND MODULE_FILES ${base}.mod)
     install(FILES ${base}.mod DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/flang")
@@ -142,9 +142,9 @@ if (NOT CMAKE_CROSSCOMPILING)
     set(base ${FLANG_INTRINSIC_MODULES_DIR}/omp_lib)
     add_custom_command(OUTPUT ${base}.mod ${base}_kinds.mod
       COMMAND ${CMAKE_COMMAND} -E make_directory ${FLANG_INTRINSIC_MODULES_DIR}
-      COMMAND flang-new -cpp -fsyntax-only ${opts} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
+      COMMAND flang -cpp -fsyntax-only ${opts} -module-dir ${FLANG_INTRINSIC_MODULES_DIR}
         ${CMAKE_BINARY_DIR}/projects/openmp/runtime/src/omp_lib.F90
-      DEPENDS flang-new ${FLANG_INTRINSIC_MODULES_DIR}/iso_c_binding.mod ${CMAKE_BINARY_DIR}/projects/openmp/runtime/src/omp_lib.F90 ${depends}
+      DEPENDS flang ${FLANG_INTRINSIC_MODULES_DIR}/iso_c_binding.mod ${CMAKE_BINARY_DIR}/projects/openmp/runtime/src/omp_lib.F90 ${depends}
     )
     add_custom_command(OUTPUT ${base}.f18.mod
       DEPENDS ${base}.mod

--- a/flang/tools/flang-driver/CMakeLists.txt
+++ b/flang/tools/flang-driver/CMakeLists.txt
@@ -11,18 +11,18 @@ set( LLVM_LINK_COMPONENTS
   TargetParser
 )
 
-add_flang_tool(flang-new
+add_flang_tool(flang
   driver.cpp
   fc1_main.cpp
 )
 
-target_link_libraries(flang-new
+target_link_libraries(flang
   PRIVATE
   flangFrontend
   flangFrontendTool
 )
 
-clang_target_link_libraries(flang-new
+clang_target_link_libraries(flang
   PRIVATE
   clangDriver
   clangBasic
@@ -30,9 +30,9 @@ clang_target_link_libraries(flang-new
 
 option(FLANG_PLUGIN_SUPPORT "Build Flang with plugin support." ON)
 
-# Enable support for plugins, which need access to symbols from flang-new
+# Enable support for plugins, which need access to symbols from flang
 if(FLANG_PLUGIN_SUPPORT)
-  export_executable_symbols_for_plugins(flang-new)
+  export_executable_symbols_for_plugins(flang)
 endif()
 
-install(TARGETS flang-new DESTINATION "${CMAKE_INSTALL_BINDIR}")
+install(TARGETS flang DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/flang/tools/flang-driver/CMakeLists.txt
+++ b/flang/tools/flang-driver/CMakeLists.txt
@@ -36,3 +36,7 @@ if(FLANG_PLUGIN_SUPPORT)
 endif()
 
 install(TARGETS flang DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+# Keep "flang-new" as a symlink for backwards compatiblity. Remove once "flang"
+# is a widely adopted name.
+add_flang_symlink(flang-new flang)

--- a/flang/tools/flang-driver/CMakeLists.txt
+++ b/flang/tools/flang-driver/CMakeLists.txt
@@ -28,6 +28,12 @@ clang_target_link_libraries(flang
   clangBasic
 )
 
+# This creates the executable with a version appended
+# and creates a symlink to it without the version
+if(CYGWIN OR NOT WIN32) # but it doesn't work on Windows
+  set_target_properties(flang PROPERTIES VERSION ${FLANG_EXECUTABLE_VERSION})
+endif()
+
 option(FLANG_PLUGIN_SUPPORT "Build Flang with plugin support." ON)
 
 # Enable support for plugins, which need access to symbols from flang

--- a/flang/tools/flang-driver/driver.cpp
+++ b/flang/tools/flang-driver/driver.cpp
@@ -95,7 +95,7 @@ int main(int argc, const char **argv) {
   llvm::StringSaver saver(a);
   ExpandResponseFiles(saver, args);
 
-  // Check if flang-new is in the frontend mode
+  // Check if flang is in the frontend mode
   auto firstArg = std::find_if(args.begin() + 1, args.end(),
                                [](const char *a) { return a != nullptr; });
   if (firstArg != args.end()) {
@@ -104,7 +104,7 @@ int main(int argc, const char **argv) {
                    << "Valid tools include '-fc1'.\n";
       return 1;
     }
-    // Call flang-new frontend
+    // Call flang frontend
     if (llvm::StringRef(args[1]).starts_with("-fc1")) {
       return executeFC1Tool(args);
     }
@@ -140,7 +140,7 @@ int main(int argc, const char **argv) {
 
   // Set the environment variable, FLANG_COMPILER_OPTIONS_STRING, to contain all
   // the compiler options. This is intended for the frontend driver,
-  // flang-new -fc1, to enable the implementation of the COMPILER_OPTIONS
+  // flang -fc1, to enable the implementation of the COMPILER_OPTIONS
   // intrinsic. To this end, the frontend driver requires the list of the
   // original compiler options, which is not available through other means.
   // TODO: This way of passing information between the compiler and frontend

--- a/flang/tools/flang-driver/driver.cpp
+++ b/flang/tools/flang-driver/driver.cpp
@@ -88,7 +88,8 @@ int main(int argc, const char **argv) {
   llvm::InitLLVM x(argc, argv);
   llvm::SmallVector<const char *, 256> args(argv, argv + argc);
 
-  clang::driver::ParsedClangName targetandMode("flang", "--driver-mode=flang");
+  clang::driver::ParsedClangName targetandMode =
+      clang::driver::ToolChain::getTargetAndModeFromProgramName(argv[0]);
   std::string driverPath = getExecutablePath(args[0]);
 
   llvm::BumpPtrAllocator a;

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -504,15 +504,15 @@ if(build_runtimes)
 
   if("openmp" IN_LIST LLVM_ENABLE_RUNTIMES)
     if (${LLVM_TOOL_FLANG_BUILD})
-      message(STATUS "Configuring build of omp_lib.mod and omp_lib_kinds.mod via flang-new")
-      set(LIBOMP_FORTRAN_MODULES_COMPILER "${CMAKE_BINARY_DIR}/bin/flang-new")
+      message(STATUS "Configuring build of omp_lib.mod and omp_lib_kinds.mod via flang")
+      set(LIBOMP_FORTRAN_MODULES_COMPILER "${CMAKE_BINARY_DIR}/bin/flang")
       set(LIBOMP_MODULES_INSTALL_PATH "${CMAKE_INSTALL_INCLUDEDIR}/flang")
       # TODO: This is a workaround until flang becomes a first-class project
-      # in llvm/CMakeList.txt.  Until then, this line ensures that flang-new is
-      # built before "openmp" is built as a runtime project.  Besides "flang-new"
+      # in llvm/CMakeList.txt.  Until then, this line ensures that flang is
+      # built before "openmp" is built as a runtime project.  Besides "flang"
       # to build the compiler, we also need to add "module_files" to make sure
       # that all .mod files are also properly build.
-      list(APPEND extra_deps "flang-new" "module_files")
+      list(APPEND extra_deps "flang" "module_files")
     endif()
     foreach(dep opt llvm-link llvm-extract clang clang-offload-packager)
       if(TARGET ${dep})

--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -89,9 +89,9 @@ else()
 
   # Check for flang
   if (NOT MSVC)
-    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang-new)
+    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang)
   else()
-    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang-new.exe)
+    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang.exe)
   endif()
 
   # Set fortran test compiler if flang is found

--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -69,9 +69,9 @@ else()
 
   # Check for flang
   if (NOT MSVC)
-    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang-new)
+    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang)
   else()
-    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang-new.exe)
+    set(OPENMP_TEST_Fortran_COMPILER ${LLVM_RUNTIME_OUTPUT_INTDIR}/flang.exe)
   endif()
 
   # Set fortran test compiler if flang is found


### PR DESCRIPTION
This does a global rename from `flang-new` to `flang`. I also removed/changed any TODOs that I found related to making this change.