### PR TITLE
[Coroutines] Move util headers to include/llvm

### DIFF
--- a/llvm/include/llvm/Transforms/Coroutines/ABI.h
+++ b/llvm/include/llvm/Transforms/Coroutines/ABI.h
@@ -12,12 +12,13 @@
 // ABI enum and ABI class are used by the Coroutine passes when lowering.
 //===----------------------------------------------------------------------===//
 
-#ifndef LIB_TRANSFORMS_COROUTINES_ABI_H
-#define LIB_TRANSFORMS_COROUTINES_ABI_H
+#ifndef LLVM_TRANSFORMS_COROUTINES_ABI_H
+#define LLVM_TRANSFORMS_COROUTINES_ABI_H
 
-#include "CoroShape.h"
-#include "SuspendCrossingInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Transforms/Coroutines/CoroShape.h"
+#include "llvm/Transforms/Coroutines/MaterializationUtils.h"
+#include "llvm/Transforms/Coroutines/SuspendCrossingInfo.h"
 
 namespace llvm {
 
@@ -30,7 +31,7 @@ namespace coro {
 // ABI operations. The ABIs (e.g. Switch, Async, Retcon{Once}) are the common
 // ABIs.
 
-class LLVM_LIBRARY_VISIBILITY BaseABI {
+class BaseABI {
 public:
   BaseABI(Function &F, coro::Shape &S,
           std::function<bool(Instruction &)> IsMaterializable)
@@ -56,7 +57,7 @@ public:
   std::function<bool(Instruction &I)> IsMaterializable;
 };
 
-class LLVM_LIBRARY_VISIBILITY SwitchABI : public BaseABI {
+class SwitchABI : public BaseABI {
 public:
   SwitchABI(Function &F, coro::Shape &S,
             std::function<bool(Instruction &)> IsMaterializable)
@@ -69,7 +70,7 @@ public:
                       TargetTransformInfo &TTI) override;
 };
 
-class LLVM_LIBRARY_VISIBILITY AsyncABI : public BaseABI {
+class AsyncABI : public BaseABI {
 public:
   AsyncABI(Function &F, coro::Shape &S,
            std::function<bool(Instruction &)> IsMaterializable)
@@ -82,7 +83,7 @@ public:
                       TargetTransformInfo &TTI) override;
 };
 
-class LLVM_LIBRARY_VISIBILITY AnyRetconABI : public BaseABI {
+class AnyRetconABI : public BaseABI {
 public:
   AnyRetconABI(Function &F, coro::Shape &S,
                std::function<bool(Instruction &)> IsMaterializable)

--- a/llvm/include/llvm/Transforms/Coroutines/CoroInstr.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroInstr.h
@@ -22,8 +22,8 @@
 // the Coroutine library.
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TRANSFORMS_COROUTINES_COROINSTR_H
-#define LLVM_LIB_TRANSFORMS_COROUTINES_COROINSTR_H
+#ifndef LLVM_TRANSFORMS_COROUTINES_COROINSTR_H
+#define LLVM_TRANSFORMS_COROUTINES_COROINSTR_H
 
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/IntrinsicInst.h"
@@ -32,7 +32,7 @@
 namespace llvm {
 
 /// This class represents the llvm.coro.subfn.addr instruction.
-class LLVM_LIBRARY_VISIBILITY CoroSubFnInst : public IntrinsicInst {
+class CoroSubFnInst : public IntrinsicInst {
   enum { FrameArg, IndexArg };
 
 public:
@@ -67,7 +67,7 @@ public:
 };
 
 /// This represents the llvm.coro.alloc instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAllocInst : public IntrinsicInst {
+class CoroAllocInst : public IntrinsicInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -82,7 +82,7 @@ public:
 // FIXME: add callback metadata
 // FIXME: make a proper IntrinisicInst. Currently this is not possible,
 // because llvm.coro.await.suspend.* can be invoked.
-class LLVM_LIBRARY_VISIBILITY CoroAwaitSuspendInst : public CallBase {
+class CoroAwaitSuspendInst : public CallBase {
   enum { AwaiterArg, FrameArg, WrapperArg };
 
 public:
@@ -112,7 +112,7 @@ public:
 };
 
 /// This represents a common base class for llvm.coro.id instructions.
-class LLVM_LIBRARY_VISIBILITY AnyCoroIdInst : public IntrinsicInst {
+class AnyCoroIdInst : public IntrinsicInst {
 public:
   CoroAllocInst *getCoroAlloc() {
     for (User *U : users())
@@ -143,7 +143,7 @@ public:
 };
 
 /// This represents the llvm.coro.id instruction.
-class LLVM_LIBRARY_VISIBILITY CoroIdInst : public AnyCoroIdInst {
+class CoroIdInst : public AnyCoroIdInst {
   enum { AlignArg, PromiseArg, CoroutineArg, InfoArg };
 
 public:
@@ -232,7 +232,7 @@ public:
 
 /// This represents either the llvm.coro.id.retcon or
 /// llvm.coro.id.retcon.once instruction.
-class LLVM_LIBRARY_VISIBILITY AnyCoroIdRetconInst : public AnyCoroIdInst {
+class AnyCoroIdRetconInst : public AnyCoroIdInst {
   enum { SizeArg, AlignArg, StorageArg, PrototypeArg, AllocArg, DeallocArg };
 
 public:
@@ -246,9 +246,7 @@ public:
     return cast<ConstantInt>(getArgOperand(AlignArg))->getAlignValue();
   }
 
-  Value *getStorage() const {
-    return getArgOperand(StorageArg);
-  }
+  Value *getStorage() const { return getArgOperand(StorageArg); }
 
   /// Return the prototype for the continuation function.  The type,
   /// attributes, and calling convention of the continuation function(s)
@@ -270,8 +268,8 @@ public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
     auto ID = I->getIntrinsicID();
-    return ID == Intrinsic::coro_id_retcon
-        || ID == Intrinsic::coro_id_retcon_once;
+    return ID == Intrinsic::coro_id_retcon ||
+           ID == Intrinsic::coro_id_retcon_once;
   }
   static bool classof(const Value *V) {
     return isa<IntrinsicInst>(V) && classof(cast<IntrinsicInst>(V));
@@ -279,8 +277,7 @@ public:
 };
 
 /// This represents the llvm.coro.id.retcon instruction.
-class LLVM_LIBRARY_VISIBILITY CoroIdRetconInst
-    : public AnyCoroIdRetconInst {
+class CoroIdRetconInst : public AnyCoroIdRetconInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -292,8 +289,7 @@ public:
 };
 
 /// This represents the llvm.coro.id.retcon.once instruction.
-class LLVM_LIBRARY_VISIBILITY CoroIdRetconOnceInst
-    : public AnyCoroIdRetconInst {
+class CoroIdRetconOnceInst : public AnyCoroIdRetconInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -305,7 +301,7 @@ public:
 };
 
 /// This represents the llvm.coro.id.async instruction.
-class LLVM_LIBRARY_VISIBILITY CoroIdAsyncInst : public AnyCoroIdInst {
+class CoroIdAsyncInst : public AnyCoroIdInst {
   enum { SizeArg, AlignArg, StorageArg, AsyncFuncPtrArg };
 
 public:
@@ -356,7 +352,7 @@ public:
 };
 
 /// This represents the llvm.coro.context.alloc instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAsyncContextAllocInst : public IntrinsicInst {
+class CoroAsyncContextAllocInst : public IntrinsicInst {
   enum { AsyncFuncPtrArg };
 
 public:
@@ -375,8 +371,7 @@ public:
 };
 
 /// This represents the llvm.coro.context.dealloc instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAsyncContextDeallocInst
-    : public IntrinsicInst {
+class CoroAsyncContextDeallocInst : public IntrinsicInst {
   enum { AsyncContextArg };
 
 public:
@@ -396,7 +391,7 @@ public:
 /// This represents the llvm.coro.async.resume instruction.
 /// During lowering this is replaced by the resume function of a suspend point
 /// (the continuation function).
-class LLVM_LIBRARY_VISIBILITY CoroAsyncResumeInst : public IntrinsicInst {
+class CoroAsyncResumeInst : public IntrinsicInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -408,7 +403,7 @@ public:
 };
 
 /// This represents the llvm.coro.async.size.replace instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAsyncSizeReplace : public IntrinsicInst {
+class CoroAsyncSizeReplace : public IntrinsicInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -420,7 +415,7 @@ public:
 };
 
 /// This represents the llvm.coro.frame instruction.
-class LLVM_LIBRARY_VISIBILITY CoroFrameInst : public IntrinsicInst {
+class CoroFrameInst : public IntrinsicInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -432,7 +427,7 @@ public:
 };
 
 /// This represents the llvm.coro.free instruction.
-class LLVM_LIBRARY_VISIBILITY CoroFreeInst : public IntrinsicInst {
+class CoroFreeInst : public IntrinsicInst {
   enum { IdArg, FrameArg };
 
 public:
@@ -447,8 +442,8 @@ public:
   }
 };
 
-/// This class represents the llvm.coro.begin instruction.
-class LLVM_LIBRARY_VISIBILITY CoroBeginInst : public IntrinsicInst {
+/// This class represents the llvm.coro.begin instructions.
+class CoroBeginInst : public IntrinsicInst {
   enum { IdArg, MemArg };
 
 public:
@@ -468,7 +463,7 @@ public:
 };
 
 /// This represents the llvm.coro.save instruction.
-class LLVM_LIBRARY_VISIBILITY CoroSaveInst : public IntrinsicInst {
+class CoroSaveInst : public IntrinsicInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -480,7 +475,7 @@ public:
 };
 
 /// This represents the llvm.coro.promise instruction.
-class LLVM_LIBRARY_VISIBILITY CoroPromiseInst : public IntrinsicInst {
+class CoroPromiseInst : public IntrinsicInst {
   enum { FrameArg, AlignArg, FromArg };
 
 public:
@@ -505,7 +500,7 @@ public:
   }
 };
 
-class LLVM_LIBRARY_VISIBILITY AnyCoroSuspendInst : public IntrinsicInst {
+class AnyCoroSuspendInst : public IntrinsicInst {
 public:
   CoroSaveInst *getCoroSave() const;
 
@@ -521,7 +516,7 @@ public:
 };
 
 /// This represents the llvm.coro.suspend instruction.
-class LLVM_LIBRARY_VISIBILITY CoroSuspendInst : public AnyCoroSuspendInst {
+class CoroSuspendInst : public AnyCoroSuspendInst {
   enum { SaveArg, FinalArg };
 
 public:
@@ -553,7 +548,7 @@ inline CoroSaveInst *AnyCoroSuspendInst::getCoroSave() const {
 }
 
 /// This represents the llvm.coro.suspend.async instruction.
-class LLVM_LIBRARY_VISIBILITY CoroSuspendAsyncInst : public AnyCoroSuspendInst {
+class CoroSuspendAsyncInst : public AnyCoroSuspendInst {
 public:
   enum {
     StorageArgNoArg,
@@ -594,7 +589,7 @@ public:
 };
 
 /// This represents the llvm.coro.suspend.retcon instruction.
-class LLVM_LIBRARY_VISIBILITY CoroSuspendRetconInst : public AnyCoroSuspendInst {
+class CoroSuspendRetconInst : public AnyCoroSuspendInst {
 public:
   op_iterator value_begin() { return arg_begin(); }
   const_op_iterator value_begin() const { return arg_begin(); }
@@ -619,7 +614,7 @@ public:
 };
 
 /// This represents the llvm.coro.size instruction.
-class LLVM_LIBRARY_VISIBILITY CoroSizeInst : public IntrinsicInst {
+class CoroSizeInst : public IntrinsicInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -631,7 +626,7 @@ public:
 };
 
 /// This represents the llvm.coro.align instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAlignInst : public IntrinsicInst {
+class CoroAlignInst : public IntrinsicInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -643,7 +638,7 @@ public:
 };
 
 /// This represents the llvm.end.results instruction.
-class LLVM_LIBRARY_VISIBILITY CoroEndResults : public IntrinsicInst {
+class CoroEndResults : public IntrinsicInst {
 public:
   op_iterator retval_begin() { return arg_begin(); }
   const_op_iterator retval_begin() const { return arg_begin(); }
@@ -671,7 +666,7 @@ public:
   }
 };
 
-class LLVM_LIBRARY_VISIBILITY AnyCoroEndInst : public IntrinsicInst {
+class AnyCoroEndInst : public IntrinsicInst {
   enum { FrameArg, UnwindArg, TokenArg };
 
 public:
@@ -700,7 +695,7 @@ public:
 };
 
 /// This represents the llvm.coro.end instruction.
-class LLVM_LIBRARY_VISIBILITY CoroEndInst : public AnyCoroEndInst {
+class CoroEndInst : public AnyCoroEndInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -712,7 +707,7 @@ public:
 };
 
 /// This represents the llvm.coro.end instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAsyncEndInst : public AnyCoroEndInst {
+class CoroAsyncEndInst : public AnyCoroEndInst {
   enum { FrameArg, UnwindArg, MustTailCallFuncArg };
 
 public:
@@ -736,12 +731,11 @@ public:
 };
 
 /// This represents the llvm.coro.alloca.alloc instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAllocaAllocInst : public IntrinsicInst {
+class CoroAllocaAllocInst : public IntrinsicInst {
   enum { SizeArg, AlignArg };
+
 public:
-  Value *getSize() const {
-    return getArgOperand(SizeArg);
-  }
+  Value *getSize() const { return getArgOperand(SizeArg); }
   Align getAlignment() const {
     return cast<ConstantInt>(getArgOperand(AlignArg))->getAlignValue();
   }
@@ -756,8 +750,9 @@ public:
 };
 
 /// This represents the llvm.coro.alloca.get instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAllocaGetInst : public IntrinsicInst {
+class CoroAllocaGetInst : public IntrinsicInst {
   enum { AllocArg };
+
 public:
   CoroAllocaAllocInst *getAlloc() const {
     return cast<CoroAllocaAllocInst>(getArgOperand(AllocArg));
@@ -773,8 +768,9 @@ public:
 };
 
 /// This represents the llvm.coro.alloca.free instruction.
-class LLVM_LIBRARY_VISIBILITY CoroAllocaFreeInst : public IntrinsicInst {
+class CoroAllocaFreeInst : public IntrinsicInst {
   enum { AllocArg };
+
 public:
   CoroAllocaAllocInst *getAlloc() const {
     return cast<CoroAllocaAllocInst>(getArgOperand(AllocArg));
@@ -791,4 +787,4 @@ public:
 
 } // End namespace llvm.
 
-#endif
+#endif // LLVM_TRANSFORMS_COROUTINES_COROINSTR_H

--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -12,9 +12,9 @@
 #ifndef LLVM_TRANSFORMS_COROUTINES_COROSHAPE_H
 #define LLVM_TRANSFORMS_COROUTINES_COROSHAPE_H
 
-#include "CoroInstr.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Transforms/Coroutines/CoroInstr.h"
 
 namespace llvm {
 
@@ -49,7 +49,7 @@ enum class ABI {
 
 // Holds structural Coroutine Intrinsics for a particular function and other
 // values used during CoroSplit pass.
-struct LLVM_LIBRARY_VISIBILITY Shape {
+struct Shape {
   CoroBeginInst *CoroBegin = nullptr;
   SmallVector<AnyCoroEndInst *, 4> CoroEnds;
   SmallVector<CoroSizeInst *, 2> CoroSizes;

--- a/llvm/include/llvm/Transforms/Coroutines/CoroSplit.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroSplit.h
@@ -18,6 +18,7 @@
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Transforms/Coroutines/ABI.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Transforms/Coroutines/MaterializationUtils.h
+++ b/llvm/include/llvm/Transforms/Coroutines/MaterializationUtils.h
@@ -6,11 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SuspendCrossingInfo.h"
-#include "llvm/IR/Instruction.h"
+#include "llvm/Transforms/Coroutines/SuspendCrossingInfo.h"
 
-#ifndef LIB_TRANSFORMS_COROUTINES_MATERIALIZATIONUTILS_H
-#define LIB_TRANSFORMS_COROUTINES_MATERIALIZATIONUTILS_H
+#ifndef LLVM_TRANSFORMS_COROUTINES_MATERIALIZATIONUTILS_H
+#define LLVM_TRANSFORMS_COROUTINES_MATERIALIZATIONUTILS_H
 
 namespace llvm {
 
@@ -27,4 +26,4 @@ void doRematerializations(Function &F, SuspendCrossingInfo &Checker,
 
 } // namespace llvm
 
-#endif // LIB_TRANSFORMS_COROUTINES_MATERIALIZATIONUTILS_H
+#endif // LLVM_TRANSFORMS_COROUTINES_MATERIALIZATIONUTILS_H

--- a/llvm/include/llvm/Transforms/Coroutines/SpillUtils.h
+++ b/llvm/include/llvm/Transforms/Coroutines/SpillUtils.h
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CoroInternal.h"
-#include "SuspendCrossingInfo.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/Transforms/Coroutines/CoroShape.h"
+#include "llvm/Transforms/Coroutines/SuspendCrossingInfo.h"
 
 #ifndef LLVM_TRANSFORMS_COROUTINES_SPILLINGINFO_H
 #define LLVM_TRANSFORMS_COROUTINES_SPILLINGINFO_H

--- a/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
+++ b/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
@@ -12,16 +12,16 @@
 // ptrs in the BlockToIndexMapping.
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TRANSFORMS_COROUTINES_SUSPENDCROSSINGINFO_H
-#define LLVM_LIB_TRANSFORMS_COROUTINES_SUSPENDCROSSINGINFO_H
+#ifndef LLVM_TRANSFORMS_COROUTINES_SUSPENDCROSSINGINFO_H
+#define LLVM_TRANSFORMS_COROUTINES_SUSPENDCROSSINGINFO_H
 
-#include "CoroInstr.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instruction.h"
+#include "llvm/Transforms/Coroutines/CoroInstr.h"
 
 namespace llvm {
 

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -8,12 +8,12 @@
 
 #include "llvm/Transforms/Coroutines/CoroEarly.h"
 #include "CoroInternal.h"
-#include "CoroShape.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Transforms/Coroutines/CoroShape.h"
 
 using namespace llvm;
 

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -15,11 +15,7 @@
 // the value into the coroutine frame.
 //===----------------------------------------------------------------------===//
 
-#include "ABI.h"
 #include "CoroInternal.h"
-#include "MaterializationUtils.h"
-#include "SpillUtils.h"
-#include "SuspendCrossingInfo.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallString.h"
@@ -33,6 +29,11 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/OptimizedStructLayout.h"
+#include "llvm/Transforms/Coroutines/ABI.h"
+#include "llvm/Transforms/Coroutines/CoroInstr.h"
+#include "llvm/Transforms/Coroutines/MaterializationUtils.h"
+#include "llvm/Transforms/Coroutines/SpillUtils.h"
+#include "llvm/Transforms/Coroutines/SuspendCrossingInfo.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Transforms/Utils/PromoteMemToReg.h"

--- a/llvm/lib/Transforms/Coroutines/CoroInternal.h
+++ b/llvm/lib/Transforms/Coroutines/CoroInternal.h
@@ -11,10 +11,10 @@
 #ifndef LLVM_LIB_TRANSFORMS_COROUTINES_COROINTERNAL_H
 #define LLVM_LIB_TRANSFORMS_COROUTINES_COROINTERNAL_H
 
-#include "CoroInstr.h"
-#include "CoroShape.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/Transforms/Coroutines/CoroInstr.h"
+#include "llvm/Transforms/Coroutines/CoroShape.h"
 
 namespace llvm {
 

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -19,10 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Coroutines/CoroSplit.h"
-#include "ABI.h"
-#include "CoroInstr.h"
 #include "CoroInternal.h"
-#include "MaterializationUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PriorityWorklist.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -64,6 +61,9 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Coroutines/ABI.h"
+#include "llvm/Transforms/Coroutines/CoroInstr.h"
+#include "llvm/Transforms/Coroutines/MaterializationUtils.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/CallGraphUpdater.h"

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -10,10 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "ABI.h"
-#include "CoroInstr.h"
 #include "CoroInternal.h"
-#include "CoroShape.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/CallGraph.h"
@@ -29,6 +26,9 @@
 #include "llvm/IR/Type.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Transforms/Coroutines/ABI.h"
+#include "llvm/Transforms/Coroutines/CoroInstr.h"
+#include "llvm/Transforms/Coroutines/CoroShape.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include <cassert>
 #include <cstddef>

--- a/llvm/lib/Transforms/Coroutines/MaterializationUtils.cpp
+++ b/llvm/lib/Transforms/Coroutines/MaterializationUtils.cpp
@@ -9,12 +9,13 @@
 // This file contains classes used to materialize insts after suspends points.
 //===----------------------------------------------------------------------===//
 
-#include "MaterializationUtils.h"
-#include "SpillUtils.h"
+#include "llvm/Transforms/Coroutines/MaterializationUtils.h"
+#include "CoroInternal.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instruction.h"
+#include "llvm/Transforms/Coroutines/SpillUtils.h"
 #include <deque>
 
 using namespace llvm;

--- a/llvm/lib/Transforms/Coroutines/SpillUtils.cpp
+++ b/llvm/lib/Transforms/Coroutines/SpillUtils.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SpillUtils.h"
+#include "llvm/Transforms/Coroutines/SpillUtils.h"
+#include "CoroInternal.h"
 #include "llvm/Analysis/CFG.h"
 #include "llvm/Analysis/PtrUseVisitor.h"
 #include "llvm/IR/CFG.h"

--- a/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
+++ b/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
@@ -12,7 +12,7 @@
 // ptrs in the BlockToIndexMapping.
 //===----------------------------------------------------------------------===//
 
-#include "SuspendCrossingInfo.h"
+#include "llvm/Transforms/Coroutines/SuspendCrossingInfo.h"
 
 // The "coro-suspend-crossing" flag is very noisy. There is another debug type,
 // "coro-frame", which results in leaner debug spew.

--- a/llvm/unittests/Transforms/Coroutines/ExtraRematTest.cpp
+++ b/llvm/unittests/Transforms/Coroutines/ExtraRematTest.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Testing/Support/Error.h"
+#include "llvm/Transforms/Coroutines/ABI.h"
 #include "llvm/Transforms/Coroutines/CoroSplit.h"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Plugin libraries that use coroutines can do so right now, however, to provide their own ABI they need to be able to use various headers, some of which such are required (such as the ABI header). This change exposes the coro utils and required headers by moving them to include/llvm/Transforms/Coroutines. My experience with our out-of-tree plugin ABI has been that at least these headers are needed. The headers moved are:
* ABI.h (ABI object)
* CoroInstr.h (helpers)
 * Coroshape.h (Shape object)
 * MaterializationUtils.h (helpers)
 * SpillingUtils.h (helpers)
 * SuspendCrossingInfo.h (analysis)

This has no code changes other than those required to move the headers and these are:
 * include guard name changes
 * include path changes
 * minor clang-format induced changes
 * removal of LLVM_LIBRARY_VISIBILITY