### PR TITLE
[LLD][ELF] Assert TargetInfo correctness for when ctx becomes a local

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -3123,6 +3123,10 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
   // relocations or writing a PLT section. It also contains target-dependent
   // values such as a default image base address.
   ctx.target = getTarget(ctx);
+  // Currently, the TargetInfo structures in are function-statics. Guard against
+  // that causing problems if ctx is changed from a global variable to a local
+  // variable.
+  assert(&ctx.target->ctx == &ctx);
 
   ctx.arg.eflags = ctx.target->calcEFlags();
   // maxPageSize (sometimes called abi page size) is the maximum page size that


### PR DESCRIPTION
TargetInfos are currently function-statics, e.g: https://github.com/llvm/llvm-project/blob/6294679faa8ae57873b7fcdc00a4deb522d31c38/lld/ELF/Arch/X86_64.cpp#L1257.

Add an assert to Guard against that causing problems if ctx is changed from a global variable to a local variable.