### PR TITLE
Add clang::lifetimebound annotation to StringRef constructors.

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -81,7 +81,7 @@ namespace llvm {
     StringRef(std::nullptr_t) = delete;
 
     /// Construct a string ref from a cstring.
-    /*implicit*/ constexpr StringRef(const char *Str)
+    /*implicit*/ constexpr StringRef(const char *Str LLVM_LIFETIME_BOUND)
         : View(Str, Str ?
     // GCC 7 doesn't have constexpr char_traits. Fall back to __builtin_strlen.
 #if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 8
@@ -93,7 +93,8 @@ namespace llvm {
     }
 
     /// Construct a string ref from a pointer and length.
-    /*implicit*/ constexpr StringRef(const char *data, size_t length)
+    /*implicit*/ constexpr StringRef(const char *data LLVM_LIFETIME_BOUND,
+                                     size_t length)
         : View(data, length) {}
 
     /// Construct a string ref from an std::string.


### PR DESCRIPTION
Adding the lifetimebound annotation to the ArrayRef's array constructor can enable us to detect the following use-after-free issues:

```
llvm::StringRef TestZoneName() {
   char test[] = "foo"; // oops, missing static
   return test; // use-after-free.
}
```

See #113533