### PR TITLE
[llvm] Migrate away from PointerUnion::{is,get,dyn_cast} (NFC)

### DIFF
--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -1051,8 +1051,8 @@ public:
       OS << ", s=";
       if (Source.isNull())
         OS << "null";
-      else if (isa<DbgAssignIntrinsic *>(Source))
-        OS << cast<DbgAssignIntrinsic *>(Source);
+      else if (const auto *DAI = dyn_cast<DbgAssignIntrinsic *>(Source))
+        OS << DAI;
       else
         OS << cast<DbgVariableRecord *>(Source);
       OS << ")";

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -1052,9 +1052,9 @@ public:
       if (Source.isNull())
         OS << "null";
       else if (isa<DbgAssignIntrinsic *>(Source))
-        OS << Source.get<DbgAssignIntrinsic *>();
+        OS << cast<DbgAssignIntrinsic *>(Source);
       else
-        OS << Source.get<DbgVariableRecord *>();
+        OS << cast<DbgVariableRecord *>(Source);
       OS << ")";
     }
 

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -214,8 +214,8 @@ bool llvm::canReplaceReg(Register DstReg, Register SrcReg,
 
   // Otherwise match if the Src is already a regclass that is covered by the Dst
   // RegBank.
-  return DstRBC.is<const RegisterBank *>() && MRI.getRegClassOrNull(SrcReg) &&
-         DstRBC.get<const RegisterBank *>()->covers(
+  return isa<const RegisterBank *>(DstRBC) && MRI.getRegClassOrNull(SrcReg) &&
+         cast<const RegisterBank *>(DstRBC)->covers(
              *MRI.getRegClassOrNull(SrcReg));
 }
 

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -1033,8 +1033,8 @@ DbgInstPtr DIBuilder::insertDbgValueIntrinsic(Value *V,
   DbgInstPtr DVI = insertDbgValueIntrinsic(
       V, VarInfo, Expr, DL, InsertBefore ? InsertBefore->getParent() : nullptr,
       InsertBefore);
-  if (isa<Instruction *>(DVI))
-    cast<CallInst>(cast<Instruction *>(DVI))->setTailCall();
+  if (auto *Inst = dyn_cast<Instruction *>(DVI))
+    cast<CallInst>(Inst)->setTailCall();
   return DVI;
 }
 

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -1033,8 +1033,8 @@ DbgInstPtr DIBuilder::insertDbgValueIntrinsic(Value *V,
   DbgInstPtr DVI = insertDbgValueIntrinsic(
       V, VarInfo, Expr, DL, InsertBefore ? InsertBefore->getParent() : nullptr,
       InsertBefore);
-  if (DVI.is<Instruction *>())
-    cast<CallInst>(DVI.get<Instruction *>())->setTailCall();
+  if (isa<Instruction *>(DVI))
+    cast<CallInst>(cast<Instruction *>(DVI))->setTailCall();
   return DVI;
 }
 

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -2099,8 +2099,8 @@ static void emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
                                     AddrExpr, VarRec.DL);
   (void)Assign;
   LLVM_DEBUG(if (!Assign.isNull()) {
-    if (isa<DbgRecord *>(Assign))
-      errs() << " > INSERT: " << *cast<DbgRecord *>(Assign) << "\n";
+    if (const auto *Record = dyn_cast<DbgRecord *>(Assign))
+      errs() << " > INSERT: " << *Record << "\n";
     else
       errs() << " > INSERT: " << *cast<Instruction *>(Assign) << "\n";
   });

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -2099,10 +2099,10 @@ static void emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
                                     AddrExpr, VarRec.DL);
   (void)Assign;
   LLVM_DEBUG(if (!Assign.isNull()) {
-    if (Assign.is<DbgRecord *>())
-      errs() << " > INSERT: " << *Assign.get<DbgRecord *>() << "\n";
+    if (isa<DbgRecord *>(Assign))
+      errs() << " > INSERT: " << *cast<DbgRecord *>(Assign) << "\n";
     else
-      errs() << " > INSERT: " << *Assign.get<Instruction *>() << "\n";
+      errs() << " > INSERT: " << *cast<Instruction *>(Assign) << "\n";
   });
 }
 

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -274,7 +274,7 @@ ReplaceableMetadataImpl::getAllDbgVariableRecordUsers() {
     OwnerTy Owner = Pair.second.first;
     if (Owner.isNull())
       continue;
-    if (!Owner.is<DebugValueUser *>())
+    if (!isa<DebugValueUser *>(Owner))
       continue;
     DVRUsersWithID.push_back(&UseMap[Pair.first]);
   }
@@ -288,7 +288,7 @@ ReplaceableMetadataImpl::getAllDbgVariableRecordUsers() {
   });
   SmallVector<DbgVariableRecord *> DVRUsers;
   for (auto UserWithID : DVRUsersWithID)
-    DVRUsers.push_back(UserWithID->first.get<DebugValueUser *>()->getUser());
+    DVRUsers.push_back(cast<DebugValueUser *>(UserWithID->first)->getUser());
   return DVRUsers;
 }
 
@@ -396,8 +396,8 @@ void ReplaceableMetadataImpl::replaceAllUsesWith(Metadata *MD) {
       continue;
     }
 
-    if (Owner.is<DebugValueUser *>()) {
-      Owner.get<DebugValueUser *>()->handleChangedValue(Pair.first, MD);
+    if (isa<DebugValueUser *>(Owner)) {
+      cast<DebugValueUser *>(Owner)->handleChangedValue(Pair.first, MD);
       continue;
     }
 
@@ -436,7 +436,7 @@ void ReplaceableMetadataImpl::resolveAllUses(bool ResolveUsers) {
     auto Owner = Pair.second.first;
     if (!Owner)
       continue;
-    if (!Owner.is<Metadata *>())
+    if (!isa<Metadata *>(Owner))
       continue;
 
     // Resolve MDNodes that point at this.

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -396,8 +396,8 @@ void ReplaceableMetadataImpl::replaceAllUsesWith(Metadata *MD) {
       continue;
     }
 
-    if (isa<DebugValueUser *>(Owner)) {
-      cast<DebugValueUser *>(Owner)->handleChangedValue(Pair.first, MD);
+    if (auto *DVU = dyn_cast<DebugValueUser *>(Owner)) {
+      DVU->handleChangedValue(Pair.first, MD);
       continue;
     }
 

--- a/llvm/lib/SandboxIR/Tracker.cpp
+++ b/llvm/lib/SandboxIR/Tracker.cpp
@@ -111,10 +111,10 @@ void EraseFromParent::accept() {
 void EraseFromParent::revert(Tracker &Tracker) {
   // Place the bottom-most instruction first.
   auto [Operands, BotLLVMI] = InstrData[0];
-  if (auto *NextLLVMI = NextLLVMIOrBB.dyn_cast<llvm::Instruction *>()) {
+  if (auto *NextLLVMI = dyn_cast<llvm::Instruction *>(NextLLVMIOrBB)) {
     BotLLVMI->insertBefore(NextLLVMI);
   } else {
-    auto *LLVMBB = NextLLVMIOrBB.get<llvm::BasicBlock *>();
+    auto *LLVMBB = cast<llvm::BasicBlock *>(NextLLVMIOrBB);
     BotLLVMI->insertInto(LLVMBB, LLVMBB->end());
   }
   for (auto [OpNum, Op] : enumerate(Operands))
@@ -145,10 +145,10 @@ RemoveFromParent::RemoveFromParent(Instruction *RemovedI) : RemovedI(RemovedI) {
 }
 
 void RemoveFromParent::revert(Tracker &Tracker) {
-  if (auto *NextI = NextInstrOrBB.dyn_cast<Instruction *>()) {
+  if (auto *NextI = dyn_cast<Instruction *>(NextInstrOrBB)) {
     RemovedI->insertBefore(NextI);
   } else {
-    auto *BB = NextInstrOrBB.get<BasicBlock *>();
+    auto *BB = cast<BasicBlock *>(NextInstrOrBB);
     RemovedI->insertInto(BB, BB->end());
   }
 }
@@ -199,10 +199,10 @@ MoveInstr::MoveInstr(Instruction *MovedI) : MovedI(MovedI) {
 }
 
 void MoveInstr::revert(Tracker &Tracker) {
-  if (auto *NextI = NextInstrOrBB.dyn_cast<Instruction *>()) {
+  if (auto *NextI = dyn_cast<Instruction *>(NextInstrOrBB)) {
     MovedI->moveBefore(NextI);
   } else {
-    auto *BB = NextInstrOrBB.get<BasicBlock *>();
+    auto *BB = cast<BasicBlock *>(NextInstrOrBB);
     MovedI->moveBefore(*BB, BB->end());
   }
 }

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -5166,11 +5166,9 @@ insertNewDbgInst(DIBuilder &DIB, DbgAssignIntrinsic *Orig, AllocaInst *NewAddr,
                          DIAssignID::getDistinct(NewAddr->getContext()));
   }
 
-  Instruction *NewAssign =
-      DIB.insertDbgAssign(NewAddr, Orig->getValue(), Orig->getVariable(),
-                          NewFragmentExpr, NewAddr, NewAddrExpr,
-                          Orig->getDebugLoc())
-          .get<Instruction *>();
+  Instruction *NewAssign = cast<Instruction *>(DIB.insertDbgAssign(
+      NewAddr, Orig->getValue(), Orig->getVariable(), NewFragmentExpr, NewAddr,
+      NewAddrExpr, Orig->getDebugLoc()));
   LLVM_DEBUG(dbgs() << "Created new assign intrinsic: " << *NewAssign << "\n");
   (void)NewAssign;
 }

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -1696,7 +1696,7 @@ static void insertDbgValueOrDbgVariableRecord(DIBuilder &Builder, Value *DV,
   if (!UseNewDbgInfoFormat) {
     auto DbgVal = Builder.insertDbgValueIntrinsic(DV, DIVar, DIExpr, NewLoc,
                                                   (Instruction *)nullptr);
-    DbgVal.get<Instruction *>()->insertBefore(Instr);
+    cast<Instruction *>(DbgVal)->insertBefore(Instr);
   } else {
     // RemoveDIs: if we're using the new debug-info format, allocate a
     // DbgVariableRecord directly instead of a dbg.value intrinsic.
@@ -1713,7 +1713,7 @@ static void insertDbgValueOrDbgVariableRecordAfter(
   if (!UseNewDbgInfoFormat) {
     auto DbgVal = Builder.insertDbgValueIntrinsic(DV, DIVar, DIExpr, NewLoc,
                                                   (Instruction *)nullptr);
-    DbgVal.get<Instruction *>()->insertAfter(&*Instr);
+    cast<Instruction *>(DbgVal)->insertAfter(&*Instr);
   } else {
     // RemoveDIs: if we're using the new debug-info format, allocate a
     // DbgVariableRecord directly instead of a dbg.value intrinsic.


### PR DESCRIPTION
Note that PointerUnion::{is,get,dyn_cast} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>
