### PR TITLE
[NFC][CodingStandard] Add additional example for if-else brace rule

### DIFF
--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -1713,6 +1713,14 @@ would help to avoid running into a "dangling else" situation.
     handleOtherDecl(D);
   }
 
+  // Use braces for the `else` block to keep it uniform with the `if` block.
+  if (isa<FunctionDecl>(D)) {
+    verifyFunctionDecl(D);
+    handleFunctionDecl(D);
+  } else {
+    handleOtherDecl(D);
+  }
+
   // This should also omit braces.  The `for` loop contains only a single
   // statement, so it shouldn't have braces.  The `if` also only contains a
   // single simple statement (the `for` loop), so it also should omit braces.


### PR DESCRIPTION
Add example to document that single statement `else` needs a brace if the associated `if` needs a brace.