### PR TITLE
[libc++] Use -fexperimental-library in the test suite when available

### DIFF
--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -348,14 +348,9 @@ DEFAULT_PARAMETERS = [
         default=True,
         help="Whether to enable tests for experimental C++ Library features.",
         actions=lambda experimental: [
-            # When linking in MSVC mode via the Clang driver, a -l<foo>
-            # maps to <foo>.lib, so we need to use -llibc++experimental here
-            # to make it link against the static libc++experimental.lib.
-            # We can't check for the feature 'msvc' in available_features
-            # as those features are added after processing parameters.
             AddFeature("c++experimental"),
-            PrependLinkFlag(lambda cfg: "-llibc++experimental" if _isMSVC(cfg) else "-lc++experimental"),
-            AddCompileFlag("-D_LIBCPP_ENABLE_EXPERIMENTAL"),
+            PrependLinkFlag(lambda cfg: "-lc++experimental" if _isGCC(cfg) else "-fexperimental-library"),
+            AddCompileFlag(lambda cfg: "-D_LIBCPP_ENABLE_EXPERIMENTAL" if _isGCC(cfg) else "-fexperimental-library"),
         ]
         if experimental
         else [


### PR DESCRIPTION
That flag was introduced a long time ago at this point, so all supported versions of Clang and Clang-cl should understand it.

Closes #77646