### PR TITLE
[Clang][Driver] Support relative paths for CLANG_CONFIG_FILE_SYSTEM_DIR

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -229,7 +229,14 @@ Driver::Driver(StringRef ClangExecutable, StringRef TargetTriple,
   }
 
 #if defined(CLANG_CONFIG_FILE_SYSTEM_DIR)
-  SystemConfigDir = CLANG_CONFIG_FILE_SYSTEM_DIR;
+  if (llvm::sys::path::is_absolute(CLANG_CONFIG_FILE_SYSTEM_DIR)) {
+    SystemConfigDir = CLANG_CONFIG_FILE_SYSTEM_DIR;
+  } else {
+    SmallString<128> configFileDir(Dir);
+    llvm::sys::path::append(configFileDir, CLANG_CONFIG_FILE_SYSTEM_DIR);
+    llvm::sys::path::remove_dots(configFileDir, true);
+    SystemConfigDir = static_cast<std::string>(configFileDir);
+  }
 #endif
 #if defined(CLANG_CONFIG_FILE_USER_DIR)
   {


### PR DESCRIPTION
Shipping a system configuration file for Clang is useful, but it limits
the relocatability of the toolchain because it bakes in a reference to
an absolute path on the file system.

Let's fix that by allowing for `CLANG_CONFIG_FILE_SYSTEM_DIR` to be set
to a relative path, and then interpreting that relative to the location
of the driver if applicable.

This would be useful for the LLVM package we ship at Homebrew. We
currently have to bake in a `DEFAULT_SYSROOT` in order to ship a
toolchain that works out of the box on macOS. If
`CLANG_CONFIG_FILE_SYSTEM_DIR` supported relative paths, we could
replace that with a configuration file which would be easier to update
when the compiled-in `DEFAULT_SYSROOT` becomes stale (e.g. on macOS
version upgrades).

We could, of course, set `CLANG_CONFIG_FILE_SYSTEM_DIR` to an absolute
path to begin with. However, we do have users who install Homebrew into
a prefix that is different from the one used on our buildbots, so doing
this would result in a broken toolchain for those users.
