### PR TITLE
[libc] Define away __restrict in C++ without GNU extensions

### DIFF
--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -17,6 +17,12 @@
 #undef __END_C_DECLS
 #define __END_C_DECLS }
 
+// Standard C++ doesn't have C99 restrict but GNU C++ has it with __ spelling.
+#undef __restrict
+#ifndef __GNUC__
+#define __restrict
+#endif
+
 #undef _Noreturn
 #define _Noreturn [[noreturn]]
 


### PR DESCRIPTION
The C99 restrict keyword is spelled __restrict in the libc
headers so it can be parsed by C++ compilers with GNU extensions
that recognize it.  When GNU extensions are not available in C++
