### PR TITLE
[libfuzzer] use timer_create() instead of setitimer() for linux

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
@@ -104,11 +104,16 @@ bool ExecuteCommand(const Command &Cmd, std::string *CmdOutput) {
 }
 
 void SetTimer(int Seconds) {
-  struct itimerval T {
+  timer_t timerid;
+  struct itimerspec T {
     {Seconds, 0}, { Seconds, 0 }
   };
-  if (setitimer(ITIMER_REAL, &T, nullptr)) {
-    Printf("libFuzzer: setitimer failed with %d\n", errno);
+  if (timer_create(CLOCK_REALTIME, NULL, &timerid) == -1) {
+    Printf("libFuzzer: timer_create failed with %d\n", errno);
+    exit(1);
+  }
+  if (timer_settime(timerid, 0, &T, NULL) == -1) {
+    Printf("libFuzzer: timer_settime failed with %d\n", errno);
     exit(1);
   }
   SetSigaction(SIGALRM, AlarmHandler);

--- a/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
@@ -116,7 +116,7 @@ void SetTimer(int Seconds) {
   if (timer_settime(timerid, 0, &T, NULL) == -1) {
     Printf("libFuzzer: timer_settime failed with %d\n", errno);
     exit(1);
-  }  
+  }
 }
 
 void SetSignalHandler(const FuzzingOptions& Options) {

--- a/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
@@ -109,11 +109,11 @@ void SetTimer(int Seconds) {
     {Seconds, 0}, { Seconds, 0 }
   };
   SetSigaction(SIGALRM, AlarmHandler);
-  if (timer_create(CLOCK_REALTIME, NULL, &timerid) == -1) {
+  if (timer_create(CLOCK_REALTIME, nullptr, &timerid) == -1) {
     Printf("libFuzzer: timer_create failed with %d\n", errno);
     exit(1);
   }
-  if (timer_settime(timerid, 0, &T, NULL) == -1) {
+  if (timer_settime(timerid, 0, &T, nullptr) == -1) {
     Printf("libFuzzer: timer_settime failed with %d\n", errno);
     exit(1);
   }

--- a/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
@@ -106,7 +106,7 @@ bool ExecuteCommand(const Command &Cmd, std::string *CmdOutput) {
 void SetTimer(int Seconds) {
   timer_t TimerId;
   struct itimerspec T {
-    { Seconds, 0 }, { Seconds, 0 }
+    {Seconds, 0}, { Seconds, 0 }
   };
   SetSigaction(SIGALRM, AlarmHandler);
   if (timer_create(CLOCK_REALTIME, nullptr, &TimerId) == -1) {

--- a/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
@@ -104,16 +104,16 @@ bool ExecuteCommand(const Command &Cmd, std::string *CmdOutput) {
 }
 
 void SetTimer(int Seconds) {
-  timer_t timerid;
+  timer_t TimerId;
   struct itimerspec T {
-    {Seconds, 0}, { Seconds, 0 }
+    { Seconds, 0 }, { Seconds, 0 }
   };
   SetSigaction(SIGALRM, AlarmHandler);
-  if (timer_create(CLOCK_REALTIME, nullptr, &timerid) == -1) {
+  if (timer_create(CLOCK_REALTIME, nullptr, &TimerId) == -1) {
     Printf("libFuzzer: timer_create failed with %d\n", errno);
     exit(1);
   }
-  if (timer_settime(timerid, 0, &T, nullptr) == -1) {
+  if (timer_settime(TimerId, 0, &T, nullptr) == -1) {
     Printf("libFuzzer: timer_settime failed with %d\n", errno);
     exit(1);
   }

--- a/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
@@ -108,6 +108,7 @@ void SetTimer(int Seconds) {
   struct itimerspec T {
     {Seconds, 0}, { Seconds, 0 }
   };
+  SetSigaction(SIGALRM, AlarmHandler);
   if (timer_create(CLOCK_REALTIME, NULL, &timerid) == -1) {
     Printf("libFuzzer: timer_create failed with %d\n", errno);
     exit(1);
@@ -115,8 +116,7 @@ void SetTimer(int Seconds) {
   if (timer_settime(timerid, 0, &T, NULL) == -1) {
     Printf("libFuzzer: timer_settime failed with %d\n", errno);
     exit(1);
-  }
-  SetSigaction(SIGALRM, AlarmHandler);
+  }  
 }
 
 void SetSignalHandler(const FuzzingOptions& Options) {


### PR DESCRIPTION
SetTimer() now uses setitimer() to sending SIGALRM every ` UnitTimeoutSec/2 + 1` s
Set UnitTimeoutSec with the `-timeout=` option

 "POSIX.1-2008 marks getitimer() and setitimer() obsolete" and also has some issues regarding accuracy of the timers under load . See https://linux.die.net/man/2/setitimer.
I propose using timer_create() and sigaction() ,See http://man7.org/linux/man-pages/man2/timer_create.2.html

# test result on my x86_64 linux
`make check-fuzzer`
![image](https://github.com/user-attachments/assets/19b4e073-16a5-4daa-95ed-2cf4830c042f)
