### PR TITLE
[PS5][Driver] Pass a target emulation to the linker

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -241,6 +241,9 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // handled somewhere else.
   Args.ClaimAllArgs(options::OPT_w);
 
+  CmdArgs.push_back("-m");
+  CmdArgs.push_back("elf_x86_64_fbsd");
+
   CmdArgs.push_back(
       Args.MakeArgString("--sysroot=" + TC.getSDKLibraryRootDir()));
 

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -1,3 +1,10 @@
+// Test that a target emulation is supplied to the linker
+
+// RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-EMU %s
+
+// CHECK-EMU: {{ld(\.exe)?}}"
+// CHECK-EMU-SAME: "-m" "elf_x86_64_fbsd"
+
 // Test that PIE is the default for main components
 
 // RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-PIE %s


### PR DESCRIPTION
Until now, this has been hardcoded as a downstream patch in lld. Add it to the driver so that the private patch can be removed.

PS5 only. On PS4, the equivalent hardcoded configuration will remain in the proprietary linker.

SIE tracker: TOOLCHAIN-16704