### PR TITLE
[libc] fix lfind entrypoints

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -26,9 +26,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     # errno.h entrypoints
     libc.src.errno.errno
 
-    # search.h entrypoints
-    libc.src.search.lfind
-
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp
     libc.src.setjmp.setjmp

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -26,9 +26,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     # errno.h entrypoints
     libc.src.errno.errno
 
-    # search.h entrypoints
-    libc.src.search.lfind
-
     # string.h entrypoints
     libc.src.string.bcmp
     libc.src.string.bcopy

--- a/libc/config/darwin/arm/entrypoints.txt
+++ b/libc/config/darwin/arm/entrypoints.txt
@@ -20,9 +20,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     # errno.h entrypoints
     libc.src.errno.errno
 
-    # search.h entrypoints
-    libc.src.search.lfind 
-
     # string.h entrypoints
     libc.src.string.bcmp
     libc.src.string.bcopy

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -20,9 +20,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     # errno.h entrypoints
     libc.src.errno.errno
 
-    # search.h entrypoints
-    libc.src.search.lfind  
-
     # string.h entrypoints
     libc.src.string.bcmp
     libc.src.string.bcopy
@@ -186,6 +183,9 @@ set(TARGET_LIBC_ENTRYPOINTS
 
 if(LLVM_LIBC_FULL_BUILD)
   list(APPEND TARGET_LIBC_ENTRYPOINTS
+    # search.h entrypoints
+    libc.src.search.lfind
+
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp
     libc.src.setjmp.setjmp

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -17,9 +17,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.ctype.tolower
     libc.src.ctype.toupper
 
-    # search.h entrypoints
-    libc.src.search.lfind
-
     # string.h entrypoints
     libc.src.string.bcmp
     libc.src.string.bcopy


### PR DESCRIPTION
- move arm entrypoint to fullbuild only
- remove baremetal entrypoints; we avoid POSIX on baremetal
- remove darwin/arm and windows entrypoints since these are untested

Fixes: #114692
