### PR TITLE
[mlir][linalg][nfc] Delete references to args_in/args_out

### DIFF
--- a/mlir/docs/BufferDeallocationInternals.md
+++ b/mlir/docs/BufferDeallocationInternals.md
@@ -664,6 +664,8 @@ merged into a single step. Canonicalization removes the clone operation and
 func.func @reuseTarget(%arg0: memref<2xf32>, %result: memref<2xf32>){
   %temp = memref.alloc() : memref<2xf32>
   test.generic {
+    args_in = 1 : i64,
+    args_out = 1 : i64,
     indexing_maps = [#map0, #map0],
     iterator_types = ["parallel"]} %arg0, %temp {
   ^bb0(%gen2_arg0: f32, %gen2_arg1: f32):
@@ -681,6 +683,8 @@ Will be transformed to:
 ```mlir
 func.func @reuseTarget(%arg0: memref<2xf32>, %result: memref<2xf32>){
   test.generic {
+    args_in = 1 : i64,
+    args_out = 1 : i64,
     indexing_maps = [#map0, #map0],
     iterator_types = ["parallel"]} %arg0, %result {
   ^bb0(%gen2_arg0: f32, %gen2_arg1: f32):

--- a/mlir/docs/BufferDeallocationInternals.md
+++ b/mlir/docs/BufferDeallocationInternals.md
@@ -664,8 +664,6 @@ merged into a single step. Canonicalization removes the clone operation and
 func.func @reuseTarget(%arg0: memref<2xf32>, %result: memref<2xf32>){
   %temp = memref.alloc() : memref<2xf32>
   test.generic {
-    args_in = 1 : i64,
-    args_out = 1 : i64,
     indexing_maps = [#map0, #map0],
     iterator_types = ["parallel"]} %arg0, %temp {
   ^bb0(%gen2_arg0: f32, %gen2_arg1: f32):
@@ -683,8 +681,6 @@ Will be transformed to:
 ```mlir
 func.func @reuseTarget(%arg0: memref<2xf32>, %result: memref<2xf32>){
   test.generic {
-    args_in = 1 : i64,
-    args_out = 1 : i64,
     indexing_maps = [#map0, #map0],
     iterator_types = ["parallel"]} %arg0, %result {
   ^bb0(%gen2_arg0: f32, %gen2_arg1: f32):

--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
@@ -32,8 +32,6 @@ def BufferDeallocation : Pass<"buffer-deallocation", "func::FuncOp"> {
       ^bb2:
         %0 = memref.alloc() : memref<2xf32>
         linalg.generic {
-          args_in = 1 : i64,
-          args_out = 1 : i64,
           indexing_maps = [#map0, #map0],
           iterator_types = ["parallel"]} %arg1, %0 {
         ^bb0(%gen1_arg0: f32, %gen1_arg1: f32):
@@ -63,8 +61,6 @@ def BufferDeallocation : Pass<"buffer-deallocation", "func::FuncOp"> {
       ^bb2:  // pred: ^bb0
         %1 = memref.alloc() : memref<2xf32>
         linalg.generic {
-          args_in = 1 : i64,
-          args_out = 1 : i64,
           indexing_maps = [#map0, #map0],
           iterator_types = ["parallel"]} %arg1, %1 {
         ^bb0(%arg3: f32, %arg4: f32):
@@ -143,8 +139,6 @@ def OwnershipBasedBufferDeallocation : Pass<
       ^bb2:
         %0 = memref.alloc() : memref<2xf32>
         linalg.generic {
-          args_in = 1 : i64,
-          args_out = 1 : i64,
           indexing_maps = [#map0, #map0],
           iterator_types = ["parallel"]}
         outs(%arg1, %0 : memref<2xf32>, memref<2xf32>) {
@@ -179,7 +173,6 @@ def OwnershipBasedBufferDeallocation : Pass<
           indexing_maps = [#map, #map],
           iterator_types = ["parallel"]}
         outs(%arg1, %alloc : memref<2xf32>, memref<2xf32>)
-        attrs =  {args_in = 1 : i64, args_out = 1 : i64} {
         ^bb0(%out: f32, %out_0: f32):
           %2 = math.exp %out : f32
           linalg.yield %2, %out_0 : f32, f32

--- a/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
@@ -178,8 +178,6 @@ struct MoveInitOperandsToInput : public OpRewritePattern<GenericOp> {
 /// ]
 ///
 /// #trait = {
-///   args_in = 2,
-///   args_out = 1,
 ///   indexing_maps = #accesses,
 ///   iterator_types = ["parallel", "parallel"],
 ///   library_call = "some_external_fn"
@@ -210,8 +208,6 @@ struct MoveInitOperandsToInput : public OpRewritePattern<GenericOp> {
 /// ]
 ///
 /// #trait = {
-///   args_in = 2,
-///   args_out = 1,
 ///   indexing_maps = #accesses,
 ///   iterator_types = ["parallel", "parallel"],
 ///   library_call = "some_external_fn"

--- a/mlir/test/Dialect/Linalg/loops.mlir
+++ b/mlir/test/Dialect/Linalg/loops.mlir
@@ -254,8 +254,6 @@ func.func @copy_view(%arg0: memref<?xf32, strided<[1], offset: ?>>, %arg1: memre
   affine_map<(i, j, k) -> (i, k, j)>
 ]
 #trait2 = {
-  args_in = 1,
-  args_out = 2,
   iterator_types = ["parallel", "parallel", "parallel"],
   indexing_maps = #accesses,
   library_call = "some_external_function_name_2",
@@ -296,8 +294,6 @@ func.func @generic_region(%arg0: memref<?x?xf32, strided<[?, 1], offset: ?>>, %a
 //       CHECKPARALLEL:   store %[[e]], %{{.*}}[%[[i]], %[[k]], %[[j]]] : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>
 
 #trait4 = {
-  args_in = 1,
-  args_out = 2,
   iterator_types = ["parallel", "parallel", "parallel"],
   indexing_maps = #accesses,
   library_call = "some_external_function_name_2",
@@ -366,8 +362,6 @@ func.func @generic_index_region(
 ]
 
 #trait_broadcast = {
-  args_in = 1,
-  args_out = 1,
   indexing_maps = #broadcast_access,
   iterator_types = ["parallel", "parallel"],
   library_call = "some_broadcast_external_fn"
@@ -466,8 +460,6 @@ func.func @generic_index_op_zero_rank(%arg0: memref<i32>, %arg1: memref<3x4xi32>
 ]
 
 #trait_reduce_1D = {
-  args_in = 1,
-  args_out = 1,
   indexing_maps = #reduce_1D_access,
   iterator_types = ["reduction"],
   library_call = "some_reduce_external_fn"
@@ -510,8 +502,6 @@ func.func @generic_op_1D_reduce(%arg0: memref<?xf32>, %arg1: memref<f32>)
 ]
 
 #trait_reduce_init_1D = {
-  args_in = 2,
-  args_out = 1,
   indexing_maps = #reduce_init_1D_access,
   iterator_types = ["reduction"],
   library_call = "some_reduce_external_fn"
@@ -559,8 +549,6 @@ func.func @generic_index_op_1D_reduce(%arg0: memref<?xf32>,
 //       CHECKPARALLEL:   store %[[e]], %[[ARG2]][]
 
 #trait_const_fill = {
-  args_in = 0,
-  args_out = 1,
   indexing_maps = [affine_map<(i) -> (i)>],
   iterator_types = ["parallel"],
   library_call = "some_external_fn"
@@ -591,8 +579,6 @@ func.func @generic_const_init(%arg0: memref<?xf32>) {
   affine_map<() -> ()>
 ]
 #scalar_trait = {
-  args_in = 2,
-  args_out = 1,
   iterator_types = [],
   indexing_maps = #scalar_access,
   library_call = "some_external_fn"

--- a/mlir/test/Dialect/Linalg/transform-patterns.mlir
+++ b/mlir/test/Dialect/Linalg/transform-patterns.mlir
@@ -118,8 +118,6 @@ module attributes {transform.with_named_sequence} {
   affine_map<(m, n, k) -> (m, n)>
 ]
 #generic_matmul_trait = {
-  args_in = 2,
-  args_out = 1,
   indexing_maps = #matmul_accesses,
   library_call = "linalg_matmul",
   iterator_types = ["parallel", "parallel", "reduction"]

--- a/mlir/test/Dialect/Linalg/vectorization-with-patterns.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization-with-patterns.mlir
@@ -83,8 +83,6 @@ module attributes {transform.with_named_sequence} {
 // -----
 
 #matmul_trait = {
-  args_in = 2,
-  args_out = 1,
   indexing_maps = [
     affine_map<(m, n, k) -> (m, k)>,
     affine_map<(m, n, k) -> (k, n)>,
@@ -125,8 +123,6 @@ module attributes {transform.with_named_sequence} {
 // -----
 
 #matmul_transpose_out_trait = {
-  args_in = 2,
-  args_out = 1,
   indexing_maps = [
     affine_map<(m, n, k) -> (m, k)>,
     affine_map<(m, n, k) -> (k, n)>,
@@ -196,8 +192,6 @@ module attributes {transform.with_named_sequence} {
 // -----
 
 #matmul_trait = {
-  args_in = 2,
-  args_out = 1,
   indexing_maps = [
     affine_map<(m, n, k) -> (m, k)>,
     affine_map<(m, n, k) -> (k, n)>,
@@ -528,8 +522,6 @@ func.func @generic_vectorize(%arg0: memref<4x256xf32>,
   //   CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
   %c1_f32 = arith.constant 1.0 : f32
   linalg.generic {
-    args_in = 0 : i64,
-    args_out = 10 : i64,
     indexing_maps = [
       affine_map<(d0, d1) -> (d0, d1)>,
       affine_map<(d0, d1) -> (d1)>,


### PR DESCRIPTION
After the refactor in:
  * ed229132f1c4ea2ba0644fc345d8279e47a00565,

the `args_in` and `args_out` attributes are no longer used by
`linalg.generic`. This patch removes all the remaining references.
