### PR TITLE
[libc] Small recvfrom fixes (yaml, unpoison)

### DIFF
--- a/libc/newhdrgen/yaml/sys/socket.yaml
+++ b/libc/newhdrgen/yaml/sys/socket.yaml
@@ -49,7 +49,7 @@ functions:
     return_type: ssize_t
     arguments:
       - type: int
-      - type: const void *
+      - type: void *
       - type: size_t
       - type: int
   - name: recvfrom
@@ -58,10 +58,10 @@ functions:
     return_type: ssize_t
     arguments:
       - type: int
-      - type: const void*
+      - type: void *
       - type: size_t
       - type: int
-      - type: const struct sockaddr *
+      - type: struct sockaddr *
       - type: socklen_t *
   - name: recvmsg
     standards:
@@ -69,7 +69,7 @@ functions:
     return_type: ssize_t
     arguments:
       - type: int
-      - type: const struct msghdr *
+      - type: struct msghdr *
       - type: int
   - name: send
     standards:

--- a/libc/newhdrgen/yaml/sys/socket.yaml
+++ b/libc/newhdrgen/yaml/sys/socket.yaml
@@ -61,8 +61,8 @@ functions:
       - type: void *
       - type: size_t
       - type: int
-      - type: struct sockaddr *
-      - type: socklen_t *
+      - type: struct sockaddr *__restrict
+      - type: socklen_t *__restrict
   - name: recvmsg
     standards:
       - POSIX

--- a/libc/newhdrgen/yaml/sys/socket.yaml
+++ b/libc/newhdrgen/yaml/sys/socket.yaml
@@ -62,7 +62,7 @@ functions:
       - type: size_t
       - type: int
       - type: const struct sockaddr *
-      - type: socklen_t
+      - type: socklen_t *
   - name: recvmsg
     standards:
       - POSIX

--- a/libc/src/sys/socket/linux/recv.cpp
+++ b/libc/src/sys/socket/linux/recv.cpp
@@ -22,7 +22,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(ssize_t, recv,
-                   (int sockfd, const void *buf, size_t len, int flags)) {
+                   (int sockfd, void *buf, size_t len, int flags)) {
 #ifdef SYS_recv
   ssize_t ret =
       LIBC_NAMESPACE::syscall_impl<ssize_t>(SYS_recv, sockfd, buf, len, flags);

--- a/libc/src/sys/socket/linux/recvfrom.cpp
+++ b/libc/src/sys/socket/linux/recvfrom.cpp
@@ -23,7 +23,8 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(ssize_t, recvfrom,
                    (int sockfd, void *buf, size_t len, int flags,
-                    struct sockaddr *dest_addr, socklen_t *addrlen)) {
+                    struct sockaddr *__restrict dest_addr,
+                    socklen_t *__restrict addrlen)) {
 #ifdef SYS_recvfrom
   ssize_t ret = LIBC_NAMESPACE::syscall_impl<ssize_t>(
       SYS_recvfrom, sockfd, buf, len, flags, dest_addr, addrlen);

--- a/libc/src/sys/socket/linux/recvfrom.cpp
+++ b/libc/src/sys/socket/linux/recvfrom.cpp
@@ -22,8 +22,8 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(ssize_t, recvfrom,
-                   (int sockfd, const void *buf, size_t len, int flags,
-                    const struct sockaddr *dest_addr, socklen_t *addrlen)) {
+                   (int sockfd, void *buf, size_t len, int flags,
+                    struct sockaddr *dest_addr, socklen_t *addrlen)) {
 #ifdef SYS_recvfrom
   ssize_t ret = LIBC_NAMESPACE::syscall_impl<ssize_t>(
       SYS_recvfrom, sockfd, buf, len, flags, dest_addr, addrlen);

--- a/libc/src/sys/socket/linux/recvfrom.cpp
+++ b/libc/src/sys/socket/linux/recvfrom.cpp
@@ -45,6 +45,7 @@ LLVM_LIBC_FUNCTION(ssize_t, recvfrom,
   }
 
   MSAN_UNPOISON(buf, ret);
+  MSAN_UNPOISON(addrlen, sizeof(socklen_t));
 
   return ret;
 }

--- a/libc/src/sys/socket/linux/recvmsg.cpp
+++ b/libc/src/sys/socket/linux/recvmsg.cpp
@@ -21,7 +21,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(ssize_t, recvmsg,
-                   (int sockfd, const struct msghdr *msg, int flags)) {
+                   (int sockfd, struct msghdr *msg, int flags)) {
 #ifdef SYS_recvmsg
   ssize_t ret =
       LIBC_NAMESPACE::syscall_impl<ssize_t>(SYS_recvmsg, sockfd, msg, flags);

--- a/libc/src/sys/socket/recv.h
+++ b/libc/src/sys/socket/recv.h
@@ -14,7 +14,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-ssize_t recv(int sockfd, const void *buf, size_t len, int flags);
+ssize_t recv(int sockfd, void *buf, size_t len, int flags);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/sys/socket/recvfrom.h
+++ b/libc/src/sys/socket/recvfrom.h
@@ -17,8 +17,8 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-ssize_t recvfrom(int sockfd, const void *buf, size_t len, int flags,
-                 const struct sockaddr *address, socklen_t *addrlen);
+ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
+                 struct sockaddr *address, socklen_t *addrlen);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/sys/socket/recvfrom.h
+++ b/libc/src/sys/socket/recvfrom.h
@@ -18,7 +18,8 @@
 namespace LIBC_NAMESPACE_DECL {
 
 ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
-                 struct sockaddr *address, socklen_t *addrlen);
+                 struct sockaddr *__restrict address,
+                 socklen_t *__restrict addrlen);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/sys/socket/recvmsg.h
+++ b/libc/src/sys/socket/recvmsg.h
@@ -15,7 +15,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-ssize_t recvmsg(int sockfd, const struct msghdr *msg, int flags);
+ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags);
 
 } // namespace LIBC_NAMESPACE_DECL
 


### PR DESCRIPTION
Forgot to update the newhdrgen yaml (old headergen is fine) and forgot
to unpoison addrlen. This patch fixes those.
