### PR TITLE
Define CLANG_ABI and LLVM_ABI for z/OS

### DIFF
--- a/clang/include/clang/Support/Compiler.h
+++ b/clang/include/clang/Support/Compiler.h
@@ -49,7 +49,7 @@
 #define CLANG_TEMPLATE_ABI __declspec(dllimport)
 #define CLANG_EXPORT_TEMPLATE
 #endif
-#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX)
+#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) || defined(__MVS__)
 #define CLANG_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define CLANG_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define CLANG_EXPORT_TEMPLATE

--- a/clang/include/clang/Support/Compiler.h
+++ b/clang/include/clang/Support/Compiler.h
@@ -49,7 +49,8 @@
 #define CLANG_TEMPLATE_ABI __declspec(dllimport)
 #define CLANG_EXPORT_TEMPLATE
 #endif
-#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) || defined(__MVS__)
+#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||             \
+    defined(__MVS__)
 #define CLANG_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define CLANG_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define CLANG_EXPORT_TEMPLATE

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -197,7 +197,8 @@
 #define LLVM_EXPORT_TEMPLATE
 #endif
 #define LLVM_ABI_EXPORT __declspec(dllexport)
-#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) || defined(__MVS__)
+#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||             \
+    defined(__MVS__)
 #define LLVM_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define LLVM_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define LLVM_EXPORT_TEMPLATE

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -197,7 +197,7 @@
 #define LLVM_EXPORT_TEMPLATE
 #endif
 #define LLVM_ABI_EXPORT __declspec(dllexport)
-#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX)
+#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) || defined(__MVS__)
 #define LLVM_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define LLVM_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 #define LLVM_EXPORT_TEMPLATE


### PR DESCRIPTION
This patch fixes the build failure seen on z/OS:

```
llvm/clang/include/clang/ASTMatchers/ASTMatchers.h:7212:1: error: unknown type name 'CLANG_ABI'
```