### PR TITLE
[clang-tidy] rewrite matchers in modernize-use-starts-ends-with

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseStartsEndsWithCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStartsEndsWithCheck.cpp
@@ -12,7 +12,6 @@
 #include "../utils/Matchers.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Lex/Lexer.h"
-#include "llvm/ADT/ArrayRef.h"
 
 #include <string>
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-starts-ends-with.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-starts-ends-with.cpp
@@ -150,8 +150,8 @@ void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
   // CHECK-FIXES: puv.starts_with("a");
 
   puvf.find("a") == 0;
-  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: puvf.starts_with("a");
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use startsWith
+  // CHECK-FIXES: puvf.startsWith("a");
 
   // Here, the subclass has startsWith, the superclass has starts_with.
   // We prefer the version from the subclass.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-starts-ends-with.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-starts-ends-with.cpp
@@ -32,14 +32,9 @@ struct prefer_underscore_version_flip {
   size_t find(const char *s, size_t pos = 0) const;
 };
 
-struct prefer_underscore_version_inherit : public string_like {
-  bool startsWith(const char *s) const;
-};
-
 void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
           string_like sl, string_like_camel slc, prefer_underscore_version puv,
-          prefer_underscore_version_flip puvf,
-          prefer_underscore_version_inherit puvi) {
+          prefer_underscore_version_flip puvf) {
   s.find("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with instead of find() == 0
   // CHECK-FIXES: s.starts_with("a");
@@ -150,14 +145,8 @@ void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
   // CHECK-FIXES: puv.starts_with("a");
 
   puvf.find("a") == 0;
-  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use startsWith
-  // CHECK-FIXES: puvf.startsWith("a");
-
-  // Here, the subclass has startsWith, the superclass has starts_with.
-  // We prefer the version from the subclass.
-  puvi.find("a") == 0;
-  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use startsWith
-  // CHECK-FIXES: puvi.startsWith("a");
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
+  // CHECK-FIXES: puvf.starts_with("a");
 
   s.compare(0, 1, "a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with instead of compare() == 0


### PR DESCRIPTION
Rewrite the AST matchers for slightly more composability. 
Furthermore, check that the `starts_with` and `ends_with`
functions return a `bool`.
There is one behavioral change, in that the methods of a class (and
transitive classes) are searched once for a matching
`starts_with`/`ends_with` function, picking the first it can find.
Previously, the matchers would try to find `starts_with`, then
`startsWith`, and finally, `startswith`. Now, the first of the three that
is encountered will be the matched method.
