### PR TITLE
[clang][python] Don't add check-clang-python to check-all if cross-compiling

### DIFF
--- a/clang/bindings/python/tests/CMakeLists.txt
+++ b/clang/bindings/python/tests/CMakeLists.txt
@@ -51,6 +51,11 @@ endif()
 # to use the host Python3_EXECUTABLE and make FFI calls to functions in target
 # libraries.
 if(CMAKE_CROSSCOMPILING)
+  # FIXME: Consider a solution that allows better control over these tests in
+  # a crosscompiling scenario. e.g. registering them with lit to allow them to
+  # be explicitly skipped via appropriate LIT_ARGS, or adding a mechanism to
+  # allow specifying a python interpreter compiled for the target that could
+  # be executed using qemu-user.
   message(WARNING "check-clang-python not added to check-all as these tests fail in a cross-build setup")
   set(RUN_PYTHON_TESTS FALSE)
 endif()

--- a/clang/bindings/python/tests/CMakeLists.txt
+++ b/clang/bindings/python/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 # Tests will fail if cross-compiling for a different target, as tests will try
 # to use the host Python3_EXECUTABLE and make FFI calls to functions in target
 # libraries.
-if(CMAKE_CROSS_COMPILING)
+if(CMAKE_CROSSCOMPILING)
   message(WARNING "check-clang-python-tests not added to check-all as they fail in a cross-build setup")
   set(RUN_PYTHON_TESTS FALSE)
 endif()

--- a/clang/bindings/python/tests/CMakeLists.txt
+++ b/clang/bindings/python/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 # to use the host Python3_EXECUTABLE and make FFI calls to functions in target
 # libraries.
 if(CMAKE_CROSSCOMPILING)
-  message(WARNING "check-clang-python-tests not added to check-all as they fail in a cross-build setup")
+  message(WARNING "check-clang-python not added to check-all as these tests fail in a cross-build setup")
   set(RUN_PYTHON_TESTS FALSE)
 endif()
 

--- a/clang/bindings/python/tests/CMakeLists.txt
+++ b/clang/bindings/python/tests/CMakeLists.txt
@@ -47,6 +47,14 @@ if(${LLVM_NATIVE_ARCH} MATCHES "^(AArch64|Hexagon|Sparc|SystemZ)$")
   set(RUN_PYTHON_TESTS FALSE)
 endif()
 
+# Tests will fail if cross-compiling for a different target, as tests will try
+# to use the host Python3_EXECUTABLE and make FFI calls to functions in target
+# libraries.
+if(CMAKE_CROSS_COMPILING)
+  message(WARNING "check-clang-python-tests not added to check-all as they fail in a cross-build setup")
+  set(RUN_PYTHON_TESTS FALSE)
+endif()
+
 if(RUN_PYTHON_TESTS)
     set_property(GLOBAL APPEND PROPERTY
                  LLVM_ALL_ADDITIONAL_TEST_TARGETS check-clang-python)


### PR DESCRIPTION
Consistent with other cases for these tests, we opt not to add the target to check-all if they're known to fail. The tests fail when cross compiling for a different architecture because the host Python3_EXECUTABLE is used to run them, and FFI calls will of course fail against the libraries compiled for the target.

This is an alternate take on
<https://github.com/llvm/llvm-project/pull/111367>.