### PR TITLE
[flang][driver] Make -stdlib= option visible to flang and silently ignored by it

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5812,7 +5812,7 @@ def std_EQ : Joined<["-", "--"], "std=">,
     ;
   }]>;
 def stdlib_EQ : Joined<["-", "--"], "stdlib=">,
-  Visibility<[ClangOption, CC1Option]>,
+  Visibility<[ClangOption, CC1Option, FlangOption]>,
   HelpText<"C++ standard library to use">, Values<"libc++,libstdc++,platform">;
 def stdlibxx_isystem : JoinedOrSeparate<["-"], "stdlib++-isystem">,
   Group<clang_i_Group>,

--- a/flang/test/Integration/mixed-lang-stdlib.cpp
+++ b/flang/test/Integration/mixed-lang-stdlib.cpp
@@ -1,0 +1,48 @@
+// REQUIRES: system-linux
+// RUN: split-file %s %t
+// RUN: chmod +x %t/mixed-runtest.sh
+// RUN: %t/mixed-runtest.sh -stdlib=platform %t %t/mixed-cppfile.cpp
+// %t/mixed-fortranfile.f90 %flang | FileCheck %s
+
+//--- mixed-cppfile.cpp
+#include <iostream>
+
+extern "C" void hello(void) { std::cout << "Hello" << std::endl; }
+
+// clang-format off
+// CHECK: PASS
+//--- mixed-fortranfile.f90
+program mixed
+  implicit none
+  interface
+    subroutine hello() bind(c)
+      implicit none
+    end subroutine
+  end interface
+
+  call hello()
+end program
+
+//--- mixed-runtest.sh
+#!/bin/bash
+LDFLAGS=$1
+TMPDIR=$2
+CPPFILE=$3
+F90FILE=$4
+FLANG=$5
+BINDIR=`dirname $FLANG`
+CPPCOMP=$BINDIR/clang++
+if [ -x $CPPCOMP ]
+then
+  $CPPCOMP -shared $LDFLAGS $CPPFILE -o $TMPDIR/libmixed.so
+  $FLANG $LDFLAGS -o $TMPDIR/mixed $F90FILE -L$TMPDIR -lmixed -Wl,-rpath=$TMPDIR
+  if [ -x $TMPDIR/mixed ]
+  then
+    echo "PASS"
+  else
+    echo "FAIL"
+  fi
+else
+  # No clang compiler, just pass by default
+  echo "PASS"
+fi


### PR DESCRIPTION
This patch is to address a sudden problem I have encountered while trying to build mixed-language Fortran/C++ project. As I wanted the C++ part to utilize libc++ (instead of system-provided libstdc++), I've specified the `-stdlib=libc++` option globally, in the CXXFLAGS and LDFLAGS variables. This has saved me from making expensive changes in the Makefiles. Unfortunately, since it was the flang complier that was invoked for linking, suddenly it ended up with an error:

```
flang-new: error: unknown argument '-stdlib=libc++'; did you mean '-Xclang -stdlib=libc++'?
```

This has created a nowhere to go situation, the only remaining option is to make the -stdlib flag visible to flang and silently ignored.