### PR TITLE
[mlir] [irdl] Optional attributes in irdl

### DIFF
--- a/mlir/include/mlir/Dialect/IRDL/IR/IRDLOps.td
+++ b/mlir/include/mlir/Dialect/IRDL/IR/IRDLOps.td
@@ -328,9 +328,10 @@ def IRDL_AttributesOp : IRDL_Op<"attributes", [HasParent<"OperationOp">]> {
   }];
 
   let arguments = (ins Variadic<IRDL_AttributeType>:$attributeValues,
-                        StrArrayAttr:$attributeValueNames);
+                        StrArrayAttr:$attributeValueNames,
+                        VariadicityArrayAttr:$variadicity);
   let assemblyFormat = [{
-    custom<AttributesOp>($attributeValues, $attributeValueNames) attr-dict
+    custom<AttributesOp>($attributeValues, $attributeValueNames, $variadicity) attr-dict
   }];
 
   let hasVerifier = true;

--- a/mlir/lib/Dialect/IRDL/IR/IRDL.cpp
+++ b/mlir/lib/Dialect/IRDL/IR/IRDL.cpp
@@ -198,10 +198,10 @@ LogicalResult AttributesOp::verify() {
   for (size_t i = 0; i < numVariadicities; ++i) {
     if (variadicities[i].getValue() == Variadicity::variadic) {
       // auto test =
-      return emitOpError() << "requires attributes to have single or optional variadicity, but " << getAttributeValueNames()[i]
+      return emitOpError() << "requires attributes to have single or optional "
+                              "variadicity, but "
+                           << getAttributeValueNames()[i]
                            << " was specified as variadic.";
-
-
     }
   }
 

--- a/mlir/test/Dialect/IRDL/attributes-op.irdl.mlir
+++ b/mlir/test/Dialect/IRDL/attributes-op.irdl.mlir
@@ -1,11 +1,12 @@
 // RUN: mlir-opt %s -verify-diagnostics -split-input-file
+
 irdl.dialect @errors {
   irdl.operation @attrs1 {
     %0 = irdl.is i32
     %1 = irdl.is i64
 
-    // expected-error@+1 {{'irdl.attributes' op the number of attribute names and their constraints must be the same but got 1 and 2 respectively}}
-    "irdl.attributes"(%0, %1) <{attributeValueNames = ["attr1"]}> : (!irdl.attribute, !irdl.attribute) -> ()
+    // expected-error@+1 {{'irdl.attributes' op the number of attribute names and their constraints must be the same, but got 1 and 2 respectively}}
+    "irdl.attributes"(%0, %1) <{attributeValueNames = ["attr1"], variadicity = #irdl<variadicity_array[ single, single]>}> : (!irdl.attribute, !irdl.attribute) -> ()
   }
 }
 
@@ -15,8 +16,8 @@ irdl.dialect @errors {
   irdl.operation @attrs2 {
     %0 = irdl.is i32
     %1 = irdl.is i64
-   
-    // expected-error@+1 {{'irdl.attributes' op the number of attribute names and their constraints must be the same but got 2 and 1 respectively}}
-    "irdl.attributes"(%0) <{attributeValueNames = ["attr1", "attr2"]}> : (!irdl.attribute) -> ()
+
+    // expected-error@+1 {{'irdl.attributes' op the number of attribute names and their constraints must be the same, but got 2 and 1 respectively}}
+    "irdl.attributes"(%0) <{attributeValueNames = ["attr1", "attr2"], variadicity = #irdl<variadicity_array[ single]>}> : (!irdl.attribute) -> ()
   }
 }

--- a/mlir/test/Dialect/IRDL/variadics-error.irdl.mlir
+++ b/mlir/test/Dialect/IRDL/variadics-error.irdl.mlir
@@ -14,7 +14,7 @@ irdl.dialect @errors {
 irdl.dialect @errors {
   irdl.operation @operands2 {
     %0 = irdl.is i32
-   
+
     // expected-error@+1 {{'irdl.operands' op the number of operands and their variadicities must be the same, but got 1 and 2 respectively}}
     "irdl.operands"(%0) <{names = ["foo"], variadicity = #irdl<variadicity_array[single, single]>}> : (!irdl.attribute) -> ()
   }
@@ -36,8 +36,56 @@ irdl.dialect @errors {
 irdl.dialect @errors {
   irdl.operation @results2 {
     %0 = irdl.is i32
-   
+
     // expected-error@+1 {{'irdl.results' op the number of results and their variadicities must be the same, but got 1 and 2 respectively}}
     "irdl.results"(%0) <{names = ["foo"], variadicity = #irdl<variadicity_array[single, single]>}> : (!irdl.attribute) -> ()
   }
 }
+
+// -----
+
+irdl.dialect @errors {
+  irdl.operation @no_var {
+    %0 = irdl.is i32
+    %1 = irdl.is i64
+
+    // expected-error@+1 {{'irdl.attributes' op requires attribute 'variadicity'}}
+    "irdl.attributes"(%0) <{attributeValueNames = ["attr1"]}> : (!irdl.attribute) -> ()
+  }
+}
+
+// -----
+
+irdl.dialect @errors {
+  irdl.operation @attrs1 {
+    %0 = irdl.is i32
+    %1 = irdl.is i64
+
+    // expected-error@+1 {{'irdl.attributes' op the number of attributes and their variadicities must be the same, but got 2 and 1 respectively}}
+    "irdl.attributes"(%0, %1) <{attributeValueNames = ["attr1", "attr2"], variadicity = #irdl<variadicity_array[ single]>}> : (!irdl.attribute, !irdl.attribute) -> ()
+  }
+}
+
+// -----
+
+irdl.dialect @errors {
+  irdl.operation @attrs2 {
+    %0 = irdl.is i32
+    %1 = irdl.is i64
+
+    // expected-error@+1 {{'irdl.attributes' op the number of attributes and their variadicities must be the same, but got 1 and 2 respectively}}
+    "irdl.attributes"(%0) <{attributeValueNames = ["attr1"], variadicity = #irdl<variadicity_array[ single, single]>}> : (!irdl.attribute) -> ()
+  }
+}
+
+// -----
+
+irdl.dialect @errors {
+  irdl.operation @attrs_variadic {
+    %0 = irdl.is i32
+
+    // expected-error@+1 {{'irdl.attributes' op requires attributes to have single or optional variadicity, but "attr1" was specified as variadic}}
+    "irdl.attributes"(%0) <{attributeValueNames = ["attr1"], variadicity = #irdl<variadicity_array[ variadic]>}> : (!irdl.attribute) -> ()
+  }
+}
+

--- a/mlir/test/Dialect/IRDL/variadics.irdl.mlir
+++ b/mlir/test/Dialect/IRDL/variadics.irdl.mlir
@@ -13,9 +13,9 @@ irdl.dialect @testvar {
   }
 
   // CHECK-LABEL: irdl.operation @var_operand {
-  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16 
-  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32 
-  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64 
+  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16
+  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32
+  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64
   // CHECK-NEXT:    irdl.operands(foo: %[[v0]], bar: variadic %[[v1]], baz: %[[v2]])
   // CHECK-NEXT:  }
   irdl.operation @var_operand {
@@ -26,9 +26,9 @@ irdl.dialect @testvar {
   }
 
   // CHECK-LABEL: irdl.operation @opt_operand {
-  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16 
-  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32 
-  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64 
+  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16
+  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32
+  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64
   // CHECK-NEXT:    irdl.operands(foo: %[[v0]], bar: optional %[[v1]], baz: %[[v2]])
   // CHECK-NEXT:  }
   irdl.operation @opt_operand {
@@ -39,9 +39,9 @@ irdl.dialect @testvar {
   }
 
   // CHECK-LABEL: irdl.operation @var_and_opt_operand {
-  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16 
-  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32 
-  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64 
+  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16
+  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32
+  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64
   // CHECK-NEXT:    irdl.operands(foo: variadic %[[v0]], bar: optional %[[v1]], baz: %[[v2]])
   // CHECK-NEXT:  }
   irdl.operation @var_and_opt_operand {
@@ -62,9 +62,9 @@ irdl.dialect @testvar {
   }
 
   // CHECK-LABEL: irdl.operation @var_result {
-  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16 
-  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32 
-  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64 
+  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16
+  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32
+  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64
   // CHECK-NEXT:    irdl.results(foo: %[[v0]], bar: variadic %[[v1]], baz: %[[v2]])
   // CHECK-NEXT:  }
   irdl.operation @var_result {
@@ -75,9 +75,9 @@ irdl.dialect @testvar {
   }
 
   // CHECK-LABEL: irdl.operation @opt_result {
-  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16 
-  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32 
-  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64 
+  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16
+  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32
+  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64
   // CHECK-NEXT:    irdl.results(foo: %[[v0]], bar: optional %[[v1]], baz: %[[v2]])
   // CHECK-NEXT:  }
   irdl.operation @opt_result {
@@ -88,9 +88,9 @@ irdl.dialect @testvar {
   }
 
   // CHECK-LABEL: irdl.operation @var_and_opt_result {
-  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16 
-  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32 
-  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64 
+  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16
+  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32
+  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64
   // CHECK-NEXT:    irdl.results(foo: variadic %[[v0]], bar: optional %[[v1]], baz: %[[v2]])
   // CHECK-NEXT:  }
   irdl.operation @var_and_opt_result {
@@ -98,5 +98,22 @@ irdl.dialect @testvar {
     %1 = irdl.is i32
     %2 = irdl.is i64
     irdl.results(foo: variadic %0, bar: optional %1, baz: %2)
+  }
+
+  // CHECK-LABEL: irdl.operation @var_attr {
+  // CHECK-NEXT:    %[[v0:[^ ]*]] = irdl.is i16
+  // CHECK-NEXT:    %[[v1:[^ ]*]] = irdl.is i32
+  // CHECK-NEXT:    %[[v2:[^ ]*]] = irdl.is i64
+  // CHECK-NEXT:    irdl.attributes {"optional" = optional %[[v0]], "single" = %[[v1]], "single_no_word" = %[[v2]]}
+  // CHECK-NEXT:  }
+  irdl.operation @var_attr {
+    %0 = irdl.is i16
+    %1 = irdl.is i32
+    %2 = irdl.is i64
+    irdl.attributes {
+      "optional" = optional %0,
+      "single" = single %1,
+      "single_no_word" = %2
+    }
   }
 }

--- a/mlir/tools/tblgen-to-irdl/OpDefinitionsGen.cpp
+++ b/mlir/tools/tblgen-to-irdl/OpDefinitionsGen.cpp
@@ -454,11 +454,18 @@ irdl::OperationOp createIRDLOperation(OpBuilder &builder,
 
   SmallVector<Value> attributes;
   SmallVector<Attribute> attrNames;
+  SmallVector<irdl::VariadicityAttr> attrVariadicity;
   for (auto namedAttr : tblgenOp.getAttributes()) {
+    irdl::VariadicityAttr var;
     if (namedAttr.attr.isOptional())
-      continue;
+      var = consBuilder.getAttr<irdl::VariadicityAttr>(
+          irdl::Variadicity::optional);
+    else
+      var =
+          consBuilder.getAttr<irdl::VariadicityAttr>(irdl::Variadicity::single);
     attributes.push_back(createAttrConstraint(consBuilder, namedAttr.attr));
     attrNames.push_back(StringAttr::get(ctx, namedAttr.name));
+    attrVariadicity.push_back(var);
   }
 
   SmallVector<Value> regions;
@@ -479,8 +486,9 @@ irdl::OperationOp createIRDLOperation(OpBuilder &builder,
                                         ArrayAttr::get(ctx, resultNames),
                                         resultVariadicity);
   if (!attributes.empty())
-    consBuilder.create<irdl::AttributesOp>(UnknownLoc::get(ctx), attributes,
-                                           ArrayAttr::get(ctx, attrNames));
+    consBuilder.create<irdl::AttributesOp>(
+        UnknownLoc::get(ctx), attributes, ArrayAttr::get(ctx, attrNames),
+        irdl::VariadicityArrayAttr::get(ctx, attrVariadicity));
   if (!regions.empty())
     consBuilder.create<irdl::RegionsOp>(UnknownLoc::get(ctx), regions,
                                         ArrayAttr::get(ctx, regionNames));


### PR DESCRIPTION
Adds a variadicity array property to `irdl.attributes`, allowing optional attributes(/properties) to be defined. Also updates the tblgen-to-irdl script to support this.

@math-fehr 