### PR TITLE
[Clang][AArch64] Include SME attributes in the name mangling of function types

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -3544,7 +3544,7 @@ enum class AAPCSBitmaskSME : unsigned {
   ArmOut = 0b010,
   ArmInOut = 0b011,
   ArmPreserves = 0b100,
-  LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/ArmPreserves)
+  LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/ArmPreserves << ZT0_Shift)
 };
 
 static AAPCSBitmaskSME encodeAAPCSZAState(unsigned SMEAttrs) {
@@ -3579,24 +3579,21 @@ void CXXNameMangler::mangleSMEAttrs(unsigned SMEAttrs) {
   if (!SMEAttrs)
     return;
 
-  unsigned Bitmask = 0;
+  AAPCSBitmaskSME Bitmask = AAPCSBitmaskSME(0);
   if (SMEAttrs & FunctionType::SME_PStateSMEnabledMask)
-    Bitmask |= static_cast<unsigned>(AAPCSBitmaskSME::ArmStreamingBit);
+    Bitmask |= AAPCSBitmaskSME::ArmStreamingBit;
   else if (SMEAttrs & FunctionType::SME_PStateSMCompatibleMask)
-    Bitmask |=
-        static_cast<unsigned>(AAPCSBitmaskSME::ArmStreamingCompatibleBit);
+    Bitmask |= AAPCSBitmaskSME::ArmStreamingCompatibleBit;
 
   // TODO: Must represent __arm_agnostic("sme_za_state")
 
-  Bitmask |= static_cast<unsigned>(
-      encodeAAPCSZAState(FunctionType::getArmZAState(SMEAttrs))
-      << AAPCSBitmaskSME::ZA_Shift);
+  Bitmask |= encodeAAPCSZAState(FunctionType::getArmZAState(SMEAttrs))
+             << AAPCSBitmaskSME::ZA_Shift;
 
-  Bitmask |= static_cast<unsigned>(
-      encodeAAPCSZAState(FunctionType::getArmZT0State(SMEAttrs))
-      << AAPCSBitmaskSME::ZT0_Shift);
+  Bitmask |= encodeAAPCSZAState(FunctionType::getArmZT0State(SMEAttrs))
+             << AAPCSBitmaskSME::ZT0_Shift;
 
-  Out << "Lj" << Bitmask << "EE";
+  Out << "Lj" << static_cast<unsigned>(Bitmask) << "EE";
 }
 
 void

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -3543,21 +3543,22 @@ enum class AAPCSBitmaskSME : unsigned {
   ArmIn = 0b001,
   ArmOut = 0b010,
   ArmInOut = 0b011,
-  ArmPreserves = 0b100
+  ArmPreserves = 0b100,
+  LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/ArmPreserves)
 };
 
-static unsigned encodeAAPCSZAState(unsigned SMEAttrs) {
+static AAPCSBitmaskSME encodeAAPCSZAState(unsigned SMEAttrs) {
   switch (SMEAttrs) {
   case FunctionType::ARM_None:
-    return static_cast<unsigned>(AAPCSBitmaskSME::NoState);
+    return AAPCSBitmaskSME::NoState;
   case FunctionType::ARM_In:
-    return static_cast<unsigned>(AAPCSBitmaskSME::ArmIn);
+    return AAPCSBitmaskSME::ArmIn;
   case FunctionType::ARM_Out:
-    return static_cast<unsigned>(AAPCSBitmaskSME::ArmOut);
+    return AAPCSBitmaskSME::ArmOut;
   case FunctionType::ARM_InOut:
-    return static_cast<unsigned>(AAPCSBitmaskSME::ArmInOut);
+    return AAPCSBitmaskSME::ArmInOut;
   case FunctionType::ARM_Preserves:
-    return static_cast<unsigned>(AAPCSBitmaskSME::ArmPreserves);
+    return AAPCSBitmaskSME::ArmPreserves;
   default:
     llvm_unreachable("Unrecognised SME attribute");
   }
@@ -3578,7 +3579,6 @@ void CXXNameMangler::mangleSMEAttrs(unsigned SMEAttrs) {
   if (!SMEAttrs)
     return;
 
-  // Streaming Mode
   unsigned Bitmask = 0;
   if (SMEAttrs & FunctionType::SME_PStateSMEnabledMask)
     Bitmask |= static_cast<unsigned>(AAPCSBitmaskSME::ArmStreamingBit);
@@ -3588,11 +3588,13 @@ void CXXNameMangler::mangleSMEAttrs(unsigned SMEAttrs) {
 
   // TODO: Must represent __arm_agnostic("sme_za_state")
 
-  Bitmask |= encodeAAPCSZAState(FunctionType::getArmZAState(SMEAttrs))
-             << static_cast<unsigned>(AAPCSBitmaskSME::ZA_Shift);
+  Bitmask |= static_cast<unsigned>(
+      encodeAAPCSZAState(FunctionType::getArmZAState(SMEAttrs))
+      << AAPCSBitmaskSME::ZA_Shift);
 
-  Bitmask |= encodeAAPCSZAState(FunctionType::getArmZT0State(SMEAttrs))
-             << static_cast<unsigned>(AAPCSBitmaskSME::ZT0_Shift);
+  Bitmask |= static_cast<unsigned>(
+      encodeAAPCSZAState(FunctionType::getArmZT0State(SMEAttrs))
+      << AAPCSBitmaskSME::ZT0_Shift);
 
   Out << "Lj" << Bitmask << "EE";
 }

--- a/clang/test/CodeGenCXX/aarch64-mangle-sme-atts.cpp
+++ b/clang/test/CodeGenCXX/aarch64-mangle-sme-atts.cpp
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -target-feature +sve -target-feature +sme -target-feature +sme2 %s -emit-llvm -o - | FileCheck %s
+
+typedef __attribute__((neon_vector_type(2))) int int32x2_t;
+
+//
+// Streaming-Mode Attributes
+//
+
+// CHECK: define dso_local void @_Z12fn_streamingP11__SME_ATTRSIFvvLj1ELj0ELj0EE( 
+void fn_streaming(void (*foo)() __arm_streaming) { foo(); }
+
+// CHECK: define dso_local void @_Z12fn_streamingP11__SME_ATTRSIFivLj2ELj0ELj0EE(
+void fn_streaming(int (*foo)() __arm_streaming_compatible) { foo(); }
+
+//
+// ZA Attributes
+//
+
+// CHECK: define dso_local void @_Z15fn_za_preservedP11__SME_ATTRSIF11__Int32x2_tvLj0ELj1ELj0EE(
+__arm_new("za") void fn_za_preserved(int32x2_t (*foo)() __arm_preserves("za")) { foo(); }
+
+// CHECK: define dso_local void @_Z8fn_za_inP11__SME_ATTRSIFvu13__SVFloat64_tLj0ELj1ELj0EES_(
+__arm_new("za") void fn_za_in(void (*foo)(__SVFloat64_t) __arm_in("za"), __SVFloat64_t x) { foo(x); }
+
+// CHECK: define dso_local noundef i32 @_Z9fn_za_outP11__SME_ATTRSIFivLj0ELj1ELj0EE(
+__arm_new("za") int fn_za_out(int (*foo)() __arm_out("za")) { return foo(); }
+
+// CHECK: define dso_local void @_Z11fn_za_inoutP11__SME_ATTRSIFvvLj0ELj1ELj0EE(
+__arm_new("za") void fn_za_inout(void (*foo)() __arm_inout("za")) { foo(); }
+
+
+//
+// ZT0 Attributes
+//
+
+// CHECK: define dso_local void @_Z16fn_zt0_preservedP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+__arm_new("zt0") void fn_zt0_preserved(int (*foo)() __arm_preserves("zt0")) { foo(); }
+
+// CHECK: define dso_local void @_Z9fn_zt0_inP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+__arm_new("zt0") void fn_zt0_in(int (*foo)() __arm_in("zt0")) { foo(); }
+
+// CHECK: define dso_local void @_Z10fn_zt0_outP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+__arm_new("zt0") void fn_zt0_out(int (*foo)() __arm_out("zt0")) { foo(); }
+
+// CHECK: define dso_local void @_Z12fn_zt0_inoutP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+__arm_new("zt0") void fn_zt0_inout(int (*foo)() __arm_inout("zt0")) { foo(); }
+
+//
+// No SME Attributes
+//
+
+// CHECK: define dso_local void @_Z12no_sme_attrsPFvvE(
+void no_sme_attrs(void (*foo)()) { foo(); }
+
+// CHECK: define dso_local void @_Z24locally_streaming_callerPFvvE(
+__arm_locally_streaming void locally_streaming_caller(void (*foo)()) { foo(); }
+
+// CHECK: define dso_local void @_Z16streaming_callerv(
+void streaming_caller() __arm_streaming {}
+
+// CHECK: define dso_local void @_Z16za_shared_callerv(
+void za_shared_caller() __arm_in("za") {}
+
+// CHECK: define dso_local void @_Z17zt0_shared_callerv(
+void zt0_shared_caller() __arm_out("zt0") {}

--- a/clang/test/CodeGenCXX/aarch64-mangle-sme-atts.cpp
+++ b/clang/test/CodeGenCXX/aarch64-mangle-sme-atts.cpp
@@ -6,26 +6,26 @@ typedef __attribute__((neon_vector_type(2))) int int32x2_t;
 // Streaming-Mode Attributes
 //
 
-// CHECK: define dso_local void @_Z12fn_streamingP11__SME_ATTRSIFvvLj1ELj0ELj0EE( 
+// CHECK: define dso_local void @_Z12fn_streamingP11__SME_ATTRSIFvvELj1EE
 void fn_streaming(void (*foo)() __arm_streaming) { foo(); }
 
-// CHECK: define dso_local void @_Z12fn_streamingP11__SME_ATTRSIFivLj2ELj0ELj0EE(
-void fn_streaming(int (*foo)() __arm_streaming_compatible) { foo(); }
+// CHECK: define dso_local void @_Z23fn_streaming_compatibleP11__SME_ATTRSIFivELj2EE(
+void fn_streaming_compatible(int (*foo)() __arm_streaming_compatible) { foo(); }
 
 //
 // ZA Attributes
 //
 
-// CHECK: define dso_local void @_Z15fn_za_preservedP11__SME_ATTRSIF11__Int32x2_tvLj0ELj1ELj0EE(
+// CHECK: define dso_local void @_Z15fn_za_preservedP11__SME_ATTRSIF11__Int32x2_tvELj32EE(
 __arm_new("za") void fn_za_preserved(int32x2_t (*foo)() __arm_preserves("za")) { foo(); }
 
-// CHECK: define dso_local void @_Z8fn_za_inP11__SME_ATTRSIFvu13__SVFloat64_tLj0ELj1ELj0EES_(
+// CHECK: define dso_local void @_Z8fn_za_inP11__SME_ATTRSIFvu13__SVFloat64_tELj8EES_(
 __arm_new("za") void fn_za_in(void (*foo)(__SVFloat64_t) __arm_in("za"), __SVFloat64_t x) { foo(x); }
 
-// CHECK: define dso_local noundef i32 @_Z9fn_za_outP11__SME_ATTRSIFivLj0ELj1ELj0EE(
+// CHECK: define dso_local noundef i32 @_Z9fn_za_outP11__SME_ATTRSIFivELj16EE(
 __arm_new("za") int fn_za_out(int (*foo)() __arm_out("za")) { return foo(); }
 
-// CHECK: define dso_local void @_Z11fn_za_inoutP11__SME_ATTRSIFvvLj0ELj1ELj0EE(
+// CHECK: define dso_local void @_Z11fn_za_inoutP11__SME_ATTRSIFvvELj24EE(
 __arm_new("za") void fn_za_inout(void (*foo)() __arm_inout("za")) { foo(); }
 
 
@@ -33,17 +33,26 @@ __arm_new("za") void fn_za_inout(void (*foo)() __arm_inout("za")) { foo(); }
 // ZT0 Attributes
 //
 
-// CHECK: define dso_local void @_Z16fn_zt0_preservedP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+// CHECK: define dso_local void @_Z16fn_zt0_preservedP11__SME_ATTRSIFivELj256EE(
 __arm_new("zt0") void fn_zt0_preserved(int (*foo)() __arm_preserves("zt0")) { foo(); }
 
-// CHECK: define dso_local void @_Z9fn_zt0_inP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+// CHECK: define dso_local void @_Z9fn_zt0_inP11__SME_ATTRSIFivELj64EE(
 __arm_new("zt0") void fn_zt0_in(int (*foo)() __arm_in("zt0")) { foo(); }
 
-// CHECK: define dso_local void @_Z10fn_zt0_outP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+// CHECK: define dso_local void @_Z10fn_zt0_outP11__SME_ATTRSIFivELj128EE(
 __arm_new("zt0") void fn_zt0_out(int (*foo)() __arm_out("zt0")) { foo(); }
 
-// CHECK: define dso_local void @_Z12fn_zt0_inoutP11__SME_ATTRSIFivLj0ELj0ELj1EE(
+// CHECK: define dso_local void @_Z12fn_zt0_inoutP11__SME_ATTRSIFivELj192EE(
 __arm_new("zt0") void fn_zt0_inout(int (*foo)() __arm_inout("zt0")) { foo(); }
+
+//
+// Streaming-mode, ZA & ZT0 Attributes
+//
+
+// CHECK: define dso_local void @_Z17fn_all_attr_typesP11__SME_ATTRSIFivELj282EE(
+__arm_new("za") __arm_new("zt0")
+void fn_all_attr_types(int (*foo)() __arm_streaming_compatible __arm_inout("za") __arm_preserves("zt0"))
+{ foo(); }
 
 //
 // No SME Attributes


### PR DESCRIPTION
Similar to arm_sve_vector_bits, the mangling of function types is implemented as a pseudo template if there are any SME attributes present, i.e.

  `__SME_ATTRS<normal_function_type, sme_state>`

For example, the following function:

  `void f(svint8_t (*fn)() __arm_streaming) { fn(); }`

would be mangled as:

  `_Z1fP11__SME_ATTRSIFu10__SVInt8_tELj1EE`

See https://github.com/ARM-software/acle/pull/358