### PR TITLE
[llvm-cxxfilt] De-emphasize "function" in llvm-cxxfilt docs and --help

### DIFF
--- a/llvm/docs/CommandGuide/llvm-cxxfilt.rst
+++ b/llvm/docs/CommandGuide/llvm-cxxfilt.rst
@@ -59,8 +59,7 @@ OPTIONS
 
 .. option:: --quote
 
-  Add `"` `"` around demangled function symbols. Do not quote already quoted
-  symbols.
+  Add `"` `"` around demangled names. Do not quote already quoted names.
 
 .. option:: --strip-underscore, -_
 
@@ -69,7 +68,7 @@ OPTIONS
 
 .. option:: --types, -t
 
-  Attempt to demangle names as type names as well as function names.
+  Attempt to demangle names as type names as well as symbol names.
 
 .. option:: --version
 

--- a/llvm/tools/llvm-cxxfilt/Opts.td
+++ b/llvm/tools/llvm-cxxfilt/Opts.td
@@ -15,9 +15,9 @@ multiclass Eq<string name, string help> {
 }
 
 def help : FF<"help", "Display this help">;
-def quote : FF<"quote", "Quote demangled function names with \" \" if not already quoted">;
+def quote : FF<"quote", "Quote demangled names with \" \" if not already quoted">;
 defm strip_underscore : BB<"strip-underscore", "Strip the leading underscore", "Don't strip the leading underscore">;
-def types : FF<"types", "Attempt to demangle types as well as function names">;
+def types : FF<"types", "Attempt to demangle types as well as symbol names">;
 def no_params : FF<"no-params", "Skip function parameters and return types">;
 def version : FF<"version", "Display the version">;
 


### PR DESCRIPTION
llvm-cxxfilt can demangle names of data symbols, in addition to function names.

    $ llvm-cxxfilt _Z4data
    data

And type names too, on request:

    $ llvm-cxxfilt -t i
    int

Update some overly specific the wording in the --help and documentation that suggests otherwise.