### PR TITLE
[AMDGPU] Fix 3495d04 MIR test

### DIFF
--- a/llvm/test/CodeGen/MIR/AMDGPU/spill-phys-vgprs.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/spill-phys-vgprs.mir
@@ -6,6 +6,11 @@
 ---
 name: csr_sgpr_spill
 tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: false
+  scratchRSrcReg: '$sgpr0_sgpr1_sgpr2_sgpr3'
+  stackPtrOffsetReg: '$sgpr32'
+  hasSpilledSGPRs: true
 body: |
   bb.0:
     S_NOP 0


### PR DESCRIPTION
Needed to specify scratchRSrcReg and spreg in order to stop after prologepilog.

- Fixes #113129 test failure