### PR TITLE
[C2y] Add conformance test for WG14 N3364

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -286,6 +286,11 @@ C2y Feature Support
   language modes but is now rejected (all of the other qualifiers and storage
   class specifiers were previously rejected).
 
+- Updated conformance for `N3364 <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3364.pdf>`_
+  on floating-point translation-time initialization with signaling NaN. This
+  paper adopts Clang's existing practice, so there were no changes to compiler
+  behavior.
+
 C23 Feature Support
 ^^^^^^^^^^^^^^^^^^^
 

--- a/clang/test/C/C2y/n3364.c
+++ b/clang/test/C/C2y/n3364.c
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic -emit-llvm -o - %s
+// RUN: %clang_cc1 -verify -Wall -pedantic -emit-llvm -o - %s
+// expected-no-diagnostics
+
+/* WG14 N3364: Yes
+ * Give consistent wording for SNAN initialization v3
+ *
+ * Ensure that initializing from a signaling NAN (optionally with a unary + or
+ * -) at translation time behaves correctly at runtime.
+ */
+
+#define FLT_SNAN __builtin_nansf("1")
+#define DBL_SNAN __builtin_nans("1")
+#define LD_SNAN __builtin_nansl("1")
+
+float f1 = FLT_SNAN;
+float f2 = +FLT_SNAN;
+float f3 = -FLT_SNAN;
+// CHECK: @f1 = {{.*}}global float 0x7FF0000020000000
+// CHECK: @f2 = {{.*}}global float 0x7FF0000020000000
+// CHECK: @f3 = {{.*}}global float 0xFFF0000020000000
+
+double d1 = DBL_SNAN;
+double d2 = +DBL_SNAN;
+double d3 = -DBL_SNAN;
+// CHECK: @d1 = {{.*}}global double 0x7FF0000000000001
+// CHECK: @d2 = {{.*}}global double 0x7FF0000000000001
+// CHECK: @d3 = {{.*}}global double 0xFFF0000000000001
+
+long double ld1 = LD_SNAN;
+long double ld2 = +LD_SNAN;
+long double ld3 = -LD_SNAN;
+// CHECK: @ld1 = {{.*}}global {{double 0x7FF0000000000001|x86_fp80 0xK7FFF8000000000000001|fp128 0xL00000000000000017FFF000000000000}}
+// CHECK: @ld2 = {{.*}}global {{double 0x7FF0000000000001|x86_fp80 0xK7FFF8000000000000001|fp128 0xL00000000000000017FFF000000000000}}
+// CHECK: @ld3 = {{.*}}global {{double 0xFFF0000000000001|x86_fp80 0xKFFFF8000000000000001|fp128 0xL0000000000000001FFFF000000000000}}

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -231,7 +231,7 @@ conformance.</p>
     <tr>
       <td>Give consistent wording for SNAN initialization v3</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3364.pdf">N3364</a></td>
-      <td class="unknown" align="center">Unknown</td>
+      <td class="full" align="center">Yes</td>
     </tr>
     <tr>
       <td>Case range expressions v3.1</td>


### PR DESCRIPTION
This paper is defining the translation-time behavior of initialization with a signaling NaN. Clang has always supported the correct behavior.