### PR TITLE
[mlir] Allow CXX standard to be overridden

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 # Must go below project(..)
 include(GNUInstallDirs)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 
 if(MLIR_STANDALONE_BUILD)
   find_package(LLVM CONFIG REQUIRED)


### PR DESCRIPTION
MLIR previously hardcoded the CXX version to C++17. Updated to allow for the CXX version to be set by clients (mirrors other LLVM projects).