### PR TITLE
 [PowerPC] Update matchRegisterName() to return MCRegister instead of bool

### DIFF
--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -103,7 +103,7 @@ class PPCAsmParser : public MCTargetAsmParser {
 
   bool isPPC64() const { return IsPPC64; }
 
-  bool matchRegisterName(MCRegister &RegNo, int64_t &IntVal);
+  MCRegister matchRegisterName(int64_t &IntVal);
 
   bool parseRegister(MCRegister &Reg, SMLoc &StartLoc, SMLoc &EndLoc) override;
   ParseStatus tryParseRegister(MCRegister &Reg, SMLoc &StartLoc,
@@ -1291,13 +1291,14 @@ bool PPCAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
   llvm_unreachable("Implement any new match types added!");
 }
 
-bool PPCAsmParser::matchRegisterName(MCRegister &RegNo, int64_t &IntVal) {
+MCRegister PPCAsmParser::matchRegisterName(int64_t &IntVal) {
   if (getParser().getTok().is(AsmToken::Percent))
     getParser().Lex(); // Eat the '%'.
 
   if (!getParser().getTok().is(AsmToken::Identifier))
-    return true;
+    return PPC::NoRegister;
 
+  MCRegister RegNo;
   StringRef Name = getParser().getTok().getString();
   if (Name.equals_insensitive("lr")) {
     RegNo = isPPC64() ? PPC::LR8 : PPC::LR;
@@ -1345,9 +1346,10 @@ bool PPCAsmParser::matchRegisterName(MCRegister &RegNo, int64_t &IntVal) {
              !Name.substr(3).getAsInteger(10, IntVal) && IntVal < 8) {
     RegNo = DMRRegs[IntVal];
   } else
-    return true;
+    return PPC::NoRegister;
+
   getParser().Lex();
-  return false;
+  return RegNo;
 }
 
 bool PPCAsmParser::parseRegister(MCRegister &Reg, SMLoc &StartLoc,
@@ -1362,9 +1364,9 @@ ParseStatus PPCAsmParser::tryParseRegister(MCRegister &Reg, SMLoc &StartLoc,
   const AsmToken &Tok = getParser().getTok();
   StartLoc = Tok.getLoc();
   EndLoc = Tok.getEndLoc();
-  Reg = PPC::NoRegister;
   int64_t IntVal;
-  if (matchRegisterName(Reg, IntVal))
+  Reg = matchRegisterName(IntVal);
+  if (!Reg)
     return ParseStatus::NoMatch;
   return ParseStatus::Success;
 }
@@ -1541,9 +1543,8 @@ bool PPCAsmParser::parseOperand(OperandVector &Operands) {
   // Special handling for register names.  These are interpreted
   // as immediates corresponding to the register number.
   case AsmToken::Percent: {
-    MCRegister RegNo;
     int64_t IntVal;
-    if (matchRegisterName(RegNo, IntVal))
+    if (! matchRegisterName(IntVal))
       return Error(S, "invalid register name");
 
     Operands.push_back(PPCOperand::CreateImm(IntVal, S, E, isPPC64()));
@@ -1627,8 +1628,7 @@ bool PPCAsmParser::parseOperand(OperandVector &Operands) {
     int64_t IntVal;
     switch (getLexer().getKind()) {
     case AsmToken::Percent: {
-      MCRegister RegNo;
-      if (matchRegisterName(RegNo, IntVal))
+      if (! matchRegisterName(IntVal))
         return Error(S, "invalid register name");
       break;
     }
@@ -1875,7 +1875,6 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializePowerPCAsmParser() {
   RegisterMCAsmParser<PPCAsmParser> D(getThePPC64LETarget());
 }
 
-#define GET_REGISTER_MATCHER
 #define GET_MATCHER_IMPLEMENTATION
 #define GET_MNEMONIC_SPELL_CHECKER
 #include "PPCGenAsmMatcher.inc"

--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -1875,6 +1875,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializePowerPCAsmParser() {
   RegisterMCAsmParser<PPCAsmParser> D(getThePPC64LETarget());
 }
 
+#define GET_REGISTER_MATCHER
 #define GET_MATCHER_IMPLEMENTATION
 #define GET_MNEMONIC_SPELL_CHECKER
 #include "PPCGenAsmMatcher.inc"

--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -1296,7 +1296,7 @@ MCRegister PPCAsmParser::matchRegisterName(int64_t &IntVal) {
     getParser().Lex(); // Eat the '%'.
 
   if (!getParser().getTok().is(AsmToken::Identifier))
-    return PPC::NoRegister;
+    return MCRegister();
 
   MCRegister RegNo;
   StringRef Name = getParser().getTok().getString();
@@ -1346,7 +1346,7 @@ MCRegister PPCAsmParser::matchRegisterName(int64_t &IntVal) {
              !Name.substr(3).getAsInteger(10, IntVal) && IntVal < 8) {
     RegNo = DMRRegs[IntVal];
   } else
-    return PPC::NoRegister;
+    return MCRegister();
 
   getParser().Lex();
   return RegNo;

--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -1365,8 +1365,7 @@ ParseStatus PPCAsmParser::tryParseRegister(MCRegister &Reg, SMLoc &StartLoc,
   StartLoc = Tok.getLoc();
   EndLoc = Tok.getEndLoc();
   int64_t IntVal;
-  Reg = matchRegisterName(IntVal);
-  if (!Reg)
+  if (!(Reg = matchRegisterName(IntVal)))
     return ParseStatus::NoMatch;
   return ParseStatus::Success;
 }

--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -1544,7 +1544,7 @@ bool PPCAsmParser::parseOperand(OperandVector &Operands) {
   // as immediates corresponding to the register number.
   case AsmToken::Percent: {
     int64_t IntVal;
-    if (! matchRegisterName(IntVal))
+    if (!matchRegisterName(IntVal))
       return Error(S, "invalid register name");
 
     Operands.push_back(PPCOperand::CreateImm(IntVal, S, E, isPPC64()));
@@ -1628,7 +1628,7 @@ bool PPCAsmParser::parseOperand(OperandVector &Operands) {
     int64_t IntVal;
     switch (getLexer().getKind()) {
     case AsmToken::Percent: {
-      if (! matchRegisterName(IntVal))
+      if (!matchRegisterName(IntVal))
         return Error(S, "invalid register name");
       break;
     }


### PR DESCRIPTION
Initial patch to start using TableGen's auto generated function `MatchRegisterName()`. 

Update `PPCAsmParser::matchRegisterName()` implementation to align more with tablegen's auto generated function.