### PR TITLE
[TableGen][SelectionDAG] Remove the `implicit` DAG node

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -2579,8 +2579,7 @@ class BaseAddSubCarry<bit isSub, RegisterClass regtype, string asm,
 class BaseAddSubCarrySetFlags<bit isSub, RegisterClass regtype, string asm,
                               SDNode OpNode>
     : BaseBaseAddSubCarry<isSub, regtype, asm,
-        [(set regtype:$Rd, (OpNode regtype:$Rn, regtype:$Rm, NZCV)),
-         (implicit NZCV)]> {
+        [(set regtype:$Rd, (OpNode regtype:$Rn, regtype:$Rm, NZCV))]> {
   let Defs = [NZCV];
 }
 
@@ -5891,34 +5890,34 @@ multiclass FPComparison<bit signalAllNans, string asm,
                         SDPatternOperator OpNode = null_frag> {
   let Defs = [NZCV] in {
   def Hrr : BaseTwoOperandFPComparison<signalAllNans, FPR16, asm,
-      [(OpNode (f16 FPR16:$Rn), (f16 FPR16:$Rm)), (implicit NZCV)]> {
+      [(OpNode (f16 FPR16:$Rn), (f16 FPR16:$Rm))]> {
     let Inst{23-22} = 0b11;
     let Predicates = [HasFullFP16];
   }
 
   def Hri : BaseOneOperandFPComparison<signalAllNans, FPR16, asm,
-      [(OpNode (f16 FPR16:$Rn), fpimm0), (implicit NZCV)]> {
+      [(OpNode (f16 FPR16:$Rn), fpimm0)]> {
     let Inst{23-22} = 0b11;
     let Predicates = [HasFullFP16];
   }
 
   def Srr : BaseTwoOperandFPComparison<signalAllNans, FPR32, asm,
-      [(OpNode FPR32:$Rn, (f32 FPR32:$Rm)), (implicit NZCV)]> {
+      [(OpNode FPR32:$Rn, (f32 FPR32:$Rm))]> {
     let Inst{23-22} = 0b00;
   }
 
   def Sri : BaseOneOperandFPComparison<signalAllNans, FPR32, asm,
-      [(OpNode (f32 FPR32:$Rn), fpimm0), (implicit NZCV)]> {
+      [(OpNode (f32 FPR32:$Rn), fpimm0)]> {
     let Inst{23-22} = 0b00;
   }
 
   def Drr : BaseTwoOperandFPComparison<signalAllNans, FPR64, asm,
-      [(OpNode FPR64:$Rn, (f64 FPR64:$Rm)), (implicit NZCV)]> {
+      [(OpNode FPR64:$Rn, (f64 FPR64:$Rm))]> {
     let Inst{23-22} = 0b01;
   }
 
   def Dri : BaseOneOperandFPComparison<signalAllNans, FPR64, asm,
-      [(OpNode (f64 FPR64:$Rn), fpimm0), (implicit NZCV)]> {
+      [(OpNode (f64 FPR64:$Rn), fpimm0)]> {
     let Inst{23-22} = 0b01;
   }
   } // Defs = [NZCV]

--- a/llvm/lib/Target/AVR/AVRInstrInfo.td
+++ b/llvm/lib/Target/AVR/AVRInstrInfo.td
@@ -365,7 +365,7 @@ let isCommutable = 1, Constraints = "$src = $rd", Defs = [SREG] in {
   // Adds two 8-bit registers.
   def ADDRdRr : FRdRr<0b0000, 0b11, (outs GPR8:$rd),(ins GPR8:$src, GPR8:$rr),
                       "add\t$rd, $rr",
-                      [(set i8:$rd, (add i8:$src, i8:$rr)), (implicit SREG)]>;
+                      [(set i8:$rd, (add i8:$src, i8:$rr))]>;
 
   // ADDW Rd+1:Rd, Rr+1:Rr
   // Pseudo instruction to add four 8-bit registers as two 16-bit values.
@@ -375,15 +375,14 @@ let isCommutable = 1, Constraints = "$src = $rd", Defs = [SREG] in {
   // adc Rd+1, Rr+1
   def ADDWRdRr : Pseudo<(outs DREGS:$rd), (ins DREGS:$src, DREGS:$rr),
                         "addw\t$rd, $rr",
-                        [(set i16:$rd, (add i16:$src, i16:$rr)),
-                         (implicit SREG)]>;
+                        [(set i16:$rd, (add i16:$src, i16:$rr))]>;
 
   // ADC Rd, Rr
   // Adds two 8-bit registers with carry.
   let Uses = [SREG] in
   def ADCRdRr : FRdRr<0b0001, 0b11, (outs GPR8:$rd), (ins GPR8:$src, GPR8:$rr),
                       "adc\t$rd, $rr",
-                      [(set i8:$rd, (adde i8:$src, i8:$rr)), (implicit SREG)]>;
+                      [(set i8:$rd, (adde i8:$src, i8:$rr))]>;
 
   // ADCW Rd+1:Rd, Rr+1:Rr
   // Pseudo instruction to add four 8-bit registers as two 16-bit values with
@@ -395,15 +394,13 @@ let isCommutable = 1, Constraints = "$src = $rd", Defs = [SREG] in {
   let Uses = [SREG] in
   def ADCWRdRr : Pseudo<(outs DREGS:$rd), (ins DREGS:$src, DREGS:$rr),
                         "adcw\t$rd, $rr",
-                        [(set i16:$rd, (adde i16:$src, i16:$rr)),
-                         (implicit SREG)]>;
+                        [(set i16:$rd, (adde i16:$src, i16:$rr))]>;
 
   // AIDW Rd, k
   // Adds an immediate 6-bit value K to Rd, placing the result in Rd.
   def ADIWRdK : FWRdK<0b0, (outs IWREGS:$rd), (ins IWREGS :$src, imm_arith6:$k),
                       "adiw\t$rd, $k",
-                      [(set i16:$rd, (add i16:$src, uimm6:$k)),
-                       (implicit SREG)]>,
+                      [(set i16:$rd, (add i16:$src, uimm6:$k))]>,
                 Requires<[HasADDSUBIW]>;
 }
 
@@ -415,7 +412,7 @@ let Constraints = "$rs = $rd", Defs = [SREG] in {
   // Subtracts the 8-bit value of Rr from Rd and places the value in Rd.
   def SUBRdRr : FRdRr<0b0001, 0b10, (outs GPR8:$rd), (ins GPR8:$rs, GPR8:$rr),
                       "sub\t$rd, $rr",
-                      [(set i8:$rd, (sub i8:$rs, i8:$rr)), (implicit SREG)]>;
+                      [(set i8:$rd, (sub i8:$rs, i8:$rr))]>;
 
   // SUBW Rd+1:Rd, Rr+1:Rr
   // Subtracts two 16-bit values and places the result into Rd.
@@ -425,12 +422,11 @@ let Constraints = "$rs = $rd", Defs = [SREG] in {
   // sbc Rd+1, Rr+1
   def SUBWRdRr : Pseudo<(outs DREGS:$rd), (ins DREGS:$rs, DREGS:$rr),
                         "subw\t$rd, $rr",
-                        [(set i16:$rd, (sub i16:$rs, i16:$rr)),
-                         (implicit SREG)]>;
+                        [(set i16:$rd, (sub i16:$rs, i16:$rr))]>;
 
   def SUBIRdK : FRdK<0b0101, (outs LD8:$rd), (ins LD8:$rs, imm_ldi8:$k),
                      "subi\t$rd, $k",
-                     [(set i8:$rd, (sub i8:$rs, imm:$k)), (implicit SREG)]>;
+                     [(set i8:$rd, (sub i8:$rs, imm:$k))]>;
 
   // SUBIW Rd+1:Rd, K+1:K
   //
@@ -439,20 +435,18 @@ let Constraints = "$rs = $rd", Defs = [SREG] in {
   // sbci Rd+1, K+1
   def SUBIWRdK : Pseudo<(outs DLDREGS:$rd), (ins DLDREGS:$rs, i16imm:$rr),
                         "subiw\t$rd, $rr",
-                        [(set i16:$rd, (sub i16:$rs, imm:$rr)),
-                         (implicit SREG)]>;
+                        [(set i16:$rd, (sub i16:$rs, imm:$rr))]>;
 
   def SBIWRdK : FWRdK<0b1, (outs IWREGS:$rd), (ins IWREGS:$rs, imm_arith6:$k),
                       "sbiw\t$rd, $k",
-                      [(set i16:$rd, (sub i16:$rs, uimm6:$k)),
-                       (implicit SREG)]>,
+                      [(set i16:$rd, (sub i16:$rs, uimm6:$k))]>,
                 Requires<[HasADDSUBIW]>;
 
   // Subtract with carry operations which must read the carry flag in SREG.
   let Uses = [SREG] in {
     def SBCRdRr : FRdRr<0b0000, 0b10, (outs GPR8:$rd), (ins GPR8:$rs, GPR8:$rr),
                         "sbc\t$rd, $rr",
-                        [(set i8:$rd, (sube i8:$rs, i8:$rr)), (implicit SREG)]>;
+                        [(set i8:$rd, (sube i8:$rs, i8:$rr))]>;
 
     // SBCW Rd+1:Rd, Rr+1:Rr
     //
@@ -461,20 +455,18 @@ let Constraints = "$rs = $rd", Defs = [SREG] in {
     // sbc Rd+1, Rr+1
     def SBCWRdRr : Pseudo<(outs DREGS:$rd), (ins DREGS:$rs, DREGS:$rr),
                           "sbcw\t$rd, $rr",
-                          [(set i16:$rd, (sube i16:$rs, i16:$rr)),
-                           (implicit SREG)]>;
+                          [(set i16:$rd, (sube i16:$rs, i16:$rr))]>;
 
     def SBCIRdK : FRdK<0b0100, (outs LD8:$rd), (ins LD8:$rs, imm_ldi8:$k),
                        "sbci\t$rd, $k",
-                       [(set i8:$rd, (sube i8:$rs, imm:$k)), (implicit SREG)]>;
+                       [(set i8:$rd, (sube i8:$rs, imm:$k))]>;
 
     // SBCIW Rd+1:Rd, K+1:K
     // sbci Rd,   K
     // sbci Rd+1, K+1
     def SBCIWRdK : Pseudo<(outs DLDREGS:$rd), (ins DLDREGS:$rs, i16imm:$rr),
                           "sbciw\t$rd, $rr",
-                          [(set i16:$rd, (sube i16:$rs, imm:$rr)),
-                           (implicit SREG)]>;
+                          [(set i16:$rd, (sube i16:$rs, imm:$rr))]>;
   }
 }
 
@@ -484,11 +476,11 @@ let Constraints = "$rs = $rd", Defs = [SREG] in {
 let Constraints = "$src = $rd", Defs = [SREG] in {
   def INCRd : FRd<0b1001, 0b0100011, (outs GPR8:$rd), (ins GPR8:$src),
                   "inc\t$rd",
-                  [(set i8:$rd, (add i8:$src, 1)), (implicit SREG)]>;
+                  [(set i8:$rd, (add i8:$src, 1))]>;
 
   def DECRd : FRd<0b1001, 0b0101010, (outs GPR8:$rd), (ins GPR8:$src),
                   "dec\t$rd",
-                  [(set i8:$rd, (add i8:$src, -1)), (implicit SREG)]>;
+                  [(set i8:$rd, (add i8:$src, -1))]>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -538,7 +530,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
   let isCommutable = 1 in {
     def ANDRdRr : FRdRr<0b0010, 0b00, (outs GPR8:$rd),
                         (ins GPR8:$src, GPR8:$rr), "and\t$rd, $rr",
-                        [(set i8:$rd, (and i8:$src, i8:$rr)), (implicit SREG)]>;
+                        [(set i8:$rd, (and i8:$src, i8:$rr))]>;
 
     // ANDW Rd+1:Rd, Rr+1:Rr
     //
@@ -547,12 +539,11 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
     // and Rd+1, Rr+1
     def ANDWRdRr : Pseudo<(outs DREGS:$rd), (ins DREGS:$src, DREGS:$rr),
                           "andw\t$rd, $rr",
-                          [(set i16:$rd, (and i16:$src, i16:$rr)),
-                           (implicit SREG)]>;
+                          [(set i16:$rd, (and i16:$src, i16:$rr))]>;
 
     def ORRdRr : FRdRr<0b0010, 0b10, (outs GPR8:$rd), (ins GPR8:$src, GPR8:$rr),
                        "or\t$rd, $rr",
-                       [(set i8:$rd, (or i8:$src, i8:$rr)), (implicit SREG)]>;
+                       [(set i8:$rd, (or i8:$src, i8:$rr))]>;
 
     // ORW Rd+1:Rd, Rr+1:Rr
     //
@@ -561,12 +552,11 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
     // or Rd+1, Rr+1
     def ORWRdRr : Pseudo<(outs DREGS:$rd), (ins DREGS:$src, DREGS:$rr),
                          "orw\t$rd, $rr",
-                         [(set i16:$rd, (or i16:$src, i16:$rr)),
-                          (implicit SREG)]>;
+                         [(set i16:$rd, (or i16:$src, i16:$rr))]>;
 
     def EORRdRr : FRdRr<0b0010, 0b01, (outs GPR8:$rd),
                         (ins GPR8:$src, GPR8:$rr), "eor\t$rd, $rr",
-                        [(set i8:$rd, (xor i8:$src, i8:$rr)), (implicit SREG)]>;
+                        [(set i8:$rd, (xor i8:$src, i8:$rr))]>;
 
     // EORW Rd+1:Rd, Rr+1:Rr
     //
@@ -575,13 +565,12 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
     // eor Rd+1, Rr+1
     def EORWRdRr : Pseudo<(outs DREGS:$rd), (ins DREGS:$src, DREGS:$rr),
                           "eorw\t$rd, $rr",
-                          [(set i16:$rd, (xor i16:$src, i16:$rr)),
-                           (implicit SREG)]>;
+                          [(set i16:$rd, (xor i16:$src, i16:$rr))]>;
   }
 
   def ANDIRdK : FRdK<0b0111, (outs LD8:$rd), (ins LD8:$src, imm_ldi8:$k),
                      "andi\t$rd, $k",
-                     [(set i8:$rd, (and i8:$src, imm:$k)), (implicit SREG)]>;
+                     [(set i8:$rd, (and i8:$src, imm:$k))]>;
 
   // ANDI Rd+1:Rd, K+1:K
   //
@@ -590,12 +579,11 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
   // andi Rd+1, K+1
   def ANDIWRdK : Pseudo<(outs DLDREGS:$rd), (ins DLDREGS:$src, i16imm:$k),
                         "andiw\t$rd, $k",
-                        [(set i16:$rd, (and i16:$src, imm:$k)),
-                         (implicit SREG)]>;
+                        [(set i16:$rd, (and i16:$src, imm:$k))]>;
 
   def ORIRdK : FRdK<0b0110, (outs LD8:$rd), (ins LD8:$src, imm_ldi8:$k),
                     "ori\t$rd, $k",
-                    [(set i8:$rd, (or i8:$src, imm:$k)), (implicit SREG)]>;
+                    [(set i8:$rd, (or i8:$src, imm:$k))]>;
 
   // ORIW Rd+1:Rd, K+1,K
   //
@@ -604,8 +592,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
   // ori Rd+1, K+1
   def ORIWRdK : Pseudo<(outs DLDREGS:$rd), (ins DLDREGS:$src, i16imm:$rr),
                        "oriw\t$rd, $rr",
-                       [(set i16:$rd, (or i16:$src, imm:$rr)),
-                        (implicit SREG)]>;
+                       [(set i16:$rd, (or i16:$src, imm:$rr))]>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -613,7 +600,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
 //===----------------------------------------------------------------------===//
 let Constraints = "$src = $rd", Defs = [SREG] in {
   def COMRd : FRd<0b1001, 0b0100000, (outs GPR8:$rd), (ins GPR8:$src),
-                  "com\t$rd", [(set i8:$rd, (not i8:$src)), (implicit SREG)]>;
+                  "com\t$rd", [(set i8:$rd, (not i8:$src))]>;
 
   // COMW Rd+1:Rd
   //
@@ -621,10 +608,10 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
   // com Rd
   // com Rd+1
   def COMWRd : Pseudo<(outs DREGS:$rd), (ins DREGS:$src), "comw\t$rd",
-                      [(set i16:$rd, (not i16:$src)), (implicit SREG)]>;
+                      [(set i16:$rd, (not i16:$src))]>;
 
   def NEGRd : FRd<0b1001, 0b0100001, (outs GPR8:$rd), (ins GPR8:$src),
-                  "neg\t$rd", [(set i8:$rd, (ineg i8:$src)), (implicit SREG)]>;
+                  "neg\t$rd", [(set i8:$rd, (ineg i8:$src))]>;
 
   // NEGW Rd+1:Rd
   //
@@ -722,7 +709,7 @@ let Defs = [SREG] in {
 
   def CPRdRr : FRdRr<0b0001, 0b01, (outs), (ins GPR8:$rd, GPR8:$rr),
                      "cp\t$rd, $rr",
-                     [(AVRcmp i8:$rd, i8:$rr), (implicit SREG)]>;
+                     [(AVRcmp i8:$rd, i8:$rr)]>;
 
   // CPW Rd+1:Rd, Rr+1:Rr
   //
@@ -731,12 +718,12 @@ let Defs = [SREG] in {
   // cpc Rd+1, Rr+1
   def CPWRdRr : Pseudo<(outs), (ins DREGS:$src, DREGS:$src2),
                        "cpw\t$src, $src2",
-                       [(AVRcmp i16:$src, i16:$src2), (implicit SREG)]>;
+                       [(AVRcmp i16:$src, i16:$src2)]>;
 
   let Uses = [SREG] in
   def CPCRdRr : FRdRr<0b0000, 0b01, (outs), (ins GPR8:$rd, GPR8:$rr),
                       "cpc\t$rd, $rr",
-                      [(AVRcmpc i8:$rd, i8:$rr), (implicit SREG)]>;
+                      [(AVRcmpc i8:$rd, i8:$rr)]>;
 
   // CPCW Rd+1:Rd. Rr+1:Rr
   //
@@ -746,12 +733,12 @@ let Defs = [SREG] in {
   let Uses = [SREG] in
   def CPCWRdRr : Pseudo<(outs), (ins DREGS:$src, DREGS:$src2),
                         "cpcw\t$src, $src2",
-                        [(AVRcmpc i16:$src, i16:$src2), (implicit SREG)]>;
+                        [(AVRcmpc i16:$src, i16:$src2)]>;
 
   // CPI Rd, K
   // Compares a register with an 8 bit immediate.
   def CPIRdK : FRdK<0b0011, (outs), (ins LD8:$rd, imm_ldi8:$k), "cpi\t$rd, $k",
-                    [(AVRcmp i8:$rd, imm:$k), (implicit SREG)]>;
+                    [(AVRcmp i8:$rd, imm:$k)]>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1386,11 +1373,10 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                       "lslw\t$rd",
                       [(set i16
                         : $rd, (AVRlsl i16
-                                : $src)),
-                       (implicit SREG)]>;
+                                : $src))]>;
 
   def LSLWHiRd : Pseudo<(outs DREGS:$rd), (ins DREGS:$src), "lslwhi\t$rd",
-                        [(set i16:$rd, (AVRlslhi i16:$src)), (implicit SREG)]>;
+                        [(set i16:$rd, (AVRlslhi i16:$src))]>;
 
   def LSLWNRd : Pseudo<(outs DLDREGS
                         : $rd),
@@ -1401,8 +1387,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                          (set i16
                           : $rd, (AVRlslwn i16
                                   : $src, imm
-                                  : $bits)),
-                         (implicit SREG)
+                                  : $bits))
                        ]>;
 
   def LSLBNRd : Pseudo<(outs LD8
@@ -1414,8 +1399,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                          (set i8
                           : $rd, (AVRlslbn i8
                                   : $src, imm
-                                  : $bits)),
-                         (implicit SREG)
+                                  : $bits))
                        ]>;
 
   def LSRRd
@@ -1426,8 +1410,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
              : $src),
             "lsr\t$rd", [(set i8
                           : $rd, (AVRlsr i8
-                                  : $src)),
-                         (implicit SREG)]>;
+                                  : $src))]>;
 
   def LSRWRd : Pseudo<(outs DREGS
                        : $rd),
@@ -1436,11 +1419,10 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                       "lsrw\t$rd",
                       [(set i16
                         : $rd, (AVRlsr i16
-                                : $src)),
-                       (implicit SREG)]>;
+                                : $src))]>;
 
   def LSRWLoRd : Pseudo<(outs DREGS:$rd), (ins DREGS:$src), "lsrwlo\t$rd",
-                        [(set i16:$rd, (AVRlsrlo i16:$src)), (implicit SREG)]>;
+                        [(set i16:$rd, (AVRlsrlo i16:$src))]>;
 
   def LSRWNRd : Pseudo<(outs DLDREGS
                         : $rd),
@@ -1451,8 +1433,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                          (set i16
                           : $rd, (AVRlsrwn i16
                                   : $src, imm
-                                  : $bits)),
-                         (implicit SREG)
+                                  : $bits))
                        ]>;
 
   def LSRBNRd : Pseudo<(outs LD8
@@ -1464,8 +1445,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                          (set i8
                           : $rd, (AVRlsrbn i8
                                   : $src, imm
-                                  : $bits)),
-                         (implicit SREG)
+                                  : $bits))
                        ]>;
 
   def ASRRd
@@ -1476,8 +1456,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
              : $src),
             "asr\t$rd", [(set i8
                           : $rd, (AVRasr i8
-                                  : $src)),
-                         (implicit SREG)]>;
+                                  : $src))]>;
 
   def ASRWNRd : Pseudo<(outs DREGS
                         : $rd),
@@ -1488,8 +1467,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                          (set i16
                           : $rd, (AVRasrwn i16
                                   : $src, imm
-                                  : $bits)),
-                         (implicit SREG)
+                                  : $bits))
                        ]>;
 
   def ASRBNRd : Pseudo<(outs LD8
@@ -1501,8 +1479,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                          (set i8
                           : $rd, (AVRasrbn i8
                                   : $src, imm
-                                  : $bits)),
-                         (implicit SREG)
+                                  : $bits))
                        ]>;
 
   def ASRWRd : Pseudo<(outs DREGS
@@ -1512,25 +1489,22 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                       "asrw\t$rd",
                       [(set i16
                         : $rd, (AVRasr i16
-                                : $src)),
-                       (implicit SREG)]>;
+                                : $src))]>;
 
   def ASRWLoRd : Pseudo<(outs DREGS:$rd), (ins DREGS:$src), "asrwlo\t$rd",
-                        [(set i16:$rd, (AVRasrlo i16:$src)), (implicit SREG)]>;
+                        [(set i16:$rd, (AVRasrlo i16:$src))]>;
   let Uses = [R1] in
   def ROLBRdR1 : Pseudo<(outs GPR8:$rd),
                         (ins GPR8:$src),
                         "rolb\t$rd",
-                        [(set i8:$rd, (AVRrol i8:$src)),
-                        (implicit SREG)]>,
+                        [(set i8:$rd, (AVRrol i8:$src))]>,
                  Requires<[HasNonTinyEncoding]>;
 
   let Uses = [R17] in
   def ROLBRdR17 : Pseudo<(outs GPR8:$rd),
                          (ins GPR8:$src),
                          "rolb\t$rd",
-                         [(set i8:$rd, (AVRrol i8:$src)),
-                         (implicit SREG)]>,
+                         [(set i8:$rd, (AVRrol i8:$src))]>,
                   Requires<[HasTinyEncoding]>;
 
   def RORBRd : Pseudo<(outs GPR8
@@ -1540,8 +1514,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                       "rorb\t$rd",
                       [(set i8
                         : $rd, (AVRror i8
-                                : $src)),
-                       (implicit SREG)]>;
+                                : $src))]>;
 
   // Bit rotate operations.
   let Uses = [SREG] in {
@@ -1554,8 +1527,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                  "rolw\t$rd",
                  [(set i16
                    : $rd, (AVRrol i16
-                           : $src)),
-                  (implicit SREG)]>;
+                           : $src))]>;
 
     def RORRd : FRd<0b1001, 0b0100111,
                     (outs GPR8
@@ -1572,8 +1544,7 @@ let Constraints = "$src = $rd", Defs = [SREG] in {
                  "rorw\t$rd",
                  [(set i16
                    : $rd, (AVRror i16
-                           : $src)),
-                  (implicit SREG)]>;
+                           : $src))]>;
   }
 }
 
@@ -1740,8 +1711,7 @@ def SEXT
                       "sext\t$dst, $src",
                       [(set i16
                         : $dst, (sext i8
-                                 : $src)),
-                       (implicit SREG)]>;
+                                 : $src))]>;
 
 def ZEXT
     : ExtensionPseudo<(outs DREGS
@@ -1751,8 +1721,7 @@ def ZEXT
                       "zext\t$dst, $src",
                       [(set i16
                         : $dst, (zext i8
-                                 : $src)),
-                       (implicit SREG)]>;
+                                 : $src))]>;
 
 // This pseudo gets expanded into a movw+adiw thus it clobbers SREG.
 let Defs = [SREG],

--- a/llvm/lib/Target/MSP430/MSP430InstrInfo.td
+++ b/llvm/lib/Target/MSP430/MSP430InstrInfo.td
@@ -451,21 +451,17 @@ multiclass Arith<bits<4> opcode, string asmstring, SDPatternOperator node,
   let isCommutable = commutes in {
   def 8rr : I8rr<opcode, (outs GR8:$rd), (ins GR8:$src2, GR8:$rs),
                  !strconcat(asmstring, ".b\t$rs, $rd"),
-                 [(set GR8:$rd, (node GR8:$src2, GR8:$rs)),
-                  (implicit SR)]>;
+                 [(set GR8:$rd, (node GR8:$src2, GR8:$rs))]>;
   def 16rr : I16rr<opcode, (outs GR16:$rd), (ins GR16:$src2, GR16:$rs),
                    !strconcat(asmstring, "\t$rs, $rd"),
-                   [(set GR16:$rd, (node GR16:$src2, GR16:$rs)),
-                    (implicit SR)]>;
+                   [(set GR16:$rd, (node GR16:$src2, GR16:$rs))]>;
   }
   def 8rm : I8rm<opcode, (outs GR8:$rd), (ins GR8:$src2, memsrc:$src),
                  !strconcat(asmstring, ".b\t$src, $rd"),
-                 [(set GR8:$rd, (node GR8:$src2, (load addr:$src))),
-                  (implicit SR)]>;
+                 [(set GR8:$rd, (node GR8:$src2, (load addr:$src)))]>;
   def 16rm : I16rm<opcode, (outs GR16:$rd), (ins GR16:$src2, memsrc:$src),
                    !strconcat(asmstring, "\t$src, $rd"),
-                   [(set GR16:$rd, (node GR16:$src2, (load addr:$src))),
-                    (implicit SR)]>;
+                   [(set GR16:$rd, (node GR16:$src2, (load addr:$src)))]>;
   def 8rn : I8rn<opcode, (outs GR8:$rd), (ins GR8:$src2, indreg:$rs),
                  !strconcat(asmstring, ".b\t$rs, $rd"), []>;
   def 16rn : I16rn<opcode, (outs GR16:$rd), (ins GR16:$src2, indreg:$rs),
@@ -480,55 +476,43 @@ multiclass Arith<bits<4> opcode, string asmstring, SDPatternOperator node,
   }
   def 8rc : I8rc<opcode, (outs GR8:$rd), (ins GR8:$src2, cg8imm:$imm),
                  !strconcat(asmstring, ".b\t$imm, $rd"),
-                 [(set GR8:$rd, (node GR8:$src2, cg8imm:$imm)),
-                  (implicit SR)]>;
+                 [(set GR8:$rd, (node GR8:$src2, cg8imm:$imm))]>;
   def 16rc : I16rc<opcode, (outs GR16:$rd), (ins GR16:$src2, cg16imm:$imm),
                  !strconcat(asmstring, "\t$imm, $rd"),
-                 [(set GR16:$rd, (node GR16:$src2, cg16imm:$imm)),
-                  (implicit SR)]>;
+                 [(set GR16:$rd, (node GR16:$src2, cg16imm:$imm))]>;
   def 8ri : I8ri<opcode, (outs GR8:$rd), (ins GR8:$src2, i8imm:$imm),
                  !strconcat(asmstring, ".b\t$imm, $rd"),
-                 [(set GR8:$rd, (node GR8:$src2, imm:$imm)),
-                  (implicit SR)]>;
+                 [(set GR8:$rd, (node GR8:$src2, imm:$imm))]>;
   def 16ri : I16ri<opcode, (outs GR16:$rd), (ins GR16:$src2, i16imm:$imm),
                  !strconcat(asmstring, "\t$imm, $rd"),
-                 [(set GR16:$rd, (node GR16:$src2, imm:$imm)),
-                  (implicit SR)]>;
+                 [(set GR16:$rd, (node GR16:$src2, imm:$imm))]>;
   }
   def 8mr : I8mr<opcode, (outs), (ins memdst:$dst, GR8:$rs),
                  !strconcat(asmstring, ".b\t$rs, $dst"),
-                 [(store (node (load addr:$dst), GR8:$rs), addr:$dst),
-                  (implicit SR)]>;
+                 [(store (node (load addr:$dst), GR8:$rs), addr:$dst)]>;
   def 16mr : I16mr<opcode, (outs), (ins memdst:$dst, GR16:$rs),
                    !strconcat(asmstring, "\t$rs, $dst"),
-                   [(store (node (load addr:$dst), GR16:$rs), addr:$dst),
-                    (implicit SR)]>;
+                   [(store (node (load addr:$dst), GR16:$rs), addr:$dst)]>;
   def 8mc : I8mc<opcode, (outs), (ins memdst:$dst, cg8imm:$imm),
                  !strconcat(asmstring, ".b\t$imm, $dst"),
-                 [(store (node (load addr:$dst), (i8 cg8imm:$imm)), addr:$dst),
-                  (implicit SR)]>;
+                 [(store (node (load addr:$dst), (i8 cg8imm:$imm)), addr:$dst)]>;
   def 16mc : I16mc<opcode, (outs), (ins memdst:$dst, cg16imm:$imm),
                    !strconcat(asmstring, "\t$imm, $dst"),
-                   [(store (node (load addr:$dst), (i16 cg16imm:$imm)), addr:$dst),
-                    (implicit SR)]>;
+                   [(store (node (load addr:$dst), (i16 cg16imm:$imm)), addr:$dst)]>;
   def 8mi : I8mi<opcode, (outs), (ins memdst:$dst, i8imm:$imm),
                  !strconcat(asmstring, ".b\t$imm, $dst"),
-                 [(store (node (load addr:$dst), (i8 imm:$imm)), addr:$dst),
-                  (implicit SR)]>;
+                 [(store (node (load addr:$dst), (i8 imm:$imm)), addr:$dst)]>;
   def 16mi : I16mi<opcode, (outs), (ins memdst:$dst, i16imm:$imm),
                    !strconcat(asmstring, "\t$imm, $dst"),
-                   [(store (node (load addr:$dst), (i16 imm:$imm)), addr:$dst),
-                    (implicit SR)]>;
+                   [(store (node (load addr:$dst), (i16 imm:$imm)), addr:$dst)]>;
   def 8mm : I8mm<opcode, (outs), (ins memdst:$dst, memsrc:$src),
                  !strconcat(asmstring, ".b\t$src, $dst"),
                  [(store (node (load addr:$dst), 
-                               (i8 (load addr:$src))), addr:$dst),
-                  (implicit SR)]>;
+                               (i8 (load addr:$src))), addr:$dst)]>;
   def 16mm : I16mm<opcode, (outs), (ins memdst:$dst, memsrc:$src),
                    !strconcat(asmstring, "\t$src, $dst"),
                    [(store (node (load addr:$dst), 
-                                 (i16 (load addr:$src))), addr:$dst),
-                    (implicit SR)]>;
+                                 (i16 (load addr:$src))), addr:$dst)]>;
   def 8mn : I8mn<opcode, (outs), (ins memdst:$dst, indreg:$rs),
                  !strconcat(asmstring, ".b\t$rs, $dst"), []>;
   def 16mn : I16mn<opcode, (outs), (ins memdst:$dst, indreg:$rs),
@@ -631,32 +615,27 @@ let Defs = [SR] in {
 def RRA8r :   II8r<0b010,
                    (outs GR8:$rd), (ins GR8:$rs),
                    "rra.b\t$rd",
-                   [(set GR8:$rd, (MSP430rra GR8:$rs)),
-                    (implicit SR)]>;
+                   [(set GR8:$rd, (MSP430rra GR8:$rs))]>;
 def RRA16r : II16r<0b010,
                     (outs GR16:$rd), (ins GR16:$rs),
                     "rra\t$rd",
-                    [(set GR16:$rd, (MSP430rra GR16:$rs)),
-                     (implicit SR)]>;
+                    [(set GR16:$rd, (MSP430rra GR16:$rs))]>;
 
 let Uses = [SR] in {
 def RRC8r :   II8r<0b000,
                    (outs GR8:$rd), (ins GR8:$rs),
                    "rrc.b\t$rd",
-                   [(set GR8:$rd, (MSP430rrc GR8:$rs)),
-                    (implicit SR)]>;
+                   [(set GR8:$rd, (MSP430rrc GR8:$rs))]>;
 def RRC16r : II16r<0b000,
                    (outs GR16:$rd), (ins GR16:$rs),
                    "rrc\t$rd",
-                   [(set GR16:$rd, (MSP430rrc GR16:$rs)),
-                    (implicit SR)]>;
+                   [(set GR16:$rd, (MSP430rrc GR16:$rs))]>;
 } // Uses = [SR]
 
 def SEXT16r : II16r<0b011,
                     (outs GR16:$rd), (ins GR16:$rs),
                     "sxt\t$rd",
-                    [(set GR16:$rd, (sext_inreg GR16:$rs, i8)),
-                     (implicit SR)]>;
+                    [(set GR16:$rd, (sext_inreg GR16:$rs, i8))]>;
 
 } // Defs = [SR]
 
@@ -678,13 +657,11 @@ let Defs = [SR] in {
 def RRA8m  : II8m<0b010,
                    (outs), (ins memsrc:$src),
                    "rra.b\t$src",
-                   [(store (MSP430rra (i8 (load addr:$src))), addr:$src),
-                    (implicit SR)]>;
+                   [(store (MSP430rra (i8 (load addr:$src))), addr:$src)]>;
 def RRA16m : II16m<0b010,
                    (outs), (ins memsrc:$src),
                    "rra\t$src",
-                   [(store (MSP430rra (i16 (load addr:$src))), addr:$src),
-                    (implicit SR)]>;
+                   [(store (MSP430rra (i16 (load addr:$src))), addr:$src)]>;
 
 def RRA8n  : II8n<0b010, (outs), (ins indreg:$rs), "rra.b\t$rs", []>;
 def RRA16n : II16n<0b010, (outs), (ins indreg:$rs), "rra\t$rs", []>;
@@ -695,13 +672,11 @@ let Uses = [SR] in {
 def RRC8m  : II8m<0b000,
                    (outs), (ins memsrc:$src),
                    "rrc.b\t$src",
-                   [(store (MSP430rrc (i8 (load addr:$src))), addr:$src),
-                    (implicit SR)]>;
+                   [(store (MSP430rrc (i8 (load addr:$src))), addr:$src)]>;
 def RRC16m : II16m<0b000,
                    (outs), (ins memsrc:$src),
                    "rrc\t$src",
-                   [(store (MSP430rrc (i16 (load addr:$src))), addr:$src),
-                    (implicit SR)]>;
+                   [(store (MSP430rrc (i16 (load addr:$src))), addr:$src)]>;
 
 def RRC8n  : II8n<0b000, (outs), (ins indreg:$rs), "rrc.b\t$rs", []>;
 def RRC16n : II16n<0b000, (outs), (ins indreg:$rs), "rrc\t$rs", []>;
@@ -714,8 +689,7 @@ def SEXT16m : II16m<0b011,
                     (outs), (ins memsrc:$src),
                     "sxt\t$src",
                     [(store (sext_inreg (extloadi16i8 addr:$src), i8),
-                             addr:$src),
-                     (implicit SR)]>;
+                             addr:$src)]>;
 def SEXT16n : II16n<0b011, (outs), (ins indreg:$rs), "sxt\t$rs", []>;
 def SEXT16p : II16p<0b011, (outs), (ins postreg:$rs), "sxt\t$rs", []>;
 
@@ -733,62 +707,58 @@ let Defs = [SR] in {
 def CMP8rr  : I8rr<0b1001,
                    (outs), (ins GR8:$rd, GR8:$rs),
                    "cmp.b\t$rs, $rd",
-                   [(MSP430cmp GR8:$rd, GR8:$rs), (implicit SR)]>;
+                   [(MSP430cmp GR8:$rd, GR8:$rs)]>;
 def CMP16rr : I16rr<0b1001,
                     (outs), (ins GR16:$rd, GR16:$rs),
                     "cmp\t$rs, $rd",
-                    [(MSP430cmp GR16:$rd, GR16:$rs), (implicit SR)]>;
+                    [(MSP430cmp GR16:$rd, GR16:$rs)]>;
 
 def CMP8rc  : I8rc<0b1001,
                    (outs), (ins GR8:$rd, cg8imm:$imm),
                    "cmp.b\t$imm, $rd",
-                   [(MSP430cmp GR8:$rd, cg8imm:$imm), (implicit SR)]>;
+                   [(MSP430cmp GR8:$rd, cg8imm:$imm)]>;
 def CMP16rc : I16rc<0b1001,
                     (outs), (ins GR16:$rd, cg16imm:$imm),
                     "cmp\t$imm, $rd",
-                    [(MSP430cmp GR16:$rd, cg16imm:$imm), (implicit SR)]>;
+                    [(MSP430cmp GR16:$rd, cg16imm:$imm)]>;
 
 def CMP8ri  : I8ri<0b1001,
                    (outs), (ins GR8:$rd, i8imm:$imm),
                    "cmp.b\t$imm, $rd",
-                   [(MSP430cmp GR8:$rd, imm:$imm), (implicit SR)]>;
+                   [(MSP430cmp GR8:$rd, imm:$imm)]>;
 def CMP16ri : I16ri<0b1001,
                     (outs), (ins GR16:$rd, i16imm:$imm),
                     "cmp\t$imm, $rd",
-                    [(MSP430cmp GR16:$rd, imm:$imm), (implicit SR)]>;
+                    [(MSP430cmp GR16:$rd, imm:$imm)]>;
 
 def CMP8mc  : I8mc<0b1001,
                    (outs), (ins memsrc:$dst, cg8imm:$imm),
                    "cmp.b\t$imm, $dst",
-                   [(MSP430cmp (load addr:$dst), (i8 cg8imm:$imm)),
-                    (implicit SR)]>;
+                   [(MSP430cmp (load addr:$dst), (i8 cg8imm:$imm))]>;
 def CMP16mc : I16mc<0b1001,
                     (outs), (ins memsrc:$dst, cg16imm:$imm),
                     "cmp\t$imm, $dst",
-                    [(MSP430cmp (load addr:$dst), (i16 cg16imm:$imm)),
-                     (implicit SR)]>;
+                    [(MSP430cmp (load addr:$dst), (i16 cg16imm:$imm))]>;
 
 def CMP8mi  : I8mi<0b1001,
                    (outs), (ins memsrc:$dst, i8imm:$imm),
                    "cmp.b\t$imm, $dst",
                    [(MSP430cmp (load addr:$dst),
-                               (i8 imm:$imm)), (implicit SR)]>;
+                               (i8 imm:$imm))]>;
 def CMP16mi : I16mi<0b1001,
                     (outs), (ins memsrc:$dst, i16imm:$imm),
                     "cmp\t$imm, $dst",
                      [(MSP430cmp (load addr:$dst),
-                                 (i16 imm:$imm)), (implicit SR)]>;
+                                 (i16 imm:$imm))]>;
 
 def CMP8rm  : I8rm<0b1001,
                    (outs), (ins GR8:$rd, memsrc:$src),
                    "cmp.b\t$src, $rd",
-                   [(MSP430cmp GR8:$rd, (load addr:$src)), 
-                    (implicit SR)]>;
+                   [(MSP430cmp GR8:$rd, (load addr:$src))]>;
 def CMP16rm : I16rm<0b1001,
                     (outs), (ins GR16:$rd, memsrc:$src),
                     "cmp\t$src, $rd",
-                    [(MSP430cmp GR16:$rd, (load addr:$src)),
-                     (implicit SR)]>;
+                    [(MSP430cmp GR16:$rd, (load addr:$src))]>;
 
 def CMP8rn  : I8rn<0b1001,
                    (outs), (ins GR8:$rd, indreg:$rs), "cmp.b\t$rs, $rd", []>;
@@ -803,22 +773,18 @@ def CMP16rp : I16rp<0b1001,
 def CMP8mr  : I8mr<0b1001,
                    (outs), (ins memsrc:$dst, GR8:$rs),
                    "cmp.b\t$rs, $dst",
-                   [(MSP430cmp (load addr:$dst), GR8:$rs),
-                    (implicit SR)]>;
+                   [(MSP430cmp (load addr:$dst), GR8:$rs)]>;
 def CMP16mr : I16mr<0b1001,
                     (outs), (ins memsrc:$dst, GR16:$rs),
                     "cmp\t$rs, $dst",
-                    [(MSP430cmp (load addr:$dst), GR16:$rs), 
-                     (implicit SR)]>;
+                    [(MSP430cmp (load addr:$dst), GR16:$rs)]>;
 def CMP8mm  : I8mm<0b1001,
                    (outs), (ins memdst:$dst, memsrc:$src),
                    "cmp.b\t$src, $dst",
-                   [(MSP430cmp (load addr:$dst), (i8 (load addr:$src))),
-                    (implicit SR)]>;
+                   [(MSP430cmp (load addr:$dst), (i8 (load addr:$src)))]>;
 def CMP16mm : I16mm<0b1001, (outs), (ins memdst:$dst, memsrc:$src),
                     "cmp\t$src, $dst",
-                    [(MSP430cmp (load addr:$dst), (i16 (load addr:$src))),
-                     (implicit SR)]>;
+                    [(MSP430cmp (load addr:$dst), (i16 (load addr:$src)))]>;
 
 def CMP8mn  : I8mn<0b1001, (outs), (ins memsrc:$dst, indreg:$rs),
                    "cmp.b\t$rs, $dst", []>;
@@ -836,46 +802,38 @@ let isCommutable = 1 in {
 def BIT8rr  : I8rr<0b1011,
                    (outs), (ins GR8:$rd, GR8:$rs),
                    "bit.b\t$rs, $rd",
-                   [(MSP430cmp (and_su GR8:$rd, GR8:$rs), 0),
-                    (implicit SR)]>;
+                   [(MSP430cmp (and_su GR8:$rd, GR8:$rs), 0)]>;
 def BIT16rr : I16rr<0b1011,
                     (outs), (ins GR16:$rd, GR16:$rs),
                     "bit\t$rs, $rd",
-                    [(MSP430cmp (and_su GR16:$rd, GR16:$rs), 0),
-                     (implicit SR)]>;
+                    [(MSP430cmp (and_su GR16:$rd, GR16:$rs), 0)]>;
 }
 def BIT8rc  : I8rc<0b1011,
                    (outs), (ins GR8:$rd, cg8imm:$imm),
                    "bit.b\t$imm, $rd",
-                   [(MSP430cmp (and_su GR8:$rd, cg8imm:$imm), 0),
-                    (implicit SR)]>;
+                   [(MSP430cmp (and_su GR8:$rd, cg8imm:$imm), 0)]>;
 def BIT16rc : I16rc<0b1011,
                     (outs), (ins GR16:$rd, cg16imm:$imm),
                     "bit\t$imm, $rd",
-                    [(MSP430cmp (and_su GR16:$rd, cg16imm:$imm), 0),
-                     (implicit SR)]>;
+                    [(MSP430cmp (and_su GR16:$rd, cg16imm:$imm), 0)]>;
 
 def BIT8ri  : I8ri<0b1011,
                    (outs), (ins GR8:$rd, i8imm:$imm),
                    "bit.b\t$imm, $rd",
-                   [(MSP430cmp (and_su GR8:$rd, imm:$imm), 0),
-                    (implicit SR)]>;
+                   [(MSP430cmp (and_su GR8:$rd, imm:$imm), 0)]>;
 def BIT16ri : I16ri<0b1011,
                     (outs), (ins GR16:$rd, i16imm:$imm),
                     "bit\t$imm, $rd",
-                    [(MSP430cmp (and_su GR16:$rd, imm:$imm), 0),
-                     (implicit SR)]>;
+                    [(MSP430cmp (and_su GR16:$rd, imm:$imm), 0)]>;
 
 def BIT8rm  : I8rm<0b1011,
                    (outs), (ins GR8:$rd, memdst:$src),
                    "bit.b\t$src, $rd",
-                   [(MSP430cmp (and_su GR8:$rd,  (load addr:$src)), 0),
-                    (implicit SR)]>;
+                   [(MSP430cmp (and_su GR8:$rd,  (load addr:$src)), 0)]>;
 def BIT16rm : I16rm<0b1011,
                     (outs), (ins GR16:$rd, memdst:$src),
                     "bit\t$src, $rd",
-                    [(MSP430cmp (and_su GR16:$rd,  (load addr:$src)), 0),
-                     (implicit SR)]>;
+                    [(MSP430cmp (and_su GR16:$rd,  (load addr:$src)), 0)]>;
 
 def BIT8rn  : I8rn<0b1011, (outs), (ins GR8:$rd, indreg:$rs),
                    "bit.b\t$rs, $rd", []>;
@@ -890,50 +848,42 @@ def BIT16rp : I16rp<0b1011, (outs), (ins GR16:$rd, postreg:$rs),
 def BIT8mr  : I8mr<0b1011,
                   (outs), (ins memsrc:$dst, GR8:$rs),
                   "bit.b\t$rs, $dst",
-                  [(MSP430cmp (and_su (load addr:$dst), GR8:$rs), 0),
-                   (implicit SR)]>;
+                  [(MSP430cmp (and_su (load addr:$dst), GR8:$rs), 0)]>;
 def BIT16mr : I16mr<0b1011,
                     (outs), (ins memsrc:$dst, GR16:$rs),
                     "bit\t$rs, $dst",
-                    [(MSP430cmp (and_su (load addr:$dst), GR16:$rs), 0),
-                     (implicit SR)]>;
+                    [(MSP430cmp (and_su (load addr:$dst), GR16:$rs), 0)]>;
 
 def BIT8mc  : I8mc<0b1011,
                    (outs), (ins memsrc:$dst, cg8imm:$imm),
                    "bit.b\t$imm, $dst",
-                   [(MSP430cmp (and_su (load addr:$dst), (i8 cg8imm:$imm)), 0),
-                    (implicit SR)]>;
+                   [(MSP430cmp (and_su (load addr:$dst), (i8 cg8imm:$imm)), 0)]>;
 def BIT16mc : I16mc<0b1011,
                     (outs), (ins memdst:$dst, cg16imm:$imm),
                     "bit\t$imm, $dst",
-                    [(MSP430cmp (and_su (load addr:$dst), (i16 cg16imm:$imm)), 0),
-                     (implicit SR)]>;
+                    [(MSP430cmp (and_su (load addr:$dst), (i16 cg16imm:$imm)), 0)]>;
 
 def BIT8mi  : I8mi<0b1011,
                    (outs), (ins memsrc:$dst, i8imm:$imm),
                    "bit.b\t$imm, $dst",
-                   [(MSP430cmp (and_su (load addr:$dst), (i8 imm:$imm)), 0),
-                    (implicit SR)]>;
+                   [(MSP430cmp (and_su (load addr:$dst), (i8 imm:$imm)), 0)]>;
 def BIT16mi : I16mi<0b1011,
                     (outs), (ins memsrc:$dst, i16imm:$imm),
                     "bit\t$imm, $dst",
-                    [(MSP430cmp (and_su (load addr:$dst), (i16 imm:$imm)), 0),
-                     (implicit SR)]>;
+                    [(MSP430cmp (and_su (load addr:$dst), (i16 imm:$imm)), 0)]>;
 
 def BIT8mm  : I8mm<0b1011,
                    (outs), (ins memsrc:$dst, memsrc:$src),
                    "bit.b\t$src, $dst",
                    [(MSP430cmp (and_su (i8 (load addr:$dst)),
                                        (load addr:$src)),
-                                 0),
-                      (implicit SR)]>;
+                                 0)]>;
 def BIT16mm : I16mm<0b1011,
                     (outs), (ins memsrc:$dst, memsrc:$src),
                     "bit\t$src, $dst",
                     [(MSP430cmp (and_su (i16 (load addr:$dst)),
                                         (load addr:$src)),
-                                 0),
-                     (implicit SR)]>;
+                                 0)]>;
 def BIT8mn  : I8mn<0b1011, (outs), (ins memsrc:$dst, indreg:$rs),
                    "bit.b\t$rs, $dst", []>;
 def BIT16mn : I16mn<0b1011, (outs), (ins memsrc:$dst, indreg:$rs),

--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -3585,11 +3585,10 @@ static bool isFusableLoadOpStorePattern(StoreSDNode *StoreNode,
 // be transferred from a node in the pattern to the result node, probably with
 // a new keyword. For example, we have this
 // def DEC64m : RI<0xFF, MRM1m, (outs), (ins i64mem:$dst), "dec{q}\t$dst",
-//  [(store (add (loadi64 addr:$dst), -1), addr:$dst),
-//   (implicit EFLAGS)]>;
+//  [(store (add (loadi64 addr:$dst), -1), addr:$dst)]>;
 // but maybe need something like this
 // def DEC64m : RI<0xFF, MRM1m, (outs), (ins i64mem:$dst), "dec{q}\t$dst",
-//  [(store (add (loadi64 addr:$dst), -1), addr:$dst),
+//  [(store (X86add_flag (loadi64 addr:$dst), -1), addr:$dst),
 //   (transferrable EFLAGS)]>;
 //
 // Until then, we manually fold these and instruction select the operation

--- a/llvm/lib/Target/X86/X86InstrArithmetic.td
+++ b/llvm/lib/Target/X86/X86InstrArithmetic.td
@@ -73,7 +73,7 @@ multiclass Mul<bits<8> o, string m, Format RegMRM, Format MemMRM, SDPatternOpera
   // syntax can be accepted.
   let Defs = [AL, EFLAGS, AX], Uses = [AL] in
     def 8r : MulDivOpR<o, RegMRM, m, Xi8, WriteIMul8,
-                       [(set AL, (node AL, GR8:$src1)), (implicit EFLAGS)]>;
+                       [(set AL, EFLAGS, (node AL, GR8:$src1))]>;
   let Defs = [AX, DX, EFLAGS], Uses = [AX] in
     def 16r : MulDivOpR<o, RegMRM, m, Xi16, WriteIMul16, []>, OpSize16;
   let Defs = [EAX, EDX, EFLAGS], Uses = [EAX] in
@@ -82,7 +82,7 @@ multiclass Mul<bits<8> o, string m, Format RegMRM, Format MemMRM, SDPatternOpera
     def 64r : MulDivOpR<o, RegMRM, m, Xi64, WriteIMul64, []>;
   let Defs = [AL, EFLAGS, AX], Uses = [AL] in
     def 8m : MulDivOpM<o, MemMRM, m, Xi8, WriteIMul8,
-                       [(set AL, (node AL, (loadi8 addr:$src1))), (implicit EFLAGS)]>;
+                       [(set AL, EFLAGS, (node AL, (loadi8 addr:$src1)))]>;
   let Defs = [AX, DX, EFLAGS], Uses = [AX] in
     def 16m : MulDivOpM<o, MemMRM, m, Xi16, WriteIMul16, []>, OpSize16;
   let Defs = [EAX, EDX, EFLAGS], Uses = [EAX] in
@@ -386,12 +386,10 @@ class DecOpR_RF<X86TypeInfo t, bit ndd = 0> : UnaryOpR_RF<0xFF, MRM1r, "dec", t,
 class IncOpR_R<X86TypeInfo t, bit ndd = 0> : UnaryOpR_R<0xFF, MRM0r, "inc", t, null_frag, ndd>;
 class DecOpR_R<X86TypeInfo t, bit ndd = 0> : UnaryOpR_R<0xFF, MRM1r, "dec", t, null_frag, ndd>;
 class IncOpM_MF<X86TypeInfo t> : UnaryOpM_MF<0xFF, MRM0m, "inc", t, null_frag> {
-  let Pattern = [(store (add (t.LoadNode addr:$src1), 1), addr:$src1),
-                 (implicit EFLAGS)];
+  let Pattern = [(store (add (t.LoadNode addr:$src1), 1), addr:$src1)];
 }
 class DecOpM_MF<X86TypeInfo t> : UnaryOpM_MF<0xFF, MRM1m, "dec", t, null_frag> {
-  let Pattern = [(store (add (t.LoadNode addr:$src1), -1), addr:$src1),
-                 (implicit EFLAGS)];
+  let Pattern = [(store (add (t.LoadNode addr:$src1), -1), addr:$src1)];
 }
 class IncOpM_RF<X86TypeInfo t> : UnaryOpM_RF<0xFF, MRM0m, "inc", t, null_frag> {
   let Pattern = [(set t.RegClass:$dst, EFLAGS, (add (t.LoadNode addr:$src1), 1))];

--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -74,8 +74,7 @@ def VASTART_SAVE_XMM_REGS : I<0, Pseudo,
                               (outs),
                               (ins GR8:$al, i8mem:$regsavefi, variable_ops),
                               "#VASTART_SAVE_XMM_REGS $al, $regsavefi",
-                              [(X86vastart_save_xmm_regs GR8:$al, addr:$regsavefi),
-                               (implicit EFLAGS)]>;
+                              [(X86vastart_save_xmm_regs GR8:$al, addr:$regsavefi)]>;
 }
 
 let usesCustomInserter = 1, Defs = [EFLAGS] in {
@@ -87,15 +86,15 @@ def VAARG_64 : I<0, Pseudo,
                  (ins i8mem:$ap, i32imm:$size, i8imm:$mode, i32imm:$align),
                  "#VAARG_64 $dst, $ap, $size, $mode, $align",
                  [(set GR64:$dst,
-                    (X86vaarg64 addr:$ap, timm:$size, timm:$mode, timm:$align)),
-                  (implicit EFLAGS)]>, Requires<[In64BitMode, IsLP64]>;
+                    (X86vaarg64 addr:$ap, timm:$size, timm:$mode, timm:$align))]>,
+               Requires<[In64BitMode, IsLP64]>;
 def VAARG_X32 : I<0, Pseudo,
                  (outs GR32:$dst),
                  (ins i8mem:$ap, i32imm:$size, i8imm:$mode, i32imm:$align),
                  "#VAARG_X32 $dst, $ap, $size, $mode, $align",
                  [(set GR32:$dst,
-                    (X86vaargx32 addr:$ap, timm:$size, timm:$mode, timm:$align)),
-                  (implicit EFLAGS)]>, Requires<[In64BitMode, NotLP64]>;
+                    (X86vaargx32 addr:$ap, timm:$size, timm:$mode, timm:$align))]>,
+                Requires<[In64BitMode, NotLP64]>;
 }
 
 // When using segmented stacks these are lowered into instructions which first

--- a/llvm/lib/Target/X86/X86InstrMisc.td
+++ b/llvm/lib/Target/X86/X86InstrMisc.td
@@ -1163,14 +1163,12 @@ multiclass Lzcnt<bits<8> o, string m, SDPatternOperator node, X86TypeInfo t,
                  SchedWrite schedrr, SchedWrite schedrm, string suffix = ""> {
   def rr#suffix : ITy<o, MRMSrcReg, t, (outs t.RegClass:$dst),
                       (ins t.RegClass:$src1), m, unaryop_ndd_args,
-                      [(set t.RegClass:$dst, (node t.RegClass:$src1)),
-                                              (implicit EFLAGS)]>,
+                      [(set t.RegClass:$dst, (node t.RegClass:$src1))]>,
                   TB, Sched<[schedrr]>;
   let mayLoad = 1 in
     def rm#suffix : ITy<o, MRMSrcMem, t, (outs t.RegClass:$dst),
                         (ins t.MemOperand:$src1), m, unaryop_ndd_args,
-                        [(set t.RegClass:$dst, (node (t.LoadNode addr:$src1))),
-                                                (implicit EFLAGS)]>,
+                        [(set t.RegClass:$dst, (node (t.LoadNode addr:$src1)))]>,
                     TB, Sched<[schedrm]>;
 }
 

--- a/llvm/lib/Target/X86/X86InstrSystem.td
+++ b/llvm/lib/Target/X86/X86InstrSystem.td
@@ -690,7 +690,7 @@ let Defs = [RAX, RDX, RSI], Uses = [RAX, RSI] in
 let SchedRW = [WriteSystem] in {
 let Defs = [EAX, EDX], Uses = [ECX] in
   def RDPKRUr : I<0x01, MRM_EE, (outs), (ins), "rdpkru",
-                  [(set EAX, (X86rdpkru ECX)), (implicit EDX)]>, TB;
+                  [(set EAX, EDX, (X86rdpkru ECX))]>, TB;
 let Uses = [EAX, ECX, EDX] in
   def WRPKRUr : I<0x01, MRM_EF, (outs), (ins), "wrpkru",
                   [(X86wrpkru EAX, EDX, ECX)]>, TB;

--- a/llvm/lib/Target/X86/X86InstrUtils.td
+++ b/llvm/lib/Target/X86/X86InstrUtils.td
@@ -1147,8 +1147,7 @@ class BinOpMR_M<bits<8> o, string m, X86TypeInfo t>
 // BinOpMR_MF - Instructions that read "[mem], reg" and write "[mem]", EFLAGS.
 class BinOpMR_MF<bits<8> o, string m, X86TypeInfo t, SDPatternOperator node>
   : BinOpMR<o, m, binop_args, t, (outs),
-            [(store (node (load addr:$src1), t.RegClass:$src2), addr:$src1),
-             (implicit EFLAGS)]>,
+            [(store (node (load addr:$src1), t.RegClass:$src2), addr:$src1)]>,
     Sched<[WriteALURMW,
            // base, scale, index, offset, segment
            ReadDefault, ReadDefault, ReadDefault, ReadDefault, ReadDefault,
@@ -1168,7 +1167,7 @@ class BinOpMRF_RF<bits<8> o, string m, X86TypeInfo t, SDPatternOperator node>
 class BinOpMRF_MF<bits<8> o, string m, X86TypeInfo t, SDPatternOperator node>
   : BinOpMR<o, m, binop_args, t, (outs),
             [(store (node (load addr:$src1), t.RegClass:$src2, EFLAGS),
-             addr:$src1), (implicit EFLAGS)]>,
+             addr:$src1)]>,
     Sched<[WriteADCRMW,
           // base, scale, index, offset, segment
           ReadDefault, ReadDefault, ReadDefault,
@@ -1211,7 +1210,7 @@ class BinOpMI_M<bits<8> o, string m, X86TypeInfo t, Format f>
 class BinOpMI_MF<bits<8> o, string m, X86TypeInfo t, SDPatternOperator node, Format f>
   : BinOpMI<o, m, binop_args, t, f, (outs),
             [(store (node (t.VT (load addr:$src1)),
-             t.ImmOperator:$src2), addr:$src1), (implicit EFLAGS)]>,
+             t.ImmOperator:$src2), addr:$src1)]>,
     Sched<[WriteALURMW]>, DefEFLAGS {
   let mayStore = 1;
 }
@@ -1227,7 +1226,7 @@ class BinOpMIF_RF<bits<8> o, string m, X86TypeInfo t, SDNode node, Format f>
 class BinOpMIF_MF<bits<8> o, string m, X86TypeInfo t, SDNode node, Format f>
   : BinOpMI<o, m, binop_args, t, f, (outs),
             [(store (node (t.VT (load addr:$src1)),
-             t.ImmOperator:$src2, EFLAGS), addr:$src1), (implicit EFLAGS)]>,
+             t.ImmOperator:$src2, EFLAGS), addr:$src1)]>,
     Sched<[WriteADCRMW]>, DefEFLAGS, UseEFLAGS {
   let mayStore = 1;
 }
@@ -1348,8 +1347,8 @@ class UnaryOpR_RF<bits<8> o, Format f, string m, X86TypeInfo t,
                   SDPatternOperator node = null_frag, bit ndd = 0>
   : UnaryOpR<o, f, m, !if(!eq(ndd, 0), unaryop_args, unaryop_ndd_args), t,
              (outs t.RegClass:$dst),
-             [(set t.RegClass:$dst, (node t.RegClass:$src1)),
-              (implicit EFLAGS)]>, DefEFLAGS, NDD<ndd>;
+             [(set t.RegClass:$dst, (node t.RegClass:$src1))]>,
+    DefEFLAGS, NDD<ndd>;
 
 // UnaryOpM - Instructions that read "[mem]".
 class UnaryOpM<bits<8> o, Format f, string m, string args, X86TypeInfo t,
@@ -1381,7 +1380,7 @@ class UnaryOpM_M<bits<8> o, Format f, string m, X86TypeInfo t,
 class UnaryOpM_MF<bits<8> o, Format f, string m, X86TypeInfo t,
                   SDPatternOperator node = null_frag>
   : UnaryOpM<o, f, m, unaryop_args, t, (outs),
-             [(store (node (t.LoadNode addr:$src1)), addr:$src1),
-              (implicit EFLAGS)]>, Sched<[WriteALURMW]>, DefEFLAGS {
+             [(store (node (t.LoadNode addr:$src1)), addr:$src1)]>,
+    Sched<[WriteALURMW]>, DefEFLAGS {
   let mayStore = 1;
 }

--- a/llvm/test/CodeGen/X86/GlobalISel/select-blsi.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-blsi.mir
@@ -27,9 +27,8 @@ body:             |
     ; CHECK: liveins: $edi
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gr32 = COPY $edi
-    ; CHECK-NEXT: [[MOV32r0_:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
-    ; CHECK-NEXT: [[SUB32rr:%[0-9]+]]:gr32 = SUB32rr [[MOV32r0_]], [[COPY]], implicit-def dead $eflags
-    ; CHECK-NEXT: [[AND32rr:%[0-9]+]]:gr32 = AND32rr [[SUB32rr]], [[COPY]], implicit-def dead $eflags
+    ; CHECK-NEXT: [[NEG32r:%[0-9]+]]:gr32 = NEG32r [[COPY]], implicit-def dead $eflags
+    ; CHECK-NEXT: [[AND32rr:%[0-9]+]]:gr32 = AND32rr [[NEG32r]], [[COPY]], implicit-def dead $eflags
     ; CHECK-NEXT: $edi = COPY [[AND32rr]]
     %0(s32) = COPY $edi
     %1(s32) = G_CONSTANT i32 0
@@ -58,8 +57,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gr32 = COPY $edi
     ; CHECK-NEXT: [[MOV32r0_:%[0-9]+]]:gr32 = MOV32r0 implicit-def dead $eflags
-    ; CHECK-NEXT: [[SUB32ri:%[0-9]+]]:gr32 = SUB32ri [[MOV32r0_]], 0, implicit-def dead $eflags
-    ; CHECK-NEXT: [[AND32rr:%[0-9]+]]:gr32 = AND32rr [[SUB32ri]], [[COPY]], implicit-def dead $eflags
+    ; CHECK-NEXT: [[NEG32r:%[0-9]+]]:gr32 = NEG32r [[MOV32r0_]], implicit-def dead $eflags
+    ; CHECK-NEXT: [[AND32rr:%[0-9]+]]:gr32 = AND32rr [[NEG32r]], [[COPY]], implicit-def dead $eflags
     ; CHECK-NEXT: $edi = COPY [[AND32rr]]
     %0(s32) = COPY $edi
     %1(s32) = G_CONSTANT i32 0

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -1838,7 +1838,7 @@ MVT::SimpleValueType SDNodeInfo::getKnownType(unsigned ResNo) const {
 
 static unsigned GetNumNodeResults(const Record *Operator,
                                   CodeGenDAGPatterns &CDP) {
-  if (Operator->getName() == "set" || Operator->getName() == "implicit")
+  if (Operator->getName() == "set")
     return 0; // All return nothing.
 
   if (Operator->isSubClassOf("Intrinsic"))
@@ -2945,8 +2945,7 @@ TreePatternNodePtr TreePattern::ParseTreePattern(const Init *TheInit,
       !Operator->isSubClassOf("Instruction") &&
       !Operator->isSubClassOf("SDNodeXForm") &&
       !Operator->isSubClassOf("Intrinsic") &&
-      !Operator->isSubClassOf("ComplexPattern") &&
-      Operator->getName() != "set" && Operator->getName() != "implicit")
+      !Operator->isSubClassOf("ComplexPattern") && Operator->getName() != "set")
     error("Unrecognized node '" + Operator->getName() + "'!");
 
   //  Check to see if this is something that is illegal in an input pattern.
@@ -3453,21 +3452,6 @@ void CodeGenDAGPatterns::FindPatternInputsAndOutputs(
     bool isUse = HandleUse(I, Pat, InstInputs);
     if (!isUse && Pat->getTransformFn())
       I.error("Cannot specify a transform function for a non-input value!");
-    return;
-  }
-
-  if (Pat->getOperator()->getName() == "implicit") {
-    for (unsigned i = 0, e = Pat->getNumChildren(); i != e; ++i) {
-      TreePatternNode &Dest = Pat->getChild(i);
-      if (!Dest.isLeaf())
-        I.error("implicitly defined value should be a register!");
-
-      const DefInit *Val = dyn_cast<DefInit>(Dest.getLeafValue());
-      if (!Val || !Val->getDef()->isSubClassOf("Register"))
-        I.error("implicitly defined value should be a register!");
-      if (Val)
-        InstImpResults.push_back(Val->getDef());
-    }
     return;
   }
 

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -902,8 +902,6 @@ void MatcherGen::EmitResultInstructionAsOperand(
   // If this is the root instruction of a pattern that has physical registers in
   // its result pattern, add output VTs for them.  For example, X86 has:
   //   (set AL, (mul ...))
-  // This also handles implicit results like:
-  //   (implicit EFLAGS)
   if (isRoot && !Pattern.getDstRegs().empty()) {
     // If the root came from an implicit def in the instruction handling stuff,
     // don't re-add it.
@@ -1038,7 +1036,7 @@ void MatcherGen::EmitResultCode() {
   //
   unsigned NumSrcResults = Pattern.getSrcPattern().getNumTypes();
 
-  // If the pattern also has (implicit) results, count them as well.
+  // If the pattern also has implicit results, count them as well.
   if (!Pattern.getDstRegs().empty()) {
     // If the root came from an implicit def in the instruction handling stuff,
     // don't re-add it.


### PR DESCRIPTION
The node was introduced in 59c39dc1 and was intended to allow writing patterns like this:
`[(set AL, (mul AL, GR8:$src1)), (implicit EFLAGS)]`

However, it does not introduce new functionality because the same pattern can be equivalently expressed as:
`[(set AL, EFLAGS, (mul AL, GR8:$src1))]`

The latter form is also more flexible as it allows reordering output operands.

In most places uses of `implicit` were redundant -- removing them didn't change anything in the generated DAG tables. The only three cases where it did have effect are in X86InstrArithmetic.td and X86InstrSystem.td -- those were rewritten to use `set` node.

Removing `implicit` from some patterns made them importable by GISel, hence the change in a test.