### PR TITLE
[NFC] Fix c++ style comment in c file

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -2980,7 +2980,7 @@ enum CXTypeKind {
   CXType_Atomic = 177,
   CXType_BTFTagAttributed = 178,
 
-  // HLSL Types
+  /* HLSL Types */
   CXType_HLSLResource = 179,
   CXType_HLSLAttributedResource = 180
 };

--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -8,6 +8,7 @@
 #include "clang-c/Documentation.h"
 #include "clang-c/Index.h"
 #include "clang/Config/config.h"
+#include "llvm/Support/AutoConvert.h"
 #include <assert.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -8,7 +8,6 @@
 #include "clang-c/Documentation.h"
 #include "clang-c/Index.h"
 #include "clang/Config/config.h"
-#include "llvm/Support/AutoConvert.h"
 #include <assert.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -44,7 +44,8 @@ std::error_code disablezOSAutoConversion(int FD);
 
 /** \brief Query the z/OS enhanced ASCII auto-conversion status of a file
  * descriptor and force the conversion if the file is not tagged with a
- */ codepage.
+ * codepage.
+ */
 std::error_code enablezOSAutoConversion(int FD);
 
 /** Restore the z/OS enhanced ASCII auto-conversion for the std handle. */

--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -1,4 +1,4 @@
-//===- AutoConvert.h - Auto conversion between ASCII/EBCDIC -----*- C++ -*-===//
+/*===- AutoConvert.h - Auto conversion between ASCII/EBCDIC -----*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,7 +9,7 @@
 // This file contains functions used for auto conversion between
 // ASCII/EBCDIC codepages specific to z/OS.
 //
-//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===*/
 
 #ifndef LLVM_SUPPORT_AUTOCONVERT_H
 #define LLVM_SUPPORT_AUTOCONVERT_H
@@ -18,7 +18,7 @@
 #include <_Ccsid.h>
 #ifdef __cplusplus
 #include <system_error>
-#endif // __cplusplus
+#endif /* __cplusplus */
 
 #define CCSID_IBM_1047 1047
 #define CCSID_UTF_8 1208
@@ -26,35 +26,36 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif /* __cplusplus */
 int enablezOSAutoConversion(int FD);
 int disablezOSAutoConversion(int FD);
 int restorezOSStdHandleAutoConversion(int FD);
 #ifdef __cplusplus
 }
-#endif // __cplusplus
+#endif /* __cplusplus */
 
 #ifdef __cplusplus
 namespace llvm {
 
-/// \brief Disable the z/OS enhanced ASCII auto-conversion for the file
-/// descriptor.
+/** \brief Disable the z/OS enhanced ASCII auto-conversion for the file
+ * descriptor.
+ */
 std::error_code disablezOSAutoConversion(int FD);
 
-/// \brief Query the z/OS enhanced ASCII auto-conversion status of a file
-/// descriptor and force the conversion if the file is not tagged with a
-/// codepage.
+/** \brief Query the z/OS enhanced ASCII auto-conversion status of a file
+ * descriptor and force the conversion if the file is not tagged with a
+ */ codepage.
 std::error_code enablezOSAutoConversion(int FD);
 
-/// Restore the z/OS enhanced ASCII auto-conversion for the std handle.
+/** Restore the z/OS enhanced ASCII auto-conversion for the std handle. */
 std::error_code restorezOSStdHandleAutoConversion(int FD);
 
-/// \brief Set the tag information for a file descriptor.
+/** \brief Set the tag information for a file descriptor. */
 std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
 
-} // namespace llvm
-#endif // __cplusplus
+} /* namespace llvm */
+#endif /* __cplusplus */
 
-#endif // __MVS__
+#endif /* __MVS__ */
 
-#endif // LLVM_SUPPORT_AUTOCONVERT_H
+#endif /* LLVM_SUPPORT_AUTOCONVERT_H */


### PR DESCRIPTION
This is one of the many PRs to fix errors with LLVM_ENABLE_WERROR=on. Built by GCC 11.

Fix warnings:
llvm-project/clang/include/clang-c/Index.h:2983:3: error: C++ style comments are not allowed in ISO C90 [-Werror]
 2983 |   // HLSL Types
