### PR TITLE
[BOLT] link_fdata support for hardcoded offsets in no-LBR

### DIFF
--- a/bolt/test/AArch64/fdata-nolbr.s
+++ b/bolt/test/AArch64/fdata-nolbr.s
@@ -1,0 +1,18 @@
+# Check that using link_fdata tool in non-lbr mode allows using hardcoded
+# addresses for basic block offsets.
+
+# REQUIRES: system-linux
+
+# RUN: %clang %cflags -o %t %s
+# RUN: %clang %s %cflags -Wl,-q -o %t
+# RUN: not link_fdata --no-lbr %s %t %t.fdata 2>&1 | FileCheck %s
+
+  .text
+  .globl  foo
+  .type foo, %function
+foo:
+# FDATA: 1 foo 0 10
+    ret
+
+# Currently does not work on non-lbr mode.
+# CHECK: AssertionError: ERROR: wrong format/whitespaces must be escaped

--- a/bolt/test/AArch64/fdata-nolbr.s
+++ b/bolt/test/AArch64/fdata-nolbr.s
@@ -5,7 +5,8 @@
 
 # RUN: %clang %cflags -o %t %s
 # RUN: %clang %s %cflags -Wl,-q -o %t
-# RUN: not link_fdata --no-lbr %s %t %t.fdata 2>&1 | FileCheck %s
+# RUN: link_fdata --no-lbr %s %t %t.fdata
+# RUN: cat %t.fdata | FileCheck %s
 
   .text
   .globl  foo
@@ -14,5 +15,5 @@ foo:
 # FDATA: 1 foo 0 10
     ret
 
-# Currently does not work on non-lbr mode.
-# CHECK: AssertionError: ERROR: wrong format/whitespaces must be escaped
+# CHECK: no_lbr
+# CHECK-NEXT: 1 foo 0 10

--- a/bolt/test/link_fdata.py
+++ b/bolt/test/link_fdata.py
@@ -58,7 +58,7 @@ with open(args.input, "r") as f:
         fdata_match = fdata_pat.match(profile_line)
         preagg_match = preagg_pat.match(profile_line)
         nolbr_match = nolbr_pat.match(profile_line)
-        if fdata_match:
+        if fdata_match and not (nolbr_match and args.no_lbr):
             src_dst, execnt, mispred = fdata_match.groups()
             # Split by whitespaces not preceded by a backslash (negative lookbehind)
             chunks = re.split(r"(?<!\\) +", src_dst)


### PR DESCRIPTION
  
Allow using hardcoded offsets to blocks, eg:
```
// RUN: link_fdata --no-lbr ...
// FDATA: 1 foo 0 10
```
    
For LBR mode this was already supported. See for example:
- tail-duplication-complex.s