### PR TITLE
[rtsan][compiler-rt] Get rid of [[blocking]] stub in tests

### DIFF
--- a/compiler-rt/test/rtsan/blocking_call.cpp
+++ b/compiler-rt/test/rtsan/blocking_call.cpp
@@ -11,22 +11,19 @@ void custom_blocking_function() [[clang::blocking]] {
   printf("In blocking function\n");
 }
 
-void safe_call() [[clang::blocking]] { printf("In safe call\n"); }
-
-void process() [[clang::nonblocking]] { custom_blocking_function(); }
+void realtime_function() [[clang::nonblocking]] { custom_blocking_function(); }
+void nonrealtime_function() { custom_blocking_function(); }
 
 int main() {
-  safe_call(); // This shouldn't die, because it isn't in nonblocking context.
-  process();
+  nonrealtime_function();
+  realtime_function();
   return 0;
-  // CHECK: ==ERROR: RealtimeSanitizer: blocking-call
-  // CHECK-NEXT: Call to blocking function `custom_blocking_function()` in real-time context!
-  // CHECK-NEXT: {{.*custom_blocking_function*}}
-  // CHECK-NEXT: {{.*process*}}
-
-  // We should crash before this line is printed
-  // CHECK-NOT: {{.*In blocking function.*}}
-
-  // should only occur once
-  // CHECK-NOT: ==ERROR: RealtimeSanitizer: blocking-call
 }
+
+// CHECK: ==ERROR: RealtimeSanitizer: blocking-call
+// CHECK-NEXT: Call to blocking function `custom_blocking_function()` in real-time context!
+// CHECK-NEXT: {{.*custom_blocking_function*}}
+// CHECK-NEXT: {{.*realtime_function*}}
+
+// should only occur once
+// CHECK-NOT: ==ERROR: RealtimeSanitizer: blocking-call


### PR DESCRIPTION
Added the printfs to ensure we wouldn't have these empty functions compiled out.