### PR TITLE
[OpenMP][test] Regression tests for OpenMPIRBuilder.

### DIFF
--- a/openmp/runtime/test/atomic/kmp_atomic_cas.c
+++ b/openmp/runtime/test/atomic/kmp_atomic_cas.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/openmp/runtime/test/atomic/kmp_atomic_cas_cpt.c
+++ b/openmp/runtime/test/atomic/kmp_atomic_cas_cpt.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/openmp/runtime/test/atomic/omp_atomic.c
+++ b/openmp/runtime/test/atomic/omp_atomic.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include <math.h>
 #include "omp_testsuite.h"

--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import lit.formats
+import shlex
 
 # Tell pylint that we know config and lit_config exist somewhere.
 if 'PYLINT_IMPORT' in os.environ:
@@ -47,6 +48,9 @@ flags = " -I " + config.test_source_root + \
     " " + config.test_extra_flags
 config.test_flags = " -I " + config.omp_header_directory + flags
 config.test_flags_use_compiler_omp_h = flags
+
+if "-fopenmp-enable-irbuilder" in (shlex.split(config.test_openmp_flags) + shlex.split(config.test_flags)):
+    config.available_features.add("irbuilder")
 
 # extra libraries
 libs = ""

--- a/openmp/runtime/test/lock/omp_lock.c
+++ b/openmp/runtime/test/lock/omp_lock.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run
 // RUN: env KMP_LOCK_KIND=tas KMP_SPIN_BACKOFF_PARAMS=2048,200 %libomp-run
 // RUN: env KMP_LOCK_KIND=futex %libomp-run
+// UNSUPPORTED: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/lock/omp_nest_lock.c
+++ b/openmp/runtime/test/lock/omp_nest_lock.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/lock/omp_test_lock.c
+++ b/openmp/runtime/test/lock/omp_test_lock.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run
 // RUN: env KMP_LOCK_KIND=tas %libomp-run
 // RUN: env KMP_LOCK_KIND=futex %libomp-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/lock/omp_test_nest_lock.c
+++ b/openmp/runtime/test/lock/omp_test_nest_lock.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/master/omp_master.c
+++ b/openmp/runtime/test/master/omp_master.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/misc_bugs/cancellation_for_sections.c
+++ b/openmp/runtime/test/misc_bugs/cancellation_for_sections.c
@@ -1,6 +1,7 @@
 // RUN: %libomp-compile && env OMP_CANCELLATION=true %libomp-run
 // Clang had a bug until version 4.0.1 which resulted in a hang.
 // UNSUPPORTED: clang-3, clang-4.0.0
+// XFAIL: irbuilder
 
 // Regression test for a bug in cancellation to cover effect of `#pragma omp cancel`
 // in a loop construct, on sections construct.

--- a/openmp/runtime/test/misc_bugs/omp_foreign_thread_team_reuse.c
+++ b/openmp/runtime/test/misc_bugs/omp_foreign_thread_team_reuse.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/ompt/cancel/cancel_parallel.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_parallel.c
@@ -1,7 +1,7 @@
 // RUN: %libomp-compile && env OMP_CANCELLATION=true %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // Current GOMP interface implementation does not support cancellation
-// XFAIL: gcc
+// XFAIL: gcc, irbuilder
 
 #include "callback.h"
 #include "omp.h"

--- a/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
@@ -2,7 +2,7 @@
 // REQUIRES: ompt
 // UNSUPPORTED: clang-3, clang-4.0.0
 // Current GOMP interface implementation does not support cancellation; icc 16 has a bug
-// XFAIL: gcc, icc-16
+// XFAIL: gcc, icc-16, irbuilder
 
 #include "callback.h"
 #include <unistd.h>  

--- a/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
@@ -1,7 +1,7 @@
 // RUN: %libomp-compile && env OMP_CANCELLATION=true %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // Current GOMP interface implementation does not support cancellation; icc 16 does not distinguish between sections and loops
-// XFAIL: icc-16
+// XFAIL: icc-16, irbuilder
 
 #include "callback.h"
 #include <unistd.h>

--- a/openmp/runtime/test/ompt/misc/control_tool.c
+++ b/openmp/runtime/test/ompt/misc/control_tool.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
@@ -2,6 +2,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/parallel/nested.c
+++ b/openmp/runtime/test/ompt/parallel/nested.c
@@ -2,6 +2,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/parallel/nested_lwt.c
+++ b/openmp/runtime/test/ompt/parallel/nested_lwt.c
@@ -2,6 +2,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 #include <unistd.h>

--- a/openmp/runtime/test/ompt/parallel/nested_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/nested_serialized.c
@@ -2,6 +2,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/parallel/nested_thread_num.c
+++ b/openmp/runtime/test/ompt/parallel/nested_thread_num.c
@@ -2,6 +2,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/parallel/parallel_if0.c
+++ b/openmp/runtime/test/ompt/parallel/parallel_if0.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 
 int main()

--- a/openmp/runtime/test/ompt/parallel/serialized.c
+++ b/openmp/runtime/test/ompt/parallel/serialized.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 
 int main()

--- a/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/single.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/single.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/flush.c
+++ b/openmp/runtime/test/ompt/synchronization/flush.c
@@ -1,7 +1,7 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // GCC generates code that does not call the runtime for the flush construct
-// XFAIL: gcc
+// XFAIL: gcc,irbuilder
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/synchronization/masked.c
+++ b/openmp/runtime/test/ompt/synchronization/masked.c
@@ -1,7 +1,7 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // GCC generates code that does not call the runtime for the master construct
-// XFAIL: gcc
+// XFAIL: gcc,irbuilder
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/synchronization/master.c
+++ b/openmp/runtime/test/ompt/synchronization/master.c
@@ -1,7 +1,7 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // GCC generates code that does not call the runtime for the master construct
-// XFAIL: gcc
+// XFAIL: gcc,irbuilder
 
 #define USE_PRIVATE_TOOL 1
 #include "callback.h"

--- a/openmp/runtime/test/ompt/synchronization/taskgroup.c
+++ b/openmp/runtime/test/ompt/synchronization/taskgroup.c
@@ -1,6 +1,7 @@
 // RUN:  %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
 
 #include "callback.h"
 #include <unistd.h>  

--- a/openmp/runtime/test/ompt/synchronization/taskwait.c
+++ b/openmp/runtime/test/ompt/synchronization/taskwait.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/test_nest_lock_parallel.c
+++ b/openmp/runtime/test/ompt/synchronization/test_nest_lock_parallel.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/tasks/dependences.c
+++ b/openmp/runtime/test/ompt/tasks/dependences.c
@@ -1,6 +1,7 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/tasks/dependences_mutexinoutset.c
+++ b/openmp/runtime/test/ompt/tasks/dependences_mutexinoutset.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// XFAIL: irbuilder
 
 // GCC 9 introduced codegen for mutexinoutset
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7, gcc-8

--- a/openmp/runtime/test/ompt/tasks/explicit_task.c
+++ b/openmp/runtime/test/ompt/tasks/explicit_task.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h> 

--- a/openmp/runtime/test/ompt/tasks/serialized.c
+++ b/openmp/runtime/test/ompt/tasks/serialized.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/tasks/task_if0-depend.c
+++ b/openmp/runtime/test/ompt/tasks/task_if0-depend.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// XFAIL: irbuilder
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/tasks/task_late_fulfill.c
+++ b/openmp/runtime/test/ompt/tasks/task_late_fulfill.c
@@ -1,6 +1,7 @@
 // RUN: %libomp-compile && env OMP_NUM_THREADS='3' \
 // RUN:    %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// XFAIL: irbuilder
 
 // Checked gcc 10.1 still does not support detach clause on task construct.
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7, gcc-8, gcc-9, gcc-10

--- a/openmp/runtime/test/ompt/tasks/task_memory.c
+++ b/openmp/runtime/test/ompt/tasks/task_memory.c
@@ -1,6 +1,8 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
+
 #define USE_PRIVATE_TOOL 1
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/tasks/task_types.c
+++ b/openmp/runtime/test/ompt/tasks/task_types.c
@@ -1,5 +1,7 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// XFAIL: irbuilder
+
 #include "callback.h"
 #include <omp.h>
 #include <math.h>

--- a/openmp/runtime/test/ompt/tasks/task_types_serialized.c
+++ b/openmp/runtime/test/ompt/tasks/task_types_serialized.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// XFAIL: irbuilder
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/tasks/taskwait-depend.c
+++ b/openmp/runtime/test/ompt/tasks/taskwait-depend.c
@@ -10,6 +10,7 @@
 // support for taskwait with depend clause introduced in clang-14
 // UNSUPPORTED: clang-5, clang-6, clang-6, clang-8, clang-9, clang-10, clang-11,
 // clang-12, clang-13
+// XFAIL: irbuilder
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/tasks/taskyield.c
+++ b/openmp/runtime/test/ompt/tasks/taskyield.c
@@ -1,7 +1,7 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // Current GOMP interface implements taskyield as stub
-// XFAIL: gcc
+// XFAIL: gcc,irbuilder
 
 #include "callback.h"
 #include <omp.h>   

--- a/openmp/runtime/test/ompt/worksharing/for/auto_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_split.c
@@ -3,6 +3,7 @@
 // REQUIRES: ompt
 // GCC doesn't call runtime for auto = static schedule
 // XFAIL: gcc
+// XFAIL: irbuilder
 
 #define SCHEDULE auto
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/dynamic_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/dynamic_split.c
@@ -2,6 +2,7 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
 
 #define SCHEDULE dynamic
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/guided_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided_split.c
@@ -2,6 +2,7 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
 
 #define SCHEDULE guided
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
@@ -2,6 +2,7 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// XFAIL: irbuilder
 
 #define SCHEDULE runtime
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/static_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/static_split.c
@@ -3,6 +3,7 @@
 // REQUIRES: ompt
 // GCC doesn't call runtime for static schedule
 // XFAIL: gcc
+// XFAIL: irbuilder
 
 #define SCHEDULE static
 #include "base_split.h"

--- a/openmp/runtime/test/parallel/omp_dtor_parallel_dtor.cpp
+++ b/openmp/runtime/test/parallel/omp_dtor_parallel_dtor.cpp
@@ -1,0 +1,35 @@
+// RUN: %libomp-cxx-compile
+// RUN: %libomp-run
+
+// XFAIL: irbuilder
+
+#include <stddef.h>
+#include <stdio.h>
+#include <omp.h>
+
+struct Destructible {
+  int &Ref;
+  int Count;
+  Destructible(int &Ref, int Count) : Ref(Ref), Count(Count) {}
+  ~Destructible() { Ref += Count; }
+};
+
+int main() {
+  int common = 0;
+  int result[2] = {0, 0};
+
+  Destructible dtor1{common, 1};
+
+#pragma omp parallel num_threads(2)
+  {
+    int tid = omp_get_thread_num();
+    Destructible dtor2{result[tid], 1};
+  }
+
+  if (common == 1 && result[0] == 1 && result[1] == 1) {
+    printf("SUCCESS\n");
+    return EXIT_SUCCESS;
+  }
+  printf("FAILED\n");
+  return EXIT_FAILURE;
+}

--- a/openmp/runtime/test/parallel/omp_dtor_parallel_dtor.cpp
+++ b/openmp/runtime/test/parallel/omp_dtor_parallel_dtor.cpp
@@ -26,10 +26,10 @@ int main() {
     Destructible dtor2{result[tid], 1};
   }
 
-  if (common == 1 && result[0] == 1 && result[1] == 1) {
+  if (common == 0 && result[0] == 1 && result[1] == 1) {
     printf("SUCCESS\n");
     return EXIT_SUCCESS;
   }
-  printf("FAILED\n");
+  printf("FAILED (%d, %d, %d)\n", common, result[0], result[1]);
   return EXIT_FAILURE;
 }

--- a/openmp/runtime/test/parallel/omp_parallel_copyin.c
+++ b/openmp/runtime/test/parallel/omp_parallel_copyin.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "omp_testsuite.h"

--- a/openmp/runtime/test/parallel/omp_parallel_default.c
+++ b/openmp/runtime/test/parallel/omp_parallel_default.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/parallel/omp_parallel_firstprivate.c
+++ b/openmp/runtime/test/parallel/omp_parallel_firstprivate.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "omp_testsuite.h"

--- a/openmp/runtime/test/parallel/omp_parallel_goto.c
+++ b/openmp/runtime/test/parallel/omp_parallel_goto.c
@@ -1,0 +1,34 @@
+// RUN: %libomp-compile
+// RUN: %libomp-run
+
+// XFAIL: irbuilder
+
+#include <stddef.h>
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int result[] = {0, 0};
+
+#pragma omp parallel num_threads(2)
+  {
+    int tid = omp_get_thread_num();
+    result[tid] += 1;
+    goto cont;
+
+  orphaned:
+    result[tid] += 2;
+    printf("Never executed\n");
+
+  cont:
+    result[tid] += 4;
+  }
+
+  if (result[0] == 5 && result[1] == 5) {
+    printf("SUCCESS\n");
+    return EXIT_SUCCESS;
+  }
+
+  printf("FAILED\n");
+  return EXIT_FAILURE;
+}

--- a/openmp/runtime/test/parallel/omp_parallel_if.c
+++ b/openmp/runtime/test/parallel/omp_parallel_if.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/parallel/omp_parallel_private.c
+++ b/openmp/runtime/test/parallel/omp_parallel_private.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "omp_testsuite.h"

--- a/openmp/runtime/test/parallel/omp_parallel_shared.c
+++ b/openmp/runtime/test/parallel/omp_parallel_shared.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/tasking/bug_taskwait_detach.cpp
+++ b/openmp/runtime/test/tasking/bug_taskwait_detach.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomp-cxx-compile-and-run
+// XFAIL: irbuilder
 
 #include <omp.h>
 

--- a/openmp/runtime/test/tasking/hidden_helper_task/gtid.cpp
+++ b/openmp/runtime/test/tasking/hidden_helper_task/gtid.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomp-cxx-compile-and-run
 // RUN: %libomp-cxx-compile && env OMP_NUM_THREADS=1 %libomp-run
+// XFAIL: irbuilder
 
 /*
  * This test aims to check whether hidden helper thread has right gtid. We also

--- a/openmp/runtime/test/tasking/kmp_detach_tasks_t1.c
+++ b/openmp/runtime/test/tasking/kmp_detach_tasks_t1.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile && env OMP_NUM_THREADS='3' %libomp-run
 // RUN: %libomp-compile && env OMP_NUM_THREADS='1' %libomp-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_detach_tasks_t2.c
+++ b/openmp/runtime/test/tasking/kmp_detach_tasks_t2.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile && env OMP_NUM_THREADS='3' %libomp-run
 // RUN: %libomp-compile && env OMP_NUM_THREADS='1' %libomp-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_detach_tasks_t3.c
+++ b/openmp/runtime/test/tasking/kmp_detach_tasks_t3.c
@@ -2,6 +2,7 @@
 // RUN: %libomp-compile && env OMP_NUM_THREADS='1' %libomp-run
 // The runtime currently does not get dependency information from GCC.
 // UNSUPPORTED: gcc
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_task_depend_all.c
+++ b/openmp/runtime/test/tasking/kmp_task_depend_all.c
@@ -1,6 +1,7 @@
 // RUN: %libomp-compile-and-run
 // The runtime currently does not get dependency information from GCC.
 // UNSUPPORTED: gcc
+// XFAIL: irbuilder
 
 // Tests OMP 5.x task dependence "omp_all_memory",
 // emulates compiler codegen versions for new dep kind

--- a/openmp/runtime/test/tasking/kmp_task_modifier_simple_par_new.cpp
+++ b/openmp/runtime/test/tasking/kmp_task_modifier_simple_par_new.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomp-cxx-compile-and-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_task_modifier_simple_par_old.cpp
+++ b/openmp/runtime/test/tasking/kmp_task_modifier_simple_par_old.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomp-cxx-compile-and-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_task_modifier_simple_ws_new.cpp
+++ b/openmp/runtime/test/tasking/kmp_task_modifier_simple_ws_new.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomp-cxx-compile-and-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_task_modifier_simple_ws_old.cpp
+++ b/openmp/runtime/test/tasking/kmp_task_modifier_simple_ws_old.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomp-cxx-compile-and-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_task_reduction_nest.cpp
+++ b/openmp/runtime/test/tasking/kmp_task_reduction_nest.cpp
@@ -1,7 +1,8 @@
 // RUN: %libomp-cxx-compile-and-run
 // RUN: %libomp-cxx-compile -DFLG=1 && %libomp-run
 // GCC-5 is needed for OpenMP 4.0 support (taskgroup)
-// XFAIL: gcc-4
+// XFAIL: gcc-4,irbuilder
+
 #include <cstdio>
 #include <cmath>
 #include <cassert>

--- a/openmp/runtime/test/tasking/kmp_taskloop.c
+++ b/openmp/runtime/test/tasking/kmp_taskloop.c
@@ -1,5 +1,7 @@
 // RUN: %libomp-compile-and-run
 // RUN: %libomp-compile && env KMP_TASKLOOP_MIN_TASKS=1 %libomp-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include <omp.h>
 #include "omp_my_sleep.h"

--- a/openmp/runtime/test/tasking/kmp_taskloop_5.c
+++ b/openmp/runtime/test/tasking/kmp_taskloop_5.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile-and-run
 // RUN: %libomp-compile && env KMP_TASKLOOP_MIN_TASKS=1 %libomp-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <omp.h>

--- a/openmp/runtime/test/tasking/kmp_taskwait_depend_all.c
+++ b/openmp/runtime/test/tasking/kmp_taskwait_depend_all.c
@@ -1,6 +1,7 @@
 // RUN: %libomp-compile-and-run
 // The runtime currently does not get dependency information from GCC.
 // UNSUPPORTED: gcc
+// XFAIL: irbuilder
 
 // Tests OMP 5.x task dependence "omp_all_memory",
 // emulates compiler codegen versions for new dep kind

--- a/openmp/runtime/test/tasking/kmp_taskwait_depend_in.c
+++ b/openmp/runtime/test/tasking/kmp_taskwait_depend_in.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 // test checks IN dep kind in depend clause on taskwait construct
 // uses codegen emulation

--- a/openmp/runtime/test/tasking/kmp_taskwait_nowait.c
+++ b/openmp/runtime/test/tasking/kmp_taskwait_nowait.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 // test checks IN dep kind in depend clause on taskwait nowait
 // uses codegen emulation

--- a/openmp/runtime/test/tasking/omp50_task_depend_mtx.c
+++ b/openmp/runtime/test/tasking/omp50_task_depend_mtx.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 // Tests OMP 5.0 task dependences "mutexinoutset", emulates compiler codegen
 // Mutually exclusive tasks get same input dependency info array

--- a/openmp/runtime/test/tasking/omp50_task_depend_mtx2.c
+++ b/openmp/runtime/test/tasking/omp50_task_depend_mtx2.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 // Tests OMP 5.0 task dependences "mutexinoutset", emulates compiler codegen
 // Mutually exclusive tasks get input dependency info array sorted differently

--- a/openmp/runtime/test/tasking/omp50_task_depend_mtx3.c
+++ b/openmp/runtime/test/tasking/omp50_task_depend_mtx3.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7, gcc-8
 // UNSUPPORTED: clang-3, clang-4, clang-5, clang-6, clang-7, clang-8
 // TODO: update expected result when icc supports mutexinoutset
-// XFAIL: icc
+// XFAIL: icc,irbuilder
 
 // Tests OMP 5.0 task dependences "mutexinoutset", emulates compiler codegen
 // Mutually exclusive tasks get same input dependency info array

--- a/openmp/runtime/test/tasking/omp50_taskdep_depobj.c
+++ b/openmp/runtime/test/tasking/omp50_taskdep_depobj.c
@@ -2,6 +2,7 @@
 // UNSUPPORTED: gcc-5, gcc-6, gcc-7, gcc-8
 // UNSUPPORTED: clang-5, clang-6, clang-7, clang-8, clang-9, clang-10
 // UNSUPPORTED: icc
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/tasking/omp50_taskwait_depend.c
+++ b/openmp/runtime/test/tasking/omp50_taskwait_depend.c
@@ -4,6 +4,7 @@
 // support for taskwait with depend clause introduced in clang-14
 // UNSUPPORTED: clang-5, clang-6, clang-6, clang-8, clang-9, clang-10, clang-11,
 // clang-12, clang-13
+// XFAIL: irbuilder
 
 // icc does not yet support taskwait with depend clause
 // XFAIL: icc

--- a/openmp/runtime/test/tasking/omp51_task_dep_inoutset.c
+++ b/openmp/runtime/test/tasking/omp51_task_dep_inoutset.c
@@ -1,6 +1,7 @@
 // RUN: %libomp-compile-and-run
 // RUN: %libomp-cxx-compile-and-run
 // UNSUPPORTED: gcc
+// XFAIL: irbuilder
 
 // Tests OMP 5.0 task dependences "mutexinoutset" and 5.1 "inoutset",
 // emulates compiler codegen for new dep kinds

--- a/openmp/runtime/test/tasking/omp_detach_taskwait.c
+++ b/openmp/runtime/test/tasking/omp_detach_taskwait.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile && env OMP_NUM_THREADS='3' %libomp-run
 // RUN: %libomp-compile && env OMP_NUM_THREADS='1' %libomp-run
+// XFAIL: irbuilder
 
 // Checked gcc 10.1 still does not support detach clause on task construct.
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7, gcc-8, gcc-9, gcc-10

--- a/openmp/runtime/test/tasking/omp_task_imp_firstprivate.c
+++ b/openmp/runtime/test/tasking/omp_task_imp_firstprivate.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include <math.h>
 #include "omp_testsuite.h"

--- a/openmp/runtime/test/tasking/omp_taskwait.c
+++ b/openmp/runtime/test/tasking/omp_taskwait.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 // This test is known to be fragile on NetBSD kernel at the moment,
 // https://bugs.llvm.org/show_bug.cgi?id=42020.

--- a/openmp/runtime/test/tasking/task_reduction3.c
+++ b/openmp/runtime/test/tasking/task_reduction3.c
@@ -1,6 +1,6 @@
 // RUN: %libomp-compile-and-run
 
-// XFAIL: icc
+// XFAIL: icc, irbuilder
 // UNSUPPORTED: clang-4, clang-5, clang-6, clang-7, clang-8, clang-9, clang-10
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7, gcc-8
 

--- a/openmp/runtime/test/tasking/task_reduction4.c
+++ b/openmp/runtime/test/tasking/task_reduction4.c
@@ -1,6 +1,6 @@
 // RUN: %libomp-compile-and-run
 
-// XFAIL: icc
+// XFAIL: icc, irbuilder
 // UNSUPPORTED: clang-4, clang-5, clang-6, clang-7, clang-8, clang-9, clang-10
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7, gcc-8
 

--- a/openmp/runtime/test/tasking/taskdep_if0_2.c
+++ b/openmp/runtime/test/tasking/taskdep_if0_2.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/teams/kmp_num_teams.c
+++ b/openmp/runtime/test/teams/kmp_num_teams.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile-and-run
 // UNSUPPORTED: gcc
+// XFAIL: irbuilder
 // Linking fails for icc 18/19
 // UNSUPPORTED: icc-18, icc-19
 

--- a/openmp/runtime/test/threadprivate/omp_threadprivate.c
+++ b/openmp/runtime/test/threadprivate/omp_threadprivate.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: irbuilder
+
 /*
  * Threadprivate is tested in 2 ways:
  * 1. The global variable declared as threadprivate should have

--- a/openmp/runtime/test/worksharing/for/kmp_sch_simd_runtime_api.c
+++ b/openmp/runtime/test/worksharing/for/kmp_sch_simd_runtime_api.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
 
 // The test checks schedule(simd:runtime)
 // in combination with omp_set_schedule()

--- a/openmp/runtime/test/worksharing/for/kmp_sch_simd_runtime_guided.c
+++ b/openmp/runtime/test/worksharing/for/kmp_sch_simd_runtime_guided.c
@@ -6,6 +6,7 @@
 // RUN: env OMP_SCHEDULE=dynamic,1 %libomp-run 1
 // RUN: env OMP_SCHEDULE=dynamic,2 %libomp-run 2
 // RUN: env OMP_SCHEDULE=auto      %libomp-run
+// XFAIL: irbuilder
 
 // The test checks schedule(simd:runtime)
 // in combination with OMP_SCHEDULE=guided[,chunk]

--- a/openmp/runtime/test/worksharing/for/kmp_sch_simd_runtime_static.c
+++ b/openmp/runtime/test/worksharing/for/kmp_sch_simd_runtime_static.c
@@ -1,5 +1,6 @@
 // RUN: %libomp-compile && %libomp-run
 // RUN: %libomp-run 1 && %libomp-run 2
+// XFAIL: irbuilder
 
 // The test checks schedule(simd:runtime)
 // in combination with OMP_SCHEDULE=static[,chunk]

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: irbuilder
+
 #include <stdio.h>
 #include <math.h>
 #include "omp_testsuite.h"

--- a/openmp/runtime/test/worksharing/for/omp_parallel_for_static.c
+++ b/openmp/runtime/test/worksharing/for/omp_parallel_for_static.c
@@ -1,0 +1,25 @@
+// RUN: %libomp-compile
+// RUN: %libomp-run
+
+#include <stddef.h>
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int result[2] = {0, 0};
+
+#pragma omp parallel num_threads(2)
+  {
+    int tid = omp_get_thread_num();
+#pragma omp for schedule(static)
+    for (int i = 0; i < 6; i += 1)
+      result[tid] += 1 << i;
+  }
+
+  if (result[0] == 1 + 2 + 4 && result[1] == 8 + 16 + 32) {
+    printf("SUCCESS\n");
+    return EXIT_SUCCESS;
+  }
+  printf("FAILED\n");
+  return EXIT_FAILURE;
+}

--- a/openmp/runtime/test/worksharing/for/omp_parallel_for_static_chunked.c
+++ b/openmp/runtime/test/worksharing/for/omp_parallel_for_static_chunked.c
@@ -1,0 +1,26 @@
+// RUN: %libomp-compile
+// RUN: %libomp-run
+
+#include <stddef.h>
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int result[2] = {0, 0};
+
+#pragma omp parallel num_threads(2)
+  {
+    int tid = omp_get_thread_num();
+#pragma omp for schedule(static, 3)
+    for (int i = 0; i < 10; i += 1)
+      result[tid] += 1 << i;
+  }
+
+  if (result[0] == 1 + 2 + 4 + 64 + 128 + 256 &&
+      result[1] == 8 + 16 + 32 + 512) {
+    printf("SUCCESS\n");
+    return EXIT_SUCCESS;
+  }
+  printf("FAILED\n");
+  return EXIT_FAILURE;
+}

--- a/openmp/runtime/test/worksharing/sections/omp_section_lastprivate.c
+++ b/openmp/runtime/test/worksharing/sections/omp_section_lastprivate.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/worksharing/sections/omp_section_private.c
+++ b/openmp/runtime/test/worksharing/sections/omp_section_private.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/worksharing/sections/omp_sections_nowait.c
+++ b/openmp/runtime/test/worksharing/sections/omp_sections_nowait.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/worksharing/sections/omp_sections_reduction.c
+++ b/openmp/runtime/test/worksharing/sections/omp_sections_reduction.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: irbuilder
+
 #include <stdio.h>
 #include <math.h>
 #include "omp_testsuite.h"

--- a/openmp/runtime/test/worksharing/single/omp_single.c
+++ b/openmp/runtime/test/worksharing/single/omp_single.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/runtime/test/worksharing/single/omp_single_private.c
+++ b/openmp/runtime/test/worksharing/single/omp_single_private.c
@@ -1,4 +1,6 @@
 // RUN: %libomp-compile-and-run
+// XFAIL: irbuilder
+
 #include <stdio.h>
 #include "omp_testsuite.h"
 

--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import lit.formats
+import shlex
 
 # Tell pylint that we know config and lit_config exist somewhere.
 if 'PYLINT_IMPORT' in os.environ:
@@ -48,6 +49,9 @@ config.test_flags = " -I " + config.test_source_root + \
     " -Wl,-rpath," + config.omp_library_dir + \
     " " + config.test_archer_flags + \
     " " + config.test_extra_flags
+
+if "-fopenmp-enable-irbuilder" in (shlex.split(config.test_openmp_flags) + shlex.split(config.test_flags)):
+    config.available_features.add("irbuilder")
 
 config.archer_flags = "-g -O1 -fsanitize=thread"
 

--- a/openmp/tools/archer/tests/parallel/parallel-firstprivate.c
+++ b/openmp/tools/archer/tests/parallel/parallel-firstprivate.c
@@ -14,6 +14,8 @@
 
 // RUN: %libarcher-compile-and-run | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include <omp.h>
 #include <stdio.h>
 

--- a/openmp/tools/archer/tests/races/task-dependency.c
+++ b/openmp/tools/archer/tests/races/task-dependency.c
@@ -13,6 +13,8 @@
 // RUN: %libarcher-compile-and-run-race | FileCheck %s
 // RUN: %libarcher-compile-and-run-race-noserial | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include "ompt/ompt-signal.h"
 #include <omp.h>
 #include <stdio.h>

--- a/openmp/tools/archer/tests/races/task-taskgroup-unrelated.c
+++ b/openmp/tools/archer/tests/races/task-taskgroup-unrelated.c
@@ -13,6 +13,8 @@
 // RUN: %libarcher-compile-and-run-race | FileCheck %s
 // RUN: %libarcher-compile-and-run-race-noserial | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include "ompt/ompt-signal.h"
 #include <omp.h>
 #include <stdio.h>

--- a/openmp/tools/archer/tests/races/task-taskwait-nested.c
+++ b/openmp/tools/archer/tests/races/task-taskwait-nested.c
@@ -13,6 +13,8 @@
 // RUN: %libarcher-compile-and-run-race | FileCheck %s
 // RUN: %libarcher-compile-and-run-race-noserial | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include "ompt/ompt-signal.h"
 #include <omp.h>
 #include <stdio.h>

--- a/openmp/tools/archer/tests/reduction/parallel-reduction-nowait.c
+++ b/openmp/tools/archer/tests/reduction/parallel-reduction-nowait.c
@@ -14,6 +14,8 @@
 
 // RUN: %libarcher-compile-and-run | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include <omp.h>
 #include <stdio.h>
 

--- a/openmp/tools/archer/tests/reduction/parallel-reduction.c
+++ b/openmp/tools/archer/tests/reduction/parallel-reduction.c
@@ -14,6 +14,8 @@
 
 // RUN: %libarcher-compile-and-run| FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include <omp.h>
 #include <stdio.h>
 

--- a/openmp/tools/archer/tests/task/task-dependency.c
+++ b/openmp/tools/archer/tests/task/task-dependency.c
@@ -14,6 +14,8 @@
 
 // RUN: %libarcher-compile-and-run | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include <omp.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/openmp/tools/archer/tests/task/task-taskwait-nested.c
+++ b/openmp/tools/archer/tests/task/task-taskwait-nested.c
@@ -14,6 +14,8 @@
 
 // RUN: %libarcher-compile-and-run | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include <omp.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/openmp/tools/archer/tests/task/task-taskwait.c
+++ b/openmp/tools/archer/tests/task/task-taskwait.c
@@ -14,6 +14,8 @@
 
 // RUN: %libarcher-compile-and-run | FileCheck %s
 // REQUIRES: tsan
+// XFAIL: irbuilder
+
 #include <omp.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/openmp/tools/archer/tests/task/task_late_fulfill.c
+++ b/openmp/tools/archer/tests/task/task_late_fulfill.c
@@ -10,6 +10,7 @@
 // icc compiler does not support detach clause.
 // UNSUPPORTED: icc
 // REQUIRES: tsan
+// XFAIL: irbuilder
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
Categorize libomp regression tests according to whether they currently work with -fopenmp-enable-irbuilder. Tests marked with XFAIL are reliably failing. Tests with UNSUPPORTED fail or succeed occasionally. Add some additional tests that currently fail using the OpenMPIRBuilder.

Originally submitted as https://reviews.llvm.org/D114501 which was itself accepted but never merged because reviews that were supposed to address these failures never progressed.