### PR TITLE
[lld/Macho][test] Mark objc-category-merging-minimal.s as unsupported on Windows

### DIFF
--- a/lld/test/MachO/objc-category-merging-minimal.s
+++ b/lld/test/MachO/objc-category-merging-minimal.s
@@ -1,4 +1,7 @@
 # REQUIRES: aarch64
+# UNSUPPORTED: system-windows
+#   due to awk usage
+
 # RUN: rm -rf %t; split-file %s %t && cd %t
 
 ############ Test merging multiple categories into a single category ############


### PR DESCRIPTION
With #112981, the test uses awk, which gnuwin32 doesn't seem to have.