### PR TITLE
[mlir] add missing CMake dependency on ShardingInterface generated headers for LinalgDialect

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
@@ -13,7 +13,7 @@ add_mlir_dialect_library(MLIRLinalgDialect
   MLIRLinalgOpsEnumsIncGen
   MLIRLinalgOpsIncGen
   MLIRLinalgStructuredOpsIncGen
-  MLIRShardingInterface
+  MLIRShardingInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_dialect_library(MLIRLinalgDialect
   MLIRLinalgOpsEnumsIncGen
   MLIRLinalgOpsIncGen
   MLIRLinalgStructuredOpsIncGen
+  MLIRShardingInterface
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect


### PR DESCRIPTION
This fixes non-deterministic build failures.

Fixes https://github.com/llvm/llvm-project/issues/111527