### PR TITLE
[LLDB] Enable TLS Variable Debugging Without Location Info on AArch64

### DIFF
--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -79,6 +79,8 @@ public:
     return m_location_list;
   }
 
+  bool IsThreadLocal() const;
+
   // When given invalid address, it dumps all locations. Otherwise it only dumps
   // the location that contains this address.
   bool DumpLocations(Stream *s, const Address &address);

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
@@ -73,19 +73,20 @@
 #undef DECLARE_REGISTER_INFOS_ARM64_STRUCT
 
 static lldb_private::RegisterInfo g_register_infos_pauth[] = {
-    DEFINE_EXTENSION_REG(data_mask), DEFINE_EXTENSION_REG(code_mask)};
+    DEFINE_EXTENSION_REG(data_mask, KIND_ALL_INVALID),
+    DEFINE_EXTENSION_REG(code_mask, KIND_ALL_INVALID)};
 
 static lldb_private::RegisterInfo g_register_infos_mte[] = {
-    DEFINE_EXTENSION_REG(mte_ctrl)};
+    DEFINE_EXTENSION_REG(mte_ctrl, KIND_ALL_INVALID)};
 
 static lldb_private::RegisterInfo g_register_infos_tls[] = {
-    DEFINE_EXTENSION_REG(tpidr),
+    DEFINE_EXTENSION_REG(tpidr, GENERIC_KIND(LLDB_REGNUM_GENERIC_TP)),
     // Only present when SME is present
-    DEFINE_EXTENSION_REG(tpidr2)};
+    DEFINE_EXTENSION_REG(tpidr2, KIND_ALL_INVALID)};
 
 static lldb_private::RegisterInfo g_register_infos_sme[] = {
-    DEFINE_EXTENSION_REG(svcr),
-    DEFINE_EXTENSION_REG(svg),
+    DEFINE_EXTENSION_REG(svcr, KIND_ALL_INVALID),
+    DEFINE_EXTENSION_REG(svg, KIND_ALL_INVALID),
     // 16 is a default size we will change later.
     {"za", nullptr, 16, 0, lldb::eEncodingVector, lldb::eFormatVectorOfUInt8,
      KIND_ALL_INVALID, nullptr, nullptr, nullptr}};
@@ -95,7 +96,7 @@ static lldb_private::RegisterInfo g_register_infos_sme2[] = {
      KIND_ALL_INVALID, nullptr, nullptr, nullptr}};
 
 static lldb_private::RegisterInfo g_register_infos_fpmr[] = {
-    DEFINE_EXTENSION_REG(fpmr)};
+    DEFINE_EXTENSION_REG(fpmr, KIND_ALL_INVALID)};
 
 // Number of register sets provided by this context.
 enum {

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
@@ -470,6 +470,13 @@ static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
         LLDB_INVALID_REGNUM, lldb_kind                                         \
   }
 
+// Generates register kinds array for registers with only generic kind
+#define GENERIC_KIND(generic_kind)                                             \
+  {                                                                            \
+    LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, generic_kind,                    \
+        LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM                               \
+  }
+
 // Generates register kinds array for registers with only lldb kind
 #define KIND_ALL_INVALID                                                       \
   {                                                                            \
@@ -535,10 +542,10 @@ static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
   }
 
 // Defines pointer authentication mask registers
-#define DEFINE_EXTENSION_REG(reg)                                              \
+#define DEFINE_EXTENSION_REG(reg, kind)                                        \
   {                                                                            \
     #reg, nullptr, 8, 0, lldb::eEncodingUint, lldb::eFormatHex,                \
-        KIND_ALL_INVALID, nullptr, nullptr, nullptr,                           \
+        kind, nullptr, nullptr, nullptr,                                       \
   }
 
 static lldb_private::RegisterInfo g_register_infos_arm64_le[] = {

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -230,7 +230,6 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
     const char *mangled_cstr = nullptr;
     bool is_declaration = false;
     bool has_address = false;
-    bool has_location_or_const_value = false;
     bool is_global_or_static_variable = false;
 
     DWARFFormValue specification_die_form;
@@ -269,9 +268,6 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
 
       case DW_AT_location:
       case DW_AT_const_value:
-        has_location_or_const_value = true;
-        is_global_or_static_variable = die.IsGlobalOrStaticScopeVariable();
-
         break;
 
       case DW_AT_specification:
@@ -363,7 +359,8 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
       break;
 
     case DW_TAG_variable:
-      if (name && has_location_or_const_value && is_global_or_static_variable) {
+      is_global_or_static_variable = die.IsGlobalOrStaticScopeVariable();
+      if (name && is_global_or_static_variable) {
         set.globals.Insert(ConstString(name), ref);
         // Be sure to include variables by their mangled and demangled names if
         // they have any since a variable can have a basename "i", a mangled

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -3499,6 +3499,7 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
   DWARFFormValue type_die_form;
   bool is_external = false;
   bool is_artificial = false;
+  bool is_declaration = false;
   DWARFFormValue const_value_form, location_form;
   Variable::RangeList scope_ranges;
 
@@ -3545,6 +3546,8 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
       is_artificial = form_value.Boolean();
       break;
     case DW_AT_declaration:
+      is_declaration = form_value.Boolean();
+      break;
     case DW_AT_description:
     case DW_AT_endianity:
     case DW_AT_segment:
@@ -3555,6 +3558,12 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
     case DW_AT_sibling:
       break;
     }
+  }
+
+  // If It's a declaration then symbol not present in this symbolfile
+  // return early to try other linked objects.
+  if (is_declaration) {
+    return nullptr;
   }
 
   // Prefer DW_AT_location over DW_AT_const_value. Both can be emitted e.g.

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -438,6 +438,19 @@ Status Variable::GetValuesForVariableExpressionPath(
   return error;
 }
 
+bool Variable::IsThreadLocal() const {
+  ModuleSP module_sp(m_owner_scope->CalculateSymbolContextModule());
+  // Give the symbol vendor a chance to add to the unified section list.
+  module_sp->GetSymbolFile();
+  std::vector<uint32_t> symbol_indexes;
+  module_sp->GetSymtab()->FindAllSymbolsWithNameAndType(
+      ConstString(GetName()), lldb::SymbolType::eSymbolTypeAny, symbol_indexes);
+  if (symbol_indexes.empty())
+    return false;
+  Symbol *symbol = module_sp->GetSymtab()->SymbolAtIndex(symbol_indexes[0]);
+  return symbol->GetAddress().GetSection()->IsThreadSpecific();
+}
+
 bool Variable::DumpLocations(Stream *s, const Address &address) {
   SymbolContext sc;
   CalculateSymbolContext(&sc);


### PR DESCRIPTION
On AArch64, TLS variables do not have DT_Location entries generated in the debug information due to the lack of dtpoff relocation support, unlike on x86_64. LLDB relies on this location info to calculate the TLS address, leading to issues when debugging TLS variables on AArch64.
However, GDB can successfully calculate the TLS address without relying on this debug info, by using the symbol’s address and manually calculating the offset. We adopt a similar approach for LLDB.

Fixes #71666