### PR TITLE
Insert `// NOLINTNEXTLINE(...)` for clang-tidy diagnostics

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
@@ -132,6 +132,7 @@ protected:
         assert(false && "Fix conflicts with existing fix!");
       }
     }
+    // TODO: Maybe add extra fixit here
   }
 
   void emitIncludeLocation(FullSourceLoc Loc, PresumedLoc PLoc) override {}

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -98,6 +98,7 @@ add_clang_library(clangDaemon STATIC
   InlayHints.cpp
   JSONTransport.cpp
   ModulesBuilder.cpp
+  NoLintFixes.cpp
   PathMapping.cpp
   Protocol.cpp
   Quality.cpp

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -44,6 +44,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -672,6 +673,21 @@ tryConvertToRename(const Diag *Diag, const Fix &Fix) {
   return std::nullopt;
 }
 
+// Add NOLINT insert as code actions
+std::optional<Fix> tryAddClangTidySuppression(const Diag *Diag) {
+  if (Diag->Source == Diag::ClangTidy) {
+    Fix F;
+    F.Message = llvm::formatv("ignore [{0}] for this line", Diag->Name);
+    TextEdit &E = F.Edits.emplace_back();
+    E.newText = llvm::formatv("// NOLINTNEXTLINE({0})\n", Diag->Name);
+    Position InsertPos = Diag->Range.start;
+    InsertPos.character = 0;
+    E.range = {InsertPos, InsertPos};
+    return F;
+  }
+  return std::nullopt;
+}
+
 } // namespace
 
 void ClangdServer::codeAction(const CodeActionInputs &Params,
@@ -701,7 +717,7 @@ void ClangdServer::codeAction(const CodeActionInputs &Params,
         return nullptr;
       };
       for (const auto &DiagRef : Params.Diagnostics) {
-        if (const auto *Diag = FindMatchedDiag(DiagRef))
+        if (const auto *Diag = FindMatchedDiag(DiagRef)) {
           for (const auto &Fix : Diag->Fixes) {
             if (auto Rename = tryConvertToRename(Diag, Fix)) {
               Result.Renames.emplace_back(std::move(*Rename));
@@ -709,6 +725,11 @@ void ClangdServer::codeAction(const CodeActionInputs &Params,
               Result.QuickFixes.push_back({DiagRef, Fix});
             }
           }
+
+          if (auto Fix = tryAddClangTidySuppression(Diag)) {
+            Result.QuickFixes.push_back({DiagRef, std::move(*Fix)});
+          }
+        }
       }
     }
 

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -832,8 +832,8 @@ void StoreDiags::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
     LastDiagOriginallyError = OriginallyError;
     if (!Info.getFixItHints().empty())
       AddFix(true /* try to invent a message instead of repeating the diag */);
-    if (Fixer) {
-      auto ExtraFixes = Fixer(*LastDiag, Info);
+    if (MainFixer) {
+      auto ExtraFixes = MainFixer(*LastDiag, Info);
       LastDiag->Fixes.insert(LastDiag->Fixes.end(), ExtraFixes.begin(),
                              ExtraFixes.end());
     }
@@ -851,8 +851,8 @@ void StoreDiags::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
       return;
 
     // Give include-fixer a chance to replace a note with a fix.
-    if (Fixer) {
-      auto ReplacementFixes = Fixer(*LastDiag, Info);
+    if (NoteFixer) {
+      auto ReplacementFixes = NoteFixer(*LastDiag, Info);
       if (!ReplacementFixes.empty()) {
         assert(Info.getNumFixItHints() == 0 &&
                "Include-fixer replaced a note with clang fix-its attached!");

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -312,7 +312,7 @@ std::string mainMessage(const Diag &D, const ClangdDiagnosticOptions &Opts) {
   llvm::raw_string_ostream OS(Result);
   OS << D.Message;
   if (Opts.DisplayFixesCount && !D.Fixes.empty())
-    OS << " (" << (D.Fixes.size() > 1 ? "fixes" : "fix") << " available)";
+    OS << " (" << (D.Fixes.size() > 1 ? "fixes" : "fix") << " available)"; // TODO
   // If notes aren't emitted as structured info, add them to the message.
   if (!Opts.EmitRelatedLocations)
     for (auto &Note : D.Notes) {

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -854,8 +854,6 @@ void StoreDiags::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
     if (Fixer) {
       auto ReplacementFixes = Fixer(*LastDiag, Info);
       if (!ReplacementFixes.empty()) {
-        assert(Info.getNumFixItHints() == 0 &&
-               "Include-fixer replaced a note with clang fix-its attached!");
         LastDiag->Fixes.insert(LastDiag->Fixes.end(), ReplacementFixes.begin(),
                                ReplacementFixes.end());
         return;

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -854,6 +854,8 @@ void StoreDiags::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
     if (Fixer) {
       auto ReplacementFixes = Fixer(*LastDiag, Info);
       if (!ReplacementFixes.empty()) {
+        assert(Info.getNumFixItHints() == 0 &&
+               "Include-fixer replaced a note with clang fix-its attached!");
         LastDiag->Fixes.insert(LastDiag->Fixes.end(), ReplacementFixes.begin(),
                                ReplacementFixes.end());
         return;

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -317,7 +317,7 @@ std::string mainMessage(const Diag &D, const ClangdDiagnosticOptions &Opts) {
   // the fixes is just to suppress could be misleading.
   int RealFixCount = D.Fixes.size();
   for (auto const &Fix : D.Fixes) {
-    if (isClangTidyNoLintFixes(Fix)) {
+    if (isNoLintFixes(Fix)) {
       RealFixCount--;
     }
   }

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -823,7 +823,7 @@ void StoreDiags::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
     if (!Info.getFixItHints().empty())
       AddFix(true /* try to invent a message instead of repeating the diag */);
     if (Fixer) {
-      auto ExtraFixes = Fixer(LastDiag->Severity, Info);
+      auto ExtraFixes = Fixer(*LastDiag, Info);
       LastDiag->Fixes.insert(LastDiag->Fixes.end(), ExtraFixes.begin(),
                              ExtraFixes.end());
     }
@@ -842,7 +842,7 @@ void StoreDiags::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
 
     // Give include-fixer a chance to replace a note with a fix.
     if (Fixer) {
-      auto ReplacementFixes = Fixer(LastDiag->Severity, Info);
+      auto ReplacementFixes = Fixer(*LastDiag, Info);
       if (!ReplacementFixes.empty()) {
         assert(Info.getNumFixItHints() == 0 &&
                "Include-fixer replaced a note with clang fix-its attached!");

--- a/clang-tools-extra/clangd/Diagnostics.h
+++ b/clang-tools-extra/clangd/Diagnostics.h
@@ -147,15 +147,18 @@ public:
                         const clang::Diagnostic &Info) override;
 
   /// When passed a main diagnostic, returns fixes to add to it.
+  using MainDiagFixer =
+      std::function<std::vector<Fix>(const Diag &, const clang::Diagnostic &)>;
   /// When passed a note diagnostic, returns fixes to replace it with.
-  using DiagFixer =
+  using NoteDiagFixer =
       std::function<std::vector<Fix>(const Diag &, const clang::Diagnostic &)>;
   using LevelAdjuster = std::function<DiagnosticsEngine::Level(
       DiagnosticsEngine::Level, const clang::Diagnostic &)>;
   using DiagCallback =
       std::function<void(const clang::Diagnostic &, clangd::Diag &)>;
   /// If set, possibly adds fixes for diagnostics using \p Fixer.
-  void contributeFixes(DiagFixer Fixer) { this->Fixer = Fixer; }
+  void contributeMainDiagFixes(MainDiagFixer Fixer) { this->MainFixer = Fixer; }
+  void contributeNoteDiagFixes(NoteDiagFixer Fixer) { this->NoteFixer = Fixer; }
   /// If set, this allows the client of this class to adjust the level of
   /// diagnostics, such as promoting warnings to errors, or ignoring
   /// diagnostics.
@@ -167,7 +170,8 @@ public:
 private:
   void flushLastDiag();
 
-  DiagFixer Fixer = nullptr;
+  MainDiagFixer MainFixer = nullptr;
+  NoteDiagFixer NoteFixer = nullptr;
   LevelAdjuster Adjuster = nullptr;
   DiagCallback DiagCB = nullptr;
   std::vector<Diag> Output;

--- a/clang-tools-extra/clangd/Diagnostics.h
+++ b/clang-tools-extra/clangd/Diagnostics.h
@@ -148,8 +148,8 @@ public:
 
   /// When passed a main diagnostic, returns fixes to add to it.
   /// When passed a note diagnostic, returns fixes to replace it with.
-  using DiagFixer = std::function<std::vector<Fix>(DiagnosticsEngine::Level,
-                                                   const clang::Diagnostic &)>;
+  using DiagFixer =
+      std::function<std::vector<Fix>(const Diag &, const clang::Diagnostic &)>;
   using LevelAdjuster = std::function<DiagnosticsEngine::Level(
       DiagnosticsEngine::Level, const clang::Diagnostic &)>;
   using DiagCallback =

--- a/clang-tools-extra/clangd/NoLintFixes.cpp
+++ b/clang-tools-extra/clangd/NoLintFixes.cpp
@@ -39,7 +39,7 @@ namespace clang {
 namespace clangd {
 
 std::vector<Fix>
-clangTidyNoLintFixes(const clang::tidy::ClangTidyContext &CTContext,
+noLintFixes(const clang::tidy::ClangTidyContext &CTContext,
                      const clang::Diagnostic &Info, const Diag &Diag) {
   auto RuleName = CTContext.getCheckName(Diag.ID);
   if (
@@ -93,9 +93,9 @@ clangTidyNoLintFixes(const clang::tidy::ClangTidyContext &CTContext,
   return {F};
 }
 
-const auto MsgRegex = std::regex("ignore \\[.*\\] for this line");
-bool isClangTidyNoLintFixes(const Fix &F) {
-  return std::regex_match(F.Message, MsgRegex);
+const auto Regex = std::regex(NoLintFixMsgRegexStr);
+bool isNoLintFixes(const Fix &F) {
+  return std::regex_match(F.Message, Regex);
 }
 
 } // namespace clangd

--- a/clang-tools-extra/clangd/NoLintFixes.cpp
+++ b/clang-tools-extra/clangd/NoLintFixes.cpp
@@ -1,0 +1,102 @@
+//===--- NoLintFixes.cpp -------------------------------------------*-
+// C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "NoLintFixes.h"
+#include "../clang-tidy/ClangTidyCheck.h"
+#include "../clang-tidy/ClangTidyDiagnosticConsumer.h"
+#include "../clang-tidy/ClangTidyModule.h"
+#include "AST.h"
+#include "Diagnostics.h"
+#include "FeatureModule.h"
+#include "SourceCode.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticIDs.h"
+#include "clang/Basic/LLVM.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/CompilerInvocation.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Serialization/ASTWriter.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include <cassert>
+#include <cctype>
+#include <optional>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace clang {
+namespace clangd {
+
+std::vector<Fix>
+clangTidyNoLintFixes(const clang::tidy::ClangTidyContext &CTContext,
+                     const clang::Diagnostic &Info, const Diag &Diag) {
+  auto RuleName = CTContext.getCheckName(Diag.ID);
+  if (
+      // If this isn't a clang-tidy diag
+      RuleName.empty() ||
+      // NOLINT does not work on Serverity Error or above
+      Diag.Severity >= DiagnosticsEngine::Error ||
+      // No point adding extra fixes if the Diag is for a different file
+      !Diag.InsideMainFile) {
+    return {};
+  }
+
+  auto &SrcMgr = Info.getSourceManager();
+  auto &DiagLoc = Info.getLocation();
+
+  auto F = Fix{};
+  F.Message = llvm::formatv("ignore [{0}] for this line", RuleName);
+  auto &E = F.Edits.emplace_back();
+
+  auto File = SrcMgr.getFileID(DiagLoc);
+  auto CodeTilDiag = toSourceCode(
+      SrcMgr, SourceRange(SrcMgr.getLocForStartOfFile(File), DiagLoc));
+
+  auto StartCurLine = CodeTilDiag.find_last_of('\n') + 1;
+  auto CurLine = CodeTilDiag.substr(StartCurLine);
+  auto Indent = CurLine.take_while([](char C) { return std::isspace(C); });
+
+  auto ExistingNoLintNextLineInsertPos = std::optional<int>();
+  if (StartCurLine > 0) {
+    auto StartPrevLine = CodeTilDiag.find_last_of('\n', StartCurLine - 1) + 1;
+    auto PrevLine =
+        CodeTilDiag.substr(StartPrevLine, StartCurLine - StartPrevLine - 1);
+    auto NLPos = PrevLine.find("NOLINTNEXTLINE(");
+    if (NLPos != StringRef::npos) {
+      ExistingNoLintNextLineInsertPos =
+          std::make_optional(PrevLine.find(")", NLPos));
+    }
+  }
+
+  auto InsertPos = sourceLocToPosition(SrcMgr, DiagLoc);
+  if (ExistingNoLintNextLineInsertPos) {
+    E.newText = llvm::formatv(", {0}", RuleName);
+    InsertPos.line -= 1;
+    InsertPos.character = *ExistingNoLintNextLineInsertPos;
+  } else {
+    E.newText = llvm::formatv("{0}// NOLINTNEXTLINE({1})\n", Indent, RuleName);
+    InsertPos.character = 0;
+  }
+  E.range = {InsertPos, InsertPos};
+
+  return {F};
+}
+
+const auto MsgRegex = std::regex("ignore \\[.*\\] for this line");
+bool isClangTidyNoLintFixes(const Fix &F) {
+  return std::regex_match(F.Message, MsgRegex);
+}
+
+} // namespace clangd
+} // namespace clang

--- a/clang-tools-extra/clangd/NoLintFixes.h
+++ b/clang-tools-extra/clangd/NoLintFixes.h
@@ -22,12 +22,13 @@ namespace clangd {
 
 /// Suggesting to insert "\\ NOLINTNEXTLINE(...)" to suppress clang-tidy
 /// diagnostics.
-std::vector<Fix>
-clangTidyNoLintFixes(const clang::tidy::ClangTidyContext &CTContext,
-                     const clang::Diagnostic &Info, const Diag &Diag);
+std::vector<Fix> noLintFixes(const clang::tidy::ClangTidyContext &CTContext,
+                             const clang::Diagnostic &Info, const Diag &Diag);
+
+const auto NoLintFixMsgRegexStr = std::string("ignore \\[.*\\] for this line");
 
 /// Check if a fix created by clangTidyNoLintFixes().
-bool isClangTidyNoLintFixes(const Fix &F);
+bool isNoLintFixes(const Fix &F);
 
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/NoLintFixes.h
+++ b/clang-tools-extra/clangd/NoLintFixes.h
@@ -1,0 +1,35 @@
+//===--- NoLintFixes.h ------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANGD_NOLINTFIXES_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANGD_NOLINTFIXES_H
+
+#include "../clang-tidy/ClangTidyDiagnosticConsumer.h"
+#include "../clang-tidy/ClangTidyModule.h"
+#include "Diagnostics.h"
+#include "FeatureModule.h"
+#include "clang/Basic/Diagnostic.h"
+#include <cassert>
+#include <vector>
+
+namespace clang {
+namespace clangd {
+
+/// Suggesting to insert "\\ NOLINTNEXTLINE(...)" to suppress clang-tidy
+/// diagnostics.
+std::vector<Fix>
+clangTidyNoLintFixes(const clang::tidy::ClangTidyContext &CTContext,
+                     const clang::Diagnostic &Info, const Diag &Diag);
+
+/// Check if a fix created by clangTidyNoLintFixes().
+bool isClangTidyNoLintFixes(const Fix &F);
+
+} // namespace clangd
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANGD_NOLINTFIXES_H

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -405,13 +405,12 @@ filterFastTidyChecks(const tidy::ClangTidyCheckFactories &All,
 std::vector<Fix>
 clangTidyNoLintFixes(const clang::tidy::ClangTidyContext &CTContext,
                      const clang::Diagnostic &Info, const Diag &Diag) {
-  auto RuleName = CTContext.getCheckName(Info.getID());
-  if (RuleName.empty()) {
+  auto RuleName = CTContext.getCheckName(Diag.ID);
+  if (RuleName.empty() || Diag.Severity >= DiagnosticsEngine::Error ||
+      !Diag.InsideMainFile) {
     return {};
   }
-  if (!Diag.InsideMainFile) {
-    return {};
-  }
+
   auto &SrcMgr = Info.getSourceManager();
   auto &DiagLoc = Info.getLocation();
 

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -660,16 +660,17 @@ ParsedAST::build(llvm::StringRef Filename, const ParseInputs &Inputs,
                                 &CTContext](const Diag &Diag,
                                             const clang::Diagnostic &Info) {
         auto Fixes = std::vector<Fix>();
-        auto IncludeFixes = FixIncludes->fix(Diag.Severity, Info);
 
+        auto IncludeFixes = FixIncludes->fix(Diag.Severity, Info);
         // Ensures that if clang later introduces its own fix-it for includes it
         // will get on our radar.
         assert((IncludeFixes.empty() || Info.getNumFixItHints() == 0) &&
                "Include-fixer replaced a note with clang fix-its attached!");
-
         Fixes.insert(Fixes.end(), IncludeFixes.begin(), IncludeFixes.end());
+
         auto NoLintFixes = noLintFixes(*CTContext, Info, Diag);
         Fixes.insert(Fixes.end(), NoLintFixes.begin(), NoLintFixes.end());
+
         return Fixes;
       });
       Clang->setExternalSemaSource(FixIncludes->unresolvedNameRecorder());

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -406,7 +406,12 @@ std::vector<Fix>
 clangTidyNoLintFixes(const clang::tidy::ClangTidyContext &CTContext,
                      const clang::Diagnostic &Info, const Diag &Diag) {
   auto RuleName = CTContext.getCheckName(Diag.ID);
-  if (RuleName.empty() || Diag.Severity >= DiagnosticsEngine::Error ||
+  if (
+      // If this isn't a clang-tidy diag
+      RuleName.empty() ||
+      // NOLINT does not work on Serverity Error or above
+      Diag.Severity >= DiagnosticsEngine::Error ||
+      // No point adding extra fixes if the Diag is for a different file
       !Diag.InsideMainFile) {
     return {};
   }

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -656,16 +656,22 @@ ParsedAST::build(llvm::StringRef Filename, const ParseInputs &Inputs,
               : Symbol::Include;
       FixIncludes.emplace(Filename, Inserter, *Inputs.Index,
                           /*IndexRequestLimit=*/5, Directive);
-      ASTDiags.contributeFixes(
-          [&FixIncludes, &CTContext](const Diag &Diag,
-                                     const clang::Diagnostic &Info) {
-            auto Fixes = std::vector<Fix>();
-            auto NoLintFixes = noLintFixes(*CTContext, Info, Diag);
-            Fixes.insert(Fixes.end(), NoLintFixes.begin(), NoLintFixes.end());
-            auto IncludeFixes = FixIncludes->fix(Diag.Severity, Info);
-            Fixes.insert(Fixes.end(), IncludeFixes.begin(), IncludeFixes.end());
-            return Fixes;
-          });
+      ASTDiags.contributeFixes([&FixIncludes,
+                                &CTContext](const Diag &Diag,
+                                            const clang::Diagnostic &Info) {
+        auto Fixes = std::vector<Fix>();
+        auto IncludeFixes = FixIncludes->fix(Diag.Severity, Info);
+
+        // Ensures that if clang later introduces its own fix-it for includes it
+        // will get on our radar.
+        assert((IncludeFixes.empty() || Info.getNumFixItHints() == 0) &&
+               "Include-fixer replaced a note with clang fix-its attached!");
+
+        Fixes.insert(Fixes.end(), IncludeFixes.begin(), IncludeFixes.end());
+        auto NoLintFixes = noLintFixes(*CTContext, Info, Diag);
+        Fixes.insert(Fixes.end(), NoLintFixes.begin(), NoLintFixes.end());
+        return Fixes;
+      });
       Clang->setExternalSemaSource(FixIncludes->unresolvedNameRecorder());
     }
   }

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -656,7 +656,7 @@ ParsedAST::build(llvm::StringRef Filename, const ParseInputs &Inputs,
               : Symbol::Include;
       FixIncludes.emplace(Filename, Inserter, *Inputs.Index,
                           /*IndexRequestLimit=*/5, Directive);
-      ASTDiags.contributeFixes(
+      ASTDiags.contributeMainDiagFixes(
           [&FixIncludes, &CTContext](const Diag &Diag,
                                      const clang::Diagnostic &Info) {
             auto Fixes = std::vector<Fix>();
@@ -665,6 +665,11 @@ ParsedAST::build(llvm::StringRef Filename, const ParseInputs &Inputs,
             auto IncludeFixes = FixIncludes->fix(Diag.Severity, Info);
             Fixes.insert(Fixes.end(), IncludeFixes.begin(), IncludeFixes.end());
             return Fixes;
+          });
+      ASTDiags.contributeNoteDiagFixes(
+          [&FixIncludes](const Diag &Diag,
+                                     const clang::Diagnostic &Info) {
+            return FixIncludes->fix(Diag.Severity, Info);
           });
       Clang->setExternalSemaSource(FixIncludes->unresolvedNameRecorder());
     }

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -660,7 +660,7 @@ ParsedAST::build(llvm::StringRef Filename, const ParseInputs &Inputs,
           [&FixIncludes, &CTContext](const Diag &Diag,
                                      const clang::Diagnostic &Info) {
             auto Fixes = std::vector<Fix>();
-            auto NoLintFixes = clangTidyNoLintFixes(*CTContext, Info, Diag);
+            auto NoLintFixes = noLintFixes(*CTContext, Info, Diag);
             Fixes.insert(Fixes.end(), NoLintFixes.begin(), NoLintFixes.end());
             auto IncludeFixes = FixIncludes->fix(Diag.Severity, Info);
             Fixes.insert(Fixes.end(), IncludeFixes.begin(), IncludeFixes.end());

--- a/clang-tools-extra/clangd/test/fixits-codeaction-documentchanges.test
+++ b/clang-tools-extra/clangd/test/fixits-codeaction-documentchanges.test
@@ -54,6 +54,53 @@
 # CHECK-NEXT:          {
 # CHECK-NEXT:            "edits": [
 # CHECK-NEXT:              {
+# CHECK-NEXT:                "newText": "// NOLINTNEXTLINE(clang-diagnostic-parentheses)\n",
+# CHECK-NEXT:                "range": {
+# CHECK-NEXT:                  "end": {
+# CHECK-NEXT:                    "character": 0,
+# CHECK-NEXT:                    "line": 0
+# CHECK-NEXT:                  },
+# CHECK-NEXT:                  "start": {
+# CHECK-NEXT:                    "character": 0,
+# CHECK-NEXT:                    "line": 0
+# CHECK-NEXT:                  }
+# CHECK-NEXT:                }
+# CHECK-NEXT:              }
+# CHECK-NEXT:            ],
+# CHECK-NEXT:            "textDocument": {
+# CHECK-NEXT:              "uri": "file:///clangd-test/foo.c",
+# CHECK-NEXT:              "version": 1
+# CHECK-NEXT:            }
+# CHECK-NEXT:          }
+# CHECK-NEXT:        ]
+# CHECK-NEXT:      },
+# CHECK-NEXT:      "kind": "quickfix",
+# CHECK-NEXT:      "title": "ignore [clang-diagnostic-parentheses] for this line"
+# CHECK-NEXT:    },
+# CHECK-NEXT:    {
+# CHECK-NEXT:      "diagnostics": [
+# CHECK-NEXT:        {
+# CHECK-NEXT:          "code": "-Wparentheses",
+# CHECK-NEXT:          "message": "Using the result of an assignment as a condition without parentheses (fixes available)",
+# CHECK-NEXT:          "range": {
+# CHECK-NEXT:            "end": {
+# CHECK-NEXT:              "character": 37,
+# CHECK-NEXT:              "line": 0
+# CHECK-NEXT:            },
+# CHECK-NEXT:            "start": {
+# CHECK-NEXT:              "character": 32,
+# CHECK-NEXT:              "line": 0
+# CHECK-NEXT:            }
+# CHECK-NEXT:          },
+# CHECK-NEXT:          "severity": 2,
+# CHECK-NEXT:          "source": "clang"
+# CHECK-NEXT:        }
+# CHECK-NEXT:      ],
+# CHECK-NEXT:      "edit": {
+# CHECK-NEXT:        "documentChanges": [
+# CHECK-NEXT:          {
+# CHECK-NEXT:            "edits": [
+# CHECK-NEXT:              {
 # CHECK-NEXT:                "newText": "(",
 # CHECK-NEXT:                "range": {
 # CHECK-NEXT:                  "end": {

--- a/clang-tools-extra/clangd/test/fixits-codeaction.test
+++ b/clang-tools-extra/clangd/test/fixits-codeaction.test
@@ -51,6 +51,47 @@
 # CHECK-NEXT:      ],
 # CHECK-NEXT:      "edit": {
 # CHECK-NEXT:        "changes": {
+# CHECK-NEXT:          "file:///clangd-test/foo.c": [
+# CHECK-NEXT:            {
+# CHECK-NEXT:              "newText": "// NOLINTNEXTLINE(clang-diagnostic-parentheses)\n",
+# CHECK-NEXT:              "range": {
+# CHECK-NEXT:                "end": {
+# CHECK-NEXT:                  "character": 0,
+# CHECK-NEXT:                  "line": 0
+# CHECK-NEXT:                },
+# CHECK-NEXT:                "start": {
+# CHECK-NEXT:                  "character": 0,
+# CHECK-NEXT:                  "line": 0
+# CHECK-NEXT:                }
+# CHECK-NEXT:              }
+# CHECK-NEXT:            }
+# CHECK-NEXT:          ]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      },
+# CHECK-NEXT:      "kind": "quickfix",
+# CHECK-NEXT:      "title": "ignore [clang-diagnostic-parentheses] for this line"
+# CHECK-NEXT:    },
+# CHECK-NEXT:    {
+# CHECK-NEXT:      "diagnostics": [
+# CHECK-NEXT:        {
+# CHECK-NEXT:          "code": "-Wparentheses",
+# CHECK-NEXT:          "message": "Using the result of an assignment as a condition without parentheses (fixes available)",
+# CHECK-NEXT:          "range": {
+# CHECK-NEXT:            "end": {
+# CHECK-NEXT:              "character": 37,
+# CHECK-NEXT:              "line": 0
+# CHECK-NEXT:            },
+# CHECK-NEXT:            "start": {
+# CHECK-NEXT:              "character": 32,
+# CHECK-NEXT:              "line": 0
+# CHECK-NEXT:            }
+# CHECK-NEXT:          },
+# CHECK-NEXT:          "severity": 2,
+# CHECK-NEXT:          "source": "clang"
+# CHECK-NEXT:        }
+# CHECK-NEXT:      ],
+# CHECK-NEXT:      "edit": {
+# CHECK-NEXT:        "changes": {
 # CHECK-NEXT:          "file://{{.*}}/foo.c": [
 # CHECK-NEXT:            {
 # CHECK-NEXT:              "newText": "(",

--- a/clang-tools-extra/clangd/test/fixits-command-documentchanges.test
+++ b/clang-tools-extra/clangd/test/fixits-command-documentchanges.test
@@ -37,6 +37,37 @@
 # CHECK-NEXT:            {
 # CHECK-NEXT:              "edits": [
 # CHECK-NEXT:                {
+# CHECK-NEXT:                  "newText": "// NOLINTNEXTLINE(clang-diagnostic-parentheses)\n",
+# CHECK-NEXT:                  "range": {
+# CHECK-NEXT:                    "end": {
+# CHECK-NEXT:                      "character": 0,
+# CHECK-NEXT:                      "line": 0
+# CHECK-NEXT:                    },
+# CHECK-NEXT:                    "start": {
+# CHECK-NEXT:                      "character": 0,
+# CHECK-NEXT:                      "line": 0
+# CHECK-NEXT:                    }
+# CHECK-NEXT:                  }
+# CHECK-NEXT:                }
+# CHECK-NEXT:              ],
+# CHECK-NEXT:              "textDocument": {
+# CHECK-NEXT:                "uri": "file:///clangd-test/foo.c",
+# CHECK-NEXT:                "version": 0
+# CHECK-NEXT:              }
+# CHECK-NEXT:            }
+# CHECK-NEXT:          ]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      ],
+# CHECK-NEXT:      "command": "clangd.applyFix",
+# CHECK-NEXT:      "title": "Apply fix: ignore [clang-diagnostic-parentheses] for this line"
+# CHECK-NEXT:    },
+# CHECK-NEXT:    {
+# CHECK-NEXT:      "arguments": [
+# CHECK-NEXT:        {
+# CHECK-NEXT:          "documentChanges": [
+# CHECK-NEXT:            {
+# CHECK-NEXT:              "edits": [
+# CHECK-NEXT:                {
 # CHECK-NEXT:                  "newText": "(",
 # CHECK-NEXT:                  "range": {
 # CHECK-NEXT:                    "end": {
@@ -112,6 +143,37 @@
 #      CHECK:  "id": 3,
 # CHECK-NEXT:  "jsonrpc": "2.0",
 # CHECK-NEXT:  "result": [
+# CHECK-NEXT:    {
+# CHECK-NEXT:      "arguments": [
+# CHECK-NEXT:        {
+# CHECK-NEXT:          "documentChanges": [
+# CHECK-NEXT:            {
+# CHECK-NEXT:              "edits": [
+# CHECK-NEXT:                {
+# CHECK-NEXT:                  "newText": "// NOLINTNEXTLINE(clang-diagnostic-parentheses)\n",
+# CHECK-NEXT:                  "range": {
+# CHECK-NEXT:                    "end": {
+# CHECK-NEXT:                      "character": 0,
+# CHECK-NEXT:                      "line": 0
+# CHECK-NEXT:                    },
+# CHECK-NEXT:                    "start": {
+# CHECK-NEXT:                      "character": 0,
+# CHECK-NEXT:                      "line": 0
+# CHECK-NEXT:                    }
+# CHECK-NEXT:                  }
+# CHECK-NEXT:                }
+# CHECK-NEXT:              ],
+# CHECK-NEXT:              "textDocument": {
+# CHECK-NEXT:                "uri": "file:///clangd-test/foo.c",
+# CHECK-NEXT:                "version": 0
+# CHECK-NEXT:              }
+# CHECK-NEXT:            }
+# CHECK-NEXT:          ]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      ],
+# CHECK-NEXT:      "command": "clangd.applyFix",
+# CHECK-NEXT:      "title": "Apply fix: ignore [clang-diagnostic-parentheses] for this line"
+# CHECK-NEXT:    },
 # CHECK-NEXT:    {
 # CHECK-NEXT:      "arguments": [
 # CHECK-NEXT:        {

--- a/clang-tools-extra/clangd/test/fixits-command.test
+++ b/clang-tools-extra/clangd/test/fixits-command.test
@@ -34,6 +34,31 @@
 # CHECK-NEXT:      "arguments": [
 # CHECK-NEXT:        {
 # CHECK-NEXT:          "changes": {
+# CHECK-NEXT:            "file:///clangd-test/foo.c": [
+# CHECK-NEXT:              {
+# CHECK-NEXT:                "newText": "// NOLINTNEXTLINE(clang-diagnostic-parentheses)\n",
+# CHECK-NEXT:                "range": {
+# CHECK-NEXT:                  "end": {
+# CHECK-NEXT:                    "character": 0,
+# CHECK-NEXT:                    "line": 0
+# CHECK-NEXT:                  },
+# CHECK-NEXT:                  "start": {
+# CHECK-NEXT:                    "character": 0,
+# CHECK-NEXT:                    "line": 0
+# CHECK-NEXT:                  }
+# CHECK-NEXT:                }
+# CHECK-NEXT:              }
+# CHECK-NEXT:            ]
+# CHECK-NEXT:          }
+# CHECK-NEXT:        }
+# CHECK-NEXT:      ],
+# CHECK-NEXT:      "command": "clangd.applyFix",
+# CHECK-NEXT:      "title": "Apply fix: ignore [clang-diagnostic-parentheses] for this line"
+# CHECK-NEXT:    },
+# CHECK-NEXT:    {
+# CHECK-NEXT:      "arguments": [
+# CHECK-NEXT:        {
+# CHECK-NEXT:          "changes": {
 # CHECK-NEXT:            "file://{{.*}}/foo.c": [
 # CHECK-NEXT:              {
 # CHECK-NEXT:                "newText": "(",
@@ -100,6 +125,31 @@
 #      CHECK:  "id": 3,
 # CHECK-NEXT:  "jsonrpc": "2.0",
 # CHECK-NEXT:  "result": [
+# CHECK-NEXT:    {
+# CHECK-NEXT:      "arguments": [
+# CHECK-NEXT:        {
+# CHECK-NEXT:          "changes": {
+# CHECK-NEXT:            "file:///clangd-test/foo.c": [
+# CHECK-NEXT:              {
+# CHECK-NEXT:                "newText": "// NOLINTNEXTLINE(clang-diagnostic-parentheses)\n",
+# CHECK-NEXT:                "range": {
+# CHECK-NEXT:                  "end": {
+# CHECK-NEXT:                    "character": 0,
+# CHECK-NEXT:                    "line": 0
+# CHECK-NEXT:                  },
+# CHECK-NEXT:                  "start": {
+# CHECK-NEXT:                    "character": 0,
+# CHECK-NEXT:                    "line": 0
+# CHECK-NEXT:                  }
+# CHECK-NEXT:                }
+# CHECK-NEXT:              }
+# CHECK-NEXT:            ]
+# CHECK-NEXT:          }
+# CHECK-NEXT:        }
+# CHECK-NEXT:      ],
+# CHECK-NEXT:      "command": "clangd.applyFix",
+# CHECK-NEXT:      "title": "Apply fix: ignore [clang-diagnostic-parentheses] for this line"
+# CHECK-NEXT:    },
 # CHECK-NEXT:    {
 # CHECK-NEXT:      "arguments": [
 # CHECK-NEXT:        {


### PR DESCRIPTION
In some other language servers, there will be code actions that inserts warning suppression comment for the user. This PR implements that for clangd for clang-tidy diagnostics..