### PR TITLE
[libclang/python/tests] Clean up imports

### DIFF
--- a/clang/bindings/python/tests/cindex/test_access_specifiers.py
+++ b/clang/bindings/python/tests/cindex/test_access_specifiers.py
@@ -1,17 +1,13 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import AccessSpecifier, Config
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import AccessSpecifier
-from clang.cindex import Cursor
-from clang.cindex import TranslationUnit
-
-from .util import get_cursor
-from .util import get_tu
-
 import unittest
+
+from .util import get_cursor, get_tu
 
 
 class TestAccessSpecifiers(unittest.TestCase):

--- a/clang/bindings/python/tests/cindex/test_cdb.py
+++ b/clang/bindings/python/tests/cindex/test_cdb.py
@@ -1,14 +1,10 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import CompilationDatabase, CompilationDatabaseError, Config
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import CompilationDatabase
-from clang.cindex import CompilationDatabaseError
-from clang.cindex import CompileCommands
-from clang.cindex import CompileCommand
-import os
 import gc
 import unittest
 import sys

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -1,10 +1,9 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, TranslationUnit
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
-
-from clang.cindex import TranslationUnit
 
 import unittest
 from pathlib import Path

--- a/clang/bindings/python/tests/cindex/test_comment.py
+++ b/clang/bindings/python/tests/cindex/test_comment.py
@@ -1,13 +1,13 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, TranslationUnit
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import TranslationUnit
-from tests.cindex.util import get_cursor
-
 import unittest
+
+from .util import get_cursor
 
 
 class TestComment(unittest.TestCase):

--- a/clang/bindings/python/tests/cindex/test_cursor.py
+++ b/clang/bindings/python/tests/cindex/test_cursor.py
@@ -1,24 +1,23 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import (
+    AvailabilityKind,
+    BinaryOperator,
+    Config,
+    CursorKind,
+    StorageClass,
+    TemplateArgumentKind,
+    TranslationUnit,
+    TypeKind,
+)
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-import ctypes
 import gc
 import unittest
 
-from clang.cindex import AvailabilityKind
-from clang.cindex import CursorKind
-from clang.cindex import TemplateArgumentKind
-from clang.cindex import TranslationUnit
-from clang.cindex import TypeKind
-from clang.cindex import BinaryOperator
-from clang.cindex import StorageClass
-from .util import get_cursor
-from .util import get_cursors
-from .util import get_tu
-
+from .util import get_cursor, get_cursors, get_tu
 
 kInput = """\
 struct s0 {

--- a/clang/bindings/python/tests/cindex/test_cursor_kind.py
+++ b/clang/bindings/python/tests/cindex/test_cursor_kind.py
@@ -1,10 +1,9 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, CursorKind
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
-
-from clang.cindex import CursorKind
 
 import unittest
 

--- a/clang/bindings/python/tests/cindex/test_diagnostics.py
+++ b/clang/bindings/python/tests/cindex/test_diagnostics.py
@@ -1,14 +1,13 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, Diagnostic
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import *
-from .util import get_tu
-
 import unittest
 
+from .util import get_tu
 
 # FIXME: We need support for invalid translation units to test better.
 

--- a/clang/bindings/python/tests/cindex/test_enums.py
+++ b/clang/bindings/python/tests/cindex/test_enums.py
@@ -1,18 +1,18 @@
 import unittest
 
 from clang.cindex import (
-    TokenKind,
-    CursorKind,
-    TemplateArgumentKind,
-    ExceptionSpecificationKind,
-    AvailabilityKind,
     AccessSpecifier,
-    TypeKind,
-    RefQualifierKind,
-    LinkageKind,
-    TLSKind,
-    StorageClass,
+    AvailabilityKind,
     BinaryOperator,
+    CursorKind,
+    ExceptionSpecificationKind,
+    LinkageKind,
+    RefQualifierKind,
+    StorageClass,
+    TemplateArgumentKind,
+    TLSKind,
+    TokenKind,
+    TypeKind,
 )
 
 

--- a/clang/bindings/python/tests/cindex/test_exception_specification_kind.py
+++ b/clang/bindings/python/tests/cindex/test_exception_specification_kind.py
@@ -1,18 +1,17 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, CursorKind, ExceptionSpecificationKind
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-import clang.cindex
-from clang.cindex import ExceptionSpecificationKind
-from .util import get_tu
-
 import unittest
+
+from .util import get_tu
 
 
 def find_function_declarations(node, declarations=[]):
-    if node.kind == clang.cindex.CursorKind.FUNCTION_DECL:
+    if node.kind == CursorKind.FUNCTION_DECL:
         declarations.append(node)
     for child in node.get_children():
         declarations = find_function_declarations(child, declarations)

--- a/clang/bindings/python/tests/cindex/test_file.py
+++ b/clang/bindings/python/tests/cindex/test_file.py
@@ -1,10 +1,9 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, File, Index
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
-
-from clang.cindex import Index, File
 
 import unittest
 

--- a/clang/bindings/python/tests/cindex/test_index.py
+++ b/clang/bindings/python/tests/cindex/test_index.py
@@ -1,13 +1,11 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, Index, TranslationUnit
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import *
-import os
 import unittest
-
 
 kInputsDir = os.path.join(os.path.dirname(__file__), "INPUTS")
 

--- a/clang/bindings/python/tests/cindex/test_linkage.py
+++ b/clang/bindings/python/tests/cindex/test_linkage.py
@@ -1,17 +1,13 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, LinkageKind
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import LinkageKind
-from clang.cindex import Cursor
-from clang.cindex import TranslationUnit
-
-from .util import get_cursor
-from .util import get_tu
-
 import unittest
+
+from .util import get_cursor, get_tu
 
 
 class TestLinkage(unittest.TestCase):

--- a/clang/bindings/python/tests/cindex/test_location.py
+++ b/clang/bindings/python/tests/cindex/test_location.py
@@ -1,19 +1,20 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import (
+    Config,
+    Cursor,
+    File,
+    SourceLocation,
+    SourceRange,
+    TranslationUnit,
+)
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import Cursor
-from clang.cindex import File
-from clang.cindex import SourceLocation
-from clang.cindex import SourceRange
-from clang.cindex import TranslationUnit
-from .util import get_cursor
-from .util import get_tu
-
 import unittest
 
+from .util import get_cursor, get_tu
 
 baseInput = "int one;\nint two;\n"
 

--- a/clang/bindings/python/tests/cindex/test_rewrite.py
+++ b/clang/bindings/python/tests/cindex/test_rewrite.py
@@ -1,13 +1,7 @@
-import unittest
 import tempfile
+import unittest
 
-from clang.cindex import (
-    Rewriter,
-    TranslationUnit,
-    File,
-    SourceLocation,
-    SourceRange,
-)
+from clang.cindex import File, Rewriter, SourceLocation, SourceRange, TranslationUnit
 
 
 class TestRewrite(unittest.TestCase):

--- a/clang/bindings/python/tests/cindex/test_source_range.py
+++ b/clang/bindings/python/tests/cindex/test_source_range.py
@@ -1,11 +1,11 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, SourceLocation, SourceRange, TranslationUnit
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
 import unittest
-from clang.cindex import SourceLocation, SourceRange, TranslationUnit
 
 from .util import get_tu
 

--- a/clang/bindings/python/tests/cindex/test_tls_kind.py
+++ b/clang/bindings/python/tests/cindex/test_tls_kind.py
@@ -1,17 +1,13 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, TLSKind
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import TLSKind
-from clang.cindex import Cursor
-from clang.cindex import TranslationUnit
-
-from .util import get_cursor
-from .util import get_tu
-
 import unittest
+
+from .util import get_cursor, get_tu
 
 
 class TestTLSKind(unittest.TestCase):

--- a/clang/bindings/python/tests/cindex/test_token_kind.py
+++ b/clang/bindings/python/tests/cindex/test_token_kind.py
@@ -1,10 +1,9 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, TokenKind
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
-
-from clang.cindex import TokenKind
 
 import unittest
 

--- a/clang/bindings/python/tests/cindex/test_tokens.py
+++ b/clang/bindings/python/tests/cindex/test_tokens.py
@@ -1,18 +1,13 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, CursorKind, SourceLocation, SourceRange, TokenKind
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from clang.cindex import CursorKind
-from clang.cindex import Index
-from clang.cindex import SourceLocation
-from clang.cindex import SourceRange
-from clang.cindex import TokenKind
+import unittest
 
 from .util import get_tu
-
-import unittest
 
 
 class TestTokens(unittest.TestCase):

--- a/clang/bindings/python/tests/cindex/test_translation_unit.py
+++ b/clang/bindings/python/tests/cindex/test_translation_unit.py
@@ -1,28 +1,28 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import (
+    Config,
+    Cursor,
+    CursorKind,
+    File,
+    Index,
+    SourceLocation,
+    SourceRange,
+    TranslationUnit,
+    TranslationUnitLoadError,
+    TranslationUnitSaveError,
+)
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
 
-from contextlib import contextmanager
 import gc
-import os
 import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 
-from clang.cindex import CursorKind
-from clang.cindex import Cursor
-from clang.cindex import File
-from clang.cindex import Index
-from clang.cindex import SourceLocation
-from clang.cindex import SourceRange
-from clang.cindex import TranslationUnitSaveError
-from clang.cindex import TranslationUnitLoadError
-from clang.cindex import TranslationUnit
-from .util import get_cursor
-from .util import get_tu
-
+from .util import get_cursor, get_tu
 
 kInputsDir = os.path.join(os.path.dirname(__file__), "INPUTS")
 

--- a/clang/bindings/python/tests/cindex/test_type.py
+++ b/clang/bindings/python/tests/cindex/test_type.py
@@ -1,5 +1,6 @@
 import os
-from clang.cindex import Config
+
+from clang.cindex import Config, CursorKind, RefQualifierKind, TranslationUnit, TypeKind
 
 if "CLANG_LIBRARY_PATH" in os.environ:
     Config.set_library_path(os.environ["CLANG_LIBRARY_PATH"])
@@ -7,14 +8,7 @@ if "CLANG_LIBRARY_PATH" in os.environ:
 import gc
 import unittest
 
-from clang.cindex import CursorKind
-from clang.cindex import TranslationUnit
-from clang.cindex import TypeKind
-from clang.cindex import RefQualifierKind
-from .util import get_cursor
-from .util import get_cursors
-from .util import get_tu
-
+from .util import get_cursor, get_cursors, get_tu
 
 kInput = """\
 

--- a/clang/bindings/python/tests/cindex/util.py
+++ b/clang/bindings/python/tests/cindex/util.py
@@ -1,7 +1,6 @@
 # This file provides common utility functions for the test suite.
 
-from clang.cindex import Cursor
-from clang.cindex import TranslationUnit
+from clang.cindex import Cursor, TranslationUnit
 
 
 def get_tu(source, lang="c", all_warnings=False, flags=[]):


### PR DESCRIPTION
Sort imports using `isort`.
Remove unused imports.
Collect multiple imports from the same module into a single import statement.
Unify import style.