### PR TITLE
Only insert the function in the callable map if it resolves.

### DIFF
--- a/mlir/lib/Dialect/MLProgram/Transforms/PipelineGlobalOps.cpp
+++ b/mlir/lib/Dialect/MLProgram/Transforms/PipelineGlobalOps.cpp
@@ -59,8 +59,9 @@ LogicalResult MLProgramPipelineGlobals::buildGlobalMap(ModuleOp module) {
       }
 
       auto symbol = mlir::dyn_cast<SymbolRefAttr>(callable);
-      auto *func = getFromSymbol(op, symbol);
-      callableMap[symbol] = func;
+      if (auto *func = getFromSymbol(op, symbol)) {
+        callableMap[symbol] = func;
+      }
     }
     return WalkResult::advance();
   });

--- a/mlir/test/mlir-opt/PipelineGlobalOpsCrash.mlir
+++ b/mlir/test/mlir-opt/PipelineGlobalOpsCrash.mlir
@@ -1,0 +1,8 @@
+// RUN:   mlir-opt -mlprogram-pipeline-globals %s
+
+func.func @call_and_store_after(%arg1: memref<f32>) {
+  memref.load %arg1[] {name = "caller"} : memref<f32>
+  test.call_and_store @callee(%arg1), %arg1 {name = "call", store_before_call = false} : (memref<f32>, memref<f32>) -> ()
+  memref.load %arg1[] {name = "post"} : memref<f32>
+  return
+}


### PR DESCRIPTION
First attempt at fix #109649.

The crash is caused by a null func inserted in the callable map. 

