### PR TITLE
Revert "[Bazel] Fix for  1bc58a258e2edb6221009a26d0f0037eda6c7c47"

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -8954,7 +8954,7 @@ cc_library(
             "include/mlir/Analysis/*.h",
             "include/mlir/Analysis/*/*.h",
         ],
-    ) + ["include/mlir/Transforms/RegionUtils.h"],
+    ),
     copts = [
         "$(STACK_FRAME_UNLIMITED)",
     ],


### PR DESCRIPTION
This reverts commit 5ce8a93ebb7688c66bd08fa27d2e04bca33b6763.

Commit 1bc58a258e2edb6221009a26d0f0037eda6c7c47 was reverted in a9a8351ef181610559687679a40efe24649f9600, so the bazel fix is no longer needed.