### PR TITLE
[DebugInfo] Add explicit visibility macros to CodeView template functions

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
@@ -32,7 +32,7 @@ class ClassRecord;
 class EnumRecord;
 class ModifierRecord;
 class PointerRecord;
-struct UnionRecord;
+class UnionRecord;
 } // namespace codeview
 } // namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
@@ -50,6 +50,20 @@ public:
 
   std::vector<CVType> end(TypeIndex Index);
 };
+
+// Needed by RandomAccessVisitorTest.cpp
+#define TYPE_RECORD(EnumName, EnumVal, Name)
+#define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#define MEMBER_RECORD(EnumName, EnumVal, Name)                                 \
+  extern template LLVM_TEMPLATE_ABI void ContinuationRecordBuilder::writeMemberType(    \
+      Name##Record &Record);
+#define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#include "llvm/DebugInfo/CodeView/CodeViewTypes.def"
+#undef TYPE_RECORD
+#undef TYPE_RECORD_ALIAS
+#undef MEMBER_RECORD
+#undef MEMBER_RECORD_ALIAS
+
 } // namespace codeview
 } // namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
@@ -55,8 +55,8 @@ public:
 #define TYPE_RECORD(EnumName, EnumVal, Name)
 #define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
 #define MEMBER_RECORD(EnumName, EnumVal, Name)                                 \
-  extern template LLVM_TEMPLATE_ABI void ContinuationRecordBuilder::writeMemberType(    \
-      Name##Record &Record);
+  extern template LLVM_TEMPLATE_ABI void                                       \
+  ContinuationRecordBuilder::writeMemberType(Name##Record &Record);
 #define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
 #include "llvm/DebugInfo/CodeView/CodeViewTypes.def"
 #undef TYPE_RECORD

--- a/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
@@ -35,8 +35,8 @@ public:
 // Needed by RandomAccessVisitorTest.cpp
 #define TYPE_RECORD(EnumName, EnumVal, Name)                                   \
   class Name##Record;                                                          \
-  extern template LLVM_TEMPLATE_ABI ArrayRef<uint8_t> llvm::codeview::SimpleTypeSerializer::serialize(  \
-      Name##Record &Record);
+  extern template LLVM_TEMPLATE_ABI ArrayRef<uint8_t>                          \
+  llvm::codeview::SimpleTypeSerializer::serialize(Name##Record &Record);
 #define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
 #define MEMBER_RECORD(EnumName, EnumVal, Name)
 #define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)

--- a/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/SimpleTypeSerializer.h
@@ -32,6 +32,19 @@ public:
   ArrayRef<uint8_t> serialize(const FieldListRecord &Record) = delete;
 };
 
+// Needed by RandomAccessVisitorTest.cpp
+#define TYPE_RECORD(EnumName, EnumVal, Name)                                   \
+  class Name##Record;                                                          \
+  extern template LLVM_TEMPLATE_ABI ArrayRef<uint8_t> llvm::codeview::SimpleTypeSerializer::serialize(  \
+      Name##Record &Record);
+#define TYPE_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#define MEMBER_RECORD(EnumName, EnumVal, Name)
+#define MEMBER_RECORD_ALIAS(EnumName, EnumVal, Name, AliasName)
+#include "llvm/DebugInfo/CodeView/CodeViewTypes.def"
+#undef TYPE_RECORD
+#undef TYPE_RECORD_ALIAS
+#undef MEMBER_RECORD
+#undef MEMBER_RECORD_ALIAS
 } // end namespace codeview
 } // end namespace llvm
 

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeRecord.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeRecord.h
@@ -495,7 +495,8 @@ public:
 };
 
 // LF_UNION
-struct UnionRecord : public TagRecord {
+class UnionRecord : public TagRecord {
+public:
   UnionRecord() = default;
   explicit UnionRecord(TypeRecordKind Kind) : TagRecord(Kind) {}
   UnionRecord(uint16_t MemberCount, ClassOptions Options, TypeIndex FieldList,


### PR DESCRIPTION
These will be needed for when llvm is built as a shared library on windows with explicit visibility macros enabled.
Change UnionRecord to class instead of a struct so we can use X macros from CodeViewTypes.def to forward declare all record classes.

This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and LLVM plugins on window.