### PR TITLE
[libc++][test] Clean up code in GenerateInput.h for benchmark testing

### DIFF
--- a/libcxx/test/benchmarks/GenerateInput.h
+++ b/libcxx/test/benchmarks/GenerateInput.h
@@ -45,30 +45,29 @@ inline std::string getRandomString(std::size_t Len) {
 }
 
 template <class IntT>
-inline std::vector<IntT> getDuplicateIntegerInputs(size_t N) {
+inline std::vector<IntT> getDuplicateIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs(N, static_cast<IntT>(-1));
   return inputs;
 }
 
 template <class IntT>
-inline std::vector<IntT> getSortedIntegerInputs(size_t N) {
+inline std::vector<IntT> getSortedIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
-  for (size_t i = 0; i < N; i += 1)
+  for (std::size_t i = 0; i < N; i += 1)
     inputs.push_back(i);
   return inputs;
 }
 
 template <class IntT>
-std::vector<IntT> getSortedLargeIntegerInputs(size_t N) {
+std::vector<IntT> getSortedLargeIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
-  for (size_t i = 0; i < N; ++i) {
+  for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(i + N);
-  }
   return inputs;
 }
 
 template <class IntT>
-std::vector<IntT> getSortedTopBitsIntegerInputs(size_t N) {
+std::vector<IntT> getSortedTopBitsIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs = getSortedIntegerInputs<IntT>(N);
   for (auto& E : inputs)
     E <<= ((sizeof(IntT) / 2) * CHAR_BIT);
@@ -76,7 +75,7 @@ std::vector<IntT> getSortedTopBitsIntegerInputs(size_t N) {
 }
 
 template <class IntT>
-inline std::vector<IntT> getReverseSortedIntegerInputs(size_t N) {
+inline std::vector<IntT> getReverseSortedIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
   std::size_t i = N;
   while (i > 0) {
@@ -87,61 +86,58 @@ inline std::vector<IntT> getReverseSortedIntegerInputs(size_t N) {
 }
 
 template <class IntT>
-std::vector<IntT> getPipeOrganIntegerInputs(size_t N) {
+std::vector<IntT> getPipeOrganIntegerInputs(std::size_t N) {
   std::vector<IntT> v;
   v.reserve(N);
-  for (size_t i = 0; i < N / 2; ++i)
+  for (std::size_t i = 0; i < N / 2; ++i)
     v.push_back(i);
-  for (size_t i = N / 2; i < N; ++i)
+  for (std::size_t i = N / 2; i < N; ++i)
     v.push_back(N - i);
   return v;
 }
 
 template <class IntT>
-std::vector<IntT> getRandomIntegerInputs(size_t N) {
+std::vector<IntT> getRandomIntegerInputs(std::size_t N) {
   std::vector<IntT> inputs;
-  for (size_t i = 0; i < N; ++i) {
+  for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(getRandomInteger<IntT>(0, std::numeric_limits<IntT>::max()));
-  }
   return inputs;
 }
 
-inline std::vector<std::string> getDuplicateStringInputs(size_t N) {
+inline std::vector<std::string> getDuplicateStringInputs(std::size_t N) {
   std::vector<std::string> inputs(N, getRandomString(1024));
   return inputs;
 }
 
-inline std::vector<std::string> getRandomStringInputs(size_t N) {
+inline std::vector<std::string> getRandomStringInputs(std::size_t N) {
   std::vector<std::string> inputs;
-  for (size_t i = 0; i < N; ++i) {
+  for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(getRandomString(1024));
-  }
   return inputs;
 }
 
-inline std::vector<std::string> getPrefixedRandomStringInputs(size_t N) {
+inline std::vector<std::string> getPrefixedRandomStringInputs(std::size_t N) {
   std::vector<std::string> inputs;
   constexpr int kSuffixLength = 32;
   const std::string prefix    = getRandomString(1024 - kSuffixLength);
-  for (size_t i = 0; i < N; ++i) {
+  for (std::size_t i = 0; i < N; ++i)
     inputs.push_back(prefix + getRandomString(kSuffixLength));
-  }
   return inputs;
 }
 
-inline std::vector<std::string> getSortedStringInputs(size_t N) {
+inline std::vector<std::string> getSortedStringInputs(std::size_t N) {
   std::vector<std::string> inputs = getRandomStringInputs(N);
   std::sort(inputs.begin(), inputs.end());
   return inputs;
 }
 
-inline std::vector<std::string> getReverseSortedStringInputs(size_t N) {
+inline std::vector<std::string> getReverseSortedStringInputs(std::size_t N) {
   std::vector<std::string> inputs = getSortedStringInputs(N);
   std::reverse(inputs.begin(), inputs.end());
   return inputs;
 }
 
-inline std::vector<const char*> getRandomCStringInputs(size_t N) {
+inline std::vector<const char*> getRandomCStringInputs(std::size_t N) {
   static std::vector<std::string> inputs = getRandomStringInputs(N);
   std::vector<const char*> cinputs;
   for (auto const& str : inputs)


### PR DESCRIPTION
This PR refines the code in `GenerateInput.h` used for benchmark testing by implementing the following changes:

- Replaced all unqualified usages of `size_t` with `std::size_t`.
- Removed unnecessary curly braces `{}` from for loops that contain simple single-statement bodies, in accordance with LLVM coding standards.