### PR TITLE
[HLSL][SPIRV] Fix calling convention for call in entry function.

### DIFF
--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -3164,6 +3164,7 @@ void MicrosoftCXXNameMangler::mangleCallingConvention(CallingConv CC,
   switch (CC) {
     default:
       break;
+    case CC_SpirFunction:
     case CC_Win64:
     case CC_X86_64SysV:
     case CC_C:

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -316,6 +316,11 @@ public:
     SizeType = TargetInfo::UnsignedInt;
     resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-"
                     "v96:128-v192:256-v256:256-v512:512-v1024:1024-G1");
+
+    if (Triple.getOS() == llvm::Triple::Vulkan) {
+      // For Vulkan we want to same mangling as DirectX.
+      TheCXXABI.set(TargetCXXABI::Microsoft);
+    }
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -318,7 +318,7 @@ public:
                     "v96:128-v192:256-v256:256-v512:512-v1024:1024-G1");
 
     if (Triple.getOS() == llvm::Triple::Vulkan) {
-      // For Vulkan we want to same mangling as DirectX.
+      // For Vulkan we want the same mangling as DirectX.
       TheCXXABI.set(TargetCXXABI::Microsoft);
     }
   }

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -415,6 +415,7 @@ void CGHLSLRuntime::emitEntryFunction(const FunctionDecl *FD,
   }
 
   CallInst *CI = B.CreateCall(FunctionCallee(Fn), Args);
+  CI->setCallingConv(Fn->getCallingConv());
   (void)CI;
   // FIXME: Handle codegen for return type semantics.
   // See: https://github.com/llvm/llvm-project/issues/57875

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -416,7 +416,6 @@ void CGHLSLRuntime::emitEntryFunction(const FunctionDecl *FD,
 
   CallInst *CI = B.CreateCall(FunctionCallee(Fn), Args);
   CI->setCallingConv(Fn->getCallingConv());
-  (void)CI;
   // FIXME: Handle codegen for return type semantics.
   // See: https://github.com/llvm/llvm-project/issues/57875
   B.CreateRetVoid();

--- a/clang/test/CodeGenHLSL/builtins/saturate.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/saturate.hlsl
@@ -19,77 +19,77 @@
 // NATIVE_HALF: call half @llvm.dx.saturate.f16(
 // NO_HALF: define noundef float @"?test_saturate_half
 // NO_HALF: call float @llvm.dx.saturate.f32(
-// SPIRV_HALF: define spir_func noundef half @_Z18test_saturate_halfDh(half
+// SPIRV_HALF: define spir_func noundef half @"?test_saturate_half
 // SPIRV_HALF: call half @llvm.spv.saturate.f16(half
-// SPIRV_NO_HALF: define spir_func noundef float @_Z18test_saturate_halfDh(float
+// SPIRV_NO_HALF: define spir_func noundef float @"?test_saturate_half
 // SPIRV_NO_HALF: call float @llvm.spv.saturate.f32(float
 half test_saturate_half(half p0) { return saturate(p0); }
 // NATIVE_HALF: define noundef <2 x half> @
 // NATIVE_HALF: call <2 x half> @llvm.dx.saturate.v2f16
 // NO_HALF: define noundef <2 x float> @"?test_saturate_half2
 // NO_HALF: call <2 x float> @llvm.dx.saturate.v2f32(
-// SPIRV_HALF: define spir_func noundef <2 x half> @_Z19test_saturate_half2Dv2_Dh(
+// SPIRV_HALF: define spir_func noundef <2 x half> @"?test_saturate_half2
 // SPIRV_HALF: call <2 x half> @llvm.spv.saturate.v2f16(<2 x half>
-// SPIRV_NO_HALF: define spir_func noundef <2 x float> @_Z19test_saturate_half2Dv2_Dh(<2 x float>
+// SPIRV_NO_HALF: define spir_func noundef <2 x float> @"?test_saturate_half2
 // SPIRV_NO_HALF: call <2 x float> @llvm.spv.saturate.v2f32(<2 x float>
 half2 test_saturate_half2(half2 p0) { return saturate(p0); }
 // NATIVE_HALF: define noundef <3 x half> @
 // NATIVE_HALF: call <3 x half> @llvm.dx.saturate.v3f16
 // NO_HALF: define noundef <3 x float> @"?test_saturate_half3
 // NO_HALF: call <3 x float> @llvm.dx.saturate.v3f32(
-// SPIRV_HALF: define spir_func noundef <3 x half> @_Z19test_saturate_half3Dv3_Dh(
+// SPIRV_HALF: define spir_func noundef <3 x half> @"?test_saturate_half3
 // SPIRV_HALF: call <3 x half> @llvm.spv.saturate.v3f16(<3 x half>
-// SPIRV_NO_HALF: define spir_func noundef <3 x float> @_Z19test_saturate_half3Dv3_Dh(<3 x float>
+// SPIRV_NO_HALF: define spir_func noundef <3 x float> @"?test_saturate_half3
 // SPIRV_NO_HALF: call <3 x float> @llvm.spv.saturate.v3f32(<3 x float>
 half3 test_saturate_half3(half3 p0) { return saturate(p0); }
 // NATIVE_HALF: define noundef <4 x half> @
 // NATIVE_HALF: call <4 x half> @llvm.dx.saturate.v4f16
 // NO_HALF: define noundef <4 x float> @"?test_saturate_half4
 // NO_HALF: call <4 x float> @llvm.dx.saturate.v4f32(
-// SPIRV_HALF: define spir_func noundef <4 x half> @_Z19test_saturate_half4Dv4_Dh(
+// SPIRV_HALF: define spir_func noundef <4 x half> @"?test_saturate_half4
 // SPIRV_HALF: call <4 x half> @llvm.spv.saturate.v4f16(<4 x half>
-// SPIRV_NO_HALF: define spir_func noundef <4 x float> @_Z19test_saturate_half4Dv4_Dh(<4 x float>
+// SPIRV_NO_HALF: define spir_func noundef <4 x float> @"?test_saturate_half4
 // SPIRV_NO_HALF: call <4 x float> @llvm.spv.saturate.v4f32(<4 x float>
 half4 test_saturate_half4(half4 p0) { return saturate(p0); }
 
 // CHECK: define noundef float @"?test_saturate_float
 // CHECK: call float @llvm.dx.saturate.f32(
-// SPIRV: define spir_func noundef float @_Z19test_saturate_floatf(float
+// SPIRV: define spir_func noundef float @"?test_saturate_float
 // SPIRV: call float @llvm.spv.saturate.f32(float
 float test_saturate_float(float p0) { return saturate(p0); }
 // CHECK: define noundef <2 x float> @"?test_saturate_float2
 // CHECK: call <2 x float> @llvm.dx.saturate.v2f32
-// SPIRV: define spir_func noundef <2 x float> @_Z20test_saturate_float2Dv2_f(<2 x float>
+// SPIRV: define spir_func noundef <2 x float> @"?test_saturate_float2
 // SPIRV: call <2 x float> @llvm.spv.saturate.v2f32(<2 x float>
 float2 test_saturate_float2(float2 p0) { return saturate(p0); }
 // CHECK: define noundef <3 x float> @"?test_saturate_float3
 // CHECK: call <3 x float> @llvm.dx.saturate.v3f32
-// SPIRV: define spir_func noundef <3 x float> @_Z20test_saturate_float3Dv3_f(<3 x float>
+// SPIRV: define spir_func noundef <3 x float> @"?test_saturate_float3
 // SPIRV: call <3 x float> @llvm.spv.saturate.v3f32(<3 x float>
 float3 test_saturate_float3(float3 p0) { return saturate(p0); }
 // CHECK: define noundef <4 x float> @"?test_saturate_float4
 // CHECK: call <4 x float> @llvm.dx.saturate.v4f32
-// SPIRV: define spir_func noundef <4 x float> @_Z20test_saturate_float4Dv4_f(<4 x float>
+// SPIRV: define spir_func noundef <4 x float> @"?test_saturate_float4
 // SPIRV: call <4 x float> @llvm.spv.saturate.v4f32(<4 x float>
 float4 test_saturate_float4(float4 p0) { return saturate(p0); }
 
 // CHECK: define noundef double @
 // CHECK: call double @llvm.dx.saturate.f64(
-// SPIRV: define spir_func noundef double @_Z20test_saturate_doubled(double
+// SPIRV: define spir_func noundef double @"?test_saturate_double
 // SPIRV: call double @llvm.spv.saturate.f64(double
 double test_saturate_double(double p0) { return saturate(p0); }
 // CHECK: define noundef <2 x double> @
 // CHECK: call <2 x double> @llvm.dx.saturate.v2f64
-// SPIRV: define spir_func noundef <2 x double> @_Z21test_saturate_double2Dv2_d(<2 x double>
+// SPIRV: define spir_func noundef <2 x double> @"?test_saturate_double2
 // SPIRV: call <2 x double> @llvm.spv.saturate.v2f64(<2 x double>
 double2 test_saturate_double2(double2 p0) { return saturate(p0); }
 // CHECK: define noundef <3 x double> @
 // CHECK: call <3 x double> @llvm.dx.saturate.v3f64
-// SPIRV: define spir_func noundef <3 x double> @_Z21test_saturate_double3Dv3_d(<3 x double>
+// SPIRV: define spir_func noundef <3 x double> @"?test_saturate_double3
 // SPIRV: call <3 x double> @llvm.spv.saturate.v3f64(<3 x double>
 double3 test_saturate_double3(double3 p0) { return saturate(p0); }
 // CHECK: define noundef <4 x double> @
 // CHECK: call <4 x double> @llvm.dx.saturate.v4f64
-// SPIRV: define spir_func noundef <4 x double> @_Z21test_saturate_double4Dv4_d(<4 x double>
+// SPIRV: define spir_func noundef <4 x double> @"?test_saturate_double4
 // SPIRV: call <4 x double> @llvm.spv.saturate.v4f64(<4 x double>
 double4 test_saturate_double4(double4 p0) { return saturate(p0); }

--- a/clang/test/CodeGenHLSL/builtins/wave_get_lane_index_do_while.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/wave_get_lane_index_do_while.hlsl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-pc-vulkan-library %s -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
-// CHECK: define spir_func void @main() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?main@@YAXXZ"() [[A0:#[0-9]+]] {
 void main() {
 // CHECK: entry:
 // CHECK:   %[[CT_ENTRY:[0-9]+]] = call token @llvm.experimental.convergence.entry()

--- a/clang/test/CodeGenHLSL/builtins/wave_get_lane_index_simple.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/wave_get_lane_index_simple.hlsl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-pc-vulkan-library %s -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
-// CHECK: define spir_func noundef i32 @_Z6test_1v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func noundef i32 @"?test_1@@YAIXZ"() [[A0:#[0-9]+]] {
 // CHECK: %[[CI:[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %[[CI]]) ]
 uint test_1() {

--- a/clang/test/CodeGenHLSL/builtins/wave_get_lane_index_subcall.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/wave_get_lane_index_subcall.hlsl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-pc-vulkan-library %s -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
-// CHECK: define spir_func noundef i32 @_Z6test_1v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func noundef i32 @"?test_1@@YAIXZ"() [[A0:#[0-9]+]] {
 // CHECK: %[[C1:[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %[[C1]]) ]
 uint test_1() {
@@ -10,9 +10,9 @@ uint test_1() {
 
 // CHECK-DAG: declare i32 @__hlsl_wave_get_lane_index() [[A1:#[0-9]+]]
 
-// CHECK: define spir_func noundef i32 @_Z6test_2v() [[A0]] {
+// CHECK: define spir_func noundef i32 @"?test_2@@YAIXZ"() [[A0]] {
 // CHECK: %[[C2:[0-9]+]] = call token @llvm.experimental.convergence.entry()
-// CHECK: call spir_func noundef i32 @_Z6test_1v() {{#[0-9]+}} [ "convergencectrl"(token %[[C2]]) ]
+// CHECK: call spir_func noundef i32 @"?test_1@@YAIXZ"() {{#[0-9]+}} [ "convergencectrl"(token %[[C2]]) ]
 uint test_2() {
   return test_1();
 }

--- a/clang/test/CodeGenHLSL/convergence/do.while.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/do.while.hlsl
@@ -8,27 +8,27 @@ void test1() {
   do {
   } while (cond());
 }
-// CHECK: define spir_func void @_Z5test1v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test1@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: do.body:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
 // CHECK: do.cond:
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test2() {
   do {
     foo();
   } while (cond());
 }
-// CHECK: define spir_func void @_Z5test2v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test2@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: do.body:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: do.cond:
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test3() {
   do {
@@ -36,15 +36,15 @@ void test3() {
       foo();
   } while (cond());
 }
-// CHECK: define spir_func void @_Z5test3v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test3@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: do.body:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
 // CHECK: if.then:
-// CHECK:                    call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: do.cond:
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test4() {
   do {
@@ -54,15 +54,15 @@ void test4() {
     }
   } while (cond());
 }
-// CHECK: define spir_func void @_Z5test4v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test4@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: do.body:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
 // CHECK: if.then:
-// CHECK:                    call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: do.cond:
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test5() {
   do {
@@ -74,7 +74,7 @@ void test5() {
     }
   } while (cond());
 }
-// CHECK: define spir_func void @_Z5test5v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test5@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: do.body:
@@ -82,9 +82,9 @@ void test5() {
 // CHECK: while.cond:
 // CHECK:   [[T2:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T1]]) ]
 // CHECK: if.then:
-// CHECK:                    call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T2]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T2]]) ]
 // CHECK: do.cond:
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 // CHECK-DAG: attributes [[A0]] = { {{.*}}convergent{{.*}} }
 // CHECK-DAG: attributes [[A3]] = { {{.*}}convergent{{.*}} }

--- a/clang/test/CodeGenHLSL/convergence/for.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/for.hlsl
@@ -10,68 +10,68 @@ void test1() {
     foo();
   }
 }
-// CHECK: define spir_func void @_Z5test1v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test1@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: for.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test2() {
   for (;cond();) {
     foo();
   }
 }
-// CHECK: define spir_func void @_Z5test2v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test2@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: for.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: for.body:
-// CHECK:                    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test3() {
   for (cond();;) {
     foo();
   }
 }
-// CHECK: define spir_func void @_Z5test3v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test3@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T0]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T0]]) ]
 // CHECK: for.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test4() {
   for (cond();cond2();) {
     foo();
   }
 }
-// CHECK: define spir_func void @_Z5test4v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test4@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T0]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T0]]) ]
 // CHECK: for.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z5cond2v() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond2@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: for.body:
-// CHECK:                    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test5() {
   for (cond();cond2();foo()) {
   }
 }
-// CHECK: define spir_func void @_Z5test5v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test5@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T0]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T0]]) ]
 // CHECK: for.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z5cond2v() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond2@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: for.inc:
-// CHECK:                    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test6() {
   for (cond();cond2();foo()) {
@@ -81,23 +81,23 @@ void test6() {
     }
   }
 }
-// CHECK: define spir_func void @_Z5test6v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test6@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T0]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T0]]) ]
 // CHECK: for.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z5cond2v() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond2@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: for.body:
-// CHECK:   [[C1:%[a-zA-Z0-9]+]] = call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:   [[C1:%[a-zA-Z0-9]+]] = call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK:   br i1 [[C1]], label %if.then, label %if.end
 // CHECK: if.then:
-// CHECK:   call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:   call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK:   br label %for.end
 // CHECK: if.end:
 // CHECK:   br label %for.inc
 // CHECK: for.inc:
-// CHECK:                    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test7() {
   for (cond();;) {
@@ -106,16 +106,16 @@ void test7() {
     }
   }
 }
-// CHECK: define spir_func void @_Z5test7v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test7@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T0]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T0]]) ]
 // CHECK: for.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: for.cond3:
 // CHECK:   [[T2:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T1]]) ]
-// CHECK:                    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T2]]) ]
+// CHECK:                    call spir_func void @"?foo@@YAXXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T2]]) ]
 
 // CHECK-DAG: attributes [[A0]] = { {{.*}}convergent{{.*}} }
 // CHECK-DAG: attributes [[A3]] = { {{.*}}convergent{{.*}} }

--- a/clang/test/CodeGenHLSL/convergence/while.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/while.hlsl
@@ -8,26 +8,26 @@ void test1() {
   while (cond()) {
   }
 }
-// CHECK: define spir_func void @_Z5test1v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test1@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: while.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 
 void test2() {
   while (cond()) {
     foo();
   }
 }
-// CHECK: define spir_func void @_Z5test2v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test2@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: while.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: while.body:
-// CHECK:   call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:   call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 
 void test3() {
   while (cond()) {
@@ -36,16 +36,16 @@ void test3() {
     foo();
   }
 }
-// CHECK: define spir_func void @_Z5test3v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test3@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: while.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: if.then:
 // CHECK:   br label %while.end
 // CHECK: if.end:
-// CHECK:   call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:   call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK:   br label %while.cond
 
 void test4() {
@@ -56,14 +56,14 @@ void test4() {
     }
   }
 }
-// CHECK: define spir_func void @_Z5test4v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test4@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: while.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: if.then:
-// CHECK:   call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:   call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK:   br label %while.end
 // CHECK: if.end:
 // CHECK:   br label %while.cond
@@ -78,17 +78,17 @@ void test5() {
     }
   }
 }
-// CHECK: define spir_func void @_Z5test5v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test5@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: while.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: while.cond2:
 // CHECK:   [[T2:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T1]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T2]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T2]]) ]
 // CHECK: if.then:
-// CHECK:   call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T2]]) ]
+// CHECK:   call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T2]]) ]
 // CHECK:   br label %while.end
 
 void test6() {
@@ -102,17 +102,17 @@ void test6() {
     }
   }
 }
-// CHECK: define spir_func void @_Z5test6v() [[A0:#[0-9]+]] {
+// CHECK: define spir_func void @"?test6@@YAXXZ"() [[A0:#[0-9]+]] {
 // CHECK: entry:
 // CHECK:   [[T0:%[0-9]+]] = call token @llvm.experimental.convergence.entry()
 // CHECK: while.cond:
 // CHECK:   [[T1:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T0]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK: while.cond2:
 // CHECK:   [[T2:%[0-9]+]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[T1]]) ]
-// CHECK:                    call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T2]]) ]
+// CHECK:                    call spir_func noundef i1 @"?cond@@YA_NXZ"() [[A3]] [ "convergencectrl"(token [[T2]]) ]
 // CHECK: if.then:
-// CHECK:   call spir_func void @_Z3foov() [[A3]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:   call spir_func void @"?foo@@YAXXZ"() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK:   br label %while.end
 
 // CHECK-DAG: attributes [[A0]] = { {{.*}}convergent{{.*}} }

--- a/clang/test/CodeGenHLSL/main_entry.hlsl
+++ b/clang/test/CodeGenHLSL/main_entry.hlsl
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-compute %s -hlsl-entry main \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | \
+// RUN: FileCheck %s --check-prefixes=CHECK,DXIL
+
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-pc-vulkan-compute %s -hlsl-entry main \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | \
+// RUN: FileCheck %s --check-prefixes=CHECK,SPIRV
+
+// Make sure the entry point is not mangled.
+// CHECK:define void @main()
+// DXIL:   call void @"?main@@YAXXZ"()
+// SPIRV:   call spir_func void @"?main@@YAXXZ"()
+// Make sure add function attribute and numthreads attribute.
+// CHECK:"hlsl.numthreads"="16,8,1"
+// CHECK:"hlsl.shader"="compute"
+[numthreads(16,8,1)]
+void main() {
+
+}

--- a/clang/test/CodeGenHLSL/semantics/DispatchThreadID.hlsl
+++ b/clang/test/CodeGenHLSL/semantics/DispatchThreadID.hlsl
@@ -6,7 +6,8 @@
 // CHECK:       define void @foo()
 // CHECK-DXIL:  %[[#ID:]] = call i32 @llvm.[[TARGET]].thread.id(i32 0)
 // CHECK-SPIRV: %[[#ID:]] = call i32 @llvm.[[TARGET]].thread.id(i32 0)
-// CHECK:       call void @{{.*}}foo{{.*}}(i32 %[[#ID]])
+// CHECK-DXIL:       call void @{{.*}}foo{{.*}}(i32 %[[#ID]])
+// CHECK-SPIRV:      call spir_func void @{{.*}}foo{{.*}}(i32 %[[#ID]])
 [shader("compute")]
 [numthreads(8,8,1)]
 void foo(uint Idx : SV_DispatchThreadID) {}
@@ -17,6 +18,7 @@ void foo(uint Idx : SV_DispatchThreadID) {}
 // CHECK:       %[[#ID_Y:]] = call i32 @llvm.[[TARGET]].thread.id(i32 1)
 // CHECK:       %[[#ID_XY:]] = insertelement <2 x i32> %[[#ID_X_]], i32 %[[#ID_Y]], i64 1
 // CHECK-DXIL:  call void @{{.*}}bar{{.*}}(<2 x i32> %[[#ID_XY]])
+// CHECK-SPIRV:  call spir_func void @{{.*}}bar{{.*}}(<2 x i32> %[[#ID_XY]])
 [shader("compute")]
 [numthreads(8,8,1)]
 void bar(uint2 Idx : SV_DispatchThreadID) {}

--- a/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
@@ -4,7 +4,7 @@
 // SPIRV: error: '-fnative-half-type' option requires target HLSL Version >= 2018, but HLSL Version is 'hlsl2016'
 
 // valid: "spirv-unknown-vulkan-library"
-// valid: define spir_func void @main() #0 {
+// valid: define spir_func void @"?main@@YAXXZ"() #0 {
 
 [numthreads(1,1,1)]
 void main()


### PR DESCRIPTION
- Fix the calling convention used for the call in the entry point
  wrapper. No calling convention is currently set. I can easily use the
  calling convention of the function that is being called.

- Use the Microsoft CXX abi for name mangling in Vulkan. There is a
problem with the name mangling for an HLSL entry
point when it is called `main` when using the  Itanium CXX ABI. It
does not do name mangling on main because is treated as special.
However, in Vulkan SPIR-V, a function named "main" has no special
meaning, and should be treated like any other function. This also
allows us to match the DXIL codegen better, and to create fewer special
cases.

Part of https://github.com/llvm/llvm-project/issues/108567.
