### PR TITLE
[clang][LLVM Demangler] Add a diagnostic that validates that all mang…

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -462,6 +462,9 @@ ENUM_CODEGENOPT(ZeroCallUsedRegs, llvm::ZeroCallUsedRegs::ZeroCallUsedRegsKind,
 /// non-deleting destructors. (No effect on Microsoft ABI.)
 CODEGENOPT(CtorDtorReturnThis, 1, 0)
 
+/// Whether to issue a diagnostic if a produced mangled name can not be demangled with the LLVM demangler.
+CODEGENOPT(DemanglingFailures, 1, 0)
+
 /// FIXME: Make DebugOptions its own top-level .def file.
 #include "DebugOptions.def"
 

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -463,7 +463,7 @@ ENUM_CODEGENOPT(ZeroCallUsedRegs, llvm::ZeroCallUsedRegs::ZeroCallUsedRegsKind,
 CODEGENOPT(CtorDtorReturnThis, 1, 0)
 
 /// Whether to issue a diagnostic if a produced mangled name can not be demangled with the LLVM demangler.
-CODEGENOPT(DemanglingFailures, 1, 0)
+CODEGENOPT(DiagnosticsDemanglerFailures, 1, 0)
 
 /// FIXME: Make DebugOptions its own top-level .def file.
 #include "DebugOptions.def"

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -384,4 +384,8 @@ def warn_hlsl_langstd_minimal :
   Warning<"support for HLSL language version %0 is incomplete, "
           "recommend using %1 instead">,
   InGroup<HLSLDXCCompat>;
+
+def warn_name_cannot_be_demangled : Warning<
+  "cannot demangle the name '%0'">,
+  InGroup<CXX20Compat>;
 }

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -387,5 +387,5 @@ def warn_hlsl_langstd_minimal :
 
 def warn_name_cannot_be_demangled : Warning<
   "cannot demangle the name '%0'">,
-  InGroup<CXX20Compat>;
+  InGroup<Demangler>;
 }

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1582,3 +1582,6 @@ def ExtractAPIMisuse : DiagGroup<"extractapi-misuse">;
 // Warnings about using the non-standard extension having an explicit specialization
 // with a storage class specifier.
 def ExplicitSpecializationStorageClass : DiagGroup<"explicit-specialization-storage-class">;
+
+// Diagnostics related to the LLVM demangler.
+def Demangler: DiagGroup<"demangler">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1967,6 +1967,10 @@ def fclang_abi_compat_EQ : Joined<["-"], "fclang-abi-compat=">, Group<f_clang_Gr
   Visibility<[ClangOption, CC1Option]>,
   MetaVarName<"<version>">, Values<"<major>.<minor>,latest">,
   HelpText<"Attempt to match the ABI of Clang <version>">;
+def fdemangling_failures: Flag<["-"], "fdemangling-failures">, Group<f_clang_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Produce a diagnostic if clang cannot demangle all the mangled names it generates">,
+  MarshallingInfoFlag<CodeGenOpts<"DemanglingFailures">>;
 def fclasspath_EQ : Joined<["-"], "fclasspath=">, Group<f_Group>;
 def fcolor_diagnostics : Flag<["-"], "fcolor-diagnostics">, Group<f_Group>,
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1967,10 +1967,10 @@ def fclang_abi_compat_EQ : Joined<["-"], "fclang-abi-compat=">, Group<f_clang_Gr
   Visibility<[ClangOption, CC1Option]>,
   MetaVarName<"<version>">, Values<"<major>.<minor>,latest">,
   HelpText<"Attempt to match the ABI of Clang <version>">;
-def fdemangling_failures: Flag<["-"], "fdemangling-failures">, Group<f_clang_Group>,
+def fdiagnostics_demangler_failures: Flag<["-"], "fdiagnostics-demangler-failures">, Group<f_clang_Group>,
   Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Produce a diagnostic if clang cannot demangle all the mangled names it generates">,
-  MarshallingInfoFlag<CodeGenOpts<"DemanglingFailures">>;
+  HelpText<"Produce a diagnostic if clang cannot demangle a mangled name it generates">,
+  MarshallingInfoFlag<CodeGenOpts<"DiagnosticsDemanglerFailures">>;
 def fclasspath_EQ : Joined<["-"], "fclasspath=">, Group<f_Group>;
 def fcolor_diagnostics : Flag<["-"], "fcolor-diagnostics">, Group<f_Group>,
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -41,7 +41,9 @@
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Basic/LangOptions.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TargetInfo.h"
@@ -54,6 +56,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include "llvm/Demangle/Demangle.h"
 #include "llvm/Frontend/OpenMP/OMPIRBuilder.h"
 #include "llvm/IR/AttributeMask.h"
 #include "llvm/IR/CallingConv.h"
@@ -75,6 +78,7 @@
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/TargetParser/X86TargetParser.h"
 #include "llvm/Transforms/Utils/BuildLibCalls.h"
+#include <cassert>
 #include <optional>
 
 using namespace clang;
@@ -2043,6 +2047,15 @@ StringRef CodeGenModule::getMangledName(GlobalDecl GD) {
                  *this,
                  GD.getWithKernelReferenceKind(KernelReferenceKind::Kernel),
                  ND));
+
+  if (getCodeGenOpts().DemanglingFailures &&
+      getContext().getLangOpts().getClangABICompat() >
+          LangOptions::ClangABI::Ver19) {
+    if (llvm::isMangledName(MangledName) &&
+        llvm::demangle(MangledName) == MangledName)
+      Diags.Report(ND->getLocation(), diag::warn_name_cannot_be_demangled)
+          << MangledName;
+  }
 
   auto Result = Manglings.insert(std::make_pair(MangledName, GD));
   return MangledDeclNames[CanonicalGD] = Result.first->first();

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -41,9 +41,7 @@
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/FileManager.h"
-#include "clang/Basic/LangOptions.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TargetInfo.h"
@@ -78,7 +76,6 @@
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/TargetParser/X86TargetParser.h"
 #include "llvm/Transforms/Utils/BuildLibCalls.h"
-#include <cassert>
 #include <optional>
 
 using namespace clang;
@@ -2048,9 +2045,8 @@ StringRef CodeGenModule::getMangledName(GlobalDecl GD) {
                  GD.getWithKernelReferenceKind(KernelReferenceKind::Kernel),
                  ND));
 
-  if (getCodeGenOpts().DemanglingFailures &&
-      getContext().getLangOpts().getClangABICompat() >
-          LangOptions::ClangABI::Ver19) {
+  if (getContext().getLangOpts().getClangABICompat() >
+      LangOptions::ClangABI::Ver19) {
     if (llvm::isMangledName(MangledName) &&
         llvm::demangle(MangledName) == MangledName)
       Diags.Report(ND->getLocation(), diag::warn_name_cannot_be_demangled)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4444,6 +4444,9 @@ static void RenderDiagnosticsOptions(const Driver &D, const ArgList &Args,
 
   Args.addOptOutFlag(CmdArgs, options::OPT_fspell_checking,
                      options::OPT_fno_spell_checking);
+
+  if (Args.hasArg(options::OPT_fdemangling_failures))
+    CmdArgs.push_back("-fdemangling-failures");
 }
 
 DwarfFissionKind tools::getDebugFissionKind(const Driver &D,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4445,8 +4445,8 @@ static void RenderDiagnosticsOptions(const Driver &D, const ArgList &Args,
   Args.addOptOutFlag(CmdArgs, options::OPT_fspell_checking,
                      options::OPT_fno_spell_checking);
 
-  if (Args.hasArg(options::OPT_fdemangling_failures))
-    CmdArgs.push_back("-fdemangling-failures");
+  if (Args.hasArg(options::OPT_fdiagnostics_demangler_failures))
+    CmdArgs.push_back("-fdiagnostics-demangler-failures");
 }
 
 DwarfFissionKind tools::getDebugFissionKind(const Driver &D,

--- a/clang/test/CodeGenCXX/warn-demangling-failure.cpp
+++ b/clang/test/CodeGenCXX/warn-demangling-failure.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -emit-llvm -fdemangling-failures -triple %itanium_abi_triple -o - %s | FileCheck %s
+template <class F> void parallel_loop(F &&f) { f(0); }
+
+//CHECK-LABEL: @main
+int main() {
+  int x;
+  parallel_loop([&](auto y) { // expected-warning {{cannot demangle the name '_ZZ4mainENK3$_0clIiEEDaT_'}}
+#pragma clang __debug captured
+    {
+      x = y;
+    };
+  });
+}

--- a/llvm/include/llvm/Demangle/Demangle.h
+++ b/llvm/include/llvm/Demangle/Demangle.h
@@ -67,6 +67,13 @@ char *dlangDemangle(std::string_view MangledName);
 /// demangling occurred.
 std::string demangle(std::string_view MangledName);
 
+/// Determines if the argument string is a valid mangled name known to the
+/// demangler.
+/// \param Name - reference to a string that is potentially a mangled name.
+/// \returns - true if the argument represents a valid mangled name, false
+/// otherwise.
+bool isMangledName(std::string_view Name);
+
 bool nonMicrosoftDemangle(std::string_view MangledName, std::string &Result,
                           bool CanHaveLeadingDot = true,
                           bool ParseParams = true);

--- a/llvm/lib/Demangle/Demangle.cpp
+++ b/llvm/lib/Demangle/Demangle.cpp
@@ -47,6 +47,16 @@ static bool isRustEncoding(std::string_view S) { return starts_with(S, "_R"); }
 
 static bool isDLangEncoding(std::string_view S) { return starts_with(S, "_D"); }
 
+static bool isMicrosoftEncoding(std::string_view S) {
+  return starts_with(S, '?');
+}
+
+bool llvm::isMangledName(std::string_view Name) {
+  return starts_with(Name, '.') || isItaniumEncoding(Name) ||
+         isRustEncoding(Name) || isDLangEncoding(Name) ||
+         isMicrosoftEncoding(Name);
+}
+
 bool llvm::nonMicrosoftDemangle(std::string_view MangledName,
                                 std::string &Result, bool CanHaveLeadingDot,
                                 bool ParseParams) {

--- a/llvm/lib/Demangle/Demangle.cpp
+++ b/llvm/lib/Demangle/Demangle.cpp
@@ -52,9 +52,8 @@ static bool isMicrosoftEncoding(std::string_view S) {
 }
 
 bool llvm::isMangledName(std::string_view Name) {
-  return starts_with(Name, '.') || isItaniumEncoding(Name) ||
-         isRustEncoding(Name) || isDLangEncoding(Name) ||
-         isMicrosoftEncoding(Name);
+  return isItaniumEncoding(Name) || isRustEncoding(Name) ||
+         isDLangEncoding(Name) || isMicrosoftEncoding(Name);
 }
 
 bool llvm::nonMicrosoftDemangle(std::string_view MangledName,


### PR DESCRIPTION
…led names produced by `clang` can be demangled by LLVM demangler.

Introduce the above diagnostic behind the `-fno-demangling-failures` flag to prevent unintended breakages.