### PR TITLE
[mlir] Use heterogenous lookups with std::map (NFC)

### DIFF
--- a/mlir/include/mlir/IR/DialectRegistry.h
+++ b/mlir/include/mlir/IR/DialectRegistry.h
@@ -138,7 +138,8 @@ bool hasPromisedInterface(Dialect &dialect) {
 /// encountered.
 class DialectRegistry {
   using MapTy =
-      std::map<std::string, std::pair<TypeID, DialectAllocatorFunction>>;
+      std::map<std::string, std::pair<TypeID, DialectAllocatorFunction>,
+               std::less<>>;
 
 public:
   explicit DialectRegistry();

--- a/mlir/lib/IR/Dialect.cpp
+++ b/mlir/lib/IR/Dialect.cpp
@@ -217,7 +217,7 @@ DialectRegistry::DialectRegistry() { insert<BuiltinDialect>(); }
 
 DialectAllocatorFunctionRef
 DialectRegistry::getDialectAllocator(StringRef name) const {
-  auto it = registry.find(name.str());
+  auto it = registry.find(name);
   if (it == registry.end())
     return nullptr;
   return it->second.second;


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.
