### PR TITLE
DSE: pre-commit tests for scalable vectors

### DIFF
--- a/llvm/test/Transforms/DeadStoreElimination/offsetted-overlapping-stores.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/offsetted-overlapping-stores.ll
@@ -47,6 +47,98 @@ bb:
   ret void
 }
 
+define void @ScalableVectorTestFullyOverlapping(ptr %arg, i32 %i) vscale_range(1, 2) {
+; CHECK-LABEL: @ScalableVectorTestFullyOverlapping(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 1
+; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
+; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
+; CHECK-NEXT:    store float 0.000000e+00, ptr [[I9]], align 4
+; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I3]], align 8
+; CHECK-NEXT:    ret void
+;
+bb:
+  %i7 = add nuw nsw i32 %i, 1
+  %i8 = zext i32 %i7 to i64
+  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
+  store float 0.0, ptr %i9
+  %i2 = zext i32 %i to i64
+  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
+  store <vscale x 2 x float> zeroinitializer, ptr %i3
+  ret void
+}
+
+define void @ScalableVectorTestFullyOverlapping2(ptr %arg, i32 %i) {
+; CHECK-LABEL: @ScalableVectorTestFullyOverlapping2(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 1
+; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
+; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I9]], align 8
+; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
+; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[I3]], align 16
+; CHECK-NEXT:    ret void
+;
+bb:
+  %i7 = add nuw nsw i32 %i, 1
+  %i8 = zext i32 %i7 to i64
+  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
+  store <vscale x 2 x float> zeroinitializer, ptr %i9
+  %i2 = zext i32 %i to i64
+  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
+  store <vscale x 4 x float> zeroinitializer, ptr %i3
+  ret void
+}
+
+define void @ScalableVectorTestNonOverlapping(ptr %arg, i32 %i) vscale_range(1, 2) {
+; CHECK-LABEL: @ScalableVectorTestNonOverlapping(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 10
+; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
+; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
+; CHECK-NEXT:    store float 0.000000e+00, ptr [[I9]], align 4
+; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I3]], align 8
+; CHECK-NEXT:    ret void
+;
+bb:
+  %i7 = add nuw nsw i32 %i, 10
+  %i8 = zext i32 %i7 to i64
+  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
+  store float 0.0, ptr %i9
+  %i2 = zext i32 %i to i64
+  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
+  store <vscale x 2 x float> zeroinitializer, ptr %i3
+  ret void
+}
+
+define void @ScalableVectorTestNonOverlapping2(ptr %arg, i32 %i) vscale_range(1, 2) {
+; CHECK-LABEL: @ScalableVectorTestNonOverlapping2(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 10
+; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
+; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I9]], align 8
+; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
+; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[I3]], align 16
+; CHECK-NEXT:    ret void
+;
+bb:
+  %i7 = add nuw nsw i32 %i, 10
+  %i8 = zext i32 %i7 to i64
+  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
+  store <vscale x 2 x float> zeroinitializer, ptr %i9
+  %i2 = zext i32 %i to i64
+  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
+  store <vscale x 4 x float> zeroinitializer, ptr %i3
+  ret void
+}
+
 define void @ArrayTestPartiallyOverlapping(i64 %0) {
 ;
 ; The DSE pass will not kill the store because the overlap is partial
@@ -55,9 +147,9 @@ define void @ArrayTestPartiallyOverlapping(i64 %0) {
 ; CHECK-LABEL: @ArrayTestPartiallyOverlapping(
 ; CHECK-NEXT:    [[TMP2:%.*]] = add i64 [[TMP0:%.*]], 10
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds [0 x i8], ptr @BUFFER, i64 0, i64 [[TMP2]]
-; CHECK-NEXT:    [[TMP5:%.*]] = add i64 [[TMP0]], 15
-; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds [0 x i8], ptr @BUFFER, i64 0, i64 [[TMP5]]
-; CHECK-NEXT:    store i32 1, ptr [[TMP6]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = add i64 [[TMP0]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds [0 x i8], ptr @BUFFER, i64 0, i64 [[TMP4]]
+; CHECK-NEXT:    store i32 1, ptr [[TMP5]], align 4
 ; CHECK-NEXT:    store i64 0, ptr [[TMP3]], align 4
 ; CHECK-NEXT:    ret void
 ;
@@ -94,6 +186,33 @@ bb:
   %i6 = zext i32 %i5 to i64
   %i7 = getelementptr inbounds float, ptr %arg, i64 %i6
   store <2 x float> <float 0.0, float 0.0>, ptr %i7, align 16
+  ret void
+}
+
+define void @ScalableVectorTestPartiallyOverlapping(ptr %arg, i32 %i) {
+;
+; The DSE pass will not kill the store because the overlap is partial
+; and won't fully clobber the original store.
+;
+; CHECK-LABEL: @ScalableVectorTestPartiallyOverlapping(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I:%.*]] to i64
+; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I2]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I3]], align 8
+; CHECK-NEXT:    [[I5:%.*]] = add nuw nsw i32 [[I]], 1
+; CHECK-NEXT:    [[I6:%.*]] = zext i32 [[I5]] to i64
+; CHECK-NEXT:    [[I7:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I6]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I7]], align 8
+; CHECK-NEXT:    ret void
+;
+bb:
+  %i2 = zext i32 %i to i64
+  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
+  store <vscale x 2 x float> zeroinitializer, ptr %i3
+  %i5 = add nuw nsw i32 %i, 1
+  %i6 = zext i32 %i5 to i64
+  %i7 = getelementptr inbounds float, ptr %arg, i64 %i6
+  store <vscale x 2 x float> zeroinitializer, ptr %i7
   ret void
 }
 

--- a/llvm/test/Transforms/DeadStoreElimination/offsetted-overlapping-stores.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/offsetted-overlapping-stores.ll
@@ -50,92 +50,92 @@ bb:
 define void @ScalableVectorTestFullyOverlapping(ptr %arg, i32 %i) vscale_range(1, 2) {
 ; CHECK-LABEL: @ScalableVectorTestFullyOverlapping(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 1
-; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
-; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
-; CHECK-NEXT:    store float 0.000000e+00, ptr [[I9]], align 4
-; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
-; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
-; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I3]], align 8
+; CHECK-NEXT:    [[I_1:%.*]] = add nuw nsw i32 [[I:%.*]], 1
+; CHECK-NEXT:    [[EXT_I_1:%.*]] = zext i32 [[I_1]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I_1:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_1]]
+; CHECK-NEXT:    store float 0.000000e+00, ptr [[GEP_ARG_I_1]], align 4
+; CHECK-NEXT:    [[EXT_I:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[EXT_I]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 8
 ; CHECK-NEXT:    ret void
 ;
 bb:
-  %i7 = add nuw nsw i32 %i, 1
-  %i8 = zext i32 %i7 to i64
-  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
-  store float 0.0, ptr %i9
-  %i2 = zext i32 %i to i64
-  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
-  store <vscale x 2 x float> zeroinitializer, ptr %i3
+  %i.1 = add nuw nsw i32 %i, 1
+  %ext.i.1 = zext i32 %i.1 to i64
+  %gep.arg.i.1 = getelementptr inbounds float, ptr %arg, i64 %ext.i.1
+  store float 0.0, ptr %gep.arg.i.1
+  %ext.i = zext i32 %i to i64
+  %gep.arg.i = getelementptr inbounds float, ptr %arg, i64 %ext.i
+  store <vscale x 2 x float> zeroinitializer, ptr %gep.arg.i
   ret void
 }
 
 define void @ScalableVectorTestFullyOverlapping2(ptr %arg, i32 %i) {
 ; CHECK-LABEL: @ScalableVectorTestFullyOverlapping2(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 1
-; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
-; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
-; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I9]], align 8
-; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
-; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
-; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[I3]], align 16
+; CHECK-NEXT:    [[I_1:%.*]] = add nuw nsw i32 [[I:%.*]], 1
+; CHECK-NEXT:    [[EXT_I_1:%.*]] = zext i32 [[I_1]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I_1:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_1]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I_1]], align 8
+; CHECK-NEXT:    [[EXT_I:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[EXT_I]]
+; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 16
 ; CHECK-NEXT:    ret void
 ;
 bb:
-  %i7 = add nuw nsw i32 %i, 1
-  %i8 = zext i32 %i7 to i64
-  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
-  store <vscale x 2 x float> zeroinitializer, ptr %i9
-  %i2 = zext i32 %i to i64
-  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
-  store <vscale x 4 x float> zeroinitializer, ptr %i3
+  %i.1 = add nuw nsw i32 %i, 1
+  %ext.i.1 = zext i32 %i.1 to i64
+  %gep.arg.i.1 = getelementptr inbounds float, ptr %arg, i64 %ext.i.1
+  store <vscale x 2 x float> zeroinitializer, ptr %gep.arg.i.1
+  %ext.i = zext i32 %i to i64
+  %gep.arg.i = getelementptr inbounds float, ptr %arg, i64 %ext.i
+  store <vscale x 4 x float> zeroinitializer, ptr %gep.arg.i
   ret void
 }
 
 define void @ScalableVectorTestNonOverlapping(ptr %arg, i32 %i) vscale_range(1, 2) {
 ; CHECK-LABEL: @ScalableVectorTestNonOverlapping(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 10
-; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
-; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
-; CHECK-NEXT:    store float 0.000000e+00, ptr [[I9]], align 4
-; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
-; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
-; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I3]], align 8
+; CHECK-NEXT:    [[I_10:%.*]] = add nuw nsw i32 [[I:%.*]], 10
+; CHECK-NEXT:    [[EXT_I_10:%.*]] = zext i32 [[I_10]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I_10:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_10]]
+; CHECK-NEXT:    store float 0.000000e+00, ptr [[GEP_ARG_I_10]], align 4
+; CHECK-NEXT:    [[EXT_I:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[EXT_I]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 8
 ; CHECK-NEXT:    ret void
 ;
 bb:
-  %i7 = add nuw nsw i32 %i, 10
-  %i8 = zext i32 %i7 to i64
-  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
-  store float 0.0, ptr %i9
-  %i2 = zext i32 %i to i64
-  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
-  store <vscale x 2 x float> zeroinitializer, ptr %i3
+  %i.10 = add nuw nsw i32 %i, 10
+  %ext.i.10 = zext i32 %i.10 to i64
+  %gep.arg.i.10 = getelementptr inbounds float, ptr %arg, i64 %ext.i.10
+  store float 0.0, ptr %gep.arg.i.10
+  %ext.i = zext i32 %i to i64
+  %gep.arg.i = getelementptr inbounds float, ptr %arg, i64 %ext.i
+  store <vscale x 2 x float> zeroinitializer, ptr %gep.arg.i
   ret void
 }
 
 define void @ScalableVectorTestNonOverlapping2(ptr %arg, i32 %i) vscale_range(1, 2) {
 ; CHECK-LABEL: @ScalableVectorTestNonOverlapping2(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[I7:%.*]] = add nuw nsw i32 [[I:%.*]], 10
-; CHECK-NEXT:    [[I8:%.*]] = zext i32 [[I7]] to i64
-; CHECK-NEXT:    [[I9:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I8]]
-; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I9]], align 8
-; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I]] to i64
-; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I2]]
-; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[I3]], align 16
+; CHECK-NEXT:    [[I_10:%.*]] = add nuw nsw i32 [[I:%.*]], 10
+; CHECK-NEXT:    [[EXT_I_10:%.*]] = zext i32 [[I_10]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I_10:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_10]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I_10]], align 8
+; CHECK-NEXT:    [[EXT_I:%.*]] = zext i32 [[I]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[EXT_I]]
+; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 16
 ; CHECK-NEXT:    ret void
 ;
 bb:
-  %i7 = add nuw nsw i32 %i, 10
-  %i8 = zext i32 %i7 to i64
-  %i9 = getelementptr inbounds float, ptr %arg, i64 %i8
-  store <vscale x 2 x float> zeroinitializer, ptr %i9
-  %i2 = zext i32 %i to i64
-  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
-  store <vscale x 4 x float> zeroinitializer, ptr %i3
+  %i.10 = add nuw nsw i32 %i, 10
+  %ext.i.10 = zext i32 %i.10 to i64
+  %gep.arg.i.10 = getelementptr inbounds float, ptr %arg, i64 %ext.i.10
+  store <vscale x 2 x float> zeroinitializer, ptr %gep.arg.i.10
+  %ext.i = zext i32 %i to i64
+  %gep.arg.i = getelementptr inbounds float, ptr %arg, i64 %ext.i
+  store <vscale x 4 x float> zeroinitializer, ptr %gep.arg.i
   ret void
 }
 
@@ -196,23 +196,23 @@ define void @ScalableVectorTestPartiallyOverlapping(ptr %arg, i32 %i) {
 ;
 ; CHECK-LABEL: @ScalableVectorTestPartiallyOverlapping(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[I2:%.*]] = zext i32 [[I:%.*]] to i64
-; CHECK-NEXT:    [[I3:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[I2]]
-; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I3]], align 8
-; CHECK-NEXT:    [[I5:%.*]] = add nuw nsw i32 [[I]], 1
-; CHECK-NEXT:    [[I6:%.*]] = zext i32 [[I5]] to i64
-; CHECK-NEXT:    [[I7:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[I6]]
-; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[I7]], align 8
+; CHECK-NEXT:    [[EXT_I:%.*]] = zext i32 [[I:%.*]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 8
+; CHECK-NEXT:    [[I_1:%.*]] = add nuw nsw i32 [[I]], 1
+; CHECK-NEXT:    [[EXT_I_1:%.*]] = zext i32 [[I_1]] to i64
+; CHECK-NEXT:    [[GEP_ARG_I_1:%.*]] = getelementptr inbounds float, ptr [[ARG]], i64 [[EXT_I_1]]
+; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I_1]], align 8
 ; CHECK-NEXT:    ret void
 ;
 bb:
-  %i2 = zext i32 %i to i64
-  %i3 = getelementptr inbounds float, ptr %arg, i64 %i2
-  store <vscale x 2 x float> zeroinitializer, ptr %i3
-  %i5 = add nuw nsw i32 %i, 1
-  %i6 = zext i32 %i5 to i64
-  %i7 = getelementptr inbounds float, ptr %arg, i64 %i6
-  store <vscale x 2 x float> zeroinitializer, ptr %i7
+  %ext.i = zext i32 %i to i64
+  %gep.arg.i = getelementptr inbounds float, ptr %arg, i64 %ext.i
+  store <vscale x 2 x float> zeroinitializer, ptr %gep.arg.i
+  %i.1 = add nuw nsw i32 %i, 1
+  %ext.i.1 = zext i32 %i.1 to i64
+  %gep.arg.i.1 = getelementptr inbounds float, ptr %arg, i64 %ext.i.1
+  store <vscale x 2 x float> zeroinitializer, ptr %gep.arg.i.1
   ret void
 }
 

--- a/llvm/test/Transforms/DeadStoreElimination/offsetted-overlapping-stores.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/offsetted-overlapping-stores.ll
@@ -49,7 +49,6 @@ bb:
 
 define void @ScalableVectorTestFullyOverlapping(ptr %arg, i32 %i) vscale_range(1, 2) {
 ; CHECK-LABEL: @ScalableVectorTestFullyOverlapping(
-; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I_1:%.*]] = add nuw nsw i32 [[I:%.*]], 1
 ; CHECK-NEXT:    [[EXT_I_1:%.*]] = zext i32 [[I_1]] to i64
 ; CHECK-NEXT:    [[GEP_ARG_I_1:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_1]]
@@ -59,7 +58,6 @@ define void @ScalableVectorTestFullyOverlapping(ptr %arg, i32 %i) vscale_range(1
 ; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 8
 ; CHECK-NEXT:    ret void
 ;
-bb:
   %i.1 = add nuw nsw i32 %i, 1
   %ext.i.1 = zext i32 %i.1 to i64
   %gep.arg.i.1 = getelementptr inbounds float, ptr %arg, i64 %ext.i.1
@@ -72,7 +70,6 @@ bb:
 
 define void @ScalableVectorTestFullyOverlapping2(ptr %arg, i32 %i) {
 ; CHECK-LABEL: @ScalableVectorTestFullyOverlapping2(
-; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I_1:%.*]] = add nuw nsw i32 [[I:%.*]], 1
 ; CHECK-NEXT:    [[EXT_I_1:%.*]] = zext i32 [[I_1]] to i64
 ; CHECK-NEXT:    [[GEP_ARG_I_1:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_1]]
@@ -82,7 +79,6 @@ define void @ScalableVectorTestFullyOverlapping2(ptr %arg, i32 %i) {
 ; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 16
 ; CHECK-NEXT:    ret void
 ;
-bb:
   %i.1 = add nuw nsw i32 %i, 1
   %ext.i.1 = zext i32 %i.1 to i64
   %gep.arg.i.1 = getelementptr inbounds float, ptr %arg, i64 %ext.i.1
@@ -95,7 +91,6 @@ bb:
 
 define void @ScalableVectorTestNonOverlapping(ptr %arg, i32 %i) vscale_range(1, 2) {
 ; CHECK-LABEL: @ScalableVectorTestNonOverlapping(
-; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I_10:%.*]] = add nuw nsw i32 [[I:%.*]], 10
 ; CHECK-NEXT:    [[EXT_I_10:%.*]] = zext i32 [[I_10]] to i64
 ; CHECK-NEXT:    [[GEP_ARG_I_10:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_10]]
@@ -105,7 +100,6 @@ define void @ScalableVectorTestNonOverlapping(ptr %arg, i32 %i) vscale_range(1, 
 ; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 8
 ; CHECK-NEXT:    ret void
 ;
-bb:
   %i.10 = add nuw nsw i32 %i, 10
   %ext.i.10 = zext i32 %i.10 to i64
   %gep.arg.i.10 = getelementptr inbounds float, ptr %arg, i64 %ext.i.10
@@ -118,7 +112,6 @@ bb:
 
 define void @ScalableVectorTestNonOverlapping2(ptr %arg, i32 %i) vscale_range(1, 2) {
 ; CHECK-LABEL: @ScalableVectorTestNonOverlapping2(
-; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I_10:%.*]] = add nuw nsw i32 [[I:%.*]], 10
 ; CHECK-NEXT:    [[EXT_I_10:%.*]] = zext i32 [[I_10]] to i64
 ; CHECK-NEXT:    [[GEP_ARG_I_10:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I_10]]
@@ -128,7 +121,6 @@ define void @ScalableVectorTestNonOverlapping2(ptr %arg, i32 %i) vscale_range(1,
 ; CHECK-NEXT:    store <vscale x 4 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 16
 ; CHECK-NEXT:    ret void
 ;
-bb:
   %i.10 = add nuw nsw i32 %i, 10
   %ext.i.10 = zext i32 %i.10 to i64
   %gep.arg.i.10 = getelementptr inbounds float, ptr %arg, i64 %ext.i.10
@@ -195,7 +187,6 @@ define void @ScalableVectorTestPartiallyOverlapping(ptr %arg, i32 %i) {
 ; and won't fully clobber the original store.
 ;
 ; CHECK-LABEL: @ScalableVectorTestPartiallyOverlapping(
-; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[EXT_I:%.*]] = zext i32 [[I:%.*]] to i64
 ; CHECK-NEXT:    [[GEP_ARG_I:%.*]] = getelementptr inbounds float, ptr [[ARG:%.*]], i64 [[EXT_I]]
 ; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I]], align 8
@@ -205,7 +196,6 @@ define void @ScalableVectorTestPartiallyOverlapping(ptr %arg, i32 %i) {
 ; CHECK-NEXT:    store <vscale x 2 x float> zeroinitializer, ptr [[GEP_ARG_I_1]], align 8
 ; CHECK-NEXT:    ret void
 ;
-bb:
   %ext.i = zext i32 %i to i64
   %gep.arg.i = getelementptr inbounds float, ptr %arg, i64 %ext.i
   store <vscale x 2 x float> zeroinitializer, ptr %gep.arg.i

--- a/llvm/test/Transforms/DeadStoreElimination/stores-of-existing-values.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/stores-of-existing-values.ll
@@ -641,7 +641,7 @@ define void @later_non_removable_store(i1 %c, ptr %p) {
 ; CHECK:       if:
 ; CHECK-NEXT:    br label [[EXIT]]
 ; CHECK:       exit:
-; CHECK-NEXT:    call void @use(ptr [[P]]) #[[ATTR6:[0-9]+]]
+; CHECK-NEXT:    call void @use(ptr [[P]]) #[[ATTR7:[0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
   store i8 1, ptr %p
@@ -653,5 +653,83 @@ if:
 
 exit:
   call void @use(ptr %p) argmemonly
+  ret void
+}
+
+define void @scalable_scalable_redundant_store(ptr %ptr) {
+; CHECK-LABEL: @scalable_scalable_redundant_store(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[PTR]], align 32
+; CHECK-NEXT:    ret void
+;
+  %gep = getelementptr i64, ptr %ptr, i64 2
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @scalable_scalable_neg(ptr %ptr) {
+; CHECK-LABEL: @scalable_scalable_neg(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 8
+; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[GEP]], align 32
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[PTR]], align 16
+; CHECK-NEXT:    ret void
+;
+  %gep = getelementptr i64, ptr %ptr, i64 8
+  store <vscale x 4 x i64> zeroinitializer, ptr %gep
+  store <vscale x 2 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @scalable_fixed_redundant_store(ptr %ptr) vscale_range(1, 2) {
+; CHECK-LABEL: @scalable_fixed_redundant_store(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[PTR]], align 32
+; CHECK-NEXT:    ret void
+;
+  %gep = getelementptr i64, ptr %ptr, i64 2
+  store <2 x i64> zeroinitializer, ptr %gep
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @scalable_fixed_neg(ptr %ptr) vscale_range(1, 2) {
+; CHECK-LABEL: @scalable_fixed_neg(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 16
+; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[PTR]], align 32
+; CHECK-NEXT:    ret void
+;
+  %gep = getelementptr i64, ptr %ptr, i64 16
+  store <2 x i64> zeroinitializer, ptr %gep
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @fixed_scalable_redundant_store(ptr %ptr) vscale_range(1, 2) {
+; CHECK-LABEL: @fixed_scalable_redundant_store(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    store <8 x i64> zeroinitializer, ptr [[PTR]], align 64
+; CHECK-NEXT:    ret void
+;
+  %gep = getelementptr i64, ptr %ptr, i64 2
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep
+  store <8 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @fixed_scalable_neg(ptr %ptr) vscale_range(1, 2) {
+; CHECK-LABEL: @fixed_scalable_neg(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    store <4 x i64> zeroinitializer, ptr [[PTR]], align 32
+; CHECK-NEXT:    ret void
+;
+  %gep = getelementptr i64, ptr %ptr, i64 2
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep
+  store <4 x i64> zeroinitializer, ptr %ptr
   ret void
 }

--- a/llvm/test/Transforms/DeadStoreElimination/stores-of-existing-values.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/stores-of-existing-values.ll
@@ -658,78 +658,91 @@ exit:
 
 define void @scalable_scalable_redundant_store(ptr %ptr) {
 ; CHECK-LABEL: @scalable_scalable_redundant_store(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
-; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    [[GEP_PTR_2:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP_PTR_2]], align 16
 ; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[PTR]], align 32
 ; CHECK-NEXT:    ret void
 ;
-  %gep = getelementptr i64, ptr %ptr, i64 2
-  store <vscale x 2 x i64> zeroinitializer, ptr %gep
+  %gep.ptr.2 = getelementptr i64, ptr %ptr, i64 2
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep.ptr.2
   store <vscale x 4 x i64> zeroinitializer, ptr %ptr
   ret void
 }
 
 define void @scalable_scalable_neg(ptr %ptr) {
 ; CHECK-LABEL: @scalable_scalable_neg(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 8
-; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[GEP]], align 32
+; CHECK-NEXT:    [[GEP_PTR_8:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 8
+; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[GEP_PTR_8]], align 32
 ; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[PTR]], align 16
 ; CHECK-NEXT:    ret void
 ;
-  %gep = getelementptr i64, ptr %ptr, i64 8
-  store <vscale x 4 x i64> zeroinitializer, ptr %gep
+  %gep.ptr.8 = getelementptr i64, ptr %ptr, i64 8
+  store <vscale x 4 x i64> zeroinitializer, ptr %gep.ptr.8
   store <vscale x 2 x i64> zeroinitializer, ptr %ptr
+  ret void
+}
+
+define void @scalable_scalable_nonconst_offset_neg(ptr %ptr, i64 %i) {
+; CHECK-LABEL: @scalable_scalable_nonconst_offset_neg(
+; CHECK-NEXT:    [[GEP_PTR_I:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 [[I:%.*]]
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP_PTR_I]], align 16
+; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[PTR]], align 32
+; CHECK-NEXT:    ret void
+;
+  %gep.ptr.i = getelementptr i64, ptr %ptr, i64 %i
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep.ptr.i
+  store <vscale x 4 x i64> zeroinitializer, ptr %ptr
   ret void
 }
 
 define void @scalable_fixed_redundant_store(ptr %ptr) vscale_range(1, 2) {
 ; CHECK-LABEL: @scalable_fixed_redundant_store(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
-; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    [[GEP_PTR_2:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr [[GEP_PTR_2]], align 16
 ; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[PTR]], align 32
 ; CHECK-NEXT:    ret void
 ;
-  %gep = getelementptr i64, ptr %ptr, i64 2
-  store <2 x i64> zeroinitializer, ptr %gep
+  %gep.ptr.2 = getelementptr i64, ptr %ptr, i64 2
+  store <2 x i64> zeroinitializer, ptr %gep.ptr.2
   store <vscale x 4 x i64> zeroinitializer, ptr %ptr
   ret void
 }
 
 define void @scalable_fixed_neg(ptr %ptr) vscale_range(1, 2) {
 ; CHECK-LABEL: @scalable_fixed_neg(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 16
-; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    [[GEP_PTR_16:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 16
+; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr [[GEP_PTR_16]], align 16
 ; CHECK-NEXT:    store <vscale x 4 x i64> zeroinitializer, ptr [[PTR]], align 32
 ; CHECK-NEXT:    ret void
 ;
-  %gep = getelementptr i64, ptr %ptr, i64 16
-  store <2 x i64> zeroinitializer, ptr %gep
+  %gep.ptr.16 = getelementptr i64, ptr %ptr, i64 16
+  store <2 x i64> zeroinitializer, ptr %gep.ptr.16
   store <vscale x 4 x i64> zeroinitializer, ptr %ptr
   ret void
 }
 
 define void @fixed_scalable_redundant_store(ptr %ptr) vscale_range(1, 2) {
 ; CHECK-LABEL: @fixed_scalable_redundant_store(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
-; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    [[GEP_PTR_2:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP_PTR_2]], align 16
 ; CHECK-NEXT:    store <8 x i64> zeroinitializer, ptr [[PTR]], align 64
 ; CHECK-NEXT:    ret void
 ;
-  %gep = getelementptr i64, ptr %ptr, i64 2
-  store <vscale x 2 x i64> zeroinitializer, ptr %gep
+  %gep.ptr.2 = getelementptr i64, ptr %ptr, i64 2
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep.ptr.2
   store <8 x i64> zeroinitializer, ptr %ptr
   ret void
 }
 
 define void @fixed_scalable_neg(ptr %ptr) vscale_range(1, 2) {
 ; CHECK-LABEL: @fixed_scalable_neg(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
-; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP]], align 16
+; CHECK-NEXT:    [[GEP_PTR_2:%.*]] = getelementptr i64, ptr [[PTR:%.*]], i64 2
+; CHECK-NEXT:    store <vscale x 2 x i64> zeroinitializer, ptr [[GEP_PTR_2]], align 16
 ; CHECK-NEXT:    store <4 x i64> zeroinitializer, ptr [[PTR]], align 32
 ; CHECK-NEXT:    ret void
 ;
-  %gep = getelementptr i64, ptr %ptr, i64 2
-  store <vscale x 2 x i64> zeroinitializer, ptr %gep
+  %gep.ptr.2 = getelementptr i64, ptr %ptr, i64 2
+  store <vscale x 2 x i64> zeroinitializer, ptr %gep.ptr.2
   store <4 x i64> zeroinitializer, ptr %ptr
   ret void
 }


### PR DESCRIPTION
As AliasAnalysis now has support for scalable sizes, add tests to DeadStoreElimination covering the scalable vectors case, in preparation to extend it.