### PR TITLE
[clang][bytecode] Fix source range of uncalled base dtor

### DIFF
--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -130,8 +130,9 @@ static bool CheckFieldsInitialized(InterpState &S, SourceLocation Loc,
       const Descriptor *Desc = BasePtr.getDeclDesc();
       if (const auto *CD = dyn_cast_if_present<CXXRecordDecl>(R->getDecl())) {
         const auto &BS = *std::next(CD->bases_begin(), I);
-        S.FFDiag(BS.getBaseTypeLoc(), diag::note_constexpr_uninitialized_base)
-            << B.Desc->getType() << BS.getSourceRange();
+        SourceLocation TypeBeginLoc = BS.getBaseTypeLoc();
+        S.FFDiag(TypeBeginLoc, diag::note_constexpr_uninitialized_base)
+            << B.Desc->getType() << SourceRange(TypeBeginLoc, BS.getEndLoc());
       } else {
         S.FFDiag(Desc->getLocation(), diag::note_constexpr_uninitialized_base)
             << B.Desc->getType();

--- a/clang/test/Misc/constexpr-subobj-init-source-ranges.cpp
+++ b/clang/test/Misc/constexpr-subobj-init-source-ranges.cpp
@@ -1,4 +1,5 @@
 // RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info %s 2>&1 | FileCheck %s --strict-whitespace
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -fexperimental-new-constant-interpreter %s 2>&1 | FileCheck %s --strict-whitespace
 
 struct DelBase {
   constexpr DelBase() = delete;


### PR DESCRIPTION
Make this emit the same source range as the current interpreter.