### PR TITLE
[libc] Remove asm-generic includes from tests

### DIFF
--- a/libc/test/src/search/hsearch_test.cpp
+++ b/libc/test/src/search/hsearch_test.cpp
@@ -15,7 +15,6 @@
 #include "src/search/hsearch.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
-#include <asm-generic/errno-base.h>
 
 TEST(LlvmLibcHsearchTest, CreateTooLarge) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;

--- a/libc/test/src/sys/mman/linux/mlock_test.cpp
+++ b/libc/test/src/sys/mman/linux/mlock_test.cpp
@@ -23,8 +23,6 @@
 #include "test/UnitTest/LibcTest.h"
 #include "test/UnitTest/Test.h"
 
-#include <asm-generic/errno-base.h>
-#include <asm-generic/mman.h>
 #include <linux/capability.h>
 #include <sys/mman.h>
 #include <sys/resource.h>


### PR DESCRIPTION
We shouldn't be including headers directly from asm-generic for macros.
It's safer to get those through the correct primary header where
possible (e.g. fcntl instead of asm-generic/fcntl).

For our public headers we may need to include the asm-generic
headers instead of defining all the macros ourselves, but that's
something for a followup PR.
