### PR TITLE
[Clang] [OMPIRBuilder] Prevent Null Pointer Dereference in OpenMP IR Builder

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6966,6 +6966,10 @@ static Function *emitTargetTaskProxyFunction(OpenMPIRBuilder &OMPBuilder,
     auto *ArgStructType =
         dyn_cast<StructType>(ArgStructAlloca->getAllocatedType());
 
+    assert(ArgStructType &&
+           "Unable to find the struct type corresponding to the alloca "
+           "instruction");
+
     AllocaInst *NewArgStructAlloca =
         Builder.CreateAlloca(ArgStructType, nullptr, "structArg");
     Value *TaskT = ProxyFn->getArg(1);

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6963,12 +6963,7 @@ static Function *emitTargetTaskProxyFunction(OpenMPIRBuilder &OMPBuilder,
     assert(ArgStructAlloca &&
            "Unable to find the alloca instruction corresponding to arguments "
            "for extracted function");
-    auto *ArgStructType =
-        dyn_cast<StructType>(ArgStructAlloca->getAllocatedType());
-
-    assert(ArgStructType &&
-           "Unable to find the struct type corresponding to the alloca "
-           "instruction");
+    auto *ArgStructType = cast<StructType>(ArgStructAlloca->getAllocatedType());
 
     AllocaInst *NewArgStructAlloca =
         Builder.CreateAlloca(ArgStructType, nullptr, "structArg");


### PR DESCRIPTION
This commit addresses Static Analyzer issues related to potential null dereference by replacing dyn_cast<> with cast<> in OMPIRBuilder.cpp to ensure that ArgStructType is not null before it is used, improving the stability and reliability of the code.