### PR TITLE
[analyzer] Disable graph-trim-interval by default

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
+++ b/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
@@ -393,9 +393,11 @@ ANALYZER_OPTION(
 
 ANALYZER_OPTION(
     unsigned, GraphTrimInterval, "graph-trim-interval",
-    "How often nodes in the ExplodedGraph should be recycled to save memory. "
-    "To disable node reclamation, set the option to 0.",
-    1000)
+    "[DEPRECATED] When set to a number N > 0, this enables reclamation of "
+    "'unimportant' nodes in the ExplodedGraph once per N node creation steps. "
+    "This reduces the memory usage, but can cause use-after-free errors or "
+    "crashes, so will be phased out.",
+    0)
 
 ANALYZER_OPTION(
     unsigned, MinCFGSizeTreatFunctionsAsLarge,

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -84,7 +84,7 @@
 // CHECK-NEXT: experimental-enable-naive-ctu-analysis = false
 // CHECK-NEXT: exploration_strategy = unexplored_first_queue
 // CHECK-NEXT: faux-bodies = true
-// CHECK-NEXT: graph-trim-interval = 1000
+// CHECK-NEXT: graph-trim-interval = 0
 // CHECK-NEXT: ignore-bison-generated-files = true
 // CHECK-NEXT: ignore-flex-generated-files = true
 // CHECK-NEXT: inline-lambdas = true


### PR DESCRIPTION
Because this hack is responsible for use-after-free errors that can trigger assertion failures, as reported e.g. in the github issue https://github.com/llvm/llvm-project/issues/105512

Disabling this performance optimization can cause severe slowdowns (up to +200% runtime) on a few specific translation units, but its effects are barely significant when they are averaged over a whole project: even on projects that are "severely affected" the slowdowns are <20 seconds.

If someone happens to be heavily affected by this performance loss (and doesn't fear the crashes) they can re-enable ExplodedNode reclamation by passing -analyzer-option graph-trim-interval=1000 (the old default) to the analyzer.

This commit is a temporary workaround to eliminate the crashes ASAP; in addition to this, we're also working to develop a long-term solution that can hopefully remove 'graph-trim-interval' altogether and replace it with different solutions that guarantee a good runtime without breaking the invariants of the ExplodedGraph. (It would be much easier to reason about the execution paths if we didn't have to think about the case that some nodes can just disappear.)