### PR TITLE
[lldb] Relax check for breakpoint site in Unwind/windows-unaligned-x86_64.test

### DIFF
--- a/lldb/test/Shell/Unwind/windows-unaligned-x86_64.test
+++ b/lldb/test/Shell/Unwind/windows-unaligned-x86_64.test
@@ -17,7 +17,7 @@ breakpoint set -n func
 # CHECK: Breakpoint 1: where = {{.*}}`{{(::)?}}func
 
 process launch
-# CHECK: stop reason = breakpoint 1.1
+# CHECK: stop reason = breakpoint 1
 
 thread backtrace
 # CHECK: frame #0: {{.*}}`{{(::)?}}func


### PR DESCRIPTION
This test checks the thread backtrace for entries of intermediate frames that aren't aligned to 16 bytes. In order to do that, it sets a single breakpoint and makes sure we stop there. It seems sufficient, however, to check that we hit the breakpoint itself and not which particular site.