### PR TITLE
[openmp] Use core_siblings_list if physical_package_id not available

### DIFF
--- a/openmp/runtime/test/affinity/kmp-hw-subset.c
+++ b/openmp/runtime/test/affinity/kmp-hw-subset.c
@@ -25,7 +25,7 @@ static int compare_hw_subset_places(const place_list_t *openmp_places,
     expected_per_place = nthreads_per_core;
   } else {
     expected_total = nsockets;
-    expected_per_place = ncores_per_socket;
+    expected_per_place = ncores_per_socket * nthreads_per_core;
   }
   if (openmp_places->num_places != expected_total) {
     fprintf(stderr, "error: KMP_HW_SUBSET did not half each resource layer!\n");


### PR DESCRIPTION
On powerpc, physical_package_id may not be available. Currently, this causes openmp to fall back to flat topology and various affinity tests fail.

Fix this by parsing core_siblings_list to deterimine which cpus belong to the same socket. This matches what the testing code does. The code to parse the CPU list format thankfully already exists.

Fixes https://github.com/llvm/llvm-project/issues/111809.