### PR TITLE
[clang] Make source locations space usage diagnostics numbers easier to read

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -389,13 +389,14 @@ def remark_sloc_usage : Remark<
   "source manager location address space usage:">,
   InGroup<DiagGroup<"sloc-usage">>, DefaultRemark, ShowInSystemHeader;
 def note_total_sloc_usage : Note<
-  "%0B in local locations, %1B in locations loaded from AST files, for a total "
-  "of %2B (%3%% of available space)">;
+  "%0B (%1B) in local locations, %2B (%3B) "
+  "in locations loaded from AST files, for a total of %4B (%5B) "
+  "(%6%% of available space)">;
 def note_file_sloc_usage : Note<
-  "file entered %0 time%s0 using %1B of space"
-  "%plural{0:|: plus %2B for macro expansions}2">;
+  "file entered %0 time%s0 using %1B (%2B) of space"
+  "%plural{0:|: plus %3B (%4B) for macro expansions}3">;
 def note_file_misc_sloc_usage : Note<
-  "%0 additional files entered using a total of %1B of space">;
+  "%0 additional files entered using a total of %1B (%2B) of space">;
 
 // Modules
 def err_module_format_unhandled : Error<

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -2227,26 +2227,26 @@ LLVM_DUMP_METHOD void SourceManager::dump() const {
   }
 }
 
-static std::string NumberToHumanString(uint64_t number) {
+static std::string NumberToHumanString(uint64_t Number) {
   static constexpr std::array<std::pair<uint64_t, char>, 4> Units = {
       {{1'000'000'000'000UL, 'T'},
        {1'000'000'000UL, 'G'},
        {1'000'000UL, 'M'},
        {1'000UL, 'k'}}};
 
-  std::string human_string;
-  llvm::raw_string_ostream human_string_stream(human_string);
+  std::string HumanString;
+  llvm::raw_string_ostream HumanStringStream(HumanString);
   for (const auto &[UnitSize, UnitSign] : Units) {
-    if (number >= UnitSize) {
-      human_string_stream << llvm::format(
-          "%.2f%c", number / static_cast<double>(UnitSize), UnitSign);
+    if (Number >= UnitSize) {
+      HumanStringStream << llvm::format(
+          "%.2f%c", Number / static_cast<double>(UnitSize), UnitSign);
       break;
     }
   }
-  if (human_string.empty()) {
-    human_string_stream << number;
+  if (HumanString.empty()) {
+    HumanStringStream << Number;
   }
-  return human_string;
+  return HumanString;
 }
 
 void SourceManager::noteSLocAddressSpaceUsage(

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -2240,19 +2241,13 @@ static std::string humanizeNumber(uint64_t Number) {
        {1'000'000UL, 'M'},
        {1'000UL, 'k'}}};
 
-  std::string HumanString;
-  llvm::raw_string_ostream HumanStringStream(HumanString);
   for (const auto &[UnitSize, UnitSign] : Units) {
     if (Number >= UnitSize) {
-      HumanStringStream << llvm::format(
-          "%.2f%c", Number / static_cast<double>(UnitSize), UnitSign);
-      break;
+      return llvm::formatv("{0:F}{1}", Number / static_cast<double>(UnitSize),
+                           UnitSign);
     }
   }
-  if (HumanString.empty()) {
-    HumanStringStream << Number;
-  }
-  return HumanString;
+  return std::to_string(Number);
 }
 
 void SourceManager::noteSLocAddressSpaceUsage(

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -2227,7 +2227,13 @@ LLVM_DUMP_METHOD void SourceManager::dump() const {
   }
 }
 
-static std::string NumberToHumanString(uint64_t Number) {
+// 123 -> "123".
+// 1234 -> "1.23k".
+// 123456 -> "123.46k".
+// 1234567 -> "1.23M".
+// 1234567890 -> "1.23G".
+// 1234567890123 -> "1.23T".
+static std::string humanizeNumber(uint64_t Number) {
   static constexpr std::array<std::pair<uint64_t, char>, 4> Units = {
       {{1'000'000'000'000UL, 'T'},
        {1'000'000'000UL, 'G'},
@@ -2318,9 +2324,9 @@ void SourceManager::noteSLocAddressSpaceUsage(
   int UsagePercent = static_cast<int>(100.0 * double(LocalUsage + LoadedUsage) /
                                       MaxLoadedOffset);
   Diag.Report(SourceLocation(), diag::note_total_sloc_usage)
-      << LocalUsage << NumberToHumanString(LocalUsage) << LoadedUsage
-      << NumberToHumanString(LoadedUsage) << (LocalUsage + LoadedUsage)
-      << NumberToHumanString(LocalUsage + LoadedUsage) << UsagePercent;
+      << LocalUsage << humanizeNumber(LocalUsage) << LoadedUsage
+      << humanizeNumber(LoadedUsage) << (LocalUsage + LoadedUsage)
+      << humanizeNumber(LocalUsage + LoadedUsage) << UsagePercent;
 
   // Produce notes on sloc address space usage for each file with a high usage.
   uint64_t ReportedSize = 0;
@@ -2328,9 +2334,9 @@ void SourceManager::noteSLocAddressSpaceUsage(
        llvm::make_range(SortedUsage.begin(), SortedEnd)) {
     Diag.Report(FileInfo.Loc, diag::note_file_sloc_usage)
         << FileInfo.Inclusions << FileInfo.DirectSize
-        << NumberToHumanString(FileInfo.DirectSize)
+        << humanizeNumber(FileInfo.DirectSize)
         << (FileInfo.TotalSize - FileInfo.DirectSize)
-        << NumberToHumanString(FileInfo.TotalSize - FileInfo.DirectSize);
+        << humanizeNumber(FileInfo.TotalSize - FileInfo.DirectSize);
     ReportedSize += FileInfo.TotalSize;
   }
 
@@ -2338,7 +2344,7 @@ void SourceManager::noteSLocAddressSpaceUsage(
   if (ReportedSize != CountedSize) {
     Diag.Report(SourceLocation(), diag::note_file_misc_sloc_usage)
         << (SortedUsage.end() - SortedEnd) << CountedSize - ReportedSize
-        << NumberToHumanString(CountedSize - ReportedSize);
+        << humanizeNumber(CountedSize - ReportedSize);
   }
 }
 

--- a/clang/test/Lexer/SourceLocationsOverflow.c
+++ b/clang/test/Lexer/SourceLocationsOverflow.c
@@ -3,17 +3,17 @@
 // CHECK-NEXT: inc1.h{{.*}}: fatal error: translation unit is too large for Clang to process: ran out of source locations
 // CHECK-NEXT: #include "inc2.h"
 // CHECK-NEXT:          ^
-// CHECK-NEXT: note: 214{{.......}}B in local locations, 0B in locations loaded from AST files, for a total of 214{{.......}}B (99% of available space)
-// CHECK-NEXT: {{.*}}inc2.h:1:1: note: file entered 214{{..}} times using 214{{.......}}B of space
+// CHECK-NEXT: note: 214{{.......}}B (2.15GB) in local locations, 0B (0B) in locations loaded from AST files, for a total of 214{{.......}}B (2.15GB) (99% of available space)
+// CHECK-NEXT: {{.*}}inc2.h:1:1: note: file entered 214{{..}} times using 214{{.......}}B (2.15GB) of space
 // CHECK-NEXT: /*.................................................................................................
 // CHECK-NEXT: ^
-// CHECK-NEXT: {{.*}}inc1.h:1:1: note: file entered 15 times using 39{{....}}B of space
+// CHECK-NEXT: {{.*}}inc1.h:1:1: note: file entered 15 times using 39{{....}}B (396.92kB) of space
 // CHECK-NEXT: #include "inc2.h"
 // CHECK-NEXT: ^
-// CHECK-NEXT: <built-in>:1:1: note: file entered {{.*}} times using {{.*}}B of space
+// CHECK-NEXT: <built-in>:1:1: note: file entered {{.*}} times using {{.*}}B ({{.*}}B) of space
 // CHECK-NEXT: # {{.*}}
 // CHECK-NEXT: ^
-// CHECK-NEXT: {{.*}}SourceLocationsOverflow.c:1:1: note: file entered 1 time using {{.*}}B of space
+// CHECK-NEXT: {{.*}}SourceLocationsOverflow.c:1:1: note: file entered 1 time using {{.*}}B ({{.*}}B) of space
 // CHECK-NEXT: // RUN: not %clang %s -S -o - 2>&1 | FileCheck %s
 // CHECK-NEXT: ^
 // CHECK-NEXT: 1 error generated.

--- a/clang/test/Misc/sloc-usage.cpp
+++ b/clang/test/Misc/sloc-usage.cpp
@@ -9,6 +9,6 @@ bool b = EQUALS(k, k);
 
 #pragma clang __debug sloc_usage // expected-remark {{address space usage}}
 // expected-note@* {{(0% of available space)}}
-// (this file)     expected-note-re@1 {{file entered 1 time using {{.*}}B of space plus 51B for macro expansions}}
-// (included file) expected-note-re@Inputs/include.h:1 {{file entered 3 times using {{.*}}B of space{{$}}}}
+// (this file)     expected-note-re@1 {{file entered 1 time using {{.*}}B ({{.*}}B) of space plus 51B (51B) for macro expansions}}
+// (included file) expected-note-re@Inputs/include.h:1 {{file entered 3 times using {{.*}}B ({{.*}}B) of space{{$}}}}
 // (builtins file) expected-note@* {{file entered}}


### PR DESCRIPTION
Instead of writing "12345678B", write "12345678B (12.34MB)".