### PR TITLE
[llvm] Win x64 Unwind V2 2/n: Support dumping UOP_Epilog

### DIFF
--- a/llvm/include/llvm/Support/Win64EH.h
+++ b/llvm/include/llvm/Support/Win64EH.h
@@ -124,6 +124,11 @@ union UnwindCode {
   uint8_t getOpInfo() const {
     return (u.UnwindOpAndOpInfo >> 4) & 0x0F;
   }
+  /// Gets the offset for an UOP_Epilog unwind code.
+  uint32_t getEpilogOffset() const {
+    assert(getUnwindOp() == UOP_Epilog);
+    return (getOpInfo() << 8) | static_cast<uint32_t>(u.CodeOffset);
+  }
 };
 
 enum {

--- a/llvm/test/tools/llvm-objdump/COFF/win64-unwindv2.yaml
+++ b/llvm/test/tools/llvm-objdump/COFF/win64-unwindv2.yaml
@@ -1,47 +1,33 @@
 # RUN: yaml2obj %s -o %t.exe
-# RUN: llvm-readobj --unwind %t.exe | FileCheck %s
+# RUN: llvm-objdump --unwind-info %t.exe | FileCheck %s
 
-# CHECK-LABEL:  UnwindInformation [
-# CHECK-NEXT:     RuntimeFunction {
-# CHECK-NEXT:       StartAddress: _ZN4RAIID2Ev (0x140001010)
-# CHECK-NEXT:       EndAddress: (0x140001017)
-# CHECK-NEXT:       UnwindInfoAddress: .xdata (0x140002000)
-# CHECK-NEXT:       UnwindInfo {
-# CHECK-NEXT:         Version: 2
-# CHECK-NEXT:         Flags [ (0x0)
-# CHECK-NEXT:         ]
-# CHECK-NEXT:         PrologSize: 4
-# CHECK-NEXT:         FrameRegister: -
-# CHECK-NEXT:         FrameOffset: -
-# CHECK-NEXT:         UnwindCodeCount: 3
-# CHECK-NEXT:         UnwindCodes [
-# CHECK-NEXT:           0x01: EPILOG atend=yes, length=0x1
-# CHECK-NEXT:           0x0B: EPILOG offset=0xB
-# CHECK-NEXT:           0x04: ALLOC_SMALL size=72
-# CHECK-NEXT:         ]
-# CHECK-NEXT:       }
-# CHECK-NEXT:     }
-# CHECK-NEXT:     RuntimeFunction {
-# CHECK-NEXT:       StartAddress: entry (0x140001020)
-# CHECK-NEXT:       EndAddress: (0x14000105C)
-# CHECK-NEXT:       UnwindInfoAddress: (0x14000200C)
-# CHECK-NEXT:       UnwindInfo {
-# CHECK-NEXT:         Version: 1
-# CHECK-NEXT:         Flags [ (0x3)
-# CHECK-NEXT:           ExceptionHandler (0x1)
-# CHECK-NEXT:           TerminateHandler (0x2)
-# CHECK-NEXT:         ]
-# CHECK-NEXT:         PrologSize: 4
-# CHECK-NEXT:         FrameRegister: -
-# CHECK-NEXT:         FrameOffset: -
-# CHECK-NEXT:         UnwindCodeCount: 1
-# CHECK-NEXT:         UnwindCodes [
-# CHECK-NEXT:           0x04: ALLOC_SMALL size=56
-# CHECK-NEXT:         ]
-# CHECK-NEXT:         Handler: __gxx_personality_seh0 (0x140001070)
-# CHECK-NEXT:       }
-# CHECK-NEXT:     }
-# CHECK-NEXT:   ]
+# CHECK-LABEL:  Unwind info:
+# CHECK-EMPTY:
+# CHECK-NEXT:   Function Table:
+# CHECK-NEXT:     Start Address: 0x1010
+# CHECK-NEXT:     End Address: 0x1017
+# CHECK-NEXT:     Unwind Info Address: 0x2000
+# CHECK-NEXT:       Version: 2
+# CHECK-NEXT:       Flags: 0
+# CHECK-NEXT:       Size of prolog: 4
+# CHECK-NEXT:       Number of Codes: 3
+# CHECK-NEXT:       No frame pointer used
+# CHECK-NEXT:       Unwind Codes:
+# CHECK-NEXT:         0x01: UOP_Epilog atend=yes, length=0x1
+# CHECK-NEXT:         0x0b: UOP_Epilog offset=0xB
+# CHECK-NEXT:         0x04: UOP_AllocSmall 72
+# CHECK-EMPTY:
+# CHECK-NEXT:   Function Table:
+# CHECK-NEXT:     Start Address: 0x1020
+# CHECK-NEXT:     End Address: 0x105c
+# CHECK-NEXT:     Unwind Info Address: 0x200c
+# CHECK-NEXT:       Version: 1
+# CHECK-NEXT:       Flags: 3 UNW_ExceptionHandler UNW_TerminateHandler
+# CHECK-NEXT:       Size of prolog: 4
+# CHECK-NEXT:       Number of Codes: 1
+# CHECK-NEXT:       No frame pointer used
+# CHECK-NEXT:       Unwind Codes:
+# CHECK-NEXT:         0x04: UOP_AllocSmall 56
 
 --- !COFF
 OptionalHeader:

--- a/llvm/tools/llvm-readobj/Win64EHDumper.cpp
+++ b/llvm/tools/llvm-readobj/Win64EHDumper.cpp
@@ -65,6 +65,8 @@ static StringRef getUnwindCodeTypeName(uint8_t Code) {
   case UOP_SaveXMM128: return "SAVE_XMM128";
   case UOP_SaveXMM128Big: return "SAVE_XMM128_FAR";
   case UOP_PushMachFrame: return "PUSH_MACHFRAME";
+  case UOP_Epilog:
+    return "EPILOG";
   }
 }
 
@@ -99,6 +101,7 @@ static unsigned getNumUsedSlots(const UnwindCode &UnwindCode) {
   case UOP_AllocSmall:
   case UOP_SetFPReg:
   case UOP_PushMachFrame:
+  case UOP_Epilog:
     return 1;
   case UOP_SaveNonVol:
   case UOP_SaveXMM128:
@@ -254,7 +257,8 @@ void Dumper::printRuntimeFunctionEntry(const Context &Ctx,
 // Prints one unwind code. Because an unwind code can occupy up to 3 slots in
 // the unwind codes array, this function requires that the correct number of
 // slots is provided.
-void Dumper::printUnwindCode(const UnwindInfo& UI, ArrayRef<UnwindCode> UC) {
+void Dumper::printUnwindCode(const UnwindInfo &UI, ArrayRef<UnwindCode> UC,
+                             bool &SeenFirstEpilog) {
   assert(UC.size() >= getNumUsedSlots(UC[0]));
 
   SW.startLine() << format("0x%02X: ", unsigned(UC[0].u.CodeOffset))
@@ -306,6 +310,23 @@ void Dumper::printUnwindCode(const UnwindInfo& UI, ArrayRef<UnwindCode> UC) {
   case UOP_PushMachFrame:
     OS << " errcode=" << (UC[0].getOpInfo() == 0 ? "no" : "yes");
     break;
+
+  case UOP_Epilog:
+    if (SeenFirstEpilog) {
+      uint32_t Offset = UC[0].getEpilogOffset();
+      if (Offset == 0) {
+        OS << " padding";
+      } else {
+        OS << " offset=" << format("0x%X", Offset);
+      }
+    } else {
+      SeenFirstEpilog = true;
+      bool AtEnd = (UC[0].getOpInfo() & 0x1) != 0;
+      uint32_t Length = UC[0].u.CodeOffset;
+      OS << " atend=" << (AtEnd ? "yes" : "no")
+         << ", length=" << format("0x%X", Length);
+    }
+    break;
   }
 
   OS << "\n";
@@ -330,6 +351,7 @@ void Dumper::printUnwindInfo(const Context &Ctx, const coff_section *Section,
   {
     ListScope UCS(SW, "UnwindCodes");
     ArrayRef<UnwindCode> UC(&UI.UnwindCodes[0], UI.NumCodes);
+    bool SeenFirstEpilog = false;
     for (const UnwindCode *UCI = UC.begin(), *UCE = UC.end(); UCI < UCE; ++UCI) {
       unsigned UsedSlots = getNumUsedSlots(*UCI);
       if (UsedSlots > UC.size()) {
@@ -337,7 +359,7 @@ void Dumper::printUnwindInfo(const Context &Ctx, const coff_section *Section,
         return;
       }
 
-      printUnwindCode(UI, ArrayRef(UCI, UCE));
+      printUnwindCode(UI, ArrayRef(UCI, UCE), SeenFirstEpilog);
       UCI = UCI + UsedSlots - 1;
     }
   }

--- a/llvm/tools/llvm-readobj/Win64EHDumper.h
+++ b/llvm/tools/llvm-readobj/Win64EHDumper.h
@@ -44,7 +44,8 @@ private:
                                  const object::coff_section *Section,
                                  uint64_t SectionOffset,
                                  const RuntimeFunction &RF);
-  void printUnwindCode(const UnwindInfo& UI, ArrayRef<UnwindCode> UC);
+  void printUnwindCode(const UnwindInfo &UI, ArrayRef<UnwindCode> UC,
+                       bool &SeenFirstEpilog);
   void printUnwindInfo(const Context &Ctx, const object::coff_section *Section,
                        off_t Offset, const UnwindInfo &UI);
   void printRuntimeFunction(const Context &Ctx,


### PR DESCRIPTION
Adds support to objdump and readobj for reading the `UOP_Epilog` entries of Windows x64 unwind v2.

`UOP_Epilog` has a weird format:

The first `UOP_Epilog` in the unwind data is the "header":
* The least-significant bit of `OpInfo` is the "At End" flag, which signifies that there is an epilog at the very end of the associated function.
* `CodeOffset` is the length each epilog described by the current unwind information (all epilogs have the same length).

Any subsequent `UOP_Epilog` represents another epilog for the current function, where `OpInfo` and `CodeOffset` are combined to a 12-bit value which is the offset of the beginning of the epilog from the end of the current function. If the offset is 0, then this entry is actually padding and can be ignored.