### PR TITLE
[PS5][Driver] Pass default -z options to PS5 linker

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -261,7 +261,7 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     // time with specific tombstones, such that they're recognisable by the
     // PlayStation debugger.
     CmdArgs.push_back("-z");
-    CmdArgs.push_back("dead-reloc-in-nonalloc=.debug*=0xffffffffffffffff");
+    CmdArgs.push_back("dead-reloc-in-nonalloc=.debug_*=0xffffffffffffffff");
     CmdArgs.push_back("-z");
     CmdArgs.push_back(
         "dead-reloc-in-nonalloc=.debug_ranges=0xfffffffffffffffe");

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -229,6 +229,8 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   const Driver &D = TC.getDriver();
   ArgStringList CmdArgs;
 
+  const bool Relocatable = Args.hasArg(options::OPT_r);
+
   // Silence warning for "clang -g foo.o -o foo"
   Args.ClaimAllArgs(options::OPT_g_Group);
   // and "clang -emit-llvm foo.o -o foo"
@@ -240,11 +242,32 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back(
       Args.MakeArgString("--sysroot=" + TC.getSDKLibraryRootDir()));
 
-  // Default to PIE for non-static executables.
-  const bool PIE =
-      !Args.hasArg(options::OPT_r, options::OPT_shared, options::OPT_static);
-  if (Args.hasFlag(options::OPT_pie, options::OPT_no_pie, PIE))
-    CmdArgs.push_back("-pie");
+  if (!Relocatable) {
+    // Default to PIE for non-static executables.
+    const bool PIE = !Args.hasArg(options::OPT_shared, options::OPT_static);
+    if (Args.hasFlag(options::OPT_pie, options::OPT_no_pie, PIE))
+      CmdArgs.push_back("-pie");
+
+    // Lazy binding of PLTs is not supported on PlayStation. They are placed in
+    // the RelRo segment.
+    CmdArgs.push_back("-z");
+    CmdArgs.push_back("now");
+
+    // Don't export linker-generated __start/stop... section bookends.
+    CmdArgs.push_back("-z");
+    CmdArgs.push_back("start-stop-visibility=hidden");
+
+    // Patch relocated regions of DWARF whose targets are eliminated at link
+    // time with specific tombstones, such that they're recognisable by the
+    // PlayStation debugger.
+    CmdArgs.push_back("-z");
+    CmdArgs.push_back("dead-reloc-in-nonalloc=.debug*=0xffffffffffffffff");
+    CmdArgs.push_back("-z");
+    CmdArgs.push_back(
+        "dead-reloc-in-nonalloc=.debug_ranges=0xfffffffffffffffe");
+    CmdArgs.push_back("-z");
+    CmdArgs.push_back("dead-reloc-in-nonalloc=.debug_loc=0xfffffffffffffffe");
+  }
 
   if (Args.hasArg(options::OPT_static))
     CmdArgs.push_back("-static");

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -242,12 +242,13 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back(
       Args.MakeArgString("--sysroot=" + TC.getSDKLibraryRootDir()));
 
-  if (!Relocatable) {
-    // Default to PIE for non-static executables.
-    const bool PIE = !Args.hasArg(options::OPT_shared, options::OPT_static);
-    if (Args.hasFlag(options::OPT_pie, options::OPT_no_pie, PIE))
-      CmdArgs.push_back("-pie");
+  // Default to PIE for non-static executables.
+  const bool PIE =
+      !Args.hasArg(options::OPT_r, options::OPT_shared, options::OPT_static);
+  if (Args.hasFlag(options::OPT_pie, options::OPT_no_pie, PIE))
+    CmdArgs.push_back("-pie");
 
+  if (!Relocatable) {
     // Lazy binding of PLTs is not supported on PlayStation. They are placed in
     // the RelRo segment.
     CmdArgs.push_back("-z");

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -14,6 +14,22 @@
 // CHECK-NO-PIE-NOT: "-pie"
 // CHECK-SHARED: "--shared"
 
+// Test the driver passes PlayStation-specific -z options to the linker.
+
+// RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-Z %s
+
+// CHECK-Z: {{ld(\.exe)?}}"
+// CHECK-Z-SAME: "-z" "now"
+// CHECK-Z-SAME: "-z" "start-stop-visibility=hidden"
+// CHECK-Z-SAME: "-z" "dead-reloc-in-nonalloc=.debug*=0xffffffffffffffff"
+// CHECK-Z-SAME: "-z" "dead-reloc-in-nonalloc=.debug_ranges=0xfffffffffffffffe"
+// CHECK-Z-SAME: "-z" "dead-reloc-in-nonalloc=.debug_loc=0xfffffffffffffffe"
+
+// RUN: %clang --target=x86_64-sie-ps5 -r %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-Z %s
+
+// CHECK-NO-Z: {{ld(\.exe)?}}"
+// CHECK-NO-Z-NOT: "-z"
+
 // Test that -static is forwarded to the linker
 
 // RUN: %clang --target=x86_64-sie-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -21,7 +21,7 @@
 // CHECK-Z: {{ld(\.exe)?}}"
 // CHECK-Z-SAME: "-z" "now"
 // CHECK-Z-SAME: "-z" "start-stop-visibility=hidden"
-// CHECK-Z-SAME: "-z" "dead-reloc-in-nonalloc=.debug*=0xffffffffffffffff"
+// CHECK-Z-SAME: "-z" "dead-reloc-in-nonalloc=.debug_*=0xffffffffffffffff"
 // CHECK-Z-SAME: "-z" "dead-reloc-in-nonalloc=.debug_ranges=0xfffffffffffffffe"
 // CHECK-Z-SAME: "-z" "dead-reloc-in-nonalloc=.debug_loc=0xfffffffffffffffe"
 


### PR DESCRIPTION
Until now, these options have been hardcoded as downstream patches in LLD. Add them to the driver so that the private patches can be removed.

PS5 only. These implementation of these behaviours will remain in the proprietary linker on PS4.

SIE tracker: TOOLCHAIN-16704