### PR TITLE
[Clang][NFC] Add a test for CWG 2913

### DIFF
--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -6,6 +6,26 @@
 // RUN: %clang_cc1 -std=c++23 -pedantic-errors -verify=expected %s
 // RUN: %clang_cc1 -std=c++2c -pedantic-errors -verify=expected %s
 
+namespace cwg2913 { // cwg2913: 20
+
+#if __cplusplus >= 202002L
+
+template<typename T>
+struct R {
+  R(T);
+  R(T, T);
+};
+
+template<typename T>
+R(T) -> R<T> requires true;
+
+template<typename T>
+R(T, T) requires true -> R<T>; // expected-error {{expected function body after function declarator}}
+
+#endif
+
+} // namespace cwg2913
+
 namespace cwg2915 { // cwg2915: 20 tentatively ready 2024-08-16
 #if __cplusplus >= 202302L
 struct A {

--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -6,7 +6,7 @@
 // RUN: %clang_cc1 -std=c++23 -pedantic-errors -verify=expected %s
 // RUN: %clang_cc1 -std=c++2c -pedantic-errors -verify=expected %s
 
-namespace cwg2913 { // cwg2913: 20
+namespace cwg2913 { // cwg2913: 20 tentatively ready 2024-08-16
 
 #if __cplusplus >= 202002L
 

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -17334,7 +17334,11 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2913.html">2913</a></td>
     <td>tentatively ready</td>
     <td>Grammar for <I>deduction-guide</I> has <I>requires-clause</I> in the wrong position</td>
-    <td class="unreleased" align="center">Clang 20</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 20 implements 2024-08-16 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2914">
     <td><a href="https://cplusplus.github.io/CWG/issues/2914.html">2914</a></td>


### PR DESCRIPTION
I marked DR2913 as implemented in 915df1ae, but I forgot to add a corresponding test, so running the script would fail thereafter.