### PR TITLE
[clang] Support `#pragma clang loop pipeline(enable)`

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4190,7 +4190,7 @@ def LoopHint : Attr {
   /// unroll_and_jam: attempt to unroll and jam loop if State == Enable.
   /// unroll_and_jam_count: unroll and jams loop 'Value' times.
   /// distribute: attempt to distribute loop if State == Enable.
-  /// pipeline: disable pipelining loop if State == Disable.
+  /// pipeline: enable pipelining loop if State == Enable.
   /// pipeline_initiation_interval: create loop schedule with initiation interval equal to 'Value'.
 
   /// #pragma unroll <argument> directive
@@ -4210,7 +4210,7 @@ def LoopHint : Attr {
                            "vectorize_predicate"],
                           ["Vectorize", "VectorizeWidth", "Interleave", "InterleaveCount",
                            "Unroll", "UnrollCount", "UnrollAndJam", "UnrollAndJamCount",
-                           "PipelineDisabled", "PipelineInitiationInterval", "Distribute",
+                           "Pipeline", "PipelineInitiationInterval", "Distribute",
                            "VectorizePredicate"]>,
               EnumArgument<"State", "LoopHintState", /*is_string=*/false,
                            ["enable", "disable", "numeric", "fixed_width",
@@ -4230,7 +4230,7 @@ def LoopHint : Attr {
     case UnrollCount: return "unroll_count";
     case UnrollAndJam: return "unroll_and_jam";
     case UnrollAndJamCount: return "unroll_and_jam_count";
-    case PipelineDisabled: return "pipeline";
+    case Pipeline: return "pipeline";
     case PipelineInitiationInterval: return "pipeline_initiation_interval";
     case Distribute: return "distribute";
     case VectorizePredicate: return "vectorize_predicate";

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3968,8 +3968,18 @@ def PipelineHintDocs : Documentation {
   placed immediately before a for, while, do-while, or a C++11 range-based for
   loop.
 
+  Using ``#pragma clang loop pipeline(enable)`` applies the software pipelining
+  optimization if possible:
+
+  .. code-block:: c++
+
+  #pragma clang loop pipeline(enable)
+  for (...) {
+    ...
+  }
+
   Using ``#pragma clang loop pipeline(disable)`` avoids the software pipelining
-  optimization. The disable state can only be specified:
+  optimization:
 
   .. code-block:: c++
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1676,8 +1676,6 @@ def err_pragma_fp_invalid_argument : Error<
 
 def err_pragma_invalid_keyword : Error<
   "invalid argument; expected 'enable'%select{|, 'full'}0%select{|, 'assume_safety'}1 or 'disable'">;
-def err_pragma_pipeline_invalid_keyword : Error<
-    "invalid argument; expected 'disable'">;
 
 // API notes.
 def err_type_unparsed : Error<"unparsed tokens following type">;

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -73,8 +73,8 @@ struct LoopAttributes {
   /// Value for llvm.loop.distribute.enable metadata.
   LVEnableState DistributeEnable;
 
-  /// Value for llvm.loop.pipeline.disable metadata.
-  bool PipelineDisabled;
+  /// Value for llvm.loop.pipeline metadata.
+  LVEnableState Pipeline;
 
   /// Value for llvm.loop.pipeline.iicount metadata.
   unsigned PipelineInitiationInterval;
@@ -281,8 +281,11 @@ public:
   /// \brief Set the unroll count for the next loop pushed.
   void setUnrollAndJamCount(unsigned C) { StagedAttrs.UnrollAndJamCount = C; }
 
-  /// Set the pipeline disabled state.
-  void setPipelineDisabled(bool S) { StagedAttrs.PipelineDisabled = S; }
+  /// Set the next pushed loop as a pipeline candidate.
+  void setPipelineEnable(bool Enable = true) {
+    StagedAttrs.Pipeline =
+        Enable ? LoopAttributes::Enable : LoopAttributes::Disable;
+  }
 
   /// Set the pipeline initiation interval.
   void setPipelineInitiationInterval(unsigned C) {

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -1454,24 +1454,24 @@ bool Parser::HandlePragmaLoopHint(LoopHint &Hint) {
   bool OptionUnroll = false;
   bool OptionUnrollAndJam = false;
   bool OptionDistribute = false;
-  bool OptionPipelineDisabled = false;
+  bool OptionPipeline = false;
   bool StateOption = false;
   if (OptionInfo) { // Pragma Unroll does not specify an option.
     OptionUnroll = OptionInfo->isStr("unroll");
     OptionUnrollAndJam = OptionInfo->isStr("unroll_and_jam");
     OptionDistribute = OptionInfo->isStr("distribute");
-    OptionPipelineDisabled = OptionInfo->isStr("pipeline");
+    OptionPipeline = OptionInfo->isStr("pipeline");
     StateOption = llvm::StringSwitch<bool>(OptionInfo->getName())
                       .Case("vectorize", true)
                       .Case("interleave", true)
                       .Case("vectorize_predicate", true)
                       .Default(false) ||
                   OptionUnroll || OptionUnrollAndJam || OptionDistribute ||
-                  OptionPipelineDisabled;
+                  OptionPipeline;
   }
 
   bool AssumeSafetyArg = !OptionUnroll && !OptionUnrollAndJam &&
-                         !OptionDistribute && !OptionPipelineDisabled;
+                         !OptionDistribute && !OptionPipeline;
   // Verify loop hint has an argument.
   if (Toks[0].is(tok::eof)) {
     ConsumeAnnotationToken();
@@ -1488,21 +1488,17 @@ bool Parser::HandlePragmaLoopHint(LoopHint &Hint) {
     SourceLocation StateLoc = Toks[0].getLocation();
     IdentifierInfo *StateInfo = Toks[0].getIdentifierInfo();
 
-    bool Valid = StateInfo &&
-                 llvm::StringSwitch<bool>(StateInfo->getName())
-                     .Case("disable", true)
-                     .Case("enable", !OptionPipelineDisabled)
-                     .Case("full", OptionUnroll || OptionUnrollAndJam)
-                     .Case("assume_safety", AssumeSafetyArg)
-                     .Default(false);
+    bool Valid =
+        StateInfo && llvm::StringSwitch<bool>(StateInfo->getName())
+                         .Case("disable", true)
+                         .Case("enable", true)
+                         .Case("full", OptionUnroll || OptionUnrollAndJam)
+                         .Case("assume_safety", AssumeSafetyArg)
+                         .Default(false);
     if (!Valid) {
-      if (OptionPipelineDisabled) {
-        Diag(Toks[0].getLocation(), diag::err_pragma_pipeline_invalid_keyword);
-      } else {
-        Diag(Toks[0].getLocation(), diag::err_pragma_invalid_keyword)
-            << /*FullKeyword=*/(OptionUnroll || OptionUnrollAndJam)
-            << /*AssumeSafetyKeyword=*/AssumeSafetyArg;
-      }
+      Diag(Toks[0].getLocation(), diag::err_pragma_invalid_keyword)
+          << /*FullKeyword=*/(OptionUnroll || OptionUnrollAndJam)
+          << /*AssumeSafetyKeyword=*/AssumeSafetyArg;
       return false;
     }
     if (Toks.size() > 2)
@@ -3591,7 +3587,7 @@ static bool ParseLoopHintValue(Preprocessor &PP, Token &Tok, Token PragmaName,
 ///    'vectorize_width' '(' loop-hint-value ')'
 ///    'interleave_count' '(' loop-hint-value ')'
 ///    'unroll_count' '(' loop-hint-value ')'
-///    'pipeline' '(' disable ')'
+///    'pipeline' '(' loop-hint-keyword ')'
 ///    'pipeline_initiation_interval' '(' loop-hint-value ')'
 ///
 ///  loop-hint-keyword:

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -142,7 +142,7 @@ static Attr *handleLoopHintAttr(Sema &S, Stmt *St, const ParsedAttr &A,
                  .Case("interleave_count", LoopHintAttr::InterleaveCount)
                  .Case("unroll", LoopHintAttr::Unroll)
                  .Case("unroll_count", LoopHintAttr::UnrollCount)
-                 .Case("pipeline", LoopHintAttr::PipelineDisabled)
+                 .Case("pipeline", LoopHintAttr::Pipeline)
                  .Case("pipeline_initiation_interval",
                        LoopHintAttr::PipelineInitiationInterval)
                  .Case("distribute", LoopHintAttr::Distribute)
@@ -170,7 +170,7 @@ static Attr *handleLoopHintAttr(Sema &S, Stmt *St, const ParsedAttr &A,
                Option == LoopHintAttr::VectorizePredicate ||
                Option == LoopHintAttr::Unroll ||
                Option == LoopHintAttr::Distribute ||
-               Option == LoopHintAttr::PipelineDisabled) {
+               Option == LoopHintAttr::Pipeline) {
       assert(StateLoc && StateLoc->Ident && "Loop hint must have an argument");
       if (StateLoc->Ident->isStr("disable"))
         State = LoopHintAttr::Disable;
@@ -516,7 +516,7 @@ CheckForIncompatibleAttributes(Sema &S,
       // Perform the check for duplicated 'distribute' hints.
       Category = Distribute;
       break;
-    case LoopHintAttr::PipelineDisabled:
+    case LoopHintAttr::Pipeline:
     case LoopHintAttr::PipelineInitiationInterval:
       Category = Pipeline;
       break;
@@ -532,7 +532,7 @@ CheckForIncompatibleAttributes(Sema &S,
         Option == LoopHintAttr::Interleave || Option == LoopHintAttr::Unroll ||
         Option == LoopHintAttr::UnrollAndJam ||
         Option == LoopHintAttr::VectorizePredicate ||
-        Option == LoopHintAttr::PipelineDisabled ||
+        Option == LoopHintAttr::Pipeline ||
         Option == LoopHintAttr::Distribute) {
       // Enable|Disable|AssumeSafety hint.  For example, vectorize(enable).
       PrevAttr = CategoryState.StateAttr;

--- a/clang/test/CodeGenCXX/pragma-pipeline.cpp
+++ b/clang/test/CodeGenCXX/pragma-pipeline.cpp
@@ -36,6 +36,15 @@ void pipeline_disabled_on_nested_loop(int *List, int Length, int Value) {
   }
 }
 
+void pipeline_enabled(int *List, int Length, int Value) {
+// CHECK-LABEL: define {{.*}} @_Z16pipeline_enabled
+#pragma clang loop pipeline(enable)
+  for (int i = 0; i < Length; i++) {
+    // CHECK: br label {{.*}}, !llvm.loop ![[LOOP_5:.*]]
+    List[i] = Value;
+  }
+}
+
 // CHECK: ![[LOOP_1]] = distinct !{![[LOOP_1]], [[MP:![0-9]+]], ![[PIPELINE_DISABLE:.*]]}
 // CHECK: ![[PIPELINE_DISABLE]] = !{!"llvm.loop.pipeline.disable", i1 true}
 
@@ -45,3 +54,6 @@ void pipeline_disabled_on_nested_loop(int *List, int Length, int Value) {
 // CHECK: ![[PIPELINE_II_10]] = !{!"llvm.loop.pipeline.initiationinterval", i32 10}
 
 // CHECK: ![[LOOP_4]] = distinct !{![[LOOP_4]], [[MP]], ![[PIPELINE_DISABLE]]}
+
+// CHECK: ![[LOOP_5]] = distinct !{![[LOOP_5]], [[MP]], ![[PIPELINE_ENABLE:.*]]}
+// CHECK: ![[PIPELINE_ENABLE]] = !{!"llvm.loop.pipeline.enable"}

--- a/clang/test/Parser/pragma-loop.cpp
+++ b/clang/test/Parser/pragma-loop.cpp
@@ -325,7 +325,7 @@ void foo(int *List, int Length) {
     List[i] = i;
   }
 
-#pragma clang loop pipeline(disable, extra)
+#pragma clang loop pipeline(enable, extra)
 /* expected-warning {{extra tokens at end of '#pragma clang loop pipeline' - ignored}}*/ while (i-6 < Length) {
     List[i] = i;
   }

--- a/clang/test/Parser/pragma-pipeline.cpp
+++ b/clang/test/Parser/pragma-pipeline.cpp
@@ -6,6 +6,11 @@
 void test(int *List, int Length, int Value) {
   int i = 0;
 
+#pragma clang loop pipeline(enable)
+  for (int i = 0; i < Length; i++) {
+    List[i] = Value;
+  }
+
 #pragma clang loop pipeline(disable)
   for (int i = 0; i < Length; i++) {
     List[i] = Value;
@@ -17,8 +22,7 @@ void test(int *List, int Length, int Value) {
   }
 
 /* expected-error {{expected ')'}} */ #pragma clang loop pipeline(disable
-/* expected-error {{invalid argument; expected 'disable'}} */ #pragma clang loop pipeline(enable)
-/* expected-error {{invalid argument; expected 'disable'}} */ #pragma clang loop pipeline(error)
+/* expected-error {{invalid argument; expected 'enable' or 'disable'}} */ #pragma clang loop pipeline(error)
 /* expected-error {{expected '('}} */ #pragma clang loop pipeline disable
 /* expected-error {{missing argument; expected an integer value}} */ #pragma clang loop pipeline_initiation_interval()
 /* expected-error {{use of undeclared identifier 'error'}} */ #pragma clang loop pipeline_initiation_interval(error)


### PR DESCRIPTION
Previously `#pragma clang loop pipeline` only accepted `disable`. This patch adds `enable` as a valid argument for this pragma. This allows Software Pipelining optimization to be applied to some loops instead of all loops.

This is clang part of the fix.

llvm part: https://github.com/llvm/llvm-project/pull/112502