### PR TITLE
[NVPTX] Promote v2i8 to v2i16 (#111189)

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -229,6 +229,10 @@ static void ComputePTXValueVTs(const TargetLowering &TLI, const DataLayout &DL,
         // v*i8 are formally lowered as v4i8
         EltVT = MVT::v4i8;
         NumElts = (NumElts + 3) / 4;
+      } else if (EltVT.getSimpleVT() == MVT::i8 && NumElts == 2) {
+        // v2i8 is promoted to v2i16
+        NumElts = 1;
+        EltVT = MVT::v2i16;
       }
       for (unsigned j = 0; j != NumElts; ++j) {
         ValueVTs.push_back(EltVT);


### PR DESCRIPTION
Promote v2i8 to v2i16, fixes a crash.
Re-enable a test in NVPTX/vector-returns.ll

Partial cherry-pick of fda2fea3d161e07ec3a8441359f761ce9dd9a977 w/o the test which does not exist in release/19.x 
https://github.com/llvm/llvm-project/issues/104864