### PR TITLE
Reapply "[scudo] Apply the min release threshold to the group" (#112252)

### DIFF
--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -1492,6 +1492,11 @@ private:
       }
 
       const uptr PushedBytesDelta = BytesInBG - BG->BytesInBGAtLastCheckpoint;
+      if (PushedBytesDelta < getMinReleaseAttemptSize(BlockSize)) {
+        Prev = BG;
+        BG = BG->Next;
+        continue;
+      }
 
       // Given the randomness property, we try to release the pages only if the
       // bytes used by free blocks exceed certain proportion of group size. Note


### PR DESCRIPTION
This reverts commit 037938d637b830332e50232d7b90b5faad039c11.

Fixed the iterator to avoid infinite loop