### PR TITLE
[MLIR][LLVM] Cleanup attr-dict printing (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -69,8 +69,7 @@ class LLVM_IntArithmeticOpWithOverflowFlag<string mnemonic, string instName,
     $res = op;
   }];
   let assemblyFormat = [{
-    $lhs `,` $rhs `` custom<OverflowFlags>($overflowFlags)
-    `` custom<LLVMOpAttrs>(attr-dict) `:` type($res)
+    $lhs `,` $rhs `` custom<OverflowFlags>($overflowFlags) attr-dict `:` type($res)
   }];
   string llvmBuilder =
     "$res = builder.Create" # instName #
@@ -88,7 +87,7 @@ class LLVM_IntArithmeticOpWithExactFlag<string mnemonic, string instName,
     $res = op;
   }];
   let assemblyFormat = [{
-    (`exact` $isExact^)? $lhs `,` $rhs custom<LLVMOpAttrs>(attr-dict) `:` type($res)
+    (`exact` $isExact^)? $lhs `,` $rhs attr-dict `:` type($res)
   }];
   string llvmBuilder =
     "$res = builder.Create" # instName #

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -140,15 +140,7 @@ static ParseResult parseLLVMOpAttrs(OpAsmParser &parser,
 static void printLLVMOpAttrs(OpAsmPrinter &printer, Operation *op,
                              DictionaryAttr attrs) {
   auto filteredAttrs = processFMFAttr(attrs.getValue());
-  if (auto iface = dyn_cast<IntegerOverflowFlagsInterface>(op)) {
-    printer.printOptionalAttrDict(
-        filteredAttrs, /*elidedAttrs=*/{iface.getOverflowFlagsAttrName()});
-  } else if (auto iface = dyn_cast<ExactFlagInterface>(op)) {
-    printer.printOptionalAttrDict(filteredAttrs,
-                                  /*elidedAttrs=*/{iface.getIsExactName()});
-  } else {
-    printer.printOptionalAttrDict(filteredAttrs);
-  }
+  printer.printOptionalAttrDict(filteredAttrs);
 }
 
 /// Verifies `symbol`'s use in `op` to ensure the symbol is a valid and


### PR DESCRIPTION
This commit simplifies the custom attribute dictionary printing and uses it only for printing ops that have fast math flags.