### PR TITLE
[libc++][test] Make macro detection more friendly to MSVC

### DIFF
--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -511,7 +511,7 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 #  define TEST_CONSTEXPR_OPERATOR_NEW
 #endif
 
-#if __SIZEOF_LONG_DOUBLE__ == __SIZEOF_DOUBLE__
+#if defined(_MSC_VER) || __SIZEOF_LONG_DOUBLE__ == __SIZEOF_DOUBLE__
 #  define TEST_LONG_DOUBLE_IS_DOUBLE
 #endif
 


### PR DESCRIPTION
MSVC STL's test suite is a bit nervous about replacing non-macro-defined identifiers with `0` (see also https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4668?view=msvc-170).

On MSVC (and MS-compatible mode of other compilers), `long double` has the same format (IEEE-754 binary64) as  `double`, so it should be OK to define `TEST_LONG_DOUBLE_IS_DOUBLE` when `_MSC_VER` is defined. Such detection should be performed first.