### PR TITLE
[LoongArch] Add processor models la64v1.0 and la64v1.1

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArch.td
+++ b/llvm/lib/Target/LoongArch/LoongArch.td
@@ -128,30 +128,41 @@ include "LoongArchInstrInfo.td"
 // LoongArch processors supported.
 //===----------------------------------------------------------------------===//
 
-def : ProcessorModel<"generic-la32", NoSchedModel, [Feature32Bit]>;
-def : ProcessorModel<"generic-la64", NoSchedModel, [Feature64Bit, FeatureUAL]>;
+def ProcessorFeatures {
+  list<SubtargetFeature> LA32G    = [Feature32Bit];
+  list<SubtargetFeature> LA64G    = [Feature64Bit,
+                                     FeatureUAL];
+  list<SubtargetFeature> LA64GD   = [Feature64Bit,
+                                     FeatureUAL,
+                                     FeatureBasicD];
+  list<SubtargetFeature> LA64V1_0 = [Feature64Bit,
+                                     FeatureUAL,
+                                     FeatureExtLASX,
+                                     FeatureExtLVZ,
+                                     FeatureExtLBT];
+  list<SubtargetFeature> LA64V1_1 = [Feature64Bit,
+                                     FeatureUAL,
+                                     FeatureExtLASX,
+                                     FeatureExtLVZ,
+                                     FeatureExtLBT,
+                                     FeatureFrecipe];
+}
+
+def : ProcessorModel<"generic-la32", NoSchedModel, ProcessorFeatures.LA32G>;
+def : ProcessorModel<"generic-la64", NoSchedModel, ProcessorFeatures.LA64G>;
 
 // Generic 64-bit processor with double-precision floating-point support.
-def : ProcessorModel<"loongarch64", NoSchedModel, [Feature64Bit,
-                                                   FeatureUAL,
-                                                   FeatureBasicD]>;
+def : ProcessorModel<"loongarch64", NoSchedModel, ProcessorFeatures.LA64GD>;
 
 // Support generic for compatibility with other targets. The triple will be used
 // to change to the appropriate la32/la64 version.
 def : ProcessorModel<"generic", NoSchedModel, []>;
 
-def : ProcessorModel<"la464", NoSchedModel, [Feature64Bit,
-                                             FeatureUAL,
-                                             FeatureExtLASX,
-                                             FeatureExtLVZ,
-                                             FeatureExtLBT]>;
+def : ProcessorModel<"la464", NoSchedModel, ProcessorFeatures.LA64V1_0>;
+def : ProcessorModel<"la64v1.0", NoSchedModel, ProcessorFeatures.LA64V1_0>;
 
-def : ProcessorModel<"la664", NoSchedModel, [Feature64Bit,
-                                             FeatureUAL,
-                                             FeatureExtLASX,
-                                             FeatureExtLVZ,
-                                             FeatureExtLBT,
-                                             FeatureFrecipe]>;
+def : ProcessorModel<"la664", NoSchedModel, ProcessorFeatures.LA64V1_1>;
+def : ProcessorModel<"la64v1.1", NoSchedModel, ProcessorFeatures.LA64V1_1>;
 
 //===----------------------------------------------------------------------===//
 // Define the LoongArch target.

--- a/llvm/test/CodeGen/LoongArch/cpus.ll
+++ b/llvm/test/CodeGen/LoongArch/cpus.ll
@@ -4,6 +4,8 @@
 ; RUN: llc < %s --mtriple=loongarch64 -mattr=+d --mcpu=loongarch64 2>&1 | FileCheck %s
 ; RUN: llc < %s --mtriple=loongarch64 -mattr=+d --mcpu=la464 2>&1 | FileCheck %s
 ; RUN: llc < %s --mtriple=loongarch64 -mattr=+d --mcpu=la664 2>&1 | FileCheck %s
+; RUN: llc < %s --mtriple=loongarch64 -mattr=+d --mcpu=la64v1.0 2>&1 | FileCheck %s
+; RUN: llc < %s --mtriple=loongarch64 -mattr=+d --mcpu=la64v1.1 2>&1 | FileCheck %s
 ; RUN: llc < %s --mtriple=loongarch64 -mattr=+d 2>&1 | FileCheck %s
 
 ; CHECK-NOT: {{.*}} is not a recognized processor for this target
@@ -21,5 +23,13 @@ define void @tune_cpu_la464() "tune-cpu"="la464" {
 }
 
 define void @tune_cpu_la664() "tune-cpu"="la664" {
+  ret void
+}
+
+define void @tune_cpu_la64v1_0() "tune-cpu"="la64v1.0" {
+  ret void
+}
+
+define void @tune_cpu_la64v1_1() "tune-cpu"="la64v1.1" {
   ret void
 }


### PR DESCRIPTION
Add support for the `la64v1.0` and `la64v1.1` processor models, enabling Rust to select features based on the version of the LoongArch instruction set. These values will align with those used in the C/C++ toolchain. [^1]

[^1]: https://github.com/loongson/la-toolchain-conventions?tab=readme-ov-file#list