### PR TITLE
[TableGen] Handle Windows line endings in x86-fold-tables.td test

### DIFF
--- a/llvm/test/TableGen/x86-fold-tables.td
+++ b/llvm/test/TableGen/x86-fold-tables.td
@@ -4,4 +4,4 @@
 //   2. cp <generated_file> x86-fold-tables.inc
 
 // RUN: llvm-tblgen -gen-x86-fold-tables -asmwriternum=1 %p/../../lib/Target/X86/X86.td -I %p/../../lib/Target/X86 -I %p/../../include -o %t
-// RUN: diff %p/x86-fold-tables.inc %t
+// RUN: diff --strip-trailing-cr %p/x86-fold-tables.inc %t


### PR DESCRIPTION
The x86-fold-tables.td has been failing for me and [in CI](https://buildkite.com/llvm-project/github-pull-requests/builds/111277#0192a122-c5c9-4e4e-bc5b-7532fec99ae4) if Git happens to decide to check out the baseline file with Windows line endings.

This fix for this is to add the `--strip-trailing-cr` option to diff to normalize the line endings before comparing them.