### PR TITLE
[CMake][Windows] Fix Debug config build when using MSBuild

### DIFF
--- a/llvm/cmake/modules/TableGen.cmake
+++ b/llvm/cmake/modules/TableGen.cmake
@@ -190,14 +190,14 @@ macro(add_tablegen target project)
   endif()
 
   # FIXME: Quick fix to reflect LLVM_TABLEGEN to llvm-min-tblgen
+  set(RAW_LLVM_TABLEGEN ${LLVM_TABLEGEN})
+  if(NOT "${RAW_LLVM_TABLEGEN}" STREQUAL "")
+    get_filename_component(RAW_LLVM_TABLEGEN ${RAW_LLVM_TABLEGEN} NAME_WE)
+  endif()
   if("${target}" STREQUAL "llvm-min-tblgen"
-      AND NOT "${LLVM_TABLEGEN}" STREQUAL "")
-    # Extract base filename from full path.
-    get_filename_component(RAW_LLVM_TABLEGEN ${LLVM_TABLEGEN} NAME_WE)
-    if(NOT "${RAW_LLVM_TABLEGEN}" STREQUAL ""
-        AND NOT "${RAW_LLVM_TABLEGEN}" STREQUAL "llvm-tblgen")
-      set(${project}_TABLEGEN_DEFAULT "${LLVM_TABLEGEN}")
-    endif()
+      AND NOT "${RAW_LLVM_TABLEGEN}" STREQUAL ""
+      AND NOT "${RAW_LLVM_TABLEGEN}" STREQUAL "llvm-tblgen")
+    set(${project}_TABLEGEN_DEFAULT "${LLVM_TABLEGEN}")
   endif()
 
   if(ADD_TABLEGEN_EXPORT)

--- a/llvm/cmake/modules/TableGen.cmake
+++ b/llvm/cmake/modules/TableGen.cmake
@@ -191,9 +191,13 @@ macro(add_tablegen target project)
 
   # FIXME: Quick fix to reflect LLVM_TABLEGEN to llvm-min-tblgen
   if("${target}" STREQUAL "llvm-min-tblgen"
-      AND NOT "${LLVM_TABLEGEN}" STREQUAL ""
-      AND NOT "${LLVM_TABLEGEN}" STREQUAL "llvm-tblgen")
-    set(${project}_TABLEGEN_DEFAULT "${LLVM_TABLEGEN}")
+      AND NOT "${LLVM_TABLEGEN}" STREQUAL "")
+    # Extract base filename from full path.
+    get_filename_component(RAW_LLVM_TABLEGEN ${LLVM_TABLEGEN} NAME_WE)
+    if(NOT "${RAW_LLVM_TABLEGEN}" STREQUAL ""
+        AND NOT "${RAW_LLVM_TABLEGEN}" STREQUAL "llvm-tblgen")
+      set(${project}_TABLEGEN_DEFAULT "${LLVM_TABLEGEN}")
+    endif()
   endif()
 
   if(ADD_TABLEGEN_EXPORT)


### PR DESCRIPTION
Commit 95d4506dda caused a failure in a debug-build with MSBuild.  That commit conditionally makes an assignment to a cmake variable, but suppresses the assignment when LLVM_TABLEGEN is precicely "llvm-tblgen". This commit updates that change, so that the assignment is suppressed when LLVM_TABLEGEN logically is "llvm-tblgen" (i.e., it also suppresses it for "llvm-tblgen.exe", or for a full pathname that ends with llvm-tblgen" or "llvm-tblgen.exe").