### PR TITLE
[NVPTX] fix debug register encoding of special %Depot register

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
@@ -176,6 +176,11 @@ void NVPTXRegisterInfo::addToDebugRegisterMap(
 int64_t NVPTXRegisterInfo::getDwarfRegNum(MCRegister RegNum, bool isEH) const {
   if (Register::isPhysicalRegister(RegNum)) {
     std::string name = NVPTXInstPrinter::getRegisterName(RegNum.id());
+    // In NVPTXFrameLowering.cpp, we do arrange for %Depot to be accessible from
+    // %SP. Using the %Depot register doesn't provide any debug info in
+    // cuda-gdb, but switching it to %SP does.
+    if (RegNum.id() == NVPTX::VRDepot)
+      name = "%SP";
     return encodeRegisterForDwarf(name);
   }
   uint64_t lookup = debugRegisterMap.lookup(RegNum.id());


### PR DESCRIPTION
cuda-gdb doesn't seem to be able to read the `%Depot` register, but because we always copy it to `%SP` in lowering, simply switching to use it fixes the problem.