### PR TITLE
[llvm] Prefer StringRef::substr(0, N) to slice(0, N) (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -709,7 +709,7 @@ namespace llvm {
       size_t Idx = find(Separator);
       if (Idx == npos)
         return std::make_pair(*this, StringRef());
-      return std::make_pair(slice(0, Idx), substr(Idx + Separator.size()));
+      return std::make_pair(substr(0, Idx), substr(Idx + Separator.size()));
     }
 
     /// Split into two substrings around the last occurrence of a separator
@@ -727,7 +727,7 @@ namespace llvm {
       size_t Idx = rfind(Separator);
       if (Idx == npos)
         return std::make_pair(*this, StringRef());
-      return std::make_pair(slice(0, Idx), substr(Idx + Separator.size()));
+      return std::make_pair(substr(0, Idx), substr(Idx + Separator.size()));
     }
 
     /// Split into substrings around the occurrences of a separator string.

--- a/llvm/lib/Bitcode/Reader/BitcodeAnalyzer.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeAnalyzer.cpp
@@ -537,7 +537,7 @@ Error BitcodeAnalyzer::decodeMetadataStringsBlob(StringRef Indent,
   unsigned StringsOffset = Record[1];
   OS << " num-strings = " << NumStrings << " {\n";
 
-  StringRef Lengths = Blob.slice(0, StringsOffset);
+  StringRef Lengths = Blob.substr(0, StringsOffset);
   SimpleBitstreamCursor R(Lengths);
   StringRef Strings = Blob.drop_front(StringsOffset);
   do {
@@ -551,7 +551,7 @@ Error BitcodeAnalyzer::decodeMetadataStringsBlob(StringRef Indent,
       return reportError("truncated chars");
 
     OS << Indent << "    '";
-    OS.write_escaped(Strings.slice(0, Size), /*hex=*/true);
+    OS.write_escaped(Strings.substr(0, Size), /*hex=*/true);
     OS << "'\n";
     Strings = Strings.drop_front(Size);
   } while (--NumStrings);

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -2299,7 +2299,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseMetadataStrings(
   if (StringsOffset > Blob.size())
     return error("Invalid record: metadata strings corrupt offset");
 
-  StringRef Lengths = Blob.slice(0, StringsOffset);
+  StringRef Lengths = Blob.substr(0, StringsOffset);
   SimpleBitstreamCursor R(Lengths);
 
   StringRef Strings = Blob.drop_front(StringsOffset);
@@ -2313,7 +2313,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseMetadataStrings(
     if (Strings.size() < Size)
       return error("Invalid record: metadata strings truncated chars");
 
-    CallBack(Strings.slice(0, Size));
+    CallBack(Strings.substr(0, Size));
     Strings = Strings.drop_front(Size);
   } while (--NumStrings);
 

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -2886,7 +2886,7 @@ bool MasmParser::expandMacro(raw_svector_ostream &OS, StringRef Body,
     }
 
     // Add the prefix.
-    OS << Body.slice(0, Pos);
+    OS << Body.substr(0, Pos);
 
     // Check if we reached the end.
     if (Pos == End)

--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -3001,7 +3001,7 @@ SRecord SRecord::getHeader(StringRef FileName) {
   // Header is a record with Type S0, Address 0, and Data that is a
   // vendor-specific text comment. For the comment we will use the output file
   // name truncated to 40 characters to match the behavior of GNU objcopy.
-  StringRef HeaderContents = FileName.slice(0, 40);
+  StringRef HeaderContents = FileName.substr(0, 40);
   ArrayRef<uint8_t> Data(
       reinterpret_cast<const uint8_t *>(HeaderContents.data()),
       HeaderContents.size());

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -2445,7 +2445,7 @@ StringRef MachOObjectFile::guessLibraryShortName(StringRef Name,
     if (Suffix != "_debug" && Suffix != "_profile")
       Suffix = StringRef();
     else
-      Foo = Foo.slice(0, Idx);
+      Foo = Foo.substr(0, Idx);
   }
 
   // First look for the form Foo.framework/Foo
@@ -2520,7 +2520,7 @@ guess_library:
   if (Lib.size() >= 3) {
     Dot = Lib.substr(Lib.size() - 2, 1);
     if (Dot == ".")
-      Lib = Lib.slice(0, Lib.size()-2);
+      Lib = Lib.substr(0, Lib.size() - 2);
   }
   return Lib;
 
@@ -2530,14 +2530,14 @@ guess_qtx:
     return StringRef();
   b = Name.rfind('/', a);
   if (b == Name.npos)
-    Lib = Name.slice(0, a);
+    Lib = Name.substr(0, a);
   else
     Lib = Name.slice(b+1, a);
   // There are library names of the form: QT.A.qtx so check for these.
   if (Lib.size() >= 3) {
     Dot = Lib.substr(Lib.size() - 2, 1);
     if (Dot == ".")
-      Lib = Lib.slice(0, Lib.size()-2);
+      Lib = Lib.substr(0, Lib.size() - 2);
   }
   return Lib;
 }
@@ -5319,7 +5319,7 @@ bool MachOObjectFile::isRelocatableObject() const {
 Expected<std::unique_ptr<MachOObjectFile>> ObjectFile::createMachOObjectFile(
     MemoryBufferRef Buffer, uint32_t UniversalCputype, uint32_t UniversalIndex,
     size_t MachOFilesetEntryOffset) {
-  StringRef Magic = Buffer.getBuffer().slice(0, 4);
+  StringRef Magic = Buffer.getBuffer().substr(0, 4);
   if (Magic == "\xFE\xED\xFA\xCE")
     return MachOObjectFile::create(Buffer, false, false, UniversalCputype,
                                    UniversalIndex, MachOFilesetEntryOffset);

--- a/llvm/lib/Option/OptTable.cpp
+++ b/llvm/lib/Option/OptTable.cpp
@@ -160,7 +160,7 @@ static unsigned matchOption(const OptTable::Info *I, StringRef Str,
 static bool optionMatches(const OptTable::Info &In, StringRef Option) {
   for (auto Prefix : In.Prefixes)
     if (Option.ends_with(In.getName()))
-      if (Option.slice(0, Option.size() - In.getName().size()) == Prefix)
+      if (Option.substr(0, Option.size() - In.getName().size()) == Prefix)
         return true;
   return false;
 }

--- a/llvm/lib/Support/CachePruning.cpp
+++ b/llvm/lib/Support/CachePruning.cpp
@@ -54,7 +54,7 @@ static Expected<std::chrono::seconds> parseDuration(StringRef Duration) {
     return make_error<StringError>("Duration must not be empty",
                                    inconvertibleErrorCode());
 
-  StringRef NumStr = Duration.slice(0, Duration.size()-1);
+  StringRef NumStr = Duration.substr(0, Duration.size() - 1);
   uint64_t Num;
   if (NumStr.getAsInteger(0, Num))
     return make_error<StringError>("'" + NumStr + "' not an integer",

--- a/llvm/lib/Support/Regex.cpp
+++ b/llvm/lib/Support/Regex.cpp
@@ -206,7 +206,7 @@ std::string Regex::sub(StringRef Repl, StringRef String,
     case '0': case '1': case '2': case '3': case '4':
     case '5': case '6': case '7': case '8': case '9': {
       // Extract the backreference number.
-      StringRef Ref = Repl.slice(0, Repl.find_first_not_of("0123456789"));
+      StringRef Ref = Repl.substr(0, Repl.find_first_not_of("0123456789"));
       Repl = Repl.substr(Ref.size());
 
       unsigned RefValue;

--- a/llvm/lib/Support/StringRef.cpp
+++ b/llvm/lib/Support/StringRef.cpp
@@ -327,7 +327,7 @@ void StringRef::split(SmallVectorImpl<StringRef> &A,
 
     // Push this split.
     if (KeepEmpty || Idx > 0)
-      A.push_back(S.slice(0, Idx));
+      A.push_back(S.substr(0, Idx));
 
     // Jump forward.
     S = S.substr(Idx + Separator.size());
@@ -353,7 +353,7 @@ void StringRef::split(SmallVectorImpl<StringRef> &A, char Separator,
 
     // Push this split.
     if (KeepEmpty || Idx > 0)
-      A.push_back(S.slice(0, Idx));
+      A.push_back(S.substr(0, Idx));
 
     // Jump forward.
     S = S.substr(Idx + 1);

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -1998,7 +1998,7 @@ private:
     size_t RootPathLen = sys::path::root_path(Trimmed, path_style).size();
     while (Trimmed.size() > RootPathLen &&
            sys::path::is_separator(Trimmed.back(), path_style))
-      Trimmed = Trimmed.slice(0, Trimmed.size() - 1);
+      Trimmed = Trimmed.substr(0, Trimmed.size() - 1);
 
     // Get the last component
     StringRef LastComponent = sys::path::filename(Trimmed, path_style);

--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -6619,7 +6619,7 @@ StringRef ARMAsmParser::splitMnemonic(StringRef Mnemonic, StringRef ExtraToken,
          Mnemonic.starts_with("vq")))) {
     unsigned CC = ARMCondCodeFromString(Mnemonic.substr(Mnemonic.size()-2));
     if (CC != ~0U) {
-      Mnemonic = Mnemonic.slice(0, Mnemonic.size() - 2);
+      Mnemonic = Mnemonic.substr(0, Mnemonic.size() - 2);
       PredicationCode = static_cast<ARMCC::CondCodes>(CC);
     }
   }
@@ -6638,7 +6638,7 @@ StringRef ARMAsmParser::splitMnemonic(StringRef Mnemonic, StringRef ExtraToken,
         Mnemonic == "vfnms" || Mnemonic == "fconsts" || Mnemonic == "bxns" ||
         Mnemonic == "blxns" || Mnemonic == "vfmas" || Mnemonic == "vmlas" ||
         (Mnemonic == "movs" && isThumb()))) {
-    Mnemonic = Mnemonic.slice(0, Mnemonic.size() - 1);
+    Mnemonic = Mnemonic.substr(0, Mnemonic.size() - 1);
     CarrySetting = true;
   }
 
@@ -6652,7 +6652,7 @@ StringRef ARMAsmParser::splitMnemonic(StringRef Mnemonic, StringRef ExtraToken,
       .Case("id", ARM_PROC::ID)
       .Default(~0U);
     if (IMod != ~0U) {
-      Mnemonic = Mnemonic.slice(0, Mnemonic.size()-2);
+      Mnemonic = Mnemonic.substr(0, Mnemonic.size() - 2);
       ProcessorIMod = IMod;
     }
   }
@@ -6667,7 +6667,7 @@ StringRef ARMAsmParser::splitMnemonic(StringRef Mnemonic, StringRef ExtraToken,
     unsigned VCC =
         ARMVectorCondCodeFromString(Mnemonic.substr(Mnemonic.size() - 1));
     if (VCC != ~0U) {
-      Mnemonic = Mnemonic.slice(0, Mnemonic.size()-1);
+      Mnemonic = Mnemonic.substr(0, Mnemonic.size() - 1);
       VPTPredicationCode = static_cast<ARMVCC::VPTCodes>(VCC);
     }
     return Mnemonic;
@@ -6676,15 +6676,15 @@ StringRef ARMAsmParser::splitMnemonic(StringRef Mnemonic, StringRef ExtraToken,
   // The "it" instruction has the condition mask on the end of the mnemonic.
   if (Mnemonic.starts_with("it")) {
     ITMask = Mnemonic.substr(2);
-    Mnemonic = Mnemonic.slice(0, 2);
+    Mnemonic = Mnemonic.substr(0, 2);
   }
 
   if (Mnemonic.starts_with("vpst")) {
     ITMask = Mnemonic.substr(4);
-    Mnemonic = Mnemonic.slice(0, 4);
+    Mnemonic = Mnemonic.substr(0, 4);
   } else if (Mnemonic.starts_with("vpt")) {
     ITMask = Mnemonic.substr(3);
-    Mnemonic = Mnemonic.slice(0, 3);
+    Mnemonic = Mnemonic.substr(0, 3);
   }
 
   return Mnemonic;
@@ -7398,7 +7398,7 @@ bool ARMAsmParser::parseInstruction(ParseInstructionInfo &Info, StringRef Name,
       // point VCMPE is actually a different instruction from VCMP, so
       // we mustn't treat them the same). In that situation, glue it
       // back on.
-      Mnemonic = Name.slice(0, Mnemonic.size() + 1);
+      Mnemonic = Name.substr(0, Mnemonic.size() + 1);
       Operands.erase(Operands.begin());
       Operands.insert(Operands.begin(),
                       ARMOperand::CreateToken(Mnemonic, NameLoc, *this));

--- a/llvm/lib/Target/Lanai/AsmParser/LanaiAsmParser.cpp
+++ b/llvm/lib/Target/Lanai/AsmParser/LanaiAsmParser.cpp
@@ -1058,7 +1058,7 @@ StringRef LanaiAsmParser::splitMnemonic(StringRef Name, SMLoc NameLoc,
     LPCC::CondCode CondCode =
         LPCC::suffixToLanaiCondCode(Mnemonic.substr(1, Next));
     if (CondCode != LPCC::UNKNOWN) {
-      Mnemonic = Mnemonic.slice(0, 1);
+      Mnemonic = Mnemonic.substr(0, 1);
       Operands->push_back(LanaiOperand::CreateToken(Mnemonic, NameLoc));
       Operands->push_back(LanaiOperand::createImm(
           MCConstantExpr::create(CondCode, getContext()), NameLoc, NameLoc));

--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -1643,7 +1643,7 @@ bool PPCAsmParser::parseInstruction(ParseInstructionInfo &Info, StringRef Name,
   // If the instruction ends in a '.', we need to create a separate
   // token for it, to match what TableGen is doing.
   size_t Dot = Name.find('.');
-  StringRef Mnemonic = Name.slice(0, Dot);
+  StringRef Mnemonic = Name.substr(0, Dot);
   if (!NewOpcode.empty()) // Underlying memory for Name is volatile.
     Operands.push_back(
         PPCOperand::CreateTokenWithStringCopy(Mnemonic, NameLoc, isPPC64()));

--- a/llvm/lib/Target/VE/AsmParser/VEAsmParser.cpp
+++ b/llvm/lib/Target/VE/AsmParser/VEAsmParser.cpp
@@ -864,7 +864,7 @@ static StringRef parseCC(StringRef Name, unsigned Prefix, unsigned Suffix,
       (!OmitCC || (CondCode != VECC::CC_AT && CondCode != VECC::CC_AF))) {
     StringRef SuffixStr = Name.substr(Suffix);
     // Push "b".
-    Name = Name.slice(0, Prefix);
+    Name = Name.substr(0, Prefix);
     Operands->push_back(VEOperand::CreateToken(Name, NameLoc));
     // Push $cond part.
     SMLoc CondLoc = SMLoc::getFromPointer(NameLoc.getPointer() + Prefix);
@@ -887,7 +887,7 @@ static StringRef parseRD(StringRef Name, unsigned Prefix, SMLoc NameLoc,
   VERD::RoundingMode RoundingMode = stringToVERD(RD);
 
   if (RoundingMode != VERD::UNKNOWN) {
-    Name = Name.slice(0, Prefix);
+    Name = Name.substr(0, Prefix);
     // push 1st like `cvt.w.d.sx`
     Operands->push_back(VEOperand::CreateToken(Name, NameLoc));
     SMLoc SuffixLoc =

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -1955,7 +1955,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         size_t DotOffset = Identifier.find_first_of('.');
         if (DotOffset != StringRef::npos) {
           consumeToken();
-          StringRef LHS = Identifier.slice(0, DotOffset);
+          StringRef LHS = Identifier.substr(0, DotOffset);
           StringRef Dot = Identifier.substr(DotOffset, 1);
           StringRef RHS = Identifier.substr(DotOffset + 1);
           if (!RHS.empty()) {

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -507,7 +507,7 @@ RISCVISAInfo::parseNormalizedArchString(StringRef Arch) {
     }
 
     size_t Idx = Arch.find('_');
-    StringRef Ext = Arch.slice(0, Idx);
+    StringRef Ext = Arch.substr(0, Idx);
     Arch = Arch.substr(Idx);
 
     StringRef Prefix, MinorVersionStr;
@@ -532,7 +532,7 @@ RISCVISAInfo::parseNormalizedArchString(StringRef Arch) {
     if (VersionStart == 0)
       return getError("missing extension name");
 
-    StringRef ExtName = Prefix.slice(0, VersionStart);
+    StringRef ExtName = Prefix.substr(0, VersionStart);
     StringRef MajorVersionStr = Prefix.substr(VersionStart);
     if (MajorVersionStr.getAsInteger(10, MajorVersion))
       return getError("failed to parse major version number");
@@ -661,7 +661,7 @@ RISCVISAInfo::parseArchString(StringRef Arch, bool EnableExperimentalExtension,
     }
 
     size_t Idx = Arch.find('_');
-    StringRef Ext = Arch.slice(0, Idx);
+    StringRef Ext = Arch.substr(0, Idx);
     Arch = Arch.substr(Idx);
 
     do {

--- a/llvm/tools/llvm-cxxdump/llvm-cxxdump.cpp
+++ b/llvm/tools/llvm-cxxdump/llvm-cxxdump.cpp
@@ -316,7 +316,7 @@ static void dumpCXXData(const ObjectFile *Obj) {
     }
     // Typeinfo names in the Itanium ABI start with '_ZTS' or '__ZTS'.
     else if (SymName.starts_with("_ZTS") || SymName.starts_with("__ZTS")) {
-      TINames[SymName] = SymContents.slice(0, SymContents.find('\0'));
+      TINames[SymName] = SymContents.substr(0, SymContents.find('\0'));
     }
     // Vtables in the Itanium ABI start with '_ZTV' or '__ZTV'.
     else if (SymName.starts_with("_ZTV") || SymName.starts_with("__ZTV")) {

--- a/llvm/tools/llvm-cxxfilt/llvm-cxxfilt.cpp
+++ b/llvm/tools/llvm-cxxfilt/llvm-cxxfilt.cpp
@@ -117,7 +117,7 @@ static void SplitStringDelims(
   // Obtain any leading delimiters.
   auto Start = std::find_if(Head, Source.end(), IsLegalChar);
   if (Start != Head)
-    OutFragments.push_back({"", Source.slice(0, Start - Head)});
+    OutFragments.push_back({"", Source.substr(0, Start - Head)});
 
   // Capture each word and the delimiters following that word.
   while (Start != Source.end()) {

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -579,7 +579,7 @@ static Expected<int64_t> parseChangeSectionLMA(StringRef ArgValue,
   if (!LMAValue)
     return createStringError(LMAValue.getError(),
                              "bad format for " + OptionName + ": value after " +
-                                 ArgValue.slice(0, 2) + " is " + StringValue +
+                                 ArgValue.substr(0, 2) + " is " + StringValue +
                                  " when it should be an integer");
   return *LMAValue;
 }
@@ -598,7 +598,7 @@ parseChangeSectionAddr(StringRef ArgValue, StringRef OptionName,
                                  " is invalid. See --help");
   char UpdateSymbol = ArgValue[LastSymbolIndex];
 
-  StringRef SectionPattern = ArgValue.slice(0, LastSymbolIndex);
+  StringRef SectionPattern = ArgValue.substr(0, LastSymbolIndex);
   if (SectionPattern.empty())
     return createStringError(
         errc::invalid_argument,

--- a/llvm/unittests/MC/DwarfLineTableHeaders.cpp
+++ b/llvm/unittests/MC/DwarfLineTableHeaders.cpp
@@ -151,7 +151,7 @@ public:
       StringRef Contents = *ContentsOrErr;
       ASSERT_TRUE(Contents.size() > ExpectedEncoding.size());
       EXPECT_EQ(
-          arrayRefFromStringRef(Contents.slice(0, ExpectedEncoding.size())),
+          arrayRefFromStringRef(Contents.substr(0, ExpectedEncoding.size())),
           ExpectedEncoding);
       return;
     }

--- a/llvm/unittests/Support/YAMLIOTest.cpp
+++ b/llvm/unittests/Support/YAMLIOTest.cpp
@@ -1077,7 +1077,7 @@ namespace yaml {
     static StringRef input(StringRef scalar, void* ctxt, MyCustomType &value) {
       size_t byStart = scalar.find("by");
       if ( byStart != StringRef::npos ) {
-        StringRef lenStr = scalar.slice(0, byStart);
+        StringRef lenStr = scalar.substr(0, byStart);
         lenStr = lenStr.rtrim();
         if ( lenStr.getAsInteger(0, value.length) ) {
           return "malformed length";

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -852,14 +852,14 @@ parseTwoOperandConstraint(StringRef S, ArrayRef<SMLoc> Loc) {
     PrintFatalError(Loc, "expected '$' prefix on asm operand name");
   Ops.first = Ops.first.substr(start + 1);
   size_t end = Ops.first.find_last_of(" \t");
-  Ops.first = Ops.first.slice(0, end);
+  Ops.first = Ops.first.substr(0, end);
   // Now the second operand.
   start = Ops.second.find_first_of('$');
   if (start == std::string::npos)
     PrintFatalError(Loc, "expected '$' prefix on asm operand name");
   Ops.second = Ops.second.substr(start + 1);
   end = Ops.second.find_last_of(" \t");
-  Ops.first = Ops.first.slice(0, end);
+  Ops.first = Ops.first.substr(0, end);
   return Ops;
 }
 

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
@@ -548,7 +548,7 @@ std::string CodeGenInstruction::FlattenAsmStringVariants(StringRef Cur,
         break;
 
     // Add the prefix to the result.
-    Res += Cur.slice(0, VariantsStart);
+    Res += Cur.substr(0, VariantsStart);
     if (VariantsStart == Cur.size())
       break;
 

--- a/llvm/utils/TableGen/OptionParserEmitter.cpp
+++ b/llvm/utils/TableGen/OptionParserEmitter.cpp
@@ -177,7 +177,7 @@ static MarshallingInfo createMarshallingInfo(const Record &R) {
       if (Idx == StringRef::npos)
         break;
       if (Idx > 0)
-        Ret.Values.push_back(ValuesStr.slice(0, Idx));
+        Ret.Values.push_back(ValuesStr.substr(0, Idx));
       ValuesStr = ValuesStr.substr(Idx + 1);
     }
     if (!ValuesStr.empty())


### PR DESCRIPTION
I'm planning to migrate StringRef to std::string_view eventually.
Since std::string_view does not have slice, this patch migrates
slice(0, N) to substr(0, N).
