### PR TITLE
[mlir][spirv] Ignore extra comma for category_args in gen_spirv_dialect.py

### DIFF
--- a/mlir/utils/spirv/gen_spirv_dialect.py
+++ b/mlir/utils/spirv/gen_spirv_dialect.py
@@ -988,6 +988,7 @@ def extract_td_op_info(op_def):
     op_tmpl_params, _ = get_string_between_nested(op_def, "<", ">")
     opstringname, rest = get_string_between(op_tmpl_params, '"', '"')
     category_args = rest.split("[", 1)[0]
+    category_args = category_args.rsplit(",", 1)[0]
 
     # Get traits
     traits, _ = get_string_between_nested(rest, "[", "]")


### PR DESCRIPTION
In the code being parsed, the comma separates following traits from the category args.  If there's no category args, it is still present.