### PR TITLE
[lldb] Unify implementation of CommandReturnObject::SetError(NFC)

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -131,7 +131,7 @@ public:
     AppendError(llvm::formatv(format, std::forward<Args>(args)...).str());
   }
 
-  void SetError(const Status &error, const char *fallback_error_cstr = nullptr);
+  void SetError(Status error);
 
   void SetError(llvm::Error error);
 

--- a/lldb/source/API/SBCommandReturnObject.cpp
+++ b/lldb/source/API/SBCommandReturnObject.cpp
@@ -326,10 +326,10 @@ void SBCommandReturnObject::SetError(lldb::SBError &error,
                                      const char *fallback_error_cstr) {
   LLDB_INSTRUMENT_VA(this, error, fallback_error_cstr);
 
-  if (error.IsValid())
-    ref().SetError(error.ref(), fallback_error_cstr);
+  if (error.IsValid() && !error.Fail())
+    ref().SetError(error.ref().Clone());
   else if (fallback_error_cstr)
-    ref().SetError(Status(), fallback_error_cstr);
+    ref().SetError(Status::FromErrorString(fallback_error_cstr));
 }
 
 void SBCommandReturnObject::SetError(const char *error_cstr) {

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -389,7 +389,7 @@ protected:
               m_bp_options_vec, result);
         }
         if (!error.Success())
-          result.SetError(error);
+          result.SetError(std::move(error));
       } else {
         // Special handling for one-liner specified inline.
         if (m_options.m_use_one_liner)

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -202,7 +202,7 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     // If the expression failed, return an error.
     if (expr_result != eExpressionCompleted) {
       if (valobj_sp)
-        result.SetError(valobj_sp->GetError());
+        result.SetError(valobj_sp->GetError().Clone());
       else
         result.AppendErrorWithFormatv(
             "unknown error evaluating expression `{0}`", expr);

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -647,8 +647,8 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
           initialize = true;
           repl_sp = target.GetREPL(repl_error, m_command_options.language,
                                     nullptr, true);
-          if (!repl_error.Success()) {
-            result.SetError(repl_error);
+          if (repl_error.Fail()) {
+            result.SetError(std::move(repl_error));
             return;
           }
         }
@@ -668,7 +668,7 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
           repl_error = Status::FromErrorStringWithFormat(
               "Couldn't create a REPL for %s",
               Language::GetNameForLanguageType(m_command_options.language));
-          result.SetError(repl_error);
+          result.SetError(std::move(repl_error));
           return;
         }
       }

--- a/lldb/source/Commands/CommandObjectMemoryTag.cpp
+++ b/lldb/source/Commands/CommandObjectMemoryTag.cpp
@@ -290,7 +290,7 @@ protected:
                                              tagged_range->GetByteSize(), tags);
 
     if (status.Fail()) {
-      result.SetError(status);
+      result.SetError(std::move(status));
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -2775,7 +2775,7 @@ protected:
           result.AppendErrorWithFormat(
               "Unable to locate the executable or symbol file with UUID %s",
               strm.GetData());
-          result.SetError(error);
+          result.SetError(std::move(error));
           return;
         }
       } else {
@@ -4409,7 +4409,7 @@ protected:
         return AddModuleSymbols(m_exe_ctx.GetTargetPtr(), module_spec, flush,
                                 result);
     } else {
-      result.SetError(error);
+      result.SetError(std::move(error));
     }
     return false;
   }

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -622,7 +622,7 @@ protected:
         result.SetStatus(eReturnStatusSuccessContinuingNoResult);
       }
     } else {
-      result.SetError(new_plan_status);
+      result.SetError(std::move(new_plan_status));
     }
   }
 
@@ -1046,7 +1046,7 @@ protected:
           new_plan_sp->SetIsControllingPlan(true);
           new_plan_sp->SetOkayToDiscard(false);
         } else {
-          result.SetError(new_plan_status);
+          result.SetError(std::move(new_plan_status));
           return;
         }
       } else {
@@ -1734,7 +1734,7 @@ protected:
       Status err = thread->JumpToLine(file, line, m_options.m_force, &warnings);
 
       if (err.Fail()) {
-        result.SetError(err);
+        result.SetError(std::move(err));
         return;
       }
 

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -107,10 +107,8 @@ void CommandReturnObject::AppendError(llvm::StringRef in_string) {
   error(GetErrorStream()) << msg << '\n';
 }
 
-void CommandReturnObject::SetError(const Status &error,
-                                   const char *fallback_error_cstr) {
-  if (error.Fail())
-    AppendError(error.AsCString(fallback_error_cstr));
+void CommandReturnObject::SetError(Status error) {
+  SetError(error.takeError());
 }
 
 void CommandReturnObject::SetError(llvm::Error error) {


### PR DESCRIPTION
This is a cleanup that moves the API towards value semantics.