### PR TITLE
[clang][Driver] Add RPATH by default

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1183,7 +1183,7 @@ void tools::addOpenMPRuntimeLibraryPath(const ToolChain &TC,
 void tools::addArchSpecificRPath(const ToolChain &TC, const ArgList &Args,
                                  ArgStringList &CmdArgs) {
   if (!Args.hasFlag(options::OPT_frtlib_add_rpath,
-                    options::OPT_fno_rtlib_add_rpath, false))
+                    options::OPT_fno_rtlib_add_rpath, true))
     return;
 
   SmallVector<std::string> CandidateRPaths(TC.getArchSpecificLibPaths());

--- a/clang/test/Driver/arch-specific-libdir-rpath.c
+++ b/clang/test/Driver/arch-specific-libdir-rpath.c
@@ -2,11 +2,11 @@
 // {RESOURCE_DIR}/lib/linux to the linker search path and to '-rpath'
 //
 // Test the default behavior when neither -frtlib-add-rpath nor
-// -fno-rtlib-add-rpath is specified, which is to skip -rpath
+// -fno-rtlib-add-rpath is specified, which is to add -rpath
 // RUN: %clang %s -### --target=x86_64-linux \
 // RUN:     -fsanitize=address -shared-libasan \
 // RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir 2>&1 \
-// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
+// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,RPATH-X86_64 %s
 //
 // Test that -rpath is not added under -fno-rtlib-add-rpath even if other
 // conditions are met.

--- a/flang/test/Driver/arch-specific-libdir-rpath.f95
+++ b/flang/test/Driver/arch-specific-libdir-rpath.f95
@@ -1,12 +1,11 @@
-! REQUIRES: x86-registered-target
 ! Test that the driver adds an arch-specific subdirectory in
 ! {RESOURCE_DIR}/lib/linux to the linker search path and to '-rpath'
 !
 ! Test the default behavior when neither -frtlib-add-rpath nor
-! -fno-rtlib-add-rpath is specified, which is to skip -rpath
+! -fno-rtlib-add-rpath is specified, which is to add -rpath
 ! RUN: %flang %s -### --target=x86_64-linux \
 ! RUN:     -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_arch_subdir 2>&1 \
-! RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
+! RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,RPATH-X86_64 %s
 !
 ! Test that -rpath is not added under -fno-rtlib-add-rpath
 ! RUN: %flang %s -### --target=x86_64-linux \

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -33,7 +33,8 @@
 ! SOLARIS-F128NONE-NOT: FortranFloat128Math
 ! UNIX-F128LIBQUADMATH-SAME: "-lFortranFloat128Math" "--as-needed" "-lquadmath" "--no-as-needed"
 ! SOLARIS-F128LIBQUADMATH-SAME: "-lFortranFloat128Math" "-z" "ignore" "-lquadmath" "-z" "record"
-! UNIX-SAME: "-lFortranRuntime" "-lFortranDecimal" "-lm"
+! UNIX-SAME: "-lFortranRuntime" "-lFortranDecimal"
+! UNIX-SAME: "-lm"
 ! COMPILER-RT: "{{.*}}{{\\|/}}libclang_rt.builtins.a"
 
 ! DARWIN-LABEL:  "{{.*}}ld{{(\.exe)?}}"


### PR DESCRIPTION
The `-frtlib-add-rpath` is very convenient when linking against various runtimes (OpenMP, Fortran, sanitizers), so much so we could argue that this should be a default behavior.

This patch makes adding RPATH the default behavior that could be prevented by explicitly using the `-fno-rtlib-add-rpath` flag.

This is an alternative to #115163