### PR TITLE
[libc++] Re-add attribute macro to clang-format

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -30,6 +30,7 @@ AttributeMacros: [
                   '_LIBCPP_DEPRECATED_IN_CXX20',
                   '_LIBCPP_DEPRECATED_IN_CXX23',
                   '_LIBCPP_DEPRECATED',
+                  '_LIBCPP_DISABLE_EXTENSION_WARNING',
                   '_LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION',
                   '_LIBCPP_EXPORTED_FROM_ABI',
                   '_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS',


### PR DESCRIPTION
That macro was removed incorrectly from the clang-format file because it had a typo in its name. However, the macro with the right name is still being used in the library (sadly, in a single place).