### PR TITLE
Jump table annotations for Linux

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -453,6 +453,10 @@ public:
   /// function to the current output stream.
   virtual void emitJumpTableInfo();
 
+  /// Emit jump table annotations correlating each table with its associated
+  /// indirect branch instruction.
+  virtual void emitJumpTableAnnotation(const MachineFunction &MF, const MachineInstr &MI);
+
   /// Emit the specified global variable to the .s file.
   virtual void emitGlobalVariable(const GlobalVariable *GV);
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -162,6 +162,10 @@ static cl::opt<bool> EmitJumpTableSizesSection(
     cl::desc("Emit a section containing jump table addresses and sizes"),
     cl::Hidden, cl::init(false));
 
+static cl::opt<bool> AnnotateJumpTables("annotate-jump-tables",
+                                        cl::desc("Annotate jump tables"),
+                                        cl::Hidden, cl::init(false));
+
 STATISTIC(EmittedInsts, "Number of machine instrs printed");
 
 char AsmPrinter::ID = 0;
@@ -1528,6 +1532,25 @@ void AsmPrinter::emitPseudoProbe(const MachineInstr &MI) {
   }
 }
 
+void AsmPrinter::emitJumpTableAnnotation(const MachineFunction &MF,
+                                         const MachineInstr &MI) {
+  if (!AnnotateJumpTables || !TM.getTargetTriple().isOSBinFormatELF())
+    return;
+
+  MCSymbol *JTISymbol = GetJTISymbol(MI.getOperand(0).getImm());
+  MCSymbol *ProvenanceLabel = OutContext.createTempSymbol("jtp");
+
+  const MCExpr *OffsetExpr =
+      MCSymbolRefExpr::create(ProvenanceLabel, OutContext);
+  const MCExpr *JTISymbolExpr =
+      MCSymbolRefExpr::create(JTISymbol, OutContext);
+
+  OutStreamer->emitRelocDirective(*OffsetExpr, "BFD_RELOC_NONE",
+                                  JTISymbolExpr, SMLoc(),
+                                  *OutContext.getSubtargetInfo());
+  OutStreamer->emitLabel(ProvenanceLabel);
+}
+
 void AsmPrinter::emitStackSizeSection(const MachineFunction &MF) {
   if (!MF.getTarget().Options.EmitStackSizeSection)
     return;
@@ -1849,8 +1872,7 @@ void AsmPrinter::emitFunctionBody() {
         OutStreamer->emitRawComment("MEMBARRIER");
         break;
       case TargetOpcode::JUMP_TABLE_DEBUG_INFO:
-        // This instruction is only used to note jump table debug info, it's
-        // purely meta information.
+        emitJumpTableAnnotation(*MF, MI);
         break;
       case TargetOpcode::INIT_UNDEF:
         // This is only used to influence register allocation behavior, no
@@ -2821,6 +2843,25 @@ void AsmPrinter::emitJumpTableInfo() {
     // label differences will be evaluated at write time.
     for (const MachineBasicBlock *MBB : JTBBs)
       emitJumpTableEntry(MJTI, MBB, JTI);
+
+    if (AnnotateJumpTables && TM.getTargetTriple().isOSBinFormatELF()) {
+      // Create a temp symbol for the end of the jump table.
+      MCSymbol *JTIEndSymbol = createTempSymbol("jt_end");
+      OutStreamer->emitLabel(JTIEndSymbol);
+
+      const MCExpr *JTISymbolExpr =
+          MCSymbolRefExpr::create(JTISymbol, OutContext);
+
+      MCSymbol *JTISymbolForSize = OutContext.getOrCreateSymbol(
+          "$JTI" + Twine(MF->getFunctionNumber()) + "_" + Twine(JTI));
+      OutStreamer->emitAssignment(JTISymbolForSize, JTISymbolExpr);
+      OutStreamer->emitSymbolAttribute(JTISymbolForSize, MCSA_ELF_TypeObject);
+
+      const MCExpr *SizeExp = MCBinaryExpr::createSub(
+          MCSymbolRefExpr::create(JTIEndSymbol, OutContext), JTISymbolExpr,
+          OutContext);
+      OutStreamer->emitELFSize(JTISymbolForSize, SizeExp);
+    }
   }
 
   if (EmitJumpTableSizesSection)

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -479,8 +479,10 @@ SDValue TargetLowering::expandIndirectJTBranch(const SDLoc &dl, SDValue Value,
                                                SDValue Addr, int JTI,
                                                SelectionDAG &DAG) const {
   SDValue Chain = Value;
-  // Jump table debug info is only needed if CodeView is enabled.
-  if (DAG.getTarget().getTargetTriple().isOSBinFormatCOFF()) {
+  const auto &Triple = DAG.getTarget().getTargetTriple();
+  // Jump table debug info is only needed if CodeView is enabled,
+  // or when adding jump table annotations to ELF objects.
+  if (Triple.isOSBinFormatCOFF() || Triple.isOSBinFormatELF()) {
     Chain = DAG.getJumpTableDebugInfo(JTI, Chain, dl);
   }
   return DAG.getNode(ISD::BRIND, dl, MVT::Other, Chain, Addr);


### PR DESCRIPTION
This patch adds jump table annotations to ELF objects so that indirect branches can be correlated with their associated jump tables by static analysis tooling operating on [partially linked] object files.

The jump table part is straight-forward:

```asm
	.section	.rodata,"a",@progbits
	.p2align	2, 0x0
.LJTI0_0:
	.long	.LBB0_1-.LJTI0_0
	.long	.LBB0_2-.LJTI0_0
	.long	.LBB0_3-.LJTI0_0
	.long	.LBB0_4-.LJTI0_0
	.long	.LBB0_5-.LJTI0_0
	.long	.LBB0_5-.LJTI0_0
.Ljt_end0:
.set $JTI0_0, .LJTI0_0
	.type	$JTI0_0,@object
	.size	$JTI0_0, .Ljt_end0-.LJTI0_0
```

The handling at the call site is a bit trickier. I ended up reusing the existing jump table debug info support, producing something like

```asm
	leaq	.LJTI0_0(%rip), %rcx
	movslq	(%rcx,%rax,4), %rax
	addq	%rcx, %rax
	.reloc .Ljtp0, BFD_RELOC_NONE, .LJTI0_0
.Ljtp0:
	jmpq	*%rax
```

which works in most cases. However, when the jump destination gets spilled to the stack, we may end up with something like

```asm
   1457c:       4a 8b 04 ed 00 00 00    mov    0x0(,%r13,8),%rax
   14583:       00 
                        14580: R_X86_64_32S     .rodata+0x88
   14584:       48 89 04 24             mov    %rax,(%rsp)

   ...
   14602:       48 8b 04 24             mov    (%rsp),%rax
                        14602: R_X86_64_NONE    .rodata+0x88
   14606:       ff e0                   jmp    *%rax
```

where the relocation is no longer attached to the `jmp` instruction but to the preceding `mov` instruction.

Any hints how to do this properly would be much appreciated.