### PR TITLE
[tsan] Fix deadlock with dyld during symbolization on darwin platforms

### DIFF
--- a/compiler-rt/lib/tsan/go/tsan_go.cpp
+++ b/compiler-rt/lib/tsan/go/tsan_go.cpp
@@ -118,6 +118,26 @@ ReportLocation *SymbolizeData(uptr addr) {
   }
 }
 
+bool SymbolizeData(uptr addr, DataInfo *info) {
+  SymbolizeDataContext cbctx;
+  internal_memset(&cbctx, 0, sizeof(cbctx));
+  cbctx.addr = addr;
+  go_runtime_cb(CallbackSymbolizeData, &cbctx);
+  if (!cbctx.res)
+    return false;
+  if (cbctx.heap) {
+    return false;
+  } else {
+    info->Clear();
+    info->name = internal_strdup(cbctx.name ? cbctx.name : "??");
+    info->file = internal_strdup(cbctx.file ? cbctx.file : "??");
+    info->line = cbctx.line;
+    info->start = cbctx.start;
+    info->size = cbctx.size;
+    return true;
+  }
+}
+
 static ThreadState *main_thr;
 static bool inited;
 

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -2064,13 +2064,17 @@ static void ReportErrnoSpoiling(ThreadState *thr, uptr pc, int sig) {
   // StackTrace::GetNestInstructionPc(pc) is used because return address is
   // expected, OutputReport() will undo this.
   ObtainCurrentStack(thr, StackTrace::GetNextInstructionPc(pc), &stack);
-  ThreadRegistryLock l(&ctx->thread_registry);
-  ScopedReport rep(ReportTypeErrnoInSignal);
-  rep.SetSigNum(sig);
-  if (!IsFiredSuppression(ctx, ReportTypeErrnoInSignal, stack)) {
-    rep.AddStack(stack, true);
-    OutputReport(thr, rep);
+  if (IsFiredSuppression(ctx, ReportTypeErrnoInSignal, stack)) {
+    return;
   }
+  ScopedReport rep(ReportTypeErrnoInSignal);
+  {
+    // ThreadRegistryLock l(&ctx->thread_registry);
+    rep.SetSigNum(sig);
+    rep.AddStack(stack, true);
+  }
+  rep.SymbolizeReport();
+  OutputReport(thr, rep);
 }
 
 static void CallUserSignalHandler(ThreadState *thr, bool sync, bool acquire,

--- a/compiler-rt/lib/tsan/rtl/tsan_mman.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_mman.cpp
@@ -182,9 +182,12 @@ static void SignalUnsafeCall(ThreadState *thr, uptr pc) {
   ObtainCurrentStack(thr, pc, &stack);
   if (IsFiredSuppression(ctx, ReportTypeSignalUnsafe, stack))
     return;
-  ThreadRegistryLock l(&ctx->thread_registry);
   ScopedReport rep(ReportTypeSignalUnsafe);
-  rep.AddStack(stack, true);
+  {
+    // ThreadRegistryLock l(&ctx->thread_registry);
+    rep.AddStack(stack, true);
+  }
+  rep.SymbolizeReport();
   OutputReport(thr, rep);
 }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_report.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_report.h
@@ -16,6 +16,7 @@
 #include "sanitizer_common/sanitizer_thread_registry.h"
 #include "sanitizer_common/sanitizer_vector.h"
 #include "tsan_defs.h"
+#include "tsan_stack_trace.h"
 
 namespace __tsan {
 
@@ -39,6 +40,7 @@ enum ReportType {
 };
 
 struct ReportStack {
+  VarSizeStackTrace raw;
   SymbolizedStack *frames = nullptr;
   bool suppressable = false;
 };

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.h
@@ -406,6 +406,7 @@ uptr TagFromShadowStackFrame(uptr pc);
 
 class ScopedReportBase {
  public:
+  void SetKindAndTag(ReportType typ, uptr tag);
   void AddMemoryAccess(uptr addr, uptr external_tag, Shadow s, Tid tid,
                        StackTrace stack, const MutexSet *mset);
   void AddStack(StackTrace stack, bool suppressable = false);
@@ -418,17 +419,16 @@ class ScopedReportBase {
   void SetCount(int count);
   void SetSigNum(int sig);
 
+  void SymbolizeReport();
   const ReportDesc *GetReport() const;
 
  protected:
+  ScopedReportBase();
   ScopedReportBase(ReportType typ, uptr tag);
   ~ScopedReportBase();
 
  private:
   ReportDesc *rep_;
-  // Symbolizer makes lots of intercepted calls. If we try to process them,
-  // at best it will cause deadlocks on internal mutexes.
-  ScopedIgnoreInterceptors ignore_interceptors_;
 
   ScopedReportBase(const ScopedReportBase &) = delete;
   void operator=(const ScopedReportBase &) = delete;
@@ -436,11 +436,9 @@ class ScopedReportBase {
 
 class ScopedReport : public ScopedReportBase {
  public:
+  explicit ScopedReport();
   explicit ScopedReport(ReportType typ, uptr tag = kExternalTagNone);
   ~ScopedReport();
-
- private:
-  ScopedErrorReportLock lock_;
 };
 
 bool ShouldReport(ThreadState *thr, ReportType typ);

--- a/compiler-rt/lib/tsan/rtl/tsan_stack_trace.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_stack_trace.cpp
@@ -38,9 +38,22 @@ void VarSizeStackTrace::Init(const uptr *pcs, uptr cnt, uptr extra_top_pc) {
     trace_buffer[cnt] = extra_top_pc;
 }
 
+void VarSizeStackTrace::Init(const StackTrace &trace) {
+  ResizeBuffer(trace.size);
+  internal_memcpy(trace_buffer, trace.trace,
+                  trace.size * sizeof(trace.trace[0]));
+}
+
 void VarSizeStackTrace::ReverseOrder() {
   for (u32 i = 0; i < (size >> 1); i++)
     Swap(trace_buffer[i], trace_buffer[size - 1 - i]);
+}
+
+void VarSizeStackTrace::Reset() {
+  size = 0;
+  trace = nullptr;
+  Free(trace_buffer);
+  trace_buffer = nullptr;
 }
 
 }  // namespace __tsan

--- a/compiler-rt/lib/tsan/rtl/tsan_stack_trace.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_stack_trace.h
@@ -24,11 +24,16 @@ struct VarSizeStackTrace : public StackTrace {
 
   VarSizeStackTrace();
   ~VarSizeStackTrace();
+
   void Init(const uptr *pcs, uptr cnt, uptr extra_top_pc = 0);
+  void Init(const StackTrace &trace);
 
   // Reverses the current stack trace order, the top frame goes to the bottom,
   // the last frame goes to the top.
   void ReverseOrder();
+
+  // Clear and release internal buffer.
+  void Reset();
 
  private:
   void ResizeBuffer(uptr new_size);

--- a/compiler-rt/lib/tsan/rtl/tsan_symbolize.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_symbolize.cpp
@@ -116,6 +116,10 @@ ReportLocation *SymbolizeData(uptr addr) {
   return ent;
 }
 
+bool SymbolizeData(uptr addr, DataInfo *info) {
+  return Symbolizer::GetOrInit()->SymbolizeData(addr, info);
+}
+
 void SymbolizeFlush() {
   Symbolizer::GetOrInit()->Flush();
 }

--- a/compiler-rt/lib/tsan/rtl/tsan_symbolize.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_symbolize.h
@@ -21,6 +21,7 @@ void EnterSymbolizer();
 void ExitSymbolizer();
 SymbolizedStack *SymbolizeCode(uptr addr);
 ReportLocation *SymbolizeData(uptr addr);
+bool SymbolizeData(uptr addr, DataInfo *info);
 void SymbolizeFlush();
 
 ReportStack *NewReportStackEntry(uptr addr);


### PR DESCRIPTION
On darwin platforms, callbacks registered via `_dyld_register_func_for_add_image` are invoked with a lock held by dyld. These callbacks, in turn, request locks in the TSan runtime due to instrumented codes or interceptors. Previously, reporting race issues involved holding TSan runtime locks and simultaneously attemping to acquire the dyld lock during symbolization, which leads to deadlock.

This commit restructures the reporting process into 3 distinct steps: data collection, symbolization and printing. Each step now only holds the necessary locks to prevent the deadlock.