### PR TITLE
[PAC][lld] Test warning emitted for non-PAuth-marked files with `-z pac-plt`

### DIFF
--- a/lld/test/ELF/aarch64-feature-pac.s
+++ b/lld/test/ELF/aarch64-feature-pac.s
@@ -76,12 +76,14 @@
 # PACDYN-NOT:      0x0000000070000001 (AARCH64_BTI_PLT)
 # PACDYN-NOT:      0x0000000070000003 (AARCH64_PAC_PLT)
 
-## Turn on PAC entries with the -z pac-plt command line option. There are no
-## warnings in this case as the choice to use PAC in PLT entries is orthogonal
-## to the choice of using PAC in relocatable objects. The presence of the PAC
-## .note.gnu.property is an indication of preference by the relocatable object.
+## Turn on PAC entries with the -z pac-plt command line option. For files w/o
+## GNU_PROPERTY_AARCH64_FEATURE_1_PAC set in GNU_PROPERTY_AARCH64_FEATURE_1_AND
+## property, emit a warning.
 
-# RUN: ld.lld %t.o %t2.o -z pac-plt %t.so -o %tpacplt.exe
+# RUN: ld.lld %t.o %t2.o -z pac-plt %t.so -o %tpacplt.exe 2>&1 | FileCheck -DFILE=%t2.o --check-prefix WARN %s
+
+# WARN: warning: [[FILE]]: -z pac-plt: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_PAC property
+
 # RUN: llvm-readelf -n %tpacplt.exe | FileCheck --check-prefix=PACPROP %s
 # RUN: llvm-readelf --dynamic-table %tpacplt.exe | FileCheck --check-prefix PACDYN2 %s
 # RUN: llvm-objdump --no-print-imm-hex -d --mattr=+v8.3a --no-show-raw-insn %tpacplt.exe | FileCheck --check-prefix PACPLT %s


### PR DESCRIPTION
b6162622c054f changed semantics of `-z pac-plt` initially introduced in
e208208a3132c, so, the following comment from test/ELF/aarch64-feature-pac.s
is no longer true:

> There are no warnings in this case as the choice to use PAC in PLT entries
> is orthogonal to the choice of using PAC in relocatable objects. The
> presence of the PAC .note.gnu.property is an indication of preference by
> the relocatable object.

This patch updates the test so we ensure a warning is emitted for an
input file when `-z pac-plt` is passed but the file does not have
GNU_PROPERTY_AARCH64_FEATURE_1_PAC set in GNU_PROPERTY_AARCH64_FEATURE_1_AND
property.