### PR TITLE
[lldb] Rename CommandReturnObject::Get.*Data -> Get.*String

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -30,16 +30,17 @@ public:
 
   ~CommandReturnObject() = default;
 
-  llvm::StringRef GetInlineDiagnosticsData(unsigned indent);
+  /// Format any inline diagnostics with an indentation of \c indent.
+  llvm::StringRef GetInlineDiagnosticString(unsigned indent);
 
-  llvm::StringRef GetOutputData() {
+  llvm::StringRef GetOutputString() {
     lldb::StreamSP stream_sp(m_out_stream.GetStreamAtIndex(eStreamStringIndex));
     if (stream_sp)
       return std::static_pointer_cast<StreamString>(stream_sp)->GetString();
     return llvm::StringRef();
   }
 
-  llvm::StringRef GetErrorData();
+  llvm::StringRef GetErrorString();
 
   Stream &GetOutputStream() {
     // Make sure we at least have our normal string stream output stream

--- a/lldb/source/API/SBCommandReturnObject.cpp
+++ b/lldb/source/API/SBCommandReturnObject.cpp
@@ -85,27 +85,27 @@ SBCommandReturnObject::operator bool() const {
 const char *SBCommandReturnObject::GetOutput() {
   LLDB_INSTRUMENT_VA(this);
 
-  ConstString output(ref().GetOutputData());
+  ConstString output(ref().GetOutputString());
   return output.AsCString(/*value_if_empty*/ "");
 }
 
 const char *SBCommandReturnObject::GetError() {
   LLDB_INSTRUMENT_VA(this);
 
-  ConstString output(ref().GetErrorData());
+  ConstString output(ref().GetErrorString());
   return output.AsCString(/*value_if_empty*/ "");
 }
 
 size_t SBCommandReturnObject::GetOutputSize() {
   LLDB_INSTRUMENT_VA(this);
 
-  return ref().GetOutputData().size();
+  return ref().GetOutputString().size();
 }
 
 size_t SBCommandReturnObject::GetErrorSize() {
   LLDB_INSTRUMENT_VA(this);
 
-  return ref().GetErrorData().size();
+  return ref().GetErrorString().size();
 }
 
 size_t SBCommandReturnObject::PutOutput(FILE *fh) {

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -1099,7 +1099,7 @@ protected:
     } else {
       // Don't change the status if the command already set it...
       if (result.GetStatus() == eReturnStatusInvalid) {
-        if (result.GetOutputData().empty())
+        if (result.GetOutputString().empty())
           result.SetStatus(eReturnStatusSuccessFinishNoResult);
         else
           result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -1205,7 +1205,7 @@ protected:
     } else {
       // Don't change the status if the command already set it...
       if (result.GetStatus() == eReturnStatusInvalid) {
-        if (result.GetOutputData().empty())
+        if (result.GetOutputString().empty())
           result.SetStatus(eReturnStatusSuccessFinishNoResult);
         else
           result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -2137,7 +2137,7 @@ protected:
     } else {
       // Don't change the status if the command already set it...
       if (result.GetStatus() == eReturnStatusInvalid) {
-        if (result.GetOutputData().empty())
+        if (result.GetOutputString().empty())
           result.SetStatus(eReturnStatusSuccessFinishNoResult);
         else
           result.SetStatus(eReturnStatusSuccessFinishResult);

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -784,9 +784,10 @@ void Debugger::Destroy(DebuggerSP &debugger_sp) {
     CommandReturnObject result(debugger_sp->GetUseColor());
     cmd_interpreter.SaveTranscript(result);
     if (result.Succeeded())
-      (*debugger_sp->GetAsyncOutputStream()) << result.GetOutputData() << '\n';
+      (*debugger_sp->GetAsyncOutputStream())
+          << result.GetOutputString() << '\n';
     else
-      (*debugger_sp->GetAsyncErrorStream()) << result.GetErrorData() << '\n';
+      (*debugger_sp->GetAsyncErrorStream()) << result.GetErrorString() << '\n';
   }
 
   debugger_sp->Clear();

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2094,11 +2094,11 @@ bool CommandInterpreter::HandleCommand(const char *command_line,
   // used instead of `GetSaveTrasncript()`. This is because the latter will
   // fail when the command is "settings set interpreter.save-transcript true".
   if (transcript_item) {
-    m_transcript_stream << result.GetOutputData();
-    m_transcript_stream << result.GetErrorData();
+    m_transcript_stream << result.GetOutputString();
+    m_transcript_stream << result.GetErrorString();
 
-    transcript_item->AddStringItem("output", result.GetOutputData());
-    transcript_item->AddStringItem("error", result.GetErrorData());
+    transcript_item->AddStringItem("output", result.GetOutputString());
+    transcript_item->AddStringItem("error", result.GetErrorString());
     transcript_item->AddFloatItem("durationInSeconds",
                                   execute_time.get().count());
   }
@@ -2632,11 +2632,11 @@ void CommandInterpreter::HandleCommands(const StringList &commands,
 
     if (options.GetPrintResults()) {
       if (tmp_result.Succeeded())
-        result.AppendMessage(tmp_result.GetOutputData());
+        result.AppendMessage(tmp_result.GetOutputString());
     }
 
     if (!success || !tmp_result.Succeeded()) {
-      llvm::StringRef error_msg = tmp_result.GetErrorData();
+      llvm::StringRef error_msg = tmp_result.GetErrorString();
       if (error_msg.empty())
         error_msg = "<unknown error>.\n";
       if (options.GetStopOnError()) {
@@ -3192,7 +3192,7 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
       unsigned prompt_len = m_debugger.GetPrompt().size();
       if (auto indent = result.GetDiagnosticIndent()) {
         llvm::StringRef diags =
-            result.GetInlineDiagnosticsData(prompt_len + *indent);
+            result.GetInlineDiagnosticString(prompt_len + *indent);
         PrintCommandOutput(io_handler, diags, true);
       }
     }
@@ -3201,13 +3201,13 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
     GetProcessOutput();
 
     if (!result.GetImmediateOutputStream()) {
-      llvm::StringRef output = result.GetOutputData();
+      llvm::StringRef output = result.GetOutputString();
       PrintCommandOutput(io_handler, output, true);
     }
 
     // Now emit the command error text from the command we just executed.
     if (!result.GetImmediateErrorStream()) {
-      llvm::StringRef error = result.GetErrorData();
+      llvm::StringRef error = result.GetErrorString();
       PrintCommandOutput(io_handler, error, false);
     }
   }

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -123,7 +123,8 @@ void CommandReturnObject::SetError(llvm::Error error) {
   }
 }
 
-llvm::StringRef CommandReturnObject::GetInlineDiagnosticsData(unsigned indent) {
+llvm::StringRef
+CommandReturnObject::GetInlineDiagnosticString(unsigned indent) {
   RenderDiagnosticDetails(m_diag_stream, indent, true, m_diagnostics);
   // Duplex the diagnostics to the secondary stream (but not inlined).
   if (auto stream_sp = m_err_stream.GetStreamAtIndex(eStreamStringIndex))
@@ -134,7 +135,7 @@ llvm::StringRef CommandReturnObject::GetInlineDiagnosticsData(unsigned indent) {
   return m_diag_stream.GetString();
 }
 
-llvm::StringRef CommandReturnObject::GetErrorData() {
+llvm::StringRef CommandReturnObject::GetErrorString() {
   // Diagnostics haven't been fetched; render them now (not inlined).
   if (!m_diagnostics.empty()) {
     RenderDiagnosticDetails(GetErrorStream(), std::nullopt, false,

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -439,7 +439,7 @@ int opts::breakpoint::evaluateBreakpoints(Debugger &Dbg) {
     CommandReturnObject Result(/*colors*/ false);
     if (!Dbg.GetCommandInterpreter().HandleCommand(
             Command.c_str(), /*add_to_history*/ eLazyBoolNo, Result)) {
-      P.formatLine("Failed: {0}", Result.GetErrorData());
+      P.formatLine("Failed: {0}", Result.GetErrorString());
       HadErrors = 1;
       continue;
     }
@@ -1161,7 +1161,7 @@ int opts::irmemorymap::evaluateMemoryMapCommands(Debugger &Dbg) {
     return CI.HandleCommand(Cmd, eLazyBoolNo, Result);
   };
   if (!IssueCmd("b main") || !IssueCmd("run")) {
-    outs() << formatv("Failed: {0}\n", Result.GetErrorData());
+    outs() << formatv("Failed: {0}\n", Result.GetErrorString());
     exit(1);
   }
 


### PR DESCRIPTION
In a later commit, I want to add a method to access diagnostics as actual structured data, which will make these function names rather confusing.