### PR TITLE
[lldb] Fix API test for file redirection to existing files

### DIFF
--- a/lldb/test/API/python_api/process/io/TestProcessIO.py
+++ b/lldb/test/API/python_api/process/io/TestProcessIO.py
@@ -99,31 +99,38 @@ class ProcessIOTestCase(TestBase):
     @expectedFlakeyLinux(bugnumber="llvm.org/pr26437")
     @skipIfDarwinEmbedded  # debugserver can't create/write files on the device
     def test_stdout_stderr_redirection_to_existing_files(self):
-        """Exercise SBLaunchInfo::AddOpenFileAction() for STDOUT and STDERR without redirecting STDIN to output files already exist."""
+        """Exercise SBLaunchInfo::AddOpenFileAction() for STDOUT and STDERR redirect to output files already exist."""
         self.setup_test()
         self.build()
         self.create_target()
-        self.write_file_with_placeholder(self.output_file)
-        self.write_file_with_placeholder(self.error_file)
+
+        # Create the output and error files with placeholder
+        placeholder = "This content should be overwritten."
+        # Local file directory and working directory are the same for local debugging
+        f = open(self.local_output_file, "w")
+        f.write(placeholder)
+        f.close()
+        f = open(self.local_error_file, "w")
+        f.write(placeholder)
+        f.close()
+        if lldb.remote_platform:
+            self.runCmd(
+                'platform put-file "{local}" "{remote}"'.format(
+                    local=self.local_output_file, remote=self.output_file
+                )
+            )
+            self.runCmd(
+                'platform put-file "{local}" "{remote}"'.format(
+                    local=self.local_error_file, remote=self.error_file
+                )
+            )
+
         self.redirect_stdout()
         self.redirect_stderr()
         self.run_process(True)
         output = self.read_output_file_and_delete()
         error = self.read_error_file_and_delete()
         self.check_process_output(output, error)
-
-    def write_file_with_placeholder(self, target_file):
-        placeholder = "This content should be overwritten."
-        if lldb.remote_platform:
-            self.runCmd(
-                'platform file write "{target}" -d "{data}"'.format(
-                    target=target_file, data=placeholder
-                )
-            )
-        else:
-            f = open(target_file, "w")
-            f.write(placeholder)
-            f.close()
 
     # target_file - path on local file system or remote file system if running remote
     # local_file - path on local system


### PR DESCRIPTION
API test failed for remote platform in [#112657](https://github.com/llvm/llvm-project/pull/112657)
See test detail: https://lab.llvm.org/buildbot/#/builders/195/builds/321

Previously when putting files onto remote platform, I used `platform file write -d <data>` which actually required a `platform file open <path>` first in order to obtain a file descriptor.
eg. in file [TestGDBRemotePlatformFile.py](https://github.com/llvm/llvm-project/blob/94e7d9c0bfe517507ea08b00fb00c32fb2837a82/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemotePlatformFile.py#L24-L32)
To fix this, use the `platform put-file` method, which is used in the `redirect_stdin` from this test already.