### PR TITLE
Add StringMap::lookup() overload to take a default value and return a reference to the value to avoid a copy

### DIFF
--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -259,7 +259,7 @@ public:
 
   /// lookup - Return the entry for the specified key, or a default
   /// provided value if no such entry exists.
-  const ValueTy &lookup(StringRef Key, const ValueTy& Value) const {
+  const ValueTy &lookup(StringRef Key, const ValueTy &Value) const {
     const_iterator Iter = find(Key);
     if (Iter != end())
       return Iter->second;

--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -257,6 +257,15 @@ public:
     return ValueTy();
   }
 
+  /// lookup - Return the entry for the specified key, or a default
+  /// provided value if no such entry exists.
+  const ValueTy &lookup(StringRef Key, const ValueTy& Value) const {
+    const_iterator Iter = find(Key);
+    if (Iter != end())
+      return Iter->second;
+    return Value;
+  }
+
   /// at - Return the entry for the specified key, or abort if no such
   /// entry exists.
   const ValueTy &at(StringRef Val) const {

--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -1289,15 +1289,9 @@ void MachineOutliner::emitInstrCountChangedRemark(
 
     std::string Fname = std::string(F.getName());
     unsigned FnCountAfter = MF->getInstructionCount();
-    unsigned FnCountBefore = 0;
-
-    // Check if the function was recorded before.
-    auto It = FunctionToInstrCount.find(Fname);
-
-    // Did we have a previously-recorded size? If yes, then set FnCountBefore
-    // to that.
-    if (It != FunctionToInstrCount.end())
-      FnCountBefore = It->second;
+    // Check if the function was recorded before and if yes, then set
+    // FnCountBefore to that.
+    unsigned FnCountBefore = FunctionToInstrCount.lookup(Fname, 0);
 
     // Compute the delta and emit a remark if there was a change.
     int64_t FnDelta = static_cast<int64_t>(FnCountAfter) -

--- a/llvm/tools/llvm-rc/ResourceScriptStmt.cpp
+++ b/llvm/tools/llvm-rc/ResourceScriptStmt.cpp
@@ -228,10 +228,7 @@ const StringMap<VersionInfoFixedType> VersionInfoFixed::FixedFieldsInfoMap = {
 
 VersionInfoFixedType VersionInfoFixed::getFixedType(StringRef Type) {
   auto UpperType = Type.upper();
-  auto Iter = FixedFieldsInfoMap.find(UpperType);
-  if (Iter != FixedFieldsInfoMap.end())
-    return Iter->getValue();
-  return FtUnknown;
+  return FixedFieldsInfoMap.lookup(UpperType, FtUnknown);
 }
 
 bool VersionInfoFixed::isTypeSupported(VersionInfoFixedType Type) {

--- a/llvm/unittests/ADT/StringMapTest.cpp
+++ b/llvm/unittests/ADT/StringMapTest.cpp
@@ -174,10 +174,15 @@ TEST_F(StringMapTest, SmallFullMapTest) {
 
   EXPECT_EQ(3u, Map.size());
   EXPECT_EQ(0, Map.lookup("eins"));
+  EXPECT_EQ(7, Map.lookup("eins", 7));
   EXPECT_EQ(2, Map.lookup("zwei"));
+  EXPECT_EQ(2, Map.lookup("zwei", 7));
   EXPECT_EQ(0, Map.lookup("drei"));
+  EXPECT_EQ(7, Map.lookup("drei", 7));
   EXPECT_EQ(4, Map.lookup("veir"));
+  EXPECT_EQ(4, Map.lookup("veir", 7));
   EXPECT_EQ(5, Map.lookup("funf"));
+  EXPECT_EQ(5, Map.lookup("funf", 7));
 }
 
 TEST_F(StringMapTest, CopyCtorTest) {


### PR DESCRIPTION
Also use it in a few places in the code where it fits.