### PR TITLE
[BOLT][merge-fdata]Fix support for fdata files starting with no_lbr on ARM platform 

### DIFF
--- a/bolt/test/merge-fdata-between-no-lbr-and-lbr.test
+++ b/bolt/test/merge-fdata-between-no-lbr-and-lbr.test
@@ -1,0 +1,14 @@
+## Test that merge-fdata fails to mix fdata files with and without the no_lbr marker.
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: not merge-fdata %t/a.fdata %t/b.fdata 2>&1 | FileCheck %s
+
+# CHECK: cannot mix profile collected on LBR and non-LBR architectures
+
+#--- a.fdata
+no_lbr
+main 1
+#--- b.fdata
+main 1

--- a/bolt/test/merge-fdata-between-two-no-lbr.test
+++ b/bolt/test/merge-fdata-between-two-no-lbr.test
@@ -1,0 +1,17 @@
+## Test that merge-fdata correctly handles merging two fdata files with the no_lbr marker.
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: merge-fdata %t/a.fdata %t/b.fdata -o %t/merged.fdata
+# RUN: FileCheck %s --input-file %t/merged.fdata
+
+# CHECK: no_lbr
+# CHECK: main 2
+
+#--- a.fdata
+no_lbr
+main 1
+#--- b.fdata
+no_lbr
+main 1


### PR DESCRIPTION
The merge-fdata tool did not support fdata files starting with no_lbr, which was not user-friendly for the ARM platform.
Therefore, I fixed this issue to enable its use on the ARM platform (with no_lbr). Additionally, I validated the merging of samples across both LBR and Non-LBR scenarios.