### PR TITLE
[WebKit checkers] Treat ref() and incrementCheckedPtrCount() as trivial

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -498,6 +498,10 @@ public:
     if (!Callee)
       return false;
 
+    auto Name = safeGetName(Callee);
+    if (Name == "ref" || Name == "incrementCheckedPtrCount")
+      return true;
+
     std::optional<bool> IsGetterOfRefCounted = isGetterOfSafePtr(Callee);
     if (IsGetterOfRefCounted && *IsGetterOfRefCounted)
       return true;

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
@@ -365,3 +365,22 @@ namespace call_with_explicit_temporary_obj {
     CheckedPtr { provide() }->method();
   }
 }
+
+namespace call_with_checked_ptr {
+
+  class Foo : public CheckedObj {
+  public:
+    CheckedPtr<CheckedObj> obj1() { return m_obj; }
+    CheckedRef<CheckedObj> obj2() { return *m_obj; }
+  private:
+    CheckedObj* m_obj;
+  };
+
+  Foo* getFoo();
+
+  void bar() {
+    getFoo()->obj1()->method();
+    getFoo()->obj2()->method();
+  }
+
+}

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -366,6 +366,8 @@ public:
   void trivial65() {
     __libcpp_verbose_abort("%s", "aborting");
   }
+  RefPtr<RefCounted> trivial66() { return children[0]; }
+  Ref<RefCounted> trivial67() { return *children[0]; }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -550,6 +552,8 @@ public:
     getFieldTrivial().trivial63(); // no-warning
     getFieldTrivial().trivial64(); // no-warning
     getFieldTrivial().trivial65(); // no-warning
+    getFieldTrivial().trivial66()->trivial6(); // no-warning
+    getFieldTrivial().trivial67()->trivial6(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning


### PR DESCRIPTION
Treat member function calls to ref() and incrementCheckedPtrCount() as trivial so that a function which returns RefPtr/Ref out of a raw reference / pointer is also considered trivial.