### PR TITLE
[OpenMP] Don't hardcode _WIN32_WINNT for MinGW targets

### DIFF
--- a/openmp/runtime/cmake/LibompDefinitions.cmake
+++ b/openmp/runtime/cmake/LibompDefinitions.cmake
@@ -16,7 +16,12 @@ function(libomp_get_definitions_flags cppflags)
     libomp_append(cppflags_local "-D _CRT_SECURE_NO_DEPRECATE")
     libomp_append(cppflags_local "-D _WINDOWS")
     libomp_append(cppflags_local "-D _WINNT")
-    libomp_append(cppflags_local "-D _WIN32_WINNT=0x0501")
+    if (MSVC)
+      # Force a default target OS version with MSVC based toolchains.
+      # (For MinGW based ones, use the toolchain's default target or what
+      # the user set in CMake flags.)
+      libomp_append(cppflags_local "-D _WIN32_WINNT=0x0501")
+    endif()
     libomp_append(cppflags_local "-D _USRDLL")
     libomp_append(cppflags_local "-D _ITERATOR_DEBUG_LEVEL=0" IF_TRUE DEBUG_BUILD)
     libomp_append(cppflags_local "-D _DEBUG" IF_TRUE DEBUG_BUILD)


### PR DESCRIPTION
Instead respect what the toolchain default is (or what the user sets via CMAKE_CXX_FLAGS).

This fixes builds with libcxx, with mingw toolchains targeting msvcrt.dll, after 5d8be4c036aa5ce4a94f1f37a9155d5c877e23db; after that commit, the libcxx public headers reference symbols such as iswspace_l, which are unavailable when targeting msvcrt.dll on older versions of Windows (it's only available in msvcrt.dll since Windows Vista).