### PR TITLE
[clang] Make -fveclib={ArmPL,SLEEF} imply -fno-math-errno

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -504,7 +504,8 @@ def warn_drv_large_data_threshold_invalid_code_model: Warning<
   InGroup<UnusedCommandLineArgument>;
 def warn_drv_math_errno_reenabled_after_veclib: Warning<
   "math errno re-enabled by '%0' after it was implicitly disabled by '%1',"
-  " this may prevent vectorization with the specified vector library">;
+  " this may prevent vectorization with the specified vector library">,
+  InGroup<MathErrnoEnabledWithVecLib>;
 
 def note_drv_command_failed_diag_msg : Note<
   "diagnostic msg: %0">;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -502,6 +502,9 @@ def err_sls_hardening_arm_not_supported : Error<
 def warn_drv_large_data_threshold_invalid_code_model: Warning<
   "'%0' only applies to medium and large code models">,
   InGroup<UnusedCommandLineArgument>;
+def warn_drv_math_errno_reenabled_after_veclib: Warning<
+  "math errno re-enabled by '%0' after it was implicitly disabled by '%1',"
+  " this may prevent vectorization with the specified vector library">;
 
 def note_drv_command_failed_diag_msg : Note<
   "diagnostic msg: %0">;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -502,9 +502,9 @@ def err_sls_hardening_arm_not_supported : Error<
 def warn_drv_large_data_threshold_invalid_code_model: Warning<
   "'%0' only applies to medium and large code models">,
   InGroup<UnusedCommandLineArgument>;
-def warn_drv_math_errno_reenabled_after_veclib: Warning<
-  "math errno re-enabled by '%0' after it was implicitly disabled by '%1',"
-  " this may prevent vectorization with the specified vector library">,
+def warn_drv_math_errno_enabled_after_veclib: Warning<
+  "math errno enabled by '%0' after it was implicitly disabled by '%1',"
+  " this may limit the utilization of the vector library">,
   InGroup<MathErrnoEnabledWithVecLib>;
 
 def note_drv_command_failed_diag_msg : Note<

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -125,6 +125,7 @@ def FloatZeroConversion : DiagGroup<"float-zero-conversion">;
 def FloatConversion :
   DiagGroup<"float-conversion", [FloatOverflowConversion,
                                  FloatZeroConversion]>;
+def MathErrnoEnabledWithVecLib : DiagGroup<"math-errno-enabled-with-veclib">;
 
 def FrameAddress : DiagGroup<"frame-address">;
 def FreeNonHeapObject : DiagGroup<"free-nonheap-object">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3410,7 +3410,8 @@ def fno_experimental_isel : Flag<["-"], "fno-experimental-isel">, Group<f_clang_
   Alias<fno_global_isel>;
 def fveclib : Joined<["-"], "fveclib=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
-    HelpText<"Use the given vector functions library">,
+    HelpText<"Use the given vector functions library."
+             "Note: -fveclib={ArmPL,SLEEF} implies -fno-math-errno">,
     Values<"Accelerate,libmvec,MASSV,SVML,SLEEF,Darwin_libsystem_m,ArmPL,AMDLIBM,none">,
     NormalizedValuesScope<"llvm::driver::VectorLibrary">,
     NormalizedValues<["Accelerate", "LIBMVEC", "MASSV", "SVML", "SLEEF",

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3410,8 +3410,10 @@ def fno_experimental_isel : Flag<["-"], "fno-experimental-isel">, Group<f_clang_
   Alias<fno_global_isel>;
 def fveclib : Joined<["-"], "fveclib=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
-    HelpText<"Use the given vector functions library."
-             "Note: In clang -fveclib={ArmPL,SLEEF} implies -fno-math-errno">,
+    HelpText<"Use the given vector functions library">,
+    HelpTextForVariants<[ClangOption, CC1Option],
+      "Use the given vector functions library. "
+      "Note: -fveclib={ArmPL,SLEEF} implies -fno-math-errno">,
     Values<"Accelerate,libmvec,MASSV,SVML,SLEEF,Darwin_libsystem_m,ArmPL,AMDLIBM,none">,
     NormalizedValuesScope<"llvm::driver::VectorLibrary">,
     NormalizedValues<["Accelerate", "LIBMVEC", "MASSV", "SVML", "SLEEF",

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3411,7 +3411,7 @@ def fno_experimental_isel : Flag<["-"], "fno-experimental-isel">, Group<f_clang_
 def fveclib : Joined<["-"], "fveclib=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
     HelpText<"Use the given vector functions library."
-             "Note: -fveclib={ArmPL,SLEEF} implies -fno-math-errno">,
+             "Note: In clang -fveclib={ArmPL,SLEEF} implies -fno-math-errno">,
     Values<"Accelerate,libmvec,MASSV,SVML,SLEEF,Darwin_libsystem_m,ArmPL,AMDLIBM,none">,
     NormalizedValuesScope<"llvm::driver::VectorLibrary">,
     NormalizedValues<["Accelerate", "LIBMVEC", "MASSV", "SVML", "SLEEF",

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3142,10 +3142,10 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
       break;
     case options::OPT_fveclib:
       VecLibArg = A;
-      if (llvm::is_contained(VecLibImpliesNoMathErrno, A->getValue())) {
+      NoMathErrnoWasImpliedByVecLib =
+          llvm::is_contained(VecLibImpliesNoMathErrno, A->getValue());
+      if (NoMathErrnoWasImpliedByVecLib)
         MathErrno = false;
-        NoMathErrnoWasImpliedByVecLib = true;
-      }
       break;
     case options::OPT_fno_trapping_math:
       if (!TrappingMathPresent && !FPExceptionBehavior.empty() &&

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2854,6 +2854,10 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
                                        bool OFastEnabled, const ArgList &Args,
                                        ArgStringList &CmdArgs,
                                        const JobAction &JA) {
+  // List of veclibs which when used with -fveclib imply -fno-math-errno.
+  constexpr std::array VecLibImpliesNoMathErrno{llvm::StringLiteral("ArmPL"),
+                                                llvm::StringLiteral("SLEEF")};
+
   // Handle various floating point optimization flags, mapping them to the
   // appropriate LLVM code generation flags. This is complicated by several
   // "umbrella" flags, so we do this by stepping through the flags incrementally
@@ -3124,6 +3128,10 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
       TrappingMath = true;
       TrappingMathPresent = true;
       FPExceptionBehavior = "strict";
+      break;
+    case options::OPT_fveclib:
+      if (llvm::is_contained(VecLibImpliesNoMathErrno, A->getValue()))
+        MathErrno = false;
       break;
     case options::OPT_fno_trapping_math:
       if (!TrappingMathPresent && !FPExceptionBehavior.empty() &&

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2860,8 +2860,8 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
                                                 llvm::StringLiteral("SLEEF")};
   bool NoMathErrnoWasImpliedByVecLib = false;
   const Arg *VecLibArg = nullptr;
-  // Track the arg (if any) that reenabled errno after -fveclib for diagnostics.
-  const Arg *ArgThatReenabledMathErrnoAfterVecLib = nullptr;
+  // Track the arg (if any) that enabled errno after -fveclib for diagnostics.
+  const Arg *ArgThatEnabledMathErrnoAfterVecLib = nullptr;
 
   // Handle various floating point optimization flags, mapping them to the
   // appropriate LLVM code generation flags. This is complicated by several
@@ -2972,7 +2972,7 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
     auto CheckMathErrnoForVecLib =
         llvm::make_scope_exit([&, MathErrnoBeforeArg = MathErrno] {
           if (NoMathErrnoWasImpliedByVecLib && !MathErrnoBeforeArg && MathErrno)
-            ArgThatReenabledMathErrnoAfterVecLib = A;
+            ArgThatEnabledMathErrnoAfterVecLib = A;
         });
 
     switch (A->getOption().getID()) {
@@ -3363,8 +3363,8 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
   if (MathErrno) {
     CmdArgs.push_back("-fmath-errno");
     if (NoMathErrnoWasImpliedByVecLib)
-      D.Diag(clang::diag::warn_drv_math_errno_reenabled_after_veclib)
-          << ArgThatReenabledMathErrnoAfterVecLib->getAsString(Args)
+      D.Diag(clang::diag::warn_drv_math_errno_enabled_after_veclib)
+          << ArgThatEnabledMathErrnoAfterVecLib->getAsString(Args)
           << VecLibArg->getAsString(Args);
   }
 

--- a/clang/test/Driver/autocomplete.c
+++ b/clang/test/Driver/autocomplete.c
@@ -114,6 +114,7 @@
 // WARNING-NEXT: -Wmain-return-type
 // WARNING-NEXT: -Wmalformed-warning-check
 // WARNING-NEXT: -Wmany-braces-around-scalar-init
+// WARNING-NEXT: -Wmath-errno-enabled-with-veclib
 // WARNING-NEXT: -Wmathematical-notation-identifier-extension
 // WARNING-NEXT: -Wmax-tokens
 // WARNING-NEXT: -Wmax-unsigned-zero

--- a/clang/test/Driver/fveclib.c
+++ b/clang/test/Driver/fveclib.c
@@ -36,16 +36,23 @@
 /* Verify that the correct vector library is passed to LTO flags. */
 
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fveclib=LIBMVEC -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-LIBMVEC %s
+// CHECK-LTO-LIBMVEC: "-fmath-errno"
 // CHECK-LTO-LIBMVEC: "-plugin-opt=-vector-library=LIBMVEC-X86"
 
 // RUN: %clang -### --target=powerpc64-unknown-linux-gnu -fveclib=MASSV -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-MASSV %s
+// CHECK-LTO-MASSV: "-fmath-errno"
 // CHECK-LTO-MASSV: "-plugin-opt=-vector-library=MASSV"
 
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fveclib=SVML -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-SVML %s
+// CHECK-LTO-SVML: "-fmath-errno"
 // CHECK-LTO-SVML: "-plugin-opt=-vector-library=SVML"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-SLEEF %s
+// CHECK-LTO-SLEEF-NOT: "-fmath-errno"
 // CHECK-LTO-SLEEF: "-plugin-opt=-vector-library=sleefgnuabi"
+// CHECK-LTO-SLEEF-NOT: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-ARMPL %s
+// CHECK-LTO-ARMPL-NOT: "-fmath-errno"
 // CHECK-LTO-ARMPL: "-plugin-opt=-vector-library=ArmPL"
+// CHECK-LTO-ARMPL-NOT: "-fmath-errno"

--- a/clang/test/Driver/fveclib.c
+++ b/clang/test/Driver/fveclib.c
@@ -75,10 +75,22 @@
 // CHECK-ERRNO-ARMPL: "-fveclib=ArmPL"
 // CHECK-ERRNO-ARMPL-NOT: "-fmath-errno"
 
-// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-FORCE-ERRNO-ARMPL %s
-// CHECK-FORCE-ERRNO-ARMPL: "-fveclib=ArmPL"
-// CHECK-FORCE-ERRNO-ARMPL-SAME: "-fmath-errno"
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-ARMPL %s
+// CHECK-REENABLE-ERRNO-ARMPL: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-ARMPL: "-fveclib=ArmPL"
+// CHECK-REENABLE-ERRNO-ARMPL-SAME: "-fmath-errno"
 
-// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-FORCE-ERRNO-SLEEF %s
-// CHECK-FORCE-ERRNO-SLEEF: "-fveclib=SLEEF"
-// CHECK-FORCE-ERRNO-SLEEF-SAME: "-fmath-errno"
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-SLEEF %s
+// CHECK-REENABLE-ERRNO-SLEEF: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=SLEEF', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-SLEEF: "-fveclib=SLEEF"
+// CHECK-REENABLE-ERRNO-SLEEF-SAME: "-fmath-errno"
+
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fno-fast-math %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-NFM %s
+// CHECK-REENABLE-ERRNO-NFM: math errno re-enabled by '-fno-fast-math' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-NFM: "-fveclib=ArmPL"
+// CHECK-REENABLE-ERRNO-NFM-SAME: "-fmath-errno"
+
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -ffp-model=strict %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-FP-MODEL %s
+// CHECK-REENABLE-ERRNO-FP-MODEL: math errno re-enabled by '-ffp-model=strict' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-FP-MODEL: "-fveclib=ArmPL"
+// CHECK-REENABLE-ERRNO-FP-MODEL-SAME: "-fmath-errno"

--- a/clang/test/Driver/fveclib.c
+++ b/clang/test/Driver/fveclib.c
@@ -76,21 +76,25 @@
 // CHECK-ERRNO-ARMPL-NOT: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-ARMPL %s
-// CHECK-REENABLE-ERRNO-ARMPL: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-ARMPL: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+
 // CHECK-REENABLE-ERRNO-ARMPL: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-ARMPL-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-SLEEF %s
-// CHECK-REENABLE-ERRNO-SLEEF: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=SLEEF', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-SLEEF: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=SLEEF', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+
 // CHECK-REENABLE-ERRNO-SLEEF: "-fveclib=SLEEF"
 // CHECK-REENABLE-ERRNO-SLEEF-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fno-fast-math %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-NFM %s
-// CHECK-REENABLE-ERRNO-NFM: math errno re-enabled by '-fno-fast-math' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-NFM: math errno re-enabled by '-fno-fast-math' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+
 // CHECK-REENABLE-ERRNO-NFM: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-NFM-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -ffp-model=strict %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-FP-MODEL %s
-// CHECK-REENABLE-ERRNO-FP-MODEL: math errno re-enabled by '-ffp-model=strict' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library
+// CHECK-REENABLE-ERRNO-FP-MODEL: math errno re-enabled by '-ffp-model=strict' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+
 // CHECK-REENABLE-ERRNO-FP-MODEL: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-FP-MODEL-SAME: "-fmath-errno"

--- a/clang/test/Driver/fveclib.c
+++ b/clang/test/Driver/fveclib.c
@@ -77,24 +77,28 @@
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-ARMPL %s
 // CHECK-REENABLE-ERRNO-ARMPL: math errno enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=ArmPL', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
-
 // CHECK-REENABLE-ERRNO-ARMPL: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-ARMPL-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-SLEEF %s
 // CHECK-REENABLE-ERRNO-SLEEF: math errno enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=SLEEF', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
-
 // CHECK-REENABLE-ERRNO-SLEEF: "-fveclib=SLEEF"
 // CHECK-REENABLE-ERRNO-SLEEF-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fno-fast-math %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-NFM %s
 // CHECK-REENABLE-ERRNO-NFM: math errno enabled by '-fno-fast-math' after it was implicitly disabled by '-fveclib=ArmPL', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
-
 // CHECK-REENABLE-ERRNO-NFM: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-NFM-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -ffp-model=strict %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-FP-MODEL %s
 // CHECK-REENABLE-ERRNO-FP-MODEL: math errno enabled by '-ffp-model=strict' after it was implicitly disabled by '-fveclib=ArmPL', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
-
 // CHECK-REENABLE-ERRNO-FP-MODEL: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-FP-MODEL-SAME: "-fmath-errno"
+
+/* Verify the warning points at the last arg to enable -fmath-errno. */
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fno-fast-math -fno-math-errno -ffp-model=strict %s 2>&1 | FileCheck --check-prefix=CHECK-ENABLED-LAST %s
+// CHECK-ENABLED-LAST: math errno enabled by '-ffp-model=strict' after it was implicitly disabled by '-fveclib=ArmPL', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
+
+/* Verify no warning when math-errno is re-enabled for a different veclib (that does not imply -fno-math-errno). */
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fmath-errno -fveclib=LIBMVEC %s 2>&1 | FileCheck --check-prefix=CHECK-REPEAT-VECLIB %s
+// CHECK-REPEAT-VECLIB-NOT: math errno enabled

--- a/clang/test/Driver/fveclib.c
+++ b/clang/test/Driver/fveclib.c
@@ -36,23 +36,49 @@
 /* Verify that the correct vector library is passed to LTO flags. */
 
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fveclib=LIBMVEC -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-LIBMVEC %s
-// CHECK-LTO-LIBMVEC: "-fmath-errno"
 // CHECK-LTO-LIBMVEC: "-plugin-opt=-vector-library=LIBMVEC-X86"
 
 // RUN: %clang -### --target=powerpc64-unknown-linux-gnu -fveclib=MASSV -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-MASSV %s
-// CHECK-LTO-MASSV: "-fmath-errno"
 // CHECK-LTO-MASSV: "-plugin-opt=-vector-library=MASSV"
 
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fveclib=SVML -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-SVML %s
-// CHECK-LTO-SVML: "-fmath-errno"
 // CHECK-LTO-SVML: "-plugin-opt=-vector-library=SVML"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-SLEEF %s
-// CHECK-LTO-SLEEF-NOT: "-fmath-errno"
 // CHECK-LTO-SLEEF: "-plugin-opt=-vector-library=sleefgnuabi"
-// CHECK-LTO-SLEEF-NOT: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -flto %s 2>&1 | FileCheck --check-prefix=CHECK-LTO-ARMPL %s
-// CHECK-LTO-ARMPL-NOT: "-fmath-errno"
 // CHECK-LTO-ARMPL: "-plugin-opt=-vector-library=ArmPL"
-// CHECK-LTO-ARMPL-NOT: "-fmath-errno"
+
+
+/* Verify that -fmath-errno is set correctly for the vector library. */
+
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fveclib=LIBMVEC %s 2>&1 | FileCheck --check-prefix=CHECK-ERRNO-LIBMVEC %s
+// CHECK-ERRNO-LIBMVEC: "-fveclib=LIBMVEC"
+// CHECK-ERRNO-LIBMVEC-SAME: "-fmath-errno"
+
+// RUN: %clang -### --target=powerpc64-unknown-linux-gnu -fveclib=MASSV %s 2>&1 | FileCheck --check-prefix=CHECK-ERRNO-MASSV %s
+// CHECK-ERRNO-MASSV: "-fveclib=MASSV"
+// CHECK-ERRNO-MASSV-SAME: "-fmath-errno"
+
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fveclib=SVML %s 2>&1 | FileCheck --check-prefix=CHECK-ERRNO-SVML %s
+// CHECK-ERRNO-SVML: "-fveclib=SVML"
+// CHECK-ERRNO-SVML-SAME: "-fmath-errno"
+
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF %s 2>&1 | FileCheck --check-prefix=CHECK-ERRNO-SLEEF %s
+// CHECK-ERRNO-SLEEF-NOT: "-fmath-errno"
+// CHECK-ERRNO-SLEEF: "-fveclib=SLEEF"
+// CHECK-ERRNO-SLEEF-NOT: "-fmath-errno"
+
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL %s 2>&1 | FileCheck --check-prefix=CHECK-ERRNO-ARMPL %s
+// CHECK-ERRNO-ARMPL-NOT: "-fmath-errno"
+// CHECK-ERRNO-ARMPL: "-fveclib=ArmPL"
+// CHECK-ERRNO-ARMPL-NOT: "-fmath-errno"
+
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-FORCE-ERRNO-ARMPL %s
+// CHECK-FORCE-ERRNO-ARMPL: "-fveclib=ArmPL"
+// CHECK-FORCE-ERRNO-ARMPL-SAME: "-fmath-errno"
+
+// RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-FORCE-ERRNO-SLEEF %s
+// CHECK-FORCE-ERRNO-SLEEF: "-fveclib=SLEEF"
+// CHECK-FORCE-ERRNO-SLEEF-SAME: "-fmath-errno"

--- a/clang/test/Driver/fveclib.c
+++ b/clang/test/Driver/fveclib.c
@@ -76,25 +76,25 @@
 // CHECK-ERRNO-ARMPL-NOT: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-ARMPL %s
-// CHECK-REENABLE-ERRNO-ARMPL: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+// CHECK-REENABLE-ERRNO-ARMPL: math errno enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=ArmPL', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
 
 // CHECK-REENABLE-ERRNO-ARMPL: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-ARMPL-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=SLEEF -fmath-errno %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-SLEEF %s
-// CHECK-REENABLE-ERRNO-SLEEF: math errno re-enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=SLEEF', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+// CHECK-REENABLE-ERRNO-SLEEF: math errno enabled by '-fmath-errno' after it was implicitly disabled by '-fveclib=SLEEF', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
 
 // CHECK-REENABLE-ERRNO-SLEEF: "-fveclib=SLEEF"
 // CHECK-REENABLE-ERRNO-SLEEF-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -fno-fast-math %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-NFM %s
-// CHECK-REENABLE-ERRNO-NFM: math errno re-enabled by '-fno-fast-math' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+// CHECK-REENABLE-ERRNO-NFM: math errno enabled by '-fno-fast-math' after it was implicitly disabled by '-fveclib=ArmPL', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
 
 // CHECK-REENABLE-ERRNO-NFM: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-NFM-SAME: "-fmath-errno"
 
 // RUN: %clang -### --target=aarch64-linux-gnu -fveclib=ArmPL -ffp-model=strict %s 2>&1 | FileCheck --check-prefix=CHECK-REENABLE-ERRNO-FP-MODEL %s
-// CHECK-REENABLE-ERRNO-FP-MODEL: math errno re-enabled by '-ffp-model=strict' after it was implicitly disabled by '-fveclib=ArmPL', this may prevent vectorization with the specified vector library [-Wmath-errno-enabled-with-veclib]
+// CHECK-REENABLE-ERRNO-FP-MODEL: math errno enabled by '-ffp-model=strict' after it was implicitly disabled by '-fveclib=ArmPL', this may limit the utilization of the vector library [-Wmath-errno-enabled-with-veclib]
 
 // CHECK-REENABLE-ERRNO-FP-MODEL: "-fveclib=ArmPL"
 // CHECK-REENABLE-ERRNO-FP-MODEL-SAME: "-fmath-errno"


### PR DESCRIPTION
These two veclibs are only available for AArch64 targets, and as mentioned in https://discourse.llvm.org/t/rfc-should-fveclib-imply-fno-math-errno-for-all-targets/81384, we (Arm) think that `-fveclib` should imply `-fno-math-errno`. By setting `-fveclib` the user shows they intend to use the vector math functions, which implies they don't care about errno. However, currently, the vector mappings won't be used in many cases without setting `-fno-math-errno` separately.

Making this change would also help resolve some inconsistencies in how vector mappings are applied (see https://github.com/llvm/llvm-project/pull/108980#discussion_r1766555560).

Note: Both SLEEF and ArmPL state that they do not set `errno`:

- https://developer.arm.com/documentation/101004/2410/General-information/Arm-Performance-Libraries-math-functions
  *  "The vector functions in libamath which are available on Linux may not set errno nor raise exceptions"
- https://sleef.org/2-references/libm/
  *  "These functions do not set errno nor raise an exception."