### PR TITLE
[MIR] Serialize virtual register flags

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -37,7 +37,7 @@ class TargetRegisterClass;
 class TargetSubtargetInfo;
 
 struct VRegInfo {
-  enum uint8_t {
+  enum : uint8_t {
     UNKNOWN, NORMAL, GENERIC, REGBANK
   } Kind = UNKNOWN;
   bool Explicit = false; ///< VReg was explicitly specified in the .mir file.
@@ -47,7 +47,7 @@ struct VRegInfo {
   } D;
   Register VReg;
   Register PreferredReg;
-  std::vector<::uint8_t> Flags;
+  std::vector<uint8_t> Flags;
 };
 
 using Name2RegClassMap = StringMap<const TargetRegisterClass *>;

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -47,6 +47,7 @@ struct VRegInfo {
   } D;
   Register VReg;
   Register PreferredReg;
+  std::vector<::uint8_t> Flags;
 };
 
 using Name2RegClassMap = StringMap<const TargetRegisterClass *>;
@@ -149,6 +150,8 @@ public:
   ///
   /// Return null if the name isn't a register bank.
   const RegisterBank *getRegBank(StringRef Name);
+
+  bool getVRegFlagValue(StringRef FlagName, uint8_t& FlagValue) const;
 
   PerTargetMIParsingState(const TargetSubtargetInfo &STI)
     : Subtarget(STI) {

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -37,9 +37,7 @@ class TargetRegisterClass;
 class TargetSubtargetInfo;
 
 struct VRegInfo {
-  enum : uint8_t {
-    UNKNOWN, NORMAL, GENERIC, REGBANK
-  } Kind = UNKNOWN;
+  enum : uint8_t { UNKNOWN, NORMAL, GENERIC, REGBANK } Kind = UNKNOWN;
   bool Explicit = false; ///< VReg was explicitly specified in the .mir file.
   union {
     const TargetRegisterClass *RC;

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -151,7 +151,7 @@ public:
   /// Return null if the name isn't a register bank.
   const RegisterBank *getRegBank(StringRef Name);
 
-  bool getVRegFlagValue(StringRef FlagName, uint8_t& FlagValue) const;
+  bool getVRegFlagValue(StringRef FlagName, uint8_t &FlagValue) const;
 
   PerTargetMIParsingState(const TargetSubtargetInfo &STI)
     : Subtarget(STI) {

--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -191,6 +191,7 @@ struct VirtualRegisterDefinition {
   UnsignedValue ID;
   StringValue Class;
   StringValue PreferredRegister;
+  std::vector<FlowStringValue> RegisterFlags;
 
   // TODO: Serialize the target specific register hints.
 
@@ -206,6 +207,8 @@ template <> struct MappingTraits<VirtualRegisterDefinition> {
     YamlIO.mapRequired("class", Reg.Class);
     YamlIO.mapOptional("preferred-register", Reg.PreferredRegister,
                        StringValue()); // Don't print out when it's empty.
+    YamlIO.mapOptional("flags", Reg.RegisterFlags,
+                       std::vector<FlowStringValue>());
   }
 
   static const bool flow = true;

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -1218,7 +1218,7 @@ public:
     return {};
   }
 
-  virtual SmallVector<SmallString<8>>
+  virtual SmallVector<StringLiteral>
   getVRegFlagsOfReg(Register Reg, const MachineFunction &MF) const {
     return {};
   }

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -1213,6 +1213,15 @@ public:
   virtual bool isNonallocatableRegisterCalleeSave(MCRegister Reg) const {
     return false;
   }
+
+  virtual std::pair<bool, uint8_t> getVRegFlagValue(StringRef Name) const {
+    return {false, 0};
+  }
+
+  virtual SmallVector<std::string>
+  getVRegFlagsOfReg(Register Reg, const MachineFunction &MF) const {
+    return {};
+  }
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -1214,11 +1214,11 @@ public:
     return false;
   }
 
-  virtual std::pair<bool, uint8_t> getVRegFlagValue(StringRef Name) const {
-    return {false, 0};
+  virtual std::optional<uint8_t> getVRegFlagValue(StringRef Name) const {
+    return {};
   }
 
-  virtual SmallVector<std::string>
+  virtual SmallVector<SmallString<8>>
   getVRegFlagsOfReg(Register Reg, const MachineFunction &MF) const {
     return {};
   }

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -130,10 +130,10 @@ bool PerTargetMIParsingState::getRegisterByName(StringRef RegName,
 bool PerTargetMIParsingState::getVRegFlagValue(StringRef FlagName,
                                                uint8_t &FlagValue) const {
   const auto *TRI = Subtarget.getRegisterInfo();
-  auto FV = TRI->getVRegFlagValue(FlagName);
-  if (!FV.has_value())
+  std::optional<uint8_t> FV = TRI->getVRegFlagValue(FlagName);
+  if (!FV)
     return true;
-  FlagValue = FV.value();
+  FlagValue = *FV;
   return false;
 }
 

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -127,6 +127,16 @@ bool PerTargetMIParsingState::getRegisterByName(StringRef RegName,
   return false;
 }
 
+bool PerTargetMIParsingState::getVRegFlagValue(StringRef FlagName, uint8_t& FlagValue) const {
+  const auto *TRI = Subtarget.getRegisterInfo();
+  assert(TRI && "Expected target register info");
+  auto [HasVReg, FV] = TRI->getVRegFlagValue(FlagName);
+  if(!HasVReg)
+    return true;
+  FlagValue = FV;
+  return false;
+}
+
 void PerTargetMIParsingState::initNames2InstrOpCodes() {
   if (!Names2InstrOpCodes.empty())
     return;
@@ -1776,6 +1786,7 @@ bool MIParser::parseRegisterOperand(MachineOperand &Dest,
 
         MRI.setRegClassOrRegBank(Reg, static_cast<RegisterBank *>(nullptr));
         MRI.setType(Reg, Ty);
+        MRI.noteNewVirtualRegister(Reg);
       }
     }
   } else if (consumeIfPresent(MIToken::lparen)) {

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1786,7 +1786,6 @@ bool MIParser::parseRegisterOperand(MachineOperand &Dest,
 
         MRI.setRegClassOrRegBank(Reg, static_cast<RegisterBank *>(nullptr));
         MRI.setType(Reg, Ty);
-        MRI.noteNewVirtualRegister(Reg);
       }
     }
   } else if (consumeIfPresent(MIToken::lparen)) {

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -127,11 +127,12 @@ bool PerTargetMIParsingState::getRegisterByName(StringRef RegName,
   return false;
 }
 
-bool PerTargetMIParsingState::getVRegFlagValue(StringRef FlagName, uint8_t& FlagValue) const {
+bool PerTargetMIParsingState::getVRegFlagValue(StringRef FlagName,
+                                               uint8_t &FlagValue) const {
   const auto *TRI = Subtarget.getRegisterInfo();
   assert(TRI && "Expected target register info");
   auto [HasVReg, FV] = TRI->getVRegFlagValue(FlagName);
-  if(!HasVReg)
+  if (!HasVReg)
     return true;
   FlagValue = FV;
   return false;

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -130,11 +130,10 @@ bool PerTargetMIParsingState::getRegisterByName(StringRef RegName,
 bool PerTargetMIParsingState::getVRegFlagValue(StringRef FlagName,
                                                uint8_t &FlagValue) const {
   const auto *TRI = Subtarget.getRegisterInfo();
-  assert(TRI && "Expected target register info");
-  auto [HasVReg, FV] = TRI->getVRegFlagValue(FlagName);
-  if (!HasVReg)
+  auto FV = TRI->getVRegFlagValue(FlagName);
+  if (!FV.has_value())
     return true;
-  FlagValue = FV;
+  FlagValue = FV.value();
   return false;
 }
 

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -696,6 +696,15 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
                                  VReg.PreferredRegister.Value, Error))
         return error(Error, VReg.PreferredRegister.SourceRange);
     }
+
+    for(const auto &FlagStringValue: VReg.RegisterFlags) {
+      uint8_t FlagValue;
+      if(Target->getVRegFlagValue(FlagStringValue.Value, FlagValue))
+        return error(FlagStringValue.SourceRange.Start,
+                      Twine("use of undefined register flag '") +
+                          FlagStringValue.Value + "'");
+        Info.Flags.push_back(FlagValue);
+    }
   }
 
   // Parse the liveins.

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -697,13 +697,13 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(Error, VReg.PreferredRegister.SourceRange);
     }
 
-    for(const auto &FlagStringValue: VReg.RegisterFlags) {
+    for (const auto &FlagStringValue : VReg.RegisterFlags) {
       uint8_t FlagValue;
-      if(Target->getVRegFlagValue(FlagStringValue.Value, FlagValue))
+      if (Target->getVRegFlagValue(FlagStringValue.Value, FlagValue))
         return error(FlagStringValue.SourceRange.Start,
-                      Twine("use of undefined register flag '") +
-                          FlagStringValue.Value + "'");
-        Info.Flags.push_back(FlagValue);
+                     Twine("use of undefined register flag '") +
+                         FlagStringValue.Value + "'");
+      Info.Flags.push_back(FlagValue);
     }
   }
 

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -321,9 +321,9 @@ static void printRegFlags(Register Reg,
                           std::vector<yaml::FlowStringValue> &RegisterFlags,
                           const MachineFunction &MF,
                           const TargetRegisterInfo *TRI) {
-  SmallVector<std::string> FlagValues = TRI->getVRegFlagsOfReg(Reg, MF);
+  auto FlagValues = TRI->getVRegFlagsOfReg(Reg, MF);
   for (auto &Flag : FlagValues) {
-    RegisterFlags.push_back(yaml::FlowStringValue(Flag));
+    RegisterFlags.push_back(yaml::FlowStringValue(Flag.str().str()));
   }
 }
 

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -113,7 +113,8 @@ public:
 
   void print(const MachineFunction &MF);
 
-  void convert(yaml::MachineFunction &MF, const MachineRegisterInfo &RegInfo,
+  void convert(yaml::MachineFunction &YamlMF, const MachineFunction &MF,
+               const MachineRegisterInfo &RegInfo,
                const TargetRegisterInfo *TRI);
   void convert(ModuleSlotTracker &MST, yaml::MachineFrameInfo &YamlMFI,
                const MachineFrameInfo &MFI);
@@ -231,7 +232,7 @@ void MIRPrinter::print(const MachineFunction &MF) {
   YamlMF.NoVRegs = MF.getProperties().hasProperty(
       MachineFunctionProperties::Property::NoVRegs);
 
-  convert(YamlMF, MF.getRegInfo(), MF.getSubtarget().getRegisterInfo());
+  convert(YamlMF, MF, MF.getRegInfo(), MF.getSubtarget().getRegisterInfo());
   MachineModuleSlotTracker MST(MMI, &MF);
   MST.incorporateFunction(MF.getFunction());
   convert(MST, YamlMF.FrameInfo, MF.getFrameInfo());
@@ -316,10 +317,21 @@ printStackObjectDbgInfo(const MachineFunction::VariableDbgInfo &DebugVar,
   }
 }
 
-void MIRPrinter::convert(yaml::MachineFunction &MF,
+static void printRegFlags(Register Reg,
+                          std::vector<yaml::FlowStringValue> &RegisterFlags,
+                          const MachineFunction &MF,
+                          const TargetRegisterInfo *TRI) {
+  SmallVector<std::string> FlagValues = TRI->getVRegFlagsOfReg(Reg, MF);
+  for (auto &Flag : FlagValues) {
+    RegisterFlags.push_back(yaml::FlowStringValue(Flag));
+  }
+}
+
+void MIRPrinter::convert(yaml::MachineFunction &YamlMF,
+                         const MachineFunction &MF,
                          const MachineRegisterInfo &RegInfo,
                          const TargetRegisterInfo *TRI) {
-  MF.TracksRegLiveness = RegInfo.tracksLiveness();
+  YamlMF.TracksRegLiveness = RegInfo.tracksLiveness();
 
   // Print the virtual register definitions.
   for (unsigned I = 0, E = RegInfo.getNumVirtRegs(); I < E; ++I) {
@@ -332,7 +344,8 @@ void MIRPrinter::convert(yaml::MachineFunction &MF,
     Register PreferredReg = RegInfo.getSimpleHint(Reg);
     if (PreferredReg)
       printRegMIR(PreferredReg, VReg.PreferredRegister, TRI);
-    MF.VirtualRegisters.push_back(VReg);
+    printRegFlags(Reg, VReg.RegisterFlags, MF, TRI);
+    YamlMF.VirtualRegisters.push_back(VReg);
   }
 
   // Print the live ins.
@@ -341,7 +354,7 @@ void MIRPrinter::convert(yaml::MachineFunction &MF,
     printRegMIR(LI.first, LiveIn.Register, TRI);
     if (LI.second)
       printRegMIR(LI.second, LiveIn.VirtualRegister, TRI);
-    MF.LiveIns.push_back(LiveIn);
+    YamlMF.LiveIns.push_back(LiveIn);
   }
 
   // Prints the callee saved registers.
@@ -353,7 +366,7 @@ void MIRPrinter::convert(yaml::MachineFunction &MF,
       printRegMIR(*I, Reg, TRI);
       CalleeSavedRegisters.push_back(Reg);
     }
-    MF.CalleeSavedRegisters = CalleeSavedRegisters;
+    YamlMF.CalleeSavedRegisters = CalleeSavedRegisters;
   }
 }
 

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -323,7 +323,7 @@ static void printRegFlags(Register Reg,
                           const TargetRegisterInfo *TRI) {
   auto FlagValues = TRI->getVRegFlagsOfReg(Reg, MF);
   for (auto &Flag : FlagValues) {
-    RegisterFlags.push_back(yaml::FlowStringValue(Flag.str().str()));
+    RegisterFlags.push_back(yaml::FlowStringValue(Flag.str()));
   }
 }
 

--- a/llvm/test/CodeGen/AMDGPU/limit-coalesce.mir
+++ b/llvm/test/CodeGen/AMDGPU/limit-coalesce.mir
@@ -2,13 +2,13 @@
 
 # Check that coalescer does not create wider register tuple than in source
 
-# CHECK:  - { id: 2, class: vreg_64, preferred-register: '' }
-# CHECK:  - { id: 3, class: vreg_64, preferred-register: '' }
-# CHECK:  - { id: 4, class: vreg_64, preferred-register: '' }
-# CHECK:  - { id: 5, class: vreg_96, preferred-register: '' }
-# CHECK:  - { id: 6, class: vreg_96, preferred-register: '' }
-# CHECK:  - { id: 7, class: vreg_128, preferred-register: '' }
-# CHECK:  - { id: 8, class: vreg_128, preferred-register: '' }
+# CHECK:  - { id: 2, class: vreg_64, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 3, class: vreg_64, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 4, class: vreg_64, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 5, class: vreg_96, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 6, class: vreg_96, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 7, class: vreg_128, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 8, class: vreg_128, preferred-register: '', flags: [  ] }
 # No more registers shall be defined
 # CHECK-NEXT: liveins:
 # CHECK:    FLAT_STORE_DWORDX2 $vgpr0_vgpr1, %4,

--- a/llvm/test/CodeGen/MIR/Generic/register-flag-error.mir
+++ b/llvm/test/CodeGen/MIR/Generic/register-flag-error.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -run-pass=none -o - %s 2>&1 | FileCheck %s --check-prefix=ERR
+# RUN: not llc -run-pass=none -filetype=null %s 2>&1 | FileCheck %s --check-prefix=ERR
 
 ---
 name:  flags

--- a/llvm/test/CodeGen/MIR/Generic/register-flag-error.mir
+++ b/llvm/test/CodeGen/MIR/Generic/register-flag-error.mir
@@ -1,0 +1,13 @@
+# RUN: not llc -run-pass=none -o - %s 2>&1 | FileCheck %s --check-prefix=ERR
+
+---
+name:  flags
+registers:
+  - { id: 0, class: _, flags: [ 'VFLAG_ERR' ] }
+body: |
+  bb.0:
+    liveins: $w0
+    %0 = G_ADD $w0, $w0
+...
+# ERR: use of undefined register flag
+# ERR: VFLAG_ERR

--- a/llvm/test/CodeGen/MIR/X86/expected-named-register-in-allocation-hint.mir
+++ b/llvm/test/CodeGen/MIR/X86/expected-named-register-in-allocation-hint.mir
@@ -14,8 +14,8 @@ name:            test
 tracksRegLiveness: true
 registers:
   - { id: 0, class: gr32 }
-  # CHECK: - { id: 1, class: gr32, preferred-register: '%0' }
-  # CHECK: - { id: 2, class: gr32, preferred-register: '$edi' }
+  # CHECK: - { id: 1, class: gr32, preferred-register: '%0', flags: [  ] }
+  # CHECK: - { id: 2, class: gr32, preferred-register: '$edi', flags: [  ] }
   - { id: 1, class: gr32, preferred-register: '%0' }
   - { id: 2, class: gr32, preferred-register: '$edi' }
 body: |

--- a/llvm/test/CodeGen/MIR/X86/generic-instr-type.mir
+++ b/llvm/test/CodeGen/MIR/X86/generic-instr-type.mir
@@ -18,11 +18,11 @@
 ---
 name:            test_vregs
 # CHECK:      registers:
-# CHECK-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# CHECK-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: _, preferred-register: '' }
-# CHECK-NEXT:   - { id: 3, class: _, preferred-register: '' }
-# CHECK-NEXT:   - { id: 4, class: _, preferred-register: '' }
+# CHECK-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 3, class: _, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 4, class: _, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }

--- a/llvm/test/CodeGen/MIR/X86/register-operand-class.mir
+++ b/llvm/test/CodeGen/MIR/X86/register-operand-class.mir
@@ -6,11 +6,11 @@
 ---
 # CHECK-LABEL: name: func
 # CHECK: registers:
-# CHECK:   - { id: 0, class: gr32, preferred-register: '' }
-# CHECK:   - { id: 1, class: gr64, preferred-register: '' }
-# CHECK:   - { id: 2, class: gr32, preferred-register: '' }
-# CHECK:   - { id: 3, class: gr16, preferred-register: '' }
-# CHECK:   - { id: 4, class: _, preferred-register: '' }
+# CHECK:   - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK:   - { id: 1, class: gr64, preferred-register: '', flags: [   ] }
+# CHECK:   - { id: 2, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK:   - { id: 3, class: gr16, preferred-register: '', flags: [   ] }
+# CHECK:   - { id: 4, class: _, preferred-register: '', flags: [   ] }
 name: func
 body: |
   bb.0:

--- a/llvm/test/CodeGen/MIR/X86/roundtrip.mir
+++ b/llvm/test/CodeGen/MIR/X86/roundtrip.mir
@@ -2,8 +2,8 @@
 ---
 # CHECK-LABEL: name: func0
 # CHECK: registers:
-# CHECK:   - { id: 0, class: gr32, preferred-register: '' }
-# CHECK:   - { id: 1, class: gr32, preferred-register: '' }
+# CHECK:   - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK:   - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
 # CHECK: body: |
 # CHECK:   bb.0:
 # CHECK:     %0:gr32 = MOV32r0 implicit-def $eflags

--- a/llvm/test/CodeGen/MIR/X86/simple-register-allocation-hints.mir
+++ b/llvm/test/CodeGen/MIR/X86/simple-register-allocation-hints.mir
@@ -15,9 +15,9 @@
 name:            test
 tracksRegLiveness: true
 # CHECK: registers:
-# CHECK-NEXT:  - { id: 0, class: gr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gr32, preferred-register: '$esi' }
-# CHECK-NEXT:  - { id: 2, class: gr32, preferred-register: '$edi' }
+# CHECK-NEXT:  - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:  - { id: 1, class: gr32, preferred-register: '$esi', flags: [   ] }
+# CHECK-NEXT:  - { id: 2, class: gr32, preferred-register: '$edi', flags: [   ] }
 registers:
   - { id: 0, class: gr32 }
   - { id: 1, class: gr32, preferred-register: '$esi' }

--- a/llvm/test/CodeGen/MIR/X86/virtual-registers.mir
+++ b/llvm/test/CodeGen/MIR/X86/virtual-registers.mir
@@ -33,9 +33,9 @@
 name:            bar
 tracksRegLiveness: true
 # CHECK:      registers:
-# CHECK-NEXT:   - { id: 0, class: gr32, preferred-register: '' }
-# CHECK-NEXT:   - { id: 1, class: gr32, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: gr32, preferred-register: '' }
+# CHECK-NEXT:   - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 2, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gr32 }
   - { id: 1, class: gr32 }
@@ -67,9 +67,9 @@ name:            foo
 tracksRegLiveness: true
 # CHECK: name: foo
 # CHECK:      registers:
-# CHECK-NEXT:   - { id: 0, class: gr32, preferred-register: '' }
-# CHECK-NEXT:   - { id: 1, class: gr32, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: gr32, preferred-register: '' }
+# CHECK-NEXT:   - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 2, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 2, class: gr32 }
   - { id: 0, class: gr32 }

--- a/llvm/test/CodeGen/X86/GlobalISel/legalize-mul-v128.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/legalize-mul-v128.mir
@@ -26,9 +26,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -56,9 +56,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -86,9 +86,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }

--- a/llvm/test/CodeGen/X86/GlobalISel/legalize-mul-v256.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/legalize-mul-v256.mir
@@ -26,9 +26,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -56,9 +56,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -86,9 +86,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }

--- a/llvm/test/CodeGen/X86/GlobalISel/legalize-mul-v512.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/legalize-mul-v512.mir
@@ -28,9 +28,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -58,9 +58,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -88,9 +88,9 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: _, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: _, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: _, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }

--- a/llvm/test/CodeGen/X86/GlobalISel/regbankselect-AVX2.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/regbankselect-AVX2.mir
@@ -33,8 +33,8 @@ selected:        false
 tracksRegLiveness: true
 # CHECK-LABEL: name:            test_mul_vec256
 # CHECK: registers:
-# CHECK:  - { id: 0, class: vecr, preferred-register: '' }
-# CHECK:  - { id: 1, class: vecr, preferred-register: '' }
+# CHECK:  - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK:  - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -56,8 +56,8 @@ selected:        false
 tracksRegLiveness: true
 # CHECK-LABEL: name:            test_add_vec256
 # CHECK: registers:
-# CHECK:  - { id: 0, class: vecr, preferred-register: '' }
-# CHECK:  - { id: 1, class: vecr, preferred-register: '' }
+# CHECK:  - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK:  - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -79,8 +79,8 @@ selected:        false
 tracksRegLiveness: true
 # CHECK-LABEL: name:            test_sub_vec256
 # CHECK: registers:
-# CHECK:  - { id: 0, class: vecr, preferred-register: '' }
-# CHECK:  - { id: 1, class: vecr, preferred-register: '' }
+# CHECK:  - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK:  - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -100,8 +100,8 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:       registers:
-# CHECK-NEXT:    - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '' }
+# CHECK-NEXT:    - { id: 0, class: gpr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -122,8 +122,8 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:       registers:
-# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '' }
-# CHECK-NEXT:    - { id: 1, class: gpr, preferred-register: '' }
+# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:    - { id: 1, class: gpr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }

--- a/llvm/test/CodeGen/X86/GlobalISel/regbankselect-AVX512.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/regbankselect-AVX512.mir
@@ -33,8 +33,8 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:       registers:
-# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '' }
-# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '' }
+# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -53,8 +53,8 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:       registers:
-# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '' }
-# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '' }
+# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -73,8 +73,8 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:       registers:
-# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '' }
-# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '' }
+# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -93,8 +93,8 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:       registers:
-# CHECK-NEXT:    - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '' }
+# CHECK-NEXT:    - { id: 0, class: gpr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:    - { id: 1, class: vecr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -115,8 +115,8 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:       registers:
-# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '' }
-# CHECK-NEXT:    - { id: 1, class: gpr, preferred-register: '' }
+# CHECK-NEXT:    - { id: 0, class: vecr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:    - { id: 1, class: gpr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }

--- a/llvm/test/CodeGen/X86/GlobalISel/regbankselect-X32.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/regbankselect-X32.mir
@@ -14,11 +14,11 @@ alignment:       16
 legalized:       true
 regBankSelected: false
 # CHECK:      registers:
-# CHECK-NEXT:   - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 1, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 3, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 4, class: gpr, preferred-register: '' }
+# CHECK-NEXT:   - { id: 0, class: gpr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 1, class: gpr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 2, class: gpr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 3, class: gpr, preferred-register: '', flags: [   ] }
+# CHECK-NEXT:   - { id: 4, class: gpr, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-GV-32.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-GV-32.mir
@@ -25,12 +25,12 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # X32:                 registers:
-# X32-NEXT:              - { id: 0, class: gr32, preferred-register: '' }
-# X32-NEXT:              - { id: 1, class: gr32, preferred-register: '' }
+# X32-NEXT:              - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# X32-NEXT:              - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
 #
 # X32ABI:              registers:
-# X32ABI-NEXT:           - { id: 0, class: low32_addr_access, preferred-register: '' }
-# X32ABI-NEXT:           - { id: 1, class: gr32, preferred-register: '' }
+# X32ABI-NEXT:           - { id: 0, class: low32_addr_access, preferred-register: '', flags: [   ] }
+# X32ABI-NEXT:           - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }
@@ -60,8 +60,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # X32ALL:              registers:
-# X32ALL-NEXT:           - { id: 0, class: gr32, preferred-register: '' }
-# X32ALL-NEXT:           - { id: 1, class: gr32, preferred-register: '' }
+# X32ALL-NEXT:           - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# X32ALL-NEXT:           - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-GV-64.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-GV-64.mir
@@ -25,8 +25,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # X64ALL:              registers:
-# X64ALL-NEXT:           - { id: 0, class: gr64, preferred-register: '' }
-# X64ALL-NEXT:           - { id: 1, class: gr64, preferred-register: '' }
+# X64ALL-NEXT:           - { id: 0, class: gr64, preferred-register: '', flags: [   ] }
+# X64ALL-NEXT:           - { id: 1, class: gr64, preferred-register: '', flags: [   ] }
 #
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
@@ -58,8 +58,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # X64ALL:              registers:
-# X64ALL-NEXT:           - { id: 0, class: gr32, preferred-register: '' }
-# X64ALL-NEXT:           - { id: 1, class: gr64, preferred-register: '' }
+# X64ALL-NEXT:           - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# X64ALL-NEXT:           - { id: 1, class: gr64, preferred-register: '', flags: [   ] }
 #
 registers:
   - { id: 0, class: gpr, preferred-register: '' }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-add-v128.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-add-v128.mir
@@ -32,19 +32,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # NOVL:            registers:
-# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '' }
+# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr128, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr128, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr128, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr128, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -74,19 +74,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # NOVL:            registers:
-# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '' }
+# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr128, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr128, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr128, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr128, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -116,19 +116,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # NOVL:            registers:
-# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '' }
+# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr128x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr128x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr128x, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr128x, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -158,19 +158,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # NOVL:            registers:
-# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '' }
-# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '' }
+# NOVL-NEXT:         - { id: 0, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
+# NOVL-NEXT:         - { id: 2, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr128x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr128x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr128x, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr128x, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-add-v256.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-add-v256.mir
@@ -30,19 +30,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # AVX2:            registers:
-# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '' }
+# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr256, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr256, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr256, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr256, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr256, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '', flags: [    ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '', flags: [    ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '', flags: [    ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -70,19 +70,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # AVX2:            registers:
-# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '' }
+# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr256, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr256, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr256, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr256, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr256, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -110,19 +110,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # AVX2:            registers:
-# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '' }
+# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr256x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr256x, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr256x, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -150,19 +150,19 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # AVX2:            registers:
-# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '' }
-# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '' }
+# AVX2-NEXT:         - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 1, class: vr256, preferred-register: '', flags: [   ] }
+# AVX2-NEXT:         - { id: 2, class: vr256, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:        registers:
-# AVX512VL-NEXT:     - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 1, class: vr256x, preferred-register: '' }
-# AVX512VL-NEXT:     - { id: 2, class: vr256x, preferred-register: '' }
+# AVX512VL-NEXT:     - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:     - { id: 2, class: vr256x, preferred-register: '', flags: [   ] }
 #
 # AVX512BWVL:      registers:
-# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '' }
-# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '' }
+# AVX512BWVL-NEXT:   - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512BWVL-NEXT:   - { id: 2, class: vr256x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-copy.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-copy.mir
@@ -35,8 +35,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: gr8, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: gr32, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: gr8, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }
@@ -61,8 +61,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: gr8, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: gr32, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: gr8, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }
@@ -87,10 +87,10 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: gr16[[ABCD:(_abcd)?]], preferred-register: '' }
-# X32-NEXT:   - { id: 1, class: gr8_abcd_l, preferred-register: '' }
-# X64-NEXT:   - { id: 1, class: gr8, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: gr32, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: gr16[[ABCD:(_abcd)?]], preferred-register: '', flags: [   ] }
+# X32-NEXT:   - { id: 1, class: gr8_abcd_l, preferred-register: '', flags: [   ] }
+# X64-NEXT:   - { id: 1, class: gr8, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }
@@ -120,9 +120,9 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: gr32, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: gr16, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: gr32, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: gr16, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }
@@ -150,10 +150,10 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: gr32[[ABCD:(_abcd)?]], preferred-register: '' }
-# X32-NEXT:   - { id: 1, class: gr8_abcd_l, preferred-register: '' }
-# X64-NEXT:   - { id: 1, class: gr8, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: gr32, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: gr32[[ABCD:(_abcd)?]], preferred-register: '', flags: [   ] }
+# X32-NEXT:   - { id: 1, class: gr8_abcd_l, preferred-register: '', flags: [   ] }
+# X64-NEXT:   - { id: 1, class: gr8, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: gr32, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }
@@ -183,10 +183,10 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: gr32, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: gr16, preferred-register: '' }
-# ALL-NEXT:   - { id: 2, class: low32_addr_access_rbp, preferred-register: '' }
-# ALL-NEXT:   - { id: 3, class: low32_addr_access_rbp, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: gr32, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: gr16, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 2, class: low32_addr_access_rbp, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 3, class: low32_addr_access_rbp, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr, preferred-register: '' }
   - { id: 1, class: gpr, preferred-register: '' }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-extract-vec256.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-extract-vec256.mir
@@ -18,12 +18,12 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # AVX:           registers:
-# AVX-NEXT:        - { id: 0, class: vr256, preferred-register: '' }
-# AVX-NEXT:        - { id: 1, class: vr128, preferred-register: '' }
+# AVX-NEXT:        - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX-NEXT:        - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:      registers:
-# AVX512VL-NEXT:   - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512VL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
+# AVX512VL-NEXT:   - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -50,12 +50,12 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # AVX:           registers:
-# AVX-NEXT:        - { id: 0, class: vr256, preferred-register: '' }
-# AVX-NEXT:        - { id: 1, class: vr128, preferred-register: '' }
+# AVX-NEXT:        - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# AVX-NEXT:        - { id: 1, class: vr128, preferred-register: '', flags: [   ] }
 #
 # AVX512VL:      registers:
-# AVX512VL-NEXT:   - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512VL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
+# AVX512VL-NEXT:   - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512VL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-extract-vec512.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-extract-vec512.mir
@@ -27,8 +27,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -53,8 +53,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: vr128x, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: vr128x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -79,8 +79,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: vr256x, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
@@ -105,8 +105,8 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '' }
-# ALL-NEXT:   - { id: 1, class: vr256x, preferred-register: '' }
+# ALL-NEXT:   - { id: 0, class: vr512, preferred-register: '', flags: [   ] }
+# ALL-NEXT:   - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-inc.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-inc.mir
@@ -13,10 +13,10 @@ name:            test_add_i8
 legalized:       true
 regBankSelected: true
 # ALL:      registers:
-# ALL-NEXT:  - { id: 0, class: gr8, preferred-register: '' }
-# INC-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# ADD-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# ALL-NEXT:  - { id: 2, class: gr8, preferred-register: '' }
+# ALL-NEXT:  - { id: 0, class: gr8, preferred-register: '', flags: [   ] }
+# INC-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [   ] }
+# ADD-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [   ] }
+# ALL-NEXT:  - { id: 2, class: gr8, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr }
   - { id: 1, class: gpr }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-memop-v256.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-memop-v256.mir
@@ -33,12 +33,12 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # NO_AVX512F:       registers:
-# NO_AVX512F-NEXT:    - { id: 0, class: gr64, preferred-register: '' }
-# NO_AVX512F-NEXT:    - { id: 1, class: vr256, preferred-register: '' }
+# NO_AVX512F-NEXT:    - { id: 0, class: gr64, preferred-register: '', flags: [   ] }
+# NO_AVX512F-NEXT:    - { id: 1, class: vr256, preferred-register: '', flags: [   ] }
 #
 # AVX512ALL:        registers:
-# AVX512ALL-NEXT:     - { id: 0, class: gr64, preferred-register: '' }
-# AVX512ALL-NEXT:     - { id: 1, class: vr256x, preferred-register: '' }
+# AVX512ALL-NEXT:     - { id: 0, class: gr64, preferred-register: '', flags: [   ] }
+# AVX512ALL-NEXT:     - { id: 1, class: vr256x, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: gpr }
   - { id: 1, class: vecr }
@@ -106,12 +106,12 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # NO_AVX512F:       registers:
-# NO_AVX512F-NEXT:    - { id: 0, class: vr256, preferred-register: '' }
-# NO_AVX512F-NEXT:    - { id: 1, class: gr64, preferred-register: '' }
+# NO_AVX512F-NEXT:    - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# NO_AVX512F-NEXT:    - { id: 1, class: gr64, preferred-register: '', flags: [   ] }
 #
 # AVX512ALL:        registers:
-# AVX512ALL-NEXT:     - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512ALL-NEXT:     - { id: 1, class: gr64, preferred-register: '' }
+# AVX512ALL-NEXT:     - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512ALL-NEXT:     - { id: 1, class: gr64, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: gpr }
@@ -146,12 +146,12 @@ alignment:       16
 legalized:       true
 regBankSelected: true
 # NO_AVX512F:       registers:
-# NO_AVX512F-NEXT:    - { id: 0, class: vr256, preferred-register: '' }
-# NO_AVX512F-NEXT:    - { id: 1, class: gr64, preferred-register: '' }
+# NO_AVX512F-NEXT:    - { id: 0, class: vr256, preferred-register: '', flags: [   ] }
+# NO_AVX512F-NEXT:    - { id: 1, class: gr64, preferred-register: '', flags: [   ] }
 #
 # AVX512ALL:        registers:
-# AVX512ALL-NEXT:     - { id: 0, class: vr256x, preferred-register: '' }
-# AVX512ALL-NEXT:     - { id: 1, class: gr64, preferred-register: '' }
+# AVX512ALL-NEXT:     - { id: 0, class: vr256x, preferred-register: '', flags: [   ] }
+# AVX512ALL-NEXT:     - { id: 1, class: gr64, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: vecr }
   - { id: 1, class: gpr }

--- a/llvm/test/CodeGen/X86/GlobalISel/x86-legalize-GV.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/x86-legalize-GV.mir
@@ -15,7 +15,7 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # CHECK:      registers:
-# CHECK-NEXT:   - { id: 0, class: _, preferred-register: '' }
+# CHECK-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _, preferred-register: '' }
 # CHECK:          %0:_(p0) = G_GLOBAL_VALUE @g_int

--- a/llvm/test/CodeGen/X86/GlobalISel/x86_64-legalize-GV.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/x86_64-legalize-GV.mir
@@ -15,7 +15,7 @@ alignment:       16
 legalized:       false
 regBankSelected: false
 # CHECK:      registers:
-# CHECK-NEXT:   - { id: 0, class: _, preferred-register: '' }
+# CHECK-NEXT:   - { id: 0, class: _, preferred-register: '', flags: [   ] }
 registers:
   - { id: 0, class: _, preferred-register: '' }
 # CHECK:          %0:_(p0) = G_GLOBAL_VALUE @g_int

--- a/llvm/test/tools/llvm-reduce/mir/preserve-reg-hints.mir
+++ b/llvm/test/tools/llvm-reduce/mir/preserve-reg-hints.mir
@@ -7,11 +7,11 @@
 # Make sure that register hints are preserved in the cloned function.
 
 # RESULT: registers:
-# RESULT-NEXT: - { id: 0, class: vgpr_32, preferred-register: '$vgpr0' }
-# RESULT-NEXT: - { id: 1, class: vgpr_32, preferred-register: '' }
-# RESULT-NEXT: - { id: 2, class: vgpr_32, preferred-register: '%1' }
-# RESULT-NEXT: - { id: 3, class: vgpr_32, preferred-register: '%4' }
-# RESULT-NEXT: - { id: 4, class: vgpr_32, preferred-register: '%3' }
+# RESULT-NEXT: - { id: 0, class: vgpr_32, preferred-register: '$vgpr0', flags: [   ] }
+# RESULT-NEXT: - { id: 1, class: vgpr_32, preferred-register: '', flags: [   ] }
+# RESULT-NEXT: - { id: 2, class: vgpr_32, preferred-register: '%1', flags: [   ] }
+# RESULT-NEXT: - { id: 3, class: vgpr_32, preferred-register: '%4', flags: [   ] }
+# RESULT-NEXT: - { id: 4, class: vgpr_32, preferred-register: '%3', flags: [   ] }
 ---
 name: register_hints
 tracksRegLiveness: true


### PR DESCRIPTION
[MIR] Serialize virtual register flags

This introduces target-specific vreg flag serialization. Flags are represented as `uint8_t` and the `TargetRegisterInfo` override provides methods `getVRegFlagValue` to deserialize and `getVRegFlagsOfReg` to serialize.