### PR TITLE
[mlir][python] Raise maximum allowed version

### DIFF
--- a/mlir/python/requirements.txt
+++ b/mlir/python/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.19.5, <=1.26
-pybind11>=2.9.0, <=2.10.3
+numpy>=1.19.5, <=2.1.2
+pybind11>=2.9.0, <=2.13.6
 PyYAML>=5.4.0, <=6.0.1
-ml_dtypes>=0.1.0, <=0.4.0   # provides several NumPy dtype extensions, including the bf16
+ml_dtypes>=0.1.0, <=0.5.0   # provides several NumPy dtype extensions, including the bf16


### PR DESCRIPTION
Raises the maximum allowed versions to more recent versions, which is a basic enabler to install them in a venv using Python 3.13.