### PR TITLE
[scudo] Apply the min release threshold to the group

### DIFF
--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -1492,6 +1492,8 @@ private:
       }
 
       const uptr PushedBytesDelta = BytesInBG - BG->BytesInBGAtLastCheckpoint;
+      if (PushedBytesDelta < getMinReleaseAttemptSize(BlockSize))
+        continue;
 
       // Given the randomness property, we try to release the pages only if the
       // bytes used by free blocks exceed certain proportion of group size. Note


### PR DESCRIPTION
For the block smaller than a page size, one block is unlikely to introduce more unused pages (at most 2 if it acrosses the page boundary and both touched pages are unused). So it's better to apply the threshold to reduce the time of scanning groups that can't release any new pages.