### PR TITLE
[MLIR][OpenMP] Update not-yet-implemented errors, NFC

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -145,7 +145,9 @@ static omp::PrivateClauseOp findPrivatizer(Operation *from,
 ///          given operation.
 static LogicalResult checkImplementationStatus(Operation &op) {
   auto todo = [&op](StringRef clauseName) {
-    return op.emitError(clauseName + " clause not yet supported");
+    return op.emitError() << "not yet implemented: Unhandled clause "
+                          << clauseName << " in " << op.getName()
+                          << " operation";
   };
 
   auto checkAligned = [&todo](auto op, LogicalResult &result) {
@@ -306,8 +308,8 @@ static LogicalResult checkImplementationStatus(Operation &op) {
               result = todo("firstprivate");
 
             if (!privatizer.getDeallocRegion().empty())
-              result =
-                  op.emitError("privatization of structures not yet supported");
+              result = op.emitError("not yet implemented: privatization of "
+                                    "structures in omp.target operation");
           }
         }
         checkThreadLimit(op, result);
@@ -4095,8 +4097,7 @@ convertHostOrTargetOperation(Operation *op, llvm::IRBuilderBase &builder,
             return success();
           })
       .Default([&](Operation *inst) {
-        return inst->emitError("unsupported OpenMP operation: ")
-               << inst->getName();
+        return inst->emitError() << "not yet implemented: " << inst->getName();
       });
 }
 

--- a/mlir/test/Target/LLVMIR/openmp-todo.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-todo.mlir
@@ -29,7 +29,7 @@ llvm.func @atomic_hint(%v : !llvm.ptr, %x : !llvm.ptr, %expr : i32) {
 llvm.func @cancel() {
   // expected-error@below {{LLVM Translation failed for operation: omp.parallel}}
   omp.parallel {
-    // expected-error@below {{unsupported OpenMP operation: omp.cancel}}
+    // expected-error@below {{not yet implemented: omp.cancel}}
     // expected-error@below {{LLVM Translation failed for operation: omp.cancel}}
     omp.cancel cancellation_construct_type(parallel)
     omp.terminator
@@ -42,7 +42,7 @@ llvm.func @cancel() {
 llvm.func @cancellation_point() {
   // expected-error@below {{LLVM Translation failed for operation: omp.parallel}}
   omp.parallel {
-    // expected-error@below {{unsupported OpenMP operation: omp.cancellation_point}}
+    // expected-error@below {{not yet implemented: omp.cancellation_point}}
     // expected-error@below {{LLVM Translation failed for operation: omp.cancellation_point}}
     omp.cancellation_point cancellation_construct_type(parallel)
     omp.terminator
@@ -67,7 +67,7 @@ llvm.func @do_simd(%lb : i32, %ub : i32, %step : i32) {
 // -----
 
 llvm.func @distribute(%lb : i32, %ub : i32, %step : i32) {
-  // expected-error@below {{unsupported OpenMP operation: omp.distribute}}
+  // expected-error@below {{not yet implemented: omp.distribute}}
   // expected-error@below {{LLVM Translation failed for operation: omp.distribute}}
   omp.distribute {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -80,7 +80,7 @@ llvm.func @distribute(%lb : i32, %ub : i32, %step : i32) {
 // -----
 
 llvm.func @ordered_region_par_level_simd() {
-  // expected-error@below {{parallelization-level clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause parallelization-level in omp.ordered.region operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.ordered.region}}
   omp.ordered.region par_level_simd {
     omp.terminator
@@ -91,7 +91,7 @@ llvm.func @ordered_region_par_level_simd() {
 // -----
 
 llvm.func @parallel_allocate(%x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.parallel operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.parallel}}
   omp.parallel allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.terminator
@@ -102,7 +102,7 @@ llvm.func @parallel_allocate(%x : !llvm.ptr) {
 // -----
 
 llvm.func @sections_allocate(%x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.sections operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.sections}}
   omp.sections allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.terminator
@@ -119,7 +119,7 @@ omp.private {type = private} @x.privatizer : !llvm.ptr alloc {
   omp.yield(%1 : !llvm.ptr)
 }
 llvm.func @sections_private(%x : !llvm.ptr) {
-  // expected-error@below {{privatization clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause privatization in omp.sections operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.sections}}
   omp.sections private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.terminator
@@ -130,7 +130,7 @@ llvm.func @sections_private(%x : !llvm.ptr) {
 // -----
 
 llvm.func @simd_aligned(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{aligned clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause aligned in omp.simd operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.simd}}
   omp.simd aligned(%x : !llvm.ptr -> 32) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -143,7 +143,7 @@ llvm.func @simd_aligned(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
 // -----
 
 llvm.func @simd_linear(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{linear clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause linear in omp.simd operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.simd}}
   omp.simd linear(%x = %step : !llvm.ptr) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -156,7 +156,7 @@ llvm.func @simd_linear(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
 // -----
 
 llvm.func @simd_nontemporal(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{nontemporal clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause nontemporal in omp.simd operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.simd}}
   omp.simd nontemporal(%x : !llvm.ptr) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -175,7 +175,7 @@ omp.private {type = private} @x.privatizer : !llvm.ptr alloc {
   omp.yield(%1 : !llvm.ptr)
 }
 llvm.func @simd_private(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{privatization clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause privatization in omp.simd operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.simd}}
   omp.simd private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -205,7 +205,7 @@ atomic {
   omp.yield
 }
 llvm.func @simd_reduction(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{reduction clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause reduction in omp.simd operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.simd}}
   omp.simd reduction(@add_f32 %x -> %prv : !llvm.ptr) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -218,7 +218,7 @@ llvm.func @simd_reduction(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
 // -----
 
 llvm.func @single_allocate(%x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.single operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.single}}
   omp.single allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.terminator
@@ -235,7 +235,7 @@ omp.private {type = private} @x.privatizer : !llvm.ptr alloc {
   omp.yield(%1 : !llvm.ptr)
 }
 llvm.func @single_private(%x : !llvm.ptr) {
-  // expected-error@below {{privatization clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause privatization in omp.single operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.single}}
   omp.single private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.terminator
@@ -246,7 +246,7 @@ llvm.func @single_private(%x : !llvm.ptr) {
 // -----
 
 llvm.func @target_allocate(%x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.terminator
@@ -257,7 +257,7 @@ llvm.func @target_allocate(%x : !llvm.ptr) {
 // -----
 
 llvm.func @target_device(%x : i32) {
-  // expected-error@below {{device clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause device in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target device(%x : i32) {
     omp.terminator
@@ -268,7 +268,7 @@ llvm.func @target_device(%x : i32) {
 // -----
 
 llvm.func @target_has_device_addr(%x : !llvm.ptr) {
-  // expected-error@below {{has_device_addr clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause has_device_addr in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target has_device_addr(%x : !llvm.ptr) {
     omp.terminator
@@ -279,7 +279,7 @@ llvm.func @target_has_device_addr(%x : !llvm.ptr) {
 // -----
 
 llvm.func @target_if(%x : i1) {
-  // expected-error@below {{if clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause if in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target if(%x) {
     omp.terminator
@@ -307,7 +307,7 @@ atomic {
   omp.yield
 }
 llvm.func @target_in_reduction(%x : !llvm.ptr) {
-  // expected-error@below {{in_reduction clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause in_reduction in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target in_reduction(@add_f32 %x -> %prv : !llvm.ptr) {
     omp.terminator
@@ -318,7 +318,7 @@ llvm.func @target_in_reduction(%x : !llvm.ptr) {
 // -----
 
 llvm.func @target_is_device_ptr(%x : !llvm.ptr) {
-  // expected-error@below {{is_device_ptr clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause is_device_ptr in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target is_device_ptr(%x : !llvm.ptr) {
     omp.terminator
@@ -336,7 +336,7 @@ omp.private {type = firstprivate} @x.privatizer : !llvm.ptr alloc {
   omp.yield(%arg0 : !llvm.ptr)
 }
 llvm.func @target_firstprivate(%x : !llvm.ptr) {
-  // expected-error@below {{firstprivate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause firstprivate in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.terminator
@@ -354,7 +354,7 @@ omp.private {type = private} @x.privatizer : !llvm.ptr alloc {
   omp.yield
 }
 llvm.func @target_struct_privatization(%x : !llvm.ptr) {
-  // expected-error@below {{privatization of structures not yet supported}}
+  // expected-error@below {{not yet implemented: privatization of structures in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.terminator
@@ -365,7 +365,7 @@ llvm.func @target_struct_privatization(%x : !llvm.ptr) {
 // -----
 
 llvm.func @target_thread_limit(%x : i32) {
-  // expected-error@below {{thread_limit clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause thread_limit in omp.target operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target}}
   omp.target thread_limit(%x : i32) {
     omp.terminator
@@ -376,7 +376,7 @@ llvm.func @target_thread_limit(%x : i32) {
 // -----
 
 llvm.func @target_enter_data_depend(%x: !llvm.ptr) {
-  // expected-error@below {{depend clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause depend in omp.target_enter_data operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target_enter_data}}
   omp.target_enter_data depend(taskdependin -> %x : !llvm.ptr) {
     omp.terminator
@@ -387,7 +387,7 @@ llvm.func @target_enter_data_depend(%x: !llvm.ptr) {
 // -----
 
 llvm.func @target_exit_data_depend(%x: !llvm.ptr) {
-  // expected-error@below {{depend clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause depend in omp.target_exit_data operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target_exit_data}}
   omp.target_exit_data depend(taskdependin -> %x : !llvm.ptr) {
     omp.terminator
@@ -398,7 +398,7 @@ llvm.func @target_exit_data_depend(%x: !llvm.ptr) {
 // -----
 
 llvm.func @target_update_depend(%x: !llvm.ptr) {
-  // expected-error@below {{depend clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause depend in omp.target_update operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target_update}}
   omp.target_update depend(taskdependin -> %x : !llvm.ptr) {
     omp.terminator
@@ -409,7 +409,7 @@ llvm.func @target_update_depend(%x: !llvm.ptr) {
 // -----
 
 llvm.func @task_allocate(%x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.task operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.task}}
   omp.task allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.terminator
@@ -437,7 +437,7 @@ atomic {
   omp.yield
 }
 llvm.func @task_in_reduction(%x : !llvm.ptr) {
-  // expected-error@below {{in_reduction clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause in_reduction in omp.task operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.task}}
   omp.task in_reduction(@add_f32 %x -> %prv : !llvm.ptr) {
     omp.terminator
@@ -448,7 +448,7 @@ llvm.func @task_in_reduction(%x : !llvm.ptr) {
 // -----
 
 llvm.func @task_mergeable() {
-  // expected-error@below {{mergeable clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause mergeable in omp.task operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.task}}
   omp.task mergeable {
     omp.terminator
@@ -459,7 +459,7 @@ llvm.func @task_mergeable() {
 // -----
 
 llvm.func @task_priority(%x : i32) {
-  // expected-error@below {{priority clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause priority in omp.task operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.task}}
   omp.task priority(%x : i32) {
     omp.terminator
@@ -476,7 +476,7 @@ omp.private {type = private} @x.privatizer : !llvm.ptr alloc {
   omp.yield(%1 : !llvm.ptr)
 }
 llvm.func @task_private(%x : !llvm.ptr) {
-  // expected-error@below {{privatization clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause privatization in omp.task operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.task}}
   omp.task private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.terminator
@@ -487,7 +487,7 @@ llvm.func @task_private(%x : !llvm.ptr) {
 // -----
 
 llvm.func @task_untied() {
-  // expected-error@below {{untied clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause untied in omp.task operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.task}}
   omp.task untied {
     omp.terminator
@@ -498,7 +498,7 @@ llvm.func @task_untied() {
 // -----
 
 llvm.func @taskgroup_allocate(%x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.taskgroup operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.taskgroup}}
   omp.taskgroup allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.terminator
@@ -526,7 +526,7 @@ atomic {
   omp.yield
 }
 llvm.func @taskgroup_task_reduction(%x : !llvm.ptr) {
-  // expected-error@below {{task_reduction clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause task_reduction in omp.taskgroup operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.taskgroup}}
   omp.taskgroup task_reduction(@add_f32 %x -> %prv : !llvm.ptr) {
     omp.terminator
@@ -537,7 +537,7 @@ llvm.func @taskgroup_task_reduction(%x : !llvm.ptr) {
 // -----
 
 llvm.func @taskloop(%lb : i32, %ub : i32, %step : i32) {
-  // expected-error@below {{unsupported OpenMP operation: omp.taskloop}}
+  // expected-error@below {{not yet implemented: omp.taskloop}}
   // expected-error@below {{LLVM Translation failed for operation: omp.taskloop}}
   omp.taskloop {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -550,7 +550,7 @@ llvm.func @taskloop(%lb : i32, %ub : i32, %step : i32) {
 // -----
 
 llvm.func @taskwait_depend(%x: !llvm.ptr) {
-  // expected-error@below {{depend clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause depend in omp.taskwait operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.taskwait}}
   omp.taskwait depend(taskdependin -> %x : !llvm.ptr) {
     omp.terminator
@@ -561,7 +561,7 @@ llvm.func @taskwait_depend(%x: !llvm.ptr) {
 // -----
 
 llvm.func @taskwait_nowait() {
-  // expected-error@below {{nowait clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause nowait in omp.taskwait operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.taskwait}}
   omp.taskwait nowait {
     omp.terminator
@@ -572,7 +572,7 @@ llvm.func @taskwait_nowait() {
 // -----
 
 llvm.func @teams_allocate(%x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.teams operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.teams}}
   omp.teams allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.terminator
@@ -589,7 +589,7 @@ omp.private {type = private} @x.privatizer : !llvm.ptr alloc {
   omp.yield(%1 : !llvm.ptr)
 }
 llvm.func @teams_private(%x : !llvm.ptr) {
-  // expected-error@below {{privatization clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause privatization in omp.teams operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.teams}}
   omp.teams private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.terminator
@@ -617,7 +617,7 @@ atomic {
   omp.yield
 }
 llvm.func @teams_reduction(%x : !llvm.ptr) {
-  // expected-error@below {{reduction clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause reduction in omp.teams operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.teams}}
   omp.teams reduction(@add_f32 %x -> %prv : !llvm.ptr) {
     omp.terminator
@@ -628,7 +628,7 @@ llvm.func @teams_reduction(%x : !llvm.ptr) {
 // -----
 
 llvm.func @wsloop_allocate(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{allocate clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.wsloop operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.wsloop}}
   omp.wsloop allocate(%x : !llvm.ptr -> %x : !llvm.ptr) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -641,7 +641,7 @@ llvm.func @wsloop_allocate(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
 // -----
 
 llvm.func @wsloop_linear(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{linear clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause linear in omp.wsloop operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.wsloop}}
   omp.wsloop linear(%x = %step : !llvm.ptr) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -654,7 +654,7 @@ llvm.func @wsloop_linear(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
 // -----
 
 llvm.func @wsloop_order(%lb : i32, %ub : i32, %step : i32) {
-  // expected-error@below {{order clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause order in omp.wsloop operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.wsloop}}
   omp.wsloop order(concurrent) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
@@ -673,7 +673,7 @@ omp.private {type = private} @x.privatizer : !llvm.ptr alloc {
   omp.yield(%1 : !llvm.ptr)
 }
 llvm.func @wsloop_private(%lb : i32, %ub : i32, %step : i32, %x : !llvm.ptr) {
-  // expected-error@below {{privatization clause not yet supported}}
+  // expected-error@below {{not yet implemented: Unhandled clause privatization in omp.wsloop operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.wsloop}}
   omp.wsloop private(@x.privatizer %x -> %arg0 : !llvm.ptr) {
     omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {


### PR DESCRIPTION
This patch improves not-yet-implemented error diagnostics to more closely follow the format used by Flang lowering for the same kind of errors. This helps keep some level of uniformity from a user perspective.