### PR TITLE
[libc] Remove dependency on `cpp::function` in `rpc.h`

### DIFF
--- a/libc/src/__support/GPU/allocator.cpp
+++ b/libc/src/__support/GPU/allocator.cpp
@@ -18,17 +18,18 @@ namespace {
 void *rpc_allocate(uint64_t size) {
   void *ptr = nullptr;
   rpc::Client::Port port = rpc::client.open<RPC_MALLOC>();
-  port.send_and_recv([=](rpc::Buffer *buffer) { buffer->data[0] = size; },
-                     [&](rpc::Buffer *buffer) {
-                       ptr = reinterpret_cast<void *>(buffer->data[0]);
-                     });
+  port.send_and_recv(
+      [=](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = size; },
+      [&](rpc::Buffer *buffer, uint32_t) {
+        ptr = reinterpret_cast<void *>(buffer->data[0]);
+      });
   port.close();
   return ptr;
 }
 
 void rpc_free(void *ptr) {
   rpc::Client::Port port = rpc::client.open<RPC_FREE>();
-  port.send([=](rpc::Buffer *buffer) {
+  port.send([=](rpc::Buffer *buffer, uint32_t) {
     buffer->data[0] = reinterpret_cast<uintptr_t>(ptr);
   });
   port.close();

--- a/libc/src/__support/OSUtil/gpu/exit.cpp
+++ b/libc/src/__support/OSUtil/gpu/exit.cpp
@@ -18,8 +18,9 @@ namespace internal {
 [[noreturn]] void exit(int status) {
   // We want to first make sure the server is listening before we exit.
   rpc::Client::Port port = rpc::client.open<RPC_EXIT>();
-  port.send_and_recv([](rpc::Buffer *) {}, [](rpc::Buffer *) {});
-  port.send([&](rpc::Buffer *buffer) {
+  port.send_and_recv([](rpc::Buffer *, uint32_t) {},
+                     [](rpc::Buffer *, uint32_t) {});
+  port.send([&](rpc::Buffer *buffer, uint32_t) {
     reinterpret_cast<uint32_t *>(buffer->data)[0] = status;
   });
   port.close();

--- a/libc/src/__support/OSUtil/gpu/io.cpp
+++ b/libc/src/__support/OSUtil/gpu/io.cpp
@@ -17,7 +17,7 @@ namespace LIBC_NAMESPACE_DECL {
 void write_to_stderr(cpp::string_view msg) {
   rpc::Client::Port port = rpc::client.open<RPC_WRITE_TO_STDERR>();
   port.send_n(msg.data(), msg.size());
-  port.recv([](rpc::Buffer *) { /* void */ });
+  port.recv([](rpc::Buffer *, uint32_t) { /* void */ });
   port.close();
 }
 

--- a/libc/src/gpu/rpc_host_call.cpp
+++ b/libc/src/gpu/rpc_host_call.cpp
@@ -21,11 +21,11 @@ LLVM_LIBC_FUNCTION(unsigned long long, rpc_host_call,
                    (void *fn, void *data, size_t size)) {
   rpc::Client::Port port = rpc::client.open<RPC_HOST_CALL>();
   port.send_n(data, size);
-  port.send([=](rpc::Buffer *buffer) {
+  port.send([=](rpc::Buffer *buffer, uint32_t) {
     buffer->data[0] = reinterpret_cast<uintptr_t>(fn);
   });
   unsigned long long ret;
-  port.recv([&](rpc::Buffer *buffer) {
+  port.recv([&](rpc::Buffer *buffer, uint32_t) {
     ret = static_cast<unsigned long long>(buffer->data[0]);
   });
   port.close();

--- a/libc/src/stdio/gpu/clearerr.cpp
+++ b/libc/src/stdio/gpu/clearerr.cpp
@@ -17,8 +17,10 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(void, clearerr, (::FILE * stream)) {
   rpc::Client::Port port = rpc::client.open<RPC_CLEARERR>();
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) { buffer->data[0] = file::from_stream(stream); },
-      [&](rpc::Buffer *) {});
+      [=](rpc::Buffer *buffer, uint32_t) {
+        buffer->data[0] = file::from_stream(stream);
+      },
+      [&](rpc::Buffer *, uint32_t) {});
   port.close();
 }
 

--- a/libc/src/stdio/gpu/fclose.cpp
+++ b/libc/src/stdio/gpu/fclose.cpp
@@ -19,8 +19,9 @@ LLVM_LIBC_FUNCTION(int, fclose, (::FILE * stream)) {
   uint64_t ret = 0;
   uintptr_t file = reinterpret_cast<uintptr_t>(stream);
   rpc::Client::Port port = rpc::client.open<RPC_CLOSE_FILE>();
-  port.send_and_recv([=](rpc::Buffer *buffer) { buffer->data[0] = file; },
-                     [&](rpc::Buffer *buffer) { ret = buffer->data[0]; });
+  port.send_and_recv(
+      [=](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = file; },
+      [&](rpc::Buffer *buffer, uint32_t) { ret = buffer->data[0]; });
   port.close();
 
   if (ret != 0)

--- a/libc/src/stdio/gpu/feof.cpp
+++ b/libc/src/stdio/gpu/feof.cpp
@@ -18,8 +18,12 @@ LLVM_LIBC_FUNCTION(int, feof, (::FILE * stream)) {
   int ret;
   rpc::Client::Port port = rpc::client.open<RPC_FEOF>();
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) { buffer->data[0] = file::from_stream(stream); },
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+      [=](rpc::Buffer *buffer, uint32_t) {
+        buffer->data[0] = file::from_stream(stream);
+      },
+      [&](rpc::Buffer *buffer, uint32_t) {
+        ret = static_cast<int>(buffer->data[0]);
+      });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/ferror.cpp
+++ b/libc/src/stdio/gpu/ferror.cpp
@@ -18,8 +18,12 @@ LLVM_LIBC_FUNCTION(int, ferror, (::FILE * stream)) {
   int ret;
   rpc::Client::Port port = rpc::client.open<RPC_FERROR>();
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) { buffer->data[0] = file::from_stream(stream); },
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+      [=](rpc::Buffer *buffer, uint32_t) {
+        buffer->data[0] = file::from_stream(stream);
+      },
+      [&](rpc::Buffer *buffer, uint32_t) {
+        ret = static_cast<int>(buffer->data[0]);
+      });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/fflush.cpp
+++ b/libc/src/stdio/gpu/fflush.cpp
@@ -18,8 +18,12 @@ LLVM_LIBC_FUNCTION(int, fflush, (::FILE * stream)) {
   int ret;
   rpc::Client::Port port = rpc::client.open<RPC_FFLUSH>();
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) { buffer->data[0] = file::from_stream(stream); },
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+      [=](rpc::Buffer *buffer, uint32_t) {
+        buffer->data[0] = file::from_stream(stream);
+      },
+      [&](rpc::Buffer *buffer, uint32_t) {
+        ret = static_cast<int>(buffer->data[0]);
+      });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/fgets.cpp
+++ b/libc/src/stdio/gpu/fgets.cpp
@@ -27,7 +27,7 @@ LLVM_LIBC_FUNCTION(char *, fgets,
   uint64_t recv_size;
   void *buf = nullptr;
   rpc::Client::Port port = rpc::client.open<RPC_READ_FGETS>();
-  port.send([=](rpc::Buffer *buffer) {
+  port.send([=](rpc::Buffer *buffer, uint32_t) {
     buffer->data[0] = count;
     buffer->data[1] = file::from_stream(stream);
   });

--- a/libc/src/stdio/gpu/file.h
+++ b/libc/src/stdio/gpu/file.h
@@ -55,13 +55,13 @@ LIBC_INLINE uint64_t write_impl(::FILE *file, const void *data, size_t size) {
   rpc::Client::Port port = rpc::client.open<opcode>();
 
   if constexpr (opcode == RPC_WRITE_TO_STREAM) {
-    port.send([&](rpc::Buffer *buffer) {
+    port.send([&](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = reinterpret_cast<uintptr_t>(file);
     });
   }
 
   port.send_n(data, size);
-  port.recv([&](rpc::Buffer *buffer) {
+  port.recv([&](rpc::Buffer *buffer, uint32_t) {
     ret = reinterpret_cast<uint64_t *>(buffer->data)[0];
   });
   port.close();
@@ -81,12 +81,12 @@ LIBC_INLINE uint64_t read_from_stream(::FILE *file, void *buf, size_t size) {
   uint64_t ret = 0;
   uint64_t recv_size;
   rpc::Client::Port port = rpc::client.open<RPC_READ_FROM_STREAM>();
-  port.send([=](rpc::Buffer *buffer) {
+  port.send([=](rpc::Buffer *buffer, uint32_t) {
     buffer->data[0] = size;
     buffer->data[1] = from_stream(file);
   });
   port.recv_n(&buf, &recv_size, [&](uint64_t) { return buf; });
-  port.recv([&](rpc::Buffer *buffer) { ret = buffer->data[0]; });
+  port.recv([&](rpc::Buffer *buffer, uint32_t) { ret = buffer->data[0]; });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/fopen.cpp
+++ b/libc/src/stdio/gpu/fopen.cpp
@@ -21,10 +21,10 @@ LLVM_LIBC_FUNCTION(::FILE *, fopen,
   rpc::Client::Port port = rpc::client.open<RPC_OPEN_FILE>();
   port.send_n(path, internal::string_length(path) + 1);
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) {
+      [=](rpc::Buffer *buffer, uint32_t) {
         inline_memcpy(buffer->data, mode, internal::string_length(mode) + 1);
       },
-      [&](rpc::Buffer *buffer) { file = buffer->data[0]; });
+      [&](rpc::Buffer *buffer, uint32_t) { file = buffer->data[0]; });
   port.close();
 
   return reinterpret_cast<FILE *>(file);

--- a/libc/src/stdio/gpu/fseek.cpp
+++ b/libc/src/stdio/gpu/fseek.cpp
@@ -18,12 +18,14 @@ LLVM_LIBC_FUNCTION(int, fseek, (::FILE * stream, long offset, int whence)) {
   int ret;
   rpc::Client::Port port = rpc::client.open<RPC_FSEEK>();
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) {
+      [=](rpc::Buffer *buffer, uint32_t) {
         buffer->data[0] = file::from_stream(stream);
         buffer->data[1] = static_cast<uint64_t>(offset);
         buffer->data[2] = static_cast<uint64_t>(whence);
       },
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+      [&](rpc::Buffer *buffer, uint32_t) {
+        ret = static_cast<int>(buffer->data[0]);
+      });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/ftell.cpp
+++ b/libc/src/stdio/gpu/ftell.cpp
@@ -18,8 +18,12 @@ LLVM_LIBC_FUNCTION(long, ftell, (::FILE * stream)) {
   long ret;
   rpc::Client::Port port = rpc::client.open<RPC_FSEEK>();
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) { buffer->data[0] = file::from_stream(stream); },
-      [&](rpc::Buffer *buffer) { ret = static_cast<long>(buffer->data[0]); });
+      [=](rpc::Buffer *buffer, uint32_t) {
+        buffer->data[0] = file::from_stream(stream);
+      },
+      [&](rpc::Buffer *buffer, uint32_t) {
+        ret = static_cast<long>(buffer->data[0]);
+      });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/remove.cpp
+++ b/libc/src/stdio/gpu/remove.cpp
@@ -18,8 +18,9 @@ LLVM_LIBC_FUNCTION(int, remove, (const char *path)) {
   int ret;
   rpc::Client::Port port = rpc::client.open<RPC_REMOVE>();
   port.send_n(path, internal::string_length(path) + 1);
-  port.recv(
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+  port.recv([&](rpc::Buffer *buffer, uint32_t) {
+    ret = static_cast<int>(buffer->data[0]);
+  });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/rename.cpp
+++ b/libc/src/stdio/gpu/rename.cpp
@@ -20,8 +20,9 @@ LLVM_LIBC_FUNCTION(int, rename, (const char *oldpath, const char *newpath)) {
   rpc::Client::Port port = rpc::client.open<RPC_RENAME>();
   port.send_n(oldpath, internal::string_length(oldpath) + 1);
   port.send_n(newpath, internal::string_length(newpath) + 1);
-  port.recv(
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+  port.recv([&](rpc::Buffer *buffer, uint32_t) {
+    ret = static_cast<int>(buffer->data[0]);
+  });
   port.close();
 
   return ret;

--- a/libc/src/stdio/gpu/ungetc.cpp
+++ b/libc/src/stdio/gpu/ungetc.cpp
@@ -18,11 +18,13 @@ LLVM_LIBC_FUNCTION(int, ungetc, (int c, ::FILE *stream)) {
   int ret;
   rpc::Client::Port port = rpc::client.open<RPC_UNGETC>();
   port.send_and_recv(
-      [=](rpc::Buffer *buffer) {
+      [=](rpc::Buffer *buffer, uint32_t) {
         buffer->data[0] = c;
         buffer->data[1] = file::from_stream(stream);
       },
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+      [&](rpc::Buffer *buffer, uint32_t) {
+        ret = static_cast<int>(buffer->data[0]);
+      });
   port.close();
   return ret;
 }

--- a/libc/src/stdio/gpu/vfprintf_utils.h
+++ b/libc/src/stdio/gpu/vfprintf_utils.h
@@ -23,14 +23,14 @@ LIBC_INLINE int vfprintf_impl(::FILE *__restrict file,
 
   if constexpr (opcode == RPC_PRINTF_TO_STREAM ||
                 opcode == RPC_PRINTF_TO_STREAM_PACKED) {
-    port.send([&](rpc::Buffer *buffer) {
+    port.send([&](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = reinterpret_cast<uintptr_t>(file);
     });
   }
 
   size_t args_size = 0;
   port.send_n(format, format_size);
-  port.recv([&](rpc::Buffer *buffer) {
+  port.recv([&](rpc::Buffer *buffer, uint32_t) {
     args_size = static_cast<size_t>(buffer->data[0]);
   });
   port.send_n(vlist, args_size);
@@ -38,7 +38,7 @@ LIBC_INLINE int vfprintf_impl(::FILE *__restrict file,
   uint32_t ret = 0;
   for (;;) {
     const char *str = nullptr;
-    port.recv([&](rpc::Buffer *buffer) {
+    port.recv([&](rpc::Buffer *buffer, uint32_t) {
       ret = static_cast<uint32_t>(buffer->data[0]);
       str = reinterpret_cast<const char *>(buffer->data[1]);
     });

--- a/libc/src/stdlib/gpu/abort.cpp
+++ b/libc/src/stdlib/gpu/abort.cpp
@@ -17,8 +17,9 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(void, abort, ()) {
   // We want to first make sure the server is listening before we abort.
   rpc::Client::Port port = rpc::client.open<RPC_ABORT>();
-  port.send_and_recv([](rpc::Buffer *) {}, [](rpc::Buffer *) {});
-  port.send([&](rpc::Buffer *) {});
+  port.send_and_recv([](rpc::Buffer *, uint32_t) {},
+                     [](rpc::Buffer *, uint32_t) {});
+  port.send([&](rpc::Buffer *, uint32_t) {});
   port.close();
 
   gpu::end_program();

--- a/libc/src/stdlib/gpu/system.cpp
+++ b/libc/src/stdlib/gpu/system.cpp
@@ -19,8 +19,9 @@ LLVM_LIBC_FUNCTION(int, system, (const char *command)) {
   int ret;
   rpc::Client::Port port = rpc::client.open<RPC_SYSTEM>();
   port.send_n(command, internal::string_length(command) + 1);
-  port.recv(
-      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+  port.recv([&](rpc::Buffer *buffer, uint32_t) {
+    ret = static_cast<int>(buffer->data[0]);
+  });
   port.close();
 
   return ret;

--- a/libc/utils/gpu/server/rpc_server.cpp
+++ b/libc/utils/gpu/server/rpc_server.cpp
@@ -302,8 +302,8 @@ rpc_status_t handle_server_impl(
   }
   case RPC_EXIT: {
     // Send a response to the client to signal that we are ready to exit.
-    port->recv_and_send([](rpc::Buffer *) {});
-    port->recv([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *, uint32_t) {});
+    port->recv([](rpc::Buffer *buffer, uint32_t) {
       int status = 0;
       std::memcpy(&status, buffer->data, sizeof(int));
       exit(status);
@@ -312,8 +312,8 @@ rpc_status_t handle_server_impl(
   }
   case RPC_ABORT: {
     // Send a response to the client to signal that we are ready to abort.
-    port->recv_and_send([](rpc::Buffer *) {});
-    port->recv([](rpc::Buffer *) {});
+    port->recv_and_send([](rpc::Buffer *, uint32_t) {});
+    port->recv([](rpc::Buffer *, uint32_t) {});
     abort();
     break;
   }
@@ -334,25 +334,25 @@ rpc_status_t handle_server_impl(
     break;
   }
   case RPC_FEOF: {
-    port->recv_and_send([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = feof(file::to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_FERROR: {
-    port->recv_and_send([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = ferror(file::to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_CLEARERR: {
-    port->recv_and_send([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
       clearerr(file::to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_FSEEK: {
-    port->recv_and_send([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = fseek(file::to_stream(buffer->data[0]),
                               static_cast<long>(buffer->data[1]),
                               static_cast<int>(buffer->data[2]));
@@ -360,19 +360,19 @@ rpc_status_t handle_server_impl(
     break;
   }
   case RPC_FTELL: {
-    port->recv_and_send([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = ftell(file::to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_FFLUSH: {
-    port->recv_and_send([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = fflush(file::to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_UNGETC: {
-    port->recv_and_send([](rpc::Buffer *buffer) {
+    port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = ungetc(static_cast<int>(buffer->data[0]),
                                file::to_stream(buffer->data[1]));
     });
@@ -429,7 +429,7 @@ rpc_status_t handle_server_impl(
     break;
   }
   case RPC_NOOP: {
-    port->recv([](rpc::Buffer *) {});
+    port->recv([](rpc::Buffer *, uint32_t) {});
     break;
   }
   default: {
@@ -552,7 +552,7 @@ uint64_t rpc_get_client_size() { return sizeof(rpc::Client); }
 
 void rpc_send(rpc_port_t ref, rpc_port_callback_ty callback, void *data) {
   auto port = reinterpret_cast<rpc::Server::Port *>(ref.handle);
-  port->send([=](rpc::Buffer *buffer) {
+  port->send([=](rpc::Buffer *buffer, uint32_t) {
     callback(reinterpret_cast<rpc_buffer_t *>(buffer), data);
   });
 }
@@ -564,7 +564,7 @@ void rpc_send_n(rpc_port_t ref, const void *const *src, uint64_t *size) {
 
 void rpc_recv(rpc_port_t ref, rpc_port_callback_ty callback, void *data) {
   auto port = reinterpret_cast<rpc::Server::Port *>(ref.handle);
-  port->recv([=](rpc::Buffer *buffer) {
+  port->recv([=](rpc::Buffer *buffer, uint32_t) {
     callback(reinterpret_cast<rpc_buffer_t *>(buffer), data);
   });
 }
@@ -579,7 +579,7 @@ void rpc_recv_n(rpc_port_t ref, void **dst, uint64_t *size, rpc_alloc_ty alloc,
 void rpc_recv_and_send(rpc_port_t ref, rpc_port_callback_ty callback,
                        void *data) {
   auto port = reinterpret_cast<rpc::Server::Port *>(ref.handle);
-  port->recv_and_send([=](rpc::Buffer *buffer) {
+  port->recv_and_send([=](rpc::Buffer *buffer, uint32_t) {
     callback(reinterpret_cast<rpc_buffer_t *>(buffer), data);
   });
 }


### PR DESCRIPTION
Summary:
I'm going to attempt to move the `rpc.h` header to a separate folder
that we can install and include outside of `libc`. Before doing this I'm
going to try to trim up the file so there's not as many things I need to
copy to make it work. This dependency on `cpp::functional` is a low
hanging fruit. I only did it so that I could overload the argument of
the work function so that passing the id was optional in the lambda,
that's not a *huge* deal and it makes it more explicit I suppose.
