### PR TITLE
[mlir] Fix build

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2848,7 +2848,7 @@ SmallVector<Value> TypeConverter::materializeTargetConversion(
         fn(builder, resultTypes, inputs, loc, originalType);
     if (result.empty())
       continue;
-    assert(TypeRange(result) == resultTypes &&
+    assert(TypeRange(ValueRange(result)) == resultTypes &&
            "callback produced incorrect number of values or values with "
            "incorrect types");
     return result;


### PR DESCRIPTION
```
mlir/lib/Transforms/Utils/DialectConversion.cpp:2851:28: error: call of overloaded ‘TypeRange(llvm::SmallVector<mlir::Value>&)’ is ambiguous
     assert(TypeRange(result) == resultTypes &&
```
