### PR TITLE
[PS5][Driver] Pass `-z rodynamic` to the linker

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -277,6 +277,10 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-z");
     CmdArgs.push_back("start-stop-visibility=hidden");
 
+    // DT_DEBUG is not supported on PlayStation.
+    CmdArgs.push_back("-z");
+    CmdArgs.push_back("rodynamic");
+
     CmdArgs.push_back("-z");
     CmdArgs.push_back("common-page-size=0x4000");
 

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -53,6 +53,7 @@
 // CHECK-EXE-SAME: "--unresolved-symbols=report-all"
 // CHECK-EXE-SAME: "-z" "now"
 // CHECK-EXE-SAME: "-z" "start-stop-visibility=hidden"
+// CHECK-EXE-SAME: "-z" "rodynamic"
 // CHECK-EXE-SAME: "-z" "common-page-size=0x4000"
 // CHECK-EXE-SAME: "-z" "max-page-size=0x4000"
 // CHECK-EXE-SAME: "-z" "dead-reloc-in-nonalloc=.debug_*=0xffffffffffffffff"


### PR DESCRIPTION
Until now, suppression of `DT_DEBUG` has been hardcoded as a downstream patch in lld. This can instead be achieved by passing `-z rodynamic`. Have the driver do this so that the private patch can be removed.

If the scope of lld's `-z rodynamic` is broadened (within reason) to do more in future, that's likely to be fine as `PT_DYNAMIC` isn't writable on PlayStation.

PS5 only. On PS4, the equivalent hardcoded configuration will remain in the proprietary linker.

SIE tracker: TOOLCHAIN-16704