### PR TITLE
[lldb] Set return status to Failed when Python command raises uncaught exception

### DIFF
--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -5,6 +5,10 @@ public:
   PyErr_Cleaner(bool print = false) : m_print(print) {}
 
   ~PyErr_Cleaner() {
+    Clean();
+  }
+
+  void Clean() {
     if (PyErr_Occurred()) {
       if (m_print && !PyErr_ExceptionMatches(PyExc_SystemExit))
         PyErr_Print();
@@ -592,8 +596,6 @@ void *lldb_private::python::LLDBSWIGPython_CastPyObjectToSBExecutionContext(PyOb
   return sb_ptr;
 }
 
-#include "lldb/Interpreter/CommandReturnObject.h"
-
 bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommand(
     const char *python_function_name, const char *session_dictionary_name,
     lldb::DebuggerSP debugger, const char *args,
@@ -650,7 +652,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommandObject(
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), cmd_retobj_arg.obj());
 
   if (PyErr_Occurred()) {
-    py_err_cleaner.~PyErr_Cleaner();
+    py_err_cleaner.Clean();
     auto command_class = self.ResolveName("__class__");
     auto module_name = command_class.ResolveName<PythonString>("__module__");
     auto class_name = command_class.ResolveName<PythonString>("__name__");
@@ -776,7 +778,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallParsedCommandObject(
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), SWIGBridge::ToSWIGWrapper(cmd_retobj).obj());
 
   if (PyErr_Occurred()) {
-    py_err_cleaner.~PyErr_Cleaner();
+    py_err_cleaner.Clean();
     auto command_class = self.ResolveName("__class__");
     auto module_name = command_class.ResolveName<PythonString>("__module__");
     auto class_name = command_class.ResolveName<PythonString>("__name__");

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -624,7 +624,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommand(
           SWIGBridge::ToSWIGWrapper(std::move(exe_ctx_ref_sp)), cmd_retobj_arg.obj(), dict);
 
   if (PyErr_Occurred())
-    cmd_retobj.SetStatus(eReturnStatusFailed);
+    cmd_retobj.AppendError("Scripted command threw an uncaught exception");
 
   return true;
 }
@@ -648,7 +648,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommandObject(
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), cmd_retobj_arg.obj());
 
   if (PyErr_Occurred())
-    cmd_retobj.SetStatus(eReturnStatusFailed);
+    cmd_retobj.AppendError("Scripted command threw an uncaught exception");
 
   return true;
 }
@@ -767,7 +767,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallParsedCommandObject(
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), SWIGBridge::ToSWIGWrapper(cmd_retobj).obj());
 
   if (PyErr_Occurred())
-    cmd_retobj.SetStatus(eReturnStatusFailed);
+    cmd_retobj.AppendError("Scripted command threw an uncaught exception");
 
   return true;
 }

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -624,6 +624,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommand(
           SWIGBridge::ToSWIGWrapper(std::move(exe_ctx_ref_sp)), cmd_retobj_arg.obj(), dict);
 
   if (PyErr_Occurred())
+    // Set status to Failed.
     cmd_retobj.AppendError("Scripted command threw an uncaught exception");
 
   return true;
@@ -648,6 +649,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommandObject(
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), cmd_retobj_arg.obj());
 
   if (PyErr_Occurred())
+    // Set status to Failed.
     cmd_retobj.AppendError("Scripted command threw an uncaught exception");
 
   return true;
@@ -767,6 +769,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallParsedCommandObject(
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), SWIGBridge::ToSWIGWrapper(cmd_retobj).obj());
 
   if (PyErr_Occurred())
+    // Set status to Failed.
     cmd_retobj.AppendError("Scripted command threw an uncaught exception");
 
   return true;

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -592,6 +592,8 @@ void *lldb_private::python::LLDBSWIGPython_CastPyObjectToSBExecutionContext(PyOb
   return sb_ptr;
 }
 
+#include "lldb/Interpreter/CommandReturnObject.h"
+
 bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommand(
     const char *python_function_name, const char *session_dictionary_name,
     lldb::DebuggerSP debugger, const char *args,
@@ -621,6 +623,9 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommand(
     pfunc(debugger_arg, PythonString(args),
           SWIGBridge::ToSWIGWrapper(std::move(exe_ctx_ref_sp)), cmd_retobj_arg.obj(), dict);
 
+  if (PyErr_Occurred())
+    cmd_retobj.SetStatus(eReturnStatusFailed);
+
   return true;
 }
 
@@ -641,6 +646,9 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommandObject(
 
   pfunc(SWIGBridge::ToSWIGWrapper(std::move(debugger)), PythonString(args),
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), cmd_retobj_arg.obj());
+
+  if (PyErr_Occurred())
+    cmd_retobj.SetStatus(eReturnStatusFailed);
 
   return true;
 }
@@ -740,8 +748,6 @@ lldb_private::python::SWIGBridge::LLDBSwigPythonHandleOptionArgumentCompletionFo
   return dict_sp;
 }
 
-#include "lldb/Interpreter/CommandReturnObject.h"
-
 bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallParsedCommandObject(
     PyObject *implementor, lldb::DebuggerSP debugger, lldb_private::StructuredDataImpl &args_impl,
     lldb_private::CommandReturnObject &cmd_retobj,
@@ -759,6 +765,9 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallParsedCommandObject(
 
   pfunc(SWIGBridge::ToSWIGWrapper(std::move(debugger)), SWIGBridge::ToSWIGWrapper(args_impl),
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), SWIGBridge::ToSWIGWrapper(cmd_retobj).obj());
+
+  if (PyErr_Occurred())
+    cmd_retobj.SetStatus(eReturnStatusFailed);
 
   return true;
 }

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -625,7 +625,8 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommand(
 
   if (PyErr_Occurred())
     // Set status to Failed.
-    cmd_retobj.AppendError("Scripted command threw an uncaught exception");
+    cmd_retobj.AppendErrorWithFormatv("Scripted command ({0}) threw an uncaught exception",
+                                      python_function_name);
 
   return true;
 }
@@ -648,9 +649,15 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallCommandObject(
   pfunc(SWIGBridge::ToSWIGWrapper(std::move(debugger)), PythonString(args),
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), cmd_retobj_arg.obj());
 
-  if (PyErr_Occurred())
+  if (PyErr_Occurred()) {
+    py_err_cleaner.~PyErr_Cleaner();
+    auto command_class = self.ResolveName("__class__");
+    auto module_name = command_class.ResolveName<PythonString>("__module__");
+    auto class_name = command_class.ResolveName<PythonString>("__name__");
     // Set status to Failed.
-    cmd_retobj.AppendError("Scripted command threw an uncaught exception");
+    cmd_retobj.AppendErrorWithFormatv("Scripted command ({0}.{1}) threw an uncaught exception",
+                                      module_name.GetString(), class_name.GetString());
+  }
 
   return true;
 }
@@ -768,9 +775,15 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallParsedCommandObject(
   pfunc(SWIGBridge::ToSWIGWrapper(std::move(debugger)), SWIGBridge::ToSWIGWrapper(args_impl),
         SWIGBridge::ToSWIGWrapper(exe_ctx_ref_sp), SWIGBridge::ToSWIGWrapper(cmd_retobj).obj());
 
-  if (PyErr_Occurred())
+  if (PyErr_Occurred()) {
+    py_err_cleaner.~PyErr_Cleaner();
+    auto command_class = self.ResolveName("__class__");
+    auto module_name = command_class.ResolveName<PythonString>("__module__");
+    auto class_name = command_class.ResolveName<PythonString>("__name__");
     // Set status to Failed.
-    cmd_retobj.AppendError("Scripted command threw an uncaught exception");
+    cmd_retobj.AppendErrorWithFormatv("Scripted command ({0}.{1}) threw an uncaught exception",
+                                      module_name.GetString(), class_name.GetString());
+  }
 
   return true;
 }

--- a/lldb/bindings/python/python.swig
+++ b/lldb/bindings/python/python.swig
@@ -117,6 +117,7 @@ def lldb_iter(obj, getsize, getelem):
 #include "../source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h"
 #include "../source/Plugins/ScriptInterpreter/Python/SWIGPythonBridge.h"
 #include "../bindings/python/python-swigsafecast.swig"
+#include "lldb/Interpreter/CommandReturnObject.h"
 using namespace lldb_private;
 using namespace lldb_private::python;
 using namespace lldb;

--- a/lldb/test/API/commands/command/script/exception/TestCommandException.py
+++ b/lldb/test/API/commands/command/script/exception/TestCommandException.py
@@ -1,0 +1,27 @@
+import os
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test(self):
+        """
+        Check that a Python command, which raises an unhandled exception, has
+        its status set to failed.
+        """
+        command_path = os.path.join(self.getSourceDir(), "throw_command.py")
+        self.runCmd(f"command script import {command_path}")
+
+        with open(os.devnull, "w") as devnull:
+            self.dbg.SetErrorFileHandle(devnull, False)
+            result = lldb.SBCommandReturnObject()
+            self.ci.HandleCommand("throw", result)
+
+        self.assertEqual(
+            result.GetStatus(),
+            lldb.eReturnStatusFailed,
+            "command unexpectedly succeeded",
+        )

--- a/lldb/test/API/commands/command/script/exception/TestCommandException.py
+++ b/lldb/test/API/commands/command/script/exception/TestCommandException.py
@@ -19,6 +19,7 @@ class TestCase(TestBase):
             self.dbg.SetErrorFileHandle(devnull, False)
             result = lldb.SBCommandReturnObject()
             self.ci.HandleCommand("throw", result)
+            self.dbg.SetErrorFileHandle(None, False)
 
         self.assertEqual(
             result.GetStatus(),

--- a/lldb/test/API/commands/command/script/exception/throw_command.py
+++ b/lldb/test/API/commands/command/script/exception/throw_command.py
@@ -1,0 +1,6 @@
+import lldb
+
+
+@lldb.command()
+def throw(debugger, cmd, ctx, result, _):
+    raise Exception("command failed")


### PR DESCRIPTION
If a python command raises an exception, but does not handle it, then the command's status should be set to `eReturnStatusFailed`.

rdar://138771864