### PR TITLE
[libc] Fix path to fcntl_overlay in cmake

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -51,7 +51,7 @@ add_proxy_header_library(
   HDRS
     mode_t.h
   DEPENDS
-    ../fcntl_overlay
+    libc.hdr.fcntl_overlay
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.mode_t
     libc.include.fcntl


### PR DESCRIPTION
The proxy header definition for mode_t was using an incorrect form for
its dependency on fcntl_overlay. The relative paths for dependencies can
only go down, not up so "../" doesn't work. This patch fixes it to be
absolute.
