### PR TITLE
[NVPTX] Don't use stack memory when bitcasting to/from v2i8

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -2332,14 +2332,15 @@ SDValue NVPTXTargetLowering::LowerBITCAST(SDValue Op, SelectionDAG &DAG) const {
   EVT fromVT = Op->getOperand(0)->getValueType(0);
 
   if (VT == MVT::v2i8) {
+    // Bitcast to i16 and unpack elements into a vector
     SDValue reg = maybeBitcast(MVT::i16, Op->getOperand(0));
-    // Promote result to v2i16
     SDValue v0 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i8, reg);
     SDValue C8 = DAG.getConstant(8, dl, MVT::i16);
     SDValue v1 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i8,
                              DAG.getNode(ISD::SRL, dl, MVT::i16, {reg, C8}));
     return DAG.getNode(ISD::BUILD_VECTOR, dl, MVT::v2i8, {v0, v1});
   } else if (fromVT == MVT::v2i8) {
+    // Pack vector elements into i16 and bitcast to final type
     SDValue v0 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i8,
                              Op->getOperand(0), DAG.getIntPtrConstant(0, dl));
     SDValue v1 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i8,

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -2336,19 +2336,20 @@ SDValue NVPTXTargetLowering::LowerBITCAST(SDValue Op, SelectionDAG &DAG) const {
     // Promote result to v2i16
     SDValue v0 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i8, reg);
     SDValue C8 = DAG.getConstant(8, dl, MVT::i16);
-    SDValue v1 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i8, 
+    SDValue v1 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i8,
                              DAG.getNode(ISD::SRL, dl, MVT::i16, {reg, C8}));
     return DAG.getNode(ISD::BUILD_VECTOR, dl, MVT::v2i8, {v0, v1});
   } else if (fromVT == MVT::v2i8) {
-    SDValue v0 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i8, Op->getOperand(0),
-                             DAG.getIntPtrConstant(0, dl));
-    SDValue v1 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i8, Op->getOperand(0),
-                             DAG.getIntPtrConstant(1, dl));
+    SDValue v0 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i8,
+                             Op->getOperand(0), DAG.getIntPtrConstant(0, dl));
+    SDValue v1 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i8,
+                             Op->getOperand(0), DAG.getIntPtrConstant(1, dl));
     SDValue E0 = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i16, v0);
     SDValue E1 = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i16, v1);
     SDValue C8 = DAG.getConstant(8, dl, MVT::i16);
-    SDValue reg = DAG.getNode(ISD::OR, dl, MVT::i16, 
-                              {E0, DAG.getNode(ISD::SHL, dl, MVT::i16, {E1, C8})});
+    SDValue reg =
+        DAG.getNode(ISD::OR, dl, MVT::i16,
+                    {E0, DAG.getNode(ISD::SHL, dl, MVT::i16, {E1, C8})});
     return maybeBitcast(VT, reg);
   }
   return Op;

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
@@ -616,6 +616,8 @@ private:
   const NVPTXSubtarget &STI; // cache the subtarget here
   SDValue getParamSymbol(SelectionDAG &DAG, int idx, EVT) const;
 
+  SDValue LowerBITCAST(SDValue Op, SelectionDAG &DAG) const;
+
   SDValue LowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerCONCAT_VECTORS(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerEXTRACT_VECTOR_ELT(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/test/CodeGen/NVPTX/i8x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/i8x2-instructions.ll
@@ -9,28 +9,25 @@
 
 target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
 
-; CHECK-LABEL: test_trunc_2xi8(
-; CHECK:      ld.param.u32 [[R1:%r[0-9]+]], [test_trunc_2xi8_param_0];
-; CHECK:      mov.b32 {[[RS1:%rs[0-9]+]], [[RS2:%rs[0-9]+]]}, [[R1]];
-; CHECK:      shl.b16 	[[RS3:%rs[0-9]+]], [[RS2]], 8;
-; CHECK:      and.b16  [[RS4:%rs[0-9]+]], [[RS1]], 255;
-; CHECK:      or.b16   [[RS5:%rs[0-9]+]], [[RS4]], [[RS3]]
-; CHECK:      cvt.u32.u16  [[R2:%r[0-9]]], [[RS5]]
-; CHECK:      st.param.b32  [func_retval0], [[R2]];
-define i16 @test_trunc_2xi8(<2 x i16> %a) #0 {
-  %trunc = trunc <2 x i16> %a to <2 x i8>
-  %res = bitcast <2 x i8> %trunc to i16
+; CHECK-LABEL: test_bitcast_2xi8_i16(
+; CHECK: ld.param.u32 	%r1, [test_bitcast_2xi8_i16_param_0];
+; CHECK: mov.b32 	{%rs1, %rs2}, %r1;
+; CHECK: shl.b16 	%rs3, %rs2, 8;
+; CHECK: and.b16  	%rs4, %rs1, 255;
+; CHECK: or.b16  	%rs5, %rs4, %rs3;
+; CHECK: cvt.u32.u16 	%r2, %rs5;
+; CHECK: st.param.b32 	[func_retval0], %r2;
+define i16 @test_bitcast_2xi8_i16(<2 x i8> %a) {
+  %res = bitcast <2 x i8> %a to i16
   ret i16 %res
 }
 
-; CHECK-LABEL: test_zext_2xi8(
-; CHECK:      ld.param.u16  [[RS1:%rs[0-9]+]], [test_zext_2xi8_param_0];
-; CHECK:      shr.u16 	[[RS2:%rs[0-9]+]], [[RS1]], 8;
-; CHECK:      mov.b32  [[R1:%r[0-9]+]], {[[RS1]], [[RS2]]}
-; CHECK:      and.b32  [[R2:%r[0-9]+]], [[R1]], 16711935;
-; CHECK:      st.param.b32  [func_retval0], [[R2]];
-define <2 x i16> @test_zext_2xi8(i16 %a) #0 {
-  %vec = bitcast i16 %a to <2 x i8>
-  %ext = zext <2 x i8> %vec to <2 x i16>
-  ret <2 x i16> %ext
+; CHECK-LABEL: test_bitcast_i16_2xi8(
+; CHECK: ld.param.u16 	%rs1, [test_bitcast_i16_2xi8_param_0];
+; CHECK: shr.u16 	%rs2, %rs1, 8;
+; CHECK: mov.b32 	%r1, {%rs1, %rs2};
+; CHECK: st.param.b32 	[func_retval0], %r1;
+define <2 x i8> @test_bitcast_i16_2xi8(i16 %a) {
+  %res = bitcast i16 %a to <2 x i8>
+  ret <2 x i8> %res
 }

--- a/llvm/test/CodeGen/NVPTX/i8x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/i8x2-instructions.ll
@@ -1,0 +1,36 @@
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -mcpu=sm_90 -mattr=+ptx80 -asm-verbose=false \
+; RUN:          -O0 -disable-post-ra -frame-pointer=all -verify-machineinstrs \
+; RUN: | FileCheck -allow-deprecated-dag-overlap -check-prefixes COMMON,I16x2 %s
+; RUN: %if ptxas %{                                                           \
+; RUN:   llc < %s -mtriple=nvptx64-nvidia-cuda -mcpu=sm_90 -asm-verbose=false \
+; RUN:          -O0 -disable-post-ra -frame-pointer=all -verify-machineinstrs \
+; RUN:   | %ptxas-verify -arch=sm_90                                          \
+; RUN: %}
+
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+
+; COMMON-LABEL: test_trunc_2xi8(
+; COMMON:      ld.param.u32 [[R1:%r[0-9]+]], [test_trunc_2xi8_param_0];
+; COMMON:      mov.b32 {[[RS1:%rs[0-9]+]], [[RS2:%rs[0-9]+]]}, [[R1]];
+; COMMON:      shl.b16 	[[RS3:%rs[0-9]+]], [[RS2]], 8;
+; COMMON:      and.b16  [[RS4:%rs[0-9]+]], [[RS1]], 255;
+; COMMON:      or.b16   [[RS5:%rs[0-9]+]], [[RS4]], [[RS3]]
+; COMMON:      cvt.u32.u16  [[R2:%r[0-9]]], [[RS5]]
+; COMMON:      st.param.b32  [func_retval0+0], [[R2]];
+define i16 @test_trunc_2xi8(<2 x i16> %a) #0 {
+  %trunc = trunc <2 x i16> %a to <2 x i8>
+  %res = bitcast <2 x i8> %trunc to i16
+  ret i16 %res
+}
+
+; COMMON-LABEL: test_zext_2xi8(
+; COMMON:      ld.param.u16  [[RS1:%rs[0-9]+]], [test_zext_2xi8_param_0];
+; COMMON:      shr.u16 	[[RS2:%rs[0-9]+]], [[RS1]], 8;
+; COMMON:      mov.b32  [[R1:%r[0-9]+]], {[[RS1]], [[RS2]]}
+; COMMON:      and.b32  [[R2:%r[0-9]+]], [[R1]], 16711935;
+; COMMON:      st.param.b32  [func_retval0+0], [[R2]];
+define <2 x i16> @test_zext_2xi8(i16 %a) #0 {
+  %vec = bitcast i16 %a to <2 x i8>
+  %ext = zext <2 x i8> %vec to <2 x i16>
+  ret <2 x i16> %ext
+}

--- a/llvm/test/CodeGen/NVPTX/i8x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/i8x2-instructions.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -mcpu=sm_90 -mattr=+ptx80 -asm-verbose=false \
 ; RUN:          -O0 -disable-post-ra -frame-pointer=all -verify-machineinstrs \
-; RUN: | FileCheck -allow-deprecated-dag-overlap -check-prefixes COMMON,I16x2 %s
+; RUN: | FileCheck  %s
 ; RUN: %if ptxas %{                                                           \
 ; RUN:   llc < %s -mtriple=nvptx64-nvidia-cuda -mcpu=sm_90 -asm-verbose=false \
 ; RUN:          -O0 -disable-post-ra -frame-pointer=all -verify-machineinstrs \
@@ -9,26 +9,26 @@
 
 target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
 
-; COMMON-LABEL: test_trunc_2xi8(
-; COMMON:      ld.param.u32 [[R1:%r[0-9]+]], [test_trunc_2xi8_param_0];
-; COMMON:      mov.b32 {[[RS1:%rs[0-9]+]], [[RS2:%rs[0-9]+]]}, [[R1]];
-; COMMON:      shl.b16 	[[RS3:%rs[0-9]+]], [[RS2]], 8;
-; COMMON:      and.b16  [[RS4:%rs[0-9]+]], [[RS1]], 255;
-; COMMON:      or.b16   [[RS5:%rs[0-9]+]], [[RS4]], [[RS3]]
-; COMMON:      cvt.u32.u16  [[R2:%r[0-9]]], [[RS5]]
-; COMMON:      st.param.b32  [func_retval0+0], [[R2]];
+; CHECK-LABEL: test_trunc_2xi8(
+; CHECK:      ld.param.u32 [[R1:%r[0-9]+]], [test_trunc_2xi8_param_0];
+; CHECK:      mov.b32 {[[RS1:%rs[0-9]+]], [[RS2:%rs[0-9]+]]}, [[R1]];
+; CHECK:      shl.b16 	[[RS3:%rs[0-9]+]], [[RS2]], 8;
+; CHECK:      and.b16  [[RS4:%rs[0-9]+]], [[RS1]], 255;
+; CHECK:      or.b16   [[RS5:%rs[0-9]+]], [[RS4]], [[RS3]]
+; CHECK:      cvt.u32.u16  [[R2:%r[0-9]]], [[RS5]]
+; CHECK:      st.param.b32  [func_retval0], [[R2]];
 define i16 @test_trunc_2xi8(<2 x i16> %a) #0 {
   %trunc = trunc <2 x i16> %a to <2 x i8>
   %res = bitcast <2 x i8> %trunc to i16
   ret i16 %res
 }
 
-; COMMON-LABEL: test_zext_2xi8(
-; COMMON:      ld.param.u16  [[RS1:%rs[0-9]+]], [test_zext_2xi8_param_0];
-; COMMON:      shr.u16 	[[RS2:%rs[0-9]+]], [[RS1]], 8;
-; COMMON:      mov.b32  [[R1:%r[0-9]+]], {[[RS1]], [[RS2]]}
-; COMMON:      and.b32  [[R2:%r[0-9]+]], [[R1]], 16711935;
-; COMMON:      st.param.b32  [func_retval0+0], [[R2]];
+; CHECK-LABEL: test_zext_2xi8(
+; CHECK:      ld.param.u16  [[RS1:%rs[0-9]+]], [test_zext_2xi8_param_0];
+; CHECK:      shr.u16 	[[RS2:%rs[0-9]+]], [[RS1]], 8;
+; CHECK:      mov.b32  [[R1:%r[0-9]+]], {[[RS1]], [[RS2]]}
+; CHECK:      and.b32  [[R2:%r[0-9]+]], [[R1]], 16711935;
+; CHECK:      st.param.b32  [func_retval0], [[R2]];
 define <2 x i16> @test_zext_2xi8(i16 %a) #0 {
   %vec = bitcast i16 %a to <2 x i8>
   %ext = zext <2 x i8> %vec to <2 x i16>


### PR DESCRIPTION
`v2i8` is an unsupported type, so we hit the default legalization rules which perform the bitcast in stack memory and is very inefficient on GPU.

This adds a custom lowering where we pack `v2i8` into `i16` and from there use another bitcast node to reach the final desired type. And also the inverse unpacking `i16` into `v2i8`.