### PR TITLE
[Legacy ThinLTO] NFC: Move helper class to an "Impl" namespace

### DIFF
--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -31,8 +31,15 @@ namespace llvm {
 class StringRef;
 class TargetMachine;
 
+/// ThinLTOCodeGeneratorImpl - Namespace used for ThinLTOCodeGenerator
+/// implementation details. It should be considered private to the
+/// implementation.
+namespace ThinLTOCodeGeneratorImpl {
+struct TargetMachineBuilder;
+}
+
 /// Helper to gather options relevant to the target machine creation
-struct TargetMachineBuilder {
+struct ThinLTOCodeGeneratorImpl::TargetMachineBuilder {
   Triple TheTriple;
   std::string MCpu;
   std::string MAttr;
@@ -301,7 +308,7 @@ public:
 
 private:
   /// Helper factory to build a TargetMachine
-  TargetMachineBuilder TMBuilder;
+  ThinLTOCodeGeneratorImpl::TargetMachineBuilder TMBuilder;
 
   /// Vector holding the in-memory buffer containing the produced binaries, when
   /// SavedObjectsDirectoryPath isn't set.

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -70,6 +70,7 @@
 #endif
 
 using namespace llvm;
+using namespace ThinLTOCodeGeneratorImpl;
 
 #define DEBUG_TYPE "thinlto"
 


### PR DESCRIPTION
`::llvm::TargetMachineBuilder` is only a helper class for
`ThinLTOCodeGenerator` and not a real facility. Move it into an "Impl"
namespace.
