### PR TITLE
Add Chris as the HLSL maintainer

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -295,6 +295,12 @@ SYCL conformance
 | alexey.bader\@intel.com (email), bader (Phabricator), bader (GitHub)
 
 
+HLSL conformance
+~~~~~~~~~~~~~~~~
+| Chris Bieneman
+| chris.bieneman\@gmail.com (email), llvm-beanz (GitHub), beanz (Discord), beanz (Discourse)
+
+
 Issue Triage
 ~~~~~~~~~~~~
 | Shafik Yaghmour


### PR DESCRIPTION
Chris has extensive knowledge of HLSL and a long track-record of quality reviews in Clang.