### PR TITLE
[NFC][CodingStandard] Extend if-else brace example with else-if

### DIFF
--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -1713,10 +1713,13 @@ would help to avoid running into a "dangling else" situation.
     handleOtherDecl(D);
   }
 
-  // Use braces for the `else` block to keep it uniform with the `if` block.
+  // Use braces for the `else if` and `else` block to keep it uniform with the
+  // `if` block.
   if (isa<FunctionDecl>(D)) {
     verifyFunctionDecl(D);
     handleFunctionDecl(D);
+  } else if (isa<GlobalVarDecl>(D)) {
+    handleGlobalVarDecl(D);
   } else {
     handleOtherDecl(D);
   }


### PR DESCRIPTION
Extend example to document that single statement `else if` needs a brace as well if the associated `if` needs a brace.