### PR TITLE
[lldb-dap] Fix lldb-dap build for windows, missing PATH_MAX.

### DIFF
--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -31,6 +31,7 @@
 #include "lldb/API/SBThread.h"
 #include "lldb/API/SBType.h"
 #include "lldb/API/SBValue.h"
+#include "lldb/Host/PosixApi.h" // IWYU pragma: keep
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-types.h"


### PR DESCRIPTION
This should fix https://lab.llvm.org/buildbot/#/builders/141/builds/3722