### PR TITLE
[RISCV][GISel] Custom promote s32 G_FPTOSI/FPTOUI on RV64.

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVRegisterBankInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVRegisterBankInfo.cpp
@@ -149,6 +149,8 @@ bool RISCVRegisterBankInfo::onlyUsesFP(const MachineInstr &MI,
                                        const MachineRegisterInfo &MRI,
                                        const TargetRegisterInfo &TRI) const {
   switch (MI.getOpcode()) {
+  case RISCV::G_FCVT_W_RV64:
+  case RISCV::G_FCVT_WU_RV64:
   case TargetOpcode::G_FPTOSI:
   case TargetOpcode::G_FPTOUI:
   case TargetOpcode::G_FCMP:
@@ -432,6 +434,8 @@ RISCVRegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
     OpdsMapping[0] = OpdsMapping[2] = OpdsMapping[3] = Mapping;
     break;
   }
+  case RISCV::G_FCVT_W_RV64:
+  case RISCV::G_FCVT_WU_RV64:
   case TargetOpcode::G_FPTOSI:
   case TargetOpcode::G_FPTOUI:
   case RISCV::G_FCLASS: {

--- a/llvm/lib/Target/RISCV/RISCVInstrGISel.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrGISel.td
@@ -49,6 +49,22 @@ def G_CTZW : RISCVGenericInstruction {
 }
 def : GINodeEquiv<G_CTZW, riscv_ctzw>;
 
+// Pseudo equivalent to a RISCVISD::FCVT_W_RV64.
+def G_FCVT_W_RV64 : RISCVGenericInstruction {
+  let OutOperandList = (outs type0:$dst);
+  let InOperandList = (ins type1:$src, untyped_imm_0:$frm);
+  let hasSideEffects = false;
+}
+def : GINodeEquiv<G_FCVT_W_RV64, riscv_fcvt_w_rv64>;
+
+// Pseudo equivalent to a RISCVISD::FCVT_WU_RV64.
+def G_FCVT_WU_RV64 : RISCVGenericInstruction {
+  let OutOperandList = (outs type0:$dst);
+  let InOperandList = (ins type1:$src, untyped_imm_0:$frm);
+  let hasSideEffects = false;
+}
+def : GINodeEquiv<G_FCVT_WU_RV64, riscv_fcvt_wu_rv64>;
+
 // Pseudo equivalent to a RISCVISD::FCLASS.
 def G_FCLASS : RISCVGenericInstruction {
   let OutOperandList = (outs type0:$dst);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
@@ -534,7 +534,7 @@ def : Pat<(store (f64 GPRPair:$rs2), (AddrRegImmINX (XLenVT GPR:$rs1), simm12:$i
           (PseudoRV32ZdinxSD GPRPair:$rs2, GPR:$rs1, simm12:$imm12)>;
 } // Predicates = [HasStdExtZdinx, IsRV32]
 
-let Predicates = [HasStdExtD] in {
+let Predicates = [HasStdExtD, IsRV32] in {
 
 // double->[u]int. Round-to-zero must be used.
 def : Pat<(i32 (any_fp_to_sint FPR64:$rs1)), (FCVT_W_D FPR64:$rs1, FRM_RTZ)>;
@@ -553,7 +553,7 @@ def : Pat<(i32 (any_lround FPR64:$rs1)), (FCVT_W_D $rs1, FRM_RMM)>;
 // [u]int->double.
 def : Pat<(any_sint_to_fp (i32 GPR:$rs1)), (FCVT_D_W GPR:$rs1, FRM_RNE)>;
 def : Pat<(any_uint_to_fp (i32 GPR:$rs1)), (FCVT_D_WU GPR:$rs1, FRM_RNE)>;
-} // Predicates = [HasStdExtD]
+} // Predicates = [HasStdExtD, IsRV32]
 
 let Predicates = [HasStdExtZdinx, IsRV32] in {
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
@@ -720,7 +720,7 @@ def : Pat<(f32 (bitconvert (i32 GPR:$rs1))), (EXTRACT_SUBREG GPR:$rs1, sub_32)>;
 def : Pat<(i32 (bitconvert FPR32INX:$rs1)), (INSERT_SUBREG (XLenVT (IMPLICIT_DEF)), FPR32INX:$rs1, sub_32)>;
 } // Predicates = [HasStdExtZfinx]
 
-let Predicates = [HasStdExtF] in {
+let Predicates = [HasStdExtF, IsRV32] in {
 // float->[u]int. Round-to-zero must be used.
 def : Pat<(i32 (any_fp_to_sint FPR32:$rs1)), (FCVT_W_S $rs1, FRM_RTZ)>;
 def : Pat<(i32 (any_fp_to_uint FPR32:$rs1)), (FCVT_WU_S $rs1, FRM_RTZ)>;
@@ -738,9 +738,9 @@ def : Pat<(i32 (any_lround FPR32:$rs1)), (FCVT_W_S $rs1, FRM_RMM)>;
 // [u]int->float. Match GCC and default to using dynamic rounding mode.
 def : Pat<(any_sint_to_fp (i32 GPR:$rs1)), (FCVT_S_W $rs1, FRM_DYN)>;
 def : Pat<(any_uint_to_fp (i32 GPR:$rs1)), (FCVT_S_WU $rs1, FRM_DYN)>;
-} // Predicates = [HasStdExtF]
+} // Predicates = [HasStdExtF, IsRV32]
 
-let Predicates = [HasStdExtZfinx] in {
+let Predicates = [HasStdExtZfinx, IsRV32] in {
 // float->[u]int. Round-to-zero must be used.
 def : Pat<(i32 (any_fp_to_sint FPR32INX:$rs1)), (FCVT_W_S_INX $rs1, FRM_RTZ)>;
 def : Pat<(i32 (any_fp_to_uint FPR32INX:$rs1)), (FCVT_WU_S_INX $rs1, FRM_RTZ)>;
@@ -758,7 +758,7 @@ def : Pat<(i32 (any_lround FPR32INX:$rs1)), (FCVT_W_S_INX $rs1, FRM_RMM)>;
 // [u]int->float. Match GCC and default to using dynamic rounding mode.
 def : Pat<(any_sint_to_fp (i32 GPR:$rs1)), (FCVT_S_W_INX $rs1, FRM_DYN)>;
 def : Pat<(any_uint_to_fp (i32 GPR:$rs1)), (FCVT_S_WU_INX $rs1, FRM_DYN)>;
-} // Predicates = [HasStdExtZfinx]
+} // Predicates = [HasStdExtZfinx, IsRV32]
 
 let Predicates = [HasStdExtF, IsRV64] in {
 // Moves (no conversion)

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
@@ -480,7 +480,7 @@ def : Pat<(riscv_fmv_x_anyexth FPR16INX:$src), (INSERT_SUBREG (XLenVT (IMPLICIT_
 def : Pat<(fcopysign FPR32INX:$rs1, FPR16INX:$rs2), (FSGNJ_S_INX $rs1, (FCVT_S_H_INX $rs2, FRM_RNE))>;
 } // Predicates = [HasStdExtZhinxmin]
 
-let Predicates = [HasStdExtZfh] in {
+let Predicates = [HasStdExtZfh, IsRV32] in {
 // half->[u]int. Round-to-zero must be used.
 def : Pat<(i32 (any_fp_to_sint (f16 FPR16:$rs1))), (FCVT_W_H $rs1, 0b001)>;
 def : Pat<(i32 (any_fp_to_uint (f16 FPR16:$rs1))), (FCVT_WU_H $rs1, 0b001)>;
@@ -500,7 +500,7 @@ def : Pat<(f16 (any_sint_to_fp (i32 GPR:$rs1))), (FCVT_H_W $rs1, FRM_DYN)>;
 def : Pat<(f16 (any_uint_to_fp (i32 GPR:$rs1))), (FCVT_H_WU $rs1, FRM_DYN)>;
 } // Predicates = [HasStdExtZfh]
 
-let Predicates = [HasStdExtZhinx] in {
+let Predicates = [HasStdExtZhinx, IsRV32] in {
 // half->[u]int. Round-to-zero must be used.
 def : Pat<(i32 (any_fp_to_sint FPR16INX:$rs1)), (FCVT_W_H_INX $rs1, 0b001)>;
 def : Pat<(i32 (any_fp_to_uint FPR16INX:$rs1)), (FCVT_WU_H_INX $rs1, 0b001)>;
@@ -518,7 +518,7 @@ def : Pat<(i32 (any_lround FPR16INX:$rs1)), (FCVT_W_H_INX $rs1, FRM_RMM)>;
 // [u]int->half. Match GCC and default to using dynamic rounding mode.
 def : Pat<(any_sint_to_fp (i32 GPR:$rs1)), (FCVT_H_W_INX $rs1, FRM_DYN)>;
 def : Pat<(any_uint_to_fp (i32 GPR:$rs1)), (FCVT_H_WU_INX $rs1, FRM_DYN)>;
-} // Predicates = [HasStdExtZhinx]
+} // Predicates = [HasStdExtZhinx, IsRV32]
 
 let Predicates = [HasStdExtZfh, IsRV64] in {
 // Use target specific isd nodes to help us remember the result is sign

--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fptoi-f16-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fptoi-f16-rv64.mir
@@ -19,9 +19,8 @@ body:             |
     ; CHECK-NEXT: $x10 = COPY [[FCVT_W_H]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:fprb(s16) = COPY $f10_h
-    %1:gprb(s32) = G_FPTOSI %0(s16)
-    %2:gprb(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:gprb(s64) = G_FCVT_W_RV64 %0(s16), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -42,9 +41,8 @@ body:             |
     ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_H]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:fprb(s16) = COPY $f10_h
-    %1:gprb(s32) = G_FPTOUI %0(s16)
-    %2:gprb(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:gprb(s64) = G_FCVT_WU_RV64 %0(s16), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...

--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fptoi-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fptoi-rv64.mir
@@ -19,9 +19,8 @@ body:             |
     ; CHECK-NEXT: $x10 = COPY [[FCVT_W_S]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:fprb(s32) = COPY $f10_f
-    %1:gprb(s32) = G_FPTOSI %0(s32)
-    %2:gprb(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:gprb(s64) = G_FCVT_W_RV64 %0(s32), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -42,9 +41,8 @@ body:             |
     ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_S]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:fprb(s32) = COPY $f10_f
-    %1:gprb(s32) = G_FPTOUI %0(s32)
-    %2:gprb(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:gprb(s64) = G_FCVT_WU_RV64 %0(s32), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -109,9 +107,8 @@ body:             |
     ; CHECK-NEXT: $x10 = COPY [[FCVT_W_D]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:fprb(s64) = COPY $f10_d
-    %1:gprb(s32) = G_FPTOSI %0(s64)
-    %2:gprb(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:gprb(s64) = G_FCVT_W_RV64 %0(s64), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -132,9 +129,8 @@ body:             |
     ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_D]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:fprb(s64) = COPY $f10_d
-    %1:gprb(s32) = G_FPTOUI %0(s64)
-    %2:gprb(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:gprb(s64) = G_FCVT_WU_RV64 %0(s64), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fptoi-f16-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fptoi-f16-rv64.mir
@@ -12,9 +12,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s1) = G_FPTOSI %0(s16)
@@ -33,9 +32,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s1) = G_FPTOUI %0(s16)
@@ -54,9 +52,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s8) = G_FPTOSI %0(s16)
@@ -75,9 +72,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s8) = G_FPTOUI %0(s16)
@@ -96,9 +92,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s16) = G_FPTOSI %0(s16)
@@ -117,9 +112,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s16) = G_FPTOUI %0(s16)
@@ -138,9 +132,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s32) = G_FPTOSI %0(s16)
@@ -159,9 +152,8 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
     %1:_(s32) = G_FPTOUI %0(s16)

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fptoi-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fptoi-rv64.mir
@@ -12,9 +12,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s1) = G_FPTOSI %0(s32)
@@ -33,9 +32,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s1) = G_FPTOUI %0(s32)
@@ -54,9 +52,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s8) = G_FPTOSI %0(s32)
@@ -75,9 +72,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s8) = G_FPTOUI %0(s32)
@@ -96,9 +92,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s16) = G_FPTOSI %0(s32)
@@ -117,9 +112,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s16) = G_FPTOUI %0(s32)
@@ -138,9 +132,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s32) = G_FPTOSI %0(s32)
@@ -159,9 +152,8 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
     %1:_(s32) = G_FPTOUI %0(s32)
@@ -218,9 +210,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s1) = G_FPTOSI %0(s64)
@@ -239,9 +230,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s1) = G_FPTOUI %0(s64)
@@ -260,9 +250,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s8) = G_FPTOSI %0(s64)
@@ -281,9 +270,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s8) = G_FPTOUI %0(s64)
@@ -302,9 +290,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s16) = G_FPTOSI %0(s64)
@@ -323,9 +310,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s16) = G_FPTOUI %0(s64)
@@ -344,9 +330,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:_(s64) = G_FCVT_W_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s32) = G_FPTOSI %0(s64)
@@ -365,9 +350,8 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:_(s64) = G_FCVT_WU_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
     %1:_(s32) = G_FPTOUI %0(s64)

--- a/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/fptoi-f16-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/fptoi-f16-rv64.mir
@@ -15,14 +15,12 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:gprb(s32) = G_FPTOSI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:gprb(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:gprb(s64) = G_FCVT_W_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
-    %1:_(s32) = G_FPTOSI %0(s16)
-    %2:_(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:_(s64) = G_FCVT_W_RV64 %0(s16), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -38,14 +36,12 @@ body:             |
     ; CHECK: liveins: $f10_h
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s16) = COPY $f10_h
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:gprb(s32) = G_FPTOUI [[COPY]](s16)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:gprb(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:gprb(s64) = G_FCVT_WU_RV64 [[COPY]](s16), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s16) = COPY $f10_h
-    %1:_(s32) = G_FPTOUI %0(s16)
-    %2:_(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:_(s64) = G_FCVT_WU_RV64 %0(s16), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...

--- a/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/fptoi-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/fptoi-rv64.mir
@@ -15,14 +15,12 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:gprb(s32) = G_FPTOSI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:gprb(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:gprb(s64) = G_FCVT_W_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
-    %1:_(s32) = G_FPTOSI %0(s32)
-    %2:_(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:_(s64) = G_FCVT_W_RV64 %0(s32), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -38,14 +36,12 @@ body:             |
     ; CHECK: liveins: $f10_f
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s32) = COPY $f10_f
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:gprb(s32) = G_FPTOUI [[COPY]](s32)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:gprb(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_WU_RV64_:%[0-9]+]]:gprb(s64) = G_FCVT_WU_RV64 [[COPY]](s32), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_WU_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s32) = COPY $f10_f
-    %1:_(s32) = G_FPTOUI %0(s32)
-    %2:_(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:_(s64) = G_FCVT_WU_RV64 %0(s32), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -103,14 +99,12 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOSI:%[0-9]+]]:gprb(s32) = G_FPTOSI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:gprb(s64) = G_ANYEXT [[FPTOSI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:gprb(s64) = G_FCVT_W_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
-    %1:_(s32) = G_FPTOSI %0(s64)
-    %2:_(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:_(s64) = G_FCVT_W_RV64 %0(s64), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...
@@ -126,14 +120,12 @@ body:             |
     ; CHECK: liveins: $f10_d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s64) = COPY $f10_d
-    ; CHECK-NEXT: [[FPTOUI:%[0-9]+]]:gprb(s32) = G_FPTOUI [[COPY]](s64)
-    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:gprb(s64) = G_ANYEXT [[FPTOUI]](s32)
-    ; CHECK-NEXT: $x10 = COPY [[ANYEXT]](s64)
+    ; CHECK-NEXT: [[FCVT_W_RV64_:%[0-9]+]]:gprb(s64) = G_FCVT_W_RV64 [[COPY]](s64), 1
+    ; CHECK-NEXT: $x10 = COPY [[FCVT_W_RV64_]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:_(s64) = COPY $f10_d
-    %1:_(s32) = G_FPTOUI %0(s64)
-    %2:_(s64) = G_ANYEXT %1(s32)
-    $x10 = COPY %2(s64)
+    %1:_(s64) = G_FCVT_W_RV64 %0(s64), 1
+    $x10 = COPY %1(s64)
     PseudoRET implicit $x10
 
 ...


### PR DESCRIPTION
I plan to make i32 an illegal type for RV64 to match SelectionDAG and to remove i32 from the GPR register class.