### PR TITLE
[llvm][TableGen] Count implicit defs as well as explicit ones in the GlobalISel TableGen emitter

### DIFF
--- a/llvm/test/TableGen/GlobalISelEmitter-implicit-defs.td
+++ b/llvm/test/TableGen/GlobalISelEmitter-implicit-defs.td
@@ -1,9 +1,8 @@
-// RUN: llvm-tblgen -gen-global-isel -warn-on-skipped-patterns -I %p/../../include -I %p/Common %s -o /dev/null 2>&1 < %s | FileCheck %s
+// RUN: llvm-tblgen -gen-global-isel -warn-on-skipped-patterns -I %p/../../include -I %p/Common %s -o /dev/null 2>&1 < %s | FileCheck %s --implicit-check-not="Skipped pattern"
 
 include "llvm/Target/Target.td"
 include "GlobalISelEmitterCommon.td"
 
-// CHECK-NOT: Skipped pattern: Src pattern result has 1 def(s) without the HasNoUse predicate set to true but Dst MI has no def
 // CHECK: Skipped pattern: Pattern defines a physical register
 let Uses = [B0], Defs = [B0] in
 def tst1 : I<(outs), (ins), [(set B0, (add B0, 1))]>;

--- a/llvm/test/TableGen/GlobalISelEmitter-implicit-defs.td
+++ b/llvm/test/TableGen/GlobalISelEmitter-implicit-defs.td
@@ -1,0 +1,13 @@
+// RUN: llvm-tblgen -gen-global-isel -warn-on-skipped-patterns -I %p/../../include -I %p/Common %s -o /dev/null 2>&1 < %s | FileCheck %s
+
+include "llvm/Target/Target.td"
+include "GlobalISelEmitterCommon.td"
+
+// CHECK-NOT: Skipped pattern: Src pattern result has 1 def(s) without the HasNoUse predicate set to true but Dst MI has no def
+// CHECK: Skipped pattern: Pattern defines a physical register
+let Uses = [B0], Defs = [B0] in
+def tst1 : I<(outs), (ins), [(set B0, (add B0, 1))]>;
+
+// CHECK: Skipped pattern: Src pattern result has 1 def(s) without the HasNoUse predicate set to true but Dst MI has no def
+let Uses = [B0] in
+def tst2 : I<(outs), (ins), [(set B0, (add B0, 1))]>;

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -2023,7 +2023,10 @@ Expected<RuleMatcher> GlobalISelEmitter::runOnPattern(const PatternToMatch &P) {
   auto &DstI = Target.getInstruction(DstOp);
   StringRef DstIName = DstI.TheDef->getName();
 
-  unsigned DstNumDefs = DstI.Operands.NumDefs,
+  // Count both implicit and explicit defs in the dst instruction.
+  // This avoids errors importing patterns that have inherent implicit defs.
+  unsigned DstExpDefs = DstI.Operands.NumDefs,
+           DstNumDefs = DstI.ImplicitDefs.size() + DstExpDefs,
            SrcNumDefs = Src.getExtTypes().size();
   if (DstNumDefs < SrcNumDefs) {
     if (DstNumDefs != 0)
@@ -2045,7 +2048,7 @@ Expected<RuleMatcher> GlobalISelEmitter::runOnPattern(const PatternToMatch &P) {
   // The root of the match also has constraints on the register bank so that it
   // matches the result instruction.
   unsigned OpIdx = 0;
-  unsigned N = std::min(DstNumDefs, SrcNumDefs);
+  unsigned N = std::min(DstExpDefs, SrcNumDefs);
   for (unsigned I = 0; I < N; ++I) {
     const TypeSetByHwMode &VTy = Src.getExtType(I);
 


### PR DESCRIPTION
`NumDefs` only counts the number of registers in `(outs)`, not any implicit defs specified with `Defs = [...]`

This causes patterns with physical register defs to fail to import here instead of later where implicit defs are rendered.

Add on `ImplicitDefs.size()` to count both and create `DstExpDefs` to count only explicit defs, used later on.