### PR TITLE
[AIX] Use internal lit shell for TableGen instead of a global setting

### DIFF
--- a/llvm/test/TableGen/lit.local.cfg
+++ b/llvm/test/TableGen/lit.local.cfg
@@ -1,3 +1,4 @@
+import platform
 import lit.formats
 
 config.suffixes = [".td"]
@@ -5,4 +6,5 @@ config.excludes = ["Common", "Inputs"]
 
 # AIX 'diff' command doesn't support --strip-trailing-cr, but the internal
 # python implementation does, so use that for cross platform compatibility
-config.test_format = lit.formats.ShTest()
+if platform.system() == "AIX":
+    config.test_format = lit.formats.ShTest()

--- a/llvm/test/TableGen/lit.local.cfg
+++ b/llvm/test/TableGen/lit.local.cfg
@@ -1,2 +1,8 @@
+import lit.formats
+
 config.suffixes = [".td"]
 config.excludes = ["Common", "Inputs"]
+
+# AIX 'diff' command doesn't support --strip-trailing-cr, but the internal
+# python implementation does, so use that for cross platform compatibility
+config.test_format = lit.formats.ShTest()

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -57,13 +57,6 @@ class LLVMConfig(object):
                 self.lit_config.note("using lit tools: {}".format(path))
                 lit_path_displayed = True
 
-        if platform.system() == "AIX":
-            # Diff on AIX doesn't have all the required features (see
-            # https://github.com/llvm/llvm-project/pull/108871 and
-            # https://github.com/llvm/llvm-project/pull/112997#issuecomment-2429656192)
-            # so always use the internal shell.
-            self.use_lit_shell = True
-
         if platform.system() == "OS/390":
             self.with_environment("_BPXK_AUTOCVT", "ON")
             self.with_environment("_TAG_REDIR_IN", "TXT")


### PR DESCRIPTION
This is to address the latest lit regressions https://lab.llvm.org/buildbot/#/builders/64/builds/1285 caused by using the internal lit shell. This change will limit using the internal lit shell to TableGen on AIX so we do not hit these regressions.