### PR TITLE
[lldb] Support tests with nested make invocations on Windows 1/2

### DIFF
--- a/lldb/test/API/functionalities/completion/Makefile
+++ b/lldb/test/API/functionalities/completion/Makefile
@@ -4,7 +4,7 @@ USE_LIBDL := 1
 a.out: lib_shared
 
 lib_shared:
-	$(MAKE) -f $(MAKEFILE_RULES) \
+	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=shared.cpp DYLIB_NAME=shared
 
 include Makefile.rules


### PR DESCRIPTION
In recent PR https://github.com/llvm/llvm-project/pull/111531 for Windows support, we enabled tests that require the `make` tool. On Windows default install directories likely contain spaces, in this case e.g. `C:\Program Files (x86)\GnuWin32\bin\make.exe`. It's typically handled well by CMake, so that today invocations from `dotest.py` don't cause issues. However, we also have nested invocations from a number of Makefiles themselves. These still fail if the path to the `make` tool contains spaces.