### PR TITLE
[DirectX] Infrastructure to collect shader flags for each function

### DIFF
--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -78,18 +78,16 @@ bool DXContainerGlobals::runOnModule(Module &M) {
 }
 
 GlobalVariable *DXContainerGlobals::getFeatureFlags(Module &M) {
-  const DXILModuleShaderFlagsInfo &MSFI =
-      getAnalysis<ShaderFlagsAnalysisWrapper>().getShaderFlags();
   // TODO: Feature flags mask is obtained as a collection of feature flags
   // of the shader flags of all functions in the module. Need to verify
   // and modify the computation of feature flags to be used.
-  uint64_t ConsolidatedFeatureFlags = 0;
-  for (const auto &FuncFlags : MSFI.getFunctionFlags()) {
-    ConsolidatedFeatureFlags |= FuncFlags.second.getFeatureFlags();
-  }
+  uint64_t CombinedFeatureFlags = getAnalysis<ShaderFlagsAnalysisWrapper>()
+                                      .getShaderFlags()
+                                      .getCombinedFlags()
+                                      .getFeatureFlags();
 
   Constant *FeatureFlagsConstant =
-      ConstantInt::get(M.getContext(), APInt(64, ConsolidatedFeatureFlags));
+      ConstantInt::get(M.getContext(), APInt(64, CombinedFeatureFlags));
   return buildContainerGlobal(M, FeatureFlagsConstant, "dx.sfi0", "SFI0");
 }
 

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -78,9 +78,6 @@ bool DXContainerGlobals::runOnModule(Module &M) {
 }
 
 GlobalVariable *DXContainerGlobals::getFeatureFlags(Module &M) {
-  // TODO: Feature flags mask is obtained as a collection of feature flags
-  // of the shader flags of all functions in the module. Need to verify
-  // and modify the computation of feature flags to be used.
   uint64_t CombinedFeatureFlags = getAnalysis<ShaderFlagsAnalysisWrapper>()
                                       .getShaderFlags()
                                       .getCombinedFlags()

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -84,7 +84,7 @@ GlobalVariable *DXContainerGlobals::getFeatureFlags(Module &M) {
   // of the shader flags of all functions in the module. Need to verify
   // and modify the computation of feature flags to be used.
   uint64_t ConsolidatedFeatureFlags = 0;
-  for (const auto &FuncFlags : MSFI.FuncShaderFlagsVec) {
+  for (const auto &FuncFlags : MSFI.getFunctionFlags()) {
     ConsolidatedFeatureFlags |= FuncFlags.second.getFeatureFlags();
   }
 

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -84,7 +84,7 @@ GlobalVariable *DXContainerGlobals::getFeatureFlags(Module &M) {
   // of the shader flags of all functions in the module. Need to verify
   // and modify the computation of feature flags to be used.
   uint64_t ConsolidatedFeatureFlags = 0;
-  for (const auto &FuncFlags : MSFI.FuncShaderFlagsMap) {
+  for (const auto &FuncFlags : MSFI.FuncShaderFlagsVec) {
     ConsolidatedFeatureFlags |= FuncFlags.second.getFeatureFlags();
   }
 

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -54,7 +54,7 @@ static DXILModuleShaderFlagsInfo computeFlags(Module &M) {
 }
 
 void ComputedShaderFlags::print(raw_ostream &OS) const {
-  uint64_t FlagVal = (uint64_t)*this;
+  uint64_t FlagVal = (uint64_t) * this;
   OS << formatv("; Shader Flags Value: {0:x8}\n;\n", FlagVal);
   if (FlagVal == 0)
     return;

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -105,14 +105,6 @@ void ComputedShaderFlags::print(raw_ostream &OS) const {
   OS << ";\n";
 }
 
-/// Insert the pair <Func, FlagMask> into the sorted vector
-/// FunctionFlags. The insertion is expected to be in-order and hence
-/// is done at the end of the already sorted list.
-void DXILModuleShaderFlagsInfo::insertInorderFunctionFlags(
-    const Function *Func, ComputedShaderFlags FlagMask) {
-  FunctionFlags.push_back({Func, FlagMask});
-}
-
 const SmallVector<std::pair<Function const *, ComputedShaderFlags>> &
 DXILModuleShaderFlagsInfo::getFunctionFlags() const {
   return FunctionFlags;

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -83,7 +83,7 @@ DXILModuleShaderFlagsInfo::DXILModuleShaderFlagsInfo(const Module &M) {
     // Insert shader flag mask for function F
     FunctionFlags.push_back({&F, CSF});
     // Update combined shader flags mask
-    CombinedSFMask |= CSF;
+    CombinedSFMask.merge(CSF);
   }
   llvm::sort(FunctionFlags);
 }

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -14,48 +14,22 @@
 #include "DXILShaderFlags.h"
 #include "DirectX.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/IR/DiagnosticInfo.h"
-#include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Module.h"
-#include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 using namespace llvm::dxil;
 
-namespace {
-/// A simple Wrapper DiagnosticInfo that generates Module-level diagnostic
-/// for Shader Flags Analysis pass
-class DiagnosticInfoShaderFlags : public DiagnosticInfo {
-private:
-  const Twine &Msg;
-  const Module &Mod;
-
-public:
-  /// \p M is the module for which the diagnostic is being emitted. \p Msg is
-  /// the message to show. Note that this class does not copy this message, so
-  /// this reference must be valid for the whole life time of the diagnostic.
-  DiagnosticInfoShaderFlags(const Module &M, const Twine &Msg,
-                            DiagnosticSeverity Severity = DS_Error)
-      : DiagnosticInfo(DK_Unsupported, Severity), Msg(Msg), Mod(M) {}
-
-  void print(DiagnosticPrinter &DP) const override {
-    DP << Mod.getName() << ": " << Msg << '\n';
-  }
-};
-} // namespace
-
-void DXILModuleShaderFlagsInfo::updateFunctionFlags(ComputedShaderFlags &CSF,
-                                                    const Instruction &I) {
-  if (!CSF.Doubles) {
+void ModuleShaderFlags::updateFunctionFlags(ComputedShaderFlags &CSF,
+                                            const Instruction &I) {
+  if (!CSF.Doubles)
     CSF.Doubles = I.getType()->isDoubleTy();
-  }
+
   if (!CSF.Doubles) {
-    for (Value *Op : I.operands()) {
+    for (Value *Op : I.operands())
       CSF.Doubles |= Op->getType()->isDoubleTy();
-    }
   }
   if (CSF.Doubles) {
     switch (I.getOpcode()) {
@@ -65,18 +39,19 @@ void DXILModuleShaderFlagsInfo::updateFunctionFlags(ComputedShaderFlags &CSF,
     case Instruction::FPToUI:
     case Instruction::FPToSI:
       // TODO: To be set if I is a call to DXIL intrinsic DXIL::Opcode::Fma
+      // https://github.com/llvm/llvm-project/issues/114554
       CSF.DX11_1_DoubleExtensions = true;
       break;
     }
   }
 }
 
-DXILModuleShaderFlagsInfo::DXILModuleShaderFlagsInfo(const Module &M) {
+void ModuleShaderFlags::initialize(const Module &M) {
   // Collect shader flags for each of the functions
   for (const auto &F : M.getFunctionList()) {
     if (F.isDeclaration())
       continue;
-    ComputedShaderFlags CSF{};
+    ComputedShaderFlags CSF;
     for (const auto &BB : F)
       for (const auto &I : BB)
         updateFunctionFlags(CSF, I);
@@ -106,21 +81,13 @@ void ComputedShaderFlags::print(raw_ostream &OS) const {
   OS << ";\n";
 }
 
-/// Get the combined shader flag mask of all module functions.
-const ComputedShaderFlags DXILModuleShaderFlagsInfo::getCombinedFlags() const {
-  return CombinedSFMask;
-}
-
-/// Return the shader flags mask of the specified function Func, if one exists.
-/// else an error
-Expected<const ComputedShaderFlags &>
-DXILModuleShaderFlagsInfo::getShaderFlagsMask(const Function *Func) const {
+/// Return the shader flags mask of the specified function Func.
+const ComputedShaderFlags &
+ModuleShaderFlags::getShaderFlagsMask(const Function *Func) const {
   std::pair<Function const *, ComputedShaderFlags> V{Func, {}};
   const auto Iter = llvm::lower_bound(FunctionFlags, V);
-  if (Iter == FunctionFlags.end() || Iter->first != Func) {
-    return createStringError("Shader Flags information of Function '" +
-                             Func->getName() + "' not found");
-  }
+  assert((Iter != FunctionFlags.end() && Iter->first == Func) &&
+         "No Shader Flags Mask exists for function");
   return Iter->second;
 }
 
@@ -130,25 +97,22 @@ DXILModuleShaderFlagsInfo::getShaderFlagsMask(const Function *Func) const {
 // Provide an explicit template instantiation for the static ID.
 AnalysisKey ShaderFlagsAnalysis::Key;
 
-DXILModuleShaderFlagsInfo ShaderFlagsAnalysis::run(Module &M,
-                                                   ModuleAnalysisManager &AM) {
-  DXILModuleShaderFlagsInfo MSFI(M);
+ModuleShaderFlags ShaderFlagsAnalysis::run(Module &M,
+                                           ModuleAnalysisManager &AM) {
+  ModuleShaderFlags MSFI;
+  MSFI.initialize(M);
   return MSFI;
 }
 
 PreservedAnalyses ShaderFlagsAnalysisPrinter::run(Module &M,
                                                   ModuleAnalysisManager &AM) {
-  DXILModuleShaderFlagsInfo FlagsInfo = AM.getResult<ShaderFlagsAnalysis>(M);
+  const ModuleShaderFlags &FlagsInfo = AM.getResult<ShaderFlagsAnalysis>(M);
   for (const auto &F : M.getFunctionList()) {
     if (F.isDeclaration())
       continue;
     OS << "; Shader Flags mask for Function: " << F.getName() << "\n";
     auto SFMask = FlagsInfo.getShaderFlagsMask(&F);
-    if (Error E = SFMask.takeError()) {
-      M.getContext().diagnose(
-          DiagnosticInfoShaderFlags(M, toString(std::move(E))));
-    }
-    SFMask->print(OS);
+    SFMask.print(OS);
   }
 
   return PreservedAnalyses::all();
@@ -158,11 +122,9 @@ PreservedAnalyses ShaderFlagsAnalysisPrinter::run(Module &M,
 // ShaderFlagsAnalysis and ShaderFlagsAnalysisPrinterPass
 
 bool ShaderFlagsAnalysisWrapper::runOnModule(Module &M) {
-  MSFI.reset(new DXILModuleShaderFlagsInfo(M));
+  MSFI.initialize(M);
   return false;
 }
-
-void ShaderFlagsAnalysisWrapper::releaseMemory() { MSFI.reset(); }
 
 char ShaderFlagsAnalysisWrapper::ID = 0;
 

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -70,34 +70,7 @@ static void updateFlags(ComputedShaderFlags &CSF, const Instruction &I) {
 
 static bool compareFuncSFPairs(const FuncShaderFlagsMask &First,
                                const FuncShaderFlagsMask &Second) {
-  // Construct string representation of the functions in each pair
-  // as "retTypefunctionNamearg1Typearg2Ty..." where the function signature is
-  // retType functionName(arg1Type, arg2Ty,...).  Spaces, braces and commas are
-  //  omitted in the string representation of the signature. This allows
-  // determining a consistent lexicographical order of all functions by their
-  // signatures.
-  std::string FirstFunSig;
-  std::string SecondFunSig;
-  raw_string_ostream FRSO(FirstFunSig);
-  raw_string_ostream SRSO(SecondFunSig);
-
-  // Return type
-  First.first->getReturnType()->print(FRSO);
-  Second.first->getReturnType()->print(SRSO);
-  // Function name
-  FRSO << First.first->getName();
-  SRSO << Second.first->getName();
-  // Argument types
-  for (const Argument &Arg : First.first->args()) {
-    Arg.getType()->print(FRSO);
-  }
-  for (const Argument &Arg : Second.first->args()) {
-    Arg.getType()->print(SRSO);
-  }
-  FRSO.flush();
-  SRSO.flush();
-
-  return FRSO.str().compare(SRSO.str()) < 0;
+  return (First.first->getName().compare(Second.first->getName()) < 0);
 }
 
 static DXILModuleShaderFlagsInfo computeFlags(Module &M) {
@@ -108,9 +81,9 @@ static DXILModuleShaderFlagsInfo computeFlags(Module &M) {
     // Each of the functions in a module are unique. Hence no prior shader flags
     // mask of the function should be present.
     if (MSFI.hasShaderFlagsMask(&F)) {
-      M.getContext().diagnose(DiagnosticInfoShaderFlags(
-          M, "Shader Flags mask for Function '" + Twine(F.getName()) +
-                 "' already exits"));
+      M.getContext().diagnose(
+          DiagnosticInfoShaderFlags(M, "Shader Flags mask for Function '" +
+                                           F.getName() + "' already exists"));
     }
     ComputedShaderFlags CSF{};
     for (const auto &BB : F)

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -77,11 +77,11 @@ static bool compareFuncSFPairs(const FuncShaderFlagsMask &First,
   return compareFunctions(First.first, Second.first);
 }
 
-static DXILModuleShaderFlagsInfo computeFlags(Module &M) {
+static DXILModuleShaderFlagsInfo computeFlags(const Module &M) {
   DXILModuleShaderFlagsInfo MSFI;
   // Create a sorted list of functions in the module
   SmallVector<Function const *> FuncList;
-  for (auto &F : M) {
+  for (const auto &F : M.getFunctionList()) {
     if (F.isDeclaration())
       continue;
     FuncList.push_back(&F);
@@ -91,7 +91,7 @@ static DXILModuleShaderFlagsInfo computeFlags(Module &M) {
   MSFI.FuncShaderFlagsVec.clear();
 
   // Collect shader flags for each of the functions
-  for (auto F : FuncList) {
+  for (const auto &F : FuncList) {
     ComputedShaderFlags CSF{};
     for (const auto &BB : *F)
       for (const auto &I : BB)

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -77,12 +77,10 @@ struct DXILModuleShaderFlagsInfo {
   Expected<const ComputedShaderFlags &>
   getShaderFlagsMask(const Function *Func) const;
   bool hasShaderFlagsMask(const Function *Func) const;
-  void clear();
-  ComputedShaderFlags getModuleFlags() const;
-  SmallVector<std::pair<Function const *, ComputedShaderFlags>>
+  const ComputedShaderFlags &getModuleFlags() const;
+  const SmallVector<std::pair<Function const *, ComputedShaderFlags>> &
   getFunctionFlags() const;
-  [[nodiscard]] bool insertInorderFunctionFlags(const Function *,
-                                                ComputedShaderFlags);
+  void insertInorderFunctionFlags(const Function *, ComputedShaderFlags);
 
 private:
   // Shader Flag mask representing module-level properties. These are

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -74,6 +74,7 @@ struct ComputedShaderFlags {
 };
 
 struct DXILModuleShaderFlagsInfo {
+  bool initialize(const Module &M);
   Expected<const ComputedShaderFlags &>
   getShaderFlagsMask(const Function *Func) const;
   bool hasShaderFlagsMask(const Function *Func) const;
@@ -90,6 +91,7 @@ private:
   // of the functions in the module. Shader Flags of each function are those
   // represented using the macro SHADER_FEATURE_FLAG.
   SmallVector<std::pair<Function const *, ComputedShaderFlags>> FunctionFlags;
+  void updateFuctionFlags(ComputedShaderFlags &CSF, const Instruction &I);
 };
 
 class ShaderFlagsAnalysis : public AnalysisInfoMixin<ShaderFlagsAnalysis> {

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -70,13 +70,13 @@ struct ComputedShaderFlags {
     return ModuleFlags;
   }
 
-  ComputedShaderFlags &operator|=(const uint64_t IVal) {
+  void merge(const uint64_t IVal) {
 #define SHADER_FEATURE_FLAG(FeatureBit, DxilModuleBit, FlagName, Str)          \
   FlagName |= (IVal & getMask(DxilModuleBit));
 #define DXIL_MODULE_FLAG(DxilModuleBit, FlagName, Str)                         \
   FlagName |= (IVal & getMask(DxilModuleBit));
 #include "llvm/BinaryFormat/DXContainerConstants.def"
-    return *this;
+    return;
   }
 
   void print(raw_ostream &OS = dbgs()) const;

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -81,7 +81,6 @@ struct DXILModuleShaderFlagsInfo {
   const ComputedShaderFlags &getModuleFlags() const;
   const SmallVector<std::pair<Function const *, ComputedShaderFlags>> &
   getFunctionFlags() const;
-  void insertInorderFunctionFlags(const Function *, ComputedShaderFlags);
 
 private:
   // Shader Flag mask representing module-level properties. These are

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -85,18 +85,16 @@ struct ComputedShaderFlags {
 
 struct ModuleShaderFlags {
   void initialize(const Module &);
-  const ComputedShaderFlags &getShaderFlagsMask(const Function *) const;
-  const ComputedShaderFlags getCombinedFlags() const { return CombinedSFMask; }
+  const ComputedShaderFlags &getFunctionFlags(const Function *) const;
+  const ComputedShaderFlags &getCombinedFlags() const { return CombinedSFMask; }
 
 private:
-  /// Vector of Function-Shader Flag mask pairs representing properties of each
-  /// of the functions in the module. Shader Flags of each function represent
-  /// both module-level and function-level flags
+  /// Vector of sorted Function-Shader Flag mask pairs representing properties
+  /// of each of the functions in the module. Shader Flags of each function
+  /// represent both module-level and function-level flags
   SmallVector<std::pair<Function const *, ComputedShaderFlags>> FunctionFlags;
   /// Combined Shader Flag Mask of all functions of the module
   ComputedShaderFlags CombinedSFMask{};
-
-  void updateFunctionFlags(ComputedShaderFlags &CSF, const Instruction &I);
 };
 
 class ShaderFlagsAnalysis : public AnalysisInfoMixin<ShaderFlagsAnalysis> {

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_TARGET_DIRECTX_DXILSHADERFLAGS_H
 #define LLVM_TARGET_DIRECTX_DXILSHADERFLAGS_H
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
@@ -66,14 +65,18 @@ struct ComputedShaderFlags {
   LLVM_DUMP_METHOD void dump() const { print(); }
 };
 
-using FunctionShaderFlagsMap =
-    SmallDenseMap<Function const *, ComputedShaderFlags>;
+using FuncShaderFlagsMask = std::pair<Function const *, ComputedShaderFlags>;
+using FunctionShaderFlagsVec = SmallVector<FuncShaderFlagsMask>;
 struct DXILModuleShaderFlagsInfo {
   // Shader Flag mask representing module-level properties
   ComputedShaderFlags ModuleFlags;
-  // Map representing shader flag mask representing properties of each of the
-  // functions in the module
-  FunctionShaderFlagsMap FuncShaderFlagsMap;
+  // Vector of Function-Shader Flag mask pairs representing properties of each
+  // of the functions in the module
+  FunctionShaderFlagsVec FuncShaderFlagsVec;
+
+  const ComputedShaderFlags getShaderFlagsMask(const Function *Func) const;
+  bool hasShaderFlagsMask(const Function *Func) const;
+  void print(raw_ostream &OS = dbgs()) const;
 };
 
 class ShaderFlagsAnalysis : public AnalysisInfoMixin<ShaderFlagsAnalysis> {

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -74,7 +74,8 @@ struct DXILModuleShaderFlagsInfo {
   // of the functions in the module
   FunctionShaderFlagsVec FuncShaderFlagsVec;
 
-  const ComputedShaderFlags getShaderFlagsMask(const Function *Func) const;
+  Expected<const ComputedShaderFlags &>
+  getShaderFlagsMask(const Function *Func) const;
   bool hasShaderFlagsMask(const Function *Func) const;
   void print(raw_ostream &OS = dbgs()) const;
 };

--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -286,11 +286,6 @@ static MDTuple *emitTopLevelLibraryNode(Module &M, MDNode *RMD,
   MDTuple *Properties = nullptr;
   if (ShaderFlags != 0) {
     SmallVector<Metadata *> MDVals;
-    // FIXME: ShaderFlagsAnalysis pass needs to collect and provide
-    // ShaderFlags for each entry function. Currently, ShaderFlags value
-    // provided by ShaderFlagsAnalysis pass is created by walking *all* the
-    // function instructions of the module. Is it is correct to use this value
-    // for metadata of the empty library entry?
     MDVals.append(
         getTagValueAsMetadata(EntryPropsTag::ShaderFlags, ShaderFlags, Ctx));
     Properties = MDNode::get(Ctx, MDVals);
@@ -302,7 +297,7 @@ static MDTuple *emitTopLevelLibraryNode(Module &M, MDNode *RMD,
 
 static void translateMetadata(Module &M, const DXILResourceMap &DRM,
                               const Resources &MDResources,
-                              const ComputedShaderFlags &ShaderFlags,
+                              const DXILModuleShaderFlagsInfo &ShaderFlags,
                               const ModuleMetadataInfo &MMDI) {
   LLVMContext &Ctx = M.getContext();
   IRBuilder<> IRB(Ctx);
@@ -318,22 +313,37 @@ static void translateMetadata(Module &M, const DXILResourceMap &DRM,
   // See https://github.com/llvm/llvm-project/issues/57928
   MDTuple *Signatures = nullptr;
 
-  if (MMDI.ShaderProfile == Triple::EnvironmentType::Library)
+  if (MMDI.ShaderProfile == Triple::EnvironmentType::Library) {
+    // Create a consolidated shader flag mask of all functions in the library
+    // to be used as shader flags mask value associated with top-level library
+    // entry metadata.
+    uint64_t ConsolidatedMask = ShaderFlags.ModuleFlags;
+    for (const auto &FunFlags : ShaderFlags.FuncShaderFlagsMap) {
+      ConsolidatedMask |= FunFlags.second;
+    }
     EntryFnMDNodes.emplace_back(
-        emitTopLevelLibraryNode(M, ResourceMD, ShaderFlags));
-  else if (MMDI.EntryPropertyVec.size() > 1) {
+        emitTopLevelLibraryNode(M, ResourceMD, ConsolidatedMask));
+  } else if (MMDI.EntryPropertyVec.size() > 1) {
     M.getContext().diagnose(DiagnosticInfoTranslateMD(
         M, "Non-library shader: One and only one entry expected"));
   }
 
   for (const EntryProperties &EntryProp : MMDI.EntryPropertyVec) {
-    // FIXME: ShaderFlagsAnalysis pass needs to collect and provide
-    // ShaderFlags for each entry function. For now, assume shader flags value
-    // of entry functions being compiled for lib_* shader profile viz.,
-    // EntryPro.Entry is 0.
-    uint64_t EntryShaderFlags =
-        (MMDI.ShaderProfile == Triple::EnvironmentType::Library) ? 0
-                                                                 : ShaderFlags;
+    auto FSFIt = ShaderFlags.FuncShaderFlagsMap.find(EntryProp.Entry);
+    if (FSFIt == ShaderFlags.FuncShaderFlagsMap.end()) {
+      M.getContext().diagnose(DiagnosticInfoTranslateMD(
+          M, "Shader Flags of Function '" + Twine(EntryProp.Entry->getName()) +
+                 "' not found"));
+    }
+    // If ShaderProfile is Library, mask is already consolidated in the
+    // top-level library node. Hence it is not emitted.
+    uint64_t EntryShaderFlags = 0;
+    if (MMDI.ShaderProfile != Triple::EnvironmentType::Library) {
+      // TODO: Create a consolidated shader flag mask of all the entry
+      // functions and its callees. The following is correct only if
+      // (*FSIt).first has no call instructions.
+      EntryShaderFlags = (*FSFIt).second | ShaderFlags.ModuleFlags;
+    }
     if (MMDI.ShaderProfile != Triple::EnvironmentType::Library) {
       if (EntryProp.ShaderStage != MMDI.ShaderProfile) {
         M.getContext().diagnose(DiagnosticInfoTranslateMD(
@@ -361,7 +371,7 @@ PreservedAnalyses DXILTranslateMetadata::run(Module &M,
                                              ModuleAnalysisManager &MAM) {
   const DXILResourceMap &DRM = MAM.getResult<DXILResourceAnalysis>(M);
   const dxil::Resources &MDResources = MAM.getResult<DXILResourceMDAnalysis>(M);
-  const ComputedShaderFlags &ShaderFlags =
+  const DXILModuleShaderFlagsInfo &ShaderFlags =
       MAM.getResult<ShaderFlagsAnalysis>(M);
   const dxil::ModuleMetadataInfo MMDI = MAM.getResult<DXILMetadataAnalysis>(M);
 
@@ -393,7 +403,7 @@ public:
         getAnalysis<DXILResourceWrapperPass>().getResourceMap();
     const dxil::Resources &MDResources =
         getAnalysis<DXILResourceMDWrapper>().getDXILResource();
-    const ComputedShaderFlags &ShaderFlags =
+    const DXILModuleShaderFlagsInfo &ShaderFlags =
         getAnalysis<ShaderFlagsAnalysisWrapper>().getShaderFlags();
     dxil::ModuleMetadataInfo MMDI =
         getAnalysis<DXILMetadataAnalysisWrapperPass>().getModuleMetadata();

--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -328,7 +328,7 @@ static void translateMetadata(Module &M, const DXILResourceMap &DRM,
 
   for (const EntryProperties &EntryProp : MMDI.EntryPropertyVec) {
     const ComputedShaderFlags &EntrySFMask =
-        ShaderFlags.getShaderFlagsMask(EntryProp.Entry);
+        ShaderFlags.getFunctionFlags(EntryProp.Entry);
 
     // If ShaderProfile is Library, mask is already consolidated in the
     // top-level library node. Hence it is not emitted.

--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -25,7 +25,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/TargetParser/Triple.h"

--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -25,6 +25,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/TargetParser/Triple.h"
@@ -317,8 +318,8 @@ static void translateMetadata(Module &M, const DXILResourceMap &DRM,
     // Create a consolidated shader flag mask of all functions in the library
     // to be used as shader flags mask value associated with top-level library
     // entry metadata.
-    uint64_t ConsolidatedMask = ShaderFlags.ModuleFlags;
-    for (const auto &FunFlags : ShaderFlags.FuncShaderFlagsVec) {
+    uint64_t ConsolidatedMask = ShaderFlags.getModuleFlags();
+    for (const auto &FunFlags : ShaderFlags.getFunctionFlags()) {
       ConsolidatedMask |= FunFlags.second;
     }
     EntryFnMDNodes.emplace_back(
@@ -332,9 +333,8 @@ static void translateMetadata(Module &M, const DXILResourceMap &DRM,
     Expected<const ComputedShaderFlags &> ECSF =
         ShaderFlags.getShaderFlagsMask(EntryProp.Entry);
     if (Error E = ECSF.takeError()) {
-      M.getContext().diagnose(DiagnosticInfoTranslateMD(
-          M, "Shader Flags information of Function '" +
-                 Twine(EntryProp.Entry->getName()) + "' not found"));
+      M.getContext().diagnose(
+          DiagnosticInfoTranslateMD(M, toString(std::move(E))));
     }
 
     // If ShaderProfile is Library, mask is already consolidated in the
@@ -344,7 +344,7 @@ static void translateMetadata(Module &M, const DXILResourceMap &DRM,
       // TODO: Create a consolidated shader flag mask of all the entry
       // functions and its callees. The following is correct only if
       // EntryProp.Entry has no call instructions.
-      EntryShaderFlags = *ECSF | ShaderFlags.ModuleFlags;
+      EntryShaderFlags = *ECSF | ShaderFlags.getModuleFlags();
     }
     if (MMDI.ShaderProfile != Triple::EnvironmentType::Library) {
       if (EntryProp.ShaderStage != MMDI.ShaderProfile) {

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
@@ -14,6 +14,4 @@ attributes #0 = { convergent norecurse nounwind "hlsl.export"}
 ; CHECK-NEXT:       Doubles:         true
 ; CHECK-NOT:   {{[A-Za-z]+: +true}}
 ; CHECK:            DX11_1_DoubleExtensions:         true
-; CHECK-NOT:   {{[A-Za-z]+: +true}}
-; CHECK:       NextUnusedBit:   false
-; CHECK: ...
+

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
@@ -11,7 +11,6 @@ attributes #0 = { convergent norecurse nounwind "hlsl.export"}
 ; CHECK: - Name:            SFI0
 ; CHECK-NEXT:     Size:            8
 ; CHECK-NEXT:     Flags:
-; CHECK-NEXT:       Doubles:         true
-; CHECK-NOT:   {{[A-Za-z]+: +true}}
+; CHECK:       Doubles:         true
 ; CHECK:            DX11_1_DoubleExtensions:         true
 

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
@@ -12,5 +12,5 @@ attributes #0 = { convergent norecurse nounwind "hlsl.export"}
 ; CHECK-NEXT:     Size:            8
 ; CHECK-NEXT:     Flags:
 ; CHECK:       Doubles:         true
-; CHECK:            DX11_1_DoubleExtensions:         true
+; CHECK:       DX11_1_DoubleExtensions:         true
 

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
@@ -1,0 +1,19 @@
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+
+target triple = "dxil-pc-shadermodel6.7-library"
+define double @div(double %a, double %b) #0 {
+  %res = fdiv double %a, %b
+  ret double %res
+}
+
+attributes #0 = { convergent norecurse nounwind "hlsl.export"}
+
+; DXC: - Name:            SFI0
+; DXC-NEXT:     Size:            8
+; DXC-NEXT:     Flags:
+; DXC-NEXT:       Doubles:         true
+; DXC-NOT:   {{[A-Za-z]+: +true}}
+; DXC:            DX11_1_DoubleExtensions:         true
+; DXC-NOT:   {{[A-Za-z]+: +true}}
+; DXC:       NextUnusedBit:   false
+; DXC: ...

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions-obj-test.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s
 
 target triple = "dxil-pc-shadermodel6.7-library"
 define double @div(double %a, double %b) #0 {
@@ -8,12 +8,12 @@ define double @div(double %a, double %b) #0 {
 
 attributes #0 = { convergent norecurse nounwind "hlsl.export"}
 
-; DXC: - Name:            SFI0
-; DXC-NEXT:     Size:            8
-; DXC-NEXT:     Flags:
-; DXC-NEXT:       Doubles:         true
-; DXC-NOT:   {{[A-Za-z]+: +true}}
-; DXC:            DX11_1_DoubleExtensions:         true
-; DXC-NOT:   {{[A-Za-z]+: +true}}
-; DXC:       NextUnusedBit:   false
-; DXC: ...
+; CHECK: - Name:            SFI0
+; CHECK-NEXT:     Size:            8
+; CHECK-NEXT:     Flags:
+; CHECK-NEXT:       Doubles:         true
+; CHECK-NOT:   {{[A-Za-z]+: +true}}
+; CHECK:            DX11_1_DoubleExtensions:         true
+; CHECK-NOT:   {{[A-Za-z]+: +true}}
+; CHECK:       NextUnusedBit:   false
+; CHECK: ...

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
@@ -2,10 +2,7 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags mask for Module:
-; CHECK-NEXT: ; Shader Flags Value: 0x00000000
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_fdiv_double
+; CHECK: ; Shader Flags mask for Function: test_fdiv_double
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000044
 ; CHECK-NEXT: ;
 ; CHECK-NEXT: ; Note: shader requires additional functionality:

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
@@ -2,7 +2,7 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags mask for Function: test_fdiv_double
+; CHECK: ; Combined Shader Flags for Module
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000044
 ; CHECK-NEXT: ;
 ; CHECK-NEXT: ; Note: shader requires additional functionality:
@@ -10,38 +10,16 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ; CHECK-NEXT: ;       Double-precision extensions for 11.1
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_uitofp_i64
-; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ; Shader Flags for Module Functions
+; CHECK-NEXT: ; Function test_fdiv_double : 0x00000044
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Note: shader requires additional functionality:
-; CHECK-NEXT: ;       Double-precision floating point
-; CHECK-NEXT: ;       Double-precision extensions for 11.1
-; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ; Function test_uitofp_i64 : 0x00000044
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_sitofp_i64
-; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ; Function test_sitofp_i64 : 0x00000044
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Note: shader requires additional functionality:
-; CHECK-NEXT: ;       Double-precision floating point
-; CHECK-NEXT: ;       Double-precision extensions for 11.1
-; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ; Function test_fptoui_i32 : 0x00000044
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_fptoui_i32
-; CHECK-NEXT: ; Shader Flags Value: 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Note: shader requires additional functionality:
-; CHECK-NEXT: ;       Double-precision floating point
-; CHECK-NEXT: ;       Double-precision extensions for 11.1
-; CHECK-NEXT: ; Note: extra DXIL module flags:
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_fptosi_i64
-; CHECK-NEXT: ; Shader Flags Value: 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Note: shader requires additional functionality:
-; CHECK-NEXT: ;       Double-precision floating point
-; CHECK-NEXT: ;       Double-precision extensions for 11.1
-; CHECK-NEXT: ; Note: extra DXIL module flags:
-; CHECK-NEXT: ;
+; CHECK-NEXT: ; Function test_fptosi_i64 : 0x00000044
 
 define double @test_fdiv_double(double %a, double %b) #0 {
   %res = fdiv double %a, %b

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
@@ -4,43 +4,39 @@ target triple = "dxil-pc-shadermodel6.7-library"
 
 ; CHECK: ; Combined Shader Flags for Module
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Note: shader requires additional functionality:
+
+; CHECK: ; Note: shader requires additional functionality:
 ; CHECK-NEXT: ;       Double-precision floating point
 ; CHECK-NEXT: ;       Double-precision extensions for 11.1
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
 ; CHECK-NEXT: ;
 ; CHECK-NEXT: ; Shader Flags for Module Functions
-; CHECK-NEXT: ; Function test_fdiv_double : 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Function test_uitofp_i64 : 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Function test_sitofp_i64 : 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Function test_fptoui_i32 : 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Function test_fptosi_i64 : 0x00000044
 
+; CHECK: ; Function test_fdiv_double : 0x00000044
 define double @test_fdiv_double(double %a, double %b) #0 {
   %res = fdiv double %a, %b
   ret double %res
 }
 
+; CHECK: ; Function test_uitofp_i64 : 0x00000044
 define double @test_uitofp_i64(i64 %a) #0 {
   %r = uitofp i64 %a to double
   ret double %r
 }
 
+; CHECK: ; Function test_sitofp_i64 : 0x00000044
 define double @test_sitofp_i64(i64 %a) #0 {
   %r = sitofp i64 %a to double
   ret double %r
 }
 
+; CHECK: ; Function test_fptoui_i32 : 0x00000044
 define i32 @test_fptoui_i32(double %a) #0 {
   %r = fptoui double %a to i32
   ret i32 %r
 }
 
+; CHECK: ; Function test_fptosi_i64 : 0x00000044
 define i64 @test_fptosi_i64(double %a) #0 {
   %r = fptosi double %a to i64
   ret i64 %r

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
@@ -13,15 +13,7 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ; CHECK-NEXT: ;       Double-precision extensions for 11.1
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_sitofp_i64
-; CHECK-NEXT: ; Shader Flags Value: 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Note: shader requires additional functionality:
-; CHECK-NEXT: ;       Double-precision floating point
-; CHECK-NEXT: ;       Double-precision extensions for 11.1
-; CHECK-NEXT: ; Note: extra DXIL module flags:
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_uitofp_i64
+; CHECK-NEXT: ; Shader Flags mask for Function: test_fptosi_i64
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000044
 ; CHECK-NEXT: ;
 ; CHECK-NEXT: ; Note: shader requires additional functionality:
@@ -37,7 +29,15 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ; CHECK-NEXT: ;       Double-precision extensions for 11.1
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_fptosi_i64
+; CHECK-NEXT: ; Shader Flags mask for Function: test_sitofp_i64
+; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Note: shader requires additional functionality:
+; CHECK-NEXT: ;       Double-precision floating point
+; CHECK-NEXT: ;       Double-precision extensions for 11.1
+; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Shader Flags mask for Function: test_uitofp_i64
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000044
 ; CHECK-NEXT: ;
 ; CHECK-NEXT: ; Note: shader requires additional functionality:

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
@@ -13,15 +13,7 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ; CHECK-NEXT: ;       Double-precision extensions for 11.1
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_fptosi_i64
-; CHECK-NEXT: ; Shader Flags Value: 0x00000044
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Note: shader requires additional functionality:
-; CHECK-NEXT: ;       Double-precision floating point
-; CHECK-NEXT: ;       Double-precision extensions for 11.1
-; CHECK-NEXT: ; Note: extra DXIL module flags:
-; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_fptoui_i32
+; CHECK-NEXT: ; Shader Flags mask for Function: test_uitofp_i64
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000044
 ; CHECK-NEXT: ;
 ; CHECK-NEXT: ; Note: shader requires additional functionality:
@@ -37,7 +29,15 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ; CHECK-NEXT: ;       Double-precision extensions for 11.1
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
 ; CHECK-NEXT: ;
-; CHECK-NEXT: ; Shader Flags mask for Function: test_uitofp_i64
+; CHECK-NEXT: ; Shader Flags mask for Function: test_fptoui_i32
+; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Note: shader requires additional functionality:
+; CHECK-NEXT: ;       Double-precision floating point
+; CHECK-NEXT: ;       Double-precision extensions for 11.1
+; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Shader Flags mask for Function: test_fptosi_i64
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000044
 ; CHECK-NEXT: ;
 ; CHECK-NEXT: ; Note: shader requires additional functionality:

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/double-extensions.ll
@@ -1,27 +1,74 @@
 ; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
-; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags Value: 0x00000044
-; CHECK: ; Note: shader requires additional functionality:
+; CHECK: ; Shader Flags mask for Module:
+; CHECK-NEXT: ; Shader Flags Value: 0x00000000
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Shader Flags mask for Function: test_fdiv_double
+; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Note: shader requires additional functionality:
 ; CHECK-NEXT: ;       Double-precision floating point
 ; CHECK-NEXT: ;       Double-precision extensions for 11.1
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
-; CHECK-NEXT: {{^;$}}
-define double @div(double %a, double %b) #0 {
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Shader Flags mask for Function: test_sitofp_i64
+; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Note: shader requires additional functionality:
+; CHECK-NEXT: ;       Double-precision floating point
+; CHECK-NEXT: ;       Double-precision extensions for 11.1
+; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Shader Flags mask for Function: test_uitofp_i64
+; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Note: shader requires additional functionality:
+; CHECK-NEXT: ;       Double-precision floating point
+; CHECK-NEXT: ;       Double-precision extensions for 11.1
+; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Shader Flags mask for Function: test_fptoui_i32
+; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Note: shader requires additional functionality:
+; CHECK-NEXT: ;       Double-precision floating point
+; CHECK-NEXT: ;       Double-precision extensions for 11.1
+; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Shader Flags mask for Function: test_fptosi_i64
+; CHECK-NEXT: ; Shader Flags Value: 0x00000044
+; CHECK-NEXT: ;
+; CHECK-NEXT: ; Note: shader requires additional functionality:
+; CHECK-NEXT: ;       Double-precision floating point
+; CHECK-NEXT: ;       Double-precision extensions for 11.1
+; CHECK-NEXT: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ;
+
+define double @test_fdiv_double(double %a, double %b) #0 {
   %res = fdiv double %a, %b
   ret double %res
 }
 
-attributes #0 = { convergent norecurse nounwind "hlsl.export"}
+define double @test_uitofp_i64(i64 %a) #0 {
+  %r = uitofp i64 %a to double
+  ret double %r
+}
 
-; DXC: - Name:            SFI0
-; DXC-NEXT:     Size:            8
-; DXC-NEXT:     Flags:
-; DXC-NEXT:       Doubles:         true
-; DXC-NOT:   {{[A-Za-z]+: +true}}
-; DXC:            DX11_1_DoubleExtensions:         true
-; DXC-NOT:   {{[A-Za-z]+: +true}}
-; DXC:       NextUnusedBit:   false
-; DXC: ...
+define double @test_sitofp_i64(i64 %a) #0 {
+  %r = sitofp i64 %a to double
+  ret double %r
+}
+
+define i32 @test_fptoui_i32(double %a) #0 {
+  %r = fptoui double %a to i32
+  ret i32 %r
+}
+
+define i64 @test_fptosi_i64(double %a) #0 {
+  %r = fptosi double %a to i64
+  ret i64 %r
+}
+
+attributes #0 = { convergent norecurse nounwind "hlsl.export"}

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/doubles.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/doubles.ll
@@ -3,7 +3,10 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags Value: 0x00000004
+; CHECK: ; Shader Flags mask for Module:
+; CHECK-NEXT: ; Shader Flags Value: 0x00000000
+; CHECK: ; Shader Flags mask for Function: add
+; CHECK-NEXT: ; Shader Flags Value: 0x00000004
 ; CHECK: ; Note: shader requires additional functionality:
 ; CHECK-NEXT: ;       Double-precision floating point
 ; CHECK-NEXT: ; Note: extra DXIL module flags:

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/doubles.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/doubles.ll
@@ -3,8 +3,6 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags mask for Module:
-; CHECK-NEXT: ; Shader Flags Value: 0x00000000
 ; CHECK: ; Shader Flags mask for Function: add
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000004
 ; CHECK: ; Note: shader requires additional functionality:

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/doubles.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/doubles.ll
@@ -3,12 +3,15 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags mask for Function: add
-; CHECK-NEXT: ; Shader Flags Value: 0x00000004
-; CHECK: ; Note: shader requires additional functionality:
-; CHECK-NEXT: ;       Double-precision floating point
-; CHECK-NEXT: ; Note: extra DXIL module flags:
-; CHECK-NEXT: {{^;$}}
+;CHECK: ; Combined Shader Flags for Module
+;CHECK-NEXT: ; Shader Flags Value: 0x00000004
+;CHECK-NEXT: ;
+;CHECK-NEXT: ; Note: shader requires additional functionality:
+;CHECK-NEXT: ;       Double-precision floating point
+;CHECK-NEXT: ; Note: extra DXIL module flags:
+;CHECK-NEXT: ;
+;CHECK-NEXT: ; Shader Flags for Module Functions
+;CHECK-NEXT: ; Function add : 0x00000004
 
 define double @add(double %a, double %b) #0 {
   %sum = fadd double %a, %b

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/no_flags.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/no_flags.ll
@@ -2,7 +2,11 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags Value: 0x00000000
+; CHECK: ; Shader Flags mask for Module:
+; CHECK-NEXT: ; Shader Flags Value: 0x00000000
+;
+; CHECK: ; Shader Flags mask for Function: add
+; CHECK-NEXT: ; Shader Flags Value: 0x00000000
 define i32 @add(i32 %a, i32 %b) {
   %sum = add i32 %a, %b
   ret i32 %sum

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/no_flags.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/no_flags.ll
@@ -2,9 +2,6 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags mask for Module:
-; CHECK-NEXT: ; Shader Flags Value: 0x00000000
-;
 ; CHECK: ; Shader Flags mask for Function: add
 ; CHECK-NEXT: ; Shader Flags Value: 0x00000000
 define i32 @add(i32 %a, i32 %b) {

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/no_flags.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/no_flags.ll
@@ -2,8 +2,12 @@
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
-; CHECK: ; Shader Flags mask for Function: add
-; CHECK-NEXT: ; Shader Flags Value: 0x00000000
+;CHECK: ; Combined Shader Flags for Module
+;CHECK-NEXT: ; Shader Flags Value: 0x00000000
+;CHECK-NEXT: ;
+;CHECK-NEXT: ; Shader Flags for Module Functions
+;CHECK-NEXT: ; Function add : 0x00000000
+
 define i32 @add(i32 %a, i32 %b) {
   %sum = add i32 %a, %b
   ret i32 %sum


### PR DESCRIPTION
Currently, ShaderFlagsAnalysis pass represents various module-level properties as well as function-level properties of a DXIL Module using a single mask. However, one mask per function is needed for accurate computation of shader flags mask, such as for entry function metadata creation.

This change introduces a structure that wraps a sorted vector of function-shader flag mask pairs that represent function properties instead of a single shader flag mask that represents module properties and properties of all functions. The result type of ShaderFlagsAnalysis pass is changed to newly-defined structure type instead of a single shader flags mask. 

This allows accurate computation of shader flags of an entry function (and all functions in a library shader) for use during its metadata generation (DXILTranslateMetadata pass) and its feature flags in DX container globals construction (DXContainerGlobals pass) based on the shader flags mask of functions. However, note that the change to implement propagation of such callee-based shader flags mask computation is planned in a follow-on PR. Consequently, this PR changes shader flag mask computation in DXILTranslateMetadata and DXContainerGlobals passes to simply be a union of module flags and shader flags of all functions, thereby retaining the existing effect of using a single shader flag mask.