### PR TITLE
[lldb] Add include for SBLanguages in lldb-enumerations

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include <lldb/API/SBLanguages.h>
+
 #ifndef SWIG
 // Macro to enable bitmask operations on an enum.  Without this, Enum | Enum
 // gets promoted to an int, so you have to say Enum a = Enum(eFoo | eBar).  If


### PR DESCRIPTION
This adds an include for SBLanguages.h in lldb-enumerations.h so that files that need this enum do not have to explicitly include SBLanguages.