### PR TITLE
[RISCV] Fix incorrect calculation of stack size used by the libcall with the ABI ilp32e and lp64e.

### DIFF
--- a/llvm/test/CodeGen/RISCV/calling-conv-ilp32e.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-ilp32e.ll
@@ -54,15 +54,15 @@ define i32 @callee_float_in_regs(i32 %a, float %b) {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: callee_float_in_regs:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv s0, a0
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a0, a1
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call __fixsfsi
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    add a0, s0, a0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_float_in_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
@@ -117,26 +117,26 @@ define i32 @caller_float_in_regs() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_float_in_regs:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 4
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    lui a1, 262144
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_float_in_regs
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_float_in_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lui a1, 262144
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_float_in_regs
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_float_in_regs(i32 1, float 2.0)
   ret i32 %1
 }
@@ -176,16 +176,16 @@ define i32 @callee_float_on_stack(i64 %a, i64 %b, i64 %c, i64 %d, float %e) {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_float_on_stack:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 8(s0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 0(s0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a1, a0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = trunc i64 %d to i32
   %2 = bitcast float %e to i32
   %3 = add i32 %1, %2
@@ -244,9 +244,9 @@ define i32 @caller_float_on_stack() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_float_on_stack:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -12
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 16
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 24
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    lui a0, 264704
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 8(sp)
@@ -261,16 +261,16 @@ define i32 @caller_float_on_stack() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a5, 0
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_float_on_stack
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 12
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_float_on_stack:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -12
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 20
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 24
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 20
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 24
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lui a0, 264704
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 8(sp)
@@ -285,7 +285,7 @@ define i32 @caller_float_on_stack() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a5, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_float_on_stack
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 12
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_float_on_stack(i64 1, i64 2, i64 3, i64 4, float 5.0)
   ret i32 %1
 }
@@ -319,14 +319,14 @@ define float @callee_tiny_scalar_ret() {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_tiny_scalar_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lui a0, 260096
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   ret float 1.0
 }
 
@@ -360,22 +360,22 @@ define i32 @caller_tiny_scalar_ret() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_tiny_scalar_ret:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 4
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_tiny_scalar_ret
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_tiny_scalar_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_tiny_scalar_ret
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call float @callee_tiny_scalar_ret()
   %2 = bitcast float %1 to i32
   ret i32 %2
@@ -428,8 +428,8 @@ define i32 @callee_double_in_regs(i32 %a, double %b) {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: callee_double_in_regs:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv s0, a0
@@ -437,7 +437,7 @@ define i32 @callee_double_in_regs(i32 %a, double %b) {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a1, a2
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call __fixdfsi
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    add a0, s0, a0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_double_in_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
@@ -495,28 +495,28 @@ define i32 @caller_double_in_regs() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_double_in_regs:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 4
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    lui a2, 262144
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a1, 0
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_double_in_regs
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_double_in_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lui a2, 262144
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_double_in_regs
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_double_in_regs(i32 1, double 2.0)
   ret i32 %1
 }
@@ -584,11 +584,11 @@ define i32 @callee_aligned_stack(i32 %a, i32 %b, fp128 %c, i32 %d, i32 %e, i64 %
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_aligned_stack:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 0(a2)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 12(s0)
@@ -601,7 +601,7 @@ define i32 @callee_aligned_stack(i32 %a, i32 %b, fp128 %c, i32 %d, i32 %e, i64 %
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a4, a5, a4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a4
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = bitcast fp128 %c to i128
   %2 = trunc i128 %1 to i32
   %3 = add i32 %2, %g
@@ -730,8 +730,8 @@ define void @caller_aligned_stack() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_aligned_stack:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -56
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -52
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 64
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -777,13 +777,13 @@ define void @caller_aligned_stack() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a6, 32(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_aligned_stack
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -64
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 56
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 52
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_aligned_stack:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -56
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -52
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 64
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -829,8 +829,8 @@ define void @caller_aligned_stack() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a6, 32(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_aligned_stack
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -64
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 56
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 52
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_aligned_stack(i32 1, i32 11,
     fp128 0xLEB851EB851EB851F400091EB851EB851, i32 12, i32 13,
     i64 20000000000, i32 14, i32 15, double 2.720000e+00, i32 16,
@@ -870,15 +870,15 @@ define double @callee_small_scalar_ret() {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_small_scalar_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lui a1, 261888
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   ret double 1.0
 }
 
@@ -912,22 +912,22 @@ define i64 @caller_small_scalar_ret() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_small_scalar_ret:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 4
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_small_scalar_ret
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_small_scalar_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_small_scalar_ret
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call double @callee_small_scalar_ret()
   %2 = bitcast double %1 to i64
   ret i64 %2
@@ -965,14 +965,14 @@ define i32 @callee_i64_in_regs(i32 %a, i64 %b) {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_i64_in_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %b_trunc = trunc i64 %b to i32
   %1 = add i32 %a, %b_trunc
   ret i32 %1
@@ -1014,28 +1014,28 @@ define i32 @caller_i64_in_regs() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_i64_in_regs:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 4
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a2, 0
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_i64_in_regs
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_i64_in_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a2, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_i64_in_regs
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_i64_in_regs(i32 1, i64 2)
   ret i32 %1
 }
@@ -1119,11 +1119,11 @@ define i32 @callee_many_scalars(i8 %a, i16 %b, i32 %c, i64 %d, i32 %e, i32 %f, i
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_many_scalars:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a6, 12(s0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a7, 0(s0)
@@ -1142,7 +1142,7 @@ define i32 @callee_many_scalars(i8 %a, i16 %b, i32 %c, i64 %d, i32 %e, i32 %f, i
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a7
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a6
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a1, a0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %a_ext = zext i8 %a to i32
   %b_ext = zext i16 %b to i32
   %1 = add i32 %a_ext, %b_ext
@@ -1212,9 +1212,9 @@ define i32 @caller_many_scalars() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_many_scalars:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -16
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 20
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 28
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 8
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 12(sp)
@@ -1231,16 +1231,16 @@ define i32 @caller_many_scalars() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a4, 0
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_many_scalars
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 16
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_many_scalars:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -16
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 28
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 28
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 12(sp)
@@ -1257,7 +1257,7 @@ define i32 @caller_many_scalars() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a4, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_many_scalars
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 16
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_many_scalars(i8 1, i16 2, i32 3, i64 4, i32 5, i32 6, i64 7, i32 8)
   ret i32 %1
 }
@@ -1338,11 +1338,11 @@ define i32 @callee_large_scalars(i128 %a, fp128 %b) {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_large_scalars:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a2, 0(a1)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a3, 0(a0)
@@ -1360,7 +1360,7 @@ define i32 @callee_large_scalars(i128 %a, fp128 %b) {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    or a0, a2, a0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    or a0, a0, a4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    seqz a0, a0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %b_bitcast = bitcast fp128 %b to i128
   %1 = icmp eq i128 %a, %b_bitcast
   %2 = zext i1 %1 to i32
@@ -1430,8 +1430,8 @@ define i32 @caller_large_scalars() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_large_scalars:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -40
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -36
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 48
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -1443,22 +1443,22 @@ define i32 @caller_large_scalars() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 8(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 4(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 0(sp)
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 36(sp)
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 32(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 28(sp)
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 24(sp)
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 20(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a2, 1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi a0, sp, 24
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi a0, sp, 16
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a1, sp
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a2, 24(sp)
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a2, 16(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_large_scalars
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -48
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 40
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 36
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_large_scalars:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -40
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -36
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 48
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -1470,17 +1470,17 @@ define i32 @caller_large_scalars() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 8(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 4(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 0(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 36(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 32(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 28(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 24(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 20(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a2, 1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, sp, 24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, sp, 16
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    mv a1, sp
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, 24(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, 16(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_large_scalars
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -48
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 40
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 36
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_large_scalars(i128 1, fp128 0xL00000000000000007FFF000000000000)
   ret i32 %1
 }
@@ -1569,11 +1569,11 @@ define i32 @callee_large_scalars_exhausted_regs(i32 %a, i32 %b, i32 %c, i32 %d, 
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_large_scalars_exhausted_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 12(s0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 4(s0)
@@ -1593,7 +1593,7 @@ define i32 @callee_large_scalars_exhausted_regs(i32 %a, i32 %b, i32 %c, i32 %d, 
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    or a0, a2, a0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    or a0, a0, a4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    seqz a0, a0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %j_bitcast = bitcast fp128 %j to i128
   %1 = icmp eq i128 %h, %j_bitcast
   %2 = zext i1 %1 to i32
@@ -1687,8 +1687,8 @@ define i32 @caller_large_scalars_exhausted_regs() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_large_scalars_exhausted_regs:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -56
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -52
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 64
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -1699,7 +1699,7 @@ define i32 @caller_large_scalars_exhausted_regs() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 12(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 9
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 8(sp)
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi a0, sp, 40
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi a0, sp, 32
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 4(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 7
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 0(sp)
@@ -1708,26 +1708,26 @@ define i32 @caller_large_scalars_exhausted_regs() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 24(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 20(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 16(sp)
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 52(sp)
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 48(sp)
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 44(sp)
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 40(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 8
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 40(sp)
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 32(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a2, 3
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a3, 4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a4, 5
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a5, 6
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 44(sp)
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw zero, 36(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_large_scalars_exhausted_regs
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -64
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 56
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 52
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_large_scalars_exhausted_regs:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -56
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -52
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 64
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -1738,7 +1738,7 @@ define i32 @caller_large_scalars_exhausted_regs() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 12(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 9
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 8(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, sp, 40
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, sp, 32
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 4(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 7
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 0(sp)
@@ -1747,21 +1747,21 @@ define i32 @caller_large_scalars_exhausted_regs() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 24(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 20(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 16(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 52(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 48(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 44(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 40(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 40(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 32(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a2, 3
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a3, 4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a4, 5
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a5, 6
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 44(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 36(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_large_scalars_exhausted_regs
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -64
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 56
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 52
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_large_scalars_exhausted_regs(
       i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i128 8, i32 9,
       fp128 0xL00000000000000007FFF000000000000)
@@ -1817,12 +1817,12 @@ define i32 @caller_mixed_scalar_libcalls(i64 %a) {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_mixed_scalar_libcalls:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -16
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 24
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -20
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 32
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi s0, sp, 24
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi s0, sp, 32
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    andi sp, sp, -8
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a2, a1
@@ -1830,18 +1830,18 @@ define i32 @caller_mixed_scalar_libcalls(i64 %a) {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a0, sp
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call __floatditf
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    lw a0, 0(sp)
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -24
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 16
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -32
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 20
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_mixed_scalar_libcalls:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -16
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -20
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 32
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 32
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    andi sp, sp, -8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    mv a2, a1
@@ -1849,9 +1849,9 @@ define i32 @caller_mixed_scalar_libcalls(i64 %a) {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    mv a0, sp
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call __floatditf
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 0(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -24
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 16
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -32
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 20
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = sitofp i64 %a to fp128
   %2 = bitcast fp128 %1 to i128
   %3 = trunc i128 %2 to i32
@@ -1895,15 +1895,15 @@ define i32 @callee_small_coerced_struct([2 x i32] %a.coerce) {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_small_coerced_struct:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    xor a0, a0, a1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    seqz a0, a0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = extractvalue [2 x i32] %a.coerce, 0
   %2 = extractvalue [2 x i32] %a.coerce, 1
   %3 = icmp eq i32 %1, %2
@@ -1945,26 +1945,26 @@ define i32 @caller_small_coerced_struct() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_small_coerced_struct:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 4
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_small_coerced_struct
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_small_coerced_struct:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_small_coerced_struct
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call i32 @callee_small_coerced_struct([2 x i32] [i32 1, i32 2])
   ret i32 %1
 }
@@ -2008,16 +2008,16 @@ define i32 @callee_large_struct(ptr byval(%struct.large) align 4 %a) {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_large_struct:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 0(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 12(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a1, a0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = getelementptr inbounds %struct.large, ptr %a, i32 0, i32 0
   %2 = getelementptr inbounds %struct.large, ptr %a, i32 0, i32 3
   %3 = load i32, ptr %1
@@ -2082,9 +2082,9 @@ define i32 @caller_large_struct() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_large_struct:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -32
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 36
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 44
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    sw a0, 16(sp)
@@ -2101,33 +2101,33 @@ define i32 @caller_large_struct() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a0, sp
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_large_struct
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 32
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_large_struct:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -32
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 40
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 44
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 40
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 44
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, -24(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, -28(s0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 2
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, -20(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, -24(s0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a2, 3
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, -16(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, -20(s0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a3, 4
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, -12(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, -40(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, -36(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, -32(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, -28(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, s0, -40
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, -16(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, -44(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, -40(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, -36(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, -32(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, s0, -44
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_large_struct
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 32
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %ls = alloca %struct.large, align 4
   %1 = bitcast ptr %ls to ptr
   %a = getelementptr inbounds %struct.large, ptr %ls, i32 0, i32 0
@@ -2176,15 +2176,15 @@ define %struct.small @callee_small_struct_ret() {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_small_struct_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a0, 1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   ret %struct.small { i32 1, ptr null }
 }
 
@@ -2220,24 +2220,24 @@ define i32 @caller_small_struct_ret() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_small_struct_ret:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_0
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 4
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_small_struct_ret
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    add a0, a0, a1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_0
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_small_struct_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_small_struct_ret
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call %struct.small @callee_small_struct_ret()
   %2 = extractvalue %struct.small %1, 0
   %3 = extractvalue %struct.small %1, 1
@@ -2289,18 +2289,18 @@ define fp128 @callee_large_scalar_ret() {
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_large_scalar_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lui a1, 524272
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 12(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 8(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 4(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw zero, 0(a0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   ret fp128 0xL00000000000000007FFF000000000000
 }
 
@@ -2345,8 +2345,8 @@ define void @caller_large_scalar_ret() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_large_scalar_ret:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -24
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -20
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 32
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -2356,13 +2356,13 @@ define void @caller_large_scalar_ret() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a0, sp
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call callee_large_scalar_ret
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -32
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 24
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 20
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_large_scalar_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -20
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 32
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
@@ -2372,8 +2372,8 @@ define void @caller_large_scalar_ret() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    mv a0, sp
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_large_scalar_ret
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -32
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 24
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 20
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = call fp128 @callee_large_scalar_ret()
   ret void
 }
@@ -2430,11 +2430,11 @@ define void @callee_large_struct_ret(ptr noalias sret(%struct.large) %agg.result
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: callee_large_struct_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 0(a0)
@@ -2444,7 +2444,7 @@ define void @callee_large_struct_ret(ptr noalias sret(%struct.large) %agg.result
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 8(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 12(a0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %a = getelementptr inbounds %struct.large, ptr %agg.result, i32 0, i32 0
   store i32 1, ptr %a, align 4
   %b = getelementptr inbounds %struct.large, ptr %agg.result, i32 0, i32 1
@@ -2503,12 +2503,12 @@ define i32 @caller_large_struct_ret() {
 ;
 ; ILP32E-FPELIM-SAVE-RESTORE-LABEL: caller_large_struct_ret:
 ; ILP32E-FPELIM-SAVE-RESTORE:       # %bb.0:
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -16
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 24
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, -20
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 32
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi s0, sp, 24
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi s0, sp, 32
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    andi sp, sp, -8
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    mv a0, sp
@@ -2516,18 +2516,18 @@ define i32 @caller_large_struct_ret() {
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    lw a0, 0(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    lw a1, 12(sp)
 ; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    add a0, a0, a1
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -24
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 16
-; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, s0, -32
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    addi sp, sp, 20
+; ILP32E-FPELIM-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
 ;
 ; ILP32E-WITHFP-SAVE-RESTORE-LABEL: caller_large_struct_ret:
 ; ILP32E-WITHFP-SAVE-RESTORE:       # %bb.0:
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -16
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call t0, __riscv_save_2
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, -20
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa_offset 32
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset ra, -4
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 24
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 32
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    andi sp, sp, -8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    mv a0, sp
@@ -2535,9 +2535,9 @@ define i32 @caller_large_struct_ret() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 0(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 12(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a1
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -24
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 16
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, s0, -32
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 20
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_2
   %1 = alloca %struct.large
   call void @callee_large_struct_ret(ptr sret(%struct.large) %1)
   %2 = getelementptr inbounds %struct.large, ptr %1, i32 0, i32 0


### PR DESCRIPTION
The purpose of this patch is to fix incorrect calculation of stack size used by the libcall with the ABI ilp32e and lp64e. It's always 12 bytes for ilp32e and 24 bytes for lp64e.