### PR TITLE
[libc++] Simplify aligned_storage

### DIFF
--- a/libcxx/include/__type_traits/aligned_storage.h
+++ b/libcxx/include/__type_traits/aligned_storage.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__cstddef/size_t.h>
-#include <__type_traits/conditional.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/nat.h>
 #include <__type_traits/type_list.h>
@@ -50,22 +49,6 @@ typedef __type_list<__align_type<unsigned char>,
         > > > > > > > > > > __all_types;
 // clang-format on
 
-template <size_t _Align>
-struct _ALIGNAS(_Align) __fallback_overaligned {};
-
-template <class _TL, size_t _Align>
-struct __find_pod;
-
-template <class _Hp, size_t _Align>
-struct __find_pod<__type_list<_Hp, __nat>, _Align> {
-  typedef __conditional_t<_Align == _Hp::value, typename _Hp::type, __fallback_overaligned<_Align> > type;
-};
-
-template <class _Hp, class _Tp, size_t _Align>
-struct __find_pod<__type_list<_Hp, _Tp>, _Align> {
-  typedef __conditional_t<_Align == _Hp::value, typename _Hp::type, typename __find_pod<_Tp, _Align>::type> type;
-};
-
 template <class _TL, size_t _Len>
 struct __find_max_align;
 
@@ -88,9 +71,7 @@ struct __find_max_align<__type_list<_Hp, _Tp>, _Len>
 
 template <size_t _Len, size_t _Align = __find_max_align<__all_types, _Len>::value>
 struct _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_TEMPLATE_VIS aligned_storage {
-  typedef typename __find_pod<__all_types, _Align>::type _Aligner;
-  union type {
-    _Aligner __align;
+  union _ALIGNAS(_Align) type {
     unsigned char __data[(_Len + _Align - 1) / _Align * _Align];
   };
 };
@@ -103,35 +84,6 @@ using aligned_storage_t _LIBCPP_DEPRECATED_IN_CXX23 = typename aligned_storage<_
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 
 #endif
-
-#define _CREATE_ALIGNED_STORAGE_SPECIALIZATION(n)                                                                      \
-  template <size_t _Len>                                                                                               \
-  struct _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_TEMPLATE_VIS aligned_storage<_Len, n> {                                   \
-    struct _ALIGNAS(n) type {                                                                                          \
-      unsigned char __lx[(_Len + n - 1) / n * n];                                                                      \
-    };                                                                                                                 \
-  }
-
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x1);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x2);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x4);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x8);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x10);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x20);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x40);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x80);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x100);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x200);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x400);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x800);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x1000);
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x2000);
-// PE/COFF does not support alignment beyond 8192 (=0x2000)
-#if !defined(_LIBCPP_OBJECT_FORMAT_COFF)
-_CREATE_ALIGNED_STORAGE_SPECIALIZATION(0x4000);
-#endif // !defined(_LIBCPP_OBJECT_FORMAT_COFF)
-
-#undef _CREATE_ALIGNED_STORAGE_SPECIALIZATION
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
The main template of `aligned_storage` is only ever used when we have extremely overaligned types (> 16384), so we effectively only ever use the specializations currently. This means that we only instantiate the main template for overaligned types. Instead of doing this dance, we can just define the main template to use `_ALIGNAS`, just like the specializations. This makes the implementation of `aligned_storage` significantly less confusing.
