### PR TITLE
[SandboxVec] Re-land "Use sbvec-passes flag to create a pipeline of Region passes after BottomUpVec. (#111223)"

### DIFF
--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -61,7 +61,8 @@ public:
     static constexpr const char EndToken = '\0';
     static constexpr const char PassDelimToken = ',';
 
-    Passes.clear();
+    assert(Passes.empty() &&
+           "setPassPipeline called on a non-empty sandboxir::PassManager");
     // Add EndToken to the end to ease parsing.
     std::string PipelineStr = std::string(Pipeline) + EndToken;
     int FlagBeginIdx = 0;

--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -36,6 +36,7 @@ protected:
 
   PassManager(StringRef Name) : ParentPass(Name) {}
   PassManager(const PassManager &) = delete;
+  PassManager(PassManager &&) = default;
   virtual ~PassManager() = default;
   PassManager &operator=(const PassManager &) = delete;
 

--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -18,6 +18,8 @@
 #ifndef LLVM_SANDBOXIR_PASSMANAGER_H
 #define LLVM_SANDBOXIR_PASSMANAGER_H
 
+#include <memory>
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/SandboxIR/Pass.h"
@@ -32,7 +34,7 @@ template <typename ParentPass, typename ContainedPass>
 class PassManager : public ParentPass {
 protected:
   /// The list of passes that this pass manager will run.
-  SmallVector<ContainedPass *> Passes;
+  SmallVector<std::unique_ptr<ContainedPass>> Passes;
 
   PassManager(StringRef Name) : ParentPass(Name) {}
   PassManager(const PassManager &) = delete;
@@ -42,16 +44,16 @@ protected:
 
 public:
   /// Adds \p Pass to the pass pipeline.
-  void addPass(ContainedPass *Pass) {
+  void addPass(std::unique_ptr<ContainedPass> Pass) {
     // TODO: Check that Pass's class type works with this PassManager type.
-    Passes.push_back(Pass);
+    Passes.push_back(std::move(Pass));
   }
 #ifndef NDEBUG
   void print(raw_ostream &OS) const override {
     OS << this->getName();
     OS << "(";
     // TODO: This should call Pass->print(OS) because Pass may be a PM.
-    interleave(Passes, OS, [&OS](auto *Pass) { OS << Pass->getName(); }, ",");
+    interleave(Passes, OS, [&OS](auto &Pass) { OS << Pass->getName(); }, ",");
     OS << ")";
   }
   LLVM_DUMP_METHOD void dump() const override {
@@ -78,38 +80,6 @@ class RegionPassManager final : public PassManager<RegionPass, RegionPass> {
 public:
   RegionPassManager(StringRef Name) : PassManager(Name) {}
   bool runOnRegion(Region &R) final;
-};
-
-/// Owns the passes and provides an API to get a pass by its name.
-class PassRegistry {
-  SmallVector<std::unique_ptr<Pass>, 8> Passes;
-  DenseMap<StringRef, Pass *> NameToPassMap;
-
-public:
-  static constexpr const char PassDelimToken = ',';
-  PassRegistry() = default;
-  /// Registers \p PassPtr and takes ownership.
-  Pass &registerPass(std::unique_ptr<Pass> &&PassPtr) {
-    auto &PassRef = *PassPtr.get();
-    NameToPassMap[PassRef.getName()] = &PassRef;
-    Passes.push_back(std::move(PassPtr));
-    return PassRef;
-  }
-  /// \Returns the pass with name \p Name, or null if not registered.
-  Pass *getPassByName(StringRef Name) const {
-    auto It = NameToPassMap.find(Name);
-    return It != NameToPassMap.end() ? It->second : nullptr;
-  }
-  /// Creates a pass pipeline and returns the first pass manager.
-  FunctionPassManager &parseAndCreatePassPipeline(StringRef Pipeline);
-
-#ifndef NDEBUG
-  void print(raw_ostream &OS) const {
-    for (const auto &PassPtr : Passes)
-      OS << PassPtr->getName() << "\n";
-  }
-  LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 } // namespace llvm::sandboxir

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -15,6 +15,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/SandboxIR/Constant.h"
 #include "llvm/SandboxIR/Pass.h"
+#include "llvm/SandboxIR/PassManager.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Legality.h"
 
 namespace llvm::sandboxir {
@@ -27,11 +28,16 @@ class BottomUpVec final : public FunctionPass {
   void vectorizeRec(ArrayRef<Value *> Bndl);
   void tryVectorize(ArrayRef<Value *> Seeds);
 
-  [[maybe_unused]] RegionPassManager *RPM;
+  // Used to build a RegionPass pipeline to be run on Regions created by the
+  // bottom-up vectorization pass.
+  PassRegistry PR;
+
+  // The PM containing the pipeline of region passes. It's owned by the pass
+  // registry.
+  RegionPassManager *RPM;
 
 public:
-  BottomUpVec(RegionPassManager *RPM)
-      : FunctionPass("bottom-up-vec"), RPM(RPM) {}
+  BottomUpVec();
   bool runOnFunction(Function &F) final;
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -28,10 +28,6 @@ class BottomUpVec final : public FunctionPass {
   void vectorizeRec(ArrayRef<Value *> Bndl);
   void tryVectorize(ArrayRef<Value *> Seeds);
 
-  // Used to build a RegionPass pipeline to be run on Regions created by the
-  // bottom-up vectorization pass. Owns the sub-passes.
-  PassRegistry PR;
-
   // The PM containing the pipeline of region passes.
   RegionPassManager RPM;
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -19,14 +19,19 @@
 
 namespace llvm::sandboxir {
 
+class RegionPassManager;
+
 class BottomUpVec final : public FunctionPass {
   bool Change = false;
   LegalityAnalysis Legality;
   void vectorizeRec(ArrayRef<Value *> Bndl);
   void tryVectorize(ArrayRef<Value *> Seeds);
 
+  [[maybe_unused]] RegionPassManager *RPM;
+
 public:
-  BottomUpVec() : FunctionPass("bottom-up-vec") {}
+  BottomUpVec(RegionPassManager *RPM)
+      : FunctionPass("bottom-up-vec"), RPM(RPM) {}
   bool runOnFunction(Function &F) final;
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -29,12 +29,11 @@ class BottomUpVec final : public FunctionPass {
   void tryVectorize(ArrayRef<Value *> Seeds);
 
   // Used to build a RegionPass pipeline to be run on Regions created by the
-  // bottom-up vectorization pass.
+  // bottom-up vectorization pass. Owns the sub-passes.
   PassRegistry PR;
 
-  // The PM containing the pipeline of region passes. It's owned by the pass
-  // registry.
-  RegionPassManager *RPM;
+  // The PM containing the pipeline of region passes.
+  RegionPassManager RPM;
 
 public:
   BottomUpVec();

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
@@ -1,0 +1,19 @@
+#ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_NULLPASS_H
+#define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_NULLPASS_H
+
+#include "llvm/SandboxIR/Pass.h"
+
+namespace llvm::sandboxir {
+
+class Region;
+
+/// A Region pass that does nothing, for use as a placeholder in tests.
+class NullPass final : public RegionPass {
+public:
+  NullPass() : RegionPass("null") {}
+  bool runOnRegion(Region &R) final { return false; }
+};
+
+} // namespace llvm::sandboxir
+
+#endif // LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_NULLPASS_H

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
@@ -26,6 +26,15 @@ class SandboxVectorizerPass : public PassInfoMixin<SandboxVectorizerPass> {
   bool runImpl(Function &F);
 
 public:
+  // Make sure the constructors/destructors are out-of-line. This works around a
+  // problem with -DBUILD_SHARED_LIBS=on where components that depend on the
+  // Vectorizer component can't find the vtable for classes like
+  // sandboxir::Pass. This way we don't have to make LLVMPasses add a direct
+  // dependency on SandboxIR.
+  SandboxVectorizerPass();
+  SandboxVectorizerPass(SandboxVectorizerPass &&);
+  ~SandboxVectorizerPass();
+
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
@@ -8,7 +8,11 @@
 #ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_SANDBOXVECTORIZER_H
 #define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_SANDBOXVECTORIZER_H
 
+#include <memory>
+
 #include "llvm/IR/PassManager.h"
+#include "llvm/SandboxIR/PassManager.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h"
 
 namespace llvm {
 
@@ -17,10 +21,21 @@ class TargetTransformInfo;
 class SandboxVectorizerPass : public PassInfoMixin<SandboxVectorizerPass> {
   TargetTransformInfo *TTI = nullptr;
 
-public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  // Used to build a RegionPass pipeline to be run on Regions created by the
+  // bottom-up vectorization pass.
+  sandboxir::PassRegistry PR;
+
+  // The main vectorizer pass.
+  std::unique_ptr<sandboxir::BottomUpVec> BottomUpVecPass;
+
+  // The PM containing the pipeline of region passes. It's owned by the pass
+  // registry.
+  sandboxir::RegionPassManager *RPM;
 
   bool runImpl(Function &F);
+public:
+  SandboxVectorizerPass();
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
@@ -11,7 +11,6 @@
 #include <memory>
 
 #include "llvm/IR/PassManager.h"
-#include "llvm/SandboxIR/PassManager.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h"
 
 namespace llvm {
@@ -21,21 +20,12 @@ class TargetTransformInfo;
 class SandboxVectorizerPass : public PassInfoMixin<SandboxVectorizerPass> {
   TargetTransformInfo *TTI = nullptr;
 
-  // Used to build a RegionPass pipeline to be run on Regions created by the
-  // bottom-up vectorization pass.
-  sandboxir::PassRegistry PR;
-
   // The main vectorizer pass.
-  std::unique_ptr<sandboxir::BottomUpVec> BottomUpVecPass;
-
-  // The PM containing the pipeline of region passes. It's owned by the pass
-  // registry.
-  sandboxir::RegionPassManager *RPM;
+  sandboxir::BottomUpVec BottomUpVecPass;
 
   bool runImpl(Function &F);
 
 public:
-  SandboxVectorizerPass();
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
@@ -33,6 +33,7 @@ class SandboxVectorizerPass : public PassInfoMixin<SandboxVectorizerPass> {
   sandboxir::RegionPassManager *RPM;
 
   bool runImpl(Function &F);
+
 public:
   SandboxVectorizerPass();
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);

--- a/llvm/lib/SandboxIR/PassManager.cpp
+++ b/llvm/lib/SandboxIR/PassManager.cpp
@@ -8,11 +8,11 @@
 
 #include "llvm/SandboxIR/PassManager.h"
 
-using namespace llvm::sandboxir;
+namespace llvm::sandboxir {
 
 bool FunctionPassManager::runOnFunction(Function &F) {
   bool Change = false;
-  for (FunctionPass *Pass : Passes) {
+  for (auto &Pass : Passes) {
     Change |= Pass->runOnFunction(F);
     // TODO: run the verifier.
   }
@@ -22,7 +22,7 @@ bool FunctionPassManager::runOnFunction(Function &F) {
 
 bool RegionPassManager::runOnRegion(Region &R) {
   bool Change = false;
-  for (RegionPass *Pass : Passes) {
+  for (auto &Pass : Passes) {
     Change |= Pass->runOnRegion(R);
     // TODO: run the verifier.
   }
@@ -30,40 +30,4 @@ bool RegionPassManager::runOnRegion(Region &R) {
   return Change;
 }
 
-FunctionPassManager &
-PassRegistry::parseAndCreatePassPipeline(StringRef Pipeline) {
-  static constexpr const char EndToken = '\0';
-  // Add EndToken to the end to ease parsing.
-  std::string PipelineStr = std::string(Pipeline) + EndToken;
-  int FlagBeginIdx = 0;
-  // Start with a FunctionPassManager.
-  auto &InitialPM = static_cast<FunctionPassManager &>(
-      registerPass(std::make_unique<FunctionPassManager>("init-fpm")));
-
-  for (auto [Idx, C] : enumerate(PipelineStr)) {
-    // Keep moving Idx until we find the end of the pass name.
-    bool FoundDelim = C == EndToken || C == PassDelimToken;
-    if (!FoundDelim)
-      continue;
-    unsigned Sz = Idx - FlagBeginIdx;
-    std::string PassName(&PipelineStr[FlagBeginIdx], Sz);
-    FlagBeginIdx = Idx + 1;
-
-    // Get the pass that corresponds to PassName and add it to the pass manager.
-    auto *Pass = getPassByName(PassName);
-    if (Pass == nullptr) {
-      errs() << "Pass '" << PassName << "' not registered!\n";
-      exit(1);
-    }
-    // TODO: This is safe for now, but would require proper upcasting once we
-    // add more Pass sub-classes.
-    InitialPM.addPass(static_cast<FunctionPass *>(Pass));
-  }
-  return InitialPM;
-}
-#ifndef NDEBUG
-void PassRegistry::dump() const {
-  print(dbgs());
-  dbgs() << "\n";
-}
-#endif // NDEBUG
+} // namespace llvm::sandboxir

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -59,6 +59,8 @@ bool BottomUpVec::runOnFunction(Function &F) {
     // TODO: Replace with proper SeedCollector function.
     auto Seeds = collectSeeds(BB);
     // TODO: Slice Seeds into smaller chunks.
+    // TODO: If vectorization succeeds, run the RegionPassManager on the
+    // resulting region.
     if (Seeds.size() >= 2)
       tryVectorize(Seeds);
   }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -27,22 +27,26 @@ static cl::opt<std::string> UserDefinedPassPipeline(
     cl::desc("Comma-separated list of vectorizer passes. If not set "
              "we run the predefined pipeline."));
 
-static void registerAllRegionPasses(sandboxir::PassRegistry &PR) {
-  PR.registerPass(std::make_unique<sandboxir::NullPass>());
+static std::unique_ptr<RegionPass> createRegionPass(StringRef Name) {
+#define REGION_PASS(NAME, CREATE_PASS)                                         \
+  if (Name == NAME)                                                            \
+    return std::make_unique<decltype(CREATE_PASS)>(CREATE_PASS);
+#include "PassRegistry.def"
+  return nullptr;
 }
 
-/// Adds to `RPM` a sequence of passes described by `Pipeline` from the `PR`
-/// pass registry.
-static void parseAndCreatePassPipeline(RegionPassManager &RPM, PassRegistry &PR,
+/// Adds to `RPM` a sequence of region passes described by `Pipeline`.
+static void parseAndCreatePassPipeline(RegionPassManager &RPM,
                                        StringRef Pipeline) {
   static constexpr const char EndToken = '\0';
+  static constexpr const char PassDelimToken = ',';
   // Add EndToken to the end to ease parsing.
   std::string PipelineStr = std::string(Pipeline) + EndToken;
   int FlagBeginIdx = 0;
 
   for (auto [Idx, C] : enumerate(PipelineStr)) {
     // Keep moving Idx until we find the end of the pass name.
-    bool FoundDelim = C == EndToken || C == PR.PassDelimToken;
+    bool FoundDelim = C == EndToken || C == PassDelimToken;
     if (!FoundDelim)
       continue;
     unsigned Sz = Idx - FlagBeginIdx;
@@ -50,26 +54,22 @@ static void parseAndCreatePassPipeline(RegionPassManager &RPM, PassRegistry &PR,
     FlagBeginIdx = Idx + 1;
 
     // Get the pass that corresponds to PassName and add it to the pass manager.
-    auto *Pass = PR.getPassByName(PassName);
-    if (Pass == nullptr) {
+    auto RegionPass = createRegionPass(PassName);
+    if (RegionPass == nullptr) {
       errs() << "Pass '" << PassName << "' not registered!\n";
       exit(1);
     }
-    // TODO: Add a type check here. The downcast is correct as long as
-    // registerAllRegionPasses only registers regions passes.
-    RPM.addPass(static_cast<sandboxir::RegionPass *>(Pass));
+    RPM.addPass(std::move(RegionPass));
   }
 }
 
 BottomUpVec::BottomUpVec() : FunctionPass("bottom-up-vec"), RPM("rpm") {
-  registerAllRegionPasses(PR);
-
   // Create a pipeline to be run on each Region created by BottomUpVec.
   if (UserDefinedPassPipeline == DefaultPipelineMagicStr) {
     // TODO: Add default passes to RPM.
   } else {
     // Create the user-defined pipeline.
-    parseAndCreatePassPipeline(RPM, PR, UserDefinedPassPipeline);
+    parseAndCreatePassPipeline(RPM, UserDefinedPassPipeline);
   }
 }
 

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
@@ -18,3 +18,5 @@
 #endif
 
 REGION_PASS("null", NullPass())
+
+#undef REGION_PASS

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
@@ -1,0 +1,20 @@
+//===- PassRegistry.def - Registry of passes --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is used as the registry of sub-passes that are part of the
+// SandboxVectorizer pass.
+//
+//===----------------------------------------------------------------------===//
+
+// NOTE: NO INCLUDE GUARD DESIRED!
+
+#ifndef REGION_PASS
+#define REGION_PASS(NAME, CREATE_PASS)
+#endif
+
+REGION_PASS("null", NullPass())

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
@@ -16,6 +16,13 @@ using namespace llvm;
 #define SV_NAME "sandbox-vectorizer"
 #define DEBUG_TYPE SV_NAME
 
+SandboxVectorizerPass::SandboxVectorizerPass() = default;
+
+SandboxVectorizerPass::SandboxVectorizerPass(SandboxVectorizerPass &&) =
+    default;
+
+SandboxVectorizerPass::~SandboxVectorizerPass() = default;
+
 PreservedAnalyses SandboxVectorizerPass::run(Function &F,
                                              FunctionAnalysisManager &AM) {
   TTI = &AM.getResult<TargetIRAnalysis>(F);

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
@@ -9,78 +9,12 @@
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/SandboxIR/Constant.h"
-#include "llvm/SandboxIR/PassManager.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h"
-#include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h"
 
 using namespace llvm;
 
 #define SV_NAME "sandbox-vectorizer"
 #define DEBUG_TYPE SV_NAME
-
-cl::opt<bool>
-    PrintPassPipeline("sbvec-print-pass-pipeline", cl::init(false), cl::Hidden,
-                      cl::desc("Prints the pass pipeline and returns."));
-
-/// A magic string for the default pass pipeline.
-const char *DefaultPipelineMagicStr = "*";
-
-cl::opt<std::string> UserDefinedPassPipeline(
-    "sbvec-passes", cl::init(DefaultPipelineMagicStr), cl::Hidden,
-    cl::desc("Comma-separated list of vectorizer passes. If not set "
-             "we run the predefined pipeline."));
-
-static void registerAllRegionPasses(sandboxir::PassRegistry &PR) {
-  PR.registerPass(std::make_unique<sandboxir::NullPass>());
-}
-
-static sandboxir::RegionPassManager &
-parseAndCreatePassPipeline(sandboxir::PassRegistry &PR, StringRef Pipeline) {
-  static constexpr const char EndToken = '\0';
-  // Add EndToken to the end to ease parsing.
-  std::string PipelineStr = std::string(Pipeline) + EndToken;
-  int FlagBeginIdx = 0;
-  auto &RPM = static_cast<sandboxir::RegionPassManager &>(
-      PR.registerPass(std::make_unique<sandboxir::RegionPassManager>("rpm")));
-
-  for (auto [Idx, C] : enumerate(PipelineStr)) {
-    // Keep moving Idx until we find the end of the pass name.
-    bool FoundDelim = C == EndToken || C == PR.PassDelimToken;
-    if (!FoundDelim)
-      continue;
-    unsigned Sz = Idx - FlagBeginIdx;
-    std::string PassName(&PipelineStr[FlagBeginIdx], Sz);
-    FlagBeginIdx = Idx + 1;
-
-    // Get the pass that corresponds to PassName and add it to the pass manager.
-    auto *Pass = PR.getPassByName(PassName);
-    if (Pass == nullptr) {
-      errs() << "Pass '" << PassName << "' not registered!\n";
-      exit(1);
-    }
-    // TODO: Add a type check here. The downcast is correct as long as
-    // registerAllRegionPasses only registers regions passes.
-    RPM.addPass(static_cast<sandboxir::RegionPass *>(Pass));
-  }
-  return RPM;
-}
-
-SandboxVectorizerPass::SandboxVectorizerPass() {
-  registerAllRegionPasses(PR);
-
-  // Create a pipeline to be run on each Region created by BottomUpVec.
-  if (UserDefinedPassPipeline == DefaultPipelineMagicStr) {
-    // Create the default pass pipeline.
-    RPM = &static_cast<sandboxir::RegionPassManager &>(PR.registerPass(
-        std::make_unique<sandboxir::FunctionPassManager>("rpm")));
-    // TODO: Add passes to the default pipeline.
-  } else {
-    // Create the user-defined pipeline.
-    RPM = &parseAndCreatePassPipeline(PR, UserDefinedPassPipeline);
-  }
-  BottomUpVecPass = std::make_unique<sandboxir::BottomUpVec>(RPM);
-}
 
 PreservedAnalyses SandboxVectorizerPass::run(Function &F,
                                              FunctionAnalysisManager &AM) {
@@ -108,13 +42,8 @@ bool SandboxVectorizerPass::runImpl(Function &LLVMF) {
     return false;
   }
 
-  if (PrintPassPipeline) {
-    RPM->printPipeline(outs());
-    return false;
-  }
-
   // Create SandboxIR for LLVMF and run BottomUpVec on it.
   sandboxir::Context Ctx(LLVMF.getContext());
   sandboxir::Function &F = *Ctx.createFunction(&LLVMF);
-  return BottomUpVecPass->runOnFunction(F);
+  return BottomUpVecPass.runOnFunction(F);
 }

--- a/llvm/test/Transforms/SandboxVectorizer/default_pass_pipeline.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/default_pass_pipeline.ll
@@ -4,8 +4,7 @@
 
 ; This checks the default pass pipeline for the sandbox vectorizer.
 define void @pipeline() {
-; CHECK: pm
-; CHECK: bottom-up-vec
+; CHECK: rpm
 ; CHECK-EMPTY:
   ret void
 }

--- a/llvm/test/Transforms/SandboxVectorizer/user_pass_pipeline.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/user_pass_pipeline.ll
@@ -1,12 +1,12 @@
-; RUN: opt -passes=sandbox-vectorizer -sbvec-print-pass-pipeline -sbvec-passes=bottom-up-vec,bottom-up-vec %s -disable-output | FileCheck %s
+; RUN: opt -passes=sandbox-vectorizer -sbvec-print-pass-pipeline -sbvec-passes=null,null %s -disable-output | FileCheck %s
 
 ; !!!WARNING!!! This won't get updated by update_test_checks.py !
 
 ; This checks the user defined pass pipeline.
 define void @pipeline() {
-; CHECK: pm
-; CHECK: bottom-up-vec
-; CHECK: bottom-up-vec
+; CHECK: rpm
+; CHECK: null
+; CHECK: null
 ; CHECK-EMPTY:
   ret void
 }

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1496,6 +1496,9 @@ cc_library(
         "include/llvm/Transforms/Vectorize/**/*.h",
     ]),
     copts = llvm_copts,
+    textual_hdrs = [
+        "lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def",
+    ],
     deps = [
         ":Analysis",
         ":Core",


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/111223 was reverted because of a build failure with `-DBUILD_SHARED_LIBS=on`.

The Passes component depends on Vectorizer (because PassBuilder needs to be able to instantiate SandboxVectorizerPass). This resulted in CMake doing this

1. when it builds lib/libLLVMVectorize.so.20.0git it adds lib/libLLVMSandboxIR.so.20.0git to the command line, because it's listed as a dependency (as expected)
2. when it's trying to build lib/libLLVMPasses.so.20.0git it adds lib/libLLVMVectorize.so.20.0git to the command line, because it's listed as a dependency (also as expected). But not libLLVMSandboxIR.so.

When SandboxVectorizerPass has its ctors/dtors defined inline, this caused "undefined reference to vtable" linker errors. This change works around that by moving ctors/dtors out of line.

Also fix a bazel build problem by adding the new `llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def` as a textual header in the Vectorizer target.