### PR TITLE
[Support] Include Support/thread.h before api implementations

### DIFF
--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -33,7 +33,6 @@
 #include <pthread_np.h> // For pthread_getthreadid_np() / pthread_set_name_np()
 #endif
 
-
 // Must be included after Threading.inc to provide definition for llvm::thread
 // because FreeBSD's condvar.h (included by user.h) misuses the "thread"
 // keyword.

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -33,6 +33,14 @@
 #include <pthread_np.h> // For pthread_getthreadid_np() / pthread_set_name_np()
 #endif
 
+
+// Must be included after Threading.inc to provide definition for llvm::thread
+// because FreeBSD's condvar.h (included by user.h) misuses the "thread"
+// keyword.
+#ifndef __FreeBSD__
+#include "llvm/Support/thread.h"
+#endif
+
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #include <errno.h>
 #include <sys/cpuset.h>

--- a/llvm/lib/Support/Windows/Threading.inc
+++ b/llvm/lib/Support/Windows/Threading.inc
@@ -12,6 +12,7 @@
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/thread.h"
 
 #include "llvm/Support/Windows/WindowsSupport.h"
 #include <process.h>


### PR DESCRIPTION
This header was included after the implementations to work around an issue with FreeBSD, however, , this causes some issues when dllexport\explicit visibility
attributes will be added to the headers on Windows, since the definitions need to see the declarations for the attributes to apply.

This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and plugins on windows.
