### PR TITLE
[GlobalISel][AArch64] Allow vector ptr to int unmerges

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1487,7 +1487,9 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     LLT SrcTy = MRI->getType(MI->getOperand(NumDsts).getReg());
     if (DstTy.isVector()) {
       // This case is the converse of G_CONCAT_VECTORS.
-      if (!SrcTy.isVector() || SrcTy.getScalarType() != DstTy.getScalarType() ||
+      if (!SrcTy.isVector() ||
+          (SrcTy.getScalarType() != DstTy.getScalarType() &&
+           !SrcTy.isPointerVector()) ||
           SrcTy.isScalableVector() != DstTy.isScalableVector() ||
           SrcTy.getSizeInBits() != NumDsts * DstTy.getSizeInBits())
         report("G_UNMERGE_VALUES source operand does not match vector "

--- a/llvm/test/CodeGen/AArch64/GlobalISel/translate-gep.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/translate-gep.ll
@@ -145,3 +145,24 @@ entry:
   %0 = getelementptr inbounds [8 x i32], ptr @arr, i64 0, <2 x i64> %offs
   ret <2 x ptr> %0
 }
+
+define <4 x ptr> @vector_gep_v4i32(<4 x ptr> %b, <4 x i32> %off) {
+  ; CHECK-LABEL: name: vector_gep_v4i32
+  ; CHECK: bb.1.entry:
+  ; CHECK-NEXT:   liveins: $q0, $q1, $q2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
+  ; CHECK-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x p0>) = G_CONCAT_VECTORS [[COPY]](<2 x s64>), [[COPY1]](<2 x s64>)
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(<4 x s32>) = COPY $q2
+  ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(<4 x s64>) = G_SEXT [[COPY2]](<4 x s32>)
+  ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(<4 x p0>) = G_PTR_ADD [[CONCAT_VECTORS]], [[SEXT]](<4 x s64>)
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(<4 x p0>) = COPY [[PTR_ADD]](<4 x p0>)
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(<2 x s64>), [[UV1:%[0-9]+]]:_(<2 x s64>) = G_UNMERGE_VALUES [[COPY3]](<4 x p0>)
+  ; CHECK-NEXT:   $q0 = COPY [[UV]](<2 x s64>)
+  ; CHECK-NEXT:   $q1 = COPY [[UV1]](<2 x s64>)
+  ; CHECK-NEXT:   RET_ReallyLR implicit $q0, implicit $q1
+entry:
+  %g = getelementptr i8, <4 x ptr> %b, <4 x i32> %off
+  ret <4 x ptr> %g
+}


### PR DESCRIPTION
Vector pointer -> scalar integer unmerges are already legal. This loosens the verifier check for vector-of-pointers -> vectors.