### PR TITLE
[LoongArch][MC] Handle more PseudoLA* instructions with la-global-with-abs feature

### DIFF
--- a/libc/include/llvm-libc-types/fexcept_t.h
+++ b/libc/include/llvm-libc-types/fexcept_t.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_TYPES_FEXCEPT_T_H
 #define LLVM_LIBC_TYPES_FEXCEPT_T_H
 
-typedef int fexcept_t;
+#if defined(__x86_64__) || defined(__i386__)
+typedef unsigned short int fexcept_t;
+#else
+typedef unsigned int fexcept_t;
+#endif
 
 #endif // LLVM_LIBC_TYPES_FEXCEPT_T_H


### PR DESCRIPTION
This is to align with GAS. Additionally, there are some minor changes:
the definition and expansion process of the TLS_DESC pseudo-instruction
were modified in the same style.

Reviewed By: heiher

Pull Request: https://github.com/llvm/llvm-project/pull/112858
