### PR TITLE
[flang] Link libflangPasses against correct libraries

### DIFF
--- a/flang/lib/Optimizer/Passes/CMakeLists.txt
+++ b/flang/lib/Optimizer/Passes/CMakeLists.txt
@@ -1,3 +1,6 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
+
 add_flang_library(flangPasses
   CommandLineOpts.cpp
   Pipelines.cpp
@@ -9,6 +12,8 @@ add_flang_library(flangPasses
   FIRCodeGen
   FIRTransforms
   FlangOpenMPTransforms
+  ${dialect_libs}
+  ${extension_libs}
   FortranCommon
   HLFIRTransforms
   MLIRPass


### PR DESCRIPTION
libflangPasses.so was not linked against the correct libraries which caused a build failure with -DBUILD_SHARED_LIBS=On. Fixes #110425