### PR TITLE
[analyzer] Fix wrong `builtin_*_overflow` return type

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
@@ -183,6 +183,7 @@ void BuiltinFunctionChecker::handleOverflowBuiltin(const CallEvent &Call,
   ProgramStateRef State = C.getState();
   SValBuilder &SVB = C.getSValBuilder();
   const Expr *CE = Call.getOriginExpr();
+  auto BoolTy = C.getASTContext().BoolTy;
 
   SVal Arg1 = Call.getArgSVal(0);
   SVal Arg2 = Call.getArgSVal(1);
@@ -194,7 +195,7 @@ void BuiltinFunctionChecker::handleOverflowBuiltin(const CallEvent &Call,
   auto [Overflow, NotOverflow] = checkOverflow(C, RetValMax, ResultType);
   if (NotOverflow) {
     ProgramStateRef StateNoOverflow =
-        State->BindExpr(CE, C.getLocationContext(), SVB.makeTruthVal(false));
+        State->BindExpr(CE, C.getLocationContext(), SVB.makeTruthVal(false, BoolTy));
 
     if (auto L = Call.getArgSVal(2).getAs<Loc>()) {
       StateNoOverflow =
@@ -213,7 +214,7 @@ void BuiltinFunctionChecker::handleOverflowBuiltin(const CallEvent &Call,
 
   if (Overflow) {
     C.addTransition(
-        State->BindExpr(CE, C.getLocationContext(), SVB.makeTruthVal(true)),
+        State->BindExpr(CE, C.getLocationContext(), SVB.makeTruthVal(true, BoolTy)),
         createBuiltinOverflowNoteTag(C));
   }
 }

--- a/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
@@ -194,8 +194,8 @@ void BuiltinFunctionChecker::handleOverflowBuiltin(const CallEvent &Call,
 
   auto [Overflow, NotOverflow] = checkOverflow(C, RetValMax, ResultType);
   if (NotOverflow) {
-    ProgramStateRef StateNoOverflow =
-        State->BindExpr(CE, C.getLocationContext(), SVB.makeTruthVal(false, BoolTy));
+    ProgramStateRef StateNoOverflow = State->BindExpr(
+        CE, C.getLocationContext(), SVB.makeTruthVal(false, BoolTy));
 
     if (auto L = Call.getArgSVal(2).getAs<Loc>()) {
       StateNoOverflow =
@@ -213,9 +213,9 @@ void BuiltinFunctionChecker::handleOverflowBuiltin(const CallEvent &Call,
   }
 
   if (Overflow) {
-    C.addTransition(
-        State->BindExpr(CE, C.getLocationContext(), SVB.makeTruthVal(true, BoolTy)),
-        createBuiltinOverflowNoteTag(C));
+    C.addTransition(State->BindExpr(CE, C.getLocationContext(),
+                                    SVB.makeTruthVal(true, BoolTy)),
+                    createBuiltinOverflowNoteTag(C));
   }
 }
 

--- a/clang/test/Analysis/builtin_overflow.c
+++ b/clang/test/Analysis/builtin_overflow.c
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -triple x86_64-unknown-unknown -verify %s \
-// RUN:   -analyzer-checker=core,debug.ExprInspection
+// RUN:   -analyzer-checker=core,debug.ExprInspection,alpha.core.BoolAssignment
 
 #define __UINT_MAX__ (__INT_MAX__ * 2U + 1U)
 #define __INT_MIN__  (-__INT_MAX__ - 1)
@@ -154,4 +154,13 @@ void test_uadd_overflow_contraints(unsigned a, unsigned b)
      clang_analyzer_warnIfReached();
      return;
    }
+}
+
+void test_bool_assign(void)
+{
+    int res;
+
+    // Reproduce issue from GH#111147. __builtin_*_overflow funcions
+    // should return _Bool, but not int.
+    _Bool ret = __builtin_mul_overflow(10, 20, &res); // no crash
 }


### PR DESCRIPTION
`builtin_*_overflow` functions return `_Bool` according to [1]. `BuiltinFunctionChecker` was using `makeTruthVal`  w/o specifying explicit type, which creates an `int` value, since it's the type of any compassion according to C standard.

Fix it by directly passing `BoolTy` to `makeTruthVal`

Closes: #111147

[1] https://clang.llvm.org/docs/LanguageExtensions.html#checked-arithmetic-builtins