### PR TITLE
[libclc] Update build instructions in readme

### DIFF
--- a/libclc/README.TXT
+++ b/libclc/README.TXT
@@ -23,28 +23,40 @@ generic implementations of most library requirements, allowing the target
 to override the generic implementation at the granularity of individual
 functions.
 
-libclc currently only supports the PTX target, but support for more
+libclc currently supports NVPTX, AMDGPU and SPIRV targets, but support for more
 targets is welcome.
 
-Compiling and installing with Make
-----------------------------------
+Compiling and installing
+------------------------
 
-$ ./configure.py --with-llvm-config=/path/to/llvm-config && make
-$ make install
+(in the following instructions you can use make or ninja)
+
+For an in-tree build, Clang must also be built at the same time:
+
+$ cmake <path-to>/llvm-project/llvm/CMakeLists.txt -DLLVM_ENABLE_PROJECTS="libclc;clang" \
+    -DCMAKE_BUILD_TYPE=Release -G Ninja
+$ ninja
+
+Then install:
+
+$ ninja install
 
 Note you can use the DESTDIR Makefile variable to do staged installs.
 
-$ make install DESTDIR=/path/for/staged/install
-
-Compiling and installing with Ninja
------------------------------------
-
-$ ./configure.py -g ninja --with-llvm-config=/path/to/llvm-config && ninja
-$ ninja install
-
-Note you can use the DESTDIR environment variable to do staged installs.
-
 $ DESTDIR=/path/for/staged/install ninja install
+
+To build against an existing LLVM build or install:
+
+$ cmake <path-to>/llvm-project/libclc/CMakeLists.txt -DCMAKE_BUILD_TYPE=Release \
+  -G Ninja -DLLVM_DIR=$(<path-to>/llvm-config --cmakedir)
+$ ninja
+
+Then install as before.
+
+In both cases, the LLVM used must include the targets you want libclc support for.
+AMDGPU and NVPTX are enabled in LLVM by default, but SPIRV must be enabled by
+passing `-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV` to CMake when configuring
+LLVM.
 
 Website
 -------

--- a/libclc/README.TXT
+++ b/libclc/README.TXT
@@ -23,8 +23,8 @@ generic implementations of most library requirements, allowing the target
 to override the generic implementation at the granularity of individual
 functions.
 
-libclc currently supports NVPTX, AMDGPU and SPIRV targets, but support for more
-targets is welcome.
+libclc currently supports PTX, AMDGPU, SPIRV and CLSPV targets, but support for
+more targets is welcome.
 
 Compiling and installing
 ------------------------
@@ -45,7 +45,7 @@ Note you can use the DESTDIR Makefile variable to do staged installs.
 
 $ DESTDIR=/path/for/staged/install ninja install
 
-To build against an existing LLVM build or install:
+To build out of tree, or in other words, against an existing LLVM build or install:
 
 $ cmake <path-to>/llvm-project/libclc/CMakeLists.txt -DCMAKE_BUILD_TYPE=Release \
   -G Ninja -DLLVM_DIR=$(<path-to>/llvm-config --cmakedir)
@@ -53,10 +53,15 @@ $ ninja
 
 Then install as before.
 
-In both cases, the LLVM used must include the targets you want libclc support for.
-AMDGPU and NVPTX are enabled in LLVM by default, but SPIRV must be enabled by
-passing `-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV` to CMake when configuring
-LLVM.
+In both cases this will include all supported targets. You can choose which
+targets are enabled by passing `-DLIBCLC_TARGETS_TO_BUILD` to CMake. The default
+is "all".
+
+In both cases, the LLVM used must include the targets you want libclc support for
+(AMDGPU and NVPTX are enabled in LLVM by default). Apart from SPIRV where you do
+not need an LLVM target but you do need the llvm-spirv tool
+(https://github.com/KhronosGroup/SPIRV-LLVM-Translator) available. Either build
+this in-tree, or place it in the directory pointed to by `LLVM_TOOLS_BINARY_DIR`.
 
 Website
 -------


### PR DESCRIPTION
The configure Python script was removed by
d6e0e6d255a7d54a3873b7a5d048eee00ef6bb6d / https://reviews.llvm.org/D69966.

The readme was never updated with the cmake way to do it. I couldn't find any dedicated buildbots for this so I'm making an educated guess. This is what built locally for me.