### PR TITLE
[ADT] Allow structured binding on StringMap of move-only type

### DIFF
--- a/llvm/include/llvm/ADT/StringMapEntry.h
+++ b/llvm/include/llvm/ADT/StringMapEntry.h
@@ -148,14 +148,24 @@ public:
   }
 };
 
-// Allow structured bindings on StringMapEntry.
+// Allow structured bindings on const StringMapEntry.
 template <std::size_t Index, typename ValueTy>
 decltype(auto) get(const StringMapEntry<ValueTy> &E) {
   static_assert(Index < 2);
   if constexpr (Index == 0)
     return E.first();
   else
-    return E.second;
+    return (E.second);
+}
+
+// Allow structured bindings on StringMapEntry.
+template <std::size_t Index, typename ValueTy>
+decltype(auto) get(StringMapEntry<ValueTy> &E) {
+  static_assert(Index < 2);
+  if constexpr (Index == 0)
+    return E.first();
+  else
+    return (E.second);
 }
 
 } // end namespace llvm

--- a/llvm/unittests/ADT/StringMapTest.cpp
+++ b/llvm/unittests/ADT/StringMapTest.cpp
@@ -552,6 +552,16 @@ TEST_F(StringMapTest, StructuredBindings) {
   }
 }
 
+TEST_F(StringMapTest, StructuredBindingsMoveOnly) {
+  StringMap<MoveOnly> A;
+  A.insert(std::make_pair("a", MoveOnly(42)));
+
+  for (auto &&[Key, Value] : A) {
+    EXPECT_EQ("a", Key);
+    EXPECT_EQ(42, Value.i);
+  }
+}
+
 namespace {
 // Simple class that counts how many moves and copy happens when growing a map
 struct CountCtorCopyAndMove {


### PR DESCRIPTION
Currently, `decltype(auto)` evaluates to `ValueTy` rather than `ValueTy&`. Parenthesizing the return value fixes this, but a non-const overload needed to be added to allow use of structured binding on a non-const `StringMapEntry`.