### PR TITLE
Include <cstdlib> in Toy Lexer examples.

### DIFF
--- a/mlir/examples/toy/Ch1/include/toy/Lexer.h
+++ b/mlir/examples/toy/Ch1/include/toy/Lexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 

--- a/mlir/examples/toy/Ch2/include/toy/Lexer.h
+++ b/mlir/examples/toy/Ch2/include/toy/Lexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 

--- a/mlir/examples/toy/Ch3/include/toy/Lexer.h
+++ b/mlir/examples/toy/Ch3/include/toy/Lexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 

--- a/mlir/examples/toy/Ch4/include/toy/Lexer.h
+++ b/mlir/examples/toy/Ch4/include/toy/Lexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 

--- a/mlir/examples/toy/Ch5/include/toy/Lexer.h
+++ b/mlir/examples/toy/Ch5/include/toy/Lexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 

--- a/mlir/examples/toy/Ch6/include/toy/Lexer.h
+++ b/mlir/examples/toy/Ch6/include/toy/Lexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 

--- a/mlir/examples/toy/Ch7/include/toy/Lexer.h
+++ b/mlir/examples/toy/Ch7/include/toy/Lexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
These files all use `strtod` - make sure to include a proper header for this function. Otherwise, building MLIR fails on some systems after the recent commit 1b5f6916199ce09244cdb52c6911f2028e6ca95a which removed inclusion of `<cmath>` and thus broke transitive inclusion of `<stdlib.h>` in these headers.