### PR TITLE
[mlir] Add a null pointer check in symbol lookup

### DIFF
--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -186,6 +186,8 @@ void DeadCodeAnalysis::initializeSymbolCallables(Operation *top) {
       // If a callable symbol has a non-call use, then we can't be guaranteed to
       // know all callsites.
       Operation *symbol = symbolTable.lookupSymbolIn(top, use.getSymbolRef());
+      if (!symbol)
+        continue;
       auto *state = getOrCreate<PredecessorState>(getProgramPointAfter(symbol));
       propagateIfChanged(state, state->setHasUnknownPredecessors());
     }

--- a/mlir/test/Analysis/DataFlow/test-dead-code-analysis.mlir
+++ b/mlir/test/Analysis/DataFlow/test-dead-code-analysis.mlir
@@ -265,3 +265,7 @@ func.func @test_dca_doesnt_crash() -> () {
   }  
   return
 }
+
+func.func @test_dca_doesnt_crash_2() -> () attributes {symbol = @notexistant} {
+   return
+}


### PR DESCRIPTION
We (TensorFlow project) ran into a case where a dead code analysis crashed because a symbol that is called/used didn't appear in the symbol table. Added a nullptr check after symbol table lookup.