### PR TITLE
More refinement of call site handling in stepping.

### DIFF
--- a/lldb/source/Target/ThreadPlanStepRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepRange.cpp
@@ -379,10 +379,9 @@ bool ThreadPlanStepRange::SetNextBranchBreakpoint() {
             !m_next_branch_bp_sp->HasResolvedLocations())
           m_could_not_resolve_hw_bp = true;
 
+        BreakpointLocationSP bp_loc = m_next_branch_bp_sp->GetLocationAtIndex(0);
         if (log) {
           lldb::break_id_t bp_site_id = LLDB_INVALID_BREAK_ID;
-          BreakpointLocationSP bp_loc =
-              m_next_branch_bp_sp->GetLocationAtIndex(0);
           if (bp_loc) {
             BreakpointSiteSP bp_site = bp_loc->GetBreakpointSite();
             if (bp_site) {
@@ -395,7 +394,44 @@ bool ThreadPlanStepRange::SetNextBranchBreakpoint() {
                     m_next_branch_bp_sp->GetID(), bp_site_id,
                     run_to_address.GetLoadAddress(&m_process.GetTarget()));
         }
-
+        // The "next branch breakpoint might land on an virtual inlined call
+        // stack.  If that's true, we should always stop at the top of the
+        // inlined call stack.  Only virtual steps should walk deeper into the
+        // inlined call stack.
+        Block *block = run_to_address.CalculateSymbolContextBlock();
+        if (bp_loc && block) {
+          LineEntry top_most_line_entry;
+          lldb::addr_t run_to_addr = run_to_address.GetFileAddress();
+          for (Block *inlined_parent = block->GetContainingInlinedBlock(); inlined_parent;
+              inlined_parent = inlined_parent->GetInlinedParent()) {
+            AddressRange range;
+            if (!inlined_parent->GetRangeContainingAddress(run_to_address, range))
+               break;
+            Address range_start_address = range.GetBaseAddress();
+            // Only compare addresses here, we may have different symbol
+            // contexts (for virtual inlined stacks), but we just want to know
+            // that they are all at the same address.
+            if (range_start_address.GetFileAddress() != run_to_addr) 
+              break;
+            const InlineFunctionInfo *inline_info = inlined_parent->GetInlinedFunctionInfo();
+            if (!inline_info)
+              break;
+            const Declaration &call_site = inline_info->GetCallSite();
+            top_most_line_entry.line = call_site.GetLine();
+            top_most_line_entry.column = call_site.GetColumn();
+            FileSpec call_site_file_spec = call_site.GetFile();
+            top_most_line_entry.original_file_sp.reset(new SupportFile(call_site_file_spec));
+            top_most_line_entry.range = range;
+            top_most_line_entry.file_sp.reset();
+            top_most_line_entry.ApplyFileMappings(GetThread().CalculateTarget());
+            if (!top_most_line_entry.file_sp)
+              top_most_line_entry.file_sp = top_most_line_entry.original_file_sp;
+          }
+          if (top_most_line_entry.IsValid()) {
+            LLDB_LOG(log, "Setting preferred line entry: {0}:{1}", top_most_line_entry.GetFile(), top_most_line_entry.line);
+            bp_loc->SetPreferredLineEntry(top_most_line_entry);
+          }
+        }
         m_next_branch_bp_sp->SetThreadID(m_tid);
         m_next_branch_bp_sp->SetBreakpointKind("next-branch-location");
 

--- a/lldb/source/Target/ThreadPlanStepRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepRange.cpp
@@ -395,7 +395,7 @@ bool ThreadPlanStepRange::SetNextBranchBreakpoint() {
                     m_next_branch_bp_sp->GetID(), bp_site_id,
                     run_to_address.GetLoadAddress(&m_process.GetTarget()));
         }
-        // The "next branch breakpoint might land on an virtual inlined call
+        // The "next branch breakpoint might land on a virtual inlined call
         // stack.  If that's true, we should always stop at the top of the
         // inlined call stack.  Only virtual steps should walk deeper into the
         // inlined call stack.

--- a/lldb/source/Target/ThreadPlanStepRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepRange.cpp
@@ -379,7 +379,8 @@ bool ThreadPlanStepRange::SetNextBranchBreakpoint() {
             !m_next_branch_bp_sp->HasResolvedLocations())
           m_could_not_resolve_hw_bp = true;
 
-        BreakpointLocationSP bp_loc = m_next_branch_bp_sp->GetLocationAtIndex(0);
+        BreakpointLocationSP bp_loc =
+            m_next_branch_bp_sp->GetLocationAtIndex(0);
         if (log) {
           lldb::break_id_t bp_site_id = LLDB_INVALID_BREAK_ID;
           if (bp_loc) {
@@ -402,33 +403,40 @@ bool ThreadPlanStepRange::SetNextBranchBreakpoint() {
         if (bp_loc && block) {
           LineEntry top_most_line_entry;
           lldb::addr_t run_to_addr = run_to_address.GetFileAddress();
-          for (Block *inlined_parent = block->GetContainingInlinedBlock(); inlined_parent;
-              inlined_parent = inlined_parent->GetInlinedParent()) {
+          for (Block *inlined_parent = block->GetContainingInlinedBlock();
+               inlined_parent;
+               inlined_parent = inlined_parent->GetInlinedParent()) {
             AddressRange range;
-            if (!inlined_parent->GetRangeContainingAddress(run_to_address, range))
-               break;
+            if (!inlined_parent->GetRangeContainingAddress(run_to_address,
+                                                           range))
+              break;
             Address range_start_address = range.GetBaseAddress();
             // Only compare addresses here, we may have different symbol
             // contexts (for virtual inlined stacks), but we just want to know
             // that they are all at the same address.
-            if (range_start_address.GetFileAddress() != run_to_addr) 
+            if (range_start_address.GetFileAddress() != run_to_addr)
               break;
-            const InlineFunctionInfo *inline_info = inlined_parent->GetInlinedFunctionInfo();
+            const InlineFunctionInfo *inline_info =
+                inlined_parent->GetInlinedFunctionInfo();
             if (!inline_info)
               break;
             const Declaration &call_site = inline_info->GetCallSite();
             top_most_line_entry.line = call_site.GetLine();
             top_most_line_entry.column = call_site.GetColumn();
             FileSpec call_site_file_spec = call_site.GetFile();
-            top_most_line_entry.original_file_sp.reset(new SupportFile(call_site_file_spec));
+            top_most_line_entry.original_file_sp.reset(
+                new SupportFile(call_site_file_spec));
             top_most_line_entry.range = range;
             top_most_line_entry.file_sp.reset();
-            top_most_line_entry.ApplyFileMappings(GetThread().CalculateTarget());
+            top_most_line_entry.ApplyFileMappings(
+                GetThread().CalculateTarget());
             if (!top_most_line_entry.file_sp)
-              top_most_line_entry.file_sp = top_most_line_entry.original_file_sp;
+              top_most_line_entry.file_sp =
+                  top_most_line_entry.original_file_sp;
           }
           if (top_most_line_entry.IsValid()) {
-            LLDB_LOG(log, "Setting preferred line entry: {0}:{1}", top_most_line_entry.GetFile(), top_most_line_entry.line);
+            LLDB_LOG(log, "Setting preferred line entry: {0}:{1}",
+                     top_most_line_entry.GetFile(), top_most_line_entry.line);
             bp_loc->SetPreferredLineEntry(top_most_line_entry);
           }
         }

--- a/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
+++ b/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
@@ -13,7 +13,6 @@ class TestInlineStepping(TestBase):
         compiler="icc",
         bugnumber="# Not really a bug.  ICC combines two inlined functions.",
     )
-    @skipIf(oslist=["linux"], archs=["arm"])  # Fails for 32 bit arm
     def test_with_python_api(self):
         """Test stepping over and into inlined functions."""
         self.build()

--- a/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
+++ b/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
@@ -329,11 +329,11 @@ class TestInlineStepping(TestBase):
         self.thread.StepOver()
         frame_0 = self.thread.frames[0]
         line_entry = frame_0.line_entry
-        self.assertEqual(line_entry.file.basename, self.main_source_spec.basename, "File matches")
+        self.assertEqual(
+            line_entry.file.basename, self.main_source_spec.basename, "File matches"
+        )
         target_line = line_number("calling.cpp", "// At caller_trivial_inline_1")
         self.assertEqual(line_entry.line, target_line, "Lines match as well.")
-        
-        
 
     def step_in_template(self):
         """Use Python APIs to test stepping in to templated functions."""


### PR DESCRIPTION
When you set a "next branch breakpoint" and run to it while stepping, you have to claim the stop at that breakpoint to be the top of the inlined call stack, or you will seem to "step in" and then plans might try to step back out again.

This records the PrefferedLineEntry for next branch breakpoints and adds a test to make sure this works.