### PR TITLE
Remove a flaky and unnecessary check

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/initializerlist/TestInitializerList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/initializerlist/TestInitializerList.py
@@ -40,5 +40,3 @@ class InitializerListTestCase(TestBase):
             "frame variable ils",
             substrs=['[4] = "surprise it is a long string!! yay!!"'],
         )
-
-        self.expect("image list", substrs=self.getLibcPlusPlusLibs())


### PR DESCRIPTION
The order in which the libraries appear is not always stable and even if it were, this test is not the right place to check for this.