### PR TITLE
[OpenMP] [OMPD] gdb plugin: remove 'imp' import

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/ompd_handles.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_handles.py
@@ -1,5 +1,4 @@
 import ompdModule
-import imp
 
 
 class ompd_parallel(object):


### PR DESCRIPTION
The 'imp' library was removed in Python 3.12.

As the code never uses the imp library, the import is simply removed.