### PR TITLE
[CMake] Enable CMP0156 if available

### DIFF
--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -30,3 +30,11 @@ endif()
 if(POLICY CMP0147)
   cmake_policy(SET CMP0147 NEW)
 endif()
+
+# CMP0156: De-duplicate libraries on link lines based on linker capabilities.
+# New in CMake 3.29: https://cmake.org/cmake/help/latest/policy/CMP0156.html
+# Avoids the deluge of 'ld: warning: ignoring duplicate libraries' warnings when
+# building with the Apple linker.
+if(POLICY CMP0156)
+  cmake_policy(SET CMP0156 NEW)
+endif()


### PR DESCRIPTION
Some linkers do not require that libraries are repeated on the command line. The Apple linker emits warnings when duplicate libraries are specified, resulting in a wall of warnings.

CMP0156 deduplicates libraries on the command line when the linker doesn't require them.

This patch enables CMP0156 to quiet the warnings when using a version of CMake that recognizes it (CMake 3.29 and newer).