### PR TITLE
[rtsan] Introduce function-name-matches suppression

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_assertions.h
+++ b/compiler-rt/lib/rtsan/rtsan_assertions.h
@@ -28,10 +28,7 @@ void ExpectNotRealtime(Context &context, const DiagnosticsInfo &info,
   if (context.InRealtimeContext() && !context.IsBypassed()) {
     ScopedBypass sb{context};
 
-    if ((info.type == DiagnosticsInfoType::InterceptedCall &&
-         IsInterceptorSuppressed(info.func_name)) ||
-        (info.type == DiagnosticsInfoType::BlockingCall &&
-         IsBlockingFnSuppressed(info.func_name)))
+    if (IsFunctionSuppressed(info.func_name))
       return;
 
     __sanitizer::BufferedStackTrace stack;

--- a/compiler-rt/lib/rtsan/rtsan_assertions.h
+++ b/compiler-rt/lib/rtsan/rtsan_assertions.h
@@ -28,6 +28,12 @@ void ExpectNotRealtime(Context &context, const DiagnosticsInfo &info,
   if (context.InRealtimeContext() && !context.IsBypassed()) {
     ScopedBypass sb{context};
 
+    if ((info.type == DiagnosticsInfoType::InterceptedCall &&
+         IsInterceptorSuppressed(info.func_name)) ||
+        (info.type == DiagnosticsInfoType::BlockingCall &&
+         IsBlockingFnSuppressed(info.func_name)))
+      return;
+
     __sanitizer::BufferedStackTrace stack;
 
     // We use the unwind_on_fatal flag here because of precedent with other

--- a/compiler-rt/lib/rtsan/rtsan_checks.inc
+++ b/compiler-rt/lib/rtsan/rtsan_checks.inc
@@ -17,4 +17,4 @@
 // SummaryKind should be a string literal.
 
 RTSAN_CHECK(CallStackContains, "call-stack-contains")
-RTSAN_CHECK(FunctionNameIs, "function-name-is")
+RTSAN_CHECK(FunctionNameMatches, "function-name-matches")

--- a/compiler-rt/lib/rtsan/rtsan_checks.inc
+++ b/compiler-rt/lib/rtsan/rtsan_checks.inc
@@ -17,5 +17,4 @@
 // SummaryKind should be a string literal.
 
 RTSAN_CHECK(CallStackContains, "call-stack-contains")
-RTSAN_CHECK(InterceptedFnName, "intercepted-fn-name")
-RTSAN_CHECK(BlockingFnName, "blocking-fn-name")
+RTSAN_CHECK(FunctionNameIs, "function-name-is")

--- a/compiler-rt/lib/rtsan/rtsan_checks.inc
+++ b/compiler-rt/lib/rtsan/rtsan_checks.inc
@@ -17,3 +17,5 @@
 // SummaryKind should be a string literal.
 
 RTSAN_CHECK(CallStackContains, "call-stack-contains")
+RTSAN_CHECK(InterceptedFnName, "intercepted-fn-name")
+RTSAN_CHECK(BlockingFnName, "blocking-fn-name")

--- a/compiler-rt/lib/rtsan/rtsan_suppressions.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_suppressions.cpp
@@ -97,7 +97,7 @@ bool __rtsan::IsFunctionSuppressed(const char *function_name) {
   if (suppression_ctx == nullptr)
     return false;
 
-  const char *flag_name = ConvertTypeToFlagName(ErrorType::FunctionNameIs);
+  const char *flag_name = ConvertTypeToFlagName(ErrorType::FunctionNameMatches);
 
   if (!suppression_ctx->HasSuppressionType(flag_name))
     return false;

--- a/compiler-rt/lib/rtsan/rtsan_suppressions.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_suppressions.cpp
@@ -92,3 +92,25 @@ bool __rtsan::IsStackTraceSuppressed(const StackTrace &stack) {
   }
   return false;
 }
+
+static bool IsFunctionSuppressed(const char *interceptor_name,
+                                 const char *flag_name) {
+  if (suppression_ctx == nullptr)
+    return false;
+
+  if (!suppression_ctx->HasSuppressionType(flag_name))
+    return false;
+
+  Suppression *s;
+  return suppression_ctx->Match(interceptor_name, flag_name, &s);
+}
+
+bool __rtsan::IsInterceptorSuppressed(const char *interceptor_name) {
+  return IsFunctionSuppressed(
+      interceptor_name, ConvertTypeToFlagName(ErrorType::InterceptedFnName));
+}
+
+bool __rtsan::IsBlockingFnSuppressed(const char *blocking_fn_name) {
+  return IsFunctionSuppressed(blocking_fn_name,
+                              ConvertTypeToFlagName(ErrorType::BlockingFnName));
+}

--- a/compiler-rt/lib/rtsan/rtsan_suppressions.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_suppressions.cpp
@@ -93,24 +93,15 @@ bool __rtsan::IsStackTraceSuppressed(const StackTrace &stack) {
   return false;
 }
 
-static bool IsFunctionSuppressed(const char *interceptor_name,
-                                 const char *flag_name) {
+bool __rtsan::IsFunctionSuppressed(const char *function_name) {
   if (suppression_ctx == nullptr)
     return false;
+
+  const char *flag_name = ConvertTypeToFlagName(ErrorType::FunctionNameIs);
 
   if (!suppression_ctx->HasSuppressionType(flag_name))
     return false;
 
   Suppression *s;
-  return suppression_ctx->Match(interceptor_name, flag_name, &s);
-}
-
-bool __rtsan::IsInterceptorSuppressed(const char *interceptor_name) {
-  return IsFunctionSuppressed(
-      interceptor_name, ConvertTypeToFlagName(ErrorType::InterceptedFnName));
-}
-
-bool __rtsan::IsBlockingFnSuppressed(const char *blocking_fn_name) {
-  return IsFunctionSuppressed(blocking_fn_name,
-                              ConvertTypeToFlagName(ErrorType::BlockingFnName));
+  return suppression_ctx->Match(function_name, flag_name, &s);
 }

--- a/compiler-rt/lib/rtsan/rtsan_suppressions.h
+++ b/compiler-rt/lib/rtsan/rtsan_suppressions.h
@@ -18,7 +18,6 @@ namespace __rtsan {
 
 void InitializeSuppressions();
 bool IsStackTraceSuppressed(const __sanitizer::StackTrace &stack);
-bool IsInterceptorSuppressed(const char *interceptor_name);
-bool IsBlockingFnSuppressed(const char *blocking_fn_name);
+bool IsFunctionSuppressed(const char *function_name);
 
 } // namespace __rtsan

--- a/compiler-rt/lib/rtsan/rtsan_suppressions.h
+++ b/compiler-rt/lib/rtsan/rtsan_suppressions.h
@@ -18,5 +18,7 @@ namespace __rtsan {
 
 void InitializeSuppressions();
 bool IsStackTraceSuppressed(const __sanitizer::StackTrace &stack);
+bool IsInterceptorSuppressed(const char *interceptor_name);
+bool IsBlockingFnSuppressed(const char *blocking_fn_name);
 
 } // namespace __rtsan

--- a/compiler-rt/test/rtsan/stack_suppressions.cpp
+++ b/compiler-rt/test/rtsan/stack_suppressions.cpp
@@ -36,8 +36,8 @@ void BlockFunc() [[clang::blocking]] {
 void *process() [[clang::nonblocking]] {
   void *ptr = MallocViolation(); // Suppressed call-stack-contains
   VectorViolations();            // Suppressed call-stack-contains with regex
-  BlockFunc();                   // Suppressed function-name-is
-  free(ptr);                     // Suppressed function-name-is
+  BlockFunc();                   // Suppressed function-name-matches
+  free(ptr);                     // Suppressed function-name-matches
 
   // This is the one that should abort the program
   // Everything else is suppressed

--- a/compiler-rt/test/rtsan/stack_suppressions.cpp
+++ b/compiler-rt/test/rtsan/stack_suppressions.cpp
@@ -36,8 +36,8 @@ void BlockFunc() [[clang::blocking]] {
 void *process() [[clang::nonblocking]] {
   void *ptr = MallocViolation(); // Suppressed call-stack-contains
   VectorViolations();            // Suppressed call-stack-contains with regex
-  BlockFunc();                   // Suppressed blocking-fn-name
-  free(ptr);                     // Suppressed intercepted-fn-name
+  BlockFunc();                   // Suppressed function-name-is
+  free(ptr);                     // Suppressed function-name-is
 
   // This is the one that should abort the program
   // Everything else is suppressed

--- a/compiler-rt/test/rtsan/stack_suppressions.cpp.supp
+++ b/compiler-rt/test/rtsan/stack_suppressions.cpp.supp
@@ -1,5 +1,5 @@
 call-stack-contains:MallocViolation
 call-stack-contains:std::*vector
 
-function-name-is:free
-function-name-is:BlockFunc
+function-name-matches:free
+function-name-matches:Block*

--- a/compiler-rt/test/rtsan/stack_suppressions.cpp.supp
+++ b/compiler-rt/test/rtsan/stack_suppressions.cpp.supp
@@ -1,4 +1,6 @@
 call-stack-contains:MallocViolation
 call-stack-contains:std::*vector
-call-stack-contains:free
-call-stack-contains:BlockFunc
+
+intercepted-fn-name:free
+
+blocking-fn-name:BlockFunc

--- a/compiler-rt/test/rtsan/stack_suppressions.cpp.supp
+++ b/compiler-rt/test/rtsan/stack_suppressions.cpp.supp
@@ -1,6 +1,5 @@
 call-stack-contains:MallocViolation
 call-stack-contains:std::*vector
 
-intercepted-fn-name:free
-
-blocking-fn-name:BlockFunc
+function-name-is:free
+function-name-is:BlockFunc


### PR DESCRIPTION
Introduces a new types of suppression:

1. function-name-matches - allows users to disable `malloc`, `free`, `pthread_mutex_lock` or similar. This could be helpful if a user thinks these are real-time safe on their OS. Also allows disabling of any function marked [[blocking]].

This is useful as a **more performant "early outs" compared to the `call-stack-contains` suppression**. `call-stack-contains` is inherently VERY costly, needing to inspect every frame of every stack for a matching string. This new suppression has an early out before we unwind the stack.
