### PR TITLE
[flang][cuda] Do not emit warning for SHARED variable in device subprogram

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -928,7 +928,9 @@ void CheckHelper::CheckObjectEntity(
         details.cudaDataAttr().value_or(common::CUDADataAttr::Device) !=
             common::CUDADataAttr::Device &&
         details.cudaDataAttr().value_or(common::CUDADataAttr::Device) !=
-            common::CUDADataAttr::Managed) {
+            common::CUDADataAttr::Managed &&
+        details.cudaDataAttr().value_or(common::CUDADataAttr::Device) !=
+            common::CUDADataAttr::Shared) {
       Warn(common::UsageWarning::CUDAUsage,
           "Dummy argument '%s' may not have ATTRIBUTES(%s) in a device subprogram"_warn_en_US,
           symbol.name(),

--- a/flang/test/Semantics/cuf03.cuf
+++ b/flang/test/Semantics/cuf03.cuf
@@ -55,13 +55,14 @@ module m
   real, unified :: um
 
  contains
-  attributes(device) subroutine devsubr(n,da)
+  attributes(device) subroutine devsubr(n,da,rs)
     integer, intent(in) :: n
     real, device :: da(*) ! ok
     real, managed :: ma(n) ! ok
     !WARNING: Pointer 'dp' may not be associated in a device subprogram
     real, device, pointer :: dp
     real, constant :: rc ! ok
+    real, shared :: rs ! ok
     !ERROR: Object 'u' with ATTRIBUTES(UNIFIED) must be declared in a host subprogram
     real, unified :: u
   end subroutine


### PR DESCRIPTION
SHARED attribute is explicitly meant to be used in device subprogram (https://docs.nvidia.com/hpc-sdk/compilers/cuda-fortran-prog-guide/index.html#cfpg-var-qual-attr-shared).

Do not emit warning. 