### PR TITLE
[clang-tidy] support string::contains

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ContainerContainsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerContainsCheck.cpp
@@ -38,7 +38,7 @@ void ContainerContainsCheck::registerMatchers(MatchFinder *Finder) {
   const auto FindCall =
       cxxMemberCallExpr(
           anyOf(argumentCountIs(1),
-                allOf(argumentCountIs(2),
+                allOf(argumentCountIs(2), // string::find takes two arguments
                       hasArgument(1, anyOf(cxxDefaultArgExpr(),
                                            ignoringParenImpCasts(Literal0))))),
           callee(cxxMethodDecl(

--- a/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/string
+++ b/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/string
@@ -50,11 +50,15 @@ struct basic_string {
   size_type find(const _Type& str, size_type pos = 0) const;
   size_type find(const C* s, size_type pos = 0) const;
   size_type find(const C* s, size_type pos, size_type n) const;
+  size_type find(C ch, size_type pos = 0) const;
 
   size_type rfind(const _Type& str, size_type pos = npos) const;
   size_type rfind(const C* s, size_type pos, size_type count) const;
   size_type rfind(const C* s, size_type pos = npos) const;
   size_type rfind(C ch, size_type pos = npos) const;
+
+  bool contains(const C *s) const;
+  bool contains(C s) const;
 
   _Type& insert(size_type pos, const _Type& str);
   _Type& insert(size_type pos, const C* s);
@@ -103,6 +107,9 @@ struct basic_string_view {
   size_type rfind(C ch, size_type pos = npos) const;
   size_type rfind(const C* s, size_type pos, size_type count) const;
   size_type rfind(const C* s, size_type pos = npos) const;
+
+  bool contains(const C *s) const;
+  bool contains(C s) const;
 
   constexpr bool starts_with(basic_string_view sv) const noexcept;
   constexpr bool starts_with(C ch) const noexcept;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-contains.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-contains.cpp
@@ -29,6 +29,43 @@ struct multimap {
   bool contains(const Key &K) const;
 };
 
+using size_t = decltype(sizeof(int));
+
+// Lightweight standin for std::string_view.
+template <typename C>
+class basic_string_view {
+public:
+  basic_string_view();
+  basic_string_view(const basic_string_view &);
+  basic_string_view(const C *);
+  ~basic_string_view();
+  int find(basic_string_view s, int pos = 0);
+  int find(const C *s, int pos = 0);
+  int find(const C *s, int pos, int n);
+  int find(char c, int pos = 0);
+  static constexpr size_t npos = -1;
+};
+typedef basic_string_view<char> string_view;
+
+// Lightweight standin for std::string.
+template <typename C>
+class basic_string {
+public:
+  basic_string();
+  basic_string(const basic_string &);
+  basic_string(const C *);
+  ~basic_string();
+  int find(basic_string s, int pos = 0);
+  int find(const C *s, int pos = 0);
+  int find(const C *s, int pos, int n);
+  int find(char c, int pos = 0);
+  bool contains(const C *s) const;
+  bool contains(C s) const;
+  bool contains(basic_string_view<C> s) const;
+  static constexpr size_t npos = -1;
+};
+typedef basic_string<char> string;
+
 } // namespace std
 
 // Check that we detect various common ways to check for membership
@@ -452,4 +489,16 @@ void testOperandPermutations(std::map<int, int>& Map) {
   if (Map.end() == Map.find(0)) {};
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use 'contains' to check for membership [readability-container-contains]
   // CHECK-FIXES: if (!Map.contains(0)) {};
+}
+
+void testStringNops(std::string Str, std::string SubStr) {
+  if (Str.find("test") == std::string::npos) {};
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use 'contains' to check for membership [readability-container-contains]
+  // CHECK-FIXES: if (!Str.contains("test")) {};
+
+  if (Str.find('c') != std::string::npos) {};
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use 'contains' to check for membership [readability-container-contains]
+  // CHECK-FIXES: if (Str.contains('c')) {};
+  
+  if (Str.find(SubStr) != std::string::npos) {};
 }


### PR DESCRIPTION
Starting from c++23, we can replace `std::string::find() == std::string::npos` with `std::string.contains()` . #109327

Currently, this is WIP because there are two limitations:

1. False positive: SubStr type is `const std::string&` which does not match `std::string::contains(basic_string_view)` type.

```
std::string SubStr;
  if (Str.find(SubStr) != std::string::npos) {};
```

2. Currently, the fixit for `std::string::find("test", 0)` is incorrect. 