### PR TITLE
[clang-tidy] Improved readability redundant casting with enums

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
@@ -40,8 +40,15 @@ static bool areTypesEqual(QualType S, QualType D) {
 
 static bool areTypesEqual(QualType TypeS, QualType TypeD,
                           bool IgnoreTypeAliases) {
-  const QualType CTypeS = TypeS.getCanonicalType();
   const QualType CTypeD = TypeD.getCanonicalType();
+
+  QualType CTypeS;
+  const auto *const EnumTypeS = TypeS->getAs<EnumType>();
+  if (EnumTypeS != nullptr && !EnumTypeS->getDecl()->isScoped())
+    CTypeS = EnumTypeS->getDecl()->getIntegerType();
+  else
+    CTypeS = TypeS.getCanonicalType();
+
   if (CTypeS != CTypeD)
     return false;
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -227,7 +227,6 @@ Changes in existing checks
   false negatives related to ``enum`` when setting `IgnoreTypeAliases`
   to `true`.
 
-
 - Improved :doc:`readability-redundant-smartptr-get
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -222,6 +222,12 @@ Changes in existing checks
   by adding the option `UseUpperCaseLiteralSuffix` to select the
   case of the literal suffix in fixes.
 
+- Improved :doc:`readability-redundant-casting
+  <clang-tidy/checks/readability/redundant-casting>` check by fixing
+  false negatives related to ``enum`` when setting ``IgnoreTypeAliases``
+  to true.
+
+
 - Improved :doc:`readability-redundant-smartptr-get
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -224,8 +224,8 @@ Changes in existing checks
 
 - Improved :doc:`readability-redundant-casting
   <clang-tidy/checks/readability/redundant-casting>` check by fixing
-  false negatives related to ``enum`` when setting ``IgnoreTypeAliases``
-  to true.
+  false negatives related to ``enum`` when setting `IgnoreTypeAliases`
+  to `true`.
 
 
 - Improved :doc:`readability-redundant-smartptr-get

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
@@ -221,3 +221,23 @@ void testRedundantDependentNTTPCasting() {
   // CHECK-MESSAGES: :[[@LINE-4]]:25: note: source type originates from referencing this non-type template parameter
   // CHECK-FIXES: {{^}}  T a = V;
 }
+
+enum E1 : char {};
+enum class E2 : char {};
+enum E3 {};
+
+void testEnum(E1 e1, E2 e2, E3 e3){
+  char a = static_cast<char>(e1);
+  // CHECK-MESSAGES-ALIASES: :[[@LINE-1]]:12: warning: redundant explicit casting to the same type 'char' as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-MESSAGES-ALIASES: :[[@LINE-3]]:18: note: source type originates from referencing this parameter
+  // CHECK-FIXES-ALIASES: {{^}}  char a = e1;
+
+  unsigned int d = static_cast<unsigned int>(e3);
+  // CHECK-MESSAGES-ALIASES: :[[@LINE-1]]:20: warning: redundant explicit casting to the same type 'unsigned int' as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-MESSAGES-ALIASES: :[[@LINE-8]]:32: note: source type originates from referencing this parameter
+  // CHECK-FIXES-ALIASES: {{^}}  unsigned int d = e3;
+
+  char b = static_cast<char>(e2);
+  char c = static_cast<char>(e3);
+  E1 e = static_cast<E1>('0');
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
@@ -224,20 +224,13 @@ void testRedundantDependentNTTPCasting() {
 
 enum E1 : char {};
 enum class E2 : char {};
-enum E3 {};
 
-void testEnum(E1 e1, E2 e2, E3 e3){
+void testEnum(E1 e1, E2 e2){
   char a = static_cast<char>(e1);
   // CHECK-MESSAGES-ALIASES: :[[@LINE-1]]:12: warning: redundant explicit casting to the same type 'char' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-MESSAGES-ALIASES: :[[@LINE-3]]:18: note: source type originates from referencing this parameter
   // CHECK-FIXES-ALIASES: {{^}}  char a = e1;
 
-  unsigned int d = static_cast<unsigned int>(e3);
-  // CHECK-MESSAGES-ALIASES: :[[@LINE-1]]:20: warning: redundant explicit casting to the same type 'unsigned int' as the sub-expression, remove this casting [readability-redundant-casting]
-  // CHECK-MESSAGES-ALIASES: :[[@LINE-8]]:32: note: source type originates from referencing this parameter
-  // CHECK-FIXES-ALIASES: {{^}}  unsigned int d = e3;
-
   char b = static_cast<char>(e2);
-  char c = static_cast<char>(e3);
   E1 e = static_cast<E1>('0');
 }


### PR DESCRIPTION
Fixed false negatives with readability-redundant-casting when the underlying types are the same and the option IgnoreTypeAliases is set to true.

Fixes #111137