### PR TITLE
Partially revert "[mlir][NVVM] Add constant memory space identifier"

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h"
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 
 #define DEBUG_TYPE "ptx-builder"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -26,6 +25,8 @@
 
 using namespace mlir;
 using namespace NVVM;
+
+static constexpr int64_t kSharedMemorySpace = 3;
 
 static char getRegisterType(Type type) {
   if (type.isInteger(1))
@@ -42,7 +43,7 @@ static char getRegisterType(Type type) {
     return 'd';
   if (auto ptr = dyn_cast<LLVM::LLVMPointerType>(type)) {
     // Shared address spaces is addressed with 32-bit pointers.
-    if (ptr.getAddressSpace() == NVVMMemorySpace::kSharedMemorySpace) {
+    if (ptr.getAddressSpace() == kSharedMemorySpace) {
       return 'r';
     }
     return 'l';


### PR DESCRIPTION

The second part of the change introduced circular dependency between LLVMDialect and BasicPtxBuilderInterface.