### PR TITLE
Update LLVMLibCArchitectures.cmake

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -84,7 +84,7 @@ if(NOT (libc_compiler_info_result EQUAL "0"))
   message(FATAL_ERROR "libc build: error querying compiler info from the "
                       "compiler: ${libc_compiler_info}")
 endif()
-string(REGEX MATCH "Target: [-_a-z0-9.]+[ \r\n]+"
+string(REGEX MATCH "Target: [-_a-zA-Z0-9.]+[ \r\n]+"
        libc_compiler_target_info ${libc_compiler_info})
 if(NOT libc_compiler_target_info)
   message(FATAL_ERROR "libc build: could not read compiler target info from:\n"


### PR DESCRIPTION
Hi there,

When building llvm-libc on the openEuler system, I encountered an issue as shown in the image below:
![image](https://github.com/user-attachments/assets/75667de4-5bea-4a95-be28-ed34db0e05b9)

This issue happens because the regular expression used in `libc/cmake/modules/LLVMLibCArchitectures.cmake`: `string(REGEX MATCH "Target: [-_a-z0-9.]+[ \r\n]+")` does not handle capital letters properly in `openEuler`. 

To fix this, I modified the regular expression to: `string(REGEX MATCH "Target: [-_a-zA-Z0-9.]+[ \r\n]+")`. This change makes it compatible with capital letters.
