### PR TITLE
Add clang::lifetimebound annotation to llvm::function_ref

### DIFF
--- a/llvm/include/llvm/ADT/STLFunctionalExtras.h
+++ b/llvm/include/llvm/ADT/STLFunctionalExtras.h
@@ -16,6 +16,7 @@
 #define LLVM_ADT_STLFUNCTIONALEXTRAS_H
 
 #include "llvm/ADT/STLForwardCompat.h"
+#include "llvm/Support/Compiler.h"
 
 #include <cstdint>
 #include <type_traits>
@@ -52,7 +53,7 @@ public:
 
   template <typename Callable>
   function_ref(
-      Callable &&callable,
+      Callable &&callable LLVM_LIFETIME_BOUND,
       // This is not the copy-constructor.
       std::enable_if_t<!std::is_same<remove_cvref_t<Callable>,
                                      function_ref>::value> * = nullptr,


### PR DESCRIPTION
This helps catch dangling llvm::function_ref references, see #114950, #114949, #114808, #114789