### PR TITLE
[libc] fix -Wmissing-attributes in setjmp

### DIFF
--- a/libc/src/setjmp/setjmp_impl.h
+++ b/libc/src/setjmp/setjmp_impl.h
@@ -13,9 +13,13 @@
 // public header setjmp.h which is also included. here.
 #include "hdr/types/jmp_buf.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/compiler.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+#ifdef LIBC_COMPILER_IS_GCC
+[[gnu::nothrow]]
+#endif
 int setjmp(jmp_buf buf);
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/setjmp/setjmp_impl.h
+++ b/libc/src/setjmp/setjmp_impl.h
@@ -17,6 +17,15 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
+// TODO(https://github.com/llvm/llvm-project/issues/112427)
+// Some of the architecture-specific definitions are marked `naked`, which in
+// GCC implies `nothrow`.
+//
+// Right now, our aliases aren't marked `nothrow`, so we wind up in a situation
+// where clang will emit -Wmissing-exception-spec if we add `nothrow` here, but
+// GCC will emit -Wmissing-attributes here without `nothrow`. We need to update
+// LLVM_LIBC_FUNCTION to denote when a function throws or not.
+
 #ifdef LIBC_COMPILER_IS_GCC
 [[gnu::nothrow]]
 #endif

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -18,7 +18,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 [[gnu::naked]]
-LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
   asm(R"(
       mov %%rbx, %c[rbx](%%rdi)
       mov %%rbp, %c[rbp](%%rdi)


### PR DESCRIPTION
Fixes:

    llvm-project/libc/src/setjmp/x86_64/setjmp.cpp:21:25: error: ‘int
    __llvm_libc_19_0_0_git::setjmp(__jmp_buf*)’ specifies less restrictive
    attribute than its target ‘int
    __llvm_libc_19_0_0_git::__setjmp_impl__(__jmp_buf*)’: ‘nothrow’
    [-Werror=missing-attributes]
       21 | LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
          |                         ^~~~~~

observed in the GCC build by manually expanding LLVM_LIBC_FUNCTION to add
`gnu::nothrow` to the alias.

We probably need to revisit adding nothrow throughout our declarations, so
there is probably a better way to clean this up in the future.

Link: #88054
