### PR TITLE
[clang-include-cleaner] Fix incorrect directory issue for writing files

### DIFF
--- a/clang-tools-extra/include-cleaner/test/tool.cpp
+++ b/clang-tools-extra/include-cleaner/test/tool.cpp
@@ -38,6 +38,17 @@ int x = foo();
 //      PRINT: #include "foo.h"
 //  PRINT-NOT: {{^}}#include "foobar.h"{{$}}
 
+//        RUN: cp %s %t.cpp
+//        RUN: clang-include-cleaner -edit %t.cpp -- -I%S/Inputs/
+//        RUN: FileCheck --match-full-lines --check-prefix=EDIT %s < %t.cpp
+//       EDIT: #include "foo.h"
+//   EDIT-NOT: {{^}}#include "foobar.h"{{$}}
+
+//        RUN: cp %s %t.cpp
+//        RUN: clang-include-cleaner -edit --ignore-headers="foobar\.h,foo\.h" %t.cpp -- -I%S/Inputs/ 
+//        RUN: FileCheck --match-full-lines --check-prefix=EDIT2 %s < %t.cpp
+//  EDIT2-NOT: {{^}}#include "foo.h"{{$}}
+
 //        RUN: mkdir -p $(dirname %t)/out
 //        RUN: cp %s %t.cpp
 //        RUN: echo "[{\"directory\":\"$(dirname %t)/out\",\"file\":\"../$(basename %t).cpp\",\"command\":\":clang++ -I%S/Inputs/ ../$(basename %t).cpp\"}]" > $(dirname %t)/out/compile_commands.json

--- a/clang-tools-extra/include-cleaner/test/tool.cpp
+++ b/clang-tools-extra/include-cleaner/test/tool.cpp
@@ -38,13 +38,12 @@ int x = foo();
 //      PRINT: #include "foo.h"
 //  PRINT-NOT: {{^}}#include "foobar.h"{{$}}
 
+//        RUN: mkdir -p $(dirname %t)/out
 //        RUN: cp %s %t.cpp
-//        RUN: clang-include-cleaner -edit %t.cpp -- -I%S/Inputs/
-//        RUN: FileCheck --match-full-lines --check-prefix=EDIT %s < %t.cpp
-//       EDIT: #include "foo.h"
-//   EDIT-NOT: {{^}}#include "foobar.h"{{$}}
-
-//        RUN: cp %s %t.cpp
-//        RUN: clang-include-cleaner -edit --ignore-headers="foobar\.h,foo\.h" %t.cpp -- -I%S/Inputs/ 
-//        RUN: FileCheck --match-full-lines --check-prefix=EDIT2 %s < %t.cpp
-//  EDIT2-NOT: {{^}}#include "foo.h"{{$}}
+//        RUN: echo "[{\"directory\":\"$(dirname %t)/out\",\"file\":\"../$(basename %t).cpp\",\"command\":\":clang++ -I%S/Inputs/ ../$(basename %t).cpp\"}]" > $(dirname %t)/out/compile_commands.json
+//       RUN: pushd $(dirname %t)
+//       RUN: clang-include-cleaner -p out -edit $(basename %t).cpp
+//       RUN: popd
+//       RUN: FileCheck --match-full-lines --check-prefix=EDIT3 %s < %t.cpp
+//     EDIT3: #include "foo.h"
+// EDIT3-NOT: {{^}}#include "foobar.h"{{$}}

--- a/clang-tools-extra/include-cleaner/test/tool.cpp
+++ b/clang-tools-extra/include-cleaner/test/tool.cpp
@@ -49,14 +49,11 @@ int x = foo();
 //        RUN: FileCheck --match-full-lines --check-prefix=EDIT2 %s < %t.cpp
 //  EDIT2-NOT: {{^}}#include "foo.h"{{$}}
 
-// This test has commands that rely on shell capabilities that won't execute
-// correctly on Windows e.g. subshell execution
-//   REQUIRES: shell
-//        RUN: mkdir -p $(dirname %t)/out
+//        RUN: rm -rf %t.dir && mkdir -p %t.dir
 //        RUN: cp %s %t.cpp
-//        RUN: echo "[{\"directory\":\"$(dirname %t)/out\",\"file\":\"../$(basename %t).cpp\",\"command\":\":clang++ -I%S/Inputs/ ../$(basename %t).cpp\"}]" > $(dirname %t)/out/compile_commands.json
-//        RUN: pushd $(dirname %t)
-//        RUN: clang-include-cleaner -p out -edit $(basename %t).cpp
+//        RUN: echo "[{\"directory\":\"%t.dir\",\"file\":\"../%{t:stem}.tmp.cpp\",\"command\":\":clang++ -I%S/Inputs/ ../%{t:stem}.tmp.cpp\"}]" | sed -e 's/\\/\\\\/g' > %t.dir/compile_commands.json
+//        RUN: pushd %t.dir
+//        RUN: clang-include-cleaner -p %{t:stem}.tmp.dir -edit ../%{t:stem}.tmp.cpp
 //        RUN: popd
 //        RUN: FileCheck --match-full-lines --check-prefix=EDIT3 %s < %t.cpp
 //      EDIT3: #include "foo.h"

--- a/clang-tools-extra/include-cleaner/test/tool.cpp
+++ b/clang-tools-extra/include-cleaner/test/tool.cpp
@@ -49,12 +49,15 @@ int x = foo();
 //        RUN: FileCheck --match-full-lines --check-prefix=EDIT2 %s < %t.cpp
 //  EDIT2-NOT: {{^}}#include "foo.h"{{$}}
 
+// This test has commands that rely on shell capabilities that won't execute
+// correctly on Windows e.g. subshell execution
+//   REQUIRES: shell
 //        RUN: mkdir -p $(dirname %t)/out
 //        RUN: cp %s %t.cpp
 //        RUN: echo "[{\"directory\":\"$(dirname %t)/out\",\"file\":\"../$(basename %t).cpp\",\"command\":\":clang++ -I%S/Inputs/ ../$(basename %t).cpp\"}]" > $(dirname %t)/out/compile_commands.json
-//       RUN: pushd $(dirname %t)
-//       RUN: clang-include-cleaner -p out -edit $(basename %t).cpp
-//       RUN: popd
-//       RUN: FileCheck --match-full-lines --check-prefix=EDIT3 %s < %t.cpp
-//     EDIT3: #include "foo.h"
-// EDIT3-NOT: {{^}}#include "foobar.h"{{$}}
+//        RUN: pushd $(dirname %t)
+//        RUN: clang-include-cleaner -p out -edit $(basename %t).cpp
+//        RUN: popd
+//        RUN: FileCheck --match-full-lines --check-prefix=EDIT3 %s < %t.cpp
+//      EDIT3: #include "foo.h"
+//  EDIT3-NOT: {{^}}#include "foobar.h"{{$}}

--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -282,6 +282,48 @@ std::function<bool(llvm::StringRef)> headerFilter() {
   };
 }
 
+// Maps absolute path of each files of each compilation commands to the
+// absolute path of the input file.
+llvm::Expected<std::map<std::string, std::string>>
+mapInputsToAbsPaths(clang::tooling::CompilationDatabase &CDB,
+                    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
+                    const std::vector<std::string> &Inputs) {
+  std::map<std::string, std::string> CDBToAbsPaths;
+  // Factory.editedFiles()` will contain the final code, along with the
+  // path given in the compilation database. That path can be
+  // absolute or relative, and if it is relative, it is relative to the
+  // "Directory" field in the compilation database. We need to make it
+  // absolute to write the final code to the correct path.
+  for (auto &Source : Inputs) {
+    llvm::SmallString<256> AbsPath(Source);
+    if (auto Err = VFS->makeAbsolute(AbsPath)) {
+      llvm::errs() << "Failed to get absolute path for " << Source << " : "
+                   << Err.message() << '\n';
+      return std::move(llvm::errorCodeToError(Err));
+    }
+    std::vector<clang::tooling::CompileCommand> Cmds =
+        CDB.getCompileCommands(AbsPath);
+    if (Cmds.empty()) {
+      // It should be found in the compilation database, even user didn't
+      // specify the compilation database, the `FixedCompilationDatabase` will
+      // create an entry from the arguments. So it is an error if we can't
+      // find the compile commands.
+      std::string ErrorMsg =
+          llvm::formatv("No compile commands found for {0}", AbsPath).str();
+      llvm::errs() << ErrorMsg << '\n';
+      return llvm::make_error<llvm::StringError>(
+          ErrorMsg, llvm::inconvertibleErrorCode());
+    }
+    for (const auto &Cmd : Cmds) {
+      llvm::SmallString<256> CDBPath(Cmd.Filename);
+      std::string Directory(Cmd.Directory);
+      llvm::sys::fs::make_absolute(Cmd.Directory, CDBPath);
+      CDBToAbsPaths[std::string(CDBPath)] = std::string(AbsPath);
+    }
+  }
+  return CDBToAbsPaths;
+}
+
 } // namespace
 } // namespace include_cleaner
 } // namespace clang
@@ -311,40 +353,10 @@ int main(int argc, const char **argv) {
   auto &CDB = OptionsParser->getCompilations();
   // CDBToAbsPaths is a map from the path in the compilation database to the
   // writable absolute path of the file.
-  std::map<std::string, std::string> CDBToAbsPaths;
-  // if Edit is enabled, `Factory.editedFiles()` will contain the final code,
-  // along with the path given in the compilation database. That path can be
-  // absolute or relative, and if it is relative, it is relative to the
-  // "Directory" field in the compilation database. We need to make it
-  // absolute to write the final code to the correct path.
-  for (auto &Source : OptionsParser->getSourcePathList()) {
-    llvm::SmallString<256> AbsPath(Source);
-    if (auto Err = VFS->makeAbsolute(AbsPath)) {
-      llvm::errs() << "Failed to get absolute path for " << Source << " : "
-                   << Err.message() << '\n';
-      return 1;
-    }
-    std::vector<clang::tooling::CompileCommand> Cmds =
-        CDB.getCompileCommands(AbsPath);
-    if (Cmds.empty()) {
-      // Try with the original path.
-      Cmds = CDB.getCompileCommands(Source);
-      if (Cmds.empty()) {
-        // It should be found in the compilation database, even user didn't
-        // specify the compilation database, the `FixedCompilationDatabase` will
-        // create an entry from the arguments. So it is an error if we can't
-        // find the compile commands.
-        llvm::errs() << "No compile commands found for " << Source << '\n';
-        return 1;
-      }
-    }
-    for (const auto &Cmd : Cmds) {
-      llvm::SmallString<256> CDBPath(Cmd.Filename);
-      std::string Directory(Cmd.Directory);
-      llvm::sys::fs::make_absolute(Cmd.Directory, CDBPath);
-      CDBToAbsPaths[std::string(CDBPath)] = std::string(AbsPath);
-    }
-  }
+  auto CDBToAbsPaths =
+      mapInputsToAbsPaths(CDB, VFS, OptionsParser->getSourcePathList());
+  if (!CDBToAbsPaths)
+    return 1;
 
   clang::tooling::ClangTool Tool(CDB, OptionsParser->getSourcePathList());
 
@@ -356,8 +368,8 @@ int main(int argc, const char **argv) {
   if (Edit) {
     for (const auto &NameAndContent : Factory.editedFiles()) {
       llvm::StringRef FileName = NameAndContent.first();
-      if (auto It = CDBToAbsPaths.find(FileName.str());
-          It != CDBToAbsPaths.end())
+      if (auto It = CDBToAbsPaths->find(FileName.str());
+          It != CDBToAbsPaths->end())
         FileName = It->second;
 
       const std::string &FinalCode = NameAndContent.second;

--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -174,7 +174,8 @@ private:
       writeHTML();
 
     // Source File's path of compiler invocation, converted to absolute path.
-    llvm::SmallString<256> AbsPath(SM.getFileEntryRefForID(SM.getMainFileID())->getName());
+    llvm::SmallString<256> AbsPath(
+        SM.getFileEntryRefForID(SM.getMainFileID())->getName());
     assert(!AbsPath.empty() && "Main file path not known?");
     SM.getFileManager().makeAbsolutePath(AbsPath);
     llvm::StringRef Code = SM.getBufferData(SM.getMainFileID());


### PR DESCRIPTION
If the current working directory of `clang-include-cleaner` differs from the directory of the input files specified in the compilation database, it doesn't adjust the input file paths properly. As a result, `clang-include-cleaner` either writes files to the wrong directory or fails to write files altogether.

This pull request fixes the issue by adjusting the input file paths based on the directory specified in the compilation database. If that directory is not writable, `clang-include-cleaner` will write the output relative to the current working directory.

Fixes #110843.