### PR TITLE
[CodeGen][NewPM] Make MFProperties methods const NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineCSE.h
+++ b/llvm/include/llvm/CodeGen/MachineCSE.h
@@ -18,7 +18,7 @@ public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 
-  MachineFunctionProperties getRequiredProperties() {
+  MachineFunctionProperties getRequiredProperties() const {
     return MachineFunctionProperties().set(
         MachineFunctionProperties::Property::IsSSA);
   }

--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -41,7 +41,7 @@ using MachineFunctionAnalysisManager = AnalysisManager<MachineFunction>;
 /// MachineFunctionProperties properly.
 template <typename PassT> class MFPropsModifier {
 public:
-  MFPropsModifier(PassT &P_, MachineFunction &MF_) : P(P_), MF(MF_) {
+  MFPropsModifier(const PassT &P_, MachineFunction &MF_) : P(P_), MF(MF_) {
     auto &MFProps = MF.getProperties();
 #ifndef NDEBUG
     if constexpr (has_get_required_properties_v<PassT>) {
@@ -71,7 +71,7 @@ public:
   }
 
 private:
-  PassT &P;
+  const PassT &P;
   MachineFunction &MF;
 
   template <typename T>

--- a/llvm/include/llvm/CodeGen/RegAllocFast.h
+++ b/llvm/include/llvm/CodeGen/RegAllocFast.h
@@ -27,12 +27,12 @@ public:
   RegAllocFastPass(RegAllocFastPassOptions Opts = RegAllocFastPassOptions())
       : Opts(Opts) {}
 
-  MachineFunctionProperties getRequiredProperties() {
+  MachineFunctionProperties getRequiredProperties() const {
     return MachineFunctionProperties().set(
         MachineFunctionProperties::Property::NoPHIs);
   }
 
-  MachineFunctionProperties getSetProperties() {
+  MachineFunctionProperties getSetProperties() const {
     if (Opts.ClearVRegs) {
       return MachineFunctionProperties().set(
           MachineFunctionProperties::Property::NoVRegs);
@@ -41,7 +41,7 @@ public:
     return MachineFunctionProperties();
   }
 
-  MachineFunctionProperties getClearedProperties() {
+  MachineFunctionProperties getClearedProperties() const {
     return MachineFunctionProperties().set(
         MachineFunctionProperties::Property::IsSSA);
   }

--- a/llvm/include/llvm/CodeGen/TwoAddressInstructionPass.h
+++ b/llvm/include/llvm/CodeGen/TwoAddressInstructionPass.h
@@ -18,7 +18,7 @@ class TwoAddressInstructionPass
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
-  MachineFunctionProperties getSetProperties() {
+  MachineFunctionProperties getSetProperties() const {
     return MachineFunctionProperties().set(
         MachineFunctionProperties::Property::TiedOpsRewritten);
   }

--- a/llvm/lib/Target/AMDGPU/GCNDPPCombine.h
+++ b/llvm/lib/Target/AMDGPU/GCNDPPCombine.h
@@ -17,7 +17,7 @@ public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MAM);
 
-  MachineFunctionProperties getRequiredProperties() {
+  MachineFunctionProperties getRequiredProperties() const {
     return MachineFunctionProperties().set(
         MachineFunctionProperties::Property::IsSSA);
   }

--- a/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.h
+++ b/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.h
@@ -19,7 +19,7 @@ public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 
-  MachineFunctionProperties getRequiredProperties() {
+  MachineFunctionProperties getRequiredProperties() const {
     return MachineFunctionProperties().set(
         MachineFunctionProperties::Property::IsSSA);
   }

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
@@ -17,7 +17,7 @@ public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 
-  MachineFunctionProperties getClearedProperties() {
+  MachineFunctionProperties getClearedProperties() const {
     // SILowerSGPRSpills introduces new Virtual VGPRs for spilling SGPRs.
     return MachineFunctionProperties()
         .set(MachineFunctionProperties::Property::IsSSA)


### PR DESCRIPTION
Makes them congruent with the legacy PM methods.

Unless it was made non-const on purpose: was it?