### PR TITLE
[lldb] Disable warning about codecvt_utf8 deprecation (NFC)

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -57,6 +57,26 @@
 
 #include "llvm/ADT/FunctionExtras.h"
 
+#if defined(__clang__) && defined(__has_warning)
+#if __has_warning("-Wimplicit-fallthrough")
+#define EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS                             \
+  _Pragma("clang diagnostic push")                                             \
+      _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#define RESTORE_DEPRECATED_DECLARATION_WARNINGS _Pragma("clang diagnostic pop")
+#endif
+#elif defined(__GNUC__) && __GNUC__ > 6
+#define EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS                             \
+  _Pragma("GCC diagnostic push")                                               \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define RESTORE_DEPRECATED_DECLARATION_WARNINGS _Pragma("GCC diagnostic pop")
+#endif
+#ifndef EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
+#define EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
+#endif
+#ifndef EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
+#define EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
+#endif
+
 namespace lldb_private {
 namespace line_editor {
 
@@ -367,7 +387,9 @@ private:
   void SetGetCharacterFunction(EditlineGetCharCallbackType callbackFn);
 
 #if LLDB_EDITLINE_USE_WCHAR
+  EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
   std::wstring_convert<std::codecvt_utf8<wchar_t>> m_utf8conv;
+  EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
 #endif
   ::EditLine *m_editline = nullptr;
   EditlineHistorySP m_history_sp;

--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -58,23 +58,20 @@
 #include "llvm/ADT/FunctionExtras.h"
 
 #if defined(__clang__) && defined(__has_warning)
-#if __has_warning("-Wimplicit-fallthrough")
-#define EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS                             \
+#if __has_warning("-Wdeprecated-declarations")
+#define LLDB_DEPRECATED_WARNING_DISABLE                                        \
   _Pragma("clang diagnostic push")                                             \
       _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-#define RESTORE_DEPRECATED_DECLARATION_WARNINGS _Pragma("clang diagnostic pop")
+#define LLDB_DEPRECATED_WARNING_RESTORE _Pragma("clang diagnostic pop")
 #endif
 #elif defined(__GNUC__) && __GNUC__ > 6
-#define EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS                             \
+#define LLDB_DEPRECATED_WARNING_DISABLE                                        \
   _Pragma("GCC diagnostic push")                                               \
       _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define RESTORE_DEPRECATED_DECLARATION_WARNINGS _Pragma("GCC diagnostic pop")
-#endif
-#ifndef EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
-#define EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
-#endif
-#ifndef EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
-#define EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
+#define LLDB_DEPRECATED_WARNING_RESTORE _Pragma("GCC diagnostic pop")
+#else
+#define LLDB_DEPRECATED_WARNING_DISABLE
+#define LLDB_DEPRECATED_WARNING_RESTORE
 #endif
 
 namespace lldb_private {
@@ -387,9 +384,9 @@ private:
   void SetGetCharacterFunction(EditlineGetCharCallbackType callbackFn);
 
 #if LLDB_EDITLINE_USE_WCHAR
-  EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
+  LLDB_DEPRECATED_WARNING_DISABLE
   std::wstring_convert<std::codecvt_utf8<wchar_t>> m_utf8conv;
-  EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
+  LLDB_DEPRECATED_WARNING_RESTORE
 #endif
   ::EditLine *m_editline = nullptr;
   EditlineHistorySP m_history_sp;

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -1576,7 +1576,7 @@ bool Editline::CompleteCharacter(char ch, EditLineGetCharType &out) {
 #else
   LLDB_DEPRECATED_WARNING_DISABLE
   std::codecvt_utf8<wchar_t> cvt;
-  EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
+  LLDB_DEPRECATED_WARNING_RESTORE
   llvm::SmallString<4> input;
   for (;;) {
     const char *from_next;

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -1574,7 +1574,9 @@ bool Editline::CompleteCharacter(char ch, EditLineGetCharType &out) {
   out = (unsigned char)ch;
   return true;
 #else
+  EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
   std::codecvt_utf8<wchar_t> cvt;
+  EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
   llvm::SmallString<4> input;
   for (;;) {
     const char *from_next;

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -1574,7 +1574,7 @@ bool Editline::CompleteCharacter(char ch, EditLineGetCharType &out) {
   out = (unsigned char)ch;
   return true;
 #else
-  EL_DISABLE_DEPRECATED_DECLARATION_WARNINGS
+  LLDB_DEPRECATED_WARNING_DISABLE
   std::codecvt_utf8<wchar_t> cvt;
   EL_RESTORE_DEPRECATED_DECLARATION_WARNINGS
   llvm::SmallString<4> input;


### PR DESCRIPTION
Disable -Wdeprecated-declarations for codecvt_utf8 in Editline. This is in preparation for #112276 which narrows the scope of -Wno-deprecated-declarations for building LLDB.