### PR TITLE
Added include of common interfaces

### DIFF
--- a/compiler-rt/include/sanitizer/ubsan_interface.h
+++ b/compiler-rt/include/sanitizer/ubsan_interface.h
@@ -13,6 +13,8 @@
 #ifndef SANITIZER_UBSAN_INTERFACE_H
 #define SANITIZER_UBSAN_INTERFACE_H
 
+#include <sanitizer/common_interface_defs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Pull request for issue #110823 
Including the file which defines the macros we use here. This would let user code only include this interface, rather than having to include two files.