### PR TITLE
[Clang] Consider outer instantiation scopes for constraint normalization

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -975,7 +975,7 @@ static const Expr *SubstituteConstraintExpressionWithoutSatisfaction(
   std::optional<LocalInstantiationScope> ScopeForParameters;
   if (const NamedDecl *ND = DeclInfo.getDecl();
       ND && ND->isFunctionOrFunctionTemplate()) {
-    ScopeForParameters.emplace(S);
+    ScopeForParameters.emplace(S, /*CombineWithOuterScope=*/true);
     const FunctionDecl *FD = ND->getAsFunction();
     for (auto *PVD : FD->parameters()) {
       if (!PVD->isParameterPack()) {

--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -702,3 +702,19 @@ class TTP;
 C v;
 
 } // namespace GH93099
+
+namespace GH114685 {
+
+template <typename T> struct ptr {
+  template <typename U>
+  friend ptr<U> make_item(auto &&args)
+    requires(sizeof(args) > 1);
+};
+
+template <typename U>
+ptr<U> make_item(auto &&args)
+  requires(sizeof(args) > 1) {}
+
+ptr<char> p;
+
+} // namespace GH114685


### PR DESCRIPTION
We need to compare constraint expressions when instantiating a friend declaration that is lexically defined within a class template. Since the evaluation is deferred, the expression might refer to untransformed function parameters such that the substitution needs the mapping of instantiation.

These mappings are maintained by the function declaration instantiation, so we need to establish a "transparent" LocalInstantiationScope before substituting into the constraint.

No release note as this fixes a regression in 19.

Fixes https://github.com/llvm/llvm-project/issues/114685