### PR TITLE
[libc++] Refactor vector::push_back to use vector::emplace

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -689,9 +689,9 @@ public:
     return std::__to_address(this->__begin_);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(const_reference __x);
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(const_reference __x) { emplace_back(__x); }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(value_type&& __x);
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(value_type&& __x) { emplace_back(std::move(__x)); }
 
   template <class... _Args>
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
@@ -897,9 +897,6 @@ private:
     __base_destruct_at_end(__new_last);
     __annotate_shrink(__old_size);
   }
-
-  template <class _Up>
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI inline pointer __push_back_slow_path(_Up&& __x);
 
   template <class... _Args>
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI inline pointer __emplace_back_slow_path(_Args&&... __args);
@@ -1489,44 +1486,6 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::shrink_to_fit() _NOE
     }
 #endif // _LIBCPP_HAS_EXCEPTIONS
   }
-}
-
-template <class _Tp, class _Allocator>
-template <class _Up>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 typename vector<_Tp, _Allocator>::pointer
-vector<_Tp, _Allocator>::__push_back_slow_path(_Up&& __x) {
-  allocator_type& __a = this->__alloc();
-  __split_buffer<value_type, allocator_type&> __v(__recommend(size() + 1), size(), __a);
-  // __v.push_back(std::forward<_Up>(__x));
-  __alloc_traits::construct(__a, std::__to_address(__v.__end_), std::forward<_Up>(__x));
-  __v.__end_++;
-  __swap_out_circular_buffer(__v);
-  return this->__end_;
-}
-
-template <class _Tp, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 inline _LIBCPP_HIDE_FROM_ABI void
-vector<_Tp, _Allocator>::push_back(const_reference __x) {
-  pointer __end = this->__end_;
-  if (__end < this->__end_cap()) {
-    __construct_one_at_end(__x);
-    ++__end;
-  } else {
-    __end = __push_back_slow_path(__x);
-  }
-  this->__end_ = __end;
-}
-
-template <class _Tp, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 inline _LIBCPP_HIDE_FROM_ABI void vector<_Tp, _Allocator>::push_back(value_type&& __x) {
-  pointer __end = this->__end_;
-  if (__end < this->__end_cap()) {
-    __construct_one_at_end(std::move(__x));
-    ++__end;
-  } else {
-    __end = __push_back_slow_path(std::move(__x));
-  }
-  this->__end_ = __end;
 }
 
 template <class _Tp, class _Allocator>


### PR DESCRIPTION
This removes some duplicate code. I suspect this was originally written that way because vector::emplace didn't exist in C++03 mode, which stopped being relevant when Clang implemented rvalue references in C++03.