### PR TITLE
workflows/release-binaries: Use static ZSTD on macOS

### DIFF
--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -101,3 +101,6 @@ set_final_stage_var(LLVM_ENABLE_PROJECTS "${LLVM_RELEASE_ENABLE_PROJECTS}" STRIN
 set_final_stage_var(CPACK_GENERATOR "TXZ" STRING)
 set_final_stage_var(CPACK_ARCHIVE_THREADS "0" STRING)
 
+if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
+  set_final_stage_var(LLVM_USE_STATIC_ZSTD "ON" BOOL)
+endif()


### PR DESCRIPTION
On macOS the shared zstd library points to a homebrew install that isn't
very stable for users.

(cherry picked from commit 748f5404ccdf28d4beef37efdaeba7a1701ab425)
