### PR TITLE
[Pass] Add `RequiredPassMixin` for non skippable passes

### DIFF
--- a/llvm/include/llvm/IR/PassManager.h
+++ b/llvm/include/llvm/IR/PassManager.h
@@ -112,6 +112,17 @@ struct AnalysisInfoMixin : PassInfoMixin<DerivedT> {
   }
 };
 
+/// A mix-in indicates that the pass cannot be skipped
+/// in pass instrumentation.
+struct RequiredPassMixin {};
+
+/// A convenient mix-in to indicate the pass cannot be skipped
+/// in pass instrumentation.
+///
+/// It automatically mixes in \c PassInfoMixin and \c RequiredPassMixin.
+template <typename DerivedT>
+struct RequiredPassInfoMixin : PassInfoMixin<DerivedT>, RequiredPassMixin {};
+
 namespace detail {
 
 /// Actual unpacker of extra arguments in getAnalysisResult,

--- a/llvm/include/llvm/IR/PassManagerInternal.h
+++ b/llvm/include/llvm/IR/PassManagerInternal.h
@@ -29,6 +29,7 @@ namespace llvm {
 template <typename IRUnitT> class AllAnalysesOn;
 template <typename IRUnitT, typename... ExtraArgTs> class AnalysisManager;
 class PreservedAnalyses;
+struct RequiredPassMixin;
 
 // Implementation details of the pass manager interfaces.
 namespace detail {
@@ -112,7 +113,10 @@ struct PassModel : PassConcept<IRUnitT, AnalysisManagerT, ExtraArgTs...> {
     return false;
   }
 
-  bool isRequired() const override { return passIsRequiredImpl<PassT>(); }
+  bool isRequired() const override {
+    return passIsRequiredImpl<PassT>() ||
+           std::is_base_of_v<RequiredPassMixin, PassT>;
+  }
 
   PassT Pass;
 };


### PR DESCRIPTION
Follow the idea in #115471, add a new kind of mix-in. This PR demonstrates how it works:
```c++
// A required pass
struct SomePass : PassInfoMixin<SomePass>, RequiredPassMixin {
    PreservedAnalysis run(...);
};
```
Rather than provide `isRequired` for each pass, it seems that checking the sub-class relationship is enough.