### PR TITLE
[ORC_RT][COFF] add more mutex to internal api

### DIFF
--- a/compiler-rt/lib/orc/coff_platform.cpp
+++ b/compiler-rt/lib/orc/coff_platform.cpp
@@ -168,6 +168,7 @@ COFFPlatformRuntimeState *COFFPlatformRuntimeState::CPS = nullptr;
 
 COFFPlatformRuntimeState::JITDylibState *
 COFFPlatformRuntimeState::getJITDylibStateByHeader(void *Header) {
+  std::lock_guard<std::recursive_mutex> Lock(JDStatesMutex);
   auto I = JDStates.find(Header);
   if (I == JDStates.end())
     return nullptr;
@@ -176,6 +177,7 @@ COFFPlatformRuntimeState::getJITDylibStateByHeader(void *Header) {
 
 COFFPlatformRuntimeState::JITDylibState *
 COFFPlatformRuntimeState::getJITDylibStateByName(std::string_view Name) {
+  std::lock_guard<std::recursive_mutex> Lock(JDStatesMutex);
   // FIXME: Avoid creating string copy here.
   auto I = JDNameToHeader.find(std::string(Name.data(), Name.size()));
   if (I == JDNameToHeader.end())


### PR DESCRIPTION
Add more mutex to wherever `JDStates` is used to avoid data race problem.