### PR TITLE
[lldb] Use CFPropertyListCreateData in debugserver (NFC)

### DIFF
--- a/lldb/tools/debugserver/source/RNBServices.cpp
+++ b/lldb/tools/debugserver/source/RNBServices.cpp
@@ -208,8 +208,8 @@ int ListApplications(std::string &plist, bool opt_runningApps,
   GetProcesses(plistMutableArray.get(), all_users);
 #endif
 
-  CFReleaser<CFDataRef> plistData(
-      ::CFPropertyListCreateXMLData(alloc, plistMutableArray.get()));
+  CFReleaser<CFDataRef> plistData(::CFPropertyListCreateData(
+      alloc, plistMutableArray.get(), kCFPropertyListXMLFormat_v1_0, 0, NULL));
 
   // write plist to service port
   if (plistData.get() != NULL) {


### PR DESCRIPTION
CFPropertyListCreateXMLData has been deprecated since macOS 10.10. Use CFPropertyListCreateData instead.