### PR TITLE
[PS5][Driver] Supply default linker scripts

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -293,6 +293,16 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         "dead-reloc-in-nonalloc=.debug_ranges=0xfffffffffffffffe");
     CmdArgs.push_back("-z");
     CmdArgs.push_back("dead-reloc-in-nonalloc=.debug_loc=0xfffffffffffffffe");
+
+    // The PlayStation loader expects linked objects to be laid out in a
+    // particular way. This is achieved by linker scripts that are supplied
+    // with the SDK. The scripts are inside <sdkroot>/target/lib, which is
+    // added as a search path elsewhere.
+    // "PRX" has long stood for "PlayStation Relocatable eXecutable".
+    CmdArgs.push_back("--default-script");
+    CmdArgs.push_back(Static   ? "static.script"
+                      : Shared ? "prx.script"
+                               : "main.script");
   }
 
   if (Static)

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -66,6 +66,19 @@
 // CHECK-NO-EXE-NOT: "--unresolved-symbols
 // CHECK-NO-EXE-NOT: "-z"
 
+// Test that an appropriate linker script is supplied by the driver.
+
+// RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-SCRIPT -DSCRIPT=main %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-SCRIPT -DSCRIPT=prx %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -static -### 2>&1 | FileCheck --check-prefixes=CHECK-SCRIPT -DSCRIPT=static %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -r -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-SCRIPT %s
+
+// CHECK-SCRIPT: {{ld(\.exe)?}}"
+// CHECK-SCRIPT-SAME: "--default-script" "[[SCRIPT]].script"
+
+// CHECK-NO-SCRIPT: {{ld(\.exe)?}}"
+// CHECK-NO-SCRIPT-NOT: "--default-script"
+
 // Test that -static is forwarded to the linker
 
 // RUN: %clang --target=x86_64-sie-ps5 -static %s -### 2>&1 | FileCheck --check-prefixes=CHECK-STATIC %s


### PR DESCRIPTION
Until now, this has been hardcoded as a downstream patch in lld. Add it to the driver so that the private patch can be removed.

PS5 only. On PS4, the equivalent hardcoded configuration will remain in the proprietary linker.

SIE tracker: TOOLCHAIN-16704