### PR TITLE
draft Attempt to get the specific_decl_iterator replaced

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/DesignatedInitializers.cpp
+++ b/clang-tools-extra/clang-tidy/utils/DesignatedInitializers.cpp
@@ -80,12 +80,12 @@ public:
       return false; // Bases can't be designated. Should we make one up?
     if (FieldsIt != FieldsEnd) {
       llvm::StringRef FieldName;
-      if (const IdentifierInfo *II = FieldsIt->getIdentifier())
+      if (const IdentifierInfo *II = (*FieldsIt)->getIdentifier())
         FieldName = II->getName();
 
       // For certain objects, their subobjects may be named directly.
       if (ForSubobject &&
-          (FieldsIt->isAnonymousStructOrUnion() ||
+          ((*FieldsIt)->isAnonymousStructOrUnion() ||
            // std::array<int,3> x = {1,2,3}. Designators not strictly valid!
            (OneField && isReservedName(FieldName))))
         return true;

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -4350,20 +4350,17 @@ public:
   // Iterator access to field members. The field iterator only visits
   // the non-static data members of this class, ignoring any static
   // data members, functions, constructors, destructors, etc.
-  using field_iterator = specific_decl_iterator<FieldDecl>;
-  using field_range = llvm::iterator_range<specific_decl_iterator<FieldDecl>>;
+  using field_range =
+      decltype(std::declval<DeclContext>().specific_decls<FieldDecl>());
+  using field_iterator = decltype(std::declval<field_range>().begin());
 
-  field_range fields() const { return field_range(field_begin(), field_end()); }
-  field_iterator field_begin() const;
+  field_range fields() const;
+  field_iterator field_begin() const { return fields().begin(); }
 
-  field_iterator field_end() const {
-    return field_iterator(decl_iterator());
-  }
+  field_iterator field_end() const { return fields().end(); }
 
   // Whether there are any fields (non-static data members) in this record.
-  bool field_empty() const {
-    return field_begin() == field_end();
-  }
+  bool field_empty() const { return fields().empty(); }
 
   /// Note that the definition of this type is now complete.
   virtual void completeDefinition();

--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -2374,6 +2374,7 @@ public:
                                    SpecificDecl *>;
 
   public:
+    decl_cast_iterator() : BaseT(ItTy{}) {}
     decl_cast_iterator(ItTy Itr) : BaseT(Itr) {}
 
     SpecificDecl *mapElement(Decl *D) const {

--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -2350,19 +2350,20 @@ public:
 
   /// decls_begin/decls_end - Iterate over the declarations stored in
   /// this context.
-  decl_range decls() const { return decl_range(decls_begin(), decls_end()); }
-  decl_iterator decls_begin() const;
-  decl_iterator decls_end() const { return decl_iterator(); }
-  bool decls_empty() const;
+  decl_range decls() const;
+  decl_iterator decls_begin() const { return decls().begin(); }
+  decl_iterator decls_end() const { return decls().end(); }
+  bool decls_empty() const {return decls().empty(); }
 
   /// noload_decls_begin/end - Iterate over the declarations stored in this
   /// context that are currently loaded; don't attempt to retrieve anything
   /// from an external source.
   decl_range noload_decls() const {
-    return decl_range(noload_decls_begin(), noload_decls_end());
+    return { decl_iterator(FirstDecl), decl_iterator{}};
   }
-  decl_iterator noload_decls_begin() const { return decl_iterator(FirstDecl); }
-  decl_iterator noload_decls_end() const { return decl_iterator(); }
+
+  decl_iterator noload_decls_begin() const { return noload_decls().begin(); }
+  decl_iterator noload_decls_end() const { return noload_decls().end(); }
 
   template <typename ItTy, typename SpecificDecl>
   class decl_cast_iterator : public llvm::mapped_iterator_base<

--- a/clang/lib/ARCMigrate/TransEmptyStatementsAndDealloc.cpp
+++ b/clang/lib/ARCMigrate/TransEmptyStatementsAndDealloc.cpp
@@ -197,10 +197,7 @@ static void cleanupDeallocOrFinalize(MigrationPass &pass) {
   Selector FinalizeSel =
       Ctx.Selectors.getNullarySelector(&pass.Ctx.Idents.get("finalize"));
 
-  typedef DeclContext::specific_decl_iterator<ObjCImplementationDecl>
-    impl_iterator;
-  for (impl_iterator I = impl_iterator(DC->decls_begin()),
-                     E = impl_iterator(DC->decls_end()); I != E; ++I) {
+  for (auto *I : DC->specific_decls<ObjCImplementationDecl>()) {
     ObjCMethodDecl *DeallocM = nullptr;
     ObjCMethodDecl *FinalizeM = nullptr;
     for (auto *MD : I->instance_methods()) {

--- a/clang/lib/ARCMigrate/TransProperties.cpp
+++ b/clang/lib/ARCMigrate/TransProperties.cpp
@@ -99,12 +99,7 @@ public:
     for (auto *Ext : iface->visible_extensions())
       collectProperties(Ext, AtProps);
 
-    typedef DeclContext::specific_decl_iterator<ObjCPropertyImplDecl>
-        prop_impl_iterator;
-    for (prop_impl_iterator
-           I = prop_impl_iterator(D->decls_begin()),
-           E = prop_impl_iterator(D->decls_end()); I != E; ++I) {
-      ObjCPropertyImplDecl *implD = *I;
+    for (auto *implD : D->specific_decls<ObjCPropertyImplDecl>()) {
       if (implD->getPropertyImplementation() != ObjCPropertyImplDecl::Synthesize)
         continue;
       ObjCPropertyDecl *propD = implD->getPropertyDecl();

--- a/clang/lib/ARCMigrate/Transforms.cpp
+++ b/clang/lib/ARCMigrate/Transforms.cpp
@@ -521,10 +521,7 @@ static void GCRewriteFinalize(MigrationPass &pass) {
   Selector FinalizeSel =
    Ctx.Selectors.getNullarySelector(&pass.Ctx.Idents.get("finalize"));
 
-  typedef DeclContext::specific_decl_iterator<ObjCImplementationDecl>
-  impl_iterator;
-  for (impl_iterator I = impl_iterator(DC->decls_begin()),
-       E = impl_iterator(DC->decls_end()); I != E; ++I) {
+  for (const auto *I : DC->specific_decls<ObjCImplementationDecl>()) {
     for (const auto *MD : I->instance_methods()) {
       if (!MD->hasBody())
         continue;

--- a/clang/lib/AST/ASTStructuralEquivalence.cpp
+++ b/clang/lib/AST/ASTStructuralEquivalence.cpp
@@ -1834,12 +1834,13 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
 
   // Check the fields for consistency.
   QualType D2Type = Context.ToCtx.getTypeDeclType(D2);
-  RecordDecl::field_iterator Field2 = D2->field_begin(),
-                             Field2End = D2->field_end();
-  for (RecordDecl::field_iterator Field1 = D1->field_begin(),
-                                  Field1End = D1->field_end();
-       Field1 != Field1End; ++Field1, ++Field2) {
-    if (Field2 == Field2End) {
+  std::optional<FieldDecl*> Field2Opt = std::nullopt;
+
+  for (auto FieldsTuple : llvm::zip_first(D1->fields(), D2->fields())) {
+    FieldDecl *Field1 = std::get<0>(FieldsTuple);
+    std::optional<FieldDecl*> Field2Opt = std::get<1>(FieldsTuple);
+
+    if (!Field2Opt.has_value()) {
       if (Context.Complain) {
         Context.Diag2(D2->getLocation(),
                       Context.getApplicableDiagnostic(
@@ -1852,12 +1853,14 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
       return false;
     }
 
-    if (!IsStructurallyEquivalent(Context, *Field1, *Field2, D2Type))
+    FieldDecl *Field2 = std::get<1>(FieldsTuple);
+    if (!IsStructurallyEquivalent(Context, Field1, Field2, D2Type))
       return false;
   }
 
-  if (Field2 != Field2End) {
+  if (Field2Opt.has_value()) {
     if (Context.Complain) {
+      FieldDecl *Field2 = *Field2Opt;
       Context.Diag2(D2->getLocation(), Context.getApplicableDiagnostic(
                                            diag::err_odr_tag_type_inconsistent))
           << Context.ToCtx.getTypeDeclType(D2);

--- a/clang/lib/AST/ComparisonCategories.cpp
+++ b/clang/lib/AST/ComparisonCategories.cpp
@@ -50,7 +50,7 @@ bool ComparisonCategoryInfo::ValueInfo::hasValidIntValue() const {
   // actually have one (and only one) field.
   const auto *Record = VD->getType()->getAsCXXRecordDecl();
   if (std::distance(Record->field_begin(), Record->field_end()) != 1 ||
-      !Record->field_begin()->getType()->isIntegralOrEnumerationType())
+      !(*Record->field_begin())->getType()->isIntegralOrEnumerationType())
     return false;
 
   return true;

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5086,14 +5086,14 @@ bool RecordDecl::isOrContainsUnion() const {
   return false;
 }
 
-RecordDecl::field_iterator RecordDecl::field_begin() const {
+RecordDecl::field_range RecordDecl::fields() const {
   if (hasExternalLexicalStorage() && !hasLoadedFieldsFromExternalStorage())
     LoadFieldsFromExternalStorage();
   // This is necessary for correctness for C++ with modules.
   // FIXME: Come up with a test case that breaks without definition.
   if (RecordDecl *D = getDefinition(); D && D != this)
-    return D->field_begin();
-  return field_iterator(decl_iterator(FirstDecl));
+    return D->fields();
+  return specific_decls<FieldDecl>();
 }
 
 /// completeDefinition - Notes that the definition of this type is now

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -500,8 +500,8 @@ bool Decl::isFlexibleArrayMemberLike(
   }
 
   // Test that the field is the last in the structure.
-  RecordDecl::field_iterator FI(
-      DeclContext::decl_iterator(const_cast<FieldDecl *>(FD)));
+  RecordDecl::field_iterator FI = llvm::find(FD->getParent()->fields(), FD);
+  assert(FI != FD->getParent()->field_end() && "Not contained in own parent?");
   return ++FI == FD->getParent()->field_end();
 }
 
@@ -1623,17 +1623,10 @@ ExternalASTSource::SetExternalVisibleDeclsForName(const DeclContext *DC,
   return List.getLookupResult();
 }
 
-DeclContext::decl_iterator DeclContext::decls_begin() const {
+DeclContext::decl_range DeclContext::decls() const {
   if (hasExternalLexicalStorage())
     LoadLexicalDeclsFromExternalStorage();
-  return decl_iterator(FirstDecl);
-}
-
-bool DeclContext::decls_empty() const {
-  if (hasExternalLexicalStorage())
-    LoadLexicalDeclsFromExternalStorage();
-
-  return !FirstDecl;
+  return {decl_iterator(FirstDecl), decl_iterator{}};
 }
 
 bool DeclContext::containsDecl(Decl *D) const {

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -2039,12 +2039,10 @@ const FieldDecl *CastExpr::getTargetFieldForToUnionCast(QualType unionType,
 const FieldDecl *CastExpr::getTargetFieldForToUnionCast(const RecordDecl *RD,
                                                         QualType OpType) {
   auto &Ctx = RD->getASTContext();
-  RecordDecl::field_iterator Field, FieldEnd;
-  for (Field = RD->field_begin(), FieldEnd = RD->field_end();
-       Field != FieldEnd; ++Field) {
+  for (FieldDecl *Field : RD->fields()) {
     if (Ctx.hasSameUnqualifiedType(Field->getType(), OpType) &&
         !Field->isUnnamedBitField()) {
-      return *Field;
+      return Field;
     }
   }
   return nullptr;

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -6610,7 +6610,7 @@ static bool HandleConstructorCall(const Expr *E, const LValue &This,
     // We might be initializing the same field again if this is an indirect
     // field initialization.
     if (FieldIt == RD->field_end() ||
-        FieldIt->getFieldIndex() > FD->getFieldIndex()) {
+        (*FieldIt)->getFieldIndex() > FD->getFieldIndex()) {
       assert(Indirect && "fields out of order?");
       return;
     }
@@ -6618,10 +6618,10 @@ static bool HandleConstructorCall(const Expr *E, const LValue &This,
     // Default-initialize any fields with no explicit initializer.
     for (; !declaresSameEntity(*FieldIt, FD); ++FieldIt) {
       assert(FieldIt != RD->field_end() && "missing field?");
-      if (!FieldIt->isUnnamedBitField())
+      if (!(*FieldIt)->isUnnamedBitField())
         Success &= handleDefaultInitValue(
-            FieldIt->getType(),
-            Result.getStructField(FieldIt->getFieldIndex()));
+            (*FieldIt)->getType(),
+            Result.getStructField((*FieldIt)->getFieldIndex()));
     }
     ++FieldIt;
   };
@@ -6728,10 +6728,10 @@ static bool HandleConstructorCall(const Expr *E, const LValue &This,
   // Default-initialize any remaining fields.
   if (!RD->isUnion()) {
     for (; FieldIt != RD->field_end(); ++FieldIt) {
-      if (!FieldIt->isUnnamedBitField())
+      if (!(*FieldIt)->isUnnamedBitField())
         Success &= handleDefaultInitValue(
-            FieldIt->getType(),
-            Result.getStructField(FieldIt->getFieldIndex()));
+            (*FieldIt)->getType(),
+            Result.getStructField((*FieldIt)->getFieldIndex()));
     }
   }
 
@@ -10562,7 +10562,7 @@ bool RecordExprEvaluator::ZeroInitialization(const Expr *E, QualType T) {
     if (!HandleLValueMember(Info, E, Subobject, *I))
       return false;
     Result = APValue(*I);
-    ImplicitValueInitExpr VIE(I->getType());
+    ImplicitValueInitExpr VIE((*I)->getType());
     return EvaluateInPlace(Result.getUnionValue(), Info, Subobject, &VIE);
   }
 
@@ -10838,19 +10838,19 @@ bool RecordExprEvaluator::VisitCXXStdInitializerListExpr(
   RecordDecl *Record = E->getType()->castAs<RecordType>()->getDecl();
   RecordDecl::field_iterator Field = Record->field_begin();
   assert(Field != Record->field_end() &&
-         Info.Ctx.hasSameType(Field->getType()->getPointeeType(),
+         Info.Ctx.hasSameType((*Field)->getType()->getPointeeType(),
                               ArrayType->getElementType()) &&
          "Expected std::initializer_list first field to be const E *");
   ++Field;
   assert(Field != Record->field_end() &&
          "Expected std::initializer_list to have two fields");
 
-  if (Info.Ctx.hasSameType(Field->getType(), Info.Ctx.getSizeType())) {
+  if (Info.Ctx.hasSameType((*Field)->getType(), Info.Ctx.getSizeType())) {
     // Length.
     Result.getStructField(1) = APValue(APSInt(ArrayType->getSize()));
   } else {
     // End pointer.
-    assert(Info.Ctx.hasSameType(Field->getType()->getPointeeType(),
+    assert(Info.Ctx.hasSameType((*Field)->getType()->getPointeeType(),
                                 ArrayType->getElementType()) &&
            "Expected std::initializer_list second field to be const E *");
     if (!HandleLValueArrayAdjustment(Info, E, Array,

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -299,14 +299,14 @@ EmptySubobjectMap::CanPlaceBaseSubobjectAtOffset(const BaseSubobjectInfo *Info,
   }
 
   // Traverse all member variables.
-  unsigned FieldNo = 0;
-  for (CXXRecordDecl::field_iterator I = Info->Class->field_begin(),
-       E = Info->Class->field_end(); I != E; ++I, ++FieldNo) {
+  for (auto FieldCountTuple : llvm::enumerate(Info->Class->fields())) {
+    FieldDecl *I = FieldCountTuple.value();
+    unsigned FieldNo = FieldCountTuple.index();
     if (I->isBitField())
       continue;
 
     CharUnits FieldOffset = Offset + getFieldOffset(Layout, FieldNo);
-    if (!CanPlaceFieldSubobjectAtOffset(*I, FieldOffset))
+    if (!CanPlaceFieldSubobjectAtOffset(I, FieldOffset))
       return false;
   }
 
@@ -346,14 +346,14 @@ void EmptySubobjectMap::UpdateEmptyBaseSubobjects(const BaseSubobjectInfo *Info,
   }
 
   // Traverse all member variables.
-  unsigned FieldNo = 0;
-  for (CXXRecordDecl::field_iterator I = Info->Class->field_begin(),
-       E = Info->Class->field_end(); I != E; ++I, ++FieldNo) {
+  for (auto FieldCountTuple : llvm::enumerate(Info->Class->fields())) {
+    FieldDecl *I = FieldCountTuple.value();
+    unsigned FieldNo = FieldCountTuple.index();
     if (I->isBitField())
       continue;
 
     CharUnits FieldOffset = Offset + getFieldOffset(Layout, FieldNo);
-    UpdateEmptyFieldSubobjects(*I, FieldOffset, PlacingEmptyBase);
+    UpdateEmptyFieldSubobjects(I, FieldOffset, PlacingEmptyBase);
   }
 }
 
@@ -411,15 +411,15 @@ EmptySubobjectMap::CanPlaceFieldSubobjectAtOffset(const CXXRecordDecl *RD,
   }
 
   // Traverse all member variables.
-  unsigned FieldNo = 0;
-  for (CXXRecordDecl::field_iterator I = RD->field_begin(), E = RD->field_end();
-       I != E; ++I, ++FieldNo) {
+  for (auto FieldCountTuple : llvm::enumerate(RD->fields())) {
+    FieldDecl *I = FieldCountTuple.value();
+    unsigned FieldNo = FieldCountTuple.index();
     if (I->isBitField())
       continue;
 
     CharUnits FieldOffset = Offset + getFieldOffset(Layout, FieldNo);
 
-    if (!CanPlaceFieldSubobjectAtOffset(*I, FieldOffset))
+    if (!CanPlaceFieldSubobjectAtOffset(I, FieldOffset))
       return false;
   }
 
@@ -522,15 +522,15 @@ void EmptySubobjectMap::UpdateEmptyFieldSubobjects(
   }
 
   // Traverse all member variables.
-  unsigned FieldNo = 0;
-  for (CXXRecordDecl::field_iterator I = RD->field_begin(), E = RD->field_end();
-       I != E; ++I, ++FieldNo) {
+  for (auto FieldCountTuple : llvm::enumerate(RD->fields())) {
+    FieldDecl *I = FieldCountTuple.value();
+    unsigned FieldNo = FieldCountTuple.index();
     if (I->isBitField())
       continue;
 
     CharUnits FieldOffset = Offset + getFieldOffset(Layout, FieldNo);
 
-    UpdateEmptyFieldSubobjects(*I, FieldOffset, PlacingOverlappingField);
+    UpdateEmptyFieldSubobjects(I, FieldOffset, PlacingOverlappingField);
   }
 }
 

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -5376,7 +5376,7 @@ HLSLAttributedResourceType::findHandleTypeOnResource(const Type *RT) {
   const clang::Type *Ty = RT->getUnqualifiedDesugaredType();
   if (const RecordDecl *RD = Ty->getAsCXXRecordDecl()) {
     if (!RD->fields().empty()) {
-      const auto &FirstFD = RD->fields().begin();
+      FieldDecl *FirstFD = *RD->field_begin();
       return dyn_cast<HLSLAttributedResourceType>(
           FirstFD->getType().getTypePtr());
     }

--- a/clang/lib/Analysis/UninitializedValues.cpp
+++ b/clang/lib/Analysis/UninitializedValues.cpp
@@ -95,10 +95,8 @@ public:
 
 void DeclToIndex::computeMap(const DeclContext &dc) {
   unsigned count = 0;
-  DeclContext::specific_decl_iterator<VarDecl> I(dc.decls_begin()),
-                                               E(dc.decls_end());
-  for ( ; I != E; ++I) {
-    const VarDecl *vd = *I;
+
+  for (const auto *vd : dc.specific_decls<VarDecl>()) {
     if (isTrackedVar(vd, &dc))
       map[vd] = count++;
   }

--- a/clang/lib/CodeGen/ABIInfoImpl.cpp
+++ b/clang/lib/CodeGen/ABIInfoImpl.cpp
@@ -138,7 +138,7 @@ QualType CodeGen::useFirstFieldIfTransparentUnion(QualType Ty) {
     const RecordDecl *UD = UT->getDecl();
     if (UD->hasAttr<TransparentUnionAttr>()) {
       assert(!UD->field_empty() && "sema created an empty transparent union");
-      return UD->field_begin()->getType();
+      return (*UD->field_begin())->getType();
     }
   }
   return Ty;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1718,8 +1718,10 @@ llvm::DIDerivedType *CGDebugInfo::createBitFieldSeparatorIfNeeded(
       PreviousMDField->getSizeInBits() == 0)
     return nullptr;
 
-  auto PreviousBitfield = RD->field_begin();
-  std::advance(PreviousBitfield, BitFieldDecl->getFieldIndex() - 1);
+  auto PreviousBitfieldItr = RD->field_begin();
+  std::advance(PreviousBitfieldItr, BitFieldDecl->getFieldIndex() - 1);
+
+  FieldDecl *PreviousBitfield = *PreviousBitfieldItr;
 
   assert(PreviousBitfield->isBitField());
 
@@ -1743,7 +1745,7 @@ llvm::DIDerivedType *CGDebugInfo::createBitFieldSeparatorIfNeeded(
   llvm::DINode::DIFlags Flags =
       getAccessFlag(PreviousBitfield->getAccess(), RD);
   llvm::DINodeArray Annotations =
-      CollectBTFDeclTagAnnotations(*PreviousBitfield);
+      CollectBTFDeclTagAnnotations(PreviousBitfield);
   return DBuilder.createBitFieldMemberType(
       RecordTy, "", File, Line, 0, StorageOffsetInBits, StorageOffsetInBits,
       Flags, DebugType, Annotations);
@@ -1802,12 +1804,8 @@ void CGDebugInfo::CollectRecordLambdaFields(
   // has the name and the location of the variable so we should iterate over
   // both concurrently.
   const ASTRecordLayout &layout = CGM.getContext().getASTRecordLayout(CXXDecl);
-  RecordDecl::field_iterator Field = CXXDecl->field_begin();
-  unsigned fieldno = 0;
-  for (CXXRecordDecl::capture_const_iterator I = CXXDecl->captures_begin(),
-                                             E = CXXDecl->captures_end();
-       I != E; ++I, ++Field, ++fieldno) {
-    const LambdaCapture &C = *I;
+  for (const auto &[fieldno, C, Field] :
+           llvm::enumerate(CXXDecl->captures(), CXXDecl->fields())) {
     if (C.capturesVariable()) {
       SourceLocation Loc = C.getLocation();
       assert(!Field->isBitField() && "lambdas don't have bitfield members!");
@@ -1824,13 +1822,12 @@ void CGDebugInfo::CollectRecordLambdaFields(
       // this of the lambda class and having a field member of 'this' or
       // by using AT_object_pointer for the function and having that be
       // used as 'this' for semantic references.
-      FieldDecl *f = *Field;
-      llvm::DIFile *VUnit = getOrCreateFile(f->getLocation());
-      QualType type = f->getType();
+      llvm::DIFile *VUnit = getOrCreateFile(Field->getLocation());
+      QualType type = Field->getType();
       StringRef ThisName =
           CGM.getCodeGenOpts().EmitCodeView ? "__this" : "this";
       llvm::DIType *fieldType = createFieldType(
-          ThisName, type, f->getLocation(), f->getAccess(),
+          ThisName, type, Field->getLocation(), Field->getAccess(),
           layout.getFieldOffset(fieldno), VUnit, RecordTy, CXXDecl);
 
       elements.push_back(fieldType);
@@ -2715,7 +2712,7 @@ static bool isDefinedInClangModule(const RecordDecl *RD) {
       // This is a template, check the origin of the first member.
       if (CXXDecl->field_begin() == CXXDecl->field_end())
         return TemplateKind == TSK_ExplicitInstantiationDeclaration;
-      if (!CXXDecl->field_begin()->isFromASTFile())
+      if (!(*CXXDecl->field_begin())->isFromASTFile())
         return false;
     }
   }

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -3118,7 +3118,7 @@ static llvm::Value *emitDestructorsFunction(CodeGenModule &CGM,
   auto FI = std::next(KmpTaskTWithPrivatesQTyRD->field_begin());
   Base = CGF.EmitLValueForField(Base, *FI);
   for (const auto *Field :
-       cast<RecordDecl>(FI->getType()->getAsTagDecl())->fields()) {
+       cast<RecordDecl>((*FI)->getType()->getAsTagDecl())->fields()) {
     if (QualType::DestructionKind DtorKind =
             Field->getType().isDestructedType()) {
       LValue FieldLValue = CGF.EmitLValueForField(Base, Field);
@@ -3269,7 +3269,7 @@ static void emitPrivatesInit(CodeGenFunction &CGF,
             CGF.ConvertTypeForMem(SharedsTy)),
         SharedsTy);
   }
-  FI = cast<RecordDecl>(FI->getType()->getAsTagDecl())->field_begin();
+  FI = cast<RecordDecl>((*FI)->getType()->getAsTagDecl())->field_begin();
   for (const PrivateDataTy &Pair : Privates) {
     // Do not initialize private locals.
     if (Pair.second.isLocalPrivate()) {
@@ -3683,8 +3683,8 @@ CGOpenMPRuntime::emitTaskInit(CodeGenFunction &CGF, SourceLocation Loc,
       std::next(TaskFunction->arg_begin(), 3)->getType();
   if (!Privates.empty()) {
     auto FI = std::next(KmpTaskTWithPrivatesQTyRD->field_begin());
-    TaskPrivatesMap =
-        emitTaskPrivateMappingFunction(CGM, Loc, Data, FI->getType(), Privates);
+    TaskPrivatesMap = emitTaskPrivateMappingFunction(
+        CGM, Loc, Data, (*FI)->getType(), Privates);
     TaskPrivatesMap = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
         TaskPrivatesMap, TaskPrivatesMapTy);
   } else {
@@ -9477,7 +9477,7 @@ static void genMapInfoForCaptures(
           MappableExprsHandler::DeviceInfoTy::None);
       CurInfo.Pointers.push_back(*CV);
       CurInfo.Sizes.push_back(CGF.Builder.CreateIntCast(
-          CGF.getTypeSize(RI->getType()), CGF.Int64Ty, /*isSigned=*/true));
+          CGF.getTypeSize((*RI)->getType()), CGF.Int64Ty, /*isSigned=*/true));
       // Copy to the device as an argument. No need to retrieve it.
       CurInfo.Types.push_back(OpenMPOffloadMappingFlags::OMP_MAP_LITERAL |
                               OpenMPOffloadMappingFlags::OMP_MAP_TARGET_PARAM |

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -1954,7 +1954,7 @@ llvm::Function *CGOpenMPRuntimeGPU::createParallelDataSharingWrapper(
   if (CS.capture_size() > 0) {
     ASTContext &CGFContext = CGF.getContext();
     for (unsigned I = 0, E = CS.capture_size(); I < E; ++I, ++CI, ++CurField) {
-      QualType ElemTy = CurField->getType();
+      QualType ElemTy = (*CurField)->getType();
       Address Src = Bld.CreateConstInBoundsGEP(SharedArgListAddress, I + Idx);
       Address TypedAddress = Bld.CreatePointerBitCastOrAddrSpaceCast(
           Src, CGF.ConvertTypeForMem(CGFContext.getPointerType(ElemTy)),

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -3122,15 +3122,13 @@ LValue CodeGenFunction::InitCapturedStruct(const CapturedStmt &S) {
   LValue SlotLV =
     MakeAddrLValue(CreateMemTemp(RecordTy, "agg.captured"), RecordTy);
 
-  RecordDecl::field_iterator CurField = RD->field_begin();
-  for (CapturedStmt::const_capture_init_iterator I = S.capture_init_begin(),
-                                                 E = S.capture_init_end();
-       I != E; ++I, ++CurField) {
-    LValue LV = EmitLValueForFieldInitialization(SlotLV, *CurField);
+  for (const auto &[CurField, I] :
+       llvm::zip_equal(RD->fields(), S.capture_inits())) {
+    LValue LV = EmitLValueForFieldInitialization(SlotLV, CurField);
     if (CurField->hasCapturedVLAType()) {
       EmitLambdaVLACapture(CurField->getCapturedVLAType(), LV);
     } else {
-      EmitInitializerForField(*CurField, LV, *I);
+      EmitInitializerForField(CurField, LV, I);
     }
   }
 

--- a/clang/lib/CodeGen/CodeGenTBAA.cpp
+++ b/clang/lib/CodeGen/CodeGenTBAA.cpp
@@ -393,7 +393,7 @@ CodeGenTBAA::CollectFields(uint64_t BaseOffset,
         continue;
       }
 
-      QualType FieldQTy = i->getType();
+      QualType FieldQTy = (*i)->getType();
       if (!CollectFields(Offset, FieldQTy, Fields,
                          MayAlias || TypeHasMayAlias(FieldQTy)))
         return false;

--- a/clang/lib/CodeGen/Targets/Mips.cpp
+++ b/clang/lib/CodeGen/Targets/Mips.cpp
@@ -156,7 +156,7 @@ llvm::Type* MipsABIInfo::HandleAggregates(QualType Ty, uint64_t TySize) const {
   // double fields.
   for (RecordDecl::field_iterator i = RD->field_begin(), e = RD->field_end();
        i != e; ++i, ++idx) {
-    const QualType Ty = i->getType();
+    const QualType Ty = (*i)->getType();
     const BuiltinType *BT = Ty->getAs<BuiltinType>();
 
     if (!BT || BT->getKind() != BuiltinType::Double)
@@ -263,12 +263,12 @@ MipsABIInfo::returnAggregateInRegs(QualType RetTy, uint64_t Size) const {
     if (FieldCnt && (FieldCnt <= 2) && !Layout.getFieldOffset(0)) {
       RecordDecl::field_iterator b = RD->field_begin(), e = RD->field_end();
       for (; b != e; ++b) {
-        const BuiltinType *BT = b->getType()->getAs<BuiltinType>();
+        const BuiltinType *BT = (*b)->getType()->getAs<BuiltinType>();
 
         if (!BT || !BT->isFloatingPoint())
           break;
 
-        RTList.push_back(CGT.ConvertType(b->getType()));
+        RTList.push_back(CGT.ConvertType((*b)->getType()));
       }
 
       if (b == e)

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -2075,14 +2075,12 @@ void X86_64ABIInfo::classify(QualType Ty, uint64_t OffsetBase, Class &Lo,
     }
 
     // Classify the fields one at a time, merging the results.
-    unsigned idx = 0;
     bool UseClang11Compat = getContext().getLangOpts().getClangABICompat() <=
                                 LangOptions::ClangABI::Ver11 ||
                             getContext().getTargetInfo().getTriple().isPS();
     bool IsUnion = RT->isUnionType() && !UseClang11Compat;
 
-    for (RecordDecl::field_iterator i = RD->field_begin(), e = RD->field_end();
-           i != e; ++i, ++idx) {
+    for (const auto &[idx, i] : llvm::enumerate(RD->fields())) {
       uint64_t Offset = OffsetBase + Layout.getFieldOffset(idx);
       bool BitField = i->isBitField();
 
@@ -2348,9 +2346,7 @@ static bool BitsContainNoUserData(QualType Ty, unsigned StartBit,
     // this could be sped up a lot by being smarter about queried fields,
     // however we're only looking at structs up to 16 bytes, so we don't care
     // much.
-    unsigned idx = 0;
-    for (RecordDecl::field_iterator i = RD->field_begin(), e = RD->field_end();
-         i != e; ++i, ++idx) {
+    for (const auto &[idx, i] : llvm::enumerate(RD->fields())) {
       unsigned FieldOffset = (unsigned)Layout.getFieldOffset(idx);
 
       // If we found a field after the region we care about, then we're done.

--- a/clang/lib/InstallAPI/Visitor.cpp
+++ b/clang/lib/InstallAPI/Visitor.cpp
@@ -693,9 +693,7 @@ bool InstallAPIVisitor::VisitCXXRecordDecl(const CXXRecordDecl *D) {
       return true;
   }
 
-  using var_iter = CXXRecordDecl::specific_decl_iterator<VarDecl>;
-  using var_range = iterator_range<var_iter>;
-  for (const auto *Var : var_range(D->decls())) {
+  for (const auto *Var : D->specific_decls<VarDecl>()) {
     // Skip const static member variables.
     // \code
     // struct S {

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6858,11 +6858,8 @@ void SemaCodeCompletion::CodeCompleteNamespaceDecl(Scope *S) {
     // extended namespace declaration. Keep track of the most recent
     // definition of each namespace.
     std::map<NamespaceDecl *, NamespaceDecl *> OrigToLatest;
-    for (DeclContext::specific_decl_iterator<NamespaceDecl>
-             NS(Ctx->decls_begin()),
-         NSEnd(Ctx->decls_end());
-         NS != NSEnd; ++NS)
-      OrigToLatest[NS->getFirstDecl()] = *NS;
+    for (auto *NS : Ctx->specific_decls<NamespaceDecl>())
+      OrigToLatest[NS->getFirstDecl()] = NS;
 
     // Add the most recent definition (or extended definition) of each
     // namespace to the list of results.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15473,14 +15473,14 @@ LambdaScopeInfo *Sema::RebuildLambdaScopeInfo(CXXMethodDecl *CallOperator) {
           /*RefersToEnclosingVariableOrCapture*/true, C.getLocation(),
           /*EllipsisLoc*/C.isPackExpansion()
                          ? C.getEllipsisLoc() : SourceLocation(),
-          I->getType(), /*Invalid*/false);
+          (*I)->getType(), /*Invalid*/false);
 
     } else if (C.capturesThis()) {
-      LSI->addThisCapture(/*Nested*/ false, C.getLocation(), I->getType(),
+      LSI->addThisCapture(/*Nested*/ false, C.getLocation(), (*I)->getType(),
                           C.getCaptureKind() == LCK_StarThis);
     } else {
-      LSI->addVLATypeCapture(C.getLocation(), I->getCapturedVLAType(),
-                             I->getType());
+      LSI->addVLATypeCapture(C.getLocation(), (*I)->getCapturedVLAType(),
+                             (*I)->getType());
     }
     ++I;
   }
@@ -19304,9 +19304,9 @@ void Sema::ActOnFields(Scope *S, SourceLocation RecLoc, Decl *EnclosingDecl,
       bool ZeroSize = true;
       bool IsEmpty = true;
       unsigned NonBitFields = 0;
-      for (RecordDecl::field_iterator I = Record->field_begin(),
-                                      E = Record->field_end();
-           (NonBitFields == 0 || ZeroSize) && I != E; ++I) {
+      for (FieldDecl *I : Record->fields()) {
+        if (NonBitFields != 0 && !ZeroSize)
+          break;
         IsEmpty = false;
         if (I->isUnnamedBitField()) {
           if (!I->isZeroLengthBitField(Context))

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3909,14 +3909,12 @@ static void handleTransparentUnionAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     return;
   }
 
-  RecordDecl::field_iterator Field = RD->field_begin(),
-                          FieldEnd = RD->field_end();
-  if (Field == FieldEnd) {
+  if (RD->field_empty()) {
     S.Diag(AL.getLoc(), diag::warn_transparent_union_attribute_zero_fields);
     return;
   }
 
-  FieldDecl *FirstField = *Field;
+  FieldDecl *FirstField = *RD->field_begin();
   QualType FirstType = FirstField->getType();
   if (FirstType->hasFloatingRepresentation() || FirstType->isVectorType()) {
     S.Diag(FirstField->getLocation(),
@@ -3929,7 +3927,7 @@ static void handleTransparentUnionAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     return;
   uint64_t FirstSize = S.Context.getTypeSize(FirstType);
   uint64_t FirstAlign = S.Context.getTypeAlign(FirstType);
-  for (; Field != FieldEnd; ++Field) {
+  for (FieldDecl *Field : RD->fields()) {
     QualType FieldType = Field->getType();
     if (FieldType->isIncompleteType())
       return;
@@ -3946,7 +3944,7 @@ static void handleTransparentUnionAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
                                   : S.Context.getTypeAlign(FieldType);
       S.Diag(Field->getLocation(),
              diag::warn_transparent_union_attribute_field_size_align)
-          << isSize << *Field << FieldBits;
+          << isSize << Field << FieldBits;
       unsigned FirstBits = isSize ? FirstSize : FirstAlign;
       S.Diag(FirstField->getLocation(),
              diag::note_transparent_union_first_field_size_align)

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2348,8 +2348,9 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
       // allow at most one initializer per member.
       bool AnyAnonStructUnionMembers = false;
       unsigned Fields = 0;
-      for (CXXRecordDecl::field_iterator I = RD->field_begin(),
-           E = RD->field_end(); I != E; ++I, ++Fields) {
+      for (auto FieldCountTuple : llvm::enumerate(RD->fields())) {
+        FieldDecl *I = FieldCountTuple.value();
+        Fields = FieldCountTuple.index();
         if (I->isAnonymousStructOrUnion()) {
           AnyAnonStructUnionMembers = true;
           break;
@@ -11826,7 +11827,7 @@ QualType Sema::CheckComparisonCategoryType(ComparisonCategoryType Kind,
   //   (2) The field is an integral or enumeration type.
   auto FIt = Info->Record->field_begin(), FEnd = Info->Record->field_end();
   if (std::distance(FIt, FEnd) != 1 ||
-      !FIt->getType()->isIntegralOrEnumerationType()) {
+      !(*FIt)->getType()->isIntegralOrEnumerationType()) {
     return UnsupportedSTLError();
   }
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -9915,8 +9915,7 @@ static CXXConstructorDecl *findUserDeclaredCtor(CXXRecordDecl *RD) {
       return CI;
 
   // Look for constructor templates.
-  typedef CXXRecordDecl::specific_decl_iterator<FunctionTemplateDecl> tmpl_iter;
-  for (tmpl_iter TI(RD->decls_begin()), TE(RD->decls_end()); TI != TE; ++TI) {
+  for (auto *TI : RD->specific_decls<FunctionTemplateDecl>()) {
     if (CXXConstructorDecl *CD =
           dyn_cast<CXXConstructorDecl>(TI->getTemplatedDecl()))
       return CD;

--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -3247,7 +3247,7 @@ static bool tryMatchRecordTypes(ASTContext &Context,
   RecordDecl::field_iterator li = left->field_begin(), le = left->field_end();
   RecordDecl::field_iterator ri = right->field_begin(), re = right->field_end();
   for (; li != le && ri != re; ++li, ++ri) {
-    if (!matchTypes(Context, strategy, li->getType(), ri->getType()))
+    if (!matchTypes(Context, strategy, (*li)->getType(), (*ri)->getType()))
       return false;
   }
   return (li == le && ri == re);

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -2287,9 +2287,9 @@ void InitListChecker::CheckStructUnionTypes(
         return;
       for (RecordDecl::field_iterator FieldEnd = RD->field_end();
            Field != FieldEnd; ++Field) {
-        if (Field->hasInClassInitializer() ||
-            (Field->isAnonymousStructOrUnion() &&
-             Field->getType()->getAsCXXRecordDecl()->hasInClassInitializer())) {
+        if ((*Field)->hasInClassInitializer() ||
+            ((*Field)->isAnonymousStructOrUnion() &&
+             (*Field)->getType()->getAsCXXRecordDecl()->hasInClassInitializer())) {
           StructuredList->setInitializedFieldInUnion(*Field);
           // FIXME: Actually build a CXXDefaultInitExpr?
           return;
@@ -2302,7 +2302,7 @@ void InitListChecker::CheckStructUnionTypes(
     // bitfield.
     for (RecordDecl::field_iterator FieldEnd = RD->field_end();
          Field != FieldEnd; ++Field) {
-      if (!Field->isUnnamedBitField()) {
+      if (!(*Field)->isUnnamedBitField()) {
         CheckEmptyInitializable(
             InitializedEntity::InitializeMember(*Field, &Entity),
             IList->getEndLoc());
@@ -2462,10 +2462,10 @@ void InitListChecker::CheckStructUnionTypes(
       return;
 
     // Stop if we've hit a flexible array member.
-    if (Field->getType()->isIncompleteArrayType())
+    if ((*Field)->getType()->isIncompleteArrayType())
       break;
 
-    if (Field->isUnnamedBitField()) {
+    if ((*Field)->isUnnamedBitField()) {
       // Don't initialize unnamed bitfields, e.g. "int : 20;"
       ++Field;
       continue;
@@ -2486,7 +2486,7 @@ void InitListChecker::CheckStructUnionTypes(
     }
 
     if (!VerifyOnly) {
-      QualType ET = SemaRef.Context.getBaseElementType(Field->getType());
+      QualType ET = SemaRef.Context.getBaseElementType((*Field)->getType());
       if (checkDestructorReference(ET, InitLoc, SemaRef)) {
         hadError = true;
         return;
@@ -2495,7 +2495,7 @@ void InitListChecker::CheckStructUnionTypes(
 
     InitializedEntity MemberEntity =
       InitializedEntity::InitializeMember(*Field, &Entity);
-    CheckSubElementType(MemberEntity, IList, Field->getType(), Index,
+    CheckSubElementType(MemberEntity, IList, (*Field)->getType(), Index,
                         StructuredList, StructuredIndex);
     InitializedSomething = true;
     InitializedFields.insert(*Field);
@@ -2525,8 +2525,8 @@ void InitListChecker::CheckStructUnionTypes(
       if (HasDesignatedInit && InitializedFields.count(*it))
         continue;
 
-      if (!it->isUnnamedBitField() && !it->hasInClassInitializer() &&
-          !it->getType()->isIncompleteArrayType()) {
+      if (!(*it)->isUnnamedBitField() && !(*it)->hasInClassInitializer() &&
+          !(*it)->getType()->isIncompleteArrayType()) {
         auto Diag = HasDesignatedInit
                         ? diag::warn_missing_designated_field_initializers
                         : diag::warn_missing_field_initializers;
@@ -2539,9 +2539,9 @@ void InitListChecker::CheckStructUnionTypes(
   // Check that any remaining fields can be value-initialized if we're not
   // building a structured list. (If we are, we'll check this later.)
   if (!StructuredList && Field != FieldEnd && !RD->isUnion() &&
-      !Field->getType()->isIncompleteArrayType()) {
+      !(*Field)->getType()->isIncompleteArrayType()) {
     for (; Field != FieldEnd && !hadError; ++Field) {
-      if (!Field->isUnnamedBitField() && !Field->hasInClassInitializer())
+      if (!(*Field)->isUnnamedBitField() && !(*Field)->hasInClassInitializer())
         CheckEmptyInitializable(
             InitializedEntity::InitializeMember(*Field, &Entity),
             IList->getEndLoc());
@@ -2555,7 +2555,7 @@ void InitListChecker::CheckStructUnionTypes(
     RecordDecl::field_iterator I = HasDesignatedInit ? RD->field_begin()
                                                      : Field;
     for (RecordDecl::field_iterator E = RD->field_end(); I != E; ++I) {
-      QualType ET = SemaRef.Context.getBaseElementType(I->getType());
+      QualType ET = SemaRef.Context.getBaseElementType((*I)->getType());
       if (checkDestructorReference(ET, IList->getEndLoc(), SemaRef)) {
         hadError = true;
         return;
@@ -2563,7 +2563,7 @@ void InitListChecker::CheckStructUnionTypes(
     }
   }
 
-  if (Field == FieldEnd || !Field->getType()->isIncompleteArrayType() ||
+  if (Field == FieldEnd || !(*Field)->getType()->isIncompleteArrayType() ||
       Index >= IList->getNumInits())
     return;
 
@@ -2579,10 +2579,10 @@ void InitListChecker::CheckStructUnionTypes(
 
   if (isa<InitListExpr>(IList->getInit(Index)) ||
       AggrDeductionCandidateParamTypes)
-    CheckSubElementType(MemberEntity, IList, Field->getType(), Index,
+    CheckSubElementType(MemberEntity, IList, (*Field)->getType(), Index,
                         StructuredList, StructuredIndex);
   else
-    CheckImplicitInitList(MemberEntity, IList, Field->getType(), Index,
+    CheckImplicitInitList(MemberEntity, IList, (*Field)->getType(), Index,
                           StructuredList, StructuredIndex);
 
   if (RD->isUnion() && StructuredList) {
@@ -2921,7 +2921,9 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
     }
 
     RecordDecl::field_iterator Field =
-        RecordDecl::field_iterator(DeclContext::decl_iterator(KnownField));
+        llvm::find(KnownField->getParent()->fields(), KnownField);
+    assert(Field != KnownField->getParent()->field_end() &&
+           "Field not in own parent?");
 
     // All of the fields of a union are located at the same place in
     // the initializer list.
@@ -2981,16 +2983,16 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
     if (IsFirstDesignator && !VerifyOnly && SemaRef.getLangOpts().CPlusPlus &&
         NextField &&
         (*NextField == RD->field_end() ||
-         (*NextField)->getFieldIndex() > Field->getFieldIndex() + 1)) {
+         (**NextField)->getFieldIndex() > (*Field)->getFieldIndex() + 1)) {
       // Find the field that we just initialized.
       FieldDecl *PrevField = nullptr;
-      for (auto FI = RD->field_begin(); FI != RD->field_end(); ++FI) {
+      for (FieldDecl *FI : RD->fields()) {
         if (FI->isUnnamedBitField())
           continue;
         if (*NextField != RD->field_end() &&
-            declaresSameEntity(*FI, **NextField))
+            declaresSameEntity(FI, **NextField))
           break;
-        PrevField = *FI;
+        PrevField = FI;
       }
 
       if (PrevField &&
@@ -3021,7 +3023,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
       StructuredList->resizeInits(SemaRef.Context, FieldIndex + 1);
 
     // This designator names a flexible array member.
-    if (Field->getType()->isIncompleteArrayType()) {
+    if ((*Field)->getType()->isIncompleteArrayType()) {
       bool Invalid = false;
       if ((DesigIdx + 1) != DIE->size()) {
         // We can't designate an object within the flexible array
@@ -3032,7 +3034,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
           SemaRef.Diag(NextD->getBeginLoc(),
                        diag::err_designator_into_flexible_array_member)
               << SourceRange(NextD->getBeginLoc(), DIE->getEndLoc());
-          SemaRef.Diag(Field->getLocation(), diag::note_flexible_array_member)
+          SemaRef.Diag((*Field)->getLocation(), diag::note_flexible_array_member)
             << *Field;
         }
         Invalid = true;
@@ -3045,7 +3047,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
           SemaRef.Diag(DIE->getInit()->getBeginLoc(),
                        diag::err_flexible_array_init_needs_braces)
               << DIE->getInit()->getSourceRange();
-          SemaRef.Diag(Field->getLocation(), diag::note_flexible_array_member)
+          SemaRef.Diag((*Field)->getLocation(), diag::note_flexible_array_member)
             << *Field;
         }
         Invalid = true;
@@ -3069,7 +3071,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
 
       InitializedEntity MemberEntity =
         InitializedEntity::InitializeMember(*Field, &Entity);
-      CheckSubElementType(MemberEntity, IList, Field->getType(), Index,
+      CheckSubElementType(MemberEntity, IList, (*Field)->getType(), Index,
                           StructuredList, newStructuredIndex);
 
       IList->setInit(OldIndex, DIE);
@@ -3083,7 +3085,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
       }
     } else {
       // Recurse to check later designated subobjects.
-      QualType FieldType = Field->getType();
+      QualType FieldType = (*Field)->getType();
       unsigned newStructuredIndex = FieldIndex;
 
       InitializedEntity MemberEntity =
@@ -3103,7 +3105,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
     // If this the first designator, our caller will continue checking
     // the rest of this struct/class/union subobject.
     if (IsFirstDesignator) {
-      if (Field != RD->field_end() && Field->isUnnamedBitField())
+      if (Field != RD->field_end() && (*Field)->isUnnamedBitField())
         ++Field;
 
       if (NextField)
@@ -8391,8 +8393,8 @@ ExprResult InitializationSequence::Perform(Sema &S,
           return InvalidType();
 
         // Start pointer
-        if (!Field->getType()->isPointerType() ||
-            !S.Context.hasSameType(Field->getType()->getPointeeType(),
+        if (!(*Field)->getType()->isPointerType() ||
+            !S.Context.hasSameType((*Field)->getType()->getPointeeType(),
                                    ElementType.withConst()))
           return InvalidType();
 
@@ -8400,13 +8402,13 @@ ExprResult InitializationSequence::Perform(Sema &S,
           return InvalidType();
 
         // Size or end pointer
-        if (const auto *PT = Field->getType()->getAs<PointerType>()) {
+        if (const auto *PT = (*Field)->getType()->getAs<PointerType>()) {
           if (!S.Context.hasSameType(PT->getPointeeType(),
                                      ElementType.withConst()))
             return InvalidType();
         } else {
-          if (Field->isBitField() ||
-              !S.Context.hasSameType(Field->getType(), S.Context.getSizeType()))
+          if ((*Field)->isBitField() ||
+              !S.Context.hasSameType((*Field)->getType(), S.Context.getSizeType()))
             return InvalidType();
         }
 

--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -2678,18 +2678,18 @@ RegionBindingsRef RegionStoreManager::bindStruct(RegionBindingsConstRef B,
     }
   }
 
-  RecordDecl::field_iterator FI, FE;
+  RecordDecl::field_iterator FI = RD->field_begin(), FE = RD->field_end();
 
-  for (FI = RD->field_begin(), FE = RD->field_end(); FI != FE; ++FI) {
+  for (; FI != FE; ++FI) {
 
     if (VI == VE)
       break;
 
     // Skip any unnamed bitfields to stay in sync with the initializers.
-    if (FI->isUnnamedBitField())
+    if ((*FI)->isUnnamedBitField())
       continue;
 
-    QualType FTy = FI->getType();
+    QualType FTy = (*FI)->getType();
     const FieldRegion* FR = MRMgr.getFieldRegion(*FI, R);
 
     if (FTy->isArrayType())

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -8987,9 +8987,9 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportFieldInitializerWithItself) {
   Decl *FromTU = getTuDecl(Code, Lang_CXX11);
   auto *FromA = FirstDeclMatcher<CXXRecordDecl>().match(
       FromTU, cxxRecordDecl(hasName("A")));
-  EXPECT_TRUE(FromA->field_begin()->getInClassInitializer());
+  EXPECT_TRUE((*FromA->field_begin())->getInClassInitializer());
   auto *ToA = Import(FromA, Lang_CXX11);
-  EXPECT_TRUE(ToA->field_begin()->getInClassInitializer());
+  EXPECT_TRUE((*ToA->field_begin())->getInClassInitializer());
 }
 
 TEST_P(ASTImporterOptionSpecificTestBase, ImportRecursiveFieldInitializer1) {
@@ -9020,7 +9020,7 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportRecursiveFieldInitializer1) {
   Decl *FromTU = getTuDecl(Code, Lang_CXX11);
   auto *FromA = FirstDeclMatcher<CXXRecordDecl>().match(
       FromTU, cxxRecordDecl(hasName("A")));
-  EXPECT_TRUE(FromA->field_begin()->getInClassInitializer());
+  EXPECT_TRUE((*FromA->field_begin())->getInClassInitializer());
   // auto *ToA = Import(FromA, Lang_CXX11);
   // EXPECT_TRUE(ToA->field_begin()->getInClassInitializer());
 }


### PR DESCRIPTION
One of the things holding up solutions to https://github.com/llvm/llvm-project/issues/113950 is the pretty rough uses of iterators in a weird way all over the place.  This patch set attempted to replace them with a llvm::make_filtered_range + a casting iterator.  I only tried to replace 'field_iterator' here plus a couple of for-each type fields, doing some algorithmic symplification where I would.

Good news: it compiles
Bad news: check-clang has ~57 failures, including failing a stack-exhaustion test, so it seems the greater size of the field-iterator (now 2x in size, since it needs to hold an 'end' iterator instead of being able to count on null) has caused our stack size to increase too much.

At the moment, I'm probably abandoning this effort.  There IS a bunch of perf that would come from the linked-list-to-vector, mixed with making the local `VarDecl` not have to care about its next-decls or decl-context (thus giving us less to transform), but this is likely a pretty sizable lift.