### PR TITLE
[clang-tidy][readability-identifier-naming] Support namespace aliases

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -1135,6 +1135,9 @@ StyleKind IdentifierNamingCheck::findStyleKind(
   if (isa<TypeAliasDecl>(D) && NamingStyles[SK_TypeAlias])
     return SK_TypeAlias;
 
+  if (isa<NamespaceAliasDecl>(D) && NamingStyles[SK_Namespace])
+    return SK_Namespace;
+
   if (const auto *Decl = dyn_cast<NamespaceDecl>(D)) {
     if (Decl->isAnonymousNamespace())
       return SK_Invalid;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -242,7 +242,7 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.
 
-- Improved :doc:`readability-readability-identifier-naming
+- Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/readability-identifier-naming>` check support
   ``namespace`` aliases.
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -242,6 +242,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.
 
+- Improved :doc:`readability-readability-identifier-naming
+  <clang-tidy/checks/readability/readability-identifier-naming>` check support
+  ``namespace`` aliases.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -243,8 +243,8 @@ Changes in existing checks
   remove `->`, when redundant `get()` is removed.
 
 - Improved :doc:`readability-identifier-naming
-  <clang-tidy/checks/readability/readability-identifier-naming>` check support
-  ``namespace`` aliases.
+  <clang-tidy/checks/readability/readability-identifier-naming>` check to
+  validate ``namespace`` aliases.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -101,6 +101,10 @@ inline namespace InlineNamespace {
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for inline namespace 'InlineNamespace'
 // CHECK-FIXES: {{^}}inline namespace inline_namespace {{{$}}
 
+namespace FOO_ALIAS = FOO_NS;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for namespace 'FOO_ALIAS' [readability-identifier-naming]
+// CHECK-FIXES: {{^}}namespace foo_alias = FOO_NS;{{$}}
+
 SYSTEM_NS::structure g_s1;
 // NO warnings or fixes expected as SYSTEM_NS and structure are declared in a header file
 


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/109385
