### PR TITLE
[PS5][Driver] Restore whole-archive state when `-fjmc`

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -375,9 +375,10 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   if (UseJMC) {
+    CmdArgs.push_back("--push-state");
     CmdArgs.push_back("--whole-archive");
     CmdArgs.push_back("-lSceJmc_nosubmission");
-    CmdArgs.push_back("--no-whole-archive");
+    CmdArgs.push_back("--pop-state");
   }
 
   if (Args.hasArg(options::OPT_fuse_ld_EQ)) {

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -89,13 +89,13 @@
 
 // Test the driver's control over the JustMyCode behavior with linker flags.
 
-// RUN: %clang --target=x86_64-sie-ps5 -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-LIB %s
-// RUN: %clang --target=x86_64-sie-ps5 -flto -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-LIB %s
+// RUN: %clang --target=x86_64-sie-ps5 -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-JMC %s
+// RUN: %clang --target=x86_64-sie-ps5 -flto -fjmc %s -### 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-JMC %s
 
 // CHECK: -plugin-opt=-enable-jmc-instrument
 
 // Check the default library name.
-// CHECK-LIB: "--push-state" "--whole-archive" "-lSceJmc_nosubmission" "--pop-state"
+// CHECK-JMC: "--push-state" "--whole-archive" "-lSceJmc_nosubmission" "--pop-state"
 
 // Test the driver's control over the -fcrash-diagnostics-dir behavior with linker flags.
 

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -95,7 +95,7 @@
 // CHECK: -plugin-opt=-enable-jmc-instrument
 
 // Check the default library name.
-// CHECK-LIB: "--whole-archive" "-lSceJmc_nosubmission" "--no-whole-archive"
+// CHECK-LIB: "--push-state" "--whole-archive" "-lSceJmc_nosubmission" "--pop-state"
 
 // Test the driver's control over the -fcrash-diagnostics-dir behavior with linker flags.
 


### PR DESCRIPTION
`--whole-archive` is passed to the linker to have it consume all objects within the SIE Just My Code library, rather than just those that fulfil outstanding references.

Prior to this change, `--no-whole-archive` was used to reset the associated archive handling state in the linker, under the assumption that `--whole-archive` wasn't already in effect. But that assumption may be incorrect. So use `--push/pop-state` to restore the previous state, whatever that may be.

Given the position of these switches on the link line, the problem described with the outgoing code is unlikely to cause an issue in practice. But push/pop protect against accidents due to future additions to and reorderings of arguments.

PS5 only. The proprietary PS4 linker doesn't support `--push/pop-state`, or an equivalent.

SIE tracker: TOOLCHAIN-16704.