### PR TITLE
[Wunsafe-buffer-usage] Fix false positives in handling string literals.

### DIFF
--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-array.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-array.cpp
@@ -38,3 +38,17 @@ void constant_idx_unsafe(unsigned idx) {
                         // expected-note@-1{{change type of 'buffer' to 'std::array' to label it for hardening}}
   buffer[10] = 0;       // expected-note{{used in buffer access here}}
 }
+
+void constant_id_string(unsigned idx) {
+  char safe_char = "abc"[1]; // no-warning
+  safe_char = ""[0];
+  safe_char = "\0"[0];
+ 
+  char abcd[5] = "abc";
+  abcd[2]; // no-warning
+
+  char unsafe_char = "abc"[3];
+  unsafe_char = "abc"[-1]; //expected-warning{{unsafe buffer access}}
+  unsafe_char = ""[1]; //expected-warning{{unsafe buffer access}} 
+  unsafe_char = ""[idx]; //expected-warning{{unsafe buffer access}}
+}


### PR DESCRIPTION
Do not warn when a string literal is indexed and the idex value is within the bounds of the length of the string.

(rdar://139106996)