### PR TITLE
[lldb] Search main function with lldb::eFunctionNameTypeFull when getting default file and line.

### DIFF
--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -430,7 +430,7 @@ SourceManager::GetDefaultFileAndLine() {
             false; // Force it to be a debug symbol.
         function_options.include_inlines = true;
         executable_ptr->FindFunctions(main_name, CompilerDeclContext(),
-                                      lldb::eFunctionNameTypeBase,
+                                      lldb::eFunctionNameTypeFull,
                                       function_options, sc_list);
         for (const SymbolContext &sc : sc_list) {
           if (sc.function) {


### PR DESCRIPTION
This is to work around the fact that `SymbolFileNativePDB::FindFunctions` only support `lldb::eFunctionNameTypeFull` and `lldb::eFunctionNameTypeMethod` now. Since `main`'s full name is the same as base name (`main`), it's okay to search with `lldb::eFunctionNameTypeFull` when trying to get the default file and line. With this, `lldb/test/Shell/Driver/TestSingleQuote.test` passes on Windows with NativePDB plugin.