### PR TITLE
[libc++][test] Cover move construction of allocators again

### DIFF
--- a/libcxx/test/std/containers/associative/map/map.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.cons/move.pass.cpp
@@ -36,6 +36,7 @@ int main(int, char**)
         assert(std::distance(m.begin(), m.end()) == 0);
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -66,6 +67,7 @@ int main(int, char**)
         assert(*std::next(m.begin(), 2) == V(3, 1));
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/associative/multimap/multimap.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.cons/move.pass.cpp
@@ -36,6 +36,7 @@ int main(int, char**)
         assert(std::distance(m.begin(), m.end()) == 0);
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -72,6 +73,7 @@ int main(int, char**)
         assert(*std::next(m.begin(), 8) == V(3, 2));
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/associative/multiset/multiset.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/multiset/multiset.cons/move.pass.cpp
@@ -36,6 +36,7 @@ int main(int, char**)
         assert(std::distance(m.begin(), m.end()) == 0);
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -73,6 +74,7 @@ int main(int, char**)
         assert(*std::next(m.begin(), 8) == 3);
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/associative/set/set.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/set.cons/move.pass.cpp
@@ -36,6 +36,7 @@ int main(int, char**)
         assert(std::distance(m.begin(), m.end()) == 0);
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);
@@ -67,6 +68,7 @@ int main(int, char**)
         assert(*std::next(m.begin(), 2) == 3);
 
         assert(mo.get_allocator() == A(7));
+        assert(mo.get_allocator().get_id() == test_alloc_base::moved_value);
         assert(mo.key_comp() == C(5));
         assert(mo.size() == 0);
         assert(std::distance(mo.begin(), mo.end()) == 0);

--- a/libcxx/test/std/containers/sequences/deque/deque.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.cons/move.pass.cpp
@@ -39,6 +39,7 @@ int main(int, char**)
         assert(c1.size() == 0);
         assert(c3.get_allocator() == old_a);
         assert(c1.get_allocator() == A(1));
+        assert(c1.get_allocator().get_id() == test_alloc_base::moved_value);
         LIBCPP_ASSERT(is_double_ended_contiguous_container_asan_correct(c1));
         LIBCPP_ASSERT(is_double_ended_contiguous_container_asan_correct(c2));
         LIBCPP_ASSERT(is_double_ended_contiguous_container_asan_correct(c3));


### PR DESCRIPTION
Previous PR #107344 fixed move constructor of `test_allocator` but dropped test coverage for move construction in some cases. This PR attempts to restore the test coverage.

Thanks @Quuxplusone for reminding.