### PR TITLE
[mlir][SPIRV] Fix build error

### DIFF
--- a/mlir/include/mlir/Conversion/SPIRVToLLVM/SPIRVToLLVM.h
+++ b/mlir/include/mlir/Conversion/SPIRVToLLVM/SPIRVToLLVM.h
@@ -29,12 +29,6 @@ public:
                         const LLVMTypeConverter &typeConverter,
                         PatternBenefit benefit = 1)
       : OpConversionPattern<SPIRVOp>(typeConverter, context, benefit) {}
-
-protected:
-  const LLVMTypeConverter *getTypeConverter() const {
-    return static_cast<const LLVMTypeConverter *>(
-        ConversionPattern::getTypeConverter());
-  }
 };
 
 /// Encodes global variable's descriptor set and binding into its name if they


### PR DESCRIPTION
Fix build error that was introduced by #111250. Also, the deleted function is not needed at all.

```
../llvm-project/mlir/include/mlir/Conversion/SPIRVToLLVM/SPIRVToLLVM.h: In member function ‘const mlir::LLVMTypeConverter* mlir::SPIRVToLLVMConversion<SPIRVOp>::getTypeConverter() const’:
../llvm-project/mlir/include/mlir/Conversion/SPIRVToLLVM/SPIRVToLLVM.h:35:12: error: invalid ‘static_cast’ from type ‘const mlir::TypeConverter*’ to type ‘const mlir::LLVMTypeConverter*’
   35 |     return static_cast<const LLVMTypeConverter *>(
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   36 |         ConversionPattern::getTypeConverter());
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../llvm-project/mlir/include/mlir/Conversion/SPIRVToLLVM/SPIRVToLLVM.h:21:7: note: class type ‘const mlir::LLVMTypeConverter’ is incomplete
```
