### PR TITLE
[clang-sycl-linker] Fix use of uninitialized memory in temp files

### DIFF
--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -230,7 +230,7 @@ Expected<StringRef> linkDeviceInputFiles(ArrayRef<std::string> InputFiles,
   CmdArgs.push_back("--suppress-warnings");
   if (Error Err = executeCommands(*LLVMLinkPath, CmdArgs))
     return std::move(Err);
-  return *OutFileOrErr;
+  return Args.MakeArgString(*OutFileOrErr);
 }
 
 // This utility function is used to gather all SYCL device library files that


### PR DESCRIPTION
This fixes the current sanitizer CI [failures](https://lab.llvm.org/buildbot/#/builders/169/builds/4839/steps/13/logs/stdio). I manually confirmed the fix with a MemorySanitizer build.