### PR TITLE
LangRef: Clarify llvm.minnum and llvm.maxnum about sNaN and signed zero

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16723,12 +16723,21 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE754 2008 semantics for minNum with +0.0>-0.0.
-This is more strict than current (C23) behavior of libm's fmin.
-Some applications like Clang, can call '``llvm.minnum.*``' with '``nsz``' attribute
-to archive the same behaivor of libm's fmin.
+Follows the IEEE-754 semantics for minNum, except that -0.0 < +0.0 for the purposes
+of this intrinsic. As for signaling NaNs, per the IEEE-754 semantics, if either operand
+is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
+function fmin, although not all implementations have implemented these recommended behaviors.
 
-For some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, they have the
+If either operand is a qNaN, returns the other non-NaN operand. Returns
+NaN only if both operands are NaN or either operand is sNaN.
+
+If the operands compare equal, returns either one of the operands.
+
+Returns -0.0 for +0.0 vs -0.0. libm doesn't require it, so that
+some applications like Clang, can call '``llvm.minnum.*``' with '``nsz``' attribute
+to archive the required behaivors of libm's fmin.
+
+Some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have the
 strictly same instructions; thus it is quite simple for these architectures.
 For other architectures, the custom or expand methods may provide '``nsz``' flavor.
 
@@ -16740,10 +16749,6 @@ Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a minnum can produce inconsistent results.
 Such as `fmin(sNaN+0.0, 1.0)` can produce qNaN or 1.0 depending on whether `+0.0`
 is optimized out.
-
-If either operand is a qNaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN or either operand is sNaN.
-If the operands compare equal, returns either one of the operands.
 
 .. _i_maxnum:
 
@@ -16780,12 +16785,21 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE754 2008 semantics for maxNum with +0.0>-0.0.
-This is more strict than current (C23) behavior of libm's fmax.
-Some applications like Clang, can call '``llvm.maxnum.*``' with '``nsz``' attribute
-to archive the same behaivor of libm's fmax.
+Follows the IEEE-754 semantics for minNum, except that -0.0 < +0.0 for the purposes
+of this intrinsic. As for signaling NaNs, per the IEEE-754 semantics, if either operand
+is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
+function fmin, although not all implementations have implemented these recommended behaviors.
 
-For some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, they have the
+If either operand is a qNaN, returns the other non-NaN operand. Returns
+NaN only if both operands are NaN or either operand is sNaN.
+
+If the operands compare equal, returns either one of the operands.
+
+Returns -0.0 for +0.0 vs -0.0. libm doesn't require it, so that
+some applications like Clang, can call '``llvm.minnum.*``' with '``nsz``' attribute
+to archive the required behaivors of libm's fmin.
+
+Some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have the
 strictly same instructions; thus it is quite simple for these architectures.
 For other architectures, the custom or expand methods may provide '``nsz``' flavor.
 
@@ -16797,10 +16811,6 @@ Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a maxnum can produce inconsistent results.
 Such as `fmax(sNaN+0.0, 1.0)` can produce qNaN or 1.0 depending on whether `+0.0`
 is optimized out.
-
-If either operand is a NaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN or either operand is sNaN.
-If the operands compare equal, returns either one of the operands.
 
 .. _i_minimum:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16731,19 +16731,19 @@ function ``fmin``, although not all implementations have implemented these recom
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
 NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a minnum can produce inconsistent results. For example,
-`minnum(fadd(sNaN, -0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
+``minnum(fadd(sNaN, -0.0), 1.0)`` can produce qNaN or 1.0 depending on whether ``fadd`` is folded.
 
 IEEE-754-2008 defines minNum, and it was removed in IEEE-754-2019. As the replacement, IEEE-754-2019
 defines :ref:`minimumNumber <llvm-minimumnum-intrinsic>`.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
-and IEEE-754-2008: the result of minnum(-0.0, +0.0) may be either -0.0 or +0.0.
+and IEEE-754-2008: the result of ``minnum(-0.0, +0.0)`` may be either -0.0 or +0.0.
 
 Some architectures, such as ARMv8 (FMINNM), LoongArch (fmin), MIPSr6 (min.fmt), PowerPC/VSX (xsmindp),
 have instructions that match these semantics exactly; thus it is quite simple for these architectures.
-Some architectures have similiar ones while they are not exact equivalent. Such as x86 implements `MINPS`,
-which implements the semantics of C code `a<b?a:b`: NUM vs qNaN always return qNaN. `MINPS` can be used
-if `nsz` and `nnan` are given.
+Some architectures have similiar ones while they are not exact equivalent. Such as x86 implements ``MINPS``,
+which implements the semantics of C code ``a<b?a:b``: NUM vs qNaN always return qNaN. ``MINPS`` can be used
+if ``nsz`` and ``nnan`` are given.
 
 For existing libc implementations, the behaviors of fmin may be quite different on sNaN and signed zero behaviors,
 even in the same release of a single libm implemention.
@@ -16791,7 +16791,7 @@ function ``fmax``, although not all implementations have implemented these recom
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
 NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a maxnum can produce inconsistent results. For example,
-`maxnum(fadd(sNaN, -0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
+``maxnum(fadd(sNaN, -0.0), 1.0)`` can produce qNaN or 1.0 depending on whether ``fadd`` is folded.
 
 IEEE-754-2008 defines maxNum, and it was removed in IEEE-754-2019. As the replacement, IEEE-754-2019
 defines :ref:`maximumNumber <llvm-maximumnum-intrinsic>`.
@@ -16801,9 +16801,9 @@ and IEEE-754-2008: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.
 
 Some architectures, such as ARMv8 (FMAXNM), LoongArch (fmax), MIPSr6 (max.fmt), PowerPC/VSX (xsmaxdp),
 have instructions that match these semantics exactly; thus it is quite simple for these architectures.
-Some architectures have similiar ones while they are not exact equivalent. Such as x86 implements `MAXPS`,
-which implements the semantics of C code `a>b?a:b`: NUM vs qNaN always return qNaN. `MAXPS` can be used
-if `nsz` and `nnan` are given.
+Some architectures have similiar ones while they are not exact equivalent. Such as x86 implements ``MAXPS``,
+which implements the semantics of C code ``a>b?a:b``: NUM vs qNaN always return qNaN. ``MAXPS`` can be used
+if ``nsz`` and ``nnan`` are given.
 
 For existing libc implementations, the behaviors of fmin may be quite different on sNaN and signed zero behaviors,
 even in the same release of a single libm implemention.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16724,7 +16724,11 @@ type.
 Semantics:
 """"""""""
 Follows the IEEE754 2008 semantics for minNum.
-This also matches the behavior of libm's fmin.
+This also matches the current (C23) behavior of libm's fmin.
+
+Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
+sNaN for qNaN vs sNaN. Withe recent libc versions, libc follows IEEE754-2008:
+NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.
@@ -16767,7 +16771,11 @@ type.
 Semantics:
 """"""""""
 Follows the IEEE754 2008 semantics for maxNum.
-This also matches the behavior of libm's fmax.
+This also matches the current (C23) behavior of libm's fmax.
+
+Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
+sNaN for qNaN vs sNaN. Withe recent libc versions, libc follows IEEE754-2008:
+NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
 
 If either operand is a NaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16734,7 +16734,7 @@ so arithmetic feeding into a minnum can produce inconsistent results. For exampl
 ``minnum(fadd(sNaN, -0.0), 1.0)`` can produce qNaN or 1.0 depending on whether ``fadd`` is folded.
 
 IEEE-754-2008 defines minNum, and it was removed in IEEE-754-2019. As the replacement, IEEE-754-2019
-defines :ref:`minimumNumber <llvm-minimumnum-intrinsic>`.
+defines :ref:`minimumNumber <i_minimumnum>`.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of ``minnum(-0.0, +0.0)`` may be either -0.0 or +0.0.
@@ -16794,7 +16794,7 @@ so arithmetic feeding into a maxnum can produce inconsistent results. For exampl
 ``maxnum(fadd(sNaN, -0.0), 1.0)`` can produce qNaN or 1.0 depending on whether ``fadd`` is folded.
 
 IEEE-754-2008 defines maxNum, and it was removed in IEEE-754-2019. As the replacement, IEEE-754-2019
-defines :ref:`maximumNumber <llvm-maximumnum-intrinsic>`.
+defines :ref:`maximumNumber <i_maximumnum>`.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16725,7 +16725,7 @@ Semantics:
 """"""""""
 Follows the semantics of minimumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
-function `fmin`, although not all implementations have implemented these recommended behaviors.
+function ``fmin``, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
 NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
@@ -16733,8 +16733,7 @@ so arithmetic feeding into a minnum can produce inconsistent results. For exampl
 `minnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
 IEEE-754-2008 defines minNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
-stricter than minNum in IEEE-754-2008, where either zero may be returned. To achieve the same permissiveness,
-the backend may implement the nsz attribute, and one may use the nsz attribute.
+stricter than minNum in IEEE-754-2008, where either zero may be returned.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of minnum(-0.0, +0.0) may be either -0.0 or +0.0.
@@ -16785,7 +16784,7 @@ Semantics:
 """"""""""
 Follows the semantics of maximumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
-function `fmin`, although not all implementations have implemented these recommended behaviors.
+function ``fmax``, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
 NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
@@ -16793,8 +16792,7 @@ so arithmetic feeding into a maxnum can produce inconsistent results. For exampl
 `maxnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
 IEEE-754-2008 defines maxNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
-stricter than minNum in IEEE-754-2008, where either zero may be returned. To achieve the same permissiveness,
-the backend may implement the nsz attribute, and one may use the nsz attribute.
+stricter than minNum in IEEE-754-2008, where either zero may be returned.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16723,8 +16723,9 @@ type.
 
 Semantics:
 """"""""""
-Follows the semantics of minimumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
-is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
+Follows the semantics of minNum in IEEE-754-2008, except that -0.0 < +0.0 for the purposes
+of this intrinsic. As for signaling NaNs, per the minNum semantics, if either operand is sNaN,
+the result is qNaN. This matches the recommended behavior for the libm
 function ``fmin``, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
@@ -16732,8 +16733,8 @@ NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consis
 so arithmetic feeding into a minnum can produce inconsistent results. For example,
 `minnum(fadd(sNaN, -0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
-IEEE-754-2008 defines minNum, and it was removed in IEEE-754-2019. The behavior of this intrinsic is
-stricter than minNum in IEEE-754-2008, where either zero may be returned.
+IEEE-754-2008 defines minNum, and it was removed in IEEE-754-2019. As the replacement, IEEE-754-2019
+defines :ref:`minimumNumber <llvm-minimumnum-intrinsic>`.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of minnum(-0.0, +0.0) may be either -0.0 or +0.0.
@@ -16782,8 +16783,9 @@ type.
 
 Semantics:
 """"""""""
-Follows the semantics of maximumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
-is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
+Follows the semantics of maxNum in IEEE-754-2008, except that -0.0 < +0.0 for the purposes
+of this intrinsic. As for signaling NaNs, per the maxNum semantics, if either operand is sNaN,
+the result is qNaN. This matches the recommended behavior for the libm
 function ``fmax``, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
@@ -16791,8 +16793,8 @@ NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consis
 so arithmetic feeding into a maxnum can produce inconsistent results. For example,
 `maxnum(fadd(sNaN, -0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
-IEEE-754-2008 defines maxNum, and it was removed in IEEE-754-2019. The behavior of this intrinsic is
-stricter than minNum in IEEE-754-2008, where either zero may be returned.
+IEEE-754-2008 defines maxNum, and it was removed in IEEE-754-2019. As the replacement, IEEE-754-2019
+defines :ref:`maximumNumber <llvm-maximumnum-intrinsic>`.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16723,21 +16723,13 @@ type.
 
 Semantics:
 """"""""""
+Follows the IEEE754 2008 semantics for minNum, except for handling of
++0.0 vs -0.0. This matches the behavior of libm's fmin.
 
-Follows the IEEE-754 semantics for minNum, except for handling of
-signaling NaNs. This match's the behavior of libm's fmin.
-
-If either operand is a NaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN. If the operands compare equal,
-returns either one of the operands. For example, this means that
-fmin(+0.0, -0.0) returns either operand.
-
-Unlike the IEEE-754 2008 behavior, this does not distinguish between
-signaling and quiet NaN inputs. If a target's implementation follows
-the standard and returns a quiet NaN if either input is a signaling
-NaN, the intrinsic lowering is responsible for quieting the inputs to
-correctly return the non-NaN input (e.g. by using the equivalent of
-``llvm.canonicalize``).
+If either operand is a qNaN, returns the other non-NaN operand. Returns
+NaN only if both operands are NaN or either operand is sNaN.
+If the operands compare equal, returns either one of the operands.
+For example, this means that fmin(+0.0, -0.0) returns either operand.
 
 .. _i_maxnum:
 
@@ -16774,20 +16766,13 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE-754 semantics for maxNum except for the handling of
-signaling NaNs. This matches the behavior of libm's fmax.
+Follows the IEEE754 2008 semantics for maxNum, except for handling of
++0.0 vs -0.0. This matches the behavior of libm's fmax.
 
 If either operand is a NaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN. If the operands compare equal,
-returns either one of the operands. For example, this means that
-fmax(+0.0, -0.0) returns either -0.0 or 0.0.
-
-Unlike the IEEE-754 2008 behavior, this does not distinguish between
-signaling and quiet NaN inputs. If a target's implementation follows
-the standard and returns a quiet NaN if either input is a signaling
-NaN, the intrinsic lowering is responsible for quieting the inputs to
-correctly return the non-NaN input (e.g. by using the equivalent of
-``llvm.canonicalize``).
+NaN only if both operands are NaN or either operand is sNaN.
+If the operands compare equal, returns either one of the operands.
+For example, this means that fmin(+0.0, -0.0) returns either operand.
 
 .. _i_minimum:
 
@@ -19666,12 +19651,12 @@ The '``llvm.vector.reduce.fmax.*``' intrinsics do a floating-point
 matches the element-type of the vector input.
 
 This instruction has the same comparison semantics as the '``llvm.maxnum.*``'
-intrinsic. That is, the result will always be a number unless all elements of
-the vector are NaN. For a vector with maximum element magnitude 0.0 and
-containing both +0.0 and -0.0 elements, the sign of the result is unspecified.
+intrinsic.  If the intrinsic call has the ``nnan`` fast-math flag, then the
+operation can assume that NaNs are not present in the input vector.
 
-If the intrinsic call has the ``nnan`` fast-math flag, then the operation can
-assume that NaNs are not present in the input vector.
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vector.reduce.fmaximum``' or '``llvm.vector.reduce.fmaximumnum``' instead.
 
 Arguments:
 """"""""""
@@ -19699,12 +19684,12 @@ The '``llvm.vector.reduce.fmin.*``' intrinsics do a floating-point
 matches the element-type of the vector input.
 
 This instruction has the same comparison semantics as the '``llvm.minnum.*``'
-intrinsic. That is, the result will always be a number unless all elements of
-the vector are NaN. For a vector with minimum element magnitude 0.0 and
-containing both +0.0 and -0.0 elements, the sign of the result is unspecified.
+intrinsic. If the intrinsic call has the ``nnan`` fast-math flag, then the
+operation can assume that NaNs are not present in the input vector.
 
-If the intrinsic call has the ``nnan`` fast-math flag, then the operation can
-assume that NaNs are not present in the input vector.
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vector.reduce.fminimum``' or '``llvm.vector.reduce.fminimumnum``' instead.
 
 Arguments:
 """"""""""
@@ -23318,12 +23303,13 @@ result type. If only ``nnan`` is set then the neutral value is ``-Infinity``.
 
 This instruction has the same comparison semantics as the
 :ref:`llvm.vector.reduce.fmax <int_vector_reduce_fmax>` intrinsic (and thus the
-'``llvm.maxnum.*``' intrinsic). That is, the result will always be a number
-unless all elements of the vector and the starting value are ``NaN``. For a
-vector with maximum element magnitude ``0.0`` and containing both ``+0.0`` and
-``-0.0`` elements, the sign of the result is unspecified.
+'``llvm.maxnum.*``' intrinsic).
 
 To ignore the start value, the neutral value can be used.
+
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vp.vector.reduce.fmaximum``' or '``llvm.vp.vector.reduce.fmaximumnum``' instead.
 
 Examples:
 """""""""
@@ -23388,12 +23374,13 @@ result type. If only ``nnan`` is set then the neutral value is ``+Infinity``.
 
 This instruction has the same comparison semantics as the
 :ref:`llvm.vector.reduce.fmin <int_vector_reduce_fmin>` intrinsic (and thus the
-'``llvm.minnum.*``' intrinsic). That is, the result will always be a number
-unless all elements of the vector and the starting value are ``NaN``. For a
-vector with maximum element magnitude ``0.0`` and containing both ``+0.0`` and
-``-0.0`` elements, the sign of the result is unspecified.
+'``llvm.minnum.*``' intrinsic).
 
 To ignore the start value, the neutral value can be used.
+
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vp.vector.reduce.fminimum``' or '``llvm.vp.vector.reduce.fminimumnum``' instead.
 
 Examples:
 """""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16736,6 +16736,11 @@ Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
 sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
 NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
 
+Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
+so arithmetic feeding into a minnum can produce inconsistent results.
+Such as `fmin(sNaN+0.0, 1.0)` can produce qNaN or 1.0 depending on whether `+0.0`
+is optimized out.
+
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.
 If the operands compare equal, returns either one of the operands.
@@ -16787,6 +16792,11 @@ For other architectures, the custom or expand methods may provide '``nsz``' flav
 Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
 sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
 NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
+
+Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
+so arithmetic feeding into a maxnum can produce inconsistent results.
+Such as `fmax(sNaN+0.0, 1.0)` can produce qNaN or 1.0 depending on whether `+0.0`
+is optimized out.
 
 If either operand is a NaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16723,20 +16723,20 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE-754 semantics for minNum, except that -0.0 < +0.0 for the purposes
-of this intrinsic. As for signaling NaNs, per the IEEE-754 semantics, if either operand
+Follows the semantics of minNum in IEEE-754-2008, except that -0.0 < +0.0 for the purposes
+of this intrinsic. As for signaling NaNs, per the minNum semantics, if either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
 function `fmin`, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or if either operand is sNaN.
 
-This behavior is more strict than the definition in C and IEEE 754, where either zero may be returned.
-To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use the nsz
-attribute on the intrinsic call.
+This behavior is stricter than minNum in IEEE-754-2008, where either zero may be returned.
+To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use
+the nsz attribute.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
-and IEEE 754: the result of minnum(-0.0, +0.0) may be either -0.0 or +0.0.
+and IEEE-754-2008: the result of minnum(-0.0, +0.0) may be either -0.0 or +0.0.
 
 Some architectures, such as ARMv8 (FMINNM), LoongArch (fmin), MIPSr6 (min.fmt), PowerPC/VSX (xsmindp),
 have instructions that match these semantics exactly; thus it is quite simple for these architectures.
@@ -16788,20 +16788,20 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE-754 semantics for minNum, except that -0.0 < +0.0 for the purposes
-of this intrinsic. As for signaling NaNs, per the IEEE-754 semantics, if either operand
+Follows the semantics of maxNum in IEEE-754-2008, except that -0.0 < +0.0 for the purposes
+of this intrinsic. As for signaling NaNs, per the maxNum semantics, if either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
 function `fmax`, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or if either operand is sNaN.
 
-This behavior is more strict than the definition in C and IEEE 754, where either zero may be returned.
-To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use the nsz
-attribute on the intrinsic call.
+This behavior is stricter than maxNum in IEEE-754-2008, where either zero may be returned.
+To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use
+the nsz attribute.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
-and IEEE 754: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.
+and IEEE-754-2008: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.
 
 Some architectures, such as ARMv8 (FMAXNM), LoongArch (fmax), MIPSr6 (max.fmt), PowerPC/VSX (xsmaxdp),
 have instructions that match these semantics exactly; thus it is quite simple for these architectures.
@@ -21998,7 +21998,7 @@ This is an overloaded intrinsic.
 Overview:
 """""""""
 
-Predicated floating-point IEEE-754 minNum of two vectors of floating-point values.
+Predicated floating-point IEEE-754-2008 minNum of two vectors of floating-point values.
 
 
 Arguments:
@@ -22047,7 +22047,7 @@ This is an overloaded intrinsic.
 Overview:
 """""""""
 
-Predicated floating-point IEEE-754 maxNum of two vectors of floating-point values.
+Predicated floating-point IEEE-754-2008 maxNum of two vectors of floating-point values.
 
 
 Arguments:
@@ -28091,7 +28091,7 @@ The third argument specifies the exception behavior as described above.
 Semantics:
 """"""""""
 
-This function follows the IEEE-754 semantics for maxNum.
+This function follows the IEEE-754-2008 semantics for maxNum.
 
 
 '``llvm.experimental.constrained.minnum``' Intrinsic
@@ -28123,7 +28123,7 @@ The third argument specifies the exception behavior as described above.
 Semantics:
 """"""""""
 
-This function follows the IEEE-754 semantics for minNum.
+This function follows the IEEE-754-2008 semantics for minNum.
 
 
 '``llvm.experimental.constrained.maximum``' Intrinsic

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16679,7 +16679,7 @@ versions of the intrinsics respect the exception behavior.
      - qNaN, invalid exception
 
    * - ``+0.0 vs -0.0``
-     - either one
+     - +0.0(max)/-0.0(min)
      - +0.0(max)/-0.0(min)
      - +0.0(max)/-0.0(min)
 
@@ -16723,8 +16723,14 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE754 2008 semantics for minNum.
-This also matches the current (C23) behavior of libm's fmin.
+Follows the IEEE754 2008 semantics for minNum with +0.0>-0.0.
+This is more strict than current (C23) behavior of libm's fmin.
+Some applications like Clang, can call '``llvm.minnum.*``' with '``nsz``' attribute
+to archive the same behaivor of libm's fmin.
+
+For some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, they have the
+strict same instructions; thus it is quite simple for these architectures.
+For other architectures, the custom or expand methods may provide '``nsz``' flavor.
 
 Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
 sNaN for qNaN vs sNaN. Withe recent libc versions, libc follows IEEE754-2008:
@@ -16770,12 +16776,14 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE754 2008 semantics for maxNum.
-This also matches the current (C23) behavior of libm's fmax.
+Follows the IEEE754 2008 semantics for maxNum with +0.0>-0.0.
+This is more strict than current (C23) behavior of libm's fmax.
+Some applications like Clang, can call '``llvm.maxnum.*``' with '``nsz``' attribute
+to archive the same behaivor of libm's fmax.
 
-Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
-sNaN for qNaN vs sNaN. Withe recent libc versions, libc follows IEEE754-2008:
-NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
+For some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, they have the
+strict same instructions; thus it is quite simple for these architectures.
+For other architectures, the custom or expand methods may provide '``nsz``' flavor.
 
 If either operand is a NaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16730,9 +16730,9 @@ function ``fmin``, although not all implementations have implemented these recom
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
 NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a minnum can produce inconsistent results. For example,
-`minnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
+`minnum(fadd(sNaN, -0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
-IEEE-754-2008 defines minNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
+IEEE-754-2008 defines minNum, and it was removed in IEEE-754-2019. The behavior of this intrinsic is
 stricter than minNum in IEEE-754-2008, where either zero may be returned.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
@@ -16744,7 +16744,7 @@ Some architectures have similiar ones while they are not exact equivalent. Such 
 which implements the semantics of C code `a<b?a:b`: NUM vs qNaN always return qNaN. `MINPS` can be used
 if `nsz` and `nnan` are given.
 
-In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
+For existing libc implementations, the behaviors of fmin may be quite different on sNaN and signed zero behaviors,
 even in the same release of a single libm implemention.
 
 .. _i_maxnum:
@@ -16789,9 +16789,9 @@ function ``fmax``, although not all implementations have implemented these recom
 If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
 NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a maxnum can produce inconsistent results. For example,
-`maxnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
+`maxnum(fadd(sNaN, -0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
-IEEE-754-2008 defines maxNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
+IEEE-754-2008 defines maxNum, and it was removed in IEEE-754-2019. The behavior of this intrinsic is
 stricter than minNum in IEEE-754-2008, where either zero may be returned.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
@@ -16803,7 +16803,7 @@ Some architectures have similiar ones while they are not exact equivalent. Such 
 which implements the semantics of C code `a>b?a:b`: NUM vs qNaN always return qNaN. `MAXPS` can be used
 if `nsz` and `nnan` are given.
 
-In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
+For existing libc implementations, the behaviors of fmin may be quite different on sNaN and signed zero behaviors,
 even in the same release of a single libm implemention.
 
 .. _i_minimum:

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16723,8 +16723,8 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE754 2008 semantics for minNum, except for handling of
-+0.0 vs -0.0. This matches the behavior of libm's fmin.
+Follows the IEEE754 2008 semantics for minNum.
+This also matches the behavior of libm's fmin.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.
@@ -16766,8 +16766,8 @@ type.
 
 Semantics:
 """"""""""
-Follows the IEEE754 2008 semantics for maxNum, except for handling of
-+0.0 vs -0.0. This matches the behavior of libm's fmax.
+Follows the IEEE754 2008 semantics for maxNum.
+This also matches the behavior of libm's fmax.
 
 If either operand is a NaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16726,26 +16726,32 @@ Semantics:
 Follows the IEEE-754 semantics for minNum, except that -0.0 < +0.0 for the purposes
 of this intrinsic. As for signaling NaNs, per the IEEE-754 semantics, if either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
-function fmin, although not all implementations have implemented these recommended behaviors.
+function `fmin`, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN or either operand is sNaN.
+NaN only if both operands are NaN or if either operand is sNaN.
 
 This behavior is more strict than the definition in C and IEEE 754, where either zero may be returned.
 To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use the nsz
 attribute on the intrinsic call.
 
-Some architectures, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have instructions that match
-these semantics exactly; thus it is quite simple for these architectures.
+If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
+and IEEE 754: the result of minnum(-0.0, +0.0) may be either -0.0 or +0.0.
+
+Some architectures, such as ARMv8 (FMINNM), LoongArch (fmin), MIPSr6 (min.fmt), PowerPC/VSX (xsmindp),
+have instructions that match these semantics exactly; thus it is quite simple for these architectures.
+Some architectures have similiar while they are not exact equivalent. Such as x86 implements `MINPS`,
+which implements the semantics of C code `a<b?a:b`: NUM vs qNaN always return qNaN. `MINPS` can be used
+if `nsz` and `nnan` are given.
+
 
 In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
-even in the same release of a single libm implemention. Such as in glibc 2.24, the Arm64 asm implemention
-has different behaviour with the generic C implemention.
+even in the same release of a single libm implemention.
 
-Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
+Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a minnum can produce inconsistent results.
-Such as `fmin(sNaN+0.0, 1.0)` can produce qNaN or 1.0 depending on whether `+0.0`
-is optimized out.
+For example, `maxnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd`
+is folded.
 
 .. _i_maxnum:
 
@@ -16785,26 +16791,31 @@ Semantics:
 Follows the IEEE-754 semantics for minNum, except that -0.0 < +0.0 for the purposes
 of this intrinsic. As for signaling NaNs, per the IEEE-754 semantics, if either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
-function fmin, although not all implementations have implemented these recommended behaviors.
+function `fmax`, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN or either operand is sNaN.
+NaN only if both operands are NaN or if either operand is sNaN.
 
 This behavior is more strict than the definition in C and IEEE 754, where either zero may be returned.
 To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use the nsz
 attribute on the intrinsic call.
 
-Some architectures, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have instructions that match
-these semantics exactly; thus it is quite simple for these architectures.
+If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
+and IEEE 754: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.
+
+Some architectures, such as ARMv8 (FMAXNM), LoongArch (fmax), MIPSr6 (max.fmt), PowerPC/VSX (xsmaxdp),
+have instructions that match these semantics exactly; thus it is quite simple for these architectures.
+Some architectures have similiar while they are not exact equivalent. Such as x86 implements `MAXPS`,
+which implements the semantics of C code `a>b?a:b`: NUM vs qNaN always return qNaN. `MAXPS` can be used
+if `nsz` and `nnan` are given.
 
 In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
-even in the same release of a single libm implemention. Such as in glibc 2.24, the Arm64 asm implemention
-has different behaviour with the generic C implemention.
+even in the same release of a single libm implemention.
 
-Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
+Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a maxnum can produce inconsistent results.
-Such as `fmax(sNaN+0.0, 1.0)` can produce qNaN or 1.0 depending on whether `+0.0`
-is optimized out.
+For example, `maxnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd`
+is folded.
 
 .. _i_minimum:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16723,24 +16723,23 @@ type.
 
 Semantics:
 """"""""""
-Follows the semantics of minNum in IEEE-754-2008, except that -0.0 < +0.0 for the purposes
-of this intrinsic. As for signaling NaNs, per the minNum semantics, if either operand
+Follows the semantics of mininumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
 function `fmin`, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or if either operand is sNaN.
 
-This behavior is stricter than minNum in IEEE-754-2008, where either zero may be returned.
-To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use
-the nsz attribute.
+IEEE-754-2008 defines minNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
+stricter than minNum in IEEE-754-2008, where either zero may be returned. To achieve the same permissiveness,
+the backend may implement the nsz attribute, and one may use the nsz attribute.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of minnum(-0.0, +0.0) may be either -0.0 or +0.0.
 
 Some architectures, such as ARMv8 (FMINNM), LoongArch (fmin), MIPSr6 (min.fmt), PowerPC/VSX (xsmindp),
 have instructions that match these semantics exactly; thus it is quite simple for these architectures.
-Some architectures have similiar while they are not exact equivalent. Such as x86 implements `MINPS`,
+Some architectures have similiar ones while they are not exact equivalent. Such as x86 implements `MINPS`,
 which implements the semantics of C code `a<b?a:b`: NUM vs qNaN always return qNaN. `MINPS` can be used
 if `nsz` and `nnan` are given.
 
@@ -16788,24 +16787,23 @@ type.
 
 Semantics:
 """"""""""
-Follows the semantics of maxNum in IEEE-754-2008, except that -0.0 < +0.0 for the purposes
-of this intrinsic. As for signaling NaNs, per the maxNum semantics, if either operand
+Follows the semantics of maxinumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
-function `fmax`, although not all implementations have implemented these recommended behaviors.
+function `fmin`, although not all implementations have implemented these recommended behaviors.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or if either operand is sNaN.
 
-This behavior is stricter than maxNum in IEEE-754-2008, where either zero may be returned.
-To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use
-the nsz attribute.
+IEEE-754-2008 defines maxNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
+stricter than minNum in IEEE-754-2008, where either zero may be returned. To achieve the same permissiveness,
+the backend may implement the nsz attribute, and one may use the nsz attribute.
 
 If the intrinsic is marked with the nsz attribute, then the effect is as in the definition in C
 and IEEE-754-2008: the result of maxnum(-0.0, +0.0) may be either -0.0 or +0.0.
 
 Some architectures, such as ARMv8 (FMAXNM), LoongArch (fmax), MIPSr6 (max.fmt), PowerPC/VSX (xsmaxdp),
 have instructions that match these semantics exactly; thus it is quite simple for these architectures.
-Some architectures have similiar while they are not exact equivalent. Such as x86 implements `MAXPS`,
+Some architectures have similiar ones while they are not exact equivalent. Such as x86 implements `MAXPS`,
 which implements the semantics of C code `a>b?a:b`: NUM vs qNaN always return qNaN. `MAXPS` can be used
 if `nsz` and `nnan` are given.
 
@@ -19697,10 +19695,6 @@ This instruction has the same comparison semantics as the '``llvm.maxnum.*``'
 intrinsic.  If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
 
-It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with vector or SIMD extensions.
-Use '``llvm.vector.reduce.fmaximum``' or '``llvm.vector.reduce.fmaximumnum``' instead.
-
 Arguments:
 """"""""""
 The argument to this intrinsic must be a vector of floating-point values.
@@ -19729,10 +19723,6 @@ matches the element-type of the vector input.
 This instruction has the same comparison semantics as the '``llvm.minnum.*``'
 intrinsic. If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
-
-It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with vector or SIMD extensions.
-Use '``llvm.vector.reduce.fminimum``' or '``llvm.vector.reduce.fminimumnum``' instead.
 
 Arguments:
 """"""""""
@@ -23350,10 +23340,6 @@ This instruction has the same comparison semantics as the
 
 To ignore the start value, the neutral value can be used.
 
-It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with vector or SIMD extensions.
-Use '``llvm.vp.vector.reduce.fmaximum``' or '``llvm.vp.vector.reduce.fmaximumnum``' instead.
-
 Examples:
 """""""""
 
@@ -23420,10 +23406,6 @@ This instruction has the same comparison semantics as the
 '``llvm.minnum.*``' intrinsic).
 
 To ignore the start value, the neutral value can be used.
-
-It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with vector or SIMD extensions.
-Use '``llvm.vp.vector.reduce.fminimum``' or '``llvm.vp.vector.reduce.fminimumnum``' instead.
 
 Examples:
 """""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16729,17 +16729,16 @@ Some applications like Clang, can call '``llvm.minnum.*``' with '``nsz``' attrib
 to archive the same behaivor of libm's fmin.
 
 For some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, they have the
-strict same instructions; thus it is quite simple for these architectures.
+strictly same instructions; thus it is quite simple for these architectures.
 For other architectures, the custom or expand methods may provide '``nsz``' flavor.
 
 Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
-sNaN for qNaN vs sNaN. Withe recent libc versions, libc follows IEEE754-2008:
+sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
 NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
 
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.
 If the operands compare equal, returns either one of the operands.
-For example, this means that fmin(+0.0, -0.0) returns either operand.
 
 .. _i_maxnum:
 
@@ -16782,13 +16781,16 @@ Some applications like Clang, can call '``llvm.maxnum.*``' with '``nsz``' attrib
 to archive the same behaivor of libm's fmax.
 
 For some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, they have the
-strict same instructions; thus it is quite simple for these architectures.
+strictly same instructions; thus it is quite simple for these architectures.
 For other architectures, the custom or expand methods may provide '``nsz``' flavor.
+
+Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
+sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
+NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
 
 If either operand is a NaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.
 If the operands compare equal, returns either one of the operands.
-For example, this means that fmin(+0.0, -0.0) returns either operand.
 
 .. _i_minimum:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16738,9 +16738,9 @@ attribute on the intrinsic call.
 Some architectures, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have instructions that match
 these semantics exactly; thus it is quite simple for these architectures.
 
-Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
-sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
-NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
+In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
+even in the same release of a single libm implemention. Such as in glibc 2.24, the Arm64 asm implemention
+has different behaviour with the generic C implemention.
 
 Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a minnum can produce inconsistent results.
@@ -16797,9 +16797,9 @@ attribute on the intrinsic call.
 Some architectures, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have instructions that match
 these semantics exactly; thus it is quite simple for these architectures.
 
-Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
-sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
-NUM vs sNaN -> qNaN; NUM vs qNaN -> NUM; qNaN vs sNaN -> qNaN; sNaN vs sNaN -> qNaN.
+In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
+even in the same release of a single libm implemention. Such as in glibc 2.24, the Arm64 asm implemention
+has different behaviour with the generic C implemention.
 
 Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
 so arithmetic feeding into a maxnum can produce inconsistent results.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16723,12 +16723,14 @@ type.
 
 Semantics:
 """"""""""
-Follows the semantics of mininumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
+Follows the semantics of minimumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
 function `fmin`, although not all implementations have implemented these recommended behaviors.
 
-If either operand is a qNaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN or if either operand is sNaN.
+If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
+NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
+so arithmetic feeding into a minnum can produce inconsistent results. For example,
+`minnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
 IEEE-754-2008 defines minNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
 stricter than minNum in IEEE-754-2008, where either zero may be returned. To achieve the same permissiveness,
@@ -16743,14 +16745,8 @@ Some architectures have similiar ones while they are not exact equivalent. Such 
 which implements the semantics of C code `a<b?a:b`: NUM vs qNaN always return qNaN. `MINPS` can be used
 if `nsz` and `nnan` are given.
 
-
 In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
 even in the same release of a single libm implemention.
-
-Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
-so arithmetic feeding into a minnum can produce inconsistent results.
-For example, `maxnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd`
-is folded.
 
 .. _i_maxnum:
 
@@ -16787,12 +16783,14 @@ type.
 
 Semantics:
 """"""""""
-Follows the semantics of maxinumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
+Follows the semantics of maximumNumber in IEEE-754-2019, except for signaling NaNs. If either operand
 is an sNaN, the result is always a qNaN. This matches the recommended behavior for the libm
 function `fmin`, although not all implementations have implemented these recommended behaviors.
 
-If either operand is a qNaN, returns the other non-NaN operand. Returns
-NaN only if both operands are NaN or if either operand is sNaN.
+If either operand is a qNaN, returns the other non-NaN operand. Returns NaN only if both operands are
+NaN or if either operand is sNaN. Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
+so arithmetic feeding into a maxnum can produce inconsistent results. For example,
+`maxnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd` is folded.
 
 IEEE-754-2008 defines maxNum, and it is removed in IEEE-754-2019. The behavior of this intrinsic is
 stricter than minNum in IEEE-754-2008, where either zero may be returned. To achieve the same permissiveness,
@@ -16809,11 +16807,6 @@ if `nsz` and `nnan` are given.
 
 In the real libc worlds, the bebhaviors of fmin may be quite different on sNaN and signed zero behaviors,
 even in the same release of a single libm implemention.
-
-Note that arithmetic on an sNaN doesn't consistently produce a qNaN,
-so arithmetic feeding into a maxnum can produce inconsistent results.
-For example, `maxnum(fadd(sNaN, 0.0), 1.0)` can produce qNaN or 1.0 depending on whether `fadd`
-is folded.
 
 .. _i_minimum:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16731,15 +16731,12 @@ function fmin, although not all implementations have implemented these recommend
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.
 
-If the operands compare equal, returns either one of the operands.
+This behavior is more strict than the definition in C and IEEE 754, where either zero may be returned.
+To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use the nsz
+attribute on the intrinsic call.
 
-Returns -0.0 for +0.0 vs -0.0. libm doesn't require it, so that
-some applications like Clang, can call '``llvm.minnum.*``' with '``nsz``' attribute
-to archive the required behaivors of libm's fmin.
-
-Some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have the
-strictly same instructions; thus it is quite simple for these architectures.
-For other architectures, the custom or expand methods may provide '``nsz``' flavor.
+Some architectures, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have instructions that match
+these semantics exactly; thus it is quite simple for these architectures.
 
 Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
 sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
@@ -16793,15 +16790,12 @@ function fmin, although not all implementations have implemented these recommend
 If either operand is a qNaN, returns the other non-NaN operand. Returns
 NaN only if both operands are NaN or either operand is sNaN.
 
-If the operands compare equal, returns either one of the operands.
+This behavior is more strict than the definition in C and IEEE 754, where either zero may be returned.
+To achieve the same permissiveness, the backend may implement the nsz attribute, and one may use the nsz
+attribute on the intrinsic call.
 
-Returns -0.0 for +0.0 vs -0.0. libm doesn't require it, so that
-some applications like Clang, can call '``llvm.minnum.*``' with '``nsz``' attribute
-to archive the required behaivors of libm's fmin.
-
-Some architecturs, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have the
-strictly same instructions; thus it is quite simple for these architectures.
-For other architectures, the custom or expand methods may provide '``nsz``' flavor.
+Some architectures, such as ARMv8, LoongArch, MIPSr6, PowerPC/VSX, have instructions that match
+these semantics exactly; thus it is quite simple for these architectures.
 
 Historically, libc returns NUM for NUM vs (sNaN or qNaN), and may return
 sNaN for qNaN vs sNaN. With the recent libc versions, libc follows IEEE754-2008:
@@ -19693,7 +19687,7 @@ intrinsic.  If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
 
 It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with Vector or SIMD extensions.
+outputs, and it is hard to optimize with vector or SIMD extensions.
 Use '``llvm.vector.reduce.fmaximum``' or '``llvm.vector.reduce.fmaximumnum``' instead.
 
 Arguments:
@@ -19726,7 +19720,7 @@ intrinsic. If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
 
 It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with Vector or SIMD extensions.
+outputs, and it is hard to optimize with vector or SIMD extensions.
 Use '``llvm.vector.reduce.fminimum``' or '``llvm.vector.reduce.fminimumnum``' instead.
 
 Arguments:
@@ -23346,7 +23340,7 @@ This instruction has the same comparison semantics as the
 To ignore the start value, the neutral value can be used.
 
 It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with Vector or SIMD extensions.
+outputs, and it is hard to optimize with vector or SIMD extensions.
 Use '``llvm.vp.vector.reduce.fmaximum``' or '``llvm.vp.vector.reduce.fmaximumnum``' instead.
 
 Examples:
@@ -23417,7 +23411,7 @@ This instruction has the same comparison semantics as the
 To ignore the start value, the neutral value can be used.
 
 It is deprecated, since the different order of inputs may produce different
-outputs, and it is hard to optimize with Vector or SIMD extensions.
+outputs, and it is hard to optimize with vector or SIMD extensions.
 Use '``llvm.vp.vector.reduce.fminimum``' or '``llvm.vp.vector.reduce.fminimumnum``' instead.
 
 Examples:

--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -1021,13 +1021,20 @@ enum NodeType {
   LRINT,
   LLRINT,
 
-  /// FMINNUM/FMAXNUM - Perform floating-point minimum or maximum on two
-  /// values.
+  /// FMINNUM/FMAXNUM - Perform floating-point minimum maximum on two values,
+  /// following IEEE-754 definitions.
   ///
-  /// In the case where a single input is a NaN (either signaling or quiet),
-  /// the non-NaN input is returned.
+  /// If one input is a signaling NaN, returns a quiet NaN. This matches
+  /// IEEE-754 2008's minnum/maxnum behavior for signaling NaNs (which differs
+  /// from 2019).
   ///
-  /// The return value of (FMINNUM 0.0, -0.0) could be either 0.0 or -0.0.
+  /// These treat -0 as ordered less than +0, matching the behavior of IEEE-754
+  /// 2019's minimumNumber/maximumNumber.
+  ///
+  /// Note that that arithmetic on an sNaN doesn't consistently produce a qNaN,
+  /// so arithmetic feeding into a minnum/maxnum can produce inconsistent
+  /// results. FMAXIMUN/FMINIMUM or FMAXIMUMNUM/FMINIMUMNUM may be better choice
+  /// for non-distinction of sNaN/qNaN handling.
   FMINNUM,
   FMAXNUM,
 

--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -1022,10 +1022,10 @@ enum NodeType {
   LLRINT,
 
   /// FMINNUM/FMAXNUM - Perform floating-point minimum maximum on two values,
-  /// following IEEE-754 definitions.
+  /// following IEEE-754 definitions except for signed zero behavior.
   ///
   /// If one input is a signaling NaN, returns a quiet NaN. This matches
-  /// IEEE-754 2008's minnum/maxnum behavior for signaling NaNs (which differs
+  /// IEEE-754 2008's minNum/maxNum behavior for signaling NaNs (which differs
   /// from 2019).
   ///
   /// These treat -0 as ordered less than +0, matching the behavior of IEEE-754

--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -1048,6 +1048,9 @@ enum NodeType {
   ///
   /// These treat -0 as ordered less than +0, matching the behavior of IEEE-754
   /// 2019's minimumNumber/maximumNumber.
+  ///
+  /// Deprecated, and will be removed soon, as FMINNUM/FMAXNUM have the same
+  /// semantics now.
   FMINNUM_IEEE,
   FMAXNUM_IEEE,
 


### PR DESCRIPTION
The documents claims that it ignores sNaN, while in the current code it may be different.

 - as the finally callback, it use libc call fmin(3)/fmax(3). while C23 clarifies that fmin(3)/fmax(3) should return NaN for sNaN vs NUM.
 - on some architectures, such as aarch64, it converts to `fmaxnm`, which returns qNaN for sNaN vs NUM.
 - on RISC-V (SPEC 2019+), it converts to `fmax`, which returns NUM for sNaN vs NUM.

Since we have introduced llvm.minimumnum and llvm.maximumnum, which follow IEEE 754-2019's minimumNumber/maximumNumber.

So, it's time for us to clarify llvm.minnum and llvm.maxnum. Since the final fallback of llvm.minnum and llvm.maxnum is
fmin(3)/fmax(3), so that it is reasonable to follow the behaviors of fmin(3)/fmax(3).

Although C23 clarified the behavior about sNaN and +0.0/-0.0:
     (NUM or NaN) vs sNaN -> qNaN
     +0.0 vs -0.0 -> either one of +0.0/-0.0
It is the same the IEEE754-2008's maxNUM and minNUM.
Not all implementation work as expected.
     
Since some architectures such as aarch64/MIPSr6/LoongArch, have instructions that implements +0.0>-0.0.
So Let's define llvm.minnum and llvm.maxnum to IEEE754-2008 with +0.0>-0.0.

The architectures without such instructions can implements `NSZ` flavor to speed up,
and the frontend, such as clang, can call them with `nsz` attribute.