### PR TITLE
[SystemZ] Introduce GNU and HLASM differences to asmwriter and update tests

### DIFF
--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMInstPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMInstPrinter.cpp
@@ -36,6 +36,10 @@ void SystemZHLASMInstPrinter::printInst(const MCInst *MI, uint64_t Address,
   // Eat the first tab character and replace it with a space since it is
   // hardcoded in AsmWriterEmitter::EmitPrintInstruction
   // TODO: introduce a line prefix member to AsmWriter to avoid this problem
-  O << " " << Str.substr(1, Str.length());
+  if (!Str.empty() && Str.front() == '\t')
+    O << " " << Str.substr(1, Str.length());
+  else
+    O << Str;
+
   printAnnotation(O, Annot);
 }

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMInstPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMInstPrinter.cpp
@@ -30,6 +30,12 @@ void SystemZHLASMInstPrinter::printInst(const MCInst *MI, uint64_t Address,
                                         StringRef Annot,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
-  printInstruction(MI, Address, O);
+  std::string Str;
+  raw_string_ostream RSO(Str);
+  printInstruction(MI, Address, RSO);
+  // Eat the first tab character and replace it with a space since it is
+  // hardcoded in AsmWriterEmitter::EmitPrintInstruction
+  // TODO: introduce a line prefix member to AsmWriter to avoid this problem
+  O << " " << Str.substr(1, Str.length());
   printAnnotation(O, Annot);
 }

--- a/llvm/lib/Target/SystemZ/SystemZInstrFormats.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrFormats.td
@@ -18,7 +18,8 @@ class InstSystemZ<int size, dag outs, dag ins, string asmstr,
   dag InOperandList = ins;
   let Size = size;
   let Pattern = pattern;
-  let AsmString = asmstr;
+  // Convert tabs to spaces, and remove space after comma for HLASM syntax
+  let AsmString = !subst("\t", "{\t| }", !subst(", ", "{, |,}", asmstr));
 
   let hasSideEffects = 0;
   let mayLoad = 0;

--- a/llvm/test/CodeGen/SystemZ/call-zos-01.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-01.ll
@@ -3,14 +3,14 @@
 ; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z10 | FileCheck %s
 
 ; CHECK-LABEL: call_char:
-; CHECK: lghi  1, 8
+; CHECK: lghi  1,8
 define i8 @call_char(){
   %retval = call i8 (i8) @pass_char(i8 8)
   ret i8 %retval
 }
 
 ; CHECK-LABEL: call_short:
-; CHECK: lghi  1, 16
+; CHECK: lghi  1,16
 define i16 @call_short() {
 entry:
   %retval = call i16 (i16) @pass_short(i16 16)
@@ -18,8 +18,8 @@ entry:
 }
 
 ; CHECK-LABEL: call_int:
-; CHECK: lghi  1, 32
-; CHECK: lghi  2, 33
+; CHECK: lghi  1,32
+; CHECK: lghi  2,33
 define i32 @call_int() {
 entry:
   %retval = call i32 (i32, i32) @pass_int(i32 32, i32 33)
@@ -27,9 +27,9 @@ entry:
 }
 
 ; CHECK-LABEL: call_long:
-; CHECK: lghi  1, 64
-; CHECK: lghi  2, 65
-; CHECK: lghi  3, 66
+; CHECK: lghi  1,64
+; CHECK: lghi  2,65
+; CHECK: lghi  3,66
 define i64 @call_long() {
 entry:
   %retval = call i64 (i64, i64, i64) @pass_long(i64 64, i64 65, i64 66)
@@ -37,7 +37,7 @@ entry:
 }
 
 ; CHECK-LABEL: call_ptr:
-; CHECK: lgr 1, 2
+; CHECK: lgr 1,2
 define i32 @call_ptr(ptr %p1, ptr %p2) {
 entry:
   %retval = call i32 (ptr) @pass_ptr(ptr %p2)
@@ -45,9 +45,9 @@ entry:
 }
 
 ; CHECK-LABEL: call_integrals:
-; CHECK: lghi  1, 64
-; CHECK: lghi  2, 32
-; CHECK: lghi  3, 16
+; CHECK: lghi  1,64
+; CHECK: lghi  2,32
+; CHECK: lghi  3,16
 define i64 @call_integrals() {
 entry:
   %retval = call i64 (i64, i32, i16, i64) @pass_integrals0(i64 64, i32 32, i16 16, i64 128)
@@ -55,29 +55,29 @@ entry:
 }
 
 ; CHECK-LABEL: pass_char:
-; CHECK: lgr 3, 1
+; CHECK: lgr 3,1
 define signext i8 @pass_char(i8 signext %arg) {
 entry:
   ret i8 %arg
 }
 
 ; CHECK-LABEL: pass_short:
-; CHECK: lgr 3, 1
+; CHECK: lgr 3,1
 define signext i16 @pass_short(i16 signext %arg) {
 entry:
   ret i16 %arg
 }
 
 ; CHECK-LABEL: pass_int:
-; CHECK: lgr 3, 2
+; CHECK: lgr 3,2
 define signext i32 @pass_int(i32 signext %arg0, i32 signext %arg1) {
 entry:
   ret i32 %arg1
 }
 
 ; CHECK-LABEL: pass_long:
-; CHECK: agr 1, 2
-; CHECK: agr 3, 1
+; CHECK: agr 1,2
+; CHECK: agr 3,1
 define signext i64 @pass_long(i64 signext %arg0, i64 signext %arg1, i64 signext %arg2) {
 entry:
   %N = add i64 %arg0, %arg1
@@ -86,8 +86,8 @@ entry:
 }
 
 ; CHECK-LABEL: pass_integrals0:
-; CHECK: ag  2, 2200(4)
-; CHECK-NEXT: lgr 3, 2
+; CHECK: ag  2,2200(4)
+; CHECK-NEXT: lgr 3,2
 define signext i64 @pass_integrals0(i64 signext %arg0, i32 signext %arg1, i16 signext %arg2, i64 signext %arg3) {
 entry:
   %N = sext i32 %arg1 to i64
@@ -96,7 +96,7 @@ entry:
 }
 
 ; CHECK-LABEL: call_float:
-; CHECK: le 0, 0({{[0-9]}})
+; CHECK: le 0,0({{[0-9]}})
 define float @call_float() {
 entry:
   %ret = call float (float) @pass_float(float 0x400921FB60000000)
@@ -104,8 +104,8 @@ entry:
 }
 
 ; CHECK-LABEL: call_double:
-; CHECK: larl  [[GENREG:[0-9]+]], L#{{CPI[0-9]+_[0-9]+}}
-; CHECK-NEXT: ld  0, 0([[GENREG]])
+; CHECK: larl  [[GENREG:[0-9]+]],L#{{CPI[0-9]+_[0-9]+}}
+; CHECK-NEXT: ld  0,0([[GENREG]])
 define double @call_double() {
 entry:
   %ret = call double (double) @pass_double(double 3.141000e+00)
@@ -113,9 +113,9 @@ entry:
 }
 
 ; CHECK-LABEL: call_longdouble:
-; CHECK: larl  [[GENREG:[0-9]+]], L#{{CPI[0-9]+_[0-9]+}}
-; CHECK-NEXT: ld  0, 0([[GENREG]])
-; CHECK-NEXT: ld  2, 8([[GENREG]])
+; CHECK: larl  [[GENREG:[0-9]+]],L#{{CPI[0-9]+_[0-9]+}}
+; CHECK-NEXT: ld  0,0([[GENREG]])
+; CHECK-NEXT: ld  2,8([[GENREG]])
 define fp128 @call_longdouble() {
 entry:
   %ret = call fp128 (fp128) @pass_longdouble(fp128 0xLE0FC1518450562CD4000921FB5444261)
@@ -123,12 +123,12 @@ entry:
 }
 
 ; CHECK-LABEL: call_floats0
-; CHECK: larl  [[GENREG:[0-9]+]], L#{{CPI[0-9]+_[0-9]+}}
-; CHECK-NEXT: ld  1, 0([[GENREG]])
-; CHECK-NEXT: ld  3, 8([[GENREG]])
-; CHECK: lxr 5, 0
-; CHECK: lxr 0, 1
-; CHECK: lxr 4, 5
+; CHECK: larl  [[GENREG:[0-9]+]],L#{{CPI[0-9]+_[0-9]+}}
+; CHECK-NEXT: ld  1,0([[GENREG]])
+; CHECK-NEXT: ld  3,8([[GENREG]])
+; CHECK: lxr 5,0
+; CHECK: lxr 0,1
+; CHECK: lxr 4,5
 define i64 @call_floats0(fp128 %arg0, double %arg1) {
 entry:
   %ret = call i64 (fp128, fp128, double) @pass_floats0(fp128 0xLE0FC1518450562CD4000921FB5444261, fp128 %arg0, double %arg1)
@@ -136,9 +136,9 @@ entry:
 }
 
 ; CHECK-LABEL: call_floats1
-; CHECK: lxr 1, 0
-; CHECK: ldr 0, 4
-; CHECK: lxr 4, 1
+; CHECK: lxr 1,0
+; CHECK: ldr 0,4
+; CHECK: lxr 4,1
 define i64 @call_floats1(fp128 %arg0, double %arg1) {
 entry:
   %ret = call i64 (double, fp128) @pass_floats1(double %arg1, fp128 %arg0)
@@ -146,8 +146,8 @@ entry:
 }
 
 ; CHECK-LABEL: pass_float:
-; CHECK: larl  1, L#{{CPI[0-9]+_[0-9]+}}
-; CHECK: aeb 0, 0(1)
+; CHECK: larl  1,L#{{CPI[0-9]+_[0-9]+}}
+; CHECK: aeb 0,0(1)
 define float @pass_float(float %arg) {
 entry:
   %X = fadd float %arg, 0x400821FB60000000
@@ -155,8 +155,8 @@ entry:
 }
 
 ; CHECK-LABEL: pass_double:
-; CHECK: larl  1, L#{{CPI[0-9]+_[0-9]+}}
-; CHECK: adb 0, 0(1)
+; CHECK: larl  1,L#{{CPI[0-9]+_[0-9]+}}
+; CHECK: adb 0,0(1)
 define double @pass_double(double %arg) {
 entry:
   %X = fadd double %arg, 1.414213e+00
@@ -164,9 +164,9 @@ entry:
 }
 
 ; CHECK-LABEL: pass_longdouble
-; CHECK: larl  1, L#{{CPI[0-9]+_[0-9]+}}
-; CHECK: lxdb  1, 0(1)
-; CHECK: axbr  0, 1
+; CHECK: larl  1,L#{{CPI[0-9]+_[0-9]+}}
+; CHECK: lxdb  1,0(1)
+; CHECK: axbr  0,1
 define fp128 @pass_longdouble(fp128 %arg) {
 entry:
   %X = fadd fp128 %arg, 0xL10000000000000004000921FB53C8D4F
@@ -174,10 +174,10 @@ entry:
 }
 
 ; CHECK-LABEL: pass_floats0
-; CHECK: larl  1, L#{{CPI[0-9]+_[0-9]+}}
-; CHECK: axbr  0, 4
-; CHECK: axbr  1, 0
-; CHECK: cxbr  1, 5
+; CHECK: larl  1,L#{{CPI[0-9]+_[0-9]+}}
+; CHECK: axbr  0,4
+; CHECK: axbr  1,0
+; CHECK: cxbr  1,5
 define i64 @pass_floats0(fp128 %arg0, fp128 %arg1, double %arg2) {
   %X = fadd fp128 %arg0, %arg1
   %arg2_ext = fpext double %arg2 to fp128

--- a/llvm/test/CodeGen/SystemZ/call-zos-02.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-02.ll
@@ -9,9 +9,9 @@ entry:
 define hidden signext i32 @caller2() {
 entry:
 ; CHECK-LABEL:   caller2:
-; CHECK:         brasl 7, caller@PLT   * encoding: [0xc0,0x75,A,A,A,A]
+; CHECK:         brasl 7,caller@PLT   * encoding: [0xc0,0x75,A,A,A,A]
 ; CHECK-NEXT:    * fixup A - offset: 2, value: caller@PLT+2, kind: FK_390_PC32DBL
-; CHECK-NEXT:    bcr     0, 3          * encoding: [0x07,0x03]
+; CHECK-NEXT:    bcr     0,3          * encoding: [0x07,0x03]
   %call = call signext i32 @caller()
   ret i32 %call
 }

--- a/llvm/test/CodeGen/SystemZ/call-zos-i128.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-i128.ll
@@ -3,15 +3,15 @@
 ; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z13 | FileCheck %s
 
 ; CHECK-LABEL: call_i128:
-; CHECK-DAG: larl    1, L#CPI0_0
-; CHECK-DAG: vl      0, 0(1), 3
-; CHECK-DAG: vst     0, 2256(4), 3
-; CHECK-DAG: larl    1, L#CPI0_1
-; CHECK-DAG: vl      0, 0(1), 3
-; CHECK-DAG: vst     0, 2272(4), 3
-; CHECK-DAG: la      1, 2288(4)
-; CHECK-DAG: la      2, 2272(4)
-; CHECK-DAG: la      3, 2256(4)
+; CHECK-DAG: larl    1,L#CPI0_0
+; CHECK-DAG: vl      0,0(1),3
+; CHECK-DAG: vst     0,2256(4),3
+; CHECK-DAG: larl    1,L#CPI0_1
+; CHECK-DAG: vl      0,0(1),3
+; CHECK-DAG: vst     0,2272(4),3
+; CHECK-DAG: la      1,2288(4)
+; CHECK-DAG: la      2,2272(4)
+; CHECK-DAG: la      3,2256(4)
 
 define i128 @call_i128() {
 entry:
@@ -20,10 +20,10 @@ entry:
 }
 
 ; CHECK-LABEL: pass_i128:
-; CHECK: vl      0, 0(3), 3
-; CHECK: vl      1, 0(2), 3
-; CHECK: vaq     0, 1, 0
-; CHECK: vst     0, 0(1), 3
+; CHECK: vl      0,0(3),3
+; CHECK: vl      1,0(2),3
+; CHECK: vaq     0,1,0
+; CHECK: vst     0,0(1),3
 define i128 @pass_i128(i128 %arg0, i128 %arg1) {
 entry:
   %N = add i128 %arg0, %arg1

--- a/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
@@ -2,18 +2,18 @@
 ; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z10 | FileCheck %s
 ; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z14 | FileCheck %s -check-prefix=ARCH12
 ; CHECK-LABEL: call_vararg_double0:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 6, 8(5)
-; CHECK-NEXT:    lg 5, 0(5)
-; CHECK-NEXT:    llihf 3, 1074118262
-; CHECK-NEXT:    oilf 3, 3367254360
-; CHECK-NEXT:    lghi 1, 1
-; CHECK-NEXT:    lghi 2, 2
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 6,8(5)
+; CHECK-NEXT:    lg 5,0(5)
+; CHECK-NEXT:    llihf 3,1074118262
+; CHECK-NEXT:    oilf 3,3367254360
+; CHECK-NEXT:    lghi 1,1
+; CHECK-NEXT:    lghi 2,2
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_double0() {
 entry:
@@ -22,21 +22,21 @@ entry:
 }
 
 ; CHECK-LABEL: call_vararg_double1:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    llihf 0, 1074118262
-; CHECK-NEXT:    oilf 0, 3367254360
-; CHECK-NEXT:    lg 6, 8(5)
-; CHECK-NEXT:    lg 5, 0(5)
-; CHECK-NEXT:    llihf 3, 1074340036
-; CHECK-NEXT:    oilf 3, 2611340116
-; CHECK-NEXT:    lghi 1, 1
-; CHECK-NEXT:    lghi 2, 2
-; CHECK-NEXT:    stg 0, 2200(4)
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    llihf 0,1074118262
+; CHECK-NEXT:    oilf 0,3367254360
+; CHECK-NEXT:    lg 6,8(5)
+; CHECK-NEXT:    lg 5,0(5)
+; CHECK-NEXT:    llihf 3,1074340036
+; CHECK-NEXT:    oilf 3,2611340116
+; CHECK-NEXT:    lghi 1,1
+; CHECK-NEXT:    lghi 2,2
+; CHECK-NEXT:    stg 0,2200(4)
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_double1() {
 entry:
@@ -45,17 +45,17 @@ entry:
 }
 
 ; CHECK-LABEL: call_vararg_double2:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 6, 24(5)
-; CHECK-NEXT:    lg 5, 16(5)
-; CHECK-NEXT:    llihf 2, 1074118262
-; CHECK-NEXT:    oilf 2, 3367254360
-; CHECK-NEXT:    lghi 1, 8200
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 6,24(5)
+; CHECK-NEXT:    lg 5,16(5)
+; CHECK-NEXT:    llihf 2,1074118262
+; CHECK-NEXT:    oilf 2,3367254360
+; CHECK-NEXT:    lghi 1,8200
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_double2() {
 entry:
@@ -64,23 +64,23 @@ entry:
 }
 
 ; CHECK-LABEL: call_vararg_double3:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    llihf 0, 1072703839
-; CHECK-NEXT:    oilf 0, 2861204133
-; CHECK-NEXT:    lg 6, 40(5)
-; CHECK-NEXT:    lg 5, 32(5)
-; CHECK-NEXT:    llihf 1, 1074118262
-; CHECK-NEXT:    oilf 1, 3367254360
-; CHECK-NEXT:    llihf 2, 1074340036
-; CHECK-NEXT:    oilf 2, 2611340116
-; CHECK-NEXT:    llihf 3, 1073127358
-; CHECK-NEXT:    oilf 3, 1992864825
-; CHECK-NEXT:    stg 0, 2200(4)
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    llihf 0,1072703839
+; CHECK-NEXT:    oilf 0,2861204133
+; CHECK-NEXT:    lg 6,40(5)
+; CHECK-NEXT:    lg 5,32(5)
+; CHECK-NEXT:    llihf 1,1074118262
+; CHECK-NEXT:    oilf 1,3367254360
+; CHECK-NEXT:    llihf 2,1074340036
+; CHECK-NEXT:    oilf 2,2611340116
+; CHECK-NEXT:    llihf 3,1073127358
+; CHECK-NEXT:    oilf 3,1992864825
+; CHECK-NEXT:    stg 0,2200(4)
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_double3() {
 entry:
@@ -90,17 +90,17 @@ entry:
 
 ;; TODO: The extra COPY after LGDR is unnecessary (machine-scheduler introduces the overlap).
 ; CHECK-LABEL: call_vararg_both0:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 6, 40(5)
-; CHECK-NEXT:    lg 5, 32(5)
-; CHECK-NEXT:    lgdr 0, 0
-; CHECK-NEXT:    lgr 2, 1
-; CHECK-NEXT:    lgr 1, 0
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 6,40(5)
+; CHECK-NEXT:    lg 5,32(5)
+; CHECK-NEXT:    lgdr 0,0
+; CHECK-NEXT:    lgr 2,1
+; CHECK-NEXT:    lgr 1,0
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_both0(i64 %arg0, double %arg1) {
   %retval  = call i64(...) @pass_vararg3(double %arg1, i64 %arg0)
@@ -108,22 +108,22 @@ define i64 @call_vararg_both0(i64 %arg0, double %arg1) {
 }
 
 ; CHECK-LABEL: call_vararg_long_double0:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    larl 1, L#CPI5_0
-; CHECK-NEXT:    ld 0, 0(1)
-; CHECK-NEXT:    ld 2, 8(1)
-; CHECK-NEXT:    lg 6, 8(5)
-; CHECK-NEXT:    lg 5, 0(5)
-; CHECK-NEXT:    lgdr 3, 0
-; CHECK-NEXT:    lghi 1, 1
-; CHECK-NEXT:    lghi 2, 2
-; CHECK-NEXT:    std 0, 2192(4)
-; CHECK-NEXT:    std 2, 2200(4)
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    larl 1,L#CPI5_0
+; CHECK-NEXT:    ld 0,0(1)
+; CHECK-NEXT:    ld 2,8(1)
+; CHECK-NEXT:    lg 6,8(5)
+; CHECK-NEXT:    lg 5,0(5)
+; CHECK-NEXT:    lgdr 3,0
+; CHECK-NEXT:    lghi 1,1
+; CHECK-NEXT:    lghi 2,2
+; CHECK-NEXT:    std 0,2192(4)
+; CHECK-NEXT:    std 2,2200(4)
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_long_double0() {
 entry:
@@ -132,19 +132,19 @@ entry:
 }
 
 ; CHECK-LABEL: call_vararg_long_double1:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 6, 8(5)
-; CHECK-NEXT:    lg 5, 0(5)
-; CHECK-NEXT:    lgdr 3, 0
-; CHECK-NEXT:    lghi 1, 1
-; CHECK-NEXT:    lghi 2, 2
-; CHECK-NEXT:    std 0, 2192(4)
-; CHECK-NEXT:    std 2, 2200(4)
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 6,8(5)
+; CHECK-NEXT:    lg 5,0(5)
+; CHECK-NEXT:    lgdr 3,0
+; CHECK-NEXT:    lghi 1,1
+; CHECK-NEXT:    lghi 2,2
+; CHECK-NEXT:    std 0,2192(4)
+; CHECK-NEXT:    std 2,2200(4)
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_long_double1(fp128 %arg0) {
 entry:
@@ -154,21 +154,21 @@ entry:
 
 ; CHECK-LABEL: call_vararg_long_double2
 ; CHECK-LABEL: call_vararg_long_double2:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    std 4, 2208(4)
-; CHECK-NEXT:    std 6, 2216(4)
-; CHECK-NEXT:    lg 6, 8(5)
-; CHECK-NEXT:    lg 5, 0(5)
-; CHECK-NEXT:    lgdr 3, 0
-; CHECK-NEXT:    lghi 1, 1
-; CHECK-NEXT:    lghi 2, 2
-; CHECK-NEXT:    std 0, 2192(4)
-; CHECK-NEXT:    std 2, 2200(4)
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    std 4,2208(4)
+; CHECK-NEXT:    std 6,2216(4)
+; CHECK-NEXT:    lg 6,8(5)
+; CHECK-NEXT:    lg 5,0(5)
+; CHECK-NEXT:    lgdr 3,0
+; CHECK-NEXT:    lghi 1,1
+; CHECK-NEXT:    lghi 2,2
+; CHECK-NEXT:    std 0,2192(4)
+; CHECK-NEXT:    std 2,2200(4)
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_long_double2(fp128 %arg0, fp128 %arg1) {
 entry:
@@ -177,16 +177,16 @@ entry:
 }
 
 ; CHECK-LABEL: call_vararg_long_double3:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 6, 40(5)
-; CHECK-NEXT:    lg 5, 32(5)
-; CHECK-NEXT:    lgdr 3, 2
-; CHECK-NEXT:    lgdr 2, 0
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 6,40(5)
+; CHECK-NEXT:    lg 5,32(5)
+; CHECK-NEXT:    lgdr 3,2
+; CHECK-NEXT:    lgdr 2,0
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_long_double3(fp128 %arg0) {
 entry:
@@ -195,77 +195,77 @@ entry:
 }
 
 ; ARCH12-LABEL: call_vec_vararg_test0
-; ARCH12: vlgvg 3, 24, 1
-; ARCH12: vlgvg 2, 24, 0
-; ARCH12: lghi  1, 1
+; ARCH12: vlgvg 3,24,1
+; ARCH12: vlgvg 2,24,0
+; ARCH12: lghi  1,1
 define void @call_vec_vararg_test0(<2 x double> %v) {
   %retval = call i64(i64, ...) @pass_vararg2(i64 1, <2 x double> %v)
   ret void
 }
 
 ; ARCH12-LABEL: call_vec_vararg_test1
-; ARCH12: larl  1, L#CPI10_0
-; ARCH12: vl    0, 0(1), 3
-; ARCH12: vlgvg 3, 24, 0
-; ARCH12: vrepg 2, 0, 1
-; ARCH12: vst   25, 2208(4), 3
-; ARCH12: vst   24, 2192(4), 3
+; ARCH12: larl  1,L#CPI10_0
+; ARCH12: vl    0,0(1),3
+; ARCH12: vlgvg 3,24,0
+; ARCH12: vrepg 2,0,1
+; ARCH12: vst   25,2208(4),3
+; ARCH12: vst   24,2192(4),3
 define void @call_vec_vararg_test1(<4 x i32> %v, <2 x i64> %w) {
   %retval = call i64(fp128, ...) @pass_vararg1(fp128 0xLE0FC1518450562CD4000921FB5444261, <4 x i32> %v, <2 x i64> %w)
   ret void
 }
 
 ; ARCH12-LABEL: call_vec_char_vararg_straddle
-; ARCH12: vlgvg 3, 24, 0
-; ARCH12: lghi  1, 1
-; ARCH12: lghi  2, 2
-; ARCH12: vst   24, 2192(4), 3
+; ARCH12: vlgvg 3,24,0
+; ARCH12: lghi  1,1
+; ARCH12: lghi  2,2
+; ARCH12: vst   24,2192(4),3
 define void @call_vec_char_vararg_straddle(<16 x i8> %v) {
   %retval = call i64(i64, i64, ...) @pass_vararg0(i64 1, i64 2, <16 x i8> %v)
   ret void
 }
 
 ; ARCH12-LABEL: call_vec_short_vararg_straddle
-; ARCH12: vlgvg 3, 24, 0
-; ARCH12: lghi  1, 1
-; ARCH12: lghi  2, 2
-; ARCH12: vst   24, 2192(4), 3
+; ARCH12: vlgvg 3,24,0
+; ARCH12: lghi  1,1
+; ARCH12: lghi  2,2
+; ARCH12: vst   24,2192(4),3
 define void @call_vec_short_vararg_straddle(<8 x i16> %v) {
   %retval = call i64(i64, i64, ...) @pass_vararg0(i64 1, i64 2, <8 x i16> %v)
   ret void
 }
 
 ; ARCH12-LABEL: call_vec_int_vararg_straddle
-; ARCH12: vlgvg 3, 24, 0
-; ARCH12: lghi  1, 1
-; ARCH12: lghi  2, 2
-; ARCH12: vst 24, 2192(4), 3
+; ARCH12: vlgvg 3,24,0
+; ARCH12: lghi  1,1
+; ARCH12: lghi  2,2
+; ARCH12: vst 24,2192(4),3
 define void @call_vec_int_vararg_straddle(<4 x i32> %v) {
   %retval = call i64(i64, i64, ...) @pass_vararg0(i64 1, i64 2, <4 x i32> %v)
   ret void
 }
 
 ; ARCH12-LABEL: call_vec_double_vararg_straddle
-; ARCH12: vlgvg 3, 24, 0
-; ARCH12: lghi  1, 1
-; ARCH12: lghi  2, 2
-; ARCH12: vst 24, 2192(4), 3
+; ARCH12: vlgvg 3,24,0
+; ARCH12: lghi  1,1
+; ARCH12: lghi  2,2
+; ARCH12: vst 24,2192(4),3
 define void @call_vec_double_vararg_straddle(<2 x double> %v) {
   %retval = call i64(i64, i64, ...) @pass_vararg0(i64 1, i64 2, <2 x double> %v)
   ret void
 }
 
 ; CHECK-LABEL: call_vararg_integral0:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 0, 2392(4)
-; CHECK-NEXT:    lg 6, 40(5)
-; CHECK-NEXT:    lg 5, 32(5)
-; CHECK-NEXT:    stg 0, 2200(4)
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 0,2392(4)
+; CHECK-NEXT:    lg 6,40(5)
+; CHECK-NEXT:    lg 5,32(5)
+; CHECK-NEXT:    stg 0,2200(4)
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_integral0(i32 signext %arg0, i16 signext %arg1, i64 signext %arg2, i8 signext %arg3) {
 entry:
@@ -274,16 +274,16 @@ entry:
 }
 
 ; CHECK-LABEL: call_vararg_float0:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 6, 24(5)
-; CHECK-NEXT:    lg 5, 16(5)
-; CHECK-NEXT:    lghi 1, 1
-; CHECK-NEXT:    llihf 2, 1073692672
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 6,24(5)
+; CHECK-NEXT:    lg 5,16(5)
+; CHECK-NEXT:    lghi 1,1
+; CHECK-NEXT:    llihf 2,1073692672
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_float0() {
 entry:
@@ -292,20 +292,20 @@ entry:
 }
 
 ; CHECK-LABEL: call_vararg_float1:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lg 6, 72(5)
-; CHECK-NEXT:    lg 5, 64(5)
-; CHECK-NEXT:    larl 1, L#CPI17_0
-; CHECK-NEXT:    le 0, 0(1)
-; CHECK-NEXT:    llihf 0, 1073692672
-; CHECK-NEXT:    llihh 2, 16384
-; CHECK-NEXT:    llihh 3, 16392
-; CHECK-NEXT:    stg 0, 2200(4)
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lg 6,72(5)
+; CHECK-NEXT:    lg 5,64(5)
+; CHECK-NEXT:    larl 1,L#CPI17_0
+; CHECK-NEXT:    le 0,0(1)
+; CHECK-NEXT:    llihf 0,1073692672
+; CHECK-NEXT:    llihh 2,16384
+; CHECK-NEXT:    llihh 3,16392
+; CHECK-NEXT:    stg 0,2200(4)
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @call_vararg_float1() {
 entry:
@@ -326,15 +326,15 @@ entry:
 ; }
 ;
 ; CHECK-LABEL: pass_vararg:
-; CHECK:         stmg 6, 7, 1904(4)
-; CHECK-NEXT:    aghi 4, -160
-; CHECK-NEXT:    stg 2, 2344(4)
-; CHECK-NEXT:    stg 3, 2352(4)
-; CHECK-NEXT:    la 0, 2352(4)
-; CHECK-NEXT:    stg 0, 2200(4)
-; CHECK-NEXT:    lg 3, 2344(4)
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 160
+; CHECK:         stmg 6,7,1904(4)
+; CHECK-NEXT:    aghi 4,-160
+; CHECK-NEXT:    stg 2,2344(4)
+; CHECK-NEXT:    stg 3,2352(4)
+; CHECK-NEXT:    la 0,2352(4)
+; CHECK-NEXT:    stg 0,2200(4)
+; CHECK-NEXT:    lg 3,2344(4)
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,160
 ; CHECK-NEXT:    b 2(7)
 define hidden i64 @pass_vararg(i64 %x, ...) {
 entry:

--- a/llvm/test/CodeGen/SystemZ/call-zos-vec.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-vec.ll
@@ -1,7 +1,7 @@
 ; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z13 | FileCheck %s
 
 ; CHECK-LABEL: sum_vecs0
-; CHECK: vag 24, 24, 25
+; CHECK: vag 24,24,25
 define <2 x i64> @sum_vecs0(<2 x i64> %v1, <2 x i64> %v2) {
 entry:
   %add0 = add <2 x i64> %v1, %v2
@@ -9,15 +9,15 @@ entry:
 }
 
 ; CHECK-LABEL: sum_vecs1
-; CHECK: vaf 1, 24, 25
-; CHECK: vaf 1, 1, 26
-; CHECK: vaf 1, 1, 27
-; CHECK: vaf 1, 1, 28
-; CHECK: vaf 1, 1, 29
-; CHECK: vl  0, 2304(4), 4
-; CHECK: vaf 1, 1, 30
-; CHECK: vaf 1, 1, 31
-; CHECK: vaf 24, 1, 0
+; CHECK: vaf 1,24,25
+; CHECK: vaf 1,1,26
+; CHECK: vaf 1,1,27
+; CHECK: vaf 1,1,28
+; CHECK: vaf 1,1,29
+; CHECK: vl  0,2304(4),4
+; CHECK: vaf 1,1,30
+; CHECK: vaf 1,1,31
+; CHECK: vaf 24,1,0
 define <4 x i32> @sum_vecs1(<4 x i32> %v1, <4 x i32> %v2, <4 x i32> %v3, <4 x i32> %v4, <4 x i32> %v5, <4 x i32> %v6, <4 x i32> %v7, <4 x i32> %v8, <4 x i32> %v9) {
 entry:
   %add0 = add <4 x i32> %v1, %v2
@@ -34,7 +34,7 @@ entry:
 ; Verify that 3 is used for passing integral types if
 ; only 24 is used.
 ; CHECK-LABEL: call_vecs0
-; CHECK: lgr 3, 1
+; CHECK: lgr 3,1
 define i64 @call_vecs0(i64 %n, <2 x i64> %v1) {
 entry:
   %ret = call i64 (<2 x i64>, i64) @pass_vecs0(<2 x i64> %v1, i64 %n)
@@ -44,8 +44,8 @@ entry:
 ; Verify that 3 is not allocated for passing integral types
 ; if 24 and %f0 are used.
 ; CHECK-LABEL: call_vecs1
-; CHECK: vlr 24, 25
-; CHECK: stg 1, 2200(4)
+; CHECK: vlr 24,25
+; CHECK: stg 1,2200(4)
 define i64 @call_vecs1(i64 %n, <2 x i64> %v1, double %x, <2 x i64> %v2) {
 entry:
   %ret = call i64 (<2 x i64>, double, i64) @pass_vecs1(<2 x i64> %v2, double %x, i64 %n)
@@ -55,7 +55,7 @@ entry:
 ; Verify that 3 is not allocated for passing integral types
 ; if 24 and 25 are used.
 ; CHECK-LABEL: call_vecs2
-; CHECK: mvghi 2208(4), 55
+; CHECK: mvghi 2208(4),55
 define i64 @call_vecs2(<2 x i64> %v1, <2 x i64> %v2) {
   %ret = call i64 (<2 x i64>, <2 x i64>, i64) @pass_vecs2(<2 x i64> %v1, <2 x i64> %v2, i64 55)
   ret i64 %ret

--- a/llvm/test/CodeGen/SystemZ/mixed-ptr-sizes.ll
+++ b/llvm/test/CodeGen/SystemZ/mixed-ptr-sizes.ll
@@ -104,8 +104,8 @@ declare void @use_foo(ptr)
 define void @ptr32_to_ptr(ptr %f, ptr addrspace(1) %i) {
 entry:
 ; CHECK-LABEL: ptr32_to_ptr:
-; CHECK:       llgtr 0, 2
-; CHECK-NEXT:  stg   0, 8(1)
+; CHECK:       llgtr 0,2
+; CHECK-NEXT:  stg   0,8(1)
   %0 = addrspacecast ptr addrspace(1) %i to ptr
   %p64 = getelementptr inbounds %struct.Foo, ptr %f, i64 0, i32 1
   store ptr %0, ptr %p64, align 8
@@ -116,8 +116,8 @@ entry:
 define void @ptr_to_ptr32(ptr %f, ptr %i) {
 entry:
 ; CHECK-LABEL: ptr_to_ptr32:
-; CHECK:       nilh 2, 32767
-; CHECK-NEXT:  st   2, 0(1)
+; CHECK:       nilh 2,32767
+; CHECK-NEXT:  st   2,0(1)
   %0 = addrspacecast ptr %i to ptr addrspace(1)
   %p32 = getelementptr inbounds %struct.Foo, ptr %f, i64 0, i32 0
   store ptr addrspace(1) %0, ptr %p32, align 8
@@ -128,7 +128,7 @@ entry:
 define void @ptr32_to_ptr32(ptr %f, ptr addrspace(1) %i) {
 entry:
 ; CHECK-LABEL: ptr32_to_ptr32:
-; CHECK:       st 2, 0(1)
+; CHECK:       st 2,0(1)
   %p32 = getelementptr inbounds %struct.Foo, ptr %f, i64 0, i32 0
   store ptr addrspace(1) %i, ptr %p32, align 8
   tail call void @use_foo(ptr %f)
@@ -137,7 +137,7 @@ entry:
 
 define void @ptr_to_ptr(ptr %f, ptr %i) {
 ; CHECK-LABEL: ptr_to_ptr:
-; CHECK:       stg 2, 8(1)
+; CHECK:       stg 2,8(1)
   %p64 = getelementptr inbounds %struct.Foo, ptr %f, i64 0, i32 1
   store ptr %i, ptr %p64, align 8
   tail call void @use_foo(ptr %f)
@@ -147,9 +147,9 @@ define void @ptr_to_ptr(ptr %f, ptr %i) {
 define void @test_indexing(ptr %f) {
 entry:
 ; CHECK-LABEL: test_indexing:
-; CHECK:       l     0, 1032
-; CHECK:       llgtr 0, 0
-; CHECK:       stg   0, 16(1)
+; CHECK:       l     0,1032
+; CHECK:       llgtr 0,0
+; CHECK:       stg   0,16(1)
   %0 = load ptr addrspace(1), ptr inttoptr (i64 1032 to ptr), align 8
   %1 = addrspacecast ptr addrspace(1) %0 to ptr
   %cp64 = getelementptr inbounds %struct.Foo, ptr %f, i64 0, i32 2
@@ -161,11 +161,11 @@ entry:
 define void @test_indexing_2(ptr %f) {
 entry:
 ; CHECK-LABEL: test_indexing_2:
-; CHECK:       lhi   0, 16
-; CHECK-NEXT:  a     0, 1032
-; CHECK-NEXT:  llgtr 2, 0
-; CHECK:       lg    0, 24(2)
-; CHECK:       stg   0, 16(1)
+; CHECK:       lhi   0,16
+; CHECK-NEXT:  a     0,1032
+; CHECK-NEXT:  llgtr 2,0
+; CHECK:       lg    0,24(2)
+; CHECK:       stg   0,16(1)
   %0 = load ptr addrspace(1), ptr inttoptr (i64 1032 to ptr), align 8
   %arrayidx = getelementptr inbounds ptr, ptr addrspace(1) %0, i32 2
   %1 = load ptr, ptr addrspace(1) %arrayidx, align 8
@@ -182,13 +182,13 @@ entry:
 define ptr @test_misc() {
 entry:
 ; CHECK-LABEL: test_misc:
-; CHECK:       lhi   0, 88
-; CHECK-NEXT:  a     0, 1208
-; CHECK-NEXT:  llgtr 1, 0
-; CHECK-NEXT:  lg    1, 0(1)
-; CHECK-NEXT:  lg    1, 8(1)
-; CHECK-NEXT:  lg    1, 904(1)
-; CHECK-NEXT:  lg    3, 1192(1)
+; CHECK:       lhi   0,88
+; CHECK-NEXT:  a     0,1208
+; CHECK-NEXT:  llgtr 1,0
+; CHECK-NEXT:  lg    1,0(1)
+; CHECK-NEXT:  lg    1,8(1)
+; CHECK-NEXT:  lg    1,904(1)
+; CHECK-NEXT:  lg    3,1192(1)
   %0 = load ptr addrspace(1), ptr inttoptr (i64 1208 to ptr), align 8
   %arrayidx = getelementptr inbounds ptr, ptr addrspace(1) %0, i32 11
   %1 = load ptr, ptr addrspace(1) %arrayidx, align 8
@@ -205,12 +205,12 @@ entry:
 define ptr addrspace(1) @test_misc_2() {
 entry:
 ; CHECK-LABEL: test_misc_2:
-; CHECK:       lhi   0, 544
-; CHECK:       a     0, 16
-; CHECK:       llgtr 1, 0
-; CHECK:       lhi   0, 24
-; CHECK:       a     0, 0(1)
-; CHECK:       llgtr 1, 0
+; CHECK:       lhi   0,544
+; CHECK:       a     0,16
+; CHECK:       llgtr 1,0
+; CHECK:       lhi   0,24
+; CHECK:       a     0,0(1)
+; CHECK:       llgtr 1,0
   %0 = load ptr addrspace(1), ptr inttoptr (i64 16 to ptr), align 16
   %arrayidx = getelementptr inbounds ptr addrspace(1), ptr addrspace(1) %0, i32 136
   %1 = load ptr addrspace(1), ptr addrspace(1) %arrayidx, align 4
@@ -222,9 +222,9 @@ entry:
 define zeroext i16 @test_misc_3() {
 entry:
 ; CHECK-LABEL: test_misc_3:
-; CHECK:       a     0, 548
-; CHECK-NEXT:  llgtr 1, 0
-; CHECK-NEXT:  llgh  3, 0(1)
+; CHECK:       a     0,548
+; CHECK-NEXT:  llgtr 1,0
+; CHECK-NEXT:  llgh  3,0(1)
 ; CHECK-NEXT:  b     2(7)
   %0 = load ptr addrspace(1), ptr inttoptr (i64 548 to ptr), align 4
   %arrayidx2 = getelementptr inbounds i16, ptr addrspace(1) %0, i32 18
@@ -236,14 +236,14 @@ entry:
 define signext i32 @test_misc_4() {
 entry:
 ; CHECK-LABEL: test_misc_4:
-; CHECK:       lhi   0, 88
-; CHECK-NEXT:  a     0, 1208
-; CHECK-NEXT:  llgtr 1, 0
-; CHECK-NEXT:  lg    1, 0(1)
-; CHECK-NEXT:  lg    1, 8(1)
-; CHECK-NEXT:  lg    1, 984(1)
-; CHECK-NEXT:  iilf  0, 67240703
-; CHECK-NEXT:  c     0, 80(1)
+; CHECK:       lhi   0,88
+; CHECK-NEXT:  a     0,1208
+; CHECK-NEXT:  llgtr 1,0
+; CHECK-NEXT:  lg    1,0(1)
+; CHECK-NEXT:  lg    1,8(1)
+; CHECK-NEXT:  lg    1,984(1)
+; CHECK-NEXT:  iilf  0,67240703
+; CHECK-NEXT:  c     0,80(1)
   %0 = load ptr addrspace(1), ptr inttoptr (i64 1208 to ptr), align 8
   %arrayidx = getelementptr inbounds ptr, ptr addrspace(1) %0, i32 11
   %1 = load ptr, ptr addrspace(1) %arrayidx, align 8
@@ -262,11 +262,11 @@ entry:
 define void @test_misc_5(ptr %f) {
 entry:
 ; CHECK-LABEL: test_misc_5:
-; CHECK:       l     0, 548
-; CHECK-NEXT:  lg  6, 8(5)
-; CHECK-NEXT:  lg  5, 0(5)
-; CHECK-NEXT:  llgtr 0, 0
-; CHECK-NEXT:  stg   0, 16(1)
+; CHECK:       l     0,548
+; CHECK-NEXT:  lg  6,8(5)
+; CHECK-NEXT:  lg  5,0(5)
+; CHECK-NEXT:  llgtr 0,0
+; CHECK-NEXT:  stg   0,16(1)
   %0 = load ptr addrspace(1), ptr inttoptr (i64 548 to ptr), align 4
   %1 = addrspacecast ptr addrspace(1) %0 to ptr
   %cp64 = getelementptr inbounds %struct.Foo, ptr %f, i64 0, i32 2
@@ -278,13 +278,13 @@ entry:
 define signext i32 @get_processor_count() {
 entry:
 ; CHECK-LABEL: get_processor_count:
-; CHECK: lhi 0, 660
-; CHECK-NEXT: a 0, 16
-; CHECK-NEXT: llgtr 1, 0
-; CHECK-NEXT: lhi 0, 53
-; CHECK-NEXT: a 0, 0(1)
-; CHECK-NEXT: llgtr 1, 0
-; CHECK-NEXT: lgb 3, 0(1)
+; CHECK: lhi 0,660
+; CHECK-NEXT: a 0,16
+; CHECK-NEXT: llgtr 1,0
+; CHECK-NEXT: lhi 0,53
+; CHECK-NEXT: a 0,0(1)
+; CHECK-NEXT: llgtr 1,0
+; CHECK-NEXT: lgb 3,0(1)
   %0 = load ptr addrspace(1), ptr inttoptr (i64 16 to ptr), align 16
   %arrayidx = getelementptr inbounds ptr addrspace(1), ptr addrspace(1) %0, i32 165
   %1 = load ptr addrspace(1), ptr addrspace(1) %arrayidx, align 4
@@ -297,20 +297,20 @@ entry:
 define void @spill_ptr32_args_to_registers(i8 addrspace(1)* %p) {
 entry:
 ; CHECK-LABEL: spill_ptr32_args_to_registers:
-; CHECK:         stmg 6, 7, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lgr 2, 1
-; CHECK-NEXT:    lg 6, 24(5)
-; CHECK-NEXT:    lg 5, 16(5)
-; CHECK-NEXT:    stg 1, 2216(4)
-; CHECK-NEXT:    stg 1, 2208(4)
-; CHECK-NEXT:    lghi 1, 5
-; CHECK-NEXT:    stg 2, 2200(4)
-; CHECK-NEXT:    lgr 3, 2
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,7,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lgr 2,1
+; CHECK-NEXT:    lg 6,24(5)
+; CHECK-NEXT:    lg 5,16(5)
+; CHECK-NEXT:    stg 1,2216(4)
+; CHECK-NEXT:    stg 1,2208(4)
+; CHECK-NEXT:    lghi 1,5
+; CHECK-NEXT:    stg 2,2200(4)
+; CHECK-NEXT:    lgr 3,2
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
   tail call void (i32, ...) @g(i32 noundef signext 5, ptr addrspace(1) noundef %p, ptr addrspace(1) noundef %p, ptr addrspace(1) noundef %p, ptr addrspace(1) noundef %p, ptr addrspace(1) noundef %p)
   ret void
@@ -328,13 +328,13 @@ declare void @g(i32 signext, ...)
 ;
 define signext i32 @setlength() {
 ; CHECK-LABEL: setlength:
-; CHECK: basr    7, 6
-; CHECK: lgr     [[MALLOC:[0-9]+]], 3
-; CHECK: basr    7, 6
-; CHECK: lgr     [[LENGTH:[0-9]+]], 3
-; CHECK: la      [[ADDR:[0-9]+]], 4([[MALLOC]])
-; CHECK: llgtr   [[ADDR]], [[ADDR]]
-; CHECK: stg     [[LENGTH]], 0([[ADDR]])
+; CHECK: basr    7,6
+; CHECK: lgr     [[MALLOC:[0-9]+]],3
+; CHECK: basr    7,6
+; CHECK: lgr     [[LENGTH:[0-9]+]],3
+; CHECK: la      [[ADDR:[0-9]+]],4([[MALLOC]])
+; CHECK: llgtr   [[ADDR]],[[ADDR]]
+; CHECK: stg     [[LENGTH]],0([[ADDR]])
 entry:
   %call = tail call ptr @__malloc31(i64 noundef 8)
   %call1 = tail call signext i32 @foo()
@@ -352,13 +352,13 @@ entry:
 ;
 define signext i32 @setlength2() {
 ; CHECK-LABEL: setlength2:
-; CHECK: basr    7, 6
-; CHECK: lgr     [[MALLOC:[0-9]+]], 3
-; CHECK: basr    7, 6
-; CHECK: lgr     [[LENGTH:[0-9]+]], 3
-; CHECK: ahi     [[MALLOC]], 4
-; CHECK: llgtr   [[ADDR]], [[MALLOC]]
-; CHECK: stg     [[LENGTH]], 0([[ADDR]])
+; CHECK: basr    7,6
+; CHECK: lgr     [[MALLOC:[0-9]+]],3
+; CHECK: basr    7,6
+; CHECK: lgr     [[LENGTH:[0-9]+]],3
+; CHECK: ahi     [[MALLOC]],4
+; CHECK: llgtr   [[ADDR]],[[MALLOC]]
+; CHECK: stg     [[LENGTH]],0([[ADDR]])
 entry:
   %call = tail call ptr addrspace(1) @domalloc(i64 noundef 8)
   %call1 = tail call signext i32 @foo()

--- a/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
@@ -3,16 +3,16 @@
 ; RUN: llc < %s -mtriple=s390x-ibm-zos | FileCheck %s
 
 ; CHECK-LABEL: DoIt:
-; CHECK:    stmg    6, 7, 1840(4)
-; CHECK:    aghi    4, -224
-; CHECK:    lg  1, 0(5)
-; CHECK:    lg  6, 16(5)
-; CHECK:    lg  5, 8(5)
-; CHECK:    stg 1, 2264(4)
-; CHECK:    basr    7, 6
-; CHECK:    bcr 0, 0
-; CHECK:    lg  7, 2072(4)
-; CHECK:    aghi    4, 224
+; CHECK:    stmg    6,7,1840(4)
+; CHECK:    aghi    4,-224
+; CHECK:    lg  1,0(5)
+; CHECK:    lg  6,16(5)
+; CHECK:    lg  5,8(5)
+; CHECK:    stg 1,2264(4)
+; CHECK:    basr    7,6
+; CHECK:    bcr 0,0
+; CHECK:    lg  7,2072(4)
+; CHECK:    aghi    4,224
 ; CHECK:    b   2(7)
 define hidden void @DoIt() {
 entry:
@@ -26,20 +26,20 @@ declare void @DoFunc()
 declare void @Caller(ptr noundef)
 
 ; CHECK-LABEL: get_i:
-; CHECK:    stmg    6, 8, 1872(4)
-; CHECK:    aghi    4, -192
-; CHECK:    lg  1, 24(5)
-; CHECK:    lg  2, 32(5)
-; CHECK:    lgf 1, 0(1)
-; CHECK:    lg  6, 48(5)
-; CHECK:    lg  5, 40(5)
-; CHECK:    l   8, 0(2)
-; CHECK:    basr    7, 6
-; CHECK:    bcr 0, 0
-; CHECK:    ar  3, 8
-; CHECK:    lgfr    3, 3
-; CHECK:    lmg 7, 8, 2072(4)
-; CHECK:    aghi    4, 192
+; CHECK:    stmg    6,8,1872(4)
+; CHECK:    aghi    4,-192
+; CHECK:    lg  1,24(5)
+; CHECK:    lg  2,32(5)
+; CHECK:    lgf 1,0(1)
+; CHECK:    lg  6,48(5)
+; CHECK:    lg  5,40(5)
+; CHECK:    l   8,0(2)
+; CHECK:    basr    7,6
+; CHECK:    bcr 0,0
+; CHECK:    ar  3,8
+; CHECK:    lgfr    3,3
+; CHECK:    lmg 7,8,2072(4)
+; CHECK:    aghi    4,192
 ; CHECK:    b   2(7)
 @i = external global i32, align 4
 @i2 = external global i32, align 4

--- a/llvm/test/CodeGen/SystemZ/zos-ada.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ada.ll
@@ -3,19 +3,19 @@
 ; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z10 | FileCheck %s
 
 ; CHECK-LABEL: caller:
-; CHECK:         stmg 6, 8, 1872(4)
-; CHECK-NEXT:    aghi 4, -192
-; CHECK-NEXT:    lgr 8, 5
-; CHECK-NEXT:    brasl 7, callee_internal@PLT
-; CHECK-NEXT:    bcr 0, 3
-; CHECK-NEXT:    lg 6, 8(8)
-; CHECK-NEXT:    lg 5, 0(8)
-; CHECK-NEXT:    lgr 8, 3
-; CHECK-NEXT:    basr 7, 6
-; CHECK-NEXT:    bcr 0, 0
-; CHECK-NEXT:    la 3, 0(3,8)
-; CHECK-NEXT:    lmg 7, 8, 2072(4)
-; CHECK-NEXT:    aghi 4, 192
+; CHECK:         stmg 6,8,1872(4)
+; CHECK-NEXT:    aghi 4,-192
+; CHECK-NEXT:    lgr 8,5
+; CHECK-NEXT:    brasl 7,callee_internal@PLT
+; CHECK-NEXT:    bcr 0,3
+; CHECK-NEXT:    lg 6,8(8)
+; CHECK-NEXT:    lg 5,0(8)
+; CHECK-NEXT:    lgr 8,3
+; CHECK-NEXT:    basr 7,6
+; CHECK-NEXT:    bcr 0,0
+; CHECK-NEXT:    la 3,0(3,8)
+; CHECK-NEXT:    lmg 7,8,2072(4)
+; CHECK-NEXT:    aghi 4,192
 ; CHECK-NEXT:    b 2(7)
 define i64 @caller() {
   %r1 = call i64 () @callee_internal()

--- a/llvm/test/CodeGen/SystemZ/zos-frameaddr.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-frameaddr.ll
@@ -5,7 +5,7 @@
 ; the optional back chain slot.
 define ptr @fp0() nounwind {
 ; CHECK-LABEL: fp0:
-; CHECK:         la 3, 2048(4)
+; CHECK:         la 3,2048(4)
 ; CHECK-NEXT:    b 2(7)
 entry:
   %0 = tail call ptr @llvm.frameaddress(i32 0)
@@ -16,11 +16,11 @@ entry:
 ; of a stack frame.
 define ptr @fp0f() nounwind {
 ; CHECK-LABEL: fp0f:
-; CHECK:         stmg 6, 7, 1904(4)
-; CHECK-NEXT:    aghi 4, -160
-; CHECK-NEXT:    la 3, 2048(4)
-; CHECK-NEXT:    lg 7, 2072(4)
-; CHECK-NEXT:    aghi 4, 160
+; CHECK:         stmg 6,7,1904(4)
+; CHECK-NEXT:    aghi 4,-160
+; CHECK-NEXT:    la 3,2048(4)
+; CHECK-NEXT:    lg 7,2072(4)
+; CHECK-NEXT:    aghi 4,160
 ; CHECK-NEXT:    b 2(7)
 entry:
   %0 = alloca i64, align 8
@@ -31,9 +31,9 @@ entry:
 ; Check the caller's frame address.
 define ptr @fpcaller() nounwind "backchain" {
 ; CHECK-LABEL: fpcaller:
-; CHECK:         stmg 4, 7, 2048(4)
-; CHECK-NEXT:    lg 3, 2048(4)
-; CHECK-NEXT:    lmg 4, 7, 2048(4)
+; CHECK:         stmg 4,7,2048(4)
+; CHECK-NEXT:    lg 3,2048(4)
+; CHECK-NEXT:    lmg 4,7,2048(4)
 ; CHECK-NEXT:    b 2(7)
 entry:
   %0 = tail call ptr @llvm.frameaddress(i32 1)
@@ -43,10 +43,10 @@ entry:
 ; Check the caller's frame address.
 define ptr @fpcallercaller() nounwind "backchain" {
 ; CHECK-LABEL: fpcallercaller:
-; CHECK:         stmg 4, 7, 2048(4)
-; CHECK-NEXT:    lg 1, 2048(4)
-; CHECK-NEXT:    lg 3, 0(1)
-; CHECK-NEXT:    lmg 4, 7, 2048(4)
+; CHECK:         stmg 4,7,2048(4)
+; CHECK-NEXT:    lg 1,2048(4)
+; CHECK-NEXT:    lg 3,0(1)
+; CHECK-NEXT:    lmg 4,7,2048(4)
 ; CHECK-NEXT:    b 2(7)
 entry:
   %0 = tail call ptr @llvm.frameaddress(i32 2)

--- a/llvm/test/CodeGen/SystemZ/zos-landingpad.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-landingpad.ll
@@ -20,8 +20,8 @@ lpad:
   %0 = landingpad { ptr, i32 } cleanup
 ; The Exception Pointer is %r1; the Exception Selector, %r2.
 ; CHECK: L#BB{{[^%]*}} %lpad
-; CHECK-DAG: stg 1, {{.*}}
-; CHECK-DAG: st 2, {{.*}}
+; CHECK-DAG: stg 1,{{.*}}
+; CHECK-DAG: st 2,{{.*}}
   %1 = extractvalue { ptr, i32 } %0, 0
   %2 = extractvalue { ptr, i32 } %0, 1
   store ptr %1, ptr %ehptr, align 8

--- a/llvm/test/CodeGen/SystemZ/zos-prologue-epilog.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-prologue-epilog.ll
@@ -6,13 +6,13 @@
 
 ; Small stack frame.
 ; CHECK-LABEL: func0
-; CHECK64: stmg  6, 7, 1872(4)
+; CHECK64: stmg  6,7,1872(4)
 ; stmg instruction's displacement field must be 2064-dsa_size
 ; as per ABI
-; CHECK64: aghi  4, -192
+; CHECK64: aghi  4,-192
 
-; CHECK64: lg  7, 2072(4)
-; CHECK64: aghi  4, 192
+; CHECK64: lg  7,2072(4)
+; CHECK64: aghi  4,192
 ; CHECK64: b 2(7)
 
 ; CHECK64: L#PPA1_func0_0:
@@ -24,11 +24,11 @@ define void @func0() {
 
 ; Spill all GPR CSRs
 ; CHECK-LABEL: func1
-; CHECK64: stmg 6, 15, 1904(4)
-; CHECK64: aghi  4, -160
+; CHECK64: stmg 6,15,1904(4)
+; CHECK64: aghi  4,-160
 
-; CHECK64: lmg 7, 15, 2072(4)
-; CHECK64: aghi  4, 160
+; CHECK64: lmg 7,15,2072(4)
+; CHECK64: aghi  4,160
 ; CHECK64: b 2(7)
 
 ; CHECK64: L#PPA1_func1_0:
@@ -85,43 +85,43 @@ define void @func1(ptr %ptr) {
 
 ; Spill all FPRs and VRs
 ; CHECK-LABEL: func2
-; CHECK64: stmg	6, 7, 1744(4)
-; CHECK64: aghi  4, -320 
-; CHECK64: std	15, {{[0-9]+}}(4)                      * 8-byte Folded Spill
-; CHECK64: std	14, {{[0-9]+}}(4)                      * 8-byte Folded Spill
-; CHECK64: std	13, {{[0-9]+}}(4)                      * 8-byte Folded Spill
-; CHECK64: std	12, {{[0-9]+}}(4)                      * 8-byte Folded Spill
-; CHECK64: std	11, {{[0-9]+}}(4)                      * 8-byte Folded Spill
-; CHECK64: std	10, {{[0-9]+}}(4)                      * 8-byte Folded Spill
-; CHECK64: std	9, {{[0-9]+}}(4)                       * 8-byte Folded Spill
-; CHECK64: std	8, {{[0-9]+}}(4)                       * 8-byte Folded Spill
-; CHECK64: vst	23, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
-; CHECK64: vst	22, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
-; CHECK64: vst	21, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
-; CHECK64: vst	20, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
-; CHECK64: vst	19, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
-; CHECK64: vst	18, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
-; CHECK64: vst	17, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
-; CHECK64: vst	16, {{[0-9]+}}(4), 4                   * 16-byte Folded Spill
+; CHECK64: stmg	6,7,1744(4)
+; CHECK64: aghi  4,-320
+; CHECK64: std	15,{{[0-9]+}}(4)                      * 8-byte Folded Spill
+; CHECK64: std	14,{{[0-9]+}}(4)                      * 8-byte Folded Spill
+; CHECK64: std	13,{{[0-9]+}}(4)                      * 8-byte Folded Spill
+; CHECK64: std	12,{{[0-9]+}}(4)                      * 8-byte Folded Spill
+; CHECK64: std	11,{{[0-9]+}}(4)                      * 8-byte Folded Spill
+; CHECK64: std	10,{{[0-9]+}}(4)                      * 8-byte Folded Spill
+; CHECK64: std	9,{{[0-9]+}}(4)                       * 8-byte Folded Spill
+; CHECK64: std	8,{{[0-9]+}}(4)                       * 8-byte Folded Spill
+; CHECK64: vst	23,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
+; CHECK64: vst	22,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
+; CHECK64: vst	21,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
+; CHECK64: vst	20,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
+; CHECK64: vst	19,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
+; CHECK64: vst	18,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
+; CHECK64: vst	17,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
+; CHECK64: vst	16,{{[0-9]+}}(4),4                   * 16-byte Folded Spill
 
-; CHECK64: ld	15, {{[0-9]+}}(4)                      * 8-byte Folded Reload
-; CHECK64: ld	14, {{[0-9]+}}(4)                      * 8-byte Folded Reload
-; CHECK64: ld	13, {{[0-9]+}}(4)                      * 8-byte Folded Reload
-; CHECK64: ld	12, {{[0-9]+}}(4)                      * 8-byte Folded Reload
-; CHECK64: ld	11, {{[0-9]+}}(4)                      * 8-byte Folded Reload
-; CHECK64: ld	10, {{[0-9]+}}(4)                      * 8-byte Folded Reload
-; CHECK64: ld	9, {{[0-9]+}}(4)                       * 8-byte Folded Reload
-; CHECK64: ld	8, {{[0-9]+}}(4)                       * 8-byte Folded Reload
-; CHECK64: vl	23, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: vl	22, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: vl	21, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: vl	20, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: vl	19, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: vl	18, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: vl	17, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: vl	16, {{[0-9]+}}(4), 4                   * 16-byte Folded Reload
-; CHECK64: lg  7, 2072(4)
-; CHECK64: aghi  4, 320
+; CHECK64: ld	15,{{[0-9]+}}(4)                      * 8-byte Folded Reload
+; CHECK64: ld	14,{{[0-9]+}}(4)                      * 8-byte Folded Reload
+; CHECK64: ld	13,{{[0-9]+}}(4)                      * 8-byte Folded Reload
+; CHECK64: ld	12,{{[0-9]+}}(4)                      * 8-byte Folded Reload
+; CHECK64: ld	11,{{[0-9]+}}(4)                      * 8-byte Folded Reload
+; CHECK64: ld	10,{{[0-9]+}}(4)                      * 8-byte Folded Reload
+; CHECK64: ld	9,{{[0-9]+}}(4)                       * 8-byte Folded Reload
+; CHECK64: ld	8,{{[0-9]+}}(4)                       * 8-byte Folded Reload
+; CHECK64: vl	23,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: vl	22,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: vl	21,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: vl	20,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: vl	19,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: vl	18,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: vl	17,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: vl	16,{{[0-9]+}}(4),4                   * 16-byte Folded Reload
+; CHECK64: lg  7,2072(4)
+; CHECK64: aghi  4,320
 ; CHECK64: b 2(7)
 
 define void @func2(ptr %ptr, ptr %vec_ptr) {
@@ -275,9 +275,9 @@ define void @func2(ptr %ptr, ptr %vec_ptr) {
 
 ; Big stack frame, force the use of agfi before stmg
 ; despite not requiring stack extension routine.
-; CHECK64: agfi  4, -1040768
-; CHECK64: stmg  6, 7, 2064(4)
-; CHECK64: agfi  4, 1040768
+; CHECK64: agfi  4,-1040768
+; CHECK64: stmg  6,7,2064(4)
+; CHECK64: agfi  4,1040768
 define void @func3() {
   %arr = alloca [130070 x i64], align 8
   call i64 (ptr) @fun1(ptr %arr)
@@ -286,14 +286,14 @@ define void @func3() {
 
 ; Requires the saving of r4 due to variable sized
 ; object in stack frame. (Eg: VLA) Sets up frame pointer in r8
-; CHECK64: stmg  4, 10, 1856(4)
-; CHECK64: aghi  4, -192
-; CHECK64: lg  6, 40(5)
-; CHECK64: lg  5, 32(5)
-; CHECK64: lgr     8, 4
-; CHECK64: basr   7, 6
-; CHECK64-NEXT: bcr     0, 0
-; CHECK64: lmg  4, 10, 2048(4)
+; CHECK64: stmg  4,10,1856(4)
+; CHECK64: aghi  4,-192
+; CHECK64: lg  6,40(5)
+; CHECK64: lg  5,32(5)
+; CHECK64: lgr     8,4
+; CHECK64: basr   7,6
+; CHECK64-NEXT: bcr     0,0
+; CHECK64: lmg  4,10,2048(4)
 define i64 @func4(i64 %n) {
   %vla = alloca i64, i64 %n, align 8
   %call = call i64 @fun2(i64 %n, ptr nonnull %vla, ptr nonnull %vla)
@@ -302,13 +302,13 @@ define i64 @func4(i64 %n) {
 
 ; Require saving of r4 and in addition, a displacement large enough
 ; to force use of agfi before stmg.
-; CHECK64: lgr	0, 4
-; CHECK64: agfi	4, -1040224
-; CHECK64: stmg  4, 10, 2048(4)
-; CHECK64: lgr     8, 4
-; CHECK64: basr   7, 6
-; CHECK64-NEXT: bcr     0, 0
-; CHECK64: lmg 4, 10, 2048(4)
+; CHECK64: lgr	0,4
+; CHECK64: agfi	4,-1040224
+; CHECK64: stmg  4,10,2048(4)
+; CHECK64: lgr     8,4
+; CHECK64: basr   7,6
+; CHECK64-NEXT: bcr     0,0
+; CHECK64: lmg 4,10,2048(4)
 define i64 @func5(i64 %n) {
   %vla = alloca i64, i64 %n, align 8
   %arr = alloca [130000 x i64], align 8
@@ -317,14 +317,14 @@ define i64 @func5(i64 %n) {
 }
 
 ; CHECK-LABEL: large_stack
-; CHECK64: agfi  4, -1048800
-; CHECK64-NEXT: llgt  3, 1208
-; CHECK64-NEXT: cg  4, 64(3)
+; CHECK64: agfi  4,-1048800
+; CHECK64-NEXT: llgt  3,1208
+; CHECK64-NEXT: cg  4,64(3)
 ; CHECK64-NEXT: jhe
 ; CHECK64: * %bb.1:
-; CHECK64: lg  3, 72(3)
-; CHECK64: basr  3, 3
-; CHECK64: stmg  6, 7, 2064(4)
+; CHECK64: lg  3,72(3)
+; CHECK64: basr  3,3
+; CHECK64: stmg  6,7,2064(4)
 define void @large_stack0() {
   %arr = alloca [131072 x i64], align 8
   call i64 (ptr) @fun1(ptr %arr)
@@ -332,18 +332,18 @@ define void @large_stack0() {
 }
 
 ; CHECK-LABEL: large_stack1
-; CHECK64: agfi  4, -1048800
-; CHECK64: lgr 0, 3
-; CHECK64: llgt  3, 1208
-; CHECK64: cg  4, 64(3)
+; CHECK64: agfi  4,-1048800
+; CHECK64: lgr 0,3
+; CHECK64: llgt  3,1208
+; CHECK64: cg  4,64(3)
 ; CHECK64: jhe L#BB7_2
 ; CHECK64: %bb.1:
-; CHECK64: lg  3, 72(3)
-; CHECK64: basr  3, 3
-; CHECK64: bcr 0, 7
+; CHECK64: lg  3,72(3)
+; CHECK64: basr  3,3
+; CHECK64: bcr 0,7
 ; CHECK64: L#BB7_2:
-; CHECK64: stmg  6, 7, 2064(4)
-; CHECK64: lgr 3, 0
+; CHECK64: stmg  6,7,2064(4)
+; CHECK64: lgr 3,0
 
 ; CHECK64: L#PPA1_large_stack1_0:
 ; CHECK64: .short	6  * Length/4 of Parms
@@ -356,21 +356,21 @@ define void @large_stack1(i64 %n1, i64 %n2, i64 %n3) {
 
 
 ; CHECK-LABEL: large_stack2
-; CHECK64: lgr 0, 4
-; CHECK64: stg 3, 2192(4)
-; CHECK64: agfi  4, -1048800
-; CHECK64: llgt  3, 1208
-; CHECK64: cg  4, 64(3)
+; CHECK64: lgr 0,4
+; CHECK64: stg 3,2192(4)
+; CHECK64: agfi  4,-1048800
+; CHECK64: llgt  3,1208
+; CHECK64: cg  4,64(3)
 ; CHECK64: jhe L#BB8_2
 ; CHECK64: %bb.1:
-; CHECK64: lg  3, 72(3)
-; CHECK64: basr  3, 3
-; CHECK64: bcr 0, 7
+; CHECK64: lg  3,72(3)
+; CHECK64: basr  3,3
+; CHECK64: bcr 0,7
 ; CHECK64: L#BB8_2:
-; CHECK64: lgr 3, 0
-; CHECK64: lg  3, 2192(3)
-; CHECK64: stmg  4, 12, 2048(4)
-; CHECK64: lgr 8, 4
+; CHECK64: lgr 3,0
+; CHECK64: lg  3,2192(3)
+; CHECK64: stmg  4,12,2048(4)
+; CHECK64: lgr 8,4
 define void @large_stack2(i64 %n1, i64 %n2, i64 %n3) {
   %arr0 = alloca [131072 x i64], align 8
   %arr1 = alloca i64, i64 %n1, align 8
@@ -386,9 +386,9 @@ define void @large_stack2(i64 %n1, i64 %n2, i64 %n3) {
 ; CHECK-NEXT:     *   Bit 2: 0 = Does not use alloca
 ; CHECK-NOT: aghi  4,
 ; CHECK-NOT: stmg
-; CHECK: agr	1, 2
-; CHECK: msgr	1, 3
-; CHECK: aghik	3, 1, -4
+; CHECK: agr	1,2
+; CHECK: msgr	1,3
+; CHECK: aghik	3,1,-4
 ; CHECK-NOT: aghi  4,
 ; CHECK-NOT: lmg
 define i64 @leaf_func0(i64 %a, i64 %b, i64 %c) {

--- a/llvm/test/CodeGen/SystemZ/zos-ret-addr.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ret-addr.ll
@@ -4,7 +4,7 @@
 ; The current function's return address is in the link register.
 define ptr @rt0() norecurse nounwind readnone {
 ; CHECK-LABEL: rt0:
-; CHECK:         lgr 3, 7
+; CHECK:         lgr 3,7
 ; CHECK-NEXT:    b 2(7)
 entry:
   %0 = tail call ptr @llvm.returnaddress(i32 0)
@@ -14,10 +14,10 @@ entry:
 ; Check the caller's return address.
 define ptr @rtcaller() nounwind "backchain" {
 ; CHECK-LABEL: rtcaller:
-; CHECK:         stmg 4, 7, 2048(4)
-; CHECK-NEXT:    lg 1, 2048(4)
-; CHECK-NEXT:    lg 3, 24(1)
-; CHECK-NEXT:    lmg 4, 7, 2048(4)
+; CHECK:         stmg 4,7,2048(4)
+; CHECK-NEXT:    lg 1,2048(4)
+; CHECK-NEXT:    lg 3,24(1)
+; CHECK-NEXT:    lmg 4,7,2048(4)
 ; CHECK-NEXT:    b 2(7)
 entry:
   %0 = tail call ptr @llvm.returnaddress(i32 1)
@@ -27,11 +27,11 @@ entry:
 ; Check the caller's caller's return address.
 define ptr @rtcallercaller() nounwind "backchain" {
 ; CHECK-LABEL: rtcallercaller:
-; CHECK:         stmg 4, 7, 2048(4)
-; CHECK-NEXT:    lg 1, 2048(4)
-; CHECK-NEXT:    lg 1, 0(1)
-; CHECK-NEXT:    lg 3, 24(1)
-; CHECK-NEXT:    lmg 4, 7, 2048(4)
+; CHECK:         stmg 4,7,2048(4)
+; CHECK-NEXT:    lg 1,2048(4)
+; CHECK-NEXT:    lg 1,0(1)
+; CHECK-NEXT:    lg 3,24(1)
+; CHECK-NEXT:    lmg 4,7,2048(4)
 ; CHECK-NEXT:    b 2(7)
 entry:
   %0 = tail call ptr @llvm.returnaddress(i32 2)

--- a/llvm/test/CodeGen/SystemZ/zos-stackpointer.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-stackpointer.ll
@@ -1,7 +1,7 @@
 ; RUN: llc < %s -mtriple=s390x-ibm-zos | FileCheck %s
 
 ; CHECK-LABEL: get_stack:
-; CHECK: lgr   3, 4
+; CHECK: lgr   3,4
 ; CHECK: b 2(7)
 
 define ptr @get_stack() nounwind {


### PR DESCRIPTION
Now that the GNU and HLASM `InstPrinter` paths are separated in https://github.com/llvm/llvm-project/pull/112975, differentiate between them in `SystemZInstrFormats.td`.

The main difference are:
- Tabs converted to space
- Remove space after comma for instruction operands