### PR TITLE
[WebAssembly] Handle block and polymorphic stack in AsmTypeCheck

### DIFF
--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -498,7 +498,9 @@ public:
 
   void addBlockTypeOperand(OperandVector &Operands, SMLoc NameLoc,
                            WebAssembly::BlockType BT) {
-    if (BT != WebAssembly::BlockType::Void) {
+    if (BT == WebAssembly::BlockType::Void) {
+      TC.setLastSig(wasm::WasmSignature{});
+    } else {
       wasm::WasmSignature Sig({static_cast<wasm::ValType>(BT)}, {});
       TC.setLastSig(Sig);
       NestingStack.back().Sig = Sig;
@@ -1002,7 +1004,8 @@ public:
       auto *Signature = Ctx.createWasmSignature();
       if (parseSignature(Signature))
         return ParseStatus::Failure;
-      TC.funcDecl(*Signature);
+      if (CurrentState == FunctionStart)
+        TC.funcDecl(*Signature);
       WasmSym->setSignature(Signature);
       WasmSym->setType(wasm::WASM_SYMBOL_TYPE_FUNCTION);
       TOut.emitFunctionType(WasmSym);

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
@@ -460,7 +460,7 @@ bool WebAssemblyAsmTypeCheck::typeCheck(SMLoc ErrorLoc, const MCInst &Inst,
     return popType(ErrorLoc, Any{});
   }
 
-  if (Name == "try" || Name == "block" || Name == "loop" || Name == "if") {
+  if (Name == "block" || Name == "loop" || Name == "if" || Name == "try") {
     bool Error = Name == "if" && popType(ErrorLoc, wasm::ValType::I32);
     // Pop block input parameters and check their types are correct
     Error |= popTypes(ErrorLoc, LastSig.Params);
@@ -472,8 +472,8 @@ bool WebAssemblyAsmTypeCheck::typeCheck(SMLoc ErrorLoc, const MCInst &Inst,
   }
 
   if (Name == "end_block" || Name == "end_loop" || Name == "end_if" ||
-      Name == "else" || Name == "end_try" || Name == "catch" ||
-      Name == "catch_all" || Name == "delegate") {
+      Name == "end_try" || Name == "delegate" || Name == "else" ||
+      Name == "catch" || Name == "catch_all") {
     assert(!BlockInfoStack.empty());
     // Check if the types on the stack match with the block return type
     const auto &LastBlockInfo = BlockInfoStack.back();

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.cpp
@@ -140,7 +140,7 @@ bool WebAssemblyAsmTypeCheck::checkTypes(SMLoc ErrorLoc,
   bool Error = false;
   bool PolymorphicStack = false;
   // Compare elements one by one from the stack top
-  for (;StackI > BlockStackStartPos && TypeI > 0; StackI--, TypeI--) {
+  for (; StackI > BlockStackStartPos && TypeI > 0; StackI--, TypeI--) {
     // If the stack is polymorphic, we assume all types in 'Types' have been
     // compared and matched
     if (std::get_if<Polymorphic>(&Stack[StackI - 1])) {
@@ -316,8 +316,7 @@ bool WebAssemblyAsmTypeCheck::getSignature(SMLoc ErrorLoc,
   return false;
 }
 
-bool WebAssemblyAsmTypeCheck::endOfFunction(SMLoc ErrorLoc,
-                                            bool ExactMatch) {
+bool WebAssemblyAsmTypeCheck::endOfFunction(SMLoc ErrorLoc, bool ExactMatch) {
   assert(!BlockInfoStack.empty());
   const auto &FuncInfo = BlockInfoStack[0];
   return checkTypes(ErrorLoc, FuncInfo.Sig.Returns, ExactMatch);

--- a/llvm/test/MC/WebAssembly/basic-assembly.s
+++ b/llvm/test/MC/WebAssembly/basic-assembly.s
@@ -82,11 +82,13 @@ test0:
     i32.const   3
     end_block            # "switch" exit.
     if                   # void
+    i32.const   0
     if          i32
-    end_if
-    else
+    i32.const   0
     end_if
     drop
+    else
+    end_if
     block       void
     i32.const   2
     return
@@ -222,11 +224,13 @@ empty_exnref_table:
 # CHECK-NEXT:      i32.const   3
 # CHECK-NEXT:      end_block           # label2:
 # CHECK-NEXT:      if
+# CHECK-NEXT:      i32.const   0
 # CHECK-NEXT:      if          i32
-# CHECK-NEXT:      end_if
-# CHECK-NEXT:      else
+# CHECK-NEXT:      i32.const   0
 # CHECK-NEXT:      end_if
 # CHECK-NEXT:      drop
+# CHECK-NEXT:      else
+# CHECK-NEXT:      end_if
 # CHECK-NEXT:      block
 # CHECK-NEXT:      i32.const   2
 # CHECK-NEXT:      return

--- a/llvm/test/MC/WebAssembly/block-assembly.s
+++ b/llvm/test/MC/WebAssembly/block-assembly.s
@@ -1,0 +1,182 @@
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+exception-handling < %s | FileCheck %s
+# Check that it converts to .o without errors, but don't check any output:
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+exception-handling -filetype=obj -o %t.o < %s
+
+  .tagtype  __cpp_exception i32
+
+block_branch_test:
+  .functype  block_branch_test () -> ()
+
+  # Block input paramter / return tests
+
+  i32.const 0
+  block (i32) -> (i32)
+  end_block
+  drop
+
+  i32.const 0
+  i64.const 0
+  block (i32, i64) -> (i32, f32)
+    drop
+    f32.const 0.0
+  end_block
+  drop
+  drop
+
+  i32.const 0
+  loop (i32) -> (f32)
+    drop
+    f32.const 0.0
+  end_loop
+  drop
+
+  i32.const 0
+  i32.const 0
+  if (i32) -> (i32)
+  else
+    i32.popcnt
+  end_if
+  drop
+
+  try i32
+    i32.const 0
+  catch       __cpp_exception
+    i32.clz
+  catch_all
+    i32.const 5
+  end_try
+  drop
+
+  i32.const 0
+  block (i32) -> (i32)
+    block (i32) -> (f32)
+      drop
+      f32.const 0.0
+    end_block
+    drop
+    i32.const 0
+  end_block
+  drop
+
+  # Branch tests
+
+  block f32
+    f32.const 0.0
+    i32.const 0
+    br_if 0
+    f32.const 1.0
+    br 0
+    # After 'br', we can pop any values from the polymorphic stack
+    i32.add
+    i32.sub
+    i32.mul
+    drop
+  end_block
+  drop
+
+  block () -> (f32, f64)
+    f32.const 0.0
+    f64.const 0.0
+    i32.const 0
+    br_if 0
+    block (f32, f64) -> (f32, f64)
+      i32.const 1
+      br_if 0
+    end_block
+  end_block
+  drop
+  drop
+
+  # Withina loop, branches target the start of the loop
+  i32.const 0
+  loop (i32) -> ()
+    i32.const 1
+    br 0
+  end_loop
+
+  end_function
+
+# CHECK-LABEL: block_branch_test
+
+# CHECK:         i32.const  0
+# CHECK-NEXT:    block     (i32) -> (i32)
+# CHECK-NEXT:    end_block                               # label0:
+# CHECK-NEXT:    drop
+
+# CHECK:         i32.const  0
+# CHECK-NEXT:    i64.const  0
+# CHECK-NEXT:    block     (i32, i64) -> (i32, f32)
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    f32.const  0x0p0
+# CHECK-NEXT:    end_block                               # label1:
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    drop
+
+# CHECK:         i32.const  0
+# CHECK-NEXT:    loop      (i32) -> (f32)                  # label2:
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    f32.const  0x0p0
+# CHECK-NEXT:    end_loop
+# CHECK-NEXT:    drop
+
+# CHECK:         i32.const  0
+# CHECK-NEXT:    i32.const  0
+# CHECK-NEXT:    if      (i32) -> (i32)
+# CHECK-NEXT:    else
+# CHECK-NEXT:    i32.popcnt
+# CHECK-NEXT:    end_if
+# CHECK-NEXT:    drop
+
+# CHECK:         try       i32
+# CHECK-NEXT:    i32.const  0
+# CHECK-NEXT:    catch     __cpp_exception                 # catch3:
+# CHECK-NEXT:    i32.clz
+# CHECK-NEXT:    catch_all
+# CHECK-NEXT:    i32.const  5
+# CHECK-NEXT:    end_try                                 # label3:
+# CHECK-NEXT:    drop
+
+# CHECK:         i32.const  0
+# CHECK-NEXT:    block     (i32) -> (i32)
+# CHECK-NEXT:    block     (i32) -> (f32)
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    f32.const  0x0p0
+# CHECK-NEXT:    end_block                               # label5:
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    i32.const  0
+# CHECK-NEXT:    end_block                               # label4:
+# CHECK-NEXT:    drop
+
+# CHECK:         block     f32
+# CHECK-NEXT:    f32.const  0x0p0
+# CHECK-NEXT:    i32.const  0
+# CHECK-NEXT:    br_if     0                               # 0: down to label6
+# CHECK-NEXT:    f32.const  0x1p0
+# CHECK-NEXT:    br        0                               # 0: down to label6
+# CHECK-NEXT:    i32.add
+# CHECK-NEXT:    i32.sub
+# CHECK-NEXT:    i32.mul
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    end_block                               # label6:
+# CHECK-NEXT:    drop
+
+# CHECK:         block     () -> (f32, f64)
+# CHECK-NEXT:    f32.const  0x0p0
+# CHECK-NEXT:    f64.const  0x0p0
+# CHECK-NEXT:    i32.const  0
+# CHECK-NEXT:    br_if     0                               # 0: down to label7
+# CHECK-NEXT:    block     (f32, f64) -> (f32, f64)
+# CHECK-NEXT:    i32.const  1
+# CHECK-NEXT:    br_if     0                               # 0: down to label8
+# CHECK-NEXT:    end_block                               # label8:
+# CHECK-NEXT:    end_block                               # label7:
+# CHECK-NEXT:    drop
+# CHECK-NEXT:    drop
+
+# CHECK:         i32.const  0
+# CHECK-NEXT:    loop      (i32) -> ()                     # label9:
+# CHECK-NEXT:    i32.const  1
+# CHECK-NEXT:    br        0                               # 0: up to label9
+# CHECK-NEXT:    end_loop
+
+# CHECK:         end_function

--- a/llvm/test/MC/WebAssembly/block-assembly.s
+++ b/llvm/test/MC/WebAssembly/block-assembly.s
@@ -87,7 +87,7 @@ block_branch_test:
   drop
   drop
 
-  # Withina loop, branches target the start of the loop
+  # Within a loop, branches target the start of the loop
   i32.const 0
   loop (i32) -> ()
     i32.const 1

--- a/llvm/test/MC/WebAssembly/reference-types.s
+++ b/llvm/test/MC/WebAssembly/reference-types.s
@@ -76,14 +76,17 @@ ref_select_test:
 # CHECK: block externref
 # CHECK: block exnref
 ref_block_test:
-  .functype ref_block_test () -> (exnref, externref, funcref)
+  .functype ref_block_test () -> ()
   block funcref
   block externref
   block exnref
   ref.null_exn
   end_block
+  drop
   ref.null_extern
   end_block
+  drop
   ref.null_func
   end_block
+  drop
   end_function

--- a/llvm/test/MC/WebAssembly/type-checker-errors.s
+++ b/llvm/test/MC/WebAssembly/type-checker-errors.s
@@ -620,9 +620,8 @@ catch_superfluous_value_at_end:
   .functype catch_superfluous_value_at_end () -> ()
   try
   catch tag_i32
-  end_try
-# FIXME: Superfluous value should be caught at end_try?
 # CHECK: :[[@LINE+1]]:3: error: type mismatch, expected [] but got [i32]
+  end_try
   end_function
 
 ref_is_null_empty_stack_while_popping:
@@ -924,4 +923,24 @@ any_value_on_stack:
   local.set 0
   drop
 
+  end_function
+
+block_param_and_return:
+  .functype block_param_and_return () -> ()
+# CHECK: :[[@LINE+1]]:3: error: type mismatch, expected [i32] but got []
+  block (i32) -> (f32)
+# CHECK: :[[@LINE+1]]:3: error: type mismatch, expected [f32] but got [i32]
+  end_block
+# CHECK: :[[@LINE+1]]:3: error: type mismatch, expected [i32] but got [f32]
+  i32.popcnt
+  drop
+
+  block f32
+  f32.const 0.0
+  br 0
+  i32.const 0
+# CHECK: :[[@LINE+1]]:3: error: type mismatch, expected [f32] but got [..., i32]
+  end_block
+
+# CHECK: :[[@LINE+1]]:3: error: type mismatch, expected [] but got [f32]
   end_function


### PR DESCRIPTION
This makes the type checker handle blocks with input parameters and return types, branches, and polymorphic stacks correctly.

We maintain the stack of "block info", which contains its input parameter type, return type, and whether it is a loop or not. And this is used when checking the validity of the value stack at the `end` marker and all branches targeting the block.

`StackType` now supports a new variant `Polymorphic`, which indicates the stack is in the polymorphic state. `Polymorphic`s are not popped even when `popType` is executed; they are only popped when the current block ends.

When popping from the value stack, we ensure we don't pop more than we are allowed to at the given block level and print appropriate error messages instead. Also after a block ends, the value stack is guaranteed to have the right types based on the block return type. For example,
```wast
block i32
  unreachable
end_block
;; You can expect to have an i32 on the stack here
```

This also adds handling for `br_if`. Previously only `br`s were checked.

`checkEnd` and `checkBr` were removed and their contents have been inlined to the main `typeCheck` function, because they are called only from a single callsite.

This also fixes two existing bugs in AsmParser, which were required to make the tests passing. I added Github comments about them inline.

This modifies several existing invalid tests, those that passed (incorrectly) before but do not pass with the new type checker anymore.

Fixes #107524.