### PR TITLE
[libc] Clean up skipped and failing cmake

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -347,6 +347,7 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # wchar.h entrypoints
     libc.src.wchar.wctob
+    libc.src.wchar.btowc
 )
 
 if(LLVM_LIBC_INCLUDE_SCUDO)
@@ -935,6 +936,11 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_rwlockattr_init
     libc.src.pthread.pthread_rwlockattr_setkind_np
     libc.src.pthread.pthread_rwlockattr_setpshared
+    libc.src.pthread.pthread_spin_destroy
+    libc.src.pthread.pthread_spin_init
+    libc.src.pthread.pthread_spin_lock
+    libc.src.pthread.pthread_spin_trylock
+    libc.src.pthread.pthread_spin_unlock
     libc.src.pthread.pthread_self
     libc.src.pthread.pthread_setname_np
     libc.src.pthread.pthread_setspecific

--- a/libc/src/stdio/scanf_core/reader.h
+++ b/libc/src/stdio/scanf_core/reader.h
@@ -22,7 +22,7 @@ using StreamUngetc = void (*)(int, void *);
 // This is intended to be either a raw string or a buffer syncronized with the
 // file's internal buffer.
 struct ReadBuffer {
-  char *buffer;
+  const char *buffer;
   size_t buff_len;
   size_t buff_cur = 0;
 };
@@ -32,6 +32,7 @@ class Reader {
 
   void *input_stream = nullptr;
 
+  // TODO: Remove these unnecessary function pointers
   StreamGetc stream_getc = nullptr;
   StreamUngetc stream_ungetc = nullptr;
 

--- a/libc/src/stdio/sscanf.cpp
+++ b/libc/src/stdio/sscanf.cpp
@@ -29,8 +29,7 @@ LLVM_LIBC_FUNCTION(int, sscanf,
                                  // and pointer semantics, as well as handling
                                  // destruction automatically.
   va_end(vlist);
-  scanf_core::ReadBuffer rb{const_cast<char *>(buffer),
-                            cpp::numeric_limits<size_t>::max()};
+  scanf_core::ReadBuffer rb{buffer, cpp::numeric_limits<size_t>::max()};
   scanf_core::Reader reader(&rb);
   int ret_val = scanf_core::scanf_main(&reader, format, args);
   // This is done to avoid including stdio.h in the internals. On most systems

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -7,5 +7,18 @@ add_entrypoint_object(
     wctob.h
   DEPENDS
     libc.hdr.types.wint_t
+    libc.hdr.stdio_macros
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  btowc
+  SRCS
+    btowc.cpp
+  HDRS
+    btowc.h
+  DEPENDS
+    libc.hdr.types.wint_t
+    libc.hdr.wchar_macros
     libc.src.__support.wctype_utils
 )

--- a/libc/src/wchar/btowc.cpp
+++ b/libc/src/wchar/btowc.cpp
@@ -11,12 +11,12 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/wctype_utils.h"
 
-#include "hdr/stdio_macros.h" // for EOF.
 #include "hdr/types/wint_t.h"
+#include "hdr/wchar_macros.h" // for WEOF.
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, btowc, (wint_t c)) {
+LLVM_LIBC_FUNCTION(wint_t, btowc, (int c)) {
   auto result = internal::btowc(c);
   if (result.has_value()) {
     return result.value();

--- a/libc/test/integration/src/unistd/CMakeLists.txt
+++ b/libc/test/integration/src/unistd/CMakeLists.txt
@@ -118,4 +118,3 @@ add_integration_test(
   ENV
     EXECV_TEST=PASS
 )
- 

--- a/libc/test/integration/src/unistd/CMakeLists.txt
+++ b/libc/test/integration/src/unistd/CMakeLists.txt
@@ -111,10 +111,11 @@ add_integration_test(
   DEPENDS
     libc_execv_test_normal_exit
     libc_execv_test_signal_exit
-    libc.errno.errno
+    libc.src.errno.errno
     libc.src.sys.wait.waitpid
     libc.src.unistd.execve
     libc.src.unistd.fork
   ENV
     EXECV_TEST=PASS
 )
+ 

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -3502,8 +3502,6 @@ add_fp_unittest(
   DEPENDS
     libc.src.math.fmaf
     libc.src.__support.macros.properties.types
-  FLAGS
-    FMA_OPT__ONLY
 )
 
 add_fp_unittest(

--- a/libc/test/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/test/src/stdio/scanf_core/CMakeLists.txt
@@ -38,7 +38,6 @@ add_libc_unittest(
     converter_test.cpp
   DEPENDS
     libc.src.stdio.scanf_core.reader
-    libc.src.stdio.scanf_core.string_reader
     libc.src.stdio.scanf_core.converter
     libc.src.__support.CPP.string_view
 )

--- a/libc/test/src/stdio/scanf_core/converter_test.cpp
+++ b/libc/test/src/stdio/scanf_core/converter_test.cpp
@@ -10,13 +10,12 @@
 #include "src/stdio/scanf_core/converter.h"
 #include "src/stdio/scanf_core/core_structs.h"
 #include "src/stdio/scanf_core/reader.h"
-#include "src/stdio/scanf_core/string_reader.h"
 
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcScanfConverterTest, RawMatchBasic) {
   const char *str = "abcdef";
-  LIBC_NAMESPACE::scanf_core::StringReader str_reader(str);
+  LIBC_NAMESPACE::scanf_core::ReadBuffer str_reader{str, sizeof(str)};
   LIBC_NAMESPACE::scanf_core::Reader reader(&str_reader);
 
   // Reading "abc" should succeed.
@@ -52,7 +51,7 @@ TEST(LlvmLibcScanfConverterTest, RawMatchBasic) {
 
 TEST(LlvmLibcScanfConverterTest, RawMatchSpaces) {
   const char *str = " a \t\n b   cd";
-  LIBC_NAMESPACE::scanf_core::StringReader str_reader(str);
+  LIBC_NAMESPACE::scanf_core::ReadBuffer str_reader{str, sizeof(str)};
   LIBC_NAMESPACE::scanf_core::Reader reader(&str_reader);
 
   // Reading "a" should fail and not advance.
@@ -99,7 +98,7 @@ TEST(LlvmLibcScanfConverterTest, RawMatchSpaces) {
 TEST(LlvmLibcScanfConverterTest, StringConvSimple) {
   const char *str = "abcDEF123 654LKJihg";
   char result[20];
-  LIBC_NAMESPACE::scanf_core::StringReader str_reader(str);
+  LIBC_NAMESPACE::scanf_core::ReadBuffer str_reader{str, sizeof(str)};
   LIBC_NAMESPACE::scanf_core::Reader reader(&str_reader);
 
   LIBC_NAMESPACE::scanf_core::FormatSection conv;
@@ -121,7 +120,7 @@ TEST(LlvmLibcScanfConverterTest, StringConvSimple) {
 
 TEST(LlvmLibcScanfConverterTest, StringConvNoWrite) {
   const char *str = "abcDEF123 654LKJihg";
-  LIBC_NAMESPACE::scanf_core::StringReader str_reader(str);
+  LIBC_NAMESPACE::scanf_core::ReadBuffer str_reader{str, sizeof(str)};
   LIBC_NAMESPACE::scanf_core::Reader reader(&str_reader);
 
   LIBC_NAMESPACE::scanf_core::FormatSection conv;
@@ -142,7 +141,7 @@ TEST(LlvmLibcScanfConverterTest, StringConvNoWrite) {
 TEST(LlvmLibcScanfConverterTest, StringConvWidth) {
   const char *str = "abcDEF123 654LKJihg";
   char result[6];
-  LIBC_NAMESPACE::scanf_core::StringReader str_reader(str);
+  LIBC_NAMESPACE::scanf_core::ReadBuffer str_reader{str, sizeof(str)};
   LIBC_NAMESPACE::scanf_core::Reader reader(&str_reader);
 
   LIBC_NAMESPACE::scanf_core::FormatSection conv;
@@ -176,7 +175,7 @@ TEST(LlvmLibcScanfConverterTest, StringConvWidth) {
 TEST(LlvmLibcScanfConverterTest, CharsConv) {
   const char *str = "abcDEF123 654LKJihg MNOpqr&*(";
   char result[20];
-  LIBC_NAMESPACE::scanf_core::StringReader str_reader(str);
+  LIBC_NAMESPACE::scanf_core::ReadBuffer str_reader{str, sizeof(str)};
   LIBC_NAMESPACE::scanf_core::Reader reader(&str_reader);
 
   LIBC_NAMESPACE::scanf_core::FormatSection conv;
@@ -231,7 +230,7 @@ TEST(LlvmLibcScanfConverterTest, CharsConv) {
 TEST(LlvmLibcScanfConverterTest, ScansetConv) {
   const char *str = "abcDEF[123] 654LKJihg";
   char result[20];
-  LIBC_NAMESPACE::scanf_core::StringReader str_reader(str);
+  LIBC_NAMESPACE::scanf_core::ReadBuffer str_reader{str, sizeof(str)};
   LIBC_NAMESPACE::scanf_core::Reader reader(&str_reader);
 
   LIBC_NAMESPACE::scanf_core::FormatSection conv;

--- a/libc/test/src/sys/statvfs/linux/CMakeLists.txt
+++ b/libc/test/src/sys/statvfs/linux/CMakeLists.txt
@@ -10,7 +10,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.statvfs.statvfs
     libc.src.sys.stat.mkdirat
-    libc.src.sys.stat.rmdir
+    libc.src.unistd.rmdir
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -24,7 +24,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.statvfs.fstatvfs
     libc.src.sys.stat.mkdirat
-    libc.src.sys.stat.rmdir
+    libc.src.unistd.rmdir
     libc.src.fcntl.open
     libc.src.unistd.close
     libc.test.UnitTest.ErrnoSetterMatcher

--- a/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
@@ -33,7 +33,7 @@ TEST(LlvmLibcSysFStatvfsTest, FStatvfsBasic) {
 TEST(LlvmLibcSysFStatvfsTest, FStatvfsInvalidPath) {
   struct statvfs buf;
 
-  constexpr const char *FILENAME = "testdata/statvfs.testdir";
+  constexpr const char *FILENAME = "statvfs.testdir";
   auto TEST_DIR = libc_make_test_file_path(FILENAME);
 
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),
@@ -47,10 +47,9 @@ TEST(LlvmLibcSysFStatvfsTest, FStatvfsInvalidPath) {
   // exist anymore.
 
   ASSERT_THAT(LIBC_NAMESPACE::fstatvfs(fd, &buf), Succeeds());
+  ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::rmdir(TEST_DIR), Succeeds(0));
 
-  ASSERT_THAT(LIBC_NAMESPACE::fstatvfs(fd, &buf), Fails(ENOENT));
-  ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
-  ASSERT_THAT(LIBC_NAMESPACE::fstatvfs(fd, &buf), Fails(ENOENT));
+  ASSERT_THAT(LIBC_NAMESPACE::fstatvfs(fd, &buf), Fails(EBADF));
 }

--- a/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
@@ -8,6 +8,7 @@
 
 #include "hdr/fcntl_macros.h"
 #include "src/__support/macros/config.h"
+#include "src/errno/libc_errno.h"
 #include "src/sys/stat/mkdirat.h"
 #include "src/sys/statvfs/statvfs.h"
 #include "src/unistd/rmdir.h"
@@ -29,7 +30,7 @@ TEST(LlvmLibcSysStatvfsTest, StatvfsInvalidPath) {
 
   // create the file, assert it exists, then delete it and assert it doesn't
   // exist anymore.
-  constexpr const char *FILENAME = "testdata/statvfs.testdir";
+  constexpr const char *FILENAME = "statvfs.testdir";
   auto TEST_DIR = libc_make_test_file_path(FILENAME);
 
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),


### PR DESCRIPTION
I normally run my cmake with LIBC_CMAKE_VERBOSE_LOGGING set to ON so I
can debug build issues more easily. One of the effects of this is I see
which tests/entrypoints are skipped on my machine. This patch fixes up
the tests and entrypoints that were skipped, but easily fixed. These
were:

libc.src.pthread.pthread_spin_destroy
libc.src.pthread.pthread_spin_init
libc.src.pthread.pthread_spin_lock
libc.src.pthread.pthread_spin_trylock
libc.src.pthread.pthread_spin_unlock
(entrypoints were just missing)

libc.src.wchar.btowc
(I forgot to finish it)

libc.test.src.sys.statvfs.linux.statvfs_test
libc.test.src.sys.statvfs.linux.fstatvfs_test
(Incorrect includes for rmdir, needed some cleanup)

libc.test.integration.src.unistd.execve_test
(wrong dep for errno)

libc.test.src.math.smoke.fmaf_test
(add_fp_unittest doesn't support flags)

libc.test.src.stdio.scanf_core.converter_test
(needed to be moved away from string_reader, further cleanup needed)
