### PR TITLE
[lldb] Transfer some environment variables into the tests on Windows build host

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -334,3 +334,22 @@ if "FREEBSD_LEGACY_PLUGIN" in os.environ:
 # Propagate XDG_CACHE_HOME
 if "XDG_CACHE_HOME" in os.environ:
     config.environment["XDG_CACHE_HOME"] = os.environ["XDG_CACHE_HOME"]
+
+# Transfer some environment variables into the tests on Windows build host.
+if platform.system() == "Windows":
+    for v in [
+        "SystemDrive",
+        "SystemRoot",
+        "ALLUSERSPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "USERDNSDOMAIN",
+        "USERDOMAIN",
+        "USERNAME",
+        "USERPROFILE",
+        "USERDOMAIN_ROAMINGPROFILE",
+        "COMPUTERNAME",
+        "ProgramData",
+    ]:
+        if v in os.environ:
+            config.environment[v] = os.environ[v]

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -337,19 +337,6 @@ if "XDG_CACHE_HOME" in os.environ:
 
 # Transfer some environment variables into the tests on Windows build host.
 if platform.system() == "Windows":
-    for v in [
-        "SystemDrive",
-        "SystemRoot",
-        "ALLUSERSPROFILE",
-        "APPDATA",
-        "LOCALAPPDATA",
-        "USERDNSDOMAIN",
-        "USERDOMAIN",
-        "USERNAME",
-        "USERPROFILE",
-        "USERDOMAIN_ROAMINGPROFILE",
-        "COMPUTERNAME",
-        "ProgramData",
-    ]:
+    for v in ["SystemDrive"]:
         if v in os.environ:
             config.environment[v] = os.environ[v]


### PR DESCRIPTION
Some API tests (compiler calls) create a lot of garbage and cause unexpected behavior in case of Windows host and Linux target, e.g.
```
lldb/test/API/commands/process/attach/%SystemDrive%/
lldb/test/API/functionalities/deleted-executable/%SystemDrive%/
lldb/test/API/functionalities/exec/%SystemDrive%/
lldb/test/API/functionalities/load_unload/%SystemDrive%/
lldb/test/API/functionalities/target-new-solib-notifications/%SystemDrive%/
lldb/test/API/functionalities/thread/create_after_attach/%SystemDrive%/
```
It can be fixed by transfer some standard Windows environment variables into API tests.