### PR TITLE
InstCombine: Fold shufflevector(select) and shufflevector(phi)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -2902,8 +2902,7 @@ Instruction *InstCombinerImpl::visitShuffleVectorInst(ShuffleVectorInst &SVI) {
 
   if (Constant *C = dyn_cast<Constant>(RHS)) {
     if (SelectInst *SI = dyn_cast<SelectInst>(LHS)) {
-      if (Instruction *I =
-              FoldOpIntoSelect(SVI, SI, /*FoldWithMultiUse=*/false))
+      if (Instruction *I = FoldOpIntoSelect(SVI, SI))
         return I;
     }
     if (PHINode *PN = dyn_cast<PHINode>(LHS)) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -2900,6 +2900,17 @@ Instruction *InstCombinerImpl::visitShuffleVectorInst(ShuffleVectorInst &SVI) {
   if (Instruction *I = foldIdentityPaddedShuffles(SVI))
     return I;
 
+  if (Constant *C = dyn_cast<Constant>(RHS)) {
+    if (SelectInst *SI = dyn_cast<SelectInst>(LHS)) {
+      if (Instruction *I = FoldOpIntoSelect(SVI, SI, /*FoldWIthMultiUse=*/false))
+        return I;
+    }
+    if (PHINode *PN = dyn_cast<PHINode>(LHS)) {
+      if (Instruction *I = foldOpIntoPhi(SVI, PN))
+        return I;
+    }
+  }
+
   if (match(RHS, m_Poison()) && canEvaluateShuffled(LHS, Mask)) {
     Value *V = evaluateInDifferentElementOrder(LHS, Mask, Builder);
     return replaceInstUsesWith(SVI, V);

--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -2902,7 +2902,8 @@ Instruction *InstCombinerImpl::visitShuffleVectorInst(ShuffleVectorInst &SVI) {
 
   if (Constant *C = dyn_cast<Constant>(RHS)) {
     if (SelectInst *SI = dyn_cast<SelectInst>(LHS)) {
-      if (Instruction *I = FoldOpIntoSelect(SVI, SI, /*FoldWIthMultiUse=*/false))
+      if (Instruction *I =
+              FoldOpIntoSelect(SVI, SI, /*FoldWithMultiUse=*/false))
         return I;
     }
     if (PHINode *PN = dyn_cast<PHINode>(LHS)) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -2900,12 +2900,12 @@ Instruction *InstCombinerImpl::visitShuffleVectorInst(ShuffleVectorInst &SVI) {
   if (Instruction *I = foldIdentityPaddedShuffles(SVI))
     return I;
 
-  if (Constant *C = dyn_cast<Constant>(RHS)) {
-    if (SelectInst *SI = dyn_cast<SelectInst>(LHS)) {
+  if (match(RHS, m_Constant())) {
+    if (auto *SI = dyn_cast<SelectInst>(LHS)) {
       if (Instruction *I = FoldOpIntoSelect(SVI, SI))
         return I;
     }
-    if (PHINode *PN = dyn_cast<PHINode>(LHS)) {
+    if (auto *PN = dyn_cast<PHINode>(LHS)) {
       if (Instruction *I = foldOpIntoPhi(SVI, PN))
         return I;
     }


### PR DESCRIPTION
- Transform `shufflevector(select(c, x, y), C)` to
  `select(c, shufflevector(x, C), shufflevector(y, C))` by re-using
  the `FoldOpIntoSelect` helper.
- Transform `shufflevector(phi(x, y), C)` to
  `phi(shufflevector(x, C), shufflevector(y, C))` by re-using the
  `foldOpInotPhi` helper.
