### PR TITLE
[clang-format] convert path to Windows path if user is using a MSYS2 shell

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -31,6 +31,7 @@ import os
 import re
 import subprocess
 import sys
+import shutil
 
 usage = ('git clang-format [OPTIONS] [<commit>] [<commit>|--staged] '
          '[--] [<file>...]')
@@ -413,6 +414,8 @@ def filter_ignored_files(dictionary, binary):
 def cd_to_toplevel():
   """Change to the top level of the git repository."""
   toplevel = run('git', 'rev-parse', '--show-toplevel')
+  if "MSYSTEM" in os.environ and shutil.which('cygpath') is not None:
+    toplevel = run('cygpath', '-w', toplevel)
   os.chdir(toplevel)
 
 


### PR DESCRIPTION
Currently, we simply rely on the result of `git rev-parse --show-toplevel` in `cd_to_toplevel()`, which when using MSYS2 shell under Windows, can result getting a UNIX path instead of Windows path, and `os.chdir(toplevel)` would simply fail.

This patch detects if user is using MSYS2 shell (by checking `MSYSTEM` environment variable and checking if `cygpath` exists) and will use `cygpath` to convert the path to Windows path.