### PR TITLE
[libc] disable failing include tests

### DIFF
--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -372,41 +372,42 @@ add_libc_test(
     libc.include.llvm-libc-macros.math_function_macros
 )
 
-add_libc_test(
-  issignaling_c_test
-  C_TEST
-  UNIT_TEST_ONLY
-  SUITE
-    libc_include_tests
-  SRCS
-    issignaling_test.c
-  COMPILE_OPTIONS
-    -Wall
-    -Werror
-  DEPENDS
-    libc.include.llvm-libc-macros.math_function_macros
-    libc.src.math.issignaling
-    libc.src.math.issignalingf
-    libc.src.math.issignalingl
-)
+# TODO(https://github.com/llvm/llvm-project/issues/114618): fix linkage failures
+# add_libc_test(
+#   issignaling_c_test
+#   C_TEST
+#   UNIT_TEST_ONLY
+#   SUITE
+#     libc_include_tests
+#   SRCS
+#     issignaling_test.c
+#   COMPILE_OPTIONS
+#     -Wall
+#     -Werror
+#   DEPENDS
+#     libc.include.llvm-libc-macros.math_function_macros
+#     libc.src.math.issignaling
+#     libc.src.math.issignalingf
+#     libc.src.math.issignalingl
+# )
 
-add_libc_test(
-  iscanonical_c_test
-  C_TEST
-  UNIT_TEST_ONLY
-  SUITE
-    libc_include_tests
-  SRCS
-    iscanonical_test.c
-  COMPILE_OPTIONS
-    -Wall
-    -Werror
-  DEPENDS
-    libc.include.llvm-libc-macros.math_function_macros
-    libc.src.math.iscanonical
-    libc.src.math.iscanonicalf
-    libc.src.math.iscanonicall
-)
+# add_libc_test(
+#   iscanonical_c_test
+#   C_TEST
+#   UNIT_TEST_ONLY
+#   SUITE
+#     libc_include_tests
+#   SRCS
+#     iscanonical_test.c
+#   COMPILE_OPTIONS
+#     -Wall
+#     -Werror
+#   DEPENDS
+#     libc.include.llvm-libc-macros.math_function_macros
+#     libc.src.math.iscanonical
+#     libc.src.math.iscanonicalf
+#     libc.src.math.iscanonicall
+# )
 
 add_libc_test(
   isinf_c_test


### PR DESCRIPTION
These are failing to link for some buildbots. It's not immediately clear why,
disable these and add a todo to investigate.

Link: #111403
Link: #114566
Link: #114618
