### PR TITLE
[C2y] Add test coverage for WG14 N3370

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -274,6 +274,12 @@ C Language Changes
 C2y Feature Support
 ^^^^^^^^^^^^^^^^^^^
 
+- Clang updated conformance for `N3370 <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3370.htm>`_
+  case range expressions. This feature was previously supported by Clang as a
+  GNU extension, so ``-Wgnu-case-range`` no longer has effect in C modes, as
+  this is now a C2y extension in C. ``-Wgnu-case-range`` still applies in C++
+  modes.
+
 C23 Feature Support
 ^^^^^^^^^^^^^^^^^^^
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -203,8 +203,13 @@ def err_expected_equal_designator : Error<"expected '=' or another designator">;
 def ext_gnu_old_style_field_designator : ExtWarn<
   "use of GNU old-style field designator extension">,
   InGroup<GNUDesignator>;
-def ext_gnu_case_range : Extension<"use of GNU case range extension">,
-  InGroup<GNUCaseRange>;
+def ext_gnu_case_range : Extension<
+  "case ranges are a GNU extension">, InGroup<GNUCaseRange>;
+def warn_c23_compat_case_range : Warning<
+  "case ranges are incompatible with C standards before C2y">,
+  DefaultIgnore, InGroup<CPre2yCompat>;
+def ext_c2y_case_range : Extension<
+  "case ranges are a C2y extension">, InGroup<C2y>;
 
 // Generic errors.
 def err_expected_expression : Error<"expected expression">;

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -890,7 +890,15 @@ StmtResult Parser::ParseCaseStatement(ParsedStmtContext StmtCtx,
     SourceLocation DotDotDotLoc;
     ExprResult RHS;
     if (TryConsumeToken(tok::ellipsis, DotDotDotLoc)) {
-      Diag(DotDotDotLoc, diag::ext_gnu_case_range);
+      // In C++, this is a GNU extension. In C, it's a C2y extension.
+      unsigned DiagId;
+      if (getLangOpts().CPlusPlus)
+        DiagId = diag::ext_gnu_case_range;
+      else if (getLangOpts().C2y)
+        DiagId = diag::warn_c23_compat_case_range;
+      else
+        DiagId = diag::ext_c2y_case_range;
+      Diag(DotDotDotLoc, DiagId);
       RHS = ParseCaseExpression(CaseLoc);
       if (RHS.isInvalid()) {
         if (!SkipUntil(tok::colon, tok::r_brace, StopAtSemi | StopBeforeMatch))

--- a/clang/test/C/C2y/n3370.c
+++ b/clang/test/C/C2y/n3370.c
@@ -1,0 +1,105 @@
+// RUN: %clang_cc1 -verify=expected,c-expected -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify=expected,c-expected,ped -std=c23 -Wall -pedantic %s
+// RUN: %clang_cc1 -verify=expected,cxx-expected,gnu -Wall -pedantic -x c++ %s
+// RUN: %clang_cc1 -verify=expected,c-expected,pre -std=c2y -Wpre-c2y-compat -Wall -pedantic %s
+
+/* WG14 N3370: Yes
+ * Case range expressions v3.1
+ *
+ * This introduces the ability to specify closed ranges in case statements in a
+ * switch statement. This was already a well-supported Clang extension before
+ * it was standardized.
+ */
+
+void correct(int i) {
+  constexpr int j = 100, k = 200;
+  switch (i) {
+  case 12 ... 14: break; /* gnu-warning {{case ranges are a GNU extension}}
+                            ped-warning {{case ranges are a C2y extension}}
+                            pre-warning {{case ranges are incompatible with C standards before C2y}}
+                          */
+  // Implementations are encouraged to diagnose empty ranges.
+  case 15 ... 11: break;  /* expected-warning {{empty case range specified}}
+                             gnu-warning {{case ranges are a GNU extension}}
+                             ped-warning {{case ranges are a C2y extension}}
+                             pre-warning {{case ranges are incompatible with C standards before C2y}}
+                           */
+  // This is not an empty range, it's a range of a single value.
+  case 10 ... 10: break; /* gnu-warning {{case ranges are a GNU extension}}
+                            ped-warning {{case ranges are a C2y extension}}
+                            pre-warning {{case ranges are incompatible with C standards before C2y}}
+                          */
+  case j ... k: break;   /* gnu-warning {{case ranges are a GNU extension}}
+                            ped-warning {{case ranges are a C2y extension}}
+                            pre-warning {{case ranges are incompatible with C standards before C2y}}
+                          */
+  }
+}
+
+void incorrect(int i) { // cxx-expected-note 2 {{declared here}}
+  switch (i) {
+  // The values have to be integer constant expressions. Note that when the
+  // initial value in the range is an error, we don't issue the warnings about
+  // extensions or incompatibility.
+  case i ... 10: break;    /* c-expected-error {{expression is not an integer constant expression}}
+                              cxx-expected-error {{case value is not a constant expression}}
+                              cxx-expected-note {{function parameter 'i' with unknown value cannot be used in a constant expression}}
+                            */
+  case 10 ... i: break;    /* c-expected-error {{expression is not an integer constant expression}}
+                              cxx-expected-error {{case value is not a constant expression}}
+                              cxx-expected-note {{function parameter 'i' with unknown value cannot be used in a constant expression}}
+                              gnu-warning {{case ranges are a GNU extension}}
+                              ped-warning {{case ranges are a C2y extension}}
+                              pre-warning {{case ranges are incompatible with C standards before C2y}}
+                            */
+  case 1.3f ... 10: break; /* c-expected-error {{integer constant expression must have integer type, not 'float'}}
+                              cxx-expected-error {{conversion from 'float' to 'int' is not allowed in a converted constant expression}}
+                            */
+  case 10 ... "a": break;  /* c-expected-error {{integer constant expression must have integer type, not 'char[2]'}}
+                              cxx-expected-error {{value of type 'const char[2]' is not implicitly convertible to 'int'}}
+                              gnu-warning {{case ranges are a GNU extension}}
+                              ped-warning {{case ranges are a C2y extension}}
+                              pre-warning {{case ranges are incompatible with C standards before C2y}}
+                            */
+  }
+
+  switch (i) {
+  // Cannot have multiple cases covering the same value.
+  // FIXME: diagnostic quality here is poor. The "previous case" note is
+  // showing up on a subsequent line (I'd expect the error and note to be
+  // reversed), and "duplicate case value 20" is showing up on a line where
+  // there is no duplicate value 20 to begin with.
+  case 10 ... 20: break; /* expected-error {{duplicate case value '11'}}
+                            expected-note {{previous case defined here}}
+                            gnu-warning {{case ranges are a GNU extension}}
+                            ped-warning {{case ranges are a C2y extension}}
+                            pre-warning {{case ranges are incompatible with C standards before C2y}}
+                          */
+  case 11: break;        /* expected-note {{previous case defined here}}
+                          */
+  case 11 ... 14: break; /* expected-error {{duplicate case value '20'}}
+                            gnu-warning {{case ranges are a GNU extension}}
+                            ped-warning {{case ranges are a C2y extension}}
+                            pre-warning {{case ranges are incompatible with C standards before C2y}}
+                          */
+  }
+
+  // The values specified by the range shall not change as a result of
+  // conversion to the promoted type of the controlling expression.
+  // FIXME: the overflow warnings seem like they probably should also trigger
+  // in C++ as they do in C.
+  switch ((unsigned char)i) {
+  case 254 ... 256: break; /* c-expected-warning {{overflow converting case value to switch condition type (256 to 0)}}
+                              gnu-warning {{case ranges are a GNU extension}}
+                              ped-warning {{case ranges are a C2y extension}}
+                              pre-warning {{case ranges are incompatible with C standards before C2y}}
+                            */
+  case 257 ... 258: break; /* c-expected-warning {{overflow converting case value to switch condition type (257 to 1)}}
+                              c-expected-warning {{overflow converting case value to switch condition type (258 to 2)}}
+                              gnu-warning {{case ranges are a GNU extension}}
+                              ped-warning {{case ranges are a C2y extension}}
+                              pre-warning {{case ranges are incompatible with C standards before C2y}}
+                            */
+  }
+}
+

--- a/clang/test/Sema/gnu-flags.c
+++ b/clang/test/Sema/gnu-flags.c
@@ -1,20 +1,19 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s -DNONE -Wno-gnu
 // RUN: %clang_cc1 -fsyntax-only -verify %s -DALL -Wgnu
 // RUN: %clang_cc1 -fsyntax-only -verify %s -DALL -Wno-gnu \
-// RUN:   -Wgnu-alignof-expression -Wgnu-case-range -Wgnu-complex-integer -Wgnu-conditional-omitted-operand \
+// RUN:   -Wgnu-alignof-expression -Wgnu-complex-integer -Wgnu-conditional-omitted-operand \
 // RUN:   -Wgnu-label-as-value -Wgnu-statement-expression \
 // RUN:   -Wgnu-compound-literal-initializer -Wgnu-flexible-array-initializer \
 // RUN:   -Wgnu-redeclared-enum  -Wgnu-folding-constant -Wgnu-empty-struct \
 // RUN:   -Wgnu-union-cast -Wgnu-variable-sized-type-not-at-end
 // RUN: %clang_cc1 -fsyntax-only -verify %s -DNONE -Wgnu \
-// RUN:   -Wno-gnu-alignof-expression -Wno-gnu-case-range -Wno-gnu-complex-integer -Wno-gnu-conditional-omitted-operand \
+// RUN:   -Wno-gnu-alignof-expression -Wno-gnu-complex-integer -Wno-gnu-conditional-omitted-operand \
 // RUN:   -Wno-gnu-label-as-value -Wno-gnu-statement-expression \
 // RUN:   -Wno-gnu-compound-literal-initializer -Wno-gnu-flexible-array-initializer \
 // RUN:   -Wno-gnu-redeclared-enum -Wno-gnu-folding-constant -Wno-gnu-empty-struct \
 // RUN:   -Wno-gnu-union-cast -Wno-gnu-variable-sized-type-not-at-end
 // Additional disabled tests:
 // %clang_cc1 -fsyntax-only -verify %s -DALIGNOF -Wno-gnu -Wgnu-alignof-expression
-// %clang_cc1 -fsyntax-only -verify %s -DCASERANGE -Wno-gnu -Wgnu-case-range
 // %clang_cc1 -fsyntax-only -verify %s -DCOMPLEXINT -Wno-gnu -Wgnu-complex-integer
 // %clang_cc1 -fsyntax-only -verify %s -DOMITTEDOPERAND -Wno-gnu -Wgnu-conditional-omitted-operand
 // %clang_cc1 -fsyntax-only -verify %s -DLABELVALUE -Wno-gnu -Wgnu-label-as-value
@@ -39,17 +38,6 @@
 
 char align;
 _Static_assert(_Alignof(align) > 0, "align's alignment is wrong");
-
-
-#if ALL || CASERANGE
-// expected-warning@+5 {{use of GNU case range extension}}
-#endif
-
-void caserange(int x) {
-  switch (x) {
-  case 42 ... 44: ;
-  }
-}
 
 
 #if ALL || COMPLEXINT

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -236,7 +236,7 @@ conformance.</p>
     <tr>
       <td>Case range expressions v3.1</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3370.htm">N3370</a></td>
-      <td class="unknown" align="center">Unknown</td>
+      <td class="full" align="center">Yes</td>
     </tr>
     <tr>
       <td>New _Lengthof() operator (v4)</td>


### PR DESCRIPTION
This paper added case ranges in switch statements, which is a GNU extension Clang has supported since at least Clang 3.0.

It updates the diagnostics to no longer call this a GNU extension except in C++ mode.