### PR TITLE
[flang][openacc] Avoid crash when variable is not declared in reduction

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -674,26 +674,28 @@ void AccStructureChecker::Enter(const parser::AccClause::Reduction &reduction) {
         common::visitors{
             [&](const parser::Designator &designator) {
               if (const auto *name = getDesignatorNameIfDataRef(designator)) {
-                const auto *type{name->symbol->GetType()};
-                if (type->IsNumeric(TypeCategory::Integer) &&
-                    !reductionIntegerSet.test(op.v)) {
-                  context_.Say(GetContext().clauseSource,
-                      "reduction operator not supported for integer type"_err_en_US);
-                } else if (type->IsNumeric(TypeCategory::Real) &&
-                    !reductionRealSet.test(op.v)) {
-                  context_.Say(GetContext().clauseSource,
-                      "reduction operator not supported for real type"_err_en_US);
-                } else if (type->IsNumeric(TypeCategory::Complex) &&
-                    !reductionComplexSet.test(op.v)) {
-                  context_.Say(GetContext().clauseSource,
-                      "reduction operator not supported for complex type"_err_en_US);
-                } else if (type->category() ==
-                        Fortran::semantics::DeclTypeSpec::Category::Logical &&
-                    !reductionLogicalSet.test(op.v)) {
-                  context_.Say(GetContext().clauseSource,
-                      "reduction operator not supported for logical type"_err_en_US);
+                if (name->symbol) {
+                  const auto *type{name->symbol->GetType()};
+                  if (type->IsNumeric(TypeCategory::Integer) &&
+                      !reductionIntegerSet.test(op.v)) {
+                    context_.Say(GetContext().clauseSource,
+                        "reduction operator not supported for integer type"_err_en_US);
+                  } else if (type->IsNumeric(TypeCategory::Real) &&
+                      !reductionRealSet.test(op.v)) {
+                    context_.Say(GetContext().clauseSource,
+                        "reduction operator not supported for real type"_err_en_US);
+                  } else if (type->IsNumeric(TypeCategory::Complex) &&
+                      !reductionComplexSet.test(op.v)) {
+                    context_.Say(GetContext().clauseSource,
+                        "reduction operator not supported for complex type"_err_en_US);
+                  } else if (type->category() ==
+                          Fortran::semantics::DeclTypeSpec::Category::Logical &&
+                      !reductionLogicalSet.test(op.v)) {
+                    context_.Say(GetContext().clauseSource,
+                        "reduction operator not supported for logical type"_err_en_US);
+                  }
+                  // TODO: check composite type.
                 }
-                // TODO: check composite type.
               }
             },
             [&](const Fortran::parser::Name &name) {

--- a/flang/test/Semantics/OpenACC/acc-reduction-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-reduction-validity.f90
@@ -3,6 +3,7 @@
 ! Check OpenACC reduction validity.
 
 program openacc_reduction_validity
+  implicit none
 
   integer :: i
   real :: r
@@ -167,6 +168,10 @@ program openacc_reduction_validity
   !ERROR: reduction operator not supported for logical type
   !$acc parallel reduction(ieor:l)
   !$acc end parallel
+
+  !ERROR: No explicit type declared for 'xyz'
+  !$acc parallel reduction(+:xyz)
+  !$acc end parallel  
 
 
 end program


### PR DESCRIPTION
Do not check reduction type when the variable has not been declared. Correct error is then emitted. 