### PR TITLE
[lldb][debugserver][NFC] Simplify macOS thread name fetching.

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachThread.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/MachThread.cpp
@@ -31,9 +31,8 @@ MachThread::MachThread(MachProcess *process, bool is_64_bit,
       m_state(eStateUnloaded), m_state_mutex(PTHREAD_MUTEX_RECURSIVE),
       m_suspend_count(0), m_stop_exception(),
       m_arch_up(DNBArchProtocol::Create(this)), m_reg_sets(NULL),
-      m_num_reg_sets(0), m_ident_info(), m_proc_threadinfo(),
-      m_dispatch_queue_name(), m_is_64_bit(is_64_bit),
-      m_pthread_qos_class_decode(nullptr) {
+      m_num_reg_sets(0), m_extended_info(), m_dispatch_queue_name(),
+      m_is_64_bit(is_64_bit), m_pthread_qos_class_decode(nullptr) {
   nub_size_t num_reg_sets = 0;
   m_reg_sets = m_arch_up->GetRegisterSetInfo(&num_reg_sets);
   m_num_reg_sets = num_reg_sets;
@@ -255,13 +254,33 @@ struct thread_basic_info *MachThread::GetBasicInfo() {
 bool MachThread::GetBasicInfo(thread_t thread,
                               struct thread_basic_info *basicInfoPtr) {
   if (MachPortNumberIsValid(thread)) {
-    unsigned int info_count = THREAD_BASIC_INFO_COUNT;
+    mach_msg_type_number_t info_count = THREAD_BASIC_INFO_COUNT;
     kern_return_t err = ::thread_info(thread, THREAD_BASIC_INFO,
                                       (thread_info_t)basicInfoPtr, &info_count);
     if (err == KERN_SUCCESS)
       return true;
   }
   ::memset(basicInfoPtr, 0, sizeof(struct thread_basic_info));
+  return false;
+}
+
+struct thread_extended_info *MachThread::GetExtendedInfo() {
+  if (MachThread::GetExtendedInfo(m_mach_port_number, &m_extended_info))
+    return &m_extended_info;
+  return NULL;
+}
+
+bool MachThread::GetExtendedInfo(thread_t thread,
+                                 struct thread_extended_info *extendedInfoPtr) {
+  if (MachPortNumberIsValid(thread)) {
+    mach_msg_type_number_t info_count = THREAD_EXTENDED_INFO_COUNT;
+    kern_return_t err =
+        ::thread_info(thread, THREAD_EXTENDED_INFO,
+                      (thread_info_t)extendedInfoPtr, &info_count);
+    if (err == KERN_SUCCESS)
+      return true;
+  }
+  ::memset(extendedInfoPtr, 0, sizeof(struct thread_extended_info));
   return false;
 }
 
@@ -579,28 +598,13 @@ uint32_t MachThread::NumSupportedHardwareWatchpoints() const {
   return m_arch_up->NumSupportedHardwareWatchpoints();
 }
 
-bool MachThread::GetIdentifierInfo() {
+const char *MachThread::GetName() {
   // Don't try to get the thread info once and cache it for the life of the
   // thread.  It changes over time, for instance
   // if the thread name changes, then the thread_handle also changes...  So you
   // have to refetch it every time.
-  mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
-  kern_return_t kret = ::thread_info(m_mach_port_number, THREAD_IDENTIFIER_INFO,
-                                     (thread_info_t)&m_ident_info, &count);
-  return kret == KERN_SUCCESS;
-
-  return false;
-}
-
-const char *MachThread::GetName() {
-  if (GetIdentifierInfo()) {
-    int len = ::proc_pidinfo(m_process->ProcessID(), PROC_PIDTHREADINFO,
-                             m_ident_info.thread_handle, &m_proc_threadinfo,
-                             sizeof(m_proc_threadinfo));
-
-    if (len && m_proc_threadinfo.pth_name[0])
-      return m_proc_threadinfo.pth_name;
-  }
+  if (GetExtendedInfo() && m_extended_info.pth_name[0])
+    return m_extended_info.pth_name;
   return NULL;
 }
 

--- a/lldb/tools/debugserver/source/MacOSX/MachThread.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachThread.h
@@ -108,6 +108,7 @@ public:
 
   bool IsUserReady();
   struct thread_basic_info *GetBasicInfo();
+  struct thread_extended_info *GetExtendedInfo();
   const char *GetBasicInfoAsString() const;
   const char *GetName();
 
@@ -126,8 +127,8 @@ public:
 protected:
   static bool GetBasicInfo(thread_t threadID,
                            struct thread_basic_info *basic_info);
-
-  bool GetIdentifierInfo();
+  static bool GetExtendedInfo(thread_t threadID,
+                              struct thread_extended_info *extended_info);
 
   //    const char *
   //    GetDispatchQueueName();
@@ -152,8 +153,7 @@ protected:
   const DNBRegisterSetInfo
       *m_reg_sets; // Register set information for this thread
   nub_size_t m_num_reg_sets;
-  thread_identifier_info_data_t m_ident_info;
-  struct proc_threadinfo m_proc_threadinfo;
+  thread_extended_info_data_t m_extended_info;
   std::string m_dispatch_queue_name;
   bool m_is_64_bit;
 


### PR DESCRIPTION
Remove unnecessary `proc_pidinfo` calling.