### PR TITLE
[PAC][lld] Fix reloc against adrp imm in PAC PLT header

### DIFF
--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -1048,7 +1048,7 @@ void AArch64BtiPac::writePltHeader(uint8_t *buf) const {
   memcpy(buf, pltData, sizeof(pltData));
 
   relocateNoSym(buf + 4, R_AARCH64_ADR_PREL_PG_HI21,
-                getAArch64Page(got + 16) - getAArch64Page(plt + 8));
+                getAArch64Page(got + 16) - getAArch64Page(plt + 4));
   relocateNoSym(buf + 8, R_AARCH64_LDST64_ABS_LO12_NC, got + 16);
   relocateNoSym(buf + 12, R_AARCH64_ADD_ABS_LO12_NC, got + 16);
   if (!btiHeader)


### PR DESCRIPTION
The PAC PLT header contains adrp instruction which immediate should be filled. In https://reviews.llvm.org/D62609, the adrp instruction address was calculated incorrectly. This patch resolves the issue.

The test is already present in test/ELF/aarch64-feature-pac.s