### PR TITLE
[SandboxIR] Remove incorrect assertion.

### DIFF
--- a/llvm/lib/SandboxIR/Instruction.cpp
+++ b/llvm/lib/SandboxIR/Instruction.cpp
@@ -124,10 +124,6 @@ void Instruction::moveBefore(BasicBlock &BB, const BBIterator &WhereIt) {
 
 void Instruction::insertBefore(Instruction *BeforeI) {
   llvm::Instruction *BeforeTopI = BeforeI->getTopmostLLVMInstruction();
-  // TODO: Move this to the verifier of sandboxir::Instruction.
-  assert(is_sorted(getLLVMInstrs(),
-                   [](auto *I1, auto *I2) { return I1->comesBefore(I2); }) &&
-         "Expected program order!");
 
   Ctx.getTracker().emplaceIfTracking<InsertIntoBB>(this);
 


### PR DESCRIPTION
`insertBefore` can be called on a detached instruction, and we can't check that the underlying instructions are ordered because instructions without BB parents have no order.

This problem showed up as a different assertion failure in `llvm::Instruction::comesBefore` in one of the unit tests when `EXPENSIVE_CHECKS` are enabled.