### PR TITLE
[XRay] Fix LLVM include in xray_interface.cpp

### DIFF
--- a/clang/include/clang/Driver/XRayArgs.h
+++ b/clang/include/clang/Driver/XRayArgs.h
@@ -36,9 +36,7 @@ public:
                llvm::opt::ArgStringList &CmdArgs, types::ID InputType) const;
 
   bool needsXRayRt() const { return XRayInstrument && XRayRT; }
-  bool needsXRayDSORt() const {
-    return XRayInstrument && XRayRT && XRayShared;
-  }
+  bool needsXRayDSORt() const { return XRayInstrument && XRayRT && XRayShared; }
   llvm::ArrayRef<std::string> modeList() const { return Modes; }
   XRayInstrSet instrumentationBundle() const { return InstrumentationBundle; }
 };

--- a/clang/lib/Driver/XRayArgs.cpp
+++ b/clang/lib/Driver/XRayArgs.cpp
@@ -63,8 +63,8 @@ XRayArgs::XRayArgs(const ToolChain &TC, const ArgList &Args) {
         << XRayInstrument->getSpelling() << Triple.str();
   }
 
-  if (Args.hasFlag(options::OPT_fxray_shared,
-                   options::OPT_fno_xray_shared, false)) {
+  if (Args.hasFlag(options::OPT_fxray_shared, options::OPT_fno_xray_shared,
+                   false)) {
     XRayShared = true;
 
     // DSO instrumentation is currently limited to x86_64
@@ -75,8 +75,8 @@ XRayArgs::XRayArgs(const ToolChain &TC, const ArgList &Args) {
 
     unsigned PICLvl = std::get<1>(tools::ParsePICArgs(TC, Args));
     if (!PICLvl) {
-      D.Diag(diag::err_opt_not_valid_without_opt)
-          << "-fxray-shared" << "-fPIC";
+      D.Diag(diag::err_opt_not_valid_without_opt) << "-fxray-shared"
+                                                  << "-fPIC";
     }
   }
 

--- a/compiler-rt/include/xray/xray_interface.h
+++ b/compiler-rt/include/xray/xray_interface.h
@@ -93,8 +93,8 @@ enum XRayPatchingStatus {
   FAILED = 3,
 };
 
-/// This tells XRay to patch the instrumentation points in all currently loaded objects. See XRayPatchingStatus
-/// for possible result values.
+/// This tells XRay to patch the instrumentation points in all currently loaded
+/// objects. See XRayPatchingStatus for possible result values.
 extern XRayPatchingStatus __xray_patch();
 
 /// This tells XRay to patch the instrumentation points in the given object.
@@ -105,8 +105,8 @@ extern XRayPatchingStatus __xray_patch_object(int32_t ObjId);
 /// result values.
 extern XRayPatchingStatus __xray_unpatch();
 
-/// Reverses the effect of __xray_patch_object. See XRayPatchingStatus for possible
-/// result values.
+/// Reverses the effect of __xray_patch_object. See XRayPatchingStatus for
+/// possible result values.
 extern XRayPatchingStatus __xray_unpatch_object(int32_t ObjId);
 
 /// This unpacks the given (packed) function id and patches
@@ -114,8 +114,8 @@ extern XRayPatchingStatus __xray_unpatch_object(int32_t ObjId);
 /// result values.
 extern XRayPatchingStatus __xray_patch_function(int32_t FuncId);
 
-/// This patches a specific function in the given object. See XRayPatchingStatus for possible
-/// result values.
+/// This patches a specific function in the given object. See XRayPatchingStatus
+/// for possible result values.
 extern XRayPatchingStatus __xray_patch_function_in_object(int32_t FuncId,
                                                           int32_t ObjId);
 
@@ -129,26 +129,29 @@ extern XRayPatchingStatus __xray_unpatch_function(int32_t FuncId);
 extern XRayPatchingStatus __xray_unpatch_function_in_object(int32_t FuncId,
                                                             int32_t ObjId);
 
-/// This function unpacks the given (packed) function id and returns the address of the corresponding function. We return 0 if we encounter any error, even if 0 may be a valid function
-/// address.
+/// This function unpacks the given (packed) function id and returns the address
+/// of the corresponding function. We return 0 if we encounter any error, even
+/// if 0 may be a valid function address.
 extern uintptr_t __xray_function_address(int32_t FuncId);
 
-/// This function returns the address of the function in the given object provided valid function and object
-/// ids. We return 0 if we encounter any error, even if 0 may be a valid function
-/// address.
+/// This function returns the address of the function in the given object
+/// provided valid function and object ids. We return 0 if we encounter any
+/// error, even if 0 may be a valid function address.
 extern uintptr_t __xray_function_address_in_object(int32_t FuncId,
                                                    int32_t ObjId);
 
-/// This function returns the maximum valid function id for the main executable (object id = 0). Returns 0 if we
-/// encounter errors (when there are no instrumented functions, etc.).
+/// This function returns the maximum valid function id for the main executable
+/// (object id = 0). Returns 0 if we encounter errors (when there are no
+/// instrumented functions, etc.).
 extern size_t __xray_max_function_id();
 
-/// This function returns the maximum valid function id for the given object. Returns 0 if we
-/// encounter errors (when there are no instrumented functions, etc.).
+/// This function returns the maximum valid function id for the given object.
+/// Returns 0 if we encounter errors (when there are no instrumented functions,
+/// etc.).
 extern size_t __xray_max_function_id_in_object(int32_t ObjId);
 
-/// This function returns the number of previously registered objects (executable + loaded DSOs).
-/// Returns 0 if XRay has not been initialized.
+/// This function returns the number of previously registered objects
+/// (executable + loaded DSOs). Returns 0 if XRay has not been initialized.
 extern size_t __xray_num_objects();
 
 /// Unpacks the function id from the given packed id.
@@ -158,7 +161,8 @@ extern int32_t __xray_unpack_function_id(int32_t PackedId);
 extern int32_t __xray_unpack_object_id(int32_t PackedId);
 
 /// Creates and returns a packed id from the given function and object ids.
-/// If the ids do not fit within the reserved number of bits for each part, the high bits are truncated.
+/// If the ids do not fit within the reserved number of bits for each part, the
+/// high bits are truncated.
 extern int32_t __xray_pack_id(int32_t FuncId, int32_t ObjId);
 
 /// Initialize the required XRay data structures. This is useful in cases where

--- a/compiler-rt/lib/xray/xray_interface.cpp
+++ b/compiler-rt/lib/xray/xray_interface.cpp
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "xray_interface_internal.h"
-#include "llvm/Support/ErrorHandling.h"
 
 #include <cinttypes>
 #include <cstdio>
@@ -411,9 +410,9 @@ XRayPatchingStatus controlPatching(bool Enable) XRAY_NEVER_INSTRUMENT {
         CombinedStatus = NOT_INITIALIZED;
       break;
     case ONGOING:
-      llvm_unreachable("Status ONGOING should not appear at this point");
+      UNREACHABLE("Status ONGOING should not appear at this point");
     default:
-      llvm_unreachable("Unhandled patching status");
+      UNREACHABLE("Unhandled patching status");
     }
   }
   return CombinedStatus;


### PR DESCRIPTION
Removes a dependency on LLVM in `xray_interface.cpp` by replacing `llvm_unreachable` with compiler-rt's `UNREACHABLE`.
Applies clang-format to some unformatted changes. 

Original PR: #90959 