### PR TITLE
Fix pointer to reference type

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -2911,6 +2911,15 @@ ValueObjectSP ValueObject::AddressOf(Status &error) {
 
   AddressType address_type = eAddressTypeInvalid;
   const bool scalar_is_load_address = false;
+
+  // For reference type we need to get the address of the object that
+  // it refers to.
+  if (GetCompilerType().IsReferenceType()) {
+    ValueObjectSP deref_obj = Dereference(error);
+    if (error.Fail() || !deref_obj)
+      return ValueObjectSP();
+    return deref_obj->AddressOf(error);
+  }
   addr_t addr = GetAddressOf(scalar_is_load_address, &address_type);
   error.Clear();
   if (addr != LLDB_INVALID_ADDRESS && address_type != eAddressTypeHost) {

--- a/lldb/test/API/lang/cpp/dereferencing_references/TestCPPDereferencingReferences.py
+++ b/lldb/test/API/lang/cpp/dereferencing_references/TestCPPDereferencingReferences.py
@@ -25,3 +25,24 @@ class TestCase(TestBase):
         # Typedef to a reference should dereference to the underlying type.
         td_val = self.expect_var_path("td_to_ref_type", type="td_int_ref")
         self.assertEqual(td_val.Dereference().GetType().GetName(), "int")
+
+    def test_take_address_of_reference(self):
+        """Tests taking address of lvalue/rvalue references in lldb works correctly."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        plref_val_from_code = self.expect_var_path("pl_ref", type="TTT *")
+        plref_val_from_expr_path = self.expect_var_path("&l_ref", type="TTT *")
+        self.assertEqual(
+            plref_val_from_code.GetValueAsAddress(),
+            plref_val_from_expr_path.GetValueAsAddress(),
+        )
+
+        prref_val_from_code = self.expect_var_path("pr_ref", type="TTT *")
+        prref_val_from_expr_path = self.expect_var_path("&r_ref", type="TTT *")
+        self.assertEqual(
+            prref_val_from_code.GetValueAsAddress(),
+            prref_val_from_expr_path.GetValueAsAddress(),
+        )

--- a/lldb/test/API/lang/cpp/dereferencing_references/main.cpp
+++ b/lldb/test/API/lang/cpp/dereferencing_references/main.cpp
@@ -9,5 +9,7 @@ int main() {
   // typedef of a reference
   td_int_ref td_to_ref_type = i;
 
+  TTT *pl_ref = &l_ref;
+  TTT *pr_ref = &r_ref;
   return l_ref; // break here
 }


### PR DESCRIPTION
We have got customer reporting "v &obj" and "p &obj" reporting different results. 
Turns out it only happens for obj that is itself a reference type which "v &obj" reports the address of the reference itself instead of the target object the reference points to. This diverged from C++ semantics.

This PR fixes this issue by returning the address of the dereferenced object if it is reference type. 

A new test is added which fails before.