### PR TITLE
Add and call `AMDGPUMCResourceInfo::reset` method

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -358,6 +358,7 @@ bool AMDGPUAsmPrinter::doInitialization(Module &M) {
       report_fatal_error("Unexpected code object version");
     }
   }
+
   return AsmPrinter::doInitialization(M);
 }
 
@@ -510,6 +511,8 @@ bool AMDGPUAsmPrinter::doFinalization(Module &M) {
 
   for (Function &F : M.functions())
     validateMCResourceInfo(F);
+
+  RI.reset();
 
   return AsmPrinter::doFinalization(M);
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -71,6 +71,8 @@ void MCResourceInfo::assignMaxRegs(MCContext &OutContext) {
   assignMaxRegSym(MaxSGPRSym, MaxSGPR);
 }
 
+void MCResourceInfo::reset() { *this = MCResourceInfo(); }
+
 void MCResourceInfo::finalize(MCContext &OutContext) {
   assert(!Finalized && "Cannot finalize ResourceInfo again.");
   Finalized = true;

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
@@ -75,6 +75,8 @@ public:
   const MCExpr *getSymRefExpr(StringRef FuncName, ResourceInfoKind RIK,
                               MCContext &Ctx);
 
+  void reset();
+  
   // Resolves the final symbols that requires the inter-function resource info
   // to be resolved.
   void finalize(MCContext &OutContext);

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
@@ -76,7 +76,7 @@ public:
                               MCContext &Ctx);
 
   void reset();
-  
+
   // Resolves the final symbols that requires the inter-function resource info
   // to be resolved.
   void finalize(MCContext &OutContext);


### PR DESCRIPTION
When compiling multiple pipelines, the `MCRegisterInfo` instance in `AMDGPUAsmPrinter` gets re-used even after finalization, so it calls `finalize()` multiple times.

Add a reset method and call it in
`AMDGPUAsmPrinter::doFinalization`.

Different approach would be to make it a `unique_ptr`.