### PR TITLE
[RISCV][ISel] Allow emitting `addiw` with u32simm12 rhs

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1896,6 +1896,7 @@ def : PatGprGpr<shiftopw<riscv_sraw>, SRAW>;
 // Select W instructions if only the lower 32 bits of the result are used.
 def : PatGprGpr<binop_allwusers<add>, ADDW>;
 def : PatGprSimm12<binop_allwusers<add>, ADDIW>;
+def : PatGprImm<binop_allwusers<add>, ADDIW, u32simm12>;
 def : PatGprGpr<binop_allwusers<sub>, SUBW>;
 def : PatGprImm<binop_allwusers<shl>, SLLIW, uimm5>;
 

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -3231,8 +3231,7 @@ define i64 @add_u32simm32_zextw(i64 %x) nounwind {
 ;
 ; RV64ZBA-LABEL: add_u32simm32_zextw:
 ; RV64ZBA:       # %bb.0: # %entry
-; RV64ZBA-NEXT:    li a1, -2
-; RV64ZBA-NEXT:    add a0, a0, a1
+; RV64ZBA-NEXT:    addi a0, a0, -2
 ; RV64ZBA-NEXT:    zext.w a0, a0
 ; RV64ZBA-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -3217,3 +3217,26 @@ entry:
   %z = and i64 %y, -8192
   ret i64 %z
 }
+
+define i64 @add_u32simm32_zextw(i64 %x) nounwind {
+; RV64I-LABEL: add_u32simm32_zextw:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:    li a1, 1
+; RV64I-NEXT:    slli a1, a1, 32
+; RV64I-NEXT:    addi a1, a1, -2
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    addi a1, a1, 1
+; RV64I-NEXT:    and a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: add_u32simm32_zextw:
+; RV64ZBA:       # %bb.0: # %entry
+; RV64ZBA-NEXT:    li a1, -2
+; RV64ZBA-NEXT:    add a0, a0, a1
+; RV64ZBA-NEXT:    zext.w a0, a0
+; RV64ZBA-NEXT:    ret
+entry:
+  %add = add i64 %x, 4294967294
+  %and = and i64 %add, 4294967295
+  ret i64 %and
+}


### PR DESCRIPTION
In InstCombine, we shrink the constant by setting unused bits to zero (e.g. `((X + -2) & 4294967295) -> ((X + 4294967294) & 4294967295)`). However, this canonicalization blocks emitting `addiw` and creates redundant li for simm32 rhs:
```
; bin/llc -mtriple=riscv64 -mattr=+zba test.ll -o -
define i64 @add_u32simm32_zextw(i64 %x) nounwind {
entry:
  %add = add i64 %x, 4294967294
  %and = and i64 %add, 4294967295
  ret i64 %and
}
```
```
add_u32simm32_zextw:                    # @add_u32simm32_zextw
# %bb.0:                                # %entry
        li      a1, -2
        add     a0, a0, a1
        zext.w  a0, a0
        ret
```

This patch addresses the issue by matching u32simm12 rhs.
