### PR TITLE
[MLIR][sparse] Fix SparseTensor `test_output.py` test

### DIFF
--- a/mlir/test/Integration/Dialect/SparseTensor/python/test_output.py
+++ b/mlir/test/Integration/Dialect/SparseTensor/python/test_output.py
@@ -183,7 +183,7 @@ def main():
         build_compile_and_run_output(attr, compiler, expected(2))
         count = count + 1
 
-    # CHECK: Passed 17 tests
+    # CHECK: Passed 21 tests
     print("Passed", count, "tests")
 
 


### PR DESCRIPTION
This PR fixes a test failure introduced in https://github.com/llvm/llvm-project/pull/109135