### PR TITLE
[libc++] Use explicit #include instead of transitive #include

### DIFF
--- a/libcxx/test/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/vector_operations.bench.cpp
@@ -14,6 +14,7 @@
 #include <deque>
 #include <functional>
 #include <vector>
+#include <string>
 #include <memory>
 
 #include "benchmark/benchmark.h"

--- a/libcxx/test/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/vector_operations.bench.cpp
@@ -14,6 +14,7 @@
 #include <deque>
 #include <functional>
 #include <vector>
+#include <memory>
 
 #include "benchmark/benchmark.h"
 

--- a/libcxx/test/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/vector_operations.bench.cpp
@@ -13,9 +13,9 @@
 #include <cstring>
 #include <deque>
 #include <functional>
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "benchmark/benchmark.h"
 


### PR DESCRIPTION
This benchmark test currently uses `std::unique_ptr` without explicitly `#include <memory>`. I think we should not rely on transitive inclusion. 