### PR TITLE
Revert "Reapply "[libc++abi] Stop copying headers to the build directory""

### DIFF
--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -86,6 +86,12 @@ set(LIBCXXABI_STATIC_OUTPUT_NAME "c++abi" CACHE STRING "Output name for the stat
 
 set(LIBCXXABI_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/c++/v1" CACHE STRING "Path to install the libc++abi headers at.")
 
+if(LLVM_LIBRARY_OUTPUT_INTDIR)
+  set(LIBCXXABI_GENERATED_INCLUDE_DIR "${LLVM_BINARY_DIR}/include/c++/v1")
+else()
+  set(LIBCXXABI_GENERATED_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include/c++/v1")
+endif()
+
 set(LIBCXXABI_LIBCXX_LIBRARY_PATH "" CACHE PATH "The path to libc++ library.")
 set(LIBCXXABI_LIBRARY_VERSION "1.0" CACHE STRING
 "Version of libc++abi. This will be reflected in the name of the shared \

--- a/libcxxabi/include/CMakeLists.txt
+++ b/libcxxabi/include/CMakeLists.txt
@@ -3,7 +3,20 @@ set(files
   cxxabi.h
   )
 
+foreach(f ${files})
+  set(src "${CMAKE_CURRENT_SOURCE_DIR}/${f}")
+  set(dst "${LIBCXXABI_GENERATED_INCLUDE_DIR}/${f}")
+  add_custom_command(OUTPUT ${dst}
+    DEPENDS ${src}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+    COMMENT "Copying CXXABI header ${f}")
+  list(APPEND _all_includes "${dst}")
+endforeach()
+
+add_custom_target(generate-cxxabi-headers ALL DEPENDS ${_all_includes})
+
 add_library(cxxabi-headers INTERFACE)
+add_dependencies(cxxabi-headers generate-cxxabi-headers)
 target_include_directories(cxxabi-headers INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (LIBCXXABI_INSTALL_HEADERS)


### PR DESCRIPTION
Reverts llvm/llvm-project#115379

Reverting since this broke the Fuchsia builders.