### PR TITLE
[BPF] fix print_btf.py test script on bigendian machines

### DIFF
--- a/llvm/test/CodeGen/BPF/BTF/print_btf.py
+++ b/llvm/test/CodeGen/BPF/BTF/print_btf.py
@@ -88,7 +88,7 @@ def print_btf(filename):
             buf = file.read()
 
     fmt_cache = {}
-    endian_pfx = ""
+    endian_pfx = ">"  # big endian
     off = 0
 
     def unpack(fmt):
@@ -104,9 +104,9 @@ def print_btf(filename):
     # Use magic number at the header start to determine endianness
     (magic,) = unpack("H")
     if magic == 0xEB9F:
-        endian_pfx = "<"
+        endian_pfx = ">"  # big endian
     elif magic == 0x9FEB:
-        endian_pfx = ">"
+        endian_pfx = "<"  # little endian
     else:
         warn(f"Unexpected BTF magic: {magic:02x}")
         return
@@ -290,6 +290,6 @@ def print_btf(filename):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        warn("Usage: {sys.argv[0]} <btf_file>")
+        warn(f"Usage: {sys.argv[0]} <btf_file>")
         sys.exit(1)
     print_btf(sys.argv[1])


### PR DESCRIPTION
Make print_btf.py correctly detect endianness of the BTF input. Input endianness is inferred from BTF magic word [2], which is a 2-byte integer at offset 0 of the input:
- sequence `EB 9F` signals big-endian input;
- sequence `9F EB` signals little-endian input.

Before this commit the magic sequence was read using "H" format for `unpack` method of python's `struct` module:
- if magic is `0xEB9F` assume little-endian;
- if magic is `0x9FEB` assume big-endian.

However, format `H` reads data in native endianness.

Thus the above logic would only be correct on little endian hosts:
- byte sequence `9F EB` read as `0xEB9F` -> little-endian input;
- byte sequence `EB 9F` read as `0x9FEB` -> big-endian input.

On the big-endian host the relation should be inverse.

Fix this by always reading magic in big-endian (format `>H`).

This fixes CI error reported for a BPF test using print_btf.py script in [1]. The error happens on a s390 host, which is big-endian.

[1] https://lab.llvm.org/buildbot/#/builders/42/builds/1192
[2] https://www.kernel.org/doc/html/latest/bpf/btf.html#btf-type-and-string-encoding