### PR TITLE
[ByteCode] Migrate away from PointerUnion::{is,get,dyn_cast} (NFC)

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.h
+++ b/clang/lib/AST/ByteCode/Descriptor.h
@@ -201,8 +201,8 @@ public:
   SourceLocation getLocation() const;
   SourceInfo getLoc() const;
 
-  const Decl *asDecl() const { return Source.dyn_cast<const Decl *>(); }
-  const Expr *asExpr() const { return Source.dyn_cast<const Expr *>(); }
+  const Decl *asDecl() const { return dyn_cast<const Decl *>(Source); }
+  const Expr *asExpr() const { return dyn_cast<const Expr *>(Source); }
   const DeclTy &getSource() const { return Source; }
 
   const ValueDecl *asValueDecl() const {

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -94,10 +94,10 @@ public:
 
   /// Returns the original FunctionDecl.
   const FunctionDecl *getDecl() const {
-    return Source.dyn_cast<const FunctionDecl *>();
+    return dyn_cast<const FunctionDecl *>(Source);
   }
   const BlockExpr *getExpr() const {
-    return Source.dyn_cast<const BlockExpr *>();
+    return dyn_cast<const BlockExpr *>(Source);
   }
 
   /// Returns the name of the function decl this code
@@ -146,18 +146,18 @@ public:
   /// Checks if the function is a constructor.
   bool isConstructor() const {
     return isa_and_nonnull<CXXConstructorDecl>(
-        Source.dyn_cast<const FunctionDecl *>());
+        dyn_cast<const FunctionDecl *>(Source));
   }
   /// Checks if the function is a destructor.
   bool isDestructor() const {
     return isa_and_nonnull<CXXDestructorDecl>(
-        Source.dyn_cast<const FunctionDecl *>());
+        dyn_cast<const FunctionDecl *>(Source));
   }
 
   /// Returns the parent record decl, if any.
   const CXXRecordDecl *getParentDecl() const {
     if (const auto *MD = dyn_cast_if_present<CXXMethodDecl>(
-            Source.dyn_cast<const FunctionDecl *>()))
+            dyn_cast<const FunctionDecl *>(Source)))
       return MD->getParent();
     return nullptr;
   }
@@ -166,7 +166,7 @@ public:
   /// which we generate custom byte code for.
   bool isLambdaStaticInvoker() const {
     if (const auto *MD = dyn_cast_if_present<CXXMethodDecl>(
-            Source.dyn_cast<const FunctionDecl *>()))
+            dyn_cast<const FunctionDecl *>(Source)))
       return MD->isLambdaStaticInvoker();
     return false;
   }
@@ -175,7 +175,7 @@ public:
   /// of a lambda record decl.
   bool isLambdaCallOperator() const {
     if (const auto *MD = dyn_cast_if_present<CXXMethodDecl>(
-            Source.dyn_cast<const FunctionDecl *>()))
+            dyn_cast<const FunctionDecl *>(Source)))
       return clang::isLambdaCallOperator(MD);
     return false;
   }

--- a/clang/lib/AST/ByteCode/Source.cpp
+++ b/clang/lib/AST/ByteCode/Source.cpp
@@ -33,7 +33,7 @@ SourceRange SourceInfo::getRange() const {
 }
 
 const Expr *SourceInfo::asExpr() const {
-  if (const auto *S = Source.dyn_cast<const Stmt *>())
+  if (const auto *S = dyn_cast<const Stmt *>(Source))
     return dyn_cast<Expr>(S);
   return nullptr;
 }

--- a/clang/lib/AST/ByteCode/Source.h
+++ b/clang/lib/AST/ByteCode/Source.h
@@ -83,8 +83,8 @@ public:
   SourceLocation getLoc() const;
   SourceRange getRange() const;
 
-  const Stmt *asStmt() const { return Source.dyn_cast<const Stmt *>(); }
-  const Decl *asDecl() const { return Source.dyn_cast<const Decl *>(); }
+  const Stmt *asStmt() const { return dyn_cast<const Stmt *>(Source); }
+  const Decl *asDecl() const { return dyn_cast<const Decl *>(Source); }
   const Expr *asExpr() const;
 
   operator bool() const { return !Source.isNull(); }


### PR DESCRIPTION
Note that PointerUnion::{is,get,dyn_cast} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>
