### PR TITLE
[NFC][mlir][emitc] fix misspelling in description of emitc.global

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -1110,9 +1110,9 @@ def EmitC_GlobalOp : EmitC_Op<"global", [Symbol]> {
 
     ```mlir
     // Global variable with an initial value.
-    emitc.global @x : emitc.array<2xf32> = dense<0.0, 2.0>
+    emitc.global @x : !emitc.array<2xf32> = dense<0.0, 2.0>
     // External global variable
-    emitc.global extern @x : emitc.array<2xf32>
+    emitc.global extern @x : !emitc.array<2xf32>
     // Constant global variable with internal linkage
     emitc.global static const @x : i32 = 0
     ```

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -1111,6 +1111,8 @@ def EmitC_GlobalOp : EmitC_Op<"global", [Symbol]> {
     ```mlir
     // Global variable with an initial value.
     emitc.global @x : !emitc.array<2xf32> = dense<0.0>
+    // Global variable with an initial values.
+    emitc.global @x : !emitc.array<3xi32> = dense<[0, 1, 2]>
     // External global variable
     emitc.global extern @x : !emitc.array<2xf32>
     // Constant global variable with internal linkage

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -1110,7 +1110,7 @@ def EmitC_GlobalOp : EmitC_Op<"global", [Symbol]> {
 
     ```mlir
     // Global variable with an initial value.
-    emitc.global @x : !emitc.array<2xf32> = dense<0.0, 2.0>
+    emitc.global @x : !emitc.array<2xf32> = dense<0.0>
     // External global variable
     emitc.global extern @x : !emitc.array<2xf32>
     // Constant global variable with internal linkage


### PR DESCRIPTION
Missing `!` before `emitc.global` was added in the `EmitC.td`.