### PR TITLE
[flang][NFC] turn (h)fir.declare side effect into debug ressource alloca

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3078,7 +3078,7 @@ def fir_IsPresentOp : fir_SimpleOp<"is_present", [NoMemoryEffect]> {
 // debug information so we would like to keep this around even if the value
 // is not used.
 def fir_DeclareOp : fir_Op<"declare", [AttrSizedOperandSegments,
-    MemoryEffects<[MemWrite<DebuggingResource>]>,
+    MemoryEffects<[MemAlloc<DebuggingResource>]>,
     DeclareOpInterfaceMethods<fir_FortranVariableOpInterface>]> {
   let summary = "declare a variable";
 

--- a/flang/include/flang/Optimizer/HLFIR/HLFIROps.td
+++ b/flang/include/flang/Optimizer/HLFIR/HLFIROps.td
@@ -36,7 +36,7 @@ class hlfir_Op<string mnemonic, list<Trait> traits>
 // from the declare operation can be used to generate debug information so we
 // don't want to remove it as dead code
 def hlfir_DeclareOp : hlfir_Op<"declare", [AttrSizedOperandSegments,
-    MemoryEffects<[MemWrite<DebuggingResource>]>,
+    MemoryEffects<[MemAlloc<DebuggingResource>]>,
     DeclareOpInterfaceMethods<fir_FortranVariableOpInterface>]> {
   let summary = "declare a variable and produce an SSA value that can be used as a variable in HLFIR operations";
 


### PR DESCRIPTION
See https://reviews.llvm.org/D157626 for the rational of declare having side effects.

The write effect is to scary for passes that look for read/write effects without caring about the resource affected. I know Slava asked for it, but I think the creation of the `DebuggingResource` was enough and that a write is too much. The alloca effect is sufficient to prevent DCE to remove it, which is all we care about currently.

This currently is flag as a reason for creating LHS temporary in assignment to vector subscripted entity with array constructor. 
There is a lot of read/write side effect analysis in the "lower-hlfir-ordered-assignments" pass, and I feel like we will just keep adding weird "debug ressource" bypassing here and there with these side effects.