### PR TITLE
[mlir][sparse][test] Adjust tests for `LowerSparseOpsToForeach`

### DIFF
--- a/mlir/test/Dialect/SparseTensor/codegen.mlir
+++ b/mlir/test/Dialect/SparseTensor/codegen.mlir
@@ -826,19 +826,3 @@ func.func @sparse_new_coo_permute_no(%arg0: !llvm.ptr) -> tensor<?x?xf32, #CooPN
   %0 = sparse_tensor.new %arg0 : !llvm.ptr to tensor<?x?xf32, #CooPNo>
   return %0 : tensor<?x?xf32, #CooPNo>
 }
-
-// CHECK-LABEL: func.func @test_tensor_dim_unranked
-//       CHECK: tensor.dim
-func.func @test_tensor_dim_unranked(%arg0: tensor<*xf32>) -> index {
-  %c = arith.constant 0 : index
-  %0 = tensor.dim %arg0, %c : tensor<*xf32>
-  return %0 : index
-}
-
-// CHECK-LABEL: func.func @test_tensor_reshape_unranked
-//       CHECK: tensor.reshape
-func.func @test_tensor_reshape_unranked(%src: tensor<*xf32>, %shape: tensor<1xi32>) -> tensor<?xf32> {
-  %dst = tensor.reshape %src(%shape)
-         : (tensor<*xf32>, tensor<1xi32>) -> tensor<?xf32>
-  return %dst : tensor<?xf32>
-}

--- a/mlir/test/Dialect/SparseTensor/no_lowering.mlir
+++ b/mlir/test/Dialect/SparseTensor/no_lowering.mlir
@@ -1,0 +1,54 @@
+// RUN: mlir-opt %s --lower-sparse-ops-to-foreach --split-input-file | FileCheck %s
+
+// Ensure that we exit gracefully rather than crashing.
+
+// CHECK-LABEL: func.func @test_tensor_dim_unranked
+//       CHECK: tensor.dim
+func.func @test_tensor_dim_unranked(%arg0: tensor<*xf32>) -> index {
+  %c = arith.constant 0 : index
+  %0 = tensor.dim %arg0, %c : tensor<*xf32>
+  return %0 : index
+}
+
+// -----
+
+#SparseVector = #sparse_tensor.encoding<{
+  map = (d0) -> (d0 : compressed)
+}>
+
+// CHECK-LABEL: func.func @test_no_constant_dim
+//       CHECK: tensor.dim
+func.func @test_no_constant_dim(%arg0: tensor<?xf64, #SparseVector>, %arg1: index) -> index {
+  %0 = tensor.dim %arg0, %arg1 : tensor<?xf64, #SparseVector>
+  return %0 : index
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_tensor_dim_no_encoding
+//       CHECK: tensor.dim
+func.func @test_tensor_dim_no_encoding(%arg0: tensor<?xf32>) -> index {
+  %c = arith.constant 0 : index
+  %0 = tensor.dim %arg0, %c : tensor<?xf32>
+  return %0 : index
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_tensor_reshape_unranked
+//       CHECK: tensor.reshape
+func.func @test_tensor_reshape_unranked(%src: tensor<*xf32>, %shape: tensor<1xi32>) -> tensor<?xf32> {
+  %dst = tensor.reshape %src(%shape)
+         : (tensor<*xf32>, tensor<1xi32>) -> tensor<?xf32>
+  return %dst : tensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_tensor_reshape_no_encoding
+//       CHECK: tensor.reshape
+func.func @test_tensor_reshape_no_encoding(%src: tensor<?x?xf32>, %shape: tensor<1xi32>) -> tensor<?xf32> {
+  %dst = tensor.reshape %src(%shape)
+         : (tensor<?x?xf32>, tensor<1xi32>) -> tensor<?xf32>
+  return %dst : tensor<?xf32>
+}


### PR DESCRIPTION
This PR relocates the tests added in #109435 to a new file named `no_lowering.mlir` and adds some new tests.