### PR TITLE
[fang][cuda] Allow * in call chevron syntax

### DIFF
--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -177,6 +177,7 @@ public:
   NODE(parser, Call)
   NODE(parser, CallStmt)
   NODE(CallStmt, Chevrons)
+  NODE(CallStmt, StarOrExpr)
   NODE(parser, CaseConstruct)
   NODE(CaseConstruct, Case)
   NODE(parser, CaseSelector)

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3247,13 +3247,14 @@ struct FunctionReference {
 
 // R1521 call-stmt -> CALL procedure-designator [ chevrons ]
 //         [( [actual-arg-spec-list] )]
-// (CUDA) chevrons -> <<< scalar-expr, scalar-expr [,
+// (CUDA) chevrons -> <<< * | scalar-expr, * | scalar-expr [,
 //          scalar-int-expr [, scalar-int-expr ] ] >>>
 struct CallStmt {
   BOILERPLATE(CallStmt);
+  WRAPPER_CLASS(StarOrExpr, std::optional<ScalarExpr>);
   struct Chevrons {
     TUPLE_CLASS_BOILERPLATE(Chevrons);
-    std::tuple<ScalarExpr, ScalarExpr, std::optional<ScalarIntExpr>,
+    std::tuple<StarOrExpr, StarOrExpr, std::optional<ScalarIntExpr>,
         std::optional<ScalarIntExpr>>
         t;
   };

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3247,7 +3247,7 @@ struct FunctionReference {
 
 // R1521 call-stmt -> CALL procedure-designator [ chevrons ]
 //         [( [actual-arg-spec-list] )]
-// (CUDA) chevrons -> <<< * | scalar-expr, * | scalar-expr [,
+// (CUDA) chevrons -> <<< * | scalar-expr, scalar-expr [,
 //          scalar-int-expr [, scalar-int-expr ] ] >>>
 struct CallStmt {
   BOILERPLATE(CallStmt);

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3254,7 +3254,7 @@ struct CallStmt {
   WRAPPER_CLASS(StarOrExpr, std::optional<ScalarExpr>);
   struct Chevrons {
     TUPLE_CLASS_BOILERPLATE(Chevrons);
-    std::tuple<StarOrExpr, StarOrExpr, std::optional<ScalarIntExpr>,
+    std::tuple<StarOrExpr, ScalarExpr, std::optional<ScalarIntExpr>,
         std::optional<ScalarIntExpr>>
         t;
   };

--- a/flang/lib/Parser/program-parsers.cpp
+++ b/flang/lib/Parser/program-parsers.cpp
@@ -474,7 +474,7 @@ TYPE_CONTEXT_PARSER("function reference"_en_US,
 
 // R1521 call-stmt -> CALL procedure-designator [chevrons]
 ///                          [( [actual-arg-spec-list] )]
-// (CUDA) chevrons -> <<< * | scalar-expr, * | scalar-expr [, scalar-int-expr
+// (CUDA) chevrons -> <<< * | scalar-expr, scalar-expr [, scalar-int-expr
 //                      [, scalar-int-expr ] ] >>>
 constexpr auto starOrExpr{
     construct<CallStmt::StarOrExpr>("*" >> pure<std::optional<ScalarExpr>>() ||

--- a/flang/lib/Parser/program-parsers.cpp
+++ b/flang/lib/Parser/program-parsers.cpp
@@ -480,7 +480,7 @@ constexpr auto starOrExpr{
     construct<CallStmt::StarOrExpr>("*" >> pure<std::optional<ScalarExpr>>() ||
         applyFunction(presentOptional<ScalarExpr>, scalarExpr))};
 TYPE_PARSER(extension<LanguageFeature::CUDA>(
-    "<<<" >> construct<CallStmt::Chevrons>(starOrExpr, ", " >> starOrExpr,
+    "<<<" >> construct<CallStmt::Chevrons>(starOrExpr, ", " >> scalarExpr,
                  maybe("," >> scalarIntExpr), maybe("," >> scalarIntExpr)) /
         ">>>"))
 constexpr auto actualArgSpecList{optionalList(actualArgSpec)};

--- a/flang/lib/Parser/program-parsers.cpp
+++ b/flang/lib/Parser/program-parsers.cpp
@@ -474,10 +474,13 @@ TYPE_CONTEXT_PARSER("function reference"_en_US,
 
 // R1521 call-stmt -> CALL procedure-designator [chevrons]
 ///                          [( [actual-arg-spec-list] )]
-// (CUDA) chevrons -> <<< scalar-expr, scalar-expr [, scalar-int-expr
+// (CUDA) chevrons -> <<< * | scalar-expr, * | scalar-expr [, scalar-int-expr
 //                      [, scalar-int-expr ] ] >>>
+constexpr auto starOrExpr{
+    construct<CallStmt::StarOrExpr>("*" >> pure<std::optional<ScalarExpr>>() ||
+        applyFunction(presentOptional<ScalarExpr>, scalarExpr))};
 TYPE_PARSER(extension<LanguageFeature::CUDA>(
-    "<<<" >> construct<CallStmt::Chevrons>(scalarExpr, "," >> scalarExpr,
+    "<<<" >> construct<CallStmt::Chevrons>(starOrExpr, ", " >> starOrExpr,
                  maybe("," >> scalarIntExpr), maybe("," >> scalarIntExpr)) /
         ">>>"))
 constexpr auto actualArgSpecList{optionalList(actualArgSpec)};

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1703,6 +1703,13 @@ public:
   void Unparse(const IntrinsicStmt &x) { // R1519
     Word("INTRINSIC :: "), Walk(x.v, ", ");
   }
+  void Unparse(const CallStmt::StarOrExpr &x) {
+    if (x.v) {
+      Walk(*x.v);
+    } else {
+      Word("*");
+    }
+  }
   void Unparse(const CallStmt::Chevrons &x) { // CUDA
     Walk(std::get<0>(x.t)); // grid
     Word(","), Walk(std::get<1>(x.t)); // block

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3076,7 +3076,7 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
       }
     } else {
       result.emplace_back(
-          AsGenericExpr(evaluate::Constant<evaluate::SubscriptInteger>{-1}));
+          AsGenericExpr(evaluate::Constant<evaluate::CInteger>{-1}));
     }
     if (auto expr{Analyze(std::get<1>(chevrons->t))};
         expr && checkLaunchArg(*expr, "block")) {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3065,7 +3065,10 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
         which);
     return false;
   }};
+
   if (const auto &chevrons{call.chevrons}) {
+    bool gridIsStar{false};
+    bool blockIsStar{false};
     auto &starOrExpr0{std::get<0>(chevrons->t)};
     if (starOrExpr0.v) {
       if (auto expr{Analyze(*starOrExpr0.v)};
@@ -3075,6 +3078,7 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
         return std::nullopt;
       }
     } else {
+      gridIsStar = true;
       result.emplace_back(
           AsGenericExpr(evaluate::Constant<evaluate::SubscriptInteger>{-1}));
     }
@@ -3087,8 +3091,12 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
         return std::nullopt;
       }
     } else {
+      blockIsStar = true;
       result.emplace_back(
           AsGenericExpr(evaluate::Constant<evaluate::SubscriptInteger>{-1}));
+    }
+    if (gridIsStar && blockIsStar) {
+      Say("Grid and block can not be * in kernel launch parameter"_err_en_US);
     }
     if (const auto &maybeExpr{std::get<2>(chevrons->t)}) {
       if (auto expr{Analyze(*maybeExpr)}) {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3065,11 +3065,10 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
         which);
     return false;
   }};
-
   if (const auto &chevrons{call.chevrons}) {
-    auto &starOrExpr0{std::get<0>(chevrons->t)};
-    if (starOrExpr0.v) {
-      if (auto expr{Analyze(*starOrExpr0.v)};
+    auto &starOrExpr{std::get<0>(chevrons->t)};
+    if (starOrExpr.v) {
+      if (auto expr{Analyze(*starOrExpr.v)};
           expr && checkLaunchArg(*expr, "grid")) {
         result.emplace_back(*expr);
       } else {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3066,17 +3066,29 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
     return false;
   }};
   if (const auto &chevrons{call.chevrons}) {
-    if (auto expr{Analyze(std::get<0>(chevrons->t))};
-        expr && checkLaunchArg(*expr, "grid")) {
-      result.emplace_back(*expr);
+    auto &starOrExpr0{std::get<0>(chevrons->t)};
+    if (starOrExpr0.v) {
+      if (auto expr{Analyze(*starOrExpr0.v)};
+          expr && checkLaunchArg(*expr, "grid")) {
+        result.emplace_back(*expr);
+      } else {
+        return std::nullopt;
+      }
     } else {
-      return std::nullopt;
+      result.emplace_back(
+          AsGenericExpr(evaluate::Constant<evaluate::SubscriptInteger>{-1}));
     }
-    if (auto expr{Analyze(std::get<1>(chevrons->t))};
-        expr && checkLaunchArg(*expr, "block")) {
-      result.emplace_back(*expr);
+    auto &starOrExpr1{std::get<1>(chevrons->t)};
+    if (starOrExpr1.v) {
+      if (auto expr{Analyze(*starOrExpr1.v)};
+          expr && checkLaunchArg(*expr, "block")) {
+        result.emplace_back(*expr);
+      } else {
+        return std::nullopt;
+      }
     } else {
-      return std::nullopt;
+      result.emplace_back(
+          AsGenericExpr(evaluate::Constant<evaluate::SubscriptInteger>{-1}));
     }
     if (const auto &maybeExpr{std::get<2>(chevrons->t)}) {
       if (auto expr{Analyze(*maybeExpr)}) {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3067,8 +3067,6 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
   }};
 
   if (const auto &chevrons{call.chevrons}) {
-    bool gridIsStar{false};
-    bool blockIsStar{false};
     auto &starOrExpr0{std::get<0>(chevrons->t)};
     if (starOrExpr0.v) {
       if (auto expr{Analyze(*starOrExpr0.v)};
@@ -3078,25 +3076,14 @@ std::optional<Chevrons> ExpressionAnalyzer::AnalyzeChevrons(
         return std::nullopt;
       }
     } else {
-      gridIsStar = true;
       result.emplace_back(
           AsGenericExpr(evaluate::Constant<evaluate::SubscriptInteger>{-1}));
     }
-    auto &starOrExpr1{std::get<1>(chevrons->t)};
-    if (starOrExpr1.v) {
-      if (auto expr{Analyze(*starOrExpr1.v)};
-          expr && checkLaunchArg(*expr, "block")) {
-        result.emplace_back(*expr);
-      } else {
-        return std::nullopt;
-      }
+    if (auto expr{Analyze(std::get<1>(chevrons->t))};
+        expr && checkLaunchArg(*expr, "block")) {
+      result.emplace_back(*expr);
     } else {
-      blockIsStar = true;
-      result.emplace_back(
-          AsGenericExpr(evaluate::Constant<evaluate::SubscriptInteger>{-1}));
-    }
-    if (gridIsStar && blockIsStar) {
-      Say("Grid and block can not be * in kernel launch parameter"_err_en_US);
+      return std::nullopt;
     }
     if (const auto &maybeExpr{std::get<2>(chevrons->t)}) {
       if (auto expr{Analyze(*maybeExpr)}) {

--- a/flang/test/Parser/cuf-sanity-common
+++ b/flang/test/Parser/cuf-sanity-common
@@ -40,7 +40,6 @@ module m
     call globalsub<<<1, 2>>>
     call globalsub<<<1, 2, 3>>>
     call globalsub<<<1, 2, 3, 4>>>
-    call globalsub<<<*,*>>>
     call globalsub<<<*,5>>>
     call globalsub<<<1,*>>>
     allocate(pa(32), pinned = isPinned)

--- a/flang/test/Parser/cuf-sanity-common
+++ b/flang/test/Parser/cuf-sanity-common
@@ -41,7 +41,6 @@ module m
     call globalsub<<<1, 2, 3>>>
     call globalsub<<<1, 2, 3, 4>>>
     call globalsub<<<*,5>>>
-    call globalsub<<<1,*>>>
     allocate(pa(32), pinned = isPinned)
   end subroutine
 end module

--- a/flang/test/Parser/cuf-sanity-common
+++ b/flang/test/Parser/cuf-sanity-common
@@ -40,6 +40,9 @@ module m
     call globalsub<<<1, 2>>>
     call globalsub<<<1, 2, 3>>>
     call globalsub<<<1, 2, 3, 4>>>
+    call globalsub<<<*,*>>>
+    call globalsub<<<*,5>>>
+    call globalsub<<<1,*>>>
     allocate(pa(32), pinned = isPinned)
   end subroutine
 end module

--- a/flang/test/Parser/cuf-sanity-tree.CUF
+++ b/flang/test/Parser/cuf-sanity-tree.CUF
@@ -166,17 +166,17 @@ include "cuf-sanity-common"
 !CHECK: | | | | | Call
 !CHECK: | | | | | | ProcedureDesignator -> Name = 'globalsub'
 !CHECK: | | | | | Chevrons
-!CHECK: | | | | | | Scalar -> Expr = '1_4'
+!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '1_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK: | | | | | | Scalar -> Expr = '2_4'
+!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '2_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
 !CHECK: | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL globalsub<<<1_4,2_4,3_4>>>()'
 !CHECK: | | | | | Call
 !CHECK: | | | | | | ProcedureDesignator -> Name = 'globalsub'
 !CHECK: | | | | | Chevrons
-!CHECK: | | | | | | Scalar -> Expr = '1_4'
+!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '1_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK: | | | | | | Scalar -> Expr = '2_4'
+!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '2_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
 !CHECK: | | | | | | Scalar -> Integer -> Expr = '3_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '3'
@@ -184,9 +184,9 @@ include "cuf-sanity-common"
 !CHECK: | | | | | Call
 !CHECK: | | | | | | ProcedureDesignator -> Name = 'globalsub'
 !CHECK: | | | | | Chevrons
-!CHECK: | | | | | | Scalar -> Expr = '1_4'
+!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '1_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK: | | | | | | Scalar -> Expr = '2_4'
+!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '2_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
 !CHECK: | | | | | | Scalar -> Integer -> Expr = '3_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '3'

--- a/flang/test/Parser/cuf-sanity-tree.CUF
+++ b/flang/test/Parser/cuf-sanity-tree.CUF
@@ -168,7 +168,7 @@ include "cuf-sanity-common"
 !CHECK: | | | | | Chevrons
 !CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '1_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '2_4'
+!CHECK: | | | | | | Scalar -> Expr = '2_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
 !CHECK: | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL globalsub<<<1_4,2_4,3_4>>>()'
 !CHECK: | | | | | Call
@@ -176,7 +176,7 @@ include "cuf-sanity-common"
 !CHECK: | | | | | Chevrons
 !CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '1_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '2_4'
+!CHECK: | | | | | | Scalar -> Expr = '2_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
 !CHECK: | | | | | | Scalar -> Integer -> Expr = '3_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '3'
@@ -186,7 +186,7 @@ include "cuf-sanity-common"
 !CHECK: | | | | | Chevrons
 !CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '1_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK: | | | | | | StarOrExpr -> Scalar -> Expr = '2_4'
+!CHECK: | | | | | | Scalar -> Expr = '2_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
 !CHECK: | | | | | | Scalar -> Integer -> Expr = '3_4'
 !CHECK: | | | | | | | LiteralConstant -> IntLiteralConstant = '3'

--- a/flang/test/Parser/cuf-sanity-unparse.CUF
+++ b/flang/test/Parser/cuf-sanity-unparse.CUF
@@ -43,6 +43,9 @@ include "cuf-sanity-common"
 !CHECK:    CALL globalsub<<<1_4,2_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4,4_4>>>()
+!CHECK:    CALL globalsub<<<-1_8,-1_8>>>()
+!CHECK:    CALL globalsub<<<-1_8,5_4>>>()
+!CHECK:    CALL globalsub<<<1_4,-1_8>>>()
 !CHECK:   ALLOCATE(pa(32_4), PINNED=ispinned)
 !CHECK:  END SUBROUTINE
 !CHECK: END MODULE

--- a/flang/test/Parser/cuf-sanity-unparse.CUF
+++ b/flang/test/Parser/cuf-sanity-unparse.CUF
@@ -44,7 +44,6 @@ include "cuf-sanity-common"
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4,4_4>>>()
 !CHECK:    CALL globalsub<<<-1_8,5_4>>>()
-!CHECK:    CALL globalsub<<<1_4,-1_8>>>()
 !CHECK:   ALLOCATE(pa(32_4), PINNED=ispinned)
 !CHECK:  END SUBROUTINE
 !CHECK: END MODULE

--- a/flang/test/Parser/cuf-sanity-unparse.CUF
+++ b/flang/test/Parser/cuf-sanity-unparse.CUF
@@ -43,7 +43,7 @@ include "cuf-sanity-common"
 !CHECK:    CALL globalsub<<<1_4,2_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4,4_4>>>()
-!CHECK:    CALL globalsub<<<-1_8,5_4>>>()
+!CHECK:    CALL globalsub<<<-1_4,5_4>>>()
 !CHECK:   ALLOCATE(pa(32_4), PINNED=ispinned)
 !CHECK:  END SUBROUTINE
 !CHECK: END MODULE

--- a/flang/test/Parser/cuf-sanity-unparse.CUF
+++ b/flang/test/Parser/cuf-sanity-unparse.CUF
@@ -43,7 +43,6 @@ include "cuf-sanity-common"
 !CHECK:    CALL globalsub<<<1_4,2_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4,4_4>>>()
-!CHECK:    CALL globalsub<<<-1_8,-1_8>>>()
 !CHECK:    CALL globalsub<<<-1_8,5_4>>>()
 !CHECK:    CALL globalsub<<<1_4,-1_8>>>()
 !CHECK:   ALLOCATE(pa(32_4), PINNED=ispinned)

--- a/flang/test/Semantics/cuf04.cuf
+++ b/flang/test/Semantics/cuf04.cuf
@@ -20,5 +20,7 @@ module m
     call globsubr
     !ERROR: Kernel launch parameters in chevrons may not be used unless calling a kernel subroutine
     call boring<<<1,2>>>
+    !ERROR: Grid and block can not be * in kernel launch parameter
+    call globsubr<<<*, *>>>
   end subroutine
 end module

--- a/flang/test/Semantics/cuf04.cuf
+++ b/flang/test/Semantics/cuf04.cuf
@@ -20,7 +20,5 @@ module m
     call globsubr
     !ERROR: Kernel launch parameters in chevrons may not be used unless calling a kernel subroutine
     call boring<<<1,2>>>
-    !ERROR: Grid and block can not be * in kernel launch parameter
-    call globsubr<<<*, *>>>
   end subroutine
 end module


### PR DESCRIPTION
Using `*` in call chevron syntax should be allowed. This patch updates the parser to allow this usage. 

```
call sub<<<*,nbBlock>>>()
```