### PR TITLE
[libc++] Remove obsolete _LIBCPP_PREDEFINED_OBJC_ARC_ADDRESSOF

### DIFF
--- a/libcxx/include/__memory/addressof.h
+++ b/libcxx/include/__memory/addressof.h
@@ -23,11 +23,9 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_NO_CFI _LIBCPP_HIDE_FROM_ABI _Tp* a
   return __builtin_addressof(__x);
 }
 
-#if _LIBCPP_HAS_OBJC_ARC && !defined(_LIBCPP_PREDEFINED_OBJC_ARC_ADDRESSOF)
+#if _LIBCPP_HAS_OBJC_ARC
 // Objective-C++ Automatic Reference Counting uses qualified pointers
-// that require special addressof() signatures. When
-// _LIBCPP_PREDEFINED_OBJC_ARC_ADDRESSOF is defined, the compiler
-// itself is providing these definitions. Otherwise, we provide them.
+// that require special addressof() signatures.
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI __strong _Tp* addressof(__strong _Tp& __x) _NOEXCEPT {
   return &__x;


### PR DESCRIPTION
I don't know if that macro was ever truly defined by Clang, however it's not anymore, so that is effectively dead code.