### PR TITLE
[LoongArch] add la v1.1 features for sys::getHostCPUFeatures

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
@@ -14,7 +14,6 @@
 #include "clang/Driver/Options.h"
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/LoongArchTargetParser.h"
-#include <string>
 
 using namespace clang::driver;
 using namespace clang::driver::tools;
@@ -141,7 +140,7 @@ void loongarch::getLoongArchTargetFeatures(const Driver &D,
     ArchName = MArch->getValue();
   ArchName = postProcessTargetCPUString(ArchName, Triple);
   llvm::LoongArch::getArchFeatures(ArchName, Features);
-  if ((std::string)(MArch->getValue()) == "native")
+  if (MArch && StringRef(MArch->getValue()) == "native")
     for (auto &F : llvm::sys::getHostCPUFeatures())
       Features.push_back(
           Args.MakeArgString((F.second ? "+" : "-") + F.first()));

--- a/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
@@ -14,6 +14,7 @@
 #include "clang/Driver/Options.h"
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/LoongArchTargetParser.h"
+#include <string>
 
 using namespace clang::driver;
 using namespace clang::driver::tools;
@@ -135,10 +136,15 @@ void loongarch::getLoongArchTargetFeatures(const Driver &D,
     Features.push_back("+lsx");
 
   std::string ArchName;
-  if (const Arg *A = Args.getLastArg(options::OPT_march_EQ))
-    ArchName = A->getValue();
+  const Arg *MArch = Args.getLastArg(options::OPT_march_EQ);
+  if (MArch)
+    ArchName = MArch->getValue();
   ArchName = postProcessTargetCPUString(ArchName, Triple);
   llvm::LoongArch::getArchFeatures(ArchName, Features);
+  if ((std::string)(MArch->getValue()) == "native")
+    for (auto &F : llvm::sys::getHostCPUFeatures())
+      Features.push_back(
+          Args.MakeArgString((F.second ? "+" : "-") + F.first()));
 
   // Select floating-point features determined by -mdouble-float,
   // -msingle-float, -msoft-float and -mfpu.

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -2006,6 +2006,15 @@ const StringMap<bool> sys::getHostCPUFeatures() {
   Features["lasx"] = hwcap & (1UL << 5); // HWCAP_LOONGARCH_LASX
   Features["lvz"] = hwcap & (1UL << 9);  // HWCAP_LOONGARCH_LVZ
 
+  Features["frecipe"] = cpucfg2 & (1U << 25); // CPUCFG.2.FRECIPE
+  Features["lam-bh"] = cpucfg2 & (1U << 27);  // CPUCFG.2.LAM_BH
+
+  // TODO: Need to complete.
+  // Features["div32"] = cpucfg2 & (1U << 26);       // CPUCFG.2.DIV32
+  // Features["lamcas"] = cpucfg2 & (1U << 28);      // CPUCFG.2.LAMCAS
+  // Features["llacq-screl"] = cpucfg2 & (1U << 29); // CPUCFG.2.LLACQ_SCREL
+  // Features["scq"] = cpucfg2 & (1U << 30);         // CPUCFG.2.SCQ
+  // Features["ld-seq-sa"] = cpucfg3 & (1U << 23); // CPUCFG.3.LD_SEQ_SA
   return Features;
 }
 #elif defined(__linux__) && defined(__riscv)


### PR DESCRIPTION
Two features (i.e. `frecipe` and `lam-bh`) are added to `sys.getHostCPUFeatures`. More features will be added in future.

In addition, this patch adds the features returned by `sys.getHostCPUFeature` when `-march=native`.