### PR TITLE
Add Shafik and hstk30 as maintainers for issue triage

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -295,6 +295,15 @@ SYCL conformance
 | alexey.bader\@intel.com (email), bader (Phabricator), bader (GitHub)
 
 
+Issue Triage
+~~~~~~~~~~~~
+| Shafik Yaghmour
+| shafik.yaghmour\@intel.com (email), shafik (GitHub), shafik.yaghmour (Discord), shafik (Discourse)
+
+| hstk30
+| hanwei62\@huawei.com (email), hstk30-hw (GitHub), hstk30(Discord), hstk30 (Discourse)
+
+
 Inactive Maintainers
 ====================
 The following people have graciously spent time performing maintainership


### PR DESCRIPTION
Both volunteered for this role. Shafik has been actively performing these duties for a while and hstk30 is interested in volunteering in this space to help out.