### PR TITLE
Reland '[lineeditor] Add `setHistorySize()` method for adjusting history size'

### DIFF
--- a/llvm/include/llvm/LineEditor/LineEditor.h
+++ b/llvm/include/llvm/LineEditor/LineEditor.h
@@ -41,6 +41,7 @@ public:
 
   void saveHistory();
   void loadHistory();
+  void setHistorySize(int size);
 
   static std::string getDefaultHistoryPath(StringRef ProgName);
 

--- a/llvm/lib/LineEditor/LineEditor.cpp
+++ b/llvm/lib/LineEditor/LineEditor.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #ifdef HAVE_LIBEDIT
 #include <histedit.h>
+constexpr int DefaultHistorySize = 800;
 #endif
 
 using namespace llvm;
@@ -220,8 +221,8 @@ LineEditor::LineEditor(StringRef ProgName, StringRef HistoryPath, FILE *In,
            NULL); // Fix the delete key.
   ::el_set(Data->EL, EL_CLIENTDATA, Data.get());
 
+  setHistorySize(DefaultHistorySize);
   HistEvent HE;
-  ::history(Data->Hist, &HE, H_SETSIZE, 800);
   ::history(Data->Hist, &HE, H_SETUNIQUE, 1);
   loadHistory();
 }
@@ -246,6 +247,11 @@ void LineEditor::loadHistory() {
     HistEvent HE;
     ::history(Data->Hist, &HE, H_LOAD, HistoryPath.c_str());
   }
+}
+
+void LineEditor::setHistorySize(int size) {
+  HistEvent HE;
+  ::history(Data->Hist, &HE, H_SETSIZE, size);
 }
 
 std::optional<std::string> LineEditor::readLine() const {
@@ -291,6 +297,7 @@ LineEditor::~LineEditor() {
 
 void LineEditor::saveHistory() {}
 void LineEditor::loadHistory() {}
+void LineEditor::setHistorySize(int size) {}
 
 std::optional<std::string> LineEditor::readLine() const {
   ::fprintf(Data->Out, "%s", Prompt.c_str());


### PR DESCRIPTION
Reland: https://github.com/llvm/llvm-project/pull/110092

Buildbot was failing due to an unused variable warning as there were 2 implementations (with and without libedit). Compared to last version, wrap the variable inside the `#ifdef HAVE_LIBEDIT`.

Apologies for the oversight @vgvassilev