### PR TITLE
[compiler-rt][profile] Duplicate filename in `parseAndSetFilename` if exists

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -900,14 +900,21 @@ static void parseAndSetFilename(const char *FilenamePat,
   ProfileNameSpecifier OldPNS = lprofCurFilename.PNS;
 
   /* The old profile name specifier takes precedence over the old one. */
-  if (PNS < OldPNS)
+  if (PNS < OldPNS) {
+    if (OldFilenamePat) {
+      free(OldFilenamePat);
+      OldFilenamePat = NULL;
+    }
     return;
+  }
 
   if (!FilenamePat)
     FilenamePat = DefaultProfileName;
 
   if (OldFilenamePat && !strcmp(OldFilenamePat, FilenamePat)) {
     lprofCurFilename.PNS = PNS;
+    free(OldFilenamePat);
+    OldFilenamePat = NULL;
     return;
   }
 

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -894,7 +894,9 @@ static void parseAndSetFilename(const char *FilenamePat,
                                 ProfileNameSpecifier PNS,
                                 unsigned CopyFilenamePat) {
 
-  const char *OldFilenamePat = lprofCurFilename.FilenamePat;
+  char *OldFilenamePat = lprofCurFilename.FilenamePat
+                             ? strdup(lprofCurFilename.FilenamePat)
+                             : NULL;
   ProfileNameSpecifier OldPNS = lprofCurFilename.PNS;
 
   /* The old profile name specifier takes precedence over the old one. */
@@ -923,6 +925,9 @@ static void parseAndSetFilename(const char *FilenamePat,
       PROF_NOTE("Override old profile path \"%s\" via %s to \"%s\" via %s.\n",
                 OldFilenamePat, getPNSStr(OldPNS), lprofCurFilename.FilenamePat,
                 getPNSStr(PNS));
+
+    free(OldFilenamePat);
+    OldFilenamePat = NULL;
   }
 
   truncateCurrentFile();


### PR DESCRIPTION
Duplicate `lprofCurFilename.FilenamePat` if the filename exists in `parseAndSetFilename`, as the original path name buffer may have been freed by the time it is used.

Fixes: https://github.com/llvm/llvm-project/issues/102109.