### PR TITLE
[NFC][Coroutines] Remove invalid coroutine intrinsic name

### DIFF
--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -69,7 +69,6 @@ static const char *const CoroIntrinsics[] = {
     "llvm.coro.async.context.dealloc",
     "llvm.coro.async.resume",
     "llvm.coro.async.size.replace",
-    "llvm.coro.async.store_resume",
     "llvm.coro.await.suspend.bool",
     "llvm.coro.await.suspend.handle",
     "llvm.coro.await.suspend.void",


### PR DESCRIPTION
Removes `llvm.coro.async.store_resume` from the list of coroutine intrinsics. This is not a valid intrinsic name, and was likely added by mistake with [this](https://reviews.llvm.org/D90612) change. Makes sense to remove it.