### PR TITLE
[AArch64] AArch64ISelDAGToDAG.cpp - disable inlining on MSVC release builds

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
@@ -31,6 +31,11 @@ using namespace llvm;
 #define DEBUG_TYPE "aarch64-isel"
 #define PASS_NAME "AArch64 Instruction Selection"
 
+// https://github.com/llvm/llvm-project/issues/114425
+#if defined(_WIN32) && !defined(__clang__) && !defined(NDEBUG)
+#pragma inline_depth(0)
+#endif
+
 //===--------------------------------------------------------------------===//
 /// AArch64DAGToDAGISel - AArch64 specific code to select AArch64 machine
 /// instructions for SelectionDAG operations.


### PR DESCRIPTION
Similar to #110986 - disabling inlining on MSVC release builds avoids an excessive build time issue affecting all recent versions of CL.EXE

Fixes #114425