### PR TITLE
[clang] Fix an em/email typo in Maintainers.rst

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -72,7 +72,7 @@ Sema
 Experimental new constant interpreter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 | Timm Bäder
-| tbaeder\@redhat.com (em), tbaeder (Phabricator), tbaederr (GitHub), tbaeder (Discourse), tbaeder (Discord)
+| tbaeder\@redhat.com (email), tbaeder (Phabricator), tbaederr (GitHub), tbaeder (Discourse), tbaeder (Discord)
 
 
 Modules & serialization


### PR DESCRIPTION
Pretty sure this was a mistake, everyone else uses "email".