### PR TITLE
[libc] Fix fexcept_t type to match canonical ABI and API

### DIFF
--- a/libc/include/llvm-libc-types/fexcept_t.h
+++ b/libc/include/llvm-libc-types/fexcept_t.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_TYPES_FEXCEPT_T_H
 #define LLVM_LIBC_TYPES_FEXCEPT_T_H
 
-typedef int fexcept_t;
+#if defined(__x86_64__) || defined(__i386__)
+typedef unsigned short int fexcept_t;
+#else
+typedef unsigned int fexcept_t;
+#endif
 
 #endif // LLVM_LIBC_TYPES_FEXCEPT_T_H


### PR DESCRIPTION
In glibc and musl, fexcept_t is unsigned short int on x86 and
unsigned int on other machines that llvm-libc supports.  Match
that ABI (only different from before on x86) and API (different
everywhere as it was previously signed).
