### PR TITLE
[lldb][test] Remove objcopy detection from API tests' CMakeLists.txt

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -96,14 +96,6 @@ if ( CMAKE_SYSTEM_NAME MATCHES "Windows" )
   endif()
 endif()
 
-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows|Darwin")
-  list(APPEND LLDB_TEST_COMMON_ARGS_VAR
-    --env ARCHIVER=${CMAKE_AR} --env OBJCOPY=${CMAKE_OBJCOPY})
-else()
-  list(APPEND LLDB_TEST_COMMON_ARGS_VAR
-    --env OBJCOPY=${LLVM_TOOLS_BINARY_DIR}/llvm-objcopy${CMAKE_EXECUTABLE_SUFFIX})
-endif()
-
 if (NOT "${LLDB_LIT_TOOLS_DIR}" STREQUAL "")
   if (NOT EXISTS "${LLDB_LIT_TOOLS_DIR}")
     message(WARNING "LLDB_LIT_TOOLS_DIR ${LLDB_LIT_TOOLS_DIR} does not exist.")


### PR DESCRIPTION
This commit essentially reverts https://reviews.llvm.org/D30453.

In #109961, objcopy util search code was added to dotest.py. dotest.py should use llvm-X by default if no path to a utility X is provided externally.

However, it doesn't work out for llvm-objcopy, since objcopy path is always overridden with the lines being removed here. It causes a problem with cross-platform testing when objcopy used by cmake doesn't support targets/executable file formats other than native.

I suppose these lines are unnecessary after #109961, so they can be safely removed.