### PR TITLE
[NFC][HLSL] Fix test function names

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/sign.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sign.hlsl
@@ -202,19 +202,19 @@ int4 test_sign_int64_t4(int64_t4 p0) { return sign(p0); }
 // CHECK: define [[FNATTRS]] i32 @
 // CHECK: [[CMP:%.*]] = icmp eq i64 [[ARG:%.*]], 0
 // CHECK: %hlsl.sign = select i1 [[CMP]], i32 0, i32 1
-int test_sign_int64_t(uint64_t p0) { return sign(p0); }
+int test_sign_uint64_t(uint64_t p0) { return sign(p0); }
 
 // CHECK: define [[FNATTRS]] <2 x i32> @
 // CHECK: [[CMP:%.*]] = icmp eq <2 x i64> [[ARG:%.*]], zeroinitializer
 // CHECK: %hlsl.sign = select <2 x i1> [[CMP]], <2 x i32> zeroinitializer, <2 x i32> <i32 1, i32 1>
-int2 test_sign_int64_t2(uint64_t2 p0) { return sign(p0); }
+int2 test_sign_uint64_t2(uint64_t2 p0) { return sign(p0); }
 
 // CHECK: define [[FNATTRS]] <3 x i32> @
 // CHECK: [[CMP:%.*]] = icmp eq <3 x i64> [[ARG:%.*]], zeroinitializer
 // CHECK: %hlsl.sign = select <3 x i1> [[CMP]], <3 x i32> zeroinitializer, <3 x i32> <i32 1, i32 1, i32 1>
-int3 test_sign_int64_t3(uint64_t3 p0) { return sign(p0); }
+int3 test_sign_uint64_t3(uint64_t3 p0) { return sign(p0); }
 
 // CHECK: define [[FNATTRS]] <4 x i32> @
 // CHECK: [[CMP:%.*]] = icmp eq <4 x i64> [[ARG:%.*]], zeroinitializer
 // CHECK: %hlsl.sign = select <4 x i1> [[CMP]], <4 x i32> zeroinitializer, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
-int4 test_sign_int64_t4(uint64_t4 p0) { return sign(p0); }
+int4 test_sign_uint64_t4(uint64_t4 p0) { return sign(p0); }


### PR DESCRIPTION
Fix test names changing `int` to `uint`.
https://github.com/llvm/llvm-project/pull/108396#discussion_r1803524539

@bob80905

            