### PR TITLE
[docs] Update docs on code-review process

### DIFF
--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -159,8 +159,11 @@ you are fairly certain that a particular community member will wish to review,
 even if that person hasn't done so yet.
 
 If new comments are posted after the patch has been approved (but not yet
-merged), these need to be addressed and all new changes have to be reviewed and
-approved by a reviewer.
+merged), these need to be addressed following similar process as outlined
+above. Specifically, a reviewer should confirm that all feedback has been
+addressed before a patch is merged, including the newly posted comments.
+Exceptions apply - e.g. there's no need to confirm that a comment requesting a
+typo to be fixed has been addressed (this should be evident from the code).
 
 Note that, if a reviewer has requested a particular community member to review,
 and after a week that community member has yet to respond, feel free to ping

--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -158,12 +158,11 @@ approved. If unsure, the reviewer should provide a qualified approval, (e.g.,
 you are fairly certain that a particular community member will wish to review,
 even if that person hasn't done so yet.
 
-If new comments are posted after the patch has been approved (but not yet
-merged), these need to be addressed following similar process as outlined
-above. Specifically, a reviewer should confirm that all feedback has been
-addressed before a patch is merged, including the newly posted comments.
-Exceptions apply - e.g. there's no need to confirm that a comment requesting a
-typo to be fixed has been addressed (this should be evident from the code).
+If additional feedback is provided after acceptance (by the same reviewer or
+another), the author should use their best judgement in deciding whether that
+feedback can be incorporated into the change without comment (say a typo) or
+requires further review discussion. More substantial comments (e.g. about the
+design) will usually require further discussion. If unsure, ask the reviewer.
 
 Note that, if a reviewer has requested a particular community member to review,
 and after a week that community member has yet to respond, feel free to ping

--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -150,13 +150,17 @@ almost always associated with a message containing the text "LGTM" (which
 stands for Looks Good To Me). Only approval from a single reviewer is required.
 
 When providing an unqualified LGTM (approval to commit), it is the
-responsibility of the reviewer to have reviewed all of the discussion and
+responsibility of the reviewer to have reviewed all of the prior discussion and
 feedback from all reviewers ensuring that all feedback has been addressed and
 that all other reviewers will almost surely be satisfied with the patch being
 approved. If unsure, the reviewer should provide a qualified approval, (e.g.,
 "LGTM, but please wait for @someone, @someone_else"). You may also do this if
 you are fairly certain that a particular community member will wish to review,
 even if that person hasn't done so yet.
+
+If new comments are posted after the patch has been approved (but not yet
+merged), these need to be addressed and all new changes have to be reviewed and
+approved by a reviewer.
 
 Note that, if a reviewer has requested a particular community member to review,
 and after a week that community member has yet to respond, feel free to ping

--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -161,7 +161,7 @@ even if that person hasn't done so yet.
 If additional feedback is provided after acceptance (by the same reviewer or
 another), the author should use their best judgement in deciding whether that
 feedback can be incorporated into the change without comment (say a typo) or
-requires further review discussion. More substantial comments (e.g. about the
+requires further review discussion. More substantial comments (e.g., about the
 design) will usually require further discussion. If unsure, ask the reviewer.
 
 Note that, if a reviewer has requested a particular community member to review,

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -105,9 +105,16 @@ get the attention of potential reviewers by CC'ing them in a comment -- just
 A reviewer may request changes or ask questions during the review. If you are
 uncertain on how to provide test cases, documentation, etc., feel free to ask
 for guidance during the review. Please address the feedback and re-post an
-updated version of your patch. This cycle continues until all requests and comments
-have been addressed and a reviewer accepts the patch with a `Looks good to me` or `LGTM`.
-Once that is done the change can be committed. If you do not have commit
+updated version of your patch. This cycle continues until all requests and
+comments have been addressed and the reviewer accepts the patch with a `Looks
+good to me` or `LGTM`. With multiple active reviewers (i.e. reviewers who left
+comments), it is good practice to seek `LGTM` from all of them. Alternatively, 
+when e.g. some reviewers go radio silent and you are blocked:
+* any reviewer can confirm that all comments from other reviewers have been
+  addressed and the change is ready to land, or
+* if you decide not to wait for explicit `LGTM` from other reviewers, please
+  leave a short justification.
+Once a change has been approved, it can be committed. If you do not have commit
 access, please let people know during the review and someone should commit it
 on your behalf.
 

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -102,9 +102,15 @@ will not be able to select reviewers in such a way, in which case you can still
 get the attention of potential reviewers by CC'ing them in a comment -- just
 @name them.
 
-If you do not have commit access, please let people know during the review and
-someone should commit it on your behalf once it has been accepted. For more
-information on LLVM's code-review process, please see :doc:`CodeReview`.
+If you have received no comments on your patch for a week, you can request a
+review by 'ping'ing the GitHub PR with "Ping". The common courtesy 'ping' rate
+is once a week. Please remember that you are asking for valuable time from
+other professional developers. Finally, if you do not have commit access,
+please let people know during the review and someone should commit it on your
+behalf once it has been accepted.
+
+For more information on LLVM's code-review process, please see
+:doc:`CodeReview`.
 
 .. _commit_from_git:
 

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -102,21 +102,9 @@ will not be able to select reviewers in such a way, in which case you can still
 get the attention of potential reviewers by CC'ing them in a comment -- just
 @name them.
 
-A reviewer may request changes or ask questions during the review. If you are
-uncertain on how to provide test cases, documentation, etc., feel free to ask
-for guidance during the review. Please address the feedback and re-post an
-updated version of your patch. This cycle continues until all requests and comments
-have been addressed and a reviewer accepts the patch with a `Looks good to me` or `LGTM`.
-Once that is done the change can be committed. If you do not have commit
-access, please let people know during the review and someone should commit it
-on your behalf.
-
-If you have received no comments on your patch for a week, you can request a
-review by 'ping'ing the GitHub PR with "Ping". The common courtesy 'ping' rate
-is once a week. Please remember that you are asking for valuable time from other
-professional developers.
-
-For more information on LLVM's code-review process, please see :doc:`CodeReview`.
+If you do not have commit access, please let people know during the review and
+someone should commit it on your behalf once it has been accepted. For more
+information on LLVM's code-review process, please see :doc:`CodeReview`.
 
 .. _commit_from_git:
 

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -105,16 +105,9 @@ get the attention of potential reviewers by CC'ing them in a comment -- just
 A reviewer may request changes or ask questions during the review. If you are
 uncertain on how to provide test cases, documentation, etc., feel free to ask
 for guidance during the review. Please address the feedback and re-post an
-updated version of your patch. This cycle continues until all requests and
-comments have been addressed and the reviewer accepts the patch with a `Looks
-good to me` or `LGTM`. With multiple active reviewers (i.e. reviewers who left
-comments), it is good practice to seek `LGTM` from all of them. Alternatively, 
-when e.g. some reviewers go radio silent and you are blocked:
-* any reviewer can confirm that all comments from other reviewers have been
-  addressed and the change is ready to land, or
-* if you decide not to wait for explicit `LGTM` from other reviewers, please
-  leave a short justification.
-Once a change has been approved, it can be committed. If you do not have commit
+updated version of your patch. This cycle continues until all requests and comments
+have been addressed and a reviewer accepts the patch with a `Looks good to me` or `LGTM`.
+Once that is done the change can be committed. If you do not have commit
 access, please let people know during the review and someone should commit it
 on your behalf.
 


### PR DESCRIPTION
Clarify what to do in cases where multiple reviewers commented on a
patch, but only one reviewer explicitly accepted.

This is mostly to standardize what the expectations are as folks tend to
approach this differently.
