### PR TITLE
GVN: strip bad TODO, FIXME (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2003,14 +2003,10 @@ static bool impliesEquivalanceIfTrue(CmpInst* Cmp) {
       Value *RHS = Cmp->getOperand(1);
       // If we can prove either side non-zero, then equality must imply
       // equivalence.
-      // FIXME: We should do this optimization if 'no signed zeros' is
-      // applicable via an instruction-level fast-math-flag or some other
-      // indicator that relaxed FP semantics are being used.
       if (isa<ConstantFP>(LHS) && !cast<ConstantFP>(LHS)->isZero())
         return true;
       if (isa<ConstantFP>(RHS) && !cast<ConstantFP>(RHS)->isZero())
         return true;
-      // TODO: Handle vector floating point constants
   }
   return false;
 }
@@ -2029,14 +2025,10 @@ static bool impliesEquivalanceIfFalse(CmpInst* Cmp) {
       Value *RHS = Cmp->getOperand(1);
       // If we can prove either side non-zero, then equality must imply
       // equivalence.
-      // FIXME: We should do this optimization if 'no signed zeros' is
-      // applicable via an instruction-level fast-math-flag or some other
-      // indicator that relaxed FP semantics are being used.
       if (isa<ConstantFP>(LHS) && !cast<ConstantFP>(LHS)->isZero())
         return true;
       if (isa<ConstantFP>(RHS) && !cast<ConstantFP>(RHS)->isZero())
         return true;
-      // TODO: Handle vector floating point constants
   }
   return false;
 }


### PR DESCRIPTION
In impliesEquivalenceIfTrue and impliesEquivalenceIfFalse, note that the optimization is invalid for the no-signed-zeros case: strip the bad FIXME. Also note that, a ConstantVector would be handled by select(fcmp()) pattern in InstCombine, and GVN is not the right place for the optimization: strip the bad TODO.

 Alive2 proof: https://alive2.llvm.org/ce/z/vEaK8M