### PR TITLE
Add exception guard for constructor vector(n, x, a)

### DIFF
--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -165,10 +165,12 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
   vector(size_type __n, const value_type& __x, const allocator_type& __a)
       : __alloc_(__a) {
+    auto __guard = std::__make_exception_guard(__destroy_vector(*this));
     if (__n > 0) {
       __vallocate(__n);
       __construct_at_end(__n, __x);
     }
+    __guard.__complete();
   }
 
   template <class _InputIterator,

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
@@ -139,6 +139,14 @@ int main(int, char**) {
   check_new_delete_called();
 #endif  // TEST_STD_VER >= 14
 
+	try { // Throw in vector(size_type, value_type, const allocator_type&) from the type
+		int throw_after = 1;
+		ThrowingT v(throw_after); 
+    std::vector<ThrowingT> vec(1, v, std::allocator<ThrowingT>());
+  } catch (int) {
+  }
+  check_new_delete_called();
+
   try { // Throw in vector(InputIterator, InputIterator) from input iterator
     std::vector<int> vec((Iterator<std::input_iterator_tag>()), Iterator<std::input_iterator_tag>(2));
   } catch (int) {

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
@@ -139,9 +139,9 @@ int main(int, char**) {
   check_new_delete_called();
 #endif  // TEST_STD_VER >= 14
 
-	try { // Throw in vector(size_type, value_type, const allocator_type&) from the type
-		int throw_after = 1;
-		ThrowingT v(throw_after); 
+  try { // Throw in vector(size_type, value_type, const allocator_type&) from the type
+    int throw_after = 1;
+    ThrowingT v(throw_after);
     std::vector<ThrowingT> vec(1, v, std::allocator<ThrowingT>());
   } catch (int) {
   }


### PR DESCRIPTION
Added exception guard to the `vector(n, x, a)` constructor to enhance exception safety. This change ensures that the `vector(n, x, a)` constructor is consistent with other constructors, such as  `vector(n)`, `vector(n, x)`, `vector(n, a)`, in terms of exception safety.