### PR TITLE
[SystemZ] Rename SystemZ ATT Asm dialect to GNU Asm dialect

### DIFF
--- a/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
+++ b/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
@@ -442,7 +442,7 @@ private:
 
   bool parseOperand(OperandVector &Operands, StringRef Mnemonic);
 
-  // Both the hlasm and att variants still rely on the basic gnu asm
+  // Both the hlasm and gnu variants still rely on the basic gnu asm
   // format with respect to inputs, clobbers, outputs etc.
   //
   // However, calling the overriden getAssemblerDialect() method in
@@ -475,8 +475,8 @@ private:
   // Are we parsing using the AD_HLASM dialect?
   inline bool isParsingHLASM() { return getMAIAssemblerDialect() == AD_HLASM; }
 
-  // Are we parsing using the AD_ATT dialect?
-  inline bool isParsingATT() { return getMAIAssemblerDialect() == AD_ATT; }
+  // Are we parsing using the AD_GNU dialect?
+  inline bool isParsingGNU() { return getMAIAssemblerDialect() == AD_GNU; }
 
 public:
   SystemZAsmParser(const MCSubtargetInfo &sti, MCAsmParser &parser,
@@ -848,7 +848,7 @@ ParseStatus SystemZAsmParser::parseRegister(OperandVector &Operands,
   }
 
   // Handle register names of the form %<prefix><number>
-  if (isParsingATT() && Parser.getTok().is(AsmToken::Percent)) {
+  if (isParsingGNU() && Parser.getTok().is(AsmToken::Percent)) {
     if (parseRegister(Reg, /*RequirePercent=*/true))
       return ParseStatus::Failure;
 
@@ -1029,7 +1029,7 @@ bool SystemZAsmParser::parseAddress(bool &HaveReg1, Register &Reg1,
   if (getLexer().is(AsmToken::LParen)) {
     Parser.Lex();
 
-    if (isParsingATT() && getLexer().is(AsmToken::Percent)) {
+    if (isParsingGNU() && getLexer().is(AsmToken::Percent)) {
       // Parse the first register.
       HaveReg1 = true;
       if (parseRegister(Reg1, /*RequirePercent=*/true))
@@ -1072,7 +1072,7 @@ bool SystemZAsmParser::parseAddress(bool &HaveReg1, Register &Reg1,
         if (parseIntegerRegister(Reg2, RegGR))
           return true;
       } else {
-        if (isParsingATT() && parseRegister(Reg2, /*RequirePercent=*/true))
+        if (isParsingGNU() && parseRegister(Reg2, /*RequirePercent=*/true))
           return true;
       }
     }
@@ -1490,7 +1490,7 @@ bool SystemZAsmParser::parseOperand(OperandVector &Operands,
   // a context-dependent parse routine, which gives the required register
   // class.  The code is here to mop up other cases, like those where
   // the instruction isn't recognized.
-  if (isParsingATT() && Parser.getTok().is(AsmToken::Percent)) {
+  if (isParsingGNU() && Parser.getTok().is(AsmToken::Percent)) {
     Register Reg;
     if (parseRegister(Reg, /*RequirePercent=*/true))
       return true;
@@ -1672,7 +1672,7 @@ ParseStatus SystemZAsmParser::parsePCRel(OperandVector &Operands,
 }
 
 bool SystemZAsmParser::isLabel(AsmToken &Token) {
-  if (isParsingATT())
+  if (isParsingGNU())
     return true;
 
   // HLASM labels are ordinary symbols.

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
@@ -13,7 +13,7 @@
 using namespace llvm;
 
 SystemZMCAsmInfoELF::SystemZMCAsmInfoELF(const Triple &TT) {
-  AssemblerDialect = AD_ATT;
+  AssemblerDialect = AD_GNU;
   CalleeSaveStackSlotSize = 8;
   CodePointerSize = 8;
   Data64bitsDirective = "\t.quad\t";

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
@@ -15,7 +15,7 @@
 
 namespace llvm {
 class Triple;
-enum SystemZAsmDialect { AD_ATT = 0, AD_HLASM = 1 };
+enum SystemZAsmDialect { AD_GNU = 0, AD_HLASM = 1 };
 
 class SystemZMCAsmInfoELF : public MCAsmInfoELF {
 public:

--- a/llvm/lib/Target/SystemZ/SystemZ.td
+++ b/llvm/lib/Target/SystemZ/SystemZ.td
@@ -67,11 +67,11 @@ def SystemZAsmParser : AsmParser {
   let ShouldEmitMatchRegisterName = 0;
 }
 
-def ATTAsmParserVariant : AsmParserVariant {
+def GNUAsmParserVariant : AsmParserVariant {
   int Variant = 0;
 
   // Variant name.
-  string Name = "att";
+  string Name = "gnu";
 }
 
 def HLASMAsmParserVariant : AsmParserVariant {
@@ -88,6 +88,6 @@ def HLASMAsmParserVariant : AsmParserVariant {
 def SystemZ : Target {
   let InstructionSet = SystemZInstrInfo;
   let AssemblyParsers = [SystemZAsmParser];
-  let AssemblyParserVariants = [ATTAsmParserVariant, HLASMAsmParserVariant];
+  let AssemblyParserVariants = [GNUAsmParserVariant, HLASMAsmParserVariant];
   let AllowRegisterRenaming = 1;
 }

--- a/llvm/lib/Target/SystemZ/SystemZInstrFormats.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrFormats.td
@@ -2050,7 +2050,7 @@ class CondVariant<bits<4> ccmaskin, string suffixin, bit alternatein,
   bit alternate = alternatein;
 
   // Whether this needs be to restricted to a specific dialect.
-  // Valid values are "att" and "hlasm", which when passed in
+  // Valid values are "gnu" and "hlasm", which when passed in
   // will set AsmVariantName.
   string asmvariant = asmvariantin;
 }
@@ -2063,20 +2063,20 @@ def CondAlways : CondVariant<15, "", 0>;
 def CondVariantO   : CondVariant<1,  "o",   0>;
 def CondVariantH   : CondVariant<2,  "h",   0>;
 def CondVariantP   : CondVariant<2,  "p",   1>;
-def CondVariantNLE : CondVariant<3,  "nle", 0, "att">;
+def CondVariantNLE : CondVariant<3,  "nle", 0, "gnu">;
 def CondVariantL   : CondVariant<4,  "l",   0>;
 def CondVariantM   : CondVariant<4,  "m",   1>;
-def CondVariantNHE : CondVariant<5,  "nhe", 0, "att">;
-def CondVariantLH  : CondVariant<6,  "lh",  0, "att">;
+def CondVariantNHE : CondVariant<5,  "nhe", 0, "gnu">;
+def CondVariantLH  : CondVariant<6,  "lh",  0, "gnu">;
 def CondVariantNE  : CondVariant<7,  "ne",  0>;
 def CondVariantNZ  : CondVariant<7,  "nz",  1>;
 def CondVariantE   : CondVariant<8,  "e",   0>;
 def CondVariantZ   : CondVariant<8,  "z",   1>;
-def CondVariantNLH : CondVariant<9,  "nlh", 0, "att">;
-def CondVariantHE  : CondVariant<10, "he",  0, "att">;
+def CondVariantNLH : CondVariant<9,  "nlh", 0, "gnu">;
+def CondVariantHE  : CondVariant<10, "he",  0, "gnu">;
 def CondVariantNL  : CondVariant<11, "nl",  0>;
 def CondVariantNM  : CondVariant<11, "nm",  1>;
-def CondVariantLE  : CondVariant<12, "le",  0, "att">;
+def CondVariantLE  : CondVariant<12, "le",  0, "gnu">;
 def CondVariantNH  : CondVariant<13, "nh",  0>;
 def CondVariantNP  : CondVariant<13, "np",  1>;
 def CondVariantNO  : CondVariant<14, "no",  0>;
@@ -2093,16 +2093,16 @@ class CV<string name>
 // and that the low bit of the mask is therefore always 0.  This means
 // that each condition has two names.  Conditions "o" and "no" are not used.
 def IntCondVariantH   : CondVariant<2,  "h",   0>;
-def IntCondVariantNLE : CondVariant<2,  "nle", 1, "att">;
+def IntCondVariantNLE : CondVariant<2,  "nle", 1, "gnu">;
 def IntCondVariantL   : CondVariant<4,  "l",   0>;
-def IntCondVariantNHE : CondVariant<4,  "nhe", 1, "att">;
-def IntCondVariantLH  : CondVariant<6,  "lh",  0, "att">;
+def IntCondVariantNHE : CondVariant<4,  "nhe", 1, "gnu">;
+def IntCondVariantLH  : CondVariant<6,  "lh",  0, "gnu">;
 def IntCondVariantNE  : CondVariant<6,  "ne",  1>;
 def IntCondVariantE   : CondVariant<8,  "e",   0>;
-def IntCondVariantNLH : CondVariant<8,  "nlh", 1, "att">;
-def IntCondVariantHE  : CondVariant<10, "he",  0, "att">;
+def IntCondVariantNLH : CondVariant<8,  "nlh", 1, "gnu">;
+def IntCondVariantHE  : CondVariant<10, "he",  0, "gnu">;
 def IntCondVariantNL  : CondVariant<10, "nl",  1>;
-def IntCondVariantLE  : CondVariant<12, "le",  0, "att">;
+def IntCondVariantLE  : CondVariant<12, "le",  0, "gnu">;
 def IntCondVariantNH  : CondVariant<12, "nh",  1>;
 
 // A helper class to look up one of the above by name.

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
@@ -121,7 +121,7 @@ def NOPR_bare : InstAlias<"nopr", (NOPR R0D), 0>;
 def JNOP : InstAlias<"jnop\t$RI2", (BRCAsm 0, brtarget16:$RI2), 0>;
 
 // An alias of BRCL 0, label
-// jgnop on att ; jlnop on hlasm
+// jgnop on gnu ; jlnop on hlasm
 def JGNOP : InstAlias<"{jgnop|jlnop}\t$RI2", (BRCLAsm 0, brtarget32:$RI2), 0>;
 
 // Fused compare-and-branch instructions.
@@ -2351,12 +2351,12 @@ def JXHG  : MnemonicAlias<"jxhg", "brxhg">;
 def JXLEG : MnemonicAlias<"jxleg", "brxlg">;
 
 def BRU   : MnemonicAlias<"bru", "j">;
-def BRUL  : MnemonicAlias<"brul", "jg", "att">;
+def BRUL  : MnemonicAlias<"brul", "jg", "gnu">;
 def BRUL_HLASM  : MnemonicAlias<"brul", "jlu", "hlasm">;
 
 foreach V = [ "E", "NE", "H", "NH", "L", "NL", "HE", "NHE", "LE", "NLE",
               "Z", "NZ", "P", "NP", "M", "NM", "LH", "NLH", "O", "NO" ] in {
   defm BRUAsm#V  : MnemonicCondBranchAlias <CV<V>, "br#", "j#">;
-  defm BRULAsm#V : MnemonicCondBranchAlias <CV<V>, "br#l", "jg#", "att">;
+  defm BRULAsm#V : MnemonicCondBranchAlias <CV<V>, "br#l", "jg#", "gnu">;
   defm BRUL_HLASMAsm#V : MnemonicCondBranchAlias <CV<V>, "br#l", "jl#", "hlasm">;
 }


### PR DESCRIPTION
The ATT assembler dialect on SystemZ seems to have been taken from the existing ATT/Intel code. However, on SystemZ, ATT does not hold any meaning. In reality, we are splitting the difference between GNU Asm syntax and HLASM Asm syntax, so it makes sense to rename ATT to GNU instead.