### PR TITLE
[clang][deps] Improve timing output

### DIFF
--- a/clang/test/ClangScanDeps/print-timing.c
+++ b/clang/test/ClangScanDeps/print-timing.c
@@ -3,7 +3,8 @@
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -print-timing > %t/result.json 2>%t/errs
 // RUN: cat %t/errs | FileCheck %s
-// CHECK: clang-scan-deps timing: {{[0-9]+}}.{{[0-9][0-9]}}s wall, {{[0-9]+}}.{{[0-9][0-9]}}s process
+// CHECK:      wall time [s]              process time [s]           instruction count
+// CHECK-NEXT: {{[0-9]+}}.{{([0-9]{4})}}  {{[0-9]+}}.{{([0-9]{4})}}  {{[0-9]+}}
 
 //--- cdb.json
 []

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -88,7 +88,6 @@ static bool DeprecatedDriverCommand;
 static ResourceDirRecipeKind ResourceDirRecipe;
 static bool Verbose;
 static bool PrintTiming;
-static bool NoPrintTimingHeader;
 static llvm::BumpPtrAllocator Alloc;
 static llvm::StringSaver Saver{Alloc};
 static std::vector<const char *> CommandLine;
@@ -221,7 +220,6 @@ static void ParseArgs(int argc, char **argv) {
   }
 
   PrintTiming = Args.hasArg(OPT_print_timing);
-  NoPrintTimingHeader = Args.hasArg(OPT_no_print_timing_header);
 
   Verbose = Args.hasArg(OPT_verbose);
 
@@ -1083,10 +1081,9 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
                  << NumIsLocalCalls << " isLocal() calls\n";
 
   if (PrintTiming) {
-    if (!NoPrintTimingHeader)
-      llvm::errs() << "wall time [s]\t"
-                   << "process time [s]\t"
-                   << "instruction count\n";
+    llvm::errs() << "wall time [s]\t"
+                 << "process time [s]\t"
+                 << "instruction count\n";
     const llvm::TimeRecord &R = T.getTotalTime();
     llvm::errs() << llvm::format("%0.4f", R.getWallTime()) << "\t"
                  << llvm::format("%0.4f", R.getProcessTime()) << "\t"

--- a/clang/tools/clang-scan-deps/Opts.td
+++ b/clang/tools/clang-scan-deps/Opts.td
@@ -34,6 +34,7 @@ def deprecated_driver_command : F<"deprecated-driver-command", "use a single dri
 defm resource_dir_recipe : Eq<"resource-dir-recipe", "How to produce missing '-resource-dir' argument">;
 
 def print_timing : F<"print-timing", "Print timing information">;
+def no_print_timing_header : F<"no-print-timing-header", "Do not print the timing information header">;
 
 def verbose : F<"v", "Use verbose output">;
 

--- a/clang/tools/clang-scan-deps/Opts.td
+++ b/clang/tools/clang-scan-deps/Opts.td
@@ -34,7 +34,6 @@ def deprecated_driver_command : F<"deprecated-driver-command", "use a single dri
 defm resource_dir_recipe : Eq<"resource-dir-recipe", "How to produce missing '-resource-dir' argument">;
 
 def print_timing : F<"print-timing", "Print timing information">;
-def no_print_timing_header : F<"no-print-timing-header", "Do not print the timing information header">;
 
 def verbose : F<"v", "Use verbose output">;
 


### PR DESCRIPTION
This patch adds the number of executed instructions into the timing output, which provides more stable results compared to wall or process time.

The format itself is also tweaked so that it's more amenable for direct import into a spreadsheet editor.