### PR TITLE
[llvm][ARM] Restore the default to -mstrict-align on Apple firmwares

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -908,7 +908,8 @@ fp16_fml_fallthrough:
       if (VersionNum < 6 ||
           Triple.getSubArch() == llvm::Triple::SubArchType::ARMSubArch_v6m)
         Features.push_back("+strict-align");
-    } else if (Triple.getVendor() == llvm::Triple::Apple && Triple.isOSBinFormatMachO()) {
+    } else if (Triple.getVendor() == llvm::Triple::Apple &&
+               Triple.isOSBinFormatMachO()) {
       // Firmwares on Apple platforms are strict-align by default.
       Features.push_back("+strict-align");
     } else if (VersionNum < 7 ||

--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -908,6 +908,9 @@ fp16_fml_fallthrough:
       if (VersionNum < 6 ||
           Triple.getSubArch() == llvm::Triple::SubArchType::ARMSubArch_v6m)
         Features.push_back("+strict-align");
+    } else if (Triple.getVendor() == llvm::Triple::Apple && Triple.isOSBinFormatMachO()) {
+      // Firmwares on Apple platforms are strict-align by default.
+      Features.push_back("+strict-align");
     } else if (VersionNum < 7 ||
                Triple.getSubArch() ==
                    llvm::Triple::SubArchType::ARMSubArch_v6m ||

--- a/clang/test/Driver/arm-alignment.c
+++ b/clang/test/Driver/arm-alignment.c
@@ -37,6 +37,12 @@
 // RUN: %clang -target thumbv8m.base-none-gnueabi -### %s 2> %t
 // RUN: FileCheck --check-prefix CHECK-ALIGNED-ARM <%t %s
 
+// RUN: %clang -target armv7em-apple-unknown-macho -mthumb -### %s 2> %t
+// RUN: FileCheck --check-prefix CHECK-ALIGNED-ARM <%t %s
+
+// RUN: %clang -target armv7em-apple-darwin -mthumb -### %s 2> %t
+// RUN: FileCheck --check-prefix CHECK-ALIGNED-ARM <%t %s
+
 // RUN: %clang --target=aarch64 -munaligned-access -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-UNALIGNED-AARCH64 < %t %s
 


### PR DESCRIPTION
This is a partial revert of e314622f204a01ffeda59cbe046dd403b01f8b74

rdar://139237593