### PR TITLE
[RISCV] Use MCStreamer::emitInstruction instead of calling AsmPrinter::EmitToStreamer. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -247,7 +247,7 @@ bool RISCVAsmPrinter::EmitToStreamer(MCStreamer &S, const MCInst &Inst) {
   bool Res = RISCVRVC::compress(CInst, Inst, *STI);
   if (Res)
     ++RISCVNumInstrsCompressed;
-  AsmPrinter::EmitToStreamer(S, Res ? CInst : Inst);
+  S.emitInstruction(Res ? CInst : Inst, *STI);
   return Res;
 }
 


### PR DESCRIPTION
This allows us to pass the STI we already have cachced instead of AsmPrinter::EmitToStreamer looking it up from the MachineFunction again.

My plan is to make EmitHwasanMemaccessSymbols use RISCVAsmPrinter::EmitToStreamer instead calling MCStreamer::emitInstruction. To do that I need control of the MCSubtargetInfo.