### PR TITLE
[codegen] Fix crash in codegen caused by pointer calculation overflow

### DIFF
--- a/clang/test/CodeGen/ubsan-emit-bounds-check-crash-msp.c
+++ b/clang/test/CodeGen/ubsan-emit-bounds-check-crash-msp.c
@@ -1,0 +1,7 @@
+// REQUIRES: msp430-registered-target
+// RUN: %clang -c -fsanitize=undefined -Wno-tentative-definition-array -Wno-return-type -Wno-unused-value -Wno-array-bounds -Xclang -verify --target=msp430-- %s
+int a;
+_Complex double b[1][1];
+void c(void) {
+  b[a][8920]; // expected-error {{Expression caused pointer calculation overflow during code generation}}
+}

--- a/clang/test/CodeGen/ubsan-emit-bounds-check-crash-x86.c
+++ b/clang/test/CodeGen/ubsan-emit-bounds-check-crash-x86.c
@@ -1,0 +1,7 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang -c -Wno-tentative-definition-array -Wno-return-type -Wno-unused-value -Wno-array-bounds -Xclang -verify --target=x86_64-- -fsanitize=undefined %s 
+int **a[];
+int main() {
+  (*a)[3300220222222200000]; // expected-error {{Expression caused pointer calculation overflow during code generation}}
+  return 0;
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/48168

This crash was found by internal randomized testing. Under certain conditions, the front end does not detect a possible overflow address calculations until codegen. This change emits a warning instead of allowing the compiler to crash.

```
clang: <root>/clang/lib/CodeGen/CGExprScalar.cpp:5834: llvm::Value* clang::CodeGen::CodeGenFunction::EmitCheckedInBoundsGEP(
    llvm::Type*, llvm::Value*, llvm::ArrayRef<llvm::Value*>, bool, bool, clang::SourceLocation, const llvm::Twine&):
    Assertion `(!isa<llvm::Constant>(EvaluatedGEP.TotalOffset) || EvaluatedGEP.OffsetOverflows == Builder.getFalse())
    && "If the offset got constant-folded, we don't expect that there was an " "overflow."' failed.

0.      Program arguments: clang -c --target=x86_64-- -fsanitize=undefined ubsan-emit-bounds-check-crash-x86.c
1.      <eof> parser at end of file
2.      ubsan-emit-bounds-check-crash-x86.c:4:5: LLVM IR generation of declaration 'main'
3.      ubsan-emit-bounds-check-crash-x86.c:4:5: Generating code for declaration 'main'
...
 #9 <addr> clang::CodeGen::CodeGenFunction::EmitCheckedInBoundsGEP(clang::CodeGen::Address,
             llvm::ArrayRef<llvm::Value*>, llvm::Type*, bool, bool, clang::SourceLocation,
             clang::CharUnits, llvm::Twine const&)
             llvm::ArrayRef<llvm::Value*>, clang::QualType, bool, bool, clang::SourceLocation,
             clang::QualType*, clang::Expr const*, llvm::Twine const&) CGExpr.cpp:0:0
             bool)
```