### PR TITLE
[GISel][AArch64][RISCV] Allow G_SEXT_INREG patterns to be imported.

### DIFF
--- a/llvm/include/llvm/Target/GlobalISel/SelectionDAGCompat.td
+++ b/llvm/include/llvm/Target/GlobalISel/SelectionDAGCompat.td
@@ -48,6 +48,7 @@ class GINodeEquiv<Instruction i, SDNode node> {
 // These are defined in the same order as the G_* instructions.
 def : GINodeEquiv<G_ANYEXT, anyext>;
 def : GINodeEquiv<G_SEXT, sext>;
+def : GINodeEquiv<G_SEXT_INREG, sext_inreg>;
 def : GINodeEquiv<G_ZEXT, zext>;
 def : GINodeEquiv<G_TRUNC, trunc>;
 def : GINodeEquiv<G_BITCAST, bitconvert>;

--- a/llvm/test/CodeGen/AArch64/aarch64-dup-ext.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-dup-ext.ll
@@ -15,8 +15,7 @@ define <8 x i16> @dupsext_v8i8_v8i16(i8 %src, <8 x i8> %b) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    lsl w8, w0, #8
 ; CHECK-GI-NEXT:    sshll v0.8h, v0.8b, #0
-; CHECK-GI-NEXT:    sxth w8, w8
-; CHECK-GI-NEXT:    asr w8, w8, #8
+; CHECK-GI-NEXT:    sbfx w8, w8, #8, #8
 ; CHECK-GI-NEXT:    dup v1.8h, w8
 ; CHECK-GI-NEXT:    mul v0.8h, v1.8h, v0.8h
 ; CHECK-GI-NEXT:    ret
@@ -175,9 +174,8 @@ define <2 x i16> @dupsext_v2i8_v2i16(i8 %src, <2 x i8> %b) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    lsl w8, w0, #8
 ; CHECK-GI-NEXT:    shl v0.2s, v0.2s, #24
-; CHECK-GI-NEXT:    sxth w8, w8
+; CHECK-GI-NEXT:    sbfx w8, w8, #8, #8
 ; CHECK-GI-NEXT:    sshr v0.2s, v0.2s, #24
-; CHECK-GI-NEXT:    asr w8, w8, #8
 ; CHECK-GI-NEXT:    dup v1.4h, w8
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-GI-NEXT:    mul v0.2s, v1.2s, v0.2s
@@ -254,8 +252,7 @@ define <8 x i16> @nonsplat_shuffleinsert(i8 %src, <8 x i8> %b) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    lsl w8, w0, #8
 ; CHECK-GI-NEXT:    sshll v0.8h, v0.8b, #0
-; CHECK-GI-NEXT:    sxth w8, w8
-; CHECK-GI-NEXT:    asr w8, w8, #8
+; CHECK-GI-NEXT:    sbfx w8, w8, #8, #8
 ; CHECK-GI-NEXT:    mov v1.h[1], w8
 ; CHECK-GI-NEXT:    ext v1.16b, v1.16b, v1.16b, #4
 ; CHECK-GI-NEXT:    mul v0.8h, v1.8h, v0.8h

--- a/llvm/test/CodeGen/AArch64/aarch64-matrix-umull-smull.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-matrix-umull-smull.ll
@@ -652,8 +652,7 @@ define i16 @red_mla_dup_ext_u8_s8_s16(ptr noalias nocapture noundef readonly %A,
 ; CHECK-GI-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-GI-NEXT:    movi v1.2d, #0000000000000000
 ; CHECK-GI-NEXT:    add x10, x0, #8
-; CHECK-GI-NEXT:    sxth w9, w9
-; CHECK-GI-NEXT:    asr w9, w9, #8
+; CHECK-GI-NEXT:    sbfx w9, w9, #8, #8
 ; CHECK-GI-NEXT:    dup v2.8h, w9
 ; CHECK-GI-NEXT:    and x9, x8, #0xfffffff0
 ; CHECK-GI-NEXT:    mov x11, x9

--- a/llvm/test/CodeGen/AArch64/arm64-mul.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-mul.ll
@@ -152,20 +152,12 @@ entry:
 
 ; Check the sext_inreg case.
 define i64 @t11(i64 %a) nounwind {
-; CHECK-SD-LABEL: t11:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    mov w8, #29594 // =0x739a
-; CHECK-SD-NEXT:    movk w8, #65499, lsl #16
-; CHECK-SD-NEXT:    smnegl x0, w0, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: t11:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    sxtw x8, w0
-; CHECK-GI-NEXT:    mov x9, #-35942 // =0xffffffffffff739a
-; CHECK-GI-NEXT:    movk x9, #65499, lsl #16
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: t11:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    mov w8, #29594 // =0x739a
+; CHECK-NEXT:    movk w8, #65499, lsl #16
+; CHECK-NEXT:    smnegl x0, w0, w8
+; CHECK-NEXT:    ret
 entry:
   %tmp1 = trunc i64 %a to i32
   %tmp2 = sext i32 %tmp1 to i64
@@ -175,20 +167,12 @@ entry:
 }
 
 define i64 @t12(i64 %a, i64 %b) nounwind {
-; CHECK-SD-LABEL: t12:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    mov w8, #35118 // =0x892e
-; CHECK-SD-NEXT:    movk w8, #65008, lsl #16
-; CHECK-SD-NEXT:    smaddl x0, w0, w8, x1
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: t12:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    sxtw x8, w0
-; CHECK-GI-NEXT:    mov x9, #-30418 // =0xffffffffffff892e
-; CHECK-GI-NEXT:    movk x9, #65008, lsl #16
-; CHECK-GI-NEXT:    madd x0, x8, x9, x1
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: t12:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    mov w8, #35118 // =0x892e
+; CHECK-NEXT:    movk w8, #65008, lsl #16
+; CHECK-NEXT:    smaddl x0, w0, w8, x1
+; CHECK-NEXT:    ret
 entry:
   %tmp1 = trunc i64 %a to i32
   %tmp2 = sext i32 %tmp1 to i64

--- a/llvm/test/CodeGen/AArch64/sadd_sat.ll
+++ b/llvm/test/CodeGen/AArch64/sadd_sat.ll
@@ -71,9 +71,9 @@ define i16 @func16(i16 %x, i16 %y) nounwind {
 ; CHECK-GI-NEXT:    sxth w8, w1
 ; CHECK-GI-NEXT:    add w8, w8, w0, sxth
 ; CHECK-GI-NEXT:    sxth w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #15
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #15, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #8, lsl #12 // =32768
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %tmp = call i16 @llvm.sadd.sat.i16(i16 %x, i16 %y);
@@ -98,9 +98,9 @@ define i8 @func8(i8 %x, i8 %y) nounwind {
 ; CHECK-GI-NEXT:    sxtb w8, w1
 ; CHECK-GI-NEXT:    add w8, w8, w0, sxtb
 ; CHECK-GI-NEXT:    sxtb w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #7
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #7, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #128
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %tmp = call i8 @llvm.sadd.sat.i8(i8 %x, i8 %y);

--- a/llvm/test/CodeGen/AArch64/sadd_sat_plus.ll
+++ b/llvm/test/CodeGen/AArch64/sadd_sat_plus.ll
@@ -76,9 +76,9 @@ define i16 @func16(i16 %x, i16 %y, i16 %z) nounwind {
 ; CHECK-GI-NEXT:    sxth w8, w8
 ; CHECK-GI-NEXT:    add w8, w8, w0, sxth
 ; CHECK-GI-NEXT:    sxth w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #15
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #15, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #8, lsl #12 // =32768
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %a = mul i16 %y, %z
@@ -106,9 +106,9 @@ define i8 @func8(i8 %x, i8 %y, i8 %z) nounwind {
 ; CHECK-GI-NEXT:    sxtb w8, w8
 ; CHECK-GI-NEXT:    add w8, w8, w0, sxtb
 ; CHECK-GI-NEXT:    sxtb w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #7
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #7, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #128
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %a = mul i8 %y, %z

--- a/llvm/test/CodeGen/AArch64/sadd_sat_vec.ll
+++ b/llvm/test/CodeGen/AArch64/sadd_sat_vec.ll
@@ -332,9 +332,9 @@ define void @v1i8(ptr %px, ptr %py, ptr %pz) nounwind {
 ; CHECK-GI-NEXT:    ldrsb w9, [x1]
 ; CHECK-GI-NEXT:    add w8, w8, w9
 ; CHECK-GI-NEXT:    sxtb w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #7
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #7, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #128
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w8, w10, w8, ne
 ; CHECK-GI-NEXT:    strb w8, [x2]
 ; CHECK-GI-NEXT:    ret
@@ -360,9 +360,9 @@ define void @v1i16(ptr %px, ptr %py, ptr %pz) nounwind {
 ; CHECK-GI-NEXT:    ldrsh w9, [x1]
 ; CHECK-GI-NEXT:    add w8, w8, w9
 ; CHECK-GI-NEXT:    sxth w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #15
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #15, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #8, lsl #12 // =32768
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w8, w10, w8, ne
 ; CHECK-GI-NEXT:    strh w8, [x2]
 ; CHECK-GI-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sext.ll
+++ b/llvm/test/CodeGen/AArch64/sext.ll
@@ -221,14 +221,11 @@ define <3 x i16> @sext_v3i8_v3i16(<3 x i8> %a) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    lsl w8, w0, #8
 ; CHECK-GI-NEXT:    lsl w9, w1, #8
-; CHECK-GI-NEXT:    lsl w10, w2, #8
-; CHECK-GI-NEXT:    sxth w8, w8
-; CHECK-GI-NEXT:    sxth w9, w9
-; CHECK-GI-NEXT:    asr w8, w8, #8
-; CHECK-GI-NEXT:    asr w9, w9, #8
+; CHECK-GI-NEXT:    sbfx w8, w8, #8, #8
+; CHECK-GI-NEXT:    sbfx w9, w9, #8, #8
 ; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    sxth w8, w10
-; CHECK-GI-NEXT:    asr w8, w8, #8
+; CHECK-GI-NEXT:    lsl w8, w2, #8
+; CHECK-GI-NEXT:    sbfx w8, w8, #8, #8
 ; CHECK-GI-NEXT:    mov v0.h[1], w9
 ; CHECK-GI-NEXT:    mov v0.h[2], w8
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
@@ -386,14 +383,11 @@ define <3 x i16> @sext_v3i10_v3i16(<3 x i10> %a) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    lsl w8, w0, #6
 ; CHECK-GI-NEXT:    lsl w9, w1, #6
-; CHECK-GI-NEXT:    lsl w10, w2, #6
-; CHECK-GI-NEXT:    sxth w8, w8
-; CHECK-GI-NEXT:    sxth w9, w9
-; CHECK-GI-NEXT:    asr w8, w8, #6
-; CHECK-GI-NEXT:    asr w9, w9, #6
+; CHECK-GI-NEXT:    sbfx w8, w8, #6, #10
+; CHECK-GI-NEXT:    sbfx w9, w9, #6, #10
 ; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    sxth w8, w10
-; CHECK-GI-NEXT:    asr w8, w8, #6
+; CHECK-GI-NEXT:    lsl w8, w2, #6
+; CHECK-GI-NEXT:    sbfx w8, w8, #6, #10
 ; CHECK-GI-NEXT:    mov v0.h[1], w9
 ; CHECK-GI-NEXT:    mov v0.h[2], w8
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0

--- a/llvm/test/CodeGen/AArch64/ssub_sat.ll
+++ b/llvm/test/CodeGen/AArch64/ssub_sat.ll
@@ -71,9 +71,9 @@ define i16 @func16(i16 %x, i16 %y) nounwind {
 ; CHECK-GI-NEXT:    sxth w8, w0
 ; CHECK-GI-NEXT:    sub w8, w8, w1, sxth
 ; CHECK-GI-NEXT:    sxth w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #15
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #15, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #8, lsl #12 // =32768
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %tmp = call i16 @llvm.ssub.sat.i16(i16 %x, i16 %y);
@@ -98,9 +98,9 @@ define i8 @func8(i8 %x, i8 %y) nounwind {
 ; CHECK-GI-NEXT:    sxtb w8, w0
 ; CHECK-GI-NEXT:    sub w8, w8, w1, sxtb
 ; CHECK-GI-NEXT:    sxtb w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #7
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #7, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #128
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %tmp = call i8 @llvm.ssub.sat.i8(i8 %x, i8 %y);

--- a/llvm/test/CodeGen/AArch64/ssub_sat_plus.ll
+++ b/llvm/test/CodeGen/AArch64/ssub_sat_plus.ll
@@ -76,9 +76,9 @@ define i16 @func16(i16 %x, i16 %y, i16 %z) nounwind {
 ; CHECK-GI-NEXT:    sxth w9, w0
 ; CHECK-GI-NEXT:    sub w8, w9, w8, sxth
 ; CHECK-GI-NEXT:    sxth w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #15
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #15, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #8, lsl #12 // =32768
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %a = mul i16 %y, %z
@@ -106,9 +106,9 @@ define i8 @func8(i8 %x, i8 %y, i8 %z) nounwind {
 ; CHECK-GI-NEXT:    sxtb w9, w0
 ; CHECK-GI-NEXT:    sub w8, w9, w8, sxtb
 ; CHECK-GI-NEXT:    sxtb w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #7
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #7, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #128
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w0, w10, w8, ne
 ; CHECK-GI-NEXT:    ret
   %a = mul i8 %y, %z

--- a/llvm/test/CodeGen/AArch64/ssub_sat_vec.ll
+++ b/llvm/test/CodeGen/AArch64/ssub_sat_vec.ll
@@ -333,9 +333,9 @@ define void @v1i8(ptr %px, ptr %py, ptr %pz) nounwind {
 ; CHECK-GI-NEXT:    ldrsb w9, [x1]
 ; CHECK-GI-NEXT:    sub w8, w8, w9
 ; CHECK-GI-NEXT:    sxtb w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #7
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #7, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #128
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w8, w10, w8, ne
 ; CHECK-GI-NEXT:    strb w8, [x2]
 ; CHECK-GI-NEXT:    ret
@@ -361,9 +361,9 @@ define void @v1i16(ptr %px, ptr %py, ptr %pz) nounwind {
 ; CHECK-GI-NEXT:    ldrsh w9, [x1]
 ; CHECK-GI-NEXT:    sub w8, w8, w9
 ; CHECK-GI-NEXT:    sxth w9, w8
-; CHECK-GI-NEXT:    asr w10, w9, #15
-; CHECK-GI-NEXT:    cmp w8, w9
+; CHECK-GI-NEXT:    sbfx w10, w8, #15, #1
 ; CHECK-GI-NEXT:    sub w10, w10, #8, lsl #12 // =32768
+; CHECK-GI-NEXT:    cmp w8, w9
 ; CHECK-GI-NEXT:    csel w8, w10, w8, ne
 ; CHECK-GI-NEXT:    strh w8, [x2]
 ; CHECK-GI-NEXT:    ret

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -1015,6 +1015,15 @@ Error GlobalISelEmitter::importChildMatcher(
         return Error::success();
       }
     }
+  } else if (auto *ChildDefInit = dyn_cast<DefInit>(SrcChild.getLeafValue())) {
+    auto *ChildRec = ChildDefInit->getDef();
+    if (ChildRec->isSubClassOf("ValueType") && !SrcChild.hasName()) {
+      // An unnamed ValueType as in (sext_inreg GPR:$foo, i8). GISel represents
+      // this as a literal constant with the scalar size.
+      MVT::SimpleValueType VT = llvm::getValueType(ChildRec);
+      OM.addPredicate<LiteralIntOperandMatcher>(MVT(VT).getScalarSizeInBits());
+      return Error::success();
+    }
   }
 
   // Immediate arguments have no meaningful type to check as they don't have


### PR DESCRIPTION
SelectionDAG uses VTSDNode to store the extension type. GlobalISel uses a literal constant operand.

For vectors, SelectionDAG uses a type with the same number of elements as other operand of the sext_inreg. I assume for GISel we would just use the scalar size.