### PR TITLE
[X86][CFE] Correct parameter type of _cmpccxadd_epi64

### DIFF
--- a/clang/include/clang/Basic/BuiltinsX86_64.def
+++ b/clang/include/clang/Basic/BuiltinsX86_64.def
@@ -150,7 +150,7 @@ TARGET_BUILTIN(__builtin_ia32_tcmmrlfp16ps, "vIUcIUcIUc", "n", "amx-complex")
 
 TARGET_BUILTIN(__builtin_ia32_prefetchi, "vvC*Ui", "nc", "prefetchi")
 TARGET_BUILTIN(__builtin_ia32_cmpccxadd32, "Siv*SiSiIi", "n", "cmpccxadd")
-TARGET_BUILTIN(__builtin_ia32_cmpccxadd64, "SLLiv*SLLiSLLiIi", "n", "cmpccxadd")
+TARGET_BUILTIN(__builtin_ia32_cmpccxadd64, "SLLiSLLi*SLLiSLLiIi", "n", "cmpccxadd")
 
 // AMX_FP16 FP16
 TARGET_BUILTIN(__builtin_ia32_tdpfp16ps, "vIUcIUcIUc", "n", "amx-fp16")

--- a/clang/lib/Headers/cmpccxaddintrin.h
+++ b/clang/lib/Headers/cmpccxaddintrin.h
@@ -63,7 +63,7 @@ typedef enum {
                                     (int)(__D))))
 
 #define _cmpccxadd_epi64(__A, __B, __C, __D)                                   \
-  ((long long)(__builtin_ia32_cmpccxadd64((void *)(__A), (long long)(__B),     \
+  ((long long)(__builtin_ia32_cmpccxadd64((__A), (long long)(__B),             \
                                           (long long)(__C), (int)(__D))))
 
 #endif // __x86_64__

--- a/clang/test/CodeGen/X86/cmpccxadd-builtins-error.c
+++ b/clang/test/CodeGen/X86/cmpccxadd-builtins-error.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 %s -ffreestanding -triple=x86_64-unknown-unknown \
-// RUN: -target-feature +cmpccxadd  -fsyntax-only -Werror -verify
+// RUN: -target-feature +cmpccxadd  -fsyntax-only -verify
 
 #include <immintrin.h>
 
@@ -12,5 +12,5 @@ long long test_cmpccxadd64(void *__A, long long __B, long long __C) {
 }
 
 long long test_cmpccxadd64_2(int *__A, long long __B, long long __C) {
-  return _cmpccxadd_epi64(__A, __B, __C, 3); // expected-error {{incompatible pointer types passing 'int *' to parameter of type 'long long *'}}
+  return _cmpccxadd_epi64(__A, __B, __C, 3); // expected-warning {{incompatible pointer types passing 'int *' to parameter of type 'long long *'}}
 }

--- a/clang/test/CodeGen/X86/cmpccxadd-builtins-error.c
+++ b/clang/test/CodeGen/X86/cmpccxadd-builtins-error.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 %s -ffreestanding -triple=x86_64-unknown-unknown \
-// RUN: -target-feature +cmpccxadd  -fsyntax-only -verify
+// RUN: -target-feature +cmpccxadd  -fsyntax-only -Werror -verify
 
 #include <immintrin.h>
 
@@ -9,4 +9,8 @@ int test_cmpccxadd32(void *__A, int __B, int __C) {
 
 long long test_cmpccxadd64(void *__A, long long __B, long long __C) {
   return _cmpccxadd_epi64(__A, __B, __C, 16); // expected-error {{argument value 16 is outside the valid range [0, 15]}}
+}
+
+long long test_cmpccxadd64_2(int *__A, long long __B, long long __C) {
+  return _cmpccxadd_epi64(__A, __B, __C, 3); // expected-error {{incompatible pointer types passing 'int *' to parameter of type 'long long *'}}
 }


### PR DESCRIPTION
This fixes correctness of https://gcc.godbolt.org/z/vexf5fW5r