### PR TITLE
[NFC] Fix multi-character character constant warning

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Minidump.h
+++ b/llvm/include/llvm/BinaryFormat/Minidump.h
@@ -247,7 +247,7 @@ static_assert(sizeof(Thread) == 48);
 struct Exception {
   static constexpr size_t MaxParameters = 15;
   static constexpr size_t MaxParameterBytes = MaxParameters * sizeof(uint64_t);
-  static const uint32_t LLDB_FLAG = 'LLDB';
+  static const uint32_t LLDB_FLAG = 0x4C4C4442; // ASCII for 'LLDB'
 
   support::ulittle32_t ExceptionCode;
   support::ulittle32_t ExceptionFlags;


### PR DESCRIPTION
This is one of the many PRs to fix errors with LLVM_ENABLE_WERROR=on. Built by GCC 11.

Fix warning:

In file included from llvm-project/llvm/lib/BinaryFormat/Minidump.cpp:9:
llvm-project/llvm/include/llvm/BinaryFormat/Minidump.h:250:37: error: multi-character character constant [-Werror=multichar]
  250 |   static const uint32_t LLDB_FLAG = 'LLDB';
