### PR TITLE
p/libc fexcept t

### DIFF
--- a/libc/include/llvm-libc-types/fexcept_t.h
+++ b/libc/include/llvm-libc-types/fexcept_t.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_TYPES_FEXCEPT_T_H
 #define LLVM_LIBC_TYPES_FEXCEPT_T_H
 
-typedef int fexcept_t;
+#if defined(__x86_64__) || defined(__i386__)
+typedef unsigned short int fexcept_t;
+#else
+typedef unsigned int fexcept_t;
+#endif
 
 #endif // LLVM_LIBC_TYPES_FEXCEPT_T_H


### PR DESCRIPTION
- **[LoongArch][MC] Handle more PseudoLA* instructions with la-global-with-abs feature**
- **[ADT] Fix ArrayRef<T>::slice (#113048)**
- **[MCParser] De-capitalize ELFAsmParser functions. NFC**
- **[libc] Use `if constexpr` for compile-time conditionals (#113417)**
- **Fix GetRandom in sanitizer_fuchsia.cpp (#110155)**
- **[AMDGPU] Avoid repeated hash lookups (NFC) (#113409)**
- **[RISCV] Add lowering for @llvm.experimental.vector.compress (#113291)**
- **[MC] Remove unused getMemtagRelocsSection**
- **[LoongArch] Support LoongArch-specific amswap[_db].{b/h} and amadd[_db].{b/h} instructions (#113255)**
- **[FuncSpec] Only compute Latency bonus when necessary (#113159)**
- **[llvm][ARM] Correct the properties of trap instructions (#113287)**
- **[RISCV][MC] Support imm symbol in parseCSRSystemRegister (#112007)**
- **[analyzer] Remove redundant "returned to caller" suffix for compound literal in StackAddressEscape**
- **[MLIR][SPIRV] Update cast from IntN to Bool (#113329)**
- **[flang][OpenMP] Support `target enter|update|exit .. nowait` (#113305)**
- **[llvm][docs] Clean up the "Landing Your Change" section of the GitHub docs (#112869)**
- **[PS5][Driver] Pass default -z options to PS5 linker (#113162)**
- **[flang][hlfir] refine hlfir.assign side effects (#113319)**
- **[flang][NFC] turn (h)fir.declare side effect into debug ressource alloca (#113321)**
- **[flang][hlfir] do not consider local temps as conflicting in assignment (#113330)**
- **[LLVM][AARCH64] Add assembly/disassembly of zeroing convert instructions (#113292)**
- **[LLD][COFF] Allow overriding EC alias symbols with lazy archive symbols (#113283)**
- **[LLVM][CMake][MSVC] Wrap linker flags for ICX on Windows (#112680)**
- **[LLD][COFF] Check both mangled and demangled symbols before adding a lazy archive symbol to the symbol table on ARM64EC (#113284)**
- **[lldb] Fix crash missing MSInheritanceAttr with DWARF on Windows (#112928)**
- **[CodeGen][NewPM] Port OptimizePHIs to NPM (#113433)**
- **[MCP] Optimize copies when src is used during backward propagation (#111130)**
- **[LoongArch] Merge base and offset for large offsets (#113277)**
- **[llvm-cxxfilt] De-emphasize "function" in llvm-cxxfilt docs and --help (#113309)**
- ** [CLANG][AArch64]Add Neon vectors for mfloat8_t (#99865)**
- **[lldb][CMake] If make isn't found, print a warning but don't error out (#111531)**
- **[clang-repl][CMake][MSVC] Wrap /EXPORT linker option for ICX (#112867)**
- **[clang] Make -fveclib={ArmPL,SLEEF} imply -fno-math-errno (#112580)**
- **[flang][OpenMP] Parse iterators, add to MAP clause, TODO for lowering (#113167)**
- **Revert "[PowerPC] Expand global named register support" (#113457)**
- **[PS5][Driver] Query `OPT_r`/`OPT_shared`/`OPT_static` just once (NFC) (#113452)**
- **[libc++][ranges] LWG4016: container-insertable checks do not match what container-inserter does (#113103)**
- **Reapply "[InstCombine] Folding `(icmp eq/ne (and X, -P2), INT_MIN)`" (#111236)**
- **[AArch64] Use INDEX for constant Neon step vectors (#113424)**
- **[mlir][Transforms] Dialect Conversion: Simplify materialization fn result type (#113031)**
- **[LLVM][AArch64] Add assembly/disassembly for FTMOPA and BFTMOPA (#113230)**
- **[LLVM][AArch64]Add assembly/disassembly for compare-and-branch  instr… (#113461)**
- **[FMV][AArch64] Unify aes with pmull and sve2-aes with sve2-pmull128. (#111673)**
- **[Bitcode] Get rid of compiler message (#113428)**
- **[ARM] Apply sign-return-address attribute to outlined function**
- **[compiler-rt][profile] Disable oneline-merging-windows.c on Windows on Arm**
- **[clang-tidy] Stop linking against clangSema (#113373)**
- **[PAC][lld] Fix reloc against adrp imm in PAC PLT header (#113429)**
- **[lldb] Cover all of SVE_TYPE in encoding switch**
- **[SystemZ] Introduce GNU and HLASM differences to asmwriter and update tests (#113369)**
- **[SandboxVectorizer] New class to actually collect and manage seeds (#113386)**
- **[llvm] Remove redundant calls to std::unique_ptr<T>::get (NFC) (#113415)**
- **[HLSL] Change StructuredBuffer resource class to SRV (#113397)**
- **[SLP]Small buidlvector only graph should contains scalars from same block**
- **[flang][cuda] Fix kernel registration (#113372)**
- **[NFC][LLVM][TableGen] Change `RecordKeeper::getClass` to return const pointer (#112261)**
- **[flang][OpenMP] Order clause AST nodes alphabetically, NFC (#113469)**
- **[WebAssembly] Implement the wide-arithmetic proposal (#111598)**
- **[libc++] Disallow std::prev(non_cpp17_bidi_iterator) (#112102)**
- **[clang-tidy][readability-container-contains] Fix matching of non-binaryOperator cases (#110386)**
- **[SLP]Expand vector to the whole register size in extracts adjustment**
- **[lit][aix] Always use internal lit shell on AIX (#113355)**
- **[gitattributes] Mark some llvm-rc inputs as requiring LF newlines (#113222)**
- **[compiler-rt] [test] Mark a couple files as requiring LF newlines**
- **[VPlan] Try to hoist Previous (and operands), if sinking fails for FORs. (#108945)**
- **[flang][cuda] Add entry point to launch cuda fortran kernel (#113490)**
- **[libc++] Add a escape hatch for making __libcpp_verbose_abort non-noexcept again (#113310)**
- **Revert "[lldb] Fix crash missing MSInheritanceAttr on CXXRecordDecl with DWARF on Windows" (#113498)**
- **Reapply "[libc++][C++03] Copy the LLVM 19 headers (#108999)" (#112127)**
- **[Legacy ThinLTO] NFC: Move helper class to an "Impl" namespace (#112846)**
- **[flang][cuda] Add specialized gpu.launch_func conversion (#113493)**
- **[rtsan] Add include guards around posix interceptors, tests (#113188)**
- **[NFC][WebAssembly] Inline var only used in assertion (#113507)**
- **[clang-format] Add KeepFormFeed option (#113268)**
- **Reland: [llvm-cov][WebAssembly] Read `__llvm_prf_names` from data segments (#112569)**
- **[VPlan] Introduce and use getVectorPreheader (NFC).**
- **[clang-format] Remove repeated `TabWidth` in Format.h**
- **[llvm] Support llvm::Any across shared libraries on windows (#108051)**
- **[SandboxIR] Add extern templates for GlobalWithNodeAPI (#111940)**
- **[DSE] Apply initializes attribute to DSE (#107282)**
- **[clang-tidy] Fix build error (NFC)**
- **[WPD][ThinLTO]Add cutoff option for WPD (#113383)**
- **[C++20][Modules] Quote header unit name in preprocessor output (-E) (#112883)**
- **replace 2 placeholder uses of undef with poison [NFC]**
- **[AArch64] Add assembly/disassembly for multi-vector AES instructions (#113307)**
- **[Clang] prevent assertion failure in value-dependent initializer expressions (#112612)**
- **Recommit: [llvm][ARM][GlobalOpt]Add widen global arrays pass  (#113289)**
- **[clang] Use {} instead of std::nullopt to initialize empty ArrayRef (#109399)**
- **[lldb][AArch64] Read fpmr register from core files (#110104)**
- **[lldb][AArch64] Add release note for AArch64 Linux FPMR register**
- **[AArch64] Allow single-element vector FP converts with +sme2p2 (#112905)**
- **[flang][debug] Support fir::ReferenceType. (#113480)**
- **[AArch64] Update feature dep. for Armv9.6 extensions (#113466)**
- **[flang][OpenMP] Parse AFFINITY clause, lowering not supported yet (#113485)**
- **[analyzer] Use dynamic type when invalidating by a member function call (#111138)**
- **Reland: [lldb] Fix crash missing MSInheritanceAttr with DWARF on Windows (#112928)**
- **[flang][debug] Fix array lower bounds in derived type members. (#113183)**
- **[mlir][vector] Fix a crash in `VectorToGPU` (#113454)**
- **[mlir] Apply ClangTidy performance finding**
- **[flang][debug] Support fir.vector type. (#112951)**
- **Fix MSVC not all control paths return a value warning. NFC.**
- **[X86] ReplaceNodeResults - adjust assert to allow XOP or GFNI subtargets to split i64 BITREVERSE nodes on 32-bit targets**
- **[libc] Pass through LIBC_CONF_MATH_OPTIMIZATIONS correctly (#113540)**
- **[PowerPC] Expand global named register support (#113482)**
- **[libc++] Remove workaround which allows setting _LIBCPP_OVERRIDABLE_FUNC_VIS externally (#113139)**
- **[GlobalMerge] Aggressively merge constants to reduce TOC entries (#111756)**
- **[libc++] Refactor vector::push_back to use vector::emplace (#113481)**
- **[cmake] Promote message when failing to find compiler-rt to warning (#111834)**
- **[NFC][compiler-rt] fix(compiler-rt/**.py): fix comparison to None (#94015)**
- **[SLP]Do not ignore undefs when trying to replace with "poisonous" shuffles**
- **[SystemZ] Update large ada tests after HLASM syntax change (#113578)**
- **[SLP]Do not check for clustered loads only**
- **[clang][analyzer][doc] Migrate ClangSA www FAQ section (#112831)**
- **[clang][analyzer][doc] Update Clang SA www docs index.html (#112833)**
- **Re-land: [ARM] Fix frame chains with M-profile PACBTI (#110285)**
- **Revert "[DSE] Apply initializes attribute to DSE" (#113589)**
- **[gn] port 6512a8d more**
- **[libc++] Exclude C++03 frozen headers from the modulemap (#113572)**
- **[gn] port 6512a8d yet more**
- **[SLP]Do correct signedness analysis for externally used scalars**
- **[gn] port 522f34cfff693fd3f (PPC AsmMatcher dep)**
- **[AArch64] Add assembly/disassembly for FRINT{32,64}{X,Z} (merging) (#113562)**
- **[gn build] Port 8a12e0131f3d**
- **[AArch64] Fix failure with inline asm and svcount (#112537)**
- **[MCParser] De-capitalize COFFAsmParser functions. NFC**
- **Unsupport flang/test/Driver/embed.f90 on Windows**
- **[OpenMP] Fix the test issue when `libomp` is built as a static library (#113522)**
- **[flang][OpenMP] Make Symbol::OmpFlagToClauseName static (#113586)**
- **Pass std::initializer_list by value to ArrayRef constructor. (#113590)**
- **[AArch64] Add assembly/disassembly for zeroing FRINT and FRECPX/FSQRT (#113543)**
- **Ensure !NDEBUG with LLVM_ENABLE_ABI_BREAKING_CHECKS does not segfault (#113588)**
- **[HLSL] Add RWStructuredBuffer definition to HLSLExternalSemaSource (#113477)**
- **[ORC] Add visibility macros to functions needed by lli and jitlink (#113271)**
- **[gn] disable building libc++ shared lib**
- **[FlowSensitive] Allow to dump nested RecordStorageLocation (#112457)**
- **[AArch64] Add support for Armv9.6-A FEAT_SPE_EXC and FEAT_TRBE_EXC (#113463)**
- **[CodeGen][NewPM] Make MFProperties methods const NFC (#113304)**
- **[NVPTX] add an optional early copy of byval arguments (#113384)**
- **[clang][dataflow] Disambiguate a ref to "internal" in CachedConstAccessorsLattice (#113601)**
- **[Legacy ThinLTO] NFC: Use explicit `static`; shrink anonymous namespace**
- **[DXIL] Add to LINK_COMPONENTS to fix BUILD_SHARED_LIBS build**
- **[compiler-rt] [test] Fix using toolchains that rely on Clang default configs (#113491)**
- **[runtimes] Probe for -nostdlib++ and -nostdinc++ with the C compiler (#108357)**
- **Reland "CFIFixup] Factor CFI remember/restore insertion into a helper (NFC)" (#113387)**
- **sanitizer_allocator.cpp: Ensure at least sizeof(void*) alignment**
- **[WebAssembly] Protect memory.fill and memory.copy from zero-length ranges. (#112617)**
- **[WebKit Checkers] Make TrivialFunctionAnalysis recognize std::array::operator[] as trivial (#113377)**
- **[VPlan] Update unit tests to use getVectorLoopRegion (NFC).**
- **[VPlan] Limit stride replacement to vector region and middle VPBB (NFC).**
- **[Support] Extend ExtensibleRTTI utility to support basic multiple inheritance. (#112643)**
- **[AMDGPU][MC] Fix disassembler problem for image_atomic with TFE (#112622)**
- **[gn] port a14a83d9a102**
- **[mlir] Convert `expand_shape` to more static form (#112265)**
- **Fix pointer to reference type (#113596)**
- **[runtimes] Allow building against an installed LLVM tree**
- **[aarch64] atan2 intrinsic lowering (p5) (#112611)**
- **[X86] Support MOVRS and AVX10.2 instructions. (#113274)**
- **[libc++] __uglify `[[clang::noescape]]` (#113280)**
- **[ThinLTO] Do not duplicate import a function that is actually defined in the current module #110064 (#111933)**
- **[lld][WebAssembly] Update datalayout strings to latest version**
- **[clang-format] Fix working -assume-filename with .clang-format-ignore (#113100)**
- **[BOLT] Set RawBranchCount in DataAggregator**
- **[BOLT] Add profile density computation**
- **[mlir] Fix bug in UnPackOp tiling implementation causing infinite loop (#113571)**
- **[clang-format][NFC] Use CLANG_SOURCE_DIR in CMakeLists**
- **Apply initializes attribute to DSE (#113630)**
- **[lldb] Move ValueObject into its own library (NFC) (#113393)**
- **[msan] Reduces overhead of #113200, by 10% (#113201)**
- **[LoongArch] fix description of clang option -m[no-]lam-bh (#113632)**
- **[MCParser] De-capitalize ParseDirectiveCGProfile. NFC**
- **[libc] Use idiomatic main() function in newhdrgen/yaml_to_classes.py (#113419)**
- **[clang-repl] Fix undefined lld::wasm::link symbol while building clangInterpreter for wasm (#113446)**
- **[MCParser] De-capitalize COFFMasmParser functions. NFC**
- **Revert "[runtimes] Probe for -nostdlib++ and -nostdinc++ with the C compiler" (#113653)**
- **[Driver] Use != instead of compare to compare strings (NFC) (#113651)**
- **[flang] Integrate the option -flang-experimental-integer-overflow into -fno-wrapv (#110063)**
- **[Scalarizer] Fix to only scalarize if intrinsic was marked as isTriviallyScalarizable (#113625)**
- **[gn] port 105d54726b1d7 (lldbValueObject)**
- **[gn] port 105d54726b1d7 more**
- **[gn] port b1be21394e9c**
- **[Clang] Enhance handling of [[deprecated]] attribute diagnostics for local variables (#113575)**
- **[RISCV] Add Smrnmi extension (#111668)**
- **Reapply " [XRay] Add support for instrumentation of DSOs on x86_64 (#90959)" (#113548)**
- **[ARM] Re-generate a test**
- **[ARM] Fix comment typo**
- **[ARM] Add debug trace for tail-call optimisation**
- **[ARM] Tail-calls do not require caller and callee arguments to match**
- **[ARM] Allow functions with sret returns to be tail-called**
- **[ARM] Allow tail calls with byval args**
- **[Clang] Always forward sret parameters to musttail calls**
- **[ARM] Avoid clobbering byval arguments when passing to tail-calls**
- **[ARM] Optimise byval arguments in tail-calls**
- **[AArch64] Add support for Armv9.6-A FEAT_PoPS architecture extension (#113496)**
- **[libc++] Granularize <vector> (#99705)**
- **[libc] Fix fexcept_t type to match canonical ABI and API**
