### PR TITLE
[flang] remove support for std::complex value lowering.

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -404,7 +404,7 @@ constexpr TypeBuilderFunc getModel<bool &>() {
 // getModel<std::complex<T>> are not implemented on purpose.
 // Prefer passing/returning the complex by reference in the runtime to
 // avoid ABI issues.
-// C++ std::complex is not an intrinsic type, and it while it is storage
+// C++ std::complex is not an intrinsic type, and while it is storage
 // compatible with C/Fortran complex type, it follows the struct value passing
 // ABI rule, which may differ from how C complex are passed on some platforms.
 

--- a/flang/unittests/Optimizer/RTBuilder.cpp
+++ b/flang/unittests/Optimizer/RTBuilder.cpp
@@ -19,7 +19,6 @@
 
 // Fake runtime header to be introspected.
 c_float_complex_t c99_cacosf(c_float_complex_t);
-std::complex<float> cpp_runtime(std::complex<float>);
 
 TEST(RTBuilderTest, ComplexRuntimeInterface) {
   mlir::DialectRegistry registry;
@@ -35,22 +34,4 @@ TEST(RTBuilderTest, ComplexRuntimeInterface) {
   auto cplx_ty = fir::ComplexType::get(&ctx, 4);
   EXPECT_EQ(c99_cacosf_funcTy.getInput(0), cplx_ty);
   EXPECT_EQ(c99_cacosf_funcTy.getResult(0), cplx_ty);
-}
-
-TEST(RTBuilderTest, CppComplexRuntimeInterface) {
-  mlir::DialectRegistry registry;
-  fir::support::registerDialects(registry);
-  mlir::MLIRContext ctx(registry);
-  fir::support::loadDialects(ctx);
-  mlir::Type cpp_runtime_signature{
-      fir::runtime::RuntimeTableKey<decltype(cpp_runtime)>::getTypeModel()(
-          &ctx)};
-  auto cpp_runtime_funcTy =
-      mlir::cast<mlir::FunctionType>(cpp_runtime_signature);
-  EXPECT_EQ(cpp_runtime_funcTy.getNumInputs(), 1u);
-  EXPECT_EQ(cpp_runtime_funcTy.getNumResults(), 1u);
-  auto fp = mlir::FloatType::getF32(&ctx);
-  auto cplx_ty = mlir::TupleType::get(&ctx, {fp, fp});
-  EXPECT_EQ(cpp_runtime_funcTy.getInput(0), cplx_ty);
-  EXPECT_EQ(cpp_runtime_funcTy.getResult(0), cplx_ty);
 }


### PR DESCRIPTION
Part of the [RFC to use mlir complex type](https://discourse.llvm.org/t/rfc-flang-replace-usages-of-fir-complex-by-mlir-complex-type/82292).