### PR TITLE
[ThinLTO][NFC] Refactor FileCache

### DIFF
--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -298,7 +298,7 @@ public:
   ///
   /// The client will receive at most one callback (via either AddStream or
   /// Cache) for each task identifier.
-  Error run(AddStreamFn AddStream, FileCache Cache = nullptr);
+  Error run(AddStreamFn AddStream, FileCache Cache = {});
 
   /// Static method that returns a list of libcall symbols that can be generated
   /// by LTO but might not be visible from bitcode symbol table.

--- a/llvm/include/llvm/Support/Caching.h
+++ b/llvm/include/llvm/Support/Caching.h
@@ -41,22 +41,29 @@ public:
 using AddStreamFn = std::function<Expected<std::unique_ptr<CachedFileStream>>(
     unsigned Task, const Twine &ModuleName)>;
 
-/// This is the type of a file cache. To request an item from the cache, pass a
-/// unique string as the Key. For hits, the cached file will be added to the
-/// link and this function will return AddStreamFn(). For misses, the cache will
-/// return a stream callback which must be called at most once to produce
-/// content for the stream. The file stream produced by the stream callback will
-/// add the file to the link after the stream is written to. ModuleName is the
-/// unique module identifier for the bitcode module the cache is being checked
-/// for.
+/// This is a callable that manages file caching operations. It accepts a task
+/// ID \p Task, a unique key \p Key, and a module name \p ModuleName, and
+/// returns AddStreamFn(). This function determines whether a cache hit or miss
+/// occurs and handles the appropriate actions.
+using FileCacheFunction = std::function<Expected<AddStreamFn>(
+    unsigned Task, StringRef Key, const Twine &ModuleName)>;
+
+/// This type represents a file cache system that manages caching of files.
+/// It encapsulates a caching function and the directory path where the cache is
+/// stored. To request an item from the cache, pass a unique string as the Key.
+/// For hits, the cached file will be added to the link and this function will
+/// return AddStreamFn(). For misses, the cache will return a stream callback
+/// which must be called at most once to produce content for the stream. The
+/// file stream produced by the stream callback will add the file to the link
+/// after the stream is written to. ModuleName is the unique module identifier
+/// for the bitcode module the cache is being checked for.
 ///
 /// Clients generally look like this:
 ///
 /// if (AddStreamFn AddStream = Cache(Task, Key, ModuleName))
 ///   ProduceContent(AddStream);
-using FileCacheFunction = std::function<Expected<AddStreamFn>(
-    unsigned Task, StringRef Key, const Twine &ModuleName)>;
-
+///
+/// CacheDirectoryPath stores the directory path where cached files are kept.
 struct FileCache {
   FileCache(FileCacheFunction CacheFn, const std::string &DirectoryPath)
       : CacheFunction(std::move(CacheFn)), CacheDirectoryPath(DirectoryPath) {}

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1483,7 +1483,7 @@ public:
         return E;
     }
 
-    if (!Cache || !CombinedIndex.modulePaths().count(ModuleID) ||
+    if (!Cache.isValid() || !CombinedIndex.modulePaths().count(ModuleID) ||
         all_of(CombinedIndex.getModuleHash(ModuleID),
                [](uint32_t V) { return V == 0; }))
       // Cache disabled or no entry for this module in the combined index or

--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -37,8 +37,8 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
   TempFilePrefixRef.toVector(TempFilePrefix);
   CacheDirectoryPathRef.toVector(CacheDirectoryPath);
 
-  return [=](unsigned Task, StringRef Key,
-             const Twine &ModuleName) -> Expected<AddStreamFn> {
+  auto Func = [=](unsigned Task, StringRef Key,
+                  const Twine &ModuleName) -> Expected<AddStreamFn> {
     // This choice of file name allows the cache to be pruned (see pruneCache()
     // in include/llvm/Support/CachePruning.h).
     SmallString<64> EntryPath;
@@ -167,4 +167,5 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
           Task);
     };
   };
+  return FileCache(Func, CacheDirectoryPathRef.str());
 }


### PR DESCRIPTION
This is a prep for https://github.com/llvm/llvm-project/pull/90933.
 
  - Change `FileCache` from a function to a type.
  - Store the cache directory in the type, which will be used when creating additional caches for two-codegen round runs that inherit this value.
