### PR TITLE
[RISCV] Check if v extension is enabled by the function features for the builtins not in Zve64*.

### DIFF
--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -623,7 +623,12 @@ bool SemaRISCV::CheckBuiltinFunctionCall(const TargetInfo &TI,
     ASTContext::BuiltinVectorTypeInfo Info = Context.getBuiltinVectorTypeInfo(
         TheCall->getType()->castAs<BuiltinType>());
 
-    if (Context.getTypeSize(Info.ElementType) == 64 && !TI.hasFeature("v"))
+    const FunctionDecl *FD = SemaRef.getCurFunctionDecl();
+    llvm::StringMap<bool> FunctionFeatureMap;
+    Context.getFunctionFeatureMap(FunctionFeatureMap, FD);
+
+    if (Context.getTypeSize(Info.ElementType) == 64 && !TI.hasFeature("v")
+        && !FunctionFeatureMap.lookup("v"))
       return Diag(TheCall->getBeginLoc(),
                   diag::err_riscv_builtin_requires_extension)
              << /* IsExtension */ true << TheCall->getSourceRange() << "v";

--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -627,8 +627,8 @@ bool SemaRISCV::CheckBuiltinFunctionCall(const TargetInfo &TI,
     llvm::StringMap<bool> FunctionFeatureMap;
     Context.getFunctionFeatureMap(FunctionFeatureMap, FD);
 
-    if (Context.getTypeSize(Info.ElementType) == 64 && !TI.hasFeature("v")
-        && !FunctionFeatureMap.lookup("v"))
+    if (Context.getTypeSize(Info.ElementType) == 64 && !TI.hasFeature("v") &&
+        !FunctionFeatureMap.lookup("v"))
       return Diag(TheCall->getBeginLoc(),
                   diag::err_riscv_builtin_requires_extension)
              << /* IsExtension */ true << TheCall->getSourceRange() << "v";


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/109694