### PR TITLE
[mlir][vector] Add verification for incorrect vector.extract

### DIFF
--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -192,6 +192,13 @@ func.func @extract_position_overflow(%arg0: vector<4x8x16xf32>) {
 
 // -----
 
+func.func @extract_scalar_missing_indices(%arg0: vector<4x8x1xf32>) {
+  // expected-error@+1 {{expected source rank to match number of indices for scalar result}}
+  %1 = vector.extract %arg0[0, 0] : f32 from vector<4x8x1xf32>
+}
+
+// -----
+
 func.func @insert_element(%arg0: f32, %arg1: vector<f32>) {
   %c = arith.constant 3 : i32
   // expected-error@+1 {{expected position to be empty with 0-D vector}}

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -151,107 +151,112 @@ func.func @extract_vector_type(%arg0: index) {
 // -----
 
 func.func @extract_position_rank_overflow(%arg0: vector<4x8x16xf32>) {
-  // expected-error@+1 {{expected a number of indices no greater than the indexed vector rank}}
+  // expected-error@+1 {{'vector.extract' op expected a number of indices no greater than the source vector rank}}
   %1 = vector.extract %arg0[0, 0, 0, 0] : f32 from vector<4x8x16xf32>
 }
 
 // -----
 
 func.func @extract_position_rank_overflow_generic(%arg0: vector<4x8x16xf32>) {
-  // expected-error@+1 {{expected a number of indices no greater than the indexed vector rank}}
+  // expected-error@+1 {{'vector.extract' op expected a number of indices no greater than the source vector rank}}
   %1 = "vector.extract" (%arg0) <{static_position = array<i64: 0, 0, 0, 0>}> : (vector<4x8x16xf32>) -> (vector<16xf32>)
 }
 
 // -----
 
 func.func @extract_position_overflow(%arg0: vector<4x8x16xf32>) {
-  // expected-error@+1 {{expected position attribute #2 to be a non-negative integer smaller than the corresponding vector dimension}}
+  // expected-error@+1 {{'vector.extract' op expected position attribute #2 to be a non-negative integer smaller than the corresponding vector dimension}}
   %1 = vector.extract %arg0[0, 43, 0] : f32 from vector<4x8x16xf32>
 }
 
 // -----
 
 func.func @extract_precise_position_overflow(%arg0: vector<4x8x16xf32>) {
-  // expected-error@+1 {{expected position attribute #3 to be a non-negative integer smaller than the corresponding vector dimension}}
+  // expected-error@+1 {{'vector.extract' op expected position attribute #3 to be a non-negative integer smaller than the corresponding vector dimension}}
   %1 = vector.extract %arg0[3, 7, 16] : f32 from vector<4x8x16xf32>
 }
 
 // -----
 
-func.func @extract_from_0d_to_scalar_wrong_index(%arg0: vector<f32>) {
-  // expected-error@+1 {{expected a number of indices no greater than the indexed vector rank}}
+func.func @extract_scalar_from_0d_wrong_index(%arg0: vector<f32>) {
+  // expected-error@+1 {{'vector.extract' op expected a number of indices no greater than the source vector rank}}
   %1 = vector.extract %arg0[0] : f32 from vector<f32>
 }
 
 // -----
 
-func.func @extract_from_0d_to_0d_wrong_index(%arg0: vector<f32>) {
-  // expected-error@+1 {{expected a number of indices no greater than the indexed vector rank}}
+func.func @extract_0d_from_0d_wrong_index(%arg0: vector<f32>) {
+  // expected-error@+1 {{'vector.extract' op expected a number of indices no greater than the source vector rank}}
   %2 = vector.extract %arg0[0] : vector<f32> from vector<f32>
 }
 
 // -----
 
-func.func @extract_from_0d_to_1d_wrong_index(%arg0: vector<f32>) {
-  // expected-error@+1 {{expected a number of indices no greater than the indexed vector rank}}
+func.func @extract_1d_from_0d_wrong_index(%arg0: vector<f32>) {
+  // expected-error@+1 {{'vector.extract' op expected a number of indices no greater than the source vector rank}}
   %3 = vector.extract %arg0[0] : vector<1xf32> from vector<f32>
 }
 
 // -----
 
-func.func @extract_from_1d_to_scalar_wrong_index(%arg0: vector<1xf32>) {
-  // expected-error@+1 {{expected indexed vector rank to match the number of indices for scalar cases}}
+func.func @extract_scalar_from_1d_wrong_index(%arg0: vector<1xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected source vector rank to match the number of indices for scalar cases}}
   %1 = vector.extract %arg0[] : f32 from vector<1xf32>
 }
 
 // -----
 
-func.func @extract_from_1d_to_0d_wrong_index(%arg0: vector<1xf32>) {
-  // expected-error@+1 {{'vector.extract' op expected indexed vector rank minus number of indices to match the rank of the non-indexed vector rank}}
+func.func @extract_0d_from_1d_wrong_index(%arg0: vector<1xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected source and destination vectors with different number of elements}}
   %2 = vector.extract %arg0[] : vector<f32> from vector<1xf32>
 }
 
 // -----
 
-func.func @extract_from_1d_to_0d(%arg0: vector<1xf32>) {
-  // expected-error@+2 {{'vector.extract' op inferred type(s) 'f32' are incompatible with return type(s) of operation 'vector<f32>'}}
-  // expected-error@+1 {{failed to infer returned types}}
+func.func @extract_0d_from_1d(%arg0: vector<1xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected source and destination vectors with different number of elements}}
   %4 = vector.extract %arg0[0] : vector<f32> from vector<1xf32>
 }
 
 // -----
 
-func.func @extract_from_2d_to_scalar(%arg0: vector<4x1xf32>) {
-  // expected-error@+1 {{'vector.extract' op expected indexed vector rank to match the number of indices for scalar cases}}
+func.func @extract_1d_from_0d(%arg0: vector<f32>) {
+  // expected-error@+1 {{'vector.extract' op expected source and destination vectors with different number of elements}}
+  %4 = vector.extract %arg0[] : vector<1xf32> from vector<f32>
+}
+
+// -----
+
+func.func @extract_scalar_from_2d(%arg0: vector<4x1xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected source vector rank to match the number of indices for scalar cases}}
   %6 = vector.extract %arg0[2] : f32 from vector<4x1xf32>
 }
 
 // -----
 
-func.func @extract_from_2d_to_0d(%arg0: vector<4x1xf32>) {
-  // expected-error@+1 {{'vector.extract' op expected indexed vector rank minus number of indices to match the rank of the non-indexed vector rank}}
+func.func @extract_0d_from_2d(%arg0: vector<4x1xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected source vector rank minus number of indices to match the rank of the extracted vector}}
   %7 = vector.extract %arg0[2] : vector<f32> from vector<4x1xf32>
 }
 
 // -----
 
-func.func @extract_from_2d_to_scalar_wrong_index(%arg0: vector<4x8xf32>) {
-  // expected-error@+1 {{'vector.extract' op expected indexed vector rank to match the number of indices for scalar cases}}
+func.func @extract_scalar_from_2d_wrong_index(%arg0: vector<4x8xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected source vector rank to match the number of indices for scalar cases}}
   %8 = vector.extract %arg0[3] : f32 from vector<4x8xf32>
 }
 
 // -----
 
-func.func @extract_from_2d_to_0d(%arg0: vector<4x8xf32>) {
-  // expected-error@+1 {{'vector.extract' op expected indexed vector rank minus number of indices to match the rank of the non-indexed vector rank}}
+func.func @extract_0d_from_2d(%arg0: vector<4x8xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected source vector rank minus number of indices to match the rank of the extracted vector}}
   %9 = vector.extract %arg0[3] : vector<f32> from vector<4x8xf32>
 }
 
 // -----
 
-func.func @extract_from_2d_to_1d(%arg0: vector<4x8xf32>) {
-  // expected-error@+2 {{'vector.extract' op inferred type(s) 'vector<8xf32>' are incompatible with return type(s) of operation 'vector<1xf32>'}}
-  // expected-error@+1 {{failed to infer returned types}}
+func.func @extract_1d_from_2d(%arg0: vector<4x8xf32>) {
+  // expected-error@+1 {{'vector.extract' op expected extracted vector shape to match the sub-vector shape of the source vector}}
   %10 = vector.extract %arg0[3] : vector<1xf32> from vector<4x8xf32>
 }
 
@@ -265,7 +270,7 @@ func.func @extract_position_overflow(%arg0: vector<4x8x16xf32>) {
 // -----
 
 func.func @extract_scalar_missing_indices(%arg0: vector<4x8x1xf32>) {
-  // expected-error@+1 {{'vector.extract' op expected indexed vector rank to match the number of indices for scalar cases}}
+  // expected-error@+1 {{'vector.extract' op expected source vector rank to match the number of indices for scalar cases}}
   %1 = vector.extract %arg0[0, 0] : f32 from vector<4x8x1xf32>
 }
 
@@ -304,21 +309,21 @@ func.func @insert_element_wrong_type(%arg0: i32, %arg1: vector<4xf32>) {
 // -----
 
 func.func @insert_vector_type(%a: f32, %b: vector<4x8x16xf32>) {
-  // expected-error@+1 {{'vector.insert' op expected a number of indices no greater than the indexed vector rank}}
+  // expected-error@+1 {{'vector.insert' op expected a number of indices no greater than the destination vector rank}}
   %1 = vector.insert %a, %b[3, 3, 3, 3, 3, 3] : f32 into vector<4x8x16xf32>
 }
 
 // -----
 
 func.func @insert_vector_type(%a: vector<4xf32>, %b: vector<4x8x16xf32>) {
-  // expected-error@+1 {{'vector.insert' op expected indexed vector rank minus number of indices to match the rank of the non-indexed vector rank}}
+  // expected-error@+1 {{'vector.insert' op expected destination vector rank minus number of indices to match the rank of the inserted vector}}
   %1 = vector.insert %a, %b[3] : vector<4xf32> into vector<4x8x16xf32>
 }
 
 // -----
 
 func.func @insert_vector_type(%a: f32, %b: vector<4x8x16xf32>) {
-  // expected-error@+1 {{'vector.insert' op expected indexed vector rank to match the number of indices for scalar cases}}
+  // expected-error@+1 {{'vector.insert' op expected destination vector rank to match the number of indices for scalar cases}}
   %1 = vector.insert %a, %b[3, 3] : f32 into vector<4x8x16xf32>
 }
 
@@ -338,16 +343,86 @@ func.func @insert_precise_position_overflow(%a: f32, %b: vector<4x8x16xf32>) {
 
 // -----
 
-func.func @insert_0d(%a: vector<f32>, %b: vector<4x8x16xf32>) {
-  // expected-error@+1 {{'vector.insert' op expected indexed vector rank minus number of indices to match the rank of the non-indexed vector rank}}
-  %1 = vector.insert %a, %b[2, 6] : vector<f32> into vector<4x8x16xf32>
+func.func @insert_scalar_into_0d_wrong_index(%arg0: f32, %arg1: vector<f32>) {
+  // expected-error@+1 {{'vector.insert' op expected a number of indices no greater than the destination vector rank}}
+  %1 = vector.insert %arg0, %arg1[0] : f32 into vector<f32>
 }
 
 // -----
 
-func.func @insert_0d(%a: f32, %b: vector<f32>) {
-  // expected-error@+1 {{'vector.insert' op expected a number of indices no greater than the indexed vector rank}}
-  %1 = vector.insert %a, %b[0] : f32 into vector<f32>
+func.func @insert_0d_into_0d_wrong_index(%arg0: vector<f32>, %arg1: vector<f32>) {
+  // expected-error@+1 {{'vector.insert' op expected a number of indices no greater than the destination vector rank}}
+  %2 = vector.insert %arg0, %arg1[0] : vector<f32> into vector<f32>
+}
+
+// -----
+
+func.func @insert_1d_into_0d_wrong_index(%arg0: vector<1xf32>, %arg1: vector<f32>) {
+  // expected-error@+1 {{'vector.insert' op expected a number of indices no greater than the destination vector rank}}
+  %3 = vector.insert %arg0, %arg1[0] : vector<1xf32> into vector<f32>
+}
+
+// -----
+
+func.func @insert_scalar_into_1d_wrong_index(%arg0: f32, %arg1: vector<1xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected destination vector rank to match the number of indices for scalar cases}}
+  %1 = vector.insert %arg0, %arg1[] : f32 into vector<1xf32>
+}
+
+// -----
+
+func.func @insert_0d_into_1d_wrong_index(%arg0: vector<f32>, %arg1: vector<1xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected source and destination vectors with different number of elements}}
+  %2 = vector.insert %arg0, %arg1[] : vector<f32> into vector<1xf32>
+}
+
+// -----
+
+func.func @insert_0d_into_1d(%arg0: vector<f32>, %arg1: vector<1xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected source and destination vectors with different number of elements}}
+  %4 = vector.insert %arg0, %arg1[0] : vector<f32> into vector<1xf32>
+}
+
+// -----
+
+func.func @insert_1d_into_0d(%arg0: vector<1xf32>, %arg1: vector<f32>) {
+  // expected-error@+1 {{'vector.insert' op expected source and destination vectors with different number of elements}}
+  %4 = vector.insert %arg0, %arg1[] : vector<1xf32> into vector<f32>
+}
+
+// -----
+
+func.func @insert_scalar_into_2d(%arg0: f32, %arg1: vector<4x1xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected destination vector rank to match the number of indices for scalar cases}}
+  %6 = vector.insert %arg0, %arg1[2] : f32 into vector<4x1xf32>
+}
+
+// -----
+
+func.func @insert_0d_into_2d(%arg0: vector<f32>, %arg1: vector<4x1xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected destination vector rank minus number of indices to match the rank of the inserted vector}}
+  %7 = vector.insert %arg0, %arg1[2] : vector<f32> into vector<4x1xf32>
+}
+
+// -----
+
+func.func @insert_scalar_into_2d_wrong_index(%arg0: f32, %arg1: vector<4x8xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected destination vector rank to match the number of indices for scalar cases}}
+  %8 = vector.insert %arg0, %arg1[3] : f32 into vector<4x8xf32>
+}
+
+// -----
+
+func.func @insert_0d_into_2d(%arg0: vector<f32>, %arg1: vector<4x8xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected destination vector rank minus number of indices to match the rank of the inserted vector}}
+  %9 = vector.insert %arg0, %arg1[3] : vector<f32> into vector<4x8xf32>
+}
+
+// -----
+
+func.func @insert_1d_into_2d(%arg0: vector<1xf32>, %arg1: vector<4x8xf32>) {
+  // expected-error@+1 {{'vector.insert' op expected inserted vector shape to match the sub-vector shape of the destination vector}}
+  %10 = vector.insert %arg0, %arg1[3] : vector<1xf32> into vector<4x8xf32>
 }
 
 // -----

--- a/mlir/test/Dialect/Vector/ops.mlir
+++ b/mlir/test/Dialect/Vector/ops.mlir
@@ -224,7 +224,7 @@ func.func @extract_const_idx(%arg0: vector<4x8x16xf32>)
 //  CHECK-SAME:   %[[VEC:.+]]: vector<4x8x16xf32>, %[[IDX:.+]]: index
 func.func @extract_val_idx(%arg0: vector<4x8x16xf32>, %idx: index)
                            -> (vector<8x16xf32>, vector<16xf32>, f32) {
-  // CHECK: vector.extract %[[VEC]][%[[IDX]]] : vector<8x16xf32> from vector<4x8x16xf32>
+  //      CHECK: vector.extract %[[VEC]][%[[IDX]]] : vector<8x16xf32> from vector<4x8x16xf32>
   %0 = vector.extract %arg0[%idx] : vector<8x16xf32> from vector<4x8x16xf32>
   // CHECK-NEXT: vector.extract %[[VEC]][%[[IDX]], %[[IDX]]] : vector<16xf32> from vector<4x8x16xf32>
   %1 = vector.extract %arg0[%idx, %idx] : vector<16xf32> from vector<4x8x16xf32>
@@ -234,17 +234,24 @@ func.func @extract_val_idx(%arg0: vector<4x8x16xf32>, %idx: index)
 }
 
 // CHECK-LABEL: @extract_0d
-func.func @extract_0d(%a: vector<f32>) -> f32 {
-  // CHECK-NEXT: vector.extract %{{.*}}[] : f32 from vector<f32>
-  %0 = vector.extract %a[] : f32 from vector<f32>
-  return %0 : f32
+func.func @extract_0d(%arg0: vector<f32>) -> (f32, vector<1xf32>) {
+  //      CHECK: vector.extract %{{.*}}[] : f32 from vector<f32>
+  %0 = vector.extract %arg0[] : f32 from vector<f32>
+  // CHECK-NEXT: vector.extract %{{.*}}[] : vector<1xf32> from vector<f32>
+  %1 = vector.extract %arg0[] : vector<1xf32> from vector<f32>
+  return %0, %1 : f32, vector<1xf32>
 }
 
-// CHECK-LABEL: @extract_single_element_vector
-func.func @extract_single_element_vector(%arg0: vector<4x8x3xf32>) -> vector<1xf32> {
-  // CHECK: vector.extract {{.*}}[0, 0, 0] : vector<1xf32> from vector<4x8x3xf32>
-  %1 = vector.extract %arg0[0, 0, 0] : vector<1xf32> from vector<4x8x3xf32>
-  return %1 : vector<1xf32>
+// CHECK-LABEL: @extract_1d
+func.func @extract_1d(%arg0: vector<1xf32>, %arg1: vector<4x1xf32>)
+                      -> (f32, vector<1xf32>, vector<1xf32>) {
+  //      CHECK: vector.extract %{{.*}}[0] : f32 from vector<1xf32>
+  %0 = vector.extract %arg0[0] : f32 from vector<1xf32>
+  // CHECK-NEXT: vector.extract %{{.*}}[0] : vector<1xf32> from vector<1xf32>
+  %1 = vector.extract %arg0[0] : vector<1xf32> from vector<1xf32>
+  // CHECK-NEXT: vector.extract %{{.*}}[2] : vector<1xf32> from vector<4x1xf32>
+  %2 = vector.extract %arg1[2] : vector<1xf32> from vector<4x1xf32>
+  return %0, %1, %2 : f32, vector<1xf32>, vector<1xf32>
 }
 
 // CHECK-LABEL: @insert_element_0d
@@ -291,12 +298,30 @@ func.func @insert_val_idx(%a: f32, %b: vector<16xf32>, %c: vector<8x16xf32>,
 }
 
 // CHECK-LABEL: @insert_0d
-func.func @insert_0d(%a: f32, %b: vector<f32>, %c: vector<2x3xf32>) -> (vector<f32>, vector<2x3xf32>) {
-  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : f32 into vector<f32>
-  %1 = vector.insert %a,  %b[] : f32 into vector<f32>
+func.func @insert_0d(%a: f32, %b: vector<f32>, %c: vector<1xf32>, %d: vector<2x3xf32>)
+                     -> (vector<f32>, vector<f32>, vector<2x3xf32>) {
+  //      CHECK: vector.insert %{{.*}}, %{{.*}}[] : f32 into vector<f32>
+  %1 = vector.insert %a, %b[] : f32 into vector<f32>
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : vector<1xf32> into vector<f32>
+  %2 = vector.insert %c, %b[] : vector<1xf32> into vector<f32>
   // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<f32> into vector<2x3xf32>
-  %2 = vector.insert %b,  %c[0, 1] : vector<f32> into vector<2x3xf32>
-  return %1, %2 : vector<f32>, vector<2x3xf32>
+  %3 = vector.insert %b, %d[0, 1] : vector<f32> into vector<2x3xf32>
+  return %1, %2, %3 : vector<f32>, vector<f32>, vector<2x3xf32>
+}
+
+// CHECK-LABEL: @insert_1d
+func.func @insert_1d(%a: f32, %b: vector<1xf32>, %c: vector<4x1xf32>,
+                     %d: vector<2x3xf32>)
+                     -> (vector<1xf32>, vector<1xf32>, vector<4x1xf32>, vector<2x3xf32>) {
+  //      CHECK: vector.insert %{{.*}}, %{{.*}}[0] : f32 into vector<1xf32>
+  %0 = vector.insert %a, %b[0] : f32 into vector<1xf32>
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0] : vector<1xf32> into vector<1xf32>
+  %1 = vector.insert %0, %b[0] : vector<1xf32> into vector<1xf32>
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[2] : vector<1xf32> into vector<4x1xf32>
+  %2 = vector.insert %b, %c[2] : vector<1xf32> into vector<4x1xf32>
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<1xf32> into vector<2x3xf32>
+  %3 = vector.insert %b, %d[0, 1] : vector<1xf32> into vector<2x3xf32>
+  return %0, %1, %2, %3 : vector<1xf32>, vector<1xf32>, vector<4x1xf32>, vector<2x3xf32>
 }
 
 // CHECK-LABEL: @outerproduct

--- a/mlir/test/Dialect/Vector/ops.mlir
+++ b/mlir/test/Dialect/Vector/ops.mlir
@@ -240,6 +240,13 @@ func.func @extract_0d(%a: vector<f32>) -> f32 {
   return %0 : f32
 }
 
+// CHECK-LABEL: @extract_single_element_vector
+func.func @extract_single_element_vector(%arg0: vector<4x8x3xf32>) -> vector<1xf32> {
+  // CHECK: vector.extract {{.*}}[0, 0, 0] : vector<1xf32> from vector<4x8x3xf32>
+  %1 = vector.extract %arg0[0, 0, 0] : vector<1xf32> from vector<4x8x3xf32>
+  return %1 : vector<1xf32>
+}
+
 // CHECK-LABEL: @insert_element_0d
 func.func @insert_element_0d(%a: f32, %b: vector<f32>) -> vector<f32> {
   // CHECK-NEXT: vector.insertelement %{{.*}}, %{{.*}}[] : vector<f32>

--- a/mlir/test/Dialect/Vector/ops.mlir
+++ b/mlir/test/Dialect/Vector/ops.mlir
@@ -234,24 +234,20 @@ func.func @extract_val_idx(%arg0: vector<4x8x16xf32>, %idx: index)
 }
 
 // CHECK-LABEL: @extract_0d
-func.func @extract_0d(%arg0: vector<f32>) -> (f32, vector<1xf32>) {
+func.func @extract_0d(%arg0: vector<f32>) -> f32 {
   //      CHECK: vector.extract %{{.*}}[] : f32 from vector<f32>
   %0 = vector.extract %arg0[] : f32 from vector<f32>
-  // CHECK-NEXT: vector.extract %{{.*}}[] : vector<1xf32> from vector<f32>
-  %1 = vector.extract %arg0[] : vector<1xf32> from vector<f32>
-  return %0, %1 : f32, vector<1xf32>
+  return %0 : f32
 }
 
 // CHECK-LABEL: @extract_1d
 func.func @extract_1d(%arg0: vector<1xf32>, %arg1: vector<4x1xf32>)
-                      -> (f32, vector<1xf32>, vector<1xf32>) {
+                      -> (f32, vector<1xf32>) {
   //      CHECK: vector.extract %{{.*}}[0] : f32 from vector<1xf32>
   %0 = vector.extract %arg0[0] : f32 from vector<1xf32>
-  // CHECK-NEXT: vector.extract %{{.*}}[0] : vector<1xf32> from vector<1xf32>
-  %1 = vector.extract %arg0[0] : vector<1xf32> from vector<1xf32>
   // CHECK-NEXT: vector.extract %{{.*}}[2] : vector<1xf32> from vector<4x1xf32>
-  %2 = vector.extract %arg1[2] : vector<1xf32> from vector<4x1xf32>
-  return %0, %1, %2 : f32, vector<1xf32>, vector<1xf32>
+  %1 = vector.extract %arg1[2] : vector<1xf32> from vector<4x1xf32>
+  return %0, %1 : f32, vector<1xf32>
 }
 
 // CHECK-LABEL: @insert_element_0d
@@ -302,8 +298,8 @@ func.func @insert_0d(%a: f32, %b: vector<f32>, %c: vector<1xf32>, %d: vector<2x3
                      -> (vector<f32>, vector<f32>, vector<2x3xf32>) {
   //      CHECK: vector.insert %{{.*}}, %{{.*}}[] : f32 into vector<f32>
   %1 = vector.insert %a, %b[] : f32 into vector<f32>
-  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : vector<1xf32> into vector<f32>
-  %2 = vector.insert %c, %b[] : vector<1xf32> into vector<f32>
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : vector<f32> into vector<f32>
+  %2 = vector.insert %b, %b[] : vector<f32> into vector<f32>
   // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<f32> into vector<2x3xf32>
   %3 = vector.insert %b, %d[0, 1] : vector<f32> into vector<2x3xf32>
   return %1, %2, %3 : vector<f32>, vector<f32>, vector<2x3xf32>
@@ -316,7 +312,7 @@ func.func @insert_1d(%a: f32, %b: vector<1xf32>, %c: vector<4x1xf32>,
   //      CHECK: vector.insert %{{.*}}, %{{.*}}[0] : f32 into vector<1xf32>
   %0 = vector.insert %a, %b[0] : f32 into vector<1xf32>
   // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0] : vector<1xf32> into vector<1xf32>
-  %1 = vector.insert %0, %b[0] : vector<1xf32> into vector<1xf32>
+  %1 = vector.insert %b, %b[0] : vector<1xf32> into vector<1xf32>
   // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[2] : vector<1xf32> into vector<4x1xf32>
   %2 = vector.insert %b, %c[2] : vector<1xf32> into vector<4x1xf32>
   // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<1xf32> into vector<2x3xf32>


### PR DESCRIPTION
This PR fixes the `vector.extract` verifier so that we have to provide as many indices as vector dimensions to extract a scalar. I.e., the following example is incorrect:

```
  %1 = vector.extract %arg0[0, 0] : f32 from vector<4x8x1xf32>
```

A similar check already exists for `vector.insert`.