### PR TITLE
[clang][bytecode] Check number of addcarry/subborrow args

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1287,7 +1287,7 @@ static bool interp__builtin_ia32_addcarry_subborrow(InterpState &S,
                                                     const InterpFrame *Frame,
                                                     const Function *Func,
                                                     const CallExpr *Call) {
-  if (!Call->getArg(0)->getType()->isIntegerType() ||
+  if (Call->getNumArgs() != 4 || !Call->getArg(0)->getType()->isIntegerType() ||
       !Call->getArg(1)->getType()->isIntegerType() ||
       !Call->getArg(2)->getType()->isIntegerType())
     return false;


### PR DESCRIPTION
Apparently this can fail as well.