### PR TITLE
[LLVM] List all instructions that are `!unpredictable`

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -7154,12 +7154,15 @@ sections that the user does not want removed after linking.
 '``unpredictable``' Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``unpredictable`` metadata may be attached to any branch or switch
-instruction. It can be used to express the unpredictability of control
-flow. Similar to the llvm.expect intrinsic, it may be used to alter
-optimizations related to compare and branch instructions. The metadata
-is treated as a boolean value; if it exists, it signals that the branch
-or switch that it is attached to is completely unpredictable.
+``unpredictable``` can be used to express the unpredictability of control flow.
+Similar to the ``llvm.expect`` intrinsic, it may be used to alter optimizations
+related to compare and branch instructions. This is treated as a boolean value:
+Any instruction it is attached to signals it is completely unpredictable.
+
+``!unpredictable`` may be attached to, and will affect, these instructions:
+* branch
+* select
+* switch
 
 .. _md_dereferenceable:
 


### PR DESCRIPTION
Support for `select ... !unpredictable` was added some time ago and is even tested for some backends, but was apparently never documented. e.g. [llvm/test/CodeGen/X86/x86-cmov-converter.ll](https://github.com/llvm/llvm-project/blob/ac5a2010ad35a72de3e75a1883e2495345b92a73/llvm/test/CodeGen/X86/x86-cmov-converter.ll#L359-L430) tests to guarantee that `select ... !unpredictable` survives the infamous cmov-to-jmp conversion.