### PR TITLE
[libc++] Fix incorrect const qualification in some ranges algorithms

### DIFF
--- a/libcxx/include/__algorithm/ranges_replace.h
+++ b/libcxx/include/__algorithm/ranges_replace.h
@@ -38,7 +38,7 @@ struct __replace {
              indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type1*>
   _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(
       _Iter __first, _Sent __last, const _Type1& __old_value, const _Type2& __new_value, _Proj __proj = {}) const {
-    auto __pred = [&](const auto& __val) -> bool { return __val == __old_value; };
+    auto __pred = [&](auto&& __val) -> bool { return __val == __old_value; };
     return ranges::__replace_if_impl(std::move(__first), std::move(__last), __pred, __new_value, __proj);
   }
 

--- a/libcxx/include/__algorithm/ranges_replace_copy.h
+++ b/libcxx/include/__algorithm/ranges_replace_copy.h
@@ -54,7 +54,7 @@ struct __replace_copy {
              const _OldType& __old_value,
              const _NewType& __new_value,
              _Proj __proj = {}) const {
-    auto __pred = [&](const auto& __value) -> bool { return __value == __old_value; };
+    auto __pred = [&](auto&& __value) -> bool { return __value == __old_value; };
     return ranges::__replace_copy_if_impl(
         std::move(__first), std::move(__last), std::move(__result), __pred, __new_value, __proj);
   }
@@ -69,7 +69,7 @@ struct __replace_copy {
   _LIBCPP_HIDE_FROM_ABI constexpr replace_copy_result<borrowed_iterator_t<_Range>, _OutIter> operator()(
       _Range&& __range, _OutIter __result, const _OldType& __old_value, const _NewType& __new_value, _Proj __proj = {})
       const {
-    auto __pred = [&](const auto& __value) -> bool { return __value == __old_value; };
+    auto __pred = [&](auto&& __value) -> bool { return __value == __old_value; };
     return ranges::__replace_copy_if_impl(
         ranges::begin(__range), ranges::end(__range), std::move(__result), __pred, __new_value, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_upper_bound.h
+++ b/libcxx/include/__algorithm/ranges_upper_bound.h
@@ -20,6 +20,7 @@
 #include <__ranges/access.h>
 #include <__ranges/concepts.h>
 #include <__ranges/dangling.h>
+#include <__utility/forward.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -38,10 +39,9 @@ struct __upper_bound {
             indirect_strict_weak_order<const _Type*, projected<_Iter, _Proj>> _Comp = ranges::less>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter
   operator()(_Iter __first, _Sent __last, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __comp_lhs_rhs_swapped = [&](const auto& __lhs, const auto& __rhs) -> bool {
-      return !std::invoke(__comp, __rhs, __lhs);
+    auto __comp_lhs_rhs_swapped = [&]<class _Lhs, class _Rhs>(_Lhs&& __lhs, _Rhs&& __rhs) -> bool {
+      return !std::invoke(__comp, std::forward<_Rhs>(__rhs), std::forward<_Lhs>(__lhs));
     };
-
     return std::__lower_bound<_RangeAlgPolicy>(__first, __last, __value, __comp_lhs_rhs_swapped, __proj);
   }
 
@@ -51,10 +51,9 @@ struct __upper_bound {
             indirect_strict_weak_order<const _Type*, projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __r, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __comp_lhs_rhs_swapped = [&](const auto& __lhs, const auto& __rhs) -> bool {
-      return !std::invoke(__comp, __rhs, __lhs);
+    auto __comp_lhs_rhs_swapped = [&]<class _Lhs, class _Rhs>(_Lhs&& __lhs, _Rhs&& __rhs) -> bool {
+      return !std::invoke(__comp, std::forward<_Rhs>(__rhs), std::forward<_Lhs>(__lhs));
     };
-
     return std::__lower_bound<_RangeAlgPolicy>(
         ranges::begin(__r), ranges::end(__r), __value, __comp_lhs_rhs_swapped, __proj);
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges_remove_copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges_remove_copy.pass.cpp
@@ -215,7 +215,6 @@ constexpr bool test() {
   }
 
   // Complexity: Exactly last - first applications of the corresponding predicate and any projection.
-
   {
     std::array in{4, 4, 5, 6};
     std::array expected{5, 6};
@@ -244,6 +243,35 @@ constexpr bool test() {
           in, out.begin(), 4, counting_projection(numberOfProj));
       assert(numberOfProj == static_cast<int>(in.size()));
       assert(std::ranges::equal(out, expected));
+    }
+  }
+
+  { // check that we don't overconstrain the algorithm (see https://github.com/llvm/llvm-project/issues/100726)
+    struct Bad {
+      int value;
+      constexpr operator int() const { return value; } // ensure a common type with Stored
+    };
+
+    struct Stored {
+      int value;
+      constexpr bool operator==(Bad const&) const; // purposefully not defined to make the program fail
+      constexpr bool operator==(Bad const& v) /* non const */ { return value == v.value; }
+      constexpr operator int() const { return value; } // ensure a common type with Bad
+    };
+
+    std::array<Stored, 3> a = {Stored{0}, Stored{1}, Stored{2}};
+    Bad val                 = {1};
+    {
+      std::array<Stored, 2> result;
+      std::ranges::remove_copy(a.begin(), a.end(), result.begin(), val);
+      assert(result[0].value == 0);
+      assert(result[1].value == 2);
+    }
+    {
+      std::array<Stored, 2> result;
+      std::ranges::remove_copy(a, result.begin(), val);
+      assert(result[0].value == 0);
+      assert(result[1].value == 2);
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges.replace.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges.replace.pass.cpp
@@ -178,6 +178,43 @@ constexpr bool test() {
     }
   }
 
+  { // check that we don't overconstrain the algorithm (see https://github.com/llvm/llvm-project/issues/100726)
+    struct Bad {
+      int value;
+      constexpr operator int() const { return value; } // ensure a common type with Stored
+    };
+
+    struct Stored {
+      int value;
+      constexpr Stored& operator=(int v) {
+        value = v;
+        return *this;
+      }
+
+      constexpr bool operator==(Bad const&) const; // purposefully not defined to make the program fail
+      constexpr bool operator==(Bad const& v) /* non const */ { return value == v.value; }
+      constexpr operator int() const { return value; } // ensure a common type with Bad
+    };
+
+    std::array<Stored, 3> a = {Stored{0}, Stored{1}, Stored{2}};
+    Bad old_val             = {1};
+    int new_val             = {99};
+    {
+      auto tmp = a;
+      std::ranges::replace(tmp.begin(), tmp.end(), old_val, new_val);
+      assert(tmp[0].value == 0);
+      assert(tmp[1].value == 99);
+      assert(tmp[2].value == 2);
+    }
+    {
+      auto tmp = a;
+      std::ranges::replace(tmp, old_val, new_val);
+      assert(tmp[0].value == 0);
+      assert(tmp[1].value == 99);
+      assert(tmp[2].value == 2);
+    }
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges_replace_copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.replace/ranges_replace_copy.pass.cpp
@@ -243,6 +243,43 @@ constexpr bool test() {
     }
   }
 
+  { // check that we don't overconstrain the algorithm (see https://github.com/llvm/llvm-project/issues/100726)
+    struct Bad {
+      int value;
+      constexpr operator int() const { return value; } // ensure a common type with Stored
+    };
+
+    struct Stored {
+      int value;
+      constexpr Stored& operator=(int v) {
+        value = v;
+        return *this;
+      }
+
+      constexpr bool operator==(Bad const&) const; // purposefully not defined to make the program fail
+      constexpr bool operator==(Bad const& v) /* non const */ { return value == v.value; }
+      constexpr operator int() const { return value; } // ensure a common type with Bad
+    };
+
+    std::array<Stored, 3> a = {Stored{0}, Stored{1}, Stored{2}};
+    Bad old_val             = {1};
+    int new_val             = {99};
+    {
+      std::array<Stored, 3> result;
+      std::ranges::replace_copy(a.begin(), a.end(), result.begin(), old_val, new_val);
+      assert(result[0].value == 0);
+      assert(result[1].value == 99);
+      assert(result[2].value == 2);
+    }
+    {
+      std::array<Stored, 3> result;
+      std::ranges::replace_copy(a, result.begin(), old_val, new_val);
+      assert(result[0].value == 0);
+      assert(result[1].value == 99);
+      assert(result[2].value == 2);
+    }
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.binary.search/upper.bound/ranges.upper_bound.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.binary.search/upper.bound/ranges.upper_bound.pass.cpp
@@ -277,6 +277,24 @@ constexpr bool test() {
     assert(ret == a + 1);
   }
 
+  { // check that we don't overconstrain the algorithm (see https://github.com/llvm/llvm-project/issues/100726)
+    struct S {
+      int value;
+      constexpr operator int() { return value; } // non-const
+    };
+    std::array<int, 5> a{0, 1, 2, 3, 4};
+    auto cmp  = [](int a, int b) { return a < b; };
+    auto proj = [](int x) { return S{x}; };
+    {
+      auto ret = std::ranges::upper_bound(a.begin(), a.end(), 2, cmp, proj);
+      assert(ret == a.begin() + 3);
+    }
+    {
+      auto ret = std::ranges::upper_bound(a, 2, cmp, proj);
+      assert(ret == a.begin() + 3);
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
We were const-qualifying some helper comparators, which let to some algorithms being overconstrained. This patch fixes the issues I was able to find and adds tests for them. It also adds tests for a few algorithms where this issue didn't exist but could easily have.

Fixes #100726