### PR TITLE
[libcxx] Update picolibc version and remove xfails due to picolibc's support for char16_t and char32_t

### DIFF
--- a/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp
@@ -11,9 +11,6 @@
 // Apple platforms don't provide <uchar.h> yet, so these tests fail.
 // XFAIL: target={{.+}}-apple-{{.+}}
 
-// mbrtoc16 not defined.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // <uchar.h>
 
 #include <uchar.h>

--- a/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp
+++ b/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp
@@ -11,9 +11,6 @@
 // Apple platforms don't provide <uchar.h> yet, so these tests fail.
 // XFAIL: target={{.+}}-apple-{{.+}}
 
-// mbrtoc16 not defined.
-// XFAIL: LIBCXX-PICOLIBC-FIXME
-
 // <cuchar>
 
 #include <cuchar>

--- a/libcxx/utils/ci/build-picolibc.sh
+++ b/libcxx/utils/ci/build-picolibc.sh
@@ -70,7 +70,7 @@ picolibc_build_dir="${build_dir}/picolibc-build"
 mkdir -p "${picolibc_source_dir}"
 mkdir -p "${picolibc_build_dir}"
 # Download a known good version of picolibc.
-picolibc_commit="48fbc2009c6473293d03d5ec6f190565c6223a5c"
+picolibc_commit="db4d0fe5952d5ecd714781e3212d4086d970735a"
 curl -L "https://github.com/picolibc/picolibc/archive/${picolibc_commit}.zip" --output "${picolibc_source_dir}/picolibc.zip"
 unzip -q "${picolibc_source_dir}/picolibc.zip" -d "${picolibc_source_dir}"
 mv "${picolibc_source_dir}/picolibc-${picolibc_commit}"/* "${picolibc_source_dir}"


### PR DESCRIPTION
picolibc recently
([link](https://github.com/picolibc/picolibc/commit/f6f68758fe2aa62854f49b90c3daeeb08242b512)) added support for char16_t and char32_t.

These xfails aren't needed anymore.

The picolibc version has been updates to v1.8.9, a version that includes the fix linked above.