### PR TITLE
[libclc] Remove mention of BSD license in readme

### DIFF
--- a/libclc/README.TXT
+++ b/libclc/README.TXT
@@ -1,7 +1,7 @@
 libclc
 ------
 
-libclc is an open source, BSD licensed implementation of the library
+libclc is an open source implementation of the library
 requirements of the OpenCL C programming language, as specified by the
 OpenCL 1.1 Specification. The following sections of the specification
 impose library requirements:


### PR DESCRIPTION
This seems to be an artifact from the intial import in 2012, but even if not, folks are better off reading the LICENSE.TXT file for the full details if they need them.

Fixes #109968