### PR TITLE
[LLVM][TableGen] Change SeachableTableEmitter to use const RecordKeeper

### DIFF
--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -1866,7 +1866,7 @@ static LateAttrParseKind getLateAttrParseKind(const Record *Attr) {
   auto *LAPK = Attr->getValueAsDef(LateParsedStr);
 
   // Typecheck the `LateParsed` field.
-  SmallVector<Record *, 1> SuperClasses;
+  SmallVector<const Record *, 1> SuperClasses;
   LAPK->getDirectSuperClasses(SuperClasses);
   if (SuperClasses.size() != 1)
     PrintFatalError(Attr, "Field `" + Twine(LateParsedStr) +

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -226,8 +226,9 @@ public:
 ///
 /// The list of superclasses is non-redundant, i.e. only contains classes that
 /// are not the superclass of some other listed class.
-class RecordRecTy final : public RecTy, public FoldingSetNode,
-                          public TrailingObjects<RecordRecTy, Record *> {
+class RecordRecTy final : public RecTy,
+                          public FoldingSetNode,
+                          public TrailingObjects<RecordRecTy, const Record *> {
   friend class Record;
   friend detail::RecordKeeperImpl;
 
@@ -248,23 +249,23 @@ public:
   }
 
   /// Get the record type with the given non-redundant list of superclasses.
-  static RecordRecTy *get(RecordKeeper &RK, ArrayRef<Record *> Classes);
-  static RecordRecTy *get(Record *Class);
+  static RecordRecTy *get(RecordKeeper &RK, ArrayRef<const Record *> Classes);
+  static RecordRecTy *get(const Record *Class);
 
   void Profile(FoldingSetNodeID &ID) const;
 
-  ArrayRef<Record *> getClasses() const {
-    return ArrayRef(getTrailingObjects<Record *>(), NumClasses);
+  ArrayRef<const Record *> getClasses() const {
+    return ArrayRef(getTrailingObjects<const Record *>(), NumClasses);
   }
 
-  using const_record_iterator = Record * const *;
+  using const_record_iterator = const Record *const *;
 
   const_record_iterator classes_begin() const { return getClasses().begin(); }
   const_record_iterator classes_end() const { return getClasses().end(); }
 
   std::string getAsString() const override;
 
-  bool isSubClassOf(Record *Class) const;
+  bool isSubClassOf(const Record *Class) const;
   bool typeIsConvertibleTo(const RecTy *RHS) const override;
 
   bool typeIsA(const RecTy *RHS) const override;
@@ -1763,7 +1764,7 @@ public:
   bool hasDirectSuperClass(const Record *SuperClass) const;
 
   /// Append the direct superclasses of this record to Classes.
-  void getDirectSuperClasses(SmallVectorImpl<Record *> &Classes) const;
+  void getDirectSuperClasses(SmallVectorImpl<const Record *> &Classes) const;
 
   bool isTemplateArg(Init *Name) const {
     return llvm::is_contained(TemplateArgs, Name);

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3004,9 +3004,9 @@ Init *TGParser::ParseValue(Record *CurRec, RecTy *ItemType, IDParseMode Mode) {
           DI->getDef()->getValue(FieldName)->addReferenceLoc(FieldNameLoc);
         } else if (auto *TI = dyn_cast<TypedInit>(Result)) {
           if (auto *RecTy = dyn_cast<RecordRecTy>(TI->getType())) {
-            for (Record *R : RecTy->getClasses())
+            for (const Record *R : RecTy->getClasses())
               if (auto *RV = R->getValue(FieldName))
-                RV->addReferenceLoc(FieldNameLoc);
+                const_cast<RecordVal *>(RV)->addReferenceLoc(FieldNameLoc);
           }
         }
       }

--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -48,10 +48,10 @@ struct GenericEnum {
   using Entry = std::pair<StringRef, int64_t>;
 
   std::string Name;
-  Record *Class = nullptr;
+  const Record *Class = nullptr;
   std::string PreprocessorGuard;
   std::vector<std::unique_ptr<Entry>> Entries;
-  DenseMap<Record *, Entry *> EntryMap;
+  DenseMap<const Record *, Entry *> EntryMap;
 };
 
 struct GenericField {
@@ -79,7 +79,7 @@ struct GenericTable {
   std::string PreprocessorGuard;
   std::string CppTypeName;
   SmallVector<GenericField, 2> Fields;
-  std::vector<Record *> Entries;
+  std::vector<const Record *> Entries;
 
   std::unique_ptr<SearchIndex> PrimaryKey;
   SmallVector<std::unique_ptr<SearchIndex>, 2> Indices;
@@ -94,20 +94,20 @@ struct GenericTable {
 };
 
 class SearchableTableEmitter {
-  RecordKeeper &Records;
+  const RecordKeeper &Records;
   std::unique_ptr<CodeGenTarget> Target;
   std::unique_ptr<CodeGenIntrinsicMap> Intrinsics;
   std::vector<std::unique_ptr<GenericEnum>> Enums;
-  DenseMap<Record *, GenericEnum *> EnumMap;
+  DenseMap<const Record *, GenericEnum *> EnumMap;
   std::set<std::string> PreprocessorGuards;
 
 public:
-  SearchableTableEmitter(RecordKeeper &R) : Records(R) {}
+  explicit SearchableTableEmitter(const RecordKeeper &R) : Records(R) {}
 
   void run(raw_ostream &OS);
 
 private:
-  typedef std::pair<Init *, int> SearchTableEntry;
+  typedef std::pair<const Init *, int> SearchTableEntry;
 
   enum TypeContext {
     TypeInStaticStruct,
@@ -116,15 +116,15 @@ private:
   };
 
   std::string primaryRepresentation(SMLoc Loc, const GenericField &Field,
-                                    Init *I) {
-    if (StringInit *SI = dyn_cast<StringInit>(I)) {
+                                    const Init *I) {
+    if (const StringInit *SI = dyn_cast<StringInit>(I)) {
       if (Field.IsCode || SI->hasCodeFormat())
         return std::string(SI->getValue());
       else
         return SI->getAsString();
-    } else if (BitsInit *BI = dyn_cast<BitsInit>(I))
+    } else if (const BitsInit *BI = dyn_cast<BitsInit>(I))
       return "0x" + utohexstr(getAsInt(BI));
-    else if (BitInit *BI = dyn_cast<BitInit>(I))
+    else if (const BitInit *BI = dyn_cast<BitInit>(I))
       return BI->getValue() ? "true" : "false";
     else if (Field.IsIntrinsic)
       return "Intrinsic::" + getIntrinsic(I).EnumName.str();
@@ -152,7 +152,8 @@ private:
     return Target->getIntrinsic(Def);
   }
 
-  bool compareBy(Record *LHS, Record *RHS, const SearchIndex &Index);
+  bool compareBy(const Record *LHS, const Record *RHS,
+                 const SearchIndex &Index);
 
   std::string searchableFieldType(const GenericTable &Table,
                                   const SearchIndex &Index,
@@ -163,7 +164,7 @@ private:
       if (Ctx == TypeInTempStruct)
         return "std::string";
       return "StringRef";
-    } else if (BitsRecTy *BI = dyn_cast<BitsRecTy>(Field.RecType)) {
+    } else if (const BitsRecTy *BI = dyn_cast<BitsRecTy>(Field.RecType)) {
       unsigned NumBits = BI->getNumBits();
       if (NumBits <= 8)
         return "uint8_t";
@@ -198,14 +199,11 @@ private:
   bool parseFieldType(GenericField &Field, Init *II);
   std::unique_ptr<SearchIndex>
   parseSearchIndex(GenericTable &Table, const RecordVal *RecVal, StringRef Name,
-                   const std::vector<StringRef> &Key, bool EarlyOut,
-                   bool ReturnRange);
+                   ArrayRef<StringRef> Key, bool EarlyOut, bool ReturnRange);
   void collectEnumEntries(GenericEnum &Enum, StringRef NameField,
-                          StringRef ValueField,
-                          const std::vector<Record *> &Items);
-  void collectTableEntries(GenericTable &Table,
-                           const std::vector<Record *> &Items);
-  int64_t getNumericKey(const SearchIndex &Index, Record *Rec);
+                          StringRef ValueField, ArrayRef<const Record *> Items);
+  void collectTableEntries(GenericTable &Table, ArrayRef<const Record *> Items);
+  int64_t getNumericKey(const SearchIndex &Index, const Record *Rec);
 };
 
 } // End anonymous namespace.
@@ -213,17 +211,17 @@ private:
 // For search indices that consists of a single field whose numeric value is
 // known, return that numeric value.
 int64_t SearchableTableEmitter::getNumericKey(const SearchIndex &Index,
-                                              Record *Rec) {
+                                              const Record *Rec) {
   assert(Index.Fields.size() == 1);
 
   // To be consistent with compareBy and primaryRepresentation elsewhere,
   // we check for IsInstruction before Enum-- these fields are not exclusive.
   if (Index.Fields[0].IsInstruction) {
-    Record *TheDef = Rec->getValueAsDef(Index.Fields[0].Name);
+    const Record *TheDef = Rec->getValueAsDef(Index.Fields[0].Name);
     return Target->getInstrIntValue(TheDef);
   }
   if (Index.Fields[0].Enum) {
-    Record *EnumEntry = Rec->getValueAsDef(Index.Fields[0].Name);
+    const Record *EnumEntry = Rec->getValueAsDef(Index.Fields[0].Name);
     return Index.Fields[0].Enum->EntryMap[EnumEntry]->second;
   }
 
@@ -232,7 +230,7 @@ int64_t SearchableTableEmitter::getNumericKey(const SearchIndex &Index,
 
 /// Less-than style comparison between \p LHS and \p RHS according to the
 /// key of \p Index.
-bool SearchableTableEmitter::compareBy(Record *LHS, Record *RHS,
+bool SearchableTableEmitter::compareBy(const Record *LHS, const Record *RHS,
                                        const SearchIndex &Index) {
   for (const auto &Field : Index.Fields) {
     Init *LHSI = LHS->getValueInit(Field.Name);
@@ -256,8 +254,8 @@ bool SearchableTableEmitter::compareBy(Record *LHS, Record *RHS,
         return false;
     } else if (Field.IsInstruction) {
       // This does not correctly compare the predefined instructions!
-      Record *LHSr = cast<DefInit>(LHSI)->getDef();
-      Record *RHSr = cast<DefInit>(RHSI)->getDef();
+      const Record *LHSr = cast<DefInit>(LHSI)->getDef();
+      const Record *RHSr = cast<DefInit>(RHSI)->getDef();
 
       bool LHSpseudo = LHSr->getValueAsBit("isPseudo");
       bool RHSpseudo = RHSr->getValueAsBit("isPseudo");
@@ -325,8 +323,8 @@ void SearchableTableEmitter::emitLookupFunction(const GenericTable &Table,
   emitLookupDeclaration(Table, Index, OS);
   OS << " {\n";
 
-  std::vector<Record *> IndexRowsStorage;
-  ArrayRef<Record *> IndexRows;
+  std::vector<const Record *> IndexRowsStorage;
+  ArrayRef<const Record *> IndexRows;
   StringRef IndexTypeName;
   StringRef IndexName;
 
@@ -346,15 +344,16 @@ void SearchableTableEmitter::emitLookupFunction(const GenericTable &Table,
 
     OS << "  static const struct IndexType Index[] = {\n";
 
-    std::vector<std::pair<Record *, unsigned>> Entries;
+    std::vector<std::pair<const Record *, unsigned>> Entries;
     Entries.reserve(Table.Entries.size());
     for (unsigned i = 0; i < Table.Entries.size(); ++i)
       Entries.emplace_back(Table.Entries[i], i);
 
-    llvm::stable_sort(Entries, [&](const std::pair<Record *, unsigned> &LHS,
-                                   const std::pair<Record *, unsigned> &RHS) {
-      return compareBy(LHS.first, RHS.first, Index);
-    });
+    llvm::stable_sort(Entries,
+                      [&](const std::pair<const Record *, unsigned> &LHS,
+                          const std::pair<const Record *, unsigned> &RHS) {
+                        return compareBy(LHS.first, RHS.first, Index);
+                      });
 
     IndexRowsStorage.reserve(Entries.size());
     for (const auto &Entry : Entries) {
@@ -552,7 +551,7 @@ void SearchableTableEmitter::emitGenericTable(const GenericTable &Table,
   // The primary data table contains all the fields defined for this map.
   OS << "constexpr " << Table.CppTypeName << " " << Table.Name << "[] = {\n";
   for (unsigned i = 0; i < Table.Entries.size(); ++i) {
-    Record *Entry = Table.Entries[i];
+    const Record *Entry = Table.Entries[i];
     OS << "  { ";
 
     ListSeparator LS;
@@ -576,18 +575,22 @@ void SearchableTableEmitter::emitGenericTable(const GenericTable &Table,
 }
 
 bool SearchableTableEmitter::parseFieldType(GenericField &Field, Init *TypeOf) {
-  if (auto Type = dyn_cast<StringInit>(TypeOf)) {
-    if (Type->getValue() == "code") {
-      Field.IsCode = true;
+  auto Type = dyn_cast<StringInit>(TypeOf);
+  if (!Type)
+    return false;
+
+  StringRef TypeStr = Type->getValue();
+
+  if (TypeStr == "code") {
+    Field.IsCode = true;
+    return true;
+  }
+
+  if (const Record *TypeRec = Records.getDef(TypeStr)) {
+    if (TypeRec->isSubClassOf("GenericEnum")) {
+      Field.Enum = EnumMap[TypeRec];
+      Field.RecType = RecordRecTy::get(Field.Enum->Class);
       return true;
-    } else {
-      if (Record *TypeRec = Records.getDef(Type->getValue())) {
-        if (TypeRec->isSubClassOf("GenericEnum")) {
-          Field.Enum = EnumMap[TypeRec];
-          Field.RecType = RecordRecTy::get(Field.Enum->Class);
-          return true;
-        }
-      }
     }
   }
 
@@ -596,7 +599,7 @@ bool SearchableTableEmitter::parseFieldType(GenericField &Field, Init *TypeOf) {
 
 std::unique_ptr<SearchIndex> SearchableTableEmitter::parseSearchIndex(
     GenericTable &Table, const RecordVal *KeyRecVal, StringRef Name,
-    const std::vector<StringRef> &Key, bool EarlyOut, bool ReturnRange) {
+    ArrayRef<StringRef> Key, bool EarlyOut, bool ReturnRange) {
   auto Index = std::make_unique<SearchIndex>();
   Index->Name = std::string(Name);
   Index->Loc = KeyRecVal->getLoc();
@@ -626,8 +629,8 @@ std::unique_ptr<SearchIndex> SearchableTableEmitter::parseSearchIndex(
 
 void SearchableTableEmitter::collectEnumEntries(
     GenericEnum &Enum, StringRef NameField, StringRef ValueField,
-    const std::vector<Record *> &Items) {
-  for (auto *EntryRec : Items) {
+    ArrayRef<const Record *> Items) {
+  for (const Record *EntryRec : Items) {
     StringRef Name;
     if (NameField.empty())
       Name = EntryRec->getName();
@@ -655,7 +658,7 @@ void SearchableTableEmitter::collectEnumEntries(
 }
 
 void SearchableTableEmitter::collectTableEntries(
-    GenericTable &Table, const std::vector<Record *> &Items) {
+    GenericTable &Table, ArrayRef<const Record *> Items) {
   if (Items.empty())
     PrintFatalError(Table.Locs,
                     Twine("Table '") + Table.Name + "' has no entries");
@@ -686,8 +689,8 @@ void SearchableTableEmitter::collectTableEntries(
     Table.Entries.push_back(EntryRec); // Add record to table's record list.
   }
 
-  Record *IntrinsicClass = Records.getClass("Intrinsic");
-  Record *InstructionClass = Records.getClass("Instruction");
+  const Record *IntrinsicClass = Records.getClass("Intrinsic");
+  const Record *InstructionClass = Records.getClass("Instruction");
   for (auto &Field : Table.Fields) {
     if (!Field.RecType)
       PrintFatalError(Twine("Cannot determine type of field '") + Field.Name +
@@ -704,7 +707,7 @@ void SearchableTableEmitter::collectTableEntries(
   SearchIndex Idx;
   std::copy(Table.Fields.begin(), Table.Fields.end(),
             std::back_inserter(Idx.Fields));
-  llvm::sort(Table.Entries, [&](Record *LHS, Record *RHS) {
+  llvm::sort(Table.Entries, [&](const Record *LHS, const Record *RHS) {
     return compareBy(LHS, RHS, Idx);
   });
 }
@@ -712,7 +715,7 @@ void SearchableTableEmitter::collectTableEntries(
 void SearchableTableEmitter::run(raw_ostream &OS) {
   // Emit tables in a deterministic order to avoid needless rebuilds.
   SmallVector<std::unique_ptr<GenericTable>, 4> Tables;
-  DenseMap<Record *, GenericTable *> TableMap;
+  DenseMap<const Record *, GenericTable *> TableMap;
   bool NeedsTarget =
       !Records.getAllDerivedDefinitionsIfDefined("Instruction").empty() ||
       !Records.getAllDerivedDefinitionsIfDefined("Intrinsic").empty();
@@ -720,7 +723,7 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
     Target = std::make_unique<CodeGenTarget>(Records);
 
   // Collect all definitions first.
-  for (auto *EnumRec : Records.getAllDerivedDefinitions("GenericEnum")) {
+  for (const auto *EnumRec : Records.getAllDerivedDefinitions("GenericEnum")) {
     StringRef NameField;
     if (!EnumRec->isValueUnset("NameField"))
       NameField = EnumRec->getValueAsString("NameField");
@@ -746,7 +749,8 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
     Enums.emplace_back(std::move(Enum));
   }
 
-  for (auto *TableRec : Records.getAllDerivedDefinitions("GenericTable")) {
+  for (const auto *TableRec :
+       Records.getAllDerivedDefinitions("GenericTable")) {
     auto Table = std::make_unique<GenericTable>();
     Table->Name = std::string(TableRec->getName());
     Table->Locs = TableRec->getLoc();
@@ -777,8 +781,9 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
                       Twine("Table FilterClass '") + FilterClass +
                           "' does not exist");
 
-    RecordVal *FilterClassFieldVal = TableRec->getValue("FilterClassField");
-    std::vector<Record *> Definitions =
+    const RecordVal *FilterClassFieldVal =
+        TableRec->getValue("FilterClassField");
+    std::vector<const Record *> Definitions =
         Records.getAllDerivedDefinitions(FilterClass);
     if (auto *FilterClassFieldInit =
             dyn_cast<StringInit>(FilterClassFieldVal->getValue())) {
@@ -803,17 +808,19 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
                            TableRec->getValueAsBit("PrimaryKeyEarlyOut"),
                            TableRec->getValueAsBit("PrimaryKeyReturnRange"));
 
-      llvm::stable_sort(Table->Entries, [&](Record *LHS, Record *RHS) {
-        return compareBy(LHS, RHS, *Table->PrimaryKey);
-      });
+      llvm::stable_sort(Table->Entries,
+                        [&](const Record *LHS, const Record *RHS) {
+                          return compareBy(LHS, RHS, *Table->PrimaryKey);
+                        });
     }
 
     TableMap.insert(std::pair(TableRec, Table.get()));
     Tables.emplace_back(std::move(Table));
   }
 
-  for (Record *IndexRec : Records.getAllDerivedDefinitions("SearchIndex")) {
-    Record *TableRec = IndexRec->getValueAsDef("Table");
+  for (const Record *IndexRec :
+       Records.getAllDerivedDefinitions("SearchIndex")) {
+    const Record *TableRec = IndexRec->getValueAsDef("Table");
     auto It = TableMap.find(TableRec);
     if (It == TableMap.end())
       PrintFatalError(IndexRec->getValue("Table"),
@@ -829,15 +836,16 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
   }
 
   // Translate legacy tables.
-  Record *SearchableTable = Records.getClass("SearchableTable");
+  const Record *SearchableTable = Records.getClass("SearchableTable");
   for (auto &NameRec : Records.getClasses()) {
-    Record *Class = NameRec.second.get();
+    const Record *Class = NameRec.second.get();
     if (Class->getSuperClasses().size() != 1 ||
         !Class->isSubClassOf(SearchableTable))
       continue;
 
     StringRef TableName = Class->getName();
-    std::vector<Record *> Items = Records.getAllDerivedDefinitions(TableName);
+    ArrayRef<const Record *> Items =
+        Records.getAllDerivedDefinitions(TableName);
     if (!Class->isValueUnset("EnumNameField")) {
       StringRef NameField = Class->getValueAsString("EnumNameField");
       StringRef ValueField;

--- a/mlir/tools/mlir-tblgen/OmpOpGen.cpp
+++ b/mlir/tools/mlir-tblgen/OmpOpGen.cpp
@@ -72,7 +72,7 @@ static StringRef extractOmpClauseName(const Record *clause) {
   assert(ompClause && "base OpenMP records expected to be defined");
 
   StringRef clauseClassName;
-  SmallVector<Record *, 1> clauseSuperClasses;
+  SmallVector<const Record *, 1> clauseSuperClasses;
   clause->getDirectSuperClasses(clauseSuperClasses);
 
   // Check if OpenMP_Clause is a direct superclass.

--- a/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp
+++ b/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp
@@ -112,7 +112,7 @@ Availability::Availability(const llvm::Record *def) : def(def) {
 }
 
 StringRef Availability::getClass() const {
-  SmallVector<Record *, 1> parentClass;
+  SmallVector<const Record *, 1> parentClass;
   def->getDirectSuperClasses(parentClass);
   if (parentClass.size() != 1) {
     PrintFatalError(def->getLoc(),
@@ -203,7 +203,7 @@ static bool emitInterfaceDefs(const RecordKeeper &recordKeeper,
   auto defs = recordKeeper.getAllDerivedDefinitions("Availability");
   SmallVector<const Record *, 1> handledClasses;
   for (const Record *def : defs) {
-    SmallVector<Record *, 1> parent;
+    SmallVector<const Record *, 1> parent;
     def->getDirectSuperClasses(parent);
     if (parent.size() != 1) {
       PrintFatalError(def->getLoc(),
@@ -293,7 +293,7 @@ static bool emitInterfaceDecls(const RecordKeeper &recordKeeper,
   auto defs = recordKeeper.getAllDerivedDefinitions("Availability");
   SmallVector<const Record *, 4> handledClasses;
   for (const Record *def : defs) {
-    SmallVector<Record *, 1> parent;
+    SmallVector<const Record *, 1> parent;
     def->getDirectSuperClasses(parent);
     if (parent.size() != 1) {
       PrintFatalError(def->getLoc(),


### PR DESCRIPTION
Change SeachableTableEmitter to use const RecordKeeper.
Also change RecordRecTy to use const Record pointers for its classes.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089