### PR TITLE
[RISCV][ISel] Select `binvi` for pattern `icmp eq/ne X, pow2`

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -2938,6 +2938,14 @@ bool RISCVDAGToDAGISel::selectSETCC(SDValue N, ISD::CondCode ExpectedCCVal,
                     0);
       return true;
     }
+    if (isPowerOf2_64(CVal) && Subtarget->hasStdExtZbs()) {
+      Val = SDValue(
+          CurDAG->getMachineNode(
+              RISCV::BINVI, DL, N->getValueType(0), LHS,
+              CurDAG->getTargetConstant(Log2_64(CVal), DL, N->getValueType(0))),
+          0);
+      return true;
+    }
   }
 
   // If nothing else we can XOR the LHS and RHS to produce zero if they are

--- a/llvm/test/CodeGen/RISCV/rv32zbs.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbs.ll
@@ -839,23 +839,35 @@ define i64 @bset_trailing_ones_i64_no_mask(i64 %a) nounwind {
 }
 
 define i1 @icmp_eq_pow2(i32 %x) nounwind {
-; CHECK-LABEL: icmp_eq_pow2:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a1, 8
-; CHECK-NEXT:    xor a0, a0, a1
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: icmp_eq_pow2:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    lui a1, 8
+; RV32I-NEXT:    xor a0, a0, a1
+; RV32I-NEXT:    seqz a0, a0
+; RV32I-NEXT:    ret
+;
+; RV32ZBS-LABEL: icmp_eq_pow2:
+; RV32ZBS:       # %bb.0:
+; RV32ZBS-NEXT:    binvi a0, a0, 15
+; RV32ZBS-NEXT:    seqz a0, a0
+; RV32ZBS-NEXT:    ret
   %cmp = icmp eq i32 %x, 32768
   ret i1 %cmp
 }
 
 define i1 @icmp_ne_pow2(i32 %x) nounwind {
-; CHECK-LABEL: icmp_ne_pow2:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a1, 8
-; CHECK-NEXT:    xor a0, a0, a1
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: icmp_ne_pow2:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    lui a1, 8
+; RV32I-NEXT:    xor a0, a0, a1
+; RV32I-NEXT:    seqz a0, a0
+; RV32I-NEXT:    ret
+;
+; RV32ZBS-LABEL: icmp_ne_pow2:
+; RV32ZBS:       # %bb.0:
+; RV32ZBS-NEXT:    binvi a0, a0, 15
+; RV32ZBS-NEXT:    seqz a0, a0
+; RV32ZBS-NEXT:    ret
   %cmp = icmp eq i32 %x, 32768
   ret i1 %cmp
 }

--- a/llvm/test/CodeGen/RISCV/rv32zbs.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbs.ll
@@ -837,3 +837,37 @@ define i64 @bset_trailing_ones_i64_no_mask(i64 %a) nounwind {
   %not = xor i64 %shift, -1
   ret i64 %not
 }
+
+define i1 @icmp_eq_pow2(i32 %x) nounwind {
+; CHECK-LABEL: icmp_eq_pow2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 8
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp eq i32 %x, 32768
+  ret i1 %cmp
+}
+
+define i1 @icmp_ne_pow2(i32 %x) nounwind {
+; CHECK-LABEL: icmp_ne_pow2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 8
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp eq i32 %x, 32768
+  ret i1 %cmp
+}
+
+define i1 @icmp_eq_nonpow2(i32 %x) nounwind {
+; CHECK-LABEL: icmp_eq_nonpow2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 8
+; CHECK-NEXT:    addi a1, a1, -1
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp eq i32 %x, 32767
+  ret i1 %cmp
+}

--- a/llvm/test/CodeGen/RISCV/rv64zbs.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbs.ll
@@ -1146,3 +1146,56 @@ define signext i64 @bset_trailing_ones_i64_no_mask(i64 signext %a) nounwind {
   %not = xor i64 %shift, -1
   ret i64 %not
 }
+
+define i1 @icmp_eq_pow2(i32 signext %x) nounwind {
+; CHECK-LABEL: icmp_eq_pow2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 8
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp eq i32 %x, 32768
+  ret i1 %cmp
+}
+
+define i1 @icmp_eq_pow2_64(i64 %x) nounwind {
+; RV64I-LABEL: icmp_eq_pow2_64:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    li a1, 1
+; RV64I-NEXT:    slli a1, a1, 40
+; RV64I-NEXT:    xor a0, a0, a1
+; RV64I-NEXT:    seqz a0, a0
+; RV64I-NEXT:    ret
+;
+; RV64ZBS-LABEL: icmp_eq_pow2_64:
+; RV64ZBS:       # %bb.0:
+; RV64ZBS-NEXT:    bseti a1, zero, 40
+; RV64ZBS-NEXT:    xor a0, a0, a1
+; RV64ZBS-NEXT:    seqz a0, a0
+; RV64ZBS-NEXT:    ret
+  %cmp = icmp eq i64 %x, 1099511627776
+  ret i1 %cmp
+}
+
+define i1 @icmp_ne_pow2(i32 signext %x) nounwind {
+; CHECK-LABEL: icmp_ne_pow2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 8
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp eq i32 %x, 32768
+  ret i1 %cmp
+}
+
+define i1 @icmp_eq_nonpow2(i32 signext %x) nounwind {
+; CHECK-LABEL: icmp_eq_nonpow2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 8
+; CHECK-NEXT:    addiw a1, a1, -1
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp eq i32 %x, 32767
+  ret i1 %cmp
+}

--- a/llvm/test/CodeGen/RISCV/rv64zbs.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbs.ll
@@ -1148,12 +1148,18 @@ define signext i64 @bset_trailing_ones_i64_no_mask(i64 signext %a) nounwind {
 }
 
 define i1 @icmp_eq_pow2(i32 signext %x) nounwind {
-; CHECK-LABEL: icmp_eq_pow2:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a1, 8
-; CHECK-NEXT:    xor a0, a0, a1
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    ret
+; RV64I-LABEL: icmp_eq_pow2:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    lui a1, 8
+; RV64I-NEXT:    xor a0, a0, a1
+; RV64I-NEXT:    seqz a0, a0
+; RV64I-NEXT:    ret
+;
+; RV64ZBS-LABEL: icmp_eq_pow2:
+; RV64ZBS:       # %bb.0:
+; RV64ZBS-NEXT:    binvi a0, a0, 15
+; RV64ZBS-NEXT:    seqz a0, a0
+; RV64ZBS-NEXT:    ret
   %cmp = icmp eq i32 %x, 32768
   ret i1 %cmp
 }
@@ -1169,8 +1175,7 @@ define i1 @icmp_eq_pow2_64(i64 %x) nounwind {
 ;
 ; RV64ZBS-LABEL: icmp_eq_pow2_64:
 ; RV64ZBS:       # %bb.0:
-; RV64ZBS-NEXT:    bseti a1, zero, 40
-; RV64ZBS-NEXT:    xor a0, a0, a1
+; RV64ZBS-NEXT:    binvi a0, a0, 40
 ; RV64ZBS-NEXT:    seqz a0, a0
 ; RV64ZBS-NEXT:    ret
   %cmp = icmp eq i64 %x, 1099511627776
@@ -1178,12 +1183,18 @@ define i1 @icmp_eq_pow2_64(i64 %x) nounwind {
 }
 
 define i1 @icmp_ne_pow2(i32 signext %x) nounwind {
-; CHECK-LABEL: icmp_ne_pow2:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a1, 8
-; CHECK-NEXT:    xor a0, a0, a1
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    ret
+; RV64I-LABEL: icmp_ne_pow2:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    lui a1, 8
+; RV64I-NEXT:    xor a0, a0, a1
+; RV64I-NEXT:    seqz a0, a0
+; RV64I-NEXT:    ret
+;
+; RV64ZBS-LABEL: icmp_ne_pow2:
+; RV64ZBS:       # %bb.0:
+; RV64ZBS-NEXT:    binvi a0, a0, 15
+; RV64ZBS-NEXT:    seqz a0, a0
+; RV64ZBS-NEXT:    ret
   %cmp = icmp eq i32 %x, 32768
   ret i1 %cmp
 }


### PR DESCRIPTION
This patch selects `binvi` for pattern `icmp eq/ne X, pow2` when zbs is available.
