### PR TITLE
[Win/X86] Make _m_prefetch[w] builtins to avoid winnt.h conflicts

### DIFF
--- a/clang/include/clang/Basic/BuiltinsX86.td
+++ b/clang/include/clang/Basic/BuiltinsX86.td
@@ -146,8 +146,13 @@ let Attributes = [Const, NoThrow, RequiredVectorWidth<256>], Features = "avx" in
 // current formulation is based on what was easiest to recognize from the
 // pre-TableGen version.
 
-let Features = "mmx", Attributes = [NoThrow, Const] in {
+let Features = "mmx", Header = "immintrin.h", Attributes = [NoThrow, Const] in {
   def _mm_prefetch : X86NoPrefixBuiltin<"void(char const *, int)">;
+}
+
+let Features = "mmx", Header = "intrin.h", Attributes = [NoThrow, Const] in {
+  def _m_prefetch : X86NoPrefixBuiltin<"void(void *)">;
+  def _m_prefetchw : X86NoPrefixBuiltin<"void(const void *)">;
 }
 
 let Features = "sse", Attributes = [NoThrow] in {

--- a/clang/include/clang/Basic/BuiltinsX86.td
+++ b/clang/include/clang/Basic/BuiltinsX86.td
@@ -147,12 +147,12 @@ let Attributes = [Const, NoThrow, RequiredVectorWidth<256>], Features = "avx" in
 // pre-TableGen version.
 
 let Features = "mmx", Header = "immintrin.h", Attributes = [NoThrow, Const] in {
-  def _mm_prefetch : X86NoPrefixBuiltin<"void(char const *, int)">;
+  def _mm_prefetch : X86LibBuiltin<"void(char const *, int)">;
 }
 
 let Features = "mmx", Header = "intrin.h", Attributes = [NoThrow, Const] in {
-  def _m_prefetch : X86NoPrefixBuiltin<"void(void *)">;
-  def _m_prefetchw : X86NoPrefixBuiltin<"void(const void *)">;
+  def _m_prefetch : X86LibBuiltin<"void(void *)">;
+  def _m_prefetchw : X86LibBuiltin<"void(void volatile const *)">;
 }
 
 let Features = "sse", Attributes = [NoThrow] in {

--- a/clang/include/clang/Basic/BuiltinsX86.td
+++ b/clang/include/clang/Basic/BuiltinsX86.td
@@ -130,12 +130,22 @@ let Attributes = [Const, NoThrow, RequiredVectorWidth<128>] in {
   }
 }
 
+let Features = "sse", Header = "xmmintrin.h", Attributes = [NoThrow, Const] in {
+  def _mm_prefetch : X86LibBuiltin<"void(void const *, int)">;
+}
+
 // AVX
 let Attributes = [Const, NoThrow, RequiredVectorWidth<256>], Features = "avx" in {
   foreach Op = ["addsub", "hadd", "hsub", "max", "min"] in {
     def Op#pd256 : X86Builtin<"_Vector<4, double>(_Vector<4, double>, _Vector<4, double>)">;
     def Op#ps256 : X86Builtin<"_Vector<8, float>(_Vector<8, float>, _Vector<8, float>)">;
   }
+}
+
+// PRFCHW
+let Features = "prfchw", Header = "x86intrin.h", Attributes = [NoThrow, Const] in {
+  def _m_prefetch : X86LibBuiltin<"void(void *)">;
+  def _m_prefetchw : X86LibBuiltin<"void(void volatile const *)">;
 }
 
 
@@ -145,15 +155,6 @@ let Attributes = [Const, NoThrow, RequiredVectorWidth<256>], Features = "avx" in
 // organization of the builtins below this point (and move them above it). The
 // current formulation is based on what was easiest to recognize from the
 // pre-TableGen version.
-
-let Features = "mmx", Header = "immintrin.h", Attributes = [NoThrow, Const] in {
-  def _mm_prefetch : X86LibBuiltin<"void(void const *, int)">;
-}
-
-let Features = "mmx", Header = "intrin.h", Attributes = [NoThrow, Const] in {
-  def _m_prefetch : X86LibBuiltin<"void(void *)">;
-  def _m_prefetchw : X86LibBuiltin<"void(void volatile const *)">;
-}
 
 let Features = "sse", Attributes = [NoThrow] in {
   def ldmxcsr : X86Builtin<"void(unsigned int)">;

--- a/clang/include/clang/Basic/BuiltinsX86.td
+++ b/clang/include/clang/Basic/BuiltinsX86.td
@@ -147,7 +147,7 @@ let Attributes = [Const, NoThrow, RequiredVectorWidth<256>], Features = "avx" in
 // pre-TableGen version.
 
 let Features = "mmx", Header = "immintrin.h", Attributes = [NoThrow, Const] in {
-  def _mm_prefetch : X86LibBuiltin<"void(char const *, int)">;
+  def _mm_prefetch : X86LibBuiltin<"void(void const *, int)">;
 }
 
 let Features = "mmx", Header = "intrin.h", Attributes = [NoThrow, Const] in {

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -15254,6 +15254,16 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     Function *F = CGM.getIntrinsic(Intrinsic::prefetch, Address->getType());
     return Builder.CreateCall(F, {Address, RW, Locality, Data});
   }
+  case X86::BI_m_prefetch:
+  case X86::BI_m_prefetchw: {
+    Value *Address = Ops[0];
+    // The 'w' suffix implies write.
+    Value *RW = ConstantInt::get(Int32Ty, BuiltinID == X86::BI_m_prefetchw ? 1 : 0);
+    Value *Locality = ConstantInt::get(Int32Ty, 0x3);
+    Value *Data = ConstantInt::get(Int32Ty, 1);
+    Function *F = CGM.getIntrinsic(Intrinsic::prefetch, Address->getType());
+    return Builder.CreateCall(F, {Address, RW, Locality, Data});
+  }
   case X86::BI_mm_clflush: {
     return Builder.CreateCall(CGM.getIntrinsic(Intrinsic::x86_sse2_clflush),
                               Ops[0]);

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -15258,7 +15258,8 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
   case X86::BI_m_prefetchw: {
     Value *Address = Ops[0];
     // The 'w' suffix implies write.
-    Value *RW = ConstantInt::get(Int32Ty, BuiltinID == X86::BI_m_prefetchw ? 1 : 0);
+    Value *RW =
+        ConstantInt::get(Int32Ty, BuiltinID == X86::BI_m_prefetchw ? 1 : 0);
     Value *Locality = ConstantInt::get(Int32Ty, 0x3);
     Value *Data = ConstantInt::get(Int32Ty, 1);
     Function *F = CGM.getIntrinsic(Intrinsic::prefetch, Address->getType());

--- a/clang/lib/Headers/prfchwintrin.h
+++ b/clang/lib/Headers/prfchwintrin.h
@@ -14,6 +14,10 @@
 #ifndef __PRFCHWINTRIN_H
 #define __PRFCHWINTRIN_H
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /// Loads a memory sequence containing the specified memory address into
 ///    all data cache levels.
 ///
@@ -26,11 +30,7 @@
 ///
 /// \param __P
 ///    A pointer specifying the memory address to be prefetched.
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_m_prefetch(void *__P)
-{
-  __builtin_prefetch (__P, 0, 3 /* _MM_HINT_T0 */);
-}
+void _m_prefetch(void *__P);
 
 /// Loads a memory sequence containing the specified memory address into
 ///    the L1 data cache and sets the cache-coherency state to modified.
@@ -48,13 +48,10 @@ _m_prefetch(void *__P)
 ///
 /// \param __P
 ///    A pointer specifying the memory address to be prefetched.
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_m_prefetchw(volatile const void *__P)
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
-  __builtin_prefetch ((const void*)__P, 1, 3 /* _MM_HINT_T0 */);
-#pragma clang diagnostic pop
-}
+void _m_prefetchw(volatile const void *__P);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
 
 #endif /* __PRFCHWINTRIN_H */

--- a/clang/lib/Headers/xmmintrin.h
+++ b/clang/lib/Headers/xmmintrin.h
@@ -2197,10 +2197,6 @@ _mm_storer_ps(float *__p, __m128 __a)
 #define _MM_HINT_T2  1
 #define _MM_HINT_NTA 0
 
-#ifndef _MSC_VER
-/* FIXME: We have to #define this because "sel" must be a constant integer, and
-   Sema doesn't do any form of constant propagation yet. */
-
 /// Loads one cache line of data from the specified address to a location
 ///    closer to the processor.
 ///
@@ -2225,9 +2221,10 @@ _mm_storer_ps(float *__p, __m128 __a)
 ///    be generated. \n
 ///    _MM_HINT_T2: Move data using the T2 hint. The PREFETCHT2 instruction will
 ///    be generated.
-#define _mm_prefetch(a, sel) (__builtin_prefetch((const void *)(a), \
-                                                 ((sel) >> 2) & 1, (sel) & 0x3))
-#endif
+///
+/// _mm_prefetch is implemented as a "library builtin" directly in Clang,
+/// similar to how it is done in MSVC. Clang will warn if the user doesn't
+/// include xmmintrin.h or immintrin.h.
 
 /// Stores a 64-bit integer in the specified aligned memory location. To
 ///    minimize caching, the data is flagged as non-temporal (unlikely to be

--- a/clang/lib/Headers/xmmintrin.h
+++ b/clang/lib/Headers/xmmintrin.h
@@ -2197,6 +2197,7 @@ _mm_storer_ps(float *__p, __m128 __a)
 #define _MM_HINT_T2  1
 #define _MM_HINT_NTA 0
 
+#if 0
 /// Loads one cache line of data from the specified address to a location
 ///    closer to the processor.
 ///
@@ -2225,6 +2226,9 @@ _mm_storer_ps(float *__p, __m128 __a)
 /// _mm_prefetch is implemented as a "library builtin" directly in Clang,
 /// similar to how it is done in MSVC. Clang will warn if the user doesn't
 /// include xmmintrin.h or immintrin.h.
+#define _mm_prefetch(a, sel) (__builtin_prefetch((const void *)(a), \
+                                                 ((sel) >> 2) & 1, (sel) & 0x3))
+#endif
 
 /// Stores a 64-bit integer in the specified aligned memory location. To
 ///    minimize caching, the data is flagged as non-temporal (unlikely to be


### PR DESCRIPTION
This is similar in spirit to previous changes to make _mm_mfence builtins to avoid conflicts with winnt.h and other MSVC ecosystem headers that pre-declare compiler intrinsics as extern "C" symbols.

This should fix issue #87515.