### PR TITLE
Add AMDGPU metadata to copyMetadataForLoad()

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3445,6 +3445,8 @@ void llvm::copyMetadataForLoad(LoadInst &Dest, const LoadInst &Source) {
   MDBuilder MDB(Dest.getContext());
   Type *NewType = Dest.getType();
   const DataLayout &DL = Source.getDataLayout();
+  LLVMContext &Ctx = Dest.getContext();
+
   for (const auto &MDPair : MD) {
     unsigned ID = MDPair.first;
     MDNode *N = MDPair.second;
@@ -3488,6 +3490,14 @@ void llvm::copyMetadataForLoad(LoadInst &Dest, const LoadInst &Source) {
       copyRangeMetadata(DL, Source, N, Dest);
       break;
     }
+    // Extended last-use / nontemporal hint on AMD GPUs
+    if (ID == Ctx.getMDKindID("amdpu.last.use"))
+      Dest.setMetadata(ID, N);
+    // Currently only relevant to atomics
+    else if (ID == Ctx.getMDKindID("amdgpu.no.remote.memory"))
+      Dest.setMetadata(ID, N);
+    else if (ID == Ctx.getMDKindID("amdgpu.no.fine.grained.memory"))
+      Dest.setMetadata(ID, N);
   }
 }
 


### PR DESCRIPTION
There's some AMDGPU-specific metadata that should also be propagated when copyMetadataForLoad() is used instead of a copyMetadata().

The amdgpu.last.use metadata is a form of nontemporal hint that should be preserved.

amdgpu.no.remote.memory and amdgpu.no.fine.grained.memory currently only enable certain atomic instructions that aren't always safe on some targets, but they might need to be applied to atomic loads in the future.