### PR TITLE
[libc++][test] Speed up input generating functions for benchmark tests

### DIFF
--- a/libcxx/test/benchmarks/GenerateInput.h
+++ b/libcxx/test/benchmarks/GenerateInput.h
@@ -53,6 +53,7 @@ inline std::vector<IntT> getDuplicateIntegerInputs(std::size_t N) {
 template <class IntT>
 inline std::vector<IntT> getSortedIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
+  inputs.reserve(N);
   for (std::size_t i = 0; i < N; i += 1)
     inputs.push_back(i);
   return inputs;
@@ -61,6 +62,7 @@ inline std::vector<IntT> getSortedIntegerInputs(std::size_t N) {
 template <class IntT>
 std::vector<IntT> getSortedLargeIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
+  inputs.reserve(N);
   for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(i + N);
   return inputs;
@@ -77,6 +79,7 @@ std::vector<IntT> getSortedTopBitsIntegerInputs(std::size_t N) {
 template <class IntT>
 inline std::vector<IntT> getReverseSortedIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
+  inputs.reserve(N);
   std::size_t i = N;
   while (i > 0) {
     --i;
@@ -99,6 +102,7 @@ std::vector<IntT> getPipeOrganIntegerInputs(std::size_t N) {
 template <class IntT>
 std::vector<IntT> getRandomIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
+  inputs.reserve(N);
   for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(getRandomInteger<IntT>(0, std::numeric_limits<IntT>::max()));
   return inputs;
@@ -111,6 +115,7 @@ inline std::vector<std::string> getDuplicateStringInputs(std::size_t N) {
 
 inline std::vector<std::string> getRandomStringInputs(std::size_t N) {
   std::vector<std::string> inputs;
+  inputs.reserve(N);
   for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(getRandomString(1024));
   return inputs;
@@ -118,6 +123,7 @@ inline std::vector<std::string> getRandomStringInputs(std::size_t N) {
 
 inline std::vector<std::string> getPrefixedRandomStringInputs(std::size_t N) {
   std::vector<std::string> inputs;
+  inputs.reserve(N);
   constexpr int kSuffixLength = 32;
   const std::string prefix    = getRandomString(1024 - kSuffixLength);
   for (std::size_t i = 0; i < N; ++i)


### PR DESCRIPTION
The input generating functions for benchmark tests in the `GenerateInput.h` file can be slightly improved by invoking `std::vector::reserve` before calling `push_back`. This slight performance improvement could potentially speed-up all benchmark tests for containers and algorithms that use these functions as inputs. 

Changes include:
- Add `reserve(N)` to the following functions: `getSortedIntegerInputs`, `getSortedLargeIntegerInputs`, `getReverseSortedIntegerInputs`, `getRandomIntegerInputs`, `getRandomStringInputs`, and `getPrefixedRandomStringInputs`.