### PR TITLE
[CodeGen] LiveIntervalUnions::Array  Implement move constructor

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveIntervalUnion.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervalUnion.h
@@ -176,6 +176,13 @@ public:
     Array() = default;
     ~Array() { clear(); }
 
+    Array(Array &&Other) : Size(Other.Size), LIUs(Other.LIUs) {
+      Other.Size = 0;
+      Other.LIUs = nullptr;
+    }
+
+    Array(const Array &) = delete;
+
     // Initialize the array to have Size entries.
     // Reuse an existing allocation if the size matches.
     void init(LiveIntervalUnion::Allocator&, unsigned Size);


### PR DESCRIPTION
Solves the double free error.