### PR TITLE
bazelbuild: fix for commit d80b9cf713fd

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -1080,6 +1080,7 @@ cc_library(
         ":ast_matchers",
         ":basic",
         ":lex",
+        ":support",
         "//llvm:Support",
     ],
 )
@@ -1232,6 +1233,7 @@ cc_library(
         ":ast",
         ":basic",
         ":lex",
+        ":support",
         "//llvm:Support",
     ],
 )


### PR DESCRIPTION
Fix for https://github.com/llvm/llvm-project/commit/d80b9cf713fd1698641c5b265de6b66618991476.

No functional changes intended.