### PR TITLE
[lldb] Add missing include to SBLanguages.h

### DIFF
--- a/lldb/scripts/generate-sbapi-dwarf-enum.py
+++ b/lldb/scripts/generate-sbapi-dwarf-enum.py
@@ -16,6 +16,8 @@ HEADER = """\
 #ifndef LLDB_API_SBLANGUAGE_H
 #define LLDB_API_SBLANGUAGE_H
 
+#include <cstdint>
+
 namespace lldb {
 /// Used by \\ref SBExpressionOptions.
 /// These enumerations use the same language enumerations as the DWARF


### PR DESCRIPTION
SBLanguages.h uses a uint16_t but is missing the include for `<cstdint>`, if any file includes this without including that it will cause a build error so this commit adds this include.