### PR TITLE
[CodeLayout] Do not verify after assigning blocks

### DIFF
--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -3572,7 +3572,7 @@ bool MachineBlockPlacement::runOnMachineFunction(MachineFunction &MF) {
   if (UseExtTspForPerf || UseExtTspForSize) {
     assert(
         !(UseExtTspForPerf && UseExtTspForSize) &&
-        "UseExtTspForPerf and UseExtTspForSize can not be set simultaneosly");
+        "UseExtTspForPerf and UseExtTspForSize can not be set simultaneously");
     applyExtTsp(/*OptForSize=*/UseExtTspForSize);
     createCFGChainExtTsp();
   }
@@ -3745,11 +3745,6 @@ void MachineBlockPlacement::assignBlockOrder(
       continue;
     MBB.updateTerminator(FTMBB);
   }
-
-#ifndef NDEBUG
-  // Make sure we correctly constructed all branches.
-  F->verify(this, "After optimized block reordering", &errs());
-#endif
 }
 
 void MachineBlockPlacement::createCFGChainExtTsp() {

--- a/llvm/test/CodeGen/X86/code_placement_ext_tsp.ll
+++ b/llvm/test/CodeGen/X86/code_placement_ext_tsp.ll
@@ -1,5 +1,5 @@
 ;; See also llvm/unittests/Transforms/Utils/CodeLayoutTest.cpp
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -enable-ext-tsp-block-placement=1 < %s | FileCheck %s
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -verify-machineinstrs -enable-ext-tsp-block-placement < %s | FileCheck %s
 
 define void @func1a()  {
 ; Test that the algorithm positions the most likely successor first

--- a/llvm/test/CodeGen/X86/code_placement_ext_tsp_large.ll
+++ b/llvm/test/CodeGen/X86/code_placement_ext_tsp_large.ll
@@ -1,8 +1,8 @@
 ; REQUIRES: asserts
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -enable-ext-tsp-block-placement=1 -ext-tsp-chain-split-threshold=128 -debug-only=block-placement < %s 2>&1 | FileCheck %s
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -enable-ext-tsp-block-placement=1 -ext-tsp-chain-split-threshold=1 -debug-only=block-placement < %s 2>&1 | FileCheck %s -check-prefix=CHECK2
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -enable-ext-tsp-block-placement=0 -debug-only=block-placement < %s 2>&1 | FileCheck %s -check-prefix=CHECK3
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -enable-ext-tsp-block-placement=1 -ext-tsp-block-placement-max-blocks=8 -debug-only=block-placement < %s 2>&1 | FileCheck %s -check-prefix=CHECK4
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -verify-machineinstrs -enable-ext-tsp-block-placement -ext-tsp-chain-split-threshold=128 -debug-only=block-placement < %s 2>&1 | FileCheck %s
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -verify-machineinstrs -enable-ext-tsp-block-placement -ext-tsp-chain-split-threshold=1 -debug-only=block-placement < %s 2>&1 | FileCheck %s -check-prefix=CHECK2
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -verify-machineinstrs -debug-only=block-placement < %s 2>&1 | FileCheck %s -check-prefix=CHECK3
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -verify-machineinstrs -enable-ext-tsp-block-placement -ext-tsp-block-placement-max-blocks=8 -debug-only=block-placement < %s 2>&1 | FileCheck %s -check-prefix=CHECK4
 
 @yydebug = dso_local global i32 0, align 4
 

--- a/llvm/test/CodeGen/X86/code_placement_ext_tsp_size.ll
+++ b/llvm/test/CodeGen/X86/code_placement_ext_tsp_size.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=true  < %s | FileCheck %s -check-prefix=CHECK-PERF
-; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -apply-ext-tsp-for-size=false < %s | FileCheck %s -check-prefix=CHECK-SIZE
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -verify-machineinstrs -apply-ext-tsp-for-size < %s | FileCheck %s -check-prefix=CHECK-SIZE
+; RUN: llc -mcpu=corei7 -mtriple=x86_64-linux -verify-machineinstrs < %s | FileCheck %s -check-prefix=CHECK-PERF
 
 define void @func1() minsize {
 ;
@@ -19,15 +19,15 @@ define void @func1() minsize {
 ; | b2  | <+
 ; +-----+
 ;
-; CHECK-PERF-LABEL: func1:
-; CHECK-PERF: %b0
-; CHECK-PERF: %b1
-; CHECK-PERF: %b2
-;
 ; CHECK-SIZE-LABEL: func1:
 ; CHECK-SIZE: %b0
-; CHECK-SIZE: %b2
 ; CHECK-SIZE: %b1
+; CHECK-SIZE: %b2
+;
+; CHECK-PERF-LABEL: func1:
+; CHECK-PERF: %b0
+; CHECK-PERF: %b2
+; CHECK-PERF: %b1
 
 b0:
   %call = call zeroext i1 @a()
@@ -75,21 +75,21 @@ define void @func_loop() minsize !prof !9 {
 ;                  |  end   |
 ;                  +--------+
 ;
-; CHECK-PERF-LABEL: func_loop:
-; CHECK-PERF: %entry
-; CHECK-PERF: %header
-; CHECK-PERF: %if.then
-; CHECK-PERF: %if.else
-; CHECK-PERF: %if.end
-; CHECK-PERF: %end
-;
 ; CHECK-SIZE-LABEL: func_loop:
 ; CHECK-SIZE: %entry
 ; CHECK-SIZE: %header
+; CHECK-SIZE: %if.then
 ; CHECK-SIZE: %if.else
 ; CHECK-SIZE: %if.end
-; CHECK-SIZE: %if.then
 ; CHECK-SIZE: %end
+;
+; CHECK-PERF-LABEL: func_loop:
+; CHECK-PERF: %entry
+; CHECK-PERF: %header
+; CHECK-PERF: %if.else
+; CHECK-PERF: %if.end
+; CHECK-PERF: %if.then
+; CHECK-PERF: %end
 
 entry:
   br label %header


### PR DESCRIPTION
Rather than invariantly running `F->verify()` when asserts are enabled, run machine IR verification in LIT tests only.

Swap `CHECK-PERF` and `CHECK-SIZE` in `code_placement_ext_tsp_large.ll`.

Remove `={0,1,true,false}` from flags in tests.