### PR TITLE
[Clang][ASTMatchers] Add visibility macros to variables declared by macros

### DIFF
--- a/clang/include/clang/ASTMatchers/ASTMatchersMacros.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersMacros.h
@@ -49,6 +49,8 @@
 #ifndef LLVM_CLANG_ASTMATCHERS_ASTMATCHERSMACROS_H
 #define LLVM_CLANG_ASTMATCHERS_ASTMATCHERSMACROS_H
 
+#include "clang/Support/Compiler.h"
+
 /// AST_MATCHER_FUNCTION(ReturnType, DefineMatcher) { ... }
 /// defines a zero parameter function named DefineMatcher() that returns a
 /// ReturnType object.
@@ -367,7 +369,7 @@
     static QualType (T::*value())() const { return &T::FunctionName; }         \
   };                                                                           \
   }                                                                            \
-  extern const ::clang::ast_matchers::internal::                               \
+  CLANG_ABI extern const ::clang::ast_matchers::internal::                     \
       TypeTraversePolymorphicMatcher<                                          \
           QualType,                                                            \
           ::clang::ast_matchers::internal::TypeMatcher##MatcherName##Getter,   \
@@ -407,7 +409,7 @@
     static TypeLoc (T::*value())() const { return &T::FunctionName##Loc; }     \
   };                                                                           \
   }                                                                            \
-  extern const ::clang::ast_matchers::internal::                               \
+  CLANG_ABI extern const ::clang::ast_matchers::internal::                     \
       TypeTraversePolymorphicMatcher<                                          \
           TypeLoc,                                                             \
           ::clang::ast_matchers::internal::                                    \


### PR DESCRIPTION
This will fix missing symbols for ASTMatchersTests on windows when building with CLANG_LINK_CLANG and explicit visibility macros are used. This PR depends on macros that will be be added in #108276
This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and LLVM\Clang plugins on window.