### PR TITLE
[ItaniumMangle] Fix `cp` versus `cl` call expression mangling for block scope

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4628,12 +4628,17 @@ static bool isParenthesizedADLCallee(const CallExpr *call) {
       (*lookup->decls_begin())->isCXXClassMember())
     return false;
 
-  // Must not have found a block scope declaration.  Note that a block scope
-  // declaration may be present alongside other declarations because of using
-  // declarations.
-  for (const auto &decl : lookup.decls())
+  // Must not have found a block scope declaration other than declarations
+  // resulting from using declarations.
+  for (const auto &decl : lookup->decls()) {
+    if (isa<UsingShadowDecl>(*decl))
+      continue;
     if (decl->isLocalExternDecl())
       return false;
+    // If, ignoring using declarations, a non-block scope declaration was
+    // found, then there are no block-scope declarations.
+    break;
+  }
 
   // Otherwise, ADL would have been triggered.
   return true;

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4628,6 +4628,13 @@ static bool isParenthesizedADLCallee(const CallExpr *call) {
       (*lookup->decls_begin())->isCXXClassMember())
     return false;
 
+  // Must not have found a block scope declaration.  Note that a block scope
+  // declaration may be present alongside other declarations because of using
+  // declarations.
+  for (const auto &decl : lookup.decls())
+    if (decl->isLocalExternDecl())
+      return false;
+
   // Otherwise, ADL would have been triggered.
   return true;
 }

--- a/clang/test/CodeGenCXX/mangle-exprs.cpp
+++ b/clang/test/CodeGenCXX/mangle-exprs.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -fclang-abi-compat=latest -emit-llvm %s -o - -triple=x86_64-apple-darwin9 | FileCheck %s
+// RUN: %clang_cc1 -std=c++14 -fclang-abi-compat=latest -emit-llvm %s -o - -triple=x86_64-apple-darwin9 | FileCheck %s
 
 namespace std {
   typedef decltype(sizeof(int)) size_t;
@@ -118,9 +118,30 @@ namespace test1 {
   // CHECK-LABEL: define linkonce_odr noundef signext i16 @_ZN5test11bIsEEDTcp3foocvT__EEES1_(
   template <class T> auto b(T t) -> decltype((foo)(T())) { return (foo)(t); }
 
+  inline short *c(short s) {
+    using test1::foo;
+    void *foo(void *);
+    // CHECK-LABEL: define {{.*}} @_ZZN5test11cEsENKUlT_E_clIsEEPDTcl3foofp_EES0_(
+    return [](auto t) -> decltype((foo)(t)) * {
+      static auto x = (foo)(t);
+      return &x;
+    }(s);
+  }
+
+  inline short *d(short s) {
+    using test1::foo;
+    // CHECK-LABEL: define {{.*}} @_ZZN5test11dEsENKUlT_E_clIsEEPDTcp3foofp_EES0_(
+    return [](auto t) -> decltype((foo)(t)) * {
+      static auto x = (foo)(t);
+      return &x;
+    }(s);
+  }
+
   void test(short s) {
     a(s);
     b(s);
+    c(s);
+    d(s);
   }
 }
 

--- a/clang/test/CodeGenCXX/mangle-exprs.cpp
+++ b/clang/test/CodeGenCXX/mangle-exprs.cpp
@@ -118,20 +118,22 @@ namespace test1 {
   // CHECK-LABEL: define linkonce_odr noundef signext i16 @_ZN5test11bIsEEDTcp3foocvT__EEES1_(
   template <class T> auto b(T t) -> decltype((foo)(T())) { return (foo)(t); }
 
+  // CHECK-LABEL: define {{.*}} @_ZN5test11cEs(
   inline short *c(short s) {
     using test1::foo;
     void *foo(void *);
-    // CHECK-LABEL: define {{.*}} @_ZZN5test11cEsENKUlT_E_clIsEEPDTcl3foofp_EES0_(
+    // CHECK: = call {{.*}} @_ZZN5test11cEsENKUlT_E_clIsEEPDTcl3foofp_EES0_(
     return [](auto t) -> decltype((foo)(t)) * {
       static auto x = (foo)(t);
       return &x;
     }(s);
   }
 
+  // CHECK-LABEL: define {{.*}} @_ZN5test11dEs(
   inline short *d(short s) {
     using test1::foo;
-    // CHECK-LABEL: define {{.*}} @_ZZN5test11dEsENKUlT_E_clIsEEPDTcp3foofp_EES0_(
-    return [](auto t) -> decltype((foo)(t)) * {
+    // CHECK: = call {{.*}} @_ZZN5test11dEsENKUlT_E_clIsEEPDTcp3foodeadfp_EES0_(
+    return [](auto t) -> decltype((foo)(*&t)) * {
       static auto x = (foo)(t);
       return &x;
     }(s);


### PR DESCRIPTION
This patch updates to use the `cl` mangling when a declaration at block
scope (suppressing ADL) is encountered. This improves compatibility with
GCC and is consistent with the wording proposed by
itanium-cxx-abi/cxx-abi#196.