### PR TITLE
[Clang][RISCV] Support -fcf-protection=return for RISC-V

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -141,6 +141,13 @@ public:
     return true;
   }
 
+  bool
+  checkCFProtectionReturnSupported(DiagnosticsEngine &Diags) const override {
+    if (ISAInfo->hasExtension("zimop"))
+      return true;
+    return TargetInfo::checkCFProtectionReturnSupported(Diags);
+  }
+
   CFBranchLabelSchemeKind getDefaultCFBranchLabelScheme() const override {
     return CFBranchLabelSchemeKind::FuncSig;
   }

--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -143,7 +143,7 @@ public:
 
   bool
   checkCFProtectionReturnSupported(DiagnosticsEngine &Diags) const override {
-    if (ISAInfo->hasExtension("zimop"))
+    if (ISAInfo->hasExtension("zicfiss"))
       return true;
     return TargetInfo::checkCFProtectionReturnSupported(Diags);
   }

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -899,8 +899,9 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
   if (CodeGenOpts.PointerAuth.IndirectGotos)
     Fn->addFnAttr("ptrauth-indirect-gotos");
 
-  // Add return control flow integrity attributes.
-  if (CodeGenOpts.CFProtectionReturn)
+  // Add return control flow integrity attributes for RISCV.
+  if (CodeGenOpts.CFProtectionReturn &&
+      getContext().getTargetInfo().getTriple().isRISCV())
     Fn->addFnAttr("hw-shadow-stack");
 
   // Apply xray attributes to the function (as a string, for now)

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -899,6 +899,10 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
   if (CodeGenOpts.PointerAuth.IndirectGotos)
     Fn->addFnAttr("ptrauth-indirect-gotos");
 
+  // Add return control flow integrity attributes.
+  if (CodeGenOpts.CFProtectionReturn)
+    Fn->addFnAttr("hw-shadow-stack");
+
   // Apply xray attributes to the function (as a string, for now)
   bool AlwaysXRayAttr = false;
   if (const auto *XRayAttr = D ? D->getAttr<XRayInstrumentAttr>() : nullptr) {

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -899,11 +899,6 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
   if (CodeGenOpts.PointerAuth.IndirectGotos)
     Fn->addFnAttr("ptrauth-indirect-gotos");
 
-  // Add return control flow integrity attributes for RISCV.
-  if (CodeGenOpts.CFProtectionReturn &&
-      getContext().getTargetInfo().getTriple().isRISCV())
-    Fn->addFnAttr("hw-shadow-stack");
-
   // Apply xray attributes to the function (as a string, for now)
   bool AlwaysXRayAttr = false;
   if (const auto *XRayAttr = D ? D->getAttr<XRayInstrumentAttr>() : nullptr) {

--- a/clang/lib/CodeGen/Targets/RISCV.cpp
+++ b/clang/lib/CodeGen/Targets/RISCV.cpp
@@ -594,6 +594,11 @@ public:
     const auto *FD = dyn_cast_or_null<FunctionDecl>(D);
     if (!FD) return;
 
+    auto *Fn = cast<llvm::Function>(GV);
+
+    if (CGM.getCodeGenOpts().CFProtectionReturn)
+      Fn->addFnAttr("hw-shadow-stack");
+
     const auto *Attr = FD->getAttr<RISCVInterruptAttr>();
     if (!Attr)
       return;
@@ -603,8 +608,6 @@ public:
     case RISCVInterruptAttr::supervisor: Kind = "supervisor"; break;
     case RISCVInterruptAttr::machine: Kind = "machine"; break;
     }
-
-    auto *Fn = cast<llvm::Function>(GV);
 
     Fn->addFnAttr("interrupt", Kind);
   }

--- a/clang/test/CodeGen/RISCV/attr-hw-shadow-stack.c
+++ b/clang/test/CodeGen/RISCV/attr-hw-shadow-stack.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple riscv64-unknown-linux -target-feature +zimop -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
+// RUN: %clang_cc1 -triple riscv64-unknown-linux -target-feature +zimop -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
+// RUN: %clang_cc1 -triple riscv32-unknown-linux -target-feature +zimop -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
+// RUN: %clang_cc1 -triple riscv32-unknown-linux -target-feature +zimop -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
+
+int foo(int *a) { return *a; }
+
+// CHECK: attributes {{.*}}"hw-shadow-stack"{{.*}}
+// NOSHADOWSTACK-NOT: attributes {{.*}}"hw-shadow-stack"{{.*}}

--- a/clang/test/CodeGen/RISCV/attr-hw-shadow-stack.c
+++ b/clang/test/CodeGen/RISCV/attr-hw-shadow-stack.c
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple riscv64-unknown-linux -target-feature +zimop -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
-// RUN: %clang_cc1 -triple riscv64-unknown-linux -target-feature +zimop -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
-// RUN: %clang_cc1 -triple riscv32-unknown-linux -target-feature +zimop -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
-// RUN: %clang_cc1 -triple riscv32-unknown-linux -target-feature +zimop -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
+// RUN: %clang_cc1 -triple riscv64 -target-feature +experimental-zicfiss -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
+// RUN: %clang_cc1 -triple riscv64 -target-feature +experimental-zicfiss -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
+// RUN: %clang_cc1 -triple riscv32 -target-feature +experimental-zicfiss -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
+// RUN: %clang_cc1 -triple riscv32 -target-feature +experimental-zicfiss -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
 
 int foo(int *a) { return *a; }
 


### PR DESCRIPTION
This patches enables the support of `-fcf-protection=return` on RISC-V, and add a string attribute "hw-shadow-stack" to every function if the option is set on RISC-V