### PR TITLE
[MLIR][LLVM] Fix import of globals with references to other globals

### DIFF
--- a/mlir/test/Target/LLVMIR/Import/global-variables.ll
+++ b/mlir/test/Target/LLVMIR/Import/global-variables.ll
@@ -41,6 +41,25 @@
 
 ; // -----
 
+; Verifies that converting a reference to a global does not convert the global
+; a second time.
+
+; CHECK-LABEL: llvm.mlir.global external constant @reference
+; CHECK-NEXT: %[[ADDR:.*]] = llvm.mlir.addressof @simple
+; CHECK-NEXT: llvm.return %[[ADDR]]
+@reference = constant ptr @simple
+
+@simple = global { ptr } { ptr null }
+
+; // -----
+
+; CHECK-LABEL: llvm.mlir.global external @recursive
+; CHECK: %[[ADDR:.*]] = llvm.mlir.addressof @recursive
+; CHECK: llvm.return %[[ADDR]]
+@recursive = global ptr @recursive
+
+; // -----
+
 ; alignment attribute.
 
 ; CHECK:  llvm.mlir.global private @global_int_align_32


### PR DESCRIPTION
This commit addresses an issue with importing globals that reference other globals. This case did not properly work due to not considering that `llvm::GlobalVariables` are derived from `llvm::Constant`.