### PR TITLE
[LIT] Rename substitution `%basename_s` to `%{s:basename}`

### DIFF
--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -535,8 +535,7 @@ TestRunner.py:
  %{fs-tmp-root}          root component of file system paths pointing to the test's temporary directory
  %{fs-sep}               file system path separator
  %t                      temporary file name unique to the test
- %basename_s             The last path component of %s
- %basename_t             The last path component of %t but without the ``.tmp`` extension
+ %basename_t             The last path component of %t but without the ``.tmp`` extension (deprecated, use ``%{t:stem}`` instead)
  %T                      parent directory of %t (not unique, deprecated, do not use)
  %%                      %
  %/s                     %s but ``\`` is replaced by ``/``
@@ -544,6 +543,8 @@ TestRunner.py:
  %/p                     %p but ``\`` is replaced by ``/``
  %/t                     %t but ``\`` is replaced by ``/``
  %/T                     %T but ``\`` is replaced by ``/``
+ %{s:basename}           The last path component of %s
+ %{t:stem}               The last path component of %t but without the ``.tmp`` extension (alias for %basename_t)
  %{s:real}               %s after expanding all symbolic links and substitute drives
  %{S:real}               %S after expanding all symbolic links and substitute drives
  %{p:real}               %p after expanding all symbolic links and substitute drives

--- a/llvm/test/TableGen/anonymous-location.td
+++ b/llvm/test/TableGen/anonymous-location.td
@@ -1,4 +1,4 @@
-// RUN: llvm-tblgen --print-detailed-records %s | FileCheck %s -DFILE=%basename_s
+// RUN: llvm-tblgen --print-detailed-records %s | FileCheck %s -DFILE=%{s:basename}
 
 class A<int a> {
   int Num = a;

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1399,7 +1399,9 @@ def getDefaultSubstitutions(test, tmpDir, tmpBase, normalize_slashes=False):
 
     substitutions.append(("%{pathsep}", os.pathsep))
     substitutions.append(("%basename_t", tmpBaseName))
-    substitutions.append(("%basename_s", sourceBaseName))
+
+    substitutions.append(("%{s:basename}", sourceBaseName))
+    substitutions.append(("%{t:stem}", tmpBaseName))
 
     substitutions.extend(
         [

--- a/llvm/utils/lit/tests/substitutions.py
+++ b/llvm/utils/lit/tests/substitutions.py
@@ -1,5 +1,7 @@
 # Basic test for substitutions.
 #
-# RUN: echo %basename_s  | FileCheck %s
-#
-# CHECK: substitutions.py
+# RUN: echo %{s:basename} | FileCheck %s --check-prefix=BASENAME
+# RUN: echo %{t:stem} %basename_t | FileCheck %s --check-prefix=TMPBASENAME
+
+# BASENAME: substitutions.py
+# TMPBASENAME: [[FIRST:[^[:space:]]+]] [[FIRST]]


### PR DESCRIPTION
Also added `%{t:stem}` as an alias for `%basename_t` and modified unit test to test these new substitutions.