### PR TITLE
[CUDA/HIP] fix propagate -cuid to a host-only compilation.

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3073,7 +3073,6 @@ class OffloadingActionBuilder final {
             CUID = llvm::utohexstr(Hash.low(), /*LowerCase=*/true);
           }
         }
-        IA->setId(CUID);
 
         if (CompileHostOnly)
           return ABRT_Success;
@@ -3081,6 +3080,8 @@ class OffloadingActionBuilder final {
         // Replicate inputs for each GPU architecture.
         auto Ty = IA->getType() == types::TY_HIP ? types::TY_HIP_DEVICE
                                                  : types::TY_CUDA_DEVICE;
+        IA->setId(CUID);
+        
         for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I) {
           CudaDeviceActions.push_back(
               C.MakeAction<InputAction>(IA->getInputArg(), Ty, IA->getId()));


### PR DESCRIPTION
build failure is observed in the hip test after patch #107483, which complains about a linking error.

"/usr/bin/ld: /opt/rocm/share/hip/samples/2_Cookbook/16_assembly_to_executable/build/square_asm.out: hidden symbol `__hip_gpubin_handle_b21320dde8d193a' isn't defined
/usr/bin/ld: final link failed: bad value"
