### PR TITLE
[NFC][TableGen] Change `CodeGenIntrinsics` to use const references

### DIFF
--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
@@ -124,7 +124,7 @@ void CodeGenIntrinsicTable::CheckTargetIndependentIntrinsics() const {
   }
 }
 
-CodeGenIntrinsic &CodeGenIntrinsicMap::operator[](const Record *Record) {
+const CodeGenIntrinsic &CodeGenIntrinsicMap::operator[](const Record *Record) {
   if (!Record->isSubClassOf("Intrinsic"))
     PrintFatalError("Intrinsic defs should be subclass of 'Intrinsic' class");
 

--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.h
@@ -169,15 +169,12 @@ struct CodeGenIntrinsic {
 };
 
 class CodeGenIntrinsicTable {
-  std::vector<CodeGenIntrinsic> Intrinsics;
-
 public:
   struct TargetSet {
     StringRef Name;
     size_t Offset;
     size_t Count;
   };
-  std::vector<TargetSet> Targets;
 
   explicit CodeGenIntrinsicTable(const RecordKeeper &RC);
 
@@ -185,14 +182,17 @@ public:
   size_t size() const { return Intrinsics.size(); }
   auto begin() const { return Intrinsics.begin(); }
   auto end() const { return Intrinsics.end(); }
-  CodeGenIntrinsic &operator[](size_t Pos) { return Intrinsics[Pos]; }
   const CodeGenIntrinsic &operator[](size_t Pos) const {
     return Intrinsics[Pos];
   }
+  ArrayRef<TargetSet> getTargets() const { return Targets; }
 
 private:
   void CheckDuplicateIntrinsics() const;
   void CheckTargetIndependentIntrinsics() const;
+
+  std::vector<CodeGenIntrinsic> Intrinsics;
+  std::vector<TargetSet> Targets;
 };
 
 // This class builds `CodeGenIntrinsic` on demand for a given Def.
@@ -202,7 +202,7 @@ class CodeGenIntrinsicMap {
 
 public:
   explicit CodeGenIntrinsicMap(const RecordKeeper &RC) : Ctx(RC) {}
-  CodeGenIntrinsic &operator[](const Record *Def);
+  const CodeGenIntrinsic &operator[](const Record *Def);
 };
 
 } // namespace llvm

--- a/llvm/utils/TableGen/IntrinsicEmitter.cpp
+++ b/llvm/utils/TableGen/IntrinsicEmitter.cpp
@@ -124,7 +124,7 @@ void IntrinsicEmitter::EmitEnumInfo(const CodeGenIntrinsicTable &Ints,
   // intrinsics like dbg.value.
   using TargetSet = CodeGenIntrinsicTable::TargetSet;
   const TargetSet *Set = nullptr;
-  for (const auto &Target : Ints.Targets) {
+  for (const auto &Target : Ints.getTargets()) {
     if (Target.Name == IntrinsicPrefix) {
       Set = &Target;
       break;
@@ -132,7 +132,7 @@ void IntrinsicEmitter::EmitEnumInfo(const CodeGenIntrinsicTable &Ints,
   }
   if (!Set) {
     // The first entry is for target independent intrinsics, so drop it.
-    auto KnowTargets = ArrayRef<TargetSet>(Ints.Targets).drop_front();
+    auto KnowTargets = Ints.getTargets().drop_front();
     PrintFatalError([KnowTargets](raw_ostream &OS) {
       OS << "tried to generate intrinsics for unknown target "
          << IntrinsicPrefix << "\nKnown targets are: ";
@@ -230,7 +230,7 @@ struct IntrinsicTargetInfo {
 };
 static constexpr IntrinsicTargetInfo TargetInfos[] = {
 )";
-  for (const auto [Name, Offset, Count] : Ints.Targets)
+  for (const auto [Name, Offset, Count] : Ints.getTargets())
     OS << formatv("  {{\"{}\", {}, {}},\n", Name, Offset, Count);
   OS << R"(};
 #endif


### PR DESCRIPTION
Change `CodeGenIntrinsics` classes to vend out const references to `CodeGenIntrinsic` or `TargetSet` objects.