### PR TITLE
[libc] Fix macro definition hermeticity

### DIFF
--- a/libc/include/llvm-libc-macros/linux/fcntl-macros.h
+++ b/libc/include/llvm-libc-macros/linux/fcntl-macros.h
@@ -88,6 +88,9 @@
 // Close on succesful
 #define F_CLOEXEC 1
 
+// Close on execute for fcntl.
+#define FD_CLOEXEC 1
+
 #define F_RDLCK 0
 #define F_WRLCK 1
 #define F_UNLCK 2

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -163,5 +163,6 @@ add_libc_unittest(
     libc.src.unistd.ftruncate
     libc.src.unistd.close
     libc.src.__support.OSUtil.osutil
+    libc.hdr.fcntl_macros
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/mman/linux/shm_test.cpp
+++ b/libc/test/src/sys/mman/linux/shm_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/fcntl_macros.h"
 #include "src/__support/OSUtil/syscall.h"
 #include "src/fcntl/fcntl.h"
 #include "src/sys/mman/mmap.h"
@@ -16,7 +17,6 @@
 #include "src/unistd/ftruncate.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/LibcTest.h"
-#include <asm-generic/fcntl.h>
 #include <sys/syscall.h>
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;


### PR DESCRIPTION
Previously shm_test was including <asm-generic/fcntl.h> for the macro
FD_CLOEXEC. This patch adds that macro to the list we have defined, and
redirects the test to use the correct proxy header.
