### PR TITLE
[AArch64] Add assembly/disassembly for FRINT{32,64}{X,Z} (merging)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -73,8 +73,13 @@ def SVEUnsupported : AArch64Unsupported {
                       SVE2Unsupported.F);
 }
 
-let F = [HasSME2p1, HasSVE2p1_or_HasSME2p1, HasSVE2p1orSSVE_AES] in
-def SME2p1Unsupported : AArch64Unsupported;
+let F = [HasSME2p2, HasSVE2p2orSME2p2] in
+def SME2p2Unsupported : AArch64Unsupported;
+
+def SME2p1Unsupported : AArch64Unsupported {
+  let F = !listconcat([HasSME2p1, HasSVE2p1_or_HasSME2p1, HasSVE2p1orSSVE_AES],
+                      SME2p2Unsupported.F);
+}
 
 def SME2Unsupported : AArch64Unsupported {
   let F = !listconcat([HasSME2, HasSVE2orSME2, HasSVE2p1_or_HasSME2, HasSSVE_FP8FMA,

--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4226,6 +4226,13 @@ let Predicates = [HasSVE2p2orSME2p2] in {
 
   // SVE2p2 floating-point convert single-to-bf (placing odd), zeroing predicate
   def BFCVTNT_ZPzZ      : sve_fp_fcvt2z<0b1010, "bfcvtnt", ZPR16, ZPR32>;
+
+  // Floating point round to integral fp value in integer size range
+  // Merging
+  defm FRINT32Z_ZPmZ : sve_fp_2op_p_zd_frint<0b00, "frint32z">;
+  defm FRINT32X_ZPmZ : sve_fp_2op_p_zd_frint<0b01, "frint32x">;
+  defm FRINT64X_ZPmZ : sve_fp_2op_p_zd_frint<0b10, "frint64z">;
+  defm FRINT64Z_ZPmZ : sve_fp_2op_p_zd_frint<0b11, "frint64x">;
 } // End HasSME2p2orSVE2p2
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -3104,6 +3104,11 @@ multiclass sve2_fp_convert_down_odd_rounding<string asm, string op, SDPatternOpe
   def : SVE_1_Op_Passthru_Pat<nxv2f32, ir_op, nxv2i1, nxv2f64, !cast<Instruction>(NAME # _DtoS)>;
 }
 
+multiclass sve_fp_2op_p_zd_frint<bits<2> opc, string asm> {
+  def _S : sve_fp_2op_p_zd<{ 0b0010, opc{1}, 0, opc{0} }, asm, ZPR32, ZPR32, ElementSizeS>;
+  def _D : sve_fp_2op_p_zd<{ 0b0010, opc{1}, 1, opc{0} }, asm, ZPR64, ZPR64, ElementSizeD>;
+}
+
 //===----------------------------------------------------------------------===//
 // SVE Floating Point Unary Operations - Unpredicated Group
 //===----------------------------------------------------------------------===//

--- a/llvm/test/MC/AArch64/SVE2p2/frint32x-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint32x-diagnostics.s
@@ -1,0 +1,32 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 2>&1 < %s| FileCheck %s
+
+// ------------------------------------------------------------------------- //
+// Invalid element width
+
+frint32x     z31.b, p7/m, z31.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32x     z31.b, p7/m, z31.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint32x     z31.h, p7/m, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32x     z31.h, p7/m, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint32x     z31.s, p7/m, z31.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32x     z31.s, p7/m, z31.d
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint32x     z31.d, p7/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32x     z31.d, p7/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// ------------------------------------------------------------------------- //
+// Invalid predicate
+
+frint32x     z31.s, p8/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid restricted predicate register, expected p0..p7 (without element suffix)
+// CHECK-NEXT: frint32x     z31.s, p8/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE2p2/frint32x.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint32x.s
@@ -1,0 +1,49 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sve2p2 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sve2p2 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+movprfx  z23.d, p3/m, z31.d
+frint32x z23.d, p3/m, z13.d  // 01100101-00010011-10101101-10110111
+// CHECK-INST:  movprfx  z23.d, p3/m, z31.d
+// CHECK-INST: frint32x z23.d, p3/m, z13.d
+// CHECK-ENCODING: [0xb7,0xad,0x13,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6513adb7 <unknown>
+
+movprfx z23, z31
+frint32x z23.s, p3/m, z13.s  // 01100101-00010001-10101101-10110111
+// CHECK-INST:  movprfx z23, z31
+// CHECK-INST: frint32x z23.s, p3/m, z13.s
+// CHECK-ENCODING: [0xb7,0xad,0x11,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6511adb7 <unknown>
+
+frint32x z0.s, p0/m, z0.s  // 01100101-00010001-10100000-00000000
+// CHECK-INST: frint32x z0.s, p0/m, z0.s
+// CHECK-ENCODING: [0x00,0xa0,0x11,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6511a000 <unknown>
+
+frint32x z21.d, p5/m, z10.d  // 01100101-00010011-10110101-01010101
+// CHECK-INST: frint32x z21.d, p5/m, z10.d
+// CHECK-ENCODING: [0x55,0xb5,0x13,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6513b555 <unknown>
+
+frint32x z31.d, p7/m, z31.d  // 01100101-00010011-10111111-11111111
+// CHECK-INST: frint32x z31.d, p7/m, z31.d
+// CHECK-ENCODING: [0xff,0xbf,0x13,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6513bfff <unknown>

--- a/llvm/test/MC/AArch64/SVE2p2/frint32z-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint32z-diagnostics.s
@@ -1,0 +1,32 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 2>&1 < %s| FileCheck %s
+
+// ------------------------------------------------------------------------- //
+// Invalid element width
+
+frint32z     z31.b, p7/m, z31.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32z     z31.b, p7/m, z31.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint32z     z31.h, p7/m, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32z     z31.h, p7/m, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint32z     z31.s, p7/m, z31.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32z     z31.s, p7/m, z31.d
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint32z     z31.d, p7/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint32z     z31.d, p7/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// ------------------------------------------------------------------------- //
+// Invalid predicate
+
+frint32z     z31.s, p8/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid restricted predicate register, expected p0..p7 (without element suffix)
+// CHECK-NEXT: frint32z     z31.s, p8/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE2p2/frint32z.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint32z.s
@@ -1,0 +1,49 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sve2p2 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sve2p2 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+movprfx  z23.d, p3/m, z31.d
+frint32z z23.d, p3/m, z13.d  // 01100101-00010010-10101101-10110111
+// CHECK-INST:  movprfx  z23.d, p3/m, z31.d
+// CHECK-INST: frint32z z23.d, p3/m, z13.d
+// CHECK-ENCODING: [0xb7,0xad,0x12,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6512adb7 <unknown>
+
+movprfx z23, z31
+frint32z z23.s, p3/m, z13.s  // 01100101-00010000-10101101-10110111
+// CHECK-INST:  movprfx z23, z31
+// CHECK-INST: frint32z z23.s, p3/m, z13.s
+// CHECK-ENCODING: [0xb7,0xad,0x10,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6510adb7 <unknown>
+
+frint32z z0.s, p0/m, z0.s  // 01100101-00010000-10100000-00000000
+// CHECK-INST: frint32z z0.s, p0/m, z0.s
+// CHECK-ENCODING: [0x00,0xa0,0x10,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6510a000 <unknown>
+
+frint32z z21.d, p5/m, z10.d  // 01100101-00010010-10110101-01010101
+// CHECK-INST: frint32z z21.d, p5/m, z10.d
+// CHECK-ENCODING: [0x55,0xb5,0x12,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6512b555 <unknown>
+
+frint32z z31.d, p7/m, z31.d  // 01100101-00010010-10111111-11111111
+// CHECK-INST: frint32z z31.d, p7/m, z31.d
+// CHECK-ENCODING: [0xff,0xbf,0x12,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6512bfff <unknown>

--- a/llvm/test/MC/AArch64/SVE2p2/frint64x-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint64x-diagnostics.s
@@ -1,0 +1,32 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 2>&1 < %s| FileCheck %s
+
+// ------------------------------------------------------------------------- //
+// Invalid element width
+
+frint64x     z31.b, p7/m, z31.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64x     z31.b, p7/m, z31.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint64x     z31.h, p7/m, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64x     z31.h, p7/m, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint64x     z31.s, p7/m, z31.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64x     z31.s, p7/m, z31.d
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint64x     z31.d, p7/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64x     z31.d, p7/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// ------------------------------------------------------------------------- //
+// Invalid predicate
+
+frint64x     z31.s, p8/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid restricted predicate register, expected p0..p7 (without element suffix)
+// CHECK-NEXT: frint64x     z31.s, p8/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE2p2/frint64x.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint64x.s
@@ -1,0 +1,49 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sve2p2 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sve2p2 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+movprfx  z23.d, p3/m, z31.d
+frint64x z23.d, p3/m, z13.d  // 01100101-00010111-10101101-10110111
+// CHECK-INST:  movprfx  z23.d, p3/m, z31.d
+// CHECK-INST: frint64x z23.d, p3/m, z13.d
+// CHECK-ENCODING: [0xb7,0xad,0x17,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6517adb7 <unknown>
+
+movprfx z23, z31
+frint64x z23.s, p3/m, z13.s  // 01100101-00010101-10101101-10110111
+// CHECK-INST:  movprfx z23, z31
+// CHECK-INST: frint64x z23.s, p3/m, z13.s
+// CHECK-ENCODING: [0xb7,0xad,0x15,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6515adb7 <unknown>
+
+frint64x z21.d, p5/m, z10.d  // 01100101-00010111-10110101-01010101
+// CHECK-INST: frint64x z21.d, p5/m, z10.d
+// CHECK-ENCODING: [0x55,0xb5,0x17,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6517b555 <unknown>
+
+frint64x z31.d, p7/m, z31.d  // 01100101-00010111-10111111-11111111
+// CHECK-INST: frint64x z31.d, p7/m, z31.d
+// CHECK-ENCODING: [0xff,0xbf,0x17,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6517bfff <unknown>
+
+frint64x z31.s, p7/m, z31.s  // 01100101-00010101-10111111-11111111
+// CHECK-INST: frint64x z31.s, p7/m, z31.s
+// CHECK-ENCODING: [0xff,0xbf,0x15,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6515bfff <unknown>

--- a/llvm/test/MC/AArch64/SVE2p2/frint64z-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint64z-diagnostics.s
@@ -1,0 +1,32 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 2>&1 < %s| FileCheck %s
+
+// ------------------------------------------------------------------------- //
+// Invalid element width
+
+frint64z     z31.b, p7/m, z31.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64z     z31.b, p7/m, z31.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint64z     z31.h, p7/m, z31.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64z     z31.h, p7/m, z31.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint64z     z31.s, p7/m, z31.d
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64z     z31.s, p7/m, z31.d
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+frint64z     z31.d, p7/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: frint64z     z31.d, p7/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// ------------------------------------------------------------------------- //
+// Invalid predicate
+
+frint64z     z31.s, p8/m, z31.s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid restricted predicate register, expected p0..p7 (without element suffix)
+// CHECK-NEXT: frint64z     z31.s, p8/m, z31.s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SVE2p2/frint64z.s
+++ b/llvm/test/MC/AArch64/SVE2p2/frint64z.s
@@ -1,0 +1,49 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sve2p2 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2p2 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2p2 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sve2p2 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+movprfx  z23.d, p3/m, z31.d
+frint64z z23.d, p3/m, z13.d  // 01100101-00010110-10101101-10110111
+// CHECK-INST:  movprfx  z23.d, p3/m, z31.d
+// CHECK-INST: frint64z z23.d, p3/m, z13.d
+// CHECK-ENCODING: [0xb7,0xad,0x16,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6516adb7 <unknown>
+
+movprfx z23, z31
+frint64z z23.s, p3/m, z13.s  // 01100101-00010100-10101101-10110111
+// CHECK-INST:  movprfx z23, z31
+// CHECK-INST: frint64z z23.s, p3/m, z13.s
+// CHECK-ENCODING: [0xb7,0xad,0x14,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6514adb7 <unknown>
+
+frint64z z0.s, p0/m, z0.s  // 01100101-00010100-10100000-00000000
+// CHECK-INST: frint64z z0.s, p0/m, z0.s
+// CHECK-ENCODING: [0x00,0xa0,0x14,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6514a000 <unknown>
+
+frint64z z21.d, p5/m, z10.d  // 01100101-00010110-10110101-01010101
+// CHECK-INST: frint64z z21.d, p5/m, z10.d
+// CHECK-ENCODING: [0x55,0xb5,0x16,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6516b555 <unknown>
+
+frint64z z31.d, p7/m, z31.d  // 01100101-00010110-10111111-11111111
+// CHECK-INST: frint64z z31.d, p7/m, z31.d
+// CHECK-ENCODING: [0xff,0xbf,0x16,0x65]
+// CHECK-ERROR: instruction requires: sme2p2 or sve2p2
+// CHECK-UNKNOWN: 6516bfff <unknown>


### PR DESCRIPTION
This patch adds assembly/disassembly support for the following SVE2.2 instructions

    - FRINT32X (merging)
    - FRINT32Z (merging)
    - FRINT64X (merging)
    - FRINT64Z (merging)
- In accordance with: https://developer.arm.com/documentation/ddi0602/latest/