### PR TITLE
[clangd] Check for editsNearCursor client capability under experimental capabilities

### DIFF
--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -504,6 +504,16 @@ bool fromJSON(const llvm::json::Value &Params, ClientCapabilities &R,
                   P.field("offsetEncoding")))
       return false;
   }
+
+  if (auto *Experimental = O->getObject("experimental")) {
+    if (auto *TextDocument = Experimental->getObject("textDocument")) {
+      if (auto *Completion = TextDocument->getObject("completion")) {
+        if (auto EditsNearCursor = Completion->getBoolean("editsNearCursor"))
+          R.CompletionFixes |= *EditsNearCursor;
+      }
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
This is done to support clients which only support adding custom (language-specific or server-specific) capabilities under 'experimental'.

Fixes https://github.com/clangd/clangd/issues/2201