### PR TITLE
Nominate Corentin Jabot for lambdas

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -78,6 +78,12 @@ Templates
 | ekeane\@nvidia.com (email), ErichKeane (Phabricator), erichkeane (GitHub)
 
 
+Lambdas
+~~~~~~~
+| Corentin Jabot
+| corentin.jabot\@gmail.com (email), cor3ntin (Phabricator), cor3ntin (GitHub)
+
+
 Debug information
 ~~~~~~~~~~~~~~~~~
 | Adrian Prantl


### PR DESCRIPTION
Corentin has largely been handling reviews touching lambdas for the past year or two, so he has significant understanding of the various moving parts of this fairly substantial C++ feature. Given that work on lambdas tends to be somewhat specialized, I think it makes sense for it to have dedicated oversight.