### PR TITLE
[lldb] Narrow scope of -Wno-deprecated-declarations (NFC)

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -188,7 +188,6 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/../clang/include")
 
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
   # Disable GCC warnings
-  append("-Wno-deprecated-declarations" CMAKE_CXX_FLAGS)
   append("-Wno-unknown-pragmas" CMAKE_CXX_FLAGS)
   append("-Wno-strict-aliasing" CMAKE_CXX_FLAGS)
 
@@ -198,7 +197,6 @@ endif()
 
 # Disable Clang warnings
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  append("-Wno-deprecated-register" CMAKE_CXX_FLAGS)
   append("-Wno-vla-extension" CMAKE_CXX_FLAGS)
 endif()
 

--- a/lldb/source/Host/macosx/objcxx/CMakeLists.txt
+++ b/lldb/source/Host/macosx/objcxx/CMakeLists.txt
@@ -16,4 +16,6 @@ add_lldb_library(lldbHostMacOSXObjCXX NO_PLUGIN_DEPENDENCIES
     TargetParser
   )
 
-target_compile_options(lldbHostMacOSXObjCXX PRIVATE -fno-objc-exceptions)
+target_compile_options(lldbHostMacOSXObjCXX PRIVATE
+  -fno-objc-exceptions
+  -Wno-deprecated-declarations)


### PR DESCRIPTION
Currently all of LLDB is being compiled with -Wno-deprecated-declarations. That's not desirable, especially as part of the LLVM monorepo, as we miss deprecation warnings from LLVM and clang.

According to the git history, this was first introduced to suppress warnings related to auto_ptr. Since then, other things have been deprecated and gone unnoticed. This patch limits the flag to Host.mm which uses a handful of LSApplication headers that have no replacement.

rdar://112040718