### PR TITLE
[Flang] [Semantics] [OpenMP] Fix semantic check to not report error for compound OMP TARGET directives.

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2418,10 +2418,16 @@ void OmpAttributeVisitor::ResolveOmpObject(
                       Symbol::Flag::OmpLastPrivate, Symbol::Flag::OmpShared,
                       Symbol::Flag::OmpLinear};
 
-                  for (Symbol::Flag ompFlag1 : dataMappingAttributeFlags) {
-                    for (Symbol::Flag ompFlag2 : dataSharingAttributeFlags) {
-                      checkExclusivelists(
-                          hostAssocSym, ompFlag1, symbol, ompFlag2);
+                  // For OMP TARGET TEAMS directive some sharing attribute
+                  // flags and mapping attribute flags can co-exist.
+                  if (!(llvm::omp::allTeamsSet.test(GetContext().directive) ||
+                          llvm::omp::allParallelSet.test(
+                              GetContext().directive))) {
+                    for (Symbol::Flag ompFlag1 : dataMappingAttributeFlags) {
+                      for (Symbol::Flag ompFlag2 : dataSharingAttributeFlags) {
+                        checkExclusivelists(
+                            hostAssocSym, ompFlag1, symbol, ompFlag2);
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
For test program like this variable array is mentioned in both shared clause and map clause. For OMP TARGET compound directives like this where we have OMP TARGET TEAMS, map clause applies to TARGET directive and SHARED clause applies to TEAMS directive. So both SHARED and MAP clauses can co-exist. 

> program test
> implicit none
>   integer :: array(10,10),i,j
>     !$omp target teams shared(array) map(tofrom:array)
>       do i=1,10
>       !$omp parallel do
>         do j=1,10
>           array(j,i)=i+j
>         end do
>       end do
>   !$omp end target teams
>   print *, array
> end program test
> 
> 

Before this PR we were checking for exclusivity for all target directives set which is now relaxed to exclusivity check not being applied to compound directives which can accept SHARED clause.