### PR TITLE
[libc][bazel] Remove -mllvm --tail-merge-threshold=0 from Bazel.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3648,7 +3648,6 @@ libc_function(
     name = "memcpy",
     srcs = ["src/string/memcpy.cpp"],
     hdrs = ["src/string/memcpy.h"],
-    copts = ["-mllvm --tail-merge-threshold=0"],
     features = no_sanitize_features,
     weak = True,
     deps = [
@@ -3685,7 +3684,6 @@ libc_function(
     name = "mempcpy",
     srcs = ["src/string/mempcpy.cpp"],
     hdrs = ["src/string/mempcpy.h"],
-    copts = ["-mllvm --tail-merge-threshold=0"],
     features = no_sanitize_features,
     weak = True,
     deps = [


### PR DESCRIPTION
Follow-up on the `-mllvm --tail-merge-threshold=0` removal promised in aeccc16497a84d61200f7ccfa3864096349260d3 (see b2a9ea4420127d10b18ae648b16757665f8bbd7c commit message on why we don't need this in Bazel, and will only keep in AArch64-specific compile flags in CMake build).