### PR TITLE
[NFC] add DiagnosticsTestHelper decl

### DIFF
--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -1024,6 +1024,7 @@ protected:
   /// @}
 };
 
+/// Declare the friend function for testing to avoid GCC warning.
 void DiagnosticsTestHelper(DiagnosticsEngine &);
 
 /// RAII class that determines when any errors have occurred

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -1024,8 +1024,6 @@ protected:
   /// @}
 };
 
-void DiagnosticsTestHelper(DiagnosticsEngine &);
-
 /// RAII class that determines when any errors have occurred
 /// between the time the instance was created and the time it was
 /// queried.

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -1024,7 +1024,6 @@ protected:
   /// @}
 };
 
-/// Declare the friend function for testing to avoid GCC warning.
 void DiagnosticsTestHelper(DiagnosticsEngine &);
 
 /// RAII class that determines when any errors have occurred

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -1024,6 +1024,8 @@ protected:
   /// @}
 };
 
+void DiagnosticsTestHelper(DiagnosticsEngine &);
+
 /// RAII class that determines when any errors have occurred
 /// between the time the instance was created and the time it was
 /// queried.

--- a/clang/unittests/Basic/DiagnosticTest.cpp
+++ b/clang/unittests/Basic/DiagnosticTest.cpp
@@ -16,8 +16,9 @@
 using namespace llvm;
 using namespace clang;
 
+// Declare DiagnosticsTestHelper to avoid GCC warning
 namespace clang {
-   void DiagnosticsTestHelper(DiagnosticsEngine &diag);
+void DiagnosticsTestHelper(DiagnosticsEngine &diag);
 }
 
 void clang::DiagnosticsTestHelper(DiagnosticsEngine &diag) {

--- a/clang/unittests/Basic/DiagnosticTest.cpp
+++ b/clang/unittests/Basic/DiagnosticTest.cpp
@@ -16,6 +16,10 @@
 using namespace llvm;
 using namespace clang;
 
+namespace clang {
+   void DiagnosticsTestHelper(DiagnosticsEngine &diag);
+}
+
 void clang::DiagnosticsTestHelper(DiagnosticsEngine &diag) {
   EXPECT_FALSE(diag.DiagStates.empty());
   EXPECT_TRUE(diag.DiagStatesByLoc.empty());


### PR DESCRIPTION
This is one of the many PRs to fix errors with LLVM_ENABLE_WERROR=on. Built by GCC 11.

Fix warning

llvm-project/clang/unittests/Basic/DiagnosticTest.cpp:19:6: error: ‘void clang::DiagnosticsTestHelper(clang::DiagnosticsEngine&)’ has not been declared within ‘clang’ [-Werror]
   19 | void clang::DiagnosticsTestHelper(DiagnosticsEngine &diag) {
      |      ^~~~~
In file included from llvm-project/clang/unittests/Basic/DiagnosticTest.cpp:9:
llvm-project/clang/include/clang/Basic/Diagnostic.h:567:15: note: only here as a ‘friend’
  567 |   friend void DiagnosticsTestHelper(DiagnosticsEngine &);
