### PR TITLE
[lldb][ClangASTImporter][NFC] Emit a log message when we break MapImported invariant

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1184,8 +1184,8 @@ void ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(
                  "({1}Decl*){2:x}, named {3} (from "
                  "(Decl*){4:x})",
                  static_cast<void *>(to->getTranslationUnitDecl()),
-                 from->getDeclKindName(), static_cast<void *>(to), getDeclName(from),
-                 static_cast<void *>(from));
+                 from->getDeclKindName(), static_cast<void *>(to),
+                 getDeclName(from), static_cast<void *>(from));
 
         // Log the AST of the TU.
         std::string ast_string;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1148,12 +1148,15 @@ void ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(
     return name_string;
   };
 
-  if (auto *D = GetAlreadyImportedOrNull(from); D && D != to)
-    LLDB_LOG(log,
-             "[ClangASTImporter] WARNING: overwriting an already imported decl "
-             "'{0:x}' ('{1}') from '{2:x}' with '{3:x}'. Likely due to a name "
-             "conflict when importing '{1}'.",
-             D, getDeclName(from), from, to);
+  if (log) {
+    if (auto *D = GetAlreadyImportedOrNull(from); D && D != to) {
+      LLDB_LOG(log,
+               "[ClangASTImporter] ERROR: overwriting an already imported decl "
+               "'{0:x}' ('{1}') from '{2:x}' with '{3:x}'. Likely due to a name "
+               "conflict when importing '{1}'.",
+               D, getDeclName(from), from, to);
+    }
+  }
 
   // We might have a forward declaration from a shared library that we
   // gave external lexical storage so that Clang asks us about the full

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1150,11 +1150,12 @@ void ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(
 
   if (log) {
     if (auto *D = GetAlreadyImportedOrNull(from); D && D != to) {
-      LLDB_LOG(log,
-               "[ClangASTImporter] ERROR: overwriting an already imported decl "
-               "'{0:x}' ('{1}') from '{2:x}' with '{3:x}'. Likely due to a name "
-               "conflict when importing '{1}'.",
-               D, getDeclName(from), from, to);
+      LLDB_LOG(
+          log,
+          "[ClangASTImporter] ERROR: overwriting an already imported decl "
+          "'{0:x}' ('{1}') from '{2:x}' with '{3:x}'. Likely due to a name "
+          "conflict when importing '{1}'.",
+          D, getDeclName(from), from, to);
     }
   }
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1179,13 +1179,12 @@ void ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(
       to_tag->setCompleteDefinition(from_tag->isCompleteDefinition());
 
       if (Log *log_ast = GetLog(LLDBLog::AST)) {
-        std::string name_string = getDeclName(from);
         LLDB_LOG(log_ast,
                  "==== [ClangASTImporter][TUDecl: {0:x}] Imported "
                  "({1}Decl*){2:x}, named {3} (from "
                  "(Decl*){4:x})",
                  static_cast<void *>(to->getTranslationUnitDecl()),
-                 from->getDeclKindName(), static_cast<void *>(to), name_string,
+                 from->getDeclKindName(), static_cast<void *>(to), getDeclName(from),
                  static_cast<void *>(from));
 
         // Log the AST of the TU.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1151,8 +1151,8 @@ void ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(
   if (auto *D = GetAlreadyImportedOrNull(from); D && D != to)
     LLDB_LOG(log,
              "[ClangASTImporter] WARNING: overwriting an already imported decl "
-             "'{0:x}' ('{1}') from '{2:x}' with {3:x}. Likely due to a name "
-             "conflict when importing {1}.",
+             "'{0:x}' ('{1}') from '{2:x}' with '{3:x}'. Likely due to a name "
+             "conflict when importing '{1}'.",
              D, getDeclName(from), from, to);
 
   // We might have a forward declaration from a shared library that we


### PR DESCRIPTION
This patch emits a warning into the expression log when we call `MapImported` on a decl which has already been imported, but with a new `to` destination decl. In asserts builds this would lead to triggering this [ASTImporter::MapImported assertion](https://github.com/llvm/llvm-project/blob/6d7712a70c163d2ae9e1dc928db31fcb45d9e404/clang/lib/AST/ASTImporter.cpp#L10493-L10494). In no-asserts builds we will likely crash, in potentially non-obvious ways. The hope is that the log message will help in diagnosing this type of issue in the field.

The underlying issue is discussed in more detail in: https://github.com/llvm/llvm-project/pull/112566.

In a non-asserts build, the last few expression log entries would look as follows:
```
     CompleteTagDecl on (ASTContext*)scratch ASTContext Completing (TagDecl*)0x00000001132d31d0 named Foo
       CTD Before:
CXXRecordDecl 0x1132d31d0 <<invalid sloc>> <invalid sloc> <undeserialized declarations> struct Foo

 [ClangASTImporter] WARNING: overwriting an already imported decl '0x000000014378fd80' ('Foo') from '0x0000000143790c00' with 0x00000001132d31d0. Likely due to a name conflict when importing 'Foo'.
     [ClangASTImporter] Imported (FieldDecl*)0x0000000143790220, named service (from (Decl*)0x0000000143791270), metadata 271
     [ClangASTImporter] Decl has no origin information in (ASTContext*)0x00000001132c8c00
 FindExternalLexicalDecls on (ASTContext*)0x0000000143c1f600 'scratch ASTContext' in 'Foo' (CXXRecordDecl*)0x000000014378FD80
   FELD Original decl (ASTContext*)0x00000001132c8c00 (Decl*)0x0000000143790c00:
CXXRecordDecl 0x143790c00 <<invalid sloc>> <invalid sloc> struct Foo definition
|-DefinitionData pass_in_registers aggregate standard_layout trivially_copyable pod trivial literal
| |-DefaultConstructor exists trivial needs_implicit
| |-CopyConstructor simple trivial has_const_param needs_implicit implicit_has_const_param
| |-MoveConstructor exists simple trivial needs_implicit
| |-CopyAssignment simple trivial has_const_param needs_implicit implicit_has_const_param
| |-MoveAssignment exists simple trivial needs_implicit
| `-Destructor simple irrelevant trivial needs_implicit
|-FieldDecl 0x143791270 <<invalid sloc>> <invalid sloc> service 'Service *'
`-FieldDecl 0x1437912c8 <<invalid sloc>> <invalid sloc> mach_endpoint 'int'

   FELD Adding [to CXXRecordDecl Foo] lexical FieldDecl FieldDecl 0x143791270 <<invalid sloc>> <invalid sloc> service 'Service *'

   FELD Adding [to CXXRecordDecl Foo] lexical FieldDecl FieldDecl 0x1437912c8 <<invalid sloc>> <invalid sloc> mach_endpoint 'int'

     [ClangASTImporter] Imported (FieldDecl*)0x0000000143790278, named mach_endpoint (from (Decl*)0x00000001437912c8), metadata 280
     [ClangASTImporter] Decl has no origin information in (ASTContext*)0x00000001132c8c00
```
Note how we start "completing" `Foo`. Then emit our new `WARNING`. Shortly after, we crash, and the log abruptly ends.

rdar://135551810