### PR TITLE
[rtsan][NFC] Refactor to scoped bypasser for __rtsan::Context

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_assertions.h
+++ b/compiler-rt/lib/rtsan/rtsan_assertions.h
@@ -21,9 +21,8 @@ template <typename OnViolationAction>
 void ExpectNotRealtime(Context &context, OnViolationAction &&OnViolation) {
   CHECK(__rtsan_is_initialized());
   if (context.InRealtimeContext() && !context.IsBypassed()) {
-    context.BypassPush();
+    ScopedBypass sb{context};
     OnViolation();
-    context.BypassPop();
   }
 }
 

--- a/compiler-rt/lib/rtsan/rtsan_context.h
+++ b/compiler-rt/lib/rtsan/rtsan_context.h
@@ -35,5 +35,17 @@ private:
   int bypass_depth_{0};
 };
 
+class ScopedBypass {
+public:
+  [[nodiscard]] explicit ScopedBypass(Context &context) : context_(context) {
+    context_.BypassPush();
+  }
+
+  ~ScopedBypass() { context_.BypassPop(); }
+
+private:
+  Context &context_;
+};
+
 Context &GetContextForThisThread();
 } // namespace __rtsan

--- a/compiler-rt/lib/rtsan/rtsan_context.h
+++ b/compiler-rt/lib/rtsan/rtsan_context.h
@@ -43,6 +43,11 @@ public:
 
   ~ScopedBypass() { context_.BypassPop(); }
 
+  ScopedBypass(const ScopedBypass &) = delete;
+  ScopedBypass &operator=(const ScopedBypass &) = delete;
+  ScopedBypass(ScopedBypass &&) = delete;
+  ScopedBypass &operator=(ScopedBypass &&) = delete;
+
 private:
   Context &context_;
 };


### PR DESCRIPTION
In an upcoming review, this code block in rtsan_assertions is going to get a lot messier.

Getting this in as a quick early refactor