### PR TITLE
[SandboxIR] Implement getNumBits for Instructions

### DIFF
--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -97,6 +97,9 @@ public:
 
   const char *getOpcodeName() const { return getOpcodeName(Opc); }
 
+  const DataLayout &getDataLayout() const {
+    return cast<llvm::Instruction>(Val)->getModule()->getDataLayout();
+  }
   // Note that these functions below are calling into llvm::Instruction.
   // A sandbox IR instruction could introduce a new opcode that could change the
   // behavior of one of these functions. It is better that these functions are

--- a/llvm/include/llvm/SandboxIR/Utils.h
+++ b/llvm/include/llvm/SandboxIR/Utils.h
@@ -56,6 +56,12 @@ public:
     return DL.getTypeSizeInBits(Ty->LLVMTy);
   }
 
+  /// \Returns the number of bits required to represent the operands or
+  /// return value of \p I.
+  static unsigned getNumBits(Instruction *I) {
+    return I->getDataLayout().getTypeSizeInBits(getExpectedType(I)->LLVMTy);
+  }
+
   /// Equivalent to MemoryLocation::getOrNone(I).
   static std::optional<llvm::MemoryLocation>
   memoryLocationGetOrNone(const Instruction *I) {

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -1512,26 +1512,6 @@ define void @bar(float %v, ptr %ptr) {
   EXPECT_EQ(sandboxir::Utils::getExpectedValue(RetV), nullptr);
 }
 
-TEST_F(SandboxIRTest, GetNumBits) {
-  parseIR(C, R"IR(
-define void @foo(float %arg0, double %arg1, i8 %arg2, i64 %arg3) {
-bb0:
-  ret void
-}
-)IR");
-  llvm::Function &Foo = *M->getFunction("foo");
-  sandboxir::Context Ctx(C);
-  sandboxir::Function *F = Ctx.createFunction(&Foo);
-  const DataLayout &DL = M->getDataLayout();
-  // getNumBits for scalars
-  EXPECT_EQ(sandboxir::Utils::getNumBits(F->getArg(0), DL),
-            DL.getTypeSizeInBits(Type::getFloatTy(C)));
-  EXPECT_EQ(sandboxir::Utils::getNumBits(F->getArg(1), DL),
-            DL.getTypeSizeInBits(Type::getDoubleTy(C)));
-  EXPECT_EQ(sandboxir::Utils::getNumBits(F->getArg(2), DL), 8u);
-  EXPECT_EQ(sandboxir::Utils::getNumBits(F->getArg(3), DL), 64u);
-}
-
 TEST_F(SandboxIRTest, RAUW_RUWIf) {
   parseIR(C, R"IR(
 define void @foo(ptr %ptr) {

--- a/llvm/unittests/SandboxIR/UtilsTest.cpp
+++ b/llvm/unittests/SandboxIR/UtilsTest.cpp
@@ -138,8 +138,12 @@ define void @foo(ptr %ptr) {
 
 TEST_F(UtilsTest, GetNumBits) {
   parseIR(C, R"IR(
-define void @foo(float %arg0, double %arg1, i8 %arg2, i64 %arg3) {
+define void @foo(float %arg0, double %arg1, i8 %arg2, i64 %arg3, ptr %arg4) {
 bb0:
+  %ld0 = load float, ptr %arg4
+  %ld1 = load double, ptr %arg4
+  %ld2 = load i8, ptr %arg4
+  %ld3 = load i64, ptr %arg4
   ret void
 }
 )IR");
@@ -155,17 +159,17 @@ bb0:
   EXPECT_EQ(sandboxir::Utils::getNumBits(F->getArg(2), DL), 8u);
   EXPECT_EQ(sandboxir::Utils::getNumBits(F->getArg(3), DL), 64u);
 
+  auto &BB = *F->begin();
+  auto It = BB.begin();
+  auto *L0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L2 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L3 = cast<sandboxir::LoadInst>(&*It++);
   // getNumBits for scalars via the Instruction overload
-  EXPECT_EQ(
-      sandboxir::Utils::getNumBits(cast<sandboxir::Instruction>(F->getArg(0))),
-      DL.getTypeSizeInBits(Type::getFloatTy(C)));
-  EXPECT_EQ(
-      sandboxir::Utils::getNumBits(cast<sandboxir::Instruction>(F->getArg(1))),
-      DL.getTypeSizeInBits(Type::getDoubleTy(C)));
-  EXPECT_EQ(
-      sandboxir::Utils::getNumBits(cast<sandboxir::Instruction>(F->getArg(2))),
-      8u);
-  EXPECT_EQ(
-      sandboxir::Utils::getNumBits(cast<sandboxir::Instruction>(F->getArg(3))),
-      64u);
+  EXPECT_EQ(sandboxir::Utils::getNumBits(L0),
+            DL.getTypeSizeInBits(Type::getFloatTy(C)));
+  EXPECT_EQ(sandboxir::Utils::getNumBits(L1),
+            DL.getTypeSizeInBits(Type::getDoubleTy(C)));
+  EXPECT_EQ(sandboxir::Utils::getNumBits(L2), 8u);
+  EXPECT_EQ(sandboxir::Utils::getNumBits(L3), 64u);
 }


### PR DESCRIPTION
This also moves the other getNumbits test into UtilsTest.cc where it belongs.