### PR TITLE
[release/19.x][libc++] Fix AppleClang version number when checking for __builtin_verbose_trap support

### DIFF
--- a/libcxx/vendor/llvm/default_assertion_handler.in
+++ b/libcxx/vendor/llvm/default_assertion_handler.in
@@ -26,7 +26,8 @@
 #  if __has_builtin(__builtin_verbose_trap)
 // AppleClang shipped a slightly different version of __builtin_verbose_trap from the upstream
 // version before upstream Clang actually got the builtin.
-#    if defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER < 17000
+// TODO: Remove once AppleClang supports the two-arguments version of the builtin.
+#    if defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER < 1700
 #      define _LIBCPP_ASSERTION_HANDLER(message) __builtin_verbose_trap(message)
 #    else
 #      define _LIBCPP_ASSERTION_HANDLER(message) __builtin_verbose_trap("libc++", message)


### PR DESCRIPTION
We should have been checking against 1700, not 17000, which was a typo.

(cherry picked from commit 1eba87904b0cbaaee82cfdb835528b85d99320ef)