### PR TITLE
Revert "[libc][bazel] Enable software prefetching for memcpy"

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
@@ -24,7 +24,7 @@ LIBC_CONFIGURE_OPTIONS = [
     # Documentation in libc/src/string/memory_utils/...
     # "LIBC_COPT_MEMCPY_USE_EMBEDDED_TINY",
     # "LIBC_COPT_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE",
-    "LIBC_COPT_MEMCPY_X86_USE_SOFTWARE_PREFETCHING",
+    # "LIBC_COPT_MEMCPY_X86_USE_SOFTWARE_PREFETCHING",
     "LIBC_COPT_MEMSET_X86_USE_SOFTWARE_PREFETCHING",
 
     # Documentation in libc/docs/dev/printf_behavior.rst


### PR DESCRIPTION
Reverts llvm/llvm-project#108939

When `AVX` is available but `-mprefer-vector-width=128` some of the `mov` instructions turn into the x86 `rep;movsb` instruction leading to poor performance on "old" architectures (sandybridge, haswell). The possible solutions are : get rid of the `-mprefer-vector-width` option or use smaller static copy sizes in `inline_memcpy_x86_sse2_ge64_sw_prefetching`. Right now a copy size of 3 cache lines (192B) relying exclusively on xmm registers gets turned into `rep;movsb`.