### PR TITLE
[libclc] Give a helpful error when an unknown target is requested

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -137,8 +137,6 @@ if( llvm-spirv_exe )
   list( APPEND LIBCLC_TARGETS_ALL  spirv-mesa3d- spirv64-mesa3d- )
 endif()
 
-list( SORT LIBCLC_TARGETS_TO_BUILD )
-
 # Verify that the user hasn't requested mesa3d targets without an available
 # llvm-spirv tool.
 if( "spirv-mesa3d-" IN_LIST LIBCLC_TARGETS_TO_BUILD OR "spirv64-mesa3d-" IN_LIST LIBCLC_TARGETS_TO_BUILD )
@@ -157,6 +155,8 @@ else()
     endif()
   endforeach()
 endif()
+
+list( SORT LIBCLC_TARGETS_TO_BUILD )
 
 # Construct LLVM version define
 set( LLVM_VERSION_DEFINE "-DHAVE_LLVM=0x${LLVM_VERSION_MAJOR}0${LLVM_VERSION_MINOR}" )

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -139,6 +139,13 @@ endif()
 
 if( LIBCLC_TARGETS_TO_BUILD STREQUAL "all" )
   set( LIBCLC_TARGETS_TO_BUILD ${LIBCLC_TARGETS_ALL} )
+else()
+  foreach(TARGET_TO_BUILD ${LIBCLC_TARGETS_TO_BUILD})
+    if (NOT ${TARGET_TO_BUILD} IN_LIST LIBCLC_TARGETS_ALL)
+      message ( FATAL_ERROR "Unknown target in LIBCLC_TARGETS_TO_BUILD: \"${TARGET_TO_BUILD}\"\n"
+                            "Valid targets are: ${LIBCLC_TARGETS_ALL}")
+    endif()
+  endforeach()
 endif()
 
 list( SORT LIBCLC_TARGETS_TO_BUILD )

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -137,17 +137,6 @@ if( llvm-spirv_exe )
   list( APPEND LIBCLC_TARGETS_ALL  spirv-mesa3d- spirv64-mesa3d- )
 endif()
 
-if( LIBCLC_TARGETS_TO_BUILD STREQUAL "all" )
-  set( LIBCLC_TARGETS_TO_BUILD ${LIBCLC_TARGETS_ALL} )
-else()
-  foreach(TARGET_TO_BUILD ${LIBCLC_TARGETS_TO_BUILD})
-    if (NOT ${TARGET_TO_BUILD} IN_LIST LIBCLC_TARGETS_ALL)
-      message ( FATAL_ERROR "Unknown target in LIBCLC_TARGETS_TO_BUILD: \"${TARGET_TO_BUILD}\"\n"
-                            "Valid targets are: ${LIBCLC_TARGETS_ALL}")
-    endif()
-  endforeach()
-endif()
-
 list( SORT LIBCLC_TARGETS_TO_BUILD )
 
 # Verify that the user hasn't requested mesa3d targets without an available
@@ -156,6 +145,17 @@ if( "spirv-mesa3d-" IN_LIST LIBCLC_TARGETS_TO_BUILD OR "spirv64-mesa3d-" IN_LIST
   if( NOT llvm-spirv_exe )
     message( FATAL_ERROR "SPIR-V targets requested, but spirv-tools is not installed" )
   endif()
+endif()
+
+if( LIBCLC_TARGETS_TO_BUILD STREQUAL "all" )
+  set( LIBCLC_TARGETS_TO_BUILD ${LIBCLC_TARGETS_ALL} )
+else()
+  foreach(TARGET_TO_BUILD ${LIBCLC_TARGETS_TO_BUILD})
+    if (NOT ${TARGET_TO_BUILD} IN_LIST LIBCLC_TARGETS_ALL)
+      message ( FATAL_ERROR "Unknown target in LIBCLC_TARGETS_TO_BUILD: \"${TARGET_TO_BUILD}\"\n"
+                            "Valid targets are: ${LIBCLC_TARGETS_ALL}\n")
+    endif()
+  endforeach()
 endif()
 
 # Construct LLVM version define


### PR DESCRIPTION
I just tried using LLVM backend names here e.g. NVPTX but libclc want's targets more like triples. This change adds a mesasge to tell you that.

Before you got:
```
 libclc target 'AMDGCN' is enabled
 CMake Error at CMakeLists.txt:253 (list):
   list index: 1 out of range (-1, 0)

 CMake Error at CMakeLists.txt:254 (list):
   list index: 2 out of range (-1, 0)

 Configuring incomplete, errors occurred!
```
Now you get:

```
 CMake Error at CMakeLists.txt:145 (message):
   Unknown target in LIBCLC_TARGETS_TO_BUILD: "AMDGCN"

   Valid targets are:
   amdgcn--;amdgcn--amdhsa;clspv--;clspv64--;r600--;nvptx--;nvptx64--;nvptx--nvidiacl;nvptx64--nvidiacl;amdgcn-mesa-mesa3d
```
Some of the targets are dynamic based on what is installed, so spirv isn't here for me because I don't have llvm-spirv installed yet.

So this is not perfect but it's an improvement on the current behaviour.