### PR TITLE
[SLP]: Introduce and use getDataFlowCost

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -772,6 +772,10 @@ public:
     return 1;
   }
 
+  InstructionCost getDataFlowCost(Type *DataType, bool IsCallingConv) const {
+    return 0;
+  }
+
   // Assume that we have a register of the right size for the type.
   unsigned getNumberOfParts(Type *Tp) const { return 1; }
 

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -2410,6 +2410,10 @@ public:
     return 10;
   }
 
+  InstructionCost getDataFlowCost(Type *DataType, bool IsCallingConv) {
+    return 0;
+  }
+
   unsigned getNumberOfParts(Type *Tp) {
     std::pair<InstructionCost, MVT> LT = getTypeLegalizationCost(Tp);
     return LT.first.isValid() ? *LT.first.getValue() : 0;

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -1116,6 +1116,13 @@ TargetTransformInfo::getCallInstrCost(Function *F, Type *RetTy,
   return Cost;
 }
 
+InstructionCost TargetTransformInfo::getDataFlowCost(Type *DataType,
+                                                     bool IsCallingConv) const {
+  InstructionCost Cost = TTIImpl->getDataFlowCost(DataType, IsCallingConv);
+  assert(Cost >= 0 && "TTI should not produce negative costs!");
+  return Cost;
+}
+
 unsigned TargetTransformInfo::getNumberOfParts(Type *Tp) const {
   return TTIImpl->getNumberOfParts(Tp);
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -306,6 +306,14 @@ bool GCNTTIImpl::hasBranchDivergence(const Function *F) const {
   return !F || !ST->isSingleLaneExecution(*F);
 }
 
+InstructionCost GCNTTIImpl::getDataFlowCost(Type *DataType,
+                                            bool IsCallingConv) {
+  if (isTypeLegal(DataType) || IsCallingConv)
+    return BaseT::getDataFlowCost(DataType, IsCallingConv);
+
+  return getNumberOfParts(DataType);
+}
+
 unsigned GCNTTIImpl::getNumberOfRegisters(unsigned RCID) const {
   // NB: RCID is not an RCID. In fact it is 0 or 1 for scalar or vector
   // registers. See getRegisterClassForType for the implementation.

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -308,7 +308,7 @@ bool GCNTTIImpl::hasBranchDivergence(const Function *F) const {
 
 InstructionCost GCNTTIImpl::getDataFlowCost(Type *DataType,
                                             bool IsCallingConv) {
-  if (isTypeLegal(DataType) || IsCallingConv)
+  if (IsCallingConv  || isTypeLegal(DataType))
     return BaseT::getDataFlowCost(DataType, IsCallingConv);
 
   return getNumberOfParts(DataType);

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
@@ -161,6 +161,8 @@ public:
   InstructionCost getCFInstrCost(unsigned Opcode, TTI::TargetCostKind CostKind,
                                  const Instruction *I = nullptr);
 
+  InstructionCost getDataFlowCost(Type *DataType, bool IsCallingConv);
+
   bool isInlineAsmSourceOfDivergence(const CallInst *CI,
                                      ArrayRef<unsigned> Indices = {}) const;
 

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -9044,51 +9044,6 @@ static SmallVector<Type *> buildIntrinsicArgTypes(const CallInst *CI,
   return ArgTys;
 }
 
-// The cost model may determine that vectorizing and eliminating a series of
-// ExtractElements is beneficial. However, if the input vector is a function
-// argument, the calling convention may require extractions in the geneerated
-// code. In this scenario, vectorizaino would then not eliminate the
-// ExtractElement sequence, but would add additional vectorization code.
-// getCCCostFromScalars does the proper accounting for this.
-static unsigned getCCCostFromScalars(ArrayRef<Value *> &Scalars,
-                                     unsigned ScalarSize,
-                                     TargetTransformInfo *TTI) {
-  SetVector<Value *> ArgRoots;
-  for (unsigned I = 0; I < ScalarSize; I++) {
-    auto *Scalar = Scalars[I];
-    if (!Scalar)
-      continue;
-    auto *EE = dyn_cast<ExtractElementInst>(Scalar);
-    if (!EE)
-      continue;
-
-    auto *Vec = EE->getOperand(0);
-    if (!Vec->getType()->isVectorTy())
-      continue;
-
-    auto F = EE->getFunction();
-    auto FoundIt = find_if(
-        F->args(), [&Vec](Argument &I) { return Vec == cast<Value>(&I); });
-
-    if (FoundIt == F->arg_end())
-      continue;
-
-    if (!ArgRoots.contains(Vec))
-      ArgRoots.insert(Vec);
-  }
-
-  if (!ArgRoots.size())
-    return 0;
-
-  unsigned Cost = 0;
-  for (auto ArgOp : ArgRoots) {
-    Cost += TTI->getDataFlowCost(ArgOp->getType(), /*IsCallingConv*/ true)
-                .getValue()
-                .value_or(0);
-  }
-  return Cost;
-}
-
 InstructionCost
 BoUpSLP::getEntryCost(const TreeEntry *E, ArrayRef<Value *> VectorizedVals,
                       SmallPtrSetImpl<Value *> &CheckedExtracts) {
@@ -9120,7 +9075,7 @@ BoUpSLP::getEntryCost(const TreeEntry *E, ArrayRef<Value *> VectorizedVals,
   auto *FinalVecTy = FixedVectorType::get(ScalarTy, EntryVF);
 
   bool NeedToShuffleReuses = !E->ReuseShuffleIndices.empty();
-  InstructionCost CommonCost = getCCCostFromScalars(VL, VL.size(), TTI);
+  InstructionCost CommonCost = 0;
   if (E->State == TreeEntry::NeedToGather) {
     if (allConstant(VL))
       return CommonCost;
@@ -9266,6 +9221,18 @@ BoUpSLP::getEntryCost(const TreeEntry *E, ArrayRef<Value *> VectorizedVals,
           if (!OpTE->ReuseShuffleIndices.empty())
             ScalarCost += TTI::TCC_Basic * (OpTE->ReuseShuffleIndices.size() -
                                             OpTE->Scalars.size());
+    }
+
+    // Calculate the cost difference of propagating a vector vs series of
+    // scalars across blocks. This may be nonzero in the case of illegal
+    // vectors.
+    Type *ScalarTy = VL0->getType()->getScalarType();
+    if (ScalarTy && isValidElementType(ScalarTy)) {
+      ScalarCost += TTI->getDataFlowCost(ScalarTy,
+                                         /*IsCallingConv=*/false) *
+                    EntryVF;
+      CommonCost += TTI->getDataFlowCost(
+          FixedVectorType::get(ScalarTy, EntryVF), /*IsCallingConv=*/false);
     }
 
     return CommonCost - ScalarCost;
@@ -10291,24 +10258,20 @@ InstructionCost BoUpSLP::getTreeCost(ArrayRef<Value *> VectorizedVals) {
     // Calculate the cost difference of propagating a vector vs series of scalars
     // across blocks. This may be nonzero in the case of illegal vectors.
     Instruction *VL0 = TE.getMainOp();
-    bool IsAPhi = VL0 && isa<PHINode>(VL0);
-    bool HasNextEntry = VL0 && ((I + 1) < VectorizableTree.size());
-    bool LiveThru = false;
-    if (HasNextEntry) {
+    if (VL0 && ((I + 1) < VectorizableTree.size())) {
       Instruction *VL1 = VectorizableTree[I + 1]->getMainOp();
-      LiveThru = VL1 && (VL0->getParent() != VL1->getParent());
-    }
-    if (IsAPhi || LiveThru) {
-      VectorType *VTy = dyn_cast<VectorType>(VL0->getType());
-      Type *ScalarTy = VTy ? VTy->getElementType() : VL0->getType();
-      if (ScalarTy && isValidElementType(ScalarTy)) {
-        InstructionCost ScalarDFlow =
-            TTI->getDataFlowCost(ScalarTy,
-                                 /*IsCallingConv*/ false) *
-            TE.getVectorFactor();
-        InstructionCost VectorDFlow =
-            TTI->getDataFlowCost(FixedVectorType::get(ScalarTy, TE.getVectorFactor()), /*IsCallingConv*/ false);
-        Cost += (VectorDFlow - ScalarDFlow);
+      if (VL1 && (VL0->getParent() != VL1->getParent())) {
+        Type *ScalarTy = VL0->getType()->getScalarType();
+        if (ScalarTy && isValidElementType(ScalarTy)) {
+          InstructionCost ScalarDFlow =
+              TTI->getDataFlowCost(ScalarTy,
+                                 /*IsCallingConv=*/false) *
+              TE.getVectorFactor();
+          InstructionCost VectorDFlow = TTI->getDataFlowCost(
+              FixedVectorType::get(ScalarTy, TE.getVectorFactor()),
+              /*IsCallingConv=*/false);
+          Cost += (VectorDFlow - ScalarDFlow);
+        }
       }
     }
 
@@ -10338,17 +10301,15 @@ InstructionCost BoUpSLP::getTreeCost(ArrayRef<Value *> VectorizedVals) {
     if (EphValues.count(EU.User))
       continue;
 
-    // Account for any additional costs required by CallingConvention for the
-    // type.
-    if (isa_and_nonnull<ReturnInst>(EU.User)) {
-      Cost +=
-          TTI->getDataFlowCost(EU.Scalar->getType(), /*IsCallingConv*/ true);
+    // No extract cost for vector "scalar"
+    if (isa<FixedVectorType>(EU.Scalar->getType())) {
+      // Account for any additional costs required by CallingConvention for the
+      // type.
+      if (isa_and_nonnull<ReturnInst>(EU.User))
+        Cost +=
+            TTI->getDataFlowCost(EU.Scalar->getType(), /*IsCallingConv=*/true);
       continue;
     }
-
-    // No extract cost for vector "scalar"
-    if (isa<FixedVectorType>(EU.Scalar->getType()))
-      continue;
 
     // If found user is an insertelement, do not calculate extract cost but try
     // to detect it as a final shuffled/identity match.
@@ -10646,6 +10607,7 @@ InstructionCost BoUpSLP::getTreeCost(ArrayRef<Value *> VectorizedVals) {
   if (ViewSLPTree)
     ViewGraph(this, "SLP" + F->getName(), false, Str);
 #endif
+
   return Cost;
 }
 


### PR DESCRIPTION
This adds getDataFlowCost to the cost model. For certain vector types (e.g. vectors of illegal types), there may be costs which are not currently captured by the cost model. For example, selectionDAGBuilder will likely scalarize vectors of illegal types that cost basic block boundaries. Similar scalarization may occur when handling illegal vector arguments or return values. This scalarization is ultimately a cost of vectorization, and it should be accounted. That said, for legal types, this type of legalization scalarization will not occur. Moreover, when it does occur, the scalarization cost is the same as the cost of the scalarized version. However, AMDGPU has code in place to reduce this type of scalarization; thus the target override.