### PR TITLE
[LLD] [MinGW] Implement --dependent-load-flag option

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -407,6 +407,9 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
                    OPT_no_allow_multiple_definition, false))
     add("-force:multiple");
 
+  if (auto *a = args.getLastArg(OPT_dependent_load_flag))
+    add("-dependentloadflag:" + StringRef(a->getValue()));
+
   if (auto *a = args.getLastArg(OPT_icf)) {
     StringRef s = a->getValue();
     if (s == "all")

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -202,6 +202,7 @@ def _HASH_HASH_HASH : Flag<["-"], "###">,
     HelpText<"Print (but do not run) the commands to run for this compilation">;
 def appcontainer: F<"appcontainer">, HelpText<"Set the appcontainer flag in the executable">;
 defm delayload: Eq<"delayload", "DLL to load only on demand">;
+defm dependent_load_flag: EEq<"dependent-load-flag", "Override default LibraryLoad flags">;
 defm mllvm: EqNoHelp<"mllvm">;
 defm pdb: Eq<"pdb", "Output PDB debug info file, chosen implicitly if the argument is empty">;
 defm Xlink : Eq<"Xlink", "Pass <arg> to the COFF linker">, MetaVarName<"<arg>">;

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -462,3 +462,6 @@ RUN: ld.lld -### foo.o -m i386pep --rpath foo 2>&1 | FileCheck -check-prefix=WAR
 RUN: ld.lld -### foo.o -m i386pep -rpath=foo 2>&1 | FileCheck -check-prefix=WARN_RPATH %s
 RUN: ld.lld -### foo.o -m i386pep --rpath=foo 2>&1 | FileCheck -check-prefix=WARN_RPATH %s
 WARN_RPATH: warning: parameter -{{-?}}rpath has no effect on PE/COFF targets
+
+RUN: ld.lld -### foo.o -m i386pe --dependent-load-flag=0x800 2>&1 | FileCheck -check-prefix=DEPENDENT_LOAD_FLAG %s
+DEPENDENT_LOAD_FLAG: -dependentloadflag:0x800


### PR DESCRIPTION
Implement MSVC's `/DEPENDENTLOADFLAG` as `--dependent-load-flag` and forward it to COFF.
I'm not sure about the name as ld.bfd doesn't support it (yet?).

There is no solid need for it yet, but it's being considered: https://github.com/msys2/MINGW-packages/pull/22216#issuecomment-2428417546