### PR TITLE
[NFC] Fix implicit-fallthrough warnings

### DIFF
--- a/clang/lib/Sema/SemaFunctionEffects.cpp
+++ b/clang/lib/Sema/SemaFunctionEffects.cpp
@@ -1540,6 +1540,7 @@ bool Sema::FunctionEffectDiff::shouldDiagnoseConversion(
       // matching is better.
       return true;
     }
+    break;
   case FunctionEffect::Kind::Blocking:
   case FunctionEffect::Kind::Allocating:
     return false;
@@ -1563,6 +1564,7 @@ bool Sema::FunctionEffectDiff::shouldDiagnoseRedeclaration(
       // All these forms of mismatches are diagnosed.
       return true;
     }
+    break;
   case FunctionEffect::Kind::Blocking:
   case FunctionEffect::Kind::Allocating:
     return false;
@@ -1592,7 +1594,7 @@ Sema::FunctionEffectDiff::shouldDiagnoseMethodOverride(
     case Kind::ConditionMismatch:
       return OverrideResult::Warn;
     }
-
+    break;
   case FunctionEffect::Kind::Blocking:
   case FunctionEffect::Kind::Allocating:
     return OverrideResult::NoAction;

--- a/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
@@ -1028,6 +1028,7 @@ static unsigned int getFenceOp(NVPTX::Ordering O, NVPTX::Scope S,
           formatv("Unsupported scope \"{}\" for acquire/release/acq_rel fence.",
                   ScopeToString(S)));
     }
+    break;
   }
   case NVPTX::Ordering::SequentiallyConsistent: {
     switch (S) {
@@ -1046,6 +1047,7 @@ static unsigned int getFenceOp(NVPTX::Ordering O, NVPTX::Scope S,
       report_fatal_error(formatv("Unsupported scope \"{}\" for seq_cst fence.",
                                  ScopeToString(S)));
     }
+    break;
   }
   case NVPTX::Ordering::NotAtomic:
   case NVPTX::Ordering::Relaxed:


### PR DESCRIPTION
This is one of the many PRs to fix errors with LLVM_ENABLE_WERROR=on. Built by GCC 11.

Fix warnings:

clang/lib/Sema/SemaFunctionEffects.cpp:1531:5: error: this statement may fall through [-Werror=implicit-fallthrough=]
 1531 |     switch (DiffKind) {
      |     ^~~~~~
