### PR TITLE
[libc++] Remove workaround which allows setting _LIBCPP_OVERRIDABLE_FUNC_VIS externally

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -408,11 +408,7 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_VISIBILITY("default")
 #    define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS _LIBCPP_VISIBILITY("default")
 #    define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
-
-// TODO: Make this a proper customization point or remove the option to override it.
-#    ifndef _LIBCPP_OVERRIDABLE_FUNC_VIS
-#      define _LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_VISIBILITY("default")
-#    endif
+#    define _LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_VISIBILITY("default")
 
 #    if !defined(_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS)
 // The inline should be removed once PR32114 is resolved


### PR DESCRIPTION
`-fvisibility-global-new-delete` has been added in Clang 18, so there is no more need to specify the visibility of new/delete via libc++-internal macros.

Some people used a custom new/delete, which requires them to have default visibility, but didn't want to leak any symbols otherwise. Since the new/delete visibility can now be controlled by a compiler flag, there is no reason to set it with out macro.

https://reviews.llvm.org/D128007 originally tried to remove the option to override the macro, but was partially reverted because people actually set this specific macro.
