### PR TITLE
[llvm] Remove `br i1 undef` from regression tests

### DIFF
--- a/llvm/test/Transforms/GVN/2011-04-27-phioperands.ll
+++ b/llvm/test/Transforms/GVN/2011-04-27-phioperands.ll
@@ -4,12 +4,12 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 
 @nuls = external global [10 x i8]
 
-define fastcc void @p_ere() nounwind {
+define fastcc void @p_ere(i1 %arg) nounwind {
 entry:
   br label %"<bb 5>"
 
 "<L18>.i":
-  br i1 undef, label %"<bb 3>.i30.i", label %doemit.exit51.i
+  br i1 %arg, label %"<bb 3>.i30.i", label %doemit.exit51.i
 
 "<bb 3>.i30.i":
   unreachable
@@ -18,7 +18,7 @@ doemit.exit51.i:
   br label %"<bb 53>.i"
 
 "<L19>.i":
-  br i1 undef, label %"<bb 3>.i55.i", label %doemit.exit76.i
+  br i1 %arg, label %"<bb 3>.i55.i", label %doemit.exit76.i
 
 "<bb 3>.i55.i":
   unreachable
@@ -34,7 +34,7 @@ doemit.exit76.i:
   br label %"<bb 53>.i"
 
 "<L24>.i":
-  br i1 undef, label %"<bb 53>.i", label %"<bb 35>.i"
+  br i1 %arg, label %"<bb 53>.i", label %"<bb 35>.i"
 
 "<bb 35>.i":
   br label %"<bb 53>.i"
@@ -51,13 +51,13 @@ doemit.exit76.i:
 "<bb 53>.i":
   %wascaret_2.i = phi i32 [ 0, %"<L39>.i" ], [ 0, %"<L29>.i" ], [ 0, %"<L28>.i" ], [ 0, %"<bb 35>.i" ], [ 0, %"<L99>.i" ], [ 0, %"<L98>.i" ], [ 0, %doemit.exit76.i ], [ 1, %doemit.exit51.i ], [ 0, %"<L24>.i" ]
   %D.5496_84.i = load ptr, ptr undef, align 8
-  br i1 undef, label %"<bb 54>.i", label %"<bb 5>"
+  br i1 %arg, label %"<bb 54>.i", label %"<bb 5>"
 
 "<bb 54>.i":
-  br i1 undef, label %"<bb 5>", label %"<bb 58>.i"
+  br i1 %arg, label %"<bb 5>", label %"<bb 58>.i"
 
 "<bb 58>.i":
-  br i1 undef, label %"<bb 64>.i", label %"<bb 59>.i"
+  br i1 %arg, label %"<bb 64>.i", label %"<bb 59>.i"
 
 "<bb 59>.i":
   br label %"<bb 64>.i"
@@ -71,7 +71,7 @@ doemit.exit76.i:
   ]
 
 "<L54>.i":
-  br i1 undef, label %"<bb 3>.i105.i", label %doemit.exit127.i
+  br i1 %arg, label %"<bb 3>.i105.i", label %doemit.exit127.i
 
 "<bb 3>.i105.i":
   unreachable
@@ -80,7 +80,7 @@ doemit.exit127.i:
   unreachable
 
 "<L55>.i":
-  br i1 undef, label %"<bb 3>.i157.i", label %"<bb 5>"
+  br i1 %arg, label %"<bb 3>.i157.i", label %"<bb 5>"
 
 "<bb 3>.i157.i":
   unreachable

--- a/llvm/test/Transforms/GVN/2012-05-22-PreCrash.ll
+++ b/llvm/test/Transforms/GVN/2012-05-22-PreCrash.ll
@@ -1,9 +1,9 @@
 ; RUN: opt < %s -passes=gvn
 ; PR12858
 
-define void @fn5(i16 signext %p1, i8 signext %p2) nounwind uwtable {
+define void @fn5(i16 signext %p1, i8 signext %p2, i1 %arg) nounwind uwtable {
 entry:
-  br i1 undef, label %if.else, label %if.then
+  br i1 %arg, label %if.else, label %if.then
 
 if.then:                                          ; preds = %entry
   br label %if.end
@@ -14,7 +14,7 @@ if.else:                                          ; preds = %entry
 
 if.end:                                           ; preds = %if.else, %if.then
   %conv1 = sext i16 %p1 to i32
-  br i1 undef, label %if.then3, label %if.else4
+  br i1 %arg, label %if.then3, label %if.else4
 
 if.then3:                                         ; preds = %if.end
   br label %if.end12

--- a/llvm/test/Transforms/GVN/PRE/phi-translate-2.ll
+++ b/llvm/test/Transforms/GVN/PRE/phi-translate-2.ll
@@ -251,7 +251,7 @@ if.end3:                                          ; preds = %if.then2, %if.else,
 ; Here the load from arrayidx1 is partially redundant, but its value is
 ; available in if.then. Check that we correctly phi-translate to the phi that
 ; the load has been replaced with.
-define void @test6(ptr %ptr) {
+define void @test6(ptr %ptr, i1 %arg) {
 ; CHECK-LABEL: @test6(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[ARRAYIDX1_PHI_TRANS_INSERT:%.*]] = getelementptr inbounds i32, ptr [[PTR:%.*]], i64 1
@@ -272,7 +272,7 @@ define void @test6(ptr %ptr) {
 ; CHECK-NEXT:    br label [[IF_END]]
 ; CHECK:       if.end:
 ; CHECK-NEXT:    [[TMP2]] = phi i32 [ [[TMP0]], [[IF_THEN]] ], [ [[TMP1]], [[WHILE]] ]
-; CHECK-NEXT:    br i1 undef, label [[WHILE_END:%.*]], label [[WHILE]]
+; CHECK-NEXT:    br i1 %arg, label [[WHILE_END:%.*]], label [[WHILE]]
 ; CHECK:       while.end:
 ; CHECK-NEXT:    ret void
 ;
@@ -295,7 +295,7 @@ if.then:
   br label %if.end
 
 if.end:
-  br i1 undef, label %while.end, label %while
+  br i1 %arg, label %while.end, label %while
 
 while.end:
   ret void

--- a/llvm/test/Transforms/GVN/PRE/pre-loop-load-new-pm.ll
+++ b/llvm/test/Transforms/GVN/PRE/pre-loop-load-new-pm.ll
@@ -432,7 +432,7 @@ cold_exit:
 }
 
 ; TODO: PRE via splittinga backedge in the cold loop. Make sure we don't insert a load into an inner loop.
-define i32 @test_inner_loop(ptr %p) {
+define i32 @test_inner_loop(ptr %p, i1 %arg) {
 ; CHECK-LABEL: @test_inner_loop(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
@@ -447,7 +447,7 @@ define i32 @test_inner_loop(ptr %p) {
 ; CHECK-NEXT:    br label [[INNER_LOOP:%.*]]
 ; CHECK:       inner_loop:
 ; CHECK-NEXT:    call void @side_effect()
-; CHECK-NEXT:    br i1 undef, label [[INNER_LOOP]], label [[BACKEDGE]]
+; CHECK-NEXT:    br i1 %arg, label [[INNER_LOOP]], label [[BACKEDGE]]
 ; CHECK:       backedge:
 ; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], [[X]]
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
@@ -472,7 +472,7 @@ cold_path:
 
 inner_loop:
   call void @side_effect()
-  br i1 undef, label %inner_loop, label %backedge
+  br i1 %arg, label %inner_loop, label %backedge
 
 backedge:
   %iv.next = add i32 %iv, %x

--- a/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
+++ b/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
@@ -636,7 +636,7 @@ cold_exit:
 }
 
 ; TODO: PRE via splittinga backedge in the cold loop. Make sure we don't insert a load into an inner loop.
-define i32 @test_inner_loop(ptr %p) {
+define i32 @test_inner_loop(ptr %p, i1 %arg) {
 ; CHECK-LABEL: @test_inner_loop(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
@@ -651,7 +651,7 @@ define i32 @test_inner_loop(ptr %p) {
 ; CHECK-NEXT:    br label [[INNER_LOOP:%.*]]
 ; CHECK:       inner_loop:
 ; CHECK-NEXT:    call void @side_effect() #[[ATTR0]]
-; CHECK-NEXT:    br i1 undef, label [[INNER_LOOP]], label [[BACKEDGE]]
+; CHECK-NEXT:    br i1 %arg, label [[INNER_LOOP]], label [[BACKEDGE]]
 ; CHECK:       backedge:
 ; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], [[X]]
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
@@ -676,7 +676,7 @@ cold_path:
 
 inner_loop:
   call void @side_effect() nofree
-  br i1 undef, label %inner_loop, label %backedge
+  br i1 %arg, label %inner_loop, label %backedge
 
 backedge:
   %iv.next = add i32 %iv, %x

--- a/llvm/test/Transforms/GVN/PRE/preserve-tbaa.ll
+++ b/llvm/test/Transforms/GVN/PRE/preserve-tbaa.ll
@@ -7,9 +7,9 @@ target datalayout = "e-p:64:64:64"
 ; CHECK-LABEL: @test(
 ; CHECK: %tmp33.pre = load i16, ptr %P, align 2, !tbaa !0
 ; CHECK: br label %for.body
-define void @test(ptr %P, ptr %Q) nounwind {
+define void @test(ptr %P, ptr %Q, i1 %arg) nounwind {
 entry:
-  br i1 undef, label %bb.nph, label %for.end
+  br i1 %arg, label %bb.nph, label %for.end
 
 bb.nph:                                           ; preds = %entry
   br label %for.body

--- a/llvm/test/Transforms/GVN/crash.ll
+++ b/llvm/test/Transforms/GVN/crash.ll
@@ -5,9 +5,9 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-apple-darwin10.0"
 
-define ptr @test1(ptr %name, i32 %namelen, ptr %o, i32 %expected_type) nounwind ssp {
+define ptr @test1(ptr %name, i32 %namelen, ptr %o, i32 %expected_type, i1 %arg) nounwind ssp {
 entry:
-  br i1 undef, label %if.end13, label %while.body.preheader
+  br i1 %arg, label %if.end13, label %while.body.preheader
 
 
 if.end13:                                         ; preds = %if.then6
@@ -22,25 +22,25 @@ while.body:                                       ; preds = %while.body.backedge
 
 lor.lhs.false:                                    ; preds = %while.body
   %tmp22 = load i32, ptr %o.addr.0                       ; <i32> [#uses=0]
-  br i1 undef, label %land.lhs.true24, label %if.end31
+  br i1 %arg, label %land.lhs.true24, label %if.end31
 
 land.lhs.true24:                                  ; preds = %lor.lhs.false
   %call28 = call ptr @parse_object(ptr undef) nounwind ; <ptr> [#uses=0]
-  br i1 undef, label %return.loopexit, label %if.end31
+  br i1 %arg, label %return.loopexit, label %if.end31
 
 if.end31:                                         ; preds = %land.lhs.true24, %lor.lhs.false
-  br i1 undef, label %return.loopexit, label %if.end41
+  br i1 %arg, label %return.loopexit, label %if.end41
 
 if.end41:                                         ; preds = %if.end31
   %tmp45 = load i32, ptr %o.addr.0                       ; <i32> [#uses=0]
-  br i1 undef, label %if.then50, label %if.else
+  br i1 %arg, label %if.then50, label %if.else
 
 if.then50:                                        ; preds = %if.end41
   %tmp53 = load ptr, ptr undef                       ; <ptr> [#uses=1]
   br label %while.body.backedge
 
 if.else:                                          ; preds = %if.end41
-  br i1 undef, label %if.then62, label %if.else67
+  br i1 %arg, label %if.then62, label %if.else67
 
 if.then62:                                        ; preds = %if.else
   br label %while.body.backedge
@@ -97,10 +97,10 @@ bb66.i:                                           ; Unreachable
 
 @g = external global i64, align 8
 
-define ptr @test3() {
+define ptr @test3(i1 %arg) {
 do.end17.i:
   %tmp18.i = load ptr, ptr undef
-  br i1 undef, label %do.body36.i, label %if.then21.i
+  br i1 %arg, label %do.body36.i, label %if.then21.i
 
 if.then21.i:
   ret ptr undef
@@ -110,7 +110,7 @@ do.body36.i:
   %add.ptr39.sum.i = add i64 %ivar38.i, 8
   %tmp40.i = getelementptr inbounds i8, ptr %tmp18.i, i64 %add.ptr39.sum.i
   %tmp41.i = load i64, ptr %tmp40.i
-  br i1 undef, label %if.then48.i, label %do.body57.i
+  br i1 %arg, label %if.then48.i, label %do.body57.i
 
 if.then48.i:
   %call54.i = call i32 @foo2()
@@ -163,7 +163,7 @@ entry:
 
 %struct.type = type { i64, i32, i32 }
 
-define fastcc void @func() nounwind uwtable ssp align 2 {
+define fastcc void @func(i1 %arg) nounwind uwtable ssp align 2 {
 entry:
   br label %reachable.bb
 
@@ -171,7 +171,7 @@ entry:
 
 unreachable.bb:
   %gep.val = getelementptr inbounds %struct.type, ptr %gep.val, i64 1
-  br i1 undef, label %u2.bb, label %u1.bb
+  br i1 %arg, label %u2.bb, label %u1.bb
 
 u1.bb:
   store i64 -1, ptr %gep.val, align 8

--- a/llvm/test/Transforms/GVN/equality-assume.ll
+++ b/llvm/test/Transforms/GVN/equality-assume.ll
@@ -109,12 +109,12 @@ define i32 @test2(ptr %p, i32 %v) {
   ret i32 %load2
 }
 
-define i32 @test3(ptr %p, i32 %v) {
+define i32 @test3(ptr %p, i32 %v, i1 %arg) {
 ; CHECK-LABEL: @test3(
 ; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr [[P:%.*]]
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[LOAD]], [[V:%.*]]
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[C]])
-; CHECK-NEXT:    br i1 undef, label [[TAKEN:%.*]], label [[MERGE:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[TAKEN:%.*]], label [[MERGE:%.*]]
 ; CHECK:       taken:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
@@ -123,16 +123,16 @@ define i32 @test3(ptr %p, i32 %v) {
   %load = load i32, ptr %p
   %c = icmp eq i32 %load, %v
   call void @llvm.assume(i1 %c)
-  br i1 undef, label %taken, label %merge
+  br i1 %arg, label %taken, label %merge
 taken:
   br label %merge
 merge:
   ret i32 %load
 }
 
-define i32 @trivial_constants(ptr %p) {
+define i32 @trivial_constants(ptr %p, i1 %arg) {
 ; CHECK-LABEL: @trivial_constants(
-; CHECK-NEXT:    br i1 undef, label [[TAKEN:%.*]], label [[MERGE:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[TAKEN:%.*]], label [[MERGE:%.*]]
 ; CHECK:       taken:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
@@ -140,17 +140,17 @@ define i32 @trivial_constants(ptr %p) {
 ;
   %c = icmp eq i32 0, 0
   call void @llvm.assume(i1 %c)
-  br i1 undef, label %taken, label %merge
+  br i1 %arg, label %taken, label %merge
 taken:
   br label %merge
 merge:
   ret i32 0
 }
 
-define i32 @conflicting_constants(ptr %p) {
+define i32 @conflicting_constants(ptr %p, i1 %arg) {
 ; CHECK-LABEL: @conflicting_constants(
 ; CHECK-NEXT:    store i8 poison, ptr null
-; CHECK-NEXT:    br i1 undef, label [[TAKEN:%.*]], label [[MERGE:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[TAKEN:%.*]], label [[MERGE:%.*]]
 ; CHECK:       taken:
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
@@ -158,7 +158,7 @@ define i32 @conflicting_constants(ptr %p) {
 ;
   %c = icmp eq i32 0, 5
   call void @llvm.assume(i1 %c)
-  br i1 undef, label %taken, label %merge
+  br i1 %arg, label %taken, label %merge
 taken:
   br label %merge
 merge:

--- a/llvm/test/Transforms/GVN/pre-new-inst.ll
+++ b/llvm/test/Transforms/GVN/pre-new-inst.ll
@@ -1,10 +1,10 @@
 ; RUN: opt -passes=gvn -S %s | FileCheck %s
 
 %MyStruct = type { i32, i32 }
-define i8 @foo(i64 %in, ptr %arr) {
+define i8 @foo(i64 %in, ptr %arr, i1 %arg) {
   %addr = alloca %MyStruct
   %dead = trunc i64 %in to i32
-  br i1 undef, label %next, label %tmp
+  br i1 %arg, label %next, label %tmp
 
 tmp:
   call void @bar()

--- a/llvm/test/Transforms/GVN/stale-loop-info.ll
+++ b/llvm/test/Transforms/GVN/stale-loop-info.ll
@@ -13,7 +13,7 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 ; Function Attrs: argmemonly
 declare void @snork.1(ptr) local_unnamed_addr #0
 
-define hidden zeroext i1 @eggs(ptr %arg, i1 %arg2) unnamed_addr align 2 {
+define hidden zeroext i1 @eggs(ptr %arg, i1 %arg2, i1 %arg3) unnamed_addr align 2 {
 bb:
   br i1 %arg2, label %bb14, label %bb3
 
@@ -25,7 +25,7 @@ bb6:                                              ; preds = %bb12, %bb3
   br label %bb7
 
 bb7:                                              ; preds = %bb6
-  br i1 undef, label %bb11, label %bb8
+  br i1 %arg3, label %bb11, label %bb8
 
 bb8:                                              ; preds = %bb7
   %tmp9 = load ptr, ptr %tmp, align 8

--- a/llvm/test/Transforms/GVN/unreachable_block_infinite_loop.ll
+++ b/llvm/test/Transforms/GVN/unreachable_block_infinite_loop.ll
@@ -12,32 +12,32 @@ unreachable_block:
     ret i32 %a
 }
 
-define i32 @pr23096_test0() {
+define i32 @pr23096_test0(i1 %arg, ptr %arg2) {
 entry:
   br label %bb0
 
 bb1:
   %ptr1 = ptrtoint ptr %ptr2 to i64
   %ptr2 = inttoptr i64 %ptr1 to ptr
-  br i1 undef, label %bb0, label %bb1
+  br i1 %arg, label %bb0, label %bb1
 
 bb0:
-  %phi = phi ptr [ undef, %entry ], [ %ptr2, %bb1 ]
+  %phi = phi ptr [ %arg2, %entry ], [ %ptr2, %bb1 ]
   %load = load i32, ptr %phi
   ret i32 %load
 }
 
-define i32 @pr23096_test1() {
+define i32 @pr23096_test1(i1 %arg, ptr %arg2) {
 entry:
   br label %bb0
 
 bb1:
   %ptr1 = getelementptr i32, ptr %ptr2, i32 0
   %ptr2 = getelementptr i32, ptr %ptr1, i32 0
-  br i1 undef, label %bb0, label %bb1
+  br i1 %arg, label %bb0, label %bb1
 
 bb0:
-  %phi = phi ptr [ undef, %entry ], [ %ptr2, %bb1 ]
+  %phi = phi ptr [ %arg2, %entry ], [ %ptr2, %bb1 ]
   %load = load i32, ptr %phi
   ret i32 %load
 }

--- a/llvm/test/Transforms/GVNHoist/hoist-call.ll
+++ b/llvm/test/Transforms/GVNHoist/hoist-call.ll
@@ -2,14 +2,14 @@
 ; RUN: opt -S -passes=gvn-hoist < %s | FileCheck %s
 
 ; Check that the call and fcmp are hoisted.
-define void @fun(float %__b) minsize {
+define void @fun(float %__b, i1 %arg) minsize {
 ; CHECK-LABEL: @fun(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[IF_THEN:%.*]]
 ; CHECK:       if.then:
 ; CHECK-NEXT:    [[TMP0:%.*]] = call float @llvm.fabs.f32(float [[__B:%.*]])
 ; CHECK-NEXT:    [[CMPINF7:%.*]] = fcmp oeq float [[TMP0]], 0x7FF0000000000000
-; CHECK-NEXT:    br i1 undef, label [[IF_THEN8:%.*]], label [[LOR_LHS_FALSE:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[IF_THEN8:%.*]], label [[LOR_LHS_FALSE:%.*]]
 ; CHECK:       lor.lhs.false:
 ; CHECK-NEXT:    unreachable
 ; CHECK:       if.then8:
@@ -19,7 +19,7 @@ entry:
   br label %if.then
 
 if.then:                                          ; preds = %entry
-  br i1 undef, label %if.then8, label %lor.lhs.false
+  br i1 %arg, label %if.then8, label %lor.lhs.false
 
 lor.lhs.false:                                    ; preds = %if.then
   %0 = call float @llvm.fabs.f32(float %__b) #2

--- a/llvm/test/Transforms/GVNHoist/hoist-mssa.ll
+++ b/llvm/test/Transforms/GVNHoist/hoist-mssa.ll
@@ -7,22 +7,22 @@
 
 @optind = external global i32, align 4
 
-define void @getopt() {
+define void @getopt(i1 %arg) {
 bb:
   br label %bb1
 
 bb1:                                              ; preds = %bb
-  br i1 undef, label %bb2, label %bb3
+  br i1 %arg, label %bb2, label %bb3
 
 bb2:                                              ; preds = %bb1
   br label %bb13
 
 bb3:                                              ; preds = %bb1
-  br i1 undef, label %bb4, label %bb9
+  br i1 %arg, label %bb4, label %bb9
 
 bb4:                                              ; preds = %bb3
   %tmp = load i32, ptr @optind, align 4
-  br i1 undef, label %bb5, label %bb7
+  br i1 %arg, label %bb5, label %bb7
 
 bb5:                                              ; preds = %bb4
   %tmp6 = add nsw i32 %tmp, 1

--- a/llvm/test/Transforms/GVNHoist/hoist-simplify-phi.ll
+++ b/llvm/test/Transforms/GVNHoist/hoist-simplify-phi.ll
@@ -10,18 +10,18 @@ target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 
 %s = type { i32, ptr, [3 x i8], i8 }
 
-define void @test() {
+define void @test(i1 %arg) {
 entry:
   br label %cond.end118
 
 cond.end118:                                      ; preds = %entry
-  br i1 undef, label %cleanup, label %if.end155
+  br i1 %arg, label %cleanup, label %if.end155
 
 if.end155:                                        ; preds = %cond.end118
   br label %while.cond
 
 while.cond:                                       ; preds = %while.body, %if.end155
-  br i1 undef, label %while.end, label %while.body
+  br i1 %arg, label %while.end, label %while.body
 
 while.body:                                       ; preds = %while.cond
   br label %while.cond
@@ -36,7 +36,7 @@ if.then174:                                       ; preds = %while.end
   unreachable
 
 if.else218:                                       ; preds = %while.end
-  br i1 undef, label %if.then226, label %if.else326
+  br i1 %arg, label %if.then226, label %if.else326
 
 if.then226:                                       ; preds = %if.else218
   %0 = load i32, ptr undef, align 4

--- a/llvm/test/Transforms/GVNHoist/hoist-very-busy.ll
+++ b/llvm/test/Transforms/GVNHoist/hoist-very-busy.ll
@@ -38,12 +38,12 @@ attributes #0 = { noreturn nounwind }
 ; CHECK: store
 ; CHECK-NOT: store
 
-define void @fun() {
+define void @fun(i1 %arg) {
 entry:
   br label %if.then
 
 if.then:                                          ; preds = %entry
-  br i1 undef, label %sw0, label %sw1
+  br i1 %arg, label %sw0, label %sw1
 
 sw0:
   store i32 1, ptr @G

--- a/llvm/test/Transforms/GVNHoist/non-trivial-phi.ll
+++ b/llvm/test/Transforms/GVNHoist/non-trivial-phi.ll
@@ -5,7 +5,7 @@
 
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 
-define void @f(ptr %p) {
+define void @f(ptr %p, i1 %arg) {
 entry:
   switch i4 undef, label %if.then30 [
     i4 4, label %if.end
@@ -16,7 +16,7 @@ if.end:
   br label %if.end19
 
 if.end19:
-  br i1 undef, label %e, label %e.thread
+  br i1 %arg, label %e, label %e.thread
 
 e.thread:
   store i8 0, ptr %p, align 4

--- a/llvm/test/Transforms/GVNHoist/pr30216.ll
+++ b/llvm/test/Transforms/GVNHoist/pr30216.ll
@@ -6,10 +6,10 @@
 @A = external global i8
 @B = external global ptr
 
-define ptr @Foo() {
-; CHECK-LABEL: define ptr @Foo() {
+define ptr @Foo(i1 %arg) {
+; CHECK-LABEL: define ptr @Foo(i1 %arg) {
 ; CHECK-NEXT:    store i8 0, ptr @A, align 1
-; CHECK-NEXT:    br i1 undef, label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
 ; CHECK:       if.then:
 ; CHECK-NEXT:    store ptr null, ptr @B, align 8
 ; CHECK-NEXT:    ret ptr null
@@ -19,7 +19,7 @@ define ptr @Foo() {
 ; CHECK-NEXT:    ret ptr [[TMP1]]
 ;
   store i8 0, ptr @A
-  br i1 undef, label %if.then, label %if.else
+  br i1 %arg, label %if.then, label %if.else
 
 if.then:
   store ptr null, ptr @B
@@ -35,10 +35,10 @@ if.else:
 
 @GlobalVar = internal global i8 0
 
-define ptr @Fun() {
-; CHECK-LABEL: define ptr @Fun() {
+define ptr @Fun(i1 %arg) {
+; CHECK-LABEL: define ptr @Fun(i1 %arg) {
 ; CHECK-NEXT:    store i8 0, ptr @A, align 1
-; CHECK-NEXT:    br i1 undef, label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
 ; CHECK:       if.then:
 ; CHECK-NEXT:    store ptr null, ptr @B, align 8
 ; CHECK-NEXT:    ret ptr null
@@ -49,7 +49,7 @@ define ptr @Fun() {
 ; CHECK-NEXT:    ret ptr [[TMP1]]
 ;
   store i8 0, ptr @A
-  br i1 undef, label %if.then, label %if.else
+  br i1 %arg, label %if.then, label %if.else
 
 if.then:
   store ptr null, ptr @B

--- a/llvm/test/Transforms/GVNHoist/pr36787.ll
+++ b/llvm/test/Transforms/GVNHoist/pr36787.ll
@@ -12,7 +12,7 @@ declare void @f2()
 
 ;CHECK-LABEL: @func
 
-define void @func() personality ptr @gxx_personality {
+define void @func(i1 %arg) personality ptr @gxx_personality {
   invoke void @f0()
           to label %3 unwind label %1
 
@@ -23,7 +23,7 @@ define void @func() personality ptr @gxx_personality {
   br label %16
 
 3:
-  br i1 undef, label %4, label %10
+  br i1 %arg, label %4, label %10
 
 ;CHECK:       4:
 ;CHECK-NEXT:    %5 = load ptr, ptr undef, align 8

--- a/llvm/test/Transforms/GVNSink/dither.ll
+++ b/llvm/test/Transforms/GVNSink/dither.ll
@@ -7,12 +7,12 @@
 
 ; CHECK-LABEL: @hoge
 ; CHECK-NOT: bb18.gvnsink.split
-define void @hoge() {
+define void @hoge(i1 %arg) {
 bb:
-  br i1 undef, label %bb4, label %bb11
+  br i1 %arg, label %bb4, label %bb11
 
 bb4:                                              ; preds = %bb3
-  br i1 undef, label %bb6, label %bb8
+  br i1 %arg, label %bb6, label %bb8
 
 bb6:                                              ; preds = %bb5
   %tmp = zext i16 undef to i64
@@ -24,7 +24,7 @@ bb8:                                              ; preds = %bb5
   br label %bb18
 
 bb11:                                             ; preds = %bb10
-  br i1 undef, label %bb12, label %bb15
+  br i1 %arg, label %bb12, label %bb15
 
 bb12:                                             ; preds = %bb11
   %tmp13 = zext i16 undef to i64

--- a/llvm/test/Transforms/GVNSink/sink-common-code.ll
+++ b/llvm/test/Transforms/GVNSink/sink-common-code.ll
@@ -762,13 +762,13 @@ if.end:
 ; CHECK-LABEL: test_pr36954
 ; CHECK-NOT: xor
 ; PR36954 reproducer containing self referencing instruction shouldn't crash GVNSink pass.
-define void @test_pr36954() {
+define void @test_pr36954(i1 %arg) {
 bb1:
   %i2 = trunc i32 undef to i8
   br label %bb2
 
 bb2:
-  br i1 undef, label %bb2, label %exit
+  br i1 %arg, label %bb2, label %exit
 
 bb4.critedge:
   %i6 = sub i8 %i2, undef

--- a/llvm/test/Transforms/GVNSink/struct.ll
+++ b/llvm/test/Transforms/GVNSink/struct.ll
@@ -5,12 +5,12 @@
 
 ; Struct indices cannot be variant.
 
-; CHECK-LABEL: @f() {
+; CHECK-LABEL: @f(i1 %arg) {
 ; CHECK: getelementptr
 ; CHECK: getelementptr
-define void @f() {
+define void @f(i1 %arg) {
 bb:
-  br i1 undef, label %bb2, label %bb1
+  br i1 %arg, label %bb2, label %bb1
 
 bb1:                                              ; preds = %bb
   %tmp = getelementptr inbounds %struct, ptr null, i64 0, i32 1
@@ -27,12 +27,12 @@ bb4:                                              ; preds = %bb2, %bb1
 
 ; Struct indices cannot be variant.
 
-; CHECK-LABEL: @g() {
+; CHECK-LABEL: @g(i1 %arg) {
 ; CHECK: getelementptr
 ; CHECK: getelementptr
-define void @g() {
+define void @g(i1 %arg) {
 bb:
-  br i1 undef, label %bb2, label %bb1
+  br i1 %arg, label %bb2, label %bb1
 
 bb1:                                              ; preds = %bb
   %tmp = getelementptr inbounds %struct2, ptr null, i64 0, i32 0, i32 1
@@ -50,12 +50,12 @@ bb4:                                              ; preds = %bb2, %bb1
 
 ; ... but the first parameter to a GEP can.
 
-; CHECK-LABEL: @h() {
+; CHECK-LABEL: @h(i1 %arg) {
 ; CHECK: getelementptr
 ; CHECK-NOT: getelementptr
-define void @h() {
+define void @h(i1 %arg) {
 bb:
-  br i1 undef, label %bb2, label %bb1
+  br i1 %arg, label %bb2, label %bb1
 
 bb1:                                              ; preds = %bb
   %tmp = getelementptr inbounds %struct, ptr null, i32 1, i32 0


### PR DESCRIPTION
This PR removes tests with `br i1 undef` under `llvm/tests/G*`.
There were a few tests that I couldn't fix to pass lit. I'll come back and fix those later.

@nunoplopes @regehr 