### PR TITLE
[mlir][llvmir] Added extra builders for CallInstrinsicOp

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1944,6 +1944,8 @@ def LLVM_CallIntrinsicOp
   }];
 
   let builders = [
+    OpBuilder<(ins "StringAttr":$intrin, "ValueRange":$args)>,
+    OpBuilder<(ins "StringAttr":$intrin, "ValueRange":$args, "FastmathFlagsAttr":$fastMathFlags)>,
     OpBuilder<(ins "Type": $resultType, "StringAttr":$intrin, "ValueRange":$args)>,
     OpBuilder<(ins "TypeRange": $resultTypes, "StringAttr":$intrin, "ValueRange":$args, "FastmathFlagsAttr":$fastMathFlags)>
   ];

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1944,9 +1944,9 @@ def LLVM_CallIntrinsicOp
   }];
 
   let builders = [
-    OpBuilder<(ins "Type": $results, "StringAttr":$intrin, "ValueRange":$args)>,
-    OpBuilder<(ins "TypeRange": $results, "StringAttr":$intrin, "ValueRange":$args, "FastmathFlagsAttr":$fastMathFlags)>
-    ];
+    OpBuilder<(ins "Type": $resultType, "StringAttr":$intrin, "ValueRange":$args)>,
+    OpBuilder<(ins "TypeRange": $resultTypes, "StringAttr":$intrin, "ValueRange":$args, "FastmathFlagsAttr":$fastMathFlags)>
+  ];
 
   let hasVerifier = 1;
 }

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1943,6 +1943,11 @@ def LLVM_CallIntrinsicOp
     attr-dict
   }];
 
+  let builders = [
+    OpBuilder<(ins "Type": $results, "StringAttr":$intrin, "ValueRange":$args)>,
+    OpBuilder<(ins "TypeRange": $results, "StringAttr":$intrin, "ValueRange":$args, "FastmathFlagsAttr":$fastMathFlags)>
+    ];
+
   let hasVerifier = 1;
 }
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3358,18 +3358,17 @@ struct LLVMOpAsmDialectInterface : public OpAsmDialectInterface {
 //===----------------------------------------------------------------------===//
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
-                            mlir::TypeRange results, mlir::StringAttr intrin,
-                            mlir::ValueRange args,
+                            mlir::TypeRange resultTypes,
+                            mlir::StringAttr intrin, mlir::ValueRange args,
                             mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
-
-  build(builder, state, results, intrin, args, fastMathFlags,
-        llvm::ArrayRef<mlir::ValueRange>{});
+  build(builder, state, resultTypes, intrin, args, fastMathFlags,
+        /*op_bundle_operands=*/{});
 }
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
-                            mlir::Type results, mlir::StringAttr intrin,
+                            mlir::Type resultType, mlir::StringAttr intrin,
                             mlir::ValueRange args) {
-  build(builder, state, {results}, intrin, args, FastmathFlagsAttr{},
-        llvm::ArrayRef<mlir::ValueRange>{});
+  build(builder, state, {resultType}, intrin, args, FastmathFlagsAttr{},
+        /*op_bundle_operands=*/{});
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3324,6 +3324,20 @@ LogicalResult CallIntrinsicOp::verify() {
   return success();
 }
 
+void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
+                            mlir::TypeRange resultTypes,
+                            mlir::StringAttr intrin, mlir::ValueRange args,
+                            mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
+  build(builder, state, resultTypes, intrin, args, fastMathFlags,
+        /*op_bundle_operands=*/{});
+}
+void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
+                            mlir::Type resultType, mlir::StringAttr intrin,
+                            mlir::ValueRange args) {
+  build(builder, state, {resultType}, intrin, args, FastmathFlagsAttr{},
+        /*op_bundle_operands=*/{});
+}
+
 //===----------------------------------------------------------------------===//
 // OpAsmDialectInterface
 //===----------------------------------------------------------------------===//
@@ -3352,24 +3366,6 @@ struct LLVMOpAsmDialectInterface : public OpAsmDialectInterface {
   }
 };
 } // namespace
-
-//===----------------------------------------------------------------------===//
-// CallIntrinsicOp
-//===----------------------------------------------------------------------===//
-
-void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
-                            mlir::TypeRange resultTypes,
-                            mlir::StringAttr intrin, mlir::ValueRange args,
-                            mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
-  build(builder, state, resultTypes, intrin, args, fastMathFlags,
-        /*op_bundle_operands=*/{});
-}
-void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
-                            mlir::Type resultType, mlir::StringAttr intrin,
-                            mlir::ValueRange args) {
-  build(builder, state, {resultType}, intrin, args, FastmathFlagsAttr{},
-        /*op_bundle_operands=*/{});
-}
 
 //===----------------------------------------------------------------------===//
 // LinkerOptionsOp

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3325,16 +3325,30 @@ LogicalResult CallIntrinsicOp::verify() {
 }
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
-                            mlir::TypeRange resultTypes,
-                            mlir::StringAttr intrin, mlir::ValueRange args,
-                            mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
-  build(builder, state, resultTypes, intrin, args, fastMathFlags,
+                            mlir::StringAttr intrin, mlir::ValueRange args) {
+  build(builder, state, /*results=*/Type{}, intrin, args, FastmathFlagsAttr{},
         /*op_bundle_operands=*/{});
 }
+
+void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
+                            mlir::StringAttr intrin, mlir::ValueRange args,
+                            mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
+  build(builder, state, /*results=*/Type{}, intrin, args, fastMathFlags,
+        /*op_bundle_operands=*/{});
+}
+
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
                             mlir::Type resultType, mlir::StringAttr intrin,
                             mlir::ValueRange args) {
   build(builder, state, {resultType}, intrin, args, FastmathFlagsAttr{},
+        /*op_bundle_operands=*/{});
+}
+
+void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
+                            mlir::TypeRange resultTypes,
+                            mlir::StringAttr intrin, mlir::ValueRange args,
+                            mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
+  build(builder, state, resultTypes, intrin, args, fastMathFlags,
         /*op_bundle_operands=*/{});
 }
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3326,14 +3326,16 @@ LogicalResult CallIntrinsicOp::verify() {
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
                             mlir::StringAttr intrin, mlir::ValueRange args) {
-  build(builder, state, /*results=*/Type{}, intrin, args, FastmathFlagsAttr{},
+  build(builder, state, /*resultTypes=*/TypeRange{}, intrin, args,
+        FastmathFlagsAttr{},
         /*op_bundle_operands=*/{});
 }
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
                             mlir::StringAttr intrin, mlir::ValueRange args,
                             mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
-  build(builder, state, /*results=*/Type{}, intrin, args, fastMathFlags,
+  build(builder, state, /*resultTypes=*/TypeRange{}, intrin, args,
+        fastMathFlags,
         /*op_bundle_operands=*/{});
 }
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3354,6 +3354,25 @@ struct LLVMOpAsmDialectInterface : public OpAsmDialectInterface {
 } // namespace
 
 //===----------------------------------------------------------------------===//
+// CallIntrinsicOp
+//===----------------------------------------------------------------------===//
+
+void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
+                            mlir::TypeRange results, mlir::StringAttr intrin,
+                            mlir::ValueRange args,
+                            mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
+
+  build(builder, state, results, intrin, args, fastMathFlags,
+        llvm::ArrayRef<mlir::ValueRange>{});
+}
+void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
+                            mlir::Type results, mlir::StringAttr intrin,
+                            mlir::ValueRange args) {
+  build(builder, state, {results}, intrin, args, FastmathFlagsAttr{},
+        llvm::ArrayRef<mlir::ValueRange>{});
+}
+
+//===----------------------------------------------------------------------===//
 // LinkerOptionsOp
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
I've added the extra builders I would like to see for CallIntrinsicOp.
This is inspired by the comment from @antiagainst from [here](https://github.com/llvm/llvm-project/pull/108933#issuecomment-2392751569). I am also building Triton.