### PR TITLE
[libc++][string] Add regression test for sized new/delete bug

### DIFF
--- a/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
@@ -8,7 +8,7 @@
 
 // <string>
 
-// allocate/deallocate must match.
+// Make sure the size we allocate and deallocate match. See https://github.com/llvm/llvm-project/pull/90292.
 
 #include <string>
 #include <cassert>

--- a/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
@@ -61,6 +61,6 @@ int main(int, char**) {
   test<uint32_t>();
   test<uint64_t>();
   test<size_t>();
-  
+
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string>
+
+// allocate/deallocate must match.
+
+#include <string>
+#include <cassert>
+#include <type_traits>
+
+#include "test_macros.h"
+
+static int allocated_;
+
+template <class T, class Sz>
+struct test_alloc {
+  typedef Sz size_type;
+  typedef std::make_signed<Sz>::type difference_type;
+  typedef T value_type;
+  typedef value_type* pointer;
+  typedef const value_type* const_pointer;
+  typedef typename std::add_lvalue_reference<value_type>::type reference;
+  typedef typename std::add_lvalue_reference<const value_type>::type const_reference;
+
+  template <class U>
+  struct rebind {
+    typedef test_alloc<U, Sz> other;
+  };
+
+  TEST_CONSTEXPR_CXX14 pointer allocate(size_type n, const void* = nullptr) {
+    allocated_ += n;
+    return std::allocator<value_type>().allocate(n);
+  }
+
+  TEST_CONSTEXPR_CXX14 void deallocate(pointer p, size_type s) {
+    allocated_ -= s;
+    std::allocator<value_type>().deallocate(p, s);
+  }
+};
+
+template <class Sz>
+void test() {
+  for (int i = 1; i < 1000; ++i) {
+    using Str = std::basic_string<char, std::char_traits<char>, test_alloc<char, Sz> >;
+    {
+      Str s(i, 't');
+      assert(allocated_ == 0 || allocated_ >= i);
+    }
+  }
+  assert(allocated_ == 0);
+}
+
+int main(int, char**) {
+  test<uint32_t>();
+  test<uint64_t>();
+  test<size_t>();
+}

--- a/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <cassert>
+#include <cstdint>
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
@@ -21,7 +21,7 @@ static int allocated_;
 template <class T, class Sz>
 struct test_alloc {
   typedef Sz size_type;
-  typedef std::make_signed<Sz>::type difference_type;
+  typedef typename std::make_signed<Sz>::type difference_type;
   typedef T value_type;
   typedef value_type* pointer;
   typedef const value_type* const_pointer;

--- a/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
@@ -61,4 +61,6 @@ int main(int, char**) {
   test<uint32_t>();
   test<uint64_t>();
   test<size_t>();
+  
+  return 0;
 }


### PR DESCRIPTION
This is regression test for #90292.

Allocator used in test is very similar to test_allocator.
However, reproducer requires size_type of the string
to be 64bit, but test_allocator uses 32bit.

32bit size_type makes `sizeof(string::__long)` to be 16,
but the alignment issue fixed with #90292 is only triggered
with default `sizeof(string::__long)` which is 24.

Fixes #92128.
