### PR TITLE
[StandardInstrumentations] Ensure non-null module pointer when getting display name for IR file

### DIFF
--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -751,7 +751,8 @@ PrintIRInstrumentation::~PrintIRInstrumentation() {
 static SmallString<32> getIRFileDisplayName(Any IR) {
   SmallString<32> Result;
   raw_svector_ostream ResultStream(Result);
-  const Module *M = unwrapModule(IR);
+  const Module *M = unwrapModule(IR, /*Force=*/true);
+  assert(M && "should have unwrapped module");
   uint64_t NameHash = xxh3_64bits(M->getName());
   unsigned MaxHashWidth = sizeof(uint64_t) * 2;
   write_hex(ResultStream, NameHash, HexPrintStyle::Lower, MaxHashWidth);

--- a/llvm/test/Other/dump-with-filter.ll
+++ b/llvm/test/Other/dump-with-filter.ll
@@ -1,0 +1,14 @@
+;; Make sure we can run -filter-print-funcs with -ir-dump-directory.
+; RUN: rm -rf %t/logs
+; RUN: opt %s -disable-output -passes='no-op-function' -print-before=no-op-function -print-after=no-op-function \
+; RUN:   -ir-dump-directory %t/logs -filter-print-funcs=test2
+; RUN: ls %t/logs | count 2
+; RUN: rm -rf %t/logs
+
+define void @test() {
+    ret void
+}
+
+define void @test2() {
+    ret void
+}


### PR DESCRIPTION
Fixes a crash when using `-filter-print-funcs` with `-ir-dump-directory`. A quick reproducer on trunk (also included as a test):

```ll
; opt -passes=no-op-function -print-after=no-op-function -filter-print-funcs=nope -ir-dump-directory=somewhere test.ll

define void @test() {
    ret void
}
```

[Compiler Explorer](https://godbolt.org/z/sPErz44h4)