### PR TITLE
[Legacy ThinLTO] Use code model from IR when creating TargetMachine

### DIFF
--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -47,7 +47,7 @@ struct ThinLTOCodeGeneratorImpl::TargetMachineBuilder {
   std::optional<Reloc::Model> RelocModel;
   CodeGenOptLevel CGOptLevel = CodeGenOptLevel::Aggressive;
 
-  std::unique_ptr<TargetMachine> create() const;
+  std::unique_ptr<TargetMachine> create(Module &) const;
 };
 
 /// This class define an interface similar to the LTOCodeGenerator, but adapted

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -576,7 +576,8 @@ void ThinLTOCodeGenerator::crossReferenceSymbol(StringRef Name) {
 }
 
 // TargetMachine factory
-std::unique_ptr<TargetMachine> TargetMachineBuilder::create() const {
+std::unique_ptr<TargetMachine>
+TargetMachineBuilder::create(Module &TheModule) const {
   std::string ErrMsg;
   const Target *TheTarget =
       TargetRegistry::lookupTarget(TheTriple.str(), ErrMsg);
@@ -589,9 +590,9 @@ std::unique_ptr<TargetMachine> TargetMachineBuilder::create() const {
   Features.getDefaultSubtargetFeatures(TheTriple);
   std::string FeatureStr = Features.getString();
 
-  std::unique_ptr<TargetMachine> TM(
-      TheTarget->createTargetMachine(TheTriple.str(), MCpu, FeatureStr, Options,
-                                     RelocModel, std::nullopt, CGOptLevel));
+  std::unique_ptr<TargetMachine> TM(TheTarget->createTargetMachine(
+      TheTriple.str(), MCpu, FeatureStr, Options, RelocModel,
+      TheModule.getCodeModel(), CGOptLevel));
   assert(TM && "Cannot create target machine");
 
   return TM;
@@ -913,8 +914,8 @@ void ThinLTOCodeGenerator::optimize(Module &TheModule) {
   initTMBuilder(TMBuilder, Triple(TheModule.getTargetTriple()));
 
   // Optimize now
-  optimizeModule(TheModule, *TMBuilder.create(), OptLevel, Freestanding,
-                 DebugPassManager, nullptr);
+  optimizeModule(TheModule, *TMBuilder.create(TheModule), OptLevel,
+                 Freestanding, DebugPassManager, nullptr);
 }
 
 /// Write out the generated object file, either from CacheEntryPath or from
@@ -990,7 +991,8 @@ void ThinLTOCodeGenerator::run() {
                                              /*IsImporting*/ false);
 
         // CodeGen
-        auto OutputBuffer = codegenModule(*TheModule, *TMBuilder.create());
+        auto OutputBuffer =
+            codegenModule(*TheModule, *TMBuilder.create(*TheModule));
         if (SavedObjectsDirectoryPath.empty())
           ProducedBinaries[count] = std::move(OutputBuffer);
         else
@@ -1177,8 +1179,8 @@ void ThinLTOCodeGenerator::run() {
         auto &ImportList = ImportLists[ModuleIdentifier];
         // Run the main process now, and generates a binary
         auto OutputBuffer = ProcessThinLTOModule(
-            *TheModule, *Index, ModuleMap, *TMBuilder.create(), ImportList,
-            ExportList, GUIDPreservedSymbols,
+            *TheModule, *Index, ModuleMap, *TMBuilder.create(*TheModule),
+            ImportList, ExportList, GUIDPreservedSymbols,
             ModuleToDefinedGVSummaries[ModuleIdentifier], CacheOptions,
             DisableCodeGen, SaveTempsDir, Freestanding, OptLevel, count,
             DebugPassManager);

--- a/llvm/test/LTO/PowerPC/codemodel-1.legacy.thinlto.ll
+++ b/llvm/test/LTO/PowerPC/codemodel-1.legacy.thinlto.ll
@@ -1,0 +1,22 @@
+; RUN: llvm-as %s -o %t.o
+; RUN: llvm-lto --thinlto-action=run %t.o
+; RUN: llvm-objdump --disassemble-symbols=._start %t.o.thinlto.o | FileCheck %s --check-prefix=CHECK-SMALL
+
+target datalayout = "E-m:a-Fi64-i64:64-n32:64-S128-v256:256:256-v512:512:512"
+target triple = "powerpc64-ibm-aix7.2.0.0"
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 1, !"Code Model", i32 1}
+!3 = !{i32 1, !"EnableSplitLTOUnit", i32 0}
+
+@data = internal constant [0 x i32] []
+
+define ptr @_start() nounwind readonly {
+entry:
+; CHECK-SMALL-LABEL:  <._start>:
+; CHECK-SMALL-NEXT: ld 3, 0(2)
+    ret ptr @data
+}

--- a/llvm/test/LTO/PowerPC/codemodel-2.legacy.thinlto.ll
+++ b/llvm/test/LTO/PowerPC/codemodel-2.legacy.thinlto.ll
@@ -1,0 +1,24 @@
+; RUN: llvm-as %s -o %t.o
+; RUN: llvm-lto --thinlto-action=run %t.o
+; RUN: llvm-objdump --disassemble-symbols=._start %t.o.thinlto.o | FileCheck %s --check-prefix=CHECK-LARGE
+
+target datalayout = "E-m:a-Fi64-i64:64-n32:64-S128-v256:256:256-v512:512:512"
+target triple = "powerpc64-ibm-aix7.2.0.0"
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 1, !"Code Model", i32 4}
+!3 = !{i32 1, !"EnableSplitLTOUnit", i32 0}
+
+@data = internal constant [0 x i32] []
+
+define ptr @_start() nounwind readonly {
+entry:
+; CHECK-LARGE-LABEL:  <._start>:
+; CHECK-LARGE-NEXT: addis 3, 2, 0
+; CHECK-LARGE-NEXT: ld 3, 0(3)
+
+    ret ptr @data
+}


### PR DESCRIPTION
It is observed that libLTO.so, which uses the legacy ThinLTO interface
respects neither the `--code-model=` option nor the code model encoded
in the IR.

This PR is a fix to respect the code model encoded in the IR.
