### PR TITLE
[FuncSpec] Update MinFunctionSize logic

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -643,7 +643,7 @@ bool FunctionSpecializer::run() {
 
     // When specializing literal constants is enabled, always require functions
     // to be larger than MinFunctionSize, to prevent excessive specialization.
-    bool RequireMinSize =
+    const bool RequireMinSize =
         !ForceSpecialization &&
         (SpecializeLiteralConstant || !F.hasFnAttribute(Attribute::NoInline));
 

--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -57,9 +57,9 @@ static cl::opt<unsigned> MaxBlockPredecessors(
     "considered during the estimation of dead code"));
 
 static cl::opt<unsigned> MinFunctionSize(
-    "funcspec-min-function-size", cl::init(300), cl::Hidden, cl::desc(
-    "Don't specialize functions that have less than this number of "
-    "instructions"));
+    "funcspec-min-function-size", cl::init(500), cl::Hidden,
+    cl::desc("Don't specialize functions that have less than this number of "
+             "instructions"));
 
 static cl::opt<unsigned> MaxCodeSizeGrowth(
     "funcspec-max-codesize-growth", cl::init(3), cl::Hidden, cl::desc(
@@ -641,12 +641,17 @@ bool FunctionSpecializer::run() {
         Metrics.analyzeBasicBlock(&BB, GetTTI(F), EphValues);
     }
 
+    // When specializing literal constants is enabled, always require functions
+    // to be larger than MinFunctionSize, to prevent excessive specialization.
+    bool RequireMinSize =
+        !ForceSpecialization &&
+        (SpecializeLiteralConstant || !F.hasFnAttribute(Attribute::NoInline));
+
     // If the code metrics reveal that we shouldn't duplicate the function,
     // or if the code size implies that this function is easy to get inlined,
     // then we shouldn't specialize it.
     if (Metrics.notDuplicatable || !Metrics.NumInsts.isValid() ||
-        (!ForceSpecialization && !F.hasFnAttribute(Attribute::NoInline) &&
-         Metrics.NumInsts < MinFunctionSize))
+        (RequireMinSize && Metrics.NumInsts < MinFunctionSize))
       continue;
 
     // TODO: For now only consider recursive functions when running multiple

--- a/llvm/test/Transforms/FunctionSpecialization/noinline.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/noinline.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S --passes="ipsccp<func-spec>" < %s | FileCheck %s
+; RUN: opt -S --passes="ipsccp<func-spec>" -funcspec-for-literal-constant=false < %s | FileCheck %s
 define dso_local i32 @p0(i32 noundef %x) {
 entry:
   %add = add nsw i32 %x, 1


### PR DESCRIPTION
Always require functions to be larger than MinFunctionSize when SpecializeLiteralConstant is enabled, and increase MinFunctionSize to 500, to prevent excessive triggering of specialisations on small functions.