### PR TITLE
[MIR] Add missing noteNewVirtualRegister callbacks

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1786,6 +1786,7 @@ bool MIParser::parseRegisterOperand(MachineOperand &Dest,
 
         MRI.setRegClassOrRegBank(Reg, static_cast<RegisterBank *>(nullptr));
         MRI.setType(Reg, Ty);
+        MRI.noteNewVirtualRegister(Reg);
       }
     }
   } else if (consumeIfPresent(MIToken::lparen)) {

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -652,10 +652,10 @@ MIRParserImpl::initializeMachineFunction(const yaml::MachineFunction &YamlMF,
 bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
                                       const yaml::MachineFunction &YamlMF) {
   MachineFunction &MF = PFS.MF;
-  MachineRegisterInfo &MRI = MF.getRegInfo();
+  MachineRegisterInfo &RegInfo = MF.getRegInfo();
   assert(RegInfo.tracksLiveness());
   if (!YamlMF.TracksRegLiveness)
-    MRI.invalidateLiveness();
+    RegInfo.invalidateLiveness();
 
   SMDiagnostic Error;
   // Parse the virtual register information.
@@ -705,7 +705,7 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
                          FlagStringValue.Value + "'");
       Info.Flags.push_back(FlagValue);
     }
-    MRI.noteNewVirtualRegister(Info.VReg);
+    RegInfo.noteNewVirtualRegister(Info.VReg);
   }
 
   // Parse the liveins.
@@ -721,7 +721,7 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(Error, LiveIn.VirtualRegister.SourceRange);
       VReg = Info->VReg;
     }
-    MRI.addLiveIn(Reg, VReg);
+    RegInfo.addLiveIn(Reg, VReg);
   }
 
   // Parse the callee saved registers (Registers that will
@@ -734,7 +734,7 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(Error, RegSource.SourceRange);
       CalleeSavedRegisters.push_back(Reg);
     }
-    MRI.setCalleeSavedRegs(CalleeSavedRegisters);
+    RegInfo.setCalleeSavedRegs(CalleeSavedRegisters);
   }
 
   return false;

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -652,10 +652,10 @@ MIRParserImpl::initializeMachineFunction(const yaml::MachineFunction &YamlMF,
 bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
                                       const yaml::MachineFunction &YamlMF) {
   MachineFunction &MF = PFS.MF;
-  MachineRegisterInfo &RegInfo = MF.getRegInfo();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
   assert(RegInfo.tracksLiveness());
   if (!YamlMF.TracksRegLiveness)
-    RegInfo.invalidateLiveness();
+    MRI.invalidateLiveness();
 
   SMDiagnostic Error;
   // Parse the virtual register information.
@@ -705,6 +705,7 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
                          FlagStringValue.Value + "'");
       Info.Flags.push_back(FlagValue);
     }
+    MRI.noteNewVirtualRegister(Info.VReg);
   }
 
   // Parse the liveins.
@@ -720,7 +721,7 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(Error, LiveIn.VirtualRegister.SourceRange);
       VReg = Info->VReg;
     }
-    RegInfo.addLiveIn(Reg, VReg);
+    MRI.addLiveIn(Reg, VReg);
   }
 
   // Parse the callee saved registers (Registers that will
@@ -733,7 +734,7 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(Error, RegSource.SourceRange);
       CalleeSavedRegisters.push_back(Reg);
     }
-    RegInfo.setCalleeSavedRegs(CalleeSavedRegisters);
+    MRI.setCalleeSavedRegs(CalleeSavedRegisters);
   }
 
   return false;


### PR DESCRIPTION
The delegates' callback isn't invoked on parsing new virtual registers.

There are two places in the serialization where new virtual registers can be discovered: in register infos and in instructions.