### PR TITLE
[lldb][test] elf-memory.test requires LLDB build with Python support

### DIFF
--- a/lldb/test/Shell/ObjectFile/ELF/elf-memory.test
+++ b/lldb/test/Shell/ObjectFile/ELF/elf-memory.test
@@ -1,4 +1,4 @@
-// REQUIRES: system-linux, native
+// REQUIRES: system-linux, native, python
 
 // This test verifies that loading an ELF file from memory works and the new
 // features that were added when loading from memory work like:


### PR DESCRIPTION
Otherwise it fails with "error: Embedded script interpreter unavailable. LLDB was built without scripting language support."