### PR TITLE
[SPARC] Fix regression from UpgradeDataLayoutString change

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -5519,12 +5519,12 @@ std::string llvm::UpgradeDataLayoutString(StringRef DL, StringRef TT) {
 
   if (T.isSPARC()) {
     // Add "-i128:128"
+    std::string I64 = "-i64:64";
     std::string I128 = "-i128:128";
     if (!StringRef(Res).contains(I128)) {
-      SmallVector<StringRef, 4> Groups;
-      Regex R("^([Ee](-[mpi][^-]*)*)((-[^mpi][^-]*)*)$");
-      if (R.match(Res, &Groups))
-        Res = (Groups[1] + I128 + Groups[3]).str();
+      size_t Pos = Res.find(I64);
+      if (Pos != size_t(-1))
+        Res.insert(Pos + I64.size(), I128);
     }
     return Res;
   }

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -5519,12 +5519,12 @@ std::string llvm::UpgradeDataLayoutString(StringRef DL, StringRef TT) {
 
   if (T.isSPARC()) {
     // Add "-i128:128"
-    std::string I64 = "-i64:64";
     std::string I128 = "-i128:128";
     if (!StringRef(Res).contains(I128)) {
-      size_t Pos = Res.find(I64);
-      assert(Pos != size_t(-1) && "no i64 data layout found!");
-      Res.insert(Pos + I64.size(), I128);
+      SmallVector<StringRef, 4> Groups;
+      Regex R("^([Ee](-[mpi][^-]*)*)((-[^mpi][^-]*)*)$");
+      if (R.match(Res, &Groups))
+        Res = (Groups[1] + I128 + Groups[3]).str();
     }
     return Res;
   }


### PR DESCRIPTION
It turns out that we cannot rely on the presence of `-i64:64` as a position reference when adding the `-i128:128` datalayout string due to some custom datalayout strings lacking it (e.g ones used by bugpoint, among other things).
Do not add the `-i128:128` string in that case.

This fixes the regression introduced in https://github.com/llvm/llvm-project/pull/106951.