### PR TITLE
[compiler-rt] [asan] Remove superfluous trailing semicolons

### DIFF
--- a/compiler-rt/lib/asan/asan_win_common_runtime_thunk.cpp
+++ b/compiler-rt/lib/asan/asan_win_common_runtime_thunk.cpp
@@ -85,11 +85,11 @@ static void WINAPI asan_thread_init(void *mod, unsigned long reason,
 // initializer is needed as a backup.
 extern "C" __declspec(allocate(".CRT$XIB")) int (*__asan_thunk_init)() =
     asan_thunk_init;
-WIN_FORCE_LINK(__asan_thunk_init);
+WIN_FORCE_LINK(__asan_thunk_init)
 
 extern "C" __declspec(allocate(".CRT$XLAB")) void(WINAPI *__asan_tls_init)(
     void *, unsigned long, void *) = asan_thread_init;
-WIN_FORCE_LINK(__asan_tls_init);
+WIN_FORCE_LINK(__asan_tls_init)
 
 ////////////////////////////////////////////////////////////////////////////////
 // ASan SEH handling.
@@ -103,7 +103,7 @@ static int SetSEHFilter() { return __asan_set_seh_filter(); }
 // __asan_intercept_seh gets optimized out, so we have to use an extra function.
 extern "C" __declspec(allocate(".CRT$XCAB")) int (*__asan_seh_interceptor)() =
     SetSEHFilter;
-WIN_FORCE_LINK(__asan_seh_interceptor);
+WIN_FORCE_LINK(__asan_seh_interceptor)
 }
 
 WIN_FORCE_LINK(__asan_dso_reg_hook)


### PR DESCRIPTION
If built as part of the main llvm build, via
ENABLE_LLVM_PROJECTS=compiler-rt, the code gets built with more warning options than if built standalone. Some of these trigger warnings like:

    warning: extra ';' outside of a function is incompatible with C++98 [-Wc++98-compat-extra-semi]