### PR TITLE
[NFC][SPIRV] Fix for selectExtInst to be able to process intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -785,8 +785,9 @@ bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
                      .addImm(Opcode);
       const unsigned NumOps = I.getNumOperands();
       unsigned Index = 1;
-      if (I.getOperand(Index).getType() ==
-          MachineOperand::MachineOperandType::MO_IntrinsicID)
+      if (Index < NumOps &&
+          I.getOperand(Index).getType() ==
+              MachineOperand::MachineOperandType::MO_IntrinsicID)
         Index = 2;
       for (; Index < NumOps; ++Index)
         MIB.add(I.getOperand(Index));


### PR DESCRIPTION
`selectExtInst` tries to add the intrinsic to the SPIRV GL extension instruction.
`MO_IntrinsicID` is always the first operand when we come from `selectIntrinsic`. 
For all those cases `selectExtInst` needs to know to start at index 2. 
