### PR TITLE
[lldb] Recommend Python 3.8 as the minimum Python version for LLDB

### DIFF
--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -66,8 +66,7 @@ else()
 endif()
 
 set(LLDB_RECOMMENDED_PYTHON "3.8")
-if(Python3_LIBRARIES AND Python3_INCLUDE_DIRS AND Python3_EXECUTABLE AND LLDB_ENABLE_SWIG
-   AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
+if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
   message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
                   "is recommended and will be required from LLDB 21.")
 endif()

--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -64,3 +64,10 @@ else()
                                       Python3_EXECUTABLE
                                       LLDB_ENABLE_SWIG)
 endif()
+
+set(LLDB_RECOMMENDED_PYTHON "3.8")
+if(Python3_LIBRARIES AND Python3_INCLUDE_DIRS AND Python3_EXECUTABLE AND LLDB_ENABLE_SWIG
+   AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
+  message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
+                  "is recommended and will be required from LLDB 21.")
+endif()

--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -51,21 +51,21 @@ CMake flag to ``On`` or ``Off`` to force the dependency to be enabled or
 disabled. When a dependency is set to ``On`` and can't be found it will cause a
 CMake configuration error.
 
-+-------------------+------------------------------------------------------+--------------------------+
-| Feature           | Description                                          | CMake Flag               |
-+===================+======================================================+==========================+
-| Editline          | Generic line editing, history, Emacs and Vi bindings | ``LLDB_ENABLE_LIBEDIT``  |
-+-------------------+------------------------------------------------------+--------------------------+
-| Curses            | Text user interface                                  | ``LLDB_ENABLE_CURSES``   |
-+-------------------+------------------------------------------------------+--------------------------+
-| LZMA              | Lossless data compression                            | ``LLDB_ENABLE_LZMA``     |
-+-------------------+------------------------------------------------------+--------------------------+
-| Libxml2           | XML                                                  | ``LLDB_ENABLE_LIBXML2``  |
-+-------------------+------------------------------------------------------+--------------------------+
-| Python            | Python scripting                                     | ``LLDB_ENABLE_PYTHON``   |
-+-------------------+------------------------------------------------------+--------------------------+
-| Lua               | Lua scripting. Lua 5.3 and 5.4 are supported.        | ``LLDB_ENABLE_LUA``      |
-+-------------------+------------------------------------------------------+--------------------------+
++-------------------+--------------------------------------------------------------+--------------------------+
+| Feature           | Description                                                  | CMake Flag               |
++===================+==============================================================+==========================+
+| Editline          | Generic line editing, history, Emacs and Vi bindings         | ``LLDB_ENABLE_LIBEDIT``  |
++-------------------+--------------------------------------------------------------+--------------------------+
+| Curses            | Text user interface                                          | ``LLDB_ENABLE_CURSES``   |
++-------------------+--------------------------------------------------------------+--------------------------+
+| LZMA              | Lossless data compression                                    | ``LLDB_ENABLE_LZMA``     |
++-------------------+--------------------------------------------------------------+--------------------------+
+| Libxml2           | XML                                                          | ``LLDB_ENABLE_LIBXML2``  |
++-------------------+--------------------------------------------------------------+--------------------------+
+| Python            | Python scripting. >= 3.0 is required, >= 3.8 is recommended. | ``LLDB_ENABLE_PYTHON``   |
++-------------------+--------------------------------------------------------------+--------------------------+
+| Lua               | Lua scripting. Lua 5.3 and 5.4 are supported.                | ``LLDB_ENABLE_LUA``      |
++-------------------+--------------------------------------------------------------+--------------------------+
 
 Depending on your platform and package manager, one might run any of the
 commands below.
@@ -75,7 +75,7 @@ commands below.
   $ yum install libedit-devel libxml2-devel ncurses-devel python-devel swig
   $ sudo apt-get install build-essential swig python3-dev libedit-dev libncurses5-dev libxml2-dev
   $ pkg install swig python libxml2
-  $ pkgin install swig python36 cmake ninja-build
+  $ pkgin install swig python38 cmake ninja-build
   $ brew install swig cmake ninja
 
 .. note::


### PR DESCRIPTION
See https://discourse.llvm.org/t/rfc-lets-document-and-enforce-a-minimum-python-version-for-lldb/82731 for discussions.

This matches LLVM's requirement to run tests. For LLDB 20 there will be a CMake warning telling builders that from LLDB 21 this will be a hard requirement. From LLDB 21, it will be an error to try to build with anything <= 3.8.

So there are no code changes in this commit. Once the llvm 20 branch is created we can remove some < 3.8 support code.

As always, if you disable Python support you will not get any new warnings or errors from this change.