### PR TITLE
[lldb][test] Fix TestUseSourceCache for readonly source trees

### DIFF
--- a/lldb/test/API/commands/settings/use_source_cache/Makefile
+++ b/lldb/test/API/commands/settings/use_source_cache/Makefile
@@ -6,3 +6,6 @@ include Makefile.rules
 # Copy file into the build folder to enable the test to modify it.
 main-copy.cpp: main.cpp
 	cp -f $< $@
+ifneq "$(OS)" "Windows_NT"  # chmod is not available on Windows
+	chmod u+w $@
+endif

--- a/lldb/test/API/commands/settings/use_source_cache/Makefile
+++ b/lldb/test/API/commands/settings/use_source_cache/Makefile
@@ -6,6 +6,4 @@ include Makefile.rules
 # Copy file into the build folder to enable the test to modify it.
 main-copy.cpp: main.cpp
 	cp -f $< $@
-ifneq "$(OS)" "Windows_NT"  # chmod is not available on Windows
 	chmod u+w $@
-endif


### PR DESCRIPTION
TestUseSourceCache attempts to write to a build artifact copied from the source tree, and asserts the write succeeded. If the source tree is read only, the copy will also be read only, causing it to fail. When producing the build artifact, ensure that it is writable.