### PR TITLE
[llvm-exegesis][X86] Groups ports 2,3, and 11 for Golden Cove

### DIFF
--- a/llvm/lib/Target/X86/X86PfmCounters.td
+++ b/llvm/lib/Target/X86/X86PfmCounters.td
@@ -210,7 +210,10 @@ def AlderLakePfmCounters : ProcPfmCounters {
   let IssueCounters = [
     PfmIssueCounter<"ADLPPort00", "uops_dispatched_port:port_0">,
     PfmIssueCounter<"ADLPPort01", "uops_dispatched_port:port_1">,
-    PfmIssueCounter<"ADLPPort02_03_10", "uops_dispatched_port:port_2_3_10">,
+    // The perfmon documentation and thus libpfm seems to incorrectly label
+    // this performance counter, as ports 2,3, and 11 are actually grouped
+    // according to most documentation. See #113941 for additional details.
+    PfmIssueCounter<"ADLPPort02_03_11", "uops_dispatched_port:port_2_3_10">,
     PfmIssueCounter<"ADLPPort04_09", "uops_dispatched_port:port_4_9">,
     PfmIssueCounter<"ADLPPort05_11", "uops_dispatched_port:port_5_11">,
     PfmIssueCounter<"ADLPPort06", "uops_dispatched_port:port_6">,
@@ -226,7 +229,10 @@ def SapphireRapidsPfmCounters : ProcPfmCounters {
   let IssueCounters = [
     PfmIssueCounter<"SPRPort00", "uops_dispatched_port:port_0">,
     PfmIssueCounter<"SPRPort01", "uops_dispatched_port:port_1">,
-    PfmIssueCounter<"SPRPort02_03_10", "uops_dispatched_port:port_2_3_10">,
+    // The perfmon documentation and thus libpfm seems to incorrectly label
+    // this performance counter, as ports 2,3, and 11 are actually grouped
+    // according to most documentation. See #113941 for additional details.
+    PfmIssueCounter<"SPRPort02_03_11", "uops_dispatched_port:port_2_3_10">,
     PfmIssueCounter<"SPRPort04_09", "uops_dispatched_port:port_4_9">,
     PfmIssueCounter<"SPRPort05_11", "uops_dispatched_port:port_5_11">,
     PfmIssueCounter<"SPRPort06", "uops_dispatched_port:port_6">,

--- a/llvm/lib/Target/X86/X86SchedAlderlakeP.td
+++ b/llvm/lib/Target/X86/X86SchedAlderlakeP.td
@@ -60,7 +60,6 @@ def ADLPPort01_05_10       : ProcResGroup<[ADLPPort01, ADLPPort05, ADLPPort10]>;
 def ADLPPort02_03          : ProcResGroup<[ADLPPort02, ADLPPort03]>;
 def ADLPPort02_03_07       : ProcResGroup<[ADLPPort02, ADLPPort03, ADLPPort07]>;
 def ADLPPort02_03_11       : ProcResGroup<[ADLPPort02, ADLPPort03, ADLPPort11]>;
-def ADLPPort02_03_10       : ProcResGroup<[ADLPPort02, ADLPPort03, ADLPPort10]>;
 def ADLPPort05_11          : ProcResGroup<[ADLPPort05, ADLPPort11]>;
 def ADLPPort07_08          : ProcResGroup<[ADLPPort07, ADLPPort08]>;
 

--- a/llvm/lib/Target/X86/X86SchedSapphireRapids.td
+++ b/llvm/lib/Target/X86/X86SchedSapphireRapids.td
@@ -59,7 +59,6 @@ def SPRPort01_05          : ProcResGroup<[SPRPort01, SPRPort05]>;
 def SPRPort01_05_10       : ProcResGroup<[SPRPort01, SPRPort05, SPRPort10]>;
 def SPRPort02_03          : ProcResGroup<[SPRPort02, SPRPort03]>;
 def SPRPort02_03_11       : ProcResGroup<[SPRPort02, SPRPort03, SPRPort11]>;
-def SPRPort02_03_10       : ProcResGroup<[SPRPort02, SPRPort03, SPRPort10]>;
 def SPRPort05_11          : ProcResGroup<[SPRPort05, SPRPort11]>;
 def SPRPort07_08          : ProcResGroup<[SPRPort07, SPRPort08]>;
 


### PR DESCRIPTION
This patch updates the PFM counter mappings for Sapphire Rapids and Alder Lake (p-cores) to group ports 2,3, and 11 despite the naming of the performance counters. This is how the scheduling models assume things work within LLVM, and seems to be a mistake within the Intel perfmon documentation.

Fixes #113941.