### PR TITLE
Update clang static analyzers per rename of member functions in CanMakeCheckedPtr.

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -3459,8 +3459,8 @@ Raw pointers and references to an object which supports CheckedPtr or CheckedRef
 .. code-block:: cpp
 
  struct CheckableObj {
-   void incrementPtrCount() {}
-   void decrementPtrCount() {}
+   void incrementCheckedPtrCount() {}
+   void decrementCheckedPtrCount() {}
  };
 
  struct Foo {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -108,7 +108,7 @@ std::optional<bool> isRefCountable(const clang::CXXRecordDecl *R) {
 }
 
 std::optional<bool> isCheckedPtrCapable(const clang::CXXRecordDecl *R) {
-  return isSmartPtrCompatible(R, "incrementPtrCount", "decrementPtrCount");
+  return isSmartPtrCompatible(R, "incrementCheckedPtrCount", "decrementCheckedPtrCount");
 }
 
 bool isRefType(const std::string &Name) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -108,7 +108,8 @@ std::optional<bool> isRefCountable(const clang::CXXRecordDecl *R) {
 }
 
 std::optional<bool> isCheckedPtrCapable(const clang::CXXRecordDecl *R) {
-  return isSmartPtrCompatible(R, "incrementCheckedPtrCount", "decrementCheckedPtrCount");
+  return isSmartPtrCompatible(R, "incrementCheckedPtrCount",
+                              "decrementCheckedPtrCount");
 }
 
 bool isRefType(const std::string &Name) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedCallArgsChecker.cpp
@@ -96,7 +96,8 @@ public:
           auto name = safeGetName(MD);
           if (name == "ref" || name == "deref")
             return;
-          if (name == "incrementPtrCount" || name == "decrementPtrCount")
+          if (name == "incrementCheckedPtrCount" ||
+              name == "decrementCheckedPtrCount")
             return;
         }
         auto *E = MemberCallExpr->getImplicitObjectArgument();

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -146,9 +146,9 @@ private:
 
 public:
   CheckedRef() : t{} {};
-  CheckedRef(T &t) : t(&t) { t.incrementPtrCount(); }
-  CheckedRef(const CheckedRef &o) : t(o.t) { if (t) t->incrementPtrCount(); }
-  ~CheckedRef() { if (t) t->decrementPtrCount(); }
+  CheckedRef(T &t) : t(&t) { t.incrementCheckedPtrCount(); }
+  CheckedRef(const CheckedRef &o) : t(o.t) { if (t) t->incrementCheckedPtrCount(); }
+  ~CheckedRef() { if (t) t->decrementCheckedPtrCount(); }
   T &get() { return *t; }
   T *ptr() { return t; }
   T *operator->() { return t; }
@@ -165,14 +165,14 @@ public:
   CheckedPtr(T *t)
     : t(t) {
     if (t)
-      t->incrementPtrCount();
+      t->incrementCheckedPtrCount();
   }
   CheckedPtr(Ref<T> &&o)
     : t(o.leakRef())
   { }
   ~CheckedPtr() {
     if (t)
-      t->decrementPtrCount();
+      t->decrementCheckedPtrCount();
   }
   T *get() { return t; }
   T *operator->() { return t; }
@@ -184,16 +184,16 @@ public:
 
 class CheckedObj {
 public:
-  void incrementPtrCount();
-  void decrementPtrCount();
+  void incrementCheckedPtrCount();
+  void decrementCheckedPtrCount();
   void method();
   int trivial() { return 123; }
 };
 
 class RefCountableAndCheckable {
 public:
-  void incrementPtrCount() const;
-  void decrementPtrCount() const;
+  void incrementCheckedPtrCount() const;
+  void decrementCheckedPtrCount() const;
   void ref() const;
   void deref() const;
   void method();


### PR DESCRIPTION
The member functions that define CheckedPtr capable type is incrementCheckedPtrCount and decrementCheckedPtrCount after the rename.