### PR TITLE
bazelbuild: fix for commit 2ce10

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -119,6 +119,11 @@ libc_support_library(
     hdrs = ["include/llvm-libc-macros/linux/fcntl-macros.h"],
 )
 
+libc_support_library(
+    name = "llvm_libc_types_size_t",
+    hdrs = ["include/llvm-libc-types/size_t.h"],
+)
+
 ########################### Macro Proxy Header Files ###########################
 
 libc_support_library(
@@ -3193,6 +3198,7 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_bitset",
         ":__support_macros_optimization",
+        ":llvm_libc_types_size_t",
         ":string_memory_utils",
     ],
 )


### PR DESCRIPTION
bazelbuild: fix for https://github.com/llvm/llvm-project/commit/2ce10f0491142863d3f21cd0adb312ab2cfed107.

No functional changes intended.
