### PR TITLE
[Coroutines] Improve use of unique_ptr

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -2211,17 +2211,13 @@ CreateNewABI(Function &F, coro::Shape &S,
 
   switch (S.ABI) {
   case coro::ABI::Switch:
-    return std::unique_ptr<coro::BaseABI>(
-        new coro::SwitchABI(F, S, IsMatCallback));
+    return std::make_unique<coro::SwitchABI>(F, S, IsMatCallback);
   case coro::ABI::Async:
-    return std::unique_ptr<coro::BaseABI>(
-        new coro::AsyncABI(F, S, IsMatCallback));
+    return std::make_unique<coro::AsyncABI>(F, S, IsMatCallback);
   case coro::ABI::Retcon:
-    return std::unique_ptr<coro::BaseABI>(
-        new coro::AnyRetconABI(F, S, IsMatCallback));
+    return std::make_unique<coro::AnyRetconABI>(F, S, IsMatCallback);
   case coro::ABI::RetconOnce:
-    return std::unique_ptr<coro::BaseABI>(
-        new coro::AnyRetconABI(F, S, IsMatCallback));
+    return std::make_unique<coro::AnyRetconABI>(F, S, IsMatCallback);
   }
   llvm_unreachable("Unknown ABI");
 }

--- a/llvm/unittests/Transforms/Coroutines/ExtraRematTest.cpp
+++ b/llvm/unittests/Transforms/Coroutines/ExtraRematTest.cpp
@@ -247,7 +247,7 @@ TEST_F(ExtraRematTest, TestCoroRematWithCustomABI) {
   ASSERT_TRUE(M);
 
   CoroSplitPass::BaseABITy GenCustomABI = [](Function &F, coro::Shape &S) {
-    return std::unique_ptr<coro::BaseABI>(new ExtraCustomABI(F, S));
+    return std::make_unique<ExtraCustomABI>(F, S);
   };
 
   CGSCCPassManager CGPM;


### PR DESCRIPTION
* Replace usage of unique_ptr<>(new ...) -> make_unique<>();