### PR TITLE
Add -mno-unaligned-access and -mbig-endian to ARM and AArch64 multilib flags

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -230,15 +230,18 @@ static void getAArch64MultilibFlags(const Driver &D,
     Result.push_back(BranchProtectionArg->getAsString(Args));
   }
 
-  const Arg *StrictAlignArg = Args.getLastArgNoClaim(
-      options::OPT_mstrict_align, options::OPT_mno_unaligned_access);
-  if (StrictAlignArg) {
-    Result.push_back(StrictAlignArg->getAsString(Args));
+  if (Arg *AlignArg = Args.getLastArg(
+          options::OPT_mstrict_align, options::OPT_mno_strict_align,
+          options::OPT_mno_unaligned_access, options::OPT_munaligned_access)) {
+    if (AlignArg->getOption().matches(options::OPT_mstrict_align) ||
+        AlignArg->getOption().matches(options::OPT_mno_unaligned_access))
+      Result.push_back(AlignArg->getAsString(Args));
   }
 
-  const Arg *BigEndian = Args.getLastArgNoClaim(options::OPT_mbig_endian);
-  if (BigEndian) {
-    Result.push_back(BigEndian->getAsString(Args));
+  if (Arg *Endian = Args.getLastArg(options::OPT_mbig_endian,
+                                    options::OPT_mlittle_endian)) {
+    if (Endian->getOption().matches(options::OPT_mbig_endian))
+      Result.push_back(Endian->getAsString(Args));
   }
 
   const Arg *ABIArg = Args.getLastArgNoClaim(options::OPT_mabi_EQ);
@@ -299,15 +302,18 @@ static void getARMMultilibFlags(const Driver &D,
     Result.push_back(BranchProtectionArg->getAsString(Args));
   }
 
-  const Arg *StrictAlignArg = Args.getLastArgNoClaim(
-      options::OPT_mstrict_align, options::OPT_mno_unaligned_access);
-  if (StrictAlignArg) {
-    Result.push_back(StrictAlignArg->getAsString(Args));
+  if (Arg *AlignArg = Args.getLastArg(
+          options::OPT_mstrict_align, options::OPT_mno_strict_align,
+          options::OPT_mno_unaligned_access, options::OPT_munaligned_access)) {
+    if (AlignArg->getOption().matches(options::OPT_mstrict_align) ||
+        AlignArg->getOption().matches(options::OPT_mno_unaligned_access))
+      Result.push_back(AlignArg->getAsString(Args));
   }
 
-  const Arg *BigEndian = Args.getLastArgNoClaim(options::OPT_mbig_endian);
-  if (BigEndian) {
-    Result.push_back(BigEndian->getAsString(Args));
+  if (Arg *Endian = Args.getLastArg(options::OPT_mbig_endian,
+                                    options::OPT_mlittle_endian)) {
+    if (Endian->getOption().matches(options::OPT_mbig_endian))
+      Result.push_back(Endian->getAsString(Args));
   }
 }
 

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -230,6 +230,18 @@ static void getAArch64MultilibFlags(const Driver &D,
     Result.push_back(BranchProtectionArg->getAsString(Args));
   }
 
+  const Arg *StrictAlignArg =
+      Args.getLastArgNoClaim(options::OPT_mstrict_align, options::OPT_mno_unaligned_access);
+  if (StrictAlignArg) {
+    Result.push_back(StrictAlignArg->getAsString(Args));
+  }
+
+  const Arg *BigEndian =
+      Args.getLastArgNoClaim(options::OPT_mbig_endian);
+  if (BigEndian) {
+    Result.push_back(BigEndian->getAsString(Args));
+  }
+
   const Arg *ABIArg = Args.getLastArgNoClaim(options::OPT_mabi_EQ);
   if (ABIArg) {
     Result.push_back(ABIArg->getAsString(Args));
@@ -286,6 +298,19 @@ static void getARMMultilibFlags(const Driver &D,
       Args.getLastArgNoClaim(options::OPT_mbranch_protection_EQ);
   if (BranchProtectionArg) {
     Result.push_back(BranchProtectionArg->getAsString(Args));
+  }
+
+  const Arg *StrictAlignArg =
+      Args.getLastArgNoClaim(options::OPT_mstrict_align, options::
+OPT_mno_unaligned_access);
+  if (StrictAlignArg) {
+    Result.push_back(StrictAlignArg->getAsString(Args));
+  }
+
+  const Arg *BigEndian =
+      Args.getLastArgNoClaim(options::OPT_mbig_endian);
+  if (BigEndian) {
+    Result.push_back(BigEndian->getAsString(Args));
   }
 }
 

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -230,14 +230,13 @@ static void getAArch64MultilibFlags(const Driver &D,
     Result.push_back(BranchProtectionArg->getAsString(Args));
   }
 
-  const Arg *StrictAlignArg =
-      Args.getLastArgNoClaim(options::OPT_mstrict_align, options::OPT_mno_unaligned_access);
+  const Arg *StrictAlignArg = Args.getLastArgNoClaim(
+      options::OPT_mstrict_align, options::OPT_mno_unaligned_access);
   if (StrictAlignArg) {
     Result.push_back(StrictAlignArg->getAsString(Args));
   }
 
-  const Arg *BigEndian =
-      Args.getLastArgNoClaim(options::OPT_mbig_endian);
+  const Arg *BigEndian = Args.getLastArgNoClaim(options::OPT_mbig_endian);
   if (BigEndian) {
     Result.push_back(BigEndian->getAsString(Args));
   }
@@ -300,15 +299,13 @@ static void getARMMultilibFlags(const Driver &D,
     Result.push_back(BranchProtectionArg->getAsString(Args));
   }
 
-  const Arg *StrictAlignArg =
-      Args.getLastArgNoClaim(options::OPT_mstrict_align, options::
-OPT_mno_unaligned_access);
+  const Arg *StrictAlignArg = Args.getLastArgNoClaim(
+      options::OPT_mstrict_align, options::OPT_mno_unaligned_access);
   if (StrictAlignArg) {
     Result.push_back(StrictAlignArg->getAsString(Args));
   }
 
-  const Arg *BigEndian =
-      Args.getLastArgNoClaim(options::OPT_mbig_endian);
+  const Arg *BigEndian = Args.getLastArgNoClaim(options::OPT_mbig_endian);
   if (BigEndian) {
     Result.push_back(BigEndian->getAsString(Args));
   }

--- a/clang/test/Driver/print-multi-selection-flags.c
+++ b/clang/test/Driver/print-multi-selection-flags.c
@@ -68,6 +68,14 @@
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=aarch64-none-elf -mbranch-protection=standard | FileCheck --check-prefix=CHECK-BRANCH-PROTECTION %s
 // CHECK-BRANCH-PROTECTION: -mbranch-protection=standard
 
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=arm-none-eabi -mno-unaligned-access | FileCheck --check-prefix=CHECK-NO-UNALIGNED-ACCESS %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=aarch64-none-elf -mno-unaligned-access | FileCheck --check-prefix=CHECK-NO-UNALIGNED-ACCESS %s
+// CHECK-NO-UNALIGNED-ACCESS: -mno-unaligned-access
+
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=arm-none-eabi -mbig-endian | FileCheck --check-prefix=CHECK-BIG-ENDIAN %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=aarch64-none-elf -mbig-endian | FileCheck --check-prefix=CHECK-BIG-ENDIAN %s
+// CHECK-BIG-ENDIAN: -mbig-endian
+
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv32-none-elf -march=rv32g | FileCheck --check-prefix=CHECK-RV32 %s
 // CHECK-RV32: --target=riscv32-unknown-none-elf
 // CHECK-RV32: -mabi=ilp32d


### PR DESCRIPTION
This adds the -mno-unaligned-access and -mbig-endian command line options to the set of flags used by the multilib selection for ARM and AArch64 targets.