### PR TITLE
[libc++][test] Fix `overload_compare_iterator::iterator_category`

### DIFF
--- a/libcxx/test/std/utilities/memory/specialized.algorithms/overload_compare_iterator.h
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/overload_compare_iterator.h
@@ -12,6 +12,7 @@
 
 #include <iterator>
 #include <memory>
+#include <type_traits>
 
 #include "test_macros.h"
 
@@ -21,11 +22,15 @@
 // See https://github.com/llvm/llvm-project/issues/69334 for details.
 template <class Iterator>
 struct overload_compare_iterator {
+  static_assert(
+      std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<Iterator>::iterator_category>::value,
+      "overload_compare_iterator can only adapt forward iterators");
+
   using value_type        = typename std::iterator_traits<Iterator>::value_type;
   using difference_type   = typename std::iterator_traits<Iterator>::difference_type;
   using reference         = typename std::iterator_traits<Iterator>::reference;
   using pointer           = typename std::iterator_traits<Iterator>::pointer;
-  using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
+  using iterator_category = std::forward_iterator_tag;
 
   overload_compare_iterator() = default;
 


### PR DESCRIPTION
`overload_compare_iterator` only supports operations required for forward iterators. On the other hand, it is used for output iterators of uninitialized memory algorithms, which requires it to be forward iterator.

As a result, `overload_compare_iterator<I>::iterator_category` should always be `std::forward_iterator_tag` if we don't extend its ability. The correct `iterator_category` can prevent standard library implementations like MSVC STL attempting random access operations on `overload_compare_iterator`.

Fixes #74756.