### PR TITLE
[z/OS][libc++] Remove `align_val_t` dependency in small_buffer.h 

### DIFF
--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -66,24 +66,14 @@ public:
     if constexpr (__fits_in_buffer<_Stored>) {
       return std::launder(reinterpret_cast<_Stored*>(__buffer_));
     } else {
-#  ifdef _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
-      byte* __allocation = static_cast<byte*>(::operator new[](sizeof(_Stored), align_val_t{alignof(_Stored)}));
-      std::construct_at(reinterpret_cast<byte**>(__buffer_), __allocation);
-      return std::launder(reinterpret_cast<_Stored*>(__allocation));
-#  else
-      return static_cast<_Stored*>(std::__libcpp_allocate(_BufferSize * sizeof(byte), _LIBCPP_ALIGNOF(byte)));
-#  endif // _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+      return static_cast<_Stored*>(std::__libcpp_allocate(_BufferSize * sizeof(byte), alignof(_Stored)));
     }
   }
 
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI void __dealloc() noexcept {
     if constexpr (!__fits_in_buffer<_Stored>)
-#  ifdef _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
-      ::operator delete[](*reinterpret_cast<void**>(__buffer_), sizeof(_Stored), align_val_t{alignof(_Stored)});
-#  else
-      std::__libcpp_deallocate((void*)__buffer_, _BufferSize * sizeof(byte), _LIBCPP_ALIGNOF(_Stored));
-#  endif // _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
+      std::__libcpp_deallocate((void*)__buffer_, _BufferSize * sizeof(byte), alignof(_Stored));
   }
 
   template <class _Stored, class... _Args>

--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -66,7 +66,9 @@ public:
     if constexpr (__fits_in_buffer<_Stored>) {
       return std::launder(reinterpret_cast<_Stored*>(__buffer_));
     } else {
-      return static_cast<_Stored*>(std::__libcpp_allocate(_BufferSize * sizeof(byte), alignof(_Stored)));
+      byte* __allocation = static_cast<byte*>(std::__libcpp_allocate(sizeof(_Stored), alignof(_Stored)));
+      std::construct_at(reinterpret_cast<byte**>(__buffer_), __allocation);
+      return std::launder(reinterpret_cast<_Stored*>(__allocation));
     }
   }
 

--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -75,7 +75,7 @@ public:
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI void __dealloc() noexcept {
     if constexpr (!__fits_in_buffer<_Stored>)
-      std::__libcpp_deallocate((void*)__buffer_, _BufferSize * sizeof(byte), alignof(_Stored));
+      std::__libcpp_deallocate(*reinterpret_cast<void**>(__buffer_), _BufferSize * sizeof(byte), alignof(_Stored));
   }
 
   template <class _Stored, class... _Args>

--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -75,7 +75,7 @@ public:
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI void __dealloc() noexcept {
     if constexpr (!__fits_in_buffer<_Stored>)
-      std::__libcpp_deallocate(*reinterpret_cast<void**>(__buffer_), _BufferSize * sizeof(byte), alignof(_Stored));
+      std::__libcpp_deallocate(*reinterpret_cast<void**>(__buffer_), sizeof(_Stored), alignof(_Stored));
   }
 
   template <class _Stored, class... _Args>

--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -61,6 +61,7 @@ public:
       return *std::launder(reinterpret_cast<_Stored**>(__buffer_));
   }
 
+#  ifdef _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI _Stored* __alloc() {
     if constexpr (__fits_in_buffer<_Stored>) {
@@ -72,11 +73,14 @@ public:
     }
   }
 
+#  endif // _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#  ifdef _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI void __dealloc() noexcept {
     if constexpr (!__fits_in_buffer<_Stored>)
       ::operator delete[](*reinterpret_cast<void**>(__buffer_), sizeof(_Stored), align_val_t{alignof(_Stored)});
   }
+#  endif // _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
 
   template <class _Stored, class... _Args>
   _LIBCPP_HIDE_FROM_ABI void __construct(_Args&&... __args) {

--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -71,7 +71,7 @@ public:
       std::construct_at(reinterpret_cast<byte**>(__buffer_), __allocation);
       return std::launder(reinterpret_cast<_Stored*>(__allocation));
 #  else
-      return static_cast<_Stored*>(std::__libcpp_allocate(_BufferSize* sizeof(byte), _LIBCPP_ALIGNOF(byte)));
+      return static_cast<_Stored*>(std::__libcpp_allocate(_BufferSize * sizeof(byte), _LIBCPP_ALIGNOF(byte)));
 #  endif // _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
     }
   }

--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -61,26 +61,30 @@ public:
       return *std::launder(reinterpret_cast<_Stored**>(__buffer_));
   }
 
-#  ifdef _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI _Stored* __alloc() {
     if constexpr (__fits_in_buffer<_Stored>) {
       return std::launder(reinterpret_cast<_Stored*>(__buffer_));
     } else {
+#  ifdef _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
       byte* __allocation = static_cast<byte*>(::operator new[](sizeof(_Stored), align_val_t{alignof(_Stored)}));
       std::construct_at(reinterpret_cast<byte**>(__buffer_), __allocation);
       return std::launder(reinterpret_cast<_Stored*>(__allocation));
+#  else
+      return static_cast<_Stored*>(std::__libcpp_allocate(_BufferSize* sizeof(byte), _LIBCPP_ALIGNOF(byte)));
+#  endif // _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
     }
   }
 
-#  endif // _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
-#  ifdef _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI void __dealloc() noexcept {
     if constexpr (!__fits_in_buffer<_Stored>)
+#  ifdef _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
       ::operator delete[](*reinterpret_cast<void**>(__buffer_), sizeof(_Stored), align_val_t{alignof(_Stored)});
-  }
+#  else
+      std::__libcpp_deallocate((void*)__buffer_, _BufferSize * sizeof(byte), _LIBCPP_ALIGNOF(_Stored));
 #  endif // _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
+  }
 
   template <class _Stored, class... _Args>
   _LIBCPP_HIDE_FROM_ABI void __construct(_Args&&... __args) {


### PR DESCRIPTION
We need to guard 2 functions to avoid errors when `small_buffer.h` is included in the modules LIT tests. For example:

```
test-suite-install/include/c++/v1/__utility/small_buffer.h:69:81: error: use of undeclared identifier 'align_val_t'
# |    69 |       byte* __allocation = static_cast<byte*>(::operator new[](sizeof(_Stored), align_val_t{alignof(_Stored)}));
# |       |                                                                                 ^
```