### PR TITLE
[polly] Add nullptr check to fix #113772

### DIFF
--- a/polly/lib/Analysis/ScopDetection.cpp
+++ b/polly/lib/Analysis/ScopDetection.cpp
@@ -1698,6 +1698,8 @@ bool ScopDetection::hasPossiblyDistributableLoop(
     DetectionContext &Context) const {
   for (auto *BB : Context.CurRegion.blocks()) {
     auto *L = LI.getLoopFor(BB);
+    if (!L)
+      continue;
     if (!Context.CurRegion.contains(L))
       continue;
     if (Context.BoxedLoopsSet.count(L))

--- a/polly/test/ScopDetect/detect-full-functions.ll
+++ b/polly/test/ScopDetect/detect-full-functions.ll
@@ -1,0 +1,17 @@
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -polly-process-unprofitable=false -disable-output -polly-detect-full-functions  < %s 2>&1 | FileCheck %s
+
+; Verify if a simple function with basic block not part of loop doesn't crash with polly-process-unprofitable=false and polly-detect-full-functions flags.
+
+; CHECK: Detected Scops in Function foo
+
+define void @foo() {
+  br label %1
+
+1:                                                ; preds = %1, %0
+  br i1 false, label %2, label %1
+
+2:                                                ; preds = %1
+  %3 = load ptr, ptr null, align 8
+  store ptr null, ptr null, align 8
+  ret void
+}


### PR DESCRIPTION
The patch adds a nullptr check before accessing the loop blocks in 'hasPossiblyDistributableLoop' function. The existing check for the loop’s containment in the region does not capture nullptr cases when the region covers the entire function. Therefore, it’s better to exit if the basic block isn’t part of any loop

Fixes #113772.