### PR TITLE
[Remarks] Fix missing include in HotnessThresholdParser for Expected

### DIFF
--- a/llvm/include/llvm/Remarks/HotnessThresholdParser.h
+++ b/llvm/include/llvm/Remarks/HotnessThresholdParser.h
@@ -16,6 +16,7 @@
 #define LLVM_REMARKS_HOTNESSTHRESHOLDPARSER_H
 
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Error.h"
 #include <optional>
 
 namespace llvm {


### PR DESCRIPTION
The use of Expected<> requires llvm/Support/Error.h to be included.