### PR TITLE
[lldb][test] Mark test() in TestBSDArchives.py as passing remotely

### DIFF
--- a/lldb/test/API/functionalities/archives/TestBSDArchives.py
+++ b/lldb/test/API/functionalities/archives/TestBSDArchives.py
@@ -25,7 +25,6 @@ class BSDArchivesTestCase(TestBase):
         oslist=["windows"],
         bugnumber="llvm.org/pr24527.  Makefile.rules doesn't know how to build static libs on Windows",
     )
-    @expectedFailureAll(remote=True)
     def test(self):
         """Break inside a() and b() defined within libfoo.a."""
         self.build()


### PR DESCRIPTION
It was xfail'ed in de2ddc8f3146b. However, it passes on a buildbot https://lab.llvm.org/staging/#/builders/195/builds/3988.