### PR TITLE
[clang] SemaFunctionEffects: When verifying a function, ignore any trailing 'requires' clause.

### DIFF
--- a/clang/lib/Sema/SemaFunctionEffects.cpp
+++ b/clang/lib/Sema/SemaFunctionEffects.cpp
@@ -1264,6 +1264,11 @@ private:
     }
 
     bool TraverseStmt(Stmt *Statement) {
+      // If this statement is a `requires` clause from the top-level function
+      // being traversed, ignore it, since it's not generating runtime code.
+      // We skip the traversal of lambdas (beyond their captures, see
+      // TraverseLambdaExpr below), so just caching this from our constructor
+      // should suffice.
       if (Statement != TrailingRequiresClause)
         return Base::TraverseStmt(Statement);
       return true;
@@ -1307,6 +1312,7 @@ private:
     }
 
     bool TraverseBlockExpr(BlockExpr * /*unused*/) {
+      // As with lambdas, don't traverse the block's body.
       // TODO: are the capture expressions (ctor call?) safe?
       return true;
     }

--- a/clang/test/Sema/attr-nonblocking-constraints.cpp
+++ b/clang/test/Sema/attr-nonblocking-constraints.cpp
@@ -388,6 +388,51 @@ void nb26() [[clang::nonblocking]] {
 	abort_wrapper(); // no diagnostic
 }
 
+// --- Make sure we don't traverse a requires clause. ---
+
+// Apparently some requires clauses are able to be collapsed into a constant before the nonblocking
+// analysis sees any function calls. This example (extracted from a real-world case where
+// `operator&&` in <valarray>, preceding the inclusion of <expected>) is sufficiently complex
+// to look like it contains function calls. There may be simpler examples.
+
+namespace ExpectedTest {
+
+template <class _Tp>
+inline constexpr bool is_copy_constructible_v = __is_constructible(_Tp, _Tp&);
+
+template <bool, class _Tp = void>
+struct enable_if {};
+template <class _Tp>
+struct enable_if<true, _Tp> {
+  typedef _Tp type;
+};
+
+template <bool _Bp, class _Tp = void>
+using enable_if_t = typename enable_if<_Bp, _Tp>::type;
+
+// Doesn't seem to matter whether the enable_if is true or false.
+template <class E1, class E2, enable_if_t<is_copy_constructible_v<E1>> = 0>
+inline bool operator&&(const E1& x, const E2& y);
+
+template <class _Tp, class _Err>
+class expected {
+public:
+  constexpr expected()
+    {}
+
+  constexpr expected(const expected&)
+    requires(is_copy_constructible_v<_Tp> && is_copy_constructible_v<_Err>)
+  = default;
+};
+
+void test() [[clang::nonblocking]]
+{
+	expected<int, int> a;
+	auto b = a;
+}
+
+} // namespace ExpectedTest
+
 // --- nonblocking implies noexcept ---
 #pragma clang diagnostic warning "-Wperf-constraint-implies-noexcept"
 


### PR DESCRIPTION
Clearly there's an omission here, that a trailing `requires` clause in a called function is being subject to effect analysis.

But despite many hours of effort I haven't been able to create a self-contained reproducer. My best effort:

```c++
#include <valarray>
#include <type_traits>
#include <expected>

template <class _Tp, _Tp __v>
struct integral_constant {
  static constexpr _Tp value = __v;
  typedef _Tp value_type;
  typedef integral_constant type;
  constexpr operator value_type() const noexcept { return value; }
  constexpr value_type operator()() const noexcept { return value; }
};

template <typename T>
struct IsInt : public integral_constant<bool, false> {};

template <>
struct IsInt<int> : public integral_constant<bool, true> {};

template <typename T>
inline constexpr bool IsInt_V = IsInt<T>::value;

template <typename T, typename E>
struct ExpectedLike {
	ExpectedLike() = default;
	
	constexpr ExpectedLike(const ExpectedLike&)
// 	requires(IsInt_V<T> && IsInt_V<E> && IsInt_V<T>)
    requires(std::is_copy_constructible_v<T> && std::is_copy_constructible_v<E> && std::is_trivially_copy_constructible_v<T> &&
             std::is_trivially_copy_constructible_v<E>)

	= default;
	
};

void nb_xx() [[clang::nonblocking]]
{
	ExpectedLike<int, int> a;
	auto b = a;
// No warning. I don't know why.

	std::expected<int, int> c;
	std::expected<int, int> d = c;
// ^^ warning: function with 'nonblocking' attribute must not call non-'nonblocking' constructor 'std::expected<int, int>::expected' [-Wfunction-effects]
}
```

The two elements of the mystery are:

- why doesn't my `ExpectedLike<T, E>` copy constructor reproduce the behavior of `std::expected<T, E>`?
- why does reproduction with `std::expected` depend on the global `operator &&` in `<valarray>`?

I've verified that the change to SemaFunctionEffects fixes the issue, but I'd sure like to be able to construct a self-contained test.