### PR TITLE
[analyzer][NFC] Make RegionStore dumps deterministic

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -70,7 +70,6 @@ private:
 
 public:
   bool isDirect() const { return P.getInt() & Direct; }
-  bool isDefault() const { return !isDirect(); }
   bool hasSymbolicOffset() const { return P.getInt() & Symbolic; }
 
   const MemRegion *getRegion() const { return P.getPointer(); }


### PR DESCRIPTION
Dump the memory space clusters before the other clusters, in alphabetical order. Then default bindings over direct bindings, and if any has symbolic offset, then those should come before the ones with concrete offsets.
In theory, we should either have a symbolic offset OR concrete offsets, but never both at the same time.

Needed for #114835