### PR TITLE
Export LLVM plugin entrypoint for windows shared library builds

### DIFF
--- a/llvm/include/llvm/Passes/PassPlugin.h
+++ b/llvm/include/llvm/Passes/PassPlugin.h
@@ -107,7 +107,7 @@ private:
 ///   };
 /// }
 /// ```
-extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK LLVM_ABI_EXPORT
 llvmGetPassPluginInfo();
 
 #endif /* LLVM_PASSES_PASSPLUGIN_H */

--- a/llvm/include/llvm/Passes/PassPlugin.h
+++ b/llvm/include/llvm/Passes/PassPlugin.h
@@ -107,7 +107,13 @@ private:
 ///   };
 /// }
 /// ```
-extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK LLVM_ABI_EXPORT
+
+#if defined(_WIN32) && defined(LLVM_BUILD_LLVM_DYLIB)
+extern "C" ::llvm::PassPluginLibraryInfo __declspec(dllexport)
 llvmGetPassPluginInfo();
+#else
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo();
+#endif
 
 #endif /* LLVM_PASSES_PASSPLUGIN_H */


### PR DESCRIPTION
Add Symbol visibility macro to llvmGetPassPluginInfo so plugins export it for windows shared library builds with explicit symbol visibility macros enabled. This also avoids the need for existing plugins having to manually add visibility macros to there llvmGetPassPluginInfo function to work on windows.

This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and plugins on window.