### PR TITLE
[llvm] optionally install backend headers

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1355,6 +1355,17 @@ if (LLVM_INCLUDE_UTILS)
   add_subdirectory(utils/llvm-lit)
 endif()
 
+set(LLVM_INSTALL_BACKEND_HEADERS
+    OFF
+    CACHE BOOL "Install back-end specific headers and table-genned files")
+if(LLVM_INSTALL_BACKEND_HEADERS AND LLVM_INSTALL_TOOLCHAIN_ONLY)
+  message(
+    FATAL_ERROR
+      "LLVM_INSTALL_BACKEND_HEADERS only works if "
+      "LLVM_INSTALL_TOOLCHAIN_ONLY is set to OFF as it installs component "
+      "library headers")
+endif()
+
 if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   install(DIRECTORY include/llvm include/llvm-c
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
@@ -1367,6 +1378,41 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     PATTERN "LICENSE.TXT"
     )
 
+  if (LLVM_INSTALL_BACKEND_HEADERS)
+    # Install table-genned files into include install dir.
+    install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/llvm"
+      COMPONENT llvm-headers
+      FILES_MATCHING
+      PATTERN "*.inc"
+      PATTERN "*.h"
+      PATTERN "*.def"
+      PATTERN "CMakeFiles" EXCLUDE
+      )
+
+    # Installing a generated config is not ideal, but
+    # lots of generated headers depend on it. It's assumed
+    # that exported static libraries will be consumed with the
+    # same toolchain LLVM was built with.
+    install(DIRECTORY ${CMAKE_BINARY_DIR}/include/
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+      COMPONENT llvm-headers
+      FILES_MATCHING
+      PATTERN "*config.h"
+      )
+
+    # Such installs lead to lots of empty directories because
+    # of a cmake issue:
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/17122
+    foreach(target ${LLVM_TARGETS_TO_BUILD})
+      install(DIRECTORY lib/Target/${target}/
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/llvm/Target/${target}"
+        COMPONENT llvm-headers
+        FILES_MATCHING
+        PATTERN "*.h"
+        )
+    endforeach()
+  endif()
   install(DIRECTORY ${LLVM_INCLUDE_DIR}/llvm ${LLVM_INCLUDE_DIR}/llvm-c
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     COMPONENT llvm-headers

--- a/llvm/docs/BuildingADistribution.rst
+++ b/llvm/docs/BuildingADistribution.rst
@@ -255,3 +255,10 @@ that are already documented include: *LLVM_TARGETS_TO_BUILD*, *LLVM_ENABLE_PROJE
   default ``install`` target. Including the development tools is not recommended
   for distributions as many of the LLVM tools are only intended for development
   and testing use.
+
+**LLVM_INSTALL_BACKEND_HEADERS**:BOOL
+  This option defaults to ``Off``: When set to ``On`` it installs backend
+  headers for specified Targets. It allows to use LLVM's backend info out of
+  project tree. Note that this option does not work if
+  LLVM_INSTALL_TOOLCHAIN_ONLY set to ``On`` as it is meant to install component
+  library headers


### PR DESCRIPTION
Currently, LLVM provides no way to access target-specific headers out-of-tree. This makes it practically impossible to use LLVM for instructions descriptions outside llvm-project repository and forces people to clone llvm and build all of it alongside their project. Or copy LLVM .tb files and run llvm-tblgen on them by hand. This commit adds a cmake option to install those headers alongside other llvm headers which makes it possible to use llvm backend headers out of llvm-project tree.