### PR TITLE
[lldb] Use PY_VERSION_HEX to simplify conditional compilation (NFC)

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -71,12 +71,12 @@ Expected<std::string> python::As<std::string>(Expected<PythonObject> &&obj) {
 }
 
 static bool python_is_finalizing() {
-#if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 13) || (PY_MAJOR_VERSION > 3)
+#if PY_VERSION_HEX >= 0x030d0000
   return Py_IsFinalizing();
-#elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 7
-  return _Py_Finalizing != nullptr;
-#else
+#elif PY_VERSION_HEX >= 0x03070000
   return _Py_IsFinalizing();
+#else
+  return _Py_Finalizing != nullptr;
 #endif
 }
 
@@ -810,7 +810,7 @@ bool PythonCallable::Check(PyObject *py_obj) {
   return PyCallable_Check(py_obj);
 }
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+#if PY_VERSION_HEX >= 0x03030000
 static const char get_arg_info_script[] = R"(
 from inspect import signature, Parameter, ismethod
 from collections import namedtuple
@@ -839,7 +839,7 @@ Expected<PythonCallable::ArgInfo> PythonCallable::GetArgInfo() const {
   if (!IsValid())
     return nullDeref();
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+#if PY_VERSION_HEX >= 0x03030000
 
   // no need to synchronize access to this global, we already have the GIL
   static PythonScript get_arg_info(get_arg_info_script);

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -50,7 +50,8 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 
 // Provide a meaningful diagnostic error if someone tries to compile this file
 // with a version of Python we don't support.
-static_assert(PY_VERSION_HEX >= 0x03000000, "LLDB requires Python 3.0");
+static_assert(PY_VERSION_HEX >= 0x03000000,
+              "LLDB requires at least Python 3.0");
 #endif
 
 #endif // LLDB_PLUGINS_SCRIPTINTERPRETER_PYTHON_LLDB_PYTHON_H

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -47,6 +47,10 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 
 // Include python for non windows machines
 #include <Python.h>
+
+// Provide a meaningful diagnostic error if someone tries to compile this file
+// with a version of Python we don't support.
+static_assert(PY_VERSION_HEX >= 0x03000000, "LLDB requires Python 3.0");
 #endif
 
 #endif // LLDB_PLUGINS_SCRIPTINTERPRETER_PYTHON_LLDB_PYTHON_H

--- a/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
+++ b/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
@@ -760,7 +760,7 @@ class NewStyle(object):
     EXPECT_EQ(arginfo.get().max_positional_args, 3u);
   }
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+#if PY_VERSION_HEX >= 0x03030000
 
   // the old implementation of GetArgInfo just doesn't work on builtins.
 


### PR DESCRIPTION
Use PY_VERSION_HEX to simplify conditional compilation depending on the Python version.

This also adds a static_assert to lldb-python to error out with a meaningful diagnostic when you try building LLDB with an older Python version in preparation for [1].

[1] https://discourse.llvm.org/t/rfc-lets-document-and-enforce-a-minimum-python-version-for-lldb/82731/15