### PR TITLE
[MIPS] Use softPromoteHalf legalization for fp16 rather than PromoteFloat

### DIFF
--- a/llvm/lib/Target/Mips/MipsISelLowering.h
+++ b/llvm/lib/Target/Mips/MipsISelLowering.h
@@ -365,6 +365,8 @@ class TargetRegisterClass;
       return ABI.IsN64() ? Mips::A1_64 : Mips::A1;
     }
 
+    bool softPromoteHalfType() const override { return true; }
+
     bool isJumpTableRelative() const override {
       return getTargetMachine().isPositionIndependent();
     }

--- a/llvm/test/CodeGen/Mips/fp16-promote.ll
+++ b/llvm/test/CodeGen/Mips/fp16-promote.ll
@@ -4,27 +4,25 @@
 define void @test_fadd(ptr %p, ptr %q) nounwind {
 ; CHECK-LIBCALL-LABEL: test_fadd:
 ; CHECK-LIBCALL:       # %bb.0:
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, -40
-; CHECK-LIBCALL-NEXT:    sdc1 $f20, 32($sp) # 8-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    sw $16, 20($sp) # 4-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    move $17, $4
-; CHECK-LIBCALL-NEXT:    lhu $4, 0($4)
+; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, -32
+; CHECK-LIBCALL-NEXT:    sdc1 $f20, 24($sp) # 8-byte Folded Spill
+; CHECK-LIBCALL-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
+; CHECK-LIBCALL-NEXT:    sw $16, 16($sp) # 4-byte Folded Spill
+; CHECK-LIBCALL-NEXT:    move $16, $4
+; CHECK-LIBCALL-NEXT:    lhu $4, 0($5)
 ; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
-; CHECK-LIBCALL-NEXT:    move $16, $5
+; CHECK-LIBCALL-NEXT:    nop
 ; CHECK-LIBCALL-NEXT:    lhu $4, 0($16)
 ; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
 ; CHECK-LIBCALL-NEXT:    mov.s $f20, $f0
 ; CHECK-LIBCALL-NEXT:    jal __gnu_f2h_ieee
-; CHECK-LIBCALL-NEXT:    add.s $f12, $f20, $f0
-; CHECK-LIBCALL-NEXT:    sh $2, 0($17)
-; CHECK-LIBCALL-NEXT:    lw $16, 20($sp) # 4-byte Folded Reload
-; CHECK-LIBCALL-NEXT:    lw $17, 24($sp) # 4-byte Folded Reload
-; CHECK-LIBCALL-NEXT:    lw $ra, 28($sp) # 4-byte Folded Reload
-; CHECK-LIBCALL-NEXT:    ldc1 $f20, 32($sp) # 8-byte Folded Reload
+; CHECK-LIBCALL-NEXT:    add.s $f12, $f0, $f20
+; CHECK-LIBCALL-NEXT:    sh $2, 0($16)
+; CHECK-LIBCALL-NEXT:    lw $16, 16($sp) # 4-byte Folded Reload
+; CHECK-LIBCALL-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
+; CHECK-LIBCALL-NEXT:    ldc1 $f20, 24($sp) # 8-byte Folded Reload
 ; CHECK-LIBCALL-NEXT:    jr $ra
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, 40
+; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, 32
   %a = load half, ptr %p, align 2
   %b = load half, ptr %q, align 2
   %r = fadd half %a, %b
@@ -263,32 +261,33 @@ define void @test_vec_fptrunc_double(<4 x double> %a, ptr %p) nounwind {
 define half @test_fadd_fadd(half %a, half %b, half %c) nounwind {
 ; CHECK-LIBCALL-LABEL: test_fadd_fadd:
 ; CHECK-LIBCALL:       # %bb.0:
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, -32
-; CHECK-LIBCALL-NEXT:    sdc1 $f20, 24($sp) # 8-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    sw $16, 16($sp) # 4-byte Folded Spill
+; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, -40
+; CHECK-LIBCALL-NEXT:    sdc1 $f20, 32($sp) # 8-byte Folded Spill
+; CHECK-LIBCALL-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
+; CHECK-LIBCALL-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
+; CHECK-LIBCALL-NEXT:    sw $16, 20($sp) # 4-byte Folded Spill
 ; CHECK-LIBCALL-NEXT:    move $16, $6
-; CHECK-LIBCALL-NEXT:    mov.s $f20, $f12
+; CHECK-LIBCALL-NEXT:    move $17, $4
+; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
+; CHECK-LIBCALL-NEXT:    move $4, $5
+; CHECK-LIBCALL-NEXT:    mov.s $f20, $f0
+; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
+; CHECK-LIBCALL-NEXT:    move $4, $17
 ; CHECK-LIBCALL-NEXT:    jal __gnu_f2h_ieee
-; CHECK-LIBCALL-NEXT:    mov.s $f12, $f14
+; CHECK-LIBCALL-NEXT:    add.s $f12, $f0, $f20
 ; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
 ; CHECK-LIBCALL-NEXT:    move $4, $2
-; CHECK-LIBCALL-NEXT:    mov.s $f21, $f0
-; CHECK-LIBCALL-NEXT:    jal __gnu_f2h_ieee
-; CHECK-LIBCALL-NEXT:    mov.s $f12, $f20
+; CHECK-LIBCALL-NEXT:    mov.s $f20, $f0
 ; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
-; CHECK-LIBCALL-NEXT:    move $4, $2
-; CHECK-LIBCALL-NEXT:    add.s $f20, $f0, $f21
+; CHECK-LIBCALL-NEXT:    move $4, $16
 ; CHECK-LIBCALL-NEXT:    jal __gnu_f2h_ieee
-; CHECK-LIBCALL-NEXT:    mtc1 $16, $f12
-; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
-; CHECK-LIBCALL-NEXT:    move $4, $2
-; CHECK-LIBCALL-NEXT:    add.s $f0, $f20, $f0
-; CHECK-LIBCALL-NEXT:    lw $16, 16($sp) # 4-byte Folded Reload
-; CHECK-LIBCALL-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
-; CHECK-LIBCALL-NEXT:    ldc1 $f20, 24($sp) # 8-byte Folded Reload
+; CHECK-LIBCALL-NEXT:    add.s $f12, $f20, $f0
+; CHECK-LIBCALL-NEXT:    lw $16, 20($sp) # 4-byte Folded Reload
+; CHECK-LIBCALL-NEXT:    lw $17, 24($sp) # 4-byte Folded Reload
+; CHECK-LIBCALL-NEXT:    lw $ra, 28($sp) # 4-byte Folded Reload
+; CHECK-LIBCALL-NEXT:    ldc1 $f20, 32($sp) # 8-byte Folded Reload
 ; CHECK-LIBCALL-NEXT:    jr $ra
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, 32
+; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, 40
   %d = fadd half %a, %b
   %e = fadd half %d, %c
   ret half %e
@@ -297,13 +296,8 @@ define half @test_fadd_fadd(half %a, half %b, half %c) nounwind {
 define half @to_half(i16 %bits) nounwind {
 ; CHECK-LIBCALL-LABEL: to_half:
 ; CHECK-LIBCALL:       # %bb.0:
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, -24
-; CHECK-LIBCALL-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    jal __gnu_h2f_ieee
-; CHECK-LIBCALL-NEXT:    nop
-; CHECK-LIBCALL-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; CHECK-LIBCALL-NEXT:    jr $ra
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, 24
+; CHECK-LIBCALL-NEXT:    move $2, $4
   %f = bitcast i16 %bits to half
   ret half %f
 }
@@ -311,14 +305,8 @@ define half @to_half(i16 %bits) nounwind {
 define i16 @from_half(half %f) nounwind {
 ; CHECK-LIBCALL-LABEL: from_half:
 ; CHECK-LIBCALL:       # %bb.0:
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, -24
-; CHECK-LIBCALL-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
-; CHECK-LIBCALL-NEXT:    jal __gnu_f2h_ieee
-; CHECK-LIBCALL-NEXT:    nop
-; CHECK-LIBCALL-NEXT:    andi $2, $2, 65535
-; CHECK-LIBCALL-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; CHECK-LIBCALL-NEXT:    jr $ra
-; CHECK-LIBCALL-NEXT:    addiu $sp, $sp, 24
+; CHECK-LIBCALL-NEXT:    move $2, $4
   %bits = bitcast half %f to i16
   ret i16 %bits
 }


### PR DESCRIPTION
Fix part of #97975.