### PR TITLE
[CodeGen] Add comment to MachineBasicBlock::instrs method.

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -369,6 +369,10 @@ public:
 
   using instr_range = iterator_range<instr_iterator>;
   using const_instr_range = iterator_range<const_instr_iterator>;
+
+  /// Range that iterates over all instructions in the basic block.
+  ///
+  /// Unlike begin/end methods the range contains bundled instructions.
   instr_range instrs() { return instr_range(instr_begin(), instr_end()); }
   const_instr_range instrs() const {
     return const_instr_range(instr_begin(), instr_end());


### PR DESCRIPTION
Add comment that `MachineBasicBlock::instrs` method returns range that iterates over bundled instructions unlike `begin`/`end` methods returns range over bundled instructions.

https://github.com/llvm/llvm-project/pull/113676#pullrequestreview-2396990040
