### PR TITLE
Expose format (attribute) info for function declarations in Clang Index API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ pythonenv*
 /clang/utils/analyzer/projects/*/RefScanBuildResults
 # automodapi puts generated documentation files here.
 /lldb/docs/python_api/
+silver-debug
+silver-build

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -3110,6 +3110,29 @@ CINDEX_LINKAGE int clang_getFieldDeclBitWidth(CXCursor C);
 CINDEX_LINKAGE int clang_Cursor_getNumArguments(CXCursor C);
 
 /**
+ * Retrieve FormatAttr on function declaration
+ */
+CINDEX_LINKAGE CXCursor clang_Cursor_getFormatAttr   (CXCursor cur);
+
+/**
+ * Retrieve string name of the type of formatting (i.e. scanf or printf)
+ * used with clang_Cursor_getFormatAttr
+ */
+CINDEX_LINKAGE CXString clang_FormatAttr_getType     (CXCursor C);
+
+/**
+ * Retrieve the arg location (0-based) of the template C-string
+ * used with clang_Cursor_getFormatAttr
+ */
+CINDEX_LINKAGE unsigned clang_FormatAttr_getFormatIdx(CXCursor C);
+
+/**
+ * Retrieve the arg location to the first format argument
+ * used with clang_Cursor_getFormatAttr
+ */
+CINDEX_LINKAGE unsigned clang_FormatAttr_getFirstArg (CXCursor C);
+
+/**
  * Retrieve the argument cursor of a function or method.
  *
  * The argument cursor can be determined for calls as well as for declarations

--- a/clang/tools/libclang/CXCursor.cpp
+++ b/clang/tools/libclang/CXCursor.cpp
@@ -1330,6 +1330,32 @@ CXTranslationUnit clang_Cursor_getTranslationUnit(CXCursor cursor) {
   return getCursorTU(cursor);
 }
 
+CXCursor clang_Cursor_getFormatAttr(CXCursor cur) {
+  const Decl *decl = cxcursor::getCursorDecl(cur);
+  if (const FunctionDecl *fd = dyn_cast_or_null<FunctionDecl>(decl))
+    if (const FormatAttr *fa = fd->getAttr<FormatAttr>())
+      return cxcursor::MakeCXCursor(fa, decl, cxcursor::getCursorTU(cur)); // cursor with FormatAttr
+  return clang_getNullCursor();
+}
+
+CXString clang_FormatAttr_getType(CXCursor cur) {
+  const FormatAttr *fa = dyn_cast_or_null<FormatAttr>(cxcursor::getCursorAttr(cur));
+  if (!fa) return cxstring::createEmpty();
+  return cxstring::createDup(fa->getType()->getName());
+}
+
+unsigned clang_FormatAttr_getFormatIdx(CXCursor cur) {
+  const FormatAttr *fa = dyn_cast_or_null<FormatAttr>(cxcursor::getCursorAttr(cur));
+  if (!fa) return 0;
+  return fa->getFormatIdx();
+}
+
+unsigned clang_FormatAttr_getFirstArg(CXCursor cur) {
+  const FormatAttr *fa = dyn_cast_or_null<FormatAttr>(cxcursor::getCursorAttr(cur));
+  if (!fa) return 0;
+  return fa->getFirstArg();
+}
+
 int clang_Cursor_getNumArguments(CXCursor C) {
   if (clang_isDeclaration(C.kind)) {
     const Decl *D = cxcursor::getCursorDecl(C);

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -59,6 +59,10 @@ LLVM_13 {
     clang_Cursor_getMangling;
     clang_Cursor_getModule;
     clang_Cursor_getNumArguments;
+    clang_Cursor_getFormatAttr;
+    clang_FormatAttr_getType;
+    clang_FormatAttr_getFormatIdx;
+    clang_FormatAttr_getFirstArg;
     clang_Cursor_getNumTemplateArguments;
     clang_Cursor_getObjCDeclQualifiers;
     clang_Cursor_getObjCManglings;


### PR DESCRIPTION
Exposes 4 new clang CX functions for use when looking at header information on function declarations (context: CXCursor_FunctionDecl)

    clang_Cursor_getFormatAttr
	Get FormatAttr at Function Declaration
        If no FormatAttr available, returns null cursor

    When cursor is not null (call clang_Cursor_isNull), we may call the following:

    clang_FormatAttr_getType
	Get the format-type field for FormatAttr (i.e. printf, scanf)

    clang_FormatAttr_getFormatIdx
	Get the arg index of format template C-string

    clang_FormatAttr_getFirstArg
	Get the arg index of first arg for formatting params


The development purpose of change was to enable the silver compiler (LLVM IR C API) to know context information on imported C functions, so it may convert arguments with more context, and no manual tables describing this information.

The change simply leverages LLVM's FormatAttr data that is already present so Clang Index users may parse C more effectively