### PR TITLE
[mlir] Support better printing for mutually recursive types

### DIFF
--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -188,6 +188,11 @@ public:
   /// be printed.
   virtual LogicalResult printAlias(Type type);
 
+  /// Check if the given type has an alias that will be printed in the future.
+  /// Returns false if the type has an alias that's currently being printed or
+  /// has already been printed. This can aid printing mutually recursive types.
+  virtual bool hasFutureAlias(Type type) const;
+
   /// Print the given string as a keyword, or a quoted and escaped string if it
   /// has any special or non-printable characters in it.
   virtual void printKeywordOrString(StringRef keyword);

--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -188,11 +188,6 @@ public:
   /// be printed.
   virtual LogicalResult printAlias(Type type);
 
-  /// Check if the given type has an alias that will be printed in the future.
-  /// Returns false if the type has an alias that's currently being printed or
-  /// has already been printed. This can aid printing mutually recursive types.
-  virtual bool hasFutureAlias(Type type) const;
-
   /// Print the given string as a keyword, or a quoted and escaped string if it
   /// has any special or non-printable characters in it.
   virtual void printKeywordOrString(StringRef keyword);
@@ -270,8 +265,11 @@ public:
   /// Attempts to start a cyclic printing region for `attrOrType`.
   /// A cyclic printing region starts with this call and ends with the
   /// destruction of the returned `CyclicPrintReset`. During this time,
-  /// calling `tryStartCyclicPrint` with the same attribute in any printer
-  /// will lead to returning failure.
+  /// calling `tryStartCyclicPrint` with the same attribute or type in any
+  /// printer will lead to returning failure. Additionally, if the printer
+  /// knows a complete definition of the attribute or type will be emitted in
+  /// the future, it'll also return failure to permit abbreviated definitions
+  /// to be used wherever possible.
   ///
   /// This makes it possible to break infinite recursions when trying to print
   /// cyclic attributes or types by printing only immutable parameters if nested
@@ -283,6 +281,8 @@ public:
                           AttrOrTypeT> ||
             std::is_base_of_v<TypeTrait::IsMutable<AttrOrTypeT>, AttrOrTypeT>,
         "Only mutable attributes or types can be cyclic");
+    if (hasFutureAlias(attrOrType.getAsOpaquePointer()))
+      return failure();
     if (failed(pushCyclicPrinting(attrOrType.getAsOpaquePointer())))
       return failure();
     return CyclicPrintReset(this);
@@ -303,6 +303,12 @@ protected:
   /// `pushCyclicPrinting`. There must be exactly one `popCyclicPrinting` call
   /// in reverse order of all successful `pushCyclicPrinting`.
   virtual void popCyclicPrinting();
+
+  /// Check if the given attribute or type (in the form of a type erased
+  /// pointer) will be printed as an alias in the future. Returns false if the
+  /// type has an alias that's currently being printed or has already been
+  /// printed. This enables cyclic print checking for mutual recursion.
+  virtual bool hasFutureAlias(const void *opaquePointer) const;
 
 private:
   AsmPrinter(const AsmPrinter &) = delete;

--- a/mlir/test/IR/recursive-type.mlir
+++ b/mlir/test/IR/recursive-type.mlir
@@ -2,10 +2,12 @@
 
 // CHECK: !testrec = !test.test_rec<type_to_alias, test_rec<type_to_alias>>
 // CHECK: ![[$NAME:.*]] = !test.test_rec_alias<name, !test.test_rec_alias<name>>
-// CHECK: ![[$NAME5:.*]] = !test.test_rec_alias<name5, !test.test_rec_alias<name3, !test.test_rec_alias<name4, !test.test_rec_alias<name5>>>>
+// CHECK: ![[$NAME5:.*]] = !test.test_rec_alias<name5, !test.test_rec_alias<name3>>
+// CHECK: ![[$NAME7:.*]] = !test.test_rec_alias<name7, !test.test_rec_alias<name6>>
 // CHECK: ![[$NAME2:.*]] = !test.test_rec_alias<name2, tuple<!test.test_rec_alias<name2>, i32>>
-// CHECK: ![[$NAME4:.*]] = !test.test_rec_alias<name4, !name5_>
-// CHECK: ![[$NAME3:.*]] = !test.test_rec_alias<name3, !name4_>
+// CHECK: ![[$NAME4:.*]] = !test.test_rec_alias<name4, ![[$NAME5]]>
+// CHECK: ![[$NAME6:.*]] = !test.test_rec_alias<name6, ![[$NAME7]]>
+// CHECK: ![[$NAME3:.*]] = !test.test_rec_alias<name3, ![[$NAME4]]>
 
 // CHECK-LABEL: @roundtrip
 func.func @roundtrip() {
@@ -28,13 +30,20 @@ func.func @roundtrip() {
   "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name2, tuple<!test.test_rec_alias<name2>, i32>>
   "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name2, tuple<!test.test_rec_alias<name2>, i32>>
 
-  // Mutual recursion.
+  // Mutual recursion with types fully spelled out.
   // CHECK: () -> ![[$NAME3]]
   // CHECK: () -> ![[$NAME4]]
   // CHECK: () -> ![[$NAME5]]
   "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name3, !test.test_rec_alias<name4, !test.test_rec_alias<name5, !test.test_rec_alias<name3>>>>
   "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name4, !test.test_rec_alias<name5, !test.test_rec_alias<name3, !test.test_rec_alias<name4>>>>
   "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name5, !test.test_rec_alias<name3, !test.test_rec_alias<name4, !test.test_rec_alias<name5>>>>
+
+  // Mutual recursion with incomplete types.
+  // CHECK: () -> ![[$NAME6]]
+  // CHECK: () -> ![[$NAME7]]
+  "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name6, !test.test_rec_alias<name7>>
+  "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name7, !test.test_rec_alias<name6>>
+
   return
 }
 

--- a/mlir/test/lib/Dialect/Test/TestTypes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestTypes.cpp
@@ -505,6 +505,10 @@ Type TestRecursiveAliasType::parse(AsmParser &parser) {
     return rec;
   }
 
+  // Allow incomplete definitions that can be completed later.
+  if (succeeded(parser.parseGreater()))
+    return rec;
+
   // Otherwise, parse the body and update the type.
   if (failed(parser.parseComma()))
     return Type();
@@ -525,7 +529,7 @@ void TestRecursiveAliasType::print(AsmPrinter &printer) const {
       printer.tryStartCyclicPrint(*this);
 
   printer << "<" << getName();
-  if (succeeded(cyclicPrint)) {
+  if (succeeded(cyclicPrint) && !printer.hasFutureAlias(*this)) {
     printer << ", ";
     printer << getBody();
   }

--- a/mlir/test/lib/Dialect/Test/TestTypes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestTypes.cpp
@@ -529,7 +529,7 @@ void TestRecursiveAliasType::print(AsmPrinter &printer) const {
       printer.tryStartCyclicPrint(*this);
 
   printer << "<" << getName();
-  if (succeeded(cyclicPrint) && !printer.hasFutureAlias(*this)) {
+  if (succeeded(cyclicPrint)) {
     printer << ", ";
     printer << getBody();
   }


### PR DESCRIPTION
For mutually recursive types, the current way types are printed forces
the earlier type alias to include a full definition of the later type.
Many recursive types (e.g. structs in ClangIR) have a notion of an
incomplete type definition, and by exposing a simple hook in the
AsmPrinter to determine whether a type will be printed in the future, we
can enable dialects to use incomplete type definitions (which they know
will be completed later) when printing mutually recursive types instead,
which makes them much easier to read.
