### PR TITLE
[libc++] Don't use aligned_alloc on iOS versions before 13

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -649,6 +649,10 @@ typedef __char32_t char32_t;
          __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500)
 #      define _LIBCPP_HAS_NO_C11_ALIGNED_ALLOC
 #    endif
+#    if (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) &&                                                    \
+         __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 130000)
+#      define _LIBCPP_HAS_NO_C11_ALIGNED_ALLOC
+#    endif
 #  elif defined(__ANDROID__) && __ANDROID_API__ < 28
 // Android only provides aligned_alloc when targeting API 28 or higher.
 #    define _LIBCPP_HAS_NO_C11_ALIGNED_ALLOC


### PR DESCRIPTION
There's a check here to not use aligned_alloc on macOS versions before 10.15, this patch adds an equivalent check that tests for iOS 13.