### PR TITLE
[VPlan] Add legal checks in VPWidenMemoryRecipe::computeCost(). NFC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2237,6 +2237,11 @@ InstructionCost VPWidenMemoryRecipe::computeCost(ElementCount VF,
     const Value *Ptr = getLoadStorePointerOperand(&Ingredient);
     assert(!Reverse &&
            "Inconsecutive memory access should not have the order.");
+    if ((isa<LoadInst>(Ingredient) &&
+         !Ctx.TTI.isLegalMaskedGather(Ty, Alignment)) ||
+        (isa<StoreInst>(Ingredient) &&
+         !Ctx.TTI.isLegalMaskedScatter(Ty, Alignment)))
+      return InstructionCost::getInvalid();
     return Ctx.TTI.getAddressComputationCost(Ty) +
            Ctx.TTI.getGatherScatterOpCost(Ingredient.getOpcode(), Ty, Ptr,
                                           IsMasked, Alignment, CostKind,


### PR DESCRIPTION
Add legal checks in the vplan-based cost model that align to the legacy cost model (setCostBasedWideningDecision()).

This is patch is not quite a NFC patch but currently we don't have a target that support `ActiveVectorLength && ScalableVector` but not support `gather/scatter` nor return a valid cost by `TTI.getGatherScatterOpCost`.

Fixing the gap can prevent potentail failure in the future.