### PR TITLE
[ci] Use check-compiler-rt target for testing compiler-rt

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -198,7 +198,7 @@ function check-targets() {
       echo "check-clang-tools"
     ;;
     compiler-rt)
-      echo "check-all"
+      echo "check-compiler-rt"
     ;;
     cross-project-tests)
       echo "check-cross-project"


### PR DESCRIPTION
Instead of "check-all" which leads to us running some tests twice if there are other "check-..." targets. For example on one of my PRs this script produced:
```
commands:
  - './.ci/monolithic-linux.sh "clang;clang;lld;clang-tools-extra;compiler-rt;llvm" "check-all check-clang check-clang-tools" "libcxx;libcxxabi;libunwind" "check-cxx check-cxxabi check-unwind"'
  commands:
  - 'C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=amd64 -host_arch=amd64'
  - 'bash .ci/monolithic-windows.sh "clang;clang-tools-extra;llvm" "check-clang check-clang-tools"'
```
Which meant that Linux ran the clang and clang-tools tests twice. These extra tests were about 24% of the test run and increased testing time (on my local machine) by 45%.

This problem can also happen with other projects but there isn't a simple fix like this one at the moment.
* pstl has a check-pstl target but it is not part of check-all and when I tried it locally I couldn't build it.
* libclc has no check- target.

I will deal with those projects later.