### PR TITLE
[SPIRV] Fix assert in `getOrCreateBaseRegister` for `i32 -1`

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -400,7 +400,7 @@ Register SPIRVGlobalRegistry::getOrCreateBaseRegister(
   }
   assert(Type->getOpcode() == SPIRV::OpTypeInt);
   SPIRVType *SpvBaseType = getOrCreateSPIRVIntegerType(BitWidth, I, TII);
-  return getOrCreateConstInt(Val->getUniqueInteger().getSExtValue(), I,
+  return getOrCreateConstInt(Val->getUniqueInteger().getZExtValue(), I,
                              SpvBaseType, TII, ZeroAsNull);
 }
 


### PR DESCRIPTION
When trying to create a const inst from a 32 bit signed value, we don't want to sign-extend it to 64 bits, as the resulting value won't actually fit in an `i32` if it was negative.

This fixes crashes in the following two tests after the APInt constructor asserts were enabled in #114539:
```
Failed Tests (2):
  LLVM :: CodeGen/SPIRV/transcoding/RelationalOperators.ll
  LLVM :: CodeGen/SPIRV/uitofp-with-bool.ll
```