### PR TITLE
[analyzer] Use dynamic type when invalidating by a member function call

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -690,9 +690,10 @@ protected:
       ValueList &Values,
       RegionAndSymbolInvalidationTraits *ETraits) const override;
 
-  /// Returns the decl refered to by the "dynamic type" of the current object.
-  /// This may be null.
-  const CXXRecordDecl *getDeclForDynamicType() const;
+  /// Returns the decl refered to by the "dynamic type" of the current object
+  /// and if the class can be a sub-class or not.
+  /// If the Pointer is null, the flag has no meaning.
+  std::pair<const CXXRecordDecl *, bool> getDeclForDynamicType() const;
 
 public:
   /// Returns the expression representing the implicit 'this' object.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -690,6 +690,10 @@ protected:
       ValueList &Values,
       RegionAndSymbolInvalidationTraits *ETraits) const override;
 
+  /// Returns the decl refered to by the "dynamic type" of the current object.
+  /// This may be null.
+  const CXXRecordDecl *getDeclForDynamicType() const;
+
 public:
   /// Returns the expression representing the implicit 'this' object.
   virtual const Expr *getCXXThisExpr() const { return nullptr; }

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -756,11 +756,8 @@ const CXXRecordDecl *CXXInstanceCall::getDeclForDynamicType() const {
   if (!DynType.isValid())
     return nullptr;
 
-  QualType Ty = DynType.getType()->getPointeeType();
-  if (Ty.isNull())
-    return nullptr;
-
-  return Ty->getAsCXXRecordDecl();
+  assert(!DynType.getType()->getPointeeType().isNull());
+  return DynType.getType()->getPointeeCXXRecordDecl();
 }
 
 RuntimeDefinition CXXInstanceCall::getRuntimeDefinition() const {

--- a/clang/test/Analysis/const-method-call.cpp
+++ b/clang/test/Analysis/const-method-call.cpp
@@ -271,3 +271,49 @@ void checkThatConstMethodCallDoesInvalidateObjectForCircularReferences() {
   // FIXME: Should be UNKNOWN.
   clang_analyzer_eval(t.x); // expected-warning{{TRUE}}
 }
+
+namespace gh77378 {
+template <typename Signature> class callable;
+
+template <typename R> class callable<R()> {
+  struct CallableType {
+    bool operator()();
+  };
+  using MethodType = R (CallableType::*)();
+  CallableType *object_{nullptr};
+  MethodType method_;
+
+public:
+  callable() = default;
+
+  template <typename T>
+  constexpr callable(const T &obj)
+      : object_{reinterpret_cast<CallableType *>(&const_cast<T &>(obj))},
+        method_{reinterpret_cast<MethodType>(
+            static_cast<bool (T::*)() const>(&T::operator()))} {}
+
+  constexpr bool const_method() const {
+    return (object_->*(method_))();
+  }
+
+  callable call() const & {
+    static const auto L = [this]() {
+      while (true) {
+        // This should not crash when conservative eval calling the member function
+        // when it unwinds the call stack due to exhausting the budget or reaching
+        // the inlining limit.
+        if (this->const_method()) {
+          break;
+        }
+      }
+      return true;
+    };
+    return L;
+  }
+};
+
+void entry() {
+  callable<bool()>{}.call().const_method();
+  // expected-warning@-1 {{Address of stack memory associated with temporary object of type 'callable<bool ()>' is still referred to by the static variable 'L' upon returning to the caller.  This will be a dangling reference}}
+}
+} // namespace gh77378


### PR DESCRIPTION
When instantiating "callable<T>", the "class CallableType" nested type will only have a declaration in the copy for the instantiation - because it's not refereed to directly by any other code that would need a complete definition.

However, in the past, when conservative eval calling member function, we took the static type of the "this" expr, and looked up the CXXRecordDecl it refereed to to see if it has any mutable members (to decide if it needs to refine invalidation or not). Unfortunately, that query needs a definition, and it asserts otherwise, thus we crashed.

To fix this, we should consult the dynamic type of the object, because that will have the definition.
I anyways added a check for "hasDefinition" just to be on the safe side.

Fixes #77378