### PR TITLE
[clang][analyzer] PointerSubChecker should not warn on pointers converted to numerical type

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/PointerSubChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerSubChecker.cpp
@@ -61,6 +61,10 @@ void PointerSubChecker::checkPreStmt(const BinaryOperator *B,
   if (LR->getSymbolicBase() || RR->getSymbolicBase())
     return;
 
+  if (!B->getLHS()->getType()->isPointerType() ||
+      !B->getRHS()->getType()->isPointerType())
+    return;
+
   const auto *ElemLR = dyn_cast<ElementRegion>(LR);
   const auto *ElemRR = dyn_cast<ElementRegion>(RR);
 

--- a/clang/test/Analysis/pointer-sub.c
+++ b/clang/test/Analysis/pointer-sub.c
@@ -1,5 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=security.PointerSub -analyzer-output=text-minimal -verify %s
 
+typedef int * Ptr;
+
 void f1(void) {
   int x, y, z[10];
   int d = &y - &x; // expected-warning{{Subtraction of two pointers that do not point into the same array is undefined behavior}}
@@ -13,6 +15,9 @@ void f1(void) {
   d = (unsigned long)&y - (unsigned long)&x; // no-warning
   unsigned long l = 1;
   d = l - (unsigned long)&y; // no-warning
+  Ptr p1 = &x;
+  Ptr p2 = &y;
+  d = p1 - p2; // expected-warning{{Subtraction of two pointers that do not point into the same array is undefined behavior}}
 }
 
 void f2(void) {

--- a/clang/test/Analysis/pointer-sub.c
+++ b/clang/test/Analysis/pointer-sub.c
@@ -12,9 +12,9 @@ void f1(void) {
   d = &x - (&x + 1); // no-warning
   d = (&x + 0) - &x; // no-warning
   d = (z + 10) - z; // no-warning
-  d = (unsigned long)&y - (unsigned long)&x; // no-warning
-  unsigned long l = 1;
-  d = l - (unsigned long)&y; // no-warning
+  d = (long long)&y - (long long)&x; // no-warning
+  long long l = 1;
+  d = l - (long long)&y; // no-warning
   Ptr p1 = &x;
   Ptr p2 = &y;
   d = p1 - p2; // expected-warning{{Subtraction of two pointers that do not point into the same array is undefined behavior}}
@@ -37,8 +37,8 @@ void f2(void) {
   d = (int *)((char *)(&a[4]) + sizeof(int)) - &a[4]; // no-warning (pointers into the same array data)
   d = (int *)((char *)(&a[4]) + 1) - &a[4]; // expected-warning{{Subtraction of two pointers that}}
 
-  long a1 = (long)&a[1];
-  long b1 = (long)&b[1];
+  long long a1 = (long long)&a[1];
+  long long b1 = (long long)&b[1];
   d = a1 - b1;
 }
 

--- a/clang/test/Analysis/pointer-sub.c
+++ b/clang/test/Analysis/pointer-sub.c
@@ -10,6 +10,9 @@ void f1(void) {
   d = &x - (&x + 1); // no-warning
   d = (&x + 0) - &x; // no-warning
   d = (z + 10) - z; // no-warning
+  d = (unsigned long)&y - (unsigned long)&x; // no-warning
+  unsigned long l = 1;
+  d = l - (unsigned long)&y; // no-warning
 }
 
 void f2(void) {
@@ -28,6 +31,10 @@ void f2(void) {
 
   d = (int *)((char *)(&a[4]) + sizeof(int)) - &a[4]; // no-warning (pointers into the same array data)
   d = (int *)((char *)(&a[4]) + 1) - &a[4]; // expected-warning{{Subtraction of two pointers that}}
+
+  long a1 = (long)&a[1];
+  long b1 = (long)&b[1];
+  d = a1 - b1;
 }
 
 void f3(void) {


### PR DESCRIPTION
Pointer values casted to integer (non-pointer) type should be able to be subtracted as usual.