### PR TITLE
[-Wunsafe-buffer-usage] Fix false positives in warning againt 2-parameter std::span constructor

### DIFF
--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct.cpp
@@ -21,6 +21,12 @@ namespace std {
 
   template< class T >
   T&& move( T&& t ) noexcept;
+
+  template <class _Tp>
+  _Tp* addressof(_Tp& __x) {
+    return &__x;
+  }
+ 
 }
 
 namespace irrelevant_constructors {
@@ -74,15 +80,26 @@ namespace construct_wt_ptr_size {
     return std::span<int>{p, 10};                    // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
   }
 
+  // addressof method defined outside std namespace.
+  template <class _Tp>
+  _Tp* addressof(_Tp& __x) {
+    return &__x;
+  }
+
   void notWarnSafeCases(unsigned n, int *p) {
     int X;
     unsigned Y = 10;
     std::span<int> S = std::span{&X, 1}; // no-warning
+    S = std::span{std::addressof(X), 1}; // no-warning
     int Arr[10];
     typedef int TenInts_t[10];
     TenInts_t Arr2;
 
     S = std::span{&X, 2};                // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+    S = std::span{std::addressof(X), 2}; // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+    // Warn when a non std method also named addressof
+    S = std::span{addressof(X), 1}; // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+
     S = std::span{new int[10], 10};      // no-warning
     S = std::span{new int[n], n};        // no-warning
     S = std::span{new int, 1};           // no-warning


### PR DESCRIPTION
Do not warn when two parameter constructor receives pointer address from a std::addressof method and the span size is set to 1.

(rdar://139298119)