### PR TITLE
[WIP][lldb][Expression] More reliable function call resolution

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -784,6 +784,14 @@ def AbiTag : Attr {
   let Documentation = [AbiTagsDocs];
 }
 
+def StructorMangledNames : Attr {
+  let Spellings = [Clang<"structor_names">];
+  let Args = [VariadicStringArgument<"MangledNames">];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Documentation = [StructorMangledNamesDocs];
+}
+
+
 def AddressSpace : TypeAttr {
   let Spellings = [Clang<"address_space">];
   let Args = [IntArgument<"AddressSpace">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3568,6 +3568,11 @@ manipulating bits of the enumerator when issuing warnings.
   }];
 }
 
+def StructorMangledNamesDocs : Documentation {
+  let Category = DocCatDecl;
+  let Content = [{ TODO }];
+}
+
 def AsmLabelDocs : Documentation {
   let Category = DocCatDecl;
   let Content = [{

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5539,6 +5539,25 @@ static void handleMSConstexprAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   D->addAttr(::new (S.Context) MSConstexprAttr(S.Context, AL));
 }
 
+static void handleStructorNamesAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+  SmallVector<StringRef, 4> Tags;
+  for (unsigned I = 0, E = AL.getNumArgs(); I != E; ++I) {
+    StringRef Tag;
+    if (!S.checkStringLiteralArgumentAttr(AL, I, Tag))
+      return;
+    Tags.push_back(Tag);
+  }
+
+  if (!AL.checkAtLeastNumArgs(S, 1))
+    return;
+
+  // Store tags without duplicates.
+  Tags.erase(std::unique(Tags.begin(), Tags.end()), Tags.end());
+
+  D->addAttr(::new (S.Context) StructorMangledNamesAttr(
+      S.Context, AL, Tags.data(), Tags.size()));
+}
+
 static void handleAbiTagAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   SmallVector<StringRef, 4> Tags;
   for (unsigned I = 0, E = AL.getNumArgs(); I != E; ++I) {
@@ -6983,6 +7002,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     S.HLSL().handleParamModifierAttr(D, AL);
     break;
 
+  case ParsedAttr::AT_StructorMangledNames:
+    handleStructorNamesAttr(S, D, AL);
+    break;
   case ParsedAttr::AT_AbiTag:
     handleAbiTagAttr(S, D, AL);
     break;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -980,7 +980,8 @@ public:
       lldb::opaque_compiler_type_t type, llvm::StringRef name,
       const char *mangled_name, const CompilerType &method_type,
       lldb::AccessType access, bool is_virtual, bool is_static, bool is_inline,
-      bool is_explicit, bool is_attr_used, bool is_artificial);
+      bool is_explicit, bool is_attr_used, bool is_artificial,
+      std::vector<std::string> const &structor_names = {});
 
   void AddMethodOverridesForCXXRecordType(lldb::opaque_compiler_type_t type);
 

--- a/lldb/test/Shell/Expr/TestAbiTagCtorsDtors.cpp
+++ b/lldb/test/Shell/Expr/TestAbiTagCtorsDtors.cpp
@@ -1,0 +1,28 @@
+// Tests that we can call abi-tagged constructors/destructors.
+
+// RUN: %build %s -o %t
+// RUN: %lldb %t -o run \
+// RUN:          -o "expression sinkTagged(getTagged())" \
+// RUN:          -o "expression Tagged()" \
+// RUN:          -o exit | FileCheck %s
+
+// CHECK: expression sinkTagged(getTagged())
+// CHECK: expression Tagged()
+
+struct Tagged {
+  [[gnu::abi_tag("Test", "CtorTag")]] [[gnu::abi_tag("v1")]] Tagged() = default;
+  [[gnu::abi_tag("Test", "DtorTag")]] [[gnu::abi_tag("v1")]] ~Tagged() {}
+
+  int mem = 15;
+};
+
+Tagged getTagged() { return Tagged(); }
+void sinkTagged(Tagged t) {}
+
+int main() {
+  Tagged t;
+
+  // TODO: is there a more reliable way of triggering destructor call?
+  sinkTagged(getTagged());
+  __builtin_debugtrap();
+}

--- a/llvm/include/llvm/Demangle/Demangle.h
+++ b/llvm/include/llvm/Demangle/Demangle.h
@@ -10,6 +10,7 @@
 #define LLVM_DEMANGLE_DEMANGLE_H
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -107,6 +108,8 @@ struct ItaniumPartialDemangler {
   /// If this function has any cv or reference qualifiers. These imply that
   /// the function is a non-static member function.
   bool hasFunctionQualifiers() const;
+
+  std::optional<int> getCtorDtorVariant() const;
 
   /// If this symbol describes a constructor or destructor.
   bool isCtorOrDtor() const;

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -1728,6 +1728,8 @@ public:
 
   template<typename Fn> void match(Fn F) const { F(Basename, IsDtor, Variant); }
 
+  int getVariant() const { return Variant; }
+
   void printLeft(OutputBuffer &OB) const override {
     if (IsDtor)
       OB += "~";


### PR DESCRIPTION
Naive implementation of all the parts of following RFC:
https://discourse.llvm.org/t/rfc-lldb-handling-abi-tagged-constructors-destructors-in-expression-evaluator/82816

Main changes:
1. Instead of relying on linkage names to resolve function symbols, encode the exact function DIE and module in the `AsmLabelAttr`. Currently we just put the `Module` pointer value into the label, which may be not sufficient if those could disappear under the expression evaluator's feet.
2. Teach the LLDB symbol resolver about (1)
3. Introduce new Clang attribute to allow specifying multiple `asm` labels for ctors/dtors (one for each variant)
4. Attach the new attribute in (3), where the mangled names use the format from (1), to function decls that LLDB creates (this prototype doesn't actually do this for methods yet, just free-functions and constructors). To determine which variant a DIE corresponds to we add a new API to the `ItaniumPartialDemangler` (though could be made into a DWARF attribute for quicker determination).

Example constructor decl would look like the following:
```
| `-CXXConstructorDecl 0x246e6f8 <<invalid sloc>> <invalid sloc> Bar 'void ()'
|   `-StructorMangledNamesAttr 0x246e7c0 <<invalid sloc>> Implicit 2:$__lldb_func_0x00000000014B6560:257 1:$__lldb_func_0x00000000014B6560:294
```