### PR TITLE
[InstCombine] Eliminate fptrunc/fpext if fast math flags allow it

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1940,6 +1940,31 @@ Instruction *InstCombinerImpl::visitFPExt(CastInst &FPExt) {
       return CastInst::Create(FPCast->getOpcode(), FPCast->getOperand(0), Ty);
   }
 
+  // fpext (fptrunc(x)) -> x, if the fast math flags allow it
+  if (auto *Trunc = dyn_cast<FPTruncInst>(Src)) {
+    // Whether this transformation is possible depends on the fast math flags of
+    // both the fpext and fptrunc.
+    FastMathFlags SrcFlags = Trunc->getFastMathFlags();
+    FastMathFlags DstFlags = FPExt.getFastMathFlags();
+    // Trunc can introduce inf and change the encoding of a nan, so the
+    // destination must have the nnan and ninf flags to indicate that we don't
+    // need to care about that. We are also removing a rounding step, and that
+    // requires both the source and destination to allow contraction.
+    if (DstFlags.noNaNs() && DstFlags.noInfs() && SrcFlags.allowContract() &&
+        DstFlags.allowContract()) {
+      Value *TruncSrc = Trunc->getOperand(0);
+      // We do need a single cast if the source and destination types don't
+      // match.
+      if (TruncSrc->getType() != Ty) {
+        Instruction *Ret = CastInst::CreateFPCast(TruncSrc, Ty);
+        Ret->copyFastMathFlags(&FPExt);
+        return Ret;
+      } else {
+        return replaceInstUsesWith(FPExt, TruncSrc);
+      }
+    }
+  }
+
   return commonCastTransforms(FPExt);
 }
 


### PR DESCRIPTION
When expressions of a floating-point type are evaluated at a higher precision (e.g. _Float16 being evaluated as float) this results in a fptrunc then fpext between each operation. With the appropriate fast math flags (nnan ninf contract) we can eliminate these cast instructions.