### PR TITLE
[ArgPromotion] Consider InvokeInst in Caller alias analysis

### DIFF
--- a/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
+++ b/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
@@ -491,10 +491,8 @@ static bool isArgUnmodifiedByAllCalls(Argument *Arg,
                                       FunctionAnalysisManager &FAM) {
   for (User *U : Arg->getParent()->users()) {
 
-    // Bail if we find an unexpected (non CallInst) use of the function.
-    auto *Call = dyn_cast<CallInst>(U);
-    if (!Call)
-      return false;
+    assert(isa<CallBase>(U) && "Expected all users of Function to be CallBase");
+    CallBase *Call = cast<CallBase>(U);
 
     MemoryLocation Loc =
         MemoryLocation::getForArgument(Call, Arg->getArgNo(), nullptr);

--- a/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
+++ b/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
@@ -491,8 +491,7 @@ static bool isArgUnmodifiedByAllCalls(Argument *Arg,
                                       FunctionAnalysisManager &FAM) {
   for (User *U : Arg->getParent()->users()) {
 
-    assert(isa<CallBase>(U) && "Expected all users of Function to be CallBase");
-    CallBase *Call = cast<CallBase>(U);
+    auto *Call = cast<CallBase>(U);
 
     MemoryLocation Loc =
         MemoryLocation::getForArgument(Call, Arg->getArgNo(), nullptr);


### PR DESCRIPTION
Check that all users of a Function are CallBase rather than CallInst when performing alias analysis using actual arguments in the calling function, as this check is also valid for Invoke instructions.

This allows replacing the existing check with an assert, as the Function only being used by CallBase derived instructions is a precondition of the transform.

This addresses post-commit review on #106216.