### PR TITLE
[cmake] Promote message when failing to find compiler-rt to warning

### DIFF
--- a/cmake/Modules/HandleCompilerRT.cmake
+++ b/cmake/Modules/HandleCompilerRT.cmake
@@ -5,7 +5,7 @@
 #    COMPILER_RT_LIBRARY-<name>-<target> to NOTFOUND
 function(cache_compiler_rt_library err_flag name target library_file)
   if(err_flag OR NOT EXISTS "${library_file}")
-    message(STATUS "Failed to find compiler-rt ${name} library for ${target}")
+    message(WARNING "Failed to find compiler-rt ${name} library for ${target}")
     set(COMPILER_RT_LIBRARY_${name}_${target} "NOTFOUND" CACHE INTERNAL
         "compiler-rt ${name} library for ${target}")
   else()


### PR DESCRIPTION
This makes the message stand out a bit more, which can be helpful to debug situations where compiler-rt is missing but shouldn't.