### PR TITLE
[libc++] Narrow the exports for common_type

### DIFF
--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -73,9 +73,9 @@ module std_core [system] {
     module common_reference                           { header "__type_traits/common_reference.h" }
     module common_type {
       header "__type_traits/common_type.h"
-      // We need to export everything from this module because common_type inherits from __builtin_common_type,
-      // which needs to be re-exported.
-      export *
+      // We need to export those because common_type inherits from either of those based on __builtin_common_type.
+      export std_core.type_traits.type_identity
+      export std_core.utility_core.empty
     }
     module conditional                                { header "__type_traits/conditional.h" }
     module conjunction                                { header "__type_traits/conjunction.h" }


### PR DESCRIPTION
Based on a comment in #99473, it seems like `export *` may be overkill.