### PR TITLE
[clang][bytecode][NFC] Make Floating::bitcastToMemory const

### DIFF
--- a/clang/lib/AST/ByteCode/Floating.h
+++ b/clang/lib/AST/ByteCode/Floating.h
@@ -135,7 +135,7 @@ public:
     return Floating(APFloat(Sem, API));
   }
 
-  void bitcastToMemory(std::byte *Buff) {
+  void bitcastToMemory(std::byte *Buff) const {
     llvm::APInt API = F.bitcastToAPInt();
     llvm::StoreIntToMemory(API, (uint8_t *)Buff, bitWidth() / 8);
   }

--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -321,7 +321,7 @@ static bool readPointerToBuffer(const Context &Ctx, const Pointer &FromPtr,
         // This is really just `long double` on x86, which is the only
         // fundamental type with padding bytes.
         if (T == PT_Float) {
-          Floating &F = P.deref<Floating>();
+          const Floating &F = P.deref<Floating>();
           unsigned NumBits =
               llvm::APFloatBase::getSizeInBits(F.getAPFloat().getSemantics());
           assert(NumBits % 8 == 0);


### PR DESCRIPTION
The other functions like this are also const.