### PR TITLE
[RISCV] Add missing assembler test case for c.addi zero, 0. NFC

### DIFF
--- a/llvm/test/MC/RISCV/rv32c-valid.s
+++ b/llvm/test/MC/RISCV/rv32c-valid.s
@@ -147,6 +147,11 @@ c.sub a4, a5
 # CHECK-ASM: encoding: [0x01,0x00]
 # CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zca' (part of the C extension, excluding compressed floating point loads/stores){{$}}
 c.nop
+# CHECK-ASM: c.addi zero, 0
+# CHECK-OBJ: c.nop
+# CHECK-ASM: encoding: [0x01,0x00]
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zca' (part of the C extension, excluding compressed floating point loads/stores){{$}}
+c.addi x0, 0
 # CHECK-ASM-AND-OBJ: c.ebreak
 # CHECK-ASM: encoding: [0x02,0x90]
 # CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zca' (part of the C extension, excluding compressed floating point loads/stores){{$}}


### PR DESCRIPTION
This is an assembly only alias for c.nop.