### PR TITLE
[MIR] Fix vreg flag vector memory leak

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -45,7 +45,7 @@ struct VRegInfo {
   } D;
   Register VReg;
   Register PreferredReg;
-  std::vector<uint8_t> Flags;
+  SmallVector<uint8_t> Flags;
 };
 
 using Name2RegClassMap = StringMap<const TargetRegisterClass *>;

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -45,7 +45,7 @@ struct VRegInfo {
   } D;
   Register VReg;
   Register PreferredReg;
-  SmallVector<uint8_t> Flags;
+  uint8_t Flags = 0;
 };
 
 using Name2RegClassMap = StringMap<const TargetRegisterClass *>;

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -703,7 +703,7 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(FlagStringValue.SourceRange.Start,
                      Twine("use of undefined register flag '") +
                          FlagStringValue.Value + "'");
-      Info.Flags.push_back(FlagValue);
+      Info.Flags |= FlagValue;
     }
     RegInfo.noteNewVirtualRegister(Info.VReg);
   }

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -703,11 +703,6 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(FlagStringValue.SourceRange.Start,
                      Twine("use of undefined register flag '") +
                          FlagStringValue.Value + "'");
-      if (Info.Flags & FlagValue)
-        return error(FlagStringValue.SourceRange.Start,
-                     Twine("flag '") + FlagStringValue.Value +
-                         "' was already set for virtual register '%" +
-                         Twine(VReg.ID.Value) + "'");
       Info.Flags |= FlagValue;
     }
     RegInfo.noteNewVirtualRegister(Info.VReg);

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -703,6 +703,11 @@ bool MIRParserImpl::parseRegisterInfo(PerFunctionMIParsingState &PFS,
         return error(FlagStringValue.SourceRange.Start,
                      Twine("use of undefined register flag '") +
                          FlagStringValue.Value + "'");
+      if (Info.Flags & FlagValue)
+        return error(FlagStringValue.SourceRange.Start,
+                     Twine("flag '") + FlagStringValue.Value +
+                         "' was already set for virtual register '%" +
+                         Twine(VReg.ID.Value) + "'");
       Info.Flags |= FlagValue;
     }
     RegInfo.noteNewVirtualRegister(Info.VReg);


### PR DESCRIPTION
A fix-it patch for bec839d8eed9dd13fa7eaffd50b28f8f913de2e2 #110229.

~`SmallVector` will inline 40 values (here) statically on the stack. Although once that is exhausted it'll heap allocate and won't be deallocated.~
No need for a container. This allows 8 flags for a register.

The virtual register flags vector had a memory leak because the vector's memory is not freed.
The `BumpPtrAllocator` handles the deallocation and misses calling the `std::vector<uint8_t> Flags` destructor.
