### PR TITLE
[lldb] Make libc++ simulator tests compatible with category-based ski…

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
@@ -46,7 +46,9 @@ class LibcxxOptionalDataFormatterSimulatorTestCase(TestBase):
 for r in range(2):
     name = f"test_r{r}"
     defines = [f"REVISION={r}"]
-    f = functools.partialmethod(
-        LibcxxOptionalDataFormatterSimulatorTestCase._run_test, defines
-    )
-    setattr(LibcxxOptionalDataFormatterSimulatorTestCase, name, f)
+
+    @functools.wraps(LibcxxOptionalDataFormatterSimulatorTestCase._run_test)
+    def test_method(self, defines=defines):
+        LibcxxOptionalDataFormatterSimulatorTestCase._run_test(self, defines)
+
+    setattr(LibcxxOptionalDataFormatterSimulatorTestCase, name, test_method)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -34,7 +34,9 @@ for v in [None, "ALTERNATE_LAYOUT"]:
             if v:
                 name += "_" + v
                 defines += [v]
-            f = functools.partialmethod(
-                LibcxxStringDataFormatterSimulatorTestCase._run_test, defines
-            )
-            setattr(LibcxxStringDataFormatterSimulatorTestCase, name, f)
+
+            @functools.wraps(LibcxxStringDataFormatterSimulatorTestCase._run_test)
+            def test_method(self, defines=defines):
+                LibcxxStringDataFormatterSimulatorTestCase._run_test(self, defines)
+
+            setattr(LibcxxStringDataFormatterSimulatorTestCase, name, test_method)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
@@ -29,7 +29,9 @@ class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
 for r in range(3):
     name = "test_r%d" % r
     defines = ["COMPRESSED_PAIR_REV=%d" % r]
-    f = functools.partialmethod(
-        LibcxxUniquePtrDataFormatterSimulatorTestCase._run_test, defines
-    )
-    setattr(LibcxxUniquePtrDataFormatterSimulatorTestCase, name, f)
+
+    @functools.wraps(LibcxxUniquePtrDataFormatterSimulatorTestCase._run_test)
+    def test_method(self, defines=defines):
+        LibcxxUniquePtrDataFormatterSimulatorTestCase._run_test(self, defines)
+
+    setattr(LibcxxUniquePtrDataFormatterSimulatorTestCase, name, test_method)


### PR DESCRIPTION
…pping, which works by setting a field on the function object. This doesn't work on a functools.partial object. Use a real function instead.