### PR TITLE
[Clang] Diagnose dangling references in std::vector.

### DIFF
--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -404,7 +404,7 @@ shouldTrackFirstArgumentForConstructor(const CXXConstructExpr *Ctor) {
   if (LHSRecordDecl->hasAttr<PointerAttr>())
     return true;
 
-  if (Ctor->getConstructor()->getNumParams() < 1 ||
+  if (Ctor->getConstructor()->param_empty() ||
       !isContainerOfPointer(LHSRecordDecl))
     return false;
 

--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -404,7 +404,7 @@ shouldTrackFirstArgumentForConstructor(const CXXConstructExpr *Ctor) {
   if (LHSRecordDecl->hasAttr<PointerAttr>())
     return true;
 
-  if (Ctor->getConstructor()->getNumParams() != 1 ||
+  if (Ctor->getConstructor()->getNumParams() < 1 ||
       !isContainerOfPointer(LHSRecordDecl))
     return false;
 

--- a/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
+++ b/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
@@ -164,14 +164,16 @@ template<typename T>
 struct initializer_list {
   const T* ptr; size_t sz;
 };
-template <typename T>
+template<typename T> class allocator {};
+template <typename T, typename Alloc = allocator<T>>
 struct vector {
   typedef __gnu_cxx::basic_iterator<T> iterator;
   iterator begin();
   iterator end();
   const T *data() const;
   vector();
-  vector(initializer_list<T> __l);
+  vector(initializer_list<T> __l,
+         const Alloc& alloc = Alloc());
 
   template<typename InputIterator>
 	vector(InputIterator first, InputIterator __last);


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/108344.

The original bailout check was overly strict, causing it to miss cases like the vector(initializer_list, allocator) constructor. This patch relaxes the check to address that issue.

Fix #111680