### PR TITLE
[libc][stdfix] disable ulkbits on riscv (#115781)

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -729,7 +729,7 @@ if(LIBC_COMPILER_HAS_FIXED_POINT)
     libc.src.stdfix.ukbits
     # TODO: https://github.com/llvm/llvm-project/issues/115778
     # libc.src.stdfix.lkbits
-    libc.src.stdfix.ulkbits
+    # libc.src.stdfix.ulkbits
   )
 endif()
 


### PR DESCRIPTION
I should have disabled this in #115781. Mea culpa.

Link: #114912
Link: #115778
Link: #115781
