### PR TITLE
[LLDB] Add a target.launch-working-dir setting

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -37,6 +37,7 @@
 #include "lldb/Utility/RealpathPrefixes.h"
 #include "lldb/Utility/Timeout.h"
 #include "lldb/lldb-public.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace lldb_private {
 
@@ -113,6 +114,8 @@ public:
   bool GetDisableSTDIO() const;
 
   void SetDisableSTDIO(bool b);
+
+  llvm::StringRef GetLaunchWorkingDirectory() const;
 
   const char *GetDisassemblyFlavor() const;
 

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -201,6 +201,13 @@ protected:
     if (target->GetDisableSTDIO())
       m_options.launch_info.GetFlags().Set(eLaunchFlagDisableSTDIO);
 
+    if (!m_options.launch_info.GetWorkingDirectory()) {
+      if (llvm::StringRef wd = target->GetLaunchWorkingDirectory();
+          !wd.empty()) {
+        m_options.launch_info.SetWorkingDirectory(FileSpec(wd));
+      }
+    }
+
     // Merge the launch info environment with the target environment.
     Environment target_env = target->GetEnvironment();
     m_options.launch_info.GetEnvironment().insert(target_env.begin(),

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -691,7 +691,10 @@ let Command = "process launch" in {
   def process_launch_plugin : Option<"plugin", "P">, Arg<"Plugin">,
     Desc<"Name of the process plugin you want to use.">;
   def process_launch_working_dir : Option<"working-dir", "w">, Arg<"DirectoryName">,
-    Desc<"Set the current working directory to <path> when running the inferior.">;
+    Desc<"Set the current working directory to <path> when running the inferior. This option "
+         "applies only to the current `process launch` invocation. If "
+         "`target.launch-working-dir` is set and this option is given, the value of this "
+         "option will be used instead of the setting.">;
   def process_launch_arch : Option<"arch", "a">, Arg<"Architecture">,
     Desc<"Set the architecture for the process to launch when ambiguous.">;
   def process_launch_environment : Option<"environment", "E">,

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4428,6 +4428,11 @@ void TargetProperties::SetDisableSTDIO(bool b) {
   const uint32_t idx = ePropertyDisableSTDIO;
   SetPropertyAtIndex(idx, b);
 }
+llvm::StringRef TargetProperties::GetLaunchWorkingDirectory() const {
+  const uint32_t idx = ePropertyLaunchWorkingDir;
+  return GetPropertyAtIndexAs<llvm::StringRef>(
+      idx, g_target_properties[idx].default_cstr_value);
+}
 
 const char *TargetProperties::GetDisassemblyFlavor() const {
   const uint32_t idx = ePropertyDisassemblyFlavor;

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -201,6 +201,13 @@ let Definition = "target" in {
   def DebugUtilityExpression: Property<"debug-utility-expression", "Boolean">,
     DefaultFalse,
     Desc<"Enable debugging of LLDB-internal utility expressions.">;
+  def LaunchWorkingDir: Property<"launch-working-dir", "String">,
+    DefaultStringValue<"">,
+    Desc<"A default value for the working directory to use when launching processes. "
+         "It is ignored when empty. This setting is only used when the target is "
+         "launched. If you change this setting, the new value will only apply to "
+         "subsequent launches. Commands that take an explicit working directory "
+         "will override this setting.">;
 }
 
 let Definition = "process_experimental" in {

--- a/lldb/test/API/commands/process/launch/TestProcessLaunch.py
+++ b/lldb/test/API/commands/process/launch/TestProcessLaunch.py
@@ -8,6 +8,7 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+from pathlib import Path
 
 
 class ProcessLaunchTestCase(TestBase):
@@ -206,3 +207,59 @@ class ProcessLaunchTestCase(TestBase):
         self.assertEqual(value, evil_var)
         process.Continue()
         self.assertState(process.GetState(), lldb.eStateExited, PROCESS_EXITED)
+
+    def test_target_launch_working_dir_prop(self):
+        """Test that the setting `target.launch-working-dir` is correctly used when launching a process."""
+        d = {"CXX_SOURCES": "print_cwd.cpp"}
+        self.build(dictionary=d)
+        self.setTearDownCleanup(d)
+        exe = self.getBuildArtifact("a.out")
+        self.runCmd("file " + exe)
+
+        mywd = "my_working_dir"
+        out_file_name = "my_working_dir_test.out"
+
+        my_working_dir_path = self.getBuildArtifact(mywd)
+        lldbutil.mkdir_p(my_working_dir_path)
+        out_file_path = os.path.join(my_working_dir_path, out_file_name)
+        another_working_dir_path = Path(
+            os.path.join(my_working_dir_path, "..")
+        ).resolve()
+
+        # If -w is not passed to process launch, then the setting will be used.
+        self.runCmd(
+            f"settings set target.launch-working-dir {another_working_dir_path}"
+        )
+        launch_command = f"process launch -o {out_file_path}"
+
+        self.expect(
+            launch_command,
+            patterns=["Process .* launched: .*a.out"],
+        )
+
+        out = lldbutil.read_file_on_target(self, out_file_path)
+
+        self.assertIn(f"stdout: {another_working_dir_path}", out)
+
+        # If -w is passed to process launch, that value will be used instead of the setting.
+        launch_command = f"process launch -w {my_working_dir_path} -o {out_file_path}"
+
+        self.expect(
+            launch_command,
+            patterns=["Process .* launched: .*a.out"],
+        )
+
+        out = lldbutil.read_file_on_target(self, out_file_path)
+        self.assertIn(f"stdout: {my_working_dir_path}", out)
+
+        # If set to empty, then LLDB's cwd will be used to launch the process.
+        self.runCmd(f"settings set target.launch-working-dir ''")
+        launch_command = f"process launch -o {out_file_path}"
+
+        self.expect(
+            launch_command,
+            patterns=["Process .* launched: .*a.out"],
+        )
+
+        out = lldbutil.read_file_on_target(self, out_file_path)
+        self.assertNotIn(f"stdout: {another_working_dir_path}", out)

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -304,6 +304,8 @@ Changes to LLDB
 * Program stdout/stderr redirection will now open the file with O_TRUNC flag, make sure to truncate the file if path already exists.
   * eg. `settings set target.output-path/target.error-path <path/to/file>`
 
+* A new setting `target.launch-working-dir` can be used to set a persistent cwd that is used by default by `process launch` and `run`.
+
 Changes to BOLT
 ---------------------------------
 


### PR DESCRIPTION
Internally we use bazel in a way in which it can drop you in a LLDB session with the target launched in a particular cwd, which is needed for things to work. We've been making this automation work via `process launch -w`. However, if later the user wants to restart the process with `r`, then they end up using a different cwd for relaunching the process. As a way to fix this, I'm adding a target-level setting that allows configuring a default cwd used for launching the process without needing the user to specify it manually.