### PR TITLE
[Clang] Improve EmitClangAttrSpellingListIndex

### DIFF
--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -67,16 +67,7 @@ public:
     IgnoredAttribute,
     UnknownAttribute,
   };
-  enum Scope {
-    SC_NONE,
-    SC_CLANG,
-    SC_GNU,
-    SC_MSVC,
-    SC_OMP,
-    SC_HLSL,
-    SC_GSL,
-    SC_RISCV
-  };
+  enum class Scope { NONE, CLANG, GNU, MSVC, OMP, HLSL, GSL, RISCV };
 
 private:
   const IdentifierInfo *AttrName = nullptr;

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -67,6 +67,16 @@ public:
     IgnoredAttribute,
     UnknownAttribute,
   };
+  enum Scope {
+    SC_NONE,
+    SC_CLANG,
+    SC_GNU,
+    SC_MSVC,
+    SC_OMP,
+    SC_HLSL,
+    SC_GSL,
+    SC_RISCV
+  };
 
 private:
   const IdentifierInfo *AttrName = nullptr;

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -17,6 +17,8 @@
 #include "clang/Basic/ParsedAttrInfo.h"
 #include "clang/Basic/TargetInfo.h"
 
+#include "llvm/ADT/StringMap.h"
+
 using namespace clang;
 
 static int hasAttributeImpl(AttributeCommonInfo::Syntax Syntax, StringRef Name,
@@ -153,18 +155,18 @@ std::string AttributeCommonInfo::getNormalizedFullName() const {
       normalizeName(getAttrName(), getScopeName(), getSyntax()));
 }
 
-const std::map<StringRef, AttributeCommonInfo::Scope> ScopeMap = {
-    {"", AttributeCommonInfo::SC_NONE},
-    {"clang", AttributeCommonInfo::SC_CLANG},
-    {"gnu", AttributeCommonInfo::SC_GNU},
-    {"msvc", AttributeCommonInfo::SC_MSVC},
-    {"omp", AttributeCommonInfo::SC_OMP},
-    {"hlsl", AttributeCommonInfo::SC_HLSL},
-    {"gsl", AttributeCommonInfo::SC_GSL},
-    {"riscv", AttributeCommonInfo::SC_RISCV}};
+const llvm::StringMap<AttributeCommonInfo::Scope> ScopeMap = {
+    {"", AttributeCommonInfo::Scope::NONE},
+    {"clang", AttributeCommonInfo::Scope::CLANG},
+    {"gnu", AttributeCommonInfo::Scope::GNU},
+    {"msvc", AttributeCommonInfo::Scope::MSVC},
+    {"omp", AttributeCommonInfo::Scope::OMP},
+    {"hlsl", AttributeCommonInfo::Scope::HLSL},
+    {"gsl", AttributeCommonInfo::Scope::GSL},
+    {"riscv", AttributeCommonInfo::Scope::RISCV}};
 
 AttributeCommonInfo::Scope
-getScopeFromNormalizedScopeName(const StringRef ScopeName) {
+getScopeFromNormalizedScopeName(StringRef ScopeName) {
   auto It = ScopeMap.find(ScopeName);
   if (It == ScopeMap.end()) {
     llvm_unreachable("Unknown normalized scope name. Shouldn't get here");

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -155,20 +155,24 @@ std::string AttributeCommonInfo::getNormalizedFullName() const {
       normalizeName(getAttrName(), getScopeName(), getSyntax()));
 }
 
-const llvm::StringMap<AttributeCommonInfo::Scope> ScopeMap = {
-    {"", AttributeCommonInfo::Scope::NONE},
-    {"clang", AttributeCommonInfo::Scope::CLANG},
-    {"gnu", AttributeCommonInfo::Scope::GNU},
-    {"msvc", AttributeCommonInfo::Scope::MSVC},
-    {"omp", AttributeCommonInfo::Scope::OMP},
-    {"hlsl", AttributeCommonInfo::Scope::HLSL},
-    {"gsl", AttributeCommonInfo::Scope::GSL},
-    {"riscv", AttributeCommonInfo::Scope::RISCV}};
+// Sorted list of attribute scope names
+static constexpr std::pair<StringRef, AttributeCommonInfo::Scope> ScopeList[] =
+    {{"", AttributeCommonInfo::Scope::NONE},
+     {"clang", AttributeCommonInfo::Scope::CLANG},
+     {"gnu", AttributeCommonInfo::Scope::GNU},
+     {"gsl", AttributeCommonInfo::Scope::GSL},
+     {"hlsl", AttributeCommonInfo::Scope::HLSL},
+     {"msvc", AttributeCommonInfo::Scope::MSVC},
+     {"omp", AttributeCommonInfo::Scope::OMP},
+     {"riscv", AttributeCommonInfo::Scope::RISCV}};
 
 AttributeCommonInfo::Scope
 getScopeFromNormalizedScopeName(StringRef ScopeName) {
-  auto It = ScopeMap.find(ScopeName);
-  assert(It != ScopeMap.end());
+  auto It = std::lower_bound(
+      std::begin(ScopeList), std::end(ScopeList), ScopeName,
+      [](const std::pair<StringRef, AttributeCommonInfo::Scope> &Element,
+         StringRef Value) { return Element.first < Value; });
+  assert(It != std::end(ScopeList));
 
   return It->second;
 }

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -172,7 +172,7 @@ getScopeFromNormalizedScopeName(StringRef ScopeName) {
       std::begin(ScopeList), std::end(ScopeList), ScopeName,
       [](const std::pair<StringRef, AttributeCommonInfo::Scope> &Element,
          StringRef Value) { return Element.first < Value; });
-  assert(It != std::end(ScopeList));
+  assert(It != std::end(ScopeList) && It->first == ScopeName);
 
   return It->second;
 }

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -168,9 +168,7 @@ const llvm::StringMap<AttributeCommonInfo::Scope> ScopeMap = {
 AttributeCommonInfo::Scope
 getScopeFromNormalizedScopeName(StringRef ScopeName) {
   auto It = ScopeMap.find(ScopeName);
-  if (It == ScopeMap.end()) {
-    llvm_unreachable("Unknown normalized scope name. Shouldn't get here");
-  }
+  assert(It != ScopeMap.end());
 
   return It->second;
 }

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -16,7 +16,6 @@
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/ParsedAttrInfo.h"
 #include "clang/Basic/TargetInfo.h"
-#include "llvm/ADT/StringMap.h"
 
 using namespace clang;
 
@@ -154,7 +153,7 @@ std::string AttributeCommonInfo::getNormalizedFullName() const {
       normalizeName(getAttrName(), getScopeName(), getSyntax()));
 }
 
-static const llvm::StringMap<AttributeCommonInfo::Scope> ScopeMap = {
+const std::map<StringRef, AttributeCommonInfo::Scope> ScopeMap = {
     {"", AttributeCommonInfo::SC_NONE},
     {"clang", AttributeCommonInfo::SC_CLANG},
     {"gnu", AttributeCommonInfo::SC_GNU},

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3861,22 +3861,21 @@ void EmitClangAttrSpellingListIndex(const RecordKeeper &Records,
     Names.erase(llvm::unique(Names), Names.end());
 
     for (const auto &[Idx, FS] : enumerate(Spellings)) {
-      if (Names.size() == 1) {
-        OS << "    if (";
-      } else {
+      OS << "    if (";
+      if (Names.size() > 1) {
         SmallVector<StringRef, 6> SameLenNames;
         llvm::copy_if(
             Names, std::back_inserter(SameLenNames),
             [&](StringRef N) { return N.size() == FS.name().size(); });
 
         if (SameLenNames.size() == 1) {
-          OS << "    if (Name.size() == " << FS.name().size() << " && ";
+          OS << "Name.size() == " << FS.name().size() << " && ";
         } else {
           // FIXME: We currently fall back to comparing entire strings if there
           // are 2 or more spelling names with the same length. This can be
           // optimized to check only for the the first differing character
           // between them instead.
-          OS << "    if (Name == \"" << FS.name() << "\""
+          OS << "Name == \"" << FS.name() << "\""
              << " && ";
         }
       }


### PR DESCRIPTION
`EmitClangAttrSpellingListIndex()` performs a lot of unnecessary string comparisons which is wasteful in time and stack space. This commit attempts to refactor this method to be more performant.

New and old `AttrSpellingListIndex.inc` files can be found here - https://gist.github.com/chinmaydd/1733a9a84932a45678c47f31be4d64d7. (CTRL-F for NEW_INC_FILE and OLD_INC_FILE)

Previous discussion can be found here: https://github.com/llvm/llvm-project/pull/114285.