### PR TITLE
[TableGen] Fix calculation of Lanemask for RCs with artificial subregs.

### DIFF
--- a/llvm/test/TableGen/ArtificialSubregs.td
+++ b/llvm/test/TableGen/ArtificialSubregs.td
@@ -104,7 +104,7 @@ def TestTarget : Target;
 // CHECK:      	SuperClasses:
 //
 // CHECK:      RegisterClass DRegs:
-// CHECK:      	LaneMask: 0000000000000004
+// CHECK:      	LaneMask: 0000000000000044
 // CHECK:      	HasDisjunctSubRegs: 1
 // CHECK:      	CoveredBySubRegs: 1
 // CHECK:      	Regs: D0 D1 D2
@@ -112,7 +112,7 @@ def TestTarget : Target;
 // CHECK:      	SuperClasses:
 //
 // CHECK:      RegisterClass QRegs:
-// CHECK:      	LaneMask: 0000000000000044
+// CHECK:      	LaneMask: 0000000000000045
 // CHECK:      	HasDisjunctSubRegs: 1
 // CHECK:      	CoveredBySubRegs: 1
 // CHECK:      	Regs: Q0 Q1 Q2

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -2300,10 +2300,8 @@ void CodeGenRegBank::inferSubClassWithSubReg(CodeGenRegisterClass *RC) {
     if (R->Artificial)
       continue;
     const CodeGenRegister::SubRegMap &SRM = R->getSubRegs();
-    for (auto I : SRM) {
-      if (!I.first->Artificial)
-        SRSets[I.first].push_back(R);
-    }
+    for (auto I : SRM)
+      SRSets[I.first].push_back(R);
   }
 
   for (auto I : SRSets)
@@ -2312,8 +2310,6 @@ void CodeGenRegBank::inferSubClassWithSubReg(CodeGenRegisterClass *RC) {
   // Find matching classes for all SRSets entries.  Iterate in SubRegIndex
   // numerical order to visit synthetic indices last.
   for (const auto &SubIdx : SubRegIndices) {
-    if (SubIdx.Artificial)
-      continue;
     SubReg2SetMap::const_iterator I = SRSets.find(&SubIdx);
     // Unsupported SubRegIndex. Skip it.
     if (I == SRSets.end())
@@ -2323,6 +2319,8 @@ void CodeGenRegBank::inferSubClassWithSubReg(CodeGenRegisterClass *RC) {
       RC->setSubClassWithSubReg(&SubIdx, RC);
       continue;
     }
+    if (SubIdx.Artificial)
+      continue;
     // This is a real subset.  See if we have a matching class.
     CodeGenRegisterClass *SubRC = getOrCreateSubClass(
         RC, &I->second, RC->getName() + "_with_" + I->first->getName());


### PR DESCRIPTION
TableGen builds up a map of "SubRegIdx -> Subclass" where Subclass is the largest class where all registers have SubRegIdx as a sub-register. When SubRegIdx (vis-a-vis the sub-register) is artificial it should still include it in the map. This map is used in various places, including in the calculation of the Lanemask of a register class, which otherwise calculates an incorrect lanemask.