### PR TITLE
[SPIR-V] Fix OpDecorate emission after vreg def.

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -990,13 +990,13 @@ bool SPIRVInstructionSelector::selectMemOperation(Register ResVReg,
     Register VarReg = MRI->createGenericVirtualRegister(LLT::scalar(64));
     GR.add(GV, GR.CurMF, VarReg);
 
-    buildOpDecorate(VarReg, I, TII, SPIRV::Decoration::Constant, {});
     BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpVariable))
         .addDef(VarReg)
         .addUse(GR.getSPIRVTypeID(VarTy))
         .addImm(SPIRV::StorageClass::UniformConstant)
         .addUse(Const)
         .constrainAllUses(TII, TRI, RBI);
+    buildOpDecorate(VarReg, I, TII, SPIRV::Decoration::Constant, {});
     SPIRVType *SourceTy = GR.getOrCreateSPIRVPointerType(
         ValTy, I, TII, SPIRV::StorageClass::UniformConstant);
     SrcReg = MRI->createGenericVirtualRegister(LLT::scalar(64));

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -829,7 +829,7 @@ static void insertSpirvDecorations(MachineFunction &MF, MachineIRBuilder MIB) {
     for (MachineInstr &MI : MBB) {
       if (!isSpvIntrinsic(MI, Intrinsic::spv_assign_decoration))
         continue;
-      MIB.setInsertPt(*MI.getParent(), MI);
+      MIB.setInsertPt(*MI.getParent(), MI.getNextNode());
       buildOpSpirvDecorations(MI.getOperand(1).getReg(), MIB,
                               MI.getOperand(2).getMetadata());
       ToErase.push_back(&MI);

--- a/llvm/test/CodeGen/SPIRV/decoration-order.ll
+++ b/llvm/test/CodeGen/SPIRV/decoration-order.ll
@@ -2,7 +2,7 @@
 ; This test checks the OpDecorate MIR is generated after the associated
 ; vreg definition in the case of an array size declared through this lowering.
 
-define spir_func i32 @foo(ptr addrspace(4) %Buf, ptr addrspace(4) %Item) {
+define spir_func i32 @foo() {
 entry:
   %var = alloca i64
   br label %block

--- a/llvm/test/CodeGen/SPIRV/decoration-order.ll
+++ b/llvm/test/CodeGen/SPIRV/decoration-order.ll
@@ -1,0 +1,15 @@
+; RUN: %if spirv-tools %{ llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; This test checks the OpDecorate MIR is generated after the associated
+; vreg definition in the case of an array size declared through this lowering.
+
+define spir_func i32 @foo(ptr addrspace(4) %Buf, ptr addrspace(4) %Item) {
+entry:
+  %var = alloca i64
+  br label %block
+
+block:
+  call void @llvm.memset.p0.i64(ptr align 8 %var, i8 0, i64 24, i1 false)
+  ret i32 0
+}
+
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly, i8, i64, i1 immarg)


### PR DESCRIPTION
In SPIR-V, OpDecorate instructions are allowed to forward-declare a virtual register. But while we are at the MIR level, we must comply with stricter rules, meaning OpDecorate should be emited after, not before the reg definition.
(In some cases, we defined those just before, switching to just after).

Related to #110652