### PR TITLE
[clang] Change "bad" to "unsupported" in register type error

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -380,6 +380,10 @@ Improvements to Clang's diagnostics
 
 - Clang now omits warnings for extra parentheses in fold expressions with single expansion (#GH101863).
 
+- The warning for an unsupported type for a named register variable is now phrased ``unsupported type for named register variable``,
+  instead of ``bad type for named register variable``. This makes it clear that the type is not supported at all, rather than being
+  suboptimal in some way the error fails to mention (#GH111550).
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9386,7 +9386,8 @@ let CategoryName = "Inline Assembly Issue" in {
     "global register variables on this target">;
   def err_asm_register_size_mismatch : Error<"size of register '%0' does not "
     "match variable size">;
-  def err_asm_bad_register_type : Error<"bad type for named register variable">;
+  def err_asm_unsupported_register_type : Error<
+    "unsupported type for named register variable">;
   def err_asm_invalid_input_size : Error<
     "invalid input size for constraint '%0'">;
   def err_asm_invalid_output_size : Error<

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7961,7 +7961,8 @@ NamedDecl *Sema::ActOnVariableDeclarator(
       }
 
       if (!R->isIntegralType(Context) && !R->isPointerType()) {
-        Diag(TInfo->getTypeLoc().getBeginLoc(), diag::err_asm_bad_register_type)
+        Diag(TInfo->getTypeLoc().getBeginLoc(),
+             diag::err_asm_unsupported_register_type)
             << TInfo->getTypeLoc().getSourceRange();
         NewVD->setInvalidDecl(true);
       }

--- a/clang/test/Sema/asm.c
+++ b/clang/test/Sema/asm.c
@@ -191,8 +191,8 @@ void iOutputConstraint(int x){
 struct foo {
   int a;
 };
-register struct foo bar asm("esp"); // expected-error {{bad type for named register variable}}
-register float baz asm("esp"); // expected-error {{bad type for named register variable}}
+register struct foo bar asm("esp"); // expected-error {{unsupported type for named register variable}}
+register float baz asm("esp"); // expected-error {{unsupported type for named register variable}}
 
 register int r0 asm ("edi"); // expected-error {{register 'edi' unsuitable for global register variables on this target}}
 register long long r1 asm ("esp"); // expected-error {{size of register 'esp' does not match variable size}}

--- a/clang/test/Sema/caret-diags-register-variable.cpp
+++ b/clang/test/Sema/caret-diags-register-variable.cpp
@@ -4,7 +4,7 @@ struct foo {
   int a;
 };
 
-//CHECK: {{.*}}: error: bad type for named register variable
+//CHECK: {{.*}}: error: unsupported type for named register variable
 //CHECK-NEXT: {{^}}register struct foo bar asm("esp");
 //CHECK-NEXT: {{^}}         ^~~~~~~~~~{{$}}
 register struct foo bar asm("esp");


### PR DESCRIPTION
This is maybe a personal take but I expect "bad" to either mean:
* Allowed but not ideal, like a "bad" memory alignment might work but it is slow.
* The tool won't allow it but is going to tell me why it didn't.

The current error doesn't elaborate so I think it's best we just say "unsupported" instead. This is clear that the type used is not allowed at all.