### PR TITLE
[llvm][cmake] Properly place clang runtime directory on linker command line when WinMsvc.cmake is involved

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -324,6 +324,12 @@ function(append value)
   endforeach(variable)
 endfunction()
 
+function(prepend value)
+  foreach(variable ${ARGN})
+    set(${variable} "${value} ${${variable}}" PARENT_SCOPE)
+  endforeach(variable)
+endfunction()
+
 function(append_if condition value)
   if (${condition})
     foreach(variable ${ARGN})
@@ -1196,7 +1202,7 @@ if (CLANG_CL AND (LLVM_BUILD_INSTRUMENTED OR LLVM_USE_SANITIZER))
   endif()
   file(TO_CMAKE_PATH "${clang_compiler_rt_file}" clang_compiler_rt_file)
   get_filename_component(clang_runtime_dir "${clang_compiler_rt_file}" DIRECTORY)
-  append("/libpath:\"${clang_runtime_dir}\""
+  prepend("/libpath:\"${clang_runtime_dir}\""
     CMAKE_EXE_LINKER_FLAGS
     CMAKE_MODULE_LINKER_FLAGS
     CMAKE_SHARED_LINKER_FLAGS)


### PR DESCRIPTION
WinMsvc.cmake, used for cross-compiling LLVM, targetting Windows, puts -libpath flags on the linker command line for the MSVC directories. Those may contain clang runtime libraries that come from MSVC, and may be incompatible with the clang compiler in use when it doesn't come from MSVC (which is obviously the case on cross-compiles). By prioritizing the clang runtime directory on the linker command line, we avoid those libraries being picked up by the linker.