### PR TITLE
[clang codegen] Emit !unpredictable metadata more consistently.

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -5338,7 +5338,15 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
       assert(!RHS && "LHS and RHS types must match");
       return nullptr;
     }
-    return Builder.CreateSelect(CondV, LHS, RHS, "cond");
+    llvm::Value *Select = Builder.CreateSelect(CondV, LHS, RHS, "cond");
+    if (auto *SelectI = dyn_cast<llvm::Instruction>(Select)) {
+      if (llvm::MDNode *Unpredictable =
+              CGF.getUnpredictableMetadata(condExpr)) {
+        SelectI->setMetadata(llvm::LLVMContext::MD_unpredictable,
+                             Unpredictable);
+      }
+    }
+    return Select;
   }
 
   // If the top of the logical operator nest, reset the MCDC temp to 0.

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -2257,17 +2257,8 @@ void CodeGenFunction::EmitSwitchStmt(const SwitchStmt &S) {
   EmitBlock(SwitchExit.getBlock(), true);
   incrementProfileCounter(&S);
 
-  // If the switch has a condition wrapped by __builtin_unpredictable,
-  // create metadata that specifies that the switch is unpredictable.
-  // Don't bother if not optimizing because that metadata would not be used.
-  auto *Call = dyn_cast<CallExpr>(S.getCond());
-  if (Call && CGM.getCodeGenOpts().OptimizationLevel != 0) {
-    auto *FD = dyn_cast_or_null<FunctionDecl>(Call->getCalleeDecl());
-    if (FD && FD->getBuiltinID() == Builtin::BI__builtin_unpredictable) {
-      llvm::MDBuilder MDHelper(getLLVMContext());
-      SwitchInsn->setMetadata(llvm::LLVMContext::MD_unpredictable,
-                              MDHelper.createUnpredictable());
-    }
+  if (llvm::MDNode *Unpredictable = getUnpredictableMetadata(S.getCond())) {
+    SwitchInsn->setMetadata(llvm::LLVMContext::MD_unpredictable, Unpredictable);
   }
 
   if (SwitchWeights) {

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1820,6 +1820,21 @@ void CodeGenFunction::EmitBranchToCounterBlock(
   EmitBranch(NextBlock);
 }
 
+llvm::MDNode *CodeGenFunction::getUnpredictableMetadata(const Expr *Cond) {
+  // If the branch has a condition wrapped by __builtin_unpredictable,
+  // create metadata that specifies that the branch is unpredictable.
+  // Don't bother if not optimizing because that metadata would not be used.
+  auto *Call = dyn_cast<CallExpr>(Cond->IgnoreImpCasts());
+  if (Call && CGM.getCodeGenOpts().OptimizationLevel != 0) {
+    auto *FD = dyn_cast_or_null<FunctionDecl>(Call->getCalleeDecl());
+    if (FD && FD->getBuiltinID() == Builtin::BI__builtin_unpredictable) {
+      llvm::MDBuilder MDHelper(getLLVMContext());
+      return MDHelper.createUnpredictable();
+    }
+  }
+  return nullptr;
+}
+
 /// EmitBranchOnBoolExpr - Emit a branch on a boolean condition (e.g. for an if
 /// statement) to the specified blocks.  Based on the condition, this might try
 /// to simplify the codegen of the conditional based on the branch.
@@ -2046,19 +2061,7 @@ void CodeGenFunction::EmitBranchOnBoolExpr(
   }
 
   llvm::MDNode *Weights = nullptr;
-  llvm::MDNode *Unpredictable = nullptr;
-
-  // If the branch has a condition wrapped by __builtin_unpredictable,
-  // create metadata that specifies that the branch is unpredictable.
-  // Don't bother if not optimizing because that metadata would not be used.
-  auto *Call = dyn_cast<CallExpr>(Cond->IgnoreImpCasts());
-  if (Call && CGM.getCodeGenOpts().OptimizationLevel != 0) {
-    auto *FD = dyn_cast_or_null<FunctionDecl>(Call->getCalleeDecl());
-    if (FD && FD->getBuiltinID() == Builtin::BI__builtin_unpredictable) {
-      llvm::MDBuilder MDHelper(getLLVMContext());
-      Unpredictable = MDHelper.createUnpredictable();
-    }
-  }
+  llvm::MDNode *Unpredictable = getUnpredictableMetadata(Cond);
 
   // If there is a Likelihood knowledge for the cond, lower it.
   // Note that if not optimizing this won't emit anything.

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -5044,6 +5044,11 @@ public:
                                 Stmt::Likelihood LH = Stmt::LH_None,
                                 const Expr *CntrIdx = nullptr);
 
+  // getUnpredictableMetadata - If the expression is a call to
+  // __builtin_unpredictable, get the corresponding metadata. Otherwise returns
+  // nullptr.
+  llvm::MDNode *getUnpredictableMetadata(const Expr *Cond);
+
   /// EmitBranchOnBoolExpr - Emit a branch on a boolean condition (e.g. for an
   /// if statement) to the specified blocks.  Based on the condition, this might
   /// try to simplify the codegen of the conditional based on the branch.

--- a/clang/test/CodeGen/builtin-unpredictable.c
+++ b/clang/test/CodeGen/builtin-unpredictable.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -disable-llvm-passes -o - %s -O1 | FileCheck %s 
-// RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -disable-llvm-passes -o - -x c++ %s -O1 | FileCheck %s 
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -disable-llvm-passes -o - %s -O1 | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -disable-llvm-passes -o - -x c++ %s -O1 | FileCheck %s
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -o - %s -O0 | FileCheck %s --check-prefix=CHECK_O0
 
 // When optimizing, the builtin should be converted to metadata.
@@ -18,7 +18,7 @@ void branch(int x) {
 // CHECK: !unpredictable [[METADATA:.+]]
 
 // CHECK_O0-NOT: builtin_unpredictable
-// CHECK_O0-NOT: !unpredictable 
+// CHECK_O0-NOT: !unpredictable
 
   if (__builtin_unpredictable(x > 0))
     foo ();
@@ -31,7 +31,7 @@ int unpredictable_switch(int x) {
 // CHECK: !unpredictable [[METADATA:.+]]
 
 // CHECK_O0-NOT: builtin_unpredictable
-// CHECK_O0-NOT: !unpredictable 
+// CHECK_O0-NOT: !unpredictable
 
   switch(__builtin_unpredictable(x)) {
   default:
@@ -45,6 +45,18 @@ int unpredictable_switch(int x) {
   };
 
   return 0;
+}
+
+int unpredictable_select(int x) {
+// CHECK-LABEL: @unpredictable_select(
+
+// CHECK-NOT: builtin_unpredictable
+// CHECK: !unpredictable [[METADATA:.+]]
+
+// CHECK_O0-NOT: builtin_unpredictable
+// CHECK_O0-NOT: !unpredictable
+
+  return __builtin_unpredictable(x) ? 1 : 33;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Conditional operators that emit a branch go through a codepath which attaches metadata to that branch. But if we take a shortcut to emit a select directly, we end up skipping that code, and don't emit the metadata.

This patch adds code to attach metadata to those select instructions. While I'm here, also refactor the code for computing the metadata a bit.