### PR TITLE
[LLDB]Provide clearer error message for invalid commands.

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandObjectMultiword.h
+++ b/lldb/include/lldb/Interpreter/CommandObjectMultiword.h
@@ -70,6 +70,8 @@ protected:
     return m_subcommand_dict;
   }
 
+  std::string GetTopSubcommands(int count);
+
   CommandObject::CommandMap m_subcommand_dict;
   bool m_can_be_removed;
 };

--- a/lldb/include/lldb/Interpreter/CommandObjectMultiword.h
+++ b/lldb/include/lldb/Interpreter/CommandObjectMultiword.h
@@ -70,7 +70,7 @@ protected:
     return m_subcommand_dict;
   }
 
-  std::string GetTopSubcommands(int count);
+  std::string GetSubcommandsHintText();
 
   CommandObject::CommandMap m_subcommand_dict;
   bool m_can_be_removed;

--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -194,26 +194,48 @@ void CommandObjectMultiword::Execute(const char *args_string,
 
   std::string error_msg;
   const size_t num_subcmd_matches = matches.GetSize();
-  if (num_subcmd_matches > 0)
-    error_msg.assign("ambiguous command ");
-  else
-    error_msg.assign("invalid command ");
-
-  error_msg.append("'");
-  error_msg.append(std::string(GetCommandName()));
-  error_msg.append(" ");
-  error_msg.append(std::string(sub_command));
-  error_msg.append("'.");
-
   if (num_subcmd_matches > 0) {
+    error_msg.assign("ambiguous command ");
+    error_msg.append("'");
+    error_msg.append(std::string(GetCommandName()));
+    error_msg.append(" ");
+    error_msg.append(std::string(sub_command));
+    error_msg.append("'.");
+
     error_msg.append(" Possible completions:");
     for (const std::string &match : matches) {
       error_msg.append("\n\t");
       error_msg.append(match);
     }
+  } else {
+    // Rather than simply complaining about the invalid (sub) command,
+    // try to offer some alternatives.
+    // This is especially useful for cases where the user types something
+    // seamingly trivial, such as `breakpoint foo`.
+    error_msg.assign(
+        llvm::Twine("'" + sub_command + "' is not a valid subcommand of \"" +
+                    GetCommandName() + "\". Valid subcommands are " +
+                    GetTopSubcommands(/*count=*/5) + ". Use \"help " +
+                    GetCommandName() + "\" to find out more.")
+            .str());
   }
   error_msg.append("\n");
   result.AppendRawError(error_msg.c_str());
+}
+
+std::string CommandObjectMultiword::GetTopSubcommands(int count) {
+  if (m_subcommand_dict.empty())
+    return "<NONE>";
+  std::string buffer = "{";
+  CommandMap::iterator pos;
+  for (pos = m_subcommand_dict.begin();
+       pos != m_subcommand_dict.end() && count > 0; ++pos, --count) {
+    buffer.append("'");
+    buffer.append(pos->first);
+    buffer.append("',");
+  }
+  buffer.append("...}");
+  return buffer;
 }
 
 void CommandObjectMultiword::GenerateHelpText(Stream &output_stream) {

--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -210,7 +210,7 @@ void CommandObjectMultiword::Execute(const char *args_string,
   } else {
     // Try to offer some alternatives to help correct the command.
     error_msg.assign(
-        llvm::Twine("'" + sub_command + "' is not a valid subcommand of \"" +
+        llvm::Twine("\"" + sub_command + "\" is not a valid subcommand of \"" +
                     GetCommandName() + "\"." + GetSubcommandsHintText() +
                     " Use \"help " + GetCommandName() + "\" to find out more.")
             .str());
@@ -225,7 +225,7 @@ std::string CommandObjectMultiword::GetSubcommandsHintText() {
   const size_t maxCount = 5;
   size_t i = 0;
   std::string buffer = " Valid subcommand";
-  buffer.append(m_subcommand_dict.size() > 1 ? "s are:" : "is");
+  buffer.append(m_subcommand_dict.size() > 1 ? "s are:" : " is");
   CommandMap::iterator pos;
   for (pos = m_subcommand_dict.begin();
        pos != m_subcommand_dict.end() && i < maxCount; ++pos, ++i) {

--- a/lldb/test/Shell/Commands/command-breakpoint-col.test
+++ b/lldb/test/Shell/Commands/command-breakpoint-col.test
@@ -3,8 +3,10 @@
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
 # RUN: %lldb -b -o 'help breakpoint set' -o 'breakpoint set -f main.c -l 2 -u 21' %t.out | FileCheck %s --check-prefix HELP --check-prefix CHECK
 # RUN: %lldb -b -o 'help _regexp-break' -o 'b main.c:2:21' %t.out | FileCheck %s --check-prefix HELP-REGEX --check-prefix CHECK
+# RUN: not %lldb -b -o 'breakpoint foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix ERROR-MSG
 # HELP: -u <column> ( --column <column> )
 # HELP: Specifies the column number on which to set this breakpoint.
 # HELP-REGEX: _regexp-break <filename>:<linenum>:<colnum>
 # HELP-REGEX: main.c:12:21{{.*}}Break at line 12 and column 21 of main.c
 # CHECK: at main.c:2:21
+# ERROR-MSG: 'foo' is not a valid subcommand of "breakpoint". Valid subcommands are {'clear','command','delete','disable','enable',...}. Use "help breakpoint" to find out more.

--- a/lldb/test/Shell/Commands/command-breakpoint-col.test
+++ b/lldb/test/Shell/Commands/command-breakpoint-col.test
@@ -3,10 +3,8 @@
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
 # RUN: %lldb -b -o 'help breakpoint set' -o 'breakpoint set -f main.c -l 2 -u 21' %t.out | FileCheck %s --check-prefix HELP --check-prefix CHECK
 # RUN: %lldb -b -o 'help _regexp-break' -o 'b main.c:2:21' %t.out | FileCheck %s --check-prefix HELP-REGEX --check-prefix CHECK
-# RUN: not %lldb -b -o 'breakpoint foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix ERROR-MSG
 # HELP: -u <column> ( --column <column> )
 # HELP: Specifies the column number on which to set this breakpoint.
 # HELP-REGEX: _regexp-break <filename>:<linenum>:<colnum>
 # HELP-REGEX: main.c:12:21{{.*}}Break at line 12 and column 21 of main.c
 # CHECK: at main.c:2:21
-# ERROR-MSG: 'foo' is not a valid subcommand of "breakpoint". Valid subcommands are {'clear','command','delete','disable','enable',...}. Use "help breakpoint" to find out more.

--- a/lldb/test/Shell/Commands/command-wrong-subcommand-error-msg.test
+++ b/lldb/test/Shell/Commands/command-wrong-subcommand-error-msg.test
@@ -1,0 +1,8 @@
+# UNSUPPORTED: system-windows
+#
+# RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
+# RUN: not %lldb -b -o 'breakpoint foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix BP-MSG
+# RUN: not %lldb -b -o 'watchpoint set foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix WP-MSG
+# CHECK: at main.c:2:21
+# BP-MSG: 'foo' is not a valid subcommand of "breakpoint". Valid subcommands are: clear, command, delete, disable, enable, and others. Use "help breakpoint" to find out more.
+# WP-MSG: 'foo' is not a valid subcommand of "watchpoint set". Valid subcommands are: expression, variable. Use "help watchpoint set" to find out more.

--- a/lldb/test/Shell/Commands/command-wrong-subcommand-error-msg.test
+++ b/lldb/test/Shell/Commands/command-wrong-subcommand-error-msg.test
@@ -4,5 +4,5 @@
 # RUN: not %lldb -b -o 'breakpoint foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix BP-MSG
 # RUN: not %lldb -b -o 'watchpoint set foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix WP-MSG
 # CHECK: at main.c:2:21
-# BP-MSG: 'foo' is not a valid subcommand of "breakpoint". Valid subcommands are: clear, command, delete, disable, enable, and others. Use "help breakpoint" to find out more.
-# WP-MSG: 'foo' is not a valid subcommand of "watchpoint set". Valid subcommands are: expression, variable. Use "help watchpoint set" to find out more.
+# BP-MSG: "foo" is not a valid subcommand of "breakpoint". Valid subcommands are: clear, command, delete, disable, enable, and others. Use "help breakpoint" to find out more.
+# WP-MSG: "foo" is not a valid subcommand of "watchpoint set". Valid subcommands are: expression, variable. Use "help watchpoint set" to find out more.


### PR DESCRIPTION
Sometimes users (esp. gdb-longtime users) accidentally use GDB syntax, such as `breakpoint foo`, and they would get an error message from LLDB saying simply `Invalid command "breakpoint foo"`, which is not very helpful. 

This change provides additional suggestions to help correcting the mistake.