### PR TITLE
[WebKit Checkers] Make TrivialFunctionAnalysis recognize std::array::operator[] as trivial

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -414,7 +414,8 @@ public:
         Name == "isMainThreadOrGCThread" || Name == "isMainRunLoop" ||
         Name == "isWebThread" || Name == "isUIThread" ||
         Name == "mayBeGCThread" || Name == "compilerFenceForCrash" ||
-        Name == "bitwise_cast" || Name.find("__builtin") == 0)
+        Name == "bitwise_cast" || Name.find("__builtin") == 0 ||
+        Name == "__libcpp_verbose_abort")
       return true;
 
     return IsFunctionTrivial(Callee);

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg-std-array.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg-std-array.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
+// expected-no-diagnostics
+
+#include "mock-types.h"
+
+void __libcpp_verbose_abort(const char *__format, ...);
+
+using size_t = __typeof(sizeof(int));
+namespace std{
+template <class T, size_t N>
+class array {
+  T elements[N];
+  
+  public:
+  T& operator[](unsigned i) {
+    if (i >= N) {
+      __libcpp_verbose_abort("%s", "aborting");
+    }
+    return elements[i];
+  }
+};
+}
+
+class ArrayClass {
+public:
+  void ref() const;
+  void deref() const;
+  typedef std::array<std::array<double, 4>, 4> Matrix;
+  double e() { return matrix[3][0]; }
+  Matrix matrix;
+};
+
+class AnotherClass {
+  RefPtr<ArrayClass> matrix;
+  void test() {
+    double val = { matrix->e()};
+  }
+};
+

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -238,6 +238,8 @@ public:
   using BaseType::BaseType;
 };
 
+void __libcpp_verbose_abort(const char *__format, ...);
+
 class RefCounted {
 public:
   void ref() const;
@@ -361,6 +363,9 @@ public:
   void trivial62() { WTFReportBacktrace(); }
   SomeType trivial63() { return SomeType(0); }
   SomeType trivial64() { return SomeType(); }
+  void trivial65() {
+    __libcpp_verbose_abort("%s", "aborting");
+  }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -544,6 +549,7 @@ public:
     getFieldTrivial().trivial62(); // no-warning
     getFieldTrivial().trivial63(); // no-warning
     getFieldTrivial().trivial64(); // no-warning
+    getFieldTrivial().trivial65(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning


### PR DESCRIPTION
TFA wasn't recognizing `__libcpp_verbose_abort` as trivial causing `std::array::operator[]` also not being recongnized as trivial.