### PR TITLE
[MLIR][Affine] Fix a crash with invalid cachesize

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/LoopTiling.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/LoopTiling.cpp
@@ -173,6 +173,11 @@ void LoopTiling::getTileSizes(ArrayRef<AffineForOp> band,
 }
 
 void LoopTiling::runOnOperation() {
+  if (cacheSizeInKiB == 0) {
+    mlir::emitError(mlir::UnknownLoc::get(&Pass::getContext()),
+                    "illegal argument: 'cache-size' cannot be zero");
+    return signalPassFailure();
+  }
   // Bands of loops to tile.
   std::vector<SmallVector<AffineForOp, 6>> bands;
   getTileableBands(getOperation(), &bands);

--- a/mlir/test/Dialect/Affine/loop-tile-cache-size-invalid.mlir
+++ b/mlir/test/Dialect/Affine/loop-tile-cache-size-invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt -affine-loop-tile="cache-size=0" %s -split-input-file -verify-diagnostics
+// XFAIL: *
+// This is @legal_loop() test case. The expected error is "illegal argument: 'cache-size' cannot be zero"
+// at unknown location because of invalid command line argument.
+
+func.func @test_cache_size_zero() {
+  %0 = memref.alloc() : memref<64xf32>
+  affine.for %i = 0 to 64 {
+    %1 = affine.load %0[%i] : memref<64xf32>
+    %2 = arith.addf %1, %1 : f32
+    affine.store %2, %0[%i] : memref<64xf32>
+  }
+  return
+}
+


### PR DESCRIPTION
Updated LoopTiling::runOnOperation() to signal pass failure incase the set cachesize is equal to zero.

 Fixes #64979.