### PR TITLE
[LangRef] Fix mislabeling in calling convention name (NFC)

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -12836,7 +12836,7 @@ This instruction requires several arguments:
    - The caller and callee prototypes must match. Pointer types of parameters
      or return types may differ in pointee type, but not in address space.
 
-  On the other hand, if the calling convention is `swifttailcc` or `swiftcc`:
+  On the other hand, if the calling convention is `swifttailcc` or `tailcc`:
 
    - Only these ABI-impacting attributes attributes are allowed: sret, byval,
      swiftself, and swiftasync.


### PR DESCRIPTION
We have explained how musttail can be guaranteed when the calling convention is not `swifttailcc` or `tailcc`, ensure what needs to adhere when it is the opposite case (reflect how it is already handled in Verifier).