### PR TITLE
[NFC][lldb-dap] Clean-up includes

### DIFF
--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -9,6 +9,7 @@
 #include "Breakpoint.h"
 #include "DAP.h"
 #include "JSONUtils.h"
+#include "lldb/API/SBBreakpointLocation.h"
 #include "llvm/ADT/StringExtras.h"
 
 using namespace lldb_dap;

--- a/lldb/tools/lldb-dap/Breakpoint.h
+++ b/lldb/tools/lldb-dap/Breakpoint.h
@@ -10,6 +10,7 @@
 #define LLDB_TOOLS_LLDB_DAP_BREAKPOINT_H
 
 #include "BreakpointBase.h"
+#include "lldb/API/SBBreakpoint.h"
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/BreakpointBase.cpp
+++ b/lldb/tools/lldb-dap/BreakpointBase.cpp
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "BreakpointBase.h"
-#include "DAP.h"
-#include "llvm/ADT/StringExtras.h"
+#include "JSONUtils.h"
 
 using namespace lldb_dap;
 

--- a/lldb/tools/lldb-dap/BreakpointBase.h
+++ b/lldb/tools/lldb-dap/BreakpointBase.h
@@ -9,10 +9,8 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_BREAKPOINTBASE_H
 #define LLDB_TOOLS_LLDB_DAP_BREAKPOINTBASE_H
 
-#include "lldb/API/SBBreakpoint.h"
 #include "llvm/Support/JSON.h"
 #include <string>
-#include <vector>
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -10,11 +10,14 @@
 #include <cstdarg>
 #include <fstream>
 #include <mutex>
-#include <sstream>
 
 #include "DAP.h"
+#include "JSONUtils.h"
 #include "LLDBUtils.h"
 #include "lldb/API/SBCommandInterpreter.h"
+#include "lldb/API/SBLanguageRuntime.h"
+#include "lldb/API/SBListener.h"
+#include "lldb/API/SBStream.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -9,16 +9,10 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_DAP_H
 #define LLDB_TOOLS_LLDB_DAP_DAP_H
 
-#include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
-
-#include <atomic>
-#include <condition_variable>
 #include <cstdio>
-#include <future>
 #include <iosfwd>
 #include <map>
 #include <optional>
-#include <set>
 #include <thread>
 
 #include "llvm/ADT/DenseMap.h"
@@ -30,24 +24,12 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "lldb/API/SBAttachInfo.h"
-#include "lldb/API/SBBreakpoint.h"
-#include "lldb/API/SBBreakpointLocation.h"
 #include "lldb/API/SBCommandInterpreter.h"
 #include "lldb/API/SBCommandReturnObject.h"
-#include "lldb/API/SBCommunication.h"
 #include "lldb/API/SBDebugger.h"
 #include "lldb/API/SBEvent.h"
 #include "lldb/API/SBFormat.h"
-#include "lldb/API/SBHostOS.h"
-#include "lldb/API/SBInstruction.h"
-#include "lldb/API/SBInstructionList.h"
-#include "lldb/API/SBLanguageRuntime.h"
 #include "lldb/API/SBLaunchInfo.h"
-#include "lldb/API/SBLineEntry.h"
-#include "lldb/API/SBListener.h"
-#include "lldb/API/SBProcess.h"
-#include "lldb/API/SBStream.h"
-#include "lldb/API/SBStringList.h"
 #include "lldb/API/SBTarget.h"
 #include "lldb/API/SBThread.h"
 
@@ -56,7 +38,6 @@
 #include "IOStream.h"
 #include "InstructionBreakpoint.h"
 #include "ProgressEvent.h"
-#include "RunInTerminal.h"
 #include "SourceBreakpoint.h"
 
 #define VARREF_LOCALS (int64_t)1

--- a/lldb/tools/lldb-dap/FifoFiles.cpp
+++ b/lldb/tools/lldb-dap/FifoFiles.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "FifoFiles.h"
+#include "JSONUtils.h"
 
 #if !defined(_WIN32)
 #include <sys/stat.h>
@@ -18,11 +19,6 @@
 #include <fstream>
 #include <future>
 #include <optional>
-#include <thread>
-
-#include "llvm/Support/FileSystem.h"
-
-#include "lldb/lldb-defines.h"
 
 using namespace llvm;
 

--- a/lldb/tools/lldb-dap/FifoFiles.h
+++ b/lldb/tools/lldb-dap/FifoFiles.h
@@ -9,10 +9,8 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_FIFOFILES_H
 #define LLDB_TOOLS_LLDB_DAP_FIFOFILES_H
 
-#include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/Support/Error.h"
-
-#include "JSONUtils.h"
+#include "llvm/Support/JSON.h"
 
 #include <chrono>
 

--- a/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
@@ -8,6 +8,7 @@
 
 #include "FunctionBreakpoint.h"
 #include "DAP.h"
+#include "JSONUtils.h"
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/IOStream.cpp
+++ b/lldb/tools/lldb-dap/IOStream.cpp
@@ -18,7 +18,6 @@
 
 #include <fstream>
 #include <string>
-#include <vector>
 
 using namespace lldb_dap;
 

--- a/lldb/tools/lldb-dap/IOStream.h
+++ b/lldb/tools/lldb-dap/IOStream.h
@@ -9,8 +9,6 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_IOSTREAM_H
 #define LLDB_TOOLS_LLDB_DAP_IOSTREAM_H
 
-#include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
-
 #if defined(_WIN32)
 // We need to #define NOMINMAX in order to skip `min()` and `max()` macro
 // definitions that conflict with other system headers.

--- a/lldb/tools/lldb-dap/InstructionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/InstructionBreakpoint.cpp
@@ -9,6 +9,7 @@
 
 #include "InstructionBreakpoint.h"
 #include "DAP.h"
+#include "JSONUtils.h"
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/InstructionBreakpoint.h
+++ b/lldb/tools/lldb-dap/InstructionBreakpoint.h
@@ -11,7 +11,6 @@
 #define LLDB_TOOLS_LLDB_DAP_INSTRUCTIONBREAKPOINT_H
 
 #include "Breakpoint.h"
-#include "llvm/ADT/StringRef.h"
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -6,25 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <algorithm>
 #include <iomanip>
 #include <optional>
 #include <sstream>
 #include <string.h>
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ScopedPrinter.h"
 
-#include "lldb/API/SBBreakpoint.h"
-#include "lldb/API/SBBreakpointLocation.h"
 #include "lldb/API/SBDeclaration.h"
+#include "lldb/API/SBStream.h"
 #include "lldb/API/SBStringList.h"
 #include "lldb/API/SBStructuredData.h"
 #include "lldb/API/SBValue.h"
-#include "lldb/Host/PosixApi.h"
 
 #include "DAP.h"
 #include "ExceptionBreakpoint.h"

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -8,6 +8,8 @@
 
 #include "LLDBUtils.h"
 #include "DAP.h"
+#include "JSONUtils.h"
+#include "lldb/API/SBStringList.h"
 
 #include <mutex>
 

--- a/lldb/tools/lldb-dap/OutputRedirector.h
+++ b/lldb/tools/lldb-dap/OutputRedirector.h
@@ -9,8 +9,6 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_OUTPUT_REDIRECTOR_H
 #define LLDB_TOOLS_LLDB_DAP_OUTPUT_REDIRECTOR_H
 
-#include <thread>
-
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 

--- a/lldb/tools/lldb-dap/RunInTerminal.cpp
+++ b/lldb/tools/lldb-dap/RunInTerminal.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "RunInTerminal.h"
+#include "JSONUtils.h"
 
 #if !defined(_WIN32)
 #include <sys/stat.h>
@@ -15,13 +16,9 @@
 #endif
 
 #include <chrono>
-#include <fstream>
 #include <future>
-#include <thread>
 
 #include "llvm/Support/FileSystem.h"
-
-#include "lldb/lldb-defines.h"
 
 using namespace llvm;
 

--- a/lldb/tools/lldb-dap/RunInTerminal.h
+++ b/lldb/tools/lldb-dap/RunInTerminal.h
@@ -10,9 +10,11 @@
 #define LLDB_TOOLS_LLDB_DAP_RUNINTERMINAL_H
 
 #include "FifoFiles.h"
+#include "lldb/API/SBError.h"
 
 #include <future>
-#include <thread>
+#include <memory>
+#include <string>
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -8,6 +8,7 @@
 
 #include "SourceBreakpoint.h"
 #include "DAP.h"
+#include "JSONUtils.h"
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -7,9 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "DAP.h"
+#include "FifoFiles.h"
+#include "RunInTerminal.h"
 #include "Watchpoint.h"
 #include "lldb/API/SBDeclaration.h"
+#include "lldb/API/SBInstruction.h"
+#include "lldb/API/SBListener.h"
 #include "lldb/API/SBMemoryRegionInfo.h"
+#include "lldb/API/SBStringList.h"
 #include "llvm/Support/Base64.h"
 
 #include <cassert>
@@ -43,17 +48,12 @@
 
 #include <algorithm>
 #include <array>
-#include <chrono>
-#include <fstream>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <set>
-#include <sstream>
 #include <thread>
 #include <vector>
 
-#include "lldb/API/SBEnvironment.h"
 #include "lldb/API/SBStream.h"
 #include "lldb/Host/Config.h"
 #include "llvm/ADT/ArrayRef.h"


### PR DESCRIPTION
This commit cleans up the includes in the `lldb-dap` subfolder. The main motivation was that I got annoyed by `clangd` always complaining about unused includes while working on lldb-dap.