### PR TITLE
[RISCV] Allow crypto features to imply dependents

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -733,7 +733,8 @@ def HasStdExtZfhOrZvfh
 
 def FeatureStdExtZvkb
     : RISCVExtension<"zvkb", 1, 0,
-                     "'Zvkb' (Vector Bit-manipulation used in Cryptography)">,
+                     "'Zvkb' (Vector Bit-manipulation used in Cryptography)",
+                     [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 52>;
 def HasStdExtZvkb : Predicate<"Subtarget->hasStdExtZvkb()">,
                     AssemblerPredicate<(all_of FeatureStdExtZvkb),
@@ -750,7 +751,8 @@ def HasStdExtZvbb : Predicate<"Subtarget->hasStdExtZvbb()">,
 
 def FeatureStdExtZvbc
     : RISCVExtension<"zvbc", 1, 0,
-                     "'Zvbc' (Vector Carryless Multiplication)">,
+                     "'Zvbc' (Vector Carryless Multiplication)",
+                     [FeatureStdExtZve64x]>,
       RISCVExtensionBitmask<0, 49>;
 def HasStdExtZvbc : Predicate<"Subtarget->hasStdExtZvbc()">,
                     AssemblerPredicate<(all_of FeatureStdExtZvbc),
@@ -758,7 +760,8 @@ def HasStdExtZvbc : Predicate<"Subtarget->hasStdExtZvbc()">,
 
 def FeatureStdExtZvbc32e
     : RISCVExperimentalExtension<"zvbc32e", 0, 7,
-                                 "'Zvbc32e' (Vector Carryless Multiplication with 32-bits elements)">;
+                                 "'Zvbc32e' (Vector Carryless Multiplication with 32-bits elements)",
+                                 [FeatureStdExtZve32x]>;
 
 def HasStdExtZvbcOrZvbc32e : Predicate<"Subtarget->hasStdExtZvbc() || Subtarget->hasStdExtZvbc32e()">,
                              AssemblerPredicate<(any_of FeatureStdExtZvbc, FeatureStdExtZvbc32e),
@@ -766,7 +769,8 @@ def HasStdExtZvbcOrZvbc32e : Predicate<"Subtarget->hasStdExtZvbc() || Subtarget-
 
 def FeatureStdExtZvkg
     : RISCVExtension<"zvkg", 1, 0,
-                     "'Zvkg' (Vector GCM instructions for Cryptography)">,
+                     "'Zvkg' (Vector GCM instructions for Cryptography)",
+                     [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 53>;
 def HasStdExtZvkg : Predicate<"Subtarget->hasStdExtZvkg()">,
                     AssemblerPredicate<(all_of FeatureStdExtZvkg),
@@ -782,7 +786,8 @@ def HasStdExtZvkgs : Predicate<"Subtarget->hasStdExtZvkgs()">,
 
 def FeatureStdExtZvkned
     : RISCVExtension<"zvkned", 1, 0,
-                     "'Zvkned' (Vector AES Encryption & Decryption (Single Round))">,
+                     "'Zvkned' (Vector AES Encryption & Decryption (Single Round))",
+                     [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 54>;
 def HasStdExtZvkned : Predicate<"Subtarget->hasStdExtZvkned()">,
                       AssemblerPredicate<(all_of FeatureStdExtZvkned),
@@ -790,7 +795,8 @@ def HasStdExtZvkned : Predicate<"Subtarget->hasStdExtZvkned()">,
 
 def FeatureStdExtZvknha
     : RISCVExtension<"zvknha", 1, 0,
-                     "'Zvknha' (Vector SHA-2 (SHA-256 only))">,
+                     "'Zvknha' (Vector SHA-2 (SHA-256 only))",
+                     [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 55>;
 def HasStdExtZvknha : Predicate<"Subtarget->hasStdExtZvknha()">,
                       AssemblerPredicate<(all_of FeatureStdExtZvknha),
@@ -798,7 +804,8 @@ def HasStdExtZvknha : Predicate<"Subtarget->hasStdExtZvknha()">,
 
 def FeatureStdExtZvknhb
     : RISCVExtension<"zvknhb", 1, 0,
-                     "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))">,
+                     "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))",
+                     [FeatureStdExtZve64x]>,
       RISCVExtensionBitmask<0, 56>;
 def HasStdExtZvknhb : Predicate<"Subtarget->hasStdExtZvknhb()">,
                       AssemblerPredicate<(all_of FeatureStdExtZvknhb),
@@ -810,7 +817,8 @@ def HasStdExtZvknhaOrZvknhb : Predicate<"Subtarget->hasStdExtZvknha() || Subtarg
 
 def FeatureStdExtZvksed
     : RISCVExtension<"zvksed", 1, 0,
-                     "'Zvksed' (SM4 Block Cipher Instructions)">,
+                     "'Zvksed' (SM4 Block Cipher Instructions)",
+                     [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 57>;
 def HasStdExtZvksed : Predicate<"Subtarget->hasStdExtZvksed()">,
                       AssemblerPredicate<(all_of FeatureStdExtZvksed),
@@ -818,7 +826,8 @@ def HasStdExtZvksed : Predicate<"Subtarget->hasStdExtZvksed()">,
 
 def FeatureStdExtZvksh
     : RISCVExtension<"zvksh", 1, 0,
-                     "'Zvksh' (SM3 Hash Function Instructions)">,
+                     "'Zvksh' (SM3 Hash Function Instructions)",
+                     [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 58>;
 def HasStdExtZvksh : Predicate<"Subtarget->hasStdExtZvksh()">,
                      AssemblerPredicate<(all_of FeatureStdExtZvksh),

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -643,60 +643,22 @@ TEST(ParseArchString, MissingDepency) {
               "'zvl*b' requires 'v' or 'zve*' extension to also be specified");
   }
 
-  for (StringRef Input : {"rv32i_zvbb"}) {
+  // These all have an implication relationship, thus should pass
+  for (StringRef Input : {
+           "rv32i_zvbb",
+           "rv32i_zvbc32e0p7",
+           "rv32i_zvbc",
+           "rv32i_zvkb",
+           "rv32i_zvkg",
+           "rv32i_zvkgs0p7",
+           "rv32i_zvkned",
+           "rv32i_zvknha",
+           "rv32i_zvksed",
+           "rv32i_zvksh",
+           "rv32i_zvknhb",
+       }) {
     EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvbb' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvbc32e0p7"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvbc32e' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvbc"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvbc' requires 'v' or 'zve64*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvkb"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvkb' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvkg"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvkg' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvkgs0p7"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvkg' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvkned"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvkned' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvknha"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvknha' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvksed"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvksed' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvksh"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'zvksh' requires 'v' or 'zve*' extension to also be specified");
-  }
-
-  for (StringRef Input : {"rv32i_zvknhb"}) {
-    EXPECT_EQ(
-        toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-        "'zvknhb' requires 'v' or 'zve64*' extension to also be specified");
+              "");
   }
 
   for (StringRef Input : {"rv32i_zacas1p0"}) {


### PR DESCRIPTION
This relationship is a logical dependency.

Note Zvbc and Zvknhb. They are explicitly called out in the spec as requiring 64 bits:
- https://github.com/riscv/riscv-crypto/blob/56ed7952d13eb5bdff92e2b522404668952f416d/doc/vector/riscv-crypto-spec-vector.adoc