### PR TITLE
[XRay] Remove reliance on default PIC behavior in DSO tests

### DIFF
--- a/clang/test/Driver/XRay/xray-shared.cpp
+++ b/clang/test/Driver/XRay/xray-shared.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fPIC -fxray-instrument -fxray-shared -c %s -o /dev/null 2>&1 | FileCheck %s
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fpic -fxray-instrument -fxray-shared -c %s -o /dev/null 2>&1 | FileCheck %s
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fxray-instrument -fxray-shared -c %s -o /dev/null 2>&1 | FileCheck %s
 // RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fno-PIC -fxray-instrument -fxray-shared -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR-PIC
 // RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fno-pic -fxray-instrument -fxray-shared -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR-PIC
 

--- a/compiler-rt/test/xray/TestCases/Posix/clang-xray-shared.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/clang-xray-shared.cpp
@@ -1,6 +1,6 @@
 // Test that the DSO-local runtime library has been linked if -fxray-shared is passed.
 //
-// RUN: %clangxx -fxray-instrument -fxray-shared %s -shared -o %t.so
+// RUN: %clangxx -fxray-instrument -fxray-shared -fPIC %s -shared -o %t.so
 // RUN: llvm-nm %t.so | FileCheck %s --check-prefix ENABLED
 
 // RUN: %clangxx -fxray-instrument %s -shared -o %t.so


### PR DESCRIPTION
Compiling with `-fxray-shared` requires position-independent code (introduced in #113548). 
Some tests do not explicitly specify this, thus falling back to the compiler default. 
If, for example, Clang is compiled with `-DCLANG_DEFAULT_PIE_ON_LINUX=OFF`, these checks fail.

This patch addresses this issue in two tests:
- Removing a check in `xray-shared.cpp` that only tests default PIC behavior
- Adding `-fPIC` explicitly in `clang-xray-shared.cpp` 