### PR TITLE
[emacs][clang-format] Add elisp API for clang-format on git diffs

### DIFF
--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -167,6 +167,9 @@ return is a ‘list’ of lines in the format ‘--lines=<start>:<end>’
 which can be passed directly to ‘clang-format’."
   ;; Use temporary buffer for output of diff.
   (with-temp-buffer
+    ;; We could use diff.el:diff-no-select here. The reason we don't
+    ;; is diff-no-select requires extra copies on the buffers which
+    ;; induces noticable slowdowns, especially on larger files.
     (let ((status (call-process
                    "diff"
                    nil

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -171,7 +171,7 @@ which can be passed directly to ‘clang-format’."
     ;; is diff-no-select requires extra copies on the buffers which
     ;; induces noticable slowdowns, especially on larger files.
     (let ((status (call-process
-                   "diff"
+                   diff-command
                    nil
                    (current-buffer)
                    nil

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -233,7 +233,7 @@ supported vc."
                            (string-width (expand-file-name base-dir))
                            nil)))
         (let ((status (call-process
-                       "git"
+                       vc-git-program
                        nil
                        `(:file, tmpfile-vc-head)
                        nil
@@ -323,7 +323,7 @@ specific locations for reformatting (i.e diff locations)."
             (if incomplete-format
                 (message "(clang-format: incomplete (syntax errors)%s)" stderr)
               (message "(clang-format: success%s)" stderr))))
-      (delete-file temp-file)
+      (ignore-errors (delete-file temp-file))
       (when (buffer-name temp-buffer) (kill-buffer temp-buffer)))))
 
 
@@ -360,7 +360,7 @@ file. If no ASSUME-FILE-NAME is given uses the function
                style
                assume-file-name
                diff-lines))))
-      (progn
+      (ignore-errors
         ;; Cleanup temporary files we created.
         (when tmpfile-vc-head (delete-file tmpfile-vc-head))
         (when tmpfile-curbuf (delete-file tmpfile-curbuf))))))

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -160,55 +160,31 @@ is a zero-based file offset, assuming ‘utf-8-unix’ coding."
                     (string-to-number (match-string 3 line)))))
       (concat (match-string 1 line) ":" (match-string 1 line)))))
 
-(defun clang-format--vc-diff-get-diff-lines (file-orig file-new)
+(defun clang-format--vc-diff-compute-diff-and-get-lines (buf-orig buf-cur)
   "Return all line regions that contain diffs between FILE-ORIG and
 FILE-NEW.  If there is no diff ‘nil’ is returned. Otherwise the
 return is a ‘list’ of lines in the format ‘--lines=<start>:<end>’
 which can be passed directly to ‘clang-format’."
   ;; Use temporary buffer for output of diff.
   (with-temp-buffer
-    (let ((status (call-process
-                   "diff"
-                   nil
-                   (current-buffer)
-                   nil
-                   ;; Binary diff has different behaviors that we
-                   ;; aren't interested in.
-                   "-a"
-                   ;; Get minimal diff (copy diff config for git-clang-format).
-                   "-U0"
-                   file-orig
-                   file-new))
-          (stderr (concat (if (zerop (buffer-size)) "" ": ")
+    (diff-no-select buf-orig buf-cur "-a -U0" t (current-buffer))
+    (let ((diff-lines '()))
+      ;; Iterate through all lines in diff buffer and collect all
+      ;; lines in current buffer that have a diff.
+      (goto-char (point-min))
+      (while (not (eobp))
+        (let ((diff-line (clang-format--vc-diff-match-diff-line
                           (buffer-substring-no-properties
-                           (point-min) (line-end-position))))
-          (diff-lines '()))
-      (cond
-       ((stringp status)
-        (error "(diff killed by signal %s%s)" status stderr))
-       ;; Return of 0 indicates no diff.
-       ((= status 0) nil)
-       ;; Return of 1 indicates found diffs and no error.
-       ((= status 1)
-        ;; Iterate through all lines in diff buffer and collect all
-        ;; lines in current buffer that have a diff.
-        (goto-char (point-min))
-        (while (not (eobp))
-          (let ((diff-line (clang-format--vc-diff-match-diff-line
-                            (buffer-substring-no-properties
-                             (line-beginning-position)
-                             (line-end-position)))))
-            (when diff-line
-              ;; Create list line regions with diffs to pass to
-              ;; clang-format.
-              (push (concat "--lines=" diff-line) diff-lines)))
-          (forward-line 1))
-        (reverse diff-lines))
-       ;; Any return != 0 && != 1 indicates some level of error.
-       (t
-        (error "(diff returned unsuccessfully %s%s)" status stderr))))))
+                           (line-beginning-position)
+                           (line-end-position)))))
+          (when diff-line
+            ;; Create list line regions with diffs to pass to
+            ;; clang-format.
+            (push (concat "--lines=" diff-line) diff-lines)))
+        (forward-line 1))
+      (reverse diff-lines))))
 
-(defun clang-format--vc-diff-get-vc-head-file (tmpfile-vc-head)
+(defun clang-format--vc-diff-get-diff-lines ()
   "Stores the contents of ‘buffer-file-name’ at vc revision HEAD into
 ‘tmpfile-vc-head’. If the current buffer is either not a file or not
 in a vc repo, this results in an error. Currently git is the only
@@ -217,39 +193,44 @@ supported vc."
   (unless (buffer-file-name)
     (error "Buffer is not visiting a file"))
 
-  (let ((base-dir (vc-root-dir))
+  (let ((inp-buf (current-buffer))
+        (base-dir (vc-root-dir))
         (backend (vc-backend (buffer-file-name))))
-    ;; We need to be able to find version control (git) root.
-    (unless base-dir
-      (error "File not known to git"))
-    (cond
-     ((string-equal backend "Git")
-      ;; Get the filename relative to git root.
-      (let ((vc-file-name (substring
-                           (expand-file-name (buffer-file-name))
-                           (string-width (expand-file-name base-dir))
-                           nil)))
-        (let ((status (call-process
-                       "git"
-                       nil
-                       `(:file, tmpfile-vc-head)
-                       nil
-                       "show" (concat "HEAD:" vc-file-name)))
-              (stderr (with-temp-buffer
-                        (unless (zerop (cadr (insert-file-contents tmpfile-vc-head)))
-                          (insert ": "))
-                        (buffer-substring-no-properties
-                         (point-min) (line-end-position)))))
-          (when (stringp status)
-            (error "(git show HEAD:%s killed by signal %s%s)"
-                   vc-file-name status stderr))
-          (unless (zerop status)
-            (error "(git show HEAD:%s returned unsuccessfully %s%s)"
-                   vc-file-name status stderr)))))
-     (t
-      (error
-       "Version control %s isn't supported, currently supported backends: git"
-       backend)))))
+    (with-temp-buffer
+      ;; We need to be able to find version control (git) root.
+      (unless base-dir
+        (error "File not known to version control system"))
+      (cond
+       ((string-equal backend "Git")
+        ;; Get the filename relative to git root.
+        (let ((vc-file-name (substring
+                             (expand-file-name (buffer-file-name inp-buf))
+                             (string-width (expand-file-name base-dir))
+                             nil)))
+          (let ((status (call-process
+                         "git"
+                         nil
+                         (current-buffer)
+                         nil
+                         "show" (concat "HEAD:" vc-file-name)))
+                (stderr (concat (if (zerop (buffer-size)) "" ": ")
+                                (buffer-substring-no-properties
+                                 (point-min) (line-end-position)))))
+            (when (stringp status)
+              (error "(git show HEAD:%s killed by signal %s%s)"
+                     vc-file-name status stderr))
+            (unless (zerop status)
+              (error "(git show HEAD:%s returned unsuccessfully %s%s)"
+                     vc-file-name status stderr)))))
+       (t
+        (error
+         "Version control %s isn't supported, currently supported backends: git"
+         backend)))
+      ;; Collect all lines where inp-buf (buffer we call
+      ;; clang-format-vc-diff on) differs from latest version of the
+      ;; backing file in the version control system.
+      (clang-format--vc-diff-compute-diff-and-get-lines
+       (current-buffer) inp-buf))))
 
 
 (defun clang-format--region-impl (start end &optional style assume-file-name lines)
@@ -323,7 +304,6 @@ specific locations for reformatting (i.e diff locations)."
       (delete-file temp-file)
       (when (buffer-name temp-buffer) (kill-buffer temp-buffer)))))
 
-
 ;;;###autoload
 (defun clang-format-vc-diff (&optional style assume-file-name)
   "The same as ‘clang-format-buffer’ but only operates on the vc
@@ -332,35 +312,15 @@ diffs from HEAD in the buffer. If no STYLE is given uses
 file. If no ASSUME-FILE-NAME is given uses the function
 ‘buffer-file-name’."
   (interactive)
-  (let ((tmpfile-vc-head nil)
-        (tmpfile-curbuf nil))
-    (unwind-protect
-        (progn
-          (setq tmpfile-vc-head
-                (make-temp-file "clang-format-vc-tmp-head-content"))
-          (clang-format--vc-diff-get-vc-head-file tmpfile-vc-head)
-          ;; Move the current buffer to a temporary file to take a
-          ;; diff. Even if current-buffer is backed by a file, we
-          ;; want to diff the buffer contents which might not be
-          ;; saved.
-          (setq tmpfile-curbuf (make-temp-file "clang-format-vc-tmp"))
-          (write-region nil nil tmpfile-curbuf nil 'nomessage)
-          ;; Get a list of lines with a diff.
-          (let ((diff-lines
-                 (clang-format--vc-diff-get-diff-lines
-                  tmpfile-vc-head tmpfile-curbuf)))
-            ;; If we have any diffs, format them.
-            (when diff-lines
-              (clang-format--region-impl
-               (point-min)
-               (point-max)
-               style
-               assume-file-name
-               diff-lines))))
-      (progn
-        ;; Cleanup temporary files we created.
-        (when tmpfile-vc-head (delete-file tmpfile-vc-head))
-        (when tmpfile-curbuf (delete-file tmpfile-curbuf))))))
+  (let ((diff-lines (clang-format--vc-diff-get-diff-lines)))
+    ;; If we have any diffs, format them.
+    (when diff-lines
+      (clang-format--region-impl
+       (point-min)
+       (point-max)
+       style
+       assume-file-name
+       diff-lines))))
 
 
 ;;;###autoload

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -360,10 +360,10 @@ file. If no ASSUME-FILE-NAME is given uses the function
                style
                assume-file-name
                diff-lines))))
-      (ignore-errors
+      (progn
         ;; Cleanup temporary files we created.
-        (when tmpfile-vc-head (delete-file tmpfile-vc-head))
-        (when tmpfile-curbuf (delete-file tmpfile-curbuf))))))
+        (when tmpfile-vc-head (ignore-errors (delete-file tmpfile-vc-head)))
+        (when tmpfile-curbuf (ignore-errors (delete-file tmpfile-curbuf)))))))
 
 
 ;;;###autoload

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -146,20 +146,6 @@ is a zero-based file offset, assuming ‘utf-8-unix’ coding."
     (lambda (byte &optional _quality _coding-system)
       (byte-to-position (1+ byte)))))
 
-(defun clang-format--vc-diff-match-diff-line (line)
-  ;; We are matching something like:
-  ;; "@@ -80 +80 @@" or "@@ -80,2 +80,2 @@"
-  ;; Return as "<LineStart>:<LineEnd>"
-  (when (string-match "^@@\s-[0-9,]+\s\\+\\([0-9]+\\)\\(,\\([0-9]+\\)\\)?\s@@$" line)
-    ;; If we have multi-line diff
-    (if (match-string 3 line)
-        (concat (match-string 1 line)
-                ":"
-                (number-to-string
-                 (+ (string-to-number (match-string 1 line))
-                    (string-to-number (match-string 3 line)))))
-      (concat (match-string 1 line) ":" (match-string 1 line)))))
-
 (defun clang-format--vc-diff-get-diff-lines (file-orig file-new)
   "Return all line regions that contain diffs between FILE-ORIG and
 FILE-NEW.  If there is no diff ‘nil’ is returned. Otherwise the
@@ -169,7 +155,7 @@ which can be passed directly to ‘clang-format’."
   (with-temp-buffer
     ;; We could use diff.el:diff-no-select here. The reason we don't
     ;; is diff-no-select requires extra copies on the buffers which
-    ;; induces noticable slowdowns, especially on larger files.
+    ;; induces noticeable slowdowns, especially on larger files.
     (let ((status (call-process
                    diff-command
                    nil
@@ -178,14 +164,16 @@ which can be passed directly to ‘clang-format’."
                    ;; Binary diff has different behaviors that we
                    ;; aren't interested in.
                    "-a"
-                   ;; Get minimal diff (copy diff config for git-clang-format).
-                   "-U0"
+                   ;; Print new lines in file-new formatted as
+                   ;; "--lines=<StartDiff:EndDiff> "
+                   "--changed-group-format=%(N=0?:--lines=%dF:%dM )"
+                   ;; Don't print anything for unchanged lines
+                   "--unchanged-group-format="
                    file-orig
                    file-new))
           (stderr (concat (if (zerop (buffer-size)) "" ": ")
                           (buffer-substring-no-properties
-                           (point-min) (line-end-position))))
-          (diff-lines '()))
+                           (point-min) (line-end-position)))))
       (cond
        ((stringp status)
         (error "(diff killed by signal %s%s)" status stderr))
@@ -193,20 +181,15 @@ which can be passed directly to ‘clang-format’."
        ((= status 0) nil)
        ;; Return of 1 indicates found diffs and no error.
        ((= status 1)
-        ;; Iterate through all lines in diff buffer and collect all
-        ;; lines in current buffer that have a diff.
-        (goto-char (point-min))
-        (while (not (eobp))
-          (let ((diff-line (clang-format--vc-diff-match-diff-line
-                            (buffer-substring-no-properties
-                             (line-beginning-position)
-                             (line-end-position)))))
-            (when diff-line
-              ;; Create list line regions with diffs to pass to
-              ;; clang-format.
-              (push (concat "--lines=" diff-line) diff-lines)))
-          (forward-line 1))
-        (reverse diff-lines))
+        ;; We had our diff command printout all diffs as
+        ;; "--lines=S0:E0 --lines=S1:E1 ... --lines=SN:EN " so just
+        ;; split the output into a list to pass to clang-format.
+        (split-string
+         (buffer-substring-no-properties (point-min) (point-max))
+         ;; All whitespace (practically only spaces).
+         "[ \f\t\n\r\v]"
+         ;; Don't create empty entries.
+         t))
        ;; Any return != 0 && != 1 indicates some level of error.
        (t
         (error "(diff returned unsuccessfully %s%s)" status stderr))))))
@@ -235,7 +218,7 @@ supported vc."
         (let ((status (call-process
                        vc-git-program
                        nil
-                       `(:file, tmpfile-vc-head)
+                       `(:file ,tmpfile-vc-head)
                        nil
                        "show" (concat "HEAD:" vc-file-name)))
               (stderr (with-temp-buffer

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -194,26 +194,21 @@ which can be passed directly to ‘clang-format’."
         ;; Find and collect all diff lines.
         ;; We are matching something like:
         ;; "@@ -80 +80 @@" or "@@ -80,2 +80,2 @@"
-        (let ((diff-lines-re
-               "^@@\s-[0-9,]+\s\\+\\([0-9]+\\)\\(,\\([0-9]+\\)\\)?\s@@$")
-              (index 0)
-              (all-lines
-               (buffer-substring-no-properties (point-min) (point-max))))
-          ;; We are essentially doing (while (re-search-forward ...) ...)
-          ;; here. We are doing it by hand with (string-match ...) as it
-          ;; is notably faster (about 50%).
-          (setq index (string-match diff-lines-re all-lines))
-          (while index
-            (let ((match1 (string-to-number (match-string 1 all-lines)))
-                  (match3 (if (match-string 3 all-lines)
-                              (string-to-number (match-string 3 all-lines))
-                            nil)))
-              (push (format
-                     "--lines=%d:%d"
-                     match1
-                     (if match3 (+ match1 match3) match1))
-                    diff-lines))
-            (setq index (string-match diff-lines-re all-lines (+ index 1)))))
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^@@\s-[0-9,]+\s\\+\\([0-9]+\\)\\(,\\([0-9]+\\)\\)?\s@@$"
+                nil
+                t
+                1)
+          (let ((match1 (string-to-number (match-string 1)))
+                (match3 (if (match-string 3)
+                            (string-to-number (match-string 3))
+                          nil)))
+            (push (format
+                   "--lines=%d:%d"
+                   match1
+                   (if match3 (+ match1 match3) match1))
+                  diff-lines)))
         (nreverse diff-lines))
        ;; Any return != 0 && != 1 indicates some level of error.
        (t

--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -196,14 +196,15 @@ which can be passed directly to ‘clang-format’."
         ;; "@@ -80 +80 @@" or "@@ -80,2 +80,2 @@"
         (goto-char (point-min))
         (while (re-search-forward
-                "^@@\s-[0-9,]+\s\\+\\([0-9]+\\)\\(,\\([0-9]+\\)\\)?\s@@$"
+                "^@@[[:blank:]]-[[:digit:],]+[[:blank:]]\\+\\([[:digit:]]+\\)\\(,\\([[:digit:]]+\\)\\)?[[:blank:]]@@$"
                 nil
                 t
                 1)
           (let ((match1 (string-to-number (match-string 1)))
-                (match3 (if (match-string 3)
-                            (string-to-number (match-string 3))
-                          nil)))
+                (match3 (let ((match3_or_nil (match-string 3)))
+                          (if match3_or_nil
+                              (string-to-number match3_or_nil)
+                            nil))))
             (push (format
                    "--lines=%d:%d"
                    match1


### PR DESCRIPTION
New proposed function `clang-format-vc-diff`.

It is the same as calling `clang-format-region` on all diffs between
the content of a buffer-file and the content of the file at git
revision HEAD. This is essentially the same thing as:
    `git-clang-format -f {filename}`
If the current buffer is saved.

The motivation is many project (LLVM included) both have code that is
non-compliant with there clang-format style and disallow unrelated
format diffs in PRs. This means users can't just run
`clang-format-buffer` on the buffer they are working on, and need to
manually go through all the regions by hand to get them
formatted. This is both an error prone and annoying workflow.
