### PR TITLE
[clang-format] Print the names of unfound files in error messages

### DIFF
--- a/clang/test/Format/error-unfound-files.cpp
+++ b/clang/test/Format/error-unfound-files.cpp
@@ -3,5 +3,3 @@
 // RUN: not clang-format a.c b.c 2>&1 | FileCheck %s
 // CHECK: a.c:
 // CHECK-NEXT: b.c:
-
-// rm -f a.c b.c

--- a/clang/test/Format/error-unfound-files.cpp
+++ b/clang/test/Format/error-unfound-files.cpp
@@ -1,0 +1,7 @@
+// RUN: rm -f a.c b.c
+
+// RUN: not clang-format a.c b.c 2>&1 | FileCheck %s
+// CHECK: a.c:
+// CHECK-NEXT: b.c:
+
+// rm -f a.c b.c

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -410,7 +410,7 @@ static bool format(StringRef FileName, bool ErrorOnIncompleteFormat = false) {
   const bool IsSTDIN = FileName == "-";
   if (!OutputXML && Inplace && IsSTDIN) {
     errs() << "error: cannot use -i when reading from stdin.\n";
-    return false;
+    return true;
   }
   // On Windows, overwriting a file with an open file mapping doesn't work,
   // so read the whole file into memory when formatting in-place.

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -419,7 +419,7 @@ static bool format(StringRef FileName, bool ErrorOnIncompleteFormat = false) {
           ? MemoryBuffer::getFileAsStream(FileName)
           : MemoryBuffer::getFileOrSTDIN(FileName, /*IsText=*/true);
   if (std::error_code EC = CodeOrErr.getError()) {
-    errs() << EC.message() << "\n";
+    errs() << FileName << ": " << EC.message() << "\n";
     return true;
   }
   std::unique_ptr<llvm::MemoryBuffer> Code = std::move(CodeOrErr.get());


### PR DESCRIPTION
Also fix the return status when `-i` is used with reading from stdin.

Fixes #113631.