### PR TITLE
[libc++][vector] include formatter only in C++23

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -324,8 +324,6 @@ template<class T, class charT> requires is-vector-bool-reference<T> // Since C++
 #include <__config>
 #include <__debug_utils/sanitizers.h>
 #include <__format/enable_insertable.h>
-#include <__format/formatter.h>
-#include <__format/formatter_bool.h>
 #include <__functional/hash.h>
 #include <__functional/unary_function.h>
 #include <__fwd/vector.h>
@@ -390,6 +388,11 @@ template<class T, class charT> requires is-vector-bool-reference<T> // Since C++
 // [vector.syn]
 #include <compare>
 #include <initializer_list>
+
+#if _LIBCPP_STD_VER >= 23
+#  include <__format/formatter.h>
+#  include <__format/formatter_bool.h>
+#endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/test/libcxx/transitive_includes/cxx03.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx03.csv
@@ -2596,7 +2596,6 @@ variant typeinfo
 variant utility
 variant version
 vector algorithm
-vector array
 vector atomic
 vector bit
 vector cctype

--- a/libcxx/test/libcxx/transitive_includes/cxx11.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx11.csv
@@ -2596,7 +2596,6 @@ variant typeinfo
 variant utility
 variant version
 vector algorithm
-vector array
 vector atomic
 vector bit
 vector cctype

--- a/libcxx/test/libcxx/transitive_includes/cxx14.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx14.csv
@@ -2649,7 +2649,6 @@ variant typeinfo
 variant utility
 variant version
 vector algorithm
-vector array
 vector atomic
 vector bit
 vector cctype

--- a/libcxx/test/libcxx/transitive_includes/cxx17.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx17.csv
@@ -2620,7 +2620,6 @@ variant typeinfo
 variant utility
 variant version
 vector algorithm
-vector array
 vector atomic
 vector bit
 vector cctype

--- a/libcxx/test/libcxx/transitive_includes/cxx20.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx20.csv
@@ -2616,7 +2616,6 @@ variant typeinfo
 variant utility
 variant version
 vector algorithm
-vector array
 vector atomic
 vector bit
 vector cctype


### PR DESCRIPTION
This is to reduce included header file size in pre C++23 build.

e.g. 2% of total included file coming from formatter_bool.h in chrome build.
https://commondatastorage.googleapis.com/chromium-browser-clang/chrome_includes_2024-10-17_004801.html#view=edges&filter=&sort=asize&reverse=&includer=%5Ethird_party%2Flibc%5C%2B%5C%2B%2Fsrc%2Finclude%2Fvector%24&included=&limit=1000