### PR TITLE
[X86] Use getAllOnesConstant instead of getConstant(-1). NFC

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -49321,7 +49321,7 @@ static SDValue combineVectorShiftImm(SDNode *N, SelectionDAG &DAG,
   if (!LogicalShift && ISD::isBuildVectorAllOnes(N0.getNode()))
     // N0 is all ones or undef. We guarantee that the bits shifted into the
     // result are all ones, not undef.
-    return DAG.getConstant(-1, SDLoc(N), VT);
+    return DAG.getAllOnesConstant(SDLoc(N), VT);
 
   auto MergeShifts = [&](SDValue X, uint64_t Amt0, uint64_t Amt1) {
     unsigned NewShiftVal = Amt0 + Amt1;


### PR DESCRIPTION
A while back I had tried to clean up cases where getConstant was implicitly truncating constants. Initially by manual audit and later with an assert. I only committed patches from the assert testing.

This code path isn't executed in lit tests so I only found it with the manual audit. This patch was still sitting in my stash so thought I go ahead and post it.