### PR TITLE
[LLD] Deprecate --lto-basic-block-sections=labels

### DIFF
--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -62,7 +62,7 @@ static lto::Config createConfig(Ctx &ctx) {
   c.Options.DataSections = true;
 
   // Check if basic block sections must be used.
-  // Allowed values for --lto-basic-block-sections are "all", "labels",
+  // Allowed values for --lto-basic-block-sections are "all",
   // "<file name specifying basic block ids>", or none.  This is the equivalent
   // of -fbasic-block-sections= flag in clang.
   if (!ctx.arg.ltoBasicBlockSections.empty()) {
@@ -70,7 +70,8 @@ static lto::Config createConfig(Ctx &ctx) {
       c.Options.BBSections = BasicBlockSection::All;
     } else if (ctx.arg.ltoBasicBlockSections == "labels") {
       c.Options.BBAddrMap = true;
-      c.Options.BBSections = BasicBlockSection::None;
+      warn("'--lto-basic-block-sections=labels' is deprecated; Please use "
+           "'--lto-basic-block-address-map' instead");
     } else if (ctx.arg.ltoBasicBlockSections == "none") {
       c.Options.BBSections = BasicBlockSection::None;
     } else {

--- a/lld/test/ELF/lto/basic-block-sections.ll
+++ b/lld/test/ELF/lto/basic-block-sections.ll
@@ -1,10 +1,13 @@
 ; REQUIRES: x86
 ; RUN: llvm-as %s -o %t.o
+; RUN: ld.lld %t.o -o %t --lto-basic-block-sections=labels --lto-O0 2>&1 | FileCheck -check-prefix=LABELSWARN %s
 ; RUN: ld.lld %t.o -o %t --lto-basic-block-sections=all --lto-O0 --save-temps
 ; RUN: llvm-readobj -s %t.lto.o | FileCheck --check-prefix=SECNAMES %s
 ; RUN: ld.lld %t.o -o %t --lto-basic-block-sections=all --lto-unique-basic-block-section-names --lto-O0 --save-temps
 ; RUN: llvm-readobj -s %t.lto.o | FileCheck --check-prefix=SECNAMES-FULL %s
 ; RUN: llvm-nm %t | FileCheck --check-prefix=SYMS %s
+
+; LABELSWARN: --lto-basic-block-sections=labels' is deprecated; Please use '--lto-basic-block-address-map' instead
 
 ; SECNAMES: Name: .text.foo {{.*}}
 ; SECNAMES: Name: .text.foo {{.*}}


### PR DESCRIPTION
This option is now replaced by `--lto-basic-block-address-map`.