### PR TITLE
Revert "[rtsan] Intercept aligned_alloc on all versions of OSX if available on build machine (#112780)"

### DIFF
--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -122,20 +122,13 @@ TEST(TestRtsanInterceptors, VallocDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
-#if __has_builtin(__builtin_available) && SANITIZER_APPLE
-#define ALIGNED_ALLOC_AVAILABLE() (__builtin_available(macOS 10.15, *))
-#else
-// We are going to assume this is true until we hit systems where it isn't
-#define ALIGNED_ALLOC_AVAILABLE() (true)
-#endif
-
+#if SANITIZER_INTERCEPT_ALIGNED_ALLOC
 TEST(TestRtsanInterceptors, AlignedAllocDiesWhenRealtime) {
-  if (ALIGNED_ALLOC_AVAILABLE()) {
-    auto Func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
-    ExpectRealtimeDeath(Func, "aligned_alloc");
-    ExpectNonRealtimeSurvival(Func);
-  }
+  auto Func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
+  ExpectRealtimeDeath(Func, "aligned_alloc");
+  ExpectNonRealtimeSurvival(Func);
 }
+#endif
 
 // free_sized and free_aligned_sized (both C23) are not yet supported
 TEST(TestRtsanInterceptors, FreeDiesWhenRealtime) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
@@ -84,25 +84,6 @@
 #define SI_NOT_MAC 1
 #endif
 
-#if SANITIZER_APPLE
-#  include <Availability.h>
-
-// aligned_alloc was introduced in OSX 10.15
-// Linking will fail when using an older SDK
-#  if defined(__MAC_10_15)
-// macOS 10.15 is greater than our minimal deployment target.  To ensure we
-// generate a weak reference so the dylib continues to work on older
-// systems, we need to forward declare the intercepted function as "weak
-// imports".
-SANITIZER_WEAK_IMPORT void *aligned_alloc(__sanitizer::usize __alignment,
-                                          __sanitizer::usize __size);
-#    define SI_MAC_SDK_10_15_AVAILABLE 1
-#  else
-#    define SI_MAC_SDK_10_15_AVAILABLE 0
-#  endif  // defined(__MAC_10_15)
-
-#endif  // SANITIZER_APPLE
-
 #if SANITIZER_IOS
 #define SI_IOS 1
 #else
@@ -519,8 +500,7 @@ SANITIZER_WEAK_IMPORT void *aligned_alloc(__sanitizer::usize __alignment,
 #define SANITIZER_INTERCEPT_PVALLOC (SI_GLIBC || SI_ANDROID)
 #define SANITIZER_INTERCEPT_CFREE (SI_GLIBC && !SANITIZER_RISCV64)
 #define SANITIZER_INTERCEPT_REALLOCARRAY SI_POSIX
-#define SANITIZER_INTERCEPT_ALIGNED_ALLOC \
-  (!SI_MAC || SI_MAC_SDK_10_15_AVAILABLE)
+#define SANITIZER_INTERCEPT_ALIGNED_ALLOC (!SI_MAC)
 #define SANITIZER_INTERCEPT_MALLOC_USABLE_SIZE (!SI_MAC && !SI_NETBSD)
 #define SANITIZER_INTERCEPT_MCHECK_MPROBE SI_LINUX_NOT_ANDROID
 #define SANITIZER_INTERCEPT_WCSLEN 1


### PR DESCRIPTION
This reverts commit 97fb21ac1d6bc528b61a555356457ff2129dfde1.

Due to issue brought up in #112780

> Unfortunately this breaks the build on our (automerger) bots, which have -mmacosx-version-min=10.13 and also -Werror=unguarded-availability-new . I was thinking about patching it via wrapping in __builtin_available check (which I believe is the right one to use, as it should match the -mmacosx-version-min ) - but can't actually think of a quick fix, due to interceptors being defined via C macros.

> llvm-project/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp:475:21: error: 'aligned_alloc' is only available on macOS 10.15 or newer [-Werror,-Wunguarded-availability-new] 475 | INTERCEPTOR(void *, aligned_alloc, SIZE_T alignment, SIZE_T size) {