### PR TITLE
[libc++] Disallow std::prev(non_cpp17_bidi_iterator)

### DIFF
--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -39,6 +39,9 @@ prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n) 
   return __x;
 }
 
+// LWG 3197
+// It is unclear what the implications of "BidirectionalIterator" in the standard are.
+// However, calling std::prev(non-bidi-iterator) is obviously an error and we should catch it at compile time.
 template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _InputIter prev(_InputIter __it) {
   static_assert(__has_bidirectional_iterator_category<_InputIter>::value,

--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -39,10 +39,10 @@ prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n) 
   return __x;
 }
 
-template <class _BidirectionalIterator,
-          __enable_if_t<__has_bidirectional_iterator_category<_BidirectionalIterator>::value, int> = 0>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _BidirectionalIterator
-prev(_BidirectionalIterator __it) {
+template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _InputIter prev(_InputIter __it) {
+  static_assert(__has_bidirectional_iterator_category<_InputIter>::value,
+                "Attempt to prev(it) with a non-bidirectional iterator");
   return std::prev(std::move(__it), 1);
 }
 

--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -23,6 +23,9 @@
 #  pragma GCC system_header
 #endif
 
+_LIBCPP_PUSH_MACROS
+#include <__undef_macros>
+
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
@@ -77,5 +80,7 @@ inline constexpr auto prev = __prev{};
 #endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD
+
+_LIBCPP_POP_MACROS
 
 #endif // _LIBCPP___ITERATOR_PREV_H

--- a/libcxx/include/__iterator/prev.h
+++ b/libcxx/include/__iterator/prev.h
@@ -17,6 +17,7 @@
 #include <__iterator/incrementable_traits.h>
 #include <__iterator/iterator_traits.h>
 #include <__type_traits/enable_if.h>
+#include <__utility/move.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -26,13 +27,20 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _InputIter
-prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n = 1) {
+prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n) {
   // Calling `advance` with a negative value on a non-bidirectional iterator is a no-op in the current implementation.
   // Note that this check duplicates the similar check in `std::advance`.
   _LIBCPP_ASSERT_PEDANTIC(__n <= 0 || __has_bidirectional_iterator_category<_InputIter>::value,
                           "Attempt to prev(it, n) with a positive n on a non-bidirectional iterator");
   std::advance(__x, -__n);
   return __x;
+}
+
+template <class _BidirectionalIterator,
+          __enable_if_t<__has_bidirectional_iterator_category<_BidirectionalIterator>::value, int> = 0>
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _BidirectionalIterator
+prev(_BidirectionalIterator __it) {
+  return std::prev(std::move(__it), 1);
 }
 
 #if _LIBCPP_STD_VER >= 20

--- a/libcxx/test/libcxx/iterators/iterator.primitives/iterator.operations/prev.verify.cpp
+++ b/libcxx/test/libcxx/iterators/iterator.primitives/iterator.operations/prev.verify.cpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// std::prev
+
+#include <iterator>
+#include "test_iterators.h"
+
+void test() {
+  int arr[] = {1, 2};
+  cpp17_input_iterator<int*> it(&arr[0]);
+  it = std::prev(it);
+  // expected-error-re@*:* {{static assertion failed due to requirement {{.*}}: Attempt to prev(it) with a non-bidirectional iterator}}
+}

--- a/libcxx/test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
@@ -18,21 +18,6 @@
 #include "test_macros.h"
 #include "test_iterators.h"
 
-template <class Iter>
-std::false_type prev_test(...);
-
-template <class Iter>
-decltype((void)std::prev(std::declval<Iter>()), std::true_type()) prev_test(int);
-
-template <class Iter>
-using CanPrev = decltype(prev_test<Iter>(0));
-
-static_assert(!CanPrev<cpp17_input_iterator<int*> >::value, "");
-static_assert(CanPrev<bidirectional_iterator<int*> >::value, "");
-#if TEST_STD_VER >= 20
-static_assert(!CanPrev<cpp20_random_access_iterator<int*> >::value);
-#endif
-
 template <class It>
 TEST_CONSTEXPR_CXX17 void
 check_prev_n(It it, typename std::iterator_traits<It>::difference_type n, It result)

--- a/libcxx/test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
@@ -22,7 +22,7 @@ template <class Iter>
 std::false_type prev_test(...);
 
 template <class Iter>
-decltype((void) std::prev(std::declval<Iter>()), std::true_type()) prev_test(int);
+decltype((void)std::prev(std::declval<Iter>()), std::true_type()) prev_test(int);
 
 template <class Iter>
 using CanPrev = decltype(prev_test<Iter>(0));
@@ -30,7 +30,7 @@ using CanPrev = decltype(prev_test<Iter>(0));
 static_assert(!CanPrev<cpp17_input_iterator<int*> >::value, "");
 static_assert(CanPrev<bidirectional_iterator<int*> >::value, "");
 #if TEST_STD_VER >= 20
-    static_assert(!CanPrev<cpp20_random_access_iterator<int*> >::value);
+static_assert(!CanPrev<cpp20_random_access_iterator<int*> >::value);
 #endif
 
 template <class It>

--- a/libcxx/test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
@@ -18,6 +18,21 @@
 #include "test_macros.h"
 #include "test_iterators.h"
 
+template <class Iter>
+std::false_type prev_test(...);
+
+template <class Iter>
+decltype((void) std::prev(std::declval<Iter>()), std::true_type()) prev_test(int);
+
+template <class Iter>
+using CanPrev = decltype(prev_test<Iter>(0));
+
+static_assert(!CanPrev<cpp17_input_iterator<int*> >::value, "");
+static_assert(CanPrev<bidirectional_iterator<int*> >::value, "");
+#if TEST_STD_VER >= 20
+    static_assert(!CanPrev<cpp20_random_access_iterator<int*> >::value);
+#endif
+
 template <class It>
 TEST_CONSTEXPR_CXX17 void
 check_prev_n(It it, typename std::iterator_traits<It>::difference_type n, It result)


### PR DESCRIPTION
The std::prev function appeared to work on non Cpp17BidirectionalIterators, however it behaved strangely by being the identity function. That was extremely misleading and potentially dangerous, since several recent iterators that are C++20 `bidirectional_iterator`s don't satisfy the Cpp17BidirectionalIterator named requirement. For example:

```
auto zv = std::views::zip(vec1, vec2);
auto it = zv.begin() + 5;
auto it2 = std::prev(it); // "it2" will be the same as "it",  instead of the previous one
```

Here, `zip_view::iterator` is a c++20 `random_access_iterator`, but it only satisfies the Cpp17InputIterator named requirement because its reference type is a proxy type. Hence `std::prev` would silently accept that iterator but it would do a no-op instead of going to the previous position.

This patch changes `std::prev` to produce an error at compile-time when instantiated with a type that is not a Cpp17BidirectionalIterator.

Fixes #109456