### PR TITLE
[ORC] skip reoptimization tests on s390x.

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -43,6 +43,10 @@ protected:
     if (Triple.isOSBinFormatCOFF() && Triple.isAArch64())
       GTEST_SKIP();
 
+    // SystemZ is not supported yet.
+    if (Triple.isSystemZ())
+      GTEST_SKIP();
+
     if (Triple.isPPC())
       GTEST_SKIP();
 


### PR DESCRIPTION
The test was failing on s390x with this error:

JIT session error: Unsupported target machine architecture in ELF object <main>-jitted-objectbuffer