### PR TITLE
[clang-tidy] Make `P +- BS / sizeof(*P)` opt-outable in `bugprone-sizeof-expression`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -71,8 +71,8 @@ SizeofExpressionCheck::SizeofExpressionCheck(StringRef Name,
       WarnOnSizeOfPointerToAggregate(
           Options.get("WarnOnSizeOfPointerToAggregate", true)),
       WarnOnSizeOfPointer(Options.get("WarnOnSizeOfPointer", false)),
-      WarnOnSizeOfPointerArithmeticWithDivisionScaled(Options.get(
-          "WarnOnSizeOfPointerArithmeticWithDivisionScaled", true)) {}
+      WarnOnArithmeticWithDivisionBySizeOf(
+          Options.get("WarnOnArithmeticWithDivisionBySizeOf", true)) {}
 
 void SizeofExpressionCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "WarnOnSizeOfConstant", WarnOnSizeOfConstant);
@@ -84,8 +84,8 @@ void SizeofExpressionCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "WarnOnSizeOfPointerToAggregate",
                 WarnOnSizeOfPointerToAggregate);
   Options.store(Opts, "WarnOnSizeOfPointer", WarnOnSizeOfPointer);
-  Options.store(Opts, "WarnOnSizeOfPointerArithmeticWithDivisionScaled",
-                WarnOnSizeOfPointerArithmeticWithDivisionScaled);
+  Options.store(Opts, "WarnOnArithmeticWithDivisionBySizeOf",
+                WarnOnArithmeticWithDivisionBySizeOf);
 }
 
 void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
@@ -310,13 +310,10 @@ void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
                  unaryExprOrTypeTraitExpr(ofKind(UETT_AlignOf)),
                  offsetOfExpr()))
           .bind("sizeof-in-ptr-arithmetic-scale-expr");
-  const auto PtrArithmeticIntegerScaleExprInterestingOperatorNames = [this] {
-    if (WarnOnSizeOfPointerArithmeticWithDivisionScaled)
-      return binaryOperator(hasAnyOperatorName("*", "/"));
-    return binaryOperator(hasOperatorName("*"));
-  };
   const auto PtrArithmeticIntegerScaleExpr = binaryOperator(
-      PtrArithmeticIntegerScaleExprInterestingOperatorNames(),
+      WarnOnArithmeticWithDivisionBySizeOf
+          ? binaryOperator(hasAnyOperatorName("*", "/"))
+          : binaryOperator(hasOperatorName("*")),
       // sizeof(...) * sizeof(...) and sizeof(...) / sizeof(...) is handled
       // by this check on another path.
       hasOperands(expr(hasType(isInteger()), unless(SizeofLikeScaleExpr)),

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -71,8 +71,8 @@ SizeofExpressionCheck::SizeofExpressionCheck(StringRef Name,
       WarnOnSizeOfPointerToAggregate(
           Options.get("WarnOnSizeOfPointerToAggregate", true)),
       WarnOnSizeOfPointer(Options.get("WarnOnSizeOfPointer", false)),
-      WarnOnArithmeticWithDivisionBySizeOf(
-          Options.get("WarnOnArithmeticWithDivisionBySizeOf", true)) {}
+      WarnOnOffsetDividedBySizeOf(
+          Options.get("WarnOnOffsetDividedBySizeOf", true)) {}
 
 void SizeofExpressionCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "WarnOnSizeOfConstant", WarnOnSizeOfConstant);
@@ -84,8 +84,8 @@ void SizeofExpressionCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "WarnOnSizeOfPointerToAggregate",
                 WarnOnSizeOfPointerToAggregate);
   Options.store(Opts, "WarnOnSizeOfPointer", WarnOnSizeOfPointer);
-  Options.store(Opts, "WarnOnArithmeticWithDivisionBySizeOf",
-                WarnOnArithmeticWithDivisionBySizeOf);
+  Options.store(Opts, "WarnOnOffsetDividedBySizeOf",
+                WarnOnOffsetDividedBySizeOf);
 }
 
 void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
@@ -311,9 +311,8 @@ void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
                  offsetOfExpr()))
           .bind("sizeof-in-ptr-arithmetic-scale-expr");
   const auto PtrArithmeticIntegerScaleExpr = binaryOperator(
-      WarnOnArithmeticWithDivisionBySizeOf
-          ? binaryOperator(hasAnyOperatorName("*", "/"))
-          : binaryOperator(hasOperatorName("*")),
+      WarnOnOffsetDividedBySizeOf ? binaryOperator(hasAnyOperatorName("*", "/"))
+                                  : binaryOperator(hasOperatorName("*")),
       // sizeof(...) * sizeof(...) and sizeof(...) / sizeof(...) is handled
       // by this check on another path.
       hasOperands(expr(hasType(isInteger()), unless(SizeofLikeScaleExpr)),

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
@@ -31,7 +31,7 @@ private:
   const bool WarnOnSizeOfCompareToConstant;
   const bool WarnOnSizeOfPointerToAggregate;
   const bool WarnOnSizeOfPointer;
-  const bool WarnOnSizeOfPointerArithmeticWithDivisionScaled;
+  const bool WarnOnArithmeticWithDivisionBySizeOf;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
@@ -31,7 +31,7 @@ private:
   const bool WarnOnSizeOfCompareToConstant;
   const bool WarnOnSizeOfPointerToAggregate;
   const bool WarnOnSizeOfPointer;
-  const bool WarnOnArithmeticWithDivisionBySizeOf;
+  const bool WarnOnOffsetDividedBySizeOf;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
@@ -31,6 +31,7 @@ private:
   const bool WarnOnSizeOfCompareToConstant;
   const bool WarnOnSizeOfPointerToAggregate;
   const bool WarnOnSizeOfPointer;
+  const bool WarnOnSizeOfPointerArithmeticWithDivisionScaled;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -144,7 +144,7 @@ Changes in existing checks
 - Improved :doc:`bugprone-sizeof-expression
   <clang-tidy/checks/bugprone/sizeof-expression>` check to find suspicious
   usages of ``sizeof()``, ``alignof()``, and ``offsetof()`` when adding or
-  subtracting from a pointer.
+  subtracting from a pointer directly or when used to scale a numeric value.
 
 - Improved :doc:`bugprone-unchecked-optional-access
   <clang-tidy/checks/bugprone/unchecked-optional-access>` to support

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -229,8 +229,8 @@ While scaling an integer up (multiplying) with ``sizeof`` is likely **always**
 an issue, a scaling down (division) is not always inherently dangerous, in case
 the developer is aware that the division happens between an appropriate number
 of _bytes_ and a ``sizeof`` value.
-Turning :option:`WarnOnSizeOfPointerArithmeticWithDivisionScaledInteger` off
-will restrict the warnings to the multiplication case.
+Turning :option:`WarnOnArithmeticWithDivisionBySizeOf` off will restrict the
+warnings to the multiplication case.
 
 This case also checks suspicious ``alignof`` and ``offsetof`` usages in
 pointer arithmetic, as both return the "size" in bytes and not elements,
@@ -311,7 +311,7 @@ Options
    idiomatic expressions that are probably intentional and correct).
    This detects occurrences of CWE 467. Default is `false`.
 
-.. option:: WarnOnSizeOfPointerArithmeticWithDivisionScaledInteger
+.. option:: WarnOnArithmeticWithDivisionBySizeOWarnOnArithmeticWithDivisionBySizeOf
 
    When `true`, the check will warn on pointer arithmetic where the
    element count is obtained from a division with ``sizeof(...)``,

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -311,7 +311,7 @@ Options
    idiomatic expressions that are probably intentional and correct).
    This detects occurrences of CWE 467. Default is `false`.
 
-.. option:: WarnOnArithmeticWithDivisionBySizeOWarnOnArithmeticWithDivisionBySizeOf
+.. option:: WarnOnArithmeticWithDivisionBySizeOf
 
    When `true`, the check will warn on pointer arithmetic where the
    element count is obtained from a division with ``sizeof(...)``,

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -221,7 +221,7 @@ and the result is typically unintended, often out of bounds.
 ``Ptr + sizeof(T)`` will offset the pointer by ``sizeof(T)`` elements,
 effectively exponentiating the scaling factor to the power of 2.
 
-Similarly, multiplying or dividing a numeric value with the ``sizeof`` an
+Similarly, multiplying or dividing a numeric value with the ``sizeof`` of an
 element or the whole buffer is suspicious, because the dimensional connection
 between the numeric value and the actual ``sizeof`` result can not always be
 deduced.
@@ -229,7 +229,7 @@ While scaling an integer up (multiplying) with ``sizeof`` is likely **always**
 an issue, a scaling down (division) is not always inherently dangerous, in case
 the developer is aware that the division happens between an appropriate number
 of _bytes_ and a ``sizeof`` value.
-Turning :option:`WarnOnArithmeticWithDivisionBySizeOf` off will restrict the
+Turning :option:`WarnOnOffsetDividedBySizeOf` off will restrict the
 warnings to the multiplication case.
 
 This case also checks suspicious ``alignof`` and ``offsetof`` usages in
@@ -311,7 +311,7 @@ Options
    idiomatic expressions that are probably intentional and correct).
    This detects occurrences of CWE 467. Default is `false`.
 
-.. option:: WarnOnArithmeticWithDivisionBySizeOf
+.. option:: WarnOnOffsetDividedBySizeOf
 
    When `true`, the check will warn on pointer arithmetic where the
    element count is obtained from a division with ``sizeof(...)``,

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -221,6 +221,17 @@ and the result is typically unintended, often out of bounds.
 ``Ptr + sizeof(T)`` will offset the pointer by ``sizeof(T)`` elements,
 effectively exponentiating the scaling factor to the power of 2.
 
+Similarly, multiplying or dividing a numeric value with the ``sizeof`` an
+element or the whole buffer is suspicious, because the dimensional connection
+between the numeric value and the actual ``sizeof`` result can not always be
+deduced.
+While scaling an integer up (multiplying) with ``sizeof`` is likely **always**
+an issue, a scaling down (division) is not always inherently dangerous, in case
+the developer is aware that the division happens between an appropriate number
+of _bytes_ and a ``sizeof`` value.
+Turning :option:`WarnOnSizeOfPointerArithmeticWithDivisionScaledInteger` off
+will restrict the warnings to the multiplication case.
+
 This case also checks suspicious ``alignof`` and ``offsetof`` usages in
 pointer arithmetic, as both return the "size" in bytes and not elements,
 potentially resulting in doubly-scaled offsets.
@@ -299,3 +310,9 @@ Options
    ``sizeof`` is an expression that produces a pointer (except for a few
    idiomatic expressions that are probably intentional and correct).
    This detects occurrences of CWE 467. Default is `false`.
+
+.. option:: WarnOnSizeOfPointerArithmeticWithDivisionScaledInteger
+
+   When `true`, the check will warn on pointer arithmetic where the
+   element count is obtained from a division with ``sizeof(...)``,
+   e.g., ``Ptr + Bytes / sizeof(*T)``. Default is `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics-no-division.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics-no-division.c
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s bugprone-sizeof-expression %t -- \
 // RUN:   -config='{CheckOptions: { \
-// RUN:     bugprone-sizeof-expression.WarnOnArithmeticWithDivisionBySizeOf: false \
+// RUN:     bugprone-sizeof-expression.WarnOnOffsetDividedBySizeOf: false \
 // RUN:   }}'
 
 typedef __SIZE_TYPE__ size_t;

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics-no-division.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics-no-division.c
@@ -1,5 +1,7 @@
 // RUN: %check_clang_tidy %s bugprone-sizeof-expression %t -- \
-// RUN:   -config="{CheckOptions: [{key: bugprone-sizeof-expression.WarnOnSizeOfPointerArithmeticWithDivisionScaled, value: 0}]}"
+// RUN:   -config='{CheckOptions: { \
+// RUN:     bugprone-sizeof-expression.WarnOnArithmeticWithDivisionBySizeOf: false \
+// RUN:   }}'
 
 typedef __SIZE_TYPE__ size_t;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics-no-division.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics-no-division.c
@@ -1,0 +1,12 @@
+// RUN: %check_clang_tidy %s bugprone-sizeof-expression %t -- \
+// RUN:   -config="{CheckOptions: [{key: bugprone-sizeof-expression.WarnOnSizeOfPointerArithmeticWithDivisionScaled, value: 0}]}"
+
+typedef __SIZE_TYPE__ size_t;
+
+void situational14(int *Buffer, size_t BufferSize) {
+  int *P = &Buffer[0];
+  while (P < Buffer + BufferSize / sizeof(*Buffer)) {
+    // NO-WARNING: This test opted out of "P +- N */ sizeof(...)" warnings.
+    ++P;
+  }
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-pointer-arithmetics.c
@@ -352,21 +352,30 @@ void good13(void) {
   int Buffer[BufferSize];
 
   int *P = &Buffer[0];
-  while (P < (Buffer + sizeof(Buffer) / sizeof(int))) {
+  while (P < Buffer + sizeof(Buffer) / sizeof(int)) {
     // NO-WARNING: Calculating the element count of the buffer here, which is
     // safe with this idiom (as long as the types don't change).
     ++P;
   }
 
-  while (P < (Buffer + sizeof(Buffer) / sizeof(Buffer[0]))) {
+  while (P < Buffer + sizeof(Buffer) / sizeof(Buffer[0])) {
     // NO-WARNING: Calculating the element count of the buffer here, which is
     // safe with this idiom.
     ++P;
   }
 
-  while (P < (Buffer + sizeof(Buffer) / sizeof(*P))) {
+  while (P < Buffer + sizeof(Buffer) / sizeof(*P)) {
     // NO-WARNING: Calculating the element count of the buffer here, which is
     // safe with this idiom.
+    ++P;
+  }
+}
+
+void situational14(int *Buffer, size_t BufferSize) {
+  int *P = &Buffer[0];
+  while (P < Buffer + BufferSize / sizeof(*Buffer)) {
+    // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic; this scaled value will be scaled again by the '+' operator
+    // CHECK-MESSAGES: :[[@LINE-2]]:21: note: '+' in pointer arithmetic internally scales with 'sizeof(int)' == {{[0-9]+}}
     ++P;
   }
 }


### PR DESCRIPTION
In some cases and for projects that deal with a lot of low-level buffers, a pattern often emerges that an array and its full size, not in the number of **elements** but in **bytes**, are known with no syntax-level connection between the two values. In order to access the array elements, the pointer arithmetic involved will have to divide `SizeInBytes` (a numeric value) with `sizeof(*Buffer)`. Since #106061, and as reported in #110551, this triggered a warning from `bugprone-sizeof-expression`, as `sizeof` appeared in pointer arithmetic where integers are scaled.

This patch adds a new check option, `WarnOnSizeOfPointerArithmeticWithDivisionScaled`, which allows users to opt-out of warning about the **division** case. In arbitrary projects, it might still be worthwhile to get these warnings until an opt-**out** in order to detect scaling issues, especially if a project might not be using low-level buffers intensively.

Fixes #110551.