### PR TITLE
[Clang][perf-training] Do build of libLLVMSupport for perf training

### DIFF
--- a/clang/utils/perf-training/bolt.lit.cfg
+++ b/clang/utils/perf-training/bolt.lit.cfg
@@ -49,3 +49,6 @@ config.substitutions.append(("%clang_cpp", f" {config.clang} --driver-mode=g++ "
 config.substitutions.append(("%clang_skip_driver", config.clang))
 config.substitutions.append(("%clang", config.clang))
 config.substitutions.append(("%test_root", config.test_exec_root))
+config.substitutions.append(('%cmake_generator', config.cmake_generator))
+config.substitutions.append(('%cmake', config.cmake_exe))
+config.substitutions.append(('%llvm_src_dir', config.llvm_src_dir))

--- a/clang/utils/perf-training/bolt.lit.site.cfg.in
+++ b/clang/utils/perf-training/bolt.lit.site.cfg.in
@@ -11,6 +11,9 @@ config.python_exe = "@Python3_EXECUTABLE@"
 config.clang_obj_root = path(r"@CLANG_BINARY_DIR@")
 config.clang_bolt_mode = "@CLANG_BOLT@"
 config.clang_bolt_name = "@CLANG_BOLT_INSTRUMENTED@"
+config.cmake_exe = "@CMAKE_COMMAND@"
+config.llvm_src_dir ="@CMAKE_SOURCE_DIR@"
+config.cmake_generator ="@CMAKE_GENERATOR@"
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CLANG_SOURCE_DIR@/utils/perf-training/bolt.lit.cfg")

--- a/clang/utils/perf-training/lit.cfg
+++ b/clang/utils/perf-training/lit.cfg
@@ -40,6 +40,5 @@ config.substitutions.append( ('%cmake_generator', config.cmake_generator ) )
 config.substitutions.append( ('%cmake', config.cmake_exe ) )
 config.substitutions.append( ('%llvm_src_dir', config.llvm_src_dir ) )
 
-print(config.substitutions)
 config.environment['LLVM_PROFILE_FILE'] = 'perf-training-%4m.profraw'
 

--- a/clang/utils/perf-training/lit.cfg
+++ b/clang/utils/perf-training/lit.cfg
@@ -34,8 +34,12 @@ config.test_format = lit.formats.ShTest(use_lit_shell == "0")
 config.substitutions.append( ('%clang_cpp_skip_driver', ' %s %s %s ' % (cc1_wrapper, config.clang, sysroot_flags)))
 config.substitutions.append( ('%clang_cpp', ' %s --driver-mode=g++ %s ' % (config.clang, sysroot_flags)))
 config.substitutions.append( ('%clang_skip_driver', ' %s %s %s ' % (cc1_wrapper, config.clang, sysroot_flags)))
-config.substitutions.append( ('%clang', ' %s %s ' % (config.clang, sysroot_flags) ) )
+config.substitutions.append( ('%clang', '%s %s ' % (config.clang, sysroot_flags) ) )
 config.substitutions.append( ('%test_root', config.test_exec_root ) )
+config.substitutions.append( ('%cmake_generator', config.cmake_generator ) )
+config.substitutions.append( ('%cmake', config.cmake_exe ) )
+config.substitutions.append( ('%llvm_src_dir', config.llvm_src_dir ) )
 
+print(config.substitutions)
 config.environment['LLVM_PROFILE_FILE'] = 'perf-training-%4m.profraw'
 

--- a/clang/utils/perf-training/lit.site.cfg.in
+++ b/clang/utils/perf-training/lit.site.cfg.in
@@ -8,6 +8,9 @@ config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 config.test_source_root = "@CLANG_PGO_TRAINING_DATA@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_exe = "@Python3_EXECUTABLE@"
+config.cmake_exe = "@CMAKE_COMMAND@"
+config.llvm_src_dir ="@CMAKE_SOURCE_DIR@"
+config.cmake_generator ="@CMAKE_GENERATOR@"
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CLANG_SOURCE_DIR@/utils/perf-training/lit.cfg")

--- a/clang/utils/perf-training/llvm-support/build.test
+++ b/clang/utils/perf-training/llvm-support/build.test
@@ -1,0 +1,2 @@
+RUN: %cmake -G %cmake_generator -B %t -S %llvm_src_dir -DCMAKE_C_COMPILER=%clang -DCMAKE_CXX_COMPILER=%clang -DCMAKE_CXX_FLAGS="--driver-mode=g++" -DCMAKE_BUILD_TYPE=Release
+RUN: %cmake --build %t -v --target LLVMSupport


### PR DESCRIPTION
This adds a build of the libLLVMSupport to the lit suite that is used for generating profile data.  This helps to improve both PGO and BOLT optimization of clang over the existing hello world training program.

I considered building all of LLVM instead of just libLLVMSupport, but there is only a marginal increase in performance for PGO only builds when training with a build of all of LLVM, and I didn't think it was enough to justify the increased build times given that it is the default configuration.

The benchmark[1] I did showed that using libLLVMSupport for training gives a 1.35 +- 0.02 speed up for clang optimized with PGO + BOLT vs just 1.05 +- 0.01 speed up when training with hello world.

For comparison, training with a full LLVM build gave a speed up of 1.35 +- 0.1.

Raw data:

| PGO Training | BOLT Training | Speed Up | Error Range |
| ------------ | ------------- | -------- | ----------- |
| LLVM Support | LLVM Support  | 1.35     | 0.02        |
| LLVM All     | LLVM All      | 1.34     | 0.01        |
| LLVM Support | Hello World   | 1.29     | 0.02        |
| LLVM All     | PGO-ONLY      | 1.27     | 0.02        |
| LLVM Support | PGO-ONLY      | 1.22     | 0.02        |
| Hello World  | Hello World   | 1.05     | 0.01        |
| Hello World  | PGO-ONLY      | 1.03     | 0.01        |

Time it takes to generate profile data (on a 64-core system):

| Training Data | PGO   | BOLT  |
| ------------- | ----- | ----- |
| LLVM All      | 1090s | 3239s |
| LLVM Support  |   91s |  655s |
| Hello World  |    2s |    9s |

[1] Benchmark was compiling SemaDecl.cpp