### PR TITLE
Revert "[InstCombine] Folding `(icmp eq/ne (and X, -P2), INT_MIN)`"

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -5015,18 +5015,6 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
     }
   }
 
-  // (icmp eq/ne (X, -P2), INT_MIN)
-  //	-> (icmp slt/sge X, INT_MIN + P2)
-  if (ICmpInst::isEquality(Pred) && BO0 &&
-      match(I.getOperand(1), m_SignMask()) &&
-      match(BO0, m_And(m_Value(), m_NegatedPower2OrZero()))) {
-    // Will Constant fold.
-    Value *NewC = Builder.CreateSub(I.getOperand(1), BO0->getOperand(1));
-    return new ICmpInst(Pred == ICmpInst::ICMP_EQ ? ICmpInst::ICMP_SLT
-                                                  : ICmpInst::ICMP_SGE,
-                        BO0->getOperand(0), NewC);
-  }
-
   {
     // Similar to above: an unsigned overflow comparison may use offset + mask:
     // ((Op1 + C) & C) u<  Op1 --> Op1 != 0

--- a/llvm/test/Transforms/InstCombine/icmp-signmask.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-signmask.ll
@@ -3,7 +3,8 @@
 
 define i1 @cmp_x_and_negp2_with_eq(i8 %x) {
 ; CHECK-LABEL: @cmp_x_and_negp2_with_eq(
-; CHECK-NEXT:    [[R:%.*]] = icmp slt i8 [[X:%.*]], -126
+; CHECK-NEXT:    [[ANDX:%.*]] = and i8 [[X:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[ANDX]], -128
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %andx = and i8 %x, -2
@@ -24,7 +25,8 @@ define i1 @cmp_x_and_negp2_with_eq_fail_not_signmask(i8 %x) {
 
 define <2 x i1> @cmp_x_and_negp2_with_ne(<2 x i8> %x) {
 ; CHECK-LABEL: @cmp_x_and_negp2_with_ne(
-; CHECK-NEXT:    [[R:%.*]] = icmp sgt <2 x i8> [[X:%.*]], <i8 -121, i8 -113>
+; CHECK-NEXT:    [[ANDX:%.*]] = and <2 x i8> [[X:%.*]], <i8 -8, i8 -16>
+; CHECK-NEXT:    [[R:%.*]] = icmp ne <2 x i8> [[ANDX]], <i8 -128, i8 -128>
 ; CHECK-NEXT:    ret <2 x i1> [[R]]
 ;
   %andx = and <2 x i8> %x, <i8 -8, i8 -16>
@@ -34,7 +36,8 @@ define <2 x i1> @cmp_x_and_negp2_with_ne(<2 x i8> %x) {
 
 define <2 x i1> @cmp_x_and_negp2_with_ne_or_z(<2 x i8> %x) {
 ; CHECK-LABEL: @cmp_x_and_negp2_with_ne_or_z(
-; CHECK-NEXT:    [[R:%.*]] = icmp sge <2 x i8> [[X:%.*]], <i8 -128, i8 -112>
+; CHECK-NEXT:    [[ANDX:%.*]] = and <2 x i8> [[X:%.*]], <i8 0, i8 -16>
+; CHECK-NEXT:    [[R:%.*]] = icmp ne <2 x i8> [[ANDX]], <i8 -128, i8 -128>
 ; CHECK-NEXT:    ret <2 x i1> [[R]]
 ;
   %andx = and <2 x i8> %x, <i8 0, i8 -16>

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -1116,7 +1116,8 @@ define i1 @test53(i32 %a, i32 %b) {
 
 define i1 @test54(i8 %a) {
 ; CHECK-LABEL: @test54(
-; CHECK-NEXT:    [[RET:%.*]] = icmp slt i8 [[A:%.*]], -64
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[A:%.*]], -64
+; CHECK-NEXT:    [[RET:%.*]] = icmp eq i8 [[TMP1]], -128
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %ext = zext i8 %a to i32


### PR DESCRIPTION
Reverts #110880 because of exposed issue is Msan instrumentation #111212.

This reverts commit a64643688526114b50c25b3eda8a57855bd2be87.
