### PR TITLE
[libc++] Rename locale_t to __libcpp_locale_t

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -492,8 +492,10 @@ set(files
   __locale
   __locale_dir/locale_base_api.h
   __locale_dir/locale_base_api/android.h
+  __locale_dir/locale_base_api/apple.h
   __locale_dir/locale_base_api/bsd_locale_defaults.h
   __locale_dir/locale_base_api/bsd_locale_fallbacks.h
+  __locale_dir/locale_base_api/freebsd.h
   __locale_dir/locale_base_api/fuchsia.h
   __locale_dir/locale_base_api/ibm.h
   __locale_dir/locale_base_api/locale_guard.h

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -247,7 +247,7 @@ class _LIBCPP_TEMPLATE_VIS collate_byname;
 
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI collate_byname<char> : public collate<char> {
-  locale_t __l_;
+  __libcpp_locale_t __l_;
 
 public:
   typedef char char_type;
@@ -266,7 +266,7 @@ protected:
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI collate_byname<wchar_t> : public collate<wchar_t> {
-  locale_t __l_;
+  __libcpp_locale_t __l_;
 
 public:
   typedef wchar_t char_type;
@@ -616,7 +616,7 @@ class _LIBCPP_TEMPLATE_VIS ctype_byname;
 
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI ctype_byname<char> : public ctype<char> {
-  locale_t __l_;
+  __libcpp_locale_t __l_;
 
 public:
   explicit ctype_byname(const char*, size_t = 0);
@@ -633,7 +633,7 @@ protected:
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI ctype_byname<wchar_t> : public ctype<wchar_t> {
-  locale_t __l_;
+  __libcpp_locale_t __l_;
 
 public:
   explicit ctype_byname(const char*, size_t = 0);
@@ -824,7 +824,7 @@ protected:
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI codecvt<wchar_t, char, mbstate_t> : public locale::facet, public codecvt_base {
-  locale_t __l_;
+  __libcpp_locale_t __l_;
 
 public:
   typedef wchar_t intern_type;

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -9,14 +9,14 @@
 #ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H
 #define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H
 
+#include <__config>
+
 #if defined(_LIBCPP_MSVCRT_LIKE)
 #  include <__locale_dir/locale_base_api/win32.h>
 #elif defined(_AIX) || defined(__MVS__)
 #  include <__locale_dir/locale_base_api/ibm.h>
 #elif defined(__ANDROID__)
 #  include <__locale_dir/locale_base_api/android.h>
-#elif defined(__sun__)
-#  include <__locale_dir/locale_base_api/solaris.h>
 #elif defined(_NEWLIB_VERSION)
 #  include <__locale_dir/locale_base_api/newlib.h>
 #elif defined(__OpenBSD__)
@@ -25,74 +25,77 @@
 #  include <__locale_dir/locale_base_api/fuchsia.h>
 #elif defined(__wasi__) || defined(_LIBCPP_HAS_MUSL_LIBC)
 #  include <__locale_dir/locale_base_api/musl.h>
-#elif defined(__APPLE__) || defined(__FreeBSD__)
-#  include <xlocale.h>
+#elif defined(__APPLE__)
+#  include <__locale_dir/locale_base_api/apple.h>
+#elif defined(__FreeBSD__)
+#  include <__locale_dir/locale_base_api/freebsd.h>
 #endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
 
+// clang-format off
 /*
 The platform-specific headers have to provide the following interface:
 
-// TODO: rename this to __libcpp_locale_t
-using locale_t = implementation-defined;
+using __libcpp_locale_t = implementation-defined;
 
-implementation-defined __libcpp_mb_cur_max_l(locale_t);
-wint_t __libcpp_btowc_l(int, locale_t);
-int __libcpp_wctob_l(wint_t, locale_t);
-size_t __libcpp_wcsnrtombs_l(char* dest, const wchar_t** src, size_t wide_char_count, size_t len, mbstate_t, locale_t);
-size_t __libcpp_wcrtomb_l(char* str, wchar_t wide_char, mbstate_t*, locale_t);
-size_t __libcpp_mbsnrtowcs_l(wchar_t* dest, const char** src, size_t max_out, size_t len, mbstate_t*, locale_t);
-size_t __libcpp_mbrtowc_l(wchar_t* dest, cosnt char* src, size_t count, mbstate_t*, locale_t);
-int __libcpp_mbtowc_l(wchar_t* dest, const char* src, size_t count, locale_t);
-size_t __libcpp_mbrlen_l(const char* str, size_t count, mbstate_t*, locale_t);
-lconv* __libcpp_localeconv_l(locale_t);
-size_t __libcpp_mbsrtowcs_l(wchar_t* dest, const char** src, size_t len, mbstate_t*, locale_t);
-int __libcpp_snprintf_l(char* dest, size_t buff_size, locale_t, const char* format, ...);
-int __libcpp_asprintf_l(char** dest, locale_t, const char* format, ...);
-int __libcpp_sscanf_l(const char* dest, locale_t, const char* format, ...);
+implementation-defined __libcpp_mb_cur_max_l(__libcpp_locale_t);
+wint_t __libcpp_btowc_l(int, __libcpp_locale_t);
+int __libcpp_wctob_l(wint_t, __libcpp_locale_t);
+size_t __libcpp_wcsnrtombs_l(char* dest, const wchar_t** src, size_t wide_char_count, size_t len, mbstate_t, __libcpp_locale_t);
+size_t __libcpp_wcrtomb_l(char* str, wchar_t wide_char, mbstate_t*, __libcpp_locale_t);
+size_t __libcpp_mbsnrtowcs_l(wchar_t* dest, const char** src, size_t max_out, size_t len, mbstate_t*, __libcpp_locale_t);
+size_t __libcpp_mbrtowc_l(wchar_t* dest, cosnt char* src, size_t count, mbstate_t*, __libcpp_locale_t);
+int __libcpp_mbtowc_l(wchar_t* dest, const char* src, size_t count, __libcpp_locale_t);
+size_t __libcpp_mbrlen_l(const char* str, size_t count, mbstate_t*, __libcpp_locale_t);
+lconv* __libcpp_localeconv_l(__libcpp_locale_t);
+size_t __libcpp_mbsrtowcs_l(wchar_t* dest, const char** src, size_t len, mbstate_t*, __libcpp_locale_t);
+int __libcpp_snprintf_l(char* dest, size_t buff_size, __libcpp_locale_t, const char* format, ...);
+int __libcpp_asprintf_l(char** dest, __libcpp_locale_t, const char* format, ...);
+int __libcpp_sscanf_l(const char* dest, __libcpp_locale_t, const char* format, ...);
 
 // TODO: change these to reserved names
-float strtof_l(const char* str, char** str_end, locale_t);
-double strtod_l(const char* str, char** str_end, locale_t);
-long double strtold_l(const char* str, char** str_end, locale_t);
-long long strtoll_l(const char* str, char** str_end, locale_t);
-unsigned long long strtoull_l(const char* str, char** str_end, locale_t);
+float strtof_l(const char* str, char** str_end, __libcpp_locale_t);
+double strtod_l(const char* str, char** str_end, __libcpp_locale_t);
+long double strtold_l(const char* str, char** str_end, __libcpp_locale_t);
+long long strtoll_l(const char* str, char** str_end, __libcpp_locale_t);
+unsigned long long strtoull_l(const char* str, char** str_end, __libcpp_locale_t);
 
-locale_t newlocale(int category_mask, const char* locale, locale_t base);
-void freelocale(locale_t);
+__libcpp_locale_t newlocale(int category_mask, const char* locale, __libcpp_locale_t base);
+void freelocale(__libcpp_locale_t);
 
-int islower_l(int ch, locale_t);
-int isupper_l(int ch, locale_t);
-int isdigit_l(int ch, locale_t);
-int isxdigit_l(int ch, locale_t);
-int strcoll_l(const char* lhs, const char* rhs, locale_t);
-size_t strxfrm_l(char* dst, const char* src, size_t n, locale_t);
-int wcscoll_l(const char* lhs, const char* rhs, locale_t);
-size_t wcsxfrm_l(wchar_t* dst, const wchar_t* src, size_t n, locale_t);
-int toupper_l(int ch, locale_t);
-int tolower_l(int ch, locale_t);
-int iswspace_l(wint_t ch, locale_t);
-int iswprint_l(wint_t ch, locale_t);
-int iswcntrl_l(wint_t ch, locale_t);
-int iswupper_l(wint_t ch, locale_t);
-int iswlower_l(wint_t ch, locale_t);
-int iswalpha_l(wint_t ch, locale_t);
-int iswblank_l(wint_t ch, locale_t);
-int iswdigit_l(wint_t ch, locale_t);
-int iswpunct_l(wint_t ch, locale_t);
-int iswxdigit_l(wint_t ch, locale_t);
-wint_t towupper_l(wint_t ch, locale_t);
-wint_t towlower_l(wint_t ch, locale_t);
-size_t strftime_l(char* str, size_t len, const char* format, const tm*, locale_t);
+int islower_l(int ch, __libcpp_locale_t);
+int isupper_l(int ch, __libcpp_locale_t);
+int isdigit_l(int ch, __libcpp_locale_t);
+int isxdigit_l(int ch, __libcpp_locale_t);
+int strcoll_l(const char* lhs, const char* rhs, __libcpp_locale_t);
+size_t strxfrm_l(char* dst, const char* src, size_t n, __libcpp_locale_t);
+int wcscoll_l(const char* lhs, const char* rhs, __libcpp_locale_t);
+size_t wcsxfrm_l(wchar_t* dst, const wchar_t* src, size_t n, __libcpp_locale_t);
+int toupper_l(int ch, __libcpp_locale_t);
+int tolower_l(int ch, __libcpp_locale_t);
+int iswspace_l(wint_t ch, __libcpp_locale_t);
+int iswprint_l(wint_t ch, __libcpp_locale_t);
+int iswcntrl_l(wint_t ch, __libcpp_locale_t);
+int iswupper_l(wint_t ch, __libcpp_locale_t);
+int iswlower_l(wint_t ch, __libcpp_locale_t);
+int iswalpha_l(wint_t ch, __libcpp_locale_t);
+int iswblank_l(wint_t ch, __libcpp_locale_t);
+int iswdigit_l(wint_t ch, __libcpp_locale_t);
+int iswpunct_l(wint_t ch, __libcpp_locale_t);
+int iswxdigit_l(wint_t ch, __libcpp_locale_t);
+wint_t towupper_l(wint_t ch, __libcpp_locale_t);
+wint_t towlower_l(wint_t ch, __libcpp_locale_t);
+size_t strftime_l(char* str, size_t len, const char* format, const tm*, __libcpp_locale_t);
 
 
 These functions are equivalent to their C counterparts,
-except that locale_t is used instead of the current global locale.
+except that __libcpp_locale_t is used instead of the current global locale.
 
 The variadic functions may be implemented as templates with a parameter pack instead of variadic functions.
 */
+// clang-format on
 
 #endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H

--- a/libcxx/include/__locale_dir/locale_base_api/android.h
+++ b/libcxx/include/__locale_dir/locale_base_api/android.h
@@ -34,11 +34,11 @@ extern "C" {
 #      include <__support/xlocale/__strtonum_fallback.h>
 #    elif __ANDROID_API__ < 26
 
-inline _LIBCPP_HIDE_FROM_ABI float strtof_l(const char* __nptr, char** __endptr, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI float strtof_l(const char* __nptr, char** __endptr, __libcpp_locale_t) {
   return ::strtof(__nptr, __endptr);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI double strtod_l(const char* __nptr, char** __endptr, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI double strtod_l(const char* __nptr, char** __endptr, __libcpp_locale_t) {
   return ::strtod(__nptr, __endptr);
 }
 
@@ -46,5 +46,7 @@ inline _LIBCPP_HIDE_FROM_ABI double strtod_l(const char* __nptr, char** __endptr
 
 #  endif // __NDK_MAJOR__ <= 16
 #endif   // __has_include(<android/ndk-version.h>)
+
+using __libcpp_locale_t = ::locale_t;
 
 #endif // _LIBCPP___LOCALE_LOCALE_BASE_API_ANDROID_H

--- a/libcxx/include/__locale_dir/locale_base_api/apple.h
+++ b/libcxx/include/__locale_dir/locale_base_api/apple.h
@@ -7,14 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___LOCALE_LOCALE_BASE_API_FUCHSIA_H
-#define _LIBCPP___LOCALE_LOCALE_BASE_API_FUCHSIA_H
+#ifndef _LIBCPP___LOCALE_LOCALE_BASE_API_APPLE_H
+#define _LIBCPP___LOCALE_LOCALE_BASE_API_APPLE_H
 
-#include <__support/xlocale/__posix_l_fallback.h>
-#include <__support/xlocale/__strtonum_fallback.h>
-#include <cstdlib>
-#include <cwchar>
+#include <xlocale.h>
 
 using __libcpp_locale_t = locale_t;
 
-#endif // _LIBCPP___LOCALE_LOCALE_BASE_API_FUCHSIA_H
+#endif // _LIBCPP___LOCALE_LOCALE_BASE_API_APPLE_H

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
@@ -28,71 +28,74 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-inline _LIBCPP_HIDE_FROM_ABI decltype(MB_CUR_MAX) __libcpp_mb_cur_max_l(locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI decltype(MB_CUR_MAX) __libcpp_mb_cur_max_l(__libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return MB_CUR_MAX;
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-inline _LIBCPP_HIDE_FROM_ABI wint_t __libcpp_btowc_l(int __c, locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI wint_t __libcpp_btowc_l(int __c, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return btowc(__c);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI int __libcpp_wctob_l(wint_t __c, locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_wctob_l(wint_t __c, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return wctob(__c);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI size_t
-__libcpp_wcsnrtombs_l(char* __dest, const wchar_t** __src, size_t __nwc, size_t __len, mbstate_t* __ps, locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_wcsnrtombs_l(
+    char* __dest, const wchar_t** __src, size_t __nwc, size_t __len, mbstate_t* __ps, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return wcsnrtombs(__dest, __src, __nwc, __len, __ps);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_wcrtomb_l(char* __s, wchar_t __wc, mbstate_t* __ps, locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI size_t
+__libcpp_wcrtomb_l(char* __s, wchar_t __wc, mbstate_t* __ps, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return wcrtomb(__s, __wc, __ps);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI size_t
-__libcpp_mbsnrtowcs_l(wchar_t* __dest, const char** __src, size_t __nms, size_t __len, mbstate_t* __ps, locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_mbsnrtowcs_l(
+    wchar_t* __dest, const char** __src, size_t __nms, size_t __len, mbstate_t* __ps, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return mbsnrtowcs(__dest, __src, __nms, __len, __ps);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI size_t
-__libcpp_mbrtowc_l(wchar_t* __pwc, const char* __s, size_t __n, mbstate_t* __ps, locale_t __l) {
+__libcpp_mbrtowc_l(wchar_t* __pwc, const char* __s, size_t __n, mbstate_t* __ps, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return mbrtowc(__pwc, __s, __n, __ps);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI int __libcpp_mbtowc_l(wchar_t* __pwc, const char* __pmb, size_t __max, locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI int
+__libcpp_mbtowc_l(wchar_t* __pwc, const char* __pmb, size_t __max, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return mbtowc(__pwc, __pmb, __max);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_mbrlen_l(const char* __s, size_t __n, mbstate_t* __ps, locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI size_t
+__libcpp_mbrlen_l(const char* __s, size_t __n, mbstate_t* __ps, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return mbrlen(__s, __n, __ps);
 }
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
 
-inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(__libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return localeconv();
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI size_t
-__libcpp_mbsrtowcs_l(wchar_t* __dest, const char** __src, size_t __len, mbstate_t* __ps, locale_t __l) {
+__libcpp_mbsrtowcs_l(wchar_t* __dest, const char** __src, size_t __len, mbstate_t* __ps, __libcpp_locale_t __l) {
   __libcpp_locale_guard __current(__l);
   return mbsrtowcs(__dest, __src, __len, __ps);
 }
 #endif
 
 inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 4, 5) int __libcpp_snprintf_l(
-    char* __s, size_t __n, locale_t __l, const char* __format, ...) {
+    char* __s, size_t __n, __libcpp_locale_t __l, const char* __format, ...) {
   va_list __va;
   va_start(__va, __format);
   __libcpp_locale_guard __current(__l);
@@ -102,7 +105,7 @@ inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 4, 5) int __libcpp_snprintf_l(
 }
 
 inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 3, 4) int __libcpp_asprintf_l(
-    char** __s, locale_t __l, const char* __format, ...) {
+    char** __s, __libcpp_locale_t __l, const char* __format, ...) {
   va_list __va;
   va_start(__va, __format);
   __libcpp_locale_guard __current(__l);
@@ -112,7 +115,7 @@ inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 3, 4) int __libcpp_asprintf_l(
 }
 
 inline _LIBCPP_ATTRIBUTE_FORMAT(__scanf__, 3, 4) int __libcpp_sscanf_l(
-    const char* __s, locale_t __l, const char* __format, ...) {
+    const char* __s, __libcpp_locale_t __l, const char* __format, ...) {
   va_list __va;
   va_start(__va, __format);
   __libcpp_locale_guard __current(__l);

--- a/libcxx/include/__locale_dir/locale_base_api/freebsd.h
+++ b/libcxx/include/__locale_dir/locale_base_api/freebsd.h
@@ -7,14 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___LOCALE_LOCALE_BASE_API_FUCHSIA_H
-#define _LIBCPP___LOCALE_LOCALE_BASE_API_FUCHSIA_H
+#ifndef _LIBCPP___LOCALE_LOCALE_BASE_API_FREEBSD_H
+#define _LIBCPP___LOCALE_LOCALE_BASE_API_FREEBSD_H
 
-#include <__support/xlocale/__posix_l_fallback.h>
-#include <__support/xlocale/__strtonum_fallback.h>
-#include <cstdlib>
-#include <cwchar>
+#include <xlocale.h>
 
 using __libcpp_locale_t = locale_t;
 
-#endif // _LIBCPP___LOCALE_LOCALE_BASE_API_FUCHSIA_H
+#endif // _LIBCPP___LOCALE_LOCALE_BASE_API_FREEBSD_H

--- a/libcxx/include/__locale_dir/locale_base_api/ibm.h
+++ b/libcxx/include/__locale_dir/locale_base_api/ibm.h
@@ -26,12 +26,14 @@
 #  include <__support/xlocale/__posix_l_fallback.h>
 #endif // defined(__MVS__)
 
+using __libcpp_locale_t = locale_t;
+
 namespace {
 
 struct __setAndRestore {
-  explicit __setAndRestore(locale_t locale) {
-    if (locale == (locale_t)0) {
-      __cloc   = newlocale(LC_ALL_MASK, "C", /* base */ (locale_t)0);
+  explicit __setAndRestore(__libcpp_locale_t locale) {
+    if (locale == (__libcpp_locale_t)0) {
+      __cloc   = newlocale(LC_ALL_MASK, "C", /* base */ (__libcpp_locale_t)0);
       __stored = uselocale(__cloc);
     } else {
       __stored = uselocale(locale);
@@ -45,36 +47,37 @@ struct __setAndRestore {
   }
 
 private:
-  locale_t __stored = (locale_t)0;
-  locale_t __cloc   = (locale_t)0;
+  __libcpp_locale_t __stored = (__libcpp_locale_t)0;
+  __libcpp_locale_t __cloc   = (__libcpp_locale_t)0;
 };
 
 } // namespace
 
 // The following are not POSIX routines.  These are quick-and-dirty hacks
 // to make things pretend to work
-inline _LIBCPP_HIDE_FROM_ABI long long strtoll_l(const char* __nptr, char** __endptr, int __base, locale_t locale) {
+inline _LIBCPP_HIDE_FROM_ABI long long
+strtoll_l(const char* __nptr, char** __endptr, int __base, __libcpp_locale_t locale) {
   __setAndRestore __newloc(locale);
   return ::strtoll(__nptr, __endptr, __base);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI double strtod_l(const char* __nptr, char** __endptr, locale_t locale) {
+inline _LIBCPP_HIDE_FROM_ABI double strtod_l(const char* __nptr, char** __endptr, __libcpp_locale_t locale) {
   __setAndRestore __newloc(locale);
   return ::strtod(__nptr, __endptr);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI float strtof_l(const char* __nptr, char** __endptr, locale_t locale) {
+inline _LIBCPP_HIDE_FROM_ABI float strtof_l(const char* __nptr, char** __endptr, __libcpp_locale_t locale) {
   __setAndRestore __newloc(locale);
   return ::strtof(__nptr, __endptr);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double strtold_l(const char* __nptr, char** __endptr, locale_t locale) {
+inline _LIBCPP_HIDE_FROM_ABI long double strtold_l(const char* __nptr, char** __endptr, __libcpp_locale_t locale) {
   __setAndRestore __newloc(locale);
   return ::strtold(__nptr, __endptr);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI unsigned long long
-strtoull_l(const char* __nptr, char** __endptr, int __base, locale_t locale) {
+strtoull_l(const char* __nptr, char** __endptr, int __base, __libcpp_locale_t locale) {
   __setAndRestore __newloc(locale);
   return ::strtoull(__nptr, __endptr, __base);
 }

--- a/libcxx/include/__locale_dir/locale_base_api/locale_guard.h
+++ b/libcxx/include/__locale_dir/locale_base_api/locale_guard.h
@@ -10,7 +10,7 @@
 #define _LIBCPP___LOCALE_LOCALE_BASE_API_LOCALE_GUARD_H
 
 #include <__config>
-#include <__locale> // for locale_t
+#include <__locale> // for __libcpp_locale_t
 #include <clocale>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -21,21 +21,21 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if !defined(_LIBCPP_LOCALE__L_EXTENSIONS)
 struct __libcpp_locale_guard {
-  _LIBCPP_HIDE_FROM_ABI __libcpp_locale_guard(locale_t& __loc) : __old_loc_(uselocale(__loc)) {}
+  _LIBCPP_HIDE_FROM_ABI __libcpp_locale_guard(__libcpp_locale_t& __loc) : __old_loc_(uselocale(__loc)) {}
 
   _LIBCPP_HIDE_FROM_ABI ~__libcpp_locale_guard() {
     if (__old_loc_)
       uselocale(__old_loc_);
   }
 
-  locale_t __old_loc_;
+  __libcpp_locale_t __old_loc_;
 
   __libcpp_locale_guard(__libcpp_locale_guard const&)            = delete;
   __libcpp_locale_guard& operator=(__libcpp_locale_guard const&) = delete;
 };
 #elif defined(_LIBCPP_MSVCRT_LIKE)
 struct __libcpp_locale_guard {
-  __libcpp_locale_guard(locale_t __l) : __status(_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)) {
+  __libcpp_locale_guard(__libcpp_locale_t __l) : __status(_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)) {
     // Setting the locale can be expensive even when the locale given is
     // already the current locale, so do an explicit check to see if the
     // current locale is already the one we want.

--- a/libcxx/include/__locale_dir/locale_base_api/musl.h
+++ b/libcxx/include/__locale_dir/locale_base_api/musl.h
@@ -20,11 +20,14 @@
 #include <cstdlib>
 #include <cwchar>
 
-inline _LIBCPP_HIDE_FROM_ABI long long strtoll_l(const char* __nptr, char** __endptr, int __base, locale_t) {
+using __libcpp_locale_t = locale_t;
+
+inline _LIBCPP_HIDE_FROM_ABI long long strtoll_l(const char* __nptr, char** __endptr, int __base, __libcpp_locale_t) {
   return ::strtoll(__nptr, __endptr, __base);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI unsigned long long strtoull_l(const char* __nptr, char** __endptr, int __base, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI unsigned long long
+strtoull_l(const char* __nptr, char** __endptr, int __base, __libcpp_locale_t) {
   return ::strtoull(__nptr, __endptr, __base);
 }
 

--- a/libcxx/include/__locale_dir/locale_base_api/openbsd.h
+++ b/libcxx/include/__locale_dir/locale_base_api/openbsd.h
@@ -16,4 +16,6 @@
 #include <ctype.h>
 #include <cwctype>
 
+using __libcpp_locale_t = locale_t;
+
 #endif // _LIBCPP___LOCALE_LOCALE_BASE_API_OPENBSD_H

--- a/libcxx/include/__locale_dir/locale_base_api/win32.h
+++ b/libcxx/include/__locale_dir/locale_base_api/win32.h
@@ -88,50 +88,57 @@ private:
   std::string __negative_sign_;
 };
 
-class locale_t {
+class __libcpp_locale_t {
 public:
-  locale_t() : __locale_(nullptr), __locale_str_(nullptr), __lc_(nullptr) {}
-  locale_t(std::nullptr_t) : __locale_(nullptr), __locale_str_(nullptr), __lc_(nullptr) {}
-  locale_t(_locale_t __xlocale, const char* __xlocale_str)
+  __libcpp_locale_t() : __locale_(nullptr), __locale_str_(nullptr), __lc_(nullptr) {}
+  __libcpp_locale_t(std::nullptr_t) : __locale_(nullptr), __locale_str_(nullptr), __lc_(nullptr) {}
+  __libcpp_locale_t(_locale_t __xlocale, const char* __xlocale_str)
       : __locale_(__xlocale), __locale_str_(__xlocale_str), __lc_(nullptr) {}
-  locale_t(const locale_t& __l) : __locale_(__l.__locale_), __locale_str_(__l.__locale_str_), __lc_(nullptr) {}
+  __libcpp_locale_t(const __libcpp_locale_t& __l)
+      : __locale_(__l.__locale_), __locale_str_(__l.__locale_str_), __lc_(nullptr) {}
 
-  ~locale_t() { delete __lc_; }
+  ~__libcpp_locale_t() { delete __lc_; }
 
-  locale_t& operator=(const locale_t& __l) {
+  __libcpp_locale_t& operator=(const __libcpp_locale_t& __l) {
     __locale_     = __l.__locale_;
     __locale_str_ = __l.__locale_str_;
     // __lc_ not copied
     return *this;
   }
 
-  friend bool operator==(const locale_t& __left, const locale_t& __right) {
+  friend bool operator==(const __libcpp_locale_t& __left, const __libcpp_locale_t& __right) {
     return __left.__locale_ == __right.__locale_;
   }
 
-  friend bool operator==(const locale_t& __left, int __right) { return __left.__locale_ == nullptr && __right == 0; }
-
-  friend bool operator==(const locale_t& __left, long long __right) {
+  friend bool operator==(const __libcpp_locale_t& __left, int __right) {
     return __left.__locale_ == nullptr && __right == 0;
   }
 
-  friend bool operator==(const locale_t& __left, std::nullptr_t) { return __left.__locale_ == nullptr; }
+  friend bool operator==(const __libcpp_locale_t& __left, long long __right) {
+    return __left.__locale_ == nullptr && __right == 0;
+  }
 
-  friend bool operator==(int __left, const locale_t& __right) { return __left == 0 && nullptr == __right.__locale_; }
+  friend bool operator==(const __libcpp_locale_t& __left, std::nullptr_t) { return __left.__locale_ == nullptr; }
 
-  friend bool operator==(std::nullptr_t, const locale_t& __right) { return nullptr == __right.__locale_; }
+  friend bool operator==(int __left, const __libcpp_locale_t& __right) {
+    return __left == 0 && nullptr == __right.__locale_;
+  }
 
-  friend bool operator!=(const locale_t& __left, const locale_t& __right) { return !(__left == __right); }
+  friend bool operator==(std::nullptr_t, const __libcpp_locale_t& __right) { return nullptr == __right.__locale_; }
 
-  friend bool operator!=(const locale_t& __left, int __right) { return !(__left == __right); }
+  friend bool operator!=(const __libcpp_locale_t& __left, const __libcpp_locale_t& __right) {
+    return !(__left == __right);
+  }
 
-  friend bool operator!=(const locale_t& __left, long long __right) { return !(__left == __right); }
+  friend bool operator!=(const __libcpp_locale_t& __left, int __right) { return !(__left == __right); }
 
-  friend bool operator!=(const locale_t& __left, std::nullptr_t __right) { return !(__left == __right); }
+  friend bool operator!=(const __libcpp_locale_t& __left, long long __right) { return !(__left == __right); }
 
-  friend bool operator!=(int __left, const locale_t& __right) { return !(__left == __right); }
+  friend bool operator!=(const __libcpp_locale_t& __left, std::nullptr_t __right) { return !(__left == __right); }
 
-  friend bool operator!=(std::nullptr_t __left, const locale_t& __right) { return !(__left == __right); }
+  friend bool operator!=(int __left, const __libcpp_locale_t& __right) { return !(__left == __right); }
+
+  friend bool operator!=(std::nullptr_t __left, const __libcpp_locale_t& __right) { return !(__left == __right); }
 
   operator bool() const { return __locale_ != nullptr; }
 
@@ -154,35 +161,41 @@ private:
 // Locale management functions
 #define freelocale _free_locale
 // FIXME: base currently unused. Needs manual work to construct the new locale
-locale_t newlocale(int __mask, const char* __locale, locale_t __base);
+__libcpp_locale_t newlocale(int __mask, const char* __locale, __libcpp_locale_t __base);
 // uselocale can't be implemented on Windows because Windows allows partial modification
 // of thread-local locale and so _get_current_locale() returns a copy while uselocale does
 // not create any copies.
 // We can still implement raii even without uselocale though.
 
-lconv* localeconv_l(locale_t& __loc);
-size_t mbrlen_l(const char* __restrict __s, size_t __n, mbstate_t* __restrict __ps, locale_t __loc);
-size_t mbsrtowcs_l(
-    wchar_t* __restrict __dst, const char** __restrict __src, size_t __len, mbstate_t* __restrict __ps, locale_t __loc);
-size_t wcrtomb_l(char* __restrict __s, wchar_t __wc, mbstate_t* __restrict __ps, locale_t __loc);
-size_t mbrtowc_l(
-    wchar_t* __restrict __pwc, const char* __restrict __s, size_t __n, mbstate_t* __restrict __ps, locale_t __loc);
+lconv* localeconv_l(__libcpp_locale_t& __loc);
+size_t mbrlen_l(const char* __restrict __s, size_t __n, mbstate_t* __restrict __ps, __libcpp_locale_t __loc);
+size_t mbsrtowcs_l(wchar_t* __restrict __dst,
+                   const char** __restrict __src,
+                   size_t __len,
+                   mbstate_t* __restrict __ps,
+                   __libcpp_locale_t __loc);
+size_t wcrtomb_l(char* __restrict __s, wchar_t __wc, mbstate_t* __restrict __ps, __libcpp_locale_t __loc);
+size_t mbrtowc_l(wchar_t* __restrict __pwc,
+                 const char* __restrict __s,
+                 size_t __n,
+                 mbstate_t* __restrict __ps,
+                 __libcpp_locale_t __loc);
 size_t mbsnrtowcs_l(wchar_t* __restrict __dst,
                     const char** __restrict __src,
                     size_t __nms,
                     size_t __len,
                     mbstate_t* __restrict __ps,
-                    locale_t __loc);
+                    __libcpp_locale_t __loc);
 size_t wcsnrtombs_l(char* __restrict __dst,
                     const wchar_t** __restrict __src,
                     size_t __nwc,
                     size_t __len,
                     mbstate_t* __restrict __ps,
-                    locale_t __loc);
-wint_t btowc_l(int __c, locale_t __loc);
-int wctob_l(wint_t __c, locale_t __loc);
+                    __libcpp_locale_t __loc);
+wint_t btowc_l(int __c, __libcpp_locale_t __loc);
+int wctob_l(wint_t __c, __libcpp_locale_t __loc);
 
-decltype(MB_CUR_MAX) MB_CUR_MAX_L(locale_t __l);
+decltype(MB_CUR_MAX) MB_CUR_MAX_L(__libcpp_locale_t __l);
 
 // the *_l functions are prefixed on Windows, only available for msvcr80+, VS2005+
 #define mbtowc_l _mbtowc_l
@@ -193,8 +206,8 @@ decltype(MB_CUR_MAX) MB_CUR_MAX_L(locale_t __l);
 #  define strtof_l _strtof_l
 #  define strtold_l _strtold_l
 #else
-_LIBCPP_EXPORTED_FROM_ABI float strtof_l(const char*, char**, locale_t);
-_LIBCPP_EXPORTED_FROM_ABI long double strtold_l(const char*, char**, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI float strtof_l(const char*, char**, __libcpp_locale_t);
+_LIBCPP_EXPORTED_FROM_ABI long double strtold_l(const char*, char**, __libcpp_locale_t);
 #endif
 inline _LIBCPP_HIDE_FROM_ABI int islower_l(int __c, _locale_t __loc) { return _islower_l((int)__c, __loc); }
 
@@ -220,16 +233,17 @@ inline _LIBCPP_HIDE_FROM_ABI int isupper_l(int __c, _locale_t __loc) { return _i
 #define towupper_l _towupper_l
 #define towlower_l _towlower_l
 #if defined(__MINGW32__) && __MSVCRT_VERSION__ < 0x0800
-_LIBCPP_EXPORTED_FROM_ABI size_t strftime_l(char* ret, size_t n, const char* format, const struct tm* tm, locale_t loc);
+_LIBCPP_EXPORTED_FROM_ABI size_t
+strftime_l(char* ret, size_t n, const char* format, const struct tm* tm, __libcpp_locale_t loc);
 #else
 #  define strftime_l _strftime_l
 #endif
 #define sscanf_l(__s, __l, __f, ...) _sscanf_l(__s, __f, __l, __VA_ARGS__)
-_LIBCPP_EXPORTED_FROM_ABI int snprintf_l(char* __ret, size_t __n, locale_t __loc, const char* __format, ...);
-_LIBCPP_EXPORTED_FROM_ABI int asprintf_l(char** __ret, locale_t __loc, const char* __format, ...);
-_LIBCPP_EXPORTED_FROM_ABI int vasprintf_l(char** __ret, locale_t __loc, const char* __format, va_list __ap);
+_LIBCPP_EXPORTED_FROM_ABI int snprintf_l(char* __ret, size_t __n, __libcpp_locale_t __loc, const char* __format, ...);
+_LIBCPP_EXPORTED_FROM_ABI int asprintf_l(char** __ret, __libcpp_locale_t __loc, const char* __format, ...);
+_LIBCPP_EXPORTED_FROM_ABI int vasprintf_l(char** __ret, __libcpp_locale_t __loc, const char* __format, va_list __ap);
 
 // not-so-pressing FIXME: use locale to determine blank characters
-inline int iswblank_l(wint_t __c, locale_t /*loc*/) { return (__c == L' ' || __c == L'\t'); }
+inline int iswblank_l(wint_t __c, __libcpp_locale_t /*loc*/) { return (__c == L' ' || __c == L'\t'); }
 
 #endif // _LIBCPP___LOCALE_LOCALE_BASE_API_WIN32_H

--- a/libcxx/include/__support/ibm/locale_mgmt_zos.h
+++ b/libcxx/include/__support/ibm/locale_mgmt_zos.h
@@ -38,13 +38,13 @@ typedef struct locale_struct {
   std::string lc_numeric;
   std::string lc_time;
   std::string lc_messages;
-}* locale_t;
+}* __libcpp_locale_t;
 
 // z/OS does not have newlocale, freelocale and uselocale.
 // The functions below are workarounds in single thread mode.
-locale_t newlocale(int category_mask, const char* locale, locale_t base);
-void freelocale(locale_t locobj);
-locale_t uselocale(locale_t newloc);
+__libcpp_locale_t newlocale(int category_mask, const char* locale, __libcpp_locale_t base);
+void freelocale(__libcpp_locale_t locobj);
+__libcpp_locale_t uselocale(__libcpp_locale_t newloc);
 
 #  ifdef __cplusplus
 }

--- a/libcxx/include/__support/xlocale/__nop_locale_mgmt.h
+++ b/libcxx/include/__support/xlocale/__nop_locale_mgmt.h
@@ -13,15 +13,15 @@
 #include <__config>
 
 // Patch over lack of extended locale support
-typedef void* locale_t;
+typedef void* __libcpp_locale_t;
 
-inline _LIBCPP_HIDE_FROM_ABI locale_t duplocale(locale_t) { return nullptr; }
+inline _LIBCPP_HIDE_FROM_ABI __libcpp_locale_t duplocale(__libcpp_locale_t) { return nullptr; }
 
-inline _LIBCPP_HIDE_FROM_ABI void freelocale(locale_t) {}
+inline _LIBCPP_HIDE_FROM_ABI void freelocale(__libcpp_locale_t) {}
 
-inline _LIBCPP_HIDE_FROM_ABI locale_t newlocale(int, const char*, locale_t) { return nullptr; }
+inline _LIBCPP_HIDE_FROM_ABI __libcpp_locale_t newlocale(int, const char*, __libcpp_locale_t) { return nullptr; }
 
-inline _LIBCPP_HIDE_FROM_ABI locale_t uselocale(locale_t) { return nullptr; }
+inline _LIBCPP_HIDE_FROM_ABI __libcpp_locale_t uselocale(__libcpp_locale_t) { return nullptr; }
 
 #define LC_COLLATE_MASK (1 << LC_COLLATE)
 #define LC_CTYPE_MASK (1 << LC_CTYPE)

--- a/libcxx/include/__support/xlocale/__posix_l_fallback.h
+++ b/libcxx/include/__support/xlocale/__posix_l_fallback.h
@@ -25,81 +25,81 @@
 #  include <wctype.h>
 #endif
 
-inline _LIBCPP_HIDE_FROM_ABI int isalnum_l(int __c, locale_t) { return ::isalnum(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isalnum_l(int __c, __libcpp_locale_t) { return ::isalnum(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int isalpha_l(int __c, locale_t) { return ::isalpha(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isalpha_l(int __c, __libcpp_locale_t) { return ::isalpha(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iscntrl_l(int __c, locale_t) { return ::iscntrl(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iscntrl_l(int __c, __libcpp_locale_t) { return ::iscntrl(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int isdigit_l(int __c, locale_t) { return ::isdigit(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isdigit_l(int __c, __libcpp_locale_t) { return ::isdigit(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int isgraph_l(int __c, locale_t) { return ::isgraph(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isgraph_l(int __c, __libcpp_locale_t) { return ::isgraph(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int islower_l(int __c, locale_t) { return ::islower(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int islower_l(int __c, __libcpp_locale_t) { return ::islower(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int isprint_l(int __c, locale_t) { return ::isprint(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isprint_l(int __c, __libcpp_locale_t) { return ::isprint(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int ispunct_l(int __c, locale_t) { return ::ispunct(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int ispunct_l(int __c, __libcpp_locale_t) { return ::ispunct(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int isspace_l(int __c, locale_t) { return ::isspace(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isspace_l(int __c, __libcpp_locale_t) { return ::isspace(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int isupper_l(int __c, locale_t) { return ::isupper(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isupper_l(int __c, __libcpp_locale_t) { return ::isupper(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int isxdigit_l(int __c, locale_t) { return ::isxdigit(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int isxdigit_l(int __c, __libcpp_locale_t) { return ::isxdigit(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int toupper_l(int __c, locale_t) { return ::toupper(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int toupper_l(int __c, __libcpp_locale_t) { return ::toupper(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int tolower_l(int __c, locale_t) { return ::tolower(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int tolower_l(int __c, __libcpp_locale_t) { return ::tolower(__c); }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-inline _LIBCPP_HIDE_FROM_ABI int iswalnum_l(wint_t __c, locale_t) { return ::iswalnum(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswalnum_l(wint_t __c, __libcpp_locale_t) { return ::iswalnum(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswalpha_l(wint_t __c, locale_t) { return ::iswalpha(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswalpha_l(wint_t __c, __libcpp_locale_t) { return ::iswalpha(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswblank_l(wint_t __c, locale_t) { return ::iswblank(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswblank_l(wint_t __c, __libcpp_locale_t) { return ::iswblank(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswcntrl_l(wint_t __c, locale_t) { return ::iswcntrl(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswcntrl_l(wint_t __c, __libcpp_locale_t) { return ::iswcntrl(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswdigit_l(wint_t __c, locale_t) { return ::iswdigit(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswdigit_l(wint_t __c, __libcpp_locale_t) { return ::iswdigit(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswgraph_l(wint_t __c, locale_t) { return ::iswgraph(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswgraph_l(wint_t __c, __libcpp_locale_t) { return ::iswgraph(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswlower_l(wint_t __c, locale_t) { return ::iswlower(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswlower_l(wint_t __c, __libcpp_locale_t) { return ::iswlower(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswprint_l(wint_t __c, locale_t) { return ::iswprint(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswprint_l(wint_t __c, __libcpp_locale_t) { return ::iswprint(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswpunct_l(wint_t __c, locale_t) { return ::iswpunct(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswpunct_l(wint_t __c, __libcpp_locale_t) { return ::iswpunct(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswspace_l(wint_t __c, locale_t) { return ::iswspace(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswspace_l(wint_t __c, __libcpp_locale_t) { return ::iswspace(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswupper_l(wint_t __c, locale_t) { return ::iswupper(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswupper_l(wint_t __c, __libcpp_locale_t) { return ::iswupper(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI int iswxdigit_l(wint_t __c, locale_t) { return ::iswxdigit(__c); }
+inline _LIBCPP_HIDE_FROM_ABI int iswxdigit_l(wint_t __c, __libcpp_locale_t) { return ::iswxdigit(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI wint_t towupper_l(wint_t __c, locale_t) { return ::towupper(__c); }
+inline _LIBCPP_HIDE_FROM_ABI wint_t towupper_l(wint_t __c, __libcpp_locale_t) { return ::towupper(__c); }
 
-inline _LIBCPP_HIDE_FROM_ABI wint_t towlower_l(wint_t __c, locale_t) { return ::towlower(__c); }
+inline _LIBCPP_HIDE_FROM_ABI wint_t towlower_l(wint_t __c, __libcpp_locale_t) { return ::towlower(__c); }
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
 
-inline _LIBCPP_HIDE_FROM_ABI int strcoll_l(const char* __s1, const char* __s2, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI int strcoll_l(const char* __s1, const char* __s2, __libcpp_locale_t) {
   return ::strcoll(__s1, __s2);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI size_t strxfrm_l(char* __dest, const char* __src, size_t __n, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI size_t strxfrm_l(char* __dest, const char* __src, size_t __n, __libcpp_locale_t) {
   return ::strxfrm(__dest, __src, __n);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI size_t
-strftime_l(char* __s, size_t __max, const char* __format, const struct tm* __tm, locale_t) {
+strftime_l(char* __s, size_t __max, const char* __format, const struct tm* __tm, __libcpp_locale_t) {
   return ::strftime(__s, __max, __format, __tm);
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-inline _LIBCPP_HIDE_FROM_ABI int wcscoll_l(const wchar_t* __ws1, const wchar_t* __ws2, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI int wcscoll_l(const wchar_t* __ws1, const wchar_t* __ws2, __libcpp_locale_t) {
   return ::wcscoll(__ws1, __ws2);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI size_t wcsxfrm_l(wchar_t* __dest, const wchar_t* __src, size_t __n, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI size_t wcsxfrm_l(wchar_t* __dest, const wchar_t* __src, size_t __n, __libcpp_locale_t) {
   return ::wcsxfrm(__dest, __src, __n);
 }
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS

--- a/libcxx/include/__support/xlocale/__strtonum_fallback.h
+++ b/libcxx/include/__support/xlocale/__strtonum_fallback.h
@@ -22,23 +22,24 @@
 #  include <wchar.h>
 #endif
 
-inline _LIBCPP_HIDE_FROM_ABI float strtof_l(const char* __nptr, char** __endptr, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI float strtof_l(const char* __nptr, char** __endptr, __libcpp_locale_t) {
   return ::strtof(__nptr, __endptr);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI double strtod_l(const char* __nptr, char** __endptr, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI double strtod_l(const char* __nptr, char** __endptr, __libcpp_locale_t) {
   return ::strtod(__nptr, __endptr);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double strtold_l(const char* __nptr, char** __endptr, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI long double strtold_l(const char* __nptr, char** __endptr, __libcpp_locale_t) {
   return ::strtold(__nptr, __endptr);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long long strtoll_l(const char* __nptr, char** __endptr, int __base, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI long long strtoll_l(const char* __nptr, char** __endptr, int __base, __libcpp_locale_t) {
   return ::strtoll(__nptr, __endptr, __base);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI unsigned long long strtoull_l(const char* __nptr, char** __endptr, int __base, locale_t) {
+inline _LIBCPP_HIDE_FROM_ABI unsigned long long
+strtoull_l(const char* __nptr, char** __endptr, int __base, __libcpp_locale_t) {
   return ::strtoull(__nptr, __endptr, __base);
 }
 

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -256,7 +256,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #  else
 #    define _LIBCPP_GET_C_LOCALE __cloc()
 // Get the C locale object
-_LIBCPP_EXPORTED_FROM_ABI locale_t __cloc();
+_LIBCPP_EXPORTED_FROM_ABI __libcpp_locale_t __cloc();
 #    define __cloc_defined
 #  endif
 
@@ -2008,7 +2008,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get<wchar_t>;
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_get {
 protected:
-  locale_t __loc_;
+  __libcpp_locale_t __loc_;
 
   __time_get(const char* __nm);
   __time_get(const string& __nm);
@@ -2103,7 +2103,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get_byname<wchar_t>;
 #  endif
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_put {
-  locale_t __loc_;
+  __libcpp_locale_t __loc_;
 
 protected:
   _LIBCPP_HIDE_FROM_ABI __time_put() : __loc_(_LIBCPP_GET_C_LOCALE) {}

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1446,8 +1446,10 @@ module std [system] {
     header "__locale_dir/locale_base_api/locale_guard.h"
     module locale_base_api {
       textual header "__locale_dir/locale_base_api/android.h"
+      textual header "__locale_dir/locale_base_api/apple.h"
       textual header "__locale_dir/locale_base_api/bsd_locale_defaults.h"
       textual header "__locale_dir/locale_base_api/bsd_locale_fallbacks.h"
+      textual header "__locale_dir/locale_base_api/freebsd.h"
       textual header "__locale_dir/locale_base_api/fuchsia.h"
       textual header "__locale_dir/locale_base_api/ibm.h"
       textual header "__locale_dir/locale_base_api/musl.h"

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -60,9 +60,9 @@ struct __libcpp_unique_locale {
 
   explicit operator bool() const { return __loc_; }
 
-  locale_t& get() { return __loc_; }
+  __libcpp_locale_t& get() { return __loc_; }
 
-  locale_t __loc_;
+  __libcpp_locale_t __loc_;
 
 private:
   __libcpp_unique_locale(__libcpp_unique_locale const&);
@@ -70,11 +70,11 @@ private:
 };
 
 #ifdef __cloc_defined
-locale_t __cloc() {
+__libcpp_locale_t __cloc() {
   // In theory this could create a race condition. In practice
   // the race condition is non-fatal since it will just create
   // a little resource leak. Better approach would be appreciated.
-  static locale_t result = newlocale(LC_ALL_MASK, "C", 0);
+  static __libcpp_locale_t result = newlocale(LC_ALL_MASK, "C", 0);
   return result;
 }
 #endif // __cloc_defined
@@ -3931,7 +3931,7 @@ __widen_from_utf8<16>::~__widen_from_utf8() {}
 __widen_from_utf8<32>::~__widen_from_utf8() {}
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-static bool checked_string_to_wchar_convert(wchar_t& dest, const char* ptr, locale_t loc) {
+static bool checked_string_to_wchar_convert(wchar_t& dest, const char* ptr, __libcpp_locale_t loc) {
   if (*ptr == '\0')
     return false;
   mbstate_t mb = {};
@@ -3957,7 +3957,7 @@ static bool is_non_breaking_space(const char* ptr) {
 }
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
 
-static bool checked_string_to_char_convert(char& dest, const char* ptr, locale_t __loc) {
+static bool checked_string_to_char_convert(char& dest, const char* ptr, __libcpp_locale_t __loc) {
   if (*ptr == '\0')
     return false;
   if (!ptr[1]) {

--- a/libcxx/src/support/ibm/xlocale_zos.cpp
+++ b/libcxx/src/support/ibm/xlocale_zos.cpp
@@ -15,26 +15,26 @@
 extern "C" {
 #endif // __cplusplus
 
-locale_t newlocale(int category_mask, const char* locale, locale_t base) {
+__libcpp_locale_t newlocale(int category_mask, const char* locale, __libcpp_locale_t base) {
   // Maintain current locale name(s) to restore later.
   std::string current_loc_name(setlocale(LC_ALL, 0));
 
   // Check for errors.
   if (category_mask == LC_ALL_MASK && setlocale(LC_ALL, locale) == nullptr) {
     errno = EINVAL;
-    return (locale_t)0;
+    return (__libcpp_locale_t)0;
   } else {
     for (int _Cat = 0; _Cat <= _LC_MAX; ++_Cat) {
       if ((_CATMASK(_Cat) & category_mask) != 0 && setlocale(_Cat, locale) == nullptr) {
         setlocale(LC_ALL, current_loc_name.c_str());
         errno = EINVAL;
-        return (locale_t)0;
+        return (__libcpp_locale_t)0;
       }
     }
   }
 
   // Create new locale.
-  locale_t newloc = new locale_struct();
+  __libcpp_locale_t newloc = new locale_struct();
 
   if (base) {
     if (category_mask != LC_ALL_MASK) {
@@ -62,12 +62,12 @@ locale_t newlocale(int category_mask, const char* locale, locale_t base) {
 
   // Restore current locale.
   setlocale(LC_ALL, current_loc_name.c_str());
-  return (locale_t)newloc;
+  return (__libcpp_locale_t)newloc;
 }
 
-void freelocale(locale_t locobj) { delete locobj; }
+void freelocale(__libcpp_locale_t locobj) { delete locobj; }
 
-locale_t uselocale(locale_t newloc) {
+__libcpp_locale_t uselocale(__libcpp_locale_t newloc) {
   // Maintain current locale name(s).
   std::string current_loc_name(setlocale(LC_ALL, 0));
 
@@ -84,12 +84,12 @@ locale_t uselocale(locale_t newloc) {
     if (is_error) {
       setlocale(LC_ALL, current_loc_name.c_str());
       errno = EINVAL;
-      return (locale_t)0;
+      return (__libcpp_locale_t)0;
     }
   }
 
   // Construct and return previous locale.
-  locale_t previous_loc = new locale_struct();
+  __libcpp_locale_t previous_loc = new locale_struct();
 
   // current_loc_name might be a comma-separated locale name list.
   if (current_loc_name.find(',') != std::string::npos) {

--- a/libcxx/src/support/win32/locale_win32.cpp
+++ b/libcxx/src/support/win32/locale_win32.cpp
@@ -18,11 +18,11 @@ int __libcpp_vasprintf(char** sptr, const char* __restrict fmt, va_list ap);
 using std::__libcpp_locale_guard;
 
 // FIXME: base and mask currently unused. Needs manual work to construct the new locale
-locale_t newlocale(int /*mask*/, const char* locale, locale_t /*base*/) {
+__libcpp_locale_t newlocale(int /*mask*/, const char* locale, __libcpp_locale_t /*base*/) {
   return {_create_locale(LC_ALL, locale), locale};
 }
 
-decltype(MB_CUR_MAX) MB_CUR_MAX_L(locale_t __l) {
+decltype(MB_CUR_MAX) MB_CUR_MAX_L(__libcpp_locale_t __l) {
 #if defined(_LIBCPP_MSVCRT)
   return ___mb_cur_max_l_func(__l);
 #else
@@ -31,27 +31,28 @@ decltype(MB_CUR_MAX) MB_CUR_MAX_L(locale_t __l) {
 #endif
 }
 
-lconv* localeconv_l(locale_t& loc) {
+lconv* localeconv_l(__libcpp_locale_t& loc) {
   __libcpp_locale_guard __current(loc);
   lconv* lc = localeconv();
   if (!lc)
     return lc;
   return loc.__store_lconv(lc);
 }
-size_t mbrlen_l(const char* __restrict s, size_t n, mbstate_t* __restrict ps, locale_t loc) {
+size_t mbrlen_l(const char* __restrict s, size_t n, mbstate_t* __restrict ps, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return mbrlen(s, n, ps);
 }
-size_t
-mbsrtowcs_l(wchar_t* __restrict dst, const char** __restrict src, size_t len, mbstate_t* __restrict ps, locale_t loc) {
+size_t mbsrtowcs_l(
+    wchar_t* __restrict dst, const char** __restrict src, size_t len, mbstate_t* __restrict ps, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return mbsrtowcs(dst, src, len, ps);
 }
-size_t wcrtomb_l(char* __restrict s, wchar_t wc, mbstate_t* __restrict ps, locale_t loc) {
+size_t wcrtomb_l(char* __restrict s, wchar_t wc, mbstate_t* __restrict ps, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return wcrtomb(s, wc, ps);
 }
-size_t mbrtowc_l(wchar_t* __restrict pwc, const char* __restrict s, size_t n, mbstate_t* __restrict ps, locale_t loc) {
+size_t mbrtowc_l(
+    wchar_t* __restrict pwc, const char* __restrict s, size_t n, mbstate_t* __restrict ps, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return mbrtowc(pwc, s, n, ps);
 }
@@ -60,7 +61,7 @@ size_t mbsnrtowcs_l(wchar_t* __restrict dst,
                     size_t nms,
                     size_t len,
                     mbstate_t* __restrict ps,
-                    locale_t loc) {
+                    __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return mbsnrtowcs(dst, src, nms, len, ps);
 }
@@ -69,20 +70,20 @@ size_t wcsnrtombs_l(char* __restrict dst,
                     size_t nwc,
                     size_t len,
                     mbstate_t* __restrict ps,
-                    locale_t loc) {
+                    __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return wcsnrtombs(dst, src, nwc, len, ps);
 }
-wint_t btowc_l(int c, locale_t loc) {
+wint_t btowc_l(int c, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return btowc(c);
 }
-int wctob_l(wint_t c, locale_t loc) {
+int wctob_l(wint_t c, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return wctob(c);
 }
 
-int snprintf_l(char* ret, size_t n, locale_t loc, const char* format, ...) {
+int snprintf_l(char* ret, size_t n, __libcpp_locale_t loc, const char* format, ...) {
   va_list ap;
   va_start(ap, format);
 #if defined(_LIBCPP_MSVCRT)
@@ -100,32 +101,32 @@ int snprintf_l(char* ret, size_t n, locale_t loc, const char* format, ...) {
   return result;
 }
 
-int asprintf_l(char** ret, locale_t loc, const char* format, ...) {
+int asprintf_l(char** ret, __libcpp_locale_t loc, const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   int result = vasprintf_l(ret, loc, format, ap);
   va_end(ap);
   return result;
 }
-int vasprintf_l(char** ret, locale_t loc, const char* format, va_list ap) {
+int vasprintf_l(char** ret, __libcpp_locale_t loc, const char* format, va_list ap) {
   __libcpp_locale_guard __current(loc);
   return __libcpp_vasprintf(ret, format, ap);
 }
 
 #if !defined(_LIBCPP_MSVCRT)
-float strtof_l(const char* nptr, char** endptr, locale_t loc) {
+float __libcpp_strtof_l(const char* nptr, char** endptr, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return strtof(nptr, endptr);
 }
 
-long double strtold_l(const char* nptr, char** endptr, locale_t loc) {
+long double __libcpp_strtold_l(const char* nptr, char** endptr, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return strtold(nptr, endptr);
 }
 #endif
 
 #if defined(__MINGW32__) && __MSVCRT_VERSION__ < 0x0800
-size_t strftime_l(char* ret, size_t n, const char* format, const struct tm* tm, locale_t loc) {
+size_t strftime_l(char* ret, size_t n, const char* format, const struct tm* tm, __libcpp_locale_t loc) {
   __libcpp_locale_guard __current(loc);
   return strftime(ret, n, format, tm);
 }


### PR DESCRIPTION
This is a step towards refactoring our amazingly complicated interface with the system's localization library. Instead of using locale_t and just assuming that the system provides it, use a proper libc++ internal name (and introduce that name properly).