### PR TITLE
Make functions always renamable

### DIFF
--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -175,6 +175,9 @@ static CalleeInfo::HotnessType getHotness(uint64_t ProfileCount,
 }
 
 static bool isNonRenamableLocal(const GlobalValue &GV) {
+  if (isa<Function>(&GV)) {
+    return false;
+  }
   return GV.hasSection() && GV.hasLocalLinkage();
 }
 

--- a/llvm/test/Bitcode/thinlto-summary-section.ll
+++ b/llvm/test/Bitcode/thinlto-summary-section.ll
@@ -4,10 +4,10 @@
 ; RUN: llvm-lto -thinlto -o %t2 %t.o
 ; RUN: llvm-bcanalyzer -dump %t2.thinlto.bc | FileCheck %s --check-prefix=COMBINED
 
-; Flags should be 0x57 (87) for local linkage (0x3), dso_local (0x40) and not being importable
+; Flags should be 0x47 (71) for local linkage (0x3), dso_local (0x40) and being importable
 ; (0x10) due to local linkage plus having a section.
-; CHECK: <PERMODULE_PROFILE {{.*}} op1=87
-; COMBINED-DAG: <COMBINED_PROFILE {{.*}} op2=87
+; CHECK: <PERMODULE_PROFILE {{.*}} op1=71
+; COMBINED-DAG: <COMBINED_PROFILE {{.*}} op2=71
 define internal void @functionWithSection() section "some_section" {
     ret void
 }


### PR DESCRIPTION
Functions with non-default sections are currently non renamable. This blocks ThinLTO to optimize code between modules.

It is unclear why functions with non-default sections should not be renamable. This patch makes them always renamable.

Perhaps, we need to block functions with non-default sections to be non renamable for some object formats (please see the RFC [Allow ThinLTO to Rename Local Functions with Sections](https://discourse.llvm.org/t/rfc-allow-thinlto-to-rename-local-functions-with-sections/82981) for a longer description on this topic).
If that is the case, then we should perhaps make this list of object formats that require special treatment explicit.