### PR TITLE
[SandboxIR] Add more functions to sandboxir:Instruction class.

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1993,32 +1993,8 @@ public:
     return cast<llvm::Instruction>(Val)->hasMetadata(KindID);
   }
 
-  /// Get the metadata of given kind attached to this Instruction.
-  /// If the metadata is not found then return null.
-  MDNode *getMetadata(unsigned KindID) const {
-    return cast<llvm::Instruction>(Val)->getMetadata(KindID);
-  }
-
-  /// Get the metadata of given kind attached to this Instruction.
-  /// If the metadata is not found then return null.
-  MDNode *getMetadata(StringRef Kind) const {
-    return cast<llvm::Instruction>(Val)->getMetadata(Kind);
-  }
-
-  /// Get all metadata attached to this Instruction. The first element of each
-  /// pair returned is the KindID, the second element is the metadata value.
-  /// This list is returned sorted by the KindID.
-  void
-  getAllMetadata(SmallVectorImpl<std::pair<unsigned, MDNode *>> &MDs) const {
-    return cast<llvm::Instruction>(Val)->getAllMetadata(MDs);
-  }
-
-  /// This does the same thing as getAllMetadata, except that it filters out the
-  /// debug location.
-  void getAllMetadataOtherThanDebugLoc(
-      SmallVectorImpl<std::pair<unsigned, MDNode *>> &MDs) const {
-    return cast<llvm::Instruction>(Val)->getAllMetadataOtherThanDebugLoc(MDs);
-  }
+  // TODO: Implement getMetadata and getAllMetadata after sandboxir::MDNode is
+  // available.
 
   // TODO: More missing functions
 

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1942,7 +1942,15 @@ public:
   /// state to allow for new SandboxIR-specific instructions.
   Opcode getOpcode() const { return Opc; }
 
-  // TODO: Missing function getOpcodeName().
+  const char *getOpcodeName() const {
+    return getOpcodeName(Opc);
+  }
+
+  // Note that these functions below are calling into llvm::Instruction. 
+  // A sandbox IR instruction could introduce a new opcode that could change the
+  // behavior of one of these functions. It is better that these functions are only
+  // added as needed and new sandbox IR instructions must explicitly check if any
+  // of these functions could have a different behavior.
 
   bool isTerminator() const {
     return cast<llvm::Instruction>(Val)->isTerminator();
@@ -1954,6 +1962,55 @@ public:
   }
   bool isShift() const { return cast<llvm::Instruction>(Val)->isShift(); }
   bool isCast() const { return cast<llvm::Instruction>(Val)->isCast(); }
+  bool isFuncletPad() const { return cast<llvm::Instruction>(Val)->isFuncletPad(); }
+  bool isSpecialTerminator() const { return cast<llvm::Instruction>(Val)->isSpecialTerminator(); }
+  bool isOnlyUserOfAnyOperand() const { return cast<llvm::Instruction>(Val)->isOnlyUserOfAnyOperand(); }
+  bool isLogicalShift() const { return cast<llvm::Instruction>(Val)->isLogicalShift(); }
+
+  //===--------------------------------------------------------------------===//
+  // Metadata manipulation.
+  //===--------------------------------------------------------------------===//
+
+  /// Return true if the instruction has any metadata attached to it.
+  bool hasMetadata() const { return cast<llvm::Instruction>(Val)->hasMetadata(); }
+
+  /// Return true if this instruction has metadata attached to it other than a
+  /// debug location.
+  bool hasMetadataOtherThanDebugLoc() const {
+     return cast<llvm::Instruction>(Val)->hasMetadataOtherThanDebugLoc();
+  }
+
+  /// Return true if this instruction has the given type of metadata attached.
+  bool hasMetadata(unsigned KindID) const {
+    return cast<llvm::Instruction>(Val)->hasMetadata(KindID);
+  }
+
+  /// Get the metadata of given kind attached to this Instruction.
+  /// If the metadata is not found then return null.
+  MDNode *getMetadata(unsigned KindID) const {
+    return cast<llvm::Instruction>(Val)->getMetadata(KindID);
+  }
+
+   /// Get the metadata of given kind attached to this Instruction.
+  /// If the metadata is not found then return null.
+  MDNode *getMetadata(StringRef Kind) const {
+    return cast<llvm::Instruction>(Val)->getMetadata(Kind);
+  }
+
+  /// Get all metadata attached to this Instruction. The first element of each
+  /// pair returned is the KindID, the second element is the metadata value.
+  /// This list is returned sorted by the KindID.
+  void
+  getAllMetadata(SmallVectorImpl<std::pair<unsigned, MDNode *>> &MDs) const {
+    return cast<llvm::Instruction>(Val)->getAllMetadata(MDs);
+  }
+
+  /// This does the same thing as getAllMetadata, except that it filters out the
+  /// debug location.
+  void getAllMetadataOtherThanDebugLoc(
+      SmallVectorImpl<std::pair<unsigned, MDNode *>> &MDs) const {
+    return cast<llvm::Instruction>(Val)->getAllMetadataOtherThanDebugLoc(MDs);
+  }
 
   // TODO: More missing functions
 

--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -1942,15 +1942,13 @@ public:
   /// state to allow for new SandboxIR-specific instructions.
   Opcode getOpcode() const { return Opc; }
 
-  const char *getOpcodeName() const {
-    return getOpcodeName(Opc);
-  }
+  const char *getOpcodeName() const { return getOpcodeName(Opc); }
 
-  // Note that these functions below are calling into llvm::Instruction. 
+  // Note that these functions below are calling into llvm::Instruction.
   // A sandbox IR instruction could introduce a new opcode that could change the
-  // behavior of one of these functions. It is better that these functions are only
-  // added as needed and new sandbox IR instructions must explicitly check if any
-  // of these functions could have a different behavior.
+  // behavior of one of these functions. It is better that these functions are
+  // only added as needed and new sandbox IR instructions must explicitly check
+  // if any of these functions could have a different behavior.
 
   bool isTerminator() const {
     return cast<llvm::Instruction>(Val)->isTerminator();
@@ -1962,22 +1960,32 @@ public:
   }
   bool isShift() const { return cast<llvm::Instruction>(Val)->isShift(); }
   bool isCast() const { return cast<llvm::Instruction>(Val)->isCast(); }
-  bool isFuncletPad() const { return cast<llvm::Instruction>(Val)->isFuncletPad(); }
-  bool isSpecialTerminator() const { return cast<llvm::Instruction>(Val)->isSpecialTerminator(); }
-  bool isOnlyUserOfAnyOperand() const { return cast<llvm::Instruction>(Val)->isOnlyUserOfAnyOperand(); }
-  bool isLogicalShift() const { return cast<llvm::Instruction>(Val)->isLogicalShift(); }
+  bool isFuncletPad() const {
+    return cast<llvm::Instruction>(Val)->isFuncletPad();
+  }
+  bool isSpecialTerminator() const {
+    return cast<llvm::Instruction>(Val)->isSpecialTerminator();
+  }
+  bool isOnlyUserOfAnyOperand() const {
+    return cast<llvm::Instruction>(Val)->isOnlyUserOfAnyOperand();
+  }
+  bool isLogicalShift() const {
+    return cast<llvm::Instruction>(Val)->isLogicalShift();
+  }
 
   //===--------------------------------------------------------------------===//
   // Metadata manipulation.
   //===--------------------------------------------------------------------===//
 
   /// Return true if the instruction has any metadata attached to it.
-  bool hasMetadata() const { return cast<llvm::Instruction>(Val)->hasMetadata(); }
+  bool hasMetadata() const {
+    return cast<llvm::Instruction>(Val)->hasMetadata();
+  }
 
   /// Return true if this instruction has metadata attached to it other than a
   /// debug location.
   bool hasMetadataOtherThanDebugLoc() const {
-     return cast<llvm::Instruction>(Val)->hasMetadataOtherThanDebugLoc();
+    return cast<llvm::Instruction>(Val)->hasMetadataOtherThanDebugLoc();
   }
 
   /// Return true if this instruction has the given type of metadata attached.
@@ -1991,7 +1999,7 @@ public:
     return cast<llvm::Instruction>(Val)->getMetadata(KindID);
   }
 
-   /// Get the metadata of given kind attached to this Instruction.
+  /// Get the metadata of given kind attached to this Instruction.
   /// If the metadata is not found then return null.
   MDNode *getMetadata(StringRef Kind) const {
     return cast<llvm::Instruction>(Val)->getMetadata(Kind);

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1957,11 +1957,6 @@ bb1:
     // Check hasMetadataOtherThanDebugLoc().
     EXPECT_EQ(LLVMI.hasMetadataOtherThanDebugLoc(),
               I.hasMetadataOtherThanDebugLoc());
-    // Check getMetadata(unsigned).
-    EXPECT_EQ(LLVMI.getMetadata(LLVMContext::MD_dbg),
-              I.getMetadata(LLVMContext::MD_dbg));
-    // Check getMetadata(StringRef).
-    EXPECT_EQ(LLVMI.getMetadata("dbg"), I.getMetadata("dbg"));
     // Check isAssociative().
     EXPECT_EQ(LLVMI.isAssociative(), I.isAssociative());
     // Check isCommutative().

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1828,9 +1828,12 @@ bb1:
   %atomicrmw = atomicrmw add ptr %ptr, i8 %v1 acquire
   %udiv = udiv i8 %ld0, %v1
   %urem = urem i8 %ld0, %v1
-  call void @foo()
-  ret void
+  call void @foo(), !dbg !1
+  ret void, !tbaa !2
 }
+
+!1 = !{}
+!2 = !{}
 )IR");
   llvm::Function *LLVMF = &*M->getFunction("foo");
   llvm::BasicBlock *LLVMBB1 = getBasicBlockByName(*LLVMF, "bb1");
@@ -1863,6 +1866,13 @@ bb1:
   EXPECT_EQ(I0->getOpcode(), sandboxir::Instruction::Opcode::Add);
   EXPECT_EQ(I1->getOpcode(), sandboxir::Instruction::Opcode::Sub);
   EXPECT_EQ(Ret->getOpcode(), sandboxir::Instruction::Opcode::Ret);
+
+  // Check getOpcodeName().
+  EXPECT_EQ(I0->getOpcodeName(), "Add");
+  EXPECT_EQ(I1->getOpcodeName(), "Sub");
+  EXPECT_EQ(Ret->getOpcodeName(), "Ret");
+
+  EXPECT_EQ(sandboxir::Instruction::getOpcodeName(sandboxir::Instruction::Opcode::Alloca), "Alloca");
 
   // Check moveBefore(I).
   I1->moveBefore(I0);
@@ -1932,6 +1942,22 @@ bb1:
     EXPECT_EQ(LLVMI.isShift(), I.isShift());
     // Check isCast().
     EXPECT_EQ(LLVMI.isCast(), I.isCast());
+    // Check isFuncletPad().
+    EXPECT_EQ(LLVMI.isFuncletPad(), I.isFuncletPad());
+    // Check isSpecialTerminator().
+    EXPECT_EQ(LLVMI.isSpecialTerminator(), I.isSpecialTerminator());
+    // Check isOnlyUserOfAnyOperand().
+    EXPECT_EQ(LLVMI.isOnlyUserOfAnyOperand(), I.isOnlyUserOfAnyOperand());
+    // Check isLogicalShift().
+    EXPECT_EQ(LLVMI.isLogicalShift(), I.isLogicalShift());
+    // Check hasMetadata().
+    EXPECT_EQ(LLVMI.hasMetadata(), I.hasMetadata());
+    // Check hasMetadataOtherThanDebugLoc().
+    EXPECT_EQ(LLVMI.hasMetadataOtherThanDebugLoc(), I.hasMetadataOtherThanDebugLoc());
+    // Check getMetadata(unsigned).
+    EXPECT_EQ(LLVMI.getMetadata(LLVMContext::MD_dbg), I.getMetadata(LLVMContext::MD_dbg));
+    // Check getMetadata(StringRef).
+    EXPECT_EQ(LLVMI.getMetadata("dbg"), I.getMetadata("dbg"));
     // Check isAssociative().
     EXPECT_EQ(LLVMI.isAssociative(), I.isAssociative());
     // Check isCommutative().

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1872,7 +1872,9 @@ bb1:
   EXPECT_EQ(I1->getOpcodeName(), "Sub");
   EXPECT_EQ(Ret->getOpcodeName(), "Ret");
 
-  EXPECT_EQ(sandboxir::Instruction::getOpcodeName(sandboxir::Instruction::Opcode::Alloca), "Alloca");
+  EXPECT_EQ(sandboxir::Instruction::getOpcodeName(
+                sandboxir::Instruction::Opcode::Alloca),
+            "Alloca");
 
   // Check moveBefore(I).
   I1->moveBefore(I0);
@@ -1953,9 +1955,11 @@ bb1:
     // Check hasMetadata().
     EXPECT_EQ(LLVMI.hasMetadata(), I.hasMetadata());
     // Check hasMetadataOtherThanDebugLoc().
-    EXPECT_EQ(LLVMI.hasMetadataOtherThanDebugLoc(), I.hasMetadataOtherThanDebugLoc());
+    EXPECT_EQ(LLVMI.hasMetadataOtherThanDebugLoc(),
+              I.hasMetadataOtherThanDebugLoc());
     // Check getMetadata(unsigned).
-    EXPECT_EQ(LLVMI.getMetadata(LLVMContext::MD_dbg), I.getMetadata(LLVMContext::MD_dbg));
+    EXPECT_EQ(LLVMI.getMetadata(LLVMContext::MD_dbg),
+              I.getMetadata(LLVMContext::MD_dbg));
     // Check getMetadata(StringRef).
     EXPECT_EQ(LLVMI.getMetadata("dbg"), I.getMetadata("dbg"));
     // Check isAssociative().


### PR DESCRIPTION
The getter functions simply turn around and call the LLVM
counterparts.  This is fine until we don't add new sandbox IR
opcodes.  At that point, we may have to explicitly check if
the behavior is different.
