### PR TITLE
clang: Fix hipstdpar test relying on default target

### DIFF
--- a/clang/test/Driver/hipstdpar.c
+++ b/clang/test/Driver/hipstdpar.c
@@ -1,21 +1,17 @@
-// REQUIRES: x86-registered-target
-// REQUIRES: amdgpu-registered-target
-// REQUIRES: system-linux
-// UNSUPPORTED: target={{.*}}-zos{{.*}}
-// XFAIL: target={{.*}}hexagon{{.*}}
-// XFAIL: target={{.*}}-scei{{.*}}
-// XFAIL: target={{.*}}-sie{{.*}}
+// REQUIRES: x86-registered-target, amdgpu-registered-target
 
-// RUN: not %clang -### --hipstdpar --hipstdpar-path=/does/not/exist -nogpulib \
+// RUN: not %clang -### --target=x86_64-unknown-linux-gnu \
+// RUN:   --hipstdpar --hipstdpar-path=/does/not/exist -nogpulib    \
 // RUN:   -nogpuinc --compile %s 2>&1 | \
 // RUN:   FileCheck --check-prefix=HIPSTDPAR-MISSING-LIB %s
-// RUN: %clang -### --hipstdpar --hipstdpar-path=%S/Inputs/hipstdpar \
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu \
+// RUN:   --hipstdpar --hipstdpar-path=%S/Inputs/hipstdpar             \
 // RUN:   --hipstdpar-thrust-path=%S/Inputs/hipstdpar/thrust \
 // RUN:   --hipstdpar-prim-path=%S/Inputs/hipstdpar/rocprim \
 // RUN:   -nogpulib -nogpuinc --compile %s 2>&1 | \
 // RUN:   FileCheck --check-prefix=HIPSTDPAR-COMPILE %s
 // RUN: touch %t.o
-// RUN: %clang -### --hipstdpar %t.o 2>&1 | FileCheck --check-prefix=HIPSTDPAR-LINK %s
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu --hipstdpar %t.o 2>&1 | FileCheck --check-prefix=HIPSTDPAR-LINK %s
 
 // HIPSTDPAR-MISSING-LIB: error: cannot find HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-path'
 // HIPSTDPAR-COMPILE: "-x" "hip"


### PR DESCRIPTION
Use explicit target and stop restricting hosts it can run on.