### PR TITLE
[Flang][OpenMP] Add some semantic checks for Linear clause

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -3568,6 +3568,15 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
     }
   }
 
+  // OpenMP 5.2: Ordered clause restriction
+  if (const auto *clause{
+          FindClause(GetContext(), llvm::omp::Clause::OMPC_ordered)}) {
+    const auto &orderedClause{std::get<parser::OmpClause::Ordered>(clause->u)};
+    if (orderedClause.v) {
+      return;
+    }
+  }
+
   auto checkForValidLinearClause_01 = [&](const parser::Name &name,
                                           bool is_ref) {
     std::string listItemName{name.ToString()};

--- a/flang/test/Examples/omp-declarative-directive.f90
+++ b/flang/test/Examples/omp-declarative-directive.f90
@@ -7,7 +7,7 @@
 ! 2.8.2 declare-simd
 
 subroutine declare_simd_1(a, b)
-  real(8), intent(inout) :: a, b
+  real(8), intent(inout), allocatable :: a, b
   !$omp declare simd(declare_simd_1) aligned(a)
   a = 3.14 + b
 end subroutine declare_simd_1

--- a/flang/test/Semantics/OpenMP/declarative-directive01.f90
+++ b/flang/test/Semantics/OpenMP/declarative-directive01.f90
@@ -23,6 +23,7 @@ end subroutine requires_2
 
 subroutine declare_simd_1(a, b)
   real(8), intent(inout) :: a, b
+  !ERROR: 'a' in ALIGNED clause must be of type C_PTR, POINTER or ALLOCATABLE
   !$omp declare simd(declare_simd_1) aligned(a)
   a = 3.14 + b
 end subroutine declare_simd_1

--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -1,0 +1,45 @@
+! REQUIRES: openmp_runtime
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags
+! OpenMP Version 5.2
+! Various checks for the linear clause
+! 5.4.6 `linear` Clause
+
+! Case 1
+subroutine linear_clause_01(arg)
+    integer, intent(in) :: arg(:)
+    !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
+    !$omp do linear(uval(arg))
+    do i = 1, 5
+        print *, arg(i)
+    end do
+end subroutine linear_clause_01
+
+! Case 2
+subroutine linear_clause_02(arg_01, arg_02)
+    !ERROR: The list item `arg_01` specified with other than linear-modifier `REF` must be of type INTEGER
+    !$omp declare simd linear(val(arg_01))
+    real, intent(in) :: arg_01(:)
+
+    !ERROR: The list item `arg_02` specified with the linear-modifier `REF` or `UVAL` must be a dummy argument without `VALUE` attribute
+    !$omp declare simd linear(uval(arg_02))
+    integer, value, intent(in) :: arg_02
+
+    !ERROR: The list item `var` must be a dummy argument
+    !ERROR: The list item `var` in a LINEAR clause must not be Cray Pointer or a variable with POINTER attribute
+    !$omp declare simd linear(uval(var))
+    integer, pointer :: var
+end subroutine linear_clause_02
+
+! Case 3
+subroutine linear_clause_03(arg)
+    integer, intent(in) :: arg
+    !ERROR: The list item `arg` specified with the linear-modifier `REF` must be polymorphic variable, assumed-shape array, or a variable with the `ALLOCATABLE` attribute
+    !ERROR: List item 'arg' present at multiple LINEAR clauses
+    !$omp declare simd linear(ref(arg)) linear(arg)
+
+    integer :: i
+    common /cc/ i
+    !ERROR: The list item `i` must be a dummy argument
+    !ERROR: 'i' is a common block name and must not appear in an LINEAR clause
+    !$omp declare simd linear(i)
+end subroutine linear_clause_03


### PR DESCRIPTION
This PR adds all the missing semantics for the Linear clause based on the OpenMP 5.2 restrictions. The restriction details are mentioned below.

OpenMP 5.2:
5.4.6 linear Clause restrictions
- A linear-modifier may be specified as ref or uval only on a declare simd directive.
- If linear-modifier is not ref, all list items must be of type integer.
- If linear-modifier is ref or uval, all list items must be dummy arguments without the VALUE attribute.
- List items must not be Cray pointers or variables that have the POINTER attribute. Cray pointer support has been deprecated.
- If linear-modifier is ref, list items must be polymorphic variables, assumed-shape arrays, or variables with the ALLOCATABLE attribute. 
- A common block name must not appear in a linear clause.
- The list-item cannot appear more than once

4.4.4 ordered Clause restriction
- If n is explicitly specified, a linear clause must not be specified on the same directive.

5.11 aligned Clause restriction
- Each list item must have C_PTR or Cray pointer type or have the POINTER or ALLOCATABLE attribute. Cray pointer support has been deprecated.