### PR TITLE
[Docs][llvm-exegesis] Clarify AArch64 support

### DIFF
--- a/llvm/docs/CommandGuide/llvm-exegesis.rst
+++ b/llvm/docs/CommandGuide/llvm-exegesis.rst
@@ -33,11 +33,22 @@ snippets.
 SUPPORTED PLATFORMS
 -------------------
 
-:program:`llvm-exegesis` currently only supports X86 (64-bit only), ARM (AArch64
-only), MIPS, and PowerPC (PowerPC64LE only) on Linux for benchmarking. Not all
-benchmarking functionality is guaranteed to work on every platform.
-:program:`llvm-exegesis` also has a separate analysis mode that is supported
-on every platform that LLVM is.
+:program:`llvm-exegesis` currently only supports X86 (64-bit only), ARM
+(AArch64 only, snippet generation is sparse), MIPS, and PowerPC (PowerPC64LE
+only) on Linux for benchmarking. Not all benchmarking functionality is
+guaranteed to work on every platform. :program:`llvm-exegesis` also has a
+separate analysis mode that is supported on every platform that LLVM is.
+
+To enable benchmarking in llvm-exegesis, LLVM must be configured and built with
+`LLVM_ENABLE_LIBPFM` enabled, as :program:`llvm-exegesis` depends on libpfm4
+for accessing performance counters. Benchmarking may fail if the target CPU is
+unsupported by libpfm. This can be verified by setting `LIBPFM_VERBOSE` and
+`LIBPFM_DEBUG` environment variables to enable verbose or debug mode for
+libpfm. If libpfm is installed in a non-standard directory, LLVM can be
+configured to locate the necessary library and header files by setting
+`LIBRARY_PATH`, `C_INCLUDE_PATH`, and `CPLUS_INCLUDE_PATH` environment
+variables. Additionally, `LD_LIBRARY_PATH` should be set so that
+:program:`llvm-exegesis` can locate the libpfm library during execution.
 
 SNIPPET ANNOTATIONS
 -------------------

--- a/llvm/tools/llvm-exegesis/README.md
+++ b/llvm/tools/llvm-exegesis/README.md
@@ -13,8 +13,8 @@ Analysis mode in `llvm-exegesis` is supported on all platforms on which LLVM is.
 #### Currently Supported Operating Systems for Benchmarking
 
 Currently, `llvm-exegesis`  only supports benchmarking on Linux. This is mainly
-due to a dependency on the Linux perf subsystem for reading performance
-counters.
+due to a dependency on the Linux perf subsystem for reading
+performance counters.
 
 The subprocess execution mode and memory annotations currently only supports
 Linux due to a heavy reliance on many Linux specific syscalls/syscall
@@ -28,7 +28,8 @@ architectures:
   * 64-bit only due to this being the only implemented calling convention
     in `llvm-exegesis` currently.
 * ARM
-  * AArch64 only
+  * Very experimental AArch64 support only: most opcodes probably won't work as
+    e.g. pseudo instructions and most register classes are not supported.
 * MIPS
 * PowerPC (PowerPC64LE only)
 


### PR DESCRIPTION
Claiming AArch64 support for llvm-exegesis is a bit of a stretch in my opinion as only a couple of opcodes with GPR64 operands will work, so I propose to clarify that AArch64 support is very experimental. Also added some clarifications about its libpfm4 dependency.