### PR TITLE
[lld][WebAssembly] Fix build break when building liblldWasm.so

### DIFF
--- a/lld/wasm/CMakeLists.txt
+++ b/lld/wasm/CMakeLists.txt
@@ -28,6 +28,7 @@ add_lld_library(lldWasm
   Object
   Option
   Passes
+  ProfileData
   Support
   TargetParser
 


### PR DESCRIPTION
Fix `BUILD_SHARED_LIBS=ON` build for d4efc3e097f40afbe8ae275150f49bb08fc04572