### PR TITLE
[lldb] Escape ? for zsh

### DIFF
--- a/lldb/source/Utility/Args.cpp
+++ b/lldb/source/Utility/Args.cpp
@@ -401,7 +401,7 @@ std::string Args::GetShellSafeArgument(const FileSpec &shell,
   static ShellDescriptor g_Shells[] = {{"bash", " '\"<>()&;"},
                                        {"fish", " '\"<>()&\\|;"},
                                        {"tcsh", " '\"<>()&;"},
-                                       {"zsh", " '\"<>()&;\\|"},
+                                       {"zsh", " '\"<>()&;\\|?"},
                                        {"sh", " '\"<>()&;"}};
 
   // safe minimal set

--- a/lldb/unittests/Utility/ArgsTest.cpp
+++ b/lldb/unittests/Utility/ArgsTest.cpp
@@ -292,8 +292,8 @@ TEST(ArgsTest, GetShellSafeArgument) {
   EXPECT_EQ(Args::GetShellSafeArgument(bash, "a\"b"), "a\\\"b");
 
   FileSpec zsh("/bin/zsh", FileSpec::Style::posix);
-  EXPECT_EQ(Args::GetShellSafeArgument(zsh, R"('";()<>&|\)"),
-            R"(\'\"\;\(\)\<\>\&\|\\)");
+  EXPECT_EQ(Args::GetShellSafeArgument(zsh, R"('"?;()<>&|\)"),
+            R"(\'\"\?\;\(\)\<\>\&\|\\)");
   // Normal characters and expressions that shouldn't be escaped.
   EXPECT_EQ(Args::GetShellSafeArgument(zsh, "aA$1*"), "aA$1*");
 


### PR DESCRIPTION
Previously on macOS with lldb-argdumper if you ran:

```
lldb -o r -- /tmp/foo "some arg?"
```

It would fail with this error:

```
error: shell expansion failed (reason: lldb-argdumper exited with error 1). consider launching with 'process launch'.
```

stderr is silenced here but the underlying error if you print it for
debugging is:

```
zsh: no matches found: ?
```

This change escapes the `?` so this argument works as expected.
