### PR TITLE
[rtsan][NFC] Put in comment describing why freeing a nullptr is safe

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -431,9 +431,12 @@ INTERCEPTOR(void, free, void *ptr) {
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
 
-  if (ptr != NULL) {
+  // According to the C and C++ standard, freeing a nullptr is guaranteed to be
+  // a no-op (and thus real-time safe). This can be confirmed for looking at
+  // __libc_free in the glibc source.
+  if (ptr != nullptr)
     __rtsan_notify_intercepted_call("free");
-  }
+
   return REAL(free)(ptr);
 }
 


### PR DESCRIPTION
Just documenting this for future devs.

Also moved to `nullptr` and deleted unnecessary braces as per the coding standard. 


A few sources:
https://en.cppreference.com/w/c/memory/free (search for "function does nothing")

https://www.open-std.org/JTC1/SC22/wg14/www/docs/n1124.pdf
> The free function causes the space pointed to by ptr to be deallocated, that is, made
available for further allocation. If ptr is a null pointer, no action occurs

https://github.com/bminor/glibc/blob/c5dd659f22058bf9b371ab1cba07631f1206c674/malloc/malloc.c#L3363-L3364