### PR TITLE
[libc++] Add a escape hatch for making __libcpp_verbose_abort non-noexcept again

### DIFF
--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -83,7 +83,9 @@ Deprecations and Removals
   ambiguity in name lookup. Code that expects such ambiguity will possibly not compile in LLVM 20.
 
 - The function ``__libcpp_verbose_abort()`` is now ``noexcept``, to match ``std::terminate()``. (The combination of
-  ``noexcept`` and ``[[noreturn]]`` has special significance for function effects analysis.)
+  ``noexcept`` and ``[[noreturn]]`` has special significance for function effects analysis.) For backwards compatibility,
+  the ``_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT`` macro can be defined to make the function non-``noexcept``. That macro
+  will be removed in LLVM 21.
 
 Upcoming Deprecations and Removals
 ----------------------------------
@@ -105,6 +107,9 @@ LLVM 21
 
   If you are using C++03 in your project, you should consider moving to a newer version of the Standard to get the most
   out of libc++.
+
+- The ``_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT`` macro will be removed in LLVM 21, making ``std::__libcpp_verbose_abort``
+  unconditionally ``noexcept``.
 
 
 ABI Affecting Changes

--- a/libcxx/include/__verbose_abort
+++ b/libcxx/include/__verbose_abort
@@ -18,10 +18,16 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
+#if defined(_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT)
+#  define _LIBCPP_VERBOSE_ABORT_NOEXCEPT
+#else
+#  define _LIBCPP_VERBOSE_ABORT_NOEXCEPT _NOEXCEPT
+#endif
+
 // This function should never be called directly from the code -- it should only be called through
 // the _LIBCPP_VERBOSE_ABORT macro.
 [[__noreturn__]] _LIBCPP_AVAILABILITY_VERBOSE_ABORT _LIBCPP_OVERRIDABLE_FUNC_VIS
-_LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...) _NOEXCEPT;
+_LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...) _LIBCPP_VERBOSE_ABORT_NOEXCEPT;
 
 // _LIBCPP_VERBOSE_ABORT(format, args...)
 //

--- a/libcxx/include/__verbose_abort
+++ b/libcxx/include/__verbose_abort
@@ -26,8 +26,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // This function should never be called directly from the code -- it should only be called through
 // the _LIBCPP_VERBOSE_ABORT macro.
-[[__noreturn__]] _LIBCPP_AVAILABILITY_VERBOSE_ABORT _LIBCPP_OVERRIDABLE_FUNC_VIS
-_LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...) _LIBCPP_VERBOSE_ABORT_NOEXCEPT;
+[[__noreturn__]] _LIBCPP_AVAILABILITY_VERBOSE_ABORT _LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_ATTRIBUTE_FORMAT(
+    __printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...) _LIBCPP_VERBOSE_ABORT_NOEXCEPT;
 
 // _LIBCPP_VERBOSE_ABORT(format, args...)
 //

--- a/libcxx/src/verbose_abort.cpp
+++ b/libcxx/src/verbose_abort.cpp
@@ -28,7 +28,7 @@ extern "C" void android_set_abort_message(const char* msg);
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-_LIBCPP_WEAK void __libcpp_verbose_abort(char const* format, ...) noexcept {
+_LIBCPP_WEAK void __libcpp_verbose_abort(char const* format, ...) _LIBCPP_VERBOSE_ABORT_NOEXCEPT {
   // Write message to stderr. We do this before formatting into a
   // buffer so that we still get some information out if that fails.
   {


### PR DESCRIPTION
This allows a slightly smoother transition for people after #109151, as requested on that PR.