### PR TITLE
[mlir][NFC] IntegerRangeAnalysis: don't loop over splat attr

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
+++ b/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
@@ -42,6 +42,12 @@ void arith::ConstantOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
   }
   if (auto arrayCstAttr =
           llvm::dyn_cast_or_null<DenseIntElementsAttr>(getValue())) {
+    if (arrayCstAttr.isSplat()) {
+      setResultRange(getResult(), ConstantIntRanges::constant(
+                                      arrayCstAttr.getSplatValue<APInt>()));
+      return;
+    }
+
     std::optional<ConstantIntRanges> result;
     for (const APInt &val : arrayCstAttr) {
       auto range = ConstantIntRanges::constant(val);

--- a/mlir/test/Dialect/Vector/int-range-interface.mlir
+++ b/mlir/test/Dialect/Vector/int-range-interface.mlir
@@ -18,6 +18,7 @@ func.func @constant_splat() -> vector<8xi32> {
 }
 
 // CHECK-LABEL: func @float_constant_splat
+// Don't crash on splat floats.
 func.func @float_constant_splat() -> vector<8xf32> {
   %0 = arith.constant dense<3.0> : vector<8xf32>
   func.return %0: vector<8xf32>

--- a/mlir/test/Dialect/Vector/int-range-interface.mlir
+++ b/mlir/test/Dialect/Vector/int-range-interface.mlir
@@ -17,6 +17,12 @@ func.func @constant_splat() -> vector<8xi32> {
   func.return %1 : vector<8xi32>
 }
 
+// CHECK-LABEL: func @float_constant_splat
+func.func @float_constant_splat() -> vector<8xf32> {
+  %0 = arith.constant dense<3.0> : vector<8xf32>
+  func.return %0: vector<8xf32>
+}
+
 // CHECK-LABEL: func @vector_splat
 // CHECK: test.reflect_bounds {smax = 5 : index, smin = 4 : index, umax = 5 : index, umin = 4 : index}
 func.func @vector_splat() -> vector<4xindex> {


### PR DESCRIPTION
Reland https://github.com/llvm/llvm-project/pull/115229 which was reverted by https://github.com/llvm/llvm-project/pull/115388 because it was hitting an assertion in IREE. From the original change: If the `DenseIntElementsAttr` is a splat value, there is no need to loop over the entire attr. Instead, just update with the splat value. 


The problem with the original implementation is that `SplatElementsAttr` might be an attr of non `APInt` (e.g. float) elements. Instead, check if `DenseIntElementsAttr` is splat and use the splat value. Added a test to ensure there's no crash when handling float attrs.