### PR TITLE
[flang] Update printing values in dump-parse-tree

### DIFF
--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -884,8 +884,10 @@ protected:
     } else if constexpr (HasSource<T>::value) {
       return x.source.ToString();
 #endif
-    } else if constexpr (std::is_same_v<T, std::string>) {
-      return x;
+    } else if constexpr (std::is_same_v<T, int>) {
+      return std::to_string(x);
+    } else if constexpr (std::is_same_v<T, bool>) {
+      return x ? "true" : "false";
     } else {
       return "";
     }

--- a/flang/test/Parser/OpenMP/allocate-tree.f90
+++ b/flang/test/Parser/OpenMP/allocate-tree.f90
@@ -18,6 +18,19 @@ program allocate_tree
     allocate(w, xarray(4), zarray(t, z))
 end program allocate_tree
 
+!CHECK: | | DeclarationConstruct -> SpecificationConstruct -> TypeDeclarationStmt
+!CHECK-NEXT: | | | DeclarationTypeSpec -> IntrinsicTypeSpec -> IntegerTypeSpec ->
+!CHECK-NEXT: | | | AttrSpec -> Allocatable
+!CHECK-NEXT: | | | EntityDecl
+!CHECK-NEXT: | | | | Name = 'w'
+!CHECK-NEXT: | | | EntityDecl
+!CHECK-NEXT: | | | | Name = 'xarray'
+!CHECK-NEXT: | | | | ArraySpec -> DeferredShapeSpecList -> int = '1'
+!CHECK-NEXT: | | | EntityDecl
+!CHECK-NEXT: | | | | Name = 'zarray'
+!CHECK-NEXT: | | | | ArraySpec -> DeferredShapeSpecList -> int = '2'
+
+
 !CHECK: | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPExecutableAllocate
 !CHECK-NEXT: | | | Verbatim
 !CHECK-NEXT: | | | OmpClauseList ->


### PR DESCRIPTION
Remove 'if std::string' that is covered by another branch of the if-statement.
Add printing of 'bool' and 'int' values, since they have corresponding `GetNodeName` definitions.