### PR TITLE
[compiler-rt][RISCV] Use u64 data type for marchid and mimpid

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/riscv.c
+++ b/compiler-rt/lib/builtins/cpu_model/riscv.c
@@ -22,8 +22,8 @@ struct {
 
 struct {
   unsigned mvendorid;
-  unsigned marchid;
-  unsigned mimpid;
+  unsigned long long marchid;
+  unsigned long long mimpid;
 } __riscv_cpu_model __attribute__((visibility("hidden"), nocommon));
 
 // NOTE: Should sync-up with RISCVFeatures.td


### PR DESCRIPTION
Base on https://github.com/riscv-non-isa/riscv-c-api-doc/pull/91 , the marchid and mimpid are MXLEN bits wide, and kernel returned them as u64 data type. So we should use u64 data type for marchid and mimpid in __riscv_cpu_model struct here.