### PR TITLE
Optimize input_iterator-pair `insert` for std::vector

### DIFF
--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -69,9 +69,13 @@ Improvements and New Features
 - The ``_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY`` ABI configuration was added, which allows storing valid bounds
   in ``std::array::iterator`` and detecting OOB accesses when the appropriate hardening mode is enabled.
 
-- The input iterator overload of `assign(_InputIterator, _InputIterator)` in `std::vector<_Tp, _Allocator>` has been
-  optimized, resulting in a performance improvement of up to 2x for trivial element types (e.g., `std::vector<int>`),
-  and up to 3.4x for non-trivial element types (e.g., `std::vector<std::vector<int>>`).
+- The ``input_iterator``-pair overload of ``void assign(InputIt, InputIt)`` has been optimized for ``std::vector``, 
+  resulting in a performance improvement of up to 2x for trivial element types (e.g., ``std::vector<int>``), and up 
+  to 3.4x for non-trivial element types (e.g., ``std::vector<std::vector<int>>``).
+
+- The ``input_iterator``-pair overload of ``iterator insert(const_iterator, InputIt, InputIt)`` has been optimized 
+  for ``std::vector``, resulting in a performance improvement of up to 10x for ``std::vector<int>``, and up to 2.3x 
+  for ``std::vector<std::vector<int>>``.
 
 - On Windows, ``<system_error>``'s ``std::system_category`` is now distinct from ``std::generic_category``. The behavior
   on other operating systems is unchanged.

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1260,7 +1260,7 @@ vector<_Tp, _Allocator>::__insert_with_sentinel(const_iterator __position, _Inpu
     auto __guard = std::__make_exception_guard(
         _AllocatorDestroyRangeReverse<allocator_type, pointer>(__alloc_, __old_last, this->__end_));
     __v.__construct_at_end_with_sentinel(std::move(__first), std::move(__last));
-    __split_buffer<value_type, allocator_type&> __merged(__recommend(size() + __v.size()), __off, __alloc_);
+    __split_buffer<value_type, allocator_type&> __merged(__recommend(size() + __v.size()), __off, __alloc_); // has `__off` positions available at the front
     std::__uninitialized_allocator_relocate(
         __alloc_, std::__to_address(__old_last), std::__to_address(this->__end_), std::__to_address(__merged.__end_));
     __guard.__complete(); // Release the guard once objects in [__old_last_, __end_) have been successfully relocated.

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1250,30 +1250,29 @@ vector<_Tp, _Allocator>::__insert_with_sentinel(const_iterator __position, _Inpu
   difference_type __off = __position - begin();
   pointer __p           = this->__begin_ + __off;
   pointer __old_last    = this->__end_;
-  for (; this->__end_ != this->__cap_ && __first != __last; ++__first) {
+  for (; this->__end_ != this->__cap_ && __first != __last; ++__first)
     __construct_one_at_end(*__first);
+
+  if (__first == __last)
+    (void)std::rotate(__p, __old_last, this->__end_);
+  else {
+    __split_buffer<value_type, allocator_type&> __v(__alloc_);
+    auto __guard = std::__make_exception_guard(
+        _AllocatorDestroyRangeReverse<allocator_type, pointer>(__alloc_, __old_last, this->__end_));
+    __v.__construct_at_end_with_sentinel(std::move(__first), std::move(__last));
+    __split_buffer<value_type, allocator_type&> __merged(__recommend(size() + __v.size()), __off, __alloc_);
+    std::__uninitialized_allocator_relocate(
+        __alloc_, std::__to_address(__old_last), std::__to_address(this->__end_), std::__to_address(__merged.__end_));
+    __guard.__complete(); // Release the guard once objects in [__old_last_, __end_) have been successfully relocated.
+    __merged.__end_ += this->__end_ - __old_last;
+    this->__end_ = __old_last;
+    std::__uninitialized_allocator_relocate(
+        __alloc_, std::__to_address(__v.__begin_), std::__to_address(__v.__end_), std::__to_address(__merged.__end_));
+    __merged.__end_ += __v.size();
+    __v.__end_   = __v.__begin_;
+    __p          = __swap_out_circular_buffer(__merged, __p);
   }
-  __split_buffer<value_type, allocator_type&> __v(this->__alloc_);
-  if (__first != __last) {
-#if _LIBCPP_HAS_EXCEPTIONS
-    try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
-      __v.__construct_at_end_with_sentinel(std::move(__first), std::move(__last));
-      difference_type __old_size = __old_last - this->__begin_;
-      difference_type __old_p    = __p - this->__begin_;
-      reserve(__recommend(size() + __v.size()));
-      __p        = this->__begin_ + __old_p;
-      __old_last = this->__begin_ + __old_size;
-#if _LIBCPP_HAS_EXCEPTIONS
-    } catch (...) {
-      erase(__make_iter(__old_last), end());
-      throw;
-    }
-#endif // _LIBCPP_HAS_EXCEPTIONS
-  }
-  __p = std::rotate(__p, __old_last, this->__end_);
-  insert(__make_iter(__p), std::make_move_iterator(__v.begin()), std::make_move_iterator(__v.end()));
-  return begin() + __off;
+  return __make_iter(__p);
 }
 
 template <class _Tp, class _Allocator>

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1269,8 +1269,8 @@ vector<_Tp, _Allocator>::__insert_with_sentinel(const_iterator __position, _Inpu
     std::__uninitialized_allocator_relocate(
         __alloc_, std::__to_address(__v.__begin_), std::__to_address(__v.__end_), std::__to_address(__merged.__end_));
     __merged.__end_ += __v.size();
-    __v.__end_   = __v.__begin_;
-    __p          = __swap_out_circular_buffer(__merged, __p);
+    __v.__end_ = __v.__begin_;
+    __p        = __swap_out_circular_buffer(__merged, __p);
   }
   return __make_iter(__p);
 }

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1260,7 +1260,8 @@ vector<_Tp, _Allocator>::__insert_with_sentinel(const_iterator __position, _Inpu
     auto __guard = std::__make_exception_guard(
         _AllocatorDestroyRangeReverse<allocator_type, pointer>(__alloc_, __old_last, this->__end_));
     __v.__construct_at_end_with_sentinel(std::move(__first), std::move(__last));
-    __split_buffer<value_type, allocator_type&> __merged(__recommend(size() + __v.size()), __off, __alloc_); // has `__off` positions available at the front
+    __split_buffer<value_type, allocator_type&> __merged(
+        __recommend(size() + __v.size()), __off, __alloc_); // has `__off` positions available at the front
     std::__uninitialized_allocator_relocate(
         __alloc_, std::__to_address(__old_last), std::__to_address(this->__end_), std::__to_address(__merged.__end_));
     __guard.__complete(); // Release the guard once objects in [__old_last_, __end_) have been successfully relocated.

--- a/libcxx/test/benchmarks/GenerateInput.h
+++ b/libcxx/test/benchmarks/GenerateInput.h
@@ -134,7 +134,14 @@ std::vector<std::vector<IntT>> getRandomIntegerInputsWithLength(std::size_t N, s
   return inputs;
 }
 
-inline std::vector<std::string> getPrefixedRandomStringInputs(std::size_t N) {
+inline std::vector<std::string> getSSORandomStringInputs(size_t N) {
+  std::vector<std::string> inputs;
+  for (size_t i = 0; i < N; ++i)
+    inputs.push_back(getRandomString(10)); // SSO
+  return inputs;
+}
+
+inline std::vector<std::string> getPrefixedRandomStringInputs(size_t N) {
   std::vector<std::string> inputs;
   inputs.reserve(N);
   constexpr int kSuffixLength = 32;

--- a/libcxx/test/benchmarks/containers/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/containers/vector_operations.bench.cpp
@@ -91,4 +91,18 @@ BENCHMARK_CAPTURE(BM_AssignInputIterIter<100>,
                   getRandomIntegerInputsWithLength<int>)
     ->Args({TestNumInputs, TestNumInputs});
 
+BENCHMARK_CAPTURE(BM_Insert_InputIterIter_NoRealloc, vector_int, std::vector<int>(100, 1), getRandomIntegerInputs<int>)
+    ->Arg(514048);
+BENCHMARK_CAPTURE(
+    BM_Insert_InputIterIter_Realloc_HalfFilled, vector_int, std::vector<int>{}, getRandomIntegerInputs<int>)
+    ->Arg(514048);
+BENCHMARK_CAPTURE(BM_Insert_InputIterIter_Realloc_NearFull, vector_int, std::vector<int>{}, getRandomIntegerInputs<int>)
+    ->Arg(514048);
+BENCHMARK_CAPTURE(
+    BM_Insert_InputIterIter_Realloc_HalfFilled, vector_string, std::vector<std::string>{}, getSSORandomStringInputs)
+    ->Arg(514048);
+BENCHMARK_CAPTURE(
+    BM_Insert_InputIterIter_Realloc_NearFull, vector_string, std::vector<std::string>{}, getSSORandomStringInputs)
+    ->Arg(514048);
+
 BENCHMARK_MAIN();

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_iter_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_iter_iter_iter.pass.cpp
@@ -24,212 +24,193 @@
 namespace adl {
 struct S {};
 void make_move_iterator(S*) {}
-}
+} // namespace adl
 
-TEST_CONSTEXPR_CXX20 bool tests()
-{
-    {
-        typedef std::vector<int> V;
-        V v(100);
-        int a[] = {1, 2, 3, 4, 5};
-        const int N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a),
-                                 cpp17_input_iterator<const int*>(a+N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-            assert(v[j] == 0);
-    }
-    {   // Vector may or may not need to reallocate because of the insertion -- test both cases.
-      { // The input range is shorter than the remaining capacity of the vector -- ensure no reallocation happens.
-        typedef std::vector<int> V;
-        V v(100);
-        v.reserve(v.size() + 10);
-        int a[]     = {1, 2, 3, 4, 5};
-        const int N = sizeof(a) / sizeof(a[0]);
-        V::iterator i =
-            v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-          assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-          assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-          assert(v[j] == 0);
-      }
-      { // The input range is longer than the remaining capacity of the vector -- ensure reallocation happens.
-        typedef std::vector<int> V;
-        V v(100);
-        v.reserve(v.size() + 2);
-        int a[]     = {1, 2, 3, 4, 5};
-        const int N = sizeof(a) / sizeof(a[0]);
-        V::iterator i =
-            v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-          assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-          assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-          assert(v[j] == 0);
-      }
-    }
-    {
-        typedef std::vector<int> V;
-        V v(100);
-        int a[] = {1, 2, 3, 4, 5};
-        const int N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
-                                 forward_iterator<const int*>(a+N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-            assert(v[j] == 0);
-    }
-    {
-        typedef std::vector<int> V;
-        V v(100);
-        while(v.size() < v.capacity()) v.push_back(0); // force reallocation
-        std::size_t sz = v.size();
-        int a[] = {1, 2, 3, 4, 5};
-        const unsigned N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
-                                 forward_iterator<const int*>(a+N));
-        assert(v.size() == sz + N);
-        assert(i == v.begin() + 10);
-        std::size_t j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < v.size(); ++j)
-            assert(v[j] == 0);
-    }
-    {
-        typedef std::vector<int> V;
-        V v(100);
-        v.reserve(128); // force no reallocation
-        std::size_t sz = v.size();
-        int a[] = {1, 2, 3, 4, 5};
-        const unsigned N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
-                                 forward_iterator<const int*>(a+N));
-        assert(v.size() == sz + N);
-        assert(i == v.begin() + 10);
-        std::size_t j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < v.size(); ++j)
-            assert(v[j] == 0);
-    }
-    {
-        typedef std::vector<int, limited_allocator<int, 308> > V;
-        V v(100);
-        int a[] = {1, 2, 3, 4, 5};
-        const int N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a),
-                                 cpp17_input_iterator<const int*>(a+N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-            assert(v[j] == 0);
-    }
-    {
-        typedef std::vector<int, limited_allocator<int, 300> > V;
-        V v(100);
-        int a[] = {1, 2, 3, 4, 5};
-        const int N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
-                                 forward_iterator<const int*>(a+N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-            assert(v[j] == 0);
-    }
+TEST_CONSTEXPR_CXX20 bool tests() {
+  //
+  // Tests for input_iterator
+  // Vector may or may not reallocate during insertion -- test both cases.
+  //
+  { // Test insertion into a vector with less spare space available than the input range, triggering reallocation
+    typedef std::vector<int> V;
+    V v(100);
+    int a[]     = {1, 2, 3, 4, 5};
+    const int N = sizeof(a) / sizeof(a[0]);
+    V::iterator i =
+        v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
+    assert(v.size() == 100 + N);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(i == v.begin() + 10);
+    int j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < 105; ++j)
+      assert(v[j] == 0);
+  }
+  { // Test insertion into a vector with sufficient spare space where no reallocation happens
+    typedef std::vector<int> V;
+    V v(100);
+    v.reserve(v.size() + 10);
+    int a[]     = {1, 2, 3, 4, 5};
+    const int N = sizeof(a) / sizeof(a[0]);
+    V::iterator i =
+        v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
+    assert(v.size() == 100 + N);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(i == v.begin() + 10);
+    int j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < 105; ++j)
+      assert(v[j] == 0);
+  }
+
+  //
+  // Tests for forward_iterator
+  //
+  {
+    typedef std::vector<int> V;
+    V v(100);
+    int a[]       = {1, 2, 3, 4, 5};
+    const int N   = sizeof(a) / sizeof(a[0]);
+    V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a), forward_iterator<const int*>(a + N));
+    assert(v.size() == 100 + N);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(i == v.begin() + 10);
+    int j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < 105; ++j)
+      assert(v[j] == 0);
+  }
+  {
+    typedef std::vector<int> V;
+    V v(100);
+    while (v.size() < v.capacity())
+      v.push_back(0); // force reallocation
+    std::size_t sz   = v.size();
+    int a[]          = {1, 2, 3, 4, 5};
+    const unsigned N = sizeof(a) / sizeof(a[0]);
+    V::iterator i    = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a), forward_iterator<const int*>(a + N));
+    assert(v.size() == sz + N);
+    assert(i == v.begin() + 10);
+    std::size_t j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < v.size(); ++j)
+      assert(v[j] == 0);
+  }
+  {
+    typedef std::vector<int> V;
+    V v(100);
+    v.reserve(128); // force no reallocation
+    std::size_t sz   = v.size();
+    int a[]          = {1, 2, 3, 4, 5};
+    const unsigned N = sizeof(a) / sizeof(a[0]);
+    V::iterator i    = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a), forward_iterator<const int*>(a + N));
+    assert(v.size() == sz + N);
+    assert(i == v.begin() + 10);
+    std::size_t j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < v.size(); ++j)
+      assert(v[j] == 0);
+  }
+  {
+    typedef std::vector<int, limited_allocator<int, 308> > V;
+    V v(100);
+    int a[]     = {1, 2, 3, 4, 5};
+    const int N = sizeof(a) / sizeof(a[0]);
+    V::iterator i =
+        v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
+    assert(v.size() == 100 + N);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(i == v.begin() + 10);
+    int j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < 105; ++j)
+      assert(v[j] == 0);
+  }
+  {
+    typedef std::vector<int, limited_allocator<int, 300> > V;
+    V v(100);
+    int a[]       = {1, 2, 3, 4, 5};
+    const int N   = sizeof(a) / sizeof(a[0]);
+    V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a), forward_iterator<const int*>(a + N));
+    assert(v.size() == 100 + N);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(i == v.begin() + 10);
+    int j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < 105; ++j)
+      assert(v[j] == 0);
+  }
 #if TEST_STD_VER >= 11
-    {
-        typedef std::vector<int, min_allocator<int> > V;
-        V v(100);
-        int a[] = {1, 2, 3, 4, 5};
-        const int N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a),
-                                 cpp17_input_iterator<const int*>(a+N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-            assert(v[j] == 0);
-    }
-    {
-        typedef std::vector<int, min_allocator<int> > V;
-        V v(100);
-        int a[] = {1, 2, 3, 4, 5};
-        const int N = sizeof(a)/sizeof(a[0]);
-        V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
-                                 forward_iterator<const int*>(a+N));
-        assert(v.size() == 100 + N);
-        assert(is_contiguous_container_asan_correct(v));
-        assert(i == v.begin() + 10);
-        int j;
-        for (j = 0; j < 10; ++j)
-            assert(v[j] == 0);
-        for (std::size_t k = 0; k < N; ++j, ++k)
-            assert(v[j] == a[k]);
-        for (; j < 105; ++j)
-            assert(v[j] == 0);
-    }
+  {
+    typedef std::vector<int, min_allocator<int> > V;
+    V v(100);
+    int a[]     = {1, 2, 3, 4, 5};
+    const int N = sizeof(a) / sizeof(a[0]);
+    V::iterator i =
+        v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
+    assert(v.size() == 100 + N);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(i == v.begin() + 10);
+    int j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < 105; ++j)
+      assert(v[j] == 0);
+  }
+  {
+    typedef std::vector<int, min_allocator<int> > V;
+    V v(100);
+    int a[]       = {1, 2, 3, 4, 5};
+    const int N   = sizeof(a) / sizeof(a[0]);
+    V::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a), forward_iterator<const int*>(a + N));
+    assert(v.size() == 100 + N);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(i == v.begin() + 10);
+    int j;
+    for (j = 0; j < 10; ++j)
+      assert(v[j] == 0);
+    for (std::size_t k = 0; k < N; ++j, ++k)
+      assert(v[j] == a[k]);
+    for (; j < 105; ++j)
+      assert(v[j] == 0);
+  }
 #endif
 
-    {
-        std::vector<adl::S> s;
-        s.insert(s.end(), cpp17_input_iterator<adl::S*>(nullptr), cpp17_input_iterator<adl::S*>(nullptr));
-    }
+  {
+    std::vector<adl::S> s;
+    s.insert(s.end(), cpp17_input_iterator<adl::S*>(nullptr), cpp17_input_iterator<adl::S*>(nullptr));
+  }
 
-    return true;
+  return true;
 }
 
-int main(int, char**)
-{
-    tests();
+int main(int, char**) {
+  tests();
 #if TEST_STD_VER > 17
-    static_assert(tests());
+  static_assert(tests());
 #endif
-    return 0;
+  return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_iter_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_iter_iter_iter.pass.cpp
@@ -46,6 +46,46 @@ TEST_CONSTEXPR_CXX20 bool tests()
         for (; j < 105; ++j)
             assert(v[j] == 0);
     }
+    {   // Vector may or may not need to reallocate because of the insertion -- test both cases.
+      { // The input range is shorter than the remaining capacity of the vector -- ensure no reallocation happens.
+        typedef std::vector<int> V;
+        V v(100);
+        v.reserve(v.size() + 10);
+        int a[]     = {1, 2, 3, 4, 5};
+        const int N = sizeof(a) / sizeof(a[0]);
+        V::iterator i =
+            v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+          assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+          assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+          assert(v[j] == 0);
+      }
+      { // The input range is longer than the remaining capacity of the vector -- ensure reallocation happens.
+        typedef std::vector<int> V;
+        V v(100);
+        v.reserve(v.size() + 2);
+        int a[]     = {1, 2, 3, 4, 5};
+        const int N = sizeof(a) / sizeof(a[0]);
+        V::iterator i =
+            v.insert(v.cbegin() + 10, cpp17_input_iterator<const int*>(a), cpp17_input_iterator<const int*>(a + N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+          assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+          assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+          assert(v[j] == 0);
+      }
+    }
     {
         typedef std::vector<int> V;
         V v(100);


### PR DESCRIPTION
As a follow-up to #113852, this PR optimizes the performance of the `insert(const_iterator pos, InputIt first, InputIt last)` function for `input_iterator`-pair inputs in `std::vector` for cases where reallocation occurs during insertion. Additionally, this optimization enhances exception safety by replacing the traditional `try-catch` mechanism with a modern exception guard for the `insert` function. 

### 1. Performance Improvement:
The optimization targets cases where insertion trigger reallocation. In scenarios without reallocation, the implementation remains unchanged.

#### Previous implementation:
The previous implementation of `insert` is inefficient in reallocation scenarios because it performs the following steps separately:
   - **`reserve()`**: This leads to the first round of relocating old elements to new memory;
   - **`rotate()`**: This leads to the second round of reorganizing the existing elements;
   - **Move-forward**: Moves the elements after the insertion position to their final positions.
   - **Insert**: performs the actual insertion.

This approach results in a lot of redundant operations, requiring the elements to undergo three rounds of relocations/reorganizations to be placed in their final positions.

#### Proposed implementation:
The proposed implementation jointly optimize the above 4 steps in the previous implementation such that each element is placed in its final position in just one round of relocation. Specifically, this optimization reduces the total cost from **2 relocations + 1 std::rotate call** to just **1 relocation**, without needing to call `std::rotate`, thereby significantly improving overall performance. 
 

### 2. Exception Safety:
Replaced the traditional try-catch mechanism with a modern exception guard to enhance exception safety.
 

### Benchmark Testing:

#### Before
```
----------------------------------------------------------------------------------------------------------
Benchmark                                                                Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------
BM_Insert_InputIterIter_NoRealloc/vector_int/514048                1005980 ns      1097760 ns          616
BM_Insert_InputIterIter_Realloc_HalfFilled/vector_int/514048        693841 ns       757618 ns          927
BM_Insert_InputIterIter_Realloc_NearFull/vector_int/514048          740592 ns       808204 ns          863
BM_Insert_InputIterIter_Realloc_HalfFilled/vector_string/514048    8008397 ns      8736346 ns           79
BM_Insert_InputIterIter_Realloc_NearFull/vector_string/514048      3238763 ns      3494092 ns          201
```

#### After
```
----------------------------------------------------------------------------------------------------------
Benchmark                                                                Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------
BM_Insert_InputIterIter_NoRealloc/vector_int/514048                1004259 ns      1095871 ns          616
BM_Insert_InputIterIter_Realloc_HalfFilled/vector_int/514048        541093 ns       590598 ns         1099
BM_Insert_InputIterIter_Realloc_NearFull/vector_int/514048           69801 ns        76075 ns         8902
BM_Insert_InputIterIter_Realloc_HalfFilled/vector_string/514048    5739119 ns      6260323 ns          115
BM_Insert_InputIterIter_Realloc_NearFull/vector_string/514048      1434683 ns      1419476 ns          489
```

#### Observations:
The optimized implementation maintains the same performance in non-reallocation scenarios while achieving significant improvements during reallocation:
- For `std::vector<int>`, the optimized implementation achieves performance improvements of 1.3x and 10x for a half-filled and almost-full vector, respectively.
- For ` std::vector<std::string>`, the optimized implementation achieves performance improvements of  1.4x and 2.3x for a half-filled and almost-full vector, respectively.
