### PR TITLE
[-Wunsafe-buffer-usage] Fix false negatives of missing 2-param span ctors in constructor initializers

### DIFF
--- a/clang/include/clang/Analysis/Analyses/UnsafeBufferUsage.h
+++ b/clang/include/clang/Analysis/Analyses/UnsafeBufferUsage.h
@@ -122,7 +122,12 @@ public:
                                     const Expr *UnsafeArg = nullptr) = 0;
 
   /// Invoked when an unsafe operation with a std container is found.
-  virtual void handleUnsafeOperationInContainer(const Stmt *Operation,
+  /// \param Invocation the `Stmt` that either is a direct call to the unsafe
+  /// span constructor or involves a direct call to it
+  /// \param UnsafeSpanCall the `Stmt` that refers to the direct call to the
+  /// unsafe span constructor
+  virtual void handleUnsafeOperationInContainer(const Stmt *Invocation,
+                                                const Stmt *UnsafeSpanCall,
                                                 bool IsRelatedToDecl,
                                                 ASTContext &Ctx) = 0;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12521,6 +12521,8 @@ def note_safe_buffer_usage_suggestions_disabled : Note<
 def warn_unsafe_buffer_usage_in_container : Warning<
   "the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information">,
   InGroup<UnsafeBufferUsageInContainer>, DefaultIgnore;
+def note_unsafe_buffer_usage_in_container : Note<
+  "the 'std::span' constructor call here">;
 #ifndef NDEBUG
 // Not a user-facing diagnostic. Useful for debugging false negatives in
 // -fsafe-buffer-usage-suggestions (i.e. lack of -Wunsafe-buffer-usage fixits).

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1282,7 +1282,8 @@ public:
   void handleUnsafeOperation(UnsafeBufferUsageHandler &Handler,
                              bool IsRelatedToDecl,
                              ASTContext &Ctx) const override {
-    Handler.handleUnsafeOperationInContainer(Invocation, Ctor, IsRelatedToDecl, Ctx);
+    Handler.handleUnsafeOperationInContainer(Invocation, Ctor, IsRelatedToDecl,
+                                             Ctx);
   }
   SourceLocation getSourceLoc() const override { return Ctor->getBeginLoc(); }
 

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2327,19 +2327,21 @@ public:
     }
   }
 
-  void handleUnsafeOperationInContainer(const Stmt *Operation,
+  void handleUnsafeOperationInContainer(const Stmt *Invocation,
+                                        const Stmt *UnsafeSpanCall,
                                         bool IsRelatedToDecl,
                                         ASTContext &Ctx) override {
     SourceLocation Loc;
     SourceRange Range;
     unsigned MsgParam = 0;
 
-    // This function only handles SpanTwoParamConstructorGadget so far, which
-    // always gives a CXXConstructExpr.
-    const auto *CtorExpr = cast<CXXConstructExpr>(Operation);
-    Loc = CtorExpr->getLocation();
-
-    S.Diag(Loc, diag::warn_unsafe_buffer_usage_in_container);
+    Loc = Invocation->getBeginLoc();
+    S.Diag(Loc, diag::warn_unsafe_buffer_usage_in_container)
+        << Invocation->getSourceRange();
+    if (Invocation != UnsafeSpanCall)
+      S.Diag(UnsafeSpanCall->getBeginLoc(),
+             diag::note_unsafe_buffer_usage_in_container)
+          << UnsafeSpanCall->getSourceRange();
     if (IsRelatedToDecl) {
       assert(!SuggestSuggestions &&
              "Variables blamed for unsafe buffer usage without suggestions!");


### PR DESCRIPTION
The analysis now searches for every descendant stmt of constructor initializers and recurses if the descendant is another constructor call.

(rdar://137999201)