### PR TITLE
[LegalizeVectorTypes] Allow non-undef vectors when widening insert_subvector op

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -7066,7 +7066,7 @@ SDValue DAGTypeLegalizer::WidenVecOp_INSERT_SUBVECTOR(SDNode *N) {
 
   // We need to make sure that the indices are still valid, otherwise we might
   // widen what was previously well-defined to something undefined.
-  if (IndicesValid && InVec.isUndef() && N->getConstantOperandVal(2) == 0)
+  if (IndicesValid && N->getConstantOperandVal(2) == 0)
     return DAG.getNode(ISD::INSERT_SUBVECTOR, SDLoc(N), VT, InVec, SubVec,
                        N->getOperand(2));
 

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-insert-subvector.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-insert-subvector.ll
@@ -1000,3 +1000,12 @@ define <4 x i32> @insert_extract_v8i32_v2i32_0(<2 x i32> %v) {
   %2 = call <4 x i32> @llvm.vector.extract.v4i32.v8i32(<8 x i32> %1, i64 0)
   ret <4 x i32> %2
 }
+
+define <vscale x 24 x i8> @insert_nxv24i8_v48i8_0(<vscale x 24 x i8> %v, <48 x i8> %w) vscale_range(2) {
+; CHECK-LABEL: insert_nxv24i8_v48i8_0:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+  %x = call <vscale x 24 x i8> @llvm.vector.insert.v48i8.nxv24i8(<vscale x 24 x i8> %v, <48 x i8> %w, i64 0)
+  ret <vscale x 24 x i8> %x
+}


### PR DESCRIPTION
When widening an insert_subvector operand there's currently a restriction that the vector being inserted into has to be undef.

It looks like this is just a conservative restriction from when it was first added: https://reviews.llvm.org/D102501

Nothing comes to mind as to why we can't allow non-undef vectors.

Fixes #114900
