### PR TITLE
[lldb][test] TestConstStaticIntegralMember.py: XFAIL DWARFv4 variant on Darwin

### DIFF
--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -150,7 +150,7 @@ class TestCase(TestBase):
         self.check_inline_static_members("-gdwarf-5")
 
     # On linux this passes due to the manual index
-    @expectedFailureDarwin(debug_info=no_match(["dsym"]))
+    @expectedFailureDarwin
     def test_inline_static_members_dwarf4(self):
         self.check_inline_static_members("-gdwarf-4")
 
@@ -203,7 +203,7 @@ class TestCase(TestBase):
         self.check_shadowed_static_inline_members("-gdwarf-5")
 
     # On linux this passes due to the manual index
-    @expectedFailureDarwin(debug_info=no_match(["dsym"]))
+    @expectedFailureDarwin
     def test_shadowed_static_inline_members_dwarf4(self):
         self.check_shadowed_static_inline_members("-gdwarf-4")
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/111859 fixed these tests for DWARFv4 on Linux by adjusting the manual index. As part of the change we unXFAILed these tests for DWARFv4 on all platforms. However, the manual index isn't used on macOS so they're still broken. This patch reverts the XFAIL on Darwin for DWARFv4.

Example CI failure:
```
FAIL: test_inline_static_members_dwarf4_dsym (TestConstStaticIntegralMember.TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1769, in test_method
    return attrvalue(self)
  File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake/llvm-project/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py", line 153, in test_inline_static_members_dwarf4
    self.check_inline_static_members("-gdwarf-4")
  File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake/llvm-project/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py", line 129, in check_inline_static_members
    self.check_global_var("A::int_val", "const int", "1")
  File "/Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake/llvm-project/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py", line 118, in check_global_var
    self.assertGreaterEqual(len(var_list), 1)
AssertionError: 0 not greater than or equal to 1
```