### PR TITLE
[flang][runtime] Fix finalization case in assignment

### DIFF
--- a/flang/runtime/assign.cpp
+++ b/flang/runtime/assign.cpp
@@ -155,9 +155,9 @@ static RT_API_ATTRS bool MayAlias(const Descriptor &x, const Descriptor &y) {
     return false; // not both allocated
   }
   const char *xDesc{reinterpret_cast<const char *>(&x)};
-  const char *xDescLast{xDesc + x.SizeInBytes()};
+  const char *xDescLast{xDesc + x.SizeInBytes() - 1};
   const char *yDesc{reinterpret_cast<const char *>(&y)};
-  const char *yDescLast{yDesc + y.SizeInBytes()};
+  const char *yDescLast{yDesc + y.SizeInBytes() - 1};
   std::int64_t xLeast, xMost, yLeast, yMost;
   MaximalByteOffsetRange(x, xLeast, xMost);
   MaximalByteOffsetRange(y, yLeast, yMost);
@@ -318,10 +318,8 @@ RT_API_ATTRS static void Assign(
     if (mustDeallocateLHS) {
       if (deferDeallocation) {
         if ((flags & NeedFinalization) && toDerived) {
-          Finalize(to, *toDerived, &terminator);
+          Finalize(*deferDeallocation, *toDerived, &terminator);
           flags &= ~NeedFinalization;
-        } else if (toDerived && !toDerived->noDestructionNeeded()) {
-          Destroy(to, /*finalize=*/false, *toDerived, &terminator);
         }
       } else {
         to.Destroy((flags & NeedFinalization) != 0, /*destroyPointers=*/false,


### PR DESCRIPTION
There were two bugs in derived type array assignment processing that caused finalization to fail to occur for a test case. The first bug was an off-by-one error in address overlap testing that caused a false positive result for the test, whose left-hand side's allocatable's descriptor was immediately adjacent in memory to the right-hand side's array's data.
The second bug was that in such overlap cases (even when legitimate) finalization would fail due to the LHS's descriptor having been copied to a temporary for deferred deallocation and then nullified.

This patch corrects the overlap analysis for this test, and also properly finalizes the LHS when overlap does exist.  Some nearby dead code was removed to avoid future confusion.

Fixes https://github.com/llvm/llvm-project/issues/113375.