### PR TITLE
[bazel] Pass --build_runfile_links=false

### DIFF
--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -48,6 +48,13 @@ common --incompatible_disallow_empty_glob
 # TODO: Remove once we move to bazel 7.x
 build --experimental_cc_shared_library
 
+# Disabling runfiles links drastically increases performance in slow disk IO
+# situations Do not build runfile trees by default. If an execution strategy
+# relies on runfile symlink tree, the tree is created on-demand. See:
+# https://github.com/bazelbuild/bazel/issues/6627 and
+# https://github.com/bazelbuild/bazel/commit/03246077f948f2790a83520e7dccc2625650e6df
+build --build_runfile_links=false
+
 ###############################################################################
 # Options to select different strategies for linking potential dependent
 # libraries. The default leaves it disabled.


### PR DESCRIPTION
This improves performance of doing a `bazel test @llvm-project//...` a
lot because previously every lit test would have some symlink tree
configured for it.
