### PR TITLE
[gitattributes] Mark some llvm-rc inputs as requiring LF newlines

### DIFF
--- a/llvm/.gitattributes
+++ b/llvm/.gitattributes
@@ -25,6 +25,7 @@ test/tools/llvm-mca/X86/directives-handle-crlf.s text eol=crlf
 
 # These files must have LF line endings because the test requires exact matching
 test/Object/Inputs/*.tbd eol=lf
+test/tools/llvm-rc/Inputs/webpage*.html text eol=lf
 test/tools/llvm-strings/radix.test text eol=lf
 test/tools/llvm-tapi-diff/Inputs/*.tbd text eol=lf
 test/tools/split-file/basic.test text eol=lf

--- a/llvm/test/tools/llvm-rc/tag-html.test
+++ b/llvm/test/tools/llvm-rc/tag-html.test
@@ -1,7 +1,5 @@
 ; RUN: rm -rf %t && mkdir %t && cd %t
-; Remove `\r` in case Git on Windows decided to checkout with Windows newlines.
-; RUN: tr -d '\r' <%p/Inputs/webpage1.html > ./webpage1.html
-; RUN: tr -d '\r' <%p/Inputs/webpage2.html > ./webpage2.html
+; RUN: cp %p/Inputs/webpage*.html .
 ; RUN: llvm-rc -no-preprocess /FO %t/tag-html.res -- %p/Inputs/tag-html.rc
 ; RUN: llvm-readobj %t/tag-html.res | FileCheck %s --check-prefix HTML
 


### PR DESCRIPTION
These text files get embedded verbatim in llvm/test/tools/llvm-rc/tag-html.test, so their newlines form needs to match the expected form exactly.

This reverts commit 2fdf49db7562eadbe01b18f0d01a955cd41b94ea, as that change no longer should be necessary. (At the time, buildbots had checkouts with all files having CRLF, and those don't get updated even if the toplevel .gitattributes were reverted in e669bbbb7265a7d4d59bac2d3889194efa167ea8. Now those buildbots have gotten fresh checkouts with all files having the right line endings.)