### PR TITLE
[Clang] Update Interpreter tests to use clang_target_link_libraries

### DIFF
--- a/clang/unittests/Interpreter/CMakeLists.txt
+++ b/clang/unittests/Interpreter/CMakeLists.txt
@@ -16,13 +16,15 @@ add_clang_unittest(ClangReplInterpreterTests
 
   EXPORT_SYMBOLS
   )
-target_link_libraries(ClangReplInterpreterTests PUBLIC
+  
+target_link_libraries(ClangReplInterpreterTests PUBLIC LLVMTestingSupport)
+
+clang_target_link_libraries(ClangReplInterpreterTests PRIVATE
   clangAST
   clangBasic
   clangInterpreter
   clangFrontend
   clangSema
-  LLVMTestingSupport
   )
 
 # Exceptions on Windows are not yet supported.


### PR DESCRIPTION
This will fix duplicate and missing linker symbol errors when using CLANG_LINK_CLANG_DYLIB on windows and explicit visibility macros are used.
This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and plugins on window.