### PR TITLE
[flang] Support -mabi=vec-extabi and -mabi=vec-default on AIX

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4662,7 +4662,8 @@ def malign_loops_EQ : Joined<["-"], "malign-loops=">, Group<clang_ignored_m_Grou
 def malign_jumps_EQ : Joined<["-"], "malign-jumps=">, Group<clang_ignored_m_Group>;
 
 let Flags = [TargetSpecific] in {
-def mabi_EQ : Joined<["-"], "mabi=">, Group<m_Group>;
+def mabi_EQ : Joined<["-"], "mabi=">, Group<m_Group>,
+  Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
 def malign_branch_EQ : CommaJoined<["-"], "malign-branch=">, Group<m_Group>,
   HelpText<"Specify types of branches to align">;
 def malign_branch_boundary_EQ : Joined<["-"], "malign-branch-boundary=">, Group<m_Group>,
@@ -7326,6 +7327,7 @@ def mabi_EQ_ieeelongdouble : Flag<["-"], "mabi=ieeelongdouble">,
   HelpText<"Use IEEE 754 quadruple-precision for long double">,
   MarshallingInfoFlag<LangOpts<"PPCIEEELongDouble">>;
 def mabi_EQ_vec_extabi : Flag<["-"], "mabi=vec-extabi">,
+  Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   HelpText<"Enable the extended Altivec ABI on AIX. Use volatile and nonvolatile vector registers">,
   MarshallingInfoFlag<LangOpts<"EnableAIXExtendedAltivecABI">>;
 def mfloat_abi : Separate<["-"], "mfloat-abi">,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -210,14 +210,13 @@ void Flang::AddPPCTargetArgs(const ArgList &Args,
 
   if (const Arg *A = Args.getLastArg(options::OPT_mabi_EQ)) {
     StringRef V = A->getValue();
-    if (V == "vec-extabi") {
+    if (V == "vec-extabi")
       VecExtabi = true;
-    } else if (V == "vec-default") {
+    else if (V == "vec-default")
       VecExtabi = false;
-    } else {
+    else
       D.Diag(diag::err_drv_unsupported_option_argument)
           << A->getSpelling() << V;
-    }
   }
 
   const llvm::Triple &T = getToolChain().getTriple();

--- a/clang/lib/Driver/ToolChains/Flang.h
+++ b/clang/lib/Driver/ToolChains/Flang.h
@@ -84,6 +84,13 @@ private:
   void AddX86_64TargetArgs(const llvm::opt::ArgList &Args,
                            llvm::opt::ArgStringList &CmdArgs) const;
 
+  /// Add specific options for PPC target.
+  ///
+  /// \param [in] Args The list of input driver arguments
+  /// \param [out] CmdArgs The list of output command arguments
+  void AddPPCTargetArgs(const llvm::opt::ArgList &Args,
+                        llvm::opt::ArgStringList &CmdArgs) const;
+
   /// Extract offload options from the driver arguments and add them to
   /// the command arguments.
   /// \param [in] C The current compilation for the driver invocation

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -44,6 +44,9 @@ public:
 
   /// The integer KINDs disabled for this target
   std::vector<int> disabledIntegerKinds;
+
+  /// Extended Altivec ABI on AIX
+  bool EnableAIXExtendedAltivecABI;
 };
 
 } // end namespace Fortran::frontend

--- a/flang/lib/Frontend/CompilerInstance.cpp
+++ b/flang/lib/Frontend/CompilerInstance.cpp
@@ -313,7 +313,6 @@ bool CompilerInstance::setUpTargetMachine() {
         << error;
     return false;
   }
-
   // Create `TargetMachine`
   const auto &CGOpts = getInvocation().getCodeGenOpts();
   std::optional<llvm::CodeGenOptLevel> OptLevelOrNone =
@@ -322,9 +321,13 @@ bool CompilerInstance::setUpTargetMachine() {
   llvm::CodeGenOptLevel OptLevel = *OptLevelOrNone;
   std::string featuresStr = getTargetFeatures();
   std::optional<llvm::CodeModel::Model> cm = getCodeModel(CGOpts.CodeModel);
+
+  llvm::TargetOptions tOpts = llvm::TargetOptions();
+  tOpts.EnableAIXExtendedAltivecABI = targetOpts.EnableAIXExtendedAltivecABI;
+
   targetMachine.reset(theTarget->createTargetMachine(
       theTriple, /*CPU=*/targetOpts.cpu,
-      /*Features=*/featuresStr, llvm::TargetOptions(),
+      /*Features=*/featuresStr, /*Options=*/tOpts,
       /*Reloc::Model=*/CGOpts.getRelocationModel(),
       /*CodeModel::Model=*/cm, OptLevel));
   assert(targetMachine && "Failed to create TargetMachine");

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -457,6 +457,16 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
 
   if (args.hasArg(clang::driver::options::OPT_fdisable_integer_16))
     opts.disabledIntegerKinds.push_back(16);
+
+  if (const llvm::opt::Arg *a =
+          args.getLastArg(clang::driver::options::OPT_mabi_EQ)) {
+    llvm::StringRef V = a->getValue();
+    if (V == "vec-extabi") {
+      opts.EnableAIXExtendedAltivecABI = true;
+    } else if (V == "vec-default") {
+      opts.EnableAIXExtendedAltivecABI = false;
+    }
+  }
 }
 // Tweak the frontend configuration based on the frontend action
 static void setUpFrontendBasedOnAction(FrontendOptions &opts) {

--- a/flang/test/Driver/mabi.f90
+++ b/flang/test/Driver/mabi.f90
@@ -1,0 +1,13 @@
+! RUN: not %flang -### -c --target=powerpc64le-unknown-linux -mabi=vec-extabi %s 2>&1 | FileCheck --check-prefix=INVALID1 %s
+! RUN: not %flang -### -c --target=x86_64-unknown-linux -mabi=vec-extabi %s 2>&1 | FileCheck --check-prefix=INVALID2 %s
+! RUN: %flang -### -c -target powerpc-unknown-aix %s 2>&1 | FileCheck --implicit-check-not=vec-extabi %s
+! RUN: %flang -### -c -target powerpc-unknown-aix -mabi=vec-default %s 2>&1 | FileCheck --implicit-check-not=vec-extabi %s
+! RUN: %flang -### -c -target powerpc-unknown-aix -mabi=vec-extabi %s 2>&1 | FileCheck --check-prefix=EXTABI %s
+
+! INVALID1: error: unsupported option '-mabi=vec-extabi' for target '{{.*}}'
+! INVALID2: error: unsupported option '-mabi=' for target '{{.*}}'
+
+! EXTABI: "-fc1"
+! EXTABI-SAME: "-mabi=vec-extabi"
+
+

--- a/flang/test/Driver/mabi.f90
+++ b/flang/test/Driver/mabi.f90
@@ -1,11 +1,13 @@
 ! RUN: not %flang -### -c --target=powerpc64le-unknown-linux -mabi=vec-extabi %s 2>&1 | FileCheck --check-prefix=INVALID1 %s
 ! RUN: not %flang -### -c --target=x86_64-unknown-linux -mabi=vec-extabi %s 2>&1 | FileCheck --check-prefix=INVALID2 %s
+! RUN: not %flang -### -c --target=powerpc-unknown-aix -mabi=abc %s 2>&1 | FileCheck --check-prefix=INVALID3 %s
 ! RUN: %flang -### -c -target powerpc-unknown-aix %s 2>&1 | FileCheck --implicit-check-not=vec-extabi %s
 ! RUN: %flang -### -c -target powerpc-unknown-aix -mabi=vec-default %s 2>&1 | FileCheck --implicit-check-not=vec-extabi %s
 ! RUN: %flang -### -c -target powerpc-unknown-aix -mabi=vec-extabi %s 2>&1 | FileCheck --check-prefix=EXTABI %s
 
 ! INVALID1: error: unsupported option '-mabi=vec-extabi' for target '{{.*}}'
 ! INVALID2: error: unsupported option '-mabi=' for target '{{.*}}'
+! INVALID3: error: unsupported argument 'abc' to option '-mabi='
 
 ! EXTABI: "-fc1"
 ! EXTABI-SAME: "-mabi=vec-extabi"

--- a/flang/test/Driver/mabi.f90
+++ b/flang/test/Driver/mabi.f90
@@ -5,6 +5,8 @@
 ! RUN: %flang -### -c -target powerpc-unknown-aix -mabi=vec-default %s 2>&1 | FileCheck --implicit-check-not=vec-extabi %s
 ! RUN: %flang -### -c -target powerpc-unknown-aix -mabi=vec-extabi %s 2>&1 | FileCheck --check-prefix=EXTABI %s
 
+! REQUIRES: target=powerpc{{.*}}
+
 ! INVALID1: error: unsupported option '-mabi=vec-extabi' for target '{{.*}}'
 ! INVALID2: error: unsupported option '-mabi=' for target '{{.*}}'
 ! INVALID3: error: unsupported argument 'abc' to option '-mabi='


### PR DESCRIPTION
This option is to enable the AIX extended and default vector ABIs.