### PR TITLE
[lldb][test] Use $(STRIP) instead of strip in API tests (Darwin-only change)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -169,31 +169,31 @@ class Builder:
         if not os.getenv("LLVM_AR"):
             utils.extend(["LLVM_AR=%s" % getToolchainUtil("llvm-ar")])
 
-        if not lldbplatformutil.platformIsDarwin():
-            if cc_type in ["clang", "cc", "gcc"]:
-                util_paths = {}
-                # Assembly a toolchain side tool cmd based on passed CC.
-                for var, name in util_names.items():
-                    # Do not override explicity specified tool from the cmd line.
-                    if not os.getenv(var):
-                        util_paths[var] = getToolchainUtil("llvm-" + name)
-                    else:
-                        util_paths[var] = os.getenv(var)
-                utils.extend(["AR=%s" % util_paths["ARCHIVER"]])
+        if cc_type in ["clang", "cc", "gcc"]:
+            util_paths = {}
+            # Assembly a toolchain side tool cmd based on passed CC.
+            for var, name in util_names.items():
+                # Do not override explicity specified tool from the cmd line.
+                if not os.getenv(var):
+                    util_paths[var] = getToolchainUtil("llvm-" + name)
+                else:
+                    util_paths[var] = os.getenv(var)
+            utils.extend(["AR=%s" % util_paths["ARCHIVER"]])
 
-                # Look for llvm-dwp or gnu dwp
-                if not lldbutil.which(util_paths["DWP"]):
-                    util_paths["DWP"] = getToolchainUtil("llvm-dwp")
-                if not lldbutil.which(util_paths["DWP"]):
-                    util_paths["DWP"] = lldbutil.which("llvm-dwp")
+            # Look for llvm-dwp or gnu dwp
+            if not lldbutil.which(util_paths["DWP"]):
+                util_paths["DWP"] = getToolchainUtil("llvm-dwp")
+            if not lldbutil.which(util_paths["DWP"]):
+                util_paths["DWP"] = lldbutil.which("llvm-dwp")
+            if not util_paths["DWP"]:
+                util_paths["DWP"] = lldbutil.which("dwp")
                 if not util_paths["DWP"]:
-                    util_paths["DWP"] = lldbutil.which("dwp")
-                    if not util_paths["DWP"]:
-                        del util_paths["DWP"]
+                    del util_paths["DWP"]
 
-                for var, path in util_paths.items():
-                    utils.append("%s=%s" % (var, path))
-        else:
+            for var, path in util_paths.items():
+                utils.append("%s=%s" % (var, path))
+
+        if lldbplatformutil.platformIsDarwin():
             utils.extend(["AR=%slibtool" % os.getenv("CROSS_COMPILE", "")])
 
         return [

--- a/lldb/test/API/lang/objc/hidden-ivars/Makefile
+++ b/lldb/test/API/lang/objc/hidden-ivars/Makefile
@@ -14,8 +14,8 @@ endif
 
 stripped: a.out libInternalDefiner.dylib
 	mkdir stripped
-	strip -Sx a.out -o stripped/a.out
-	strip -Sx libInternalDefiner.dylib -o stripped/libInternalDefiner.dylib
+	$(STRIP) -Sx a.out -o stripped/a.out
+	$(STRIP) -Sx libInternalDefiner.dylib -o stripped/libInternalDefiner.dylib
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - stripped/a.out
 endif

--- a/lldb/test/API/lang/objc/objc-ivar-stripped/Makefile
+++ b/lldb/test/API/lang/objc/objc-ivar-stripped/Makefile
@@ -6,7 +6,7 @@ all:        a.out.stripped
 include Makefile.rules
 
 a.out.stripped: a.out.dSYM
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out.stripped
 endif

--- a/lldb/test/API/lang/objc/objc-static-method-stripped/Makefile
+++ b/lldb/test/API/lang/objc/objc-static-method-stripped/Makefile
@@ -4,7 +4,7 @@ LD_EXTRAS := -lobjc -framework Foundation
 default:        a.out.stripped
 
 a.out.stripped: a.out.dSYM
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 	ln -sf a.out.dSYM a.out.stripped.dSYM
 
 include Makefile.rules

--- a/lldb/test/API/macosx/add-dsym/Makefile
+++ b/lldb/test/API/macosx/add-dsym/Makefile
@@ -8,7 +8,7 @@ hide.app/Contents/a.out.dSYM:
 	mkdir hide.app
 	mkdir hide.app/Contents
 	mv a.out.dSYM hide.app/Contents
-	strip -x a.out
+	$(STRIP) -x a.out
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out
 endif

--- a/lldb/test/API/tools/lldb-dap/module/Makefile
+++ b/lldb/test/API/tools/lldb-dap/module/Makefile
@@ -10,7 +10,7 @@ include Makefile.rules
 all: a.out.stripped
 
 a.out.stripped:
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out.stripped

--- a/lldb/test/API/tools/lldb-dap/terminated-event/Makefile
+++ b/lldb/test/API/tools/lldb-dap/terminated-event/Makefile
@@ -10,7 +10,7 @@ include Makefile.rules
 all: a.out.stripped
 
 a.out.stripped:
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out.stripped


### PR DESCRIPTION
This makes tests more portable.
Make variables for LLVM utils are passed to `make` on Darwin as well.