### PR TITLE
[SandboxIR][Pass] Implement Analyses class

### DIFF
--- a/llvm/include/llvm/SandboxIR/Pass.h
+++ b/llvm/include/llvm/SandboxIR/Pass.h
@@ -12,10 +12,28 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm::sandboxir {
+namespace llvm {
+
+class ScalarEvolution;
+
+namespace sandboxir {
 
 class Function;
 class Region;
+
+class Analyses {
+  ScalarEvolution *SE = nullptr;
+
+  Analyses() = default;
+
+public:
+  Analyses(ScalarEvolution &SE) : SE(&SE) {}
+
+public:
+  ScalarEvolution &getScalarEvolution() const { return *SE; }
+  /// For use by unit tests.
+  static Analyses emptyForTesting() { return Analyses(); }
+};
 
 /// The base class of a Sandbox IR Pass.
 class Pass {
@@ -52,7 +70,7 @@ public:
   /// \p Name can't contain any spaces or start with '-'.
   FunctionPass(StringRef Name) : Pass(Name) {}
   /// \Returns true if it modifies \p F.
-  virtual bool runOnFunction(Function &F) = 0;
+  virtual bool runOnFunction(Function &F, const Analyses &A) = 0;
 };
 
 /// A pass that runs on a sandbox::Region.
@@ -61,9 +79,10 @@ public:
   /// \p Name can't contain any spaces or start with '-'.
   RegionPass(StringRef Name) : Pass(Name) {}
   /// \Returns true if it modifies \p R.
-  virtual bool runOnRegion(Region &R) = 0;
+  virtual bool runOnRegion(Region &R, const Analyses &A) = 0;
 };
 
-} // namespace llvm::sandboxir
+} // namespace sandboxir
+} // namespace llvm
 
 #endif // LLVM_SANDBOXIR_PASS_H

--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -208,7 +208,7 @@ public:
   FunctionPassManager(StringRef Name, StringRef Pipeline,
                       CreatePassFunc CreatePass)
       : PassManager(Name, Pipeline, CreatePass) {}
-  bool runOnFunction(Function &F) final;
+  bool runOnFunction(Function &F, const Analyses &A) final;
 };
 
 class RegionPassManager final : public PassManager<RegionPass, RegionPass> {
@@ -217,7 +217,7 @@ public:
   RegionPassManager(StringRef Name, StringRef Pipeline,
                     CreatePassFunc CreatePass)
       : PassManager(Name, Pipeline, CreatePass) {}
-  bool runOnRegion(Region &R) final;
+  bool runOnRegion(Region &R, const Analyses &A) final;
 };
 
 } // namespace llvm::sandboxir

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -33,7 +33,7 @@ class BottomUpVec final : public FunctionPass {
 
 public:
   BottomUpVec(StringRef Pipeline);
-  bool runOnFunction(Function &F) final;
+  bool runOnFunction(Function &F, const Analyses &A) final;
   void printPipeline(raw_ostream &OS) const final {
     OS << getName() << "\n";
     RPM.printPipeline(OS);

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
@@ -11,7 +11,7 @@ class Region;
 class NullPass final : public RegionPass {
 public:
   NullPass() : RegionPass("null") {}
-  bool runOnRegion(Region &R) final { return false; }
+  bool runOnRegion(Region &R, const Analyses &A) final { return false; }
 };
 
 } // namespace llvm::sandboxir

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCount.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCount.h
@@ -12,7 +12,7 @@ namespace llvm::sandboxir {
 class PrintInstructionCount final : public RegionPass {
 public:
   PrintInstructionCount() : RegionPass("null") {}
-  bool runOnRegion(Region &R) final {
+  bool runOnRegion(Region &R, const Analyses &A) final {
     outs() << "InstructionCount: " << std::distance(R.begin(), R.end()) << "\n";
     return false;
   }

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h
@@ -26,7 +26,7 @@ class RegionsFromMetadata final : public FunctionPass {
 
 public:
   RegionsFromMetadata(StringRef Pipeline);
-  bool runOnFunction(Function &F) final;
+  bool runOnFunction(Function &F, const Analyses &A) final;
   void printPipeline(raw_ostream &OS) const final {
     OS << getName() << "\n";
     RPM.printPipeline(OS);

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/SandboxIR/PassManager.h"
 
@@ -19,6 +20,7 @@ class TargetTransformInfo;
 
 class SandboxVectorizerPass : public PassInfoMixin<SandboxVectorizerPass> {
   TargetTransformInfo *TTI = nullptr;
+  ScalarEvolution *SE = nullptr;
 
   // A pipeline of SandboxIR function passes run by the vectorizer.
   sandboxir::FunctionPassManager FPM;

--- a/llvm/lib/SandboxIR/PassManager.cpp
+++ b/llvm/lib/SandboxIR/PassManager.cpp
@@ -10,20 +10,20 @@
 
 namespace llvm::sandboxir {
 
-bool FunctionPassManager::runOnFunction(Function &F) {
+bool FunctionPassManager::runOnFunction(Function &F, const Analyses &A) {
   bool Change = false;
   for (auto &Pass : Passes) {
-    Change |= Pass->runOnFunction(F);
+    Change |= Pass->runOnFunction(F, A);
     // TODO: run the verifier.
   }
   // TODO: Check ChangeAll against hashes before/after.
   return Change;
 }
 
-bool RegionPassManager::runOnRegion(Region &R) {
+bool RegionPassManager::runOnRegion(Region &R, const Analyses &A) {
   bool Change = false;
   for (auto &Pass : Passes) {
-    Change |= Pass->runOnRegion(R);
+    Change |= Pass->runOnRegion(R, A);
     // TODO: run the verifier.
   }
   // TODO: Check ChangeAll against hashes before/after.

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -59,7 +59,7 @@ void BottomUpVec::vectorizeRec(ArrayRef<Value *> Bndl) {
 
 void BottomUpVec::tryVectorize(ArrayRef<Value *> Bndl) { vectorizeRec(Bndl); }
 
-bool BottomUpVec::runOnFunction(Function &F) {
+bool BottomUpVec::runOnFunction(Function &F, const Analyses &A) {
   Change = false;
   // TODO: Start from innermost BBs first
   for (auto &BB : F) {

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.cpp
@@ -17,11 +17,11 @@ RegionsFromMetadata::RegionsFromMetadata(StringRef Pipeline)
     : FunctionPass("regions-from-metadata"),
       RPM("rpm", Pipeline, SandboxVectorizerPassBuilder::createRegionPass) {}
 
-bool RegionsFromMetadata::runOnFunction(Function &F) {
+bool RegionsFromMetadata::runOnFunction(Function &F, const Analyses &A) {
   SmallVector<std::unique_ptr<sandboxir::Region>> Regions =
       sandboxir::Region::createRegionsFromMD(F);
   for (auto &R : Regions) {
-    RPM.runOnRegion(*R);
+    RPM.runOnRegion(*R, A);
   }
   return false;
 }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
@@ -51,6 +51,7 @@ SandboxVectorizerPass::~SandboxVectorizerPass() = default;
 PreservedAnalyses SandboxVectorizerPass::run(Function &F,
                                              FunctionAnalysisManager &AM) {
   TTI = &AM.getResult<TargetIRAnalysis>(F);
+  SE = &AM.getResult<ScalarEvolutionAnalysis>(F);
 
   bool Changed = runImpl(F);
   if (!Changed)
@@ -82,5 +83,6 @@ bool SandboxVectorizerPass::runImpl(Function &LLVMF) {
   // Create SandboxIR for LLVMF and run BottomUpVec on it.
   sandboxir::Context Ctx(LLVMF.getContext());
   sandboxir::Function &F = *Ctx.createFunction(&LLVMF);
-  return FPM.runOnFunction(F);
+  sandboxir::Analyses A(*SE);
+  return FPM.runOnFunction(F, A);
 }

--- a/llvm/unittests/SandboxIR/PassTest.cpp
+++ b/llvm/unittests/SandboxIR/PassTest.cpp
@@ -46,7 +46,7 @@ define void @foo() {
 
   public:
     TestPass(unsigned &BBCnt) : FunctionPass("test-pass"), BBCnt(BBCnt) {}
-    bool runOnFunction(Function &F) final {
+    bool runOnFunction(Function &F, const Analyses &A) final {
       for ([[maybe_unused]] auto &BB : F)
         ++BBCnt;
       return false;
@@ -59,7 +59,7 @@ define void @foo() {
   // Check classof().
   EXPECT_TRUE(llvm::isa<FunctionPass>(TPass));
   // Check runOnFunction();
-  TPass.runOnFunction(*F);
+  TPass.runOnFunction(*F, Analyses::emptyForTesting());
   EXPECT_EQ(BBCnt, 1u);
 #ifndef NDEBUG
   {
@@ -80,7 +80,7 @@ define void @foo() {
   class TestNamePass final : public FunctionPass {
   public:
     TestNamePass(llvm::StringRef Name) : FunctionPass(Name) {}
-    bool runOnFunction(Function &F) { return false; }
+    bool runOnFunction(Function &F, const Analyses &A) { return false; }
   };
   EXPECT_DEATH(TestNamePass("white space"), ".*whitespace.*");
   EXPECT_DEATH(TestNamePass("-dash"), ".*start with.*");
@@ -106,7 +106,7 @@ define i8 @foo(i8 %v0, i8 %v1) {
   public:
     TestPass(unsigned &InstCount)
         : RegionPass("test-pass"), InstCount(InstCount) {}
-    bool runOnRegion(Region &R) final {
+    bool runOnRegion(Region &R, const Analyses &A) final {
       for ([[maybe_unused]] auto &Inst : R) {
         ++InstCount;
       }
@@ -121,7 +121,7 @@ define i8 @foo(i8 %v0, i8 %v1) {
   llvm::SmallVector<std::unique_ptr<Region>> Regions =
       Region::createRegionsFromMD(*F);
   ASSERT_EQ(Regions.size(), 1u);
-  TPass.runOnRegion(*Regions[0]);
+  TPass.runOnRegion(*Regions[0], Analyses::emptyForTesting());
   EXPECT_EQ(InstCount, 2u);
 #ifndef NDEBUG
   {
@@ -142,7 +142,7 @@ define i8 @foo(i8 %v0, i8 %v1) {
   class TestNamePass final : public RegionPass {
   public:
     TestNamePass(llvm::StringRef Name) : RegionPass(Name) {}
-    bool runOnRegion(Region &F) { return false; }
+    bool runOnRegion(Region &F, const Analyses &A) { return false; }
   };
   EXPECT_DEATH(TestNamePass("white space"), ".*whitespace.*");
   EXPECT_DEATH(TestNamePass("-dash"), ".*start with.*");
@@ -161,7 +161,7 @@ define void @foo() {
 
   public:
     TestPass1(unsigned &BBCnt) : FunctionPass("test-pass1"), BBCnt(BBCnt) {}
-    bool runOnFunction(Function &F) final {
+    bool runOnFunction(Function &F, const Analyses &A) final {
       for ([[maybe_unused]] auto &BB : F)
         ++BBCnt;
       return false;
@@ -172,7 +172,7 @@ define void @foo() {
 
   public:
     TestPass2(unsigned &BBCnt) : FunctionPass("test-pass2"), BBCnt(BBCnt) {}
-    bool runOnFunction(Function &F) final {
+    bool runOnFunction(Function &F, const Analyses &A) final {
       for ([[maybe_unused]] auto &BB : F)
         ++BBCnt;
       return false;
@@ -185,7 +185,7 @@ define void @foo() {
   FPM.addPass(std::make_unique<TestPass1>(BBCnt1));
   FPM.addPass(std::make_unique<TestPass2>(BBCnt2));
   // Check runOnFunction().
-  FPM.runOnFunction(*F);
+  FPM.runOnFunction(*F, Analyses::emptyForTesting());
   EXPECT_EQ(BBCnt1, 1u);
   EXPECT_EQ(BBCnt2, 1u);
 #ifndef NDEBUG
@@ -216,7 +216,7 @@ define i8 @foo(i8 %v0, i8 %v1) {
   public:
     TestPass1(unsigned &InstCount)
         : RegionPass("test-pass1"), InstCount(InstCount) {}
-    bool runOnRegion(Region &R) final {
+    bool runOnRegion(Region &R, const Analyses &A) final {
       for ([[maybe_unused]] auto &Inst : R)
         ++InstCount;
       return false;
@@ -228,7 +228,7 @@ define i8 @foo(i8 %v0, i8 %v1) {
   public:
     TestPass2(unsigned &InstCount)
         : RegionPass("test-pass2"), InstCount(InstCount) {}
-    bool runOnRegion(Region &R) final {
+    bool runOnRegion(Region &R, const Analyses &A) final {
       for ([[maybe_unused]] auto &Inst : R)
         ++InstCount;
       return false;
@@ -244,7 +244,7 @@ define i8 @foo(i8 %v0, i8 %v1) {
   llvm::SmallVector<std::unique_ptr<Region>> Regions =
       Region::createRegionsFromMD(*F);
   ASSERT_EQ(Regions.size(), 1u);
-  RPM.runOnRegion(*Regions[0]);
+  RPM.runOnRegion(*Regions[0], Analyses::emptyForTesting());
   EXPECT_EQ(InstCount1, 2u);
   EXPECT_EQ(InstCount2, 2u);
 #ifndef NDEBUG
@@ -270,7 +270,7 @@ define void @f() {
   public:
     FooPass(std::string &Str, llvm::StringRef Args)
         : FunctionPass("foo-pass"), Str(Str), Args(Args.str()) {}
-    bool runOnFunction(Function &F) final {
+    bool runOnFunction(Function &F, const Analyses &A) final {
       Str += "foo<" + Args + ">";
       return false;
     }
@@ -282,7 +282,7 @@ define void @f() {
   public:
     BarPass(std::string &Str, llvm::StringRef Args)
         : FunctionPass("bar-pass"), Str(Str), Args(Args.str()) {}
-    bool runOnFunction(Function &F) final {
+    bool runOnFunction(Function &F, const Analyses &A) final {
       Str += "bar<" + Args + ">";
       return false;
     }
@@ -302,7 +302,7 @@ define void @f() {
   FunctionPassManager FPM("test-fpm");
   FPM.setPassPipeline("foo<abc>,bar<nested1<nested2<nested3>>>,foo",
                       CreatePass);
-  FPM.runOnFunction(*F);
+  FPM.runOnFunction(*F, Analyses::emptyForTesting());
   EXPECT_EQ(Str, "foo<abc>bar<nested1<nested2<nested3>>>foo<>");
 
   // A second call to setPassPipeline will trigger an assertion in debug mode.


### PR DESCRIPTION
The Analyses class provides a way to pass around commonly used Analyses to SandboxIR passes throught `runOnFunction()` and `runOnRegion()` functions.