### PR TITLE
[clang][CIR] Move CIRGen types into clang::CIRGen

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -25,14 +25,15 @@
 namespace clang {
 class DeclGroupRef;
 class DiagnosticsEngine;
+namespace CIRGen {
+class CIRGenModule;
+} // namespace CIRGen
 } // namespace clang
 
 namespace mlir {
 class MLIRContext;
 } // namespace mlir
 namespace cir {
-class CIRGenModule;
-
 class CIRGenerator : public clang::ASTConsumer {
   virtual void anchor();
   clang::DiagnosticsEngine &diags;
@@ -44,7 +45,7 @@ class CIRGenerator : public clang::ASTConsumer {
 
 protected:
   std::unique_ptr<mlir::MLIRContext> mlirCtx;
-  std::unique_ptr<CIRGenModule> cgm;
+  std::unique_ptr<clang::CIRGen::CIRGenModule> cgm;
 
 public:
   CIRGenerator(clang::DiagnosticsEngine &diags,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -22,7 +22,9 @@
 #include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
 
-using namespace cir;
+using namespace clang;
+using namespace clang::CIRGen;
+
 CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
                            clang::ASTContext &astctx,
                            const clang::CodeGenOptions &cgo,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -31,10 +31,8 @@ class LangOptions;
 class SourceLocation;
 class SourceRange;
 class TargetInfo;
-} // namespace clang
 
-using namespace clang;
-namespace cir {
+namespace CIRGen {
 
 /// This class organizes the cross-function state that is used while generating
 /// CIR code.
@@ -91,6 +89,8 @@ public:
   DiagnosticBuilder errorNYI(SourceRange, llvm::StringRef);
   DiagnosticBuilder errorNYI(SourceRange, llvm::StringRef, llvm::StringRef);
 };
-} // namespace cir
+} // namespace CIRGen
+
+} // namespace clang
 
 #endif // LLVM_CLANG_LIB_CIR_CODEGEN_CIRGENMODULE_H

--- a/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
@@ -13,7 +13,7 @@
 #ifndef LLVM_CLANG_LIB_CIR_CIRGENTYPECACHE_H
 #define LLVM_CLANG_LIB_CIR_CIRGENTYPECACHE_H
 
-namespace cir {
+namespace clang::CIRGen {
 
 /// This structure provides a set of types that are commonly used
 /// during IR emission. It's initialized once in CodeGenModule's
@@ -22,6 +22,6 @@ struct CIRGenTypeCache {
   CIRGenTypeCache() = default;
 };
 
-} // namespace cir
+} // namespace clang::CIRGen
 
 #endif // LLVM_CLANG_LIB_CIR_CODEGEN_CIRGENTYPECACHE_H

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -36,8 +36,8 @@ void CIRGenerator::Initialize(ASTContext &astCtx) {
 
   mlirCtx = std::make_unique<mlir::MLIRContext>();
   mlirCtx->loadDialect<mlir::cir::CIRDialect>();
-  cgm = std::make_unique<CIRGenModule>(*mlirCtx.get(), astCtx, codeGenOpts,
-                                       diags);
+  cgm = std::make_unique<clang::CIRGen::CIRGenModule>(*mlirCtx.get(), astCtx,
+                                                      codeGenOpts, diags);
 }
 
 mlir::ModuleOp CIRGenerator::getModule() const { return cgm->getModule(); }


### PR DESCRIPTION
https://github.com/llvm/clangir/issues/1025 explains why we want to move
the CIR dialect from the `mlir::cir` to the `cir` namespace. To avoid
overloading the `cir` namespace too much afterwards, move all symbols
whose equivalents live inside the `clang::CodeGen` namespace to a new
`clang::CIRGen` namespace, so that we match the original CodeGen's
structure more closely.