### PR TITLE
[libclc] Move sign to the CLC builtins library

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -351,7 +351,6 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     string( TOUPPER "CLC_${MACRO_ARCH}" CLC_TARGET_DEFINE )
 
     list( APPEND build_flags
-      -D__CLC_INTERNAL
       -D${CLC_TARGET_DEFINE}
       # All libclc builtin libraries see CLC headers
       -I${CMAKE_CURRENT_SOURCE_DIR}/clc/include
@@ -363,12 +362,14 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       list( APPEND build_flags -mcpu=${cpu} )
     endif()
 
+    set( clc_build_flags ${build_flags} -DCLC_INTERNAL )
+
     add_libclc_builtin_set(
       CLC_INTERNAL
       ARCH ${ARCH}
       ARCH_SUFFIX clc-${arch_suffix}
       TRIPLE ${clang_triple}
-      COMPILE_FLAGS ${build_flags}
+      COMPILE_FLAGS ${clc_build_flags}
       OPT_FLAGS ${opt_flags}
       LIB_FILES ${clc_lib_files}
     )

--- a/libclc/clc/include/clc/common/clc_sign.h
+++ b/libclc/clc/include/clc/common/clc_sign.h
@@ -1,0 +1,12 @@
+#ifndef __CLC_COMMON_CLC_SIGN_H__
+#define __CLC_COMMON_CLC_SIGN_H__
+
+#define __CLC_FUNCTION __clc_sign
+#define __CLC_BODY <clc/math/unary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+
+#endif // __CLC_COMMON_CLC_SIGN_H__

--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -3,55 +3,69 @@
 
 #define __CLC_SCALAR_GENTYPE float
 #define __CLC_FPSIZE 32
+#define __CLC_FP_LIT(x) x##F
 
 #define __CLC_GENTYPE float
 #define __CLC_INTN int
+#define __CLC_BIT_INTN int
 #define __CLC_SCALAR
 #include __CLC_BODY
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 #undef __CLC_SCALAR
 
 #define __CLC_GENTYPE float2
 #define __CLC_INTN int2
+#define __CLC_BIT_INTN int2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE float3
 #define __CLC_INTN int3
+#define __CLC_BIT_INTN int3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE float4
 #define __CLC_INTN int4
+#define __CLC_BIT_INTN int4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE float8
 #define __CLC_INTN int8
+#define __CLC_BIT_INTN int8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE float16
 #define __CLC_INTN int16
+#define __CLC_BIT_INTN int16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
+#undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
 
@@ -61,55 +75,69 @@
 
 #define __CLC_SCALAR_GENTYPE double
 #define __CLC_FPSIZE 64
+#define __CLC_FP_LIT(x) (x)
 
 #define __CLC_SCALAR
 #define __CLC_GENTYPE double
 #define __CLC_INTN int
+#define __CLC_BIT_INTN long
 #include __CLC_BODY
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 #undef __CLC_SCALAR
 
 #define __CLC_GENTYPE double2
 #define __CLC_INTN int2
+#define __CLC_BIT_INTN long2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE double3
 #define __CLC_INTN int3
+#define __CLC_BIT_INTN long3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE double4
 #define __CLC_INTN int4
+#define __CLC_BIT_INTN long4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE double8
 #define __CLC_INTN int8
+#define __CLC_BIT_INTN long8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE double16
 #define __CLC_INTN int16
+#define __CLC_BIT_INTN long16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
+#undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
 #endif
@@ -121,55 +149,69 @@
 
 #define __CLC_SCALAR_GENTYPE half
 #define __CLC_FPSIZE 16
+#define __CLC_FP_LIT(x) x##H
 
 #define __CLC_SCALAR
 #define __CLC_GENTYPE half
 #define __CLC_INTN int
+#define __CLC_BIT_INTN short
 #include __CLC_BODY
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 #undef __CLC_SCALAR
 
 #define __CLC_GENTYPE half2
 #define __CLC_INTN int2
+#define __CLC_BIT_INTN short2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE half3
 #define __CLC_INTN int3
+#define __CLC_BIT_INTN short3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE half4
 #define __CLC_INTN int4
+#define __CLC_BIT_INTN short4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE half8
 #define __CLC_INTN int8
+#define __CLC_BIT_INTN short8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
 #define __CLC_GENTYPE half16
 #define __CLC_INTN int16
+#define __CLC_BIT_INTN short16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
+#undef __CLC_BIT_INTN
 #undef __CLC_INTN
 
+#undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
 #endif

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -1,5 +1,6 @@
 common/clc_degrees.cl
 common/clc_radians.cl
+common/clc_sign.cl
 common/clc_smoothstep.cl
 geometric/clc_dot.cl
 integer/clc_abs.cl

--- a/libclc/clc/lib/generic/common/clc_sign.cl
+++ b/libclc/clc/lib/generic/common/clc_sign.cl
@@ -1,0 +1,6 @@
+#include <clc/math/clc_copysign.h>
+#include <clc/relational/clc_isnan.h>
+#include <clc/relational/clc_select.h>
+
+#define __CLC_BODY <clc_sign.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/common/clc_sign.inc
+++ b/libclc/clc/lib/generic/common/clc_sign.inc
@@ -1,0 +1,7 @@
+_CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_sign(__CLC_GENTYPE x) {
+  __CLC_BIT_INTN ret_zero = __clc_isnan(x) || x == __CLC_FP_LIT(0.0);
+  __CLC_GENTYPE ret_val =
+      __clc_select((__CLC_GENTYPE)__CLC_FP_LIT(1.0),
+                   (__CLC_GENTYPE)__CLC_FP_LIT(0.0), ret_zero);
+  return __clc_copysign(ret_val, x);
+}

--- a/libclc/generic/include/clc/float/definitions.h
+++ b/libclc/generic/include/clc/float/definitions.h
@@ -31,9 +31,7 @@
 #define M_SQRT2_F       0x1.6a09e6p+0f
 #define M_SQRT1_2_F     0x1.6a09e6p-1f
 
-#ifdef __CLC_INTERNAL
-#define M_LOG210_F      0x1.a934f0p+1f
-#endif
+#define M_LOG210_F 0x1.a934f0p+1f
 
 #ifdef cl_khr_fp64
 

--- a/libclc/generic/lib/common/sign.cl
+++ b/libclc/generic/lib/common/sign.cl
@@ -1,37 +1,8 @@
 #include <clc/clc.h>
 #include <clc/clcmacro.h>
+#include <clc/common/clc_sign.h>
 
-#define SIGN(TYPE, F) \
-_CLC_DEF _CLC_OVERLOAD TYPE sign(TYPE x) { \
-  if (isnan(x)) { \
-    return 0.0F;   \
-  }               \
-  if (x > 0.0F) { \
-    return 1.0F;  \
-  }               \
-  if (x < 0.0F) { \
-    return -1.0F; \
-  }               \
-  return x; /* -0.0 or +0.0 */  \
-}
+#define FUNCTION sign
+#define __CLC_BODY <clc/shared/unary_def.inc>
 
-SIGN(float, f)
-_CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, sign, float)
-
-#ifdef cl_khr_fp64
-
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-
-SIGN(double, )
-_CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, sign, double)
-
-#endif
-
-#ifdef cl_khr_fp16
-
-#pragma OPENCL EXTENSION cl_khr_fp16 : enable
-
-SIGN(half,)
-_CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, half, sign, half)
-
-#endif
+#include <clc/math/gentype.inc>


### PR DESCRIPTION
This commit moves the sign builtin's implementation to the CLC library.
It simultaneously optimizes it (for vector types) by removing
control-flow from the implementation.

The __CLC_INTERNAL preprocessor definition has been repurposed (without
the leading underscores) to be passed when building the internal CLC
library. It was only used in one other place to guard an extra maths
preprocessor definition, which we can do unconditionally.