### PR TITLE
[Clang] Don't assert on substituted-but-yet-expanded packs for nested lambdas

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -486,7 +486,7 @@ Bug Fixes to C++ Support
 - Clang no longer tries to capture non-odr used default arguments of template parameters of generic lambdas (#GH107048)
 - Fixed a bug where defaulted comparison operators would remove ``const`` from base classes. (#GH102588)
 - Fix a crash when using ``source_location`` in the trailing return type of a lambda expression. (#GH67134)
-- A follow-up fix was added for (#GH61460), as the previous fix was not entirely correct. (#GH86361)
+- A follow-up fix was added for (#GH61460), as the previous fix was not entirely correct. (#GH86361), (#GH112352)
 - Fixed a crash in the typo correction of an invalid CTAD guide. (#GH107887)
 - Fixed a crash when clang tries to subtitute parameter pack while retaining the parameter
   pack. (#GH63819), (#GH107560)

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -8385,14 +8385,19 @@ TreeTransform<Derived>::TransformDeclStmt(DeclStmt *S) {
     if (Transformed != D)
       DeclChanged = true;
 
-    if (LSI && isa<TypeDecl>(Transformed))
-      LSI->ContainsUnexpandedParameterPack |=
-          getSema()
-              .getASTContext()
-              .getTypeDeclType(cast<TypeDecl>(Transformed))
-              .getCanonicalType()
-              .getTypePtr()
-              ->containsUnexpandedParameterPack();
+    if (LSI) {
+      if (auto *TD = dyn_cast<TypeDecl>(Transformed))
+        LSI->ContainsUnexpandedParameterPack |=
+            getSema()
+                .getASTContext()
+                .getTypeDeclType(TD)
+                .getCanonicalType()
+                ->containsUnexpandedParameterPack();
+
+      if (auto *VD = dyn_cast<VarDecl>(Transformed))
+        LSI->ContainsUnexpandedParameterPack |=
+            VD->getType()->containsUnexpandedParameterPack();
+    }
 
     Decls.push_back(Transformed);
   }

--- a/clang/test/SemaCXX/lambda-pack-expansion.cpp
+++ b/clang/test/SemaCXX/lambda-pack-expansion.cpp
@@ -111,6 +111,8 @@ struct S {
     (void)[]<int... Is> {
       ([] {
         Is;
+        // Propagate up the flag ContainsUnexpandedParameterPack from VarDecl.
+        S var(foo<Types>);
         foo<Types>;
         bar<Values>;
       } &&

--- a/clang/test/SemaCXX/lambda-pack-expansion.cpp
+++ b/clang/test/SemaCXX/lambda-pack-expansion.cpp
@@ -94,3 +94,43 @@ template <typename... Ts> void g2(Ts... p1s) {
 void f1() { g(); }
 
 } // namespace GH61460
+
+namespace GH112352 {
+
+template <class>
+constexpr bool foo = false;
+
+template <int>
+constexpr bool bar = false;
+
+template <template<class> class>
+constexpr bool baz = false;
+
+struct S {
+  template <typename... Types, int... Values> void foldExpr1() {
+    (void)[]<int... Is> {
+      ([] {
+        Is;
+        foo<Types>;
+        bar<Values>;
+      } &&
+       ...);
+    };
+  }
+
+  template <template<class> class... TTPs> void foldExpr2() {
+    (void)[]<int... Is> {
+      ([] {
+        Is;
+        baz<TTPs>;
+      } && ...);
+    };
+  }
+};
+
+void use() {
+  S().foldExpr1();
+  S().foldExpr2();
+}
+
+} // namespace GH112352

--- a/clang/test/SemaCXX/lambda-pack-expansion.cpp
+++ b/clang/test/SemaCXX/lambda-pack-expansion.cpp
@@ -115,6 +115,7 @@ struct S {
         S var(foo<Types>);
         foo<Types>;
         bar<Values>;
+        int a = Values;
       } &&
        ...);
     };
@@ -125,6 +126,7 @@ struct S {
       ([] {
         Is;
         baz<TTPs>;
+        TTPs<int> D;
       } && ...);
     };
   }


### PR DESCRIPTION
Nested lambdas could refer to outer packs that would be expanded by a larger CXXFoldExpr, in which case that reference could happen to be a full expression containing intermediate types/expressions, e.g. SubstTemplateTypeParmPackType/FunctionParmPackExpr. They are designated as "UnexpandedPack" dependencies but don't introduce new packs anyway.

This also handles a missed case for VarDecls, where the flag of ContainsUnexpandedPack was not propagated up to the surrounding lambda.

Fixes #112352 