### PR TITLE
[LIT] Add support for `%basename_s` to get base name of source file

### DIFF
--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -535,6 +535,7 @@ TestRunner.py:
  %{fs-tmp-root}          root component of file system paths pointing to the test's temporary directory
  %{fs-sep}               file system path separator
  %t                      temporary file name unique to the test
+ %basename_s             The last path component of %s
  %basename_t             The last path component of %t but without the ``.tmp`` extension
  %T                      parent directory of %t (not unique, deprecated, do not use)
  %%                      %

--- a/llvm/test/TableGen/anonymous-location.td
+++ b/llvm/test/TableGen/anonymous-location.td
@@ -1,4 +1,4 @@
-// RUN: llvm-tblgen --print-detailed-records %s | FileCheck %s -DFILE=anonymous-location.td
+// RUN: llvm-tblgen --print-detailed-records %s | FileCheck %s -DFILE=%basename_s
 
 class A<int a> {
   int Num = a;

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1394,10 +1394,12 @@ def getDefaultSubstitutions(test, tmpDir, tmpBase, normalize_slashes=False):
     substitutions = []
     substitutions.extend(test.config.substitutions)
     tmpName = tmpBase + ".tmp"
-    baseName = os.path.basename(tmpBase)
+    tmpBaseName = os.path.basename(tmpBase)
+    sourceBaseName = os.path.basename(sourcepath)
 
     substitutions.append(("%{pathsep}", os.pathsep))
-    substitutions.append(("%basename_t", baseName))
+    substitutions.append(("%basename_t", tmpBaseName))
+    substitutions.append(("%basename_s", sourceBaseName))
 
     substitutions.extend(
         [

--- a/llvm/utils/lit/tests/substitutions.py
+++ b/llvm/utils/lit/tests/substitutions.py
@@ -1,0 +1,5 @@
+# Basic test for substitutions.
+#
+# RUN: echo %basename_s  | FileCheck %s
+#
+# CHECK: substitutions.py


### PR DESCRIPTION
Add support for `%basename_s` pattern in the RUN commands to get the base name of the source file, and adopt it in a TableGen LIT test.