### PR TITLE
[AIX][SystemZ][z/OS] Disable test for AIX, z/OS due to missing DWARF sections

### DIFF
--- a/llvm/test/DebugInfo/Generic/debug-names-accel-table-types.ll
+++ b/llvm/test/DebugInfo/Generic/debug-names-accel-table-types.ll
@@ -1,3 +1,4 @@
+; XFAIL: target={{.*}}-aix{{.*}}, target={{.*}}-zos{{.*}}
 ; RUN: %llc_dwarf -debugger-tune=lldb -accel-tables=Dwarf -filetype=obj -o %t < %s
 ; RUN: llvm-dwarfdump %t | FileCheck %s
 ; RUN: llvm-dwarfdump -debug-names %t | FileCheck --check-prefix=SAME-NAME %s


### PR DESCRIPTION
This patch disables the testcase for AIX and z/OS due to incomplete DWARF support.