### PR TITLE
[Hashing] Remove Clang<=11 -fno-pic workaround

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -311,10 +311,7 @@ struct hash_state {
 /// depend on the particular hash values. On platforms without ASLR, this is
 /// still likely non-deterministic per build.
 inline uint64_t get_execution_seed() {
-  // Work around x86-64 negative offset folding for old Clang -fno-pic
-  // https://reviews.llvm.org/D93931
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS &&                                         \
-    (!defined(__clang__) || __clang_major__ > 11)
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS
   return static_cast<uint64_t>(
       reinterpret_cast<uintptr_t>(&install_fatal_error_handler));
 #else


### PR DESCRIPTION
If the LLVM build and an API user have different
`(!defined(__clang__) || __clang_major__ > 11)` values, we will have a non-benign ODR violation and some users prefer a clear error to silent breakage.

The Clang<=11 -fno-pic x86-64 workaround is likely not useful anyway because builds are mostly PIC (`POSITION_INDEPENDENT_CODE` or LLVM_ENABLE_PIC).