### PR TITLE
Add 64bit atomic check in the is_always_lock_free_pass test.

### DIFF
--- a/libcxx/test/std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// XFAIL: LIBCXX-PICOLIBC-FIXME
+// XFAIL: !has-64-bit-atomics
 
 // <atomic>
 //


### PR DESCRIPTION
Currently this test is completely xfailed as part of the patch https://github.com/llvm/llvm-project/pull/106077. But this test works on A and R profile, not in v7M profile. Because the test contain cases in which  m-profile will fail for atomic types greater than 4 bytes in size.