### PR TITLE
[libc++] Replace template structs with template variables in <ratio>

### DIFF
--- a/libcxx/include/__chrono/duration.h
+++ b/libcxx/include/__chrono/duration.h
@@ -159,14 +159,14 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration round(const duration<
 template <class _Rep, class _Period>
 class _LIBCPP_TEMPLATE_VIS duration {
   static_assert(!__is_duration<_Rep>::value, "A duration representation can not be a duration");
-  static_assert(__is_ratio<_Period>::value, "Second template parameter of duration must be a std::ratio");
+  static_assert(__is_ratio_v<_Period>, "Second template parameter of duration must be a std::ratio");
   static_assert(_Period::num > 0, "duration period must be positive");
 
   template <class _R1, class _R2>
   struct __no_overflow {
   private:
-    static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-    static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+    static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>;
+    static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>;
     static const intmax_t __n1        = _R1::num / __gcd_n1_n2;
     static const intmax_t __d1        = _R1::den / __gcd_d1_d2;
     static const intmax_t __n2        = _R2::num / __gcd_n1_n2;

--- a/libcxx/include/ratio
+++ b/libcxx/include/ratio
@@ -99,38 +99,26 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // __static_gcd
 
 template <intmax_t _Xp, intmax_t _Yp>
-struct __static_gcd {
-  static const intmax_t value = __static_gcd<_Yp, _Xp % _Yp>::value;
-};
+inline const intmax_t __static_gcd = __static_gcd<_Yp, _Xp % _Yp>;
 
 template <intmax_t _Xp>
-struct __static_gcd<_Xp, 0> {
-  static const intmax_t value = _Xp;
-};
+inline const intmax_t __static_gcd<_Xp, 0> = _Xp;
 
 template <>
-struct __static_gcd<0, 0> {
-  static const intmax_t value = 1;
-};
+inline const intmax_t __static_gcd<0, 0> = 1;
 
 // __static_lcm
 
 template <intmax_t _Xp, intmax_t _Yp>
-struct __static_lcm {
-  static const intmax_t value = _Xp / __static_gcd<_Xp, _Yp>::value * _Yp;
-};
+inline const intmax_t __static_lcm = _Xp / __static_gcd<_Xp, _Yp> * _Yp;
 
 template <intmax_t _Xp>
-struct __static_abs {
-  static const intmax_t value = _Xp < 0 ? -_Xp : _Xp;
-};
+inline const intmax_t __static_abs = _Xp < 0 ? -_Xp : _Xp;
 
 template <intmax_t _Xp>
-struct __static_sign {
-  static const intmax_t value = _Xp == 0 ? 0 : (_Xp < 0 ? -1 : 1);
-};
+inline const intmax_t __static_sign = _Xp == 0 ? 0 : (_Xp < 0 ? -1 : 1);
 
-template <intmax_t _Xp, intmax_t _Yp, intmax_t = __static_sign<_Yp>::value>
+template <intmax_t _Xp, intmax_t _Yp, intmax_t = __static_sign<_Yp> >
 class __ll_add;
 
 template <intmax_t _Xp, intmax_t _Yp>
@@ -161,7 +149,7 @@ public:
   static const intmax_t value = _Xp + _Yp;
 };
 
-template <intmax_t _Xp, intmax_t _Yp, intmax_t = __static_sign<_Yp>::value>
+template <intmax_t _Xp, intmax_t _Yp, intmax_t = __static_sign<_Yp> >
 class __ll_sub;
 
 template <intmax_t _Xp, intmax_t _Yp>
@@ -197,8 +185,8 @@ class __ll_mul {
   static const intmax_t nan   = (1LL << (sizeof(intmax_t) * CHAR_BIT - 1));
   static const intmax_t min   = nan + 1;
   static const intmax_t max   = -min;
-  static const intmax_t __a_x = __static_abs<_Xp>::value;
-  static const intmax_t __a_y = __static_abs<_Yp>::value;
+  static const intmax_t __a_x = __static_abs<_Xp>;
+  static const intmax_t __a_y = __static_abs<_Yp>;
 
   static_assert(_Xp != nan && _Yp != nan && __a_x <= max / __a_y, "overflow in __ll_mul");
 
@@ -239,13 +227,13 @@ public:
 
 template <intmax_t _Num, intmax_t _Den = 1>
 class _LIBCPP_TEMPLATE_VIS ratio {
-  static_assert(__static_abs<_Num>::value >= 0, "ratio numerator is out of range");
+  static_assert(__static_abs<_Num> >= 0, "ratio numerator is out of range");
   static_assert(_Den != 0, "ratio divide by 0");
-  static_assert(__static_abs<_Den>::value > 0, "ratio denominator is out of range");
-  static _LIBCPP_CONSTEXPR const intmax_t __na  = __static_abs<_Num>::value;
-  static _LIBCPP_CONSTEXPR const intmax_t __da  = __static_abs<_Den>::value;
-  static _LIBCPP_CONSTEXPR const intmax_t __s   = __static_sign<_Num>::value * __static_sign<_Den>::value;
-  static _LIBCPP_CONSTEXPR const intmax_t __gcd = __static_gcd<__na, __da>::value;
+  static_assert(__static_abs<_Den> > 0, "ratio denominator is out of range");
+  static _LIBCPP_CONSTEXPR const intmax_t __na  = __static_abs<_Num>;
+  static _LIBCPP_CONSTEXPR const intmax_t __da  = __static_abs<_Den>;
+  static _LIBCPP_CONSTEXPR const intmax_t __s   = __static_sign<_Num> * __static_sign<_Den>;
+  static _LIBCPP_CONSTEXPR const intmax_t __gcd = __static_gcd<__na, __da>;
 
 public:
   static _LIBCPP_CONSTEXPR const intmax_t num = __s * __na / __gcd;
@@ -261,9 +249,10 @@ template <intmax_t _Num, intmax_t _Den>
 _LIBCPP_CONSTEXPR const intmax_t ratio<_Num, _Den>::den;
 
 template <class _Tp>
-struct __is_ratio : false_type {};
+inline const bool __is_ratio_v = false;
+
 template <intmax_t _Num, intmax_t _Den>
-struct __is_ratio<ratio<_Num, _Den> > : true_type {};
+inline const bool __is_ratio_v<ratio<_Num, _Den> > = true;
 
 typedef ratio<1LL, 1000000000000000000LL> atto;
 typedef ratio<1LL, 1000000000000000LL> femto;
@@ -285,11 +274,11 @@ typedef ratio<1000000000000000000LL, 1LL> exa;
 template <class _R1, class _R2>
 struct __ratio_multiply {
 private:
-  static const intmax_t __gcd_n1_d2 = __static_gcd<_R1::num, _R2::den>::value;
-  static const intmax_t __gcd_d1_n2 = __static_gcd<_R1::den, _R2::num>::value;
+  static const intmax_t __gcd_n1_d2 = __static_gcd<_R1::num, _R2::den>;
+  static const intmax_t __gcd_d1_n2 = __static_gcd<_R1::den, _R2::num>;
 
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 
 public:
   typedef typename ratio< __ll_mul<_R1::num / __gcd_n1_d2, _R2::num / __gcd_d1_n2>::value,
@@ -311,11 +300,11 @@ struct _LIBCPP_TEMPLATE_VIS ratio_multiply : public __ratio_multiply<_R1, _R2>::
 template <class _R1, class _R2>
 struct __ratio_divide {
 private:
-  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>;
+  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>;
 
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 
 public:
   typedef typename ratio< __ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
@@ -337,11 +326,11 @@ struct _LIBCPP_TEMPLATE_VIS ratio_divide : public __ratio_divide<_R1, _R2>::type
 template <class _R1, class _R2>
 struct __ratio_add {
 private:
-  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>;
+  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>;
 
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 
 public:
   typedef typename ratio_multiply<
@@ -366,11 +355,11 @@ struct _LIBCPP_TEMPLATE_VIS ratio_add : public __ratio_add<_R1, _R2>::type {};
 template <class _R1, class _R2>
 struct __ratio_subtract {
 private:
-  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>;
+  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>;
 
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 
 public:
   typedef typename ratio_multiply<
@@ -396,14 +385,14 @@ struct _LIBCPP_TEMPLATE_VIS ratio_subtract : public __ratio_subtract<_R1, _R2>::
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_equal : _BoolConstant<(_R1::num == _R2::num && _R1::den == _R2::den)> {
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_not_equal : _BoolConstant<!ratio_equal<_R1, _R2>::value> {
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 // ratio_less
@@ -439,10 +428,7 @@ struct __ratio_less1<_R1, _R2, _Odd, _Qp, _M1, _Qp, _M2> {
   static const bool value = __ratio_less1<ratio<_R1::den, _M1>, ratio<_R2::den, _M2>, !_Odd>::value;
 };
 
-template <class _R1,
-          class _R2,
-          intmax_t _S1 = __static_sign<_R1::num>::value,
-          intmax_t _S2 = __static_sign<_R2::num>::value>
+template <class _R1, class _R2, intmax_t _S1 = __static_sign<_R1::num>, intmax_t _S2 = __static_sign<_R2::num> >
 struct __ratio_less {
   static const bool value = _S1 < _S2;
 };
@@ -459,31 +445,31 @@ struct __ratio_less<_R1, _R2, -1LL, -1LL> {
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_less : _BoolConstant<__ratio_less<_R1, _R2>::value> {
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_less_equal : _BoolConstant<!ratio_less<_R2, _R1>::value> {
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_greater : _BoolConstant<ratio_less<_R2, _R1>::value> {
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_greater_equal : _BoolConstant<!ratio_less<_R1, _R2>::value> {
-  static_assert(__is_ratio<_R1>::value, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
-  static_assert(__is_ratio<_R2>::value, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
+  static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
 struct __ratio_gcd {
-  typedef ratio<__static_gcd<_R1::num, _R2::num>::value, __static_lcm<_R1::den, _R2::den>::value> type;
+  typedef ratio<__static_gcd<_R1::num, _R2::num>, __static_lcm<_R1::den, _R2::den> > type;
 };
 
 #if _LIBCPP_STD_VER >= 17


### PR DESCRIPTION
This avoids a bit of boilerplate.
