### PR TITLE
[X86] combineAndNotOrIntoAndNotAnd - don't fold other constant operands

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -50049,8 +50049,9 @@ static SDValue combineAndNotOrIntoAndNotAnd(SDNode *N, SelectionDAG &DAG) {
   SDValue X, Y, Z;
   if (sd_match(N, m_And(m_Value(X),
                         m_OneUse(m_Or(m_Value(Y), m_Not(m_Value(Z))))))) {
-    // Don't fold if Y is a constant to prevent infinite loops.
-    if (!isa<ConstantSDNode>(Y))
+    // Don't fold if Y or Z are constants to prevent infinite loops.
+    if (!DAG.isConstantIntBuildVectorOrConstantInt(Y) &&
+        !DAG.isConstantIntBuildVectorOrConstantInt(Z))
       return DAG.getNode(
           ISD::AND, DL, VT, X,
           DAG.getNOT(

--- a/llvm/test/CodeGen/X86/pr108731.ll
+++ b/llvm/test/CodeGen/X86/pr108731.ll
@@ -192,3 +192,23 @@ define void @PR112347(ptr %p0, ptr %p1, ptr %p2) {
   ret void
 }
 
+define void @PR113240(i64 %a) {
+; CHECK-LABEL: PR113240:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    movq %rdi, %rax
+; CHECK-NEXT:    notq %rax
+; CHECK-NEXT:    movabsq $8796093022206, %rcx # imm = 0x7FFFFFFFFFE
+; CHECK-NEXT:    notq %rcx
+; CHECK-NEXT:    orq %rax, %rcx
+; CHECK-NEXT:    andq %rdi, %rcx
+; CHECK-NEXT:    movq %rcx, 0
+; CHECK-NEXT:    retq
+entry:
+  %and = and i64 %a, 8796093022206
+  %bf.value = and i64 8796093022206, 0
+  %not = xor i64 %and, -1
+  %and4 = and i64 %a, %not
+  store i64 %and4, ptr null, align 8
+  ret void
+}
+


### PR DESCRIPTION
Looks like having a constant in `Z` also caused infinite loops. This fixes #113240.