### PR TITLE
[clang] Check null TypeSourceInfo in CreateUnaryExprOrTypeTraitExpr

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -505,6 +505,8 @@ Bug Fixes to C++ Support
 - Fix a crash when parsing a pseudo destructor involving an invalid type. (#GH111460)
 - Fixed an assertion failure when invoking recovery call expressions with explicit attributes
   and undeclared templates. (#GH107047, #GH49093)
+- Fixed a compiler crash that occurred when processing malformed code involving `sizeof` with
+  an invalid type argument. (#GH111594)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -4629,6 +4629,9 @@ ExprResult Sema::CreateUnaryExprOrTypeTraitExpr(TypeSourceInfo *TInfo,
       TInfo->getType()->isVariablyModifiedType())
     TInfo = TransformToPotentiallyEvaluated(TInfo);
 
+  if (!TInfo)
+    return ExprError();
+
   // C99 6.5.3.4p4: the type (an unsigned integer type) is size_t.
   return new (Context) UnaryExprOrTypeTraitExpr(
       ExprKind, TInfo, Context.getSizeType(), OpLoc, R.getEnd());

--- a/clang/test/SemaCXX/unary-expr-or-type-trait-invalid.cpp
+++ b/clang/test/SemaCXX/unary-expr-or-type-trait-invalid.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wno-unused-value %s
+//
+// Note: This test is ensure the code does not cause a crash as previously
+// reported in (#GH111594). The specific diagnostics are unimportant.
+
+a() {struct b c (sizeof(b * [({ {tree->d* next)} 0
+
+// expected-error@6 0+{{}}
+// expected-error@11 0+{{}}
+// expected-note@6 0+{{}}
+


### PR DESCRIPTION
Fixes #111594. The crash is caused by the following call
https://github.com/llvm/llvm-project/blob/main/clang/lib/AST/ComputeDependence.cpp#L81-L82

We already check for a null TypeInfo when creating a UnaryExprOrTypeTraitExpr here
https://github.com/llvm/llvm-project/blob/main/clang/lib/Sema/SemaExpr.cpp#L4616-L4617

but the following lines can, and in the case of the code in the issue, nullify the TypeInfo
https://github.com/llvm/llvm-project/blob/main/clang/lib/Sema/SemaExpr.cpp#L4616-L4617

Thus, adding the additional check for nullptr prevents the erroneous memory access.

@shafik Thoughts? Thanks
