### PR TITLE
[RISCV] fix SP recovery in varargs functions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -872,9 +872,7 @@ void RISCVFrameLowering::emitEpilogue(MachineFunction &MF,
   uint64_t StackSize = FirstSPAdjustAmount ? FirstSPAdjustAmount
                                            : getStackSizeWithRVVPadding(MF) -
                                                  RVFI->getReservedSpillsSize();
-  uint64_t FPOffset = FirstSPAdjustAmount ? FirstSPAdjustAmount
-                                          : getStackSizeWithRVVPadding(MF) -
-                                                RVFI->getVarArgsSaveSize();
+  uint64_t FPOffset = RealStackSize - RVFI->getVarArgsSaveSize();
   uint64_t RVVStackSize = RVFI->getRVVStackSize();
 
   bool RestoreSPFromFP = RI->hasStackRealignment(MF) ||

--- a/llvm/test/CodeGen/RISCV/varargs-with-fp-and-second-adj.ll
+++ b/llvm/test/CodeGen/RISCV/varargs-with-fp-and-second-adj.ll
@@ -28,7 +28,7 @@ define dso_local void @_Z3fooPKcz(ptr noundef %0, ...) "frame-pointer"="all" {
 ; RV64V-NEXT:    sd a0, -32(s0)
 ; RV64V-NEXT:    addi a0, s0, 8
 ; RV64V-NEXT:    sd a0, -40(s0)
-; RV64V-NEXT:    addi sp, s0, -496
+; RV64V-NEXT:    addi sp, s0, -432
 ; RV64V-NEXT:    .cfi_def_cfa sp, 496
 ; RV64V-NEXT:    ld ra, 424(sp) # 8-byte Folded Reload
 ; RV64V-NEXT:    ld s0, 416(sp) # 8-byte Folded Reload


### PR DESCRIPTION
This patch fixes sp recovery in the epilogue in varargs functions when fp register is presented and second sp adjustment is applied.

Source of the issue: https://github.com/llvm/llvm-project/pull/110809