### PR TITLE
[SystemZ][XRay] Enable XRay for SystemZ in clang

### DIFF
--- a/clang/lib/Driver/XRayArgs.cpp
+++ b/clang/lib/Driver/XRayArgs.cpp
@@ -53,6 +53,7 @@ XRayArgs::XRayArgs(const ToolChain &TC, const ArgList &Args) {
     case llvm::Triple::mipsel:
     case llvm::Triple::mips64:
     case llvm::Triple::mips64el:
+    case llvm::Triple::systemz:
       break;
     default:
       D.Diag(diag::err_drv_unsupported_opt_for_target)

--- a/clang/test/Driver/XRay/xray-mode-flags.cpp
+++ b/clang/test/Driver/XRay/xray-mode-flags.cpp
@@ -4,6 +4,8 @@
 // RUN:   | FileCheck --check-prefix=BASIC %s
 // RUN: %clang -### --target=aarch64-linux-gnu -fxray-instrument %s 2>&1 \
 // RUN:   | FileCheck --check-prefixes=FDR,BASIC %s
+// RUN: %clang -### --target=s390x-linux-gnu -fxray-instrument -fxray-modes=xray-basic %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=BASIC %s
 // RUN: %clang -### --target=x86_64-linux-gnu -fxray-instrument -fxray-modes=all %s 2>&1 \
 // RUN:   | FileCheck --check-prefixes=FDR,BASIC %s
 // RUN: %clang -### --target=x86_64-linux-gnu -fxray-instrument -fxray-modes=xray-fdr,xray-basic %s 2>&1 \


### PR DESCRIPTION
With the support for xray for SystemZ in place, the option can now be enabled in clang.