### PR TITLE
[INSTR COMBINE] implement combine select into cast

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3654,18 +3654,19 @@ static bool hasAffectedValue(Value *V, SmallPtrSetImpl<Value *> &Affected,
 // %any1 = uitofp i1 %any0 to float
 // ```
 // (also works with double)
-static std::optional<Instruction*> mabyeFoldIntoCast(Value* CondVal, ConstantFP *TrueVal, ConstantFP *FalseVal, Type *SelType, llvm::StringRef out) {
+static std::optional<Instruction *>
+mabyeFoldIntoCast(Value *CondVal, ConstantFP *TrueVal, ConstantFP *FalseVal,
+                  Type *SelType, llvm::StringRef out) {
   if (TrueVal->getValueAPF().convertToDouble() != 1.0) {
-    return std::optional<Instruction*>();
+    return std::optional<Instruction *>();
   }
 
   if (FalseVal->getValueAPF().convertToDouble() != 0.0) {
-    return std::optional<Instruction*>();
+    return std::optional<Instruction *>();
   }
 
   return CastInst::Create(llvm::Instruction::UIToFP, CondVal, SelType, out);
 }
-
 
 Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
   Value *CondVal = SI.getCondition();
@@ -3673,11 +3674,11 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
   Value *FalseVal = SI.getFalseValue();
   Type *SelType = SI.getType();
 
-  
   if (ConstantFP *True = dyn_cast<ConstantFP>(TrueVal)) {
     if (ConstantFP *False = dyn_cast<ConstantFP>(FalseVal)) {
       if (SelType->isFloatTy() || SelType->isDoubleTy()) {
-        std::optional<Instruction*> folded = mabyeFoldIntoCast(CondVal, True, False, SelType, SI.getName());
+        std::optional<Instruction *> folded =
+            mabyeFoldIntoCast(CondVal, True, False, SelType, SI.getName());
 
         if (folded.has_value()) {
           return folded.value();

--- a/llvm/test/Transforms/InstCombine/2024-11-07-FoldSelectIntoCast.ll
+++ b/llvm/test/Transforms/InstCombine/2024-11-07-FoldSelectIntoCast.ll
@@ -1,0 +1,8 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+define noundef float @ifelse(i1 noundef zeroext %x) unnamed_addr {
+start:
+; CHECK: %.= uitofp i1 %x to float
+  %. = select i1 %x, float 1.000000e+00, float 0.000000e+00
+  ret float %.
+}


### PR DESCRIPTION
Hi,
I implemented the instruction combination of this:
````
define noundef float @ifelse(i1 noundef zeroext %x) unnamed_addr {
start:
  %. = select i1 %x, float 1.000000e+00, float 0.000000e+00
  ret float %.
}
````
into this:
```

define noundef float @ifelse(i1 noundef zeroext %x) unnamed_addr {
start:
  %.= uitofp i1 %x to float
  ret float %.
}
```

Fixes #107034

@weliveindetail 
