### PR TITLE
[lldb] Make the system log a NOOP on Windows

### DIFF
--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -111,17 +111,7 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
   syslog(level, "%s", message.data());
 }
 #else
-void Host::SystemLog(Severity severity, llvm::StringRef message) {
-  switch (severity) {
-  case lldb::eSeverityInfo:
-  case lldb::eSeverityWarning:
-    llvm::outs() << message;
-    break;
-  case lldb::eSeverityError:
-    llvm::errs() << message;
-    break;
-  }
-}
+void Host::SystemLog(Severity severity, llvm::StringRef message) {}
 #endif
 #endif
 


### PR DESCRIPTION
Windows doesn't have a built-in system log. Previously we got away with writing to stdout and stderr because it was used only sporadically. As we're trying to make the system log more useful on the other platforms, the increased use become a concern. Make it a NOOP until someone figures out a reasonable alternative.