### PR TITLE
[MC][AMDGPU] Support .reloc BFD_RELOC_{NONE,32,64}

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
@@ -163,12 +163,17 @@ void AMDGPUAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
 
 std::optional<MCFixupKind>
 AMDGPUAsmBackend::getFixupKind(StringRef Name) const {
-  return StringSwitch<std::optional<MCFixupKind>>(Name)
-#define ELF_RELOC(Name, Value)                                                 \
-  .Case(#Name, MCFixupKind(FirstLiteralRelocationKind + Value))
+  auto Type = StringSwitch<unsigned>(Name)
+#define ELF_RELOC(Name, Value) .Case(#Name, Value)
 #include "llvm/BinaryFormat/ELFRelocs/AMDGPU.def"
 #undef ELF_RELOC
-      .Default(std::nullopt);
+                  .Case("BFD_RELOC_NONE", ELF::R_AMDGPU_NONE)
+                  .Case("BFD_RELOC_32", ELF::R_AMDGPU_ABS32)
+                  .Case("BFD_RELOC_64", ELF::R_AMDGPU_ABS64)
+                  .Default(-1u);
+  if (Type != -1u)
+    return static_cast<MCFixupKind>(FirstLiteralRelocationKind + Type);
+  return std::nullopt;
 }
 
 const MCFixupKindInfo &AMDGPUAsmBackend::getFixupKindInfo(

--- a/llvm/test/MC/AMDGPU/reloc-directive.s
+++ b/llvm/test/MC/AMDGPU/reloc-directive.s
@@ -19,6 +19,9 @@
 # PRINT-NEXT: .reloc 0, R_AMDGPU_REL32_HI, .data
 # PRINT-NEXT: .reloc 0, R_AMDGPU_RELATIVE64, .data
 # PRINT-NEXT: .reloc 0, R_AMDGPU_REL16, .data
+# PRINT-NEXT: .reloc 0, BFD_RELOC_NONE, .data
+# PRINT-NEXT: .reloc 0, BFD_RELOC_32, .data
+# PRINT-NEXT: .reloc 0, BFD_RELOC_64, .data
 
 # CHECK:      0x2 R_AMDGPU_NONE .data
 # CHECK-NEXT: 0x1 R_AMDGPU_NONE foo 0x4
@@ -36,6 +39,9 @@
 # CHECK-NEXT: 0x0 R_AMDGPU_REL32_HI .data
 # CHECK-NEXT: 0x0 R_AMDGPU_RELATIVE64 .data
 # CHECK-NEXT: 0x0 R_AMDGPU_REL16 .data
+# CHECK-NEXT: 0x0 R_AMDGPU_NONE .data
+# CHECK-NEXT: 0x0 R_AMDGPU_ABS32 .data
+# CHECK-NEXT: 0x0 R_AMDGPU_ABS64 .data
 
 .text
   s_nop 0
@@ -56,6 +62,9 @@
   .reloc 0, R_AMDGPU_REL32_HI, .data
   .reloc 0, R_AMDGPU_RELATIVE64, .data
   .reloc 0, R_AMDGPU_REL16, .data
+  .reloc 0, BFD_RELOC_NONE, .data
+  .reloc 0, BFD_RELOC_32, .data
+  .reloc 0, BFD_RELOC_64, .data
 
 .data
 .globl foo


### PR DESCRIPTION
Emitting BFD_RELOC_* reloc directives can cause internal errors on AMDGPU.