### PR TITLE
[NFC][GOFF] Fix char overflow

### DIFF
--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -507,72 +507,72 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
   char GOFFData[GOFF::RecordLength * 6] = {};
 
   // HDR record.
-  GOFFData[0] = 0x03;
-  GOFFData[1] = 0xF0;
-  GOFFData[50] = 0x01;
+  GOFFData[0] = (char)0x03;
+  GOFFData[1] = (char)0xF0;
+  GOFFData[50] = (char)0x01;
 
   // ESD record.
-  GOFFData[GOFF::RecordLength] = 0x03;
-  GOFFData[GOFF::RecordLength + 7] = 0x01;  // ESDID.
-  GOFFData[GOFF::RecordLength + 71] = 0x05; // Size of symbol name.
-  GOFFData[GOFF::RecordLength + 72] = 0xa5; // Symbol name is v.
-  GOFFData[GOFF::RecordLength + 73] = 0x81; // Symbol name is a.
-  GOFFData[GOFF::RecordLength + 74] = 0x99; // Symbol name is r.
-  GOFFData[GOFF::RecordLength + 75] = 0x7b; // Symbol name is #.
-  GOFFData[GOFF::RecordLength + 76] = 0x83; // Symbol name is c.
+  GOFFData[GOFF::RecordLength] = (char)0x03;
+  GOFFData[GOFF::RecordLength + 7] = (char)0x01;  // ESDID.
+  GOFFData[GOFF::RecordLength + 71] = (char)0x05; // Size of symbol name.
+  GOFFData[GOFF::RecordLength + 72] = (char)0xa5; // Symbol name is v.
+  GOFFData[GOFF::RecordLength + 73] = (char)0x81; // Symbol name is a.
+  GOFFData[GOFF::RecordLength + 74] = (char)0x99; // Symbol name is r.
+  GOFFData[GOFF::RecordLength + 75] = (char)0x7b; // Symbol name is #.
+  GOFFData[GOFF::RecordLength + 76] = (char)0x83; // Symbol name is c.
 
   // ESD record.
-  GOFFData[GOFF::RecordLength * 2] = 0x03;
-  GOFFData[GOFF::RecordLength * 2 + 3] = 0x01;
-  GOFFData[GOFF::RecordLength * 2 + 7] = 0x02;  // ESDID.
-  GOFFData[GOFF::RecordLength * 2 + 11] = 0x01; // Parent ESDID.
-  GOFFData[GOFF::RecordLength * 2 + 27] = 0x08; // Length.
-  GOFFData[GOFF::RecordLength * 2 + 40] = 0x01; // Name Space ID.
-  GOFFData[GOFF::RecordLength * 2 + 41] = 0x80;
-  GOFFData[GOFF::RecordLength * 2 + 60] = 0x04; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 61] = 0x04; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 63] = 0x0a; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 66] = 0x03; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 71] = 0x08; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 72] = 0xc3; // Symbol name is c.
-  GOFFData[GOFF::RecordLength * 2 + 73] = 0x6d; // Symbol name is _.
-  GOFFData[GOFF::RecordLength * 2 + 74] = 0xc3; // Symbol name is c.
-  GOFFData[GOFF::RecordLength * 2 + 75] = 0xd6; // Symbol name is o.
-  GOFFData[GOFF::RecordLength * 2 + 76] = 0xc4; // Symbol name is D.
-  GOFFData[GOFF::RecordLength * 2 + 77] = 0xc5; // Symbol name is E.
-  GOFFData[GOFF::RecordLength * 2 + 78] = 0xf6; // Symbol name is 6.
-  GOFFData[GOFF::RecordLength * 2 + 79] = 0xf4; // Symbol name is 4.
+  GOFFData[GOFF::RecordLength * 2] = (char)0x03;
+  GOFFData[GOFF::RecordLength * 2 + 3] = (char)0x01;
+  GOFFData[GOFF::RecordLength * 2 + 7] = (char)0x02;  // ESDID.
+  GOFFData[GOFF::RecordLength * 2 + 11] = (char)0x01; // Parent ESDID.
+  GOFFData[GOFF::RecordLength * 2 + 27] = (char)0x08; // Length.
+  GOFFData[GOFF::RecordLength * 2 + 40] = (char)0x01; // Name Space ID.
+  GOFFData[GOFF::RecordLength * 2 + 41] = (char)0x80;
+  GOFFData[GOFF::RecordLength * 2 + 60] = (char)0x04; // Size of symbol name.
+  GOFFData[GOFF::RecordLength * 2 + 61] = (char)0x04; // Size of symbol name.
+  GOFFData[GOFF::RecordLength * 2 + 63] = (char)0x0a; // Size of symbol name.
+  GOFFData[GOFF::RecordLength * 2 + 66] = (char)0x03; // Size of symbol name.
+  GOFFData[GOFF::RecordLength * 2 + 71] = (char)0x08; // Size of symbol name.
+  GOFFData[GOFF::RecordLength * 2 + 72] = (char)0xc3; // Symbol name is c.
+  GOFFData[GOFF::RecordLength * 2 + 73] = (char)0x6d; // Symbol name is _.
+  GOFFData[GOFF::RecordLength * 2 + 74] = (char)0xc3; // Symbol name is c.
+  GOFFData[GOFF::RecordLength * 2 + 75] = (char)0xd6; // Symbol name is o.
+  GOFFData[GOFF::RecordLength * 2 + 76] = (char)0xc4; // Symbol name is D.
+  GOFFData[GOFF::RecordLength * 2 + 77] = (char)0xc5; // Symbol name is E.
+  GOFFData[GOFF::RecordLength * 2 + 78] = (char)0xf6; // Symbol name is 6.
+  GOFFData[GOFF::RecordLength * 2 + 79] = (char)0xf4; // Symbol name is 4.
 
   // ESD record.
-  GOFFData[GOFF::RecordLength * 3] = 0x03;
-  GOFFData[GOFF::RecordLength * 3 + 3] = 0x02;
-  GOFFData[GOFF::RecordLength * 3 + 7] = 0x03;  // ESDID.
-  GOFFData[GOFF::RecordLength * 3 + 11] = 0x02; // Parent ESDID.
-  GOFFData[GOFF::RecordLength * 3 + 71] = 0x05; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 3 + 72] = 0xa5; // Symbol name is v.
-  GOFFData[GOFF::RecordLength * 3 + 73] = 0x81; // Symbol name is a.
-  GOFFData[GOFF::RecordLength * 3 + 74] = 0x99; // Symbol name is r.
-  GOFFData[GOFF::RecordLength * 3 + 75] = 0x7b; // Symbol name is #.
-  GOFFData[GOFF::RecordLength * 3 + 76] = 0x83; // Symbol name is c.
+  GOFFData[GOFF::RecordLength * 3] = (char)0x03;
+  GOFFData[GOFF::RecordLength * 3 + 3] = (char)0x02;
+  GOFFData[GOFF::RecordLength * 3 + 7] = (char)0x03;  // ESDID.
+  GOFFData[GOFF::RecordLength * 3 + 11] = (char)0x02; // Parent ESDID.
+  GOFFData[GOFF::RecordLength * 3 + 71] = (char)0x05; // Size of symbol name.
+  GOFFData[GOFF::RecordLength * 3 + 72] = (char)0xa5; // Symbol name is v.
+  GOFFData[GOFF::RecordLength * 3 + 73] = (char)0x81; // Symbol name is a.
+  GOFFData[GOFF::RecordLength * 3 + 74] = (char)0x99; // Symbol name is r.
+  GOFFData[GOFF::RecordLength * 3 + 75] = (char)0x7b; // Symbol name is #.
+  GOFFData[GOFF::RecordLength * 3 + 76] = (char)0x83; // Symbol name is c.
 
   // TXT record.
-  GOFFData[GOFF::RecordLength * 4] = 0x03;
-  GOFFData[GOFF::RecordLength * 4 + 1] = 0x10;
-  GOFFData[GOFF::RecordLength * 4 + 7] = 0x02;
-  GOFFData[GOFF::RecordLength * 4 + 23] = 0x08; // Data Length.
-  GOFFData[GOFF::RecordLength * 4 + 24] = 0x12;
-  GOFFData[GOFF::RecordLength * 4 + 25] = 0x34;
-  GOFFData[GOFF::RecordLength * 4 + 26] = 0x56;
-  GOFFData[GOFF::RecordLength * 4 + 27] = 0x78;
-  GOFFData[GOFF::RecordLength * 4 + 28] = 0x9a;
-  GOFFData[GOFF::RecordLength * 4 + 29] = 0xbc;
-  GOFFData[GOFF::RecordLength * 4 + 30] = 0xde;
-  GOFFData[GOFF::RecordLength * 4 + 31] = 0xf0;
+  GOFFData[GOFF::RecordLength * 4] = (char)0x03;
+  GOFFData[GOFF::RecordLength * 4 + 1] = (char)0x10;
+  GOFFData[GOFF::RecordLength * 4 + 7] = (char)0x02;
+  GOFFData[GOFF::RecordLength * 4 + 23] = (char)0x08; // Data Length.
+  GOFFData[GOFF::RecordLength * 4 + 24] = (char)0x12;
+  GOFFData[GOFF::RecordLength * 4 + 25] = (char)0x34;
+  GOFFData[GOFF::RecordLength * 4 + 26] = (char)0x56;
+  GOFFData[GOFF::RecordLength * 4 + 27] = (char)0x78;
+  GOFFData[GOFF::RecordLength * 4 + 28] = (char)0x9a;
+  GOFFData[GOFF::RecordLength * 4 + 29] = (char)0xbc;
+  GOFFData[GOFF::RecordLength * 4 + 30] = (char)0xde;
+  GOFFData[GOFF::RecordLength * 4 + 31] = (char)0xf0;
 
   // END record.
-  GOFFData[GOFF::RecordLength * 5] = 0x03;
-  GOFFData[GOFF::RecordLength * 5 + 1] = 0x40;
-  GOFFData[GOFF::RecordLength * 5 + 11] = 0x06;
+  GOFFData[GOFF::RecordLength * 5] = (char)0x03;
+  GOFFData[GOFF::RecordLength * 5 + 1] = (char)0x40;
+  GOFFData[GOFF::RecordLength * 5 + 11] = (char)0x06;
 
   StringRef Data(GOFFData, GOFF::RecordLength * 6);
 


### PR DESCRIPTION
This is one of the many PRs to fix errors with LLVM_ENABLE_WERROR=on. Built by GCC 11.

Fix warnining:

llvm/unittests/Object/GOFFObjectFileTest.cpp:511:17: error: overflow in conversion from ‘int’ to ‘char’ changes value from ‘240’ to ‘'\37777777760'’ [-Werror=overflow]
  511 |   GOFFData[1] = 0xF0;
