### PR TITLE
[lldb][test][NFC] Document DYLIB_NAME Makefile variable

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -14,9 +14,9 @@
 # DYLIB_ONLY := YES
 #
 # When specifying one of the DYLIB_*_SOURCES variables, DYLIB_NAME
-# controls the name of the produced dylib. E.g., if set to "foo",
-# the generated dylib will be called "foo.<platform-specific-extension>",
-# which on Darwin will be "foo.dylib".
+# controls the (platform-dependent) name of the produced dylib. E.g.,
+# on Darwin, if "DYLIB_NAME := foo", the generated dylib will be called
+# "foo.dylib".
 #
 # DYLIB_NAME := foo
 #

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -13,6 +13,13 @@
 # the building of the a.out executable program.  For example,
 # DYLIB_ONLY := YES
 #
+# When specifying one of the DYLIB_*_SOURCES variables, DYLIB_NAME
+# controls the name of the produced dylib. E.g., if set to "foo",
+# the generated dylib will be called "foo.<platform-specific-extension>",
+# which on Darwin will be "foo.dylib".
+#
+# DYLIB_NAME := foo
+#
 # Specifying FRAMEWORK and its variants has the effect of building a NeXT-style
 # framework.
 # FRAMEWORK := "Foo"

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -16,7 +16,7 @@
 # When specifying one of the DYLIB_*_SOURCES variables, DYLIB_NAME
 # controls the (platform-dependent) name of the produced dylib. E.g.,
 # on Darwin, if "DYLIB_NAME := foo", the generated dylib will be called
-# "foo.dylib".
+# "libfoo.dylib".
 #
 # DYLIB_NAME := foo
 #


### PR DESCRIPTION
Got caught out by this because simply specifying `DYLIB_CXX_SOURCES` (without specifying `DYLIB_NAME`) resulted in linker errors because the dylib was never built (and linked). We should probably make that a Makefile error (though I haven't audited when exactly not specifying `DYLIB_NAME` is valid; looked like that can happen when we specify `FRAMEWORK`).