### PR TITLE
[Driver] Use empty multilib file in another test

### DIFF
--- a/clang/test/Driver/aarch64-multilib-rcpc3.c
+++ b/clang/test/Driver/aarch64-multilib-rcpc3.c
@@ -1,4 +1,4 @@
-// RUN: %clang --target=aarch64-none-elf -march=armv8.9-a+rcpc3 -print-multi-flags-experimental -c %s 2>&1 | FileCheck %s
+// RUN: %clang --target=aarch64-none-elf -march=armv8.9-a+rcpc3 -print-multi-flags-experimental -multi-lib-config=%S/Inputs/multilib/empty.yaml -c %s 2>&1 | FileCheck %s
 
 // The purpose of this regression test is to make sure that when
 // compile options are converted into multilib selection flags, no


### PR DESCRIPTION
This makes the test independent of the one provided by a toolchain clang is built into, which can cause the output of
-print-multi-flags-experimental to change.