### PR TITLE
[NFC] Fix Werror=extra warning related to mismatched enum type

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1181,7 +1181,7 @@ enum : unsigned {
 // Section flags.
 enum : unsigned {
   // No flag
-  SHF_NONE = 0x0,
+  SHF_NONE= 0x0,
 
   // Section data should be writable during execution.
   SHF_WRITE = 0x1,

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1180,6 +1180,9 @@ enum : unsigned {
 
 // Section flags.
 enum : unsigned {
+  // No flag
+  SHF_NONE= 0x0,
+
   // Section data should be writable during execution.
   SHF_WRITE = 0x1,
 

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1181,7 +1181,7 @@ enum : unsigned {
 // Section flags.
 enum : unsigned {
   // No flag
-  SHF_NONE= 0x0,
+  SHF_NONE = 0x0,
 
   // Section data should be writable during execution.
   SHF_WRITE = 0x1,

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1180,9 +1180,6 @@ enum : unsigned {
 
 // Section flags.
 enum : unsigned {
-  // No flag
-  SHF_NONE= 0x0,
-
   // Section data should be writable during execution.
   SHF_WRITE = 0x1,
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2849,7 +2849,7 @@ void AsmPrinter::emitJumpTableSizesSection(const MachineJumpTableInfo *MJTI,
 
   if (isElf) {
     MCSymbolELF *LinkedToSym = dyn_cast<MCSymbolELF>(CurrentFnSym);
-    int Flags = F.hasComdat() ? ELF::SHF_GROUP : 0;
+    int Flags = F.hasComdat() ? ELF::SHF_GROUP : ELF::SHF_NONE;
 
     JumpTableSizesSection = OutContext.getELFSection(
         sectionName, ELF::SHT_LLVM_JT_SIZES, Flags, 0, GroupName, F.hasComdat(),

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2849,7 +2849,7 @@ void AsmPrinter::emitJumpTableSizesSection(const MachineJumpTableInfo *MJTI,
 
   if (isElf) {
     MCSymbolELF *LinkedToSym = dyn_cast<MCSymbolELF>(CurrentFnSym);
-    int Flags = F.hasComdat() ? ELF::SHF_GROUP : ELF::SHF_NONE;
+    int Flags = F.hasComdat() ? ELF::SHF_GROUP : 0;
 
     JumpTableSizesSection = OutContext.getELFSection(
         sectionName, ELF::SHT_LLVM_JT_SIZES, Flags, 0, GroupName, F.hasComdat(),

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2849,7 +2849,7 @@ void AsmPrinter::emitJumpTableSizesSection(const MachineJumpTableInfo *MJTI,
 
   if (isElf) {
     MCSymbolELF *LinkedToSym = dyn_cast<MCSymbolELF>(CurrentFnSym);
-    int Flags = F.hasComdat() ? ELF::SHF_GROUP : 0;
+    int Flags = F.hasComdat() ? (unsigned)ELF::SHF_GROUP : 0;
 
     JumpTableSizesSection = OutContext.getELFSection(
         sectionName, ELF::SHT_LLVM_JT_SIZES, Flags, 0, GroupName, F.hasComdat(),


### PR DESCRIPTION
This is one of the many PRs to fix errors with LLVM_ENABLE_WERROR=on. Built by GCC 11.

Fix warnings:

llvm-project/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp: In member function ‘void llvm::AsmPrinter::emitJumpTableSizesSection(const llvm::MachineJumpTableInfo*, const llvm::Function&) const’:
llvm-project/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp:2852:31: error: enumerated and non-enumerated type in conditional expression [-Werror=extra]
 2852 |     int Flags = F.hasComdat() ? ELF::SHF_GROUP : 0;
      |                 ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
