### PR TITLE
[libc++] Refactor locale_guard

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -496,11 +496,11 @@ set(files
   __locale_dir/locale_base_api/bsd_locale_fallbacks.h
   __locale_dir/locale_base_api/fuchsia.h
   __locale_dir/locale_base_api/ibm.h
-  __locale_dir/locale_base_api/locale_guard.h
   __locale_dir/locale_base_api/musl.h
   __locale_dir/locale_base_api/newlib.h
   __locale_dir/locale_base_api/openbsd.h
   __locale_dir/locale_base_api/win32.h
+  __locale_dir/locale_guard.h
   __math/abs.h
   __math/copysign.h
   __math/error_functions.h

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
@@ -13,7 +13,7 @@
 #ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_BSD_LOCALE_FALLBACKS_H
 #define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_BSD_LOCALE_FALLBACKS_H
 
-#include <__locale_dir/locale_base_api/locale_guard.h>
+#include <__locale_dir/locale_guard.h>
 #include <cstdio>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -29,64 +29,64 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 inline _LIBCPP_HIDE_FROM_ABI decltype(MB_CUR_MAX) __libcpp_mb_cur_max_l(locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return MB_CUR_MAX;
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI wint_t __libcpp_btowc_l(int __c, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return btowc(__c);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI int __libcpp_wctob_l(wint_t __c, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return wctob(__c);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI size_t
 __libcpp_wcsnrtombs_l(char* __dest, const wchar_t** __src, size_t __nwc, size_t __len, mbstate_t* __ps, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return wcsnrtombs(__dest, __src, __nwc, __len, __ps);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_wcrtomb_l(char* __s, wchar_t __wc, mbstate_t* __ps, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return wcrtomb(__s, __wc, __ps);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI size_t
 __libcpp_mbsnrtowcs_l(wchar_t* __dest, const char** __src, size_t __nms, size_t __len, mbstate_t* __ps, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return mbsnrtowcs(__dest, __src, __nms, __len, __ps);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI size_t
 __libcpp_mbrtowc_l(wchar_t* __pwc, const char* __s, size_t __n, mbstate_t* __ps, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return mbrtowc(__pwc, __s, __n, __ps);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI int __libcpp_mbtowc_l(wchar_t* __pwc, const char* __pmb, size_t __max, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return mbtowc(__pwc, __pmb, __max);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_mbrlen_l(const char* __s, size_t __n, mbstate_t* __ps, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return mbrlen(__s, __n, __ps);
 }
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
 
 inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return localeconv();
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI size_t
 __libcpp_mbsrtowcs_l(wchar_t* __dest, const char** __src, size_t __len, mbstate_t* __ps, locale_t __l) {
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   return mbsrtowcs(__dest, __src, __len, __ps);
 }
 #endif
@@ -95,7 +95,7 @@ inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 4, 5) int __libcpp_snprintf_l(
     char* __s, size_t __n, locale_t __l, const char* __format, ...) {
   va_list __va;
   va_start(__va, __format);
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   int __res = vsnprintf(__s, __n, __format, __va);
   va_end(__va);
   return __res;
@@ -105,7 +105,7 @@ inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 3, 4) int __libcpp_asprintf_l(
     char** __s, locale_t __l, const char* __format, ...) {
   va_list __va;
   va_start(__va, __format);
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   int __res = vasprintf(__s, __format, __va);
   va_end(__va);
   return __res;
@@ -115,7 +115,7 @@ inline _LIBCPP_ATTRIBUTE_FORMAT(__scanf__, 3, 4) int __libcpp_sscanf_l(
     const char* __s, locale_t __l, const char* __format, ...) {
   va_list __va;
   va_start(__va, __format);
-  __libcpp_locale_guard __current(__l);
+  __locale_guard __current(__l);
   int __res = vsscanf(__s, __format, __va);
   va_end(__va);
   return __res;

--- a/libcxx/include/__locale_dir/locale_guard.h
+++ b/libcxx/include/__locale_dir/locale_guard.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_LOCALE_GUARD_H
-#define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_LOCALE_GUARD_H
+#ifndef _LIBCPP___LOCALE_DIR_LOCALE_GUARD_H
+#define _LIBCPP___LOCALE_DIR_LOCALE_GUARD_H
 
 #include <__config>
 #include <__locale> // for locale_t
@@ -19,23 +19,9 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if !defined(_LIBCPP_LOCALE__L_EXTENSIONS)
-struct __libcpp_locale_guard {
-  _LIBCPP_HIDE_FROM_ABI __libcpp_locale_guard(locale_t& __loc) : __old_loc_(uselocale(__loc)) {}
-
-  _LIBCPP_HIDE_FROM_ABI ~__libcpp_locale_guard() {
-    if (__old_loc_)
-      uselocale(__old_loc_);
-  }
-
-  locale_t __old_loc_;
-
-  __libcpp_locale_guard(__libcpp_locale_guard const&)            = delete;
-  __libcpp_locale_guard& operator=(__libcpp_locale_guard const&) = delete;
-};
-#elif defined(_LIBCPP_MSVCRT_LIKE)
-struct __libcpp_locale_guard {
-  __libcpp_locale_guard(locale_t __l) : __status(_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)) {
+#if defined(_LIBCPP_MSVCRT_LIKE)
+struct __locale_guard {
+  __locale_guard(locale_t __l) : __status(_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)) {
     // Setting the locale can be expensive even when the locale given is
     // already the current locale, so do an explicit check to see if the
     // current locale is already the one we want.
@@ -51,7 +37,7 @@ struct __libcpp_locale_guard {
       __setlocale(__l.__get_locale());
     }
   }
-  ~__libcpp_locale_guard() {
+  ~__locale_guard() {
     // The CRT documentation doesn't explicitly say, but setlocale() does the
     // right thing when given a semicolon-separated list of locale settings
     // for the different categories in the same format as returned by
@@ -71,8 +57,22 @@ struct __libcpp_locale_guard {
   int __status;
   char* __locale_all = nullptr;
 };
+#else
+struct __locale_guard {
+  _LIBCPP_HIDE_FROM_ABI __locale_guard(locale_t& __loc) : __old_loc_(uselocale(__loc)) {}
+
+  _LIBCPP_HIDE_FROM_ABI ~__locale_guard() {
+    if (__old_loc_)
+      uselocale(__old_loc_);
+  }
+
+  locale_t __old_loc_;
+
+  __locale_guard(__locale_guard const&)            = delete;
+  __locale_guard& operator=(__locale_guard const&) = delete;
+};
 #endif
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_LOCALE_GUARD_H
+#endif // _LIBCPP___LOCALE_DIR_LOCALE_GUARD_H

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1443,7 +1443,7 @@ module std [system] {
   module locale {
     header "locale"
     header "__locale_dir/locale_base_api.h"
-    header "__locale_dir/locale_base_api/locale_guard.h"
+    header "__locale_dir/locale_guard.h"
     module locale_base_api {
       textual header "__locale_dir/locale_base_api/android.h"
       textual header "__locale_dir/locale_base_api/bsd_locale_defaults.h"

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -12,7 +12,7 @@
 #include <string>
 
 #ifdef _LIBCPP_MSVCRT_LIKE
-#  include <__locale_dir/locale_base_api/locale_guard.h>
+#  include <__locale_dir/locale_guard.h>
 #endif
 
 #define _str(s) #s
@@ -109,7 +109,7 @@ static void force_locale_initialization() {
   static bool once = []() {
     auto loc = newlocale(LC_ALL_MASK, "C", 0);
     {
-      __libcpp_locale_guard g(loc); // forces initialization of locale TLS
+      __locale_guard g(loc); // forces initialization of locale TLS
       ((void)g);
     }
     freelocale(loc);

--- a/libcxx/src/support/win32/locale_win32.cpp
+++ b/libcxx/src/support/win32/locale_win32.cpp
@@ -11,11 +11,9 @@
 #include <memory>
 #include <type_traits>
 
-#include <__locale_dir/locale_base_api/locale_guard.h>
+#include <__locale_dir/locale_guard.h>
 
 int __libcpp_vasprintf(char** sptr, const char* __restrict fmt, va_list ap);
-
-using std::__libcpp_locale_guard;
 
 // FIXME: base and mask currently unused. Needs manual work to construct the new locale
 locale_t newlocale(int /*mask*/, const char* locale, locale_t /*base*/) {
@@ -26,33 +24,33 @@ decltype(MB_CUR_MAX) MB_CUR_MAX_L(locale_t __l) {
 #if defined(_LIBCPP_MSVCRT)
   return ___mb_cur_max_l_func(__l);
 #else
-  __libcpp_locale_guard __current(__l);
+  std::__locale_guard __current(__l);
   return MB_CUR_MAX;
 #endif
 }
 
 lconv* localeconv_l(locale_t& loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   lconv* lc = localeconv();
   if (!lc)
     return lc;
   return loc.__store_lconv(lc);
 }
 size_t mbrlen_l(const char* __restrict s, size_t n, mbstate_t* __restrict ps, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return mbrlen(s, n, ps);
 }
 size_t
 mbsrtowcs_l(wchar_t* __restrict dst, const char** __restrict src, size_t len, mbstate_t* __restrict ps, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return mbsrtowcs(dst, src, len, ps);
 }
 size_t wcrtomb_l(char* __restrict s, wchar_t wc, mbstate_t* __restrict ps, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return wcrtomb(s, wc, ps);
 }
 size_t mbrtowc_l(wchar_t* __restrict pwc, const char* __restrict s, size_t n, mbstate_t* __restrict ps, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return mbrtowc(pwc, s, n, ps);
 }
 size_t mbsnrtowcs_l(wchar_t* __restrict dst,
@@ -61,7 +59,7 @@ size_t mbsnrtowcs_l(wchar_t* __restrict dst,
                     size_t len,
                     mbstate_t* __restrict ps,
                     locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return mbsnrtowcs(dst, src, nms, len, ps);
 }
 size_t wcsnrtombs_l(char* __restrict dst,
@@ -70,15 +68,15 @@ size_t wcsnrtombs_l(char* __restrict dst,
                     size_t len,
                     mbstate_t* __restrict ps,
                     locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return wcsnrtombs(dst, src, nwc, len, ps);
 }
 wint_t btowc_l(int c, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return btowc(c);
 }
 int wctob_l(wint_t c, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return wctob(c);
 }
 
@@ -90,7 +88,7 @@ int snprintf_l(char* ret, size_t n, locale_t loc, const char* format, ...) {
   int result = __stdio_common_vsprintf(
       _CRT_INTERNAL_LOCAL_PRINTF_OPTIONS | _CRT_INTERNAL_PRINTF_STANDARD_SNPRINTF_BEHAVIOR, ret, n, format, loc, ap);
 #else
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   _LIBCPP_DIAGNOSTIC_PUSH
   _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
   int result = vsnprintf(ret, n, format, ap);
@@ -108,25 +106,25 @@ int asprintf_l(char** ret, locale_t loc, const char* format, ...) {
   return result;
 }
 int vasprintf_l(char** ret, locale_t loc, const char* format, va_list ap) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return __libcpp_vasprintf(ret, format, ap);
 }
 
 #if !defined(_LIBCPP_MSVCRT)
 float strtof_l(const char* nptr, char** endptr, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return strtof(nptr, endptr);
 }
 
 long double strtold_l(const char* nptr, char** endptr, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return strtold(nptr, endptr);
 }
 #endif
 
 #if defined(__MINGW32__) && __MSVCRT_VERSION__ < 0x0800
 size_t strftime_l(char* ret, size_t n, const char* format, const struct tm* tm, locale_t loc) {
-  __libcpp_locale_guard __current(loc);
+  std::__locale_guard __current(loc);
   return strftime(ret, n, format, tm);
 }
 #endif


### PR DESCRIPTION
Rename __libcpp_locale_guard to just __locale_guard, since there's no reason for it to have __libcpp_ in its name -- it's just an internal utility.

Also, define __locale_guard unconditionally of _LIBCPP_LOCALE__L_EXTENSIONS, since that header is only used on Windows (where it has a custom definition) or from bsd_locale_fallbacks.h, which is only included when the L extensions are not provided.