### PR TITLE
[HLSL] Update tests to use splat for vector constants

### DIFF
--- a/llvm/test/CodeGen/DirectX/atan2.ll
+++ b/llvm/test/CodeGen/DirectX/atan2.ll
@@ -56,8 +56,8 @@ entry:
 ; Just Expansion, no scalarization or lowering:
 ; EXPCHECK: [[DIV:%.+]] = fdiv <4 x float> %y, %x
 ; EXPCHECK: [[ATAN:%.+]] = call <4 x float> @llvm.atan.v4f32(<4 x float> [[DIV]])
-; EXPCHECK-DAG: [[ADD_PI:%.+]] = fadd <4 x float> [[ATAN]], <float 0x400921FB60000000, float 0x400921FB60000000, float 0x400921FB60000000, float 0x400921FB60000000>
-; EXPCHECK-DAG: [[SUB_PI:%.+]] = fsub <4 x float> [[ATAN]], <float 0x400921FB60000000, float 0x400921FB60000000, float 0x400921FB60000000, float 0x400921FB60000000>
+; EXPCHECK-DAG: [[ADD_PI:%.+]] = fadd <4 x float> [[ATAN]], splat (float 0x400921FB60000000)
+; EXPCHECK-DAG: [[SUB_PI:%.+]] = fsub <4 x float> [[ATAN]], splat (float 0x400921FB60000000)
 ; EXPCHECK-DAG: [[X_LT_0:%.+]] = fcmp olt <4 x float> %x, zeroinitializer
 ; EXPCHECK-DAG: [[X_EQ_0:%.+]] = fcmp oeq <4 x float> %x, zeroinitializer
 ; EXPCHECK-DAG: [[Y_GE_0:%.+]] = fcmp oge <4 x float> %y, zeroinitializer
@@ -67,9 +67,9 @@ entry:
 ; EXPCHECK: [[XLT0_AND_YLT0:%.+]] = and <4 x i1> [[X_LT_0]], [[Y_LT_0]]
 ; EXPCHECK: [[SELECT_SUB_PI:%.+]] = select <4 x i1> [[XLT0_AND_YLT0]], <4 x float> [[SUB_PI]], <4 x float> [[SELECT_ADD_PI]]
 ; EXPCHECK: [[XEQ0_AND_YLT0:%.+]] = and <4 x i1> [[X_EQ_0]], [[Y_LT_0]]
-; EXPCHECK: [[SELECT_NEGHPI:%.+]] = select <4 x i1> [[XEQ0_AND_YLT0]], <4 x float> <float 0xBFF921FB60000000, float 0xBFF921FB60000000, float 0xBFF921FB60000000, float 0xBFF921FB60000000>, <4 x float> [[SELECT_SUB_PI]]
+; EXPCHECK: [[SELECT_NEGHPI:%.+]] = select <4 x i1> [[XEQ0_AND_YLT0]], <4 x float> splat (float 0xBFF921FB60000000), <4 x float> [[SELECT_SUB_PI]]
 ; EXPCHECK: [[XEQ0_AND_YGE0:%.+]] = and <4 x i1> [[X_EQ_0]], [[Y_GE_0]]
-; EXPCHECK: [[SELECT_HPI:%.+]] = select <4 x i1> [[XEQ0_AND_YGE0]], <4 x float> <float 0x3FF921FB60000000, float 0x3FF921FB60000000, float 0x3FF921FB60000000, float 0x3FF921FB60000000>, <4 x float> [[SELECT_NEGHPI]]
+; EXPCHECK: [[SELECT_HPI:%.+]] = select <4 x i1> [[XEQ0_AND_YGE0]], <4 x float> splat (float 0x3FF921FB60000000), <4 x float> [[SELECT_NEGHPI]]
 ; EXPCHECK: ret <4 x float> [[SELECT_HPI]]
 
 ; Scalarization occurs after expansion, so atan scalarization is tested separately.

--- a/llvm/test/CodeGen/DirectX/exp-vec.ll
+++ b/llvm/test/CodeGen/DirectX/exp-vec.ll
@@ -3,7 +3,7 @@
 ; Make sure dxil operation function calls for exp are generated for float and half.
 
 ; CHECK-LABEL: exp_float4
-; CHECK: fmul <4 x float> <float 0x3FF7154760000000, float 0x3FF7154760000000, float 0x3FF7154760000000, float 0x3FF7154760000000>,  %{{.*}}
+; CHECK: fmul <4 x float> splat (float 0x3FF7154760000000),  %{{.*}}
 ; CHECK: call <4 x float> @llvm.exp2.v4f32(<4 x float>  %{{.*}})
 define noundef <4 x float> @exp_float4(<4 x float> noundef %p0) {
 entry:

--- a/llvm/test/CodeGen/DirectX/log-vec.ll
+++ b/llvm/test/CodeGen/DirectX/log-vec.ll
@@ -4,7 +4,7 @@
 
 ; CHECK-LABEL: log_float4
 ; CHECK: call <4 x float> @llvm.log2.v4f32(<4 x float>  %{{.*}})
-; CHECK: fmul <4 x float> <float 0x3FE62E4300000000, float 0x3FE62E4300000000, float 0x3FE62E4300000000, float 0x3FE62E4300000000>,  %{{.*}}
+; CHECK: fmul <4 x float> splat (float 0x3FE62E4300000000),  %{{.*}}
 define noundef <4 x float> @log_float4(<4 x float> noundef %p0) {
 entry:
   %p0.addr = alloca <4 x float>, align 16
@@ -16,7 +16,7 @@ entry:
 
 ; CHECK-LABEL: log10_float4
 ; CHECK: call <4 x float> @llvm.log2.v4f32(<4 x float>  %{{.*}})
-; CHECK: fmul <4 x float> <float 0x3FD3441340000000, float 0x3FD3441340000000, float 0x3FD3441340000000, float 0x3FD3441340000000>,  %{{.*}}
+; CHECK: fmul <4 x float> splat (float 0x3FD3441340000000),  %{{.*}}
 define noundef <4 x float> @log10_float4(<4 x float> noundef %p0) {
 entry:
   %p0.addr = alloca <4 x float>, align 16

--- a/llvm/test/CodeGen/DirectX/step.ll
+++ b/llvm/test/CodeGen/DirectX/step.ll
@@ -24,7 +24,7 @@ entry:
 define noundef <2 x half> @test_step_half2(<2 x half> noundef %p0, <2 x half> noundef %p1) {
 entry:
   ; CHECK: %0 = fcmp olt <2 x half> %p1, %p0
-  ; CHECK: %1 = select <2 x i1> %0, <2 x half> zeroinitializer, <2 x half> <half 0xH3C00, half 0xH3C00>
+  ; CHECK: %1 = select <2 x i1> %0, <2 x half> zeroinitializer, <2 x half> splat (half 0xH3C00)
   %hlsl.step = call <2 x half> @llvm.dx.step.v2f16(<2 x half> %p0, <2 x half> %p1)
   ret <2 x half> %hlsl.step
 }
@@ -32,7 +32,7 @@ entry:
 define noundef <3 x half> @test_step_half3(<3 x half> noundef %p0, <3 x half> noundef %p1) {
 entry:
   ; CHECK: %0 = fcmp olt <3 x half> %p1, %p0
-  ; CHECK: %1 = select <3 x i1> %0, <3 x half> zeroinitializer, <3 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00>
+  ; CHECK: %1 = select <3 x i1> %0, <3 x half> zeroinitializer, <3 x half> splat (half 0xH3C00)
   %hlsl.step = call <3 x half> @llvm.dx.step.v3f16(<3 x half> %p0, <3 x half> %p1)
   ret <3 x half> %hlsl.step
 }
@@ -40,7 +40,7 @@ entry:
 define noundef <4 x half> @test_step_half4(<4 x half> noundef %p0, <4 x half> noundef %p1) {
 entry:
   ; CHECK: %0 = fcmp olt <4 x half> %p1, %p0
-  ; CHECK: %1 = select <4 x i1> %0, <4 x half> zeroinitializer, <4 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>
+  ; CHECK: %1 = select <4 x i1> %0, <4 x half> zeroinitializer, <4 x half> splat (half 0xH3C00)
   %hlsl.step = call <4 x half> @llvm.dx.step.v4f16(<4 x half> %p0, <4 x half> %p1)
   ret <4 x half> %hlsl.step
 }
@@ -56,7 +56,7 @@ entry:
 define noundef <2 x float> @test_step_float2(<2 x float> noundef %p0, <2 x float> noundef %p1) {
 entry:
   ; CHECK: %0 = fcmp olt <2 x float> %p1, %p0
-  ; CHECK: %1 = select <2 x i1> %0, <2 x float> zeroinitializer, <2 x float> <float 1.000000e+00, float 1.000000e+00>
+  ; CHECK: %1 = select <2 x i1> %0, <2 x float> zeroinitializer, <2 x float> splat (float 1.000000e+00)
   %hlsl.step = call <2 x float> @llvm.dx.step.v2f32(<2 x float> %p0, <2 x float> %p1)
   ret <2 x float> %hlsl.step
 }
@@ -64,7 +64,7 @@ entry:
 define noundef <3 x float> @test_step_float3(<3 x float> noundef %p0, <3 x float> noundef %p1) {
 entry:
   ; CHECK: %0 = fcmp olt <3 x float> %p1, %p0
-  ; CHECK: %1 = select <3 x i1> %0, <3 x float> zeroinitializer, <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  ; CHECK: %1 = select <3 x i1> %0, <3 x float> zeroinitializer, <3 x float> splat (float 1.000000e+00)
   %hlsl.step = call <3 x float> @llvm.dx.step.v3f32(<3 x float> %p0, <3 x float> %p1)
   ret <3 x float> %hlsl.step
 }
@@ -72,7 +72,7 @@ entry:
 define noundef <4 x float> @test_step_float4(<4 x float> noundef %p0, <4 x float> noundef %p1) {
 entry:
   ; CHECK: %0 = fcmp olt <4 x float> %p1, %p0
-  ; CHECK: %1 = select <4 x i1> %0, <4 x float> zeroinitializer, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  ; CHECK: %1 = select <4 x i1> %0, <4 x float> zeroinitializer, <4 x float> splat (float 1.000000e+00)
   %hlsl.step = call <4 x float> @llvm.dx.step.v4f32(<4 x float> %p0, <4 x float> %p1)
   ret <4 x float> %hlsl.step
 }


### PR DESCRIPTION
Fixes test failures after splat IR printer change: 38fffa630ee8.