### PR TITLE
[MLIR] Tweak standalone example `smoketest.py`

### DIFF
--- a/mlir/examples/standalone/python/CMakeLists.txt
+++ b/mlir/examples/standalone/python/CMakeLists.txt
@@ -43,7 +43,9 @@ add_mlir_python_common_capi_library(StandalonePythonCAPI
     # TODO: Remove this in favor of showing fine grained registration once
     # available.
     MLIRPythonExtension.RegisterEverything
+    MLIRPythonExtension.ExecutionEngine
     MLIRPythonSources.Core
+    MLIRPythonSources.Dialects
 )
 
 ################################################################################

--- a/mlir/examples/standalone/test/python/smoketest.py
+++ b/mlir/examples/standalone/test/python/smoketest.py
@@ -1,7 +1,13 @@
 # RUN: %python %s | FileCheck %s
 
 from mlir_standalone.ir import *
-from mlir_standalone.dialects import builtin as builtin_d, standalone as standalone_d
+from mlir_standalone import execution_engine, passmanager
+from mlir_standalone.dialects import (
+    builtin as builtin_d,
+    linalg as linalg_d,
+    sparse_tensor as sparse_tensor_d,
+    standalone as standalone_d,
+)
 
 with Context():
     standalone_d.register_dialect()


### PR DESCRIPTION
Hi!
While working with MLIR standalone example it took me some time to figure out how to access dialects and execution engine from MLIR Python package.

I think it might be useful to include them in the standalone build already. WDYT?
