### PR TITLE
[ELF] Add context-aware diagnostic functions

### DIFF
--- a/lld/Common/ErrorHandler.cpp
+++ b/lld/Common/ErrorHandler.cpp
@@ -335,3 +335,21 @@ void ErrorHandler::fatal(const Twine &msg) {
   error(msg);
   exitLld(1);
 }
+
+SyncStream::~SyncStream() {
+  os.flush();
+  switch (level) {
+  case DiagLevel::Log:
+    e.log(buf);
+    break;
+  case DiagLevel::Warn:
+    e.warn(buf);
+    break;
+  case DiagLevel::Err:
+    e.error(buf);
+    break;
+  case DiagLevel::Fatal:
+    e.fatal(buf);
+    break;
+  }
+}

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -66,6 +66,12 @@ std::string lld::toString(const InputFile *f) {
   return std::string(f->toStringCache);
 }
 
+const ELFSyncStream &elf::operator<<(const ELFSyncStream &s,
+                                     const InputFile *f) {
+  s << toString(f);
+  return s;
+}
+
 static ELFKind getELFKind(MemoryBufferRef mb, StringRef archiveName) {
   unsigned char size;
   unsigned char endian;

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -386,6 +386,8 @@ ELFFileBase *createObjFile(Ctx &, MemoryBufferRef mb,
 
 std::string replaceThinLTOSuffix(Ctx &, StringRef path);
 
+const ELFSyncStream &operator<<(const ELFSyncStream &, const InputFile *);
+
 } // namespace elf
 } // namespace lld
 

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -45,6 +45,15 @@ std::string lld::toString(RelType type) {
   return std::string(s);
 }
 
+const ELFSyncStream &elf::operator<<(const ELFSyncStream &s, RelType type) {
+  StringRef buf = getELFRelocationTypeName(s.ctx.arg.emachine, type);
+  if (buf == "Unknown")
+    s << "Unknown (" << type << ')';
+  else
+    s << buf;
+  return s;
+}
+
 void elf::setTarget(Ctx &ctx) {
   switch (ctx.arg.emachine) {
   case EM_386:

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -327,6 +327,8 @@ inline uint64_t overwriteULEB128(uint8_t *bufLoc, uint64_t val) {
   *bufLoc = val;
   return val;
 }
+
+const ELFSyncStream &operator<<(const ELFSyncStream &, RelType);
 } // namespace elf
 } // namespace lld
 

--- a/lld/include/lld/Common/ErrorHandler.h
+++ b/lld/include/lld/Common/ErrorHandler.h
@@ -73,11 +73,11 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileOutputBuffer.h"
+#include "llvm/Support/raw_ostream.h"
 #include <mutex>
 
 namespace llvm {
 class DiagnosticInfo;
-class raw_ostream;
 }
 
 namespace lld {
@@ -151,6 +151,21 @@ void log(const Twine &msg);
 void message(const Twine &msg, llvm::raw_ostream &s = outs());
 void warn(const Twine &msg);
 uint64_t errorCount();
+
+enum class DiagLevel { Log, Warn, Err, Fatal };
+
+// A class that synchronizes thread writing to the same stream similar
+// std::osyncstream.
+class SyncStream {
+  ErrorHandler &e;
+  DiagLevel level;
+  std::string buf;
+
+public:
+  mutable llvm::raw_string_ostream os{buf};
+  SyncStream(ErrorHandler &e, DiagLevel level) : e(e), level(level) {}
+  ~SyncStream();
+};
 
 [[noreturn]] void exitLld(int val);
 


### PR DESCRIPTION
The current diagnostic functions log/warn/error/fatal lack a context
argument and call the global `lld::errorHandler()`, which prevents
multiple lld instances in one process.

This patch introduces context-aware replacements:

* log => Log(ctx)
* warn => Warn(ctx)
* errorOrWarn => Err(ctx)
* error => ErrAlways(ctx)
* fatal => Fatal(ctx)

Example: `errorOrWarn(toString(f) + "xxx")` => `Err(ctx) << f << "xxx"`.
(`toString(f)` is shortened to `f` as a bonus and may access `ctx`
without accessing the global variable (see `Target.cpp`)).

`ctx.e = &context->e;` can be replaced with a non-global Errorhandler
when `ctx` becomes a local variable.

(For the ELF port, the long term goal is to eliminate `error`. Most can
be straightforwardly converted to `Err(ctx)`.)