### PR TITLE
Fix stepping away from the bottom-most frame of a virtual inlined call stack.

### DIFF
--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -489,7 +489,8 @@ bool ThreadPlanStepInRange::DoWillResume(lldb::StateType resume_state,
 bool ThreadPlanStepInRange::IsVirtualStep() {
   if (m_virtual_step == eLazyBoolCalculate) {
     Thread &thread = GetThread();
-    if (thread.GetCurrentInlinedDepth() == UINT32_MAX)
+    uint32_t cur_inline_depth = thread.GetCurrentInlinedDepth();
+    if (cur_inline_depth == UINT32_MAX || cur_inline_depth == 0)
       m_virtual_step = eLazyBoolNo;
     else
       m_virtual_step = eLazyBoolYes;

--- a/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
+++ b/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
@@ -364,7 +364,7 @@ class TestInlineStepping(TestBase):
         step_sequence = [["// In max_value specialized", "into"]]
         self.run_step_sequence(step_sequence)
 
-    def run_to_call_site_and_step(self, source_regex, func_name, start_pos):
+    def run_to_call_site_and_step(self, source_regex, func_name, start_pos, one_more_step_loc = None):
         main_spec = lldb.SBFileSpec("calling.cpp")
         # Set the breakpoint by file and line, not sourced regex because
         # we want to make sure we can set breakpoints on call sites:
@@ -408,6 +408,11 @@ class TestInlineStepping(TestBase):
                 # stepping for this function...
                 break
 
+        if one_more_step_loc:
+            thread.StepInto()
+            frame_0 = thread.frame[0]
+            self.assertEqual(frame_0.line_entry.line, line_number(self.main_source, one_more_step_loc),
+                                                                  "Was able to step one more time")
         process.Kill()
         target.Clear()
 
@@ -420,3 +425,7 @@ class TestInlineStepping(TestBase):
         self.run_to_call_site_and_step(
             "In caller_trivial_inline_2", "caller_trivial_inline_2", 3
         )
+        self.run_to_call_site_and_step(
+            "In caller_trivial_inline_3", "caller_trivial_inline_3", 4, "After caller_trivial_inline_3"
+        )
+        

--- a/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
+++ b/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
@@ -364,7 +364,9 @@ class TestInlineStepping(TestBase):
         step_sequence = [["// In max_value specialized", "into"]]
         self.run_step_sequence(step_sequence)
 
-    def run_to_call_site_and_step(self, source_regex, func_name, start_pos, one_more_step_loc = None):
+    def run_to_call_site_and_step(
+        self, source_regex, func_name, start_pos, one_more_step_loc=None
+    ):
         main_spec = lldb.SBFileSpec("calling.cpp")
         # Set the breakpoint by file and line, not sourced regex because
         # we want to make sure we can set breakpoints on call sites:
@@ -411,8 +413,11 @@ class TestInlineStepping(TestBase):
         if one_more_step_loc:
             thread.StepInto()
             frame_0 = thread.frame[0]
-            self.assertEqual(frame_0.line_entry.line, line_number(self.main_source, one_more_step_loc),
-                                                                  "Was able to step one more time")
+            self.assertEqual(
+                frame_0.line_entry.line,
+                line_number(self.main_source, one_more_step_loc),
+                "Was able to step one more time",
+            )
         process.Kill()
         target.Clear()
 
@@ -426,6 +431,8 @@ class TestInlineStepping(TestBase):
             "In caller_trivial_inline_2", "caller_trivial_inline_2", 3
         )
         self.run_to_call_site_and_step(
-            "In caller_trivial_inline_3", "caller_trivial_inline_3", 4, "After caller_trivial_inline_3"
+            "In caller_trivial_inline_3",
+            "caller_trivial_inline_3",
+            4,
+            "After caller_trivial_inline_3",
         )
-        

--- a/lldb/test/API/functionalities/inline-stepping/calling.cpp
+++ b/lldb/test/API/functionalities/inline-stepping/calling.cpp
@@ -95,7 +95,7 @@ void caller_trivial_inline_1() {
 
 void caller_trivial_inline_2() {
   caller_trivial_inline_3(); // In caller_trivial_inline_2.
-  inline_value += 1;
+  inline_value += 1; // After caller_trivial_inline_3
 }
 
 void caller_trivial_inline_3() {

--- a/lldb/test/API/functionalities/inline-stepping/calling.cpp
+++ b/lldb/test/API/functionalities/inline-stepping/calling.cpp
@@ -95,7 +95,7 @@ void caller_trivial_inline_1() {
 
 void caller_trivial_inline_2() {
   caller_trivial_inline_3(); // In caller_trivial_inline_2.
-  inline_value += 1; // After caller_trivial_inline_3
+  inline_value += 1;         // After caller_trivial_inline_3
 }
 
 void caller_trivial_inline_3() {


### PR DESCRIPTION
The computation of 'Thread::IsVirtualStep" was wrong - it called being at the bottom of a virtual call stack a "virtual step" but that is actually when you've gotten to concrete code and need to step for real.

I also added a test for this.