### PR TITLE
Fix the sort function for languages to have "strict weak ordering".

### DIFF
--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2649,6 +2649,7 @@ public:
                 return false;
               LanguageType lt1 = lang1->GetLanguageType();
               LanguageType lt2 = lang2->GetLanguageType();
+              if (lt1 == lt2) return false;
               if (lt1 == guessed_language)
                 return true; // make the selected frame's language come first
               if (lt2 == guessed_language)

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2649,7 +2649,8 @@ public:
                 return false;
               LanguageType lt1 = lang1->GetLanguageType();
               LanguageType lt2 = lang2->GetLanguageType();
-              if (lt1 == lt2) return false;
+              if (lt1 == lt2)
+                return false;
               if (lt1 == guessed_language)
                 return true; // make the selected frame's language come first
               if (lt2 == guessed_language)


### PR DESCRIPTION
If you build libstdc++ with "debug" strictness, the test TestTypeLookup.py will assert.  That's because we're calling llvm::sort (which redirects to std::sort) with a function that doesn't obey strict weak ordering.

The error was that when the two languages were equal, we're sometimes returning `true` but strict weak ordering requires that always be false.

This patch just makes the function behave properly.