### PR TITLE
[InlineCost] Print inline cost for invoke call sites as well

### DIFF
--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -3257,16 +3257,16 @@ InlineCostAnnotationPrinterPass::run(Function &F,
   const InlineParams Params = llvm::getInlineParams();
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
-      if (CallInst *CI = dyn_cast<CallInst>(&I)) {
-        Function *CalledFunction = CI->getCalledFunction();
+      if (auto *CB = dyn_cast<CallBase>(&I)) {
+        Function *CalledFunction = CB->getCalledFunction();
         if (!CalledFunction || CalledFunction->isDeclaration())
           continue;
         OptimizationRemarkEmitter ORE(CalledFunction);
-        InlineCostCallAnalyzer ICCA(*CalledFunction, *CI, Params, TTI,
+        InlineCostCallAnalyzer ICCA(*CalledFunction, *CB, Params, TTI,
                                     GetAssumptionCache, nullptr, &PSI, &ORE);
         ICCA.analyze();
         OS << "      Analyzing call of " << CalledFunction->getName()
-           << "... (caller:" << CI->getCaller()->getName() << ")\n";
+           << "... (caller:" << CB->getCaller()->getName() << ")\n";
         ICCA.print(OS);
         OS << "\n";
       }

--- a/llvm/test/Transforms/Inline/inline-cost-annotation-pass.ll
+++ b/llvm/test/Transforms/Inline/inline-cost-annotation-pass.ll
@@ -33,3 +33,34 @@ define ptr @main() {
   %2 = call ptr @foo()
   ret ptr %1
 }
+
+; Make sure it also analyzes invoke call sites.
+
+; CHECK:       Analyzing call of g... (caller:f)
+; CHECK: define i32 @g(i32 %v) {
+; CHECK: ; cost before = {{.*}}, cost after = {{.*}}, threshold before = {{.*}}, threshold after = {{.*}}, cost delta = {{.*}}
+; CHECK:   %p = icmp ugt i32 %v, 35
+; CHECK: ; cost before = {{.*}}, cost after = {{.*}}, threshold before = {{.*}}, threshold after = {{.*}}, cost delta = {{.*}}
+; CHECK:   %r = select i1 %p, i32 %v, i32 7
+; CHECK: ; cost before = {{.*}}, cost after = {{.*}}, threshold before = {{.*}}, threshold after = {{.*}}, cost delta = {{.*}}
+; CHECK:   ret i32 %r
+; CHECK: }
+define i32 @g(i32 %v) {
+  %p = icmp ugt i32 %v, 35
+  %r = select i1 %p, i32 %v, i32 7
+  ret i32 %r
+}
+
+define void @f(i32 %v, ptr %dst) personality ptr @__gxx_personality_v0 {
+  %v1 = invoke i32 @g(i32 %v)
+          to label %bb1 unwind label %bb2
+bb1:
+  store i32 %v1, ptr %dst
+  ret void
+bb2:
+  %lpad.loopexit80 = landingpad { ptr, i32 }
+          cleanup
+  ret void
+}
+
+declare i32 @__gxx_personality_v0(...)


### PR DESCRIPTION
Previously InlineCostAnnotationPrinter only prints inline cost for call instructions. I don't think there is any reason not to analyze invoke and its callee, and this patch adds such support.