### PR TITLE
[NFC] Remove unnececary check from test

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
@@ -205,7 +205,6 @@ TEST(SanitizerLinux, ThreadDescriptorSize) {
   void *result;
   ASSERT_EQ(0, pthread_create(&tid, 0, thread_descriptor_size_test_func, 0));
   ASSERT_EQ(0, pthread_join(tid, &result));
-  EXPECT_EQ(0u, ThreadDescriptorSize());
   InitTlsSize();
   EXPECT_EQ((uptr)result, ThreadDescriptorSize());
 }


### PR DESCRIPTION
Important part of the test to have correct
`ThreadDescriptorSize` after `InitTlsSize()`.

It's not a problem if another test called
`InitTlsSize()` before.

Fixes #112399.
