### PR TITLE
[sema] enhance error handling for compound stmt body in `StmtExpr`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -443,6 +443,7 @@ Bug Fixes in This Version
 - The warning emitted for an unsupported register variable type now points to
   the unsupported type instead of the ``register`` keyword (#GH109776).
 - Fixed a crash when emit ctor for global variant with flexible array init  (#GH113187).
+- Fixed a crash when GNU statement expression contains invalid statement (#GH113468).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/SemaCXX/gh113468.cpp
+++ b/clang/test/SemaCXX/gh113468.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+constexpr int expr() {
+  if (({
+        int f;
+        f = 0;
+        if (f)
+          break; // expected-error {{'break' statement not in loop or switch statement}}
+      }))
+    return 2;
+  return 1;
+}


### PR DESCRIPTION
Mark the whole StmtExpr invalid when the last statement in compound statement is invalid.
Because the last statement need to do copy initialization, it causes subsequent errors to simply ignore last invalid statement.

Fixed: #113468
