### PR TITLE
[MLIR][Vector] Add a missing builder implementation for Vector_WarpEx…

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -6422,6 +6422,12 @@ void WarpExecuteOnLane0Op::getSuccessorRegions(
 }
 
 void WarpExecuteOnLane0Op::build(OpBuilder &builder, OperationState &result,
+                                 Value laneId, int64_t warpSize) {
+  build(builder, result, TypeRange(), laneId, warpSize,
+        /*operands=*/std::nullopt, /*argTypes=*/std::nullopt);
+}
+
+void WarpExecuteOnLane0Op::build(OpBuilder &builder, OperationState &result,
                                  TypeRange resultTypes, Value laneId,
                                  int64_t warpSize) {
   build(builder, result, resultTypes, laneId, warpSize,


### PR DESCRIPTION
…ecuteOnLane0Op

The op declares three builders:
```
let builders = [
    OpBuilder<(ins "Value":$laneid, "int64_t":$warpSize)>,
    OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid,
                   "int64_t":$warpSize)>,
    // `blockArgTypes` are different than `args` types as they are they
    // represent all the `args` instances visibile to lane 0. Therefore we need
    // to explicit pass the type.
    OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid,
                   "int64_t":$warpSize, "ValueRange":$args,
                   "TypeRange":$blockArgTypes)>
  ];
```

This adds the missing implementation for the first builder.