### PR TITLE
[ELF] Change Ctx::target to unique_ptr

### DIFF
--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -1208,12 +1208,10 @@ void lld::elf::createTaggedSymbols(const SmallVector<ELFFileBase *, 0> &files) {
   }
 }
 
-TargetInfo *elf::getAArch64TargetInfo(Ctx &ctx) {
+void elf::setAArch64TargetInfo(Ctx &ctx) {
   if ((ctx.arg.andFeatures & GNU_PROPERTY_AARCH64_FEATURE_1_BTI) ||
-      ctx.arg.zPacPlt) {
-    static AArch64BtiPac t(ctx);
-    return &t;
-  }
-  static AArch64 t(ctx);
-  return &t;
+      ctx.arg.zPacPlt)
+    ctx.target.reset(new AArch64BtiPac(ctx));
+  else
+    ctx.target.reset(new AArch64(ctx));
 }

--- a/lld/ELF/Arch/AMDGPU.cpp
+++ b/lld/ELF/Arch/AMDGPU.cpp
@@ -219,7 +219,4 @@ int64_t AMDGPU::getImplicitAddend(const uint8_t *buf, RelType type) const {
   }
 }
 
-TargetInfo *elf::getAMDGPUTargetInfo(Ctx &ctx) {
-  static AMDGPU target(ctx);
-  return &target;
-}
+void elf::setAMDGPUTargetInfo(Ctx &ctx) { ctx.target.reset(new AMDGPU(ctx)); }

--- a/lld/ELF/Arch/ARM.cpp
+++ b/lld/ELF/Arch/ARM.cpp
@@ -1533,10 +1533,7 @@ template <typename ELFT> void elf::writeARMCmseImportLib() {
           "': " + toString(std::move(e)));
 }
 
-TargetInfo *elf::getARMTargetInfo(Ctx &ctx) {
-  static ARM target(ctx);
-  return &target;
-}
+void elf::setARMTargetInfo(Ctx &ctx) { ctx.target.reset(new ARM(ctx)); }
 
 template void elf::writeARMCmseImportLib<ELF32LE>();
 template void elf::writeARMCmseImportLib<ELF32BE>();

--- a/lld/ELF/Arch/AVR.cpp
+++ b/lld/ELF/Arch/AVR.cpp
@@ -267,10 +267,7 @@ void AVR::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
   }
 }
 
-TargetInfo *elf::getAVRTargetInfo(Ctx &ctx) {
-  static AVR target(ctx);
-  return &target;
-}
+void elf::setAVRTargetInfo(Ctx &ctx) { ctx.target.reset(new AVR(ctx)); }
 
 static uint32_t getEFlags(InputFile *file) {
   return cast<ObjFile<ELF32LE>>(file)->getObj().getHeader().e_flags;

--- a/lld/ELF/Arch/Hexagon.cpp
+++ b/lld/ELF/Arch/Hexagon.cpp
@@ -404,7 +404,4 @@ int64_t Hexagon::getImplicitAddend(const uint8_t *buf, RelType type) const {
   }
 }
 
-TargetInfo *elf::getHexagonTargetInfo(Ctx &ctx) {
-  static Hexagon target(ctx);
-  return &target;
-}
+void elf::setHexagonTargetInfo(Ctx &ctx) { ctx.target.reset(new Hexagon(ctx)); }

--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -893,7 +893,6 @@ void LoongArch::finalizeRelax(int passes) const {
   }
 }
 
-TargetInfo *elf::getLoongArchTargetInfo(Ctx &ctx) {
-  static LoongArch target(ctx);
-  return &target;
+void elf::setLoongArchTargetInfo(Ctx &ctx) {
+  ctx.target.reset(new LoongArch(ctx));
 }

--- a/lld/ELF/Arch/MSP430.cpp
+++ b/lld/ELF/Arch/MSP430.cpp
@@ -88,7 +88,4 @@ void MSP430::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
   }
 }
 
-TargetInfo *elf::getMSP430TargetInfo(Ctx &ctx) {
-  static MSP430 target(ctx);
-  return &target;
-}
+void elf::setMSP430TargetInfo(Ctx &ctx) { ctx.target.reset(new MSP430(ctx)); }

--- a/lld/ELF/Arch/Mips.cpp
+++ b/lld/ELF/Arch/Mips.cpp
@@ -778,23 +778,23 @@ template <class ELFT> bool elf::isMipsPIC(const Defined *sym) {
   return cast<ObjFile<ELFT>>(file)->getObj().getHeader().e_flags & EF_MIPS_PIC;
 }
 
-TargetInfo *elf::getMipsTargetInfo(Ctx &ctx) {
+void elf::setMipsTargetInfo(Ctx &ctx) {
   switch (ctx.arg.ekind) {
   case ELF32LEKind: {
-    static MIPS<ELF32LE> t(ctx);
-    return &t;
+    ctx.target.reset(new MIPS<ELF32LE>(ctx));
+    return;
   }
   case ELF32BEKind: {
-    static MIPS<ELF32BE> t(ctx);
-    return &t;
+    ctx.target.reset(new MIPS<ELF32BE>(ctx));
+    return;
   }
   case ELF64LEKind: {
-    static MIPS<ELF64LE> t(ctx);
-    return &t;
+    ctx.target.reset(new MIPS<ELF64LE>(ctx));
+    return;
   }
   case ELF64BEKind: {
-    static MIPS<ELF64BE> t(ctx);
-    return &t;
+    ctx.target.reset(new MIPS<ELF64BE>(ctx));
+    return;
   }
   default:
     llvm_unreachable("unsupported target");

--- a/lld/ELF/Arch/PPC.cpp
+++ b/lld/ELF/Arch/PPC.cpp
@@ -525,7 +525,4 @@ void PPC::relocateAlloc(InputSectionBase &sec, uint8_t *buf) const {
   }
 }
 
-TargetInfo *elf::getPPCTargetInfo(Ctx &ctx) {
-  static PPC target(ctx);
-  return &target;
-}
+void elf::setPPCTargetInfo(Ctx &ctx) { ctx.target.reset(new PPC(ctx)); }

--- a/lld/ELF/Arch/PPC64.cpp
+++ b/lld/ELF/Arch/PPC64.cpp
@@ -1750,7 +1750,4 @@ bool PPC64::adjustPrologueForCrossSplitStack(uint8_t *loc, uint8_t *end,
   return true;
 }
 
-TargetInfo *elf::getPPC64TargetInfo(Ctx &ctx) {
-  static PPC64 target(ctx);
-  return &target;
-}
+void elf::setPPC64TargetInfo(Ctx &ctx) { ctx.target.reset(new PPC64(ctx)); }

--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -1328,7 +1328,4 @@ void elf::mergeRISCVAttributesSections(Ctx &) {
                            mergeAttributesSection(sections));
 }
 
-TargetInfo *elf::getRISCVTargetInfo(Ctx &ctx) {
-  static RISCV target(ctx);
-  return &target;
-}
+void elf::setRISCVTargetInfo(Ctx &ctx) { ctx.target.reset(new RISCV(ctx)); }

--- a/lld/ELF/Arch/SPARCV9.cpp
+++ b/lld/ELF/Arch/SPARCV9.cpp
@@ -193,7 +193,4 @@ void SPARCV9::writePlt(uint8_t *buf, const Symbol & /*sym*/,
   relocateNoSym(buf + 4, R_SPARC_WDISP19, -(off + 4 - pltEntrySize));
 }
 
-TargetInfo *elf::getSPARCV9TargetInfo(Ctx &ctx) {
-  static SPARCV9 target(ctx);
-  return &target;
-}
+void elf::setSPARCV9TargetInfo(Ctx &ctx) { ctx.target.reset(new SPARCV9(ctx)); }

--- a/lld/ELF/Arch/SystemZ.cpp
+++ b/lld/ELF/Arch/SystemZ.cpp
@@ -601,7 +601,4 @@ void SystemZ::relocate(uint8_t *loc, const Relocation &rel,
   }
 }
 
-TargetInfo *elf::getSystemZTargetInfo(Ctx &ctx) {
-  static SystemZ t(ctx);
-  return &t;
-}
+void elf::setSystemZTargetInfo(Ctx &ctx) { ctx.target.reset(new SystemZ(ctx)); }

--- a/lld/ELF/Arch/X86.cpp
+++ b/lld/ELF/Arch/X86.cpp
@@ -708,21 +708,17 @@ void RetpolineNoPic::writePlt(uint8_t *buf, const Symbol &sym,
   write32le(buf + 22, -off - 26);
 }
 
-TargetInfo *elf::getX86TargetInfo(Ctx &ctx) {
+void elf::setX86TargetInfo(Ctx &ctx) {
   if (ctx.arg.zRetpolineplt) {
-    if (ctx.arg.isPic) {
-      static RetpolinePic t(ctx);
-      return &t;
-    }
-    static RetpolineNoPic t(ctx);
-    return &t;
+    if (ctx.arg.isPic)
+      ctx.target.reset(new RetpolinePic(ctx));
+    else
+      ctx.target.reset(new RetpolineNoPic(ctx));
+    return;
   }
 
-  if (ctx.arg.andFeatures & GNU_PROPERTY_X86_FEATURE_1_IBT) {
-    static IntelIBT t(ctx);
-    return &t;
-  }
-
-  static X86 t(ctx);
-  return &t;
+  if (ctx.arg.andFeatures & GNU_PROPERTY_X86_FEATURE_1_IBT)
+    ctx.target.reset(new IntelIBT(ctx));
+  else
+    ctx.target.reset(new X86(ctx));
 }

--- a/lld/ELF/Arch/X86_64.cpp
+++ b/lld/ELF/Arch/X86_64.cpp
@@ -1239,21 +1239,17 @@ void RetpolineZNow::writePlt(uint8_t *buf, const Symbol &sym,
   write32le(buf + 8, ctx.in.plt->getVA() - pltEntryAddr - 12);
 }
 
-TargetInfo *elf::getX86_64TargetInfo(Ctx &ctx) {
+void elf::setX86_64TargetInfo(Ctx &ctx) {
   if (ctx.arg.zRetpolineplt) {
-    if (ctx.arg.zNow) {
-      static RetpolineZNow t(ctx);
-      return &t;
-    }
-    static Retpoline t(ctx);
-    return &t;
+    if (ctx.arg.zNow)
+      ctx.target.reset(new RetpolineZNow(ctx));
+    else
+      ctx.target.reset(new Retpoline(ctx));
+    return;
   }
 
-  if (ctx.arg.andFeatures & GNU_PROPERTY_X86_FEATURE_1_IBT) {
-    static IntelIBT t(ctx);
-    return &t;
-  }
-
-  static X86_64 t(ctx);
-  return &t;
+  if (ctx.arg.andFeatures & GNU_PROPERTY_X86_FEATURE_1_IBT)
+    ctx.target.reset(new IntelIBT(ctx));
+  else
+    ctx.target.reset(new X86_64(ctx));
 }

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -542,7 +542,7 @@ struct Ctx {
   Config arg;
   LinkerDriver driver;
   LinkerScript *script;
-  TargetInfo *target;
+  std::unique_ptr<TargetInfo> target;
 
   // These variables are initialized by Writer and should not be used before
   // Writer is initialized.

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -98,7 +98,7 @@ void Ctx::reset() {
   driver.~LinkerDriver();
   new (&driver) LinkerDriver(*this);
   script = nullptr;
-  target = nullptr;
+  target.reset();
 
   bufferStart = nullptr;
   mainPart = nullptr;
@@ -3122,7 +3122,7 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
   // The Target instance handles target-specific stuff, such as applying
   // relocations or writing a PLT section. It also contains target-dependent
   // values such as a default image base address.
-  ctx.target = getTarget(ctx);
+  setTarget(ctx);
 
   ctx.arg.eflags = ctx.target->calcEFlags();
   // maxPageSize (sometimes called abi page size) is the maximum page size that

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -45,39 +45,39 @@ std::string lld::toString(RelType type) {
   return std::string(s);
 }
 
-TargetInfo *elf::getTarget(Ctx &ctx) {
+void elf::setTarget(Ctx &ctx) {
   switch (ctx.arg.emachine) {
   case EM_386:
   case EM_IAMCU:
-    return getX86TargetInfo(ctx);
+    return setX86TargetInfo(ctx);
   case EM_AARCH64:
-    return getAArch64TargetInfo(ctx);
+    return setAArch64TargetInfo(ctx);
   case EM_AMDGPU:
-    return getAMDGPUTargetInfo(ctx);
+    return setAMDGPUTargetInfo(ctx);
   case EM_ARM:
-    return getARMTargetInfo(ctx);
+    return setARMTargetInfo(ctx);
   case EM_AVR:
-    return getAVRTargetInfo(ctx);
+    return setAVRTargetInfo(ctx);
   case EM_HEXAGON:
-    return getHexagonTargetInfo(ctx);
+    return setHexagonTargetInfo(ctx);
   case EM_LOONGARCH:
-    return getLoongArchTargetInfo(ctx);
+    return setLoongArchTargetInfo(ctx);
   case EM_MIPS:
-    return getMipsTargetInfo(ctx);
+    return setMipsTargetInfo(ctx);
   case EM_MSP430:
-    return getMSP430TargetInfo(ctx);
+    return setMSP430TargetInfo(ctx);
   case EM_PPC:
-    return getPPCTargetInfo(ctx);
+    return setPPCTargetInfo(ctx);
   case EM_PPC64:
-    return getPPC64TargetInfo(ctx);
+    return setPPC64TargetInfo(ctx);
   case EM_RISCV:
-    return getRISCVTargetInfo(ctx);
+    return setRISCVTargetInfo(ctx);
   case EM_SPARCV9:
-    return getSPARCV9TargetInfo(ctx);
+    return setSPARCV9TargetInfo(ctx);
   case EM_S390:
-    return getSystemZTargetInfo(ctx);
+    return setSystemZTargetInfo(ctx);
   case EM_X86_64:
-    return getX86_64TargetInfo(ctx);
+    return setX86_64TargetInfo(ctx);
   default:
     fatal("unsupported e_machine value: " + Twine(ctx.arg.emachine));
   }

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -179,21 +179,21 @@ protected:
   uint64_t defaultImageBase = 0x10000;
 };
 
-TargetInfo *getAArch64TargetInfo(Ctx &);
-TargetInfo *getAMDGPUTargetInfo(Ctx &);
-TargetInfo *getARMTargetInfo(Ctx &);
-TargetInfo *getAVRTargetInfo(Ctx &);
-TargetInfo *getHexagonTargetInfo(Ctx &);
-TargetInfo *getLoongArchTargetInfo(Ctx &);
-TargetInfo *getMSP430TargetInfo(Ctx &);
-TargetInfo *getMipsTargetInfo(Ctx &);
-TargetInfo *getPPC64TargetInfo(Ctx &);
-TargetInfo *getPPCTargetInfo(Ctx &);
-TargetInfo *getRISCVTargetInfo(Ctx &);
-TargetInfo *getSPARCV9TargetInfo(Ctx &);
-TargetInfo *getSystemZTargetInfo(Ctx &);
-TargetInfo *getX86TargetInfo(Ctx &);
-TargetInfo *getX86_64TargetInfo(Ctx &);
+void setAArch64TargetInfo(Ctx &);
+void setAMDGPUTargetInfo(Ctx &);
+void setARMTargetInfo(Ctx &);
+void setAVRTargetInfo(Ctx &);
+void setHexagonTargetInfo(Ctx &);
+void setLoongArchTargetInfo(Ctx &);
+void setMSP430TargetInfo(Ctx &);
+void setMipsTargetInfo(Ctx &);
+void setPPC64TargetInfo(Ctx &);
+void setPPCTargetInfo(Ctx &);
+void setRISCVTargetInfo(Ctx &);
+void setSPARCV9TargetInfo(Ctx &);
+void setSystemZTargetInfo(Ctx &);
+void setX86TargetInfo(Ctx &);
+void setX86_64TargetInfo(Ctx &);
 
 struct ErrorPlace {
   InputSectionBase *isec;
@@ -244,7 +244,7 @@ void convertArmInstructionstoBE8(InputSection *sec, uint8_t *buf);
 void createTaggedSymbols(const SmallVector<ELFFileBase *, 0> &files);
 void initSymbolAnchors();
 
-TargetInfo *getTarget(Ctx &);
+void setTarget(Ctx &);
 
 template <class ELFT> bool isMipsPIC(const Defined *sym);
 


### PR DESCRIPTION
also rename `TargetInfo *getXXXTargetInfo` to `void setXXXTargetInfo` and change it to set `ctx.target`. This ensures that when `ctx` becomes a local variable, two lld invocations will not reuse the function-local static variable.