### PR TITLE
[Clang][Comments] Make @relates an inline comment command

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -598,6 +598,8 @@ Bug Fixes to AST Handling
 - Fixed a crash that occurred when dividing by zero in complex integer division. (#GH55390).
 - Fixed a bug in ``ASTContext::getRawCommentForAnyRedecl()`` where the function could
   sometimes incorrectly return null even if a comment was present. (#GH108145)
+- Clang now correctly parses the argument of the ``relates``, ``related``, ``relatesalso``,
+  and ``relatedalso`` comment commands.
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/AST/CommentCommands.td
+++ b/clang/include/clang/AST/CommentCommands.td
@@ -111,6 +111,11 @@ def Extends    : InlineCommand<"extends">;
 def Implements : InlineCommand<"implements">;
 def MemberOf   : InlineCommand<"memberof">;
 
+def Relates     : InlineCommand<"relates">;
+def Related     : InlineCommand<"related">;
+def RelatesAlso : InlineCommand<"relatesalso">;
+def RelatedAlso : InlineCommand<"relatedalso">;
+
 //===----------------------------------------------------------------------===//
 // BlockCommand
 //===----------------------------------------------------------------------===//
@@ -247,11 +252,6 @@ def TableOfContents : VerbatimLineCommand<"tableofcontents">;
 def Page     : VerbatimLineCommand<"page">;
 def Mainpage : VerbatimLineCommand<"mainpage">;
 def Subpage  : VerbatimLineCommand<"subpage">;
-
-def Relates     : VerbatimLineCommand<"relates">;
-def Related     : VerbatimLineCommand<"related">;
-def RelatesAlso : VerbatimLineCommand<"relatesalso">;
-def RelatedAlso : VerbatimLineCommand<"relatedalso">;
 
 def AddIndex : VerbatimLineCommand<"addindex">;
 

--- a/clang/test/AST/ast-dump-comment.cpp
+++ b/clang/test/AST/ast-dump-comment.cpp
@@ -73,6 +73,11 @@ int Test_InlineCommandCommentAnchor;
 // CHECK:      VarDecl{{.*}}Test_InlineCommandComment
 // CHECK:        InlineCommandComment{{.*}} Name="anchor" RenderAnchor Arg[0]="Aaa"
 
+/// \relates Aaa
+int Test_InlineCommandCommentRelates;
+// CHECK:      VarDecl{{.*}}Test_InlineCommandCommentRelates
+// CHECK:        InlineCommandComment{{.*}} Name="relates" RenderNormal Arg[0]="Aaa"
+
 /// <a>Aaa</a>
 /// <br/>
 int Test_HTMLTagComment;


### PR DESCRIPTION
According to the [Doxygen documentation](https://www.doxygen.nl/manual/commands.html#cmdrelates), the `relates`, `related`, `relatesalso`, and `relatedalso` commands all have a single argument. This patch changes their classification from `VerbatimLineCommand` to `InlineCommand` so the argument is correctly parsed. 