### PR TITLE
[clang] Introduce diagnostics suppression mappings

### DIFF
--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
@@ -81,7 +81,8 @@ ExpandModularHeadersPPCallbacks::ExpandModularHeadersPPCallbacks(
   Diags.setSourceManager(&Sources);
   // FIXME: Investigate whatever is there better way to initialize DiagEngine
   // or whatever DiagEngine can be shared by multiple preprocessors
-  ProcessWarningOptions(Diags, Compiler.getDiagnosticOpts());
+  ProcessWarningOptions(Diags, Compiler.getDiagnosticOpts(),
+                        Compiler.getVirtualFileSystem());
 
   LangOpts.Modules = false;
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -801,6 +801,9 @@ New features
   attribute, the compiler can generate warnings about the use of any language features, or calls to
   other functions, which may block.
 
+- Introduced ``-warning-suppression-mappings`` flag to control diagnostic
+  suppressions per file. See `documentation <https://clang.llvm.org/docs/WarningSuppressionMappings.html>_` for details.
+
 Crash and bug fixes
 ^^^^^^^^^^^^^^^^^^^
 

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1338,8 +1338,10 @@ of the project, even if there are violations in some headers.
   # This compilation won't emit any unused findings for sources under foo/
   # directory. But it'll still complain for all the other sources, e.g:
   $ cat foo/bar.cc
-  #include "dir/include.h" // clang flags unused declarations here.
+  #include "dir/include.h" // Clang flags unused declarations here.
   #include "foo/include.h" // but unused warnings under this source is omitted.
+  #include "next_to_bar_cc.h" // as are unused warnings from this header file.
+  // Further, unused warnings in the remainder of bar.cc are also omitted.
 
 
 See :doc:`WarningSuppressionMappings` for details about the file format and

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1324,10 +1324,9 @@ disabling all warnings wins.
 Controlling Diagnostics via Suppression Mappings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Warning suppression mappings enables users to suppress clang's diagnostics in a
+Warning suppression mappings enable users to suppress Clang's diagnostics in a
 per-file granular manner. Enabling enforcement of diagnostics in specific parts
-of the project, even if there are violations in dependencies or other parts of
-the codebase.
+of the project, even if there are violations in some headers.
 
 .. code-block:: console
 
@@ -1337,7 +1336,11 @@ the codebase.
 
   $ clang --warning-suppression-mappings=mapping.txt -Wunused foo/bar.cc
   # This compilation won't emit any unused findings for sources under foo/
-  # directory. But it'll still complain for all the other sources.
+  # directory. But it'll still complain for all the other sources, e.g:
+  $ cat foo/bar.cc
+  #include "dir/include.h" // clang flags unused declarations here.
+  #include "foo/include.h" // but unused warnings under this source is omitted.
+
 
 See :doc:`WarningSuppressionMappings` for details about the file format and
 functionality.

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -151,6 +151,10 @@ Options to Control Error and Warning Messages
   instantiation backtrace for a single warning or error. The default is 10, and
   the limit can be disabled with `-ftemplate-backtrace-limit=0`.
 
+.. option:: --warning-suppression-mappings=foo.txt
+
+   :ref:`Suppress certain diagnostics for certain files. <warning_suppression_mappings>`
+
 .. _cl_diag_formatting:
 
 Formatting of Diagnostics
@@ -1314,6 +1318,29 @@ with its corresponding `Wno-` option.
 
 Note that when combined with :option:`-w` (which disables all warnings),
 disabling all warnings wins.
+
+.. _warning_suppression_mappings:
+
+Controlling Diagnostics via Suppression Mappings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Warning suppression mappings enables users to suppress clang's diagnostics in a
+per-file granular manner. Enabling enforcement of diagnostics in specific parts
+of the project, even if there are violations in dependencies or other parts of
+the codebase.
+
+.. code-block:: console
+
+  $ cat mappings.txt
+  [unused]
+  src:foo/*
+
+  $ clang --warning-suppression-mappings=mapping.txt -Wunused foo/bar.cc
+  # This compilation won't emit any unused findings for sources under foo/
+  # directory. But it'll still complain for all the other sources.
+
+See :doc:`WarningSuppressionMappings` for details about the file format and
+functionality.
 
 Controlling Static Analyzer Diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/WarningSuppressionMappings.rst
+++ b/clang/docs/WarningSuppressionMappings.rst
@@ -1,0 +1,92 @@
+============================
+Warning suppression mappings
+============================
+
+.. contents::
+   :local:
+
+Introduction
+============
+
+Warning suppression mappings enables users to suppress clang's diagnostics in a
+per-file granular manner. Enabling enforcement of diagnostics in specific parts
+of the project, even if there are violations in dependencies or other parts of
+the codebase.
+
+Goal and usage
+==============
+
+Clang allows diagnostics to be configured at a translation-unit granularity.
+If a foo.cpp is compiled with -Wfoo, all transitively included headers also need
+to be clean. Hence turning on new warnings at large codebases is quite difficult
+today:
+- It requires cleaning up all the existing warnings, which might not be possible
+  when some dependencies aren't in project owner's control.
+- Preventing backsliding in the meanwhile as the diagnostic can't be enforced at
+  all until codebase is cleaned up.
+
+Warning suppression mappings aims to alleviate some of these concerns by making
+diagnostic configuration granularity finer, at a source file level.
+
+To achieve this, user may create a file listing which diagnostic groups to
+suppress in which files, and pass it as a command line argument to clang with
+``--warning-suppression-mappings`` flag.
+
+Note that this mechanism won't enable any diagnostics on its own. Users should
+still turn on warnings in their compilations with explicit ``-Wfoo`` flags.
+
+Example
+=======
+
+.. code-block:: bash
+
+  $ cat my/user/code.cpp
+  #include <foo/bar.h>
+  namespace { void unused_func1(); }
+
+  $ cat foo/bar.h
+  namespace { void unused_func2(); }
+
+  $ cat suppression_mappings.txt
+  # Suppress -Wunused warnings in all files, apart from the ones under `foo/`.
+  [unused]
+  src:*
+  src:*foo/*=emit
+  $ clang -Wunused --warning-suppression-mappings=suppression_mappings.txt my/user/code.cpp
+  # prints warning: unused function 'unused_func2', but no warnings for `unused_func1`.
+
+Format
+======
+
+Warning suppression mappings uses a format similar to
+:doc:`SanitizerSpecialCaseList`.
+
+Users can mention sections to describe which diagnostic group behaviours to
+change. Sections are denoted as ``[unused]`` in this format. Each section name
+must match a diagnostic group.
+When a diagnostic is matched by multiple groups, the latest one takes
+precendence.
+
+Afterwards in each section, users can have multiple entities that match source
+files based on the globs. These entities look like ``src:*/my/dir/*``.
+Users can also use ``emit`` category to exclude a subdirectory from suppression.
+Source files are matched against these globs either as paths relative to current
+working directory, or as absolute paths.
+When a source file matches multiple globs, the longest one takes precendence.
+
+.. code-block:: bash
+
+    # Lines starting with # are ignored.
+    # Configure suppression globs for `-Wunused` warnings
+    [unused]
+    # Suppress on all files by default.
+    src:*
+    # But enforce for all the sources under foo/.
+    src:*foo/*=emit
+
+    # unused-function warnings are a subgroup of `-Wunused`. So this section
+    # takes precedence over the previous one for unused-function warnings, but
+    # not for unused-variable warnings.
+    [unused-function]
+    # Only suppress for sources under bar/.
+    src:*bar/*

--- a/clang/docs/WarningSuppressionMappings.rst
+++ b/clang/docs/WarningSuppressionMappings.rst
@@ -8,29 +8,26 @@ Warning suppression mappings
 Introduction
 ============
 
-Warning suppression mappings enables users to suppress clang's diagnostics in a
+Warning suppression mappings enable users to suppress Clang's diagnostics in a
 per-file granular manner. Enabling enforcement of diagnostics in specific parts
-of the project, even if there are violations in dependencies or other parts of
-the codebase.
+of the project, even if there are violations in some headers.
 
 Goal and usage
 ==============
 
 Clang allows diagnostics to be configured at a translation-unit granularity.
-If a foo.cpp is compiled with -Wfoo, all transitively included headers also need
-to be clean. Hence turning on new warnings at large codebases is quite difficult
-today:
-- It requires cleaning up all the existing warnings, which might not be possible
-  when some dependencies aren't in project owner's control.
-- Preventing backsliding in the meanwhile as the diagnostic can't be enforced at
-  all until codebase is cleaned up.
+If a ``foo.cpp`` is compiled with ``-Wfoo``, all transitively included headers
+also need to be clean. Hence turning on new warnings in large codebases can be
+difficult today. Since it requires cleaning up all the existing warnings,
+which might not be possible when some dependencies aren't in the project owner's
+control or because new violations are creeping up quicker than the clean up.
 
-Warning suppression mappings aims to alleviate some of these concerns by making
+Warning suppression mappings aim to alleviate some of these concerns by making
 diagnostic configuration granularity finer, at a source file level.
 
-To achieve this, user may create a file listing which diagnostic groups to
-suppress in which files, and pass it as a command line argument to clang with
-``--warning-suppression-mappings`` flag.
+To achieve this, user can create a file that lists which diagnostic groups to
+suppress in which files or paths, and pass it as a command line argument to
+Clang with the ``--warning-suppression-mappings`` flag.
 
 Note that this mechanism won't enable any diagnostics on its own. Users should
 still turn on warnings in their compilations with explicit ``-Wfoo`` flags.
@@ -58,7 +55,7 @@ Example
 Format
 ======
 
-Warning suppression mappings uses a format similar to
+Warning suppression mappings uses the same format as
 :doc:`SanitizerSpecialCaseList`.
 
 Users can mention sections to describe which diagnostic group behaviours to
@@ -69,9 +66,10 @@ precendence.
 
 Afterwards in each section, users can have multiple entities that match source
 files based on the globs. These entities look like ``src:*/my/dir/*``.
-Users can also use ``emit`` category to exclude a subdirectory from suppression.
-Source files are matched against these globs either as paths relative to current
-working directory, or as absolute paths.
+Users can also use the ``emit`` category to exclude a subdirectory from
+suppression.
+Source files are matched against these globs either as paths relative to th
+current working directory, or as absolute paths.
 When a source file matches multiple globs, the longest one takes precendence.
 
 .. code-block:: bash

--- a/clang/docs/WarningSuppressionMappings.rst
+++ b/clang/docs/WarningSuppressionMappings.rst
@@ -17,20 +17,25 @@ Goal and usage
 
 Clang allows diagnostics to be configured at a translation-unit granularity.
 If a ``foo.cpp`` is compiled with ``-Wfoo``, all transitively included headers
-also need to be clean. Hence turning on new warnings in large codebases can be
-difficult today. Since it requires cleaning up all the existing warnings,
-which might not be possible when some dependencies aren't in the project owner's
-control or because new violations are creeping up quicker than the clean up.
+also need to be clean. Hence turning on new warnings in large codebases requires
+cleaning up all the existing warnings. This might not be possible when some
+dependencies aren't in the project owner's control or because new violations are
+creeping up quicker than the clean up.
 
 Warning suppression mappings aim to alleviate some of these concerns by making
 diagnostic configuration granularity finer, at a source file level.
 
-To achieve this, user can create a file that lists which diagnostic groups to
-suppress in which files or paths, and pass it as a command line argument to
-Clang with the ``--warning-suppression-mappings`` flag.
+To achieve this, user can create a file that lists which :doc:`diagnostic
+groups <DiagnosticsReference>` to suppress in which files or paths, and pass it
+as a command line argument to Clang with the ``--warning-suppression-mappings``
+flag.
 
 Note that this mechanism won't enable any diagnostics on its own. Users should
 still turn on warnings in their compilations with explicit ``-Wfoo`` flags.
+`Controlling diagnostics pragmas
+<https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas>`_
+take precedence over suppression mappings. Ensuring code author's explicit
+intent is always preserved.
 
 Example
 =======
@@ -58,19 +63,18 @@ Format
 Warning suppression mappings uses the same format as
 :doc:`SanitizerSpecialCaseList`.
 
-Users can mention sections to describe which diagnostic group behaviours to
-change. Sections are denoted as ``[unused]`` in this format. Each section name
-must match a diagnostic group.
-When a diagnostic is matched by multiple groups, the latest one takes
-precendence.
+Sections describe which diagnostic group's behaviour to change, e.g.
+``[unused]``. When a diagnostic is matched by multiple sections, the latest
+section takes precedence.
 
 Afterwards in each section, users can have multiple entities that match source
 files based on the globs. These entities look like ``src:*/my/dir/*``.
 Users can also use the ``emit`` category to exclude a subdirectory from
 suppression.
-Source files are matched against these globs either as paths relative to th
+Source files are matched against these globs either as paths relative to the
 current working directory, or as absolute paths.
-When a source file matches multiple globs, the longest one takes precendence.
+When a source file matches multiple globs in a section, the longest one takes
+precedence.
 
 .. code-block:: bash
 

--- a/clang/docs/WarningSuppressionMappings.rst
+++ b/clang/docs/WarningSuppressionMappings.rst
@@ -71,8 +71,11 @@ Afterwards in each section, users can have multiple entities that match source
 files based on the globs. These entities look like ``src:*/my/dir/*``.
 Users can also use the ``emit`` category to exclude a subdirectory from
 suppression.
-Source files are matched against these globs either as paths relative to the
-current working directory, or as absolute paths.
+Source files are matched against these globs either:
+
+- as paths relative to the current working directory
+- as absolute paths.
+
 When a source file matches multiple globs in a section, the longest one takes
 precedence.
 

--- a/clang/docs/index.rst
+++ b/clang/docs/index.rst
@@ -22,6 +22,7 @@ Using Clang as a Compiler
    ClangCommandLineReference
    AttributeReference
    DiagnosticsReference
+   WarningSuppressionMappings
    CrossCompilation
    ClangStaticAnalyzer
    ThreadSafetyAnalysis

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -960,7 +960,7 @@ public:
   /// Mapping file is expected to be a special case list with sections denoting
   /// diagnostic groups and `src` entries for globs to suppress. `emit` category
   /// can be used to disable suppression. Longest glob that matches a filepath
-  /// takes precendence. For example:
+  /// takes precedence. For example:
   ///   [unused]
   ///   src:clang/*
   ///   src:clang/foo/*=emit

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -960,17 +960,19 @@ public:
   /// can be used to disable suppression. Longest glob that matches a filepath
   /// takes precendence. For example:
   ///   [unused]
-  ///   src:*clang/*
-  ///   src:*clang/foo/*=emit
-  ///   src:*clang/foo/bar/*
+  ///   src:clang/*
+  ///   src:clang/foo/*=emit
+  ///   src:clang/foo/bar/*
   ///
   /// Such a mappings file suppress all diagnostics produced by -Wunused in all
   /// sources under `clang/` directory apart from `clang/foo/`. Diagnostics
-  /// under `clang/foo/bar/` will also be suppressed.
+  /// under `clang/foo/bar/` will also be suppressed. Note that the FilePath is
+  /// matched against the globs as-is.
   /// These take presumed locations into account, and can still be overriden by
   /// clang-diagnostics pragmas.
   void setDiagSuppressionMapping(llvm::MemoryBuffer &MB);
-  bool isSuppressedViaMapping(diag::kind D, llvm::StringRef FilePath) const;
+  bool isSuppressedViaMapping(diag::kind DiagId,
+                              llvm::StringRef FilePath) const;
 
   /// Issue the message to the client.
   ///

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -26,8 +26,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/VirtualFileSystem.h"
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -43,6 +41,10 @@
 namespace llvm {
 class Error;
 class raw_ostream;
+class MemoryBuffer;
+namespace vfs {
+class FileSystem;
+} // namespace vfs
 } // namespace llvm
 
 namespace clang {
@@ -970,7 +972,7 @@ public:
   /// matched against the globs as-is.
   /// These take presumed locations into account, and can still be overriden by
   /// clang-diagnostics pragmas.
-  void setDiagSuppressionMapping(llvm::MemoryBuffer &MB);
+  void setDiagSuppressionMapping(llvm::MemoryBuffer &Input);
   bool isSuppressedViaMapping(diag::kind DiagId,
                               llvm::StringRef FilePath) const;
 

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -953,11 +953,12 @@ public:
     return (Level)Diags->getDiagnosticLevel(DiagID, Loc, *this);
   }
 
-  /// Diagnostic suppression mappings can be used to ignore diagnostics based on
-  /// the file they occur in. Mapping file is expected to be a special case list
-  /// with sections denoting diagnostic groups and `src` entries for globs to
-  /// suppress. `emit` category can be used to disable suppression. Longest glob
-  /// that matches a filepath takes precendence. For example:
+  /// Diagnostic suppression mappings can be used to suppress specific
+  /// diagnostics in specific files.
+  /// Mapping file is expected to be a special case list with sections denoting
+  /// diagnostic groups and `src` entries for globs to suppress. `emit` category
+  /// can be used to disable suppression. Longest glob that matches a filepath
+  /// takes precendence. For example:
   ///   [unused]
   ///   src:*clang/*
   ///   src:*clang/foo/*=emit

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -836,5 +836,5 @@ def warn_missing_include_dirs : Warning<
   "no such include directory: '%0'">, InGroup<MissingIncludeDirs>, DefaultIgnore;
 
 def err_drv_malformed_warning_suppression_mapping : Error<
-  "failed to process suppression mapping file '%0' : %1">;
+  "failed to process suppression mapping file '%0': %1">;
 }

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -834,4 +834,7 @@ def err_drv_triple_version_invalid : Error<
 
 def warn_missing_include_dirs : Warning<
   "no such include directory: '%0'">, InGroup<MissingIncludeDirs>, DefaultIgnore;
+
+def err_drv_malformed_warning_suppression_mapping : Error<
+  "failed to process suppression mapping file '%0' : %1">;
 }

--- a/clang/include/clang/Basic/DiagnosticOptions.h
+++ b/clang/include/clang/Basic/DiagnosticOptions.h
@@ -108,6 +108,9 @@ public:
   /// The file to serialize diagnostics to (non-appending).
   std::string DiagnosticSerializationFile;
 
+  /// File that defines suppression mappings.
+  std::string SuppressionMappingsFile;
+
   /// The list of -W... options used to alter the diagnostic mappings, with the
   /// prefixes removed.
   std::vector<std::string> Warnings;

--- a/clang/include/clang/Basic/DiagnosticOptions.h
+++ b/clang/include/clang/Basic/DiagnosticOptions.h
@@ -108,8 +108,8 @@ public:
   /// The file to serialize diagnostics to (non-appending).
   std::string DiagnosticSerializationFile;
 
-  /// File that defines suppression mappings.
-  std::string SuppressionMappingsFile;
+  /// File that defines diagnostic suppression mappings.
+  std::string DiagnosticSuppressionMappingsFile;
 
   /// The list of -W... options used to alter the diagnostic mappings, with the
   /// prefixes removed.

--- a/clang/include/clang/Basic/DiagnosticOptions.h
+++ b/clang/include/clang/Basic/DiagnosticOptions.h
@@ -108,7 +108,7 @@ public:
   /// The file to serialize diagnostics to (non-appending).
   std::string DiagnosticSerializationFile;
 
-  /// File that defines diagnostic suppression mappings.
+  /// Path for the file that defines diagnostic suppression mappings.
   std::string DiagnosticSuppressionMappingsFile;
 
   /// The list of -W... options used to alter the diagnostic mappings, with the

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9020,5 +9020,5 @@ def wasm_opt : Flag<["--"], "wasm-opt">,
 
 def warning_suppression_mappings_EQ : Joined<["--"],
   "warning-suppression-mappings=">, Group<Diag_Group>,
-  HelpText<"File containing list of sources to suppress diagnostics for. See XXX for format">,
+  HelpText<"File containing list of sources to suppress diagnostics for.">,
   Visibility<[ClangOption, CC1Option]>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9020,5 +9020,5 @@ def wasm_opt : Flag<["--"], "wasm-opt">,
 
 def warning_suppression_mappings_EQ : Joined<["--"],
   "warning-suppression-mappings=">, Group<Diag_Group>,
-  HelpText<"File containing diagnostic suppresion mappings. See user manual for"
-  " file format.">, Visibility<[ClangOption, CC1Option]>;
+  HelpText<"File containing diagnostic suppresion mappings. See user manual "
+  "for file format.">, Visibility<[ClangOption, CC1Option]>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9020,5 +9020,5 @@ def wasm_opt : Flag<["--"], "wasm-opt">,
 
 def warning_suppression_mappings_EQ : Joined<["--"],
   "warning-suppression-mappings=">, Group<Diag_Group>,
-  HelpText<"File containing list of sources to suppress diagnostics for.">,
-  Visibility<[ClangOption, CC1Option]>;
+  HelpText<"File containing diagnostic suppresion mappings. See user manual for"
+  " file format.">, Visibility<[ClangOption, CC1Option]>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9017,3 +9017,8 @@ def wasm_opt : Flag<["--"], "wasm-opt">,
   Group<m_Group>,
   HelpText<"Enable the wasm-opt optimizer (default)">,
   MarshallingInfoNegativeFlag<LangOpts<"NoWasmOpt">>;
+
+def warning_suppression_mappings_EQ : Joined<["--"],
+  "warning-suppression-mappings=">, Group<Diag_Group>,
+  HelpText<"File containing list of sources to suppress diagnostics for. See XXX for format">,
+  Visibility<[ClangOption, CC1Option]>;

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include <cassert>
 #include <list>
 #include <memory>
@@ -701,11 +702,10 @@ public:
   /// used by some diagnostics printers (for logging purposes only).
   ///
   /// \return The new object on success, or null on failure.
-  static IntrusiveRefCntPtr<DiagnosticsEngine>
-  createDiagnostics(DiagnosticOptions *Opts,
-                    DiagnosticConsumer *Client = nullptr,
-                    bool ShouldOwnClient = true,
-                    const CodeGenOptions *CodeGenOpts = nullptr);
+  static IntrusiveRefCntPtr<DiagnosticsEngine> createDiagnostics(
+      DiagnosticOptions *Opts, DiagnosticConsumer *Client = nullptr,
+      bool ShouldOwnClient = true, const CodeGenOptions *CodeGenOpts = nullptr,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr);
 
   /// Create the file manager and replace any existing one with it.
   ///

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -21,6 +21,7 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TokenKinds.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
@@ -28,6 +29,7 @@
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/CrashRecoveryContext.h"
 #include "llvm/Support/Unicode.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
@@ -475,6 +477,16 @@ void DiagnosticsEngine::setSeverityForAll(diag::Flavor Flavor,
   for (diag::kind Diag : AllDiags)
     if (Diags->isBuiltinWarningOrExtension(Diag))
       setSeverity(Diag, Map, Loc);
+}
+
+void DiagnosticsEngine::setDiagSuppressionMapping(
+    decltype(DiagSuppressionMapping) Mapping) {
+  DiagSuppressionMapping = std::move(Mapping);
+}
+
+bool DiagnosticsEngine::isSuppressedViaMapping(diag::kind D,
+                                               llvm::StringRef FilePath) const {
+  return DiagSuppressionMapping && DiagSuppressionMapping(D, FilePath);
 }
 
 void DiagnosticsEngine::Report(const StoredDiagnostic &storedDiag) {

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -532,10 +532,10 @@ void WarningsSpecialCaseList::processSections(DiagnosticsEngine &Diags) {
       LineAndSectionEntry;
   LineAndSectionEntry.reserve(Sections.size());
   for (const auto &Entry : Sections) {
-    llvm::StringRef DiagName = Entry.first();
+    llvm::StringRef DiagName = Entry.getKey();
     // Each section has a matcher with that section's name, attached to that
     // line.
-    const auto &DiagSectionMatcher = Entry.second.SectionMatcher;
+    const auto &DiagSectionMatcher = Entry.getValue().SectionMatcher;
     unsigned DiagLine = DiagSectionMatcher->Globs.at(DiagName).second;
     LineAndSectionEntry.emplace_back(DiagLine, &Entry);
   }
@@ -586,7 +586,7 @@ bool WarningsSpecialCaseList::isDiagSuppressed(diag::kind DiagId,
   if (SrcEntriesIt == EntityTypeToCategories.end())
     return false;
   const llvm::StringMap<llvm::SpecialCaseList::Matcher> &CategoriesToMatchers =
-      SrcEntriesIt->second;
+      SrcEntriesIt->getValue();
   return globsMatches(CategoriesToMatchers, FilePath);
 }
 
@@ -596,8 +596,8 @@ bool WarningsSpecialCaseList::globsMatches(
   llvm::StringRef LongestMatch;
   bool LongestIsPositive = false;
   for (const auto &Entry : CategoriesToMatchers) {
-    llvm::StringRef Category = Entry.first();
-    const llvm::SpecialCaseList::Matcher &Matcher = Entry.second;
+    llvm::StringRef Category = Entry.getKey();
+    const llvm::SpecialCaseList::Matcher &Matcher = Entry.getValue();
     bool IsPositive = Category != "emit";
     for (const auto &[Pattern, Glob] : Matcher.Globs) {
       if (Pattern.size() < LongestMatch.size())

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -532,8 +532,8 @@ public:
     }
   }
 
-  bool isDiagSuppressed(diag::kind D, llvm::StringRef FilePath) const {
-    auto Section = DiagToSection.find(D);
+  bool isDiagSuppressed(diag::kind DiagId, llvm::StringRef FilePath) const {
+    auto Section = DiagToSection.find(DiagId);
     if (Section == DiagToSection.end())
       return false;
     auto &DiagEntries = Section->second->Entries;
@@ -578,15 +578,15 @@ void DiagnosticsEngine::setDiagSuppressionMapping(llvm::MemoryBuffer &MB) {
     return;
   }
   SCL->processSections(*this);
-  DiagSuppressionMapping = [SCL(std::move(SCL))](diag::kind K,
+  DiagSuppressionMapping = [SCL(std::move(SCL))](diag::kind DiagId,
                                                   llvm::StringRef Path) {
-    return SCL->isDiagSuppressed(K, Path);
+    return SCL->isDiagSuppressed(DiagId, Path);
   };
 }
 
-bool DiagnosticsEngine::isSuppressedViaMapping(diag::kind D,
+bool DiagnosticsEngine::isSuppressedViaMapping(diag::kind DiagId,
                                                llvm::StringRef FilePath) const {
-  return DiagSuppressionMapping && DiagSuppressionMapping(D, FilePath);
+  return DiagSuppressionMapping && DiagSuppressionMapping(DiagId, FilePath);
 }
 
 void DiagnosticsEngine::Report(const StoredDiagnostic &storedDiag) {

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -561,11 +561,11 @@ void WarningsSpecialCaseList::processSections(DiagnosticsEngine &Diags) {
 }
 
 void DiagnosticsEngine::setDiagSuppressionMapping(llvm::MemoryBuffer &Input) {
-  std::string Err;
-  auto WarningSuppressionList = WarningsSpecialCaseList::create(Input, Err);
+  std::string Error;
+  auto WarningSuppressionList = WarningsSpecialCaseList::create(Input, Error);
   if (!WarningSuppressionList) {
     Report(diag::err_drv_malformed_warning_suppression_mapping)
-        << Input.getBufferIdentifier() << Err;
+        << Input.getBufferIdentifier() << Error;
     return;
   }
   WarningSuppressionList->processSections(*this);
@@ -597,7 +597,7 @@ bool WarningsSpecialCaseList::globsMatches(
   bool LongestIsPositive = false;
   for (const auto &Entry : CategoriesToMatchers) {
     llvm::StringRef Category = Entry.first();
-    const auto &Matcher = Entry.second;
+    const llvm::SpecialCaseList::Matcher &Matcher = Entry.second;
     bool IsPositive = Category != "emit";
     for (const auto &[Pattern, Glob] : Matcher.Globs) {
       if (Pattern.size() < LongestMatch.size())

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -487,6 +487,8 @@ void DiagnosticsEngine::setSeverityForAll(diag::Flavor Flavor,
 }
 
 namespace {
+// FIXME: We should isolate the parser from SpecialCaseList and just use it
+// here.
 class WarningsSpecialCaseList : public llvm::SpecialCaseList {
 public:
   static std::unique_ptr<WarningsSpecialCaseList>

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -606,7 +606,7 @@ DiagnosticIDs::getDiagnosticSeverity(unsigned DiagID, SourceLocation Loc,
   // We also use presumed locations here to improve reproducibility for
   // preprocessed inputs.
   if (!Mapping.isPragma()) {
-    if (auto PLoc = SM.getPresumedLoc(Loc);
+    if (PresumedLoc PLoc = SM.getPresumedLoc(Loc);
         PLoc.isValid() && Diag.isSuppressedViaMapping(
                               DiagID, llvm::sys::path::remove_leading_dotslash(
                                           PLoc.getFilename())))

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Path.h"
 #include <map>
 #include <optional>
 using namespace clang;
@@ -606,8 +607,9 @@ DiagnosticIDs::getDiagnosticSeverity(unsigned DiagID, SourceLocation Loc,
   // preprocessed inputs.
   if (!Mapping.isPragma()) {
     if (auto PLoc = SM.getPresumedLoc(Loc);
-        PLoc.isValid() &&
-        Diag.isSuppressedViaMapping(DiagID, PLoc.getFilename()))
+        PLoc.isValid() && Diag.isSuppressedViaMapping(
+                              DiagID, llvm::sys::path::remove_leading_dotslash(
+                                          PLoc.getFilename())))
       return diag::Severity::Ignored;
   }
 

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -600,12 +600,10 @@ DiagnosticIDs::getDiagnosticSeverity(unsigned DiagID, SourceLocation Loc,
       SM.isInSystemMacro(Loc))
     return diag::Severity::Ignored;
 
-  // Apply suppression mappings if severity wasn't explicitly mapped with a
-  // clang-diagnostics pragma to ensure pragmas always take precedence over
-  // mappings.
-  // We also use presumed locations here to improve reproducibility for
-  // preprocessed inputs.
+  // Clang-diagnostics pragmas always take precedence over suppression mapping.
   if (!Mapping.isPragma()) {
+    // We also use presumed locations here to improve reproducibility for
+    // preprocessed inputs.
     if (PresumedLoc PLoc = SM.getPresumedLoc(Loc);
         PLoc.isValid() && Diag.isSuppressedViaMapping(
                               DiagID, llvm::sys::path::remove_leading_dotslash(

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -599,6 +599,18 @@ DiagnosticIDs::getDiagnosticSeverity(unsigned DiagID, SourceLocation Loc,
       SM.isInSystemMacro(Loc))
     return diag::Severity::Ignored;
 
+  // Apply suppression mappings if severity wasn't explicitly mapped with a
+  // clang-diagnostics pragma to ensure pragmas always take precedence over
+  // mappings.
+  // We also use presumed locations here to improve reproducibility for
+  // preprocessed inputs.
+  if (!Mapping.isPragma()) {
+    if (auto PLoc = SM.getPresumedLoc(Loc);
+        PLoc.isValid() &&
+        Diag.isSuppressedViaMapping(DiagID, PLoc.getFilename()))
+      return diag::Severity::Ignored;
+  }
+
   return Result;
 }
 

--- a/clang/lib/Basic/Warnings.cpp
+++ b/clang/lib/Basic/Warnings.cpp
@@ -23,10 +23,21 @@
 // simpler because a remark can't be promoted to an error.
 #include "clang/Basic/AllDiagnostics.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticDriver.h"
+#include "clang/Basic/DiagnosticIDs.h"
 #include "clang/Basic/DiagnosticOptions.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMapEntry.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SpecialCaseList.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include <algorithm>
 #include <cstring>
+#include <memory>
 #include <utility>
+#include <vector>
 using namespace clang;
 
 // EmitUnknownDiagWarning - Emit a warning and typo hint for unknown warning
@@ -41,8 +52,96 @@ static void EmitUnknownDiagWarning(DiagnosticsEngine &Diags,
       << (Prefix.str() += std::string(Suggestion));
 }
 
+namespace {
+class WarningsSpecialCaseList : public llvm::SpecialCaseList {
+public:
+  static std::unique_ptr<WarningsSpecialCaseList>
+  create(const llvm::MemoryBuffer &MB, std::string &Err) {
+    auto SCL = std::make_unique<WarningsSpecialCaseList>();
+    if (SCL->createInternal(&MB, Err))
+      return SCL;
+    return nullptr;
+  }
+
+  // Section names refer to diagnostic groups, which cover multiple individual
+  // diagnostics. Expand diagnostic groups here to individual diagnostics.
+  // A diagnostic can have multiple diagnostic groups associated with it, we let
+  // the last section take precedence in such cases.
+  void processSections(DiagnosticsEngine &Diags) {
+    // Drop the default section introduced by special case list, we only support
+    // exact diagnostic group names.
+    Sections.erase("*");
+    // Make sure we iterate sections by their line numbers.
+    std::vector<std::pair<unsigned, const llvm::StringMapEntry<Section> *>>
+        LineAndSection;
+    for (const auto &Entry : Sections) {
+      LineAndSection.emplace_back(
+          Entry.second.SectionMatcher->Globs.at(Entry.first()).second, &Entry);
+    }
+    llvm::sort(LineAndSection);
+    for (const auto &[_, Entry] : LineAndSection) {
+      SmallVector<diag::kind, 256> GroupDiags;
+      if (Diags.getDiagnosticIDs()->getDiagnosticsInGroup(
+              clang::diag::Flavor::WarningOrError, Entry->first(),
+              GroupDiags)) {
+        EmitUnknownDiagWarning(Diags, clang::diag::Flavor::WarningOrError, "",
+                               Entry->first());
+        continue;
+      }
+      for (auto D : GroupDiags)
+        DiagToSection[D] = &Entry->getValue();
+    }
+  }
+
+  bool isDiagSuppressed(diag::kind D, llvm::StringRef FilePath) const {
+    auto Section = DiagToSection.find(D);
+    if (Section == DiagToSection.end())
+      return false;
+    auto SrcEntries = Section->second->Entries.find("src");
+    if(SrcEntries == Section->second->Entries.end())
+      return false;
+    // Find the longest glob pattern that matches FilePath. A positive match
+    // implies D should be suppressed for FilePath.
+    llvm::StringRef LongestMatch;
+    bool LongestWasNegative;
+    for (const auto &CatIt : SrcEntries->second) {
+      bool IsNegative = CatIt.first() == "emit";
+      for (const auto &GlobIt : CatIt.second.Globs) {
+        if (GlobIt.getKeyLength() < LongestMatch.size())
+          continue;
+        if (!GlobIt.second.first.match(FilePath))
+          continue;
+        LongestMatch = GlobIt.getKey();
+        LongestWasNegative = IsNegative;
+      }
+    }
+    return !LongestMatch.empty() && !LongestWasNegative;
+  }
+
+private:
+  llvm::DenseMap<diag::kind, const Section*> DiagToSection;
+};
+
+void parseSuppressionMappings(const llvm::MemoryBuffer &MB,
+                              DiagnosticsEngine &Diags) {
+  std::string Err;
+  auto SCL = WarningsSpecialCaseList::create(MB, Err);
+  if (!SCL) {
+    Diags.Report(diag::err_drv_malformed_warning_suppression_mapping)
+        << MB.getBufferIdentifier() << Err;
+    return;
+  }
+  SCL->processSections(Diags);
+  Diags.setDiagSuppressionMapping(
+      [SCL(std::move(SCL))](diag::kind K, llvm::StringRef Path) {
+        return SCL->isDiagSuppressed(K, Path);
+      });
+}
+} // namespace
+
 void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
                                   const DiagnosticOptions &Opts,
+                                  llvm::vfs::FileSystem& VFS,
                                   bool ReportDiags) {
   Diags.setSuppressSystemWarnings(true);  // Default to -Wno-system-headers
   Diags.setIgnoreAllWarnings(Opts.IgnoreWarnings);
@@ -69,6 +168,14 @@ void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
     Diags.setExtensionHandlingBehavior(diag::Severity::Warning);
   else
     Diags.setExtensionHandlingBehavior(diag::Severity::Ignored);
+
+  if (!Opts.SuppressionMappingsFile.empty()) {
+    if (auto Buf = VFS.getBufferForFile(Opts.SuppressionMappingsFile)) {
+      parseSuppressionMappings(**Buf, Diags);
+    } else if (ReportDiags) {
+      Diags.Report(diag::err_drv_no_such_file) << Opts.SuppressionMappingsFile;
+    }
+  }
 
   SmallVector<diag::kind, 10> _Diags;
   const IntrusiveRefCntPtr< DiagnosticIDs > DiagIDs =

--- a/clang/lib/Basic/Warnings.cpp
+++ b/clang/lib/Basic/Warnings.cpp
@@ -46,7 +46,6 @@ static void EmitUnknownDiagWarning(DiagnosticsEngine &Diags,
       << (Prefix.str() += std::string(Suggestion));
 }
 
-
 void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
                                   const DiagnosticOptions &Opts,
                                   llvm::vfs::FileSystem &VFS,

--- a/clang/lib/Basic/Warnings.cpp
+++ b/clang/lib/Basic/Warnings.cpp
@@ -26,17 +26,11 @@
 #include "clang/Basic/DiagnosticDriver.h"
 #include "clang/Basic/DiagnosticIDs.h"
 #include "clang/Basic/DiagnosticOptions.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringMapEntry.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SpecialCaseList.h"
 #include "llvm/Support/VirtualFileSystem.h"
-#include <algorithm>
 #include <cstring>
 #include <memory>
-#include <utility>
 #include <vector>
 using namespace clang;
 
@@ -52,92 +46,6 @@ static void EmitUnknownDiagWarning(DiagnosticsEngine &Diags,
       << (Prefix.str() += std::string(Suggestion));
 }
 
-namespace {
-class WarningsSpecialCaseList : public llvm::SpecialCaseList {
-public:
-  static std::unique_ptr<WarningsSpecialCaseList>
-  create(const llvm::MemoryBuffer &MB, std::string &Err) {
-    auto SCL = std::make_unique<WarningsSpecialCaseList>();
-    if (SCL->createInternal(&MB, Err))
-      return SCL;
-    return nullptr;
-  }
-
-  // Section names refer to diagnostic groups, which cover multiple individual
-  // diagnostics. Expand diagnostic groups here to individual diagnostics.
-  // A diagnostic can have multiple diagnostic groups associated with it, we let
-  // the last section take precedence in such cases.
-  void processSections(DiagnosticsEngine &Diags) {
-    // Drop the default section introduced by special case list, we only support
-    // exact diagnostic group names.
-    Sections.erase("*");
-    // Make sure we iterate sections by their line numbers.
-    std::vector<std::pair<unsigned, const llvm::StringMapEntry<Section> *>>
-        LineAndSection;
-    for (const auto &Entry : Sections) {
-      LineAndSection.emplace_back(
-          Entry.second.SectionMatcher->Globs.at(Entry.first()).second, &Entry);
-    }
-    llvm::sort(LineAndSection);
-    for (const auto &[_, Entry] : LineAndSection) {
-      SmallVector<diag::kind, 256> GroupDiags;
-      if (Diags.getDiagnosticIDs()->getDiagnosticsInGroup(
-              clang::diag::Flavor::WarningOrError, Entry->first(),
-              GroupDiags)) {
-        EmitUnknownDiagWarning(Diags, clang::diag::Flavor::WarningOrError, "",
-                               Entry->first());
-        continue;
-      }
-      for (auto D : GroupDiags)
-        DiagToSection[D] = &Entry->getValue();
-    }
-  }
-
-  bool isDiagSuppressed(diag::kind D, llvm::StringRef FilePath) const {
-    auto Section = DiagToSection.find(D);
-    if (Section == DiagToSection.end())
-      return false;
-    auto SrcEntries = Section->second->Entries.find("src");
-    if (SrcEntries == Section->second->Entries.end())
-      return false;
-    // Find the longest glob pattern that matches FilePath. A positive match
-    // implies D should be suppressed for FilePath.
-    llvm::StringRef LongestMatch;
-    bool LongestWasNegative;
-    for (const auto &CatIt : SrcEntries->second) {
-      bool IsNegative = CatIt.first() == "emit";
-      for (const auto &GlobIt : CatIt.second.Globs) {
-        if (GlobIt.getKeyLength() < LongestMatch.size())
-          continue;
-        if (!GlobIt.second.first.match(FilePath))
-          continue;
-        LongestMatch = GlobIt.getKey();
-        LongestWasNegative = IsNegative;
-      }
-    }
-    return !LongestMatch.empty() && !LongestWasNegative;
-  }
-
-private:
-  llvm::DenseMap<diag::kind, const Section *> DiagToSection;
-};
-
-void parseSuppressionMappings(const llvm::MemoryBuffer &MB,
-                              DiagnosticsEngine &Diags) {
-  std::string Err;
-  auto SCL = WarningsSpecialCaseList::create(MB, Err);
-  if (!SCL) {
-    Diags.Report(diag::err_drv_malformed_warning_suppression_mapping)
-        << MB.getBufferIdentifier() << Err;
-    return;
-  }
-  SCL->processSections(Diags);
-  Diags.setDiagSuppressionMapping(
-      [SCL(std::move(SCL))](diag::kind K, llvm::StringRef Path) {
-        return SCL->isDiagSuppressed(K, Path);
-      });
-}
-} // namespace
 
 void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
                                   const DiagnosticOptions &Opts,
@@ -169,11 +77,13 @@ void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
   else
     Diags.setExtensionHandlingBehavior(diag::Severity::Ignored);
 
-  if (!Opts.SuppressionMappingsFile.empty()) {
-    if (auto Buf = VFS.getBufferForFile(Opts.SuppressionMappingsFile)) {
-      parseSuppressionMappings(**Buf, Diags);
+  if (!Opts.DiagnosticSuppressionMappingsFile.empty()) {
+    if (auto Buf =
+            VFS.getBufferForFile(Opts.DiagnosticSuppressionMappingsFile)) {
+      Diags.setDiagSuppressionMapping(**Buf);
     } else if (ReportDiags) {
-      Diags.Report(diag::err_drv_no_such_file) << Opts.SuppressionMappingsFile;
+      Diags.Report(diag::err_drv_no_such_file)
+          << Opts.DiagnosticSuppressionMappingsFile;
     }
   }
 

--- a/clang/lib/Basic/Warnings.cpp
+++ b/clang/lib/Basic/Warnings.cpp
@@ -98,7 +98,7 @@ public:
     if (Section == DiagToSection.end())
       return false;
     auto SrcEntries = Section->second->Entries.find("src");
-    if(SrcEntries == Section->second->Entries.end())
+    if (SrcEntries == Section->second->Entries.end())
       return false;
     // Find the longest glob pattern that matches FilePath. A positive match
     // implies D should be suppressed for FilePath.
@@ -119,7 +119,7 @@ public:
   }
 
 private:
-  llvm::DenseMap<diag::kind, const Section*> DiagToSection;
+  llvm::DenseMap<diag::kind, const Section *> DiagToSection;
 };
 
 void parseSuppressionMappings(const llvm::MemoryBuffer &MB,
@@ -141,7 +141,7 @@ void parseSuppressionMappings(const llvm::MemoryBuffer &MB,
 
 void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
                                   const DiagnosticOptions &Opts,
-                                  llvm::vfs::FileSystem& VFS,
+                                  llvm::vfs::FileSystem &VFS,
                                   bool ReportDiags) {
   Diags.setSuppressSystemWarnings(true);  // Default to -Wno-system-headers
   Diags.setIgnoreAllWarnings(Opts.IgnoreWarnings);

--- a/clang/lib/Basic/Warnings.cpp
+++ b/clang/lib/Basic/Warnings.cpp
@@ -77,9 +77,9 @@ void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
     Diags.setExtensionHandlingBehavior(diag::Severity::Ignored);
 
   if (!Opts.DiagnosticSuppressionMappingsFile.empty()) {
-    if (auto Buf =
+    if (auto FileContents =
             VFS.getBufferForFile(Opts.DiagnosticSuppressionMappingsFile)) {
-      Diags.setDiagSuppressionMapping(**Buf);
+      Diags.setDiagSuppressionMapping(**FileContents);
     } else if (ReportDiags) {
       Diags.Report(diag::err_drv_no_such_file)
           << Opts.DiagnosticSuppressionMappingsFile;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4514,6 +4514,13 @@ static void RenderDiagnosticsOptions(const Driver &D, const ArgList &Args,
 
   Args.addOptOutFlag(CmdArgs, options::OPT_fspell_checking,
                      options::OPT_fno_spell_checking);
+
+  if (const Arg *A =
+          Args.getLastArg(options::OPT_warning_suppression_mappings_EQ)) {
+    if (!D.getVFS().exists(A->getValue()))
+      D.Diag(clang::diag::err_drv_no_such_file) << A->getValue();
+    CmdArgs.push_back(Args.MakeArgString(A->getSpelling() + A->getValue()));
+  }
 }
 
 DwarfFissionKind tools::getDebugFissionKind(const Driver &D,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -44,6 +44,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Frontend/Debug/Options.h"
@@ -4515,12 +4516,7 @@ static void RenderDiagnosticsOptions(const Driver &D, const ArgList &Args,
   Args.addOptOutFlag(CmdArgs, options::OPT_fspell_checking,
                      options::OPT_fno_spell_checking);
 
-  if (const Arg *A =
-          Args.getLastArg(options::OPT_warning_suppression_mappings_EQ)) {
-    if (!D.getVFS().exists(A->getValue()))
-      D.Diag(clang::diag::err_drv_no_such_file) << A->getValue();
-    CmdArgs.push_back(Args.MakeArgString(A->getSpelling() + A->getValue()));
-  }
+  Args.addLastArg(CmdArgs, options::OPT_warning_suppression_mappings_EQ);
 }
 
 DwarfFissionKind tools::getDebugFissionKind(const Driver &D,

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1702,7 +1702,8 @@ bool ASTUnit::LoadFromCompilerInvocation(
   Invocation->getPreprocessorOpts().RetainRemappedFileBuffers = true;
   Invocation->getFrontendOpts().DisableFree = false;
   getDiagnostics().Reset();
-  ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts(), *VFS);
+  ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts(),
+                        *VFS);
 
   std::unique_ptr<llvm::MemoryBuffer> OverrideMainBuffer;
   if (PrecompilePreambleAfterNParses > 0) {
@@ -1710,7 +1711,8 @@ bool ASTUnit::LoadFromCompilerInvocation(
     OverrideMainBuffer =
         getMainBufferWithPrecompiledPreamble(PCHContainerOps, *Invocation, VFS);
     getDiagnostics().Reset();
-    ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts(), *VFS);
+    ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts(),
+                          *VFS);
   }
 
   SimpleTimer ParsingTimer(WantTiming);

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1367,7 +1367,7 @@ ASTUnit::getMainBufferWithPrecompiledPreamble(
       // after parsing the preamble.
       getDiagnostics().Reset();
       ProcessWarningOptions(getDiagnostics(),
-                            PreambleInvocationIn.getDiagnosticOpts());
+                            PreambleInvocationIn.getDiagnosticOpts(), *VFS);
       getDiagnostics().setNumWarnings(NumWarningsInPreamble);
 
       PreambleRebuildCountdown = 1;
@@ -1593,7 +1593,8 @@ ASTUnit *ASTUnit::LoadFromCompilerInvocationAction(
   // We'll manage file buffers ourselves.
   CI->getPreprocessorOpts().RetainRemappedFileBuffers = true;
   CI->getFrontendOpts().DisableFree = false;
-  ProcessWarningOptions(AST->getDiagnostics(), CI->getDiagnosticOpts());
+  ProcessWarningOptions(AST->getDiagnostics(), CI->getDiagnosticOpts(),
+                        AST->getFileManager().getVirtualFileSystem());
 
   // Create the compiler instance to use for building the AST.
   std::unique_ptr<CompilerInstance> Clang(
@@ -1701,7 +1702,7 @@ bool ASTUnit::LoadFromCompilerInvocation(
   Invocation->getPreprocessorOpts().RetainRemappedFileBuffers = true;
   Invocation->getFrontendOpts().DisableFree = false;
   getDiagnostics().Reset();
-  ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts());
+  ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts(), *VFS);
 
   std::unique_ptr<llvm::MemoryBuffer> OverrideMainBuffer;
   if (PrecompilePreambleAfterNParses > 0) {
@@ -1709,7 +1710,7 @@ bool ASTUnit::LoadFromCompilerInvocation(
     OverrideMainBuffer =
         getMainBufferWithPrecompiledPreamble(PCHContainerOps, *Invocation, VFS);
     getDiagnostics().Reset();
-    ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts());
+    ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts(), *VFS);
   }
 
   SimpleTimer ParsingTimer(WantTiming);
@@ -1902,7 +1903,8 @@ bool ASTUnit::Reparse(std::shared_ptr<PCHContainerOperations> PCHContainerOps,
   // Clear out the diagnostics state.
   FileMgr.reset();
   getDiagnostics().Reset();
-  ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts());
+  ProcessWarningOptions(getDiagnostics(), Invocation->getDiagnosticOpts(),
+                        *VFS);
   if (OverrideMainBuffer)
     getDiagnostics().setNumWarnings(NumWarningsInPreamble);
 
@@ -2241,7 +2243,8 @@ void ASTUnit::CodeComplete(
   CaptureDroppedDiagnostics Capture(CaptureDiagsKind::All,
                                     Clang->getDiagnostics(),
                                     &StoredDiagnostics, nullptr);
-  ProcessWarningOptions(Diag, Inv.getDiagnosticOpts());
+  ProcessWarningOptions(Diag, Inv.getDiagnosticOpts(),
+                        FileMgr.getVirtualFileSystem());
 
   // Create the target instance.
   if (!Clang->createTarget()) {

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -39,6 +39,7 @@
 #include "clang/Serialization/ASTReader.h"
 #include "clang/Serialization/GlobalModuleIndex.h"
 #include "clang/Serialization/InMemoryModuleCache.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/Statistic.h"
@@ -54,6 +55,7 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/Timer.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
 #include <optional>
@@ -332,18 +334,21 @@ static void SetupSerializedDiagnostics(DiagnosticOptions *DiagOpts,
 
 void CompilerInstance::createDiagnostics(DiagnosticConsumer *Client,
                                          bool ShouldOwnClient) {
-  Diagnostics = createDiagnostics(&getDiagnosticOpts(), Client,
-                                  ShouldOwnClient, &getCodeGenOpts());
+  Diagnostics = createDiagnostics(
+      &getDiagnosticOpts(), Client, ShouldOwnClient, &getCodeGenOpts(),
+      FileMgr ? FileMgr->getVirtualFileSystemPtr() : nullptr);
 }
 
-IntrusiveRefCntPtr<DiagnosticsEngine>
-CompilerInstance::createDiagnostics(DiagnosticOptions *Opts,
-                                    DiagnosticConsumer *Client,
-                                    bool ShouldOwnClient,
-                                    const CodeGenOptions *CodeGenOpts) {
+IntrusiveRefCntPtr<DiagnosticsEngine> CompilerInstance::createDiagnostics(
+    DiagnosticOptions *Opts, DiagnosticConsumer *Client, bool ShouldOwnClient,
+    const CodeGenOptions *CodeGenOpts,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS) {
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
   IntrusiveRefCntPtr<DiagnosticsEngine>
       Diags(new DiagnosticsEngine(DiagID, Opts));
+
+  if (!VFS)
+    VFS = llvm::vfs::getRealFileSystem();
 
   // Create the diagnostic client for reporting errors or for
   // implementing -verify.
@@ -367,7 +372,7 @@ CompilerInstance::createDiagnostics(DiagnosticOptions *Opts,
                                Opts->DiagnosticSerializationFile);
 
   // Configure our handling of diagnostics.
-  ProcessWarningOptions(*Diags, *Opts);
+  ProcessWarningOptions(*Diags, *Opts, *VFS);
 
   return Diags;
 }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2521,6 +2521,11 @@ void CompilerInvocationBase::GenerateDiagnosticArgs(
 
     Consumer(StringRef("-R") + Remark);
   }
+
+  if (!Opts.SuppressionMappingsFile.empty()) {
+    GenerateArg(Consumer, OPT_warning_suppression_mappings_EQ,
+                Opts.SuppressionMappingsFile);
+  }
 }
 
 std::unique_ptr<DiagnosticOptions>
@@ -2596,6 +2601,9 @@ bool clang::ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
         << Opts.TabStop << DiagnosticOptions::DefaultTabStop;
     Opts.TabStop = DiagnosticOptions::DefaultTabStop;
   }
+
+  if (const Arg *A = Args.getLastArg(OPT_warning_suppression_mappings_EQ))
+    Opts.SuppressionMappingsFile = A->getValue();
 
   addDiagnosticArgs(Args, OPT_W_Group, OPT_W_value_Group, Opts.Warnings);
   addDiagnosticArgs(Args, OPT_R_Group, OPT_R_value_Group, Opts.Remarks);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2522,9 +2522,9 @@ void CompilerInvocationBase::GenerateDiagnosticArgs(
     Consumer(StringRef("-R") + Remark);
   }
 
-  if (!Opts.SuppressionMappingsFile.empty()) {
+  if (!Opts.DiagnosticSuppressionMappingsFile.empty()) {
     GenerateArg(Consumer, OPT_warning_suppression_mappings_EQ,
-                Opts.SuppressionMappingsFile);
+                Opts.DiagnosticSuppressionMappingsFile);
   }
 }
 
@@ -2603,7 +2603,7 @@ bool clang::ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   }
 
   if (const Arg *A = Args.getLastArg(OPT_warning_suppression_mappings_EQ))
-    Opts.SuppressionMappingsFile = A->getValue();
+    Opts.DiagnosticSuppressionMappingsFile = A->getValue();
 
   addDiagnosticArgs(Args, OPT_W_Group, OPT_W_value_Group, Opts.Warnings);
   addDiagnosticArgs(Args, OPT_R_Group, OPT_R_value_Group, Opts.Remarks);

--- a/clang/lib/Frontend/PrecompiledPreamble.cpp
+++ b/clang/lib/Frontend/PrecompiledPreamble.cpp
@@ -479,7 +479,7 @@ llvm::ErrorOr<PrecompiledPreamble> PrecompiledPreamble::Build(
 
   // Clear out old caches and data.
   Diagnostics.Reset();
-  ProcessWarningOptions(Diagnostics, Clang->getDiagnosticOpts());
+  ProcessWarningOptions(Diagnostics, Clang->getDiagnosticOpts(), *VFS);
 
   VFS =
       createVFSFromCompilerInvocation(Clang->getInvocation(), Diagnostics, VFS);

--- a/clang/lib/Interpreter/CodeCompletion.cpp
+++ b/clang/lib/Interpreter/CodeCompletion.cpp
@@ -380,8 +380,8 @@ void ReplCodeCompleter::codeComplete(CompilerInstance *InterpCI,
   AU->CodeComplete(CodeCompletionFileName, 1, Col, RemappedFiles, false, false,
                    false, consumer,
                    std::make_shared<clang::PCHContainerOperations>(), *diag,
-                   InterpCI->getLangOpts(), InterpCI->getSourceManager(),
-                   InterpCI->getFileManager(), sd, tb, std::move(Act));
+                   InterpCI->getLangOpts(), AU->getSourceManager(),
+                   AU->getFileManager(), sd, tb, std::move(Act));
 }
 
 } // namespace clang

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -603,7 +603,9 @@ bool PCHValidator::ReadDiagnosticOptions(
       new DiagnosticsEngine(DiagIDs, DiagOpts.get()));
   // This should never fail, because we would have processed these options
   // before writing them to an ASTFile.
-  ProcessWarningOptions(*Diags, *DiagOpts, /*Report*/false);
+  ProcessWarningOptions(*Diags, *DiagOpts,
+                        PP.getFileManager().getVirtualFileSystem(),
+                        /*Report*/ false);
 
   ModuleManager &ModuleMgr = Reader.getModuleManager();
   assert(ModuleMgr.size() >= 1 && "what ASTFile is this then");

--- a/clang/test/Misc/Inputs/suppression-mapping.txt
+++ b/clang/test/Misc/Inputs/suppression-mapping.txt
@@ -1,0 +1,4 @@
+# Suppress unused warnings in all files, apart from the ones under `foo/`.
+[unused]
+src:*
+src:*foo/*=emit

--- a/clang/test/Misc/Inputs/suppression-mapping.txt
+++ b/clang/test/Misc/Inputs/suppression-mapping.txt
@@ -2,3 +2,8 @@
 [unused]
 src:*
 src:*foo/*=emit
+
+# Some warning groups can have strange spellings.
+[format=2]
+src:*
+src:*foo/*=emit

--- a/clang/test/Misc/Inputs/suppression-mapping.txt
+++ b/clang/test/Misc/Inputs/suppression-mapping.txt
@@ -3,6 +3,10 @@
 src:*
 src:*foo/*=emit
 
+# This should take precedence over `unused` group, as it's mentioned later.
+[unused-variable]
+# We don't suppress unused-variable warnings in "any" file.
+
 # Some warning groups can have strange spellings.
 [format=2]
 src:*

--- a/clang/test/Misc/warning-suppression-mappings-pragmas.cpp
+++ b/clang/test/Misc/warning-suppression-mappings-pragmas.cpp
@@ -1,0 +1,16 @@
+// Check that clang-diagnostic pragmas take precedence over suppression mapping.
+// RUN: %clang -cc1 -verify -Wformat=2 --warning-suppression-mappings=%S/Inputs/suppression-mapping.txt -fsyntax-only %s
+
+__attribute__((__format__ (__printf__, 1, 2)))
+void format_err(const char* const pString, ...);
+
+void foo() {
+  const char *x;
+  format_err(x); // Warning suppressed here.
+  // check that pragmas take precedence
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wformat=2"
+  format_err(x); // expected-warning{{format string is not a string literal (potentially insecure)}} \
+                 // expected-note{{treat the string as an argument to avoid this}}
+#pragma clang diagnostic pop
+}

--- a/clang/test/Misc/warning-suppression-mappings.cpp
+++ b/clang/test/Misc/warning-suppression-mappings.cpp
@@ -1,0 +1,16 @@
+// Check for warnings
+// RUN: not %clang --warning-suppression-mappings=foo.txt -fsyntax-only %s 2>&1 | FileCheck -check-prefix MISSING_MAPPING %s
+// RUN: not %clang -cc1 --warning-suppression-mappings=foo.txt -fsyntax-only %s 2>&1 | FileCheck -check-prefix MISSING_MAPPING %s
+// MISSING_MAPPING: error: no such file or directory: 'foo.txt'
+
+// Check that it's no-op when diagnostics aren't enabled.
+// RUN: %clang -cc1 -Werror --warning-suppression-mappings=%S/Inputs/suppression-mapping.txt -fsyntax-only %s 2>&1 | FileCheck -check-prefix WARNINGS_DISABLED --allow-empty %s
+// WARNINGS_DISABLED-NOT: warning:
+// WARNINGS_DISABLED-NOT: error:
+
+// RUN: %clang -cc1 -verify -Wunused --warning-suppression-mappings=%S/Inputs/suppression-mapping.txt -fsyntax-only %s
+
+namespace { void foo(); }
+
+#line 42 "foo/bar.h"
+namespace { void bar(); } // expected-warning{{unused function 'bar'}}

--- a/clang/test/Misc/warning-suppression-mappings.cpp
+++ b/clang/test/Misc/warning-suppression-mappings.cpp
@@ -4,13 +4,27 @@
 // MISSING_MAPPING: error: no such file or directory: 'foo.txt'
 
 // Check that it's no-op when diagnostics aren't enabled.
-// RUN: %clang -cc1 -Werror --warning-suppression-mappings=%S/Inputs/suppression-mapping.txt -fsyntax-only %s 2>&1 | FileCheck -check-prefix WARNINGS_DISABLED --allow-empty %s
+// RUN: %clang -cc1 -Wno-everything -Werror --warning-suppression-mappings=%S/Inputs/suppression-mapping.txt -fsyntax-only %s 2>&1 | FileCheck -check-prefix WARNINGS_DISABLED --allow-empty %s
 // WARNINGS_DISABLED-NOT: warning:
 // WARNINGS_DISABLED-NOT: error:
 
-// RUN: %clang -cc1 -verify -Wunused --warning-suppression-mappings=%S/Inputs/suppression-mapping.txt -fsyntax-only %s
+// RUN: %clang -cc1 -verify -Wformat=2 -Wunused --warning-suppression-mappings=%S/Inputs/suppression-mapping.txt -fsyntax-only %s
 
-namespace { void foo(); }
+__attribute__((__format__ (__printf__, 1, 2)))
+void format_err(const char* const pString, ...);
+
+namespace {
+void foo() {
+  const char *x;
+  format_err(x); // Warning suppressed here.
+}
+}
 
 #line 42 "foo/bar.h"
-namespace { void bar(); } // expected-warning{{unused function 'bar'}}
+namespace {
+void bar() { // expected-warning{{unused function 'bar'}}
+  const char *x;
+  format_err(x); // expected-warning{{format string is not a string literal (potentially insecure)}} \
+                 // expected-note{{treat the string as an argument to avoid this}}
+}
+}

--- a/clang/test/Misc/warning-suppression-mappings.cpp
+++ b/clang/test/Misc/warning-suppression-mappings.cpp
@@ -17,6 +17,7 @@ namespace {
 void foo() {
   const char *x;
   format_err(x); // Warning suppressed here.
+  const char *y; // expected-warning{{unused variable 'y'}}
 }
 }
 

--- a/clang/tools/driver/cc1gen_reproducer_main.cpp
+++ b/clang/tools/driver/cc1gen_reproducer_main.cpp
@@ -121,9 +121,10 @@ generateReproducerForInvocationArguments(ArrayRef<const char *> Argv,
 
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
   DiagnosticsEngine Diags(DiagID, &*DiagOpts, new IgnoringDiagConsumer());
-  ProcessWarningOptions(Diags, *DiagOpts, /*ReportDiags=*/false);
-  Driver TheDriver(ToolContext.Path, llvm::sys::getDefaultTargetTriple(),
-                   Diags);
+  auto VFS = llvm::vfs::getRealFileSystem();
+  ProcessWarningOptions(Diags, *DiagOpts, *VFS, /*ReportDiags=*/false);
+  Driver TheDriver(ToolContext.Path, llvm::sys::getDefaultTargetTriple(), Diags,
+                   /*Title=*/"clang LLVM compiler", VFS);
   TheDriver.setTargetAndMode(TargetAndMode);
   if (ToolContext.NeedsPrependArg)
     TheDriver.setPrependArg(ToolContext.PrependArg);

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Support/StringSaver.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
 #include <memory>
@@ -334,9 +335,11 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
         Diags.takeClient(), std::move(SerializedConsumer)));
   }
 
-  ProcessWarningOptions(Diags, *DiagOpts, /*ReportDiags=*/false);
+  auto VFS = llvm::vfs::getRealFileSystem();
+  ProcessWarningOptions(Diags, *DiagOpts, *VFS, /*ReportDiags=*/false);
 
-  Driver TheDriver(Path, llvm::sys::getDefaultTargetTriple(), Diags);
+  Driver TheDriver(Path, llvm::sys::getDefaultTargetTriple(), Diags,
+                   /*Title=*/"clang LLVM compiler", VFS);
   auto TargetAndMode = ToolChain::getTargetAndModeFromProgramName(ProgName);
   TheDriver.setTargetAndMode(TargetAndMode);
   // If -canonical-prefixes is set, GetExecutablePath will have resolved Path

--- a/clang/unittests/Basic/DiagnosticTest.cpp
+++ b/clang/unittests/Basic/DiagnosticTest.cpp
@@ -195,7 +195,7 @@ protected:
 private:
   class CaptureDiagnosticConsumer : public DiagnosticConsumer {
   public:
-   std::vector<StoredDiagnostic> StoredDiags;
+    std::vector<StoredDiagnostic> StoredDiags;
 
     void HandleDiagnostic(DiagnosticsEngine::Level level,
                           const Diagnostic &Info) override {

--- a/clang/unittests/Basic/DiagnosticTest.cpp
+++ b/clang/unittests/Basic/DiagnosticTest.cpp
@@ -223,7 +223,7 @@ TEST_F(SuppressionMappingTest, MalformedFile) {
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
   EXPECT_THAT(takeDiags(), testing::ElementsAre(WithMessage(
                                "failed to process suppression mapping file "
-                               "'foo.txt' : malformed line 1: 'asdf'")));
+                               "'foo.txt': malformed line 1: 'asdf'")));
 }
 
 TEST_F(SuppressionMappingTest, UnknownDiagName) {

--- a/clang/unittests/Basic/DiagnosticTest.cpp
+++ b/clang/unittests/Basic/DiagnosticTest.cpp
@@ -210,14 +210,14 @@ MATCHER_P(WithMessage, Msg, "has diagnostic message") {
 }
 
 TEST_F(SuppressionMappingTest, MissingMappingFile) {
-  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().DiagnosticSuppressionMappingsFile = "foo.txt";
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
   EXPECT_THAT(takeDiags(), testing::ElementsAre(WithMessage(
                                "no such file or directory: 'foo.txt'")));
 }
 
 TEST_F(SuppressionMappingTest, MalformedFile) {
-  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().DiagnosticSuppressionMappingsFile = "foo.txt";
   FS->addFile("foo.txt", /*ModificationTime=*/{},
               llvm::MemoryBuffer::getMemBuffer("asdf", "foo.txt"));
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
@@ -227,7 +227,7 @@ TEST_F(SuppressionMappingTest, MalformedFile) {
 }
 
 TEST_F(SuppressionMappingTest, UnknownDiagName) {
-  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().DiagnosticSuppressionMappingsFile = "foo.txt";
   FS->addFile("foo.txt", /*ModificationTime=*/{},
               llvm::MemoryBuffer::getMemBuffer("[non-existing-warning]"));
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
@@ -241,7 +241,7 @@ TEST_F(SuppressionMappingTest, SuppressesGroup) {
   [unused]
   src:*
   )txt";
-  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().DiagnosticSuppressionMappingsFile = "foo.txt";
   FS->addFile("foo.txt", /*ModificationTime=*/{},
               llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
@@ -258,7 +258,7 @@ TEST_F(SuppressionMappingTest, ExclusionsWork) {
   src:*
   src:*foo.cpp=emit
   )txt";
-  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().DiagnosticSuppressionMappingsFile = "foo.txt";
   FS->addFile("foo.txt", /*ModificationTime=*/{},
               llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
@@ -277,7 +277,7 @@ TEST_F(SuppressionMappingTest, LongestMatchWins) {
   src:*clang/lib/Sema/*=emit
   src:*clang/lib/Sema/foo*
   )txt";
-  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().DiagnosticSuppressionMappingsFile = "foo.txt";
   FS->addFile("foo.txt", /*ModificationTime=*/{},
               llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
@@ -296,7 +296,7 @@ TEST_F(SuppressionMappingTest, IsIgnored) {
   [unused]
   src:*clang/*
   )txt";
-  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().DiagnosticSuppressionMappingsFile = "foo.txt";
   Diags.getDiagnosticOptions().Warnings = {"unused"};
   FS->addFile("foo.txt", /*ModificationTime=*/{},
               llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));

--- a/clang/unittests/Basic/DiagnosticTest.cpp
+++ b/clang/unittests/Basic/DiagnosticTest.cpp
@@ -10,8 +10,17 @@
 #include "clang/Basic/DiagnosticError.h"
 #include "clang/Basic/DiagnosticIDs.h"
 #include "clang/Basic/DiagnosticLex.h"
+#include "clang/Basic/DiagnosticSema.h"
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <optional>
+#include <vector>
 
 using namespace llvm;
 using namespace clang;
@@ -167,4 +176,159 @@ TEST(DiagnosticTest, storedDiagEmptyWarning) {
   // Make sure an empty warning can round-trip with \c StoredDiagnostic.
   Diags.Report(CaptureConsumer.StoredDiags.front());
 }
+
+class SuppressionMappingTest : public testing::Test {
+public:
+  SuppressionMappingTest() {
+    Diags.setClient(&CaptureConsumer, /*ShouldOwnClient=*/false);
+  }
+
+protected:
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> FS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  DiagnosticsEngine Diags{new DiagnosticIDs(), new DiagnosticOptions};
+
+  std::vector<StoredDiagnostic> takeDiags() {
+    return std::move(CaptureConsumer.StoredDiags);
+  }
+
+private:
+  class CaptureDiagnosticConsumer : public DiagnosticConsumer {
+  public:
+   std::vector<StoredDiagnostic> StoredDiags;
+
+    void HandleDiagnostic(DiagnosticsEngine::Level level,
+                          const Diagnostic &Info) override {
+      StoredDiags.push_back(StoredDiagnostic(level, Info));
+    }
+  };
+  CaptureDiagnosticConsumer CaptureConsumer;
+};
+
+MATCHER_P(WithMessage, Msg, "has diagnostic message") {
+  return arg.getMessage() == Msg;
 }
+
+TEST_F(SuppressionMappingTest, MissingMappingFile) {
+  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
+  EXPECT_THAT(takeDiags(), testing::ElementsAre(WithMessage(
+                               "no such file or directory: 'foo.txt'")));
+}
+
+TEST_F(SuppressionMappingTest, MalformedFile) {
+  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  FS->addFile("foo.txt", /*ModificationTime=*/{},
+              llvm::MemoryBuffer::getMemBuffer("asdf", "foo.txt"));
+  clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
+  EXPECT_THAT(takeDiags(), testing::ElementsAre(WithMessage(
+                               "failed to process suppression mapping file "
+                               "'foo.txt' : malformed line 1: 'asdf'")));
+}
+
+TEST_F(SuppressionMappingTest, UnknownDiagName) {
+  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  FS->addFile("foo.txt", /*ModificationTime=*/{},
+              llvm::MemoryBuffer::getMemBuffer("[non-existing-warning]"));
+  clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
+  EXPECT_THAT(takeDiags(),
+              testing::ElementsAre(WithMessage(
+                  "unknown warning option 'non-existing-warning'")));
+}
+
+TEST_F(SuppressionMappingTest, SuppressesGroup) {
+  llvm::StringLiteral SuppressionMappingFile = R"txt(
+  [unused]
+  src:*
+  )txt";
+  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  FS->addFile("foo.txt", /*ModificationTime=*/{},
+              llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));
+  clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
+  EXPECT_THAT(takeDiags(), testing::IsEmpty());
+
+  EXPECT_TRUE(
+      Diags.isSuppressedViaMapping(diag::warn_unused_function, "foo.cpp"));
+  EXPECT_FALSE(Diags.isSuppressedViaMapping(diag::warn_deprecated, "foo.cpp"));
+}
+
+TEST_F(SuppressionMappingTest, ExclusionsWork) {
+  llvm::StringLiteral SuppressionMappingFile = R"txt(
+  [unused]
+  src:*
+  src:*foo.cpp=emit
+  )txt";
+  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  FS->addFile("foo.txt", /*ModificationTime=*/{},
+              llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));
+  clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
+  EXPECT_THAT(takeDiags(), testing::IsEmpty());
+
+  EXPECT_TRUE(
+      Diags.isSuppressedViaMapping(diag::warn_unused_function, "bar.cpp"));
+  EXPECT_FALSE(
+      Diags.isSuppressedViaMapping(diag::warn_unused_function, "foo.cpp"));
+}
+
+TEST_F(SuppressionMappingTest, LongestMatchWins) {
+  llvm::StringLiteral SuppressionMappingFile = R"txt(
+  [unused]
+  src:*clang/*
+  src:*clang/lib/Sema/*=emit
+  src:*clang/lib/Sema/foo*
+  )txt";
+  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  FS->addFile("foo.txt", /*ModificationTime=*/{},
+              llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));
+  clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
+  EXPECT_THAT(takeDiags(), testing::IsEmpty());
+
+  EXPECT_TRUE(Diags.isSuppressedViaMapping(diag::warn_unused_function,
+                                           "clang/lib/Basic/foo.h"));
+  EXPECT_FALSE(Diags.isSuppressedViaMapping(diag::warn_unused_function,
+                                            "clang/lib/Sema/bar.h"));
+  EXPECT_TRUE(Diags.isSuppressedViaMapping(diag::warn_unused_function,
+                                           "clang/lib/Sema/foo.h"));
+}
+
+TEST_F(SuppressionMappingTest, IsIgnored) {
+  llvm::StringLiteral SuppressionMappingFile = R"txt(
+  [unused]
+  src:*clang/*
+  )txt";
+  Diags.getDiagnosticOptions().SuppressionMappingsFile = "foo.txt";
+  Diags.getDiagnosticOptions().Warnings = {"unused"};
+  FS->addFile("foo.txt", /*ModificationTime=*/{},
+              llvm::MemoryBuffer::getMemBuffer(SuppressionMappingFile));
+  clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
+  EXPECT_THAT(takeDiags(), testing::IsEmpty());
+
+  FileManager FM({}, FS);
+  SourceManager SM(Diags, FM);
+
+  auto ClangID =
+      SM.createFileID(llvm::MemoryBuffer::getMemBuffer("", "clang/foo.h"));
+  auto NonClangID =
+      SM.createFileID(llvm::MemoryBuffer::getMemBuffer("", "llvm/foo.h"));
+  auto PresumedClangID =
+      SM.createFileID(llvm::MemoryBuffer::getMemBuffer("", "llvm/foo2.h"));
+  // Add a line directive to point into clang/foo.h
+  SM.AddLineNote(SM.getLocForStartOfFile(PresumedClangID), 42,
+                 SM.getLineTableFilenameID("clang/foo.h"), false, false,
+                 clang::SrcMgr::C_User);
+
+  EXPECT_TRUE(Diags.isIgnored(diag::warn_unused_function,
+                              SM.getLocForStartOfFile(ClangID)));
+  EXPECT_FALSE(Diags.isIgnored(diag::warn_unused_function,
+                               SM.getLocForStartOfFile(NonClangID)));
+  EXPECT_TRUE(Diags.isIgnored(diag::warn_unused_function,
+                              SM.getLocForStartOfFile(PresumedClangID)));
+
+  // Pretend we have a clang-diagnostic pragma to enforce the warning. Make sure
+  // suppressing mapping doesn't take over.
+  Diags.setSeverity(diag::warn_unused_function, diag::Severity::Error,
+                    SM.getLocForStartOfFile(ClangID));
+  EXPECT_FALSE(Diags.isIgnored(diag::warn_unused_function,
+                               SM.getLocForStartOfFile(ClangID)));
+}
+} // namespace

--- a/clang/unittests/Frontend/CompilerInvocationTest.cpp
+++ b/clang/unittests/Frontend/CompilerInvocationTest.cpp
@@ -1046,4 +1046,14 @@ TEST_F(CommandLineTest, PluginArgsRoundTripDeterminism) {
 
   ASSERT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
 }
+
+TEST_F(CommandLineTest, WarningSuppressionMappings) {
+  const char *Args[] = {"--warning-suppression-mappings=foo.txt"};
+
+  EXPECT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
+  EXPECT_EQ(Invocation.getDiagnosticOpts().SuppressionMappingsFile, "foo.txt");
+
+  Invocation.generateCC1CommandLine(GeneratedArgs, *this);
+  EXPECT_THAT(GeneratedArgs, Contains(StrEq(Args[0])));
+}
 } // anonymous namespace

--- a/clang/unittests/Frontend/CompilerInvocationTest.cpp
+++ b/clang/unittests/Frontend/CompilerInvocationTest.cpp
@@ -1051,7 +1051,8 @@ TEST_F(CommandLineTest, WarningSuppressionMappings) {
   const char *Args[] = {"--warning-suppression-mappings=foo.txt"};
 
   EXPECT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
-  EXPECT_EQ(Invocation.getDiagnosticOpts().SuppressionMappingsFile, "foo.txt");
+  EXPECT_EQ(Invocation.getDiagnosticOpts().DiagnosticSuppressionMappingsFile,
+            "foo.txt");
 
   Invocation.generateCC1CommandLine(GeneratedArgs, *this);
   EXPECT_THAT(GeneratedArgs, Contains(StrEq(Args[0])));

--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -122,7 +122,6 @@ protected:
     // Returns zero if no match is found.
     unsigned match(StringRef Query) const;
 
-  private:
     StringMap<std::pair<GlobPattern, unsigned>> Globs;
     std::vector<std::pair<std::unique_ptr<Regex>, unsigned>> RegExes;
   };


### PR DESCRIPTION
This implements
https://discourse.llvm.org/t/rfc-add-support-for-controlling-diagnostics-severities-at-file-level-granularity-through-command-line/81292.

Users now can suppress warnings for certain headers by providing a
mapping with globs, a sample file looks like:
```
[unused]
src:*
src:*clang/*=emit
```

This will suppress warnings from `-Wunused` group in all files that
aren't under `clang/` directory. This mapping file can be passed to
clang via `--warning-suppression-mappings=foo.txt`.

At a high level, mapping file is stored in DiagnosticOptions and then
processed with rest of the warning flags when creating a
DiagnosticsEngine. This is a functor that uses SpecialCaseLists
underneath to match against globs coming from the mappings file.

This implies processing warning options now performs IO, relevant
interfaces are updated to take in a VFS, falling back to RealFileSystem
when one is not available.
