### PR TITLE
[compiler-rt] [profile] Add missing (void) to prototypes, for C sources

### DIFF
--- a/compiler-rt/lib/profile/InstrProfiling.h
+++ b/compiler-rt/lib/profile/InstrProfiling.h
@@ -114,11 +114,11 @@ char *__llvm_profile_begin_counters(void);
 char *__llvm_profile_end_counters(void);
 char *__llvm_profile_begin_bitmap(void);
 char *__llvm_profile_end_bitmap(void);
-ValueProfNode *__llvm_profile_begin_vnodes();
-ValueProfNode *__llvm_profile_end_vnodes();
-const VTableProfData *__llvm_profile_begin_vtables();
-const VTableProfData *__llvm_profile_end_vtables();
-uint32_t *__llvm_profile_begin_orderfile();
+ValueProfNode *__llvm_profile_begin_vnodes(void);
+ValueProfNode *__llvm_profile_end_vnodes(void);
+const VTableProfData *__llvm_profile_begin_vtables(void);
+const VTableProfData *__llvm_profile_end_vtables(void);
+uint32_t *__llvm_profile_begin_orderfile(void);
 
 /*!
  * \brief Merge profile data from buffer.
@@ -216,7 +216,7 @@ void __llvm_profile_initialize(void);
  * merge mode is turned on for instrumented programs with shared libs).
  * Side-effect: this API call will invoke malloc with dynamic memory allocation.
  */
-const char *__llvm_profile_get_path_prefix();
+const char *__llvm_profile_get_path_prefix(void);
 
 /*!
  * \brief Return filename (including path) of the profile data. Note that if the
@@ -229,7 +229,7 @@ const char *__llvm_profile_get_path_prefix();
  * instrumented image/DSO). This API only retrieves the filename from the copy
  * of the runtime available to the calling image.
  */
-const char *__llvm_profile_get_filename();
+const char *__llvm_profile_get_filename(void);
 
 /*! \brief Get the magic token for the file format. */
 uint64_t __llvm_profile_get_magic(void);
@@ -293,7 +293,7 @@ int __llvm_profile_get_padding_sizes_for_counters(
  * certain processes in case the processes don't have permission to write to
  * the disks, and trying to do so would result in side effects such as crashes.
  */
-void __llvm_profile_set_dumped();
+void __llvm_profile_set_dumped(void);
 
 /*!
  * This variable is defined in InstrProfilingRuntime.cpp as a hidden

--- a/compiler-rt/lib/profile/InstrProfilingInternal.h
+++ b/compiler-rt/lib/profile/InstrProfilingInternal.h
@@ -167,20 +167,20 @@ int lprofWriteDataImpl(ProfDataWriter *Writer,
 void lprofMergeValueProfData(struct ValueProfData *SrcValueProfData,
                              __llvm_profile_data *DstData);
 
-VPDataReaderType *lprofGetVPDataReader();
+VPDataReaderType *lprofGetVPDataReader(void);
 
 /* Internal interface used by test to reset the max number of 
  * tracked values per value site to be \p MaxVals.
  */
 void lprofSetMaxValsPerSite(uint32_t MaxVals);
-void lprofSetupValueProfiler();
+void lprofSetupValueProfiler(void);
 
 /* Return the profile header 'signature' value associated with the current
  * executable or shared library. The signature value can be used to for
  * a profile name that is unique to this load module so that it does not
  * collide with profiles from other binaries. It also allows shared libraries
  * to dump merged profile data into its own profile file. */
-uint64_t lprofGetLoadModuleSignature();
+uint64_t lprofGetLoadModuleSignature(void);
 
 /* 
  * Return non zero value if the profile data has already been

--- a/compiler-rt/lib/profile/InstrProfilingPort.h
+++ b/compiler-rt/lib/profile/InstrProfilingPort.h
@@ -111,7 +111,7 @@
 
 #if defined(_WIN32)
 #include <windows.h>
-static inline size_t getpagesize() {
+static inline size_t getpagesize(void) {
   SYSTEM_INFO S;
   GetNativeSystemInfo(&S);
   return S.dwPageSize;

--- a/compiler-rt/lib/profile/InstrProfilingUtil.h
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.h
@@ -69,10 +69,10 @@ void *lprofPtrFetchAdd(void **Mem, long ByteIncr);
 /* Temporarily suspend SIGKILL. Return value of 1 means a restore is needed.
  * Other return values mean no restore is needed.
  */
-int lprofSuspendSigKill();
+int lprofSuspendSigKill(void);
 
 /* Restore previously suspended SIGKILL. */
-void lprofRestoreSigKill();
+void lprofRestoreSigKill(void);
 
 static inline size_t lprofRoundUpTo(size_t x, size_t boundary) {
   return (x + boundary - 1) & ~(boundary - 1);


### PR DESCRIPTION
If built as part of the main llvm build, via
ENABLE_LLVM_PROJECTS=compiler-rt, the code gets built with more warning options than if built standalone. Some of these trigger warnings like:

    warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]