### PR TITLE
[lldb] Symlink Python binding to fully soversioned library

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -137,7 +137,7 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
   if(LLDB_BUILD_FRAMEWORK)
     set(LIBLLDB_SYMLINK_DEST "${LLDB_FRAMEWORK_ABSOLUTE_BUILD_DIR}/LLDB.framework/LLDB")
   else()
-    set(LIBLLDB_SYMLINK_DEST "${LLVM_SHLIB_OUTPUT_INTDIR}/liblldb${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(LIBLLDB_SYMLINK_DEST "${LLVM_SHLIB_OUTPUT_INTDIR}/liblldb${CMAKE_SHARED_LIBRARY_SUFFIX}.${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}")
   endif()
   set(LIBLLDB_SYMLINK_OUTPUT_FILE "_lldb${LLDB_PYTHON_EXT_SUFFIX}")
   create_relative_symlink(${swig_target} ${LIBLLDB_SYMLINK_DEST}


### PR DESCRIPTION
In Debian packaging the soversionless library is typically put into a -dev package and links to the current soversion things should be built against.  
This means that installing the bindings requires unnecessarily installing the -dev package in addition to the library package itself.  
There's no downside to linking to the full soversion since I don't think liblldb and the bindings are compatible across major versions anyway.