### PR TITLE
MLIR BUILD.bazel:  fold `BasicPtxBuilderInterface` into `NVVMDialect`

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -6301,11 +6301,17 @@ gentbl_cc_library(
 
 cc_library(
     name = "NVVMDialect",
-    srcs = ["lib/Dialect/LLVMIR/IR/NVVMDialect.cpp"],
-    hdrs = ["include/mlir/Dialect/LLVMIR/NVVMDialect.h"],
+    srcs = [
+        "lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp",
+        "lib/Dialect/LLVMIR/IR/NVVMDialect.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h",
+        "include/mlir/Dialect/LLVMIR/NVVMDialect.h",
+    ],
     includes = ["include"],
     deps = [
-        ":BasicPtxBuilderInterface",
+        ":BasicPtxBuilderIntGen",
         ":BytecodeOpInterface",
         ":ConvertToLLVMInterface",
         ":DialectUtils",
@@ -6504,21 +6510,6 @@ gentbl_cc_library(
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/NVVMOps.td",
     deps = [":NVVMOpsTdFiles"],
-)
-
-cc_library(
-    name = "BasicPtxBuilderInterface",
-    srcs = ["lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp"],
-    hdrs = [
-        "include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h",
-    ],
-    includes = ["include"],
-    deps = [
-        ":BasicPtxBuilderIntGen",
-        ":IR",
-        ":LLVMDialect",
-        ":Support",
-    ],
 )
 
 cc_library(


### PR DESCRIPTION
While doing an integrate into downstream https://github.com/iree-org/iree, I ran into a typical Bazel error with `BasicPtxBuilderInterface.cpp` including `NVVMDialect.h` which was not exposed as a header by a declared dependency.  I tried fixing this the straightforward way, by letting `:BasicPtxBuilderInterface` depend on `:NVVMDialect` , but that caused another Bazel error: circular dependency between these two targets, as `:NVVMDialect` was already depending on `:BasicPtxBuilderInterface`. I tried breaking that circle by dropping the latter dependency, but it was a real dependency in the code, specifically in the TableGen-generated code. So in the end it seems that these two targets just need to be fused, which this PR does.