### PR TITLE
[mlir] Fix nested codeowners for vector dialect

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,10 +83,10 @@
 /mlir/**/*VectorToLLVM* @banach-space @dcaballe @nicolasvasilache
 /mlir/**/*X86Vector* @aartbik @dcaballe @nicolasvasilache
 /mlir/include/mlir/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
-/mlir/include/mlir/Dialect/Vector/IR @kuhar
+/mlir/include/mlir/Dialect/Vector/IR @kuhar @banach-space @dcaballe @nicolasvasilache @Groverkss
 /mlir/lib/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
-/mlir/lib/Dialect/Vector/Transforms/* @banach-space @dcaballe @hanhanW @nicolasvasilache
-/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @banach-space @dcaballe @MaheshRavishankar @nicolasvasilache
+/mlir/lib/Dialect/Vector/Transforms/* @banach-space @dcaballe @hanhanW @nicolasvasilache @Groverkss
+/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @banach-space @dcaballe @hanhanW @MaheshRavishankar @nicolasvasilache @Groverkss
 /mlir/**/*EmulateNarrowType* @dcaballe @hanhanW
 
 # Presburger library in MLIR

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,7 +83,7 @@
 /mlir/**/*VectorToLLVM* @banach-space @dcaballe @nicolasvasilache
 /mlir/**/*X86Vector* @aartbik @dcaballe @nicolasvasilache
 /mlir/include/mlir/Dialect/Vector @banach-space @dcaballe @Groverkss @nicolasvasilache
-/mlir/include/mlir/Dialect/Vector/IR @kuhar @banach-space @dcaballe @Groverkss @nicolasvasilache
+/mlir/include/mlir/Dialect/Vector/IR @banach-space @dcaballe @Groverkss @kuhar @nicolasvasilache
 /mlir/lib/Dialect/Vector @banach-space @dcaballe @Groverkss @nicolasvasilache
 /mlir/lib/Dialect/Vector/Transforms/* @banach-space @dcaballe @Groverkss @hanhanW @nicolasvasilache
 /mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @banach-space @dcaballe @Groverkss @hanhanW @MaheshRavishankar @nicolasvasilache

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,11 +82,11 @@
 /mlir/**/*VectorToSCF* @banach-space @dcaballe @matthias-springer @nicolasvasilache
 /mlir/**/*VectorToLLVM* @banach-space @dcaballe @nicolasvasilache
 /mlir/**/*X86Vector* @aartbik @dcaballe @nicolasvasilache
-/mlir/include/mlir/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
-/mlir/include/mlir/Dialect/Vector/IR @kuhar @banach-space @dcaballe @nicolasvasilache @Groverkss
-/mlir/lib/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
-/mlir/lib/Dialect/Vector/Transforms/* @banach-space @dcaballe @hanhanW @nicolasvasilache @Groverkss
-/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @banach-space @dcaballe @hanhanW @MaheshRavishankar @nicolasvasilache @Groverkss
+/mlir/include/mlir/Dialect/Vector @banach-space @dcaballe @Groverkss @nicolasvasilache
+/mlir/include/mlir/Dialect/Vector/IR @kuhar @banach-space @dcaballe @Groverkss @nicolasvasilache
+/mlir/lib/Dialect/Vector @banach-space @dcaballe @Groverkss @nicolasvasilache
+/mlir/lib/Dialect/Vector/Transforms/* @banach-space @dcaballe @Groverkss @hanhanW @nicolasvasilache
+/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @banach-space @dcaballe @Groverkss @hanhanW @MaheshRavishankar @nicolasvasilache
 /mlir/**/*EmulateNarrowType* @dcaballe @hanhanW
 
 # Presburger library in MLIR


### PR DESCRIPTION
Due to how CODEOWNERS works, if a file matches two rules, the later rule will take precedence.

Because of this, /mlir/include/mlir/Dialect/Vector rules were not matching against /mlir/include/mlir/Dialect/Vector/IR .

This patch adds users in the directory rules, to the finer grained rules, which I'm guessing was the intended effect that they expected when they were added.