### PR TITLE
[flang] Downgrade specific format error to warning

### DIFF
--- a/flang/include/flang/Common/format.h
+++ b/flang/include/flang/Common/format.h
@@ -136,7 +136,7 @@ private:
 
   const CHAR *cursor_{}; // current location in format_
   const CHAR *laCursor_{}; // lookahead cursor
-  TokenKind previousTokenKind_{TokenKind::None};
+  Token previousToken_{};
   Token token_{}; // current token
   Token knrToken_{}; // k, n, or r UnsignedInteger token
   Token scaleFactorToken_{}; // most recent scale factor token P
@@ -193,7 +193,7 @@ template <typename CHAR> void FormatValidator<CHAR>::NextToken() {
   // At entry, cursor_ points before the start of the next token.
   // At exit, cursor_ points to last CHAR of token_.
 
-  previousTokenKind_ = token_.kind();
+  previousToken_ = token_;
   CHAR c{NextChar()};
   token_.set_kind(TokenKind::None);
   token_.set_offset(cursor_ - format_);
@@ -431,7 +431,7 @@ template <typename CHAR> void FormatValidator<CHAR>::NextToken() {
     }
     SetLength();
     if (stmt_ == IoStmtKind::Read &&
-        previousTokenKind_ != TokenKind::DT) { // 13.3.2p6
+        previousToken_.kind() != TokenKind::DT) { // 13.3.2p6
       ReportError("String edit descriptor in READ format expression");
     } else if (token_.kind() != TokenKind::String) {
       ReportError("Unterminated string");
@@ -887,8 +887,10 @@ template <typename CHAR> bool FormatValidator<CHAR>::Check() {
       // Possible first token of the next format item; token not yet processed.
       if (commaRequired) {
         const char *s{"Expected ',' or ')' in format expression"}; // C1302
-        if (previousTokenKind_ == TokenKind::UnsignedInteger &&
+        if (previousToken_.kind() == TokenKind::UnsignedInteger &&
+            previousToken_.length() > 1 &&
             itemsWithLeadingInts_.test(token_.kind())) {
+          // F10.32F10.3 is ambiguous, F10.3F10.3 is not
           ReportError(s);
         } else {
           ReportWarning(s);

--- a/flang/test/Semantics/io07.f90
+++ b/flang/test/Semantics/io07.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 1001 format(A)
 
      !ERROR: Format statement must be labeled
@@ -23,9 +23,13 @@
      endif
 
      ! C1302 warnings; no errors
+     !WARNING: Expected ',' or ')' in format expression
 2051 format(1X3/)
+     !WARNING: Expected ',' or ')' in format expression
 2052 format(1X003/)
+     !WARNING: Expected ',' or ')' in format expression
 2053 format(3P7I2)
+     !WARNING: Expected ',' or ')' in format expression
 2054 format(3PI2)
 
      !ERROR: Expected ',' or ')' in format expression
@@ -37,13 +41,14 @@
      !ERROR: Expected ',' or ')' in format expression
 2103 format(3I8 3Z8)
 
-     !ERROR: Expected ',' or ')' in format expression
+     !WARNING: Expected ',' or ')' in format expression
 2104 format(3I8 Z8)
 
 3001 format(*(I3))
 3002 format(5X,*(2(A)))
 
      !ERROR: Unlimited format item list must contain a data edit descriptor
+     !WARNING: 'X' edit descriptor must have a positive position value
 3101 format(*(X))
 
      !ERROR: Unlimited format item list must contain a data edit descriptor
@@ -52,9 +57,11 @@
      !ERROR: Unlimited format item list must contain a data edit descriptor
 3103 format(5X, 'abc', *((:)))
 
+     !WARNING: 'X' edit descriptor must have a positive position value
 4001 format(2(X))
 
      !ERROR: List repeat specifier must be positive
+     !WARNING: 'X' edit descriptor must have a positive position value
      !ERROR: 'DT' edit descriptor repeat specifier must be positive
 4101 format(0(X), 0dt)
 


### PR DESCRIPTION
When a format is missing a comma between two edit descriptors, the previous token was an integer, and the following item is a repeatable edit descriptor or a parenthesized group, we emit an error, since it can't be known where the digits of the integer should be split.  But in the case of a single digit, the situation is not ambiguous, and the message should be a warning.

Fixes https://github.com/llvm/llvm-project/issues/110261.