### PR TITLE
[mlir][spirv] Make gen_spirv_dialect.py more precise when finding inst_category

### DIFF
--- a/mlir/utils/spirv/gen_spirv_dialect.py
+++ b/mlir/utils/spirv/gen_spirv_dialect.py
@@ -979,7 +979,8 @@ def extract_td_op_info(op_def):
     # Get instruction category
     prefix = "SPIRV_"
     inst_category = [
-        o[len(prefix) :] for o in re.findall(prefix + r"\w+Op", op_def.split(":", 1)[1])
+        o[len(prefix) :]
+        for o in re.findall(prefix + r"\w+Op\b", op_def.split(":", 1)[1])
     ]
     assert len(inst_category) <= 1, "more than one ops in the same section!"
     inst_category = inst_category[0] if len(inst_category) == 1 else "Op"


### PR DESCRIPTION
Use a word boundary, current code was currently failing when parsing the definition of because it would also match
`CooperativeMatrixOp` from a later mention of
`SPIRV_KHR_CooperativeMatrixOperandsAttr`.