### PR TITLE
[MLIR] Add MLIRConversionPassIncGen to cmake deps for FrozenRewritePatternSet

### DIFF
--- a/mlir/lib/Rewrite/CMakeLists.txt
+++ b/mlir/lib/Rewrite/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_library(MLIRRewrite
 
   DEPENDS
   mlir-generic-headers
+  MLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR


### PR DESCRIPTION
Fixes missing header in downstream circt python wheel build (e.g. https://github.com/llvm/circt/actions/runs/11022589675/job/30612234430).

Confirmed by
* https://github.com/llvm/circt/actions/runs/11040046220/job/30667073462
* https://github.com/llvm/circt/commit/0646e7e9276ff9bf6e7561c399fbe8c3431b509a