### PR TITLE
Enable .ptr .global .align attributes for kernel attributes for CUDA

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1,4 +1,4 @@
-///===-- NVPTXAsmPrinter.cpp - NVPTX LLVM assembly writer ------------------===//
+//===-- NVPTXAsmPrinter.cpp - NVPTX LLVM assembly writer ------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1602,21 +1602,11 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
         if (PTy) {
           O << "\t.param .u" << PTySizeInBits << " .ptr ";
 
-          switch (PTy->getAddressSpace()) {
-          default:
-            break;
-          case ADDRESS_SPACE_GLOBAL:
-            O << ".global ";
-            break;
-          case ADDRESS_SPACE_SHARED:
-            O << ".shared ";
-            break;
-          case ADDRESS_SPACE_CONST:
-            O << ".const ";
-            break;
-          case ADDRESS_SPACE_LOCAL:
-            O << ".local ";
-            break;
+          const unsigned AddrSpace = PTy->getAddressSpace();
+          if (AddrSpace != ADDRESS_SPACE_GENERIC) {
+            O << ".";
+            emitPTXAddressSpace(AddrSpace, O);
+            O << " ";
           }
 
           const bool IsCUDA =

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1601,11 +1601,16 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
       if (isKernelFunc) {
         if (PTy) {
           // Special handling for pointer arguments to kernel
+          // CUDA kernels assume that pointers are in global address space
+          // See:
+          // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parameter-state-space
           O << "\t.param .u" << PTySizeInBits << " ";
 
-          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() !=
-              NVPTX::CUDA) {
-            int addrSpace = PTy->getAddressSpace();
+          int addrSpace = PTy->getAddressSpace();
+          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() == NVPTX::CUDA) {
+            assert(addrSpace == 0 && "Invalid address space");
+            O << ".ptr .global ";
+          } else {
             switch (addrSpace) {
             default:
               O << ".ptr ";
@@ -1620,13 +1625,9 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
               O << ".ptr .global ";
               break;
             }
-            Align ParamAlign = I->getParamAlign().valueOrOne();
-            O << ".align " << ParamAlign.value() << " ";
-          } else if (I->getParamAlign().valueOrOne() != 1) {
-            O << ".ptr .global ";
-            Align ParamAlign = I->getParamAlign().value();
-            O << ".align " << ParamAlign.value() << " ";
           }
+          Align ParamAlign = I->getParamAlign().valueOrOne();
+          O << ".align " << ParamAlign.value() << " ";
           O << TLI->getParamName(F, paramIndex);
           continue;
         }

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1607,7 +1607,8 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
           O << "\t.param .u" << PTySizeInBits << " ";
 
           int addrSpace = PTy->getAddressSpace();
-          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() == NVPTX::CUDA) {
+          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() ==
+              NVPTX::CUDA) {
             assert(addrSpace == 0 && "Invalid address space");
             O << ".ptr .global ";
           } else {

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1622,6 +1622,10 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
             }
             Align ParamAlign = I->getParamAlign().valueOrOne();
             O << ".align " << ParamAlign.value() << " ";
+          } else if (I->getParamAlign().valueOrOne() != 1) {
+            O << ".ptr .global ";
+            Align ParamAlign = I->getParamAlign().value();
+            O << ".align " << ParamAlign.value() << " ";
           }
           O << TLI->getParamName(F, paramIndex);
           continue;

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1600,10 +1600,6 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
 
       if (isKernelFunc) {
         if (PTy) {
-          // Special handling for pointer arguments to kernel
-          // CUDA kernels assume that pointers are in global address space
-          // See:
-          // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parameter-state-space
           O << "\t.param .u" << PTySizeInBits << " ";
 
           int addrSpace = PTy->getAddressSpace();

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1607,8 +1607,8 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
           O << "\t.param .u" << PTySizeInBits << " ";
 
           int addrSpace = PTy->getAddressSpace();
-          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() ==
-              NVPTX::CUDA) {
+
+          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() == NVPTX::CUDA) {
             // Special handling for pointer arguments to kernel
             // CUDA kernels assume that pointers are in global address space
             // See:

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1,4 +1,4 @@
-//===-- NVPTXAsmPrinter.cpp - NVPTX LLVM assembly writer ------------------===//
+///===-- NVPTXAsmPrinter.cpp - NVPTX LLVM assembly writer ------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -1603,18 +1603,12 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
           O << "\t.param .u" << PTySizeInBits << " ";
 
           int addrSpace = PTy->getAddressSpace();
-<<<<<<< HEAD
-
-          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() == NVPTX::CUDA) {
+          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() ==
+              NVPTX::CUDA) {
             // Special handling for pointer arguments to kernel
             // CUDA kernels assume that pointers are in global address space
             // See:
             // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parameter-state-space
-=======
-          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() ==
-              NVPTX::CUDA) {
->>>>>>> 3d49f303bf57 (Update NVPTXAsmPrinter.cpp)
-            assert(addrSpace == 0 && "Invalid address space");
             O << ".ptr .global ";
             if (I->getParamAlign().valueOrOne() != 1) {
               Align ParamAlign = I->getParamAlign().value();

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1607,12 +1607,17 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
           O << "\t.param .u" << PTySizeInBits << " ";
 
           int addrSpace = PTy->getAddressSpace();
+<<<<<<< HEAD
 
           if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() == NVPTX::CUDA) {
             // Special handling for pointer arguments to kernel
             // CUDA kernels assume that pointers are in global address space
             // See:
             // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parameter-state-space
+=======
+          if (static_cast<NVPTXTargetMachine &>(TM).getDrvInterface() ==
+              NVPTX::CUDA) {
+>>>>>>> 3d49f303bf57 (Update NVPTXAsmPrinter.cpp)
             assert(addrSpace == 0 && "Invalid address space");
             O << ".ptr .global ";
             if (I->getParamAlign().valueOrOne() != 1) {

--- a/llvm/test/CodeGen/NVPTX/i1-param.ll
+++ b/llvm/test/CodeGen/NVPTX/i1-param.ll
@@ -8,7 +8,7 @@ target triple = "nvptx-nvidia-cuda"
 
 ; CHECK: .entry foo
 ; CHECK:   .param .u8 foo_param_0
-; CHECK:   .param .u64 foo_param_1
+; CHECK:   .param .u64 .ptr .global foo_param_1
 define void @foo(i1 %p, ptr %out) {
   %val = zext i1 %p to i32
   store i32 %val, ptr %out

--- a/llvm/test/CodeGen/NVPTX/i1-param.ll
+++ b/llvm/test/CodeGen/NVPTX/i1-param.ll
@@ -8,7 +8,7 @@ target triple = "nvptx-nvidia-cuda"
 
 ; CHECK: .entry foo
 ; CHECK:   .param .u8 foo_param_0
-; CHECK:   .param .u64 .ptr foo_param_1
+; CHECK:   .param .u64 .ptr .align 1 foo_param_1
 define void @foo(i1 %p, ptr %out) {
   %val = zext i1 %p to i32
   store i32 %val, ptr %out

--- a/llvm/test/CodeGen/NVPTX/i1-param.ll
+++ b/llvm/test/CodeGen/NVPTX/i1-param.ll
@@ -8,7 +8,7 @@ target triple = "nvptx-nvidia-cuda"
 
 ; CHECK: .entry foo
 ; CHECK:   .param .u8 foo_param_0
-; CHECK:   .param .u64 .ptr .global foo_param_1
+; CHECK:   .param .u64 .ptr foo_param_1
 define void @foo(i1 %p, ptr %out) {
   %val = zext i1 %p to i32
   store i32 %val, ptr %out

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -3,10 +3,10 @@
 
 %struct.Large = type { [16 x double] }
 
-; CHECK-LABEL: func_align
+; CHECK-LABEL: .entry func_align(
 ; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
 ; CHECK: .param .u64 .ptr .global func_align_param_1,
-; CHECK: .param .u32 .ptr .global func_align_param_2
+; CHECK: .param .u64 .ptr .global func_align_param_2
 define void @func_align(ptr nocapture readonly align 16 %input, ptr nocapture %out, ptr addrspace(3) %n) {
 entry:
   %0 = addrspacecast ptr %out to ptr addrspace(1)
@@ -17,7 +17,7 @@ entry:
   ret void
 }
 
-; CHECK-LABEL: func
+; CHECK-LABEL: .entry func(
 ; CHECK: .param .u64 .ptr .global func_param_0,
 ; CHECK: .param .u64 .ptr .global func_param_1,
 ; CHECK: .param .u32 func_param_2

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -1,13 +1,19 @@
-; RUN: llc < %s -march=nvptx64 -mcpu=sm_72 2>&1 | FileCheck %s
-; RUN: %if ptxas %{ llc < %s -march=nvptx64 -mcpu=sm_72 | %ptxas-verify %}
+; RUN: llc < %s -march=nvptx64 -mcpu=sm_60 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -march=nvptx64 -mcpu=sm_60 | %ptxas-verify %}
 
 %struct.Large = type { [16 x double] }
 
 ; CHECK-LABEL: .entry func_align(
-; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
-; CHECK: .param .u64 .ptr .global func_align_param_1,
-; CHECK: .param .u64 .ptr .global func_align_param_2
-define void @func_align(ptr nocapture readonly align 16 %input, ptr nocapture %out, ptr addrspace(3) %n) {
+; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0
+; CHECK: .param .u64 .ptr .global .align 16 func_align_param_1
+; CHECK: .param .u64 .ptr .global .align 16 func_align_param_2
+; CHECK: .param .u64 .ptr .shared .align 16 func_align_param_3
+; CHECK: .param .u64 .ptr .const  .align 16 func_align_param_4
+define void @func_align(ptr nocapture readonly align 16 %input,
+                        ptr nocapture align 16 %out,
+                        ptr addrspace(1) align 16 %global,
+                        ptr addrspace(3) align 16 %shared,
+                        ptr addrspace(4) align 16 %const) {
 entry:
   %0 = addrspacecast ptr %out to ptr addrspace(1)
   %1 = addrspacecast ptr %input to ptr addrspace(1)
@@ -17,11 +23,17 @@ entry:
   ret void
 }
 
-; CHECK-LABEL: .entry func(
-; CHECK: .param .u64 .ptr .global func_param_0,
-; CHECK: .param .u64 .ptr .global func_param_1,
-; CHECK: .param .u32 func_param_2
-define void @func(ptr nocapture readonly %input, ptr nocapture %out, i32 %n) {
+; CHECK-LABEL: .entry func_noalign(
+; CHECK: .param .u64 .ptr .global func_noalign_param_0
+; CHECK: .param .u64 .ptr .global func_noalign_param_1
+; CHECK: .param .u64 .ptr .global func_noalign_param_2
+; CHECK: .param .u64 .ptr .shared func_noalign_param_3
+; CHECK: .param .u64 .ptr .const func_noalign_param_4
+define void @func_noalign(ptr nocapture readonly %input,
+                          ptr nocapture %out,
+                          ptr addrspace(1) %global,
+                          ptr addrspace(3) %shared,
+                          ptr addrspace(4) %const) {
 entry:
   %0 = addrspacecast ptr %out to ptr addrspace(1)
   %1 = addrspacecast ptr %input to ptr addrspace(1)
@@ -33,4 +45,4 @@ entry:
 
 !nvvm.annotations = !{!0, !1}
 !0 = !{ptr @func_align, !"kernel", i32 1}
-!1 = !{ptr @func, !"kernel", i32 1}
+!1 = !{ptr @func_noalign, !"kernel", i32 1}

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -4,7 +4,7 @@
 %struct.Large = type { [16 x double] }
 
 ; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
-; CHECK: .param .u64 func_align_param_1,
+; CHECK: .param .u64 .ptr .global func_align_param_1,
 ; CHECK: .param .u32 func_align_param_2
 define void @func_align(ptr nocapture readonly align 16 %input, ptr nocapture %out, i32 %n) {
 entry:
@@ -16,8 +16,8 @@ entry:
   ret void
 }
 
-; CHECK: .param .u64 func_param_0,
-; CHECK: .param .u64 func_param_1,
+; CHECK: .param .ptr .global .u64 func_param_0,
+; CHECK: .param .ptr .global .u64 func_param_1,
 ; CHECK: .param .u32 func_param_2
 define void @func(ptr nocapture readonly %input, ptr nocapture %out, i32 %n) {
 entry:

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -1,0 +1,34 @@
+; RUN: llc < %s -march=nvptx64 -mcpu=sm_72 2>&1 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -march=nvptx64 -mcpu=sm_72 | %ptxas-verify %}
+
+%struct.Large = type { [16 x double] }
+
+; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
+; CHECK: .param .u64 func_align_param_1,
+; CHECK: .param .u32 func_align_param_2
+define void @func_align(ptr nocapture readonly align 16 %input, ptr nocapture %out, i32 %n) {
+entry:
+  %0 = addrspacecast ptr %out to ptr addrspace(1)
+  %1 = addrspacecast ptr %input to ptr addrspace(1)
+  %getElem = getelementptr inbounds %struct.Large, ptr addrspace(1) %1, i64 0, i32 0, i64 5
+  %tmp2 = load i32, ptr addrspace(1) %getElem, align 8
+  store i32 %tmp2, ptr addrspace(1) %0, align 4
+  ret void
+}
+
+; CHECK: .param .u64 func_param_0,
+; CHECK: .param .u64 func_param_1,
+; CHECK: .param .u32 func_param_2
+define void @func(ptr nocapture readonly %input, ptr nocapture %out, i32 %n) {
+entry:
+  %0 = addrspacecast ptr %out to ptr addrspace(1)
+  %1 = addrspacecast ptr %input to ptr addrspace(1)
+  %getElem = getelementptr inbounds %struct.Large, ptr addrspace(1) %1, i64 0, i32 0, i64 5
+  %tmp2 = load i32, ptr addrspace(1) %getElem, align 8
+  store i32 %tmp2, ptr addrspace(1) %0, align 4
+  ret void
+}
+
+!nvvm.annotations = !{!0, !1}
+!0 = !{ptr @func_align, !"kernel", i32 1}
+!1 = !{ptr @func, !"kernel", i32 1}

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -21,12 +21,12 @@ entry:
 }
 
 ; CHECK-LABEL: .entry func_noalign(
-; CHECK: .param .u64 .ptr         func_noalign_param_0
-; CHECK: .param .u64 .ptr         func_noalign_param_1
-; CHECK: .param .u64 .ptr .global func_noalign_param_2
-; CHECK: .param .u64 .ptr .shared func_noalign_param_3
-; CHECK: .param .u64 .ptr .const  func_noalign_param_4
-; CHECK: .param .u64 .ptr .local  func_noalign_param_5
+; CHECK: .param .u64 .ptr         .align 1 func_noalign_param_0
+; CHECK: .param .u64 .ptr         .align 1 func_noalign_param_1
+; CHECK: .param .u64 .ptr .global .align 1 func_noalign_param_2
+; CHECK: .param .u64 .ptr .shared .align 1 func_noalign_param_3
+; CHECK: .param .u64 .ptr .const  .align 1 func_noalign_param_4
+; CHECK: .param .u64 .ptr .local  .align 1 func_noalign_param_5
 define void @func_noalign(ptr nocapture readonly %input,
                           ptr nocapture %out,
                           ptr addrspace(1) %global,

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -4,42 +4,36 @@
 %struct.Large = type { [16 x double] }
 
 ; CHECK-LABEL: .entry func_align(
-; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0
-; CHECK: .param .u64 .ptr .global .align 16 func_align_param_1
-; CHECK: .param .u64 .ptr .global .align 16 func_align_param_2
-; CHECK: .param .u64 .ptr .shared .align 16 func_align_param_3
+; CHECK: .param .u64 .ptr         .align 1  func_align_param_0
+; CHECK: .param .u64 .ptr         .align 2  func_align_param_1
+; CHECK: .param .u64 .ptr .global .align 4  func_align_param_2
+; CHECK: .param .u64 .ptr .shared .align 8  func_align_param_3
 ; CHECK: .param .u64 .ptr .const  .align 16 func_align_param_4
-define void @func_align(ptr nocapture readonly align 16 %input,
-                        ptr nocapture align 16 %out,
-                        ptr addrspace(1) align 16 %global,
-                        ptr addrspace(3) align 16 %shared,
-                        ptr addrspace(4) align 16 %const) {
+; CHECK: .param .u64 .ptr .local  .align 32 func_align_param_5
+define void @func_align(ptr nocapture readonly align 1 %input,
+                        ptr nocapture align 2 %out,
+                        ptr addrspace(1) align 4 %global,
+                        ptr addrspace(3) align 8 %shared,
+                        ptr addrspace(4) align 16 %const,
+                        ptr addrspace(5) align 32 %local) {
 entry:
-  %0 = addrspacecast ptr %out to ptr addrspace(1)
-  %1 = addrspacecast ptr %input to ptr addrspace(1)
-  %getElem = getelementptr inbounds %struct.Large, ptr addrspace(1) %1, i64 0, i32 0, i64 5
-  %tmp2 = load i32, ptr addrspace(1) %getElem, align 8
-  store i32 %tmp2, ptr addrspace(1) %0, align 4
   ret void
 }
 
 ; CHECK-LABEL: .entry func_noalign(
-; CHECK: .param .u64 .ptr .global func_noalign_param_0
-; CHECK: .param .u64 .ptr .global func_noalign_param_1
+; CHECK: .param .u64 .ptr         func_noalign_param_0
+; CHECK: .param .u64 .ptr         func_noalign_param_1
 ; CHECK: .param .u64 .ptr .global func_noalign_param_2
 ; CHECK: .param .u64 .ptr .shared func_noalign_param_3
-; CHECK: .param .u64 .ptr .const func_noalign_param_4
+; CHECK: .param .u64 .ptr .const  func_noalign_param_4
+; CHECK: .param .u64 .ptr .local  func_noalign_param_5
 define void @func_noalign(ptr nocapture readonly %input,
                           ptr nocapture %out,
                           ptr addrspace(1) %global,
                           ptr addrspace(3) %shared,
-                          ptr addrspace(4) %const) {
+                          ptr addrspace(4) %const,
+                          ptr addrspace(5) %local) {
 entry:
-  %0 = addrspacecast ptr %out to ptr addrspace(1)
-  %1 = addrspacecast ptr %input to ptr addrspace(1)
-  %getElem = getelementptr inbounds %struct.Large, ptr addrspace(1) %1, i64 0, i32 0, i64 5
-  %tmp2 = load i32, ptr addrspace(1) %getElem, align 8
-  store i32 %tmp2, ptr addrspace(1) %0, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -6,7 +6,7 @@
 ; CHECK-LABEL: func_align
 ; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
 ; CHECK: .param .u64 .ptr .global func_align_param_1,
-; CHECK: .param .u64 .ptr .global func_align_param_2
+; CHECK: .param .u32 .ptr .global func_align_param_2
 define void @func_align(ptr nocapture readonly align 16 %input, ptr nocapture %out, ptr addrspace(3) %n) {
 entry:
   %0 = addrspacecast ptr %out to ptr addrspace(1)

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -5,7 +5,7 @@
 
 ; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
 ; CHECK: .param .u64 .ptr .global func_align_param_1,
-; CHECK: .param .u32 .ptr .global func_align_param_2
+; CHECK: .param .u32 func_align_param_2
 define void @func_align(ptr nocapture readonly align 16 %input, ptr addrspace(3) nocapture %out, i32 %n) {
 entry:
   %0 = addrspacecast ptr %out to ptr addrspace(1)

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -5,8 +5,8 @@
 
 ; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
 ; CHECK: .param .u64 .ptr .global func_align_param_1,
-; CHECK: .param .u32 func_align_param_2
-define void @func_align(ptr nocapture readonly align 16 %input, ptr nocapture %out, i32 %n) {
+; CHECK: .param .u32 .ptr .global func_align_param_2
+define void @func_align(ptr nocapture readonly align 16 %input, ptr addrspace(3) nocapture %out, i32 %n) {
 entry:
   %0 = addrspacecast ptr %out to ptr addrspace(1)
   %1 = addrspacecast ptr %input to ptr addrspace(1)

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -6,8 +6,8 @@
 ; CHECK-LABEL: func_align
 ; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
 ; CHECK: .param .u64 .ptr .global func_align_param_1,
-; CHECK: .param .u32 func_align_param_2
-define void @func_align(ptr nocapture readonly align 16 %input, ptr addrspace(3) nocapture %out, i32 %n) {
+; CHECK: .param .u64 .ptr .global func_align_param_2
+define void @func_align(ptr nocapture readonly align 16 %input, ptr nocapture %out, ptr addrspace(3) %n) {
 entry:
   %0 = addrspacecast ptr %out to ptr addrspace(1)
   %1 = addrspacecast ptr %input to ptr addrspace(1)
@@ -18,8 +18,8 @@ entry:
 }
 
 ; CHECK-LABEL: func
-; CHECK: .param .ptr .global .u64 func_param_0,
-; CHECK: .param .ptr .global .u64 func_param_1,
+; CHECK: .param .u64 .ptr .global func_param_0,
+; CHECK: .param .u64 .ptr .global func_param_1,
 ; CHECK: .param .u32 func_param_2
 define void @func(ptr nocapture readonly %input, ptr nocapture %out, i32 %n) {
 entry:

--- a/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
+++ b/llvm/test/CodeGen/NVPTX/kernel-param-align.ll
@@ -3,6 +3,7 @@
 
 %struct.Large = type { [16 x double] }
 
+; CHECK-LABEL: func_align
 ; CHECK: .param .u64 .ptr .global .align 16 func_align_param_0,
 ; CHECK: .param .u64 .ptr .global func_align_param_1,
 ; CHECK: .param .u32 func_align_param_2
@@ -16,6 +17,7 @@ entry:
   ret void
 }
 
+; CHECK-LABEL: func
 ; CHECK: .param .ptr .global .u64 func_param_0,
 ; CHECK: .param .ptr .global .u64 func_param_1,
 ; CHECK: .param .u32 func_param_2


### PR DESCRIPTION
The current issue is PTX doesn't vectorise load and stores that can be vectorized.

We noticed that we were missing vectorization for sin, cos and power operations from LLVM resulting in lesser speedup. The reason is currently we don't generate any .ptr and .align attributes for kernel parameters in CUDA and the required alignment information is missing. This results in missing out on vectorization opportunities.
The change enables adding .align attribute for alignment information and .ptr attribute for kernel pointers in kernel parameters under the assumption that all kernel parameters pointers point to global memory space. This results in vectorization and boosting the speedup by ~2x.
.align is enabled only when the pointer has explicit alignment specifier.

PTX ISA doc - https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#kernel-parameter-attribute-ptr

This is a rework of the original patch proposed in #79646