### PR TITLE
[clang][DebugInfo] Revert to printing canonical typenames for template aliases

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1472,15 +1472,6 @@ llvm::DIType *CGDebugInfo::CreateType(const TemplateSpecializationType *Ty,
     return AliasTy;
   }
 
-  // Disable PrintCanonicalTypes here because we want
-  // the DW_AT_name to benefit from the TypePrinter's ability
-  // to skip defaulted template arguments.
-  //
-  // FIXME: Once -gsimple-template-names is enabled by default
-  // and we attach template parameters to alias template DIEs
-  // we don't need to worry about customizing the PrintingPolicy
-  // here anymore.
-  PP.PrintCanonicalTypes = false;
   printTemplateArgumentList(OS, Ty->template_arguments(), PP,
                             TD->getTemplateParameters());
   return DBuilder.createTypedef(Src, OS.str(), getOrCreateFile(Loc),

--- a/clang/test/CodeGenCXX/debug-info-alias.cpp
+++ b/clang/test/CodeGenCXX/debug-info-alias.cpp
@@ -24,7 +24,7 @@ x::bar<int> bi;
 // CHECK: [[BFLOAT]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<float>"
 x::bar<float> bf;
 // CHECK: !DIGlobalVariable(name: "bz",{{.*}} type: [[BBAZ:![0-9]+]]
-// CHECK: [[BBAZ]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<baz<int, int> >"
+// CHECK: [[BBAZ]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<baz<int,{{[ ].*}}int> >"
 x::bar<baz<int>> bz;
 
 using

--- a/clang/test/CodeGenCXX/debug-info-alias.cpp
+++ b/clang/test/CodeGenCXX/debug-info-alias.cpp
@@ -24,7 +24,7 @@ x::bar<int> bi;
 // CHECK: [[BFLOAT]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<float>"
 x::bar<float> bf;
 // CHECK: !DIGlobalVariable(name: "bz",{{.*}} type: [[BBAZ:![0-9]+]]
-// CHECK: [[BBAZ]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<baz<int> >"
+// CHECK: [[BBAZ]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<baz<int, int> >"
 x::bar<baz<int>> bz;
 
 using

--- a/clang/test/CodeGenCXX/debug-info-alias.cpp
+++ b/clang/test/CodeGenCXX/debug-info-alias.cpp
@@ -24,7 +24,7 @@ x::bar<int> bi;
 // CHECK: [[BFLOAT]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<float>"
 x::bar<float> bf;
 // CHECK: !DIGlobalVariable(name: "bz",{{.*}} type: [[BBAZ:![0-9]+]]
-// CHECK: [[BBAZ]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<baz<int,{{[ ].*}}int> >"
+// CHECK: [[BBAZ]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<baz<int,{{ *}}int> >"
 x::bar<baz<int>> bz;
 
 using


### PR DESCRIPTION
This was originally added in https://reviews.llvm.org/D142268 to have LLDB display variable typenames that benefit from suppressing defaulted template arguments.

We currently represent template aliases as `DW_AT_typedef`s instead of `DW_TAG_template_alias`. This means for types like:
```
template <class _Tp>
using __remove_cv_t = __remove_cv(_Tp);

template <class _Tp>
using remove_cv_t = __remove_cv_t<_Tp>;

template<typename T>
class optional {
  using value_type = T;
  remove_cv_t<value_type> __val_;
}
```
we would generate DWARF like:
```
0x0000274f:       DW_TAG_typedef
                    DW_AT_type  (0x0000000000002758 "__remove_cv_t<value_type>")
                    DW_AT_name  ("remove_cv_t<value_type>")

```

This is an actual libc++ type layout introduced in https://github.com/llvm/llvm-project/pull/110355, and uncovered a shortcoming of LLDB's data-formatter infrastructure, where we cache formatters on the contents of `DW_AT_name` (which currently wouldn't be a fully resolved typename for template specializations).

To unblock the libc++ change, I think we can revert this without much fallout.

Then we have two options for follow-up (or do both):
1. reland this but adjust the LLDB formatter cache so it doesn't cache formatters for template specializations
2. implement support for `DW_TAG_template_alias` in LLDB (and make Clang generate them by default).