### PR TITLE
[llvm-project][llvm] .gitignore supports filtering folders starting with cmake-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ autoconf/autom4te.cache
 /CMakeSettings.json
 # CLion project configuration
 /.idea
+/cmake-build*
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).

--- a/llvm/.gitignore
+++ b/llvm/.gitignore
@@ -32,6 +32,7 @@ autoconf/autom4te.cache
 /CMakeSettings.json
 # CLion project configuration
 /.idea
+/cmake-build*
 # Qt Creator project configuration
 /CMakeLists.txt.user
 


### PR DESCRIPTION
Using clion to build llvm, in debug mode, the cmake-build-debug folder will be created by default, and in release mode, the cmake-build-release folder will be created by default, and these folders need to be filtered out of the .gitignore again, or else they will contaminate the current working environment.