### PR TITLE
[clang][codegen] Fix ABI for HVA/HFA returns on x86_64 MSVC

### DIFF
--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -1110,6 +1110,10 @@ static bool isTrivialForMSVC(const CXXRecordDecl *RD, QualType Ty,
       isa<VectorType>(Base)) {
     return true;
   }
+  if (CGM.getTarget().getTriple().isX86() &&
+      CGM.getABIInfo().isHomogeneousAggregate(Ty, Base, NumElts)) {
+    return true;
+  }
 
   // We use the C++14 definition of an aggregate, so we also
   // check for:

--- a/clang/test/CodeGenCXX/homogeneous-aggregates.cpp
+++ b/clang/test/CodeGenCXX/homogeneous-aggregates.cpp
@@ -302,3 +302,22 @@ struct test2 : base2 { test2(double); protected: double v2;};
 test2 f(test2 *x) { return *x; }
 // WOA64: define dso_local void @"?f@pr62223@@YA?AUtest2@1@PEAU21@@Z"(ptr dead_on_unwind inreg noalias writable sret(%"struct.pr62223::test2") align 8 %{{.*}}, ptr noundef %{{.*}})
 }
+
+namespace pr113104 {
+struct HFA {
+  float a;
+  float b;
+};
+
+using HVA = float __attribute__((__vector_size__(16), __aligned__(16)));
+
+struct base_hfa { HFA v1; };
+struct test_hfa : base_hfa { test_hfa(double); protected: HFA v2;};
+test_hfa CC f(test_hfa *x) { return *x; }
+// X64: define dso_local x86_vectorcallcc %"struct.pr113104::test_hfa" @"\01_ZN8pr1131041fEPNS_8test_hfaE@@8"(ptr noundef %x)
+
+struct base_hva { HVA v1; };
+struct test_hva : base_hva { test_hva(double); protected: HVA v2;};
+test_hva CC f(test_hva *x) { return *x; }
+// X64: define dso_local x86_vectorcallcc %"struct.pr113104::test_hva" @"\01_ZN8pr1131041fEPNS_8test_hvaE@@8"(ptr noundef %x)
+}


### PR DESCRIPTION
MSVC normally has a bunch of restrictions on returning values directly which don't apply to passing values directly.  (This roughly corresponds to the definition of a C++14 aggregate.)  However, these restrictions don't apply to HVAs and HFAs; make sure we check for that.

Code from tests on godbolt:
https://godbolt.org/z/3hnGxYaah

Fixes llvm/llvm-project#63417