### PR TITLE
[RISCV][AsmParser] Allow parsing vset{i}vli omitting LMUL parameter

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2222,8 +2222,14 @@ bool RISCVAsmParser::parseVTypeToken(const AsmToken &Tok, VTypeState &State,
     State = VTypeState_LMUL;
     return false;
   case VTypeState_LMUL: {
-    if (!Identifier.consume_front("m"))
-      break;
+    // Set LMUL to default if it is omitted.
+    if (!Identifier.consume_front("m")) {
+      Lmul = 1;
+      Fractional = false;
+      State = VTypeState_TailPolicy;
+      return parseVTypeToken(Tok, State, Sew, Lmul, Fractional, TailAgnostic,
+                             MaskAgnostic);
+    }
     Fractional = Identifier.consume_front("f");
     if (Identifier.getAsInteger(10, Lmul))
       break;
@@ -2320,7 +2326,7 @@ bool RISCVAsmParser::generateVTypeError(SMLoc ErrorLoc) {
   return Error(
       ErrorLoc,
       "operand must be "
-      "e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]");
+      "e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}");
 }
 
 ParseStatus RISCVAsmParser::parseMaskReg(OperandVector &Operands) {

--- a/llvm/test/MC/RISCV/rvv/invalid.s
+++ b/llvm/test/MC/RISCV/rvv/invalid.s
@@ -1,6 +1,12 @@
 # RUN: not llvm-mc -triple=riscv64 --mattr=+v --mattr=+f %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 
+vsetvli a2, a0, e8, ta, ma
+# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+
+vsetivli a2, 16, e8, ta, ma
+# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+
 vsetivli a2, 32, e8,m1
 # CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
 

--- a/llvm/test/MC/RISCV/rvv/invalid.s
+++ b/llvm/test/MC/RISCV/rvv/invalid.s
@@ -1,102 +1,96 @@
 # RUN: not llvm-mc -triple=riscv64 --mattr=+v --mattr=+f %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 
-vsetvli a2, a0, e8, ta, ma
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
-
-vsetivli a2, 16, e8, ta, ma
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
-
 vsetivli a2, 32, e8,m1
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetivli a2, zero, e8,m1
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetivli a2, 5, (1 << 10)
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetivli a2, 5, 0x400
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetivli a2, 5, e31
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, (1 << 11)
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, 0x800
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 
 vsetvli a2, a0, e31
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e32,m3
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, m1,e32
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e32,m16
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e128,m8
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e256,m8
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e512,m8
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e1024,m8
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e2048,m8
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e1,m8
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1,tx
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1,ta,mx
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1,ma
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1,mu
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8x,m1,tu,mu
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1z,tu,mu
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,mf1,tu,mu
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1,tu,mut
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1,tut,mu
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,m1,ta
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vsetvli a2, a0, e8,1,ta,ma
-# CHECK-ERROR: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+# CHECK-ERROR: operand must be e{8|16|32|64}[,m{1|2|4|8|f2|f4|f8}],{ta|tu},{ma|mu}
 
 vadd.vv v1, v3, v2, v4.t
 # CHECK-ERROR: operand must be v0.t

--- a/llvm/test/MC/RISCV/rvv/vsetvl.s
+++ b/llvm/test/MC/RISCV/rvv/vsetvl.s
@@ -10,6 +10,19 @@
 # RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+v %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 
+# LMUL is omitted.
+vsetvli a2, a0, e8, ta, ma
+# CHECK-INST: vsetvli a2, a0, e8, m1, ta, ma
+# CHECK-ENCODING: [0x57,0x76,0x05,0x0c]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: 0c057657 <unknown>
+
+vsetivli a2, 16, e8, ta, ma
+# CHECK-INST: vsetivli a2, 16, e8, m1, ta, ma
+# CHECK-ENCODING: [0x57,0x76,0x08,0xcc]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: cc087657 <unknown>
+
 # reserved filed: vlmul[2:0]=4, vsew[2:0]=0b1xx, non-zero bits 8/9/10.
 vsetvli a2, a0, 0x224
 # CHECK-INST: vsetvli a2, a0, 548


### PR DESCRIPTION
From RISC-V Unprivileged Specification version 20240411 (https://github.com/riscv/riscv-isa-manual/releases/tag/20240411) , paragraph 31.6, it's valid to omit LMUL parameter.
GCC has already supported it: https://godbolt.org/z/qs1svYY44.
So this patch introduces support of such behavior. 