### PR TITLE
[yaml2obj][obj2yaml][objdump] Handle MIPS COFF files

### DIFF
--- a/llvm/include/llvm/Object/WindowsMachineFlag.h
+++ b/llvm/include/llvm/Object/WindowsMachineFlag.h
@@ -43,6 +43,8 @@ template <typename T> Triple::ArchType getMachineArchType(T machine) {
   case COFF::IMAGE_FILE_MACHINE_ARM64EC:
   case COFF::IMAGE_FILE_MACHINE_ARM64X:
     return llvm::Triple::ArchType::aarch64;
+  case COFF::IMAGE_FILE_MACHINE_R4000:
+    return llvm::Triple::ArchType::mipsel;
   default:
     return llvm::Triple::ArchType::UnknownArch;
   }

--- a/llvm/include/llvm/ObjectYAML/COFFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/COFFYAML.h
@@ -179,6 +179,10 @@ struct ScalarEnumerationTraits<COFF::RelocationTypeAMD64> {
   static void enumeration(IO &IO, COFF::RelocationTypeAMD64 &Value);
 };
 
+template <> struct ScalarEnumerationTraits<COFF::RelocationTypesMips> {
+  static void enumeration(IO &IO, COFF::RelocationTypesMips &Value);
+};
+
 template <>
 struct ScalarEnumerationTraits<COFF::RelocationTypesARM> {
   static void enumeration(IO &IO, COFF::RelocationTypesARM &Value);

--- a/llvm/lib/Object/COFFObjectFile.cpp
+++ b/llvm/lib/Object/COFFObjectFile.cpp
@@ -1132,6 +1132,8 @@ StringRef COFFObjectFile::getFileFormatName() const {
     return "COFF-ARM64EC";
   case COFF::IMAGE_FILE_MACHINE_ARM64X:
     return "COFF-ARM64X";
+  case COFF::IMAGE_FILE_MACHINE_R4000:
+    return "COFF-MIPS";
   default:
     return "COFF-<unknown arch>";
   }

--- a/llvm/lib/ObjectYAML/COFFYAML.cpp
+++ b/llvm/lib/ObjectYAML/COFFYAML.cpp
@@ -183,6 +183,25 @@ void ScalarEnumerationTraits<COFF::RelocationTypeAMD64>::enumeration(
   ECase(IMAGE_REL_AMD64_SSPAN32);
 }
 
+void ScalarEnumerationTraits<COFF::RelocationTypesMips>::enumeration(
+    IO &IO, COFF::RelocationTypesMips &Value) {
+  ECase(IMAGE_REL_MIPS_ABSOLUTE);
+  ECase(IMAGE_REL_MIPS_REFHALF);
+  ECase(IMAGE_REL_MIPS_REFWORD);
+  ECase(IMAGE_REL_MIPS_JMPADDR);
+  ECase(IMAGE_REL_MIPS_REFHI);
+  ECase(IMAGE_REL_MIPS_REFLO);
+  ECase(IMAGE_REL_MIPS_GPREL);
+  ECase(IMAGE_REL_MIPS_LITERAL);
+  ECase(IMAGE_REL_MIPS_SECTION);
+  ECase(IMAGE_REL_MIPS_SECREL);
+  ECase(IMAGE_REL_MIPS_SECRELLO);
+  ECase(IMAGE_REL_MIPS_SECRELHI);
+  ECase(IMAGE_REL_MIPS_JMPADDR16);
+  ECase(IMAGE_REL_MIPS_REFWORDNB);
+  ECase(IMAGE_REL_MIPS_PAIR);
+}
+
 void ScalarEnumerationTraits<COFF::RelocationTypesARM>::enumeration(
     IO &IO, COFF::RelocationTypesARM &Value) {
   ECase(IMAGE_REL_ARM_ABSOLUTE);
@@ -425,6 +444,10 @@ void MappingTraits<COFFYAML::Relocation>::mapping(IO &IO,
     IO.mapRequired("Type", NT->Type);
   } else if (H.Machine == COFF::IMAGE_FILE_MACHINE_AMD64) {
     MappingNormalization<NType<COFF::RelocationTypeAMD64>, uint16_t> NT(
+        IO, Rel.Type);
+    IO.mapRequired("Type", NT->Type);
+  } else if (H.Machine == COFF::IMAGE_FILE_MACHINE_R4000) {
+    MappingNormalization<NType<COFF::RelocationTypesMips>, uint16_t> NT(
         IO, Rel.Type);
     IO.mapRequired("Type", NT->Type);
   } else if (H.Machine == COFF::IMAGE_FILE_MACHINE_ARMNT) {

--- a/llvm/test/tools/yaml2obj/COFF/basic-mips.yaml
+++ b/llvm/test/tools/yaml2obj/COFF/basic-mips.yaml
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t
-# RUN: llvm-readobj --file-headers %t | FileCheck %s
+# RUN: llvm-readobj --file-headers --relocs %t | FileCheck %s
 # RUN: obj2yaml %t | FileCheck %s --check-prefix=ROUNDTRIP
 
 # CHECK: Format: COFF-MIPS

--- a/llvm/test/tools/yaml2obj/COFF/basic-mips.yaml
+++ b/llvm/test/tools/yaml2obj/COFF/basic-mips.yaml
@@ -1,0 +1,96 @@
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-readobj --file-headers %t | FileCheck %s
+# RUN: obj2yaml %t | FileCheck %s --check-prefix=ROUNDTRIP
+
+# CHECK: OptionalHeaderSize: 224
+# CHECK: ImageBase: 0x40000000
+
+# ROUNDTRIP: ImageBase: 1073741824
+# ROUNDTRIP: VirtualAddress:  4096
+# ROUNDTRIP: VirtualAddress:  8192
+# ROUNDTRIP: VirtualAddress:  12288
+
+--- !COFF
+OptionalHeader:
+  AddressOfEntryPoint: 4096
+  ImageBase:       1073741824
+  SectionAlignment: 4096
+  FileAlignment:   512
+  MajorOperatingSystemVersion: 6
+  MinorOperatingSystemVersion: 0
+  MajorImageVersion: 0
+  MinorImageVersion: 0
+  MajorSubsystemVersion: 6
+  MinorSubsystemVersion: 0
+  Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
+  DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]
+  SizeOfStackReserve: 1048576
+  SizeOfStackCommit: 4096
+  SizeOfHeapReserve: 1048576
+  SizeOfHeapCommit: 4096
+  ExportTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ImportTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ResourceTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ExceptionTable:
+    RelativeVirtualAddress: 12288
+    Size:            8
+  CertificateTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  BaseRelocationTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  Debug:
+    RelativeVirtualAddress: 0
+    Size:            0
+  Architecture:
+    RelativeVirtualAddress: 0
+    Size:            0
+  GlobalPtr:
+    RelativeVirtualAddress: 0
+    Size:            0
+  TlsTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  LoadConfigTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  BoundImport:
+    RelativeVirtualAddress: 0
+    Size:            0
+  IAT:
+    RelativeVirtualAddress: 0
+    Size:            0
+  DelayImportDescriptor:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ClrRuntimeHeader:
+    RelativeVirtualAddress: 0
+    Size:            0
+header:
+  Machine:         IMAGE_FILE_MACHINE_R4000
+  Characteristics: [ IMAGE_FILE_EXECUTABLE_IMAGE ]
+sections:
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    VirtualAddress:  4096
+    VirtualSize:     4
+    SectionData:     C0035FD6
+  - Name:            .rdata
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    VirtualAddress:  8192
+    VirtualSize:     12
+    SectionData:     0100400800000000E4E3E3E3
+  - Name:            .pdata
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    VirtualAddress:  12288
+    VirtualSize:     8
+    SectionData:     '0010000000200000'
+symbols:         []
+...

--- a/llvm/test/tools/yaml2obj/COFF/basic-mips.yaml
+++ b/llvm/test/tools/yaml2obj/COFF/basic-mips.yaml
@@ -2,95 +2,38 @@
 # RUN: llvm-readobj --file-headers %t | FileCheck %s
 # RUN: obj2yaml %t | FileCheck %s --check-prefix=ROUNDTRIP
 
-# CHECK: OptionalHeaderSize: 224
-# CHECK: ImageBase: 0x40000000
+# CHECK: Format: COFF-MIPS
+# CHECK: Arch: mipsel
+# CHECK: Machine: IMAGE_FILE_MACHINE_R4000 (0x166)
+# CHECK: Relocations [
+# CHECK:  Section (1) .text {
+# CHECK:    0x4 IMAGE_REL_MIPS_JMPADDR main (0)
+# CHECK:  }
+# CHECK: ]
 
-# ROUNDTRIP: ImageBase: 1073741824
-# ROUNDTRIP: VirtualAddress:  4096
-# ROUNDTRIP: VirtualAddress:  8192
-# ROUNDTRIP: VirtualAddress:  12288
+# ROUNDTRIP:      Machine: IMAGE_FILE_MACHINE_R4000
+# ROUNDTRIP:      Relocations:
+# ROUNDTRIP-NEXT: - VirtualAddress: 4
+# ROUNDTRIP-NEXT:   SymbolName:     main
+# ROUNDTRIP-NEXT:   Type:           IMAGE_REL_MIPS_JMPADDR
 
 --- !COFF
-OptionalHeader:
-  AddressOfEntryPoint: 4096
-  ImageBase:       1073741824
-  SectionAlignment: 4096
-  FileAlignment:   512
-  MajorOperatingSystemVersion: 6
-  MinorOperatingSystemVersion: 0
-  MajorImageVersion: 0
-  MinorImageVersion: 0
-  MajorSubsystemVersion: 6
-  MinorSubsystemVersion: 0
-  Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
-  DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]
-  SizeOfStackReserve: 1048576
-  SizeOfStackCommit: 4096
-  SizeOfHeapReserve: 1048576
-  SizeOfHeapCommit: 4096
-  ExportTable:
-    RelativeVirtualAddress: 0
-    Size:            0
-  ImportTable:
-    RelativeVirtualAddress: 0
-    Size:            0
-  ResourceTable:
-    RelativeVirtualAddress: 0
-    Size:            0
-  ExceptionTable:
-    RelativeVirtualAddress: 12288
-    Size:            8
-  CertificateTable:
-    RelativeVirtualAddress: 0
-    Size:            0
-  BaseRelocationTable:
-    RelativeVirtualAddress: 0
-    Size:            0
-  Debug:
-    RelativeVirtualAddress: 0
-    Size:            0
-  Architecture:
-    RelativeVirtualAddress: 0
-    Size:            0
-  GlobalPtr:
-    RelativeVirtualAddress: 0
-    Size:            0
-  TlsTable:
-    RelativeVirtualAddress: 0
-    Size:            0
-  LoadConfigTable:
-    RelativeVirtualAddress: 0
-    Size:            0
-  BoundImport:
-    RelativeVirtualAddress: 0
-    Size:            0
-  IAT:
-    RelativeVirtualAddress: 0
-    Size:            0
-  DelayImportDescriptor:
-    RelativeVirtualAddress: 0
-    Size:            0
-  ClrRuntimeHeader:
-    RelativeVirtualAddress: 0
-    Size:            0
 header:
   Machine:         IMAGE_FILE_MACHINE_R4000
-  Characteristics: [ IMAGE_FILE_EXECUTABLE_IMAGE ]
 sections:
   - Name:            .text
     Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
-    VirtualAddress:  4096
-    VirtualSize:     4
-    SectionData:     C0035FD6
-  - Name:            .rdata
-    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
-    VirtualAddress:  8192
     VirtualSize:     12
-    SectionData:     0100400800000000E4E3E3E3
-  - Name:            .pdata
-    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
-    VirtualAddress:  12288
-    VirtualSize:     8
-    SectionData:     '0010000000200000'
-symbols:         []
+    SectionData:     000000000000000C00000000
+    Relocations:
+      - VirtualAddress:  4
+        SymbolName:      main
+        Type:            IMAGE_REL_MIPS_JMPADDR
+symbols:
+  - Name: main
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
 ...


### PR DESCRIPTION
- handle IMAGE_FILE_MACHINE_R4000 machine type
- handle MIPS COFF relocations

llvm-objdump can now parse MIPS COFF files.