### PR TITLE
[asan] Flush stderr in test

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/ignore_free_hook.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/ignore_free_hook.cpp
@@ -26,14 +26,17 @@ bool ignore_free = false;
 
 extern "C" {
 WEAK_ON_APPLE void __sanitizer_free_hook(const volatile void *ptr) {
-  if (ptr == glob_ptr)
+  if (ptr == glob_ptr) {
     fprintf(stderr, "Free Hook\n");
+    fflush(stderr);
+  }
 }
 
 WEAK_ON_APPLE int __sanitizer_ignore_free_hook(const volatile void *ptr) {
   if (ptr != glob_ptr)
     return 0;
   fprintf(stderr, ignore_free ? "Free Ignored\n" : "Free Respected\n");
+  fflush(stderr);
   return ignore_free;
 }
 } // extern "C"


### PR DESCRIPTION
This is the ASan equivalent of https://github.com/llvm/llvm-project/pull/114083.

The x86_64_lam_qemu buildbots started failing
(https://lab.llvm.org/buildbot/#/builders/139/builds/5462/steps/2/logs/stdio). Based on the logs, it appears the ASan check is correct but it did not match the stderr/stdout output. This patch attempts to fix the issue by flushing stderr as appropriate.