### PR TITLE
[flang][Driver] When linking with the Fortran runtime, the `addArchSpecificRPath()` should be called too

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1293,6 +1293,7 @@ void tools::addFortranRuntimeLibs(const ToolChain &TC, const ArgList &Args,
     }
     CmdArgs.push_back("-lFortranRuntime");
     CmdArgs.push_back("-lFortranDecimal");
+    addArchSpecificRPath(TC, Args, CmdArgs);
   }
 
   // libomp needs libatomic for atomic operations if using libgcc

--- a/flang/test/Driver/arch-specific-libdir-rpath.f95
+++ b/flang/test/Driver/arch-specific-libdir-rpath.f95
@@ -16,6 +16,13 @@
 !
 ! Test that -rpath is added
 !
+! Add LIBPATH, RPATH
+!
+! RUN: %flang %s -### --target=x86_64-linux \
+! RUN:     -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_arch_subdir \
+! RUN:     -frtlib-add-rpath 2>&1 \
+! RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,RPATH-X86_64 %s
+!
 ! Add LIBPATH, RPATH for OpenMP
 !
 ! RUN: %flang %s -### --target=x86_64-linux -fopenmp \


### PR DESCRIPTION
When linking with other runtimes (OpenMP, sanitizers), the addArchSpecificRPath() is being called. The same thing should happen when linking with the Fortran runtime, this will improve user experience massively.