### PR TITLE
Nominate Sirraide for AST visitors and Sema

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -33,6 +33,12 @@ AST matchers
 | aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord), AaronBallman (IRC)
 
 
+AST Visitors
+~~~~~~~~~~~~
+| Sirraide
+| aeternalmail\@gmail.com (email), Sirraide (GitHub), Ætérnal (Discord), Sirraide (Discourse)
+
+
 Clang LLVM IR generation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 | John McCall
@@ -55,6 +61,12 @@ Analysis & CFG
 
 | Stanislav Gatev
 | sgatev\@google.com (email), sgatev (Phabricator), sgatev (GitHub)
+
+
+Sema
+~~~~
+| Sirraide
+| aeternalmail\@gmail.com (email), Sirraide (GitHub), Ætérnal (Discord), Sirraide (Discourse)
 
 
 Experimental new constant interpreter


### PR DESCRIPTION
Sirraide has been actively reviewing Sema code for a while now and definitely has the expertise to help maintain that section of the compiler. Further, he has been refactoring AST visitors to try to reduce the compile time overhead associated with them and would be a good resource for keeping an eye on that part of the code base too.