### PR TITLE
[Clang][Sema] Bump the instantiated index when skipping past non-init-captures

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -728,6 +728,7 @@ bool Sema::addInstantiatedCapturesToScope(
     ValueDecl *CapturedPattern = CapturePattern.getCapturedVar();
 
     if (!CapturedPattern->isInitCapture()) {
+      Instantiated++;
       continue;
     }
 

--- a/clang/test/SemaTemplate/concepts-lambda.cpp
+++ b/clang/test/SemaTemplate/concepts-lambda.cpp
@@ -279,3 +279,18 @@ void dependent_capture_packs() {
   L(V<0>{}, V<1>{}, V<2>{})(V<3>{}, V<4>{})(1);
 }
 } // namespace init_captures
+
+namespace GH110721 {
+
+template <int N> void connect() {
+  int x = N, y = N;
+  [x, y = y]()
+    requires requires { x; }
+  {}();
+}
+
+void foo() {
+  connect<42>();
+}
+
+} // namespace GH110721


### PR DESCRIPTION
Otherwise, we would probably have an unmatched instantiated declaration for init-captures when they come after a non-init capture.

No release note because the bug only affects the trunk so far.

Fixes #110721