### PR TITLE
[lldb] Use SEND_ERROR instead of FATAL_ERROR in test/CMakeLists.txt

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Lit requires a Python3 interpreter, let's be careful and fail early if it's
 # not present.
 if (NOT DEFINED Python3_EXECUTABLE)
-  message(FATAL_ERROR
+  message(SEND_ERROR
     "LLDB test suite requires a Python3 interpreter but none "
     "was found. Please install Python3 or disable tests with "
     "`LLDB_INCLUDE_TESTS=OFF`.")
@@ -22,7 +22,7 @@ if(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS)
   foreach(module ${useful_python_modules})
     lldb_find_python_module(${module})
     if (NOT PY_${module}_FOUND)
-      message(FATAL_ERROR
+      message(SEND_ERROR
         "Python module '${module}' not found. Please install it via pip or via "
         "your operating system's package manager. Alternatively, disable "
         "strict testing requirements with "
@@ -66,10 +66,10 @@ if (LLDB_TEST_OBJC_GNUSTEP)
   find_package(GNUstepObjC)
   if (NOT GNUstepObjC_FOUND)
     if (LLDB_TEST_OBJC_GNUSTEP_DIR)
-      message(FATAL_ERROR "Failed to find GNUstep libobjc2 in ${LLDB_TEST_OBJC_GNUSTEP_DIR}. "
+      message(SEND_ERROR "Failed to find GNUstep libobjc2 in ${LLDB_TEST_OBJC_GNUSTEP_DIR}. "
                           "Please check LLDB_TEST_OBJC_GNUSTEP_DIR or turn off LLDB_TEST_OBJC_GNUSTEP.")
     else()
-      message(FATAL_ERROR "Failed to find GNUstep libobjc2. "
+      message(SEND_ERROR "Failed to find GNUstep libobjc2. "
                           "Please set LLDB_TEST_OBJC_GNUSTEP_DIR or turn off LLDB_TEST_OBJC_GNUSTEP.")
     endif()
   endif()
@@ -185,7 +185,7 @@ if(TARGET clang)
         set(LIBCXX_LIBRARY_DIR "${LLDB_TEST_LIBCXX_ROOT_DIR}/lib${LIBCXX_LIBDIR_SUFFIX}")
         set(LIBCXX_GENERATED_INCLUDE_DIR "${LLDB_TEST_LIBCXX_ROOT_DIR}/include/c++/v1")
       else()
-        message(FATAL_ERROR
+        message(SEND_ERROR
             "Couldn't find libcxx build in '${LLDB_TEST_LIBCXX_ROOT_DIR}'. To run the "
             "test-suite for a standalone LLDB build please build libcxx and point "
             "LLDB_TEST_LIBCXX_ROOT_DIR to it.")
@@ -194,7 +194,7 @@ if(TARGET clang)
       # We require libcxx for the test suite, so if we aren't building it,
       # provide a helpful error about how to resolve the situation.
       if(NOT LLDB_HAS_LIBCXX)
-        message(FATAL_ERROR
+        message(SEND_ERROR
           "LLDB test suite requires libc++, but it is currently disabled. "
           "Please add `libcxx` to `LLVM_ENABLE_RUNTIMES` or disable tests via "
           "`LLDB_INCLUDE_TESTS=OFF`.")


### PR DESCRIPTION
Use SEND_ERROR (continue processing, but skip generation) instead of FATAL_ERROR (stop processing and generation). This means that developers get to see all errors at once, instead of seeing just the first error and having to reconfigure to discover the next one.