### PR TITLE
[clang-format] Fix a crash on C# `goto case`

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -2148,7 +2148,7 @@ bool UnwrappedLineParser::tryToParsePropertyAccessor() {
   if (!Style.isCSharp())
     return false;
   // See if it's a property accessor.
-  if (FormatTok->Previous->isNot(tok::identifier))
+  if (!FormatTok->Previous || FormatTok->Previous->isNot(tok::identifier))
     return false;
 
   // See if we are inside a property accessor.

--- a/clang/unittests/Format/FormatTestCSharp.cpp
+++ b/clang/unittests/Format/FormatTestCSharp.cpp
@@ -1688,6 +1688,18 @@ TEST_F(FormatTestCSharp, BrokenBrackets) {
   EXPECT_NE("", format("int where b <")); // reduced from crasher
 }
 
+TEST_F(FormatTestCSharp, GotoCaseLabel) {
+  verifyNoCrash("switch (i) {\n"
+                "case 0:\n"
+                "  goto case 1;\n"
+                "case 1:\n"
+                "  j = 0;\n"
+                "  {\n"
+                "    break;\n"
+                "  }\n"
+                "}");
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
Fixes #113011.