### PR TITLE
[StackSafetyAnalysis] Bail out when calling ifunc

### DIFF
--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -528,7 +528,7 @@ void StackSafetyLocalAnalysis::analyzeAllUses(Value *Ptr,
         // dso_preemptable aliases or aliases with interposable linkage.
         const GlobalValue *Callee =
             dyn_cast<GlobalValue>(CB.getCalledOperand()->stripPointerCasts());
-        if (!Callee) {
+        if (!Callee || isa<GlobalIFunc>(Callee)) {
           US.addRange(I, UnknownRange, /*IsSafe=*/false);
           break;
         }

--- a/llvm/test/Analysis/StackSafetyAnalysis/local.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/local.ll
@@ -1120,5 +1120,21 @@ define void @NonPointer(ptr %p) {
   ret void
 }
 
+@ifunc = dso_local ifunc i64 (ptr), ptr @ifunc_resolver
+
+define dso_local void @CallIfunc(ptr noundef %uaddr) local_unnamed_addr {
+; CHECK-LABEL: @CallIfunc
+; CHECK-NEXT:  args uses:
+; CHECK-NEXT:    uaddr[]: full-set
+entry:
+  tail call i64 @ifunc(ptr noundef %uaddr)
+  ret void
+}
+
+define dso_local ptr @ifunc_resolver() {
+entry:
+  ret ptr null
+}
+
 declare void @llvm.lifetime.start.p0(i64, ptr nocapture)
 declare void @llvm.lifetime.end.p0(i64, ptr nocapture)


### PR DESCRIPTION
An assertion failure arises when a call instruction calls a GlobalIFunc.
Since we cannot reason about the underlying function, just bail out.

Fix #87923
