### PR TITLE
[ADT] Use data() and size() within StringRef (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -102,7 +102,7 @@ namespace llvm {
 
     /// Construct a string ref from an std::string.
     /*implicit*/ StringRef(const std::string &Str)
-      : Data(Str.data()), Length(Str.length()) {}
+        : Data(Str.data()), Length(Str.length()) {}
 
     /// Construct a string ref from an std::string_view.
     /*implicit*/ constexpr StringRef(std::string_view Str)
@@ -112,9 +112,9 @@ namespace llvm {
     /// @name Iterators
     /// @{
 
-    iterator begin() const { return Data; }
+    iterator begin() const { return data(); }
 
-    iterator end() const { return Data + Length; }
+    iterator end() const { return data() + size(); }
 
     reverse_iterator rbegin() const {
       return std::make_reverse_iterator(end());
@@ -143,7 +143,7 @@ namespace llvm {
     [[nodiscard]] constexpr const char *data() const { return Data; }
 
     /// empty - Check if the string is empty.
-    [[nodiscard]] constexpr bool empty() const { return Length == 0; }
+    [[nodiscard]] constexpr bool empty() const { return size() == 0; }
 
     /// size - Get the string size.
     [[nodiscard]] constexpr size_t size() const { return Length; }
@@ -151,13 +151,13 @@ namespace llvm {
     /// front - Get the first character in the string.
     [[nodiscard]] char front() const {
       assert(!empty());
-      return Data[0];
+      return data()[0];
     }
 
     /// back - Get the last character in the string.
     [[nodiscard]] char back() const {
       assert(!empty());
-      return Data[Length-1];
+      return data()[size() - 1];
     }
 
     // copy - Allocate copy in Allocator and return StringRef to it.
@@ -166,14 +166,14 @@ namespace llvm {
       // Don't request a length 0 copy from the allocator.
       if (empty())
         return StringRef();
-      char *S = A.template Allocate<char>(Length);
+      char *S = A.template Allocate<char>(size());
       std::copy(begin(), end(), S);
-      return StringRef(S, Length);
+      return StringRef(S, size());
     }
 
     /// Check for string equality, ignoring case.
     [[nodiscard]] bool equals_insensitive(StringRef RHS) const {
-      return Length == RHS.Length && compare_insensitive(RHS) == 0;
+      return size() == RHS.size() && compare_insensitive(RHS) == 0;
     }
 
     /// compare - Compare two strings; the result is negative, zero, or positive
@@ -181,13 +181,14 @@ namespace llvm {
     /// the \p RHS.
     [[nodiscard]] int compare(StringRef RHS) const {
       // Check the prefix for a mismatch.
-      if (int Res = compareMemory(Data, RHS.Data, std::min(Length, RHS.Length)))
+      if (int Res =
+              compareMemory(data(), RHS.data(), std::min(size(), RHS.size())))
         return Res < 0 ? -1 : 1;
 
       // Otherwise the prefixes match, so we only need to check the lengths.
-      if (Length == RHS.Length)
+      if (size() == RHS.size())
         return 0;
-      return Length < RHS.Length ? -1 : 1;
+      return size() < RHS.size() ? -1 : 1;
     }
 
     /// Compare two strings, ignoring case.
@@ -225,8 +226,9 @@ namespace llvm {
 
     /// str - Get the contents as an std::string.
     [[nodiscard]] std::string str() const {
-      if (!Data) return std::string();
-      return std::string(Data, Length);
+      if (!data())
+        return std::string();
+      return std::string(data(), size());
     }
 
     /// @}
@@ -234,8 +236,8 @@ namespace llvm {
     /// @{
 
     [[nodiscard]] char operator[](size_t Index) const {
-      assert(Index < Length && "Invalid index!");
-      return Data[Index];
+      assert(Index < size() && "Invalid index!");
+      return data()[Index];
     }
 
     /// Disallow accidental assignment from a temporary std::string.
@@ -260,8 +262,8 @@ namespace llvm {
 
     /// Check if this string starts with the given \p Prefix.
     [[nodiscard]] bool starts_with(StringRef Prefix) const {
-      return Length >= Prefix.Length &&
-             compareMemory(Data, Prefix.Data, Prefix.Length) == 0;
+      return size() >= Prefix.size() &&
+             compareMemory(data(), Prefix.data(), Prefix.size()) == 0;
     }
     [[nodiscard]] bool starts_with(char Prefix) const {
       return !empty() && front() == Prefix;
@@ -272,9 +274,9 @@ namespace llvm {
 
     /// Check if this string ends with the given \p Suffix.
     [[nodiscard]] bool ends_with(StringRef Suffix) const {
-      return Length >= Suffix.Length &&
-             compareMemory(end() - Suffix.Length, Suffix.Data, Suffix.Length) ==
-                 0;
+      return size() >= Suffix.size() &&
+             compareMemory(end() - Suffix.size(), Suffix.data(),
+                           Suffix.size()) == 0;
     }
     [[nodiscard]] bool ends_with(char Suffix) const {
       return !empty() && back() == Suffix;
@@ -342,10 +344,10 @@ namespace llvm {
     /// \returns The index of the last occurrence of \p C, or npos if not
     /// found.
     [[nodiscard]] size_t rfind(char C, size_t From = npos) const {
-      size_t I = std::min(From, Length);
+      size_t I = std::min(From, size());
       while (I) {
         --I;
-        if (Data[I] == C)
+        if (data()[I] == C)
           return I;
       }
       return npos;
@@ -447,8 +449,8 @@ namespace llvm {
     /// Return the number of occurrences of \p C in the string.
     [[nodiscard]] size_t count(char C) const {
       size_t Count = 0;
-      for (size_t I = 0; I != Length; ++I)
-        if (Data[I] == C)
+      for (size_t I = 0; I != size(); ++I)
+        if (data()[I] == C)
           ++Count;
       return Count;
     }
@@ -567,8 +569,8 @@ namespace llvm {
     /// suffix (starting with \p Start) will be returned.
     [[nodiscard]] constexpr StringRef substr(size_t Start,
                                              size_t N = npos) const {
-      Start = std::min(Start, Length);
-      return StringRef(Data + Start, std::min(N, Length - Start));
+      Start = std::min(Start, size());
+      return StringRef(data() + Start, std::min(N, size() - Start));
     }
 
     /// Return a StringRef equal to 'this' but with only the first \p N
@@ -679,9 +681,9 @@ namespace llvm {
     /// will be returned. If this is less than \p Start, an empty string will
     /// be returned.
     [[nodiscard]] StringRef slice(size_t Start, size_t End) const {
-      Start = std::min(Start, Length);
-      End = std::clamp(End, Start, Length);
-      return StringRef(Data + Start, End - Start);
+      Start = std::min(Start, size());
+      End = std::clamp(End, Start, size());
+      return StringRef(data() + Start, End - Start);
     }
 
     /// Split into two substrings around the first occurrence of a separator
@@ -786,25 +788,25 @@ namespace llvm {
     /// Return string with consecutive \p Char characters starting from the
     /// the left removed.
     [[nodiscard]] StringRef ltrim(char Char) const {
-      return drop_front(std::min(Length, find_first_not_of(Char)));
+      return drop_front(std::min(size(), find_first_not_of(Char)));
     }
 
     /// Return string with consecutive characters in \p Chars starting from
     /// the left removed.
     [[nodiscard]] StringRef ltrim(StringRef Chars = " \t\n\v\f\r") const {
-      return drop_front(std::min(Length, find_first_not_of(Chars)));
+      return drop_front(std::min(size(), find_first_not_of(Chars)));
     }
 
     /// Return string with consecutive \p Char characters starting from the
     /// right removed.
     [[nodiscard]] StringRef rtrim(char Char) const {
-      return drop_back(Length - std::min(Length, find_last_not_of(Char) + 1));
+      return drop_back(size() - std::min(size(), find_last_not_of(Char) + 1));
     }
 
     /// Return string with consecutive characters in \p Chars starting from
     /// the right removed.
     [[nodiscard]] StringRef rtrim(StringRef Chars = " \t\n\v\f\r") const {
-      return drop_back(Length - std::min(Length, find_last_not_of(Chars) + 1));
+      return drop_back(size() - std::min(size(), find_last_not_of(Chars) + 1));
     }
 
     /// Return string with consecutive \p Char characters starting from the
@@ -831,9 +833,9 @@ namespace llvm {
         // If there is no carriage return, assume unix
         return "\n";
       }
-      if (Pos + 1 < Length && Data[Pos + 1] == '\n')
+      if (Pos + 1 < size() && data()[Pos + 1] == '\n')
         return "\r\n"; // Windows
-      if (Pos > 0 && Data[Pos - 1] == '\n')
+      if (Pos > 0 && data()[Pos - 1] == '\n')
         return "\n\r"; // You monster!
       return "\r";     // Classic Mac
     }

--- a/llvm/lib/Support/StringRef.cpp
+++ b/llvm/lib/Support/StringRef.cpp
@@ -35,21 +35,23 @@ static int ascii_strncasecmp(const char *LHS, const char *RHS, size_t Length) {
 }
 
 int StringRef::compare_insensitive(StringRef RHS) const {
-  if (int Res = ascii_strncasecmp(Data, RHS.Data, std::min(Length, RHS.Length)))
+  if (int Res =
+          ascii_strncasecmp(data(), RHS.data(), std::min(size(), RHS.size())))
     return Res;
-  if (Length == RHS.Length)
+  if (size() == RHS.size())
     return 0;
-  return Length < RHS.Length ? -1 : 1;
+  return size() < RHS.size() ? -1 : 1;
 }
 
 bool StringRef::starts_with_insensitive(StringRef Prefix) const {
-  return Length >= Prefix.Length &&
-      ascii_strncasecmp(Data, Prefix.Data, Prefix.Length) == 0;
+  return size() >= Prefix.size() &&
+         ascii_strncasecmp(data(), Prefix.data(), Prefix.size()) == 0;
 }
 
 bool StringRef::ends_with_insensitive(StringRef Suffix) const {
-  return Length >= Suffix.Length &&
-      ascii_strncasecmp(end() - Suffix.Length, Suffix.Data, Suffix.Length) == 0;
+  return size() >= Suffix.size() &&
+         ascii_strncasecmp(end() - Suffix.size(), Suffix.data(),
+                           Suffix.size()) == 0;
 }
 
 size_t StringRef::find_insensitive(char C, size_t From) const {
@@ -59,33 +61,33 @@ size_t StringRef::find_insensitive(char C, size_t From) const {
 
 /// compare_numeric - Compare strings, handle embedded numbers.
 int StringRef::compare_numeric(StringRef RHS) const {
-  for (size_t I = 0, E = std::min(Length, RHS.Length); I != E; ++I) {
+  for (size_t I = 0, E = std::min(size(), RHS.size()); I != E; ++I) {
     // Check for sequences of digits.
-    if (isDigit(Data[I]) && isDigit(RHS.Data[I])) {
+    if (isDigit(data()[I]) && isDigit(RHS.data()[I])) {
       // The longer sequence of numbers is considered larger.
       // This doesn't really handle prefixed zeros well.
       size_t J;
       for (J = I + 1; J != E + 1; ++J) {
-        bool ld = J < Length && isDigit(Data[J]);
-        bool rd = J < RHS.Length && isDigit(RHS.Data[J]);
+        bool ld = J < size() && isDigit(data()[J]);
+        bool rd = J < RHS.size() && isDigit(RHS.data()[J]);
         if (ld != rd)
           return rd ? -1 : 1;
         if (!rd)
           break;
       }
       // The two number sequences have the same length (J-I), just memcmp them.
-      if (int Res = compareMemory(Data + I, RHS.Data + I, J - I))
+      if (int Res = compareMemory(data() + I, RHS.data() + I, J - I))
         return Res < 0 ? -1 : 1;
       // Identical number sequences, continue search after the numbers.
       I = J - 1;
       continue;
     }
-    if (Data[I] != RHS.Data[I])
-      return (unsigned char)Data[I] < (unsigned char)RHS.Data[I] ? -1 : 1;
+    if (data()[I] != RHS.data()[I])
+      return (unsigned char)data()[I] < (unsigned char)RHS.data()[I] ? -1 : 1;
   }
-  if (Length == RHS.Length)
+  if (size() == RHS.size())
     return 0;
-  return Length < RHS.Length ? -1 : 1;
+  return size() < RHS.size() ? -1 : 1;
 }
 
 // Compute the edit distance between the two given strings.
@@ -128,11 +130,11 @@ std::string StringRef::upper() const {
 /// \return - The index of the first occurrence of \arg Str, or npos if not
 /// found.
 size_t StringRef::find(StringRef Str, size_t From) const {
-  if (From > Length)
+  if (From > size())
     return npos;
 
-  const char *Start = Data + From;
-  size_t Size = Length - From;
+  const char *Start = data() + From;
+  size_t Size = size() - From;
 
   const char *Needle = Str.data();
   size_t N = Str.size();
@@ -142,7 +144,7 @@ size_t StringRef::find(StringRef Str, size_t From) const {
     return npos;
   if (N == 1) {
     const char *Ptr = (const char *)::memchr(Start, Needle[0], Size);
-    return Ptr == nullptr ? npos : Ptr - Data;
+    return Ptr == nullptr ? npos : Ptr - data();
   }
 
   const char *Stop = Start + (Size - N + 1);
@@ -153,7 +155,7 @@ size_t StringRef::find(StringRef Str, size_t From) const {
     // good enough.
     do {
       if (std::memcmp(Start, Needle, 2) == 0)
-        return Start - Data;
+        return Start - data();
       ++Start;
     } while (Start < Stop);
     return npos;
@@ -163,7 +165,7 @@ size_t StringRef::find(StringRef Str, size_t From) const {
   if (Size < 16 || N > 255) {
     do {
       if (std::memcmp(Start, Needle, N) == 0)
-        return Start - Data;
+        return Start - data();
       ++Start;
     } while (Start < Stop);
     return npos;
@@ -179,7 +181,7 @@ size_t StringRef::find(StringRef Str, size_t From) const {
     uint8_t Last = Start[N - 1];
     if (LLVM_UNLIKELY(Last == (uint8_t)Needle[N - 1]))
       if (std::memcmp(Start, Needle, N - 1) == 0)
-        return Start - Data;
+        return Start - data();
 
     // Otherwise skip the appropriate number of bytes.
     Start += BadCharSkip[Last];
@@ -200,11 +202,11 @@ size_t StringRef::find_insensitive(StringRef Str, size_t From) const {
 }
 
 size_t StringRef::rfind_insensitive(char C, size_t From) const {
-  From = std::min(From, Length);
+  From = std::min(From, size());
   size_t i = From;
   while (i != 0) {
     --i;
-    if (toLower(Data[i]) == toLower(C))
+    if (toLower(data()[i]) == toLower(C))
       return i;
   }
   return npos;
@@ -220,9 +222,9 @@ size_t StringRef::rfind(StringRef Str) const {
 
 size_t StringRef::rfind_insensitive(StringRef Str) const {
   size_t N = Str.size();
-  if (N > Length)
+  if (N > size())
     return npos;
-  for (size_t i = Length - N + 1, e = 0; i != e;) {
+  for (size_t i = size() - N + 1, e = 0; i != e;) {
     --i;
     if (substr(i, N).equals_insensitive(Str))
       return i;
@@ -240,8 +242,8 @@ StringRef::size_type StringRef::find_first_of(StringRef Chars,
   for (char C : Chars)
     CharBits.set((unsigned char)C);
 
-  for (size_type i = std::min(From, Length), e = Length; i != e; ++i)
-    if (CharBits.test((unsigned char)Data[i]))
+  for (size_type i = std::min(From, size()), e = size(); i != e; ++i)
+    if (CharBits.test((unsigned char)data()[i]))
       return i;
   return npos;
 }
@@ -262,8 +264,8 @@ StringRef::size_type StringRef::find_first_not_of(StringRef Chars,
   for (char C : Chars)
     CharBits.set((unsigned char)C);
 
-  for (size_type i = std::min(From, Length), e = Length; i != e; ++i)
-    if (!CharBits.test((unsigned char)Data[i]))
+  for (size_type i = std::min(From, size()), e = size(); i != e; ++i)
+    if (!CharBits.test((unsigned char)data()[i]))
       return i;
   return npos;
 }
@@ -278,8 +280,8 @@ StringRef::size_type StringRef::find_last_of(StringRef Chars,
   for (char C : Chars)
     CharBits.set((unsigned char)C);
 
-  for (size_type i = std::min(From, Length) - 1, e = -1; i != e; --i)
-    if (CharBits.test((unsigned char)Data[i]))
+  for (size_type i = std::min(From, size()) - 1, e = -1; i != e; --i)
+    if (CharBits.test((unsigned char)data()[i]))
       return i;
   return npos;
 }
@@ -287,8 +289,8 @@ StringRef::size_type StringRef::find_last_of(StringRef Chars,
 /// find_last_not_of - Find the last character in the string that is not
 /// \arg C, or npos if not found.
 StringRef::size_type StringRef::find_last_not_of(char C, size_t From) const {
-  for (size_type i = std::min(From, Length) - 1, e = -1; i != e; --i)
-    if (Data[i] != C)
+  for (size_type i = std::min(From, size()) - 1, e = -1; i != e; --i)
+    if (data()[i] != C)
       return i;
   return npos;
 }
@@ -303,8 +305,8 @@ StringRef::size_type StringRef::find_last_not_of(StringRef Chars,
   for (char C : Chars)
     CharBits.set((unsigned char)C);
 
-  for (size_type i = std::min(From, Length) - 1, e = -1; i != e; --i)
-    if (!CharBits.test((unsigned char)Data[i]))
+  for (size_type i = std::min(From, size()) - 1, e = -1; i != e; --i)
+    if (!CharBits.test((unsigned char)data()[i]))
       return i;
   return npos;
 }


### PR DESCRIPTION
This patch uses data() and size() within StringRef instead of Data and
Length.  This makes it easier to replace Data and Length with
std::string_view in the future, which in turn allows us to forward
most of StringRef functions to the counterparts in std::string_view.
