### PR TITLE
[Dexter] Remove outdated imp dependency

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -7,7 +7,6 @@
 """Interface for communicating with the LLDB debugger via its python interface.
 """
 
-import imp
 import os
 import shlex
 from subprocess import CalledProcessError, check_output, STDOUT
@@ -18,6 +17,7 @@ from dex.dextIR import FrameIR, LocIR, StepIR, StopReason, ValueIR
 from dex.dextIR import StackFrame, SourceLocation, ProgramState
 from dex.utils.Exceptions import DebuggerException, LoadDebuggerException
 from dex.utils.ReturnCode import ReturnCode
+from dex.utils.Imports import load_module
 
 
 class LLDB(DebuggerBase):
@@ -82,8 +82,7 @@ class LLDB(DebuggerBase):
             )
 
         try:
-            module_info = imp.find_module("lldb", [pythonpath])
-            return imp.load_module("lldb", *module_info)
+            return load_module("lldb", pythonpath)
         except ImportError as e:
             msg = str(e)
             if msg.endswith("not a valid Win32 application."):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -7,7 +7,6 @@
 """Interface for communicating with the Visual Studio debugger via DTE."""
 
 import abc
-import imp
 import os
 import sys
 from enum import IntEnum
@@ -19,15 +18,14 @@ from dex.debugger.DebuggerBase import DebuggerBase, watch_is_active
 from dex.dextIR import FrameIR, LocIR, StepIR, StopReason, ValueIR
 from dex.dextIR import StackFrame, SourceLocation, ProgramState
 from dex.utils.Exceptions import Error, LoadDebuggerException
+from dex.utils.Imports import load_module
 from dex.utils.ReturnCode import ReturnCode
-
 
 def _load_com_module():
     try:
-        module_info = imp.find_module(
-            "ComInterface", [os.path.join(os.path.dirname(__file__), "windows")]
+        return load_module(
+            "ComInterface", os.path.join(os.path.dirname(__file__), "windows")
         )
-        return imp.load_module("ComInterface", *module_info)
     except ImportError as e:
         raise LoadDebuggerException(e, sys.exc_info())
 

--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/Main.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/Main.py
@@ -10,7 +10,6 @@ parsing and running the unit-testing harnesses, before calling the reequested
 subtool.
 """
 
-import imp
 import os
 import sys
 
@@ -18,6 +17,7 @@ from dex.utils import PrettyOutput, Timer
 from dex.utils import ExtArgParse as argparse
 from dex.utils import get_root_directory
 from dex.utils.Exceptions import Error, ToolArgumentError
+from dex.utils.Imports import load_module
 from dex.utils.Logging import Logger
 from dex.utils.UnitTests import unit_tests_ok
 from dex.utils.Version import version
@@ -135,9 +135,7 @@ def _import_tool_module(tool_name):
     tool_name = tool_name.replace("-", "_")
 
     tools_directory = get_tools_directory()
-    module_info = imp.find_module(tool_name, [tools_directory])
-
-    return imp.load_module(tool_name, *module_info)
+    return load_module(tool_name, tools_directory)
 
 
 def tool_main(context, tool, args):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/help/Tool.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/help/Tool.py
@@ -6,10 +6,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Help tool."""
 
-import imp
 import textwrap
 
 from dex.tools import ToolBase, get_tool_names, get_tools_directory, tool_main
+from dex.utils.Imports import load_module
 from dex.utils.ReturnCode import ReturnCode
 
 
@@ -39,8 +39,7 @@ class Tool(ToolBase):
         tools_directory = get_tools_directory()
         for tool_name in sorted(self._visible_tool_names):
             internal_name = tool_name.replace("-", "_")
-            module_info = imp.find_module(internal_name, [tools_directory])
-            tool_doc = imp.load_module(internal_name, *module_info).Tool.__doc__
+            tool_doc = load_module(internal_name, tools_directory).Tool.__doc__
             tool_doc = tool_doc.strip() if tool_doc else ""
             tool_doc = textwrap.fill(" ".join(tool_doc.split()), 80)
             s += "<g>{}</>\n{}\n\n".format(tool_name, tool_doc)
@@ -53,6 +52,5 @@ class Tool(ToolBase):
 
         tool_name = self.context.options.tool.replace("-", "_")
         tools_directory = get_tools_directory()
-        module_info = imp.find_module(tool_name, [tools_directory])
-        module = imp.load_module(tool_name, *module_info)
+        module = load_module(tool_name, tools_directory)
         return tool_main(self.context, module.Tool(self.context), ["--help"])

--- a/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
@@ -1,0 +1,10 @@
+import importlib
+import sys
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, f"{path}/{name}/__init__.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
@@ -1,9 +1,12 @@
 import importlib
+import os
 import sys
 
 
 def load_module(name, path):
-    spec = importlib.util.spec_from_file_location(name, f"{path}/{name}/__init__.py")
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(path, name, "__init__.py")
+    )
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/111815

This patch replaces usage of the python `imp` library, which is deprecated since python3.4 and removed in python3.12, with the `importlib` library. As part of this update the repeated find_module+load_module pattern is moved into a utility function, since the importlib equivalent is much more verbose.