### PR TITLE
[flang] fix possible iterator underflow

### DIFF
--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -415,12 +415,12 @@ auto SemanticsContext::SearchScopeIndex(parser::CharBlock source)
   if (!scopeIndex_.empty()) {
     auto iter{scopeIndex_.upper_bound(source)};
     auto begin{scopeIndex_.begin()};
-    do {
+    while (iter != begin) {
       --iter;
       if (iter->first.Contains(source)) {
         return iter;
       }
-    } while (iter != begin);
+    }
   }
   return scopeIndex_.end();
 }


### PR DESCRIPTION
Replaced do-while with while loop in SemanticsContext::SearchScopeIndex(parser::CharBlock source) to prevent iterator underflow when upper_bound returns begin(). This ensures the iterator check happens before decrementing.