### PR TITLE
[OpenACC] Implement `loop` restrictions on `for` loops.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12735,6 +12735,19 @@ def err_acc_gang_reduction_numgangs_conflict
 def err_reduction_op_mismatch
     : Error<"OpenACC 'reduction' variable must have the same operator in all "
             "nested constructs (%0 vs %1)">;
+def err_acc_loop_variable_type
+    : Error<"loop variable of loop associated with an OpenACC 'loop' construct "
+            "must be of integer, pointer, or random-access-iterator type (is "
+            "%0)">;
+def err_acc_loop_variable
+    : Error<"OpenACC 'loop' construct must have initialization clause in "
+            "canonical form ('var = init' or 'T var = init')">;
+def err_acc_loop_terminating_condition
+    : Error<"OpenACC 'loop' construct must have a terminating condition">;
+def err_acc_loop_not_monotonic
+    : Error<"OpenACC 'loop' variable must monotonically increase or decrease "
+            "('++', '--', or compound assignment)">;
+
 // AMDGCN builtins diagnostics
 def err_amdgcn_global_load_lds_size_invalid_value : Error<"invalid size value">;
 def note_amdgcn_global_load_lds_size_valid_value : Note<"size must be 1, 2, or 4">;

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -1498,14 +1498,15 @@ StmtResult Parser::ParseOpenACCDirectiveStmt() {
     return StmtError();
 
   StmtResult AssocStmt;
-  SemaOpenACC::AssociatedStmtRAII AssocStmtRAII(
-      getActions().OpenACC(), DirInfo.DirKind, {}, DirInfo.Clauses);
+  SemaOpenACC::AssociatedStmtRAII AssocStmtRAII(getActions().OpenACC(),
+                                                DirInfo.DirKind, DirInfo.DirLoc,
+                                                {}, DirInfo.Clauses);
   if (doesDirectiveHaveAssociatedStmt(DirInfo.DirKind)) {
     ParsingOpenACCDirectiveRAII DirScope(*this, /*Value=*/false);
     ParseScope ACCScope(this, getOpenACCScopeFlags(DirInfo.DirKind));
 
     AssocStmt = getActions().OpenACC().ActOnAssociatedStmt(
-        DirInfo.StartLoc, DirInfo.DirKind, ParseStatement());
+        DirInfo.StartLoc, DirInfo.DirKind, DirInfo.Clauses, ParseStatement());
   }
 
   return getActions().OpenACC().ActOnEndStmtDirective(

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2360,7 +2360,11 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc) {
   // OpenACC Restricts a for-loop inside of certain construct/clause
   // combinations, so diagnose that here in OpenACC mode.
   SemaOpenACC::LoopInConstructRAII LCR{getActions().OpenACC()};
-  getActions().OpenACC().ActOnForStmtBegin(ForLoc);
+  if (ForRangeInfo.ParsedForRangeDecl())
+    getActions().OpenACC().ActOnRangeForStmtBegin(ForLoc, ForRangeStmt.get());
+  else
+    getActions().OpenACC().ActOnForStmtBegin(
+        ForLoc, FirstPart.get(), SecondPart.get().second, ThirdPart.get());
 
   // C99 6.8.5p5 - In C99, the body of the for statement is a scope, even if
   // there is no compound stmt.  C90 does not have this clause.  We only do this

--- a/clang/lib/Sema/SemaOpenACC.cpp
+++ b/clang/lib/Sema/SemaOpenACC.cpp
@@ -1520,13 +1520,14 @@ void CollectActiveReductionClauses(
 SemaOpenACC::SemaOpenACC(Sema &S) : SemaBase(S) {}
 
 SemaOpenACC::AssociatedStmtRAII::AssociatedStmtRAII(
-    SemaOpenACC &S, OpenACCDirectiveKind DK,
+    SemaOpenACC &S, OpenACCDirectiveKind DK, SourceLocation DirLoc,
     ArrayRef<const OpenACCClause *> UnInstClauses,
     ArrayRef<OpenACCClause *> Clauses)
     : SemaRef(S), OldActiveComputeConstructInfo(S.ActiveComputeConstructInfo),
       DirKind(DK), OldLoopGangClauseOnKernelLoc(S.LoopGangClauseOnKernelLoc),
       OldLoopWorkerClauseLoc(S.LoopWorkerClauseLoc),
       OldLoopVectorClauseLoc(S.LoopVectorClauseLoc),
+      OldLoopWithoutSeqLoc(S.LoopWithoutSeqLoc),
       ActiveReductionClauses(S.ActiveReductionClauses),
       LoopRAII(SemaRef, /*PreserveDepth=*/false) {
 
@@ -1548,10 +1549,18 @@ SemaOpenACC::AssociatedStmtRAII::AssociatedStmtRAII(
     SemaRef.LoopGangClauseOnKernelLoc = {};
     SemaRef.LoopWorkerClauseLoc = {};
     SemaRef.LoopVectorClauseLoc = {};
+    SemaRef.LoopWithoutSeqLoc = {};
   } else if (DirKind == OpenACCDirectiveKind::Loop) {
     CollectActiveReductionClauses(S.ActiveReductionClauses, Clauses);
     SetCollapseInfoBeforeAssociatedStmt(UnInstClauses, Clauses);
     SetTileInfoBeforeAssociatedStmt(UnInstClauses, Clauses);
+
+    // Set the active 'loop' location if there isn't a 'seq' on it, so we can
+    // diagnose the for loops.
+    SemaRef.LoopWithoutSeqLoc = {};
+    if (Clauses.end() ==
+        llvm::find_if(Clauses, llvm::IsaPred<OpenACCSeqClause>))
+      SemaRef.LoopWithoutSeqLoc = DirLoc;
 
     // OpenACC 3.3 2.9.2: When the parent compute construct is a kernels
     // construct, the gang clause behaves as follows. ... The region of a loop
@@ -1653,6 +1662,7 @@ SemaOpenACC::AssociatedStmtRAII::~AssociatedStmtRAII() {
   SemaRef.LoopGangClauseOnKernelLoc = OldLoopGangClauseOnKernelLoc;
   SemaRef.LoopWorkerClauseLoc = OldLoopWorkerClauseLoc;
   SemaRef.LoopVectorClauseLoc = OldLoopVectorClauseLoc;
+  SemaRef.LoopWithoutSeqLoc = OldLoopWithoutSeqLoc;
   SemaRef.ActiveReductionClauses.swap(ActiveReductionClauses);
 
   if (DirKind == OpenACCDirectiveKind::Parallel ||
@@ -2573,14 +2583,15 @@ void SemaOpenACC::ActOnDoStmt(SourceLocation DoLoc) {
   }
 }
 
-void SemaOpenACC::ActOnForStmtBegin(SourceLocation ForLoc) {
-  if (!getLangOpts().OpenACC)
-    return;
+void SemaOpenACC::ForStmtBeginHelper(SourceLocation ForLoc,
+                                     ForStmtBeginChecker &C) {
+  assert(getLangOpts().OpenACC && "Check enabled when not OpenACC?");
 
   // Enable the while/do-while checking.
   LoopInfo.TopLevelLoopSeen = true;
 
   if (CollapseInfo.CurCollapseCount && *CollapseInfo.CurCollapseCount > 0) {
+    C.check();
 
     // OpenACC 3.3 2.9.1:
     // Each associated loop, except the innermost, must contain exactly one loop
@@ -2604,6 +2615,8 @@ void SemaOpenACC::ActOnForStmtBegin(SourceLocation ForLoc) {
   }
 
   if (TileInfo.CurTileCount && *TileInfo.CurTileCount > 0) {
+    C.check();
+
     if (LoopInfo.CurLevelHasLoopAlready) {
       Diag(ForLoc, diag::err_acc_clause_multiple_loops) << /*Tile*/ 1;
       assert(TileInfo.ActiveTile && "No tile object?");
@@ -2622,6 +2635,431 @@ void SemaOpenACC::ActOnForStmtBegin(SourceLocation ForLoc) {
   // Set this to 'false' for the body of this loop, so that the next level
   // checks independently.
   LoopInfo.CurLevelHasLoopAlready = false;
+}
+
+namespace {
+bool isValidLoopVariableType(QualType LoopVarTy) {
+  // Just skip if it is dependent, it could be any of the below.
+  if (LoopVarTy->isDependentType())
+    return true;
+
+  // The loop variable must be of integer,
+  if (LoopVarTy->isIntegerType())
+    return true;
+
+  // C/C++ pointer,
+  if (LoopVarTy->isPointerType())
+    return true;
+
+  // or C++ random-access iterator type.
+  if (const auto *RD = LoopVarTy->getAsCXXRecordDecl()) {
+    // Note: Only do CXXRecordDecl because RecordDecl can't be a random access
+    // iterator type!
+
+    // We could either do a lot of work to see if this matches
+    // random-access-iterator, but it seems that just checking that the
+    // 'iterator_category' typedef is more than sufficient. If programmers are
+    // willing to lie about this, we can let them.
+
+    for (const auto *TD :
+         llvm::make_filter_range(RD->decls(), llvm::IsaPred<TypedefNameDecl>)) {
+      const auto *TDND = cast<TypedefNameDecl>(TD)->getCanonicalDecl();
+
+      if (TDND->getName() != "iterator_category")
+        continue;
+
+      // If there is no type for this decl, return false.
+      if (TDND->getUnderlyingType().isNull())
+        return false;
+
+      const CXXRecordDecl *ItrCategoryDecl =
+          TDND->getUnderlyingType()->getAsCXXRecordDecl();
+
+      // If the category isn't a record decl, it isn't the tag type.
+      if (!ItrCategoryDecl)
+        return false;
+
+      auto IsRandomAccessIteratorTag = [](const CXXRecordDecl *RD) {
+        if (RD->getName() != "random_access_iterator_tag")
+          return false;
+        // Checks just for std::random_access_iterator_tag.
+        return RD->getEnclosingNamespaceContext()->isStdNamespace();
+      };
+
+      if (IsRandomAccessIteratorTag(ItrCategoryDecl))
+        return true;
+
+      // We can also support types inherited from the
+      // random_access_iterator_tag.
+      for (CXXBaseSpecifier BS : ItrCategoryDecl->bases()) {
+
+        if (IsRandomAccessIteratorTag(BS.getType()->getAsCXXRecordDecl()))
+          return true;
+      }
+
+      return false;
+    }
+  }
+
+  return false;
+}
+
+} // namespace
+
+void SemaOpenACC::ForStmtBeginChecker::check() {
+  if (!SemaRef.LoopWithoutSeqLoc.isValid())
+    return;
+
+  if (AlreadyChecked)
+    return;
+  AlreadyChecked = true;
+
+  // OpenACC3.3 2.1:
+  // A loop associated with a loop construct that does not have a seq clause
+  // must be written to meet all the following conditions:
+  // - The loop variable must be of integer, C/C++ pointer, or C++ random-access
+  // iterator type.
+  // - The loop variable must monotonically increase or decrease in the
+  // direction of its termination condition.
+  // - The loop trip count must be computable in constant time when entering the
+  // loop construct.
+  //
+  // For a C++ range-based for loop, the loop variable
+  // identified by the above conditions is the internal iterator, such as a
+  // pointer, that the compiler generates to iterate the range.  it is not the
+  // variable declared by the for loop.
+
+  if (IsRangeFor) {
+    // If the range-for is being instantiated and didn't change, don't
+    // re-diagnose.
+    if (!RangeFor.has_value())
+      return;
+    // For a range-for, we can assume everything is 'corect' other than the type
+    // of the iterator, so check that.
+    const DeclStmt *RangeStmt = (*RangeFor)->getBeginStmt();
+
+    // In some dependent contexts, the autogenerated range statement doesn't get
+    // included until instantiation, so skip for now.
+    if (!RangeStmt)
+      return;
+
+    const ValueDecl *InitVar = cast<ValueDecl>(RangeStmt->getSingleDecl());
+    QualType VarType = InitVar->getType().getNonReferenceType();
+    if (!isValidLoopVariableType(VarType)) {
+      SemaRef.Diag(InitVar->getBeginLoc(), diag::err_acc_loop_variable_type)
+          << VarType;
+      SemaRef.Diag(SemaRef.LoopWithoutSeqLoc, diag::note_acc_construct_here)
+          << "loop";
+    }
+    return;
+  }
+
+  // Else we are in normal 'ForStmt', so we can diagnose everything.
+  // We only have to check cond/inc if they have changed, but 'init' needs to
+  // just suppress its diagnostics if it hasn't changed.
+  const ValueDecl *InitVar = checkInit();
+  if (Cond.has_value())
+    checkCond();
+  if (Inc.has_value())
+    checkInc(InitVar);
+}
+const ValueDecl *SemaOpenACC::ForStmtBeginChecker::checkInit() {
+  if (!Init) {
+    if (InitChanged) {
+      SemaRef.Diag(ForLoc, diag::err_acc_loop_variable);
+      SemaRef.Diag(SemaRef.LoopWithoutSeqLoc, diag::note_acc_construct_here)
+          << "loop";
+    }
+    return nullptr;
+  }
+
+  auto DiagLoopVar = [&]() {
+    if (InitChanged) {
+      SemaRef.Diag(Init->getBeginLoc(), diag::err_acc_loop_variable);
+      SemaRef.Diag(SemaRef.LoopWithoutSeqLoc, diag::note_acc_construct_here)
+          << "loop";
+    }
+    return nullptr;
+  };
+
+  if (const auto *ExprTemp = dyn_cast<ExprWithCleanups>(Init))
+    Init = ExprTemp->getSubExpr();
+  if (const auto *E = dyn_cast<Expr>(Init))
+    Init = E->IgnoreParenImpCasts();
+
+  const ValueDecl *InitVar = nullptr;
+
+  if (const auto *BO = dyn_cast<BinaryOperator>(Init)) {
+    // Allow assignment operator here.
+
+    if (!BO->isAssignmentOp())
+      return DiagLoopVar();
+
+    const Expr *LHS = BO->getLHS()->IgnoreParenImpCasts();
+
+    if (const auto *DRE = dyn_cast<DeclRefExpr>(LHS))
+      InitVar = DRE->getDecl();
+  } else if (const auto *DS = dyn_cast<DeclStmt>(Init)) {
+    // Allow T t = <whatever>
+    if (!DS->isSingleDecl())
+      return DiagLoopVar();
+
+    InitVar = dyn_cast<ValueDecl>(DS->getSingleDecl());
+
+    // Ensure we have an initializer, unless this is a record/dependent type.
+
+    if (InitVar) {
+      if (!isa<VarDecl>(InitVar))
+        return DiagLoopVar();
+
+      if (!InitVar->getType()->isRecordType() &&
+          !InitVar->getType()->isDependentType() &&
+          !cast<VarDecl>(InitVar)->hasInit())
+        return DiagLoopVar();
+    }
+  } else if (auto *CE = dyn_cast<CXXOperatorCallExpr>(Init)) {
+    // Allow assignment operator call.
+    if (CE->getOperator() != OO_Equal)
+      return DiagLoopVar();
+
+    const Expr *LHS = CE->getArg(0)->IgnoreParenImpCasts();
+
+    if (auto *DRE = dyn_cast<DeclRefExpr>(LHS)) {
+      InitVar = DRE->getDecl();
+    } else if (auto *ME = dyn_cast<MemberExpr>(LHS)) {
+      if (isa<CXXThisExpr>(ME->getBase()->IgnoreParenImpCasts()))
+        InitVar = ME->getMemberDecl();
+    }
+  }
+
+  if (!InitVar)
+    return DiagLoopVar();
+
+  InitVar = cast<ValueDecl>(InitVar->getCanonicalDecl());
+  QualType VarType = InitVar->getType().getNonReferenceType();
+
+  // Since we have one, all we need to do is ensure it is the right type.
+  if (!isValidLoopVariableType(VarType)) {
+    if (InitChanged) {
+      SemaRef.Diag(InitVar->getBeginLoc(), diag::err_acc_loop_variable_type)
+          << VarType;
+      SemaRef.Diag(SemaRef.LoopWithoutSeqLoc, diag::note_acc_construct_here)
+          << "loop";
+    }
+    return nullptr;
+  }
+
+  return InitVar;
+}
+void SemaOpenACC::ForStmtBeginChecker::checkCond() {
+  if (!*Cond) {
+    SemaRef.Diag(ForLoc, diag::err_acc_loop_terminating_condition);
+    SemaRef.Diag(SemaRef.LoopWithoutSeqLoc, diag::note_acc_construct_here)
+        << "loop";
+  }
+  // Nothing else to do here.  we could probably do some additional work to look
+  // into the termination condition, but that error-prone.  For now, we don't
+  // implement anything other than 'there is a termination condition', and if
+  // codegen/MLIR comes up with some necessary restrictions, we can implement
+  // them here.
+}
+
+void SemaOpenACC::ForStmtBeginChecker::checkInc(const ValueDecl *Init) {
+
+  if (!*Inc) {
+    SemaRef.Diag(ForLoc, diag::err_acc_loop_not_monotonic);
+    SemaRef.Diag(SemaRef.LoopWithoutSeqLoc, diag::note_acc_construct_here)
+        << "loop";
+    return;
+  }
+  auto DiagIncVar = [this] {
+    SemaRef.Diag((*Inc)->getBeginLoc(), diag::err_acc_loop_not_monotonic);
+    SemaRef.Diag(SemaRef.LoopWithoutSeqLoc, diag::note_acc_construct_here)
+        << "loop";
+    return;
+  };
+
+  if (const auto *ExprTemp = dyn_cast<ExprWithCleanups>(*Inc))
+    Inc = ExprTemp->getSubExpr();
+  if (const auto *E = dyn_cast<Expr>(*Inc))
+    Inc = E->IgnoreParenImpCasts();
+
+  auto getDeclFromExpr = [](const Expr *E) -> const ValueDecl * {
+    E = E->IgnoreParenImpCasts();
+    if (const auto *FE = dyn_cast<FullExpr>(E))
+      E = FE->getSubExpr();
+
+    E = E->IgnoreParenImpCasts();
+
+    if (!E)
+      return nullptr;
+    if (const auto *DRE = dyn_cast<DeclRefExpr>(E))
+      return dyn_cast<ValueDecl>(DRE->getDecl());
+
+    if (const auto *ME = dyn_cast<MemberExpr>(E))
+      if (isa<CXXThisExpr>(ME->getBase()->IgnoreParenImpCasts()))
+        return ME->getMemberDecl();
+
+    return nullptr;
+  };
+
+  const ValueDecl *IncVar = nullptr;
+
+  // Here we enforce the monotonically increase/decrease:
+  if (const auto *UO = dyn_cast<UnaryOperator>(*Inc)) {
+    // Allow increment/decrement ops.
+    if (!UO->isIncrementDecrementOp())
+      return DiagIncVar();
+    IncVar = getDeclFromExpr(UO->getSubExpr());
+  } else if (const auto *BO = dyn_cast<BinaryOperator>(*Inc)) {
+    switch (BO->getOpcode()) {
+    default:
+      return DiagIncVar();
+    case BO_AddAssign:
+    case BO_SubAssign:
+    case BO_MulAssign:
+    case BO_DivAssign:
+    case BO_Assign:
+      // += -= *= /= should all be fine here, this should be all of the
+      // 'monotonical' compound-assign ops.
+      // Assignment we just give up on, we could do better, and ensure that it
+      // is a binary/operator expr doing more work, but that seems like a lot
+      // of work for an error prone check.
+      break;
+    }
+    IncVar = getDeclFromExpr(BO->getLHS());
+  } else if (const auto *CE = dyn_cast<CXXOperatorCallExpr>(*Inc)) {
+    switch (CE->getOperator()) {
+    default:
+      return DiagIncVar();
+    case OO_PlusPlus:
+    case OO_MinusMinus:
+    case OO_PlusEqual:
+    case OO_MinusEqual:
+    case OO_StarEqual:
+    case OO_SlashEqual:
+    case OO_Equal:
+      // += -= *= /= should all be fine here, this should be all of the
+      // 'monotonical' compound-assign ops.
+      // Assignment we just give up on, we could do better, and ensure that it
+      // is a binary/operator expr doing more work, but that seems like a lot
+      // of work for an error prone check.
+      break;
+    }
+
+    IncVar = getDeclFromExpr(CE->getArg(0));
+
+  } else if (const auto *ME = dyn_cast<CXXMemberCallExpr>(*Inc)) {
+    IncVar = getDeclFromExpr(ME->getImplicitObjectArgument());
+    // We can't really do much for member expressions, other than hope they are
+    // doing the right thing, so give up here.
+  }
+
+  if (!IncVar)
+    return DiagIncVar();
+
+  // InitVar shouldn't be null unless there was an error, so don't diagnose if
+  // that is the case. Else we should ensure that it refers to the  loop
+  // value.
+  if (Init && IncVar->getCanonicalDecl() != Init->getCanonicalDecl())
+    return DiagIncVar();
+
+  return;
+}
+
+void SemaOpenACC::ActOnForStmtBegin(SourceLocation ForLoc, const Stmt *OldFirst,
+                                    const Stmt *First, const Stmt *OldSecond,
+                                    const Stmt *Second, const Stmt *OldThird,
+                                    const Stmt *Third) {
+  if (!getLangOpts().OpenACC)
+    return;
+
+  std::optional<const Stmt *> S;
+  if (OldSecond == Second)
+    S = std::nullopt;
+  else
+    S = Second;
+  std::optional<const Stmt *> T;
+  if (OldThird == Third)
+    S = std::nullopt;
+  else
+    S = Third;
+
+  bool InitChanged = false;
+  if (OldFirst != First) {
+    InitChanged = true;
+
+    // VarDecls are always rebuild because they are dependent, so we can do a
+    // little work to suppress some of the double checking based on whether the
+    // type is instantiation dependent.
+    QualType OldVDTy;
+    QualType NewVDTy;
+    if (const auto *DS = dyn_cast<DeclStmt>(OldFirst))
+      if (const VarDecl *VD = dyn_cast_if_present<VarDecl>(
+              DS->isSingleDecl() ? DS->getSingleDecl() : nullptr))
+        OldVDTy = VD->getType();
+    if (const auto *DS = dyn_cast<DeclStmt>(First))
+      if (const VarDecl *VD = dyn_cast_if_present<VarDecl>(
+              DS->isSingleDecl() ? DS->getSingleDecl() : nullptr))
+        NewVDTy = VD->getType();
+
+    if (!OldVDTy.isNull() && !NewVDTy.isNull())
+      InitChanged = OldVDTy->isInstantiationDependentType() !=
+                    NewVDTy->isInstantiationDependentType();
+  }
+
+  ForStmtBeginChecker FSBC{*this, ForLoc, First, InitChanged, S, T};
+  if (!LoopInfo.TopLevelLoopSeen) {
+    FSBC.check();
+  }
+
+  ForStmtBeginHelper(ForLoc, FSBC);
+}
+
+void SemaOpenACC::ActOnForStmtBegin(SourceLocation ForLoc, const Stmt *First,
+                                    const Stmt *Second, const Stmt *Third) {
+  if (!getLangOpts().OpenACC)
+    return;
+
+  ForStmtBeginChecker FSBC{*this,  ForLoc, First, /*InitChanged=*/true,
+                           Second, Third};
+  if (!LoopInfo.TopLevelLoopSeen) {
+    FSBC.check();
+  }
+
+  ForStmtBeginHelper(ForLoc, FSBC);
+}
+
+void SemaOpenACC::ActOnRangeForStmtBegin(SourceLocation ForLoc,
+                                         const Stmt *OldRangeFor,
+                                         const Stmt *RangeFor) {
+  if (!getLangOpts().OpenACC)
+    return;
+
+  std::optional<const CXXForRangeStmt *> RF;
+
+  if (OldRangeFor == RangeFor)
+    RF = std::nullopt;
+  else
+    RF = cast<CXXForRangeStmt>(RangeFor);
+
+  ForStmtBeginChecker FSBC{*this, ForLoc, RF};
+  if (!LoopInfo.TopLevelLoopSeen) {
+    FSBC.check();
+  }
+  ForStmtBeginHelper(ForLoc, FSBC);
+}
+
+void SemaOpenACC::ActOnRangeForStmtBegin(SourceLocation ForLoc,
+                                         const Stmt *RangeFor) {
+  if (!getLangOpts().OpenACC)
+    return;
+
+  ForStmtBeginChecker FSBC{*this, ForLoc, cast<CXXForRangeStmt>(RangeFor)};
+  if (!LoopInfo.TopLevelLoopSeen) {
+    FSBC.check();
+  }
+  ForStmtBeginHelper(ForLoc, FSBC);
 }
 
 namespace {
@@ -2657,6 +3095,7 @@ SourceLocation FindInterveningCodeInLoop(const Stmt *CurStmt) {
 void SemaOpenACC::ActOnForStmtEnd(SourceLocation ForLoc, StmtResult Body) {
   if (!getLangOpts().OpenACC)
     return;
+
   // Set this to 'true' so if we find another one at this level we can diagnose.
   LoopInfo.CurLevelHasLoopAlready = true;
 
@@ -2758,9 +3197,9 @@ StmtResult SemaOpenACC::ActOnEndStmtDirective(OpenACCDirectiveKind K,
   llvm_unreachable("Unhandled case in directive handling?");
 }
 
-StmtResult SemaOpenACC::ActOnAssociatedStmt(SourceLocation DirectiveLoc,
-                                            OpenACCDirectiveKind K,
-                                            StmtResult AssocStmt) {
+StmtResult SemaOpenACC::ActOnAssociatedStmt(
+    SourceLocation DirectiveLoc, OpenACCDirectiveKind K,
+    ArrayRef<const OpenACCClause *> Clauses, StmtResult AssocStmt) {
   switch (K) {
   default:
     llvm_unreachable("Unimplemented associated statement application");
@@ -2808,10 +3247,7 @@ StmtResult SemaOpenACC::ActOnAssociatedStmt(SourceLocation DirectiveLoc,
       return StmtError();
     }
 
-    // TODO OpenACC: 2.9 ~ line 2010 specifies that the associated loop has some
-    // restrictions when there is a 'seq' clause in place. We probably need to
-    // implement that, including piping in the clauses here.
-    return AssocStmt;
+    return AssocStmt.get();
   }
   llvm_unreachable("Invalid associated statement application");
 }

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -8298,7 +8298,9 @@ TreeTransform<Derived>::TransformForStmt(ForStmt *S) {
   // OpenACC Restricts a for-loop inside of certain construct/clause
   // combinations, so diagnose that here in OpenACC mode.
   SemaOpenACC::LoopInConstructRAII LCR{SemaRef.OpenACC()};
-  SemaRef.OpenACC().ActOnForStmtBegin(S->getBeginLoc());
+  SemaRef.OpenACC().ActOnForStmtBegin(
+      S->getBeginLoc(), S->getInit(), Init.get(), S->getCond(),
+      Cond.get().second, S->getInc(), Inc.get());
 
   // Transform the body
   StmtResult Body = getDerived().TransformStmt(S->getBody());
@@ -9048,7 +9050,7 @@ TreeTransform<Derived>::TransformCXXForRangeStmt(CXXForRangeStmt *S) {
   // OpenACC Restricts a while-loop inside of certain construct/clause
   // combinations, so diagnose that here in OpenACC mode.
   SemaOpenACC::LoopInConstructRAII LCR{SemaRef.OpenACC()};
-  SemaRef.OpenACC().ActOnForStmtBegin(S->getBeginLoc());
+  SemaRef.OpenACC().ActOnRangeForStmtBegin(S->getBeginLoc(), S, NewStmt.get());
 
   StmtResult Body = getDerived().TransformStmt(S->getBody());
   if (Body.isInvalid())
@@ -12073,11 +12075,11 @@ StmtResult TreeTransform<Derived>::TransformOpenACCComputeConstruct(
 
   // Transform Structured Block.
   SemaOpenACC::AssociatedStmtRAII AssocStmtRAII(
-      getSema().OpenACC(), C->getDirectiveKind(), C->clauses(),
-      TransformedClauses);
+      getSema().OpenACC(), C->getDirectiveKind(), C->getDirectiveLoc(),
+      C->clauses(), TransformedClauses);
   StmtResult StrBlock = getDerived().TransformStmt(C->getStructuredBlock());
   StrBlock = getSema().OpenACC().ActOnAssociatedStmt(
-      C->getBeginLoc(), C->getDirectiveKind(), StrBlock);
+      C->getBeginLoc(), C->getDirectiveKind(), TransformedClauses, StrBlock);
 
   return getDerived().RebuildOpenACCComputeConstruct(
       C->getDirectiveKind(), C->getBeginLoc(), C->getDirectiveLoc(),
@@ -12100,11 +12102,11 @@ TreeTransform<Derived>::TransformOpenACCLoopConstruct(OpenACCLoopConstruct *C) {
 
   // Transform Loop.
   SemaOpenACC::AssociatedStmtRAII AssocStmtRAII(
-      getSema().OpenACC(), C->getDirectiveKind(), C->clauses(),
-      TransformedClauses);
+      getSema().OpenACC(), C->getDirectiveKind(), C->getDirectiveLoc(),
+      C->clauses(), TransformedClauses);
   StmtResult Loop = getDerived().TransformStmt(C->getLoop());
-  Loop = getSema().OpenACC().ActOnAssociatedStmt(C->getBeginLoc(),
-                                                 C->getDirectiveKind(), Loop);
+  Loop = getSema().OpenACC().ActOnAssociatedStmt(
+      C->getBeginLoc(), C->getDirectiveKind(), TransformedClauses, Loop);
 
   return getDerived().RebuildOpenACCLoopConstruct(
       C->getBeginLoc(), C->getDirectiveLoc(), C->getEndLoc(),

--- a/clang/test/AST/ast-print-openacc-loop-construct.cpp
+++ b/clang/test/AST/ast-print-openacc-loop-construct.cpp
@@ -5,320 +5,320 @@ struct SomeStruct{};
 constexpr int get_value() { return 1; }
 void foo() {
 // CHECK: #pragma acc loop
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop device_type(SomeStruct)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop device_type(SomeStruct)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop device_type(int)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop device_type(int)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop dtype(bool)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop dtype(bool)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop dtype(AnotherIdent)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop dtype(AnotherIdent)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop independent
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop independent
-  for(;;);
+  for(int i = 0;i<5;++i);
 // CHECK: #pragma acc loop seq
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop seq
-  for(;;);
+  for(int i = 0;i<5;++i);
 // CHECK: #pragma acc loop auto
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop auto
-  for(;;);
+  for(int i = 0;i<5;++i);
 
   int i;
   float array[5];
 
 // CHECK: #pragma acc loop private(i, array[1], array, array[1:2])
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop private(i, array[1], array, array[1:2])
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop collapse(1)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop collapse(1)
-  for(;;);
+  for(int i = 0;i<5;++i);
 // CHECK: #pragma acc loop collapse(force:1)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop collapse(force:1)
-  for(;;);
+  for(int i = 0;i<5;++i);
 // CHECK: #pragma acc loop collapse(2)
-// CHECK-NEXT: for (;;)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop collapse(2)
-  for(;;)
-    for(;;);
+  for(int i = 0;i<5;++i)
+    for(int i = 0;i<5;++i);
 // CHECK: #pragma acc loop collapse(force:2)
-// CHECK-NEXT: for (;;)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop collapse(force:2)
-  for(;;)
-    for(;;);
+  for(int i = 0;i<5;++i)
+    for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop tile(1, 3, *, get_value())
-// CHECK-NEXT: for (;;)
-// CHECK-NEXT: for (;;)
-// CHECK-NEXT: for (;;)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop tile(1, 3, *, get_value())
-  for(;;)
-    for(;;)
-      for(;;)
-        for(;;);
+  for(int i = 0;i<5;++i)
+    for(int i = 0;i<5;++i)
+      for(int i = 0;i<5;++i)
+        for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop gang(dim: 2)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop gang(dim:2)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop gang(static: i)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop gang(static:i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop gang(static: i) gang(dim: 2)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop gang(static:i) gang(dim:2)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc parallel
 // CHECK-NEXT: #pragma acc loop gang(dim: 2)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop gang(dim:2)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc parallel
 // CHECK-NEXT: #pragma acc loop gang(static: i)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop gang(static:i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc parallel
 // CHECK-NEXT: #pragma acc loop gang(static: i) gang(dim: 2)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop gang(static:i) gang(dim:2)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc kernels
 // CHECK-NEXT: #pragma acc loop gang(num: i) gang(static: i)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc kernels
 #pragma acc loop gang(i) gang(static:i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc kernels
 // CHECK-NEXT: #pragma acc loop gang(num: i) gang(static: i)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc kernels
 #pragma acc loop gang(num:i) gang(static:i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc serial
 // CHECK-NEXT: #pragma acc loop gang(static: i)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc serial
 #pragma acc loop gang(static:i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc serial
 // CHECK-NEXT: #pragma acc loop gang(static: *)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc serial
 #pragma acc loop gang(static:*)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc serial
 // CHECK-NEXT: #pragma acc loop
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc serial
 #pragma acc loop gang
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop worker
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc parallel
 // CHECK-NEXT: #pragma acc loop worker
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc serial
 // CHECK-NEXT: #pragma acc loop worker
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc serial
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc kernels
 // CHECK-NEXT: #pragma acc loop worker(num: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc kernels
 #pragma acc loop worker(5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc kernels
 // CHECK-NEXT: #pragma acc loop worker(num: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc kernels
 #pragma acc loop worker(num:5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
   // CHECK: #pragma acc loop vector
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop vector(length: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop vector(5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc loop vector(length: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc loop vector(length:5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc parallel
 // CHECK-NEXT: #pragma acc loop vector
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc parallel
 // CHECK-NEXT: #pragma acc loop vector(length: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop vector(5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc parallel
 // CHECK-NEXT: #pragma acc loop vector(length: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc parallel
 #pragma acc loop vector(length:5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc kernels
 // CHECK-NEXT: #pragma acc loop vector
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc kernels
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc kernels
 // CHECK-NEXT: #pragma acc loop vector(length: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc kernels
 #pragma acc loop vector(5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc kernels
 // CHECK-NEXT: #pragma acc loop vector(length: 5)
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc kernels
 #pragma acc loop vector(length:5)
-  for(;;);
+  for(int i = 0;i<5;++i);
 
 // CHECK: #pragma acc serial
 // CHECK-NEXT: #pragma acc loop vector
-// CHECK-NEXT: for (;;)
+// CHECK-NEXT: for (int i = 0; i < 5; ++i)
 // CHECK-NEXT: ;
 #pragma acc serial
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0;i<5;++i);
 
   int *iPtr;
   bool SomeB;
 
 //CHECK: #pragma acc loop reduction(+: iPtr)
 #pragma acc loop reduction(+: iPtr)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(*: i)
 #pragma acc loop reduction(*: i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(max: SomeB)
 #pragma acc loop reduction(max: SomeB)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(min: iPtr)
 #pragma acc loop reduction(min: iPtr)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(&: i)
 #pragma acc loop reduction(&: i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(|: SomeB)
 #pragma acc loop reduction(|: SomeB)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(^: iPtr)
 #pragma acc loop reduction(^: iPtr)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(&&: i)
 #pragma acc loop reduction(&&: i)
-  for(;;);
+  for(int i = 0;i<5;++i);
 //CHECK: #pragma acc loop reduction(||: SomeB)
 #pragma acc loop reduction(||: SomeB)
-  for(;;);
+  for(int i = 0;i<5;++i);
 }

--- a/clang/test/ParserOpenACC/parse-clauses.c
+++ b/clang/test/ParserOpenACC/parse-clauses.c
@@ -42,156 +42,156 @@ void func() {
   // expected-error@+2{{OpenACC clause 'auto' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq independent auto
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+4{{OpenACC clause 'independent' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+3{{previous clause is here}}
   // expected-error@+2{{OpenACC clause 'auto' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq, independent auto
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+4{{OpenACC clause 'independent' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+3{{previous clause is here}}
   // expected-error@+2{{OpenACC clause 'auto' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq independent, auto
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+4{{OpenACC clause 'seq' not yet implemented, clause ignored}}
   // expected-warning@+3{{OpenACC clause 'independent' not yet implemented, clause ignored}}
   // expected-warning@+2{{OpenACC clause 'auto' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'kernels loop' not yet implemented, pragma ignored}}
 #pragma acc kernels loop seq independent auto
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+4{{OpenACC clause 'seq' not yet implemented, clause ignored}}
   // expected-warning@+3{{OpenACC clause 'independent' not yet implemented, clause ignored}}
   // expected-warning@+2{{OpenACC clause 'auto' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop seq, independent auto
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+4{{OpenACC clause 'seq' not yet implemented, clause ignored}}
   // expected-warning@+3{{OpenACC clause 'independent' not yet implemented, clause ignored}}
   // expected-warning@+2{{OpenACC clause 'auto' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'parallel loop' not yet implemented, pragma ignored}}
 #pragma acc parallel loop seq independent, auto
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 
   // expected-error@+1{{expected identifier}}
 #pragma acc loop , seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected identifier}}
 #pragma acc loop seq,
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected '('}}
 #pragma acc loop collapse
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop collapse()
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{invalid tag 'unknown' on 'collapse' clause}}
   // expected-error@+1{{expected expression}}
 #pragma acc loop collapse(unknown:)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop collapse(force:)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'unknown' on 'collapse' clause}}
 #pragma acc loop collapse(unknown:1)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc loop collapse(force:1)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc loop collapse(1)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop collapse(5, 6)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 }
 
 void DefaultClause() {
   // expected-error@+2{{expected '('}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop default
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected '('}}
 #pragma acc serial default self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected '('}}
 #pragma acc serial default, self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected identifier}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial default(
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{invalid value for 'default' clause; expected 'present' or 'none'}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial default( self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected identifier}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial default(, self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected '('}}
   // expected-error@+1{{expected identifier}}
 #pragma acc serial default)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected '('}}
   // expected-error@+1{{expected identifier}}
 #pragma acc serial default), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected identifier}}
 #pragma acc serial default()
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected identifier}}
 #pragma acc serial default() self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected identifier}}
 #pragma acc serial default(), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid value for 'default' clause; expected 'present' or 'none'}}
 #pragma acc serial default(invalid)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid value for 'default' clause; expected 'present' or 'none'}}
 #pragma acc serial default(auto) self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid value for 'default' clause; expected 'present' or 'none'}}
 #pragma acc serial default(invalid), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial default(none)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial default(present), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 }
 
 void IfClause() {
@@ -199,102 +199,102 @@ void IfClause() {
   // expected-error@+2{{expected '('}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop if
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected '('}}
 #pragma acc serial if private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected '('}}
 #pragma acc serial if, private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial if(
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{use of undeclared identifier 'self'}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial if( self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+4{{expected expression}}
   // expected-error@+3{{use of undeclared identifier 'self'}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial if(, self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected '('}}
   // expected-error@+1{{expected identifier}}
 #pragma acc serial if)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected '('}}
   // expected-error@+1{{expected identifier}}
 #pragma acc serial if) private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected '('}}
   // expected-error@+1{{expected identifier}}
 #pragma acc serial if), private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc serial if()
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc serial if() private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc serial if(), private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{use of undeclared identifier 'invalid_expr'}}
 #pragma acc serial if(invalid_expr)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc serial if() private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial if(i > j)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial if(1+5>3), private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 }
 
 void SelfClause() {
   // expected-warning@+2{{OpenACC clause 'self' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+3{{OpenACC clause 'self' not yet implemented, clause ignored}}
   // expected-warning@+2{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
   // expected-warning@+1{{OpenACC clause 'seq' not yet implemented, clause ignored}}
 #pragma acc serial loop self, seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+4{{expected expression}}
   // expected-error@+3{{expected ')'}}
   // expected-note@+2{{to match this '('}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop self(
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+4{{use of undeclared identifier 'seq'}}
   // expected-error@+3{{expected ')'}}
   // expected-note@+2{{to match this '('}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop self( seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+5{{expected expression}}
   // expected-error@+4{{use of undeclared identifier 'seq'}}
@@ -302,68 +302,68 @@ void SelfClause() {
   // expected-note@+2{{to match this '('}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop self(, seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected identifier}}
   // expected-warning@+2{{OpenACC clause 'self' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop self)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected identifier}}
   // expected-warning@+2{{OpenACC clause 'self' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop self) seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected identifier}}
   // expected-warning@+2{{OpenACC clause 'self' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
 #pragma acc serial loop self), seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 
   // expected-error@+3{{expected expression}}
   // expected-warning@+2{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
   // expected-warning@+1{{OpenACC clause 'seq' not yet implemented, clause ignored}}
 #pragma acc serial loop self(), seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+4{{expected expression}}
   // expected-error@+3{{expected expression}}
   // expected-warning@+2{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
   // expected-warning@+1{{OpenACC clause 'seq' not yet implemented, clause ignored}}
 #pragma acc serial loop self(,), seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{use of undeclared identifier 'invalid_expr'}}
   // expected-warning@+2{{OpenACC construct 'serial loop' not yet implemented, pragma ignored}}
   // expected-warning@+1{{OpenACC clause 'seq' not yet implemented, clause ignored}}
 #pragma acc serial loop self(invalid_expr), seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   int i, j;
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial self(i > j
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{use of undeclared identifier 'seq'}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial self(i > j, seq
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{left operand of comma operator has no effect}}
 #pragma acc serial self(i, j)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial self(i > j)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial self(1+5>3), private(i)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 }
 
 struct Members {
@@ -381,7 +381,7 @@ void SelfUpdate() {
   // expected-error@+2{{expected '('}}
   // expected-warning@+1{{OpenACC construct 'update' not yet implemented, pragma ignored}}
 #pragma acc update self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+6{{use of undeclared identifier 'zero'}}
   // expected-error@+5{{expected ','}}
@@ -390,123 +390,123 @@ void SelfUpdate() {
   // expected-warning@+2{{OpenACC clause 'if_present' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'update' not yet implemented, pragma ignored}}
 #pragma acc update self(zero : s.array[s.value : 5], s.value), if_present
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+3{{OpenACC clause 'self' not yet implemented, clause ignored}}
   // expected-warning@+2{{OpenACC clause 'if_present' not yet implemented, clause ignored}}
   // expected-warning@+1{{OpenACC construct 'update' not yet implemented, pragma ignored}}
 #pragma acc update self(s.array[s.value : 5], s.value), if_present
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 }
 
 void VarListClauses() {
   // expected-error@+1{{expected '('}}
 #pragma acc serial copy
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected '('}}
 #pragma acc serial copy, self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected '('}}
   // expected-error@+1{{expected identifier}}
 #pragma acc serial copy)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected '('}}
   // expected-error@+1{{expected identifier}}
 #pragma acc serial copy), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial copy(
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc serial copy(, self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc serial copy()
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc serial copy(), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   struct Members s;
   struct HasMembersArray HasMem;
 
 #pragma acc serial copy(s.array[s.value]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copy(s.array[s.value], s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copy(HasMem.MemArr[3].array[1]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copy(HasMem.MemArr[3].array[1:4]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{OpenACC sub-array is not allowed here}}
 #pragma acc serial copy(HasMem.MemArr[1:3].array[1]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{OpenACC sub-array is not allowed here}}
 #pragma acc serial copy(HasMem.MemArr[1:3].array[1:2]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copy(HasMem.MemArr[:]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc serial copy(HasMem.MemArr[::]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ']'}}
   // expected-note@+1{{to match this '['}}
 #pragma acc serial copy(HasMem.MemArr[: :]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copy(HasMem.MemArr[3:]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'pcopy' is a deprecated clause name and is now an alias for 'copy'}}
 #pragma acc serial pcopy(HasMem.MemArr[3:])
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'present_or_copy' is a deprecated clause name and is now an alias for 'copy'}}
 #pragma acc serial present_or_copy(HasMem.MemArr[3:])
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented, clause ignored}}
 #pragma acc serial use_device(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented, clause ignored}}
 #pragma acc serial use_device(s.array[s.value : 5]), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected ','}}
 #pragma acc serial no_create(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial no_create(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected ','}}
 #pragma acc serial present(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial present(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 
   void *IsPointer;
@@ -515,266 +515,266 @@ void VarListClauses() {
   // expected-error@+2{{OpenACC sub-array is not allowed here}}
   // expected-note@+1{{expected variable of pointer type}}
 #pragma acc serial deviceptr(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial deviceptr(IsPointer), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+4{{expected ','}}
   // expected-error@+3{{expected pointer in 'attach' clause, type is 'char'}}
   // expected-error@+2{{OpenACC sub-array is not allowed here}}
   // expected-note@+1{{expected variable of pointer type}}
 #pragma acc serial attach(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial attach(IsPointer), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented, clause ignored}}
 #pragma acc serial detach(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented, clause ignored}}
 #pragma acc serial detach(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected ','}}
 #pragma acc serial private(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial private(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected ','}}
 #pragma acc serial firstprivate(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial firstprivate(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented, clause ignored}}
 #pragma acc serial delete(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented, clause ignored}}
 #pragma acc serial delete(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented, clause ignored}}
 #pragma acc serial use_device(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented, clause ignored}}
 #pragma acc serial use_device(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented, clause ignored}}
 #pragma acc serial device_resident(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented, clause ignored}}
 #pragma acc serial device_resident(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented, clause ignored}}
 #pragma acc serial link(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented, clause ignored}}
 #pragma acc serial link(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented, clause ignored}}
 #pragma acc serial host(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented, clause ignored}}
 #pragma acc serial host(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ','}}
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented, clause ignored}}
 #pragma acc serial device(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented, clause ignored}}
 #pragma acc serial device(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected ','}}
 #pragma acc serial copyout(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copyout(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copyout(zero:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'pcopyout' is a deprecated clause name and is now an alias for 'copyout'}}
 #pragma acc serial pcopyout(s.array[s.value : 5], s.value)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'present_or_copyout' is a deprecated clause name and is now an alias for 'copyout'}}
 #pragma acc serial present_or_copyout(zero:s.array[s.value : 5], s.value)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copyout(zero : s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{use of undeclared identifier 'zero'}}
   // expected-error@+1{{expected ','}}
 #pragma acc serial copyout(zero s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'readonly' on 'copyout' clause}}
 #pragma acc serial copyout(readonly:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'invalid' on 'copyout' clause}}
 #pragma acc serial copyout(invalid:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'invalid' on 'copyout' clause}}
 #pragma acc serial copyout(invalid:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{use of undeclared identifier 'invalid'}}
   // expected-error@+1{{expected ','}}
 #pragma acc serial copyout(invalid s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected ','}}
 #pragma acc serial create(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial create(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial create(zero:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'pcreate' is a deprecated clause name and is now an alias for 'create'}}
 #pragma acc serial pcreate(s.array[s.value : 5], s.value)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'present_or_create' is a deprecated clause name and is now an alias for 'create'}}
 #pragma acc serial present_or_create(zero:s.array[s.value : 5], s.value)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial create(zero : s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{use of undeclared identifier 'zero'}}
   // expected-error@+1{{expected ','}}
 #pragma acc serial create(zero s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'readonly' on 'create' clause}}
 #pragma acc serial create(readonly:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'invalid' on 'create' clause}}
 #pragma acc serial create(invalid:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'invalid' on 'create' clause}}
 #pragma acc serial create(invalid:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{use of undeclared identifier 'invalid'}}
   // expected-error@+1{{expected ','}}
 #pragma acc serial create(invalid s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected ','}}
 #pragma acc serial copyin(s.array[s.value] s.array[s.value :5] ), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copyin(s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copyin(readonly:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'pcopyin' is a deprecated clause name and is now an alias for 'copyin'}}
 #pragma acc serial pcopyin(s.array[s.value : 5], s.value)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-warning@+1{{OpenACC clause name 'present_or_copyin' is a deprecated clause name and is now an alias for 'copyin'}}
 #pragma acc serial present_or_copyin(readonly:s.array[s.value : 5], s.value)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc serial copyin(readonly : s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{use of undeclared identifier 'readonly'}}
   // expected-error@+1{{expected ','}}
 #pragma acc serial copyin(readonly s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'zero' on 'copyin' clause}}
 #pragma acc serial copyin(zero :s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'invalid' on 'copyin' clause}}
 #pragma acc serial copyin(invalid:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{invalid tag 'invalid' on 'copyin' clause}}
 #pragma acc serial copyin(invalid:s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{use of undeclared identifier 'invalid'}}
   // expected-error@+1{{expected ','}}
 #pragma acc serial copyin(invalid s.array[s.value : 5], s.value), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 }
 
 void ReductionClauseParsing() {
   char *Begin, *End;
   // expected-error@+1{{expected '('}}
 #pragma acc serial reduction
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+2{{missing reduction operator, expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||', follwed by a ':'}}
   // expected-error@+1{{expected expression}}
 #pragma acc serial reduction()
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{missing reduction operator, expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||', follwed by a ':'}}
 #pragma acc serial reduction(Begin)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{missing reduction operator, expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||', follwed by a ':'}}
 #pragma acc serial reduction(Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{missing reduction operator, expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||', follwed by a ':'}}
 #pragma acc serial reduction(Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(+:Begin)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(+:Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(*: Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(max : Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(min: Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(&: Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(|: Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(^: Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial self, reduction(&&: Begin, End)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc serial reduction(||: Begin, End), self
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 }
 
 int returns_int();
@@ -899,99 +899,99 @@ void IntExprParsing() {
 
 
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+1{{expected expression}}
 #pragma acc loop vector()
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{invalid tag 'invalid' on 'vector' clause}}
   // expected-error@+1{{expected expression}}
 #pragma acc loop vector(invalid:)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+1{{invalid tag 'invalid' on 'vector' clause}}
 #pragma acc loop vector(invalid:5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+1{{expected expression}}
 #pragma acc loop vector(length:)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{invalid tag 'num' on 'vector' clause}}
   // expected-error@+1{{expected expression}}
 #pragma acc loop vector(num:)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop vector(5, 4)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop vector(length:6,4)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+3{{invalid tag 'num' on 'vector' clause}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop vector(num:6,4)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc loop vector(5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+1{{invalid tag 'num' on 'vector' clause}}
 #pragma acc loop vector(num:5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc loop vector(length:5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc loop vector(returns_int())
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc loop vector(length:returns_int())
-  for(;;);
+  for(int i = 0; i < 5;++i);
 
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+1{{expected expression}}
 #pragma acc loop worker()
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{invalid tag 'invalid' on 'worker' clause}}
   // expected-error@+1{{expected expression}}
 #pragma acc loop worker(invalid:)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc kernels
   // expected-error@+1{{invalid tag 'invalid' on 'worker' clause}}
 #pragma acc loop worker(invalid:5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+1{{expected expression}}
 #pragma acc loop worker(num:)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{invalid tag 'length' on 'worker' clause}}
   // expected-error@+1{{expected expression}}
 #pragma acc loop worker(length:)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop worker(5, 4)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop worker(num:6,4)
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // expected-error@+3{{invalid tag 'length' on 'worker' clause}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop worker(length:6,4)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc kernels
 #pragma acc loop worker(5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc kernels
   // expected-error@+1{{invalid tag 'length' on 'worker' clause}}
 #pragma acc loop worker(length:5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc kernels
 #pragma acc loop worker(num:5)
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc kernels
 #pragma acc loop worker(returns_int())
-  for(;;);
+  for(int i = 0; i < 5;++i);
 #pragma acc kernels
   // expected-error@+1{{invalid tag 'length' on 'worker' clause}}
 #pragma acc loop worker(length:returns_int())
-  for(;;);
+  for(int i = 0; i < 5;++i);
 }
 
 void device_type() {
@@ -1139,190 +1139,190 @@ void Tile() {
   int* Foo;
   // expected-error@+1{{expected '('}}
 #pragma acc loop tile
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop tile(
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{expected expression}}
 #pragma acc loop tile()
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop tile(,
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{expected expression}}
 #pragma acc loop tile(,)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{use of undeclared identifier 'invalid'}}
 #pragma acc loop tile(returns_int(), *, invalid, *)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop tile(returns_int() *, Foo, *)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{indirection requires pointer operand ('int' invalid)}}
 #pragma acc loop tile(* returns_int() , *)
-  for(;;){
-    for(;;);
+  for(int j = 0; j < 5;++j){
+    for(int i = 0; i < 5;++i);
   }
 
 #pragma acc loop tile(*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{OpenACC 'tile' clause size expression must be an asterisk or a constant expression}}
 #pragma acc loop tile(*Foo, *Foo)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc loop tile(5)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 #pragma acc loop tile(*, 5)
-  for(;;){
-    for(;;);
+  for(int j = 0; j < 5;++j){
+    for(int i = 0; i < 5;++i);
   }
 #pragma acc loop tile(5, *)
-  for(;;){
-    for(;;);
+  for(int j = 0; j < 5;++j){
+    for(int i = 0; i < 5;++i);
   }
 #pragma acc loop tile(5, *, 3, *)
-  for(;;){
-    for(;;)
-      for(;;)
-        for(;;);
+  for(int j = 0; j < 5;++j){
+    for(int k = 0; k < 5;++k)
+      for(int l = 0;l < 5;++l)
+        for(int i = 0; i < 5;++i);
   }
 }
 
 void Gang() {
 #pragma acc loop gang
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang()
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(5, *)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(5, num:*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(num:5, *)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(num:5, num:*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(num:*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc loop gang(dim:2)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(dim:5, dim:*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{expected expression}}
 #pragma acc loop gang(dim:*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc loop gang(static:*)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{OpenACC 'gang' clause may have at most one 'static' argument}}
   // expected-note@+1{{previous expression is here}}
 #pragma acc loop gang(static:*, static:5)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc kernels
 #pragma acc loop gang(static:*, 5)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc kernels
 #pragma acc loop gang(static:45, 5)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(static:45,
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(static:45
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(static:*,
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(static:*
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(45,
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(45
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(num:45,
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(num:45
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+3{{expected expression}}
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(dim:45,
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
 #pragma acc loop gang(dim:45
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 #pragma acc kernels
 #pragma acc loop gang(static:*, 5)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+1{{argument to 'gang' clause dimension must be a constant expression}}
 #pragma acc loop gang(static:*, dim:returns_int())
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
   // expected-error@+2 2{{'num' argument on 'gang' clause is not permitted on an orphaned 'loop' construct}}
   // expected-error@+1{{argument to 'gang' clause dimension must be a constant expression}}
 #pragma acc loop gang(num: 32, static:*, dim:returns_int(), 5)
-  for(;;){}
+  for(int i = 0; i < 5;++i) {}
 
 }
 

--- a/clang/test/ParserOpenACC/parse-clauses.cpp
+++ b/clang/test/ParserOpenACC/parse-clauses.cpp
@@ -3,20 +3,20 @@
 template<unsigned I, typename T>
 void templ() {
 #pragma acc loop collapse(I)
-  for(;;)
-    for(;;)
-      for(;;)
-        for(;;)
-          for(;;)
-            for(;;)
-              for(;;);
+  for(int i = 0; i < 5;++i)
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k)
+        for(int l = 0; l < 5; ++l)
+          for(int m = 0; m < 5; ++m)
+            for(int n = 0; n < 5; ++n)
+              for(int o = 0; o < 5; ++o);
 
 #pragma acc loop collapse(T::value)
-  for(;;)
-    for(;;)
-      for(;;)
-        for(;;)
-          for(;;)
+  for(int i = 0;i < 5;++i)
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k)
+        for(int l = 0; l < 5; ++l)
+          for(int m = 0; m < 5;++m)
             for(;;)
               for(;;);
 

--- a/clang/test/ParserOpenACC/parse-constructs.c
+++ b/clang/test/ParserOpenACC/parse-constructs.c
@@ -84,7 +84,7 @@ void func() {
   for(;;){}
   // expected-error@+1{{invalid OpenACC clause 'clause'}}
 #pragma acc loop clause list
-  for(;;){}
+  for(int i = 0; i < 6;++i){}
   // expected-error@+1{{invalid OpenACC clause 'invalid'}}
 #pragma acc parallel invalid clause list
   for(;;){}

--- a/clang/test/SemaOpenACC/compute-construct-async-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-async-clause.c
@@ -41,5 +41,5 @@ void Test() {
 
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop async(1)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-attach-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-attach-clause.c
@@ -61,5 +61,5 @@ void uses() {
 
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop attach(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-copy-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-copy-clause.c
@@ -62,11 +62,11 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop copy(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopy(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copy(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-copyin-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-copyin-clause.c
@@ -68,11 +68,11 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop copyin(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyin(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyin(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-copyout-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-copyout-clause.c
@@ -68,11 +68,11 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop copyout(LocalInt)
-  for(;;);
+  for(int i = 0; i < 6;++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyout(LocalInt)
-  for(;;);
+  for(int i = 0; i < 6;++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyout(LocalInt)
-  for(;;);
+  for(int i = 0; i < 6;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-create-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-create-clause.c
@@ -69,11 +69,11 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop create(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop pcreate(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_create(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-default-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-default-clause.c
@@ -43,7 +43,7 @@ void SingleOnly() {
 
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
   #pragma acc loop default(none)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 
   // expected-warning@+2{{OpenACC construct 'wait' not yet implemented}}
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'wait' directive}}
@@ -52,5 +52,5 @@ void SingleOnly() {
 
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop default(present)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-deviceptr-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-deviceptr-clause.c
@@ -61,5 +61,5 @@ void uses() {
 
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop deviceptr(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-firstprivate-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-firstprivate-clause.c
@@ -55,5 +55,5 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop firstprivate(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-if-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-if-clause.c
@@ -62,5 +62,5 @@ void BoolExpr(int *I, float *F) {
 
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop if(I)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-no_create-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-no_create-clause.c
@@ -54,5 +54,5 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop no_create(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-num_gangs-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-num_gangs-clause.c
@@ -54,5 +54,5 @@ void Test() {
 
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop num_gangs(1)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-num_workers-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-num_workers-clause.c
@@ -33,5 +33,5 @@ void Test() {
 
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop num_workers(1)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-present-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-present-clause.c
@@ -54,5 +54,5 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop present(LocalInt)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-self-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-self-clause.c
@@ -82,5 +82,5 @@ void WarnMaybeNotUsed(int val1, int val2) {
 
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop self
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-vector_length-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-vector_length-clause.c
@@ -33,5 +33,5 @@ void Test() {
 
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop vector_length(1)
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/compute-construct-wait-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-wait-clause.c
@@ -38,5 +38,5 @@ void uses() {
 
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop wait
-  for(;;);
+  for(int i = 5; i < 10;++i);
 }

--- a/clang/test/SemaOpenACC/loop-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-ast.cpp
@@ -13,13 +13,19 @@ void NormalFunc() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop
-  for(;;);
+  for(int i = 0; i < 5;++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} <orphan>
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl {{.*}} used i 'int'
+  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'bool' '<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr
+  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}} prefix '++'
+  // CHECK-NEXT: DeclRefExpr{{.*}} 'i' 'int'
   // CHECK-NEXT: NullStmt
 
   int array[5];
@@ -40,13 +46,19 @@ void NormalFunc() {
     // CHECK-NEXT: CompoundStmt
     {
 #pragma acc loop
-      for(;;);
+      for(int i = 0; i < 5;++i);
     // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: [[PAR_ADDR]]
     // CHECK-NEXT: ForStmt
+    // CHECK-NEXT: DeclStmt
+    // CHECK-NEXT: VarDecl {{.*}} used i 'int'
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
     // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
+    // CHECK-NEXT: BinaryOperator{{.*}}'bool' '<'
+    // CHECK-NEXT: ImplicitCastExpr
+    // CHECK-NEXT: DeclRefExpr
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 5
+    // CHECK-NEXT: UnaryOperator{{.*}} prefix '++'
+    // CHECK-NEXT: DeclRefExpr{{.*}} 'i' 'int'
     // CHECK-NEXT: NullStmt
     }
   }
@@ -90,22 +102,34 @@ void TemplFunc() {
 #pragma acc loop
     // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: [[PAR_ADDR_UNINST]]
     // CHECK-NEXT: ForStmt
+    // CHECK-NEXT: DeclStmt
+    // CHECK-NEXT: VarDecl {{.*}} i 'int'
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
     // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
+    // CHECK-NEXT: BinaryOperator{{.*}}'bool' '<'
+    // CHECK-NEXT: ImplicitCastExpr
+    // CHECK-NEXT: DeclRefExpr
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 5
+    // CHECK-NEXT: UnaryOperator{{.*}} prefix '++'
+    // CHECK-NEXT: DeclRefExpr{{.*}} 'i' 'int'
     // CHECK-NEXT: NullStmt
-      for(;;);
+      for(int i = 0; i < 5;++i);
 
 #pragma acc loop
     // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: [[PAR_ADDR_UNINST]]
     // CHECK-NEXT: ForStmt
+    // CHECK-NEXT: DeclStmt
+    // CHECK-NEXT: VarDecl {{.*}} i 'int'
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
     // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
-    // CHECK-NEXT: <<<NULL>>>
+    // CHECK-NEXT: BinaryOperator{{.*}}'bool' '<'
+    // CHECK-NEXT: ImplicitCastExpr
+    // CHECK-NEXT: DeclRefExpr
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 5
+    // CHECK-NEXT: UnaryOperator{{.*}} prefix '++'
+    // CHECK-NEXT: DeclRefExpr{{.*}} 'i' 'int'
     // CHECK-NEXT: NullStmt
-      for(;;);
+      for(int i = 0; i < 5;++i);
     }
   }
 
@@ -150,18 +174,30 @@ void TemplFunc() {
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: [[PAR_ADDR_INST]]
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl {{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'bool' '<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr
+  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}} prefix '++'
+  // CHECK-NEXT: DeclRefExpr{{.*}} 'i' 'int'
   // CHECK-NEXT: NullStmt
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: [[PAR_ADDR_INST]]
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl {{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'bool' '<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr
+  // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}} prefix '++'
+  // CHECK-NEXT: DeclRefExpr{{.*}} 'i' 'int'
   // CHECK-NEXT: NullStmt
 
   // CHECK-NEXT: DeclStmt

--- a/clang/test/SemaOpenACC/loop-construct-auto_seq_independent-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-auto_seq_independent-ast.cpp
@@ -11,14 +11,20 @@ void NormalUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop auto
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: auto clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop seq
@@ -33,14 +39,20 @@ void NormalUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop independent
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: independent clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 }
 
@@ -52,14 +64,20 @@ void TemplUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop auto
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: auto clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop seq
@@ -74,14 +92,20 @@ void TemplUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop independent
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: independent clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 
   // Instantiations.
@@ -93,10 +117,16 @@ void TemplUses() {
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: auto clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
@@ -111,10 +141,16 @@ void TemplUses() {
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: independent clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 }
 

--- a/clang/test/SemaOpenACC/loop-construct-auto_seq_independent-clauses.c
+++ b/clang/test/SemaOpenACC/loop-construct-auto_seq_independent-clauses.c
@@ -2,36 +2,36 @@
 
 void uses() {
 #pragma acc loop auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 
   // expected-error@+2{{OpenACC clause 'seq' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop auto seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'independent' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop auto independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'auto' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'independent' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'auto' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop independent auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'seq' on 'loop' construct conflicts with previous data dependence clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop independent seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 
   int Var;
   int *VarPtr;
@@ -39,819 +39,819 @@ void uses() {
   // 'auto' can combine with any other clause.
   // expected-warning@+1{{OpenACC clause 'finalize' not yet implemented}}
 #pragma acc loop auto finalize
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'if_present' not yet implemented}}
 #pragma acc loop auto if_present
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto worker
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto vector
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'nohost' not yet implemented}}
 #pragma acc loop auto nohost
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop auto default(none)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop auto if(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop auto self
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop auto copy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop auto pcopy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop auto present_or_copy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented}}
 #pragma acc loop auto use_device(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop auto attach(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented}}
 #pragma acc loop auto delete(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented}}
 #pragma acc loop auto detach(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented}}
 #pragma acc loop auto device(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop auto deviceptr(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented}}
 #pragma acc loop auto device_resident(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop auto firstprivate(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented}}
 #pragma acc loop auto host(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented}}
 #pragma acc loop auto link(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop auto no_create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop auto present(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto private(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop auto copyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop auto pcopyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop auto present_or_copyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop auto copyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop auto pcopyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop auto present_or_copyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop auto create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop auto pcreate(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop auto present_or_create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto reduction(+:Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto collapse(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'bind' not yet implemented}}
 #pragma acc loop auto bind(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop auto vector_length(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop auto num_gangs(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop auto num_workers(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_num' not yet implemented}}
 #pragma acc loop auto device_num(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'default_async' not yet implemented}}
 #pragma acc loop auto default_async(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto device_type(*)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto dtype(*)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop auto async
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto tile(1+2, 1)
-  for(;;)
-    for(;;);
+  for(unsigned j = 0; j < 5; ++j)
+    for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop auto gang
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop auto wait
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 
   // expected-warning@+1{{OpenACC clause 'finalize' not yet implemented}}
 #pragma acc loop finalize auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'if_present' not yet implemented}}
 #pragma acc loop if_present auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop worker auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop vector auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'nohost' not yet implemented}}
 #pragma acc loop nohost auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop default(none) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop if(1) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop self auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop copy(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopy(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copy(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented}}
 #pragma acc loop use_device(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop attach(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented}}
 #pragma acc loop delete(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented}}
 #pragma acc loop detach(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented}}
 #pragma acc loop device(VarPtr) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop deviceptr(VarPtr) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented}}
 #pragma acc loop device_resident(VarPtr) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop firstprivate(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented}}
 #pragma acc loop host(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented}}
 #pragma acc loop link(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop no_create(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop present(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop private(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop copyout(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyout(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyout(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop copyin(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyin(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyin(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop create(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop pcreate(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_create(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop reduction(+:Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop collapse(1) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'bind' not yet implemented}}
 #pragma acc loop bind(Var) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop vector_length(1) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop num_gangs(1) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop num_workers(1) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_num' not yet implemented}}
 #pragma acc loop device_num(1) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'default_async' not yet implemented}}
 #pragma acc loop default_async(1) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop dtype(*) auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop async auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop tile(1+2, 1) auto
-  for(;;)
-    for(;;);
+  for(unsigned j = 0; j < 5; ++j)
+    for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop gang auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop wait auto
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 
   // 'independent' can also be combined with any clauses
   // expected-warning@+1{{OpenACC clause 'finalize' not yet implemented}}
 #pragma acc loop independent finalize
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'if_present' not yet implemented}}
 #pragma acc loop independent if_present
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent worker
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent vector
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'nohost' not yet implemented}}
 #pragma acc loop independent nohost
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop independent default(none)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop independent if(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop independent self
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop independent copy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop independent pcopy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop independent present_or_copy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented}}
 #pragma acc loop independent use_device(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop independent attach(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented}}
 #pragma acc loop independent delete(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented}}
 #pragma acc loop independent detach(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented}}
 #pragma acc loop independent device(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop independent deviceptr(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented}}
 #pragma acc loop independent device_resident(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop independent firstprivate(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented}}
 #pragma acc loop independent host(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented}}
 #pragma acc loop independent link(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop independent no_create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop independent present(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent private(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop independent copyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop independent pcopyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop independent present_or_copyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop independent copyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop independent pcopyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop independent present_or_copyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop independent create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop independent pcreate(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop independent present_or_create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent reduction(+:Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent collapse(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'bind' not yet implemented}}
 #pragma acc loop independent bind(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop independent vector_length(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop independent num_gangs(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop independent num_workers(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_num' not yet implemented}}
 #pragma acc loop independent device_num(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'default_async' not yet implemented}}
 #pragma acc loop independent default_async(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent device_type(*)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent dtype(*)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop independent async
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent tile(1+2, 1)
-  for(;;)
-    for(;;);
+  for(unsigned j = 0; j < 5; ++j)
+    for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop independent gang
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop independent wait
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 
   // expected-warning@+1{{OpenACC clause 'finalize' not yet implemented}}
 #pragma acc loop finalize independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'if_present' not yet implemented}}
 #pragma acc loop if_present independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop worker independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop vector independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'nohost' not yet implemented}}
 #pragma acc loop nohost independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop default(none) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop if(1) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop self independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop copy(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopy(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copy(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented}}
 #pragma acc loop use_device(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop attach(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented}}
 #pragma acc loop delete(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented}}
 #pragma acc loop detach(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented}}
 #pragma acc loop device(VarPtr) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop deviceptr(VarPtr) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented}}
 #pragma acc loop device_resident(VarPtr) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop firstprivate(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented}}
 #pragma acc loop host(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented}}
 #pragma acc loop link(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop no_create(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop present(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop private(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop copyout(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyout(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyout(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop copyin(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyin(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyin(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop create(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop pcreate(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_create(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop reduction(+:Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop collapse(1) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'bind' not yet implemented}}
 #pragma acc loop bind(Var) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop vector_length(1) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop num_gangs(1) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop num_workers(1) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_num' not yet implemented}}
 #pragma acc loop device_num(1) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'default_async' not yet implemented}}
 #pragma acc loop default_async(1) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop dtype(*) independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop async independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop tile(1+2, 1) independent
-  for(;;)
-    for(;;);
+  for(unsigned j = 0; j < 5; ++j)
+    for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop gang independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop wait independent
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 
   // 'seq' cannot be combined with 'gang', 'worker' or 'vector'
   // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'seq' clause on a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq gang
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'seq' clause on a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq worker
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'seq' clause on a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop seq vector
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'finalize' not yet implemented}}
 #pragma acc loop seq finalize
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'if_present' not yet implemented}}
 #pragma acc loop seq if_present
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'nohost' not yet implemented}}
 #pragma acc loop seq nohost
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop seq default(none)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop seq if(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop seq self
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop seq copy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop seq pcopy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop seq present_or_copy(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented}}
 #pragma acc loop seq use_device(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop seq attach(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented}}
 #pragma acc loop seq delete(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented}}
 #pragma acc loop seq detach(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented}}
 #pragma acc loop seq device(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop seq deviceptr(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented}}
 #pragma acc loop seq device_resident(VarPtr)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop seq firstprivate(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented}}
 #pragma acc loop seq host(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented}}
 #pragma acc loop seq link(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop seq no_create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop seq present(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop seq private(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop seq copyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop seq pcopyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop seq present_or_copyout(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop seq copyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop seq pcopyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop seq present_or_copyin(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop seq create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop seq pcreate(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop seq present_or_create(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop seq reduction(+:Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop seq collapse(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'bind' not yet implemented}}
 #pragma acc loop seq bind(Var)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop seq vector_length(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop seq num_gangs(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop seq num_workers(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_num' not yet implemented}}
 #pragma acc loop seq device_num(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'default_async' not yet implemented}}
 #pragma acc loop seq default_async(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop seq device_type(*)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop seq dtype(*)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop seq async
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop seq tile(1+2, 1)
   for(;;)
-    for(;;);
+    for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop seq wait
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 
   // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'gang' clause on a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop gang seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'worker' clause on a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop worker seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'vector' clause on a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop vector seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'finalize' not yet implemented}}
 #pragma acc loop finalize seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'if_present' not yet implemented}}
 #pragma acc loop if_present seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'nohost' not yet implemented}}
 #pragma acc loop nohost seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop default(none) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop if(1) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop self seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop copy(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopy(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copy(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'use_device' not yet implemented}}
 #pragma acc loop use_device(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop attach(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'delete' not yet implemented}}
 #pragma acc loop delete(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'detach' not yet implemented}}
 #pragma acc loop detach(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device' not yet implemented}}
 #pragma acc loop device(VarPtr) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop deviceptr(VarPtr) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_resident' not yet implemented}}
 #pragma acc loop device_resident(VarPtr) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop firstprivate(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'host' not yet implemented}}
 #pragma acc loop host(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'link' not yet implemented}}
 #pragma acc loop link(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop no_create(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop present(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop private(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop copyout(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyout(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyout(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop copyin(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop pcopyin(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_copyin(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop create(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop pcreate(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop present_or_create(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop reduction(+:Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop collapse(1) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'bind' not yet implemented}}
 #pragma acc loop bind(Var) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop vector_length(1) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop num_gangs(1) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop num_workers(1) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'device_num' not yet implemented}}
 #pragma acc loop device_num(1) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-warning@+1{{OpenACC clause 'default_async' not yet implemented}}
 #pragma acc loop default_async(1) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop dtype(*) seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop async seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 #pragma acc loop tile(1+2, 1) seq
   for(;;)
-    for(;;);
+    for(unsigned i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop wait seq
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 }

--- a/clang/test/SemaOpenACC/loop-construct-collapse-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-collapse-ast.cpp
@@ -16,21 +16,27 @@ void NormalUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop collapse(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct
   // CHECK-NEXT: collapse clause
   // CHECK-NEXT: ConstantExpr{{.*}}'int'
   // CHECK-NEXT: value: Int 1
   // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 1
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop collapse(force:S{})
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct
   // CHECK-NEXT: collapse clause
   // CHECK-NEXT: ConstantExpr{{.*}}'int'
@@ -41,10 +47,16 @@ void NormalUses() {
   // CHECK-NEXT: MaterializeTemporaryExpr{{.*}}'S' lvalue
   // CHECK-NEXT: CXXTemporaryObjectExpr{{.*}}'S' 'void ()' list
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 }
 
@@ -57,26 +69,38 @@ void TemplUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop collapse(Value)
-  for(;;)
-  for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
   // CHECK-NEXT: OpenACCLoopConstruct
   // CHECK-NEXT: collapse clause
   // CHECK-NEXT: DeclRefExpr{{.*}} 'unsigned int' NonTypeTemplateParm{{.*}} 'Value'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} j 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop collapse(force:T{} + S{})
-  for(;;)
-  for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
   // CHECK-NEXT: OpenACCLoopConstruct
   // CHECK-NEXT: collapse clause
   // CHECK-NEXT: BinaryOperator {{.*}}'+'
@@ -84,15 +108,27 @@ void TemplUses() {
   // CHECK-NEXT: InitListExpr
   // CHECK-NEXT: CXXTemporaryObjectExpr{{.*}}'S' 'void ()' list
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} j 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
   // CHECK-NEXT: NullStmt
 
   // Instantiation:
@@ -111,15 +147,27 @@ void TemplUses() {
   // CHECK-NEXT: NonTypeTemplateParmDecl
   // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} j 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
   // CHECK-NEXT: NullStmt
 
   // CHECK-NEXT: OpenACCLoopConstruct
@@ -138,15 +186,27 @@ void TemplUses() {
   // CHECK-NEXT: MaterializeTemporaryExpr{{.*}}'S' lvalue
   // CHECK-NEXT: CXXTemporaryObjectExpr{{.*}}'S' 'void ()' list
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} j 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
   // CHECK-NEXT: NullStmt
 
 }

--- a/clang/test/SemaOpenACC/loop-construct-collapse-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-collapse-clause.cpp
@@ -18,7 +18,7 @@ void only_one_on_loop() {
   // expected-error@+2{{OpenACC 'collapse' clause cannot appear more than once on a 'loop' directive}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop collapse(1) collapse(1)
-  for(;;);
+  for(unsigned i = 0; i < 5; ++i);
 }
 
 constexpr int three() { return 3; }
@@ -54,61 +54,61 @@ void negative_constexpr_templ() {
   // expected-note@#NCETN1{{in instantiation of function template specialization 'negative_constexpr_templ<int, -1>'}}
   // expected-note@#NCET1{{in instantiation of function template specialization 'negative_constexpr_templ<int, 1>'}}
 #pragma acc loop collapse(T{})
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'collapse' clause loop count must be a positive integer value, evaluated to -1}}
 #pragma acc loop collapse(Val)
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 }
 
 void negative_constexpr(int i) {
 #pragma acc loop collapse(2)
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
 #pragma acc loop collapse(1)
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'collapse' clause loop count must be a positive integer value, evaluated to 0}}
 #pragma acc loop collapse(0)
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'collapse' clause loop count must be a positive integer value, evaluated to -1}}
 #pragma acc loop collapse(-1)
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
 #pragma acc loop collapse(one())
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'collapse' clause loop count must be a positive integer value, evaluated to 0}}
 #pragma acc loop collapse(zero())
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'collapse' clause loop count must be a positive integer value, evaluated to -1}}
 #pragma acc loop collapse(neg())
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'collapse' clause loop count must be a constant expression}}
 #pragma acc loop collapse(NotConstexpr{})
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'collapse' clause loop count must be a positive integer value, evaluated to -1}}
 #pragma acc loop collapse(ConvertsNegative{})
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
 #pragma acc loop collapse(ConvertsOne{})
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   negative_constexpr_templ<int, -1>(); // #NCETN1
 
@@ -120,8 +120,8 @@ void depth_too_high_templ() {
   // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(Val)
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 }
 
 void depth_too_high() {
@@ -130,20 +130,20 @@ void depth_too_high() {
   // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(three())
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 
   // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(ConvertsThree{})
-  for(;;)
-    for(;;);
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
 }
 
 template<typename T, unsigned Three>
@@ -161,16 +161,16 @@ void not_single_loop_templ() {
   // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(Three)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
       do{}while(true); // expected-error{{do loop cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
     }
   }
 
 #pragma acc loop collapse(Three)
-  for(;;) {
-    for(;;){
-      for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
+      for(unsigned k = 0; k < 5;++k) {
         do{}while(true);
       }
     }
@@ -199,18 +199,18 @@ void not_single_loop() {
 
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
-  for(;;) {
-    for(;;){
-      for(;;);
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
+      for(unsigned k = 0; k < 5;++k);
     }
     while(true); // expected-error{{while loop cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
   }
 
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
-  for(;;) {
-    for(;;){
-      for(;;);
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
+      for(unsigned k = 0; k < 5;++k);
     }
     do{}while(true); // expected-error{{do loop cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
   }
@@ -218,29 +218,29 @@ void not_single_loop() {
   // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
       while(true); // expected-error{{while loop cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
     }
   }
   // expected-error@+2{{'collapse' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1 2{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
       do{}while(true); // expected-error{{do loop cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
     }
   }
 
 #pragma acc loop collapse(2)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
       do{}while(true);
     }
   }
 #pragma acc loop collapse(2)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
       while(true);
     }
   }
@@ -257,29 +257,29 @@ void not_single_loop() {
 
   // expected-note@+1 {{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
-  for (;;) {
-    for (;;) {
-      for(;;);
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
+      for(unsigned k = 0; k < 5;++k);
     }
     // expected-error@+1{{more than one for-loop in a loop associated with OpenACC 'loop' construct with a 'collapse' clause}}
-    for(;;);
+      for(unsigned k = 0; k < 5;++k);
   }
 
   // expected-note@+1 {{active 'collapse' clause defined here}}
 #pragma acc loop collapse(3)
-  for (;;) {
-    for (;;) {
-      for(;;);
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
+      for(unsigned k = 0; k < 5;++k);
     // expected-error@+1{{more than one for-loop in a loop associated with OpenACC 'loop' construct with a 'collapse' clause}}
-      for(;;);
+      for(unsigned k = 0; k < 5;++k);
     }
   }
 
-  for(;;);
+  for(unsigned k = 0; k < 5;++k);
 #pragma acc loop collapse(3)
-  for (;;) {
-    for (;;) {
-      for (;;);
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
+      for(unsigned k = 0; k < 5;++k);
     }
   }
 }
@@ -287,12 +287,12 @@ void not_single_loop() {
 template<unsigned Two, unsigned Three>
 void no_other_directives() {
 #pragma acc loop collapse(Two)
-  for(;;) {
-    for (;;) { // last loop associated with the top level.
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {// last loop associated with the top level.
     // expected-error@+1{{'collapse' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop collapse(Three) // expected-note 2{{active 'collapse' clause defined here}}
-      for(;;) {
-        for(;;) {
+      for(unsigned k = 0; k < 6;++k) {
+        for(unsigned l = 0; l < 5; ++l) {
     // expected-error@+1{{OpenACC 'serial' construct cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
 #pragma acc serial
           ;
@@ -301,12 +301,12 @@ void no_other_directives() {
     }
   }
 #pragma acc loop collapse(Two)// expected-note{{active 'collapse' clause defined here}}
-  for(;;) {
-    for (;;) { // last loop associated with the top level.
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {// last loop associated with the top level.
 #pragma acc loop collapse(Three)
-      for(;;) {
-        for(;;) {
-          for(;;);
+      for(unsigned k = 0; k < 6;++k) {
+        for(unsigned l = 0; l < 5; ++l) {
+          for(unsigned m = 0; m < 5; ++m);
         }
       }
     }
@@ -321,17 +321,17 @@ void no_other_directives() {
 
   // Ok, not inside the intervening list
 #pragma acc loop collapse(2)
-  for(;;) {
-    for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
 #pragma acc data // expected-warning{{OpenACC construct 'data' not yet implemented}}
     }
   }
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(2)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     // expected-error@+1{{OpenACC 'data' construct cannot appear in intervening code of a 'loop' with a 'collapse' clause}}
 #pragma acc data // expected-warning{{OpenACC construct 'data' not yet implemented}}
-    for(;;) {
+    for(unsigned j = 0; j < 5; ++j) {
     }
   }
 }
@@ -342,140 +342,158 @@ template<unsigned Two>
 void intervening_without_force_templ() {
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(2)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     // expected-error@+1{{inner loops must be tightly nested inside a 'collapse' clause on a 'loop' construct}}
     call();
-    for(;;){}
+    for(unsigned j = 0; j < 5; ++j);
   }
 
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(Two)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     // expected-error@+1{{inner loops must be tightly nested inside a 'collapse' clause on a 'loop' construct}}
     call();
-    for(;;){}
+    for(unsigned j = 0; j < 5; ++j);
   }
 
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(2)
-  for(;;) {
-    for(;;){}
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j);
     // expected-error@+1{{inner loops must be tightly nested inside a 'collapse' clause on a 'loop' construct}}
     call();
   }
 
 #pragma acc loop collapse(force:2)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     call();
-    for(;;){}
+    for(unsigned j = 0; j < 5; ++j);
   }
 
 #pragma acc loop collapse(force:Two)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     call();
-    for(;;){}
+    for(unsigned j = 0; j < 5; ++j);
   }
 
 
 #pragma acc loop collapse(force:2)
-  for(;;) {
-    for(;;){}
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j);
     call();
   }
 
 #pragma acc loop collapse(force:Two)
-  for(;;) {
-    for(;;){}
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j);
     call();
   }
 
 #pragma acc loop collapse(Two)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
     call();
     }
   }
 
 #pragma acc loop collapse(Two)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     {
       {
-        for(;;){
-        call();
+        for(unsigned j = 0; j < 5; ++j) {
+          call();
         }
       }
     }
   }
 
 #pragma acc loop collapse(force:Two)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
     call();
     }
   }
 
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(Two)
-  for(;;) {
-    for(;;){}
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j);
     // expected-error@+1{{inner loops must be tightly nested inside a 'collapse' clause on a 'loop' construct}}
     call();
   }
+
+#pragma acc loop collapse(2)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(int i = 0;;++i)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-5{{'loop' construct is here}}
+    for(int j = 0;;++j)
+      for(;;);
 }
 
 void intervening_without_force() {
   intervening_without_force_templ<2>(); // expected-note{{in instantiation of function template specialization}}
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(2)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     // expected-error@+1{{inner loops must be tightly nested inside a 'collapse' clause on a 'loop' construct}}
     call();
-    for(;;){}
+    for(unsigned j = 0; j < 5; ++j);
   }
 
   // expected-note@+1{{active 'collapse' clause defined here}}
 #pragma acc loop collapse(2)
-  for(;;) {
-    for(;;){}
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j);
     // expected-error@+1{{inner loops must be tightly nested inside a 'collapse' clause on a 'loop' construct}}
     call();
   }
 
   // The below two are fine, as they use the 'force' tag.
 #pragma acc loop collapse(force:2)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     call();
-    for(;;){}
+    for(unsigned j = 0; j < 5; ++j);
   }
 
 #pragma acc loop collapse(force:2)
-  for(;;) {
-    for(;;){}
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j);
     call();
   }
 
 #pragma acc loop collapse(2)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
     call();
     }
   }
 #pragma acc loop collapse(2)
-  for(;;) {
+  for(unsigned i = 0; i < 5; ++i) {
     {
       {
-        for(;;){
-        call();
+        for(unsigned j = 0; j < 5; ++j) {
+          call();
         }
       }
     }
   }
 
 #pragma acc loop collapse(force:2)
-  for(;;) {
-    for(;;){
+  for(unsigned i = 0; i < 5; ++i) {
+    for(unsigned j = 0; j < 5; ++j) {
     call();
     }
   }
+
+#pragma acc loop collapse(2)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(int i = 0;;++i)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-5{{'loop' construct is here}}
+    for(int j = 0;;++j)
+      for(;;);
 }
 

--- a/clang/test/SemaOpenACC/loop-construct-device_type-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-device_type-ast.cpp
@@ -20,70 +20,106 @@ void NormalUses() {
   // CHECK-NEXT: VarDecl{{.*}} SomeVar 'bool'
 
 #pragma acc loop device_type(SomeS) dtype(SomeImpl)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: device_type(SomeS)
   // CHECK-NEXT: dtype(SomeImpl)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 #pragma acc loop device_type(SomeVar) dtype(int)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: device_type(SomeVar)
   // CHECK-NEXT: dtype(int)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 #pragma acc loop device_type(private) dtype(struct)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: device_type(private)
   // CHECK-NEXT: dtype(struct)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 #pragma acc loop device_type(private) dtype(class)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: device_type(private)
   // CHECK-NEXT: dtype(class)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 #pragma acc loop device_type(float) dtype(*)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: device_type(float)
   // CHECK-NEXT: dtype(*)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 #pragma acc loop device_type(float, int) dtype(*)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: device_type(float, int)
   // CHECK-NEXT: dtype(*)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 }
 
@@ -94,15 +130,21 @@ void TemplUses() {
   // CHECK-NEXT: FunctionDecl{{.*}}TemplUses
   // CHECK-NEXT: CompoundStmt
 #pragma acc loop device_type(T) dtype(T)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}
   // CHECK-NEXT: device_type(T)
   // CHECK-NEXT: dtype(T)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 
 
@@ -116,10 +158,16 @@ void TemplUses() {
   // CHECK-NEXT: device_type(T)
   // CHECK-NEXT: dtype(T)
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: CompoundStmt
 }
 

--- a/clang/test/SemaOpenACC/loop-construct-device_type-clause.c
+++ b/clang/test/SemaOpenACC/loop-construct-device_type-clause.c
@@ -7,193 +7,193 @@ void uses() {
   STy SImpl;
 
 #pragma acc loop device_type(I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(S) dtype(STy)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop dtype(SImpl)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop dtype(int) device_type(*)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop dtype(true) device_type(false)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{expected identifier}}
 #pragma acc loop dtype(int, *)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop device_type(I, int)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{expected ','}}
   // expected-error@+1{{expected identifier}}
 #pragma acc loop dtype(int{})
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{expected identifier}}
 #pragma acc loop dtype(5)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{expected identifier}}
 #pragma acc loop dtype(MACRO)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 
   // Only 'collapse', 'gang', 'worker', 'vector', 'seq', 'independent', 'auto',
   // and 'tile'  allowed after 'device_type'.
 
 #pragma acc loop device_type(*) vector
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{OpenACC clause 'finalize' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) finalize
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'if_present' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) if_present
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) seq
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) independent
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) auto
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'nohost' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) nohost
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'default' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) default(none)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'if' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) if(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'self' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) self
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   int Var;
   int *VarPtr;
   // expected-error@+1{{OpenACC 'copy' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) copy(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopy' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) pcopy(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copy' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) present_or_copy(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'use_device' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) use_device(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'attach' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) attach(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'delete' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) delete(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'detach' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) detach(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'device' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) device(VarPtr)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'deviceptr' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) deviceptr(VarPtr)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'device_resident' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*)  device_resident(VarPtr)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'firstprivate' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) firstprivate(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'host' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) host(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'link' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) link(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'no_create' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) no_create(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) present(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'private' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) private(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) copyout(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyout' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) pcopyout(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyout' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) present_or_copyout(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) copyin(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcopyin' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) pcopyin(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_copyin' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) present_or_copyin(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'create' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) create(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'pcreate' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) pcreate(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'present_or_create' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) present_or_create(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'reduction' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) reduction(+:Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(*) collapse(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'bind' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) bind(Var)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'vector_length' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) vector_length(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_gangs' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) num_gangs(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'num_workers' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) num_workers(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'device_num' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) device_num(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{OpenACC clause 'default_async' may not follow a 'device_type' clause in a 'loop' construct}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop device_type(*) default_async(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'async' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) async
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop device_type(*) tile(*, 1)
-  for(;;)
-    for(;;);
+  for(int j = 0; j < 5; ++j)
+    for(int i = 0; i < 5; ++i);
 
 #pragma acc loop dtype(*) gang
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC 'wait' clause is not valid on 'loop' directive}}
 #pragma acc loop device_type(*) wait
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }

--- a/clang/test/SemaOpenACC/loop-construct-device_type-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-device_type-clause.cpp
@@ -3,21 +3,21 @@
 template<typename T>
 void TemplUses() {
 #pragma acc loop device_type(I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop dtype(*)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(class)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(private)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop device_type(bool)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc kernels dtype(true) device_type(false)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+2{{expected ','}}
   // expected-error@+1{{expected identifier}}
 #pragma acc loop device_type(T::value)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 void Inst() {

--- a/clang/test/SemaOpenACC/loop-construct-gang-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-gang-ast.cpp
@@ -16,13 +16,19 @@ void NormalUses() {
   // CHECK-NEXT: value: Int 1
   // CHECK-NEXT: IntegerLiteral{{.*}}'int' 1
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop gang(dim:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   int Val;
   // CHECK-NEXT: DeclStmt
@@ -33,13 +39,19 @@ void NormalUses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop gang(static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -49,14 +61,20 @@ void NormalUses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop gang(num:1) gang(static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -67,14 +85,20 @@ void NormalUses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop gang(dim:1, static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -82,41 +106,59 @@ void NormalUses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop gang(static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: gang clause static
   // CHECK-NEXT: OpenACCAsteriskSizeExpr
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop gang(static:*)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: gang clause
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop gang
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 template<typename T, unsigned One>
@@ -132,37 +174,55 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: gang clause dim
   // CHECK-NEXT: DeclRefExpr{{.*}}'unsigned int' NonTypeTemplateParm{{.*}} 'One' 'unsigned int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop gang(dim:One)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: gang clause static
   // CHECK-NEXT: DeclRefExpr{{.*}}'T' lvalue ParmVar{{.*}} 'Val' 'T'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop gang(static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: gang clause static
   // CHECK-NEXT: OpenACCAsteriskSizeExpr
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop gang(static:*)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -171,14 +231,20 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: gang clause static
   // CHECK-NEXT: DeclRefExpr{{.*}}'T' lvalue ParmVar{{.*}} 'Val' 'T'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop gang(dim:One) gang(static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -186,41 +252,59 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: DeclRefExpr{{.*}}'unsigned int' NonTypeTemplateParm{{.*}} 'One' 'unsigned int'
   // CHECK-NEXT: DeclRefExpr{{.*}}'T' lvalue ParmVar{{.*}} 'Val' 'T'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop gang(dim:One, static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: gang clause static
   // CHECK-NEXT: DeclRefExpr{{.*}}'T' lvalue ParmVar{{.*}} 'Val' 'T'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop gang(static:Val)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: gang clause
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop gang
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // Instantiation:
   // CHECK-NEXT: FunctionDecl{{.*}} used TemplateUses 'void (int)' implicit_instantiation
@@ -238,10 +322,16 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: NonTypeTemplateParmDecl{{.*}} 'unsigned int' depth 0 index 1 One
   // CHECK-NEXT: IntegerLiteral{{.*}}'unsigned int' 1
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
@@ -249,20 +339,32 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue ParmVar{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: gang clause static
   // CHECK-NEXT: OpenACCAsteriskSizeExpr
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
@@ -277,10 +379,16 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue ParmVar{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
@@ -294,10 +402,16 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue ParmVar{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
@@ -306,20 +420,32 @@ void TemplateUses(T Val) {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue ParmVar{{.*}} 'Val' 'int'
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: gang clause
   // CHECK-NEXT: ForStmt
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
-  // CHECK-NEXT: <<<NULL>>
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
+  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 }
 

--- a/clang/test/SemaOpenACC/loop-construct-gang-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-gang-clause.cpp
@@ -10,65 +10,65 @@ void ParallelOrOrphanTempl() {
   T i;
   // expected-error@+1{{'num' argument on 'gang' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop gang(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{'num' argument on 'gang' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop gang(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'parallel' compute construct}}
 #pragma acc parallel
 #pragma acc loop gang(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'parallel' compute construct}}
 #pragma acc parallel
 #pragma acc loop gang(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{argument to 'gang' clause dimension must be a constant expression}}
 #pragma acc loop gang(dim:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{argument to 'gang' clause dimension must be a constant expression}}
 #pragma acc parallel
 #pragma acc loop gang(dim:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 0}}
 #pragma acc loop gang(dim:Zero)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 0}}
 #pragma acc parallel
 #pragma acc loop gang(dim:Zero)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 4}}
 #pragma acc loop gang(dim:Four)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 4}}
 #pragma acc parallel
 #pragma acc loop gang(dim:Four)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop gang(static:i) gang(dim:Two)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc parallel
 #pragma acc loop gang(dim:Two) gang(static:*)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc parallel
 #pragma acc loop gang(dim:Two, static:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+4{{OpenACC 'gang' clause may have at most one 'static' argument}}
   // expected-note@+3{{previous expression is here}}
   // expected-error@+2{{OpenACC 'gang' clause may have at most one 'dim' argument}}
   // expected-note@+1{{previous expression is here}}
 #pragma acc loop gang(static:i, static:i, dim:Two, dim:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 void ParallelOrOrphan() {
@@ -77,65 +77,65 @@ void ParallelOrOrphan() {
   int i;
   // expected-error@+1{{'num' argument on 'gang' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop gang(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{'num' argument on 'gang' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop gang(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'parallel' compute construct}}
 #pragma acc parallel
 #pragma acc loop gang(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'parallel' compute construct}}
 #pragma acc parallel
 #pragma acc loop gang(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{argument to 'gang' clause dimension must be a constant expression}}
 #pragma acc loop gang(dim:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{argument to 'gang' clause dimension must be a constant expression}}
 #pragma acc parallel
 #pragma acc loop gang(dim:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 0}}
 #pragma acc loop gang(dim:0)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 0}}
 #pragma acc parallel
 #pragma acc loop gang(dim:0)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 4}}
 #pragma acc loop gang(dim:4)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 4}}
 #pragma acc parallel
 #pragma acc loop gang(dim:4)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop gang(static:i) gang(dim:2)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   S s;
   // expected-error@+2{{OpenACC clause 'gang' requires expression of integer type ('S' invalid)}}
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:s)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   Converts C;
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:C)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 template<typename SomeS, typename SomeC, typename Int>
@@ -144,20 +144,20 @@ void StaticIsIntegralTempl() {
   // expected-error@+2{{OpenACC clause 'gang' requires expression of integer type ('S' invalid)}}
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:s)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   SomeC C;
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:C)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   Int i;
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:*)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 void StaticIsIntegral() {
@@ -167,12 +167,12 @@ void StaticIsIntegral() {
   // expected-error@+2{{OpenACC clause 'gang' requires expression of integer type ('S' invalid)}}
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:s)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   Converts C;
 #pragma acc parallel
 #pragma acc loop gang(dim:2) gang(static:C)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 template<unsigned I>
@@ -180,21 +180,21 @@ void SerialTempl() {
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop gang(I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop gang(num:I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'dim' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop gang(dim:I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc serial
 #pragma acc loop gang(static:I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 void Serial() {
@@ -203,27 +203,27 @@ void Serial() {
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop gang(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop gang(num:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'dim' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop gang(dim:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc serial
 #pragma acc loop gang(static:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   int i;
 
 #pragma acc serial
 #pragma acc loop gang(static:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 template<typename T>
@@ -232,23 +232,23 @@ void KernelsTempl() {
   // expected-error@+2{{'dim' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'kernels' compute construct}}
 #pragma acc kernels
 #pragma acc loop gang(dim:t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop gang(static:t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{'num' argument to 'gang' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'num_gangs' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels num_gangs(t)
 #pragma acc loop gang(t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{'num' argument to 'gang' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'num_gangs' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels num_gangs(t)
 #pragma acc loop gang(num:t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 void Kernels() {
@@ -257,67 +257,67 @@ void Kernels() {
   // expected-error@+2{{'dim' argument on 'gang' clause is not permitted on a 'loop' construct associated with a 'kernels' compute construct}}
 #pragma acc kernels
 #pragma acc loop gang(dim:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   unsigned t;
 #pragma acc kernels
 #pragma acc loop gang(static:t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{'num' argument to 'gang' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'num_gangs' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels num_gangs(1)
 #pragma acc loop gang(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{'num' argument to 'gang' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'num_gangs' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels num_gangs(1)
 #pragma acc loop gang(num:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop gang(num:1)
-  for(;;) {
+  for(int j = 0; j < 5; ++j) {
     // expected-error@+2{{loop with a 'gang' clause may not exist in the region of a 'gang' clause on a 'kernels' compute construct}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc loop gang(static:1)
-    for(;;);
+    for(int i = 0; i < 5; ++i);
   }
 
 #pragma acc kernels
 #pragma acc loop gang(num:1)
-  for(;;) {
+  for(int j = 0; j < 5; ++j) {
     // allowed, intervening compute construct
 #pragma acc serial
 #pragma acc loop gang(static:1)
-    for(;;);
+    for(int i = 0; i < 5; ++i);
   }
 
 #pragma acc kernels
 #pragma acc loop gang(num:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // OK, on a different 'loop', not in the assoc statement.
 #pragma acc loop gang(static:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{OpenACC 'gang' clause may have at most one unnamed or 'num' argument}}
   // expected-note@+2{{previous expression is here}}
 #pragma acc kernels
 #pragma acc loop gang(5, num:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{OpenACC 'gang' clause may have at most one unnamed or 'num' argument}}
   // expected-note@+2{{previous expression is here}}
 #pragma acc kernels
 #pragma acc loop gang(num:5, 1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{OpenACC 'gang' clause may have at most one unnamed or 'num' argument}}
   // expected-note@+2{{previous expression is here}}
 #pragma acc kernels
 #pragma acc loop gang(num:5, num:1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 void MaxOneEntry() {
@@ -325,11 +325,11 @@ void MaxOneEntry() {
   // expected-note@+2{{previous expression is here}}
 #pragma acc kernels
 #pragma acc loop gang(static: 1, static:1)
-    for(;;);
+    for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop gang gang(static:1)
-    for(;;);
+    for(int i = 0; i < 5; ++i);
 }
 
 

--- a/clang/test/SemaOpenACC/loop-construct-private-clause.c
+++ b/clang/test/SemaOpenACC/loop-construct-private-clause.c
@@ -23,110 +23,110 @@ void uses(int IntParam, short *PointerParam, float ArrayParam[5], Complete Compo
 
   // Check Appertainment:
 #pragma acc loop private(LocalInt)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // Valid cases:
 #pragma acc loop private(LocalInt, LocalPointer, LocalArray)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray[:])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray[:5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray[2:])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray[2:1])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray[2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.EnumMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.ScalarMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.ArrayMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.ArrayMember[5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.PointerMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(GlobalInt, GlobalArray, GlobalPointer, GlobalComposite)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(GlobalArray[2], GlobalPointer[2], GlobalComposite.CompositeMember.A)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite, GlobalComposite)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(IntParam, PointerParam, ArrayParam, CompositeParam)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(PointerParam[IntParam], ArrayParam[IntParam], CompositeParam.CompositeMember.A)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(LocalArray) private(LocalArray[2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(LocalArray, LocalArray[2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(LocalComposite, LocalComposite.ScalarMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(LocalComposite.CompositeMember.A, LocalComposite.ScalarMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(LocalComposite.CompositeMember.A) private(LocalComposite.ScalarMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   Complete LocalComposite2;
 #pragma acc loop private(LocalComposite2.ScalarMember, LocalComposite2.ScalarMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // Invalid cases, arbitrary expressions.
   struct Incomplete *I;
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(*I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(GlobalInt + IntParam)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(+GlobalInt)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{OpenACC sub-array length is unspecified and cannot be inferred because the subscripted value is not an array}}
 #pragma acc loop private(PointerParam[:])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(PointerParam[:5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(PointerParam[:IntParam])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC sub-array length is unspecified and cannot be inferred because the subscripted value is not an array}}
 #pragma acc loop private(PointerParam[2:])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(PointerParam[2:5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(PointerParam[2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(ArrayParam[:])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(ArrayParam[:5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(ArrayParam[:IntParam])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(ArrayParam[2:])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC sub-array specified range [2:5] would be out of the range of the subscripted array size of 5}}
 #pragma acc loop private(ArrayParam[2:5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(ArrayParam[2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{OpenACC sub-array specified range [2:5] would be out of the range of the subscripted array size of 5}}
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private((float*)ArrayParam[2:5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private((float)ArrayParam[2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }

--- a/clang/test/SemaOpenACC/loop-construct-private-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-private-clause.cpp
@@ -24,92 +24,92 @@ void uses(int IntParam, char *PointerParam, float ArrayParam[5], Complete Compos
   // Check Appertainment:
 
 #pragma acc loop private(LocalInt)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // Valid cases:
 #pragma acc loop private(LocalInt, LocalPointer, LocalArray)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalArray[2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.EnumMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.ScalarMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.ArrayMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.ArrayMember[5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite.PointerMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(GlobalInt, GlobalArray, GlobalPointer, GlobalComposite)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(GlobalArray[2], GlobalPointer[2], GlobalComposite.CompositeMember.A)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(LocalComposite, GlobalComposite)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(IntParam, PointerParam, ArrayParam, CompositeParam) private(IntParamRef)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(PointerParam[IntParam], ArrayParam[IntParam], CompositeParam.CompositeMember.A)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 
   // Invalid cases, arbitrary expressions.
   Incomplete *I;
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(*I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(GlobalInt + IntParam)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(+GlobalInt)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 template<typename T, unsigned I, typename V>
 void TemplUses(T t, T (&arrayT)[I], V TemplComp) {
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(+t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(+I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // NTTP's are only valid if it is a reference to something.
   // expected-error@+2{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
   // expected-note@#TEMPL_USES_INST{{in instantiation of}}
 #pragma acc loop private(I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
 #pragma acc loop private(t, I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(arrayT)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(TemplComp)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(TemplComp.PointerMember[5])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(TemplComp.PointerMember[5]) private(TemplComp)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
  int *Pointer;
 #pragma acc loop private(Pointer[:I])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 #pragma acc loop private(Pointer[:t])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // expected-error@+1{{OpenACC sub-array length is unspecified and cannot be inferred because the subscripted value is not an array}}
 #pragma acc loop private(Pointer[1:])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 template<unsigned I, auto &NTTP_REF>
@@ -118,10 +118,10 @@ void NTTP() {
   // expected-error@+2{{OpenACC variable is not a valid variable name, sub-array, array element, member of a composite variable, or composite variable member}}
   // expected-note@#NTTP_INST{{in instantiation of}}
 #pragma acc loop private(I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(NTTP_REF)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 struct S {
@@ -133,16 +133,16 @@ struct S {
 
 void S::foo() {
 #pragma acc loop private(ThisMember, this->ThisMemberArray[1])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(ThisMemberArray[1:2])
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(this)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop private(ThisMember, this->ThisMember)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 void Inst() {

--- a/clang/test/SemaOpenACC/loop-construct-reduction-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-reduction-ast.cpp
@@ -13,113 +13,167 @@ void NormalFunc(int i, float f) {
   // CHECK-NEXT: ParmVarDecl
   // CHECK-NEXT: CompoundStmt
 #pragma acc loop reduction(+: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: +
   // CHECK-NEXT: DeclRefExpr{{.*}} 'int' lvalue ParmVar{{.*}} 'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(*: f)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: *
   // CHECK-NEXT: DeclRefExpr{{.*}} 'float' lvalue ParmVar{{.*}} 'f' 'float'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(max: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: max
   // CHECK-NEXT: DeclRefExpr{{.*}} 'int' lvalue ParmVar{{.*}} 'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(min: f)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: min
   // CHECK-NEXT: DeclRefExpr{{.*}} 'float' lvalue ParmVar{{.*}} 'f' 'float'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(&: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: &
   // CHECK-NEXT: DeclRefExpr{{.*}} 'int' lvalue ParmVar{{.*}} 'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(|: f)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: |
   // CHECK-NEXT: DeclRefExpr{{.*}} 'float' lvalue ParmVar{{.*}} 'f' 'float'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 
 #pragma acc loop reduction(^: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: ^
   // CHECK-NEXT: DeclRefExpr{{.*}} 'int' lvalue ParmVar{{.*}} 'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(&&: f)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: &&
   // CHECK-NEXT: DeclRefExpr{{.*}} 'float' lvalue ParmVar{{.*}} 'f' 'float'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 
 #pragma acc loop reduction(||: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: ||
   // CHECK-NEXT: DeclRefExpr{{.*}} 'int' lvalue ParmVar{{.*}} 'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   }
 
@@ -137,28 +191,40 @@ void TemplFunc() {
   // CHECK-NEXT: VarDecl{{.*}} t 'T'
 
 #pragma acc loop reduction(+: t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: +
   // CHECK-NEXT: DeclRefExpr{{.*}} 'T' lvalue Var{{.*}} 't' 'T'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(*: T::SomeFloat)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: *
   // CHECK-NEXT: DependentScopeDeclRefExpr{{.*}} '<dependent type>' lvalue
   // CHECK-NEXT: NestedNameSpecifier TypeSpec 'T'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
   typename T::IntTy i;
@@ -166,89 +232,131 @@ void TemplFunc() {
   // CHECK-NEXT: VarDecl{{.*}} i 'typename T::IntTy'
 
 #pragma acc loop reduction(max: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: max
   // CHECK-NEXT: DeclRefExpr{{.*}} 'typename T::IntTy' lvalue Var{{.*}} 'i' 'typename T::IntTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(min: t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: min
   // CHECK-NEXT: DeclRefExpr{{.*}} 'T' lvalue Var{{.*}} 't' 'T'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(&: T::SomeFloat)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: &
   // CHECK-NEXT: DependentScopeDeclRefExpr{{.*}} '<dependent type>' lvalue
   // CHECK-NEXT: NestedNameSpecifier TypeSpec 'T'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(|: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: |
   // CHECK-NEXT: DeclRefExpr{{.*}} 'typename T::IntTy' lvalue Var{{.*}} 'i' 'typename T::IntTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(^: t)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: ^
   // CHECK-NEXT: DeclRefExpr{{.*}} 'T' lvalue Var{{.*}} 't' 'T'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(&&: T::SomeFloat)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: &&
   // CHECK-NEXT: DependentScopeDeclRefExpr{{.*}} '<dependent type>' lvalue
   // CHECK-NEXT: NestedNameSpecifier TypeSpec 'T'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 #pragma acc loop reduction(||: i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: ||
   // CHECK-NEXT: DeclRefExpr{{.*}} 'typename T::IntTy' lvalue Var{{.*}} 'i' 'typename T::IntTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
   // Match the instantiation:
@@ -267,10 +375,16 @@ void TemplFunc() {
   // CHECK-NEXT: reduction clause Operator: +
   // CHECK-NEXT: DeclRefExpr{{.*}} 'InstTy' lvalue Var{{.*}} 't' 'InstTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
@@ -278,10 +392,16 @@ void TemplFunc() {
   // CHECK-NEXT: DeclRefExpr{{.*}} 'const float' lvalue Var{{.*}} 'SomeFloat' 'const float'
   // CHECK-NEXT: NestedNameSpecifier TypeSpec 'InstTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: DeclStmt
@@ -291,20 +411,32 @@ void TemplFunc() {
   // CHECK-NEXT: reduction clause Operator: max
   // CHECK-NEXT: DeclRefExpr{{.*}} 'typename InstTy::IntTy':'int' lvalue Var{{.*}} 'i' 'typename InstTy::IntTy':'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: min
   // CHECK-NEXT: DeclRefExpr{{.*}} 'InstTy' lvalue Var{{.*}} 't' 'InstTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
@@ -312,30 +444,48 @@ void TemplFunc() {
   // CHECK-NEXT: DeclRefExpr{{.*}} 'const float' lvalue Var{{.*}} 'SomeFloat' 'const float'
   // CHECK-NEXT: NestedNameSpecifier TypeSpec 'InstTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: |
   // CHECK-NEXT: DeclRefExpr{{.*}} 'typename InstTy::IntTy':'int' lvalue Var{{.*}} 'i' 'typename InstTy::IntTy':'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: ^
   // CHECK-NEXT: DeclRefExpr{{.*}} 'InstTy' lvalue Var{{.*}} 't' 'InstTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
@@ -343,20 +493,32 @@ void TemplFunc() {
   // CHECK-NEXT: DeclRefExpr{{.*}} 'const float' lvalue Var{{.*}} 'SomeFloat' 'const float'
   // CHECK-NEXT: NestedNameSpecifier TypeSpec 'InstTy'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: reduction clause Operator: ||
   // CHECK-NEXT: DeclRefExpr{{.*}} 'typename InstTy::IntTy':'int' lvalue Var{{.*}} 'i' 'typename InstTy::IntTy':'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 }

--- a/clang/test/SemaOpenACC/loop-construct-reduction-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-reduction-clause.cpp
@@ -31,14 +31,14 @@ void uses() {
 #pragma acc serial
   {
 #pragma acc loop reduction(+:CoS, I, F)
-    for(;;){}
+    for(int i = 0; i < 5; ++i){}
   }
 
 #pragma acc serial
   {
   // expected-error@+1{{OpenACC 'reduction' variable must be of scalar type, sub-array, or a composite of scalar types; type is 'int[5]'}}
 #pragma acc loop reduction(+:Array)
-    for(;;){}
+    for(int i = 0; i < 5; ++i){}
   }
 
 #pragma acc serial
@@ -46,17 +46,17 @@ void uses() {
   // expected-error@+2{{OpenACC 'reduction' composite variable must not have non-scalar field}}
   // expected-note@#COS_FIELD{{invalid field is here}}
 #pragma acc loop reduction(+:ChC)
-    for(;;){}
+    for(int i = 0; i < 5; ++i){}
   }
 
 #pragma acc serial
   {
 #pragma acc loop reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc loop reduction(&:I)
-      for(;;) {
+      for(int i = 0; i < 5; ++i) {
       }
     }
   }
@@ -64,11 +64,11 @@ void uses() {
 #pragma acc serial
   {
 #pragma acc loop reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc loop reduction(&:I)
-      for(;;) {
+      for(int i = 0; i < 5; ++i) {
       }
     }
   }
@@ -76,12 +76,12 @@ void uses() {
 #pragma acc serial
   {
 #pragma acc loop reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
 #pragma acc serial
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop reduction(&:I)
-      for(;;) {
+      for(int i = 0; i < 5; ++i) {
       }
     }
   }
@@ -90,11 +90,11 @@ void uses() {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-2{{previous clause is here}}
 #pragma acc loop reduction(&:I)
-  for(;;){}
+  for(int i = 0; i < 5; ++i){}
 
 #pragma acc serial
 #pragma acc loop reduction(&:I)
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (+ vs &)}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc serial reduction(+:I)
@@ -104,7 +104,7 @@ void uses() {
 #pragma acc parallel
   {
 #pragma acc loop reduction(+:I) gang(dim:1)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -113,7 +113,7 @@ void uses() {
   // expected-error@+2{{OpenACC 'gang' clause with a 'dim' value greater than 1 cannot appear on the same 'loop' construct as a 'reduction' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop reduction(+:I) gang(dim:2)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -122,7 +122,7 @@ void uses() {
   // expected-error@+2{{OpenACC 'reduction' clause cannot appear on the same 'loop' construct as a 'gang' clause with a 'dim' value greater than 1}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop gang(dim:2) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -131,7 +131,7 @@ void uses() {
   // expected-error@+2{{OpenACC 'reduction' clause cannot appear on the same 'loop' construct as a 'gang' clause with a 'dim' value greater than 1}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop gang gang(dim:1) gang(dim:2) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -141,7 +141,7 @@ void uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop gang(dim:1) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -151,7 +151,7 @@ void uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop reduction(+:I) gang(dim:1)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 }
@@ -167,14 +167,14 @@ void templ_uses() {
 #pragma acc serial
   {
 #pragma acc loop reduction(+:CoS, I)
-    for(;;){}
+    for(int i = 0; i < 5; ++i){}
   }
 
 #pragma acc serial
   {
   // expected-error@+1{{OpenACC 'reduction' variable must be of scalar type, sub-array, or a composite of scalar types; type is 'int[5]'}}
 #pragma acc loop reduction(+:Array)
-    for(;;){}
+    for(int i = 0; i < 5; ++i){}
   }
 
 #pragma acc serial
@@ -182,17 +182,17 @@ void templ_uses() {
   // expected-error@+2{{OpenACC 'reduction' composite variable must not have non-scalar field}}
   // expected-note@#COS_FIELD{{invalid field is here}}
 #pragma acc loop reduction(+:ChC)
-    for(;;){}
+    for(int i = 0; i < 5; ++i){}
   }
 
 #pragma acc serial
   {
 #pragma acc loop reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc loop reduction(&:I)
-      for(;;) {
+      for(int i = 0; i < 5; ++i) {
       }
     }
   }
@@ -200,11 +200,11 @@ void templ_uses() {
 #pragma acc serial
   {
 #pragma acc loop reduction(+:Array[3])
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc loop reduction(&:Array[3])
-      for(;;) {
+      for(int i = 0; i < 5; ++i) {
       }
     }
   }
@@ -212,11 +212,11 @@ void templ_uses() {
 #pragma acc serial
   {
 #pragma acc loop reduction(+:Array[0:3])
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc loop reduction(&:Array[1:4])
-      for(;;) {
+      for(int i = 0; i < 5; ++i) {
       }
     }
   }
@@ -224,11 +224,11 @@ void templ_uses() {
 #pragma acc serial
   {
 #pragma acc loop reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     // expected-error@+2{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
     // expected-note@-3{{previous clause is here}}
 #pragma acc serial reduction(&:I)
-      for(;;) {
+      for(int i = 0; i < 5; ++i) {
       }
     }
   }
@@ -236,7 +236,7 @@ void templ_uses() {
 #pragma acc parallel
   {
 #pragma acc loop reduction(+:I) gang(dim:One)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -245,7 +245,7 @@ void templ_uses() {
   // expected-error@+2{{OpenACC 'gang' clause with a 'dim' value greater than 1 cannot appear on the same 'loop' construct as a 'reduction' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop reduction(+:I) gang(dim:2)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -254,7 +254,7 @@ void templ_uses() {
   // expected-error@+2{{OpenACC 'reduction' clause cannot appear on the same 'loop' construct as a 'gang' clause with a 'dim' value greater than 1}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop gang(dim:2) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 #pragma acc parallel
@@ -262,7 +262,7 @@ void templ_uses() {
   // expected-error@+2{{OpenACC 'gang' clause with a 'dim' value greater than 1 cannot appear on the same 'loop' construct as a 'reduction' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop reduction(+:I) gang(dim:Two)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -271,7 +271,7 @@ void templ_uses() {
   // expected-error@+2{{OpenACC 'reduction' clause cannot appear on the same 'loop' construct as a 'gang' clause with a 'dim' value greater than 1}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop gang(dim:Two) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -279,7 +279,7 @@ void templ_uses() {
 #pragma acc parallel num_gangs(One)
   {
 #pragma acc loop reduction(+:I) gang(dim:One)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -289,7 +289,7 @@ void templ_uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop reduction(+:I) gang(dim:One)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -299,14 +299,14 @@ void templ_uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop gang(dim:One) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
 #pragma acc parallel num_gangs(One)
   {
 #pragma acc loop reduction(+:I) gang(dim:1)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -316,7 +316,7 @@ void templ_uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop reduction(+:I) gang(dim:1)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -326,14 +326,14 @@ void templ_uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop gang(dim:1) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
 #pragma acc parallel num_gangs(1)
   {
 #pragma acc loop reduction(+:I) gang(dim:One)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -343,7 +343,7 @@ void templ_uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop reduction(+:I) gang(dim:One)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 
@@ -353,7 +353,7 @@ void templ_uses() {
     // expected-note@+2{{previous clause is here}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop gang(dim:One) reduction(+:I)
-    for(;;) {
+    for(int i = 0; i < 5; ++i) {
     }
   }
 }

--- a/clang/test/SemaOpenACC/loop-construct-tile-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-tile-ast.cpp
@@ -16,10 +16,10 @@ void NormalUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop tile(S{}, 1, 2, *)
-  for(;;)
-    for(;;)
-      for(;;)
-        for(;;);
+  for(int i = 0;i < 5;++i)
+    for(int j = 0;j < 5;++j)
+      for(int k = 0;k < 5;++k)
+        for(int l = 0;l < 5;++l);
   // CHECK-NEXT: OpenACCLoopConstruct
   // CHECK-NEXT: tile clause
   // CHECK-NEXT: ConstantExpr{{.*}} 'int'
@@ -37,25 +37,49 @@ void NormalUses() {
   // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 2
   // CHECK-NEXT: OpenACCAsteriskSizeExpr{{.*}}'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} j 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} k 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'k' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'k' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} l 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'l' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'l' 'int'
   // CHECK-NEXT: NullStmt
 }
 
@@ -68,12 +92,12 @@ void TemplUses() {
   // CHECK-NEXT: CompoundStmt
 
 #pragma acc loop tile(S{}, T{}, *, T{} + S{}, Value, Value + 3)
-  for(;;)
-    for(;;)
-      for(;;)
-        for(;;)
-          for(;;)
-            for(;;);
+  for(int i = 0;i < 5;++i)
+    for(int j = 0;j < 5;++j)
+      for(int k = 0;k < 5;++k)
+        for(int l = 0;l < 5;++l)
+          for(int m = 0;m < 5;++m)
+            for(int n = 0;n < 5;++n);
   // CHECK-NEXT: OpenACCLoopConstruct
   // CHECK-NEXT: tile clause
   //
@@ -102,35 +126,71 @@ void TemplUses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}} 'unsigned int' <IntegralCast>
   // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 3
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} j 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} k 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'k' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'k' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} l 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'l' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'l' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} m 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'m' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'m' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} n 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'n' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'n' 'int'
   // CHECK-NEXT: NullStmt
 
   // Instantiation:
@@ -192,35 +252,71 @@ void TemplUses() {
   // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 3
 
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} j 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'j' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} k 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'k' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'k' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} l 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'l' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'l' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} m 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'m' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'m' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} n 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'n' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'n' 'int'
   // CHECK-NEXT: NullStmt
 
 }

--- a/clang/test/SemaOpenACC/loop-construct-tile-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-tile-clause.cpp
@@ -31,18 +31,18 @@ template<typename T, int Val>
 void negative_zero_constexpr_templ() {
   // expected-error@+1 2{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to 0}}
 #pragma acc loop tile(*, T{})
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to -1}}
 #pragma acc loop tile(Val, *)
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to 0}}
 #pragma acc loop tile(zero(), *)
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 }
 
 void negative_zero_constexpr() {
@@ -51,46 +51,46 @@ void negative_zero_constexpr() {
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to 0}}
 #pragma acc loop tile(0, *)
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to 0}}
 #pragma acc loop tile(1, 0)
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to -1}}
 #pragma acc loop tile(1, -1)
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to -1}}
 #pragma acc loop tile(-1, 0)
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to 0}}
 #pragma acc loop tile(zero(), 0)
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to -1}}
 #pragma acc loop tile(1, neg())
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be an asterisk or a constant expression}}
 #pragma acc loop tile(NotConstexpr{})
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{OpenACC 'tile' clause size expression must be positive integer value, evaluated to -1}}
 #pragma acc loop tile(1, ConvertsNegative{})
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
 #pragma acc loop tile(*, ConvertsOne{})
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 }
 
 template<unsigned One>
@@ -107,13 +107,13 @@ void only_for_loops_templ() {
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile(One, 2) // expected-note 2{{active 'tile' clause defined here}}
-  for (;;)
+  for(int i = 0; i < 5; ++i)
       // expected-error@+1{{while loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
     while(true);
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile(One, 2) // expected-note 2{{active 'tile' clause defined here}}
-  for (;;)
+  for(int i = 0; i < 5; ++i)
       // expected-error@+1{{do loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
     do{}while(true);
 }
@@ -132,13 +132,13 @@ void only_for_loops() {
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile(1, 2) // expected-note 2{{active 'tile' clause defined here}}
-  for (;;)
+  for(int i = 0; i < 5; ++i)
       // expected-error@+1{{while loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
     while(true);
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile(1, 2) // expected-note 2{{active 'tile' clause defined here}}
-  for (;;)
+  for(int i = 0; i < 5; ++i)
       // expected-error@+1{{do loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
     do{}while(true);
 }
@@ -147,27 +147,27 @@ void only_one_on_loop() {
   // expected-error@+2{{OpenACC 'tile' clause cannot appear more than once on a 'loop' directive}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc loop tile(1) tile(1)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 template<unsigned Val>
 void depth_too_high_templ() {
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (Val, *, Val) // expected-note{{active 'tile' clause defined here}}
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (Val, *, Val) // expected-note 2{{active 'tile' clause defined here}}
-  for(;;)
-    for(;;)
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j)
       // expected-error@+1{{while loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
       while(true);
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (Val, *, Val) // expected-note 2{{active 'tile' clause defined here}}
-  for(;;)
-    for(;;)
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j)
       // expected-error@+1{{do loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
       do{}while(true);
 
@@ -175,16 +175,16 @@ void depth_too_high_templ() {
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (Val, *, Val) // expected-note 2{{active 'tile' clause defined here}}
-  for(;;)
+  for(int i = 0; i < 5; ++i)
     for(auto x : Arr)
       // expected-error@+1{{while loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
       while(true)
-        for(;;);
+        for(int j = 0; j < 5; ++j);
 
 #pragma acc loop tile (Val, *, Val)
-  for(;;)
+  for(int i = 0; i < 5; ++i)
     for(auto x : Arr)
-      for(;;)
+      for(int j = 0; j < 5; ++j)
         while(true);
 }
 
@@ -195,35 +195,35 @@ int Arr[5];
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (1, *, 3) // expected-note{{active 'tile' clause defined here}}
-  for(;;)
-    for(;;);
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j);
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (1, *, 3) // expected-note 2{{active 'tile' clause defined here}}
-  for(;;)
-    for(;;)
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j)
       // expected-error@+1{{while loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
       while(true);
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (1, *, 3) // expected-note 2{{active 'tile' clause defined here}}
-  for(;;)
-    for(;;)
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j)
       // expected-error@+1{{do loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
       do{}while(true);
 
   // expected-error@+1{{'tile' clause specifies a loop count greater than the number of available loops}}
 #pragma acc loop tile (1, *, 3) // expected-note 2{{active 'tile' clause defined here}}
-  for(;;)
-    for(;;)
+  for(int i = 0; i < 5; ++i)
+    for(int j = 0; j < 5; ++j)
       // expected-error@+1{{while loop cannot appear in intervening code of a 'loop' with a 'tile' clause}}
       while(true)
-        for(;;);
+        for(int j = 0; j < 5; ++j);
 
 #pragma acc loop tile (1, *, 3)
-  for(;;)
+  for(int i = 0; i < 5; ++i)
     for(auto x : Arr)
-      for(;;)
+      for(int j = 0; j < 5; ++j)
         while(true);
 }
 
@@ -233,12 +233,12 @@ void not_single_loop_templ() {
   int Arr[Val];
 
 #pragma acc loop tile (Val, *, 3) // expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     for (auto x : Arr)
-      for(;;);
+      for(int k = 0; k < 5; ++k);
   // expected-error@+1{{more than one for-loop in a loop associated with OpenACC 'loop' construct with a 'tile' clause}}
-    for(;;)
-      for(;;);
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k);
   }
 }
 
@@ -248,12 +248,12 @@ void not_single_loop() {
   int Arr[5];
 
 #pragma acc loop tile (1, *, 3)// expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     for (auto x : Arr)
-      for(;;);
+      for(int k = 0; k < 5; ++k);
   // expected-error@+1{{more than one for-loop in a loop associated with OpenACC 'loop' construct with a 'tile' clause}}
-    for(;;)
-      for(;;);
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k);
   }
 }
 
@@ -263,19 +263,19 @@ void no_other_directives_templ() {
   int Arr[Val];
 
 #pragma acc loop tile (Val, *, 3) // expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     for (auto x : Arr) {
   // expected-error@+1{{OpenACC 'serial' construct cannot appear in intervening code of a 'loop' with a 'tile' clause}}
 #pragma acc serial
       ;
-      for(;;);
+      for(int j = 0; j < 5; ++j);
     }
   }
 
   // OK, in innermost
 #pragma acc loop tile (Val, *, 3)
-  for(;;) {
-    for (;;) {
+  for(int i = 0; i < 5; ++i) {
+    for(int j = 0; j < 5; ++j) {
       for (auto x : Arr) {
 #pragma acc serial
       ;
@@ -289,19 +289,19 @@ void no_other_directives() {
   int Arr[5];
 
 #pragma acc loop tile (1, *, 3) // expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     for (auto x : Arr) {
   // expected-error@+1{{OpenACC 'serial' construct cannot appear in intervening code of a 'loop' with a 'tile' clause}}
 #pragma acc serial
       ;
-      for(;;);
+      for(int j = 0; j < 5; ++j);
     }
   }
 
   // OK, in innermost
 #pragma acc loop tile (3, *, 3)
-  for(;;) {
-    for (;;) {
+  for(int i = 0; i < 5; ++i) {
+    for(int j = 0; j < 5; ++j) {
       for (auto x : Arr) {
 #pragma acc serial
       ;
@@ -314,25 +314,31 @@ void call();
 template<unsigned Val>
 void intervening_templ() {
 #pragma acc loop tile(1, Val, *) // expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     //expected-error@+1{{inner loops must be tightly nested inside a 'tile' clause on a 'loop' construct}}
     call();
-    for(;;)
-      for(;;);
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc loop tile(1, Val, *) // expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     //expected-error@+1{{inner loops must be tightly nested inside a 'tile' clause on a 'loop' construct}}
     unsigned I;
-    for(;;)
-      for(;;);
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc loop tile(1, Val, *)
-  for(;;) {
-    for(;;)
-      for(;;)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(int i = 0;;++i) {
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-5{{'loop' construct is here}}
+    for(int j = 0;;++j)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-8{{'loop' construct is here}}
+      for(int k = 0;;++k)
         call();
   }
 }
@@ -341,25 +347,39 @@ void intervening() {
   intervening_templ<3>();
 
 #pragma acc loop tile(1, 2, *) // expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     //expected-error@+1{{inner loops must be tightly nested inside a 'tile' clause on a 'loop' construct}}
     call();
-    for(;;)
-      for(;;);
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc loop tile(1, 2, *) // expected-note{{active 'tile' clause defined here}}
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
     //expected-error@+1{{inner loops must be tightly nested inside a 'tile' clause on a 'loop' construct}}
     unsigned I;
-    for(;;)
-      for(;;);
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc loop tile(1, 2, *)
-  for(;;) {
-    for(;;)
-      for(;;)
+  for(int i = 0; i < 5; ++i) {
+    for(int j = 0; j < 5; ++j)
+      for(int k = 0; k < 5; ++k)
+        call();
+  }
+
+#pragma acc loop tile(1, 2, *)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(int i = 0;;++i) {
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-5{{'loop' construct is here}}
+    for(int j = 0;;++j)
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-8{{'loop' construct is here}}
+      for(int k = 0;;++k)
+        for(;;)
         call();
   }
 }
@@ -370,7 +390,7 @@ void collapse_tile_depth() {
   // expected-error@+2{{'tile' clause specifies a loop count greater than the number of available loops}}
   // expected-note@+1{{active 'tile' clause defined here}}
 #pragma acc loop tile(1, 2, 3) collapse (3)
-  for(;;) {
-    for(;;);
+  for(int i = 0; i < 5;++i) {
+    for(int j = 0; j < 5; ++j);
   }
 }

--- a/clang/test/SemaOpenACC/loop-construct-vector-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-vector-ast.cpp
@@ -20,78 +20,114 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: DeclRefExpr{{.*}}'unsigned int' NonTypeTemplateParm{{.*}}'I' 'unsigned int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop vector(I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: DeclRefExpr{{.*}}'ConvertsToInt' lvalue ParmVar{{.*}}'CTI' 'ConvertsToInt'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop vector(length:CTI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: DeclRefExpr{{.*}}'Int' lvalue ParmVar{{.*}}'IsI' 'Int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop vector(length:IsI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: DeclRefExpr{{.*}}'Int' lvalue ParmVar{{.*}}'IsI' 'Int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop vector(length:IsI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 
   // Instantiations:
@@ -109,10 +145,16 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
@@ -121,10 +163,16 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: NonTypeTemplateParmDecl{{.*}}'unsigned int' depth 0 index 0 I
   // CHECK-NEXT: IntegerLiteral{{.*}} 'unsigned int' 3
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
@@ -134,10 +182,16 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: MemberExpr{{.*}} .operator int
   // CHECK-NEXT: DeclRefExpr{{.*}}'Converts' lvalue ParmVar{{.*}}'CTI' 'Converts'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
@@ -146,20 +200,32 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue ParmVar{{.*}}'IsI' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
@@ -168,10 +234,16 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue ParmVar{{.*}}'IsI' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 
 
@@ -204,26 +276,38 @@ void uses() {
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue Var
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop vector(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: vector clause
@@ -232,26 +316,38 @@ void uses() {
   // CHECK-NEXT: MemberExpr{{.*}} .operator int
   // CHECK-NEXT: DeclRefExpr{{.*}}'Converts' lvalue Var{{.*}}'C' 'Converts'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop vector(length:C)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -261,14 +357,20 @@ void uses() {
   // CHECK-NEXT: MemberExpr{{.*}} .operator int
   // CHECK-NEXT: DeclRefExpr{{.*}}'Converts' lvalue Var{{.*}}'C' 'Converts'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop vector(C)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -276,27 +378,39 @@ void uses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue Var
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop vector(length:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -306,14 +420,20 @@ void uses() {
   // CHECK-NEXT: MemberExpr{{.*}} .operator int
   // CHECK-NEXT: DeclRefExpr{{.*}}'Converts' lvalue Var{{.*}}'C' 'Converts'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop vector(C)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
@@ -321,26 +441,38 @@ void uses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue Var
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop vector(length:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: vector clause
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop vector
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 #endif // PCH_HELPER

--- a/clang/test/SemaOpenACC/loop-construct-vector-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-vector-clause.cpp
@@ -3,59 +3,59 @@
 template<typename Int, typename NotInt, typename ConvertsToInt>
 void TemplUses(Int I, NotInt NI, ConvertsToInt CTI) {
 #pragma acc loop vector(I)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
 #pragma acc parallel
 #pragma acc loop vector(length: I)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
 #pragma acc kernels
 #pragma acc loop vector(CTI)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
   // expected-error@+2{{OpenACC clause 'vector' requires expression of integer type ('NoConvert' invalid)}}
 #pragma acc kernels
 #pragma acc loop vector(length: NI)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
   // expected-error@+2{{'num' argument on 'vector' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop vector(length: I)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
   // expected-error@+3{{'num' argument to 'vector' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'vector_length' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels vector_length(I)
 #pragma acc loop vector(length: CTI)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
 #pragma acc loop vector
-  for(;;) {
-    for(;;);
+  for(int i = 0; i < 5; ++i) {
+    for(int j = 0; j < 5; ++j);
     // expected-error@+2{{loop with a 'vector' clause may not exist in the region of a 'vector' clause}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop vector
-    for(;;);
-    for(;;);
+    for(int j = 0; j < 5; ++j);
+    for(int j = 0; j < 5; ++j);
   }
 
 #pragma acc loop vector
-  for(;;) {
-    for(;;);
+  for(int i = 0; i < 5; ++i) {
+    for(int j = 0; j < 5; ++j);
     // expected-error@+4{{loop with a 'vector' clause may not exist in the region of a 'vector' clause}}
     // expected-error@+3{{loop with a 'worker' clause may not exist in the region of a 'vector' clause}}
     // expected-error@+2{{loop with a 'gang' clause may not exist in the region of a 'vector' clause}}
     // expected-note@-6 3{{previous clause is here}}
 #pragma acc loop vector, worker, gang
-    for(;;);
-    for(;;);
+    for(int j = 0; j < 5; ++j);
+    for(int j = 0; j < 5; ++j);
   }
 
 #pragma acc loop vector
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
 #pragma acc serial
 #pragma acc loop vector
-    for(;;);
+    for(int j = 0; j < 5; ++j);
   }
 }
 
@@ -72,65 +72,65 @@ void uses() {
   Converts CTI;
 
 #pragma acc loop vector(i)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
 #pragma acc parallel
 #pragma acc loop vector(length: i)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
 #pragma acc kernels
 #pragma acc loop vector(CTI)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
   // expected-error@+2{{OpenACC clause 'vector' requires expression of integer type ('NoConvert' invalid)}}
 #pragma acc kernels
 #pragma acc loop vector(length: NI)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
   // expected-error@+2{{'num' argument on 'vector' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop vector(length: i)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
   // expected-error@+3{{'num' argument to 'vector' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'vector_length' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels vector_length(i)
 #pragma acc loop vector(length: i)
-  for(;;);
+  for(int j = 0; j < 5; ++j);
 
 #pragma acc loop vector
-  for(;;) {
-    for(;;);
+  for(int i = 0; i < 5; ++i) {
+    for(int j = 0; j < 5; ++j);
     // expected-error@+2{{loop with a 'vector' clause may not exist in the region of a 'vector' clause}}
     // expected-note@-4{{previous clause is here}}
 #pragma acc loop vector
-    for(;;);
-    for(;;);
+    for(int j = 0; j < 5; ++j);
+    for(int j = 0; j < 5; ++j);
   }
 
 #pragma acc loop vector
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
 #pragma acc serial
 #pragma acc loop vector
-    for(;;);
+    for(int j = 0; j < 5; ++j);
   }
 
 #pragma acc loop vector
-  for(;;) {
-    for(;;);
+  for(int i = 0; i < 5; ++i) {
+    for(int j = 0; j < 5; ++j);
     // expected-error@+4{{loop with a 'vector' clause may not exist in the region of a 'vector' clause}}
     // expected-error@+3{{loop with a 'worker' clause may not exist in the region of a 'vector' clause}}
     // expected-error@+2{{loop with a 'gang' clause may not exist in the region of a 'vector' clause}}
     // expected-note@-6 3{{previous clause is here}}
 #pragma acc loop vector, worker, gang
-    for(;;);
-    for(;;);
+    for(int j = 0; j < 5; ++j);
+    for(int j = 0; j < 5; ++j);
   }
 
 #pragma acc loop vector
-  for(;;) {
+  for(int i = 0; i < 5; ++i) {
 #pragma acc serial
 #pragma acc loop vector, worker, gang
-    for(;;);
+    for(int j = 0; j < 5; ++j);
   }
 }

--- a/clang/test/SemaOpenACC/loop-construct-worker-ast.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-worker-ast.cpp
@@ -20,81 +20,117 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: DeclRefExpr{{.*}} 'ConvertsToInt' lvalue ParmVar
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop worker(CTI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: DeclRefExpr{{.*}} 'Int' lvalue ParmVar
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop worker(num:IsI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: DeclRefExpr{{.*}} 'unsigned int' NonTypeTemplateParm{{.*}}'I' 'unsigned int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop worker(num:I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // Instantiations:
   // CHECK-NEXT: FunctionDecl{{.*}} TemplUses 'void (Converts, int)' implicit_instantiation
@@ -111,30 +147,48 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
@@ -145,10 +199,16 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: MemberExpr{{.*}} .operator int
   // CHECK-NEXT: DeclRefExpr{{.*}} 'Converts' lvalue ParmVar
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
@@ -157,10 +217,16 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: ImplicitCastExpr{{.*}} 'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}} 'int' lvalue ParmVar{{.*}} 'IsI' 'int'
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
   //
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} kernels
@@ -170,10 +236,16 @@ void TemplUses(ConvertsToInt CTI, Int IsI) {
   // CHECK-NEXT: NonTypeTemplateParmDecl{{.*}}'unsigned int' depth 0 index 0 I
   // CHECK-NEXT: IntegerLiteral{{.*}} 'unsigned int' 3
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 }
 
@@ -191,39 +263,57 @@ void uses() {
   // CHECK: OpenACCLoopConstruct{{.*}}<orphan>
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} parallel
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc parallel
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // CHECK-NEXT: OpenACCComputeConstruct 0x[[COMPUTE_ADDR:[0-9a-f]+]]{{.*}} serial
   // CHECK-NEXT: OpenACCLoopConstruct{{.*}} parent: 0x[[COMPUTE_ADDR]]
   // CHECK-NEXT: worker clause{{.*}}
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc serial
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   Converts CTI;
   // CHECK-NEXT: DeclStmt
@@ -238,14 +328,20 @@ void uses() {
   // CHECK-NEXT: MemberExpr{{.*}} .operator int
   // CHECK-NEXT: DeclRefExpr{{.*}}'Converts' lvalue Var
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop worker(CTI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   int IsI;
   // CHECK-NEXT: DeclStmt
@@ -257,14 +353,20 @@ void uses() {
   // CHECK-NEXT: ImplicitCastExpr{{.*}}'int' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr{{.*}}'int' lvalue Var
   // CHECK-NEXT: ForStmt
+  // CHECK-NEXT: DeclStmt
+  // CHECK-NEXT: VarDecl{{.*}} i 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 0
   // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
-  // CHECK-NEXT: <<<NULL>>>
+  // CHECK-NEXT: BinaryOperator{{.*}}'<'
+  // CHECK-NEXT: ImplicitCastExpr
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
+  // CHECK-NEXT: IntegerLiteral{{.*}} 'int' 5
+  // CHECK-NEXT: UnaryOperator{{.*}}++
+  // CHECK-NEXT: DeclRefExpr{{.*}}'i' 'int'
   // CHECK-NEXT: NullStmt
 #pragma acc kernels
 #pragma acc loop worker(num:IsI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }
 
 #endif // PCH_HELPER

--- a/clang/test/SemaOpenACC/loop-construct-worker-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-worker-clause.cpp
@@ -6,47 +6,47 @@ void TemplUses(NotInt NI, ConvertsToInt CTI, Int IsI) {
 
   // expected-error@+1{{'num' argument on 'worker' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop worker(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{'num' argument on 'worker' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop worker(num:IsI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker(CTI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker(IsI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker(I)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
   // expected-error@+1{{OpenACC clause 'worker' requires expression of integer type ('NoConvert' invalid)}}
 #pragma acc loop worker(NI)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{'num' argument to 'worker' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'num_workers' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels num_workers(IsI)
 #pragma acc loop worker(num:CTI)
-  for(;;);
- for(;;);
+  for(int i = 0; i < 5; ++i);
+ for(int i = 0; i < 5; ++i);
 }
 
 struct NoConvert{};
@@ -58,145 +58,145 @@ void uses() {
   TemplUses<3>(NoConvert{}, Converts{}, 5); // expected-note{{in instantiation of function template specialization}}
 
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc parallel
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   int i;
 
   // expected-error@+1{{'num' argument on 'worker' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop worker(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'worker' clause is not permitted on a 'loop' construct associated with a 'parallel' compute construct}}
 #pragma acc parallel
 #pragma acc loop worker(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+1{{'num' argument on 'worker' clause is not permitted on an orphaned 'loop' construct}}
 #pragma acc loop worker(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'worker' clause is not permitted on a 'loop' construct associated with a 'parallel' compute construct}}
 #pragma acc parallel
 #pragma acc loop worker(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc serial
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'worker' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop worker(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+2{{'num' argument on 'worker' clause is not permitted on a 'loop' construct associated with a 'serial' compute construct}}
 #pragma acc serial
 #pragma acc loop worker(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker(i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   Converts Cvts;
 
 #pragma acc kernels
 #pragma acc loop worker(Cvts)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   NoConvert NoCvts;
 
 #pragma acc kernels
   // expected-error@+1{{OpenACC clause 'worker' requires expression of integer type ('NoConvert' invalid)}}
 #pragma acc loop worker(NoCvts)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc kernels
 #pragma acc loop worker(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
   // expected-error@+3{{'num' argument to 'worker' clause not allowed on a 'loop' construct associated with a 'kernels' construct that has a 'num_workers' clause}}
   // expected-note@+1{{previous clause is here}}
 #pragma acc kernels num_workers(i)
 #pragma acc loop worker(num:i)
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
     // expected-error@+3{{loop with a 'worker' clause may not exist in the region of a 'worker' clause}}
     // expected-error@+2{{loop with a 'gang' clause may not exist in the region of a 'worker' clause}}
     // expected-note@-4 2{{previous clause is here}}
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
 #pragma acc parallel
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 
 
 #pragma acc parallel
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
     // expected-error@+3{{loop with a 'worker' clause may not exist in the region of a 'worker' clause}}
     // expected-error@+2{{loop with a 'gang' clause may not exist in the region of a 'worker' clause}}
     // expected-note@-4 2{{previous clause is here}}
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc parallel
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
 #pragma acc parallel
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc serial
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
     // expected-error@+3{{loop with a 'worker' clause may not exist in the region of a 'worker' clause}}
     // expected-error@+2{{loop with a 'gang' clause may not exist in the region of a 'worker' clause}}
     // expected-note@-4 2{{previous clause is here}}
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc serial
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
 #pragma acc parallel
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc kernels
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
     // expected-error@+3{{loop with a 'worker' clause may not exist in the region of a 'worker' clause}}
     // expected-error@+2{{loop with a 'gang' clause may not exist in the region of a 'worker' clause}}
     // expected-note@-4 2{{previous clause is here}}
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 
 #pragma acc kernels
 #pragma acc loop worker
-  for(;;) {
+  for(int i= 0; i< 5; ++i) {
 #pragma acc parallel
 #pragma acc loop worker, gang
-  for(;;) {}
+  for(int k = 0; k < 5; ++k);
   }
 }

--- a/clang/test/SemaOpenACC/loop-construct.cpp
+++ b/clang/test/SemaOpenACC/loop-construct.cpp
@@ -1,0 +1,384 @@
+// RUN: %clang_cc1 %s -fopenacc -verify -Wno-empty-body -Wno-unused-value
+namespace std {
+  struct random_access_iterator_tag{};
+}
+
+struct SomeStruct{
+  void operator++();
+  void operator++(int);
+};
+
+struct SomeIterator {
+  bool operator!=(SomeIterator&);
+  void operator++();
+  void operator++(int);
+  int operator*();
+};
+
+struct SomeRAIterator {
+  using iterator_category = std::random_access_iterator_tag;
+  SomeRAIterator();
+  SomeRAIterator(int i);
+
+  void operator=(int i);
+  SomeRAIterator &operator=(SomeRAIterator&);
+
+  void operator++(int);
+  void operator++();
+  int operator*();
+  void operator+=(int);
+  bool operator!=(SomeRAIterator&);
+    // TODO
+};
+
+struct HasIteratorCollection {
+  SomeIterator &begin();
+  SomeIterator &end();
+};
+
+struct HasRAIteratorCollection {
+  SomeRAIterator &begin();
+  SomeRAIterator &end();
+};
+
+void func_call();
+
+template<typename Int, typename IntPtr, typename Float, typename Struct, typename Iterator, typename RandAccessIterator>
+void SeqLoopRules() {
+
+  // No rules in this section!
+#pragma acc loop seq
+  for(;;);
+
+#pragma acc loop seq
+  for(float f;;);
+
+#pragma acc loop seq
+  for(int f;;);
+
+#pragma acc loop seq
+  for(int f,g;;);
+
+#pragma acc loop seq
+  for(Int f;;);
+
+#pragma acc loop seq
+  for(Int *f;;);
+
+#pragma acc loop seq
+  for(IntPtr f;;);
+
+#pragma acc loop seq
+  for(Float *f;;);
+
+#pragma acc loop seq
+  for(SomeStruct f;;);
+
+#pragma acc loop seq
+  for(Struct f;;);
+
+#pragma acc loop seq
+  for(SomeIterator f;;);
+
+#pragma acc loop seq
+  for(Iterator f;;);
+
+#pragma acc loop seq
+  for(SomeRAIterator f;;);
+
+#pragma acc loop seq
+  for(RandAccessIterator f;;);
+
+#pragma acc loop seq
+  for(Int f;;);
+
+#pragma acc loop seq
+  for(Int f;;++f);
+
+#pragma acc loop seq
+  for(Int f;;f+=1);
+
+  int i;
+#pragma acc loop seq
+  for(Int f;;i+=1);
+
+#pragma acc loop seq
+  for(Int f;;i++);
+
+#pragma acc loop seq
+  for(RandAccessIterator f;;i++);
+
+#pragma acc loop seq
+  for(RandAccessIterator f;;func_call());
+
+  Int Array[5];
+#pragma acc loop seq
+  for(auto X : Array);
+
+#pragma acc loop seq
+  for(auto X : HasIteratorCollection{});
+
+#pragma acc loop seq
+  for(auto X : HasRAIteratorCollection{});
+
+  RandAccessIterator f;
+#pragma acc loop seq
+  for(f;;f++);
+
+#pragma acc loop seq
+  for(f = 0;;++f);
+
+#pragma acc loop seq
+  for(f = 0;;f++);
+
+#pragma acc loop seq
+  for(f = 0;;f+=1);
+}
+
+
+template<typename Int, typename IntPtr, typename Float, typename Struct, typename Iterator, typename RandAccessIterator>
+void LoopRules() {
+
+  // Loop variable must be integer, pointer, or random_access_iterator
+#pragma acc loop
+  // expected-error@+6{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(;;);
+
+#pragma acc loop
+  // expected-error@+6{{loop variable of loop associated with an OpenACC 'loop' construct must be of integer, pointer, or random-access-iterator type (is 'float')}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(float f = 0;;);
+
+#pragma acc loop
+  // expected-error@+6{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(int f;;);
+
+#pragma acc loop
+  // expected-error@+6 2{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2 2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(int f,g;;);
+
+#pragma acc loop
+  // expected-error@+4{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(Int f;;++f);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(Int *f = nullptr;;++f);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(IntPtr f = nullptr;;++f);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(Float *f = nullptr;;++f);
+
+#pragma acc loop
+  // expected-error@+6{{loop variable of loop associated with an OpenACC 'loop' construct must be of integer, pointer, or random-access-iterator type (is 'SomeStruct')}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(SomeStruct f;;);
+
+#pragma acc loop
+  // expected-error@+4{{loop variable of loop associated with an OpenACC 'loop' construct must be of integer, pointer, or random-access-iterator type (is 'SomeStruct')}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(Struct f;;++f);
+
+#pragma acc loop
+  // expected-error@+4{{loop variable of loop associated with an OpenACC 'loop' construct must be of integer, pointer, or random-access-iterator type (is 'SomeIterator')}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(SomeIterator f;;++f);
+
+#pragma acc loop
+  // expected-error@+4{{loop variable of loop associated with an OpenACC 'loop' construct must be of integer, pointer, or random-access-iterator type (is 'SomeIterator')}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(Iterator f;;++f);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(SomeRAIterator f;;++f);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(RandAccessIterator f;;++f);
+
+  Int i;
+#pragma acc loop
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-4{{'loop' construct is here}}
+  for( i = 0;;);
+
+#pragma acc loop
+  // expected-error@+6 2{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2 2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for( i;;);
+
+#pragma acc loop
+  // expected-error@+6{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for( int j ;;);
+
+#pragma acc loop
+  // expected-error@+6 2{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2 2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for( int j, k = 0;;);
+
+#pragma acc loop
+  // expected-error@+6{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(Int f;;);
+
+#pragma acc loop
+  // expected-error@+4{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(Int f;;++f);
+
+#pragma acc loop
+  // expected-error@+4{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(Int f;;f+=1);
+
+#pragma acc loop
+  // expected-error@+6{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(Int f;;i+=1);
+
+#pragma acc loop
+  // expected-error@+6{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-4{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-6{{'loop' construct is here}}
+  for(Int f;;i++);
+
+#pragma acc loop
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(RandAccessIterator f;;i++);
+
+#pragma acc loop
+  // expected-error@+4{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  // expected-error@+2{{OpenACC 'loop' variable must monotonically increase or decrease ('++', '--', or compound assignment)}}
+  // expected-note@-4{{'loop' construct is here}}
+  for(RandAccessIterator f;;func_call());
+
+  // Not much we can do here other than check for random access iterator.
+  Int Array[5];
+#pragma acc loop
+  for(auto X : Array);
+
+#pragma acc loop
+  // expected-error@+2 2{{loop variable of loop associated with an OpenACC 'loop' construct must be of integer, pointer, or random-access-iterator type (is 'SomeIterator')}}
+  // expected-note@-2 2{{'loop' construct is here}}
+  for(auto X : HasIteratorCollection{});
+
+#pragma acc loop
+  for(auto X : HasRAIteratorCollection{});
+
+  RandAccessIterator end;
+#pragma acc loop
+  for(RandAccessIterator f = 0; f != end; ++f);
+
+  RandAccessIterator f;
+#pragma acc loop
+  // expected-error@+2 2{{OpenACC 'loop' construct must have initialization clause in canonical form ('var = init' or 'T var = init'}}
+  // expected-note@-2 2{{'loop' construct is here}}
+  for(f;f != end;f++);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(f = 0;;++f);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(f = 0;;f++);
+
+#pragma acc loop
+  // expected-error@+2{{OpenACC 'loop' construct must have a terminating condition}}
+  // expected-note@-2{{'loop' construct is here}}
+  for(f = 0;;f+=1);
+
+#pragma acc loop
+  for(f = 0;f != end;++f);
+
+#pragma acc loop
+  for(f = 0;f != end;f++);
+
+#pragma acc loop
+  for(f = 0;f != end;f+=1);
+}
+
+void inst() {
+  SeqLoopRules<int, int*, float, SomeStruct, SomeIterator, SomeRAIterator>();
+  // expected-note@+1{{in instantiation of function template specialization}}
+  LoopRules<int, int*, float, SomeStruct, SomeIterator, SomeRAIterator>();
+}
+

--- a/clang/test/SemaOpenACC/loop-loc-and-stmt.c
+++ b/clang/test/SemaOpenACC/loop-loc-and-stmt.c
@@ -34,5 +34,5 @@ void func() {
   {}
 
 #pragma acc loop
-  for(;;);
+  for(int i = 0; i < 5; ++i);
 }

--- a/clang/test/SemaOpenACC/loop-loc-and-stmt.cpp
+++ b/clang/test/SemaOpenACC/loop-loc-and-stmt.cpp
@@ -34,7 +34,7 @@ struct S {
     {}
 
 #pragma acc loop
-    for(;;);
+    for(int i = 0; i < 6; ++i);
 
     int array[5];
 
@@ -66,7 +66,7 @@ void templ_func() {
   {}
 
 #pragma acc loop
-  for(T i;;);
+  for(T i = 0; i < 1; ++i);
 
   T array[5];
 


### PR DESCRIPTION
OpenACC restricts the contents of a 'for' loop affected by a 'loop' construct without a 'seq'. The loop variable must be integer, pointer, or random-access-iterator, it must monotonically increase/decrease, and the trip count must be computable at runtime before the function.

This patch tries to implement some of these limitations to the best of our ability, though it causes us to be perhaps overly restrictive at the moment. I expect we'll revisit some of these rules/add additional supported forms of loop-variable and 'monotonically increasing' here, but the currently enforced rules are heavily inspired by the OMP implementation here.