### PR TITLE
[lldb][test] Explicitly add target triple to no_unique_address Shell tests

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/x86/no_unique_address-alignment.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/no_unique_address-alignment.cpp
@@ -1,6 +1,6 @@
 // XFAIL: *
 
-// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %clang --target=x86_64-apple-macosx -c -gdwarf -o %t %s
 // RUN: %lldb %t \
 // RUN:   -o "expr alignof(OverlappingFields)" \
 // RUN:   -o "expr sizeof(OverlappingFields)" \

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/no_unique_address-base-alignment.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/no_unique_address-base-alignment.cpp
@@ -1,6 +1,6 @@
 // XFAIL: *
 
-// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %clang --target=x86_64-apple-macosx -c -gdwarf -o %t %s
 // RUN: %lldb %t \
 // RUN:   -o "expr alignof(OverlappingDerived)" \
 // RUN:   -o "expr sizeof(OverlappingDerived)" \


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/111902.

Makes sure all the `no_unique_address` tests are in the same place and we don't rely on the host target triple (which means we don't need to account for `[[msvc::no_unique_address]]` on Windows).

Now that we don't compile with the host compiler, this patch also adds `-c` to the compilation command since we don't actually need the linked binary in the test anyway (and on Darwin linking through Clang requires the `xcrun` prefix to set up the SDK paths, etc.). We already do this in `no_unique_address-with-bitfields.cpp` anyway.