### PR TITLE
[libc] Use relative inclusion for public headers.

### DIFF
--- a/libc/include/gpu/rpc.h.def
+++ b/libc/include/gpu/rpc.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-types/rpc_opcodes_t.h"
+#include "../llvm-libc-types/rpc_opcodes_t.h"
 
 %%public_api()
 

--- a/libc/include/llvm-libc-macros/containerof-macro.h
+++ b/libc/include/llvm-libc-macros/containerof-macro.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_CONTAINEROF_MACRO_H
 #define LLVM_LIBC_MACROS_CONTAINEROF_MACRO_H
 
-#include "llvm-libc-macros/offsetof-macro.h"
+#include "offsetof-macro.h"
 
 #define __containerof(ptr, type, member)                                       \
   ({                                                                           \

--- a/libc/include/llvm-libc-macros/sys-queue-macros.h
+++ b/libc/include/llvm-libc-macros/sys-queue-macros.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_MACROS_SYS_QUEUE_MACROS_H
 #define LLVM_LIBC_MACROS_SYS_QUEUE_MACROS_H
 
-#include "llvm-libc-macros/containerof-macro.h"
-#include "llvm-libc-macros/null-macro.h"
+#include "containerof-macro.h"
+#include "null-macro.h"
 
 #ifdef __cplusplus
 #define QUEUE_TYPEOF(type) type

--- a/libc/include/llvm-libc-types/__mutex_type.h
+++ b/libc/include/llvm-libc-types/__mutex_type.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES___MUTEX_TYPE_H
 #define LLVM_LIBC_TYPES___MUTEX_TYPE_H
 
-#include "llvm-libc-types/__futex_word.h"
+#include "__futex_word.h"
 
 typedef struct {
   unsigned char __timed;

--- a/libc/include/llvm-libc-types/cnd_t.h
+++ b/libc/include/llvm-libc-types/cnd_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_CND_T_H
 #define LLVM_LIBC_TYPES_CND_T_H
 
-#include "llvm-libc-types/__futex_word.h"
+#include "__futex_word.h"
 
 typedef struct {
   void *__qfront;

--- a/libc/include/llvm-libc-types/cookie_io_functions_t.h
+++ b/libc/include/llvm-libc-types/cookie_io_functions_t.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_COOKIE_IO_FUNCTIONS_T_H
 #define LLVM_LIBC_TYPES_COOKIE_IO_FUNCTIONS_T_H
 
-#include "llvm-libc-types/off64_t.h"
-#include "llvm-libc-types/size_t.h"
-#include "llvm-libc-types/ssize_t.h"
+#include "off64_t.h"
+#include "size_t.h"
+#include "ssize_t.h"
 
 typedef ssize_t cookie_read_function_t(void *, char *, size_t);
 typedef ssize_t cookie_write_function_t(void *, const char *, size_t);

--- a/libc/include/llvm-libc-types/fd_set.h
+++ b/libc/include/llvm-libc-types/fd_set.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_FD_SET_H
 #define LLVM_LIBC_TYPES_FD_SET_H
 
-#include "../llvm-libc-macros/sys-select-macros.h" // FD_SETSIZE
+#include "../llvm-libc-macros/sys-select-macros.h" // __FD_SET_WORD_TYPE, __FD_SET_ARRAYSIZE
 
 typedef struct {
   __FD_SET_WORD_TYPE __set[__FD_SET_ARRAYSIZE];

--- a/libc/include/llvm-libc-types/fd_set.h
+++ b/libc/include/llvm-libc-types/fd_set.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_FD_SET_H
 #define LLVM_LIBC_TYPES_FD_SET_H
 
-#include "llvm-libc-macros/sys-select-macros.h" // FD_SETSIZE
+#include "../llvm-libc-macros/sys-select-macros.h" // FD_SETSIZE
 
 typedef struct {
   __FD_SET_WORD_TYPE __set[__FD_SET_ARRAYSIZE];

--- a/libc/include/llvm-libc-types/mtx_t.h
+++ b/libc/include/llvm-libc-types/mtx_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_MTX_T_H
 #define LLVM_LIBC_TYPES_MTX_T_H
 
-#include "llvm-libc-types/__mutex_type.h"
+#include "__mutex_type.h"
 
 typedef __mutex_type mtx_t;
 

--- a/libc/include/llvm-libc-types/once_flag.h
+++ b/libc/include/llvm-libc-types/once_flag.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_ONCE_FLAG_H
 #define LLVM_LIBC_TYPES_ONCE_FLAG_H
 
-#include "llvm-libc-types/__futex_word.h"
+#include "__futex_word.h"
 
 #ifdef __linux__
 typedef __futex_word once_flag;

--- a/libc/include/llvm-libc-types/pthread_attr_t.h
+++ b/libc/include/llvm-libc-types/pthread_attr_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_ATTR_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_ATTR_T_H
 
-#include "llvm-libc-types/size_t.h"
+#include "size_t.h"
 
 typedef struct {
   int __detachstate;

--- a/libc/include/llvm-libc-types/pthread_mutex_t.h
+++ b/libc/include/llvm-libc-types/pthread_mutex_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_MUTEX_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_MUTEX_T_H
 
-#include "llvm-libc-types/__mutex_type.h"
+#include "__mutex_type.h"
 
 typedef __mutex_type pthread_mutex_t;
 

--- a/libc/include/llvm-libc-types/pthread_once_t.h
+++ b/libc/include/llvm-libc-types/pthread_once_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_ONCE_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_ONCE_T_H
 
-#include "llvm-libc-types/__futex_word.h"
+#include "__futex_word.h"
 
 #ifdef __linux__
 typedef __futex_word pthread_once_t;

--- a/libc/include/llvm-libc-types/pthread_rwlock_t.h
+++ b/libc/include/llvm-libc-types/pthread_rwlock_t.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_RWLOCK_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_RWLOCK_T_H
 
-#include "llvm-libc-types/__futex_word.h"
-#include "llvm-libc-types/pid_t.h"
+#include "__futex_word.h"
+#include "pid_t.h"
 typedef struct {
   unsigned __is_pshared : 1;
   unsigned __preference : 1;

--- a/libc/include/llvm-libc-types/pthread_spinlock_t.h
+++ b/libc/include/llvm-libc-types/pthread_spinlock_t.h
@@ -8,7 +8,7 @@
 
 #ifndef LLVM_LIBC_TYPES_PTHREAD_SPINLOCK_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_SPINLOCK_T_H
-#include "llvm-libc-types/pid_t.h"
+#include "pid_t.h"
 typedef struct {
   unsigned char __lockword;
   pid_t __owner;

--- a/libc/include/llvm-libc-types/pthread_t.h
+++ b/libc/include/llvm-libc-types/pthread_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_T_H
 
-#include "llvm-libc-types/__thread_type.h"
+#include "__thread_type.h"
 
 typedef __thread_type pthread_t;
 

--- a/libc/include/llvm-libc-types/siginfo_t.h
+++ b/libc/include/llvm-libc-types/siginfo_t.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_LIBC_TYPES_SIGINFO_T_H
 #define LLVM_LIBC_TYPES_SIGINFO_T_H
 
-#include "llvm-libc-types/clock_t.h"
-#include "llvm-libc-types/pid_t.h"
-#include "llvm-libc-types/uid_t.h"
-#include "llvm-libc-types/union_sigval.h"
+#include "clock_t.h"
+#include "pid_t.h"
+#include "uid_t.h"
+#include "union_sigval.h"
 
 #define SI_MAX_SIZE 128
 

--- a/libc/include/llvm-libc-types/sigset_t.h
+++ b/libc/include/llvm-libc-types/sigset_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_SIGSET_T_H
 #define LLVM_LIBC_TYPES_SIGSET_T_H
 
-#include "../llvm-libc-macros/signal-macros.h"
+#include "../llvm-libc-macros/signal-macros.h" // __NSIGSET_WORDS
 
 // This definition can be adjusted/specialized for different targets and
 // platforms as necessary. This definition works for Linux on most targets.

--- a/libc/include/llvm-libc-types/sigset_t.h
+++ b/libc/include/llvm-libc-types/sigset_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_SIGSET_T_H
 #define LLVM_LIBC_TYPES_SIGSET_T_H
 
-#include "llvm-libc-macros/signal-macros.h"
+#include "../llvm-libc-macros/signal-macros.h"
 
 // This definition can be adjusted/specialized for different targets and
 // platforms as necessary. This definition works for Linux on most targets.

--- a/libc/include/llvm-libc-types/stack_t.h
+++ b/libc/include/llvm-libc-types/stack_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STACK_T_H
 #define LLVM_LIBC_TYPES_STACK_T_H
 
-#include "llvm-libc-types/size_t.h"
+#include "size_t.h"
 
 typedef struct {
   // The order of the fields declared here should match the kernel definition

--- a/libc/include/llvm-libc-types/struct_dirent.h
+++ b/libc/include/llvm-libc-types/struct_dirent.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_DIRENT_H
 #define LLVM_LIBC_TYPES_STRUCT_DIRENT_H
 
-#include "llvm-libc-types/ino_t.h"
-#include "llvm-libc-types/off_t.h"
+#include "ino_t.h"
+#include "off_t.h"
 
 struct dirent {
   ino_t d_ino;

--- a/libc/include/llvm-libc-types/struct_epoll_event.h
+++ b/libc/include/llvm-libc-types/struct_epoll_event.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_EPOLL_EVENT_H
 #define LLVM_LIBC_TYPES_STRUCT_EPOLL_EVENT_H
 
-#include "llvm-libc-types/struct_epoll_data.h"
+#include "struct_epoll_data.h"
 
 typedef struct
 #ifdef __x86_64__

--- a/libc/include/llvm-libc-types/struct_f_owner_ex.h
+++ b/libc/include/llvm-libc-types/struct_f_owner_ex.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_F_OWNER_EX_H
 #define LLVM_LIBC_TYPES_STRUCT_F_OWNER_EX_H
 
-#include "llvm-libc-types/pid_t.h"
+#include "pid_t.h"
 
 enum pid_type {
   F_OWNER_TID = 0,

--- a/libc/include/llvm-libc-types/struct_flock.h
+++ b/libc/include/llvm-libc-types/struct_flock.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_FLOCK_H
 #define LLVM_LIBC_TYPES_STRUCT_FLOCK_H
 
-#include "llvm-libc-types/off_t.h"
-#include "llvm-libc-types/pid_t.h"
+#include "off_t.h"
+#include "pid_t.h"
 
 #include <stdint.h>
 

--- a/libc/include/llvm-libc-types/struct_flock64.h
+++ b/libc/include/llvm-libc-types/struct_flock64.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_FLOCK64_H
 #define LLVM_LIBC_TYPES_STRUCT_FLOCK64_H
 
-#include "llvm-libc-types/off64_t.h"
-#include "llvm-libc-types/pid_t.h"
+#include "off64_t.h"
+#include "pid_t.h"
 
 #include <stdint.h>
 

--- a/libc/include/llvm-libc-types/struct_rlimit.h
+++ b/libc/include/llvm-libc-types/struct_rlimit.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_RLIMIT_H
 #define LLVM_LIBC_TYPES_STRUCT_RLIMIT_H
 
-#include "llvm-libc-types/rlim_t.h"
+#include "rlim_t.h"
 
 struct rlimit {
   rlim_t rlim_cur;

--- a/libc/include/llvm-libc-types/struct_rusage.h
+++ b/libc/include/llvm-libc-types/struct_rusage.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_RUSAGE_H
 #define LLVM_LIBC_TYPES_STRUCT_RUSAGE_H
 
-#include "llvm-libc-types/struct_timeval.h"
+#include "struct_timeval.h"
 
 struct rusage {
   struct timeval ru_utime;

--- a/libc/include/llvm-libc-types/struct_sched_param.h
+++ b/libc/include/llvm-libc-types/struct_sched_param.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SCHED_PARAM_H
 #define LLVM_LIBC_TYPES_STRUCT_SCHED_PARAM_H
 
-#include "llvm-libc-types/pid_t.h"
-#include "llvm-libc-types/struct_timespec.h"
-#include "llvm-libc-types/time_t.h"
+#include "pid_t.h"
+#include "struct_timespec.h"
+#include "time_t.h"
 
 struct sched_param {
   // Process or thread execution scheduling priority.

--- a/libc/include/llvm-libc-types/struct_sigaction.h
+++ b/libc/include/llvm-libc-types/struct_sigaction.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SIGACTION_H
 #define LLVM_LIBC_TYPES_STRUCT_SIGACTION_H
 
-#include "llvm-libc-types/siginfo_t.h"
-#include "llvm-libc-types/sigset_t.h"
+#include "siginfo_t.h"
+#include "sigset_t.h"
 
 struct sigaction {
   union {

--- a/libc/include/llvm-libc-types/struct_sockaddr.h
+++ b/libc/include/llvm-libc-types/struct_sockaddr.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SOCKADDR_H
 #define LLVM_LIBC_TYPES_STRUCT_SOCKADDR_H
 
-#include "llvm-libc-types/sa_family_t.h"
+#include "sa_family_t.h"
 
 struct sockaddr {
   sa_family_t sa_family;

--- a/libc/include/llvm-libc-types/struct_sockaddr_un.h
+++ b/libc/include/llvm-libc-types/struct_sockaddr_un.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SOCKADDR_UN_H
 #define LLVM_LIBC_TYPES_STRUCT_SOCKADDR_UN_H
 
-#include "llvm-libc-types/sa_family_t.h"
+#include "sa_family_t.h"
 
 // This is the sockaddr specialization for AF_UNIX or AF_LOCAL sockets, as
 // defined by posix.

--- a/libc/include/llvm-libc-types/struct_stat.h
+++ b/libc/include/llvm-libc-types/struct_stat.h
@@ -9,16 +9,16 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_STAT_H
 #define LLVM_LIBC_TYPES_STRUCT_STAT_H
 
-#include "llvm-libc-types/blkcnt_t.h"
-#include "llvm-libc-types/blksize_t.h"
-#include "llvm-libc-types/dev_t.h"
-#include "llvm-libc-types/gid_t.h"
-#include "llvm-libc-types/ino_t.h"
-#include "llvm-libc-types/mode_t.h"
-#include "llvm-libc-types/nlink_t.h"
-#include "llvm-libc-types/off_t.h"
-#include "llvm-libc-types/struct_timespec.h"
-#include "llvm-libc-types/uid_t.h"
+#include "blkcnt_t.h"
+#include "blksize_t.h"
+#include "dev_t.h"
+#include "gid_t.h"
+#include "ino_t.h"
+#include "mode_t.h"
+#include "nlink_t.h"
+#include "off_t.h"
+#include "struct_timespec.h"
+#include "uid_t.h"
 
 struct stat {
   dev_t st_dev;

--- a/libc/include/llvm-libc-types/struct_termios.h
+++ b/libc/include/llvm-libc-types/struct_termios.h
@@ -9,9 +9,9 @@
 #ifndef __LLVM_LIBC_TYPES_STRUCT_TERMIOS_H__
 #define __LLVM_LIBC_TYPES_STRUCT_TERMIOS_H__
 
-#include "llvm-libc-types/cc_t.h"
-#include "llvm-libc-types/speed_t.h"
-#include "llvm-libc-types/tcflag_t.h"
+#include "cc_t.h"
+#include "speed_t.h"
+#include "tcflag_t.h"
 
 struct termios {
   tcflag_t c_iflag; // Input mode flags

--- a/libc/include/llvm-libc-types/struct_timespec.h
+++ b/libc/include/llvm-libc-types/struct_timespec.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_TIMESPEC_H
 #define LLVM_LIBC_TYPES_STRUCT_TIMESPEC_H
 
-#include "llvm-libc-types/time_t.h"
+#include "time_t.h"
 
 struct timespec {
   time_t tv_sec; /* Seconds.  */

--- a/libc/include/llvm-libc-types/struct_timeval.h
+++ b/libc/include/llvm-libc-types/struct_timeval.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_TIMEVAL_H
 #define LLVM_LIBC_TYPES_STRUCT_TIMEVAL_H
 
-#include "llvm-libc-types/suseconds_t.h"
-#include "llvm-libc-types/time_t.h"
+#include "suseconds_t.h"
+#include "time_t.h"
 
 struct timeval {
   time_t tv_sec;       // Seconds

--- a/libc/include/llvm-libc-types/thrd_t.h
+++ b/libc/include/llvm-libc-types/thrd_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_THRD_T_H
 #define LLVM_LIBC_TYPES_THRD_T_H
 
-#include "llvm-libc-types/__thread_type.h"
+#include "__thread_type.h"
 
 typedef __thread_type thrd_t;
 

--- a/libc/include/sys/auxv.h.def
+++ b/libc/include/sys/auxv.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-auxv-macros.h"
+#include "../llvm-libc-macros/sys-auxv-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/epoll.h.def
+++ b/libc/include/sys/epoll.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-epoll-macros.h"
+#include "../llvm-libc-macros/sys-epoll-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/ioctl.h.def
+++ b/libc/include/sys/ioctl.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-ioctl-macros.h"
+#include "../llvm-libc-macros/sys-ioctl-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/mman.h.def
+++ b/libc/include/sys/mman.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-mman-macros.h"
+#include "../llvm-libc-macros/sys-mman-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/queue.h
+++ b/libc/include/sys/queue.h
@@ -9,6 +9,6 @@
 #ifndef SYS_QUEUE_H
 #define SYS_QUEUE_H
 
-#include "llvm-libc-macros/sys-queue-macros.h"
+#include "../llvm-libc-macros/sys-queue-macros.h"
 
 #endif // SYS_QUEUE_H

--- a/libc/include/sys/random.h.def
+++ b/libc/include/sys/random.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-random-macros.h"
+#include "../llvm-libc-macros/sys-random-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/resource.h.def
+++ b/libc/include/sys/resource.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-resource-macros.h"
+#include "../llvm-libc-macros/sys-resource-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/select.h.def
+++ b/libc/include/sys/select.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-select-macros.h"
+#include "../llvm-libc-macros/sys-select-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/socket.h.def
+++ b/libc/include/sys/socket.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-socket-macros.h"
+#include "../llvm-libc-macros/sys-socket-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/stat.h.def
+++ b/libc/include/sys/stat.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-stat-macros.h"
+#include "../llvm-libc-macros/sys-stat-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/time.h.def
+++ b/libc/include/sys/time.h.def
@@ -11,9 +11,9 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-types/struct_timeval.h"
+#include "../llvm-libc-types/struct_timeval.h"
 
-#include "llvm-libc-macros/sys-time-macros.h"
+#include "../llvm-libc-macros/sys-time-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/wait.h.def
+++ b/libc/include/sys/wait.h.def
@@ -11,7 +11,7 @@
 
 #include "__llvm-libc-common.h"
 
-#include "llvm-libc-macros/sys-wait-macros.h"
+#include "../llvm-libc-macros/sys-wait-macros.h"
 
 %%public_api()
 

--- a/libc/utils/gpu/loader/Loader.h
+++ b/libc/utils/gpu/loader/Loader.h
@@ -11,8 +11,8 @@
 
 #include "utils/gpu/server/llvmlibc_rpc_server.h"
 
+#include "include/llvm-libc-types/rpc_opcodes_t.h"
 #include "include/llvm-libc-types/test_rpc_opcodes_t.h"
-#include "llvm-libc-types/rpc_opcodes_t.h"
 
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
We are finalizing the header inclusion policy, and for our public headers in the `libc/include` folder, they must use relative path in `"..."` when including each other.

This PR does the cleanup making sure that all the public header inclusions in `libc/include` folder use relative paths. 