### PR TITLE
[LLVM][AArch64] Add assembly/disassembly of SVE BFSCALE instruction

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4164,7 +4164,7 @@ defm BFMAX_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fmax>;
 } // HasSVEB16B16, UseExperimentalZeroingPseudos
 
 let Predicates = [HasSVEBFSCALE] in {
-  def BFSCALE_ZPZZ : sve_fp_2op_p_zds_bfscale<0b1001, "bfscale", DestructiveBinaryComm>;
+  def BFSCALE_ZPZZ : sve_fp_2op_p_zds_bfscale<0b1001, "bfscale", DestructiveBinary>;
 } // HasSVEBFSCALE
 //===----------------------------------------------------------------------===//
 // SME2.1 or SVE2.1 instructions

--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4163,7 +4163,9 @@ defm BFMIN_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fmin>;
 defm BFMAX_ZPZZ   : sve_fp_2op_p_zds_zeroing_bfloat<int_aarch64_sve_fmax>;
 } // HasSVEB16B16, UseExperimentalZeroingPseudos
 
-
+let Predicates = [HasSVEBFSCALE] in {
+  def BFSCALE_ZPZZ : sve_fp_2op_p_zds_bfscale<0b1001, "bfscale", DestructiveBinaryComm>;
+} // HasSVEBFSCALE
 //===----------------------------------------------------------------------===//
 // SME2.1 or SVE2.1 instructions
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -2174,6 +2174,10 @@ multiclass sve_fp_2op_p_zds_bfloat<bits<4> opc, string asm, string Ps,
   def : SVE_3_Op_Pat<nxv8bf16, op, nxv8i1, nxv8bf16, nxv8bf16, !cast<Instruction>(NAME)>;
 }
 
+class  sve_fp_2op_p_zds_bfscale<bits<4> opc, string asm,  DestructiveInstTypeEnum flags> : sve_fp_2op_p_zds<0b00, opc, asm, ZPR16>{
+    let DestructiveInstType = flags;
+  }
+
 multiclass sve_fp_2op_p_zds_zeroing_hsd<SDPatternOperator op> {
   def _H_ZERO : PredTwoOpPseudo<NAME # _H, ZPR16, FalseLanesZero>;
   def _S_ZERO : PredTwoOpPseudo<NAME # _S, ZPR32, FalseLanesZero>;

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -2174,9 +2174,10 @@ multiclass sve_fp_2op_p_zds_bfloat<bits<4> opc, string asm, string Ps,
   def : SVE_3_Op_Pat<nxv8bf16, op, nxv8i1, nxv8bf16, nxv8bf16, !cast<Instruction>(NAME)>;
 }
 
-class  sve_fp_2op_p_zds_bfscale<bits<4> opc, string asm,  DestructiveInstTypeEnum flags> : sve_fp_2op_p_zds<0b00, opc, asm, ZPR16>{
-    let DestructiveInstType = flags;
-  }
+class  sve_fp_2op_p_zds_bfscale<bits<4> opc, string asm,  DestructiveInstTypeEnum flags>
+: sve_fp_2op_p_zds<0b00, opc, asm, ZPR16>{
+  let DestructiveInstType = flags;
+}
 
 multiclass sve_fp_2op_p_zds_zeroing_hsd<SDPatternOperator op> {
   def _H_ZERO : PredTwoOpPseudo<NAME # _H, ZPR16, FalseLanesZero>;

--- a/llvm/test/MC/AArch64/SVE2/bfscale-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE2/bfscale-diagnostics.s
@@ -34,3 +34,10 @@ bfscale z31.h, p7/m, z20.h, z31.h
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: operand must match destination register
 // CHECK-NEXT: bfscale z31.h, p7/m, z20.h, z31.h
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// ------------------------------------------------------------------------- //
+// Using zeroing predicate
+bfscale z0.h, p0/z, z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bfscale z0.h, p0/z, z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE2/bfscale-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE2/bfscale-diagnostics.s
@@ -1,0 +1,36 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve-bfscale  2>&1 < %s| FileCheck %s
+
+
+// ------------------------------------------------------------------------- //
+// Invalid element width
+
+bfscale z31.h, p7/m, z31.h, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bfscale z31.h, p7/m, z31.h, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bfscale z31.h, p7/m, z31.b, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bfscale z31.h, p7/m, z31.b, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bfscale z31.d, p7/m, z31.h, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bfscale z31.d, p7/m, z31.h, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// ------------------------------------------------------------------------- //
+// Predicate register out of range
+
+bfscale z31.h, p8/m, z31.h, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid restricted predicate register, expected p0..p7 (without element suffix)
+// CHECK-NEXT: bfscale z31.h, p8/m, z31.h, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// ------------------------------------------------------------------------- //
+// Destination and source register don't match
+
+bfscale z31.h, p7/m, z20.h, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: operand must match destination register
+// CHECK-NEXT: bfscale z31.h, p7/m, z20.h, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE2/bfscale.s
+++ b/llvm/test/MC/AArch64/SVE2/bfscale.s
@@ -1,0 +1,50 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve,+sve-bfscale < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve,+sve-bfscale < %s \
+// RUN:        | llvm-objdump -d --mattr=+sve,+sve-bfscale - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve,+sve-bfscale < %s \
+// RUN:        | llvm-objdump -d --mattr=-sve-bfscale - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve,+sve-bfscale < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sve,+sve-bfscale -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+bfscale z0.h, p0/m, z0.h, z0.h  // 01100101-00001001-10000000-00000000
+// CHECK-INST: bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK-ENCODING: [0x00,0x80,0x09,0x65]
+// CHECK-ERROR: instruction requires: sve-bfscale
+// CHECK-UNKNOWN: 65098000 <unknown>
+
+bfscale z21.h, p5/m, z21.h, z10.h  // 01100101-00001001-10010101-01010101
+// CHECK-INST: bfscale z21.h, p5/m, z21.h, z10.h
+// CHECK-ENCODING: [0x55,0x95,0x09,0x65]
+// CHECK-ERROR: instruction requires: sve-bfscale
+// CHECK-UNKNOWN: 65099555 <unknown>
+
+bfscale z31.h, p7/m, z31.h, z31.h  // 01100101-00001001-10011111-11111111
+// CHECK-INST: bfscale z31.h, p7/m, z31.h, z31.h
+// CHECK-ENCODING: [0xff,0x9f,0x09,0x65]
+// CHECK-ERROR: instruction requires: sve-bfscale
+// CHECK-UNKNOWN: 65099fff <unknown>
+
+// --------------------------------------------------------------------------//
+// Test compatibility with MOVPRFX instruction.
+
+movprfx  z23.h, p3/m, z31.h
+bfscale z23.h, p3/m, z23.h, z13.h  // 01100101-00001001-10001101-10110111
+// CHECK-INST:  movprfx  z23.h, p3/m, z31.h
+// CHECK-INST: bfscale z23.h, p3/m, z23.h, z13.h
+// CHECK-ENCODING: [0xb7,0x8d,0x09,0x65]
+// CHECK-ERROR: instruction requires: sve-bfscale
+// CHECK-UNKNOWN: 65098db7 <unknown>
+
+movprfx z23, z31
+bfscale z23.h, p3/m, z23.h, z13.h  // 01100101-00001001-10001101-10110111
+// CHECK-INST:  movprfx z23, z31
+// CHECK-INST: bfscale z23.h, p3/m, z23.h, z13.h
+// CHECK-ENCODING: [0xb7,0x8d,0x09,0x65]
+// CHECK-ERROR: instruction requires: sve-bfscale
+// CHECK-UNKNOWN: 65098db7 <unknown>

--- a/llvm/test/MC/AArch64/SVE2/directive-arch-negative.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-arch-negative.s
@@ -29,3 +29,9 @@ rax1 z0.d, z0.d, z0.d
 bgrp z21.s, z10.s, z21.s
 // CHECK: error: instruction requires: sve2-bitperm
 // CHECK-NEXT: bgrp z21.s, z10.s, z21.s
+
+.arch armv9-a+sve-bfscale
+.arch armv9-a+nosve-bfscale
+bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK: error: instruction requires: sve-bfscale
+// CHECK-NEXT: bfscale z0.h, p0/m, z0.h, z0.h

--- a/llvm/test/MC/AArch64/SVE2/directive-arch.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-arch.s
@@ -19,3 +19,7 @@ rax1 z0.d, z0.d, z0.d
 .arch armv9-a+sve2-bitperm
 bgrp z21.s, z10.s, z21.s
 // CHECK: bgrp z21.s, z10.s, z21.s
+
+.arch armv9-a+sve-bfscale
+bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK: bfscale z0.h, p0/m, z0.h, z0.h

--- a/llvm/test/MC/AArch64/SVE2/directive-arch_extension-negative.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-arch_extension-negative.s
@@ -29,3 +29,9 @@ rax1 z0.d, z0.d, z0.d
 bgrp z21.s, z10.s, z21.s
 // CHECK: error: instruction requires: sve2-bitperm
 // CHECK-NEXT: bgrp z21.s, z10.s, z21.s
+
+.arch_extension sve-bfscale
+.arch_extension nosve-bfscale
+bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK: error: instruction requires: sve-bfscale
+// CHECK-NEXT: bfscale z0.h, p0/m, z0.h, z0.h

--- a/llvm/test/MC/AArch64/SVE2/directive-arch_extension.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-arch_extension.s
@@ -19,3 +19,7 @@ rax1 z0.d, z0.d, z0.d
 .arch_extension sve2-bitperm
 bgrp z21.s, z10.s, z21.s
 // CHECK: bgrp z21.s, z10.s, z21.s
+
+.arch_extension sve-bfscale
+bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK: bfscale z0.h, p0/m, z0.h, z0.h

--- a/llvm/test/MC/AArch64/SVE2/directive-cpu-negative.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-cpu-negative.s
@@ -29,3 +29,9 @@ rax1 z0.d, z0.d, z0.d
 bgrp z21.s, z10.s, z21.s
 // CHECK: error: instruction requires: sve2-bitperm
 // CHECK-NEXT: bgrp z21.s, z10.s, z21.s
+
+.cpu generic+sve-bfscale
+.cpu generic+nosve-bfscale
+bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK: error: instruction requires: sve-bfscale
+// CHECK-NEXT: bfscale z0.h, p0/m, z0.h, z0.h

--- a/llvm/test/MC/AArch64/SVE2/directive-cpu.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-cpu.s
@@ -19,3 +19,8 @@ rax1 z0.d, z0.d, z0.d
 .cpu generic+sve2-bitperm
 bgrp z21.s, z10.s, z21.s
 // CHECK: bgrp z21.s, z10.s, z21.s
+
+.cpu generic+sve-bfscale
+bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK-d: error: instruction requires: sve-bfscale
+// CHECK: bfscale z0.h, p0/m, z0.h, z0.h

--- a/llvm/test/MC/AArch64/SVE2/directive-cpu.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-cpu.s
@@ -22,5 +22,4 @@ bgrp z21.s, z10.s, z21.s
 
 .cpu generic+sve-bfscale
 bfscale z0.h, p0/m, z0.h, z0.h
-// CHECK: error: instruction requires: sve-bfscale
-// CHECK-NEXT: bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK: bfscale z0.h, p0/m, z0.h, z0.h

--- a/llvm/test/MC/AArch64/SVE2/directive-cpu.s
+++ b/llvm/test/MC/AArch64/SVE2/directive-cpu.s
@@ -22,5 +22,5 @@ bgrp z21.s, z10.s, z21.s
 
 .cpu generic+sve-bfscale
 bfscale z0.h, p0/m, z0.h, z0.h
-// CHECK-d: error: instruction requires: sve-bfscale
-// CHECK: bfscale z0.h, p0/m, z0.h, z0.h
+// CHECK: error: instruction requires: sve-bfscale
+// CHECK-NEXT: bfscale z0.h, p0/m, z0.h, z0.h


### PR DESCRIPTION
This patch add assembly/disassembly and tests for sve bfscale instruction according to https://developer.arm.com/documentation/ddi0602 . 