### PR TITLE
[clang-tidy] Stop linking against clangSema

### DIFF
--- a/clang-tools-extra/clang-tidy/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/CMakeLists.txt
@@ -35,7 +35,6 @@ clang_target_link_libraries(clangTidy
   clangFrontend
   clangLex
   clangRewrite
-  clangSema
   clangSerialization
   clangTooling
   clangToolingCore

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -336,6 +336,7 @@ private:
   std::unique_ptr<ClangTidyProfiling> Profiling;
   std::unique_ptr<ast_matchers::MatchFinder> Finder;
   std::vector<std::unique_ptr<ClangTidyCheck>> Checks;
+  void anchor() override {};
 };
 
 } // namespace


### PR DESCRIPTION
This is bad layering-wise. The only fix needed now is to anchor `SemaConsumer` vtable, which is also done in this patch.