### PR TITLE
[RISCV] Add OperandType to loadfpimm.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
@@ -35,6 +35,8 @@ def LoadFPImmOperand : AsmOperandClass {
 def loadfpimm : Operand<XLenVT> {
   let ParserMatchClass = LoadFPImmOperand;
   let PrintMethod = "printFPImmOperand";
+  let OperandType = "OPERAND_UIMM5";
+  let OperandNamespace = "RISCVOp";
 }
 
 def RTZArg : AsmOperandClass {


### PR DESCRIPTION
This is represented in the MachineInstr and MCInst as a 5-bit unsigned immediate so we use OPERAND_UIMM5. If someone needs to know for sure its an FLI constant in the future we can break it out to a new type.