### PR TITLE
[lldb] Log errors to the system log if they would otherwise get dropped

### DIFF
--- a/lldb/include/lldb/Utility/Log.h
+++ b/lldb/include/lldb/Utility/Log.h
@@ -335,6 +335,15 @@ template <typename Cat> Log *GetLog(Cat mask) {
   return LogChannelFor<Cat>().GetLog(Log::MaskType(mask));
 }
 
+/// Getter and setter for the error log (see g_error_log).
+/// The error log is set to the system log in SystemInitializerFull. We can't
+/// use the system log directly because that would violate the layering between
+/// Utility and Host.
+/// @{
+void SetLLDBErrorLog(Log *log);
+Log *GetLLDBErrorLog();
+/// @}
+
 } // namespace lldb_private
 
 /// The LLDB_LOG* macros defined below are the way to emit log messages.
@@ -387,6 +396,9 @@ template <typename Cat> Log *GetLog(Cat mask) {
     if (log_private && error_private) {                                        \
       log_private->FormatError(::std::move(error_private), __FILE__, __func__, \
                                __VA_ARGS__);                                   \
+    } else if (::lldb_private::Log *log_error = GetLLDBErrorLog()) {           \
+      log_error->FormatError(::std::move(error_private), __FILE__, __func__,   \
+                             __VA_ARGS__);                                     \
     } else                                                                     \
       ::llvm::consumeError(::std::move(error_private));                        \
   } while (0)
@@ -401,6 +413,9 @@ template <typename Cat> Log *GetLog(Cat mask) {
     if (log_private && log_private->GetVerbose() && error_private) {           \
       log_private->FormatError(::std::move(error_private), __FILE__, __func__, \
                                __VA_ARGS__);                                   \
+    } else if (::lldb_private::Log *log_error = GetLLDBErrorLog()) {           \
+      log_error->FormatError(::std::move(error_private), __FILE__, __func__,   \
+                             __VA_ARGS__);                                     \
     } else                                                                     \
       ::llvm::consumeError(::std::move(error_private));                        \
   } while (0)

--- a/lldb/include/lldb/Utility/Log.h
+++ b/lldb/include/lldb/Utility/Log.h
@@ -393,12 +393,11 @@ Log *GetLLDBErrorLog();
   do {                                                                         \
     ::lldb_private::Log *log_private = (log);                                  \
     ::llvm::Error error_private = (error);                                     \
+    if (!log_private)                                                          \
+      log_private = lldb_private::GetLLDBErrorLog();                           \
     if (log_private && error_private) {                                        \
       log_private->FormatError(::std::move(error_private), __FILE__, __func__, \
                                __VA_ARGS__);                                   \
-    } else if (::lldb_private::Log *log_error = GetLLDBErrorLog()) {           \
-      log_error->FormatError(::std::move(error_private), __FILE__, __func__,   \
-                             __VA_ARGS__);                                     \
     } else                                                                     \
       ::llvm::consumeError(::std::move(error_private));                        \
   } while (0)
@@ -413,9 +412,6 @@ Log *GetLLDBErrorLog();
     if (log_private && log_private->GetVerbose() && error_private) {           \
       log_private->FormatError(::std::move(error_private), __FILE__, __func__, \
                                __VA_ARGS__);                                   \
-    } else if (::lldb_private::Log *log_error = GetLLDBErrorLog()) {           \
-      log_error->FormatError(::std::move(error_private), __FILE__, __func__,   \
-                             __VA_ARGS__);                                     \
     } else                                                                     \
       ::llvm::consumeError(::std::move(error_private));                        \
   } while (0)

--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -84,6 +84,9 @@ llvm::Error SystemInitializerFull::Initialize() {
   // Use the Debugger's LLDBAssert callback.
   SetLLDBAssertCallback(Debugger::AssertCallback);
 
+  // Use the system log to report errors that would otherwise get dropped.
+  SetLLDBErrorLog(GetLog(SystemLog::System));
+
   LLDB_LOG(GetLog(SystemLog::System), "{0}", GetVersion());
 
   return llvm::Error::success();

--- a/lldb/source/Utility/Log.cpp
+++ b/lldb/source/Utility/Log.cpp
@@ -43,6 +43,10 @@ char TeeLogHandler::ID;
 
 llvm::ManagedStatic<Log::ChannelMap> Log::g_channel_map;
 
+// The error log is used by LLDB_LOG_ERROR and LLDB_LOG_ERRORV. If the given
+// log channel is not enabled, error messages are logged to the error log.
+static std::atomic<Log *> g_error_log = nullptr;
+
 void Log::ForEachCategory(
     const Log::ChannelMap::value_type &entry,
     llvm::function_ref<void(llvm::StringRef, llvm::StringRef)> lambda) {
@@ -460,3 +464,7 @@ void TeeLogHandler::Emit(llvm::StringRef message) {
   m_first_log_handler->Emit(message);
   m_second_log_handler->Emit(message);
 }
+
+void lldb_private::SetLLDBErrorLog(Log *log) { g_error_log.exchange(log); }
+
+Log *lldb_private::GetLLDBErrorLog() { return g_error_log; }

--- a/lldb/source/Utility/Log.cpp
+++ b/lldb/source/Utility/Log.cpp
@@ -43,8 +43,8 @@ char TeeLogHandler::ID;
 
 llvm::ManagedStatic<Log::ChannelMap> Log::g_channel_map;
 
-// The error log is used by LLDB_LOG_ERROR and LLDB_LOG_ERRORV. If the given
-// log channel is not enabled, error messages are logged to the error log.
+// The error log is used by LLDB_LOG_ERROR. If the given log channel passed to
+// LLDB_LOG_ERROR is not enabled, error messages are logged to the error log.
 static std::atomic<Log *> g_error_log = nullptr;
 
 void Log::ForEachCategory(

--- a/lldb/source/Utility/Log.cpp
+++ b/lldb/source/Utility/Log.cpp
@@ -465,6 +465,6 @@ void TeeLogHandler::Emit(llvm::StringRef message) {
   m_second_log_handler->Emit(message);
 }
 
-void lldb_private::SetLLDBErrorLog(Log *log) { g_error_log.exchange(log); }
+void lldb_private::SetLLDBErrorLog(Log *log) { g_error_log.store(log); }
 
 Log *lldb_private::GetLLDBErrorLog() { return g_error_log; }


### PR DESCRIPTION
Log errors to the (always-on) system log if they would otherwise get dropped by LLDB_LOG_ERROR and LLDB_LOG_ERRORV.