### PR TITLE
[modules][test] Bump maximum size for embed-files-compressed.cpp for the sake of RISC-V

### DIFF
--- a/clang/test/Modules/embed-files-compressed.cpp
+++ b/clang/test/Modules/embed-files-compressed.cpp
@@ -17,7 +17,7 @@
 // RUN: %clang_cc1 -fmodules -I%t -fmodules-cache-path=%t -fmodule-name=a -emit-module %t/modulemap -fmodules-embed-all-files -o %t/a.pcm
 //
 // The above embeds ~4.5MB of highly-predictable /s and \ns into the pcm file.
-// Check that the resulting file is under 60KB:
+// Check that the resulting file is under 80KB:
 //
 // RUN: wc -c %t/a.pcm | FileCheck --check-prefix=CHECK-SIZE %s
-// CHECK-SIZE: {{(^|[^0-9])[1-5][0-9][0-9][0-9][0-9]($|[^0-9])}}
+// CHECK-SIZE: {{(^|[^0-9])[1-7][0-9][0-9][0-9][0-9]($|[^0-9])}}


### PR DESCRIPTION
The size of a.pcm produced by an RV64 clang running natively is 67416 bytes, causing this test to fail. Bump up the maximum size. The test still retains its original intent as far as I can see, as it's really trying to ensure that compressing kicks in and reduces the multi-megabyte input.