### PR TITLE
[RISCV] Combine RVBUnary and RVKUnary into classes that are more similar to ALU(W)_r(r/i). NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -606,6 +606,16 @@ class Priv_rr<string opcodestr, bits<7> funct7>
   let rd = 0;
 }
 
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Unary_r<bits<12> imm12, bits<3> funct3, string opcodestr>
+    : RVInstIUnary<imm12, funct3, OPC_OP_IMM, (outs GPR:$rd), (ins GPR:$rs1),
+                   opcodestr, "$rd, $rs1">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class UnaryW_r<bits<12> imm12, bits<3> funct3, string opcodestr>
+    : RVInstIUnary<imm12, funct3, OPC_OP_IMM_32, (outs GPR:$rd), (ins GPR:$rs1),
+                   opcodestr, "$rd, $rs1">;
+
 //===----------------------------------------------------------------------===//
 // Instructions
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
@@ -233,12 +233,6 @@ class RVBUnaryR<bits<7> funct7, bits<3> funct3,
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVBUnary<bits<12> imm12, bits<3> funct3,
-               RISCVOpcode opcode, string opcodestr>
-    : RVInstIUnary<imm12, funct3, opcode, (outs GPR:$rd), (ins GPR:$rs1),
-                   opcodestr, "$rd, $rs1">;
-
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVBShift_ri<bits<5> imm11_7, bits<3> funct3, RISCVOpcode opcode,
                   string opcodestr>
     : RVInstIShift<imm11_7, funct3, opcode, (outs GPR:$rd),
@@ -333,27 +327,27 @@ def XPERM8 : ALU_rr<0b0010100, 0b100, "xperm8">,
 } // Predicates = [HasStdExtZbkx]
 
 let Predicates = [HasStdExtZbb], IsSignExtendingOpW = 1 in {
-def CLZ  : RVBUnary<0b011000000000, 0b001, OPC_OP_IMM, "clz">,
+def CLZ  : Unary_r<0b011000000000, 0b001, "clz">,
            Sched<[WriteCLZ, ReadCLZ]>;
-def CTZ  : RVBUnary<0b011000000001, 0b001, OPC_OP_IMM, "ctz">,
+def CTZ  : Unary_r<0b011000000001, 0b001, "ctz">,
            Sched<[WriteCTZ, ReadCTZ]>;
-def CPOP : RVBUnary<0b011000000010, 0b001, OPC_OP_IMM, "cpop">,
+def CPOP : Unary_r<0b011000000010, 0b001, "cpop">,
            Sched<[WriteCPOP, ReadCPOP]>;
 } // Predicates = [HasStdExtZbb]
 
 let Predicates = [HasStdExtZbb, IsRV64], IsSignExtendingOpW = 1 in {
-def CLZW   : RVBUnary<0b011000000000, 0b001, OPC_OP_IMM_32, "clzw">,
-             Sched<[WriteCLZ32, ReadCLZ32]>;
-def CTZW   : RVBUnary<0b011000000001, 0b001, OPC_OP_IMM_32, "ctzw">,
-             Sched<[WriteCTZ32, ReadCTZ32]>;
-def CPOPW  : RVBUnary<0b011000000010, 0b001, OPC_OP_IMM_32, "cpopw">,
-             Sched<[WriteCPOP32, ReadCPOP32]>;
+def CLZW  : UnaryW_r<0b011000000000, 0b001, "clzw">,
+            Sched<[WriteCLZ32, ReadCLZ32]>;
+def CTZW  : UnaryW_r<0b011000000001, 0b001, "ctzw">,
+            Sched<[WriteCTZ32, ReadCTZ32]>;
+def CPOPW : UnaryW_r<0b011000000010, 0b001, "cpopw">,
+            Sched<[WriteCPOP32, ReadCPOP32]>;
 } // Predicates = [HasStdExtZbb, IsRV64]
 
 let Predicates = [HasStdExtZbb], IsSignExtendingOpW = 1 in {
-def SEXT_B : RVBUnary<0b011000000100, 0b001, OPC_OP_IMM, "sext.b">,
+def SEXT_B : Unary_r<0b011000000100, 0b001, "sext.b">,
              Sched<[WriteIALU, ReadIALU]>;
-def SEXT_H : RVBUnary<0b011000000101, 0b001, OPC_OP_IMM, "sext.h">,
+def SEXT_H : Unary_r<0b011000000101, 0b001, "sext.h">,
              Sched<[WriteIALU, ReadIALU]>;
 } // Predicates = [HasStdExtZbb]
 
@@ -403,28 +397,28 @@ def ZEXT_H_RV64 : RVBUnaryR<0b0000100, 0b100, OPC_OP_32, "zext.h">,
 } // Predicates = [HasStdExtZbb, IsRV64]
 
 let Predicates = [HasStdExtZbbOrZbkb, IsRV32] in {
-def REV8_RV32 : RVBUnary<0b011010011000, 0b101, OPC_OP_IMM, "rev8">,
+def REV8_RV32 : Unary_r<0b011010011000, 0b101, "rev8">,
                 Sched<[WriteREV8, ReadREV8]>;
 } // Predicates = [HasStdExtZbbOrZbkb, IsRV32]
 
 let Predicates = [HasStdExtZbbOrZbkb, IsRV64] in {
-def REV8_RV64 : RVBUnary<0b011010111000, 0b101, OPC_OP_IMM, "rev8">,
+def REV8_RV64 : Unary_r<0b011010111000, 0b101, "rev8">,
                 Sched<[WriteREV8, ReadREV8]>;
 } // Predicates = [HasStdExtZbbOrZbkb, IsRV64]
 
 let Predicates = [HasStdExtZbb] in {
-def ORC_B : RVBUnary<0b001010000111, 0b101, OPC_OP_IMM, "orc.b">,
+def ORC_B : Unary_r<0b001010000111, 0b101, "orc.b">,
             Sched<[WriteORCB, ReadORCB]>;
 } // Predicates = [HasStdExtZbb]
 
 let Predicates = [HasStdExtZbkb] in
-def BREV8 : RVBUnary<0b011010000111, 0b101, OPC_OP_IMM, "brev8">,
+def BREV8 : Unary_r<0b011010000111, 0b101, "brev8">,
             Sched<[WriteBREV8, ReadBREV8]>;
 
 let Predicates = [HasStdExtZbkb, IsRV32] in {
-def ZIP_RV32   : RVBUnary<0b000010001111, 0b001, OPC_OP_IMM, "zip">,
+def ZIP_RV32   : Unary_r<0b000010001111, 0b001, "zip">,
                  Sched<[WriteZIP, ReadZIP]>;
-def UNZIP_RV32 : RVBUnary<0b000010001111, 0b101, OPC_OP_IMM, "unzip">,
+def UNZIP_RV32 : Unary_r<0b000010001111, 0b101, "unzip">,
                  Sched<[WriteZIP, ReadZIP]>;
 } // Predicates = [HasStdExtZbkb, IsRV32]
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZk.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZk.td
@@ -52,10 +52,6 @@ def byteselect : RISCVOp<i32>, TImmLeaf<i32, [{return isUInt<2>(Imm);}]> {
 //===----------------------------------------------------------------------===//
 // Instruction class templates
 //===----------------------------------------------------------------------===//
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVKUnary<bits<12> imm12, bits<3> funct3, string opcodestr>
-    : RVInstIUnary<imm12, funct3, OPC_OP_IMM, (outs GPR:$rd), (ins GPR:$rs1),
-                   opcodestr, "$rd, $rs1">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVKByteSelect<bits<5> funct5, string opcodestr>
@@ -88,7 +84,7 @@ let Predicates = [HasStdExtZknd, IsRV64] in {
 def AES64DS  : ALU_rr<0b0011101, 0b000, "aes64ds">;
 def AES64DSM : ALU_rr<0b0011111, 0b000, "aes64dsm">;
 
-def AES64IM  : RVKUnary<0b001100000000, 0b001, "aes64im">;
+def AES64IM  : Unary_r<0b001100000000, 0b001, "aes64im">;
 } // Predicates = [HasStdExtZknd, IsRV64]
 
 let Predicates = [HasStdExtZkndOrZkne, IsRV64] in {
@@ -108,10 +104,10 @@ def AES64ESM  : ALU_rr<0b0011011, 0b000, "aes64esm">;
 } // Predicates = [HasStdExtZkne, IsRV64]
 
 let Predicates = [HasStdExtZknh], IsSignExtendingOpW = 1 in {
-def SHA256SIG0 : RVKUnary<0b000100000010, 0b001, "sha256sig0">;
-def SHA256SIG1 : RVKUnary<0b000100000011, 0b001, "sha256sig1">;
-def SHA256SUM0 : RVKUnary<0b000100000000, 0b001, "sha256sum0">;
-def SHA256SUM1 : RVKUnary<0b000100000001, 0b001, "sha256sum1">;
+def SHA256SIG0 : Unary_r<0b000100000010, 0b001, "sha256sig0">;
+def SHA256SIG1 : Unary_r<0b000100000011, 0b001, "sha256sig1">;
+def SHA256SUM0 : Unary_r<0b000100000000, 0b001, "sha256sum0">;
+def SHA256SUM1 : Unary_r<0b000100000001, 0b001, "sha256sum1">;
 } // Predicates = [HasStdExtZknh]
 
 let Predicates = [HasStdExtZknh, IsRV32] in {
@@ -124,10 +120,10 @@ def SHA512SUM1R : ALU_rr<0b0101001, 0b000, "sha512sum1r">;
 } // [HasStdExtZknh, IsRV32]
 
 let Predicates = [HasStdExtZknh, IsRV64] in {
-def SHA512SIG0 : RVKUnary<0b000100000110, 0b001, "sha512sig0">;
-def SHA512SIG1 : RVKUnary<0b000100000111, 0b001, "sha512sig1">;
-def SHA512SUM0 : RVKUnary<0b000100000100, 0b001, "sha512sum0">;
-def SHA512SUM1 : RVKUnary<0b000100000101, 0b001, "sha512sum1">;
+def SHA512SIG0 : Unary_r<0b000100000110, 0b001, "sha512sig0">;
+def SHA512SIG1 : Unary_r<0b000100000111, 0b001, "sha512sig1">;
+def SHA512SUM0 : Unary_r<0b000100000100, 0b001, "sha512sum0">;
+def SHA512SUM1 : Unary_r<0b000100000101, 0b001, "sha512sum1">;
 } // Predicates = [HasStdExtZknh, IsRV64]
 
 let Predicates = [HasStdExtZksed], IsSignExtendingOpW = 1 in {
@@ -136,8 +132,8 @@ def SM4KS : RVKByteSelect<0b11010, "sm4ks">;
 } // Predicates = [HasStdExtZksed]
 
 let Predicates = [HasStdExtZksh], IsSignExtendingOpW = 1 in {
-def SM3P0 : RVKUnary<0b000100001000, 0b001, "sm3p0">;
-def SM3P1 : RVKUnary<0b000100001001, 0b001, "sm3p1">;
+def SM3P0 : Unary_r<0b000100001000, 0b001, "sm3p0">;
+def SM3P1 : Unary_r<0b000100001001, 0b001, "sm3p1">;
 } // Predicates = [HasStdExtZksh]
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Create Unary_r and UnaryW_r that use OP_IMM and OP_IMM_32.