### PR TITLE
[libc][newhdrgen] Fix NameError in yaml_to_classes.py

### DIFF
--- a/libc/newhdrgen/yaml_to_classes.py
+++ b/libc/newhdrgen/yaml_to_classes.py
@@ -253,7 +253,7 @@ def main():
     args = parser.parse_args()
 
     if args.add_function:
-        add_function_to_yaml(yaml_file, args.add_function)
+        add_function_to_yaml(args.yaml_file, args.add_function)
 
     header_class = GpuHeader if args.export_decls else HeaderFile
     header = load_yaml_file(args.yaml_file, header_class, args.entry_points)


### PR DESCRIPTION
Fixes "NameError: name 'yaml_file' is not defined" that would be raised
whenever running yaml_to_classes.py with the --add_function option since
commit 2e6d451d1565814415e2692ef8e5c3942d4c11a2.
