### PR TITLE
[compiler-rt][profile] Use `flock` shim on Windows even if detection fails

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -152,7 +152,8 @@ COMPILER_RT_VISIBILITY int lprofLockFd(int fd) {
     }
   }
   return 0;
-#elif defined(COMPILER_RT_HAS_FLOCK)
+#elif defined(COMPILER_RT_HAS_FLOCK) || defined(_WIN32)
+  // Windows doesn't have flock but WindowsMMap.h provides a shim
   flock(fd, LOCK_EX);
   return 0;
 #else
@@ -179,7 +180,8 @@ COMPILER_RT_VISIBILITY int lprofUnlockFd(int fd) {
     }
   }
   return 0;
-#elif defined(COMPILER_RT_HAS_FLOCK)
+#elif defined(COMPILER_RT_HAS_FLOCK) || defined(_WIN32)
+  // Windows doesn't have flock but WindowsMMap.h provides a shim
   flock(fd, LOCK_UN);
   return 0;
 #else


### PR DESCRIPTION
This is a follow-up fix for d4efc3e097f40afbe8ae275150f49bb08fc04572, which introduced CMake-time feature test for `flock`. The feature test always fails on Windows, but we still need to use the `flock` shim provided by WindowsMMap.h regardless of the feature test result.