### PR TITLE
[flang][OpenMP] Don't check unlabelled `cycle` branching for target loops

### DIFF
--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -74,6 +74,9 @@ public:
         case llvm::omp::Directive::OMPD_distribute_parallel_for:
         case llvm::omp::Directive::OMPD_distribute_simd:
         case llvm::omp::Directive::OMPD_distribute_parallel_for_simd:
+        case llvm::omp::Directive::OMPD_target_teams_distribute_parallel_do:
+        case llvm::omp::Directive::
+            OMPD_target_teams_distribute_parallel_do_simd:
           return;
         default:
           break;

--- a/flang/test/Semantics/OpenMP/do05-positivecase.f90
+++ b/flang/test/Semantics/OpenMP/do05-positivecase.f90
@@ -42,4 +42,19 @@ program omp_do
   end do
   !$omp end parallel
 
+  !$omp target teams distribute parallel do
+  !DEF:/omp_do/OtherConstruct4/i (OmpPrivate ,OmpPreDetermined) HostAssoc INTEGER(4)
+  do i=1,100
+    !REF:/omp_do/OtherConstruct4/i
+    if(i<10) cycle
+  end do
+  !$omp end target teams distribute parallel do
+
+  !$omp target teams distribute parallel do simd
+  !DEF:/omp_do/OtherConstruct5/i (OmpLinear,OmpPreDetermined) HostAssoc INTEGER(4)
+  do i=1,100
+    !REF:/omp_do/OtherConstruct5/i
+    if(i<10) cycle
+  end do
+  !$omp end target teams distribute parallel do simd
 end program omp_do


### PR DESCRIPTION
Properly handles `cycle` branching inside target distribute loops.