### PR TITLE
[sanitizer][test] Unify LD_LIBRARY_PATH handling

### DIFF
--- a/compiler-rt/test/asan/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/asan/Unit/lit.site.cfg.py.in
@@ -8,25 +8,6 @@ import shlex
 # Load common config for all compiler-rt unit tests.
 lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/unittests/lit.common.unit.configured")
 
-def push_ld_library_path(config, new_path):
-  new_ld_library_path = os.path.pathsep.join(
-    (new_path, config.environment.get('LD_LIBRARY_PATH', '')))
-  config.environment['LD_LIBRARY_PATH'] = new_ld_library_path
-
-  if platform.system() == 'FreeBSD':
-    new_ld_32_library_path = os.path.pathsep.join(
-      (new_path, config.environment.get('LD_32_LIBRARY_PATH', '')))
-    config.environment['LD_32_LIBRARY_PATH'] = new_ld_32_library_path
-
-  if platform.system() == 'SunOS':
-    new_ld_library_path_32 = os.path.pathsep.join(
-      (new_path, config.environment.get('LD_LIBRARY_PATH_32', '')))
-    config.environment['LD_LIBRARY_PATH_32'] = new_ld_library_path_32
-
-    new_ld_library_path_64 = os.path.pathsep.join(
-      (new_path, config.environment.get('LD_LIBRARY_PATH_64', '')))
-    config.environment['LD_LIBRARY_PATH_64'] = new_ld_library_path_64
-
 # Setup config name.
 config.name = 'AddressSanitizer-Unit'
 
@@ -47,20 +28,6 @@ config.test_exec_root = os.path.join("@COMPILER_RT_BINARY_DIR@",
                                      "lib", "asan", "tests", test_dir)
 
 config.test_source_root = config.test_exec_root
-
-# When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
-# config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
-# host triple as the trailing path component. The value is incorrect for i386
-# tests on x86_64 hosts and vice versa. Adjust config.compiler_rt_libdir
-# accordingly.
-if config.enable_per_target_runtime_dir:
-    if config.target_arch == 'i386':
-        config.compiler_rt_libdir = re.sub(r'/x86_64(?=-[^/]+$)', '/i386', config.compiler_rt_libdir)
-    elif config.target_arch == 'x86_64':
-        config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
-
-# Set LD_LIBRARY_PATH to pick dynamic runtime up properly.
-push_ld_library_path(config, config.compiler_rt_libdir)
 
 if not config.parallelism_group:
   config.parallelism_group = 'shadow-memory'

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -165,14 +165,22 @@ config.available_features.add(compiler_id)
 # tests on 64-bit hosts and vice versa. Adjust config.compiler_rt_libdir
 # accordingly.
 if config.enable_per_target_runtime_dir:
-    if config.target_arch == 'i386':
-        config.compiler_rt_libdir = re.sub(r'/x86_64(?=-[^/]+$)', '/i386', config.compiler_rt_libdir)
-    elif config.target_arch == 'x86_64':
-        config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
-    if config.target_arch == 'sparc':
-        config.compiler_rt_libdir = re.sub(r'/sparcv9(?=-[^/]+$)', '/sparc', config.compiler_rt_libdir)
-    elif config.target_arch == 'sparcv9':
-        config.compiler_rt_libdir = re.sub(r'/sparc(?=-[^/]+$)', '/sparcv9', config.compiler_rt_libdir)
+    if config.target_arch == "i386":
+        config.compiler_rt_libdir = re.sub(
+            r"/x86_64(?=-[^/]+$)", "/i386", config.compiler_rt_libdir
+        )
+    elif config.target_arch == "x86_64":
+        config.compiler_rt_libdir = re.sub(
+            r"/i386(?=-[^/]+$)", "/x86_64", config.compiler_rt_libdir
+        )
+    if config.target_arch == "sparc":
+        config.compiler_rt_libdir = re.sub(
+            r"/sparcv9(?=-[^/]+$)", "/sparc", config.compiler_rt_libdir
+        )
+    elif config.target_arch == "sparcv9":
+        config.compiler_rt_libdir = re.sub(
+            r"/sparc(?=-[^/]+$)", "/sparcv9", config.compiler_rt_libdir
+        )
 
 # Check if the test compiler resource dir matches the local build directory
 # (which happens with -DLLVM_ENABLE_PROJECTS=clang;compiler-rt) or if we are

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -161,18 +161,18 @@ config.available_features.add(compiler_id)
 
 # When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
 # config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
-# triple as the trailing path component. The value is incorrect for -m32/-m64.
-# Adjust config.compiler_rt accordingly.
+# host triple as the trailing path component. The value is incorrect for 32-bit
+# tests on 64-bit hosts and vice versa. Adjust config.compiler_rt_libdir
+# accordingly.
 if config.enable_per_target_runtime_dir:
-    if "-m32" in shlex.split(config.target_cflags):
-        config.compiler_rt_libdir = re.sub(
-            r"/x86_64(?=-[^/]+$)", "/i386", config.compiler_rt_libdir
-        )
-    elif "-m64" in shlex.split(config.target_cflags):
-        config.compiler_rt_libdir = re.sub(
-            r"/i386(?=-[^/]+$)", "/x86_64", config.compiler_rt_libdir
-        )
-
+    if config.target_arch == 'i386':
+        config.compiler_rt_libdir = re.sub(r'/x86_64(?=-[^/]+$)', '/i386', config.compiler_rt_libdir)
+    elif config.target_arch == 'x86_64':
+        config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
+    if config.target_arch == 'sparc':
+        config.compiler_rt_libdir = re.sub(r'/sparcv9(?=-[^/]+$)', '/sparc', config.compiler_rt_libdir)
+    elif config.target_arch == 'sparcv9':
+        config.compiler_rt_libdir = re.sub(r'/sparc(?=-[^/]+$)', '/sparcv9', config.compiler_rt_libdir)
 
 # Check if the test compiler resource dir matches the local build directory
 # (which happens with -DLLVM_ENABLE_PROJECTS=clang;compiler-rt) or if we are


### PR DESCRIPTION
When testing on Linux/sparc64 with a `runtimes` build, the `UBSan-Standalone-sparc :: TestCases/Misc/Linux/sigaction.cpp` test `FAIL`s:
```
runtimes/runtimes-bins/compiler-rt/test/ubsan/Standalone-sparc/TestCases/Misc/Linux/Output/sigaction.cpp.tmp: error while loading shared libraries: libclang_rt.ubsan_standalone.so: wrong ELF class: ELFCLASS64
```
It turns out SPARC needs the same `LD_LIBRARY_PATH` handling as x86.

This is what this patch does, at the same time noticing that the current duplication between `lit.common.cfg.py` and `asan/Unit/lit.site.cfg.py.in` isn't necessary.

Tested on `sparc64-unknown-linux-gnu` and `x86_64-pc-linux-gnu`.