### PR TITLE
[doc] Add --verify-json to dwarfdump documentation

### DIFF
--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -150,6 +150,12 @@ OPTIONS
             compile unit chains, DIE relationships graph, address
             ranges, and more.
 
+.. option:: --verify-json=<path>
+
+            Output JSON-formatted error summary to the a file specfied by
+            <path>. Implies :option:`--verify`.  The output format is described
+            in the section below (:ref:`verify-json-format`).
+
 .. option:: --version
 
             Display the version of the tool.
@@ -195,6 +201,28 @@ For aggregated values, the following keys are used:
       - `#bytes` ==> the number of bytes
       - `#variables - entry values ...` ==> the number of variables excluding
         the entry values etc.
+
+.. _verify-json-format:
+
+FORMAT OF VERIFY JSON OUTPUT
+----------------------------
+
+The format of the JSON output created by the :option:`--verify-json=<path>` is::
+
+  { 
+    "error-categories": { 
+      "<first category description>": {"count": 1234},
+      "<next category description>": {"count": 4321}
+    },
+    "error-count": 5555
+  }
+
+The following is generated if there are no errors reported::
+
+  { 
+    "error-categories": {},
+    "error-count": 0
+  }
 
 EXIT STATUS
 -----------

--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -207,7 +207,7 @@ For aggregated values, the following keys are used:
 FORMAT OF VERIFY JSON OUTPUT
 ----------------------------
 
-The format of the JSON output created by the :option:`--verify-json=<path>` is::
+The format of the JSON output created by the :option:`--verify-json` is::
 
   { 
     "error-categories": { 


### PR DESCRIPTION
This adds documentation for --verify-json, see: https://github.com/llvm/llvm-project/pull/81762.

Note: GitHub won't seem to allow me add the original author @kevinfrei as a reviewer for some reason.