### PR TITLE
[libc][bazel] config macros is a support library

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -53,7 +53,7 @@ config_setting(
 
 ################################## Base Config #################################
 
-cc_library(
+libc_support_library(
     name = "__support_macros_config",
     hdrs = ["src/__support/macros/config.h"],
 )


### PR DESCRIPTION
Previously __support_macros_config was a cc_library, but making it a
libc_support_library makes things cleaner.
