### PR TITLE
[OpenMP] Add critical region lock for NVPTX targets

### DIFF
--- a/offload/DeviceRTL/src/Synchronization.cpp
+++ b/offload/DeviceRTL/src/Synchronization.cpp
@@ -398,6 +398,10 @@ void setLock(omp_lock_t *Lock) {
   } // wait for 0 to be the read value
 }
 
+void unsetCriticalLock(omp_lock_t *Lock) { unsetLock(Lock); }
+
+void setCriticalLock(omp_lock_t *Lock) { setLock(Lock); }
+
 #pragma omp end declare variant
 ///}
 


### PR DESCRIPTION
Summary:
We define this on AMDGCN but not NVPTX, which leads to some failures
dependong on the target.
