### PR TITLE
[TableGen] Change TableGenMain to use const RecordKeeper

### DIFF
--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -317,7 +317,7 @@ ClangComponent("clang-component",
                cl::desc("Only use warnings from specified component"),
                cl::value_desc("component"), cl::Hidden);
 
-bool ClangTableGenMain(raw_ostream &OS, RecordKeeper &Records) {
+bool ClangTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
   switch (Action) {
   case PrintRecords:
     OS << Records;           // No argument, dump all contents

--- a/llvm/include/llvm/TableGen/Main.h
+++ b/llvm/include/llvm/TableGen/Main.h
@@ -22,7 +22,7 @@ class RecordKeeper;
 
 /// Perform the action using Records, and write output to OS.
 /// Returns true on error, false otherwise.
-using TableGenMainFn = bool (raw_ostream &OS, RecordKeeper &Records);
+using TableGenMainFn = bool(raw_ostream &OS, const RecordKeeper &Records);
 
 int TableGenMain(const char *argv0,
                  std::function<TableGenMainFn> MainFn = nullptr);

--- a/llvm/lib/TableGen/TableGenBackendSkeleton.cpp
+++ b/llvm/lib/TableGen/TableGenBackendSkeleton.cpp
@@ -1,4 +1,4 @@
-//===- SkeletonEmitter.cpp - Skeleton TableGen backend          -*- C++ -*-===//
+//===- TableGenBackendSkeleton.cpp - Skeleton TableGen backend --*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -29,10 +29,10 @@ namespace {
 
 class SkeletonEmitter {
 private:
-  RecordKeeper &Records;
+  const RecordKeeper &Records;
 
 public:
-  SkeletonEmitter(RecordKeeper &RK) : Records(RK) {}
+  SkeletonEmitter(const RecordKeeper &RK) : Records(RK) {}
 
   void run(raw_ostream &OS);
 }; // emitter class
@@ -55,7 +55,7 @@ static TableGen::Emitter::OptClass<SkeletonEmitter>
 //===----------------------------------------------------------------------===//
 // Option B: Register "EmitSkeleton" directly
 // The emitter entry may be private scope.
-static void EmitSkeleton(RecordKeeper &RK, raw_ostream &OS) {
+static void EmitSkeleton(const RecordKeeper &RK, raw_ostream &OS) {
   // Instantiate the emitter class and invoke run().
   SkeletonEmitter(RK).run(OS);
 }

--- a/mlir/lib/Tools/mlir-tblgen/MlirTblgenMain.cpp
+++ b/mlir/lib/Tools/mlir-tblgen/MlirTblgenMain.cpp
@@ -126,7 +126,7 @@ static const mlir::GenInfo *generator;
 
 // TableGenMain requires a function pointer so this function is passed in which
 // simply wraps the call to the generator.
-static bool mlirTableGenMain(raw_ostream &os, RecordKeeper &records) {
+static bool mlirTableGenMain(raw_ostream &os, const RecordKeeper &records) {
   if (actionOnDeprecatedValue != DeprecatedAction::None)
     warnOfDeprecatedUses(records);
 


### PR DESCRIPTION
Change TableGenMain's `MainFn` argument to be a function that accepts a const reference to RecordKeeper.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089

