### PR TITLE
[llvm][ADT] Structured bindings for move-only types in `StringMap`

### DIFF
--- a/llvm/include/llvm/ADT/StringMapEntry.h
+++ b/llvm/include/llvm/ADT/StringMapEntry.h
@@ -172,14 +172,10 @@ template <typename ValueTy>
 struct std::tuple_size<llvm::StringMapEntry<ValueTy>>
     : std::integral_constant<std::size_t, 2> {};
 
-template <typename ValueTy>
-struct std::tuple_element<0, llvm::StringMapEntry<ValueTy>> {
-  using type = llvm::StringRef;
-};
-
-template <typename ValueTy>
-struct std::tuple_element<1, llvm::StringMapEntry<ValueTy>> {
-  using type = ValueTy;
+template <std::size_t Index, typename ValueTy>
+struct std::tuple_element<Index, llvm::StringMapEntry<ValueTy>>
+    : std::conditional<Index == 0, llvm::StringRef, ValueTy> {
+  static_assert(Index == 0 || Index == 1);
 };
 
 #endif // LLVM_ADT_STRINGMAPENTRY_H

--- a/llvm/include/llvm/ADT/StringMapEntry.h
+++ b/llvm/include/llvm/ADT/StringMapEntry.h
@@ -148,40 +148,22 @@ public:
 
 // Allow structured bindings on StringMapEntry.
 
-namespace detail {
-template <std::size_t Index> struct StringMapEntryGet;
-
-template <> struct StringMapEntryGet<0> {
-  template <typename ValueTy> static StringRef get(StringMapEntry<ValueTy> &E) {
-    return E.getKey();
-  }
-
-  template <typename ValueTy>
-  static StringRef get(const StringMapEntry<ValueTy> &E) {
-    return E.getKey();
-  }
-};
-
-template <> struct StringMapEntryGet<1> {
-  template <typename ValueTy> static ValueTy &get(StringMapEntry<ValueTy> &E) {
-    return E.getValue();
-  }
-
-  template <typename ValueTy>
-  static const ValueTy &get(const StringMapEntry<ValueTy> &E) {
-    return E.getValue();
-  }
-};
-} // namespace detail
-
 template <std::size_t Index, typename ValueTy>
 decltype(auto) get(StringMapEntry<ValueTy> &E) {
-  return detail::StringMapEntryGet<Index>::get(E);
+  static_assert(Index == 0 || Index == 1);
+  if constexpr (Index == 0)
+    return E.getKey();
+  if constexpr (Index == 1)
+    return E.getValue();
 }
 
 template <std::size_t Index, typename ValueTy>
 decltype(auto) get(const StringMapEntry<ValueTy> &E) {
-  return detail::StringMapEntryGet<Index>::get(E);
+  static_assert(Index == 0 || Index == 1);
+  if constexpr (Index == 0)
+    return E.getKey();
+  if constexpr (Index == 1)
+    return E.getValue();
 }
 
 } // end namespace llvm

--- a/llvm/include/llvm/ADT/StringMapEntry.h
+++ b/llvm/include/llvm/ADT/StringMapEntry.h
@@ -150,19 +150,19 @@ public:
 
 template <std::size_t Index, typename ValueTy>
 decltype(auto) get(StringMapEntry<ValueTy> &E) {
-  static_assert(Index == 0 || Index == 1);
+  static_assert(Index < 2);
   if constexpr (Index == 0)
     return E.getKey();
-  if constexpr (Index == 1)
+  else
     return E.getValue();
 }
 
 template <std::size_t Index, typename ValueTy>
 decltype(auto) get(const StringMapEntry<ValueTy> &E) {
-  static_assert(Index == 0 || Index == 1);
+  static_assert(Index < 2);
   if constexpr (Index == 0)
     return E.getKey();
-  if constexpr (Index == 1)
+  else
     return E.getValue();
 }
 

--- a/llvm/include/llvm/ADT/StringMapEntry.h
+++ b/llvm/include/llvm/ADT/StringMapEntry.h
@@ -174,8 +174,6 @@ struct std::tuple_size<llvm::StringMapEntry<ValueTy>>
 
 template <std::size_t Index, typename ValueTy>
 struct std::tuple_element<Index, llvm::StringMapEntry<ValueTy>>
-    : std::conditional<Index == 0, llvm::StringRef, ValueTy> {
-  static_assert(Index == 0 || Index == 1);
-};
+    : std::tuple_element<Index, std::pair<llvm::StringRef, ValueTy>> {};
 
 #endif // LLVM_ADT_STRINGMAPENTRY_H

--- a/llvm/unittests/ADT/StringMapTest.cpp
+++ b/llvm/unittests/ADT/StringMapTest.cpp
@@ -381,6 +381,9 @@ struct MoveOnly {
     return *this;
   }
 
+  bool operator==(const MoveOnly &RHS) const { return i == RHS.i; }
+  bool operator!=(const MoveOnly &RHS) const { return i != RHS.i; }
+
 private:
   MoveOnly(const MoveOnly &) = delete;
   MoveOnly &operator=(const MoveOnly &) = delete;
@@ -549,6 +552,26 @@ TEST_F(StringMapTest, StructuredBindings) {
   for (auto &[Key, Value] : A) {
     EXPECT_EQ("a", Key);
     EXPECT_EQ(42, Value);
+  }
+
+  for (const auto &[Key, Value] : A) {
+    EXPECT_EQ("a", Key);
+    EXPECT_EQ(42, Value);
+  }
+}
+
+TEST_F(StringMapTest, StructuredBindingsMoveOnly) {
+  StringMap<MoveOnly> A;
+  A.insert(std::make_pair("a", MoveOnly(42)));
+
+  for (auto &[Key, Value] : A) {
+    EXPECT_EQ("a", Key);
+    EXPECT_EQ(MoveOnly(42), Value);
+  }
+
+  for (const auto &[Key, Value] : A) {
+    EXPECT_EQ("a", Key);
+    EXPECT_EQ(MoveOnly(42), Value);
   }
 }
 


### PR DESCRIPTION
This PR implements destructuring of `StringMapEntry<T>` where `T` is a move-only type. Also adds the non-const version.