### PR TITLE
[NVPTX] Set cache line size to 128 for __GCC_DESTRUCTIVE_SIZE

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -186,6 +186,10 @@ public:
   bool hasBFloat16Type() const override { return true; }
 
   OffloadArch getGPU() const { return GPU; }
+
+  std::pair<unsigned, unsigned> hardwareInterferenceSizes() const override {
+    return std::make_pair(128, 128);
+  }
 };
 } // namespace targets
 } // namespace clang


### PR DESCRIPTION
Summary:
According to the white papers, the cache line size on NVPTX
architectures is 128 bytes. This should be what's returned by these
preprocessor macros.
