### PR TITLE
[llvm-objdump] Add preliminary support for decoding binary files

### DIFF
--- a/llvm/include/llvm/Object/Binary.h
+++ b/llvm/include/llvm/Object/Binary.h
@@ -71,6 +71,7 @@ protected:
 
     ID_GOFF,
     ID_Wasm,
+    ID_Binary,
 
     ID_EndObjects
   };
@@ -191,7 +192,8 @@ DEFINE_ISA_CONVERSION_FUNCTIONS(Binary, LLVMBinaryRef)
 /// @param Source The data to create the Binary from.
 Expected<std::unique_ptr<Binary>> createBinary(MemoryBufferRef Source,
                                                LLVMContext *Context = nullptr,
-                                               bool InitContent = true);
+                                               bool InitContent = true,
+                                               bool RawBinary = false);
 
 template <typename T> class OwningBinary {
   std::unique_ptr<T> Bin;
@@ -243,7 +245,8 @@ template <typename T> const T* OwningBinary<T>::getBinary() const {
 
 Expected<OwningBinary<Binary>> createBinary(StringRef Path,
                                             LLVMContext *Context = nullptr,
-                                            bool InitContent = true);
+                                            bool InitContent = true,
+                                            bool RawBinary = false);
 
 } // end namespace object
 

--- a/llvm/include/llvm/Object/BinaryObjectFile.h
+++ b/llvm/include/llvm/Object/BinaryObjectFile.h
@@ -1,0 +1,130 @@
+//===- BinaryObjectFile.h - Binary object file implementation ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the BinaryObjectFile class.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_OBJECT_RAWOBJECTFILE_H
+#define LLVM_OBJECT_RAWOBJECTFILE_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
+#include "llvm/Object/Binary.h"
+#include "llvm/Object/Error.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Object/SymbolicFile.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/ScopedPrinter.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
+#include "llvm/TargetParser/Triple.h"
+#include <cassert>
+#include <cstdint>
+
+namespace llvm {
+
+template <typename T> class SmallVectorImpl;
+
+namespace object {
+
+struct BinarySymbol {
+  uint32_t Flags = 0;
+  uint64_t Value = 0;
+  StringRef Name;
+};
+
+struct BinaryRelocation {
+  uint64_t Offset = 0;
+  uint64_t Symbol = 0;
+  uint64_t Type = 0;
+};
+
+struct BinarySection {
+  uint64_t Offset = 0;
+  uint64_t Index = 0;
+  uint64_t Address = 0;
+  uint64_t Size = 0;
+  StringRef Name;
+  std::vector<BinaryRelocation> Relocations;
+};
+
+class BinaryObjectFile : public ObjectFile {
+private:
+  std::vector<BinarySymbol> Symbols;
+  std::vector<BinarySection> Sections;
+
+public:
+  BinaryObjectFile(MemoryBufferRef Source);
+
+  bool is64Bit() const override;
+
+  basic_symbol_iterator symbol_begin() const override;
+  basic_symbol_iterator symbol_end() const override;
+  section_iterator section_begin() const override;
+  section_iterator section_end() const override;
+
+  const BinarySymbol &getBinarySymbol(const DataRefImpl &Symb) const;
+  const BinarySymbol &getBinarySymbol(const SymbolRef &Symb) const;
+
+  void moveSymbolNext(DataRefImpl &Symb) const override;
+  Expected<StringRef> getSymbolName(DataRefImpl Symb) const override;
+  Expected<uint32_t> getSymbolFlags(DataRefImpl Symb) const override;
+  Expected<uint64_t> getSymbolAddress(DataRefImpl Symb) const override;
+  uint64_t getSymbolValueImpl(DataRefImpl Symb) const override;
+  uint64_t getCommonSymbolSizeImpl(DataRefImpl Symb) const override;
+  Expected<SymbolRef::Type> getSymbolType(DataRefImpl Symb) const override;
+  Expected<section_iterator> getSymbolSection(DataRefImpl Symb) const override;
+
+  const BinarySection &getBinarySection(const DataRefImpl Ref) const;
+  const BinarySection &getBinarySection(const SectionRef &Section) const;
+
+  void moveSectionNext(DataRefImpl &Sec) const override;
+  Expected<StringRef> getSectionName(DataRefImpl Sec) const override;
+  uint64_t getSectionAddress(DataRefImpl Sec) const override;
+  uint64_t getSectionIndex(DataRefImpl Sec) const override;
+  uint64_t getSectionSize(DataRefImpl Sec) const override;
+  Expected<ArrayRef<uint8_t>>
+  getSectionContents(DataRefImpl Sec) const override;
+  uint64_t getSectionAlignment(DataRefImpl Sec) const override;
+  bool isSectionCompressed(DataRefImpl Sec) const override;
+  bool isSectionText(DataRefImpl Sec) const override;
+  bool isSectionData(DataRefImpl Sec) const override;
+  bool isSectionBSS(DataRefImpl Sec) const override;
+  bool isSectionVirtual(DataRefImpl Sec) const override;
+
+  relocation_iterator section_rel_begin(DataRefImpl Sec) const override;
+  relocation_iterator section_rel_end(DataRefImpl Sec) const override;
+
+  const BinaryRelocation &getBinaryRelocation(const RelocationRef &Ref) const;
+  const BinaryRelocation &getBinaryRelocation(DataRefImpl Ref) const;
+
+  // Overrides from RelocationRef.
+  void moveRelocationNext(DataRefImpl &Rel) const override;
+  uint64_t getRelocationOffset(DataRefImpl Rel) const override;
+  symbol_iterator getRelocationSymbol(DataRefImpl Rel) const override;
+  uint64_t getRelocationType(DataRefImpl Rel) const override;
+  void getRelocationTypeName(DataRefImpl Rel,
+                             SmallVectorImpl<char> &Result) const override;
+
+  uint8_t getBytesInAddress() const override;
+  StringRef getFileFormatName() const override;
+  Triple::ArchType getArch() const override;
+  Expected<SubtargetFeatures> getFeatures() const override;
+  std::optional<StringRef> tryGetCPUName() const override;
+  bool isRelocatableObject() const override;
+};
+
+} // end namespace object
+} // end namespace llvm
+
+#endif // LLVM_OBJECT_RAWOBJECTFILE_H

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -43,6 +43,7 @@ class SectionRef;
 class SymbolRef;
 class symbol_iterator;
 class WasmObjectFile;
+class BinaryObjectFile;
 
 using section_iterator = content_iterator<SectionRef>;
 
@@ -400,6 +401,9 @@ public:
 
   static Expected<std::unique_ptr<WasmObjectFile>>
   createWasmObjectFile(MemoryBufferRef Object);
+
+  static Expected<std::unique_ptr<BinaryObjectFile>>
+  createBinaryObjectFile(MemoryBufferRef Object);
 };
 
 /// A filtered iterator for SectionRefs that skips sections based on some given

--- a/llvm/lib/Object/BinaryObjectFile.cpp
+++ b/llvm/lib/Object/BinaryObjectFile.cpp
@@ -1,0 +1,242 @@
+//===- BinaryObjectFile.cpp - Binary object file implementation -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Part of the BinaryObjectFile class implementation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Object/BinaryObjectFile.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Object/Error.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
+#include "llvm/TargetParser/Triple.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+using namespace llvm;
+using namespace object;
+
+BinaryObjectFile::BinaryObjectFile(MemoryBufferRef Source)
+    : ObjectFile(ID_Binary, Source), Symbols(), Sections() {
+  Symbols.push_back(BinarySymbol{});
+  Symbols[0].Name = ".data";
+  Sections.push_back(BinarySection{});
+  Sections[0].Size = Source.getBufferSize();
+}
+
+Expected<std::unique_ptr<BinaryObjectFile>>
+ObjectFile::createBinaryObjectFile(MemoryBufferRef Obj) {
+  Error Err = Error::success();
+  auto ObjectFile = std::make_unique<BinaryObjectFile>(Obj);
+  return std::move(ObjectFile);
+}
+
+bool BinaryObjectFile::is64Bit() const { return true; }
+
+basic_symbol_iterator BinaryObjectFile::symbol_begin() const {
+  DataRefImpl Ref;
+  Ref.d.a = 1; // Arbitrary non-zero value so that Ref.p is non-null
+  Ref.d.b = 0; // Symbol index
+  return BasicSymbolRef(Ref, this);
+}
+
+basic_symbol_iterator BinaryObjectFile::symbol_end() const {
+  DataRefImpl Ref;
+  Ref.d.a = 1; // Arbitrary non-zero value so that Ref.p is non-null
+  Ref.d.b = Symbols.size(); // Symbol index
+  return BasicSymbolRef(Ref, this);
+}
+
+void BinaryObjectFile::moveSymbolNext(DataRefImpl &Symb) const { Symb.d.b++; }
+
+const BinarySymbol &
+BinaryObjectFile::getBinarySymbol(const DataRefImpl &Symb) const {
+  assert(Symb.d.b < Symbols.size());
+  return Symbols[Symb.d.b];
+}
+
+const BinarySymbol &
+BinaryObjectFile::getBinarySymbol(const SymbolRef &Symb) const {
+  return getBinarySymbol(Symb.getRawDataRefImpl());
+}
+
+const BinarySection &
+BinaryObjectFile::getBinarySection(const DataRefImpl Ref) const {
+  assert(Ref.d.a < Sections.size());
+  return Sections[Ref.d.a];
+}
+
+const BinarySection &
+BinaryObjectFile::getBinarySection(const SectionRef &Section) const {
+  return getBinarySection(Section.getRawDataRefImpl());
+}
+
+const BinaryRelocation &
+BinaryObjectFile::getBinaryRelocation(const RelocationRef &Ref) const {
+  return getBinaryRelocation(Ref.getRawDataRefImpl());
+}
+
+const BinaryRelocation &
+BinaryObjectFile::getBinaryRelocation(DataRefImpl Ref) const {
+  assert(Ref.d.a < Sections.size());
+  const BinarySection &Sec = Sections[Ref.d.a];
+  assert(Ref.d.b < Sec.Relocations.size());
+  return Sec.Relocations[Ref.d.b];
+}
+
+Expected<StringRef> BinaryObjectFile::getSymbolName(DataRefImpl Symb) const {
+  return getBinarySymbol(Symb).Name;
+}
+
+Expected<uint32_t> BinaryObjectFile::getSymbolFlags(DataRefImpl Symb) const {
+  return getBinarySymbol(Symb).Flags;
+}
+
+uint64_t BinaryObjectFile::getSymbolValueImpl(DataRefImpl Symb) const {
+  return getBinarySymbol(Symb).Value;
+}
+
+uint64_t BinaryObjectFile::getCommonSymbolSizeImpl(DataRefImpl Symb) const {
+  llvm_unreachable("not yet implemented");
+  return 0;
+}
+
+Expected<SymbolRef::Type>
+BinaryObjectFile::getSymbolType(DataRefImpl Symb) const {
+  return SymbolRef::ST_Other;
+}
+
+Expected<section_iterator>
+BinaryObjectFile::getSymbolSection(DataRefImpl Symb) const {
+  DataRefImpl Ref;
+  Ref.d.a = 0;
+  return section_iterator(SectionRef(Ref, this));
+}
+
+Expected<uint64_t> BinaryObjectFile::getSymbolAddress(DataRefImpl Sym) const {
+  return getSymbolValue(Sym);
+}
+
+section_iterator BinaryObjectFile::section_begin() const {
+  DataRefImpl Ref;
+  Ref.d.a = 0;
+  return section_iterator(SectionRef(Ref, this));
+}
+
+section_iterator BinaryObjectFile::section_end() const {
+  DataRefImpl Ref;
+  Ref.d.a = Sections.size();
+  return section_iterator(SectionRef(Ref, this));
+}
+void BinaryObjectFile::moveSectionNext(DataRefImpl &Sec) const { Sec.d.a++; }
+
+Expected<StringRef> BinaryObjectFile::getSectionName(DataRefImpl Ref) const {
+  return getBinarySection(Ref).Name;
+}
+
+uint64_t BinaryObjectFile::getSectionAddress(DataRefImpl Ref) const {
+  return getBinarySection(Ref).Address;
+}
+uint64_t BinaryObjectFile::getSectionIndex(DataRefImpl Ref) const {
+  return getBinarySection(Ref).Index;
+}
+uint64_t BinaryObjectFile::getSectionSize(DataRefImpl Ref) const {
+  return getBinarySection(Ref).Size;
+}
+
+Expected<ArrayRef<uint8_t>>
+BinaryObjectFile::getSectionContents(DataRefImpl Sec) const {
+  return ArrayRef<uint8_t>((const uint8_t *)Data.getBuffer().data(),
+                           Data.getBufferSize());
+}
+
+uint64_t BinaryObjectFile::getSectionAlignment(DataRefImpl Sec) const {
+  return 1;
+}
+
+bool BinaryObjectFile::isSectionCompressed(DataRefImpl Sec) const {
+  return false;
+}
+bool BinaryObjectFile::isSectionText(DataRefImpl Sec) const { return true; }
+bool BinaryObjectFile::isSectionData(DataRefImpl Sec) const { return false; }
+bool BinaryObjectFile::isSectionBSS(DataRefImpl Sec) const { return false; }
+bool BinaryObjectFile::isSectionVirtual(DataRefImpl Sec) const { return false; }
+
+relocation_iterator BinaryObjectFile::section_rel_begin(DataRefImpl Ref) const {
+  DataRefImpl RelocRef;
+  RelocRef.d.a = Ref.d.a;
+  RelocRef.d.b = 0;
+  return relocation_iterator(RelocationRef(RelocRef, this));
+}
+
+relocation_iterator BinaryObjectFile::section_rel_end(DataRefImpl Ref) const {
+  const BinarySection &Sec = getBinarySection(Ref);
+  DataRefImpl RelocRef;
+  RelocRef.d.a = Ref.d.a;
+  RelocRef.d.b = Sec.Relocations.size();
+  return relocation_iterator(RelocationRef(RelocRef, this));
+}
+
+void BinaryObjectFile::moveRelocationNext(DataRefImpl &Rel) const { Rel.d.b++; }
+
+uint64_t BinaryObjectFile::getRelocationOffset(DataRefImpl Ref) const {
+  const BinaryRelocation &Rel = getBinaryRelocation(Ref);
+  return Rel.Offset;
+}
+
+symbol_iterator BinaryObjectFile::getRelocationSymbol(DataRefImpl Ref) const {
+  const BinaryRelocation &Rel = getBinaryRelocation(Ref);
+  DataRefImpl Sym;
+  Sym.d.a = 1;
+  Sym.d.b = Rel.Symbol;
+  return symbol_iterator(SymbolRef(Sym, this));
+}
+
+uint64_t BinaryObjectFile::getRelocationType(DataRefImpl Ref) const {
+  const BinaryRelocation &Rel = getBinaryRelocation(Ref);
+  return Rel.Type;
+}
+
+void BinaryObjectFile::getRelocationTypeName(
+    DataRefImpl Ref, SmallVectorImpl<char> &Result) const {
+  const BinaryRelocation &Rel = getBinaryRelocation(Ref);
+  StringRef Res;
+  switch (Rel.Type) {
+  case 0:
+  default:
+    Res = "unknown";
+    break;
+  }
+  Result.append(Res.begin(), Res.end());
+}
+
+uint8_t BinaryObjectFile::getBytesInAddress() const {
+  return is64Bit() ? 8 : 4;
+}
+
+StringRef BinaryObjectFile::getFileFormatName() const { return "binary"; }
+
+Triple::ArchType BinaryObjectFile::getArch() const {
+  return Triple::UnknownArch;
+}
+
+Expected<SubtargetFeatures> BinaryObjectFile::getFeatures() const {
+  return SubtargetFeatures();
+}
+
+std::optional<StringRef> BinaryObjectFile::tryGetCPUName() const {
+  return std::nullopt;
+}
+
+bool BinaryObjectFile::isRelocatableObject() const { return false; }

--- a/llvm/lib/Object/CMakeLists.txt
+++ b/llvm/lib/Object/CMakeLists.txt
@@ -33,6 +33,7 @@ add_llvm_component_library(LLVMObject
   WindowsMachineFlag.cpp
   WindowsResource.cpp
   XCOFFObjectFile.cpp
+  BinaryObjectFile.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Object

--- a/llvm/tools/llvm-objdump/BinaryDump.cpp
+++ b/llvm/tools/llvm-objdump/BinaryDump.cpp
@@ -1,0 +1,42 @@
+//===-- BinaryDump.cpp - raw-binary dumper ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the raw binary dumper for llvm-objdump.
+///
+//===----------------------------------------------------------------------===//
+
+#include "BinaryDump.h"
+
+#include "llvm-objdump.h"
+#include "llvm/Object/BinaryObjectFile.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Error.h"
+
+using namespace llvm;
+using namespace llvm::object;
+
+namespace {
+class BinaryDumper : public objdump::Dumper {
+  const BinaryObjectFile &Obj;
+
+public:
+  BinaryDumper(const BinaryObjectFile &O) : Dumper(O), Obj(O) {}
+};
+} // namespace
+
+std::unique_ptr<objdump::Dumper>
+objdump::createBinaryDumper(const BinaryObjectFile &Obj) {
+  return std::make_unique<BinaryDumper>(Obj);
+}
+
+Error objdump::getBinaryRelocationValueString(const BinaryObjectFile *Obj,
+                                              const RelocationRef &RelRef,
+                                              SmallVectorImpl<char> &Result) {
+  return Error::success();
+}

--- a/llvm/tools/llvm-objdump/BinaryDump.h
+++ b/llvm/tools/llvm-objdump/BinaryDump.h
@@ -1,0 +1,30 @@
+//===-- BinaryDump.h - raw-binary dumper ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TOOLS_LLVM_OBJDUMP_BINARYDUMP_H
+#define LLVM_TOOLS_LLVM_OBJDUMP_BINARYDUMP_H
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace llvm {
+class Error;
+namespace object {
+class BinaryObjectFile;
+class RelocationRef;
+} // namespace object
+
+namespace objdump {
+
+Error getBinaryRelocationValueString(const object::BinaryObjectFile *Obj,
+                                     const object::RelocationRef &RelRef,
+                                     llvm::SmallVectorImpl<char> &Result);
+
+} // namespace objdump
+} // namespace llvm
+
+#endif

--- a/llvm/tools/llvm-objdump/CMakeLists.txt
+++ b/llvm/tools/llvm-objdump/CMakeLists.txt
@@ -30,6 +30,7 @@ add_llvm_tool(llvm-objdump
   ELFDump.cpp
   MachODump.cpp
   OffloadDump.cpp
+  BinaryDump.cpp
   WasmDump.cpp
   XCOFFDump.cpp
   DEPENDS

--- a/llvm/tools/llvm-objdump/ObjdumpOpts.td
+++ b/llvm/tools/llvm-objdump/ObjdumpOpts.td
@@ -38,6 +38,9 @@ def arch_name_EQ : Joined<["--"], "arch-name=">,
 def archive_headers : Flag<["--"], "archive-headers">,
   HelpText<"Display archive header information">;
 
+def binary : Flag<["--"], "binary">,
+  HelpText<"Treat the file as binary, to be combined with --triple=">;
+
 defm build_id :
   Eq<"build-id", "Build ID to look up. Once found, added as an input file">,
   MetaVarName<"<hex>">;

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm-objdump.h"
+#include "BinaryDump.h"
 #include "COFFDump.h"
 #include "ELFDump.h"
 #include "MachODump.h"
@@ -51,6 +52,7 @@
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/Archive.h"
+#include "llvm/Object/BinaryObjectFile.h"
 #include "llvm/Object/BuildID.h"
 #include "llvm/Object/COFF.h"
 #include "llvm/Object/COFFImportFile.h"
@@ -300,6 +302,7 @@ enum class ColorOutput {
 
 static uint64_t AdjustVMA;
 static bool AllHeaders;
+static bool BinaryFile;
 static std::string ArchName;
 bool objdump::ArchiveHeaders;
 bool objdump::Demangle;
@@ -386,6 +389,8 @@ static Expected<std::unique_ptr<Dumper>> createDumper(const ObjectFile &Obj) {
     return createWasmDumper(*O);
   if (const auto *O = dyn_cast<XCOFFObjectFile>(&Obj))
     return createXCOFFDumper(*O);
+  if (const auto *O = dyn_cast<BinaryObjectFile>(&Obj))
+    return createBinaryDumper(*O);
 
   return createStringError(errc::invalid_argument,
                            "unsupported object file format");
@@ -553,6 +558,8 @@ static Error getRelocationValueString(const RelocationRef &Rel,
   if (auto *XCOFF = dyn_cast<XCOFFObjectFile>(Obj))
     return getXCOFFRelocationValueString(*XCOFF, Rel, SymbolDescription,
                                          Result);
+  if (auto *Binary = dyn_cast<BinaryObjectFile>(Obj))
+    return getBinaryRelocationValueString(Binary, Rel, Result);
   llvm_unreachable("unknown object file format");
 }
 
@@ -3392,7 +3399,8 @@ static void dumpInput(StringRef file) {
   }
 
   // Attempt to open the binary.
-  OwningBinary<Binary> OBinary = unwrapOrError(createBinary(file), file);
+  OwningBinary<Binary> OBinary =
+      unwrapOrError(createBinary(file, nullptr, true, BinaryFile), file);
   Binary &Binary = *OBinary.getBinary();
 
   if (Archive *A = dyn_cast<Archive>(&Binary))
@@ -3576,6 +3584,10 @@ static void parseObjdumpOptions(const llvm::opt::InputArgList &InputArgs) {
   parseIntArg(InputArgs, OBJDUMP_debug_vars_indent_EQ, DbgIndent);
 
   parseMachOOptions(InputArgs);
+
+  if (InputArgs.getLastArg(OBJDUMP_binary)) {
+    BinaryFile = true;
+  }
 
   // Parse -M (--disassembler-options) and deprecated
   // --x86-asm-syntax={att,intel}.

--- a/llvm/tools/llvm-objdump/llvm-objdump.h
+++ b/llvm/tools/llvm-objdump/llvm-objdump.h
@@ -38,6 +38,7 @@ class ELFObjectFileBase;
 class MachOObjectFile;
 class WasmObjectFile;
 class XCOFFObjectFile;
+class BinaryObjectFile;
 } // namespace object
 
 namespace objdump {
@@ -104,6 +105,7 @@ std::unique_ptr<Dumper> createELFDumper(const object::ELFObjectFileBase &Obj);
 std::unique_ptr<Dumper> createMachODumper(const object::MachOObjectFile &Obj);
 std::unique_ptr<Dumper> createWasmDumper(const object::WasmObjectFile &Obj);
 std::unique_ptr<Dumper> createXCOFFDumper(const object::XCOFFObjectFile &Obj);
+std::unique_ptr<Dumper> createBinaryDumper(const object::BinaryObjectFile &Obj);
 
 // Various helper functions.
 


### PR DESCRIPTION
this pull request occurred because I frequently use `-bbinary -mi386:x86-64 -Mintel` with the binutils objdump to disassemble binary files. in this patch, the code adds one section and one symbol named `.data`. it uses `-b` or `--binary` along with the pre-existing `--triple` option which makes it very close but slightly different from binutils objdump. this needs testing with other targets and currently it returns true to `bool is64Bit()` which I guess is mostly just for formatting. it doesn't know what triple it has been invoked with. I guess it should work fine on 32-bit targets.

- binutils - `objdump -D -bbinary -mi386:x86-64 -Mintel test.bin`
- this patch - `llvm-objdump -d -b --triple x86_64 -Mintel test.bin` 

```
$ echo '49 0f c7 0f'  | xxd -r -p - > test.bin
$ llvm-objdump -d --binary -Mintel --triple x86_64 test.bin

test.bin:    file format binary

Disassembly of section :

0000000000000000 <.data>:
       0: 49 0f c7 0f         cmpxchg16b	xmmword ptr [r15]
```