### PR TITLE
[clang][analyzer] Less redundant warnings from FixedAddressChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/FixedAddressChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/FixedAddressChecker.cpp
@@ -43,9 +43,9 @@ void FixedAddressChecker::checkPreStmt(const BinaryOperator *B,
   if (!T->isPointerType())
     return;
 
-  // Omit warning if the RHS has already pointer type.
-  // The value may come from a variable and is candidate for a previous warning
-  // from the checker.
+  // Omit warning if the RHS has already pointer type. Without this passing
+  // around one fixed value in several pointer variables would produce several
+  // redundant warnings.
   if (B->getRHS()->IgnoreParenCasts()->getType()->isPointerType())
     return;
 

--- a/clang/lib/StaticAnalyzer/Checkers/FixedAddressChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/FixedAddressChecker.cpp
@@ -43,6 +43,12 @@ void FixedAddressChecker::checkPreStmt(const BinaryOperator *B,
   if (!T->isPointerType())
     return;
 
+  // Omit warning if the RHS has already pointer type.
+  // The value may come from a variable and is candidate for a previous warning
+  // from the checker.
+  if (B->getRHS()->IgnoreParenCasts()->getType()->isPointerType())
+    return;
+
   SVal RV = C.getSVal(B->getRHS());
 
   if (!RV.isConstant() || RV.isZeroConstant())

--- a/clang/test/Analysis/ptr-arith.c
+++ b/clang/test/Analysis/ptr-arith.c
@@ -42,6 +42,10 @@ domain_port (const char *domain_b, const char *domain_e,
 void f4(void) {
   int *p;
   p = (int*) 0x10000; // expected-warning{{Using a fixed address is not portable because that address will probably not be valid in all environments or platforms}}
+
+  int *p1;
+  p1 = p; // no warning
+
   long x = 0x10100;
   x += 10;
   p = (int*) x; // expected-warning{{Using a fixed address is not portable because that address will probably not be valid in all environments or platforms}}


### PR DESCRIPTION
If a fixed value is assigned to a pointer variable, the checker did emit a warning. If the pointer variable is assigned to another pointer variable, this resulted in another warning. The checker now emits warning only if a value with non-pointer type is assigned (to a pointer variable).