### PR TITLE
[ObjC] Enable diagnose_if on Objective-C methods

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -741,8 +741,8 @@ public:
   /// unevaluated context. Returns true if the expression could be folded to a
   /// constant.
   bool EvaluateWithSubstitution(APValue &Value, ASTContext &Ctx,
-                                const FunctionDecl *Callee,
-                                ArrayRef<const Expr*> Args,
+                                const NamedDecl *Callee,
+                                ArrayRef<const Expr *> Args,
                                 const Expr *This = nullptr) const;
 
   enum class ConstantExprKind {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10302,13 +10302,15 @@ public:
                               bool MissingImplicitThis = false);
 
   /// Emit diagnostics for the diagnose_if attributes on Function, ignoring any
-  /// non-ArgDependent DiagnoseIfAttrs.
+  /// non-ArgDependent DiagnoseIfAttrs. Function should be a function, a
+  /// C++ method, or an Objective-C method. ThisArg should be non-NULL only for
+  /// C++ methods.
   ///
   /// Argument-dependent diagnose_if attributes should be checked each time a
   /// function is used as a direct callee of a function call.
   ///
   /// Returns true if any errors were emitted.
-  bool diagnoseArgDependentDiagnoseIfAttrs(const FunctionDecl *Function,
+  bool diagnoseArgDependentDiagnoseIfAttrs(const NamedDecl *Function,
                                            const Expr *ThisArg,
                                            ArrayRef<const Expr *> Args,
                                            SourceLocation Loc);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -742,6 +742,10 @@ public:
     Parms.insert(FD->param_begin(), FD->param_end());
   }
 
+  ArgumentDependenceChecker(const ObjCMethodDecl *MD) {
+    Parms.insert(MD->param_begin(), MD->param_end());
+  }
+
   bool referencesArgs(Expr *E) {
     Result = false;
     TraverseStmt(E);
@@ -866,6 +870,8 @@ static void handleDiagnoseIfAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   bool ArgDependent = false;
   if (const auto *FD = dyn_cast<FunctionDecl>(D))
     ArgDependent = ArgumentDependenceChecker(FD).referencesArgs(Cond);
+  else if (const auto *MD = dyn_cast<ObjCMethodDecl>(D))
+    ArgDependent = ArgumentDependenceChecker(MD).referencesArgs(Cond);
   D->addAttr(::new (S.Context) DiagnoseIfAttr(
       S.Context, AL, Cond, Msg, DiagType, ArgDependent, cast<NamedDecl>(D)));
 }

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -2706,6 +2706,11 @@ ExprResult SemaObjC::BuildClassMessage(
         << Method->getDeclName();
   }
 
+  // Check any arg-dependent diagnose_if conditions;
+  if (Method)
+    SemaRef.diagnoseArgDependentDiagnoseIfAttrs(Method, nullptr, ArgsIn,
+                                                RBracLoc);
+
   // Warn about explicit call of +initialize on its own class. But not on 'super'.
   if (Method && Method->getMethodFamily() == OMF_initialize) {
     if (!SuperLoc.isValid()) {
@@ -3238,6 +3243,11 @@ ExprResult SemaObjC::BuildInstanceMessage(
           LBracLoc, Method->getReturnType(),
           diag::err_illegal_message_expr_incomplete_type))
     return ExprError();
+
+  // Check any arg-dependent diagnose_if conditions;
+  if (Method)
+    SemaRef.diagnoseArgDependentDiagnoseIfAttrs(Method, nullptr, ArgsIn,
+                                                RBracLoc);
 
   // In ARC, forbid the user from sending messages to
   // retain/release/autorelease/dealloc/retainCount explicitly.

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7360,7 +7360,7 @@ static bool diagnoseDiagnoseIfAttrsWith(Sema &S, const NamedDecl *ND,
   return false;
 }
 
-bool Sema::diagnoseArgDependentDiagnoseIfAttrs(const FunctionDecl *Function,
+bool Sema::diagnoseArgDependentDiagnoseIfAttrs(const NamedDecl *Function,
                                                const Expr *ThisArg,
                                                ArrayRef<const Expr *> Args,
                                                SourceLocation Loc) {
@@ -7372,7 +7372,7 @@ bool Sema::diagnoseArgDependentDiagnoseIfAttrs(const FunctionDecl *Function,
         // EvaluateWithSubstitution only cares about the position of each
         // argument in the arg list, not the ParmVarDecl* it maps to.
         if (!DIA->getCond()->EvaluateWithSubstitution(
-                Result, Context, cast<FunctionDecl>(DIA->getParent()), Args, ThisArg))
+                Result, Context, DIA->getParent(), Args, ThisArg))
           return false;
         return Result.isInt() && Result.getInt().getBoolValue();
       });

--- a/clang/test/SemaObjC/diagnose_if.m
+++ b/clang/test/SemaObjC/diagnose_if.m
@@ -6,11 +6,25 @@ _Static_assert(__has_feature(attribute_diagnose_if_objc), "feature check failed?
 
 @interface I
 -(void)meth _diagnose_if(1, "don't use this", "warning"); // expected-note 1{{from 'diagnose_if'}}
+- (void)meth:(int *)x
+    _diagnose_if(x == 0, "x is NULL",
+                 "warning"); // expected-note 1{{from 'diagnose_if'}}
++ (void)meth:(int *)x
+    _diagnose_if(x == 0, "x is NULL",
+                 "warning"); // expected-note 1{{from 'diagnose_if'}}
 @property (assign) id prop _diagnose_if(1, "don't use this", "warning"); // expected-note 2{{from 'diagnose_if'}}
 @end
 
 void test(I *i) {
   [i meth]; // expected-warning {{don't use this}}
+
+  int x;
+  [i meth:&x];
+  [i meth:0]; // expected-warning {{x is NULL}}
+
+  [I meth:&x];
+  [I meth:0]; // expected-warning {{x is NULL}}
+
   id o1 = i.prop; // expected-warning {{don't use this}}
   id o2 = [i prop]; // expected-warning {{don't use this}}
 }


### PR DESCRIPTION
This change enables checking argument-dependent `diagnose_if` diagnostics on Objective-C methods.

It changes EvaluateWithSubstitution to accept any NamedDecl, concretely expecting them to be either FunctionDecls or ObjCMethodDecls.

rdar://138000724