### PR TITLE
[ORC] skip reoptimization tests on i386

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -47,6 +47,10 @@ protected:
     if (Triple.isSystemZ())
       GTEST_SKIP();
 
+    // 32-bit X86 is not supported yet.
+    if (Triple.isX86() && Triple.isArch32Bit())
+      GTEST_SKIP();
+
     if (Triple.isPPC())
       GTEST_SKIP();
 


### PR DESCRIPTION
This test currently segfaults on i386-unknown-linux-gnu builds.