### PR TITLE
[SPIR-V][Codegen] Represent the property of the target to declare and use typed pointers and update MachineVerifier to use it

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -455,6 +455,12 @@ public:
     return true;
   }
 
+  /// Return true if the target can handle the declaration and use of pointers
+  /// that specify the type of data they point to, meaning that interpretation
+  /// of the data type is not left to instructions that utilize the pointer, but
+  /// encoded by the pointer declaration.
+  virtual bool hasTypedPointer() const { return false; }
+
   /// Return true if the @llvm.experimental.vector.partial.reduce.* intrinsic
   /// should be expanded using generic code in SelectionDAGBuilder.
   virtual bool

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1294,7 +1294,9 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       report("bitcast sizes must match", MI);
 
     if (SrcTy == DstTy)
-      report("bitcast must change the type", MI);
+      if (!SrcTy.isPointer() ||
+          !MF->getSubtarget().getTargetLowering()->hasTypedPointer())
+        report("bitcast must change the type", MI);
 
     break;
   }

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -41,6 +41,9 @@ public:
   // prevent creation of jump tables
   bool areJTsAllowed(const Function *) const override { return false; }
 
+  // allow for typed pointers
+  bool hasTypedPointer() const override { return true; }
+
   // This is to prevent sexts of non-i64 vector indices which are generated
   // within general IRTranslator hence type generation for it is omitted.
   MVT getVectorIdxTy(const DataLayout &DL) const override {

--- a/llvm/test/MachineVerifier/SPIRV/test_typedptr_bitcast.mir
+++ b/llvm/test/MachineVerifier/SPIRV/test_typedptr_bitcast.mir
@@ -1,0 +1,15 @@
+#RUN: llc -mtriple=spirv64-unknown-unknown -o - -global-isel -run-pass=none -verify-machineinstrs %s 2>&1 | FileCheck %s
+
+---
+name:            test_typedptr_bitcast
+legalized:       true
+regBankSelected: false
+selected:        false
+tracksRegLiveness: true
+liveins:
+body:             |
+  bb.0:
+    ; CHECK-NOT: Bad machine code: bitcast must change the type
+    %0:_(p0) = G_IMPLICIT_DEF
+    %1:_(p0) = G_BITCAST %0
+...


### PR DESCRIPTION
When MachineVerifier validates G_BITCAST we see a check of a kind: `if Source Type is equal to Destination Type then report error "bitcast must change the type"`. This doesn't take into account the notion of a typed pointer that is important for SPIR-V where a user may and should use bitcast between pointers with different pointee types (see, https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpBitcast). It's important for correct lowering in SPIR-V, because interpretation of the data type is not left to instructions that utilize the pointer, but encoded by the pointer declaration, and the SPIRV target can and must handle the declaration and use of pointers that specify the type of data they point to.

It's not feasible to improve validation of G_BITCAST using just information provided by low level types of source and destination. This PR proposes a solution by introducing a new class member `hasTypedPointer()` to represent the required target lowering property. This function is used then by `MachineVerifier` to allow for pointer type source and destination operands, and is overridden by SPIRV implementation of target lowering rules.
