### PR TITLE
[FlowSensitive] Allow to dump nested RecordStorageLocation

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
@@ -133,8 +133,7 @@ public:
       for (const auto &Child : RLoc->children())
         JOS.attributeObject("f:" + Child.first->getNameAsString(), [&] {
           if (Child.second)
-            if (Value *Val = Env.getValue(*Child.second))
-              dump(*Val);
+            dump(*Child.second);
         });
 
       for (const auto &SyntheticField : RLoc->synthetic_fields())


### PR DESCRIPTION
We have an internal analysis that uses them, and the HTML dump would
fail on the assertion.
