### PR TITLE
[clang-format] Enable sorting includes although formatting disabled

### DIFF
--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2656,6 +2656,14 @@ struct FormatStyle {
   /// \version 12
   EmptyLineBeforeAccessModifierStyle EmptyLineBeforeAccessModifier;
 
+  enum EnableSortIncludesOptions : int8_t {
+    ESI_IfFormatEnabled,
+    ESI_Always,
+    ESI_Never,
+  };
+
+  EnableSortIncludesOptions EnableSortIncludes;
+
   /// If ``true``, clang-format detects whether function calls and
   /// definitions are formatted with one parameter per line.
   ///
@@ -5203,6 +5211,7 @@ struct FormatStyle {
            DisableFormat == R.DisableFormat &&
            EmptyLineAfterAccessModifier == R.EmptyLineAfterAccessModifier &&
            EmptyLineBeforeAccessModifier == R.EmptyLineBeforeAccessModifier &&
+           EnableSortIncludes == R.EnableSortIncludes &&
            ExperimentalAutoDetectBinPacking ==
                R.ExperimentalAutoDetectBinPacking &&
            FixNamespaceComments == R.FixNamespaceComments &&


### PR DESCRIPTION
Projects exist, which do not want to use an automated formatting, but
could benefit from sorting the includes, especially to include the main
headers first in order to improve the self-consistency of headers.

While this was possible with `clang-format` for some time, it was
disabled with commit `61dc0f2b593da149a4c0cea67819cd7bdbdd50b8`. The
main reason was that it is confusing for users.

This commit enables sorting the includes more explicitly, to allow the
feature without confusing users.