### PR TITLE
[ci] Don't add check-all target when pstl project is enabled

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -216,7 +216,7 @@ function check-targets() {
       echo "check-lldb"
     ;;
     pstl)
-      echo "check-all"
+      # Currently we do not run pstl tests in CI.
     ;;
     libclc)
       # Currently there is no testing for libclc.

--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -191,6 +191,9 @@ function keep-modified-projects() {
 }
 
 function check-targets() {
+  # Do not use "check-all" here because if there is "check-all" plus a
+  # project specific target like "check-clang", that project's tests
+  # will be run twice.
   projects=${@}
   for project in ${projects}; do
     case ${project} in


### PR DESCRIPTION
Fixes #110265

Adding check-all causes us to run some tests twice if a project specific target like check-clang is also added.

check-pstl is an alternative but as far as I can tell, check-all does not include this so we have not been running the tests in CI anyway.

When I tried to run check-pstl locally I got a lot of compiler errors but have not found any instructions on how to setup a correct build environment. Even if such instructions exist, it's probably more than we want to do in CI.

According to Louis Dionne, the project is probably not active. So if it's ever revived it'll be up to the new contributors to enable testing.