### PR TITLE
Update the EBO static_assert to dheck against APFloat::Storage instead of IEEEFloat.

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1474,10 +1474,14 @@ public:
   friend APFloat frexp(const APFloat &X, int &Exp, roundingMode RM);
   friend IEEEFloat;
   friend DoubleAPFloat;
+  friend class APFloatEBOChecker;
 };
 
-static_assert(sizeof(APFloat) == sizeof(detail::IEEEFloat),
-              "Empty base class optimization is not performed.");
+class APFloatEBOChecker {
+  static_assert(sizeof(APFloat) == sizeof(APFloat::U),
+                "Empty base class optimization is not performed.");
+};
+
 
 /// See friend declarations above.
 ///

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1477,12 +1477,6 @@ public:
   friend class APFloatEBOChecker;
 };
 
-class APFloatEBOChecker {
-  static_assert(sizeof(APFloat) == sizeof(APFloat::U),
-                "Empty base class optimization is not performed.");
-};
-
-
 /// See friend declarations above.
 ///
 /// These additional declarations are required in order to compile LLVM with IBM

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1474,6 +1474,8 @@ public:
   friend APFloat frexp(const APFloat &X, int &Exp, roundingMode RM);
   friend IEEEFloat;
   friend DoubleAPFloat;
+  // Since Storage is private, friend class APFloatEBOChecker is added to allow
+  // access to it in APFloat.cpp.
   friend class APFloatEBOChecker;
 };
 

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -99,6 +99,11 @@ enum class fltNanEncoding {
   NegativeZero,
 };
 
+class APFloatEBOChecker {
+  static_assert(sizeof(APFloat) == sizeof(APFloat::U),
+                "Empty base class optimization is not performed.");
+};
+
 /* Represents floating point arithmetic semantics.  */
 struct fltSemantics {
   /* The largest E such that 2^E is representable; this matches the


### PR DESCRIPTION
The addition of the the following code in commit https://github.com/llvm/llvm-project/commit/6004f5550c8032f4c632cdbf5dbc0894bb33e51f#diff-3ec11da67f69353fd755e59cc71f551b5e93773fd4e6f6327c7f1c7074a82709R1474

```
static_assert(sizeof(APFloat) == sizeof(detail::IEEEFloat),
              "Empty base class optimization is not performed.");
 ```
              
broke our downstream code as not all the members of APFloat is IEEE.

This PR supersedes PR #111780. 

We made some changed to our downstream code to accommodate the upstream change. 
This PR is to modify the EBO static_assert to check against the `sizeof(APFloat::Storage)` instead of `sizeof(detail::IEEEFloat)`, which seems satisfy both upstream and downstream code.  
We also moved the assert to `APFloat.cpp` from the header file as per discussion in PR #111780 

@Ariel-Burton