### PR TITLE
llvm-reduce: Fix not checking shouldKeep in special-globals reduction

### DIFF
--- a/llvm/test/tools/llvm-reduce/special-globals-missing-should-keep-assert.ll
+++ b/llvm/test/tools/llvm-reduce/special-globals-missing-should-keep-assert.ll
@@ -1,0 +1,20 @@
+; RUN: llvm-reduce -abort-on-invalid-reduction --delta-passes=special-globals --test FileCheck --test-arg --check-prefix=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t.0
+; RUN: FileCheck --implicit-check-not=define --check-prefix=CHECK-FINAL %s < %t.0
+
+; Check that we don't hit "input module no longer interesting after
+; counting chunks" The special-globals reduction was not checking
+; shouldKeep before unconditionally erasing it.
+
+; CHECK-INTERESTINGNESS: llvm.used
+; CHECK-FINAL: llvm.used
+; CHECK-FINAL: define void @kept_used
+; CHECK-FINAL: define void @other
+@llvm.used = appending global [2 x ptr] [ptr @kept_used, ptr @other ]
+
+define void @kept_used() {
+  ret void
+}
+
+define void @other() {
+  ret void
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceSpecialGlobals.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceSpecialGlobals.cpp
@@ -33,8 +33,10 @@ static void extractSpecialGlobalsFromModule(Oracle &O,
 
   for (StringRef Name : SpecialGlobalNames) {
     if (auto *Used = Program.getNamedGlobal(Name)) {
-      Used->replaceAllUsesWith(getDefaultValue(Used->getType()));
-      Used->eraseFromParent();
+      if (!O.shouldKeep()) {
+        Used->replaceAllUsesWith(getDefaultValue(Used->getType()));
+        Used->eraseFromParent();
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes "input module no longer interesting after counting chunks"
assertion on cases where llvm.used matters.