### PR TITLE
[IR] Allow MDString in operand bundles

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2666,8 +2666,8 @@ are grouped into a single :ref:`attribute group <attrgrp>`.
 Operand Bundles
 ---------------
 
-Operand bundles are tagged sets of SSA values that can be associated
-with certain LLVM instructions (currently only ``call`` s and
+Operand bundles are tagged sets of SSA values or metadata strings that can be
+associated with certain LLVM instructions (currently only ``call`` s and
 ``invoke`` s).  In a way they are like metadata, but dropping them is
 incorrect and will change program semantics.
 
@@ -2675,7 +2675,7 @@ Syntax::
 
     operand bundle set ::= '[' operand bundle (, operand bundle )* ']'
     operand bundle ::= tag '(' [ bundle operand ] (, bundle operand )* ')'
-    bundle operand ::= SSA value
+    bundle operand ::= SSA value | metadata string
     tag ::= string constant
 
 Operand bundles are **not** part of a function's signature, and a

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -88,6 +88,8 @@ Changes to the LLVM IR
   * `llvm.nvvm.ptr.shared.to.gen`
   * `llvm.nvvm.ptr.constant.to.gen`
   * `llvm.nvvm.ptr.local.to.gen`
+  
+* Operand bundle values can now be metadata strings.
 
 Changes to LLVM infrastructure
 ------------------------------

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -66,6 +66,7 @@ namespace llvm {
       t_EmptyArray,          // No value:  []
       t_Constant,            // Value in ConstantVal.
       t_ConstantSplat,       // Value in ConstantVal.
+      t_MDString,            // Value in StrVal.
       t_InlineAsm,           // Value in FTy/StrVal/StrVal2/UIntVal.
       t_ConstantStruct,      // Value in ConstantStructElts.
       t_PackedConstantStruct // Value in ConstantStructElts.

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -66,7 +66,6 @@ namespace llvm {
       t_EmptyArray,          // No value:  []
       t_Constant,            // Value in ConstantVal.
       t_ConstantSplat,       // Value in ConstantVal.
-      t_MDString,            // Value in StrVal.
       t_InlineAsm,           // Value in FTy/StrVal/StrVal2/UIntVal.
       t_ConstantStruct,      // Value in ConstantStructElts.
       t_PackedConstantStruct // Value in ConstantStructElts.

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -529,6 +529,9 @@ enum PossiblyExactOperatorOptionalFlags { PEO_EXACT = 0 };
 /// PossiblyDisjointInst's SubclassOptionalData contents.
 enum PossiblyDisjointInstOptionalFlags { PDI_DISJOINT = 0 };
 
+/// Mark to distinguish metadata from value in an operator bundle.
+enum MetadataOperandBundleValueMarker { OB_METADATA = 0x80000000 };
+
 /// GetElementPtrOptionalFlags - Flags for serializing
 /// GEPOperator's SubclassOptionalData contents.
 enum GetElementPtrOptionalFlags {

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -3207,9 +3207,8 @@ bool LLParser::parseOptionalOperandBundles(
       if (Ty->isMetadataTy()) {
         if (parseMetadataAsValue(Input, PFS))
           return true;
-      } else {
-        if (parseValue(Ty, Input, PFS))
-          return true;
+      } else if (parseValue(Ty, Input, PFS)) {
+        return true;
       }
       Inputs.push_back(Input);
     }

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -3941,6 +3941,15 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     ID.Kind = ValID::t_Constant;
     return false;
 
+  case lltok::exclaim: {
+    Lex.Lex();
+    ID.StrVal = Lex.getStrVal();
+    if (parseToken(lltok::StringConstant, "expected string"))
+      return true;
+    ID.Kind = ValID::t_MDString;
+    return false;
+  }
+
   case lltok::kw_asm: {
     // ValID ::= 'asm' SideEffect? AlignStack? IntelDialect? STRINGCONSTANT ','
     //             STRINGCONSTANT
@@ -6211,6 +6220,11 @@ bool LLParser::convertValIDToValue(Type *Ty, ValID &ID, Value *&V,
                                getTypeString(Ty->getScalarType()) + "'");
     V = ConstantVector::getSplat(cast<VectorType>(Ty)->getElementCount(),
                                  ID.ConstantVal);
+    return false;
+  case ValID::t_MDString:
+    if (!Ty->isMetadataTy())
+      return error(ID.Loc, "invalid type for metadata string");
+    V = MetadataAsValue::get(Context, MDString::get(Context, ID.StrVal));
     return false;
   case ValID::t_ConstantStruct:
   case ValID::t_PackedConstantStruct:

--- a/llvm/test/Bitcode/compatibility.ll
+++ b/llvm/test/Bitcode/compatibility.ll
@@ -1327,6 +1327,14 @@ continue:
   ret i32 0
 }
 
+declare void @instructions.bundles.callee(i32)
+define void @instructions.bundles.metadata(i32 %x) {
+entry:
+  call void @instructions.bundles.callee(i32 %x) [ "foo"(i32 42, metadata !"abc"), "bar"(metadata !"abcde", metadata !"qwerty") ]
+; CHECK: call void @instructions.bundles.callee(i32 %x) [ "foo"(i32 42, metadata !"abc"), "bar"(metadata !"abcde", metadata !"qwerty") ]
+  ret void
+}
+
 ; Instructions -- Unary Operations
 define void @instructions.unops(double %op1) {
   fneg double %op1

--- a/llvm/test/Bitcode/operand-bundles.ll
+++ b/llvm/test/Bitcode/operand-bundles.ll
@@ -56,6 +56,13 @@ define void @f4(i32* %ptr) {
   ret void
 }
 
+define void @f5(i32 %x) {
+entry:
+  call void @callee1(i32 10, i32 %x) [ "foo"(i32 42, metadata !"abc"), "bar"(metadata !"abcde", metadata !"qwerty") ]
+; CHECK: call void @callee1(i32 10, i32 %x) [ "foo"(i32 42, metadata !"abc"), "bar"(metadata !"abcde", metadata !"qwerty") ]
+  ret void
+}
+
 ; Invoke versions of the above tests:
 
 
@@ -148,5 +155,22 @@ exception:
   %cleanup = landingpad i8 cleanup
   br label %normal
 normal:
+  ret void
+}
+
+define void @g5(ptr %ptr) personality i8 3 {
+entry:
+  %l = load i32, ptr %ptr, align 4
+  %x = add i32 42, 1
+  invoke void @callee1(i32 10, i32 %x) [ "foo"(i32 42, metadata !"abc"), "bar"(metadata !"abcde", metadata !"qwerty") ]
+          to label %normal unwind label %exception
+; CHECK:   invoke void @callee1(i32 10, i32 %x) [ "foo"(i32 42, metadata !"abc"), "bar"(metadata !"abcde", metadata !"qwerty") ]
+
+exception:                                        ; preds = %entry
+  %cleanup = landingpad i8
+          cleanup
+  br label %normal
+
+normal:                                           ; preds = %exception, %entry
   ret void
 }


### PR DESCRIPTION
This change implements support of metadata strings in operand bundle values. It makes possible calls like:

    call void @some_func(i32 %x) [ "foo"(i32 42, metadata !"abc") ]

It requires some extension of the bitcode serialization. As SSA values and metadata are stored in different tables, there must be a way to distinguish them during deserialization. It is implemented by putting a special marker before the metadata index. The marker cannot be treated as a reference to any SSA value, so it unambiguously identifies metadata. It allows extending the bitcode serialization without breaking compatibility.

Metadata as operand bundle values are intended to be used in floating-point function calls. They would represent the same information as now is passed by the constrained intrinsic arguments.