### PR TITLE
[LLDB][DYLD] Remove logic around not rebasing when main executable has a load address

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -108,21 +108,6 @@ void DynamicLoaderPOSIXDYLD::DidAttach() {
   // if we dont have a load address we cant re-base
   bool rebase_exec = load_offset != LLDB_INVALID_ADDRESS;
 
-  // if we have a valid executable
-  if (executable_sp.get()) {
-    lldb_private::ObjectFile *obj = executable_sp->GetObjectFile();
-    if (obj) {
-      // don't rebase if the module already has a load address
-      Target &target = m_process->GetTarget();
-      Address addr = obj->GetImageInfoAddress(&target);
-      if (addr.GetLoadAddress(&target) != LLDB_INVALID_ADDRESS)
-        rebase_exec = false;
-    }
-  } else {
-    // no executable, nothing to re-base
-    rebase_exec = false;
-  }
-
   // if the target executable should be re-based
   if (rebase_exec) {
     ModuleList module_list;

--- a/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpUUID.py
+++ b/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpUUID.py
@@ -328,6 +328,7 @@ class MiniDumpUUIDTestCase(TestBase):
         self.addTearDownHook(lambda: os.chdir(old_cwd))
         os.chdir(self.getBuildDir())
         name = "file-with-a-name-unlikely-to-exist-in-the-current-directory.so"
+        open(name, "a").close()
         modules = self.get_minidump_modules(
             self.getSourcePath("relative_module_name.yaml")
         )

--- a/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpUUID.py
+++ b/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpUUID.py
@@ -327,6 +327,7 @@ class MiniDumpUUIDTestCase(TestBase):
         old_cwd = os.getcwd()
         self.addTearDownHook(lambda: os.chdir(old_cwd))
         os.chdir(self.getBuildDir())
+        name = "file-with-a-name-unlikely-to-exist-in-the-current-directory.so"
         modules = self.get_minidump_modules(
             self.getSourcePath("relative_module_name.yaml")
         )

--- a/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpUUID.py
+++ b/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpUUID.py
@@ -327,8 +327,6 @@ class MiniDumpUUIDTestCase(TestBase):
         old_cwd = os.getcwd()
         self.addTearDownHook(lambda: os.chdir(old_cwd))
         os.chdir(self.getBuildDir())
-        name = "file-with-a-name-unlikely-to-exist-in-the-current-directory.so"
-        open(name, "a").close()
         modules = self.get_minidump_modules(
             self.getSourcePath("relative_module_name.yaml")
         )


### PR DESCRIPTION
This is a part of #109477 that I'm making into it's own patch. Here we remove logic from the DYLD that prevents it's logic from running if the main executable already has a load address. Instead we let the DYLD fully determine what should be loaded and what shouldn't.