### PR TITLE
[clang-tidy] fix crash in altera-id-dependent-backward-branch

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -141,6 +141,10 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`altera-id-dependent-backward-branch
+  <clang-tidy/checks/altera/id-dependent-backward-branch>` check by fixing
+  crashes from invalid code.
+
 - Improved :doc:`bugprone-casting-through-void
   <clang-tidy/checks/bugprone/casting-through-void>` check to suggest replacing
   the offending code with ``reinterpret_cast``, to more clearly express intent.

--- a/clang-tools-extra/test/clang-tidy/checkers/altera/id-dependent-backward-branch.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/altera/id-dependent-backward-branch.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s altera-id-dependent-backward-branch %t -- -header-filter=.* "--" -cl-std=CL1.2 -c
+// RUN: %check_clang_tidy %s altera-id-dependent-backward-branch %t -- -header-filter=.* "--" -cl-std=CLC++1.0 -c
 
 void error() {
   // ==== Conditional Expressions ====
@@ -80,3 +80,9 @@ void success() {
     }
   }
 }
+
+template<char... STOP>
+void gh55408(char const input[], int pos) {
+  while (((input[pos] != STOP) && ...));
+}
+


### PR DESCRIPTION
Add some checks for `nullptr` and change some `dyn_cast` to
`dyn_cast_if_present` to avoid crashes.

Fixes #55408
