### PR TITLE
[AArch64][PAC] Move emission of LR checks in tail calls to AsmPrinter

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2274,6 +2274,7 @@ void AArch64AsmPrinter::LowerMOVaddrPAC(const MachineInstr &MI) {
                                                      : AArch64PACKey::DA);
 
         emitPtrauthCheckAuthenticatedValue(AArch64::X16, AArch64::X17, AuthKey,
+                                           AArch64PAuth::AuthCheckMethod::XPAC,
                                            /*ShouldTrap=*/true,
                                            /*OnFailure=*/nullptr);
       }
@@ -2406,6 +2407,7 @@ void AArch64AsmPrinter::LowerLOADgotAUTH(const MachineInstr &MI) {
         (AuthOpcode == AArch64::AUTIA ? AArch64PACKey::IA : AArch64PACKey::DA);
 
     emitPtrauthCheckAuthenticatedValue(AuthResultReg, AArch64::X17, AuthKey,
+                                       AArch64PAuth::AuthCheckMethod::XPAC,
                                        /*ShouldTrap=*/true,
                                        /*OnFailure=*/nullptr);
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -107,6 +107,19 @@ unsigned AArch64InstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   unsigned NumBytes = 0;
   const MCInstrDesc &Desc = MI.getDesc();
 
+  if (!MI.isBundle() && isTailCallReturnInst(MI)) {
+    NumBytes = Desc.getSize() ? Desc.getSize() : 4;
+
+    const auto *MFI = MF->getInfo<AArch64FunctionInfo>();
+    if (!MFI->shouldSignReturnAddress(MF))
+      return NumBytes;
+
+    auto &STI = MF->getSubtarget<AArch64Subtarget>();
+    auto Method = STI.getAuthenticatedLRCheckMethod(*MF);
+    NumBytes += AArch64PAuth::getCheckerSizeInBytes(Method);
+    return NumBytes;
+  }
+
   // Size should be preferably set in
   // llvm/lib/Target/AArch64/AArch64InstrInfo.td (default case).
   // Specific cases handle instructions of variable sizes

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -114,7 +114,7 @@ unsigned AArch64InstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     if (!MFI->shouldSignReturnAddress(MF))
       return NumBytes;
 
-    auto &STI = MF->getSubtarget<AArch64Subtarget>();
+    const auto &STI = MF->getSubtarget<AArch64Subtarget>();
     auto Method = STI.getAuthenticatedLRCheckMethod(*MF);
     NumBytes += AArch64PAuth::getCheckerSizeInBytes(Method);
     return NumBytes;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1964,6 +1964,8 @@ let Predicates = [HasPAuth] in {
   }
 
   // Size 16: 4 fixed + 8 variable, to compute discriminator.
+  // The size returned by getInstSizeInBytes() is incremented according
+  // to the variant of LR check.
   let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Size = 16,
       Uses = [SP] in {
     def AUTH_TCRETURN

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1984,16 +1984,16 @@ let Predicates = [HasPAuth] in {
 
   let Predicates = [TailCallAny] in
     def : Pat<(AArch64authtcret tcGPR64:$dst, (i32 timm:$FPDiff), (i32 timm:$Key),
-                                (i64 timm:$Disc), tcGPR64:$AddrDisc),
+                                (i64 timm:$Disc), tcGPRnotx16x17:$AddrDisc),
               (AUTH_TCRETURN tcGPR64:$dst, imm:$FPDiff, imm:$Key, imm:$Disc,
-                             tcGPR64:$AddrDisc)>;
+                             tcGPRnotx16x17:$AddrDisc)>;
 
   let Predicates = [TailCallX16X17] in
     def : Pat<(AArch64authtcret tcGPRx16x17:$dst, (i32 timm:$FPDiff),
                                 (i32 timm:$Key), (i64 timm:$Disc),
-                                tcGPR64:$AddrDisc),
+                                tcGPRnotx16x17:$AddrDisc),
               (AUTH_TCRETURN_BTI tcGPRx16x17:$dst, imm:$FPDiff, imm:$Key,
-                                 imm:$Disc, tcGPR64:$AddrDisc)>;
+                                 imm:$Disc, tcGPRnotx16x17:$AddrDisc)>;
 }
 
 // v9.5-A pointer authentication extensions

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1969,7 +1969,7 @@ let Predicates = [HasPAuth] in {
   // As the check requires either x16 or x17 as a scratch register and
   // authenticated tail call instructions have two register operands,
   // make sure at least one register is usable as a scratch one - for that
-  // purpose, use tcGPRnotx16x17 register class for the second operand.
+  // purpose, use tcGPRnotx16x17 register class for one of the operands.
   let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Size = 16,
       Uses = [SP] in {
     def AUTH_TCRETURN

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1966,15 +1966,19 @@ let Predicates = [HasPAuth] in {
   // Size 16: 4 fixed + 8 variable, to compute discriminator.
   // The size returned by getInstSizeInBytes() is incremented according
   // to the variant of LR check.
+  // As the check requires either x16 or x17 as a scratch register and
+  // authenticated tail call instructions have two register operands,
+  // make sure at least one register is usable as a scratch one - for that
+  // purpose, use tcGPRnotx16x17 register class for the second operand.
   let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Size = 16,
       Uses = [SP] in {
     def AUTH_TCRETURN
       : Pseudo<(outs), (ins tcGPR64:$dst, i32imm:$FPDiff, i32imm:$Key,
-                            i64imm:$Disc, tcGPR64:$AddrDisc),
+                            i64imm:$Disc, tcGPRnotx16x17:$AddrDisc),
                []>, Sched<[WriteBrReg]>;
     def AUTH_TCRETURN_BTI
       : Pseudo<(outs), (ins tcGPRx16x17:$dst, i32imm:$FPDiff, i32imm:$Key,
-                            i64imm:$Disc, tcGPR64:$AddrDisc),
+                            i64imm:$Disc, tcGPRnotx16x17:$AddrDisc),
                []>, Sched<[WriteBrReg]>;
   }
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1973,8 +1973,8 @@ let Predicates = [HasPAuth] in {
   let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Size = 16,
       Uses = [SP] in {
     def AUTH_TCRETURN
-      : Pseudo<(outs), (ins tcGPR64:$dst, i32imm:$FPDiff, i32imm:$Key,
-                            i64imm:$Disc, tcGPRnotx16x17:$AddrDisc),
+      : Pseudo<(outs), (ins tcGPRnotx16x17:$dst, i32imm:$FPDiff, i32imm:$Key,
+                            i64imm:$Disc, tcGPR64:$AddrDisc),
                []>, Sched<[WriteBrReg]>;
     def AUTH_TCRETURN_BTI
       : Pseudo<(outs), (ins tcGPRx16x17:$dst, i32imm:$FPDiff, i32imm:$Key,
@@ -1983,10 +1983,10 @@ let Predicates = [HasPAuth] in {
   }
 
   let Predicates = [TailCallAny] in
-    def : Pat<(AArch64authtcret tcGPR64:$dst, (i32 timm:$FPDiff), (i32 timm:$Key),
-                                (i64 timm:$Disc), tcGPRnotx16x17:$AddrDisc),
-              (AUTH_TCRETURN tcGPR64:$dst, imm:$FPDiff, imm:$Key, imm:$Disc,
-                             tcGPRnotx16x17:$AddrDisc)>;
+    def : Pat<(AArch64authtcret tcGPRnotx16x17:$dst, (i32 timm:$FPDiff), (i32 timm:$Key),
+                                (i64 timm:$Disc), tcGPR64:$AddrDisc),
+              (AUTH_TCRETURN tcGPRnotx16x17:$dst, imm:$FPDiff, imm:$Key, imm:$Disc,
+                             tcGPR64:$AddrDisc)>;
 
   let Predicates = [TailCallX16X17] in
     def : Pat<(AArch64authtcret tcGPRx16x17:$dst, (i32 timm:$FPDiff),

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.h
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.h
@@ -35,27 +35,29 @@ namespace AArch64PAuth {
 /// ```
 ///   <authenticate LR>
 ///   <method-specific checker>
-/// ret_block:
-///   <more instructions>
-///   ...
-///
-/// break_block:
+/// on_fail:
 ///   brk <code>
+/// on_success:
+///   <more instructions>
+///
 /// ```
 enum class AuthCheckMethod {
   /// Do not check the value at all
   None,
+
   /// Perform a load to a temporary register
   DummyLoad,
+
   /// Check by comparing bits 62 and 61 of the authenticated address.
   ///
   /// This method modifies control flow and inserts the following checker:
   ///
   /// ```
   ///   eor Xtmp, Xn, Xn, lsl #1
-  ///   tbnz Xtmp, #62, break_block
+  ///   tbz Xtmp, #62, on_success
   /// ```
   HighBitsNoTBI,
+
   /// Check by comparing the authenticated value with an XPAC-ed one without
   /// using PAuth instructions not encoded as HINT. Can only be applied to LR.
   ///
@@ -68,9 +70,19 @@ enum class AuthCheckMethod {
   ///   ; the authentication succeeded and the temporary register contains the
   ///   ; *real* result of authentication.
   ///   cmp Xtmp, LR
-  ///   b.ne break_block
+  ///   b.eq on_success
   /// ```
   XPACHint,
+
+  /// Similar to XPACHint but using Armv8.3-only XPAC instruction, thus
+  /// not restricted to LR:
+  /// ```
+  ///   mov Xtmp, Xn
+  ///   xpac(i|d) Xn
+  ///   cmp Xtmp, Xn
+  ///   b.eq on_success
+  /// ```
+  XPAC,
 };
 
 #define AUTH_CHECK_METHOD_CL_VALUES_COMMON                                     \
@@ -86,22 +98,6 @@ enum class AuthCheckMethod {
       AUTH_CHECK_METHOD_CL_VALUES_COMMON,                                      \
       clEnumValN(AArch64PAuth::AuthCheckMethod::XPACHint, "xpac-hint",         \
                  "Compare with the result of XPACLRI")
-
-/// Explicitly checks that pointer authentication succeeded.
-///
-/// Assuming AuthenticatedReg contains a value returned by one of the AUT*
-/// instructions, check the value using Method just before the instruction
-/// pointed to by MBBI. If the check succeeds, execution proceeds to the
-/// instruction pointed to by MBBI, otherwise a CPU exception is generated.
-///
-/// Some of the methods may need to know if the pointer was authenticated
-/// using an I-key or D-key and which register can be used as temporary.
-/// If an explicit BRK instruction is used to generate an exception, BrkImm
-/// specifies its immediate operand.
-void checkAuthenticatedRegister(MachineBasicBlock::iterator MBBI,
-                                AuthCheckMethod Method,
-                                Register AuthenticatedReg, Register TmpReg,
-                                bool UseIKey, unsigned BrkImm);
 
 /// Returns the number of bytes added by checkAuthenticatedRegister.
 unsigned getCheckerSizeInBytes(AuthCheckMethod Method);

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.h
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.h
@@ -86,13 +86,15 @@ enum class AuthCheckMethod {
 };
 
 #define AUTH_CHECK_METHOD_CL_VALUES_COMMON                                     \
-      clEnumValN(AArch64PAuth::AuthCheckMethod::None, "none",                  \
-                 "Do not check authenticated address"),                        \
+  clEnumValN(AArch64PAuth::AuthCheckMethod::None, "none",                      \
+             "Do not check authenticated address"),                            \
       clEnumValN(AArch64PAuth::AuthCheckMethod::DummyLoad, "load",             \
                  "Perform dummy load from authenticated address"),             \
-      clEnumValN(AArch64PAuth::AuthCheckMethod::HighBitsNoTBI,                 \
-                 "high-bits-notbi",                                            \
-                 "Compare bits 62 and 61 of address (TBI should be disabled)")
+      clEnumValN(                                                              \
+          AArch64PAuth::AuthCheckMethod::HighBitsNoTBI, "high-bits-notbi",     \
+          "Compare bits 62 and 61 of address (TBI should be disabled)"),       \
+      clEnumValN(AArch64PAuth::AuthCheckMethod::XPAC, "xpac",                  \
+                 "Compare with the result of XPAC (requires Armv8.3-a)")
 
 #define AUTH_CHECK_METHOD_CL_VALUES_LR                                         \
       AUTH_CHECK_METHOD_CL_VALUES_COMMON,                                      \

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -249,6 +249,10 @@ def tcGPR64 : RegisterClass<"AArch64", [i64], 64, (sub GPR64common, X19, X20, X2
 def tcGPRx17 : RegisterClass<"AArch64", [i64], 64, (add X17)>;
 def tcGPRx16x17 : RegisterClass<"AArch64", [i64], 64, (add X16, X17)>;
 def tcGPRnotx16 : RegisterClass<"AArch64", [i64], 64, (sub tcGPR64, X16)>;
+// LR checking code expects either x16 or x17 to be available as a scratch
+// register - for that reason restrict one of two register operands of
+// AUTH_TCRETURN* pseudos.
+def tcGPRnotx16x17 : RegisterClass<"AArch64", [i64], 64, (sub tcGPR64, X16, X17)>;
 
 // Register set that excludes registers that are reserved for procedure calls.
 // This is used for pseudo-instructions that are actually implemented using a

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -386,8 +386,6 @@ AArch64Subtarget::AArch64Subtarget(const Triple &TT, StringRef CPU,
   if (ReservedRegNames.count("X29") || ReservedRegNames.count("FP"))
     ReserveXRegisterForRA.set(29);
 
-  AddressCheckPSV.reset(new AddressCheckPseudoSourceValue(TM));
-
   EnableSubregLiveness = EnableSubregLivenessTracking.getValue();
 }
 

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -442,29 +442,6 @@ public:
   /// a function.
   std::optional<uint16_t>
   getPtrAuthBlockAddressDiscriminatorIfEnabled(const Function &ParentFn) const;
-
-  const PseudoSourceValue *getAddressCheckPSV() const {
-    return AddressCheckPSV.get();
-  }
-
-private:
-  /// Pseudo value representing memory load performed to check an address.
-  ///
-  /// This load operation is solely used for its side-effects: if the address
-  /// is not mapped (or not readable), it triggers CPU exception, otherwise
-  /// execution proceeds and the value is not used.
-  class AddressCheckPseudoSourceValue : public PseudoSourceValue {
-  public:
-    AddressCheckPseudoSourceValue(const TargetMachine &TM)
-        : PseudoSourceValue(TargetCustom, TM) {}
-
-    bool isConstant(const MachineFrameInfo *) const override { return false; }
-    bool isAliased(const MachineFrameInfo *) const override { return true; }
-    bool mayAlias(const MachineFrameInfo *) const override { return true; }
-    void printCustom(raw_ostream &OS) const override { OS << "AddressCheck"; }
-  };
-
-  std::unique_ptr<AddressCheckPseudoSourceValue> AddressCheckPSV;
 };
 } // End llvm namespace
 

--- a/llvm/test/CodeGen/AArch64/ptrauth-call.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-call.ll
@@ -173,9 +173,9 @@ define void @test_tailcall_omit_mov_x16_x16(ptr %objptr) #0 {
 ; CHECK:         mov     x17, x0
 ; CHECK:         movk    x17, #6503, lsl #48
 ; CHECK:         autda   x16, x17
-; CHECK:         ldr     x1, [x16]
+; CHECK:         ldr     x2, [x16]
 ; CHECK:         movk    x16, #54167, lsl #48
-; CHECK:         braa    x1, x16
+; CHECK:         braa    x2, x16
   %vtable.signed = load ptr, ptr %objptr, align 8
   %objptr.int = ptrtoint ptr %objptr to i64
   %vtable.discr = tail call i64 @llvm.ptrauth.blend(i64 %objptr.int, i64 6503)

--- a/llvm/test/CodeGen/AArch64/ptrauth-call.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-call.ll
@@ -169,13 +169,13 @@ define i32 @test_tailcall_ib_var(ptr %arg0, ptr %arg1) #0 {
 
 define void @test_tailcall_omit_mov_x16_x16(ptr %objptr) #0 {
 ; CHECK-LABEL: test_tailcall_omit_mov_x16_x16:
-; CHECK:         ldr     x16, [x0]
-; CHECK:         mov     x17, x0
-; CHECK:         movk    x17, #6503, lsl #48
-; CHECK:         autda   x16, x17
-; CHECK:         ldr     x2, [x16]
-; CHECK:         movk    x16, #54167, lsl #48
-; CHECK:         braa    x2, x16
+; CHECK-NEXT:    ldr     x16, [x0]
+; CHECK-NEXT:    mov     x17, x0
+; CHECK-NEXT:    movk    x17, #6503, lsl #48
+; CHECK-NEXT:    autda   x16, x17
+; CHECK-NEXT:    ldr     x1, [x16]
+; CHECK-NEXT:    movk    x16, #54167, lsl #48
+; CHECK-NEXT:    braa    x1, x16
   %vtable.signed = load ptr, ptr %objptr, align 8
   %objptr.int = ptrtoint ptr %objptr to i64
   %vtable.discr = tail call i64 @llvm.ptrauth.blend(i64 %objptr.int, i64 6503)

--- a/llvm/test/CodeGen/AArch64/ptrauth-ret-trap.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-ret-trap.ll
@@ -7,10 +7,10 @@
 ; CHECK-NEXT:   ldr x30, [sp], #16
 ; CHECK-NEXT:   autibsp
 ; CHECK-NEXT:   eor x16, x30, x30, lsl #1
-; CHECK-NEXT:   tbnz x16, #62, [[BAD:.L.*]]
-; CHECK-NEXT:   b bar
-; CHECK-NEXT:   [[BAD]]:
+; CHECK-NEXT:   tbz x16, #62, [[GOOD:.L.*]]
 ; CHECK-NEXT:   brk #0xc471
+; CHECK-NEXT:   [[GOOD]]:
+; CHECK-NEXT:   b bar
 define i32 @test_tailcall() #0 {
   call i32 @bar()
   %c = tail call i32 @bar()
@@ -27,10 +27,10 @@ define i32 @test_tailcall_noframe() #0 {
 ; CHECK-LABEL: test_tailcall_indirect:
 ; CHECK:         autibsp
 ; CHECK:         eor     x16, x30, x30, lsl #1
-; CHECK:         tbnz    x16, #62, [[BAD:.L.*]]
-; CHECK:         br      x0
-; CHECK: [[BAD]]:
+; CHECK:         tbz     x16, #62, [[GOOD:.L.*]]
 ; CHECK:         brk     #0xc471
+; CHECK: [[GOOD]]:
+; CHECK:         br      x0
 define void @test_tailcall_indirect(ptr %fptr) #0 {
   call i32 @test_tailcall()
   tail call void %fptr()
@@ -40,10 +40,10 @@ define void @test_tailcall_indirect(ptr %fptr) #0 {
 ; CHECK-LABEL: test_tailcall_indirect_in_x9:
 ; CHECK:         autibsp
 ; CHECK:         eor     x16, x30, x30, lsl #1
-; CHECK:         tbnz    x16, #62, [[BAD:.L.*]]
-; CHECK:         br      x9
-; CHECK: [[BAD]]:
+; CHECK:         tbz     x16, #62, [[GOOD:.L.*]]
 ; CHECK:         brk     #0xc471
+; CHECK: [[GOOD]]:
+; CHECK:         br      x9
 define void @test_tailcall_indirect_in_x9(ptr sret(i64) %ret, [8 x i64] %in, ptr %fptr) #0 {
   %ptr = alloca i8, i32 16
   call i32 @test_tailcall()
@@ -54,11 +54,11 @@ define void @test_tailcall_indirect_in_x9(ptr sret(i64) %ret, [8 x i64] %in, ptr
 ; CHECK-LABEL: test_auth_tailcall_indirect:
 ; CHECK:         autibsp
 ; CHECK:         eor     x16, x30, x30, lsl #1
-; CHECK:         tbnz    x16, #62, [[BAD:.L.*]]
+; CHECK:         tbz     x16, #62, [[GOOD:.L.*]]
+; CHECK:         brk     #0xc471
+; CHECK: [[GOOD]]:
 ; CHECK:         mov x16, #42
 ; CHECK:         braa      x0, x16
-; CHECK: [[BAD]]:
-; CHECK:         brk     #0xc471
 define void @test_auth_tailcall_indirect(ptr %fptr) #0 {
   call i32 @test_tailcall()
   tail call void %fptr() [ "ptrauth"(i32 0, i64 42) ]
@@ -68,10 +68,10 @@ define void @test_auth_tailcall_indirect(ptr %fptr) #0 {
 ; CHECK-LABEL: test_auth_tailcall_indirect_in_x9:
 ; CHECK:         autibsp
 ; CHECK:         eor     x16, x30, x30, lsl #1
-; CHECK:         tbnz    x16, #62, [[BAD:.L.*]]
-; CHECK:         brabz      x9
-; CHECK: [[BAD]]:
+; CHECK:         tbz     x16, #62, [[GOOD:.L.*]]
 ; CHECK:         brk     #0xc471
+; CHECK: [[GOOD]]:
+; CHECK:         brabz      x9
 define void @test_auth_tailcall_indirect_in_x9(ptr sret(i64) %ret, [8 x i64] %in, ptr %fptr) #0 {
   %ptr = alloca i8, i32 16
   call i32 @test_tailcall()
@@ -82,10 +82,10 @@ define void @test_auth_tailcall_indirect_in_x9(ptr sret(i64) %ret, [8 x i64] %in
 ; CHECK-LABEL: test_auth_tailcall_indirect_bti:
 ; CHECK:         autibsp
 ; CHECK:         eor     x17, x30, x30, lsl #1
-; CHECK:         tbnz    x17, #62, [[BAD:.L.*]]
-; CHECK:         brabz      x16
-; CHECK: [[BAD]]:
+; CHECK:         tbz     x17, #62, [[GOOD:.L.*]]
 ; CHECK:         brk     #0xc471
+; CHECK: [[GOOD]]:
+; CHECK:         brabz      x16
 define void @test_auth_tailcall_indirect_bti(ptr sret(i64) %ret, [8 x i64] %in, ptr %fptr) #0 "branch-target-enforcement"="true" {
   %ptr = alloca i8, i32 16
   call i32 @test_tailcall()

--- a/llvm/test/CodeGen/AArch64/ptrauth-tail-call-regalloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-tail-call-regalloc.ll
@@ -1,59 +1,113 @@
-; RUN: llc -mtriple aarch64-linux-pauthtest -o - %s \
+; RUN: llc -mtriple aarch64 -o - %s \
 ; RUN:     -aarch64-authenticated-lr-check-method=xpac-hint \
 ; RUN:     -stop-before=aarch64-ptrauth \
 ; RUN:     | FileCheck --check-prefix=MIR %s
 
-; RUN: llc -mtriple aarch64-linux-pauthtest -o - %s \
+; RUN: llc -mtriple aarch64 -o - %s -asm-verbose=0 \
 ; RUN:     -aarch64-authenticated-lr-check-method=xpac-hint \
 ; RUN:     | FileCheck --check-prefix=ASM %s
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
 
-; Test that expansion of AUTH_TCRETURN does not crash due to unavailability of
-; neither x16 nor x17 as a scratch register.
+;; Test that expansion of AUTH_TCRETURN does not crash due to unavailability of
+;; neither x16 nor x17 as a scratch register.
 define i32 @test_scratch_reg_nobti(ptr %callee, ptr %addr) #0 {
 entry:
-  ; Force spilling of LR
+  ;; Force spilling of LR
   tail call void asm sideeffect "", "~{lr}"()
-  ; Clobber x0-x15 and x18-x29
+  ;; Clobber x0-x15 and x18-x29. This is rather fragile but it was observed to
+  ;; trick regalloc into allocating both x16 and x17 as inputs of AUTH_TCRETURN.
   tail call void asm sideeffect "", "~{x0},~{x1},~{x2},~{x3},~{x4},~{x5},~{x6},~{x7},~{x8},~{x9},~{x10},~{x11},~{x12},~{x13},~{x14},~{x15}"()
   tail call void asm sideeffect "", "~{x18},~{x19},~{x20},~{x21},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28},~{fp}"()
   %addr.i = ptrtoint ptr %addr to i64
   %call = tail call i32 %callee() #1 [ "ptrauth"(i32 0, i64 %addr.i) ]
   ret i32 %call
 }
+;; Ensure the specific tail call pseudo instruction is used.
 ; MIR-LABEL: name: test_scratch_reg_nobti
 ; MIR:         AUTH_TCRETURN{{ }}
 ;
-; ASM-LABEL: @test_scratch_reg_nobti
-; ASM:         autibsp
-; ASM-NEXT:    eor  x17, x30, x30, lsl #1
-; ASM-NEXT:    tbz  x17, #62, .Lauth_success_0
-; ASM-NEXT:    brk  #0xc471
+; ASM-LABEL: test_scratch_reg_nobti:
+; ASM-NEXT:    pacibsp
+; ASM-NEXT:    sub     sp, sp, #112
+; ASM-NEXT:    stp     x29, x30, [sp, #16]
+; ASM-NEXT:    mov     x16, x1
+; ASM-NEXT:    stp     x28, x27, [sp, #32]
+; ASM-NEXT:    stp     x26, x25, [sp, #48]
+; ASM-NEXT:    stp     x24, x23, [sp, #64]
+; ASM-NEXT:    stp     x22, x21, [sp, #80]
+; ASM-NEXT:    stp     x20, x19, [sp, #96]
+; ASM-NEXT:    str     x0, [sp, #8]
+; ASM-NEXT:    //APP
+; ASM-NEXT:    //NO_APP
+; ASM-NEXT:    //APP
+; ASM-NEXT:    //NO_APP
+; ASM-NEXT:    //APP
+; ASM-NEXT:    //NO_APP
+; ASM-NEXT:    ldr     x0, [sp, #8]
+; ASM-NEXT:    ldp     x20, x19, [sp, #96]
+; ASM-NEXT:    ldp     x22, x21, [sp, #80]
+; ASM-NEXT:    ldp     x24, x23, [sp, #64]
+; ASM-NEXT:    ldp     x26, x25, [sp, #48]
+; ASM-NEXT:    ldp     x28, x27, [sp, #32]
+; ASM-NEXT:    ldp     x29, x30, [sp, #16]
+; ASM-NEXT:    add     sp, sp, #112
+; ASM-NEXT:    autibsp
+; ASM-NEXT:    eor     x17, x30, x30, lsl #1
+; ASM-NEXT:    tbz     x17, #62, .Lauth_success_0
+; ASM-NEXT:    brk     #0xc471
 ; ASM-NEXT:  .Lauth_success_0:
-; ASM-NEXT:    braa x0, x16
+; ASM-NEXT:    braa    x0, x16
+; ASM-NEXT:  .Lfunc_end0:
 
-; The same for AUTH_TCRETURN_BTI.
+;; The same for AUTH_TCRETURN_BTI.
 define i32 @test_scratch_reg_bti(ptr %callee, ptr %addr) "branch-target-enforcement" #0 {
 entry:
-  ; Force spilling of LR
+  ;; Force spilling of LR
   tail call void asm sideeffect "", "~{lr}"()
-  ; Clobber x0-x15 and x18-x29
+  ;; Clobber x0-x15 and x18-x29. This is rather fragile but it was observed to
+  ;; trick regalloc into allocating both x16 and x17 as inputs of AUTH_TCRETURN_BTI.
   tail call void asm sideeffect "", "~{x0},~{x1},~{x2},~{x3},~{x4},~{x5},~{x6},~{x7},~{x8},~{x9},~{x10},~{x11},~{x12},~{x13},~{x14},~{x15}"()
   tail call void asm sideeffect "", "~{x18},~{x19},~{x20},~{x21},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28},~{fp}"()
   %addr.i = ptrtoint ptr %addr to i64
   %call = tail call i32 %callee() #1 [ "ptrauth"(i32 0, i64 %addr.i) ]
   ret i32 %call
 }
+;; Ensure the specific tail call pseudo instruction is used.
 ; MIR-LABEL: name: test_scratch_reg_bti
 ; MIR:         AUTH_TCRETURN_BTI
 ;
-; ASM-LABEL: @test_scratch_reg_bti
-; ASM:         autibsp
-; ASM-NEXT:    eor  x17, x30, x30, lsl #1
-; ASM-NEXT:    tbz  x17, #62, .Lauth_success_1
-; ASM-NEXT:    brk  #0xc471
+; ASM-LABEL: test_scratch_reg_bti:
+; ASM-NEXT:    pacibsp
+; ASM-NEXT:    sub     sp, sp, #112
+; ASM-NEXT:    stp     x29, x30, [sp, #16]
+; ASM-NEXT:    mov     x16, x0
+; ASM-NEXT:    stp     x28, x27, [sp, #32]
+; ASM-NEXT:    stp     x26, x25, [sp, #48]
+; ASM-NEXT:    stp     x24, x23, [sp, #64]
+; ASM-NEXT:    stp     x22, x21, [sp, #80]
+; ASM-NEXT:    stp     x20, x19, [sp, #96]
+; ASM-NEXT:    str     x1, [sp, #8]
+; ASM-NEXT:    //APP
+; ASM-NEXT:    //NO_APP
+; ASM-NEXT:    //APP
+; ASM-NEXT:    //NO_APP
+; ASM-NEXT:    //APP
+; ASM-NEXT:    //NO_APP
+; ASM-NEXT:    ldr     x0, [sp, #8]
+; ASM-NEXT:    ldp     x20, x19, [sp, #96]
+; ASM-NEXT:    ldp     x22, x21, [sp, #80]
+; ASM-NEXT:    ldp     x24, x23, [sp, #64]
+; ASM-NEXT:    ldp     x26, x25, [sp, #48]
+; ASM-NEXT:    ldp     x28, x27, [sp, #32]
+; ASM-NEXT:    ldp     x29, x30, [sp, #16]
+; ASM-NEXT:    add     sp, sp, #112
+; ASM-NEXT:    autibsp
+; ASM-NEXT:    eor     x17, x30, x30, lsl #1
+; ASM-NEXT:    tbz     x17, #62, .Lauth_success_1
+; ASM-NEXT:    brk     #0xc471
 ; ASM-NEXT:  .Lauth_success_1:
-; ASM-NEXT:    braa x16, x0
+; ASM-NEXT:    braa    x16, x0
+; ASM-NEXT:  .Lfunc_end1:
 
 attributes #0 = { nounwind "ptrauth-auth-traps" "ptrauth-calls" "ptrauth-returns" "target-features"="+pauth" }

--- a/llvm/test/CodeGen/AArch64/ptrauth-tail-call-regalloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-tail-call-regalloc.ll
@@ -1,0 +1,59 @@
+; RUN: llc -mtriple aarch64-linux-pauthtest -o - %s \
+; RUN:     -aarch64-authenticated-lr-check-method=xpac-hint \
+; RUN:     -stop-before=aarch64-ptrauth \
+; RUN:     | FileCheck --check-prefix=MIR %s
+
+; RUN: llc -mtriple aarch64-linux-pauthtest -o - %s \
+; RUN:     -aarch64-authenticated-lr-check-method=xpac-hint \
+; RUN:     | FileCheck --check-prefix=ASM %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; Test that expansion of AUTH_TCRETURN does not crash due to unavailability of
+; neither x16 nor x17 as a scratch register.
+define i32 @test_scratch_reg_nobti(ptr %callee, ptr %addr) #0 {
+entry:
+  ; Force spilling of LR
+  tail call void asm sideeffect "", "~{lr}"()
+  ; Clobber x0-x15 and x18-x29
+  tail call void asm sideeffect "", "~{x0},~{x1},~{x2},~{x3},~{x4},~{x5},~{x6},~{x7},~{x8},~{x9},~{x10},~{x11},~{x12},~{x13},~{x14},~{x15}"()
+  tail call void asm sideeffect "", "~{x18},~{x19},~{x20},~{x21},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28},~{fp}"()
+  %addr.i = ptrtoint ptr %addr to i64
+  %call = tail call i32 %callee() #1 [ "ptrauth"(i32 0, i64 %addr.i) ]
+  ret i32 %call
+}
+; MIR-LABEL: name: test_scratch_reg_nobti
+; MIR:         AUTH_TCRETURN{{ }}
+;
+; ASM-LABEL: @test_scratch_reg_nobti
+; ASM:         autibsp
+; ASM-NEXT:    eor  x17, x30, x30, lsl #1
+; ASM-NEXT:    tbz  x17, #62, .Lauth_success_0
+; ASM-NEXT:    brk  #0xc471
+; ASM-NEXT:  .Lauth_success_0:
+; ASM-NEXT:    braa x0, x16
+
+; The same for AUTH_TCRETURN_BTI.
+define i32 @test_scratch_reg_bti(ptr %callee, ptr %addr) "branch-target-enforcement" #0 {
+entry:
+  ; Force spilling of LR
+  tail call void asm sideeffect "", "~{lr}"()
+  ; Clobber x0-x15 and x18-x29
+  tail call void asm sideeffect "", "~{x0},~{x1},~{x2},~{x3},~{x4},~{x5},~{x6},~{x7},~{x8},~{x9},~{x10},~{x11},~{x12},~{x13},~{x14},~{x15}"()
+  tail call void asm sideeffect "", "~{x18},~{x19},~{x20},~{x21},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28},~{fp}"()
+  %addr.i = ptrtoint ptr %addr to i64
+  %call = tail call i32 %callee() #1 [ "ptrauth"(i32 0, i64 %addr.i) ]
+  ret i32 %call
+}
+; MIR-LABEL: name: test_scratch_reg_bti
+; MIR:         AUTH_TCRETURN_BTI
+;
+; ASM-LABEL: @test_scratch_reg_bti
+; ASM:         autibsp
+; ASM-NEXT:    eor  x17, x30, x30, lsl #1
+; ASM-NEXT:    tbz  x17, #62, .Lauth_success_1
+; ASM-NEXT:    brk  #0xc471
+; ASM-NEXT:  .Lauth_success_1:
+; ASM-NEXT:    braa x16, x0
+
+attributes #0 = { nounwind "ptrauth-auth-traps" "ptrauth-calls" "ptrauth-returns" "target-features"="+pauth" }

--- a/llvm/test/CodeGen/AArch64/sign-return-address-tailcall.ll
+++ b/llvm/test/CodeGen/AArch64/sign-return-address-tailcall.ll
@@ -14,16 +14,16 @@ define i32 @tailcall_direct() "sign-return-address"="non-leaf" {
 ; LDR-NEXT:       ldr w16, [x30]
 ;
 ; BITS-NOTBI-NEXT: eor x16, x30, x30, lsl #1
-; BITS-NOTBI-NEXT: tbnz x16, #62, .[[FAIL:LBB[_0-9]+]]
+; BITS-NOTBI-NEXT: tbz x16, #62, .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; XPAC-NEXT:      mov x16, x30
 ; XPAC-NEXT:      [[XPACLRI]]
-; XPAC-NEXT:      cmp x16, x30
-; XPAC-NEXT:      b.ne .[[FAIL:LBB[_0-9]+]]
+; XPAC-NEXT:      cmp x30, x16
+; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
-; COMMON-NEXT:    b callee
-; BRK-NEXT:     .[[FAIL]]:
 ; BRK-NEXT:       brk #0xc470
+; BRK-NEXT:     .[[GOOD]]:
+; COMMON-NEXT:    b callee
   tail call void asm sideeffect "", "~{lr}"()
   %call = tail call i32 @callee()
   ret i32 %call
@@ -39,16 +39,16 @@ define i32 @tailcall_indirect(ptr %fptr) "sign-return-address"="non-leaf" {
 ; LDR-NEXT:       ldr w16, [x30]
 ;
 ; BITS-NOTBI-NEXT: eor x16, x30, x30, lsl #1
-; BITS-NOTBI-NEXT: tbnz x16, #62, .[[FAIL:LBB[_0-9]+]]
+; BITS-NOTBI-NEXT: tbz x16, #62, .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; XPAC-NEXT:      mov x16, x30
 ; XPAC-NEXT:      [[XPACLRI]]
-; XPAC-NEXT:      cmp x16, x30
-; XPAC-NEXT:      b.ne .[[FAIL:LBB[_0-9]+]]
+; XPAC-NEXT:      cmp x30, x16
+; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
-; COMMON-NEXT:    br x0
-; BRK-NEXT:     .[[FAIL]]:
 ; BRK-NEXT:       brk #0xc470
+; BRK-NEXT:     .[[GOOD]]:
+; COMMON-NEXT:    br x0
   tail call void asm sideeffect "", "~{lr}"()
   %call = tail call i32 %fptr()
   ret i32 %call
@@ -80,16 +80,16 @@ define i32 @tailcall_direct_noframe_sign_all() "sign-return-address"="all" {
 ; LDR-NEXT:       ldr w16, [x30]
 ;
 ; BITS-NOTBI-NEXT: eor x16, x30, x30, lsl #1
-; BITS-NOTBI-NEXT: tbnz x16, #62, .[[FAIL:LBB[_0-9]+]]
+; BITS-NOTBI-NEXT: tbz x16, #62, .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; XPAC-NEXT:      mov x16, x30
 ; XPAC-NEXT:      [[XPACLRI]]
-; XPAC-NEXT:      cmp x16, x30
-; XPAC-NEXT:      b.ne .[[FAIL:LBB[_0-9]+]]
+; XPAC-NEXT:      cmp x30, x16
+; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
-; COMMON-NEXT:    b callee
-; BRK-NEXT:     .[[FAIL]]:
 ; BRK-NEXT:       brk #0xc470
+; BRK-NEXT:     .[[GOOD]]:
+; COMMON-NEXT:    b callee
   %call = tail call i32 @callee()
   ret i32 %call
 }
@@ -104,16 +104,16 @@ define i32 @tailcall_indirect_noframe_sign_all(ptr %fptr) "sign-return-address"=
 ; LDR-NEXT:       ldr w16, [x30]
 ;
 ; BITS-NOTBI-NEXT: eor x16, x30, x30, lsl #1
-; BITS-NOTBI-NEXT: tbnz x16, #62, .[[FAIL:LBB[_0-9]+]]
+; BITS-NOTBI-NEXT: tbz x16, #62, .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; XPAC-NEXT:      mov x16, x30
 ; XPAC-NEXT:      [[XPACLRI]]
-; XPAC-NEXT:      cmp x16, x30
-; XPAC-NEXT:      b.ne .[[FAIL:LBB[_0-9]+]]
+; XPAC-NEXT:      cmp x30, x16
+; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
-; COMMON-NEXT:    br x0
-; BRK-NEXT:     .[[FAIL]]:
 ; BRK-NEXT:       brk #0xc470
+; BRK-NEXT:     .[[GOOD]]:
+; COMMON-NEXT:    br x0
   %call = tail call i32 %fptr()
   ret i32 %call
 }
@@ -121,9 +121,9 @@ define i32 @tailcall_indirect_noframe_sign_all(ptr %fptr) "sign-return-address"=
 define i32 @tailcall_ib_key() "sign-return-address"="all" "sign-return-address-key"="b_key" {
 ; COMMON-LABEL: tailcall_ib_key:
 ;
+; BRK:            brk #0xc471
+; BRK-NEXT:     .{{Lauth_success.*}}:
 ; COMMON:         b callee
-; BRK-NEXT:     .{{LBB.*}}:
-; BRK-NEXT:       brk #0xc471
   tail call void asm sideeffect "", "~{lr}"()
   %call = tail call i32 @callee()
   ret i32 %call
@@ -141,16 +141,16 @@ define i32 @tailcall_two_branches(i1 %0) "sign-return-address"="all" {
 ; LDR-NEXT:          ldr w16, [x30]
 ;
 ; BITS-NOTBI-NEXT:   eor x16, x30, x30, lsl #1
-; BITS-NOTBI-NEXT:   tbnz x16, #62, .[[FAIL:LBB[_0-9]+]]
+; BITS-NOTBI-NEXT:   tbz x16, #62, .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; XPAC-NEXT:         mov x16, x30
 ; XPAC-NEXT:         [[XPACLRI]]
-; XPAC-NEXT:         cmp x16, x30
-; XPAC-NEXT:         b.ne .[[FAIL:LBB[_0-9]+]]
+; XPAC-NEXT:         cmp x30, x16
+; XPAC-NEXT:         b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
-; COMMON-NEXT:       b callee
-; BRK-NEXT:        .[[FAIL]]:
 ; BRK-NEXT:          brk #0xc470
+; BRK-NEXT:        .[[GOOD]]:
+; COMMON-NEXT:       b callee
   br i1 %0, label %2, label %3
 2:
   call void @callee2()

--- a/llvm/test/CodeGen/AArch64/sign-return-address-tailcall.ll
+++ b/llvm/test/CodeGen/AArch64/sign-return-address-tailcall.ll
@@ -3,6 +3,7 @@
 ; RUN: llc -mtriple=aarch64 -asm-verbose=0 -aarch64-authenticated-lr-check-method=high-bits-notbi        < %s | FileCheck -DAUTIASP="hint #29" --check-prefixes=COMMON,BITS-NOTBI,BRK %s
 ; RUN: llc -mtriple=aarch64 -asm-verbose=0 -aarch64-authenticated-lr-check-method=xpac-hint              < %s | FileCheck -DAUTIASP="hint #29" -DXPACLRI="hint #7" --check-prefixes=COMMON,XPAC,BRK %s
 ; RUN: llc -mtriple=aarch64 -asm-verbose=0 -aarch64-authenticated-lr-check-method=xpac-hint -mattr=v8.3a < %s | FileCheck -DAUTIASP="autiasp"  -DXPACLRI="xpaclri" --check-prefixes=COMMON,XPAC,BRK %s
+; RUN: llc -mtriple=aarch64 -asm-verbose=0 -aarch64-authenticated-lr-check-method=xpac      -mattr=v8.3a < %s | FileCheck -DAUTIASP="autiasp"  --check-prefixes=COMMON,XPAC83,BRK %s
 
 define i32 @tailcall_direct() "sign-return-address"="non-leaf" {
 ; COMMON-LABEL: tailcall_direct:
@@ -20,6 +21,11 @@ define i32 @tailcall_direct() "sign-return-address"="non-leaf" {
 ; XPAC-NEXT:      [[XPACLRI]]
 ; XPAC-NEXT:      cmp x30, x16
 ; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
+;
+; XPAC83-NEXT:    mov x16, x30
+; XPAC83-NEXT:    xpaci x16
+; XPAC83-NEXT:    cmp x30, x16
+; XPAC83-NEXT:    b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; BRK-NEXT:       brk #0xc470
 ; BRK-NEXT:     .[[GOOD]]:
@@ -45,6 +51,11 @@ define i32 @tailcall_indirect(ptr %fptr) "sign-return-address"="non-leaf" {
 ; XPAC-NEXT:      [[XPACLRI]]
 ; XPAC-NEXT:      cmp x30, x16
 ; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
+;
+; XPAC83-NEXT:    mov x16, x30
+; XPAC83-NEXT:    xpaci x16
+; XPAC83-NEXT:    cmp x30, x16
+; XPAC83-NEXT:    b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; BRK-NEXT:       brk #0xc470
 ; BRK-NEXT:     .[[GOOD]]:
@@ -87,6 +98,11 @@ define i32 @tailcall_direct_noframe_sign_all() "sign-return-address"="all" {
 ; XPAC-NEXT:      cmp x30, x16
 ; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
+; XPAC83-NEXT:    mov x16, x30
+; XPAC83-NEXT:    xpaci x16
+; XPAC83-NEXT:    cmp x30, x16
+; XPAC83-NEXT:    b.eq .[[GOOD:Lauth_success[_0-9]+]]
+;
 ; BRK-NEXT:       brk #0xc470
 ; BRK-NEXT:     .[[GOOD]]:
 ; COMMON-NEXT:    b callee
@@ -110,6 +126,11 @@ define i32 @tailcall_indirect_noframe_sign_all(ptr %fptr) "sign-return-address"=
 ; XPAC-NEXT:      [[XPACLRI]]
 ; XPAC-NEXT:      cmp x30, x16
 ; XPAC-NEXT:      b.eq .[[GOOD:Lauth_success[_0-9]+]]
+;
+; XPAC83-NEXT:    mov x16, x30
+; XPAC83-NEXT:    xpaci x16
+; XPAC83-NEXT:    cmp x30, x16
+; XPAC83-NEXT:    b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; BRK-NEXT:       brk #0xc470
 ; BRK-NEXT:     .[[GOOD]]:
@@ -147,6 +168,11 @@ define i32 @tailcall_two_branches(i1 %0) "sign-return-address"="all" {
 ; XPAC-NEXT:         [[XPACLRI]]
 ; XPAC-NEXT:         cmp x30, x16
 ; XPAC-NEXT:         b.eq .[[GOOD:Lauth_success[_0-9]+]]
+;
+; XPAC83-NEXT:       mov x16, x30
+; XPAC83-NEXT:       xpaci x16
+; XPAC83-NEXT:       cmp x30, x16
+; XPAC83-NEXT:       b.eq .[[GOOD:Lauth_success[_0-9]+]]
 ;
 ; BRK-NEXT:          brk #0xc470
 ; BRK-NEXT:        .[[GOOD]]:


### PR DESCRIPTION
Move the emission of the checks performed on the authenticated LR value
during tail calls to AArch64AsmPrinter class, so that different checker
sequences can be reused by pseudo instructions expanded there.
This adds one more option to AuthCheckMethod enumeration, the generic
XPAC variant which is not restricted to checking the LR register.