### PR TITLE
[RISCV] Use the MCStreamer reference passed to RISCVAsmPrinter::EmitToStreamer. NFCI

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -247,7 +247,7 @@ bool RISCVAsmPrinter::EmitToStreamer(MCStreamer &S, const MCInst &Inst) {
   bool Res = RISCVRVC::compress(CInst, Inst, *STI);
   if (Res)
     ++RISCVNumInstrsCompressed;
-  AsmPrinter::EmitToStreamer(*OutStreamer, Res ? CInst : Inst);
+  AsmPrinter::EmitToStreamer(S, Res ? CInst : Inst);
   return Res;
 }
 


### PR DESCRIPTION
We passed a MCStreamer to the function but hardcoded *OutStreamer instead of using it. It's very likely that OutStreamer is the only streamer used, but lets not assume that without doing the audit.