### PR TITLE
[lldb] Expose structured command diagnostics via the SBAPI.

### DIFF
--- a/lldb/include/lldb/API/SBCommandReturnObject.h
+++ b/lldb/include/lldb/API/SBCommandReturnObject.h
@@ -45,6 +45,7 @@ public:
   const char *GetOutput();
 
   const char *GetError();
+  SBStructuredData GetErrorData();
 
 #ifndef SWIG
   LLDB_DEPRECATED_FIXME("Use PutOutput(SBFile) or PutOutput(FileSP)",

--- a/lldb/include/lldb/API/SBStructuredData.h
+++ b/lldb/include/lldb/API/SBStructuredData.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_API_SBSTRUCTUREDDATA_H
 #define LLDB_API_SBSTRUCTUREDDATA_H
 
+#include "lldb/API/SBCommandReturnObject.h"
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBModule.h"
 #include "lldb/API/SBScriptObject.h"
@@ -110,6 +111,7 @@ public:
 
 protected:
   friend class SBAttachInfo;
+  friend class SBCommandReturnObject;
   friend class SBLaunchInfo;
   friend class SBDebugger;
   friend class SBTarget;

--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -13,6 +13,7 @@
 #include "lldb/Utility/DiagnosticsRendering.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StreamTee.h"
+#include "lldb/Utility/StructuredData.h"
 #include "lldb/lldb-private.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -31,7 +32,7 @@ public:
   ~CommandReturnObject() = default;
 
   /// Format any inline diagnostics with an indentation of \c indent.
-  llvm::StringRef GetInlineDiagnosticString(unsigned indent);
+  std::string GetInlineDiagnosticString(unsigned indent);
 
   llvm::StringRef GetOutputString() {
     lldb::StreamSP stream_sp(m_out_stream.GetStreamAtIndex(eStreamStringIndex));
@@ -40,7 +41,13 @@ public:
     return llvm::StringRef();
   }
 
-  llvm::StringRef GetErrorString();
+  /// Return the errors as a string.
+  ///
+  /// If \c with_diagnostics is true, all diagnostics are also
+  /// rendered into the string. Otherwise the expectation is that they
+  /// are fetched with \ref GetInlineDiagnosticString().
+  std::string GetErrorString(bool with_diagnostics = true);
+  StructuredData::ObjectSP GetErrorData();
 
   Stream &GetOutputStream() {
     // Make sure we at least have our normal string stream output stream
@@ -168,7 +175,6 @@ private:
   StreamTee m_out_stream;
   StreamTee m_err_stream;
   std::vector<DiagnosticDetail> m_diagnostics;
-  StreamString m_diag_stream;
   std::optional<uint16_t> m_diagnostic_indent;
 
   lldb::ReturnStatus m_status = lldb::eReturnStatusStarted;
@@ -178,6 +184,7 @@ private:
 
   /// If true, then the input handle from the debugger will be hooked up.
   bool m_interactive = true;
+  bool m_colors;
 };
 
 } // namespace lldb_private

--- a/lldb/source/API/SBCommandReturnObject.cpp
+++ b/lldb/source/API/SBCommandReturnObject.cpp
@@ -11,6 +11,8 @@
 #include "lldb/API/SBError.h"
 #include "lldb/API/SBFile.h"
 #include "lldb/API/SBStream.h"
+#include "lldb/API/SBStructuredData.h"
+#include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Instrumentation.h"
@@ -94,6 +96,15 @@ const char *SBCommandReturnObject::GetError() {
 
   ConstString output(ref().GetErrorString());
   return output.AsCString(/*value_if_empty*/ "");
+}
+
+SBStructuredData SBCommandReturnObject::GetErrorData() {
+  LLDB_INSTRUMENT_VA(this);
+
+  StructuredData::ObjectSP data(ref().GetErrorData());
+  SBStructuredData sb_data;
+  sb_data.m_impl_up->SetObjectSP(data);
+  return sb_data;
 }
 
 size_t SBCommandReturnObject::GetOutputSize() {

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -194,7 +194,7 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     // Record the position of the expression in the command.
     std::optional<uint16_t> indent;
     if (fixed_expression.empty()) {
-      size_t pos = m_original_command.find(expr);
+      size_t pos = m_original_command.rfind(expr);
       if (pos != llvm::StringRef::npos)
         indent = pos;
     }

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -485,35 +485,8 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
 
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
-        // Retrieve the diagnostics.
-        std::vector<DiagnosticDetail> details;
-        llvm::consumeError(llvm::handleErrors(
-            result_valobj_sp->GetError().ToError(),
-            [&](DiagnosticError &error) { details = error.GetDetails(); }));
-        // Find the position of the expression in the command.
-        std::optional<uint16_t> expr_pos;
-        size_t nchar = m_original_command.find(expr);
-        if (nchar != std::string::npos)
-          expr_pos = nchar + GetDebugger().GetPrompt().size();
-
-        if (!details.empty()) {
-          bool show_inline =
-              GetDebugger().GetShowInlineDiagnostics() && !expr.contains('\n');
-          RenderDiagnosticDetails(error_stream, expr_pos, show_inline, details);
-        } else {
-          const char *error_cstr = result_valobj_sp->GetError().AsCString();
-          llvm::StringRef error(error_cstr);
-          if (!error.empty()) {
-            if (!error.starts_with("error:"))
-              error_stream << "error: ";
-            error_stream << error;
-            if (!error.ends_with('\n'))
-              error_stream.EOL();
-          } else {
-            error_stream << "error: unknown error\n";
-          }
-        }
         result.SetStatus(eReturnStatusFailed);
+        result.SetError(result_valobj_sp->GetError().ToError());
       }
     }
   } else {
@@ -533,10 +506,13 @@ void CommandObjectExpression::IOHandlerInputComplete(IOHandler &io_handler,
   CommandReturnObject return_obj(
       GetCommandInterpreter().GetDebugger().GetUseColor());
   EvaluateExpression(line.c_str(), *output_sp, *error_sp, return_obj);
+
   if (output_sp)
     output_sp->Flush();
-  if (error_sp)
+  if (error_sp) {
+    *error_sp << return_obj.GetErrorString();
     error_sp->Flush();
+  }
 }
 
 bool CommandObjectExpression::IOHandlerIsInputComplete(IOHandler &io_handler,
@@ -678,6 +654,14 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
       return;
     }
   }
+
+  // Previously the indent was set up for diagnosing command line
+  // parsing errors. Now point it to the expression.
+  std::optional<uint16_t> indent;
+  size_t pos = m_original_command.rfind(expr);
+  if (pos != llvm::StringRef::npos)
+    indent = pos;
+  result.SetDiagnosticIndent(indent);
 
   Target &target = GetTarget();
   if (EvaluateExpression(expr, result.GetOutputStream(),

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2636,20 +2636,18 @@ void CommandInterpreter::HandleCommands(const StringList &commands,
     }
 
     if (!success || !tmp_result.Succeeded()) {
-      llvm::StringRef error_msg = tmp_result.GetErrorString();
+      std::string error_msg = tmp_result.GetErrorString();
       if (error_msg.empty())
         error_msg = "<unknown error>.\n";
       if (options.GetStopOnError()) {
-        result.AppendErrorWithFormat(
-            "Aborting reading of commands after command #%" PRIu64
-            ": '%s' failed with %s",
-            (uint64_t)idx, cmd, error_msg.str().c_str());
+        result.AppendErrorWithFormatv("Aborting reading of commands after "
+                                      "command #{0}: '{1}' failed with {2}",
+                                      (uint64_t)idx, cmd, error_msg);
         m_debugger.SetAsyncExecution(old_async_execution);
         return;
       } else if (options.GetPrintResults()) {
-        result.AppendMessageWithFormat(
-            "Command #%" PRIu64 " '%s' failed with %s", (uint64_t)idx + 1, cmd,
-            error_msg.str().c_str());
+        result.AppendMessageWithFormatv("Command #{0} '{1}' failed with {2}",
+                                        (uint64_t)idx + 1, cmd, error_msg);
       }
     }
 
@@ -3187,11 +3185,12 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
        io_handler.GetFlags().Test(eHandleCommandFlagPrintResult)) ||
       io_handler.GetFlags().Test(eHandleCommandFlagPrintErrors)) {
     // Display any inline diagnostics first.
-    if (!result.GetImmediateErrorStream() &&
-        GetDebugger().GetShowInlineDiagnostics()) {
+    const bool inline_diagnostics = !result.GetImmediateErrorStream() &&
+                                    GetDebugger().GetShowInlineDiagnostics();
+    if (inline_diagnostics) {
       unsigned prompt_len = m_debugger.GetPrompt().size();
       if (auto indent = result.GetDiagnosticIndent()) {
-        llvm::StringRef diags =
+        std::string diags =
             result.GetInlineDiagnosticString(prompt_len + *indent);
         PrintCommandOutput(io_handler, diags, true);
       }
@@ -3207,7 +3206,7 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
 
     // Now emit the command error text from the command we just executed.
     if (!result.GetImmediateErrorStream()) {
-      llvm::StringRef error = result.GetErrorString();
+      std::string error = result.GetErrorString(!inline_diagnostics);
       PrintCommandOutput(io_handler, error, false);
     }
   }

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -184,53 +184,44 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
         # the first argument are probably stable enough that this test can check for them.
         self.assertIn("void NSLog(NSString *format", value.GetError().GetCString())
 
-    def test_command_expr_formatting(self):
-        """Test that the source and caret positions LLDB prints are correct"""
+    def test_command_expr_sbdata(self):
+        """Test the structured diagnostics data"""
         self.build()
 
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "// Break here", self.main_source_spec
         )
-        frame = thread.GetFrameAtIndex(0)
-        self.expect("settings set show-inline-diagnostics true")
+        interp = self.dbg.GetCommandInterpreter()
+        cro = lldb.SBCommandReturnObject()
+        interp.HandleCommand("expression -- a+b", cro)
 
-        def check(input_ref):
-            self.expect(input_ref[0], error=True, substrs=input_ref[1:])
+        diags = cro.GetErrorData()
+        # Version.
+        version = diags.GetValueForKey("version")
+        self.assertEqual(version.GetIntegerValue(), 1)
 
-        check(
-            [
-                "expression -- a+b",
-                "              ^ ^",
-                "              | error: use of undeclared identifier 'b'",
-                "              error: use of undeclared identifier 'a'",
-            ]
-        )
+        details = diags.GetValueForKey("details")
 
-        check(
-            [
-                "expr -- a",
-                "        ^",
-                "        error: use of undeclared identifier 'a'",
-            ]
-        )
-        check(
-            [
-                "expr -i 0 -o 0 -- a",
-                "                  ^",
-                "                  error: use of undeclared identifier 'a'",
-            ]
-        )
+        # Detail 1/2: undeclared 'a'
+        diag = details.GetItemAtIndex(0)
 
-        self.expect(
-            "expression --top-level -- template<typename T> T FOO(T x) { return x/2;}"
-        )
-        check(
-            [
-                'expression -- FOO("")',
-                "              ^",
-                "              note: in instantiation of function template specialization 'FOO<const char *>' requested here",
-                "error: <user expression",
-                "invalid operands to binary expression",
-            ]
-        )
-        check(["expression --\na\n+\nb", "error: <user", "a", "error: <user", "b"])
+        severity = diag.GetValueForKey("severity")
+        message = diag.GetValueForKey("message")
+        rendered = diag.GetValueForKey("rendered")
+        sloc = diag.GetValueForKey("source_location")
+        filename = sloc.GetValueForKey("file")
+        hidden = sloc.GetValueForKey("hidden")
+        in_user_input = sloc.GetValueForKey("in_user_input")
+
+        self.assertEqual(str(severity), "error")
+        self.assertIn("undeclared identifier 'a'", str(message))
+        # The rendered string should contain the source file.
+        self.assertIn("user expression", str(rendered))
+        self.assertIn("user expression", str(filename))
+        self.assertFalse(hidden.GetBooleanValue())
+        self.assertTrue(in_user_input.GetBooleanValue())
+
+        # Detail 1/2: undeclared 'b'
+        diag = details.GetItemAtIndex(1)
+        message = diag.GetValueForKey("message")
+        self.assertIn("undeclared identifier 'b'", str(message))

--- a/lldb/test/Shell/Commands/Inputs/multiline-expr.txt
+++ b/lldb/test/Shell/Commands/Inputs/multiline-expr.txt
@@ -1,0 +1,6 @@
+expression --
+a
++
+b
+
+quit

--- a/lldb/test/Shell/Commands/command-expr-diagnostics.test
+++ b/lldb/test/Shell/Commands/command-expr-diagnostics.test
@@ -1,0 +1,32 @@
+# RUN: echo quit | %lldb -o "expression a+b" \
+# RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK1
+#            (lldb) expression a+b
+# CHECK1:{{^                  \^ \^}}
+# CHECK1: {{^                  | error: use of undeclared identifier 'b'}}
+# CHECK1: {{^                  error: use of undeclared identifier 'a'}}
+
+# RUN: echo quit | %lldb -o "expr a" \
+# RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK2
+#            (lldb) expr a 
+# CHECK2:{{^            \^}}
+
+# RUN: echo quit | %lldb -o "expr -i 0 -o 0 -- a" \
+# RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK3
+#            (lldb) expr -i 0 -o 0 -- a
+# CHECK3:{{^                         \^}}
+# CHECK3: {{^                         error: use of undeclared identifier 'a'}}
+
+# RUN: echo "int main(){return 0;}">%t.c
+# RUN: %clang_host %t.c -o %t.exe
+# RUN: echo quit | %lldb %t.exe -o "b main" -o r -o \
+# RUN: "expr --top-level -- template<typename T> T FOO(T x) { return x/2;}" -o \
+# RUN: "expression -- FOO(\"\")" 2>&1 | FileCheck %s --check-prefix=CHECK4
+#            (lldb) expression -- FOO("")
+# CHECK4:{{^                     \^}}
+# CHECK4: {{^                     note: in instantiation of function template}}
+# CHECK4: error: <user expression
+
+# RUN: echo expression --\na\n+\nb
+# RUN: cat %S/Inputs/multiline-expr.txt | %lldb 2>&1 | FileCheck %s --strict-whitespace --check-prefix=CHECK5
+# CHECK5: error: <user{{.*}}a
+# CHECK5: error: <user{{.*}}b


### PR DESCRIPTION
This allows IDEs to render LLDB expression diagnostics to their liking without relying on characterprecise ASCII art from LLDB. It is exposed as a versioned SBStructuredData object, since it is expected that this may need to be tweaked based on actual usage.