### PR TITLE
[analyzer][StackAddressEscape] Remove redundant "returned to caller" suffix for compound literal

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -78,7 +78,7 @@ SourceRange StackAddrEscapeChecker::genName(raw_ostream &os, const MemRegion *R,
     const CompoundLiteralExpr *CL = CR->getLiteralExpr();
     os << "stack memory associated with a compound literal "
           "declared on line "
-       << SM.getExpansionLineNumber(CL->getBeginLoc()) << " returned to caller";
+       << SM.getExpansionLineNumber(CL->getBeginLoc());
     range = CL->getSourceRange();
   } else if (const auto *AR = dyn_cast<AllocaRegion>(R)) {
     const Expr *ARE = AR->getExpr();

--- a/clang/test/Analysis/stack-addr-ps.c
+++ b/clang/test/Analysis/stack-addr-ps.c
@@ -20,17 +20,21 @@ int* f3(int x, int *y) {
 
 void* compound_literal(int x, int y) {
   if (x)
-    return &(unsigned short){((unsigned short)0x22EF)}; // expected-warning{{Address of stack memory}} expected-warning{{address of stack memory}}
+    return &(unsigned short){((unsigned short)0x22EF)};
+  // expected-warning-re@-1{{Address of stack memory associated with a compound literal declared on line {{[0-9]+}} returned to caller [core.StackAddressEscape]}}
+  // expected-warning@-2{{address of stack memory}}
 
   int* array[] = {};
   struct s { int z; double y; int w; };
   
   if (y)
-    return &((struct s){ 2, 0.4, 5 * 8 }); // expected-warning{{Address of stack memory}} expected-warning{{address of stack memory}}
-    
+    return &((struct s){ 2, 0.4, 5 * 8 });
+  // expected-warning-re@-1{{Address of stack memory associated with a compound literal declared on line {{[0-9]+}} returned to caller [core.StackAddressEscape]}}
+  // expected-warning@-2{{address of stack memory}}
   
   void* p = &((struct s){ 42, 0.4, x ? 42 : 0 });
-  return p; // expected-warning{{Address of stack memory}}
+  return p;
+  // expected-warning-re@-1{{Address of stack memory associated with a compound literal declared on line {{[0-9]+}} returned to caller [core.StackAddressEscape]}}
 }
 
 void* alloca_test(void) {


### PR DESCRIPTION
This patch simplifies the diagnostic message in the core.StackAddrEscape for stack memory associated with compound literals by removing the redundant "returned to caller" suffix.
Example: https://godbolt.org/z/KxM67vr7c

```c
// clang --analyze -Xanalyzer -analyzer-checker=core.StackAddressEscape
void* compound_literal() {
  return &(unsigned short){((unsigned short)0x22EF)};
}
```

warning: Address of stack memory associated with a compound literal declared on line 2 **returned to caller returned to caller** [core.StackAddressEscape]