### PR TITLE
[RISCV][FMV] Remove support for negative priority

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2903,7 +2903,7 @@ void CodeGenFunction::EmitMultiVersionResolver(
   }
 }
 
-static int getPriorityFromAttrString(StringRef AttrStr) {
+static unsigned getPriorityFromAttrString(StringRef AttrStr) {
   SmallVector<StringRef, 8> Attrs;
 
   AttrStr.split(Attrs, ';');

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2913,9 +2913,8 @@ static unsigned getPriorityFromAttrString(StringRef AttrStr) {
   for (auto Attr : Attrs) {
     if (Attr.consume_front("priority=")) {
       unsigned Result;
-      if (!Attr.getAsInteger(0, Result)) {
+      if (!Attr.getAsInteger(0, Result))
         Priority = Result;
-      }
     }
   }
 

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2909,17 +2909,15 @@ static int getPriorityFromAttrString(StringRef AttrStr) {
   AttrStr.split(Attrs, ';');
 
   // Default Priority is zero.
-  int Priority = 0;
+  unsigned Priority = 0;
   for (auto Attr : Attrs) {
     if (Attr.consume_front("priority=")) {
-      int Result;
+      unsigned Result;
       if (!Attr.getAsInteger(0, Result)) {
         Priority = Result;
       }
     }
   }
-
-  assert(Priority >= 0);
 
   return Priority;
 }

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2919,6 +2919,8 @@ static int getPriorityFromAttrString(StringRef AttrStr) {
     }
   }
 
+  assert(Priority >= 0);
+
   return Priority;
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3072,8 +3072,8 @@ bool Sema::checkTargetVersionAttr(SourceLocation LiteralLoc, Decl *D,
         if (HasPriority)
           DuplicateAttr = true;
         HasPriority = true;
-        int Digit;
-        if (AttrStr.getAsInteger(0, Digit) || Digit < 0)
+        unsigned Digit;
+        if (AttrStr.getAsInteger(0, Digit))
           return Diag(LiteralLoc, diag::warn_unsupported_target_attribute)
                  << Unsupported << None << AttrStr << TargetVersion;
       } else {
@@ -3226,8 +3226,8 @@ bool Sema::checkTargetClonesAttrString(
           HasDefault = true;
         } else if (AttrStr.consume_front("priority=")) {
           IsPriority = true;
-          int Digit;
-          if (AttrStr.getAsInteger(0, Digit) || Digit < 0)
+          unsigned Digit;
+          if (AttrStr.getAsInteger(0, Digit))
             return Diag(CurLoc, diag::warn_unsupported_target_attribute)
                    << Unsupported << None << Str << TargetClones;
         } else {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3073,7 +3073,7 @@ bool Sema::checkTargetVersionAttr(SourceLocation LiteralLoc, Decl *D,
           DuplicateAttr = true;
         HasPriority = true;
         int Digit;
-        if (AttrStr.getAsInteger(0, Digit))
+        if (AttrStr.getAsInteger(0, Digit) || Digit < 0)
           return Diag(LiteralLoc, diag::warn_unsupported_target_attribute)
                  << Unsupported << None << AttrStr << TargetVersion;
       } else {
@@ -3227,7 +3227,7 @@ bool Sema::checkTargetClonesAttrString(
         } else if (AttrStr.consume_front("priority=")) {
           IsPriority = true;
           int Digit;
-          if (AttrStr.getAsInteger(0, Digit))
+          if (AttrStr.getAsInteger(0, Digit) || Digit < 0)
             return Diag(CurLoc, diag::warn_unsupported_target_attribute)
                    << Unsupported << None << Str << TargetClones;
         } else {

--- a/clang/test/CodeGen/attr-target-clones-riscv.c
+++ b/clang/test/CodeGen/attr-target-clones-riscv.c
@@ -16,10 +16,9 @@ __attribute__((target_clones("default", "arch=+zvkt"))) int foo6(void) { return 
 __attribute__((target_clones("default", "arch=+zbb", "arch=+zba", "arch=+zbb,+zba"))) int foo7(void) { return 2; }
 __attribute__((target_clones("default", "arch=+zbb;priority=2", "arch=+zba;priority=1", "arch=+zbb,+zba;priority=3"))) int foo8(void) { return 2; }
 __attribute__((target_clones("default", "arch=+zbb;priority=1", "priority=2;arch=+zba", "priority=3;arch=+zbb,+zba"))) int foo9(void) { return 2; }
-__attribute__((target_clones("default", "arch=+zbb;priority=-1", "priority=-2;arch=+zba", "priority=3;arch=+zbb,+zba"))) int foo10(void) { return 2; }
 
 
-int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() + foo8() + foo9() + foo10(); }
+int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() + foo8() + foo9(); }
 
 //.
 // CHECK: @__riscv_feature_bits = external dso_local global { i32, [2 x i64] }
@@ -32,7 +31,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK: @foo7.ifunc = weak_odr alias i32 (), ptr @foo7
 // CHECK: @foo8.ifunc = weak_odr alias i32 (), ptr @foo8
 // CHECK: @foo9.ifunc = weak_odr alias i32 (), ptr @foo9
-// CHECK: @foo10.ifunc = weak_odr alias i32 (), ptr @foo10
 // CHECK: @foo1 = weak_odr ifunc i32 (), ptr @foo1.resolver
 // CHECK: @foo2 = weak_odr ifunc i32 (), ptr @foo2.resolver
 // CHECK: @foo3 = weak_odr ifunc i32 (), ptr @foo3.resolver
@@ -42,7 +40,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK: @foo7 = weak_odr ifunc i32 (), ptr @foo7.resolver
 // CHECK: @foo8 = weak_odr ifunc i32 (), ptr @foo8.resolver
 // CHECK: @foo9 = weak_odr ifunc i32 (), ptr @foo9.resolver
-// CHECK: @foo10 = weak_odr ifunc i32 (), ptr @foo10.resolver
 //.
 // CHECK-LABEL: define dso_local signext i32 @foo1.default(
 // CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
@@ -347,57 +344,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK-NEXT:    ret ptr @foo9.default
 //
 //
-// CHECK-LABEL: define dso_local signext i32 @foo10.default(
-// CHECK-SAME: ) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define dso_local signext i32 @foo10._zbb(
-// CHECK-SAME: ) #[[ATTR2]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define dso_local signext i32 @foo10._zba(
-// CHECK-SAME: ) #[[ATTR6]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define dso_local signext i32 @foo10._zba_zbb(
-// CHECK-SAME: ) #[[ATTR7]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define weak_odr ptr @foo10.resolver() comdat {
-// CHECK-NEXT:  resolver_entry:
-// CHECK-NEXT:    call void @__init_riscv_feature_bits(ptr null)
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[TMP0]], 402653184
-// CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i64 [[TMP1]], 402653184
-// CHECK-NEXT:    br i1 [[TMP2]], label [[RESOLVER_RETURN:%.*]], label [[RESOLVER_ELSE:%.*]]
-// CHECK:       resolver_return:
-// CHECK-NEXT:    ret ptr @foo10._zba_zbb
-// CHECK:       resolver_else:
-// CHECK-NEXT:    [[TMP3:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP4:%.*]] = and i64 [[TMP3]], 268435456
-// CHECK-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[TMP4]], 268435456
-// CHECK-NEXT:    br i1 [[TMP5]], label [[RESOLVER_RETURN1:%.*]], label [[RESOLVER_ELSE2:%.*]]
-// CHECK:       resolver_return1:
-// CHECK-NEXT:    ret ptr @foo10._zbb
-// CHECK:       resolver_else2:
-// CHECK-NEXT:    [[TMP6:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], 134217728
-// CHECK-NEXT:    [[TMP8:%.*]] = icmp eq i64 [[TMP7]], 134217728
-// CHECK-NEXT:    br i1 [[TMP8]], label [[RESOLVER_RETURN3:%.*]], label [[RESOLVER_ELSE4:%.*]]
-// CHECK:       resolver_return3:
-// CHECK-NEXT:    ret ptr @foo10._zba
-// CHECK:       resolver_else4:
-// CHECK-NEXT:    ret ptr @foo10.default
-//
-//
 // CHECK-LABEL: define dso_local signext i32 @bar(
 // CHECK-SAME: ) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
@@ -418,9 +364,7 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK-NEXT:    [[ADD13:%.*]] = add nsw i32 [[ADD11]], [[CALL12]]
 // CHECK-NEXT:    [[CALL14:%.*]] = call signext i32 @foo9()
 // CHECK-NEXT:    [[ADD15:%.*]] = add nsw i32 [[ADD13]], [[CALL14]]
-// CHECK-NEXT:    [[CALL16:%.*]] = call signext i32 @foo10()
-// CHECK-NEXT:    [[ADD17:%.*]] = add nsw i32 [[ADD15]], [[CALL16]]
-// CHECK-NEXT:    ret i32 [[ADD17]]
+// CHECK-NEXT:    ret i32 [[ADD15]]
 //
 //.
 // CHECK: attributes #[[ATTR0]] = { noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+64bit,+i" }

--- a/clang/test/CodeGen/attr-target-version-riscv.c
+++ b/clang/test/CodeGen/attr-target-version-riscv.c
@@ -32,12 +32,7 @@ __attribute__((target_version("arch=+zbb;priority=9"))) int foo7(void) { return 
 __attribute__((target_version("arch=+zbb,+zba;priority=10"))) int foo7(void) { return 1; }
 __attribute__((target_version("default"))) int foo7(void) { return 1; }
 
-__attribute__((target_version("priority=-1;arch=+zba"))) int foo8(void) { return 1; }
-__attribute__((target_version("arch=+zbb;priority=-2"))) int foo8(void) { return 1; }
-__attribute__((target_version("arch=+zbb,+zba;priority=3"))) int foo8(void) { return 1; }
-__attribute__((target_version("default"))) int foo8(void) { return 1; }
-
-int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() + foo8(); }
+int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7(); }
 //.
 // CHECK: @__riscv_feature_bits = external dso_local global { i32, [2 x i64] }
 // CHECK: @foo1 = weak_odr ifunc i32 (), ptr @foo1.resolver
@@ -47,7 +42,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK: @foo5 = weak_odr ifunc i32 (), ptr @foo5.resolver
 // CHECK: @foo6 = weak_odr ifunc i32 (), ptr @foo6.resolver
 // CHECK: @foo7 = weak_odr ifunc i32 (), ptr @foo7.resolver
-// CHECK: @foo8 = weak_odr ifunc i32 (), ptr @foo8.resolver
 //.
 // CHECK-LABEL: define dso_local signext i32 @foo1._v(
 // CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
@@ -193,30 +187,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK-NEXT:    ret i32 1
 //
 //
-// CHECK-LABEL: define dso_local signext i32 @foo8._zba(
-// CHECK-SAME: ) #[[ATTR5]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
-// CHECK-LABEL: define dso_local signext i32 @foo8._zbb(
-// CHECK-SAME: ) #[[ATTR2]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
-// CHECK-LABEL: define dso_local signext i32 @foo8._zba_zbb(
-// CHECK-SAME: ) #[[ATTR6]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
-// CHECK-LABEL: define dso_local signext i32 @foo8.default(
-// CHECK-SAME: ) #[[ATTR1]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
 // CHECK-LABEL: define dso_local signext i32 @bar(
 // CHECK-SAME: ) #[[ATTR1]] {
 // CHECK-NEXT:  entry:
@@ -233,9 +203,7 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK-NEXT:    [[ADD9:%.*]] = add nsw i32 [[ADD7]], [[CALL8]]
 // CHECK-NEXT:    [[CALL10:%.*]] = call signext i32 @foo7()
 // CHECK-NEXT:    [[ADD11:%.*]] = add nsw i32 [[ADD9]], [[CALL10]]
-// CHECK-NEXT:    [[CALL12:%.*]] = call signext i32 @foo8()
-// CHECK-NEXT:    [[ADD13:%.*]] = add nsw i32 [[ADD11]], [[CALL12]]
-// CHECK-NEXT:    ret i32 [[ADD13]]
+// CHECK-NEXT:    ret i32 [[ADD11]]
 //
 //
 // CHECK-LABEL: define weak_odr ptr @foo1.resolver() comdat {
@@ -397,33 +365,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5() + foo6() + foo7() 
 // CHECK-NEXT:    ret ptr @foo7._zba
 // CHECK:       resolver_else4:
 // CHECK-NEXT:    ret ptr @foo7.default
-//
-//
-// CHECK-LABEL: define weak_odr ptr @foo8.resolver() comdat {
-// CHECK-NEXT:  resolver_entry:
-// CHECK-NEXT:    call void @__init_riscv_feature_bits(ptr null)
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[TMP0]], 402653184
-// CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i64 [[TMP1]], 402653184
-// CHECK-NEXT:    br i1 [[TMP2]], label [[RESOLVER_RETURN:%.*]], label [[RESOLVER_ELSE:%.*]]
-// CHECK:       resolver_return:
-// CHECK-NEXT:    ret ptr @foo8._zba_zbb
-// CHECK:       resolver_else:
-// CHECK-NEXT:    [[TMP3:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP4:%.*]] = and i64 [[TMP3]], 134217728
-// CHECK-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[TMP4]], 134217728
-// CHECK-NEXT:    br i1 [[TMP5]], label [[RESOLVER_RETURN1:%.*]], label [[RESOLVER_ELSE2:%.*]]
-// CHECK:       resolver_return1:
-// CHECK-NEXT:    ret ptr @foo8._zba
-// CHECK:       resolver_else2:
-// CHECK-NEXT:    [[TMP6:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], 268435456
-// CHECK-NEXT:    [[TMP8:%.*]] = icmp eq i64 [[TMP7]], 268435456
-// CHECK-NEXT:    br i1 [[TMP8]], label [[RESOLVER_RETURN3:%.*]], label [[RESOLVER_ELSE4:%.*]]
-// CHECK:       resolver_return3:
-// CHECK-NEXT:    ret ptr @foo8._zbb
-// CHECK:       resolver_else4:
-// CHECK-NEXT:    ret ptr @foo8.default
 //
 //.
 // CHECK: attributes #[[ATTR0]] = { noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+64bit,+d,+f,+i,+v,+zicsr,+zve32f,+zve32x,+zve64d,+zve64f,+zve64x,+zvl128b,+zvl32b,+zvl64b" }

--- a/clang/test/CodeGenCXX/attr-target-clones-riscv.cpp
+++ b/clang/test/CodeGenCXX/attr-target-clones-riscv.cpp
@@ -16,9 +16,8 @@ __attribute__((target_clones("default", "arch=+zvkt"))) int foo6(void) { return 
 __attribute__((target_clones("default", "arch=+zbb", "arch=+zba", "arch=+zbb,+zba"))) int foo7(void) { return 2; }
 __attribute__((target_clones("default", "arch=+zbb;priority=2", "arch=+zba;priority=1", "arch=+zbb,+zba;priority=3"))) int foo8(void) { return 2; }
 __attribute__((target_clones("default", "arch=+zbb;priority=1", "priority=2;arch=+zba", "priority=3;arch=+zbb,+zba"))) int foo9(void) { return 2; }
-__attribute__((target_clones("default", "arch=+zbb;priority=-1", "priority=-2;arch=+zba", "priority=3;arch=+zbb,+zba"))) int foo10(void) { return 2; }
 
-int bar() { return foo1() + foo2() + foo3() + foo4() + foo5()+ foo6() + foo7() + foo8() + foo9() + foo10(); }
+int bar() { return foo1() + foo2() + foo3() + foo4() + foo5()+ foo6() + foo7() + foo8() + foo9(); }
 
 //.
 // CHECK: @__riscv_feature_bits = external dso_local global { i32, [2 x i64] }
@@ -31,7 +30,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5()+ foo6() + foo7() +
 // CHECK: @_Z4foo7v.ifunc = weak_odr alias i32 (), ptr @_Z4foo7v
 // CHECK: @_Z4foo8v.ifunc = weak_odr alias i32 (), ptr @_Z4foo8v
 // CHECK: @_Z4foo9v.ifunc = weak_odr alias i32 (), ptr @_Z4foo9v
-// CHECK: @_Z5foo10v.ifunc = weak_odr alias i32 (), ptr @_Z5foo10v
 // CHECK: @_Z4foo1v = weak_odr ifunc i32 (), ptr @_Z4foo1v.resolver
 // CHECK: @_Z4foo2v = weak_odr ifunc i32 (), ptr @_Z4foo2v.resolver
 // CHECK: @_Z4foo3v = weak_odr ifunc i32 (), ptr @_Z4foo3v.resolver
@@ -41,7 +39,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5()+ foo6() + foo7() +
 // CHECK: @_Z4foo7v = weak_odr ifunc i32 (), ptr @_Z4foo7v.resolver
 // CHECK: @_Z4foo8v = weak_odr ifunc i32 (), ptr @_Z4foo8v.resolver
 // CHECK: @_Z4foo9v = weak_odr ifunc i32 (), ptr @_Z4foo9v.resolver
-// CHECK: @_Z5foo10v = weak_odr ifunc i32 (), ptr @_Z5foo10v.resolver
 //.
 // CHECK-LABEL: define dso_local noundef signext i32 @_Z4foo1v.default(
 // CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
@@ -346,57 +343,6 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5()+ foo6() + foo7() +
 // CHECK-NEXT:    ret ptr @_Z4foo9v.default
 //
 //
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z5foo10v.default(
-// CHECK-SAME: ) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z5foo10v._zbb(
-// CHECK-SAME: ) #[[ATTR1]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z5foo10v._zba(
-// CHECK-SAME: ) #[[ATTR5]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z5foo10v._zba_zbb(
-// CHECK-SAME: ) #[[ATTR6]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK-LABEL: define weak_odr ptr @_Z5foo10v.resolver() comdat {
-// CHECK-NEXT:  resolver_entry:
-// CHECK-NEXT:    call void @__init_riscv_feature_bits(ptr null)
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[TMP0]], 402653184
-// CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i64 [[TMP1]], 402653184
-// CHECK-NEXT:    br i1 [[TMP2]], label [[RESOLVER_RETURN:%.*]], label [[RESOLVER_ELSE:%.*]]
-// CHECK:       resolver_return:
-// CHECK-NEXT:    ret ptr @_Z5foo10v._zba_zbb
-// CHECK:       resolver_else:
-// CHECK-NEXT:    [[TMP3:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP4:%.*]] = and i64 [[TMP3]], 268435456
-// CHECK-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[TMP4]], 268435456
-// CHECK-NEXT:    br i1 [[TMP5]], label [[RESOLVER_RETURN1:%.*]], label [[RESOLVER_ELSE2:%.*]]
-// CHECK:       resolver_return1:
-// CHECK-NEXT:    ret ptr @_Z5foo10v._zbb
-// CHECK:       resolver_else2:
-// CHECK-NEXT:    [[TMP6:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], 134217728
-// CHECK-NEXT:    [[TMP8:%.*]] = icmp eq i64 [[TMP7]], 134217728
-// CHECK-NEXT:    br i1 [[TMP8]], label [[RESOLVER_RETURN3:%.*]], label [[RESOLVER_ELSE4:%.*]]
-// CHECK:       resolver_return3:
-// CHECK-NEXT:    ret ptr @_Z5foo10v._zba
-// CHECK:       resolver_else4:
-// CHECK-NEXT:    ret ptr @_Z5foo10v.default
-//
-//
 // CHECK-LABEL: define dso_local noundef signext i32 @_Z3barv(
 // CHECK-SAME: ) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
@@ -417,9 +363,7 @@ int bar() { return foo1() + foo2() + foo3() + foo4() + foo5()+ foo6() + foo7() +
 // CHECK-NEXT:    [[ADD13:%.*]] = add nsw i32 [[ADD11]], [[CALL12]]
 // CHECK-NEXT:    [[CALL14:%.*]] = call noundef signext i32 @_Z4foo9v()
 // CHECK-NEXT:    [[ADD15:%.*]] = add nsw i32 [[ADD13]], [[CALL14]]
-// CHECK-NEXT:    [[CALL16:%.*]] = call noundef signext i32 @_Z5foo10v()
-// CHECK-NEXT:    [[ADD17:%.*]] = add nsw i32 [[ADD15]], [[CALL16]]
-// CHECK-NEXT:    ret i32 [[ADD17]]
+// CHECK-NEXT:    ret i32 [[ADD15]]
 //
 //.
 // CHECK: attributes #[[ATTR0]] = { mustprogress noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+64bit,+i,+m,+zmmul" }

--- a/clang/test/CodeGenCXX/attr-target-version-riscv.cpp
+++ b/clang/test/CodeGenCXX/attr-target-version-riscv.cpp
@@ -32,11 +32,6 @@ __attribute__((target_version("arch=+zbb;priority=9"))) int foo7(void) { return 
 __attribute__((target_version("arch=+zbb,+zba;priority=10"))) int foo7(void) { return 1; }
 __attribute__((target_version("default"))) int foo7(void) { return 1; }
 
-__attribute__((target_version("priority=-1;arch=+zba"))) int foo8(void) { return 1; }
-__attribute__((target_version("arch=+zbb;priority=-2"))) int foo8(void) { return 1; }
-__attribute__((target_version("arch=+zbb,+zba;priority=3"))) int foo8(void) { return 1; }
-__attribute__((target_version("default"))) int foo8(void) { return 1; }
-
 int bar() { return foo1() + foo2() + foo3(); }
 //.
 // CHECK: @__riscv_feature_bits = external dso_local global { i32, [2 x i64] }
@@ -47,7 +42,6 @@ int bar() { return foo1() + foo2() + foo3(); }
 // CHECK: @_Z4foo5v = weak_odr ifunc i32 (), ptr @_Z4foo5v.resolver
 // CHECK: @_Z4foo6v = weak_odr ifunc i32 (), ptr @_Z4foo6v.resolver
 // CHECK: @_Z4foo7v = weak_odr ifunc i32 (), ptr @_Z4foo7v.resolver
-// CHECK: @_Z4foo8v = weak_odr ifunc i32 (), ptr @_Z4foo8v.resolver
 //.
 // CHECK-LABEL: define dso_local noundef signext i32 @_Z4foo1v._v(
 // CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
@@ -188,30 +182,6 @@ int bar() { return foo1() + foo2() + foo3(); }
 //
 //
 // CHECK-LABEL: define dso_local noundef signext i32 @_Z4foo7v.default(
-// CHECK-SAME: ) #[[ATTR1]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z4foo8v._zba(
-// CHECK-SAME: ) #[[ATTR4]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z4foo8v._zbb(
-// CHECK-SAME: ) #[[ATTR2]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z4foo8v._zba_zbb(
-// CHECK-SAME: ) #[[ATTR5]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 1
-//
-//
-// CHECK-LABEL: define dso_local noundef signext i32 @_Z4foo8v.default(
 // CHECK-SAME: ) #[[ATTR1]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i32 1
@@ -387,33 +357,6 @@ int bar() { return foo1() + foo2() + foo3(); }
 // CHECK-NEXT:    ret ptr @_Z4foo7v._zba
 // CHECK:       resolver_else4:
 // CHECK-NEXT:    ret ptr @_Z4foo7v.default
-//
-//
-// CHECK-LABEL: define weak_odr ptr @_Z4foo8v.resolver() comdat {
-// CHECK-NEXT:  resolver_entry:
-// CHECK-NEXT:    call void @__init_riscv_feature_bits(ptr null)
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[TMP0]], 402653184
-// CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i64 [[TMP1]], 402653184
-// CHECK-NEXT:    br i1 [[TMP2]], label [[RESOLVER_RETURN:%.*]], label [[RESOLVER_ELSE:%.*]]
-// CHECK:       resolver_return:
-// CHECK-NEXT:    ret ptr @_Z4foo8v._zba_zbb
-// CHECK:       resolver_else:
-// CHECK-NEXT:    [[TMP3:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP4:%.*]] = and i64 [[TMP3]], 134217728
-// CHECK-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[TMP4]], 134217728
-// CHECK-NEXT:    br i1 [[TMP5]], label [[RESOLVER_RETURN1:%.*]], label [[RESOLVER_ELSE2:%.*]]
-// CHECK:       resolver_return1:
-// CHECK-NEXT:    ret ptr @_Z4foo8v._zba
-// CHECK:       resolver_else2:
-// CHECK-NEXT:    [[TMP6:%.*]] = load i64, ptr getelementptr inbounds ({ i32, [2 x i64] }, ptr @__riscv_feature_bits, i32 0, i32 1, i32 0), align 8
-// CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], 268435456
-// CHECK-NEXT:    [[TMP8:%.*]] = icmp eq i64 [[TMP7]], 268435456
-// CHECK-NEXT:    br i1 [[TMP8]], label [[RESOLVER_RETURN3:%.*]], label [[RESOLVER_ELSE4:%.*]]
-// CHECK:       resolver_return3:
-// CHECK-NEXT:    ret ptr @_Z4foo8v._zbb
-// CHECK:       resolver_else4:
-// CHECK-NEXT:    ret ptr @_Z4foo8v.default
 //
 //.
 // CHECK: attributes #[[ATTR0]] = { mustprogress noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+64bit,+d,+f,+i,+m,+v,+zicsr,+zmmul,+zve32f,+zve32x,+zve64d,+zve64f,+zve64x,+zvl128b,+zvl32b,+zvl64b" }

--- a/clang/test/SemaCXX/attr-target-clones-riscv.cpp
+++ b/clang/test/SemaCXX/attr-target-clones-riscv.cpp
@@ -33,6 +33,9 @@ void __attribute__((target_clones("default;priority=2", "arch=+c"))) UnsupportDe
 // expected-warning@+1 {{unsupported 'priority=2;default' in the 'target_clones' attribute string; 'target_clones' attribute ignored}}
 void __attribute__((target_clones("priority=2;default", "arch=+c"))) UnsupportDefaultPriority2() {}
 
+// expected-warning@+1 {{unsupported 'arch=+c;priority=-1' in the 'target_clones' attribute string; 'target_clones' attribute ignored}}
+void __attribute__((target_clones("default", "arch=+c;priority=-1"))) UnsupportNegativePriority() {}
+
 // expected-warning@+1 {{unsupported 'arch=+c,zbb' in the 'target_clones' attribute string; 'target_clones' attribute ignored}}
 void __attribute__((target_clones("default", "arch=+c,zbb"))) WithoutAddSign() {}
 

--- a/clang/test/SemaCXX/attr-target-version-riscv.cpp
+++ b/clang/test/SemaCXX/attr-target-version-riscv.cpp
@@ -111,3 +111,9 @@ __attribute__((target_version("default"))) int invalidVerson4(void) { return 2; 
 __attribute__((target_version("priority=1"))) int prioriyWithoutArch(void) { return 2; }
 // expected-error@+1 {{redefinition of 'prioriyWithoutArch'}}
 __attribute__((target_version("default"))) int prioriyWithoutArch(void) { return 2; }
+
+// expected-warning@+2 {{unsupported '-1' in the 'target_version' attribute string; 'target_version' attribute ignored}}
+// expected-note@+1 {{previous definition is here}}
+__attribute__((target_version("arch=+c;priority=-1"))) int UnsupportNegativePriority(void) { return 2; }
+// expected-error@+1 {{redefinition of 'UnsupportNegativePriority'}}
+__attribute__((target_version("default"))) int UnsupportNegativePriority(void) { return 2; }


### PR DESCRIPTION
Ensure that target_version and target_clones do not accept negative numbers for the priority feature. 

Base on discussion on https://github.com/riscv-non-isa/riscv-c-api-doc/pull/85.