### PR TITLE
[MIR] Fix tests for flags in register info

### DIFF
--- a/llvm/test/CodeGen/AArch64/GlobalISel/arm64-regbankselect.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/arm64-regbankselect.mir
@@ -216,11 +216,11 @@ name:            phiPropagation
 legalized:       true
 tracksRegLiveness:   true
 # CHECK:      registers:
-# CHECK-NEXT:   - { id: 0, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:   - { id: 1, class: gpr64sp, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:   - { id: 3, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 4, class: gpr, preferred-register: '' }
+# CHECK-NEXT:   - { id: 0, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 1, class: gpr64sp, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 2, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 3, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 4, class: gpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: gpr32 }
   - { id: 1, class: gpr64sp }
@@ -359,8 +359,8 @@ body: |
 name:            ignoreTargetSpecificInst
 legalized:       true
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr64, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr64, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: gpr64 }
   - { id: 1, class: gpr64 }
@@ -397,9 +397,9 @@ name:            bitcast_s32_gpr
 legalized:       true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
-# FAST-NEXT:   - { id: 1, class: fpr, preferred-register: '' }
-# GREEDY-NEXT: - { id: 1, class: gpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# FAST-NEXT:   - { id: 1, class: fpr, preferred-register: '', flags: [  ] }
+# GREEDY-NEXT: - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -423,9 +423,9 @@ name:            bitcast_s32_fpr
 legalized:       true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: fpr, preferred-register: '' }
-# FAST-NEXT:   - { id: 1, class: gpr, preferred-register: '' }
-# GREEDY-NEXT: - { id: 1, class: fpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: fpr, preferred-register: '', flags: [  ] }
+# FAST-NEXT:   - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
+# GREEDY-NEXT: - { id: 1, class: fpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -448,9 +448,9 @@ name:            bitcast_s32_gpr_fpr
 legalized:       true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
-# FAST-NEXT:  - { id: 1, class: fpr, preferred-register: '' }
-# GREEDY-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# FAST-NEXT:  - { id: 1, class: fpr, preferred-register: '', flags: [  ] }
+# GREEDY-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -632,8 +632,8 @@ registers:
   - { id: 0, class: fpr128}
   - { id: 1, class: _}
 # CHECK: registers:
-# CHECK:  - { id: 0, class: fpr128, preferred-register: '' }
-# CHECK:  - { id: 1, class: fpr, preferred-register: '' }
+# CHECK:  - { id: 0, class: fpr128, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 1, class: fpr, preferred-register: '', flags: [  ] }
 # CHECK: %1:fpr(s128) = COPY %0
 body:             |
   bb.1:
@@ -659,8 +659,8 @@ registers:
   - { id: 0, class: _}
   - { id: 1, class: _}
 # CHECK: registers:
-# CHECK:  - { id: 0, class: gpr, preferred-register: '' }
-# CHECK:  - { id: 1, class: gpr, preferred-register: '' }
+# CHECK:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
 # CHECK: %0:gpr(s32) = COPY $w0
 # CHECK-NEXT: %1:gpr(s16) = G_TRUNC %0(s32)
 body:             |
@@ -723,11 +723,11 @@ name:            floatingPointLoad
 legalized:       true
 
 # CHECK: registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 4, class: fpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 4, class: fpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -765,11 +765,11 @@ name:            floatingPointStore
 legalized:       true
 
 # CHECK: registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 4, class: fpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 4, class: fpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -803,10 +803,10 @@ name:            fp16Ext32
 alignment:       4
 legalized:       true
 # CHECK: registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -838,10 +838,10 @@ name:            fp16Ext64
 alignment:       4
 legalized:       true
 # CHECK: registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 3, class: fpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -873,9 +873,9 @@ name:            fp32Ext64
 alignment:       4
 legalized:       true
 # CHECK: registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: fpr, preferred-register: '' }
-# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:   - { id: 2, class: fpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -900,7 +900,7 @@ body:             |
 # Make sure we map FP16 ABI on FPR register bank.
 # CHECK-LABEL: name: passFp16
 # CHECK: registers:
-# CHECK:  - { id: 0, class: fpr, preferred-register: '' }
+# CHECK:  - { id: 0, class: fpr, preferred-register: '', flags: [  ] }
 # CHECK:  %0:fpr(s16) = COPY $h0
 # CHECK-NEXT: $h0 = COPY %0(s16)
 name:            passFp16
@@ -922,9 +922,9 @@ body:             |
 # In that example, the copy comes from an ABI lowering of a fp type.
 # CHECK-LABEL: name: passFp16ViaAllocas
 # CHECK: registers:
-# CHECK:  - { id: 0, class: fpr, preferred-register: '' }
-# CHECK:  - { id: 1, class: gpr, preferred-register: '' }
-# CHECK:  - { id: 2, class: fpr, preferred-register: '' }
+# CHECK:  - { id: 0, class: fpr, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK:  - { id: 2, class: fpr, preferred-register: '', flags: [  ] }
 #
 # CHECK:  %0:fpr(s16) = COPY $h0
 # CHECK-NEXT: %1:gpr(p0) = G_FRAME_INDEX %stack.0.p.addr

--- a/llvm/test/CodeGen/AArch64/GlobalISel/call-translator.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/call-translator.ll
@@ -35,7 +35,7 @@ define void @test_simple_arg(i32 %in) {
 ; CHECK-LABEL: name: test_indirect_call
 ; CHECK: registers:
 ; Make sure the register feeding the indirect call is properly constrained.
-; CHECK: - { id: [[FUNC:[0-9]+]], class: gpr64, preferred-register: '' }
+; CHECK: - { id: [[FUNC:[0-9]+]], class: gpr64, preferred-register: '', flags: [  ] }
 ; CHECK: %[[FUNC]]:gpr64(p0) = COPY $x0
 ; CHECK: BLR %[[FUNC]](p0), csr_aarch64_aapcs, implicit-def $lr, implicit $sp
 ; CHECK: RET_ReallyLR

--- a/llvm/test/CodeGen/AArch64/GlobalISel/regbankselect-dbg-value.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/regbankselect-dbg-value.mir
@@ -31,7 +31,7 @@
 name:            test_dbg_value
 legalized:       true
 # CHECK: registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
 body: |
   bb.0:
     liveins: $w0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-intrinsic-aarch64-hint.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-intrinsic-aarch64-hint.mir
@@ -14,7 +14,7 @@ legalized:       true
 regBankSelected: true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: gpr }
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-static.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-static.mir
@@ -31,7 +31,7 @@ legalized:       true
 regBankSelected: true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr64sp, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr64sp, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: gpr }
 
@@ -105,12 +105,12 @@ legalized:       true
 regBankSelected: true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 2, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 4, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 5, class: gpr32, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 2, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 4, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 5, class: gpr32, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: gpr }
   - { id: 1, class: gpr }
@@ -159,12 +159,12 @@ legalized:       true
 regBankSelected: true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: fpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 2, class: fpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 4, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 5, class: gpr32, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: fpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 2, class: fpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 4, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 5, class: gpr32, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: fpr }
   - { id: 1, class: gpr }
@@ -202,10 +202,10 @@ regBankSelected: true
 tracksRegLiveness: true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: fpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# CHECK-NEXT:  - { id: 2, class: fpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: fpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 2, class: fpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: fpr }
   - { id: 1, class: gpr }
@@ -240,16 +240,16 @@ regBankSelected: true
 tracksRegLiveness: true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 2, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 4, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 5, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 6, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 7, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 8, class: gpr64, preferred-register: '' }
-# CHECK-NEXT:  - { id: 9, class: gpr64, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 2, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 4, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 5, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 6, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 7, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 8, class: gpr64, preferred-register: '', flags: [  ] }
+# CHECK-NEXT:  - { id: 9, class: gpr64, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: gpr }
   - { id: 1, class: gpr }

--- a/llvm/test/CodeGen/ARM/GlobalISel/arm-regbankselect.mir
+++ b/llvm/test/CodeGen/ARM/GlobalISel/arm-regbankselect.mir
@@ -109,9 +109,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -135,9 +135,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -161,9 +161,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -187,9 +187,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -213,9 +213,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -239,9 +239,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -265,9 +265,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -291,9 +291,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -317,9 +317,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -343,9 +343,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -369,9 +369,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -395,12 +395,12 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
-# CHECK: - { id: 4, class: gprb, preferred-register: '' }
-# CHECK: - { id: 5, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 4, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 5, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -429,11 +429,11 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
-# CHECK: - { id: 4, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 4, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -464,11 +464,11 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
-# CHECK: - { id: 4, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 4, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -497,9 +497,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -522,7 +522,7 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
 body:             |
@@ -538,8 +538,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -557,8 +557,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -576,8 +576,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -595,7 +595,7 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
 body:             |
@@ -611,9 +611,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -635,9 +635,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -659,9 +659,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -683,9 +683,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -707,10 +707,10 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -736,10 +736,10 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -765,10 +765,10 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -794,11 +794,11 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: gprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
-# CHECK: - { id: 4, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 4, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -829,8 +829,8 @@ selected:        false
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
-# CHECK: { id: 0, class: gprb, preferred-register: '' }
-# CHECK: { id: 1, class: gprb, preferred-register: '' }
+# CHECK: { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 # Check that we map the condition of the G_BRCOND into the GPR.
 # For the G_BR, there are no registers to map, but make sure we don't crash.
 body:             |
@@ -864,11 +864,11 @@ registers:
   - { id: 2, class: _ }
   - { id: 3, class: _ }
   - { id: 4, class: _ }
-# CHECK: { id: 0, class: gprb, preferred-register: '' }
-# CHECK: { id: 1, class: gprb, preferred-register: '' }
-# CHECK: { id: 2, class: gprb, preferred-register: '' }
-# CHECK: { id: 3, class: gprb, preferred-register: '' }
-# CHECK: { id: 4, class: gprb, preferred-register: '' }
+# CHECK: { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 2, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 3, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 4, class: gprb, preferred-register: '', flags: [  ] }
 body:             |
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
@@ -905,11 +905,11 @@ registers:
   - { id: 2, class: _ }
   - { id: 3, class: _ }
   - { id: 4, class: _ }
-# CHECK: { id: 0, class: gprb, preferred-register: '' }
-# CHECK: { id: 1, class: gprb, preferred-register: '' }
-# CHECK: { id: 2, class: fprb, preferred-register: '' }
-# CHECK: { id: 3, class: fprb, preferred-register: '' }
-# CHECK: { id: 4, class: fprb, preferred-register: '' }
+# CHECK: { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 2, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 3, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: { id: 4, class: fprb, preferred-register: '', flags: [  ] }
 body:             |
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
@@ -939,9 +939,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -965,9 +965,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -991,9 +991,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -1017,9 +1017,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -1043,9 +1043,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -1069,9 +1069,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -1095,9 +1095,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -1121,9 +1121,9 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }
@@ -1147,8 +1147,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1169,8 +1169,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1191,10 +1191,10 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
-# CHECK: - { id: 3, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1218,10 +1218,10 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
-# CHECK: - { id: 3, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1245,8 +1245,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1266,8 +1266,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1287,7 +1287,7 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
 body:             |
@@ -1305,7 +1305,7 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
 body:             |
@@ -1323,8 +1323,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1345,8 +1345,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1366,8 +1366,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1388,8 +1388,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: fprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1409,8 +1409,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1431,8 +1431,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1452,8 +1452,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1474,8 +1474,8 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: fprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: fprb, preferred-register: '', flags: [  ] }
 registers:
   - { id: 0, class: _ }
   - { id: 1, class: _ }
@@ -1495,11 +1495,11 @@ legalized:       true
 regBankSelected: false
 selected:        false
 # CHECK: registers:
-# CHECK: - { id: 0, class: gprb, preferred-register: '' }
-# CHECK: - { id: 1, class: gprb, preferred-register: '' }
-# CHECK: - { id: 2, class: fprb, preferred-register: '' }
-# CHECK: - { id: 3, class: gprb, preferred-register: '' }
-# CHECK: - { id: 4, class: gprb, preferred-register: '' }
+# CHECK: - { id: 0, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 1, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 2, class: fprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 3, class: gprb, preferred-register: '', flags: [  ] }
+# CHECK: - { id: 4, class: gprb, preferred-register: '', flags: [  ] }
 
 registers:
   - { id: 0, class: _ }

--- a/llvm/test/CodeGen/ARM/peephole-callee-save-regalloc.mir
+++ b/llvm/test/CodeGen/ARM/peephole-callee-save-regalloc.mir
@@ -5,7 +5,7 @@
 # the register class of the consumer.
 #
 # Check that register class for %5 is unchanged as 'tcgpr'
-# CHECK: { id: 5, class: tcgpr, preferred-register: '' }
+# CHECK: { id: 5, class: tcgpr, preferred-register: '', flags: [  ] }
 # CHECK: TCRETURNri killed %5
 
 --- |

--- a/llvm/test/CodeGen/MIR/AArch64/register-operand-bank.mir
+++ b/llvm/test/CodeGen/MIR/AArch64/register-operand-bank.mir
@@ -6,8 +6,8 @@
 ---
 # CHECK-LABEL: name: func
 # CHECK: registers:
-# CHECK:   - { id: 0, class: gpr, preferred-register: '' }
-# CHECK:   - { id: 1, class: fpr, preferred-register: '' }
+# CHECK:   - { id: 0, class: gpr, preferred-register: '', flags: [  ] }
+# CHECK:   - { id: 1, class: fpr, preferred-register: '', flags: [  ] }
 name: func
 body: |
   bb.0:

--- a/llvm/test/CodeGen/PowerPC/aix-p8vector-liveins.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-p8vector-liveins.ll
@@ -18,15 +18,15 @@ entry:
 }
 
 ; POWR8-LABEL: name:            vssr
-; POWR8:       - { id: 0, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 1, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 2, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 3, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 4, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 5, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 6, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 7, class: vssrc, preferred-register: '' }
-; POWR8:       - { id: 8, class: vssrc, preferred-register: '' }
+; POWR8:       - { id: 0, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 1, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 2, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 3, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 4, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 5, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 6, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 7, class: vssrc, preferred-register: '', flags: [  ] }
+; POWR8:       - { id: 8, class: vssrc, preferred-register: '', flags: [  ] }
 ; POWR8:       %4:vssrc = COPY $f5
 ; POWR8:       %3:vssrc = COPY $f4
 ; POWR8:       %2:vssrc = COPY $f3
@@ -40,15 +40,15 @@ entry:
 
 ; NOP8V-LABEL: name:            vssr
 ; NOP8V:       registers:
-; NOP8V:       - { id: 0, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 1, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 2, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 3, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 4, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 5, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 6, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 7, class: f4rc, preferred-register: '' }
-; NOP8V:       - { id: 8, class: f4rc, preferred-register: '' }
+; NOP8V:       - { id: 0, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 1, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 2, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 3, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 4, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 5, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 6, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 7, class: f4rc, preferred-register: '', flags: [  ] }
+; NOP8V:       - { id: 8, class: f4rc, preferred-register: '', flags: [  ] }
 ; NOP8V:        %4:f4rc = COPY $f5
 ; NOP8V:        %3:f4rc = COPY $f4
 ; NOP8V:        %2:f4rc = COPY $f3
@@ -71,15 +71,15 @@ entry:
 
 ; VSX-LABEL:   vsfr
 ; VSX:         registers:
-; VSX:          - { id: 0, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 1, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 2, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 3, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 4, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 5, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 6, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 7, class: vsfrc, preferred-register: '' }
-; VSX:          - { id: 8, class: vsfrc, preferred-register: '' }
+; VSX:          - { id: 0, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 1, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 2, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 3, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 4, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 5, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 6, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 7, class: vsfrc, preferred-register: '', flags: [  ] }
+; VSX:          - { id: 8, class: vsfrc, preferred-register: '', flags: [  ] }
 ; VSX:          %4:vsfrc = COPY $f5
 ; VSX:          %3:vsfrc = COPY $f4
 ; VSX:          %2:vsfrc = COPY $f3
@@ -93,15 +93,15 @@ entry:
 
 ; NOVSX-LABEL:  vsfr
 ; NOVSX:        registers:
-; NOVSX:        - { id: 0, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 1, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 2, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 3, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 4, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 5, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 6, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 7, class: f8rc, preferred-register: '' }
-; NOVSX:        - { id: 8, class: f8rc, preferred-register: '' }
+; NOVSX:        - { id: 0, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 1, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 2, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 3, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 4, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 5, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 6, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 7, class: f8rc, preferred-register: '', flags: [  ] }
+; NOVSX:        - { id: 8, class: f8rc, preferred-register: '', flags: [  ] }
 ; NOVSX:        %4:f8rc = COPY $f5
 ; NOVSX:        %3:f8rc = COPY $f4
 ; NOVSX:        %2:f8rc = COPY $f3


### PR DESCRIPTION
[MIR] Serialize virtual register flags #110228 introduces register flags which appear empty in .mir dumps. Future tests should use `-simplify-mir`.