### PR TITLE
Revert "[tsan] Don't use `enum __tsan_memory_order` in tsan interface"

### DIFF
--- a/compiler-rt/include/sanitizer/tsan_interface_atomic.h
+++ b/compiler-rt/include/sanitizer/tsan_interface_atomic.h
@@ -43,178 +43,183 @@ typedef enum {
 } __tsan_memory_order;
 
 __tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_load(const volatile __tsan_atomic8 *a, int mo);
+__tsan_atomic8_load(const volatile __tsan_atomic8 *a, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL
-__tsan_atomic16_load(const volatile __tsan_atomic16 *a, int mo);
+__tsan_atomic16_load(const volatile __tsan_atomic16 *a, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL
-__tsan_atomic32_load(const volatile __tsan_atomic32 *a, int mo);
+__tsan_atomic32_load(const volatile __tsan_atomic32 *a, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL
-__tsan_atomic64_load(const volatile __tsan_atomic64 *a, int mo);
+__tsan_atomic64_load(const volatile __tsan_atomic64 *a, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 SANITIZER_CDECL
-__tsan_atomic128_load(const volatile __tsan_atomic128 *a, int mo);
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_load(
+    const volatile __tsan_atomic128 *a, __tsan_memory_order mo);
 #endif
 
 void SANITIZER_CDECL __tsan_atomic8_store(volatile __tsan_atomic8 *a,
-                                          __tsan_atomic8 v, int mo);
+                                          __tsan_atomic8 v,
+                                          __tsan_memory_order mo);
 void SANITIZER_CDECL __tsan_atomic16_store(volatile __tsan_atomic16 *a,
-                                           __tsan_atomic16 v, int mo);
+                                           __tsan_atomic16 v,
+                                           __tsan_memory_order mo);
 void SANITIZER_CDECL __tsan_atomic32_store(volatile __tsan_atomic32 *a,
-                                           __tsan_atomic32 v, int mo);
+                                           __tsan_atomic32 v,
+                                           __tsan_memory_order mo);
 void SANITIZER_CDECL __tsan_atomic64_store(volatile __tsan_atomic64 *a,
-                                           __tsan_atomic64 v, int mo);
+                                           __tsan_atomic64 v,
+                                           __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 void SANITIZER_CDECL __tsan_atomic128_store(volatile __tsan_atomic128 *a,
-                                            __tsan_atomic128 v, int mo);
+                                            __tsan_atomic128 v,
+                                            __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_exchange(volatile __tsan_atomic8 *a, __tsan_atomic8 v, int mo);
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_exchange(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_exchange(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 v, int mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_exchange(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 v, int mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_exchange(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 v, int mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_exchange(
-    volatile __tsan_atomic128 *a, __tsan_atomic128 v, int mo);
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_fetch_add(volatile __tsan_atomic8 *a, __tsan_atomic8 v, int mo);
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_add(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_add(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 v, int mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_add(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 v, int mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_add(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 v, int mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_add(
-    volatile __tsan_atomic128 *a, __tsan_atomic128 v, int mo);
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_fetch_sub(volatile __tsan_atomic8 *a, __tsan_atomic8 v, int mo);
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_sub(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_sub(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 v, int mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_sub(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 v, int mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_sub(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 v, int mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_sub(
-    volatile __tsan_atomic128 *a, __tsan_atomic128 v, int mo);
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_fetch_and(volatile __tsan_atomic8 *a, __tsan_atomic8 v, int mo);
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_and(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_and(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 v, int mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_and(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 v, int mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_and(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 v, int mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_and(
-    volatile __tsan_atomic128 *a, __tsan_atomic128 v, int mo);
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_fetch_or(volatile __tsan_atomic8 *a, __tsan_atomic8 v, int mo);
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_or(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_or(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 v, int mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_or(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 v, int mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_or(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 v, int mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_or(
-    volatile __tsan_atomic128 *a, __tsan_atomic128 v, int mo);
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_fetch_xor(volatile __tsan_atomic8 *a, __tsan_atomic8 v, int mo);
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_xor(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_xor(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 v, int mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_xor(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 v, int mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_xor(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 v, int mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_xor(
-    volatile __tsan_atomic128 *a, __tsan_atomic128 v, int mo);
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 SANITIZER_CDECL
-__tsan_atomic8_fetch_nand(volatile __tsan_atomic8 *a, __tsan_atomic8 v, int mo);
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_nand(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_nand(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 v, int mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_nand(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 v, int mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_nand(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 v, int mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_nand(
-    volatile __tsan_atomic128 *a, __tsan_atomic128 v, int mo);
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
 int SANITIZER_CDECL __tsan_atomic8_compare_exchange_weak(
-    volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 int SANITIZER_CDECL __tsan_atomic16_compare_exchange_weak(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 int SANITIZER_CDECL __tsan_atomic32_compare_exchange_weak(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 int SANITIZER_CDECL __tsan_atomic64_compare_exchange_weak(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
 int SANITIZER_CDECL __tsan_atomic128_compare_exchange_weak(
     volatile __tsan_atomic128 *a, __tsan_atomic128 *c, __tsan_atomic128 v,
-    int mo, int fail_mo);
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
 int SANITIZER_CDECL __tsan_atomic8_compare_exchange_strong(
-    volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 int SANITIZER_CDECL __tsan_atomic16_compare_exchange_strong(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 int SANITIZER_CDECL __tsan_atomic32_compare_exchange_strong(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 int SANITIZER_CDECL __tsan_atomic64_compare_exchange_strong(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
 int SANITIZER_CDECL __tsan_atomic128_compare_exchange_strong(
     volatile __tsan_atomic128 *a, __tsan_atomic128 *c, __tsan_atomic128 v,
-    int mo, int fail_mo);
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
 __tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_compare_exchange_val(
-    volatile __tsan_atomic8 *a, __tsan_atomic8 c, __tsan_atomic8 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic8 *a, __tsan_atomic8 c, __tsan_atomic8 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 __tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_compare_exchange_val(
-    volatile __tsan_atomic16 *a, __tsan_atomic16 c, __tsan_atomic16 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic16 *a, __tsan_atomic16 c, __tsan_atomic16 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 __tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_compare_exchange_val(
-    volatile __tsan_atomic32 *a, __tsan_atomic32 c, __tsan_atomic32 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic32 *a, __tsan_atomic32 c, __tsan_atomic32 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 __tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_compare_exchange_val(
-    volatile __tsan_atomic64 *a, __tsan_atomic64 c, __tsan_atomic64 v, int mo,
-    int fail_mo);
+    volatile __tsan_atomic64 *a, __tsan_atomic64 c, __tsan_atomic64 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
 __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_compare_exchange_val(
     volatile __tsan_atomic128 *a, __tsan_atomic128 c, __tsan_atomic128 v,
-    int mo, int fail_mo);
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
-void SANITIZER_CDECL __tsan_atomic_thread_fence(int mo);
-void SANITIZER_CDECL __tsan_atomic_signal_fence(int mo);
+void SANITIZER_CDECL __tsan_atomic_thread_fence(__tsan_memory_order mo);
+void SANITIZER_CDECL __tsan_atomic_signal_fence(__tsan_memory_order mo);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp
@@ -40,15 +40,14 @@ int setcontext(const ucontext_t *ucp);
 
 namespace __tsan {
 
-// The non-barrier versions of OSAtomic* functions are semantically
-// morder::relaxed, but the two variants (e.g. OSAtomicAdd32 and
-// OSAtomicAdd32Barrier) are actually aliases of each other, and we cannot have
-// different interceptors for them, because they're actually the same function.
-// Thus, we have to stay conservative and treat the non-barrier versions as
-// morder::acq_rel.
-static constexpr morder kMacOrderBarrier = morder::acq_rel;
-static constexpr morder kMacOrderNonBarrier = morder::acq_rel;
-static constexpr morder kMacFailureOrder = morder::relaxed;
+// The non-barrier versions of OSAtomic* functions are semantically mo_relaxed,
+// but the two variants (e.g. OSAtomicAdd32 and OSAtomicAdd32Barrier) are
+// actually aliases of each other, and we cannot have different interceptors for
+// them, because they're actually the same function.  Thus, we have to stay
+// conservative and treat the non-barrier versions as mo_acq_rel.
+static constexpr morder kMacOrderBarrier = mo_acq_rel;
+static constexpr morder kMacOrderNonBarrier = mo_acq_rel;
+static constexpr morder kMacFailureOrder = mo_relaxed;
 
 #  define OSATOMIC_INTERCEPTOR(return_t, t, tsan_t, f, tsan_atomic_f, mo) \
     TSAN_INTERCEPTOR(return_t, f, t x, volatile t *ptr) {                 \
@@ -465,7 +464,7 @@ struct fake_shared_weak_count {
 // Shared and weak pointers in C++ maintain reference counts via atomics in
 // libc++.dylib, which are TSan-invisible, and this leads to false positives in
 // destructor code. These interceptors re-implements the whole functions so that
-// the morder::acq_rel semantics of the atomic decrement are visible.
+// the mo_acq_rel semantics of the atomic decrement are visible.
 //
 // Unfortunately, the interceptors cannot simply Acquire/Release some sync
 // object and call the original function, because it would have a race between
@@ -480,11 +479,11 @@ STDCXX_INTERCEPTOR(void, _ZNSt3__119__shared_weak_count16__release_sharedEv,
 
   SCOPED_TSAN_INTERCEPTOR(_ZNSt3__119__shared_weak_count16__release_sharedEv,
                           o);
-  if (__tsan_atomic64_fetch_add(&o->shared_owners, -1, morder::release) == 0) {
+  if (__tsan_atomic64_fetch_add(&o->shared_owners, -1, mo_release) == 0) {
     Acquire(thr, pc, (uptr)&o->shared_owners);
     o->on_zero_shared();
-    if (__tsan_atomic64_fetch_add(&o->shared_weak_owners, -1,
-                                  morder::release) == 0) {
+    if (__tsan_atomic64_fetch_add(&o->shared_weak_owners, -1, mo_release) ==
+        0) {
       Acquire(thr, pc, (uptr)&o->shared_weak_owners);
       o->on_zero_shared_weak();
     }
@@ -497,7 +496,7 @@ STDCXX_INTERCEPTOR(bool, _ZNSt3__114__shared_count16__release_sharedEv,
     return REAL(_ZNSt3__114__shared_count16__release_sharedEv)(o);
 
   SCOPED_TSAN_INTERCEPTOR(_ZNSt3__114__shared_count16__release_sharedEv, o);
-  if (__tsan_atomic64_fetch_add(&o->shared_owners, -1, morder::release) == 0) {
+  if (__tsan_atomic64_fetch_add(&o->shared_owners, -1, mo_release) == 0) {
     Acquire(thr, pc, (uptr)&o->shared_owners);
     o->on_zero_shared();
     return true;

--- a/compiler-rt/lib/tsan/rtl/tsan_interface.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface.h
@@ -219,193 +219,193 @@ __extension__ typedef __int128 a128;
 
 // Part of ABI, do not change.
 // https://github.com/llvm/llvm-project/blob/main/libcxx/include/atomic
-enum class morder : int {
-  relaxed,
-  consume,
-  acquire,
-  release,
-  acq_rel,
-  seq_cst
-};
+typedef enum {
+  mo_relaxed,
+  mo_consume,
+  mo_acquire,
+  mo_release,
+  mo_acq_rel,
+  mo_seq_cst
+} morder;
 
 struct ThreadState;
 
 extern "C" {
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_load(const volatile a8 *a, int mo);
+a8 __tsan_atomic8_load(const volatile a8 *a, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_load(const volatile a16 *a, int mo);
+a16 __tsan_atomic16_load(const volatile a16 *a, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_load(const volatile a32 *a, int mo);
+a32 __tsan_atomic32_load(const volatile a32 *a, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_load(const volatile a64 *a, int mo);
+a64 __tsan_atomic64_load(const volatile a64 *a, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_load(const volatile a128 *a, int mo);
+a128 __tsan_atomic128_load(const volatile a128 *a, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __tsan_atomic8_store(volatile a8 *a, a8 v, int mo);
+void __tsan_atomic8_store(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-void __tsan_atomic16_store(volatile a16 *a, a16 v, int mo);
+void __tsan_atomic16_store(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-void __tsan_atomic32_store(volatile a32 *a, a32 v, int mo);
+void __tsan_atomic32_store(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-void __tsan_atomic64_store(volatile a64 *a, a64 v, int mo);
+void __tsan_atomic64_store(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-void __tsan_atomic128_store(volatile a128 *a, a128 v, int mo);
+void __tsan_atomic128_store(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_exchange(volatile a8 *a, a8 v, int mo);
+a8 __tsan_atomic8_exchange(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_exchange(volatile a16 *a, a16 v, int mo);
+a16 __tsan_atomic16_exchange(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_exchange(volatile a32 *a, a32 v, int mo);
+a32 __tsan_atomic32_exchange(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_exchange(volatile a64 *a, a64 v, int mo);
+a64 __tsan_atomic64_exchange(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_exchange(volatile a128 *a, a128 v, int mo);
+a128 __tsan_atomic128_exchange(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_fetch_add(volatile a8 *a, a8 v, int mo);
+a8 __tsan_atomic8_fetch_add(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_fetch_add(volatile a16 *a, a16 v, int mo);
+a16 __tsan_atomic16_fetch_add(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_fetch_add(volatile a32 *a, a32 v, int mo);
+a32 __tsan_atomic32_fetch_add(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_fetch_add(volatile a64 *a, a64 v, int mo);
+a64 __tsan_atomic64_fetch_add(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_fetch_add(volatile a128 *a, a128 v, int mo);
+a128 __tsan_atomic128_fetch_add(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_fetch_sub(volatile a8 *a, a8 v, int mo);
+a8 __tsan_atomic8_fetch_sub(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_fetch_sub(volatile a16 *a, a16 v, int mo);
+a16 __tsan_atomic16_fetch_sub(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_fetch_sub(volatile a32 *a, a32 v, int mo);
+a32 __tsan_atomic32_fetch_sub(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_fetch_sub(volatile a64 *a, a64 v, int mo);
+a64 __tsan_atomic64_fetch_sub(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_fetch_sub(volatile a128 *a, a128 v, int mo);
+a128 __tsan_atomic128_fetch_sub(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_fetch_and(volatile a8 *a, a8 v, int mo);
+a8 __tsan_atomic8_fetch_and(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_fetch_and(volatile a16 *a, a16 v, int mo);
+a16 __tsan_atomic16_fetch_and(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_fetch_and(volatile a32 *a, a32 v, int mo);
+a32 __tsan_atomic32_fetch_and(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_fetch_and(volatile a64 *a, a64 v, int mo);
+a64 __tsan_atomic64_fetch_and(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_fetch_and(volatile a128 *a, a128 v, int mo);
+a128 __tsan_atomic128_fetch_and(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_fetch_or(volatile a8 *a, a8 v, int mo);
+a8 __tsan_atomic8_fetch_or(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_fetch_or(volatile a16 *a, a16 v, int mo);
+a16 __tsan_atomic16_fetch_or(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_fetch_or(volatile a32 *a, a32 v, int mo);
+a32 __tsan_atomic32_fetch_or(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_fetch_or(volatile a64 *a, a64 v, int mo);
+a64 __tsan_atomic64_fetch_or(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_fetch_or(volatile a128 *a, a128 v, int mo);
+a128 __tsan_atomic128_fetch_or(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_fetch_xor(volatile a8 *a, a8 v, int mo);
+a8 __tsan_atomic8_fetch_xor(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_fetch_xor(volatile a16 *a, a16 v, int mo);
+a16 __tsan_atomic16_fetch_xor(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_fetch_xor(volatile a32 *a, a32 v, int mo);
+a32 __tsan_atomic32_fetch_xor(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_fetch_xor(volatile a64 *a, a64 v, int mo);
+a64 __tsan_atomic64_fetch_xor(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_fetch_xor(volatile a128 *a, a128 v, int mo);
+a128 __tsan_atomic128_fetch_xor(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_fetch_nand(volatile a8 *a, a8 v, int mo);
+a8 __tsan_atomic8_fetch_nand(volatile a8 *a, a8 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_fetch_nand(volatile a16 *a, a16 v, int mo);
+a16 __tsan_atomic16_fetch_nand(volatile a16 *a, a16 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_fetch_nand(volatile a32 *a, a32 v, int mo);
+a32 __tsan_atomic32_fetch_nand(volatile a32 *a, a32 v, morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_fetch_nand(volatile a64 *a, a64 v, int mo);
+a64 __tsan_atomic64_fetch_nand(volatile a64 *a, a64 v, morder mo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
-a128 __tsan_atomic128_fetch_nand(volatile a128 *a, a128 v, int mo);
+a128 __tsan_atomic128_fetch_nand(volatile a128 *a, a128 v, morder mo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-int __tsan_atomic8_compare_exchange_strong(volatile a8 *a, a8 *c, a8 v, int mo,
-                                           int fmo);
+int __tsan_atomic8_compare_exchange_strong(volatile a8 *a, a8 *c, a8 v,
+                                           morder mo, morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic16_compare_exchange_strong(volatile a16 *a, a16 *c, a16 v,
-                                            int mo, int fmo);
+                                            morder mo, morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic32_compare_exchange_strong(volatile a32 *a, a32 *c, a32 v,
-                                            int mo, int fmo);
+                                            morder mo, morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic64_compare_exchange_strong(volatile a64 *a, a64 *c, a64 v,
-                                            int mo, int fmo);
+                                            morder mo, morder fmo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic128_compare_exchange_strong(volatile a128 *a, a128 *c, a128 v,
-                                             int mo, int fmo);
+                                             morder mo, morder fmo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-int __tsan_atomic8_compare_exchange_weak(volatile a8 *a, a8 *c, a8 v, int mo,
-                                         int fmo);
+int __tsan_atomic8_compare_exchange_weak(volatile a8 *a, a8 *c, a8 v, morder mo,
+                                         morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic16_compare_exchange_weak(volatile a16 *a, a16 *c, a16 v,
-                                          int mo, int fmo);
+                                          morder mo, morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic32_compare_exchange_weak(volatile a32 *a, a32 *c, a32 v,
-                                          int mo, int fmo);
+                                          morder mo, morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic64_compare_exchange_weak(volatile a64 *a, a64 *c, a64 v,
-                                          int mo, int fmo);
+                                          morder mo, morder fmo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_atomic128_compare_exchange_weak(volatile a128 *a, a128 *c, a128 v,
-                                           int mo, int fmo);
+                                           morder mo, morder fmo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-a8 __tsan_atomic8_compare_exchange_val(volatile a8 *a, a8 c, a8 v, int mo,
-                                       int fmo);
+a8 __tsan_atomic8_compare_exchange_val(volatile a8 *a, a8 c, a8 v, morder mo,
+                                       morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a16 __tsan_atomic16_compare_exchange_val(volatile a16 *a, a16 c, a16 v, int mo,
-                                         int fmo);
+a16 __tsan_atomic16_compare_exchange_val(volatile a16 *a, a16 c, a16 v,
+                                         morder mo, morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a32 __tsan_atomic32_compare_exchange_val(volatile a32 *a, a32 c, a32 v, int mo,
-                                         int fmo);
+a32 __tsan_atomic32_compare_exchange_val(volatile a32 *a, a32 c, a32 v,
+                                         morder mo, morder fmo);
 SANITIZER_INTERFACE_ATTRIBUTE
-a64 __tsan_atomic64_compare_exchange_val(volatile a64 *a, a64 c, a64 v, int mo,
-                                         int fmo);
+a64 __tsan_atomic64_compare_exchange_val(volatile a64 *a, a64 c, a64 v,
+                                         morder mo, morder fmo);
 #if __TSAN_HAS_INT128
 SANITIZER_INTERFACE_ATTRIBUTE
 a128 __tsan_atomic128_compare_exchange_val(volatile a128 *a, a128 c, a128 v,
-                                           int mo, int fmo);
+                                           morder mo, morder fmo);
 #endif
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __tsan_atomic_thread_fence(int mo);
+void __tsan_atomic_thread_fence(morder mo);
 SANITIZER_INTERFACE_ATTRIBUTE
-void __tsan_atomic_signal_fence(int mo);
+void __tsan_atomic_signal_fence(morder mo);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __tsan_go_atomic32_load(ThreadState *thr, uptr cpc, uptr pc, u8 *a);


### PR DESCRIPTION
This reverts commit aa75b16ca994eed953e63d00d6e10d3332e048f6.
