### PR TITLE
Fix libnvptxcompiler_static.a absolute path

### DIFF
--- a/mlir/lib/Target/LLVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVM/CMakeLists.txt
@@ -70,17 +70,23 @@ if ("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
     if(MLIR_ENABLE_NVPTXCOMPILER)
       # Find the `nvptxcompiler` library.
       # TODO: Bump the MLIR CMake version to 3.25 and use `CUDA::nvptxcompiler_static`.
-      find_library(MLIR_NVPTXCOMPILER_LIB nvptxcompiler_static
+      find_library(MLIR_NVPTXCOMPILER_LIB_PATH nvptxcompiler_static
                   PATHS ${CUDAToolkit_LIBRARY_DIR} NO_DEFAULT_PATH)
 
       # Fail if `nvptxcompiler_static` couldn't be found.
-      if(MLIR_NVPTXCOMPILER_LIB STREQUAL "MLIR_NVPTXCOMPILER_LIB-NOTFOUND")
+      if(MLIR_NVPTXCOMPILER_LIB_PATH STREQUAL "MLIR_NVPTXCOMPILER_LIB_PATH-NOTFOUND")
         message(FATAL_ERROR
                 "Requested using the `nvptxcompiler` library backend but it couldn't be found.")
       endif()
 
+      add_library(MLIR_NVPTXCOMPILER_LIB STATIC IMPORTED GLOBAL)
+      # Downstream projects can modify this path and use it in CMake. For example:
+      # add_library(MLIR_NVPTXCOMPILER_LIB STATIC IMPORTED GLOBAL)
+      # set_property(TARGET MLIR_NVPTXCOMPILER_LIB PROPERTY IMPORTED_LOCATION ${...})  
+      # where `...` is to be replaced with the path to the library.
+      set_property(TARGET MLIR_NVPTXCOMPILER_LIB PROPERTY IMPORTED_LOCATION ${MLIR_NVPTXCOMPILER_LIB_PATH})
       # Link against `nvptxcompiler_static`. TODO: use `CUDA::nvptxcompiler_static`.
-      target_link_libraries(MLIRNVVMTarget PRIVATE ${MLIR_NVPTXCOMPILER_LIB})
+      target_link_libraries(MLIRNVVMTarget PRIVATE MLIR_NVPTXCOMPILER_LIB)
       target_include_directories(obj.MLIRNVVMTarget PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
     endif()
   else()


### PR DESCRIPTION
Now when building llvm-solid with `-DMLIR_ENABLE_NVPTXCOMPILER=ON`, there will be an absolute path (`/path/to/libnvptxcompiler_static.a`) in MLIRNVVMTarget dependencies (in `/build/path/install/lib/cmake/mlir/MLIRTargets.cmake`).  For example,

```cmake
set_target_properties(MLIRNVVMTarget PROPERTIES
  INTERFACE_LINK_LIBRARIES "MLIRIR;MLIRExecutionEngineUtils;MLIRSupport;MLIRGPUDialect;MLIRTargetLLVM;MLIRNVVMToLLVMIRTranslation;LLVMSupport;/path/to/libnvptxcompiler_static.a"
)
```

If downstream project uses pre-built llvm and depends on MLIRNVVMTarget, it may fail to build due to the absence of the `libnvptxcompiler_static.a` absolute path.

After this commit, there will no absolute path in `/build/path/install/lib/cmake/mlir/MLIRTargets.cmake`

```cmake
set_target_properties(MLIRNVVMTarget PROPERTIES
  INTERFACE_LINK_LIBRARIES "MLIRIR;MLIRExecutionEngineUtils;MLIRSupport;MLIRGPUDialect;MLIRTargetLLVM;MLIRNVVMToLLVMIRTranslation;LLVMSupport;\$<LINK_ONLY:MLIR_NVPTXCOMPILER_LIB>"
)
```

Then downstream project can modify `libnvptxcompiler_static.a` path and use cmake to build. For example,

```cmake
# find_library(...)

add_library(MLIR_NVPTXCOMPILER_LIB STATIC IMPORTED GLOBAL)
set_property(TARGET MLIR_NVPTXCOMPILER_LIB PROPERTY IMPORTED_LOCATION ${...})  
```
