### PR TITLE
[HLSL] Add empty struct test cases to `__builtin_hlsl_is_typed_resource_element_compatible` test file

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2210,8 +2210,10 @@ bool SemaHLSL::IsTypedResourceElementCompatible(clang::QualType QT) {
   llvm::SmallVector<QualType, 4> QTTypes;
   BuildFlattenedTypeList(QT, QTTypes);
 
-  assert(QTTypes.size() > 0 &&
-         "expected at least one constituent type from non-null type");
+  // empty structs are not typed resource element compatible
+  if (QTTypes.size() == 0)
+    return false;
+
   QualType FirstQT = SemaRef.Context.getCanonicalType(QTTypes[0]);
 
   // element count cannot exceed 4

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2200,17 +2200,20 @@ static void BuildFlattenedTypeList(QualType BaseTy,
 }
 
 bool SemaHLSL::IsTypedResourceElementCompatible(clang::QualType QT) {
-  if (QT.isNull())
+  // null and array types are not allowed.
+  if (QT.isNull() || QT->isArrayType())
     return false;
 
-  // check if the outer type was an array type
-  if (QT->isArrayType())
+  // UDT types are not allowed
+  clang::QualType CanonicalType = QT.getCanonicalType();
+  if (CanonicalType->getAs<clang::RecordType>()) {
     return false;
+  }
 
   llvm::SmallVector<QualType, 4> QTTypes;
   BuildFlattenedTypeList(QT, QTTypes);
 
-  // empty structs are not typed resource element compatible
+  // empty element type is not typed resource element compatible
   if (QTTypes.size() == 0)
     return false;
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2224,6 +2224,10 @@ bool SemaHLSL::IsTypedResourceElementCompatible(clang::QualType QT) {
     if (ArraySize > 4)
       return false;
 
+    QualType ElTy = VT->getElementType();
+    if (ElTy->isBooleanType())
+      return false;
+
     if (SemaRef.Context.getTypeSize(QT) / 8 > 16)
       return false;
     return true;

--- a/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
+++ b/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
@@ -108,4 +108,13 @@ struct TypeDefTest {
 
 _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(TypeDefTest), "");
 
+struct EmptyStruct {};
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(EmptyStruct), "");
 
+struct EmptyDerived : EmptyStruct {};
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(EmptyDerived), "");
+
+struct EmptyBase : EmptyStruct {
+  int4 V;
+};
+_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(EmptyBase), ""); 

--- a/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
+++ b/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
@@ -107,3 +107,5 @@ struct TypeDefTest {
 };
 
 _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(TypeDefTest), "");
+
+

--- a/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
+++ b/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
@@ -1,120 +1,28 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.6-library -finclude-default-header -fnative-half-type -verify %s
 // expected-no-diagnostics
 
-struct oneInt {
-    int i;
-};
-
-struct twoInt {
-   int aa;
-   int ab;
-};
-
-struct threeInts {
-  oneInt o;
-  twoInt t;
-};
-
-struct oneFloat {
-    float f;
-};
-struct depthDiff {
-  int i;
-  oneInt o;
-  oneFloat f;
-};
-
-struct notHomogenous{     
-  int i;
-  float f;
-};
-
-struct EightElements {
-  twoInt x[2];
-  twoInt y[2];
-};
-
-struct EightHalves {
-half x[8]; 
-};
-
-struct intVec {
-  int2 i;
-};
-
-struct oneIntWithVec {
-  int i;
-  oneInt i2;
-  int2 i3;
-};
-
-struct weirdStruct {
-  int i;
-  intVec iv;
-};
 
 _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(int), "");
 _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(float), "");
 _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(float4), "");
 _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(double2), "");
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(oneInt), "");
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(oneFloat), "");
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(twoInt), "");
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(threeInts), "");
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(notHomogenous), "");
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(depthDiff), "");
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(EightElements), "");
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(EightHalves), "");
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(oneIntWithVec), "");
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(weirdStruct), "");
+
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(RWBuffer<int>), "");
 
+struct s {
+    int x;
+};
+
+// structs not allowed
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(s), "");
 
 // arrays not allowed
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(half[4]), "");
 
-template<typename T> struct TemplatedBuffer {
-    T a;
-    __hlsl_resource_t h;
-};
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(TemplatedBuffer<int>), "");
+typedef vector<int, 8> int8;
+// too many elements
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(int8), "");
 
-struct MyStruct1 : TemplatedBuffer<float> {
-    float x;
-};
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(MyStruct1), "");
+// size exceeds 16 bytes, and exceeds element count limit after splitting 64 bit types into 32 bit types
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(double3), "");
 
-struct MyStruct2 {
-    const TemplatedBuffer<float> TB[10];
-};
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(MyStruct2), "");
-
-template<typename T> struct SimpleTemplate {
-    T a;
-};
-
-// though the element type is incomplete, the type trait should still technically return true
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(SimpleTemplate<__hlsl_resource_t>), "");
-
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(SimpleTemplate<float>), "");
-
-
-typedef int myInt;
-
-struct TypeDefTest {
-    int x;
-    myInt y;
-};
-
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(TypeDefTest), "");
-
-struct EmptyStruct {};
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(EmptyStruct), "");
-
-struct EmptyDerived : EmptyStruct {};
-_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(EmptyDerived), "");
-
-struct EmptyBase : EmptyStruct {
-  int4 V;
-};
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(EmptyBase), ""); 

--- a/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
+++ b/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
@@ -13,8 +13,21 @@ struct s {
     int x;
 };
 
+struct Empty {};
+
+template<typename T> struct TemplatedBuffer {
+    T a;
+};
+
+template<typename T> struct TemplatedVector {
+    vector<T, 4> v;
+};
+
 // structs not allowed
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(s), "");
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(Empty), "");
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(TemplatedBuffer<int>), "");
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(TemplatedVector<int>), "");
 
 // arrays not allowed
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(half[4]), "");
@@ -22,6 +35,9 @@ _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(half[4]), ""
 typedef vector<int, 8> int8;
 // too many elements
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(int8), "");
+
+typedef int MyInt;
+_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(MyInt), "");
 
 // size exceeds 16 bytes, and exceeds element count limit after splitting 64 bit types into 32 bit types
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(double3), "");

--- a/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
+++ b/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatible.hlsl
@@ -39,6 +39,14 @@ _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(int8), "");
 typedef int MyInt;
 _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(MyInt), "");
 
+// bool and enums not allowed
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(bool), "");
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(vector<bool, 2>), "");
+
+enum numbers { one, two, three };
+
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(numbers), "");
+
 // size exceeds 16 bytes, and exceeds element count limit after splitting 64 bit types into 32 bit types
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(double3), "");
 

--- a/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatibleErrors.hlsl
+++ b/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatibleErrors.hlsl
@@ -7,4 +7,3 @@ _Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(__hlsl_resour
 struct notComplete;
 // expected-error@+1{{incomplete type 'notComplete' where a complete type is required}}
 _Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(notComplete), "");
- 

--- a/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatibleErrors.hlsl
+++ b/clang/test/SemaHLSL/Types/Traits/IsTypedResourceElementCompatibleErrors.hlsl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.6-library -finclude-default-header -fnative-half-type -verify %s
 
 // types must be complete
-_Static_assert(__builtin_hlsl_is_typed_resource_element_compatible(__hlsl_resource_t), "");
+_Static_assert(!__builtin_hlsl_is_typed_resource_element_compatible(__hlsl_resource_t), "");
 
 // expected-note@+1{{forward declaration of 'notComplete'}}
 struct notComplete;


### PR DESCRIPTION
This PR adds empty struct cases to the test file for the builtin.