### PR TITLE
[scudo] Fix isOwned on MTE devices.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -785,6 +785,9 @@ public:
   // A corrupted chunk will not be reported as owned, which is WAI.
   bool isOwned(const void *Ptr) {
     initThreadMaybe();
+    // If the allocation is not owned, the tags could be wrong.
+    ScopedDisableMemoryTagChecks x(
+        useMemoryTagging<AllocatorConfig>(Primary.Options.load()));
 #ifdef GWP_ASAN_HOOKS
     if (GuardedAlloc.pointerIsMine(Ptr))
       return true;

--- a/compiler-rt/lib/scudo/standalone/memtag.h
+++ b/compiler-rt/lib/scudo/standalone/memtag.h
@@ -122,9 +122,12 @@ inline NORETURN void enableSystemMemoryTaggingTestOnly() {
 
 class ScopedDisableMemoryTagChecks {
   uptr PrevTCO;
+  bool active;
 
 public:
-  ScopedDisableMemoryTagChecks() {
+  ScopedDisableMemoryTagChecks(bool cond = true) : active(cond) {
+    if (!active)
+      return;
     __asm__ __volatile__(
         R"(
         .arch_extension memtag
@@ -135,6 +138,8 @@ public:
   }
 
   ~ScopedDisableMemoryTagChecks() {
+    if (!active)
+      return;
     __asm__ __volatile__(
         R"(
         .arch_extension memtag
@@ -269,7 +274,7 @@ inline NORETURN void enableSystemMemoryTaggingTestOnly() {
 }
 
 struct ScopedDisableMemoryTagChecks {
-  ScopedDisableMemoryTagChecks() {}
+  ScopedDisableMemoryTagChecks(UNUSED bool cond = true) {}
 };
 
 inline NORETURN uptr selectRandomTag(uptr Ptr, uptr ExcludeMask) {


### PR DESCRIPTION
If called on address that is actually not owned, the tags could not match. Disable tag checks in isOwned().