### PR TITLE
[AArch64] Add assembly/disassembly for FMOP4{A,S} (non-widening) double-precision instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
@@ -1055,3 +1055,8 @@ let Predicates = [HasSME2p2, HasSMEB16B16] in {
   defm BFMOP4A : sme2_bfmop4as_non_widening<0, "bfmop4a">;
   defm BFMOP4S : sme2_bfmop4as_non_widening<1, "bfmop4s">;
 }
+
+let Predicates = [HasSME2p2, HasSMEF64F64] in {
+  defm FMOP4A : sme2_fmop4as_fp64_non_widening<0, "fmop4a">;
+  defm FMOP4S : sme2_fmop4as_fp64_non_widening<1, "fmop4s">;
+}

--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -5491,3 +5491,40 @@ multiclass sme2_fmop4as_fp32_non_widening<bit S, string mnemonic> {
   // Multiple vectors
   def _M2Z2Z_S : sme2_fp32_quarter_tile_outer_product<1, 1, S, mnemonic, ZZ_s_mul_r_Lo, ZZ_s_mul_r_Hi>;
 }
+
+class sme2_fp64_quarter_tile_outer_product<bit M, bit N, bit S, string mnemonic, RegisterOperand zn_ty, RegisterOperand zm_ty>
+    : I<(outs TileOp64:$ZAda),
+        (ins TileOp64:$_ZAda, zn_ty:$Zn, zm_ty:$Zm),
+        mnemonic, "\t$ZAda, $Zn, $Zm",
+        "", []>, Sched<[]> {
+  bits<3> ZAda;
+  bits<3> Zn;
+  bits<3> Zm;
+
+  let Inst{31-21} = 0b10000000110;
+  let Inst{20} = M;
+  let Inst{19-17} = Zm;
+  let Inst{16-10} = 0b0000000;
+  let Inst{9} = N;
+  let Inst{8-6} = Zn;
+  let Inst{5} = 0;
+  let Inst{4} = S;
+  let Inst{3} = 0b1;
+  let Inst{2-0} = ZAda;
+
+  let Constraints = "$ZAda = $_ZAda";
+}
+
+multiclass sme2_fmop4as_fp64_non_widening<bit S, string mnemonic> {
+  // Single vectors
+  def _MZZ_D : sme2_fp64_quarter_tile_outer_product<0, 0, S, mnemonic, ZPR64Mul2_Lo, ZPR64Mul2_Hi>;
+
+  // Multiple and single vectors
+  def _M2ZZ_D : sme2_fp64_quarter_tile_outer_product<0, 1, S, mnemonic, ZZ_d_mul_r_Lo, ZPR64Mul2_Hi>;
+
+  // Single and multiple vectors
+  def _MZ2Z_D : sme2_fp64_quarter_tile_outer_product<1, 0, S, mnemonic, ZPR64Mul2_Lo, ZZ_d_mul_r_Hi>;
+
+  // Multiple vectors
+  def _M2Z2Z_D : sme2_fp64_quarter_tile_outer_product<1, 1, S, mnemonic, ZZ_d_mul_r_Lo, ZZ_d_mul_r_Hi>;
+}

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening-diagnostics.s
@@ -1,0 +1,243 @@
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f64f64 < %s 2>&1 | FileCheck %s
+
+// FMOP4A
+
+// Single vectors
+
+fmop4a za0.s, z0.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.s..z14.s
+
+fmop4a za8.d, z0.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, z0.s, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4a za0.d, z15.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4a za0.d, z16.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4a za0.d, z0.d, z16.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4a za0.d, z12.d, z17.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4a za0.d, z12.d, z14.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4a za0.d, z12.d, z31.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+// Single and multiple vectors
+
+fmop4a za0.s, z0.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.s..z14.s
+
+fmop4a za8.d, z0.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, z0.s, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4a za0.d, z1.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4a za0.d, z16.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4a za0.d, z0.d, {z16.s-z17.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, z0.d, {z17.d-z18.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.d, z0.d, {z16.d-z18.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, z0.d, {z12.d-z13.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+// Multiple and single vectors
+
+fmop4a za0.s, {z0.d-z1.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za8.d, {z0.d-z1.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z0.s-z1.s}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z1.d-z2.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.d, {z0.d-z2.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z16.d-z17.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.d, {z0.d-z1.d}, z16.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4a za0.d, {z0.d-z1.d}, z17.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4a za0.d, {z0.d-z1.d}, z12.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+// Multiple vectors
+
+fmop4a za0.s, {z0.d-z1.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za8.d, {z0.d-z1.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z0.s-z1.s}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z1.d-z2.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.d, {z0.d-z2.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z18.d-z19.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.d, {z0.d-z1.d}, {z16.s-z17.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z0.d-z1.d}, {z19.d-z20.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.d, {z0.d-z1.d}, {z16.d-z18.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.d, {z0.d-z1.d}, {z10.d-z11.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+// FMOP4S
+
+// Single vectors
+
+fmop4s za0.s, z0.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.s..z14.s
+
+fmop4s za8.d, z0.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, z0.s, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4s za0.d, z15.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4s za0.d, z16.d, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4s za0.d, z0.d, z16.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4s za0.d, z12.d, z17.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4s za0.d, z12.d, z14.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4s za0.d, z12.d, z31.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+// Single and multiple vectors
+
+fmop4s za0.s, z0.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.s..z14.s
+
+fmop4s za8.d, z0.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, z0.s, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4s za0.d, z1.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4s za0.d, z16.d, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.d..z14.d
+
+fmop4s za0.d, z0.d, {z16.s-z17.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, z0.d, {z17.d-z18.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+fmop4s za0.d, z0.d, {z16.d-z18.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, z0.d, {z12.d-z13.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+// Multiple and single vectors
+
+fmop4s za0.s, {z0.d-z1.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za8.d, {z0.d-z1.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z0.s-z1.s}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z1.d-z2.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4s za0.d, {z0.d-z2.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z16.d-z17.d}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4s za0.d, {z0.d-z1.d}, z16.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4s za0.d, {z0.d-z1.d}, z17.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+fmop4s za0.d, {z0.d-z1.d}, z12.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.d..z30.d
+
+// Multiple vectors
+
+fmop4s za0.s, {z0.d-z1.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za8.d, {z0.d-z1.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z0.s-z1.s}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z1.d-z2.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4s za0.d, {z0.d-z2.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z18.d-z19.d}, {z16.d-z17.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4s za0.d, {z0.d-z1.d}, {z16.s-z17.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z0.d-z1.d}, {z19.d-z20.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+fmop4s za0.d, {z0.d-z1.d}, {z16.d-z18.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4s za0.d, {z0.d-z1.d}, {z10.d-z11.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
@@ -6,7 +6,7 @@
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f64f64 < %s \
 // RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f64f64 - | FileCheck %s --check-prefix=CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f64f64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f64f64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
@@ -1,0 +1,180 @@
+
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f64f64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f64f64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f64f64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f64f64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f64f64 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f64f64 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+
+// FMOP4A
+
+// Single vectors
+
+fmop4a  za0.d, z0.d, z16.d  // 10000000-11000000-00000000-00001000
+// CHECK-INST: fmop4a  za0.d, z0.d, z16.d
+// CHECK-ENCODING: [0x08,0x00,0xc0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c00008 <unknown>
+
+fmop4a  za5.d, z10.d, z20.d  // 10000000-11000100-00000001-01001101
+// CHECK-INST: fmop4a  za5.d, z10.d, z20.d
+// CHECK-ENCODING: [0x4d,0x01,0xc4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c4014d <unknown>
+
+fmop4a  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11001111
+// CHECK-INST: fmop4a  za7.d, z14.d, z30.d
+// CHECK-ENCODING: [0xcf,0x01,0xce,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80ce01cf <unknown>
+
+// Single and multiple vectors
+
+fmop4a  za0.d, z0.d, {z16.d-z17.d}  // 10000000-11010000-00000000-00001000
+// CHECK-INST: fmop4a  za0.d, z0.d, { z16.d, z17.d }
+// CHECK-ENCODING: [0x08,0x00,0xd0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d00008 <unknown>
+
+fmop4a  za5.d, z10.d, {z20.d-z21.d}  // 10000000-11010100-00000001-01001101
+// CHECK-INST: fmop4a  za5.d, z10.d, { z20.d, z21.d }
+// CHECK-ENCODING: [0x4d,0x01,0xd4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d4014d <unknown>
+
+fmop4a  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11001111
+// CHECK-INST: fmop4a  za7.d, z14.d, { z30.d, z31.d }
+// CHECK-ENCODING: [0xcf,0x01,0xde,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80de01cf <unknown>
+
+// Multiple and single vectors
+
+fmop4a  za0.d, {z0.d-z1.d}, z16.d  // 10000000-11000000-00000010-00001000
+// CHECK-INST: fmop4a  za0.d, { z0.d, z1.d }, z16.d
+// CHECK-ENCODING: [0x08,0x02,0xc0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c00208 <unknown>
+
+fmop4a  za5.d, {z10.d-z11.d}, z20.d  // 10000000-11000100-00000011-01001101
+// CHECK-INST: fmop4a  za5.d, { z10.d, z11.d }, z20.d
+// CHECK-ENCODING: [0x4d,0x03,0xc4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c4034d <unknown>
+
+fmop4a  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11001111
+// CHECK-INST: fmop4a  za7.d, { z14.d, z15.d }, z30.d
+// CHECK-ENCODING: [0xcf,0x03,0xce,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80ce03cf <unknown>
+
+// Multiple vectors
+
+fmop4a  za0.d, {z0.d-z1.d}, {z16.d-z17.d}  // 10000000-11010000-00000010-00001000
+// CHECK-INST: fmop4a  za0.d, { z0.d, z1.d }, { z16.d, z17.d }
+// CHECK-ENCODING: [0x08,0x02,0xd0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d00208 <unknown>
+
+fmop4a  za5.d, {z10.d-z11.d}, {z20.d-z21.d}  // 10000000-11010100-00000011-01001101
+// CHECK-INST: fmop4a  za5.d, { z10.d, z11.d }, { z20.d, z21.d }
+// CHECK-ENCODING: [0x4d,0x03,0xd4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d4034d <unknown>
+
+fmop4a  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11001111
+// CHECK-INST: fmop4a  za7.d, { z14.d, z15.d }, { z30.d, z31.d }
+// CHECK-ENCODING: [0xcf,0x03,0xde,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80de03cf <unknown>
+
+
+// FMOP4S
+
+// Single vectors
+
+fmop4s  za0.d, z0.d, z16.d  // 10000000-11000000-00000000-00011000
+// CHECK-INST: fmop4s  za0.d, z0.d, z16.d
+// CHECK-ENCODING: [0x18,0x00,0xc0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c00018 <unknown>
+
+fmop4s  za5.d, z10.d, z20.d  // 10000000-11000100-00000001-01011101
+// CHECK-INST: fmop4s  za5.d, z10.d, z20.d
+// CHECK-ENCODING: [0x5d,0x01,0xc4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c4015d <unknown>
+
+fmop4s  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11011111
+// CHECK-INST: fmop4s  za7.d, z14.d, z30.d
+// CHECK-ENCODING: [0xdf,0x01,0xce,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80ce01df <unknown>
+
+// Single and multiple vectors
+
+fmop4s  za0.d, z0.d, {z16.d-z17.d}  // 10000000-11010000-00000000-00011000
+// CHECK-INST: fmop4s  za0.d, z0.d, { z16.d, z17.d }
+// CHECK-ENCODING: [0x18,0x00,0xd0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d00018 <unknown>
+
+fmop4s  za5.d, z10.d, {z20.d-z21.d}  // 10000000-11010100-00000001-01011101
+// CHECK-INST: fmop4s  za5.d, z10.d, { z20.d, z21.d }
+// CHECK-ENCODING: [0x5d,0x01,0xd4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d4015d <unknown>
+
+fmop4s  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11011111
+// CHECK-INST: fmop4s  za7.d, z14.d, { z30.d, z31.d }
+// CHECK-ENCODING: [0xdf,0x01,0xde,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80de01df <unknown>
+
+// Multiple and single vectors
+
+fmop4s  za0.d, {z0.d-z1.d}, z16.d  // 10000000-11000000-00000010-00011000
+// CHECK-INST: fmop4s  za0.d, { z0.d, z1.d }, z16.d
+// CHECK-ENCODING: [0x18,0x02,0xc0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c00218 <unknown>
+
+fmop4s  za5.d, {z10.d-z11.d}, z20.d  // 10000000-11000100-00000011-01011101
+// CHECK-INST: fmop4s  za5.d, { z10.d, z11.d }, z20.d
+// CHECK-ENCODING: [0x5d,0x03,0xc4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80c4035d <unknown>
+
+fmop4s  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11011111
+// CHECK-INST: fmop4s  za7.d, { z14.d, z15.d }, z30.d
+// CHECK-ENCODING: [0xdf,0x03,0xce,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80ce03df <unknown>
+
+// Multiple vectors
+
+fmop4s  za0.d, {z0.d-z1.d}, {z16.d-z17.d}  // 10000000-11010000-00000010-00011000
+// CHECK-INST: fmop4s  za0.d, { z0.d, z1.d }, { z16.d, z17.d }
+// CHECK-ENCODING: [0x18,0x02,0xd0,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d00218 <unknown>
+
+fmop4s  za5.d, {z10.d-z11.d}, {z20.d-z21.d}  // 10000000-11010100-00000011-01011101
+// CHECK-INST: fmop4s  za5.d, { z10.d, z11.d }, { z20.d, z21.d }
+// CHECK-ENCODING: [0x5d,0x03,0xd4,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80d4035d <unknown>
+
+fmop4s  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11011111
+// CHECK-INST: fmop4s  za7.d, { z14.d, z15.d }, { z30.d, z31.d }
+// CHECK-ENCODING: [0xdf,0x03,0xde,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-UNKNOWN: 80de03df <unknown>


### PR DESCRIPTION
The new instructions are described in
https://developer.arm.com/documentation/ddi0602/2024-09/SME-Instructions