### PR TITLE
[libc++][test] Augment `test_alloc` in `deallocate_size.pass.cpp`

### DIFF
--- a/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/deallocate_size.pass.cpp
@@ -34,15 +34,32 @@ struct test_alloc {
     typedef test_alloc<U, Sz> other;
   };
 
-  TEST_CONSTEXPR_CXX14 pointer allocate(size_type n, const void* = nullptr) {
+  TEST_CONSTEXPR test_alloc() TEST_NOEXCEPT {}
+
+  template <class U>
+  TEST_CONSTEXPR test_alloc(const test_alloc<U, Sz>&) TEST_NOEXCEPT {}
+
+  pointer allocate(size_type n, const void* = nullptr) {
     allocated_ += n;
     return std::allocator<value_type>().allocate(n);
   }
 
-  TEST_CONSTEXPR_CXX14 void deallocate(pointer p, size_type s) {
+  void deallocate(pointer p, size_type s) {
     allocated_ -= s;
     std::allocator<value_type>().deallocate(p, s);
   }
+
+  template <class U>
+  friend TEST_CONSTEXPR bool operator==(const test_alloc&, const test_alloc<U, Sz>&) TEST_NOEXCEPT {
+    return true;
+  }
+
+#if TEST_STD_VER < 20
+  template <class U>
+  friend TEST_CONSTEXPR bool operator!=(const test_alloc&, const test_alloc<U, Sz>&) TEST_NOEXCEPT {
+    return false;
+  }
+#endif
 };
 
 template <class Sz>


### PR DESCRIPTION
Making it meet the requirements for allocator since C++11. Fixes #113609.

This PR doesn't make it meet the C++03 allocator requirements, because that would make the type too verbose and libc++ has backported many C++11 features to the C++03 mode.

Drive-by: Removes the `TEST_CONSTEXPR_CXX14` on `allocate`/`dealocate` which is never in effect (and causes IFNDR-ness before C++23), since these functions modify the namespace-scoped variable `allocated_`.