### PR TITLE
[llvm] Don't flush llvm::raw_string_ostream (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -1838,7 +1838,6 @@ struct BFIDOTGraphTraitsBase : public DefaultDOTGraphTraits {
 
     raw_string_ostream OS(Result);
     OS << "color=\"red\"";
-    OS.flush();
     return Result;
   }
 
@@ -1898,7 +1897,6 @@ struct BFIDOTGraphTraitsBase : public DefaultDOTGraphTraits {
       }
     }
 
-    OS.flush();
     return Str;
   }
 };

--- a/llvm/include/llvm/Analysis/LazyCallGraph.h
+++ b/llvm/include/llvm/Analysis/LazyCallGraph.h
@@ -511,7 +511,6 @@ public:
       std::string Name;
       raw_string_ostream OS(Name);
       OS << *this;
-      OS.flush();
       return Name;
     }
   };
@@ -652,7 +651,6 @@ public:
       std::string Name;
       raw_string_ostream OS(Name);
       OS << *this;
-      OS.flush();
       return Name;
     }
 

--- a/llvm/include/llvm/Support/FormatVariadic.h
+++ b/llvm/include/llvm/Support/FormatVariadic.h
@@ -104,7 +104,6 @@ public:
     std::string Result;
     raw_string_ostream Stream(Result);
     Stream << *this;
-    Stream.flush();
     return Result;
   }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -224,7 +224,6 @@ bool DWARFVerifier::verifyName(const DWARFDie &Die) {
   raw_string_ostream OS(ReconstructedName);
   std::string OriginalFullName;
   Die.getFullName(OS, &OriginalFullName);
-  OS.flush();
   if (OriginalFullName.empty() || OriginalFullName == ReconstructedName)
     return false;
 

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -529,7 +529,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     Result += '(';
     raw_string_ostream OS(Result);
     getValueAsType()->print(OS, false, true);
-    OS.flush();
     Result += ')';
     return Result;
   }
@@ -642,7 +641,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
       OS << getModRefStr(MR);
     }
     OS << ")";
-    OS.flush();
     return Result;
   }
 
@@ -661,7 +659,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     OS << "i" << CR.getBitWidth() << " ";
     OS << CR.getLower() << ", " << CR.getUpper();
     OS << ")";
-    OS.flush();
     return Result;
   }
 
@@ -672,7 +669,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     OS << "initializes(";
     CRL.print(OS);
     OS << ")";
-    OS.flush();
     return Result;
   }
 

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -245,7 +245,6 @@ char *LLVMGetDiagInfoDescription(LLVMDiagnosticInfoRef DI) {
   DiagnosticPrinterRawOStream DP(Stream);
 
   unwrap(DI)->print(DP);
-  Stream.flush();
 
   return LLVMCreateMessage(MsgStorage.c_str());
 }
@@ -473,7 +472,6 @@ char *LLVMPrintModuleToString(LLVMModuleRef M) {
   raw_string_ostream os(buf);
 
   unwrap(M)->print(os, nullptr);
-  os.flush();
 
   return strdup(buf.c_str());
 }
@@ -651,8 +649,6 @@ char *LLVMPrintTypeToString(LLVMTypeRef Ty) {
     unwrap(Ty)->print(os);
   else
     os << "Printing <null> Type";
-
-  os.flush();
 
   return strdup(buf.c_str());
 }
@@ -1046,8 +1042,6 @@ char* LLVMPrintValueToString(LLVMValueRef Val) {
   else
     os << "Printing <null> Value";
 
-  os.flush();
-
   return strdup(buf.c_str());
 }
 
@@ -1063,8 +1057,6 @@ char *LLVMPrintDbgRecordToString(LLVMDbgRecordRef Record) {
     unwrap(Record)->print(os);
   else
     os << "Printing <null> DbgRecord";
-
-  os.flush();
 
   return strdup(buf.c_str());
 }

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -371,7 +371,6 @@ void DiagnosticInfoUnsupported::print(DiagnosticPrinter &DP) const {
 
   OS << getLocationStr() << ": in function " << getFunction().getName() << ' '
      << *getFunction().getFunctionType() << ": " << Msg << '\n';
-  OS.flush();
   DP << Str;
 }
 

--- a/llvm/lib/IR/Mangler.cpp
+++ b/llvm/lib/IR/Mangler.cpp
@@ -226,7 +226,6 @@ void llvm::emitLinkerFlagsForGlobalCOFF(raw_ostream &OS, const GlobalValue *GV,
       std::string Flag;
       raw_string_ostream FlagOS(Flag);
       Mangler.getNameWithPrefix(FlagOS, GV, false);
-      FlagOS.flush();
       if (Flag[0] == GV->getDataLayout().getGlobalPrefix())
         OS << Flag.substr(1);
       else
@@ -265,7 +264,6 @@ void llvm::emitLinkerFlagsForGlobalCOFF(raw_ostream &OS, const GlobalValue *GV,
     std::string Flag;
     raw_string_ostream FlagOS(Flag);
     Mangler.getNameWithPrefix(FlagOS, GV, false);
-    FlagOS.flush();
     if (Flag[0] == GV->getDataLayout().getGlobalPrefix())
       OS << Flag.substr(1);
     else

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -111,7 +111,6 @@ ArchiveMemberHeader::ArchiveMemberHeader(const Archive *Parent,
       raw_string_ostream OS(Buf);
       OS.write_escaped(
           StringRef(ArMemHdr->Terminator, sizeof(ArMemHdr->Terminator)));
-      OS.flush();
       std::string Msg("terminator characters in archive member \"" + Buf +
                       "\" not the correct \"`\\n\" values for the archive "
                       "member header ");
@@ -282,7 +281,6 @@ Expected<StringRef> ArchiveMemberHeader::getName(uint64_t Size) const {
       std::string Buf;
       raw_string_ostream OS(Buf);
       OS.write_escaped(Name.substr(1).rtrim(' '));
-      OS.flush();
       uint64_t ArchiveOffset =
           reinterpret_cast<const char *>(ArMemHdr) - Parent->getData().data();
       return malformedError("long name offset characters after the '/' are "
@@ -321,7 +319,6 @@ Expected<StringRef> ArchiveMemberHeader::getName(uint64_t Size) const {
       std::string Buf;
       raw_string_ostream OS(Buf);
       OS.write_escaped(Name.substr(3).rtrim(' '));
-      OS.flush();
       uint64_t ArchiveOffset =
           reinterpret_cast<const char *>(ArMemHdr) - Parent->getData().data();
       return malformedError("long name length characters after the #1/ are "

--- a/llvm/lib/Object/ArchiveWriter.cpp
+++ b/llvm/lib/Object/ArchiveWriter.cpp
@@ -347,7 +347,6 @@ static MemberData computeStringTable(StringRef Names) {
   printWithSpacePadding(Out, "//", 48);
   printWithSpacePadding(Out, Size + Pad, 10);
   Out << "`\n";
-  Out.flush();
   return {{}, std::move(Header), Names, Pad ? "\n" : ""};
 }
 
@@ -959,7 +958,6 @@ computeMemberData(raw_ostream &StringTable, raw_ostream &SymNames,
       printMemberHeader(Out, Pos, StringTable, MemberNames, Kind, Thin, *M,
                         ModTime, Size);
     }
-    Out.flush();
 
     std::vector<unsigned> Symbols;
     if (NeedSymbols != SymtabWritingMode::NoSymtab) {

--- a/llvm/lib/Object/IRSymtab.cpp
+++ b/llvm/lib/Object/IRSymtab.cpp
@@ -333,7 +333,6 @@ Error Builder::addSymbol(const ModuleSymbolTable &Msymtab,
       std::string FallbackName;
       raw_string_ostream OS(FallbackName);
       Msymtab.printSymbolName(OS, Fallback);
-      OS.flush();
       setStr(Uncommon().COFFWeakExternFallbackName, Saver.save(FallbackName));
     }
   }
@@ -358,7 +357,6 @@ Error Builder::build(ArrayRef<Module *> IRMods) {
     if (Error Err = addModule(M))
       return Err;
 
-  COFFLinkerOptsOS.flush();
   setStr(Hdr.COFFLinkerOpts, Saver.save(COFFLinkerOpts));
 
   // We are about to fill in the header's range fields, so reserve space for it

--- a/llvm/lib/ObjectYAML/DWARFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/DWARFEmitter.cpp
@@ -1262,7 +1262,6 @@ emitDebugSectionImpl(const DWARFYAML::Data &DI, StringRef Sec,
 
   if (Error Err = EmitFunc(DebugInfoStream, DI))
     return Err;
-  DebugInfoStream.flush();
   if (!Data.empty())
     OutputBuffers[Sec] = MemoryBuffer::getMemBufferCopy(Data);
 

--- a/llvm/lib/ObjectYAML/WasmEmitter.cpp
+++ b/llvm/lib/ObjectYAML/WasmEmitter.cpp
@@ -77,7 +77,6 @@ public:
   SubSectionWriter(raw_ostream &OS) : OS(OS), StringStream(OutString) {}
 
   void done() {
-    StringStream.flush();
     encodeULEB128(OutString.size(), OS);
     OS << OutString;
     OutString.clear();
@@ -537,7 +536,6 @@ void WasmWriter::writeSectionContent(raw_ostream &OS,
     Func.Body.writeAsBinary(StringStream);
 
     // Write the section size followed by the content
-    StringStream.flush();
     encodeULEB128(OutString.size(), OS);
     OS << OutString;
   }
@@ -645,8 +643,6 @@ bool WasmWriter::writeWasm(raw_ostream &OS) {
     if (HasError)
       return false;
 
-    StringStream.flush();
-
     unsigned HeaderSecSizeEncodingLen =
         Sec->HeaderSecSizeEncodingLen.value_or(5);
     unsigned RequiredLen = getULEB128Size(OutString.size());
@@ -674,7 +670,6 @@ bool WasmWriter::writeWasm(raw_ostream &OS) {
     std::string OutString;
     raw_string_ostream StringStream(OutString);
     writeRelocSection(StringStream, *Sec, SectionIndex++);
-    StringStream.flush();
 
     encodeULEB128(OutString.size(), OS);
     OS << OutString;

--- a/llvm/lib/Remarks/YAMLRemarkParser.cpp
+++ b/llvm/lib/Remarks/YAMLRemarkParser.cpp
@@ -31,7 +31,6 @@ static void handleDiagnostic(const SMDiagnostic &Diag, void *Ctx) {
   Diag.print(/*ProgName=*/nullptr, OS, /*ShowColors*/ false,
              /*ShowKindLabels*/ true);
   OS << '\n';
-  OS.flush();
 }
 
 YAMLParseError::YAMLParseError(StringRef Msg, SourceMgr &SM,

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -573,7 +573,6 @@ int main(int argc, char **argv, char * const *envp) {
       std::string Buf;
       raw_string_ostream OS(Buf);
       logAllUnhandledErrors(ArOrErr.takeError(), OS);
-      OS.flush();
       errs() << Buf;
       exit(1);
     }

--- a/llvm/tools/llvm-ifs/llvm-ifs.cpp
+++ b/llvm/tools/llvm-ifs/llvm-ifs.cpp
@@ -258,7 +258,6 @@ static Error writeIFS(StringRef FilePath, IFSStub &Stub, bool WriteIfChanged) {
   Error YAMLErr = writeIFSToOutputStream(OutStr, Stub);
   if (YAMLErr)
     return YAMLErr;
-  OutStr.flush();
 
   if (WriteIfChanged) {
     if (ErrorOr<std::unique_ptr<MemoryBuffer>> BufOrError =

--- a/llvm/tools/llvm-lipo/llvm-lipo.cpp
+++ b/llvm/tools/llvm-lipo/llvm-lipo.cpp
@@ -49,7 +49,6 @@ static const StringRef ToolName = "llvm-lipo";
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   reportError(Buf);
 }
 
@@ -58,7 +57,6 @@ static const StringRef ToolName = "llvm-lipo";
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   WithColor::error(errs(), ToolName) << "'" << File << "': " << Buf;
   exit(EXIT_FAILURE);
 }

--- a/llvm/tools/llvm-mca/Views/DispatchStatistics.cpp
+++ b/llvm/tools/llvm-mca/Views/DispatchStatistics.cpp
@@ -44,7 +44,6 @@ void DispatchStatistics::printDispatchHistogram(raw_ostream &OS) const {
                << "%)\n";
   }
 
-  TempStream.flush();
   OS << Buffer;
 }
 
@@ -79,7 +78,6 @@ void DispatchStatistics::printDispatchStalls(raw_ostream &OS) const {
   SS << "\nUSH     - Uncategorised Structural Hazard:           ";
   printStalls(SS, HWStalls[HWStallEvent::CustomBehaviourStall], NumCycles);
   SS << '\n';
-  SS.flush();
   OS << Buffer;
 }
 

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -635,7 +635,6 @@ int main(int argc, char **argv) {
                         << ", use -skip-unsupported-instructions=lack-sched to "
                            "ignore these on the input.\n";
                   IP->printInst(&IE.Inst, 0, "", *STI, SS);
-                  SS.flush();
                   WithColor::note()
                       << "instruction: " << InstructionStr << '\n';
                 })) {

--- a/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
+++ b/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
@@ -434,7 +434,6 @@ static int printLineInfoForInput(bool LoadObjects, bool UseDebugObj) {
       std::string Buf;
       raw_string_ostream OS(Buf);
       logAllUnhandledErrors(MaybeObj.takeError(), OS);
-      OS.flush();
       ErrorAndExit("unable to create object file: '" + Buf + "'");
     }
 
@@ -570,7 +569,6 @@ static int executeInput() {
         std::string Buf;
         raw_string_ostream OS(Buf);
         logAllUnhandledErrors(MaybeObj.takeError(), OS);
-        OS.flush();
         ErrorAndExit("unable to create object file: '" + Buf + "'");
       }
 
@@ -975,7 +973,6 @@ static int linkAndVerify() {
       std::string Buf;
       raw_string_ostream OS(Buf);
       logAllUnhandledErrors(MaybeObj.takeError(), OS);
-      OS.flush();
       ErrorAndExit("unable to create object file: '" + Buf + "'");
     }
 

--- a/llvm/tools/llvm-size/llvm-size.cpp
+++ b/llvm/tools/llvm-size/llvm-size.cpp
@@ -121,7 +121,6 @@ static void error(llvm::Error E, StringRef FileName, const Archive::Child &C,
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   errs() << ": " << Buf << "\n";
 }
 
@@ -139,7 +138,6 @@ static void error(llvm::Error E, StringRef FileName,
   std::string Buf;
   raw_string_ostream OS(Buf);
   logAllUnhandledErrors(std::move(E), OS);
-  OS.flush();
   errs() << ": " << Buf << "\n";
 }
 


### PR DESCRIPTION
Don't call `raw_string_ostream::flush()`, which is essentially a no-op.
As specified in the docs, raw_string_ostream is always unbuffered.
( 65b13610a5226b84889b923bae884ba395ad084d for further reference )