### PR TITLE
[clang] Add steakhal to the Clang Static Analyzer maintainers

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -131,6 +131,8 @@ Clang static analyzer
 | Gábor Horváth
 | xazax.hun\@gmail.com (email), xazax.hun (Phabricator), Xazax-hun (GitHub)
 
+| Balázs Benics
+| benicsbalazs\@gmail.com (email), steakhal (Phabricator), steakhal (GitHub)
 
 Compiler options
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I've been contributing to the Clang Static Analyzer for a while now. I think from 2019, or something like that.
I've ensured the quality of the Static Analyzer releases for the last ~4-6 releases now, with testing, fixing and backporting patches; also writing comprehensive release notes for each release.
I have a strong sense of ownership of the code I contribute.
I follow the issue tracker, and also try to follow and participate in RFCs on Discourse if I'm not overloaded.
I also check Discord time-to-time, but I rarely see anything there.

You can find the maintainer section of the LLVM DeveloperPolicy [here](https://llvm.org/docs/DeveloperPolicy.html#maintainers) to read more about the responsibilities.