### PR TITLE
[clang] Lifetimebound in assignment operator should work for non-gsl annotated types.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10188,7 +10188,7 @@ def warn_new_dangling_initializer_list : Warning<
   "will be destroyed at the end of the full-expression">,
   InGroup<DanglingInitializerList>;
 def warn_dangling_pointer_assignment : Warning<
-   "object backing the pointer %0 "
+   "object backing the %select{|pointer }0%1 "
    "will be destroyed at the end of the full-expression">,
    InGroup<DanglingAssignment>;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10188,7 +10188,7 @@ def warn_new_dangling_initializer_list : Warning<
   "will be destroyed at the end of the full-expression">,
   InGroup<DanglingInitializerList>;
 def warn_dangling_pointer_assignment : Warning<
-   "object backing the %select{|pointer }0%1 "
+   "object backing %select{|the pointer }0%1 "
    "will be destroyed at the end of the full-expression">,
    InGroup<DanglingAssignment>;
 

--- a/clang/test/SemaCXX/attr-lifetimebound.cpp
+++ b/clang/test/SemaCXX/attr-lifetimebound.cpp
@@ -330,8 +330,8 @@ struct StatusOr {
 };
 
 void test(StatusOr<FooView> foo1, StatusOr<NonAnnotatedFooView> foo2) {
-  foo1 = Foo(); // expected-warning {{object backing the pointer foo1 will be destroyed at the end}}
-  // No warning on non-gsl annotated types.
-  foo2 = NonAnnotatedFoo();
+  foo1 = Foo(); // expected-warning {{object backing the foo1 will be destroyed at the end}}
+  // This warning is triggered by the lifetimebound annotation, regardless of whether the class type is annotated with GSL.
+  foo2 = NonAnnotatedFoo(); // expected-warning {{object backing the foo2 will be destroyed at the end}}
 }
 } // namespace GH106372


### PR DESCRIPTION
This issue is identified during the discussion of [this comment](https://github.com/llvm/llvm-project/issues/112234#issuecomment-2426102198).

There will be no release note for this fix as it is a follow-up to [#106997](https://github.com/llvm/llvm-project/pull/106997).