### PR TITLE
[AST] Avoid repeated hash lookups (NFC)

### DIFF
--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -259,12 +259,10 @@ bool CXXBasePaths::lookupInBases(ASTContext &Context,
             BaseRecord = TD->getTemplatedDecl();
         }
         if (BaseRecord) {
-          if (!BaseRecord->hasDefinition() ||
-              VisitedDependentRecords.count(BaseRecord)) {
+          if (!BaseRecord->hasDefinition())
             BaseRecord = nullptr;
-          } else {
-            VisitedDependentRecords.insert(BaseRecord);
-          }
+          else if (!VisitedDependentRecords.insert(BaseRecord).second)
+            BaseRecord = nullptr;
         }
       } else {
         BaseRecord = cast<CXXRecordDecl>(


### PR DESCRIPTION
Here I'm splitting up the existing "if" statement into two.  Mixing
hasDefinition() and insert() in one "if" condition would be extremely
confusing as hasDefinition() doesn't change anything while insert()
does.
