### PR TITLE
[lldb][docs] Document Lua 5.3 as the only supported version

### DIFF
--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -64,7 +64,7 @@ CMake configuration error.
 +-------------------+------------------------------------------------------+--------------------------+
 | Python            | Python scripting                                     | ``LLDB_ENABLE_PYTHON``   |
 +-------------------+------------------------------------------------------+--------------------------+
-| Lua               | Lua scripting                                        | ``LLDB_ENABLE_LUA``      |
+| Lua               | Lua scripting. Only version 5.3 is supported.        | ``LLDB_ENABLE_LUA``      |
 +-------------------+------------------------------------------------------+--------------------------+
 
 Depending on your platform and package manager, one might run any of the


### PR DESCRIPTION
Technically you can manually set `LUA_LIBRARIES` and others to use a different version, and I don't see any version checks in the C++ code. However, I'm not sure that is intentional, it looks more like a side effect of how the CMake was written.