### PR TITLE
[libc] {u}lkbits broken on riscv32

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -728,8 +728,8 @@ if(LIBC_COMPILER_HAS_FIXED_POINT)
     libc.src.stdfix.kbits
     libc.src.stdfix.ukbits
     # TODO: https://github.com/llvm/llvm-project/issues/115778
-    # libc.src.stdfix.lkbits
-    # libc.src.stdfix.ulkbits
+    libc.src.stdfix.lkbits
+    libc.src.stdfix.ulkbits
   )
 endif()
 

--- a/libc/include/llvm-libc-types/stdfix-types.h
+++ b/libc/include/llvm-libc-types/stdfix-types.h
@@ -14,12 +14,12 @@ typedef signed short int int_r_t;
 typedef signed int int_lr_t;
 typedef signed short int_hk_t;
 typedef signed int int_k_t;
-typedef signed long int_lk_t;
+typedef signed long long int_lk_t;
 typedef unsigned char uint_uhr_t;
 typedef unsigned short int uint_ur_t;
 typedef unsigned int uint_ulr_t;
 typedef unsigned short int uint_uhk_t;
 typedef unsigned int uint_uk_t;
-typedef unsigned long uint_ulk_t;
+typedef unsigned long long uint_ulk_t;
 
 #endif // LLVM_LIBC_TYPES_STDFIX_TYPES_H


### PR DESCRIPTION
- Re-enabled ulkbits and lkbits for Risc-V
- Bumped `int_lk_t` to a `signed long long` and a `uint_ulk_t` to an `unsigned long long` to guarantee they both fit in 8 bytes, which `long _Accum` and `unsigned long _Accum` are defaulted to on 32bit architectures.

This is probably inconvenient on systems that have a word size larger than 64 bits?

#115778