### PR TITLE
[clang][bytecode] Allow ArrayElemPtr ops on null pointers

### DIFF
--- a/clang/test/AST/ByteCode/complex.cpp
+++ b/clang/test/AST/ByteCode/complex.cpp
@@ -407,8 +407,7 @@ namespace ComplexConstexpr {
                                   // ref-note {{cannot access real component of null}} \
                                   // expected-note {{read of dereferenced null pointer}}
   constexpr float pi = __imag *p; // both-error {{constant expr}} \
-                                  // ref-note {{cannot access imaginary component of null}} \
-                                  // expected-note {{cannot perform pointer arithmetic on null pointer}}
+                                  // ref-note {{cannot access imaginary component of null}}
   constexpr const _Complex double *q = &test3 + 1;
   constexpr double qr = __real *q; // ref-error {{constant expr}} \
                                    // ref-note {{cannot access real component of pointer past the end}}


### PR DESCRIPTION
This regresses one of the _Complex test cases a bit, but since the diagnostic output wasn't very good here in the first place, let's ignore it.