### PR TITLE
[libclang/python/tests] Remove Python <3.6 workarounds

### DIFF
--- a/clang/bindings/python/tests/cindex/test_cdb.py
+++ b/clang/bindings/python/tests/cindex/test_cdb.py
@@ -12,9 +12,7 @@ import os
 import gc
 import unittest
 import sys
-from .util import skip_if_no_fspath
-from .util import str_to_path
-
+from pathlib import Path
 
 kInputsDir = os.path.join(os.path.dirname(__file__), "INPUTS")
 
@@ -48,13 +46,10 @@ class TestCDB(unittest.TestCase):
         cmds = cdb.getCompileCommands("/home/john.doe/MyProject/project.cpp")
         self.assertNotEqual(len(cmds), 0)
 
-    @skip_if_no_fspath
     def test_lookup_succeed_pathlike(self):
         """Same as test_lookup_succeed, but with PathLikes"""
-        cdb = CompilationDatabase.fromDirectory(str_to_path(kInputsDir))
-        cmds = cdb.getCompileCommands(
-            str_to_path("/home/john.doe/MyProject/project.cpp")
-        )
+        cdb = CompilationDatabase.fromDirectory(Path(kInputsDir))
+        cmds = cdb.getCompileCommands(Path("/home/john.doe/MyProject/project.cpp"))
         self.assertNotEqual(len(cmds), 0)
 
     def test_all_compilecommand(self):

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -7,8 +7,7 @@ if "CLANG_LIBRARY_PATH" in os.environ:
 from clang.cindex import TranslationUnit
 
 import unittest
-from .util import skip_if_no_fspath
-from .util import str_to_path
+from pathlib import Path
 
 
 class TestCodeCompletion(unittest.TestCase):
@@ -57,11 +56,10 @@ void f() {
         ]
         self.check_completion_results(cr, expected)
 
-    @skip_if_no_fspath
     def test_code_complete_pathlike(self):
         files = [
             (
-                str_to_path("fake.c"),
+                Path("fake.c"),
                 """
 /// Aaa.
 int test1;
@@ -77,14 +75,14 @@ void f() {
         ]
 
         tu = TranslationUnit.from_source(
-            str_to_path("fake.c"),
+            Path("fake.c"),
             ["-std=c99"],
             unsaved_files=files,
             options=TranslationUnit.PARSE_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION,
         )
 
         cr = tu.codeComplete(
-            str_to_path("fake.c"),
+            Path("fake.c"),
             9,
             1,
             unsaved_files=files,

--- a/clang/bindings/python/tests/cindex/test_translation_unit.py
+++ b/clang/bindings/python/tests/cindex/test_translation_unit.py
@@ -7,9 +7,9 @@ if "CLANG_LIBRARY_PATH" in os.environ:
 from contextlib import contextmanager
 import gc
 import os
-import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 from clang.cindex import CursorKind
 from clang.cindex import Cursor
@@ -22,8 +22,6 @@ from clang.cindex import TranslationUnitLoadError
 from clang.cindex import TranslationUnit
 from .util import get_cursor
 from .util import get_tu
-from .util import skip_if_no_fspath
-from .util import str_to_path
 
 
 kInputsDir = os.path.join(os.path.dirname(__file__), "INPUTS")
@@ -47,7 +45,7 @@ def save_tu_pathlike(tu):
     Returns the filename it was saved to.
     """
     with tempfile.NamedTemporaryFile() as t:
-        tu.save(str_to_path(t.name))
+        tu.save(Path(t.name))
         yield t.name
 
 
@@ -105,24 +103,21 @@ int SOME_DEFINE;
         self.assertEqual(spellings[-1], "y")
 
     def test_unsaved_files_2(self):
-        if sys.version_info.major >= 3:
-            from io import StringIO
-        else:
-            from io import BytesIO as StringIO
+        from io import StringIO
+
         tu = TranslationUnit.from_source(
             "fake.c", unsaved_files=[("fake.c", StringIO("int x;"))]
         )
         spellings = [c.spelling for c in tu.cursor.get_children()]
         self.assertEqual(spellings[-1], "x")
 
-    @skip_if_no_fspath
     def test_from_source_accepts_pathlike(self):
         tu = TranslationUnit.from_source(
-            str_to_path("fake.c"),
+            Path("fake.c"),
             ["-Iincludes"],
             unsaved_files=[
                 (
-                    str_to_path("fake.c"),
+                    Path("fake.c"),
                     """
 #include "fake.h"
     int x;
@@ -130,7 +125,7 @@ int SOME_DEFINE;
     """,
                 ),
                 (
-                    str_to_path("includes/fake.h"),
+                    Path("includes/fake.h"),
                     """
 #define SOME_DEFINE y
     """,
@@ -192,7 +187,6 @@ int SOME_DEFINE;
             self.assertTrue(os.path.exists(path))
             self.assertGreater(os.path.getsize(path), 0)
 
-    @skip_if_no_fspath
     def test_save_pathlike(self):
         """Ensure TranslationUnit.save() works with PathLike filename."""
 
@@ -234,14 +228,13 @@ int SOME_DEFINE;
             # Just in case there is an open file descriptor somewhere.
             del tu2
 
-    @skip_if_no_fspath
     def test_load_pathlike(self):
         """Ensure TranslationUnits can be constructed from saved files -
         PathLike variant."""
         tu = get_tu("int foo();")
         self.assertEqual(len(tu.diagnostics), 0)
         with save_tu(tu) as path:
-            tu2 = TranslationUnit.from_ast_file(filename=str_to_path(path))
+            tu2 = TranslationUnit.from_ast_file(filename=Path(path))
             self.assertEqual(len(tu2.diagnostics), 0)
 
             foo = get_cursor(tu2, "foo")
@@ -268,18 +261,17 @@ int SOME_DEFINE;
         with self.assertRaises(Exception):
             f = tu.get_file("foobar.cpp")
 
-    @skip_if_no_fspath
     def test_get_file_pathlike(self):
         """Ensure tu.get_file() works appropriately with PathLike filenames."""
 
         tu = get_tu("int foo();")
 
-        f = tu.get_file(str_to_path("t.c"))
+        f = tu.get_file(Path("t.c"))
         self.assertIsInstance(f, File)
         self.assertEqual(f.name, "t.c")
 
         with self.assertRaises(Exception):
-            f = tu.get_file(str_to_path("foobar.cpp"))
+            f = tu.get_file(Path("foobar.cpp"))
 
     def test_get_source_location(self):
         """Ensure tu.get_source_location() works."""

--- a/clang/bindings/python/tests/cindex/util.py
+++ b/clang/bindings/python/tests/cindex/util.py
@@ -1,16 +1,5 @@
 # This file provides common utility functions for the test suite.
 
-import os
-
-HAS_FSPATH = hasattr(os, "fspath")
-
-if HAS_FSPATH:
-    from pathlib import Path as str_to_path
-else:
-    str_to_path = None
-
-import unittest
-
 from clang.cindex import Cursor
 from clang.cindex import TranslationUnit
 
@@ -81,14 +70,8 @@ def get_cursors(source, spelling):
     return cursors
 
 
-skip_if_no_fspath = unittest.skipUnless(
-    HAS_FSPATH, "Requires file system path protocol / Python 3.6+"
-)
-
 __all__ = [
     "get_cursor",
     "get_cursors",
     "get_tu",
-    "skip_if_no_fspath",
-    "str_to_path",
 ]


### PR DESCRIPTION
This removes workarounds for Python versions before 3.6, since our minimum Python version has been bumped to 3.8