### PR TITLE
[Dexter] Set up ComInterface module to be imported correctly

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -24,7 +24,9 @@ from dex.utils.ReturnCode import ReturnCode
 def _load_com_module():
     try:
         return load_module(
-            "ComInterface", os.path.join(os.path.dirname(__file__), "windows")
+            "ComInterface",
+            os.path.join(os.path.dirname(__file__), "windows"),
+            "ComInterface.py",
         )
     except ImportError as e:
         raise LoadDebuggerException(e, sys.exc_info())

--- a/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
@@ -3,10 +3,15 @@ import os
 import sys
 
 
-def load_module(name, path):
-    spec = importlib.util.spec_from_file_location(
-        name, os.path.join(path, name, "__init__.py")
+def load_module(name, path, mod_file="__init__.py"):
+    # The module is either defined by a directory, in which case we search for
+    # `path/name/__init__.py`, or it is a single file at `path/mod_file`.
+    mod_path = (
+        os.path.join(path, name, mod_file)
+        if mod_file == "__init__.py"
+        else os.path.join(path, mod_file)
     )
+    spec = importlib.util.spec_from_file_location(name, mod_path)
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)

--- a/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/utils/Imports.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import os
 import sys
 


### PR DESCRIPTION
Fixes issue added by: https://github.com/llvm/llvm-project/pull/111833

Following the previous commit that changed how Dexter imports modules, the ComInterface module import became broken. This is because it had a different directory structure to other modules, where we want to import single file rather than a dir containing a __init__.py. For this case, an optional extra arg has been added to load_module allowing a filename to be specified, letting us import ComInterface.py directly and fixing the issue.