### PR TITLE
[libc++][test] Improve ThrowingT to Accurately Throw after throw_after > 1 Use

### DIFF
--- a/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
@@ -49,13 +49,14 @@ struct ThrowingT {
     --throw_after_n;
   }
 
-  ThrowingT(const ThrowingT&) {
+  ThrowingT(const ThrowingT& rhs) : throw_after_n_{rhs.throw_after_n_} {
     if (throw_after_n_ == nullptr || *throw_after_n_ == 0)
       throw 1;
     --*throw_after_n_;
   }
 
-  ThrowingT& operator=(const ThrowingT&) {
+  ThrowingT& operator=(const ThrowingT& rhs) {
+    throw_after_n_ = rhs.throw_after_n_;
     if (throw_after_n_ == nullptr || *throw_after_n_ == 0)
       throw 1;
     --*throw_after_n_;

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
@@ -49,7 +49,7 @@ struct ThrowingT {
     --throw_after_n;
   }
 
-  ThrowingT(const ThrowingT& rhs) : throw_after_n_{rhs.throw_after_n_} {
+  ThrowingT(const ThrowingT& rhs) : throw_after_n_(rhs.throw_after_n_) {
     if (throw_after_n_ == nullptr || *throw_after_n_ == 0)
       throw 1;
     --*throw_after_n_;


### PR DESCRIPTION
This PR fixes the `ThrowingT` class, which currently fails to raise exceptions after a specified number of copy construction operations. The class is intended to throw in a controlled manner based on a specified counter value `throw_after`. However, its current implementation of the copy constructor fails to achieve this goal.

The problem arises because the copy constructor does not initialize the `throw_after_n_` member, leaving `throw_after_n_` to default to `nullptr` as defined by the in-class initializer (`int* throw_after_n_ = nullptr;`). As a result, its copy constructor always checks against `nullptr`, causing an immediate exception rather than throwing after the specified number `throw_after` of uses. The fix is straightforward: simply initialize the `throw_after_n_` member in the member initializer list. 

This issue was previously uncovered because all exception tests for `std::vector` in `exceptions.pass.cpp` used a `throw_after` value of 1, which coincidentally aligned with the class's behavior.
 
A small test demonstrating the improper behavior of `ThrowingT` is available at [Godbolt link](https://godbolt.org/z/rMazGd17x).