### PR TITLE
Nominate Vlad Serebrennikov for C++ DRs

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -226,6 +226,12 @@ C++ conformance
 | hubert.reinterpretcast\@gmail.com (email), hubert.reinterpretcast (Phabricator), hubert-reinterpretcast (GitHub)
 
 
+C++ Defect Reports
+~~~~~~~~~~~~~~~~~~
+| Vlad Serebrennikov
+| serebrennikov.vladislav\@gmail.com (email), Endilll (GitHub), Endill (Discord), Endill (Discourse)
+
+
 Objective-C/C++ conformance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 | John McCall


### PR DESCRIPTION
Vlad has been improving our C++ DR conformance testing story for many months at this point and writing these kinds of test is sometimes non- trivial, so having a maintainer specific for this is helpful.