### PR TITLE
[ci] Don't add more check targets if "check-all" is present

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -192,40 +192,49 @@ function keep-modified-projects() {
 
 function check-targets() {
   projects=${@}
+  targets=""
   for project in ${projects}; do
     case ${project} in
     clang-tools-extra)
-      echo "check-clang-tools"
+      targets="${targets} check-clang-tools"
     ;;
     compiler-rt)
-      echo "check-all"
+      targets="${targets} check-all"
     ;;
     cross-project-tests)
-      echo "check-cross-project"
+      targets="${targets} check-cross-project"
     ;;
     libcxx)
-      echo "check-cxx"
+      targets="${targets} check-cxx"
     ;;
     libcxxabi)
-      echo "check-cxxabi"
+      targets="${targets} check-cxxabi"
     ;;
     libunwind)
-      echo "check-unwind"
+      targets="${targets} check-unwind"
     ;;
     lldb)
-      echo "check-lldb"
+      targets="${targets} check-lldb"
     ;;
     pstl)
-      echo "check-all"
+      targets="${targets} check-all"
     ;;
     libclc)
-      echo "check-all"
+      targets="${targets} check-all"
     ;;
     *)
-      echo "check-${project}"
+      targets="${targets} check-${project}"
     ;;
     esac
   done
+
+  # check-all includes every project and runtime. Adding more targets would
+  # make tests run multiple times.
+  if [[ $targets == *"check-all"* ]]; then
+    echo "check-all"
+  else
+    echo ${targets}
+  fi
 }
 
 # Project specific pipelines.


### PR DESCRIPTION
Fixes #110265.

Where I noticed that because compiler-rt added the "check-all" target we were actually testing clang and clang-tools twice. One for "all" and once with their specific targets.

This what the generated commands looked like before this commit (Linux/Windows):
```
  commands:
  - './.ci/monolithic-linux.sh "clang;clang;lld;clang-tools-extra;compiler-rt;llvm" "check-all check-clang check-clang-tools" "libcxx;libcxxabi;libunwind" "check-cxx check-cxxabi check-unwind"'
  commands:
  - 'C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=amd64 -host_arch=amd64'
  - 'bash .ci/monolithic-windows.sh "clang;clang-tools-extra;llvm" "check-clang check-clang-tools"'
```
Windows avoided this issue because compiler-rt is ignored there due to failing tests, but the same issue could happen there in future.

These extra tests were about 24% of the test run and increased testing time (on my local machine) by 45%.

With the changes I've made here, if a project needs "check-all" we will use only that target for the whole build. Since check-all includes everything else.

The generated commands are now:
```
  commands:
  - './.ci/monolithic-linux.sh "clang;clang;lld;clang-tools-extra;compiler-rt;llvm" "check-all" "libcxx;libcxxabi;libunwind" "check-cxx check-cxxabi check-unwind"'
  commands:
  - 'C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=amd64 -host_arch=amd64'
  - 'bash .ci/monolithic-windows.sh "clang;clang-tools-extra;llvm" "check-clang check-clang-tools"'
```
The monolithic build is actually 2 builds, one for projects and one for runtimes. So the new logic applies to both. This will be useful if/when CI builds compiler-rt/libclc/pstl as runtimes.