### PR TITLE
Revert "[libc++] LWG3870: Remove `voidify` (#110355)"

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -296,7 +296,7 @@
 "`LWG3862 <https://wg21.link/LWG3862>`__","``basic_const_iterator``'s ``common_type`` specialization is underconstrained","2023-02 (Issaquah)","","",""
 "`LWG3865 <https://wg21.link/LWG3865>`__","Sorting a range of ``pairs``","2023-02 (Issaquah)","|Complete|","17.0",""
 "`LWG3869 <https://wg21.link/LWG3869>`__","Deprecate ``std::errc`` constants related to UNIX STREAMS","2023-02 (Issaquah)","|Complete|","19.0",""
-"`LWG3870 <https://wg21.link/LWG3870>`__","Remove ``voidify``","2023-02 (Issaquah)","|Complete|","20.0",""
+"`LWG3870 <https://wg21.link/LWG3870>`__","Remove ``voidify``","2023-02 (Issaquah)","","",""
 "`LWG3871 <https://wg21.link/LWG3871>`__","Adjust note about ``terminate``","2023-02 (Issaquah)","","",""
 "`LWG3872 <https://wg21.link/LWG3872>`__","``basic_const_iterator`` should have custom ``iter_move``","2023-02 (Issaquah)","","",""
 "`LWG3875 <https://wg21.link/LWG3875>`__","``std::ranges::repeat_view<T, IntegerClass>::iterator`` may be ill-formed","2023-02 (Issaquah)","|Complete|","17.0",""

--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -560,6 +560,7 @@ set(files
   __memory/unique_temporary_buffer.h
   __memory/uses_allocator.h
   __memory/uses_allocator_construction.h
+  __memory/voidify.h
   __memory_resource/memory_resource.h
   __memory_resource/monotonic_buffer_resource.h
   __memory_resource/polymorphic_allocator.h

--- a/libcxx/include/__memory/construct_at.h
+++ b/libcxx/include/__memory/construct_at.h
@@ -14,6 +14,7 @@
 #include <__config>
 #include <__iterator/access.h>
 #include <__memory/addressof.h>
+#include <__memory/voidify.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_array.h>
 #include <__utility/declval.h>
@@ -37,7 +38,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp, class... _Args, class = decltype(::new(std::declval<void*>()) _Tp(std::declval<_Args>()...))>
 _LIBCPP_HIDE_FROM_ABI constexpr _Tp* construct_at(_Tp* __location, _Args&&... __args) {
   _LIBCPP_ASSERT_NON_NULL(__location != nullptr, "null pointer given to construct_at");
-  return ::new (static_cast<void*>(__location)) _Tp(std::forward<_Args>(__args)...);
+  return ::new (std::__voidify(*__location)) _Tp(std::forward<_Args>(__args)...);
 }
 
 #endif
@@ -48,7 +49,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Tp* __construct_at(_Tp* __l
   return std::construct_at(__location, std::forward<_Args>(__args)...);
 #else
   return _LIBCPP_ASSERT_NON_NULL(__location != nullptr, "null pointer given to construct_at"),
-         ::new (static_cast<void*>(__location)) _Tp(std::forward<_Args>(__args)...);
+         ::new (std::__voidify(*__location)) _Tp(std::forward<_Args>(__args)...);
 #endif
 }
 

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -21,6 +21,7 @@
 #include <__memory/allocator_traits.h>
 #include <__memory/construct_at.h>
 #include <__memory/pointer_traits.h>
+#include <__memory/voidify.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/extent.h>
 #include <__type_traits/is_array.h>
@@ -63,7 +64,7 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
   try {
 #endif
     for (; __ifirst != __ilast && !__stop_copying(__idx); ++__ifirst, (void)++__idx)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(*__ifirst);
+      ::new (std::__voidify(*__idx)) _ValueType(*__ifirst);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__ofirst, __idx);
@@ -93,7 +94,7 @@ __uninitialized_copy_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __of
   try {
 #endif
     for (; __n > 0 && !__stop_copying(__idx); ++__ifirst, (void)++__idx, (void)--__n)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(*__ifirst);
+      ::new (std::__voidify(*__idx)) _ValueType(*__ifirst);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__ofirst, __idx);
@@ -123,7 +124,7 @@ __uninitialized_fill(_ForwardIterator __first, _Sentinel __last, const _Tp& __x)
   try {
 #endif
     for (; __idx != __last; ++__idx)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__x);
+      ::new (std::__voidify(*__idx)) _ValueType(__x);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__first, __idx);
@@ -151,7 +152,7 @@ __uninitialized_fill_n(_ForwardIterator __first, _Size __n, const _Tp& __x) {
   try {
 #endif
     for (; __n > 0; ++__idx, (void)--__n)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__x);
+      ::new (std::__voidify(*__idx)) _ValueType(__x);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__first, __idx);
@@ -181,7 +182,7 @@ __uninitialized_default_construct(_ForwardIterator __first, _Sentinel __last) {
   try {
 #  endif
     for (; __idx != __last; ++__idx)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType;
+      ::new (std::__voidify(*__idx)) _ValueType;
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__first, __idx);
@@ -207,7 +208,7 @@ inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator __uninitialized_default_construct_
   try {
 #  endif
     for (; __n > 0; ++__idx, (void)--__n)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType;
+      ::new (std::__voidify(*__idx)) _ValueType;
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__first, __idx);
@@ -234,7 +235,7 @@ __uninitialized_value_construct(_ForwardIterator __first, _Sentinel __last) {
   try {
 #  endif
     for (; __idx != __last; ++__idx)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType();
+      ::new (std::__voidify(*__idx)) _ValueType();
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__first, __idx);
@@ -260,7 +261,7 @@ inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator __uninitialized_value_construct_n(
   try {
 #  endif
     for (; __n > 0; ++__idx, (void)--__n)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType();
+      ::new (std::__voidify(*__idx)) _ValueType();
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__first, __idx);
@@ -296,7 +297,7 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
   try {
 #  endif
     for (; __ifirst != __ilast && !__stop_moving(__idx); ++__idx, (void)++__ifirst) {
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__iter_move(__ifirst));
+      ::new (std::__voidify(*__idx)) _ValueType(__iter_move(__ifirst));
     }
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
@@ -334,7 +335,7 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
   try {
 #  endif
     for (; __n > 0 && !__stop_moving(__idx); ++__idx, (void)++__ifirst, --__n)
-      ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__iter_move(__ifirst));
+      ::new (std::__voidify(*__idx)) _ValueType(__iter_move(__ifirst));
 #  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     std::__destroy(__ofirst, __idx);

--- a/libcxx/include/__memory/voidify.h
+++ b/libcxx/include/__memory/voidify.h
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___MEMORY_VOIDIFY_H
+#define _LIBCPP___MEMORY_VOIDIFY_H
+
+#include <__config>
+#include <__memory/addressof.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <typename _Tp>
+_LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void* __voidify(_Tp& __from) {
+  // Cast away cv-qualifiers to allow modifying elements of a range through const iterators.
+  return const_cast<void*>(static_cast<const volatile void*>(std::addressof(__from)));
+}
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___MEMORY_VOIDIFY_H

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1528,6 +1528,7 @@ module std [system] {
     }
     module uses_allocator                     { header "__memory/uses_allocator.h" }
     module uses_allocator_construction        { header "__memory/uses_allocator_construction.h" }
+    module voidify                            { header "__memory/voidify.h" }
 
     header "memory"
     export *
@@ -2237,5 +2238,3 @@ module std_private_mbstate_t [system] {
   header "__mbstate_t.h"
   export *
 }
-
-module std_private_memory_voidify                         [system] { header "__memory/voidify.h" }

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -2237,3 +2237,5 @@ module std_private_mbstate_t [system] {
   header "__mbstate_t.h"
   export *
 }
+
+module std_private_memory_voidify                         [system] { header "__memory/voidify.h" }

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -287,7 +287,7 @@ struct __optional_destruct_base<_Tp, false> {
   static_assert(is_object_v<value_type>, "instantiation of optional with a non-object type is undefined behavior");
   union {
     char __null_state_;
-    remove_cv_t<value_type> __val_;
+    value_type __val_;
   };
   bool __engaged_;
 
@@ -323,7 +323,7 @@ struct __optional_destruct_base<_Tp, true> {
   static_assert(is_object_v<value_type>, "instantiation of optional with a non-object type is undefined behavior");
   union {
     char __null_state_;
-    remove_cv_t<value_type> __val_;
+    value_type __val_;
   };
   bool __engaged_;
 
@@ -377,7 +377,7 @@ struct __optional_storage_base : __optional_destruct_base<_Tp> {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __assign_from(_That&& __opt) {
     if (this->__engaged_ == __opt.has_value()) {
       if (this->__engaged_)
-        static_cast<_Tp&>(this->__val_) = std::forward<_That>(__opt).__get();
+        this->__val_ = std::forward<_That>(__opt).__get();
     } else {
       if (this->__engaged_)
         this->reset();

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp
@@ -80,6 +80,21 @@ constexpr bool test()
         a.deallocate(p, 2);
     }
 
+    {
+        std::allocator<Counted> a;
+        Counted const* p = a.allocate(2);
+        int count = 0;
+        std::construct_at(p, count);
+        assert(count == 1);
+        std::construct_at(p+1, count);
+        assert(count == 2);
+        (p+1)->~Counted();
+        assert(count == 1);
+        p->~Counted();
+        assert(count == 0);
+        a.deallocate(const_cast<Counted*>(p), 2);
+    }
+
     return true;
 }
 

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/specialized.construct/ranges_construct_at.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/specialized.construct/ranges_construct_at.pass.cpp
@@ -99,6 +99,16 @@ constexpr bool test() {
     alloc.deallocate(out, 2);
   }
 
+  // Works with const pointers.
+  {
+    int x = 1;
+    const int* ptr = &x;
+
+    const int* result = std::ranges::construct_at(ptr, 42);
+    assert(result == ptr);
+    assert(x == 42);
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.default/ranges_uninitialized_default_construct.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.default/ranges_uninitialized_default_construct.pass.cpp
@@ -163,5 +163,30 @@ int main(int, char**) {
   }
 #endif  // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators, (iter, sentinel) overload.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    std::ranges::uninitialized_default_construct(buf.cbegin(), buf.cend());
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
+  // Works with const iterators, (range) overload.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+    auto range = std::ranges::subrange(buf.cbegin(), buf.cend());
+
+    std::ranges::uninitialized_default_construct(range);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.default/ranges_uninitialized_default_construct_n.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.default/ranges_uninitialized_default_construct_n.pass.cpp
@@ -75,5 +75,17 @@ int main(int, char**) {
   }
 #endif  // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    std::ranges::uninitialized_default_construct_n(buf.cbegin(), N);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.value/ranges_uninitialized_value_construct.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.value/ranges_uninitialized_value_construct.pass.cpp
@@ -183,5 +183,30 @@ int main(int, char**) {
   }
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators, (iter, sentinel) overload.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    std::ranges::uninitialized_value_construct(buf.cbegin(), buf.cend());
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
+  // Works with const iterators, (range) overload.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    auto range = std::ranges::subrange(buf.cbegin(), buf.cend());
+    std::ranges::uninitialized_value_construct(range);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.value/ranges_uninitialized_value_construct_n.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.construct.value/ranges_uninitialized_value_construct_n.pass.cpp
@@ -94,5 +94,17 @@ int main(int, char**) {
   }
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    std::ranges::uninitialized_value_construct_n(buf.cbegin(), N);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.copy/ranges_uninitialized_copy.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.copy/ranges_uninitialized_copy.pass.cpp
@@ -278,6 +278,39 @@ int main(int, char**) {
   Counted::reset();
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators, (iter, sentinel) overload.
+  {
+    constexpr int N = 5;
+    Counted in[N] = {Counted(1), Counted(2), Counted(3), Counted(4), Counted(5)};
+    Buffer<Counted, N> out;
+    Counted::reset();
+
+    std::ranges::uninitialized_copy(in, in + N, out.cbegin(), out.cend());
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::equal(in, in + N, out.begin(), out.end()));
+
+    std::destroy(out.begin(), out.end());
+  }
+  Counted::reset();
+
+  // Works with const iterators, (range) overload.
+  {
+    constexpr int N = 5;
+    Counted in[N] = {Counted(1), Counted(2), Counted(3), Counted(4), Counted(5)};
+    Buffer<Counted, N> out;
+    Counted::reset();
+
+    std::ranges::subrange out_range(out.cbegin(), out.cend());
+    std::ranges::uninitialized_copy(in, out_range);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::equal(in, in + N, out.begin(), out.end()));
+
+    std::destroy(out.begin(), out.end());
+  }
+  Counted::reset();
+
   // Conversions, (iter, sentinel) overload.
   {
     constexpr int N = 3;

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.copy/ranges_uninitialized_copy_n.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.copy/ranges_uninitialized_copy_n.pass.cpp
@@ -104,6 +104,22 @@ int main(int, char**) {
 
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators.
+  {
+    constexpr int N = 5;
+    Counted in[N] = {Counted(1), Counted(2), Counted(3), Counted(4), Counted(5)};
+    Buffer<Counted, N> out;
+    Counted::reset();
+
+    std::ranges::uninitialized_copy_n(in, N, out.cbegin(), out.cend());
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::equal(in, in + N, out.begin(), out.end()));
+
+    std::destroy(out.begin(), out.end());
+  }
+  Counted::reset();
+
   // Conversions.
   {
     constexpr int N = 3;

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.fill.n/ranges_uninitialized_fill_n.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.fill.n/ranges_uninitialized_fill_n.pass.cpp
@@ -101,5 +101,19 @@ int main(int, char**) {
   }
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    std::ranges::uninitialized_fill_n(buf.cbegin(), N, x);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::all_of(buf.begin(), buf.end(), pred));
+
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.fill/ranges_uninitialized_fill.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.fill/ranges_uninitialized_fill.pass.cpp
@@ -198,5 +198,34 @@ int main(int, char**) {
   }
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators, (iter, sentinel) overload.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    std::ranges::uninitialized_fill(buf.cbegin(), buf.cend(), x);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::all_of(buf.begin(), buf.end(), pred));
+
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
+  // Works with const iterators, (range) overload.
+  {
+    constexpr int N = 5;
+    Buffer<Counted, N> buf;
+
+    auto range = std::ranges::subrange(buf.cbegin(), buf.cend());
+    std::ranges::uninitialized_fill(range, x);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::all_of(buf.begin(), buf.end(), pred));
+
+    std::destroy(buf.begin(), buf.end());
+    Counted::reset();
+  }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move.pass.cpp
@@ -282,6 +282,39 @@ int main(int, char**) {
   Counted::reset();
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators, (iter, sentinel) overload.
+  {
+    constexpr int N = 5;
+    Counted in[N] = {Counted(1), Counted(2), Counted(3), Counted(4), Counted(5)};
+    Buffer<Counted, N> out;
+    Counted::reset();
+
+    std::ranges::uninitialized_move(in, in + N, out.cbegin(), out.cend());
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::equal(in, in + N, out.begin(), out.end()));
+
+    std::destroy(out.begin(), out.end());
+  }
+  Counted::reset();
+
+  // Works with const iterators, (range) overload.
+  {
+    constexpr int N = 5;
+    Counted in[N] = {Counted(1), Counted(2), Counted(3), Counted(4), Counted(5)};
+    Buffer<Counted, N> out;
+    Counted::reset();
+
+    std::ranges::subrange out_range (out.cbegin(), out.cend());
+    std::ranges::uninitialized_move(in, out_range);
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::equal(in, in + N, out.begin(), out.end()));
+
+    std::destroy(out.begin(), out.end());
+  }
+  Counted::reset();
+
   // Conversions, (iter, sentinel) overload.
   {
     constexpr int N = 3;

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move_n.pass.cpp
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move_n.pass.cpp
@@ -105,6 +105,22 @@ int main(int, char**) {
 
 #endif // TEST_HAS_NO_EXCEPTIONS
 
+  // Works with const iterators.
+  {
+    constexpr int N = 5;
+    Counted in[N] = {Counted(1), Counted(2), Counted(3), Counted(4), Counted(5)};
+    Buffer<Counted, N> out;
+    Counted::reset();
+
+    std::ranges::uninitialized_move_n(in, N, out.cbegin(), out.cend());
+    assert(Counted::current_objects == N);
+    assert(Counted::total_objects == N);
+    assert(std::equal(in, in + N, out.begin(), out.end()));
+
+    std::destroy(out.begin(), out.end());
+  }
+  Counted::reset();
+
   // Conversions.
   {
     constexpr int N = 3;

--- a/llvm/utils/gn/secondary/libcxx/include/BUILD.gn
+++ b/llvm/utils/gn/secondary/libcxx/include/BUILD.gn
@@ -632,6 +632,7 @@ if (current_toolchain == default_toolchain) {
       "__memory/unique_temporary_buffer.h",
       "__memory/uses_allocator.h",
       "__memory/uses_allocator_construction.h",
+      "__memory/voidify.h",
       "__memory_resource/memory_resource.h",
       "__memory_resource/monotonic_buffer_resource.h",
       "__memory_resource/polymorphic_allocator.h",


### PR DESCRIPTION
This reverts commit 78f9a8b82d772ff04a12ef95f2c9d31ee8f3e409.

This caused the LLDB test `TestDataFormatterGenericOptional.py` to fail with:
```
FAIL: test_with_run_command_libcpp_dwarf (TestDataFormatterGenericOptional.GenericOptionalDataFormatterTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1769, in test_method
    return attrvalue(self)
  File "/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/lldb/packages/Python/lldbsuite/test/decorators.py", line 148, in wrapper
    return func(*args, **kwargs)
  File "/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/lldb/packages/Python/lldbsuite/test/decorators.py", line 148, in wrapper
    return func(*args, **kwargs)
  File "/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py", line 103, in test_with_run_command_libcpp
    self.do_test_with_run_command(USE_LIBCPP)
  File "/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py", line 59, in do_test_with_run_command
    self.expect(
  File "/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 2475, in expect
    self.fail(log_msg)
AssertionError: Ran command:
"frame var numbers"

Got output:
(optional_int_vect) numbers =  Has Value=true  {
  Value = {
    __begin_ = 0x0000600002be8000
    __end_ = 0x0000600002be8010
    __cap_ = 0x0000600002be8010
    __padding1_781_ = (__padding_ = "\U00000001\0\xf7\0ה\xd2\xf0*\0\0\0*\0\0\0\U00000001\xb4Zo*\0\0\0*\0\0\0\U00000001\0\0\0\0\U0000001d\xc7\0\0\0\0\0\xbc[\x85\U00000001\0\0\0\0\U00000001\0\0\0\U00000002\0\0\0\U00000003\0\0\0\U00000004")
    __alloc_ = {}
    __padding2_781_ = (__padding_ = "\U00000001\0\xf7\0ה\xd2\xf0*\0\0\0*\0\0\0\U00000001\xb4Zo*\0\0\0*\0\0\0\U00000001\0\0\0\0\U0000001d\xc7\0\0\0\0\0\xbc[\x85\U00000001\0\0\0\0\U00000001\0\0\0\U00000002\0\0\0\U00000003\0\0\0\U00000004")
  }
}

Expecting sub string: "(optional_int_vect) numbers =  Has Value=true  {" (was found)
Expecting sub string: "Value = size=4 {" (was not found)
Config=arm64-/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/lldb-build/bin/clang
----------------------------------------------------------------------
Ran 6 tests in 3.259s

FAILED (failures=2, skipped=4)
```

Will need a bit more time to look into a solution