### PR TITLE
[llvm-debuginfod-find] Fix help text regression

### DIFF
--- a/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
+++ b/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
@@ -81,13 +81,11 @@ static void parseArgs(int argc, char **argv) {
         llvm::outs(), "llvm-debuginfod-find [options] <input build_id>",
         "llvm-debuginfod-find: Fetch debuginfod artifacts\n\n"
         "This program is a frontend to the debuginfod client library. The "
-        "cache "
-        "directory, request timeout (in seconds), and debuginfod server urls "
-        "are "
-        "set by these environment variables:\n"
+        "cache directory, request timeout (in seconds), and debuginfod server "
+        "urls are set by these environment variables:\n"
         "DEBUGINFOD_CACHE_PATH (default set by sys::path::cache_directory)\n"
         "DEBUGINFOD_TIMEOUT (defaults to 90s)\n"
-        "DEBUGINFOD_URLS=[comma separated URLs] (defaults to empty)\n");
+        "DEBUGINFOD_URLS=[comma separated URLs] (defaults to empty)");
     std::exit(0);
   }
 

--- a/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
+++ b/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
@@ -79,7 +79,13 @@ static void parseArgs(int argc, char **argv) {
   if (Args.hasArg(OPT_help)) {
     Tbl.printHelp(llvm::outs(),
                   "llvm-debuginfod-find [options] <input build_id>",
-                  ToolName.str().c_str());
+                   "llvm-debuginfod-find: Fetch debuginfod artifacts\n\n"
+      "This program is a frontend to the debuginfod client library. The cache "
+      "directory, request timeout (in seconds), and debuginfod server urls are "
+      "set by these environment variables:\n"
+      "DEBUGINFOD_CACHE_PATH (default set by sys::path::cache_directory)\n"
+      "DEBUGINFOD_TIMEOUT (defaults to 90s)\n"
+      "DEBUGINFOD_URLS=[comma separated URLs] (defaults to empty)\n");
     std::exit(0);
   }
 

--- a/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
+++ b/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
@@ -77,15 +77,17 @@ static void parseArgs(int argc, char **argv) {
       });
 
   if (Args.hasArg(OPT_help)) {
-    Tbl.printHelp(llvm::outs(),
-                  "llvm-debuginfod-find [options] <input build_id>",
-                   "llvm-debuginfod-find: Fetch debuginfod artifacts\n\n"
-      "This program is a frontend to the debuginfod client library. The cache "
-      "directory, request timeout (in seconds), and debuginfod server urls are "
-      "set by these environment variables:\n"
-      "DEBUGINFOD_CACHE_PATH (default set by sys::path::cache_directory)\n"
-      "DEBUGINFOD_TIMEOUT (defaults to 90s)\n"
-      "DEBUGINFOD_URLS=[comma separated URLs] (defaults to empty)\n");
+    Tbl.printHelp(
+        llvm::outs(), "llvm-debuginfod-find [options] <input build_id>",
+        "llvm-debuginfod-find: Fetch debuginfod artifacts\n\n"
+        "This program is a frontend to the debuginfod client library. The "
+        "cache "
+        "directory, request timeout (in seconds), and debuginfod server urls "
+        "are "
+        "set by these environment variables:\n"
+        "DEBUGINFOD_CACHE_PATH (default set by sys::path::cache_directory)\n"
+        "DEBUGINFOD_TIMEOUT (defaults to 90s)\n"
+        "DEBUGINFOD_URLS=[comma separated URLs] (defaults to empty)\n");
     std::exit(0);
   }
 


### PR DESCRIPTION
While porting the tool from using cl:opt to OptTable, I had mistakenly
deleted the help text header that was originally part of the tool.
Bringing it back in this patch.
