### PR TITLE
clang crash assigning to a global named register variable #109778

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11522,8 +11522,8 @@ getRegisterByName(const char* RegName, LLT VT, const MachineFunction &MF) const 
   if (AArch64::X1 <= Reg && Reg <= AArch64::X28) {
     const AArch64RegisterInfo *MRI = Subtarget->getRegisterInfo();
     unsigned DwarfRegNum = MRI->getDwarfRegNum(Reg, false);
-    if (!Subtarget->isXRegisterReserved(DwarfRegNum) &&
-        !MRI->isReservedReg(MF, Reg))
+    if (Subtarget->isXRegisterReserved(DwarfRegNum) ||
+        MRI->isReservedReg(MF, Reg))
       Reg = 0;
   }
   if (Reg)

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11518,9 +11518,7 @@ SDValue AArch64TargetLowering::LowerSPONENTRY(SDValue Op,
 // this table could be generated automatically from RegInfo.
 Register AArch64TargetLowering::
 getRegisterByName(const char* RegName, LLT VT, const MachineFunction &MF) const {
-  Register Reg = MatchRegisterAltName(RegName);
-  if (Reg == AArch64::NoRegister)
-    Reg = MatchRegisterName(RegName);
+  Register Reg = MatchRegisterName(RegName);
   if (Reg == AArch64::NoRegister)
     report_fatal_error(
         Twine("Invalid register name \"" + StringRef(RegName) + "\"."));

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11522,7 +11522,8 @@ getRegisterByName(const char* RegName, LLT VT, const MachineFunction &MF) const 
   if (AArch64::X1 <= Reg && Reg <= AArch64::X28) {
     const AArch64RegisterInfo *MRI = Subtarget->getRegisterInfo();
     unsigned DwarfRegNum = MRI->getDwarfRegNum(Reg, false);
-// check if X Register is reserved.
+// check if X Register is reserved at either subtarget level or the 
+// machine function level.
     if (Subtarget->isXRegisterReserved(DwarfRegNum) ||
         MRI->isReservedReg(MF, Reg))
       Reg = 0;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11522,8 +11522,8 @@ getRegisterByName(const char* RegName, LLT VT, const MachineFunction &MF) const 
   if (AArch64::X1 <= Reg && Reg <= AArch64::X28) {
     const AArch64RegisterInfo *MRI = Subtarget->getRegisterInfo();
     unsigned DwarfRegNum = MRI->getDwarfRegNum(Reg, false);
-// check if X Register is reserved at either subtarget level or the 
-// machine function level.
+    // check if X Register is reserved at either subtarget level or the
+    // machine function level.
     if (Subtarget->isXRegisterReserved(DwarfRegNum) ||
         MRI->isReservedReg(MF, Reg))
       Reg = 0;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11522,6 +11522,7 @@ getRegisterByName(const char* RegName, LLT VT, const MachineFunction &MF) const 
   if (AArch64::X1 <= Reg && Reg <= AArch64::X28) {
     const AArch64RegisterInfo *MRI = Subtarget->getRegisterInfo();
     unsigned DwarfRegNum = MRI->getDwarfRegNum(Reg, false);
+// check if X Register is reserved.
     if (Subtarget->isXRegisterReserved(DwarfRegNum) ||
         MRI->isReservedReg(MF, Reg))
       Reg = 0;

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -71,6 +71,8 @@ protected:
   unsigned MinimumJumpTableEntries = 4;
   unsigned MaxJumpTableSize = 0;
 
+  std::bitset<AArch64::NUM_TARGET_REGS> UserReservedRegister;
+
   // ReserveXRegister[i] - X#i is not available as a general purpose register.
   BitVector ReserveXRegister;
 
@@ -208,6 +210,10 @@ public:
     return MinVectorRegisterBitWidth;
   }
 
+  bool isRegisterReservedByUser(Register i) const {
+    assert(i < AArch64::NUM_TARGET_REGS && "Register out of range");
+    return UserReservedRegister[i];
+  }
   bool isXRegisterReserved(size_t i) const { return ReserveXRegister[i]; }
   bool isXRegisterReservedForRA(size_t i) const { return ReserveXRegisterForRA[i]; }
   unsigned getNumXRegisterReserved() const {

--- a/llvm/test/CodeGen/AArch64/aarch64-named-reg-x18.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-named-reg-x18.ll
@@ -1,9 +1,8 @@
-; RUN: not --crash llc < %s -mtriple=aarch64-fuchsia 2>&1 | FileCheck %s
+; RUN: llc -mtriple=aarch64-fuchsia -o - %s
 
 define void @set_x18(i64 %x) {
 entry:
 ; FIXME: Include an allocatable-specific error message
-; CHECK: Invalid register name "x18".
   tail call void @llvm.write_register.i64(metadata !0, i64 %x)
   ret void
 }

--- a/llvm/test/CodeGen/AArch64/aarch64-named-reg-x18.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-named-reg-x18.ll
@@ -1,8 +1,9 @@
-; RUN: llc -mtriple=aarch64-fuchsia -o - %s
+; RUN: not --crash llc < %s -mtriple=aarch64-fuchsia 2>&1 | FileCheck %s
 
 define void @set_x18(i64 %x) {
 entry:
 ; FIXME: Include an allocatable-specific error message
+; CHECK: Invalid register name "x18".
   tail call void @llvm.write_register.i64(metadata !0, i64 %x)
   ret void
 }

--- a/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
@@ -4,11 +4,7 @@
 define i32 @get_stack() nounwind {
 entry:
 ; FIXME: Include an allocatable-specific error message
-<<<<<<< Updated upstream
-; CHECK: Couldn't find the register class
-=======
 ; CHECK: Trying to obtain non-reserved register "x5".
->>>>>>> Stashed changes
 	%sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }

--- a/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
@@ -4,7 +4,11 @@
 define i32 @get_stack() nounwind {
 entry:
 ; FIXME: Include an allocatable-specific error message
+<<<<<<< Updated upstream
 ; CHECK: Couldn't find the register class
+=======
+; CHECK: Trying to obtain non-reserved register "x5".
+>>>>>>> Stashed changes
 	%sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }

--- a/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-named-reg-alloc.ll
@@ -4,7 +4,7 @@
 define i32 @get_stack() nounwind {
 entry:
 ; FIXME: Include an allocatable-specific error message
-; CHECK: Invalid register name "x5".
+; CHECK: Couldn't find the register class
 	%sp = call i32 @llvm.read_register.i32(metadata !0)
   ret i32 %sp
 }


### PR DESCRIPTION
fixed crash

I am not sure if the fix is correct. I tried to analyze the logic and found potential issue in the logic and corrected it. Because of this, two testcases;

arm64-named-reg-alloc.ll :
; RUN: not --crash llc < %s -mtriple=arm64-apple-darwin 2>&1 | FileCheck %s
; RUN: not --crash llc < %s -mtriple=arm64-linux-gnueabi 2>&1 | FileCheck %s

define i32 @get_stack() nounwind {
entry:
; FIXME: Include an allocatable-specific error message
; CHECK: Invalid register name "x5".
        %sp = call i32 @llvm.read_register.i32(metadata !0)
  ret i32 %sp
}

declare i32 @llvm.read_register.i32(metadata) nounwind

!0 = !{!"x5\00"}


aarch64-named-reg-x18.ll :
; RUN: llc -mtriple=aarch64-fuchsia -o - %s

define void @set_x18(i64 %x) {
entry:
; FIXME: Include an allocatable-specific error message
  tail call void @llvm.write_register.i64(metadata !0, i64 %x)
  ret void
}

declare void @llvm.write_register.i64(metadata, i64) nounwind

!0 = !{!"x18"}


I am new to project. Please help me here.