### PR TITLE
[libunwind] Fix libunwind library path for runtime test

### DIFF
--- a/libunwind/test/configs/cmake-bridge.cfg.in
+++ b/libunwind/test/configs/cmake-bridge.cfg.in
@@ -31,4 +31,4 @@ if not @LIBUNWIND_ENABLE_THREADS@:
 # Add substitutions for bootstrapping the test suite configuration
 config.substitutions.append(('%{install-prefix}', '@LIBUNWIND_TESTING_INSTALL_PREFIX@'))
 config.substitutions.append(('%{include}', '@LIBUNWIND_TESTING_INSTALL_PREFIX@/include'))
-config.substitutions.append(('%{lib}', '@LIBUNWIND_TESTING_INSTALL_PREFIX@/lib'))
+config.substitutions.append(('%{lib}', '@LIBUNWIND_TESTING_INSTALL_PREFIX@/@LIBUNWIND_INSTALL_LIBRARY_DIR@'))


### PR DESCRIPTION
This patch fixes an issue when test runner cannot find libwind library when LLVM_ENABLE_PER_TARGET_RUNTIME_DIR is used.