### PR TITLE
[mlir][scf] Extend consumer fusion to multiple tilable users

### DIFF
--- a/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.cpp
+++ b/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.cpp
@@ -171,24 +171,27 @@ transform::TestFuseAndYieldOp::apply(TransformRewriter &rewriter,
 template <typename Range>
 static LogicalResult
 applyFuseConsumer(RewriterBase &rewriter, Operation *transformOp,
-                  Range &&payloadOps, TransformResults &transformResults) {
+                  Range &&payloadOps, uint32_t numConsumerToFuse,
+                  TransformResults &transformResults) {
   SmallVector<Operation *> originalConsumerOps;
   SmallVector<Operation *> fusedConsumerOps;
 
   for (Operation *target : payloadOps) {
     rewriter.setInsertionPoint(target);
 
-    FailureOr<scf::SCFFuseConsumerOfSliceResult> fuseConsumerResults =
-        scf::tileAndFuseConsumerOfSlice(rewriter, target);
+    while (numConsumerToFuse--) {
+      FailureOr<scf::SCFFuseConsumerOfSliceResult> fuseConsumerResults =
+          scf::tileAndFuseConsumerOfSlice(rewriter, target);
 
-    if (failed(fuseConsumerResults))
-      return failure();
+      if (failed(fuseConsumerResults))
+        return failure();
 
-    // Report back the relevant handles to the transform op.
-    originalConsumerOps.push_back(
-        fuseConsumerResults->origConsumerOperand->getOwner());
-    fusedConsumerOps.push_back(
-        fuseConsumerResults->tiledAndFusedConsumerOperand->getOwner());
+      // Report back the relevant handles to the transform op.
+      originalConsumerOps.push_back(
+          fuseConsumerResults->origConsumerOperand->getOwner());
+      fusedConsumerOps.push_back(
+          fuseConsumerResults->tiledAndFusedConsumerOperand->getOwner());
+    }
   }
 
   transformResults.set(transformOp->getOpResult(0), originalConsumerOps);
@@ -200,9 +203,9 @@ DiagnosedSilenceableFailure
 transform::TestFuseConsumerOp::apply(TransformRewriter &rewriter,
                                      TransformResults &transformResults,
                                      TransformState &state) {
-  LogicalResult result =
-      applyFuseConsumer(rewriter, getOperation(),
-                        state.getPayloadOps(getTarget()), transformResults);
+  LogicalResult result = applyFuseConsumer(
+      rewriter, getOperation(), state.getPayloadOps(getTarget()),
+      getNumConsumerToFuse(), transformResults);
   return failed(result) ? DiagnosedSilenceableFailure::definiteFailure()
                         : DiagnosedSilenceableFailure::success();
 }

--- a/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.td
+++ b/mlir/test/lib/Interfaces/TilingInterface/TestTilingInterfaceTransformOps.td
@@ -59,12 +59,14 @@ def TestFuseConsumerOp : Op<Transform_Dialect, "test.fuse_consumer",
   }];
 
   let arguments =
-    (ins TransformHandleTypeInterface:$target);
+    (ins TransformHandleTypeInterface:$target,
+        DefaultValuedAttr<I32Attr, "1">:$num_consumer_to_fuse);
   let results = (outs TransformHandleTypeInterface:$consumer,
                       TransformHandleTypeInterface:$fused_consumer);
 
   let assemblyFormat = [{
-    $target attr-dict `:` functional-type(operands, results)
+    $target (`num_consumer_to_fuse` `=` $num_consumer_to_fuse^)? 
+    attr-dict `:` functional-type(operands, results)
   }];
 }
 


### PR DESCRIPTION
Currently, consumer fusion expects single usage(or others are terminator op). This patch support multiple consumers fusion. I.e. fusing following input 
```
%0 = scf.for {
  ...
  %p = tiledProducer
  ...
}
%1 = tilableOp1 ins(%0 :
%2 = tilableOp2 ins(%0 :
```
into
```
%0:3 = scf.for {
  ...
  %p = tiledProducer
  %1 = tilableOp1 ins(%p :
  %2 = tilableOp2 ins(%p :
  ...
}
```

The key process is ensuring(or adapting) that the `lastDefOfConsumer` must be before the `firstUserOfLoop`. 

To enable this feature in TEST mlir, we need to specify `num_consumer_to_fuse = 2` with default value equal to 1. On the other hand, as for downstream use, developers can customize the behavior. The fusing order of multiple consumers is decided by the use list order of the according `Value`.
