### PR TITLE
[mlir][doc][SPIR-V] Add missing `>`

### DIFF
--- a/mlir/docs/Dialects/SPIR-V.md
+++ b/mlir/docs/Dialects/SPIR-V.md
@@ -388,7 +388,7 @@ This corresponds to SPIR-V [struct type][StructType]. Its syntax is
 ```
 struct-member-decoration ::= integer-literal? spirv-decoration*
 struct-type ::= `!spirv.struct<` spirv-type (`[` struct-member-decoration `]`)?
-                     (`, ` spirv-type (`[` struct-member-decoration `]`)?
+                     (`, ` spirv-type (`[` struct-member-decoration `]`)? `>`
 ```
 
 For Example,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c3a8761f-647f-4a52-a68c-06a4cb543924)

If I'm not mistaken, there should be a right bracket here?