### PR TITLE
[TableGen] Change `getValueAsListOfDefs` to return const pointer vector

### DIFF
--- a/clang/utils/TableGen/ASTTableGen.h
+++ b/clang/utils/TableGen/ASTTableGen.h
@@ -320,7 +320,7 @@ public:
   }
 
   std::vector<const llvm::Record *> getBufferElementTypes() const {
-    return get()->getValueAsListOfConstDefs(BufferElementTypesFieldName);
+    return get()->getValueAsListOfDefs(BufferElementTypesFieldName);
   }
 
   static llvm::StringRef getTableGenNodeClassName() {

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -1746,8 +1746,7 @@ getSpellingListIndex(const std::vector<FlattenedSpelling> &SpellingList,
 }
 
 static void writeAttrAccessorDefinition(const Record &R, raw_ostream &OS) {
-  std::vector<const Record *> Accessors =
-      R.getValueAsListOfConstDefs("Accessors");
+  std::vector<const Record *> Accessors = R.getValueAsListOfDefs("Accessors");
   if (Accessors.empty())
     return;
 
@@ -1964,7 +1963,7 @@ struct AttributeSubjectMatchRule {
 
   std::vector<const Record *> getSubjects() const {
     return (Constraint ? Constraint : MetaSubject)
-        ->getValueAsListOfConstDefs("Subjects");
+        ->getValueAsListOfDefs("Subjects");
   }
 
   std::vector<const Record *> getLangOpts() const {
@@ -1972,11 +1971,11 @@ struct AttributeSubjectMatchRule {
       // Lookup the options in the sub-rule first, in case the sub-rule
       // overrides the rules options.
       std::vector<const Record *> Opts =
-          Constraint->getValueAsListOfConstDefs("LangOpts");
+          Constraint->getValueAsListOfDefs("LangOpts");
       if (!Opts.empty())
         return Opts;
     }
-    return MetaSubject->getValueAsListOfConstDefs("LangOpts");
+    return MetaSubject->getValueAsListOfDefs("LangOpts");
   }
 
   // Abstract rules are used only for sub-rules
@@ -2105,7 +2104,7 @@ PragmaClangAttributeSupport::PragmaClangAttributeSupport(
                                        const Record *Constraint) {
     Rules.emplace_back(MetaSubject, Constraint);
     for (const Record *Subject :
-         SubjectContainer->getValueAsListOfConstDefs("Subjects")) {
+         SubjectContainer->getValueAsListOfDefs("Subjects")) {
       bool Inserted =
           SubjectsToRules
               .try_emplace(Subject, RuleOrAggregateRuleSet::getRule(
@@ -2503,7 +2502,7 @@ static void emitClangAttrTypeArgList(const RecordKeeper &Records,
   std::map<std::string, FSIVecTy> FSIMap;
   for (const auto *Attr : Records.getAllDerivedDefinitions("Attr")) {
     // Determine whether the first argument is a type.
-    std::vector<const Record *> Args = Attr->getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = Attr->getValueAsListOfDefs("Args");
     if (Args.empty())
       continue;
 
@@ -2581,7 +2580,7 @@ static void emitClangAttrVariadicIdentifierArgList(const RecordKeeper &Records,
   std::map<std::string, FSIVecTy> FSIMap;
   for (const auto *A : Records.getAllDerivedDefinitions("Attr")) {
     // Determine whether the first argument is a variadic identifier.
-    std::vector<const Record *> Args = A->getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = A->getValueAsListOfDefs("Args");
     if (Args.empty() || !isVariadicIdentifierArgument(Args[0]))
       continue;
     generateFlattenedSpellingInfo(*A, FSIMap);
@@ -2614,7 +2613,7 @@ emitClangAttrUnevaluatedStringLiteralList(const RecordKeeper &Records,
   std::map<std::string, FSIVecTy> FSIMap;
   for (const auto *Attr : Records.getAllDerivedDefinitions("Attr")) {
     // Determine whether there are any string arguments.
-    uint32_t ArgMask = MakeMask(Attr->getValueAsListOfConstDefs("Args"));
+    uint32_t ArgMask = MakeMask(Attr->getValueAsListOfDefs("Args"));
     if (!ArgMask)
       continue;
     generateFlattenedSpellingInfo(*Attr, FSIMap, ArgMask);
@@ -2630,7 +2629,7 @@ static void emitClangAttrIdentifierArgList(const RecordKeeper &Records,
   std::map<std::string, FSIVecTy> FSIMap;
   for (const auto *Attr : Records.getAllDerivedDefinitions("Attr")) {
     // Determine whether the first argument is an identifier.
-    std::vector<const Record *> Args = Attr->getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = Attr->getValueAsListOfDefs("Args");
     if (Args.empty() || !isIdentifierArgument(Args[0]))
       continue;
     generateFlattenedSpellingInfo(*Attr, FSIMap);
@@ -2648,7 +2647,7 @@ static void emitClangAttrStrictIdentifierArgList(const RecordKeeper &Records,
     if (!Attr->getValueAsBit("StrictEnumParameters"))
       continue;
     // Check that there is really an identifier argument.
-    std::vector<const Record *> Args = Attr->getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = Attr->getValueAsListOfDefs("Args");
     if (none_of(Args, [&](const Record *R) { return isIdentifierArgument(R); }))
       continue;
     generateFlattenedSpellingInfo(*Attr, FSIMap);
@@ -2670,7 +2669,7 @@ static void emitClangAttrThisIsaIdentifierArgList(const RecordKeeper &Records,
   std::map<std::string, FSIVecTy> FSIMap;
   for (const auto *A : Records.getAllDerivedDefinitions("Attr")) {
     // Determine whether the first argument is a variadic identifier.
-    std::vector<const Record *> Args = A->getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = A->getValueAsListOfDefs("Args");
     if (Args.empty() || !keywordThisIsaIdentifierInArgument(Args[0]))
       continue;
     generateFlattenedSpellingInfo(*A, FSIMap);
@@ -2763,8 +2762,7 @@ static void emitAttributes(const RecordKeeper &Records, raw_ostream &OS,
     else
       OS << "\n// " << R.getName() << "Attr implementation\n\n";
 
-    std::vector<const Record *> ArgRecords =
-        R.getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> ArgRecords = R.getValueAsListOfDefs("Args");
     std::vector<std::unique_ptr<Argument>> Args;
     Args.reserve(ArgRecords.size());
 
@@ -3539,7 +3537,7 @@ void EmitClangAttrPCHRead(const RecordKeeper &Records, raw_ostream &OS) {
           std::make_unique<VariadicExprArgument>("DelayedArgs", R.getName());
       DelayedArgs->writePCHReadDecls(OS);
     }
-    ArgRecords = R.getValueAsListOfConstDefs("Args");
+    ArgRecords = R.getValueAsListOfDefs("Args");
     Args.clear();
     for (const auto *Arg : ArgRecords) {
       Args.emplace_back(createArgument(*Arg, R.getName()));
@@ -3578,7 +3576,7 @@ void EmitClangAttrPCHWrite(const RecordKeeper &Records, raw_ostream &OS) {
     if (!R.getValueAsBit("ASTNode"))
       continue;
     OS << "  case attr::" << R.getName() << ": {\n";
-    std::vector<const Record *> Args = R.getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = R.getValueAsListOfDefs("Args");
     if (R.isSubClassOf(InhClass) || !Args.empty())
       OS << "    const auto *SA = cast<" << R.getName()
          << "Attr>(A);\n";
@@ -3769,7 +3767,7 @@ void EmitClangRegularKeywordAttributeInfo(const RecordKeeper &Records,
     for (const auto &S : GetFlattenedSpellings(*R)) {
       if (!isRegularKeywordAttribute(S))
         continue;
-      std::vector<const Record *> Args = R->getValueAsListOfConstDefs("Args");
+      std::vector<const Record *> Args = R->getValueAsListOfDefs("Args");
       bool HasArgs = any_of(
           Args, [](const Record *Arg) { return !Arg->getValueAsBit("Fake"); });
 
@@ -3999,8 +3997,7 @@ void EmitClangAttrTemplateInstantiateHelper(ArrayRef<const Record *> Attrs,
       continue;
     }
 
-    std::vector<const Record *> ArgRecords =
-        R.getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> ArgRecords = R.getValueAsListOfDefs("Args");
     std::vector<std::unique_ptr<Argument>> Args;
     Args.reserve(ArgRecords.size());
 
@@ -4205,7 +4202,7 @@ static void GenerateAppertainsTo(const Record &Attr, raw_ostream &OS) {
 
   const Record *SubjectObj = Attr.getValueAsDef("Subjects");
   std::vector<const Record *> Subjects =
-      SubjectObj->getValueAsListOfConstDefs("Subjects");
+      SubjectObj->getValueAsListOfDefs("Subjects");
 
   // If the list of subjects is empty, it is assumed that the attribute
   // appertains to everything.
@@ -4337,7 +4334,7 @@ static void GenerateMutualExclusionsChecks(const Record &Attr,
   for (const Record *Exclusion :
        Records.getAllDerivedDefinitions("MutualExclusions")) {
     std::vector<const Record *> MutuallyExclusiveAttrs =
-        Exclusion->getValueAsListOfConstDefs("Exclusions");
+        Exclusion->getValueAsListOfDefs("Exclusions");
     auto IsCurAttr = [Attr](const Record *R) {
       return R->getName() == Attr.getName();
     };
@@ -4483,8 +4480,7 @@ static void GenerateLangOptRequirements(const Record &R,
                                         raw_ostream &OS) {
   // If the attribute has an empty or unset list of language requirements,
   // use the default handler.
-  std::vector<const Record *> LangOpts =
-      R.getValueAsListOfConstDefs("LangOpts");
+  std::vector<const Record *> LangOpts = R.getValueAsListOfDefs("LangOpts");
   if (LangOpts.empty())
     return;
 
@@ -4629,7 +4625,7 @@ static bool isParamExpr(const Record *Arg) {
 void GenerateIsParamExpr(const Record &Attr, raw_ostream &OS) {
   OS << "bool isParamExpr(size_t N) const override {\n";
   OS << "  return ";
-  auto Args = Attr.getValueAsListOfConstDefs("Args");
+  auto Args = Attr.getValueAsListOfDefs("Args");
   for (size_t I = 0; I < Args.size(); ++I)
     if (isParamExpr(Args[I]))
       OS << "(N == " << I << ") || ";
@@ -4792,7 +4788,7 @@ void EmitClangAttrParsedAttrImpl(const RecordKeeper &Records, raw_ostream &OS) {
     GenerateLangOptRequirements(Attr, OS);
     GenerateTargetRequirements(Attr, Dupes, OS);
     GenerateSpellingTargetRequirements(
-        Attr, Attr.getValueAsListOfConstDefs("TargetSpecificSpellings"), OS);
+        Attr, Attr.getValueAsListOfDefs("TargetSpecificSpellings"), OS);
     GenerateSpellingIndexToSemanticSpelling(Attr, OS);
     PragmaAttributeSupport.generateStrictConformsTo(*I->second, OS);
     GenerateHandleDeclAttribute(Attr, OS);
@@ -4959,7 +4955,7 @@ void EmitClangAttrTextNodeDump(const RecordKeeper &Records, raw_ostream &OS) {
     if (Spellings.size() > 1 && !SpellingNamesAreCommon(Spellings))
       SS << "    OS << \" \" << A->getSpelling();\n";
 
-    std::vector<const Record *> Args = R.getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = R.getValueAsListOfDefs("Args");
     for (const auto *Arg : Args)
       createArgument(*Arg, R.getName())->writeDump(SS);
 
@@ -4989,7 +4985,7 @@ void EmitClangAttrNodeTraverse(const RecordKeeper &Records, raw_ostream &OS) {
     std::string FunctionContent;
     raw_string_ostream SS(FunctionContent);
 
-    std::vector<const Record *> Args = R.getValueAsListOfConstDefs("Args");
+    std::vector<const Record *> Args = R.getValueAsListOfDefs("Args");
     for (const auto *Arg : Args)
       createArgument(*Arg, R.getName())->writeDumpChildren(SS);
     if (Attr->getValueAsBit("AcceptsExprPack"))
@@ -5033,8 +5029,7 @@ void EmitClangAttrDocTable(const RecordKeeper &Records, raw_ostream &OS) {
   for (const auto *A : Records.getAllDerivedDefinitions("Attr")) {
     if (!A->getValueAsBit("ASTNode"))
       continue;
-    std::vector<const Record *> Docs =
-        A->getValueAsListOfConstDefs("Documentation");
+    std::vector<const Record *> Docs = A->getValueAsListOfDefs("Documentation");
     assert(!Docs.empty());
     // Only look at the first documentation if there are several.
     // (Currently there's only one such attr, revisit if this becomes common).
@@ -5254,7 +5249,7 @@ void EmitClangAttrDocs(const RecordKeeper &Records, raw_ostream &OS) {
   for (const auto *A : Records.getAllDerivedDefinitions("Attr")) {
     const Record &Attr = *A;
     std::vector<const Record *> Docs =
-        Attr.getValueAsListOfConstDefs("Documentation");
+        Attr.getValueAsListOfDefs("Documentation");
     for (const auto *D : Docs) {
       const Record &Doc = *D;
       const Record *Category = Doc.getValueAsDef("Category");

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -48,7 +48,7 @@ public:
         Records.getAllDerivedDefinitions("DiagGroup");
     for (unsigned i = 0, e = DiagGroups.size(); i != e; ++i) {
       std::vector<const Record *> SubGroups =
-          DiagGroups[i]->getValueAsListOfConstDefs("SubGroups");
+          DiagGroups[i]->getValueAsListOfDefs("SubGroups");
       for (unsigned j = 0, e = SubGroups.size(); j != e; ++j)
         Mapping[SubGroups[j]].push_back(DiagGroups[i]);
     }

--- a/clang/utils/TableGen/ClangOpcodesEmitter.cpp
+++ b/clang/utils/TableGen/ClangOpcodesEmitter.cpp
@@ -69,7 +69,7 @@ void Enumerate(const Record *R, StringRef N,
 
     if (const auto *TypeClass = dyn_cast<DefInit>(Types->getElement(I))) {
       for (const auto *Type :
-           TypeClass->getDef()->getValueAsListOfConstDefs("Types")) {
+           TypeClass->getDef()->getValueAsListOfDefs("Types")) {
         TypePath.push_back(Type);
         Rec(I + 1, ID + Type->getName());
         TypePath.pop_back();
@@ -117,7 +117,7 @@ void ClangOpcodesEmitter::EmitInterp(raw_ostream &OS, StringRef N,
             [this, R, &OS, &N](ArrayRef<const Record *> TS, const Twine &ID) {
               bool CanReturn = R->getValueAsBit("CanReturn");
               bool ChangesPC = R->getValueAsBit("ChangesPC");
-              const auto &Args = R->getValueAsListOfConstDefs("Args");
+              const auto &Args = R->getValueAsListOfDefs("Args");
 
               OS << "case OP_" << ID << ": {\n";
 
@@ -176,7 +176,7 @@ void ClangOpcodesEmitter::EmitDisasm(raw_ostream &OS, StringRef N,
     OS << "  PrintName(\"" << ID << "\");\n";
     OS << "  OS << \"\\t\"";
 
-    for (const auto *Arg : R->getValueAsListOfConstDefs("Args")) {
+    for (const auto *Arg : R->getValueAsListOfDefs("Args")) {
       OS << " << ReadArg<" << Arg->getValueAsString("Name") << ">(P, PC)";
       OS << " << \" \"";
     }
@@ -194,7 +194,7 @@ void ClangOpcodesEmitter::EmitEmitter(raw_ostream &OS, StringRef N,
 
   OS << "#ifdef GET_LINK_IMPL\n";
   Enumerate(R, N, [R, &OS](ArrayRef<const Record *>, const Twine &ID) {
-    const auto &Args = R->getValueAsListOfConstDefs("Args");
+    const auto &Args = R->getValueAsListOfDefs("Args");
 
     // Emit the list of arguments.
     OS << "bool ByteCodeEmitter::emit" << ID << "(";
@@ -227,7 +227,7 @@ void ClangOpcodesEmitter::EmitEmitter(raw_ostream &OS, StringRef N,
 void ClangOpcodesEmitter::EmitProto(raw_ostream &OS, StringRef N,
                                     const Record *R) {
   OS << "#if defined(GET_EVAL_PROTO) || defined(GET_LINK_PROTO)\n";
-  auto Args = R->getValueAsListOfConstDefs("Args");
+  auto Args = R->getValueAsListOfDefs("Args");
   Enumerate(R, N, [&OS, &Args](ArrayRef<const Record *> TS, const Twine &ID) {
     OS << "bool emit" << ID << "(";
     for (size_t I = 0, N = Args.size(); I < N; ++I) {
@@ -268,7 +268,7 @@ void ClangOpcodesEmitter::EmitGroup(raw_ostream &OS, StringRef N,
     return;
 
   const auto *Types = R->getValueAsListInit("Types");
-  const auto &Args = R->getValueAsListOfConstDefs("Args");
+  const auto &Args = R->getValueAsListOfDefs("Args");
 
   Twine EmitFuncName = "emit" + N;
 
@@ -333,7 +333,7 @@ void ClangOpcodesEmitter::EmitGroup(raw_ostream &OS, StringRef N,
     // Print a switch statement selecting T.
     if (auto *TypeClass = dyn_cast<DefInit>(Types->getElement(I))) {
       OS << "  switch (T" << I << ") {\n";
-      auto Cases = TypeClass->getDef()->getValueAsListOfConstDefs("Types");
+      auto Cases = TypeClass->getDef()->getValueAsListOfDefs("Types");
       for (auto *Case : Cases) {
         OS << "  case PT_" << Case->getName() << ":\n";
         TS.push_back(Case);
@@ -364,7 +364,7 @@ void ClangOpcodesEmitter::EmitEval(raw_ostream &OS, StringRef N,
   OS << "#ifdef GET_EVAL_IMPL\n";
   Enumerate(R, N,
             [this, R, &N, &OS](ArrayRef<const Record *> TS, const Twine &ID) {
-              auto Args = R->getValueAsListOfConstDefs("Args");
+              auto Args = R->getValueAsListOfDefs("Args");
 
               OS << "bool EvalEmitter::emit" << ID << "(";
               for (size_t I = 0, N = Args.size(); I < N; ++I) {

--- a/clang/utils/TableGen/ClangOpenCLBuiltinEmitter.cpp
+++ b/clang/utils/TableGen/ClangOpenCLBuiltinEmitter.cpp
@@ -480,9 +480,8 @@ static void VerifySignature(ArrayRef<const Record *> Signature,
       }
 
       // Check number of data types.
-      unsigned NTypes = T->getValueAsDef("TypeList")
-                            ->getValueAsListOfConstDefs("List")
-                            .size();
+      unsigned NTypes =
+          T->getValueAsDef("TypeList")->getValueAsListOfDefs("List").size();
       if (NTypes != GenTypeTypes && NTypes != 1) {
         if (GenTypeTypes > 1) {
           // We already saw a gentype with a different number of types.
@@ -512,7 +511,7 @@ void BuiltinNameEmitter::GetOverloads() {
     StringRef BName = B->getValueAsString("Name");
     FctOverloadMap.try_emplace(BName);
 
-    auto Signature = B->getValueAsListOfConstDefs("Signature");
+    auto Signature = B->getValueAsListOfDefs("Signature");
     // Reuse signatures to avoid unnecessary duplicates.
     auto it =
         find_if(SignaturesList,
@@ -636,8 +635,8 @@ void BuiltinNameEmitter::EmitBuiltinTable() {
           Overload.first->getValueAsDef("MaxVersion")->getValueAsInt("ID");
 
       OS << "  { " << Overload.second << ", "
-         << Overload.first->getValueAsListOfConstDefs("Signature").size()
-         << ", " << (Overload.first->getValueAsBit("IsPure")) << ", "
+         << Overload.first->getValueAsListOfDefs("Signature").size() << ", "
+         << (Overload.first->getValueAsBit("IsPure")) << ", "
          << (Overload.first->getValueAsBit("IsConst")) << ", "
          << (Overload.first->getValueAsBit("IsConv")) << ", "
          << FunctionExtensionIndex[ExtName] << ", "
@@ -852,7 +851,7 @@ static void OCL2Qual(Sema &S, const OpenCLTypeStruct &Ty,
     // the plain scalar types for now; other type information such as vector
     // size and type qualifiers will be added after the switch statement.
     std::vector<const Record *> BaseTypes =
-        GenType->getValueAsDef("TypeList")->getValueAsListOfConstDefs("List");
+        GenType->getValueAsDef("TypeList")->getValueAsListOfDefs("List");
 
     // Collect all QualTypes for a single vector size into TypeList.
     OS << "      SmallVector<QualType, " << BaseTypes.size() << "> TypeList;\n";
@@ -1028,8 +1027,7 @@ void OpenCLBuiltinFileEmitterBase::getTypeLists(
     std::vector<int64_t> &VectorList) const {
   bool isGenType = Type->isSubClassOf("GenericType");
   if (isGenType) {
-    TypeList =
-        Type->getValueAsDef("TypeList")->getValueAsListOfConstDefs("List");
+    TypeList = Type->getValueAsDef("TypeList")->getValueAsListOfDefs("List");
     VectorList =
         Type->getValueAsDef("VectorList")->getValueAsListOfInts("List");
     return;
@@ -1215,7 +1213,7 @@ void OpenCLBuiltinTestEmitter::emit() {
     StringRef Name = B->getValueAsString("Name");
 
     SmallVector<SmallVector<std::string, 2>, 4> FTypes;
-    expandTypesInSignature(B->getValueAsListOfConstDefs("Signature"), FTypes);
+    expandTypesInSignature(B->getValueAsListOfDefs("Signature"), FTypes);
 
     OS << "// Test " << Name << "\n";
 
@@ -1284,7 +1282,7 @@ void OpenCLBuiltinHeaderEmitter::emit() {
     std::string OptionalVersionEndif = emitVersionGuard(B);
 
     SmallVector<SmallVector<std::string, 2>, 4> FTypes;
-    expandTypesInSignature(B->getValueAsListOfConstDefs("Signature"), FTypes);
+    expandTypesInSignature(B->getValueAsListOfDefs("Signature"), FTypes);
 
     for (const auto &Signature : FTypes) {
       StringRef OptionalTypeExtEndif = emitTypeExtensionGuards(Signature);

--- a/clang/utils/TableGen/SveEmitter.cpp
+++ b/clang/utils/TableGen/SveEmitter.cpp
@@ -1163,7 +1163,7 @@ void SVEEmitter::createIntrinsic(
   uint64_t MemEltType = R->getValueAsInt("MemEltType");
 
   int64_t Flags = 0;
-  for (const Record *FlagRec : R->getValueAsListOfConstDefs("Flags"))
+  for (const Record *FlagRec : R->getValueAsListOfDefs("Flags"))
     Flags |= FlagRec->getValueAsInt("Value");
 
   // Create a dummy TypeSpec for non-overloaded builtins.
@@ -1193,7 +1193,7 @@ void SVEEmitter::createIntrinsic(
   for (auto TS : TypeSpecs) {
     // Collate a list of range/option checks for the immediates.
     SmallVector<ImmCheck, 2> ImmChecks;
-    for (const Record *ImmR : R->getValueAsListOfConstDefs("ImmChecks")) {
+    for (const Record *ImmR : R->getValueAsListOfDefs("ImmChecks")) {
       int64_t ArgIdx = ImmR->getValueAsInt("ImmArgIdx");
       int64_t EltSizeArgIdx = ImmR->getValueAsInt("TypeContextArgIdx");
       int64_t Kind = ImmR->getValueAsDef("Kind")->getValueAsInt("Value");

--- a/libc/utils/HdrGen/PublicAPICommand.cpp
+++ b/libc/utils/HdrGen/PublicAPICommand.cpp
@@ -109,7 +109,7 @@ static AttributeMap collectAttributeMacros(const SpecMap &Spec,
 static void emitAttributeMacroDecls(const AttributeMap &MacroAttr,
                                     llvm::raw_ostream &OS) {
   for (auto &[Macro, Attr] : MacroAttr) {
-    std::vector<llvm::Record *> Instances =
+    std::vector<const llvm::Record *> Instances =
         Attr->getValueAsListOfDefs("Instances");
     llvm::SmallVector<std::pair<AttributeStyle, const llvm::Record *>> Styles;
     std::transform(Instances.begin(), Instances.end(),
@@ -190,7 +190,7 @@ static void emitAttributeMacroDecls(const AttributeMap &MacroAttr,
 
 static void emitAttributeMacroForFunction(const llvm::Record *FunctionSpec,
                                           llvm::raw_ostream &OS) {
-  std::vector<llvm::Record *> Attributes =
+  std::vector<const llvm::Record *> Attributes =
       FunctionSpec->getValueAsListOfDefs("Attributes");
   llvm::interleave(
       Attributes.begin(), Attributes.end(),

--- a/libc/utils/LibcTableGenUtil/APIIndexer.cpp
+++ b/libc/utils/LibcTableGenUtil/APIIndexer.cpp
@@ -81,22 +81,22 @@ std::string APIIndexer::getTypeAsString(const llvm::Record *TypeRecord) {
 
 void APIIndexer::indexStandardSpecDef(const llvm::Record *StandardSpec) {
   auto HeaderSpecList = StandardSpec->getValueAsListOfDefs("Headers");
-  for (llvm::Record *HeaderSpec : HeaderSpecList) {
+  for (const llvm::Record *HeaderSpec : HeaderSpecList) {
     llvm::StringRef Header = HeaderSpec->getValueAsString("Name");
     if (!StdHeader.has_value() || Header == StdHeader) {
       PublicHeaders.emplace(Header);
       auto MacroSpecList = HeaderSpec->getValueAsListOfDefs("Macros");
       // TODO: Trigger a fatal error on duplicate specs.
-      for (llvm::Record *MacroSpec : MacroSpecList)
+      for (const llvm::Record *MacroSpec : MacroSpecList)
         MacroSpecMap[std::string(MacroSpec->getValueAsString("Name"))] =
             MacroSpec;
 
       auto TypeSpecList = HeaderSpec->getValueAsListOfDefs("Types");
-      for (llvm::Record *TypeSpec : TypeSpecList)
+      for (const llvm::Record *TypeSpec : TypeSpecList)
         TypeSpecMap[std::string(TypeSpec->getValueAsString("Name"))] = TypeSpec;
 
       auto FunctionSpecList = HeaderSpec->getValueAsListOfDefs("Functions");
-      for (llvm::Record *FunctionSpec : FunctionSpecList) {
+      for (const llvm::Record *FunctionSpec : FunctionSpecList) {
         auto FunctionName = std::string(FunctionSpec->getValueAsString("Name"));
         FunctionSpecMap[FunctionName] = FunctionSpec;
         FunctionToHeaderMap[FunctionName] = std::string(Header);
@@ -104,13 +104,13 @@ void APIIndexer::indexStandardSpecDef(const llvm::Record *StandardSpec) {
 
       auto EnumerationSpecList =
           HeaderSpec->getValueAsListOfDefs("Enumerations");
-      for (llvm::Record *EnumerationSpec : EnumerationSpecList) {
+      for (const llvm::Record *EnumerationSpec : EnumerationSpecList) {
         EnumerationSpecMap[std::string(
             EnumerationSpec->getValueAsString("Name"))] = EnumerationSpec;
       }
 
       auto ObjectSpecList = HeaderSpec->getValueAsListOfDefs("Objects");
-      for (llvm::Record *ObjectSpec : ObjectSpecList) {
+      for (const llvm::Record *ObjectSpec : ObjectSpecList) {
         auto ObjectName = std::string(ObjectSpec->getValueAsString("Name"));
         ObjectSpecMap[ObjectName] = ObjectSpec;
         ObjectToHeaderMap[ObjectName] = std::string(Header);
@@ -124,7 +124,7 @@ void APIIndexer::indexPublicAPIDef(const llvm::Record *PublicAPI) {
   // requested is from an included standard. Such a check is done while
   // generating the API.
   auto MacroDefList = PublicAPI->getValueAsListOfDefs("Macros");
-  for (llvm::Record *MacroDef : MacroDefList)
+  for (const llvm::Record *MacroDef : MacroDefList)
     MacroDefsMap[std::string(MacroDef->getValueAsString("Name"))] = MacroDef;
 
   auto TypeList = PublicAPI->getValueAsListOfStrings("Types");

--- a/llvm/include/llvm/TableGen/DirectiveEmitter.h
+++ b/llvm/include/llvm/TableGen/DirectiveEmitter.h
@@ -136,23 +136,23 @@ public:
   Directive(const Record *Def) : BaseRecord(Def) {}
 
   std::vector<const Record *> getAllowedClauses() const {
-    return Def->getValueAsListOfConstDefs("allowedClauses");
+    return Def->getValueAsListOfDefs("allowedClauses");
   }
 
   std::vector<const Record *> getAllowedOnceClauses() const {
-    return Def->getValueAsListOfConstDefs("allowedOnceClauses");
+    return Def->getValueAsListOfDefs("allowedOnceClauses");
   }
 
   std::vector<const Record *> getAllowedExclusiveClauses() const {
-    return Def->getValueAsListOfConstDefs("allowedExclusiveClauses");
+    return Def->getValueAsListOfDefs("allowedExclusiveClauses");
   }
 
   std::vector<const Record *> getRequiredClauses() const {
-    return Def->getValueAsListOfConstDefs("requiredClauses");
+    return Def->getValueAsListOfDefs("requiredClauses");
   }
 
   std::vector<const Record *> getLeafConstructs() const {
-    return Def->getValueAsListOfConstDefs("leafConstructs");
+    return Def->getValueAsListOfDefs("leafConstructs");
   }
 
   Record *getAssociation() const { return Def->getValueAsDef("association"); }
@@ -204,7 +204,7 @@ public:
   }
 
   std::vector<const Record *> getClauseVals() const {
-    return Def->getValueAsListOfConstDefs("allowedClauseValues");
+    return Def->getValueAsListOfDefs("allowedClauseValues");
   }
 
   bool isValueOptional() const { return Def->getValueAsBit("isValueOptional"); }

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1916,10 +1916,7 @@ public:
   /// This method looks up the specified field and returns its value as a
   /// vector of records, throwing an exception if the field does not exist or
   /// if the value is not the right type.
-  std::vector<Record*> getValueAsListOfDefs(StringRef FieldName) const;
-  // Temporary function to help staged migration to const Record pointers.
-  std::vector<const Record *>
-  getValueAsListOfConstDefs(StringRef FieldName) const;
+  std::vector<const Record *> getValueAsListOfDefs(StringRef FieldName) const;
 
   /// This method looks up the specified field and returns its value as a
   /// vector of integers, throwing an exception if the field does not exist or

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -3047,22 +3047,8 @@ ListInit *Record::getValueAsListInit(StringRef FieldName) const {
                                 "' exists but does not have a list value");
 }
 
-std::vector<Record*>
-Record::getValueAsListOfDefs(StringRef FieldName) const {
-  ListInit *List = getValueAsListInit(FieldName);
-  std::vector<Record*> Defs;
-  for (Init *I : List->getValues()) {
-    if (DefInit *DI = dyn_cast<DefInit>(I))
-      Defs.push_back(DI->getDef());
-    else
-      PrintFatalError(getLoc(), "Record `" + getName() + "', field `" +
-        FieldName + "' list is not entirely DefInit!");
-  }
-  return Defs;
-}
-
 std::vector<const Record *>
-Record::getValueAsListOfConstDefs(StringRef FieldName) const {
+Record::getValueAsListOfDefs(StringRef FieldName) const {
   ListInit *List = getValueAsListInit(FieldName);
   std::vector<const Record *> Defs;
   for (const Init *I : List->getValues()) {

--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -597,7 +597,7 @@ emitRegisterNameString(raw_ostream &O, StringRef AltName,
     } else {
       // Make sure the register has an alternate name for this index.
       std::vector<const Record *> AltNameList =
-          Reg.TheDef->getValueAsListOfConstDefs("RegAltNameIndices");
+          Reg.TheDef->getValueAsListOfDefs("RegAltNameIndices");
       unsigned Idx = 0, e;
       for (e = AltNameList.size();
            Idx < e && (AltNameList[Idx]->getName() != AltName); ++Idx)
@@ -1012,7 +1012,7 @@ void AsmWriterEmitter::EmitPrintAliasInstruction(raw_ostream &O) {
       if (PassSubtarget) {
         // We only consider ReqFeatures predicates if PassSubtarget
         std::vector<const Record *> RF =
-            CGA.TheDef->getValueAsListOfConstDefs("Predicates");
+            CGA.TheDef->getValueAsListOfDefs("Predicates");
         copy_if(RF, std::back_inserter(ReqFeatures), [](const Record *R) {
           return R->getValueAsBit("AssemblerMatcherPredicate");
         });

--- a/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
@@ -39,8 +39,8 @@ LLVM_DUMP_METHOD
 void HwMode::dump() const { dbgs() << Name << ": " << Features << '\n'; }
 
 HwModeSelect::HwModeSelect(const Record *R, CodeGenHwModes &CGH) {
-  std::vector<const Record *> Modes = R->getValueAsListOfConstDefs("Modes");
-  std::vector<const Record *> Objects = R->getValueAsListOfConstDefs("Objects");
+  std::vector<const Record *> Modes = R->getValueAsListOfDefs("Modes");
+  std::vector<const Record *> Objects = R->getValueAsListOfDefs("Objects");
   if (Modes.size() != Objects.size()) {
     PrintError(
         R->getLoc(),

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
@@ -485,8 +485,8 @@ CodeGenInstruction::CodeGenInstruction(const Record *R)
   isCodeGenOnly = R->getValueAsBit("isCodeGenOnly");
   isPseudo = R->getValueAsBit("isPseudo");
   isMeta = R->getValueAsBit("isMeta");
-  ImplicitDefs = R->getValueAsListOfConstDefs("Defs");
-  ImplicitUses = R->getValueAsListOfConstDefs("Uses");
+  ImplicitDefs = R->getValueAsListOfDefs("Defs");
+  ImplicitUses = R->getValueAsListOfDefs("Uses");
 
   // This flag is only inferred from the pattern.
   hasChain = false;

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -80,7 +80,7 @@ void CodeGenSubRegIndex::updateComponents(CodeGenRegBank &RegBank) {
     return;
 
   std::vector<const Record *> Comps =
-      TheDef->getValueAsListOfConstDefs("ComposedOf");
+      TheDef->getValueAsListOfDefs("ComposedOf");
   if (!Comps.empty()) {
     if (Comps.size() != 2)
       PrintFatalError(TheDef->getLoc(),
@@ -93,7 +93,7 @@ void CodeGenSubRegIndex::updateComponents(CodeGenRegBank &RegBank) {
   }
 
   std::vector<const Record *> Parts =
-      TheDef->getValueAsListOfConstDefs("CoveringSubRegIndices");
+      TheDef->getValueAsListOfDefs("CoveringSubRegIndices");
   if (!Parts.empty()) {
     if (Parts.size() < 2)
       PrintFatalError(TheDef->getLoc(),
@@ -169,9 +169,8 @@ CodeGenRegister::CodeGenRegister(const Record *R, unsigned Enum)
 
 void CodeGenRegister::buildObjectGraph(CodeGenRegBank &RegBank) {
   std::vector<const Record *> SRIs =
-      TheDef->getValueAsListOfConstDefs("SubRegIndices");
-  std::vector<const Record *> SRs =
-      TheDef->getValueAsListOfConstDefs("SubRegs");
+      TheDef->getValueAsListOfDefs("SubRegIndices");
+  std::vector<const Record *> SRs = TheDef->getValueAsListOfDefs("SubRegs");
 
   if (SRIs.size() != SRs.size())
     PrintFatalError(TheDef->getLoc(),
@@ -629,7 +628,7 @@ struct TupleExpander : SetTheory::Expander {
   void expand(SetTheory &ST, const Record *Def,
               SetTheory::RecSet &Elts) override {
     std::vector<const Record *> Indices =
-        Def->getValueAsListOfConstDefs("SubRegIndices");
+        Def->getValueAsListOfDefs("SubRegIndices");
     unsigned Dim = Indices.size();
     ListInit *SubRegs = Def->getValueAsListInit("SubRegs");
     if (Dim != SubRegs->size())
@@ -764,8 +763,7 @@ CodeGenRegisterClass::CodeGenRegisterClass(CodeGenRegBank &RegBank,
     : TheDef(R), Name(std::string(R->getName())),
       TopoSigs(RegBank.getNumTopoSigs()), EnumValue(-1), TSFlags(0) {
   GeneratePressureSet = R->getValueAsBit("GeneratePressureSet");
-  std::vector<const Record *> TypeList =
-      R->getValueAsListOfConstDefs("RegTypes");
+  std::vector<const Record *> TypeList = R->getValueAsListOfDefs("RegTypes");
   if (TypeList.empty())
     PrintFatalError(R->getLoc(), "RegTypes list must not be empty!");
   for (unsigned i = 0, e = TypeList.size(); i != e; ++i) {

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
@@ -310,13 +310,13 @@ static void processSTIPredicate(STIPredicateFunction &Fn,
   // definitions. Each unique opcode will be associated with an OpcodeInfo
   // object.
   for (const Record *Def : Fn.getDefinitions()) {
-    ConstRecVec Classes = Def->getValueAsListOfConstDefs("Classes");
+    ConstRecVec Classes = Def->getValueAsListOfDefs("Classes");
     for (const Record *EC : Classes) {
       const Record *Pred = EC->getValueAsDef("Predicate");
       if (!Predicate2Index.contains(Pred))
         Predicate2Index[Pred] = NumUniquePredicates++;
 
-      ConstRecVec Opcodes = EC->getValueAsListOfConstDefs("Opcodes");
+      ConstRecVec Opcodes = EC->getValueAsListOfDefs("Opcodes");
       for (const Record *Opcode : Opcodes) {
         if (!Opcode2Index.contains(Opcode)) {
           Opcode2Index[Opcode] = OpcodeMappings.size();
@@ -341,14 +341,14 @@ static void processSTIPredicate(STIPredicateFunction &Fn,
   // Construct a OpcodeInfo object for every unique opcode declared by an
   // InstructionEquivalenceClass definition.
   for (const Record *Def : Fn.getDefinitions()) {
-    ConstRecVec Classes = Def->getValueAsListOfConstDefs("Classes");
+    ConstRecVec Classes = Def->getValueAsListOfDefs("Classes");
     const Record *SchedModel = Def->getValueAsDef("SchedModel");
     unsigned ProcIndex = ProcModelMap.find(SchedModel)->second;
     APInt ProcMask(ProcModelMap.size(), 0);
     ProcMask.setBit(ProcIndex);
 
     for (const Record *EC : Classes) {
-      ConstRecVec Opcodes = EC->getValueAsListOfConstDefs("Opcodes");
+      ConstRecVec Opcodes = EC->getValueAsListOfDefs("Opcodes");
 
       std::vector<int64_t> OpIndices =
           EC->getValueAsListOfInts("OperandIndices");
@@ -669,7 +669,7 @@ void CodeGenSchedModels::collectSchedRW() {
   for (CodeGenSchedRW &CGRW : SchedWrites) {
     if (!CGRW.IsSequence)
       continue;
-    findRWs(CGRW.TheDef->getValueAsListOfConstDefs("Writes"), CGRW.Sequence,
+    findRWs(CGRW.TheDef->getValueAsListOfDefs("Writes"), CGRW.Sequence,
             /*IsRead=*/false);
   }
   // Initialize Aliases vectors.
@@ -857,8 +857,7 @@ void CodeGenSchedModels::collectSchedClasses() {
     Record *ItinDef = Inst->TheDef->getValueAsDef("Itinerary");
     IdxVec Writes, Reads;
     if (!Inst->TheDef->isValueUnset("SchedRW"))
-      findRWs(Inst->TheDef->getValueAsListOfConstDefs("SchedRW"), Writes,
-              Reads);
+      findRWs(Inst->TheDef->getValueAsListOfDefs("SchedRW"), Writes, Reads);
 
     // ProcIdx == 0 indicates the class applies to all processors.
     unsigned SCIdx = addSchedClass(ItinDef, Writes, Reads, /*ProcIndices*/ {0});
@@ -920,8 +919,7 @@ void CodeGenSchedModels::collectSchedClasses() {
                         << InstName);
       IdxVec Writes;
       IdxVec Reads;
-      findRWs(RWDef->getValueAsListOfConstDefs("OperandReadWrites"), Writes,
-              Reads);
+      findRWs(RWDef->getValueAsListOfDefs("OperandReadWrites"), Writes, Reads);
       LLVM_DEBUG({
         for (unsigned WIdx : Writes)
           dbgs() << " " << SchedWrites[WIdx].Name;
@@ -1130,8 +1128,7 @@ void CodeGenSchedModels::collectProcItins() {
     if (!ProcModel.hasItineraries())
       continue;
 
-    ConstRecVec ItinRecords =
-        ProcModel.ItinsDef->getValueAsListOfConstDefs("IID");
+    ConstRecVec ItinRecords = ProcModel.ItinsDef->getValueAsListOfDefs("IID");
     assert(!ItinRecords.empty() && "ProcModel.hasItineraries is incorrect");
 
     // Populate ItinDefList with Itinerary records.
@@ -1224,8 +1221,7 @@ void CodeGenSchedModels::inferFromItinClass(const Record *ItinClassDef,
     // For all ItinRW entries.
     bool HasMatch = false;
     for (const Record *Rec : PM.ItinRWDefs) {
-      ConstRecVec Matched =
-          Rec->getValueAsListOfConstDefs("MatchedItinClasses");
+      ConstRecVec Matched = Rec->getValueAsListOfDefs("MatchedItinClasses");
       if (!llvm::is_contained(Matched, ItinClassDef))
         continue;
       if (HasMatch)
@@ -1234,8 +1230,7 @@ void CodeGenSchedModels::inferFromItinClass(const Record *ItinClassDef,
                             " in ItinResources for " + PM.ModelName);
       HasMatch = true;
       IdxVec Writes, Reads;
-      findRWs(Rec->getValueAsListOfConstDefs("OperandReadWrites"), Writes,
-              Reads);
+      findRWs(Rec->getValueAsListOfDefs("OperandReadWrites"), Writes, Reads);
       inferFromRW(Writes, Reads, FromClassIdx, PIdx);
     }
   }
@@ -1257,7 +1252,7 @@ void CodeGenSchedModels::inferFromInstRWs(unsigned SCIdx) {
     if (II == IE)
       continue;
     IdxVec Writes, Reads;
-    findRWs(Rec->getValueAsListOfConstDefs("OperandReadWrites"), Writes, Reads);
+    findRWs(Rec->getValueAsListOfDefs("OperandReadWrites"), Writes, Reads);
     unsigned PIdx = getProcModel(Rec->getValueAsDef("SchedModel")).Index;
     inferFromRW(Writes, Reads, SCIdx, PIdx); // May mutate SchedClasses.
     SchedClasses[SCIdx].InstRWProcIndices.insert(PIdx);
@@ -1350,8 +1345,7 @@ bool PredTransitions::mutuallyExclusive(Record *PredDef,
 
     const CodeGenSchedRW &SchedRW = SchedModels.getSchedRW(PC.RWIdx, PC.IsRead);
     assert(SchedRW.HasVariants && "PredCheck must refer to a SchedVariant");
-    ConstRecVec Variants =
-        SchedRW.TheDef->getValueAsListOfConstDefs("Variants");
+    ConstRecVec Variants = SchedRW.TheDef->getValueAsListOfDefs("Variants");
     if (any_of(Variants, [PredDef](const Record *R) {
           return R->getValueAsDef("Predicate") == PredDef;
         })) {
@@ -1498,7 +1492,7 @@ void PredTransitions::pushVariant(const TransVariant &VInfo, bool IsRead) {
     Record *PredDef = VInfo.VarOrSeqDef->getValueAsDef("Predicate");
     Trans.PredTerm.emplace_back(IsRead, VInfo.RWIdx, PredDef);
     ConstRecVec SelectedDefs =
-        VInfo.VarOrSeqDef->getValueAsListOfConstDefs("Selected");
+        VInfo.VarOrSeqDef->getValueAsListOfDefs("Selected");
     SchedModels.findRWs(SelectedDefs, SelectedRWs, IsRead);
   } else {
     assert(VInfo.VarOrSeqDef->isSubClassOf("WriteSequence") &&
@@ -1769,8 +1763,7 @@ bool CodeGenSchedModels::hasSuperGroup(ConstRecVec &SubUnits,
   for (const Record *ProcResourceDef : PM.ProcResourceDefs) {
     if (!ProcResourceDef->isSubClassOf("ProcResGroup"))
       continue;
-    ConstRecVec SuperUnits =
-        ProcResourceDef->getValueAsListOfConstDefs("Resources");
+    ConstRecVec SuperUnits = ProcResourceDef->getValueAsListOfDefs("Resources");
     auto RI = SubUnits.begin(), RE = SubUnits.end();
     for (; RI != RE; ++RI) {
       if (!is_contained(SuperUnits, *RI)) {
@@ -1789,12 +1782,12 @@ void CodeGenSchedModels::verifyProcResourceGroups(CodeGenProcModel &PM) {
     if (!PM.ProcResourceDefs[i]->isSubClassOf("ProcResGroup"))
       continue;
     ConstRecVec CheckUnits =
-        PM.ProcResourceDefs[i]->getValueAsListOfConstDefs("Resources");
+        PM.ProcResourceDefs[i]->getValueAsListOfDefs("Resources");
     for (unsigned j = i + 1; j < e; ++j) {
       if (!PM.ProcResourceDefs[j]->isSubClassOf("ProcResGroup"))
         continue;
       ConstRecVec OtherUnits =
-          PM.ProcResourceDefs[j]->getValueAsListOfConstDefs("Resources");
+          PM.ProcResourceDefs[j]->getValueAsListOfDefs("Resources");
       if (std::find_first_of(CheckUnits.begin(), CheckUnits.end(),
                              OtherUnits.begin(),
                              OtherUnits.end()) != CheckUnits.end()) {
@@ -1833,7 +1826,7 @@ void CodeGenSchedModels::collectRegisterFiles() {
                       "Invalid RegisterFile with zero physical registers");
     }
 
-    ConstRecVec RegisterClasses = RF->getValueAsListOfConstDefs("RegClasses");
+    ConstRecVec RegisterClasses = RF->getValueAsListOfDefs("RegClasses");
     std::vector<int64_t> RegisterCosts = RF->getValueAsListOfInts("RegCosts");
     ListInit *MoveElimInfo = RF->getValueAsListInit("AllowMoveElimination");
     for (unsigned I = 0, E = RegisterClasses.size(); I < E; ++I) {
@@ -1871,8 +1864,7 @@ void CodeGenSchedModels::collectProcResources() {
       Record *RWModelDef = RW->getValueAsDef("SchedModel");
       unsigned PIdx = getProcModel(RWModelDef).Index;
       IdxVec Writes, Reads;
-      findRWs(RW->getValueAsListOfConstDefs("OperandReadWrites"), Writes,
-              Reads);
+      findRWs(RW->getValueAsListOfDefs("OperandReadWrites"), Writes, Reads);
       collectRWResources(Writes, Reads, PIdx);
     }
 
@@ -2016,7 +2008,7 @@ void CodeGenSchedModels::collectItinProcResources(const Record *ItinClassDef) {
     // For all ItinRW entries.
     bool HasMatch = false;
     for (const Record *R : PM.ItinRWDefs) {
-      ConstRecVec Matched = R->getValueAsListOfConstDefs("MatchedItinClasses");
+      ConstRecVec Matched = R->getValueAsListOfDefs("MatchedItinClasses");
       if (!llvm::is_contained(Matched, ItinClassDef))
         continue;
       if (HasMatch)
@@ -2025,7 +2017,7 @@ void CodeGenSchedModels::collectItinProcResources(const Record *ItinClassDef) {
                             " in ItinResources for " + PM.ModelName);
       HasMatch = true;
       IdxVec Writes, Reads;
-      findRWs(R->getValueAsListOfConstDefs("OperandReadWrites"), Writes, Reads);
+      findRWs(R->getValueAsListOfDefs("OperandReadWrites"), Writes, Reads);
       collectRWResources(Writes, Reads, PIdx);
     }
   }
@@ -2192,7 +2184,7 @@ bool CodeGenProcModel::isUnsupported(const CodeGenInstruction &Inst) const {
 
 bool CodeGenProcModel::hasReadOfWrite(const Record *WriteDef) const {
   for (auto &RADef : ReadAdvanceDefs) {
-    ConstRecVec ValidWrites = RADef->getValueAsListOfConstDefs("ValidWrites");
+    ConstRecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
     if (is_contained(ValidWrites, WriteDef))
       return true;
   }

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -133,7 +133,7 @@ bool CodeGenTarget::getAllowRegisterRenaming() const {
 ///
 const Record *CodeGenTarget::getAsmParser() const {
   std::vector<const Record *> LI =
-      TargetRec->getValueAsListOfConstDefs("AssemblyParsers");
+      TargetRec->getValueAsListOfDefs("AssemblyParsers");
   if (AsmParserNum >= LI.size())
     PrintFatalError("Target does not have an AsmParser #" +
                     Twine(AsmParserNum) + "!");
@@ -145,7 +145,7 @@ const Record *CodeGenTarget::getAsmParser() const {
 ///
 const Record *CodeGenTarget::getAsmParserVariant(unsigned Idx) const {
   std::vector<const Record *> LI =
-      TargetRec->getValueAsListOfConstDefs("AssemblyParserVariants");
+      TargetRec->getValueAsListOfDefs("AssemblyParserVariants");
   if (Idx >= LI.size())
     PrintFatalError("Target does not have an AsmParserVariant #" + Twine(Idx) +
                     "!");
@@ -163,7 +163,7 @@ unsigned CodeGenTarget::getAsmParserVariantCount() const {
 ///
 const Record *CodeGenTarget::getAsmWriter() const {
   std::vector<const Record *> LI =
-      TargetRec->getValueAsListOfConstDefs("AssemblyWriters");
+      TargetRec->getValueAsListOfDefs("AssemblyWriters");
   if (AsmWriterNum >= LI.size())
     PrintFatalError("Target does not have an AsmWriter #" +
                     Twine(AsmWriterNum) + "!");
@@ -407,7 +407,7 @@ ComplexPattern::ComplexPattern(const Record *R) {
   Ty = R->getValueAsDef("Ty");
   NumOperands = R->getValueAsInt("NumOperands");
   SelectFunc = std::string(R->getValueAsString("SelectFunc"));
-  RootNodes = R->getValueAsListOfConstDefs("RootNodes");
+  RootNodes = R->getValueAsListOfDefs("RootNodes");
 
   // FIXME: This is a hack to statically increase the priority of patterns which
   // maps a sub-dag to a complex pattern. e.g. favors LEA over ADD. To get best

--- a/llvm/utils/TableGen/Common/PredicateExpander.cpp
+++ b/llvm/utils/TableGen/Common/PredicateExpander.cpp
@@ -297,7 +297,7 @@ void PredicateExpander::expandOpcodeSwitchStatement(
 void PredicateExpander::expandStatement(raw_ostream &OS, const Record *Rec) {
   // Assume that padding has been added by the caller.
   if (Rec->isSubClassOf("MCOpcodeSwitchStatement")) {
-    expandOpcodeSwitchStatement(OS, Rec->getValueAsListOfConstDefs("Cases"),
+    expandOpcodeSwitchStatement(OS, Rec->getValueAsListOfDefs("Cases"),
                                 Rec->getValueAsDef("DefaultCase"));
     return;
   }

--- a/llvm/utils/TableGen/CompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/CompressInstEmitter.cpp
@@ -479,7 +479,7 @@ void CompressInstEmitter::evaluateCompressPat(const Record *Rec) {
 
   // Get the target features for the CompressPat.
   std::vector<const Record *> PatReqFeatures;
-  std::vector<const Record *> RF = Rec->getValueAsListOfConstDefs("Predicates");
+  std::vector<const Record *> RF = Rec->getValueAsListOfDefs("Predicates");
   copy_if(RF, std::back_inserter(PatReqFeatures), [](const Record *R) {
     return R->getValueAsBit("AssemblerMatcherPredicate");
   });
@@ -688,7 +688,7 @@ void CompressInstEmitter::emitCompressInstEmitter(raw_ostream &OS,
     // Add Dest instruction required features.
     std::vector<const Record *> ReqFeatures;
     std::vector<const Record *> RF =
-        Dest.TheDef->getValueAsListOfConstDefs("Predicates");
+        Dest.TheDef->getValueAsListOfDefs("Predicates");
     copy_if(RF, std::back_inserter(ReqFeatures), [](const Record *R) {
       return R->getValueAsBit("AssemblerMatcherPredicate");
     });

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -108,7 +108,7 @@ int DFAPacketizerEmitter::collectAllFuncUnits(
   int totalFUs = 0;
   // Parse functional units for all the itineraries.
   for (const Record *Proc : ProcItinList) {
-    std::vector<const Record *> FUs = Proc->getValueAsListOfConstDefs("FU");
+    std::vector<const Record *> FUs = Proc->getValueAsListOfDefs("FU");
 
     LLVM_DEBUG(dbgs() << "    FU:"
                       << " (" << FUs.size() << " FUs) " << Proc->getName());
@@ -139,7 +139,7 @@ int DFAPacketizerEmitter::collectAllComboFuncs(
   int numCombos = 0;
   for (unsigned i = 0, N = ComboFuncList.size(); i < N; ++i) {
     const Record *Func = ComboFuncList[i];
-    std::vector<const Record *> FUs = Func->getValueAsListOfConstDefs("CFD");
+    std::vector<const Record *> FUs = Func->getValueAsListOfDefs("CFD");
 
     LLVM_DEBUG(dbgs() << "    CFD:" << i << " (" << FUs.size() << " combo FUs) "
                       << Func->getName() << "\n");
@@ -151,7 +151,7 @@ int DFAPacketizerEmitter::collectAllComboFuncs(
       const Record *FuncData = FUs[j];
       const Record *ComboFunc = FuncData->getValueAsDef("TheComboFunc");
       const std::vector<const Record *> FuncList =
-          FuncData->getValueAsListOfConstDefs("FuncList");
+          FuncData->getValueAsListOfDefs("FuncList");
       const std::string &ComboFuncName = std::string(ComboFunc->getName());
       uint64_t ComboBit = FUNameToBitsMap[ComboFuncName];
       uint64_t ComboResources = ComboBit;

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -116,7 +116,7 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
   }
 
   // Get overload records
-  std::vector<const Record *> Recs = R->getValueAsListOfConstDefs("overloads");
+  std::vector<const Record *> Recs = R->getValueAsListOfDefs("overloads");
 
   // Sort records in ascending order of DXIL version
   AscendingSortByVersion(Recs);
@@ -126,7 +126,7 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
   }
 
   // Get stage records
-  Recs = R->getValueAsListOfConstDefs("stages");
+  Recs = R->getValueAsListOfDefs("stages");
 
   if (Recs.empty()) {
     PrintFatalError(R, Twine("Atleast one specification of valid stage for ") +
@@ -141,7 +141,7 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
   }
 
   // Get attribute records
-  Recs = R->getValueAsListOfConstDefs("attributes");
+  Recs = R->getValueAsListOfDefs("attributes");
 
   // Sort records in ascending order of DXIL version
   AscendingSortByVersion(Recs);

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -2681,7 +2681,7 @@ void GICombinerEmitter::gatherRules(std::vector<RuleMatcher> &ActiveRules,
                                     ArrayRef<const Record *> RulesAndGroups) {
   for (const Record *Rec : RulesAndGroups) {
     if (!Rec->isValueUnset("Rules")) {
-      gatherRules(ActiveRules, Rec->getValueAsListOfConstDefs("Rules"));
+      gatherRules(ActiveRules, Rec->getValueAsListOfDefs("Rules"));
       continue;
     }
 
@@ -2720,7 +2720,7 @@ void GICombinerEmitter::run(raw_ostream &OS) {
 
   Records.startTimer("Gather rules");
   std::vector<RuleMatcher> Rules;
-  gatherRules(Rules, Combiner->getValueAsListOfConstDefs("Rules"));
+  gatherRules(Rules, Combiner->getValueAsListOfDefs("Rules"));
   if (ErrorsPrinted)
     PrintFatalError(Combiner->getLoc(), "Failed to parse one or more rules");
 

--- a/llvm/utils/TableGen/InstrDocsEmitter.cpp
+++ b/llvm/utils/TableGen/InstrDocsEmitter.cpp
@@ -214,7 +214,7 @@ static void EmitInstrDocs(const RecordKeeper &RK, raw_ostream &OS) {
 
     // Predicates.
     std::vector<const Record *> Predicates =
-        II->TheDef->getValueAsListOfConstDefs("Predicates");
+        II->TheDef->getValueAsListOfDefs("Predicates");
     if (!Predicates.empty()) {
       OS << "Predicates: ";
       ListSeparator LS;

--- a/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
+++ b/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
@@ -101,7 +101,7 @@ void MacroFusionPredicatorEmitter::emitMacroFusionImpl(
 
   for (const Record *Fusion : Fusions) {
     std::vector<const Record *> Predicates =
-        Fusion->getValueAsListOfConstDefs("Predicates");
+        Fusion->getValueAsListOfDefs("Predicates");
     bool IsCommutable = Fusion->getValueAsBit("IsCommutable");
 
     OS << "bool is" << Fusion->getName() << "(\n";

--- a/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
@@ -172,7 +172,7 @@ static void emitRISCVProcs(const RecordKeeper &RK, raw_ostream &OS) {
   // Iterate on all definition records.
   for (const Record *Rec :
        RK.getAllDerivedDefinitionsIfDefined("RISCVProcessorModel")) {
-    const std::vector<Record *> &Features =
+    const std::vector<const Record *> &Features =
         Rec->getValueAsListOfDefs("Features");
     bool FastScalarUnalignedAccess = any_of(Features, [&](auto &Feature) {
       return Feature->getValueAsString("Name") == "unaligned-scalar-mem";

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -284,7 +284,7 @@ unsigned SubtargetEmitter::FeatureKeyValues(raw_ostream &OS,
        << "\"" << CommandLineName << "\", "
        << "\"" << Desc << "\", " << Target << "::" << Name << ", ";
 
-    ConstRecVec ImpliesList = Feature->getValueAsListOfConstDefs("Implies");
+    ConstRecVec ImpliesList = Feature->getValueAsListOfDefs("Implies");
 
     printFeatureMask(OS, ImpliesList, FeatureMap);
 
@@ -320,9 +320,9 @@ unsigned SubtargetEmitter::CPUKeyValues(raw_ostream &OS,
 
   for (const Record *Processor : ProcessorList) {
     StringRef Name = Processor->getValueAsString("Name");
-    ConstRecVec FeatureList = Processor->getValueAsListOfConstDefs("Features");
+    ConstRecVec FeatureList = Processor->getValueAsListOfDefs("Features");
     ConstRecVec TuneFeatureList =
-        Processor->getValueAsListOfConstDefs("TuneFeatures");
+        Processor->getValueAsListOfDefs("TuneFeatures");
 
     // Emit as "{ "cpu", "description", 0, { f1 , f2 , ... fn } },".
     OS << " { "
@@ -354,7 +354,7 @@ void SubtargetEmitter::FormItineraryStageString(const std::string &Name,
                                                 std::string &ItinString,
                                                 unsigned &NStages) {
   // Get states list
-  ConstRecVec StageList = ItinData->getValueAsListOfConstDefs("Stages");
+  ConstRecVec StageList = ItinData->getValueAsListOfDefs("Stages");
 
   // For each stage
   unsigned N = NStages = StageList.size();
@@ -367,7 +367,7 @@ void SubtargetEmitter::FormItineraryStageString(const std::string &Name,
     ItinString += "  { " + itostr(Cycles) + ", ";
 
     // Get unit list
-    ConstRecVec UnitList = Stage->getValueAsListOfConstDefs("Units");
+    ConstRecVec UnitList = Stage->getValueAsListOfDefs("Units");
 
     // For each unit
     for (unsigned j = 0, M = UnitList.size(); j < M;) {
@@ -415,7 +415,7 @@ void SubtargetEmitter::FormItineraryBypassString(const std::string &Name,
                                                  const Record *ItinData,
                                                  std::string &ItinString,
                                                  unsigned NOperandCycles) {
-  ConstRecVec BypassList = ItinData->getValueAsListOfConstDefs("Bypasses");
+  ConstRecVec BypassList = ItinData->getValueAsListOfDefs("Bypasses");
   unsigned N = BypassList.size();
   unsigned i = 0;
   ListSeparator LS;
@@ -445,7 +445,7 @@ void SubtargetEmitter::EmitStageAndOperandCycleData(
     if (!ItinsDefSet.insert(ProcModel.ItinsDef).second)
       continue;
 
-    ConstRecVec FUs = ProcModel.ItinsDef->getValueAsListOfConstDefs("FU");
+    ConstRecVec FUs = ProcModel.ItinsDef->getValueAsListOfDefs("FU");
     if (FUs.empty())
       continue;
 
@@ -459,7 +459,7 @@ void SubtargetEmitter::EmitStageAndOperandCycleData(
 
     OS << "} // end namespace " << Name << "FU\n";
 
-    ConstRecVec BPs = ProcModel.ItinsDef->getValueAsListOfConstDefs("BP");
+    ConstRecVec BPs = ProcModel.ItinsDef->getValueAsListOfDefs("BP");
     if (!BPs.empty()) {
       OS << "\n// Pipeline forwarding paths for itineraries \"" << Name
          << "\"\n"
@@ -1005,7 +1005,7 @@ void SubtargetEmitter::ExpandProcResources(
     const Record *PRDef = PRVec[i];
     ConstRecVec SubResources;
     if (PRDef->isSubClassOf("ProcResGroup"))
-      SubResources = PRDef->getValueAsListOfConstDefs("Resources");
+      SubResources = PRDef->getValueAsListOfDefs("Resources");
     else {
       SubResources.push_back(PRDef);
       PRDef = SchedModels.findProcResUnits(PRDef, PM, PRDef->getLoc());
@@ -1027,7 +1027,7 @@ void SubtargetEmitter::ExpandProcResources(
     for (const Record *PR : PM.ProcResourceDefs) {
       if (PR == PRDef || !PR->isSubClassOf("ProcResGroup"))
         continue;
-      ConstRecVec SuperResources = PR->getValueAsListOfConstDefs("Resources");
+      ConstRecVec SuperResources = PR->getValueAsListOfDefs("Resources");
       ConstRecIter SubI = SubResources.begin(), SubE = SubResources.end();
       for (; SubI != SubE; ++SubI) {
         if (!is_contained(SuperResources, *SubI)) {
@@ -1104,18 +1104,16 @@ void SubtargetEmitter::GenSchedClassTables(const CodeGenProcModel &ProcModel,
       if (RWDef) {
         Writes.clear();
         Reads.clear();
-        SchedModels.findRWs(
-            RWDef->getValueAsListOfConstDefs("OperandReadWrites"), Writes,
-            Reads);
+        SchedModels.findRWs(RWDef->getValueAsListOfDefs("OperandReadWrites"),
+                            Writes, Reads);
       }
     }
     if (Writes.empty()) {
       // Check this processor's itinerary class resources.
       for (const Record *I : ProcModel.ItinRWDefs) {
-        ConstRecVec Matched =
-            I->getValueAsListOfConstDefs("MatchedItinClasses");
+        ConstRecVec Matched = I->getValueAsListOfDefs("MatchedItinClasses");
         if (is_contained(Matched, SC.ItinClassDef)) {
-          SchedModels.findRWs(I->getValueAsListOfConstDefs("OperandReadWrites"),
+          SchedModels.findRWs(I->getValueAsListOfDefs("OperandReadWrites"),
                               Writes, Reads);
           break;
         }
@@ -1165,8 +1163,7 @@ void SubtargetEmitter::GenSchedClassTables(const CodeGenProcModel &ProcModel,
         SCDesc.RetireOOO |= WriteRes->getValueAsBit("RetireOOO");
 
         // Create an entry for each ProcResource listed in WriteRes.
-        ConstRecVec PRVec =
-            WriteRes->getValueAsListOfConstDefs("ProcResources");
+        ConstRecVec PRVec = WriteRes->getValueAsListOfDefs("ProcResources");
         std::vector<int64_t> ReleaseAtCycles =
             WriteRes->getValueAsListOfInts("ReleaseAtCycles");
 
@@ -1276,7 +1273,7 @@ void SubtargetEmitter::GenSchedClassTables(const CodeGenProcModel &ProcModel,
         break;
       }
       ConstRecVec ValidWrites =
-          ReadAdvance->getValueAsListOfConstDefs("ValidWrites");
+          ReadAdvance->getValueAsListOfDefs("ValidWrites");
       IdxVec WriteIDs;
       if (ValidWrites.empty())
         WriteIDs.push_back(0);

--- a/llvm/utils/TableGen/X86RecognizableInstr.cpp
+++ b/llvm/utils/TableGen/X86RecognizableInstr.cpp
@@ -154,7 +154,7 @@ RecognizableInstr::RecognizableInstr(DisassemblerTables &tables,
       UID(uid), Spec(&tables.specForUID(uid)) {
   // Check for 64-bit inst which does not require REX
   // FIXME: Is there some better way to check for In64BitMode?
-  for (const Record *Predicate : Rec->getValueAsListOfConstDefs("Predicates")) {
+  for (const Record *Predicate : Rec->getValueAsListOfDefs("Predicates")) {
     if (Predicate->getName().contains("Not64Bit") ||
         Predicate->getName().contains("In32Bit")) {
       Is32Bit = true;

--- a/mlir/lib/TableGen/Predicate.cpp
+++ b/mlir/lib/TableGen/Predicate.cpp
@@ -82,7 +82,7 @@ const llvm::Record *CombinedPred::getCombinerDef() const {
 std::vector<const llvm::Record *> CombinedPred::getChildren() const {
   assert(def->getValue("children") &&
          "CombinedPred must have a value 'children'");
-  return def->getValueAsListOfConstDefs("children");
+  return def->getValueAsListOfDefs("children");
 }
 
 namespace {

--- a/mlir/tools/mlir-tblgen/BytecodeDialectGen.cpp
+++ b/mlir/tools/mlir-tblgen/BytecodeDialectGen.cpp
@@ -437,14 +437,14 @@ static bool emitBCRW(const RecordKeeper &records, raw_ostream &os) {
         it->getValueAsString("dialect") != selectedBcDialect)
       continue;
     dialectAttrOrType[it->getValueAsString("dialect")].attr =
-        it->getValueAsListOfConstDefs("elems");
+        it->getValueAsListOfDefs("elems");
   }
   for (const Record *it : records.getAllDerivedDefinitions("DialectTypes")) {
     if (!selectedBcDialect.empty() &&
         it->getValueAsString("dialect") != selectedBcDialect)
       continue;
     dialectAttrOrType[it->getValueAsString("dialect")].type =
-        it->getValueAsListOfConstDefs("elems");
+        it->getValueAsListOfDefs("elems");
   }
 
   if (dialectAttrOrType.size() != 1)

--- a/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp
+++ b/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp
@@ -167,7 +167,7 @@ std::vector<Availability> getAvailabilities(const Record &def) {
 
   if (def.getValue("availability")) {
     std::vector<const Record *> availDefs =
-        def.getValueAsListOfConstDefs("availability");
+        def.getValueAsListOfDefs("availability");
     availabilities.reserve(availDefs.size());
     for (const Record *avail : availDefs)
       availabilities.emplace_back(avail);
@@ -1451,7 +1451,7 @@ static bool emitCapabilityImplication(const RecordKeeper &recordKeeper,
       continue;
 
     std::vector<const Record *> impliedCapsDefs =
-        def.getValueAsListOfConstDefs("implies");
+        def.getValueAsListOfDefs("implies");
     os << "  case spirv::Capability::" << enumerant.getSymbol()
        << ": {static const spirv::Capability implies[" << impliedCapsDefs.size()
        << "] = {";


### PR DESCRIPTION
Change `getValueAsListOfDefs` to return a vector of const Record pointer, and remove `getValueAsListOfConstDefs` that was added as a transition aid.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089