### PR TITLE
[mlir][vector] Update document for `vector.splat`(NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2808,7 +2808,7 @@ def Vector_SplatOp : Vector_Op<"splat", [
 
     ```mlir
     %s = arith.constant 10.1 : f32
-    %t = vector.splat %s : vector<8x16xi32>
+    %t = vector.splat %s : vector<8x16xf32>
     ```
   }];
 


### PR DESCRIPTION
This PR updates the document for `vector.splat`, specifying that the operand type must match the element type of the result.