### PR TITLE
[rtsan] Intercept aligned_alloc on all versions of OSX if available on build machine

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -461,19 +461,6 @@ INTERCEPTOR(void *, valloc, SIZE_T size) {
   return REAL(valloc)(size);
 }
 
-// aligned_alloc was introduced in OSX 10.15
-// Linking will fail when using an older SDK
-#if SANITIZER_APPLE && defined(__MAC_10_15)
-// macOS 10.15 is greater than our minimal deployment target.  To ensure we
-// generate a weak reference so the dylib continues to work on older
-// systems, we need to forward declare the intercepted function as "weak
-// imports".
-SANITIZER_WEAK_IMPORT void *aligned_alloc(SIZE_T __alignment, SIZE_T __size);
-
-#undef SANITIZER_INTERCEPT_ALIGNED_ALLOC
-#define SANITIZER_INTERCEPT_ALIGNED_ALLOC 1
-#endif // SANITIZER_APPLE && defined(__MAC_10_15)
-
 #if SANITIZER_INTERCEPT_ALIGNED_ALLOC
 INTERCEPTOR(void *, aligned_alloc, SIZE_T alignment, SIZE_T size) {
   __rtsan_notify_intercepted_call("aligned_alloc");

--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -463,15 +463,18 @@ INTERCEPTOR(void *, valloc, SIZE_T size) {
 
 // aligned_alloc was introduced in OSX 10.15
 // Linking will fail when using an older SDK
-#if defined(__MAC_10_15)
+#if SANITIZER_APPLE && defined(__MAC_10_15)
 // macOS 10.15 is greater than our minimal deployment target.  To ensure we
 // generate a weak reference so the dylib continues to work on older
 // systems, we need to forward declare the intercepted function as "weak
 // imports".
 SANITIZER_WEAK_IMPORT void *aligned_alloc(SIZE_T __alignment, SIZE_T __size);
-#endif // defined(__MAC_10_15)
 
-#if SANITIZER_INTERCEPT_ALIGNED_ALLOC || SANITIZER_APPLE
+#undef SANITIZER_INTERCEPT_ALIGNED_ALLOC
+#define SANITIZER_INTERCEPT_ALIGNED_ALLOC 1
+#endif // SANITIZER_APPLE && defined(__MAC_10_15)
+
+#if SANITIZER_INTERCEPT_ALIGNED_ALLOC
 INTERCEPTOR(void *, aligned_alloc, SIZE_T alignment, SIZE_T size) {
   __rtsan_notify_intercepted_call("aligned_alloc");
   return REAL(aligned_alloc)(alignment, size);

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -121,10 +121,10 @@ TEST(TestRtsanInterceptors, VallocDiesWhenRealtime) {
 }
 
 #if __has_builtin(__builtin_available) && SANITIZER_APPLE
-#define ALIGNED_ALLOC_AVAILABLE() __builtin_available(macOS 10.15, *)
+#define ALIGNED_ALLOC_AVAILABLE() (__builtin_available(macOS 10.15, *))
 #else
 // We are going to assume this is true until we hit systems where it isn't
-#define ALIGNED_ALLOC_AVAILABLE() true
+#define ALIGNED_ALLOC_AVAILABLE() (true)
 #endif
 
 TEST(TestRtsanInterceptors, AlignedAllocDiesWhenRealtime) {

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -120,13 +120,17 @@ TEST(TestRtsanInterceptors, VallocDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
-#if SANITIZER_INTERCEPT_ALIGNED_ALLOC
 TEST(TestRtsanInterceptors, AlignedAllocDiesWhenRealtime) {
-  auto Func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
-  ExpectRealtimeDeath(Func, "aligned_alloc");
-  ExpectNonRealtimeSurvival(Func);
-}
+#if SANITIZER_APPLE
+  if (__builtin_available(macOS 10.15, *)) {
+#endif // SANITIZER_APPLE
+    auto Func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
+    ExpectRealtimeDeath(Func, "aligned_alloc");
+    ExpectNonRealtimeSurvival(Func);
+#if SANITIZER_APPLE
+  }
 #endif
+}
 
 // free_sized and free_aligned_sized (both C23) are not yet supported
 TEST(TestRtsanInterceptors, FreeDiesWhenRealtime) {

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -120,16 +120,19 @@ TEST(TestRtsanInterceptors, VallocDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
+#if __has_builtin(__builtin_available) && SANITIZER_APPLE
+#define ALIGNED_ALLOC_AVAILABLE() __builtin_available(macOS 10.15, *)
+#else
+// We are going to assume this is true until we hit systems where it isn't
+#define ALIGNED_ALLOC_AVAILABLE() true
+#endif
+
 TEST(TestRtsanInterceptors, AlignedAllocDiesWhenRealtime) {
-#if SANITIZER_APPLE
-  if (__builtin_available(macOS 10.15, *)) {
-#endif // SANITIZER_APPLE
+  if (ALIGNED_ALLOC_AVAILABLE()) {
     auto Func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
     ExpectRealtimeDeath(Func, "aligned_alloc");
     ExpectNonRealtimeSurvival(Func);
-#if SANITIZER_APPLE
   }
-#endif
 }
 
 // free_sized and free_aligned_sized (both C23) are not yet supported

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
@@ -86,7 +86,22 @@
 
 #if SANITIZER_APPLE
 #  include <Availability.h>
-#endif
+
+// aligned_alloc was introduced in OSX 10.15
+// Linking will fail when using an older SDK
+#  if defined(__MAC_10_15)
+// macOS 10.15 is greater than our minimal deployment target.  To ensure we
+// generate a weak reference so the dylib continues to work on older
+// systems, we need to forward declare the intercepted function as "weak
+// imports".
+SANITIZER_WEAK_IMPORT void *aligned_alloc(__sanitizer::usize __alignment,
+                                          __sanitizer::usize __size);
+#    define SI_MAC_SDK_10_15_AVAILABLE 1
+#  else
+#    define SI_MAC_SDK_10_15_AVAILABLE 0
+#  endif  // defined(__MAC_10_15)
+
+#endif  // SANITIZER_APPLE
 
 #if SANITIZER_IOS
 #define SI_IOS 1
@@ -507,27 +522,8 @@
 #define SANITIZER_INTERCEPT_PVALLOC (SI_GLIBC || SI_ANDROID)
 #define SANITIZER_INTERCEPT_CFREE (SI_GLIBC && !SANITIZER_RISCV64)
 #define SANITIZER_INTERCEPT_REALLOCARRAY SI_POSIX
-
-#if SANITIZER_APPLE && defined(__MAC_10_15)
-#  define SI_MAC_SDK_10_15_AVAILABLE 1
-#else
-#  define SI_MAC_SDK_10_15_AVAILABLE 0
-#endif  // SANITIZER_APPLE && defined(__MAC_10_15)
-
-// aligned_alloc was introduced in OSX 10.15
-// Linking will fail when using an older SDK
-#if SI_MAC_SDK_10_15_AVAILABLE
-// macOS 10.15 is greater than our minimal deployment target.  To ensure we
-// generate a weak reference so the dylib continues to work on older
-// systems, we need to forward declare the intercepted function as "weak
-// imports".
-SANITIZER_WEAK_IMPORT void *aligned_alloc(__sanitizer::usize __alignment,
-                                          __sanitizer::usize __size);
-#endif  // SI_MAC_SDK_10_15_AVAILABLE
-
 #define SANITIZER_INTERCEPT_ALIGNED_ALLOC \
   (!SI_MAC || SI_MAC_SDK_10_15_AVAILABLE)
-
 #define SANITIZER_INTERCEPT_MALLOC_USABLE_SIZE (!SI_MAC && !SI_NETBSD)
 #define SANITIZER_INTERCEPT_MCHECK_MPROBE SI_LINUX_NOT_ANDROID
 #define SANITIZER_INTERCEPT_WCSLEN 1


### PR DESCRIPTION
This follows the pattern seen here, where tsan uses libdispatch, even if the functions aren't available in our minimum version.

https://github.com/llvm/llvm-project/blob/f7669ba3d9443bc95dd63fa25beea13e6265fdc5/compiler-rt/lib/tsan/rtl/tsan_interceptors_libdispatch.cpp#L226-L247

I think it would be good to propagate this change to the other sanitizers, as currently, no sanitizer actually intercepts aligned alloc on mac, stemming from:
https://github.com/llvm/llvm-project/blob/f7669ba3d9443bc95dd63fa25beea13e6265fdc5/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h#L497

Ideally, if this pattern looked good, we could add it to sanitizer_malloc_mac.inc, and the other sanitizers would have this enabled.