### PR TITLE
[RISCV][Clang] Add RequiredFeatures to zvfh intrinsics

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -1651,9 +1651,13 @@ let ManualCodegen = [{
 
     // 13.5. Vector Widening Floating-Point Multiply
     let Log2LMUL = [-2, -1, 0, 1, 2] in {
-      defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "xf",
-                                          [["vv", "w", "wvvu"],
+      defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "f",
+                                           [["vv", "w", "wvvu"],
                                             ["vf", "w", "wveu"]]>;
+      let RequiredFeatures = ["Zvfh"] in
+        defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "x",
+                                             [["vv", "w", "wvvu"],
+                                              ["vf", "w", "wveu"]]>;
     }
   }
   // 13.3. Vector Widening Floating-Point Add/Subtract Instructions
@@ -1663,9 +1667,13 @@ let ManualCodegen = [{
 
   // 13.5. Vector Widening Floating-Point Multiply
   let Log2LMUL = [-2, -1, 0, 1, 2] in {
-    defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "xf",
-                                        [["vv", "w", "wvv"],
+    defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "f",
+                                         [["vv", "w", "wvv"],
                                           ["vf", "w", "wve"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm vfwmul : RVVOutOp0Op1BuiltinSet<"vfwmul", "x",
+                                           [["vv", "w", "wvv"],
+                                            ["vf", "w", "wve"]]>;
   }
 }
 }
@@ -1846,20 +1854,30 @@ let ManualCodegen = [{
 }] in {
   let HasFRMRoundModeOp = 1 in {
     // 13.8. Vector Floating-Point Square-Root Instruction
-    defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "xfd", [["v", "v", "vvu"]]>;
+    defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "fd", [["v", "v", "vvu"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "x", [["v", "v", "vvu"]]>;
 
     // 13.10. Vector Floating-Point Reciprocal Estimate Instruction
-    defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "xfd", [["v", "v", "vvu"]]>;
+    defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "fd", [["v", "v", "vvu"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "x", [["v", "v", "vvu"]]>;
   }
   // 13.8. Vector Floating-Point Square-Root Instruction
-  defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "xfd", [["v", "v", "vv"]]>;
+  defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "fd", [["v", "v", "vv"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm vfsqrt : RVVOutBuiltinSet<"vfsqrt", "x", [["v", "v", "vv"]]>;
 
   // 13.10. Vector Floating-Point Reciprocal Estimate Instruction
-  defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "xfd", [["v", "v", "vv"]]>;
+  defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "fd", [["v", "v", "vv"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm vfrec7 : RVVOutBuiltinSet<"vfrec7", "x", [["v", "v", "vv"]]>;
 }
 
 // 13.9. Vector Floating-Point Reciprocal Square-Root Estimate Instruction
-defm vfrsqrt7 : RVVOutBuiltinSet<"vfrsqrt7", "xfd", [["v", "v", "vv"]]>;
+defm vfrsqrt7 : RVVOutBuiltinSet<"vfrsqrt7", "fd", [["v", "v", "vv"]]>;
+let RequiredFeatures = ["Zvfh"] in
+  defm vfrsqrt7 : RVVOutBuiltinSet<"vfrsqrt7", "x", [["v", "v", "vv"]]>;
 
 // 13.11. Vector Floating-Point MIN/MAX Instructions
 defm vfmin : RVVFloatingBinBuiltinSet;
@@ -1870,8 +1888,12 @@ defm vfsgnj  : RVVFloatingBinBuiltinSet;
 defm vfsgnjn : RVVFloatingBinBuiltinSet;
 defm vfsgnjx : RVVFloatingBinBuiltinSet;
 }
-defm vfneg_v : RVVPseudoVFUnaryBuiltin<"vfsgnjn", "xfd">;
-defm vfabs_v : RVVPseudoVFUnaryBuiltin<"vfsgnjx", "xfd">;
+defm vfneg_v : RVVPseudoVFUnaryBuiltin<"vfsgnjn", "fd">;
+let RequiredFeatures = ["Zvfh"] in
+  defm vfneg_v : RVVPseudoVFUnaryBuiltin<"vfsgnjn", "x">;
+defm vfabs_v : RVVPseudoVFUnaryBuiltin<"vfsgnjx", "fd">;
+let RequiredFeatures = ["Zvfh"] in
+  defm vfabs_v : RVVPseudoVFUnaryBuiltin<"vfsgnjx", "x">;
 
 // 13.13. Vector Floating-Point Compare Instructions
 let MaskedPolicyScheme = HasPassthruOperand,
@@ -1885,8 +1907,11 @@ defm vmfge : RVVFloatingMaskOutBuiltinSet;
 }
 
 // 13.14. Vector Floating-Point Classify Instruction
-let Name = "vfclass_v", UnMaskedPolicyScheme = HasPassthruOperand in
-  def vfclass : RVVOp0Builtin<"Uv", "Uvv", "xfd">;
+let UnMaskedPolicyScheme = HasPassthruOperand in {
+defm vfclass : RVVOp0BuiltinSet<"vfclass", "fd", [["v", "Uv", "Uvv"]]>;
+let RequiredFeatures = ["Zvfh"] in
+  defm vfclass : RVVOp0BuiltinSet<"vfclass", "x", [["v", "Uv", "Uvv"]]>;
+}
 
 // 13.15. Vector Floating-Point Merge Instruction
 // C/C++ Operand: (mask, op1, op2, vl), Builtin: (op1, op2, mask, vl)
@@ -1907,8 +1932,11 @@ let HasMasked = false,
   let RequiredFeatures = ["Zvfbfmin"] in
     defm vmerge : RVVOutOp1BuiltinSet<"vmerge", "y",
                                       [["vvm", "v", "vvvm"]]>;
-  defm vfmerge : RVVOutOp1BuiltinSet<"vfmerge", "xfd",
+  defm vfmerge : RVVOutOp1BuiltinSet<"vfmerge", "fd",
                                      [["vfm", "v", "vvem"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm vfmerge : RVVOutOp1BuiltinSet<"vfmerge", "x",
+                                       [["vfm", "v", "vvem"]]>;
 }
 
 // 13.16. Vector Floating-Point Move Instruction
@@ -1916,55 +1944,71 @@ let HasMasked = false,
     UnMaskedPolicyScheme = HasPassthruOperand,
     SupportOverloading = false,
     MaskedPolicyScheme = NonePolicy,
-    OverloadedName = "vfmv_v" in
-  defm vfmv_v : RVVOutBuiltinSet<"vfmv_v_f", "xfd",
-                                  [["f", "v", "ve"]]>;
+    OverloadedName = "vfmv_v" in {
+  defm vfmv_v : RVVOutBuiltinSet<"vfmv_v_f", "fd",
+                                 [["f", "v", "ve"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm vfmv_v : RVVOutBuiltinSet<"vfmv_v_f", "x",
+                                   [["f", "v", "ve"]]>;
+}
 
 // 13.17. Single-Width Floating-Point/Integer Type-Convert Instructions
 let UnMaskedPolicyScheme = HasPassthruOperand in {
-def vfcvt_rtz_xu_f_v : RVVConvToUnsignedBuiltin<"vfcvt_rtz_xu">;
-def vfcvt_rtz_x_f_v : RVVConvToSignedBuiltin<"vfcvt_rtz_x">;
+let OverloadedName = "vfcvt_rtz_xu" in {
+  defm : RVVConvBuiltinSet<"vfcvt_rtz_xu_f_v", "fd", [["Uv", "Uvv"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm : RVVConvBuiltinSet<"vfcvt_rtz_xu_f_v", "x", [["Uv", "Uvv"]]>;
+}
+let OverloadedName = "vfcvt_rtz_x" in {
+  defm : RVVConvBuiltinSet<"vfcvt_rtz_x_f_v", "fd", [["Iv", "Ivv"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm : RVVConvBuiltinSet<"vfcvt_rtz_x_f_v", "x", [["Iv", "Ivv"]]>;
+}
 
 // 13.18. Widening Floating-Point/Integer Type-Convert Instructions
 let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
-  def vfwcvt_rtz_xu_f_v : RVVConvToWidenUnsignedBuiltin<"vfwcvt_rtz_xu">;
-  def vfwcvt_rtz_x_f_v : RVVConvToWidenSignedBuiltin<"vfwcvt_rtz_x">;
-  def vfwcvt_f_xu_v : RVVConvBuiltin<"Fw", "FwUv", "si", "vfwcvt_f">;
-  def vfwcvt_f_x_v : RVVConvBuiltin<"Fw", "Fwv", "si", "vfwcvt_f">;
-  let RequiredFeatures = ["Zvfh"] in {
-    let Name = "vfwcvt_f_xu_v",
-        IRName = "vfwcvt_f_xu_v",
-        MaskedIRName = "vfwcvt_f_xu_v_mask" in
-      def : RVVConvBuiltin<"Fw", "FwUv", "c", "vfwcvt_f">;
-    let Name = "vfwcvt_f_x_v",
-        IRName = "vfwcvt_f_x_v",
-        MaskedIRName = "vfwcvt_f_x_v_mask" in
-      def : RVVConvBuiltin<"Fw", "Fwv", "c", "vfwcvt_f">;
+  let OverloadedName = "vfwcvt_rtz_xu" in {
+    defm : RVVConvBuiltinSet<"vfwcvt_rtz_xu_f_v", "f", [["Uw", "Uwv"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm : RVVConvBuiltinSet<"vfwcvt_rtz_xu_f_v", "x", [["Uw", "Uwv"]]>;
   }
-  def vfwcvt_f_f_v : RVVConvBuiltin<"w", "wv", "f", "vfwcvt_f">;
-  let RequiredFeatures = ["Zvfhmin"] in
-    def vfwcvt_f_f_v_fp16 : RVVConvBuiltin<"w", "wv", "x", "vfwcvt_f"> {
-      let Name = "vfwcvt_f_f_v";
-      let IRName = "vfwcvt_f_f_v";
-      let MaskedIRName = "vfwcvt_f_f_v_mask";
+  let OverloadedName = "vfwcvt_rtz_x" in {
+    defm : RVVConvBuiltinSet<"vfwcvt_rtz_x_f_v", "f", [["Iw", "Iwv"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm : RVVConvBuiltinSet<"vfwcvt_rtz_x_f_v", "x", [["Iw", "Iwv"]]>;
+  }
+  let OverloadedName = "vfwcvt_f" in {
+    defm : RVVConvBuiltinSet<"vfwcvt_f_xu_v", "si", [["Fw", "FwUv"]]>;
+    defm : RVVConvBuiltinSet<"vfwcvt_f_x_v", "si", [["Fw", "Fwv"]]>;
+    let RequiredFeatures = ["Zvfh"] in {
+      defm : RVVConvBuiltinSet<"vfwcvt_f_xu_v", "c", [["Fw", "FwUv"]]>;
+      defm : RVVConvBuiltinSet<"vfwcvt_f_x_v", "c", [["Fw", "Fwv"]]>;
     }
+  }
+  let OverloadedName = "vfwcvt_f" in {
+    defm : RVVConvBuiltinSet<"vfwcvt_f_f_v", "f", [["w", "wv"]]>;
+    let RequiredFeatures = ["Zvfhmin"] in
+      defm : RVVConvBuiltinSet<"vfwcvt_f_f_v", "x", [["w", "wv"]]>;
+  }
 }
 
 // 13.19. Narrowing Floating-Point/Integer Type-Convert Instructions
 let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
-  def vfncvt_rtz_xu_f_w : RVVConvToNarrowingUnsignedBuiltin<"vfncvt_rtz_xu">;
-  def vfncvt_rtz_x_f_w : RVVConvToNarrowingSignedBuiltin<"vfncvt_rtz_x">;
-  let RequiredFeatures = ["Zvfh"] in {
-    let Name = "vfncvt_rtz_xu_f_w",
-        IRName = "vfncvt_rtz_xu_f_w",
-        MaskedIRName = "vfncvt_rtz_xu_f_w_mask" in
-      def : RVVConvBuiltin<"Uv", "UvFw", "c", "vfncvt_rtz_xu">;
-    let Name = "vfncvt_rtz_x_f_w",
-        IRName = "vfncvt_rtz_x_f_w",
-        MaskedIRName = "vfncvt_rtz_x_f_w_mask" in
-      def : RVVConvBuiltin<"Iv", "IvFw", "c", "vfncvt_rtz_x">;
+  let OverloadedName = "vfncvt_rtz_xu" in {
+    defm : RVVConvBuiltinSet<"vfncvt_rtz_xu_f_w", "si", [["Uv", "UvFw"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm : RVVConvBuiltinSet<"vfncvt_rtz_xu_f_w", "c", [["Uv", "UvFw"]]>;
   }
-  def vfncvt_rod_f_f_w : RVVConvBuiltin<"v", "vw", "xf", "vfncvt_rod_f">;
+  let OverloadedName = "vfncvt_rtz_x" in {
+    defm : RVVConvBuiltinSet<"vfncvt_rtz_x_f_w", "si", [["Iv", "IvFw"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm : RVVConvBuiltinSet<"vfncvt_rtz_x_f_w", "c", [["Iv", "IvFw"]]>;
+  }
+  let OverloadedName = "vfncvt_rod_f" in {
+    defm : RVVConvBuiltinSet<"vfncvt_rod_f_f_w", "f", [["v", "vw"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm : RVVConvBuiltinSet<"vfncvt_rod_f_f_w", "x", [["v", "vw"]]>;
+  }
 }
 
 // Zvfbfmin - Vector convert BF16 to FP32
@@ -2016,54 +2060,62 @@ let ManualCodegen = [{
 }] in {
   let HasFRMRoundModeOp = 1 in {
     // 14.17. Single-Width Floating-Point/Integer Type-Convert Instructions
-    let OverloadedName = "vfcvt_x" in
-      defm :
-        RVVConvBuiltinSet<"vfcvt_x_f_v", "xfd", [["Iv", "Ivvu"]]>;
-    let OverloadedName = "vfcvt_xu" in
-      defm :
-        RVVConvBuiltinSet<"vfcvt_xu_f_v", "xfd", [["Uv", "Uvvu"]]>;
+    let OverloadedName = "vfcvt_x" in {
+      defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "fd", [["Iv", "Ivvu"]]>;
+      let RequiredFeatures = ["Zvfh"] in
+        defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "x", [["Iv", "Ivvu"]]>;
+    }
+    let OverloadedName = "vfcvt_xu" in {
+      defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "fd", [["Uv", "Uvvu"]]>;
+      let RequiredFeatures = ["Zvfh"] in
+        defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "x", [["Uv", "Uvvu"]]>;
+    }
     let OverloadedName = "vfcvt_f" in {
-      defm :
-        RVVConvBuiltinSet<"vfcvt_f_x_v", "xfd", [["v", "vIvu"]]>;
-      defm :
-        RVVConvBuiltinSet<"vfcvt_f_xu_v", "xfd", [["v", "vUvu"]]>;
+      defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "fd", [["v", "vIvu"]]>;
+      defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "fd", [["v", "vUvu"]]>;
+      let RequiredFeatures = ["Zvfh"] in {
+        defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "x", [["v", "vIvu"]]>;
+        defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "x", [["v", "vUvu"]]>;
+      }
     }
 
     // 13.18. Widening Floating-Point/Integer Type-Convert Instructions
     let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
-      let OverloadedName = "vfwcvt_x" in
-        defm :
-          RVVConvBuiltinSet<"vfwcvt_x_f_v", "xf", [["Iw", "Iwvu"]]>;
-      let OverloadedName = "vfwcvt_xu" in
-        defm :
-          RVVConvBuiltinSet<"vfwcvt_xu_f_v", "xf", [["Uw", "Uwvu"]]>;
+      let OverloadedName = "vfwcvt_x" in {
+        defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "f", [["Iw", "Iwvu"]]>;
+        let RequiredFeatures = ["Zvfh"] in
+          defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "x", [["Iw", "Iwvu"]]>;
+      }
+      let OverloadedName = "vfwcvt_xu" in {
+        defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "f", [["Uw", "Uwvu"]]>;
+        let RequiredFeatures = ["Zvfh"] in
+          defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "x", [["Uw", "Uwvu"]]>;
+      }
     }
     // 13.19. Narrowing Floating-Point/Integer Type-Convert Instructions
     let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
-      let OverloadedName = "vfncvt_x" in
-        defm :
-          RVVConvBuiltinSet<"vfncvt_x_f_w", "si", [["Iv", "IvFwu"]]>;
-      let OverloadedName = "vfncvt_xu" in
-        defm :
-          RVVConvBuiltinSet<"vfncvt_xu_f_w", "si", [["Uv", "UvFwu"]]>;
-      let RequiredFeatures = ["Zvfh"] in {
-        let OverloadedName = "vfncvt_x" in
-          defm :
-            RVVConvBuiltinSet<"vfncvt_x_f_w", "c", [["Iv", "IvFwu"]]>;
-        let OverloadedName = "vfncvt_xu" in
-          defm :
-            RVVConvBuiltinSet<"vfncvt_xu_f_w", "c", [["Uv", "UvFwu"]]>;
+      let OverloadedName = "vfncvt_x" in {
+        defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "si", [["Iv", "IvFwu"]]>;
+        let RequiredFeatures = ["Zvfh"] in
+          defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "c", [["Iv", "IvFwu"]]>;
+      }
+      let OverloadedName = "vfncvt_xu" in {
+        defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "si", [["Uv", "UvFwu"]]>;
+        let RequiredFeatures = ["Zvfh"] in
+          defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "c", [["Uv", "UvFwu"]]>;
       }
       let OverloadedName = "vfncvt_f" in {
-        defm :
-          RVVConvBuiltinSet<"vfncvt_f_x_w", "xf", [["v", "vIwu"]]>;
-        defm :
-          RVVConvBuiltinSet<"vfncvt_f_xu_w", "xf", [["v", "vUwu"]]>;
+        defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "f", [["v", "vIwu"]]>;
+        defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "f", [["v", "vUwu"]]>;
+        let RequiredFeatures = ["Zvfh"] in {
+          defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "x", [["v", "vIwu"]]>;
+          defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "x", [["v", "vUwu"]]>;
+        }
       }
       let OverloadedName = "vfncvt_f" in {
         defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "f", [["v", "vwu"]]>;
         let RequiredFeatures = ["Zvfhmin"] in
-        defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "x", [["v", "vwu"]]>;
+          defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "x", [["v", "vwu"]]>;
       }
     }
 
@@ -2074,54 +2126,62 @@ let ManualCodegen = [{
   }
 
   // 13.17. Single-Width Floating-Point/Integer Type-Convert Instructions
-  let OverloadedName = "vfcvt_x" in
-    defm :
-      RVVConvBuiltinSet<"vfcvt_x_f_v", "xfd", [["Iv", "Ivv"]]>;
-  let OverloadedName = "vfcvt_xu" in
-    defm :
-      RVVConvBuiltinSet<"vfcvt_xu_f_v", "xfd", [["Uv", "Uvv"]]>;
+  let OverloadedName = "vfcvt_x" in {
+    defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "fd", [["Iv", "Ivv"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm : RVVConvBuiltinSet<"vfcvt_x_f_v", "x", [["Iv", "Ivv"]]>;
+  }
+  let OverloadedName = "vfcvt_xu" in {
+    defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "fd", [["Uv", "Uvv"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm : RVVConvBuiltinSet<"vfcvt_xu_f_v", "x", [["Uv", "Uvv"]]>;
+  }
   let OverloadedName = "vfcvt_f" in {
-    defm :
-      RVVConvBuiltinSet<"vfcvt_f_x_v", "xfd", [["v", "vIv"]]>;
-    defm :
-      RVVConvBuiltinSet<"vfcvt_f_xu_v", "xfd", [["v", "vUv"]]>;
+    defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "fd", [["v", "vIv"]]>;
+    defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "fd", [["v", "vUv"]]>;
+    let RequiredFeatures = ["Zvfh"] in {
+      defm : RVVConvBuiltinSet<"vfcvt_f_x_v", "x", [["v", "vIv"]]>;
+      defm : RVVConvBuiltinSet<"vfcvt_f_xu_v", "x", [["v", "vUv"]]>;
+    }
   }
 
   // 13.18. Widening Floating-Point/Integer Type-Convert Instructions
   let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
-    let OverloadedName = "vfwcvt_x" in
-      defm :
-        RVVConvBuiltinSet<"vfwcvt_x_f_v", "xf", [["Iw", "Iwv"]]>;
-    let OverloadedName = "vfwcvt_xu" in
-      defm :
-        RVVConvBuiltinSet<"vfwcvt_xu_f_v", "xf", [["Uw", "Uwv"]]>;
+    let OverloadedName = "vfwcvt_x" in {
+      defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "f", [["Iw", "Iwv"]]>;
+      let RequiredFeatures = ["Zvfh"] in
+        defm : RVVConvBuiltinSet<"vfwcvt_x_f_v", "x", [["Iw", "Iwv"]]>;
+    }
+    let OverloadedName = "vfwcvt_xu" in {
+      defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "f", [["Uw", "Uwv"]]>;
+      let RequiredFeatures = ["Zvfh"] in
+        defm : RVVConvBuiltinSet<"vfwcvt_xu_f_v", "x", [["Uw", "Uwv"]]>;
+    }
   }
   // 13.19. Narrowing Floating-Point/Integer Type-Convert Instructions
   let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
-    let OverloadedName = "vfncvt_x" in
-      defm :
-        RVVConvBuiltinSet<"vfncvt_x_f_w", "si", [["Iv", "IvFw"]]>;
-    let OverloadedName = "vfncvt_xu" in
-      defm :
-        RVVConvBuiltinSet<"vfncvt_xu_f_w", "si", [["Uv", "UvFw"]]>;
-    let RequiredFeatures = ["Zvfh"] in {
-      let OverloadedName = "vfncvt_x" in
-        defm :
-          RVVConvBuiltinSet<"vfncvt_x_f_w", "c", [["Iv", "IvFw"]]>;
-      let OverloadedName = "vfncvt_xu" in
-        defm :
-          RVVConvBuiltinSet<"vfncvt_xu_f_w", "c", [["Uv", "UvFw"]]>;
+    let OverloadedName = "vfncvt_x" in {
+      defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "si", [["Iv", "IvFw"]]>;
+      let RequiredFeatures = ["Zvfh"] in
+        defm : RVVConvBuiltinSet<"vfncvt_x_f_w", "c", [["Iv", "IvFw"]]>;
+    }
+    let OverloadedName = "vfncvt_xu" in {
+      defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "si", [["Uv", "UvFw"]]>;
+      let RequiredFeatures = ["Zvfh"] in
+        defm : RVVConvBuiltinSet<"vfncvt_xu_f_w", "c", [["Uv", "UvFw"]]>;
     }
     let OverloadedName = "vfncvt_f" in {
-      defm :
-        RVVConvBuiltinSet<"vfncvt_f_x_w", "xf", [["v", "vIw"]]>;
-      defm :
-        RVVConvBuiltinSet<"vfncvt_f_xu_w", "xf", [["v", "vUw"]]>;
+      defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "f", [["v", "vIw"]]>;
+      defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "f", [["v", "vUw"]]>;
+      let RequiredFeatures = ["Zvfh"] in {
+        defm : RVVConvBuiltinSet<"vfncvt_f_x_w", "x", [["v", "vIw"]]>;
+        defm : RVVConvBuiltinSet<"vfncvt_f_xu_w", "x", [["v", "vUw"]]>;
+      }
     }
     let OverloadedName = "vfncvt_f" in {
       defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "f", [["v", "vw"]]>;
       let RequiredFeatures = ["Zvfhmin"] in
-      defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "x", [["v", "vw"]]>;
+        defm : RVVConvBuiltinSet<"vfncvt_f_f_w", "x", [["v", "vw"]]>;
     }
   }
 
@@ -2281,15 +2341,24 @@ let HasMasked = false, MaskedPolicyScheme = NonePolicy in {
 
 // 16.2. Floating-Point Scalar Move Instructions
 let HasMasked = false, MaskedPolicyScheme = NonePolicy in {
-  let HasVL = false, OverloadedName = "vfmv_f" in
-    defm vfmv_f : RVVOp0BuiltinSet<"vfmv_f_s", "xfd",
+  let HasVL = false, OverloadedName = "vfmv_f" in {
+    defm vfmv_f : RVVOp0BuiltinSet<"vfmv_f_s", "fd",
+                                   [["s", "ve", "ev"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm vfmv_f : RVVOp0BuiltinSet<"vfmv_f_s", "x",
                                      [["s", "ve", "ev"]]>;
+  }
   let OverloadedName = "vfmv_s",
       UnMaskedPolicyScheme = HasPassthruOperand,
-      SupportOverloading = false in
-    defm vfmv_s : RVVOutBuiltinSet<"vfmv_s_f", "xfd",
+      SupportOverloading = false in {
+    defm vfmv_s : RVVOutBuiltinSet<"vfmv_s_f", "fd",
+                                   [["f", "v", "ve"],
+                                    ["x", "Uv", "UvUe"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm vfmv_s : RVVOutBuiltinSet<"vfmv_s_f", "x",
                                      [["f", "v", "ve"],
                                       ["x", "Uv", "UvUe"]]>;
+  }
 }
 
 // 16.3. Vector Slide Instructions
@@ -2325,7 +2394,10 @@ let RequiredFeatures = ["Zvfbfmin"] in {
   defm vrgather : RVVOutBuiltinSet<"vrgather_vx", "y",
                                    [["vx", "v", "vvz"]]>;
 }
-defm vrgatherei16 : RVVOutBuiltinSet<"vrgatherei16_vv", "csilxfd",
+defm vrgatherei16 : RVVOutBuiltinSet<"vrgatherei16_vv", "csilfd",
+                                     [["vv", "v", "vv(Log2EEW:4)Uv"]]>;
+let RequiredFeatures = ["Zvfh"] in
+defm vrgatherei16 : RVVOutBuiltinSet<"vrgatherei16_vv", "x",
                                      [["vv", "v", "vv(Log2EEW:4)Uv"]]>;
 // unsigned type
 defm vrgather : RVVOutBuiltinSet<"vrgather_vv", "csil",

--- a/clang/include/clang/Basic/riscv_vector_common.td
+++ b/clang/include/clang/Basic/riscv_vector_common.td
@@ -458,52 +458,91 @@ let HasMaskedOffOperand = false in {
                                    ["vx", "Uv", "UvUvUeUv"]]>;
   }
   multiclass RVVFloatingTerBuiltinSet {
-    defm "" : RVVOutOp1BuiltinSet<NAME, "xfd",
+    defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                   [["vv", "v", "vvvv"],
                                    ["vf", "v", "vvev"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutOp1BuiltinSet<NAME, "x",
+                                    [["vv", "v", "vvvv"],
+                                     ["vf", "v", "vvev"]]>;
   }
   multiclass RVVFloatingTerBuiltinSetRoundingMode {
-    defm "" : RVVOutOp1BuiltinSet<NAME, "xfd",
+    defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
                                   [["vv", "v", "vvvvu"],
                                    ["vf", "v", "vvevu"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutOp1BuiltinSet<NAME, "x",
+                                    [["vv", "v", "vvvvu"],
+                                     ["vf", "v", "vvevu"]]>;
   }
 }
 
 let HasMaskedOffOperand = false, Log2LMUL = [-2, -1, 0, 1, 2] in {
   multiclass RVVFloatingWidenTerBuiltinSet {
-    defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "xf",
+    defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "f",
                                       [["vv", "w", "wwvv"],
                                        ["vf", "w", "wwev"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "x",
+                                        [["vv", "w", "wwvv"],
+                                         ["vf", "w", "wwev"]]>;
   }
   multiclass RVVFloatingWidenTerBuiltinSetRoundingMode {
-    defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "xf",
+    defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "f",
                                       [["vv", "w", "wwvvu"],
                                        ["vf", "w", "wwevu"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm ""  : RVVOutOp1Op2BuiltinSet<NAME, "x",
+                                        [["vv", "w", "wwvvu"],
+                                         ["vf", "w", "wwevu"]]>;
   }
 }
 
-multiclass RVVFloatingBinBuiltinSet
-    : RVVOutOp1BuiltinSet<NAME, "xfd",
-                          [["vv", "v", "vvv"],
-                           ["vf", "v", "vve"]]>;
+multiclass RVVFloatingBinBuiltinSet {
+  defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
+                                [["vv", "v", "vvv"],
+                                 ["vf", "v", "vve"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVOutOp1BuiltinSet<NAME, "x",
+                                  [["vv", "v", "vvv"],
+                                   ["vf", "v", "vve"]]>;
+}
 
-multiclass RVVFloatingBinBuiltinSetRoundingMode
-    : RVVOutOp1BuiltinSet<NAME, "xfd",
-                          [["vv", "v", "vvvu"],
-                           ["vf", "v", "vveu"]]>;
+multiclass RVVFloatingBinBuiltinSetRoundingMode {
+  defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
+                                [["vv", "v", "vvvu"],
+                                 ["vf", "v", "vveu"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVOutOp1BuiltinSet<NAME, "x",
+                                  [["vv", "v", "vvvu"],
+                                   ["vf", "v", "vveu"]]>;
+}
 
-multiclass RVVFloatingBinVFBuiltinSet
-    : RVVOutOp1BuiltinSet<NAME, "xfd",
-                          [["vf", "v", "vve"]]>;
+multiclass RVVFloatingBinVFBuiltinSet {
+  defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
+                                [["vf", "v", "vve"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVOutOp1BuiltinSet<NAME, "x",
+                                  [["vf", "v", "vve"]]>;
+}
 
-multiclass RVVFloatingBinVFBuiltinSetRoundingMode
-    : RVVOutOp1BuiltinSet<NAME, "xfd",
-                          [["vf", "v", "vveu"]]>;
+multiclass RVVFloatingBinVFBuiltinSetRoundingMode {
+  defm "" : RVVOutOp1BuiltinSet<NAME, "fd",
+                                [["vf", "v", "vveu"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVOutOp1BuiltinSet<NAME, "x",
+                                  [["vf", "v", "vveu"]]>;
+}
 
-multiclass RVVFloatingMaskOutBuiltinSet
-    : RVVOp0Op1BuiltinSet<NAME, "xfd",
-                          [["vv", "vm", "mvv"],
-                           ["vf", "vm", "mve"]]>;
+multiclass RVVFloatingMaskOutBuiltinSet {
+  defm "" : RVVOp0Op1BuiltinSet<NAME, "fd",
+                                [["vv", "vm", "mvv"],
+                                 ["vf", "vm", "mve"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVOp0Op1BuiltinSet<NAME, "x",
+                                  [["vv", "vm", "mvv"],
+                                   ["vf", "vm", "mve"]]>;
+}
 
 multiclass RVVFloatingMaskOutVFBuiltinSet
     : RVVOp0Op1BuiltinSet<NAME, "fd",
@@ -547,8 +586,11 @@ class RVVMaskOp0Builtin<string prototype> : RVVOp0Builtin<"m", prototype, "c"> {
 let UnMaskedPolicyScheme = HasPolicyOperand,
     HasMaskedOffOperand = false in {
   multiclass RVVSlideUpBuiltinSet {
-    defm "" : RVVOutBuiltinSet<NAME, "csilxfd",
+    defm "" : RVVOutBuiltinSet<NAME, "csilfd",
                                [["vx","v", "vvvz"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutBuiltinSet<NAME, "x",
+                                 [["vx","v", "vvvz"]]>;
     defm "" : RVVOutBuiltinSet<NAME, "csil",
                                [["vx","Uv", "UvUvUvz"]]>;
   }
@@ -569,8 +611,11 @@ let UnMaskedPolicyScheme = HasPassthruOperand,
       IntrinsicTypes = {ResultType, Ops.back()->getType()};
     }] in {
   multiclass RVVSlideDownBuiltinSet {
-    defm "" : RVVOutBuiltinSet<NAME, "csilxfd",
+    defm "" : RVVOutBuiltinSet<NAME, "csilfd",
                                [["vx","v", "vvz"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutBuiltinSet<NAME, "x",
+                                 [["vx","v", "vvz"]]>;
     defm "" : RVVOutBuiltinSet<NAME, "csil",
                                [["vx","Uv", "UvUvz"]]>;
   }
@@ -611,20 +656,32 @@ let HasMaskedOffOperand = true in {
                                   [["vs", "UvUSv", "USvUvUSv"]]>;
   }
   multiclass RVVFloatingReductionBuiltin {
-    defm "" : RVVOutOp0BuiltinSet<NAME, "xfd",
+    defm "" : RVVOutOp0BuiltinSet<NAME, "fd",
                                   [["vs", "vSv", "SvvSv"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutOp0BuiltinSet<NAME, "x",
+                                    [["vs", "vSv", "SvvSv"]]>;
   }
   multiclass RVVFloatingReductionBuiltinRoundingMode {
-    defm "" : RVVOutOp0BuiltinSet<NAME, "xfd",
+    defm "" : RVVOutOp0BuiltinSet<NAME, "fd",
                                   [["vs", "vSv", "SvvSvu"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutOp0BuiltinSet<NAME, "x",
+                                    [["vs", "vSv", "SvvSvu"]]>;
   }
   multiclass RVVFloatingWidenReductionBuiltin {
-    defm "" : RVVOutOp0BuiltinSet<NAME, "xf",
+    defm "" : RVVOutOp0BuiltinSet<NAME, "f",
                                   [["vs", "vSw", "SwvSw"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutOp0BuiltinSet<NAME, "x",
+                                    [["vs", "vSw", "SwvSw"]]>;
   }
   multiclass RVVFloatingWidenReductionBuiltinRoundingMode {
-    defm "" : RVVOutOp0BuiltinSet<NAME, "xf",
+    defm "" : RVVOutOp0BuiltinSet<NAME, "f",
                                   [["vs", "vSw", "SwvSwu"]]>;
+    let RequiredFeatures = ["Zvfh"] in
+      defm "" : RVVOutOp0BuiltinSet<NAME, "x",
+                                    [["vs", "vSw", "SwvSwu"]]>;
   }
 }
 
@@ -684,22 +741,42 @@ multiclass RVVUnsignedWidenOp0BinBuiltinSet
                              [["wv", "Uw", "UwUwUv"],
                               ["wx", "Uw", "UwUwUe"]]>;
 
-multiclass RVVFloatingWidenBinBuiltinSet
-    : RVVWidenBuiltinSet<NAME, "xf",
-                         [["vv", "w", "wvv"],
-                          ["vf", "w", "wve"]]>;
+multiclass RVVFloatingWidenBinBuiltinSet {
+  defm "" : RVVWidenBuiltinSet<NAME, "f",
+                               [["vv", "w", "wvv"],
+                                ["vf", "w", "wve"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVWidenBuiltinSet<NAME, "x",
+                                 [["vv", "w", "wvv"],
+                                  ["vf", "w", "wve"]]>;
+}
 
-multiclass RVVFloatingWidenBinBuiltinSetRoundingMode
-    : RVVWidenBuiltinSet<NAME, "xf",
-                         [["vv", "w", "wvvu"],
-                          ["vf", "w", "wveu"]]>;
+multiclass RVVFloatingWidenBinBuiltinSetRoundingMode {
+  defm "" : RVVWidenBuiltinSet<NAME, "f",
+                               [["vv", "w", "wvvu"],
+                                ["vf", "w", "wveu"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVWidenBuiltinSet<NAME, "x",
+                                 [["vv", "w", "wvvu"],
+                                  ["vf", "w", "wveu"]]>;
+}
 
-multiclass RVVFloatingWidenOp0BinBuiltinSet
-    : RVVWidenWOp0BuiltinSet<NAME # "_w", "xf",
-                             [["wv", "w", "wwv"],
-                              ["wf", "w", "wwe"]]>;
+multiclass RVVFloatingWidenOp0BinBuiltinSet {
+  defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "f",
+                                   [["wv", "w", "wwv"],
+                                    ["wf", "w", "wwe"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "x",
+                                     [["wv", "w", "wwv"],
+                                      ["wf", "w", "wwe"]]>;
+}
 
-multiclass RVVFloatingWidenOp0BinBuiltinSetRoundingMode
-    : RVVWidenWOp0BuiltinSet<NAME # "_w", "xf",
-                             [["wv", "w", "wwvu"],
-                              ["wf", "w", "wweu"]]>;
+multiclass RVVFloatingWidenOp0BinBuiltinSetRoundingMode {
+  defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "f",
+                                   [["wv", "w", "wwvu"],
+                                    ["wf", "w", "wweu"]]>;
+  let RequiredFeatures = ["Zvfh"] in
+    defm "" : RVVWidenWOp0BuiltinSet<NAME # "_w", "x",
+                                     [["wv", "w", "wwvu"],
+                                      ["wf", "w", "wweu"]]>;
+}

--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -282,20 +282,6 @@ void RISCVIntrinsicManagerImpl::ConstructRVVIntrinsics(
       if ((BaseTypeI & Record.TypeRangeMask) != BaseTypeI)
         continue;
 
-      // TODO: Remove the check below and use RequiredFeatures in
-      // riscv_vector.td to check the intrinsics instead, the type check should
-      // be done in checkRVVTypeSupport. This check also not able to work on the
-      // intrinsics that have Float16 but the BaseType is not Float16 such as
-      // `vfcvt_f_x_v`.
-      if (BaseType == BasicType::Float16) {
-        if ((Record.RequiredExtensions & RVV_REQ_Zvfhmin) == RVV_REQ_Zvfhmin) {
-          if (!TI.hasFeature("zvfhmin"))
-            continue;
-        } else if (!TI.hasFeature("zvfh")) {
-          continue;
-        }
-      }
-
       // Expanded with different LMUL.
       for (int Log2LMUL = -3; Log2LMUL <= 3; Log2LMUL++) {
         if (!(Record.Log2LMULMask & (1 << (Log2LMUL + 3))))


### PR DESCRIPTION
This is a follow-up patch for
https://github.com/llvm/llvm-project/pull/101811.
That we can remove the type checking for fp16 from SemaRISCV.cpp.

Fixes: https://github.com/llvm/llvm-project/issues/101621 and https://github.com/llvm/llvm-project/issues/94306