### PR TITLE
[libc++] Use proper functions instead of macros in bsd_locale_defaults.h

### DIFF
--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -54,7 +54,7 @@ size_t __libcpp_mbsnrtowcs_l(wchar_t* dest, const char** src, size_t max_out, si
 size_t __libcpp_mbrtowc_l(wchar_t* dest, cosnt char* src, size_t count, mbstate_t*, locale_t);
 int __libcpp_mbtowc_l(wchar_t* dest, const char* src, size_t count, locale_t);
 size_t __libcpp_mbrlen_l(const char* str, size_t count, mbstate_t*, locale_t);
-lconv* __libcpp_localeconv_l(locale_t);
+lconv* __libcpp_localeconv_l(locale_t&);
 size_t __libcpp_mbsrtowcs_l(wchar_t* dest, const char** src, size_t len, mbstate_t*, locale_t);
 int __libcpp_snprintf_l(char* dest, size_t buff_size, locale_t, const char* format, ...);
 int __libcpp_asprintf_l(char** dest, locale_t, const char* format, ...);

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -54,6 +54,7 @@ size_t __libcpp_mbsnrtowcs_l(wchar_t* dest, const char** src, size_t max_out, si
 size_t __libcpp_mbrtowc_l(wchar_t* dest, cosnt char* src, size_t count, mbstate_t*, locale_t);
 int __libcpp_mbtowc_l(wchar_t* dest, const char* src, size_t count, locale_t);
 size_t __libcpp_mbrlen_l(const char* str, size_t count, mbstate_t*, locale_t);
+// TODO: __libcpp_localeconv_l shouldn't take a reference, but the Windows implementation doesn't allow copying locale_t
 lconv* __libcpp_localeconv_l(locale_t&);
 size_t __libcpp_mbsrtowcs_l(wchar_t* dest, const char** src, size_t len, mbstate_t*, locale_t);
 int __libcpp_snprintf_l(char* dest, size_t buff_size, locale_t, const char* format, ...);

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -9,6 +9,8 @@
 #ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H
 #define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H
 
+#include <__config>
+
 #if defined(_LIBCPP_MSVCRT_LIKE)
 #  include <__locale_dir/locale_base_api/win32.h>
 #elif defined(_AIX) || defined(__MVS__)
@@ -25,6 +27,12 @@
 #  include <__locale_dir/locale_base_api/apple.h>
 #elif defined(__FreeBSD__)
 #  include <__locale_dir/locale_base_api/freebsd.h>
+#endif
+
+#ifdef _LIBCPP_LOCALE__L_EXTENSIONS
+#  include <__locale_dir/locale_base_api/bsd_locale_defaults.h>
+#else
+#  include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>
 #endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
@@ -82,33 +82,33 @@ __libcpp_mbsrtowcs_l(wchar_t* __dest, const char** __src, size_t __len, mbstate_
 }
 #endif
 
+_LIBCPP_DIAGNOSTIC_PUSH
+_LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wgcc-compat")
+_LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral") // GCC doesn't support [[gnu::format]] on variadic templates
+#ifdef _LIBCPP_COMPILER_CLANG_BASED
+#  define _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(...) _LIBCPP_ATTRIBUTE_FORMAT(__VA_ARGS__)
+#else
+#  define _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT
+#endif
+
 template <class... _Args>
-_LIBCPP_HIDE_FROM_ABI int
-__libcpp_snprintf_l(char* __s, size_t __n, locale_t __loc, const char* __format, _Args&&... __args) {
-  _LIBCPP_DIAGNOSTIC_PUSH
-  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
-  _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(__printf__, 4, 5) int __libcpp_snprintf_l(
+    char* __s, size_t __n, locale_t __loc, const char* __format, _Args&&... __args) {
   return ::snprintf_l(__s, __n, __loc, __format, std::forward<_Args>(__args)...);
-  _LIBCPP_DIAGNOSTIC_POP
 }
 
 template <class... _Args>
-_LIBCPP_HIDE_FROM_ABI int __libcpp_asprintf_l(char** __s, locale_t __loc, const char* __format, _Args&&... __args) {
-  _LIBCPP_DIAGNOSTIC_PUSH
-  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
-  _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(__printf__, 3, 4) int __libcpp_asprintf_l(
+    char** __s, locale_t __loc, const char* __format, _Args&&... __args) {
   return ::asprintf_l(__s, __loc, __format, std::forward<_Args>(__args)...);
-  _LIBCPP_DIAGNOSTIC_POP
 }
 
 template <class... _Args>
-_LIBCPP_HIDE_FROM_ABI int __libcpp_sscanf_l(const char* __s, locale_t __loc, const char* __format, _Args&&... __args) {
-  _LIBCPP_DIAGNOSTIC_PUSH
-  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
-  _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(__scanf__, 3, 4) int __libcpp_sscanf_l(
+    const char* __s, locale_t __loc, const char* __format, _Args&&... __args) {
   return ::sscanf_l(__s, __loc, __format, std::forward<_Args>(__args)...);
-  _LIBCPP_DIAGNOSTIC_POP
 }
+_LIBCPP_DIAGNOSTIC_POP
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
@@ -30,7 +30,7 @@
 #include <__config>
 #include <__cstddef/size_t.h>
 #include <__std_mbstate_t.h>
-#include <cstdarg>
+#include <__utility/forward.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -82,31 +82,32 @@ __libcpp_mbsrtowcs_l(wchar_t* __dest, const char** __src, size_t __len, mbstate_
 }
 #endif
 
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 4, 5) int __libcpp_snprintf_l(
-    char* __s, size_t __n, locale_t __loc, const char* __format, ...) {
-  va_list __va;
-  va_start(__va, __format);
-  int __res = ::vsnprintf_l(__s, __n, __loc, __format, __va);
-  va_end(__va);
-  return __res;
+template <class... _Args>
+_LIBCPP_HIDE_FROM_ABI int
+__libcpp_snprintf_l(char* __s, size_t __n, locale_t __loc, const char* __format, _Args&&... __args) {
+  _LIBCPP_DIAGNOSTIC_PUSH
+  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+  _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+  return ::snprintf_l(__s, __n, __loc, __format, std::forward<_Args>(__args)...);
+  _LIBCPP_DIAGNOSTIC_POP
 }
 
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 3, 4) int __libcpp_asprintf_l(
-    char** __s, locale_t __loc, const char* __format, ...) {
-  va_list __va;
-  va_start(__va, __format);
-  int __res = ::vasprintf_l(__s, __loc, __format, __va);
-  va_end(__va);
-  return __res;
+template <class... _Args>
+_LIBCPP_HIDE_FROM_ABI int __libcpp_asprintf_l(char** __s, locale_t __loc, const char* __format, _Args&&... __args) {
+  _LIBCPP_DIAGNOSTIC_PUSH
+  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+  _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+  return ::asprintf_l(__s, __loc, __format, std::forward<_Args>(__args)...);
+  _LIBCPP_DIAGNOSTIC_POP
 }
 
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATTRIBUTE_FORMAT(__scanf__, 3, 4) int __libcpp_sscanf_l(
-    const char* __s, locale_t __loc, const char* __format, ...) {
-  va_list __va;
-  va_start(__va, __format);
-  int __res = ::vsscanf_l(__s, __loc, __format, __va);
-  va_end(__va);
-  return __res;
+template <class... _Args>
+_LIBCPP_HIDE_FROM_ABI int __libcpp_sscanf_l(const char* __s, locale_t __loc, const char* __format, _Args&&... __args) {
+  _LIBCPP_DIAGNOSTIC_PUSH
+  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+  _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral")
+  return ::sscanf_l(__s, __loc, __format, std::forward<_Args>(__args)...);
+  _LIBCPP_DIAGNOSTIC_POP
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
@@ -73,7 +73,7 @@ inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_mbrlen_l(const char* __s, size_t __
 }
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
 
-inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(locale_t __loc) { return ::localeconv_l(__loc); }
+inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(locale_t& __loc) { return ::localeconv_l(__loc); }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI size_t

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_defaults.h
@@ -14,23 +14,101 @@
 #ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_BSD_LOCALE_DEFAULTS_H
 #define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_BSD_LOCALE_DEFAULTS_H
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  include <wchar.h>
+#endif
+
+// <xlocale.h> must come after the includes above since the functions it includes depend on
+// what headers have been included up to that point.
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#  include <xlocale.h>
+#endif
+
+#include <__config>
+#include <__cstddef/size_t.h>
+#include <__std_mbstate_t.h>
+#include <cstdarg>
+
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
 
-#define __libcpp_mb_cur_max_l(loc) MB_CUR_MAX_L(loc)
-#define __libcpp_btowc_l(ch, loc) btowc_l(ch, loc)
-#define __libcpp_wctob_l(wch, loc) wctob_l(wch, loc)
-#define __libcpp_wcsnrtombs_l(dst, src, nwc, len, ps, loc) wcsnrtombs_l(dst, src, nwc, len, ps, loc)
-#define __libcpp_wcrtomb_l(src, wc, ps, loc) wcrtomb_l(src, wc, ps, loc)
-#define __libcpp_mbsnrtowcs_l(dst, src, nms, len, ps, loc) mbsnrtowcs_l(dst, src, nms, len, ps, loc)
-#define __libcpp_mbrtowc_l(pwc, s, n, ps, l) mbrtowc_l(pwc, s, n, ps, l)
-#define __libcpp_mbtowc_l(pwc, pmb, max, l) mbtowc_l(pwc, pmb, max, l)
-#define __libcpp_mbrlen_l(s, n, ps, l) mbrlen_l(s, n, ps, l)
-#define __libcpp_localeconv_l(l) localeconv_l(l)
-#define __libcpp_mbsrtowcs_l(dest, src, len, ps, l) mbsrtowcs_l(dest, src, len, ps, l)
-#define __libcpp_snprintf_l(...) snprintf_l(__VA_ARGS__)
-#define __libcpp_asprintf_l(...) asprintf_l(__VA_ARGS__)
-#define __libcpp_sscanf_l(...) sscanf_l(__VA_ARGS__)
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+inline _LIBCPP_HIDE_FROM_ABI decltype(MB_CUR_MAX) __libcpp_mb_cur_max_l(locale_t __loc) { return MB_CUR_MAX_L(__loc); }
+
+#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+inline _LIBCPP_HIDE_FROM_ABI wint_t __libcpp_btowc_l(int __c, locale_t __loc) { return ::btowc_l(__c, __loc); }
+
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_wctob_l(wint_t __c, locale_t __loc) { return ::wctob_l(__c, __loc); }
+
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_wcsnrtombs_l(
+    char* __dest, const wchar_t** __src, size_t __nwc, size_t __len, mbstate_t* __ps, locale_t __loc) {
+  return ::wcsnrtombs_l(__dest, __src, __nwc, __len, __ps, __loc);
+}
+
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_wcrtomb_l(char* __s, wchar_t __wc, mbstate_t* __ps, locale_t __loc) {
+  return ::wcrtomb_l(__s, __wc, __ps, __loc);
+}
+
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_mbsnrtowcs_l(
+    wchar_t* __dest, const char** __src, size_t __nms, size_t __len, mbstate_t* __ps, locale_t __loc) {
+  return ::mbsnrtowcs_l(__dest, __src, __nms, __len, __ps, __loc);
+}
+
+inline _LIBCPP_HIDE_FROM_ABI size_t
+__libcpp_mbrtowc_l(wchar_t* __pwc, const char* __s, size_t __n, mbstate_t* __ps, locale_t __loc) {
+  return ::mbrtowc_l(__pwc, __s, __n, __ps, __loc);
+}
+
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_mbtowc_l(wchar_t* __pwc, const char* __pmb, size_t __max, locale_t __loc) {
+  return ::mbtowc_l(__pwc, __pmb, __max, __loc);
+}
+
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_mbrlen_l(const char* __s, size_t __n, mbstate_t* __ps, locale_t __loc) {
+  return ::mbrlen_l(__s, __n, __ps, __loc);
+}
+#endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
+
+inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(locale_t __loc) { return ::localeconv_l(__loc); }
+
+#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+inline _LIBCPP_HIDE_FROM_ABI size_t
+__libcpp_mbsrtowcs_l(wchar_t* __dest, const char** __src, size_t __len, mbstate_t* __ps, locale_t __loc) {
+  return ::mbsrtowcs_l(__dest, __src, __len, __ps, __loc);
+}
+#endif
+
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 4, 5) int __libcpp_snprintf_l(
+    char* __s, size_t __n, locale_t __loc, const char* __format, ...) {
+  va_list __va;
+  va_start(__va, __format);
+  int __res = ::vsnprintf_l(__s, __n, __loc, __format, __va);
+  va_end(__va);
+  return __res;
+}
+
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 3, 4) int __libcpp_asprintf_l(
+    char** __s, locale_t __loc, const char* __format, ...) {
+  va_list __va;
+  va_start(__va, __format);
+  int __res = ::vasprintf_l(__s, __loc, __format, __va);
+  va_end(__va);
+  return __res;
+}
+
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATTRIBUTE_FORMAT(__scanf__, 3, 4) int __libcpp_sscanf_l(
+    const char* __s, locale_t __loc, const char* __format, ...) {
+  va_list __va;
+  va_start(__va, __format);
+  int __res = ::vsscanf_l(__s, __loc, __format, __va);
+  va_end(__va);
+  return __res;
+}
+
+_LIBCPP_END_NAMESPACE_STD
 
 #endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_BSD_LOCALE_DEFAULTS_H

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
@@ -80,7 +80,7 @@ inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_mbrlen_l(const char* __s, size_t __
 }
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
 
-inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(locale_t __l) {
+inline _LIBCPP_HIDE_FROM_ABI lconv* __libcpp_localeconv_l(locale_t& __l) {
   __locale_guard __current(__l);
   return localeconv();
 }

--- a/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
+++ b/libcxx/include/__locale_dir/locale_base_api/bsd_locale_fallbacks.h
@@ -13,9 +13,11 @@
 #ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_BSD_LOCALE_FALLBACKS_H
 #define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_BSD_LOCALE_FALLBACKS_H
 
+#include <locale.h>
+
 #include <__locale_dir/locale_guard.h>
-#include <cstdio>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -215,7 +215,7 @@ template <class charT> class messages_byname;
 #  include <streambuf>
 #  include <version>
 
-// TODO: Fix __bsd_locale_defaults.h
+// TODO: Properly qualify calls now that __bsd_locale_defaults.h defines functions instead of macros
 // NOLINTBEGIN(libcpp-robust-against-adl)
 
 #  if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
@@ -228,16 +228,6 @@ template <class charT> class messages_byname;
 #    endif
 #  else
 #    define _LIBCPP_HAS_CATOPEN 0
-#  endif
-
-#  ifdef _LIBCPP_LOCALE__L_EXTENSIONS
-#    include <__locale_dir/locale_base_api/bsd_locale_defaults.h>
-#  else
-#    include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>
-#  endif
-
-#  if defined(__APPLE__) || defined(__FreeBSD__)
-#    include <xlocale.h>
 #  endif
 
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/test/libcxx/clang_modules_include.gen.py
+++ b/libcxx/test/libcxx/clang_modules_include.gen.py
@@ -31,7 +31,7 @@ for header in public_headers:
 
 // Older macOS SDKs were not properly modularized, which causes issues with localization.
 // This feature should instead be based on the SDK version.
-// XFAIL: stdlib=system && target={{{{.+}}}}-apple-macosx13{{{{.*}}}}
+// UNSUPPORTED: stdlib=system && target={{{{.+}}}}-apple-macosx13{{{{.*}}}}
 
 // GCC doesn't support -fcxx-modules
 // UNSUPPORTED: gcc
@@ -65,7 +65,7 @@ print(
 
 // Older macOS SDKs were not properly modularized, which causes issues with localization.
 // This feature should instead be based on the SDK version.
-// XFAIL: stdlib=system && target={{{{.+}}}}-apple-macosx13{{{{.*}}}}
+// UNSUPPORTED: stdlib=system && target={{{{.+}}}}-apple-macosx13{{{{.*}}}}
 
 // GCC doesn't support -fcxx-modules
 // UNSUPPORTED: gcc

--- a/libcxx/test/libcxx/clang_modules_include.gen.py
+++ b/libcxx/test/libcxx/clang_modules_include.gen.py
@@ -29,6 +29,10 @@ for header in public_headers:
 //--- {header}.compile.pass.cpp
 // RUN: %{{cxx}} %s %{{flags}} %{{compile_flags}} -fmodules -fcxx-modules -fmodules-cache-path=%t -fsyntax-only
 
+// Older macOS SDKs were not properly modularized, which causes issues with localization.
+// This feature should instead be based on the SDK version.
+// XFAIL: stdlib=system && target={{{{.+}}}}-apple-macosx13{{{{.*}}}}
+
 // GCC doesn't support -fcxx-modules
 // UNSUPPORTED: gcc
 
@@ -58,6 +62,10 @@ print(
 // RUN: %{{cxx}} %s %{{flags}} %{{compile_flags}} -fmodules -fcxx-modules -fmodules-cache-path=%t -fsyntax-only
 
 // REQUIRES: clang-modules-build
+
+// Older macOS SDKs were not properly modularized, which causes issues with localization.
+// This feature should instead be based on the SDK version.
+// XFAIL: stdlib=system && target={{{{.+}}}}-apple-macosx13{{{{.*}}}}
 
 // GCC doesn't support -fcxx-modules
 // UNSUPPORTED: gcc


### PR DESCRIPTION
We were using macros instead of functions, leading to the inability to properly qualify calls to those symbols inside <locale>. This is also a step towards making the locale API modules-correct.