### PR TITLE
Nominate Vassil Vassilev for Modules and Plugins

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -71,6 +71,9 @@ Modules & serialization
 | Michael Spencer
 | bigcheesegs\@gmail.com (email), Bigcheese (Phabricator), Bigcheese (GitHub)
 
+| Vassil Vassilev
+| Vassil.Vassilev\@cern.ch (email), v.g.vassilev (Phabricator), vgvassilev (GitHub)
+
 
 Templates
 ~~~~~~~~~
@@ -170,6 +173,12 @@ Attributes
 ~~~~~~~~~~
 | Erich Keane
 | ekeane\@nvidia.com (email), ErichKeane (Phabricator), erichkeane (GitHub)
+
+
+Plugins
+~~~~~~~
+| Vassil Vassilev
+| Vassil.Vassilev\@cern.ch (email), v.g.vassilev (Phabricator), vgvassilev (GitHub)
 
 
 Inline assembly


### PR DESCRIPTION
Vassil has significant experience helping users with the plugin interface in Clang, especially around the new efforts to bring plugin support to Windows. He also is knowledgeable about modules support.