### PR TITLE
[libc] Fix 'fgets' test on the GPU for some C libraries

### DIFF
--- a/libc/test/src/stdio/fgets_test.cpp
+++ b/libc/test/src/stdio/fgets_test.cpp
@@ -43,6 +43,8 @@ TEST(LlvmLibcFgetsTest, WriteAndReadCharacters) {
   file = LIBC_NAMESPACE::fopen(FILENAME, "r");
   ASSERT_FALSE(file == nullptr);
 
+  // The GPU build relies on the host C library, so this check may be different.
+#ifndef LIBC_TARGET_ARCH_IS_GPU
   // If we request just 1 byte, it should return just a null byte and not
   // advance the read head. This is implementation defined.
   output = LIBC_NAMESPACE::fgets(buff, 1, file);
@@ -54,6 +56,7 @@ TEST(LlvmLibcFgetsTest, WriteAndReadCharacters) {
   // This is also implementation defined.
   output = LIBC_NAMESPACE::fgets(buff, 0, file);
   ASSERT_TRUE(output == nullptr);
+#endif
 
   const char *output_arr[] = {
       "1234567", "89\n", "1234567", "\n", "123456\n", "1",


### PR DESCRIPTION
Summary:
The GPU handling for a lot of `FILE *` functions pretty much just
forwards it to the host via RPC. This test checks for implementation
defined behavior, which sometimes passes and sometimes doesn't. We just
disable it here so it works on the standard semantics.

We do this forwarding primarily for interopt w/ the host if the user is
compiling from an offloading language (e.g. CUDA).
