### PR TITLE
[LinkerWrapper] Remove handling of special bitcode flags

### DIFF
--- a/clang/docs/ClangLinkerWrapper.rst
+++ b/clang/docs/ClangLinkerWrapper.rst
@@ -30,14 +30,11 @@ only for the linker wrapper will be forwarded to the wrapped linker job.
   USAGE: clang-linker-wrapper [options] -- <options to passed to the linker>
 
   OPTIONS:
-    --bitcode-library=<kind>-<triple>-<arch>=<path>
-                           Extra bitcode library to link
     --cuda-path=<dir>      Set the system CUDA path
     --device-debug         Use debugging
     --device-linker=<value> or <triple>=<value>
                            Arguments to pass to the device linker invocation
     --dry-run              Print program arguments without running
-    --embed-bitcode        Embed linked bitcode in the module
     --help-hidden          Display all available options
     --help                 Display available options (--help-hidden for more)
     --host-triple=<triple> Triple to use for the host compilation

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -600,17 +600,6 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args) {
   for (StringRef Arg : Args.getAllArgValues(OPT_compiler_arg_EQ))
     CmdArgs.push_back(Args.MakeArgString(Arg));
 
-  for (StringRef Arg : Args.getAllArgValues(OPT_builtin_bitcode_EQ)) {
-    if (llvm::Triple(Arg.split('=').first) == Triple)
-      CmdArgs.append({"-Xclang", "-mlink-builtin-bitcode", "-Xclang",
-                      Args.MakeArgString(Arg.split('=').second)});
-  }
-
-  // The OpenMPOpt pass can introduce new calls and is expensive, we do
-  // not want this when running CodeGen through clang.
-  if (Args.hasArg(OPT_clang_backend) || Args.hasArg(OPT_builtin_bitcode_EQ))
-    CmdArgs.append({"-mllvm", "-openmp-opt-disable"});
-
   if (Error Err = executeCommands(*ClangPath, CmdArgs))
     return std::move(Err);
 
@@ -1360,13 +1349,6 @@ getDeviceInput(const ArgList &Args) {
       if (Extracted)
         break;
     }
-  }
-
-  for (StringRef Library : Args.getAllArgValues(OPT_bitcode_library_EQ)) {
-    auto FileOrErr = getInputBitcodeLibrary(Library);
-    if (!FileOrErr)
-      return FileOrErr.takeError();
-    InputFiles[*FileOrErr].push_back(std::move(*FileOrErr));
   }
 
   SmallVector<SmallVector<OffloadFile>> InputsForTarget;

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -22,22 +22,12 @@ def host_triple_EQ : Joined<["--"], "host-triple=">,
 def opt_level : Joined<["--"], "opt-level=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"<O0, O1, O2, or O3>">,
   HelpText<"Optimization level for LTO">;
-def bitcode_library_EQ : Joined<["--"], "bitcode-library=">,
-  Flags<[WrapperOnlyOption]>, MetaVarName<"<kind>-<triple>-<arch>=<path>">,
-  HelpText<"Extra bitcode library to link">;
-def builtin_bitcode_EQ : Joined<["--"], "builtin-bitcode=">,
-  Flags<[WrapperOnlyOption]>, MetaVarName<"<triple>=<path>">,
-  HelpText<"Perform a special internalizing link on the bitcode file. "
-           "This is necessary for some vendor libraries to be linked correctly">;
 def device_linker_args_EQ : Joined<["--"], "device-linker=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"<value> or <triple>=<value>">,
   HelpText<"Arguments to pass to the device linker invocation">;
 def device_compiler_args_EQ : Joined<["--"], "device-compiler=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"<value> or <triple>=<value>">,
   HelpText<"Arguments to pass to the device compiler invocation">;
-def clang_backend : Flag<["--"], "clang-backend">,
-  Flags<[WrapperOnlyOption]>,
-  HelpText<"Run the backend using clang rather than the LTO backend">;
 def dry_run : Flag<["--"], "dry-run">,
   Flags<[WrapperOnlyOption]>,
   HelpText<"Print program arguments without running">;


### PR DESCRIPTION
Summary:
These flags were used in the very early days while we were trying to
port stuff. Now that we just pass bitcode to the device link job it
can be easily replaced by `-Xoffload-linker foo.bc`.
