### PR TITLE
[mlir][NFC] Avoid a warning

### DIFF
--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -422,7 +422,7 @@ llvm::cl::OptionValue<OpPassManager>::operator=(
   return *this;
 }
 
-llvm::cl::OptionValue<OpPassManager>::~OptionValue<OpPassManager>() = default;
+llvm::cl::OptionValue<OpPassManager>::~OptionValue() = default;
 
 void llvm::cl::OptionValue<OpPassManager>::setValue(
     const OpPassManager &newValue) {


### PR DESCRIPTION
warning: template-id not allowed for destructor in C++20 [-Wtemplate-id-cdtor]