### PR TITLE
AArch64: Remove incorrect REQUIRES arm-registered-target from test

### DIFF
--- a/llvm/test/CodeGen/AArch64/vecreduce-propagate-sd-flags.ll
+++ b/llvm/test/CodeGen/AArch64/vecreduce-propagate-sd-flags.ll
@@ -1,4 +1,3 @@
-; REQUIRES: arm-registered-target
 ; REQUIRES: asserts
 ; RUN: llc -o /dev/null %s -debug-only=legalize-types 2>&1 | FileCheck %s
 


### PR DESCRIPTION
The test only depends on AArch64 as it should.