### PR TITLE
[Clang][Darwin] Introduce `SubFrameworks` as a SDK default location

### DIFF
--- a/clang/lib/InstallAPI/DirectoryScanner.cpp
+++ b/clang/lib/InstallAPI/DirectoryScanner.cpp
@@ -277,7 +277,8 @@ llvm::Error DirectoryScanner::scanForFrameworks(StringRef Directory) {
   // Expect a certain directory structure and naming convention to find
   // frameworks.
   static const char *SubDirectories[] = {"System/Library/Frameworks/",
-                                         "System/Library/PrivateFrameworks/"};
+                                         "System/Library/PrivateFrameworks/",
+                                         "System/Library/SubFrameworks"};
 
   // Check if the directory is already a framework.
   if (isFramework(Directory)) {

--- a/clang/lib/Lex/InitHeaderSearch.cpp
+++ b/clang/lib/Lex/InitHeaderSearch.cpp
@@ -347,6 +347,7 @@ void InitHeaderSearch::AddDefaultIncludePaths(
       } else {
         AddPath("/System/Library/Frameworks", System, true);
         AddPath("/Library/Frameworks", System, true);
+        AddPath("/System/Library/SubFrameworks", System, true);
       }
     }
     return;

--- a/clang/lib/Lex/InitHeaderSearch.cpp
+++ b/clang/lib/Lex/InitHeaderSearch.cpp
@@ -346,8 +346,8 @@ void InitHeaderSearch::AddDefaultIncludePaths(
         AddPath("/System/DriverKit/System/Library/Frameworks", System, true);
       } else {
         AddPath("/System/Library/Frameworks", System, true);
-        AddPath("/Library/Frameworks", System, true);
         AddPath("/System/Library/SubFrameworks", System, true);
+        AddPath("/Library/Frameworks", System, true);
       }
     }
     return;

--- a/clang/test/Driver/darwin-subframeworks.c
+++ b/clang/test/Driver/darwin-subframeworks.c
@@ -1,0 +1,15 @@
+// Add default directories before running clang to check default 
+// search paths. 
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: cp -R %S/Inputs/MacOSX15.1.sdk %t/
+// RUN: mkdir -p %t/MacOSX15.1.sdk/System/Library/Frameworks
+// RUN: mkdir -p %t/MacOSX15.1.sdk/System/Library/SubFrameworks
+// RUN: mkdir -p %t/MacOSX15.1.sdk/usr/include
+
+// RUN: %clang %s -target arm64-apple-darwin13.0 -isysroot %t/MacOSX15.1.sdk -E -v 2>&1 | FileCheck %s
+
+// CHECK:    -isysroot [[PATH:[^ ]*/MacOSX15.1.sdk]]
+// CHECK:    #include <...> search starts here:
+// CHECK:    [[PATH]]/usr/include
+// CHECK:    [[PATH]]/System/Library/Frameworks (framework directory)
+// CHECK:    [[PATH]]/System/Library/SubFrameworks (framework directory)

--- a/clang/test/Driver/darwin-subframeworks.c
+++ b/clang/test/Driver/darwin-subframeworks.c
@@ -1,3 +1,6 @@
+// UNSUPPORTED: system-windows
+//   Windows is unsupported because we use the Unix path separator `\`.
+
 // Add default directories before running clang to check default 
 // search paths. 
 // RUN: rm -rf %t && mkdir -p %t

--- a/llvm/lib/TextAPI/Utils.cpp
+++ b/llvm/lib/TextAPI/Utils.cpp
@@ -120,6 +120,9 @@ bool llvm::MachO::isPrivateLibrary(StringRef Path, bool IsSymLink) {
   if (Path.starts_with("/System/Library/PrivateFrameworks"))
     return true;
 
+  if (Path.starts_with("/System/Library/SubFrameworks"))
+    return true;
+
   // Everything in /usr/lib/swift (including sub-directories) are considered
   // public.
   if (Path.consume_front("/usr/lib/swift/"))

--- a/llvm/test/tools/llvm-readtapi/stubify-delete.test
+++ b/llvm/test/tools/llvm-readtapi/stubify-delete.test
@@ -2,17 +2,20 @@
 # Setup a mix of public and private libraries that resemble apple sdk.
 ; RUN: mkdir -p %t/sysroot/usr/local/lib/ %t/sysroot/usr/lib/
 ; RUN: mkdir -p %t/sysroot/System/Library/Frameworks/System.framework %t/sysroot/System/Library/PrivateFrameworks/Fat.framework
+; RUN: mkdir -p %t/sysroot/System/Library/SubFrameworks/Fat.framework/Headers
 ; RUN: yaml2obj %S/Inputs/libSystem.1.yaml -o %t/sysroot/System/Library/Frameworks/System.framework/System
 ; RUN: yaml2obj %S/Inputs/objc.yaml -o %t/sysroot/usr/lib/libobjc.dylib
 ; RUN: cp %t/sysroot/usr/lib/libobjc.dylib %t/sysroot/usr/local/lib/libobjc-unstable.dylib
 ; RUN: yaml2obj %S/Inputs/universal.yaml -o %t/sysroot/System/Library/PrivateFrameworks/Fat.framework/Fat
+; RUN: cp %t/sysroot/System/Library/PrivateFrameworks/Fat.framework/Fat %t/sysroot/System/Library/SubFrameworks/Fat.framework/Fat
+; RUN: touch %t/sysroot/System/Library/SubFrameworks/Fat.framework/Headers/Fat.h
 ; RUN: llvm-readtapi -stubify %t/sysroot --delete-input --delete-private-libraries 2>&1 | FileCheck %s --allow-empty  --implicit-check-not warning: --implicit-check-not error:
 # Validate expected files are removed.
 ; RUN: not test -f %t/sysroot/System/Library/PrivateFrameworks
 ; RUN: not test -f %t/sysroot/usr/local
 ; RUN: not test -f %t/sysroot/usr/lib/libobjc.dylib
 ; RUN: not test -f %t/sysroot/System/Library/Frameworks/System.framework/System
+; RUN: not test -f %t/sysroot/System/Library/SubFrameworks/Fat.framework/Fat
 ; RUN: test -f %t/sysroot/System/Library/Frameworks/System.framework/System.tbd
 ; RUN: test -f %t/sysroot/usr/lib/libobjc.tbd
-
-
+; RUN: test -f %t/sysroot/System/Library/SubFrameworks/Fat.framework/Headers/Fat.h

--- a/llvm/tools/llvm-readtapi/llvm-readtapi.cpp
+++ b/llvm/tools/llvm-readtapi/llvm-readtapi.cpp
@@ -255,15 +255,20 @@ static void stubifyDirectory(const StringRef InputPath, Context &Ctx) {
     if (EC)
       reportError(IT->path() + ": " + EC.message());
 
-    // Skip header directories (include/Headers/PrivateHeaders) and module
-    // files.
+    // Skip header directories (include/Headers/PrivateHeaders).
     StringRef Path = IT->path();
-    if (Path.ends_with("/include") || Path.ends_with("/Headers") ||
-        Path.ends_with("/PrivateHeaders") || Path.ends_with("/Modules") ||
-        Path.ends_with(".map") || Path.ends_with(".modulemap")) {
-      IT.no_push();
-      continue;
+    if (sys::fs::is_directory(Path)) {
+      const StringRef Stem = sys::path::stem(Path);
+      if ((Stem == "include") || (Stem == "Headers") ||
+          (Stem == "PrivateHeaders") || (Stem == "Modules")) {
+        IT.no_push();
+        continue;
+      }
     }
+
+    // Skip module files too.
+    if (Path.ends_with(".map") || Path.ends_with(".modulemap"))
+      continue;
 
     // Check if the entry is a symlink. We don't follow symlinks but we record
     // their content.


### PR DESCRIPTION
* Have clang always append & pass `System/Library/SubFrameworks` when determining default sdk search paths.
* Teach `clang-installapi` to traverse there for framework input.
* Teach `llvm-readtapi` that the library files (TBD or binary) in there should be considered private.

resolves: <rdar://137457006>