### PR TITLE
[AArch64] Add assembly/disassembly for FMOP4A (widening, 2-way, FP8 to FP16) instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
@@ -1071,6 +1071,7 @@ let Predicates = [HasSME2p2, HasSMEF8F32], Uses = [FPMR, FPCR] in {
 
 let Predicates = [HasSME2p2, HasSMEF8F16], Uses = [FPMR, FPCR] in {
   def FTMOPA_M2ZZZI_BtoH : sme_tmopa_16b<0b01001, ZZ_b_mul_r, ZPR8, "ftmopa">;
+  defm FMOP4A : sme2_fmop4a_fp8_fp16_2way<"fmop4a">;
 } // [HasSME2p2, HasSMEF8F16],  Uses = [FPMR, FPCR]
 
 let Predicates = [HasSME2p2, HasSMEF16F16] in {

--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -5728,14 +5728,14 @@ class sme2_fp8_fp16_quarter_tile_outer_product<bit M, bit N, string mnemonic, Re
 
 multiclass sme2_fmop4a_fp8_fp16_2way<string mnemonic> {
   // Single vectors
-  def _MZZ_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0, 0, mnemonic, ZPR8Mul2_Lo, ZPR8Mul2_Hi>;
+  def _MZZ_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0b0, 0b0, mnemonic, ZPR8Mul2_Lo, ZPR8Mul2_Hi>;
 
   // Multiple and single vectors
-  def _M2ZZ_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0, 1, mnemonic, ZZ_b_mul_r_Lo, ZPR8Mul2_Hi>;
+  def _M2ZZ_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0b0, 0b1, mnemonic, ZZ_b_mul_r_Lo, ZPR8Mul2_Hi>;
 
   // Single and multiple vectors
-  def _MZ2Z_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<1, 0, mnemonic, ZPR8Mul2_Lo, ZZ_b_mul_r_Hi>;
+  def _MZ2Z_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0b1, 0b0, mnemonic, ZPR8Mul2_Lo, ZZ_b_mul_r_Hi>;
 
   // Multiple vectors
-  def _M2Z2Z_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<1, 1, mnemonic, ZZ_b_mul_r_Lo, ZZ_b_mul_r_Hi>;
+  def _M2Z2Z_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0b1, 0b1, mnemonic, ZZ_b_mul_r_Lo, ZZ_b_mul_r_Hi>;
 }

--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -5704,3 +5704,38 @@ multiclass sme2_fmop4as_fp16_fp32_widening<bit S, string mnemonic> {
   // Multiple vectors
   def _M2Z2Z_HtoS : sme2_fp16_fp32_quarter_tile_outer_product<1, 1, S, mnemonic, ZZ_h_mul_r_Lo, ZZ_h_mul_r_Hi>;
 }
+
+class sme2_fp8_fp16_quarter_tile_outer_product<bit M, bit N, string mnemonic, RegisterOperand zn_ty, RegisterOperand zm_ty>
+    : I<(outs TileOp16:$ZAda),
+        (ins TileOp16:$_ZAda, zn_ty:$Zn, zm_ty:$Zm),
+        mnemonic, "\t$ZAda, $Zn, $Zm",
+        "", []>, Sched<[]> {
+  bit     ZAda;
+  bits<3> Zn;
+  bits<3> Zm;
+
+  let Inst{31-21} = 0b10000000001;
+  let Inst{20} = M;
+  let Inst{19-17} = Zm;
+  let Inst{16-10} = 0b0000000;
+  let Inst{9} = N;
+  let Inst{8-6} = Zn;
+  let Inst{5-1} = 0b00100;
+  let Inst{0} = ZAda;
+
+  let Constraints = "$ZAda = $_ZAda";
+}
+
+multiclass sme2_fmop4a_fp8_fp16_2way<string mnemonic> {
+  // Single vectors
+  def _MZZ_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0, 0, mnemonic, ZPR8Mul2_Lo, ZPR8Mul2_Hi>;
+
+  // Multiple and single vectors
+  def _M2ZZ_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<0, 1, mnemonic, ZZ_b_mul_r_Lo, ZPR8Mul2_Hi>;
+
+  // Single and multiple vectors
+  def _MZ2Z_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<1, 0, mnemonic, ZPR8Mul2_Lo, ZZ_b_mul_r_Hi>;
+
+  // Multiple vectors
+  def _M2Z2Z_BtoH : sme2_fp8_fp16_quarter_tile_outer_product<1, 1, mnemonic, ZZ_b_mul_r_Lo, ZZ_b_mul_r_Hi>;
+}

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening-diagnostics.s
@@ -1,0 +1,120 @@
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f8f16 < %s 2>&1 | FileCheck %s
+
+// Single vectors
+
+fmop4a za0.d, z0.b, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid matrix operand
+
+fmop4a za2.h, z0.b, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, z0.s, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.b..z14.b
+
+fmop4a za0.h, z15.b, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.b..z14.b
+
+fmop4a za0.h, z16.b, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.b..z14.b
+
+fmop4a za0.h, z0.b, z16.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.b..z30.b
+
+fmop4a za0.h, z12.b, z17.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.b..z30.b
+
+fmop4a za0.h, z12.b, z14.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.b..z30.b
+
+fmop4a za0.h, z12.b, z31.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.b..z30.b
+
+// Single and multiple vectors
+
+fmop4a za0.d, z0.b, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid matrix operand
+
+fmop4a za2.h, z0.b, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, z0.s, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.b..z14.b
+
+fmop4a za0.h, z1.b, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.b..z14.b
+
+fmop4a za0.h, z16.b, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z0.b..z14.b
+
+fmop4a za0.h, z0.b, {z16.s-z17.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, z0.b, {z17.b-z18.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.h, z0.b, {z16.b-z18.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, z0.b, {z12.b-z13.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+// Multiple and single vectors
+
+fmop4a za0.d, {z0.b-z1.b}, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid matrix operand
+
+fmop4a za2.h, {z0.b-z1.b}, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, {z0.s-z1.b}, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: mismatched register size suffix
+
+fmop4a za0.h, {z1.b-z2.b}, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za2.h, {z0.b-z2.b}, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, {z16.b-z17.b}, z16.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.h, {z0.b-z1.b}, z16.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.b..z30.b
+
+fmop4a za0.h, {z0.b-z1.b}, z17.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.b..z30.b
+
+fmop4a za0.h, {z0.b-z1.b}, z12.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid restricted vector register, expected even register in z16.b..z30.b
+
+// Multiple vectors
+
+fmop4a za0.d, {z0.b-z1.b}, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid matrix operand
+
+fmop4a za2.h, {z0.b-z1.b}, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, {z0.s-z1.s}, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, {z1.b-z2.b}, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.h, {z0.b-z2.b}, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, {z18.b-z19.b}, {z16.b-z17.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z0-z14, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.h, {z0.b-z1.b}, {z16.s-z17.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, {z0.b-z1.b}, {z19.b-z20.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types
+
+fmop4a za0.h, {z0.b-z1.b}, {z18.b-z20.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+fmop4a za0.h, {z0.b-z1.b}, {z10.b-z11.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors in the range z16-z30, where the first vector is a multiple of 2 and with matching element types

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening.s
@@ -1,0 +1,95 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f16 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f8f16 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f16 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f8f16 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+// Single vectors
+
+fmop4a  za0.h, z0.b, z16.b  // 10000000-00100000-00000000-00001000
+// CHECK-INST: fmop4a  za0.h, z0.b, z16.b
+// CHECK-ENCODING: [0x08,0x00,0x20,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80200008 <unknown>
+
+fmop4a  za1.h, z12.b, z24.b  // 10000000-00101000-00000001-10001001
+// CHECK-INST: fmop4a  za1.h, z12.b, z24.b
+// CHECK-ENCODING: [0x89,0x01,0x28,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80280189 <unknown>
+
+fmop4a  za1.h, z14.b, z30.b  // 10000000-00101110-00000001-11001001
+// CHECK-INST: fmop4a  za1.h, z14.b, z30.b
+// CHECK-ENCODING: [0xc9,0x01,0x2e,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 802e01c9 <unknown>
+
+// Single and multiple vectors
+
+fmop4a  za0.h, z0.b, {z16.b-z17.b}  // 10000000-00110000-00000000-00001000
+// CHECK-INST: fmop4a  za0.h, z0.b, { z16.b, z17.b }
+// CHECK-ENCODING: [0x08,0x00,0x30,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80300008 <unknown>
+
+fmop4a  za1.h, z10.b, {z20.b-z21.b}  // 10000000-00110100-00000001-01001001
+// CHECK-INST: fmop4a  za1.h, z10.b, { z20.b, z21.b }
+// CHECK-ENCODING: [0x49,0x01,0x34,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80340149 <unknown>
+
+fmop4a  za1.h, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11001001
+// CHECK-INST: fmop4a  za1.h, z14.b, { z30.b, z31.b }
+// CHECK-ENCODING: [0xc9,0x01,0x3e,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 803e01c9 <unknown>
+
+// Multiple and single vectors
+
+fmop4a  za0.h, {z0.b-z1.b}, z16.b  // 10000000-00100000-00000010-00001000
+// CHECK-INST: fmop4a  za0.h, { z0.b, z1.b }, z16.b
+// CHECK-ENCODING: [0x08,0x02,0x20,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80200208 <unknown>
+
+fmop4a  za1.h, {z10.b-z11.b}, z20.b  // 10000000-00100100-00000011-01001001
+// CHECK-INST: fmop4a  za1.h, { z10.b, z11.b }, z20.b
+// CHECK-ENCODING: [0x49,0x03,0x24,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80240349 <unknown>
+
+fmop4a  za1.h, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11001001
+// CHECK-INST: fmop4a  za1.h, { z14.b, z15.b }, z30.b
+// CHECK-ENCODING: [0xc9,0x03,0x2e,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 802e03c9 <unknown>
+
+
+// Multiple vectors
+
+fmop4a  za0.h, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-00000010-00001000
+// CHECK-INST: fmop4a  za0.h, { z0.b, z1.b }, { z16.b, z17.b }
+// CHECK-ENCODING: [0x08,0x02,0x30,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80300208 <unknown>
+
+fmop4a  za1.h, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-00000011-01001001
+// CHECK-INST: fmop4a  za1.h, { z10.b, z11.b }, { z20.b, z21.b }
+// CHECK-ENCODING: [0x49,0x03,0x34,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 80340349 <unknown>
+
+fmop4a  za1.h, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-00000011-11001001
+// CHECK-INST: fmop4a  za1.h, { z14.b, z15.b }, { z30.b, z31.b }
+// CHECK-ENCODING: [0xc9,0x03,0x3e,0x80]
+// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-UNKNOWN: 803e03c9 <unknown>
+


### PR DESCRIPTION
The new instructions are described in
https://developer.arm.com/documentation/ddi0602/2024-09/SME-Instructions