### PR TITLE
[lldb] Highlight "note:" in CommandReturnObject

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -110,6 +110,11 @@ public:
   void AppendMessageWithFormat(const char *format, ...)
       __attribute__((format(printf, 2, 3)));
 
+  void AppendNote(llvm::StringRef in_string);
+
+  void AppendNoteWithFormat(const char *format, ...)
+      __attribute__((format(printf, 2, 3)));
+
   void AppendWarning(llvm::StringRef in_string);
 
   void AppendWarningWithFormat(const char *format, ...)
@@ -125,6 +130,11 @@ public:
   template <typename... Args>
   void AppendMessageWithFormatv(const char *format, Args &&... args) {
     AppendMessage(llvm::formatv(format, std::forward<Args>(args)...).str());
+  }
+
+  template <typename... Args>
+  void AppendNoteWithFormatv(const char *format, Args &&...args) {
+    AppendNote(llvm::formatv(format, std::forward<Args>(args)...).str());
   }
 
   template <typename... Args>

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -121,10 +121,10 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
       if (note_shown)
         return;
 
-      result.GetOutputStream()
-          << "note: object description requested, but type doesn't implement "
-             "a custom object description. Consider using \"p\" instead of "
-             "\"po\" (this note will only be shown once per debug session).\n";
+      result.AppendNote(
+          "object description requested, but type doesn't implement "
+          "a custom object description. Consider using \"p\" instead of "
+          "\"po\" (this note will only be shown once per debug session).\n");
       note_shown = true;
     }
   };
@@ -164,8 +164,8 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
         StringRef flags;
         if (args.HasArgs())
           flags = args.GetArgString();
-        result.AppendMessageWithFormatv("note: ran `frame variable {0}{1}`",
-                                        flags, expr);
+        result.AppendNoteWithFormatv("ran `frame variable {0}{1}`", flags,
+                                     expr);
       }
 
       dump_val_object(*valobj_sp);
@@ -224,8 +224,7 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
       StringRef flags;
       if (args.HasArgs())
         flags = args.GetArgStringWithDelimiter();
-      result.AppendMessageWithFormatv("note: ran `expression {0}{1}`", flags,
-                                      expr);
+      result.AppendNoteWithFormatv("ran `expression {0}{1}`", flags, expr);
     }
 
     if (valobj_sp->GetError().GetError() != UserExpression::kNoResult)

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -27,6 +27,12 @@ static llvm::raw_ostream &warning(Stream &strm) {
          << "warning: ";
 }
 
+static llvm::raw_ostream &note(Stream &strm) {
+  return llvm::WithColor(strm.AsRawOstream(), llvm::HighlightColor::Note,
+                         llvm::ColorMode::Enable)
+         << "note: ";
+}
+
 static void DumpStringToStreamWithNewline(Stream &strm, const std::string &s) {
   bool add_newline = false;
   if (!s.empty()) {
@@ -74,6 +80,18 @@ void CommandReturnObject::AppendMessageWithFormat(const char *format, ...) {
   GetOutputStream() << sstrm.GetString();
 }
 
+void CommandReturnObject::AppendNoteWithFormat(const char *format, ...) {
+  if (!format)
+    return;
+  va_list args;
+  va_start(args, format);
+  StreamString sstrm;
+  sstrm.PrintfVarArg(format, args);
+  va_end(args);
+
+  note(GetOutputStream()) << sstrm.GetString();
+}
+
 void CommandReturnObject::AppendWarningWithFormat(const char *format, ...) {
   if (!format)
     return;
@@ -90,6 +108,12 @@ void CommandReturnObject::AppendMessage(llvm::StringRef in_string) {
   if (in_string.empty())
     return;
   GetOutputStream() << in_string.rtrim() << '\n';
+}
+
+void CommandReturnObject::AppendNote(llvm::StringRef in_string) {
+  if (in_string.empty())
+    return;
+  note(GetOutputStream()) << in_string.rtrim() << '\n';
 }
 
 void CommandReturnObject::AppendWarning(llvm::StringRef in_string) {


### PR DESCRIPTION
We have helpers to emit warnings and errors. Do the same thing for notes to they stand out more.