### PR TITLE
[libunwind][AIX] Call dlclose only when dlsym() fails

### DIFF
--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -2151,8 +2151,8 @@ bool UnwindCursor<A, R>::getInfoFromTBTable(pint_t pc, R &registers) {
         if (xlcPersonalityV0 == NULL) {
           _LIBUNWIND_TRACE_UNWINDING("dlsym() failed with errno=%d\n", errno);
           assert(0 && "dlsym() failed");
+          dlclose(libHandle);
         }
-        dlclose(libHandle);
         errno = saveErrno;
       }
       xlcPersonalityV0InitLock.unlock();

--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -2150,8 +2150,8 @@ bool UnwindCursor<A, R>::getInfoFromTBTable(pint_t pc, R &registers) {
             dlsym(libHandle, "__xlcxx_personality_v0"));
         if (xlcPersonalityV0 == NULL) {
           _LIBUNWIND_TRACE_UNWINDING("dlsym() failed with errno=%d\n", errno);
-          assert(0 && "dlsym() failed");
           dlclose(libHandle);
+          assert(0 && "dlsym() failed");
         }
         errno = saveErrno;
       }


### PR DESCRIPTION
The personality routine `__xlcxx_personality_v0` in `libc++abi` is hard-coded in the unwinder as the handler for EH in applications generated by the legacy IBM C++ compiler. The symbol is resolved dynamically using `dlopen` to avoid a hard dependency of `libunwind` on `libc++abi` for cases such as non-C++ applications. However, `dlclose` was incorrectly called after `dlsym` succeeded, potentially invalidating the function pointer obtained from `dlsym` when the memory allocated for the `dlopen` is reclaimed. This PR changes to call `dlclose` only when `dlsym` fails.