### PR TITLE
[Clang][TableGen] Use const pointers for various Init objects in NeonEmitter

### DIFF
--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -321,7 +321,7 @@ class Intrinsic {
   ClassKind CK;
   /// The list of DAGs for the body. May be empty, in which case we should
   /// emit a builtin call.
-  ListInit *Body;
+  const ListInit *Body;
   /// The architectural ifdef guard.
   std::string ArchGuard;
   /// The architectural target() guard.
@@ -372,9 +372,9 @@ class Intrinsic {
 
 public:
   Intrinsic(const Record *R, StringRef Name, StringRef Proto, TypeSpec OutTS,
-            TypeSpec InTS, ClassKind CK, ListInit *Body, NeonEmitter &Emitter,
-            StringRef ArchGuard, StringRef TargetGuard, bool IsUnavailable,
-            bool BigEndianSafe)
+            TypeSpec InTS, ClassKind CK, const ListInit *Body,
+            NeonEmitter &Emitter, StringRef ArchGuard, StringRef TargetGuard,
+            bool IsUnavailable, bool BigEndianSafe)
       : R(R), Name(Name.str()), OutTS(OutTS), InTS(InTS), CK(CK), Body(Body),
         ArchGuard(ArchGuard.str()), TargetGuard(TargetGuard.str()),
         IsUnavailable(IsUnavailable), BigEndianSafe(BigEndianSafe),
@@ -554,19 +554,20 @@ private:
     DagEmitter(Intrinsic &Intr, StringRef CallPrefix) :
       Intr(Intr), CallPrefix(CallPrefix) {
     }
-    std::pair<Type, std::string> emitDagArg(Init *Arg, std::string ArgName);
-    std::pair<Type, std::string> emitDagSaveTemp(DagInit *DI);
-    std::pair<Type, std::string> emitDagSplat(DagInit *DI);
-    std::pair<Type, std::string> emitDagDup(DagInit *DI);
-    std::pair<Type, std::string> emitDagDupTyped(DagInit *DI);
-    std::pair<Type, std::string> emitDagShuffle(DagInit *DI);
-    std::pair<Type, std::string> emitDagCast(DagInit *DI, bool IsBitCast);
-    std::pair<Type, std::string> emitDagCall(DagInit *DI,
+    std::pair<Type, std::string> emitDagArg(const Init *Arg,
+                                            std::string ArgName);
+    std::pair<Type, std::string> emitDagSaveTemp(const DagInit *DI);
+    std::pair<Type, std::string> emitDagSplat(const DagInit *DI);
+    std::pair<Type, std::string> emitDagDup(const DagInit *DI);
+    std::pair<Type, std::string> emitDagDupTyped(const DagInit *DI);
+    std::pair<Type, std::string> emitDagShuffle(const DagInit *DI);
+    std::pair<Type, std::string> emitDagCast(const DagInit *DI, bool IsBitCast);
+    std::pair<Type, std::string> emitDagCall(const DagInit *DI,
                                              bool MatchMangledName);
-    std::pair<Type, std::string> emitDagNameReplace(DagInit *DI);
-    std::pair<Type, std::string> emitDagLiteral(DagInit *DI);
-    std::pair<Type, std::string> emitDagOp(DagInit *DI);
-    std::pair<Type, std::string> emitDag(DagInit *DI);
+    std::pair<Type, std::string> emitDagNameReplace(const DagInit *DI);
+    std::pair<Type, std::string> emitDagLiteral(const DagInit *DI);
+    std::pair<Type, std::string> emitDagOp(const DagInit *DI);
+    std::pair<Type, std::string> emitDag(const DagInit *DI);
   };
 };
 
@@ -1410,9 +1411,9 @@ void Intrinsic::emitBody(StringRef CallPrefix) {
 
   // We have a list of "things to output". The last should be returned.
   for (auto *I : Body->getValues()) {
-    if (StringInit *SI = dyn_cast<StringInit>(I)) {
+    if (const auto *SI = dyn_cast<StringInit>(I)) {
       Lines.push_back(replaceParamsIn(SI->getAsString()));
-    } else if (DagInit *DI = dyn_cast<DagInit>(I)) {
+    } else if (const auto *DI = dyn_cast<DagInit>(I)) {
       DagEmitter DE(*this, CallPrefix);
       Lines.push_back(DE.emitDag(DI).second + ";");
     }
@@ -1438,9 +1439,9 @@ void Intrinsic::emitReturn() {
   emitNewLine();
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDag(DagInit *DI) {
+std::pair<Type, std::string> Intrinsic::DagEmitter::emitDag(const DagInit *DI) {
   // At this point we should only be seeing a def.
-  DefInit *DefI = cast<DefInit>(DI->getOperator());
+  const DefInit *DefI = cast<DefInit>(DI->getOperator());
   std::string Op = DefI->getAsString();
 
   if (Op == "cast" || Op == "bitcast")
@@ -1467,7 +1468,8 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDag(DagInit *DI) {
   return std::make_pair(Type::getVoid(), "");
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagOp(DagInit *DI) {
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagOp(const DagInit *DI) {
   std::string Op = cast<StringInit>(DI->getArg(0))->getAsUnquotedString();
   if (DI->getNumArgs() == 2) {
     // Unary op.
@@ -1486,7 +1488,7 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagOp(DagInit *DI) {
 }
 
 std::pair<Type, std::string>
-Intrinsic::DagEmitter::emitDagCall(DagInit *DI, bool MatchMangledName) {
+Intrinsic::DagEmitter::emitDagCall(const DagInit *DI, bool MatchMangledName) {
   std::vector<Type> Types;
   std::vector<std::string> Values;
   for (unsigned I = 0; I < DI->getNumArgs() - 1; ++I) {
@@ -1498,7 +1500,7 @@ Intrinsic::DagEmitter::emitDagCall(DagInit *DI, bool MatchMangledName) {
 
   // Look up the called intrinsic.
   std::string N;
-  if (StringInit *SI = dyn_cast<StringInit>(DI->getArg(0)))
+  if (const auto *SI = dyn_cast<StringInit>(DI->getArg(0)))
     N = SI->getAsUnquotedString();
   else
     N = emitDagArg(DI->getArg(0), "").second;
@@ -1529,8 +1531,8 @@ Intrinsic::DagEmitter::emitDagCall(DagInit *DI, bool MatchMangledName) {
   return std::make_pair(Callee.getReturnType(), S);
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagCast(DagInit *DI,
-                                                                bool IsBitCast){
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagCast(const DagInit *DI, bool IsBitCast) {
   // (cast MOD* VAL) -> cast VAL to type given by MOD.
   std::pair<Type, std::string> R =
       emitDagArg(DI->getArg(DI->getNumArgs() - 1),
@@ -1552,7 +1554,7 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagCast(DagInit *DI,
       castToType =
           Intr.Variables[std::string(DI->getArgNameStr(ArgIdx))].getType();
     } else {
-      StringInit *SI = dyn_cast<StringInit>(DI->getArg(ArgIdx));
+      const auto *SI = dyn_cast<StringInit>(DI->getArg(ArgIdx));
       assert_with_loc(SI, "Expected string type or $Name for cast type");
 
       if (SI->getAsUnquotedString() == "R") {
@@ -1599,7 +1601,8 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagCast(DagInit *DI,
   return std::make_pair(castToType, S);
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagShuffle(DagInit *DI){
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagShuffle(const DagInit *DI) {
   // See the documentation in arm_neon.td for a description of these operators.
   class LowHalf : public SetTheory::Operator {
   public:
@@ -1710,7 +1713,8 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagShuffle(DagInit *DI){
   return std::make_pair(T, S);
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagDup(DagInit *DI) {
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagDup(const DagInit *DI) {
   assert_with_loc(DI->getNumArgs() == 1, "dup() expects one argument");
   std::pair<Type, std::string> A =
       emitDagArg(DI->getArg(0), std::string(DI->getArgNameStr(0)));
@@ -1729,7 +1733,8 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagDup(DagInit *DI) {
   return std::make_pair(T, S);
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagDupTyped(DagInit *DI) {
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagDupTyped(const DagInit *DI) {
   assert_with_loc(DI->getNumArgs() == 2, "dup_typed() expects two arguments");
   std::pair<Type, std::string> B =
       emitDagArg(DI->getArg(1), std::string(DI->getArgNameStr(1)));
@@ -1737,7 +1742,7 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagDupTyped(DagInit *DI)
                   "dup_typed() requires a scalar as the second argument");
   Type T;
   // If the type argument is a constant string, construct the type directly.
-  if (StringInit *SI = dyn_cast<StringInit>(DI->getArg(0))) {
+  if (const auto *SI = dyn_cast<StringInit>(DI->getArg(0))) {
     T = Type::fromTypedefName(SI->getAsUnquotedString());
     assert_with_loc(!T.isVoid(), "Unknown typedef");
   } else
@@ -1755,7 +1760,8 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagDupTyped(DagInit *DI)
   return std::make_pair(T, S);
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagSplat(DagInit *DI) {
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagSplat(const DagInit *DI) {
   assert_with_loc(DI->getNumArgs() == 2, "splat() expects two arguments");
   std::pair<Type, std::string> A =
       emitDagArg(DI->getArg(0), std::string(DI->getArgNameStr(0)));
@@ -1774,7 +1780,8 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagSplat(DagInit *DI) {
   return std::make_pair(Intr.getBaseType(), S);
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagSaveTemp(DagInit *DI) {
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagSaveTemp(const DagInit *DI) {
   assert_with_loc(DI->getNumArgs() == 2, "save_temp() expects two arguments");
   std::pair<Type, std::string> A =
       emitDagArg(DI->getArg(1), std::string(DI->getArgNameStr(1)));
@@ -1797,7 +1804,7 @@ std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagSaveTemp(DagInit *DI)
 }
 
 std::pair<Type, std::string>
-Intrinsic::DagEmitter::emitDagNameReplace(DagInit *DI) {
+Intrinsic::DagEmitter::emitDagNameReplace(const DagInit *DI) {
   std::string S = Intr.Name;
 
   assert_with_loc(DI->getNumArgs() == 2, "name_replace requires 2 arguments!");
@@ -1812,14 +1819,15 @@ Intrinsic::DagEmitter::emitDagNameReplace(DagInit *DI) {
   return std::make_pair(Type::getVoid(), S);
 }
 
-std::pair<Type, std::string> Intrinsic::DagEmitter::emitDagLiteral(DagInit *DI){
+std::pair<Type, std::string>
+Intrinsic::DagEmitter::emitDagLiteral(const DagInit *DI) {
   std::string Ty = cast<StringInit>(DI->getArg(0))->getAsUnquotedString();
   std::string Value = cast<StringInit>(DI->getArg(1))->getAsUnquotedString();
   return std::make_pair(Type::fromTypedefName(Ty), Value);
 }
 
 std::pair<Type, std::string>
-Intrinsic::DagEmitter::emitDagArg(Init *Arg, std::string ArgName) {
+Intrinsic::DagEmitter::emitDagArg(const Init *Arg, std::string ArgName) {
   if (!ArgName.empty()) {
     assert_with_loc(!Arg->isComplete(),
                     "Arguments must either be DAGs or names, not both!");
@@ -1830,7 +1838,7 @@ Intrinsic::DagEmitter::emitDagArg(Init *Arg, std::string ArgName) {
   }
 
   assert(Arg && "Neither ArgName nor Arg?!");
-  DagInit *DI = dyn_cast<DagInit>(Arg);
+  const auto *DI = dyn_cast<DagInit>(Arg);
   assert_with_loc(DI, "Arguments must either be DAGs or names!");
 
   return emitDag(DI);
@@ -1994,7 +2002,7 @@ void NeonEmitter::createIntrinsic(const Record *R,
   // decent location information even when highly nested.
   CurrentRecord = R;
 
-  ListInit *Body = OperationRec->getValueAsListInit("Ops");
+  const ListInit *Body = OperationRec->getValueAsListInit("Ops");
 
   std::vector<TypeSpec> TypeSpecs = TypeSpec::fromTypeSpecs(Types);
 


### PR DESCRIPTION
Use const pointers for various Init objects in NeonEmitter.  This is a part of effort to have better const correctness in TableGen backends:


https://discourse.llvm.org/t/psa-planned-changes-to-tablegen-getallderiveddefinitions-api-potential-downstream-breakages/81089