### PR TITLE
[TableGen] Make `!and` and `!or` short-circuit

### DIFF
--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -1646,7 +1646,7 @@ and non-0 as true.
 ``!and(``\ *a*\ ``,`` *b*\ ``, ...)``
     This operator does a bitwise AND on *a*, *b*, etc., and produces the
     result. A logical AND can be performed if all the arguments are either
-    0 or 1. This operator is short-circuit to 0 when one of the operands
+    0 or 1. This operator is short-circuit to 0 when the left-most operand
     is 0.
 
 ``!cast<``\ *type*\ ``>(``\ *a*\ ``)``
@@ -1873,8 +1873,8 @@ and non-0 as true.
 ``!or(``\ *a*\ ``,`` *b*\ ``, ...)``
     This operator does a bitwise OR on *a*, *b*, etc., and produces the
     result. A logical OR can be performed if all the arguments are either
-    0 or 1. This operator is short-circuit to -1 (all ones) if one of the
-    operands is -1.
+    0 or 1. This operator is short-circuit to -1 (all ones) the left-most
+    operand is -1.
 
 ``!range([``\ *start*\ ``,]`` *end*\ ``[,``\ *step*\ ``])``
     This operator produces half-open range sequence ``[start : end : step)`` as

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -1646,7 +1646,8 @@ and non-0 as true.
 ``!and(``\ *a*\ ``,`` *b*\ ``, ...)``
     This operator does a bitwise AND on *a*, *b*, etc., and produces the
     result. A logical AND can be performed if all the arguments are either
-    0 or 1.
+    0 or 1. This operator is short-circuit to 0 when one of the operands
+    is 0.
 
 ``!cast<``\ *type*\ ``>(``\ *a*\ ``)``
     This operator performs a cast on *a* and produces the result.
@@ -1872,7 +1873,8 @@ and non-0 as true.
 ``!or(``\ *a*\ ``,`` *b*\ ``, ...)``
     This operator does a bitwise OR on *a*, *b*, etc., and produces the
     result. A logical OR can be performed if all the arguments are either
-    0 or 1.
+    0 or 1. This operator is short-circuit to -1 (all ones) if one of the
+    operands is -1.
 
 ``!range([``\ *start*\ ``,]`` *end*\ ``[,``\ *step*\ ``])``
     This operator produces half-open range sequence ``[start : end : step)`` as

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1558,12 +1558,6 @@ const Init *BinOpInit::resolveReferences(Resolver &R) const {
           (Opc == OR && LHSi->getValue() == -1))
         return LHSi;
     }
-    if (const auto *RHSi = dyn_cast_or_null<IntInit>(
-            rhs->convertInitializerTo(IntRecTy::get(getRecordKeeper())))) {
-      if ((Opc == AND && !RHSi->getValue()) ||
-          (Opc == OR && RHSi->getValue() == -1))
-        return RHSi;
-    }
   }
 
   if (LHS != lhs || RHS != rhs)

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1543,6 +1543,23 @@ const Init *BinOpInit::resolveReferences(Resolver &R) const {
   const Init *lhs = LHS->resolveReferences(R);
   const Init *rhs = RHS->resolveReferences(R);
 
+  if (getOpcode() == AND) {
+    // Short-circuit. Regardless whether this is a logical or bitwise
+    // AND.
+    if (lhs != LHS)
+      if (const auto *LHSi = dyn_cast_or_null<IntInit>(
+              lhs->convertInitializerTo(IntRecTy::get(getRecordKeeper())))) {
+        if (!LHSi->getValue())
+          return LHSi;
+      }
+    if (rhs != RHS)
+      if (const auto *RHSi = dyn_cast_or_null<IntInit>(
+              rhs->convertInitializerTo(IntRecTy::get(getRecordKeeper())))) {
+        if (!RHSi->getValue())
+          return RHSi;
+      }
+  }
+
   if (LHS != lhs || RHS != rhs)
     return (BinOpInit::get(getOpcode(), lhs, rhs, getType()))
         ->Fold(R.getCurrentRecord());

--- a/llvm/test/TableGen/true-false.td
+++ b/llvm/test/TableGen/true-false.td
@@ -72,15 +72,11 @@ def rec7 {
 // CHECK: def rec8
 // CHECK:   list<int> newSeq = [];
 // CHECK:   list<int> newSeq2 = [];
-// CHECK:   list<int> newSeq3 = [];
-// CHECK:   list<int> newSeq4 = [];
 
 class Foo <list<int> seq = []> {
-  bit containsStr = !ne(!find(NAME, "BAR"), -1);
-  list<int> newSeq  = !if(!and(!not(!empty(seq)), containsStr), !tail(seq), seq);
-  list<int> newSeq2 = !if(!and(containsStr, !not(!empty(seq))), !tail(seq), seq);
-  list<int> newSeq3 = !if(!or(containsStr, -1), seq, !tail(seq));
-  list<int> newSeq4 = !if(!or(-1, containsStr), seq, !tail(seq));
+  bit unresolved = !ne(!find(NAME, "BAR"), -1);
+  list<int> newSeq  = !if(!and(false, unresolved), !tail(seq), seq);
+  list<int> newSeq2 = !if(!or(-1, unresolved), seq, !tail(seq));
 }
 
 def rec8 : Foo<>;

--- a/llvm/test/TableGen/true-false.td
+++ b/llvm/test/TableGen/true-false.td
@@ -67,16 +67,20 @@ def rec7 {
   bits<3> flags = { true, false, true };
 }
 
-// The `!and` should be short-circuit such that `!tail` on empty list will never
+// `!and` and `!or` should be short-circuit such that `!tail` on empty list will never
 // be evaluated.
 // CHECK: def rec8
 // CHECK:   list<int> newSeq = [];
 // CHECK:   list<int> newSeq2 = [];
+// CHECK:   list<int> newSeq3 = [];
+// CHECK:   list<int> newSeq4 = [];
 
 class Foo <list<int> seq = []> {
   bit containsStr = !ne(!find(NAME, "BAR"), -1);
   list<int> newSeq  = !if(!and(!not(!empty(seq)), containsStr), !tail(seq), seq);
   list<int> newSeq2 = !if(!and(containsStr, !not(!empty(seq))), !tail(seq), seq);
+  list<int> newSeq3 = !if(!or(containsStr, -1), seq, !tail(seq));
+  list<int> newSeq4 = !if(!or(-1, containsStr), seq, !tail(seq));
 }
 
 def rec8 : Foo<>;

--- a/llvm/test/TableGen/true-false.td
+++ b/llvm/test/TableGen/true-false.td
@@ -67,6 +67,20 @@ def rec7 {
   bits<3> flags = { true, false, true };
 }
 
+// The `!and` should be short-circuit such that `!tail` on empty list will never
+// be evaluated.
+// CHECK: def rec8
+// CHECK:   list<int> newSeq = [];
+// CHECK:   list<int> newSeq2 = [];
+
+class Foo <list<int> seq = []> {
+  bit containsStr = !ne(!find(NAME, "BAR"), -1);
+  list<int> newSeq  = !if(!and(!not(!empty(seq)), containsStr), !tail(seq), seq);
+  list<int> newSeq2 = !if(!and(containsStr, !not(!empty(seq))), !tail(seq), seq);
+}
+
+def rec8 : Foo<>;
+
 #ifdef ERROR1
 // ERROR1: Record name '1' is not a string
 


### PR DESCRIPTION
By preemptively simplifying the result of `!and` and `!or`, we can fold some of the conditional operators, like `!if` or `!cond`, as early as possible.