### PR TITLE
[NFC] [clang] Use std::string instead of StringRef to reduce stack usage

### DIFF
--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -157,10 +157,10 @@ unsigned AttributeCommonInfo::calculateAttributeSpellingListIndex() const {
   // Both variables will be used in tablegen generated
   // attribute spell list index matching code.
   auto Syntax = static_cast<AttributeCommonInfo::Syntax>(getSyntax());
-  // We use std::string instead of StringRef to prevent local stack 
+  // We use std::string instead of StringRef to prevent local stack
   // allocation of literal strings for comparison.
-  const std::string Scope = normalizeAttrScopeName(getScopeName(), Syntax);
-  const std::string Name = normalizeAttrName(getAttrName(), Scope, Syntax);
+  const std::string Scope(normalizeAttrScopeName(getScopeName(), Syntax));
+  const std::string Name(normalizeAttrName(getAttrName(), Scope, Syntax));
 
 #include "clang/Sema/AttrSpellingListIndex.inc"
 }

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -157,8 +157,10 @@ unsigned AttributeCommonInfo::calculateAttributeSpellingListIndex() const {
   // Both variables will be used in tablegen generated
   // attribute spell list index matching code.
   auto Syntax = static_cast<AttributeCommonInfo::Syntax>(getSyntax());
-  StringRef Scope = normalizeAttrScopeName(getScopeName(), Syntax);
-  StringRef Name = normalizeAttrName(getAttrName(), Scope, Syntax);
+  // We use std::string instead of StringRef to prevent local stack 
+  // allocation of literal strings for comparison.
+  const std::string Scope = normalizeAttrScopeName(getScopeName(), Syntax);
+  const std::string Name = normalizeAttrName(getAttrName(), Scope, Syntax);
 
 #include "clang/Sema/AttrSpellingListIndex.inc"
 }


### PR DESCRIPTION
Comparisons between StringRef and string literals are lowered by MSVC to happen on the stack. All string literals are allocated unique stack slots increasing the overall stack usage of `calculateAttributeSpellingListIndex`. Use of `std::string` forces allocation of a string type per literal, reducing the overall stack usage of the function.