### PR TITLE
[AMDGPU] Make `__GCC_DESTRUCTIVE_SIZE` 128 on AMDGPU

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -464,6 +464,10 @@ public:
   bool hasHIPImageSupport() const override { return HasImage; }
 
   std::pair<unsigned, unsigned> hardwareInterferenceSizes() const override {
+    // This is imprecise as the value can vary between 64, 128 (even 256!) bytes
+    // depending on the level of cache and the target architecture. We select
+    // the size that corresponds to the largest L1 cache line for all
+    // architectures.
     return std::make_pair(128, 128);
   }
 };

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -462,6 +462,10 @@ public:
   }
 
   bool hasHIPImageSupport() const override { return HasImage; }
+
+  std::pair<unsigned, unsigned> hardwareInterferenceSizes() const override {
+    return std::make_pair(128, 128);
+  }
 };
 
 } // namespace targets

--- a/clang/test/Driver/amdgpu-macros.cl
+++ b/clang/test/Driver/amdgpu-macros.cl
@@ -153,6 +153,8 @@
 // ARCH-GCN-DAG: #define __[[FAMILY]]__ 1
 // ARCH-GCN-DAG: #define __amdgcn_processor__ "[[CPU]]"
 // ARCH-GCN-DAG: #define __AMDGCN_WAVEFRONT_SIZE [[WAVEFRONT_SIZE]]
+// ARCH-GCN-DAG: #define __GCC_DESTRUCTIVE_SIZE 128
+// ARCH-GCN-DAG: #define __GCC_CONSTRUCTIVE_SIZE 128
 // UNSAFEFPATOMIC-DAG: #define __AMDGCN_UNSAFE_FP_ATOMICS__ 1
 
 // RUN: %clang -E -dM -target amdgcn -mcpu=gfx906 -mwavefrontsize64 \


### PR DESCRIPTION
Summary:
The cache line size on AMDGPU varies between 64 and 128 (The lowest L2
cache also goes to 256 on some architectures.) This macro is intended to
present a size that will not cause destructive interference, so we
choose the larger of those values.
