### PR TITLE
[Baze] Add missing lldbDataFormatter.py back to BUILD.bazel.

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -32,6 +32,7 @@ exports_files([
     "include/llvm/IR/Intrinsics.td",
     "include/llvm/Option/OptParser.td",
     "utils/lit/lit.py",
+    "utils/lldbDataFormatters.py",
 ])
 
 # It may be tempting to add compiler flags here, but that should be avoided.


### PR DESCRIPTION
- [x] Add `utils/lldbDataFormatters.py` back. 