### PR TITLE
[clangd] Update clangDaemonTweaks to set symbol visibility macros

### DIFF
--- a/clang-tools-extra/clangd/refactor/tweaks/CMakeLists.txt
+++ b/clang-tools-extra/clangd/refactor/tweaks/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LLVM_LINK_COMPONENTS
 # To enable these tweaks in executables or shared libraries, add
 # $<TARGET_OBJECTS:obj.clangDaemonTweaks> to a list of sources, see
 # clangd/tool/CMakeLists.txt for an example.
-add_clang_library(clangDaemonTweaks OBJECT
+add_clang_library(clangDaemonTweaks CLANG_IMPORT OBJECT
   AddUsing.cpp
   AnnotateHighlightings.cpp
   DumpAST.cpp

--- a/clang-tools-extra/clangd/refactor/tweaks/CMakeLists.txt
+++ b/clang-tools-extra/clangd/refactor/tweaks/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LLVM_LINK_COMPONENTS
 # To enable these tweaks in executables or shared libraries, add
 # $<TARGET_OBJECTS:obj.clangDaemonTweaks> to a list of sources, see
 # clangd/tool/CMakeLists.txt for an example.
-add_clang_library(clangDaemonTweaks CLANG_IMPORT OBJECT
+add_clang_library(clangDaemonTweaks OBJECT
   AddUsing.cpp
   AnnotateHighlightings.cpp
   DumpAST.cpp

--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -47,7 +47,7 @@ endmacro()
 
 macro(add_clang_library name)
   cmake_parse_arguments(ARG
-    "SHARED;STATIC;INSTALL_WITH_TOOLCHAIN;CLANG_IMPORT"
+    "SHARED;STATIC;OBJECT;INSTALL_WITH_TOOLCHAIN;CLANG_EXPORT"
     ""
     "ADDITIONAL_HEADERS"
     ${ARGN})
@@ -115,7 +115,7 @@ macro(add_clang_library name)
     if(TARGET "obj.${name}")
       target_compile_definitions("obj.${name}" PUBLIC CLANG_BUILD_STATIC)
     endif()
-  elseif(TARGET "obj.${name}" AND NOT ARG_SHARED AND NOT ARG_STATIC AND NOT ARG_CLANG_IMPORT)
+  elseif(TARGET "obj.${name}" AND (ARG_CLANG_EXPORT OR NOT (ARG_SHARED OR ARG_STATIC OR ARG_OBJECT)))
     # Clang component libraries linked to clang-cpp are declared without SHARED or STATIC
     target_compile_definitions("obj.${name}" PUBLIC CLANG_EXPORTS)
   endif()

--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -47,7 +47,7 @@ endmacro()
 
 macro(add_clang_library name)
   cmake_parse_arguments(ARG
-    "SHARED;STATIC;INSTALL_WITH_TOOLCHAIN"
+    "SHARED;STATIC;INSTALL_WITH_TOOLCHAIN;CLANG_IMPORT"
     ""
     "ADDITIONAL_HEADERS"
     ${ARGN})
@@ -115,7 +115,7 @@ macro(add_clang_library name)
     if(TARGET "obj.${name}")
       target_compile_definitions("obj.${name}" PUBLIC CLANG_BUILD_STATIC)
     endif()
-  elseif(TARGET "obj.${name}" AND NOT ARG_SHARED AND NOT ARG_STATIC)
+  elseif(TARGET "obj.${name}" AND NOT ARG_SHARED AND NOT ARG_STATIC AND NOT ARG_CLANG_IMPORT)
     # Clang component libraries linked to clang-cpp are declared without SHARED or STATIC
     target_compile_definitions("obj.${name}" PUBLIC CLANG_EXPORTS)
   endif()


### PR DESCRIPTION
Update clangDaemonTweaks cmake target to set explicit symbol visibility macros to correct mode for windows.
This will fix linker duplicate symbols errors from clangDaemonTweaks exporting clang symbols instead of importing them for windows shared library builds using explicit symbol visibly.

This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and LLVM/Clang plugins on window.