### PR TITLE
[lldb][test] Fix TestStdCXXDisassembly test

### DIFF
--- a/lldb/test/API/lang/cpp/stl/Makefile
+++ b/lldb/test/API/lang/cpp/stl/Makefile
@@ -1,5 +1,9 @@
 CXX_SOURCES := main.cpp
 
-USE_LIBSTDCPP := 1
+ifneq ($(OS),Darwin)
+    USE_LIBSTDCPP := 1
+else
+    USE_SYSTEM_STDLIB := 1
+endif
 
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/stl/Makefile
+++ b/lldb/test/API/lang/cpp/stl/Makefile
@@ -1,5 +1,5 @@
 CXX_SOURCES := main.cpp
 
-USE_SYSTEM_STDLIB := 1
+USE_LIBSTDCPP := 1
 
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
+++ b/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
@@ -43,7 +43,10 @@ class StdCXXDisassembleTestCase(TestBase):
         # At this point, lib_stdcxx is the full path to the stdc++ library and
         # module is the corresponding SBModule.
 
-        self.expect(lib_stdcxx, "Library StdC++ is located", exe=False, substrs=["lib"])
+        if "lib" not in lib_stdcxx:
+            self.skipTest(
+                "This test requires libstdc++.so or libc++.dylib in the target's module list."
+            )
 
         self.runCmd("image dump symtab '%s'" % lib_stdcxx)
         raw_output = self.res.GetOutput()


### PR DESCRIPTION
The patch #98694 was not enough. This test is still failed on the buildbot https://lab.llvm.org/staging/#/builders/195/builds/4438 
Use `USE_LIBSTDCPP := 1` instead for non Darwin OS and skip the test if libstdc++.so is missing.