### PR TITLE
[Driver] Use heterogenous lookups with std::set (NFC)

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPUtility.cpp
+++ b/clang/lib/Driver/ToolChains/HIPUtility.cpp
@@ -148,8 +148,8 @@ private:
   bool Verbose;
   std::set<std::string> FatBinSymbols;
   std::set<std::string> GPUBinHandleSymbols;
-  std::set<std::string> DefinedFatBinSymbols;
-  std::set<std::string> DefinedGPUBinHandleSymbols;
+  std::set<std::string, std::less<>> DefinedFatBinSymbols;
+  std::set<std::string, std::less<>> DefinedGPUBinHandleSymbols;
   const std::string FatBinPrefix = "__hip_fatbin";
   const std::string GPUBinHandlePrefix = "__hip_gpubin_handle";
 
@@ -260,11 +260,10 @@ private:
 
       // Add undefined symbols if they are not in the defined sets
       if (isFatBinSymbol &&
-          DefinedFatBinSymbols.find(Name.str()) == DefinedFatBinSymbols.end())
+          DefinedFatBinSymbols.find(Name) == DefinedFatBinSymbols.end())
         FatBinSymbols.insert(Name.str());
-      else if (isGPUBinHandleSymbol &&
-               DefinedGPUBinHandleSymbols.find(Name.str()) ==
-                   DefinedGPUBinHandleSymbols.end())
+      else if (isGPUBinHandleSymbol && DefinedGPUBinHandleSymbols.find(Name) ==
+                                           DefinedGPUBinHandleSymbols.end())
         GPUBinHandleSymbols.insert(Name.str());
     }
   }


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.
