### PR TITLE
[fuzzer] fix clang-cl build fuzzer lit test failure

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
@@ -22,6 +22,11 @@ using namespace fuzzer;
 #define STRINGIFY(A) STRINGIFY_(A)
 
 #if LIBFUZZER_MSVC
+#define GET_FUNCTION_ADDRESS(fn) &fn
+#else
+#define GET_FUNCTION_ADDRESS(fn) __builtin_function_start(fn)
+#endif // LIBFUZER_MSVC
+
 // Copied from compiler-rt/lib/sanitizer_common/sanitizer_win_defs.h
 #if defined(_M_IX86) || defined(__i386__)
 #define WIN_SYM_PREFIX "_"
@@ -31,17 +36,9 @@ using namespace fuzzer;
 
 // Declare external functions as having alternativenames, so that we can
 // determine if they are not defined.
-#define EXTERNAL_FUNC(Name, Default)                                   \
-  __pragma(comment(linker, "/alternatename:" WIN_SYM_PREFIX STRINGIFY( \
+#define EXTERNAL_FUNC(Name, Default)                                           \
+  __pragma(comment(linker, "/alternatename:" WIN_SYM_PREFIX STRINGIFY(         \
                                Name) "=" WIN_SYM_PREFIX STRINGIFY(Default)))
-#else
-// Declare external functions as weak to allow them to default to a specified
-// function if not defined explicitly. We must use weak symbols because clang's
-// support for alternatename is not 100%, see
-// https://bugs.llvm.org/show_bug.cgi?id=40218 for more details.
-#define EXTERNAL_FUNC(Name, Default) \
-  __attribute__((weak, alias(STRINGIFY(Default))))
-#endif  // LIBFUZZER_MSVC
 
 extern "C" {
 #define EXT_FUNC(NAME, RETURN_TYPE, FUNC_SIG, WARN)         \
@@ -57,20 +54,23 @@ extern "C" {
 }
 
 template <typename T>
-static T *GetFnPtr(T *Fun, T *FunDef, const char *FnName, bool WarnIfMissing) {
+static T *GetFnPtr(void *Fun, void *FunDef, const char *FnName,
+                   bool WarnIfMissing) {
   if (Fun == FunDef) {
     if (WarnIfMissing)
       Printf("WARNING: Failed to find function \"%s\".\n", FnName);
     return nullptr;
   }
-  return Fun;
+  return (T *)Fun;
 }
 
 namespace fuzzer {
 
 ExternalFunctions::ExternalFunctions() {
-#define EXT_FUNC(NAME, RETURN_TYPE, FUNC_SIG, WARN) \
-  this->NAME = GetFnPtr<decltype(::NAME)>(::NAME, ::NAME##Def, #NAME, WARN);
+#define EXT_FUNC(NAME, RETURN_TYPE, FUNC_SIG, WARN)                            \
+  this->NAME = GetFnPtr<decltype(::NAME)>(GET_FUNCTION_ADDRESS(::NAME),        \
+                                          GET_FUNCTION_ADDRESS(::NAME##Def),   \
+                                          #NAME, WARN);
 
 #include "FuzzerExtFunctions.def"
 


### PR DESCRIPTION
The `check-fuzzer` runs fine with cl build llvm, but the following lit tests fail with clang-cl build llvm
```
********************
Timed Out Tests (2):
  libFuzzer-x86_64-default-Windows :: fork-ubsan.test
  libFuzzer-x86_64-default-Windows :: fuzzer-oom.test

********************
Failed Tests (22):
  libFuzzer-x86_64-default-Windows :: acquire-crash-state.test
  libFuzzer-x86_64-default-Windows :: cross_over_copy.test
  libFuzzer-x86_64-default-Windows :: cross_over_insert.test
  libFuzzer-x86_64-default-Windows :: exit_on_src_pos.test
  libFuzzer-x86_64-default-Windows :: fuzzer-alignment-assumption.test
  libFuzzer-x86_64-default-Windows :: fuzzer-implicit-integer-sign-change.test
  libFuzzer-x86_64-default-Windows :: fuzzer-implicit-signed-integer-truncation-or-sign-change.test
  libFuzzer-x86_64-default-Windows :: fuzzer-implicit-signed-integer-truncation.test
  libFuzzer-x86_64-default-Windows :: fuzzer-implicit-unsigned-integer-truncation.test
  libFuzzer-x86_64-default-Windows :: fuzzer-printcovpcs.test
  libFuzzer-x86_64-default-Windows :: fuzzer-timeout.test
  libFuzzer-x86_64-default-Windows :: fuzzer-ubsan.test
  libFuzzer-x86_64-default-Windows :: minimize_crash.test
  libFuzzer-x86_64-default-Windows :: minimize_two_crashes.test
  libFuzzer-x86_64-default-Windows :: null-deref-on-empty.test
  libFuzzer-x86_64-default-Windows :: null-deref.test
  libFuzzer-x86_64-default-Windows :: print-func.test
  libFuzzer-x86_64-default-Windows :: stack-overflow-with-asan.test
  libFuzzer-x86_64-default-Windows :: trace-malloc-2.test
  libFuzzer-x86_64-default-Windows :: trace-malloc-unbalanced.test
  libFuzzer-x86_64-default-Windows :: trace-malloc.test
```

The related commits are https://github.com/llvm/llvm-project/commit/53a81d4d26f0409de8a0655d7af90f2bea222a12 and https://github.com/llvm/llvm-project/commit/e31efd8f6fbc27000a4933f889e0deb922411006. Following the change in https://github.com/llvm/llvm-project/commit/e31efd8f6fbc27000a4933f889e0deb922411006 can fix these failures.

As for the issue mentioned in the comment that alternatename support in clang not good enough(https://bugs.llvm.org/show_bug.cgi?id=40218). I find that using `__builtin_function_start(func)` instead of directly using `func` would make it work as intended.