### PR TITLE
[flang] Retain spaces when preprocessing fixed-form source

### DIFF
--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -75,6 +75,7 @@ const SourceFile *Parsing::Prescan(const std::string &path, Options options) {
       messages_, *currentCooked_, preprocessor_, options.features};
   prescanner.set_fixedForm(options.isFixedForm)
       .set_fixedFormColumnLimit(options.fixedFormColumns)
+      .set_preprocessingOnly(options.prescanAndReformat)
       .set_expandIncludeLines(!options.prescanAndReformat ||
           options.expandIncludeLinesInPreprocessedOutput)
       .AddCompilerDirectiveSentinel("dir$");

--- a/flang/lib/Parser/prescan.h
+++ b/flang/lib/Parser/prescan.h
@@ -48,6 +48,10 @@ public:
   Preprocessor &preprocessor() { return preprocessor_; }
   common::LanguageFeatureControl &features() { return features_; }
 
+  Prescanner &set_preprocessingOnly(bool yes) {
+    preprocessingOnly_ = yes;
+    return *this;
+  }
   Prescanner &set_expandIncludeLines(bool yes) {
     expandIncludeLines_ = yes;
     return *this;
@@ -213,6 +217,7 @@ private:
   Preprocessor &preprocessor_;
   AllSources &allSources_;
   common::LanguageFeatureControl features_;
+  bool preprocessingOnly_{false};
   bool expandIncludeLines_{true};
   bool isNestedInIncludeDirective_{false};
   bool backslashFreeFormContinuation_{false};

--- a/flang/test/Parser/continuation-in-conditional-compilation.f
+++ b/flang/test/Parser/continuation-in-conditional-compilation.f
@@ -1,6 +1,6 @@
 ! RUN: %flang_fc1 -fopenmp -fopenacc -E %s 2>&1 | FileCheck %s
       program main
-! CHECK: k01=1+1
+! CHECK: k01=1+ 1
       k01=1+
 !$   &  1
 

--- a/flang/test/Preprocessing/pp029.F
+++ b/flang/test/Preprocessing/pp029.F
@@ -1,5 +1,5 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: if (777 .eq. 777) then
+! CHECK: if (77 7.eq. 777) then
 * \ newline allowed in #define
       integer, parameter :: KWM = 666
 #define KWM 77\

--- a/flang/test/Preprocessing/pp031.F
+++ b/flang/test/Preprocessing/pp031.F
@@ -1,6 +1,6 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: if (777//Ccomment.eq.777)then
-! CHECK: print *, 'pp031.F no: ', 777//Ccomment
+! CHECK: if (777 // C comment.eq. 777) then
+! CHECK: print *, 'pp031.F no: ', 777 // C comment
 *  // C++ comment NOT erased from #define
       integer, parameter :: KWM = 666
 #define KWM 777 // C comment

--- a/flang/test/Preprocessing/pp041.F
+++ b/flang/test/Preprocessing/pp041.F
@@ -1,5 +1,5 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
-! CHECK: j = 666WMj=j+1WM211
+! CHECK: j = 666WMj= j+ 1WM211
 * use KWM expansion as continuation indicators
 #define KWM 0
 #define KWM2 1

--- a/flang/test/Preprocessing/renaming.F
+++ b/flang/test/Preprocessing/renaming.F
@@ -1,5 +1,5 @@
 ! RUN: %flang -E %s | FileCheck %s
-! CHECK: ((1)*10000+(11)*100)
+! CHECK: ((1) * 10000 + (11) * 100)
 ! Ensure that a keyword-like macro can be used to rename a
 ! function-like macro.
 #define TO_VERSION2(MAJOR, MINOR) ((MAJOR) * 10000 + (MINOR) * 100)


### PR DESCRIPTION
When running fixed-form source through the compiler under -E, don't aggressively remove space characters, since the parser won't be parsing the result and some tools might need to see the spaces in the -E preprocessed output.

Fixes https://github.com/llvm/llvm-project/issues/112279.