### PR TITLE
[flang] Fix broken shared library build

### DIFF
--- a/flang/include/flang/Semantics/type.h
+++ b/flang/include/flang/Semantics/type.h
@@ -29,6 +29,13 @@ namespace Fortran::parser {
 struct Keyword;
 }
 
+namespace Fortran::evaluate { // avoid including all of Evaluate/tools.h
+template <typename T>
+std::optional<bool> AreEquivalentInInterface(const Expr<T> &, const Expr<T> &);
+extern template std::optional<bool> AreEquivalentInInterface<SomeInteger>(
+    const Expr<SomeInteger> &, const Expr<SomeInteger> &);
+} // namespace Fortran::evaluate
+
 namespace Fortran::semantics {
 
 class Scope;
@@ -110,7 +117,11 @@ public:
     return category_ == that.category_ && expr_ == that.expr_;
   }
   bool operator!=(const ParamValue &that) const { return !(*this == that); }
-  bool IsEquivalentInInterface(const ParamValue &) const;
+  bool IsEquivalentInInterface(const ParamValue &that) const {
+    return (category_ == that.category_ &&
+        expr_.has_value() == that.expr_.has_value() &&
+        (!expr_ || evaluate::AreEquivalentInInterface(*expr_, *that.expr_)));
+  }
   std::string AsFortran() const;
 
 private:

--- a/flang/lib/Semantics/type.cpp
+++ b/flang/lib/Semantics/type.cpp
@@ -758,12 +758,6 @@ void ParamValue::SetExplicit(SomeIntExpr &&x) {
   expr_ = std::move(x);
 }
 
-bool ParamValue::IsEquivalentInInterface(const ParamValue &that) const {
-  return (category_ == that.category_ &&
-      expr_.has_value() == that.expr_.has_value() &&
-      (!expr_ || evaluate::AreEquivalentInInterface(*expr_, *that.expr_)));
-}
-
 std::string ParamValue::AsFortran() const {
   switch (category_) {
     SWITCH_COVERS_ALL_CASES


### PR DESCRIPTION
I just introduced a dependency from the Evaluate library to the Semantics library, which is circular in a shared library build. Rearrange the code a little to ensure that the dependence is only on a header.