### PR TITLE
[libc][cmake] disable include tests in overlay mode

### DIFF
--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -18,13 +18,14 @@ if(LIBC_TARGET_OS_IS_GPU)
   endif()
 endif()
 
-add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(utils)
 
 if(NOT LLVM_LIBC_FULL_BUILD)
   return()
 endif()
+
+add_subdirectory(include)
 
 if(NOT ${LIBC_TARGET_OS} STREQUAL "linux" AND
    NOT ${LIBC_TARGET_OS} STREQUAL "gpu")

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -36,50 +36,46 @@ add_libc_test(
     -Wno-gnu-statement-expression-from-macro-expansion
 )
 
-# stdbit_test only tests our generated stdbit.h, which is not generated in
-# overlay mode.
-if(LLVM_LIBC_FULL_BUILD AND libc.include.stdbit IN_LIST TARGET_PUBLIC_HEADERS)
-  add_libc_test(
-    stdbit_test
-    SUITE
-      libc_include_tests
-    HDRS
-      stdbit_stub.h
-    SRCS
-      stdbit_test.cpp
-    DEPENDS
-      libc.include.llvm-libc-macros.stdbit_macros
-      libc.include.llvm_libc_common_h
-      libc.include.stdbit
-      # Intentionally do not depend on libc.src.stdbit.*. The include test is
-      # simply testing the macros provided by stdbit.h, not the implementation
-      # of the underlying functions which the type generic macros may dispatch
-      # to.
-  )
-  add_libc_test(
-    stdbit_c_test
-    C_TEST
-    UNIT_TEST_ONLY
-    SUITE
-      libc_include_tests
-    HDRS
-      stdbit_stub.h
-    SRCS
-      stdbit_test.c
-    COMPILE_OPTIONS
-      -Wall
-      -Werror
-    DEPENDS
-      libc.include.llvm-libc-macros.stdbit_macros
-      libc.include.llvm_libc_common_h
-      libc.include.stdbit
-      libc.src.assert.__assert_fail
-      # Intentionally do not depend on libc.src.stdbit.*. The include test is
-      # simply testing the macros provided by stdbit.h, not the implementation
-      # of the underlying functions which the type generic macros may dispatch
-      # to.
-  )
-endif()
+add_libc_test(
+  stdbit_test
+  SUITE
+    libc_include_tests
+  HDRS
+    stdbit_stub.h
+  SRCS
+    stdbit_test.cpp
+  DEPENDS
+    libc.include.llvm-libc-macros.stdbit_macros
+    libc.include.llvm_libc_common_h
+    libc.include.stdbit
+    # Intentionally do not depend on libc.src.stdbit.*. The include test is
+    # simply testing the macros provided by stdbit.h, not the implementation
+    # of the underlying functions which the type generic macros may dispatch
+    # to.
+)
+add_libc_test(
+  stdbit_c_test
+  C_TEST
+  UNIT_TEST_ONLY
+  SUITE
+    libc_include_tests
+  HDRS
+    stdbit_stub.h
+  SRCS
+    stdbit_test.c
+  COMPILE_OPTIONS
+    -Wall
+    -Werror
+  DEPENDS
+    libc.include.llvm-libc-macros.stdbit_macros
+    libc.include.llvm_libc_common_h
+    libc.include.stdbit
+    libc.src.assert.__assert_fail
+    # Intentionally do not depend on libc.src.stdbit.*. The include test is
+    # simply testing the macros provided by stdbit.h, not the implementation
+    # of the underlying functions which the type generic macros may dispatch
+    # to.
+)
 
 add_libc_test(
   stdckdint_test


### PR DESCRIPTION
This avoids -Wmacro-redefinition diagnostics observed when building the
libc_include_tests ninja target.

For example, the signbit_test will attempt to include BOTH our
math-macros.h (via math-function-macros.h), and the system's math.h (via
hdr/math_macros.h).

While it's nice that we can get some coverage of the headers we will provide to
end users of fullbuilds in CI of overlay builds, it's not worth chasing each
individual conflict and disabling some include tests as conflicts arise.

Disable the include tests unless `-DLLVM_LIBC_FULL_BUILD=ON` is specified.
