### PR TITLE
Replace documentation mentions of IRC with Discord

### DIFF
--- a/clang/www/OpenProjects.html
+++ b/clang/www/OpenProjects.html
@@ -160,8 +160,8 @@ a text editor could change.</p></li>
 <p>If you hit a bug with Clang, it is very useful for us if you reduce the code
 that demonstrates the problem down to something small. There are many ways to
 do this; ask on <a href="https://discourse.llvm.org/c/clang">Discourse</a>,
-<a href="https://discord.com/channels/636084430946959380/636725486533345280">Discord</a>,
-or <a href="https://llvm.org/docs/GettingInvolved.html#irc"IRC</a> for advice.</p>
+<a href="https://discord.com/channels/636084430946959380/636725486533345280">Discord</a>
+for advice.</p>
 
 </div>
 </body>

--- a/libunwind/docs/index.rst
+++ b/libunwind/docs/index.rst
@@ -78,7 +78,7 @@ and `Getting started with LLVM <https://llvm.org/docs/GettingStarted.html>`__.
 
 If you think you've found a bug in libunwind, please report it using
 the `LLVM bug tracker`_. If you're not sure, you
-can ask for support on the `Runtimes forum`_ or on IRC.
+can ask for support on the `Runtimes forum`_ or on Discord.
 Please use the tag "libunwind" for new threads.
 
 **Patches**

--- a/llvm/docs/CodeOfConduct.rst
+++ b/llvm/docs/CodeOfConduct.rst
@@ -24,12 +24,12 @@ the spirit in which it's intended - a guide to make it easier to communicate
 and participate in the community.
 
 This code of conduct applies to all spaces managed by the LLVM project or The
-LLVM Foundation. This includes Discord channels, mailing lists, bug trackers,
-LLVM events such as the developer meetings and socials, and any other forums
-created by the project that the community uses for communication. It applies to
-all of your communication and conduct in these spaces, including emails, chats,
-things you say, slides, videos, posters, signs, or even t-shirts you display in
-these spaces. 
+LLVM Foundation. This includes IRC and Discord channels, mailing lists, bug
+trackers, LLVM events such as the developer meetings and socials, and any other
+forums created by the project that the community uses for communication. It
+applies to all of your communication and conduct in these spaces, including
+emails, chats, things you say, slides, videos, posters, signs, or even t-shirts
+you display in these spaces.
 
 In rare cases, violations of this code outside of these spaces may affect a 
 person’s ability to participate within these spaces. Important examples 

--- a/llvm/docs/CodeOfConduct.rst
+++ b/llvm/docs/CodeOfConduct.rst
@@ -24,12 +24,12 @@ the spirit in which it's intended - a guide to make it easier to communicate
 and participate in the community.
 
 This code of conduct applies to all spaces managed by the LLVM project or The
-LLVM Foundation. This includes IRC channels, mailing lists, bug trackers, LLVM
-events such as the developer meetings and socials, and any other forums created
-by the project that the community uses for communication. It applies to all of
-your communication and conduct in these spaces, including emails, chats, things
-you say, slides, videos, posters, signs, or even t-shirts you display in these
-spaces. 
+LLVM Foundation. This includes Discord channels, mailing lists, bug trackers,
+LLVM events such as the developer meetings and socials, and any other forums
+created by the project that the community uses for communication. It applies to
+all of your communication and conduct in these spaces, including emails, chats,
+things you say, slides, videos, posters, signs, or even t-shirts you display in
+these spaces. 
 
 In rare cases, violations of this code outside of these spaces may affect a 
 person’s ability to participate within these spaces. Important examples 

--- a/llvm/docs/CodeReview.rst
+++ b/llvm/docs/CodeReview.rst
@@ -248,8 +248,8 @@ larger features. Common ways to speed up review times for your patches are:
   get this patch landed and ping it every couple of days. If it is
   not urgent, the common courtesy ping rate is one week. Remember that you're
   asking for valuable time from other professional developers.
-* Ask for help on IRC. Developers on IRC will be able to either help you
-  directly, or tell you who might be a good reviewer.
+* Ask for help on Discord. Developers on Discord will be able to either help
+  you directly, or tell you who might be a good reviewer.
 * Split your patch into multiple smaller patches that build on each other. The
   smaller your patch is, the higher the probability that somebody will take a quick
   look at it. When doing this, it is helpful to add "[N/M]" (for 1 <= N <= M) to

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -6,7 +6,7 @@ Contributing to LLVM
 Thank you for your interest in contributing to LLVM! There are multiple ways to
 contribute, and we appreciate all contributions. In case you have questions,
 you can either use the `Forum`_ or, for a more interactive chat, go to our
-`Discord server`_ or the IRC #llvm channel on `irc.oftc.net`_.
+`Discord server`_.
 
 If you want to contribute code, please familiarize yourself with the :doc:`DeveloperPolicy`.
 

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -201,7 +201,7 @@ within an area of a project:
     * aid release managers with backporting and other release-related
       activities,
     * be a point of contact for contributors who need help (answering questions
-      on Discord/Discourse/IRC or holding office hours).
+      on Discord/Discourse or holding office hours).
 
 Each top-level project in the monorepo will specify one or more
 lead maintainers who are responsible for ensuring community needs are

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -201,7 +201,7 @@ within an area of a project:
     * aid release managers with backporting and other release-related
       activities,
     * be a point of contact for contributors who need help (answering questions
-      on Discord/Discourse or holding office hours).
+      on Discord/Discourse/IRC or holding office hours).
 
 Each top-level project in the monorepo will specify one or more
 lead maintainers who are responsible for ensuring community needs are

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -201,7 +201,7 @@ within an area of a project:
     * aid release managers with backporting and other release-related
       activities,
     * be a point of contact for contributors who need help (answering questions
-      on Discord/Discourse/Discord or holding office hours).
+      on Discord/Discourse or holding office hours).
 
 Each top-level project in the monorepo will specify one or more
 lead maintainers who are responsible for ensuring community needs are

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -201,7 +201,7 @@ within an area of a project:
     * aid release managers with backporting and other release-related
       activities,
     * be a point of contact for contributors who need help (answering questions
-      on Discord/Discourse/IRC or holding office hours).
+      on Discord/Discourse/Discord or holding office hours).
 
 Each top-level project in the monorepo will specify one or more
 lead maintainers who are responsible for ensuring community needs are

--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -377,7 +377,6 @@ Guidance for office hours hosts
 
     * the `#office-hours Discord channel
       <https://discord.com/channels/636084430946959380/976196303681896538>`__.
-    * :ref:`IRC`
 
   Doing this can help:
     * overcome potential anxiety to call in for a first time,
@@ -388,27 +387,18 @@ Guidance for office hours hosts
   from the list above.
 
 
-.. _IRC:
-
-IRC
----
+Discord
+-------
 
 Users and developers of the LLVM project (including subprojects such as Clang)
-can be found in #llvm on `irc.oftc.net <irc://irc.oftc.net/llvm>`_. The channel
-is actively moderated.
+can be found on the community's `Discord <https://discord.com/channels/636084430946959380/636725486533345280>`_
+chat server. The server is actively moderated.
 
-The #llvm-build channel has a bot for
+The #buildbot-status channel has a bot for
 `LLVM buildbot <http://lab.llvm.org/buildbot/#/console>`_ status changes. The
-bot will post a message with a link to a build bot and a blamelist when a build
-goes from passing to failing and again (without the blamelist) when the build
-goes from failing back to passing. It is a good channel for actively monitoring
-build statuses, but it is a noisy channel due to the automated messages. The
-channel is not actively moderated.
-
-In addition to the traditional IRC there is a
-`Discord <https://discord.com/channels/636084430946959380/636725486533345280>`_
-chat server available. To sign up, please use this
-`invitation link <https://discord.com/invite/xS7Z362>`_.
+bot will update the channel with a link to a build bot when a build goes from
+passing to failing and again when the build goes from failing back to passing.
+It is a good channel for actively monitoring build statuses.
 
 
 .. _meetups-social-events:

--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -373,9 +373,7 @@ Guidance for office hours hosts
 * When starting an office hours session, consider typing something like "*Hi,
   I'm available for chats in the next half hour at* video chat URL. *I'm
   looking forward to having conversations on the video chat or here.*" on the
-  LLVM chat channels that you are already on. These could include:
-
-    * the `#office-hours Discord channel
+  the `#office-hours Discord channel
       <https://discord.com/channels/636084430946959380/976196303681896538>`__.
 
   Doing this can help:

--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -373,8 +373,7 @@ Guidance for office hours hosts
 * When starting an office hours session, consider typing something like "*Hi,
   I'm available for chats in the next half hour at* video chat URL. *I'm
   looking forward to having conversations on the video chat or here.*" on the
-  the `#office-hours Discord channel
-      <https://discord.com/channels/636084430946959380/976196303681896538>`__.
+  the `#office-hours Discord channel <https://discord.com/channels/636084430946959380/976196303681896538>`__.
 
   Doing this can help:
     * overcome potential anxiety to call in for a first time,
@@ -396,7 +395,7 @@ The #buildbot-status channel has a bot for
 `LLVM buildbot <http://lab.llvm.org/buildbot/#/console>`_ status changes. The
 bot will update the channel with a link to a build bot when a build goes from
 passing to failing and again when the build goes from failing back to passing.
-It is a good channel for actively monitoring build statuses.
+It is a great way to actively monitor the status of the build.
 
 
 .. _meetups-social-events:

--- a/llvm/docs/ResponseGuide.rst
+++ b/llvm/docs/ResponseGuide.rst
@@ -189,7 +189,7 @@ taken, but below is a list of possible resolutions:
   violation.
 * A private verbal warning and/or reprimand from the committee to the
   individual(s) involved and request to stop this behavior. This conversation
-  may happen in person, email, by phone, video chat, or IRC.
+  may happen in person, email, by phone, video chat, or Discord.
 * Request that the reportee avoid any interaction with, and physical proximity
   to, another person for the remainder of the event.
 * Refusal of alcoholic beverage purchases by the reportee at LLVM events.
@@ -202,8 +202,7 @@ taken, but below is a list of possible resolutions:
 * Immediately ending any volunteer responsibilities and privileges the reportee
   holds.
 * An imposed suspension (e.g., asking someone to "take a week off" from mailing
-  lists, bug tracker, IRC, Discord, repositories, or other communication
-  forms). 
+  lists, bug tracker, Discord, repositories, or other communication forms). 
 * A permanent or temporary ban from some or all LLVM Project spaces (online or
   in person).
 

--- a/llvm/docs/_templates/indexsidebar.html
+++ b/llvm/docs/_templates/indexsidebar.html
@@ -15,7 +15,7 @@
     <li><a href="https://llvm.org/docs/Contributing.html">Contributing to LLVM</a></li>
     <li><a href="https://llvm.org/docs/HowToSubmitABug.html">Submitting Bug Reports</a></li>
     <li><a href="https://llvm.org/docs/GettingInvolved.html#mailing-lists">Mailing Lists</a></li>
-    <li><a href="https://llvm.org/docs/GettingInvolved.html#irc">IRC</a></li>
+    <li><a href="https://llvm.org/docs/GettingInvolved.html#discord">Discord</a></li>
     <li><a href="https://llvm.org/docs/GettingInvolved.html#meetups-and-social-events">Meetups and Social Events</a></li>
 </ul>
 


### PR DESCRIPTION
This does not touch code owners or credits files that list IRC handles, that can be done separately if we want to make that change.

See https://discourse.llvm.org/t/rfc-remove-irc-as-a-recommended-communication-channel/82808/3 for the RFC.