### PR TITLE
[clang-tidy] fix bugprone-sizeof-expression when sizeof expression with template types

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -402,7 +402,7 @@ void SizeofExpressionCheck::check(const MatchFinder::MatchResult &Result) {
           << E->getLHS()->getSourceRange() << E->getRHS()->getSourceRange();
     } else if (NumTy && DenomTy && NumTy == DenomTy &&
                !NumTy->isDependentType()) {
-      // dependent type should not be compared.
+      // Dependent type should not be compared.
       diag(E->getOperatorLoc(),
            "suspicious usage of 'sizeof(...)/sizeof(...)'; both expressions "
            "have the same type")

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -400,7 +400,9 @@ void SizeofExpressionCheck::check(const MatchFinder::MatchResult &Result) {
            "suspicious usage of 'sizeof(array)/sizeof(...)';"
            " denominator differs from the size of array elements")
           << E->getLHS()->getSourceRange() << E->getRHS()->getSourceRange();
-    } else if (NumTy && DenomTy && NumTy == DenomTy) {
+    } else if (NumTy && DenomTy && NumTy == DenomTy &&
+               !NumTy->isDependentType()) {
+      // dependent type should not be compared.
       diag(E->getOperatorLoc(),
            "suspicious usage of 'sizeof(...)/sizeof(...)'; both expressions "
            "have the same type")

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -175,7 +175,8 @@ Changes in existing checks
 - Improved :doc:`bugprone-sizeof-expression
   <clang-tidy/checks/bugprone/sizeof-expression>` check to find suspicious
   usages of ``sizeof()``, ``alignof()``, and ``offsetof()`` when adding or
-  subtracting from a pointer directly or when used to scale a numeric value.
+  subtracting from a pointer directly or when used to scale a numeric value and
+  fix false positive when sizeof expression with template types.
 
 - Improved :doc:`bugprone-unchecked-optional-access
   <clang-tidy/checks/bugprone/unchecked-optional-access>` to support

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -385,3 +385,8 @@ int ValidExpressions() {
   sum += sizeof(PtrArray) / sizeof(A[0]);
   return sum;
 }
+
+template<class T>
+int ValidateTemplateTypeExpressions(T t) {
+  return sizeof(t.val) / sizeof(t.val[0]);
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -386,7 +386,9 @@ int ValidExpressions() {
   return sum;
 }
 
+namespace gh115175 {
 template<class T>
 int ValidateTemplateTypeExpressions(T t) {
   return sizeof(t.val) / sizeof(t.val[0]);
 }
+} // namespace gh115175


### PR DESCRIPTION
Fixed: #115175.
`dependent type` are not the same even pointers are the same.
