### PR TITLE
[PS5][Driver] Supply libraries and CRT objects to the linker

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -367,7 +367,7 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("--no-demangle");
 
   // Sanitizer runtimes must be supplied before all other objects and libs.
-  if (!Args.hasArg(options::OPT_nodefaultlibs, options::OPT_nostdlib))
+  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs))
     TC.addSanitizerArgs(Args, CmdArgs, "-l", "");
 
   const bool AddStartFiles =

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -183,6 +183,7 @@ void tools::PS4cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(
         Args.MakeArgString(Twine("-lto-debug-options=") + LTOArgs));
 
+  // Sanitizer runtimes must be supplied before all other objects and libs.
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs))
     TC.addSanitizerArgs(Args, CmdArgs, "-l", "");
 
@@ -358,9 +359,6 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (StringRef Jobs = getLTOParallelism(Args, D); !Jobs.empty())
     AddLTOFlag(Twine("jobs=") + Jobs);
 
-  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs))
-    TC.addSanitizerArgs(Args, CmdArgs, "-l", "");
-
   TC.AddFilePathLibArgs(Args, CmdArgs);
   Args.addAllArgs(CmdArgs, {options::OPT_L, options::OPT_T_Group,
                             options::OPT_s, options::OPT_t});
@@ -368,17 +366,63 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_Z_Xlinker__no_demangle))
     CmdArgs.push_back("--no-demangle");
 
-  AddLinkerInputs(TC, Inputs, Args, CmdArgs, JA);
+  // Sanitizer runtimes must be supplied before all other objects and libs.
+  if (!Args.hasArg(options::OPT_nodefaultlibs, options::OPT_nostdlib))
+    TC.addSanitizerArgs(Args, CmdArgs, "-l", "");
 
-  if (Args.hasArg(options::OPT_pthread)) {
-    CmdArgs.push_back("-lpthread");
+  const bool AddStartFiles =
+      !Relocatable &&
+      !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib);
+
+  auto AddCRTObject = [&](const char *Name) {
+    CmdArgs.push_back(Args.MakeArgString(TC.GetFilePath(Name)));
+  };
+
+  if (AddStartFiles) {
+    if (!Shared)
+      AddCRTObject("crt1.o");
+    AddCRTObject("crti.o");
+    AddCRTObject(Shared   ? "crtbeginS.o"
+                 : Static ? "crtbeginT.o"
+                          : "crtbegin.o");
   }
 
-  if (UseJMC) {
-    CmdArgs.push_back("--push-state");
-    CmdArgs.push_back("--whole-archive");
-    CmdArgs.push_back("-lSceJmc_nosubmission");
-    CmdArgs.push_back("--pop-state");
+  AddLinkerInputs(TC, Inputs, Args, CmdArgs, JA);
+
+  if (!Relocatable &&
+      !Args.hasArg(options::OPT_nodefaultlibs, options::OPT_nostdlib)) {
+
+    if (UseJMC) {
+      CmdArgs.push_back("--push-state");
+      CmdArgs.push_back("--whole-archive");
+      CmdArgs.push_back("-lSceJmc_nosubmission");
+      CmdArgs.push_back("--pop-state");
+    }
+
+    if (Args.hasArg(options::OPT_pthread))
+      CmdArgs.push_back("-lpthread");
+
+    if (Static) {
+      if (!Args.hasArg(options::OPT_nostdlibxx))
+        CmdArgs.push_back("-lstdc++");
+      if (!Args.hasArg(options::OPT_nolibc)) {
+        CmdArgs.push_back("-lm");
+        CmdArgs.push_back("-lc");
+      }
+
+      CmdArgs.push_back("-lcompiler_rt");
+      CmdArgs.push_back("-lkernel");
+    } else {
+      // The C and C++ libraries are combined.
+      if (!Args.hasArg(options::OPT_nolibc, options::OPT_nostdlibxx))
+        CmdArgs.push_back("-lc_stub_weak");
+
+      CmdArgs.push_back("-lkernel_stub_weak");
+    }
+  }
+  if (AddStartFiles) {
+    AddCRTObject(Shared ? "crtendS.o" : "crtend.o");
+    AddCRTObject("crtn.o");
   }
 
   if (Args.hasArg(options::OPT_fuse_ld_EQ)) {

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -131,7 +131,7 @@
 // CHECK-LD: {{ld(\.exe)?}}"
 // CHECK-MAIN-CRT-SAME: "crt1.o" "crti.o" "crtbegin.o"
 // CHECK-SHARED-CRT-SAME: "crti.o" "crtbeginS.o"
-// CHECK-STATIC-CRT-SAMW: "crt1.o" "crti.o" "crtbeginT.o"
+// CHECK-STATIC-CRT-SAME: "crt1.o" "crti.o" "crtbeginT.o"
 
 // CHECK-NO-LIBC-NOT: "-lc{{(_stub_weak)?}}"
 // CHECK-NO-LIBCPP-NOT: "-l{{c_stub_weak|stdc\+\+}}"

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -104,37 +104,34 @@
 // RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
 // RUN: %clang --target=x86_64-sie-ps5 %s -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
 // RUN: %clang --target=x86_64-sie-ps5 %s -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -r -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -r -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
 
 // RUN: %clang --target=x86_64-sie-ps5 %s -pthread -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-PTHREAD %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-STATIC-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" --check-prefixes=CHECK-LD,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -shared -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" --check-prefixes=CHECK-LD,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -static -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" --check-prefixes=CHECK-LD,CHECK-STATIC-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-NO-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-NO-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-NO-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -### 2>&1 | FileCheck "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD,CHECK-MAIN-CRT %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -shared -### 2>&1 | FileCheck "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD,CHECK-SHARED-CRT %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -static -### 2>&1 | FileCheck "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD,CHECK-STATIC-CRT %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -shared -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -static -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-NO-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-NO-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBCPP,CHECK-NO-LIBC,CHECK-STATIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -shared -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -static -### 2>&1 | FileCheck "--implicit-check-not=\"-lc\"" --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBCPP,CHECK-STATIC-CORE-LIBS %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-NO-LIBCPP,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-NO-LIBCPP,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-NO-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -shared -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -static -### 2>&1 | FileCheck "--implicit-check-not=\"-lstdc++\"" --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
 
 // CHECK-LD: {{ld(\.exe)?}}"
 // CHECK-MAIN-CRT-SAME: "crt1.o" "crti.o" "crtbegin.o"
 // CHECK-SHARED-CRT-SAME: "crti.o" "crtbeginS.o"
 // CHECK-STATIC-CRT-SAME: "crt1.o" "crti.o" "crtbeginT.o"
-
-// CHECK-NO-LIBC-NOT: "-lc{{(_stub_weak)?}}"
-// CHECK-NO-LIBCPP-NOT: "-l{{c_stub_weak|stdc\+\+}}"
 
 // CHECK-DYNAMIC-LIBC-SAME: "-lc_stub_weak"
 // CHECK-DYNAMIC-CORE-LIBS-SAME: "-lkernel_stub_weak"
@@ -147,9 +144,6 @@
 // CHECK-MAIN-CRT-SAME: "crtend.o" "crtn.o"
 // CHECK-SHARED-CRT-SAME: "crtendS.o" "crtn.o"
 // CHECK-STATIC-CRT-SAME: "crtend.o" "crtn.o"
-
-// CHECK-NO-CRT-NOT: "crt{{[^"]*}}.o"
-// CHECK-NO-LIBS-NOT: "-l{{[^"]*}}"
 
 // Test the driver's control over the -fcrash-diagnostics-dir behavior with linker flags.
 

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -104,34 +104,37 @@
 // RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
 // RUN: %clang --target=x86_64-sie-ps5 %s -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
 // RUN: %clang --target=x86_64-sie-ps5 %s -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -r -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -r -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
 
 // RUN: %clang --target=x86_64-sie-ps5 %s -pthread -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-PTHREAD %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" --check-prefixes=CHECK-LD,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -shared -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" --check-prefixes=CHECK-LD,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -static -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" --check-prefixes=CHECK-LD,CHECK-STATIC-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-DYNAMIC-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostartfiles -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-STATIC-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -### 2>&1 | FileCheck "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD,CHECK-MAIN-CRT %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -shared -### 2>&1 | FileCheck "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD,CHECK-SHARED-CRT %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -static -### 2>&1 | FileCheck "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD,CHECK-STATIC-CRT %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-NO-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-NO-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nodefaultlibs -pthread -fjmc -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-NO-LIBS %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -shared -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -static -### 2>&1 | FileCheck "--implicit-check-not=\"crt{{[^\"]*}}.o\"" "--implicit-check-not=\"-l{{[^\"]*}}\"" --check-prefixes=CHECK-LD %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib -pthread -fjmc -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-NO-CRT,CHECK-NO-LIBS %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -shared -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -static -### 2>&1 | FileCheck "--implicit-check-not=\"-lc\"" --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBCPP,CHECK-STATIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-NO-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-NO-LIBC,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nolibc -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBCPP,CHECK-NO-LIBC,CHECK-STATIC-CORE-LIBS %s
 
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -shared -### 2>&1 | FileCheck "--implicit-check-not=\"-lc_stub_weak\"" --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-DYNAMIC-CORE-LIBS %s
-// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -static -### 2>&1 | FileCheck "--implicit-check-not=\"-lstdc++\"" --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-MAIN-CRT,CHECK-NO-LIBCPP,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-SHARED-CRT,CHECK-NO-LIBCPP,CHECK-DYNAMIC-CORE-LIBS %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-NO-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
 
 // CHECK-LD: {{ld(\.exe)?}}"
 // CHECK-MAIN-CRT-SAME: "crt1.o" "crti.o" "crtbegin.o"
 // CHECK-SHARED-CRT-SAME: "crti.o" "crtbeginS.o"
 // CHECK-STATIC-CRT-SAME: "crt1.o" "crti.o" "crtbeginT.o"
+
+// CHECK-NO-LIBC-NOT: "-lc{{(_stub_weak)?}}"
+// CHECK-NO-LIBCPP-NOT: "-l{{c_stub_weak|stdc\+\+}}"
 
 // CHECK-DYNAMIC-LIBC-SAME: "-lc_stub_weak"
 // CHECK-DYNAMIC-CORE-LIBS-SAME: "-lkernel_stub_weak"
@@ -144,6 +147,9 @@
 // CHECK-MAIN-CRT-SAME: "crtend.o" "crtn.o"
 // CHECK-SHARED-CRT-SAME: "crtendS.o" "crtn.o"
 // CHECK-STATIC-CRT-SAME: "crtend.o" "crtn.o"
+
+// CHECK-NO-CRT-NOT: "crt{{[^"]*}}.o"
+// CHECK-NO-LIBS-NOT: "-l{{[^"]*}}"
 
 // Test the driver's control over the -fcrash-diagnostics-dir behavior with linker flags.
 


### PR DESCRIPTION
Until now, these have been hardcoded as a downstream patches in lld. Add them to the driver so that the private patches can be removed.

PS5 only. On PS4, the equivalent hardcoded configuration will remain in the proprietary linker.

SIE tracker: TOOLCHAIN-16704