### PR TITLE
[RISCV] RVA23S64 should include H extension

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProfiles.td
+++ b/llvm/lib/Target/RISCV/RISCVProfiles.td
@@ -77,7 +77,8 @@ defvar RVA23U64Features = !listconcat(RVA22U64Features,
                                        FeatureStdExtSupm]);
 
 defvar RVA23S64BaseFeatures = !listconcat(RVA22S64BaseFeatures,
-                                          [FeatureStdExtSvnapot,
+                                          [FeatureStdExtH,
+                                           FeatureStdExtSvnapot,
                                            FeatureStdExtSstc,
                                            FeatureStdExtSscofpmf,
                                            FeatureStdExtSsnpm,


### PR DESCRIPTION
RVA23 defines Hypervisor (H) extension to be required for RVA23S64:

https://drive.google.com/file/d/12QKRm92cLcEk8-5J9NI91m0fAQOxqNAq/view?usp=sharing