### PR TITLE
[compiler-rt][RISCV] Avoid using __init_riscv_feature_bits as a direc…

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/riscv.c
+++ b/compiler-rt/lib/builtins/cpu_model/riscv.c
@@ -344,7 +344,7 @@ static void __init_riscv_feature_bits_ctor(void) CONSTRUCTOR_ATTRIBUTE;
 // run before constructors without the priority set.  However, it still runs
 // after ifunc initializers and needs to be called explicitly there.
 
-static void CONSTRUCTOR_ATTRIBUTE __init_riscv_feature_bits_ctor (void) {
+static void CONSTRUCTOR_ATTRIBUTE __init_riscv_feature_bits_ctor(void) {
   __init_riscv_feature_bits(0);
 }
 

--- a/compiler-rt/lib/builtins/cpu_model/riscv.c
+++ b/compiler-rt/lib/builtins/cpu_model/riscv.c
@@ -335,7 +335,8 @@ static void initRISCVFeature(struct riscv_hwprobe Hwprobes[]) {
 
 static int FeaturesBitCached = 0;
 
-void __init_riscv_feature_bits(void *) CONSTRUCTOR_ATTRIBUTE;
+void __init_riscv_feature_bits(void *);
+static void __init_riscv_feature_bits_ctor(void) CONSTRUCTOR_ATTRIBUTE;
 
 // A constructor function that sets __riscv_feature_bits, and
 // __riscv_vendor_feature_bits to the right values.  This needs to run
@@ -343,10 +344,14 @@ void __init_riscv_feature_bits(void *) CONSTRUCTOR_ATTRIBUTE;
 // run before constructors without the priority set.  However, it still runs
 // after ifunc initializers and needs to be called explicitly there.
 
+static void CONSTRUCTOR_ATTRIBUTE __init_riscv_feature_bits_ctor (void) {
+  __init_riscv_feature_bits(0);
+}
+
 // PlatformArgs allows the platform to provide pre-computed data and access it
 // without extra effort. For example, Linux could pass the vDSO object to avoid
 // an extra system call.
-void CONSTRUCTOR_ATTRIBUTE __init_riscv_feature_bits(void *PlatformArgs) {
+void __init_riscv_feature_bits(void *PlatformArgs) {
 
   if (FeaturesBitCached)
     return;


### PR DESCRIPTION
…t constructor

`__init_riscv_feature_bits` takes an argument that can be platform-specific, potentially pointing to the VDSO address of the hwprobe system call for Linux. However, marking it as a constructor does not guarantee that 0/NULL will always be passed to this argument, which may result in treating an uninitialized or garbage value as a pointer to hwprobe, leading to a crash.

The simplest solution is to introduce a small constructor function to ensure that the platform-specific argument is set to 0/NULL.