### PR TITLE
[rtsan][asan] NFC Fix hyperlink to CMake doc

### DIFF
--- a/clang/docs/AddressSanitizer.rst
+++ b/clang/docs/AddressSanitizer.rst
@@ -26,7 +26,7 @@ Typical slowdown introduced by AddressSanitizer is **2x**.
 How to build
 ============
 
-Build LLVM/Clang with `CMake <https://llvm.org/docs/CMake.html>` and enable
+Build LLVM/Clang with `CMake <https://llvm.org/docs/CMake.html>`_ and enable
 the ``compiler-rt`` runtime. An example CMake configuration that will allow
 for the use/testing of AddressSanitizer:
 

--- a/clang/docs/RealtimeSanitizer.rst
+++ b/clang/docs/RealtimeSanitizer.rst
@@ -21,7 +21,7 @@ The runtime slowdown introduced by RealtimeSanitizer is negligible.
 How to build
 ============
 
-Build LLVM/Clang with `CMake <https://llvm.org/docs/CMake.html>` and enable the
+Build LLVM/Clang with `CMake <https://llvm.org/docs/CMake.html>`_ and enable the
 ``compiler-rt`` runtime. An example CMake configuration that will allow for the
 use/testing of RealtimeSanitizer:
 


### PR DESCRIPTION
The links right now show up like:

<img width="449" alt="Screenshot 2024-10-28 at 8 55 04 AM" src="https://github.com/user-attachments/assets/9e6b3e1f-e78f-46cb-a9f7-8164b6233340">

([rtsan](https://clang.llvm.org/docs/RealtimeSanitizer.html), [asan](https://clang.llvm.org/docs/AddressSanitizer.html))

This change fixes them to be more traditional blue hyperlinks:

<img width="446" alt="Screenshot 2024-10-28 at 8 55 54 AM" src="https://github.com/user-attachments/assets/653450aa-435b-49ad-9e4d-72c6f9bdd8fd">
