### PR TITLE
InstCombine/Demanded: simplify srem case (NFC)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -861,30 +861,15 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
     // X % -1 demands all the bits because we don't want to introduce
     // INT_MIN % -1 (== undef) by accident.
     if (match(I->getOperand(1), m_APInt(Rem)) && !Rem->isAllOnes()) {
-      APInt RA = Rem->abs();
-      if (RA.isPowerOf2()) {
-        if (DemandedMask.ult(RA))    // srem won't affect demanded bits
+      if (Rem->isPowerOf2()) {
+        if (DemandedMask.ult(*Rem)) // srem won't affect demanded bits
           return I->getOperand(0);
 
-        APInt LowBits = RA - 1;
+        APInt LowBits = *Rem - 1;
         APInt Mask2 = LowBits | APInt::getSignMask(BitWidth);
         if (SimplifyDemandedBits(I, 0, Mask2, LHSKnown, Depth + 1, Q))
           return I;
-
-        // The low bits of LHS are unchanged by the srem.
-        Known.Zero = LHSKnown.Zero & LowBits;
-        Known.One = LHSKnown.One & LowBits;
-
-        // If LHS is non-negative or has all low bits zero, then the upper bits
-        // are all zero.
-        if (LHSKnown.isNonNegative() || LowBits.isSubsetOf(LHSKnown.Zero))
-          Known.Zero |= ~LowBits;
-
-        // If LHS is negative and not all low bits are zero, then the upper bits
-        // are all one.
-        if (LHSKnown.isNegative() && LowBits.intersects(LHSKnown.One))
-          Known.One |= ~LowBits;
-
+        Known = KnownBits::srem(LHSKnown, KnownBits::makeConstant(*Rem));
         break;
       }
     }


### PR DESCRIPTION
The srem case of SimplifyDemandedUseBits partially duplicates KnownBits::srem. It is guarded by a statement that takes the absolute value of the RHS and checks whether it is a power of 2, but the abs() call here useless, since an srem with a negative RHS is flipped into one with a positive RHS, adjusting LHS appropriately. Stripping the abs call allows us to call KnownBits::srem instead of partially duplicating it.