### PR TITLE
[MemProf] Include <ctime> to avoid MSVC failure

### DIFF
--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/OnDiskHashTable.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
+#include <ctime>
 #include <memory>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
My change in bb3915149a7c9b1660db9caebfc96343352e8454 added a call to
std::time which worked generally as there must be some transitive
include of <ctime>. However, I saw one MSVC bot failure:

InstrProfWriter.cpp(202): error C2039: 'time': is not a member of 'std'

from https://lab.llvm.org/buildbot/#/builders/63/builds/2325.

Presumably explictly including <ctime> should fix this.
