### PR TITLE
[clang][Sema] Bad register variable type error should point to the type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -395,6 +395,8 @@ Bug Fixes in This Version
 - Fixed a crash when trying to transform a dependent address space type. Fixes #GH101685.
 - Fixed a crash when diagnosing format strings and encountering an empty
   delimited escape sequence (e.g., ``"\o{}"``). #GH102218
+- The warning emitted for an unsupported register variable type now points to
+  the type instead of the ``register`` keyword (#GH109776).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -396,7 +396,7 @@ Bug Fixes in This Version
 - Fixed a crash when diagnosing format strings and encountering an empty
   delimited escape sequence (e.g., ``"\o{}"``). #GH102218
 - The warning emitted for an unsupported register variable type now points to
-  the type instead of the ``register`` keyword (#GH109776).
+  the unsupported type instead of the ``register`` keyword (#GH109776).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7957,8 +7957,8 @@ NamedDecl *Sema::ActOnVariableDeclarator(
       }
 
       if (!R->isIntegralType(Context) && !R->isPointerType()) {
-        Diag(TInfo->getTypeLoc().getBeginLoc(),
-             diag::err_asm_bad_register_type);
+        Diag(TInfo->getTypeLoc().getBeginLoc(), diag::err_asm_bad_register_type)
+            << TInfo->getTypeLoc().getSourceRange();
         NewVD->setInvalidDecl(true);
       }
     }

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7957,7 +7957,8 @@ NamedDecl *Sema::ActOnVariableDeclarator(
       }
 
       if (!R->isIntegralType(Context) && !R->isPointerType()) {
-        Diag(D.getBeginLoc(), diag::err_asm_bad_register_type);
+        Diag(TInfo->getTypeLoc().getBeginLoc(),
+             diag::err_asm_bad_register_type);
         NewVD->setInvalidDecl(true);
       }
     }

--- a/clang/test/Sema/caret-diags-register-variable.cpp
+++ b/clang/test/Sema/caret-diags-register-variable.cpp
@@ -1,0 +1,20 @@
+// RUN: not %clang_cc1 -triple i386-pc-linux-gnu -std=c++11 -fsyntax-only -fno-diagnostics-show-line-numbers -fcaret-diagnostics-max-lines=5 %s 2>&1 | FileCheck %s -strict-whitespace
+
+struct foo {
+  int a;
+};
+
+//CHECK: {{.*}}: error: bad type for named register variable
+//CHECK-NEXT: {{^}}register struct foo bar asm("esp");
+//CHECK-NEXT: {{^}}         ^{{$}}
+register struct foo bar asm("esp"); // expected-error {{bad type for named register variable}}
+
+//CHECK: {{.*}}: error: register 'edi' unsuitable for global register variables on this target
+//CHECK-NEXT: {{^}}register int r0 asm ("edi");
+//CHECK-NEXT: {{^}}                     ^{{$}}
+register int r0 asm ("edi");
+
+//CHECK: {{.*}}: error: size of register 'esp' does not match variable size
+//CHECK-NEXT: {{^}}register long long r1 asm ("esp");
+//CHECK-NEXT: {{^}}                           ^{{$}}
+register long long r1 asm ("esp");

--- a/clang/test/Sema/caret-diags-register-variable.cpp
+++ b/clang/test/Sema/caret-diags-register-variable.cpp
@@ -6,7 +6,7 @@ struct foo {
 
 //CHECK: {{.*}}: error: bad type for named register variable
 //CHECK-NEXT: {{^}}register struct foo bar asm("esp");
-//CHECK-NEXT: {{^}}         ^{{$}}
+//CHECK-NEXT: {{^}}         ^~~~~~~~~~{{$}}
 register struct foo bar asm("esp");
 
 //CHECK: {{.*}}: error: register 'edi' unsuitable for global register variables on this target

--- a/clang/test/Sema/caret-diags-register-variable.cpp
+++ b/clang/test/Sema/caret-diags-register-variable.cpp
@@ -7,7 +7,7 @@ struct foo {
 //CHECK: {{.*}}: error: bad type for named register variable
 //CHECK-NEXT: {{^}}register struct foo bar asm("esp");
 //CHECK-NEXT: {{^}}         ^{{$}}
-register struct foo bar asm("esp"); // expected-error {{bad type for named register variable}}
+register struct foo bar asm("esp");
 
 //CHECK: {{.*}}: error: register 'edi' unsuitable for global register variables on this target
 //CHECK-NEXT: {{^}}register int r0 asm ("edi");


### PR DESCRIPTION
...not the register keyword. Fixes #109776.

Until now the error was only tested in clang/test/Sema/asm.c, where you can't check for the "^" character. I've added a new caret test file as I see has been done for other error types.