### PR TITLE
Add explicit symbol visibility macros to InstrProfData.inc

### DIFF
--- a/compiler-rt/include/profile/InstrProfData.inc
+++ b/compiler-rt/include/profile/InstrProfData.inc
@@ -62,6 +62,15 @@
 #define INSTR_PROF_VISIBILITY
 #endif
 
+/* This is include is needed for symbol visibility macros used on
+ * ValueProfRecord\ValueProfData so there functions are exported from the
+ * LLVM shared library on windows. */
+#ifdef __cplusplus
+#include "llvm/Support/Compiler.h"
+#else
+#define LLVM_ABI
+#endif
+
 // clang-format off:consider re-enabling clang-format if auto-formatted C macros
 // are readable (e.g., after `issue #82426` is fixed)
 /* INSTR_PROF_DATA start. */
@@ -373,7 +382,7 @@ INSTR_PROF_SECT_ENTRY(IPSK_covinit, \
  * This is the header of the data structure that defines the on-disk
  * layout of the value profile data of a particular kind for one function.
  */
-typedef struct ValueProfRecord {
+typedef struct LLVM_ABI ValueProfRecord {
   /* The kind of the value profile record. */
   uint32_t Kind;
   /*
@@ -423,7 +432,7 @@ typedef struct ValueProfRecord {
  * Per-function header/control data structure for value profiling
  * data in indexed format.
  */
-typedef struct ValueProfData {
+typedef struct LLVM_ABI ValueProfData {
   /*
    * Total size in bytes including this field. It must be a multiple
    * of sizeof(uint64_t).

--- a/compiler-rt/include/profile/InstrProfData.inc
+++ b/compiler-rt/include/profile/InstrProfData.inc
@@ -62,7 +62,7 @@
 #define INSTR_PROF_VISIBILITY
 #endif
 
-/* This is include is needed for symbol visibility macros used on
+/* This include is needed for symbol visibility macros used on
  * ValueProfRecord\ValueProfData so there functions are exported from the
  * LLVM shared library on windows. */
 #ifdef __cplusplus

--- a/llvm/include/llvm/ProfileData/InstrProfData.inc
+++ b/llvm/include/llvm/ProfileData/InstrProfData.inc
@@ -62,6 +62,15 @@
 #define INSTR_PROF_VISIBILITY
 #endif
 
+/* This is include is needed for symbol visibility macros used on
+ * ValueProfRecord\ValueProfData so there functions are exported from the
+ * LLVM shared library on windows. */
+#ifdef __cplusplus
+#include "llvm/Support/Compiler.h"
+#else
+#define LLVM_ABI
+#endif
+
 // clang-format off:consider re-enabling clang-format if auto-formatted C macros
 // are readable (e.g., after `issue #82426` is fixed)
 /* INSTR_PROF_DATA start. */
@@ -373,7 +382,7 @@ INSTR_PROF_SECT_ENTRY(IPSK_covinit, \
  * This is the header of the data structure that defines the on-disk
  * layout of the value profile data of a particular kind for one function.
  */
-typedef struct ValueProfRecord {
+typedef struct LLVM_ABI ValueProfRecord {
   /* The kind of the value profile record. */
   uint32_t Kind;
   /*
@@ -423,7 +432,7 @@ typedef struct ValueProfRecord {
  * Per-function header/control data structure for value profiling
  * data in indexed format.
  */
-typedef struct ValueProfData {
+typedef struct LLVM_ABI ValueProfData {
   /*
    * Total size in bytes including this field. It must be a multiple
    * of sizeof(uint64_t).

--- a/llvm/include/llvm/ProfileData/InstrProfData.inc
+++ b/llvm/include/llvm/ProfileData/InstrProfData.inc
@@ -62,7 +62,7 @@
 #define INSTR_PROF_VISIBILITY
 #endif
 
-/* This is include is needed for symbol visibility macros used on
+/* This include is needed for symbol visibility macros used on
  * ValueProfRecord\ValueProfData so there functions are exported from the
  * LLVM shared library on windows. */
 #ifdef __cplusplus


### PR DESCRIPTION
Add explicit symbol visibility macros to InstrProfData.inc

Annotating these symbols will fix missing symbols for InstrProfTest when
using shared library builds on windows with explicit visibility macros enabled.
Add a empty fallback definition for LLVM_ABI macro so the code works in compiler-rt.

This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and plugins on window.

```
llvm\lld-link : error : undefined symbol: public: void ValueProfData::deserializeTo(InstrProfRecord&,  InstrProfSymtab*)
>>> referenced by unittests\ProfileData\InstrProfTest.cpp:1372 void ValueProfileReadWriteTest_value_prof_data_read_write_Test::TestBody()
```