### PR TITLE
Fix a thinko in the CallSite handling code:

### DIFF
--- a/lldb/source/Symbol/CompileUnit.cpp
+++ b/lldb/source/Symbol/CompileUnit.cpp
@@ -326,10 +326,11 @@ void CompileUnit::ResolveSymbolContext(
   // the function containing the PC of the line table match.  That way we can
   // limit the call site search to that function.
   // We will miss functions that ONLY exist as a call site entry.
-  
+
   if (line_entry.IsValid() &&
-      (line_entry.line != line || (column_num != 0 && line_entry.column != column_num))
-      && (resolve_scope & eSymbolContextLineEntry) && check_inlines) {
+      (line_entry.line != line ||
+       (column_num != 0 && line_entry.column != column_num)) &&
+      (resolve_scope & eSymbolContextLineEntry) && check_inlines) {
     // We don't move lines over function boundaries, so the address in the
     // line entry will be the in function that contained the line that might
     // be a CallSite, and we can just iterate over that function to find any

--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/Makefile
@@ -1,0 +1,19 @@
+CXX_SOURCES := main.cpp
+LD_EXTRAS := ns1.o ns2.o ns3.o ns4.o
+
+a.out: main.o ns1.o ns2.o ns3.o ns4.o
+
+ns1.o: common.cpp
+	$(CC) -g -c -DNAMESPACE=ns1 -o $@ $<
+
+ns2.o: common.cpp
+	$(CC) -g -c -DNAMESPACE=ns2 -o $@ $<
+
+ns3.o: common.cpp
+	$(CC) -g -c -DNAMESPACE=ns3 -o $@ $<
+
+ns4.o: common.cpp
+	$(CC) -g -c -DNAMESPACE=ns4 -o $@ $<
+
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/TestFileBreakpoinsSameCUName.py
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/TestFileBreakpoinsSameCUName.py
@@ -19,11 +19,14 @@ class TestBreakpointSameCU(TestBase):
         comment_line = line_number("common.cpp", "// A comment here")
         self.assertNotEqual(comment_line, 0, "line_number worked")
         bkpt = target.BreakpointCreateByLocation("common.cpp", comment_line)
-        self.assertEqual(bkpt.GetNumLocations(), 4, "Got the right number of breakpoints")
+        self.assertEqual(
+            bkpt.GetNumLocations(), 4, "Got the right number of breakpoints"
+        )
 
         # And break on the code, both should work:
         code_line = line_number("common.cpp", "// The line with code")
         self.assertNotEqual(comment_line, 0, "line_number worked again")
         bkpt = target.BreakpointCreateByLocation("common.cpp", code_line)
-        self.assertEqual(bkpt.GetNumLocations(), 4, "Got the right number of breakpoints")
-        
+        self.assertEqual(
+            bkpt.GetNumLocations(), 4, "Got the right number of breakpoints"
+        )

--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/TestFileBreakpoinsSameCUName.py
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/TestFileBreakpoinsSameCUName.py
@@ -1,0 +1,29 @@
+"""
+Test setting a breakpoint by file and line when many instances of the
+same file name exist in the CU list.
+"""
+
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestBreakpointSameCU(TestBase):
+    def test_breakpoint_same_cu(self):
+        self.build()
+        target = self.createTestTarget()
+
+        # Break both on the line before the code:
+        comment_line = line_number("common.cpp", "// A comment here")
+        self.assertNotEqual(comment_line, 0, "line_number worked")
+        bkpt = target.BreakpointCreateByLocation("common.cpp", comment_line)
+        self.assertEqual(bkpt.GetNumLocations(), 4, "Got the right number of breakpoints")
+
+        # And break on the code, both should work:
+        code_line = line_number("common.cpp", "// The line with code")
+        self.assertNotEqual(comment_line, 0, "line_number worked again")
+        bkpt = target.BreakpointCreateByLocation("common.cpp", code_line)
+        self.assertEqual(bkpt.GetNumLocations(), 4, "Got the right number of breakpoints")
+        

--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/common.cpp
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/common.cpp
@@ -1,0 +1,12 @@
+#define XSTR(x) STR(x)
+#define STR(x) #x
+
+
+namespace NAMESPACE {
+  static int g_value = 0;
+void DoSomeStuff() {
+  // A comment here
+  g_value++; // The line with code
+}
+
+}  // end NAMESPACE

--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/common.cpp
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/common.cpp
@@ -1,12 +1,8 @@
-#define XSTR(x) STR(x)
-#define STR(x) #x
-
-
 namespace NAMESPACE {
-  static int g_value = 0;
+static int g_value = 0;
 void DoSomeStuff() {
   // A comment here
   g_value++; // The line with code
 }
 
-}  // end NAMESPACE
+} // namespace NAMESPACE

--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/main.cpp
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/main.cpp
@@ -1,0 +1,25 @@
+namespace ns1 {
+  extern void DoSomeStuff();
+}
+
+namespace ns2 {
+  extern void DoSomeStuff();
+}
+
+namespace ns3 {
+  extern void DoSomeStuff();
+}
+
+namespace ns4 {
+  extern void DoSomeStuff();
+}
+
+
+int main(int argc, char* argv[]) {
+  ns1::DoSomeStuff();
+  ns2::DoSomeStuff();
+  ns3::DoSomeStuff();
+  ns4::DoSomeStuff();
+
+  return 0;
+}

--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/main.cpp
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/main.cpp
@@ -1,21 +1,20 @@
 namespace ns1 {
-  extern void DoSomeStuff();
+extern void DoSomeStuff();
 }
 
 namespace ns2 {
-  extern void DoSomeStuff();
+extern void DoSomeStuff();
 }
 
 namespace ns3 {
-  extern void DoSomeStuff();
+extern void DoSomeStuff();
 }
 
 namespace ns4 {
-  extern void DoSomeStuff();
+extern void DoSomeStuff();
 }
 
-
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
   ns1::DoSomeStuff();
   ns2::DoSomeStuff();
   ns3::DoSomeStuff();


### PR DESCRIPTION
I have to check for the sc list size being changed by the call-site search, not just that it had more than one element.

Added a test for multiple CU's with the same name in a given module, which would have caught this mistake.

We were also doing all the work to find call sites when the found decl and specified decl's only difference was a column, but the incoming specification hadn't specified a column (column number == 0).