### PR TITLE
[clang-format] Make bitwise and imply requires clause

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3470,10 +3470,10 @@ bool UnwrappedLineParser::parseRequires() {
   case tok::r_paren:
   case tok::kw_noexcept:
   case tok::kw_const:
+  case tok::amp:
     // This is a requires clause.
     parseRequiresClause(RequiresToken);
     return true;
-  case tok::amp:
   case tok::ampamp: {
     // This can be either:
     // if (... && requires (T t) ...)
@@ -3526,17 +3526,6 @@ bool UnwrappedLineParser::parseRequires() {
         FormatTok = Tokens->setPosition(StoredPosition);
         parseRequiresExpression(RequiresToken);
         return false;
-      }
-      break;
-    case tok::equalequal:
-    case tok::greaterequal:
-    case tok::lessequal:
-    case tok::r_paren:
-    case tok::pipepipe:
-      if (OpenAngles == 0) {
-        FormatTok = Tokens->setPosition(StoredPosition);
-        parseRequiresClause(RequiresToken);
-        return true;
       }
       break;
     case tok::eof:

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3528,6 +3528,17 @@ bool UnwrappedLineParser::parseRequires() {
         return false;
       }
       break;
+    case tok::equalequal:
+    case tok::greaterequal:
+    case tok::lessequal:
+    case tok::r_paren:
+    case tok::pipepipe:
+      if (OpenAngles == 0) {
+        FormatTok = Tokens->setPosition(StoredPosition);
+        parseRequiresClause(RequiresToken);
+        return true;
+      }
+      break;
     case tok::eof:
       // Break out of the loop.
       Lookahead = 50;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1298,19 +1298,13 @@ TEST_F(TokenAnnotatorTest, UnderstandsRequiresClausesAndConcepts) {
   EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresExpression);
 
   // Second function definition is required due to lookahead
-  Tokens = annotate("void f() & requires(n == 1) {}\nvoid g();");
+  Tokens = annotate("void f() &\n"
+                    "  requires(n == 1)\n"
+                    "{}\n"
+                    "void g();");
   ASSERT_EQ(Tokens.size(), 19u) << Tokens;
   EXPECT_TOKEN(Tokens[4], tok::amp, TT_PointerOrReference);
   EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresClause);
-
-  Tokens = annotate("void f() & requires(n || h) {}\nvoid g();");
-  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
-  EXPECT_TOKEN(Tokens[4], tok::amp, TT_PointerOrReference);
-  EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresClause);
-
-  Tokens = annotate("bool x = t && requires(F<n == 1> x) { x.foo(); };");
-  ASSERT_EQ(Tokens.size(), 25u) << Tokens;
-  EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresExpression);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsRequiresExpressions) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1296,6 +1296,21 @@ TEST_F(TokenAnnotatorTest, UnderstandsRequiresClausesAndConcepts) {
   Tokens = annotate("bool x = t && requires(Foo<C1 || C2> x) { x.foo(); };");
   ASSERT_EQ(Tokens.size(), 25u) << Tokens;
   EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresExpression);
+
+  // Second function definition is required due to lookahead
+  Tokens = annotate("void f() & requires(n == 1) {}\nvoid g();");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[4], tok::amp, TT_PointerOrReference);
+  EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresClause);
+
+  Tokens = annotate("void f() & requires(n || h) {}\nvoid g();");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[4], tok::amp, TT_PointerOrReference);
+  EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresClause);
+
+  Tokens = annotate("bool x = t && requires(F<n == 1> x) { x.foo(); };");
+  ASSERT_EQ(Tokens.size(), 25u) << Tokens;
+  EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresExpression);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsRequiresExpressions) {


### PR DESCRIPTION
This patch adjusts the requires clause/expression parser to imply a requires clause if it is preceded by a bitwise and operator `&`, and assume it is a reference qualifier. The justification is that bitwise operations should not be used for requires expressions.

This is a band-aid fix. The real problems lie in the lookahead heuristic in the same method. It may be worth it to rewrite that whole heuristic to track more state in the future, instead of just blindly marching forward across multiple unrelated definitions, since right now, the definition following the one with the requires clause can influence whether the heuristic chooses clause or expression.

Fixes https://github.com/llvm/llvm-project/issues/110485