### PR TITLE
[AST] Bump Type::NumOfBuiltinTypeBits. NFCI.

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -1930,7 +1930,7 @@ protected:
     unsigned : NumTypeBits;
 
     /// The kind (BuiltinType::Kind) of builtin type this is.
-    static constexpr unsigned NumOfBuiltinTypeBits = 9;
+    static constexpr unsigned NumOfBuiltinTypeBits = 10;
     unsigned Kind : NumOfBuiltinTypeBits;
   };
 


### PR DESCRIPTION
BuiltinType::LastKind is currently 507 which is close to the current
limit of 511.
