### PR TITLE
[Minidump] Add extern template declarations for MinidumpFile::getListStream

### DIFF
--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -15,15 +15,9 @@
 #include "llvm/ADT/iterator.h"
 #include "llvm/BinaryFormat/Minidump.h"
 #include "llvm/Object/Binary.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
-namespace minidump {
-struct Module;
-struct Thread;
-struct MemoryDescriptor;
-} // namespace minidump
 namespace object {
 
 /// A class providing access to the contents of a minidump file.
@@ -377,13 +371,27 @@ Expected<ArrayRef<T>> MinidumpFile::getDataSliceAs(ArrayRef<uint8_t> Data,
   return ArrayRef<T>(reinterpret_cast<const T *>(Slice->data()), Count);
 }
 
-// Needed by MinidumpTest.cpp
-extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<minidump::Module>>
-    MinidumpFile::getListStream(minidump::StreamType) const;
-extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<minidump::Thread>>
-    MinidumpFile::getListStream(minidump::StreamType) const;
-extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<minidump::MemoryDescriptor>>
-    MinidumpFile::getListStream(minidump::StreamType) const;
+template <typename T>
+Expected<ArrayRef<T>>
+MinidumpFile::getListStream(minidump::StreamType Type) const {
+  std::optional<ArrayRef<uint8_t>> Stream = getRawStream(Type);
+  if (!Stream)
+    return createError("No such stream");
+  auto ExpectedSize = getDataSliceAs<support::ulittle32_t>(*Stream, 0, 1);
+  if (!ExpectedSize)
+    return ExpectedSize.takeError();
+
+  size_t ListSize = ExpectedSize.get()[0];
+
+  size_t ListOffset = 4;
+  // Some producers insert additional padding bytes to align the list to an
+  // 8-byte boundary. Check for that by comparing the list size with the overall
+  // stream size.
+  if (ListOffset + sizeof(T) * ListSize < Stream->size())
+    ListOffset = 8;
+
+  return getDataSliceAs<T>(*Stream, ListOffset, ListSize);
+}
 
 } // end namespace object
 } // end namespace llvm

--- a/llvm/include/llvm/Object/Minidump.h
+++ b/llvm/include/llvm/Object/Minidump.h
@@ -15,9 +15,15 @@
 #include "llvm/ADT/iterator.h"
 #include "llvm/BinaryFormat/Minidump.h"
 #include "llvm/Object/Binary.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
+namespace minidump {
+struct Module;
+struct Thread;
+struct MemoryDescriptor;
+} // namespace minidump
 namespace object {
 
 /// A class providing access to the contents of a minidump file.
@@ -370,6 +376,14 @@ Expected<ArrayRef<T>> MinidumpFile::getDataSliceAs(ArrayRef<uint8_t> Data,
 
   return ArrayRef<T>(reinterpret_cast<const T *>(Slice->data()), Count);
 }
+
+// Needed by MinidumpTest.cpp
+extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<minidump::Module>>
+    MinidumpFile::getListStream(minidump::StreamType) const;
+extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<minidump::Thread>>
+    MinidumpFile::getListStream(minidump::StreamType) const;
+extern template LLVM_TEMPLATE_ABI Expected<ArrayRef<minidump::MemoryDescriptor>>
+    MinidumpFile::getListStream(minidump::StreamType) const;
 
 } // end namespace object
 } // end namespace llvm

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -78,33 +78,6 @@ MinidumpFile::getMemoryInfoList() const {
                     MemoryInfoIterator({}, H.SizeOfEntry));
 }
 
-template <typename T>
-Expected<ArrayRef<T>> MinidumpFile::getListStream(StreamType Type) const {
-  std::optional<ArrayRef<uint8_t>> Stream = getRawStream(Type);
-  if (!Stream)
-    return createError("No such stream");
-  auto ExpectedSize = getDataSliceAs<support::ulittle32_t>(*Stream, 0, 1);
-  if (!ExpectedSize)
-    return ExpectedSize.takeError();
-
-  size_t ListSize = ExpectedSize.get()[0];
-
-  size_t ListOffset = 4;
-  // Some producers insert additional padding bytes to align the list to an
-  // 8-byte boundary. Check for that by comparing the list size with the overall
-  // stream size.
-  if (ListOffset + sizeof(T) * ListSize < Stream->size())
-    ListOffset = 8;
-
-  return getDataSliceAs<T>(*Stream, ListOffset, ListSize);
-}
-template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<Module>>
-    MinidumpFile::getListStream(StreamType) const;
-template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<Thread>>
-    MinidumpFile::getListStream(StreamType) const;
-template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<MemoryDescriptor>>
-    MinidumpFile::getListStream(StreamType) const;
-
 Expected<ArrayRef<uint8_t>> MinidumpFile::getDataSlice(ArrayRef<uint8_t> Data,
                                                        uint64_t Offset,
                                                        uint64_t Size) {

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -98,11 +98,11 @@ Expected<ArrayRef<T>> MinidumpFile::getListStream(StreamType Type) const {
 
   return getDataSliceAs<T>(*Stream, ListOffset, ListSize);
 }
-template Expected<ArrayRef<Module>>
+template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<Module>>
     MinidumpFile::getListStream(StreamType) const;
-template Expected<ArrayRef<Thread>>
+template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<Thread>>
     MinidumpFile::getListStream(StreamType) const;
-template Expected<ArrayRef<MemoryDescriptor>>
+template LLVM_EXPORT_TEMPLATE Expected<ArrayRef<MemoryDescriptor>>
     MinidumpFile::getListStream(StreamType) const;
 
 Expected<ArrayRef<uint8_t>> MinidumpFile::getDataSlice(ArrayRef<uint8_t> Data,


### PR DESCRIPTION
Add extern template defs along with visibility macros to MinidumpFile::getListStream that is needed by MinidumpTest.cpp when llvm is built as shared library on windows with explicit visibility macros enabled.

This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and LLVM plugins on window.