### PR TITLE
[libomp][AIX] Use SO version "1" for AIX libomp

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -212,6 +212,15 @@ if(OPENMP_MSVC_NAME_SCHEME)
     LINK_FLAGS "${LIBOMP_CONFIGURED_LDFLAGS}"
     LINKER_LANGUAGE ${LIBOMP_LINKER_LANGUAGE}
  )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  set(LIBOMP_SHARED_OUTPUT_NAME "omp" CACHE STRING "Output name for the shared libomp runtime library.")
+  set_target_properties(omp PROPERTIES
+    OUTPUT_NAME "${LIBOMP_SHARED_OUTPUT_NAME}"
+    LINK_FLAGS "${LIBOMP_CONFIGURED_LDFLAGS}"
+    LINKER_LANGUAGE ${LIBOMP_LINKER_LANGUAGE}
+    VERSION "1.0"
+    SOVERSION "1"
+  )
 else()
   set_target_properties(omp PROPERTIES
     PREFIX "" SUFFIX "" OUTPUT_NAME "${LIBOMP_LIB_FILE}"
@@ -426,11 +435,7 @@ if(WIN32)
   endforeach()
 else()
 
-  if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
-    install(FILES ${LIBOMP_LIBRARY_DIR}/libomp.a DESTINATION "${OPENMP_INSTALL_LIBDIR}" COMPONENT runtime)
-  else()
-    install(TARGETS omp ${export_to_llvmexports} ${LIBOMP_INSTALL_KIND} DESTINATION "${OPENMP_INSTALL_LIBDIR}")
-  endif()
+  install(TARGETS omp ${export_to_llvmexports} ${LIBOMP_INSTALL_KIND} DESTINATION "${OPENMP_INSTALL_LIBDIR}")
 
   if(${LIBOMP_INSTALL_ALIASES})
     # Create aliases (symlinks) of the library for backwards compatibility


### PR DESCRIPTION
For `libomp` on AIX, we build shared object `libomp.so` first and then archive it into libomp.a. This patch changes to use SO version `1` and name the shared object `libomp.so.1` so that it is consistent with the naming of other shared objects in AIX libraries, e.g., `libc++.so.1` in `libc++.a`. With this change, the change made in commit bde51d9b0d473447ea12fb14924f14ea167eec85 to ensure only `libomp.a` is published on AIX is no longer necessary and is removed.