### PR TITLE
[libc++] Add macros for try/catch and rethrow

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -60,6 +60,10 @@ IndentWrappedFunctionNames: false
 IndentRequires: true
 InsertTrailingCommas: Wrapped
 KeepEmptyLinesAtTheStartOfBlocks: false
+Macros:
+- _LIBCPP_TRY=if (true)
+- _LIBCPP_CATCH(a)=else if (false)
+
 MaxEmptyLinesToKeep: 1
 PackConstructorInitializers: NextLine
 

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1231,6 +1231,16 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_HAS_EXPLICIT_THIS_PARAMETER 0
 #  endif
 
+#  if _LIBCPP_HAS_EXCEPTIONS
+#    define _LIBCPP_TRY try
+#    define _LIBCPP_CATCH(...) catch(__VA_ARGS__)
+#    define _LIBCPP_RETHROW throw
+#  else
+#    define _LIBCPP_TRY if (true)
+#    define _LIBCPP_CATCH(...) if (false)
+#    define _LIBCPP_RETHROW ((void)0)
+#  endif
+
 #endif // __cplusplus
 
 #endif // _LIBCPP___CONFIG

--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -1144,12 +1144,9 @@ private:
       } else {
         // In this case, we know the values are just like before we attempted emplacement,
         // and we also know that the keys have been emplaced successfully. Just roll back the keys.
-#  if _LIBCPP_HAS_EXCEPTIONS
-        try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+        _LIBCPP_TRY {
           __containers_.keys.erase(__key_it);
-#  if _LIBCPP_HAS_EXCEPTIONS
-        } catch (...) {
+        } _LIBCPP_CATCH(...) {
           // Now things are funky for real. We're failing to rollback the keys.
           // Just give up and clear the whole thing.
           //
@@ -1157,7 +1154,6 @@ private:
           // original value-emplacement exception propagate normally.
           clear() /* noexcept */;
         }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
       }
     });
     auto __mapped_it = __containers_.values.emplace(__it_mapped, std::forward<_MArgs>(__mapped_args)...);

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -1212,9 +1212,7 @@ void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__move_assign(__hash_table& __u, 
     max_load_factor() = __u.max_load_factor();
     if (bucket_count() != 0) {
       __next_pointer __cache = __detach();
-#if _LIBCPP_HAS_EXCEPTIONS
-      try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+      _LIBCPP_TRY {
         const_iterator __i = __u.begin();
         while (__cache != nullptr && __u.size() != 0) {
           __cache->__upcast()->__get_value() = std::move(__u.remove(__i++)->__get_value());
@@ -1222,12 +1220,10 @@ void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__move_assign(__hash_table& __u, 
           __node_insert_multi(__cache->__upcast());
           __cache = __next;
         }
-#if _LIBCPP_HAS_EXCEPTIONS
-      } catch (...) {
+      } _LIBCPP_CATCH(...) {
         __deallocate_node(__cache);
-        throw;
+        _LIBCPP_RETHROW;
       }
-#endif // _LIBCPP_HAS_EXCEPTIONS
       __deallocate_node(__cache);
     }
     const_iterator __i = __u.begin();
@@ -1258,21 +1254,17 @@ void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__assign_unique(_InputIterator __
 
   if (bucket_count() != 0) {
     __next_pointer __cache = __detach();
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (; __cache != nullptr && __first != __last; ++__first) {
         __cache->__upcast()->__get_value() = *__first;
         __next_pointer __next              = __cache->__next_;
         __node_insert_unique(__cache->__upcast());
         __cache = __next;
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __deallocate_node(__cache);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     __deallocate_node(__cache);
   }
   for (; __first != __last; ++__first)
@@ -1290,21 +1282,17 @@ void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__assign_multi(_InputIterator __f
       " or the nodes value type");
   if (bucket_count() != 0) {
     __next_pointer __cache = __detach();
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (; __cache != nullptr && __first != __last; ++__first) {
         __cache->__upcast()->__get_value() = *__first;
         __next_pointer __next              = __cache->__next_;
         __node_insert_multi(__cache->__upcast());
         __cache = __next;
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __deallocate_node(__cache);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     __deallocate_node(__cache);
   }
   for (; __first != __last; ++__first)

--- a/libcxx/include/__iterator/counted_iterator.h
+++ b/libcxx/include/__iterator/counted_iterator.h
@@ -132,16 +132,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator++(int) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__count_ > 0, "Iterator already at or past end.");
     --__count_;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
+    _LIBCPP_TRY {
       return __current_++;
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       ++__count_;
-      throw;
+      _LIBCPP_RETHROW;
     }
-#  else
-    return __current_++;
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 
   _LIBCPP_HIDE_FROM_ABI constexpr counted_iterator operator++(int)

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -460,9 +460,7 @@ public:
 
   template <class _Yp, class _Dp, __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(_Yp* __p, _Dp __d) : __ptr_(__p) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef typename __shared_ptr_default_allocator<_Yp>::type _AllocT;
       typedef __shared_ptr_pointer<_Yp*, _Dp, _AllocT> _CntrlBlk;
 #ifndef _LIBCPP_CXX03_LANG
@@ -471,12 +469,10 @@ public:
     __cntrl_ = new _CntrlBlk(__p, __d, _AllocT());
 #endif // not _LIBCPP_CXX03_LANG
       __enable_weak_this(__p, __p);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __d(__p);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 
   template <class _Yp,
@@ -484,9 +480,7 @@ public:
             class _Alloc,
             __enable_if_t<__shared_ptr_deleter_ctor_reqs<_Dp, _Yp, _Tp>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI shared_ptr(_Yp* __p, _Dp __d, _Alloc __a) : __ptr_(__p) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef __shared_ptr_pointer<_Yp*, _Dp, _Alloc> _CntrlBlk;
       typedef typename __allocator_traits_rebind<_Alloc, _CntrlBlk>::type _A2;
       typedef __allocator_destructor<_A2> _D2;
@@ -500,12 +494,10 @@ public:
 #endif // not _LIBCPP_CXX03_LANG
       __cntrl_ = std::addressof(*__hold2.release());
       __enable_weak_this(__p, __p);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __d(__p);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 
   template <class _Dp>
@@ -514,9 +506,7 @@ public:
       _Dp __d,
       __enable_if_t<__shared_ptr_nullptr_deleter_ctor_reqs<_Dp>::value, __nullptr_sfinae_tag> = __nullptr_sfinae_tag())
       : __ptr_(nullptr) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef typename __shared_ptr_default_allocator<_Tp>::type _AllocT;
       typedef __shared_ptr_pointer<nullptr_t, _Dp, _AllocT> _CntrlBlk;
 #ifndef _LIBCPP_CXX03_LANG
@@ -524,12 +514,10 @@ public:
 #else
     __cntrl_ = new _CntrlBlk(__p, __d, _AllocT());
 #endif // not _LIBCPP_CXX03_LANG
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __d(__p);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 
   template <class _Dp, class _Alloc>
@@ -539,9 +527,7 @@ public:
       _Alloc __a,
       __enable_if_t<__shared_ptr_nullptr_deleter_ctor_reqs<_Dp>::value, __nullptr_sfinae_tag> = __nullptr_sfinae_tag())
       : __ptr_(nullptr) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef __shared_ptr_pointer<nullptr_t, _Dp, _Alloc> _CntrlBlk;
       typedef typename __allocator_traits_rebind<_Alloc, _CntrlBlk>::type _A2;
       typedef __allocator_destructor<_A2> _D2;
@@ -554,12 +540,10 @@ public:
         _CntrlBlk(__p, __d, __a);
 #endif // not _LIBCPP_CXX03_LANG
       __cntrl_ = std::addressof(*__hold2.release());
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __d(__p);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 
   template <class _Yp>

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -60,17 +60,13 @@ template <class _ValueType, class _InputIterator, class _Sentinel1, class _Forwa
 inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitialized_copy(
     _InputIterator __ifirst, _Sentinel1 __ilast, _ForwardIterator __ofirst, _EndPredicate __stop_copying) {
   _ForwardIterator __idx = __ofirst;
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif
+  _LIBCPP_TRY {
     for (; __ifirst != __ilast && !__stop_copying(__idx); ++__ifirst, (void)++__idx)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(*__ifirst);
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__ofirst, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif
 
   return pair<_InputIterator, _ForwardIterator>(std::move(__ifirst), std::move(__idx));
 }
@@ -90,17 +86,13 @@ template <class _ValueType, class _InputIterator, class _Size, class _ForwardIte
 inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator>
 __uninitialized_copy_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofirst, _EndPredicate __stop_copying) {
   _ForwardIterator __idx = __ofirst;
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif
+  _LIBCPP_TRY {
     for (; __n > 0 && !__stop_copying(__idx); ++__ifirst, (void)++__idx, (void)--__n)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(*__ifirst);
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__ofirst, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif
 
   return pair<_InputIterator, _ForwardIterator>(std::move(__ifirst), std::move(__idx));
 }
@@ -120,17 +112,13 @@ template <class _ValueType, class _ForwardIterator, class _Sentinel, class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator
 __uninitialized_fill(_ForwardIterator __first, _Sentinel __last, const _Tp& __x) {
   _ForwardIterator __idx = __first;
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif
+  _LIBCPP_TRY {
     for (; __idx != __last; ++__idx)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__x);
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__first, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif
 
   return __idx;
 }
@@ -148,17 +136,13 @@ template <class _ValueType, class _ForwardIterator, class _Size, class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator
 __uninitialized_fill_n(_ForwardIterator __first, _Size __n, const _Tp& __x) {
   _ForwardIterator __idx = __first;
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif
+  _LIBCPP_TRY {
     for (; __n > 0; ++__idx, (void)--__n)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__x);
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__first, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif
 
   return __idx;
 }
@@ -178,17 +162,13 @@ template <class _ValueType, class _ForwardIterator, class _Sentinel>
 inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator
 __uninitialized_default_construct(_ForwardIterator __first, _Sentinel __last) {
   auto __idx = __first;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif
+  _LIBCPP_TRY {
     for (; __idx != __last; ++__idx)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__first, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#  endif
 
   return __idx;
 }
@@ -204,17 +184,13 @@ inline _LIBCPP_HIDE_FROM_ABI void uninitialized_default_construct(_ForwardIterat
 template <class _ValueType, class _ForwardIterator, class _Size>
 inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator __uninitialized_default_construct_n(_ForwardIterator __first, _Size __n) {
   auto __idx = __first;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif
+  _LIBCPP_TRY {
     for (; __n > 0; ++__idx, (void)--__n)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__first, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#  endif
 
   return __idx;
 }
@@ -231,17 +207,13 @@ template <class _ValueType, class _ForwardIterator, class _Sentinel>
 inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator
 __uninitialized_value_construct(_ForwardIterator __first, _Sentinel __last) {
   auto __idx = __first;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif
+  _LIBCPP_TRY {
     for (; __idx != __last; ++__idx)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType();
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__first, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#  endif
 
   return __idx;
 }
@@ -257,17 +229,13 @@ inline _LIBCPP_HIDE_FROM_ABI void uninitialized_value_construct(_ForwardIterator
 template <class _ValueType, class _ForwardIterator, class _Size>
 inline _LIBCPP_HIDE_FROM_ABI _ForwardIterator __uninitialized_value_construct_n(_ForwardIterator __first, _Size __n) {
   auto __idx = __first;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif
+  _LIBCPP_TRY {
     for (; __n > 0; ++__idx, (void)--__n)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType();
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__first, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#  endif
 
   return __idx;
 }
@@ -293,18 +261,14 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
     _EndPredicate __stop_moving,
     _IterMove __iter_move) {
   auto __idx = __ofirst;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif
+  _LIBCPP_TRY {
     for (; __ifirst != __ilast && !__stop_moving(__idx); ++__idx, (void)++__ifirst) {
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__iter_move(__ifirst));
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__ofirst, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#  endif
 
   return {std::move(__ifirst), std::move(__idx)};
 }
@@ -331,17 +295,13 @@ template <class _ValueType,
 inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitialized_move_n(
     _InputIterator __ifirst, _Size __n, _ForwardIterator __ofirst, _EndPredicate __stop_moving, _IterMove __iter_move) {
   auto __idx = __ofirst;
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif
+  _LIBCPP_TRY {
     for (; __n > 0 && !__stop_moving(__idx); ++__idx, (void)++__ifirst, --__n)
       ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(__iter_move(__ifirst));
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     std::__destroy(__ofirst, __idx);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#  endif
 
   return {std::move(__ifirst), std::move(__idx)};
 }

--- a/libcxx/include/__ostream/basic_ostream.h
+++ b/libcxx/include/__ostream/basic_ostream.h
@@ -155,15 +155,11 @@ basic_ostream<_CharT, _Traits>::sentry::sentry(basic_ostream<_CharT, _Traits>& _
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>::sentry::~sentry() {
   if (__os_.rdbuf() && __os_.good() && (__os_.flags() & ios_base::unitbuf) && uncaught_exceptions() == 0) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       if (__os_.rdbuf()->pubsync() == -1)
         __os_.setstate(ios_base::badbit);
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -184,15 +180,11 @@ basic_ostream<_CharT, _Traits>::~basic_ostream() {}
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>&
 basic_ostream<_CharT, _Traits>::operator<<(basic_streambuf<char_type, traits_type>* __sb) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       if (__sb) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-        try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+        _LIBCPP_TRY {
           typedef istreambuf_iterator<_CharT, _Traits> _Ip;
           typedef ostreambuf_iterator<_CharT, _Traits> _Op;
           _Ip __i(__sb);
@@ -206,27 +198,21 @@ basic_ostream<_CharT, _Traits>::operator<<(basic_streambuf<char_type, traits_typ
           }
           if (__c == 0)
             this->setstate(ios_base::failbit);
-#  if _LIBCPP_HAS_EXCEPTIONS
-        } catch (...) {
+        } _LIBCPP_CATCH(...) {
           this->__set_failbit_and_consider_rethrow();
         }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
       } else
         this->setstate(ios_base::badbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(bool __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -234,19 +220,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(bool 
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(short __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       ios_base::fmtflags __flags = ios_base::flags() & ios_base::basefield;
@@ -261,19 +243,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(short
               .failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsigned short __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -281,19 +259,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsig
       if (__f.put(*this, *this, this->fill(), static_cast<unsigned long>(__n)).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(int __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       ios_base::fmtflags __flags = ios_base::flags() & ios_base::basefield;
@@ -308,19 +282,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(int _
               .failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsigned int __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -328,19 +298,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsig
       if (__f.put(*this, *this, this->fill(), static_cast<unsigned long>(__n)).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(long __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -348,19 +314,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(long 
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsigned long __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -368,19 +330,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsig
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(long long __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -388,19 +346,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(long 
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsigned long long __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -408,19 +362,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(unsig
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(float __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -428,19 +378,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(float
       if (__f.put(*this, *this, this->fill(), static_cast<double>(__n)).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(double __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -448,19 +394,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(doubl
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(long double __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -468,19 +410,15 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(long 
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(const void* __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef num_put<char_type, ostreambuf_iterator<char_type, traits_type> > _Fp;
@@ -488,20 +426,16 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(const
       if (__f.put(*this, *this, this->fill(), __n).failed())
         this->setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 __put_character_sequence(basic_ostream<_CharT, _Traits>& __os, const _CharT* __str, size_t __len) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
@@ -515,11 +449,9 @@ __put_character_sequence(basic_ostream<_CharT, _Traits>& __os, const _CharT* __s
               .failed())
         __os.setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return __os;
 }
 
@@ -530,9 +462,7 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_
 
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, char __cn) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       _CharT __c = __os.widen(__cn);
@@ -547,11 +477,9 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_
               .failed())
         __os.setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return __os;
 }
 
@@ -579,9 +507,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const _CharT* __str) {
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const char* __strn) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
@@ -608,11 +534,9 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const char* __strn) {
               .failed())
         __os.setstate(ios_base::badbit | ios_base::failbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return __os;
 }
 
@@ -637,9 +561,7 @@ operator<<(basic_ostream<char, _Traits>& __os, const unsigned char* __str) {
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::put(char_type __c) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     sentry __s(*this);
     if (__s) {
       typedef ostreambuf_iterator<_CharT, _Traits> _Op;
@@ -648,37 +570,29 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::put(char_type __
       if (__o.failed())
         this->setstate(ios_base::badbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::write(const char_type* __s, streamsize __n) {
-#  if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     sentry __sen(*this);
     if (__sen && __n) {
       if (this->rdbuf()->sputn(__s, __n) != __n)
         this->setstate(ios_base::badbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 
 template <class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::flush() {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     if (this->rdbuf()) {
       sentry __s(*this);
       if (__s) {
@@ -686,11 +600,9 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::flush() {
           this->setstate(ios_base::badbit);
       }
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
 }
 

--- a/libcxx/include/__ostream/print.h
+++ b/libcxx/include/__ostream/print.h
@@ -52,9 +52,7 @@ __vprint_nonunicode(ostream& __os, string_view __fmt, format_args __args, bool _
     const char* __str = __o.data();
     size_t __len      = __o.size();
 
-#    if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#    endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef ostreambuf_iterator<char> _Ip;
       if (std::__pad_and_output(
               _Ip(__os),
@@ -66,11 +64,9 @@ __vprint_nonunicode(ostream& __os, string_view __fmt, format_args __args, bool _
               .failed())
         __os.setstate(ios_base::badbit | ios_base::failbit);
 
-#    if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __os.__set_badbit_and_consider_rethrow();
     }
-#    endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -115,9 +111,7 @@ _LIBCPP_HIDE_FROM_ABI void __vprint_unicode(ostream& __os, string_view __fmt, fo
   // This is the path for the native API, start with flushing.
   __os.flush();
 
-#        if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#        endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     ostream::sentry __s(__os);
     if (__s) {
 #        ifndef _LIBCPP_WIN32API
@@ -129,11 +123,9 @@ _LIBCPP_HIDE_FROM_ABI void __vprint_unicode(ostream& __os, string_view __fmt, fo
 #        endif
     }
 
-#        if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#        endif // _LIBCPP_HAS_EXCEPTIONS
 #      endif   // _LIBCPP_AVAILABILITY_HAS_PRINT
 }
 

--- a/libcxx/include/__pstl/backends/libdispatch.h
+++ b/libcxx/include/__pstl/backends/libdispatch.h
@@ -142,15 +142,11 @@ struct __cpu_traits<__libdispatch_backend_tag> {
 
     unique_ptr<__merge_range_t[], decltype(__destroy)> __ranges(
         [&]() -> __merge_range_t* {
-#  if _LIBCPP_HAS_EXCEPTIONS
-          try {
-#  endif
+          _LIBCPP_TRY {
             return std::allocator<__merge_range_t>().allocate(__n_ranges);
-#  if _LIBCPP_HAS_EXCEPTIONS
-          } catch (const std::bad_alloc&) {
+          } _LIBCPP_CATCH(const std::bad_alloc&) {
             return nullptr;
           }
-#  endif
         }(),
         __destroy);
 

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -406,9 +406,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::swap(__split
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::shrink_to_fit() _NOEXCEPT {
   if (capacity() > size()) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       __split_buffer<value_type, __alloc_rr&> __t(size(), 0, __alloc_);
       __t.__construct_at_end(move_iterator<pointer>(__begin_), move_iterator<pointer>(__end_));
       __t.__end_ = __t.__begin_ + (__end_ - __begin_);
@@ -416,10 +414,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::shrink_to_fi
       std::swap(__begin_, __t.__begin_);
       std::swap(__end_, __t.__end_);
       std::swap(__end_cap_, __t.__end_cap_);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1073,9 +1073,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::reserve(size_type __
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::shrink_to_fit() _NOEXCEPT {
   if (capacity() > size()) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       allocator_type& __a = this->__alloc();
       __split_buffer<value_type, allocator_type&> __v(size(), size(), __a);
       // The Standard mandates shrink_to_fit() does not increase the capacity.
@@ -1083,10 +1081,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::shrink_to_fit() _NOE
       // due to swapping the elements.
       if (__v.capacity() < capacity())
         __swap_out_circular_buffer(__v);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -1271,21 +1267,17 @@ vector<_Tp, _Allocator>::__insert_with_sentinel(const_iterator __position, _Inpu
   }
   __split_buffer<value_type, allocator_type&> __v(__a);
   if (__first != __last) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       __v.__construct_at_end_with_sentinel(std::move(__first), std::move(__last));
       difference_type __old_size = __old_last - this->__begin_;
       difference_type __old_p    = __p - this->__begin_;
       reserve(__recommend(size() + __v.size()));
       __p        = this->__begin_ + __old_p;
       __old_last = this->__begin_ + __old_size;
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH (...) {
       erase(__make_iter(__old_last), end());
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
   __p = std::rotate(__p, __old_last, this->__end_);
   insert(__make_iter(__p), std::make_move_iterator(__v.begin()), std::make_move_iterator(__v.end()));

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -398,18 +398,14 @@ private:
   template <class _InputIterator, class _Sentinel>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __init_with_sentinel(_InputIterator __first, _Sentinel __last) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (; __first != __last; ++__first)
         push_back(*__first);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       if (__begin_ != nullptr)
         __storage_traits::deallocate(__alloc(), __begin_, __cap());
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 
   template <class _Iterator, class _Sentinel>
@@ -856,14 +852,10 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::reserve(size_type _
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::shrink_to_fit() _NOEXCEPT {
   if (__external_cap_to_internal(size()) > __cap()) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       vector(*this, allocator_type(__alloc())).swap(*this);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -952,21 +944,17 @@ vector<bool, _Allocator>::__insert_with_sentinel(const_iterator __position, _Inp
   }
   vector __v(get_allocator());
   if (__first != __last) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       __v.__assign_with_sentinel(std::move(__first), std::move(__last));
       difference_type __old_size = static_cast<difference_type>(__old_end - begin());
       difference_type __old_p    = __p - begin();
       reserve(__recommend(size() + __v.size()));
       __p       = begin() + __old_p;
       __old_end = begin() + __old_size;
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       erase(__old_end, end());
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
   __p = std::rotate(__p, __old_end, end());
   insert(__p, __v.begin(), __v.end());

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -2125,22 +2125,18 @@ void deque<_Tp, _Allocator>::__add_front_capacity(size_type __n) {
     size_type __ds = (__nb + __back_capacity) * __block_size - __map_.empty();
     __split_buffer<pointer, __pointer_allocator&> __buf(
         std::max<size_type>(2 * __map_.capacity(), __nb + __map_.size()), 0, __map_.__alloc_);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (; __nb > 0; --__nb) {
         __buf.emplace_back(__alloc_traits::allocate(__a, __block_size));
         // ASan: this is empty container, we have to poison whole block
         __annotate_poison_block(std::__to_address(__buf.back()), std::__to_address(__buf.back() + __block_size));
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __annotate_delete();
       for (__map_pointer __i = __buf.begin(); __i != __buf.end(); ++__i)
         __alloc_traits::deallocate(__a, *__i, __block_size);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     for (; __back_capacity > 0; --__back_capacity) {
       __buf.emplace_back(__map_.back());
       __map_.pop_back();
@@ -2250,22 +2246,18 @@ void deque<_Tp, _Allocator>::__add_back_capacity(size_type __n) {
         std::max<size_type>(2 * __map_.capacity(), __nb + __map_.size()),
         __map_.size() - __front_capacity,
         __map_.__alloc_);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (; __nb > 0; --__nb) {
         __buf.emplace_back(__alloc_traits::allocate(__a, __block_size));
         // ASan: this is an empty container, we have to poison the whole block
         __annotate_poison_block(std::__to_address(__buf.back()), std::__to_address(__buf.back() + __block_size));
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __annotate_delete();
       for (__map_pointer __i = __buf.begin(); __i != __buf.end(); ++__i)
         __alloc_traits::deallocate(__a, *__i, __block_size);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     for (; __front_capacity > 0; --__front_capacity) {
       __buf.emplace_back(__map_.front());
       __map_.pop_front();

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -1128,22 +1128,18 @@ forward_list<_Tp, _Alloc>::insert_after(const_iterator __p, size_type __n, const
   if (__n > 0) {
     __node_pointer __first = this->__create_node(/* next = */ nullptr, __v);
     __node_pointer __last  = __first;
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (--__n; __n != 0; --__n, __last = __last->__next_) {
         __last->__next_ = this->__create_node(/* next = */ nullptr, __v);
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       while (__first != nullptr) {
         __node_pointer __next = __first->__next_;
         this->__delete_node(__first);
         __first = __next;
       }
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     __last->__next_ = __r->__next_;
     __r->__next_    = __first;
     __r             = static_cast<__begin_node_pointer>(__last);
@@ -1168,22 +1164,18 @@ forward_list<_Tp, _Alloc>::__insert_after_with_sentinel(const_iterator __p, _Inp
     __node_pointer __first = this->__create_node(/* next = */ nullptr, *__f);
     __node_pointer __last  = __first;
 
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (++__f; __f != __l; ++__f, ((void)(__last = __last->__next_))) {
         __last->__next_ = this->__create_node(/* next = */ nullptr, *__f);
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       while (__first != nullptr) {
         __node_pointer __next = __first->__next_;
         this->__delete_node(__first);
         __first = __next;
       }
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
 
     __last->__next_ = __r->__next_;
     __r->__next_    = __first;

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -487,14 +487,10 @@ inline basic_filebuf<_CharT, _Traits>& basic_filebuf<_CharT, _Traits>::operator=
 
 template <class _CharT, class _Traits>
 basic_filebuf<_CharT, _Traits>::~basic_filebuf() {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     close();
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   if (__owns_eb_)
     delete[] __extbuf_;
   if (__owns_ib_)

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -779,15 +779,11 @@ inline __deferred_assoc_state<_Rp, _Fp>::__deferred_assoc_state(_Fp&& __f) : __f
 
 template <class _Rp, class _Fp>
 void __deferred_assoc_state<_Rp, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     this->set_value(__func_());
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Fp>
@@ -809,16 +805,12 @@ inline __deferred_assoc_state<void, _Fp>::__deferred_assoc_state(_Fp&& __f) : __
 
 template <class _Fp>
 void __deferred_assoc_state<void, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     __func_();
     this->set_value();
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class _Fp>
@@ -840,15 +832,11 @@ inline __async_assoc_state<_Rp, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(s
 
 template <class _Rp, class _Fp>
 void __async_assoc_state<_Rp, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     this->set_value(__func_());
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class _Fp>
@@ -876,16 +864,12 @@ inline __async_assoc_state<void, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(
 
 template <class _Fp>
 void __async_assoc_state<void, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     __func_();
     this->set_value();
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH (...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Fp>
@@ -1656,15 +1640,11 @@ void packaged_task<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __args) {
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     __p_.set_value(__f_(std::forward<_ArgTypes>(__args)...));
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __p_.set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class... _ArgTypes>
@@ -1673,15 +1653,11 @@ void packaged_task<_Rp(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... __
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     __p_.set_value_at_thread_exit(__f_(std::forward<_ArgTypes>(__args)...));
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __p_.set_exception_at_thread_exit(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class... _ArgTypes>
@@ -1758,16 +1734,12 @@ void packaged_task<void(_ArgTypes...)>::operator()(_ArgTypes... __args) {
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     __f_(std::forward<_ArgTypes>(__args)...);
     __p_.set_value();
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH (...) {
     __p_.set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class... _ArgTypes>
@@ -1776,16 +1748,12 @@ void packaged_task<void(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... _
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     __f_(std::forward<_ArgTypes>(__args)...);
     __p_.set_value_at_thread_exit();
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __p_.set_exception_at_thread_exit(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class... _ArgTypes>
@@ -1857,18 +1825,14 @@ async(launch __policy, _Fp&& __f, _Args&&... __args) {
   typedef __async_func<__decay_t<_Fp>, __decay_t<_Args>...> _BF;
   typedef typename _BF::_Rp _Rp;
 
-#    if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#    endif
+  _LIBCPP_TRY {
     if (__does_policy_contain(__policy, launch::async))
       return std::__make_async_assoc_state<_Rp>(
           _BF(_LIBCPP_AUTO_CAST(std::forward<_Fp>(__f)), _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
-#    if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     if (__policy == launch::async)
-      throw;
+      _LIBCPP_RETHROW;
   }
-#    endif
 
   if (__does_policy_contain(__policy, launch::deferred))
     return std::__make_deferred_assoc_state<_Rp>(

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -237,9 +237,7 @@ public:
 template <class _CharT, class _Traits, class _MoneyT>
 _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t7<_MoneyT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     typename basic_istream<_CharT, _Traits>::sentry __s(__is);
     if (__s) {
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
@@ -249,11 +247,9 @@ operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t7<_MoneyT>& __x) {
       __mf.get(_Ip(__is), _Ip(), __x.__intl_, __is, __err, __x.__mon_);
       __is.setstate(__err);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __is.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return __is;
 }
 
@@ -286,9 +282,7 @@ public:
 template <class _CharT, class _Traits, class _MoneyT>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t8<_MoneyT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       typedef ostreambuf_iterator<_CharT, _Traits> _Op;
@@ -297,11 +291,9 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t8<_MoneyT>& __x) {
       if (__mf.put(_Op(__os), __x.__intl_, __os, __os.fill(), __x.__mon_).failed())
         __os.setstate(ios_base::badbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return __os;
 }
 
@@ -334,9 +326,7 @@ public:
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t9<_CharT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     typename basic_istream<_CharT, _Traits>::sentry __s(__is);
     if (__s) {
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
@@ -346,11 +336,9 @@ operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t9<_CharT>& __x) {
       __tf.get(_Ip(__is), _Ip(), __is, __err, __x.__tm_, __x.__fmt_, __x.__fmt_ + _Traits::length(__x.__fmt_));
       __is.setstate(__err);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __is.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return __is;
 }
 
@@ -383,9 +371,7 @@ public:
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t10<_CharT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       typedef ostreambuf_iterator<_CharT, _Traits> _Op;
@@ -395,11 +381,9 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t10<_CharT>& __x) {
               .failed())
         __os.setstate(ios_base::badbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   return __os;
 }
 

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -357,21 +357,17 @@ __input_arithmetic(basic_istream<_CharT, _Traits>& __is, _Tp& __n) {
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __s(__is);
   if (__s) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
       typedef num_get<_CharT, _Ip> _Fp;
       std::use_facet<_Fp>(__is.getloc()).get(_Ip(__is), _Ip(), __is, __state, __n);
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif
     __is.setstate(__state);
   }
   return __is;
@@ -438,9 +434,7 @@ __input_arithmetic_with_numeric_limits(basic_istream<_CharT, _Traits>& __is, _Tp
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __s(__is);
   if (__s) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
       typedef num_get<_CharT, _Ip> _Fp;
       long __temp;
@@ -454,15 +448,13 @@ __input_arithmetic_with_numeric_limits(basic_istream<_CharT, _Traits>& __is, _Tp
       } else {
         __n = static_cast<_Tp>(__temp);
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     __is.setstate(__state);
   }
   return __is;
@@ -484,9 +476,7 @@ __input_c_string(basic_istream<_CharT, _Traits>& __is, _CharT* __p, size_t __n) 
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif
+    _LIBCPP_TRY {
       _CharT* __s               = __p;
       const ctype<_CharT>& __ct = std::use_facet<ctype<_CharT> >(__is.getloc());
       while (__s != __p + (__n - 1)) {
@@ -505,15 +495,13 @@ __input_c_string(basic_istream<_CharT, _Traits>& __is, _CharT* __p, size_t __n) 
       __is.width(0);
       if (__s == __p)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif
     __is.setstate(__state);
   }
   return __is;
@@ -572,23 +560,19 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& operator>>(basic_istream<_
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif
+    _LIBCPP_TRY {
       typename _Traits::int_type __i = __is.rdbuf()->sbumpc();
       if (_Traits::eq_int_type(__i, _Traits::eof()))
         __state |= ios_base::eofbit | ios_base::failbit;
       else
         __c = _Traits::to_char_type(__i);
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif
     __is.setstate(__state);
   }
   return __is;
@@ -614,9 +598,7 @@ basic_istream<_CharT, _Traits>::operator>>(basic_streambuf<char_type, traits_typ
   sentry __s(*this, true);
   if (__s) {
     if (__sb) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-      try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+      _LIBCPP_TRY {
         while (true) {
           typename traits_type::int_type __i = this->rdbuf()->sgetc();
           if (traits_type::eq_int_type(__i, _Traits::eof())) {
@@ -630,18 +612,16 @@ basic_istream<_CharT, _Traits>::operator>>(basic_streambuf<char_type, traits_typ
         }
         if (__gc_ == 0)
           __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-      } catch (...) {
+      } _LIBCPP_CATCH(...) {
         __state |= ios_base::badbit;
         if (__gc_ == 0)
           __state |= ios_base::failbit;
 
         this->__setstate_nothrow(__state);
         if (this->exceptions() & ios_base::failbit || this->exceptions() & ios_base::badbit) {
-          throw;
+          _LIBCPP_RETHROW;
         }
       }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     } else {
       __state |= ios_base::failbit;
     }
@@ -657,22 +637,18 @@ typename basic_istream<_CharT, _Traits>::int_type basic_istream<_CharT, _Traits>
   int_type __r              = traits_type::eof();
   sentry __s(*this, true);
   if (__s) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif
+    _LIBCPP_TRY {
       __r = this->rdbuf()->sbumpc();
       if (traits_type::eq_int_type(__r, traits_type::eof()))
         __state |= ios_base::failbit | ios_base::eofbit;
       else
         __gc_ = 1;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       this->__setstate_nothrow(this->rdstate() | ios_base::badbit);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif
     this->setstate(__state);
   }
   return __r;
@@ -685,9 +661,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::get(char_type* _
   sentry __sen(*this, true);
   if (__sen) {
     if (__n > 0) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-      try {
-#  endif
+      _LIBCPP_TRY {
         while (__gc_ < __n - 1) {
           int_type __i = this->rdbuf()->sgetc();
           if (traits_type::eq_int_type(__i, traits_type::eof())) {
@@ -703,17 +677,15 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::get(char_type* _
         }
         if (__gc_ == 0)
           __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-      } catch (...) {
+      } _LIBCPP_CATCH(...) {
         __state |= ios_base::badbit;
         this->__setstate_nothrow(__state);
         if (this->exceptions() & ios_base::badbit) {
           if (__n > 0)
             *__s = char_type();
-          throw;
+          _LIBCPP_RETHROW;
         }
       }
-#  endif
     } else {
       __state |= ios_base::failbit;
     }
@@ -734,9 +706,7 @@ basic_istream<_CharT, _Traits>::get(basic_streambuf<char_type, traits_type>& __s
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       while (true) {
         typename traits_type::int_type __i = this->rdbuf()->sgetc();
         if (traits_type::eq_int_type(__i, traits_type::eof())) {
@@ -751,12 +721,10 @@ basic_istream<_CharT, _Traits>::get(basic_streambuf<char_type, traits_type>& __s
         __inc_gcount();
         this->rdbuf()->sbumpc();
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       // according to the spec, exceptions here are caught but not rethrown
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     if (__gc_ == 0)
       __state |= ios_base::failbit;
     this->setstate(__state);
@@ -771,9 +739,7 @@ basic_istream<_CharT, _Traits>::getline(char_type* __s, streamsize __n, char_typ
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       while (true) {
         typename traits_type::int_type __i = this->rdbuf()->sgetc();
         if (traits_type::eq_int_type(__i, traits_type::eof())) {
@@ -794,8 +760,7 @@ basic_istream<_CharT, _Traits>::getline(char_type* __s, streamsize __n, char_typ
         this->rdbuf()->sbumpc();
         __inc_gcount();
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
@@ -803,10 +768,9 @@ basic_istream<_CharT, _Traits>::getline(char_type* __s, streamsize __n, char_typ
           *__s = char_type();
         if (__gc_ == 0)
           __state |= ios_base::failbit;
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
   if (__n > 0)
     *__s = char_type();
@@ -822,9 +786,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::ignore(streamsiz
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       if (__n == numeric_limits<streamsize>::max()) {
         while (true) {
           typename traits_type::int_type __i = this->rdbuf()->sbumpc();
@@ -848,15 +810,13 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::ignore(streamsiz
             break;
         }
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return *this;
@@ -869,21 +829,17 @@ typename basic_istream<_CharT, _Traits>::int_type basic_istream<_CharT, _Traits>
   int_type __r              = traits_type::eof();
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       __r = this->rdbuf()->sgetc();
       if (traits_type::eq_int_type(__r, traits_type::eof()))
         __state |= ios_base::eofbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return __r;
@@ -895,21 +851,17 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::read(char_type* 
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       __gc_ = this->rdbuf()->sgetn(__s, __n);
       if (__gc_ != __n)
         __state |= ios_base::failbit | ios_base::eofbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -923,9 +875,7 @@ streamsize basic_istream<_CharT, _Traits>::readsome(char_type* __s, streamsize _
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       streamsize __c = this->rdbuf()->in_avail();
       switch (__c) {
       case -1:
@@ -940,15 +890,13 @@ streamsize basic_istream<_CharT, _Traits>::readsome(char_type* __s, streamsize _
           __state |= ios_base::failbit | ios_base::eofbit;
         break;
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -963,20 +911,16 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::putback(char_typ
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       if (this->rdbuf() == nullptr || this->rdbuf()->sputbackc(__c) == traits_type::eof())
         __state |= ios_base::badbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -991,20 +935,16 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::unget() {
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       if (this->rdbuf() == nullptr || this->rdbuf()->sungetc() == traits_type::eof())
         __state |= ios_base::badbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -1021,22 +961,18 @@ int basic_istream<_CharT, _Traits>::sync() {
 
   int __r = 0;
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       if (this->rdbuf()->pubsync() == -1) {
         __state |= ios_base::badbit;
         __r = -1;
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return __r;
@@ -1048,19 +984,15 @@ typename basic_istream<_CharT, _Traits>::pos_type basic_istream<_CharT, _Traits>
   pos_type __r(-1);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       __r = this->rdbuf()->pubseekoff(0, ios_base::cur, ios_base::in);
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return __r;
@@ -1072,20 +1004,16 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::seekg(pos_type _
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       if (this->rdbuf()->pubseekpos(__pos, ios_base::in) == pos_type(-1))
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return *this;
@@ -1097,20 +1025,16 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::seekg(off_type _
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       if (this->rdbuf()->pubseekoff(__off, __dir, ios_base::in) == pos_type(-1))
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
       if (this->exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return *this;
@@ -1121,9 +1045,7 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& ws(basic_istream<_CharT, _
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       const ctype<_CharT>& __ct = std::use_facet<ctype<_CharT> >(__is.getloc());
       while (true) {
         typename _Traits::int_type __i = __is.rdbuf()->sgetc();
@@ -1135,15 +1057,13 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& ws(basic_istream<_CharT, _
           break;
         __is.rdbuf()->sbumpc();
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     __is.setstate(__state);
   }
   return __is;
@@ -1211,9 +1131,7 @@ operator>>(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif
+    _LIBCPP_TRY {
       __str.clear();
       using _Size              = typename basic_string<_CharT, _Traits, _Allocator>::size_type;
       streamsize const __width = __is.width();
@@ -1243,15 +1161,13 @@ operator>>(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _
       __is.width(0);
       if (__c == 0)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif
     __is.setstate(__state);
   }
   return __is;
@@ -1263,9 +1179,7 @@ getline(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _All
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif
+    _LIBCPP_TRY {
       __str.clear();
       streamsize __extr = 0;
       while (true) {
@@ -1286,15 +1200,13 @@ getline(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _All
       }
       if (__extr == 0)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
         throw;
       }
     }
-#  endif
     __is.setstate(__state);
   }
   return __is;
@@ -1324,9 +1236,7 @@ operator>>(basic_istream<_CharT, _Traits>& __is, bitset<_Size>& __x) {
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif
+    _LIBCPP_TRY {
       basic_string<_CharT, _Traits> __str;
       const ctype<_CharT>& __ct = std::use_facet<ctype<_CharT> >(__is.getloc());
       size_t __c                = 0;
@@ -1348,15 +1258,13 @@ operator>>(basic_istream<_CharT, _Traits>& __is, bitset<_Size>& __x) {
       __x = bitset<_Size>(__str);
       if (_Size > 0 && __c == 0)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
       if (__is.exceptions() & ios_base::badbit) {
-        throw;
+        _LIBCPP_RETHROW;
       }
     }
-#  endif
     __is.setstate(__state);
   }
   return __is;

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -1159,14 +1159,11 @@ list<_Tp, _Alloc>::insert(const_iterator __p, size_type __n, const value_type& _
     ++__ds;
     __r          = iterator(__node->__as_link());
     iterator __e = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (--__n; __n != 0; --__n, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr, __x)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
         __node_pointer __current = __e.__ptr_->__as_node();
@@ -1175,9 +1172,8 @@ list<_Tp, _Alloc>::insert(const_iterator __p, size_type __n, const value_type& _
           break;
         __e = iterator(__prev);
       }
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__p.__ptr_, __r.__ptr_, __e.__ptr_);
     __base::__sz() += __ds;
   }
@@ -1201,14 +1197,11 @@ list<_Tp, _Alloc>::__insert_with_sentinel(const_iterator __p, _Iterator __f, _Se
     ++__ds;
     __r          = iterator(__node->__as_link());
     iterator __e = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (++__f; __f != __l; ++__f, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr, *__f)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
         __node_pointer __current = __e.__ptr_->__as_node();
@@ -1217,9 +1210,8 @@ list<_Tp, _Alloc>::__insert_with_sentinel(const_iterator __p, _Iterator __f, _Se
           break;
         __e = iterator(__prev);
       }
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__p.__ptr_, __r.__ptr_, __e.__ptr_);
     __base::__sz() += __ds;
   }
@@ -1372,14 +1364,11 @@ void list<_Tp, _Alloc>::resize(size_type __n) {
     ++__ds;
     iterator __r = iterator(__node->__as_link());
     iterator __e = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (--__n; __n != 0; --__n, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
         __node_pointer __current = __e.__ptr_->__as_node();
@@ -1388,9 +1377,8 @@ void list<_Tp, _Alloc>::resize(size_type __n) {
           break;
         __e = iterator(__prev);
       }
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes_at_back(__r.__ptr_, __e.__ptr_);
     __base::__sz() += __ds;
   }
@@ -1408,14 +1396,11 @@ void list<_Tp, _Alloc>::resize(size_type __n, const value_type& __x) {
     __base_pointer __nl = __node->__as_link();
     iterator __r        = iterator(__nl);
     iterator __e        = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (--__n; __n != 0; --__n, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr, __x)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
         __node_pointer __current = __e.__ptr_->__as_node();
@@ -1424,9 +1409,8 @@ void list<_Tp, _Alloc>::resize(size_type __n, const value_type& __x) {
           break;
         __e = iterator(__prev);
       }
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__base::__end_as_link(), __r.__ptr_, __e.__ptr_);
     __base::__sz() += __ds;
   }

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -786,9 +786,7 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::overflow(int_type __c) {
     if (this->pptr() == this->epptr()) {
       if (!(__mode_ & ios_base::out))
         return traits_type::eof();
-#  if _LIBCPP_HAS_EXCEPTIONS
-      try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+      _LIBCPP_TRY {
         ptrdiff_t __nout = this->pptr() - this->pbase();
         ptrdiff_t __hm   = __hm_ - this->pbase();
         __str_.push_back(char_type());
@@ -797,11 +795,9 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::overflow(int_type __c) {
         this->setp(__p, __p + __str_.size());
         this->__pbump(__nout);
         __hm_ = this->pbase() + __hm;
-#  if _LIBCPP_HAS_EXCEPTIONS
-      } catch (...) {
+      } _LIBCPP_CATCH(...) {
         return traits_type::eof();
       }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
     }
     __hm_ = std::max(this->pptr() + 1, __hm_);
     if (__mode_ & ios_base::in) {

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -2440,19 +2440,15 @@ basic_string<_CharT, _Traits, _Allocator>::__init_with_sentinel(_InputIterator _
   __rep_ = __rep();
   __annotate_new(0);
 
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     for (; __first != __last; ++__first)
       push_back(*__first);
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     __annotate_delete();
     if (__is_long())
       __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _CharT, class _Traits, class _Allocator>
@@ -2487,18 +2483,14 @@ basic_string<_CharT, _Traits, _Allocator>::__init_with_size(_InputIterator __fir
     __set_long_size(__sz);
   }
 
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     auto __end = __copy_non_overlapping_range(__first, __last, std::__to_address(__p));
     traits_type::assign(*__end, value_type());
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH (...) {
     if (__is_long())
       __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   __annotate_new(__sz);
 }
 
@@ -3396,9 +3388,7 @@ basic_string<_CharT, _Traits, _Allocator>::__shrink_or_extend(size_type __target
       // Shrink
       // - called from shrink_to_fit should not throw.
       // - called from reserve may throw but is not required to.
-#if _LIBCPP_HAS_EXCEPTIONS
-      try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+      _LIBCPP_TRY {
         auto __allocation = std::__allocate_at_least(__alloc_, __target_capacity + 1);
 
         // The Standard mandates shrink_to_fit() does not increase the capacity.
@@ -3410,11 +3400,9 @@ basic_string<_CharT, _Traits, _Allocator>::__shrink_or_extend(size_type __target
         }
         __new_data        = __allocation.ptr;
         __target_capacity = __allocation.count - 1;
-#if _LIBCPP_HAS_EXCEPTIONS
-      } catch (...) {
+      } _LIBCPP_CATCH(...) {
         return;
       }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     }
     __begin_lifetime(__new_data, __target_capacity + 1);
     __now_long = true;

--- a/libcxx/include/syncstream
+++ b/libcxx/include/syncstream
@@ -273,14 +273,10 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI ~basic_syncbuf() {
-#    if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#    endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       emit();
-#    if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
     }
-#    endif // _LIBCPP_HAS_EXCEPTIONS
     __dec_reference();
   }
 
@@ -337,9 +333,7 @@ protected:
       return traits_type::not_eof(__c);
 
     if (this->pptr() == this->epptr()) {
-#    if _LIBCPP_HAS_EXCEPTIONS
-      try {
-#    endif
+      _LIBCPP_TRY {
         size_t __size = __str_.size();
         __str_.resize(__str_.capacity() + 1);
         _LIBCPP_ASSERT_INTERNAL(__str_.size() > __size, "the buffer hasn't grown");
@@ -348,11 +342,9 @@ protected:
         this->setp(__p, __p + __str_.size());
         this->pbump(__size);
 
-#    if _LIBCPP_HAS_EXCEPTIONS
-      } catch (...) {
+      } _LIBCPP_CATCH(...) {
         return traits_type::eof();
       }
-#    endif
     }
 
     return this->sputc(traits_type::to_char_type(__c));
@@ -480,17 +472,12 @@ public:
     // TODO validate other unformatted output functions.
     typename basic_ostream<char_type, traits_type>::sentry __s(*this);
     if (__s) {
-#    if _LIBCPP_HAS_EXCEPTIONS
-      try {
-#    endif
-
+      _LIBCPP_TRY {
         if (__sb_.emit() == false)
           this->setstate(ios::badbit);
-#    if _LIBCPP_HAS_EXCEPTIONS
-      } catch (...) {
+      } _LIBCPP_CATCH(...) {
         this->__set_badbit_and_consider_rethrow();
       }
-#    endif
     }
   }
 

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -1984,17 +1984,13 @@ template <class _Tp>
 inline valarray<_Tp>::valarray(size_t __n) : __begin_(nullptr), __end_(nullptr) {
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (size_t __n_left = __n; __n_left; --__n_left, ++__end_)
         ::new ((void*)__end_) value_type();
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2007,17 +2003,13 @@ template <class _Tp>
 valarray<_Tp>::valarray(const value_type* __p, size_t __n) : __begin_(nullptr), __end_(nullptr) {
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (size_t __n_left = __n; __n_left; ++__end_, ++__p, --__n_left)
         ::new ((void*)__end_) value_type(*__p);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2025,17 +2017,13 @@ template <class _Tp>
 valarray<_Tp>::valarray(const valarray& __v) : __begin_(nullptr), __end_(nullptr) {
   if (__v.size()) {
     __begin_ = __end_ = allocator<value_type>().allocate(__v.size());
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (value_type* __p = __v.__begin_; __p != __v.__end_; ++__end_, ++__p)
         ::new ((void*)__end_) value_type(*__p);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__v.size());
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2051,18 +2039,14 @@ valarray<_Tp>::valarray(initializer_list<value_type> __il) : __begin_(nullptr), 
   const size_t __n = __il.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#  if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       size_t __n_left = __n;
       for (const value_type* __p = __il.begin(); __n_left; ++__end_, ++__p, --__n_left)
         ::new ((void*)__end_) value_type(*__p);
-#  if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2073,18 +2057,14 @@ valarray<_Tp>::valarray(const slice_array<value_type>& __sa) : __begin_(nullptr)
   const size_t __n = __sa.__size_;
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       size_t __n_left = __n;
       for (const value_type* __p = __sa.__vp_; __n_left; ++__end_, __p += __sa.__stride_, --__n_left)
         ::new ((void*)__end_) value_type(*__p);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2093,19 +2073,15 @@ valarray<_Tp>::valarray(const gslice_array<value_type>& __ga) : __begin_(nullptr
   const size_t __n = __ga.__1d_.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef const size_t* _Ip;
       const value_type* __s = __ga.__vp_;
       for (_Ip __i = __ga.__1d_.__begin_, __e = __ga.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2114,19 +2090,15 @@ valarray<_Tp>::valarray(const mask_array<value_type>& __ma) : __begin_(nullptr),
   const size_t __n = __ma.__1d_.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef const size_t* _Ip;
       const value_type* __s = __ma.__vp_;
       for (_Ip __i = __ma.__1d_.__begin_, __e = __ma.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2135,19 +2107,15 @@ valarray<_Tp>::valarray(const indirect_array<value_type>& __ia) : __begin_(nullp
   const size_t __n = __ia.__1d_.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       typedef const size_t* _Ip;
       const value_type* __s = __ia.__vp_;
       for (_Ip __i = __ia.__1d_.__begin_, __e = __ia.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2636,17 +2604,13 @@ void valarray<_Tp>::resize(size_t __n, value_type __x) {
   __clear(size());
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       for (size_t __n_left = __n; __n_left; --__n_left, ++__end_)
         ::new ((void*)__end_) value_type(__x);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       __clear(__n);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1061,27 +1061,21 @@ public:
         std::swap(__lhs, __rhs);
       }
       __impl __tmp(std::move(*__rhs));
-#  if _LIBCPP_HAS_EXCEPTIONS
       if constexpr (__all<is_nothrow_move_constructible_v<_Types>...>::value) {
         this->__generic_construct(*__rhs, std::move(*__lhs));
       } else {
         // EXTENSION: When the move construction of `__lhs` into `__rhs` throws
         // and `__tmp` is nothrow move constructible then we move `__tmp` back
         // into `__rhs` and provide the strong exception safety guarantee.
-        try {
+        _LIBCPP_TRY {
           this->__generic_construct(*__rhs, std::move(*__lhs));
-        } catch (...) {
+        } _LIBCPP_CATCH(...) {
           if (__tmp.__move_nothrow()) {
             this->__generic_construct(*__rhs, std::move(__tmp));
           }
-          throw;
+          _LIBCPP_RETHROW;
         }
       }
-#  else
-      // this isn't consolidated with the `if constexpr` branch above due to
-      // `throw` being ill-formed with exceptions disabled even when discarded.
-      this->__generic_construct(*__rhs, std::move(*__lhs));
-#  endif
       this->__generic_construct(*__lhs, std::move(__tmp));
     }
   }

--- a/libcxx/src/filesystem/error.h
+++ b/libcxx/src/filesystem/error.h
@@ -186,16 +186,12 @@ struct ErrorHandler {
   T report(const error_code& ec, const char* msg, ...) const {
     va_list ap;
     va_start(ap, msg);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       report_impl(ec, msg, ap);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       va_end(ap);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     va_end(ap);
     return error_value<T>();
   }
@@ -206,16 +202,12 @@ struct ErrorHandler {
   T report(errc const& err, const char* msg, ...) const {
     va_list ap;
     va_start(ap, msg);
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+    _LIBCPP_TRY {
       report_impl(make_error_code(err), msg, ap);
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
+    } _LIBCPP_CATCH(...) {
       va_end(ap);
-      throw;
+      _LIBCPP_RETHROW;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
     va_end(ap);
     return error_value<T>();
   }

--- a/libcxx/src/filesystem/format_string.h
+++ b/libcxx/src/filesystem/format_string.h
@@ -56,16 +56,12 @@ inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 2) string format_string(const cha
   string ret;
   va_list ap;
   va_start(ap, msg);
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     ret = detail::vformat_string(msg, ap);
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     va_end(ap);
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
   va_end(ap);
   return ret;
 }

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -219,9 +219,7 @@ locale::__imp::__imp(size_t refs) : facet(refs), facets_(N), name_("C") {
 }
 
 locale::__imp::__imp(const string& name, size_t refs) : facet(refs), facets_(N), name_(name) {
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     facets_ = locale::classic().__locale_->facets_;
     for (unsigned i = 0; i < facets_.size(); ++i)
       if (facets_[i])
@@ -268,14 +266,12 @@ locale::__imp::__imp(const string& name, size_t refs) : facet(refs), facets_(N),
 #if _LIBCPP_HAS_WIDE_CHARACTERS
     install(new messages_byname<wchar_t>(name_));
 #endif
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     for (unsigned i = 0; i < facets_.size(); ++i)
       if (facets_[i])
         facets_[i]->__release_shared();
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 locale::__imp::__imp(const __imp& other) : facets_(max<size_t>(N, other.facets_.size())), name_(other.name_) {
@@ -291,9 +287,7 @@ locale::__imp::__imp(const __imp& other, const string& name, locale::category c)
   for (unsigned i = 0; i < facets_.size(); ++i)
     if (facets_[i])
       facets_[i]->__add_shared();
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     if (c & locale::collate) {
       install(new collate_byname<char>(name));
 #if _LIBCPP_HAS_WIDE_CHARACTERS
@@ -348,14 +342,12 @@ locale::__imp::__imp(const __imp& other, const string& name, locale::category c)
       install(new messages_byname<wchar_t>(name));
 #endif
     }
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     for (unsigned i = 0; i < facets_.size(); ++i)
       if (facets_[i])
         facets_[i]->__release_shared();
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class F>
@@ -370,9 +362,7 @@ locale::__imp::__imp(const __imp& other, const __imp& one, locale::category c)
   for (unsigned i = 0; i < facets_.size(); ++i)
     if (facets_[i])
       facets_[i]->__add_shared();
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     if (c & locale::collate) {
       install_from<std::collate<char> >(one);
 #if _LIBCPP_HAS_WIDE_CHARACTERS
@@ -443,14 +433,12 @@ locale::__imp::__imp(const __imp& other, const __imp& one, locale::category c)
       install_from<std::messages<wchar_t> >(one);
 #endif
     }
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     for (unsigned i = 0; i < facets_.size(); ++i)
       if (facets_[i])
         facets_[i]->__release_shared();
-    throw;
+    _LIBCPP_RETHROW;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 locale::__imp::__imp(const __imp& other, facet* f, long id)

--- a/libcxx/src/support/runtime/exception_fallback.ipp
+++ b/libcxx/src/support/runtime/exception_fallback.ipp
@@ -34,18 +34,14 @@ terminate_handler set_terminate(terminate_handler func) noexcept {
 terminate_handler get_terminate() noexcept { return __libcpp_atomic_load(&__terminate_handler); }
 
 [[noreturn]] void terminate() noexcept {
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     (*get_terminate())();
     // handler should not return
     __libcpp_verbose_abort("terminate_handler unexpectedly returned\n");
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     // handler should not throw exception
     __libcpp_verbose_abort("terminate_handler unexpectedly threw an exception\n");
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 bool uncaught_exception() noexcept { return uncaught_exceptions() > 0; }

--- a/libcxx/src/support/runtime/exception_msvc.ipp
+++ b/libcxx/src/support/runtime/exception_msvc.ipp
@@ -42,18 +42,14 @@ terminate_handler set_terminate(terminate_handler func) noexcept { return ::set_
 terminate_handler get_terminate() noexcept { return ::_get_terminate(); }
 
 [[noreturn]] void terminate() noexcept {
-#if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+  _LIBCPP_TRY {
     (*get_terminate())();
     // handler should not return
     __libcpp_verbose_abort("terminate_handler unexpectedly returned\n");
-#if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
+  } _LIBCPP_CATCH(...) {
     // handler should not throw exception
     __libcpp_verbose_abort("terminate_handler unexpectedly threw an exception\n");
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 bool uncaught_exception() noexcept { return uncaught_exceptions() > 0; }


### PR DESCRIPTION
This makes code using try/catch blocks significantly more readable, since we avoid a bunch of `#if _LIBCPP_HAS_EXCEPTIONS`.
