### PR TITLE
[lldb][NFC] Fix a build failure with MSVC

### DIFF
--- a/lldb/include/lldb/Utility/Status.h
+++ b/lldb/include/lldb/Utility/Status.h
@@ -83,8 +83,7 @@ class ExpressionErrorBase
     : public llvm::ErrorInfo<ExpressionErrorBase, CloneableECError> {
 public:
   using llvm::ErrorInfo<ExpressionErrorBase, CloneableECError>::ErrorInfo;
-  ExpressionErrorBase(std::error_code ec, std::string msg = {})
-      : ErrorInfo(ec) {}
+  ExpressionErrorBase(std::error_code ec) : ErrorInfo(ec) {}
   lldb::ErrorType GetErrorType() const override;
   static char ID;
 };


### PR DESCRIPTION
This fixes a build error with msvc for code introduced in #106442:

```
...\lldb\source\Expression\DiagnosticManager.cpp(37): error C2668: 'llvm::ErrorInfo<lldb_private::ExpressionError,lldb_private::ExpressionErrorBase>::ErrorInfo': ambiguous call to overloaded function
...\llvm\include\llvm/Support/Error.h(357): note: could be 'llvm::ErrorInfo<lldb_private::ExpressionError,lldb_private::ExpressionErrorBase>::ErrorInfo(std::error_code)', which inherits 'lldb_private::CloneableECError::CloneableECError(std::error_code)' via base class 'lldb_private::ExpressionErrorBase'
...\llvm\include\llvm/Support/Error.h(357): note: or       'llvm::ErrorInfo<lldb_private::ExpressionError,lldb_private::ExpressionErrorBase>::ErrorInfo(std::error_code,std::string)', which inherits 'lldb_private::ExpressionErrorBase::ExpressionErrorBase(std::error_code,std::string)' via base class 'lldb_private::ExpressionErrorBase'
...\lldb\source\Expression\DiagnosticManager.cpp(37): note: while trying to match the argument list '(std::error_code)'
```