### PR TITLE
[clangd] [Modules] Use ASTReader directly in IsModuleFileUpToDate

### DIFF
--- a/clang-tools-extra/clangd/ModulesBuilder.cpp
+++ b/clang-tools-extra/clangd/ModulesBuilder.cpp
@@ -136,8 +136,9 @@ bool IsModuleFileUpToDate(PathRef ModuleFilePath,
   HSOpts->ForceCheckCXX20ModulesInputFiles = true;
   HSOpts->ValidateASTInputFilesContent = true;
 
+  clang::clangd::IgnoreDiagnostics IgnoreDiags;
   IntrusiveRefCntPtr<DiagnosticsEngine> Diags =
-      CompilerInstance::createDiagnostics(new DiagnosticOptions());
+      CompilerInstance::createDiagnostics(new DiagnosticOptions, &D, /*ShouldOwnClient=*/false);
 
   LangOptions LangOpts;
   LangOpts.SkipODRCheckInGMF = true;

--- a/clang-tools-extra/clangd/ModulesBuilder.cpp
+++ b/clang-tools-extra/clangd/ModulesBuilder.cpp
@@ -138,7 +138,7 @@ bool IsModuleFileUpToDate(PathRef ModuleFilePath,
 
   clang::clangd::IgnoreDiagnostics IgnoreDiags;
   IntrusiveRefCntPtr<DiagnosticsEngine> Diags =
-      CompilerInstance::createDiagnostics(new DiagnosticOptions, &D, /*ShouldOwnClient=*/false);
+      CompilerInstance::createDiagnostics(new DiagnosticOptions, &IgnoreDiags, /*ShouldOwnClient=*/false);
 
   LangOptions LangOpts;
   LangOpts.SkipODRCheckInGMF = true;
@@ -159,7 +159,8 @@ bool IsModuleFileUpToDate(PathRef ModuleFilePath,
   ASTReader Reader(PP, *ModuleCache, /*ASTContext=*/nullptr,
                    PCHOperations.getRawReader(), {});
 
-  Reader.setListener(std::make_unique<PPIntializer>(PP));
+  // We don't need any listener here. By default it will use a validator listener.
+  Reader.setListener(nullptr);
 
   if (Reader.ReadAST(ModuleFilePath, serialization::MK_MainFile,
                      SourceLocation(),

--- a/clang-tools-extra/clangd/ModulesBuilder.cpp
+++ b/clang-tools-extra/clangd/ModulesBuilder.cpp
@@ -138,7 +138,8 @@ bool IsModuleFileUpToDate(PathRef ModuleFilePath,
 
   clang::clangd::IgnoreDiagnostics IgnoreDiags;
   IntrusiveRefCntPtr<DiagnosticsEngine> Diags =
-      CompilerInstance::createDiagnostics(new DiagnosticOptions, &IgnoreDiags, /*ShouldOwnClient=*/false);
+      CompilerInstance::createDiagnostics(new DiagnosticOptions, &IgnoreDiags,
+                                          /*ShouldOwnClient=*/false);
 
   LangOptions LangOpts;
   LangOpts.SkipODRCheckInGMF = true;
@@ -159,7 +160,8 @@ bool IsModuleFileUpToDate(PathRef ModuleFilePath,
   ASTReader Reader(PP, *ModuleCache, /*ASTContext=*/nullptr,
                    PCHOperations.getRawReader(), {});
 
-  // We don't need any listener here. By default it will use a validator listener.
+  // We don't need any listener here. By default it will use a validator
+  // listener.
   Reader.setListener(nullptr);
 
   if (Reader.ReadAST(ModuleFilePath, serialization::MK_MainFile,

--- a/clang-tools-extra/clangd/ModulesBuilder.cpp
+++ b/clang-tools-extra/clangd/ModulesBuilder.cpp
@@ -12,6 +12,7 @@
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Serialization/ASTReader.h"
+#include "clang/Serialization/InMemoryModuleCache.h"
 
 namespace clang {
 namespace clangd {
@@ -127,50 +128,64 @@ struct ModuleFile {
   std::string ModuleFilePath;
 };
 
-bool IsModuleFileUpToDate(
-    PathRef ModuleFilePath,
-    const PrerequisiteModules &RequisiteModules) {
-IntrusiveRefCntPtr<DiagnosticsEngine> Diags =
-      CompilerInstance::createDiagnostics(new DiagnosticOptions());
-
+bool IsModuleFileUpToDate(PathRef ModuleFilePath,
+                          const PrerequisiteModules &RequisiteModules,
+                          llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS) {
   auto HSOpts = std::make_shared<HeaderSearchOptions>();
   RequisiteModules.adjustHeaderSearchOptions(*HSOpts);
   HSOpts->ForceCheckCXX20ModulesInputFiles = true;
   HSOpts->ValidateASTInputFilesContent = true;
 
+  IntrusiveRefCntPtr<DiagnosticsEngine> Diags =
+      CompilerInstance::createDiagnostics(new DiagnosticOptions());
+
+  LangOptions LangOpts;
+  LangOpts.SkipODRCheckInGMF = true;
+
+  FileManager FileMgr(FileSystemOptions(), VFS);
+
+  SourceManager SourceMgr(*Diags, FileMgr);
+
+  HeaderSearch HeaderInfo(HSOpts, SourceMgr, *Diags, LangOpts,
+                          /*Target=*/nullptr);
+
+  TrivialModuleLoader ModuleLoader;
+  Preprocessor PP(std::make_shared<PreprocessorOptions>(), *Diags, LangOpts,
+                  SourceMgr, HeaderInfo, ModuleLoader);
+
+  IntrusiveRefCntPtr<InMemoryModuleCache> ModuleCache = new InMemoryModuleCache;
   PCHContainerOperations PCHOperations;
-  std::unique_ptr<ASTUnit> Unit = ASTUnit::LoadFromASTFile(
-      ModuleFilePath.str(), PCHOperations.getRawReader(), ASTUnit::LoadASTOnly,
-      Diags, FileSystemOptions(), std::move(HSOpts));
+  ASTReader Reader(PP, *ModuleCache, /*ASTContext=*/nullptr,
+                   PCHOperations.getRawReader(), {});
 
-  if (!Unit)
-    return false;
+  Reader.setListener(std::make_unique<PPIntializer>(PP));
 
-  auto Reader = Unit->getASTReader();
-  if (!Reader)
+  if (Reader.ReadAST(ModuleFilePath, serialization::MK_MainFile,
+                     SourceLocation(),
+                     ASTReader::ARR_None) != ASTReader::Success)
     return false;
 
   bool UpToDate = true;
-  Reader->getModuleManager().visit([&](serialization::ModuleFile &MF) -> bool {
-    Reader->visitInputFiles(
+  Reader.getModuleManager().visit([&](serialization::ModuleFile &MF) -> bool {
+    Reader.visitInputFiles(
         MF, /*IncludeSystem=*/false, /*Complain=*/false,
         [&](const serialization::InputFile &IF, bool isSystem) {
           if (!IF.getFile() || IF.isOutOfDate())
             UpToDate = false;
         });
-
     return !UpToDate;
   });
-
   return UpToDate;
 }
 
 bool IsModuleFilesUpToDate(
     llvm::SmallVector<PathRef> ModuleFilePaths,
-    const PrerequisiteModules &RequisiteModules) {
-  return llvm::all_of(ModuleFilePaths, [&RequisiteModules](auto ModuleFilePath) {
-    return IsModuleFileUpToDate(ModuleFilePath, RequisiteModules);
-  });
+    const PrerequisiteModules &RequisiteModules,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS) {
+  return llvm::all_of(
+      ModuleFilePaths, [&RequisiteModules, VFS](auto ModuleFilePath) {
+        return IsModuleFileUpToDate(ModuleFilePath, RequisiteModules, VFS);
+      });
 }
 
 // StandalonePrerequisiteModules - stands for PrerequisiteModules for which all
@@ -347,7 +362,7 @@ bool StandalonePrerequisiteModules::canReuse(
   SmallVector<StringRef> BMIPaths;
   for (auto &MF : RequiredModules)
     BMIPaths.push_back(MF.ModuleFilePath);
-  return IsModuleFilesUpToDate(BMIPaths, *this);
+  return IsModuleFilesUpToDate(BMIPaths, *this, VFS);
 }
 
 } // namespace clangd


### PR DESCRIPTION
@kadircet mentioned in https://github.com/llvm/llvm-project/commit/448d8fa880be5cae0f63c3b248f07f647013a5a4#diff-fb3ba8a781117ff04736f951a274812cb7ad1678f9d71d4d91870b711ab45da0L285 that:

> this is definitely a functional change, clangd is used in environments that solely relies on VFS, and doesn't depend on ASTUnit at all.

> right now this is both introducing a dependency on ASTUnit, and making all the logical IO physical instead. can you instead use the regular compiler utilities in clangd, and get the astreader from CompilerInstance directly, which is VFS-aware, and doesn't depend on ASTUnit ?

This tries to resolve the problem by creating ASTReader directly and use VFS to create the FileManager.

---

// Original comments

But I like ASTUnit since I feel it is a better abstract here. For compiler instance, we need to provide the compiler invocation. But for the purpose here. we're just trying to open the BMI file to verify if the source files are out of date or not. We don't need compiler invocation here completely. So I prefer ASTUnit here especially clangd already depends on clangFrontend already so I feel like I didn't introduce a new dependency.

Then I added the `VFS` argument to `ASTUnit` to address the Virtual/Physical FS problem.