### PR TITLE
[libc++] Amend error message for _LIBCPP_HAS_THREAD_API_EXTERNAL

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -858,7 +858,7 @@ typedef __char32_t char32_t;
 #  endif
 
 #  if !_LIBCPP_HAS_THREADS && _LIBCPP_HAS_THREAD_API_EXTERNAL
-#    error _LIBCPP_HAS_THREAD_API_EXTERNAL may not be true when _LIBCPP_HAS_THREADS is true.
+#    error _LIBCPP_HAS_THREAD_API_EXTERNAL may only be true when _LIBCPP_HAS_THREADS is true.
 #  endif
 
 #  if !_LIBCPP_HAS_MONOTONIC_CLOCK && _LIBCPP_HAS_THREADS


### PR DESCRIPTION
Noticed this while debugging a few things following https://github.com/llvm/llvm-project/pull/112094. Amended error message to reflect conditional check.