### PR TITLE
[mlir][affine] Make --affine-super-vectorize fail if no vector size is specified

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/SuperVectorize.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/SuperVectorize.cpp
@@ -1763,6 +1763,12 @@ void Vectorize::runOnOperation() {
     return signalPassFailure();
   }
 
+  if (vectorSizes.empty()) {
+    f.emitError("Vector rank cannot be zero, specify pass option ")
+        << vectorSizes.getArgStr();
+    return signalPassFailure();
+  }
+
   if (vectorizeReductions && vectorSizes.size() != 1) {
     f.emitError("Vectorizing reductions is supported only for 1-D vectors.");
     return signalPassFailure();

--- a/mlir/test/Dialect/Affine/SuperVectorize/invalid-no-size.mlir
+++ b/mlir/test/Dialect/Affine/SuperVectorize/invalid-no-size.mlir
@@ -1,0 +1,9 @@
+// RUN: mlir-opt %s -verify-diagnostics --affine-super-vectorize
+
+// expected-error@+1 {{Vector rank cannot be zero, specify pass option virtual-vector-size}} 
+func.func @with_zero_vector_size(%arg0: memref<21x12x12xi1>) {
+  affine.for %arg1 = 0 to 84 step 4294967295 {
+  }
+  return
+}
+


### PR DESCRIPTION
Fix #114528 