### PR TITLE
[clang][docs] Revise documentation for `__builtin_reduce_(max|min)`.

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -745,12 +745,8 @@ Let ``VT`` be a vector type and ``ET`` the element type of ``VT``.
 ======================================= ====================================================================== ==================================
          Name                            Operation                                                              Supported element types
 ======================================= ====================================================================== ==================================
- ET __builtin_reduce_max(VT a)           return x or y, whichever is larger; If exactly one argument is         integer and floating point types
-                                         a NaN, return the other argument. If both arguments are NaNs,
-                                         fmax() return a NaN.
- ET __builtin_reduce_min(VT a)           return x or y, whichever is smaller; If exactly one argument           integer and floating point types
-                                         is a NaN, return the other argument. If both arguments are
-                                         NaNs, fmax() return a NaN.
+ ET __builtin_reduce_max(VT a)           return the largest element of the vector.                              integer and floating point types
+ ET __builtin_reduce_min(VT a)           return the smallest element of the vector.                             integer and floating point types
  ET __builtin_reduce_add(VT a)           \+                                                                     integer types
  ET __builtin_reduce_mul(VT a)           \*                                                                     integer types
  ET __builtin_reduce_and(VT a)           &                                                                      integer types

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -745,8 +745,12 @@ Let ``VT`` be a vector type and ``ET`` the element type of ``VT``.
 ======================================= ====================================================================== ==================================
          Name                            Operation                                                              Supported element types
 ======================================= ====================================================================== ==================================
- ET __builtin_reduce_max(VT a)           return the largest element of the vector.                              integer and floating point types
- ET __builtin_reduce_min(VT a)           return the smallest element of the vector.                             integer and floating point types
+ ET __builtin_reduce_max(VT a)           return the largest element of the vector. If the element type is       integer and floating point types
+                                         floating point, this function has the same comparison semantics as 
+                                         ``__builtin_reduce_maximum``.
+ ET __builtin_reduce_min(VT a)           return the smallest element of the vector. If the element type is      integer and floating point types
+                                         floating point, this function has the same comparison semantics as 
+                                         ``__builtin_reduce_minimum``.
  ET __builtin_reduce_add(VT a)           \+                                                                     integer types
  ET __builtin_reduce_mul(VT a)           \*                                                                     integer types
  ET __builtin_reduce_and(VT a)           &                                                                      integer types

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -745,12 +745,10 @@ Let ``VT`` be a vector type and ``ET`` the element type of ``VT``.
 ======================================= ====================================================================== ==================================
          Name                            Operation                                                              Supported element types
 ======================================= ====================================================================== ==================================
- ET __builtin_reduce_max(VT a)           return the largest element of the vector. If the element type is       integer and floating point types
-                                         floating point, this function has the same comparison semantics as 
-                                         ``__builtin_reduce_maximum``.
- ET __builtin_reduce_min(VT a)           return the smallest element of the vector. If the element type is      integer and floating point types
-                                         floating point, this function has the same comparison semantics as 
-                                         ``__builtin_reduce_minimum``.
+ ET __builtin_reduce_max(VT a)           return the largest element of the vector. The result will always be    integer and floating point types
+                                         a number unless all elements of the vector are NaN.
+ ET __builtin_reduce_min(VT a)           return the smallest element of the vector. The result will always be   integer and floating point types
+                                         a number unless all elements of the vector are NaN.
  ET __builtin_reduce_add(VT a)           \+                                                                     integer types
  ET __builtin_reduce_mul(VT a)           \*                                                                     integer types
  ET __builtin_reduce_and(VT a)           &                                                                      integer types

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -745,10 +745,10 @@ Let ``VT`` be a vector type and ``ET`` the element type of ``VT``.
 ======================================= ====================================================================== ==================================
          Name                            Operation                                                              Supported element types
 ======================================= ====================================================================== ==================================
- ET __builtin_reduce_max(VT a)           return the largest element of the vector. The result will always be    integer and floating point types
-                                         a number unless all elements of the vector are NaN.
- ET __builtin_reduce_min(VT a)           return the smallest element of the vector. The result will always be   integer and floating point types
-                                         a number unless all elements of the vector are NaN.
+ ET __builtin_reduce_max(VT a)           return the largest element of the vector. The floating point result    integer and floating point types
+                                         will always be a number unless all elements of the vector are NaN.
+ ET __builtin_reduce_min(VT a)           return the smallest element of the vector. The floating point result   integer and floating point types
+                                         will always be a number unless all elements of the vector are NaN.
  ET __builtin_reduce_add(VT a)           \+                                                                     integer types
  ET __builtin_reduce_mul(VT a)           \*                                                                     integer types
  ET __builtin_reduce_and(VT a)           &                                                                      integer types


### PR DESCRIPTION
The function operation described in the document did not match its actual semantic meaning, this patch resolved the problem.