### PR TITLE
[doc] Fix Kaleidoscope tutorial chapter 3 code snippet and full listing discrepancies

### DIFF
--- a/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl03.rst
+++ b/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl03.rst
@@ -74,7 +74,7 @@ parser, which will be used to report errors found during code generation
 .. code-block:: c++
 
     static std::unique_ptr<LLVMContext> TheContext;
-    static std::unique_ptr<IRBuilder<>> Builder(TheContext);
+    static std::unique_ptr<IRBuilder<>> Builder;
     static std::unique_ptr<Module> TheModule;
     static std::map<std::string, Value *> NamedValues;
 
@@ -171,7 +171,7 @@ variables <LangImpl07.html#user-defined-local-variables>`_.
       case '<':
         L = Builder->CreateFCmpULT(L, R, "cmptmp");
         // Convert bool 0/1 to double 0.0 or 1.0
-        return Builder->CreateUIToFP(L, Type::getDoubleTy(TheContext),
+        return Builder->CreateUIToFP(L, Type::getDoubleTy(*TheContext),
                                      "booltmp");
       default:
         return LogErrorV("invalid binary operator");


### PR DESCRIPTION
Kaleidoscope tutorial [chapter 3](https://llvm.org/docs/tutorial/MyFirstLanguageFrontend/LangImpl03.html) contains two discrepancies between snippets and full listing.

This is a fix for the following discrepancies:

1. 
https://github.com/llvm/llvm-project/blob/fb0ef6b66e3c7e91481568c15ed67c047dab84e1/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl03.rst?plain=1#L77
https://github.com/llvm/llvm-project/blob/fb0ef6b66e3c7e91481568c15ed67c047dab84e1/llvm/examples/Kaleidoscope/Chapter3/toy.cpp#L404

2.
https://github.com/llvm/llvm-project/blob/fb0ef6b66e3c7e91481568c15ed67c047dab84e1/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl03.rst?plain=1#L174
https://github.com/llvm/llvm-project/blob/fb0ef6b66e3c7e91481568c15ed67c047dab84e1/llvm/examples/Kaleidoscope/Chapter3/toy.cpp#L440