### PR TITLE
[lldb-dap][test] Set disableASLR to False for tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -367,7 +367,7 @@ class DAPTestCaseBase(TestBase):
         cwd=None,
         env=None,
         stopOnEntry=False,
-        disableASLR=True,
+        disableASLR=False,
         disableSTDIO=False,
         shellExpandArguments=False,
         trace=False,

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -451,7 +451,7 @@ class DAPTestCaseBase(TestBase):
         cwd=None,
         env=None,
         stopOnEntry=False,
-        disableASLR=True,
+        disableASLR=False,
         disableSTDIO=False,
         shellExpandArguments=False,
         trace=False,


### PR DESCRIPTION
When running in constrained environments like docker, disabling ASLR might fail with errors like:
```
AssertionError: False is not true : launch failed (Cannot launch
'/__w/.../lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.test_subtleFrames/a.out':
personality set failed: Operation not permitted)
```
E.g., https://github.com/llvm/llvm-project/pull/110303

Hence we already run `settings set target.disable-aslr false` as part of the init-commands for the non-DAP tests (see https://github.com/llvm/llvm-project/pull/88312 and https://discourse.llvm.org/t/running-lldb-in-a-container/76801).

But we never adjusted it for the DAP tests. As a result we get conflicting test logs like:
```
 {
    "arguments": {
      "commandEscapePrefix": null,
      "disableASLR": true,
     ....
      "initCommands": [
        ...
        "settings set target.disable-aslr false",
```

Disabling ASLR by default in tests isn't useulf (it's only really a debugging aid for users). So this patch sets `disableASLR=False` by default.