### PR TITLE
[Flang] [Semantics] [OpenMP] Added missing semantic check with nested target region.

### DIFF
--- a/flang/test/Semantics/OpenMP/nested-simd.f90
+++ b/flang/test/Semantics/OpenMP/nested-simd.f90
@@ -166,6 +166,7 @@ SUBROUTINE NESTED_BAD(N)
       end do
       !$omp end task
       !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct, the `SCAN` construct and the `ORDERED` construct with the `SIMD` clause.
+      !ERROR: If TARGET directive is nested inside TARGET SIMD region, the behaviour is unspecified
       !$omp target 
       do J = 1, N
         K = 2

--- a/flang/test/Semantics/OpenMP/nested-simd.f90
+++ b/flang/test/Semantics/OpenMP/nested-simd.f90
@@ -166,7 +166,6 @@ SUBROUTINE NESTED_BAD(N)
       end do
       !$omp end task
       !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct, the `SCAN` construct and the `ORDERED` construct with the `SIMD` clause.
-      !ERROR: If TARGET directive is nested inside TARGET SIMD region, the behaviour is unspecified
       !$omp target 
       do J = 1, N
         K = 2

--- a/flang/test/Semantics/OpenMP/nested-target.f90
+++ b/flang/test/Semantics/OpenMP/nested-target.f90
@@ -5,7 +5,7 @@
 ! 2.12.5 Target Construct
 
 program main
-  integer :: i, j, N = 10
+  integer :: i, j, N = 10, n1, n2, res(100)
   real :: a, arrayA(512), arrayB(512), ai(10)
   real, allocatable :: B(:)
 
@@ -49,5 +49,18 @@ program main
   !$omp target exit data map(delete:B)
   !$omp end target
   deallocate(B)
+
+  n1 = 10
+  n2 = 10
+  !$omp target teams map(to:a)
+  !PORTABILITY: If TARGET DATA directive is nested inside TARGET TEAMS region, the behaviour is unspecified
+  !$omp target data map(n1,n2)
+  do i=1, n1
+     do j=1, n2
+      res((i-1)*10+j) = i*j
+     end do
+  end do
+  !$omp end target data
+  !$omp end target teams
 
 end program main

--- a/flang/test/Semantics/OpenMP/nested-target.f90
+++ b/flang/test/Semantics/OpenMP/nested-target.f90
@@ -63,4 +63,15 @@ program main
   !$omp end target data
   !$omp end target teams
 
+  !$omp target teams map(to:a) map(from:n1,n2)
+  !PORTABILITY: If TARGET TEAMS DISTRIBUTE PARALLEL DO directive is nested inside TARGET region, the behaviour is unspecified
+  !$omp target teams distribute parallel do
+  do i=1, n1
+     do j=1, n2
+      res((i-1)*10+j) = i*j
+     end do
+  end do
+  !$omp end target teams distribute parallel do
+  !$omp end target teams
+
 end program main

--- a/flang/test/Semantics/OpenMP/nested-target.f90
+++ b/flang/test/Semantics/OpenMP/nested-target.f90
@@ -53,7 +53,7 @@ program main
   n1 = 10
   n2 = 10
   !$omp target teams map(to:a)
-  !PORTABILITY: If TARGET DATA directive is nested inside TARGET TEAMS region, the behaviour is unspecified
+  !PORTABILITY: If TARGET DATA directive is nested inside TARGET region, the behaviour is unspecified
   !$omp target data map(n1,n2)
   do i=1, n1
      do j=1, n2


### PR DESCRIPTION
Issue semantic warning for any combination of nested OMP TARGET directives inside another OMP TARGET region.

This change would not affect OMP TARGET inside an OMP TARGET DATA. However, it issues warning for OMP TARGET DATA inside an OMP TARGET region.