### PR TITLE
[clang] Add test for CWG110 "Can template functions and classes be declared in the same scope?"

### DIFF
--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -119,6 +119,16 @@ namespace cwg109 { // cwg109: yes
   };
 }
 
+namespace cwg110 { // cwg110: 2.8
+template <typename>
+void f();
+
+class f;
+
+template <typename>
+void f(int);
+} // namespace cwg110
+
 namespace cwg111 { // cwg111: dup 535
   struct A { A(); A(volatile A&, int = 0); A(A&, const char * = "foo"); };
   struct B : A { B(); }; // #cwg111-B

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -120,13 +120,17 @@ namespace cwg109 { // cwg109: yes
 }
 
 namespace cwg110 { // cwg110: 2.8
-template <typename>
-void f();
+template <typename T>
+void f(T);
 
-class f;
+class f {};
 
-template <typename>
-void f(int);
+template <typename T>
+void f(T, T);
+
+class f g;
+void (*h)(int) = static_cast<void(*)(int)>(f);
+void (*i)(int, int) = static_cast<void(*)(int, int)>(f);
 } // namespace cwg110
 
 namespace cwg111 { // cwg111: dup 535

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -705,7 +705,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/110.html">110</a></td>
     <td>CD6</td>
     <td>Can template functions and classes be declared in the same scope?</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.8</td>
   </tr>
   <tr id="111">
     <td><a href="https://cplusplus.github.io/CWG/issues/111.html">111</a></td>


### PR DESCRIPTION
[P1787R6](https://wg21.link/p1787r6):
> [CWG110](https://cplusplus.github.io/CWG/issues/110.html) is resolved by reducing the restriction in [temp.pre] to a note (matching the behavior of GCC, Clang, and ICC).

Wording: see changes to [temp.pre]/7

I believe the wording for the questions raised in the issue is now the definition of corresponding declarations that is given in [[basic.scope.scope]/4](https://eel.is/c++draft/basic.scope#scope-4):
> Two declarations correspond if they (re)introduce the same name, both declare constructors, or both declare destructors, unless 
> — either is a using-declarator, or
> — one declares a type (not a typedef-name) and the other declares a variable, non-static data member other than of an anonymous union ([class.union.anon]), enumerator, function, or function template, or
> — each declares a function or function template and they do not declare corresponding overloads.

Then it's used as an input for the definition of potentially conflicting declarations given in [[basic.scope.scope]/6](https://eel.is/c++draft/basic.scope#scope-6).

Answering the question in the title: yes, having a function template and a type with the same name that has the same target scope is well-formed.

A keen eye might spot that the current [[temp.pre]/7](https://eel.is/c++draft/temp.pre#7) note doesn't reflect all of the exceptions from the definition of corresponding declarations in [basic.scope.scope]/4, namely 4.1 and 4.2. I believe the note is defective, and I opened an editorial PR against the draft to fix that: https://github.com/cplusplus/draft/pull/7284.
