### PR TITLE
Revert "[Clang] skip default argument instantiation for non-defining friend declarations without specialization info to meet [dcl.fct.default] p4"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -636,8 +636,6 @@ Bug Fixes to C++ Support
   an implicitly instantiated class template specialization. (#GH51051)
 - Fixed an assertion failure caused by invalid enum forward declarations. (#GH112208)
 - Name independent data members were not correctly initialized from default member initializers. (#GH114069)
-- Fixed an assertion failure caused by invalid default argument substitutions in non-defining
-  friend declarations. (#GH113324).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6018,17 +6018,6 @@ bool Sema::GatherArgumentsForCall(SourceLocation CallLoc, FunctionDecl *FDecl,
     } else {
       assert(Param && "can't use default arguments without a known callee");
 
-      // FIXME: We don't track member specialization info for non-defining
-      // friend declarations, so we will not be able to later find the function
-      // pattern. As a workaround, don't instantiate the default argument in
-      // this case. This is correct per wording and only an error recovery
-      // issue, as per [dcl.fct.default]p4:
-      //   if a friend declaration D specifies a default argument expression,
-      //   that declaration shall be a definition.
-      if (FDecl->getFriendObjectKind() != Decl::FOK_None &&
-          FDecl->getMemberSpecializationInfo() == nullptr)
-        return true;
-
       ExprResult ArgExpr = BuildCXXDefaultArgExpr(CallLoc, FDecl, Param);
       if (ArgExpr.isInvalid())
         return true;

--- a/clang/test/CXX/temp/temp.res/p4.cpp
+++ b/clang/test/CXX/temp/temp.res/p4.cpp
@@ -185,22 +185,3 @@ template<typename T> struct S {
   friend void X::f(T::type);
 };
 }
-
-namespace GH113324 {
-template <typename = int> struct ct {
-  friend void f1(ct, int = 0);               // expected-error {{friend declaration specifying a default argument must be a definition}}
-  friend void f2(ct a, ct = decltype(a){ }); // expected-error {{friend declaration specifying a default argument must be a definition}}
-};
-
-template<class T> using alias = int;
-template<typename T> struct C {
-  // FIXME: We miss diagnosing the default argument instantiation failure (forming reference to void)
-  friend void f3(C, int a = alias<T&>(1)); // expected-error {{friend declaration specifying a default argument must be a definition}}
-};
-
-void test() {
-  f1(ct<>{});
-  f2(ct<>{});
-  f3(C<void>());
-}
-} // namespace GH113324


### PR DESCRIPTION
Reverts llvm/llvm-project#113777

Reverted due to regression reported here: https://github.com/llvm/llvm-project/pull/113777#issuecomment-2463465741