### PR TITLE
[clang-include-cleaner] Fix -Wpessimizing-move warning introduced in 4cda28c1ada702a08f6960eb4c93919187c1d4d1

### DIFF
--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -299,7 +299,7 @@ mapInputsToAbsPaths(clang::tooling::CompilationDatabase &CDB,
     if (auto Err = VFS->makeAbsolute(AbsPath)) {
       llvm::errs() << "Failed to get absolute path for " << Source << " : "
                    << Err.message() << '\n';
-      return std::move(llvm::errorCodeToError(Err));
+      return llvm::errorCodeToError(Err);
     }
     std::vector<clang::tooling::CompileCommand> Cmds =
         CDB.getCompileCommands(AbsPath);


### PR DESCRIPTION
Failing log: https://lab.llvm.org/buildbot/#/builders/145/builds/2540