### PR TITLE
[Clang] Add __ugly__ spelling for the msvc attribute scope

### DIFF
--- a/clang/include/clang/Basic/Attributes.h
+++ b/clang/include/clang/Basic/Attributes.h
@@ -23,6 +23,30 @@ int hasAttribute(AttributeCommonInfo::Syntax Syntax,
                  const IdentifierInfo *Scope, const IdentifierInfo *Attr,
                  const TargetInfo &Target, const LangOptions &LangOpts);
 
+inline const char* deuglifyAttrScope(StringRef Scope) {
+  if (Scope == "_Clang")
+    return "clang";
+  if (Scope == "__gnu__")
+    return "gnu";
+  if (Scope == "__msvc__")
+    return "msvc";
+  return nullptr;
+}
+
+inline const char* uglifyAttrScope(StringRef Scope) {
+  if (Scope == "clang")
+    return "_Clang";
+  if (Scope == "gnu")
+    return "__gnu__";
+  if (Scope == "msvc")
+    return "__msvc__";
+  return nullptr;
+}
+
+inline bool isPotentiallyUglyScope(StringRef Scope) {
+  return Scope == "gnu" || Scope == "clang" || Scope == "msvc";
+}
+
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_ATTRIBUTES_H

--- a/clang/test/SemaCXX/cxx2a-ms-no-unique-address.cpp
+++ b/clang/test/SemaCXX/cxx2a-ms-no-unique-address.cpp
@@ -16,6 +16,9 @@ struct [[msvc::no_unique_address]] S { // expected-error {{only applies to non-b
   [[msvc::no_unique_address()]] int arglist; // expected-error {{cannot have an argument list}} unsupported-warning {{unknown}}
 
   int [[msvc::no_unique_address]] c; // expected-error {{cannot be applied to types}} unsupported-error {{cannot be applied to types}}
+  [[__msvc__::__no_unique_address__]] int d; // unsupported-warning {{unknown}}
+  [[__msvc__::no_unique_address]] int e; // unsupported-warning {{unknown}}
+  [[msvc::__no_unique_address__]] int g; // unsupported-warning {{unknown}}
 };
 
 struct CStructNoUniqueAddress {


### PR DESCRIPTION
This is required to avoid macro clashing when using attributes like `[[msvc::no_unique_address]]`.

This patch also refactor the logic for attribute scope \_\_uglification\_\_ into a single place to make it easier to add additional cases in case another one is required at some point again.

