### PR TITLE
[libcxx] [ci] Test mingw environments with msvcrt.dll, too

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -250,10 +250,11 @@ jobs:
         - { config: clang-cl-no-vcruntime, mingw: false }
         - { config: clang-cl-debug, mingw: false }
         - { config: clang-cl-static-crt, mingw: false }
-        - { config: mingw-dll, mingw: true }
-        - { config: mingw-static, mingw: true }
-        - { config: mingw-dll-i686, mingw: true }
-        - { config: mingw-incomplete-sysroot, mingw: true }
+        - { config: mingw-dll, mingw: true, crt: ucrt }
+        - { config: mingw-static, mingw: true, crt: ucrt }
+        - { config: mingw-dll-i686, mingw: true, crt: ucrt }
+        - { config: mingw-incomplete-sysroot, mingw: true, crt: ucrt }
+        - { config: mingw-msvcrt, mingw: true, crt: msvcrt }
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -267,7 +268,7 @@ jobs:
       - name: Install llvm-mingw
         if: ${{ matrix.mingw == true }}
         run: |
-          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20240606/llvm-mingw-20240606-ucrt-x86_64.zip
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20240606/llvm-mingw-20240606-${{matrix.crt}}-x86_64.zip
           powershell Expand-Archive llvm-mingw*.zip -DestinationPath .
           del llvm-mingw*.zip
           mv llvm-mingw* c:\llvm-mingw

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -772,6 +772,15 @@ mingw-incomplete-sysroot)
     step "Building the runtimes"
     ${NINJA} -vC "${BUILD_DIR}"
 ;;
+mingw-msvcrt)
+    # All tests don't pass in msvcrt based configurations (and we don't have
+    # the right XFAIL markings for it yet), thus initially only test building.
+    clean
+    generate-cmake \
+          -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake"
+    step "Building the runtimes"
+    ${NINJA} -vC "${BUILD_DIR}"
+;;
 aix)
     clean
     generate-cmake -C "${MONOREPO_ROOT}/libcxx/cmake/caches/AIX.cmake" \


### PR DESCRIPTION
On Windows, there are many alternative C runtimes that a process can use; the modern default choice is UCRT, which is what we use and test so far.

MinGW toolchains can also use msvcrt.dll, which traditionally was the default within MinGW environments, while UCRT is the new default.

msvcrt.dll is a much less featureful C runtime than UCRT; a number of things don't work quite as they should (in particular, locales are essentially entirely broken within msvcrt.dll).

Each release of llvm-mingw is built targeting both UCRT and msvcrt.dll; therefore, it is valuable to test libcxx upstream with this configuration as well. In most cases, both C runtime choices use the exact same codepaths, but we have one ifdef regarding this, see the current handling of strftime_l in
src/support/win32/locale_win32.cpp. This adds build test coverage of this piece of code.

As a number of tests fail in this configuration, only test building libcxx in this configuration for now. After adding suitable XFAILs, we can enable running the tests as well.