### PR TITLE
[APInt] Enable APInt ctor assertion by default

### DIFF
--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -109,7 +109,7 @@ public:
   /// \param implicitTrunc allow implicit truncation of non-zero/sign bits of
   ///                      val beyond the range of numBits
   APInt(unsigned numBits, uint64_t val, bool isSigned = false,
-        bool implicitTrunc = true)
+        bool implicitTrunc = false)
       : BitWidth(numBits) {
     if (!implicitTrunc) {
       if (isSigned) {


### PR DESCRIPTION
This enables the assertion introduced in https://github.com/llvm/llvm-project/pull/106524, which checks that the value passed to the APInt constructor is indeed a valid N-bit signed or unsigned integer.

Places that previously violated the assertion were updated in advance, e.g. in https://github.com/llvm/llvm-project/pull/80309.

It is possible to opt-out of the check and restore the previous behavior by setting implicitTrunc=true.