### PR TITLE
[Support] Extend ExtensibleRTTI utility to support basic multiple inheritance.

### DIFF
--- a/llvm/include/llvm/Support/ExtensibleRTTI.h
+++ b/llvm/include/llvm/Support/ExtensibleRTTI.h
@@ -120,21 +120,11 @@ public:
   template <typename QueryT> bool isA() const { return isA(QueryT::classID()); }
 
   bool isA(const void *const ClassID) const override {
-    return ClassID == classID() || parentsAreA<ParentTs...>(ClassID);
+    return ClassID == classID() || (ParentTs::isA(ClassID) || ...);
   }
 
   template <typename T> static bool classof(const T *R) {
     return R->template isA<ThisT>();
-  }
-
-private:
-  template <typename T> bool parentsAreA(const void *const ClassID) const {
-    return T::isA(ClassID);
-  }
-
-  template <typename T, typename T2, typename... Ts>
-  bool parentsAreA(const void *const ClassID) const {
-    return T::isA(ClassID) || parentsAreA<T2, Ts...>(ClassID);
   }
 };
 

--- a/llvm/include/llvm/Support/ExtensibleRTTI.h
+++ b/llvm/include/llvm/Support/ExtensibleRTTI.h
@@ -89,13 +89,15 @@ private:
 
 /// Inheritance utility for extensible RTTI.
 ///
-/// Supports single inheritance only: A class can only have one
-/// ExtensibleRTTI-parent (i.e. a parent for which the isa<> test will work),
-/// though it can have many non-ExtensibleRTTI parents.
+/// Multiple inheritance is supported, but RTTIExtends only inherits
+/// constructors from the first base class. All subsequent bases will be
+/// default constructed. Virtual and non-public inheritance are not supported.
 ///
 /// RTTIExtents uses CRTP so the first template argument to RTTIExtends is the
-/// newly introduced type, and the *second* argument is the parent class.
+/// newly introduced type, and the *second and later* arguments are the parent
+/// classes.
 ///
+/// @code{.cpp}
 /// class MyType : public RTTIExtends<MyType, RTTIRoot> {
 /// public:
 ///   static char ID;
@@ -106,11 +108,25 @@ private:
 ///   static char ID;
 /// };
 ///
-template <typename ThisT, typename... ParentTs>
-class RTTIExtends : public ParentTs... {
+/// class MyOtherType : public RTTIExtends<MyOtherType, MyType> {
+/// public:
+///   static char ID;
+/// };
+///
+/// class MyMultipleInheritanceType
+///   : public RTTIExtends<MyMultipleInheritanceType,
+///                        MyDerivedType, MyOtherType> {
+/// public:
+///   static char ID;
+/// };
+///
+/// @endcode
+///
+template <typename ThisT, typename ParentT, typename... ParentTs>
+class RTTIExtends : public ParentT, public ParentTs... {
 public:
-  // Inherit constructors from ParentT.
-  using ParentTs::ParentTs...;
+  // Inherit constructors from the first Parent.
+  using ParentT::ParentT;
 
   static const void *classID() { return &ThisT::ID; }
 
@@ -120,7 +136,8 @@ public:
   template <typename QueryT> bool isA() const { return isA(QueryT::classID()); }
 
   bool isA(const void *const ClassID) const override {
-    return ClassID == classID() || (ParentTs::isA(ClassID) || ...);
+    return ClassID == classID() || ParentT::isA(ClassID) ||
+           (ParentTs::isA(ClassID) || ...);
   }
 
   template <typename T> static bool classof(const T *R) {

--- a/llvm/unittests/Support/ExtensibleRTTITest.cpp
+++ b/llvm/unittests/Support/ExtensibleRTTITest.cpp
@@ -36,15 +36,24 @@ public:
   static char ID;
 };
 
+class MyMultipleInheritanceType
+    : public RTTIExtends<MyMultipleInheritanceType, MyDerivedType,
+                         MyOtherDerivedType> {
+public:
+  static char ID;
+};
+
 char MyBaseType::ID = 0;
 char MyDerivedType::ID = 0;
 char MyOtherDerivedType::ID = 0;
 char MyDeeperDerivedType::ID = 0;
+char MyMultipleInheritanceType::ID = 0;
 
 TEST(ExtensibleRTTI, isa) {
   MyBaseType B;
   MyDerivedType D;
   MyDeeperDerivedType DD;
+  MyMultipleInheritanceType MI;
 
   EXPECT_TRUE(isa<MyBaseType>(B));
   EXPECT_FALSE(isa<MyDerivedType>(B));
@@ -60,26 +69,53 @@ TEST(ExtensibleRTTI, isa) {
   EXPECT_TRUE(isa<MyDerivedType>(DD));
   EXPECT_FALSE(isa<MyOtherDerivedType>(DD));
   EXPECT_TRUE(isa<MyDeeperDerivedType>(DD));
+
+  EXPECT_TRUE(isa<MyBaseType>(MI));
+  EXPECT_TRUE(isa<MyDerivedType>(MI));
+  EXPECT_TRUE(isa<MyOtherDerivedType>(MI));
+  EXPECT_FALSE(isa<MyDeeperDerivedType>(MI));
+  EXPECT_TRUE(isa<MyMultipleInheritanceType>(MI));
 }
 
 TEST(ExtensibleRTTI, cast) {
-  MyDerivedType D;
-  MyBaseType &BD = D;
+  MyMultipleInheritanceType MI;
+  MyDerivedType &D = MI;
+  MyOtherDerivedType &OD = MI;
+  MyBaseType &B = D;
 
-  (void)cast<MyBaseType>(D);
-  (void)cast<MyBaseType>(BD);
-  (void)cast<MyDerivedType>(BD);
+  EXPECT_EQ(&cast<MyBaseType>(D), &B);
+  EXPECT_EQ(&cast<MyDerivedType>(MI), &D);
+  EXPECT_EQ(&cast<MyOtherDerivedType>(MI), &OD);
+  EXPECT_EQ(&cast<MyMultipleInheritanceType>(MI), &MI);
 }
 
 TEST(ExtensibleRTTI, dyn_cast) {
-  MyBaseType B;
-  MyDerivedType D;
+  MyMultipleInheritanceType MI;
+  MyDerivedType &D = MI;
+  MyOtherDerivedType &OD = MI;
   MyBaseType &BD = D;
+  MyBaseType &BOD = OD;
 
-  EXPECT_EQ(dyn_cast<MyDerivedType>(&B), nullptr);
-  EXPECT_EQ(dyn_cast<MyDerivedType>(&D), &D);
   EXPECT_EQ(dyn_cast<MyBaseType>(&BD), &BD);
   EXPECT_EQ(dyn_cast<MyDerivedType>(&BD), &D);
+
+  EXPECT_EQ(dyn_cast<MyBaseType>(&BOD), &BOD);
+  EXPECT_EQ(dyn_cast<MyOtherDerivedType>(&BOD), &OD);
+
+  EXPECT_EQ(dyn_cast<MyBaseType>(&D), &BD);
+  EXPECT_EQ(dyn_cast<MyDerivedType>(&D), &D);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&D), &MI);
+
+  EXPECT_EQ(dyn_cast<MyBaseType>(&OD), &BOD);
+  EXPECT_EQ(dyn_cast<MyOtherDerivedType>(&OD), &OD);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&OD), &MI);
+
+  EXPECT_EQ(dyn_cast<MyDerivedType>(&MI), &D);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&MI), &MI);
+
+  EXPECT_EQ(dyn_cast<MyDerivedType>(&MI), &D);
+  EXPECT_EQ(dyn_cast<MyOtherDerivedType>(&MI), &OD);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&MI), &MI);
 }
 
 } // namespace

--- a/llvm/unittests/Support/ExtensibleRTTITest.cpp
+++ b/llvm/unittests/Support/ExtensibleRTTITest.cpp
@@ -43,11 +43,29 @@ public:
   static char ID;
 };
 
+class MyTypeWithConstructor
+    : public RTTIExtends<MyTypeWithConstructor, MyBaseType> {
+public:
+  static char ID;
+
+  MyTypeWithConstructor(int) {}
+};
+
+class MyDerivedTypeWithConstructor
+    : public RTTIExtends<MyDerivedTypeWithConstructor, MyTypeWithConstructor> {
+public:
+  static char ID;
+
+  MyDerivedTypeWithConstructor(int x) : RTTIExtends(x) {}
+};
+
 char MyBaseType::ID = 0;
 char MyDerivedType::ID = 0;
 char MyOtherDerivedType::ID = 0;
 char MyDeeperDerivedType::ID = 0;
 char MyMultipleInheritanceType::ID = 0;
+char MyTypeWithConstructor::ID = 0;
+char MyDerivedTypeWithConstructor::ID = 0;
 
 TEST(ExtensibleRTTI, isa) {
   MyBaseType B;
@@ -116,6 +134,10 @@ TEST(ExtensibleRTTI, dyn_cast) {
   EXPECT_EQ(dyn_cast<MyDerivedType>(&MI), &D);
   EXPECT_EQ(dyn_cast<MyOtherDerivedType>(&MI), &OD);
   EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&MI), &MI);
+}
+
+TEST(ExtensibleRTTI, multiple_inheritance_constructor) {
+  MyDerivedTypeWithConstructor V(42);
 }
 
 } // namespace


### PR DESCRIPTION
Clients can now pass multiple parent classes to RTTIExtends. Each parent class will be inherited from publicly (and non-virtually). The isa, cast, and dyn_cast methods will now work as expected for types with multiple inheritance.