### PR TITLE
[clang][ItaniumMangle] Mangle friend function templates with a constr…

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -426,6 +426,7 @@ Bug Fixes to C++ Support
 - Fixed an assertion failure in debug mode, and potential crashes in release mode, when
   diagnosing a failed cast caused indirectly by a failed implicit conversion to the type of the constructor parameter.
 - Fixed an assertion failure by adjusting integral to boolean vector conversions (#GH108326)
+- Fixed mangling of friend function templates with a constraint that depends on a template parameter from an enclosing template. (#GH110247)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -426,7 +426,7 @@ Bug Fixes to C++ Support
 - Fixed an assertion failure in debug mode, and potential crashes in release mode, when
   diagnosing a failed cast caused indirectly by a failed implicit conversion to the type of the constructor parameter.
 - Fixed an assertion failure by adjusting integral to boolean vector conversions (#GH108326)
-- Fixed mangling of friend function templates with a constraint that depends on a template parameter from an enclosing template. (#GH110247)
+- Mangle friend function templates with a constraint that depends on a template parameter from an enclosing template as members of the enclosing class. (#GH110247)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -693,21 +693,12 @@ ItaniumMangleContextImpl::getEffectiveDeclContext(const Decl *D) {
     if (VD->isExternC())
       return getASTContext().getTranslationUnitDecl();
 
-  if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
+  if (const auto *FD = D->getAsFunction()) {
     if (FD->isExternC())
       return getASTContext().getTranslationUnitDecl();
     // Member-like constrained friends are mangled as if they were members of
     // the enclosing class.
     if (FD->isMemberLikeConstrainedFriend() &&
-        getASTContext().getLangOpts().getClangABICompat() >
-            LangOptions::ClangABI::Ver17)
-      return D->getLexicalDeclContext()->getRedeclContext();
-  }
-
-  if (const auto *FTD = dyn_cast<FunctionTemplateDecl>(D)) {
-    // Member-like constrained friends are mangled as if they were members of
-    // the enclosing class.
-    if (FTD->getTemplatedDecl()->isMemberLikeConstrainedFriend() &&
         getASTContext().getLangOpts().getClangABICompat() >
             LangOptions::ClangABI::Ver17)
       return D->getLexicalDeclContext()->getRedeclContext();

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -2276,7 +2276,7 @@ void CXXNameMangler::mangleTemplatePrefix(GlobalDecl GD,
       if (FD->getTemplatedDecl()->isMemberLikeConstrainedFriend() &&
           getASTContext().getLangOpts().getClangABICompat() >
               LangOptions::ClangABI::Ver17)
-      DC = GD.getDecl()->getLexicalDeclContext()->getRedeclContext();
+        DC = GD.getDecl()->getLexicalDeclContext()->getRedeclContext();
     }
     manglePrefix(DC, NoFunction);
     if (isa<BuiltinTemplateDecl>(ND) || isa<ConceptDecl>(ND))

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -2270,6 +2270,14 @@ void CXXNameMangler::mangleTemplatePrefix(GlobalDecl GD,
     mangleTemplateParameter(TTP->getDepth(), TTP->getIndex());
   } else {
     const DeclContext *DC = Context.getEffectiveDeclContext(ND);
+    if (const auto *FD = dyn_cast<FunctionTemplateDecl>(GD.getDecl())) {
+      // Member-like constrained friends are mangled as if they were members of
+      // the enclosing class.
+      if (FD->getTemplatedDecl()->isMemberLikeConstrainedFriend() &&
+          getASTContext().getLangOpts().getClangABICompat() >
+              LangOptions::ClangABI::Ver17)
+      DC = GD.getDecl()->getLexicalDeclContext()->getRedeclContext();
+    }
     manglePrefix(DC, NoFunction);
     if (isa<BuiltinTemplateDecl>(ND) || isa<ConceptDecl>(ND))
       mangleUnqualifiedName(GD, DC, nullptr);

--- a/clang/test/CodeGenCXX/mangle-concept.cpp
+++ b/clang/test/CodeGenCXX/mangle-concept.cpp
@@ -58,19 +58,19 @@ namespace test2 {
     // CHECK: call {{.*}}@_ZN5test21AIiEF1fEzQ4TrueIT_E(
     // CLANG17: call {{.*}}@_ZN5test21fEz(
     f(ai);
-    // CHECK: call {{.*}}@_ZN5test2F1gIvEEvzQaa4TrueIT_E4TrueITL0__E(
+    // CHECK: call {{.*}}@_ZN5test21AIiEF1gIvEEvzQaa4TrueIT_E4TrueITL0__E(
     // CLANG17: call {{.*}}@_ZN5test21gIvEEvz(
     g(ai);
     // CHECK: call {{.*}}@_ZN5test21hIvEEvzQ4TrueITL0__E(
     // CLANG17: call {{.*}}@_ZN5test21hIvEEvz(
     h(ai);
-    // CHECK: call {{.*}}@_ZN5test2F1iIvQaa4TrueIT_E4TrueITL0__EEEvz(
+    // CHECK: call {{.*}}@_ZN5test21AIiEF1iIvQaa4TrueIT_E4TrueITL0__EEEvz(
     // CLANG17: call {{.*}}@_ZN5test21iIvEEvz(
     i(ai);
     // CHECK: call {{.*}}@_ZN5test21jIvQ4TrueITL0__EEEvz(
     // CLANG17: call {{.*}}@_ZN5test21jIvEEvz(
     j(ai);
-    // CHECK: call {{.*}}@_ZN5test2F1kITk4TruevQ4TrueIT_EEEvz(
+    // CHECK: call {{.*}}@_ZN5test21AIiEF1kITk4TruevQ4TrueIT_EEEvz(
     // CLANG17: call {{.*}}@_ZN5test21kIvEEvz(
     k(ai);
     // CHECK: call {{.*}}@_ZN5test21lITk4TruevEEvz(

--- a/clang/test/CodeGenCXX/mangle-concept.cpp
+++ b/clang/test/CodeGenCXX/mangle-concept.cpp
@@ -52,6 +52,7 @@ namespace test2 {
   };
 
   A<int> ai;
+  A<bool> aj;
 
   // CHECK-LABEL: define {{.*}}@{{.*}}test2{{.*}}use
   void use() {
@@ -76,6 +77,28 @@ namespace test2 {
     // CHECK: call {{.*}}@_ZN5test21lITk4TruevEEvz(
     // CLANG17: call {{.*}}@_ZN5test21lIvEEvz(
     l(ai);
+
+    // CHECK: call {{.*}}@_ZN5test21AIbEF1fEzQ4TrueIT_E(
+    // CLANG17: call {{.*}}@_ZN5test21fEz(
+    f(aj);
+    // CHECK: call {{.*}}@_ZN5test21AIbEF1gIvEEvzQaa4TrueIT_E4TrueITL0__E(
+    // CLANG17: call {{.*}}@_ZN5test21gIvEEvz(
+    g(aj);
+    // CHECK: call {{.*}}@_ZN5test21hIvEEvzQ4TrueITL0__E(
+    // CLANG17: call {{.*}}@_ZN5test21hIvEEvz(
+    h(aj);
+    // CHECK: call {{.*}}@_ZN5test21AIbEF1iIvQaa4TrueIT_E4TrueITL0__EEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21iIvEEvz(
+    i(aj);
+    // CHECK: call {{.*}}@_ZN5test21jIvQ4TrueITL0__EEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21jIvEEvz(
+    j(aj);
+    // CHECK: call {{.*}}@_ZN5test21AIbEF1kITk4TruevQ4TrueIT_EEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21kIvEEvz(
+    k(aj);
+    // CHECK: call {{.*}}@_ZN5test21lITk4TruevEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21lIvEEvz(
+    l(aj);
   }
 }
 


### PR DESCRIPTION
…aint that depends on a template parameter from an enclosing template as members of the enclosing class.

Such function templates should be considered member-like constrained friends per [temp.friend]p9 and https://github.com/itanium-cxx-abi/cxx-abi/issues/24#issuecomment-934977198).