### PR TITLE
[GenericCycle] Add a Cache for getExitBlocks in GenericCycle

### DIFF
--- a/llvm/include/llvm/ADT/GenericCycleImpl.h
+++ b/llvm/include/llvm/ADT/GenericCycleImpl.h
@@ -47,8 +47,8 @@ bool GenericCycle<ContextT>::contains(const GenericCycle *C) const {
 template <typename ContextT>
 void GenericCycle<ContextT>::getExitBlocks(
     SmallVectorImpl<BlockT *> &TmpStorage) const {
-  if (!ExitBlocksCache->empty()) {
-    TmpStorage = *ExitBlocksCache;
+  if (!ExitBlocksCache.empty()) {
+    TmpStorage = ExitBlocksCache;
     return;
   }
 
@@ -70,7 +70,7 @@ void GenericCycle<ContextT>::getExitBlocks(
 
     TmpStorage.resize(NumExitBlocks);
   }
-  ExitBlocksCache->append(TmpStorage.begin(), TmpStorage.end());
+  ExitBlocksCache.append(TmpStorage.begin(), TmpStorage.end());
 }
 
 template <typename ContextT>
@@ -304,6 +304,8 @@ void GenericCycleInfo<ContextT>::moveTopLevelCycleToNewParent(CycleT *NewParent,
   for (auto &It : BlockMapTopLevel)
     if (It.second == Child)
       It.second = NewParent;
+  NewParent->clearCache();
+  Child->clearCache();
 }
 
 template <typename ContextT>
@@ -322,6 +324,7 @@ void GenericCycleInfo<ContextT>::addBlockToCycle(BlockT *Block, CycleT *Cycle) {
   }
 
   BlockMapTopLevel.try_emplace(Block, Cycle);
+  Cycle->clearCache();
 }
 
 /// \brief Main function of the cycle info computations.

--- a/llvm/include/llvm/ADT/GenericCycleImpl.h
+++ b/llvm/include/llvm/ADT/GenericCycleImpl.h
@@ -47,6 +47,11 @@ bool GenericCycle<ContextT>::contains(const GenericCycle *C) const {
 template <typename ContextT>
 void GenericCycle<ContextT>::getExitBlocks(
     SmallVectorImpl<BlockT *> &TmpStorage) const {
+  if (!ExitBlocksCache->empty()) {
+    TmpStorage = *ExitBlocksCache;
+    return;
+  }
+
   TmpStorage.clear();
 
   size_t NumExitBlocks = 0;
@@ -65,6 +70,7 @@ void GenericCycle<ContextT>::getExitBlocks(
 
     TmpStorage.resize(NumExitBlocks);
   }
+  ExitBlocksCache->append(TmpStorage.begin(), TmpStorage.end());
 }
 
 template <typename ContextT>

--- a/llvm/include/llvm/ADT/GenericCycleInfo.h
+++ b/llvm/include/llvm/ADT/GenericCycleInfo.h
@@ -141,12 +141,7 @@ public:
   bool contains(const GenericCycle *C) const;
 
   const GenericCycle *getParentCycle() const { return ParentCycle; }
-
-  GenericCycle *getParentCycle() {
-    clearCache();
-    return ParentCycle;
-  }
-
+  GenericCycle *getParentCycle() { return ParentCycle; }
   unsigned getDepth() const { return Depth; }
 
   /// Return all of the successor blocks of this cycle.

--- a/llvm/include/llvm/ADT/GenericCycleInfo.h
+++ b/llvm/include/llvm/ADT/GenericCycleInfo.h
@@ -116,9 +116,7 @@ public:
   /// Clear the cache of the cycle.
   /// This should be run in all non-const function in GenericCycle
   /// and GenericCycleInfo.
-  void clearCache() const {
-    ExitBlocksCache.clear();
-  }
+  void clearCache() const { ExitBlocksCache.clear(); }
 
   /// \brief Return whether \p Block is an entry block of the cycle.
   bool isEntry(const BlockT *Block) const {

--- a/llvm/include/llvm/ADT/GenericCycleInfo.h
+++ b/llvm/include/llvm/ADT/GenericCycleInfo.h
@@ -74,12 +74,16 @@ private:
   ///       always have the same depth.
   unsigned Depth = 0;
 
+  /// Cache for the results of GetExitBlocks
+  std::unique_ptr<SmallVector<BlockT *, 4>> ExitBlocksCache;
+
   void clear() {
     Entries.clear();
     Children.clear();
     Blocks.clear();
     Depth = 0;
     ParentCycle = nullptr;
+    ExitBlocksCache->clear();
   }
 
   void appendEntry(BlockT *Block) { Entries.push_back(Block); }
@@ -91,7 +95,8 @@ private:
   GenericCycle &operator=(GenericCycle &&Rhs) = delete;
 
 public:
-  GenericCycle() = default;
+  GenericCycle()
+      : ExitBlocksCache(std::make_unique<SmallVector<BlockT *, 4>>()){};
 
   /// \brief Whether the cycle is a natural loop.
   bool isReducible() const { return Entries.size() == 1; }

--- a/llvm/include/llvm/ADT/GenericCycleInfo.h
+++ b/llvm/include/llvm/ADT/GenericCycleInfo.h
@@ -96,7 +96,7 @@ private:
 
 public:
   GenericCycle()
-      : ExitBlocksCache(std::make_unique<SmallVector<BlockT *, 4>>()){};
+      : ExitBlocksCache(std::make_unique<SmallVector<BlockT *, 4>>()) {};
 
   /// \brief Whether the cycle is a natural loop.
   bool isReducible() const { return Entries.size() == 1; }


### PR DESCRIPTION
In `UniformityAnalysis`, we need to get the exit blocks of cycles in the `DivergencePropagator` and currently, we have to do a search for the exit blocks every time. In this change, we add a cache of the results in the `GenericCycle` so that it can save the compile time. By testing, for some large cases, this can save about 60% compile time in the `UniformityAnalysis`.