### PR TITLE
[llvm][AsmPrinter] Add an option to print instruction latencies

### DIFF
--- a/llvm/include/llvm/MC/MCSchedule.h
+++ b/llvm/include/llvm/MC/MCSchedule.h
@@ -14,9 +14,11 @@
 #ifndef LLVM_MC_MCSCHEDULE_H
 #define LLVM_MC_MCSCHEDULE_H
 
-#include "llvm/Config/llvm-config.h"
-#include "llvm/Support/DataTypes.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cassert>
+#include <optional>
 
 namespace llvm {
 
@@ -25,6 +27,7 @@ struct InstrItinerary;
 class MCSubtargetInfo;
 class MCInstrInfo;
 class MCInst;
+class MCInstrDesc;
 class InstrItineraryData;
 
 /// Define a kind of processor resource that will be modeled by the scheduler.
@@ -369,8 +372,14 @@ struct MCSchedModel {
                                  const MCSchedClassDesc &SCDesc);
 
   int computeInstrLatency(const MCSubtargetInfo &STI, unsigned SClass) const;
+
   int computeInstrLatency(const MCSubtargetInfo &STI, const MCInstrInfo &MCII,
                           const MCInst &Inst) const;
+
+  template <typename MCSubtargetInfo, typename MCInstrInfo,
+            typename InstrItineraryData, typename MCInstOrMachineInstr>
+  int computeInstrLatency(const MCSubtargetInfo &STI, const MCInstrInfo &MCII,
+                          const MCInstOrMachineInstr &Inst) const;
 
   // Returns the reciprocal throughput information from a MCSchedClassDesc.
   static double
@@ -392,6 +401,65 @@ struct MCSchedModel {
   /// Returns the default initialized model.
   static const MCSchedModel Default;
 };
+
+// The first three are only template'd arguments so we can get away with leaving
+// them as incomplete types below. The third is a template over
+// MCInst/MachineInstr so as to avoid a layering violation here that would make
+// the MC layer depend on CodeGen.
+template <typename MCSubtargetInfo, typename MCInstrInfo,
+          typename InstrItineraryData, typename MCInstOrMachineInstr>
+int MCSchedModel::computeInstrLatency(const MCSubtargetInfo &STI,
+                                      const MCInstrInfo &MCII,
+                                      const MCInstOrMachineInstr &Inst) const {
+  static const int NoInformationAvailable = -1;
+  // Check if we have a scheduling model for instructions.
+  if (!hasInstrSchedModel()) {
+    // Try to fall back to the itinerary model if the scheduling model doesn't
+    // have a scheduling table.  Note the default does not have a table.
+
+    llvm::StringRef CPU = STI.getCPU();
+
+    // Check if we have a CPU to get the itinerary information.
+    if (CPU.empty())
+      return NoInformationAvailable;
+
+    // Get itinerary information.
+    InstrItineraryData IID = STI.getInstrItineraryForCPU(CPU);
+    // Get the scheduling class of the requested instruction.
+    const MCInstrDesc &Desc = MCII.get(Inst.getOpcode());
+    unsigned SCClass = Desc.getSchedClass();
+
+    unsigned Latency = 0;
+
+    for (unsigned Idx = 0, IdxEnd = Inst.getNumOperands(); Idx != IdxEnd; ++Idx)
+      if (std::optional<unsigned> OperCycle = IID.getOperandCycle(SCClass, Idx))
+        Latency = std::max(Latency, *OperCycle);
+
+    return int(Latency);
+  }
+
+  unsigned SchedClass = MCII.get(Inst.getOpcode()).getSchedClass();
+  const MCSchedClassDesc *SCDesc = getSchedClassDesc(SchedClass);
+  if (!SCDesc->isValid())
+    return 0;
+
+  if constexpr (std::is_same_v<MCInstOrMachineInstr, MCInst>) {
+    unsigned CPUID = getProcessorID();
+    while (SCDesc->isVariant()) {
+      SchedClass =
+          STI.resolveVariantSchedClass(SchedClass, &Inst, &MCII, CPUID);
+      SCDesc = getSchedClassDesc(SchedClass);
+    }
+
+    if (SchedClass)
+      return MCSchedModel::computeInstrLatency(STI, *SCDesc);
+
+    llvm_unreachable("unsupported variant scheduling class");
+  } else if (SchedClass)
+    return MCSchedModel::computeInstrLatency(STI, SchedClass);
+
+  return NoInformationAvailable;
+}
 
 } // namespace llvm
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -171,7 +171,7 @@ static cl::opt<bool> EmitJumpTableSizesSection(
 // not completely accurate, and we don't want to be misleading.
 static cl::opt<bool> PrintLatency(
     "asm-print-latency",
-    cl::desc("Print instruction latencies as verbose asm comments."),
+    cl::desc("Print instruction latencies as verbose asm comments"),
     cl::Hidden, cl::init(false));
 
 STATISTIC(EmittedInsts, "Number of machine instrs printed");

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1096,8 +1096,8 @@ void AsmPrinter::emitFunctionEntryLabel() {
 /// \return The maximum expected latency over all the operands or -1
 /// if no information is available.
 static std::optional<int> getItineraryLatency(const MachineInstr &MI,
-                               const MachineFunction *MF,
-                               const MCSubtargetInfo *STI) {
+                                              const MachineFunction *MF,
+                                              const MCSubtargetInfo *STI) {
   const TargetInstrInfo *TII = MF->getSubtarget().getInstrInfo();
 
   // Check if we have a CPU to get the itinerary information.
@@ -1122,7 +1122,8 @@ static std::optional<int> getItineraryLatency(const MachineInstr &MI,
 /// Gets latency information for \p Inst.
 /// \return The maximum expected latency over all the definitions or -1
 /// if no information is available.
-static std::optional<int> getLatency(const MachineInstr &MI, const MCSubtargetInfo *STI) {
+static std::optional<int> getLatency(const MachineInstr &MI,
+                                     const MCSubtargetInfo *STI) {
   const MCSchedModel &SCModel = STI->getSchedModel();
 
   const MachineFunction *MF = MI.getMF();

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -171,8 +171,8 @@ static cl::opt<bool> EmitJumpTableSizesSection(
 // not completely accurate, and we don't want to be misleading.
 static cl::opt<bool> PrintLatency(
     "asm-print-latency",
-    cl::desc("Print instruction latencies as verbose asm comments"),
-    cl::Hidden, cl::init(false));
+    cl::desc("Print instruction latencies as verbose asm comments"), cl::Hidden,
+    cl::init(false));
 
 STATISTIC(EmittedInsts, "Number of machine instrs printed");
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1124,11 +1124,10 @@ static std::optional<int> getItineraryLatency(const MachineInstr &MI,
 /// if no information is available.
 static std::optional<int> getLatency(const MachineInstr &MI, const MCSubtargetInfo *STI) {
   const MCSchedModel &SCModel = STI->getSchedModel();
-  const int NoInformationAvailable = -1;
 
   const MachineFunction *MF = MI.getMF();
   if (!MF)
-    return NoInformationAvailable;
+    return std::nullopt;
 
   // Check if we have a scheduling model for instructions.
   if (!SCModel.hasInstrSchedModel())
@@ -1142,7 +1141,7 @@ static std::optional<int> getLatency(const MachineInstr &MI, const MCSubtargetIn
   unsigned SCClass = Desc.getSchedClass();
   int Latency = SCModel.computeInstrLatency(*STI, SCClass);
   if (Latency <= 0)
-    return NoInformationAvailable;
+    return std::nullopt;
   return Latency;
 }
 

--- a/llvm/lib/MC/MCDisassembler/Disassembler.cpp
+++ b/llvm/lib/MC/MCDisassembler/Disassembler.cpp
@@ -195,7 +195,7 @@ static int getItineraryLatency(LLVMDisasmContext *DC, const MCInst &Inst) {
 static int getLatency(LLVMDisasmContext *DC, const MCInst &Inst) {
   // Try to compute scheduling information.
   const MCSubtargetInfo *STI = DC->getSubtargetInfo();
-  const MCSchedModel SCModel = STI->getSchedModel();
+  const MCSchedModel &SCModel = STI->getSchedModel();
   const int NoInformationAvailable = -1;
 
   // Check if we have a scheduling model for instructions.

--- a/llvm/lib/MC/MCDisassembler/Disassembler.cpp
+++ b/llvm/lib/MC/MCDisassembler/Disassembler.cpp
@@ -166,7 +166,7 @@ static void emitComments(LLVMDisasmContext *DC,
 /// on the information available in \p DC.
 static void emitLatency(LLVMDisasmContext *DC, const MCInst &Inst) {
   const MCSubtargetInfo *STI = DC->getSubtargetInfo();
-  const MCInstrInfo *MCII =  DC->getInstrInfo();
+  const MCInstrInfo *MCII = DC->getInstrInfo();
   const MCSchedModel &SCModel = STI->getSchedModel();
   int Latency = SCModel.computeInstrLatency(*STI, *MCII, Inst);
 

--- a/llvm/lib/MC/MCSchedule.cpp
+++ b/llvm/lib/MC/MCSchedule.cpp
@@ -66,59 +66,12 @@ int MCSchedModel::computeInstrLatency(const MCSubtargetInfo &STI,
   llvm_unreachable("unsupported variant scheduling class");
 }
 
-/// Gets latency information for \p Inst from the itinerary
-/// scheduling model.
-/// \return The maximum expected latency over all the operands or -1
-/// if no information is available.
-static int getItineraryLatency(const MCSubtargetInfo &STI,
-                               const MCInstrInfo &MCII, const MCInst &Inst) {
-  static const int NoInformationAvailable = -1;
-
-  llvm::StringRef CPU = STI.getCPU();
-
-  // Check if we have a CPU to get the itinerary information.
-  if (CPU.empty())
-    return NoInformationAvailable;
-
-  // Get itinerary information.
-  InstrItineraryData IID = STI.getInstrItineraryForCPU(CPU);
-  // Get the scheduling class of the requested instruction.
-  const MCInstrDesc &Desc = MCII.get(Inst.getOpcode());
-  unsigned SCClass = Desc.getSchedClass();
-
-  unsigned Latency = 0;
-
-  for (unsigned Idx = 0, IdxEnd = Inst.getNumOperands(); Idx != IdxEnd; ++Idx)
-    if (std::optional<unsigned> OperCycle = IID.getOperandCycle(SCClass, Idx))
-      Latency = std::max(Latency, *OperCycle);
-
-  return int(Latency);
-}
-
 int MCSchedModel::computeInstrLatency(const MCSubtargetInfo &STI,
                                       const MCInstrInfo &MCII,
                                       const MCInst &Inst) const {
-  // Check if we have a scheduling model for instructions.
-  if (!hasInstrSchedModel())
-    // Try to fall back to the itinerary model if the scheduling model doesn't
-    // have a scheduling table.  Note the default does not have a table.
-    return getItineraryLatency(STI, MCII, Inst);
-
-  unsigned SchedClass = MCII.get(Inst.getOpcode()).getSchedClass();
-  const MCSchedClassDesc *SCDesc = getSchedClassDesc(SchedClass);
-  if (!SCDesc->isValid())
-    return 0;
-
-  unsigned CPUID = getProcessorID();
-  while (SCDesc->isVariant()) {
-    SchedClass = STI.resolveVariantSchedClass(SchedClass, &Inst, &MCII, CPUID);
-    SCDesc = getSchedClassDesc(SchedClass);
-  }
-
-  if (SchedClass)
-    return MCSchedModel::computeInstrLatency(STI, *SCDesc);
-
-  llvm_unreachable("unsupported variant scheduling class");
+  return MCSchedModel::computeInstrLatency<MCSubtargetInfo, MCInstrInfo,
+                                           InstrItineraryData, MCInst>(
+      STI, MCII, Inst);
 }
 
 double

--- a/llvm/test/CodeGen/AArch64/latency.ll
+++ b/llvm/test/CodeGen/AArch64/latency.ll
@@ -1,0 +1,10 @@
+; RUN: llc -mtriple=arm64-apple-ios %s -o - -mcpu=cyclone -asm-print-latency=1 | FileCheck %s --match-full-lines --check-prefix=ON
+; RUN: llc -mtriple=arm64-apple-ios %s -o - -mcpu=cyclone -asm-print-latency=0 | FileCheck %s --match-full-lines --check-prefix=OFF
+; RUN: llc -mtriple=arm64-apple-ios %s -o - -mcpu=cyclone                      | FileCheck %s --match-full-lines --check-prefix=OFF
+
+define <4 x i64> @load_v4i64(ptr %ptr){
+; ON:     ldp q0, q1, [x0] ; Latency: 4
+; OFF:    ldp q0, q1, [x0]
+  %a = load <4 x i64>, ptr %ptr
+  ret <4 x i64> %a
+}

--- a/llvm/test/CodeGen/ARM/latency.ll
+++ b/llvm/test/CodeGen/ARM/latency.ll
@@ -1,0 +1,16 @@
+; RUN: llc -mtriple=thumb-none-eabi %s -o - -mcpu=cortex-m0 -asm-print-latency=1 | FileCheck %s --match-full-lines --check-prefix=ON
+; RUN: llc -mtriple=thumb-none-eabi %s -o - -mcpu=cortex-m0 -asm-print-latency=0 | FileCheck %s --match-full-lines --check-prefix=OFF
+; RUN: llc -mtriple=thumb-none-eabi %s -o - -mcpu=cortex-m0                      | FileCheck %s --match-full-lines --check-prefix=OFF
+
+define i64 @load_i64(ptr %ptr){
+; ON:   ldr     r2, [r0]                        @  Latency: 4
+; ON:   ldr     r1, [r0, #4]                    @  Latency: 4
+; ON:   mov     r0, r2                          @  Latency: 2
+; ON:   bx      lr
+; OFF:  ldr     r2, [r0]
+; OFF:  ldr     r1, [r0, #4]
+; OFF:  mov     r0, r2
+; OFf:  bx      lr
+  %a = load i64, ptr %ptr
+  ret i64 %a
+}


### PR DESCRIPTION
... matching what we have in the disassembler.  This isn't turned on by default since several of the scheduling models are not completely accurate, and we don't want to be misleading.