### PR TITLE
[LLD][COFF] Support anti-dependency symbols

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -737,7 +737,7 @@ StringRef LinkerDriver::mangleMaybe(Symbol *s) {
   // If we find a similar mangled symbol, make this an alias to it and return
   // its name.
   log(unmangled->getName() + " aliased to " + mangled->getName());
-  unmangled->weakAlias = ctx.symtab.addUndefined(mangled->getName());
+  unmangled->setWeakAlias(ctx.symtab.addUndefined(mangled->getName()));
   return mangled->getName();
 }
 
@@ -2520,7 +2520,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
           continue;
         if (auto *u = dyn_cast<Undefined>(sym))
           if (!u->weakAlias)
-            u->weakAlias = ctx.symtab.addUndefined(to);
+            u->setWeakAlias(ctx.symtab.addUndefined(to));
       }
 
       // If any inputs are bitcode files, the LTO code generator may create

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -315,7 +315,7 @@ void SymbolTable::loadMinGWSymbols() {
             warn("Resolving " + origName + " by linking to " + newName);
           else
             log("Resolving " + origName + " by linking to " + newName);
-          undef->weakAlias = l;
+          undef->setWeakAlias(l);
           continue;
         }
       }

--- a/lld/COFF/Symbols.h
+++ b/lld/COFF/Symbols.h
@@ -100,7 +100,7 @@ protected:
       : symbolKind(k), isExternal(true), isCOMDAT(false),
         writtenToSymtab(false), isUsedInRegularObj(false),
         pendingArchiveLoad(false), isGCRoot(false), isRuntimePseudoReloc(false),
-        deferUndefined(false), canInline(true), isWeak(false),
+        deferUndefined(false), canInline(true), isWeak(false), isAntiDep(false),
         nameSize(n.size()), nameData(n.empty() ? nullptr : n.data()) {
     assert((!n.empty() || k <= LastDefinedCOFFKind) &&
            "If the name is empty, the Symbol must be a DefinedCOFF.");
@@ -144,6 +144,9 @@ public:
   // This information isn't written to the output; rather, it's used for
   // managing weak symbol overrides.
   unsigned isWeak : 1;
+
+  // True if the symbol is an anti-dependency.
+  unsigned isAntiDep : 1;
 
 protected:
   // Symbol name length. Assume symbol lengths fit in a 32-bit integer.
@@ -343,6 +346,11 @@ public:
   Symbol *getWeakAlias();
   Defined *getDefinedWeakAlias() {
     return dyn_cast_or_null<Defined>(getWeakAlias());
+  }
+
+  void setWeakAlias(Symbol *sym, bool antiDep = false) {
+    weakAlias = sym;
+    isAntiDep = antiDep;
   }
 
   // If this symbol is external weak, replace this object with aliased symbol.

--- a/lld/test/COFF/weak-antidep-chain.test
+++ b/lld/test/COFF/weak-antidep-chain.test
@@ -1,0 +1,68 @@
+REQUIRES: x86
+RUN: split-file %s %t.dir && cd %t.dir
+
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows chain-bad.s -o chain-bad.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows chain-bad2.s -o chain-bad2.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows globals-bad.s -o globals-bad.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows chain-good.s -o chain-good.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows chain-good2.s -o chain-good2.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows globals-good.s -o globals-good.obj
+
+Temporary anti-dependency chains are allowed as long as they are broken by non-alias symbols.
+
+RUN: lld-link -machine:amd64 -dll -noentry -out:test.dll chain-good.obj globals-good.obj
+RUN: lld-link -machine:amd64 -dll -noentry -out:test.dll chain-good2.obj globals-good.obj
+
+Chaining of anti-dependency symbols is not allowed.
+
+RUN: not lld-link -machine:amd64 -dll -noentry -out:test.dll chain-bad.obj globals-bad.obj 2>&1 \
+RUN:              | FileCheck -check-prefix=ANTIDEP %s
+RUN: not lld-link -machine:amd64 -dll -noentry -out:test.dll chain-bad2.obj globals-bad.obj 2>&1 \
+RUN:              | FileCheck -check-prefix=ANTIDEP %s
+
+ANTIDEP:      lld-link: error: undefined symbol: sym
+ANTIDEP-NEXT: >>> referenced by chain-bad
+
+#--- chain-bad.s
+    .weak_anti_dep sym
+.set sym,sym2
+    .weak_anti_dep sym2
+.set sym2,sym3
+
+#--- chain-bad2.s
+    .weak_anti_dep sym2
+.set sym2,sym3
+    .weak sym
+.set sym,sym2
+
+#--- globals-bad.s
+    .section .test,"r"
+    .global sym3
+.set sym3,3
+
+#--- chain-good.s
+    .weak_anti_dep sym
+.set sym,sym2
+    .weak_anti_dep sym2
+.set sym2,sym3
+    .weak_anti_dep sym3
+.set sym3,sym4
+    .weak_anti_dep sym4
+
+#--- chain-good2.s
+    .weak_anti_dep sym
+.set sym,sym2
+    .weak_anti_dep sym2
+.set sym2,sym3
+    .weak_anti_dep sym3
+.set sym3,weak_sym
+    .weak weak_sym
+.set weak_sym,sym4
+    .weak_anti_dep sym4
+
+#--- globals-good.s
+    .section .test,"r"
+    .global sym2
+.set sym2,2
+    .global sym4
+.set sym4,4

--- a/lld/test/COFF/weak-antidep.test
+++ b/lld/test/COFF/weak-antidep.test
@@ -1,0 +1,54 @@
+REQUIRES: x86
+RUN: split-file %s %t.dir && cd %t.dir
+
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows antidep.s -o antidep.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows antidep2.s -o antidep2.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows weak.s -o weak.obj
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows test.s -o test.obj
+
+Check that a regular weak alias overrides an anti-dependency symbol.
+
+RUN: lld-link -dll -noentry -out:out1.dll antidep.obj weak.obj test.obj
+RUN: llvm-readobj --hex-dump=.test out1.dll | FileCheck --check-prefix=CHECK2 %s
+
+RUN: lld-link -dll -noentry -out:out2.dll weak.obj antidep.obj test.obj
+RUN: llvm-readobj --hex-dump=.test out2.dll | FileCheck --check-prefix=CHECK2 %s
+
+RUN: lld-link -dll -noentry -out:out3.dll antidep.obj weak.obj test.obj -lld-allow-duplicate-weak
+RUN: llvm-readobj --hex-dump=.test out3.dll | FileCheck --check-prefix=CHECK2 %s
+
+RUN: lld-link -dll -noentry -out:out4.dll weak.obj antidep.obj test.obj -lld-allow-duplicate-weak
+RUN: llvm-readobj --hex-dump=.test out4.dll | FileCheck --check-prefix=CHECK2 %s
+
+When an anti-dependency symbol is duplicated, the first definition takes precedence over subsequent ones.
+
+RUN: lld-link -dll -noentry -out:out5.dll antidep.obj antidep2.obj test.obj
+RUN: llvm-readobj --hex-dump=.test out5.dll | FileCheck --check-prefix=CHECK1 %s
+
+RUN: lld-link -dll -noentry -out:out6.dll antidep2.obj antidep.obj test.obj
+RUN: llvm-readobj --hex-dump=.test out6.dll | FileCheck --check-prefix=CHECK2 %s
+
+CHECK1: 01000000
+CHECK2: 02000000
+
+#--- antidep.s
+     .weak_anti_dep sym
+.set sym,target1
+
+#--- antidep2.s
+     .weak_anti_dep sym
+.set sym,target2
+
+#--- weak.s
+     .weak sym
+.set sym,target2
+
+#--- test.s
+     .section .target,"dr"
+     .globl target1
+.set target1,1
+     .globl target2
+.set target2,2
+
+     .section .test,"dr"
+     .long sym


### PR DESCRIPTION
Co-authored-by: Billy Laws

Anti-dependency symbols are allowed to be duplicated, with the first definition taking precedence. If a regular weak alias is present, it is preferred over an anti-dependency definition. Chaining anti-dependencies is not allowed.