### PR TITLE
[MLIR][Linalg] Fix unclosed code block which broke generated docs - NFC

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
@@ -561,7 +561,7 @@ def BroadcastOp : LinalgStructuredBase_Op<"broadcast", [
 def MatmulOp : LinalgStructuredBase_Op<"matmul", [
                AttrSizedOperandSegments,
                LinalgContractionOpInterface]> {
-    
+
   let summary = [{
     Performs a matrix multiplication of two 2D inputs without broadcast or transpose.
     }];
@@ -593,16 +593,17 @@ def MatmulOp : LinalgStructuredBase_Op<"matmul", [
                   ]
                   ins(%arg0, %arg1 : memref<3xf32>, memref<5x7xf32>)
                   outs(%arg2: memref<3x7xf32>)
-     ```
+    ```
 
-     Example Broadcast and transpose:
-     ```
-     linalg.matmul indexing_maps = [
-                       affine_map<(d0, d1, d2) -> (d2, d0)>, // transpose
-                       affine_map<(d0, d1, d2) -> (d2)>,     // broadcast
-                       affine_map<(d0, d1, d2) -> (d0, d1)>
-                     ]
-                     ins(%arg0, %arg1 : memref<5x3xf32>, memref<7xf32>) outs(%arg2: memref<3x7xf32>)
+    Example Broadcast and transpose:
+    ```
+    linalg.matmul indexing_maps = [
+                      affine_map<(d0, d1, d2) -> (d2, d0)>, // transpose
+                      affine_map<(d0, d1, d2) -> (d2)>,     // broadcast
+                      affine_map<(d0, d1, d2) -> (d0, d1)>
+                    ]
+                    ins(%arg0, %arg1 : memref<5x3xf32>, memref<7xf32>) outs(%arg2: memref<3x7xf32>)
+    ```
     }];
 
     let arguments = (ins


### PR DESCRIPTION
#115319 added a tablegen description for an op (MatmulOp) but missed closing one of the code blocks in the description. As a result the generated docs broke, i.e. https://mlir.llvm.org/docs/Dialects/Linalg was broken after this code block.