### PR TITLE
[libcxx] Workaround for build error after #108999

### DIFF
--- a/libcxx/utils/generate_iwyu_mapping.py
+++ b/libcxx/utils/generate_iwyu_mapping.py
@@ -15,7 +15,7 @@ def IWYU_mapping(header: str) -> typing.Optional[typing.List[str]]:
         "__pstl/.+",
         "__support/.+",
         "__utility/private_constructor_tag.h",
-        "__cxx03/.+", # FIXME: Workaround for https://github.com/llvm/llvm-project/pull/108999
+        "__cxx03/.+",  # FIXME: Workaround for https://github.com/llvm/llvm-project/pull/108999
     ]
     if any(re.match(pattern, header) for pattern in ignore):
         return None


### PR DESCRIPTION
We see erros like following after #108999

```
FAILED: include/c++/v1/libcxx.imp ./libcxx_build_msan/include/c++/v1/libcxx.imp
cd ./libcxx_build_msan/libcxx/include && /usr/bin/python3 ./llvm-project/libcxx/utils/generate_iwyu_mapping.py -o ./libcxx_build_msan/include/c++/v1/libcxx.imp
Traceback (most recent call last):
  File "./llvm-project/libcxx/utils/generate_iwyu_mapping.py", line 94, in <module>
    main(sys.argv[1:])
  File "./llvm-project/libcxx/utils/generate_iwyu_mapping.py", line 84, in main
    raise RuntimeError(f"{header}: Header {public} is not a valid header")
RuntimeError: __cxx03/__algorithm/all_of.h: Header cxx03 is not a valid header
ninja: build stopped: subcommand failed.

```
