### PR TITLE
[llvm] Migrate away from PointerUnion::{is,get,dyn_cast} (NFC)

### DIFF
--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -371,29 +371,29 @@ public:
       return I == RHS.I;
     }
     const Value *operator*() const {
-      ValueAsMetadata *VAM = I.is<ValueAsMetadata *>()
-                                 ? I.get<ValueAsMetadata *>()
-                                 : *I.get<ValueAsMetadata **>();
+      ValueAsMetadata *VAM = isa<ValueAsMetadata *>(I)
+                                 ? cast<ValueAsMetadata *>(I)
+                                 : *cast<ValueAsMetadata **>(I);
       return VAM->getValue();
     };
     Value *operator*() {
-      ValueAsMetadata *VAM = I.is<ValueAsMetadata *>()
-                                 ? I.get<ValueAsMetadata *>()
-                                 : *I.get<ValueAsMetadata **>();
+      ValueAsMetadata *VAM = isa<ValueAsMetadata *>(I)
+                                 ? cast<ValueAsMetadata *>(I)
+                                 : *cast<ValueAsMetadata **>(I);
       return VAM->getValue();
     }
     location_op_iterator &operator++() {
-      if (I.is<ValueAsMetadata *>())
-        I = I.get<ValueAsMetadata *>() + 1;
+      if (auto *VAM = dyn_cast<ValueAsMetadata *>(I))
+        I = VAM + 1;
       else
-        I = I.get<ValueAsMetadata **>() + 1;
+        I = cast<ValueAsMetadata **>(I) + 1;
       return *this;
     }
     location_op_iterator &operator--() {
-      if (I.is<ValueAsMetadata *>())
-        I = I.get<ValueAsMetadata *>() - 1;
+      if (auto *VAM = dyn_cast<ValueAsMetadata *>(I))
+        I = VAM - 1;
       else
-        I = I.get<ValueAsMetadata **>() - 1;
+        I = cast<ValueAsMetadata **>(I) - 1;
       return *this;
     }
   };

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -2118,9 +2118,9 @@ Expected<RuleMatcher> GlobalISelEmitter::runOnPattern(const PatternToMatch &P) {
         return failedImport(
             "Cannot infer register class for SUBREG_TO_REG operand #0");
       MatchedRC = *MaybeRegClass;
-    } else if (MatchedRC.get<const Record *>()->isSubClassOf("RegisterOperand"))
-      MatchedRC = MatchedRC.get<const Record *>()->getValueAsDef("RegClass");
-    else if (!MatchedRC.get<const Record *>()->isSubClassOf("RegisterClass"))
+    } else if (cast<const Record *>(MatchedRC)->isSubClassOf("RegisterOperand"))
+      MatchedRC = cast<const Record *>(MatchedRC)->getValueAsDef("RegClass");
+    else if (!cast<const Record *>(MatchedRC)->isSubClassOf("RegisterClass"))
       return failedImport("Dst MI def isn't a register class" + to_string(Dst));
 
     OperandMatcher &OM = InsnMatcher.getOperand(OpIdx);
@@ -2130,10 +2130,10 @@ Expected<RuleMatcher> GlobalISelEmitter::runOnPattern(const PatternToMatch &P) {
     // GIM_CheckIsSameOperand predicates by the defineOperand method.
     OM.setSymbolicName(getMangledRootDefName(DstIOperand.Name));
     M.defineOperand(OM.getSymbolicName(), OM);
-    if (MatchedRC.is<const Record *>())
-      MatchedRC = &Target.getRegisterClass(MatchedRC.get<const Record *>());
+    if (auto *R = dyn_cast<const Record *>(MatchedRC))
+      MatchedRC = &Target.getRegisterClass(R);
     OM.addPredicate<RegisterBankOperandMatcher>(
-        *MatchedRC.get<const CodeGenRegisterClass *>());
+        *cast<const CodeGenRegisterClass *>(MatchedRC));
     ++OpIdx;
   }
 


### PR DESCRIPTION
Note that PointerUnion::{is,get,dyn_cast} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>
