### PR TITLE
[SandboxVec] Add BottomUpVec test flag to build regions from metadata.

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -29,10 +29,11 @@ class BottomUpVec final : public FunctionPass {
   void tryVectorize(ArrayRef<Value *> Seeds);
 
   // The PM containing the pipeline of region passes.
-  RegionPassManager RPM;
+  // TODO: Remove maybe_unused once we build regions to run passes on.
+  [[maybe_unused]] RegionPassManager *RPM;
 
 public:
-  BottomUpVec();
+  BottomUpVec(RegionPassManager *RPM);
   bool runOnFunction(Function &F) final;
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCountPass.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCountPass.h
@@ -1,0 +1,24 @@
+#ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTINSTRUCTIONCOUNTPASS_H
+#define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTINSTRUCTIONCOUNTPASS_H
+
+#include "llvm/SandboxIR/Pass.h"
+
+namespace llvm::sandboxir {
+
+class Region;
+
+/// A Region pass that prints the instruction count for the region to stdout.
+/// Used to test -sbvec-passes while we don't have any actual optimization
+/// passes.
+class PrintInstructionCountPass final : public RegionPass {
+public:
+  PrintInstructionCountPass() : RegionPass("null") {}
+  bool runOnRegion(Region &R) final {
+    outs() << "InstructionCount: " << std::distance(R.begin(), R.end()) << "\n";
+    return false;
+  }
+};
+
+} // namespace llvm::sandboxir
+
+#endif // LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTINSTRUCTIONCOUNTPASS_H

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCountPass.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCountPass.h
@@ -2,10 +2,9 @@
 #define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTINSTRUCTIONCOUNTPASS_H
 
 #include "llvm/SandboxIR/Pass.h"
+#include "llvm/SandboxIR/Region.h"
 
 namespace llvm::sandboxir {
-
-class Region;
 
 /// A Region pass that prints the instruction count for the region to stdout.
 /// Used to test -sbvec-passes while we don't have any actual optimization

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
@@ -20,6 +20,11 @@ class TargetTransformInfo;
 class SandboxVectorizerPass : public PassInfoMixin<SandboxVectorizerPass> {
   TargetTransformInfo *TTI = nullptr;
 
+  // A pipeline of region passes. Typically, this will be run by BottomUpVec on
+  // each region it creates, but it can also be run on regions created from
+  // IR metadata in tests.
+  sandboxir::RegionPassManager RPM;
+
   // The main vectorizer pass.
   sandboxir::BottomUpVec BottomUpVecPass;
 

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
@@ -18,5 +18,6 @@
 #endif
 
 REGION_PASS("null", NullPass())
+REGION_PASS("print-instruction-count", PrintInstructionCountPass())
 
 #undef REGION_PASS

--- a/llvm/test/Transforms/SandboxVectorizer/regions-from-metadata.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/regions-from-metadata.ll
@@ -1,0 +1,16 @@
+; RUN: opt -disable-output --passes=sandbox-vectorizer \
+; RUN:    -sbvec-passes=print-instruction-count \
+; RUN:    -sbvec-use-regions-from-metadata %s | FileCheck %s
+
+define i8 @foo(i8 %v0, i8 %v1) {
+  %t0 = add i8 %v0, 1, !sandboxvec !0
+  %t1 = add i8 %t0, %v1, !sandboxvec !1
+  %t2 = add i8 %t1, %v1, !sandboxvec !1
+  ret i8 %t2
+}
+
+!0 = distinct !{!"sandboxregion"}
+!1 = distinct !{!"sandboxregion"}
+
+; CHECK: InstructionCount: 1
+; CHECK: InstructionCount: 2


### PR DESCRIPTION
This allows us to write lit tests for region passes where regions are specified by metadata in textual IR. See added test file for an example.