### PR TITLE
[llvm][cmake][Trivial] use /Zc:preprocessor with MSVC only explicitly

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -581,7 +581,7 @@ if( MSVC )
 
   append("/Zc:inline" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
-  if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Enable standards-conforming preprocessor.
     # https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor
     append("/Zc:preprocessor" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)


### PR DESCRIPTION
Only MSVC recognizes this flag, so be explicit. As an example the Intel C++ Compiler (IntelLLVM in CMake) also has an MSVC compatible CLI, but does not suppport this flag.