### PR TITLE
[mlir][IR][NFC] `PostDominanceInfo`: Mark all functions as `const`

### DIFF
--- a/mlir/include/mlir/IR/Dominance.h
+++ b/mlir/include/mlir/IR/Dominance.h
@@ -202,20 +202,20 @@ public:
   using super::super;
 
   /// Return true if operation A properly postdominates operation B.
-  bool properlyPostDominates(Operation *a, Operation *b);
+  bool properlyPostDominates(Operation *a, Operation *b) const;
 
   /// Return true if operation A postdominates operation B.
-  bool postDominates(Operation *a, Operation *b) {
+  bool postDominates(Operation *a, Operation *b) const {
     return a == b || properlyPostDominates(a, b);
   }
 
   /// Return true if the specified block A properly postdominates block B.
-  bool properlyPostDominates(Block *a, Block *b) {
+  bool properlyPostDominates(Block *a, Block *b) const {
     return super::properlyDominates(a, b);
   }
 
   /// Return true if the specified block A postdominates block B.
-  bool postDominates(Block *a, Block *b) {
+  bool postDominates(Block *a, Block *b) const {
     return a == b || properlyPostDominates(a, b);
   }
 };

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -327,7 +327,8 @@ bool DominanceInfo::properlyDominates(Value a, Operation *b) const {
 //===----------------------------------------------------------------------===//
 
 /// Returns true if statement 'a' properly postdominates statement b.
-bool PostDominanceInfo::properlyPostDominates(Operation *a, Operation *b) {
+bool PostDominanceInfo::properlyPostDominates(Operation *a,
+                                              Operation *b) const {
   auto *aBlock = a->getBlock(), *bBlock = b->getBlock();
   assert(aBlock && bBlock && "operations must be in a block");
 


### PR DESCRIPTION
Same as `DominanceInfo`, all functions should be `const`.
