### PR TITLE
[flang] fix: split ifndef for CHECK and CHECK_MSG

### DIFF
--- a/flang/include/flang/Common/idioms.h
+++ b/flang/include/flang/Common/idioms.h
@@ -87,7 +87,10 @@ template <typename... LAMBDAS> visitors(LAMBDAS... x) -> visitors<LAMBDAS...>;
 // To disable, compile with '-DCHECK=(void)'
 #ifndef CHECK
 #define CHECK(x) ((x) || (DIE("CHECK(" #x ") failed"), false))
+#endif
+
 // Same as above, but with a custom error message.
+#ifndef CHECK_MSG
 #define CHECK_MSG(x, y) ((x) || (DIE("CHECK(" #x ") failed: " #y), false))
 #endif
 


### PR DESCRIPTION
Resolves https://github.com/llvm/llvm-project/issues/114703

I think it's the best practice that each macro has it's own `ifndef` check and this way the build issue is resolved for me.

I also find the names of these macro a bit too generic - an easy recipe for conflicts. In my case, the error was likely caused by something else defining `CHECK` but not `CHECK_MSG`, so likely these `CHECK` and `CHECK_MSG` weren't actually working at all because the result of `ifndef` is always false. 

As a definitive fix, perhaps it makes sense to rename them to something more specific, e.g. `FLANG_CHECK` and `FLANG_CHECK_MSG`.
