### PR TITLE
[lldb] add --platform-available-ports option to the dotest.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -103,6 +103,7 @@ failed = False
 lldb_platform_name = None
 lldb_platform_url = None
 lldb_platform_working_dir = None
+lldb_platform_available_ports = None
 
 # Apple SDK
 apple_sdk = None

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -419,6 +419,8 @@ def parseOptionsAndInitTestdirs():
         configuration.lldb_platform_url = args.lldb_platform_url
     if args.lldb_platform_working_dir:
         configuration.lldb_platform_working_dir = args.lldb_platform_working_dir
+    if args.lldb_platform_available_ports:
+        configuration.lldb_platform_available_ports = args.lldb_platform_available_ports
     if platform_system == "Darwin" and args.apple_sdk:
         configuration.apple_sdk = args.apple_sdk
     if args.test_build_dir:

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -292,6 +292,13 @@ def create_parser():
         metavar="platform-working-dir",
         help="The directory to use on the remote platform.",
     )
+    group.add_argument(
+        "--platform-available-ports",
+        dest="lldb_platform_available_ports",
+        type=lambda ports: [int(port.strip()) for port in ports.split(":")],
+        metavar="platform-available-ports",
+        help="Ports available for connection to a lldb server on the remote platform",
+    )
 
     # Test-suite behaviour
     group = parser.add_argument_group("Runtime behaviour options")

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -295,7 +295,7 @@ def create_parser():
     group.add_argument(
         "--platform-available-ports",
         dest="lldb_platform_available_ports",
-        type=lambda ports: [int(port.strip()) for port in ports.split(":")],
+        nargs="*",
         metavar="platform-available-ports",
         help="Ports available for connection to a lldb server on the remote platform",
     )

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -296,6 +296,7 @@ def create_parser():
         "--platform-available-ports",
         dest="lldb_platform_available_ports",
         nargs="*",
+        type=int,
         metavar="platform-available-ports",
         help="Ports available for connection to a lldb server on the remote platform",
     )

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -749,6 +749,10 @@ class Base(unittest.TestCase):
         """Return absolute path to a file in the test's source directory."""
         return os.path.join(self.getSourceDir(), name)
 
+    def getPlatformAvailablePorts(self):
+        """Return ports available for connection to a lldb server on the remote platform."""
+        return configuration.lldb_platform_available_ports
+
     @classmethod
     def setUpCommands(cls):
         commands = [

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -185,9 +185,8 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
             ]
 
     def get_next_port(self):
-        available_ports = self.getPlatformAvailablePorts()
-        if available_ports:
-            return random.choice(available_ports)
+        if available_ports := self.getPlatformAvailablePorts():
+            return int(random.choice(available_ports))
         return 12000 + random.randint(0, 7999)
 
     def reset_test_sequence(self):

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -185,6 +185,9 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
             ]
 
     def get_next_port(self):
+        available_ports = self.getPlatformAvailablePorts()
+        if available_ports:
+            return random.choice(available_ports)
         return 12000 + random.randint(0, 7999)
 
     def reset_test_sequence(self):

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -186,7 +186,7 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
 
     def get_next_port(self):
         if available_ports := self.getPlatformAvailablePorts():
-            return int(random.choice(available_ports))
+            return random.choice(available_ports)
         return 12000 + random.randint(0, 7999)
 
     def reset_test_sequence(self):


### PR DESCRIPTION
This patch adds --platform-available-ports option to the dotest.py script to avoid hardcoded gdb ports in lldb testsuite.

Currently, this option could be helpful in GdbRemoteTestCases (e.g. TestLldbGdbServer, TestNonStop, TestGdbRemoteThreadsInStopReply, TestGdbRemotePlatformFile, TestGdbRemote_vCont)