### PR TITLE
[CodeGen] Move EnableSinkAndFold to TargetOptions

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetPassConfig.h
+++ b/llvm/include/llvm/CodeGen/TargetPassConfig.h
@@ -131,11 +131,6 @@ protected:
   /// Default setting for -enable-tail-merge on this target.
   bool EnableTailMerge = true;
 
-  /// Enable sinking of instructions in MachineSink where a computation can be
-  /// folded into the addressing mode of a memory load/store instruction or
-  /// replace a copy.
-  bool EnableSinkAndFold = false;
-
   /// Require processing of functions such that callees are generated before
   /// callers.
   bool RequireCodeGenSCCOrder = false;
@@ -197,9 +192,6 @@ public:
 
   bool getEnableTailMerge() const { return EnableTailMerge; }
   void setEnableTailMerge(bool Enable) { setOpt(EnableTailMerge, Enable); }
-
-  bool getEnableSinkAndFold() const { return EnableSinkAndFold; }
-  void setEnableSinkAndFold(bool Enable) { setOpt(EnableSinkAndFold, Enable); }
 
   bool requiresCodeGenSCCOrder() const { return RequireCodeGenSCCOrder; }
   void setRequiresCodeGenSCCOrder(bool Enable = true) {

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -137,7 +137,8 @@ namespace llvm {
           ApproxFuncFPMath(false), EnableAIXExtendedAltivecABI(false),
           HonorSignDependentRoundingFPMathOption(false), NoZerosInBSS(false),
           GuaranteedTailCallOpt(false), StackSymbolOrdering(true),
-          EnableFastISel(false), EnableGlobalISel(false), UseInitArray(false),
+          EnableSinkAndFold(false), EnableFastISel(false),
+          EnableGlobalISel(false), UseInitArray(false),
           DisableIntegratedAS(false), FunctionSections(false),
           DataSections(false), IgnoreXCOFFVisibility(false),
           XCOFFTracebackTable(true), UniqueSectionNames(true),
@@ -238,6 +239,11 @@ namespace llvm {
     /// heuristics). When false, the local symbols are left in whatever order
     /// they were generated. Default is true.
     unsigned StackSymbolOrdering : 1;
+
+    /// EnableSinkAndFold - Enable sinking of instructions in MachineSink where
+    /// a computation can be folded into the addressing mode of a memory
+    /// load/store instruction or replace a copy.
+    unsigned EnableSinkAndFold : 1;
 
     /// EnableFastISel - This flag enables fast-path instruction selection
     /// which trades away generated code quality in favor of reducing

--- a/llvm/lib/CodeGen/MachineSink.cpp
+++ b/llvm/lib/CodeGen/MachineSink.cpp
@@ -54,6 +54,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -729,7 +730,8 @@ bool MachineSinking::runOnMachineFunction(MachineFunction &MF) {
   AA = &getAnalysis<AAResultsWrapperPass>().getAAResults();
   RegClassInfo.runOnMachineFunction(MF);
   TargetPassConfig *PassConfig = &getAnalysis<TargetPassConfig>();
-  EnableSinkAndFold = PassConfig->getEnableSinkAndFold();
+  auto &TM = PassConfig->getTM<TargetMachine>();
+  EnableSinkAndFold = TM.Options.EnableSinkAndFold;
 
   bool EverMadeChange = false;
 

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -505,7 +505,7 @@ public:
       : TargetPassConfig(TM, PM) {
     if (TM.getOptLevel() != CodeGenOptLevel::None)
       substitutePass(&PostRASchedulerID, &PostMachineSchedulerID);
-    setEnableSinkAndFold(EnableSinkFold);
+    TM.Options.EnableSinkAndFold = EnableSinkFold;
   }
 
   AArch64TargetMachine &getAArch64TargetMachine() const {

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -337,7 +337,7 @@ public:
       : TargetPassConfig(TM, PM) {
     if (TM.getOptLevel() != CodeGenOptLevel::None)
       substitutePass(&PostRASchedulerID, &PostMachineSchedulerID);
-    setEnableSinkAndFold(EnableSinkFold);
+    TM.Options.EnableSinkAndFold = EnableSinkFold;
     EnableLoopTermFold = true;
   }
 


### PR DESCRIPTION
`EnableSinkAndFold` was in `TargetPassConfig` unavailable in the new pass infrastructure.