### PR TITLE
[dsymutil] Provide an option to ignore object timestamp mismatches

### DIFF
--- a/llvm/docs/CommandGuide/dsymutil.rst
+++ b/llvm/docs/CommandGuide/dsymutil.rst
@@ -83,6 +83,10 @@ OPTIONS
  used in conjunction with ``--update`` option, this option will cause redundant
  accelerator tables to be removed.
 
+.. option:: --no-object-timestamp
+
+ Don't check timestamp for object files.
+
 .. option:: --no-odr
 
  Do not use ODR (One Definition Rule) for uniquing C++ types.

--- a/llvm/test/tools/dsymutil/X86/timestamp-mismatch.test
+++ b/llvm/test/tools/dsymutil/X86/timestamp-mismatch.test
@@ -3,10 +3,14 @@ RUN: cp %p/../Inputs/basic.macho.x86_64 %t/Inputs
 RUN: cp %p/../Inputs/basic1.macho.x86_64.o %t/Inputs
 RUN: cp %p/../Inputs/basic2.macho.x86_64.o %t/Inputs
 RUN: cp %p/../Inputs/basic3.macho.x86_64.o %t/Inputs
-RUN: dsymutil -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
+RUN: dsymutil -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --check-prefix=WARN
+RUN: dsymutil -no-object-timestamp -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --allow-empty --check-prefix=NOWARN
 
-RUN: dsymutil --linker parallel -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --check-prefix=WARN
+RUN: dsymutil --linker parallel -no-object-timestamp -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --allow-empty --check-prefix=NOWARN
 
-CHECK: warning: {{.*}}/Inputs/basic1.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})
-CHECK: warning: {{.*}}/Inputs/basic2.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})
-CHECK: warning: {{.*}}/Inputs/basic3.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})
+WARN: warning: {{.*}}/Inputs/basic1.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})
+WARN: warning: {{.*}}/Inputs/basic2.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})
+WARN: warning: {{.*}}/Inputs/basic3.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})
+
+NOWARN-NOT: warning: {{.*}}/Inputs/basic3.macho.x86_64.o: timestamp mismatch between object file ({{.*}}) and debug map ({{.*}})

--- a/llvm/test/tools/dsymutil/cmdline.test
+++ b/llvm/test/tools/dsymutil/cmdline.test
@@ -15,6 +15,7 @@ CHECK: -flat
 CHECK: -gen-reproducer
 CHECK: -help
 CHECK: -keep-function-for-static
+CHECK: -no-object-timestamp
 CHECK: -no-odr
 CHECK: -no-output
 CHECK: -no-swiftmodule-timestamp

--- a/llvm/tools/dsymutil/BinaryHolder.cpp
+++ b/llvm/tools/dsymutil/BinaryHolder.cpp
@@ -41,9 +41,13 @@ getMachOFatMemoryBuffers(StringRef Filename, MemoryBuffer &Mem,
   return Buffers;
 }
 
+BinaryHolder::BinaryHolder(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
+                           BinaryHolder::Options Opts)
+    : VFS(VFS), Opts(Opts) {}
+
 Error BinaryHolder::ArchiveEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
                                        StringRef Filename,
-                                       TimestampTy Timestamp, bool Verbose) {
+                                       TimestampTy Timestamp, Options Opts) {
   StringRef ArchiveFilename = getArchiveAndObjectName(Filename).first;
 
   // Try to load archive and force it to be memory mapped.
@@ -55,7 +59,7 @@ Error BinaryHolder::ArchiveEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
 
   MemBuffer = std::move(*ErrOrBuff);
 
-  if (Verbose)
+  if (Opts.Verbose)
     WithColor::note() << "loaded archive '" << ArchiveFilename << "'\n";
 
   // Load one or more archive buffers, depending on whether we're dealing with
@@ -88,7 +92,7 @@ Error BinaryHolder::ArchiveEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
 
 Error BinaryHolder::ObjectEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
                                       StringRef Filename, TimestampTy Timestamp,
-                                      bool Verbose) {
+                                      Options Opts) {
   // Try to load regular binary and force it to be memory mapped.
   auto ErrOrBuff = (Filename == "-")
                        ? MemoryBuffer::getSTDIN()
@@ -96,7 +100,7 @@ Error BinaryHolder::ObjectEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
   if (auto Err = ErrOrBuff.getError())
     return errorCodeToError(Err);
 
-  if (Filename != "-" && Timestamp != sys::TimePoint<>()) {
+  if (Opts.Warn && Filename != "-" && Timestamp != sys::TimePoint<>()) {
     llvm::ErrorOr<vfs::Status> Stat = VFS->status(Filename);
     if (!Stat)
       return errorCodeToError(Stat.getError());
@@ -110,7 +114,7 @@ Error BinaryHolder::ObjectEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
 
   MemBuffer = std::move(*ErrOrBuff);
 
-  if (Verbose)
+  if (Opts.Verbose)
     WithColor::note() << "loaded object.\n";
 
   // Load one or more object buffers, depending on whether we're dealing with a
@@ -164,7 +168,7 @@ BinaryHolder::ObjectEntry::getObject(const Triple &T) const {
 Expected<const BinaryHolder::ObjectEntry &>
 BinaryHolder::ArchiveEntry::getObjectEntry(StringRef Filename,
                                            TimestampTy Timestamp,
-                                           bool Verbose) {
+                                           Options Opts) {
   StringRef ArchiveFilename;
   StringRef ObjectFilename;
   std::tie(ArchiveFilename, ObjectFilename) = getArchiveAndObjectName(Filename);
@@ -192,7 +196,7 @@ BinaryHolder::ArchiveEntry::getObjectEntry(StringRef Filename,
           if (Timestamp != sys::TimePoint<>() &&
               Timestamp != std::chrono::time_point_cast<std::chrono::seconds>(
                                ModTimeOrErr.get())) {
-            if (Verbose)
+            if (Opts.Verbose)
               WithColor::warning()
                   << *NameOrErr
                   << ": timestamp mismatch between archive member ("
@@ -201,7 +205,7 @@ BinaryHolder::ArchiveEntry::getObjectEntry(StringRef Filename,
             continue;
           }
 
-          if (Verbose)
+          if (Opts.Verbose)
             WithColor::note() << "found member in archive.\n";
 
           auto ErrOrMem = Child.getMemoryBufferRef();
@@ -230,7 +234,7 @@ BinaryHolder::ArchiveEntry::getObjectEntry(StringRef Filename,
 
 Expected<const BinaryHolder::ObjectEntry &>
 BinaryHolder::getObjectEntry(StringRef Filename, TimestampTy Timestamp) {
-  if (Verbose)
+  if (Opts.Verbose)
     WithColor::note() << "trying to open '" << Filename << "'\n";
 
   // If this is an archive, we might have either the object or the archive
@@ -241,17 +245,17 @@ BinaryHolder::getObjectEntry(StringRef Filename, TimestampTy Timestamp) {
     ArchiveRefCounter[ArchiveFilename]++;
     if (ArchiveCache.count(ArchiveFilename)) {
       return ArchiveCache[ArchiveFilename]->getObjectEntry(Filename, Timestamp,
-                                                           Verbose);
+                                                           Opts);
     } else {
       auto AE = std::make_unique<ArchiveEntry>();
-      auto Err = AE->load(VFS, Filename, Timestamp, Verbose);
+      auto Err = AE->load(VFS, Filename, Timestamp, Opts);
       if (Err) {
         // Don't return the error here: maybe the file wasn't an archive.
         llvm::consumeError(std::move(Err));
       } else {
         ArchiveCache[ArchiveFilename] = std::move(AE);
-        return ArchiveCache[ArchiveFilename]->getObjectEntry(
-            Filename, Timestamp, Verbose);
+        return ArchiveCache[ArchiveFilename]->getObjectEntry(Filename,
+                                                             Timestamp, Opts);
       }
     }
   }
@@ -262,7 +266,7 @@ BinaryHolder::getObjectEntry(StringRef Filename, TimestampTy Timestamp) {
   ObjectRefCounter[Filename]++;
   if (!ObjectCache.count(Filename)) {
     auto OE = std::make_unique<ObjectEntry>();
-    auto Err = OE->load(VFS, Filename, Timestamp, Verbose);
+    auto Err = OE->load(VFS, Filename, Timestamp, Opts);
     if (Err)
       return std::move(Err);
     ObjectCache[Filename] = std::move(OE);
@@ -279,7 +283,7 @@ void BinaryHolder::clear() {
 }
 
 void BinaryHolder::eraseObjectEntry(StringRef Filename) {
-  if (Verbose)
+  if (Opts.Verbose)
     WithColor::note() << "erasing '" << Filename << "' from cache\n";
 
   if (isArchive(Filename)) {

--- a/llvm/tools/dsymutil/BinaryHolder.h
+++ b/llvm/tools/dsymutil/BinaryHolder.h
@@ -38,8 +38,15 @@ class BinaryHolder {
 public:
   using TimestampTy = sys::TimePoint<std::chrono::seconds>;
 
-  BinaryHolder(IntrusiveRefCntPtr<vfs::FileSystem> VFS, bool Verbose = false)
-      : VFS(VFS), Verbose(Verbose) {}
+  struct Options {
+    Options(bool Verbose = false, bool Warn = true)
+        : Verbose(Verbose), Warn(Warn) {}
+    bool Verbose;
+    bool Warn;
+  };
+
+  BinaryHolder(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
+               BinaryHolder::Options Opts = {});
 
   // Forward declarations for friend declaration.
   class ObjectEntry;
@@ -58,7 +65,7 @@ public:
   public:
     /// Load the given object binary in memory.
     Error load(IntrusiveRefCntPtr<vfs::FileSystem> VFS, StringRef Filename,
-               TimestampTy Timestamp, bool Verbose = false);
+               TimestampTy Timestamp, BinaryHolder::Options = {});
 
     /// Access all owned ObjectFiles.
     std::vector<const object::ObjectFile *> getObjects() const;
@@ -110,11 +117,11 @@ public:
 
     /// Load the given object binary in memory.
     Error load(IntrusiveRefCntPtr<vfs::FileSystem> VFS, StringRef Filename,
-               TimestampTy Timestamp, bool Verbose = false);
+               TimestampTy Timestamp, BinaryHolder::Options = {});
 
     Expected<const ObjectEntry &> getObjectEntry(StringRef Filename,
                                                  TimestampTy Timestamp,
-                                                 bool Verbose = false);
+                                                 BinaryHolder::Options = {});
 
   private:
     std::vector<std::unique_ptr<object::Archive>> Archives;
@@ -143,7 +150,7 @@ private:
   /// Virtual File System instance.
   IntrusiveRefCntPtr<vfs::FileSystem> VFS;
 
-  bool Verbose;
+  Options Opts;
 };
 
 } // namespace dsymutil

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -65,6 +65,10 @@ def no_swiftmodule_timestamp: F<"no-swiftmodule-timestamp">,
   HelpText<"Don't check timestamp for swiftmodule files.">,
   Group<grp_general>;
 
+def no_object_timestamp: F<"no-object-timestamp">,
+  HelpText<"Don't check timestamp for object files.">,
+  Group<grp_general>;
+
 def no_odr: F<"no-odr">,
   HelpText<"Do not use ODR (One Definition Rule) for type uniquing.">,
   Group<grp_general>;

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -108,6 +108,7 @@ struct DsymutilOptions {
   bool Flat = false;
   bool InputIsYAMLDebugMap = false;
   bool ForceKeepFunctionForStatic = false;
+  bool NoObjectTimestamp = false;
   std::string OutputFile;
   std::string Toolchain;
   std::string ReproducerPath;
@@ -292,6 +293,7 @@ static Expected<DsymutilOptions> getOptions(opt::InputArgList &Args) {
   Options.DumpStab = Args.hasArg(OPT_symtab);
   Options.Flat = Args.hasArg(OPT_flat);
   Options.InputIsYAMLDebugMap = Args.hasArg(OPT_yaml_input);
+  Options.NoObjectTimestamp = Args.hasArg(OPT_no_object_timestamp);
 
   if (Expected<DWARFVerify> Verify = getVerifyKind(Args)) {
     Options.Verify = *Verify;
@@ -664,7 +666,10 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
 
   for (auto &InputFile : Options.InputFiles) {
     // Shared a single binary holder for all the link steps.
-    BinaryHolder BinHolder(Options.LinkOpts.VFS, Options.LinkOpts.Verbose);
+    BinaryHolder::Options BinOpts;
+    BinOpts.Verbose = Options.LinkOpts.Verbose;
+    BinOpts.Warn = !Options.NoObjectTimestamp;
+    BinaryHolder BinHolder(Options.LinkOpts.VFS, BinOpts);
 
     // Dump the symbol table for each input file and requested arch
     if (Options.DumpStab) {


### PR DESCRIPTION
Provide a option (--no-object-timestamp) to ignore object file timestamp
mismatches. We already have a similar option for Swift modules
(--no-swiftmodule-timestamp).

rdar://123975869

Depends on #113234