### PR TITLE
[lldb][test] Provide proper path to LLVM utils in API tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -176,7 +176,7 @@ class Builder:
                 for var, name in util_names.items():
                     # Do not override explicity specified tool from the cmd line.
                     if not os.getenv(var):
-                        util_paths[var] = getToolchainUtil(name)
+                        util_paths[var] = getToolchainUtil("llvm-" + name)
                     else:
                         util_paths[var] = os.getenv(var)
                 utils.extend(["AR=%s" % util_paths["ARCHIVER"]])


### PR DESCRIPTION
In aea066849, API tests were supposed to use LLVM tools.
However, a path to a utility is made up incorrectly there: util name should be prefixed with `llvm-`.

Hence, it's fixed here.