### PR TITLE
[mlir] Prefer StringRef::substr to slice (NFC)

### DIFF
--- a/mlir/include/mlir/Support/IndentedOstream.h
+++ b/mlir/include/mlir/Support/IndentedOstream.h
@@ -166,8 +166,7 @@ inline void mlir::raw_indented_ostream::write_impl(const char *ptr,
       break;
     }
 
-    auto split =
-        std::make_pair(str.slice(0, idx), str.slice(idx + 1, StringRef::npos));
+    auto split = std::make_pair(str.substr(0, idx), str.substr(idx + 1));
     // Print empty new line without spaces if line only has spaces and no extra
     // prefix is requested.
     if (!split.first.ltrim().empty() || !currentExtraPrefix.empty())

--- a/mlir/lib/Query/QueryParser.cpp
+++ b/mlir/lib/Query/QueryParser.cpp
@@ -181,8 +181,8 @@ QueryRef QueryParser::doParse() {
     if (!matcher) {
       return makeInvalidQueryFromDiagnostics(diag);
     }
-    auto actualSource = origMatcherSource.slice(0, origMatcherSource.size() -
-                                                       matcherSource.size());
+    auto actualSource = origMatcherSource.substr(0, origMatcherSource.size() -
+                                                        matcherSource.size());
     QueryRef query = new MatchQuery(actualSource, *matcher);
     query->remainingContent = matcherSource;
     return query;


### PR DESCRIPTION
I'm planning to migrate StringRef to std::string_view
eventually.  Since std::string_view does not have slice, this patch
migrates:

  slice(0, N)                to  substr(0, N)
  slice(N, StringRef::npos)  to  substr(N)
