### PR TITLE
[InstCombine][GitHub] Auto-add llvm:instcombine label (NFC)

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -605,6 +605,14 @@ llvm:transforms:
   - llvm/test/Transforms/**
   - llvm/unittests/Transforms/**
 
+llvm:instcombine:
+  - llvm/lib/Analysis/InstructionSimplify.cpp
+  - llvm/lib/Transforms/InstCombine/**
+  - llvm/include/llvm/Transforms/InstCombine/
+  - llvm/include/llvm/Analysis/InstructionSimplify.h
+  - llvm/test/Transforms/InstCombine/**
+  - llvm/test/Transforms/InstSimplify/**
+
 clangd:
   - clang-tools-extra/clangd/**
 


### PR DESCRIPTION
Add `llvm:instcombine` label to PRs touching InstCombine or InstSimplify. (We track InstSimplify issues under `llvm:instcombine` as well, so I added it here as well.)