### PR TITLE
[clang] Fix eager skipping on new with unknown type and no new-initializer

### DIFF
--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3694,7 +3694,7 @@ bool Parser::ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
       SawError = true;
       if (FailImmediatelyOnInvalidExpr)
         break;
-      SkipUntil(tok::comma, tok::r_paren, StopBeforeMatch);
+      SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
     } else {
       Exprs.push_back(Expr.get());
     }

--- a/clang/test/AST/new-unknown-type.cpp
+++ b/clang/test/AST/new-unknown-type.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -verify -ast-dump %s | FileCheck %s
+
+extern void foo(Unknown*); // expected-error {{unknown type name 'Unknown'}}
+
+namespace a {
+  void computeSomething() {
+    foo(new Unknown()); // expected-error {{unknown type name 'Unknown'}}
+    foo(new Unknown{}); // expected-error {{unknown type name 'Unknown'}}
+    foo(new Unknown);   // expected-error {{unknown type name 'Unknown'}}
+  }
+} // namespace a
+
+namespace b {
+  struct Bar{};
+} // namespace b
+
+// CHECK:      |-NamespaceDecl 0x{{[^ ]*}} <line:5:1, line:11:1> line:5:11 a
+// CHECK-NEXT: | `-FunctionDecl 0x{{[^ ]*}} <line:6:3, line:10:3> line:6:8 computeSomething 'void ()'
+// CHECK-NEXT: |   `-CompoundStmt 0x{{[^ ]*}} <col:27, line:10:3>
+// CHECK-NEXT: |-NamespaceDecl 0x{{[^ ]*}} <line:13:1, line:15:1> line:13:11 b
+// CHECK-NEXT: | `-CXXRecordDecl 0x{{[^ ]*}} <line:14:3, col:14> col:10 referenced struct Bar definition
+
+static b::Bar bar;
+// CHECK:      `-VarDecl 0x{{[^ ]*}} <line:23:1, col:15> col:15 bar 'b::Bar' static callinit
+// CHECK-NEXT:   `-CXXConstructExpr 0x{{[^ ]*}} <col:15> 'b::Bar' 'void () noexcept'

--- a/clang/test/Parser/colon-colon-parentheses.cpp
+++ b/clang/test/Parser/colon-colon-parentheses.cpp
@@ -11,7 +11,7 @@ int S::(*e;  // expected-error{{expected unqualified-id}}
 int S::*f;
 int g = S::(a);  // expected-error {{expected unqualified-id}} expected-error {{use of undeclared identifier 'a'}}
 int h = S::(b;  // expected-error {{expected unqualified-id}} expected-error {{use of undeclared identifier 'b'}}
-            );
+            );  // expected-error {{expected unqualified-id}}
 int i = S::c;
 
 void foo() {

--- a/clang/test/Parser/cxx-ambig-paren-expr-asan.cpp
+++ b/clang/test/Parser/cxx-ambig-paren-expr-asan.cpp
@@ -6,4 +6,3 @@ int H((int()[)]);
 // expected-error@-1 {{expected expression}}
 // expected-error@-2 {{expected ']'}}
 // expected-note@-3 {{to match this '['}}
-// expected-error@-4 {{expected ';' after top level declarator}}


### PR DESCRIPTION
i.e., in `function(new Unknown);` the parser should skip only until the semicolon.

Before this change, everything was skipped until a balanced closing parenthesis or brace was found. This strategy can cause completely bogus ASTs. For instance, in the case of the test `new-unknown-type.cpp`, `struct Bar` would end nested under the namespace `a::b`.