### PR TITLE
[compiler-rt] Destroy pthread attrs after use in tests

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/fake_stack_gc.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/fake_stack_gc.cpp
@@ -89,6 +89,7 @@ int main(void) {
 
   pthread_t tid;
   assert(pthread_create(&tid, &attr, Thread, alt_stack) == 0);
+  assert(pthread_attr_destroy(&attr) == 0);
 
   pthread_join(tid, nullptr);
 

--- a/compiler-rt/test/asan/TestCases/Posix/unpoison-alternate-stack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/unpoison-alternate-stack.cpp
@@ -159,6 +159,7 @@ int main() {
   pthread_attr_init(&ThreadAttr);
   pthread_attr_setstack(&ThreadAttr, Mapping, DefaultStackSize);
   pthread_create(&Thread, &ThreadAttr, &threadFun, (void *)&AltStack);
+  pthread_attr_destroy(&ThreadAttr);
 
   pthread_join(Thread, nullptr);
 

--- a/compiler-rt/test/lsan/TestCases/leak_check_before_thread_started.cpp
+++ b/compiler-rt/test/lsan/TestCases/leak_check_before_thread_started.cpp
@@ -37,6 +37,7 @@ void create_detached_thread() {
   pthread_mutex_lock(&mutex);
   int res = pthread_create(&thread_id, &attr, func, arg);
   assert(res == 0);
+  pthread_attr_destroy(&attr);
 }
 
 int main() {


### PR DESCRIPTION
The attr typically located on the stack is of an opaque pthread_attr_t type, which may be a pointer that gets initialized by pthread_attr_init(). Explicitly clean up the attr with pthread_attr_destroy() to avoid a leak on such platforms to avoid unexpected test failures with lsan enabled.

This primarily affects FreeBSD; NetBSD, musl, and glibc will seemingly all use a full-sized pthread_attr_t.