### PR TITLE
Fix build break when building RISCVInstrInfo.cpp with MSVC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -779,7 +779,7 @@ MachineInstr *RISCVInstrInfo::foldMemoryOperandImpl(
     if (RISCV::getRVVMCOpcode(MI.getOpcode()) == RISCV::VMV_X_S) {
       unsigned Log2SEW =
           MI.getOperand(RISCVII::getSEWOpNum(MI.getDesc())).getImm();
-      if (STI.getXLen() < (1 << Log2SEW))
+      if (STI.getXLen() < (1U << Log2SEW))
         return nullptr;
       switch (Log2SEW) {
       case 3:


### PR DESCRIPTION
After #109774 MSVC is failing to build LLVM with the error:

```
llvm\lib\Target\RISCV\RISCVInstrInfo.cpp(782): warning C4018: '<': signed/unsigned mismatch
```

Fix is ensure that the RHS is an unsigned integer.