### PR TITLE
[PAuthLR] Add Missing Break Statement for MachineOperand Switch Statement

### DIFF
--- a/llvm/lib/CodeGen/MachineOperand.cpp
+++ b/llvm/lib/CodeGen/MachineOperand.cpp
@@ -772,6 +772,7 @@ static void printCFI(raw_ostream &OS, const MCCFIInstruction &CFI,
     OS << "negate_ra_sign_state_with_pc ";
     if (MCSymbol *Label = CFI.getLabel())
       MachineOperand::printSymbol(OS, *Label);
+    break;
   default:
     // TODO: Print the other CFI Operations.
     OS << "<unserializable cfi directive>";


### PR DESCRIPTION
There was a missing break, which led to an unannotated fallthrough when merging #112171. This has caused sanitizer builds to fail.

This adds the missing break in the switch statement to ensure that the fallthrough does not occur.