### PR TITLE
[Flang][OpenMP]Add tests for TODOs and small changes to improve messages

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1255,8 +1255,8 @@ static void genTaskClauses(lower::AbstractConverter &converter,
   cp.processUntied(clauseOps);
   // TODO Support delayed privatization.
 
-  cp.processTODO<clause::Affinity, clause::Detach, clause::InReduction>(
-      loc, llvm::omp::Directive::OMPD_task);
+  cp.processTODO<clause::Affinity, clause::Detach, clause::InReduction,
+                 clause::Mergeable>(loc, llvm::omp::Directive::OMPD_task);
 }
 
 static void genTaskgroupClauses(lower::AbstractConverter &converter,
@@ -2764,7 +2764,10 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
         !std::holds_alternative<clause::ThreadLimit>(clause.u) &&
         !std::holds_alternative<clause::Threads>(clause.u) &&
         !std::holds_alternative<clause::UseDeviceAddr>(clause.u) &&
-        !std::holds_alternative<clause::UseDevicePtr>(clause.u)) {
+        !std::holds_alternative<clause::UseDevicePtr>(clause.u) &&
+        !std::holds_alternative<clause::InReduction>(clause.u) &&
+        !std::holds_alternative<clause::Mergeable>(clause.u) &&
+        !std::holds_alternative<clause::TaskReduction>(clause.u)) {
       TODO(clauseLocation, "OpenMP Block construct clause");
     }
   }

--- a/flang/test/Lower/OpenMP/Todo/reduction-inscan.f90
+++ b/flang/test/Lower/OpenMP/Todo/reduction-inscan.f90
@@ -1,0 +1,14 @@
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: Reduction modifiers are not supported
+subroutine reduction_inscan()
+  integer :: i,j
+  i = 0
+
+  !$omp do reduction(inscan, +:i)
+  do j=1,10
+     i = i + 1
+  end do
+  !$omp end do
+end subroutine reduction_inscan

--- a/flang/test/Lower/OpenMP/Todo/reduction-task.f90
+++ b/flang/test/Lower/OpenMP/Todo/reduction-task.f90
@@ -1,0 +1,12 @@
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: Reduction modifiers are not supported
+subroutine reduction_task()
+  integer :: i
+  i = 0
+
+  !$omp parallel reduction(task, +:i)
+  i = i + 1
+  !$omp end parallel 
+end subroutine reduction_task

--- a/flang/test/Lower/OpenMP/Todo/target-inreduction.f90
+++ b/flang/test/Lower/OpenMP/Todo/target-inreduction.f90
@@ -1,15 +1,15 @@
-! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
-! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -fopenmp-version=50 -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -fopenmp-version=50 -o - %s 2>&1 | FileCheck %s
 
 !===============================================================================
 ! `mergeable` clause
 !===============================================================================
 
 ! CHECK: not yet implemented: Unhandled clause IN_REDUCTION in TARGET construct
-subroutine omp_targer_inreduction()
+subroutine omp_target_inreduction()
   integer i
   i = 0
   !$omp target in_reduction(+:i)
   i = i + 1
   !$omp end target
-end subroutine omp_targer_inreduction
+end subroutine omp_target_inreduction

--- a/flang/test/Lower/OpenMP/Todo/target-inreduction.f90
+++ b/flang/test/Lower/OpenMP/Todo/target-inreduction.f90
@@ -5,9 +5,11 @@
 ! `mergeable` clause
 !===============================================================================
 
-! CHECK: not yet implemented: Unhandled clause MERGEABLE in TASK construct
-subroutine omp_task_mergeable()
-  !$omp task mergeable
-  call foo()
-  !$omp end task
-end subroutine omp_task_mergeable
+! CHECK: not yet implemented: Unhandled clause IN_REDUCTION in TARGET construct
+subroutine omp_targer_inreduction()
+  integer i
+  i = 0
+  !$omp target in_reduction(+:i)
+  i = i + 1
+  !$omp end target
+end subroutine omp_targer_inreduction

--- a/flang/test/Lower/OpenMP/Todo/task-inreduction.f90
+++ b/flang/test/Lower/OpenMP/Todo/task-inreduction.f90
@@ -5,9 +5,11 @@
 ! `mergeable` clause
 !===============================================================================
 
-! CHECK: not yet implemented: Unhandled clause MERGEABLE in TASK construct
-subroutine omp_task_mergeable()
-  !$omp task mergeable
-  call foo()
+! CHECK: not yet implemented: Unhandled clause IN_REDUCTION in TASK construct
+subroutine omp_task_in_reduction()
+  integer i
+  i = 0
+  !$omp task in_reduction(+:i)
+  i = i + 1
   !$omp end task
-end subroutine omp_task_mergeable
+end subroutine omp_task_in_reduction

--- a/flang/test/Lower/OpenMP/Todo/taskgroup-task-reduction.f90
+++ b/flang/test/Lower/OpenMP/Todo/taskgroup-task-reduction.f90
@@ -1,0 +1,10 @@
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: Unhandled clause TASK_REDUCTION in TASKGROUP construct
+subroutine omp_taskgroup_task_reduction
+  integer :: res
+  !$omp taskgroup task_reduction(+:res)
+  res = res + 1
+  !$omp end taskgroup
+end subroutine omp_taskgroup_task_reduction

--- a/flang/test/Lower/OpenMP/Todo/taskloop.f90
+++ b/flang/test/Lower/OpenMP/Todo/taskloop.f90
@@ -1,0 +1,13 @@
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: Taskloop construct
+subroutine omp_taskloop
+  integer :: res, i
+  !$omp taskloop
+  do i = 1, 10
+     res = res + 1
+  end do
+  !$omp end taskloop
+end subroutine omp_taskloop
+

--- a/flang/test/Lower/OpenMP/Todo/taskwait-depend.f90
+++ b/flang/test/Lower/OpenMP/Todo/taskwait-depend.f90
@@ -1,0 +1,10 @@
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: Unhandled clause DEPEND in TASKWAIT construct
+subroutine omp_tw_depend
+  integer :: res
+  !$omp taskwait depend(out: res)
+  res = res + 1
+end subroutine omp_tw_depend
+

--- a/flang/test/Lower/OpenMP/Todo/taskwait-nowait.f90
+++ b/flang/test/Lower/OpenMP/Todo/taskwait-nowait.f90
@@ -1,0 +1,8 @@
+! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s -fopenmp-version=51 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s -fopenmp-version=51 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: Unhandled clause NOWAIT in TASKWAIT construct
+subroutine omp_tw_nowait
+  !$omp taskwait nowait
+end subroutine omp_tw_nowait
+


### PR DESCRIPTION
The bulk of this change are new tests to check that we get a "Not yet implemneted: *some stuff here*" message when using some not yet supported OpenMP functionality.

For some of these cases, this also means adding additional clauses to a filter list in OpenMP.cpp - this changes nothing [to the best of my understanding] other than allowing the clause to get to the point where it can be rejected in a TODO with a more clear message. One of the TOOD filters were missing Mergeable clause, so this was also added and the existing test updated for the new more specific error message.

There is no functional change intended here.