### PR TITLE
[lldb] Use heterogenous lookups with std::map (NFC) (#115590)

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandObject.h
+++ b/lldb/include/lldb/Interpreter/CommandObject.h
@@ -35,8 +35,9 @@ namespace lldb_private {
 
 template <typename ValueType>
 int AddNamesMatchingPartialString(
-    const std::map<std::string, ValueType> &in_map, llvm::StringRef cmd_str,
-    StringList &matches, StringList *descriptions = nullptr) {
+    const std::map<std::string, ValueType, std::less<>> &in_map,
+    llvm::StringRef cmd_str, StringList &matches,
+    StringList *descriptions = nullptr) {
   int number_added = 0;
 
   const bool add_all = cmd_str.empty();
@@ -54,7 +55,8 @@ int AddNamesMatchingPartialString(
 }
 
 template <typename ValueType>
-size_t FindLongestCommandWord(std::map<std::string, ValueType> &dict) {
+size_t
+FindLongestCommandWord(std::map<std::string, ValueType, std::less<>> &dict) {
   auto end = dict.end();
   size_t max_len = 0;
 
@@ -107,7 +109,7 @@ public:
   typedef std::vector<CommandArgumentData>
       CommandArgumentEntry; // Used to build individual command argument lists
 
-  typedef std::map<std::string, lldb::CommandObjectSP> CommandMap;
+  typedef std::map<std::string, lldb::CommandObjectSP, std::less<>> CommandMap;
 
   CommandObject(CommandInterpreter &interpreter, llvm::StringRef name,
     llvm::StringRef help = "", llvm::StringRef syntax = "",

--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -32,7 +32,7 @@ CommandObjectMultiword::GetSubcommandSPExact(llvm::StringRef sub_cmd) {
   if (m_subcommand_dict.empty())
     return {};
 
-  auto pos = m_subcommand_dict.find(std::string(sub_cmd));
+  auto pos = m_subcommand_dict.find(sub_cmd);
   if (pos == m_subcommand_dict.end())
     return {};
 
@@ -64,7 +64,7 @@ CommandObjectSP CommandObjectMultiword::GetSubcommandSP(llvm::StringRef sub_cmd,
     // function, since I now know I have an exact match...
 
     sub_cmd = matches->GetStringAtIndex(0);
-    pos = m_subcommand_dict.find(std::string(sub_cmd));
+    pos = m_subcommand_dict.find(sub_cmd);
     if (pos != m_subcommand_dict.end())
       return_cmd_sp = pos->second;
   }


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.
