### PR TITLE
[ORC] Add signext on @sum() arguments in test.

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
@@ -41,9 +41,9 @@ struct TargetI32ArgExtensions {
   TargetI32ArgExtensions(std::string TargetTriple, bool Signed = true) {
     Triple T(TargetTriple);
     if (auto AK = TargetLibraryInfo::getExtAttrForI32Return(T, Signed))
-      Ret = Attribute::getNameFromAttrKind(AK);
+      Ret = Attribute::getNameFromAttrKind(AK).str() + " ";
     if (auto AK = TargetLibraryInfo::getExtAttrForI32Param(T, Signed))
-      Arg = Attribute::getNameFromAttrKind(AK);
+      Arg = Attribute::getNameFromAttrKind(AK).str() + " ";
   }
 };
 
@@ -111,7 +111,7 @@ public:
     if (SumExample.empty()) {
       TargetI32ArgExtensions ArgExt(TargetTriple);
       std::ostringstream OS;
-      OS << "define " << ArgExt.Ret << " i32 "
+      OS << "define " << ArgExt.Ret << "i32 "
          << "@sum(i32 " << ArgExt.Arg << "%x, i32 " << ArgExt.Arg << "%y)"
          << R"( {
           entry:

--- a/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
@@ -38,11 +38,11 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ThreadSafeModule, LLVMOrcThreadSafeModuleRef)
 struct TargetI32ArgExtensions {
   std::string Ret;
   std::string Arg;
-  TargetI32ArgExtensions(std::string TargetTriple) {
+  TargetI32ArgExtensions(std::string TargetTriple, bool Signed = true) {
     Triple T(TargetTriple);
-    if (auto AK = TargetLibraryInfo::getExtAttrForI32Return(T))
+    if (auto AK = TargetLibraryInfo::getExtAttrForI32Return(T, Signed))
       Ret = Attribute::getNameFromAttrKind(AK);
-    if (auto AK = TargetLibraryInfo::getExtAttrForI32Param(T))
+    if (auto AK = TargetLibraryInfo::getExtAttrForI32Param(T, Signed))
       Arg = Attribute::getNameFromAttrKind(AK);
   }
 };


### PR DESCRIPTION
Use static std::strings for the textual representations of @sum(). The usage of static variables is already there, e.g. with TargetTriple, so I have assumed that this is thread-safe.

The TargetTriple is not the full Triple class, but just the string representation. If the complete version of this is needed, the full Triple is needed so that it can be passed to TargetLibraryInfo getExtAttrForI32Param/Return. For now, there is just a string recognition of s390 which does need the extensions. Maybe this is ok for now as this is just a test, after all..?

Fixes: #112503
