### PR TITLE
[symbolizer] Change the ErrorHandler from llvm::function_ref to std::function.

### DIFF
--- a/llvm/include/llvm/DebugInfo/Symbolize/DIPrinter.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/DIPrinter.h
@@ -65,7 +65,7 @@ struct PrinterConfig {
   int SourceContextLines;
 };
 
-using ErrorHandler = function_ref<void(const ErrorInfoBase &, StringRef)>;
+using ErrorHandler = std::function<void(const ErrorInfoBase &, StringRef)>;
 
 class PlainPrinterBase : public DIPrinter {
 protected:


### PR DESCRIPTION
This fixes dangling `ErrorHandler` references ([here](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/sanitizer_common/symbolizer/sanitizer_symbolize.cpp#L48-L53) is an example).

`llvm::function_ref` doesn't own the callable, and it is not safe to store a function_ref (the `PlainPrinterBase` stores a `llvm::function_ref` which can easily lead to dangling references).
