### PR TITLE
[clang] Avoid unnecessary call to clang::NamespaceDecl::isRedundantInlineQualifierFor().

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1738,13 +1738,12 @@ void NamedDecl::printNestedNameSpecifier(raw_ostream &OS,
 
     // Suppress inline namespace if it doesn't make the result ambiguous.
     if (Ctx->isInlineNamespace() && NameInScope) {
-      bool isRedundant =
-          cast<NamespaceDecl>(Ctx)->isRedundantInlineQualifierFor(NameInScope);
       if (P.SuppressInlineNamespace ==
               PrintingPolicy::SuppressInlineNamespaceMode::All ||
           (P.SuppressInlineNamespace ==
                PrintingPolicy::SuppressInlineNamespaceMode::Redundant &&
-           isRedundant)) {
+           cast<NamespaceDecl>(Ctx)->isRedundantInlineQualifierFor(
+               NameInScope))) {
         continue;
       }
     }


### PR DESCRIPTION
We observed 2X slowdown in lldb's expression evaluation with https://github.com/llvm/llvm-project/pull/109147 in some cases. It turns out that calling `isRedundantInlineQualifierFor` is quite expensive. Using short-circuit evaluation in the if statement to avoid unnecessary calls to that function.