### PR TITLE
[lld] Fix warning in SymbolTable.cpp

### DIFF
--- a/lld/ELF/SymbolTable.cpp
+++ b/lld/ELF/SymbolTable.cpp
@@ -337,7 +337,7 @@ void SymbolTable::scanVersionScript() {
         globalAsteriskFound = !isLocal;
       }
     }
-    assignWildcard(pat, isLocal ? VER_NDX_LOCAL : ver->id, ver->name);
+    assignWildcard(pat, isLocal ? (uint16_t)VER_NDX_LOCAL : ver->id, ver->name);
   };
   for (VersionDefinition &v : llvm::reverse(ctx.arg.versionDefinitions)) {
     for (SymbolVersion &pat : v.nonLocalPatterns)


### PR DESCRIPTION
Fix gcc warning:

lld/ELF/SymbolTable.cpp:340:33: warning: enumeral and non-enumeral type in conditional expression [-Wextra]