### PR TITLE
[flang][cuda] Relax the verifier for cuf.register_kernel op

### DIFF
--- a/flang/lib/Optimizer/Dialect/CUF/CUFOps.cpp
+++ b/flang/lib/Optimizer/Dialect/CUF/CUFOps.cpp
@@ -281,12 +281,12 @@ mlir::LogicalResult cuf::RegisterKernelOp::verify() {
 
   mlir::SymbolTable gpuSymTab(gpuMod);
   auto func = gpuSymTab.lookup<mlir::gpu::GPUFuncOp>(getKernelName());
-  if (!func)
-    return emitOpError("device function not found");
-
-  if (!func.isKernel())
-    return emitOpError("only kernel gpu.func can be registered");
-
+  if (func) {
+    // Only check if the gpu.func is found. It might be converted to LLVMFuncOp
+    // already.
+    if (!func.isKernel())
+      return emitOpError("only kernel gpu.func can be registered");
+  }
   return mlir::success();
 }
 

--- a/flang/lib/Optimizer/Dialect/CUF/CUFOps.cpp
+++ b/flang/lib/Optimizer/Dialect/CUF/CUFOps.cpp
@@ -277,8 +277,12 @@ mlir::LogicalResult cuf::RegisterKernelOp::verify() {
 
   mlir::SymbolTable symTab(mod);
   auto gpuMod = symTab.lookup<mlir::gpu::GPUModuleOp>(getKernelModuleName());
-  if (!gpuMod)
+  if (!gpuMod) {
+    // If already a gpu.binary then stop the check here.
+    if (symTab.lookup<mlir::gpu::BinaryOp>(getKernelModuleName()))
+      return mlir::success();
     return emitOpError("gpu module not found");
+  }
 
   mlir::SymbolTable gpuSymTab(gpuMod);
   if (auto func = gpuSymTab.lookup<mlir::gpu::GPUFuncOp>(getKernelName())) {

--- a/flang/test/Fir/cuf-invalid.fir
+++ b/flang/test/Fir/cuf-invalid.fir
@@ -144,6 +144,21 @@ module attributes {gpu.container_module} {
 // -----
 
 module attributes {gpu.container_module} {
+  gpu.module @cuda_device_mod {
+    gpu.func @_QPsub_device1() {
+      gpu.return
+    }
+  }
+  llvm.func internal @__cudaFortranConstructor() {
+    // expected-error@+1{{'cuf.register_kernel' op device function not found}}
+    cuf.register_kernel @cuda_device_mod::@_QPsub_device2
+    llvm.return
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module} {
   llvm.func internal @__cudaFortranConstructor() {
     // expected-error@+1{{'cuf.register_kernel' op gpu module not found}}
     cuf.register_kernel @cuda_device_mod::@_QPsub_device1
@@ -157,6 +172,21 @@ module attributes {gpu.container_module} {
   llvm.func internal @__cudaFortranConstructor() {
     // expected-error@+1{{'cuf.register_kernel' op expect a module and a kernel name}}
     cuf.register_kernel @_QPsub_device1
+    llvm.return
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module} {
+  gpu.module @cuda_device_mod {
+    llvm.func @_QPsub_device1() {
+      llvm.return
+    }
+  }
+  llvm.func internal @__cudaFortranConstructor() {
+    // expected-error@+1{{'cuf.register_kernel' op only gpu.kernel llvm.func can be registered}}
+    cuf.register_kernel @cuda_device_mod::@_QPsub_device1
     llvm.return
   }
 }

--- a/flang/test/Fir/cuf-invalid.fir
+++ b/flang/test/Fir/cuf-invalid.fir
@@ -144,21 +144,6 @@ module attributes {gpu.container_module} {
 // -----
 
 module attributes {gpu.container_module} {
-  gpu.module @cuda_device_mod {
-    gpu.func @_QPsub_device1() {
-      gpu.return
-    }
-  }
-  llvm.func internal @__cudaFortranConstructor() {
-    // expected-error@+1{{'cuf.register_kernel' op device function not found}}
-    cuf.register_kernel @cuda_device_mod::@_QPsub_device2
-    llvm.return
-  }
-}
-
-// -----
-
-module attributes {gpu.container_module} {
   llvm.func internal @__cudaFortranConstructor() {
     // expected-error@+1{{'cuf.register_kernel' op gpu module not found}}
     cuf.register_kernel @cuda_device_mod::@_QPsub_device1


### PR DESCRIPTION
Relax the verifier since the `gpu.func` might be converted to `llvm.func` before `cuf.register_kernel` is converted.