### PR TITLE
[flang][OpenMP] Deprecation message for DESTROY with no argument

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2652,15 +2652,13 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Destroy &x) {
     if (x.v) {
       if (version < argSince) {
         context_.Say(GetContext().clauseSource,
-            "The object parameter in DESTROY clause on DEPOPJ construct "
-            "is not allowed in %s, %s"_warn_en_US,
+            "The object parameter in DESTROY clause on DEPOPJ construct is not allowed in %s, %s"_warn_en_US,
             ThisVersion(version), TryVersion(argSince));
       }
     } else {
       if (version >= noargDeprecatedIn) {
         context_.Say(GetContext().clauseSource,
-            "The DESTROY clause without argument on DEPOBJ construct "
-            "is deprecated in %s"_warn_en_US,
+            "The DESTROY clause without argument on DEPOBJ construct is deprecated in %s"_warn_en_US,
             ThisVersion(noargDeprecatedIn));
       }
     }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2648,11 +2648,21 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Destroy &x) {
   llvm::omp::Directive dir{GetContext().directive};
   unsigned version{context_.langOptions().OpenMPVersion};
   if (dir == llvm::omp::Directive::OMPD_depobj) {
-    if (version < 52) {
-      context_.Say(GetContext().clauseSource,
-          "The object parameter in DESTROY clause in DEPOPJ construct "
-          "was introduced in %s"_port_en_US,
-          ThisVersion(52));
+    unsigned argSince{52}, noargDeprecatedIn{52};
+    if (x.v) {
+      if (version < argSince) {
+        context_.Say(GetContext().clauseSource,
+            "The object parameter in DESTROY clause on DEPOPJ construct "
+            "is not allowed in %s, %s"_warn_en_US,
+            ThisVersion(version), TryVersion(argSince));
+      }
+    } else {
+      if (version >= noargDeprecatedIn) {
+        context_.Say(GetContext().clauseSource,
+            "The DESTROY clause without argument on DEPOBJ construct "
+            "is deprecated in %s"_warn_en_US,
+            ThisVersion(noargDeprecatedIn));
+      }
     }
   }
 }

--- a/flang/test/Semantics/OpenMP/depobj-construct-v50.f90
+++ b/flang/test/Semantics/OpenMP/depobj-construct-v50.f90
@@ -23,6 +23,6 @@ end
 subroutine f03
   integer :: obj, jbo
 !ERROR: The DESTROY clause must refer to the same object as the DEPOBJ construct
-!PORTABILITY: The object parameter in DESTROY clause in DEPOPJ construct was introduced in OpenMP v5.2
+!WARNING: The object parameter in DESTROY clause on DEPOPJ construct is not allowed in OpenMP v5.0, try -fopenmp-version=52
   !$omp depobj(obj) destroy(jbo)
 end

--- a/flang/test/Semantics/OpenMP/depobj-construct-v52.f90
+++ b/flang/test/Semantics/OpenMP/depobj-construct-v52.f90
@@ -13,3 +13,9 @@ subroutine f03
 !ERROR: The DESTROY clause must refer to the same object as the DEPOBJ construct
   !$omp depobj(obj) destroy(jbo)
 end
+
+subroutine f06
+  integer :: obj
+!WARNING: The DESTROY clause without argument on DEPOBJ construct is deprecated in OpenMP v5.2
+  !$omp depobj(obj) destroy
+end


### PR DESCRIPTION
[5.2:625:17] The syntax of the DESTROY clause on the DEPOBJ construct with no argument was deprecated.