### PR TITLE
[clang][bytecode] Diagnose non-const initialiers in diagnoseUnknownDecl

### DIFF
--- a/clang/test/SemaCXX/c99-variable-length-array.cpp
+++ b/clang/test/SemaCXX/c99-variable-length-array.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -Wvla-extension %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wvla-extension %s -fexperimental-new-constant-interpreter
 struct NonPOD {
   NonPOD();
 };


### PR DESCRIPTION
This is more similar to the diagnostic output of the current interpreter