### PR TITLE
[flang] Avoid generating duplicate symbol in comdat

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2931,6 +2931,9 @@ private:
       comdatOp =
           rewriter.create<mlir::LLVM::ComdatOp>(module.getLoc(), comdatName);
     }
+    if (auto select = comdatOp.lookupSymbol<mlir::LLVM::ComdatSelectorOp>(
+            global.getSymName()))
+      return;
     mlir::OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPointToEnd(&comdatOp.getBody().back());
     auto selectorOp = rewriter.create<mlir::LLVM::ComdatSelectorOp>(

--- a/flang/test/Fir/comdat-present.fir
+++ b/flang/test/Fir/comdat-present.fir
@@ -1,0 +1,14 @@
+// RUN: fir-opt %s --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %s
+// RUN: fir-opt %s --fir-to-llvm-ir="target=x86_64-pc-windows-msvc" | FileCheck %s
+
+fir.global linkonce_odr @global_linkonce_odr constant : i32 {
+  %0 = arith.constant 0 : i32
+  fir.has_value %0 : i32
+}
+
+llvm.comdat @__llvm_comdat {
+  llvm.comdat_selector @global_linkonce_odr any
+}
+
+// CHECK-LABEL: llvm.comdat @__llvm_comdat
+// CHECK: llvm.comdat_selector @global_linkonce_odr any


### PR DESCRIPTION
In case where a fir.global might be duplicated in an inner module (gpu.module), the conversion pattern will be applied on the module and the gpu module version of the global and try to generate multiple comdat with the same symbol name. This is what we have in the implementation of CUDA Fortran. 

Just check for the presence of the `ComdatSelectorOp` before creating a new one. 