### PR TITLE
[flang][OpenMP] Treat POINTER variables as valid variable list items

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -200,8 +200,12 @@ bool OmpStructureChecker::CheckAllowedClause(llvmOmpClause clause) {
   return CheckAllowed(clause);
 }
 
+bool OmpStructureChecker::IsVariableListItem(const Symbol &sym) {
+  return evaluate::IsVariable(sym) || sym.attrs().test(Attr::POINTER);
+}
+
 bool OmpStructureChecker::IsExtendedListItem(const Symbol &sym) {
-  return evaluate::IsVariable(sym) || sym.IsSubprogram();
+  return IsVariableListItem(sym) || sym.IsSubprogram();
 }
 
 bool OmpStructureChecker::IsCloselyNestedRegion(const OmpDirectiveSet &set) {
@@ -2351,7 +2355,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause &x) {
     SymbolSourceMap symbols;
     GetSymbolsInObjectList(*objList, symbols);
     for (const auto &[sym, source] : symbols) {
-      if (!evaluate::IsVariable(sym)) {
+      if (!IsVariableListItem(*sym)) {
         deferredNonVariables_.insert({sym, source});
       }
     }
@@ -3428,7 +3432,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::To &x) {
   SymbolSourceMap symbols;
   GetSymbolsInObjectList(objList, symbols);
   for (const auto &[sym, source] : symbols) {
-    if (!evaluate::IsVariable(*sym)) {
+    if (!IsVariableListItem(*sym)) {
       context_.SayWithDecl(
           *sym, source, "'%s' must be a variable"_err_en_US, sym->name());
     }

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -141,6 +141,7 @@ public:
 
 private:
   bool CheckAllowedClause(llvmOmpClause clause);
+  bool IsVariableListItem(const Symbol &sym);
   bool IsExtendedListItem(const Symbol &sym);
   void CheckMultipleOccurrence(semantics::UnorderedSymbolSet &listVars,
       const std::list<parser::Name> &nameList, const parser::CharBlock &item,

--- a/flang/test/Semantics/OpenMP/shared-pointer.f90
+++ b/flang/test/Semantics/OpenMP/shared-pointer.f90
@@ -1,0 +1,13 @@
+!RUN: %flang_fc1 -fopenmp -emit-fir -o - %s | FileCheck %s
+!RUN: bbc -fopenmp -emit-fir -o - %s | FileCheck %s
+
+!Allow POINTER variables in OpenMP SHARED clause. Check that this
+!code compiles.
+
+!CHECK-LABEL: func.func @_QPfoo
+subroutine foo()
+  procedure(), pointer :: pf
+  !$omp parallel shared(pf)
+  !$omp end parallel
+end
+


### PR DESCRIPTION
Follow-up to 418920b3fbdefec5b56ee2b9db96884d0ada7329, which started diagnosing the legality of objects in OpenMP clauses (and caused some test failures).