### PR TITLE
[llvm-rc] Handle Windows line endings in tag-html test

### DIFF
--- a/llvm/test/tools/llvm-rc/tag-html.test
+++ b/llvm/test/tools/llvm-rc/tag-html.test
@@ -1,5 +1,7 @@
 ; RUN: rm -rf %t && mkdir %t && cd %t
-; RUN: cp %p/Inputs/webpage*.html .
+; Remove `\r` in case Git on Windows decided to checkout with Windows newlines.
+; RUN: tr -d '\r' <%p/Inputs/webpage1.html > ./webpage1.html
+; RUN: tr -d '\r' <%p/Inputs/webpage2.html > ./webpage2.html
 ; RUN: llvm-rc -no-preprocess /FO %t/tag-html.res -- %p/Inputs/tag-html.rc
 ; RUN: llvm-readobj %t/tag-html.res | FileCheck %s --check-prefix HTML
 


### PR DESCRIPTION
The tag-html.test has been failing for me and [in CI](https://buildkite.com/llvm-project/github-pull-requests/builds/111277#0192a122-c5c9-4e4e-bc5b-7532fec99ae4) if Git happens to decide to check out the baseline file with Windows line endings.

This fix for this is to call `tr` to strip Windows newlines when copying the baselines files to the test output directory before embedding them.