### PR TITLE
[libc] Do not redefine `wchar_t` when compiling in C++

### DIFF
--- a/libc/include/llvm-libc-types/wchar_t.h
+++ b/libc/include/llvm-libc-types/wchar_t.h
@@ -9,6 +9,11 @@
 #ifndef LLVM_LIBC_TYPES_WCHAR_T_H
 #define LLVM_LIBC_TYPES_WCHAR_T_H
 
+// wchar_t is a fundamental type in C++.
+#ifndef __cplusplus
+
 typedef __WCHAR_TYPE__ wchar_t;
+
+#endif
 
 #endif // LLVM_LIBC_TYPES_WCHAR_T_H


### PR DESCRIPTION
Summary:
This is a fundamental type in C++, so we can't redefine it.
