### PR TITLE
Fix build break in SemaHLSL.cpp on MSVC 2022: warning C4715: 'getResourceClass': not all control paths return a value

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -102,9 +102,9 @@ static ResourceClass getResourceClass(RegisterType RT) {
     return ResourceClass::Sampler;
   case RegisterType::C:
   case RegisterType::I:
-  default:
     llvm_unreachable("unexpected RegisterType value");
   }
+  llvm_unreachable("unhandled RegisterType");
 }
 
 DeclBindingInfo *ResourceBindings::addDeclBindingInfo(const VarDecl *VD,

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -102,6 +102,7 @@ static ResourceClass getResourceClass(RegisterType RT) {
     return ResourceClass::Sampler;
   case RegisterType::C:
   case RegisterType::I:
+  default:
     llvm_unreachable("unexpected RegisterType value");
   }
 }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -102,9 +102,10 @@ static ResourceClass getResourceClass(RegisterType RT) {
     return ResourceClass::Sampler;
   case RegisterType::C:
   case RegisterType::I:
-    llvm_unreachable("unexpected RegisterType value");
+    // Deliberately falling through to the unreachable below.
+    break;
   }
-  llvm_unreachable("unhandled RegisterType");
+  llvm_unreachable("unexpected RegisterType value");
 }
 
 DeclBindingInfo *ResourceBindings::addDeclBindingInfo(const VarDecl *VD,


### PR DESCRIPTION
Moves the existing `llvm_unreachable` statement to the bottom of the function and changes the case statement to deliberately fall through to it.

Build break was introduced by #111203

It was not caught by the builders as they use Visual Studio 2019, whereas this warning only appears in 2022.