### PR TITLE
[rtsan] Add test to ensure coroutines get caught

### DIFF
--- a/compiler-rt/test/rtsan/coroutine.cpp
+++ b/compiler-rt/test/rtsan/coroutine.cpp
@@ -1,0 +1,31 @@
+// RUN: %clangxx -std=c++20 -fsanitize=realtime %s -o %t
+// RUN: not %run %t 2>&1 | FileCheck %s
+// UNSUPPORTED: ios
+
+// Intent: Coroutines allocate memory and are not allowed in a [[clang::nonblocking]] function.
+
+#include <coroutine>
+
+struct SimpleCoroutine {
+  struct promise_type {
+    SimpleCoroutine get_return_object() { return SimpleCoroutine{}; }
+    std::suspend_never initial_suspend() { return {}; }
+    std::suspend_never final_suspend() noexcept { return {}; }
+    void unhandled_exception() {}
+    void return_void() {}
+  };
+};
+
+SimpleCoroutine example_coroutine() { co_return; }
+
+void calls_a_coroutine() [[clang::nonblocking]] { example_coroutine(); }
+
+int main() {
+  calls_a_coroutine();
+  return 0;
+}
+
+// CHECK: ==ERROR: RealtimeSanitizer
+
+// Somewhere in the stack this should be mentioned
+// CHECK: calls_a_coroutine


### PR DESCRIPTION
Coroutines allocate when they are called:

https://en.cppreference.com/w/cpp/language/coroutines

> When a coroutine begins execution, it performs the following:

> [allocates](https://en.cppreference.com/w/cpp/language/coroutines#Dynamic_allocation) the coroutine state object using [operator new](https://en.cppreference.com/w/cpp/memory/new/operator_new).

Just adding this test as a sanity check that we catch this allocation, and it passes on my machines