### PR TITLE
[Clang][TableGen] Change NeonEmitter to use const Record *

### DIFF
--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -410,8 +410,7 @@ public:
     }
 
     int ArgIdx, Kind, TypeArgIdx;
-    std::vector<Record *> ImmCheckList = R->getValueAsListOfDefs("ImmChecks");
-    for (const auto *I : ImmCheckList) {
+    for (const Record *I : R->getValueAsListOfDefs("ImmChecks")) {
       unsigned EltSizeInBits = 0, VecSizeInBits = 0;
 
       ArgIdx = I->getValueAsInt("ImmArgIdx");

--- a/clang/utils/TableGen/SveEmitter.cpp
+++ b/clang/utils/TableGen/SveEmitter.cpp
@@ -1161,11 +1161,9 @@ void SVEEmitter::createIntrinsic(
   uint64_t Merge = R->getValueAsInt("Merge");
   StringRef MergeSuffix = R->getValueAsString("MergeSuffix");
   uint64_t MemEltType = R->getValueAsInt("MemEltType");
-  std::vector<Record*> FlagsList = R->getValueAsListOfDefs("Flags");
-  std::vector<Record*> ImmCheckList = R->getValueAsListOfDefs("ImmChecks");
 
   int64_t Flags = 0;
-  for (auto FlagRec : FlagsList)
+  for (const Record *FlagRec : R->getValueAsListOfConstDefs("Flags"))
     Flags |= FlagRec->getValueAsInt("Value");
 
   // Create a dummy TypeSpec for non-overloaded builtins.
@@ -1195,10 +1193,10 @@ void SVEEmitter::createIntrinsic(
   for (auto TS : TypeSpecs) {
     // Collate a list of range/option checks for the immediates.
     SmallVector<ImmCheck, 2> ImmChecks;
-    for (auto *R : ImmCheckList) {
-      int64_t ArgIdx = R->getValueAsInt("ImmArgIdx");
-      int64_t EltSizeArgIdx = R->getValueAsInt("TypeContextArgIdx");
-      int64_t Kind = R->getValueAsDef("Kind")->getValueAsInt("Value");
+    for (const Record *ImmR : R->getValueAsListOfConstDefs("ImmChecks")) {
+      int64_t ArgIdx = ImmR->getValueAsInt("ImmArgIdx");
+      int64_t EltSizeArgIdx = ImmR->getValueAsInt("TypeContextArgIdx");
+      int64_t Kind = ImmR->getValueAsDef("Kind")->getValueAsInt("Value");
       assert(ArgIdx >= 0 && Kind >= 0 &&
              "ImmArgIdx and Kind must be nonnegative");
 


### PR DESCRIPTION
This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089