### PR TITLE
[lldb][test] Fix inline_sites_live.cpp Shell when run on Linux remotely from Windows

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
@@ -22,11 +22,11 @@ int main(int argc, char** argv) {
   foo(argc);
 }
 
-// CHECK:      * thread #1, stop reason = breakpoint 1
+// CHECK:      * thread #1, {{.*}}stop reason = breakpoint 1
 // CHECK-NEXT:    frame #0: {{.*}}`main [inlined] bar(param=2)
 // CHECK:      (lldb) expression param
 // CHECK-NEXT: (int) $0 = 2
-// CHECK:      * thread #1, stop reason = breakpoint 2
+// CHECK:      * thread #1, {{.*}}stop reason = breakpoint 2
 // CHECK-NEXT:    frame #0: {{.*}}`main [inlined] foo(param=1)
 // CHECK:      (lldb) expression param
 // CHECK-NEXT: (int) $1 = 1


### PR DESCRIPTION
This test fails on https://lab.llvm.org/staging/#/builders/197/builds/76/steps/18/logs/FAIL__lldb-shell__inline_sites_live_cpp because of a little difference in the lldb output.

```
# .---command stderr------------
# | C:\buildbot\as-builder-10\lldb-x-aarch64\llvm-project\lldb\test\Shell\SymbolFile\NativePDB\inline_sites_live.cpp:25:11: error: CHECK: expected string not found in input
# | // CHECK: * thread #1, stop reason = breakpoint 1
# |           ^
# | <stdin>:1:1: note: scanning from here
# | (lldb) platform select remote-linux
# | ^
# | <stdin>:28:27: note: possible intended match here
# | * thread #1, name = 'inline_sites_li', stop reason = breakpoint 1.3
# |                           ^
# | 

```