### PR TITLE
[llvm][NFC] Fix typos: replace “avaliable” with “available” across various files

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.cpp
@@ -126,7 +126,7 @@ struct CognitiveComplexity final {
   // Limit of 25 is the "upstream"'s default.
   static constexpr unsigned DefaultLimit = 25U;
 
-  // Based on the publicly-avaliable numbers for some big open-source projects
+  // Based on the publicly-available numbers for some big open-source projects
   // https://sonarcloud.io/projects?languages=c%2Ccpp&size=5   we can estimate:
   // value ~20 would result in no allocs for 98% of functions, ~12 for 96%, ~10
   // for 91%, ~8 for 88%, ~6 for 84%, ~4 for 77%, ~2 for 64%, and ~1 for 37%.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity.cpp
@@ -69,10 +69,10 @@ end:
 //----------------------------------------------------------------------------//
 
 // break does not increase cognitive complexity.
-// only  break LABEL  does, but it is unavaliable in C or C++
+// only  break LABEL  does, but it is unavailable in C or C++
 
 // continue does not increase cognitive complexity.
-// only  continue LABEL  does, but it is unavaliable in C or C++
+// only  continue LABEL  does, but it is unavailable in C or C++
 
 void unittest_b1_00() {
 // CHECK-NOTES: :[[@LINE-1]]:6: warning: function 'unittest_b1_00' has cognitive complexity of 33 (threshold 0) [readability-function-cognitive-complexity]

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h
@@ -315,7 +315,7 @@ public:
 
   /// Returns a list of filenames of dynamic libraries that this archive has
   /// imported. This class does not load these libraries by itself. User is
-  /// responsible for making sure these libraries are avaliable to the JITDylib.
+  /// responsible for making sure these libraries are available to the JITDylib.
   const std::set<std::string> &getImportedDynamicLibraries() const {
     return ImportedDynamicLibraries;
   }

--- a/llvm/include/llvm/Target/TargetMacroFusion.td
+++ b/llvm/include/llvm/Target/TargetMacroFusion.td
@@ -14,7 +14,7 @@ def first_fusion_target : FusionTarget;
 def second_fusion_target : FusionTarget;
 def both_fusion_target : FusionTarget;
 
-// Base class of FusionPredicate, etc. The avaliable variables are:
+// Base class of FusionPredicate, etc. The available variables are:
 // * const TargetInstrInfo &TII
 // * const TargetSubtargetInfo &STI
 // * const MachineRegisterInfo &MRI

--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -898,7 +898,7 @@ public:
     bool ShouldPreserveDominatorTree;
     std::optional<DominatorTree> LazilyComputedDomTree;
 
-    // Do we already have a DominatorTree avaliable from the previous pass?
+    // Do we already have a DominatorTree available from the previous pass?
     // Note that we should *NOT* require it, to avoid the case where we end up
     // not needing it, but the legacy PM would have computed it for us anyways.
     if (auto *DTWP = getAnalysisIfAvailable<DominatorTreeWrapperPass>()) {

--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -223,7 +223,7 @@ def SiFive7VS          : ProcResource<1>; // Store sequencer
 // The VCQ accepts instructions from the the A Pipe and holds them until the
 // vector unit is ready to dequeue them. The unit dequeues up to one instruction
 // per cycle, in order, as soon as the sequencer for that type of instruction is
-// avaliable. This resource is meant to be used for 1 cycle by all vector
+// available. This resource is meant to be used for 1 cycle by all vector
 // instructions, to model that only one vector instruction may be dequed at a
 // time. The actual dequeueing into the sequencer is modeled by the VA, VL, and
 // VS sequencer resources below. Each of them will only accept a single

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -2490,7 +2490,7 @@ static bool detectShiftUntilBitTestIdiom(Loop *CurLoop, Value *&BaseX,
       dyn_cast<Instruction>(CurrXPN->getIncomingValueForBlock(LoopHeaderBB));
 
   assert(CurLoop->isLoopInvariant(BaseX) &&
-         "Expected BaseX to be avaliable in the preheader!");
+         "Expected BaseX to be available in the preheader!");
 
   if (!NextX || !match(NextX, m_Shl(m_Specific(CurrX), m_One()))) {
     // FIXME: support right-shift?

--- a/llvm/test/MC/ARM/mve-fp-registers.s
+++ b/llvm/test/MC/ARM/mve-fp-registers.s
@@ -1,5 +1,5 @@
 // Some simple operations on S, D and Q registers (loads, stores and moves) are
-// also avaliable in MVE, even in the integer-only version. Some of these
+// also available in MVE, even in the integer-only version. Some of these
 // instructions (operating on D or Q registers, or FP16 values) are only
 // available for certain targets.
 

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -2510,7 +2510,7 @@ LogicalResult BytecodeReader::Impl::defineValues(EncodingReader &reader,
 }
 
 Value BytecodeReader::Impl::createForwardRef() {
-  // Check for an avaliable existing operation to use. Otherwise, create a new
+  // Check for an available existing operation to use. Otherwise, create a new
   // fake operation to use for the reference.
   if (!openForwardRefOps.empty()) {
     Operation *op = &openForwardRefOps.back();


### PR DESCRIPTION
This pull request corrects multiple occurrences of the typo "avaliable" to "available" across the LLVM and Clang codebase. These changes improve the clarity and accuracy of comments and documentation. Specific modifications are in the following files:

1. clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.cpp: Updated comments in readability checks for cognitive complexity.
2. llvm/include/llvm/ExecutionEngine/Orc/ExecutionUtils.h: Corrected documentation for JITDylib responsibilities.
3. llvm/include/llvm/Target/TargetMacroFusion.td: Fixed descriptions for FusionPredicate variables.
4. llvm/lib/CodeGen/SafeStack.cpp: Improved comments on DominatorTree availability.
5. llvm/lib/Target/RISCV/RISCVSchedSiFive7.td: Enhanced resource usage descriptions for vector units.
6. llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp: Updated invariant description in shift-detect idiom logic.
7. llvm/test/MC/ARM/mve-fp-registers.s: Amended ARM MVE register availability notes.
8. mlir/lib/Bytecode/Reader/BytecodeReader.cpp: Adjusted forward reference descriptions for bytecode reader operations.

These changes have no impact on code functionality, focusing solely on documentation clarity.