### PR TITLE
[analyzer][NFC] Remove dangling method declaration from ErrnoChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ErrnoChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ErrnoChecker.cpp
@@ -42,7 +42,6 @@ public:
                      ArrayRef<const MemRegion *> ExplicitRegions,
                      ArrayRef<const MemRegion *> Regions,
                      const LocationContext *LCtx, const CallEvent *Call) const;
-  void checkBranchCondition(const Stmt *Condition, CheckerContext &Ctx) const;
 
   /// Indicates if a read (load) of \c errno is allowed in a non-condition part
   /// of \c if, \c switch, loop and conditional statements when the errno


### PR DESCRIPTION
Remove the declaration of `ErrnoChecker::checkBranchCondition()` because this method is not defined or used anywhere. (It's probably a leftover from some old refactoring.)