### PR TITLE
[memprof] Teach createMIBNode to take ArrayRef (NFC)

### DIFF
--- a/llvm/lib/Analysis/MemoryProfileInfo.cpp
+++ b/llvm/lib/Analysis/MemoryProfileInfo.cpp
@@ -184,10 +184,9 @@ void CallStackTrie::addCallStack(MDNode *MIB) {
   addCallStack(getMIBAllocType(MIB), CallStack, getMIBTotalSize(MIB));
 }
 
-static MDNode *createMIBNode(LLVMContext &Ctx,
-                             std::vector<uint64_t> &MIBCallStack,
+static MDNode *createMIBNode(LLVMContext &Ctx, ArrayRef<uint64_t> MIBCallStack,
                              AllocationType AllocType, uint64_t TotalSize) {
-  std::vector<Metadata *> MIBPayload(
+  SmallVector<Metadata *> MIBPayload(
       {buildCallstackMetadata(MIBCallStack, Ctx)});
   MIBPayload.push_back(
       MDString::get(Ctx, getAllocTypeAttributeString(AllocType)));


### PR DESCRIPTION
createMIBNode does not modify MIBCallStack, so we can take ArrayRef
instead.

While I am at it, this patch changes the type of MIBPayload to
SmallVector.  We put at most three elements, so we can avoid a heap
allocation.
