### PR TITLE
[OpenACC] Check Loop counts for 'collapse' clause.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12622,6 +12622,12 @@ def err_acc_invalid_in_collapse_loop
             "in intervening code of a 'loop' with a 'collapse' clause">;
 def note_acc_collapse_clause_here
     : Note<"active 'collapse' clause defined here">;
+def err_acc_collapse_multiple_loops
+    : Error<"more than one for-loop in a loop associated with OpenACC 'loop' "
+            "construct with a 'collapse' clause">;
+def err_acc_collapse_insufficient_loops
+    : Error<"'collapse' clause specifies a loop count greater than the number "
+            "of available loops">;
 
 // AMDGCN builtins diagnostics
 def err_amdgcn_global_load_lds_size_invalid_value : Error<"invalid size value">;

--- a/clang/test/SemaOpenACC/loop-construct-collapse-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-collapse-clause.cpp
@@ -115,10 +115,42 @@ void negative_constexpr(int i) {
   negative_constexpr_templ<int, 1>(); // #NCET1
 }
 
+template<unsigned Val>
+void depth_too_high_templ() {
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1{{active 'collapse' clause defined here}}
+#pragma acc loop collapse(Val)
+  for(;;)
+    for(;;);
+}
+
+void depth_too_high() {
+  depth_too_high_templ<3>(); // expected-note{{in instantiation of function template specialization}}
+
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1{{active 'collapse' clause defined here}}
+#pragma acc loop collapse(3)
+  for(;;)
+    for(;;);
+
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1{{active 'collapse' clause defined here}}
+#pragma acc loop collapse(three())
+  for(;;)
+    for(;;);
+
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1{{active 'collapse' clause defined here}}
+#pragma acc loop collapse(ConvertsThree{})
+  for(;;)
+    for(;;);
+}
+
 template<typename T, unsigned Three>
 void not_single_loop_templ() {
   T Arr[5];
-  // expected-note@+1{{active 'collapse' clause defined here}}
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
   for(auto x : Arr) {
     for(auto y : Arr){
@@ -126,7 +158,8 @@ void not_single_loop_templ() {
     }
   }
 
-  // expected-note@+1{{active 'collapse' clause defined here}}
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(Three)
   for(;;) {
     for(;;){
@@ -142,7 +175,8 @@ void not_single_loop_templ() {
       }
     }
   }
-  // expected-note@+1{{active 'collapse' clause defined here}}
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(Three)
   for(auto x : Arr) {
     for(auto y: Arr) {
@@ -181,15 +215,16 @@ void not_single_loop() {
     do{}while(true); // expected-error{{do loop cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
   }
 
-  // expected-note@+1{{active 'collapse' clause defined here}}
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
   for(;;) {
     for(;;){
       while(true); // expected-error{{while loop cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
     }
   }
-
-  // expected-note@+1{{active 'collapse' clause defined here}}
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
   for(;;) {
     for(;;){
@@ -211,8 +246,8 @@ void not_single_loop() {
   }
 
   int Arr[5];
-
-  // expected-note@+1{{active 'collapse' clause defined here}}
+  // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
+  // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
   for(auto x : Arr) {
     for(auto y : Arr){
@@ -220,6 +255,33 @@ void not_single_loop() {
     }
   }
 
+  // expected-note@+1 {{active 'collapse' clause defined here}}
+#pragma acc loop collapse(3)
+  for (;;) {
+    for (;;) {
+      for(;;);
+    }
+    // expected-error@+1{{more than one for-loop in a loop associated with OpenACC 'loop' construct with a 'collapse' clause}}
+    for(;;);
+  }
+
+  // expected-note@+1 {{active 'collapse' clause defined here}}
+#pragma acc loop collapse(3)
+  for (;;) {
+    for (;;) {
+      for(;;);
+    // expected-error@+1{{more than one for-loop in a loop associated with OpenACC 'loop' construct with a 'collapse' clause}}
+      for(;;);
+    }
+  }
+
+  for(;;);
+#pragma acc loop collapse(3)
+  for (;;) {
+    for (;;) {
+      for (;;);
+    }
+  }
 }
 
 template<unsigned Two, unsigned Three>
@@ -227,7 +289,8 @@ void no_other_directives() {
 #pragma acc loop collapse(Two)
   for(;;) {
     for (;;) { // last loop associated with the top level.
-#pragma acc loop collapse(Three) // expected-note{{active 'collapse' clause defined here}}
+    // expected-error@+1{{'collapse' clause specifies a loop count greater than the number of available loops}}
+#pragma acc loop collapse(Three) // expected-note 2{{active 'collapse' clause defined here}}
       for(;;) {
         for(;;) {
     // expected-error@+1{{OpenACC 'serial' construct cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
@@ -243,6 +306,7 @@ void no_other_directives() {
 #pragma acc loop collapse(Three)
       for(;;) {
         for(;;) {
+          for(;;);
         }
       }
     }


### PR DESCRIPTION
OpenACC Spec requires that each loop associated with a 'collapse' have exactly 1 loop/nest. This is implemented in 2 parts: 1- diagnosing when we see a 2nd loop at any level with an applicable 'collapse'
2- Diagnosing if we didn't see enough 'depth' of loops.

Other loops (non-for) are diagnosed by a previous patch, and other intervening code will be diagnosed in a followup.