### PR TITLE
[clang codegen] avoid to crash when emit init func for global variable with flexible array init

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -442,6 +442,7 @@ Bug Fixes in This Version
 - Fixed a crash using ``__array_rank`` on 64-bit targets. (#GH113044).
 - The warning emitted for an unsupported register variable type now points to
   the unsupported type instead of the ``register`` keyword (#GH109776).
+- Fixed a crash when emit ctor for global variant with flexible array init  (#GH113187).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5529,12 +5529,14 @@ void CodeGenModule::EmitGlobalVarDefinition(const VarDecl *D,
         T = D->getType();
 
       if (getLangOpts().CPlusPlus) {
-        if (InitDecl->hasFlexibleArrayInit(getContext()))
-          ErrorUnsupported(D, "flexible array initializer");
         Init = EmitNullConstant(T);
-
         if (!IsDefinitionAvailableExternally)
           NeedsGlobalCtor = true;
+        if (InitDecl->hasFlexibleArrayInit(getContext())) {
+          ErrorUnsupported(D, "flexible array initializer");
+          // We cannot create ctor for flexible array initializer
+          NeedsGlobalCtor = false;
+        }
       } else {
         ErrorUnsupported(D, "static initializer");
         Init = llvm::UndefValue::get(getTypes().ConvertType(T));

--- a/clang/test/CodeGenCXX/flexible-array-init.cpp
+++ b/clang/test/CodeGenCXX/flexible-array-init.cpp
@@ -2,6 +2,7 @@
 // RUN: %clang_cc1 -triple i386-unknown-unknown -emit-llvm-only -verify -DFAIL1 %s
 // RUN: %clang_cc1 -triple i386-unknown-unknown -emit-llvm-only -verify -DFAIL2 %s
 // RUN: %clang_cc1 -triple i386-unknown-unknown -emit-llvm-only -verify -DFAIL3 %s
+// RUN: %clang_cc1 -triple i386-unknown-unknown -emit-llvm-only -verify -DFAIL4 %s
 
 struct A { int x; int y[]; };
 A a = { 1, 7, 11 };
@@ -22,6 +23,11 @@ void g() {
 #ifdef FAIL3
 struct B { int x; char y; char z[]; };
 B e = {f(), f(), f(), f()}; // expected-error {{cannot compile this flexible array initializer yet}}
+#endif
+#ifdef FAIL4
+union { char a[]; } z = {};
+union { char a[]; } z0 = {z.a[0]}; // expected-error {{cannot compile this flexible array initializer yet}}
+char keep() {	return z0.a[0]; }
 #endif
 
 namespace zero_initializer {


### PR DESCRIPTION
Fixes: #113187
Avoid to create init function since clang does not support global variable with flexible array init.
It will cause assertion failure later.
