### PR TITLE
Fix assertion when tiling linalg.generic

### DIFF
--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -382,6 +382,9 @@ public:
   /// Returns true if the AffineMap represents a symbol-less permutation map.
   bool isPermutation() const;
 
+  /// Returns true if the AffineMap contains non-positive coefficients
+  bool isNonPositiveCoefficients() const;
+
   /// Returns the map consisting of the `resultPos` subset.
   AffineMap getSubMap(ArrayRef<unsigned> resultPos) const;
 

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -119,6 +119,14 @@ struct LinalgOpTilingInterface
     // specified could lead to out of bounds accesses.
     Location loc = op->getLoc();
     LinalgOp linalgOp = cast<LinalgOp>(op);
+    SmallVector<AffineMap> indexingMaps = linalgOp.getIndexingMapsArray();
+    if (llvm::any_of(linalgOp.getIndexingMapsArray(), [](AffineMap m) {
+          return m.isNonPositiveCoefficients();
+        })) {
+      return linalgOp.emitOpError(
+          "tiling not supported because op has a non positive coefficient");
+    }
+
     SmallVector<Value> valuesToTile = linalgOp->getOperands();
     SmallVector<Value> tiledOperands = makeTiledShapes(
         b, loc, linalgOp, valuesToTile, offsets, sizes, {}, true);

--- a/mlir/test/Dialect/Linalg/tile-invalid.mlir
+++ b/mlir/test/Dialect/Linalg/tile-invalid.mlir
@@ -1,0 +1,29 @@
+// RUN: mlir-opt %s -transform-interpreter -split-input-file -verify-diagnostics
+
+#map1 = affine_map<(d0) -> (d0)>
+#map2 = affine_map<(d0) -> (-d0 + 7)>
+
+func.func @test(%arg0: tensor<8xi8>, %arg1: tensor<8xi8>) -> tensor<8xi8> {
+   // expected-error @below{{tiling not supported because op has a non positive coefficient}}
+   // expected-error @below{{op faild to tile operation}}
+   // expected-error @below{{op failed to generate tiling loops}}
+  %0 = linalg.generic {
+    indexing_maps = [#map2, #map1],
+    iterator_types = ["parallel"]}
+  ins(%arg0 : tensor<8xi8>)
+  outs(%arg1 : tensor<8xi8>) {
+  ^bb0(%in: i8, %out: i8):
+    linalg.yield %in : i8
+  } -> tensor<8xi8>
+  return %0 : tensor<8xi8>
+}
+
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1:2 = transform.structured.tile_using_for
+      %0 tile_sizes [2] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+     transform.yield
+  }
+}


### PR DESCRIPTION
This patch fixes assertion during tiling due to unsupported linalg.generic containing negative coefficients in indexing expressions by adding a check before attempting tiling

Closes #113021 