### PR TITLE
Remove redundant checks related to quantized type

### DIFF
--- a/mlir/lib/Dialect/Quant/IR/QuantTypes.cpp
+++ b/mlir/lib/Dialect/Quant/IR/QuantTypes.cpp
@@ -322,8 +322,6 @@ LogicalResult UniformQuantizedType::verifyInvariants(
   // Verify scale.
   double minScale = getMinScale(expressedType);
   double maxScale = getMaxScale(expressedType);
-  if (scale <= 0.0 || std::isinf(scale) || std::isnan(scale))
-    return emitError() << "illegal scale: " << scale;
   if (scale < minScale || scale > maxScale)
     return emitError() << "scale out of expressed type range [" << minScale
                        << ", " << maxScale << "]";
@@ -388,8 +386,6 @@ LogicalResult UniformQuantizedPerAxisType::verifyInvariants(
   double minScale = getMinScale(expressedType);
   double maxScale = getMaxScale(expressedType);
   for (double scale : scales) {
-    if (scale <= 0.0 || std::isinf(scale) || std::isnan(scale))
-      return emitError() << "illegal scale: " << scale;
     if (scale < minScale || scale > maxScale)
       return emitError() << "scale out of expressed type range [" << minScale
                          << ", " << maxScale << "]";

--- a/mlir/test/Dialect/Quant/parse-uniform-invalid.mlir
+++ b/mlir/test/Dialect/Quant/parse-uniform-invalid.mlir
@@ -107,7 +107,7 @@
 
 // -----
 // Illegal scale: negative
-// expected-error@+1 {{illegal scale: -1.000000}}
+// expected-error@+1 {{scale out of expressed type range}}
 !qalias = !quant.uniform<i8<-4:3>:f32, -1.0:127>
 
 // -----


### PR DESCRIPTION
[APFloat::getSmallest](https://github.com/llvm/llvm-project/blob/915df1ae41652e2f595ce741dcd8f01878ef4e30/llvm/include/llvm/ADT/APFloat.h#L1060) (and similarly `APFloat:getLargest`)
```
APFloat getSmallest(const fltSemantics &Sem, bool Negative = false); 
```
return the positive number when the default value for the  second argument is used.

With that being said, the check  [QuantTypes.cpp#L325](https://github.com/llvm/llvm-project/blob/96f37ae45310885e09195be09d9c05e1c1dff86b/mlir/lib/Dialect/Quant/IR/QuantTypes.cpp#L325)

```c++
 if (scale <= 0.0 || std::isinf(scale) || std::isnan(scale))
    return emitError() << "illegal scale: " << scale;
```  

is already covered by the check which follows  [QuantTypes.cpp#L327](https://github.com/llvm/llvm-project/blob/96f37ae45310885e09195be09d9c05e1c1dff86b/mlir/lib/Dialect/Quant/IR/QuantTypes.cpp#L327)

```c++
  if (scale < minScale || scale > maxScale)
    return emitError() << "scale out of expressed type range [" << minScale
                       << ", " << maxScale << "]";
```

given that range `[positive-smallest-finite-number, positive-largest-finite-number]` does not include `inf` and `nan`s. 

I propose to remove the redundant check. Any suggestion for improving the error message is welcome.