### PR TITLE
[libc] Clean up 'vasprintf' implementation

### DIFF
--- a/libc/src/stdio/asprintf.cpp
+++ b/libc/src/stdio/asprintf.cpp
@@ -11,10 +11,11 @@
 #include "src/__support/macros/config.h"
 #include "src/stdio/printf_core/vasprintf_internal.h"
 
-namespace LIBC_NAMESPACE {
+namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, asprintf,
-                   (char **__restrict buffer, const char *format, ...)) {
+                   (char **__restrict buffer, const char *__restrict format,
+                    ...)) {
   va_list vlist;
   va_start(vlist, format);
   internal::ArgList args(vlist); // This holder class allows for easier copying
@@ -25,4 +26,4 @@ LLVM_LIBC_FUNCTION(int, asprintf,
   return ret;
 }
 
-} // namespace LIBC_NAMESPACE
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/asprintf.h
+++ b/libc/src/stdio/asprintf.h
@@ -13,7 +13,7 @@
 
 namespace LIBC_NAMESPACE {
 
-int asprintf(char **__restrict s, const char *format, ...);
+int asprintf(char **__restrict s, const char *__restrict format, ...);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdio/printf_core/vasprintf_internal.h
+++ b/libc/src/stdio/printf_core/vasprintf_internal.h
@@ -13,7 +13,7 @@
 #include "src/stdio/printf_core/writer.h"
 #include <stdlib.h> // malloc, realloc, free
 
-namespace LIBC_NAMESPACE {
+namespace LIBC_NAMESPACE_DECL {
 namespace printf_core {
 
 LIBC_INLINE int resize_overflow_hook(cpp::string_view new_str, void *target) {
@@ -40,7 +40,7 @@ LIBC_INLINE int resize_overflow_hook(cpp::string_view new_str, void *target) {
 
 constexpr size_t DEFAULT_BUFFER_SIZE = 200;
 
-LIBC_INLINE int vasprintf_internal(char **ret, const char *format,
+LIBC_INLINE int vasprintf_internal(char **ret, const char *__restrict format,
                                    internal::ArgList args) {
   char init_buff_on_stack[DEFAULT_BUFFER_SIZE];
   printf_core::WriteBuffer wb(init_buff_on_stack, DEFAULT_BUFFER_SIZE,
@@ -64,4 +64,4 @@ LIBC_INLINE int vasprintf_internal(char **ret, const char *format,
   return ret_val;
 }
 } // namespace printf_core
-} // namespace LIBC_NAMESPACE
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/vasprintf.cpp
+++ b/libc/src/stdio/vasprintf.cpp
@@ -10,14 +10,15 @@
 #include "src/__support/arg_list.h"
 #include "src/stdio/printf_core/vasprintf_internal.h"
 
-namespace LIBC_NAMESPACE {
+namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, vasprintf,
-                   (char **__restrict ret, const char *format, va_list vlist)) {
+                   (char **__restrict ret, const char *__restrict format,
+                    va_list vlist)) {
   internal::ArgList args(vlist); // This holder class allows for easier copying
                                  // and pointer semantics, as well as handling
                                  // destruction automatically.
   return printf_core::vasprintf_internal(ret, format, args);
 }
 
-} // namespace LIBC_NAMESPACE
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/vasprintf.h
+++ b/libc/src/stdio/vasprintf.h
@@ -13,7 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-int vasprintf(char **__restrict s, const char *format, va_list vlist);
+int vasprintf(char **__restrict s, const char *__restrict format,
+              va_list vlist);
 
 } // namespace LIBC_NAMESPACE
 


### PR DESCRIPTION
Summary:
This had some leftover references to the old namespace and didn't put
restrict on it.
