### PR TITLE
[libc] Fix %m on CPUs with float128 but no int128

### DIFF
--- a/libc/src/stdio/printf_core/parser.h
+++ b/libc/src/stdio/printf_core/parser.h
@@ -265,7 +265,7 @@ public:
       case ('m'):
         // %m is an odd conversion in that it doesn't consume an argument, it
         // just takes the current value of errno as its argument.
-        section.conv_val_raw = libc_errno;
+        section.conv_val_raw = static_cast<int>(libc_errno);
         break;
 #endif // LIBC_COPT_PRINTF_DISABLE_STRERROR
 #ifndef LIBC_COPT_PRINTF_DISABLE_WRITE_INT


### PR DESCRIPTION
This bug is caused by the BigInt implementation failing to initialize
from errno. Explanation below, but the fix is a static cast to int.

The bug only shows up on risc-v 32 because of a chain of type-oddities:
1) Errno is provided by a struct with an implicit cast to int.
2) The printf parser uses an int128 to store the value of a conversion
   on systems with long double greater than double.
3) On systems without native int128 support we use our own BigInt instead.

These combine such that if both long double and int128 exist (e.g. on
x86) there's no issue, errno is implicitly cast to int, which is
extended to int128. If long double is double (e.g. on arm32) then int64
is used in the printf parser, the implicit cast works, and there's no
issue. The only way this would come up is if the target has a proper
long double type, but not int128, which is the case for at least the
current risc-v 32 bot.
