### PR TITLE
[libc][setjmp] remove naked fn attr

### DIFF
--- a/libc/src/setjmp/setjmp_impl.h
+++ b/libc/src/setjmp/setjmp_impl.h
@@ -17,18 +17,6 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-// TODO(https://github.com/llvm/llvm-project/issues/112427)
-// Some of the architecture-specific definitions are marked `naked`, which in
-// GCC implies `nothrow`.
-//
-// Right now, our aliases aren't marked `nothrow`, so we wind up in a situation
-// where clang will emit -Wmissing-exception-spec if we add `nothrow` here, but
-// GCC will emit -Wmissing-attributes here without `nothrow`. We need to update
-// LLVM_LIBC_FUNCTION to denote when a function throws or not.
-
-#ifdef LIBC_COMPILER_IS_GCC
-[[gnu::nothrow]]
-#endif
 int setjmp(jmp_buf buf);
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/setjmp/x86_64/CMakeLists.txt
+++ b/libc/src/setjmp/x86_64/CMakeLists.txt
@@ -8,6 +8,7 @@ add_entrypoint_object(
     libc.hdr.types.jmp_buf
   COMPILE_OPTIONS
     -O3
+    -fomit-frame-pointer
 )
 
 add_entrypoint_object(

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -17,6 +17,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
+  long tmp;
   asm(R"(
       mov %%rbx, %[rbx]
       mov %%rbp, %[rbp]
@@ -25,16 +26,16 @@ LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
       mov %%r14, %[r14]
       mov %%r15, %[r15]
 
-      lea 8(%%rsp), %%rax
-      mov %%rax, %[rsp]
+      lea 8(%%rsp), %[tmp]
+      mov %[tmp], %[rsp]
 
-      mov (%%rsp), %%rax
-      mov %%rax, %[rip]
-      )" ::[rbx] "m"(buf->rbx),
-      [rbp] "m"(buf->rbp), [r12] "m"(buf->r12), [r13] "m"(buf->r13),
-      [r14] "m"(buf->r14), [r15] "m"(buf->r15), [rsp] "m"(buf->rsp),
-      [rip] "m"(buf->rip)
-      : "rax");
+      mov (%%rsp), %[tmp]
+      mov %[tmp], %[rip]
+      )"
+      : [tmp] "=r"(tmp)
+      : [rbx] "m"(buf->rbx), [rbp] "m"(buf->rbp), [r12] "m"(buf->r12),
+        [r13] "m"(buf->r13), [r14] "m"(buf->r14), [r15] "m"(buf->r15),
+        [rsp] "m"(buf->rsp), [rip] "m"(buf->rip));
   return 0;
 }
 

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "include/llvm-libc-macros/offsetof-macro.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/setjmp/setjmp_impl.h"
@@ -17,29 +16,31 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-[[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
   asm(R"(
-      mov %%rbx, %c[rbx](%%rdi)
-      mov %%rbp, %c[rbp](%%rdi)
-      mov %%r12, %c[r12](%%rdi)
-      mov %%r13, %c[r13](%%rdi)
-      mov %%r14, %c[r14](%%rdi)
-      mov %%r15, %c[r15](%%rdi)
+      mov %%rbx, %[rbx]
+      mov %%rbp, %[rbp]
+      mov %%r12, %[r12]
+      mov %%r13, %[r13]
+      mov %%r14, %[r14]
+      mov %%r15, %[r15]
 
       lea 8(%%rsp), %%rax
-      mov %%rax, %c[rsp](%%rdi)
+      mov %%rax, %[rsp]
 
       mov (%%rsp), %%rax
-      mov %%rax, %c[rip](%%rdi)
-
-      xorl %%eax, %%eax
-      retq)" ::[rbx] "i"(offsetof(__jmp_buf, rbx)),
-      [rbp] "i"(offsetof(__jmp_buf, rbp)), [r12] "i"(offsetof(__jmp_buf, r12)),
-      [r13] "i"(offsetof(__jmp_buf, r13)), [r14] "i"(offsetof(__jmp_buf, r14)),
-      [r15] "i"(offsetof(__jmp_buf, r15)), [rsp] "i"(offsetof(__jmp_buf, rsp)),
-      [rip] "i"(offsetof(__jmp_buf, rip))
+      mov %%rax, %[rip]
+      )" ::
+      [rbx] "m"(buf->rbx),
+      [rbp] "m"(buf->rbp),
+      [r12] "m"(buf->r12),
+      [r13] "m"(buf->r13),
+      [r14] "m"(buf->r14),
+      [r15] "m"(buf->r15),
+      [rsp] "m"(buf->rsp),
+      [rip] "m"(buf->rip)
       : "rax");
+  return 0;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -32,7 +32,7 @@ LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
       mov (%%rsp), %[tmp]
       mov %[tmp], %[rip]
       )"
-      : [tmp] "=r"(tmp)
+      : [tmp] "=&r"(tmp)
       : [rbx] "m"(buf->rbx), [rbp] "m"(buf->rbp), [r12] "m"(buf->r12),
         [r13] "m"(buf->r13), [r14] "m"(buf->r14), [r15] "m"(buf->r15),
         [rsp] "m"(buf->rsp), [rip] "m"(buf->rip));

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -30,14 +30,9 @@ LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
 
       mov (%%rsp), %%rax
       mov %%rax, %[rip]
-      )" ::
-      [rbx] "m"(buf->rbx),
-      [rbp] "m"(buf->rbp),
-      [r12] "m"(buf->r12),
-      [r13] "m"(buf->r13),
-      [r14] "m"(buf->r14),
-      [r15] "m"(buf->r15),
-      [rsp] "m"(buf->rsp),
+      )" ::[rbx] "m"(buf->rbx),
+      [rbp] "m"(buf->rbp), [r12] "m"(buf->r12), [r13] "m"(buf->r13),
+      [r14] "m"(buf->r14), [r15] "m"(buf->r15), [rsp] "m"(buf->rsp),
       [rip] "m"(buf->rip)
       : "rax");
   return 0;


### PR DESCRIPTION
Even though I just added it in 66f968cf3725 (and fixed up in 46200fcf941d),
while writing the i386 version, I found that simply using "m" constraints
allowed for me to avoid offsetof and naked function attribute, while generating
the same exact disassembly. Simplify x86_64 setjmp using this style.
