### PR TITLE
Add exception guard for vector(n, x, a) ctor

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -487,10 +487,12 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
   vector(size_type __n, const value_type& __x, const allocator_type& __a)
       : __alloc_(__a) {
+		auto __guard = std::__make_exception_guard(__destroy_vector(*this));
     if (__n > 0) {
       __vallocate(__n);
       __construct_at_end(__n, __x);
     }
+		__guard.__complete();
   }
 
   template <class _InputIterator,


### PR DESCRIPTION
### Overview of Changes
Added an exception guard to the `vector` constructor to enhance exception safety.

### Details
This change ensures that the `vector(n, x, a)` constructor is consistent with other constructors, such as `vector(n, x)` and `vector(n, a)`, in terms of exception safety.

### Impact
Improves robustness and resource management during exceptions.