### PR TITLE
[lldb][NFC] Make the target's SectionLoadList private.

### DIFF
--- a/lldb/include/lldb/Target/SectionLoadHistory.h
+++ b/lldb/include/lldb/Target/SectionLoadHistory.h
@@ -45,7 +45,7 @@ public:
                                      const lldb::SectionSP &section_sp);
 
   bool ResolveLoadAddress(uint32_t stop_id, lldb::addr_t load_addr,
-                          Address &so_addr);
+                          Address &so_addr, bool allow_section_end = false);
 
   bool SetSectionLoadAddress(uint32_t stop_id,
                              const lldb::SectionSP &section_sp,

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1222,7 +1222,8 @@ public:
   bool ResolveFileAddress(lldb::addr_t load_addr, Address &so_addr);
 
   bool ResolveLoadAddress(lldb::addr_t load_addr, Address &so_addr,
-                          uint32_t stop_id = SectionLoadHistory::eStopIDNow);
+                          uint32_t stop_id = SectionLoadHistory::eStopIDNow,
+                          bool allow_section_end = false);
 
   bool SetSectionLoadAddress(const lldb::SectionSP &section,
                              lldb::addr_t load_addr,

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1151,9 +1151,14 @@ public:
                              Address &pointer_addr,
                              bool force_live_memory = false);
 
-  SectionLoadList &GetSectionLoadList() {
-    return m_section_load_history.GetCurrentSectionLoadList();
-  }
+
+  bool SectionLoadListIsEmpty() const;
+
+  lldb::addr_t GetSectionLoadAddress(const lldb::SectionSP &section_sp);
+
+  void ClearSectionLoadList();
+
+  void DumpSectionLoadList(Stream &s);
 
   static Target *GetTargetFromContexts(const ExecutionContext *exe_ctx_ptr,
                                        const SymbolContext *sc_ptr);
@@ -1666,6 +1671,10 @@ protected:
 
   Target(const Target &) = delete;
   const Target &operator=(const Target &) = delete;
+
+  SectionLoadList &GetSectionLoadList() {
+    return m_section_load_history.GetCurrentSectionLoadList();
+  }
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1151,8 +1151,7 @@ public:
                              Address &pointer_addr,
                              bool force_live_memory = false);
 
-
-  bool SectionLoadListIsEmpty() const;
+  bool HasLoadedSections();
 
   lldb::addr_t GetSectionLoadAddress(const lldb::SectionSP &section_sp);
 

--- a/lldb/source/API/SBBreakpoint.cpp
+++ b/lldb/source/API/SBBreakpoint.cpp
@@ -137,7 +137,7 @@ SBBreakpointLocation SBBreakpoint::FindLocationByAddress(addr_t vm_addr) {
           bkpt_sp->GetTarget().GetAPIMutex());
       Address address;
       Target &target = bkpt_sp->GetTarget();
-      if (!target.GetSectionLoadList().ResolveLoadAddress(vm_addr, address)) {
+      if (!target.ResolveLoadAddress(vm_addr, address)) {
         address.SetRawAddress(vm_addr);
       }
       sb_bp_location.SetLocation(bkpt_sp->FindLocationByAddress(address));
@@ -157,7 +157,7 @@ break_id_t SBBreakpoint::FindLocationIDByAddress(addr_t vm_addr) {
         bkpt_sp->GetTarget().GetAPIMutex());
     Address address;
     Target &target = bkpt_sp->GetTarget();
-    if (!target.GetSectionLoadList().ResolveLoadAddress(vm_addr, address)) {
+    if (!target.ResolveLoadAddress(vm_addr, address)) {
       address.SetRawAddress(vm_addr);
     }
     break_id = bkpt_sp->FindLocationIDByAddress(address);

--- a/lldb/source/Breakpoint/BreakpointLocationList.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocationList.cpp
@@ -103,8 +103,7 @@ BreakpointLocationList::FindByAddress(const Address &addr) const {
       so_addr = addr;
     } else {
       // Try and resolve as a load address if possible.
-      m_owner.GetTarget().GetSectionLoadList().ResolveLoadAddress(
-          addr.GetOffset(), so_addr);
+      m_owner.GetTarget().ResolveLoadAddress(addr.GetOffset(), so_addr);
       if (!so_addr.IsValid()) {
         // The address didn't resolve, so just set to passed in addr.
         so_addr = addr;

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -269,10 +269,10 @@ CommandObjectDisassemble::GetContainingAddressRanges() {
   };
 
   Target &target = GetTarget();
-  if (!target.GetSectionLoadList().IsEmpty()) {
+  if (!target.SectionLoadListIsEmpty()) {
     Address symbol_containing_address;
-    if (target.GetSectionLoadList().ResolveLoadAddress(
-            m_options.symbol_containing_addr, symbol_containing_address)) {
+    if (target.ResolveLoadAddress(m_options.symbol_containing_addr, 
+                                  symbol_containing_address)) {
       get_range(symbol_containing_address);
     }
   } else {

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -269,9 +269,9 @@ CommandObjectDisassemble::GetContainingAddressRanges() {
   };
 
   Target &target = GetTarget();
-  if (!target.SectionLoadListIsEmpty()) {
+  if (target.HasLoadedSections()) {
     Address symbol_containing_address;
-    if (target.ResolveLoadAddress(m_options.symbol_containing_addr, 
+    if (target.ResolveLoadAddress(m_options.symbol_containing_addr,
                                   symbol_containing_address)) {
       get_range(symbol_containing_address);
     }

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -95,7 +95,7 @@ public:
         addr_t reg_addr = reg_value.GetAsUInt64(LLDB_INVALID_ADDRESS);
         if (reg_addr != LLDB_INVALID_ADDRESS) {
           Address so_reg_addr;
-          if (exe_ctx.GetTargetRef().ResolveLoadAddress(reg_addr, 
+          if (exe_ctx.GetTargetRef().ResolveLoadAddress(reg_addr,
                                                         so_reg_addr)) {
             strm.PutCString("  ");
             so_reg_addr.Dump(&strm, exe_ctx.GetBestExecutionContextScope(),

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -95,8 +95,8 @@ public:
         addr_t reg_addr = reg_value.GetAsUInt64(LLDB_INVALID_ADDRESS);
         if (reg_addr != LLDB_INVALID_ADDRESS) {
           Address so_reg_addr;
-          if (exe_ctx.GetTargetRef().GetSectionLoadList().ResolveLoadAddress(
-                  reg_addr, so_reg_addr)) {
+          if (exe_ctx.GetTargetRef().ResolveLoadAddress(reg_addr, 
+                                                        so_reg_addr)) {
             strm.PutCString("  ");
             so_reg_addr.Dump(&strm, exe_ctx.GetBestExecutionContextScope(),
                              Address::DumpStyleResolvedDescription);

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -302,7 +302,7 @@ protected:
     size_t num_matches = 0;
     assert(module_list.GetSize() > 0);
     Target &target = GetTarget();
-    if (target.SectionLoadListIsEmpty()) {
+    if (!target.HasLoadedSections()) {
       // The target isn't loaded yet, we need to lookup the file address in all
       // modules.  Note: the module list option does not apply to addresses.
       const size_t num_modules = module_list.GetSize();
@@ -959,7 +959,7 @@ protected:
       StreamString error_strm;
       SymbolContextList sc_list;
 
-      if (target.SectionLoadListIsEmpty()) {
+      if (!target.HasLoadedSections()) {
         // The target isn't loaded yet, we need to lookup the file address in
         // all modules
         const ModuleList &module_list = target.GetImages();

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -302,7 +302,7 @@ protected:
     size_t num_matches = 0;
     assert(module_list.GetSize() > 0);
     Target &target = GetTarget();
-    if (target.GetSectionLoadList().IsEmpty()) {
+    if (target.SectionLoadListIsEmpty()) {
       // The target isn't loaded yet, we need to lookup the file address in all
       // modules.  Note: the module list option does not apply to addresses.
       const size_t num_modules = module_list.GetSize();
@@ -328,7 +328,7 @@ protected:
     } else {
       // The target has some things loaded, resolve this address to a compile
       // unit + file + line and display
-      if (target.GetSectionLoadList().ResolveLoadAddress(addr, so_addr)) {
+      if (target.ResolveLoadAddress(addr, so_addr)) {
         ModuleSP module_sp(so_addr.GetModule());
         // Check to make sure this module is in our list.
         if (module_sp && module_list.GetIndexForModule(module_sp.get()) !=
@@ -959,7 +959,7 @@ protected:
       StreamString error_strm;
       SymbolContextList sc_list;
 
-      if (target.GetSectionLoadList().IsEmpty()) {
+      if (target.SectionLoadListIsEmpty()) {
         // The target isn't loaded yet, we need to lookup the file address in
         // all modules
         const ModuleList &module_list = target.GetImages();
@@ -987,8 +987,7 @@ protected:
       } else {
         // The target has some things loaded, resolve this address to a compile
         // unit + file + line and display
-        if (target.GetSectionLoadList().ResolveLoadAddress(m_options.address,
-                                                           so_addr)) {
+        if (target.ResolveLoadAddress(m_options.address, so_addr)) {
           ModuleSP module_sp(so_addr.GetModule());
           if (module_sp) {
             SymbolContext sc;

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1522,7 +1522,7 @@ static bool LookupAddressInModule(CommandInterpreter &interpreter, Stream &strm,
     Address so_addr;
     SymbolContext sc;
     Target *target = interpreter.GetExecutionContext().GetTargetPtr();
-    if (target && !target->SectionLoadListIsEmpty()) {
+    if (target && target->HasLoadedSections()) {
       if (!target->ResolveLoadAddress(addr, so_addr))
         return false;
       else if (so_addr.GetModule().get() != module)
@@ -2974,7 +2974,7 @@ protected:
                               sect_name);
                           break;
                         } else {
-                          if (target.SetSectionLoadAddress(section_sp, 
+                          if (target.SetSectionLoadAddress(section_sp,
                                                            load_addr))
                             changed = true;
                           result.AppendMessageWithFormat(
@@ -3329,7 +3329,7 @@ protected:
           if (objfile) {
             Address base_addr(objfile->GetBaseAddress());
             if (base_addr.IsValid()) {
-              if (!target.SectionLoadListIsEmpty()) {
+              if (target.HasLoadedSections()) {
                 lldb::addr_t load_addr = base_addr.GetLoadAddress(&target);
                 if (load_addr == LLDB_INVALID_ADDRESS) {
                   base_addr.Dump(&strm, &target,

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1522,8 +1522,8 @@ static bool LookupAddressInModule(CommandInterpreter &interpreter, Stream &strm,
     Address so_addr;
     SymbolContext sc;
     Target *target = interpreter.GetExecutionContext().GetTargetPtr();
-    if (target && !target->GetSectionLoadList().IsEmpty()) {
-      if (!target->GetSectionLoadList().ResolveLoadAddress(addr, so_addr))
+    if (target && !target->SectionLoadListIsEmpty()) {
+      if (!target->ResolveLoadAddress(addr, so_addr))
         return false;
       else if (so_addr.GetModule().get() != module)
         return false;
@@ -2974,8 +2974,8 @@ protected:
                               sect_name);
                           break;
                         } else {
-                          if (target.GetSectionLoadList().SetSectionLoadAddress(
-                                  section_sp, load_addr))
+                          if (target.SetSectionLoadAddress(section_sp, 
+                                                           load_addr))
                             changed = true;
                           result.AppendMessageWithFormat(
                               "section '%s' loaded at 0x%" PRIx64 "\n",
@@ -3329,7 +3329,7 @@ protected:
           if (objfile) {
             Address base_addr(objfile->GetBaseAddress());
             if (base_addr.IsValid()) {
-              if (!target.GetSectionLoadList().IsEmpty()) {
+              if (!target.SectionLoadListIsEmpty()) {
                 lldb::addr_t load_addr = base_addr.GetLoadAddress(&target);
                 if (load_addr == LLDB_INVALID_ADDRESS) {
                   base_addr.Dump(&strm, &target,
@@ -3544,8 +3544,7 @@ protected:
                                         function_options, sc_list);
     } else if (m_options.m_type == eLookupTypeAddress && target) {
       Address addr;
-      if (target->GetSectionLoadList().ResolveLoadAddress(m_options.m_addr,
-                                                          addr)) {
+      if (target->ResolveLoadAddress(m_options.m_addr, addr)) {
         SymbolContext sc;
         ModuleSP module_sp(addr.GetModule());
         module_sp->ResolveSymbolContextForAddress(addr,
@@ -5270,7 +5269,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetTarget();
-    target.GetSectionLoadList().Dump(result.GetOutputStream(), &target);
+    target.DumpSectionLoadList(result.GetOutputStream());
     result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 };

--- a/lldb/source/Core/Address.cpp
+++ b/lldb/source/Core/Address.cpp
@@ -138,7 +138,7 @@ static bool ReadAddress(ExecutionContextScope *exe_scope,
     // If we have any sections that are loaded, try and resolve using the
     // section load list
     Target *target = exe_ctx.GetTargetPtr();
-    if (target && !target->SectionLoadListIsEmpty()) {
+    if (target && target->HasLoadedSections()) {
       if (target->ResolveLoadAddress(deref_addr, deref_so_addr))
         return true;
     } else {

--- a/lldb/source/Core/Address.cpp
+++ b/lldb/source/Core/Address.cpp
@@ -138,9 +138,8 @@ static bool ReadAddress(ExecutionContextScope *exe_scope,
     // If we have any sections that are loaded, try and resolve using the
     // section load list
     Target *target = exe_ctx.GetTargetPtr();
-    if (target && !target->GetSectionLoadList().IsEmpty()) {
-      if (target->GetSectionLoadList().ResolveLoadAddress(deref_addr,
-                                                          deref_so_addr))
+    if (target && !target->SectionLoadListIsEmpty()) {
+      if (target->ResolveLoadAddress(deref_addr, deref_so_addr))
         return true;
     } else {
       // If we were not running, yet able to read an integer, we must have a
@@ -1046,8 +1045,7 @@ AddressClass Address::GetAddressClass() const {
 
 bool Address::SetLoadAddress(lldb::addr_t load_addr, Target *target,
                              bool allow_section_end) {
-  if (target && target->GetSectionLoadList().ResolveLoadAddress(
-                    load_addr, *this, allow_section_end))
+  if (target && target->ResolveLoadAddress(load_addr, *this, allow_section_end))
     return true;
   m_section_wp.reset();
   m_offset = load_addr;

--- a/lldb/source/Core/Address.cpp
+++ b/lldb/source/Core/Address.cpp
@@ -1045,7 +1045,9 @@ AddressClass Address::GetAddressClass() const {
 
 bool Address::SetLoadAddress(lldb::addr_t load_addr, Target *target,
                              bool allow_section_end) {
-  if (target && target->ResolveLoadAddress(load_addr, *this, allow_section_end))
+  if (target && target->ResolveLoadAddress(load_addr, *this,
+                                           SectionLoadHistory::eStopIDNow,
+                                           allow_section_end))
     return true;
   m_section_wp.reset();
   m_offset = load_addr;

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -107,11 +107,7 @@ static Address ResolveAddress(Target &target, const Address &addr) {
     Address resolved_addr;
     // If we weren't passed in a section offset address range, try and resolve
     // it to something
-    bool is_resolved = target.GetSectionLoadList().IsEmpty()
-                           ? target.GetImages().ResolveFileAddress(
-                                 addr.GetOffset(), resolved_addr)
-                           : target.GetSectionLoadList().ResolveLoadAddress(
-                                 addr.GetOffset(), resolved_addr);
+    bool is_resolved = target.SectionLoadListIsEmpty() ? target.GetImages().ResolveFileAddress(addr.GetOffset(), resolved_addr) : target.ResolveLoadAddress(addr.GetOffset(), resolved_addr);
 
     // We weren't able to resolve the address, just treat it as a raw address
     if (is_resolved && resolved_addr.IsValid())

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -107,7 +107,11 @@ static Address ResolveAddress(Target &target, const Address &addr) {
     Address resolved_addr;
     // If we weren't passed in a section offset address range, try and resolve
     // it to something
-    bool is_resolved = target.SectionLoadListIsEmpty() ? target.GetImages().ResolveFileAddress(addr.GetOffset(), resolved_addr) : target.ResolveLoadAddress(addr.GetOffset(), resolved_addr);
+    bool is_resolved =
+        target.HasLoadedSections()
+            ? target.ResolveLoadAddress(addr.GetOffset(), resolved_addr)
+            : target.GetImages().ResolveFileAddress(addr.GetOffset(),
+                                                    resolved_addr);
 
     // We weren't able to resolve the address, just treat it as a raw address
     if (is_resolved && resolved_addr.IsValid())

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -139,7 +139,7 @@ static lldb::offset_t DumpInstructions(const DataExtractor &DE, Stream *s,
       if (target_sp->ResolveLoadAddress(addr, so_addr)) {
         data_from_file = false;
       } else {
-        if (target_sp->SectionLoadListIsEmpty() ||
+        if (!target_sp->HasLoadedSections() ||
             !target_sp->GetImages().ResolveFileAddress(addr, so_addr))
           so_addr.SetRawAddress(addr);
       }

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -136,10 +136,10 @@ static lldb::offset_t DumpInstructions(const DataExtractor &DE, Stream *s,
       lldb::addr_t addr = base_addr + start_offset;
       lldb_private::Address so_addr;
       bool data_from_file = true;
-      if (target_sp->GetSectionLoadList().ResolveLoadAddress(addr, so_addr)) {
+      if (target_sp->ResolveLoadAddress(addr, so_addr)) {
         data_from_file = false;
       } else {
-        if (target_sp->GetSectionLoadList().IsEmpty() ||
+        if (target_sp->SectionLoadListIsEmpty() ||
             !target_sp->GetImages().ResolveFileAddress(addr, so_addr))
           so_addr.SetRawAddress(addr);
       }
@@ -707,8 +707,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
         TargetSP target_sp(exe_scope->CalculateTarget());
         lldb_private::Address so_addr;
         if (target_sp) {
-          if (target_sp->GetSectionLoadList().ResolveLoadAddress(addr,
-                                                                 so_addr)) {
+          if (target_sp->ResolveLoadAddress(addr, so_addr)) {
             s->PutChar(' ');
             so_addr.Dump(s, exe_scope, Address::DumpStyleResolvedDescription,
                          Address::DumpStyleModuleWithFileAddress);
@@ -719,8 +718,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
             if (ProcessSP process_sp = exe_scope->CalculateProcess()) {
               if (ABISP abi_sp = process_sp->GetABI()) {
                 addr_t addr_fixed = abi_sp->FixCodeAddress(addr);
-                if (target_sp->GetSectionLoadList().ResolveLoadAddress(
-                        addr_fixed, so_addr)) {
+                if (target_sp->ResolveLoadAddress(addr_fixed, so_addr)) {
                   s->PutChar(' ');
                   s->Printf("(0x%*.*" PRIx64 ")", (int)(2 * item_byte_size),
                             (int)(2 * item_byte_size), addr_fixed);

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -412,7 +412,7 @@ static bool DumpAddressAndContent(Stream &s, const SymbolContext *sc,
   Target *target = Target::GetTargetFromContexts(exe_ctx, sc);
 
   addr_t vaddr = LLDB_INVALID_ADDRESS;
-  if (target && !target->GetSectionLoadList().IsEmpty())
+  if (target && !target->SectionLoadListIsEmpty())
     vaddr = addr.GetLoadAddress(target);
   if (vaddr == LLDB_INVALID_ADDRESS)
     vaddr = addr.GetFileAddress();

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -412,7 +412,7 @@ static bool DumpAddressAndContent(Stream &s, const SymbolContext *sc,
   Target *target = Target::GetTargetFromContexts(exe_ctx, sc);
 
   addr_t vaddr = LLDB_INVALID_ADDRESS;
-  if (target && !target->SectionLoadListIsEmpty())
+  if (target && target->HasLoadedSections())
     vaddr = addr.GetLoadAddress(target);
   if (vaddr == LLDB_INVALID_ADDRESS)
     vaddr = addr.GetFileAddress();

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -234,7 +234,7 @@ addr_t Section::GetLoadBaseAddress(Target *target) const {
       load_base_addr += GetOffset();
   }
   if (load_base_addr == LLDB_INVALID_ADDRESS) {
-    load_base_addr = target->GetSectionLoadList().GetSectionLoadAddress(
+    load_base_addr = target->GetSectionLoadAddress(
         const_cast<Section *>(this)->shared_from_this());
   }
   return load_base_addr;
@@ -638,7 +638,7 @@ bool SectionList::ContainsSection(user_id_t sect_id) const {
 void SectionList::Dump(llvm::raw_ostream &s, unsigned indent, Target *target,
                        bool show_header, uint32_t depth) const {
   bool target_has_loaded_sections =
-      target && !target->GetSectionLoadList().IsEmpty();
+      target && !target->SectionLoadListIsEmpty();
   if (show_header && !m_sections.empty()) {
     s.indent(indent);
     s << llvm::formatv(

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -637,8 +637,7 @@ bool SectionList::ContainsSection(user_id_t sect_id) const {
 
 void SectionList::Dump(llvm::raw_ostream &s, unsigned indent, Target *target,
                        bool show_header, uint32_t depth) const {
-  bool target_has_loaded_sections =
-      target && !target->SectionLoadListIsEmpty();
+  bool target_has_loaded_sections = target && target->HasLoadedSections();
   if (show_header && !m_sections.empty()) {
     s.indent(indent);
     s << llvm::formatv(

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -364,7 +364,7 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
           // memory sections loaded. This allows you to use "target modules
           // load" to load your executable and any shared libraries, then
           // execute commands where you can look at types in data sections.
-         if (!target->SectionLoadListIsEmpty()) {
+          if (target->HasLoadedSections()) {
             address = m_value.ULongLong(LLDB_INVALID_ADDRESS);
             if (target->ResolveLoadAddress(address, file_so_addr)) {
               address_type = eAddressTypeLoad;

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -364,10 +364,9 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
           // memory sections loaded. This allows you to use "target modules
           // load" to load your executable and any shared libraries, then
           // execute commands where you can look at types in data sections.
-          const SectionLoadList &target_sections = target->GetSectionLoadList();
-          if (!target_sections.IsEmpty()) {
+         if (!target->SectionLoadListIsEmpty()) {
             address = m_value.ULongLong(LLDB_INVALID_ADDRESS);
-            if (target_sections.ResolveLoadAddress(address, file_so_addr)) {
+            if (target->ResolveLoadAddress(address, file_so_addr)) {
               address_type = eAddressTypeLoad;
               data.SetByteOrder(target->GetArchitecture().GetByteOrder());
               data.SetAddressByteSize(

--- a/lldb/source/DataFormatters/CXXFunctionPointer.cpp
+++ b/lldb/source/DataFormatters/CXXFunctionPointer.cpp
@@ -39,9 +39,8 @@ bool lldb_private::formatters::CXXFunctionPointerSummaryProvider(
 
       Address so_addr;
       Target *target = exe_ctx.GetTargetPtr();
-      if (target && !target->GetSectionLoadList().IsEmpty()) {
-        target->GetSectionLoadList().ResolveLoadAddress(func_ptr_address,
-                                                        so_addr);
+      if (target && !target->SectionLoadListIsEmpty()) {
+        target->ResolveLoadAddress(func_ptr_address, so_addr);
         if (so_addr.GetSection() == nullptr) {
           // If we have an address that doesn't correspond to any symbol,
           // it might have authentication bits.  Strip them & see if it

--- a/lldb/source/DataFormatters/CXXFunctionPointer.cpp
+++ b/lldb/source/DataFormatters/CXXFunctionPointer.cpp
@@ -39,7 +39,7 @@ bool lldb_private::formatters::CXXFunctionPointerSummaryProvider(
 
       Address so_addr;
       Target *target = exe_ctx.GetTargetPtr();
-      if (target && !target->SectionLoadListIsEmpty()) {
+      if (target && target->HasLoadedSections()) {
         target->ResolveLoadAddress(func_ptr_address, so_addr);
         if (so_addr.GetSection() == nullptr) {
           // If we have an address that doesn't correspond to any symbol,

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -178,8 +178,8 @@ bool ObjectFileJIT::SetLoadAddress(Target &target, lldb::addr_t value,
       SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
       if (section_sp && section_sp->GetFileSize() > 0 &&
           !section_sp->IsThreadSpecific()) {
-        if (target.GetSectionLoadList().SetSectionLoadAddress(
-                section_sp, section_sp->GetFileAddress() + value))
+        if (target.SetSectionLoadAddress(section_sp, 
+                                         section_sp->GetFileAddress() + value))
           ++num_loaded_sections;
       }
     }

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -178,7 +178,7 @@ bool ObjectFileJIT::SetLoadAddress(Target &target, lldb::addr_t value,
       SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
       if (section_sp && section_sp->GetFileSize() > 0 &&
           !section_sp->IsThreadSpecific()) {
-        if (target.SetSectionLoadAddress(section_sp, 
+        if (target.SetSectionLoadAddress(section_sp,
                                          section_sp->GetFileAddress() + value))
           ++num_loaded_sections;
       }

--- a/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
+++ b/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
@@ -76,7 +76,7 @@ lldb::addr_t ArchitectureMips::GetBreakableLoadAddress(lldb::addr_t addr,
 
   Address resolved_addr;
 
-  if (target.SectionLoadListIsEmpty())
+  if (!target.HasLoadedSections())
     // No sections are loaded, so we must assume we are not running yet and
     // need to operate only on file address.
     target.ResolveFileAddress(addr, resolved_addr);

--- a/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
+++ b/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
@@ -76,8 +76,7 @@ lldb::addr_t ArchitectureMips::GetBreakableLoadAddress(lldb::addr_t addr,
 
   Address resolved_addr;
 
-  SectionLoadList &section_load_list = target.GetSectionLoadList();
-  if (section_load_list.IsEmpty())
+  if (target.SectionLoadListIsEmpty())
     // No sections are loaded, so we must assume we are not running yet and
     // need to operate only on file address.
     target.ResolveFileAddress(addr, resolved_addr);

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1787,7 +1787,7 @@ const char *DisassemblerLLVMC::SymbolLookup(uint64_t value, uint64_t *type_ptr,
           module_sp->ResolveFileAddress(value, value_so_addr);
           module_sp->ResolveFileAddress(pc, pc_so_addr);
         }
-      } else if (target && !target->SectionLoadListIsEmpty()) {
+      } else if (target && target->HasLoadedSections()) {
         target->ResolveLoadAddress(value, value_so_addr);
         target->ResolveLoadAddress(pc, pc_so_addr);
       }

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1787,9 +1787,9 @@ const char *DisassemblerLLVMC::SymbolLookup(uint64_t value, uint64_t *type_ptr,
           module_sp->ResolveFileAddress(value, value_so_addr);
           module_sp->ResolveFileAddress(pc, pc_so_addr);
         }
-      } else if (target && !target->GetSectionLoadList().IsEmpty()) {
-        target->GetSectionLoadList().ResolveLoadAddress(value, value_so_addr);
-        target->GetSectionLoadList().ResolveLoadAddress(pc, pc_so_addr);
+      } else if (target && !target->SectionLoadListIsEmpty()) {
+        target->ResolveLoadAddress(value, value_so_addr);
+        target->ResolveLoadAddress(pc, pc_so_addr);
       }
 
       SymbolContext sym_ctx;

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -368,7 +368,7 @@ bool DynamicLoaderMacOS::NotifyBreakpointHit(void *baton,
               dyld_instance->UnloadAllImages();
               dyld_instance->ClearDYLDModule();
               process->GetTarget().GetImages().Clear();
-              process->GetTarget().GetSectionLoadList().Clear();
+              process->GetTarget().ClearSectionLoadList();
 
               addr_t all_image_infos = process->GetImageInfoAddress();
               int addr_size =

--- a/lldb/source/Plugins/DynamicLoader/Static/DynamicLoaderStatic.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Static/DynamicLoaderStatic.cpp
@@ -103,7 +103,7 @@ void DynamicLoaderStatic::LoadAllImagesAtFileAddresses() {
           for (size_t sect_idx = 0; sect_idx < num_sections; ++sect_idx) {
             SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
             if (section_sp) {
-              if (target.GetSectionLoadAddress(section_sp) != 
+              if (target.GetSectionLoadAddress(section_sp) !=
                   LLDB_INVALID_ADDRESS) {
                 no_load_addresses = false;
                 break;

--- a/lldb/source/Plugins/DynamicLoader/Static/DynamicLoaderStatic.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Static/DynamicLoaderStatic.cpp
@@ -103,8 +103,8 @@ void DynamicLoaderStatic::LoadAllImagesAtFileAddresses() {
           for (size_t sect_idx = 0; sect_idx < num_sections; ++sect_idx) {
             SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
             if (section_sp) {
-              if (target.GetSectionLoadList().GetSectionLoadAddress(
-                      section_sp) != LLDB_INVALID_ADDRESS) {
+              if (target.GetSectionLoadAddress(section_sp) != 
+                  LLDB_INVALID_ADDRESS) {
                 no_load_addresses = false;
                 break;
               }

--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -546,8 +546,7 @@ static std::string Sprintf(const char *format, ...) {
 
 static std::string GetSymbolNameFromAddress(ProcessSP process_sp, addr_t addr) {
   lldb_private::Address so_addr;
-  if (!process_sp->GetTarget().GetSectionLoadList().ResolveLoadAddress(addr,
-                                                                       so_addr))
+  if (!process_sp->GetTarget().ResolveLoadAddress(addr, so_addr))
     return "";
 
   lldb_private::Symbol *symbol = so_addr.CalculateSymbolContextSymbol();
@@ -561,8 +560,7 @@ static std::string GetSymbolNameFromAddress(ProcessSP process_sp, addr_t addr) {
 static void GetSymbolDeclarationFromAddress(ProcessSP process_sp, addr_t addr,
                                             Declaration &decl) {
   lldb_private::Address so_addr;
-  if (!process_sp->GetTarget().GetSectionLoadList().ResolveLoadAddress(addr,
-                                                                       so_addr))
+  if (!process_sp->GetTarget().ResolveLoadAddress(addr, so_addr))
     return;
 
   lldb_private::Symbol *symbol = so_addr.CalculateSymbolContextSymbol();
@@ -600,8 +598,7 @@ addr_t InstrumentationRuntimeTSan::GetFirstNonInternalFramePc(
     addr_t addr = *maybe_addr;
 
     lldb_private::Address so_addr;
-    if (!process_sp->GetTarget().GetSectionLoadList().ResolveLoadAddress(
-            addr, so_addr))
+    if (!process_sp->GetTarget().ResolveLoadAddress(addr, so_addr))
       continue;
 
     if (so_addr.GetModule() == runtime_module_sp)

--- a/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
+++ b/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
@@ -377,7 +377,7 @@ bool JITLoaderGDB::ReadJITDescriptorImpl(bool all_entries) {
             for (uint32_t i = 0; i < num_sections; ++i) {
               SectionSP section_sp(section_list->GetSectionAtIndex(i));
               if (section_sp) {
-                target.GetSectionLoadList().SetSectionUnloaded(section_sp);
+                target.SetSectionUnloaded(section_sp);
               }
             }
           }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -266,21 +266,20 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
 
   Target &target = process->GetTarget();
 
-  if (target.GetSectionLoadList().IsEmpty())
+  if (target.SectionLoadListIsEmpty())
     return optional_info;
 
   Address vtable_first_entry_resolved;
 
-  if (!target.GetSectionLoadList().ResolveLoadAddress(
-          vtable_address_first_entry, vtable_first_entry_resolved))
+  if (!target.ResolveLoadAddress(vtable_address_first_entry, 
+                                 vtable_first_entry_resolved))
     return optional_info;
 
   Address vtable_addr_resolved;
   SymbolContext sc;
   Symbol *symbol = nullptr;
 
-  if (!target.GetSectionLoadList().ResolveLoadAddress(vtable_address,
-                                                      vtable_addr_resolved))
+  if (!target.ResolveLoadAddress(vtable_address, vtable_addr_resolved))
     return optional_info;
 
   target.GetImages().ResolveSymbolContextForAddress(
@@ -322,8 +321,8 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
   // Setup for cases 2, 4 and 5 we have a pointer to a function after the
   // vtable. We will use a process of elimination to drop through each case
   // and obtain the data we need.
-  if (target.GetSectionLoadList().ResolveLoadAddress(
-          possible_function_address, function_address_resolved)) {
+  if (target.ResolveLoadAddress(possible_function_address, 
+                                function_address_resolved)) {
     target.GetImages().ResolveSymbolContextForAddress(
         function_address_resolved, eSymbolContextEverything, sc);
     symbol = sc.symbol;
@@ -418,15 +417,14 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
 
   TargetSP target_sp(thread.CalculateTarget());
 
-  if (target_sp->GetSectionLoadList().IsEmpty())
+  if (target_sp->SectionLoadListIsEmpty())
     return ret_plan_sp;
 
   Address pc_addr_resolved;
   SymbolContext sc;
   Symbol *symbol;
 
-  if (!target_sp->GetSectionLoadList().ResolveLoadAddress(curr_pc,
-                                                          pc_addr_resolved))
+  if (!target_sp->ResolveLoadAddress(curr_pc, pc_addr_resolved))
     return ret_plan_sp;
 
   target_sp->GetImages().ResolveSymbolContextForAddress(

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -266,12 +266,12 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
 
   Target &target = process->GetTarget();
 
-  if (target.SectionLoadListIsEmpty())
+  if (!target.HasLoadedSections())
     return optional_info;
 
   Address vtable_first_entry_resolved;
 
-  if (!target.ResolveLoadAddress(vtable_address_first_entry, 
+  if (!target.ResolveLoadAddress(vtable_address_first_entry,
                                  vtable_first_entry_resolved))
     return optional_info;
 
@@ -321,7 +321,7 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
   // Setup for cases 2, 4 and 5 we have a pointer to a function after the
   // vtable. We will use a process of elimination to drop through each case
   // and obtain the data we need.
-  if (target.ResolveLoadAddress(possible_function_address, 
+  if (target.ResolveLoadAddress(possible_function_address,
                                 function_address_resolved)) {
     target.GetImages().ResolveSymbolContextForAddress(
         function_address_resolved, eSymbolContextEverything, sc);
@@ -417,7 +417,7 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
 
   TargetSP target_sp(thread.CalculateTarget());
 
-  if (target_sp->SectionLoadListIsEmpty())
+  if (!target_sp->HasLoadedSections())
     return ret_plan_sp;
 
   Address pc_addr_resolved;

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -762,8 +762,7 @@ bool ObjectFileELF::SetLoadAddress(Target &target, lldb::addr_t value,
           if (GetAddressByteSize() == 4)
             load_addr &= 0xFFFFFFFF;
 
-          if (target.GetSectionLoadList().SetSectionLoadAddress(section_sp,
-                                                                load_addr))
+          if (target.SetSectionLoadAddress(section_sp, load_addr))
             ++num_loaded_sections;
         }
       }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6245,7 +6245,7 @@ bool ObjectFileMachO::SetLoadAddress(Target &target, lldb::addr_t value,
                   "0x%" PRIx64,
                   section_sp->GetName().AsCString(),
                   section_sp->GetFileAddress() + value);
-        if (target.SetSectionLoadAddress(section_sp, 
+        if (target.SetSectionLoadAddress(section_sp,
                                          section_sp->GetFileAddress() + value,
                                          warn_multiple))
           ++num_loaded_sections;
@@ -6268,7 +6268,7 @@ bool ObjectFileMachO::SetLoadAddress(Target &target, lldb::addr_t value,
                     "ObjectFileMachO::SetLoadAddress segment '%s' load addr is "
                     "0x%" PRIx64,
                     section_sp->GetName().AsCString(), section_load_addr);
-          if (target.SetSectionLoadAddress(section_sp, section_load_addr, 
+          if (target.SetSectionLoadAddress(section_sp, section_load_addr,
                                            warn_multiple))
             ++num_loaded_sections;
         }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6245,9 +6245,9 @@ bool ObjectFileMachO::SetLoadAddress(Target &target, lldb::addr_t value,
                   "0x%" PRIx64,
                   section_sp->GetName().AsCString(),
                   section_sp->GetFileAddress() + value);
-        if (target.GetSectionLoadList().SetSectionLoadAddress(
-                section_sp, section_sp->GetFileAddress() + value,
-                warn_multiple))
+        if (target.SetSectionLoadAddress(section_sp, 
+                                         section_sp->GetFileAddress() + value,
+                                         warn_multiple))
           ++num_loaded_sections;
       }
     }
@@ -6268,8 +6268,8 @@ bool ObjectFileMachO::SetLoadAddress(Target &target, lldb::addr_t value,
                     "ObjectFileMachO::SetLoadAddress segment '%s' load addr is "
                     "0x%" PRIx64,
                     section_sp->GetName().AsCString(), section_load_addr);
-          if (target.GetSectionLoadList().SetSectionLoadAddress(
-                  section_sp, section_load_addr, warn_multiple))
+          if (target.SetSectionLoadAddress(section_sp, section_load_addr, 
+                                           warn_multiple))
             ++num_loaded_sections;
         }
       }

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -482,7 +482,7 @@ bool ObjectFilePECOFF::SetLoadAddress(Target &target, addr_t value,
         // that have SHF_ALLOC in their flag bits.
         SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
         if (section_sp && !section_sp->IsThreadSpecific()) {
-          if (target.GetSectionLoadList().SetSectionLoadAddress(
+          if (target.SetSectionLoadAddress(
                   section_sp, section_sp->GetFileAddress() + value))
             ++num_loaded_sections;
         }

--- a/lldb/source/Plugins/ObjectFile/Placeholder/ObjectFilePlaceholder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Placeholder/ObjectFilePlaceholder.cpp
@@ -59,8 +59,7 @@ bool ObjectFilePlaceholder::SetLoadAddress(Target &target, addr_t value,
   GetModule()->GetSectionList();
   assert(m_sections_up->GetNumSections(0) == 1);
 
-  target.GetSectionLoadList().SetSectionLoadAddress(
-      m_sections_up->GetSectionAtIndex(0), m_base);
+  target.SetSectionLoadAddress(m_sections_up->GetSectionAtIndex(0), m_base);
   return true;
 }
 

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -367,12 +367,12 @@ void ProcessMinidump::BuildMemoryRegions() {
 
   MemoryRegionInfos to_add;
   ModuleList &modules = GetTarget().GetImages();
-  SectionLoadList &load_list = GetTarget().GetSectionLoadList();
+  Target &target = GetTarget();
   modules.ForEach([&](const ModuleSP &module_sp) {
     SectionList *sections = module_sp->GetSectionList();
     for (size_t i = 0; i < sections->GetSize(); ++i) {
       SectionSP section_sp = sections->GetSectionAtIndex(i);
-      addr_t load_addr = load_list.GetSectionLoadAddress(section_sp);
+      addr_t load_addr = target.GetSectionLoadAddress(section_sp);
       if (load_addr == LLDB_INVALID_ADDRESS)
         continue;
       MemoryRegionInfo::RangeType section_range(load_addr,

--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleSaver.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleSaver.cpp
@@ -263,8 +263,7 @@ BuildModulesSection(Process &process, FileSpec directory) {
 
     lldb::addr_t load_addr = LLDB_INVALID_ADDRESS;
     Address base_addr(objfile->GetBaseAddress());
-    if (base_addr.IsValid() &&
-        !process.GetTarget().SectionLoadListIsEmpty())
+    if (base_addr.IsValid() && process.GetTarget().HasLoadedSections())
       load_addr = base_addr.GetLoadAddress(&process.GetTarget());
 
     if (load_addr == LLDB_INVALID_ADDRESS)

--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleSaver.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleSaver.cpp
@@ -264,7 +264,7 @@ BuildModulesSection(Process &process, FileSpec directory) {
     lldb::addr_t load_addr = LLDB_INVALID_ADDRESS;
     Address base_addr(objfile->GetBaseAddress());
     if (base_addr.IsValid() &&
-        !process.GetTarget().GetSectionLoadList().IsEmpty())
+        !process.GetTarget().SectionLoadListIsEmpty())
       load_addr = base_addr.GetLoadAddress(&process.GetTarget());
 
     if (load_addr == LLDB_INVALID_ADDRESS)

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -644,8 +644,7 @@ ObjectFile::GetLoadableData(Target &target) {
   for (size_t i = 0; i < section_count; ++i) {
     LoadableData loadable;
     SectionSP section_sp = section_list->GetSectionAtIndex(i);
-    loadable.Dest =
-        target.GetSectionLoadList().GetSectionLoadAddress(section_sp);
+    loadable.Dest = target.GetSectionLoadAddress(section_sp);
     if (loadable.Dest == LLDB_INVALID_ADDRESS)
       continue;
     // We can skip sections like bss

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -123,7 +123,7 @@ bool ProcessTrace::GetProcessInfo(ProcessInstanceInfo &info) {
 size_t ProcessTrace::DoReadMemory(addr_t addr, void *buf, size_t size,
                                   Status &error) {
   Address resolved_address;
-  GetTarget().GetSectionLoadList().ResolveLoadAddress(addr, resolved_address);
+  GetTarget().ResolveLoadAddress(addr, resolved_address);
 
   return GetTarget().ReadMemoryFromFileCache(resolved_address, buf, size,
                                              error);

--- a/lldb/source/Target/SectionLoadHistory.cpp
+++ b/lldb/source/Target/SectionLoadHistory.cpp
@@ -112,7 +112,8 @@ SectionLoadHistory::GetSectionLoadAddress(uint32_t stop_id,
 }
 
 bool SectionLoadHistory::ResolveLoadAddress(uint32_t stop_id, addr_t load_addr,
-                                            Address &so_addr) {
+                                            Address &so_addr,
+                                            bool allow_section_end) {
   // First find the top level section that this load address exists in
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   const bool read_only = true;

--- a/lldb/source/Target/SectionLoadHistory.cpp
+++ b/lldb/source/Target/SectionLoadHistory.cpp
@@ -119,7 +119,8 @@ bool SectionLoadHistory::ResolveLoadAddress(uint32_t stop_id, addr_t load_addr,
   const bool read_only = true;
   SectionLoadList *section_load_list =
       GetSectionLoadListForStopID(stop_id, read_only);
-  return section_load_list->ResolveLoadAddress(load_addr, so_addr);
+  return section_load_list->ResolveLoadAddress(load_addr, so_addr,
+                                               allow_section_end);
 }
 
 bool SectionLoadHistory::SetSectionLoadAddress(

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3216,8 +3216,9 @@ Status Target::Install(ProcessLaunchInfo *launch_info) {
 }
 
 bool Target::ResolveLoadAddress(addr_t load_addr, Address &so_addr,
-                                uint32_t stop_id) {
-  return m_section_load_history.ResolveLoadAddress(stop_id, load_addr, so_addr);
+                                uint32_t stop_id, bool allow_section_end) {
+  return m_section_load_history.ResolveLoadAddress(stop_id, load_addr, so_addr,
+                                                   allow_section_end);
 }
 
 bool Target::ResolveFileAddress(lldb::addr_t file_addr,

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5147,9 +5147,7 @@ Target::ReportStatistics(const lldb_private::StatisticsOptions &options) {
 
 void Target::ResetStatistics() { m_stats.Reset(*this); }
 
-bool Target::SectionLoadListIsEmpty() const {
-  return const_cast<Target *>(this)->GetSectionLoadList().IsEmpty();
-}
+bool Target::HasLoadedSections() { return !GetSectionLoadList().IsEmpty(); }
 
 lldb::addr_t Target::GetSectionLoadAddress(const lldb::SectionSP &section_sp) {
   return GetSectionLoadList().GetSectionLoadAddress(section_sp);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5146,3 +5146,17 @@ Target::ReportStatistics(const lldb_private::StatisticsOptions &options) {
 }
 
 void Target::ResetStatistics() { m_stats.Reset(*this); }
+
+bool Target::SectionLoadListIsEmpty() const {
+  return const_cast<Target *>(this)->GetSectionLoadList().IsEmpty();
+}
+
+lldb::addr_t Target::GetSectionLoadAddress(const lldb::SectionSP &section_sp) {
+  return GetSectionLoadList().GetSectionLoadAddress(section_sp);
+}
+
+void Target::ClearSectionLoadList() { GetSectionLoadList().Clear(); }
+
+void Target::DumpSectionLoadList(Stream &s) {
+  GetSectionLoadList().Dump(s, this);
+}

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -263,8 +263,7 @@ bool ThreadPlanStepInRange::ShouldStop(Event *event_ptr) {
           const Architecture *arch = GetTarget().GetArchitecturePlugin();
           if (arch) {
             Address curr_sec_addr;
-            GetTarget().GetSectionLoadList().ResolveLoadAddress(curr_addr,
-                                                                curr_sec_addr);
+            GetTarget().ResolveLoadAddress(curr_addr, curr_sec_addr);
             bytes_to_skip = arch->GetBytesToSkip(*sc.symbol, curr_sec_addr);
           }
         }

--- a/lldb/source/Target/ThreadPlanTracer.cpp
+++ b/lldb/source/Target/ThreadPlanTracer.cpp
@@ -140,8 +140,7 @@ void ThreadPlanAssemblyTracer::Log() {
   Address pc_addr;
   bool addr_valid = false;
   uint8_t buffer[16] = {0}; // Must be big enough for any single instruction
-  addr_valid = m_process.GetTarget().GetSectionLoadList().ResolveLoadAddress(
-      pc, pc_addr);
+  addr_valid = m_process.GetTarget().ResolveLoadAddress(pc, pc_addr);
 
   pc_addr.Dump(stream, &GetThread(), Address::DumpStyleResolvedDescription,
                Address::DumpStyleModuleWithFileAddress);


### PR DESCRIPTION
Lots of code around LLDB was directly accessing the target's section load list. This NFC patch makes the section load list private so the Target class can access it, but everyone else now uses accessor functions. This allows us to control the resolving of addresses and will allow for functionality in LLDB which can lazily resolve addresses in JIT plug-ins with a future patch.