### PR TITLE
[compiler-rt] Include stdlib.h for exit()

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
@@ -14,6 +14,7 @@
 
 #include "FuzzerExtFunctions.h"
 #include "FuzzerIO.h"
+#include <stdlib.h>
 
 using namespace fuzzer;
 


### PR DESCRIPTION
It was originally included transitively, but no longer is after recent <vector> cleanups in libc++.

Similar to #113951.