### PR TITLE
Pass std::initializer_list by value to ArrayRef constructor.

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -113,7 +113,7 @@ namespace llvm {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winit-list-lifetime"
 #endif
-    constexpr /*implicit*/ ArrayRef(const std::initializer_list<T> &Vec)
+    constexpr /*implicit*/ ArrayRef(std::initializer_list<T> Vec)
         : Data(Vec.begin() == Vec.end() ? (T *)nullptr : Vec.begin()),
           Length(Vec.size()) {}
 #if LLVM_GNUC_PREREQ(9, 0, 0)


### PR DESCRIPTION
The std::initializer_list is a lightweight object, it is passed by value in general.

This would also avoid a false positive when adding the lifetimebound annotation (#113547)

```
ArrayRef<int> foo(std::initializer_list<int> list) {
  return ArrayRef<int>(list);
}
```