### PR TITLE
[TableGen] Change backend callback to require const RecordKeeper

### DIFF
--- a/llvm/include/llvm/TableGen/TableGenBackend.h
+++ b/llvm/include/llvm/TableGen/TableGenBackend.h
@@ -23,8 +23,7 @@ class RecordKeeper;
 class raw_ostream;
 
 namespace TableGen::Emitter {
-// Supports const and non-const forms of callback functions.
-using FnT = function_ref<void(RecordKeeper &Records, raw_ostream &OS)>;
+using FnT = function_ref<void(const RecordKeeper &Records, raw_ostream &OS)>;
 
 /// Creating an `Opt` object registers the command line option \p Name with
 /// TableGen backend and associates the callback \p CB with that option. If
@@ -37,7 +36,9 @@ struct Opt {
 /// Convienence wrapper around `Opt` that registers `EmitterClass::run` as the
 /// callback.
 template <class EmitterC> class OptClass : Opt {
-  static void run(RecordKeeper &RK, raw_ostream &OS) { EmitterC(RK).run(OS); }
+  static void run(const RecordKeeper &RK, raw_ostream &OS) {
+    EmitterC(RK).run(OS);
+  }
 
 public:
   OptClass(StringRef Name, StringRef Desc) : Opt(Name, run, Desc) {}
@@ -45,7 +46,7 @@ public:
 
 /// Apply callback for any command line option registered above. Returns false
 /// is no callback was applied.
-bool ApplyCallback(RecordKeeper &Records, raw_ostream &OS);
+bool ApplyCallback(const RecordKeeper &Records, raw_ostream &OS);
 
 } // namespace TableGen::Emitter
 

--- a/llvm/lib/TableGen/TableGenBackend.cpp
+++ b/llvm/lib/TableGen/TableGenBackend.cpp
@@ -60,7 +60,7 @@ Opt::Opt(StringRef Name, FnT CB, StringRef Desc, bool ByDefault) {
 
 /// Apply callback specified on the command line. Returns true if no callback
 /// was applied.
-bool llvm::TableGen::Emitter::ApplyCallback(RecordKeeper &Records,
+bool llvm::TableGen::Emitter::ApplyCallback(const RecordKeeper &Records,
                                             raw_ostream &OS) {
   FnT Fn = CallbackFunction->getValue();
   if (!Fn)


### PR DESCRIPTION
Change TableGen backend callback function to require a const RecordKeeper argument (by changing it from function_ref to just a function pointer). This undoes parts of https://github.com/llvm/llvm-project/pull/104716 which was added to enable gradual migration of TableGen backends to use const RecordKeeper (by allowing either const or non-const references). Now that all backends have been migrated to const reference, we do not need this.

This is a part of effort to have better const correctness in TableGen backends:

https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089