### PR TITLE
[CMake] Export symbols after `target_link_libraries` for lld

### DIFF
--- a/lld/CMakeLists.txt
+++ b/lld/CMakeLists.txt
@@ -189,6 +189,11 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
 endif()
 
 add_subdirectory(Common)
+add_subdirectory(COFF)
+add_subdirectory(ELF)
+add_subdirectory(MachO)
+add_subdirectory(MinGW)
+add_subdirectory(wasm)
 add_subdirectory(tools/lld)
 
 if (LLVM_INCLUDE_TESTS)
@@ -201,10 +206,5 @@ if (LLVM_INCLUDE_TESTS)
 endif()
 
 add_subdirectory(docs)
-add_subdirectory(COFF)
-add_subdirectory(ELF)
-add_subdirectory(MachO)
-add_subdirectory(MinGW)
-add_subdirectory(wasm)
 
 add_subdirectory(cmake/modules)

--- a/lld/tools/lld/CMakeLists.txt
+++ b/lld/tools/lld/CMakeLists.txt
@@ -9,7 +9,6 @@ add_lld_tool(lld
   SUPPORT_PLUGINS
   GENERATE_DRIVER
   )
-export_executable_symbols_for_plugins(lld)
 
 function(lld_target_link_libraries target type)
   if (TARGET obj.${target})
@@ -33,6 +32,8 @@ lld_target_link_libraries(lld
   lldMinGW
   lldWasm
   )
+
+export_executable_symbols_for_plugins(lld)
 
 if(NOT LLD_SYMLINKS_TO_CREATE)
   set(LLD_SYMLINKS_TO_CREATE


### PR DESCRIPTION
Found that lld only exports very few symbols after enable `LLVM_EXPORT_SYMBOLS_FOR_PLUGINS`.

We need to collect `LINK_LIBRARIES` after all `target_link_libraries` calls.
