### PR TITLE
[GSYM] Remove redundant getInliningInfoForAddress call

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -699,7 +699,6 @@ llvm::Error DwarfTransformer::verify(StringRef GsymPath,
             Log << "    [" << Idx << "]: " << gii.Name << " @ " << gii.Dir
                 << '/' << gii.Base << ':' << gii.Line << '\n';
           }
-          DwarfInlineInfos = DICtx.getInliningInfoForAddress(SectAddr, DLIS);
           Gsym->dump(Log, *FI);
         }
         continue;


### PR DESCRIPTION
In DwarfTransformer::verify() line number information is retrieved for
each address using:

  auto DwarfInlineInfos =
      DICtx.getInliningInfoForAddress(SectAddr, DLIS);

Later down the loop, another such invocation was made before:

  Gsym->dump(Log, *FI);

There is a continue after that, DwarfInlineInfos do not affect the
dump() invocation, I am not aware of any other side effects that is
needed from the extra getInliningInfoForAddress() invocation, and tests
pass without it, so just remove it.
