### PR TITLE
[mlir][GPU] Lower gpu.memcpy with an offset to memcpy

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/Utils/MemRefUtils.h
+++ b/mlir/include/mlir/Dialect/MemRef/Utils/MemRefUtils.h
@@ -31,6 +31,11 @@ namespace memref {
 /// contiguous chunk of memory.
 bool isStaticShapeAndContiguousRowMajor(MemRefType type);
 
+/// Return true, if the memref type has a rank and contains at least
+/// one dimension of size 0, indicating it is empty. UnrankedMemRefType is
+/// considered non-empty by this function.
+bool isEmpty(BaseMemRefType type);
+
 /// For a `memref` with `offset`, `sizes` and `strides`, returns the
 /// offset, size, and potentially the size padded at the front to use for the
 /// linearized `memref`.

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -869,7 +869,7 @@ struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
       // special case handled by memrefCopy.
       return memrefType &&
              (memrefType.getLayout().isIdentity() ||
-              (memrefType.hasStaticShape() && memrefType.getNumElements() > 0 &&
+              (!memref::isEmpty(memrefType) &&
                memref::isStaticShapeAndContiguousRowMajor(memrefType)));
     };
 

--- a/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
+++ b/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
@@ -49,6 +49,10 @@ bool isStaticShapeAndContiguousRowMajor(MemRefType type) {
   return curDim < 0;
 }
 
+bool isEmpty(BaseMemRefType type) {
+  return type.hasRank() && llvm::is_contained(type.getShape(), 0);
+}
+
 std::pair<LinearizedMemRefInfo, OpFoldResult> getLinearizedMemRefOffsetAndSize(
     OpBuilder &builder, Location loc, int srcBits, int dstBits,
     OpFoldResult offset, ArrayRef<OpFoldResult> sizes,

--- a/mlir/test/Conversion/GPUCommon/lower-memcpy-to-gpu-runtime-calls.mlir
+++ b/mlir/test/Conversion/GPUCommon/lower-memcpy-to-gpu-runtime-calls.mlir
@@ -6,13 +6,30 @@ module attributes {gpu.container_module} {
   func.func @foo(%dst : memref<7xf32, 1>, %src : memref<7xf32>) {
     // CHECK: %[[t0:.*]] = llvm.call @mgpuStreamCreate
     %t0 = gpu.wait async
-    // CHECK: %[[size_bytes:.*]] = llvm.ptrtoint
+    // CHECK: %[[size_bytes:.*]] = llvm.mul
     // CHECK-NOT: llvm.addrspacecast
     // CHECK: %[[addr_cast:.*]] = llvm.addrspacecast
     // CHECK: llvm.call @mgpuMemcpy(%[[addr_cast]], %{{.*}}, %[[size_bytes]], %[[t0]])
     %t1 = gpu.memcpy async [%t0] %dst, %src : memref<7xf32, 1>, memref<7xf32>
     // CHECK: llvm.call @mgpuStreamSynchronize(%[[t0]])
     // CHECK: llvm.call @mgpuStreamDestroy(%[[t0]])
+    gpu.wait [%t1]
+    return
+  }
+
+  // CHECK: func @test_copy_memref_with_offset
+  func.func @test_copy_memref_with_offset(%dst : memref<10xf32, strided<[1], offset: 8>>, %src : memref<10xf32, strided<[1], offset: 3>>) {
+    // CHECK: %[[stream:.*]] = llvm.call @mgpuStreamCreate
+    %t0 = gpu.wait async
+    // CHECK: %[[cst3:.*]] = llvm.mlir.constant(3 : index)
+    // CHECK: %[[src:.*]] = llvm.getelementptr %{{.*}}[%[[cst3]]]
+    // CHECK: %[[cst8:.*]] = llvm.mlir.constant(8 : index) 
+    // CHECK: %[[dst:.*]] = llvm.getelementptr %{{.*}}[%[[cst8]]]
+    // CHECK: %[[size_bytes:.*]] = llvm.mul
+    // CHECK: llvm.call @mgpuMemcpy(%[[dst]], %[[src]], %[[size_bytes]], %[[stream]])
+    %t1 = gpu.memcpy async [%t0] %dst, %src : memref<10xf32, strided<[1], offset: 8>>, memref<10xf32, strided<[1], offset: 3>>
+    // CHECK: llvm.call @mgpuStreamSynchronize(%[[stream]])
+    // CHECK: llvm.call @mgpuStreamDestroy(%[[stream]])
     gpu.wait [%t1]
     return
   }


### PR DESCRIPTION
This commit adds support for `gpu.memcpy` to handle memref types with offsets and contiguous memory layouts, allowing the lowering of the following IR:

```mlir
%view = memref.subview %mem[1,0] [1,2] [1,1] : memref<4x4xf32> to memref<2xf32, strided<[1], offset: 4>>
gpu.memcpy %d, %view : memref<2xf32>, memref<2xf32, strided<[1], offset: 4>>
```

Related discussion: [https://discourse.llvm.org/t/gpu-memcpy-does-not-support-generic-memref-layouts/80695](https://discourse.llvm.org/t/gpu-memcpy-does-not-support-generic-memref-layouts/80695)