### PR TITLE
[clang] Set FPOptions at the beginning of CompoundStmt

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1684,6 +1684,15 @@ public:
     return hasStoredFPFeatures() ? getStoredFPFeatures() : FPOptionsOverride();
   }
 
+  /// Get FPOptions inside this statement. They may differ from the outer
+  /// options due to pragmas.
+  /// \param CurFPOptions FPOptions outside this statement.
+  FPOptions getInsideFPOptions(FPOptions CurFPOptions) const {
+    return hasStoredFPFeatures()
+               ? getStoredFPFeatures().applyOverrides(CurFPOptions)
+               : CurFPOptions;
+  }
+
   using body_iterator = Stmt **;
   using body_range = llvm::iterator_range<body_iterator>;
 

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1684,10 +1684,10 @@ public:
     return hasStoredFPFeatures() ? getStoredFPFeatures() : FPOptionsOverride();
   }
 
-  /// Get FPOptions inside this statement. They may differ from the outer
+  /// Get FPOptions active inside this statement. They may differ from the outer
   /// options due to pragmas.
   /// \param CurFPOptions FPOptions outside this statement.
-  FPOptions getInsideFPOptions(FPOptions CurFPOptions) const {
+  FPOptions getActiveFPOptions(FPOptions CurFPOptions) const {
     return hasStoredFPFeatures()
                ? getStoredFPFeatures().applyOverrides(CurFPOptions)
                : CurFPOptions;

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -522,6 +522,11 @@ CodeGenFunction::EmitCompoundStmtWithoutScope(const CompoundStmt &S,
   assert((!GetLast || (GetLast && ExprResult)) &&
          "If GetLast is true then the CompoundStmt must have a StmtExprResult");
 
+  // Optionally set up the new FP environment, if the compound statement
+  // contains a pragma that modifies it.
+  FPOptions NewFP = S.getInsideFPOptions(CurFPFeatures);
+  CGFPOptionsRAII SavedFPFeatues(*this, NewFP);
+
   Address RetAlloca = Address::invalid();
 
   for (auto *CurStmt : S.body()) {

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -524,7 +524,7 @@ CodeGenFunction::EmitCompoundStmtWithoutScope(const CompoundStmt &S,
 
   // Optionally set up the new FP environment, if the compound statement
   // contains a pragma that modifies it.
-  FPOptions NewFP = S.getInsideFPOptions(CurFPFeatures);
+  FPOptions NewFP = S.getActiveFPOptions(CurFPFeatures);
   CGFPOptionsRAII SavedFPFeatues(*this, NewFP);
 
   Address RetAlloca = Address::invalid();

--- a/clang/test/CodeGen/fast-math.c
+++ b/clang/test/CodeGen/fast-math.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -ffast-math -ffp-contract=fast -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -ffast-math -ffp-contract=fast -emit-llvm -O2 -o - %s | FileCheck %s
 float f0, f1, f2;
 
 void foo(void) {
@@ -9,3 +9,19 @@ void foo(void) {
 
   // CHECK: ret
 }
+
+float issue_84648a(float *x) {
+  return x[0] == x[1] ? x[1] : x[0];
+}
+
+// CHECK-LABEL: define{{.*}} float @issue_84648a(ptr {{.*}})
+// CHECK:       [[VAL:%.+]] = load float, ptr
+// CHECK:       ret float [[VAL]]
+
+float issue_84648b(float *x) {
+#pragma float_control(precise, on)
+  return x[0] == x[1] ? x[1] : x[0];
+}
+
+// CHECK-LABEL: define{{.*}} float @issue_84648b(ptr{{.*}} %x)
+// CHECK:       fcmp oeq


### PR DESCRIPTION
CompoundStmt has FPOptions, that should be set for IRBuilder when generating code if that statement.

It must fix the issue #84648.