### PR TITLE
[lldb] Use system c++ lib for LLDB STL tests

### DIFF
--- a/lldb/test/API/lang/cpp/stl/Makefile
+++ b/lldb/test/API/lang/cpp/stl/Makefile
@@ -1,9 +1,3 @@
 CXX_SOURCES := main.cpp
 
-ifneq ($(OS),Darwin)
-    USE_LIBSTDCPP := 1
-else
-    USE_SYSTEM_STDLIB := 1
-endif
-
 include Makefile.rules


### PR DESCRIPTION
This change partially reverts #112357 to avoid test failures on machines which do not have gcc installed.


Test run: https://ci.chromium.org/ui/p/fuchsia/builders/toolchain.ci.shadow/lldb-linux-x64/b8733897350805827393/overview 