### PR TITLE
[lldb] Improve command status when dwim-print has no result

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -231,7 +231,7 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     if (valobj_sp->GetError().GetError() != UserExpression::kNoResult)
       dump_val_object(*valobj_sp);
     else
-      result.SetStatus(eReturnStatusSuccessFinishResult);
+      result.SetStatus(eReturnStatusSuccessFinishNoResult);
 
     if (suppress_result)
       if (auto result_var_sp =


### PR DESCRIPTION
When an expression produces no result, set `dwim-print` status to `eReturnStatusSuccessFinishNoResult`.