### PR TITLE
[libc++][NFC] Remove dead code from make_{signed,unsigned}

### DIFF
--- a/libcxx/include/__type_traits/make_signed.h
+++ b/libcxx/include/__type_traits/make_signed.h
@@ -11,11 +11,7 @@
 
 #include <__config>
 #include <__type_traits/copy_cv.h>
-#include <__type_traits/is_enum.h>
-#include <__type_traits/is_integral.h>
-#include <__type_traits/nat.h>
 #include <__type_traits/remove_cv.h>
-#include <__type_traits/type_list.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -29,43 +25,22 @@ template <class _Tp>
 using __make_signed_t = __make_signed(_Tp);
 
 #else
-// clang-format off
-typedef __type_list<signed char,
-        __type_list<signed short,
-        __type_list<signed int,
-        __type_list<signed long,
-        __type_list<signed long long,
-#  if _LIBCPP_HAS_INT128
-        __type_list<__int128_t,
-#  endif
-        __nat
-#  if _LIBCPP_HAS_INT128
-        >
-#  endif
-        > > > > > __signed_types;
-// clang-format on
-
-template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
+template <class _Tp>
 struct __make_signed{};
 
-template <class _Tp>
-struct __make_signed<_Tp, true> {
-  typedef typename __find_first<__signed_types, sizeof(_Tp)>::type type;
-};
-
 // clang-format off
-template <> struct __make_signed<bool,               true> {};
-template <> struct __make_signed<  signed short,     true> {typedef short     type;};
-template <> struct __make_signed<unsigned short,     true> {typedef short     type;};
-template <> struct __make_signed<  signed int,       true> {typedef int       type;};
-template <> struct __make_signed<unsigned int,       true> {typedef int       type;};
-template <> struct __make_signed<  signed long,      true> {typedef long      type;};
-template <> struct __make_signed<unsigned long,      true> {typedef long      type;};
-template <> struct __make_signed<  signed long long, true> {typedef long long type;};
-template <> struct __make_signed<unsigned long long, true> {typedef long long type;};
+template <> struct __make_signed<bool              > {};
+template <> struct __make_signed<  signed short    > {typedef short     type;};
+template <> struct __make_signed<unsigned short    > {typedef short     type;};
+template <> struct __make_signed<  signed int      > {typedef int       type;};
+template <> struct __make_signed<unsigned int      > {typedef int       type;};
+template <> struct __make_signed<  signed long     > {typedef long      type;};
+template <> struct __make_signed<unsigned long     > {typedef long      type;};
+template <> struct __make_signed<  signed long long> {typedef long long type;};
+template <> struct __make_signed<unsigned long long> {typedef long long type;};
 #  if _LIBCPP_HAS_INT128
-template <> struct __make_signed<__int128_t,         true> {typedef __int128_t type;};
-template <> struct __make_signed<__uint128_t,        true> {typedef __int128_t type;};
+template <> struct __make_signed<__int128_t        > {typedef __int128_t type;};
+template <> struct __make_signed<__uint128_t       > {typedef __int128_t type;};
 #  endif
 // clang-format on
 

--- a/libcxx/include/__type_traits/make_unsigned.h
+++ b/libcxx/include/__type_traits/make_unsigned.h
@@ -12,12 +12,8 @@
 #include <__config>
 #include <__type_traits/conditional.h>
 #include <__type_traits/copy_cv.h>
-#include <__type_traits/is_enum.h>
-#include <__type_traits/is_integral.h>
 #include <__type_traits/is_unsigned.h>
-#include <__type_traits/nat.h>
 #include <__type_traits/remove_cv.h>
-#include <__type_traits/type_list.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -31,43 +27,23 @@ template <class _Tp>
 using __make_unsigned_t = __make_unsigned(_Tp);
 
 #else
-// clang-format off
-typedef __type_list<unsigned char,
-        __type_list<unsigned short,
-        __type_list<unsigned int,
-        __type_list<unsigned long,
-        __type_list<unsigned long long,
-#  if _LIBCPP_HAS_INT128
-        __type_list<__uint128_t,
-#  endif
-        __nat
-#  if _LIBCPP_HAS_INT128
-        >
-#  endif
-        > > > > > __unsigned_types;
-// clang-format on
-
-template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
-struct __make_unsigned{};
 
 template <class _Tp>
-struct __make_unsigned<_Tp, true> {
-  typedef typename __find_first<__unsigned_types, sizeof(_Tp)>::type type;
-};
+struct __make_unsigned{};
 
 // clang-format off
-template <> struct __make_unsigned<bool,               true> {};
-template <> struct __make_unsigned<  signed short,     true> {typedef unsigned short     type;};
-template <> struct __make_unsigned<unsigned short,     true> {typedef unsigned short     type;};
-template <> struct __make_unsigned<  signed int,       true> {typedef unsigned int       type;};
-template <> struct __make_unsigned<unsigned int,       true> {typedef unsigned int       type;};
-template <> struct __make_unsigned<  signed long,      true> {typedef unsigned long      type;};
-template <> struct __make_unsigned<unsigned long,      true> {typedef unsigned long      type;};
-template <> struct __make_unsigned<  signed long long, true> {typedef unsigned long long type;};
-template <> struct __make_unsigned<unsigned long long, true> {typedef unsigned long long type;};
+template <> struct __make_unsigned<bool              > {};
+template <> struct __make_unsigned<  signed short    > {typedef unsigned short     type;};
+template <> struct __make_unsigned<unsigned short    > {typedef unsigned short     type;};
+template <> struct __make_unsigned<  signed int      > {typedef unsigned int       type;};
+template <> struct __make_unsigned<unsigned int      > {typedef unsigned int       type;};
+template <> struct __make_unsigned<  signed long     > {typedef unsigned long      type;};
+template <> struct __make_unsigned<unsigned long     > {typedef unsigned long      type;};
+template <> struct __make_unsigned<  signed long long> {typedef unsigned long long type;};
+template <> struct __make_unsigned<unsigned long long> {typedef unsigned long long type;};
 #  if _LIBCPP_HAS_INT128
-template <> struct __make_unsigned<__int128_t,         true> {typedef __uint128_t        type;};
-template <> struct __make_unsigned<__uint128_t,        true> {typedef __uint128_t        type;};
+template <> struct __make_unsigned<__int128_t        > {typedef __uint128_t        type;};
+template <> struct __make_unsigned<__uint128_t       > {typedef __uint128_t        type;};
 #  endif
 // clang-format on
 

--- a/libcxx/include/__type_traits/type_list.h
+++ b/libcxx/include/__type_traits/type_list.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_TYPE_LIST_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -22,19 +21,6 @@ template <class _Hp, class _Tp>
 struct __type_list {
   typedef _Hp _Head;
   typedef _Tp _Tail;
-};
-
-template <class _TypeList, size_t _Size, bool = _Size <= sizeof(typename _TypeList::_Head)>
-struct __find_first;
-
-template <class _Hp, class _Tp, size_t _Size>
-struct __find_first<__type_list<_Hp, _Tp>, _Size, true> {
-  typedef _LIBCPP_NODEBUG _Hp type;
-};
-
-template <class _Hp, class _Tp, size_t _Size>
-struct __find_first<__type_list<_Hp, _Tp>, _Size, false> {
-  typedef _LIBCPP_NODEBUG typename __find_first<_Tp, _Size>::type type;
 };
 
 _LIBCPP_END_NAMESPACE_STD


### PR DESCRIPTION
The removed specializations aren't ever actually used, so we can just remove them and any code that they use.
