### PR TITLE
[llvm-debuginfo-analyzer] Add support for DW_AT_GNU_template_name.

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -369,6 +369,9 @@ void LVDWARFReader::processOneAttribute(const DWARFDie &Die,
   case dwarf::DW_AT_name:
     CurrentElement->setName(dwarf::toStringRef(FormValue));
     break;
+  case dwarf::DW_AT_GNU_template_name:
+    CurrentElement->setValue(dwarf::toStringRef(FormValue));
+    break;
   case dwarf::DW_AT_linkage_name:
   case dwarf::DW_AT_MIPS_linkage_name:
     CurrentElement->setLinkageName(dwarf::toStringRef(FormValue));

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_GNU_template_name.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_GNU_template_name.test
@@ -1,0 +1,60 @@
+; REQUIRES: x86-registered-target
+
+; For the given test case:
+
+;  1 // Template Template parameters.
+;  2 // Simple template class
+;  3 template <typename T> class Foo { T Member; };
+;  4
+;  5 // Template template class
+;  6 template <template <typename T> class TemplateType>
+;  7 class Bar {
+;  8   TemplateType<int> Int;
+;  9 };
+; 10
+; 11 template <template <template <typename> class> class TemplateTemplateType>
+; 12 class Baz {
+; 13   TemplateTemplateType<Foo> Foo;
+; 14 };
+; 15
+; 16 typedef Baz<Bar> Example;
+; 17
+; 18 Example TT;
+
+; The llvm-debuginfo-analyzer does not support the DW_AT_GNU_template_name
+; attribute. When using '--attribute=encoded' and the template argument is
+; another template, it will show:
+;   {Encoded} <>
+
+; The object file is generated using the following commands:
+;
+; clang++ -Xclang -disable-O0-optnone -Xclang -disable-llvm-passes
+;         -fno-discard-value-names -emit-llvm -S -g -O0
+;         DW_AT_GNU_template_name.cpp -o DW_AT_GNU_template_name.ll
+; llc --filetype=obj DW_AT_GNU_template_name.ll -o DW_AT_GNU_template_name.o
+;
+; llvm-debuginfo-analyzer --attribute=encoded --print=symbols
+;                         DW_AT_GNU_template_name.o
+
+; RUN: llc --filetype=obj \
+; RUN:     %p/Inputs/DW_AT_GNU_template_name.ll -o %t.DW_AT_GNU_template_name.o
+
+; RUN: llvm-debuginfo-analyzer --attribute=encoded \
+; RUN:                         --print=symbols \
+; RUN:                         %t.DW_AT_GNU_template_name.o 2>&1 | \
+; RUN: FileCheck --strict-whitespace %s
+
+; CHECK: Logical View:
+; CHECK:            {File} '{{.*}}dw_at_gnu_template_name.o'
+; CHECK-EMPTY:
+; CHECK:              {CompileUnit} 'dw_at_gnu_template_name.cpp'
+; CHECK:      3         {Class} 'Foo<int>'
+; CHECK:                  {Encoded} <int>
+; CHECK:      3           {Member} private 'Member' -> 'int'
+; CHECK:      7         {Class} 'Bar<Foo>'
+; CHECK:                  {Encoded} <Foo>
+; CHECK:      8           {Member} private 'Int' -> 'Foo<int>'
+; CHECK:     12         {Class} 'Baz<Bar>'
+; CHECK:                  {Encoded} <Bar>
+; CHECK:     13           {Member} private 'Foo' -> 'Bar<Foo>'
+; CHECK:     18         {Variable} extern 'TT' -> 'Example'

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_GNU_template_name.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_GNU_template_name.test
@@ -23,7 +23,7 @@
 
 ; The llvm-debuginfo-analyzer did not support the DW_AT_GNU_template_name
 ; attribute. When using '--attribute=encoded' and the template argument is
-; another template, it will show:
+; another template, it would show:
 ;   {Encoded} <>
 
 ; The object file is generated using the following commands:

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_GNU_template_name.test
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_GNU_template_name.test
@@ -21,7 +21,7 @@
 ; 17
 ; 18 Example TT;
 
-; The llvm-debuginfo-analyzer does not support the DW_AT_GNU_template_name
+; The llvm-debuginfo-analyzer did not support the DW_AT_GNU_template_name
 ; attribute. When using '--attribute=encoded' and the template argument is
 ; another template, it will show:
 ;   {Encoded} <>

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/Inputs/DW_AT_GNU_template_name.ll
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/Inputs/DW_AT_GNU_template_name.ll
@@ -1,0 +1,36 @@
+source_filename = "DW_AT_GNU_template_name.cpp"
+target triple = "x86_64-pc-linux-gnu"
+
+%class.Baz = type { %class.Bar }
+%class.Bar = type { %class.Foo }
+%class.Foo = type { i32 }
+
+@TT = dso_local global %class.Baz zeroinitializer, align 4, !dbg !0
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!22, !23}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "TT", scope: !2, file: !3, line: 18, type: !5, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !3, emissionKind: FullDebug, globals: !4)
+!3 = !DIFile(filename: "DW_AT_GNU_template_name.cpp", directory: "")
+!4 = !{!0}
+!5 = !DIDerivedType(tag: DW_TAG_typedef, name: "Example", file: !3, line: 16, baseType: !6)
+!6 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "Baz<Bar>", file: !3, line: 12, size: 32, flags: DIFlagTypePassByValue, elements: !7, templateParams: !20, identifier: "_ZTS3BazI3BarE")
+!7 = !{!8}
+!8 = !DIDerivedType(tag: DW_TAG_member, name: "Foo", scope: !6, file: !3, line: 13, baseType: !9, size: 32)
+!9 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "Bar<Foo>", file: !3, line: 7, size: 32, flags: DIFlagTypePassByValue, elements: !10, templateParams: !18, identifier: "_ZTS3BarI3FooE")
+!10 = !{!11}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "Int", scope: !9, file: !3, line: 8, baseType: !12, size: 32)
+!12 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "Foo<int>", file: !3, line: 3, size: 32, flags: DIFlagTypePassByValue, elements: !13, templateParams: !16, identifier: "_ZTS3FooIiE")
+!13 = !{!14}
+!14 = !DIDerivedType(tag: DW_TAG_member, name: "Member", scope: !12, file: !3, line: 3, baseType: !15, size: 32)
+!15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!16 = !{!17}
+!17 = !DITemplateTypeParameter(name: "T", type: !15)
+!18 = !{!19}
+!19 = !DITemplateValueParameter(tag: DW_TAG_GNU_template_template_param, name: "TemplateType", value: !"Foo")
+!20 = !{!21}
+!21 = !DITemplateValueParameter(tag: DW_TAG_GNU_template_template_param, name: "TemplateTemplateType", value: !"Bar")
+!22 = !{i32 7, !"Dwarf Version", i32 5}
+!23 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
For the given C++ code:
```
  template <typename T> class Foo { T Member; };

  template <template <typename T> class TemplateType>
  class Bar {
    TemplateType<int> Int;
  };

  template <template <template <typename> class> class TemplateTemplateType>
  class Baz {
    TemplateTemplateType<Foo> Foo;
  };

  typedef Baz<Bar> Example;
  Example TT;
```
The '--attribute=encoded' option, will produce the logical view:
```
  {Class} 'Foo<int>'
    {Encoded} <int>
  {Class} 'Bar<Foo>'
    {Encoded} <>                 <-- Missing the template argument info (Foo)
  {Class} 'Baz<Bar>'
    {Encoded} <>                 <-- Missing the template argument info (Bar)
```
When the template argument is another template it is not included in the {Encoded} field. The correct output should be:
```
  {Class} 'Foo<int>'
    {Encoded} <int>
  {Class} 'Bar<Foo>'
    {Encoded} <Foo>
  {Class} 'Baz<Bar>'
    {Encoded} <Bar>
```