### PR TITLE
[clang][deps] Share `FileManager` between modules

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -335,7 +335,9 @@ public:
 
     ScanInstance.getFrontendOpts().GenerateGlobalModuleIndex = false;
     ScanInstance.getFrontendOpts().UseGlobalModuleIndex = false;
-    ScanInstance.getFrontendOpts().ModulesShareFileManager = false;
+    // This will prevent us compiling individual modules asynchronously since
+    // FileManager is not thread-safe, but it does improve performance for now.
+    ScanInstance.getFrontendOpts().ModulesShareFileManager = true;
     ScanInstance.getHeaderSearchOpts().ModuleFormat = "raw";
     ScanInstance.getHeaderSearchOpts().ModulesIncludeVFSUsage =
         any(OptimizeArgs & ScanningOptimizations::VFS);


### PR DESCRIPTION
The `FileManager` sharing between module-building `CompilerInstance`s was disabled a while ago due to `FileEntry::getName()` being unreliable. Now that we use `FileEntryRef::getNameAsRequested()` in places where it matters, re-enabling `FileManager` is sound and improves performance of `clang-scan-deps` by ~6.2%.