### PR TITLE
[Sema] Fix warning in SemaOpenACC.cpp

### DIFF
--- a/clang/lib/Sema/SemaOpenACC.cpp
+++ b/clang/lib/Sema/SemaOpenACC.cpp
@@ -2216,7 +2216,7 @@ ExprResult SemaOpenACC::CheckGangExpr(OpenACCGangKind GK, Expr *E) {
     case OpenACCGangKind::Static:
       return CheckGangStaticExpr(*this, E);
     }
-  }
+  } break;
   default:
     llvm_unreachable("Non compute construct in active compute construct?");
   }


### PR DESCRIPTION
Fix gcc warning:

clang/lib/Sema/SemaOpenACC.cpp:2208:5: warning: this statement may fall through [-Wimplicit-fallthrough=]