### PR TITLE
[flang][OpenMP]Add TODO for unsupported OpenMP taskwait depend feature

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -2604,6 +2604,9 @@ static void genOMP(
       std::get<parser::OmpClauseList>(simpleStandaloneConstruct.t), semaCtx);
   mlir::Location currentLocation = converter.genLocation(directive.source);
 
+  if (directive.v == llvm::omp::Directive::OMPD_taskwait && !clauses.empty())
+    TODO(converter.getCurrentLocation(), "taskwait with depend unsupported");
+
   ConstructQueue queue{
       buildConstructQueue(converter.getFirOpBuilder().getModule(), semaCtx,
                           eval, directive.source, directive.v, clauses)};


### PR DESCRIPTION
Instead of asserting (debug) or not producing any code (release), tell user that `taskwait depend` this won't work.