### PR TITLE
[NFC,SHT_LLVM_BB_ADDR_MAP] Fix undefined behaviour in ELF.cpp.

### DIFF
--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -823,7 +823,6 @@ decodeBBAddrMapImpl(const ELFFile<ELFT> &EF,
     uint32_t NumBlocksInBBRange = 0;
     uint32_t NumBBRanges = 1;
     typename ELFFile<ELFT>::uintX_t RangeBaseAddress = 0;
-    std::vector<BBAddrMap::BBEntry> BBEntries;
     if (FeatEnable.MultiBBRange) {
       NumBBRanges = readULEB128As<uint32_t>(Data, Cur, ULEBSizeErr);
       if (!Cur || ULEBSizeErr)
@@ -851,6 +850,7 @@ decodeBBAddrMapImpl(const ELFFile<ELFT> &EF,
         RangeBaseAddress = *AddressOrErr;
         NumBlocksInBBRange = readULEB128As<uint32_t>(Data, Cur, ULEBSizeErr);
       }
+      std::vector<BBAddrMap::BBEntry> BBEntries;
       for (uint32_t BlockIndex = 0; !MetadataDecodeErr && !ULEBSizeErr && Cur &&
                                     (BlockIndex < NumBlocksInBBRange);
            ++BlockIndex) {


### PR DESCRIPTION
`BBEntries` is defined outside of the loop and is used after move which is undefined behavior.