### PR TITLE
[RISCV] Separate HW/SW shadow stack on RISC-V

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -67,10 +67,14 @@ static const std::pair<MCPhysReg, int8_t> FixedCSRFIMap[] = {
 static void emitSCSPrologue(MachineFunction &MF, MachineBasicBlock &MBB,
                             MachineBasicBlock::iterator MI,
                             const DebugLoc &DL) {
-  if (!MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack))
+  const auto &STI = MF.getSubtarget<RISCVSubtarget>();
+  bool HasHWShadowStack = MF.getFunction().hasFnAttribute("hw-shadow-stack") &&
+                          STI.hasStdExtZimop();
+  bool HasSWShadowStack =
+      MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack);
+  if (!HasHWShadowStack && !HasSWShadowStack)
     return;
 
-  const auto &STI = MF.getSubtarget<RISCVSubtarget>();
   const llvm::RISCVRegisterInfo *TRI = STI.getRegisterInfo();
   Register RAReg = TRI->getRARegister();
 
@@ -82,7 +86,7 @@ static void emitSCSPrologue(MachineFunction &MF, MachineBasicBlock &MBB,
     return;
 
   const RISCVInstrInfo *TII = STI.getInstrInfo();
-  if (!STI.hasForcedSWShadowStack() && STI.hasStdExtZicfiss()) {
+  if (HasHWShadowStack) {
     BuildMI(MBB, MI, DL, TII->get(RISCV::SSPUSH)).addReg(RAReg);
     return;
   }
@@ -129,10 +133,14 @@ static void emitSCSPrologue(MachineFunction &MF, MachineBasicBlock &MBB,
 static void emitSCSEpilogue(MachineFunction &MF, MachineBasicBlock &MBB,
                             MachineBasicBlock::iterator MI,
                             const DebugLoc &DL) {
-  if (!MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack))
+  const auto &STI = MF.getSubtarget<RISCVSubtarget>();
+  bool HasHWShadowStack = MF.getFunction().hasFnAttribute("hw-shadow-stack") &&
+                          STI.hasStdExtZimop();
+  bool HasSWShadowStack =
+      MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack);
+  if (!HasHWShadowStack && !HasSWShadowStack)
     return;
 
-  const auto &STI = MF.getSubtarget<RISCVSubtarget>();
   Register RAReg = STI.getRegisterInfo()->getRARegister();
 
   // See emitSCSPrologue() above.
@@ -142,7 +150,7 @@ static void emitSCSEpilogue(MachineFunction &MF, MachineBasicBlock &MBB,
     return;
 
   const RISCVInstrInfo *TII = STI.getInstrInfo();
-  if (!STI.hasForcedSWShadowStack() && STI.hasStdExtZicfiss()) {
+  if (HasHWShadowStack) {
     BuildMI(MBB, MI, DL, TII->get(RISCV::SSPOPCHK)).addReg(RAReg);
     return;
   }

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -69,7 +69,7 @@ static void emitSCSPrologue(MachineFunction &MF, MachineBasicBlock &MBB,
                             const DebugLoc &DL) {
   const auto &STI = MF.getSubtarget<RISCVSubtarget>();
   bool HasHWShadowStack = MF.getFunction().hasFnAttribute("hw-shadow-stack") &&
-                          STI.hasStdExtZimop();
+                          STI.hasStdExtZicfiss();
   bool HasSWShadowStack =
       MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack);
   if (!HasHWShadowStack && !HasSWShadowStack)
@@ -135,7 +135,7 @@ static void emitSCSEpilogue(MachineFunction &MF, MachineBasicBlock &MBB,
                             const DebugLoc &DL) {
   const auto &STI = MF.getSubtarget<RISCVSubtarget>();
   bool HasHWShadowStack = MF.getFunction().hasFnAttribute("hw-shadow-stack") &&
-                          STI.hasStdExtZimop();
+                          STI.hasStdExtZicfiss();
   bool HasSWShadowStack =
       MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack);
   if (!HasHWShadowStack && !HasSWShadowStack)

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZicfiss.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZicfiss.td
@@ -24,7 +24,7 @@ class RVC_SSInst<bits<5> rs1val, RegisterClass reg_class, string opcodestr> :
 // Instructions
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasStdExtZimop] in {
+let Predicates = [HasStdExtZicfiss] in {
 let Uses = [SSP], Defs = [SSP], hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def SSPOPCHK : RVInstI<0b100, OPC_SYSTEM, (outs), (ins GPRX1X5:$rs1), "sspopchk",
                        "$rs1"> {
@@ -45,28 +45,28 @@ def SSPUSH : RVInstR<0b1100111, 0b100, OPC_SYSTEM, (outs), (ins GPRX1X5:$rs2),
   let rd = 0b00000;
   let rs1 = 0b00000;
 }
-} // Predicates = [HasStdExtZimop]
+} // Predicates = [HasStdExtZicfiss]
 
-let Predicates = [HasStdExtZimop, HasStdExtZcmop],
+let Predicates = [HasStdExtZicfiss, HasStdExtZcmop],
     DecoderNamespace = "Zicfiss" in {
 let Uses = [SSP], Defs = [SSP], hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def C_SSPUSH : RVC_SSInst<0b00001, GPRX1, "c.sspush">;
 
 let Uses = [SSP], Defs = [SSP], hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def C_SSPOPCHK : RVC_SSInst<0b00101, GPRX5, "c.sspopchk">;
-} // Predicates = [HasStdExtZimop, HasStdExtZcmop]
+} // Predicates = [HasStdExtZicfiss, HasStdExtZcmop]
 
-let Predicates = [HasStdExtZimop] in
+let Predicates = [HasStdExtZicfiss] in
 defm SSAMOSWAP_W  : AMO_rr_aq_rl<0b01001, 0b010, "ssamoswap.w">;
 
-let Predicates = [HasStdExtZimop, IsRV64] in
+let Predicates = [HasStdExtZicfiss, IsRV64] in
 defm SSAMOSWAP_D  : AMO_rr_aq_rl<0b01001, 0b011, "ssamoswap.d">;
 
 //===----------------------------------------------------------------------===/
 // Compress Instruction tablegen backend.
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasStdExtZimop, HasStdExtZcmop] in {
+let Predicates = [HasStdExtZicfiss, HasStdExtZcmop] in {
 def : CompressPat<(SSPUSH X1), (C_SSPUSH X1)>;
 def : CompressPat<(SSPOPCHK X5), (C_SSPOPCHK X5)>;
-} // Predicates = [HasStdExtZimop, HasStdExtZcmop]
+} // Predicates = [HasStdExtZicfiss, HasStdExtZcmop]

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZicfiss.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZicfiss.td
@@ -24,7 +24,7 @@ class RVC_SSInst<bits<5> rs1val, RegisterClass reg_class, string opcodestr> :
 // Instructions
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasStdExtZicfiss] in {
+let Predicates = [HasStdExtZimop] in {
 let Uses = [SSP], Defs = [SSP], hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def SSPOPCHK : RVInstI<0b100, OPC_SYSTEM, (outs), (ins GPRX1X5:$rs1), "sspopchk",
                        "$rs1"> {
@@ -45,28 +45,28 @@ def SSPUSH : RVInstR<0b1100111, 0b100, OPC_SYSTEM, (outs), (ins GPRX1X5:$rs2),
   let rd = 0b00000;
   let rs1 = 0b00000;
 }
-} // Predicates = [HasStdExtZicfiss]
+} // Predicates = [HasStdExtZimop]
 
-let Predicates = [HasStdExtZicfiss, HasStdExtZcmop],
+let Predicates = [HasStdExtZimop, HasStdExtZcmop],
     DecoderNamespace = "Zicfiss" in {
 let Uses = [SSP], Defs = [SSP], hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def C_SSPUSH : RVC_SSInst<0b00001, GPRX1, "c.sspush">;
 
 let Uses = [SSP], Defs = [SSP], hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def C_SSPOPCHK : RVC_SSInst<0b00101, GPRX5, "c.sspopchk">;
-} // Predicates = [HasStdExtZicfiss, HasStdExtZcmop]
+} // Predicates = [HasStdExtZimop, HasStdExtZcmop]
 
-let Predicates = [HasStdExtZicfiss] in
+let Predicates = [HasStdExtZimop] in
 defm SSAMOSWAP_W  : AMO_rr_aq_rl<0b01001, 0b010, "ssamoswap.w">;
 
-let Predicates = [HasStdExtZicfiss, IsRV64] in
+let Predicates = [HasStdExtZimop, IsRV64] in
 defm SSAMOSWAP_D  : AMO_rr_aq_rl<0b01001, 0b011, "ssamoswap.d">;
 
 //===----------------------------------------------------------------------===/
 // Compress Instruction tablegen backend.
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasStdExtZicfiss, HasStdExtZcmop] in {
+let Predicates = [HasStdExtZimop, HasStdExtZcmop] in {
 def : CompressPat<(SSPUSH X1), (C_SSPUSH X1)>;
 def : CompressPat<(SSPOPCHK X5), (C_SSPOPCHK X5)>;
-} // Predicates = [HasStdExtZicfiss, HasStdExtZcmop]
+} // Predicates = [HasStdExtZimop, HasStdExtZcmop]

--- a/llvm/test/CodeGen/RISCV/shadowcallstack.ll
+++ b/llvm/test/CodeGen/RISCV/shadowcallstack.ll
@@ -104,7 +104,9 @@ define i32 @f3() shadowcallstack {
 ; RV32-ZICFISS-NEXT:    .cfi_restore ra
 ; RV32-ZICFISS-NEXT:    addi sp, sp, 16
 ; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
-; RV32-ZICFISS-NEXT:    sspopchk ra
+; RV32-ZICFISS-NEXT:    lw ra, -4(gp)
+; RV32-ZICFISS-NEXT:    addi gp, gp, -4
+; RV32-ZICFISS-NEXT:    .cfi_restore gp
 ; RV32-ZICFISS-NEXT:    ret
 ;
 ; RV64-ZICFISS-LABEL: f3:
@@ -121,7 +123,9 @@ define i32 @f3() shadowcallstack {
 ; RV64-ZICFISS-NEXT:    .cfi_restore ra
 ; RV64-ZICFISS-NEXT:    addi sp, sp, 16
 ; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
-; RV64-ZICFISS-NEXT:    sspopchk ra
+; RV64-ZICFISS-NEXT:    ld ra, -8(gp)
+; RV64-ZICFISS-NEXT:    addi gp, gp, -8
+; RV64-ZICFISS-NEXT:    .cfi_restore gp
 ; RV64-ZICFISS-NEXT:    ret
   %res = call i32 @bar()
   %res1 = add i32 %res, 1
@@ -243,6 +247,7 @@ define i32 @f4() shadowcallstack {
 ; RV32-ZICFISS-NEXT:    .cfi_restore s1
 ; RV32-ZICFISS-NEXT:    .cfi_restore s2
 ; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-ZICFISS-NEXT:    lw ra, -4(gp)
 ; RV32-ZICFISS-NEXT:    addi gp, gp, -4
 ; RV32-ZICFISS-NEXT:    .cfi_restore gp
@@ -282,6 +287,7 @@ define i32 @f4() shadowcallstack {
 ; RV64-ZICFISS-NEXT:    .cfi_restore s1
 ; RV64-ZICFISS-NEXT:    .cfi_restore s2
 ; RV64-ZICFISS-NEXT:    addi sp, sp, 32
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-ZICFISS-NEXT:    ld ra, -8(gp)
 ; RV64-ZICFISS-NEXT:    addi gp, gp, -8
 ; RV64-ZICFISS-NEXT:    .cfi_restore gp
@@ -401,7 +407,9 @@ define i32 @f3_hw() "hw-shadow-stack" {
 ; RV32-NEXT:    .cfi_offset ra, -4
 ; RV32-NEXT:    call bar
 ; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    .cfi_restore ra
 ; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: f3_hw:
@@ -412,7 +420,9 @@ define i32 @f3_hw() "hw-shadow-stack" {
 ; RV64-NEXT:    .cfi_offset ra, -8
 ; RV64-NEXT:    call bar
 ; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    .cfi_restore ra
 ; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-NEXT:    ret
 ;
 ; RV32-ZICFISS-LABEL: f3_hw:
@@ -424,7 +434,9 @@ define i32 @f3_hw() "hw-shadow-stack" {
 ; RV32-ZICFISS-NEXT:    .cfi_offset ra, -4
 ; RV32-ZICFISS-NEXT:    call bar
 ; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    .cfi_restore ra
 ; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-ZICFISS-NEXT:    sspopchk ra
 ; RV32-ZICFISS-NEXT:    ret
 ;
@@ -437,7 +449,9 @@ define i32 @f3_hw() "hw-shadow-stack" {
 ; RV64-ZICFISS-NEXT:    .cfi_offset ra, -8
 ; RV64-ZICFISS-NEXT:    call bar
 ; RV64-ZICFISS-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    .cfi_restore ra
 ; RV64-ZICFISS-NEXT:    addi sp, sp, 16
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-ZICFISS-NEXT:    sspopchk ra
 ; RV64-ZICFISS-NEXT:    ret
   %res = call i32 @bar()
@@ -472,7 +486,12 @@ define i32 @f4_hw() "hw-shadow-stack" {
 ; RV32-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-NEXT:    .cfi_restore ra
+; RV32-NEXT:    .cfi_restore s0
+; RV32-NEXT:    .cfi_restore s1
+; RV32-NEXT:    .cfi_restore s2
 ; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: f4_hw:
@@ -501,7 +520,12 @@ define i32 @f4_hw() "hw-shadow-stack" {
 ; RV64-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-NEXT:    .cfi_restore ra
+; RV64-NEXT:    .cfi_restore s0
+; RV64-NEXT:    .cfi_restore s1
+; RV64-NEXT:    .cfi_restore s2
 ; RV64-NEXT:    addi sp, sp, 32
+; RV64-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-NEXT:    ret
 ;
 ; RV32-ZICFISS-LABEL: f4_hw:
@@ -531,7 +555,12 @@ define i32 @f4_hw() "hw-shadow-stack" {
 ; RV32-ZICFISS-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32-ZICFISS-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
 ; RV32-ZICFISS-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    .cfi_restore ra
+; RV32-ZICFISS-NEXT:    .cfi_restore s0
+; RV32-ZICFISS-NEXT:    .cfi_restore s1
+; RV32-ZICFISS-NEXT:    .cfi_restore s2
 ; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-ZICFISS-NEXT:    sspopchk ra
 ; RV32-ZICFISS-NEXT:    ret
 ;
@@ -562,7 +591,12 @@ define i32 @f4_hw() "hw-shadow-stack" {
 ; RV64-ZICFISS-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; RV64-ZICFISS-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
 ; RV64-ZICFISS-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    .cfi_restore ra
+; RV64-ZICFISS-NEXT:    .cfi_restore s0
+; RV64-ZICFISS-NEXT:    .cfi_restore s1
+; RV64-ZICFISS-NEXT:    .cfi_restore s2
 ; RV64-ZICFISS-NEXT:    addi sp, sp, 32
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-ZICFISS-NEXT:    sspopchk ra
 ; RV64-ZICFISS-NEXT:    ret
   %res1 = call i32 @bar()
@@ -671,7 +705,9 @@ define i32 @f3_both() "hw-shadow-stack" shadowcallstack {
 ; RV32-NEXT:    .cfi_offset ra, -4
 ; RV32-NEXT:    call bar
 ; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    .cfi_restore ra
 ; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    lw ra, -4(gp)
 ; RV32-NEXT:    addi gp, gp, -4
 ; RV32-NEXT:    .cfi_restore gp
@@ -688,7 +724,9 @@ define i32 @f3_both() "hw-shadow-stack" shadowcallstack {
 ; RV64-NEXT:    .cfi_offset ra, -8
 ; RV64-NEXT:    call bar
 ; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    .cfi_restore ra
 ; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-NEXT:    ld ra, -8(gp)
 ; RV64-NEXT:    addi gp, gp, -8
 ; RV64-NEXT:    .cfi_restore gp
@@ -703,7 +741,9 @@ define i32 @f3_both() "hw-shadow-stack" shadowcallstack {
 ; RV32-ZICFISS-NEXT:    .cfi_offset ra, -4
 ; RV32-ZICFISS-NEXT:    call bar
 ; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    .cfi_restore ra
 ; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-ZICFISS-NEXT:    sspopchk ra
 ; RV32-ZICFISS-NEXT:    ret
 ;
@@ -716,7 +756,9 @@ define i32 @f3_both() "hw-shadow-stack" shadowcallstack {
 ; RV64-ZICFISS-NEXT:    .cfi_offset ra, -8
 ; RV64-ZICFISS-NEXT:    call bar
 ; RV64-ZICFISS-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    .cfi_restore ra
 ; RV64-ZICFISS-NEXT:    addi sp, sp, 16
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-ZICFISS-NEXT:    sspopchk ra
 ; RV64-ZICFISS-NEXT:    ret
   %res = call i32 @bar()
@@ -754,7 +796,12 @@ define i32 @f4_both() "hw-shadow-stack" shadowcallstack {
 ; RV32-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-NEXT:    .cfi_restore ra
+; RV32-NEXT:    .cfi_restore s0
+; RV32-NEXT:    .cfi_restore s1
+; RV32-NEXT:    .cfi_restore s2
 ; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    lw ra, -4(gp)
 ; RV32-NEXT:    addi gp, gp, -4
 ; RV32-NEXT:    .cfi_restore gp
@@ -789,7 +836,12 @@ define i32 @f4_both() "hw-shadow-stack" shadowcallstack {
 ; RV64-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-NEXT:    .cfi_restore ra
+; RV64-NEXT:    .cfi_restore s0
+; RV64-NEXT:    .cfi_restore s1
+; RV64-NEXT:    .cfi_restore s2
 ; RV64-NEXT:    addi sp, sp, 32
+; RV64-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-NEXT:    ld ra, -8(gp)
 ; RV64-NEXT:    addi gp, gp, -8
 ; RV64-NEXT:    .cfi_restore gp
@@ -822,7 +874,12 @@ define i32 @f4_both() "hw-shadow-stack" shadowcallstack {
 ; RV32-ZICFISS-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32-ZICFISS-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
 ; RV32-ZICFISS-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    .cfi_restore ra
+; RV32-ZICFISS-NEXT:    .cfi_restore s0
+; RV32-ZICFISS-NEXT:    .cfi_restore s1
+; RV32-ZICFISS-NEXT:    .cfi_restore s2
 ; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-ZICFISS-NEXT:    sspopchk ra
 ; RV32-ZICFISS-NEXT:    ret
 ;
@@ -853,7 +910,12 @@ define i32 @f4_both() "hw-shadow-stack" shadowcallstack {
 ; RV64-ZICFISS-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; RV64-ZICFISS-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
 ; RV64-ZICFISS-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    .cfi_restore ra
+; RV64-ZICFISS-NEXT:    .cfi_restore s0
+; RV64-ZICFISS-NEXT:    .cfi_restore s1
+; RV64-ZICFISS-NEXT:    .cfi_restore s2
 ; RV64-ZICFISS-NEXT:    addi sp, sp, 32
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-ZICFISS-NEXT:    sspopchk ra
 ; RV64-ZICFISS-NEXT:    ret
   %res1 = call i32 @bar()

--- a/llvm/test/CodeGen/RISCV/shadowcallstack.ll
+++ b/llvm/test/CodeGen/RISCV/shadowcallstack.ll
@@ -7,10 +7,6 @@
 ; RUN:   -verify-machineinstrs | FileCheck %s --check-prefix=RV32-ZICFISS
 ; RUN: llc -mtriple=riscv64 -mattr=+experimental-zicfiss < %s \
 ; RUN:   -verify-machineinstrs | FileCheck %s --check-prefix=RV64-ZICFISS
-; RUN: llc -mtriple=riscv32 -mattr=+experimental-zicfiss,forced-sw-shadow-stack \
-; RUN:    -verify-machineinstrs < %s | FileCheck %s --check-prefix=RV32
-; RUN: llc -mtriple=riscv64 -mattr=+experimental-zicfiss,forced-sw-shadow-stack \
-; RUN:    -verify-machineinstrs < %s | FileCheck %s --check-prefix=RV64
 
 define void @f1() shadowcallstack {
 ; RV32-LABEL: f1:
@@ -96,7 +92,9 @@ define i32 @f3() shadowcallstack {
 ;
 ; RV32-ZICFISS-LABEL: f3:
 ; RV32-ZICFISS:       # %bb.0:
-; RV32-ZICFISS-NEXT:    sspush ra
+; RV32-ZICFISS-NEXT:    addi gp, gp, 4
+; RV32-ZICFISS-NEXT:    sw ra, -4(gp)
+; RV32-ZICFISS-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
 ; RV32-ZICFISS-NEXT:    addi sp, sp, -16
 ; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
 ; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
@@ -111,7 +109,9 @@ define i32 @f3() shadowcallstack {
 ;
 ; RV64-ZICFISS-LABEL: f3:
 ; RV64-ZICFISS:       # %bb.0:
-; RV64-ZICFISS-NEXT:    sspush ra
+; RV64-ZICFISS-NEXT:    addi gp, gp, 8
+; RV64-ZICFISS-NEXT:    sd ra, -8(gp)
+; RV64-ZICFISS-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
 ; RV64-ZICFISS-NEXT:    addi sp, sp, -16
 ; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
 ; RV64-ZICFISS-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
@@ -211,7 +211,9 @@ define i32 @f4() shadowcallstack {
 ;
 ; RV32-ZICFISS-LABEL: f4:
 ; RV32-ZICFISS:       # %bb.0:
-; RV32-ZICFISS-NEXT:    sspush ra
+; RV32-ZICFISS-NEXT:    addi gp, gp, 4
+; RV32-ZICFISS-NEXT:    sw ra, -4(gp)
+; RV32-ZICFISS-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
 ; RV32-ZICFISS-NEXT:    addi sp, sp, -16
 ; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
 ; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
@@ -241,13 +243,16 @@ define i32 @f4() shadowcallstack {
 ; RV32-ZICFISS-NEXT:    .cfi_restore s1
 ; RV32-ZICFISS-NEXT:    .cfi_restore s2
 ; RV32-ZICFISS-NEXT:    addi sp, sp, 16
-; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
-; RV32-ZICFISS-NEXT:    sspopchk ra
+; RV32-ZICFISS-NEXT:    lw ra, -4(gp)
+; RV32-ZICFISS-NEXT:    addi gp, gp, -4
+; RV32-ZICFISS-NEXT:    .cfi_restore gp
 ; RV32-ZICFISS-NEXT:    ret
 ;
 ; RV64-ZICFISS-LABEL: f4:
 ; RV64-ZICFISS:       # %bb.0:
-; RV64-ZICFISS-NEXT:    sspush ra
+; RV64-ZICFISS-NEXT:    addi gp, gp, 8
+; RV64-ZICFISS-NEXT:    sd ra, -8(gp)
+; RV64-ZICFISS-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
 ; RV64-ZICFISS-NEXT:    addi sp, sp, -32
 ; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 32
 ; RV64-ZICFISS-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
@@ -277,8 +282,9 @@ define i32 @f4() shadowcallstack {
 ; RV64-ZICFISS-NEXT:    .cfi_restore s1
 ; RV64-ZICFISS-NEXT:    .cfi_restore s2
 ; RV64-ZICFISS-NEXT:    addi sp, sp, 32
-; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 0
-; RV64-ZICFISS-NEXT:    sspopchk ra
+; RV64-ZICFISS-NEXT:    ld ra, -8(gp)
+; RV64-ZICFISS-NEXT:    addi gp, gp, -8
+; RV64-ZICFISS-NEXT:    .cfi_restore gp
 ; RV64-ZICFISS-NEXT:    ret
   %res1 = call i32 @bar()
   %res2 = call i32 @bar()
@@ -319,6 +325,309 @@ define i32 @f5() shadowcallstack nounwind {
 ;
 ; RV32-ZICFISS-LABEL: f5:
 ; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    addi gp, gp, 4
+; RV32-ZICFISS-NEXT:    sw ra, -4(gp)
+; RV32-ZICFISS-NEXT:    addi sp, sp, -16
+; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    lw ra, -4(gp)
+; RV32-ZICFISS-NEXT:    addi gp, gp, -4
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f5:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    addi gp, gp, 8
+; RV64-ZICFISS-NEXT:    sd ra, -8(gp)
+; RV64-ZICFISS-NEXT:    addi sp, sp, -16
+; RV64-ZICFISS-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    addi sp, sp, 16
+; RV64-ZICFISS-NEXT:    ld ra, -8(gp)
+; RV64-ZICFISS-NEXT:    addi gp, gp, -8
+; RV64-ZICFISS-NEXT:    ret
+  %res = call i32 @bar()
+  %res1 = add i32 %res, 1
+  ret i32 %res
+}
+
+define void @f1_hw() "hw-shadow-stack" {
+; RV32-LABEL: f1_hw:
+; RV32:       # %bb.0:
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f1_hw:
+; RV64:       # %bb.0:
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f1_hw:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f1_hw:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    ret
+  ret void
+}
+
+define void @f2_hw() "hw-shadow-stack" {
+; RV32-LABEL: f2_hw:
+; RV32:       # %bb.0:
+; RV32-NEXT:    tail foo
+;
+; RV64-LABEL: f2_hw:
+; RV64:       # %bb.0:
+; RV64-NEXT:    tail foo
+;
+; RV32-ZICFISS-LABEL: f2_hw:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    tail foo
+;
+; RV64-ZICFISS-LABEL: f2_hw:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    tail foo
+  tail call void @foo()
+  ret void
+}
+
+define i32 @f3_hw() "hw-shadow-stack" {
+; RV32-LABEL: f3_hw:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi gp, gp, 4
+; RV32-NEXT:    sw ra, -4(gp)
+; RV32-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset ra, -4
+; RV32-NEXT:    call bar
+; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    lw ra, -4(gp)
+; RV32-NEXT:    addi gp, gp, -4
+; RV32-NEXT:    .cfi_restore gp
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f3_hw:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi gp, gp, 8
+; RV64-NEXT:    sd ra, -8(gp)
+; RV64-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    .cfi_def_cfa_offset 16
+; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    .cfi_offset ra, -8
+; RV64-NEXT:    call bar
+; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    ld ra, -8(gp)
+; RV64-NEXT:    addi gp, gp, -8
+; RV64-NEXT:    .cfi_restore gp
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f3_hw:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    sspush ra
+; RV32-ZICFISS-NEXT:    addi sp, sp, -16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
+; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    .cfi_offset ra, -4
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    sspopchk ra
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f3_hw:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    sspush ra
+; RV64-ZICFISS-NEXT:    addi sp, sp, -16
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
+; RV64-ZICFISS-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    .cfi_offset ra, -8
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    addi sp, sp, 16
+; RV64-ZICFISS-NEXT:    sspopchk ra
+; RV64-ZICFISS-NEXT:    ret
+  %res = call i32 @bar()
+  %res1 = add i32 %res, 1
+  ret i32 %res
+}
+
+define i32 @f4_hw() "hw-shadow-stack" {
+; RV32-LABEL: f4_hw:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi gp, gp, 4
+; RV32-NEXT:    sw ra, -4(gp)
+; RV32-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s2, 0(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset ra, -4
+; RV32-NEXT:    .cfi_offset s0, -8
+; RV32-NEXT:    .cfi_offset s1, -12
+; RV32-NEXT:    .cfi_offset s2, -16
+; RV32-NEXT:    call bar
+; RV32-NEXT:    mv s0, a0
+; RV32-NEXT:    call bar
+; RV32-NEXT:    mv s1, a0
+; RV32-NEXT:    call bar
+; RV32-NEXT:    mv s2, a0
+; RV32-NEXT:    call bar
+; RV32-NEXT:    add s0, s0, s1
+; RV32-NEXT:    add a0, s2, a0
+; RV32-NEXT:    add a0, s0, a0
+; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    lw ra, -4(gp)
+; RV32-NEXT:    addi gp, gp, -4
+; RV32-NEXT:    .cfi_restore gp
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f4_hw:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi gp, gp, 8
+; RV64-NEXT:    sd ra, -8(gp)
+; RV64-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
+; RV64-NEXT:    addi sp, sp, -32
+; RV64-NEXT:    .cfi_def_cfa_offset 32
+; RV64-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s2, 0(sp) # 8-byte Folded Spill
+; RV64-NEXT:    .cfi_offset ra, -8
+; RV64-NEXT:    .cfi_offset s0, -16
+; RV64-NEXT:    .cfi_offset s1, -24
+; RV64-NEXT:    .cfi_offset s2, -32
+; RV64-NEXT:    call bar
+; RV64-NEXT:    mv s0, a0
+; RV64-NEXT:    call bar
+; RV64-NEXT:    mv s1, a0
+; RV64-NEXT:    call bar
+; RV64-NEXT:    mv s2, a0
+; RV64-NEXT:    call bar
+; RV64-NEXT:    add s0, s0, s1
+; RV64-NEXT:    add a0, s2, a0
+; RV64-NEXT:    addw a0, s0, a0
+; RV64-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 32
+; RV64-NEXT:    ld ra, -8(gp)
+; RV64-NEXT:    addi gp, gp, -8
+; RV64-NEXT:    .cfi_restore gp
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f4_hw:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    sspush ra
+; RV32-ZICFISS-NEXT:    addi sp, sp, -16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
+; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    sw s2, 0(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    .cfi_offset ra, -4
+; RV32-ZICFISS-NEXT:    .cfi_offset s0, -8
+; RV32-ZICFISS-NEXT:    .cfi_offset s1, -12
+; RV32-ZICFISS-NEXT:    .cfi_offset s2, -16
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    mv s0, a0
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    mv s1, a0
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    mv s2, a0
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    add s0, s0, s1
+; RV32-ZICFISS-NEXT:    add a0, s2, a0
+; RV32-ZICFISS-NEXT:    add a0, s0, a0
+; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    sspopchk ra
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f4_hw:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    sspush ra
+; RV64-ZICFISS-NEXT:    addi sp, sp, -32
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 32
+; RV64-ZICFISS-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    sd s2, 0(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    .cfi_offset ra, -8
+; RV64-ZICFISS-NEXT:    .cfi_offset s0, -16
+; RV64-ZICFISS-NEXT:    .cfi_offset s1, -24
+; RV64-ZICFISS-NEXT:    .cfi_offset s2, -32
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    mv s0, a0
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    mv s1, a0
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    mv s2, a0
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    add s0, s0, s1
+; RV64-ZICFISS-NEXT:    add a0, s2, a0
+; RV64-ZICFISS-NEXT:    addw a0, s0, a0
+; RV64-ZICFISS-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    addi sp, sp, 32
+; RV64-ZICFISS-NEXT:    sspopchk ra
+; RV64-ZICFISS-NEXT:    ret
+  %res1 = call i32 @bar()
+  %res2 = call i32 @bar()
+  %res3 = call i32 @bar()
+  %res4 = call i32 @bar()
+  %res12 = add i32 %res1, %res2
+  %res34 = add i32 %res3, %res4
+  %res1234 = add i32 %res12, %res34
+  ret i32 %res1234
+}
+
+define i32 @f5_hw() "hw-shadow-stack" nounwind {
+; RV32-LABEL: f5_hw:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi gp, gp, 4
+; RV32-NEXT:    sw ra, -4(gp)
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    call bar
+; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    lw ra, -4(gp)
+; RV32-NEXT:    addi gp, gp, -4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f5_hw:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi gp, gp, 8
+; RV64-NEXT:    sd ra, -8(gp)
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    call bar
+; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    ld ra, -8(gp)
+; RV64-NEXT:    addi gp, gp, -8
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f5_hw:
+; RV32-ZICFISS:       # %bb.0:
 ; RV32-ZICFISS-NEXT:    sspush ra
 ; RV32-ZICFISS-NEXT:    addi sp, sp, -16
 ; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
@@ -328,7 +637,306 @@ define i32 @f5() shadowcallstack nounwind {
 ; RV32-ZICFISS-NEXT:    sspopchk ra
 ; RV32-ZICFISS-NEXT:    ret
 ;
-; RV64-ZICFISS-LABEL: f5:
+; RV64-ZICFISS-LABEL: f5_hw:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    sspush ra
+; RV64-ZICFISS-NEXT:    addi sp, sp, -16
+; RV64-ZICFISS-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    addi sp, sp, 16
+; RV64-ZICFISS-NEXT:    sspopchk ra
+; RV64-ZICFISS-NEXT:    ret
+  %res = call i32 @bar()
+  %res1 = add i32 %res, 1
+  ret i32 %res
+}
+
+define void @f1_both() "hw-shadow-stack" shadowcallstack {
+; RV32-LABEL: f1_both:
+; RV32:       # %bb.0:
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f1_both:
+; RV64:       # %bb.0:
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f1_both:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f1_both:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    ret
+  ret void
+}
+
+define void @f2_both() "hw-shadow-stack" shadowcallstack {
+; RV32-LABEL: f2_both:
+; RV32:       # %bb.0:
+; RV32-NEXT:    tail foo
+;
+; RV64-LABEL: f2_both:
+; RV64:       # %bb.0:
+; RV64-NEXT:    tail foo
+;
+; RV32-ZICFISS-LABEL: f2_both:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    tail foo
+;
+; RV64-ZICFISS-LABEL: f2_both:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    tail foo
+  tail call void @foo()
+  ret void
+}
+
+define i32 @f3_both() "hw-shadow-stack" shadowcallstack {
+; RV32-LABEL: f3_both:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi gp, gp, 4
+; RV32-NEXT:    sw ra, -4(gp)
+; RV32-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset ra, -4
+; RV32-NEXT:    call bar
+; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    lw ra, -4(gp)
+; RV32-NEXT:    addi gp, gp, -4
+; RV32-NEXT:    .cfi_restore gp
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f3_both:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi gp, gp, 8
+; RV64-NEXT:    sd ra, -8(gp)
+; RV64-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    .cfi_def_cfa_offset 16
+; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    .cfi_offset ra, -8
+; RV64-NEXT:    call bar
+; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    ld ra, -8(gp)
+; RV64-NEXT:    addi gp, gp, -8
+; RV64-NEXT:    .cfi_restore gp
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f3_both:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    sspush ra
+; RV32-ZICFISS-NEXT:    addi sp, sp, -16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
+; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    .cfi_offset ra, -4
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    sspopchk ra
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f3_both:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    sspush ra
+; RV64-ZICFISS-NEXT:    addi sp, sp, -16
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
+; RV64-ZICFISS-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    .cfi_offset ra, -8
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    addi sp, sp, 16
+; RV64-ZICFISS-NEXT:    sspopchk ra
+; RV64-ZICFISS-NEXT:    ret
+  %res = call i32 @bar()
+  %res1 = add i32 %res, 1
+  ret i32 %res
+}
+
+define i32 @f4_both() "hw-shadow-stack" shadowcallstack {
+; RV32-LABEL: f4_both:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi gp, gp, 4
+; RV32-NEXT:    sw ra, -4(gp)
+; RV32-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s2, 0(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset ra, -4
+; RV32-NEXT:    .cfi_offset s0, -8
+; RV32-NEXT:    .cfi_offset s1, -12
+; RV32-NEXT:    .cfi_offset s2, -16
+; RV32-NEXT:    call bar
+; RV32-NEXT:    mv s0, a0
+; RV32-NEXT:    call bar
+; RV32-NEXT:    mv s1, a0
+; RV32-NEXT:    call bar
+; RV32-NEXT:    mv s2, a0
+; RV32-NEXT:    call bar
+; RV32-NEXT:    add s0, s0, s1
+; RV32-NEXT:    add a0, s2, a0
+; RV32-NEXT:    add a0, s0, a0
+; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    lw ra, -4(gp)
+; RV32-NEXT:    addi gp, gp, -4
+; RV32-NEXT:    .cfi_restore gp
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f4_both:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi gp, gp, 8
+; RV64-NEXT:    sd ra, -8(gp)
+; RV64-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
+; RV64-NEXT:    addi sp, sp, -32
+; RV64-NEXT:    .cfi_def_cfa_offset 32
+; RV64-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s2, 0(sp) # 8-byte Folded Spill
+; RV64-NEXT:    .cfi_offset ra, -8
+; RV64-NEXT:    .cfi_offset s0, -16
+; RV64-NEXT:    .cfi_offset s1, -24
+; RV64-NEXT:    .cfi_offset s2, -32
+; RV64-NEXT:    call bar
+; RV64-NEXT:    mv s0, a0
+; RV64-NEXT:    call bar
+; RV64-NEXT:    mv s1, a0
+; RV64-NEXT:    call bar
+; RV64-NEXT:    mv s2, a0
+; RV64-NEXT:    call bar
+; RV64-NEXT:    add s0, s0, s1
+; RV64-NEXT:    add a0, s2, a0
+; RV64-NEXT:    addw a0, s0, a0
+; RV64-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 32
+; RV64-NEXT:    ld ra, -8(gp)
+; RV64-NEXT:    addi gp, gp, -8
+; RV64-NEXT:    .cfi_restore gp
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f4_both:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    sspush ra
+; RV32-ZICFISS-NEXT:    addi sp, sp, -16
+; RV32-ZICFISS-NEXT:    .cfi_def_cfa_offset 16
+; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    sw s2, 0(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    .cfi_offset ra, -4
+; RV32-ZICFISS-NEXT:    .cfi_offset s0, -8
+; RV32-ZICFISS-NEXT:    .cfi_offset s1, -12
+; RV32-ZICFISS-NEXT:    .cfi_offset s2, -16
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    mv s0, a0
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    mv s1, a0
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    mv s2, a0
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    add s0, s0, s1
+; RV32-ZICFISS-NEXT:    add a0, s2, a0
+; RV32-ZICFISS-NEXT:    add a0, s0, a0
+; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    sspopchk ra
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f4_both:
+; RV64-ZICFISS:       # %bb.0:
+; RV64-ZICFISS-NEXT:    sspush ra
+; RV64-ZICFISS-NEXT:    addi sp, sp, -32
+; RV64-ZICFISS-NEXT:    .cfi_def_cfa_offset 32
+; RV64-ZICFISS-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    sd s2, 0(sp) # 8-byte Folded Spill
+; RV64-ZICFISS-NEXT:    .cfi_offset ra, -8
+; RV64-ZICFISS-NEXT:    .cfi_offset s0, -16
+; RV64-ZICFISS-NEXT:    .cfi_offset s1, -24
+; RV64-ZICFISS-NEXT:    .cfi_offset s2, -32
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    mv s0, a0
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    mv s1, a0
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    mv s2, a0
+; RV64-ZICFISS-NEXT:    call bar
+; RV64-ZICFISS-NEXT:    add s0, s0, s1
+; RV64-ZICFISS-NEXT:    add a0, s2, a0
+; RV64-ZICFISS-NEXT:    addw a0, s0, a0
+; RV64-ZICFISS-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
+; RV64-ZICFISS-NEXT:    addi sp, sp, 32
+; RV64-ZICFISS-NEXT:    sspopchk ra
+; RV64-ZICFISS-NEXT:    ret
+  %res1 = call i32 @bar()
+  %res2 = call i32 @bar()
+  %res3 = call i32 @bar()
+  %res4 = call i32 @bar()
+  %res12 = add i32 %res1, %res2
+  %res34 = add i32 %res3, %res4
+  %res1234 = add i32 %res12, %res34
+  ret i32 %res1234
+}
+
+define i32 @f5_both() "hw-shadow-stack" shadowcallstack nounwind {
+; RV32-LABEL: f5_both:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi gp, gp, 4
+; RV32-NEXT:    sw ra, -4(gp)
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    call bar
+; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    lw ra, -4(gp)
+; RV32-NEXT:    addi gp, gp, -4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: f5_both:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi gp, gp, 8
+; RV64-NEXT:    sd ra, -8(gp)
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    call bar
+; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    ld ra, -8(gp)
+; RV64-NEXT:    addi gp, gp, -8
+; RV64-NEXT:    ret
+;
+; RV32-ZICFISS-LABEL: f5_both:
+; RV32-ZICFISS:       # %bb.0:
+; RV32-ZICFISS-NEXT:    sspush ra
+; RV32-ZICFISS-NEXT:    addi sp, sp, -16
+; RV32-ZICFISS-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-ZICFISS-NEXT:    call bar
+; RV32-ZICFISS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32-ZICFISS-NEXT:    addi sp, sp, 16
+; RV32-ZICFISS-NEXT:    sspopchk ra
+; RV32-ZICFISS-NEXT:    ret
+;
+; RV64-ZICFISS-LABEL: f5_both:
 ; RV64-ZICFISS:       # %bb.0:
 ; RV64-ZICFISS-NEXT:    sspush ra
 ; RV64-ZICFISS-NEXT:    addi sp, sp, -16

--- a/llvm/test/CodeGen/RISCV/shadowcallstack.ll
+++ b/llvm/test/CodeGen/RISCV/shadowcallstack.ll
@@ -395,9 +395,6 @@ define void @f2_hw() "hw-shadow-stack" {
 define i32 @f3_hw() "hw-shadow-stack" {
 ; RV32-LABEL: f3_hw:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi gp, gp, 4
-; RV32-NEXT:    sw ra, -4(gp)
-; RV32-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
 ; RV32-NEXT:    addi sp, sp, -16
 ; RV32-NEXT:    .cfi_def_cfa_offset 16
 ; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
@@ -405,16 +402,10 @@ define i32 @f3_hw() "hw-shadow-stack" {
 ; RV32-NEXT:    call bar
 ; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    addi sp, sp, 16
-; RV32-NEXT:    lw ra, -4(gp)
-; RV32-NEXT:    addi gp, gp, -4
-; RV32-NEXT:    .cfi_restore gp
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: f3_hw:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi gp, gp, 8
-; RV64-NEXT:    sd ra, -8(gp)
-; RV64-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
 ; RV64-NEXT:    addi sp, sp, -16
 ; RV64-NEXT:    .cfi_def_cfa_offset 16
 ; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
@@ -422,9 +413,6 @@ define i32 @f3_hw() "hw-shadow-stack" {
 ; RV64-NEXT:    call bar
 ; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    addi sp, sp, 16
-; RV64-NEXT:    ld ra, -8(gp)
-; RV64-NEXT:    addi gp, gp, -8
-; RV64-NEXT:    .cfi_restore gp
 ; RV64-NEXT:    ret
 ;
 ; RV32-ZICFISS-LABEL: f3_hw:
@@ -460,9 +448,6 @@ define i32 @f3_hw() "hw-shadow-stack" {
 define i32 @f4_hw() "hw-shadow-stack" {
 ; RV32-LABEL: f4_hw:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi gp, gp, 4
-; RV32-NEXT:    sw ra, -4(gp)
-; RV32-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x7c #
 ; RV32-NEXT:    addi sp, sp, -16
 ; RV32-NEXT:    .cfi_def_cfa_offset 16
 ; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
@@ -488,16 +473,10 @@ define i32 @f4_hw() "hw-shadow-stack" {
 ; RV32-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    addi sp, sp, 16
-; RV32-NEXT:    lw ra, -4(gp)
-; RV32-NEXT:    addi gp, gp, -4
-; RV32-NEXT:    .cfi_restore gp
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: f4_hw:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi gp, gp, 8
-; RV64-NEXT:    sd ra, -8(gp)
-; RV64-NEXT:    .cfi_escape 0x16, 0x03, 0x02, 0x73, 0x78 #
 ; RV64-NEXT:    addi sp, sp, -32
 ; RV64-NEXT:    .cfi_def_cfa_offset 32
 ; RV64-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
@@ -523,9 +502,6 @@ define i32 @f4_hw() "hw-shadow-stack" {
 ; RV64-NEXT:    ld s1, 8(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s2, 0(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    addi sp, sp, 32
-; RV64-NEXT:    ld ra, -8(gp)
-; RV64-NEXT:    addi gp, gp, -8
-; RV64-NEXT:    .cfi_restore gp
 ; RV64-NEXT:    ret
 ;
 ; RV32-ZICFISS-LABEL: f4_hw:
@@ -602,28 +578,20 @@ define i32 @f4_hw() "hw-shadow-stack" {
 define i32 @f5_hw() "hw-shadow-stack" nounwind {
 ; RV32-LABEL: f5_hw:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi gp, gp, 4
-; RV32-NEXT:    sw ra, -4(gp)
 ; RV32-NEXT:    addi sp, sp, -16
 ; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    call bar
 ; RV32-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    addi sp, sp, 16
-; RV32-NEXT:    lw ra, -4(gp)
-; RV32-NEXT:    addi gp, gp, -4
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: f5_hw:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi gp, gp, 8
-; RV64-NEXT:    sd ra, -8(gp)
 ; RV64-NEXT:    addi sp, sp, -16
 ; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
 ; RV64-NEXT:    call bar
 ; RV64-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    addi sp, sp, 16
-; RV64-NEXT:    ld ra, -8(gp)
-; RV64-NEXT:    addi gp, gp, -8
 ; RV64-NEXT:    ret
 ;
 ; RV32-ZICFISS-LABEL: f5_hw:


### PR DESCRIPTION
This patch follows https://github.com/llvm/llvm-project/pull/112477.
Previously `-fsanitize=shadow-call-stack` (which get transform to `Attribute::ShadowCallStack`) is used for enable both hardware and software shadow stack, and another option `-force-sw-shadow-stack` is needed if the user wants to use the software shadow stack where hardware software shadow stack could be supported. It decouples both by using the string attribute `hw-shadow-stack` to distinguish from the software shadow stack attribute.