### PR TITLE
Different info in docs in AST methods

### DIFF
--- a/clang/docs/LibASTMatchersReference.html
+++ b/clang/docs/LibASTMatchersReference.html
@@ -7239,9 +7239,9 @@ Given
   void z(Y y, X x) { y.m(); x.m(); x.g(); (g()).m(); }
 cxxMemberCallExpr(onImplicitObjectArgument(hasType(
     cxxRecordDecl(hasName("Y")))))
-  matches `y.m()`, `x.m()` and (g()).m(), but not `x.g()`.
+  matches `y.m()`, `x.m()` and (`g()).m()`, but not `x.g()`).
 cxxMemberCallExpr(on(callExpr()))
-  does not match `(g()).m()`, because the parens are not ignored.
+  only matches `(g()).m()` (the parens are ignored).
 
 FIXME: Overload to allow directly matching types?
 </pre></td></tr>

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -4199,7 +4199,7 @@ AST_MATCHER_P_OVERLOAD(QualType, references, internal::Matcher<Decl>,
 ///     cxxRecordDecl(hasName("Y")))))
 ///   matches `y.m()`, `x.m()` and (g()).m(), but not `x.g()`.
 /// cxxMemberCallExpr(on(callExpr()))
-///   does not match `(g()).m()`, because the parens are not ignored.
+///   does match `(g()).m()`, because the parens are ignored.
 ///
 /// FIXME: Overload to allow directly matching types?
 AST_MATCHER_P(CXXMemberCallExpr, onImplicitObjectArgument,

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -4197,9 +4197,9 @@ AST_MATCHER_P_OVERLOAD(QualType, references, internal::Matcher<Decl>,
 /// \endcode
 /// cxxMemberCallExpr(onImplicitObjectArgument(hasType(
 ///     cxxRecordDecl(hasName("Y")))))
-///   matches `y.m()`, `x.m()` and (g()).m(), but not `x.g()`.
+///   matches `y.m()`, `x.m()` and (`g()).m()`, but not `x.g()`).
 /// cxxMemberCallExpr(on(callExpr()))
-///   does match `(g()).m()`, because the parens are ignored.
+///   only matches `(g()).m()` (the parens are ignored).
 ///
 /// FIXME: Overload to allow directly matching types?
 AST_MATCHER_P(CXXMemberCallExpr, onImplicitObjectArgument,


### PR DESCRIPTION
[Here](https://github.com/llvm/llvm-project/blob/6a98c4a1602591c942f01dceb3aa29ffd4cf1e5b/clang/include/clang/ASTMatchers/ASTMatchers.h#L4188-L4203) and [here](https://github.com/llvm/llvm-project/blob/6a98c4a1602591c942f01dceb3aa29ffd4cf1e5b/clang/include/clang/ASTMatchers/ASTMatchers.h#L3679-L3695) we can see similar code samples and same examples:
```
cxxMemberCallExpr(on(callExpr()))
```

In the first case, it is [written](https://github.com/llvm/llvm-project/blob/6a98c4a1602591c942f01dceb3aa29ffd4cf1e5b/clang/include/clang/ASTMatchers/ASTMatchers.h#L4201) that the object must not be matched:
```
/// cxxMemberCallExpr(on(callExpr()))
///   does not match `(g()).m()`, because the parens are not ignored.
```
In the second case, it is [written](https://github.com/llvm/llvm-project/blob/6a98c4a1602591c942f01dceb3aa29ffd4cf1e5b/clang/include/clang/ASTMatchers/ASTMatchers.h#L3693) that the object must be matched:
```
/// cxxMemberCallExpr(on(callExpr()))
///   matches `(g()).m()`.
```

I think that parens are ignored