### PR TITLE
Revert "Add clang::lifetimebound annotation to llvm::function_ref (#1…

### DIFF
--- a/llvm/include/llvm/ADT/STLFunctionalExtras.h
+++ b/llvm/include/llvm/ADT/STLFunctionalExtras.h
@@ -16,7 +16,6 @@
 #define LLVM_ADT_STLFUNCTIONALEXTRAS_H
 
 #include "llvm/ADT/STLForwardCompat.h"
-#include "llvm/Support/Compiler.h"
 
 #include <cstdint>
 #include <type_traits>
@@ -53,7 +52,7 @@ public:
 
   template <typename Callable>
   function_ref(
-      Callable &&callable LLVM_LIFETIME_BOUND,
+      Callable &&callable,
       // This is not the copy-constructor.
       std::enable_if_t<!std::is_same<remove_cvref_t<Callable>,
                                      function_ref>::value> * = nullptr,


### PR DESCRIPTION
…15019)"

This reverts commit 9f796159f28775b3f93d77e173c1fd3413c2e60e.

This is breaking compiler-rt/lib/sanitizer_common/...

Author knows about the breakage.