### PR TITLE
[flang] Fix typo in `CustomIntrinsicCall.h` (NFC)

### DIFF
--- a/flang/include/flang/Lower/CustomIntrinsicCall.h
+++ b/flang/include/flang/Lower/CustomIntrinsicCall.h
@@ -98,7 +98,7 @@ lowerCustomIntrinsic(fir::FirOpBuilder &builder, mlir::Location loc,
                      const OperandGetter &getOperand, std::size_t numOperands,
                      Fortran::lower::StatementContext &stmtCtx);
 
-/// DEPRICATED: NEW CODE SHOULD USE THE VERSION OF genIntrinsicCall WITHOUT A
+/// DEPRECATED: NEW CODE SHOULD USE THE VERSION OF genIntrinsicCall WITHOUT A
 /// StatementContext, DECLARED IN IntrinsicCall.h
 /// Generate the FIR+MLIR operations for the generic intrinsic \p name
 /// with argument \p args and expected result type \p resultType.


### PR DESCRIPTION
Fix typo in `CustomIntrinsicCall.h`.


NOTE: This PR is a way for me to test my new commit access! Please let me merge this pull request in after it has been approved.