### PR TITLE
AMDGPU: Fix broken frame index expansion for v_add_co_u32_e64

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -2607,7 +2607,7 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
           MI->removeOperand(FIOperandNum);
 
           unsigned NumOps = MI->getNumOperands();
-          for (unsigned I = NumOps - 2; I >= 2; --I)
+          for (unsigned I = NumOps - 2; I >= NumDefs + 1; --I)
             MI->removeOperand(I);
 
           if (NumDefs == 2)

--- a/llvm/test/CodeGen/AMDGPU/eliminate-frame-index-v-add-co-u32.mir
+++ b/llvm/test/CodeGen/AMDGPU/eliminate-frame-index-v-add-co-u32.mir
@@ -1661,3 +1661,170 @@ body:             |
     SI_RETURN implicit $vgpr0
 
 ...
+
+---
+name: v_add_co_u32_e64__fi_sgpr_kernel
+tracksRegLiveness: true
+stack:
+  - { id: 0, size: 20, alignment: 4 }
+machineFunctionInfo:
+  scratchRSrcReg:  '$sgpr0_sgpr1_sgpr2_sgpr3'
+  frameOffsetReg:  '$sgpr33'
+  stackPtrOffsetReg: '$sgpr32'
+  isEntryFunction: true
+body:             |
+  bb.0:
+    liveins: $sgpr4
+
+    ; MUBUFW64-LABEL: name: v_add_co_u32_e64__fi_sgpr_kernel
+    ; MUBUFW64: liveins: $sgpr4, $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: {{  $}}
+    ; MUBUFW64-NEXT: $sgpr0 = S_ADD_U32 $sgpr0, $noreg, implicit-def $scc, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: $sgpr1 = S_ADDC_U32 $sgpr1, 0, implicit-def dead $scc, implicit $scc, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: renamable $vgpr0 = V_MOV_B32_e32 killed $sgpr4, implicit $exec
+    ; MUBUFW64-NEXT: SI_RETURN implicit $vgpr0
+    ;
+    ; FLATSCRW64-LABEL: name: v_add_co_u32_e64__fi_sgpr_kernel
+    ; FLATSCRW64: liveins: $sgpr4
+    ; FLATSCRW64-NEXT: {{  $}}
+    ; FLATSCRW64-NEXT: renamable $vgpr0 = V_MOV_B32_e32 killed $sgpr4, implicit $exec
+    ; FLATSCRW64-NEXT: SI_RETURN implicit $vgpr0
+    renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 %stack.0, killed $sgpr4, 0, implicit $exec
+    SI_RETURN implicit $vgpr0
+
+...
+
+---
+name: v_add_co_u32_e64__fi_sgpr_func
+tracksRegLiveness: true
+stack:
+  - { id: 0, size: 20, alignment: 4 }
+machineFunctionInfo:
+  scratchRSrcReg:  '$sgpr0_sgpr1_sgpr2_sgpr3'
+  frameOffsetReg:  '$sgpr33'
+  stackPtrOffsetReg: '$sgpr32'
+body:             |
+  bb.0:
+    liveins: $sgpr4
+
+    ; MUBUFW64-LABEL: name: v_add_co_u32_e64__fi_sgpr_func
+    ; MUBUFW64: liveins: $sgpr4
+    ; MUBUFW64-NEXT: {{  $}}
+    ; MUBUFW64-NEXT: renamable $vgpr1 = V_LSHRREV_B32_e64 6, $sgpr32, implicit $exec
+    ; MUBUFW64-NEXT: renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 killed $sgpr4, killed $vgpr1, 0, implicit $exec
+    ; MUBUFW64-NEXT: SI_RETURN implicit $vgpr0
+    ;
+    ; GFX940-LABEL: name: v_add_co_u32_e64__fi_sgpr_func
+    ; GFX940: liveins: $sgpr4
+    ; GFX940-NEXT: {{  $}}
+    ; GFX940-NEXT: $vgpr1 = V_MOV_B32_e32 $sgpr32, implicit $exec
+    ; GFX940-NEXT: renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 killed $sgpr4, killed $vgpr1, 0, implicit $exec
+    ; GFX940-NEXT: SI_RETURN implicit $vgpr0
+    ;
+    ; GFX11-LABEL: name: v_add_co_u32_e64__fi_sgpr_func
+    ; GFX11: liveins: $sgpr4
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 $sgpr32, killed $sgpr4, 0, implicit $exec
+    ; GFX11-NEXT: SI_RETURN implicit $vgpr0
+    ;
+    ; GFX12-LABEL: name: v_add_co_u32_e64__fi_sgpr_func
+    ; GFX12: liveins: $sgpr4
+    ; GFX12-NEXT: {{  $}}
+    ; GFX12-NEXT: renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 $sgpr32, killed $sgpr4, 0, implicit $exec
+    ; GFX12-NEXT: SI_RETURN implicit $vgpr0
+    renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 %stack.0, killed $sgpr4, 0, implicit $exec
+    SI_RETURN implicit $vgpr0
+
+...
+
+---
+name: v_add_co_u32_e64__fi_inc_same_vgpr_kernel
+tracksRegLiveness: true
+stack:
+  - { id: 0, size: 20, alignment: 4 }
+machineFunctionInfo:
+  scratchRSrcReg:  '$sgpr0_sgpr1_sgpr2_sgpr3'
+  frameOffsetReg:  '$sgpr33'
+  stackPtrOffsetReg: '$sgpr32'
+  isEntryFunction: true
+body:             |
+  bb.0:
+    liveins: $vgpr0
+
+    ; MUBUFW64-LABEL: name: v_add_co_u32_e64__fi_inc_same_vgpr_kernel
+    ; MUBUFW64: liveins: $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: {{  $}}
+    ; MUBUFW64-NEXT: $sgpr0 = S_ADD_U32 $sgpr0, $noreg, implicit-def $scc, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: $sgpr1 = S_ADDC_U32 $sgpr1, 0, implicit-def dead $scc, implicit $scc, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: SI_RETURN implicit $vgpr0
+    ;
+    ; FLATSCRW64-LABEL: name: v_add_co_u32_e64__fi_inc_same_vgpr_kernel
+    ; FLATSCRW64: liveins: $vgpr0
+    ; FLATSCRW64-NEXT: {{  $}}
+    ; FLATSCRW64-NEXT: SI_RETURN implicit $vgpr0
+    renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 %stack.0, killed $vgpr0, 0, implicit $exec
+    SI_RETURN implicit $vgpr0
+
+...
+
+---
+name: v_add_co_u32_e64__fi_inc_same_vgpr_func
+tracksRegLiveness: true
+stack:
+  - { id: 0, size: 20, alignment: 4 }
+machineFunctionInfo:
+  scratchRSrcReg:  '$sgpr0_sgpr1_sgpr2_sgpr3'
+  frameOffsetReg:  '$sgpr33'
+  stackPtrOffsetReg: '$sgpr32'
+body:             |
+  bb.0:
+    liveins: $vgpr0
+
+    ; MUBUFW64-LABEL: name: v_add_co_u32_e64__fi_inc_same_vgpr_func
+    ; MUBUFW64: liveins: $vgpr0
+    ; MUBUFW64-NEXT: {{  $}}
+    ; MUBUFW64-NEXT: renamable $vgpr1 = V_LSHRREV_B32_e64 6, $sgpr32, implicit $exec
+    ; MUBUFW64-NEXT: renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 killed $vgpr0, killed $vgpr1, 0, implicit $exec
+    ; MUBUFW64-NEXT: SI_RETURN implicit $vgpr0
+    ;
+    ; FLATSCRW64-LABEL: name: v_add_co_u32_e64__fi_inc_same_vgpr_func
+    ; FLATSCRW64: liveins: $vgpr0
+    ; FLATSCRW64-NEXT: {{  $}}
+    ; FLATSCRW64-NEXT: renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 $sgpr32, killed $vgpr0, 0, implicit $exec
+    ; FLATSCRW64-NEXT: SI_RETURN implicit $vgpr0
+    renamable $vgpr0, dead renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 %stack.0, killed $vgpr0, 0, implicit $exec
+    SI_RETURN implicit $vgpr0
+
+...
+
+---
+name: v_add_co_u32_e64__fi_sgpr_kernel_live_co
+tracksRegLiveness: true
+stack:
+  - { id: 0, size: 20, alignment: 4 }
+machineFunctionInfo:
+  scratchRSrcReg:  '$sgpr0_sgpr1_sgpr2_sgpr3'
+  frameOffsetReg:  '$sgpr33'
+  stackPtrOffsetReg: '$sgpr32'
+  isEntryFunction: true
+body:             |
+  bb.0:
+    liveins: $sgpr4
+
+    ; MUBUFW64-LABEL: name: v_add_co_u32_e64__fi_sgpr_kernel_live_co
+    ; MUBUFW64: liveins: $sgpr4, $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: {{  $}}
+    ; MUBUFW64-NEXT: $sgpr0 = S_ADD_U32 $sgpr0, $noreg, implicit-def $scc, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: $sgpr1 = S_ADDC_U32 $sgpr1, 0, implicit-def dead $scc, implicit $scc, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3
+    ; MUBUFW64-NEXT: renamable $vgpr0, renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 0, killed $sgpr4, 0, implicit $exec
+    ; MUBUFW64-NEXT: SI_RETURN implicit $vgpr0, implicit $sgpr4_sgpr5
+    ;
+    ; FLATSCRW64-LABEL: name: v_add_co_u32_e64__fi_sgpr_kernel_live_co
+    ; FLATSCRW64: liveins: $sgpr4
+    ; FLATSCRW64-NEXT: {{  $}}
+    ; FLATSCRW64-NEXT: renamable $vgpr0, renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 0, killed $sgpr4, 0, implicit $exec
+    ; FLATSCRW64-NEXT: SI_RETURN implicit $vgpr0, implicit $sgpr4_sgpr5
+    renamable $vgpr0, renamable $sgpr4_sgpr5 = V_ADD_CO_U32_e64 %stack.0, killed $sgpr4, 0, implicit $exec
+    SI_RETURN implicit $vgpr0, implicit $sgpr4_sgpr5
+
+...


### PR DESCRIPTION
With an explicit carry out operand, one too many operands were deleted
resulting in a malformed v_mov_b32.