### PR TITLE
[lldb] Set LLDB_USE_NATIVE_PDB_READER at the directory level

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/ast-functions-msvc.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/ast-functions-msvc.cpp
@@ -3,5 +3,5 @@
 
 // RUN: %build --compiler=msvc --nodefaultlib -o %t.exe -- %S/ast-functions.cpp
 
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/ast-functions.lldbinit 2>&1 | FileCheck %S/ast-functions.cpp

--- a/lldb/test/Shell/SymbolFile/NativePDB/ast-functions.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/ast-functions.cpp
@@ -4,8 +4,7 @@
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
 
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
-// RUN:     %p/Inputs/ast-functions.lldbinit 2>&1 | FileCheck %s
+// RUN: %lldb -f %t.exe -s %p/Inputs/ast-functions.lldbinit 2>&1 | FileCheck %s
 
 static int static_fn() {
   return 42;

--- a/lldb/test/Shell/SymbolFile/NativePDB/ast-methods.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/ast-methods.cpp
@@ -3,10 +3,10 @@
 
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -GR- -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/ast-methods.lldbinit 2>&1 | FileCheck %s --check-prefix=AST
 
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols --dump-ast %t.exe | FileCheck %s --check-prefix=SYMBOL
+// RUN: lldb-test symbols --dump-ast %t.exe | FileCheck %s --check-prefix=SYMBOL
 
 struct Struct {
   void simple_method() {}

--- a/lldb/test/Shell/SymbolFile/NativePDB/ast-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/ast-types.cpp
@@ -4,7 +4,7 @@
 // Test various interesting cases for AST reconstruction.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/ast-types.lldbinit 2>&1 | FileCheck %s
 
 // Test trivial versions of each tag type.

--- a/lldb/test/Shell/SymbolFile/NativePDB/bitfields.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/bitfields.cpp
@@ -4,7 +4,7 @@
 // Test various interesting cases for AST reconstruction.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/bitfields.lldbinit 2>&1 | FileCheck %s
 
 // Test trivial versions of each tag type.

--- a/lldb/test/Shell/SymbolFile/NativePDB/blocks.s
+++ b/lldb/test/Shell/SymbolFile/NativePDB/blocks.s
@@ -4,7 +4,7 @@
 // Test block range is set.
 // RUN: llvm-mc -triple=x86_64-windows-msvc --filetype=obj %s > %t.obj
 // RUN: lld-link /debug:full /nodefaultlib /entry:main %t.obj /out:%t.exe /base:0x140000000
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb %t.exe -o "image lookup -a 0x140001014 -v" -o "exit" | FileCheck %s
+// RUN: %lldb %t.exe -o "image lookup -a 0x140001014 -v" -o "exit" | FileCheck %s
 
 // CHECK:      Function: id = {{.*}}, name = "main", range = [0x0000000140001000-0x0000000140001044)
 // CHECK-NEXT: FuncType: id = {{.*}}, byte-size = 0, compiler_type = "int (void)"

--- a/lldb/test/Shell/SymbolFile/NativePDB/break-by-function.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/break-by-function.cpp
@@ -4,7 +4,7 @@
 // Test that we can set simple breakpoints using PDB on any platform.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/break-by-function.lldbinit | FileCheck %s
 
 // Use different indentation style for each overload so that the starting

--- a/lldb/test/Shell/SymbolFile/NativePDB/break-by-line.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/break-by-line.cpp
@@ -4,7 +4,7 @@
 // Test that we can set simple breakpoints using PDB on any platform.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/break-by-line.lldbinit | FileCheck %s
 
 // This is a separate test from break-by-function.cpp because this test is

--- a/lldb/test/Shell/SymbolFile/NativePDB/class_layout.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/class_layout.cpp
@@ -4,7 +4,7 @@
 // Make sure class layout is correct.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/class_layout.lldbinit 2>&1 | FileCheck %s
 
 // CHECK:      (lldb) expr a

--- a/lldb/test/Shell/SymbolFile/NativePDB/disassembly.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/disassembly.cpp
@@ -4,7 +4,7 @@
 // Test that we can show disassembly and source.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/disassembly.lldbinit | FileCheck %s
 
 // Some context lines before the function.

--- a/lldb/test/Shell/SymbolFile/NativePDB/function-types-builtins.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/function-types-builtins.cpp
@@ -3,7 +3,7 @@
 
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/function-types-builtins.lldbinit | FileCheck %s
 
 // Test that we can display function signatures with simple builtin

--- a/lldb/test/Shell/SymbolFile/NativePDB/function-types-calling-conv.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/function-types-calling-conv.cpp
@@ -3,7 +3,7 @@
 
 // RUN: %clang_cl --target=i386-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/function-types-calling-conv.lldbinit | FileCheck %s
 
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/function-types-classes.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/function-types-classes.cpp
@@ -4,7 +4,7 @@
 // Test that we can display function signatures with class types.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/function-types-classes.lldbinit | FileCheck %s
 
 // This is just some unimportant helpers needed so that we can get reference and

--- a/lldb/test/Shell/SymbolFile/NativePDB/global-classes.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/global-classes.cpp
@@ -5,7 +5,7 @@
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 \
 // RUN:   -Xclang -fkeep-static-consts -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/globals-classes.lldbinit | FileCheck %s
 
 enum class EnumType : unsigned {

--- a/lldb/test/Shell/SymbolFile/NativePDB/global-ctor-dtor.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/global-ctor-dtor.cpp
@@ -4,7 +4,7 @@
 // Global ctor and dtor should be globals decls.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -GS- -fno-addrsig -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb -force
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols --dump-ast %t.exe | FileCheck %s
+// RUN: lldb-test symbols --dump-ast %t.exe | FileCheck %s
 
 struct A {
   ~A() {};

--- a/lldb/test/Shell/SymbolFile/NativePDB/globals-bss.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/globals-bss.cpp
@@ -5,7 +5,7 @@
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
 // RUN: llvm-readobj -S %t.exe | FileCheck --check-prefix=BSS %s
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/globals-bss.lldbinit 2>&1 | FileCheck %s
 
 int GlobalVariable = 0;

--- a/lldb/test/Shell/SymbolFile/NativePDB/globals-fundamental.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/globals-fundamental.cpp
@@ -5,7 +5,7 @@
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 \
 // RUN:   -Xclang -fkeep-static-consts -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/globals-fundamental.lldbinit | FileCheck %s
 
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/icf.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/icf.cpp
@@ -4,7 +4,7 @@
 // Test lldb finds the correct parent context decl for functions and class methods when icf happens.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -GS- -fno-addrsig -c /Fo%t.obj -- %s
 // RUN: lld-link -opt:icf -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols --dump-ast %t.exe | FileCheck %s
+// RUN: lldb-test symbols --dump-ast %t.exe | FileCheck %s
 
 struct A {
   int f1(int x) {

--- a/lldb/test/Shell/SymbolFile/NativePDB/incomplete-tag-type.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/incomplete-tag-type.cpp
@@ -4,7 +4,7 @@
 // RUN: %clang_cl --target=x86_64-windows-msvc -c /Fo%t1.obj -- %p/Inputs/incomplete-tag-type.cpp
 // RUN: %clang_cl --target=x86_64-windows-msvc /O1 /Z7 -c /Fo%t2.obj -- %s
 // RUN: lld-link /debug:full /nodefaultlib /entry:main %t1.obj %t2.obj /out:%t.exe /pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -o \
+// RUN: %lldb -f %t.exe -o \
 // RUN:   "settings set interpreter.stop-command-source-on-error false" \
 // RUN:   -o "expression b" -o "expression d" -o "expression static_e_ref" -o "exit" 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/inline_sites.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/inline_sites.test
@@ -3,7 +3,7 @@
 
 # RUN: llvm-mc -triple=x86_64-windows-msvc --filetype=obj %p/Inputs/inline_sites.s > %t.obj
 # RUN: lld-link -debug:full -nodefaultlib -entry:main -base:0x140000000 %t.obj -out:%t.exe
-# RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+# RUN: %lldb -f %t.exe -s \
 # RUN:     %p/Inputs/inline_sites.lldbinit 2>&1 | FileCheck %s
 
 # CHECK:      (lldb) image dump line-table a.cpp -v

--- a/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: system-windows
 
 // RUN: %build -o %t.exe -- %s
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/inline_sites_live.lldbinit 2>&1 | FileCheck %s
 
 void use(int) {}

--- a/lldb/test/Shell/SymbolFile/NativePDB/lit.local.cfg
+++ b/lldb/test/Shell/SymbolFile/NativePDB/lit.local.cfg
@@ -1,0 +1,1 @@
+config.environment["LLDB_USE_NATIVE_PDB_READER"] = "1"

--- a/lldb/test/Shell/SymbolFile/NativePDB/load-pdb.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/load-pdb.cpp
@@ -10,7 +10,7 @@
 // RUN:     -out:%t/executable/foo.exe -pdb:%t/executable/foo.pdb
 // Rename the PDB file so that the name is different from the name inside the executable (foo.exe).
 // RUN: mv %t/executable/foo.pdb %t/executable/bar.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb %t/executable/foo.exe \
+// RUN: %lldb %t/executable/foo.exe \
 // RUN: -o "target symbols add %t/executable/bar.pdb" \
 // RUN: -o "b main" \
 // RUN: -o "image dump symfile" -o "quit" | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables-registers.s
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables-registers.s
@@ -3,7 +3,7 @@
 
 # RUN: llvm-mc -triple=x86_64-windows-msvc --filetype=obj %s > %t.obj
 # RUN: lld-link /debug:full /nodefaultlib /entry:main %t.obj /out:%t.exe /base:0x140000000
-# RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+# RUN: %lldb -f %t.exe -s \
 # RUN:     %p/Inputs/local-variables-registers.lldbinit 2>&1 | FileCheck %s
 
 # This file is compiled from following source file:

--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
@@ -2,7 +2,7 @@
 
 // REQUIRES: system-windows
 // RUN: %build -o %t.exe -- %s
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/local-variables.lldbinit 2>&1 | FileCheck %s
 
 int Function(int Param1, char Param2) {

--- a/lldb/test/Shell/SymbolFile/NativePDB/locate-pdb.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/locate-pdb.cpp
@@ -17,12 +17,12 @@
 // RUN:     -out:%t/executable/foo.exe -pdb:%t/symbols/bar.pdb
 
 // Find the PDB in its build location
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t/executable/foo.exe -s \
+// RUN: %lldb -f %t/executable/foo.exe -s \
 // RUN:     %p/Inputs/locate-pdb.lldbinit | FileCheck %s
 
 // Also find the PDB when it's adjacent to the executable
 // RUN: mv -f %t/symbols/bar.pdb %t/executable/bar.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t/executable/foo.exe -s \
+// RUN: %lldb -f %t/executable/foo.exe -s \
 // RUN:     %p/Inputs/locate-pdb.lldbinit | FileCheck %s
 
 int main(int argc, char** argv) {

--- a/lldb/test/Shell/SymbolFile/NativePDB/lookup-by-address.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/lookup-by-address.cpp
@@ -3,7 +3,7 @@
 
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -GR- -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -base:0x400000 -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -O "target create %t.exe" -o "image lookup -a 0x401000" -o "exit" | FileCheck %s --check-prefix=ADDRESS
+// RUN: %lldb -O "target create %t.exe" -o "image lookup -a 0x401000" -o "exit" | FileCheck %s --check-prefix=ADDRESS
 int main(int argc, char **argv) {
   return 0;
 }

--- a/lldb/test/Shell/SymbolFile/NativePDB/lookup-by-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/lookup-by-types.cpp
@@ -1,7 +1,7 @@
 // clang-format off
 
 // RUN: %build -o %t.exe -- %s
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/lookup-by-types.lldbinit 2>&1 | FileCheck %s
 
 class B;

--- a/lldb/test/Shell/SymbolFile/NativePDB/nested-blocks-same-address.s
+++ b/lldb/test/Shell/SymbolFile/NativePDB/nested-blocks-same-address.s
@@ -4,7 +4,7 @@
 # Test when nested S_BLOCK32 have same address range, ResolveSymbolContext should return the innnermost block.
 # RUN: llvm-mc -triple=x86_64-windows-msvc --filetype=obj %s > %t.obj
 # RUN: lld-link /debug:full /nodefaultlib /entry:main %t.obj /out:%t.exe /base:0x140000000
-# RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -o "image lookup -a 0x14000103c -v" -o "exit" | FileCheck %s
+# RUN: %lldb -f %t.exe -o "image lookup -a 0x14000103c -v" -o "exit" | FileCheck %s
 
 # This file is compiled from following source file:
 # $ clang-cl /Z7 /GS- /c /O2 test.cpp /Fatest.s

--- a/lldb/test/Shell/SymbolFile/NativePDB/nested-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/nested-types.cpp
@@ -5,7 +5,7 @@
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 \
 // RUN:   -Xclang -fkeep-static-consts -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/nested-types.lldbinit 2>&1 | FileCheck %s
 
 struct S {

--- a/lldb/test/Shell/SymbolFile/NativePDB/s_constant.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/s_constant.cpp
@@ -5,7 +5,7 @@
 
 // RUN: llvm-mc -filetype=obj -triple=x86_64-pc-win32 %p/Inputs/s_constant.s > %t.obj
 // RUN: %build --compiler=clang-cl --nodefaultlib --mode=link -o %t.exe -- %t.obj
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/s_constant.lldbinit | FileCheck %s
 
 // clang-cl cannot generate S_CONSTANT records, but we need to test that we can

--- a/lldb/test/Shell/SymbolFile/NativePDB/source-list.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/source-list.cpp
@@ -4,7 +4,7 @@
 // Test that we can set display source of functions.
 // RUN: %clang_cl --target=x86_64-windows-msvc -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/source-list.lldbinit | FileCheck %s
 
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/stack_unwinding01.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/stack_unwinding01.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: lld, system-windows
 
 // RUN: %build --compiler=clang-cl --nodefaultlib -o %t.exe -- %s
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/stack_unwinding01.lldbinit 2>&1 | FileCheck %s
 
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
@@ -4,7 +4,7 @@
 // Test that we can display tag types.
 // RUN: %clang_cl --target=x86_64-windows-msvc -GS- -Od -Z7 -c /Fo%t.obj -- %s
 // RUN: lld-link -debug:full -nodefaultlib -entry:main %t.obj -out:%t.exe -pdb:%t.pdb
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -s \
+// RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/tag-types.lldbinit | FileCheck %s
 
 // Test struct

--- a/lldb/test/Shell/SymbolFile/NativePDB/typedefs.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/typedefs.cpp
@@ -2,7 +2,7 @@
 
 // REQUIRES: system-windows
 // RUN: %build --compiler=clang-cl --nodefaultlib -o %t.exe -- %s
-// RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols -dump-ast %t.exe | FileCheck %s
+// RUN: lldb-test symbols -dump-ast %t.exe | FileCheck %s
 
 namespace A {
   namespace B {

--- a/lldb/test/Shell/SymbolFile/PDB/ast-restore.test
+++ b/lldb/test/Shell/SymbolFile/PDB/ast-restore.test
@@ -1,10 +1,10 @@
 REQUIRES: system-windows, msvc
 RUN: %build --compiler=msvc --nodefaultlib --output=%t.exe %S/Inputs/AstRestoreTest.cpp
-RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=ENUM %s
+RUN: lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=ENUM %s
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=ENUM %s
 RUN: lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=GLOBAL %s
 RUN: lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=BASE %s
-RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=CLASS %s
+RUN: lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=CLASS %s
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=CLASS %s
 RUN: lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=INNER %s
 RUN: lldb-test symbols -dump-ast %t.exe | FileCheck --check-prefix=TEMPLATE %s

--- a/lldb/test/Shell/SymbolFile/PDB/compilands.test
+++ b/lldb/test/Shell/SymbolFile/PDB/compilands.test
@@ -2,7 +2,7 @@ REQUIRES: system-windows, msvc
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/CompilandsTest.cpp.obj %S/Inputs/CompilandsTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/CompilandsTest.cpp.exe %T/CompilandsTest.cpp.obj
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %T/CompilandsTest.cpp.exe | FileCheck %s
-RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %T/CompilandsTest.cpp.exe | FileCheck %s
+RUN: lldb-test symbols %T/CompilandsTest.cpp.exe | FileCheck %s
 
 ; Link default libraries
 

--- a/lldb/test/Shell/SymbolFile/PDB/function-level-linking.test
+++ b/lldb/test/Shell/SymbolFile/PDB/function-level-linking.test
@@ -2,4 +2,4 @@ REQUIRES: system-windows, lld
 RUN: %clang_cl_host /c /Zi /Gy %S/Inputs/FunctionLevelLinkingTest.cpp /o %t.obj
 RUN: lld-link /debug:full /nodefaultlib /entry:main /order:@%S/Inputs/FunctionLevelLinkingTest.ord %t.obj /out:%t.exe
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols -verify %t.exe
-RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols -verify %t.exe
+RUN: lldb-test symbols -verify %t.exe

--- a/lldb/test/Shell/SymbolFile/PDB/lit.local.cfg
+++ b/lldb/test/Shell/SymbolFile/PDB/lit.local.cfg
@@ -1,0 +1,1 @@
+config.environment["LLDB_USE_NATIVE_PDB_READER"] = "0"

--- a/lldb/test/Shell/SymbolFile/PDB/variables-locations.test
+++ b/lldb/test/Shell/SymbolFile/PDB/variables-locations.test
@@ -1,6 +1,6 @@
 REQUIRES: system-windows, lld
 RUN: %build --compiler=clang-cl --output=%t.exe %S/Inputs/VariablesLocationsTest.cpp
-RUN: env LLDB_USE_NATIVE_PDB_READER=0 %lldb -b -s %S/Inputs/VariablesLocationsTest.script -- %t.exe | FileCheck %s
+RUN: %lldb -b -s %S/Inputs/VariablesLocationsTest.script -- %t.exe | FileCheck %s
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -b -s %S/Inputs/VariablesLocationsTest.script -- %t.exe | FileCheck %s
 
 CHECK: g_var = 2222


### PR DESCRIPTION
Lit allows you to set environment variables for all tests in a directory using a `lit.local.cfg` file. Do this for the PDB and NativePDB tests.