### PR TITLE
[IR] Prevent implicit SymbolTableListTraits template instantiation

### DIFF
--- a/llvm/include/llvm/IR/SymbolTableListTraits.h
+++ b/llvm/include/llvm/IR/SymbolTableListTraits.h
@@ -106,6 +106,15 @@ public:
   static ValueSymbolTable *toPtr(ValueSymbolTable &R) { return &R; }
 };
 
+// The SymbolTableListTraits template is explicitly instantiated for the
+// following data types, so add extern template statements to prevent implicit
+// instantiation.
+extern template class SymbolTableListTraits<BasicBlock>;
+extern template class SymbolTableListTraits<Function>;
+extern template class SymbolTableListTraits<GlobalAlias>;
+extern template class SymbolTableListTraits<GlobalIFunc>;
+extern template class SymbolTableListTraits<GlobalVariable>;
+
 /// List that automatically updates parent links and symbol tables.
 ///
 /// When nodes are inserted into and removed from this list, the associated


### PR DESCRIPTION
The `SymbolTableListTraits` template is explicitly instantiated for the
following types:
  * `llvm/lib/IR/Function.cpp`
    - `BasicBlock`
  * `llvm/lib/IR/Module.cpp`
    - `Function`
    - `GlobalAlias`
    - `GlobalIFunc`
    - `GlobalVariable`

When LLVM is built on Windows with the `LLVM_EXPORT_SYMBOLS_FOR_PLUGINS`
option enabled, the implicit instantiation of the template prevents the
`SymbolTableListTraits` template from being exported. This causes link
errors when the template or IR API is used in a plugin.

This change prevents the template being implicitly instantiated for
these types.