### PR TITLE
[NFC] Fix flakiness in test if run unsharded

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
@@ -205,7 +205,6 @@ TEST(SanitizerLinux, ThreadDescriptorSize) {
   void *result;
   ASSERT_EQ(0, pthread_create(&tid, 0, thread_descriptor_size_test_func, 0));
   ASSERT_EQ(0, pthread_join(tid, &result));
-  EXPECT_EQ(0u, ThreadDescriptorSize());
   InitTlsSize();
   EXPECT_EQ((uptr)result, ThreadDescriptorSize());
 }


### PR DESCRIPTION
If we run all test in a single process, there is high
probability that `99` is already claimed.
