### PR TITLE
[WebAssembly] Support the new "Lime1" CPU

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -929,9 +929,15 @@ and `-mbulk-memory` flags, which correspond to the [Bulk Memory Operations]
 and [Non-trapping float-to-int Conversions] language features, which are
 [widely implemented in engines].
 
+A new Lime1 target CPU is added, -mcpu=lime1. This CPU follows the definition of
+the Lime1 CPU [here], and enables -mmultivalue, -mmutable-globals,
+-mcall-indirect-overlong, -msign-ext, -mbulk-memory-opt, -mnontrapping-fptoint,
+and -mextended-const.
+
 [Bulk Memory Operations]: https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md
 [Non-trapping float-to-int Conversions]: https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md
 [widely implemented in engines]: https://webassembly.org/features/
+[here]: https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1
 
 AVR Support
 ^^^^^^^^^^^

--- a/clang/lib/Basic/Targets/WebAssembly.cpp
+++ b/clang/lib/Basic/Targets/WebAssembly.cpp
@@ -167,6 +167,17 @@ bool WebAssemblyTargetInfo::initFeatureMap(
     Features["reference-types"] = true;
     Features["sign-ext"] = true;
   };
+  auto addLime1Features = [&]() {
+    // Lime1:
+    // <https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1>
+    Features["multivalue"] = true;
+    Features["mutable-globals"] = true;
+    Features["call-indirect-overlong"] = true;
+    Features["sign-ext"] = true;
+    Features["bulk-memory-opt"] = true;
+    Features["nontrapping-fptoint"] = true;
+    Features["extended-const"] = true;
+  };
   auto addBleedingEdgeFeatures = [&]() {
     addGenericFeatures();
     Features["atomics"] = true;
@@ -180,6 +191,8 @@ bool WebAssemblyTargetInfo::initFeatureMap(
   };
   if (CPU == "generic") {
     addGenericFeatures();
+  } else if (CPU == "lime1") {
+    addLime1Features();
   } else if (CPU == "bleeding-edge") {
     addBleedingEdgeFeatures();
   }

--- a/clang/lib/Basic/Targets/WebAssembly.cpp
+++ b/clang/lib/Basic/Targets/WebAssembly.cpp
@@ -31,7 +31,7 @@ static constexpr Builtin::Info BuiltinInfo[] = {
 };
 
 static constexpr llvm::StringLiteral ValidCPUNames[] = {
-    {"mvp"}, {"bleeding-edge"}, {"generic"}};
+    {"mvp"}, {"bleeding-edge"}, {"generic"}, {"lime"}};
 
 StringRef WebAssemblyTargetInfo::getABI() const { return ABI; }
 

--- a/clang/lib/Basic/Targets/WebAssembly.cpp
+++ b/clang/lib/Basic/Targets/WebAssembly.cpp
@@ -170,13 +170,13 @@ bool WebAssemblyTargetInfo::initFeatureMap(
   auto addLime1Features = [&]() {
     // Lime1:
     // <https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1>
+    Features["bulk-memory-opt"] = true;
+    Features["call-indirect-overlong"] = true;
+    Features["extended-const"] = true;
     Features["multivalue"] = true;
     Features["mutable-globals"] = true;
-    Features["call-indirect-overlong"] = true;
-    Features["sign-ext"] = true;
-    Features["bulk-memory-opt"] = true;
     Features["nontrapping-fptoint"] = true;
-    Features["extended-const"] = true;
+    Features["sign-ext"] = true;
   };
   auto addBleedingEdgeFeatures = [&]() {
     addGenericFeatures();

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -226,9 +226,15 @@ and `-mbulk-memory` flags, which correspond to the [Bulk Memory Operations]
 and [Non-trapping float-to-int Conversions] language features, which are
 [widely implemented in engines].
 
+A new Lime1 target CPU is added, -mcpu=lime1. This CPU follows the definition of
+the Lime1 CPU [here], and enables -mmultivalue, -mmutable-globals,
+-mcall-indirect-overlong, -msign-ext, -mbulk-memory-opt, -mnontrapping-fptoint,
+and -mextended-const.
+
 [Bulk Memory Operations]: https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md
 [Non-trapping float-to-int Conversions]: https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md
 [widely implemented in engines]: https://webassembly.org/features/
+[here]: https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1
 
 Changes to the Windows Target
 -----------------------------

--- a/llvm/lib/Target/WebAssembly/WebAssembly.td
+++ b/llvm/lib/Target/WebAssembly/WebAssembly.td
@@ -127,6 +127,13 @@ def : ProcessorModel<"generic", NoSchedModel,
                        FeatureMutableGlobals, FeatureNontrappingFPToInt,
                        FeatureReferenceTypes, FeatureSignExt]>;
 
+// Lime1: <https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1>
+def : ProcessorModel<"lime1", NoSchedModel,
+                      [FeatureMultivalue, FeatureMutableGlobals,
+                       FeatureCallIndirectOverlong, FeatureSignExt,
+                       FeatureBulkMemoryOpt, FeatureNontrappingFPToInt,
+                       FeatureExtendedConst]>;
+
 // Latest and greatest experimental version of WebAssembly. Bugs included!
 def : ProcessorModel<"bleeding-edge", NoSchedModel,
                       [FeatureAtomics, FeatureBulkMemory, FeatureBulkMemoryOpt,

--- a/llvm/lib/Target/WebAssembly/WebAssembly.td
+++ b/llvm/lib/Target/WebAssembly/WebAssembly.td
@@ -129,10 +129,10 @@ def : ProcessorModel<"generic", NoSchedModel,
 
 // Lime1: <https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1>
 def : ProcessorModel<"lime1", NoSchedModel,
-                      [FeatureMultivalue, FeatureMutableGlobals,
-                       FeatureCallIndirectOverlong, FeatureSignExt,
-                       FeatureBulkMemoryOpt, FeatureNontrappingFPToInt,
-                       FeatureExtendedConst]>;
+                      [FeatureBulkMemoryOpt, FeatureCallIndirectOverlong,
+                       FeatureExtendedConst, FeatureMultivalue,
+                       FeatureMutableGlobals, FeatureNontrappingFPToInt,
+                       FeatureSignExt]>;
 
 // Latest and greatest experimental version of WebAssembly. Bugs included!
 def : ProcessorModel<"bleeding-edge", NoSchedModel,

--- a/llvm/test/CodeGen/WebAssembly/target-features-cpus.ll
+++ b/llvm/test/CodeGen/WebAssembly/target-features-cpus.ll
@@ -1,5 +1,6 @@
 ; RUN: llc < %s -mcpu=mvp | FileCheck %s --check-prefixes MVP
 ; RUN: llc < %s -mcpu=generic | FileCheck %s --check-prefixes GENERIC
+; RUN: llc < %s -mcpu=lime1 | FileCheck %s --check-prefixes LIME1
 ; RUN: llc < %s | FileCheck %s --check-prefixes GENERIC
 ; RUN: llc < %s -mcpu=bleeding-edge | FileCheck %s --check-prefixes BLEEDING-EDGE
 
@@ -38,6 +39,32 @@ target triple = "wasm32-unknown-unknown"
 ; GENERIC-NEXT: .int8  43
 ; GENERIC-NEXT: .int8  8
 ; GENERIC-NEXT: .ascii  "sign-ext"
+
+; lime1: +bulk-memory-opt, +call-indirect-overlong, +extended-const, +multivalue,
+;        +mutable-globals, +nontrapping-fptoint, +sign-ext
+; LIME1-LABEL: .custom_section.target_features,"",@
+; LIME1-NEXT: .int8  7
+; LIME1-NEXT: .int8  43
+; LIME1-NEXT: .int8  15
+; LIME1-NEXT: .ascii  "bulk-memory-opt"
+; LIME1-NEXT: .int8  43
+; LIME1-NEXT: .int8  22
+; LIME1-NEXT: .ascii  "call-indirect-overlong"
+; LIME1-NEXT: .int8  43
+; LIME1-NEXT: .int8  14
+; LIME1-NEXT: .ascii  "extended-const"
+; LIME1-NEXT: .int8  43
+; LIME1-NEXT: .int8  10
+; LIME1-NEXT: .ascii  "multivalue"
+; LIME1-NEXT: .int8  43
+; LIME1-NEXT: .int8  15
+; LIME1-NEXT: .ascii  "mutable-globals"
+; LIME1-NEXT: .int8  43
+; LIME1-NEXT: .int8  19
+; LIME1-NEXT: .ascii  "nontrapping-fptoint"
+; LIME1-NEXT: .int8  43
+; LIME1-NEXT: .int8  8
+; LIME1-NEXT: .ascii  "sign-ext"
 
 ; bleeding-edge: +atomics, +bulk-memory, +bulk-memory-opt,
 ;                +call-indirect-overlong, +exception-handling,


### PR DESCRIPTION
This adds WebAssembly support for the new [Lime1 CPU].

First, this defines some new target features. These are subsets of existing
features that reflect implementation concerns:

 - "call-indirect-overlong" - implied by "reference-types"; just the overlong
   encoding for the `call_indirect` immediate, and not the actual reference
   types.

 - "bulk-memory-opt" - implied by "bulk-memory": just `memory.copy` and
   `memory.fill`, and not the other instructions in the bulk-memory
    proposal.

Next, this defines a new target CPU, "lime1", which enables mutable-globals,
bulk-memory-opt, multivalue, sign-ext, nontrapping-fptoint, extended-const,
and call-indirect-overlong. Unlike the default "generic" CPU, "lime1" is meant
to be frozen, and followed up by "lime2" and so on when new features are
desired.

[Lime1 CPU]: https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1
