### PR TITLE
[libc++] __uglify non-conforming member typedef `base`

### DIFF
--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -78,9 +78,9 @@ Deprecations and Removals
   supported as an extension anymore, please migrate any code that uses e.g. ``std::vector<const T>`` to be
   standards conforming.
 
-- Non-conforming member typedefs ``iterator`` and ``const_iterator`` of ``std::bitset`` are removed. Previously, they
-  were private but could cause ambiguity in name lookup. Code that expects such ambiguity will possibly not compile in
-  LLVM 20.
+- Non-conforming member typedefs ``base``, ``iterator`` and ``const_iterator`` of ``std::bitset``, and member typedef
+  ``base`` of ``std::forward_list`` and ``std::list`` are removed. Previously, they were private but could cause
+  ambiguity in name lookup. Code that expects such ambiguity will possibly not compile in LLVM 20.
 
 - The function ``__libcpp_verbose_abort()`` is now ``noexcept``, to match ``std::terminate()``. (The combination of
   ``noexcept`` and ``[[noreturn]]`` has special significance for function effects analysis.)

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -612,15 +612,15 @@ class _LIBCPP_TEMPLATE_VIS bitset
     : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
 public:
   static const unsigned __n_words = _Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1;
-  typedef __bitset<__n_words, _Size> base;
+  typedef __bitset<__n_words, _Size> __base;
 
 public:
-  typedef typename base::reference reference;
-  typedef typename base::const_reference const_reference;
+  typedef typename __base::reference reference;
+  typedef typename __base::const_reference const_reference;
 
   // 23.3.5.1 constructors:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bitset() _NOEXCEPT {}
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bitset(unsigned long long __v) _NOEXCEPT : base(__v) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bitset(unsigned long long __v) _NOEXCEPT : __base(__v) {}
   template <class _CharT, __enable_if_t<_IsCharLikeType<_CharT>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit bitset(
       const _CharT* __str,
@@ -681,11 +681,15 @@ public:
 
   // element access:
 #ifdef _LIBCPP_ABI_BITSET_VECTOR_BOOL_CONST_SUBSCRIPT_RETURN_BOOL
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator[](size_t __p) const { return base::__make_ref(__p); }
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator[](size_t __p) const { return __base::__make_ref(__p); }
 #else
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR const_reference operator[](size_t __p) const { return base::__make_ref(__p); }
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR const_reference operator[](size_t __p) const {
+    return __base::__make_ref(__p);
+  }
 #endif
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 reference operator[](size_t __p) { return base::__make_ref(__p); }
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 reference operator[](size_t __p) {
+    return __base::__make_ref(__p);
+  }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long to_ulong() const;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long long to_ullong() const;
   template <class _CharT, class _Traits, class _Allocator>
@@ -726,10 +730,10 @@ private:
       _CharT __c   = __str[__mp - 1 - __i];
       (*this)[__i] = _Traits::eq(__c, __one);
     }
-    std::fill(base::__make_iter(__i), base::__make_iter(_Size), false);
+    std::fill(__base::__make_iter(__i), __base::__make_iter(_Size), false);
   }
 
-  _LIBCPP_HIDE_FROM_ABI size_t __hash_code() const _NOEXCEPT { return base::__hash_code(); }
+  _LIBCPP_HIDE_FROM_ABI size_t __hash_code() const _NOEXCEPT { return __base::__hash_code(); }
 
   friend struct hash<bitset>;
 };
@@ -737,43 +741,43 @@ private:
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>&
 bitset<_Size>::operator&=(const bitset& __rhs) _NOEXCEPT {
-  base::operator&=(__rhs);
+  __base::operator&=(__rhs);
   return *this;
 }
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>&
 bitset<_Size>::operator|=(const bitset& __rhs) _NOEXCEPT {
-  base::operator|=(__rhs);
+  __base::operator|=(__rhs);
   return *this;
 }
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>&
 bitset<_Size>::operator^=(const bitset& __rhs) _NOEXCEPT {
-  base::operator^=(__rhs);
+  __base::operator^=(__rhs);
   return *this;
 }
 
 template <size_t _Size>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>& bitset<_Size>::operator<<=(size_t __pos) _NOEXCEPT {
   __pos = std::min(__pos, _Size);
-  std::copy_backward(base::__make_iter(0), base::__make_iter(_Size - __pos), base::__make_iter(_Size));
-  std::fill_n(base::__make_iter(0), __pos, false);
+  std::copy_backward(__base::__make_iter(0), __base::__make_iter(_Size - __pos), __base::__make_iter(_Size));
+  std::fill_n(__base::__make_iter(0), __pos, false);
   return *this;
 }
 
 template <size_t _Size>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>& bitset<_Size>::operator>>=(size_t __pos) _NOEXCEPT {
   __pos = std::min(__pos, _Size);
-  std::copy(base::__make_iter(__pos), base::__make_iter(_Size), base::__make_iter(0));
-  std::fill_n(base::__make_iter(_Size - __pos), __pos, false);
+  std::copy(__base::__make_iter(__pos), __base::__make_iter(_Size), __base::__make_iter(0));
+  std::fill_n(__base::__make_iter(_Size - __pos), __pos, false);
   return *this;
 }
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>& bitset<_Size>::set() _NOEXCEPT {
-  std::fill_n(base::__make_iter(0), _Size, true);
+  std::fill_n(__base::__make_iter(0), _Size, true);
   return *this;
 }
 
@@ -788,7 +792,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>& bitset<_Size>
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>& bitset<_Size>::reset() _NOEXCEPT {
-  std::fill_n(base::__make_iter(0), _Size, false);
+  std::fill_n(__base::__make_iter(0), _Size, false);
   return *this;
 }
 
@@ -810,7 +814,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size> bitset<
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>& bitset<_Size>::flip() _NOEXCEPT {
-  base::flip();
+  __base::flip();
   return *this;
 }
 
@@ -819,19 +823,19 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset<_Size>& bitset<_Size>
   if (__pos >= _Size)
     __throw_out_of_range("bitset flip argument out of range");
 
-  reference __r = base::__make_ref(__pos);
+  reference __r = __base::__make_ref(__pos);
   __r           = ~__r;
   return *this;
 }
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long bitset<_Size>::to_ulong() const {
-  return base::to_ulong();
+  return __base::to_ulong();
 }
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long long bitset<_Size>::to_ullong() const {
-  return base::to_ullong();
+  return __base::to_ullong();
 }
 
 template <size_t _Size>
@@ -868,13 +872,13 @@ bitset<_Size>::to_string(char __zero, char __one) const {
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 size_t bitset<_Size>::count() const _NOEXCEPT {
-  return static_cast<size_t>(std::count(base::__make_iter(0), base::__make_iter(_Size), true));
+  return static_cast<size_t>(std::count(__base::__make_iter(0), __base::__make_iter(_Size), true));
 }
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool
 bitset<_Size>::operator==(const bitset& __rhs) const _NOEXCEPT {
-  return std::equal(base::__make_iter(0), base::__make_iter(_Size), __rhs.__make_iter(0));
+  return std::equal(__base::__make_iter(0), __base::__make_iter(_Size), __rhs.__make_iter(0));
 }
 
 #if _LIBCPP_STD_VER <= 17
@@ -896,12 +900,12 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool bitset<_Size>::test(siz
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool bitset<_Size>::all() const _NOEXCEPT {
-  return base::all();
+  return __base::all();
 }
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool bitset<_Size>::any() const _NOEXCEPT {
-  return base::any();
+  return __base::any();
 }
 
 template <size_t _Size>

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -640,12 +640,12 @@ void __forward_list_base<_Tp, _Alloc>::clear() _NOEXCEPT {
 
 template <class _Tp, class _Alloc /*= allocator<_Tp>*/>
 class _LIBCPP_TEMPLATE_VIS forward_list : private __forward_list_base<_Tp, _Alloc> {
-  typedef __forward_list_base<_Tp, _Alloc> base;
-  typedef typename base::__node_allocator __node_allocator;
-  typedef typename base::__node_type __node_type;
-  typedef typename base::__node_traits __node_traits;
-  typedef typename base::__node_pointer __node_pointer;
-  typedef typename base::__begin_node_pointer __begin_node_pointer;
+  typedef __forward_list_base<_Tp, _Alloc> __base;
+  typedef typename __base::__node_allocator __node_allocator;
+  typedef typename __base::__node_type __node_type;
+  typedef typename __base::__node_traits __node_traits;
+  typedef typename __base::__node_pointer __node_pointer;
+  typedef typename __base::__begin_node_pointer __begin_node_pointer;
 
 public:
   typedef _Tp value_type;
@@ -666,8 +666,8 @@ public:
   typedef typename allocator_traits<allocator_type>::size_type size_type;
   typedef typename allocator_traits<allocator_type>::difference_type difference_type;
 
-  typedef typename base::iterator iterator;
-  typedef typename base::const_iterator const_iterator;
+  typedef typename __base::iterator iterator;
+  typedef typename __base::const_iterator const_iterator;
 #if _LIBCPP_STD_VER >= 20
   typedef size_type __remove_return_type;
 #else
@@ -684,7 +684,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v);
 
   template <__enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v, const allocator_type& __a) : base(__a) {
+  _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v, const allocator_type& __a) : __base(__a) {
     insert_after(cbefore_begin(), __n, __v);
   }
 
@@ -697,7 +697,7 @@ public:
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI forward_list(from_range_t, _Range&& __range, const allocator_type& __a = allocator_type())
-      : base(__a) {
+      : __base(__a) {
     prepend_range(std::forward<_Range>(__range));
   }
 #endif
@@ -708,8 +708,8 @@ public:
   _LIBCPP_HIDE_FROM_ABI forward_list& operator=(const forward_list& __x);
 
 #ifndef _LIBCPP_CXX03_LANG
-  _LIBCPP_HIDE_FROM_ABI forward_list(forward_list&& __x) noexcept(is_nothrow_move_constructible<base>::value)
-      : base(std::move(__x)) {}
+  _LIBCPP_HIDE_FROM_ABI forward_list(forward_list&& __x) noexcept(is_nothrow_move_constructible<__base>::value)
+      : __base(std::move(__x)) {}
   _LIBCPP_HIDE_FROM_ABI forward_list(forward_list&& __x, const __type_identity_t<allocator_type>& __a);
 
   _LIBCPP_HIDE_FROM_ABI forward_list(initializer_list<value_type> __il);
@@ -738,35 +738,37 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void assign(size_type __n, const value_type& __v);
 
-  _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT { return allocator_type(base::__alloc()); }
+  _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT { return allocator_type(__base::__alloc()); }
 
-  _LIBCPP_HIDE_FROM_ABI iterator begin() _NOEXCEPT { return iterator(base::__before_begin()->__next_); }
+  _LIBCPP_HIDE_FROM_ABI iterator begin() _NOEXCEPT { return iterator(__base::__before_begin()->__next_); }
   _LIBCPP_HIDE_FROM_ABI const_iterator begin() const _NOEXCEPT {
-    return const_iterator(base::__before_begin()->__next_);
+    return const_iterator(__base::__before_begin()->__next_);
   }
   _LIBCPP_HIDE_FROM_ABI iterator end() _NOEXCEPT { return iterator(nullptr); }
   _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT { return const_iterator(nullptr); }
 
   _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT {
-    return const_iterator(base::__before_begin()->__next_);
+    return const_iterator(__base::__before_begin()->__next_);
   }
   _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT { return const_iterator(nullptr); }
 
-  _LIBCPP_HIDE_FROM_ABI iterator before_begin() _NOEXCEPT { return iterator(base::__before_begin()); }
-  _LIBCPP_HIDE_FROM_ABI const_iterator before_begin() const _NOEXCEPT { return const_iterator(base::__before_begin()); }
+  _LIBCPP_HIDE_FROM_ABI iterator before_begin() _NOEXCEPT { return iterator(__base::__before_begin()); }
+  _LIBCPP_HIDE_FROM_ABI const_iterator before_begin() const _NOEXCEPT {
+    return const_iterator(__base::__before_begin());
+  }
   _LIBCPP_HIDE_FROM_ABI const_iterator cbefore_begin() const _NOEXCEPT {
-    return const_iterator(base::__before_begin());
+    return const_iterator(__base::__before_begin());
   }
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const _NOEXCEPT {
-    return base::__before_begin()->__next_ == nullptr;
+    return __base::__before_begin()->__next_ == nullptr;
   }
   _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT {
-    return std::min<size_type>(__node_traits::max_size(base::__alloc()), numeric_limits<difference_type>::max());
+    return std::min<size_type>(__node_traits::max_size(__base::__alloc()), numeric_limits<difference_type>::max());
   }
 
-  _LIBCPP_HIDE_FROM_ABI reference front() { return base::__before_begin()->__next_->__get_value(); }
-  _LIBCPP_HIDE_FROM_ABI const_reference front() const { return base::__before_begin()->__next_->__get_value(); }
+  _LIBCPP_HIDE_FROM_ABI reference front() { return __base::__before_begin()->__next_->__get_value(); }
+  _LIBCPP_HIDE_FROM_ABI const_reference front() const { return __base::__before_begin()->__next_->__get_value(); }
 
 #ifndef _LIBCPP_CXX03_LANG
 #  if _LIBCPP_STD_VER >= 17
@@ -823,12 +825,12 @@ public:
       _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
 #endif
   {
-    base::swap(__x);
+    __base::swap(__x);
   }
 
   _LIBCPP_HIDE_FROM_ABI void resize(size_type __n);
   _LIBCPP_HIDE_FROM_ABI void resize(size_type __n, const value_type& __v);
-  _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { base::clear(); }
+  _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __base::clear(); }
 
   _LIBCPP_HIDE_FROM_ABI void splice_after(const_iterator __p, forward_list&& __x);
   _LIBCPP_HIDE_FROM_ABI void splice_after(const_iterator __p, forward_list&& __x, const_iterator __i);
@@ -899,12 +901,12 @@ forward_list(from_range_t, _Range&&, _Alloc = _Alloc()) -> forward_list<ranges::
 #endif
 
 template <class _Tp, class _Alloc>
-inline forward_list<_Tp, _Alloc>::forward_list(const allocator_type& __a) : base(__a) {}
+inline forward_list<_Tp, _Alloc>::forward_list(const allocator_type& __a) : __base(__a) {}
 
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(size_type __n) {
   if (__n > 0) {
-    for (__begin_node_pointer __p = base::__before_begin(); __n > 0; --__n, __p = __p->__next_as_begin()) {
+    for (__begin_node_pointer __p = __base::__before_begin(); __n > 0; --__n, __p = __p->__next_as_begin()) {
       __p->__next_ = this->__create_node(/* next = */ nullptr);
     }
   }
@@ -912,9 +914,9 @@ forward_list<_Tp, _Alloc>::forward_list(size_type __n) {
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp, class _Alloc>
-forward_list<_Tp, _Alloc>::forward_list(size_type __n, const allocator_type& __base_alloc) : base(__base_alloc) {
+forward_list<_Tp, _Alloc>::forward_list(size_type __n, const allocator_type& __base_alloc) : __base(__base_alloc) {
   if (__n > 0) {
-    for (__begin_node_pointer __p = base::__before_begin(); __n > 0; --__n, __p = __p->__next_as_begin()) {
+    for (__begin_node_pointer __p = __base::__before_begin(); __n > 0; --__n, __p = __p->__next_as_begin()) {
       __p->__next_ = this->__create_node(/* next = */ nullptr);
     }
   }
@@ -934,26 +936,27 @@ forward_list<_Tp, _Alloc>::forward_list(_InputIterator __f, _InputIterator __l) 
 
 template <class _Tp, class _Alloc>
 template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> >
-forward_list<_Tp, _Alloc>::forward_list(_InputIterator __f, _InputIterator __l, const allocator_type& __a) : base(__a) {
+forward_list<_Tp, _Alloc>::forward_list(_InputIterator __f, _InputIterator __l, const allocator_type& __a)
+    : __base(__a) {
   insert_after(cbefore_begin(), __f, __l);
 }
 
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(const forward_list& __x)
-    : base(__node_traits::select_on_container_copy_construction(__x.__alloc())) {
+    : __base(__node_traits::select_on_container_copy_construction(__x.__alloc())) {
   insert_after(cbefore_begin(), __x.begin(), __x.end());
 }
 
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(const forward_list& __x, const __type_identity_t<allocator_type>& __a)
-    : base(__a) {
+    : __base(__a) {
   insert_after(cbefore_begin(), __x.begin(), __x.end());
 }
 
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>& forward_list<_Tp, _Alloc>::operator=(const forward_list& __x) {
   if (this != std::addressof(__x)) {
-    base::__copy_assign_alloc(__x);
+    __base::__copy_assign_alloc(__x);
     assign(__x.begin(), __x.end());
   }
   return *this;
@@ -962,8 +965,8 @@ forward_list<_Tp, _Alloc>& forward_list<_Tp, _Alloc>::operator=(const forward_li
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(forward_list&& __x, const __type_identity_t<allocator_type>& __a)
-    : base(std::move(__x), __a) {
-  if (base::__alloc() != __x.__alloc()) {
+    : __base(std::move(__x), __a) {
+  if (__base::__alloc() != __x.__alloc()) {
     typedef move_iterator<iterator> _Ip;
     insert_after(cbefore_begin(), _Ip(__x.begin()), _Ip(__x.end()));
   }
@@ -975,7 +978,7 @@ forward_list<_Tp, _Alloc>::forward_list(initializer_list<value_type> __il) {
 }
 
 template <class _Tp, class _Alloc>
-forward_list<_Tp, _Alloc>::forward_list(initializer_list<value_type> __il, const allocator_type& __a) : base(__a) {
+forward_list<_Tp, _Alloc>::forward_list(initializer_list<value_type> __il, const allocator_type& __a) : __base(__a) {
   insert_after(cbefore_begin(), __il.begin(), __il.end());
 }
 
@@ -983,14 +986,14 @@ template <class _Tp, class _Alloc>
 void forward_list<_Tp, _Alloc>::__move_assign(forward_list& __x, true_type)
     _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value) {
   clear();
-  base::__move_assign_alloc(__x);
-  base::__before_begin()->__next_ = __x.__before_begin()->__next_;
-  __x.__before_begin()->__next_   = nullptr;
+  __base::__move_assign_alloc(__x);
+  __base::__before_begin()->__next_ = __x.__before_begin()->__next_;
+  __x.__before_begin()->__next_     = nullptr;
 }
 
 template <class _Tp, class _Alloc>
 void forward_list<_Tp, _Alloc>::__move_assign(forward_list& __x, false_type) {
-  if (base::__alloc() == __x.__alloc())
+  if (__base::__alloc() == __x.__alloc())
     __move_assign(__x, true_type());
   else {
     typedef move_iterator<iterator> _Ip;
@@ -1061,29 +1064,30 @@ typename forward_list<_Tp, _Alloc>::reference
 void
 #  endif
 forward_list<_Tp, _Alloc>::emplace_front(_Args&&... __args) {
-  base::__before_begin()->__next_ =
-      this->__create_node(/* next = */ base::__before_begin()->__next_, std::forward<_Args>(__args)...);
+  __base::__before_begin()->__next_ =
+      this->__create_node(/* next = */ __base::__before_begin()->__next_, std::forward<_Args>(__args)...);
 #  if _LIBCPP_STD_VER >= 17
-  return base::__before_begin()->__next_->__get_value();
+  return __base::__before_begin()->__next_->__get_value();
 #  endif
 }
 
 template <class _Tp, class _Alloc>
 void forward_list<_Tp, _Alloc>::push_front(value_type&& __v) {
-  base::__before_begin()->__next_ = this->__create_node(/* next = */ base::__before_begin()->__next_, std::move(__v));
+  __base::__before_begin()->__next_ =
+      this->__create_node(/* next = */ __base::__before_begin()->__next_, std::move(__v));
 }
 
 #endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 void forward_list<_Tp, _Alloc>::push_front(const value_type& __v) {
-  base::__before_begin()->__next_ = this->__create_node(/* next = */ base::__before_begin()->__next_, __v);
+  __base::__before_begin()->__next_ = this->__create_node(/* next = */ __base::__before_begin()->__next_, __v);
 }
 
 template <class _Tp, class _Alloc>
 void forward_list<_Tp, _Alloc>::pop_front() {
-  __node_pointer __p              = base::__before_begin()->__next_;
-  base::__before_begin()->__next_ = __p->__next_;
+  __node_pointer __p                = __base::__before_begin()->__next_;
+  __base::__before_begin()->__next_ = __p->__next_;
   this->__delete_node(__p);
 }
 
@@ -1380,8 +1384,9 @@ template <class _Tp, class _Alloc>
 template <class _Compare>
 void forward_list<_Tp, _Alloc>::merge(forward_list& __x, _Compare __comp) {
   if (this != std::addressof(__x)) {
-    base::__before_begin()->__next_ = __merge(base::__before_begin()->__next_, __x.__before_begin()->__next_, __comp);
-    __x.__before_begin()->__next_   = nullptr;
+    __base::__before_begin()->__next_ =
+        __merge(__base::__before_begin()->__next_, __x.__before_begin()->__next_, __comp);
+    __x.__before_begin()->__next_ = nullptr;
   }
 }
 
@@ -1425,7 +1430,7 @@ forward_list<_Tp, _Alloc>::__merge(__node_pointer __f1, __node_pointer __f2, _Co
 template <class _Tp, class _Alloc>
 template <class _Compare>
 inline void forward_list<_Tp, _Alloc>::sort(_Compare __comp) {
-  base::__before_begin()->__next_ = __sort(base::__before_begin()->__next_, std::distance(begin(), end()), __comp);
+  __base::__before_begin()->__next_ = __sort(__base::__before_begin()->__next_, std::distance(begin(), end()), __comp);
 }
 
 template <class _Tp, class _Alloc>
@@ -1455,7 +1460,7 @@ forward_list<_Tp, _Alloc>::__sort(__node_pointer __f1, difference_type __sz, _Co
 
 template <class _Tp, class _Alloc>
 void forward_list<_Tp, _Alloc>::reverse() _NOEXCEPT {
-  __node_pointer __p = base::__before_begin()->__next_;
+  __node_pointer __p = __base::__before_begin()->__next_;
   if (__p != nullptr) {
     __node_pointer __f = __p->__next_;
     __p->__next_       = nullptr;
@@ -1465,7 +1470,7 @@ void forward_list<_Tp, _Alloc>::reverse() _NOEXCEPT {
       __p                = __f;
       __f                = __t;
     }
-    base::__before_begin()->__next_ = __p;
+    __base::__before_begin()->__next_ = __p;
   }
 }
 

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -665,14 +665,14 @@ void __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
 
 template <class _Tp, class _Alloc /*= allocator<_Tp>*/>
 class _LIBCPP_TEMPLATE_VIS list : private __list_imp<_Tp, _Alloc> {
-  typedef __list_imp<_Tp, _Alloc> base;
-  typedef typename base::__node_type __node_type;
-  typedef typename base::__node_allocator __node_allocator;
-  typedef typename base::__node_pointer __node_pointer;
-  typedef typename base::__node_alloc_traits __node_alloc_traits;
-  typedef typename base::__node_base __node_base;
-  typedef typename base::__node_base_pointer __node_base_pointer;
-  typedef typename base::__base_pointer __base_pointer;
+  typedef __list_imp<_Tp, _Alloc> __base;
+  typedef typename __base::__node_type __node_type;
+  typedef typename __base::__node_allocator __node_allocator;
+  typedef typename __base::__node_pointer __node_pointer;
+  typedef typename __base::__node_alloc_traits __node_alloc_traits;
+  typedef typename __base::__node_base __node_base;
+  typedef typename __base::__node_base_pointer __node_base_pointer;
+  typedef typename __base::__base_pointer __base_pointer;
 
 public:
   typedef _Tp value_type;
@@ -682,12 +682,12 @@ public:
                 "Allocator::value_type must be same type as value_type");
   typedef value_type& reference;
   typedef const value_type& const_reference;
-  typedef typename base::pointer pointer;
-  typedef typename base::const_pointer const_pointer;
-  typedef typename base::size_type size_type;
-  typedef typename base::difference_type difference_type;
-  typedef typename base::iterator iterator;
-  typedef typename base::const_iterator const_iterator;
+  typedef typename __base::pointer pointer;
+  typedef typename __base::const_pointer const_pointer;
+  typedef typename __base::size_type size_type;
+  typedef typename __base::difference_type difference_type;
+  typedef typename __base::iterator iterator;
+  typedef typename __base::const_iterator const_iterator;
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 #if _LIBCPP_STD_VER >= 20
@@ -697,14 +697,14 @@ public:
 #endif
 
   _LIBCPP_HIDE_FROM_ABI list() _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value) {}
-  _LIBCPP_HIDE_FROM_ABI explicit list(const allocator_type& __a) : base(__a) {}
+  _LIBCPP_HIDE_FROM_ABI explicit list(const allocator_type& __a) : __base(__a) {}
   _LIBCPP_HIDE_FROM_ABI explicit list(size_type __n);
 #if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI explicit list(size_type __n, const allocator_type& __a);
 #endif
   _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x);
   template <__enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x, const allocator_type& __a) : base(__a) {
+  _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x, const allocator_type& __a) : __base(__a) {
     for (; __n > 0; --__n)
       push_back(__x);
   }
@@ -717,7 +717,8 @@ public:
 
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
-  _LIBCPP_HIDE_FROM_ABI list(from_range_t, _Range&& __range, const allocator_type& __a = allocator_type()) : base(__a) {
+  _LIBCPP_HIDE_FROM_ABI list(from_range_t, _Range&& __range, const allocator_type& __a = allocator_type())
+      : __base(__a) {
     prepend_range(std::forward<_Range>(__range));
   }
 #endif
@@ -757,18 +758,18 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT;
 
-  _LIBCPP_HIDE_FROM_ABI size_type size() const _NOEXCEPT { return base::__sz(); }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const _NOEXCEPT { return base::empty(); }
+  _LIBCPP_HIDE_FROM_ABI size_type size() const _NOEXCEPT { return __base::__sz(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const _NOEXCEPT { return __base::empty(); }
   _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT {
-    return std::min<size_type>(base::__node_alloc_max_size(), numeric_limits<difference_type >::max());
+    return std::min<size_type>(__base::__node_alloc_max_size(), numeric_limits<difference_type >::max());
   }
 
-  _LIBCPP_HIDE_FROM_ABI iterator begin() _NOEXCEPT { return base::begin(); }
-  _LIBCPP_HIDE_FROM_ABI const_iterator begin() const _NOEXCEPT { return base::begin(); }
-  _LIBCPP_HIDE_FROM_ABI iterator end() _NOEXCEPT { return base::end(); }
-  _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT { return base::end(); }
-  _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT { return base::begin(); }
-  _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT { return base::end(); }
+  _LIBCPP_HIDE_FROM_ABI iterator begin() _NOEXCEPT { return __base::begin(); }
+  _LIBCPP_HIDE_FROM_ABI const_iterator begin() const _NOEXCEPT { return __base::begin(); }
+  _LIBCPP_HIDE_FROM_ABI iterator end() _NOEXCEPT { return __base::end(); }
+  _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT { return __base::end(); }
+  _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT { return __base::begin(); }
+  _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT { return __base::end(); }
 
   _LIBCPP_HIDE_FROM_ABI reverse_iterator rbegin() _NOEXCEPT { return reverse_iterator(end()); }
   _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rbegin() const _NOEXCEPT { return const_reverse_iterator(end()); }
@@ -779,19 +780,19 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI reference front() {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "list::front called on empty list");
-    return base::__end_.__next_->__as_node()->__get_value();
+    return __base::__end_.__next_->__as_node()->__get_value();
   }
   _LIBCPP_HIDE_FROM_ABI const_reference front() const {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "list::front called on empty list");
-    return base::__end_.__next_->__as_node()->__get_value();
+    return __base::__end_.__next_->__as_node()->__get_value();
   }
   _LIBCPP_HIDE_FROM_ABI reference back() {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "list::back called on empty list");
-    return base::__end_.__prev_->__as_node()->__get_value();
+    return __base::__end_.__prev_->__as_node()->__get_value();
   }
   _LIBCPP_HIDE_FROM_ABI const_reference back() const {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "list::back called on empty list");
-    return base::__end_.__prev_->__as_node()->__get_value();
+    return __base::__end_.__prev_->__as_node()->__get_value();
   }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -864,9 +865,9 @@ public:
       _NOEXCEPT_(!__node_alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
 #endif
   {
-    base::swap(__c);
+    __base::swap(__c);
   }
-  _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { base::clear(); }
+  _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __base::clear(); }
 
   _LIBCPP_HIDE_FROM_ABI void pop_front();
   _LIBCPP_HIDE_FROM_ABI void pop_back();
@@ -967,24 +968,24 @@ inline void list<_Tp, _Alloc>::__link_nodes(__base_pointer __p, __base_pointer _
 // Link in nodes [__f, __l] at the front of the list
 template <class _Tp, class _Alloc>
 inline void list<_Tp, _Alloc>::__link_nodes_at_front(__base_pointer __f, __base_pointer __l) {
-  __f->__prev_          = base::__end_as_link();
-  __l->__next_          = base::__end_.__next_;
-  __l->__next_->__prev_ = __l;
-  base::__end_.__next_  = __f;
+  __f->__prev_           = __base::__end_as_link();
+  __l->__next_           = __base::__end_.__next_;
+  __l->__next_->__prev_  = __l;
+  __base::__end_.__next_ = __f;
 }
 
 // Link in nodes [__f, __l] at the back of the list
 template <class _Tp, class _Alloc>
 inline void list<_Tp, _Alloc>::__link_nodes_at_back(__base_pointer __f, __base_pointer __l) {
-  __l->__next_          = base::__end_as_link();
-  __f->__prev_          = base::__end_.__prev_;
-  __f->__prev_->__next_ = __f;
-  base::__end_.__prev_  = __l;
+  __l->__next_           = __base::__end_as_link();
+  __f->__prev_           = __base::__end_.__prev_;
+  __f->__prev_->__next_  = __f;
+  __base::__end_.__prev_ = __l;
 }
 
 template <class _Tp, class _Alloc>
 inline typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::__iterator(size_type __n) {
-  return __n <= base::__sz() / 2 ? std::next(begin(), __n) : std::prev(end(), base::__sz() - __n);
+  return __n <= __base::__sz() / 2 ? std::next(begin(), __n) : std::prev(end(), __base::__sz() - __n);
 }
 
 template <class _Tp, class _Alloc>
@@ -999,7 +1000,7 @@ list<_Tp, _Alloc>::list(size_type __n) {
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp, class _Alloc>
-list<_Tp, _Alloc>::list(size_type __n, const allocator_type& __a) : base(__a) {
+list<_Tp, _Alloc>::list(size_type __n, const allocator_type& __a) : __base(__a) {
   for (; __n > 0; --__n)
     emplace_back();
 }
@@ -1020,20 +1021,20 @@ list<_Tp, _Alloc>::list(_InpIter __f, _InpIter __l) {
 
 template <class _Tp, class _Alloc>
 template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> >
-list<_Tp, _Alloc>::list(_InpIter __f, _InpIter __l, const allocator_type& __a) : base(__a) {
+list<_Tp, _Alloc>::list(_InpIter __f, _InpIter __l, const allocator_type& __a) : __base(__a) {
   for (; __f != __l; ++__f)
     __emplace_back(*__f);
 }
 
 template <class _Tp, class _Alloc>
 list<_Tp, _Alloc>::list(const list& __c)
-    : base(__node_alloc_traits::select_on_container_copy_construction(__c.__node_alloc())) {
+    : __base(__node_alloc_traits::select_on_container_copy_construction(__c.__node_alloc())) {
   for (const_iterator __i = __c.begin(), __e = __c.end(); __i != __e; ++__i)
     push_back(*__i);
 }
 
 template <class _Tp, class _Alloc>
-list<_Tp, _Alloc>::list(const list& __c, const __type_identity_t<allocator_type>& __a) : base(__a) {
+list<_Tp, _Alloc>::list(const list& __c, const __type_identity_t<allocator_type>& __a) : __base(__a) {
   for (const_iterator __i = __c.begin(), __e = __c.end(); __i != __e; ++__i)
     push_back(*__i);
 }
@@ -1041,7 +1042,7 @@ list<_Tp, _Alloc>::list(const list& __c, const __type_identity_t<allocator_type>
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
-list<_Tp, _Alloc>::list(initializer_list<value_type> __il, const allocator_type& __a) : base(__a) {
+list<_Tp, _Alloc>::list(initializer_list<value_type> __il, const allocator_type& __a) : __base(__a) {
   for (typename initializer_list<value_type>::const_iterator __i = __il.begin(), __e = __il.end(); __i != __e; ++__i)
     push_back(*__i);
 }
@@ -1054,12 +1055,12 @@ list<_Tp, _Alloc>::list(initializer_list<value_type> __il) {
 
 template <class _Tp, class _Alloc>
 inline list<_Tp, _Alloc>::list(list&& __c) noexcept(is_nothrow_move_constructible<__node_allocator>::value)
-    : base(std::move(__c.__node_alloc())) {
+    : __base(std::move(__c.__node_alloc())) {
   splice(end(), __c);
 }
 
 template <class _Tp, class _Alloc>
-inline list<_Tp, _Alloc>::list(list&& __c, const __type_identity_t<allocator_type>& __a) : base(__a) {
+inline list<_Tp, _Alloc>::list(list&& __c, const __type_identity_t<allocator_type>& __a) : __base(__a) {
   if (__a == __c.get_allocator())
     splice(end(), __c);
   else {
@@ -1078,7 +1079,7 @@ inline list<_Tp, _Alloc>& list<_Tp, _Alloc>::operator=(list&& __c) noexcept(
 
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::__move_assign(list& __c, false_type) {
-  if (base::__node_alloc() != __c.__node_alloc()) {
+  if (__base::__node_alloc() != __c.__node_alloc()) {
     typedef move_iterator<iterator> _Ip;
     assign(_Ip(__c.begin()), _Ip(__c.end()));
   } else
@@ -1089,7 +1090,7 @@ template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::__move_assign(list& __c,
                                       true_type) noexcept(is_nothrow_move_assignable<__node_allocator>::value) {
   clear();
-  base::__move_assign_alloc(__c);
+  __base::__move_assign_alloc(__c);
   splice(end(), __c);
 }
 
@@ -1098,7 +1099,7 @@ void list<_Tp, _Alloc>::__move_assign(list& __c,
 template <class _Tp, class _Alloc>
 inline list<_Tp, _Alloc>& list<_Tp, _Alloc>::operator=(const list& __c) {
   if (this != std::addressof(__c)) {
-    base::__copy_assign_alloc(__c);
+    __base::__copy_assign_alloc(__c);
     assign(__c.begin(), __c.end());
   }
   return *this;
@@ -1137,14 +1138,14 @@ void list<_Tp, _Alloc>::assign(size_type __n, const value_type& __x) {
 
 template <class _Tp, class _Alloc>
 inline _Alloc list<_Tp, _Alloc>::get_allocator() const _NOEXCEPT {
-  return allocator_type(base::__node_alloc());
+  return allocator_type(__base::__node_alloc());
 }
 
 template <class _Tp, class _Alloc>
 typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::insert(const_iterator __p, const value_type& __x) {
   __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, __x);
   __link_nodes(__p.__ptr_, __node->__as_link(), __node->__as_link());
-  ++base::__sz();
+  ++__base::__sz();
   return iterator(__node->__as_link());
 }
 
@@ -1178,7 +1179,7 @@ list<_Tp, _Alloc>::insert(const_iterator __p, size_type __n, const value_type& _
     }
 #endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__p.__ptr_, __r.__ptr_, __e.__ptr_);
-    base::__sz() += __ds;
+    __base::__sz() += __ds;
   }
   return __r;
 }
@@ -1220,7 +1221,7 @@ list<_Tp, _Alloc>::__insert_with_sentinel(const_iterator __p, _Iterator __f, _Se
     }
 #endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__p.__ptr_, __r.__ptr_, __e.__ptr_);
-    base::__sz() += __ds;
+    __base::__sz() += __ds;
   }
   return __r;
 }
@@ -1230,7 +1231,7 @@ void list<_Tp, _Alloc>::push_front(const value_type& __x) {
   __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, __x);
   __base_pointer __nl   = __node->__as_link();
   __link_nodes_at_front(__nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
 }
 
 template <class _Tp, class _Alloc>
@@ -1238,7 +1239,7 @@ void list<_Tp, _Alloc>::push_back(const value_type& __x) {
   __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, __x);
   __base_pointer __nl   = __node->__as_link();
   __link_nodes_at_back(__nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
 }
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -1248,7 +1249,7 @@ void list<_Tp, _Alloc>::push_front(value_type&& __x) {
   __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::move(__x));
   __base_pointer __nl   = __node->__as_link();
   __link_nodes_at_front(__nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
 }
 
 template <class _Tp, class _Alloc>
@@ -1256,7 +1257,7 @@ void list<_Tp, _Alloc>::push_back(value_type&& __x) {
   __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::move(__x));
   __base_pointer __nl   = __node->__as_link();
   __link_nodes_at_back(__nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
 }
 
 template <class _Tp, class _Alloc>
@@ -1271,7 +1272,7 @@ list<_Tp, _Alloc>::emplace_front(_Args&&... __args) {
       this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::forward<_Args>(__args)...);
   __base_pointer __nl = __node->__as_link();
   __link_nodes_at_front(__nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
 #  if _LIBCPP_STD_VER >= 17
   return __node->__get_value();
 #  endif
@@ -1289,7 +1290,7 @@ list<_Tp, _Alloc>::emplace_back(_Args&&... __args) {
       this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::forward<_Args>(__args)...);
   __base_pointer __nl = __node->__as_link();
   __link_nodes_at_back(__nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
 #  if _LIBCPP_STD_VER >= 17
   return __node->__get_value();
 #  endif
@@ -1302,7 +1303,7 @@ typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::emplace(const_iterator _
       this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::forward<_Args>(__args)...);
   __base_pointer __nl = __node->__as_link();
   __link_nodes(__p.__ptr_, __nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
   return iterator(__nl);
 }
 
@@ -1311,7 +1312,7 @@ typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::insert(const_iterator __
   __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::move(__x));
   __base_pointer __nl   = __node->__as_link();
   __link_nodes(__p.__ptr_, __nl, __nl);
-  ++base::__sz();
+  ++__base::__sz();
   return iterator(__nl);
 }
 
@@ -1320,18 +1321,18 @@ typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::insert(const_iterator __
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::pop_front() {
   _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "list::pop_front() called with empty list");
-  __base_pointer __n = base::__end_.__next_;
-  base::__unlink_nodes(__n, __n);
-  --base::__sz();
+  __base_pointer __n = __base::__end_.__next_;
+  __base::__unlink_nodes(__n, __n);
+  --__base::__sz();
   this->__delete_node(__n->__as_node());
 }
 
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::pop_back() {
   _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "list::pop_back() called on an empty list");
-  __base_pointer __n = base::__end_.__prev_;
-  base::__unlink_nodes(__n, __n);
-  --base::__sz();
+  __base_pointer __n = __base::__end_.__prev_;
+  __base::__unlink_nodes(__n, __n);
+  --__base::__sz();
   this->__delete_node(__n->__as_node());
 }
 
@@ -1340,8 +1341,8 @@ typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::erase(const_iterator __p
   _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__p != end(), "list::erase(iterator) called with a non-dereferenceable iterator");
   __base_pointer __n = __p.__ptr_;
   __base_pointer __r = __n->__next_;
-  base::__unlink_nodes(__n, __n);
-  --base::__sz();
+  __base::__unlink_nodes(__n, __n);
+  --__base::__sz();
   this->__delete_node(__n->__as_node());
   return iterator(__r);
 }
@@ -1349,11 +1350,11 @@ typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::erase(const_iterator __p
 template <class _Tp, class _Alloc>
 typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::erase(const_iterator __f, const_iterator __l) {
   if (__f != __l) {
-    base::__unlink_nodes(__f.__ptr_, __l.__ptr_->__prev_);
+    __base::__unlink_nodes(__f.__ptr_, __l.__ptr_->__prev_);
     while (__f != __l) {
       __base_pointer __n = __f.__ptr_;
       ++__f;
-      --base::__sz();
+      --__base::__sz();
       this->__delete_node(__n->__as_node());
     }
   }
@@ -1362,10 +1363,10 @@ typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::erase(const_iterator __f
 
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::resize(size_type __n) {
-  if (__n < base::__sz())
+  if (__n < __base::__sz())
     erase(__iterator(__n), end());
-  else if (__n > base::__sz()) {
-    __n -= base::__sz();
+  else if (__n > __base::__sz()) {
+    __n -= __base::__sz();
     size_type __ds        = 0;
     __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr);
     ++__ds;
@@ -1391,16 +1392,16 @@ void list<_Tp, _Alloc>::resize(size_type __n) {
     }
 #endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes_at_back(__r.__ptr_, __e.__ptr_);
-    base::__sz() += __ds;
+    __base::__sz() += __ds;
   }
 }
 
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::resize(size_type __n, const value_type& __x) {
-  if (__n < base::__sz())
+  if (__n < __base::__sz())
     erase(__iterator(__n), end());
-  else if (__n > base::__sz()) {
-    __n -= base::__sz();
+  else if (__n > __base::__sz()) {
+    __n -= __base::__sz();
     size_type __ds        = 0;
     __node_pointer __node = this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, __x);
     ++__ds;
@@ -1426,8 +1427,8 @@ void list<_Tp, _Alloc>::resize(size_type __n, const value_type& __x) {
       throw;
     }
 #endif // _LIBCPP_HAS_EXCEPTIONS
-    __link_nodes(base::__end_as_link(), __r.__ptr_, __e.__ptr_);
-    base::__sz() += __ds;
+    __link_nodes(__base::__end_as_link(), __r.__ptr_, __e.__ptr_);
+    __base::__sz() += __ds;
   }
 }
 
@@ -1438,9 +1439,9 @@ void list<_Tp, _Alloc>::splice(const_iterator __p, list& __c) {
   if (!__c.empty()) {
     __base_pointer __f = __c.__end_.__next_;
     __base_pointer __l = __c.__end_.__prev_;
-    base::__unlink_nodes(__f, __l);
+    __base::__unlink_nodes(__f, __l);
     __link_nodes(__p.__ptr_, __f, __l);
-    base::__sz() += __c.__sz();
+    __base::__sz() += __c.__sz();
     __c.__sz() = 0;
   }
 }
@@ -1449,10 +1450,10 @@ template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::splice(const_iterator __p, list& __c, const_iterator __i) {
   if (__p.__ptr_ != __i.__ptr_ && __p.__ptr_ != __i.__ptr_->__next_) {
     __base_pointer __f = __i.__ptr_;
-    base::__unlink_nodes(__f, __f);
+    __base::__unlink_nodes(__f, __f);
     __link_nodes(__p.__ptr_, __f, __f);
     --__c.__sz();
-    ++base::__sz();
+    ++__base::__sz();
   }
 }
 
@@ -1465,9 +1466,9 @@ void list<_Tp, _Alloc>::splice(const_iterator __p, list& __c, const_iterator __f
     if (this != std::addressof(__c)) {
       size_type __s = std::distance(__f, __l) + 1;
       __c.__sz() -= __s;
-      base::__sz() += __s;
+      __base::__sz() += __s;
     }
-    base::__unlink_nodes(__first, __last);
+    __base::__unlink_nodes(__first, __last);
     __link_nodes(__p.__ptr_, __first, __last);
   }
 }
@@ -1547,12 +1548,12 @@ void list<_Tp, _Alloc>::merge(list& __c, _Comp __comp) {
         iterator __m2  = std::next(__f2);
         for (; __m2 != __e2 && __comp(*__m2, *__f1); ++__m2, (void)++__ds)
           ;
-        base::__sz() += __ds;
+        __base::__sz() += __ds;
         __c.__sz() -= __ds;
         __base_pointer __f = __f2.__ptr_;
         __base_pointer __l = __m2.__ptr_->__prev_;
         __f2               = __m2;
-        base::__unlink_nodes(__f, __l);
+        __base::__unlink_nodes(__f, __l);
         __m2 = std::next(__f1);
         __link_nodes(__f1.__ptr_, __f, __l);
         __f1 = __m2;
@@ -1571,7 +1572,7 @@ inline void list<_Tp, _Alloc>::sort() {
 template <class _Tp, class _Alloc>
 template <class _Comp>
 inline void list<_Tp, _Alloc>::sort(_Comp __comp) {
-  __sort(begin(), end(), base::__sz(), __comp);
+  __sort(begin(), end(), __base::__sz(), __comp);
 }
 
 template <class _Tp, class _Alloc>
@@ -1585,7 +1586,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
   case 2:
     if (__comp(*--__e2, *__f1)) {
       __base_pointer __f = __e2.__ptr_;
-      base::__unlink_nodes(__f, __f);
+      __base::__unlink_nodes(__f, __f);
       __link_nodes(__f1.__ptr_, __f, __f);
       return __e2;
     }
@@ -1603,7 +1604,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
     __base_pointer __l = __m2.__ptr_->__prev_;
     __r                = __f2;
     __e1 = __f2 = __m2;
-    base::__unlink_nodes(__f, __l);
+    __base::__unlink_nodes(__f, __l);
     __m2 = std::next(__f1);
     __link_nodes(__f1.__ptr_, __f, __l);
     __f1 = __m2;
@@ -1619,7 +1620,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
       if (__e1 == __f2)
         __e1 = __m2;
       __f2 = __m2;
-      base::__unlink_nodes(__f, __l);
+      __base::__unlink_nodes(__f, __l);
       __m2 = std::next(__f1);
       __link_nodes(__f1.__ptr_, __f, __l);
       __f1 = __m2;
@@ -1631,7 +1632,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
 
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::reverse() _NOEXCEPT {
-  if (base::__sz() > 1) {
+  if (__base::__sz() > 1) {
     iterator __e = end();
     for (iterator __i = begin(); __i.__ptr_ != __e.__ptr_;) {
       std::swap(__i.__ptr_->__prev_, __i.__ptr_->__next_);

--- a/libcxx/test/std/containers/sequences/forwardlist/types.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/types.pass.cpp
@@ -30,6 +30,24 @@
 #include "test_macros.h"
 #include "min_allocator.h"
 
+// Ensures that we don't use a non-uglified name 'base' in the implementation of 'forward_list'.
+
+struct my_base {
+  typedef my_base base;
+};
+
+template <class T, class A = std::allocator<T> >
+struct my_derived : my_base, std::forward_list<T, A> {};
+
+static_assert(std::is_same<my_derived<char>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<int>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<my_base>::base, my_base>::value, "");
+#if TEST_STD_VER >= 11
+static_assert(std::is_same<my_derived<char, min_allocator<char>>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<int, min_allocator<int>>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<my_base, min_allocator<my_base>>::base, my_base>::value, "");
+#endif
+
 struct A { std::forward_list<A> v; }; // incomplete type support
 
 int main(int, char**)

--- a/libcxx/test/std/containers/sequences/list/types.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/types.pass.cpp
@@ -27,6 +27,24 @@
 #include "test_macros.h"
 #include "min_allocator.h"
 
+// Ensures that we don't use a non-uglified name 'base' in the implementation of 'list'.
+
+struct my_base {
+  typedef my_base base;
+};
+
+template <class T, class A = std::allocator<T> >
+struct my_derived : my_base, std::list<T, A> {};
+
+static_assert(std::is_same<my_derived<char>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<int>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<my_base>::base, my_base>::value, "");
+#if TEST_STD_VER >= 11
+static_assert(std::is_same<my_derived<char, min_allocator<char>>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<int, min_allocator<int>>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<my_base, min_allocator<my_base>>::base, my_base>::value, "");
+#endif
+
 struct A { std::list<A> v; }; // incomplete type support
 
 int main(int, char**)

--- a/libcxx/test/std/utilities/template.bitset/bitset.members/nonstdmem.uglified.compile.pass.cpp
+++ b/libcxx/test/std/utilities/template.bitset/bitset.members/nonstdmem.uglified.compile.pass.cpp
@@ -8,8 +8,8 @@
 
 // <bitset>
 
-// This test ensures that we don't use a non-uglified name 'iterator' and
-// 'const_iterator' in the implementation of bitset.
+// This test ensures that we don't use a non-uglified name 'iterator',
+// 'const_iterator', and 'base' in the implementation of bitset.
 //
 // See https://github.com/llvm/llvm-project/issues/111125.
 
@@ -20,6 +20,7 @@
 struct my_base {
   typedef int* iterator;
   typedef const int* const_iterator;
+  typedef my_base base;
 };
 
 template <std::size_t N>
@@ -44,3 +45,13 @@ static_assert(std::is_same<my_derived<32>::const_iterator, const int*>::value, "
 static_assert(std::is_same<my_derived<48>::const_iterator, const int*>::value, "");
 static_assert(std::is_same<my_derived<64>::const_iterator, const int*>::value, "");
 static_assert(std::is_same<my_derived<96>::const_iterator, const int*>::value, "");
+
+static_assert(std::is_same<my_derived<0>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<1>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<8>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<12>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<16>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<32>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<48>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<64>::base, my_base>::value, "");
+static_assert(std::is_same<my_derived<96>::base, my_base>::value, "");


### PR DESCRIPTION
Currently, libc++'s `bitset`, `forward_list`, and `list` have non-conforming member typedef name `base`. The typedef is private, but can cause ambiguity in name lookup.

Some other classes in libc++ that are either implementation details or not precisely specified by the standard also have member typdef `base`. I think this can still be conforming.

Follows up #80706 and #111127.