### PR TITLE
[FMV] Remove feature dgh.

### DIFF
--- a/clang/test/CodeGen/aarch64-cpu-supports-target.c
+++ b/clang/test/CodeGen/aarch64-cpu-supports-target.c
@@ -7,7 +7,7 @@ int check_all_feature() {
     return 2;
   else if (__builtin_cpu_supports("aes+pmull+fp16+dit+dpb+dpb2+jscvt"))
     return 3;
-  else if (__builtin_cpu_supports("fcma+rcpc+rcpc2+rcpc3+frintts+dgh"))
+  else if (__builtin_cpu_supports("fcma+rcpc+rcpc2+rcpc3+frintts"))
     return 4;
   else if (__builtin_cpu_supports("i8mm+bf16+sve"))
     return 5;

--- a/clang/test/CodeGen/aarch64-fmv-dependencies.c
+++ b/clang/test/CodeGen/aarch64-fmv-dependencies.c
@@ -15,9 +15,6 @@ __attribute__((target_version("bti"))) int fmv(void) { return 0; }
 // CHECK: define dso_local i32 @fmv._Mcrc() #[[crc:[0-9]+]] {
 __attribute__((target_version("crc"))) int fmv(void) { return 0; }
 
-// CHECK: define dso_local i32 @fmv._Mdgh() #[[ATTR0:[0-9]+]] {
-__attribute__((target_version("dgh"))) int fmv(void) { return 0; }
-
 // CHECK: define dso_local i32 @fmv._Mdit() #[[dit:[0-9]+]] {
 __attribute__((target_version("dit"))) int fmv(void) { return 0; }
 
@@ -157,7 +154,6 @@ int caller() {
 // CHECK: attributes #[[bf16]] = { {{.*}} "target-features"="+bf16,+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[bti]] = { {{.*}} "target-features"="+bti,+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[crc]] = { {{.*}} "target-features"="+crc,+fp-armv8,+neon,+outline-atomics,+v8a"
-// CHECK: attributes #[[ATTR0]] = { {{.*}} "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[dit]] = { {{.*}} "target-features"="+dit,+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[dotprod]] = { {{.*}} "target-features"="+dotprod,+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[dpb]] = { {{.*}} "target-features"="+ccpp,+fp-armv8,+neon,+outline-atomics,+v8a"
@@ -167,6 +163,7 @@ int caller() {
 // CHECK: attributes #[[fcma]] = { {{.*}} "target-features"="+complxnum,+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[flagm]] = { {{.*}} "target-features"="+flagm,+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[flagm2]] = { {{.*}} "target-features"="+altnzcv,+flagm,+fp-armv8,+neon,+outline-atomics,+v8a"
+// CHECK: attributes #[[ATTR0]] = { {{.*}} "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[fp16]] = { {{.*}} "target-features"="+fp-armv8,+fullfp16,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[fp16fml]] = { {{.*}} "target-features"="+fp-armv8,+fp16fml,+fullfp16,+neon,+outline-atomics,+v8a"
 // CHECK: attributes #[[frintts]] = { {{.*}} "target-features"="+fp-armv8,+fptoint,+neon,+outline-atomics,+v8a"

--- a/clang/test/CodeGen/attr-target-version.c
+++ b/clang/test/CodeGen/attr-target-version.c
@@ -17,7 +17,6 @@ int __attribute__((target_version("dpb"))) fmv_one(void) { return 2; }
 int __attribute__((target_version("default"))) fmv_one(void) { return 0; }
 int __attribute__((target_version("fp"))) fmv_two(void) { return 1; }
 int __attribute__((target_version("simd"))) fmv_two(void) { return 2; }
-int __attribute__((target_version("dgh"))) fmv_two(void) { return 3; }
 int __attribute__((target_version("fp16+simd"))) fmv_two(void) { return 4; }
 int __attribute__((target_version("default"))) fmv_two(void) { return 0; }
 int foo() {
@@ -252,13 +251,6 @@ int caller(void) { return used_def_without_default_decl() + used_decl_without_de
 // CHECK-SAME: () #[[ATTR12]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i32 2
-//
-//
-// CHECK: Function Attrs: noinline nounwind optnone
-// CHECK-LABEL: define {{[^@]+}}@fmv_two._Mdgh
-// CHECK-SAME: () #[[ATTR9]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i32 3
 //
 //
 // CHECK: Function Attrs: noinline nounwind optnone
@@ -576,29 +568,21 @@ int caller(void) { return used_def_without_default_decl() + used_decl_without_de
 // CHECK-NEXT:    ret ptr @fmv_two._Mfp16Msimd
 // CHECK:       resolver_else:
 // CHECK-NEXT:    [[TMP4:%.*]] = load i64, ptr @__aarch64_cpu_features, align 8
-// CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], 33554432
-// CHECK-NEXT:    [[TMP6:%.*]] = icmp eq i64 [[TMP5]], 33554432
+// CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], 512
+// CHECK-NEXT:    [[TMP6:%.*]] = icmp eq i64 [[TMP5]], 512
 // CHECK-NEXT:    [[TMP7:%.*]] = and i1 true, [[TMP6]]
 // CHECK-NEXT:    br i1 [[TMP7]], label [[RESOLVER_RETURN1:%.*]], label [[RESOLVER_ELSE2:%.*]]
 // CHECK:       resolver_return1:
-// CHECK-NEXT:    ret ptr @fmv_two._Mdgh
+// CHECK-NEXT:    ret ptr @fmv_two._Msimd
 // CHECK:       resolver_else2:
 // CHECK-NEXT:    [[TMP8:%.*]] = load i64, ptr @__aarch64_cpu_features, align 8
-// CHECK-NEXT:    [[TMP9:%.*]] = and i64 [[TMP8]], 512
-// CHECK-NEXT:    [[TMP10:%.*]] = icmp eq i64 [[TMP9]], 512
+// CHECK-NEXT:    [[TMP9:%.*]] = and i64 [[TMP8]], 256
+// CHECK-NEXT:    [[TMP10:%.*]] = icmp eq i64 [[TMP9]], 256
 // CHECK-NEXT:    [[TMP11:%.*]] = and i1 true, [[TMP10]]
 // CHECK-NEXT:    br i1 [[TMP11]], label [[RESOLVER_RETURN3:%.*]], label [[RESOLVER_ELSE4:%.*]]
 // CHECK:       resolver_return3:
-// CHECK-NEXT:    ret ptr @fmv_two._Msimd
-// CHECK:       resolver_else4:
-// CHECK-NEXT:    [[TMP12:%.*]] = load i64, ptr @__aarch64_cpu_features, align 8
-// CHECK-NEXT:    [[TMP13:%.*]] = and i64 [[TMP12]], 256
-// CHECK-NEXT:    [[TMP14:%.*]] = icmp eq i64 [[TMP13]], 256
-// CHECK-NEXT:    [[TMP15:%.*]] = and i1 true, [[TMP14]]
-// CHECK-NEXT:    br i1 [[TMP15]], label [[RESOLVER_RETURN5:%.*]], label [[RESOLVER_ELSE6:%.*]]
-// CHECK:       resolver_return5:
 // CHECK-NEXT:    ret ptr @fmv_two._Mfp
-// CHECK:       resolver_else6:
+// CHECK:       resolver_else4:
 // CHECK-NEXT:    ret ptr @fmv_two.default
 //
 //

--- a/clang/test/Sema/aarch64-cpu-supports.c
+++ b/clang/test/Sema/aarch64-cpu-supports.c
@@ -15,7 +15,7 @@ int test_aarch64_features(void) {
   if (__builtin_cpu_supports("sve2,sve"))
     return 4;
   // expected-warning@+1 {{invalid cpu feature string}}
-  if (__builtin_cpu_supports("dgh+sve2-pmull"))
+  if (__builtin_cpu_supports("aes+sve2-pmull"))
     return 5;
   // expected-warning@+1 {{invalid cpu feature string}}
   if (__builtin_cpu_supports("default"))

--- a/clang/test/Sema/attr-target-clones-aarch64.c
+++ b/clang/test/Sema/attr-target-clones-aarch64.c
@@ -19,10 +19,9 @@ int __attribute__((target_clones("sve+dotprod"))) redecl3(void);
 int redecl3(void);
 
 int __attribute__((target_clones("rng", "fp16fml+fp", "default"))) redecl4(void);
-// expected-error@+3 {{'target_clones' attribute does not match previous declaration}}
+// expected-error@+2 {{'target_clones' attribute does not match previous declaration}}
 // expected-note@-2 {{previous declaration is here}}
-// expected-warning@+1 {{version list contains entries that don't impact code generation}}
-int __attribute__((target_clones("dgh", "bf16+dpb", "default"))) redecl4(void) { return 1; }
+int __attribute__((target_clones("dit", "bf16+dpb", "default"))) redecl4(void) { return 1; }
 
 int __attribute__((target_version("flagm2"))) redef2(void) { return 1; }
 // expected-error@+2 {{multiversioned function redeclarations require identical target attributes}}

--- a/compiler-rt/lib/builtins/cpu_model/AArch64CPUFeatures.inc
+++ b/compiler-rt/lib/builtins/cpu_model/AArch64CPUFeatures.inc
@@ -47,7 +47,7 @@ enum CPUFeatures {
   FEAT_RCPC,
   FEAT_RCPC2,
   FEAT_FRINTTS,
-  FEAT_DGH,
+  RESERVED_FEAT_DGH, // previously used and now ABI legacy
   FEAT_I8MM,
   FEAT_BF16,
   RESERVED_FEAT_EBF16, // previously used and now ABI legacy

--- a/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/mrs.inc
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64/fmv/mrs.inc
@@ -61,8 +61,6 @@ static void __init_cpu_features_constructor(unsigned long hwcap,
     setCPUFeature(FEAT_RNG);
   if (hwcap2 & HWCAP2_I8MM)
     setCPUFeature(FEAT_I8MM);
-  if (hwcap2 & HWCAP2_DGH)
-    setCPUFeature(FEAT_DGH);
   if (hwcap2 & HWCAP2_FRINT)
     setCPUFeature(FEAT_FRINTTS);
   if (hwcap2 & HWCAP2_SVEF32MM)

--- a/llvm/include/llvm/TargetParser/AArch64CPUFeatures.inc
+++ b/llvm/include/llvm/TargetParser/AArch64CPUFeatures.inc
@@ -47,7 +47,7 @@ enum CPUFeatures {
   FEAT_RCPC,
   FEAT_RCPC2,
   FEAT_FRINTTS,
-  FEAT_DGH,
+  RESERVED_FEAT_DGH, // previously used and now ABI legacy
   FEAT_I8MM,
   FEAT_BF16,
   RESERVED_FEAT_EBF16, // previously used and now ABI legacy

--- a/llvm/lib/Target/AArch64/AArch64FMV.td
+++ b/llvm/lib/Target/AArch64/AArch64FMV.td
@@ -41,7 +41,6 @@ def : FMVExtension<"aes", "FEAT_PMULL", "+aes,+fp-armv8,+neon", 150>;
 def : FMVExtension<"bf16", "FEAT_BF16", "+bf16", 280>;
 def : FMVExtension<"bti", "FEAT_BTI", "+bti", 510>;
 def : FMVExtension<"crc", "FEAT_CRC", "+crc", 110>;
-def : FMVExtension<"dgh", "FEAT_DGH", "", 260>;
 def : FMVExtension<"dit", "FEAT_DIT", "+dit", 180>;
 def : FMVExtension<"dotprod", "FEAT_DOTPROD", "+dotprod,+fp-armv8,+neon", 104>;
 def : FMVExtension<"dpb", "FEAT_DPB", "+ccpp", 190>;


### PR DESCRIPTION
It belongs to the HINT space so it can be executed as NOP if the hardware doesn't support it.

Reviewed in ACLE -> https://github.com/ARM-software/acle/pull/357