### PR TITLE
[APFloat] Fix `APFloat::getOne`

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1046,7 +1046,10 @@ public:
   ///
   /// \param Negative True iff the number should be negative.
   static APFloat getOne(const fltSemantics &Sem, bool Negative = false) {
-    return APFloat(Sem, Negative ? -1 : 1);
+    APFloat Val(Sem, 1U);
+    if (Negative)
+      Val.changeSign();
+    return Val;
   }
 
   /// Factory for Positive and Negative Infinity.

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -892,6 +892,13 @@ TEST(APFloatTest, Zero) {
   EXPECT_EQ(fcNegZero, APFloat(-0.0).classify());
 }
 
+TEST(APFloatTest, getOne) {
+  EXPECT_EQ(APFloat::getOne(APFloat::IEEEsingle(), false).convertToFloat(),
+            1.0f);
+  EXPECT_EQ(APFloat::getOne(APFloat::IEEEsingle(), true).convertToFloat(),
+            -1.0f);
+}
+
 TEST(APFloatTest, DecimalStringsWithoutNullTerminators) {
   // Make sure that we can parse strings without null terminators.
   // rdar://14323230.


### PR DESCRIPTION
`APFloat::APFloat(const fltSemantics &Semantics, integerPart I)` interprets 'I' as a unsigned integer.
Fix the bug found in https://github.com/llvm/llvm-project/pull/112113#discussion_r1799744541.
