### PR TITLE
[clang][bytecode] Explicitly truncate in IntegralAP::from()

### DIFF
--- a/clang/lib/AST/ByteCode/Integral.h
+++ b/clang/lib/AST/ByteCode/Integral.h
@@ -122,11 +122,14 @@ public:
   APSInt toAPSInt() const {
     return APSInt(APInt(Bits, static_cast<uint64_t>(V), Signed), !Signed);
   }
-  APSInt toAPSInt(unsigned NumBits) const {
+  APSInt toAPSInt(unsigned BitWidth) const { return APSInt(toAPInt(BitWidth)); }
+  APInt toAPInt(unsigned BitWidth) const {
     if constexpr (Signed)
-      return APSInt(toAPSInt().sextOrTrunc(NumBits), !Signed);
+      return APInt(Bits, static_cast<uint64_t>(V), Signed)
+          .sextOrTrunc(BitWidth);
     else
-      return APSInt(toAPSInt().zextOrTrunc(NumBits), !Signed);
+      return APInt(Bits, static_cast<uint64_t>(V), Signed)
+          .zextOrTrunc(BitWidth);
   }
   APValue toAPValue(const ASTContext &) const { return APValue(toAPSInt()); }
 

--- a/clang/lib/AST/ByteCode/IntegralAP.h
+++ b/clang/lib/AST/ByteCode/IntegralAP.h
@@ -112,12 +112,7 @@ public:
 
   template <unsigned Bits, bool InputSigned>
   static IntegralAP from(Integral<Bits, InputSigned> I, unsigned BitWidth) {
-    // TODO: Avoid implicit trunc?
-    // See https://github.com/llvm/llvm-project/issues/112510.
-    APInt Copy = APInt(BitWidth, static_cast<uint64_t>(I), InputSigned,
-                       /*implicitTrunc=*/true);
-
-    return IntegralAP<Signed>(Copy);
+    return IntegralAP<Signed>(I.toAPInt(BitWidth));
   }
 
   static IntegralAP zero(int32_t BitWidth) {


### PR DESCRIPTION
Add Integral::toAPInt(), which truncates to the given BitWidth, similar to the toAPSInt() we already have.