### PR TITLE
[SPIR-V] Add missing ScalarOpts library

### DIFF
--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -56,6 +56,7 @@ add_llvm_target(SPIRVCodeGen
   MC
   SPIRVDesc
   SPIRVInfo
+  ScalarOpts
   SelectionDAG
   Support
   Target


### PR DESCRIPTION
Fixes an "undefined reference to `llvm::createRegToMemWrapperPass()'" linker error introduced by cba70550ccf5 ("[SPIR-V] Fix BB ordering & register lifetime (#111026)", 2024-10-30).