### PR TITLE
[MachineVerifier] Report errors from one thread at a time

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -95,6 +95,8 @@ using namespace llvm;
 
 namespace {
 
+/// Used the by the ReportedErrors class to guarantee only one error is reported
+/// at one time.
 static ManagedStatic<sys::SmartMutex<true>> ReportedErrorsLock;
 
 struct MachineVerifier {
@@ -239,12 +241,16 @@ struct MachineVerifier {
   LiveStacks *LiveStks = nullptr;
   SlotIndexes *Indexes = nullptr;
 
+  /// A class to track the number of reported error and to guarantee that only
+  /// one error is reported at one time.
   class ReportedErrors {
     unsigned NumReported = 0;
     bool AbortOnError;
 
   public:
+    /// \param AbortOnError -- If set, abort after printing the first error.
     ReportedErrors(bool AbortOnError) : AbortOnError(AbortOnError) {}
+
     ~ReportedErrors() {
       if (!hasError())
         return;
@@ -268,6 +274,7 @@ struct MachineVerifier {
       return NumReported == 1;
     }
 
+    /// \returns true if an error was reported.
     bool hasError() { return NumReported; }
   };
   ReportedErrors ReportedErrs;

--- a/llvm/test/MachineVerifier/test_g_multiple_errors.mir
+++ b/llvm/test/MachineVerifier/test_g_multiple_errors.mir
@@ -1,0 +1,22 @@
+# RUN: not --crash llc -mtriple=aarch64 -o /dev/null -run-pass=none -verify-machineinstrs %s 2>&1 | FileCheck %s --implicit-check-not="Bad machine code"
+# REQUIRES: aarch64-registered-target
+
+# Check that errors are reported from only one function.
+# CHECK: *** Bad machine code: Generic virtual register use cannot be undef ***
+# CHECK: Found 1 machine code errors.
+
+---
+name:            foo
+liveins:
+body:             |
+  bb.0:
+    $x0 = COPY undef %0:_(s64)
+...
+
+---
+name:            bar
+liveins:
+body:             |
+  bb.0:
+    $x0 = COPY undef %0:_(s64)
+...

--- a/llvm/test/MachineVerifier/test_multiple_errors.mir
+++ b/llvm/test/MachineVerifier/test_multiple_errors.mir
@@ -1,7 +1,7 @@
-# RUN: not --crash llc -mtriple=aarch64 -o /dev/null -run-pass=none -verify-machineinstrs %s 2>&1 | FileCheck %s --implicit-check-not="Bad machine code"
+# RUN: not --crash llc -mtriple=aarch64 -o /dev/null -run-pass=none %s 2>&1 | FileCheck %s --implicit-check-not="Bad machine code"
 # REQUIRES: aarch64-registered-target
 
-# Check that errors are reported from only one function.
+# Since we abort after reporting the first error, we should only expect one error to be reported.
 # CHECK: *** Bad machine code: Generic virtual register use cannot be undef ***
 # CHECK: Found 1 machine code errors.
 


### PR DESCRIPTION
Create the `ReportedErrors` class to track the number of reported errors during verification. The class will block reporting errors if some other thread is currently reporting an error.

I've encountered a case where there were many different verifications reporting errors at the same time on different threads. This ensures that we don't start printing the error from one case until we are completely done printing errors from other cases. Most of the time `AbortOnError = true` so we usually abort after reporting the first error.

Depends on https://github.com/llvm/llvm-project/pull/111602.