### PR TITLE
[compiler-rt] Make add_custom_libcxx() resilient to DESTDIR being set

### DIFF
--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -713,7 +713,7 @@ macro(add_custom_libcxx name prefix)
     USES_TERMINAL_INSTALL 1
     LIST_SEPARATOR |
     EXCLUDE_FROM_ALL TRUE
-    # Ensure that DESDIR=... set in the out environment does not affect this
+    # Ensure that DESTDIR=... set in the out environment does not affect this
     # target (we always need to install to the build directory).
     INSTALL_COMMAND env DESTDIR= ${CMAKE_COMMAND} --build ${prefix}/build --target install
     INSTALL_BYPRODUCTS "${prefix}/lib/libc++.a" "${prefix}/lib/libc++abi.a"

--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -713,6 +713,9 @@ macro(add_custom_libcxx name prefix)
     USES_TERMINAL_INSTALL 1
     LIST_SEPARATOR |
     EXCLUDE_FROM_ALL TRUE
+    # Ensure that DESDIR=... set in the out environment does not affect this
+    # target (we always need to install to the build directory).
+    INSTALL_COMMAND env DESTDIR= ${CMAKE_COMMAND} --build ${prefix}/build --target install
     INSTALL_BYPRODUCTS "${prefix}/lib/libc++.a" "${prefix}/lib/libc++abi.a"
     )
 


### PR DESCRIPTION
If DESTDIR is set in the environment during the build/test stage, the
local libc++ installation will be installed under DESTDIR instead of being
in the build directory.

See https://github.com/llvm/llvm-project/pull/115077#issuecomment-2464640457
and https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
