### PR TITLE
[clang-tidy][performance-move-const-arg] Fix crash when argument type has no definition

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
@@ -209,8 +209,9 @@ void MoveConstArgCheck::check(const MatchFinder::MatchResult &Result) {
     }
 
     if (const CXXRecordDecl *RecordDecl = ArgType->getAsCXXRecordDecl();
-        RecordDecl && !(RecordDecl->hasMoveConstructor() &&
-                        RecordDecl->hasMoveAssignment())) {
+        RecordDecl && RecordDecl->hasDefinition() &&
+        !(RecordDecl->hasMoveConstructor() &&
+          RecordDecl->hasMoveAssignment())) {
       const bool MissingMoveAssignment = !RecordDecl->hasMoveAssignment();
       const bool MissingMoveConstructor = !RecordDecl->hasMoveConstructor();
       const bool MissingBoth = MissingMoveAssignment && MissingMoveConstructor;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -208,6 +208,10 @@ Changes in existing checks
   <clang-tidy/checks/performance/avoid-endl>` check to use ``std::endl`` as
   placeholder when lexer cannot get source text.
 
+- Improved :doc:`performance-move-const-arg
+  <clang-tidy/checks/performance/move-const-arg>` check to fix a crash when
+  an argument type is declared but not defined.
+
 - Improved :doc:`readability-container-contains
   <clang-tidy/checks/readability/container-contains>` check to let it work on
   any class that has a ``contains`` method.

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/move-const-arg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/move-const-arg.cpp
@@ -546,3 +546,17 @@ void testAlsoNonMoveable() {
 }
 
 } // namespace issue_62550
+
+namespace GH111450 {
+struct Status;
+
+struct Error {
+    Error(const Status& S);
+};
+
+struct Result {
+  Error E;
+  Result(Status&& S) : E(std::move(S)) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: passing result of std::move() as a const reference argument; no move will actually happen [performance-move-const-arg]
+};
+} // namespace GH111450


### PR DESCRIPTION

Fix #111450.

When the argument type is forward-declared and there is no definition, `hasMoveConstructor` triggers the assert here:
https://github.com/llvm/llvm-project/blob/7f65377880ce6a0e5eaa4cb2591b86b8c8a24ee6/clang/include/clang/AST/DeclCXX.h#L465
https://github.com/llvm/llvm-project/blob/7f65377880ce6a0e5eaa4cb2591b86b8c8a24ee6/clang/include/clang/AST/DeclCXX.h#L864

Check `hasDefinition()` before `hasMoveConstructor()`.
