### PR TITLE
[clang][python] Add CLANG_DISABLE_RUN_PYTHON_TESTS CMake option to disable clang python bindings tests

### DIFF
--- a/clang/bindings/python/tests/CMakeLists.txt
+++ b/clang/bindings/python/tests/CMakeLists.txt
@@ -47,6 +47,12 @@ if(${LLVM_NATIVE_ARCH} MATCHES "^(AArch64|Hexagon|Sparc|SystemZ)$")
   set(RUN_PYTHON_TESTS FALSE)
 endif()
 
+# Allow user to explicitly disable these tests.
+option(CLANG_DISABLE_RUN_PYTHON_TESTS "Do not run Clang Python bindings tests" OFF)
+if(CLANG_DISABLE_RUN_PYTHON_TESTS)
+  set(RUN_PYTHON_TESTS FALSE)
+endif()
+
 if(RUN_PYTHON_TESTS)
     set_property(GLOBAL APPEND PROPERTY
                  LLVM_ALL_ADDITIONAL_TEST_TARGETS check-clang-python)


### PR DESCRIPTION
We already have hard-coded logic to disable adding these tests to the `check-all` target in various cases. It's handy to have a CMake option to disable if in an environment where the tests don't work and you want `check-all` to work as expected.

---
By my understanding there's no ability to treat CMake options as tri-state, where I'd be able to tell if it was explicitly st to ON, explicitly set to OFF, or left to the default. So the new option is just "force disable" rather than allowing a force enable/

CC also @linux4life798 as another contributor I can see from the commit logs.

--- 
Closed in favour of https://github.com/llvm/llvm-project/pull/111657