### PR TITLE
[mlir][LLVMIR] Add LLVMDialect check in `DIScopeForLLVMFuncOp`

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
@@ -91,6 +91,10 @@ struct DIScopeForLLVMFuncOp
     Location loc = module.getLoc();
 
     MLIRContext *context = &getContext();
+    if (!context->getLoadedDialect<LLVM::LLVMDialect>()) {
+      emitError(loc, "LLVM dialect is not loaded.");
+      return signalPassFailure();
+    }
 
     // To find a DICompileUnitAttr attached to a parent (the module for
     // example), otherwise create a default one.


### PR DESCRIPTION
This PR adds an LLVMDialect check in `DIScopeForLLVMFuncOp` to prevent crashes. Fixes #108390.