### PR TITLE
fix: Target Process may crash or freezes on detaching process on windows

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.h
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.h
@@ -46,7 +46,7 @@ private:
   void FreeProcessHandles();
   void DebugLoop();
   ExceptionResult HandleExceptionEvent(const EXCEPTION_DEBUG_INFO &info,
-                                       DWORD thread_id);
+                                       DWORD thread_id, bool shutting_down);
   DWORD HandleCreateThreadEvent(const CREATE_THREAD_DEBUG_INFO &info,
                                 DWORD thread_id);
   DWORD HandleCreateProcessEvent(const CREATE_PROCESS_DEBUG_INFO &info,

--- a/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
+++ b/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
@@ -12,7 +12,6 @@ from lldbsuite.test import lldbutil
 class DetachResumesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr89077")
     def test_detach_resumes(self):
         self.build()
         exe = self.getBuildArtifact()


### PR DESCRIPTION
~~I hope this fixes~~ ~~#67825~~ ~~Actually a another issue, see [comment below](https://github.com/llvm/llvm-project/pull/115712#issuecomment-2470966129)~~

Fixes #67825 Fixes #89077

Fixes [RIDER-99436](https://youtrack.jetbrains.com/issue/RIDER-99436/Unity-Editor-will-be-crashed-when-detaching-LLDB-debugger-in-Rider), which is upstream issue of #67825.

This PR changes the timing of calling `DebugActiveProcessStop` to after calling `ContinueDebugEvent` for last debugger exception.

I confirmed the crashing behavior is because we call `DebugActiveProcessStop` before `ContinueDebugEvent` for last debugger exception with https://github.com/anatawa12/debug-api-test.

I have no idea how should I test this so I did not add tests. Could you let me know how should I test for this chages?
