### PR TITLE
[WebAssembly] Print instructions with type checking errors

### DIFF
--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -1157,8 +1157,8 @@ public:
           Inst.setOpcode(Opc64);
         }
       }
-      if (!SkipTypeCheck && TC.typeCheck(IDLoc, Inst, Operands))
-        return true;
+      if (!SkipTypeCheck)
+        TC.typeCheck(IDLoc, Inst, Operands);
       Out.emitInstruction(Inst, getSTI());
       if (CurrentState == EndFunction) {
         onEndOfFunction(IDLoc);

--- a/llvm/test/MC/WebAssembly/annotations-typecheck.s
+++ b/llvm/test/MC/WebAssembly/annotations-typecheck.s
@@ -1,0 +1,11 @@
+# RUN: not llvm-mc -triple=wasm32-unknown-unknown < %s | FileCheck %s
+
+# This tests annotations are handled correctly even if there is a type checking
+# error (which are unrelated to the block annotations).
+test_annotation:
+  .functype   test_annotation () -> ()
+  block (i32) -> ()
+    drop
+# CHECK-NOT: # End marker mismatch!
+  end_block
+  end_function


### PR DESCRIPTION
When there was a type checking error, we didn't run `InstPrinter`. This can be confusing because when there is an error in, say, block parameter type, `InstPrinter` doesn't run even if it has nothing to do with block parameter types, and all those updates to `ControlFlowStack` or `TryStack` do not happen:
https://github.com/llvm/llvm-project/blob/c20b90ab8557b38efe8e8e993d41d8c08b798267/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyInstPrinter.cpp#L135-L151

For example,
```wast
block (i32) -> () ;; Block input parameter error
end_block         ;; Now this errors out as "End marker mismatch"
```
This is confusing because there is a `block` and the `end_block` is not a mismatch. Only that `block` has a type checking error, but that's not an end marker mismatch.

I think we can just print the instruction whether we had a type checking error or not, and this will be less confusing.