### PR TITLE
[X86] Make POP imply pointer-size operands, as with PUSH for Intel syntax

### DIFF
--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -4495,7 +4495,7 @@ bool X86AsmParser::matchAndEmitIntelInstruction(
   // compatible with gas.
   StringRef Mnemonic = (static_cast<X86Operand &>(*Operands[0])).getToken();
   if (UnsizedMemOp) {
-    static const char *const PtrSizedInstrs[] = {"call", "jmp", "push"};
+    static const char *const PtrSizedInstrs[] = {"call", "jmp", "push", "pop"};
     for (const char *Instr : PtrSizedInstrs) {
       if (Mnemonic == Instr) {
         UnsizedMemOp->Mem.Size = getPointerWidth();

--- a/llvm/test/MC/X86/intel-syntax-ambiguous.s
+++ b/llvm/test/MC/X86/intel-syntax-ambiguous.s
@@ -30,6 +30,7 @@ sub [eax], 1
 // gas assumes these instructions are pointer-sized by default, and we follow
 // suit.
 push [eax]
+pop [eax]
 call [eax]
 jmp [eax]
 // CHECK-NOT: error:

--- a/llvm/test/MC/X86/intel-syntax-ptr-sized.s
+++ b/llvm/test/MC/X86/intel-syntax-ptr-sized.s
@@ -6,6 +6,8 @@ push [eax]
 // CHECK: pushl (%eax)
 call [eax]
 // CHECK: calll *(%eax)
+pop [eax]
+// CHECK: popl (%eax)
 jmp [eax]
 // CHECK: jmpl *(%eax)
 
@@ -25,6 +27,8 @@ push [eax]
 // CHECK: pushw (%eax)
 call [eax]
 // CHECK: callw *(%eax)
+pop [eax]
+// CHECK: popw (%eax)
 jmp [eax]
 // CHECK: jmpw *(%eax)
 


### PR DESCRIPTION
On x86-32 the word PUSH (50+rd) and POP (58+rd) instructions assume only 32-bit operands, and on x86-64 they assume only 64-bit operands; in neither case should the absence of an operand size be ambiguous.

Those special case were added in f6fb78089060818b4352b540abc44da4f62b95ef and lacking of POP seemed an oversight.

This closes https://github.com/llvm/llvm-project/issues/114531.