### PR TITLE
[lit] Allow passthrough of some QEMU_* environment variables to lit

### DIFF
--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -64,6 +64,8 @@ class TestingConfig(object):
             "SOURCE_DATE_EPOCH",
             "GTEST_FILTER",
             "DFLTCC",
+            "QEMU_LD_PREFIX",
+            "QEMU_CPU",
         ]
 
         if sys.platform.startswith("aix"):


### PR DESCRIPTION
This is an alternate implementation of a patch proposed by @preames in <https://reviews.llvm.org/D128840>. As noted there, when running non-native binaries with binfmt_misc and qemu-user you typically need to set some environment variables (at least, QEMU_LD_PREFIX), but lit strips them by default. This patch adds what I think are the two main ones to the list of those that aren't stripped. It does so in a place that applies to all lit test suites (rather than just LLVM's), and as can be seen from the other env vars in `pass_vars` I think there's already plenty of precedent for passing through environment variables known to be potentially useful to LLVM developers.