### PR TITLE
[TableGen] Use heterogenous lookups with std::map (NFC)

### DIFF
--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -340,7 +340,7 @@ class Intrinsic {
   /// The index of the key type passed to CGBuiltin.cpp for polymorphic calls.
   int PolymorphicKeyType;
   /// The local variables defined.
-  std::map<std::string, Variable> Variables;
+  std::map<std::string, Variable, std::less<>> Variables;
   /// NeededEarly - set if any other intrinsic depends on this intrinsic.
   bool NeededEarly;
   /// UseMacro - set if we should implement using a macro or unset for a
@@ -1548,8 +1548,8 @@ Intrinsic::DagEmitter::emitDagCast(const DagInit *DI, bool IsBitCast) {
     //   5. The value "H" or "D" to half or double the bitwidth.
     //   6. The value "8" to convert to 8-bit (signed) integer lanes.
     if (!DI->getArgNameStr(ArgIdx).empty()) {
-      assert_with_loc(Intr.Variables.find(std::string(
-                          DI->getArgNameStr(ArgIdx))) != Intr.Variables.end(),
+      assert_with_loc(Intr.Variables.find(DI->getArgNameStr(ArgIdx)) !=
+                          Intr.Variables.end(),
                       "Variable not found");
       castToType =
           Intr.Variables[std::string(DI->getArgNameStr(ArgIdx))].getType();


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.
