### PR TITLE
[PAC][lld] Do not emit warnings for `-z pac-plt` with valid PAuth core info

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2792,10 +2792,8 @@ static void readSecurityNotes(Ctx &ctx) {
       referenceFileName = (*it)->getName();
     }
   }
-  bool hasValidPauthAbiCoreInfo =
-      (!ctx.aarch64PauthAbiCoreInfo.empty() &&
-       llvm::any_of(ctx.aarch64PauthAbiCoreInfo,
-                    [](uint8_t c) { return c != 0; }));
+  bool hasValidPauthAbiCoreInfo = llvm::any_of(
+      ctx.aarch64PauthAbiCoreInfo, [](uint8_t c) { return c != 0; });
 
   for (ELFFileBase *f : ctx.objectFiles) {
     uint32_t features = f->andFeatures;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2792,6 +2792,10 @@ static void readSecurityNotes(Ctx &ctx) {
       referenceFileName = (*it)->getName();
     }
   }
+  bool hasValidPauthAbiCoreInfo =
+      (!ctx.aarch64PauthAbiCoreInfo.empty() &&
+       llvm::any_of(ctx.aarch64PauthAbiCoreInfo,
+                    [](uint8_t c) { return c != 0; }));
 
   for (ELFFileBase *f : ctx.objectFiles) {
     uint32_t features = f->andFeatures;
@@ -2830,10 +2834,12 @@ static void readSecurityNotes(Ctx &ctx) {
                      "GNU_PROPERTY_X86_FEATURE_1_IBT property";
       features |= GNU_PROPERTY_X86_FEATURE_1_IBT;
     }
-    if (ctx.arg.zPacPlt && !(features & GNU_PROPERTY_AARCH64_FEATURE_1_PAC)) {
+    if (ctx.arg.zPacPlt && !(hasValidPauthAbiCoreInfo ||
+                             (features & GNU_PROPERTY_AARCH64_FEATURE_1_PAC))) {
       Warn(ctx) << f
                 << ": -z pac-plt: file does not have "
-                   "GNU_PROPERTY_AARCH64_FEATURE_1_PAC property";
+                   "GNU_PROPERTY_AARCH64_FEATURE_1_PAC property and no valid "
+                   "PAuth core info present for this link job";
       features |= GNU_PROPERTY_AARCH64_FEATURE_1_PAC;
     }
     ctx.arg.andFeatures &= features;

--- a/lld/test/ELF/aarch64-feature-pac.s
+++ b/lld/test/ELF/aarch64-feature-pac.s
@@ -82,7 +82,7 @@
 
 # RUN: ld.lld %t.o %t2.o -z pac-plt %t.so -o %tpacplt.exe 2>&1 | FileCheck -DFILE=%t2.o --check-prefix WARN %s
 
-# WARN: warning: [[FILE]]: -z pac-plt: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_PAC property
+# WARN: warning: [[FILE]]: -z pac-plt: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_PAC property and no valid PAuth core info present for this link job
 
 # RUN: llvm-readelf -n %tpacplt.exe | FileCheck --check-prefix=PACPROP %s
 # RUN: llvm-readelf --dynamic-table %tpacplt.exe | FileCheck --check-prefix PACDYN2 %s

--- a/lld/test/ELF/aarch64-feature-pauth.s
+++ b/lld/test/ELF/aarch64-feature-pauth.s
@@ -33,13 +33,53 @@
 # RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu no-info.s -o noinfo1.o
 # RUN: cp noinfo1.o noinfo2.o
 # RUN: not ld.lld -z pauth-report=error noinfo1.o tag1.o noinfo2.o -o /dev/null 2>&1 | FileCheck --check-prefix ERR5 %s
-# RUN: ld.lld -z pauth-report=warning noinfo1.o tag1.o noinfo2.o -o /dev/null 2>&1 | FileCheck --check-prefix WARN %s
+# RUN: ld.lld -z pauth-report=warning noinfo1.o tag1.o noinfo2.o -o /dev/null 2>&1 | FileCheck --check-prefix WARN1 %s
 # RUN: ld.lld -z pauth-report=none noinfo1.o tag1.o noinfo2.o --fatal-warnings -o /dev/null
 
 # ERR5:      error: noinfo1.o: -z pauth-report: file does not have AArch64 PAuth core info while 'tag1.o' has one
 # ERR5-NEXT: error: noinfo2.o: -z pauth-report: file does not have AArch64 PAuth core info while 'tag1.o' has one
-# WARN:      warning: noinfo1.o: -z pauth-report: file does not have AArch64 PAuth core info while 'tag1.o' has one
-# WARN-NEXT: warning: noinfo2.o: -z pauth-report: file does not have AArch64 PAuth core info while 'tag1.o' has one
+# WARN1:      warning: noinfo1.o: -z pauth-report: file does not have AArch64 PAuth core info while 'tag1.o' has one
+# WARN1-NEXT: warning: noinfo2.o: -z pauth-report: file does not have AArch64 PAuth core info while 'tag1.o' has one
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu abi-tag-zero.s            -o tag-zero.o
+# RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu %p/Inputs/aarch64-func2.s -o func2.o
+# RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu %p/Inputs/aarch64-func3.s -o func3.o
+# RUN: ld.lld func3.o --shared -o func3.so
+# RUN: ld.lld tag1.o     func2.o func3.so -z pac-plt --shared -o pacplt-nowarn --fatal-warnings
+# RUN: ld.lld tag-zero.o func2.o func3.so -z pac-plt --shared -o pacplt-warn 2>&1 | FileCheck --check-prefix WARN2 %s
+
+# WARN2:      warning: tag-zero.o: -z pac-plt: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_PAC property and no valid PAuth core info present for this link job
+# WARN2-NEXT: warning: func2.o: -z pac-plt: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_PAC property and no valid PAuth core info present for this link job
+
+# RUN: llvm-readelf -d pacplt-nowarn | FileCheck --check-prefix=PACPLTTAG %s
+# RUN: llvm-readelf -d pacplt-warn   | FileCheck --check-prefix=PACPLTTAG %s
+
+# PACPLTTAG:      0x0000000070000003 (AARCH64_PAC_PLT)
+
+# RUN: llvm-objdump -d pacplt-nowarn | FileCheck --check-prefix PACPLT -DA=10380 -DB=478 -DC=480 %s
+# RUN: llvm-objdump -d pacplt-warn   | FileCheck --check-prefix PACPLT -DA=10390 -DB=488 -DC=490 %s
+
+# PACPLT: Disassembly of section .text:
+# PACPLT:      <func2>:
+# PACPLT-NEXT:     bl      0x[[A]] <func3@plt>
+# PACPLT-NEXT:     ret
+# PACPLT: Disassembly of section .plt:
+# PACPLT:      <.plt>:
+# PACPLT-NEXT:     stp     x16, x30, [sp, #-0x10]!
+# PACPLT-NEXT:     adrp    x16, 0x30000 <func3+0x30000>
+# PACPLT-NEXT:     ldr     x17, [x16, #0x[[B]]]
+# PACPLT-NEXT:     add     x16, x16, #0x[[B]]
+# PACPLT-NEXT:     br      x17
+# PACPLT-NEXT:     nop
+# PACPLT-NEXT:     nop
+# PACPLT-NEXT:     nop
+# PACPLT:      <func3@plt>:
+# PACPLT-NEXT:     adrp    x16, 0x30000 <func3+0x30000>
+# PACPLT-NEXT:     ldr     x17, [x16, #0x[[C]]]
+# PACPLT-NEXT:     add     x16, x16, #0x[[C]]
+# PACPLT-NEXT:     autia1716
+# PACPLT-NEXT:     br      x17
+# PACPLT-NEXT:     nop
 
 #--- abi-tag-short.s
 
@@ -105,6 +145,18 @@
 .long 16
 .quad 42 // platform
 .quad 2  // version
+
+#--- abi-tag-zero.s
+
+.section ".note.gnu.property", "a"
+.long 4
+.long 24
+.long 5
+.asciz "GNU"
+.long 0xc0000001
+.long 16
+.quad 0  // platform
+.quad 0  // version
 
 #--- no-info.s
 

--- a/lld/test/ELF/aarch64-feature-pauth.s
+++ b/lld/test/ELF/aarch64-feature-pauth.s
@@ -45,7 +45,7 @@
 # RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu %p/Inputs/aarch64-func2.s -o func2.o
 # RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu %p/Inputs/aarch64-func3.s -o func3.o
 # RUN: ld.lld func3.o --shared -o func3.so
-# RUN: ld.lld tag1.o     func2.o func3.so -z pac-plt --shared -o pacplt-nowarn --fatal-warnings
+# RUN: ld.lld tag1.o func2.o func3.so -z pac-plt --shared -o pacplt-nowarn --fatal-warnings
 # RUN: ld.lld tag-zero.o func2.o func3.so -z pac-plt --shared -o pacplt-warn 2>&1 | FileCheck --check-prefix WARN2 %s
 
 # WARN2:      warning: tag-zero.o: -z pac-plt: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_PAC property and no valid PAuth core info present for this link job


### PR DESCRIPTION
When PAuth core info is present and (platform,version) is not (0,0),
treat input files as pac-enabled and do not emit a warning with
`-z pac-plt` passed.