### PR TITLE
[libc] Use `if constexpr` for compile-time conditionals

### DIFF
--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -124,35 +124,35 @@ public:
 
   bool match(T actualValue) {
     actual = actualValue;
-    if (cpp::is_complex_type_same<T, _Complex float>())
+    if constexpr (cpp::is_complex_type_same<T, _Complex float>())
       return matchComplex<float>();
-    else if (cpp::is_complex_type_same<T, _Complex double>())
+    else if constexpr (cpp::is_complex_type_same<T, _Complex double>())
       return matchComplex<double>();
-    else if (cpp::is_complex_type_same<T, _Complex long double>())
+    else if constexpr (cpp::is_complex_type_same<T, _Complex long double>())
       return matchComplex<long double>();
 #ifdef LIBC_TYPES_HAS_CFLOAT16
-    else if (cpp::is_complex_type_same<T, cfloat16>)
+    else if constexpr (cpp::is_complex_type_same<T, cfloat16>)
       return matchComplex<float16>();
 #endif
 #ifdef LIBC_TYPES_HAS_CFLOAT128
-    else if (cpp::is_complex_type_same<T, cfloat128>)
+    else if constexpr (cpp::is_complex_type_same<T, cfloat128>)
       return matchComplex<float128>();
 #endif
   }
 
   void explainError() override {
-    if (cpp::is_complex_type_same<T, _Complex float>())
+    if constexpr (cpp::is_complex_type_same<T, _Complex float>())
       return explainErrorComplex<float>();
-    else if (cpp::is_complex_type_same<T, _Complex double>())
+    else if constexpr (cpp::is_complex_type_same<T, _Complex double>())
       return explainErrorComplex<double>();
-    else if (cpp::is_complex_type_same<T, _Complex long double>())
+    else if constexpr (cpp::is_complex_type_same<T, _Complex long double>())
       return explainErrorComplex<long double>();
 #ifdef LIBC_TYPES_HAS_CFLOAT16
-    else if (cpp::is_complex_type_same<T, cfloat16>)
+    else if constexpr (cpp::is_complex_type_same<T, cfloat16>)
       return explainErrorComplex<float16>();
 #endif
 #ifdef LIBC_TYPES_HAS_CFLOAT128
-    else if (cpp::is_complex_type_same<T, cfloat128>)
+    else if constexpr (cpp::is_complex_type_same<T, cfloat128>)
       return explainErrorComplex<float128>();
 #endif
   }


### PR DESCRIPTION
Don't use plain `if` for things that are compile-time constants.
Instead, use `if constexpr`.  This both ensures that these are
properly wired up constant expressions as intended, and prevents
warnings from the compiler about useless `if` checks that look in
the source like they're meant to do something at runtime but will
just be compiled away.
