### PR TITLE
[libc] Pass through LIBC_CONF_MATH_OPTIMIZATIONS correctly

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -84,7 +84,7 @@ function(_get_compile_options_from_config output_var)
   endif()
 
   if(LIBC_CONF_MATH_OPTIMIZATIONS)
-    list(APPEND compile_options "-DLIBC_MATH=${LIBC_CONF_MATH_OPTIMIZATIONS}")
+    list(APPEND config_options "-DLIBC_MATH=${LIBC_CONF_MATH_OPTIMIZATIONS}")
   endif()
 
   set(${output_var} ${config_options} PARENT_SCOPE)


### PR DESCRIPTION
It's checked in a cmake function that builds up a list called `config_options`. But the check was appending to a list called `compile_options`, so the intended `-DLIBC_MATH=whatever` didn't end up on the actual compile command lines.