### PR TITLE
[GVN][NewGVN] Take call attributes into account in expressions

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
@@ -315,6 +315,12 @@ public:
     return EB->getExpressionType() == ET_Call;
   }
 
+  bool equals(const Expression &Other) const override;
+  bool exactlyEquals(const Expression &Other) const override {
+    return Expression::exactlyEquals(Other) &&
+           cast<CallExpression>(Other).Call == Call;
+  }
+
   // Debugging support
   void printInternal(raw_ostream &OS, bool PrintEType) const override {
     if (PrintEType)

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -143,7 +143,7 @@ struct llvm::GVNPass::Expression {
   Type *type = nullptr;
   SmallVector<uint32_t, 4> varargs;
 
-  std::optional<AttributeList> attrs;
+  AttributeList attrs;
 
   Expression(uint32_t o = ~2U) : opcode(o) {}
 
@@ -156,10 +156,10 @@ struct llvm::GVNPass::Expression {
       return false;
     if (varargs != other.varargs)
       return false;
-    if (attrs.has_value() != other.attrs.has_value())
+    if (attrs.isEmpty() != other.attrs.isEmpty())
       return false;
-    if (attrs.has_value() &&
-        !attrs->intersectWith(type->getContext(), *other.attrs).has_value())
+    if (!attrs.isEmpty() &&
+        !attrs.intersectWith(type->getContext(), other.attrs).has_value())
       return false;
     return true;
   }

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -156,9 +156,7 @@ struct llvm::GVNPass::Expression {
       return false;
     if (varargs != other.varargs)
       return false;
-    if (attrs.isEmpty() != other.attrs.isEmpty())
-      return false;
-    if (!attrs.isEmpty() &&
+    if (!attrs.isEmpty() && !other.attrs.isEmpty() &&
         !attrs.intersectWith(type->getContext(), other.attrs).has_value())
       return false;
     return true;

--- a/llvm/test/Transforms/GVN/pr113997.ll
+++ b/llvm/test/Transforms/GVN/pr113997.ll
@@ -31,3 +31,36 @@ if.else:
 if.then:
   ret i1 false
 }
+
+define i1 @bucket2(i32 noundef %x) {
+; CHECK-LABEL: define i1 @bucket2(
+; CHECK-SAME: i32 noundef [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[CTPOP1:%.*]] = tail call range(i32 1, 32) i32 @llvm.ctpop.i32(i32 zeroext [[X]])
+; CHECK-NEXT:    [[CTPOP1INC:%.*]] = add i32 [[CTPOP1]], 1
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp samesign ult i32 [[CTPOP1INC]], 3
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[CMP1]], i1 [[CMP2]], i1 false
+; CHECK-NEXT:    br i1 [[COND]], label %[[IF_THEN:.*]], label %[[IF_ELSE:.*]]
+; CHECK:       [[IF_ELSE]]:
+; CHECK-NEXT:    [[CTPOP2:%.*]] = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[X]])
+; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[CTPOP1INC]], 2
+; CHECK-NEXT:    ret i1 [[RES]]
+; CHECK:       [[IF_THEN]]:
+; CHECK-NEXT:    ret i1 false
+;
+  %cmp1 = icmp sgt i32 %x, 0
+  %ctpop1 = tail call range(i32 1, 32) i32 @llvm.ctpop.i32(i32 zeroext %x)
+  %ctpop1inc = add i32 %ctpop1, 1
+  %cmp2 = icmp samesign ult i32 %ctpop1inc, 3
+  %cond = select i1 %cmp1, i1 %cmp2, i1 false
+  br i1 %cond, label %if.then, label %if.else
+
+if.else:
+  %ctpop2 = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 %x)
+  %ctpop2inc = add i32 %ctpop2, 1
+  %res = icmp eq i32 %ctpop2inc, 2
+  ret i1 %res
+
+if.then:
+  ret i1 false
+}

--- a/llvm/test/Transforms/GVN/pr113997.ll
+++ b/llvm/test/Transforms/GVN/pr113997.ll
@@ -32,6 +32,8 @@ if.then:
   ret i1 false
 }
 
+; Make sure we don't merge these two users of the incompatible call pair.
+
 define i1 @bucket2(i32 noundef %x) {
 ; CHECK-LABEL: define i1 @bucket2(
 ; CHECK-SAME: i32 noundef [[X:%.*]]) {
@@ -43,7 +45,8 @@ define i1 @bucket2(i32 noundef %x) {
 ; CHECK-NEXT:    br i1 [[COND]], label %[[IF_THEN:.*]], label %[[IF_ELSE:.*]]
 ; CHECK:       [[IF_ELSE]]:
 ; CHECK-NEXT:    [[CTPOP2:%.*]] = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[X]])
-; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[CTPOP1INC]], 2
+; CHECK-NEXT:    [[CTPOP2INC:%.*]] = add i32 [[CTPOP2]], 1
+; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[CTPOP2INC]], 2
 ; CHECK-NEXT:    ret i1 [[RES]]
 ; CHECK:       [[IF_THEN]]:
 ; CHECK-NEXT:    ret i1 false

--- a/llvm/test/Transforms/NewGVN/pr113997.ll
+++ b/llvm/test/Transforms/NewGVN/pr113997.ll
@@ -32,6 +32,8 @@ if.then:
   ret i1 false
 }
 
+; Make sure we don't merge these two users of the incompatible call pair.
+
 define i1 @bucket2(i32 noundef %x) {
 ; CHECK-LABEL: define i1 @bucket2(
 ; CHECK-SAME: i32 noundef [[X:%.*]]) {
@@ -42,7 +44,9 @@ define i1 @bucket2(i32 noundef %x) {
 ; CHECK-NEXT:    [[COND:%.*]] = select i1 [[CMP1]], i1 [[CMP2]], i1 false
 ; CHECK-NEXT:    br i1 [[COND]], label %[[IF_THEN:.*]], label %[[IF_ELSE:.*]]
 ; CHECK:       [[IF_ELSE]]:
-; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[CTPOP1INC]], 2
+; CHECK-NEXT:    [[CTPOP2:%.*]] = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[X]])
+; CHECK-NEXT:    [[CTPOP2INC:%.*]] = add i32 [[CTPOP2]], 1
+; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[CTPOP2INC]], 2
 ; CHECK-NEXT:    ret i1 [[RES]]
 ; CHECK:       [[IF_THEN]]:
 ; CHECK-NEXT:    ret i1 false

--- a/llvm/test/Transforms/NewGVN/pr113997.ll
+++ b/llvm/test/Transforms/NewGVN/pr113997.ll
@@ -31,3 +31,35 @@ if.else:
 if.then:
   ret i1 false
 }
+
+define i1 @bucket2(i32 noundef %x) {
+; CHECK-LABEL: define i1 @bucket2(
+; CHECK-SAME: i32 noundef [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[CTPOP1:%.*]] = tail call range(i32 1, 32) i32 @llvm.ctpop.i32(i32 zeroext [[X]])
+; CHECK-NEXT:    [[CTPOP1INC:%.*]] = add i32 [[CTPOP1]], 1
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp samesign ult i32 [[CTPOP1INC]], 3
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[CMP1]], i1 [[CMP2]], i1 false
+; CHECK-NEXT:    br i1 [[COND]], label %[[IF_THEN:.*]], label %[[IF_ELSE:.*]]
+; CHECK:       [[IF_ELSE]]:
+; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[CTPOP1INC]], 2
+; CHECK-NEXT:    ret i1 [[RES]]
+; CHECK:       [[IF_THEN]]:
+; CHECK-NEXT:    ret i1 false
+;
+  %cmp1 = icmp sgt i32 %x, 0
+  %ctpop1 = tail call range(i32 1, 32) i32 @llvm.ctpop.i32(i32 zeroext %x)
+  %ctpop1inc = add i32 %ctpop1, 1
+  %cmp2 = icmp samesign ult i32 %ctpop1inc, 3
+  %cond = select i1 %cmp1, i1 %cmp2, i1 false
+  br i1 %cond, label %if.then, label %if.else
+
+if.else:
+  %ctpop2 = tail call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 %x)
+  %ctpop2inc = add i32 %ctpop2, 1
+  %res = icmp eq i32 %ctpop2inc, 2
+  ret i1 %res
+
+if.then:
+  ret i1 false
+}


### PR DESCRIPTION
Drop `canBeReplacedBy` and take call attributes into account in expressions.
Address comment https://github.com/llvm/llvm-project/pull/114011#pullrequestreview-2409772313.
