### PR TITLE
[llvm] Add serialization to uint32_t for FixedPointSemantics

### DIFF
--- a/llvm/include/llvm/ADT/APFixedPoint.h
+++ b/llvm/include/llvm/ADT/APFixedPoint.h
@@ -114,6 +114,15 @@ public:
   }
   bool operator!=(FixedPointSemantics Other) const { return !(*this == Other); }
 
+  /// Convert the semantics to a 32-bit unsigned integer.
+  /// The result is dependent on the host endianness and not stable across LLVM
+  /// versions. See getFromOpaqueInt() to convert it back to a
+  /// FixedPointSemantics object.
+  uint32_t toOpaqueInt() const;
+  /// Create a FixedPointSemantics object from an integer created via
+  /// toOpaqueInt().
+  static FixedPointSemantics getFromOpaqueInt(uint32_t);
+
 private:
   unsigned Width          : WidthBitWidth;
   signed int LsbWeight    : LsbWeightBitWidth;

--- a/llvm/lib/Support/APFixedPoint.cpp
+++ b/llvm/lib/Support/APFixedPoint.cpp
@@ -29,6 +29,16 @@ void FixedPointSemantics::print(llvm::raw_ostream &OS) const {
   OS << "IsSaturated=" << IsSaturated;
 }
 
+uint32_t FixedPointSemantics::toOpaqueInt() const {
+  return llvm::bit_cast<uint32_t>(*this);
+}
+
+FixedPointSemantics FixedPointSemantics::getFromOpaqueInt(uint32_t I) {
+  FixedPointSemantics F(0, 0, false, false, false);
+  std::memcpy(&F, &I, sizeof(F));
+  return F;
+}
+
 APFixedPoint APFixedPoint::convert(const FixedPointSemantics &DstSema,
                                    bool *Overflow) const {
   APSInt NewVal = Val;

--- a/llvm/unittests/ADT/APFixedPointTest.cpp
+++ b/llvm/unittests/ADT/APFixedPointTest.cpp
@@ -1274,4 +1274,35 @@ TEST(FixedPoint, div) {
                                               true, false, false)));
 }
 
+TEST(FixedPoint, semanticsSerialization) {
+  auto roundTrip = [](FixedPointSemantics FPS) -> bool {
+    uint32_t I = FPS.toOpaqueInt();
+    FixedPointSemantics FPS2 = FixedPointSemantics::getFromOpaqueInt(I);
+    return FPS == FPS2;
+  };
+
+  ASSERT_TRUE(roundTrip(getS32Pos2()));
+  ASSERT_TRUE(roundTrip(getU8Pos4()));
+  ASSERT_TRUE(roundTrip(getS16Neg18()));
+  ASSERT_TRUE(roundTrip(getU8Neg10()));
+  ASSERT_TRUE(roundTrip(getPadULFractSema()));
+  ASSERT_TRUE(roundTrip(getPadUFractSema()));
+  ASSERT_TRUE(roundTrip(getPadUSFractSema()));
+  ASSERT_TRUE(roundTrip(getPadULAccumSema()));
+  ASSERT_TRUE(roundTrip(getPadUAccumSema()));
+  ASSERT_TRUE(roundTrip(getPadUSAccumSema()));
+  ASSERT_TRUE(roundTrip(getULFractSema()));
+  ASSERT_TRUE(roundTrip(getUFractSema()));
+  ASSERT_TRUE(roundTrip(getUSFractSema()));
+  ASSERT_TRUE(roundTrip(getULAccumSema()));
+  ASSERT_TRUE(roundTrip(getUAccumSema()));
+  ASSERT_TRUE(roundTrip(getUSAccumSema()));
+  ASSERT_TRUE(roundTrip(getLFractSema()));
+  ASSERT_TRUE(roundTrip(getFractSema()));
+  ASSERT_TRUE(roundTrip(getSFractSema()));
+  ASSERT_TRUE(roundTrip(getLAccumSema()));
+  ASSERT_TRUE(roundTrip(getAccumSema()));
+  ASSERT_TRUE(roundTrip(getSAccumSema()));
+}
+
 } // namespace


### PR DESCRIPTION
FixedPointSemantics is exactly 32bits and this static_assert'ed after its declaration. Add support for converting it to and from a uint32_t.