### PR TITLE
Nominate Shafik Yaghmour and Vlad Serebrennikov for C++ conformance

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -231,6 +231,12 @@ C++ conformance
 | Hubert Tong
 | hubert.reinterpretcast\@gmail.com (email), hubert.reinterpretcast (Phabricator), hubert-reinterpretcast (GitHub)
 
+| Shafik Yaghmour
+| shafik.yaghmour\@intel.com (email), shafik (GitHub), shafik.yaghmour (Discord), shafik (Discourse)
+
+| Vlad Serebrennikov
+| serebrennikov.vladislav\@gmail.com (email), Endilll (GitHub), Endill (Discord), Endill (Discourse)
+
 
 C++ Defect Reports
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Shafik and Vlad are both members of WG21 and both have familiarity with reasoning about the C++ standard. They've both volunteered to help answer conformance related questions, and this is an area where we get quite a bit of questions so having a larger stable of maintainers is quite useful.