### PR TITLE
[MLIR][TosaValidation] Enable float element-types on default

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
@@ -521,7 +521,8 @@ LogicalResult TosaValidation::applyVariableCheck(Operation *op) {
 
 bool TosaValidation::isValidElementType(Type type) {
   if (isa<FloatType>(type)) {
-    if (!isEnabledProfile(TosaProfileEnum::MainInference))
+    if (!isEnabledProfile(TosaProfileEnum::Undefined) &&
+        !isEnabledProfile(TosaProfileEnum::MainInference))
       return false;
     return type.isF32() || type.isF16() || type.isBF16();
   }


### PR DESCRIPTION
After change in tosa-validation profiles to list-option, float element types where no more allowed in default (where profile is/contains undefined enumeration value). This change allows floats when undefined value is contained in the profile.