### PR TITLE
[mlir][transforms] Add `signalPassFailure` in RemoveDeadValues

### DIFF
--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -589,7 +589,7 @@ void RemoveDeadValues::runOnOperation() {
   });
 
   if (acceptableIR.wasInterrupted())
-    return;
+    return signalPassFailure();
 
   module->walk([&](Operation *op) {
     if (auto funcOp = dyn_cast<FunctionOpInterface>(op)) {


### PR DESCRIPTION
This PR adds `signalPassFailure` in RemoveDeadValues to ensure that a pipeline would stop here.
Fixes #111757.