### PR TITLE
[APINotes] Document immortal reference type annotation

### DIFF
--- a/clang/docs/APINotes.rst
+++ b/clang/docs/APINotes.rst
@@ -172,10 +172,28 @@ declaration kind), all of which are optional:
   ::
 
     Tags:
+    - Name: OwnedStorage
+      SwiftImportAs: owned
+
+:SwiftRetainOp, SwiftReleaseOp:
+
+  Controls the lifetime operations of a class which uses custom reference
+  counting. The class must be annotated as a reference type using
+  ``SwiftImportAs: reference``. The values are either names of global functions,
+  each taking a single parameter of a pointer type, or ``immortal`` for a type
+  that is considered alive for the duration of the program.
+
+  ::
+
+    Tags:
     - Name: RefCountedStorage
       SwiftImportAs: reference
       SwiftReleaseOp: RCRelease
       SwiftRetainOp: RCRetain
+    - Name: ImmortalSingleton
+      SwiftImportAs: reference
+      SwiftReleaseOp: immortal
+      SwiftRetainOp: immortal
 
 :SwiftCopyable:
 


### PR DESCRIPTION
API Notes allow annotating a C++ reference type with its retain/release operations. These are honored by the Swift compiler when the type is used from Swift. Apart from names of C++ functions that need to be called to retain/release the object, API Notes also accept a value of `immortal` which indicates that the object is to be considered alive for the duration of the program.