### PR TITLE
[DWARF]Set uuid for symbol file spec

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -4357,6 +4357,7 @@ const std::shared_ptr<SymbolFileDWARFDwo> &SymbolFileDWARF::GetDwpSymbolFile() {
     FileSpecList search_paths = Target::GetDefaultDebugFileSearchPaths();
     ModuleSpec module_spec;
     module_spec.GetFileSpec() = m_objfile_sp->GetFileSpec();
+    module_spec.GetUUID() = m_objfile_sp->GetUUID();
     FileSpec dwp_filespec;
     for (const auto &symfile : symfiles.files()) {
       module_spec.GetSymbolFileSpec() =


### PR DESCRIPTION
The gnu build id was lost while creating the new module spec, this result in the SymbolLocatorDebuginfod not able to locate symbol file.

before this change while connecting to debuginfod server I am seeing this warning unable to locate debug file, also parameter not shown.
```
warning: (x86_64) /home/hyubo/.cache/llvm-debuginfod/client/llvmcache-18224759554195557949 unable to locate separate debug file (dwo, dwp). Debugging will be degraded. (troubleshoot with https://fburl.com/missing_dwo)
(lldb) bt
* thread #1, name = 'crasher', stop reason = signal SIGABRT
  * frame #0: 0x00007fe9f909c993 libc.so.6`__GI___pthread_kill [inlined] __pthread_kill_internal(signo=6, threadid=<unavailable>) at pthread_kill.c:46:37
...
    frame #4: 0x000000000020c46a llvmcache-18224759554195557949`c4crasher::Crasher::crasher(unsigned long) at crasher.h:428
...
```
After this change:
```
# no warnings
(lldb) bt
* thread #1, name = 'crasher', stop reason = signal SIGABRT
  * frame #0: 0x00007fe9f909c993 libc.so.6`__GI___pthread_kill [inlined] __pthread_kill_internal(signo=6, threadid=<unavailable>) at pthread_kill.c:46:37
...
    frame #4: 0x000000000020c46a llvmcache-18224759554195557949`c4crasher::Crasher::crasher(this=0x00007fff44c51998, depth=0) at crasher.h:428
```

   