### PR TITLE
[APInt] Fix getAllOnes() with zero width

### DIFF
--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -112,14 +112,21 @@ public:
         bool implicitTrunc = true)
       : BitWidth(numBits) {
     if (!implicitTrunc) {
-      if (BitWidth == 0) {
-        assert(val == 0 && "Value must be zero for 0-bit APInt");
-      } else if (isSigned) {
-        assert(llvm::isIntN(BitWidth, val) &&
-               "Value is not an N-bit signed value");
+      if (isSigned) {
+        if (BitWidth == 0) {
+          assert((val == 0 || val == uint64_t(-1)) &&
+                 "Value must be 0 or -1 for signed 0-bit APInt");
+        } else {
+          assert(llvm::isIntN(BitWidth, val) &&
+                 "Value is not an N-bit signed value");
+        }
       } else {
-        assert(llvm::isUIntN(BitWidth, val) &&
-               "Value is not an N-bit unsigned value");
+        if (BitWidth == 0) {
+          assert(val == 0 && "Value must be zero for unsigned 0-bit APInt");
+        } else {
+          assert(llvm::isUIntN(BitWidth, val) &&
+                 "Value is not an N-bit unsigned value");
+        }
       }
     }
     if (isSingleWord()) {

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -3423,6 +3423,7 @@ TEST(APIntTest, ZeroWidth) {
   EXPECT_EQ(0U, ZW.getBitWidth());
   EXPECT_EQ(0U, APInt(0, ArrayRef<uint64_t>({0, 1, 2})).getBitWidth());
   EXPECT_EQ(0U, APInt(0, "0", 10).getBitWidth());
+  EXPECT_EQ(0U, APInt::getAllOnes(0).getBitWidth());
 
   // Default constructor is single bit wide.
   EXPECT_EQ(1U, APInt().getBitWidth());


### PR DESCRIPTION
This makes sure that APInt::getAllOnes() keeps working after the APInt constructor assertions are enabled.

I'm relaxing the requirement for the signed case to either an all zeros or all ones integer. This is basically saying that we can interpret the zero-width integer as either positive or negative.