### PR TITLE
[libc++] Add output groups to run-buildbot

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -7,7 +7,7 @@
 #
 # ===----------------------------------------------------------------------===##
 
-set -ex
+set -e
 set -o pipefail
 unset LANG
 unset LC_ALL
@@ -96,12 +96,37 @@ if [ -z "${CMAKE}" ]; then
     fi
 fi
 
+function step() {
+  endstep
+  set +x
+  if [[ ! -z ${GITHUB_ACTIONS+x} ]]; then
+    echo "::group::$1"
+    export IN_GROUP=1
+  else
+    echo "--- $1"
+  fi
+  set -x
+}
+
+function endstep() {
+  set +x
+  if [[ ! -z ${GITHUB_ACTIONS+x} ]] && [[ ! -z ${IN_GROUP+x} ]]; then
+    echo "::endgroup::"
+    unset IN_GROUP
+  fi
+  set -x
+}
+
+function error() {
+    echo "::error::$1"
+}
+
 function clean() {
     rm -rf "${BUILD_DIR}"
 }
 
 function generate-cmake-base() {
-    echo "--- Generating CMake"
+    step "Generating CMake"
     ${CMAKE} \
           -S "${MONOREPO_ROOT}/runtimes" \
           -B "${BUILD_DIR}" \
@@ -138,29 +163,32 @@ function generate-cmake-android() {
 }
 
 function check-runtimes() {
-    echo "+++ Running the libc++ tests"
+    step "Building libc++ test dependencies"
+    ${NINJA} -vC "${BUILD_DIR}" cxx-test-depends
+
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx
 
-    echo "+++ Running the libc++abi tests"
+    step "Running the libc++abi tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxxabi
 
-    echo "+++ Running the libunwind tests"
+    step "Running the libunwind tests"
     ${NINJA} -vC "${BUILD_DIR}" check-unwind
 }
 
 # TODO: The goal is to test this against all configurations. We should also move
 #       this to the Lit test suite instead of being a separate CMake target.
 function check-abi-list() {
-    echo "+++ Running the libc++ ABI list test"
+    step "Running the libc++ ABI list test"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx-abilist || (
-        echo "+++ Generating the libc++ ABI list after failed check"
+        error "Generating the libc++ ABI list after failed check"
         ${NINJA} -vC "${BUILD_DIR}" generate-cxx-abilist
         false
     )
 }
 
 function check-cxx-benchmarks() {
-    echo "--- Running the benchmarks"
+    step "Running the benchmarks"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx-benchmarks
 }
 
@@ -170,12 +198,13 @@ function test-armv7m-picolibc() {
     # To make it easier to get this builder up and running, build picolibc
     # from scratch. Anecdotally, the build-picolibc script takes about 16 seconds.
     # This could be optimised by building picolibc into the Docker container.
+    step "Building picolibc from source"
     ${MONOREPO_ROOT}/libcxx/utils/ci/build-picolibc.sh \
         --build-dir "${BUILD_DIR}" \
         --install-dir "${INSTALL_DIR}" \
         --target armv7m-none-eabi
 
-    echo "--- Generating CMake"
+    step "Generating CMake for compiler-rt"
     flags="--sysroot=${INSTALL_DIR}"
     ${CMAKE} \
         -S "${MONOREPO_ROOT}/compiler-rt" \
@@ -187,6 +216,8 @@ function test-armv7m-picolibc() {
         -DCMAKE_CXX_FLAGS="${flags}" \
         -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON \
         "${@}"
+
+    step "Generating CMake for libc++"
     generate-cmake \
         -DLIBCXX_TEST_CONFIG="armv7m-picolibc-libc++.cfg.in" \
         -DLIBCXXABI_TEST_CONFIG="armv7m-picolibc-libc++abi.cfg.in" \
@@ -195,6 +226,7 @@ function test-armv7m-picolibc() {
         -DCMAKE_CXX_FLAGS="${flags}" \
         "${@}"
 
+    step "Installing compiler-rt"
     ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
 
     # Prior to clang 19, armv7m-none-eabi normalised to armv7m-none-unknown-eabi.
@@ -208,9 +240,9 @@ function test-armv7m-picolibc() {
 }
 
 # Print the version of a few tools to aid diagnostics in some cases
+step "Diagnose tools in use"
 ${CMAKE} --version
 ${NINJA} --version
-
 if [ ! -z "${CXX}" ]; then ${CXX} --version; fi
 
 case "${BUILDER}" in
@@ -220,10 +252,9 @@ check-generated-output)
     clean
     generate-cmake
 
-    set +x # Printing all the commands below just creates extremely confusing output
-
     # Reject patches that forgot to re-run the generator scripts.
-    echo "+++ Making sure the generator scripts were run"
+    step "Making sure the generator scripts were run"
+    set +x # Printing all the commands below just creates extremely confusing output
     ${NINJA} -vC "${BUILD_DIR}" libcxx-generate-files
     git diff | tee ${BUILD_DIR}/generated_output.patch
     git ls-files -o --exclude-standard | tee ${BUILD_DIR}/generated_output.status
@@ -235,9 +266,8 @@ check-generated-output)
         false
     fi
 
-    # Reject patches that introduce non-ASCII characters or hard tabs.
-    # Depends on LC_COLLATE set at the top of this script.
-    set -x
+    # This depends on LC_COLLATE set at the top of this script.
+    step "Reject patches that introduce non-ASCII characters or hard tabs."
     ! grep -rn '[^ -~]' libcxx/include libcxx/src libcxx/test \
            --exclude '*.dat' \
            --exclude '*unicode*.cpp' \
@@ -345,7 +375,7 @@ generic-ubsan)
 bootstrapping-build)
     clean
 
-    echo "--- Generating CMake"
+    step "Generating CMake"
     ${CMAKE} \
           -S "${MONOREPO_ROOT}/llvm" \
           -B "${BUILD_DIR}" \
@@ -362,14 +392,14 @@ bootstrapping-build)
           -DLLVM_ENABLE_ASSERTIONS=ON \
           -DLLVM_LIT_ARGS="-sv --xunit-xml-output test-results.xml --timeout=1500 --time-tests"
 
-    echo "+++ Running the LLDB libc++ data formatter tests"
+    step "Running the LLDB libc++ data formatter tests"
     ${NINJA} -vC "${BUILD_DIR}" lldb-api-test-deps
     ${BUILD_DIR}/bin/llvm-lit -sv --param dotest-args='--category libc++' "${MONOREPO_ROOT}/lldb/test/API"
 
-    echo "--- Running the libc++ and libc++abi tests"
+    step "Running the libc++ and libc++abi tests"
     ${NINJA} -vC "${BUILD_DIR}" check-runtimes
 
-    echo "+++ Installing libc++ and libc++abi to a fake location"
+    step "Installing libc++ and libc++abi to a fake location"
     ${NINJA} -vC "${BUILD_DIR}" install-runtimes
 
     ccache -s
@@ -502,6 +532,7 @@ generic-optimized-speed)
 apple-configuration)
     clean
 
+    step "Installing libc++ with the Apple system configuration"
     arch="$(uname -m)"
     xcrun --sdk macosx                                              \
         ${MONOREPO_ROOT}/libcxx/utils/ci/apple-install-libcxx.sh    \
@@ -512,6 +543,7 @@ apple-configuration)
             --architectures "${arch}"                               \
             --version "999.99"
 
+    step "Running tests against Apple-configured libc++"
     # TODO: It would be better to run the tests against the fake-installed version of libc++ instead
     xcrun --sdk macosx ninja -vC "${BUILD_DIR}/${arch}" check-cxx check-cxxabi check-cxx-abilist
 ;;
@@ -524,6 +556,7 @@ apple-system-hardened)
     params+=";hardening_mode=fast"
 
     # In the Apple system configuration, we build libc++ and libunwind separately.
+    step "Installing libc++ and libc++abi in Apple-system configuration"
     ${CMAKE} \
         -S "${MONOREPO_ROOT}/runtimes" \
         -B "${BUILD_DIR}/cxx" \
@@ -539,6 +572,7 @@ apple-system-hardened)
         -DLIBCXX_TEST_PARAMS="${params}" \
         -DLIBCXXABI_TEST_PARAMS="${params}"
 
+    step "Installing libunwind in Apple-system configuration"
     ${CMAKE} \
         -S "${MONOREPO_ROOT}/runtimes" \
         -B "${BUILD_DIR}/unwind" \
@@ -551,13 +585,13 @@ apple-system-hardened)
         -DLIBUNWIND_TEST_PARAMS="${params}" \
         -DCMAKE_INSTALL_NAME_DIR="/usr/lib/system"
 
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}/cxx" check-cxx
 
-    echo "+++ Running the libc++abi tests"
+    step "Running the libc++abi tests"
     ${NINJA} -vC "${BUILD_DIR}/cxx" check-cxxabi
 
-    echo "+++ Running the libunwind tests"
+    step "Running the libunwind tests"
     ${NINJA} -vC "${BUILD_DIR}/unwind" check-unwind
 ;;
 apple-system)
@@ -568,6 +602,7 @@ apple-system)
     params="target_triple=${arch}-apple-macosx${version}"
 
     # In the Apple system configuration, we build libc++ and libunwind separately.
+    step "Installing libc++ and libc++abi in Apple-system configuration"
     ${CMAKE} \
         -S "${MONOREPO_ROOT}/runtimes" \
         -B "${BUILD_DIR}/cxx" \
@@ -583,6 +618,7 @@ apple-system)
         -DLIBCXX_TEST_PARAMS="${params}" \
         -DLIBCXXABI_TEST_PARAMS="${params}"
 
+    step "Installing libunwind in Apple-system configuration"
     ${CMAKE} \
         -S "${MONOREPO_ROOT}/runtimes" \
         -B "${BUILD_DIR}/unwind" \
@@ -595,13 +631,13 @@ apple-system)
         -DLIBUNWIND_TEST_PARAMS="${params}" \
         -DCMAKE_INSTALL_NAME_DIR="/usr/lib/system"
 
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}/cxx" check-cxx
 
-    echo "+++ Running the libc++abi tests"
+    step "Running the libc++abi tests"
     ${NINJA} -vC "${BUILD_DIR}/cxx" check-cxxabi
 
-    echo "+++ Running the libunwind tests"
+    step "Running the libunwind tests"
     ${NINJA} -vC "${BUILD_DIR}/unwind" check-unwind
 ;;
 benchmarks)
@@ -664,13 +700,13 @@ clang-cl-dll)
     # anyway), thus just disable the experimental library. Remove this
     # setting when cmake and the test driver does the right thing automatically.
     generate-cmake-libcxx-win -DLIBCXX_TEST_PARAMS="enable_experimental=False"
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-static)
     clean
     generate-cmake-libcxx-win -DLIBCXX_ENABLE_SHARED=OFF
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-no-vcruntime)
@@ -681,14 +717,14 @@ clang-cl-no-vcruntime)
     # exceptions enabled.
     generate-cmake-libcxx-win -DLIBCXX_TEST_PARAMS="enable_experimental=False" \
                               -DLIBCXX_TEST_CONFIG="llvm-libc++-shared-no-vcruntime-clangcl.cfg.in"
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-debug)
     clean
     generate-cmake-libcxx-win -DLIBCXX_TEST_PARAMS="enable_experimental=False" \
                               -DCMAKE_BUILD_TYPE=Debug
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-static-crt)
@@ -697,7 +733,7 @@ clang-cl-static-crt)
     # the static CRT, as opposed to "MultiThreadedDLL" which is the default).
     generate-cmake-libcxx-win -DLIBCXX_ENABLE_SHARED=OFF \
                               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 mingw-dll)
@@ -743,6 +779,7 @@ mingw-incomplete-sysroot)
           -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake"
     # Only test that building succeeds; there's not much extra value in running
     # the tests here, as it would be equivalent to the mingw-dll config above.
+    step "Building the runtimes"
     ${NINJA} -vC "${BUILD_DIR}"
 ;;
 aix)
@@ -760,7 +797,7 @@ android-ndk-*)
     ANDROID_EMU_IMG="${BUILDER#android-ndk-}"
     . "${MONOREPO_ROOT}/libcxx/utils/ci/vendor/android/emulator-functions.sh"
     if ! validate_emu_img "${ANDROID_EMU_IMG}"; then
-        echo "error: android-ndk suffix must be a valid emulator image (${ANDROID_EMU_IMG})" >&2
+        error "android-ndk suffix must be a valid emulator image (${ANDROID_EMU_IMG})" >&2
         exit 1
     fi
     ARCH=$(arch_of_emu_img ${ANDROID_EMU_IMG})
@@ -792,9 +829,9 @@ android-ndk-*)
     # directories.
     adb shell mkdir -p /data/local/tmp/adb_run
     adb push "${BUILD_DIR}/lib/libc++_shared.so" /data/local/tmp/libc++/libc++_shared.so
-    echo "+++ Running the libc++ tests"
+    step "Running the libc++ tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxx
-    echo "+++ Running the libc++abi tests"
+    step "Running the libc++abi tests"
     ${NINJA} -vC "${BUILD_DIR}" check-cxxabi
 ;;
 #################################################################
@@ -810,3 +847,5 @@ android-ndk-*)
     exit 1
 ;;
 esac
+
+endstep # Make sure we close any still-open output group


### PR DESCRIPTION
This improves the CI output by providing collapsable sections for sub-parts of our build.

This was originally opened as #75233.