### PR TITLE
[memprof] Use MinimumSupportedVersion in place of Verion0 (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -669,7 +669,8 @@ public:
 class IndexedMemProfReader {
 private:
   /// The MemProf version.
-  memprof::IndexedVersion Version = memprof::Version0;
+  memprof::IndexedVersion Version =
+      static_cast<memprof::IndexedVersion>(memprof::MinimumSupportedVersion);
   /// MemProf profile schema (if available).
   memprof::MemProfSchema Schema;
   /// MemProf record profile data on-disk indexed via llvm::md5(FunctionName).

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -86,12 +86,16 @@ public:
   // MemprofGenerateRandomHotness is enabled. The random seed can be either
   // provided by MemprofGenerateRandomHotnessSeed, or if that is 0, one will be
   // generated in the writer using the current time.
-  InstrProfWriter(
-      bool Sparse = false, uint64_t TemporalProfTraceReservoirSize = 0,
-      uint64_t MaxTemporalProfTraceLength = 0, bool WritePrevVersion = false,
-      memprof::IndexedVersion MemProfVersionRequested = memprof::Version0,
-      bool MemProfFullSchema = false, bool MemprofGenerateRandomHotness = false,
-      unsigned MemprofGenerateRandomHotnessSeed = 0);
+  InstrProfWriter(bool Sparse = false,
+                  uint64_t TemporalProfTraceReservoirSize = 0,
+                  uint64_t MaxTemporalProfTraceLength = 0,
+                  bool WritePrevVersion = false,
+                  memprof::IndexedVersion MemProfVersionRequested =
+                      static_cast<memprof::IndexedVersion>(
+                          memprof::MinimumSupportedVersion),
+                  bool MemProfFullSchema = false,
+                  bool MemprofGenerateRandomHotness = false,
+                  unsigned MemprofGenerateRandomHotnessSeed = 0);
   ~InstrProfWriter();
 
   StringMap<ProfilingData> &getProfileData() { return FunctionData; }


### PR DESCRIPTION
I'm planning to remove old versions of the MemProf indexed formats at
some point.  Replacing these occurrences of Version0 with
MinimumSupportedVersion allows me to touch fewer places when I remove
old versions in the future.

Note that these two parameters being touched in this patch have
nothing to do with the default MemProf version that llvm-profdata
uses, which is controlled by MemProfVersionRequested in
llvm-profdata.cpp.
