### PR TITLE
[SandboxIR][NFC] Move intrinsic code to Utils::isMemIntrinsic()

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -61,6 +61,7 @@ public:
   virtual ~DGNode() = default;
   /// \Returns true if this is before \p Other in program order.
   bool comesBefore(const DGNode *Other) { return I->comesBefore(Other->I); }
+
   /// \Returns true if \p I is a memory dependency candidate instruction.
   static bool isMemDepCandidate(Instruction *I) {
     AllocaInst *Alloca;


### PR DESCRIPTION
This patch moves the intrinsic specific code from Utils::isMemDepCandidate() to a new function: Utils::isMemIntrinsic().