### PR TITLE
[MLIR][SPIRV] Replace some auto to concrete type

### DIFF
--- a/mlir/lib/Dialect/SPIRV/Utils/LayoutUtils.cpp
+++ b/mlir/lib/Dialect/SPIRV/Utils/LayoutUtils.cpp
@@ -43,7 +43,7 @@ VulkanLayoutUtils::decorateType(spirv::StructType structType,
     Size memberSize = 0;
     Size memberAlignment = 1;
 
-    auto memberType =
+    Type memberType =
         decorateType(structType.getElementType(i), memberSize, memberAlignment);
     structMemberOffset = llvm::alignTo(structMemberOffset, memberAlignment);
     memberTypes.push_back(memberType);
@@ -105,12 +105,12 @@ Type VulkanLayoutUtils::decorateType(Type type, VulkanLayoutUtils::Size &size,
 Type VulkanLayoutUtils::decorateType(VectorType vectorType,
                                      VulkanLayoutUtils::Size &size,
                                      VulkanLayoutUtils::Size &alignment) {
-  const auto numElements = vectorType.getNumElements();
-  auto elementType = vectorType.getElementType();
+  const unsigned numElements = vectorType.getNumElements();
+  Type elementType = vectorType.getElementType();
   Size elementSize = 0;
   Size elementAlignment = 1;
 
-  auto memberType = decorateType(elementType, elementSize, elementAlignment);
+  Type memberType = decorateType(elementType, elementSize, elementAlignment);
   // According to the Vulkan spec:
   // 1. "A two-component vector has a base alignment equal to twice its scalar
   // alignment."
@@ -124,12 +124,12 @@ Type VulkanLayoutUtils::decorateType(VectorType vectorType,
 Type VulkanLayoutUtils::decorateType(spirv::ArrayType arrayType,
                                      VulkanLayoutUtils::Size &size,
                                      VulkanLayoutUtils::Size &alignment) {
-  const auto numElements = arrayType.getNumElements();
-  auto elementType = arrayType.getElementType();
+  const unsigned numElements = arrayType.getNumElements();
+  Type elementType = arrayType.getElementType();
   Size elementSize = 0;
   Size elementAlignment = 1;
 
-  auto memberType = decorateType(elementType, elementSize, elementAlignment);
+  Type memberType = decorateType(elementType, elementSize, elementAlignment);
   // According to the Vulkan spec:
   // "An array has a base alignment equal to the base alignment of its element
   // type."
@@ -140,10 +140,10 @@ Type VulkanLayoutUtils::decorateType(spirv::ArrayType arrayType,
 
 Type VulkanLayoutUtils::decorateType(spirv::RuntimeArrayType arrayType,
                                      VulkanLayoutUtils::Size &alignment) {
-  auto elementType = arrayType.getElementType();
+  Type elementType = arrayType.getElementType();
   Size elementSize = 0;
 
-  auto memberType = decorateType(elementType, elementSize, alignment);
+  Type memberType = decorateType(elementType, elementSize, alignment);
   return spirv::RuntimeArrayType::get(memberType, elementSize);
 }
 
@@ -154,7 +154,7 @@ VulkanLayoutUtils::getScalarTypeAlignment(Type scalarType) {
   // 2. "A scalar has a base alignment equal to its scalar alignment."
   // 3. "A scalar, vector or matrix type has an extended alignment equal to its
   // base alignment."
-  auto bitWidth = scalarType.getIntOrFloatBitWidth();
+  unsigned bitWidth = scalarType.getIntOrFloatBitWidth();
   if (bitWidth == 1)
     return 1;
   return bitWidth / 8;
@@ -166,7 +166,7 @@ bool VulkanLayoutUtils::isLegalType(Type type) {
     return true;
   }
 
-  auto storageClass = ptrType.getStorageClass();
+  const spirv::StorageClass storageClass = ptrType.getStorageClass();
   auto structType = dyn_cast<spirv::StructType>(ptrType.getPointeeType());
   if (!structType) {
     return true;


### PR DESCRIPTION
Resolve https://github.com/llvm/llvm-project/pull/112018#discussion_r1818279122

As described in clang-tidy, the auto type specifier will only be introduced in 

- Iterators
- New expressions
- Cast expressions

https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-auto.html