### PR TITLE
[llvm-dis] Fix non-deterministic disassembly across multiple inputs

### DIFF
--- a/llvm/test/tools/llvm-dis/multiple-files-equivalent.ll
+++ b/llvm/test/tools/llvm-dis/multiple-files-equivalent.ll
@@ -1,0 +1,15 @@
+; RUN: llvm-as -o %t0 %s
+; RUN: cp %t0 %t1
+; RUN: llvm-dis %t0 %t1
+; RUN: FileCheck %s < %t0.ll
+; RUN: FileCheck %s < %t1.ll
+
+; Test that if we disassemble the same bitcode twice, the type names are
+; unchanged between the two. This protects against a bug whereby state was
+; preserved across inputs and the types ended up with different names.
+
+; CHECK: %Foo = type { ptr }
+%Foo = type { ptr }
+
+; CHECK: @foo = global %Foo zeroinitializer
+@foo = global %Foo zeroinitializer


### PR DESCRIPTION
Prior to this patch, the LLVMContext was shared across inputs to llvm-dis.

Consequently, NamedStructTypes was shared across inputs, which impacts StructType::setName - if a name was reused across inputs, it would get renamed during construction of the struct type, leading to tricky to diagnose confusion.