### PR TITLE
[clang-format] Handle C# `goto case` constructs

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1568,6 +1568,11 @@ void UnwrappedLineParser::parseStructuralElement(
     }
     parseCaseLabel();
     return;
+  case tok::kw_goto:
+    nextToken();
+    if (FormatTok->is(tok::kw_case))
+      nextToken();
+    break;
   case tok::kw_try:
   case tok::kw___try:
     if (Style.isJavaScript() && Line->MustBeDeclaration) {

--- a/clang/unittests/Format/FormatTestCSharp.cpp
+++ b/clang/unittests/Format/FormatTestCSharp.cpp
@@ -1689,15 +1689,25 @@ TEST_F(FormatTestCSharp, BrokenBrackets) {
 }
 
 TEST_F(FormatTestCSharp, GotoCaseLabel) {
-  verifyNoCrash("switch (i) {\n"
-                "case 0:\n"
-                "  goto case 1;\n"
-                "case 1:\n"
-                "  j = 0;\n"
-                "  {\n"
-                "    break;\n"
-                "  }\n"
-                "}");
+  verifyFormat("switch (i)\n"
+               "{\n"
+               "case 0:\n"
+               "    goto case 1;\n"
+               "case 1:\n"
+               "    j = 0;\n"
+               "    {\n"
+               "        break;\n"
+               "    }\n"
+               "}",
+               "switch (i) {\n"
+               "case 0:\n"
+               "  goto case 1;\n"
+               "case 1:\n"
+               "  j = 0;\n"
+               "  {\n"
+               "    break;\n"
+               "  }\n"
+               "}");
 }
 
 } // namespace


### PR DESCRIPTION
Fixes #113256.