### PR TITLE
[NFC][Fuzzer] Refactor to avoid a false warning from gcc

### DIFF
--- a/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
+++ b/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
@@ -115,19 +115,18 @@ static void handleLLVMFatalError(void *, const char *Message, bool) {
 extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
                                                         char ***argv) {
   EnableDebugBuffering = true;
+  StringRef ExecName = *argv[0];
 
   InitializeAllTargets();
   InitializeAllTargetMCs();
   InitializeAllAsmPrinters();
   InitializeAllAsmParsers();
 
-  handleExecNameEncodedBEOpts(*argv[0]);
+  handleExecNameEncodedBEOpts(ExecName);
   parseFuzzerCLOpts(*argc, *argv);
 
-  std::string execName = *argv[0];
-
   if (TargetTriple.empty()) {
-    errs() << execName << ": -mtriple must be specified\n";
+    errs() << ExecName << ": -mtriple must be specified\n";
     exit(1);
   }
 
@@ -137,10 +136,10 @@ extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
   if (auto Level = CodeGenOpt::parseLevel(OptLevel)) {
     OLvl = *Level;
   } else {
-    errs() << execName << ": invalid optimization level.\n";
+    errs() << ExecName << ": invalid optimization level.\n";
     return 1;
   }
-  ExitOnError ExitOnErr(std::string(execName) + ": error:");
+  ExitOnError ExitOnErr(std::string(ExecName) + ": error:");
   TM = ExitOnErr(codegen::createTargetMachineForTriple(
       Triple::normalize(TargetTriple), OLvl));
   assert(TM && "Could not allocate target machine!");

--- a/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
+++ b/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
@@ -124,8 +124,10 @@ extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
   handleExecNameEncodedBEOpts(*argv[0]);
   parseFuzzerCLOpts(*argc, *argv);
 
+  std::string execName = *argv[0];
+
   if (TargetTriple.empty()) {
-    errs() << *argv[0] << ": -mtriple must be specified\n";
+    errs() << execName << ": -mtriple must be specified\n";
     exit(1);
   }
 
@@ -135,10 +137,10 @@ extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
   if (auto Level = CodeGenOpt::parseLevel(OptLevel)) {
     OLvl = *Level;
   } else {
-    errs() << argv[0] << ": invalid optimization level.\n";
+    errs() << execName << ": invalid optimization level.\n";
     return 1;
   }
-  ExitOnError ExitOnErr(std::string(*argv[0]) + ": error:");
+  ExitOnError ExitOnErr(std::string(execName) + ": error:");
   TM = ExitOnErr(codegen::createTargetMachineForTriple(
       Triple::normalize(TargetTriple), OLvl));
   assert(TM && "Could not allocate target machine!");

--- a/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
+++ b/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
@@ -175,6 +175,7 @@ static void handleLLVMFatalError(void *, const char *Message, bool) {
 extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
                                                         char ***argv) {
   EnableDebugBuffering = true;
+  StringRef ExecName = *argv[0];
 
   // Make sure we print the summary and the current unit when LLVM errors out.
   install_fatal_error_handler(handleLLVMFatalError, nullptr);
@@ -188,17 +189,16 @@ extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
   // Parse input options
   //
 
-  handleExecNameEncodedOptimizerOpts(*argv[0]);
+  handleExecNameEncodedOptimizerOpts(ExecName);
   parseFuzzerCLOpts(*argc, *argv);
 
   // Create TargetMachine
   //
-  std::string execName = *argv[0];
   if (TargetTripleStr.empty()) {
-    errs() << execName << ": -mtriple must be specified\n";
+    errs() << ExecName << ": -mtriple must be specified\n";
     exit(1);
   }
-  ExitOnError ExitOnErr(std::string(execName) + ": error:");
+  ExitOnError ExitOnErr(std::string(ExecName) + ": error:");
   TM = ExitOnErr(codegen::createTargetMachineForTriple(
       Triple::normalize(TargetTripleStr)));
 
@@ -206,14 +206,14 @@ extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
   //
 
   if (PassPipeline.empty()) {
-    errs() << execName << ": at least one pass should be specified\n";
+    errs() << ExecName << ": at least one pass should be specified\n";
     exit(1);
   }
 
   PassBuilder PB(TM.get());
   ModulePassManager MPM;
   if (auto Err = PB.parsePassPipeline(MPM, PassPipeline)) {
-    errs() << execName << ": " << toString(std::move(Err)) << "\n";
+    errs() << ExecName << ": " << toString(std::move(Err)) << "\n";
     exit(1);
   }
 

--- a/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
+++ b/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
@@ -193,12 +193,12 @@ extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
 
   // Create TargetMachine
   //
-
+  std::string execName = *argv[0];
   if (TargetTripleStr.empty()) {
-    errs() << *argv[0] << ": -mtriple must be specified\n";
+    errs() << execName << ": -mtriple must be specified\n";
     exit(1);
   }
-  ExitOnError ExitOnErr(std::string(*argv[0]) + ": error:");
+  ExitOnError ExitOnErr(std::string(execName) + ": error:");
   TM = ExitOnErr(codegen::createTargetMachineForTriple(
       Triple::normalize(TargetTripleStr)));
 
@@ -206,14 +206,14 @@ extern "C" LLVM_ATTRIBUTE_USED int LLVMFuzzerInitialize(int *argc,
   //
 
   if (PassPipeline.empty()) {
-    errs() << *argv[0] << ": at least one pass should be specified\n";
+    errs() << execName << ": at least one pass should be specified\n";
     exit(1);
   }
 
   PassBuilder PB(TM.get());
   ModulePassManager MPM;
   if (auto Err = PB.parsePassPipeline(MPM, PassPipeline)) {
-    errs() << *argv[0] << ": " << toString(std::move(Err)) << "\n";
+    errs() << execName << ": " << toString(std::move(Err)) << "\n";
     exit(1);
   }
 


### PR DESCRIPTION
This is one of the many PRs to fix errors with LLVM_ENABLE_WERROR=on. Built by GCC 11.

Refactor the code to avoid the false warning

llvm-project/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
llvm-project/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp: In function ‘int LLVMFuzzerInitialize(int*, char***)’:
llvm-project/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp:141:43: error: ISO C++ forbids zero-size array ‘argv’ [-Werror=pedantic]
  141 |   ExitOnError ExitOnErr(std::string(*argv[0]) + ": error:");
      |
