### PR TITLE
Optimize vector::assign for InputIterator-only pair inputs

### DIFF
--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -69,9 +69,8 @@ Improvements and New Features
 - The ``_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY`` ABI configuration was added, which allows storing valid bounds
   in ``std::array::iterator`` and detecting OOB accesses when the appropriate hardening mode is enabled.
 
-- The `assign(_InputIterator, _InputIterator)` function of `std::vector<_Tp, _Allocator>` has been optimized for
-  non-trivial element types, such as `std::vector<std::string>`, with a performance improvement of up to 2.3x. The
-  performance for trivial types, such as `std::vector<int>`, remains similar or shows slight improvements.
+- The input iterator overload of `assign(_InputIterator, _InputIterator)` in `std::vector<_Tp, _Allocator>` has been 
+  optimized, resulting in a performance improvement of up to 3.7x.
 
 Deprecations and Removals
 -------------------------

--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -69,6 +69,10 @@ Improvements and New Features
 - The ``_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY`` ABI configuration was added, which allows storing valid bounds
   in ``std::array::iterator`` and detecting OOB accesses when the appropriate hardening mode is enabled.
 
+- The `assign(_InputIterator, _InputIterator)` function of `std::vector<_Tp, _Allocator>` has been optimized for
+  non-trivial element types, such as `std::vector<std::string>`, with a performance improvement of up to 2.3x. The
+  performance for trivial types, such as `std::vector<int>`, remains similar or shows slight improvements.
+
 Deprecations and Removals
 -------------------------
 

--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -69,8 +69,9 @@ Improvements and New Features
 - The ``_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY`` ABI configuration was added, which allows storing valid bounds
   in ``std::array::iterator`` and detecting OOB accesses when the appropriate hardening mode is enabled.
 
-- The input iterator overload of `assign(_InputIterator, _InputIterator)` in `std::vector<_Tp, _Allocator>` has been 
-  optimized, resulting in a performance improvement of up to 3.7x.
+- The input iterator overload of `assign(_InputIterator, _InputIterator)` in `std::vector<_Tp, _Allocator>` has been
+  optimized, resulting in a performance improvement of up to 2x for trivial element types (e.g., `std::vector<int>`),
+  and up to 3.4x for non-trivial element types (e.g., `std::vector<std::vector<int>>`).
 
 Deprecations and Removals
 -------------------------

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1004,7 +1004,7 @@ template <class _Iterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
 vector<_Tp, _Allocator>::__assign_with_sentinel(_Iterator __first, _Sentinel __last) {
   pointer __cur = __begin_;
-  for (; __first != __last && __cur != __end_; ++__cur, ++__first)
+  for (; __first != __last && __cur != __end_; ++__first, (void)++__cur)
     *__cur = *__first;
   if (__cur != __end_)
     __destruct_at_end(__cur);

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1006,11 +1006,12 @@ vector<_Tp, _Allocator>::__assign_with_sentinel(_Iterator __first, _Sentinel __l
   pointer __cur = __begin_;
   for (; __first != __last && __cur != __end_; ++__first, (void)++__cur)
     *__cur = *__first;
-  if (__cur != __end_)
+  if (__cur != __end_) {
     __destruct_at_end(__cur);
-  else
+  } else {
     for (; __first != __last; ++__first)
       emplace_back(*__first);
+  }
 }
 
 template <class _Tp, class _Allocator>

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1003,9 +1003,14 @@ template <class _Tp, class _Allocator>
 template <class _Iterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
 vector<_Tp, _Allocator>::__assign_with_sentinel(_Iterator __first, _Sentinel __last) {
-  clear();
-  for (; __first != __last; ++__first)
-    emplace_back(*__first);
+  pointer __cur = __begin_;
+  for (; __first != __last && __cur != __end_; ++__cur, ++__first)
+    *__cur = *__first;
+  if (__cur != __end_)
+    __destruct_at_end(__cur);
+  else
+    for (; __first != __last; ++__first)
+      emplace_back(*__first);
 }
 
 template <class _Tp, class _Allocator>

--- a/libcxx/test/benchmarks/ContainerBenchmarks.h
+++ b/libcxx/test/benchmarks/ContainerBenchmarks.h
@@ -50,6 +50,76 @@ void BM_Assignment(benchmark::State& st, Container) {
   }
 }
 
+// Wrap any Iterator into an input iterator
+template <typename Iterator>
+class InputIterator {
+  using iter_traits = std::iterator_traits<Iterator>;
+
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type        = typename iter_traits::value_type;
+  using difference_type   = typename iter_traits::difference_type;
+  using pointer           = typename iter_traits::pointer;
+  using reference         = typename iter_traits::reference;
+
+  InputIterator(Iterator it) : current_(it) {}
+
+  reference operator*() { return *current_; }
+  InputIterator& operator++() {
+    ++current_;
+    return *this;
+  }
+  InputIterator operator++(int) {
+    InputIterator tmp = *this;
+    ++(*this);
+    return tmp;
+  }
+
+  friend bool operator==(const InputIterator& lhs, const InputIterator& rhs) { return lhs.current_ == rhs.current_; }
+  friend bool operator!=(const InputIterator& lhs, const InputIterator& rhs) { return !(lhs == rhs); }
+
+private:
+  Iterator current_;
+};
+
+template <typename Iterator>
+InputIterator<Iterator> make_input_iterator(Iterator it) {
+  return InputIterator<Iterator>(it);
+}
+
+template <class Container,
+          class GenInputs,
+          typename std::enable_if<std::is_trivial<typename Container::value_type>::value>::type* = nullptr>
+void BM_AssignInputIterIter(benchmark::State& st, Container c, GenInputs gen) {
+  auto in = gen(st.range(1));
+  benchmark::DoNotOptimize(&in);
+  for (auto _ : st) {
+    st.PauseTiming();
+    c.resize(st.range(0));
+    benchmark::DoNotOptimize(&c);
+    st.ResumeTiming();
+    c.assign(make_input_iterator(in.begin()), make_input_iterator(in.end()));
+    benchmark::ClobberMemory();
+  }
+}
+
+template <class Container,
+          class GenInputs,
+          typename std::enable_if<!std::is_trivial<typename Container::value_type>::value>::type* = nullptr>
+void BM_AssignInputIterIter(benchmark::State& st, Container c, GenInputs gen) {
+  auto v  = gen(1, 100);
+  auto in = gen(st.range(1), 32);
+  benchmark::DoNotOptimize(&in);
+  for (auto _ : st) {
+    st.PauseTiming();
+    c.resize(st.range(0), v[0]);
+    benchmark::DoNotOptimize(&c);
+    st.ResumeTiming();
+    c.assign(make_input_iterator(in.begin()), make_input_iterator(in.end()));
+    benchmark::ClobberMemory();
+  }
+}
+
 template <class Container>
 void BM_ConstructSizeValue(benchmark::State& st, Container, typename Container::value_type const& val) {
   const auto size = st.range(0);

--- a/libcxx/test/benchmarks/ContainerBenchmarks.h
+++ b/libcxx/test/benchmarks/ContainerBenchmarks.h
@@ -69,7 +69,7 @@ template <class Container,
           class GenInputs,
           typename std::enable_if<!std::is_trivial<typename Container::value_type>::value>::type* = nullptr>
 void BM_AssignInputIterIter(benchmark::State& st, Container c, GenInputs gen) {
-  auto v  = gen(1, 100);
+  auto v = gen(1, 100);
   c.resize(st.range(0), v[0]);
   auto in = gen(st.range(1), 32);
   benchmark::DoNotOptimize(&in);

--- a/libcxx/test/benchmarks/ContainerBenchmarks.h
+++ b/libcxx/test/benchmarks/ContainerBenchmarks.h
@@ -51,27 +51,11 @@ void BM_Assignment(benchmark::State& st, Container) {
   }
 }
 
-template <class Container,
-          class GenInputs,
-          typename std::enable_if<std::is_trivial<typename Container::value_type>::value>::type* = nullptr>
+template <std::size_t... sz, typename Container, typename GenInputs>
 void BM_AssignInputIterIter(benchmark::State& st, Container c, GenInputs gen) {
-  auto in = gen(st.range(1));
-  c.resize(st.range(0));
-  benchmark::DoNotOptimize(&in);
-  benchmark::DoNotOptimize(&c);
-  for (auto _ : st) {
-    c.assign(cpp17_input_iterator(in.begin()), cpp17_input_iterator(in.end()));
-    benchmark::ClobberMemory();
-  }
-}
-
-template <class Container,
-          class GenInputs,
-          typename std::enable_if<!std::is_trivial<typename Container::value_type>::value>::type* = nullptr>
-void BM_AssignInputIterIter(benchmark::State& st, Container c, GenInputs gen) {
-  auto v = gen(1, 100);
+  auto v = gen(1, sz...);
   c.resize(st.range(0), v[0]);
-  auto in = gen(st.range(1), 32);
+  auto in = gen(st.range(1), sz...);
   benchmark::DoNotOptimize(&in);
   benchmark::DoNotOptimize(&c);
   for (auto _ : st) {

--- a/libcxx/test/benchmarks/GenerateInput.h
+++ b/libcxx/test/benchmarks/GenerateInput.h
@@ -121,11 +121,20 @@ inline std::vector<std::string> getRandomStringInputs(std::size_t N) {
   return inputs;
 }
 
-inline std::vector<std::string> getRandomStringInputsWithLength(std::size_t N, std::size_t len) {
+inline std::vector<std::string> getRandomStringInputsWithLength(std::size_t N, std::size_t len) { // N-by-len
   std::vector<std::string> inputs;
   inputs.reserve(N);
-  for (size_t i = 0; i < N; ++i)
+  for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(getRandomString(len));
+  return inputs;
+}
+
+template <class IntT>
+inline std::vector<std::vector<IntT>> getRandomIntegerInputsWithLength(std::size_t N, std::size_t len) { // N-by-len
+  std::vector<std::vector<IntT>> inputs;
+  inputs.reserve(N);
+  for (std::size_t i = 0; i < N; ++i)
+    inputs.push_back(getRandomIntegerInputs<IntT>(len));
   return inputs;
 }
 

--- a/libcxx/test/benchmarks/GenerateInput.h
+++ b/libcxx/test/benchmarks/GenerateInput.h
@@ -108,19 +108,6 @@ std::vector<IntT> getRandomIntegerInputs(std::size_t N) {
   return inputs;
 }
 
-inline std::vector<std::string> getDuplicateStringInputs(std::size_t N) {
-  std::vector<std::string> inputs(N, getRandomString(1024));
-  return inputs;
-}
-
-inline std::vector<std::string> getRandomStringInputs(std::size_t N) {
-  std::vector<std::string> inputs;
-  inputs.reserve(N);
-  for (std::size_t i = 0; i < N; ++i)
-    inputs.push_back(getRandomString(1024));
-  return inputs;
-}
-
 inline std::vector<std::string> getRandomStringInputsWithLength(std::size_t N, std::size_t len) { // N-by-len
   std::vector<std::string> inputs;
   inputs.reserve(N);
@@ -129,8 +116,17 @@ inline std::vector<std::string> getRandomStringInputsWithLength(std::size_t N, s
   return inputs;
 }
 
+inline std::vector<std::string> getDuplicateStringInputs(std::size_t N) {
+  std::vector<std::string> inputs(N, getRandomString(1024));
+  return inputs;
+}
+
+inline std::vector<std::string> getRandomStringInputs(std::size_t N) {
+  return getRandomStringInputsWithLength(N, 1024);
+}
+
 template <class IntT>
-inline std::vector<std::vector<IntT>> getRandomIntegerInputsWithLength(std::size_t N, std::size_t len) { // N-by-len
+std::vector<std::vector<IntT>> getRandomIntegerInputsWithLength(std::size_t N, std::size_t len) { // N-by-len
   std::vector<std::vector<IntT>> inputs;
   inputs.reserve(N);
   for (std::size_t i = 0; i < N; ++i)

--- a/libcxx/test/benchmarks/GenerateInput.h
+++ b/libcxx/test/benchmarks/GenerateInput.h
@@ -121,6 +121,14 @@ inline std::vector<std::string> getRandomStringInputs(std::size_t N) {
   return inputs;
 }
 
+inline std::vector<std::string> getRandomStringInputsWithLength(std::size_t N, std::size_t len) {
+  std::vector<std::string> inputs;
+  inputs.reserve(N);
+  for (size_t i = 0; i < N; ++i)
+    inputs.push_back(getRandomString(len));
+  return inputs;
+}
+
 inline std::vector<std::string> getPrefixedRandomStringInputs(std::size_t N) {
   std::vector<std::string> inputs;
   inputs.reserve(N);

--- a/libcxx/test/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/vector_operations.bench.cpp
@@ -85,4 +85,8 @@ BENCHMARK_CAPTURE(BM_AssignInputIterIter, vector_int, std::vector<int>{}, getRan
 BENCHMARK_CAPTURE(BM_AssignInputIterIter, vector_string, std::vector<std::string>{}, getRandomStringInputsWithLength)
     ->Args({TestNumInputs, TestNumInputs});
 
+BENCHMARK_CAPTURE(
+    BM_AssignInputIterIter, vector_vector_int, std::vector<std::vector<int>>{}, getRandomIntegerInputsWithLength<int>)
+    ->Args({TestNumInputs, TestNumInputs});
+
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/vector_operations.bench.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "benchmark/benchmark.h"
-
 #include "ContainerBenchmarks.h"
 #include "GenerateInput.h"
 

--- a/libcxx/test/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/vector_operations.bench.cpp
@@ -79,4 +79,10 @@ BENCHMARK(bm_grow<std::string>);
 BENCHMARK(bm_grow<std::unique_ptr<int>>);
 BENCHMARK(bm_grow<std::deque<int>>);
 
+BENCHMARK_CAPTURE(BM_AssignInputIterIter, vector_int, std::vector<int>{}, getRandomIntegerInputs<int>)
+    ->Args({TestNumInputs, TestNumInputs});
+
+BENCHMARK_CAPTURE(BM_AssignInputIterIter, vector_string, std::vector<std::string>{}, getRandomStringInputsWithLength)
+    ->Args({TestNumInputs, TestNumInputs});
+
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/vector_operations.bench.cpp
@@ -82,11 +82,14 @@ BENCHMARK(bm_grow<std::deque<int>>);
 BENCHMARK_CAPTURE(BM_AssignInputIterIter, vector_int, std::vector<int>{}, getRandomIntegerInputs<int>)
     ->Args({TestNumInputs, TestNumInputs});
 
-BENCHMARK_CAPTURE(BM_AssignInputIterIter, vector_string, std::vector<std::string>{}, getRandomStringInputsWithLength)
+BENCHMARK_CAPTURE(
+    BM_AssignInputIterIter<32>, vector_string, std::vector<std::string>{}, getRandomStringInputsWithLength)
     ->Args({TestNumInputs, TestNumInputs});
 
-BENCHMARK_CAPTURE(
-    BM_AssignInputIterIter, vector_vector_int, std::vector<std::vector<int>>{}, getRandomIntegerInputsWithLength<int>)
+BENCHMARK_CAPTURE(BM_AssignInputIterIter<100>,
+                  vector_vector_int,
+                  std::vector<std::vector<int>>{},
+                  getRandomIntegerInputsWithLength<int>)
     ->Args({TestNumInputs, TestNumInputs});
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
This PR optimizes the input iterator overload of `assign(_InputIterator, _InputIterator)` in `std::vector<_Tp, _Allocator>` by directly assigning to already initialized memory, rather than first destroying existing elements and then constructing new ones. By eliminating unnecessary destruction and construction, the proposed algorithm enhances the performance by up to 2x for trivial element types (e.g., `std::vector<int>`), up to 2.6x for non-trivial element types like `std::vector<std::string>`, and up to 3.4x for more complex non-trivial types (e.g., `std::vector<std::vector<int>>`).

###  Google Benchmarks

Benchmark tests (`libcxx/test/benchmarks/vector_operations.bench.cpp`) were conducted for the `assign()` implementations before and after this patch. The tests focused on trivial element types like `std::vector<int>`, and non-trivial element types such as `std::vector<std::string>` and `std::vector<std::vector<int>>`. 



#### Before
```
-------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations
-------------------------------------------------------------------------------------------------
BM_AssignInputIterIter/vector_int/1024/1024                  1157 ns         1169 ns       608188
BM_AssignInputIterIter<32>/vector_string/1024/1024          14559 ns        14710 ns        47277
BM_AssignInputIterIter<32>/vector_vector_int/1024/1024      26846 ns        27129 ns        25925
```


#### After
```
-------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations
-------------------------------------------------------------------------------------------------
BM_AssignInputIterIter/vector_int/1024/1024                   561 ns          566 ns      1242251
BM_AssignInputIterIter<32>/vector_string/1024/1024           5604 ns         5664 ns       128365
BM_AssignInputIterIter<32>/vector_vector_int/1024/1024       7927 ns         8012 ns        88579
```
