### PR TITLE
clang: Add llvm-mc to CLANG_TEST_DEPS

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -127,6 +127,7 @@ if( NOT CLANG_BUILT_STANDALONE )
     llvm-dwarfdump
     llvm-ifs
     llvm-lto2
+    llvm-mc
     llvm-modextract
     llvm-nm
     llvm-objcopy


### PR DESCRIPTION
Attempt to fit sporadic precommit test failures in
hip-partial-link.hip

The driver really shouldn't be using llvm-mc in the first place
though, filed #112031 to fix this.