### PR TITLE
Revert "CMake: Remove unnecessary dependencies on LLVM/MLIR"

### DIFF
--- a/llvm/lib/MC/CMakeLists.txt
+++ b/llvm/lib/MC/CMakeLists.txt
@@ -79,6 +79,7 @@ add_llvm_component_library(LLVMMC
   Support
   TargetParser
   BinaryFormat
+  DebugInfoCodeView
 
   DEPENDS
   intrinsics_gen

--- a/mlir/lib/Conversion/ConvertToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ConvertToLLVM/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_conversion_library(MLIRConvertToLLVMPass
   MLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
+  MLIRConvertToLLVMInterface
   MLIRIR
   MLIRLLVMCommonConversion
   MLIRLLVMDialect

--- a/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
@@ -34,6 +34,8 @@ add_mlir_conversion_library(MLIRVectorToLLVMPass
   LINK_LIBS PUBLIC
   MLIRVectorToLLVM
 
+  MLIRArmNeonDialect
+  MLIRArmSMEDialect
   MLIRArmSVEDialect
   MLIRArmSVETransforms
   MLIRAMXDialect

--- a/mlir/lib/Dialect/Affine/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Affine/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ add_mlir_dialect_library(MLIRAffineTransforms
   MLIRIR
   MLIRMemRefDialect
   MLIRPass
+  MLIRSCFUtils
   MLIRSideEffectInterfaces
   MLIRTensorDialect
   MLIRTransformUtils

--- a/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
@@ -20,6 +20,8 @@ add_mlir_dialect_library(MLIRArithTransforms
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRArithDialect
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRFuncDialect
   MLIRFuncTransforms
   MLIRInferIntRangeInterface

--- a/mlir/lib/Dialect/Func/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Func/Transforms/CMakeLists.txt
@@ -12,6 +12,8 @@ add_mlir_dialect_library(MLIRFuncTransforms
   MLIRFuncTransformsIncGen
 
   LINK_LIBS PUBLIC
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRFuncDialect
   MLIRIR
   MLIRMemRefDialect

--- a/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -67,7 +67,9 @@ add_mlir_dialect_library(MLIRGPUTransforms
   MLIRPass
   MLIRSCFDialect
   MLIRSideEffectInterfaces
+  MLIRSPIRVTarget
   MLIRSupport
+  MLIRROCDLTarget
   MLIRTransformUtils
   MLIRVectorDialect
   )

--- a/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
@@ -25,12 +25,14 @@ add_mlir_dialect_library(MLIRLinalgDialect
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRParser
+  MLIRShardingInterface
   MLIRSideEffectInterfaces
   MLIRSparseTensorDialect
   MLIRSCFDialect
   MLIRMathDialect
   MLIRMemRefDialect
   MLIRTensorDialect
+  MLIRTilingInterface
   MLIRValueBoundsOpInterface
   MLIRViewLikeInterface
   )

--- a/mlir/lib/Dialect/Linalg/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/Transforms/CMakeLists.txt
@@ -48,11 +48,14 @@ add_mlir_dialect_library(MLIRLinalgTransforms
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect
+  MLIRAffineTransforms
   MLIRAffineUtils
   MLIRAnalysis
   MLIRArithDialect
   MLIRArithTransforms
   MLIRArithUtils
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRComplexDialect
   MLIRDestinationStyleOpInterface
   MLIRDialectUtils
@@ -63,15 +66,20 @@ add_mlir_dialect_library(MLIRLinalgTransforms
   MLIRIR
   MLIRMemRefDialect
   MLIRMemRefTransforms
+  MLIRMeshDialect
   MLIRMeshTransforms
   MLIRLinalgDialect
   MLIRLinalgUtils
   MLIRSCFDialect
   MLIRSCFTransforms
+  MLIRSCFUtils
   MLIRPass
+  MLIRShardingInterface
   MLIRSubsetOpInterface
   MLIRSparseTensorDialect
   MLIRTensorDialect
+  MLIRTensorTilingInterfaceImpl
+  MLIRTensorTransforms
   MLIRTransforms
   MLIRTransformUtils
   MLIRValueBoundsOpInterface

--- a/mlir/lib/Dialect/MemRef/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/MemRef/Transforms/CMakeLists.txt
@@ -22,10 +22,13 @@ add_mlir_dialect_library(MLIRMemRefTransforms
   MLIRMemRefPassIncGen
 
   LINK_LIBS PUBLIC
+  MLIRAffineDialect
   MLIRAffineTransforms
   MLIRAffineUtils
   MLIRArithDialect
   MLIRArithTransforms
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRDialectUtils
   MLIRFuncDialect
   MLIRGPUDialect

--- a/mlir/lib/Dialect/Mesh/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Mesh/Transforms/CMakeLists.txt
@@ -23,6 +23,8 @@ add_mlir_dialect_library(MLIRMeshTransforms
   MLIRIR
   MLIRMeshDialect
   MLIRPass
+  MLIRShardingInterface
   MLIRSupport
   MLIRTensorDialect
+  MLIRTosaShardingInterfaceImpl
 )

--- a/mlir/lib/Dialect/SCF/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/SCF/Transforms/CMakeLists.txt
@@ -29,6 +29,8 @@ add_mlir_dialect_library(MLIRSCFTransforms
   MLIRAffineDialect
   MLIRAffineAnalysis
   MLIRArithDialect
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRDestinationStyleOpInterface
   MLIRDialectUtils
   MLIRIR
@@ -38,7 +40,9 @@ add_mlir_dialect_library(MLIRSCFTransforms
   MLIRSCFUtils
   MLIRSideEffectInterfaces
   MLIRSupport
+  MLIRTensorDialect
   MLIRTensorTransforms
+  MLIRTilingInterface
   MLIRTransforms
   MLIRTransformUtils
 )

--- a/mlir/lib/Dialect/Tensor/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Tensor/Transforms/CMakeLists.txt
@@ -20,9 +20,12 @@ add_mlir_dialect_library(MLIRTensorTransforms
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect
+  MLIRAffineTransforms
   MLIRAffineUtils
   MLIRArithDialect
   MLIRArithUtils
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRDialectUtils
   MLIRIR
   MLIRLinalgDialect
@@ -32,6 +35,7 @@ add_mlir_dialect_library(MLIRTensorTransforms
   MLIRSubsetOpInterface
   MLIRTensorDialect
   MLIRTensorUtils
+  MLIRTilingInterface
   MLIRTransforms
   MLIRVectorDialect
   MLIRVectorUtils

--- a/mlir/lib/Dialect/Tosa/CMakeLists.txt
+++ b/mlir/lib/Dialect/Tosa/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(MLIRTosaDialect
   MLIRDialect
   MLIRCallInterfaces
   MLIRControlFlowInterfaces
+  MLIRQuantDialect
   MLIRQuantUtils
   MLIRSideEffectInterfaces
   MLIRTensorDialect
@@ -34,8 +35,10 @@ add_mlir_dialect_library(MLIRTosaShardingInterfaceImpl
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRMeshDialect
   MLIRShardingInterface
   MLIRSupport
+  MLIRTosaDialect
   )
 
 add_subdirectory(Transforms)

--- a/mlir/lib/Dialect/Vector/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Vector/Transforms/CMakeLists.txt
@@ -35,6 +35,8 @@ add_mlir_dialect_library(MLIRVectorTransforms
   MLIRAffineAnalysis
   MLIRAffineUtils
   MLIRArithDialect
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRDialectUtils
   MLIRGPUDialect
   MLIRIR

--- a/mlir/lib/Target/LLVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVM/CMakeLists.txt
@@ -125,6 +125,7 @@ add_mlir_dialect_library(MLIRROCDLTarget
   MLIRSupport
   MLIRGPUDialect
   MLIRTargetLLVM
+  MLIRROCDLToLLVMIRTranslation
   )
 
 if(MLIR_ENABLE_ROCM_CONVERSIONS)

--- a/mlir/lib/Target/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/CMakeLists.txt
@@ -38,6 +38,7 @@ add_mlir_translation_library(MLIRTargetLLVMIRExport
   MLIRDLTIDialect
   MLIRLLVMDialect
   MLIRLLVMIRTransforms
+  MLIRTranslateLib
   MLIRTransformUtils
   )
 
@@ -78,6 +79,7 @@ add_mlir_translation_library(MLIRTargetLLVMIRImport
   LINK_LIBS PUBLIC
   MLIRDLTIDialect
   MLIRLLVMDialect
+  MLIRTranslateLib
   )
 
 add_mlir_translation_library(MLIRFromLLVMIRTranslationRegistration

--- a/mlir/lib/Target/SPIRV/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_translation_library(MLIRSPIRVBinaryUtils
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRSPIRVDialect
   MLIRSupport
   )
 
@@ -20,9 +21,11 @@ add_mlir_translation_library(MLIRSPIRVTranslateRegistration
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRSPIRVDialect
   MLIRSPIRVSerialization
   MLIRSPIRVDeserialization
   MLIRSupport
+  MLIRTranslateLib
   )
 
 add_mlir_dialect_library(MLIRSPIRVTarget
@@ -31,6 +34,7 @@ add_mlir_dialect_library(MLIRSPIRVTarget
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRGPUDialect
+  MLIRSPIRVDialect
   MLIRSPIRVSerialization
   MLIRSupport
   )

--- a/mlir/lib/Target/SPIRV/Serialization/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/Serialization/CMakeLists.txt
@@ -8,7 +8,10 @@ add_mlir_translation_library(MLIRSPIRVSerialization
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRSPIRVDialect
   MLIRSPIRVBinaryUtils
   MLIRSupport
   MLIRTranslateLib
   )
+
+

--- a/mlir/lib/Transforms/CMakeLists.txt
+++ b/mlir/lib/Transforms/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_library(MLIRTransforms
 
   LINK_LIBS PUBLIC
   MLIRAnalysis
+  MLIRCopyOpInterface
   MLIRFunctionInterfaces
   MLIRLoopLikeInterface
   MLIRMemorySlotInterfaces

--- a/mlir/unittests/Target/LLVM/CMakeLists.txt
+++ b/mlir/unittests/Target/LLVM/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(MLIRTargetLLVMTests
   MLIRNVVMToLLVMIRTranslation
   MLIRROCDLToLLVMIRTranslation
   MLIRGPUToLLVMIRTranslation
-  MLIRParser
   ${llvm_libs}
 )
 


### PR DESCRIPTION
Reverts llvm/llvm-project#110362

Multiple bots are broken.