### PR TITLE
[flang] add getElementType() to fir::SquenceType and fir::VectorType

### DIFF
--- a/flang/include/flang/Optimizer/Builder/PPCIntrinsicCall.h
+++ b/flang/include/flang/Optimizer/Builder/PPCIntrinsicCall.h
@@ -182,7 +182,7 @@ struct VecTypeInfo {
 static inline VecTypeInfo getVecTypeFromFirType(mlir::Type firTy) {
   assert(mlir::isa<fir::VectorType>(firTy));
   VecTypeInfo vecTyInfo;
-  vecTyInfo.eleTy = mlir::dyn_cast<fir::VectorType>(firTy).getEleTy();
+  vecTyInfo.eleTy = mlir::dyn_cast<fir::VectorType>(firTy).getElementType();
   vecTyInfo.len = mlir::dyn_cast<fir::VectorType>(firTy).getLen();
   return vecTyInfo;
 }

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -465,6 +465,8 @@ def fir_SequenceType : FIR_Type<"Sequence", "array"> {
         size = size * static_cast<std::uint64_t>(extent);
       return size;
     }
+
+    mlir::Type getElementType() const { return getEleTy(); }
   }];
 }
 
@@ -519,6 +521,8 @@ def fir_VectorType : FIR_Type<"Vector", "vector"> {
 
   let extraClassDeclaration = [{
     static bool isValidElementType(mlir::Type t);
+
+    mlir::Type getElementType() const { return getEleTy(); }
   }];
 
   let skipDefaultBuilders = 1;

--- a/flang/lib/Lower/ConvertConstant.cpp
+++ b/flang/lib/Lower/ConvertConstant.cpp
@@ -584,7 +584,8 @@ genInlinedArrayLit(Fortran::lower::AbstractConverter &converter,
     } while (con.IncrementSubscripts(subscripts));
   } else if constexpr (T::category == Fortran::common::TypeCategory::Derived) {
     do {
-      mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrayTy).getEleTy();
+      mlir::Type eleTy =
+          mlir::cast<fir::SequenceType>(arrayTy).getElementType();
       mlir::Value elementVal =
           genScalarLit(converter, loc, con.At(subscripts), eleTy,
                        /*outlineInReadOnlyMemory=*/false);
@@ -594,7 +595,7 @@ genInlinedArrayLit(Fortran::lower::AbstractConverter &converter,
   } else {
     llvm::SmallVector<mlir::Attribute> rangeStartIdx;
     uint64_t rangeSize = 0;
-    mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrayTy).getEleTy();
+    mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrayTy).getElementType();
     do {
       auto getElementVal = [&]() {
         return builder.createConvert(loc, eleTy,
@@ -643,7 +644,7 @@ genOutlineArrayLit(Fortran::lower::AbstractConverter &converter,
                    mlir::Location loc, mlir::Type arrayTy,
                    const Fortran::evaluate::Constant<T> &constant) {
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
-  mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrayTy).getEleTy();
+  mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrayTy).getElementType();
   llvm::StringRef globalName = converter.getUniqueLitName(
       loc, std::make_unique<Fortran::lower::SomeExpr>(toEvExpr(constant)),
       eleTy);

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1574,7 +1574,7 @@ public:
     mlir::Location loc = getLoc();
     mlir::Value addr = fir::getBase(array);
     mlir::Type arrTy = fir::dyn_cast_ptrEleTy(addr.getType());
-    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
     mlir::Type seqTy = builder.getRefType(builder.getVarLenSeqTy(eleTy));
     mlir::Type refTy = builder.getRefType(eleTy);
     mlir::Value base = builder.createConvert(loc, seqTy, addr);
@@ -1659,7 +1659,7 @@ public:
     mlir::Location loc = getLoc();
     mlir::Value addr = fir::getBase(exv);
     mlir::Type arrTy = fir::dyn_cast_ptrOrBoxEleTy(addr.getType());
-    mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+    mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
     mlir::Type refTy = builder.getRefType(eleTy);
     mlir::IndexType idxTy = builder.getIndexType();
     llvm::SmallVector<mlir::Value> arrayCoorArgs;
@@ -4145,7 +4145,7 @@ private:
     mlir::Location loc = getLoc();
     return [=, builder = &converter.getFirOpBuilder()](IterSpace iters) {
       mlir::Type arrTy = fir::dyn_cast_ptrOrBoxEleTy(tmp.getType());
-      auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+      auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
       mlir::Type eleRefTy = builder->getRefType(eleTy);
       mlir::IntegerType i1Ty = builder->getI1Type();
       // Adjust indices for any shift of the origin of the array.
@@ -5759,7 +5759,7 @@ private:
         return fir::BoxValue(embox, lbounds, nonDeferredLenParams);
       };
     }
-    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
     if (isReferentiallyOpaque()) {
       // Semantics are an opaque reference to an array.
       // This case forwards a continuation that will generate the address

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -579,7 +579,8 @@ private:
       return createVectorSubscriptElementAddrOp(partInfo, baseType,
                                                 resultExtents);
 
-    mlir::Type resultType = mlir::cast<fir::SequenceType>(baseType).getEleTy();
+    mlir::Type resultType =
+        mlir::cast<fir::SequenceType>(baseType).getElementType();
     if (!resultTypeShape.empty()) {
       // Ranked array section. The result shape comes from the array section
       // subscripts.
@@ -811,7 +812,7 @@ private:
       }
     }
     builder.setInsertionPoint(elementalAddrOp);
-    return mlir::cast<fir::SequenceType>(baseType).getEleTy();
+    return mlir::cast<fir::SequenceType>(baseType).getElementType();
   }
 
   /// Yield the designator for the final part-ref inside the

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -518,7 +518,7 @@ static fir::GlobalOp defineGlobal(Fortran::lower::AbstractConverter &converter,
   // type does not support nested structures.
   if (mlir::isa<fir::SequenceType>(symTy) &&
       !Fortran::semantics::IsAllocatableOrPointer(sym)) {
-    mlir::Type eleTy = mlir::cast<fir::SequenceType>(symTy).getEleTy();
+    mlir::Type eleTy = mlir::cast<fir::SequenceType>(symTy).getElementType();
     if (mlir::isa<mlir::IntegerType, mlir::FloatType, mlir::ComplexType,
                   fir::LogicalType>(eleTy)) {
       const auto *details =

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -3824,7 +3824,7 @@ IntrinsicLibrary::genReduction(FN func, FD funcDim, llvm::StringRef errMsg,
   if (absentDim || rank == 1) {
     mlir::Type ty = array.getType();
     mlir::Type arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
     if (fir::isa_complex(eleTy)) {
       mlir::Value result = builder.createTemporary(loc, eleTy);
       func(builder, loc, array, mask, result);
@@ -6137,7 +6137,7 @@ IntrinsicLibrary::genReduce(mlir::Type resultType,
 
   mlir::Type ty = array.getType();
   mlir::Type arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
 
   // Handle optional arguments
   bool absentDim = isStaticallyAbsent(args[2]);

--- a/flang/lib/Optimizer/Builder/PPCIntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/PPCIntrinsicCall.cpp
@@ -2797,7 +2797,7 @@ void PPCIntrinsicLibrary::genMmaIntr(llvm::ArrayRef<fir::ExtendedValue> args) {
     if (vType != targetType) {
       if (mlir::isa<mlir::VectorType>(targetType)) {
         // Perform vector type conversion for arguments passed by value.
-        auto eleTy{mlir::dyn_cast<fir::VectorType>(vType).getEleTy()};
+        auto eleTy{mlir::dyn_cast<fir::VectorType>(vType).getElementType()};
         auto len{mlir::dyn_cast<fir::VectorType>(vType).getLen()};
         mlir::VectorType mlirType = mlir::VectorType::get(len, eleTy);
         auto v0{builder.createConvert(loc, mlirType, v)};

--- a/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
@@ -1157,7 +1157,7 @@ void fir::runtime::genMaxloc(fir::FirOpBuilder &builder, mlir::Location loc,
                              mlir::Value back) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   fir::factory::CharacterExprHelper charHelper{builder, loc};
   auto [cat, kind] = fir::mlirTypeToCategoryKind(loc, eleTy);
   mlir::func::FuncOp func;
@@ -1189,7 +1189,7 @@ mlir::Value fir::runtime::genMaxval(fir::FirOpBuilder &builder,
                                     mlir::Value maskBox) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto dim = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
   auto [cat, kind] = fir::mlirTypeToCategoryKind(loc, eleTy);
   mlir::func::FuncOp func;
@@ -1241,7 +1241,7 @@ void fir::runtime::genMinloc(fir::FirOpBuilder &builder, mlir::Location loc,
                              mlir::Value back) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto [cat, kind] = fir::mlirTypeToCategoryKind(loc, eleTy);
   mlir::func::FuncOp func;
   REAL_INTRINSIC_INSTANCES(Minloc, )
@@ -1298,7 +1298,7 @@ mlir::Value fir::runtime::genMinval(fir::FirOpBuilder &builder,
                                     mlir::Value maskBox) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto dim = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
   auto [cat, kind] = fir::mlirTypeToCategoryKind(loc, eleTy);
 
@@ -1326,7 +1326,7 @@ void fir::runtime::genNorm2Dim(fir::FirOpBuilder &builder, mlir::Location loc,
   mlir::func::FuncOp func;
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   if (eleTy.isF128())
     func = fir::runtime::getRuntimeFunc<ForcedNorm2DimReal16>(loc, builder);
   else
@@ -1348,7 +1348,7 @@ mlir::Value fir::runtime::genNorm2(fir::FirOpBuilder &builder,
   mlir::func::FuncOp func;
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto dim = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
 
   if (eleTy.isF32())
@@ -1398,7 +1398,7 @@ mlir::Value fir::runtime::genProduct(fir::FirOpBuilder &builder,
                                      mlir::Value resultBox) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto dim = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
 
   auto [cat, kind] = fir::mlirTypeToCategoryKind(loc, eleTy);
@@ -1482,7 +1482,7 @@ mlir::Value fir::runtime::genSum(fir::FirOpBuilder &builder, mlir::Location loc,
                                  mlir::Value resultBox) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto dim = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
 
   auto [cat, kind] = fir::mlirTypeToCategoryKind(loc, eleTy);
@@ -1521,7 +1521,7 @@ mlir::Value fir::runtime::genSum(fir::FirOpBuilder &builder, mlir::Location loc,
     mlir::func::FuncOp func;                                                   \
     auto ty = arrayBox.getType();                                              \
     auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);                              \
-    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();              \
+    auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();        \
     auto dim = builder.createIntegerConstant(loc, builder.getIndexType(), 0);  \
                                                                                \
     if (eleTy.isInteger(builder.getKindMap().getIntegerBitsize(1)))            \
@@ -1596,7 +1596,7 @@ void fir::runtime::genReduce(fir::FirOpBuilder &builder, mlir::Location loc,
                              bool argByRef) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto dim = builder.createIntegerConstant(loc, builder.getI32Type(), 1);
 
   assert(resultBox && "expect non null value for the result");
@@ -1646,7 +1646,7 @@ mlir::Value fir::runtime::genReduce(fir::FirOpBuilder &builder,
                                     bool argByRef) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto dim = builder.createIntegerConstant(loc, builder.getI32Type(), 1);
 
   assert((fir::isa_real(eleTy) || fir::isa_integer(eleTy) ||
@@ -1687,7 +1687,7 @@ void fir::runtime::genReduceDim(fir::FirOpBuilder &builder, mlir::Location loc,
                                 mlir::Value resultBox, bool argByRef) {
   auto ty = arrayBox.getType();
   auto arrTy = fir::dyn_cast_ptrOrBoxEleTy(ty);
-  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(arrTy).getElementType();
   auto [cat, kind] = fir::mlirTypeToCategoryKind(loc, eleTy);
 
   mlir::func::FuncOp func;

--- a/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
@@ -365,11 +365,11 @@ void fir::runtime::genMatmul(fir::FirOpBuilder &builder, mlir::Location loc,
   mlir::func::FuncOp func;
   auto boxATy = matrixABox.getType();
   auto arrATy = fir::dyn_cast_ptrOrBoxEleTy(boxATy);
-  auto arrAEleTy = mlir::cast<fir::SequenceType>(arrATy).getEleTy();
+  auto arrAEleTy = mlir::cast<fir::SequenceType>(arrATy).getElementType();
   auto [aCat, aKind] = fir::mlirTypeToCategoryKind(loc, arrAEleTy);
   auto boxBTy = matrixBBox.getType();
   auto arrBTy = fir::dyn_cast_ptrOrBoxEleTy(boxBTy);
-  auto arrBEleTy = mlir::cast<fir::SequenceType>(arrBTy).getEleTy();
+  auto arrBEleTy = mlir::cast<fir::SequenceType>(arrBTy).getElementType();
   auto [bCat, bKind] = fir::mlirTypeToCategoryKind(loc, arrBEleTy);
 
 #define MATMUL_INSTANCE(ACAT, AKIND, BCAT, BKIND)                              \
@@ -417,11 +417,11 @@ void fir::runtime::genMatmulTranspose(fir::FirOpBuilder &builder,
   mlir::func::FuncOp func;
   auto boxATy = matrixABox.getType();
   auto arrATy = fir::dyn_cast_ptrOrBoxEleTy(boxATy);
-  auto arrAEleTy = mlir::cast<fir::SequenceType>(arrATy).getEleTy();
+  auto arrAEleTy = mlir::cast<fir::SequenceType>(arrATy).getElementType();
   auto [aCat, aKind] = fir::mlirTypeToCategoryKind(loc, arrAEleTy);
   auto boxBTy = matrixBBox.getType();
   auto arrBTy = fir::dyn_cast_ptrOrBoxEleTy(boxBTy);
-  auto arrBEleTy = mlir::cast<fir::SequenceType>(arrBTy).getEleTy();
+  auto arrBEleTy = mlir::cast<fir::SequenceType>(arrBTy).getElementType();
   auto [bCat, bKind] = fir::mlirTypeToCategoryKind(loc, arrBEleTy);
 
 #define MATMUL_INSTANCE(ACAT, AKIND, BCAT, BKIND)                              \

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2619,7 +2619,7 @@ private:
             dims = dimsLeft - 1;
             continue;
           }
-          cpnTy = mlir::cast<fir::SequenceType>(cpnTy).getEleTy();
+          cpnTy = mlir::cast<fir::SequenceType>(cpnTy).getElementType();
           // append array range in reverse (FIR arrays are column-major)
           offs.append(arrIdx.rbegin(), arrIdx.rend());
           arrIdx.clear();
@@ -2633,7 +2633,7 @@ private:
             arrIdx.push_back(nxtOpnd);
             continue;
           }
-          cpnTy = mlir::cast<fir::SequenceType>(cpnTy).getEleTy();
+          cpnTy = mlir::cast<fir::SequenceType>(cpnTy).getElementType();
           offs.push_back(nxtOpnd);
           continue;
         }

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1359,7 +1359,7 @@ bool fir::ConvertOp::isPointerCompatible(mlir::Type ty) {
 static std::optional<mlir::Type> getVectorElementType(mlir::Type ty) {
   mlir::Type elemTy;
   if (mlir::isa<fir::VectorType>(ty))
-    elemTy = mlir::dyn_cast<fir::VectorType>(ty).getEleTy();
+    elemTy = mlir::dyn_cast<fir::VectorType>(ty).getElementType();
   else if (mlir::isa<mlir::VectorType>(ty))
     elemTy = mlir::dyn_cast<mlir::VectorType>(ty).getElementType();
   else
@@ -1533,7 +1533,7 @@ llvm::LogicalResult fir::CoordinateOp::verify() {
     }
     if (dimension) {
       if (--dimension == 0)
-        eleTy = mlir::cast<fir::SequenceType>(eleTy).getEleTy();
+        eleTy = mlir::cast<fir::SequenceType>(eleTy).getElementType();
     } else {
       if (auto t = mlir::dyn_cast<mlir::TupleType>(eleTy)) {
         // FIXME: Generally, we don't know which field of the tuple is being
@@ -3817,7 +3817,7 @@ void fir::StoreOp::build(mlir::OpBuilder &builder, mlir::OperationState &result,
 //===----------------------------------------------------------------------===//
 
 inline fir::CharacterType::KindTy stringLitOpGetKind(fir::StringLitOp op) {
-  auto eleTy = mlir::cast<fir::SequenceType>(op.getType()).getEleTy();
+  auto eleTy = mlir::cast<fir::SequenceType>(op.getType()).getElementType();
   return mlir::cast<fir::CharacterType>(eleTy).getFKind();
 }
 


### PR DESCRIPTION
getElementType() was missing from Sequence and Vector types. Did a replace of the obvious places getEleTy() was used for these two types and updated to use this name instead.