### PR TITLE
[lldb][test] Add libcxx-simulators test for std::optional

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+override CXXFLAGS_EXTRAS += -std=c++14
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
@@ -19,21 +19,33 @@ class LibcxxOptionalDataFormatterSimulatorTestCase(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, "Break here", lldb.SBFileSpec("main.cpp")
         )
-        self.expect_var_path("maybe_int", summary=' Has Value=true ',
-                             children=[ValueCheck(name="Value", summary=None, value="42")])
-        self.expect_var_path("maybe_string", summary=' Has Value=true ',
-                             children=[ValueCheck(name="Value", summary='"Hello"')])
+        self.expect_var_path(
+            "maybe_int",
+            summary=" Has Value=true ",
+            children=[ValueCheck(name="Value", summary=None, value="42")],
+        )
+        self.expect_var_path(
+            "maybe_string",
+            summary=" Has Value=true ",
+            children=[ValueCheck(name="Value", summary='"Hello"')],
+        )
 
-        self.expect_expr("maybe_int", result_summary=' Has Value=true ',
-                         result_children=[ValueCheck(name="Value", summary=None, value="42")])
+        self.expect_expr(
+            "maybe_int",
+            result_summary=" Has Value=true ",
+            result_children=[ValueCheck(name="Value", summary=None, value="42")],
+        )
 
-        self.expect_expr("maybe_string", result_summary=' Has Value=true ',
-                         result_children=[ValueCheck(name="Value", summary='"Hello"')])
+        self.expect_expr(
+            "maybe_string",
+            result_summary=" Has Value=true ",
+            result_children=[ValueCheck(name="Value", summary='"Hello"')],
+        )
 
 
 for r in range(2):
-    name = f'test_r{r}'
-    defines = [f'REVISION={r}']
+    name = f"test_r{r}"
+    defines = [f"REVISION={r}"]
     f = functools.partialmethod(
         LibcxxOptionalDataFormatterSimulatorTestCase._run_test, defines
     )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
@@ -1,0 +1,40 @@
+"""
+Test we can understand various layouts of the libc++'s std::optional
+"""
+
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+import functools
+
+
+class LibcxxOptionalDataFormatterSimulatorTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def _run_test(self, defines):
+        cxxflags_extras = " ".join(["-D%s" % d for d in defines])
+        self.build(dictionary=dict(CXXFLAGS_EXTRAS=cxxflags_extras))
+        lldbutil.run_to_source_breakpoint(
+            self, "Break here", lldb.SBFileSpec("main.cpp")
+        )
+        self.expect_var_path("maybe_int", summary=' Has Value=true ',
+                             children=[ValueCheck(name="Value", summary=None, value="42")])
+        self.expect_var_path("maybe_string", summary=' Has Value=true ',
+                             children=[ValueCheck(name="Value", summary='"Hello"')])
+
+        self.expect_expr("maybe_int", result_summary=' Has Value=true ',
+                         result_children=[ValueCheck(name="Value", summary=None, value="42")])
+
+        self.expect_expr("maybe_string", result_summary=' Has Value=true ',
+                         result_children=[ValueCheck(name="Value", summary='"Hello"')])
+
+
+for r in range(2):
+    name = f'test_r{r}'
+    defines = [f'REVISION={r}']
+    f = functools.partialmethod(
+        LibcxxOptionalDataFormatterSimulatorTestCase._run_test, defines
+    )
+    setattr(LibcxxOptionalDataFormatterSimulatorTestCase, name, f)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/main.cpp
@@ -1,4 +1,5 @@
 #include <type_traits>
+#include <utility>
 
 #if REVISION == 0
 // Pre-a3942b3 layout.

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/main.cpp
@@ -1,0 +1,103 @@
+#include <type_traits>
+
+#if REVISION == 0
+// Pre-a3942b3 layout.
+#define HAS_REMOVE_CV
+#endif
+// REVISION == 1: current layout
+
+namespace std {
+namespace __lldb {
+
+struct in_place_t {
+  explicit in_place_t() = default;
+};
+constexpr in_place_t in_place{};
+
+template <class _Tp, bool = is_trivially_destructible<_Tp>::value>
+struct __optional_destruct_base {
+  typedef _Tp value_type;
+  union {
+    char __null_state_;
+#ifdef HAS_REMOVE_CV
+    remove_cv_t<value_type> __val_;
+#else // !HAS_REMOVE_CV
+    value_type __val_;
+#endif
+  };
+  bool __engaged_;
+
+  template <class... _Args>
+  constexpr explicit __optional_destruct_base(in_place_t, _Args &&...__args)
+      : __val_(std::forward<_Args>(__args)...), __engaged_(true) {}
+};
+
+template <class _Tp, bool = is_reference<_Tp>::value>
+struct __optional_storage_base : __optional_destruct_base<_Tp> {
+  using __base = __optional_destruct_base<_Tp>;
+  using value_type = _Tp;
+  using __base::__base;
+};
+
+template <class _Tp, bool = is_trivially_copy_constructible<_Tp>::value>
+struct __optional_copy_base : __optional_storage_base<_Tp> {
+  using __optional_storage_base<_Tp>::__optional_storage_base;
+};
+
+template <class _Tp, bool = is_trivially_move_constructible<_Tp>::value>
+struct __optional_move_base : __optional_copy_base<_Tp> {
+  using __optional_copy_base<_Tp>::__optional_copy_base;
+};
+
+template <class _Tp, bool = is_trivially_destructible<_Tp>::value &&
+                            is_trivially_copy_constructible<_Tp>::value &&
+                            is_trivially_copy_assignable<_Tp>::value>
+struct __optional_copy_assign_base : __optional_move_base<_Tp> {
+  using __optional_move_base<_Tp>::__optional_move_base;
+};
+
+template <class _Tp, bool = is_trivially_destructible<_Tp>::value &&
+                            is_trivially_move_constructible<_Tp>::value &&
+                            is_trivially_move_assignable<_Tp>::value>
+struct __optional_move_assign_base : __optional_copy_assign_base<_Tp> {
+  using __optional_copy_assign_base<_Tp>::__optional_copy_assign_base;
+};
+
+template <bool _CanCopy, bool _CanMove> struct __sfinae_ctor_base {};
+
+template <class _Tp>
+using __optional_sfinae_ctor_base_t =
+    __sfinae_ctor_base<is_copy_constructible<_Tp>::value,
+                       is_move_constructible<_Tp>::value>;
+
+template <bool _CanCopy, bool _CanMove> struct __sfinae_assign_base {};
+
+template <class _Tp>
+using __optional_sfinae_assign_base_t = __sfinae_assign_base<
+    (is_copy_constructible<_Tp>::value && is_copy_assignable<_Tp>::value),
+    (is_move_constructible<_Tp>::value && is_move_assignable<_Tp>::value)>;
+
+template <class _Tp>
+class optional : private __optional_move_assign_base<_Tp>,
+                 private __optional_sfinae_ctor_base_t<_Tp>,
+                 private __optional_sfinae_assign_base_t<_Tp> {
+  using __base = __optional_move_assign_base<_Tp>;
+
+public:
+  using value_type = _Tp;
+
+public:
+  template <class _Up = value_type>
+  constexpr explicit optional(_Up &&__v)
+      : __base(in_place, std::forward<_Up>(__v)) {}
+};
+
+} // namespace __lldb
+} // namespace std
+
+int main() {
+  std::__lldb::optional<char const *> maybe_string{"Hello"};
+  std::__lldb::optional<int> maybe_int{42};
+  __builtin_printf("Break here\n");
+  return 0;
+}


### PR DESCRIPTION
Follow-up to the LLDB std::optional data-formatter test failure caused by https://github.com/llvm/llvm-project/pull/110355.

Two formats are supported:
1. `__val_` has type `value_type`
2. `__val_`'s type is wrapped in `std::remove_cv_t`