### PR TITLE
[NFC] Eliminate use of `lookupLLVMIntrinsicByName` in Coroutines

### DIFF
--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -100,8 +100,7 @@ static const char *const CoroIntrinsics[] = {
 
 #ifndef NDEBUG
 static bool isCoroutineIntrinsicName(StringRef Name) {
-  return Intrinsic::lookupLLVMIntrinsicByName(CoroIntrinsics, Name, "coro") !=
-         -1;
+  return llvm::binary_search(CoroIntrinsics, Name);
 }
 #endif
 
@@ -111,7 +110,6 @@ bool coro::isSuspendBlock(BasicBlock *BB) {
 
 bool coro::declaresAnyIntrinsic(const Module &M) {
   for (StringRef Name : CoroIntrinsics) {
-    assert(isCoroutineIntrinsicName(Name) && "not a coroutine intrinsic");
     if (M.getNamedValue(Name))
       return true;
   }


### PR DESCRIPTION
Eliminate use of `lookupLLVMIntrinsicByName` from Coroutines in preparation of changing it to support a different form of intrinsic name table generated by intrinsic emitter.

Also eliminate call to `isCoroutineIntrinsicName` from `declaresAnyIntrinsic` as the list of names traversed is the same list which `isCoroutineIntrinsicName` checks.