### PR TITLE
[lldb][test] Use llvm-strip instead of strip on non-Darwin platforms for TestSymbolFileJSON

### DIFF
--- a/lldb/test/API/functionalities/json/symbol-file/Makefile
+++ b/lldb/test/API/functionalities/json/symbol-file/Makefile
@@ -3,6 +3,10 @@ C_SOURCES := main.c
 all: stripped.out
 
 stripped.out : a.out
+ifeq "$(OS)" "Darwin"
 	strip a.out -o stripped.out
+else
+	$(STRIP) a.out -o stripped.out
+endif
 
 include Makefile.rules


### PR DESCRIPTION
This is to fix buildbot failure https://lab.llvm.org/staging/#/builders/195/builds/4242.

The test doesn't pass with llvm-strip on macOS. Apparently, llvm-strip/llvm-objcopy can't clean symbols from Mach-O nlists.