### PR TITLE
[rtsan] Add stats summary even when halt_on_error=true

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -75,8 +75,11 @@ static auto OnViolationAction(DiagnosticsInfo info) {
       handle.inc_use_count_unsafe();
     }
 
-    if (flags().halt_on_error)
+    if (flags().halt_on_error) {
+      if (flags().print_stats_on_exit)
+        PrintStatisticsSummary();
       Die();
+    }
   };
 }
 

--- a/compiler-rt/test/rtsan/exit_stats.cpp
+++ b/compiler-rt/test/rtsan/exit_stats.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
-// RUN: env RTSAN_OPTIONS="halt_on_error=false,print_stats_on_exit=true" %run %t 2>&1 | FileCheck %s
+// RUN: %env_rtsan_opts="halt_on_error=false,print_stats_on_exit=true" %run %t 2>&1 | FileCheck %s
+// RUN: %env_rtsan_opts="halt_on_error=true,print_stats_on_exit=true" not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-HALT
 
 // UNSUPPORTED: ios
 
@@ -22,3 +23,7 @@ int main() {
 // CHECK: RealtimeSanitizer exit stats:
 // CHECK-NEXT: Total error count: 10
 // CHECK-NEXT: Unique error count: 1
+
+// CHECK-HALT: RealtimeSanitizer exit stats:
+// CHECK-HALT-NEXT: Total error count: 1
+// CHECK-HALT-NEXT: Unique error count: 1


### PR DESCRIPTION
I discovered this on another branch. We only output the summary when halt_on_exit=false.

Questions:
1. Should this configuration be valid? It will always definitionally output "total = 1, unique =1". We could just abort early as an invalid combo


Edit: on second thought, if we add more stats in the future we will want to output them here too, so I think this is a valid fix for this issue.