### PR TITLE
[clang][CIR] Change buildX functions to emitX

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -50,7 +50,7 @@ mlir::Location CIRGenModule::getLoc(SourceRange cRange) {
   return mlir::FusedLoc::get({begin, end}, metadata, builder.getContext());
 }
 
-void CIRGenModule::buildGlobal(clang::GlobalDecl gd) {
+void CIRGenModule::emitGlobal(clang::GlobalDecl gd) {
   const auto *global = cast<ValueDecl>(gd.getDecl());
 
   if (const auto *fd = dyn_cast<FunctionDecl>(global)) {
@@ -71,19 +71,19 @@ void CIRGenModule::buildGlobal(clang::GlobalDecl gd) {
   }
 
   // TODO(CIR): Defer emitting some global definitions until later
-  buildGlobalDefinition(gd);
+  emitGlobalDefinition(gd);
 }
 
-void CIRGenModule::buildGlobalFunctionDefinition(clang::GlobalDecl gd,
-                                                 mlir::Operation *op) {
+void CIRGenModule::emitGlobalFunctionDefinition(clang::GlobalDecl gd,
+                                                mlir::Operation *op) {
   auto const *funcDecl = cast<FunctionDecl>(gd.getDecl());
   auto funcOp = builder.create<cir::FuncOp>(
       getLoc(funcDecl->getSourceRange()), funcDecl->getIdentifier()->getName());
   theModule.push_back(funcOp);
 }
 
-void CIRGenModule::buildGlobalDefinition(clang::GlobalDecl gd,
-                                         mlir::Operation *op) {
+void CIRGenModule::emitGlobalDefinition(clang::GlobalDecl gd,
+                                        mlir::Operation *op) {
   const auto *decl = cast<ValueDecl>(gd.getDecl());
   if (const auto *fd = dyn_cast<FunctionDecl>(decl)) {
     // TODO(CIR): Skip generation of CIR for functions with available_externally
@@ -99,15 +99,15 @@ void CIRGenModule::buildGlobalDefinition(clang::GlobalDecl gd,
 
     if (fd->isMultiVersion())
       errorNYI(fd->getSourceRange(), "multiversion functions");
-    buildGlobalFunctionDefinition(gd, op);
+    emitGlobalFunctionDefinition(gd, op);
     return;
   }
 
-  llvm_unreachable("Invalid argument to CIRGenModule::buildGlobalDefinition");
+  llvm_unreachable("Invalid argument to CIRGenModule::emitGlobalDefinition");
 }
 
 // Emit code for a single top level declaration.
-void CIRGenModule::buildTopLevelDecl(Decl *decl) {
+void CIRGenModule::emitTopLevelDecl(Decl *decl) {
 
   // Ignore dependent declarations.
   if (decl->isTemplated())
@@ -123,7 +123,7 @@ void CIRGenModule::buildTopLevelDecl(Decl *decl) {
     auto *fd = cast<FunctionDecl>(decl);
     // Consteval functions shouldn't be emitted.
     if (!fd->isConsteval())
-      buildGlobal(fd);
+      emitGlobal(fd);
     break;
   }
   }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -72,15 +72,15 @@ public:
   mlir::Location getLoc(clang::SourceLocation cLoc);
   mlir::Location getLoc(clang::SourceRange cRange);
 
-  void buildTopLevelDecl(clang::Decl *decl);
+  void emitTopLevelDecl(clang::Decl *decl);
 
   /// Emit code for a single global function or variable declaration. Forward
   /// declarations are emitted lazily.
-  void buildGlobal(clang::GlobalDecl gd);
+  void emitGlobal(clang::GlobalDecl gd);
 
-  void buildGlobalDefinition(clang::GlobalDecl gd,
-                             mlir::Operation *op = nullptr);
-  void buildGlobalFunctionDefinition(clang::GlobalDecl gd, mlir::Operation *op);
+  void emitGlobalDefinition(clang::GlobalDecl gd,
+                            mlir::Operation *op = nullptr);
+  void emitGlobalFunctionDefinition(clang::GlobalDecl gd, mlir::Operation *op);
 
   /// Helpers to emit "not yet implemented" error diagnostics
   DiagnosticBuilder errorNYI(llvm::StringRef);

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -45,7 +45,7 @@ mlir::ModuleOp CIRGenerator::getModule() const { return cgm->getModule(); }
 bool CIRGenerator::HandleTopLevelDecl(DeclGroupRef group) {
 
   for (Decl *decl : group)
-    cgm->buildTopLevelDecl(decl);
+    cgm->emitTopLevelDecl(decl);
 
   return true;
 }


### PR DESCRIPTION
The buildX naming convention originated when the CIRGen implementation
was planned to be substantially different from original CodeGen. CIRGen
is now a much closer adaption of CodeGen, and the emitX to buildX
renaming just makes things more confusing, since CodeGen also has some
helper functions whose names start with build or Build, so it's not
immediately clear which CodeGen function corresponds to a CIRGen buildX
function. Rename the buildX functions back to emitX to fix this.