### PR TITLE
[C++20][Modules] Allow import for a header unit after #pragma

### DIFF
--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -951,9 +951,16 @@ void Preprocessor::Lex(Token &Result) {
         break;
       [[fallthrough]];
     default:
-      TrackGMFState.handleMisc();
-      StdCXXImportSeqState.handleMisc();
-      ModuleDeclState.handleMisc();
+      if (tok::isPragmaAnnotation(Result.getKind())) {
+        // For `#pragma ...` mimic ';'.
+        TrackGMFState.handleSemi();
+        StdCXXImportSeqState.handleSemi();
+        ModuleDeclState.handleSemi();
+      } else {
+        TrackGMFState.handleMisc();
+        StdCXXImportSeqState.handleMisc();
+        ModuleDeclState.handleMisc();
+      }
       break;
     }
   }

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -902,6 +902,10 @@ void Preprocessor::Lex(Token &Result) {
     case tok::r_brace:
       StdCXXImportSeqState.handleCloseBrace();
       break;
+#define PRAGMA_ANNOTATION(X) case tok::annot_##X:
+// For `#pragma ...` mimic ';'.
+#include "clang/Basic/TokenKinds.def"
+#undef PRAGMA_ANNOTATION
     // This token is injected to represent the translation of '#include "a.h"'
     // into "import a.h;". Mimic the notional ';'.
     case tok::annot_module_include:
@@ -951,16 +955,9 @@ void Preprocessor::Lex(Token &Result) {
         break;
       [[fallthrough]];
     default:
-      if (tok::isPragmaAnnotation(Result.getKind())) {
-        // For `#pragma ...` mimic ';'.
-        TrackGMFState.handleSemi();
-        StdCXXImportSeqState.handleSemi();
-        ModuleDeclState.handleSemi();
-      } else {
-        TrackGMFState.handleMisc();
-        StdCXXImportSeqState.handleMisc();
-        ModuleDeclState.handleMisc();
-      }
+      TrackGMFState.handleMisc();
+      StdCXXImportSeqState.handleMisc();
+      ModuleDeclState.handleMisc();
       break;
     }
   }

--- a/clang/test/Headers/import_header_unit_after_pragma.cpp
+++ b/clang/test/Headers/import_header_unit_after_pragma.cpp
@@ -1,0 +1,18 @@
+// RUN: rm -fR %t
+// RUN: split-file %s %t
+// RUN: cd %t
+// RUN: %clang_cc1 -verify -std=c++20 -emit-header-unit -xc++-user-header bz0.h
+// RUN: %clang_cc1 -verify -std=c++20 -emit-header-unit -xc++-user-header -fmodule-file=bz0.pcm bz.cpp
+
+//--- compare
+#pragma GCC visibility push(default)
+#pragma GCC visibility pop
+
+//--- bz0.h
+#include "compare"
+// expected-no-diagnostics
+
+//--- bz.cpp
+#include "compare"
+
+import "bz0.h"; // expected-warning {{the implementation of header units is in an experimental phase}}


### PR DESCRIPTION
Summary:
`#pragma` and headers that finish with them shouldn't prevent `import "header_unit.h"` syntax.

Test Plan: check-clang