### PR TITLE
adding missing lib MLIRDestinationStyleOpInterface

### DIFF
--- a/mlir/lib/Dialect/Mesh/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Mesh/IR/CMakeLists.txt
@@ -13,4 +13,5 @@ add_mlir_dialect_library(MLIRMeshDialect
   MLIRIR
   MLIRSupport
   MLIRViewLikeInterface
+  MLIRDestinationStyleOpInterface
 )


### PR DESCRIPTION
fixing CI failures caused by #114238 by adding MLIRDestinationStyleOpInterface lib
@jplehr @mfrancio @rengolin 