### PR TITLE
[clang][bytecode][NFC] Fix a possible build warning

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -88,9 +88,8 @@ struct BitcastBuffer {
   const std::byte *data() const { return Data.data(); }
 
   std::byte *getBytes(unsigned BitOffset) const {
-    if (BitOffset % 8 == 0)
-      return const_cast<std::byte *>(data() + (BitOffset / 8));
-    assert(false && "hmm, how to best handle this?");
+    assert(BitOffset % 8 == 0);
+    return const_cast<std::byte *>(data() + (BitOffset / 8));
   }
 
   bool allInitialized() const {


### PR DESCRIPTION
InterpBuiltinBitCast.cpp:95:3: warning: non-void function does not return a value in all control paths [-Wreturn-type]
   95 |   }
      |   ^
1 warning generated.