### PR TITLE
[clang] Add covariance tests that make sure we return an error when return value is different in pointer / lvalue ref / rvalue ref

### DIFF
--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -93,7 +93,7 @@ struct B : A {
 } // namespace example2
 } // namespace cwg952
 
-namespace cwg960 { // cwg960: 2.8
+namespace cwg960 { // cwg960: 3.0
 struct a {};
 class A {
 #if __cplusplus >= 201103L

--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -100,12 +100,12 @@ class A {
   // Check lvalue ref vs rvalue ref vs pointer.
   virtual a& rvalue_ref();
   virtual a&& lvalue_ref();
-  virtual a& rvalue_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
-  virtual a&& lvalue_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
-  virtual a& rvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
-  virtual a* pointer_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
-  virtual a&& lvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
-  virtual a* pointer_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
+  virtual a& rvalue_vs_lvalue_ref(); // #cwg960-A-rvalue_vs_lvalue_ref
+  virtual a&& lvalue_vs_rvalue_ref(); // #cwg960-A-lvalue_vs_rvalue_ref
+  virtual a& rvalue_ref_vs_pointer(); // #cwg960-A-rvalue_ref_vs_pointer
+  virtual a* pointer_vs_rvalue_ref(); // #cwg960-A-pointer_vs_rvalue_ref
+  virtual a&& lvalue_ref_vs_pointer(); // #cwg960-A-lvalue_ref_vs_pointer
+  virtual a* pointer_vs_lvalue_ref(); // #cwg960-A-pointer_vs_lvalue_ref
 #endif
 };
 
@@ -114,12 +114,30 @@ class B : A {
   // Check lvalue ref vs rvalue ref vs pointer.
   a& rvalue_ref() override;
   a&& lvalue_ref() override;
-  a&& rvalue_vs_lvalue_ref() override; // expected-error{{virtual function 'rvalue_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a &')}}
-  a& lvalue_vs_rvalue_ref() override; // expected-error{{virtual function 'lvalue_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a &&')}}
-  a* rvalue_ref_vs_pointer() override; // expected-error{{virtual function 'rvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &')}}
-  a& pointer_vs_rvalue_ref() override; // expected-error{{virtual function 'pointer_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a *')}}
-  a* lvalue_ref_vs_pointer() override; // expected-error{{virtual function 'lvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &&')}}
-  a&& pointer_vs_lvalue_ref() override; // expected-error{{virtual function 'pointer_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a *')}}
+
+  a&& rvalue_vs_lvalue_ref() override; 
+  // since-cxx11-error@-1 {{virtual function 'rvalue_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a &')}}
+  //   since-cxx11-note@#cwg960-A-rvalue_vs_lvalue_ref {{overridden virtual function is here}}
+
+  a& lvalue_vs_rvalue_ref() override;
+  // since-cxx11-error@-1 {{virtual function 'lvalue_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a &&')}}
+  //   since-cxx11-note@#cwg960-A-lvalue_vs_rvalue_ref {{overridden virtual function is here}}
+
+  a* rvalue_ref_vs_pointer() override;
+  // since-cxx11-error@-1 {{virtual function 'rvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &')}}
+  //   since-cxx11-note@#cwg960-A-rvalue_ref_vs_pointer {{overridden virtual function is here}}
+
+  a& pointer_vs_rvalue_ref() override;
+  // since-cxx11-error@-1 {{virtual function 'pointer_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a *')}}
+  //   since-cxx11-note@#cwg960-A-pointer_vs_rvalue_ref {{overridden virtual function is here}}
+
+  a* lvalue_ref_vs_pointer() override;
+  // since-cxx11-error@-1 {{virtual function 'lvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &&')}}
+  //   since-cxx11-note@#cwg960-A-lvalue_ref_vs_pointer {{overridden virtual function is here}}
+
+  a&& pointer_vs_lvalue_ref() override;
+  // since-cxx11-error@-1 {{virtual function 'pointer_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a *')}}
+  //   since-cxx11-note@#cwg960-A-pointer_vs_lvalue_ref {{overridden virtual function is here}}
 #endif
 };
 

--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -93,6 +93,38 @@ struct B : A {
 } // namespace example2
 } // namespace cwg952
 
+namespace cwg960 { // cwg960: 2.8
+struct a {};
+class A {
+#if __cplusplus >= 201103L
+  // Check lvalue ref vs rvalue ref vs pointer.
+  virtual a& rvalue_ref();
+  virtual a&& lvalue_ref();
+  virtual a& rvalue_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
+  virtual a&& lvalue_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
+  virtual a& rvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
+  virtual a* pointer_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
+  virtual a&& lvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
+  virtual a* pointer_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
+#endif
+};
+
+class B : A {
+#if __cplusplus >= 201103L
+  // Check lvalue ref vs rvalue ref vs pointer.
+  a& rvalue_ref() override;
+  a&& lvalue_ref() override;
+  a&& rvalue_vs_lvalue_ref() override; // expected-error{{virtual function 'rvalue_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a &')}}
+  a& lvalue_vs_rvalue_ref() override; // expected-error{{virtual function 'lvalue_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a &&')}}
+  a* rvalue_ref_vs_pointer() override; // expected-error{{virtual function 'rvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &')}}
+  a& pointer_vs_rvalue_ref() override; // expected-error{{virtual function 'pointer_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a *')}}
+  a* lvalue_ref_vs_pointer() override; // expected-error{{virtual function 'lvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &&')}}
+  a&& pointer_vs_lvalue_ref() override; // expected-error{{virtual function 'pointer_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a *')}}
+#endif
+};
+
+} // namespace cwg960
+
 namespace cwg974 { // cwg974: yes
 #if __cplusplus >= 201103L
   void test() {

--- a/clang/test/SemaCXX/virtual-override.cpp
+++ b/clang/test/SemaCXX/virtual-override.cpp
@@ -102,16 +102,6 @@ class A {
   virtual const volatile a* const_volatile_vs_unualified_class();
   virtual a* unqualified_vs_const_volatile_class(); // expected-note{{overridden virtual function is here}}
 
-  // Check lvalue ref vs rvalue ref vs pointer.
-  virtual a& rvalue_ref();
-  virtual a&& lvalue_ref();
-  virtual a& rvalue_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
-  virtual a&& lvalue_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
-  virtual a& rvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
-  virtual a* pointer_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
-  virtual a&& lvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
-  virtual a* pointer_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
-
   // Check non class.
   virtual const int* const_vs_unqualified_non_class(); // expected-note{{overridden virtual function is here}}
   virtual int* unqualified_vs_const_non_class(); // expected-note{{overridden virtual function is here}}
@@ -136,16 +126,6 @@ class B : A {
 
   a* const_volatile_vs_unualified_class() override;
   const volatile a* unqualified_vs_const_volatile_class() override; // expected-error{{return type of virtual function 'unqualified_vs_const_volatile_class' is not covariant with the return type of the function it overrides (class type 'const volatile a *' does not have the same cv-qualification as or less cv-qualification than class type 'a *')}}
-
-  // Check lvalue ref vs rvalue ref vs pointer.
-  a& rvalue_ref() override;
-  a&& lvalue_ref() override;
-  a&& rvalue_vs_lvalue_ref() override; // expected-error{{virtual function 'rvalue_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a &')}}
-  a& lvalue_vs_rvalue_ref() override; // expected-error{{virtual function 'lvalue_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a &&')}}
-  a* rvalue_ref_vs_pointer() override; // expected-error{{virtual function 'rvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &')}}
-  a& pointer_vs_rvalue_ref() override; // expected-error{{virtual function 'pointer_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a *')}}
-  a* lvalue_ref_vs_pointer() override; // expected-error{{virtual function 'lvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &&')}}
-  a&& pointer_vs_lvalue_ref() override; // expected-error{{virtual function 'pointer_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a *')}}
 
   // Check non class.
   int* const_vs_unqualified_non_class() override; // expected-error{{virtual function 'const_vs_unqualified_non_class' has a different return type ('int *') than the function it overrides (which has return type 'const int *')}}

--- a/clang/test/SemaCXX/virtual-override.cpp
+++ b/clang/test/SemaCXX/virtual-override.cpp
@@ -83,7 +83,7 @@ namespace T6 {
 struct a { };
 
 class A {
-  // Classes.
+  // Check cv-qualification.
   virtual const a* const_vs_unqualified_class();
   virtual a* unqualified_vs_const_class(); // expected-note{{overridden virtual function is here}}
 
@@ -102,13 +102,23 @@ class A {
   virtual const volatile a* const_volatile_vs_unualified_class();
   virtual a* unqualified_vs_const_volatile_class(); // expected-note{{overridden virtual function is here}}
 
-  // Non Classes.
+  // Check lvalue ref vs rvalue ref vs pointer.
+  virtual a& rvalue_ref();
+  virtual a&& lvalue_ref();
+  virtual a& rvalue_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
+  virtual a&& lvalue_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
+  virtual a& rvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
+  virtual a* pointer_vs_rvalue_ref(); // expected-note{{overridden virtual function is here}}
+  virtual a&& lvalue_ref_vs_pointer(); // expected-note{{overridden virtual function is here}}
+  virtual a* pointer_vs_lvalue_ref(); // expected-note{{overridden virtual function is here}}
+
+  // Check non class.
   virtual const int* const_vs_unqualified_non_class(); // expected-note{{overridden virtual function is here}}
   virtual int* unqualified_vs_const_non_class(); // expected-note{{overridden virtual function is here}}
 };
 
 class B : A {
-  // Classes.
+  // Check cv-qualification.
   a* const_vs_unqualified_class() override;
   const a* unqualified_vs_const_class() override; // expected-error{{return type of virtual function 'unqualified_vs_const_class' is not covariant with the return type of the function it overrides (class type 'const a *' does not have the same cv-qualification as or less cv-qualification than class type 'a *')}}
 
@@ -127,7 +137,17 @@ class B : A {
   a* const_volatile_vs_unualified_class() override;
   const volatile a* unqualified_vs_const_volatile_class() override; // expected-error{{return type of virtual function 'unqualified_vs_const_volatile_class' is not covariant with the return type of the function it overrides (class type 'const volatile a *' does not have the same cv-qualification as or less cv-qualification than class type 'a *')}}
 
-  // Non Classes.
+  // Check lvalue ref vs rvalue ref vs pointer.
+  a& rvalue_ref() override;
+  a&& lvalue_ref() override;
+  a&& rvalue_vs_lvalue_ref() override; // expected-error{{virtual function 'rvalue_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a &')}}
+  a& lvalue_vs_rvalue_ref() override; // expected-error{{virtual function 'lvalue_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a &&')}}
+  a* rvalue_ref_vs_pointer() override; // expected-error{{virtual function 'rvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &')}}
+  a& pointer_vs_rvalue_ref() override; // expected-error{{virtual function 'pointer_vs_rvalue_ref' has a different return type ('a &') than the function it overrides (which has return type 'a *')}}
+  a* lvalue_ref_vs_pointer() override; // expected-error{{virtual function 'lvalue_ref_vs_pointer' has a different return type ('a *') than the function it overrides (which has return type 'a &&')}}
+  a&& pointer_vs_lvalue_ref() override; // expected-error{{virtual function 'pointer_vs_lvalue_ref' has a different return type ('a &&') than the function it overrides (which has return type 'a *')}}
+
+  // Check non class.
   int* const_vs_unqualified_non_class() override; // expected-error{{virtual function 'const_vs_unqualified_non_class' has a different return type ('int *') than the function it overrides (which has return type 'const int *')}}
   const int* unqualified_vs_const_non_class() override; // expected-error{{virtual function 'unqualified_vs_const_non_class' has a different return type ('const int *') than the function it overrides (which has return type 'int *')}}
 };

--- a/clang/test/SemaCXX/virtual-override.cpp
+++ b/clang/test/SemaCXX/virtual-override.cpp
@@ -83,7 +83,7 @@ namespace T6 {
 struct a { };
 
 class A {
-  // Check cv-qualification.
+  // Classes.
   virtual const a* const_vs_unqualified_class();
   virtual a* unqualified_vs_const_class(); // expected-note{{overridden virtual function is here}}
 
@@ -102,13 +102,13 @@ class A {
   virtual const volatile a* const_volatile_vs_unualified_class();
   virtual a* unqualified_vs_const_volatile_class(); // expected-note{{overridden virtual function is here}}
 
-  // Check non class.
+  // Non Classes.
   virtual const int* const_vs_unqualified_non_class(); // expected-note{{overridden virtual function is here}}
   virtual int* unqualified_vs_const_non_class(); // expected-note{{overridden virtual function is here}}
 };
 
 class B : A {
-  // Check cv-qualification.
+  // Classes.
   a* const_vs_unqualified_class() override;
   const a* unqualified_vs_const_class() override; // expected-error{{return type of virtual function 'unqualified_vs_const_class' is not covariant with the return type of the function it overrides (class type 'const a *' does not have the same cv-qualification as or less cv-qualification than class type 'a *')}}
 
@@ -127,7 +127,7 @@ class B : A {
   a* const_volatile_vs_unualified_class() override;
   const volatile a* unqualified_vs_const_volatile_class() override; // expected-error{{return type of virtual function 'unqualified_vs_const_volatile_class' is not covariant with the return type of the function it overrides (class type 'const volatile a *' does not have the same cv-qualification as or less cv-qualification than class type 'a *')}}
 
-  // Check non class.
+  // Non Classes.
   int* const_vs_unqualified_non_class() override; // expected-error{{virtual function 'const_vs_unqualified_non_class' has a different return type ('int *') than the function it overrides (which has return type 'const int *')}}
   const int* unqualified_vs_const_non_class() override; // expected-error{{virtual function 'unqualified_vs_const_non_class' has a different return type ('const int *') than the function it overrides (which has return type 'int *')}}
 };

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -5579,7 +5579,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/960.html">960</a></td>
     <td>CD2</td>
     <td>Covariant functions and lvalue/rvalue references</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.8</td>
   </tr>
   <tr id="961">
     <td><a href="https://cplusplus.github.io/CWG/issues/961.html">961</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -5579,7 +5579,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/960.html">960</a></td>
     <td>CD2</td>
     <td>Covariant functions and lvalue/rvalue references</td>
-    <td class="full" align="center">Clang 2.8</td>
+    <td class="full" align="center">Clang 3.0</td>
   </tr>
   <tr id="961">
     <td><a href="https://cplusplus.github.io/CWG/issues/961.html">961</a></td>


### PR DESCRIPTION
Per https://cplusplus.github.io/CWG/issues/960.html.