### PR TITLE
[lldb-dap] Disable TestDAP_optimized under ASAN

### DIFF
--- a/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
+++ b/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
@@ -28,6 +28,7 @@ class TestDAP_optimized(lldbdap_testcase.DAPTestCaseBase):
         parent_frame = self.dap_server.get_stackFrame(frameIndex=1)
         self.assertTrue(parent_frame["name"].endswith(" [opt]"))
 
+    @skipIfAsan # On ASAN builds this test intermittently fails https://github.com/llvm/llvm-project/issues/111061
     @skipIfWindows
     def test_optimized_variable(self):
         """Test optimized variable value contains error."""


### PR DESCRIPTION
This test is failing on green dragon and I couldn't figure out why,
disabling it for now under ASAN to get the bot green.

Opened an issue (https://github.com/llvm/llvm-project/issues/111061) to track the problem.