### PR TITLE
Nominate Erich Keane for OpenACC

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -244,6 +244,12 @@ OpenCL conformance
 | anastasia\@compiler-experts.com (email), Anastasia (Phabricator), AnastasiaStulova (GitHub)
 
 
+OpenACC
+~~~~~~~
+| Erich Keane
+| ekeane\@nvidia.com (email), ErichKeane (Phabricator), erichkeane (GitHub)
+
+
 SYCL conformance
 ~~~~~~~~~~~~~~~~
 | Alexey Bader


### PR DESCRIPTION
Erich is the driving force behind the OpenACC implementation work that has recently begun in Clang. Given his expertise on the topic and that he's already aware of maintainer expectations (he maintains templates and attributes currently), we should recognize that he's also the one maintaining OpenACC.