### PR TITLE
[polly] Avoid llvm::Type::getPointerTo() (NFC)

### DIFF
--- a/polly/lib/CodeGen/LoopGeneratorsKMP.cpp
+++ b/polly/lib/CodeGen/LoopGeneratorsKMP.cpp
@@ -28,27 +28,23 @@ void ParallelLoopGeneratorKMP::createCallSpawnThreads(Value *SubFn,
 
   if (!KMPCMicroTy) {
     // void (*kmpc_micro)(kmp_int32 *global_tid, kmp_int32 *bound_tid, ...)
-    Type *MicroParams[] = {Builder.getInt32Ty()->getPointerTo(),
-                           Builder.getInt32Ty()->getPointerTo()};
+    Type *MicroParams[] = {Builder.getPtrTy(0), Builder.getPtrTy(0)};
 
     KMPCMicroTy = FunctionType::get(Builder.getVoidTy(), MicroParams, true);
   }
 
   // If F is not available, declare it.
   if (!F) {
-    StructType *IdentTy =
-        StructType::getTypeByName(M->getContext(), "struct.ident_t");
-
     GlobalValue::LinkageTypes Linkage = Function::ExternalLinkage;
-    Type *Params[] = {IdentTy->getPointerTo(), Builder.getInt32Ty(),
-                      KMPCMicroTy->getPointerTo()};
+    Type *Params[] = {Builder.getPtrTy(0), Builder.getInt32Ty(),
+                      Builder.getPtrTy(0)};
 
     FunctionType *Ty = FunctionType::get(Builder.getVoidTy(), Params, true);
     F = Function::Create(Ty, Linkage, Name, M);
   }
 
-  Value *Task = Builder.CreatePointerBitCastOrAddrSpaceCast(
-      SubFn, KMPCMicroTy->getPointerTo());
+  Value *Task =
+      Builder.CreatePointerBitCastOrAddrSpaceCast(SubFn, Builder.getPtrTy(0));
 
   Value *Args[] = {SourceLocationInfo,
                    Builder.getInt32(4) /* Number of arguments (w/o Task) */,
@@ -77,12 +73,9 @@ void ParallelLoopGeneratorKMP::deployParallelExecution(Function *SubFn,
 }
 
 Function *ParallelLoopGeneratorKMP::prepareSubFnDefinition(Function *F) const {
-  std::vector<Type *> Arguments = {Builder.getInt32Ty()->getPointerTo(),
-                                   Builder.getInt32Ty()->getPointerTo(),
-                                   LongType,
-                                   LongType,
-                                   LongType,
-                                   Builder.getPtrTy()};
+  std::vector<Type *> Arguments = {
+      Builder.getPtrTy(0), Builder.getPtrTy(0), LongType, LongType, LongType,
+      Builder.getPtrTy()};
 
   FunctionType *FT = FunctionType::get(Builder.getVoidTy(), Arguments, false);
   Function *SubFn = Function::Create(FT, Function::InternalLinkage,
@@ -320,11 +313,8 @@ Value *ParallelLoopGeneratorKMP::createCallGlobalThreadNum() {
 
   // If F is not available, declare it.
   if (!F) {
-    StructType *IdentTy =
-        StructType::getTypeByName(M->getContext(), "struct.ident_t");
-
     GlobalValue::LinkageTypes Linkage = Function::ExternalLinkage;
-    Type *Params[] = {IdentTy->getPointerTo()};
+    Type *Params[] = {Builder.getPtrTy(0)};
 
     FunctionType *Ty = FunctionType::get(Builder.getInt32Ty(), Params, false);
     F = Function::Create(Ty, Linkage, Name, M);
@@ -342,11 +332,8 @@ void ParallelLoopGeneratorKMP::createCallPushNumThreads(Value *GlobalThreadID,
 
   // If F is not available, declare it.
   if (!F) {
-    StructType *IdentTy =
-        StructType::getTypeByName(M->getContext(), "struct.ident_t");
-
     GlobalValue::LinkageTypes Linkage = Function::ExternalLinkage;
-    Type *Params[] = {IdentTy->getPointerTo(), Builder.getInt32Ty(),
+    Type *Params[] = {Builder.getPtrTy(0), Builder.getInt32Ty(),
                       Builder.getInt32Ty()};
 
     FunctionType *Ty = FunctionType::get(Builder.getVoidTy(), Params, false);
@@ -367,20 +354,18 @@ void ParallelLoopGeneratorKMP::createCallStaticInit(Value *GlobalThreadID,
   const std::string Name =
       is64BitArch() ? "__kmpc_for_static_init_8" : "__kmpc_for_static_init_4";
   Function *F = M->getFunction(Name);
-  StructType *IdentTy =
-      StructType::getTypeByName(M->getContext(), "struct.ident_t");
 
   // If F is not available, declare it.
   if (!F) {
     GlobalValue::LinkageTypes Linkage = Function::ExternalLinkage;
 
-    Type *Params[] = {IdentTy->getPointerTo(),
+    Type *Params[] = {Builder.getPtrTy(0),
                       Builder.getInt32Ty(),
                       Builder.getInt32Ty(),
-                      Builder.getInt32Ty()->getPointerTo(),
-                      LongType->getPointerTo(),
-                      LongType->getPointerTo(),
-                      LongType->getPointerTo(),
+                      Builder.getPtrTy(0),
+                      Builder.getPtrTy(0),
+                      Builder.getPtrTy(0),
+                      Builder.getPtrTy(0),
                       LongType,
                       LongType};
 
@@ -414,7 +399,7 @@ void ParallelLoopGeneratorKMP::createCallStaticFini(Value *GlobalThreadID) {
   // If F is not available, declare it.
   if (!F) {
     GlobalValue::LinkageTypes Linkage = Function::ExternalLinkage;
-    Type *Params[] = {IdentTy->getPointerTo(), Builder.getInt32Ty()};
+    Type *Params[] = {Builder.getPtrTy(0), Builder.getInt32Ty()};
     FunctionType *Ty = FunctionType::get(Builder.getVoidTy(), Params, false);
     F = Function::Create(Ty, Linkage, Name, M);
   }
@@ -432,14 +417,12 @@ void ParallelLoopGeneratorKMP::createCallDispatchInit(Value *GlobalThreadID,
   const std::string Name =
       is64BitArch() ? "__kmpc_dispatch_init_8" : "__kmpc_dispatch_init_4";
   Function *F = M->getFunction(Name);
-  StructType *IdentTy =
-      StructType::getTypeByName(M->getContext(), "struct.ident_t");
 
   // If F is not available, declare it.
   if (!F) {
     GlobalValue::LinkageTypes Linkage = Function::ExternalLinkage;
 
-    Type *Params[] = {IdentTy->getPointerTo(),
+    Type *Params[] = {Builder.getPtrTy(0),
                       Builder.getInt32Ty(),
                       Builder.getInt32Ty(),
                       LongType,
@@ -481,12 +464,9 @@ Value *ParallelLoopGeneratorKMP::createCallDispatchNext(Value *GlobalThreadID,
   if (!F) {
     GlobalValue::LinkageTypes Linkage = Function::ExternalLinkage;
 
-    Type *Params[] = {IdentTy->getPointerTo(),
-                      Builder.getInt32Ty(),
-                      Builder.getInt32Ty()->getPointerTo(),
-                      LongType->getPointerTo(),
-                      LongType->getPointerTo(),
-                      LongType->getPointerTo()};
+    Type *Params[] = {Builder.getPtrTy(0), Builder.getInt32Ty(),
+                      Builder.getPtrTy(0), Builder.getPtrTy(0),
+                      Builder.getPtrTy(0), Builder.getPtrTy(0)};
 
     FunctionType *Ty = FunctionType::get(Builder.getInt32Ty(), Params, false);
     F = Function::Create(Ty, Linkage, Name, M);


### PR DESCRIPTION
`llvm::Type::getPointerTo()` is to be deprecated & removed soon.