### PR TITLE
[mlir][arith] Fix type conversion in emulate-wide-int

### DIFF
--- a/mlir/lib/Dialect/Arith/Transforms/EmulateWideInt.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/EmulateWideInt.cpp
@@ -1081,7 +1081,7 @@ arith::WideIntEmulationConverter::WideIntEmulationConverter(
     if (width == 2 * maxIntWidth)
       return VectorType::get(2, IntegerType::get(ty.getContext(), maxIntWidth));
 
-    return std::nullopt;
+    return nullptr;
   });
 
   // Vector case.
@@ -1102,7 +1102,7 @@ arith::WideIntEmulationConverter::WideIntEmulationConverter(
                              IntegerType::get(ty.getContext(), maxIntWidth));
     }
 
-    return std::nullopt;
+    return nullptr;
   });
 
   // Function case.
@@ -1111,11 +1111,11 @@ arith::WideIntEmulationConverter::WideIntEmulationConverter(
     //   (i2N, i2N) -> i2N --> (vector<2xiN>, vector<2xiN>) -> vector<2xiN>
     SmallVector<Type> inputs;
     if (failed(convertTypes(ty.getInputs(), inputs)))
-      return std::nullopt;
+      return nullptr;
 
     SmallVector<Type> results;
     if (failed(convertTypes(ty.getResults(), results)))
-      return std::nullopt;
+      return nullptr;
 
     return FunctionType::get(ty.getContext(), inputs, results);
   });

--- a/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
+++ b/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
@@ -1,0 +1,43 @@
+// RUN: mlir-opt --arith-emulate-wide-int="widest-int-supported=32" \
+// RUN:   --split-input-file --verify-diagnostics %s
+
+// Make sure we do not crash on unsupported types.
+
+// Unsupported result type in `arith.extsi`.
+func.func @unsupported_result_integer(%arg0: i64) -> i64 {
+  // expected-error@+1 {{failed to legalize operation 'arith.extsi' that was explicitly marked illegal}}
+  %0 = arith.extsi %arg0: i64 to i128
+  %2 = arith.muli %0, %0 : i128
+  %3 = arith.trunci %2 : i128 to i64
+  return %3 : i64
+}
+
+// -----
+
+// Unsupported result type in `arith.extsi`.
+func.func @unsupported_result_vector(%arg0: vector<4xi64>) -> vector<4xi64> {
+  // expected-error@+1 {{failed to legalize operation 'arith.extsi' that was explicitly marked illegal}}
+  %0 = arith.extsi %arg0: vector<4xi64> to vector<4xi128>
+  %2 = arith.muli %0, %0 : vector<4xi128>
+  %3 = arith.trunci %2 : vector<4xi128> to vector<4xi64>
+  return %3 : vector<4xi64>
+}
+
+// -----
+
+// Unsupported function return type.
+// expected-error@+1 {{failed to legalize operation 'func.func' that was explicitly marked illegal}}
+func.func @unsupported_return_type(%arg0: vector<4xi64>) -> vector<4xi128> {
+  %0 = arith.extsi %arg0: vector<4xi64> to vector<4xi128>
+  return %0 : vector<4xi128>
+}
+
+// -----
+
+// Unsupported function argument type.
+// expected-error@+1 {{failed to legalize operation 'func.func' that was explicitly marked illegal}}
+func.func @unsupported_return_type(%arg0: vector<4xi128>) -> vector<4xi64> {
+  %0 = arith.trunci %arg0: vector<4xi128> to vector<4xi64>
+  return %0 : vector<4xi64>
+}
+

--- a/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
+++ b/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
@@ -36,7 +36,7 @@ func.func @unsupported_return_type(%arg0: vector<4xi64>) -> vector<4xi128> {
 
 // Unsupported function argument type.
 // expected-error@+1 {{failed to legalize operation 'func.func' that was explicitly marked illegal}}
-func.func @unsupported_return_type(%arg0: vector<4xi128>) -> vector<4xi64> {
+func.func @unsupported_argument_type(%arg0: vector<4xi128>) -> vector<4xi64> {
   %0 = arith.trunci %arg0: vector<4xi128> to vector<4xi64>
   return %0 : vector<4xi64>
 }


### PR DESCRIPTION
Use `nullptr` to indicate that type conversion failed and no fallback conversion should be attempted.

Fixes: https://github.com/llvm/llvm-project/issues/108163