### PR TITLE
[libc][bazel] Fix linter warning - remove unused load.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -8,7 +8,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load(":libc_configure_options.bzl", "LIBC_CONFIGURE_OPTIONS")
 load(":libc_namespace.bzl", "LIBC_NAMESPACE")
-load(":platforms.bzl", "PLATFORM_CPU_ARM64", "PLATFORM_CPU_X86_64")
+load(":platforms.bzl", "PLATFORM_CPU_X86_64")
 
 def libc_internal_target(name):
     return name + ".__internal__"


### PR DESCRIPTION
This load is no longer necessary since PLATFORM_CPU_ARM64 was removed in fa17977c315062646d4d1e01262d68dd69313e61