### PR TITLE
[LLDB][Minidump] Fix bug where we were using the wrong collection for thread stacks

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -853,7 +853,7 @@ Status MinidumpFileBuilder::AddMemoryList() {
   uint64_t total_size = GetCurrentDataEndOffset();
   auto iterator = all_core_memory_vec.begin();
   while (iterator != all_core_memory_vec.end()) {
-    if (m_saved_stack_ranges.count(iterator->range.start()) > 0) {
+    if (m_thread_by_range_end.count(iterator->range.end()) > 0) {
       // We don't save stacks twice.
       ranges_32.push_back(*iterator);
       total_size +=

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -172,7 +172,6 @@ private:
   // to duplicate it in the exception data.
   std::unordered_map<lldb::tid_t, llvm::minidump::LocationDescriptor>
       m_tid_to_reg_ctx;
-  std::unordered_set<lldb::addr_t> m_saved_stack_ranges;
   lldb::FileUP m_core_file;
   lldb_private::SaveCoreOptions m_save_core_options;
 };


### PR DESCRIPTION
In my prior two save core API's, I experimented on how to save stacks with the new API. I incorrectly left these in, as the existing `m_thread_by_range_end` was the correct choice.

I have removed the no-op collection, and moved to use the proper one. It's worth noting this was not caught by testing because we do not verify where the items are contained in the minidump. This would require a test being aware of how minidumps are structured, or adding a textual tool that we can then scan the output of.