### PR TITLE
[clang] Update string and string_view in lifetimebound tests

### DIFF
--- a/clang/test/SemaCXX/attr-lifetimebound.cpp
+++ b/clang/test/SemaCXX/attr-lifetimebound.cpp
@@ -85,7 +85,7 @@ namespace std {
     char &operator[](size_t) const [[clang::lifetimebound]];
   };
   using string =  basic_string<char>;
-  string operator""s(const char *, size_t); // expected-warning {{}}
+  string operator""s(const char *, size_t); // expected-warning {{user-defined literal suffixes not starting with '_' are reserved}}
 
   template<typename T>
   struct basic_string_view {
@@ -94,7 +94,7 @@ namespace std {
     basic_string_view(const string &s [[clang::lifetimebound]]);
   };
   using string_view = basic_string_view<char>;
-  string_view operator""sv(const char *, size_t); // expected-warning {{}}
+  string_view operator""sv(const char *, size_t); // expected-warning {{user-defined literal suffixes not starting with '_' are reserved}}
 
   struct vector {
     int *data();

--- a/clang/test/SemaCXX/attr-lifetimebound.cpp
+++ b/clang/test/SemaCXX/attr-lifetimebound.cpp
@@ -75,23 +75,26 @@ namespace usage_ok {
   }
 }
 
-# 1 "<std>" 1 3
 namespace std {
   using size_t = __SIZE_TYPE__;
-  struct string {
-    string();
-    string(const char*);
+  template<typename T>
+  struct basic_string {
+    basic_string();
+    basic_string(const T*);
 
     char &operator[](size_t) const [[clang::lifetimebound]];
   };
-  string operator""s(const char *, size_t);
+  using string =  basic_string<char>;
+  string operator""s(const char *, size_t); // expected-warning {{}}
 
-  struct string_view {
-    string_view();
-    string_view(const char *p [[clang::lifetimebound]]);
-    string_view(const string &s [[clang::lifetimebound]]);
+  template<typename T>
+  struct basic_string_view {
+    basic_string_view();
+    basic_string_view(const T *p);
+    basic_string_view(const string &s [[clang::lifetimebound]]);
   };
-  string_view operator""sv(const char *, size_t);
+  using string_view = basic_string_view<char>;
+  string_view operator""sv(const char *, size_t); // expected-warning {{}}
 
   struct vector {
     int *data();
@@ -100,7 +103,6 @@ namespace std {
 
   template<typename K, typename V> struct map {};
 }
-# 68 "attr-lifetimebound.cpp" 2
 
 using std::operator""s;
 using std::operator""sv;
@@ -112,7 +114,7 @@ namespace p0936r0_examples {
   void f() {
     std::string_view sv = "hi";
     std::string_view sv2 = sv + sv; // expected-warning {{temporary}}
-    sv2 = sv + sv; // FIXME: can we infer that we should warn here too?
+    sv2 = sv + sv; // expected-warning {{object backing the pointer}}
   }
 
   struct X { int a, b; };
@@ -237,11 +239,6 @@ template <class T> T *addressof(T &arg) {
     return reinterpret_cast<T *>(
         &const_cast<char &>(reinterpret_cast<const volatile char &>(arg)));
 }
-
-template<typename T>
-struct basic_string_view {
-  basic_string_view(const T *);
-};
 
 template <class T> struct span {
   template<size_t _ArrayExtent>


### PR DESCRIPTION
Removes pragmas like `# 1 "<std>" 1 3` to make line numbers in failing tests more accurate.
Use `basic_string_view` instead `string_view` to kick in GSL owner/pointer auto inference.