### PR TITLE
[CodeGen][MISched] Set DumpDirection after initPolicy

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -1297,7 +1297,6 @@ protected:
   ScheduleDAGMI *DAG = nullptr;
   SchedBoundary Top;
   SchedBoundary Bot;
-  MachineSchedPolicy RegionPolicy;
 
   /// Candidate last picked from Top boundary.
   SchedCandidate TopCand;

--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -219,6 +219,7 @@ public:
                           MachineBasicBlock::iterator End,
                           unsigned NumRegionInstrs) {}
 
+  virtual MachineSchedPolicy getPolicy() const { return {}; }
   virtual void dumpPolicy() const {}
 
   /// Check if pressure tracking is needed before building the DAG and
@@ -1167,12 +1168,16 @@ protected:
   const TargetSchedModel *SchedModel = nullptr;
   const TargetRegisterInfo *TRI = nullptr;
 
+  MachineSchedPolicy RegionPolicy;
+
   SchedRemainder Rem;
 
   GenericSchedulerBase(const MachineSchedContext *C) : Context(C) {}
 
   void setPolicy(CandPolicy &Policy, bool IsPostRA, SchedBoundary &CurrZone,
                  SchedBoundary *OtherZone);
+
+  MachineSchedPolicy getPolicy() const override { return RegionPolicy; }
 
 #ifndef NDEBUG
   void traceCandidate(const SchedCandidate &Cand);
@@ -1253,8 +1258,6 @@ public:
 
 protected:
   ScheduleDAGMILive *DAG = nullptr;
-
-  MachineSchedPolicy RegionPolicy;
 
   // State of the top and bottom scheduled instruction boundaries.
   SchedBoundary Top;


### PR DESCRIPTION
Previously we set the dump direction according to command line
options, but we may override the scheduling direction in `initPolicy`
and this results in mismatch between dump and actual policy.

Here we simply set the dump direction after initializing the policy.
