### PR TITLE
[AArch64] Pass -mabi option through to multilib

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -227,6 +227,11 @@ static void getAArch64MultilibFlags(const Driver &D,
   if (BranchProtectionArg) {
     Result.push_back(BranchProtectionArg->getAsString(Args));
   }
+
+  const Arg *ABIArg = Args.getLastArgNoClaim(options::OPT_mabi_EQ);
+  if (ABIArg) {
+    Result.push_back(ABIArg->getAsString(Args));
+  }
 }
 
 static void getARMMultilibFlags(const Driver &D,

--- a/clang/test/Driver/print-multi-selection-flags.c
+++ b/clang/test/Driver/print-multi-selection-flags.c
@@ -19,6 +19,11 @@
 // CHECK-HARD: -mfloat-abi=hard
 // CHECK-HARD: -mfpu=fpv5-d16
 
+// RUN: %clang -print-multi-flags-experimental --target=aarch64-none-elf -mabi=aapcs | FileCheck --check-prefix=CHECK-ABI-AAPCS %s
+// RUN: %clang -print-multi-flags-experimental --target=aarch64-none-elf -mabi=aapcs-soft | FileCheck --check-prefix=CHECK-ABI-AAPCS-SOFT %s
+// CHECK-ABI-AAPCS: -mabi=aapcs
+// CHECK-ABI-AAPCS-SOFT: -mabi=aapcs-soft
+
 // RUN: %clang -print-multi-flags-experimental --target=arm-none-eabi -mfloat-abi=soft -march=armv8-m.main+nofp | FileCheck --check-prefix=CHECK-V8MMAIN-NOFP %s
 // CHECK-V8MMAIN-NOFP: --target=thumbv8m.main-unknown-none-eabi
 // CHECK-V8MMAIN-NOFP: -mfloat-abi=soft


### PR DESCRIPTION
Pass the -mabi option through to multilib, so that it can be used for library selection.