### PR TITLE
[libc++] Remove <stddef.h> includes from the granularized <cstddef> headers

### DIFF
--- a/libcxx/include/__cstddef/nullptr_t.h
+++ b/libcxx/include/__cstddef/nullptr_t.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___CSTDDEF_NULLPTR_T_H
 
 #include <__config>
-#include <stddef.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -18,7 +17,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::nullptr_t;
+using nullptr_t = decltype(nullptr);
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__cstddef/ptrdiff_t.h
+++ b/libcxx/include/__cstddef/ptrdiff_t.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___CSTDDEF_PTRDIFF_T_H
 
 #include <__config>
-#include <stddef.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -18,7 +17,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::ptrdiff_t _LIBCPP_USING_IF_EXISTS;
+using ptrdiff_t = decltype(static_cast<int*>(nullptr) - static_cast<int*>(nullptr));
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__cstddef/size_t.h
+++ b/libcxx/include/__cstddef/size_t.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___CSTDDEF_SIZE_T_H
 
 #include <__config>
-#include <stddef.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -18,7 +17,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::size_t _LIBCPP_USING_IF_EXISTS;
+using size_t = decltype(sizeof(int));
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__exception/exception_ptr.h
+++ b/libcxx/include/__exception/exception_ptr.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___EXCEPTION_EXCEPTION_PTR_H
 
 #include <__config>
+#include <__cstddef/nullptr_t.h>
 #include <__exception/operations.h>
 #include <__memory/addressof.h>
 #include <__memory/construct_at.h>

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -12,6 +12,7 @@
 
 #include <__assert>
 #include <__config>
+#include <__cstddef/nullptr_t.h>
 #include <__exception/exception.h>
 #include <__functional/binary_function.h>
 #include <__functional/invoke.h>

--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___FUNCTIONAL_HASH_H
 
 #include <__config>
+#include <__cstddef/nullptr_t.h>
 #include <__functional/unary_function.h>
 #include <__fwd/functional.h>
 #include <__type_traits/conjunction.h>

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -13,6 +13,7 @@
 #include <__compare/compare_three_way.h>
 #include <__compare/ordering.h>
 #include <__config>
+#include <__cstddef/nullptr_t.h>
 #include <__cstddef/ptrdiff_t.h>
 #include <__exception/exception.h>
 #include <__functional/binary_function.h>

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -200,6 +200,7 @@ template <class T, class Allocator, class Predicate>
 #include <__algorithm/lexicographical_compare_three_way.h>
 #include <__algorithm/min.h>
 #include <__config>
+#include <__cstddef/nullptr_t.h>
 #include <__iterator/distance.h>
 #include <__iterator/iterator_traits.h>
 #include <__iterator/move_iterator.h>

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -87,6 +87,7 @@ void  operator delete[](void* ptr, void*) noexcept;
 */
 
 #include <__config>
+#include <__cstddef/max_align_t.h>
 #include <__cstddef/size_t.h>
 #include <__exception/exception.h>
 #include <__type_traits/is_function.h>

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -208,6 +208,7 @@ namespace std {
 #include <__algorithm/min.h>
 #include <__assert>
 #include <__config>
+#include <__cstddef/nullptr_t.h>
 #include <__cstddef/ptrdiff_t.h>
 #include <__cstddef/size_t.h>
 #include <__functional/hash.h>

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cmp/cmp_nullptr.pass.cpp
@@ -37,8 +37,9 @@
 // template<class T>
 //     strong_ordering operator<=>(shared_ptr<T> const& x, nullptr_t) noexcept;   // C++20
 
-#include <memory>
 #include <cassert>
+#include <cstddef>
+#include <memory>
 
 #include "test_macros.h"
 #include "test_comparisons.h"

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
@@ -39,9 +39,9 @@
 //   constexpr compare_three_way_result_t<typename unique_ptr<T, D>::pointer>
 //     operator<=>(const unique_ptr<T, D>& x, nullptr_t);                        // C++20
 
-#include <memory>
 #include <cassert>
-#include <type_traits>
+#include <cstddef>
+#include <memory>
 
 #include "test_macros.h"
 #include "test_comparisons.h"


### PR DESCRIPTION
We can define some of these aliases without having to include the system <stddef.h> and there doesn't seem to be much of a reason we shouldn't do it this way.
