### PR TITLE
[libc] Make strtointeger handle all bigint types

### DIFF
--- a/libc/src/__support/str_to_integer.h
+++ b/libc/src/__support/str_to_integer.h
@@ -11,6 +11,8 @@
 
 #include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/type_traits.h"
+#include "src/__support/CPP/type_traits/make_unsigned.h"
+#include "src/__support/big_int.h"
 #include "src/__support/common.h"
 #include "src/__support/ctype_utils.h"
 #include "src/__support/macros/config.h"
@@ -77,9 +79,7 @@ template <class T>
 LIBC_INLINE StrToNumResult<T>
 strtointeger(const char *__restrict src, int base,
              const size_t src_len = cpp::numeric_limits<size_t>::max()) {
-  using ResultType = typename cpp::conditional_t<(cpp::is_same_v<T, UInt128> ||
-                                                  cpp::is_same_v<T, Int128>),
-                                                 UInt128, unsigned long long>;
+  using ResultType = make_integral_or_big_int_unsigned_t<T>;
 
   ResultType result = 0;
 
@@ -137,13 +137,13 @@ strtointeger(const char *__restrict src, int base,
       result = abs_max;
       error_val = ERANGE;
     } else {
-      result = result * base;
+      result = static_cast<ResultType>(result * base);
     }
     if (result > abs_max - cur_digit) {
       result = abs_max;
       error_val = ERANGE;
     } else {
-      result = result + cur_digit;
+      result = static_cast<ResultType>(result + cur_digit);
     }
   }
 
@@ -156,12 +156,7 @@ strtointeger(const char *__restrict src, int base,
       return {cpp::numeric_limits<T>::min(), str_len, error_val};
   }
 
-  return {
-      is_positive
-          ? static_cast<T>(result)
-          : static_cast<T>(
-                -static_cast<make_integral_or_big_int_unsigned_t<T>>(result)),
-      str_len, error_val};
+  return {static_cast<T>(is_positive ? result : -result), str_len, error_val};
 }
 
 } // namespace internal


### PR DESCRIPTION
Needed for #110894

The strtointeger code was updated to support some bigint types in #85201
but not all. This patch finishes the cleanup so that it can work for a
wider range of types.
