### PR TITLE
[mlir][func] Fix ReturnOp issue #112146

### DIFF
--- a/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
+++ b/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
@@ -338,8 +338,10 @@ def FuncOp : Func_Op<"func", [
 // ReturnOp
 //===----------------------------------------------------------------------===//
 
-def ReturnOp : Func_Op<"return", [Pure, HasParent<"FuncOp">,
-                                MemRefsNormalizable, ReturnLike, Terminator]> {
+def ReturnOp : Func_Op<"return", [
+    Pure, HasParent<"FuncOp">, MemRefsNormalizable, ReturnLike, Terminator,
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface, ["getSuccessorRegions"]>]
+  > {
   let summary = "Function return operation";
   let description = [{
     The `func.return` operation represents a return operation within a function.

--- a/mlir/lib/Dialect/Func/IR/FuncOps.cpp
+++ b/mlir/lib/Dialect/Func/IR/FuncOps.cpp
@@ -306,6 +306,12 @@ LogicalResult ReturnOp::verify() {
   return success();
 }
 
+void ReturnOp::getSuccessorRegions(ArrayRef<Attribute> operands,
+                                   SmallVectorImpl<RegionSuccessor> &regions) {
+  // Return control back to func::FuncOp.
+  regions.push_back(RegionSuccessor());
+}
+
 //===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This patches fixes issue https://github.com/llvm/llvm-project/issues/112146, where an assertion was being triggered by `func::ReturnOp::getSuccessorRegions` and `func::FuncOp` not implementing `RegionBranchOpInterface`.