### PR TITLE
[lldb][test] Fix remote Shell tests failures on Windows host

### DIFF
--- a/lldb/test/Shell/Commands/command-disassemble-mixed.c
+++ b/lldb/test/Shell/Commands/command-disassemble-mixed.c
@@ -1,6 +1,6 @@
 // invalid mixed disassembly line
 
-// XFAIL: system-windows
+// XFAIL: target-windows
 
 // RUN: %clang_host -g %s -o %t
 // RUN: %lldb %t -o "dis -m -n main" -o "exit" | FileCheck %s

--- a/lldb/test/Shell/Commands/command-expr-diagnostics.test
+++ b/lldb/test/Shell/Commands/command-expr-diagnostics.test
@@ -1,4 +1,4 @@
-# XFAIL: system-windows
+# XFAIL: target-windows
 # RUN: echo quit | %lldb -o "expression a+b" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK1
 #            (lldb) expression a+b

--- a/lldb/test/Shell/Commands/command-target-create-resolve-exe.test
+++ b/lldb/test/Shell/Commands/command-target-create-resolve-exe.test
@@ -1,4 +1,4 @@
-# REQUIRES: system-windows
+# REQUIRES: target-windows
 
 ## This checks that when starting lldb (or using `target create`) with a
 ## program name which is on $PATH, or not specify the .exe suffix of a program

--- a/lldb/test/Shell/Expr/TestAnonNamespaceParamFunc.cpp
+++ b/lldb/test/Shell/Expr/TestAnonNamespaceParamFunc.cpp
@@ -3,7 +3,7 @@
 // linkage. In this case, a function whose argument
 // is not legally usable outside this TU.
 
-// XFAIL: system-windows
+// XFAIL: target-windows
 
 // RUN: %build %s -o %t
 // RUN: %lldb %t -o run -o "expression func(a)" -o exit | FileCheck %s

--- a/lldb/test/Shell/Expr/TestIRMemoryMapWindows.test
+++ b/lldb/test/Shell/Expr/TestIRMemoryMapWindows.test
@@ -1,4 +1,4 @@
-# REQUIRES: system-windows
+# REQUIRES: target-windows
 
 # RUN: %clang_cl_host /Zi /GS- %p/Inputs/call-function.cpp /c /o %t.obj
 # RUN: %msvc_link /debug:full %t.obj /out:%t

--- a/lldb/test/Shell/Process/Windows/exception_access_violation.cpp
+++ b/lldb/test/Shell/Process/Windows/exception_access_violation.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 
-// REQUIRES: system-windows
+// REQUIRES: target-windows
 // RUN: %build --compiler=clang-cl -o %t.exe -- %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -o "run" -- write | FileCheck --check-prefix=WRITE %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -o "run" -- read | FileCheck --check-prefix=READ %s

--- a/lldb/test/Shell/Process/Windows/process_load.cpp
+++ b/lldb/test/Shell/Process/Windows/process_load.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 
-// REQUIRES: system-windows
+// REQUIRES: target-windows
 // RUN: %build --compiler=clang-cl -o %t.exe -- %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -f %t.exe -o "b main" -o "process launch" -o "process load kernel32.dll" | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
@@ -1,4 +1,4 @@
-// XFAIL: system-windows
+// XFAIL: target-windows
 // RUN: %clangxx_host -gdwarf -o %t %s
 // RUN: %lldb %t \
 // RUN:   -o "expr alignof(packed)" \

--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 
-// REQUIRES: system-windows
+// REQUIRES: target-windows
 // RUN: %build -o %t.exe -- %s
 // RUN: %lldb -f %t.exe -s \
 // RUN:     %p/Inputs/local-variables.lldbinit 2>&1 | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/NativePDB/stack_unwinding01.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/stack_unwinding01.cpp
@@ -1,5 +1,5 @@
 // clang-format off
-// REQUIRES: lld, system-windows
+// REQUIRES: lld, target-windows
 
 // RUN: %build --compiler=clang-cl --nodefaultlib -o %t.exe -- %s
 // RUN: %lldb -f %t.exe -s \

--- a/lldb/test/Shell/SymbolFile/PDB/calling-conventions-arm.test
+++ b/lldb/test/Shell/SymbolFile/PDB/calling-conventions-arm.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, lld, (target-arm || target-aarch64) 
+REQUIRES: target-windows, lld, (target-arm || target-aarch64)
 RUN: %build --compiler=clang-cl --arch=32 --nodefaultlib --output=%t.exe %S/Inputs/CallingConventionsTest.cpp
 RUN: %build --compiler=clang-cl --arch=64 --nodefaultlib --output=%t.exe %S/Inputs/CallingConventionsTest.cpp
 RUN: lldb-test symbols -dump-ast %t.exe | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/PDB/class-layout.test
+++ b/lldb/test/Shell/SymbolFile/PDB/class-layout.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: target-windows, msvc
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/ClassLayoutTest.cpp.obj %S/Inputs/ClassLayoutTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/ClassLayoutTest.cpp.exe %T/ClassLayoutTest.cpp.obj
 RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/PDB/compilands.test
+++ b/lldb/test/Shell/SymbolFile/PDB/compilands.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: target-windows, msvc
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/CompilandsTest.cpp.obj %S/Inputs/CompilandsTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/CompilandsTest.cpp.exe %T/CompilandsTest.cpp.obj
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %T/CompilandsTest.cpp.exe | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/PDB/expressions.test
+++ b/lldb/test/Shell/SymbolFile/PDB/expressions.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: target-windows, msvc
 RUN: %build --compiler=msvc --nodefaultlib --output=%t.exe %S/Inputs/ExpressionsTest.cpp
 RUN: not %lldb -b -s %S/Inputs/ExpressionsTest0.script -s %S/Inputs/ExpressionsTest1.script -s %S/Inputs/ExpressionsTest2.script -- %t.exe 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/PDB/func-symbols.test
+++ b/lldb/test/Shell/SymbolFile/PDB/func-symbols.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, lld
+REQUIRES: target-windows, lld
 RUN: %build --compiler=clang-cl --arch=32 --nodefaultlib --output=%T/FuncSymbolsTest.exe %S/Inputs/FuncSymbolsTestMain.cpp %S/Inputs/FuncSymbols.cpp
 RUN: lldb-test symbols %T/FuncSymbolsTest.exe | FileCheck --check-prefix=CHECK-ONE %s
 RUN: lldb-test symbols %T/FuncSymbolsTest.exe | FileCheck --check-prefix=CHECK-TWO %s

--- a/lldb/test/Shell/SymbolFile/PDB/function-level-linking.test
+++ b/lldb/test/Shell/SymbolFile/PDB/function-level-linking.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, lld
+REQUIRES: target-windows, lld
 RUN: %clang_cl_host /c /Zi /Gy %S/Inputs/FunctionLevelLinkingTest.cpp /o %t.obj
 RUN: lld-link /debug:full /nodefaultlib /entry:main /order:@%S/Inputs/FunctionLevelLinkingTest.ord %t.obj /out:%t.exe
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols -verify %t.exe

--- a/lldb/test/Shell/SymbolFile/PDB/pointers.test
+++ b/lldb/test/Shell/SymbolFile/PDB/pointers.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: target-windows, msvc
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/PointerTypeTest.cpp.obj %S/Inputs/PointerTypeTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/PointerTypeTest.cpp.exe %T/PointerTypeTest.cpp.obj
 RUN: lldb-test symbols %T/PointerTypeTest.cpp.exe | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/PDB/type-quals.test
+++ b/lldb/test/Shell/SymbolFile/PDB/type-quals.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: target-windows, msvc
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/TypeQualsTest.cpp.obj %S/Inputs/TypeQualsTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/TypeQualsTest.cpp.exe %T/TypeQualsTest.cpp.obj
 RUN: lldb-test symbols %T/TypeQualsTest.cpp.exe | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/PDB/udt-layout.test
+++ b/lldb/test/Shell/SymbolFile/PDB/udt-layout.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, lld
+REQUIRES: target-windows, lld
 RUN: %build --compiler=clang-cl --output=%t.exe %S/Inputs/UdtLayoutTest.cpp
 RUN: %lldb -b -s %S/Inputs/UdtLayoutTest.script -- %t.exe | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/PDB/variables-locations.test
+++ b/lldb/test/Shell/SymbolFile/PDB/variables-locations.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, lld
+REQUIRES: target-windows, lld
 RUN: %build --compiler=clang-cl --output=%t.exe %S/Inputs/VariablesLocationsTest.cpp
 RUN: %lldb -b -s %S/Inputs/VariablesLocationsTest.script -- %t.exe | FileCheck %s
 RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb -b -s %S/Inputs/VariablesLocationsTest.script -- %t.exe | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/PDB/vbases.test
+++ b/lldb/test/Shell/SymbolFile/PDB/vbases.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, lld
+REQUIRES: target-windows, lld
 RUN: %build --compiler=clang-cl --output=%t.exe %S/Inputs/VBases.cpp
 RUN: %lldb -b -s %S/Inputs/VBases.script -- %t.exe | FileCheck %s
 

--- a/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
+++ b/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
@@ -1,4 +1,4 @@
-# REQUIRES: system-windows
+# REQUIRES: target-windows
 
 # Checks that dependent modules preloaded by LLDB are not duplicated when the
 # process actually loads the DLL.

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -69,6 +69,9 @@ toolchain.use_support_substitutions(config)
 if re.match(r"^arm(hf.*-linux)|(.*-linux-gnuabihf)", config.target_triple):
     config.available_features.add("armhf-linux")
 
+if re.match(r".*-(windows|mingw32)", config.target_triple):
+    config.available_features.add("target-windows")
+
 if re.match(r".*-(windows-msvc)$", config.target_triple):
     config.available_features.add("windows-msvc")
 


### PR DESCRIPTION
Since the remote Shell test execution feature was added, these tests should now be disabled on Windows target instead of Windows host.

It should fix failures on https://lab.llvm.org/staging/#/builders/197/builds/76.