### PR TITLE
[clang] Fix 71315698c9 in presence of incomplete types

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -8900,7 +8900,12 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
           << Call->getCallee()->getSourceRange());
     else if (const auto *RT = PointeeTy->getAs<RecordType>()) {
 
-      bool IsTriviallyCopyableCXXRecord =
+      // FIXME: Do not consider incomplete types even though they may be
+      // completed later. GCC does not diagnose such code, but we may want to
+      // consider diagnosing it in the future, perhaps under a different, but
+      // related, diagnostic group.
+      bool MayBeTriviallyCopyableCXXRecord =
+          RT->isIncompleteType() ||
           RT->desugar().isTriviallyCopyableType(Context);
 
       if ((BId == Builtin::BImemset || BId == Builtin::BIbzero) &&
@@ -8910,7 +8915,7 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
                                 << ArgIdx << FnName << PointeeTy << 0);
         SearchNonTrivialToInitializeField::diag(PointeeTy, Dest, *this);
       } else if ((BId == Builtin::BImemset || BId == Builtin::BIbzero) &&
-                 !IsTriviallyCopyableCXXRecord && ArgIdx == 0) {
+                 !MayBeTriviallyCopyableCXXRecord && ArgIdx == 0) {
         // FIXME: Limiting this warning to dest argument until we decide
         // whether it's valid for source argument too.
         DiagRuntimeBehavior(Dest->getExprLoc(), Dest,
@@ -8923,7 +8928,7 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
                                 << ArgIdx << FnName << PointeeTy << 1);
         SearchNonTrivialToCopyField::diag(PointeeTy, Dest, *this);
       } else if ((BId == Builtin::BImemcpy || BId == Builtin::BImemmove) &&
-                 !IsTriviallyCopyableCXXRecord && ArgIdx == 0) {
+                 !MayBeTriviallyCopyableCXXRecord && ArgIdx == 0) {
         // FIXME: Limiting this warning to dest argument until we decide
         // whether it's valid for source argument too.
         DiagRuntimeBehavior(Dest->getExprLoc(), Dest,

--- a/clang/test/SemaCXX/constexpr-string.cpp
+++ b/clang/test/SemaCXX/constexpr-string.cpp
@@ -670,8 +670,6 @@ namespace MemcpyEtc {
   constexpr bool test_address_of_incomplete_struct_type() { // expected-error {{never produces a constant}}
     struct Incomplete;
     extern Incomplete x, y;
-    // expected-warning@+2 {{first argument in call to '__builtin_memcpy' is a pointer to non-trivially copyable type 'Incomplete'}}
-    // expected-note@+1 {{explicitly cast the pointer to silence this warning}}
     __builtin_memcpy(&x, &x, 4);
     // expected-note@-1 2{{cannot constant evaluate 'memcpy' between objects of incomplete type 'Incomplete'}}
     return true;

--- a/clang/test/SemaCXX/warn-memaccess.cpp
+++ b/clang/test/SemaCXX/warn-memaccess.cpp
@@ -7,11 +7,16 @@ extern "C" void *memcpy(void *s1, const void *s2, unsigned n);
 
 class TriviallyCopyable {};
 class NonTriviallyCopyable { NonTriviallyCopyable(const NonTriviallyCopyable&);};
+struct Incomplete;
 
 void test_bzero(TriviallyCopyable* tc,
-                 NonTriviallyCopyable *ntc) {
+                NonTriviallyCopyable *ntc,
+                Incomplete* i) {
   // OK
   bzero(tc, sizeof(*tc));
+
+  // OK
+  bzero(i, 10);
 
   // expected-warning@+2{{first argument in call to 'bzero' is a pointer to non-trivially copyable type 'NonTriviallyCopyable'}}
   // expected-note@+1{{explicitly cast the pointer to silence this warning}}
@@ -22,9 +27,13 @@ void test_bzero(TriviallyCopyable* tc,
 }
 
 void test_memset(TriviallyCopyable* tc,
-                 NonTriviallyCopyable *ntc) {
+                 NonTriviallyCopyable *ntc,
+                 Incomplete* i) {
   // OK
   memset(tc, 0, sizeof(*tc));
+
+  // OK
+  memset(i, 0, 10);
 
   // expected-warning@+2{{first argument in call to 'memset' is a pointer to non-trivially copyable type 'NonTriviallyCopyable'}}
   // expected-note@+1{{explicitly cast the pointer to silence this warning}}
@@ -36,9 +45,13 @@ void test_memset(TriviallyCopyable* tc,
 
 
 void test_memcpy(TriviallyCopyable* tc0, TriviallyCopyable* tc1,
-                 NonTriviallyCopyable *ntc0, NonTriviallyCopyable *ntc1) {
+                 NonTriviallyCopyable *ntc0, NonTriviallyCopyable *ntc1,
+                 Incomplete *i0, Incomplete *i1) {
   // OK
   memcpy(tc0, tc1, sizeof(*tc0));
+
+  // OK
+  memcpy(i0, i1, 10);
 
   // expected-warning@+2{{first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'NonTriviallyCopyable'}}
   // expected-note@+1{{explicitly cast the pointer to silence this warning}}
@@ -52,9 +65,13 @@ void test_memcpy(TriviallyCopyable* tc0, TriviallyCopyable* tc1,
 }
 
 void test_memmove(TriviallyCopyable* tc0, TriviallyCopyable* tc1,
-                 NonTriviallyCopyable *ntc0, NonTriviallyCopyable *ntc1) {
+                  NonTriviallyCopyable *ntc0, NonTriviallyCopyable *ntc1,
+                  Incomplete *i0, Incomplete *i1) {
   // OK
   memmove(tc0, tc1, sizeof(*tc0));
+
+  // OK
+  memmove(i0, i1, 10);
 
   // expected-warning@+2{{first argument in call to 'memmove' is a pointer to non-trivially copyable type 'NonTriviallyCopyable'}}
   // expected-note@+1{{explicitly cast the pointer to silence this warning}}


### PR DESCRIPTION
Incomplete types are not considered trivially copyable by clang but we don't want to warn about invalid argument for memcpy / memset in that case because we cannot prove they are not Trivially Copyable.