### PR TITLE
Fix out-of-bounds access to std::unique_ptr<T[]>

### DIFF
--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -1252,10 +1252,10 @@ highlightLines(StringRef FileData, unsigned StartLineNumber,
     for (unsigned I = 0; I <= Spelling.size(); ++I) {
       // This line is done.
       if (I == Spelling.size() || isVerticalWhitespace(Spelling[I])) {
-        SmallVector<TextDiagnostic::StyleRange> &LineRanges =
-            SnippetRanges[L - StartLineNumber];
-
         if (L >= StartLineNumber) {
+          SmallVector<TextDiagnostic::StyleRange> &LineRanges =
+              SnippetRanges[L - StartLineNumber];
+
           if (L == TokenStartLine) // First line
             appendStyle(LineRanges, T, StartCol, LineLength);
           else if (L == TokenEndLine) // Last line

--- a/clang/test/Frontend/highlight-text.c
+++ b/clang/test/Frontend/highlight-text.c
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -fsyntax-only %s 2> %t
+// RUN: FileCheck < %t %s
+#define F (1 << 99)
+
+#define M \
+F | F
+
+int a = M;
+// CHECK: :8:9: warning: shift count >= width of type [-Wshift-count-overflow]
+// CHECK-NEXT:     8 | int a = M;
+// CHECK-NEXT:       |         ^
+// CHECK-NEXT: :5:11: note: expanded from macro 'M'
+// CHECK-NEXT:     5 | #define M \
+// CHECK-NEXT:       |           ^
+// CHECK-NEXT: :3:14: note: expanded from macro '\
+// CHECK-NEXT: F'
+// CHECK-NEXT:     3 | #define F (1 << 99)
+// CHECK-NEXT:       |              ^  ~~
+// CHECK-NEXT: :8:9: warning: shift count >= width of type [-Wshift-count-overflow]
+// CHECK-NEXT:     8 | int a = M;
+// CHECK-NEXT:       |         ^
+// CHECK-NEXT: :6:5: note: expanded from macro 'M'
+// CHECK-NEXT:     6 | F | F
+// CHECK-NEXT:       |     ^
+// CHECK-NEXT: :3:14: note: expanded from macro 'F'
+// CHECK-NEXT:     3 | #define F (1 << 99)
+// CHECK-NEXT:       |              ^  ~~


### PR DESCRIPTION
This manifested as an assertion failure in Clang built against libc++ with
hardening enabled (e.g.  -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG):
`libcxx/include/__memory/unique_ptr.h:596: assertion __checker_.__in_bounds(std::__to_address(__ptr_), __i) failed: unique_ptr<T[]>::operator[](index): index out of range`
