### PR TITLE
[clang-include-fixer] Use heterogenous lookups with std::map (NFC)

### DIFF
--- a/clang-tools-extra/clang-include-fixer/InMemorySymbolIndex.cpp
+++ b/clang-tools-extra/clang-include-fixer/InMemorySymbolIndex.cpp
@@ -21,7 +21,7 @@ InMemorySymbolIndex::InMemorySymbolIndex(
 
 std::vector<SymbolAndSignals>
 InMemorySymbolIndex::search(llvm::StringRef Identifier) {
-  auto I = LookupTable.find(std::string(Identifier));
+  auto I = LookupTable.find(Identifier);
   if (I != LookupTable.end())
     return I->second;
   return {};

--- a/clang-tools-extra/clang-include-fixer/InMemorySymbolIndex.h
+++ b/clang-tools-extra/clang-include-fixer/InMemorySymbolIndex.h
@@ -27,7 +27,8 @@ public:
   search(llvm::StringRef Identifier) override;
 
 private:
-  std::map<std::string, std::vector<find_all_symbols::SymbolAndSignals>>
+  std::map<std::string, std::vector<find_all_symbols::SymbolAndSignals>,
+           std::less<>>
       LookupTable;
 };
 


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.
