### PR TITLE
[MLIR][ROCDL] Added `SchedGroupBarrier` and `IglpOpt` ops

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -297,6 +297,24 @@ def ROCDL_SchedBarrier : ROCDL_IntrOp<"sched.barrier", [], [], [], 0>,
     "createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_sched_barrier,builder.getInt32(op.getMask()));";
 }
 
+def ROCDL_SchedGroupBarrier : ROCDL_IntrOp<"sched.group.barrier", [], [], [], 0>,
+  Arguments<(ins I32Attr:$mask, I32Attr:$size, I32Attr:$groupId)> {
+  let results = (outs);
+  let assemblyFormat = "$mask `,` $size `,` $groupId attr-dict";
+  string llvmBuilder = [{
+    createIntrinsicCall(builder,
+      llvm::Intrinsic::amdgcn_sched_group_barrier,
+      {builder.getInt32(op.getMask()), builder.getInt32(op.getSize()), builder.getInt32(op.getGroupId())});
+  }];
+}
+
+def ROCDL_IglpOpt : ROCDL_IntrOp<"iglp.opt", [], [], [], 0>,
+  Arguments<(ins I32Attr:$variant)> {
+  let results = (outs);
+  let assemblyFormat = "$variant attr-dict";
+  string llvmBuilder =
+    "createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_iglp_opt,builder.getInt32(op.getVariant()));";
+}
 
 //===---------------------------------------------------------------------===//
 // Xdlops intrinsics

--- a/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -41,6 +41,18 @@ func.func @rocdl.sched_barrier() {
   llvm.return
 }
 
+func.func @rocdl_sched_group_barrier() {
+  // CHECK: rocdl.sched.group.barrier
+  rocdl.sched.group.barrier 8, 1, 0
+  llvm.return
+}
+
+func.func @rocdl_iglp_opt() {
+  // CHECK: rocdl.iglp.opt
+  rocdl.iglp.opt 0
+  llvm.return
+}
+
 func.func @rocdl.setprio() {
   // CHECK: rocdl.s.setprio
   rocdl.s.setprio 0

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -179,6 +179,22 @@ llvm.func @rocdl.schedbarrier() {
   llvm.return
 }
 
+llvm.func @rocdl.sched.group.barrier() {
+  // CHECK-LABEL: rocdl.sched.group.barrier
+  // CHECK-NEXT: call void @llvm.amdgcn.sched.group.barrier(i32 8, i32 1, i32 0)
+  rocdl.sched.group.barrier 8, 1, 0
+  llvm.return
+}
+
+llvm.func @rocdl.iglp.opt() {
+  // CHECK-LABEL: rocdl.iglp.opt
+  // CHECK-NEXT: call void @llvm.amdgcn.iglp.opt(i32 0)
+  rocdl.iglp.opt 0
+  // CHECK-NEXT: call void @llvm.amdgcn.iglp.opt(i32 1)
+  rocdl.iglp.opt 1
+  llvm.return
+}
+
 llvm.func @rocdl.xdlops(%arg0 : f32, %arg1 : f32,
                    %arg2 : vector<32 x f32>, %arg3: i32,
                    %arg4 : vector<16 x f32>, %arg5 : vector<4xf32>,


### PR DESCRIPTION
This PR adds missing `sched.group.barrier` and `rocdl.iglp.opt` ops to the ROCDL dialect (see [here](https://github.com/llvm/llvm-project/blob/ec78f0da0e9b1b8e2b2323e434ea742e272dd913/clang/include/clang/Basic/BuiltinsAMDGPU.def#L66-L68)). The ops are converted to the corresponding intrinsic calls during the translation from MLIR to LLVM IRs. This intrinsics are hints to the instruction scheduler of the AMDGPU backend.