### PR TITLE
[DirectX] Fix broken dxil-dis tests after #106146

### DIFF
--- a/llvm/test/tools/dxil-dis/BasicIR.ll
+++ b/llvm/test/tools/dxil-dis/BasicIR.ll
@@ -2,7 +2,7 @@
 
 ; RUN: llc --filetype=obj %s --stop-after=dxil-write-bitcode -o %t && llvm-bcanalyzer --dump-blockinfo %t | FileCheck %s  --check-prefix=BLOCK_INFO
 
-; CHECK: define internal i32 @foo(i32 %X, i32 %Y) {
+; CHECK: define i32 @foo(i32 %X, i32 %Y) {
 ; CHECK:   %Z = sub i32 %X, %Y
 ; CHECK:   %Q = add i32 %Z, %Y
 ; CHECK:   ret i32 %Q
@@ -17,7 +17,7 @@
 
 target triple = "dxil-unknown-shadermodel6.7-library"
 
-define i32 @foo(i32 %X, i32 %Y) {
+define i32 @foo(i32 %X, i32 %Y) "hlsl.export" {
   %Z = sub i32 %X, %Y
   %Q = add i32 %Z, %Y
   ret i32 %Q

--- a/llvm/test/tools/dxil-dis/attribute-filter.ll
+++ b/llvm/test/tools/dxil-dis/attribute-filter.ll
@@ -4,7 +4,6 @@
 target triple = "dxil-unknown-shadermodel6.7-library"
 
 ; CHECK: Function Attrs: nounwind readnone
-; Function Attrs: norecurse nounwind readnone willreturn
 define float @fma(float %0, float %1, float %2) #0 {
   %4 = fmul float %0, %1
   %5 = fadd float %4, %2
@@ -12,7 +11,6 @@ define float @fma(float %0, float %1, float %2) #0 {
 }
 
 ; CHECK: Function Attrs: readnone
-; Function Attrs: norecurse readnone willreturn
 define float @fma2(float %0, float %1, float %2) #1 {
   %4 = fmul float %0, %1
   %5 = fadd float %4, %2
@@ -20,7 +18,7 @@ define float @fma2(float %0, float %1, float %2) #1 {
 }
 
 ; CHECK: attributes #0 = { nounwind readnone "fp32-denorm-mode"="any" "waveops-include-helper-lanes" }
-attributes #0 = { norecurse nounwind readnone willreturn "disable-tail-calls"="false" "waveops-include-helper-lanes" "fp32-denorm-mode"="any" }
+attributes #0 = { norecurse nounwind readnone willreturn "disable-tail-calls"="false" "waveops-include-helper-lanes" "fp32-denorm-mode"="any" "hlsl.export" }
 
 ; CHECK: attributes #1 = { readnone "fp32-denorm-mode"="ftz" "waveops-include-helper-lanes" }
-attributes #1 = { norecurse memory(none) willreturn "disable-tail-calls"="false" "waveops-include-helper-lanes" "fp32-denorm-mode"="ftz" }
+attributes #1 = { norecurse memory(none) willreturn "disable-tail-calls"="false" "waveops-include-helper-lanes" "fp32-denorm-mode"="ftz" "hlsl.export" }

--- a/llvm/test/tools/dxil-dis/debug-info.ll
+++ b/llvm/test/tools/dxil-dis/debug-info.ll
@@ -2,8 +2,7 @@
 target triple = "dxil-unknown-shadermodel6.7-library"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 
-; CHECK: define internal float @fma(float, float, float) unnamed_addr #0 !dbg [[Fn:[!][0-9]+]]
-; Function Attrs: norecurse nounwind readnone willreturn
+; CHECK: define float @fma(float, float, float) unnamed_addr #0 !dbg [[Fn:[!][0-9]+]]
 define dso_local float @fma(float %0, float %1, float %2) local_unnamed_addr #0 !dbg !6 {
 ; CHECK-NEXT: call void @llvm.dbg.value(metadata float %0, metadata [[VarX:[!][0-9]+]], metadata [[Expr:[!][0-9]+]]), !dbg [[Line1:[!][0-9]+]]
 ; CHECK-NEXT: call void @llvm.dbg.value(metadata float %1, metadata [[VarY:[!][0-9]+]], metadata [[Expr]]), !dbg [[Line1]]
@@ -18,11 +17,7 @@ define dso_local float @fma(float %0, float %1, float %2) local_unnamed_addr #0 
   ret float %5, !dbg !17
 }
 
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare void @llvm.dbg.value(metadata, metadata, metadata) #1
-
-attributes #0 = { norecurse nounwind readnone willreturn }
-attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #0 = { norecurse nounwind readnone willreturn "hlsl.export" }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}

--- a/llvm/test/tools/dxil-dis/opaque-gep.ll
+++ b/llvm/test/tools/dxil-dis/opaque-gep.ll
@@ -1,22 +1,24 @@
 ; RUN: llc --filetype=obj %s -o - | dxil-dis -o - | FileCheck %s
 target triple = "dxil-unknown-shadermodel6.7-library"
 
-define i32 @fn(ptr %0)  {
+define i32 @fn(ptr %0) #0 {
   %2 = getelementptr i32, ptr %0, i32 4
   %3 = load i32, ptr %2
   ret i32 %3
 }
 
-; CHECK:        define internal i32 @fn(i32*)
+; CHECK:        define i32 @fn(i32*)
 ; CHECK-NEXT:   %2 = getelementptr i32, i32* %0, i32 4
 ; CHECK-NEXT:   %3 = load i32, i32* %2, align 4
 
-define i32 @fn2(ptr addrspace(1) %0)  {
+define i32 @fn2(ptr addrspace(1) %0) #0 {
   %2 = getelementptr i32, ptr addrspace(1) %0, i32 4
   %3 = load i32, ptr addrspace(1) %2
   ret i32 %3
 }
 
-; CHECK:        define internal i32 @fn2(i32 addrspace(1)*)
+; CHECK:        define i32 @fn2(i32 addrspace(1)*)
 ; CHECK-NEXT:   %2 = getelementptr i32, i32 addrspace(1)* %0, i32 4
 ; CHECK-NEXT:   %3 = load i32, i32 addrspace(1)* %2, align 4
+
+attributes #0 = { "hlsl.export" }

--- a/llvm/test/tools/dxil-dis/opaque-pointers.ll
+++ b/llvm/test/tools/dxil-dis/opaque-pointers.ll
@@ -1,59 +1,61 @@
 ; RUN: llc --filetype=obj %s -o - | dxil-dis -o - | FileCheck %s
 target triple = "dxil-unknown-shadermodel6.7-library"
 
-define i64 @test(ptr %p) {
+define i64 @test(ptr %p) #0 {
   store i32 0, ptr %p
   %v = load i64, ptr %p
   ret i64 %v
 }
 
-; CHECK: define internal i64 @test(i8* %p) {
+; CHECK: define i64 @test(i8* %p) {
 ; CHECK-NEXT: %1 = bitcast i8* %p to i32*
 ; CHECK-NEXT: store i32 0, i32* %1, align 4
 ; CHECK-NEXT: %2 = bitcast i8* %p to i64*
 ; CHECK-NEXT: %3 = load i64, i64* %2, align 8
 
-define i64 @test2(ptr %p) {
+define i64 @test2(ptr %p) #0 {
   store i64 0, ptr %p
   %v = load i64, ptr %p
   ret i64 %v
 }
 
-; CHECK: define internal i64 @test2(i64* %p) {
+; CHECK: define i64 @test2(i64* %p) {
 ; CHECK-NEXT: store i64 0, i64* %p, align 8
 ; CHECK-NEXT: %v = load i64, i64* %p, align 8
 
-define i64 @test3(ptr addrspace(1) %p) {
+define i64 @test3(ptr addrspace(1) %p) #0 {
   store i32 0, ptr addrspace(1) %p
   %v = load i64, ptr addrspace(1) %p
   ret i64 %v
 }
 
-; CHECK: define internal i64 @test3(i8 addrspace(1)* %p) {
+; CHECK: define i64 @test3(i8 addrspace(1)* %p) {
 ; CHECK-NEXT: %1 = bitcast i8 addrspace(1)* %p to i32 addrspace(1)*
 ; CHECK-NEXT: store i32 0, i32 addrspace(1)* %1, align 4
 ; CHECK-NEXT: %2 = bitcast i8 addrspace(1)* %p to i64 addrspace(1)*
 ; CHECK-NEXT: %3 = load i64, i64 addrspace(1)* %2, align 8
 
-define i64 @test4(ptr addrspace(1) %p) {
+define i64 @test4(ptr addrspace(1) %p) #0 {
   store i64 0, ptr addrspace(1) %p
   %v = load i64, ptr addrspace(1) %p
   ret i64 %v
 }
 
-; CHECK: define internal i64 @test4(i64 addrspace(1)* %p) {
+; CHECK: define i64 @test4(i64 addrspace(1)* %p) {
 ; CHECK-NEXT: store i64 0, i64 addrspace(1)* %p, align 8
 ; CHECK-NEXT: %v = load i64, i64 addrspace(1)* %p, align 8
 
 
-define i64 @test5(ptr %p) {
+define i64 @test5(ptr %p) #0 {
   %casted = addrspacecast ptr %p to ptr addrspace(1)
   store i64 0, ptr addrspace(1) %casted
   %v = load i64, ptr addrspace(1) %casted
   ret i64 %v
 }
 
-; CHECK: define internal i64 @test5(i8* %p) {
+; CHECK: define i64 @test5(i8* %p) {
 ; CHECK-NEXT: %casted = addrspacecast i8* %p to i64 addrspace(1)*
 ; CHECK-NEXT: store i64 0, i64 addrspace(1)* %casted, align 8
 ; CHECK-NEXT: %v = load i64, i64 addrspace(1)* %casted, align 8
+
+attributes #0 = { "hlsl.export" }

--- a/llvm/test/tools/dxil-dis/opaque-value_as_metadata.ll
+++ b/llvm/test/tools/dxil-dis/opaque-value_as_metadata.ll
@@ -6,9 +6,11 @@ target triple = "dxil-unknown-shadermodel6.7-library"
 
 @CBV = external constant %"$Globals"
 
-define void @main() {
+define void @main() #0 {
   ret void
 }
+
+attributes #0 = { "hlsl.export" }
 
 !llvm.ident = !{!0}
 !dx.version = !{!1}

--- a/llvm/test/tools/dxil-dis/shuffle.ll
+++ b/llvm/test/tools/dxil-dis/shuffle.ll
@@ -7,7 +7,6 @@ target triple = "dxil-unknown-shadermodel6.7-library"
 ; Make sure shufflevector works for DXIL bitcode writer.
 ; CHECK:shufflevector <2 x float> %{{.*}}, <2 x float> undef, <2 x i32> <i32 1, i32 0>
 
-; Function Attrs: noinline nounwind optnone
 define noundef <2 x float> @foo(<2 x float> noundef %a) #0 {
 entry:
   %a.addr = alloca <2 x float>, align 8
@@ -17,7 +16,7 @@ entry:
   ret <2 x float> %1
 }
 
-attributes #0 = { noinline nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="64" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #0 = { noinline nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="64" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "hlsl.export" }
 
 !llvm.module.flags = !{!0, !1, !3}
 


### PR DESCRIPTION
In ab7518050183 "[DirectX] Remove trivially dead functions at linkage finalize (#106146)" we updated the compiler to remove DXIL functions that aren't marked with the "hlsl.export" attribute, but it seems we forgot to add this attribute to the tests in `tools/dxil-dis`.