### PR TITLE
[lldb][test] Use `xcrun -f strip` for API tests on Darwin

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -10,6 +10,7 @@ import lldbsuite.test.lldbplatformutil as lldbplatformutil
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test import configuration
 from lldbsuite.test_event import build_exception
+from lldbsuite.support import seven
 
 
 class Builder:
@@ -189,6 +190,9 @@ class Builder:
                 util_paths["DWP"] = lldbutil.which("dwp")
                 if not util_paths["DWP"]:
                     del util_paths["DWP"]
+
+            if lldbplatformutil.platformIsDarwin():
+                util_paths["STRIP"] = seven.get_command_output("xcrun -f strip")
 
             for var, path in util_paths.items():
                 utils.append("%s=%s" % (var, path))

--- a/lldb/test/API/functionalities/json/symbol-file/Makefile
+++ b/lldb/test/API/functionalities/json/symbol-file/Makefile
@@ -3,6 +3,6 @@ C_SOURCES := main.c
 all: stripped.out
 
 stripped.out : a.out
-	strip a.out -o stripped.out
+	$(STRIP) a.out -o stripped.out
 
 include Makefile.rules


### PR DESCRIPTION
A follow-up for https://github.com/llvm/llvm-project/pull/111816.

This is to fix buildbot failure https://lab.llvm.org/staging/#/builders/195/builds/4242.

TestSymbolFileJSON.py doesn't pass with llvm-strip on macOS. Apparently, llvm-strip/llvm-objcopy can't clean symbols from Mach-O nlists.