### PR TITLE
[clang][rtsan] Add sanitize_realtime_unsafe attr to [[clang::blocking]] function IR

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -850,6 +850,8 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
       for (const FunctionEffectWithCondition &Fe : FD->getFunctionEffects()) {
         if (Fe.Effect.kind() == FunctionEffect::Kind::NonBlocking)
           Fn->addFnAttr(llvm::Attribute::SanitizeRealtime);
+        else if (Fe.Effect.kind() == FunctionEffect::Kind::Blocking)
+          Fn->addFnAttr(llvm::Attribute::SanitizeRealtimeUnsafe);
       }
 
   // Apply fuzzing attribute to the function.

--- a/clang/test/CodeGen/rtsan_attribute_inserted.c
+++ b/clang/test/CodeGen/rtsan_attribute_inserted.c
@@ -1,7 +1,11 @@
 // RUN: %clang_cc1  -triple x86_64-unknown-linux -fsanitize=realtime %s -emit-llvm -o - %s | FileCheck %s
 
 float process(float *a) [[clang::nonblocking]] { return *a; }
-
-// CHECK-LABEL: @process{{.*}}#0 {
+// CHECK: @process{{.*}} #0 {
 // CHECK: attributes #0 = {
-// CHECK-SAME: {{.*sanitize_realtime.*}}
+// CHECK-SAME: {{.*sanitize_realtime .*}}
+
+int spinlock(int *a) [[clang::blocking]] { return *a; }
+// CHECK: @spinlock{{.*}} #1 {
+// CHECK: attributes #1 = {
+// CHECK-SAME: {{.*sanitize_realtime_unsafe .*}}

--- a/clang/test/CodeGen/rtsan_no_attribute_sanitizer_disabled.c
+++ b/clang/test/CodeGen/rtsan_no_attribute_sanitizer_disabled.c
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 -triple aarch64-unknown-linux-gnu -emit-llvm -o - %s | FileCheck %s
 
 float process(float *a) [[clang::nonblocking]] { return *a; }
+int spinlock(int *a) [[clang::blocking]] { return *a; }
 
-// Without the -fsanitize=realtime flag, we shouldn't attach the attribute.
-// CHECK-NOT: {{.*sanitize_realtime.*}}
+// Without the -fsanitize=realtime flag, we shouldn't attach the attributes.
+// CHECK-NOT: {{.*sanitize_realtime .*}}
+// CHECK-NOT: {{.*sanitize_realtime_unsafe .*}}


### PR DESCRIPTION
# Clang CodeGen for [[clang::blocking]] with RTSan

Follows https://github.com/llvm/llvm-project/pull/106754 and https://github.com/llvm/llvm-project/pull/109543. This is the final patch for the feature. 

## Motivation

Calls to system library functions such as malloc are easy for RealtimeSanitizer to intercept. If such a call is made in a [[clang::nonblocking]] function (a real-time context), RealtimeSanitizer will error. Real-time programmers also write their own blocking (real-time unsafe) functions that may or may not call intercepted functions. We wish to introduce a mechanism whereby RealtimeSanitizer can error on calls to these, too, if called within a real-time context.

At the same time as introducing [[clang::nonblocking]], the [[clang::blocking]] attribute was also introduced. With the function effects warnings (as errors) activated, blocking functions cannot be called from non-blocking functions, and this is enforced at compile time. The purpose of this series of PRs is to introduce similar functionality into RealtimeSanitizer, so that it can make the equivalent check at run time.

## Implementation

We recently merged the `sanitize_realtime_unsafe` LLVM function attribute into `main`, as well as the LLVM pass to notify the sanitizer runtime of the blocking call. Our final step is to switch on the feature by updating Clang's CodeGen. This patch just adds the `sanitize_realtime_unsafe` attribute to the IR for functions attributed with `[[clang::blocking]]`.

Once the feature is switched on, RealtimeSanitizer will error if any calls to functions attributed with `[[clang::blocking]]` are made from `[[clang::nonblocking]]` functions.

## Integration Roadmap

The above functionality is currently split into three patches.

- [x] https://github.com/llvm/llvm-project/pull/106754,
- [x] https://github.com/llvm/llvm-project/pull/109543, and
- [ ] An update to Clang's CodeGen to add the `sanitize_realtime_unsafe` attribute to functions attributed with `[[clang::blocking]]` (this PR)
