### PR TITLE
[ci] Don't add a testing target for libclc

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -219,7 +219,7 @@ function check-targets() {
       echo "check-all"
     ;;
     libclc)
-      echo "check-all"
+      # Currently there is no testing for libclc.
     ;;
     *)
       echo "check-${project}"


### PR DESCRIPTION
According to https://github.com/llvm/llvm-project/pull/111369#issuecomment-2400152471 there is no testing to be done here.

Adding "check-all" only risks duplicating tests if other project specific "check-" targets are also added.