### PR TITLE
[Clang] Avoid a crash when parsing an invalid pseudo-destructor

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -481,6 +481,7 @@ Bug Fixes to C++ Support
 - Clang now uses the correct set of template argument lists when comparing the constraints of
   out-of-line definitions and member templates explicitly specialized for a given implicit instantiation of
   a class template. (#GH102320)
+- Fix a crash when parsing a pseudo destructor involving an invalid type. (#GH111460)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8429,7 +8429,8 @@ ExprResult Sema::ActOnPseudoDestructorExpr(Scope *S, Expr *Base,
   QualType ObjectType;
   QualType T;
   TypeLocBuilder TLB;
-  if (CheckArrow(*this, ObjectType, Base, OpKind, OpLoc))
+  if (CheckArrow(*this, ObjectType, Base, OpKind, OpLoc) ||
+      DS.getTypeSpecType() == DeclSpec::TST_error)
     return ExprError();
 
   switch (DS.getTypeSpecType()) {

--- a/clang/test/Parser/cxx2c-pack-indexing.cpp
+++ b/clang/test/Parser/cxx2c-pack-indexing.cpp
@@ -63,3 +63,14 @@ struct base {
 int main() {
     SS<int, base>().f(0);
 }
+
+
+namespace GH11460 {
+template <typename... T>
+requires( ); // expected-error {{expected expression}}
+struct SS {
+    void f( ) {
+        (*p).~T...[](); // expected-error {{use of undeclared identifier 'p'}}
+    }
+};
+}


### PR DESCRIPTION
Fixes #111460.