### PR TITLE
Nominate Saleem and myself as maintainers for API Notes

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -132,6 +132,14 @@ Compiler options
 | jan_svoboda\@apple.com (email), jansvoboda11 (Phabricator), jansvoboda11 (GitHub)
 
 
+API Notes
+~~~~~~~~~~~~~~~~
+| Egor Zhdan
+| e_zhdan\@apple.com (email), egorzhdan (GitHub), egor.zhdan (Discourse)
+
+| Saleem Abdulrasool
+| compnerd\@compnerd.org (email), compnerd (GitHub), compnerd (Discourse)
+
 OpenBSD driver
 ~~~~~~~~~~~~~~
 | Brad Smith

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -140,6 +140,7 @@ API Notes
 | Saleem Abdulrasool
 | compnerd\@compnerd.org (email), compnerd (GitHub), compnerd (Discourse)
 
+
 OpenBSD driver
 ~~~~~~~~~~~~~~
 | Brad Smith


### PR DESCRIPTION
Saleem has upstreamed a large chunk of API Notes infrastructure from the Apple fork, and over the past year I've upstreamed the remaining part of API Notes, added new annotations and improved C++ language support.

https://github.com/llvm/llvm-project/commits/main/clang/lib/APINotes