### PR TITLE
[MemProf] Disable memprof ICP support by default

### DIFF
--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -82,7 +82,7 @@ static cl::opt<std::string> ModuleSummaryDotFile(
     cl::desc("File to emit dot graph of new summary into"));
 
 static cl::opt<bool> EnableMemProfIndirectCallSupport(
-    "enable-memprof-indirect-call-support", cl::init(true), cl::Hidden,
+    "enable-memprof-indirect-call-support", cl::init(false), cl::Hidden,
     cl::desc(
         "Enable MemProf support for summarizing and cloning indirect calls"));
 


### PR DESCRIPTION
A failure showed up after this was committed, rather than revert simply
disable this new support to simplify investigation and further testing.
