### PR TITLE
[LLDB] Fix symbol breakpoint lookups for non-C-like languages

### DIFF
--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "lldb/Core/Highlighter.h"
+#include "lldb/Core/Module.h"
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/DataFormatters/DumpValueObjectOptions.h"
 #include "lldb/DataFormatters/FormatClasses.h"
@@ -378,6 +379,21 @@ public:
   /// Returns the keyword used for catch statements in this language, e.g.
   /// Python uses \b except. Defaults to \b catch.
   virtual llvm::StringRef GetCatchKeyword() const { return "catch"; }
+
+  /// Method invoked by \a Module::LookupInfo::Prune used to filter out symbol
+  /// search results.
+  ///
+  /// \param[in] sc A symbol that passed the common symbol search lookup
+  ///   process.
+  /// \param[in] lookup_info The full lookup info.
+  ///
+  /// \return whether the given symbol should be discarded from the search
+  /// results.
+  virtual bool
+  SymbolLookupHookShouldPruneResult(const SymbolContext &sc,
+                                    const Module::LookupInfo &lookup_info) {
+    return false;
+  }
 
 protected:
   // Classes that inherit from Language can see and modify these

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -121,6 +121,9 @@ public:
 
   const Highlighter *GetHighlighter() const override { return &m_highlighter; }
 
+  bool SymbolLookupHookShouldPruneResult(
+      const SymbolContext &sc, const Module::LookupInfo &lookup_info) override;
+
   // Static Functions
   static void Initialize();
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
@@ -59,7 +59,8 @@ bool DWARFIndex::ProcessFunctionDIE(
     return true;
 
   // In case of a full match, we just insert everything we find.
-  if (name_type_mask & eFunctionNameTypeFull && die.GetMangledName() == name)
+  if (name_type_mask & eFunctionNameTypeFull &&
+      (die.GetMangledName() == name || die.GetName() == name))
     return callback(die);
 
   // If looking for ObjC selectors, we need to also check if the name is a


### PR DESCRIPTION
I'm developing the Mojo language, and some symbol breakpoints don't work because of two reasons that this PR fixes:

- There's a prune step that operates on the assuption that the symbol is C-like. That was discarding lots of the Mojo breakpoints
- When finding functions for symbol breakpoints with eFunctionNameTypeFull, LLDB was only matching die.getMangledName() and not die.GetName(). The latter is the one useful for Mojo, because the former has some unreadable format in Mojo that is not exposed to the user. This shouldn't cause any regression for C-like languages, as the prune step would sanitize them anyway, but it's useful for languages like Mojo.