### PR TITLE
[libc++] Split Apple and Freebsd locale support into their own headers

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -492,8 +492,10 @@ set(files
   __locale
   __locale_dir/locale_base_api.h
   __locale_dir/locale_base_api/android.h
+  __locale_dir/locale_base_api/apple.h
   __locale_dir/locale_base_api/bsd_locale_defaults.h
   __locale_dir/locale_base_api/bsd_locale_fallbacks.h
+  __locale_dir/locale_base_api/freebsd.h
   __locale_dir/locale_base_api/fuchsia.h
   __locale_dir/locale_base_api/ibm.h
   __locale_dir/locale_base_api/musl.h

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -21,8 +21,10 @@
 #  include <__locale_dir/locale_base_api/fuchsia.h>
 #elif defined(__wasi__) || defined(_LIBCPP_HAS_MUSL_LIBC)
 #  include <__locale_dir/locale_base_api/musl.h>
-#elif defined(__APPLE__) || defined(__FreeBSD__)
-#  include <xlocale.h>
+#elif defined(__APPLE__)
+#  include <__locale_dir/locale_base_api/apple.h>
+#elif defined(__FreeBSD__)
+#  include <__locale_dir/locale_base_api/freebsd.h>
 #endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__locale_dir/locale_base_api/apple.h
+++ b/libcxx/include/__locale_dir/locale_base_api/apple.h
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//===-----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_APPLE_H
+#define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_APPLE_H
+
+#include <xlocale.h>
+
+#endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_APPLE_H

--- a/libcxx/include/__locale_dir/locale_base_api/freebsd.h
+++ b/libcxx/include/__locale_dir/locale_base_api/freebsd.h
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//===-----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_FREEBSD_H
+#define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_FREEBSD_H
+
+#include <xlocale.h>
+
+#endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_FREEBSD_H

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1446,8 +1446,10 @@ module std [system] {
     header "__locale_dir/locale_guard.h"
     module locale_base_api {
       textual header "__locale_dir/locale_base_api/android.h"
+      textual header "__locale_dir/locale_base_api/apple.h"
       textual header "__locale_dir/locale_base_api/bsd_locale_defaults.h"
       textual header "__locale_dir/locale_base_api/bsd_locale_fallbacks.h"
+      textual header "__locale_dir/locale_base_api/freebsd.h"
       textual header "__locale_dir/locale_base_api/fuchsia.h"
       textual header "__locale_dir/locale_base_api/ibm.h"
       textual header "__locale_dir/locale_base_api/musl.h"


### PR DESCRIPTION
For now these headers don't provide much benefit, however as we refactor the locale base API they will provide a location to specify the localization interface on these platforms.