### PR TITLE
Make `FunctionOpInterface` check `ReturnLike`

### DIFF
--- a/mlir/include/mlir/Interfaces/FunctionInterfaces.h
+++ b/mlir/include/mlir/Interfaces/FunctionInterfaces.h
@@ -20,6 +20,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallString.h"
 

--- a/mlir/include/mlir/Interfaces/FunctionInterfaces.td
+++ b/mlir/include/mlir/Interfaces/FunctionInterfaces.td
@@ -108,6 +108,29 @@ def FunctionOpInterface : OpInterface<"FunctionOpInterface", [
         }
       }
 
+      // FunctionOpInterface is tied to a ReturnLike.
+      Operation *terminator = entryBlock.getTerminator();
+      if (terminator->hasTrait<OpTrait::ReturnLike>()) {
+        return $_op.emitOpError("The body of a FunctionOpInterface must")
+              << "have a ReturnLike terminator.";
+      }
+
+      // Match ReturnLike's operand types and FunctionOpInterface's 
+      // result types.
+      auto returnOperandTypes = terminator->getOperandTypes();
+      auto funcResultTypes =  $_op->getResultTypes();
+      if (funcResultTypes.size() != returnOperandTypes.size()) {
+        return $_op.emitOpError("The number of a FunctionOpInterface's")
+              << "result must match that of the ReturnLike operands.";
+      }
+
+      for (unsigned i = 0; i < funcResultTypes.size(); ++i) {
+        if (funcResultTypes[i] != returnOperandTypes[i]) {
+          return $_op.emitOpError("The result types of a FunctionOpInterface")
+              << "must match the operand types of the ReturnLike.";
+        }
+      }
+
       return success();
     }]>,
     InterfaceMethod<[{

--- a/mlir/include/mlir/Interfaces/FunctionInterfaces.td
+++ b/mlir/include/mlir/Interfaces/FunctionInterfaces.td
@@ -110,9 +110,10 @@ def FunctionOpInterface : OpInterface<"FunctionOpInterface", [
 
       // FunctionOpInterface is tied to a ReturnLike.
       Operation *terminator = entryBlock.getTerminator();
-      if (terminator->hasTrait<OpTrait::ReturnLike>()) {
-        return $_op.emitOpError("The body of a FunctionOpInterface must")
-              << "have a ReturnLike terminator.";
+      if (!terminator->hasTrait<OpTrait::ReturnLike>()) {
+        return $_op.emitOpError("The body of a FunctionOpInterface must have ")
+              << "a ReturnLike terminator, but the current terminator does not "
+              << "have this trait.";
       }
 
       // Match ReturnLike's operand types and FunctionOpInterface's 
@@ -121,7 +122,7 @@ def FunctionOpInterface : OpInterface<"FunctionOpInterface", [
       auto funcResultTypes =  $_op->getResultTypes();
       if (funcResultTypes.size() != returnOperandTypes.size()) {
         return $_op.emitOpError("The number of a FunctionOpInterface's")
-              << "result must match that of the ReturnLike operands.";
+              << "results must match that of the ReturnLike operands.";
       }
 
       for (unsigned i = 0; i < funcResultTypes.size(); ++i) {

--- a/mlir/lib/Dialect/Bufferization/Transforms/OneShotModuleBufferize.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/OneShotModuleBufferize.cpp
@@ -302,8 +302,8 @@ getFuncOpsOrderedByCalls(ModuleOp moduleOp,
       Operation *returnOp = getAssumedUniqueReturnOp(funcOp);
       if (!returnOp)
         return funcOp->emitError()
-               << "cannot bufferize a FuncOp with tensors and "
-                  "without a unique ReturnOp";
+               << "cannot bufferize a FunctionOpInterface with tensors and "
+                  "without a unique ReturnLike";
     }
 
     // Collect function calls and populate the caller map.


### PR DESCRIPTION
**Description:** 

This PR is a follow-up for https://github.com/llvm/llvm-project/pull/110322. The previous PR makes `OneShotBufferize` check if a function operation has a terminator with the `ReturnLike` trait. However, `transform.named_sequence` does not expect `yieldOp` to have the trait. In that PR, the issue is circumvented by `--transform-interpreter="debug-payload-root-tag=payload" `.

This PR tries to tie `ReturnLike` to `FunctionOpInface`. However, I am not sure if it is correct to check `ReturnLike` in the tablegen for `FunctionOpInface`. I have not yet handled all the errors.  Just want to create this PR for further confirmation. 
We might also need to wait for this fix for `transform.named_sequence`  (https://github.com/llvm/llvm-project/pull/111408) to be merged?