### PR TITLE
[PAC][lld][AArch64][ELF] Support signed GOT

### DIFF
--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -202,11 +202,16 @@ RelExpr AArch64::getRelExpr(RelType type, const Symbol &s,
   case R_AARCH64_LD64_GOT_LO12_NC:
   case R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC:
     return R_GOT;
+  case R_AARCH64_AUTH_LD64_GOT_LO12_NC:
+  case R_AARCH64_AUTH_GOT_ADD_LO12_NC:
+    return R_AARCH64_AUTH_GOT;
   case R_AARCH64_LD64_GOTPAGE_LO15:
     return RE_AARCH64_GOT_PAGE;
   case R_AARCH64_ADR_GOT_PAGE:
   case R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21:
     return RE_AARCH64_GOT_PAGE_PC;
+  case R_AARCH64_AUTH_ADR_GOT_PAGE:
+    return RE_AARCH64_AUTH_GOT_PAGE_PC;
   case R_AARCH64_GOTPCREL32:
   case R_AARCH64_GOT_LD_PREL19:
     return R_GOT_PC;
@@ -258,6 +263,7 @@ int64_t AArch64::getImplicitAddend(const uint8_t *buf, RelType type) const {
     return read64(ctx, buf + 8);
   case R_AARCH64_NONE:
   case R_AARCH64_GLOB_DAT:
+  case R_AARCH64_AUTH_GLOB_DAT:
   case R_AARCH64_JUMP_SLOT:
     return 0;
   case R_AARCH64_ABS16:
@@ -528,9 +534,11 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
       write32(ctx, loc, val);
     break;
   case R_AARCH64_ADD_ABS_LO12_NC:
+  case R_AARCH64_AUTH_GOT_ADD_LO12_NC:
     write32Imm12(loc, val);
     break;
   case R_AARCH64_ADR_GOT_PAGE:
+  case R_AARCH64_AUTH_ADR_GOT_PAGE:
   case R_AARCH64_ADR_PREL_PG_HI21:
   case R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21:
   case R_AARCH64_TLSDESC_ADR_PAGE21:
@@ -580,6 +588,7 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
     break;
   case R_AARCH64_LDST64_ABS_LO12_NC:
   case R_AARCH64_LD64_GOT_LO12_NC:
+  case R_AARCH64_AUTH_LD64_GOT_LO12_NC:
   case R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC:
   case R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC:
   case R_AARCH64_TLSDESC_LD64_LO12:

--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -204,7 +204,7 @@ RelExpr AArch64::getRelExpr(RelType type, const Symbol &s,
     return R_GOT;
   case R_AARCH64_AUTH_LD64_GOT_LO12_NC:
   case R_AARCH64_AUTH_GOT_ADD_LO12_NC:
-    return R_AARCH64_AUTH_GOT;
+    return RE_AARCH64_AUTH_GOT;
   case R_AARCH64_LD64_GOTPAGE_LO15:
     return RE_AARCH64_GOT_PAGE;
   case R_AARCH64_ADR_GOT_PAGE:

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -783,6 +783,7 @@ uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
   case RE_ARM_SBREL:
     return r.sym->getVA(ctx, a) - getARMStaticBase(*r.sym);
   case R_GOT:
+  case R_AARCH64_AUTH_GOT:
   case R_RELAX_TLS_GD_TO_IE_ABS:
     return r.sym->getGotVA(ctx) + a;
   case RE_LOONGARCH_GOT:
@@ -810,6 +811,7 @@ uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
   case R_RELAX_TLS_GD_TO_IE_GOT_OFF:
     return r.sym->getGotOffset(ctx) + a;
   case RE_AARCH64_GOT_PAGE_PC:
+  case RE_AARCH64_AUTH_GOT_PAGE_PC:
   case RE_AARCH64_RELAX_TLS_GD_TO_IE_PAGE_PC:
     return getAArch64Page(r.sym->getGotVA(ctx) + a) - getAArch64Page(p);
   case RE_AARCH64_GOT_PAGE:

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -783,7 +783,7 @@ uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
   case RE_ARM_SBREL:
     return r.sym->getVA(ctx, a) - getARMStaticBase(*r.sym);
   case R_GOT:
-  case R_AARCH64_AUTH_GOT:
+  case RE_AARCH64_AUTH_GOT:
   case R_RELAX_TLS_GD_TO_IE_ABS:
     return r.sym->getGotVA(ctx) + a;
   case RE_LOONGARCH_GOT:

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1781,8 +1781,11 @@ static bool handleNonPreemptibleIfunc(Ctx &ctx, Symbol &sym, uint16_t flags) {
     // don't try to call the PLT as if it were an ifunc resolver.
     d.type = STT_FUNC;
 
-    if (flags & NEEDS_GOT)
+    if (flags & NEEDS_GOT) {
+      assert(!(flags & NEEDS_GOT_AUTH) &&
+             "R_AARCH64_AUTH_IRELATIVE is not supported yet");
       addGotEntry(ctx, sym);
+    }
   } else if (flags & NEEDS_GOT) {
     // Redirect GOT accesses to point to the Igot.
     sym.gotInIgot = true;

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1805,6 +1805,7 @@ void elf::postScanRelocations(Ctx &ctx) {
         diag << "both AUTH and non-AUTH GOT entries for '" << sym.getName()
              << "' requested, but only one type of GOT entry per symbol is "
                 "supported";
+        return;
       }
       if (flags & NEEDS_GOT_AUTH)
         addGotAuthEntry(ctx, sym);

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1093,10 +1093,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
           (expr == R_AARCH64_AUTH_GOT || expr == R_AARCH64_AUTH_GOT_PAGE_PC);
       uint16_t flags = sym.flags.load(std::memory_order_relaxed);
       if (!(flags & NEEDS_GOT)) {
-        if (needsGotAuth)
-          sym.setFlags(NEEDS_GOT | NEEDS_GOT_AUTH);
-        else
-          sym.setFlags(NEEDS_GOT);
+        sym.setFlags(needsGotAuth ? (NEEDS_GOT | NEEDS_GOT_AUTH) : NEEDS_GOT);
       } else if (needsGotAuth != static_cast<bool>(flags & NEEDS_GOT_AUTH)) {
         fatal("both AUTH and non-AUTH GOT entries for '" + sym.getName() +
               "' requested, but only one type of GOT entry per symbol is "

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1095,9 +1095,10 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
       if (!(flags & NEEDS_GOT)) {
         sym.setFlags(needsGotAuth ? (NEEDS_GOT | NEEDS_GOT_AUTH) : NEEDS_GOT);
       } else if (needsGotAuth != static_cast<bool>(flags & NEEDS_GOT_AUTH)) {
-        fatal("both AUTH and non-AUTH GOT entries for '" + sym.getName() +
-              "' requested, but only one type of GOT entry per symbol is "
-              "supported");
+        Err(ctx) << "both AUTH and non-AUTH GOT entries for '" << sym.getName()
+                 << "' requested, but only one type of GOT entry per symbol is "
+                    "supported"
+                 << getLocation(ctx, *sec, sym, offset);
       }
     }
   } else if (needsPlt(expr)) {

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1095,10 +1095,11 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
       if (!(flags & NEEDS_GOT)) {
         sym.setFlags(needsGotAuth ? (NEEDS_GOT | NEEDS_GOT_AUTH) : NEEDS_GOT);
       } else if (needsGotAuth != static_cast<bool>(flags & NEEDS_GOT_AUTH)) {
-        Err(ctx) << "both AUTH and non-AUTH GOT entries for '" << sym.getName()
-                 << "' requested, but only one type of GOT entry per symbol is "
-                    "supported"
-                 << getLocation(ctx, *sec, sym, offset);
+        auto diag = Err(ctx);
+        diag << "both AUTH and non-AUTH GOT entries for '" << sym.getName()
+             << "' requested, but only one type of GOT entry per symbol is "
+                "supported";
+        printLocation(diag, *sec, sym, offset);
       }
     }
   } else if (needsPlt(expr)) {

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1090,7 +1090,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
       // Many LoongArch TLS relocs reuse the RE_LOONGARCH_GOT type, in which
       // case the NEEDS_GOT flag shouldn't get set.
       bool needsGotAuth =
-          (expr == R_AARCH64_AUTH_GOT || expr == R_AARCH64_AUTH_GOT_PAGE_PC);
+          (expr == RE_AARCH64_AUTH_GOT || expr == RE_AARCH64_AUTH_GOT_PAGE_PC);
       uint16_t flags = sym.flags.load(std::memory_order_relaxed);
       if (!(flags & NEEDS_GOT)) {
         sym.setFlags(needsGotAuth ? (NEEDS_GOT | NEEDS_GOT_AUTH) : NEEDS_GOT);

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -92,7 +92,9 @@ enum RelExpr {
   // of a relocation type, there are some relocations whose semantics are
   // unique to a target. Such relocation are marked with RE_<TARGET_NAME>.
   RE_AARCH64_GOT_PAGE_PC,
+  RE_AARCH64_AUTH_GOT_PAGE_PC,
   RE_AARCH64_GOT_PAGE,
+  RE_AARCH64_AUTH_GOT,
   RE_AARCH64_PAGE_PC,
   RE_AARCH64_RELAX_TLS_GD_TO_IE_PAGE_PC,
   RE_AARCH64_TLSDESC_PAGE,

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -52,6 +52,7 @@ enum {
   NEEDS_GOT_DTPREL = 1 << 7,
   NEEDS_TLSIE = 1 << 8,
   NEEDS_GOT_AUTH = 1 << 9,
+  NEEDS_GOT_NONAUTH = 1 << 10,
 };
 
 // The base class for real symbol classes.

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -51,6 +51,7 @@ enum {
   NEEDS_TLSGD_TO_IE = 1 << 6,
   NEEDS_GOT_DTPREL = 1 << 7,
   NEEDS_TLSIE = 1 << 8,
+  NEEDS_GOT_AUTH = 1 << 9,
 };
 
 // The base class for real symbol classes.

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -668,8 +668,10 @@ void GotSection::addConstant(const Relocation &r) { relocations.push_back(r); }
 void GotSection::addEntry(const Symbol &sym) {
   assert(sym.auxIdx == ctx.symAux.size() - 1);
   ctx.symAux.back().gotIdx = numEntries++;
-  if (sym.hasFlag(NEEDS_GOT_AUTH))
-    authEntries.push_back({(numEntries - 1) * ctx.arg.wordsize, sym.isFunc()});
+}
+
+void GotSection::addAuthEntry(const Symbol &sym) {
+  authEntries.push_back({(numEntries - 1) * ctx.arg.wordsize, sym.isFunc()});
 }
 
 bool GotSection::addTlsDescEntry(const Symbol &sym) {

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -735,13 +735,13 @@ void GotSection::writeTo(uint8_t *buf) {
   ctx.target->writeGotHeader(buf);
   ctx.target->relocateAlloc(*this, buf);
   for (const AuthEntryInfo &authEntry : authEntries) {
-    // https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#default-signing-schema
+    // https://github.com/ARM-software/abi-aa/blob/2024Q3/pauthabielf64/pauthabielf64.rst#default-signing-schema
     //   Signed GOT entries use the IA key for symbols of type STT_FUNC and the
     //   DA key for all other symbol types, with the address of the GOT entry as
     //   the modifier. The static linker must encode the signing schema into the
     //   GOT slot.
     //
-    // https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#encoding-the-signing-schema
+    // https://github.com/ARM-software/abi-aa/blob/2024Q3/pauthabielf64/pauthabielf64.rst#encoding-the-signing-schema
     //   If address diversity is set and the discriminator
     //   is 0 then modifier = Place
     uint8_t *dest = buf + authEntry.offset;

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -745,7 +745,7 @@ void GotSection::writeTo(uint8_t *buf) {
     //   If address diversity is set and the discriminator
     //   is 0 then modifier = Place
     uint8_t *dest = buf + authEntry.offset;
-    uint64_t key = authEntry.isSymbolFunc ? /*IA*/ 0b00 : /*DA*/ 0b10;
+    uint64_t key = authEntry.isSymbolFunc ? /*IA=*/0b00 : /*DA=*/0b10;
     uint64_t addrDiversity = 1;
     write64(ctx, dest, (addrDiversity << 63) | (key << 60));
   }

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -668,6 +668,8 @@ void GotSection::addConstant(const Relocation &r) { relocations.push_back(r); }
 void GotSection::addEntry(const Symbol &sym) {
   assert(sym.auxIdx == ctx.symAux.size() - 1);
   ctx.symAux.back().gotIdx = numEntries++;
+  if (sym.hasFlag(NEEDS_GOT_AUTH))
+    authEntries.push_back({(numEntries - 1) * ctx.arg.wordsize, sym.isFunc()});
 }
 
 bool GotSection::addTlsDescEntry(const Symbol &sym) {
@@ -732,6 +734,21 @@ void GotSection::writeTo(uint8_t *buf) {
     return;
   ctx.target->writeGotHeader(buf);
   ctx.target->relocateAlloc(*this, buf);
+  for (const AuthEntryInfo &authEntry : authEntries) {
+    // https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#default-signing-schema
+    //   Signed GOT entries use the IA key for symbols of type STT_FUNC and the
+    //   DA key for all other symbol types, with the address of the GOT entry as
+    //   the modifier. The static linker must encode the signing schema into the
+    //   GOT slot.
+    //
+    // https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#encoding-the-signing-schema
+    //   If address diversity is set and the discriminator
+    //   is 0 then modifier = Place
+    uint8_t *dest = buf + authEntry.offset;
+    uint64_t key = authEntry.isSymbolFunc ? /*IA*/ 0b00 : /*DA*/ 0b10;
+    uint64_t addrDiversity = 1;
+    write64(ctx, dest, (addrDiversity << 63) | (key << 60));
+  }
 }
 
 static uint64_t getMipsPageAddr(uint64_t addr) {

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -112,6 +112,7 @@ public:
 
   void addConstant(const Relocation &r);
   void addEntry(const Symbol &sym);
+  void addAuthEntry(const Symbol &sym);
   bool addTlsDescEntry(const Symbol &sym);
   bool addDynTlsEntry(const Symbol &sym);
   bool addTlsIndex();

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -131,6 +131,11 @@ protected:
   size_t numEntries = 0;
   uint32_t tlsIndexOff = -1;
   uint64_t size = 0;
+  struct AuthEntryInfo {
+    size_t offset;
+    bool isSymbolFunc;
+  };
+  SmallVector<AuthEntryInfo, 0> authEntries;
 };
 
 // .note.GNU-stack section.

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -79,15 +79,8 @@ _start:
 
 #--- err.s
 # RUN: llvm-mc -filetype=obj -triple=aarch64 err.s -o err.o
-
 # RUN: not ld.lld err.o a.so -pie -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
-
-# ERR:      error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
-# ERR-NEXT: >>> defined in a.so
-# ERR-NEXT: >>> referenced by err.o:(.text+0x8)
-# ERR:      error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
-# ERR-NEXT: >>> defined in a.so
-# ERR-NEXT: >>> referenced by err.o:(.text+0xc)
+# ERR: error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
 
 .globl _start
 _start:

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -2,12 +2,12 @@
 
 # RUN: rm -rf %t && split-file %s %t && cd %t
 
-# RUN: llvm-mc -filetype=obj -triple=aarch64-none-linux %p/Inputs/shared.s -o a.o
+# RUN: llvm-mc -filetype=obj -triple=aarch64 %p/Inputs/shared.s -o a.o
 # RUN: ld.lld -shared a.o -o a.so
 
 #--- ok.s
 
-# RUN: llvm-mc -filetype=obj -triple=aarch64-none-linux ok.s -o ok.o
+# RUN: llvm-mc -filetype=obj -triple=aarch64 ok.s -o ok.o
 
 # RUN: ld.lld ok.o a.so -pie -o external
 # RUN: llvm-readelf -r -S -x .got external | FileCheck %s --check-prefix=EXTERNAL
@@ -80,7 +80,7 @@ _start:
 
 #--- err.s
 
-# RUN: llvm-mc -filetype=obj -triple=aarch64-none-linux err.s -o err.o
+# RUN: llvm-mc -filetype=obj -triple=aarch64 err.s -o err.o
 
 # RUN: not ld.lld err.o a.so -pie -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
 

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -1,0 +1,94 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64-none-linux %p/Inputs/shared.s -o a.o
+# RUN: ld.lld -shared a.o -o a.so
+
+#--- ok.s
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64-none-linux ok.s -o ok.o
+
+# RUN: ld.lld ok.o a.so -pie -o external
+# RUN: llvm-readelf -r -S -x .got external | FileCheck %s --check-prefix=EXTERNAL
+
+# RUN: ld.lld ok.o a.o -pie -o local
+# RUN: llvm-readelf -r -S -x .got -s local | FileCheck %s --check-prefix=LOCAL
+
+# EXTERNAL:      Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
+# EXTERNAL-NEXT: 0000000000020380  000000010000e201 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 bar + 0
+# EXTERNAL-NEXT: 0000000000020388  000000020000e201 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 zed + 0
+
+## Symbol's values for bar and zed are equal since they contain no content (see Inputs/shared.s)
+# LOCAL:         Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
+# LOCAL-NEXT:    0000000000020320  0000000000000411 R_AARCH64_AUTH_RELATIVE 10260
+# LOCAL-NEXT:    0000000000020328  0000000000000411 R_AARCH64_AUTH_RELATIVE 10260
+
+# EXTERNAL:      Hex dump of section '.got':
+# EXTERNAL-NEXT: 0x00020380 00000000 00000080 00000000 000000a0
+#                                          ^^
+#                                          0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
+#                                                            ^^
+#                                                            0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
+
+# LOCAL: Symbol table '.symtab' contains {{.*}} entries:
+# LOCAL:    Num:    Value          Size Type    Bind   Vis       Ndx Name
+# LOCAL:         0000000000010260     0 FUNC    GLOBAL DEFAULT     6 bar
+# LOCAL:         0000000000010260     0 NOTYPE  GLOBAL DEFAULT     6 zed
+
+# LOCAL:         Hex dump of section '.got':
+# LOCAL-NEXT:    0x00020320 00000000 00000080 00000000 000000a0
+#                                          ^^
+#                                          0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
+#                                                            ^^
+#                                                            0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
+
+# RUN: llvm-objdump -d external | FileCheck %s --check-prefix=EXTERNAL-ASM
+
+# EXTERNAL-ASM:      <_start>:
+# EXTERNAL-ASM-NEXT: adrp x0, 0x20000
+# EXTERNAL-ASM-NEXT: ldr  x0, [x0, #0x380]
+# EXTERNAL-ASM-NEXT: adrp x1, 0x20000
+# EXTERNAL-ASM-NEXT: add  x1, x1, #0x380
+# EXTERNAL-ASM-NEXT: adrp x0, 0x20000
+# EXTERNAL-ASM-NEXT: ldr  x0, [x0, #0x388]
+# EXTERNAL-ASM-NEXT: adrp x1, 0x20000
+# EXTERNAL-ASM-NEXT: add  x1, x1, #0x388
+
+# RUN: llvm-objdump -d local | FileCheck %s --check-prefix=LOCAL-ASM
+
+# LOCAL-ASM:         <_start>:
+# LOCAL-ASM-NEXT:    adrp x0, 0x20000
+# LOCAL-ASM-NEXT:    ldr  x0, [x0, #0x320]
+# LOCAL-ASM-NEXT:    adrp x1, 0x20000
+# LOCAL-ASM-NEXT:    add  x1, x1, #0x320
+# LOCAL-ASM-NEXT:    adrp x0, 0x20000
+# LOCAL-ASM-NEXT:    ldr  x0, [x0, #0x328]
+# LOCAL-ASM-NEXT:    adrp x1, 0x20000
+# LOCAL-ASM-NEXT:    add  x1, x1, #0x328
+
+.globl _start
+_start:
+  adrp x0, :got_auth:bar
+  ldr  x0, [x0, :got_auth_lo12:bar]
+  adrp x1, :got_auth:bar
+  add  x1, x1, :got_auth_lo12:bar
+  adrp x0, :got_auth:zed
+  ldr  x0, [x0, :got_auth_lo12:zed]
+  adrp x1, :got_auth:zed
+  add  x1, x1, :got_auth_lo12:zed
+
+#--- err.s
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64-none-linux err.s -o err.o
+
+# RUN: not ld.lld err.o a.so -pie -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
+
+# ERR: error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
+
+.globl _start
+_start:
+  adrp x0, :got_auth:bar
+  ldr  x0, [x0, :got_auth_lo12:bar]
+  adrp x0, :got:bar
+  ldr  x0, [x0, :got_lo12:bar]

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -15,8 +15,8 @@
 # RUN: llvm-readelf -r -S -x .got -s local | FileCheck %s --check-prefix=LOCAL
 
 # EXTERNAL:      Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
-# EXTERNAL-NEXT: 0000000000020380  000000010000e201 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 bar + 0
-# EXTERNAL-NEXT: 0000000000020388  000000020000e201 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 zed + 0
+# EXTERNAL-NEXT: 0000000000020380  0000000100000412 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 bar + 0
+# EXTERNAL-NEXT: 0000000000020388  0000000200000412 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 zed + 0
 
 ## Symbol's values for bar and zed are equal since they contain no content (see Inputs/shared.s)
 # LOCAL:         Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -6,7 +6,6 @@
 # RUN: ld.lld -shared a.o -o a.so
 
 #--- ok.s
-
 # RUN: llvm-mc -filetype=obj -triple=aarch64 ok.s -o ok.o
 
 # RUN: ld.lld ok.o a.so -pie -o external
@@ -79,10 +78,9 @@ _start:
   add  x1, x1, :got_auth_lo12:zed
 
 #--- err.s
-
 # RUN: llvm-mc -filetype=obj -triple=aarch64 err.s -o err.o
 
-# RUN: not ld.lld err.o a.so -pie -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
+# RUN: not ld.lld err.o a.so -pie -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
 
 # ERR:      error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
 # ERR-NEXT: >>> defined in a.so

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -84,7 +84,12 @@ _start:
 
 # RUN: not ld.lld err.o a.so -pie -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
 
-# ERR: error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
+# ERR:      error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
+# ERR-NEXT: >>> defined in a.so
+# ERR-NEXT: >>> referenced by err.o:(.text+0x8)
+# ERR:      error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
+# ERR-NEXT: >>> defined in a.so
+# ERR-NEXT: >>> referenced by err.o:(.text+0xC)
 
 .globl _start
 _start:

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -89,7 +89,7 @@ _start:
 # ERR-NEXT: >>> referenced by err.o:(.text+0x8)
 # ERR:      error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
 # ERR-NEXT: >>> defined in a.so
-# ERR-NEXT: >>> referenced by err.o:(.text+0xC)
+# ERR-NEXT: >>> referenced by err.o:(.text+0xc)
 
 .globl _start
 _start:

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -26,10 +26,10 @@
 
 # EXTERNAL:      Hex dump of section '.got':
 # EXTERNAL-NEXT: 0x00020380 00000000 00000080 00000000 000000a0
-#                                          ^^
-#                                          0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
-#                                                            ^^
-#                                                            0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
+##                                         ^^
+##                                         0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
+##                                                           ^^
+##                                                           0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
 
 # LOCAL: Symbol table '.symtab' contains {{.*}} entries:
 # LOCAL:    Num:    Value          Size Type    Bind   Vis       Ndx Name
@@ -38,10 +38,10 @@
 
 # LOCAL:         Hex dump of section '.got':
 # LOCAL-NEXT:    0x00020320 00000000 00000080 00000000 000000a0
-#                                          ^^
-#                                          0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
-#                                                            ^^
-#                                                            0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
+##                                         ^^
+##                                         0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
+##                                                           ^^
+##                                                           0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
 
 # RUN: llvm-objdump -d external | FileCheck %s --check-prefix=EXTERNAL-ASM
 

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -8,11 +8,11 @@
 #--- ok.s
 # RUN: llvm-mc -filetype=obj -triple=aarch64 ok.s -o ok.o
 
-# RUN: ld.lld ok.o a.so -pie -o external
-# RUN: llvm-readelf -r -S -x .got external | FileCheck %s --check-prefix=EXTERNAL
+# RUN: ld.lld ok.o a.so -pie -o ok1
+# RUN: llvm-readelf -r -S -x .got ok1 | FileCheck %s --check-prefix=EXTERNAL
 
-# RUN: ld.lld ok.o a.o -pie -o local
-# RUN: llvm-readelf -r -S -x .got -s local | FileCheck %s --check-prefix=LOCAL
+# RUN: ld.lld ok.o a.o -pie -o ok2
+# RUN: llvm-readelf -r -S -x .got -s ok2 | FileCheck %s --check-prefix=LOCAL
 
 # EXTERNAL:      Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
 # EXTERNAL-NEXT: 0000000000020380  0000000100000412 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 bar + 0
@@ -42,7 +42,7 @@
 ##                                                           ^^
 ##                                                           0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
 
-# RUN: llvm-objdump -d external | FileCheck %s --check-prefix=EXTERNAL-ASM
+# RUN: llvm-objdump -d ok1 | FileCheck %s --check-prefix=EXTERNAL-ASM
 
 # EXTERNAL-ASM:      <_start>:
 # EXTERNAL-ASM-NEXT: adrp x0, 0x20000
@@ -54,7 +54,7 @@
 # EXTERNAL-ASM-NEXT: adrp x1, 0x20000
 # EXTERNAL-ASM-NEXT: add  x1, x1, #0x388
 
-# RUN: llvm-objdump -d local | FileCheck %s --check-prefix=LOCAL-ASM
+# RUN: llvm-objdump -d ok2 | FileCheck %s --check-prefix=LOCAL-ASM
 
 # LOCAL-ASM:         <_start>:
 # LOCAL-ASM-NEXT:    adrp x0, 0x20000

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -79,7 +79,7 @@ _start:
 
 #--- err.s
 # RUN: llvm-mc -filetype=obj -triple=aarch64 err.s -o err.o
-# RUN: not ld.lld err.o a.so -pie -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
+# RUN: not ld.lld err.o a.so -pie 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
 # ERR: error: both AUTH and non-AUTH GOT entries for 'bar' requested, but only one type of GOT entry per symbol is supported
 
 .globl _start

--- a/lld/test/ELF/aarch64-got-relocations-pauth.s
+++ b/lld/test/ELF/aarch64-got-relocations-pauth.s
@@ -9,62 +9,62 @@
 # RUN: llvm-mc -filetype=obj -triple=aarch64 ok.s -o ok.o
 
 # RUN: ld.lld ok.o a.so -pie -o ok1
-# RUN: llvm-readelf -r -S -x .got ok1 | FileCheck %s --check-prefix=EXTERNAL
+# RUN: llvm-readelf -r -S -x .got ok1 | FileCheck %s --check-prefix=OK1
 
 # RUN: ld.lld ok.o a.o -pie -o ok2
-# RUN: llvm-readelf -r -S -x .got -s ok2 | FileCheck %s --check-prefix=LOCAL
+# RUN: llvm-readelf -r -S -x .got -s ok2 | FileCheck %s --check-prefix=OK2
 
-# EXTERNAL:      Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
-# EXTERNAL-NEXT: 0000000000020380  0000000100000412 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 bar + 0
-# EXTERNAL-NEXT: 0000000000020388  0000000200000412 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 zed + 0
+# OK1:      Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
+# OK1-NEXT: 0000000000020380  0000000100000412 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 bar + 0
+# OK1-NEXT: 0000000000020388  0000000200000412 R_AARCH64_AUTH_GLOB_DAT 0000000000000000 zed + 0
 
 ## Symbol's values for bar and zed are equal since they contain no content (see Inputs/shared.s)
-# LOCAL:         Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
-# LOCAL-NEXT:    0000000000020320  0000000000000411 R_AARCH64_AUTH_RELATIVE 10260
-# LOCAL-NEXT:    0000000000020328  0000000000000411 R_AARCH64_AUTH_RELATIVE 10260
+# OK2:         Offset            Info             Type                    Symbol's Value   Symbol's Name + Addend
+# OK2-NEXT:    0000000000020320  0000000000000411 R_AARCH64_AUTH_RELATIVE 10260
+# OK2-NEXT:    0000000000020328  0000000000000411 R_AARCH64_AUTH_RELATIVE 10260
 
-# EXTERNAL:      Hex dump of section '.got':
-# EXTERNAL-NEXT: 0x00020380 00000000 00000080 00000000 000000a0
+# OK1:      Hex dump of section '.got':
+# OK1-NEXT: 0x00020380 00000000 00000080 00000000 000000a0
 ##                                         ^^
 ##                                         0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
 ##                                                           ^^
 ##                                                           0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
 
-# LOCAL: Symbol table '.symtab' contains {{.*}} entries:
-# LOCAL:    Num:    Value          Size Type    Bind   Vis       Ndx Name
-# LOCAL:         0000000000010260     0 FUNC    GLOBAL DEFAULT     6 bar
-# LOCAL:         0000000000010260     0 NOTYPE  GLOBAL DEFAULT     6 zed
+# OK2: Symbol table '.symtab' contains {{.*}} entries:
+# OK2:    Num:    Value          Size Type    Bind   Vis       Ndx Name
+# OK2:         0000000000010260     0 FUNC    GLOBAL DEFAULT     6 bar
+# OK2:         0000000000010260     0 NOTYPE  GLOBAL DEFAULT     6 zed
 
-# LOCAL:         Hex dump of section '.got':
-# LOCAL-NEXT:    0x00020320 00000000 00000080 00000000 000000a0
+# OK2:         Hex dump of section '.got':
+# OK2-NEXT:    0x00020320 00000000 00000080 00000000 000000a0
 ##                                         ^^
 ##                                         0b10000000 bit 63 address diversity = true, bits 61..60 key = IA
 ##                                                           ^^
 ##                                                           0b10100000 bit 63 address diversity = true, bits 61..60 key = DA
 
-# RUN: llvm-objdump -d ok1 | FileCheck %s --check-prefix=EXTERNAL-ASM
+# RUN: llvm-objdump -d ok1 | FileCheck %s --check-prefix=OK1-ASM
 
-# EXTERNAL-ASM:      <_start>:
-# EXTERNAL-ASM-NEXT: adrp x0, 0x20000
-# EXTERNAL-ASM-NEXT: ldr  x0, [x0, #0x380]
-# EXTERNAL-ASM-NEXT: adrp x1, 0x20000
-# EXTERNAL-ASM-NEXT: add  x1, x1, #0x380
-# EXTERNAL-ASM-NEXT: adrp x0, 0x20000
-# EXTERNAL-ASM-NEXT: ldr  x0, [x0, #0x388]
-# EXTERNAL-ASM-NEXT: adrp x1, 0x20000
-# EXTERNAL-ASM-NEXT: add  x1, x1, #0x388
+# OK1-ASM:      <_start>:
+# OK1-ASM-NEXT: adrp x0, 0x20000
+# OK1-ASM-NEXT: ldr  x0, [x0, #0x380]
+# OK1-ASM-NEXT: adrp x1, 0x20000
+# OK1-ASM-NEXT: add  x1, x1, #0x380
+# OK1-ASM-NEXT: adrp x0, 0x20000
+# OK1-ASM-NEXT: ldr  x0, [x0, #0x388]
+# OK1-ASM-NEXT: adrp x1, 0x20000
+# OK1-ASM-NEXT: add  x1, x1, #0x388
 
-# RUN: llvm-objdump -d ok2 | FileCheck %s --check-prefix=LOCAL-ASM
+# RUN: llvm-objdump -d ok2 | FileCheck %s --check-prefix=OK2-ASM
 
-# LOCAL-ASM:         <_start>:
-# LOCAL-ASM-NEXT:    adrp x0, 0x20000
-# LOCAL-ASM-NEXT:    ldr  x0, [x0, #0x320]
-# LOCAL-ASM-NEXT:    adrp x1, 0x20000
-# LOCAL-ASM-NEXT:    add  x1, x1, #0x320
-# LOCAL-ASM-NEXT:    adrp x0, 0x20000
-# LOCAL-ASM-NEXT:    ldr  x0, [x0, #0x328]
-# LOCAL-ASM-NEXT:    adrp x1, 0x20000
-# LOCAL-ASM-NEXT:    add  x1, x1, #0x328
+# OK2-ASM:         <_start>:
+# OK2-ASM-NEXT:    adrp x0, 0x20000
+# OK2-ASM-NEXT:    ldr  x0, [x0, #0x320]
+# OK2-ASM-NEXT:    adrp x1, 0x20000
+# OK2-ASM-NEXT:    add  x1, x1, #0x320
+# OK2-ASM-NEXT:    adrp x0, 0x20000
+# OK2-ASM-NEXT:    ldr  x0, [x0, #0x328]
+# OK2-ASM-NEXT:    adrp x1, 0x20000
+# OK2-ASM-NEXT:    add  x1, x1, #0x328
 
 .globl _start
 _start:


### PR DESCRIPTION
Depends on #113811

Support `R_AARCH64_AUTH_ADR_GOT_PAGE`, `R_AARCH64_AUTH_GOT_LO12_NC` and
`R_AARCH64_AUTH_GOT_ADD_LO12_NC` GOT-generating relocations. For preemptible
symbols, dynamic relocation `R_AARCH64_AUTH_GLOB_DAT` is emitted. Otherwise,
we unconditionally emit `R_AARCH64_AUTH_RELATIVE` dynamic relocation since
pointers in signed GOT needs to be signed during dynamic link time.