### PR TITLE
[mlir][transf] Traits and interf. of alternatives, foreach, and yield.

### DIFF
--- a/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
@@ -24,10 +24,7 @@ include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 
 def AlternativesOp : TransformDialectOp<"alternatives",
-    [DeclareOpInterfaceMethods<RegionBranchOpInterface,
-        ["getEntrySuccessorOperands", "getSuccessorRegions",
-         "getRegionInvocationBounds"]>,
-     DeclareOpInterfaceMethods<TransformOpInterface>,
+    [DeclareOpInterfaceMethods<TransformOpInterface>,
      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      IsolatedFromAbove, PossibleTopLevelTransformOpTrait,
      SingleBlockImplicitTerminator<"::mlir::transform::YieldOp">]> {
@@ -37,8 +34,8 @@ def AlternativesOp : TransformDialectOp<"alternatives",
     sequence of transform operations to be applied to the same payload IR. The
     regions are visited in order of appearance, and transforms in them are
     applied in their respective order of appearance. If one of these transforms
-    fails to apply, the remaining ops in the same region are skipped an the next
-    region is attempted. If all transformations in a region succeed, the
+    fails to apply, the remaining ops in the same region are skipped and the
+    next region is attempted. If all transformations in a region succeed, the
     remaining regions are skipped and the entire "alternatives" transformation
     succeeds. If all regions contained a failing transformation, the entire
     "alternatives" transformation fails.
@@ -610,8 +607,6 @@ def ForeachMatchOp : TransformDialectOp<"foreach_match", [
 def ForeachOp : TransformDialectOp<"foreach",
     [DeclareOpInterfaceMethods<TransformOpInterface>,
      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     DeclareOpInterfaceMethods<RegionBranchOpInterface, [
-         "getSuccessorRegions", "getEntrySuccessorOperands"]>,
      SingleBlockImplicitTerminator<"::mlir::transform::YieldOp">
     ]> {
   let summary = "Executes the body for each element of the payload";
@@ -1358,7 +1353,8 @@ def VerifyOp : TransformDialectOp<"verify",
 }
 
 def YieldOp : TransformDialectOp<"yield",
-    [Terminator, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+    [Terminator, ReturnLike,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Yields operation handles from a transform IR region";
   let description = [{
     This terminator operation yields operation handles from regions of the

--- a/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
@@ -87,6 +87,13 @@ def AlternativesOp : TransformDialectOp<"alternatives",
       transform.yield %arg0 : !transform.any_op
     }
     ```
+
+    Note that this operation does not implement the `RegionBranchOpInterface`.
+    That interface verifies that the operands and results passed across the
+    control flow edges are equal (or compatible). In particular, it expects the
+    result passed from a region to its successor to be the argument of that
+    region; however, the argument of all `alternatives` regions are always
+    provided by the parent op and never by the precedessor region.
   }];
 
   let arguments = (ins Optional<TransformHandleTypeInterface>:$scope);
@@ -641,6 +648,14 @@ def ForeachOp : TransformDialectOp<"foreach",
     sequence fails immediately with the same failure, leaving the payload IR in
     a potentially invalid state, i.e., this operation offers no transformation
     rollback capabilities.
+
+    Note that this operation does not implement the `RegionBranchOpInterface`.
+    That interface verifies that the operands and results passed across the
+    control flow edges are equal (or compatible). In particular, it expects the
+    result passed from a region to the parent to *be* the result of that op;
+    however, the result of the `body` region only *contributes* to the result
+    in that the result of the op is an aggregation of of the results of all
+    iterations of the body.
   }];
 
   let arguments = (ins Variadic<Transform_AnyHandleOrParamType>:$targets,


### PR DESCRIPTION
This PR revisits the traits and interfaces of the `alternatives`, `foreach`, and `yield`ops. First, it adds the `ReturnLike` trait to `transform.yield`. This is required in the one-shot bufferization pass since the merging of #110332, which analyzes any `FunctionOpInterface` and expects them to have a `ReturnLike` terminator.

This uncovered problems with `alternatives` and `foreach`, which implemented the `RegionBranchOpInterface`. That interface verifies that the operands and results passed across the control flow edges from the parent op to its regions and back are equal (or compatible). Which results are passed back from regions to the parent op depend on the terminator and/or whether it is `ReturnLike`. Making `yield` a `ReturnLike` op, those checks fail without other changes.

We explored and rejected the possibility to fix the implementation of `RegionBranchOpInterface` of the two concerned ops in #111408. The problem is that the interface expects the result passed from a region to the parent op to *be* the result of the op, whereas in the two ops they *contribute* to the result: in `alternatives` only the operand yielded from one of the regions becomes the result whereas the others are ignored, and in `foreach` the operands from all iterations are fused into a new value that becomes the result of the op.