### PR TITLE
[libc++][test] Use `ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings)` for `-Wno-psabi`

### DIFF
--- a/libcxx/test/std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp
@@ -18,7 +18,7 @@
 
 // Ignore diagnostic about vector types changing the ABI on some targets, since
 // that is irrelevant for this test.
-// ADDITIONAL_COMPILE_FLAGS: -Wno-psabi
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-psabi
 
 #include <atomic>
 #include <cassert>


### PR DESCRIPTION
MSVC doesn't understand `-Wno-psabi`, which was introduced here by @ldionne in #106077.

Using `ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings)` (implemented by #75317) avoids passing this to MSVC.