### PR TITLE
Comment out CF16 entrypoints for aarch64 and CF128 entrypoints for X84-64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -612,8 +612,8 @@ set(TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_FLOAT16)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # complex.h C23 _Complex _Float16 entrypoints
-    libc.src.complex.crealf16
-    libc.src.complex.cimagf16
+    # libc.src.complex.crealf16
+    # libc.src.complex.cimagf16
     
     # math.h C23 _Float16 entrypoints
     libc.src.math.canonicalizef16

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -722,8 +722,8 @@ endif()
 if(LIBC_TYPES_HAS_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # complex.h C23 _Complex _Float128 entrypoints
-    libc.src.complex.crealf128
-    libc.src.complex.cimagf128
+    # libc.src.complex.crealf128
+    # libc.src.complex.cimagf128
     
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128


### PR DESCRIPTION
Temporarily Fixes buildbot errors due to #113300