### PR TITLE
Fix an integer trunctation issues for the DW_AT_frame_base DWARF loca…

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -229,9 +229,9 @@ bool DWARFDebugInfoEntry::GetDIENamesAndRanges(
         case DW_AT_frame_base:
           if (frame_base) {
             if (form_value.BlockData()) {
-              uint32_t block_offset =
+              uint64_t block_offset =
                   form_value.BlockData() - data.GetDataStart();
-              uint32_t block_length = form_value.Unsigned();
+              uint64_t block_length = form_value.Unsigned();
               *frame_base =
                   DWARFExpressionList(module,
                                       DWARFExpression(DataExtractor(


### PR DESCRIPTION
…tion expression.

This patch allows offsets to the DW_AT_frame_base to exceed 4GB. Prior to this, for any .debug_info.dwo offset that exceeded 4GB, we would truncate the offset to the DW_AT_frame_base expression bytes to be 32 bit only. Changing the offset to 64 bits restores correct functionality.

No test for this as we don't want to create a .dwp file that has a .debug_info.dwo size that is over 4GB.