### PR TITLE
[clang][NFC] Move `concepts::createSubstDiagAt` from AST to Sema

### DIFF
--- a/clang/include/clang/AST/ExprConcepts.h
+++ b/clang/include/clang/AST/ExprConcepts.h
@@ -489,14 +489,6 @@ public:
     return R->getKind() == RK_Nested;
   }
 };
-
-using EntityPrinter = llvm::function_ref<void(llvm::raw_ostream &)>;
-
-/// \brief create a Requirement::SubstitutionDiagnostic with only a
-/// SubstitutedEntity and DiagLoc using Sema's allocator.
-Requirement::SubstitutionDiagnostic *
-createSubstDiagAt(Sema &S, SourceLocation Location, EntityPrinter Printer);
-
 } // namespace concepts
 
 /// C++2a [expr.prim.req]:

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13435,6 +13435,13 @@ public:
     return CodeSynthesisContexts.size() > NonInstantiationEntries;
   }
 
+  using EntityPrinter = llvm::function_ref<void(llvm::raw_ostream &)>;
+
+  /// \brief create a Requirement::SubstitutionDiagnostic with only a
+  /// SubstitutedEntity and DiagLoc using Sema's allocator.
+  concepts::Requirement::SubstitutionDiagnostic *
+  createSubstDiagAt(SourceLocation Location, EntityPrinter Printer);
+
   ///@}
 
   //

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13438,7 +13438,7 @@ public:
   using EntityPrinter = llvm::function_ref<void(llvm::raw_ostream &)>;
 
   /// \brief create a Requirement::SubstitutionDiagnostic with only a
-  /// SubstitutedEntity and DiagLoc using Sema's allocator.
+  /// SubstitutedEntity and DiagLoc using ASTContext's allocator.
   concepts::Requirement::SubstitutionDiagnostic *
   createSubstDiagAt(SourceLocation Location, EntityPrinter Printer);
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -9444,11 +9444,11 @@ Sema::BuildExprRequirement(
     ExprResult Constraint = SubstExpr(IDC, MLTAL);
     if (Constraint.isInvalid()) {
       return new (Context) concepts::ExprRequirement(
-          concepts::createSubstDiagAt(*this, IDC->getExprLoc(),
-                                      [&](llvm::raw_ostream &OS) {
-                                        IDC->printPretty(OS, /*Helper=*/nullptr,
-                                                         getPrintingPolicy());
-                                      }),
+          createSubstDiagAt(IDC->getExprLoc(),
+                            [&](llvm::raw_ostream &OS) {
+                              IDC->printPretty(OS, /*Helper=*/nullptr,
+                                               getPrintingPolicy());
+                            }),
           IsSimple, NoexceptLoc, ReturnTypeRequirement);
     }
     SubstitutedConstraintExpr =

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -2654,7 +2654,7 @@ QualType TemplateInstantiator::TransformSubstTemplateTypeParmPackType(
 
 static concepts::Requirement::SubstitutionDiagnostic *
 createSubstDiag(Sema &S, TemplateDeductionInfo &Info,
-                concepts::EntityPrinter Printer) {
+                Sema::EntityPrinter Printer) {
   SmallString<128> Message;
   SourceLocation ErrorLoc;
   if (Info.hasSFINAEDiagnostic()) {
@@ -2675,12 +2675,11 @@ createSubstDiag(Sema &S, TemplateDeductionInfo &Info,
 }
 
 concepts::Requirement::SubstitutionDiagnostic *
-concepts::createSubstDiagAt(Sema &S, SourceLocation Location,
-                            EntityPrinter Printer) {
+Sema::createSubstDiagAt(SourceLocation Location, EntityPrinter Printer) {
   SmallString<128> Entity;
   llvm::raw_svector_ostream OS(Entity);
   Printer(OS);
-  const ASTContext &C = S.Context;
+  const ASTContext &C = Context;
   return new (C) concepts::Requirement::SubstitutionDiagnostic{
       /*SubstitutedEntity=*/C.backupStr(Entity),
       /*DiagLoc=*/Location, /*DiagMessage=*/StringRef()};


### PR DESCRIPTION
This fixes layering violation introduced in 2fd01d75a863184766ee0c82b5c0fc8be172448a. The declaration is moved to `SemaTemplateInstantiate` section of `Sema.h`, after the file where it's implemented.