### PR TITLE
[lldb] Add a link to LLDB's Discord channel on the website

### DIFF
--- a/lldb/docs/index.rst
+++ b/lldb/docs/index.rst
@@ -181,6 +181,7 @@ interesting areas to contribute to lldb.
 
    Source Code <https://github.com/llvm/llvm-project>
    Releases <https://github.com/llvm/llvm-project/releases>
+   Discord <https://discord.com/channels/636084430946959380/636732809708306432>
    Discussion Forums <https://discourse.llvm.org/c/subprojects/lldb/8>
    Developer Policy <https://llvm.org/docs/DeveloperPolicy.html>
    Bug Reports <https://github.com/llvm/llvm-project/issues?q=is%3Aissue+label%3Alldb+is%3Aopen>


### PR DESCRIPTION
Looking at #114276, I realized we have a link to Discourse on the website, but not Discord. I think it would be helpful to have that link there for real-time community discussion.