### PR TITLE
[clang][RISCV][Zicfilp] Emit RISCV function-signature-based CFI label in llvm::Function metadata

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1952,6 +1952,9 @@ public:
   /// (struct/union/class/enum) decl.
   QualType getTagDeclType(const TagDecl *Decl) const;
 
+  /// Return the type for "void *"
+  QualType getVoidPtrType() const { return VoidPtrTy; }
+
   /// Return the unique type for "size_t" (C99 7.17), defined in
   /// <stddef.h>.
   ///
@@ -1978,6 +1981,10 @@ public:
   /// unique wchar_t type. In C99, this returns a type compatible with the type
   /// defined in <stddef.h> as defined by the target.
   QualType getWideCharType() const { return WideCharTy; }
+
+  /// Return the type of wide characters in C context, no matter whether it's C
+  /// or C++ being compiled.
+  QualType getWCharTypeInC() const;
 
   /// Return the type of "signed wchar_t".
   ///

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -215,6 +215,11 @@ public:
 
   virtual void mangleModuleInitializer(const Module *Module, raw_ostream &) = 0;
 
+  virtual void mangleForRISCVZicfilpFuncSigLabel(const FunctionType &FT,
+                                                 const bool IsCXXInstanceMethod,
+                                                 const bool IsCXXVirtualMethod,
+                                                 raw_ostream &) = 0;
+
   // This has to live here, otherwise the CXXNameMangler won't have access to
   // it.
   virtual DiscriminatorOverrideTy getDiscriminatorOverride() const = 0;

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -6712,6 +6712,12 @@ CanQualType ASTContext::getUIntMaxType() const {
   return getFromTargetType(Target->getUIntMaxType());
 }
 
+/// Return the type of wide characters in C context, no matter whether it's C
+/// or C++ being compiled.
+QualType ASTContext::getWCharTypeInC() const {
+  return getFromTargetType(Target->getWCharType());
+}
+
 /// getSignedWCharType - Return the type of "signed wchar_t".
 /// Used when in C++, as a GCC extension.
 QualType ASTContext::getSignedWCharType() const {

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -1639,8 +1639,23 @@ public:
   /// Set type metadata to the given function.
   void setKCFIType(const FunctionDecl *FD, llvm::Function *F);
 
+  /// Set RISC-V Zicfilp func-sig CFI label in metadata of the given function.
+  void setRISCVZicfilpFuncSigLabel(const FunctionDecl &FD, llvm::Function *F);
+
   /// Emit KCFI type identifier constants and remove unused identifiers.
   void finalizeKCFITypes();
+
+  /// Fixup RISCV Zicfilp func-sig CFI labels
+  void finalizeRISCVZicfilpFuncSigLabels();
+
+  /// Fixup RISCV Zicfilp func-sig CFI label for llvm::Function
+  void finalizeRISCVZicfilpFuncSigLabel(llvm::Function &F);
+
+  /// Calculate function signature based on RISC-V Zicfilp func-sig scheme
+  std::string calcRISCVZicfilpFuncSig(const FunctionType &FT, const bool IsMain,
+                                      const bool IsCXXInstanceMethod,
+                                      const bool IsCXXVirtualMethod,
+                                      const bool IsCXXDestructor);
 
   /// Whether this function's return type has no side effects, and thus may
   /// be trivially discarded if it is unused.
@@ -1809,6 +1824,8 @@ public:
     // behavior. So projects like the Linux kernel can rely on it.
     return !getLangOpts().CPlusPlus;
   }
+
+  bool UseRISCVZicfilpFuncSigCFI;
 
 private:
   bool shouldDropDLLAttribute(const Decl *D, const llvm::GlobalValue *GV) const;

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-covariant-virtual-method.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-covariant-virtual-method.cpp
@@ -1,0 +1,39 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s --check-prefixes=PTR,LREF,RREF
+
+class Class {
+public:
+  // test - virtual methods with return type that can possibly be covariant
+  //        mangle return class as `class v`
+  // PTR-LABEL: define{{.*}} @_ZN5Class35virtualMethodWithCovariantPtrReturnEv
+  // PTR-SAME: ({{.*}}){{.* !riscv_lpad_func_sig}} [[SIG_MD_PTR:![0-9]+]]
+  // PTR-SAME: {{.* !riscv_lpad_label}} [[LB_MD_PTR:![0-9]+]] {{.*}}{
+  //
+  virtual Class *virtualMethodWithCovariantPtrReturn() { return this; }
+
+  // LREF-LABEL: define{{.*}} @_ZN5Class36virtualMethodWithCovariantLRefReturnEv
+  // LREF-SAME: ({{.*}}){{.* !riscv_lpad_func_sig}} [[SIG_MD_LREF:![0-9]+]]
+  // LREF-SAME: {{.* !riscv_lpad_label}} [[LB_MD_LREF:![0-9]+]] {{.*}}{
+  //
+  virtual Class &virtualMethodWithCovariantLRefReturn() { return *this; }
+
+  // RREF-LABEL: define{{.*}} @_ZN5Class36virtualMethodWithCovariantRRefReturnEv
+  // RREF-SAME: ({{.*}}){{.* !riscv_lpad_func_sig}} [[SIG_MD_RREF:![0-9]+]]
+  // RREF-SAME: {{.* !riscv_lpad_label}} [[LB_MD_RREF:![0-9]+]] {{.*}}{
+  //
+  virtual Class &&virtualMethodWithCovariantRRefReturn() {
+    return static_cast<Class&&>(*this);
+  }
+};
+
+// PTR-DAG: [[SIG_MD_PTR]] = !{!"M1vFP1vvE"}
+// PTR-DAG: [[LB_MD_PTR]] = !{i32 996333}
+// LREF-DAG: [[SIG_MD_LREF]] = !{!"M1vFR1vvE"}
+// LREF-DAG: [[LB_MD_LREF]] = !{i32 918198}
+// RREF-DAG: [[SIG_MD_RREF]] = !{!"M1vFO1vvE"}
+// RREF-DAG: [[LB_MD_RREF]] = !{i32 86168}
+
+void use() { Class C; }

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-destructor.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-destructor.cpp
@@ -1,0 +1,19 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+
+class Class {
+public:
+  // test - destructors should use `void (*)(void*)`
+  // CHECK-LABEL: define{{.*}} @_ZN5ClassD1Ev({{.*}})
+  // CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+  // CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+  // CHECK-DAG: [[SIG_MD]] = !{!"FvPvE"}
+  // CHECK-DAG: [[LB_MD]] = !{i32 408002}
+  //
+  ~Class() {}
+};
+
+void use() { Class C; }

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-incovariant-virtual-method.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-incovariant-virtual-method.cpp
@@ -1,0 +1,20 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+
+class Class {
+public:
+  // test - virtual methods with return type that cannot be covariant mangle
+  //        return type as it is declared
+  // CHECK-LABEL: define{{.*}} @_ZN5Class34virtualMethodWithIncovariantReturnEv
+  // CHECK-SAME: ({{.*}}){{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+  // CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+  // CHECK-DAG: [[SIG_MD]] = !{!"M1vFivE"}
+  // CHECK-DAG: [[LB_MD]] = !{i32 910118}
+  //
+  virtual int virtualMethodWithIncovariantReturn() { return 0; }
+};
+
+void use() { Class C; }

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-method.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-method.cpp
@@ -1,0 +1,21 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+
+class Class {
+public:
+  // test - C++ member functions should use "pointer-to-member-type" mangling
+  //        rule, with `<class type>` being `1v` instead of the real class
+  //        (i.e. use a dummy class named `v`)
+  // CHECK-LABEL: define{{.*}} @_ZN5Class14instanceMethodEv({{.*}})
+  // CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+  // CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+  // CHECK-DAG: [[SIG_MD]] = !{!"M1vFvvE"}
+  // CHECK-DAG: [[LB_MD]] = !{i32 974748}
+  //
+  void instanceMethod() {}
+};
+
+void use(Class &C) { C.instanceMethod(); }

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-static-method.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-class-static-method.cpp
@@ -1,0 +1,23 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+
+// CHECK-LABEL: define{{.*}} @_Z13nonMemberFuncv()
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+//
+void nonMemberFunc() {}
+
+class Class {
+public:
+  // test - static methods are mangled as non-member function
+  // CHECK-LABEL: define{{.*}} @_ZN5Class12staticMethodEv()
+  // CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD]]
+  // CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD]] {{.*}}{
+  //
+  static void staticMethod() {}
+};
+
+void use() { Class::staticMethod(); }

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-func-empty-param-list.c
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-func-empty-param-list.c
@@ -1,0 +1,17 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c %s \
+// RUN:  | FileCheck %s
+
+// test - functions with an empty parameter list are treated as `void (*)(void)`
+// CHECK-LABEL: define{{.*}} @funcWithEmptyParameterList()
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+//
+void funcWithEmptyParameterList() {}
+// CHECK-LABEL: define{{.*}} @funcWithVoidParameterList()
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD]] {{.*}}{
+//
+void funcWithVoidParameterList(void) {}

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-func-empty-param-list.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-func-empty-param-list.cpp
@@ -1,0 +1,17 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+
+// test - functions with an empty parameter list are treated as `void (*)(void)`
+// CHECK-LABEL: define{{.*}} @_Z26funcWithEmptyParameterListv()
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+//
+void funcWithEmptyParameterList() {}
+// CHECK-LABEL: define{{.*}} @_Z25funcWithVoidParameterListv()
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD]] {{.*}}{
+//
+void funcWithVoidParameterList(void) {}

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-ignore-exception-spec.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-ignore-exception-spec.cpp
@@ -1,0 +1,17 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -fcxx-exceptions -fexceptions \
+// RUN:  -emit-llvm -o - -x c++ %s | FileCheck %s
+
+// test - `<exception-spec>` should be ignored
+// CHECK-LABEL: define{{.*}} @_Z9funcThrowv()
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+///
+void funcThrow() { throw 0; }
+// CHECK-LABEL: define{{.*}} @_Z12funcNoExceptv()
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD]] {{.*}}{
+//
+void funcNoExcept() noexcept {}

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-main.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-main.cpp
@@ -1,0 +1,41 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -DNO_PARAM -triple riscv64 -target-cpu generic-rv64 \
+// RUN:  -target-feature +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+// RUN: %clang_cc1 -DONE_PARAM -triple riscv64 -target-cpu generic-rv64 \
+// RUN:  -target-feature +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+// RUN: %clang_cc1 -DTWO_PARAMS -triple riscv64 -target-cpu generic-rv64 \
+// RUN:  -target-feature +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+// RUN: %clang_cc1 -DTWO_PARAMS -triple riscv64 -target-cpu generic-rv64 \
+// RUN:  -target-feature +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+
+// test - main functions should use `int (*)(int, char**)`
+// CHECK-LABEL: define{{.*}} @main({{.*}})
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+// CHECK-DAG: [[SIG_MD]] = !{!"FiiPPcE"}
+// CHECK-DAG: [[LB_MD]] = !{i32 853561}
+//
+
+#ifdef NO_PARAM
+int main() { return 0; }
+#endif
+
+#ifdef ONE_PARAM
+int main(int argc) { return argc; }
+#endif
+
+#ifdef TWO_PARAMS
+int main(int argc, char **argv) { return argc; }
+#endif
+
+#ifdef THREE_PARAMS
+int main(int argc, char **argv, char **envp) { return argc; }
+#endif

--- a/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-wchar-t.cpp
+++ b/clang/test/CodeGen/RISCV/zicfilp-func-sig/mangle-wchar-t.cpp
@@ -1,0 +1,14 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-cpu generic-rv64 -target-feature \
+// RUN:  +experimental-zicfilp -fcf-protection=branch \
+// RUN:  -mcf-branch-label-scheme=func-sig -emit-llvm -o - -x c++ %s \
+// RUN:  | FileCheck %s
+
+// test - `wchar_t` in C++ should be mangled to `wchar_t` in C
+// CHECK-LABEL: define{{.*}} @_Z14funcWithWCharTw({{.*}})
+// CHECK-SAME: {{.* !riscv_lpad_func_sig}} [[SIG_MD:![0-9]+]]
+// CHECK-SAME: {{.* !riscv_lpad_label}} [[LB_MD:![0-9]+]] {{.*}}{
+// CHECK-DAG: [[SIG_MD]] = !{!"FviE"}
+// CHECK-DAG: [[LB_MD]] = !{i32 374765}
+//
+void funcWithWCharT(wchar_t) {}

--- a/llvm/include/llvm/Support/RISCVISAUtils.h
+++ b/llvm/include/llvm/Support/RISCVISAUtils.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Utilities shared by TableGen and RISCVISAInfo.
+// Utilities shared by TableGen, RISCVISAInfo and other RISC-V specifics.
 //
 //===----------------------------------------------------------------------===//
 
@@ -42,6 +42,10 @@ struct ExtensionComparator {
 /// in canonical order of extension.
 typedef std::map<std::string, ExtensionVersion, ExtensionComparator>
     OrderedExtensionMap;
+
+/// Obtain a 20-bit integer from a (function-signature) string using the method
+/// defined in the psABI for Zicfilp func-sig CFI scheme
+uint32_t zicfilpFuncSigHash(const StringRef FuncSig);
 
 } // namespace RISCVISAUtils
 

--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -78,6 +78,7 @@ add_llvm_unittest(SupportTests
   ReverseIterationTest.cpp
   ReplaceFileTest.cpp
   RISCVAttributeParserTest.cpp
+  RISCVISAUtils.cpp
   ScaledNumberTest.cpp
   ScopedPrinterTest.cpp
   SHA256.cpp

--- a/llvm/unittests/Support/RISCVISAUtils.cpp
+++ b/llvm/unittests/Support/RISCVISAUtils.cpp
@@ -1,0 +1,23 @@
+//===- LLvm/unittest/Support/RISCVISAUtils.cpp - RISCVISAUtils tests ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/RISCVISAUtils.h"
+#include "gtest/gtest.h"
+
+using namespace llvm::RISCVISAUtils;
+
+TEST(ZicfilpFuncSigHash, testCommonCase) {
+  // A common representitive case is the signature of the main function
+  EXPECT_EQ(zicfilpFuncSigHash("FiiPPcE"), 853561U);
+}
+
+// The lowest 20 bits of a MD5 hash should be discarded if they're all zeros
+TEST(ZicfilpFuncSigHash, testDiscardAllZeroLabels) {
+  // as_number(md5('20412333')) = 0x7a13472ff22eb53e31f6a76027000000
+  EXPECT_EQ(zicfilpFuncSigHash("20412333"), 0x60270U);
+}


### PR DESCRIPTION
This method calculates a CFI label used in the RISC-V Zicfilp func-sig CFI scheme for a given function type/declaration. The scheme, according to psABI, encodes the label based on function signature, and the rules are modified from the Itanium C++ ABI mangling rule to allow functions (callees) that are called indirectly to have the expected label as indicated by the function pointer type seen at the call site (caller).

This method is a pre-requisite to enable RISC-V Zicfilp CFI with func-sig label scheme.

The implemented psABI scheme can be found at riscv-non-isa/riscv-elf-psabi-doc#434 .

Update: This PR is expanded to include emitting the RISC-V Zicfilp func-sig CFI label in the metadata of generated `llvm::Function`s. The purpose is to allow testing of the mangled function signatures.