### PR TITLE
[X86] Add AMD Llano family detection

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/x86.c
+++ b/compiler-rt/lib/builtins/cpu_model/x86.c
@@ -649,6 +649,7 @@ static const char *getAMDProcessorTypeAndSubtype(unsigned Family,
     CPU = "k8";
     break;
   case 16:
+  case 18:
     CPU = "amdfam10";
     *Type = AMDFAM10H; // "amdfam10"
     switch (Model) {

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1050,6 +1050,7 @@ static const char *getAMDProcessorTypeAndSubtype(unsigned Family,
     CPU = "k8";
     break;
   case 16:
+  case 18:
     CPU = "amdfam10";
     *Type = X86::AMDFAM10H; // "amdfam10"
     switch (Model) {


### PR DESCRIPTION
Very simple one liner, adds the missing detection for the Llano family which is essentially a refreshed K10:
Documentation of the family id: https://en.wikichip.org/wiki/amd/cpuid#Family_18_.2812h.29
Documentation that it fits into amdfam10: https://en.wikipedia.org/wiki/AMD_10h#12h
