### PR TITLE
[Coroutines] Improve dump of BB label to avoid str copies

### DIFF
--- a/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
+++ b/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
@@ -25,6 +25,8 @@
 
 namespace llvm {
 
+class ModuleSlotTracker;
+
 // Provides two way mapping between the blocks and numbers.
 class BlockToIndexMapping {
   SmallVector<BasicBlock *, 32> V;
@@ -96,7 +98,8 @@ public:
   // Print order is in RPO
   void dump() const;
   void dump(StringRef Label, BitVector const &BV,
-            const ReversePostOrderTraversal<Function *> &RPOT) const;
+            const ReversePostOrderTraversal<Function *> &RPOT,
+            ModuleSlotTracker &MST) const;
 #endif
 
   SuspendCrossingInfo(Function &F,

--- a/llvm/lib/Transforms/Coroutines/MaterializationUtils.cpp
+++ b/llvm/lib/Transforms/Coroutines/MaterializationUtils.cpp
@@ -15,6 +15,7 @@
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instruction.h"
+#include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/Transforms/Coroutines/SpillUtils.h"
 #include <deque>
 
@@ -104,19 +105,25 @@ struct RematGraph {
   }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  static std::string getBasicBlockLabel(const BasicBlock *BB) {
-    if (BB->hasName())
-      return BB->getName().str();
+  static void dumpBasicBlockLabel(const BasicBlock *BB,
+                                  ModuleSlotTracker &MST) {
+    if (BB->hasName()) {
+      dbgs() << BB->getName();
+      return;
+    }
 
-    std::string S;
-    raw_string_ostream OS(S);
-    BB->printAsOperand(OS, false);
-    return OS.str().substr(1);
+    dbgs() << MST.getLocalSlot(BB);
   }
 
   void dump() const {
+    BasicBlock *BB = EntryNode->Node->getParent();
+    Function *F = BB->getParent();
+
+    ModuleSlotTracker MST(F->getParent());
+    MST.incorporateFunction(*F);
+
     dbgs() << "Entry (";
-    dbgs() << getBasicBlockLabel(EntryNode->Node->getParent());
+    dumpBasicBlockLabel(BB, MST);
     dbgs() << ") : " << *EntryNode->Node << "\n";
     for (auto &E : Remats) {
       dbgs() << *(E.first) << "\n";

--- a/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
+++ b/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Coroutines/SuspendCrossingInfo.h"
+#include "llvm/IR/ModuleSlotTracker.h"
 
 // The "coro-suspend-crossing" flag is very noisy. There is another debug type,
 // "coro-frame", which results in leaner debug spew.
@@ -20,24 +21,26 @@
 
 namespace llvm {
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-static std::string getBasicBlockLabel(const BasicBlock *BB) {
-  if (BB->hasName())
-    return BB->getName().str();
+static void dumpBasicBlockLabel(const BasicBlock *BB, ModuleSlotTracker &MST) {
+  if (BB->hasName()) {
+    dbgs() << BB->getName();
+    return;
+  }
 
-  std::string S;
-  raw_string_ostream OS(S);
-  BB->printAsOperand(OS, false);
-  return OS.str().substr(1);
+  dbgs() << MST.getLocalSlot(BB);
 }
 
-LLVM_DUMP_METHOD void SuspendCrossingInfo::dump(
-    StringRef Label, BitVector const &BV,
-    const ReversePostOrderTraversal<Function *> &RPOT) const {
+LLVM_DUMP_METHOD void
+SuspendCrossingInfo::dump(StringRef Label, BitVector const &BV,
+                          const ReversePostOrderTraversal<Function *> &RPOT,
+                          ModuleSlotTracker &MST) const {
   dbgs() << Label << ":";
   for (const BasicBlock *BB : RPOT) {
     auto BBNo = Mapping.blockToIndex(BB);
-    if (BV[BBNo])
-      dbgs() << " " << getBasicBlockLabel(BB);
+    if (BV[BBNo]) {
+      dbgs() << " ";
+      dumpBasicBlockLabel(BB, MST);
+    }
   }
   dbgs() << "\n";
 }
@@ -49,12 +52,16 @@ LLVM_DUMP_METHOD void SuspendCrossingInfo::dump() const {
   BasicBlock *const B = Mapping.indexToBlock(0);
   Function *F = B->getParent();
 
+  ModuleSlotTracker MST(F->getParent());
+  MST.incorporateFunction(*F);
+
   ReversePostOrderTraversal<Function *> RPOT(F);
   for (const BasicBlock *BB : RPOT) {
     auto BBNo = Mapping.blockToIndex(BB);
-    dbgs() << getBasicBlockLabel(BB) << ":\n";
-    dump("   Consumes", Block[BBNo].Consumes, RPOT);
-    dump("      Kills", Block[BBNo].Kills, RPOT);
+    dumpBasicBlockLabel(BB, MST);
+    dbgs() << ":\n";
+    dump("   Consumes", Block[BBNo].Consumes, RPOT, MST);
+    dump("      Kills", Block[BBNo].Kills, RPOT, MST);
   }
   dbgs() << "\n";
 }


### PR DESCRIPTION
* This avoids the need to call printAsOperand that requires use of an ostream and thus avoids a str copy.
* ModuleSlotTracker is used to get a BB # for BB's without names when dumping SuspendCrossingInfo and materialization info.
* getBasicBlockLabel() is changed to dumpBasicBlockLabel() that directly prints the label to dbgs()
* The label corresponds with the print-before BB #s.
* This change does not require any additional arguments to be added to dump() methods, at least those that currently do not require any args.