### PR TITLE
[NFC] Replace more DenseMaps with SmallDenseMaps

### DIFF
--- a/clang/include/clang/AST/CXXInheritance.h
+++ b/clang/include/clang/AST/CXXInheritance.h
@@ -268,7 +268,7 @@ struct UniqueVirtualMethod {
 /// subobject in which that virtual function occurs).
 class OverridingMethods {
   using ValuesT = SmallVector<UniqueVirtualMethod, 4>;
-  using MapType = llvm::MapVector<unsigned, ValuesT>;
+  using MapType = llvm::SmallMapVector<unsigned, ValuesT, 16>;
 
   MapType Overrides;
 

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -392,8 +392,8 @@ class CXXNameMangler {
   AbiTagState *AbiTags = nullptr;
   AbiTagState AbiTagsRoot;
 
-  llvm::DenseMap<uintptr_t, unsigned> Substitutions;
-  llvm::DenseMap<StringRef, unsigned> ModuleSubstitutions;
+  llvm::SmallDenseMap<uintptr_t, unsigned, 16> Substitutions;
+  llvm::SmallDenseMap<StringRef, unsigned, 16> ModuleSubstitutions;
 
   ASTContext &getASTContext() const { return Context.getASTContext(); }
 

--- a/llvm/include/llvm/ADT/SCCIterator.h
+++ b/llvm/include/llvm/ADT/SCCIterator.h
@@ -73,7 +73,7 @@ class scc_iterator : public iterator_facade_base<
   ///
   /// nodeVisitNumbers are per-node visit numbers, also used as DFS flags.
   unsigned visitNum;
-  DenseMap<NodeRef, unsigned> nodeVisitNumbers;
+  SmallDenseMap<NodeRef, unsigned, 16> nodeVisitNumbers;
 
   /// Stack holding nodes of the SCC.
   std::vector<NodeRef> SCCNodeStack;

--- a/llvm/include/llvm/Analysis/ConstraintSystem.h
+++ b/llvm/include/llvm/Analysis/ConstraintSystem.h
@@ -51,7 +51,7 @@ class ConstraintSystem {
 
   /// A map of variables (IR values) to their corresponding index in the
   /// constraint system.
-  DenseMap<Value *, unsigned> Value2Index;
+  SmallDenseMap<Value *, unsigned, 16> Value2Index;
 
   // Eliminate constraints from the system using Fourier–Motzkin elimination.
   bool eliminateUsingFM();
@@ -70,7 +70,7 @@ public:
       Value2Index.insert({Arg, Value2Index.size() + 1});
     }
   }
-  ConstraintSystem(const DenseMap<Value *, unsigned> &Value2Index)
+  ConstraintSystem(const SmallDenseMap<Value *, unsigned, 16> &Value2Index)
       : NumVariables(Value2Index.size()), Value2Index(Value2Index) {}
 
   bool addVariableRow(ArrayRef<int64_t> R) {
@@ -92,8 +92,8 @@ public:
     return true;
   }
 
-  DenseMap<Value *, unsigned> &getValue2Index() { return Value2Index; }
-  const DenseMap<Value *, unsigned> &getValue2Index() const {
+  SmallDenseMap<Value *, unsigned, 16> &getValue2Index() { return Value2Index; }
+  const SmallDenseMap<Value *, unsigned, 16> &getValue2Index() const {
     return Value2Index;
   }
 

--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -41,8 +41,8 @@ class DominanceFrontierBase {
 public:
   // Dom set for a bb. Use SetVector to make iterating dom frontiers of a bb
   // deterministic.
-  using DomSetType = SetVector<BlockT *>;
-  using DomSetMapType = DenseMap<BlockT *, DomSetType>; // Dom set map
+  using DomSetType = SmallSetVector<BlockT *, 16>;
+  using DomSetMapType = SmallDenseMap<BlockT *, DomSetType, 16>; // Dom set map
 
 protected:
   using BlockTraits = GraphTraits<BlockT *>;

--- a/llvm/include/llvm/Analysis/DominanceFrontierImpl.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontierImpl.h
@@ -55,7 +55,7 @@ void DominanceFrontierBase<BlockT, IsPostDom>::print(raw_ostream &OS) const {
       OS << " <<exit node>>";
     OS << " is:\t";
 
-    const SetVector<BlockT *> &BBs = I->second;
+    const SmallSetVector<BlockT *, 16> &BBs = I->second;
 
     for (const BlockT *BB : BBs) {
       OS << ' ';

--- a/llvm/include/llvm/Analysis/LoopIterator.h
+++ b/llvm/include/llvm/Analysis/LoopIterator.h
@@ -97,8 +97,8 @@ struct LoopBodyTraits {
 class LoopBlocksDFS {
 public:
   /// Postorder list iterators.
-  typedef std::vector<BasicBlock*>::const_iterator POIterator;
-  typedef std::vector<BasicBlock*>::const_reverse_iterator RPOIterator;
+  typedef SmallVector<BasicBlock*, 16>::const_iterator POIterator;
+  typedef SmallVector<BasicBlock*, 16>::const_reverse_iterator RPOIterator;
 
   friend class LoopBlocksTraversal;
 
@@ -108,8 +108,8 @@ private:
   /// Map each block to its postorder number. A block is only mapped after it is
   /// preorder visited by DFS. It's postorder number is initially zero and set
   /// to nonzero after it is finished by postorder traversal.
-  DenseMap<BasicBlock*, unsigned> PostNumbers;
-  std::vector<BasicBlock*> PostBlocks;
+  SmallDenseMap<BasicBlock*, unsigned, 16> PostNumbers;
+  SmallVector<BasicBlock*, 16> PostBlocks;
 
 public:
   LoopBlocksDFS(Loop *Container) :

--- a/llvm/include/llvm/Analysis/LoopIterator.h
+++ b/llvm/include/llvm/Analysis/LoopIterator.h
@@ -97,8 +97,8 @@ struct LoopBodyTraits {
 class LoopBlocksDFS {
 public:
   /// Postorder list iterators.
-  typedef SmallVector<BasicBlock *, 16>::const_iterator POIterator;
-  typedef SmallVector<BasicBlock *, 16>::const_reverse_iterator RPOIterator;
+  typedef SmallVector<BasicBlock*, 16>::const_iterator POIterator;
+  typedef SmallVector<BasicBlock*, 16>::const_reverse_iterator RPOIterator;
 
   friend class LoopBlocksTraversal;
 
@@ -108,8 +108,8 @@ private:
   /// Map each block to its postorder number. A block is only mapped after it is
   /// preorder visited by DFS. It's postorder number is initially zero and set
   /// to nonzero after it is finished by postorder traversal.
-  SmallDenseMap<BasicBlock *, unsigned, 16> PostNumbers;
-  SmallVector<BasicBlock *, 16> PostBlocks;
+  SmallDenseMap<BasicBlock*, unsigned, 16> PostNumbers;
+  SmallVector<BasicBlock*, 16> PostBlocks;
 
 public:
   LoopBlocksDFS(Loop *Container) :

--- a/llvm/include/llvm/Analysis/LoopIterator.h
+++ b/llvm/include/llvm/Analysis/LoopIterator.h
@@ -97,8 +97,8 @@ struct LoopBodyTraits {
 class LoopBlocksDFS {
 public:
   /// Postorder list iterators.
-  typedef SmallVector<BasicBlock*, 16>::const_iterator POIterator;
-  typedef SmallVector<BasicBlock*, 16>::const_reverse_iterator RPOIterator;
+  typedef SmallVector<BasicBlock *, 16>::const_iterator POIterator;
+  typedef SmallVector<BasicBlock *, 16>::const_reverse_iterator RPOIterator;
 
   friend class LoopBlocksTraversal;
 
@@ -108,8 +108,8 @@ private:
   /// Map each block to its postorder number. A block is only mapped after it is
   /// preorder visited by DFS. It's postorder number is initially zero and set
   /// to nonzero after it is finished by postorder traversal.
-  SmallDenseMap<BasicBlock*, unsigned, 16> PostNumbers;
-  SmallVector<BasicBlock*, 16> PostBlocks;
+  SmallDenseMap<BasicBlock *, unsigned, 16> PostNumbers;
+  SmallVector<BasicBlock *, 16> PostBlocks;
 
 public:
   LoopBlocksDFS(Loop *Container) :

--- a/llvm/include/llvm/Analysis/MemorySSA.h
+++ b/llvm/include/llvm/Analysis/MemorySSA.h
@@ -879,7 +879,7 @@ private:
   Loop *L = nullptr;
 
   // Memory SSA mappings
-  DenseMap<const Value *, MemoryAccess *> ValueToMemoryAccess;
+  SmallDenseMap<const Value *, MemoryAccess *, 16> ValueToMemoryAccess;
 
   // These two mappings contain the main block to access/def mappings for
   // MemorySSA. The list contained in PerBlockAccesses really owns all the
@@ -895,7 +895,7 @@ private:
   // Note that the numbering is local to a block, even though the map is
   // global.
   mutable SmallPtrSet<const BasicBlock *, 16> BlockNumberingValid;
-  mutable DenseMap<const MemoryAccess *, unsigned long> BlockNumbering;
+  mutable SmallDenseMap<const MemoryAccess *, unsigned long, 16> BlockNumbering;
 
   // Memory SSA building info
   std::unique_ptr<ClobberWalkerBase> WalkerBase;

--- a/llvm/include/llvm/Analysis/MustExecute.h
+++ b/llvm/include/llvm/Analysis/MustExecute.h
@@ -58,7 +58,7 @@ class raw_ostream;
 /// methods except for computeLoopSafetyInfo is undefined.
 class LoopSafetyInfo {
   // Used to update funclet bundle operands.
-  DenseMap<BasicBlock *, ColorVector> BlockColors;
+  BlockColorMapT BlockColors;
 
 protected:
   /// Computes block colors.
@@ -66,7 +66,7 @@ protected:
 
 public:
   /// Returns block colors map that is used to update funclet operand bundles.
-  const DenseMap<BasicBlock *, ColorVector> &getBlockColors() const;
+  const BlockColorMapT &getBlockColors() const;
 
   /// Copy colors of block \p Old into the block \p New.
   void copyColors(BasicBlock *New, BasicBlock *Old);

--- a/llvm/include/llvm/IR/EHPersonalities.h
+++ b/llvm/include/llvm/IR/EHPersonalities.h
@@ -107,12 +107,13 @@ inline bool isNoOpWithoutInvoke(EHPersonality Pers) {
 bool canSimplifyInvokeNoUnwind(const Function *F);
 
 typedef TinyPtrVector<BasicBlock *> ColorVector;
+typedef SmallDenseMap<BasicBlock *, ColorVector, 16> BlockColorMapT;
 
 /// If an EH funclet personality is in use (see isFuncletEHPersonality),
 /// this will recompute which blocks are in which funclet. It is possible that
 /// some blocks are in multiple funclets. Consider this analysis to be
 /// expensive.
-DenseMap<BasicBlock *, ColorVector> colorEHFunclets(Function &F);
+BlockColorMapT colorEHFunclets(Function &F);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/IR/PredIteratorCache.h
+++ b/llvm/include/llvm/IR/PredIteratorCache.h
@@ -26,7 +26,7 @@ namespace llvm {
 /// wants the predecessor list for the same blocks.
 class PredIteratorCache {
   /// Cached list of predecessors, allocated in Memory.
-  DenseMap<BasicBlock *, ArrayRef<BasicBlock *>> BlockToPredsMap;
+  SmallDenseMap<BasicBlock *, ArrayRef<BasicBlock *>, 16> BlockToPredsMap;
 
   /// Memory - This is the space that holds cached preds.
   BumpPtrAllocator Memory;

--- a/llvm/include/llvm/Transforms/Utils/Cloning.h
+++ b/llvm/include/llvm/Transforms/Utils/Cloning.h
@@ -81,7 +81,7 @@ struct ClonedCodeInfo {
   /// Like VMap, but maps only unsimplified instructions. Values in the map
   /// may be dangling, it is only intended to be used via isSimplified(), to
   /// check whether the main VMap mapping involves simplification or not.
-  DenseMap<const Value *, const Value *> OrigVMap;
+  SmallDenseMap<const Value *, const Value *, 16> OrigVMap;
 
   ClonedCodeInfo() = default;
 

--- a/llvm/include/llvm/Transforms/Utils/SSAUpdaterImpl.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdaterImpl.h
@@ -70,7 +70,7 @@ private:
       : BB(ThisBB), AvailableVal(V), DefBB(V ? this : nullptr) {}
   };
 
-  using AvailableValsTy = DenseMap<BlkT *, ValT>;
+  using AvailableValsTy = SmallDenseMap<BlkT *, ValT, 16>;
 
   AvailableValsTy *AvailableVals;
 

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -608,7 +608,7 @@ class InlineCostCallAnalyzer final : public CallAnalyzer {
   /// The mapping of caller Alloca values to their accumulated cost savings. If
   /// we have to disable SROA for one of the allocas, this tells us how much
   /// cost must be added.
-  DenseMap<AllocaInst *, int> SROAArgCosts;
+  SmallDenseMap<AllocaInst *, int, 16> SROAArgCosts;
 
   /// Return true if \p Call is a cold callsite.
   bool isColdCallSite(CallBase &Call, BlockFrequencyInfo *CallerBFI);

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -322,7 +322,7 @@ class LazyValueInfoImpl {
   SmallVector<std::pair<BasicBlock*, Value*>, 8> BlockValueStack;
 
   /// Keeps track of which block-value pairs are in BlockValueStack.
-  DenseSet<std::pair<BasicBlock*, Value*> > BlockValueSet;
+  SmallDenseSet<std::pair<BasicBlock*, Value*>, 16> BlockValueSet;
 
   /// Push BV onto BlockValueStack unless it's already in there.
   /// Returns true on success.

--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -28,7 +28,7 @@ using namespace llvm;
 
 #define DEBUG_TYPE "must-execute"
 
-const DenseMap<BasicBlock *, ColorVector> &
+const BlockColorMapT &
 LoopSafetyInfo::getBlockColors() const {
   return BlockColors;
 }

--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -28,7 +28,8 @@ using namespace llvm;
 
 #define DEBUG_TYPE "must-execute"
 
-const BlockColorMapT &LoopSafetyInfo::getBlockColors() const {
+const BlockColorMapT &
+LoopSafetyInfo::getBlockColors() const {
   return BlockColors;
 }
 

--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -28,8 +28,7 @@ using namespace llvm;
 
 #define DEBUG_TYPE "must-execute"
 
-const BlockColorMapT &
-LoopSafetyInfo::getBlockColors() const {
+const BlockColorMapT &LoopSafetyInfo::getBlockColors() const {
   return BlockColors;
 }
 

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -4151,7 +4151,7 @@ std::optional<ValueIDNum> InstrRefBasedLDV::resolveDbgPHIsImpl(
   // Adapted LLVM SSA Updater:
   LDVSSAUpdater Updater(Loc, MLiveIns);
   // Map of which Def or PHI is the current value in each block.
-  DenseMap<LDVSSABlock *, BlockValueNum> AvailableValues;
+  SmallDenseMap<LDVSSABlock *, BlockValueNum, 16> AvailableValues;
   // Set of PHIs that we have created along the way.
   SmallVector<LDVSSAPhi *, 8> CreatedPHIs;
 

--- a/llvm/lib/CodeGen/MachineSSAUpdater.cpp
+++ b/llvm/lib/CodeGen/MachineSSAUpdater.cpp
@@ -34,7 +34,7 @@ using namespace llvm;
 
 #define DEBUG_TYPE "machine-ssaupdater"
 
-using AvailableValsTy = DenseMap<MachineBasicBlock *, Register>;
+using AvailableValsTy = SmallDenseMap<MachineBasicBlock *, Register, 16>;
 
 static AvailableValsTy &getAvailableVals(void *AV) {
   return *static_cast<AvailableValsTy*>(AV);

--- a/llvm/lib/CodeGen/WinEHPrepare.cpp
+++ b/llvm/lib/CodeGen/WinEHPrepare.cpp
@@ -90,7 +90,7 @@ private:
   EHPersonality Personality = EHPersonality::Unknown;
 
   const DataLayout *DL = nullptr;
-  DenseMap<BasicBlock *, ColorVector> BlockColors;
+  BlockColorMapT BlockColors;
   MapVector<BasicBlock *, std::vector<BasicBlock *>> FuncletBlocks;
 };
 
@@ -189,7 +189,7 @@ static BasicBlock *getCleanupRetUnwindDest(const CleanupPadInst *CleanupPad) {
 static void calculateStateNumbersForInvokes(const Function *Fn,
                                             WinEHFuncInfo &FuncInfo) {
   auto *F = const_cast<Function *>(Fn);
-  DenseMap<BasicBlock *, ColorVector> BlockColors = colorEHFunclets(*F);
+  BlockColorMapT BlockColors = colorEHFunclets(*F);
   for (BasicBlock &BB : *F) {
     auto *II = dyn_cast<InvokeInst>(BB.getTerminator());
     if (!II)

--- a/llvm/lib/IR/EHPersonalities.cpp
+++ b/llvm/lib/IR/EHPersonalities.cpp
@@ -102,10 +102,10 @@ bool llvm::canSimplifyInvokeNoUnwind(const Function *F) {
   return !EHa && !isAsynchronousEHPersonality(Personality);
 }
 
-DenseMap<BasicBlock *, ColorVector> llvm::colorEHFunclets(Function &F) {
+BlockColorMapT llvm::colorEHFunclets(Function &F) {
   SmallVector<std::pair<BasicBlock *, BasicBlock *>, 16> Worklist;
   BasicBlock *EntryBlock = &F.getEntryBlock();
-  DenseMap<BasicBlock *, ColorVector> BlockColors;
+  BlockColorMapT BlockColors;
 
   // Build up the color map, which maps each block to its set of 'colors'.
   // For any block B the "colors" of B are the set of funclets F (possibly

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -363,7 +363,7 @@ class Verifier : public InstVisitor<Verifier>, VerifierSupport {
 
   /// Cache which blocks are in which funclet, if an EH funclet personality is
   /// in use. Otherwise empty.
-  DenseMap<BasicBlock *, ColorVector> BlockEHFuncletColors;
+  BlockColorMapT BlockEHFuncletColors;
 
   /// Cache of constants visited in search of ConstantExprs.
   SmallPtrSet<const Constant *, 32> ConstantExprVisited;

--- a/llvm/lib/Target/X86/X86WinEHState.cpp
+++ b/llvm/lib/Target/X86/X86WinEHState.cpp
@@ -70,9 +70,9 @@ private:
   bool isStateStoreNeeded(EHPersonality Personality, CallBase &Call);
   void rewriteSetJmpCall(IRBuilder<> &Builder, Function &F, CallBase &Call,
                          Value *State);
-  int getBaseStateForBB(DenseMap<BasicBlock *, ColorVector> &BlockColors,
+  int getBaseStateForBB(BlockColorMapT &BlockColors,
                         WinEHFuncInfo &FuncInfo, BasicBlock *BB);
-  int getStateForCall(DenseMap<BasicBlock *, ColorVector> &BlockColors,
+  int getStateForCall(BlockColorMapT &BlockColors,
                       WinEHFuncInfo &FuncInfo, CallBase &Call);
 
   // Module-level type getters.
@@ -501,7 +501,7 @@ void WinEHStatePass::rewriteSetJmpCall(IRBuilder<> &Builder, Function &F,
 
 // Figure out what state we should assign calls in this block.
 int WinEHStatePass::getBaseStateForBB(
-    DenseMap<BasicBlock *, ColorVector> &BlockColors, WinEHFuncInfo &FuncInfo,
+    BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
     BasicBlock *BB) {
   int BaseState = ParentBaseState;
   auto &BBColors = BlockColors[BB];
@@ -520,7 +520,7 @@ int WinEHStatePass::getBaseStateForBB(
 
 // Calculate the state a call-site is in.
 int WinEHStatePass::getStateForCall(
-    DenseMap<BasicBlock *, ColorVector> &BlockColors, WinEHFuncInfo &FuncInfo,
+    BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
     CallBase &Call) {
   if (auto *II = dyn_cast<InvokeInst>(&Call)) {
     // Look up the state number of the EH pad this unwinds to.
@@ -644,7 +644,7 @@ void WinEHStatePass::addStateStores(Function &F, WinEHFuncInfo &FuncInfo) {
     calculateWinCXXEHStateNumbers(&F, FuncInfo);
 
   // Iterate all the instructions and emit state number stores.
-  DenseMap<BasicBlock *, ColorVector> BlockColors = colorEHFunclets(F);
+  BlockColorMapT BlockColors = colorEHFunclets(F);
   ReversePostOrderTraversal<Function *> RPOT(&F);
 
   // InitialStates yields the state of the first call-site for a BasicBlock.

--- a/llvm/lib/Target/X86/X86WinEHState.cpp
+++ b/llvm/lib/Target/X86/X86WinEHState.cpp
@@ -70,10 +70,10 @@ private:
   bool isStateStoreNeeded(EHPersonality Personality, CallBase &Call);
   void rewriteSetJmpCall(IRBuilder<> &Builder, Function &F, CallBase &Call,
                          Value *State);
-  int getBaseStateForBB(BlockColorMapT &BlockColors,
-                        WinEHFuncInfo &FuncInfo, BasicBlock *BB);
-  int getStateForCall(BlockColorMapT &BlockColors,
-                      WinEHFuncInfo &FuncInfo, CallBase &Call);
+  int getBaseStateForBB(BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
+                        BasicBlock *BB);
+  int getStateForCall(BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
+                      CallBase &Call);
 
   // Module-level type getters.
   Type *getEHLinkRegistrationType();
@@ -500,9 +500,8 @@ void WinEHStatePass::rewriteSetJmpCall(IRBuilder<> &Builder, Function &F,
 }
 
 // Figure out what state we should assign calls in this block.
-int WinEHStatePass::getBaseStateForBB(
-    BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
-    BasicBlock *BB) {
+int WinEHStatePass::getBaseStateForBB(BlockColorMapT &BlockColors,
+                                      WinEHFuncInfo &FuncInfo, BasicBlock *BB) {
   int BaseState = ParentBaseState;
   auto &BBColors = BlockColors[BB];
 
@@ -519,9 +518,8 @@ int WinEHStatePass::getBaseStateForBB(
 }
 
 // Calculate the state a call-site is in.
-int WinEHStatePass::getStateForCall(
-    BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
-    CallBase &Call) {
+int WinEHStatePass::getStateForCall(BlockColorMapT &BlockColors,
+                                    WinEHFuncInfo &FuncInfo, CallBase &Call) {
   if (auto *II = dyn_cast<InvokeInst>(&Call)) {
     // Look up the state number of the EH pad this unwinds to.
     assert(FuncInfo.InvokeStateMap.count(II) && "invoke has no state!");

--- a/llvm/lib/Target/X86/X86WinEHState.cpp
+++ b/llvm/lib/Target/X86/X86WinEHState.cpp
@@ -70,10 +70,10 @@ private:
   bool isStateStoreNeeded(EHPersonality Personality, CallBase &Call);
   void rewriteSetJmpCall(IRBuilder<> &Builder, Function &F, CallBase &Call,
                          Value *State);
-  int getBaseStateForBB(BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
-                        BasicBlock *BB);
-  int getStateForCall(BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
-                      CallBase &Call);
+  int getBaseStateForBB(BlockColorMapT &BlockColors,
+                        WinEHFuncInfo &FuncInfo, BasicBlock *BB);
+  int getStateForCall(BlockColorMapT &BlockColors,
+                      WinEHFuncInfo &FuncInfo, CallBase &Call);
 
   // Module-level type getters.
   Type *getEHLinkRegistrationType();
@@ -500,8 +500,9 @@ void WinEHStatePass::rewriteSetJmpCall(IRBuilder<> &Builder, Function &F,
 }
 
 // Figure out what state we should assign calls in this block.
-int WinEHStatePass::getBaseStateForBB(BlockColorMapT &BlockColors,
-                                      WinEHFuncInfo &FuncInfo, BasicBlock *BB) {
+int WinEHStatePass::getBaseStateForBB(
+    BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
+    BasicBlock *BB) {
   int BaseState = ParentBaseState;
   auto &BBColors = BlockColors[BB];
 
@@ -518,8 +519,9 @@ int WinEHStatePass::getBaseStateForBB(BlockColorMapT &BlockColors,
 }
 
 // Calculate the state a call-site is in.
-int WinEHStatePass::getStateForCall(BlockColorMapT &BlockColors,
-                                    WinEHFuncInfo &FuncInfo, CallBase &Call) {
+int WinEHStatePass::getStateForCall(
+    BlockColorMapT &BlockColors, WinEHFuncInfo &FuncInfo,
+    CallBase &Call) {
   if (auto *II = dyn_cast<InvokeInst>(&Call)) {
     // Look up the state number of the EH pad this unwinds to.
     assert(FuncInfo.InvokeStateMap.count(II) && "invoke has no state!");

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5307,7 +5307,7 @@ bool InstCombinerImpl::prepareWorklist(Function &F) {
   bool MadeIRChange = false;
   SmallPtrSet<BasicBlock *, 32> LiveBlocks;
   SmallVector<Instruction *, 128> InstrsForInstructionWorklist;
-  DenseMap<Constant *, Constant *> FoldedConstants;
+  SmallDenseMap<Constant *, Constant *, 16> FoldedConstants;
   AliasScopeTracker SeenAliasScopes;
 
   auto HandleOnlyLiveSuccessor = [&](BasicBlock *BB, BasicBlock *LiveSucc) {

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -669,7 +669,7 @@ public:
       return;
     assert(TrackInsertedCalls && "Calls were wrongly tracked");
 
-    DenseMap<BasicBlock *, ColorVector> BlockColors = colorEHFunclets(*OwnerFn);
+    BlockColorMapT BlockColors = colorEHFunclets(*OwnerFn);
     for (CallInst *CI : InsertedCalls) {
       BasicBlock *BB = CI->getParent();
       assert(BB && "Instruction doesn't belong to a BasicBlock");

--- a/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
@@ -864,7 +864,7 @@ BasicBlock *FuncPGOInstrumentation<Edge, BBInfo>::getInstrBB(Edge *E) {
 // value profiling call for the value profile candidate call.
 static void
 populateEHOperandBundle(VPCandidateInfo &Cand,
-                        DenseMap<BasicBlock *, ColorVector> &BlockColors,
+                        BlockColorMapT &BlockColors,
                         SmallVectorImpl<OperandBundleDef> &OpBundles) {
   auto *OrigCall = dyn_cast<CallBase>(Cand.AnnotatedInst);
   if (!OrigCall)
@@ -1006,7 +1006,7 @@ void FunctionInstrumenter::instrument() {
   // Windows exception handling attached to them. However, if value profiling is
   // inserted for one of these calls, then a funclet value will need to be set
   // on the instrumentation call based on the funclet coloring.
-  DenseMap<BasicBlock *, ColorVector> BlockColors;
+  BlockColorMapT BlockColors;
   if (F.hasPersonalityFn() &&
       isScopedEHPersonality(classifyEHPersonality(F.getPersonalityFn())))
     BlockColors = colorEHFunclets(F);

--- a/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
@@ -863,7 +863,8 @@ BasicBlock *FuncPGOInstrumentation<Edge, BBInfo>::getInstrBB(Edge *E) {
 // funclet information, if any is needed, that should be placed on the generated
 // value profiling call for the value profile candidate call.
 static void
-populateEHOperandBundle(VPCandidateInfo &Cand, BlockColorMapT &BlockColors,
+populateEHOperandBundle(VPCandidateInfo &Cand,
+                        BlockColorMapT &BlockColors,
                         SmallVectorImpl<OperandBundleDef> &OpBundles) {
   auto *OrigCall = dyn_cast<CallBase>(Cand.AnnotatedInst);
   if (!OrigCall)

--- a/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
@@ -863,8 +863,7 @@ BasicBlock *FuncPGOInstrumentation<Edge, BBInfo>::getInstrBB(Edge *E) {
 // funclet information, if any is needed, that should be placed on the generated
 // value profiling call for the value profile candidate call.
 static void
-populateEHOperandBundle(VPCandidateInfo &Cand,
-                        BlockColorMapT &BlockColors,
+populateEHOperandBundle(VPCandidateInfo &Cand, BlockColorMapT &BlockColors,
                         SmallVectorImpl<OperandBundleDef> &OpBundles) {
   auto *OrigCall = dyn_cast<CallBase>(Cand.AnnotatedInst);
   if (!OrigCall)

--- a/llvm/lib/Transforms/ObjCARC/ObjCARC.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARC.cpp
@@ -24,7 +24,7 @@ using namespace llvm::objcarc;
 CallInst *objcarc::createCallInstWithColors(
     FunctionCallee Func, ArrayRef<Value *> Args, const Twine &NameStr,
     BasicBlock::iterator InsertBefore,
-    const DenseMap<BasicBlock *, ColorVector> &BlockColors) {
+    const BlockColorMapT &BlockColors) {
   FunctionType *FTy = Func.getFunctionType();
   Value *Callee = Func.getCallee();
   SmallVector<OperandBundleDef, 1> OpBundles;
@@ -73,13 +73,13 @@ BundledRetainClaimRVs::insertAfterInvokes(Function &F, DominatorTree *DT) {
 
 CallInst *BundledRetainClaimRVs::insertRVCall(BasicBlock::iterator InsertPt,
                                               CallBase *AnnotatedCall) {
-  DenseMap<BasicBlock *, ColorVector> BlockColors;
+  BlockColorMapT BlockColors;
   return insertRVCallWithColors(InsertPt, AnnotatedCall, BlockColors);
 }
 
 CallInst *BundledRetainClaimRVs::insertRVCallWithColors(
     BasicBlock::iterator InsertPt, CallBase *AnnotatedCall,
-    const DenseMap<BasicBlock *, ColorVector> &BlockColors) {
+    const BlockColorMapT &BlockColors) {
   IRBuilder<> Builder(InsertPt->getParent(), InsertPt);
   Function *Func = *objcarc::getAttachedARCFunction(AnnotatedCall);
   assert(Func && "operand isn't a Function");

--- a/llvm/lib/Transforms/ObjCARC/ObjCARC.h
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARC.h
@@ -100,7 +100,7 @@ static inline MDString *getRVInstMarker(Module &M) {
 CallInst *createCallInstWithColors(
     FunctionCallee Func, ArrayRef<Value *> Args, const Twine &NameStr,
     BasicBlock::iterator InsertBefore,
-    const DenseMap<BasicBlock *, ColorVector> &BlockColors);
+    const BlockColorMapT &BlockColors);
 
 class BundledRetainClaimRVs {
 public:
@@ -119,7 +119,7 @@ public:
   /// Insert a retainRV/claimRV call with colors.
   CallInst *insertRVCallWithColors(
       BasicBlock::iterator InsertPt, CallBase *AnnotatedCall,
-      const DenseMap<BasicBlock *, ColorVector> &BlockColors);
+      const BlockColorMapT &BlockColors);
 
   /// See if an instruction is a bundled retainRV/claimRV call.
   bool contains(const Instruction *I) const {

--- a/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
@@ -414,8 +414,7 @@ void ObjCARCContract::tryToContractReleaseIntoStoreStrong(
 
 bool ObjCARCContract::tryToPeepholeInstruction(
     Function &F, Instruction *Inst, inst_iterator &Iter,
-    bool &TailOkForStoreStrongs,
-    const BlockColorMapT &BlockColors) {
+    bool &TailOkForStoreStrongs, const BlockColorMapT &BlockColors) {
   // Only these library routines return their argument. In particular,
   // objc_retainBlock does not necessarily return its argument.
   ARCInstKind Class = GetBasicARCInstKind(Inst);

--- a/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
@@ -414,7 +414,8 @@ void ObjCARCContract::tryToContractReleaseIntoStoreStrong(
 
 bool ObjCARCContract::tryToPeepholeInstruction(
     Function &F, Instruction *Inst, inst_iterator &Iter,
-    bool &TailOkForStoreStrongs, const BlockColorMapT &BlockColors) {
+    bool &TailOkForStoreStrongs,
+    const BlockColorMapT &BlockColors) {
   // Only these library routines return their argument. In particular,
   // objc_retainBlock does not necessarily return its argument.
   ARCInstKind Class = GetBasicARCInstKind(Inst);

--- a/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
@@ -501,7 +501,7 @@ class ObjCARCOpt {
   /// is in fact used in the current function.
   unsigned UsedInThisFunction;
 
-  DenseMap<BasicBlock *, ColorVector> BlockEHColors;
+  BlockColorMapT BlockEHColors;
 
   bool OptimizeRetainRVCall(Function &F, Instruction *RetainRV);
   void OptimizeAutoreleaseRVCall(Function &F, Instruction *AutoreleaseRV,

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -285,10 +285,10 @@ public:
     }
   }
 
-  DenseMap<Value *, unsigned> &getValue2Index(bool Signed) {
+  SmallDenseMap<Value *, unsigned, 16> &getValue2Index(bool Signed) {
     return Signed ? SignedCS.getValue2Index() : UnsignedCS.getValue2Index();
   }
-  const DenseMap<Value *, unsigned> &getValue2Index(bool Signed) const {
+  const SmallDenseMap<Value *, unsigned, 16> &getValue2Index(bool Signed) const {
     return Signed ? SignedCS.getValue2Index() : UnsignedCS.getValue2Index();
   }
 
@@ -893,7 +893,7 @@ void ConstraintInfo::transferToOtherSystem(
 #ifndef NDEBUG
 
 static void dumpConstraint(ArrayRef<int64_t> C,
-                           const DenseMap<Value *, unsigned> &Value2Index) {
+                           const SmallDenseMap<Value *, unsigned, 16> &Value2Index) {
   ConstraintSystem CS(Value2Index);
   CS.addVariableRowFill(C);
   CS.dump();

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -288,8 +288,7 @@ public:
   SmallDenseMap<Value *, unsigned, 16> &getValue2Index(bool Signed) {
     return Signed ? SignedCS.getValue2Index() : UnsignedCS.getValue2Index();
   }
-  const SmallDenseMap<Value *, unsigned, 16> &
-  getValue2Index(bool Signed) const {
+  const SmallDenseMap<Value *, unsigned, 16> &getValue2Index(bool Signed) const {
     return Signed ? SignedCS.getValue2Index() : UnsignedCS.getValue2Index();
   }
 

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -288,7 +288,8 @@ public:
   SmallDenseMap<Value *, unsigned, 16> &getValue2Index(bool Signed) {
     return Signed ? SignedCS.getValue2Index() : UnsignedCS.getValue2Index();
   }
-  const SmallDenseMap<Value *, unsigned, 16> &getValue2Index(bool Signed) const {
+  const SmallDenseMap<Value *, unsigned, 16> &
+  getValue2Index(bool Signed) const {
     return Signed ? SignedCS.getValue2Index() : UnsignedCS.getValue2Index();
   }
 

--- a/llvm/lib/Transforms/Scalar/Reassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/Reassociate.cpp
@@ -417,7 +417,7 @@ static bool LinearizeExprTree(Instruction *I,
 
   // Leaves - Keeps track of the set of putative leaves as well as the number of
   // paths to each leaf seen so far.
-  using LeafMap = DenseMap<Value *, uint64_t>;
+  using LeafMap = SmallDenseMap<Value *, uint64_t, 16>;
   LeafMap Leaves; // Leaf -> Total weight so far.
   SmallVector<Value *, 8> LeafOrder; // Ensure deterministic leaf output order.
   const DataLayout DL = I->getDataLayout();

--- a/llvm/lib/Transforms/Utils/SSAUpdater.cpp
+++ b/llvm/lib/Transforms/Utils/SSAUpdater.cpp
@@ -37,7 +37,7 @@ using namespace llvm;
 
 #define DEBUG_TYPE "ssaupdater"
 
-using AvailableValsTy = DenseMap<BasicBlock *, Value *>;
+using AvailableValsTy = SmallDenseMap<BasicBlock *, Value *, 16>;
 
 static AvailableValsTy &getAvailableVals(void *AV) {
   return *static_cast<AvailableValsTy*>(AV);


### PR DESCRIPTION
These DenseMaps all appear as some of the most frequent sources of memory-allocations that could otherwise be accomodated with an initial stack allocation. For simplicity, I've typedef'd one map-type to be BlockColorMapT, used by various block colouring functions.

This also features one opportunistic replacement of std::vector with SmallVector, as it's in a path that obviously always allocates.

Compared to the other patches reducing DenseMap allocations the benefits from this one are quite small -- I've reached the point of diminishing returns: https://llvm-compile-time-tracker.com/compare.php?from=c7fbcae72557cbe14bca615038254649c1177401&to=0785a8d0fd31541d6a8af616111312780e268611&stat=instructions:u