### PR TITLE
[LoongArch][MC] Handle more PseudoLA* instructions with la-global-with-abs feature

### DIFF
--- a/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
+++ b/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
@@ -163,11 +163,9 @@ class LoongArchAsmParser : public MCTargetAsmParser {
   void emitLoadAddressTLSGDLarge(MCInst &Inst, SMLoc IDLoc, MCStreamer &Out);
 
   // Helper to emit pseudo instruction "la.tls.desc $rd, sym".
-  void emitLoadAddressTLSDescAbs(MCInst &Inst, SMLoc IDLoc, MCStreamer &Out);
-  void emitLoadAddressTLSDescPcrel(MCInst &Inst, SMLoc IDLoc, MCStreamer &Out);
+  void emitLoadAddressTLSDesc(MCInst &Inst, SMLoc IDLoc, MCStreamer &Out);
   // Helper to emit pseudo instruction "la.tls.desc $rd, $rj, sym".
-  void emitLoadAddressTLSDescPcrelLarge(MCInst &Inst, SMLoc IDLoc,
-                                        MCStreamer &Out);
+  void emitLoadAddressTLSDescLarge(MCInst &Inst, SMLoc IDLoc, MCStreamer &Out);
 
   // Helper to emit pseudo instruction "li.w/d $rd, $imm".
   void emitLoadImm(MCInst &Inst, SMLoc IDLoc, MCStreamer &Out);
@@ -1023,14 +1021,42 @@ void LoongArchAsmParser::emitLoadAddressPcrelLarge(MCInst &Inst, SMLoc IDLoc,
 void LoongArchAsmParser::emitLoadAddressGot(MCInst &Inst, SMLoc IDLoc,
                                             MCStreamer &Out) {
   // la.got $rd, sym
-  // expands to:
-  //   pcalau12i $rd, %got_pc_hi20(sym)
-  //   ld.w/d    $rd, $rd, %got_pc_lo12(sym)
   MCRegister DestReg = Inst.getOperand(0).getReg();
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   InstSeq Insts;
   unsigned LD = is64Bit() ? LoongArch::LD_D : LoongArch::LD_W;
 
+  if (getSTI().hasFeature(LoongArch::LaGlobalWithAbs)) {
+    // with feature: +la-glabal-with-abs
+    // for 32bit:
+    //   lu12i.w $rd, %got_hi20(sym)
+    //   ori     $rd, $rd, %got_lo12(sym)
+    //   ld.w    $rd, $rd, 0
+    //
+    // for 64bit:
+    //   lu12i.w $rd, %got_hi20(sym)
+    //   ori     $rd, $rd, %got_lo12(sym)
+    //   lu32i.d $rd, %got64_lo20(sym)
+    //   lu52i.d $rd, $rd, %got64_hi12(sym)
+    //   ld.d    $rd, $rd, 0
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::LU12I_W, LoongArchMCExpr::VK_LoongArch_GOT_HI20));
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::ORI, LoongArchMCExpr::VK_LoongArch_GOT_LO12));
+
+    if (is64Bit()) {
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU32I_D, LoongArchMCExpr::VK_LoongArch_GOT64_LO20));
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU52I_D, LoongArchMCExpr::VK_LoongArch_GOT64_HI12));
+    }
+    Insts.push_back(LoongArchAsmParser::Inst(LD));
+    emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+    return;
+  }
+  // expands to:
+  //   pcalau12i $rd, %got_pc_hi20(sym)
+  //   ld.w/d    $rd, $rd, %got_pc_lo12(sym)
   Insts.push_back(LoongArchAsmParser::Inst(
       LoongArch::PCALAU12I, LoongArchMCExpr::VK_LoongArch_GOT_PC_HI20));
   Insts.push_back(
@@ -1087,14 +1113,43 @@ void LoongArchAsmParser::emitLoadAddressTLSLE(MCInst &Inst, SMLoc IDLoc,
 void LoongArchAsmParser::emitLoadAddressTLSIE(MCInst &Inst, SMLoc IDLoc,
                                               MCStreamer &Out) {
   // la.tls.ie $rd, sym
-  // expands to:
-  //   pcalau12i $rd, %ie_pc_hi20(sym)
-  //   ld.w/d    $rd, $rd, %ie_pc_lo12(sym)
   MCRegister DestReg = Inst.getOperand(0).getReg();
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   InstSeq Insts;
   unsigned LD = is64Bit() ? LoongArch::LD_D : LoongArch::LD_W;
 
+  if (getSTI().hasFeature(LoongArch::LaGlobalWithAbs)) {
+    // with feature: +la-glabal-with-abs
+    // for 32bit:
+    //   lu12i.w $rd, %ie_hi20(sym)
+    //   ori     $rd, $rd, %ie_lo12(sym)
+    //   ld.w    $rd, $rd, 0
+    //
+    // for 64bit:
+    //   lu12i.w $rd, %ie_hi20(sym)
+    //   ori     $rd, $rd, %ie_lo12(sym)
+    //   lu32i.d $rd, %ie64_lo20(sym)
+    //   lu52i.d $rd, $rd, %ie64_hi12(sym)
+    //   ld.d    $rd, $rd, 0
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::LU12I_W, LoongArchMCExpr::VK_LoongArch_TLS_IE_HI20));
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::ORI, LoongArchMCExpr::VK_LoongArch_TLS_IE_LO12));
+
+    if (is64Bit()) {
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU32I_D, LoongArchMCExpr::VK_LoongArch_TLS_IE64_LO20));
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU52I_D, LoongArchMCExpr::VK_LoongArch_TLS_IE64_HI12));
+    }
+    Insts.push_back(LoongArchAsmParser::Inst(LD));
+    emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+    return;
+  }
+
+  // expands to:
+  //   pcalau12i $rd, %ie_pc_hi20(sym)
+  //   ld.w/d    $rd, $rd, %ie_pc_lo12(sym)
   Insts.push_back(LoongArchAsmParser::Inst(
       LoongArch::PCALAU12I, LoongArchMCExpr::VK_LoongArch_TLS_IE_PC_HI20));
   Insts.push_back(LoongArchAsmParser::Inst(
@@ -1133,14 +1188,40 @@ void LoongArchAsmParser::emitLoadAddressTLSIELarge(MCInst &Inst, SMLoc IDLoc,
 void LoongArchAsmParser::emitLoadAddressTLSLD(MCInst &Inst, SMLoc IDLoc,
                                               MCStreamer &Out) {
   // la.tls.ld $rd, sym
-  // expands to:
-  //   pcalau12i $rd, %ld_pc_hi20(sym)
-  //   addi.w/d  $rd, $rd, %got_pc_lo12(sym)
   MCRegister DestReg = Inst.getOperand(0).getReg();
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   InstSeq Insts;
   unsigned ADDI = is64Bit() ? LoongArch::ADDI_D : LoongArch::ADDI_W;
 
+  if (getSTI().hasFeature(LoongArch::LaGlobalWithAbs)) {
+    // with feature: +la-glabal-with-abs
+    // for 32bit:
+    //   lu12i.w $rd, %ld_hi20(sym)
+    //   ori     $rd, $rd, %got_lo12(sym)
+    //
+    // for 64bit:
+    //   lu12i.w $rd, %ld_hi20(sym)
+    //   ori     $rd, $rd, %got_lo12(sym)
+    //   lu32i.d $rd, %got64_lo20(sym)
+    //   lu52i.d $rd, $rd, %got64_hi12(sym)
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::LU12I_W, LoongArchMCExpr::VK_LoongArch_TLS_LD_HI20));
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::ORI, LoongArchMCExpr::VK_LoongArch_GOT_LO12));
+
+    if (is64Bit()) {
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU32I_D, LoongArchMCExpr::VK_LoongArch_GOT64_LO20));
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU52I_D, LoongArchMCExpr::VK_LoongArch_GOT64_HI12));
+    }
+    emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+    return;
+  }
+
+  // expands to:
+  //   pcalau12i $rd, %ld_pc_hi20(sym)
+  //   addi.w/d  $rd, $rd, %got_pc_lo12(sym)
   Insts.push_back(LoongArchAsmParser::Inst(
       LoongArch::PCALAU12I, LoongArchMCExpr::VK_LoongArch_TLS_LD_PC_HI20));
   Insts.push_back(LoongArchAsmParser::Inst(
@@ -1179,14 +1260,40 @@ void LoongArchAsmParser::emitLoadAddressTLSLDLarge(MCInst &Inst, SMLoc IDLoc,
 void LoongArchAsmParser::emitLoadAddressTLSGD(MCInst &Inst, SMLoc IDLoc,
                                               MCStreamer &Out) {
   // la.tls.gd $rd, sym
-  // expands to:
-  //   pcalau12i $rd, %gd_pc_hi20(sym)
-  //   addi.w/d  $rd, $rd, %got_pc_lo12(sym)
   MCRegister DestReg = Inst.getOperand(0).getReg();
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   InstSeq Insts;
   unsigned ADDI = is64Bit() ? LoongArch::ADDI_D : LoongArch::ADDI_W;
 
+  if (getSTI().hasFeature(LoongArch::LaGlobalWithAbs)) {
+    // with feature: +la-glabal-with-abs
+    // for 32bit:
+    //   lu12i.w $rd, %gd_hi20(sym)
+    //   ori     $rd, $rd, %got_lo12(sym)
+    //
+    // for 64bit:
+    //   lu12i.w $rd, %gd_hi20(sym)
+    //   ori     $rd, $rd, %got_lo12(sym)
+    //   lu32i.d $rd, %got64_lo20(sym)
+    //   lu52i.d $rd, $rd, %got64_hi12(sym)
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::LU12I_W, LoongArchMCExpr::VK_LoongArch_TLS_GD_HI20));
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::ORI, LoongArchMCExpr::VK_LoongArch_GOT_LO12));
+
+    if (is64Bit()) {
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU32I_D, LoongArchMCExpr::VK_LoongArch_GOT64_LO20));
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU52I_D, LoongArchMCExpr::VK_LoongArch_GOT64_HI12));
+    }
+    emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+    return;
+  }
+
+  // expands to:
+  //   pcalau12i $rd, %gd_pc_hi20(sym)
+  //   addi.w/d  $rd, $rd, %got_pc_lo12(sym)
   Insts.push_back(LoongArchAsmParser::Inst(
       LoongArch::PCALAU12I, LoongArchMCExpr::VK_LoongArch_TLS_GD_PC_HI20));
   Insts.push_back(LoongArchAsmParser::Inst(
@@ -1222,63 +1329,56 @@ void LoongArchAsmParser::emitLoadAddressTLSGDLarge(MCInst &Inst, SMLoc IDLoc,
   emitLAInstSeq(DestReg, TmpReg, Symbol, Insts, IDLoc, Out);
 }
 
-void LoongArchAsmParser::emitLoadAddressTLSDescAbs(MCInst &Inst, SMLoc IDLoc,
-                                                   MCStreamer &Out) {
-  // `la.tls.desc $rd, sym` with `la-global-with-abs` feature
-  // for la32 expands to:
-  //   lu12i.w $rd, %desc_hi20(sym)
-  //   ori     $rd, $rd, %desc_lo12(sym)
-  //   ld.w    $ra, $rd, %desc_ld(sym)
-  //   jirl    $ra, $ra, %desc_call(sym)
-  //
-  // for la64 expands to:
-  //   lu12i.w $rd, %desc_hi20(sym)
-  //   ori     $rd, $rd, %desc_lo12(sym)
-  //   lu32i.d $rd, %desc64_lo20(sym)
-  //   lu52i.d $rd, $rd, %desc64_hi12(sym)
-  //   ld.d    $ra, $rd, %desc_ld(sym)
-  //   jirl    $ra, $ra, %desc_call(sym)
-  MCRegister DestReg = Inst.getOperand(0).getReg();
-  const MCExpr *Symbol = Inst.getOpcode() == LoongArch::PseudoLA_TLS_DESC_ABS
-                             ? Inst.getOperand(1).getExpr()
-                             : Inst.getOperand(2).getExpr();
-  unsigned LD = is64Bit() ? LoongArch::LD_D : LoongArch::LD_W;
-  InstSeq Insts;
-
-  Insts.push_back(LoongArchAsmParser::Inst(
-      LoongArch::LU12I_W, LoongArchMCExpr::VK_LoongArch_TLS_DESC_HI20));
-  Insts.push_back(LoongArchAsmParser::Inst(
-      LoongArch::ORI, LoongArchMCExpr::VK_LoongArch_TLS_DESC_LO12));
-
-  if (is64Bit()) {
-    Insts.push_back(LoongArchAsmParser::Inst(
-        LoongArch::LU32I_D, LoongArchMCExpr::VK_LoongArch_TLS_DESC64_LO20));
-    Insts.push_back(LoongArchAsmParser::Inst(
-        LoongArch::LU52I_D, LoongArchMCExpr::VK_LoongArch_TLS_DESC64_HI12));
-  }
-
-  Insts.push_back(
-      LoongArchAsmParser::Inst(LD, LoongArchMCExpr::VK_LoongArch_TLS_DESC_LD));
-  Insts.push_back(LoongArchAsmParser::Inst(
-      LoongArch::JIRL, LoongArchMCExpr::VK_LoongArch_TLS_DESC_CALL));
-
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
-}
-
-void LoongArchAsmParser::emitLoadAddressTLSDescPcrel(MCInst &Inst, SMLoc IDLoc,
-                                                     MCStreamer &Out) {
+void LoongArchAsmParser::emitLoadAddressTLSDesc(MCInst &Inst, SMLoc IDLoc,
+                                                MCStreamer &Out) {
   // la.tls.desc $rd, sym
-  // expands to:
-  //   pcalau12i $rd, %desc_pc_hi20(sym)
-  //   addi.w/d  $rd, $rd, %desc_pc_lo12(sym)
-  //   ld.w/d    $ra, $rd, %desc_ld(sym)
-  //   jirl      $ra, $ra, %desc_call(sym)
   MCRegister DestReg = Inst.getOperand(0).getReg();
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   unsigned ADDI = is64Bit() ? LoongArch::ADDI_D : LoongArch::ADDI_W;
   unsigned LD = is64Bit() ? LoongArch::LD_D : LoongArch::LD_W;
   InstSeq Insts;
 
+  if (getSTI().hasFeature(LoongArch::LaGlobalWithAbs)) {
+    // with feature: +la-glabal-with-abs
+    // for la32 expands to:
+    //   lu12i.w $rd, %desc_hi20(sym)
+    //   ori     $rd, $rd, %desc_lo12(sym)
+    //   ld.w    $ra, $rd, %desc_ld(sym)
+    //   jirl    $ra, $ra, %desc_call(sym)
+    //
+    // for la64 expands to:
+    //   lu12i.w $rd, %desc_hi20(sym)
+    //   ori     $rd, $rd, %desc_lo12(sym)
+    //   lu32i.d $rd, %desc64_lo20(sym)
+    //   lu52i.d $rd, $rd, %desc64_hi12(sym)
+    //   ld.d    $ra, $rd, %desc_ld(sym)
+    //   jirl    $ra, $ra, %desc_call(sym)
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::LU12I_W, LoongArchMCExpr::VK_LoongArch_TLS_DESC_HI20));
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::ORI, LoongArchMCExpr::VK_LoongArch_TLS_DESC_LO12));
+
+    if (is64Bit()) {
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU32I_D, LoongArchMCExpr::VK_LoongArch_TLS_DESC64_LO20));
+      Insts.push_back(LoongArchAsmParser::Inst(
+          LoongArch::LU52I_D, LoongArchMCExpr::VK_LoongArch_TLS_DESC64_HI12));
+    }
+
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LD, LoongArchMCExpr::VK_LoongArch_TLS_DESC_LD));
+    Insts.push_back(LoongArchAsmParser::Inst(
+        LoongArch::JIRL, LoongArchMCExpr::VK_LoongArch_TLS_DESC_CALL));
+
+    emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+    return;
+  }
+
+  // expands to:
+  //   pcalau12i $rd, %desc_pc_hi20(sym)
+  //   addi.w/d  $rd, $rd, %desc_pc_lo12(sym)
+  //   ld.w/d    $ra, $rd, %desc_ld(sym)
+  //   jirl      $ra, $ra, %desc_call(sym)
   Insts.push_back(LoongArchAsmParser::Inst(
       LoongArch::PCALAU12I, LoongArchMCExpr::VK_LoongArch_TLS_DESC_PC_HI20));
   Insts.push_back(LoongArchAsmParser::Inst(
@@ -1291,9 +1391,8 @@ void LoongArchAsmParser::emitLoadAddressTLSDescPcrel(MCInst &Inst, SMLoc IDLoc,
   emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
 }
 
-void LoongArchAsmParser::emitLoadAddressTLSDescPcrelLarge(MCInst &Inst,
-                                                          SMLoc IDLoc,
-                                                          MCStreamer &Out) {
+void LoongArchAsmParser::emitLoadAddressTLSDescLarge(MCInst &Inst, SMLoc IDLoc,
+                                                     MCStreamer &Out) {
   // la.tls.desc $rd, $rj, sym
   // expands to:
   //   pcalau12i $rd, %desc_pc_hi20(sym)
@@ -1438,15 +1537,11 @@ bool LoongArchAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
   case LoongArch::PseudoLA_TLS_GD_LARGE:
     emitLoadAddressTLSGDLarge(Inst, IDLoc, Out);
     return false;
-  case LoongArch::PseudoLA_TLS_DESC_ABS:
-  case LoongArch::PseudoLA_TLS_DESC_ABS_LARGE:
-    emitLoadAddressTLSDescAbs(Inst, IDLoc, Out);
+  case LoongArch::PseudoLA_TLS_DESC:
+    emitLoadAddressTLSDesc(Inst, IDLoc, Out);
     return false;
-  case LoongArch::PseudoLA_TLS_DESC_PC:
-    emitLoadAddressTLSDescPcrel(Inst, IDLoc, Out);
-    return false;
-  case LoongArch::PseudoLA_TLS_DESC_PC_LARGE:
-    emitLoadAddressTLSDescPcrelLarge(Inst, IDLoc, Out);
+  case LoongArch::PseudoLA_TLS_DESC_LARGE:
+    emitLoadAddressTLSDescLarge(Inst, IDLoc, Out);
     return false;
   case LoongArch::PseudoLI_W:
   case LoongArch::PseudoLI_D:
@@ -1475,10 +1570,8 @@ unsigned LoongArchAsmParser::checkTargetMatchPredicate(MCInst &Inst) {
         return Match_RequiresAMORdDifferRkRj;
     }
     break;
-  case LoongArch::PseudoLA_TLS_DESC_ABS:
-  case LoongArch::PseudoLA_TLS_DESC_ABS_LARGE:
-  case LoongArch::PseudoLA_TLS_DESC_PC:
-  case LoongArch::PseudoLA_TLS_DESC_PC_LARGE: {
+  case LoongArch::PseudoLA_TLS_DESC:
+  case LoongArch::PseudoLA_TLS_DESC_LARGE: {
     MCRegister Rd = Inst.getOperand(0).getReg();
     if (Rd != LoongArch::R4)
       return Match_RequiresLAORdR4;

--- a/llvm/lib/Target/LoongArch/LoongArchExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchExpandPseudoInsts.cpp
@@ -160,9 +160,9 @@ bool LoongArchPreRAExpandPseudo::expandMI(
     return expandLoadAddressTLSGD(MBB, MBBI, NextMBBI);
   case LoongArch::PseudoLA_TLS_GD_LARGE:
     return expandLoadAddressTLSGD(MBB, MBBI, NextMBBI, /*Large=*/true);
-  case LoongArch::PseudoLA_TLS_DESC_PC:
+  case LoongArch::PseudoLA_TLS_DESC:
     return expandLoadAddressTLSDesc(MBB, MBBI, NextMBBI);
-  case LoongArch::PseudoLA_TLS_DESC_PC_LARGE:
+  case LoongArch::PseudoLA_TLS_DESC_LARGE:
     return expandLoadAddressTLSDesc(MBB, MBBI, NextMBBI, /*Large=*/true);
   case LoongArch::PseudoCALL:
   case LoongArch::PseudoCALL_MEDIUM:

--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -1927,8 +1927,8 @@ LoongArchTargetLowering::lowerGlobalTLSAddress(SDValue Op,
   }
 
   return getTLSDescAddr(N, DAG,
-                        Large ? LoongArch::PseudoLA_TLS_DESC_PC_LARGE
-                              : LoongArch::PseudoLA_TLS_DESC_PC,
+                        Large ? LoongArch::PseudoLA_TLS_DESC_LARGE
+                              : LoongArch::PseudoLA_TLS_DESC,
                         Large);
 }
 

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
@@ -1655,27 +1655,17 @@ let isCall = 1, isBarrier = 1, hasSideEffects = 0, mayStore = 0, mayLoad = 0,
 def PseudoDESC_CALL : Pseudo<(outs GPR:$rd), (ins GPR:$rj, simm16_lsl2:$imm16)>,
                       PseudoInstExpansion<(JIRL GPR:$rd, GPR:$rj,
                                            simm16_lsl2:$imm16)>;
-
 // TLSDESC
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0, isCodeGenOnly = 0,
-    isAsmParserOnly = 1, Defs = [R1] in {
-def PseudoLA_TLS_DESC_ABS : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src),
-                                   [], "la.tls.desc", "$dst, $src">,
-                                   Requires<[IsLA32, HasLaGlobalWithAbs]>;
-def PseudoLA_TLS_DESC_ABS_LARGE : Pseudo<(outs GPR:$dst),
-                                         (ins GPR:$tmp, bare_symbol:$src), [],
-                                         "la.tls.desc", "$dst, $src">,
-                                  Requires<[IsLA64, HasLaGlobalWithAbs]>;
-def PseudoLA_TLS_DESC_PC : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
-                                  "la.tls.desc", "$dst, $src">;
-}
-
+    isAsmParserOnly = 1, Defs = [R1] in
+def PseudoLA_TLS_DESC : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
+                               "la.tls.desc", "$dst, $src">;
 let isCall = 1, isBarrier = 1, hasSideEffects = 0, mayStore = 0, mayLoad = 0,
     isCodeGenOnly = 0, isAsmParserOnly = 1, Defs = [R1, R4] in
-def PseudoLA_TLS_DESC_PC_LARGE : Pseudo<(outs GPR:$dst),
-                                        (ins GPR:$tmp, bare_symbol:$src), [],
-                                        "la.tls.desc", "$dst, $tmp, $src">,
-                                 Requires<[IsLA64]>;
+def PseudoLA_TLS_DESC_LARGE : Pseudo<(outs GPR:$dst),
+                                     (ins GPR:$tmp, bare_symbol:$src), [],
+                                     "la.tls.desc", "$dst, $tmp, $src">,
+                              Requires<[IsLA64]>;
 
 // Load address inst alias: "la", "la.global" and "la.local".
 // Default:

--- a/llvm/test/MC/LoongArch/Macros/macros-la.s
+++ b/llvm/test/MC/LoongArch/Macros/macros-la.s
@@ -3,7 +3,7 @@
 # RUN: llvm-readobj -r %t | FileCheck %s --check-prefix=RELOC
 # RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+relax %s -o %t.relax
 # RUN: llvm-readobj -r %t.relax | FileCheck %s --check-prefixes=RELOC,RELAX
-# RUN: llvm-mc --triple=loongarch64 --defsym ABS=1 --mattr=+la-global-with-abs \
+# RUN: llvm-mc --triple=loongarch64 --mattr=+la-global-with-abs \
 # RUN:     %s | FileCheck %s --check-prefix=ABS
 
 # RELOC:      Relocations [
@@ -15,6 +15,11 @@ la.abs $a0, sym_abs
 # CHECK-NEXT: lu32i.d $a0, %abs64_lo20(sym_abs)
 # CHECK-NEXT: lu52i.d $a0, $a0, %abs64_hi12(sym_abs)
 # CHECK-EMPTY:
+# ABS:        lu12i.w $a0, %abs_hi20(sym_abs)
+# ABS-NEXT:   ori $a0, $a0, %abs_lo12(sym_abs)
+# ABS-NEXT:   lu32i.d $a0, %abs64_lo20(sym_abs)
+# ABS-NEXT:   lu52i.d $a0, $a0, %abs64_hi12(sym_abs)
+# ABS-EMPTY:
 # RELOC-NEXT: R_LARCH_ABS_HI20 sym_abs 0x0
 # RELOC-NEXT: R_LARCH_ABS_LO12 sym_abs 0x0
 # RELOC-NEXT: R_LARCH_ABS64_LO20 sym_abs 0x0
@@ -24,11 +29,97 @@ la.pcrel $a0, sym_pcrel
 # CHECK-NEXT: pcalau12i $a0, %pc_hi20(sym_pcrel)
 # CHECK-NEXT: addi.d $a0, $a0, %pc_lo12(sym_pcrel)
 # CHECK-EMPTY:
+# ABS-NEXT:   pcalau12i $a0, %pc_hi20(sym_pcrel)
+# ABS-NEXT:   addi.d $a0, $a0, %pc_lo12(sym_pcrel)
+# ABS-EMPTY:
 # RELOC-NEXT: R_LARCH_PCALA_HI20 sym_pcrel 0x0
 # RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_PCALA_LO12 sym_pcrel 0x0
 # RELAX-NEXT: R_LARCH_RELAX - 0x0
 
+la.got $a0, sym_got
+# CHECK-NEXT: pcalau12i $a0, %got_pc_hi20(sym_got)
+# CHECK-NEXT: ld.d $a0, $a0, %got_pc_lo12(sym_got)
+# CHECK-EMPTY:
+# ABS-NEXT:   lu12i.w $a0, %got_hi20(sym_got)
+# ABS-NEXT:   ori $a0, $a0, %got_lo12(sym_got)
+# ABS-NEXT:   lu32i.d $a0, %got64_lo20(sym_got)
+# ABS-NEXT:   lu52i.d $a0, $a0, %got64_hi12(sym_got)
+# ABS-NEXT:   ld.d $a0, $a0, 0
+# ABS-EMPTY:
+# RELOC-NEXT: R_LARCH_GOT_PC_HI20 sym_got 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_got 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+
+la.tls.le $a0, sym_le
+# CHECK-NEXT: lu12i.w $a0, %le_hi20(sym_le)
+# CHECK-NEXT: ori $a0, $a0, %le_lo12(sym_le)
+# CHECK-EMPTY:
+# ABS-NEXT:   lu12i.w $a0, %le_hi20(sym_le)
+# ABS-NEXT:   ori $a0, $a0, %le_lo12(sym_le)
+# ABS-EMPTY:
+# RELOC-NEXT: R_LARCH_TLS_LE_HI20 sym_le 0x0
+# RELOC-NEXT: R_LARCH_TLS_LE_LO12 sym_le 0x0
+
+la.tls.ie $a0, sym_ie
+# CHECK-NEXT: pcalau12i $a0, %ie_pc_hi20(sym_ie)
+# CHECK-NEXT: ld.d $a0, $a0, %ie_pc_lo12(sym_ie)
+# CHECK-EMPTY:
+# ABS-NEXT:   lu12i.w $a0, %ie_hi20(sym_ie)
+# ABS-NEXT:   ori $a0, $a0, %ie_lo12(sym_ie)
+# ABS-NEXT:   lu32i.d $a0, %ie64_lo20(sym_ie)
+# ABS-NEXT:   lu52i.d $a0, $a0, %ie64_hi12(sym_ie)
+# ABS-NEXT:   ld.d $a0, $a0, 0
+# ABS-EMPTY:
+# RELOC-NEXT: R_LARCH_TLS_IE_PC_HI20 sym_ie 0x0
+# RELOC-NEXT: R_LARCH_TLS_IE_PC_LO12 sym_ie 0x0
+
+la.tls.ld $a0, sym_ld
+# CHECK-NEXT: pcalau12i $a0, %ld_pc_hi20(sym_ld)
+# CHECK-NEXT: addi.d $a0, $a0, %got_pc_lo12(sym_ld)
+# CHECK-EMPTY:
+# ABS-NEXT:   lu12i.w $a0, %ld_hi20(sym_ld)
+# ABS-NEXT:   ori $a0, $a0, %got_lo12(sym_ld)
+# ABS-NEXT:   lu32i.d $a0, %got64_lo20(sym_ld)
+# ABS-NEXT:   lu52i.d $a0, $a0, %got64_hi12(sym_ld)
+# ABS-EMPTY:
+# RELOC-NEXT: R_LARCH_TLS_LD_PC_HI20 sym_ld 0x0
+# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_ld 0x0
+
+la.tls.gd $a0, sym_gd
+# CHECK-NEXT: pcalau12i $a0, %gd_pc_hi20(sym_gd)
+# CHECK-NEXT: addi.d $a0, $a0, %got_pc_lo12(sym_gd)
+# CHECK-EMPTY:
+# ABS-NEXT:   lu12i.w $a0, %gd_hi20(sym_gd)
+# ABS-NEXT:   ori $a0, $a0, %got_lo12(sym_gd)
+# ABS-NEXT:   lu32i.d $a0, %got64_lo20(sym_gd)
+# ABS-NEXT:   lu52i.d $a0, $a0, %got64_hi12(sym_gd)
+# ABS-EMPTY:
+# RELOC-NEXT: R_LARCH_TLS_GD_PC_HI20 sym_gd 0x0
+# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_gd 0x0
+
+la.tls.desc $a0, sym_desc
+# CHECK-NEXT: pcalau12i $a0, %desc_pc_hi20(sym_desc)
+# CHECK-NEXT: addi.d $a0, $a0, %desc_pc_lo12(sym_desc)
+# CHECK-NEXT: ld.d $ra, $a0, %desc_ld(sym_desc)
+# CHECK-NEXT: jirl $ra, $ra, %desc_call(sym_desc)
+# CHECK-EMPTY:
+# ABS-NEXT:   lu12i.w $a0, %desc_hi20(sym_desc)
+# ABS-NEXT:   ori $a0, $a0, %desc_lo12(sym_desc)
+# ABS-NEXT:   lu32i.d $a0, %desc64_lo20(sym_desc)
+# ABS-NEXT:   lu52i.d $a0, $a0, %desc64_hi12(sym_desc)
+# ABS-NEXT:   ld.d $ra, $a0, %desc_ld(sym_desc)
+# ABS-NEXT:   jirl $ra, $ra, %desc_call(sym_desc)
+# ABS-EMPTY:
+# RELOC-NEXT: R_LARCH_TLS_DESC_PC_HI20 sym_desc 0x0
+# RELOC-NEXT: R_LARCH_TLS_DESC_PC_LO12 sym_desc 0x0
+# RELOC-NEXT: R_LARCH_TLS_DESC_LD sym_desc 0x0
+# RELOC-NEXT: R_LARCH_TLS_DESC_CALL sym_desc 0x0
+
+#############################################################
+## with a temporary register.
+#############################################################
 la.pcrel $a0, $a1, sym_pcrel_large
 # CHECK-NEXT: pcalau12i $a0, %pc_hi20(sym_pcrel_large)
 # CHECK-NEXT: addi.d $a1, $zero, %pc_lo12(sym_pcrel_large)
@@ -40,15 +131,6 @@ la.pcrel $a0, $a1, sym_pcrel_large
 # RELOC-NEXT: R_LARCH_PCALA_LO12 sym_pcrel_large 0x0
 # RELOC-NEXT: R_LARCH_PCALA64_LO20 sym_pcrel_large 0x0
 # RELOC-NEXT: R_LARCH_PCALA64_HI12 sym_pcrel_large 0x0
-
-la.got $a0, sym_got
-# CHECK-NEXT: pcalau12i $a0, %got_pc_hi20(sym_got)
-# CHECK-NEXT: ld.d $a0, $a0, %got_pc_lo12(sym_got)
-# CHECK-EMPTY:
-# RELOC-NEXT: R_LARCH_GOT_PC_HI20 sym_got 0x0
-# RELAX-NEXT: R_LARCH_RELAX - 0x0
-# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_got 0x0
-# RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 la.got $a0, $a1, sym_got_large
 # CHECK-NEXT: pcalau12i $a0, %got_pc_hi20(sym_got_large)
@@ -62,20 +144,6 @@ la.got $a0, $a1, sym_got_large
 # RELOC-NEXT: R_LARCH_GOT64_PC_LO20 sym_got_large 0x0
 # RELOC-NEXT: R_LARCH_GOT64_PC_HI12 sym_got_large 0x0
 
-la.tls.le $a0, sym_le
-# CHECK-NEXT: lu12i.w $a0, %le_hi20(sym_le)
-# CHECK-NEXT: ori $a0, $a0, %le_lo12(sym_le)
-# CHECK-EMPTY:
-# RELOC-NEXT: R_LARCH_TLS_LE_HI20 sym_le 0x0
-# RELOC-NEXT: R_LARCH_TLS_LE_LO12 sym_le 0x0
-
-la.tls.ie $a0, sym_ie
-# CHECK-NEXT: pcalau12i $a0, %ie_pc_hi20(sym_ie)
-# CHECK-NEXT: ld.d $a0, $a0, %ie_pc_lo12(sym_ie)
-# CHECK-EMPTY:
-# RELOC-NEXT: R_LARCH_TLS_IE_PC_HI20 sym_ie 0x0
-# RELOC-NEXT: R_LARCH_TLS_IE_PC_LO12 sym_ie 0x0
-
 la.tls.ie $a0, $a1, sym_ie_large
 # CHECK-NEXT: pcalau12i $a0, %ie_pc_hi20(sym_ie_large)
 # CHECK-NEXT: addi.d $a1, $zero, %ie_pc_lo12(sym_ie_large)
@@ -87,13 +155,6 @@ la.tls.ie $a0, $a1, sym_ie_large
 # RELOC-NEXT: R_LARCH_TLS_IE_PC_LO12 sym_ie_large 0x0
 # RELOC-NEXT: R_LARCH_TLS_IE64_PC_LO20 sym_ie_large 0x0
 # RELOC-NEXT: R_LARCH_TLS_IE64_PC_HI12 sym_ie_large 0x0
-
-la.tls.ld $a0, sym_ld
-# CHECK-NEXT: pcalau12i $a0, %ld_pc_hi20(sym_ld)
-# CHECK-NEXT: addi.d $a0, $a0, %got_pc_lo12(sym_ld)
-# CHECK-EMPTY:
-# RELOC-NEXT: R_LARCH_TLS_LD_PC_HI20 sym_ld 0x0
-# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_ld 0x0
 
 la.tls.ld $a0, $a1, sym_ld_large
 # CHECK-NEXT: pcalau12i $a0, %ld_pc_hi20(sym_ld_large)
@@ -107,13 +168,6 @@ la.tls.ld $a0, $a1, sym_ld_large
 # RELOC-NEXT: R_LARCH_GOT64_PC_LO20 sym_ld_large 0x0
 # RELOC-NEXT: R_LARCH_GOT64_PC_HI12 sym_ld_large 0x0
 
-la.tls.gd $a0, sym_gd
-# CHECK-NEXT: pcalau12i $a0, %gd_pc_hi20(sym_gd)
-# CHECK-NEXT: addi.d $a0, $a0, %got_pc_lo12(sym_gd)
-# CHECK-EMPTY:
-# RELOC-NEXT: R_LARCH_TLS_GD_PC_HI20 sym_gd 0x0
-# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_gd 0x0
-
 la.tls.gd $a0, $a1, sym_gd_large
 # CHECK-NEXT: pcalau12i $a0, %gd_pc_hi20(sym_gd_large)
 # CHECK-NEXT: addi.d $a1, $zero, %got_pc_lo12(sym_gd_large)
@@ -125,17 +179,6 @@ la.tls.gd $a0, $a1, sym_gd_large
 # RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_gd_large 0x0
 # RELOC-NEXT: R_LARCH_GOT64_PC_LO20 sym_gd_large 0x0
 # RELOC-NEXT: R_LARCH_GOT64_PC_HI12 sym_gd_large 0x0
-
-la.tls.desc $a0, sym_desc
-# CHECK-NEXT: pcalau12i $a0, %desc_pc_hi20(sym_desc)
-# CHECK-NEXT: addi.d $a0, $a0, %desc_pc_lo12(sym_desc)
-# CHECK-NEXT: ld.d $ra, $a0, %desc_ld(sym_desc)
-# CHECK-NEXT: jirl $ra, $ra, %desc_call(sym_desc)
-# CHECK-EMPTY:
-# RELOC-NEXT: R_LARCH_TLS_DESC_PC_HI20 sym_desc 0x0
-# RELOC-NEXT: R_LARCH_TLS_DESC_PC_LO12 sym_desc 0x0
-# RELOC-NEXT: R_LARCH_TLS_DESC_LD sym_desc 0x0
-# RELOC-NEXT: R_LARCH_TLS_DESC_CALL sym_desc 0x0
 
 la.tls.desc $a0, $a1, sym_desc_large
 # CHECK-NEXT: pcalau12i $a0, %desc_pc_hi20(sym_desc_large)
@@ -156,18 +199,3 @@ la.tls.desc $a0, $a1, sym_desc_large
 
 # RELOC-NEXT:   }
 # RELOC-NEXT: ]
-
-#############################################################
-## with feature: +la-global-with-abs
-#############################################################
-.ifdef ABS
-
-la.tls.desc $a0, sym_desc
-# ABS:      lu12i.w $a0, %desc_hi20(sym_desc)
-# ABS-NEXT: ori $a0, $a0, %desc_lo12(sym_desc)
-# ABS-NEXT: lu32i.d $a0, %desc64_lo20(sym_desc)
-# ABS-NEXT: lu52i.d $a0, $a0, %desc64_hi12(sym_desc)
-# ABS-NEXT: ld.d $ra, $a0, %desc_ld(sym_desc)
-# ABS-NEXT: jirl $ra, $ra, %desc_call(sym_desc)
-
-.endif


### PR DESCRIPTION
This is to align with GAS. Additionally, there are some minor changes:
the definition and expansion process of the TLS_DESC pseudo-instruction
were modified in the same style.
