### PR TITLE
[clang][NFC] Add test for CWG1898 "Use of “equivalent” in overload resolution"

### DIFF
--- a/clang/test/CXX/drs/cwg18xx.cpp
+++ b/clang/test/CXX/drs/cwg18xx.cpp
@@ -640,3 +640,48 @@ namespace H {
   struct S s;
 }
 }
+
+namespace cwg1898 { // cwg1898: 2.7
+void e(int) {} // #cwg1898-e-int
+void e(int) {}
+// expected-error@-1 {{redefinition of 'e'}}
+//   expected-note@#cwg1898-e-int {{previous definition is here}}
+void e(long) {}
+
+void f(int) {} // #cwg1898-f-int
+void f(const int) {}
+// expected-error@-1 {{redefinition of 'f'}}
+//   expected-note@#cwg1898-f-int {{previous definition is here}}
+
+void g(int) {} // #cwg1898-g-int
+void g(volatile int) {}
+// since-cxx20-warning@-1 {{volatile-qualified parameter type 'volatile int' is deprecated}}
+// expected-error@-2 {{redefinition of 'g'}}
+//   expected-note@#cwg1898-g-int {{previous definition is here}}
+
+void h(int *) {} // #cwg1898-h-int
+void h(int[]) {}
+// expected-error@-1 {{redefinition of 'h'}}
+//   expected-note@#cwg1898-h-int {{previous definition is here}}
+
+void i(int *) {} // #cwg1898-i-int
+void i(int[2]) {}
+// expected-error@-1 {{redefinition of 'i'}}
+//   expected-note@#cwg1898-i-int {{previous definition is here}}
+
+void j(void(*)()) {} // #cwg1898-j-int
+void j(void()) {}
+// expected-error@-1 {{redefinition of 'j'}}
+//   expected-note@#cwg1898-j-int {{previous definition is here}}
+
+struct A {
+  void k(int) {} // #cwg1898-k-int
+  void k(int) {}
+  // expected-error@-1 {{class member cannot be redeclared}}
+  //   expected-note@#cwg1898-k-int {{previous definition is here}}
+};
+
+struct B : A {
+  void k(int) {}
+};
+} // namespace cwg1898

--- a/clang/test/CXX/drs/cwg18xx.cpp
+++ b/clang/test/CXX/drs/cwg18xx.cpp
@@ -642,46 +642,69 @@ namespace H {
 }
 
 namespace cwg1898 { // cwg1898: 2.7
-void e(int) {} // #cwg1898-e-int
+void e(int) {} // #cwg1898-e
 void e(int) {}
 // expected-error@-1 {{redefinition of 'e'}}
-//   expected-note@#cwg1898-e-int {{previous definition is here}}
-void e(long) {}
+//   expected-note@#cwg1898-e {{previous definition is here}}
 
-void f(int) {} // #cwg1898-f-int
+void e2(int) {}
+void e2(long) {} // OK, different type
+
+void f(int) {} // #cwg1898-f
 void f(const int) {}
 // expected-error@-1 {{redefinition of 'f'}}
-//   expected-note@#cwg1898-f-int {{previous definition is here}}
+//   expected-note@#cwg1898-f {{previous definition is here}}
 
-void g(int) {} // #cwg1898-g-int
+void g(int) {} // #cwg1898-g
 void g(volatile int) {}
 // since-cxx20-warning@-1 {{volatile-qualified parameter type 'volatile int' is deprecated}}
 // expected-error@-2 {{redefinition of 'g'}}
-//   expected-note@#cwg1898-g-int {{previous definition is here}}
+//   expected-note@#cwg1898-g {{previous definition is here}}
 
-void h(int *) {} // #cwg1898-h-int
+void h(int *) {} // #cwg1898-h
 void h(int[]) {}
 // expected-error@-1 {{redefinition of 'h'}}
-//   expected-note@#cwg1898-h-int {{previous definition is here}}
+//   expected-note@#cwg1898-h {{previous definition is here}}
 
-void i(int *) {} // #cwg1898-i-int
-void i(int[2]) {}
-// expected-error@-1 {{redefinition of 'i'}}
-//   expected-note@#cwg1898-i-int {{previous definition is here}}
+void h2(int *) {} // #cwg1898-h2
+void h2(int[2]) {}
+// expected-error@-1 {{redefinition of 'h2'}}
+//   expected-note@#cwg1898-h2 {{previous definition is here}}
 
-void j(void(*)()) {} // #cwg1898-j-int
+void h3(int (*)[2]) {} // #cwg1898-h3
+void h3(int [3][2]) {}
+// expected-error@-1 {{redefinition of 'h3'}}
+//   expected-note@#cwg1898-h3 {{previous definition is here}}
+
+void h4(int (*)[2]) {}
+void h4(int [3][3]) {} // OK, differ in non-top-level extent of array
+
+void i(int *) {}
+void i(const int *) {} // OK, pointee cv-qualification is not discarded
+
+void i2(int *) {} // #cwg1898-i2
+void i2(int * const) {}
+// expected-error@-1 {{redefinition of 'i2'}}
+//   expected-note@#cwg1898-i2 {{previous definition is here}}
+
+void j(void(*)()) {} // #cwg1898-j
 void j(void()) {}
 // expected-error@-1 {{redefinition of 'j'}}
-//   expected-note@#cwg1898-j-int {{previous definition is here}}
+//   expected-note@#cwg1898-j {{previous definition is here}}
+
+void j2(void(int)) {} // #cwg1898-j2
+void j2(void(const int)) {}
+// expected-error@-1 {{redefinition of 'j2'}}
+//   expected-note@#cwg1898-j2 {{previous definition is here}}
 
 struct A {
-  void k(int) {} // #cwg1898-k-int
+  void k(int) {} // #cwg1898-k
   void k(int) {}
   // expected-error@-1 {{class member cannot be redeclared}}
-  //   expected-note@#cwg1898-k-int {{previous definition is here}}
+  //   expected-note@#cwg1898-k {{previous definition is here}}
 };
 
 struct B : A {
-  void k(int) {}
+  void k(int) {} // OK, shadows A::k
 };
 } // namespace cwg1898

--- a/clang/test/CXX/drs/cwg18xx.cpp
+++ b/clang/test/CXX/drs/cwg18xx.cpp
@@ -707,4 +707,19 @@ struct A {
 struct B : A {
   void k(int) {} // OK, shadows A::k
 };
+
+void l() {}
+void l(...) {}
+
+#if __cplusplus >= 201103L
+template <typename T>
+void m(T) {}
+template <typename... Ts>
+void m(Ts...) {}
+
+template <typename T, typename U>
+void m2(T, U) {}
+template <typename... Ts, typename U>
+void m2(Ts..., U) {}
+#endif
 } // namespace cwg1898

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -11219,7 +11219,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1898.html">1898</a></td>
     <td>CD6</td>
     <td>Use of &#8220;equivalent&#8221; in overload resolution</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="1899">
     <td><a href="https://cplusplus.github.io/CWG/issues/1899.html">1899</a></td>


### PR DESCRIPTION
[CWG1898](https://cplusplus.github.io/CWG/issues/1898.html) Use of “equivalent” in overload resolution
====================

[P1787R6](https://wg21.link/p1787r6):
> CWG1898 is resolved by explicitly using the defined term parameter-type-list.

Except that now it's called non-object-parameter-type-list, which is defined in [dcl.fct] [p8](https://eel.is/c++draft/dcl.fct#8) and [p4](https://eel.is/c++draft/dcl.fct#8).

As for the wording, the first sentence [\_N4140\_.[over.dcl]/1](https://timsong-cpp.github.io/cppwp/n4140/over.dcl#1) where the word "equivalent" was used:
> Two function declarations of the same name refer to the same function if they are in the same scope and have equivalent parameter declarations ([over.load]).

was replaced with what is now known as "corresponding overloads", defined in [[basic.scope.scope]/4](https://eel.is/c++draft/basic.scope#scope-4). The definition is present in P1787R6, but it's hard to reference, because the "corresponding overloads" term was coined later.