### PR TITLE
[AArch64] make REVD non-MOVPRFXable

### DIFF
--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -1429,8 +1429,6 @@ class sve2_int_perm_revd<string asm>
   let Inst{4-0}   = Zd;
 
   let Constraints = "$Zd = $_Zd";
-  let DestructiveInstType = DestructiveUnary;
-  let ElementSize = ZPR128.ElementSize;
 }
 
 multiclass sve2_int_perm_revd<string asm, SDPatternOperator op> {

--- a/llvm/test/MC/AArch64/SME/revd-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME/revd-diagnostics.s
@@ -27,3 +27,12 @@ revd z0.q, p0/m, z0.s
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
 // CHECK-NEXT: revd z0.q, p0/m, z0.s
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// --------------------------------------------------------------------------//
+// Negative tests for instructions that are incompatible with movprfx
+
+movprfx z21, z25
+revd    z21.q, p5/m, z10.q
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: instruction is unpredictable when following a movprfx, suggest replacing movprfx with mov
+// CHECK-NEXT: revd    z21.q, p5/m, z10.q
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SME/revd.s
+++ b/llvm/test/MC/AArch64/SME/revd.s
@@ -35,18 +35,3 @@ revd    z31.q, p7/m, z31.q
 // CHECK-ENCODING: [0xff,0x9f,0x2e,0x05]
 // CHECK-ERROR: instruction requires: sme
 // CHECK-UNKNOWN: 052e9fff <unknown>
-
-// --------------------------------------------------------------------------//
-// Test compatibility with MOVPRFX instruction.
-
-movprfx z21, z25
-// CHECK-INST: movprfx  z21, z25
-// CHECK-ENCODING: [0x35,0xbf,0x20,0x04]
-// CHECK-ERROR: instruction requires: sve or sme
-// CHECK-UNKNOWN: 0420bf35 <unknown>
-
-revd    z21.q, p5/m, z10.q
-// CHECK-INST: revd    z21.q, p5/m, z10.q
-// CHECK-ENCODING: [0x55,0x95,0x2e,0x05]
-// CHECK-ERROR: instruction requires: sme
-// CHECK-UNKNOWN: 052e9555 <unknown>


### PR DESCRIPTION
This patch updates REVD instruction and makes it non-MOVPRFXable as per https://developer.arm.com/documentation/ddi0602/2024-06/SVE-Instructions/REVD--Reverse-64-bit-doublewords-in-elements--predicated--?lang=en