### PR TITLE
[lldb] Use heterogenous lookups with std::map (NFC)

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1274,7 +1274,7 @@ CommandObject *CommandInterpreter::GetUserCommandObject(
     llvm::StringRef cmd, StringList *matches, StringList *descriptions) const {
   std::string cmd_str(cmd);
   auto find_exact = [&](const CommandObject::CommandMap &map) {
-    auto found_elem = map.find(std::string(cmd));
+    auto found_elem = map.find(cmd);
     if (found_elem == map.end())
       return (CommandObject *)nullptr;
     CommandObject *exact_cmd = found_elem->second.get();
@@ -1310,7 +1310,7 @@ CommandObject *CommandInterpreter::GetAliasCommandObject(
     llvm::StringRef cmd, StringList *matches, StringList *descriptions) const {
   auto find_exact =
       [&](const CommandObject::CommandMap &map) -> CommandObject * {
-    auto found_elem = map.find(cmd.str());
+    auto found_elem = map.find(cmd);
     if (found_elem == map.end())
       return (CommandObject *)nullptr;
     CommandObject *exact_cmd = found_elem->second.get();
@@ -1340,13 +1340,12 @@ CommandObject *CommandInterpreter::GetAliasCommandObject(
 }
 
 bool CommandInterpreter::CommandExists(llvm::StringRef cmd) const {
-  return m_command_dict.find(std::string(cmd)) != m_command_dict.end();
+  return m_command_dict.find(cmd) != m_command_dict.end();
 }
 
 bool CommandInterpreter::GetAliasFullName(llvm::StringRef cmd,
                                           std::string &full_name) const {
-  bool exact_match =
-      (m_alias_dict.find(std::string(cmd)) != m_alias_dict.end());
+  bool exact_match = (m_alias_dict.find(cmd) != m_alias_dict.end());
   if (exact_match) {
     full_name.assign(std::string(cmd));
     return exact_match;
@@ -1374,15 +1373,15 @@ bool CommandInterpreter::GetAliasFullName(llvm::StringRef cmd,
 }
 
 bool CommandInterpreter::AliasExists(llvm::StringRef cmd) const {
-  return m_alias_dict.find(std::string(cmd)) != m_alias_dict.end();
+  return m_alias_dict.find(cmd) != m_alias_dict.end();
 }
 
 bool CommandInterpreter::UserCommandExists(llvm::StringRef cmd) const {
-  return m_user_dict.find(std::string(cmd)) != m_user_dict.end();
+  return m_user_dict.find(cmd) != m_user_dict.end();
 }
 
 bool CommandInterpreter::UserMultiwordCommandExists(llvm::StringRef cmd) const {
-  return m_user_mw_dict.find(std::string(cmd)) != m_user_mw_dict.end();
+  return m_user_mw_dict.find(cmd) != m_user_mw_dict.end();
 }
 
 CommandAlias *
@@ -1406,7 +1405,7 @@ CommandInterpreter::AddAlias(llvm::StringRef alias_name,
 }
 
 bool CommandInterpreter::RemoveAlias(llvm::StringRef alias_name) {
-  auto pos = m_alias_dict.find(std::string(alias_name));
+  auto pos = m_alias_dict.find(alias_name);
   if (pos != m_alias_dict.end()) {
     m_alias_dict.erase(pos);
     return true;
@@ -1415,7 +1414,7 @@ bool CommandInterpreter::RemoveAlias(llvm::StringRef alias_name) {
 }
 
 bool CommandInterpreter::RemoveCommand(llvm::StringRef cmd, bool force) {
-  auto pos = m_command_dict.find(std::string(cmd));
+  auto pos = m_command_dict.find(cmd);
   if (pos != m_command_dict.end()) {
     if (force || pos->second->IsRemovable()) {
       // Only regular expression objects or python commands are removable under
@@ -1428,8 +1427,7 @@ bool CommandInterpreter::RemoveCommand(llvm::StringRef cmd, bool force) {
 }
 
 bool CommandInterpreter::RemoveUser(llvm::StringRef user_name) {
-  CommandObject::CommandMap::iterator pos =
-      m_user_dict.find(std::string(user_name));
+  CommandObject::CommandMap::iterator pos = m_user_dict.find(user_name);
   if (pos != m_user_dict.end()) {
     m_user_dict.erase(pos);
     return true;
@@ -1438,8 +1436,7 @@ bool CommandInterpreter::RemoveUser(llvm::StringRef user_name) {
 }
 
 bool CommandInterpreter::RemoveUserMultiword(llvm::StringRef multi_name) {
-  CommandObject::CommandMap::iterator pos =
-      m_user_mw_dict.find(std::string(multi_name));
+  CommandObject::CommandMap::iterator pos = m_user_mw_dict.find(multi_name);
   if (pos != m_user_mw_dict.end()) {
     m_user_mw_dict.erase(pos);
     return true;
@@ -2213,7 +2210,7 @@ const CommandAlias *
 CommandInterpreter::GetAlias(llvm::StringRef alias_name) const {
   OptionArgVectorSP ret_val;
 
-  auto pos = m_alias_dict.find(std::string(alias_name));
+  auto pos = m_alias_dict.find(alias_name);
   if (pos != m_alias_dict.end())
     return (CommandAlias *)pos->second.get();
 


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.  Note that CommandMap just
started accepting heterogeneous lookups (#115634).
