### PR TITLE
[SPIR-V] No OpBitcast is generated for a bitcast between identical types

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -175,10 +175,13 @@ static void buildOpBitcast(SPIRVGlobalRegistry *GR, MachineIRBuilder &MIB,
   MachineRegisterInfo *MRI = MIB.getMRI();
   if (!MRI->getRegClassOrNull(ResVReg))
     MRI->setRegClass(ResVReg, GR->getRegClass(ResType));
-  MIB.buildInstr(SPIRV::OpBitcast)
-      .addDef(ResVReg)
-      .addUse(GR->getSPIRVTypeID(ResType))
-      .addUse(OpReg);
+  if (ResType == OpType)
+    MIB.buildInstr(TargetOpcode::COPY).addDef(ResVReg).addUse(OpReg);
+  else
+    MIB.buildInstr(SPIRV::OpBitcast)
+        .addDef(ResVReg)
+        .addUse(GR->getSPIRVTypeID(ResType))
+        .addUse(OpReg);
 }
 
 // We do instruction selections early instead of calling MIB.buildBitcast()

--- a/llvm/test/CodeGen/SPIRV/no-opbitcast-between-identical-types.ll
+++ b/llvm/test/CodeGen/SPIRV/no-opbitcast-between-identical-types.ll
@@ -1,0 +1,17 @@
+; The goal of the test case is to ensure that no OpBitcast is generated for a bitcast between identical types.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: OpFunction
+; CHECK-NO: OpBitcast
+; CHECK: OpReturn
+
+define void @foo() {
+entry:
+  %r = bitcast i32 0 to i32
+  ret void
+}


### PR DESCRIPTION
The goal of the PR is to ensure that no OpBitcast is generated for a bitcast between identical types.

This PR resolves https://github.com/llvm/llvm-project/issues/114482