### PR TITLE
[LLD][COFF] Define remaining ARM64EC builtin symbols

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2471,8 +2471,11 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
     ctx.symtab.addAbsolute("__hybrid_auxiliary_iat_copy", 0);
     ctx.symtab.addAbsolute("__hybrid_code_map", 0);
     ctx.symtab.addAbsolute("__hybrid_code_map_count", 0);
+    ctx.symtab.addAbsolute("__hybrid_image_info_bitfield", 0);
     ctx.symtab.addAbsolute("__x64_code_ranges_to_entry_points", 0);
     ctx.symtab.addAbsolute("__x64_code_ranges_to_entry_points_count", 0);
+    ctx.symtab.addSynthetic("__guard_check_icall_a64n_fptr", nullptr);
+    ctx.symtab.addSynthetic("__arm64x_native_entrypoint", nullptr);
   }
 
   if (config->pseudoRelocs) {

--- a/lld/test/COFF/Inputs/loadconfig-arm64ec.s
+++ b/lld/test/COFF/Inputs/loadconfig-arm64ec.s
@@ -69,7 +69,7 @@ __chpe_metadata:
         .rva __os_arm64x_check_call
         .rva __os_arm64x_check_icall
         .rva __os_arm64x_check_icall_cfg
-        .word 0 // __arm64x_native_entrypoint
+        .rva __arm64x_native_entrypoint
         .rva __hybrid_auxiliary_iat
         .word __x64_code_ranges_to_entry_points_count
         .word __arm64x_redirection_metadata_count
@@ -81,7 +81,7 @@ __chpe_metadata:
         .rva __hybrid_auxiliary_iat_copy
         .rva __hybrid_auxiliary_delayload_iat
         .rva __hybrid_auxiliary_delayload_iat_copy
-        .word 0 // __hybrid_image_info_bitfield
+        .word __hybrid_image_info_bitfield
         .rva __os_arm64x_helper3
         .rva __os_arm64x_helper4
         .rva __os_arm64x_helper5

--- a/lld/test/COFF/arm64ec-loadcfg.s
+++ b/lld/test/COFF/arm64ec-loadcfg.s
@@ -1,0 +1,38 @@
+# REQUIRES: aarch64
+
+# RUN: llvm-mc -filetype=obj -triple=arm64ec-windows %s -o %t.obj
+# RUN: llvm-mc -filetype=obj -triple=arm64ec-windows %S/Inputs/loadconfig-arm64ec.s -o %t-loadconfig.obj
+
+# RUN: lld-link -machine:arm64ec -dll -noentry %t.obj %t-loadconfig.obj -out:%t.dll
+
+# RUN: llvm-readobj --coff-load-config %t.dll | FileCheck --check-prefix=LOADCFG %s
+# LOADCFG:      CHPEMetadata [
+# LOADCFG-NEXT:   Version: 0x2
+# LOADCFG-NEXT:   CodeMap: 4096
+# LOADCFG-NEXT:   CodeRangesToEntryPoints: 4096
+# LOADCFG-NEXT:   RedirectionMetadata: 12288
+# LOADCFG-NEXT:   __os_arm64x_dispatch_call_no_redirect: 0x1158
+# LOADCFG-NEXT:   __os_arm64x_dispatch_ret: 0x1160
+# LOADCFG-NEXT:   __os_arm64x_dispatch_call: 0x1168
+# LOADCFG-NEXT:   __os_arm64x_dispatch_icall: 0x1170
+# LOADCFG-NEXT:   __os_arm64x_dispatch_icall_cfg: 0x1188
+# LOADCFG-NEXT:   AlternateEntryPoint: 0x0
+# LOADCFG-NEXT:   AuxiliaryIAT: 0x0
+# LOADCFG-NEXT:   GetX64InformationFunctionPointer: 0x1178
+# LOADCFG-NEXT:   SetX64InformationFunctionPointer: 0x1180
+# LOADCFG-NEXT:   ExtraRFETable: 0x0
+# LOADCFG-NEXT:   ExtraRFETableSize: 0x0
+# LOADCFG-NEXT:   __os_arm64x_dispatch_fptr: 0x1190
+# LOADCFG-NEXT:   AuxiliaryIATCopy: 0x0
+# LOADCFG-NEXT:   AuxiliaryDelayloadIAT: 0x0
+# LOADCFG-NEXT:   AuxiliaryDelayloadIATCopy: 0x0
+# LOADCFG-NEXT:   HybridImageInfoBitfield: 0x0
+# LOADCFG-NEXT: ]
+
+# RUN: llvm-readobj --hex-dump=.test %t.dll | FileCheck --check-prefix=TEST %s
+# TEST: 0x180003000 00000000 00000000 00000000
+
+.section .test,"dr"
+        .rva __arm64x_native_entrypoint
+        .rva __guard_check_icall_a64n_fptr
+        .word __hybrid_image_info_bitfield


### PR DESCRIPTION
__arm64x_native_entrypoint and __guard_check_icall_a64n_fptr are relevant only for hybrid ARM64X images, we need support for separate namespaces before we can support them.

__hybrid_image_info_bitfield is 0 in MSVC linker in all tests I tried.