### PR TITLE
[libc] Remove FE_ALL_EXCEPT check in hdr/fenv_macros.h.

### DIFF
--- a/libc/hdr/fenv_macros.h
+++ b/libc/hdr/fenv_macros.h
@@ -19,7 +19,6 @@
 
 // In some environment, FE_ALL_EXCEPT is set to 0 and the remaining exceptions
 // FE_* are missing.
-#if (FE_ALL_EXCEPT == 0)
 #ifndef FE_DIVBYZERO
 #define FE_DIVBYZERO 0
 #endif // FE_DIVBYZERO
@@ -39,12 +38,6 @@
 #ifndef FE_UNDERFLOW
 #define FE_UNDERFLOW 0
 #endif // FE_UNDERFLOW
-#else
-// If this is not provided by the system, define it for use internally.
-#ifndef __FE_DENORM
-#define __FE_DENORM (1 << 6)
-#endif
-#endif
 
 // Rounding mode macros might be missing.
 #ifndef FE_DOWNWARD

--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -297,31 +297,35 @@ private:
 #define EXPECT_FP_EXCEPTION(expected)                                          \
   do {                                                                         \
     if (math_errhandling & MATH_ERREXCEPT) {                                   \
-      EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) &           \
-                    ((expected) ? (expected) : FE_ALL_EXCEPT),                 \
-                (expected));                                                   \
+      EXPECT_EQ(                                                               \
+          LIBC_NAMESPACE::fputil::test_except(                                 \
+              static_cast<int>(FE_ALL_EXCEPT)) &                               \
+              ((expected) ? (expected) : static_cast<int>(FE_ALL_EXCEPT)),     \
+          (expected));                                                         \
     }                                                                          \
   } while (0)
 
 #define ASSERT_FP_EXCEPTION(expected)                                          \
   do {                                                                         \
     if (math_errhandling & MATH_ERREXCEPT) {                                   \
-      ASSERT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) &           \
-                    ((expected) ? (expected) : FE_ALL_EXCEPT),                 \
-                (expected));                                                   \
+      ASSERT_EQ(                                                               \
+          LIBC_NAMESPACE::fputil::test_except(                                 \
+              static_cast<int>(FE_ALL_EXCEPT)) &                               \
+              ((expected) ? (expected) : static_cast<int>(FE_ALL_EXCEPT)),     \
+          (expected));                                                         \
     }                                                                          \
   } while (0)
 
 #define EXPECT_FP_EQ_WITH_EXCEPTION(expected_val, actual_val, expected_except) \
   do {                                                                         \
-    LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                       \
+    LIBC_NAMESPACE::fputil::clear_except(static_cast<int>(FE_ALL_EXCEPT));     \
     EXPECT_FP_EQ(expected_val, actual_val);                                    \
     EXPECT_FP_EXCEPTION(expected_except);                                      \
   } while (0)
 
 #define EXPECT_FP_IS_NAN_WITH_EXCEPTION(actual_val, expected_except)           \
   do {                                                                         \
-    LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                       \
+    LIBC_NAMESPACE::fputil::clear_except(static_cast<int>(FE_ALL_EXCEPT));     \
     EXPECT_FP_IS_NAN(actual_val);                                              \
     EXPECT_FP_EXCEPTION(expected_except);                                      \
   } while (0)
@@ -374,7 +378,7 @@ private:
     using namespace LIBC_NAMESPACE::fputil::testing;                           \
     ForceRoundingMode __r((rounding_mode));                                    \
     if (__r.success) {                                                         \
-      LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                     \
+      LIBC_NAMESPACE::fputil::clear_except(static_cast<int>(FE_ALL_EXCEPT));   \
       EXPECT_FP_EQ((expected), (actual));                                      \
       EXPECT_FP_EXCEPTION(expected_except);                                    \
     }                                                                          \


### PR DESCRIPTION
FE_ALL_EXCEPT macro might not be a valid preprocessor constant expression in some environment.
Moreover, FE_ALL_EXCEPT might not be defined as int.