### PR TITLE
[clangd] Add padding to struct hover information

### DIFF
--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -73,6 +73,68 @@ TEST(Hover, Structured) {
          HI.Type = "void ()";
          HI.Parameters.emplace();
        }},
+      {R"cpp(
+            struct [[F^oo]] {
+              char a;
+              long long b;
+            };
+          )cpp",
+       [](HoverInfo &HI) {
+         HI.NamespaceScope = "";
+         HI.Name = "Foo";
+         HI.Kind = index::SymbolKind::Struct;
+         HI.Definition = "struct Foo {}";
+         HI.Size = 128;
+         HI.Padding = 56;
+         HI.Align = 64;
+       }},
+      {R"cpp(
+            struct [[F^oo]] {
+              int b;
+              char a;
+            };
+          )cpp",
+       [](HoverInfo &HI) {
+         HI.NamespaceScope = "";
+         HI.Name = "Foo";
+         HI.Kind = index::SymbolKind::Struct;
+         HI.Definition = "struct Foo {}";
+         HI.Size = 64;
+         HI.Padding = 24;
+         HI.Align = 32;
+       }},
+      {R"cpp(
+            struct [[F^oo]] {
+              double a;
+              char b;
+              double c;
+            };
+          )cpp",
+       [](HoverInfo &HI) {
+         HI.NamespaceScope = "";
+         HI.Name = "Foo";
+         HI.Kind = index::SymbolKind::Struct;
+         HI.Definition = "struct Foo {}";
+         HI.Size = 192;
+         HI.Padding = 46;
+         HI.Align = 64;
+       }},      {R"cpp(
+            struct [[F^oo]] {
+              double a;
+              char b;
+              double c;
+              char d;
+            };
+          )cpp",
+       [](HoverInfo &HI) {
+         HI.NamespaceScope = "";
+         HI.Name = "Foo";
+         HI.Kind = index::SymbolKind::Struct;
+         HI.Definition = "struct Foo {}";
+         HI.Size = 256;
+         HI.Padding = 112;
+         HI.Align = 64;
+       }},
       // Field
       {R"cpp(
           namespace ns1 { namespace ns2 {

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -118,7 +118,8 @@ TEST(Hover, Structured) {
          HI.Size = 192;
          HI.Padding = 46;
          HI.Align = 64;
-       }},      {R"cpp(
+       }},
+      {R"cpp(
             struct [[F^oo]] {
               double a;
               char b;


### PR DESCRIPTION
Hi team, I've written a small patch as a small quality of life improvement for my development and figured it may be worth sharing. Please let me know what you think:

HI.Padding is already available for a struct's member variables but the struct itself is not displaying how much padding has been added to it. This commit sums up all padding within a struct and adds it to a struct's hover information.

```
struct Foo
{
    char a;
    int b;
    char c;
};
```
results in
![Screenshot 2024-11-10 at 9 50 52 AM](https://github.com/user-attachments/assets/163d1582-4de0-4673-9024-8f04465f221a)

I've also added additional tests to HoverTests.cpp.