### PR TITLE
[clang][bytcode] Convert Fixed Point values to target semantics...

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2177,7 +2177,8 @@ inline bool CastFixedPoint(InterpState &S, CodePtr OpPC, uint32_t FPS) {
           E->getExprLoc(), diag::warn_fixedpoint_constant_overflow)
           << Result.toDiagnosticString(S.getASTContext()) << E->getType();
     }
-    S.CCEDiag(E, diag::note_constexpr_overflow) << Result << E->getType();
+    S.CCEDiag(E, diag::note_constexpr_overflow)
+        << Result.toDiagnosticString(S.getASTContext()) << E->getType();
     if (!S.noteUndefinedBehavior())
       return false;
   }

--- a/clang/test/AST/ByteCode/fixed-point.cpp
+++ b/clang/test/AST/ByteCode/fixed-point.cpp
@@ -42,10 +42,8 @@ namespace BinOps {
   static_assert(1 + A == 14.0k);
   static_assert((A + A) == 26);
 
-  /// FIXME: Conversion between fixed point semantics.
-  static_assert(A + 100000 == 14.0k); // expected-error {{static assertion failed}} \
-                                      // ref-error {{is not an integral constant expression}} \
-                                      // ref-note {{is outside the range of representable values}}
+  static_assert(A + 100000 == 14.0k); // both-error {{is not an integral constant expression}} \
+                                      // both-note {{is outside the range of representable values}}
 }
 
 namespace FixedPointCasts {


### PR DESCRIPTION
... after a binary operation. The Result of the operation is in the common semantics of RHS and LHS, so we need to convert that to the semantics of the BinaryOperator expression.