### PR TITLE
[libc++] __uglify `[[clang::noescape]]`

### DIFF
--- a/libcxx/include/__charconv/from_chars_floating_point.h
+++ b/libcxx/include/__charconv/from_chars_floating_point.h
@@ -37,13 +37,13 @@ struct __from_chars_result {
 
 template <class _Fp>
 _LIBCPP_EXPORTED_FROM_ABI __from_chars_result<_Fp> __from_chars_floating_point(
-    [[clang::noescape]] const char* __first, [[clang::noescape]] const char* __last, chars_format __fmt);
+    _LIBCPP_NOESCAPE const char* __first, _LIBCPP_NOESCAPE const char* __last, chars_format __fmt);
 
 extern template __from_chars_result<float> __from_chars_floating_point(
-    [[clang::noescape]] const char* __first, [[clang::noescape]] const char* __last, chars_format __fmt);
+    _LIBCPP_NOESCAPE const char* __first, _LIBCPP_NOESCAPE const char* __last, chars_format __fmt);
 
 extern template __from_chars_result<double> __from_chars_floating_point(
-    [[clang::noescape]] const char* __first, [[clang::noescape]] const char* __last, chars_format __fmt);
+    _LIBCPP_NOESCAPE const char* __first, _LIBCPP_NOESCAPE const char* __last, chars_format __fmt);
 
 template <class _Fp>
 _LIBCPP_HIDE_FROM_ABI from_chars_result

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1167,6 +1167,12 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_LIFETIMEBOUND
 #  endif
 
+#  if __has_cpp_attribute(_Clang::__noescape__)
+#    define _LIBCPP_NOESCAPE [[_Clang::__noescape__]]
+#  else
+#    define _LIBCPP_NOESCAPE
+#  endif
+
 #  if __has_attribute(__nodebug__)
 #    define _LIBCPP_NODEBUG __attribute__((__nodebug__))
 #  else

--- a/libcxx/src/charconv.cpp
+++ b/libcxx/src/charconv.cpp
@@ -77,13 +77,13 @@ to_chars_result to_chars(char* __first, char* __last, long double __value, chars
 
 template <class _Fp>
 __from_chars_result<_Fp> __from_chars_floating_point(
-    [[clang::noescape]] const char* __first, [[clang::noescape]] const char* __last, chars_format __fmt) {
+    _LIBCPP_NOESCAPE const char* __first, _LIBCPP_NOESCAPE const char* __last, chars_format __fmt) {
   return std::__from_chars_floating_point_impl<_Fp>(__first, __last, __fmt);
 }
 
 template __from_chars_result<float> __from_chars_floating_point(
-    [[clang::noescape]] const char* __first, [[clang::noescape]] const char* __last, chars_format __fmt);
+    _LIBCPP_NOESCAPE const char* __first, _LIBCPP_NOESCAPE const char* __last, chars_format __fmt);
 
 template __from_chars_result<double> __from_chars_floating_point(
-    [[clang::noescape]] const char* __first, [[clang::noescape]] const char* __last, chars_format __fmt);
+    _LIBCPP_NOESCAPE const char* __first, _LIBCPP_NOESCAPE const char* __last, chars_format __fmt);
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/test/libcxx/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx/system_reserved_names.gen.py
@@ -154,6 +154,10 @@ for header in public_headers:
 #define Xp SYSTEM_RESERVED_NAME
 #define Xs SYSTEM_RESERVED_NAME
 
+// These attribute-tokens are not reserved, so the user can macro-define them.
+#define lifetimebound SYSTEM_RESERVED_NAME
+#define noescape SYSTEM_RESERVED_NAME
+
 // The classic Windows min/max macros
 #define min SYSTEM_RESERVED_NAME
 #define max SYSTEM_RESERVED_NAME

--- a/libcxx/test/libcxx/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx/system_reserved_names.gen.py
@@ -154,10 +154,6 @@ for header in public_headers:
 #define Xp SYSTEM_RESERVED_NAME
 #define Xs SYSTEM_RESERVED_NAME
 
-// These attribute-tokens are not reserved, so the user can macro-define them.
-#define lifetimebound SYSTEM_RESERVED_NAME
-#define noescape SYSTEM_RESERVED_NAME
-
 // The classic Windows min/max macros
 #define min SYSTEM_RESERVED_NAME
 #define max SYSTEM_RESERVED_NAME


### PR DESCRIPTION
Identifiers `clang` and `noescape` are not reserved by the C++ standard, so perhaps we need to use the equivalent reserved forms.

Also changes the occurrences of that attribute to a macro, following the convention for `[[_Clang::__lifetimebound__]]`.

Addresses https://github.com/llvm/llvm-project/pull/91651#discussion_r1807852646.