### PR TITLE
[libc++] Only include the system <stdint.h> and <locale.h> if they exist

### DIFF
--- a/libcxx/include/clocale
+++ b/libcxx/include/clocale
@@ -36,7 +36,9 @@ lconv* localeconv();
 
 #include <__config>
 
-#include <locale.h>
+#if __has_include(<locale.h>)
+#  include <locale.h>
+#endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/cstdint
+++ b/libcxx/include/cstdint
@@ -142,7 +142,9 @@ Types:
 
 #include <__config>
 
-#include <stdint.h>
+#if __has_include(<stdint.h>)
+#  include <stdint.h>
+#endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header


### PR DESCRIPTION
Prior to aa7f377c96, we only did an #include_next of those system headers if they existed. After removing those headers from libc++, we started assuming that the system provided the headers because we unconditionally started including them. This patch fixes that.