### PR TITLE
[libclang/python/tests] Remove unused variables

### DIFF
--- a/clang/bindings/python/tests/cindex/test_cdb.py
+++ b/clang/bindings/python/tests/cindex/test_cdb.py
@@ -31,7 +31,7 @@ class TestCDB(unittest.TestCase):
         with open(os.devnull, "wb") as null:
             os.dup2(null.fileno(), 2)
         with self.assertRaises(CompilationDatabaseError) as cm:
-            cdb = CompilationDatabase.fromDirectory(path)
+            CompilationDatabase.fromDirectory(path)
         os.dup2(stderr, 2)
         os.close(stderr)
 
@@ -40,7 +40,7 @@ class TestCDB(unittest.TestCase):
 
     def test_create(self):
         """Check we can load a compilation database"""
-        cdb = CompilationDatabase.fromDirectory(kInputsDir)
+        CompilationDatabase.fromDirectory(kInputsDir)
 
     def test_lookup_succeed(self):
         """Check we get some results if the file exists in the db"""
@@ -175,7 +175,7 @@ class TestCDB(unittest.TestCase):
         cmds = cdb.getCompileCommands("/home/john.doe/MyProject/project.cpp")
         del cdb
         gc.collect()
-        workingdir = cmds[0].directory
+        cmds[0].directory
 
     def test_compilationCommands_references(self):
         """Ensure CompilationsCommand keeps a reference to CompilationCommands"""
@@ -185,4 +185,4 @@ class TestCDB(unittest.TestCase):
         cmd0 = cmds[0]
         del cmds
         gc.collect()
-        workingdir = cmd0.directory
+        cmd0.directory

--- a/clang/bindings/python/tests/cindex/test_cursor.py
+++ b/clang/bindings/python/tests/cindex/test_cursor.py
@@ -170,7 +170,7 @@ class TestCursor(unittest.TestCase):
         self.assertIsInstance(cursor.translation_unit, TranslationUnit)
 
         # If the TU was destroyed, this should cause a segfault.
-        parent = cursor.semantic_parent
+        cursor.semantic_parent
 
     def test_canonical(self):
         source = "struct X; struct X; struct X { int member; };"

--- a/clang/bindings/python/tests/cindex/test_index.py
+++ b/clang/bindings/python/tests/cindex/test_index.py
@@ -14,7 +14,7 @@ kInputsDir = os.path.join(os.path.dirname(__file__), "INPUTS")
 
 class TestIndex(unittest.TestCase):
     def test_create(self):
-        index = Index.create()
+        Index.create()
 
     # FIXME: test Index.read
 

--- a/clang/bindings/python/tests/cindex/test_type.py
+++ b/clang/bindings/python/tests/cindex/test_type.py
@@ -138,7 +138,7 @@ class TestType(unittest.TestCase):
         self.assertIsInstance(t.translation_unit, TranslationUnit)
 
         # If the TU was destroyed, this should cause a segfault.
-        decl = t.get_declaration()
+        t.get_declaration()
 
     def testConstantArray(self):
         tu = get_tu(constarrayInput)
@@ -459,8 +459,8 @@ class A
             (["-target", "i386-pc-win32"], (8, 16, 0, 32, 64, 96)),
             (["-target", "msp430-none-none"], (2, 14, 0, 32, 64, 96)),
         ]
-        for flags, values in tries:
-            align, total, f1, bariton, foo, bar = values
+        for _, values in tries:
+            _, _, f1, bariton, foo, bar = values
             tu = get_tu(source)
             teststruct = get_cursor(tu, "Test")
             children = list(teststruct.get_children())


### PR DESCRIPTION
Remove all occurrences of unused varialbes in the python bindings tests.
Use `_` to ignore unused values in tuple unpacking expressions.