### PR TITLE
[lldb][test] Skip libc++ tests if it is linked statically

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -776,7 +776,7 @@ def canRunLibcxxTests():
 
     if platform == "linux":
         with tempfile.NamedTemporaryFile() as f:
-            cmd = [configuration.compiler, "-xc++", "-stdlib=libc++", "-o", f.name, "-"]
+            cmd = [configuration.compiler, "-xc++", "-stdlib=libc++", "-l:libc++.so", "-o", f.name, "-"]
             p = subprocess.Popen(
                 cmd,
                 stdin=subprocess.PIPE,

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -776,7 +776,15 @@ def canRunLibcxxTests():
 
     if platform == "linux":
         with tempfile.NamedTemporaryFile() as f:
-            cmd = [configuration.compiler, "-xc++", "-stdlib=libc++", "-l:libc++.so", "-o", f.name, "-"]
+            cmd = [
+                configuration.compiler,
+                "-xc++",
+                "-stdlib=libc++",
+                "-l:libc++.so",
+                "-o",
+                f.name,
+                "-",
+            ]
             p = subprocess.Popen(
                 cmd,
                 stdin=subprocess.PIPE,

--- a/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
-    @skipIfLinux  # https://discourse.llvm.org/t/lldb-test-failures-on-linux/80095
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
@@ -14,7 +14,6 @@ class TestDbgInfoContentVector(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "12.0"])
     @skipIf(macos_version=["<", "14.0"])
     @skipIfDarwin  # https://github.com/llvm/llvm-project/issues/106475
-    @skipIfLinux  # https://discourse.llvm.org/t/lldb-test-failures-on-linux/80095
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 class TestVectorOfVectors(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
-    @skipIfLinux  # https://discourse.llvm.org/t/lldb-test-failures-on-linux/80095
     def test(self):
         self.build()
 


### PR DESCRIPTION
Some tests from 'import-std-module' used to fail on the builder
https://lab.llvm.org/staging/#/builders/195/builds/4470, since libcxx is
set up to be linked statically with test binaries on it.

Thus, they were temporarily disabled in https://github.com/llvm/llvm-project/pull/112530. Here, this commit is
reverted.

When libcxx is linked with a program as an archive of static libraries,
functions that aren't used in the program are omitted. Then, jitted
expressions from the tests try calling several functions
that aren't present in the process image, which causes the failure.

LLD (and GNU ld AFAIK) links a binary with libcxx shared library
if libc++.so is present in corresponding library search paths.
Otherwise, it tries static linking. Here, a linker flag is added
to a clang call in libcxx tests configuration, which ensures that
libc++.so is present and found by linker.

Forcing linker to keep all functions from libcxx archive in this way https://github.com/llvm/llvm-project/pull/98701,
without checking whether libcxx is linked statically looks like a less
clean solution, but I'm not sure about that.