### PR TITLE
[flang] enable assumed-rank lowering by default

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -46,10 +46,10 @@
 #include "llvm/Support/Debug.h"
 #include <optional>
 
-static llvm::cl::opt<bool> allowAssumedRank(
-    "allow-assumed-rank",
-    llvm::cl::desc("Enable assumed rank lowering - experimental"),
-    llvm::cl::init(false));
+static llvm::cl::opt<bool>
+    allowAssumedRank("allow-assumed-rank",
+                     llvm::cl::desc("Enable assumed rank lowering"),
+                     llvm::cl::init(true));
 
 #define DEBUG_TYPE "flang-lower-variable"
 

--- a/flang/test/Lower/HLFIR/assumed-rank-calls.f90
+++ b/flang/test/Lower/HLFIR/assumed-rank-calls.f90
@@ -1,7 +1,7 @@
 ! Test passing of assumed-ranks that require creating a
 ! a new descriptor for the dummy argument (different lower bounds,
 ! attribute, or dynamic type)
-! RUN: bbc -emit-hlfir -allow-assumed-rank -o - %s | FileCheck %s
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
 
 subroutine test_alloc_to_nonalloc(x)
   real, allocatable ::  x(..)

--- a/flang/test/Lower/HLFIR/assumed-rank-entry.f90
+++ b/flang/test/Lower/HLFIR/assumed-rank-entry.f90
@@ -1,6 +1,6 @@
 ! Test assumed-rank dummy argument that is not present in
 ! all ENTRY statements.
-! RUN: bbc -emit-hlfir -allow-assumed-rank -o - %s | FileCheck %s
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
 
 subroutine test_main_entry(x)
   real :: x(..)

--- a/flang/test/Lower/HLFIR/assumed-rank-inquiries-2.f90
+++ b/flang/test/Lower/HLFIR/assumed-rank-inquiries-2.f90
@@ -1,6 +1,6 @@
 ! Test lowering of SIZE/SIZEOF inquiry intrinsics with assumed-ranks
 ! arguments.
-! RUN: bbc -emit-hlfir -o - %s -allow-assumed-rank | FileCheck %s
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
 
 
 subroutine test_size_1(x)

--- a/flang/test/Lower/HLFIR/assumed-rank-inquiries-3.f90
+++ b/flang/test/Lower/HLFIR/assumed-rank-inquiries-3.f90
@@ -1,5 +1,5 @@
 ! Test shape lowering for assumed-rank
-! RUN: bbc -emit-hlfir -o - %s -allow-assumed-rank | FileCheck %s
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
 
 subroutine test_shape(x)
   real :: x(..)

--- a/flang/test/Lower/HLFIR/assumed-rank-inquiries.f90
+++ b/flang/test/Lower/HLFIR/assumed-rank-inquiries.f90
@@ -1,5 +1,5 @@
 ! Test lowering of inquiry intrinsics with assumed-ranks arguments.
-! RUN: bbc -emit-hlfir -o - %s -allow-assumed-rank | FileCheck %s
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
 
 subroutine test_allocated(x)
   real, allocatable :: x(..)

--- a/flang/test/Lower/HLFIR/assumed-rank-internal-proc.f90
+++ b/flang/test/Lower/HLFIR/assumed-rank-internal-proc.f90
@@ -1,5 +1,5 @@
 ! Test assumed-rank capture inside internal procedures.
-! RUN: bbc -emit-hlfir -o - %s -allow-assumed-rank | FileCheck %s
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
 
 subroutine test_assumed_rank(x)
   real :: x(..)

--- a/flang/test/Lower/HLFIR/convert-variable-assumed-rank.f90
+++ b/flang/test/Lower/HLFIR/convert-variable-assumed-rank.f90
@@ -1,5 +1,5 @@
 ! Test lowering of assumed-rank variables
-! RUN: bbc -emit-hlfir %s -allow-assumed-rank -o - | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s
 
 module assumed_rank_tests
 interface

--- a/flang/test/Lower/HLFIR/select-rank.f90
+++ b/flang/test/Lower/HLFIR/select-rank.f90
@@ -1,5 +1,5 @@
 ! Test lowering of select rank to HLFIR
-! RUN: bbc -emit-hlfir -o - %s -allow-assumed-rank | FileCheck %s
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
 
 module iface_helpers
 interface


### PR DESCRIPTION
Aside from [this minor TODO about polymorphic RANK(*) selector](https://github.com/llvm/llvm-project/blob/2b8e81ce919e8db857dc2ba20012e9020af07294/flang/lib/Lower/Bridge.cpp#L3459), the implementation for assumed-rank is ready for everyone to use.