### PR TITLE
[Flang][Offload][Tests] Set default OpenMP version to 5.2 (52)

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -88,7 +88,7 @@ config.test_flags = " -I " + config.test_source_root + \
 
 # compiler specific flags
 config.test_flags_clang = ""
-config.test_flags_flang = ""
+config.test_flags_flang = "-fopenmp-version=52"
 
 if config.omp_host_rtl_directory:
     config.test_flags = config.test_flags + " -L " + \


### PR DESCRIPTION
We recently added versioning support to Flang's OpenMP, which restricts and enables certain things based on the OpenMP specification version. Currently one of the check-offload tests makes use of a feature that's at a slightly higher version than the current default causing it to fail.

This PR basically applies the highest current OpenMP version number as a default argument for the lit.cfg, if we need more fine grained control in the future we can expand it to different lit commands for each relevant version than can then be added in each test. But for now, to keep it simple, just set the max level version.