### PR TITLE
[NFC] Make 'Triple&' param a 'const&' instead

### DIFF
--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -339,7 +339,7 @@ public:
   Kind kind() const { return (Kind)Format; }
   bool isThin() const { return IsThin; }
   static object::Archive::Kind getDefaultKind();
-  static object::Archive::Kind getDefaultKindForTriple(Triple &T);
+  static object::Archive::Kind getDefaultKindForTriple(const Triple &T);
 
   child_iterator child_begin(Error &Err, bool SkipInternal = true) const;
   child_iterator child_end() const;

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -969,7 +969,7 @@ Archive::Archive(MemoryBufferRef Source, Error &Err)
   Err = Error::success();
 }
 
-object::Archive::Kind Archive::getDefaultKindForTriple(Triple &T) {
+object::Archive::Kind Archive::getDefaultKindForTriple(const Triple &T) {
   if (T.isOSDarwin())
     return object::Archive::K_DARWIN;
   if (T.isOSAIX())


### PR DESCRIPTION
There isn’t really a reason for it not to be a `const&` (afaict), and it is a bit annoying because some APIs (e.g. `TargetMachine::getTargetTriple()`) return a `const Triple&`.